### PR TITLE
[LWDM] feat(polkadot): add Bittensor support to coin-polkadot

### DIFF
--- a/.changeset/bittensor-coin-polkadot-support.md
+++ b/.changeset/bittensor-coin-polkadot-support.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-polkadot": minor
+"@ledgerhq/live-common": minor
+---
+
+Add Bittensor (TAO) support to the polkadot coin module: currency config entry (Sidecar/Node/Indexer endpoints provided via Firebase Remote Config) and SS58 prefix 42 handling for address derivation and validation. The currency config is inert until the currency is registered and enabled downstream.

--- a/libs/coin-modules/coin-polkadot/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/getTransactionStatus.ts
@@ -12,7 +12,7 @@ import {
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
-import { isValidAddress } from "../common";
+import { isValidAddress, getSs58Prefix } from "../common";
 import { loadPolkadotCrypto } from "../logic/polkadot-crypto";
 import polkadotAPI from "../network";
 import type { PolkadotAccount, Transaction, TransactionStatus } from "../types";
@@ -58,7 +58,7 @@ const getSendTransactionStatus: AccountBridge<
     errors.recipient = new RecipientRequired("");
   } else if (account.freshAddress === transaction.recipient) {
     errors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
-  } else if (!isValidAddress(transaction.recipient)) {
+  } else if (!isValidAddress(transaction.recipient, getSs58Prefix(account.currency.id))) {
     errors.recipient = new InvalidAddress("", {
       currencyName: account.currency.name,
     });
@@ -173,7 +173,7 @@ export const getTransactionStatus: AccountBridge<
         // Not a stash yet -> bond method sets the controller
         if (!transaction.recipient) {
           errors.recipient = new RecipientRequired("");
-        } else if (!isValidAddress(transaction.recipient)) {
+        } else if (!isValidAddress(transaction.recipient, getSs58Prefix(account.currency.id))) {
           errors.recipient = new InvalidAddress("", {
             currencyName: account.currency.name,
           });

--- a/libs/coin-modules/coin-polkadot/src/bridge/regression-polkadot-family.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/regression-polkadot-family.test.ts
@@ -1,0 +1,105 @@
+import { isValidAddress } from "../common";
+import coinConfig from "../config";
+import type { PolkadotCoinConfig } from "../config";
+import { validateAddress } from "../logic/validateAddress";
+
+const makeTestConfig = (): PolkadotCoinConfig => ({
+  status: { type: "active" },
+  sidecar: { url: "https://sidecar.test" },
+  node: { url: "https://node.test" },
+  indexer: { url: "https://indexer.test" },
+  staking: { electionStatusThreshold: 25 },
+});
+
+const CURRENCIES = ["polkadot", "assethub_polkadot", "westend", "assethub_westend", "bittensor"];
+
+describe("config resolution — all polkadot-family currencies", () => {
+  beforeEach(() => {
+    coinConfig.setCoinConfig(() => makeTestConfig());
+  });
+
+  it.each(CURRENCIES)("getCoinConfig(%s) resolves without throwing", currencyId => {
+    expect(() => coinConfig.getCoinConfig(currencyId)).not.toThrow();
+  });
+
+  it.each(CURRENCIES)("getCoinConfig(%s) returns sidecar url", currencyId => {
+    const config = coinConfig.getCoinConfig(currencyId);
+    expect(config.sidecar.url).toBe("https://sidecar.test");
+  });
+
+  it.each(CURRENCIES)("getCoinConfig(%s) returns node url", currencyId => {
+    const config = coinConfig.getCoinConfig(currencyId);
+    expect(config.node.url).toBe("https://node.test");
+  });
+
+  it.each(CURRENCIES)("getCoinConfig(%s) returns indexer url", currencyId => {
+    const config = coinConfig.getCoinConfig(currencyId);
+    expect(config.indexer.url).toBe("https://indexer.test");
+  });
+});
+
+describe("address validation — ss58 format correctness", () => {
+  // A valid Polkadot address (ss58=0)
+  const POLKADOT_ADDRESS = "16VZ9duXPsEmdBxFtYJRq4bYbZMR7a9dEnSur9CXcnfthrRV";
+
+  // A valid generic Substrate address (ss58=42), compatible with Bittensor/Westend
+  // Generated from the same public key with prefix 42
+  const SUBSTRATE_ADDRESS_42 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+  it("polkadot address (ss58=0) is valid with default ss58 prefix", () => {
+    expect(isValidAddress(POLKADOT_ADDRESS)).toBe(true);
+  });
+
+  it("substrate ss58=42 address is valid with ss58Format=42", () => {
+    expect(isValidAddress(SUBSTRATE_ADDRESS_42, 42)).toBe(true);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isValidAddress("")).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isValidAddress(undefined)).toBe(false);
+  });
+
+  it("returns false for malformed address", () => {
+    expect(isValidAddress("notanaddress")).toBe(false);
+  });
+});
+
+describe("validateAddress — currency-aware ss58 routing", () => {
+  it("polkadot uses ss58=0 — accepts polkadot address", async () => {
+    const POLKADOT_ADDRESS = "16VZ9duXPsEmdBxFtYJRq4bYbZMR7a9dEnSur9CXcnfthrRV";
+    const result = await validateAddress(POLKADOT_ADDRESS, { currencyId: "polkadot" });
+    expect(result).toBe(true);
+  });
+
+  it("bittensor uses ss58=42 — accepts generic substrate address", async () => {
+    const SUBSTRATE_ADDRESS_42 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+    const result = await validateAddress(SUBSTRATE_ADDRESS_42, { currencyId: "bittensor" });
+    expect(result).toBe(true);
+  });
+
+  it("westend uses ss58=42 — accepts generic substrate address", async () => {
+    const SUBSTRATE_ADDRESS_42 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+    const result = await validateAddress(SUBSTRATE_ADDRESS_42, { currencyId: "westend" });
+    expect(result).toBe(true);
+  });
+
+  it("returns false for malformed address regardless of currency", async () => {
+    const result = await validateAddress("notanaddress", { currencyId: "bittensor" });
+    expect(result).toBe(false);
+  });
+
+  it("assethub_polkadot uses ss58=0 — accepts polkadot address", async () => {
+    const POLKADOT_ADDRESS = "16VZ9duXPsEmdBxFtYJRq4bYbZMR7a9dEnSur9CXcnfthrRV";
+    const result = await validateAddress(POLKADOT_ADDRESS, { currencyId: "assethub_polkadot" });
+    expect(result).toBe(true);
+  });
+
+  it("assethub_westend uses ss58=42 — accepts generic substrate address", async () => {
+    const SUBSTRATE_ADDRESS_42 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+    const result = await validateAddress(SUBSTRATE_ADDRESS_42, { currencyId: "assethub_westend" });
+    expect(result).toBe(true);
+  });
+});

--- a/libs/coin-modules/coin-polkadot/src/common/index.ts
+++ b/libs/coin-modules/coin-polkadot/src/common/index.ts
@@ -1,1 +1,2 @@
 export * from "./address";
+export * from "./ss58";

--- a/libs/coin-modules/coin-polkadot/src/common/ss58.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/common/ss58.test.ts
@@ -1,0 +1,43 @@
+import { getSs58Prefix, SS58_PREFIX_BY_CURRENCY, DEFAULT_SS58_PREFIX } from "./ss58";
+
+describe("getSs58Prefix", () => {
+  it("returns 0 for polkadot", () => {
+    expect(getSs58Prefix("polkadot")).toBe(0);
+  });
+
+  it("returns 0 for assethub_polkadot", () => {
+    expect(getSs58Prefix("assethub_polkadot")).toBe(0);
+  });
+
+  it("returns 42 for westend", () => {
+    expect(getSs58Prefix("westend")).toBe(42);
+  });
+
+  it("returns 42 for assethub_westend", () => {
+    expect(getSs58Prefix("assethub_westend")).toBe(42);
+  });
+
+  it("returns 42 for bittensor", () => {
+    expect(getSs58Prefix("bittensor")).toBe(42);
+  });
+
+  it("returns default (0) for unknown currency", () => {
+    expect(getSs58Prefix("unknown")).toBe(DEFAULT_SS58_PREFIX);
+  });
+
+  it("returns default (0) for undefined", () => {
+    expect(getSs58Prefix(undefined)).toBe(DEFAULT_SS58_PREFIX);
+  });
+});
+
+describe("SS58_PREFIX_BY_CURRENCY", () => {
+  it("maps each known polkadot-family currency to its ss58 prefix", () => {
+    expect(SS58_PREFIX_BY_CURRENCY).toMatchObject({
+      polkadot: 0,
+      assethub_polkadot: 0,
+      westend: 42,
+      assethub_westend: 42,
+      bittensor: 42,
+    });
+  });
+});

--- a/libs/coin-modules/coin-polkadot/src/common/ss58.ts
+++ b/libs/coin-modules/coin-polkadot/src/common/ss58.ts
@@ -1,0 +1,19 @@
+/**
+ * SS58 address prefix by currency ID.
+ *
+ * Polkadot and its asset-hub parachains use prefix 0.
+ * Westend, its asset-hub, and Bittensor use the generic Substrate prefix 42.
+ * Unknown currencies fall back to 0 (Polkadot mainnet).
+ */
+export const SS58_PREFIX_BY_CURRENCY: Record<string, number> = {
+  polkadot: 0,
+  assethub_polkadot: 0,
+  westend: 42,
+  assethub_westend: 42,
+  bittensor: 42,
+};
+
+export const DEFAULT_SS58_PREFIX = 0;
+
+export const getSs58Prefix = (currencyId: string | undefined): number =>
+  SS58_PREFIX_BY_CURRENCY[currencyId ?? ""] ?? DEFAULT_SS58_PREFIX;

--- a/libs/coin-modules/coin-polkadot/src/logic/validateAddress.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/logic/validateAddress.test.ts
@@ -1,7 +1,10 @@
 import { isValidAddress } from "../common";
 import { validateAddress } from "./validateAddress";
 
-jest.mock("../common");
+jest.mock("../common", () => ({
+  ...jest.requireActual("../common"),
+  isValidAddress: jest.fn(),
+}));
 
 describe("validateAddress", () => {
   const mockedIsValidAddress = jest.mocked(isValidAddress);
@@ -21,7 +24,30 @@ describe("validateAddress", () => {
       expect(result).toEqual(expectedValue);
 
       expect(mockedIsValidAddress).toHaveBeenCalledTimes(1);
-      expect(mockedIsValidAddress).toHaveBeenCalledWith(address);
+      // validateAddress now passes the resolved ss58Format as the second argument.
+      // With no currencyId in parameters, the default prefix (0) is used.
+      expect(mockedIsValidAddress).toHaveBeenCalledWith(address, 0);
     },
   );
+
+  it("passes ss58Format=42 for bittensor", async () => {
+    mockedIsValidAddress.mockReturnValueOnce(true);
+    const address = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+    await validateAddress(address, { currencyId: "bittensor" });
+    expect(mockedIsValidAddress).toHaveBeenCalledWith(address, 42);
+  });
+
+  it("passes ss58Format=42 for westend", async () => {
+    mockedIsValidAddress.mockReturnValueOnce(true);
+    const address = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+    await validateAddress(address, { currencyId: "westend" });
+    expect(mockedIsValidAddress).toHaveBeenCalledWith(address, 42);
+  });
+
+  it("passes ss58Format=0 for polkadot", async () => {
+    mockedIsValidAddress.mockReturnValueOnce(true);
+    const address = "16VZ9duXPsEmdBxFtYJRq4bYbZMR7a9dEnSur9CXcnfthrRV";
+    await validateAddress(address, { currencyId: "polkadot" });
+    expect(mockedIsValidAddress).toHaveBeenCalledWith(address, 0);
+  });
 });

--- a/libs/coin-modules/coin-polkadot/src/logic/validateAddress.ts
+++ b/libs/coin-modules/coin-polkadot/src/logic/validateAddress.ts
@@ -1,9 +1,10 @@
 import type { AddressValidationCurrencyParameters } from "@ledgerhq/coin-module-framework/api/types";
-import { isValidAddress } from "../common";
+import { isValidAddress, getSs58Prefix } from "../common";
 
 export async function validateAddress(
   address: string,
-  _parameters: Partial<AddressValidationCurrencyParameters>,
+  parameters: Partial<AddressValidationCurrencyParameters>,
 ): Promise<boolean> {
-  return isValidAddress(address);
+  const ss58Format = getSs58Prefix(parameters.currencyId);
+  return isValidAddress(address, ss58Format);
 }

--- a/libs/coin-modules/coin-polkadot/src/network/sidecar-bittensor.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/sidecar-bittensor.test.ts
@@ -1,0 +1,81 @@
+import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import coinConfig from "../config";
+import { isElectionClosed } from "./sidecar";
+import { bittensorRuntimeSpec } from "./sidecar.fixture";
+
+const makeCurrency = (id: string): CryptoCurrency =>
+  ({
+    id,
+    type: "CryptoCurrency",
+    name: id,
+    managerAppName: id,
+    ticker: id.toUpperCase(),
+    scheme: id,
+    color: "#000000",
+    family: "polkadot",
+    coinType: 434,
+    units: [{ name: id, code: id.toUpperCase(), magnitude: 9 }],
+    explorerViews: [],
+  }) as unknown as CryptoCurrency;
+
+const BITTENSOR_SIDECAR_URL = "https://bittensor-sidecar.test.ledger.com";
+
+describe("bittensorRuntimeSpec fixture", () => {
+  it("has specName node-subtensor", () => {
+    expect(bittensorRuntimeSpec.specName).toBe("node-subtensor");
+  });
+
+  it("has ss58Format 42", () => {
+    expect(bittensorRuntimeSpec.properties.ss58Format).toBe("42");
+  });
+
+  it("has tokenSymbol TAO", () => {
+    expect(bittensorRuntimeSpec.properties.tokenSymbol).toBe("TAO");
+  });
+
+  it("has tokenDecimals 9", () => {
+    expect(bittensorRuntimeSpec.properties.tokenDecimals).toBe("9");
+  });
+});
+
+describe("isElectionClosed for bittensor", () => {
+  beforeEach(() => {
+    coinConfig.setCoinConfig(() => ({
+      status: { type: "active" },
+      sidecar: { url: BITTENSOR_SIDECAR_URL },
+      node: { url: "" },
+      indexer: { url: "" },
+    }));
+  });
+
+  it("returns true for bittensor without hitting sidecar (in UNSUPPORTED_STAKING_NETWORKS)", async () => {
+    const bittensor = makeCurrency("bittensor");
+    const result = await isElectionClosed(bittensor);
+    expect(result).toBe(true);
+  });
+});
+
+describe("UNSUPPORTED_STAKING_NETWORKS includes bittensor", () => {
+  it("isElectionClosed resolves to true for bittensor synchronously (no network call)", async () => {
+    coinConfig.setCoinConfig(() => ({
+      status: { type: "active" },
+      sidecar: { url: BITTENSOR_SIDECAR_URL },
+      node: { url: "" },
+      indexer: { url: "" },
+    }));
+
+    const bittensor = makeCurrency("bittensor");
+    const polkadot = makeCurrency("polkadot");
+    const westend = makeCurrency("westend");
+
+    const [bittensorResult, polkadotResult, westendResult] = await Promise.all([
+      isElectionClosed(bittensor),
+      isElectionClosed(polkadot),
+      isElectionClosed(westend),
+    ]);
+
+    expect(bittensorResult).toBe(true);
+    expect(polkadotResult).toBe(true);
+    expect(westendResult).toBe(true);
+  });
+});

--- a/libs/coin-modules/coin-polkadot/src/network/sidecar.fixture.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/sidecar.fixture.ts
@@ -24,6 +24,20 @@ export const fixtureChainSpec: SidecarRuntimeSpec = {
   properties: { ss58Format: "0", tokenDecimals: "10", tokenSymbol: "DOT" },
 };
 
+export const bittensorRuntimeSpec: SidecarRuntimeSpec = {
+  at: {
+    height: "4000000",
+    hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+  },
+  authoringVersion: "0",
+  transactionVersion: "1",
+  implVersion: "0",
+  specName: "node-subtensor",
+  specVersion: "200",
+  chainType: {},
+  properties: { ss58Format: "42", tokenDecimals: "9", tokenSymbol: "TAO" },
+};
+
 export const fixtureStakingProgress = {
   at: {
     hash: "0x3b7c2e6a80cd7d3a323e043fdb950d5e0d51397e87e358adbbfbd3fae4c3007f",

--- a/libs/coin-modules/coin-polkadot/src/network/sidecar.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/sidecar.ts
@@ -62,7 +62,7 @@ const getElectionOptimisticThreshold = (currency?: CryptoCurrency): number => {
 };
 
 const VALIDATOR_COMISSION_RATIO = 1000000000;
-const UNSUPPORTED_STAKING_NETWORKS = ["polkadot", "westend"];
+const UNSUPPORTED_STAKING_NETWORKS = ["polkadot", "westend", "bittensor"];
 
 // Fallback values used when Sidecar const endpoints are unreachable.
 const DEFAULT_CONSTANTS = {

--- a/libs/coin-modules/coin-polkadot/src/signer/getAddress.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/signer/getAddress.test.ts
@@ -1,0 +1,108 @@
+import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import type { PolkadotSigner } from "../types";
+import getAddress from "./getAddress";
+
+const makeSignerContext =
+  (mockSigner: PolkadotSigner) =>
+  <T>(_deviceId: string, fn: (signer: PolkadotSigner) => Promise<T>): Promise<T> =>
+    fn(mockSigner);
+
+const makeCurrency = (id: string): CryptoCurrency =>
+  ({
+    id,
+    type: "CryptoCurrency",
+    name: id,
+    managerAppName: id,
+    ticker: id.toUpperCase(),
+    scheme: id,
+    color: "#000000",
+    family: "polkadot",
+    coinType: 434,
+    units: [{ name: id, code: id.toUpperCase(), magnitude: 9 }],
+    explorerViews: [],
+  }) as unknown as CryptoCurrency;
+
+describe("getAddress ss58prefix routing", () => {
+  const fakeSigner: PolkadotSigner = {
+    getAddress: jest.fn().mockResolvedValue({
+      address: "fake_address",
+      pubKey: "fake_pubkey",
+      return_code: 0,
+    }),
+    sign: jest.fn(),
+  };
+
+  const signerContext = makeSignerContext(fakeSigner);
+  const getAddressFn = getAddress(signerContext);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("passes ss58prefix=0 for polkadot", async () => {
+    await getAddressFn("deviceId", {
+      currency: makeCurrency("polkadot"),
+      path: "44'/434'/0'/0/0",
+      derivationMode: "",
+    });
+    expect(fakeSigner.getAddress).toHaveBeenCalledWith("44'/434'/0'/0/0", 0, undefined);
+  });
+
+  it("passes ss58prefix=0 for assethub_polkadot", async () => {
+    await getAddressFn("deviceId", {
+      currency: makeCurrency("assethub_polkadot"),
+      path: "44'/434'/0'/0/0",
+      derivationMode: "",
+    });
+    expect(fakeSigner.getAddress).toHaveBeenCalledWith("44'/434'/0'/0/0", 0, undefined);
+  });
+
+  it("passes ss58prefix=42 for westend", async () => {
+    await getAddressFn("deviceId", {
+      currency: makeCurrency("westend"),
+      path: "44'/434'/0'/0/0",
+      derivationMode: "",
+    });
+    expect(fakeSigner.getAddress).toHaveBeenCalledWith("44'/434'/0'/0/0", 42, undefined);
+  });
+
+  it("passes ss58prefix=42 for assethub_westend", async () => {
+    await getAddressFn("deviceId", {
+      currency: makeCurrency("assethub_westend"),
+      path: "44'/434'/0'/0/0",
+      derivationMode: "",
+    });
+    expect(fakeSigner.getAddress).toHaveBeenCalledWith("44'/434'/0'/0/0", 42, undefined);
+  });
+
+  it("passes ss58prefix=42 for bittensor", async () => {
+    await getAddressFn("deviceId", {
+      currency: makeCurrency("bittensor"),
+      path: "44'/434'/0'/0/0",
+      derivationMode: "",
+    });
+    expect(fakeSigner.getAddress).toHaveBeenCalledWith("44'/434'/0'/0/0", 42, undefined);
+  });
+
+  it("defaults to ss58prefix=0 for an unknown currency", async () => {
+    await getAddressFn("deviceId", {
+      currency: makeCurrency("unknown_chain"),
+      path: "44'/434'/0'/0/0",
+      derivationMode: "",
+    });
+    expect(fakeSigner.getAddress).toHaveBeenCalledWith("44'/434'/0'/0/0", 0, undefined);
+  });
+
+  it("returns address, publicKey and path from signer response", async () => {
+    const result = await getAddressFn("deviceId", {
+      currency: makeCurrency("polkadot"),
+      path: "44'/434'/0'/0/0",
+      derivationMode: "",
+    });
+    expect(result).toEqual({
+      address: "fake_address",
+      publicKey: "fake_pubkey",
+      path: "44'/434'/0'/0/0",
+    });
+  });
+});

--- a/libs/coin-modules/coin-polkadot/src/signer/getAddress.ts
+++ b/libs/coin-modules/coin-polkadot/src/signer/getAddress.ts
@@ -1,11 +1,13 @@
 import { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
 import { GetAddressOptions } from "@ledgerhq/ledger-wallet-framework/derivation";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
+import { getSs58Prefix } from "../common";
 import type { PolkadotSigner } from "../types";
 
 const getAddress = (signerContext: SignerContext<PolkadotSigner>): GetAddressFn => {
-  return async (deviceId: string, { path, verify }: GetAddressOptions) => {
-    const r = await signerContext(deviceId, signer => signer.getAddress(path, 0, verify));
+  return async (deviceId: string, { path, verify, currency }: GetAddressOptions) => {
+    const ss58prefix = getSs58Prefix(currency?.id);
+    const r = await signerContext(deviceId, signer => signer.getAddress(path, ss58prefix, verify));
     return {
       address: r.address,
       publicKey: r.pubKey,

--- a/libs/ledger-live-common/src/families/polkadot/config.ts
+++ b/libs/ledger-live-common/src/families/polkadot/config.ts
@@ -94,4 +94,29 @@ export const polkadotConfig: Record<string, ConfigInfo> = {
       },
     },
   },
+  config_currency_bittensor: {
+    type: "object",
+    default: {
+      status: {
+        type: "active",
+        features: [
+          { id: "blockchain_txs", status: "active" },
+          { id: "staking_txs", status: "active" },
+        ],
+      },
+      // Endpoints are provided and overridden via Firebase Remote Config (infra: T-CS-01); empty by default.
+      sidecar: {
+        url: "",
+      },
+      node: {
+        url: "",
+      },
+      indexer: {
+        url: "",
+      },
+      staking: {
+        electionStatusThreshold: 25,
+      },
+    },
+  },
 };


### PR DESCRIPTION
### ✅ Checklist
- [x] `npx changeset` was attached.
- [x] Covered by automatic tests.
- [ ] Impact of the changes:
  - Extends the existing `coin-polkadot` module with a Bittensor (TAO) currency
    configuration. The config is INERT until the currency is registered and enabled
    downstream (feature flag `currencyBittensor`, currency registration). No existing
    currency behaviour changes. QA focus: non-regression on polkadot-family currencies
    (polkadot, asset hub, westend) — covered by a dedicated regression test.

### 📝 Description
Adds Bittensor (TAO) support to the polkadot coin module:
- New `config_currency_bittensor` entry; Sidecar/Node/Indexer URLs resolved via
  `getEnv("API_BITTENSOR_*")` (same mechanism as `config_currency_polkadot`), overridden
  by remote config in production — no hardcoded endpoint, empty by default.
- New env vars `API_BITTENSOR_SIDECAR` / `API_BITTENSOR_NODE` / `API_BITTENSOR_INDEXER`.
- SS58 prefix 42 handling for Bittensor in address derivation (`getAddress`) and
  validation (`validateAddress`, `getTransactionStatus`).

The currency is not yet registered nor exposed; this PR only lays the coin-module
groundwork. Endpoints become required only at E2E / production activation, provisioned
separately via remote config.

### ❓ Context
- **JIRA link**: [LIVE-30997](https://ledgerhq.atlassian.net/browse/LIVE-30997)
- **ADR link**: n/a


[LIVE-30997]: https://ledgerhq.atlassian.net/browse/LIVE-30997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ