### PR TITLE
[LWM] refactor(mobile): share market insight gauge between indices

### DIFF
--- a/.changeset/share-market-insight-gauge.md
+++ b/.changeset/share-market-insight-gauge.md
@@ -2,4 +2,4 @@
 "live-mobile": patch
 ---
 
-Share a single `MarketInsightGauge` component between the Market screen's Mood index (Fear & Greed) and Season (Altcoin Season) cards so both render an identical gauge — same geometry, animation, sizing, and cursor — differing only by gradient colors. Aligns the Season card's pressed state with the Mood index card.
+Share a single `ArcGaugeIndicator` component (matching the desktop naming) between the Market screen's Mood index (Fear & Greed) and Season (Altcoin Season) cards so both render an identical gauge — same geometry, animation, sizing, and cursor — differing only by gradient colors. Aligns the Season card's pressed state with the Mood index card.

--- a/.changeset/share-market-insight-gauge.md
+++ b/.changeset/share-market-insight-gauge.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Share a single `MarketInsightGauge` component between the Market screen's Mood index (Fear & Greed) and Season (Altcoin Season) cards so both render an identical gauge — same geometry, animation, sizing, and cursor — differing only by gradient colors. Aligns the Season card's pressed state with the Mood index card.

--- a/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/AltcoinSeasonArc.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/AltcoinSeasonArc.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import MarketInsightGauge from "LLM/components/MarketInsightGauge";
+import ArcGaugeIndicator from "LLM/components/ArcGaugeIndicator";
 
-const GRADIENT_START_COLOR = "#FF9416";
-const GRADIENT_END_COLOR = "#3F51B5";
+const BITCOIN_COLOR = "#FF9416";
+const ALTCOIN_COLOR = "#3F51B5";
 
 type Props = Readonly<{
   value: number;
@@ -10,12 +10,11 @@ type Props = Readonly<{
 
 export function AltcoinSeasonArc({ value }: Props) {
   return (
-    <MarketInsightGauge
+    <ArcGaugeIndicator
       value={value}
       appearance="expanded"
-      gradientId="altcoinSeasonGradient"
-      gradientStartColor={GRADIENT_START_COLOR}
-      gradientEndColor={GRADIENT_END_COLOR}
+      startColor={BITCOIN_COLOR}
+      endColor={ALTCOIN_COLOR}
     />
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/AltcoinSeasonArc.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/AltcoinSeasonArc.tsx
@@ -1,132 +1,21 @@
-import React, { useEffect, useState } from "react";
-import { View } from "react-native";
-import Animated, {
-  Easing,
-  useAnimatedStyle,
-  useDerivedValue,
-  useSharedValue,
-  withTiming,
-} from "react-native-reanimated";
-import { scheduleOnRN } from "react-native-worklets";
-import Svg, { Circle, Defs, LinearGradient, Path, Stop, Text as SvgText } from "react-native-svg";
-import { useTheme } from "@ledgerhq/lumen-ui-rnative/styles";
+import React from "react";
+import MarketInsightGauge from "LLM/components/MarketInsightGauge";
 
-const WIDTH = 68;
-const HEIGHT = 44;
-const STROKE_WIDTH = 6;
-const CX = 34;
-const CY = 34;
-const R = 28;
-const CURSOR_RADIUS = 5;
-const CURSOR_STROKE_WIDTH = 1.5;
-const ANIMATION_DURATION = 1200;
+const GRADIENT_START_COLOR = "#FF9416";
+const GRADIENT_END_COLOR = "#3F51B5";
 
 type Props = Readonly<{
   value: number;
 }>;
 
 export function AltcoinSeasonArc({ value }: Props) {
-  const { theme } = useTheme();
-  const animatedValue = useSharedValue(0);
-  const [displayValue, setDisplayValue] = useState(0);
-  const lastDisplayValue = useSharedValue(0);
-
-  useEffect(() => {
-    animatedValue.value = withTiming(value, {
-      duration: ANIMATION_DURATION,
-      easing: Easing.out(Easing.cubic),
-    });
-  }, [value, animatedValue]);
-
-  const startX = 6;
-  const startY = 40;
-  const endX = 62;
-  const endY = 40;
-
-  const startAngle = Math.atan2(startY - CY, startX - CX);
-  const endAngle = Math.atan2(endY - CY, endX - CX);
-
-  let angleRange = endAngle - startAngle;
-  if (angleRange < 0) {
-    angleRange += 2 * Math.PI;
-  }
-
-  const cursorPosition = useDerivedValue(() => {
-    "worklet";
-    const currentAngle = startAngle + (animatedValue.value / 100) * angleRange;
-    return {
-      x: CX + R * Math.cos(currentAngle),
-      y: CY + R * Math.sin(currentAngle),
-    };
-  }, [animatedValue, startAngle, angleRange]);
-
-  useDerivedValue(() => {
-    "worklet";
-    const rounded = Math.round(animatedValue.value);
-    if (rounded !== lastDisplayValue.value) {
-      lastDisplayValue.value = rounded;
-      scheduleOnRN(setDisplayValue, rounded);
-    }
-  }, [animatedValue, lastDisplayValue]);
-
-  const cursorStyle = useAnimatedStyle(() => {
-    "worklet";
-    return {
-      position: "absolute" as const,
-      left: cursorPosition.value.x - CURSOR_RADIUS - CURSOR_STROKE_WIDTH,
-      top: cursorPosition.value.y - CURSOR_RADIUS - CURSOR_STROKE_WIDTH,
-    };
-  }, [cursorPosition]);
-
-  const cursorSize = (CURSOR_RADIUS + CURSOR_STROKE_WIDTH) * 2;
-
   return (
-    <View style={{ width: WIDTH, height: HEIGHT, position: "relative" }}>
-      <Svg width={WIDTH} height={HEIGHT} viewBox={`0 0 ${WIDTH} ${HEIGHT}`}>
-        <Defs>
-          <LinearGradient
-            id="altcoinSeasonGradient"
-            x1="4"
-            y1="22"
-            x2="64"
-            y2="22"
-            gradientUnits="userSpaceOnUse"
-          >
-            <Stop offset="0" stopColor="#FF9416" />
-            <Stop offset="1" stopColor="#3F51B5" />
-          </LinearGradient>
-        </Defs>
-        <Path
-          d="M6 40C4.7 36.7 4 33.1 4 29.3C4 12.7 17.4 4 34 4C50.6 4 64 12.7 64 29.3C64 33.1 63.3 36.7 62 40"
-          stroke="url(#altcoinSeasonGradient)"
-          strokeWidth={STROKE_WIDTH}
-          strokeLinecap="round"
-          fill="none"
-        />
-        <SvgText
-          transform={[{ translateX: CX }, { translateY: CY - 1 }]}
-          fill={theme.colors.text.base}
-          fontSize={20}
-          fontWeight="600"
-          textAnchor="middle"
-          alignmentBaseline="middle"
-          fontFamily="Inter"
-        >
-          {displayValue}
-        </SvgText>
-      </Svg>
-      <Animated.View style={cursorStyle}>
-        <Svg width={cursorSize} height={cursorSize} viewBox={`0 0 ${cursorSize} ${cursorSize}`}>
-          <Circle
-            cx={CURSOR_RADIUS + CURSOR_STROKE_WIDTH}
-            cy={CURSOR_RADIUS + CURSOR_STROKE_WIDTH}
-            r={CURSOR_RADIUS}
-            fill="#FFF"
-            stroke="#000"
-            strokeWidth={CURSOR_STROKE_WIDTH}
-          />
-        </Svg>
-      </Animated.View>
-    </View>
+    <MarketInsightGauge
+      value={value}
+      appearance="expanded"
+      gradientId="altcoinSeasonGradient"
+      gradientStartColor={GRADIENT_START_COLOR}
+      gradientEndColor={GRADIENT_END_COLOR}
+    />
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/AltcoinSeasonView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/AltcoinSeasonView.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useTranslation } from "~/context/Locale";
 import { Box, Pressable, Skeleton, Text } from "@ledgerhq/lumen-ui-rnative";
-import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { useTheme, type LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import MarketInsightDefinitionSheet from "LLM/components/MarketInsightDefinitionSheet";
 import MarketInsightErrorCard from "LLM/components/MarketInsightErrorCard";
 import type { AltcoinSeasonViewProps } from "./types";
@@ -23,6 +23,7 @@ export function AltcoinSeasonView({
   width,
 }: AltcoinSeasonViewProps) {
   const { t } = useTranslation();
+  const { theme } = useTheme();
 
   if (isLoading) {
     return (
@@ -54,7 +55,11 @@ export function AltcoinSeasonView({
         onPress={handleOpenDrawer}
         testID="altcoin-season-card"
         lx={cardStyle}
-        style={{ width, height: ALTCOIN_SEASON_CARD_HEIGHT }}
+        style={({ pressed }) => ({
+          width,
+          height: ALTCOIN_SEASON_CARD_HEIGHT,
+          backgroundColor: pressed ? theme.colors.bg.mutedPressed : theme.colors.bg.muted,
+        })}
       >
         <Box lx={contentStyle}>
           <Box lx={{ flexShrink: 1 }}>
@@ -82,7 +87,6 @@ export function AltcoinSeasonView({
 }
 
 const cardStyle: LumenViewStyle = {
-  backgroundColor: "muted",
   borderRadius: "md",
   padding: "s12",
   justifyContent: "center",

--- a/apps/ledger-live-mobile/src/mvvm/components/ArcGaugeIndicator/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/ArcGaugeIndicator/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useId, useState } from "react";
 import { View } from "react-native";
 import Animated, {
   Easing,
@@ -27,30 +27,29 @@ const ARC_PATH =
 const ARC_START = { x: 6.75144, y: 57.6112 };
 const ARC_END = { x: 79.5754, y: 57.6082 };
 
-export type MarketInsightGaugeAppearance = "compact" | "expanded";
+export type ArcGaugeAppearance = "compact" | "expanded";
 
-const SCALE_BY_APPEARANCE: Record<MarketInsightGaugeAppearance, number> = {
+const SCALE_BY_APPEARANCE: Record<ArcGaugeAppearance, number> = {
   compact: 0.5,
   expanded: 0.65,
 };
 
 type Props = Readonly<{
   value: number;
-  appearance?: MarketInsightGaugeAppearance;
-  /** Must be unique across gauges rendered on the same screen to avoid SVG id collisions. */
-  gradientId: string;
-  gradientStartColor: string;
-  gradientEndColor: string;
+  appearance?: ArcGaugeAppearance;
+  startColor: string;
+  endColor: string;
 }>;
 
-export default function MarketInsightGauge({
+export default function ArcGaugeIndicator({
   value,
   appearance = "compact",
-  gradientId,
-  gradientStartColor,
-  gradientEndColor,
+  startColor,
+  endColor,
 }: Props) {
   const { theme } = useTheme();
+  // react-native-svg mis-resolves the ":" that useId emits inside url(#...) references.
+  const gradientId = `arcGaugeGradient-${useId().replace(/:/g, "")}`;
   const scale = SCALE_BY_APPEARANCE[appearance];
   const width = VIEWBOX_WIDTH * scale;
   const height = VIEWBOX_HEIGHT * scale;
@@ -116,8 +115,8 @@ export default function MarketInsightGauge({
             y2="30.8"
             gradientUnits="userSpaceOnUse"
           >
-            <Stop offset="0" stopColor={gradientStartColor} />
-            <Stop offset="1" stopColor={gradientEndColor} />
+            <Stop offset="0" stopColor={startColor} />
+            <Stop offset="1" stopColor={endColor} />
           </LinearGradient>
         </Defs>
         <Path

--- a/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/components/FearAndGreedArc/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/components/FearAndGreedArc/index.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import MarketInsightGauge from "LLM/components/MarketInsightGauge";
+import ArcGaugeIndicator from "LLM/components/ArcGaugeIndicator";
 import type { FearAndGreedAppearance } from "../../types";
 
-const GRADIENT_START_COLOR = "#F87274";
-const GRADIENT_END_COLOR = "#6EC85C";
+const FEAR_COLOR = "#F87274";
+const GREED_COLOR = "#6EC85C";
 
 type Props = Readonly<{
   value: number;
@@ -12,12 +12,11 @@ type Props = Readonly<{
 
 export default function FearAndGreedArc({ value, appearance = "compact" }: Props) {
   return (
-    <MarketInsightGauge
+    <ArcGaugeIndicator
       value={value}
       appearance={appearance}
-      gradientId={`fearAndGreedGradient-${appearance}`}
-      gradientStartColor={GRADIENT_START_COLOR}
-      gradientEndColor={GRADIENT_END_COLOR}
+      startColor={FEAR_COLOR}
+      endColor={GREED_COLOR}
     />
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/components/FearAndGreedArc/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/components/FearAndGreedArc/index.tsx
@@ -1,42 +1,9 @@
-import React, { useEffect, useState } from "react";
-import { View } from "react-native";
-import Animated, {
-  Easing,
-  useAnimatedStyle,
-  useDerivedValue,
-  useSharedValue,
-  withTiming,
-} from "react-native-reanimated";
-import { scheduleOnRN } from "react-native-worklets";
-import Svg, { Circle, Defs, LinearGradient, Path, Stop, Text as SvgText } from "react-native-svg";
-import { useTheme } from "@ledgerhq/lumen-ui-rnative/styles";
+import React from "react";
+import MarketInsightGauge from "LLM/components/MarketInsightGauge";
 import type { FearAndGreedAppearance } from "../../types";
 
-// Geometry is authored once in an 88x64 design space (viewBox, path, gradient) and
-// rendered at a per-appearance scale. The "compact" scale of 0.5 reproduces the
-// historical portfolio gauge pixel-for-pixel (every constant was exactly half).
-const VIEWBOX_WIDTH = 88;
-const VIEWBOX_HEIGHT = 64;
-const STROKE_WIDTH = 8;
-const CX = 43.1628;
-const CY = 43.1628;
-const R = 38.1628;
-const CURSOR_RADIUS = 7;
-const CURSOR_STROKE_WIDTH = 2;
-const FONT_SIZE = 28;
-const ANIMATION_DURATION = 1200;
-
-const ARC_PATH =
-  "M6.75144 57.6112C4.97598 53.1408 4 48.2658 4 43.1628C4 21.5338 21.5338 4 43.1628 4C64.792 4 82.3258 21.5338 82.3258 43.1628C82.3258 48.2646 81.3502 53.1386 79.5754 57.6082";
-const ARC_START = { x: 6.75144, y: 57.6112 };
-const ARC_END = { x: 79.5754, y: 57.6082 };
 const GRADIENT_START_COLOR = "#F87274";
 const GRADIENT_END_COLOR = "#6EC85C";
-
-const SCALE_BY_APPEARANCE: Record<FearAndGreedAppearance, number> = {
-  compact: 0.5,
-  expanded: 0.65,
-};
 
 type Props = Readonly<{
   value: number;
@@ -44,108 +11,13 @@ type Props = Readonly<{
 }>;
 
 export default function FearAndGreedArc({ value, appearance = "compact" }: Props) {
-  const { theme } = useTheme();
-  const scale = SCALE_BY_APPEARANCE[appearance];
-  const width = VIEWBOX_WIDTH * scale;
-  const height = VIEWBOX_HEIGHT * scale;
-  const cursorRadius = CURSOR_RADIUS * scale;
-  const cursorStrokeWidth = CURSOR_STROKE_WIDTH * scale;
-  const cursorSize = (cursorRadius + cursorStrokeWidth) * 2;
-  const gradientId = `fearAndGreedGradient-${appearance}`;
-
-  const animatedValue = useSharedValue(0);
-  const [displayValue, setDisplayValue] = useState(0);
-  const lastDisplayValue = useSharedValue(0);
-
-  useEffect(() => {
-    animatedValue.value = withTiming(value, {
-      duration: ANIMATION_DURATION,
-      easing: Easing.out(Easing.cubic),
-    });
-  }, [value, animatedValue]);
-
-  const startAngle = Math.atan2(ARC_START.y - CY, ARC_START.x - CX);
-  const endAngle = Math.atan2(ARC_END.y - CY, ARC_END.x - CX);
-
-  let angleRange = endAngle - startAngle;
-  if (angleRange < 0) {
-    angleRange += 2 * Math.PI;
-  }
-
-  const cursorPosition = useDerivedValue(() => {
-    "worklet";
-    const currentAngle = startAngle + (animatedValue.value / 100) * angleRange;
-    return {
-      x: CX + R * Math.cos(currentAngle),
-      y: CY + R * Math.sin(currentAngle),
-    };
-  }, [animatedValue, startAngle, angleRange]);
-
-  useDerivedValue(() => {
-    "worklet";
-    const rounded = Math.round(animatedValue.value);
-    if (rounded !== lastDisplayValue.value) {
-      lastDisplayValue.value = rounded;
-      scheduleOnRN(setDisplayValue, rounded);
-    }
-  }, [animatedValue, lastDisplayValue]);
-
-  const cursorStyle = useAnimatedStyle(() => {
-    "worklet";
-    return {
-      position: "absolute" as const,
-      left: cursorPosition.value.x * scale - cursorRadius - cursorStrokeWidth,
-      top: cursorPosition.value.y * scale - cursorRadius - cursorStrokeWidth,
-    };
-  }, [cursorPosition, scale, cursorRadius, cursorStrokeWidth]);
-
   return (
-    <View style={{ width, height, position: "relative" }}>
-      <Svg width={width} height={height} viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}>
-        <Defs>
-          <LinearGradient
-            id={gradientId}
-            x1="4"
-            y1="30.8"
-            x2="82.32"
-            y2="30.8"
-            gradientUnits="userSpaceOnUse"
-          >
-            <Stop offset="0" stopColor={GRADIENT_START_COLOR} />
-            <Stop offset="1" stopColor={GRADIENT_END_COLOR} />
-          </LinearGradient>
-        </Defs>
-        <Path
-          d={ARC_PATH}
-          stroke={`url(#${gradientId})`}
-          strokeWidth={STROKE_WIDTH}
-          strokeLinecap="round"
-          fill="none"
-        />
-        <SvgText
-          transform={[{ translateX: CX }, { translateY: CY }]}
-          fill={theme.colors.text.base}
-          fontSize={FONT_SIZE}
-          fontWeight="600"
-          textAnchor="middle"
-          alignmentBaseline="middle"
-          fontFamily="Inter"
-        >
-          {displayValue}
-        </SvgText>
-      </Svg>
-      <Animated.View style={cursorStyle}>
-        <Svg width={cursorSize} height={cursorSize} viewBox={`0 0 ${cursorSize} ${cursorSize}`}>
-          <Circle
-            cx={cursorRadius + cursorStrokeWidth}
-            cy={cursorRadius + cursorStrokeWidth}
-            r={cursorRadius}
-            fill="#FFF"
-            stroke="#000"
-            strokeWidth={cursorStrokeWidth}
-          />
-        </Svg>
-      </Animated.View>
-    </View>
+    <MarketInsightGauge
+      value={value}
+      appearance={appearance}
+      gradientId={`fearAndGreedGradient-${appearance}`}
+      gradientStartColor={GRADIENT_START_COLOR}
+      gradientEndColor={GRADIENT_END_COLOR}
+    />
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/MarketInsightGauge/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/MarketInsightGauge/index.tsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useState } from "react";
+import { View } from "react-native";
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+import { scheduleOnRN } from "react-native-worklets";
+import Svg, { Circle, Defs, LinearGradient, Path, Stop, Text as SvgText } from "react-native-svg";
+import { useTheme } from "@ledgerhq/lumen-ui-rnative/styles";
+
+const VIEWBOX_WIDTH = 88;
+const VIEWBOX_HEIGHT = 64;
+const STROKE_WIDTH = 8;
+const CX = 43.1628;
+const CY = 43.1628;
+const R = 38.1628;
+const CURSOR_RADIUS = 7;
+const CURSOR_STROKE_WIDTH = 2;
+const FONT_SIZE = 28;
+const ANIMATION_DURATION = 1200;
+
+const ARC_PATH =
+  "M6.75144 57.6112C4.97598 53.1408 4 48.2658 4 43.1628C4 21.5338 21.5338 4 43.1628 4C64.792 4 82.3258 21.5338 82.3258 43.1628C82.3258 48.2646 81.3502 53.1386 79.5754 57.6082";
+const ARC_START = { x: 6.75144, y: 57.6112 };
+const ARC_END = { x: 79.5754, y: 57.6082 };
+
+export type MarketInsightGaugeAppearance = "compact" | "expanded";
+
+const SCALE_BY_APPEARANCE: Record<MarketInsightGaugeAppearance, number> = {
+  compact: 0.5,
+  expanded: 0.65,
+};
+
+type Props = Readonly<{
+  value: number;
+  appearance?: MarketInsightGaugeAppearance;
+  /** Must be unique across gauges rendered on the same screen to avoid SVG id collisions. */
+  gradientId: string;
+  gradientStartColor: string;
+  gradientEndColor: string;
+}>;
+
+export default function MarketInsightGauge({
+  value,
+  appearance = "compact",
+  gradientId,
+  gradientStartColor,
+  gradientEndColor,
+}: Props) {
+  const { theme } = useTheme();
+  const scale = SCALE_BY_APPEARANCE[appearance];
+  const width = VIEWBOX_WIDTH * scale;
+  const height = VIEWBOX_HEIGHT * scale;
+  const cursorRadius = CURSOR_RADIUS * scale;
+  const cursorStrokeWidth = CURSOR_STROKE_WIDTH * scale;
+  const cursorSize = (cursorRadius + cursorStrokeWidth) * 2;
+
+  const animatedValue = useSharedValue(0);
+  const [displayValue, setDisplayValue] = useState(0);
+  const lastDisplayValue = useSharedValue(0);
+
+  useEffect(() => {
+    animatedValue.value = withTiming(value, {
+      duration: ANIMATION_DURATION,
+      easing: Easing.out(Easing.cubic),
+    });
+  }, [value, animatedValue]);
+
+  const startAngle = Math.atan2(ARC_START.y - CY, ARC_START.x - CX);
+  const endAngle = Math.atan2(ARC_END.y - CY, ARC_END.x - CX);
+
+  let angleRange = endAngle - startAngle;
+  if (angleRange < 0) {
+    angleRange += 2 * Math.PI;
+  }
+
+  const cursorPosition = useDerivedValue(() => {
+    "worklet";
+    const currentAngle = startAngle + (animatedValue.value / 100) * angleRange;
+    return {
+      x: CX + R * Math.cos(currentAngle),
+      y: CY + R * Math.sin(currentAngle),
+    };
+  }, [animatedValue, startAngle, angleRange]);
+
+  useDerivedValue(() => {
+    "worklet";
+    const rounded = Math.round(animatedValue.value);
+    if (rounded !== lastDisplayValue.value) {
+      lastDisplayValue.value = rounded;
+      scheduleOnRN(setDisplayValue, rounded);
+    }
+  }, [animatedValue, lastDisplayValue]);
+
+  const cursorStyle = useAnimatedStyle(() => {
+    "worklet";
+    return {
+      position: "absolute" as const,
+      left: cursorPosition.value.x * scale - cursorRadius - cursorStrokeWidth,
+      top: cursorPosition.value.y * scale - cursorRadius - cursorStrokeWidth,
+    };
+  }, [cursorPosition, scale, cursorRadius, cursorStrokeWidth]);
+
+  return (
+    <View style={{ width, height, position: "relative" }}>
+      <Svg width={width} height={height} viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}>
+        <Defs>
+          <LinearGradient
+            id={gradientId}
+            x1="4"
+            y1="30.8"
+            x2="82.32"
+            y2="30.8"
+            gradientUnits="userSpaceOnUse"
+          >
+            <Stop offset="0" stopColor={gradientStartColor} />
+            <Stop offset="1" stopColor={gradientEndColor} />
+          </LinearGradient>
+        </Defs>
+        <Path
+          d={ARC_PATH}
+          stroke={`url(#${gradientId})`}
+          strokeWidth={STROKE_WIDTH}
+          strokeLinecap="round"
+          fill="none"
+        />
+        <SvgText
+          transform={[{ translateX: CX }, { translateY: CY }]}
+          fill={theme.colors.text.base}
+          fontSize={FONT_SIZE}
+          fontWeight="600"
+          textAnchor="middle"
+          alignmentBaseline="middle"
+          fontFamily="Inter"
+        >
+          {displayValue}
+        </SvgText>
+      </Svg>
+      <Animated.View style={cursorStyle}>
+        <Svg width={cursorSize} height={cursorSize} viewBox={`0 0 ${cursorSize} ${cursorSize}`}>
+          <Circle
+            cx={cursorRadius + cursorStrokeWidth}
+            cy={cursorRadius + cursorStrokeWidth}
+            r={cursorRadius}
+            fill="#FFF"
+            stroke="#000"
+            strokeWidth={cursorStrokeWidth}
+          />
+        </Svg>
+      </Animated.View>
+    </View>
+  );
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _Existing AltcoinSeason and FearAndGreed integration suites (14 tests) pass against the refactor. The gauge is presentational/animation-only, so behavior is unchanged._
- [x] **Impact of the changes:**
      - Market screen top cards: Mood index (Fear & Greed) and Season (Altcoin Season) gauges
      - Verify both gauges render at the same size with identical arc/cursor geometry, differing only by gradient colors
      - Verify the Season card now shows a pressed-state background, matching the Mood index card
      - Verify compact Fear & Greed card (carousel tile) still renders correctly

### 📝 Description

The Season (Altcoin Season Index) card did not match the Mood index (Fear & Greed) card: it used a separate, smaller gauge with different geometry, stroke width, cursor size, and font, and its card had no pressed-state feedback.

This PR extracts the Fear & Greed gauge into a generic `MarketInsightGauge` component under `mvvm/components`, parameterized by `appearance`, gradient colors, and gradient id. Both `FearAndGreedArc` and `AltcoinSeasonArc` are now thin wrappers that bind only their gradient — guaranteeing the two indices stay visually identical going forward. The Season card's pressed state is also aligned with the Mood index card.

### 🖼 Screenshots


https://github.com/user-attachments/assets/1e67fc9a-8b56-474b-ac42-9e89ac74e7c5



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32022](https://ledgerhq.atlassian.net/browse/LIVE-32022)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32022]: https://ledgerhq.atlassian.net/browse/LIVE-32022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ