### PR TITLE
[LWDM] feat(LIVE-31602): hedera sdk client configuration in coin config

### DIFF
--- a/.changeset/kind-pears-brake.md
+++ b/.changeset/kind-pears-brake.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+feat: hedera sdk client configuration in coin config

--- a/libs/coin-modules/coin-hedera/src/config.ts
+++ b/libs/coin-modules/coin-hedera/src/config.ts
@@ -11,6 +11,12 @@ export interface HederaConfig {
    */
   useNetworkTimestamp: boolean;
   networkType: "mainnet" | "testnet";
+  sdkClientOptions?: {
+    maxAttempts?: number;
+    requestTimeout?: number;
+    minBackoff?: number;
+    maxBackoff?: number;
+  };
   apiUrls: {
     mirrorNode: string;
     hgraph: string;

--- a/libs/coin-modules/coin-hedera/src/network/rpc.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/rpc.test.ts
@@ -6,19 +6,20 @@ import { rpcClient } from "./rpc";
 
 const mockCurrency = getMockedCurrency();
 
-const mockClient = {
-  close: jest.fn(),
-  setMaxNodesPerTransaction: jest.fn().mockReturnThis(),
-  setNetwork: jest.fn().mockReturnThis(),
-  updateNetwork: jest.fn(),
-} as unknown as Client;
+const createMockClient = (): Client =>
+  ({
+    close: jest.fn(),
+    setMaxAttempts: jest.fn(),
+    setMaxBackoff: jest.fn(),
+    setMaxNodesPerTransaction: jest.fn(),
+    setMinBackoff: jest.fn(),
+    setNetwork: jest.fn(),
+    setRequestTimeout: jest.fn(),
+    updateNetwork: jest.fn(),
+  }) as unknown as Client;
 
-const mockTestnetClient = {
-  close: jest.fn(),
-  setMaxNodesPerTransaction: jest.fn().mockReturnThis(),
-  setNetwork: jest.fn().mockReturnThis(),
-  updateNetwork: jest.fn(),
-} as unknown as Client;
+const mockClient = createMockClient();
+const mockTestnetClient = createMockClient();
 
 jest.mock("@hashgraph/sdk", () => {
   return {
@@ -75,6 +76,56 @@ describe("rpcClient", () => {
       expect(testnetClient).toBe(mockTestnetClient);
       expect(mainnetClient2).toBe(mainnetClient);
       expect(testnetClient2).toBe(testnetClient);
+    });
+
+    it("applies sdkClient options from config", async () => {
+      const configWithSdkOptions = {
+        ...mockConfig,
+        sdkClientOptions: {
+          maxAttempts: 0,
+          requestTimeout: 5_000,
+          minBackoff: 100,
+          maxBackoff: 500,
+        },
+      };
+
+      await rpcClient.getInstance(configWithSdkOptions);
+
+      expect(mockClient.setMaxNodesPerTransaction).toHaveBeenCalledWith(1);
+      expect(mockClient.setMaxAttempts).toHaveBeenCalledWith(0);
+      expect(mockClient.setRequestTimeout).toHaveBeenCalledWith(5_000);
+      expect(mockClient.setMinBackoff).toHaveBeenCalledWith(100);
+      expect(mockClient.setMaxBackoff).toHaveBeenCalledWith(500);
+    });
+
+    it("does not apply sdk retry options when sdkClientOptions is omitted", async () => {
+      await rpcClient.getInstance(mockConfig);
+
+      expect(mockClient.setMaxNodesPerTransaction).toHaveBeenCalledWith(1);
+      expect(mockClient.setMaxAttempts).not.toHaveBeenCalled();
+      expect(mockClient.setRequestTimeout).not.toHaveBeenCalled();
+      expect(mockClient.setMinBackoff).not.toHaveBeenCalled();
+      expect(mockClient.setMaxBackoff).not.toHaveBeenCalled();
+    });
+
+    it("creates separate cached clients for different sdkClientOptions settings on the same network", async () => {
+      const defaultSdkClient = createMockClient();
+      jest
+        .mocked(Client.forMainnetAsync)
+        .mockResolvedValueOnce(mockClient)
+        .mockResolvedValueOnce(defaultSdkClient);
+
+      const noRetryConfig = { ...mockConfig, sdkClientOptions: { maxAttempts: 0 } };
+      const defaultRetryConfig = { ...mockConfig };
+
+      const noRetryClient = await rpcClient.getInstance(noRetryConfig);
+      const defaultRetryClient = await rpcClient.getInstance(defaultRetryConfig);
+
+      expect(Client.forMainnetAsync).toHaveBeenCalledTimes(2);
+      expect(noRetryClient).toBe(mockClient);
+      expect(defaultRetryClient).toBe(defaultSdkClient);
+      expect(mockClient.setMaxAttempts).toHaveBeenCalledWith(0);
+      expect(defaultSdkClient.setMaxAttempts).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/coin-modules/coin-hedera/src/network/rpc.ts
+++ b/libs/coin-modules/coin-hedera/src/network/rpc.ts
@@ -1,6 +1,6 @@
 import type { Transaction as HederaTransaction, TransactionResponse } from "@hashgraph/sdk";
 import { Client } from "@hashgraph/sdk";
-import { type HederaCoinConfig } from "../config";
+import type { HederaCoinConfig } from "../config";
 import { resolveConfig } from "../logic/utils";
 
 async function broadcastTransaction({
@@ -15,29 +15,56 @@ async function broadcastTransaction({
 
 const _hederaClients: Map<string, Promise<Client>> = new Map();
 
-async function createClient(networkType: string): Promise<Client> {
+function getClientCacheKey(config: HederaCoinConfig): string {
+  if (config.sdkClientOptions) {
+    return `${config.networkType}:${JSON.stringify(config.sdkClientOptions)}`;
+  }
+
+  return config.networkType;
+}
+
+function applySdkClientOptions(client: Client, config: HederaCoinConfig): void {
+  if (typeof config.sdkClientOptions?.maxAttempts === "number") {
+    client.setMaxAttempts(config.sdkClientOptions.maxAttempts);
+  }
+  if (typeof config.sdkClientOptions?.requestTimeout === "number") {
+    client.setRequestTimeout(config.sdkClientOptions.requestTimeout);
+  }
+  if (typeof config.sdkClientOptions?.minBackoff === "number") {
+    client.setMinBackoff(config.sdkClientOptions.minBackoff);
+  }
+  if (typeof config.sdkClientOptions?.maxBackoff === "number") {
+    client.setMaxBackoff(config.sdkClientOptions.maxBackoff);
+  }
+}
+
+async function createClient(config: HederaCoinConfig): Promise<Client> {
   const client =
-    networkType === "mainnet" ? await Client.forMainnetAsync() : await Client.forTestnetAsync();
+    config.networkType === "mainnet"
+      ? await Client.forMainnetAsync()
+      : await Client.forTestnetAsync();
 
   // limit max nodes per transaction to 1 to avoid multiple signatures
   client.setMaxNodesPerTransaction(1);
+  applySdkClientOptions(client, config);
 
   return client;
 }
 
 async function getInstance(configOrCurrencyId: HederaCoinConfig | string): Promise<Client> {
-  const { networkType } = resolveConfig(configOrCurrencyId);
+  const config = resolveConfig(configOrCurrencyId);
+  const cacheKey = getClientCacheKey(config);
 
-  if (!_hederaClients.has(networkType)) {
-    const promise = createClient(networkType).catch(error => {
-      _hederaClients.delete(networkType);
+  if (!_hederaClients.has(cacheKey)) {
+    const promise = createClient(config).catch(error => {
+      _hederaClients.delete(cacheKey);
       throw error;
     });
 
-    _hederaClients.set(networkType, promise);
+    _hederaClients.set(cacheKey, promise);
   }
 
-  return _hederaClients.get(networkType)!;
+  return _hederaClients.get(cacheKey)!;
 }
 
 // for testing purposes only, used to reset singleton client instances


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Hedera SDK configuration can be now optionally overridden with coin configuration

### 📝 Description

This PR adds `sdkClientOptions` to coin-hedera configuration, it can be used to override following SDK defaults:
- maxAttempts
- requestTimeout
- minBackoff
- maxBackoff

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-31602

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
