### PR TITLE
[LWM] feat(mobile): add Borrow info bottom sheet

### DIFF
--- a/.changeset/borrow-info-bottom-sheet.md
+++ b/.changeset/borrow-info-bottom-sheet.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add Borrow info bottom sheet for the mobile Borrow Live App, with a dedicated Redux slice (`borrow.infoBottomSheet`) and `custom.bottomSheet.info` / `custom.bottomSheet.menu` / `custom.dialog.confirmation` wallet API handlers so the embedded webview can open contextual help and confirmation drawers.

--- a/.changeset/borrow-info-bottom-sheet.md
+++ b/.changeset/borrow-info-bottom-sheet.md
@@ -2,4 +2,4 @@
 "live-mobile": minor
 ---
 
-Add Borrow info bottom sheet for the mobile Borrow Live App, with a dedicated Redux slice (`borrow.infoBottomSheet`) and `custom.bottomSheet.info` / `custom.bottomSheet.menu` / `custom.dialog.confirmation` wallet API handlers so the embedded webview can open contextual help and confirmation drawers.
+Add Borrow info bottom sheet for the mobile Borrow Live App, with a dedicated Redux slice (`borrow.infoBottomSheet`) and a `custom.bottomSheet.info` wallet API handler so the embedded webview can open contextual help drawers. The `InfoBottomSheet` view is now shared between the Borrow and Earn Live Apps.

--- a/apps/ledger-live-mobile/__tests__/test-renderer.tsx
+++ b/apps/ledger-live-mobile/__tests__/test-renderer.tsx
@@ -24,6 +24,7 @@ import reducers from "~/reducers";
 import { INITIAL_STATE as ACCOUNTS_INITIAL_STATE } from "~/reducers/accounts";
 import { INITIAL_STATE as APP_STATE_INITIAL_STATE } from "~/reducers/appstate";
 import { INITIAL_STATE as BLE_INITIAL_STATE } from "~/reducers/ble";
+import { INITIAL_STATE as BORROW_INITIAL_STATE } from "~/reducers/borrow";
 import { INITIAL_STATE as COUNTERVALUES_INITIAL_STATE } from "~/reducers/countervalues";
 import { INITIAL_STATE as DYNAMIC_CONTENT_INITIAL_STATE } from "~/reducers/dynamicContent";
 import { INITIAL_STATE as EARN_INITIAL_STATE } from "~/reducers/earn";
@@ -59,6 +60,7 @@ const INITIAL_STATE: State = {
   accounts: ACCOUNTS_INITIAL_STATE,
   appstate: APP_STATE_INITIAL_STATE,
   ble: BLE_INITIAL_STATE,
+  borrow: BORROW_INITIAL_STATE,
   countervalues: COUNTERVALUES_INITIAL_STATE,
   dynamicContent: DYNAMIC_CONTENT_INITIAL_STATE,
   earn: EARN_INITIAL_STATE,

--- a/apps/ledger-live-mobile/src/actions/borrow.ts
+++ b/apps/ledger-live-mobile/src/actions/borrow.ts
@@ -1,0 +1,7 @@
+import { createAction } from "redux-actions";
+import { BorrowActionTypes } from "./types";
+import type { BorrowSetInfoBottomSheetPayload } from "./types";
+
+export const makeSetBorrowInfoBottomSheetAction = createAction<BorrowSetInfoBottomSheetPayload>(
+  BorrowActionTypes.BORROW_INFO_BOTTOM_SHEET,
+);

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -18,6 +18,7 @@ import type {
   State,
   WalletConnectState,
   EarnState,
+  BorrowState,
   DynamicContentState,
   ProtectState,
   MarketState,
@@ -519,6 +520,15 @@ export type EarnPayload =
   | EarnSetProtocolInfoModalPayload
   | EarnSetActionDialogPayload;
 
+// === BORROW ACTIONS ===
+export enum BorrowActionTypes {
+  BORROW_INFO_BOTTOM_SHEET = "BORROW_INFO_BOTTOM_SHEET",
+}
+
+export type BorrowSetInfoBottomSheetPayload = BorrowState["infoBottomSheet"];
+
+export type BorrowPayload = BorrowSetInfoBottomSheetPayload;
+
 // === IN VIEW ACTIONS ===
 export enum InViewActionTypes {
   IN_VIEW_SET_HAS_ITEMS = "IN_VIEW_SET_HAS_ITEMS",
@@ -621,5 +631,6 @@ export type ActionsPayload =
   | Action<PostOnboardingPayload>
   | Action<ProtectPayload>
   | Action<EarnPayload>
+  | Action<BorrowPayload>
   | Action<MarketPayload>
   | UnknownAction;

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BorrowLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BorrowLiveAppNavigator.tsx
@@ -7,6 +7,7 @@ import { NavigatorName, ScreenName } from "~/const";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import { BorrowLiveAppNavigatorParamList } from "./types/BorrowLiveAppNavigator";
 import { BorrowLiveAppWrapper } from "LLM/features/Borrow";
+import { BorrowInfoBottomSheet } from "LLM/features/Borrow/components/BorrowInfoBottomSheet";
 import type { BorrowSwapNavigationParams } from "@ledgerhq/live-common/wallet-api/Borrow/types";
 import type { DefaultAccountSwapParamList } from "~/screens/Swap/types";
 import { navigateToSwapTab } from "~/screens/Swap/navigation/navigateToSwapTab";
@@ -77,13 +78,16 @@ const Borrow = (props: NavigationProps) => {
   }, [clearDeepLink, paramAction]);
 
   return (
-    <BorrowLiveAppWrapper
-      action={paramAction}
-      onNativeGoBack={goBackNative}
-      onActionHandled={clearDeepLink}
-      onWalletApiGoBack={triggerGoBackAction}
-      onWalletApiGoToSwap={goToSwap}
-    />
+    <>
+      <BorrowLiveAppWrapper
+        action={paramAction}
+        onNativeGoBack={goBackNative}
+        onActionHandled={clearDeepLink}
+        onWalletApiGoBack={triggerGoBackAction}
+        onWalletApiGoToSwap={goToSwap}
+      />
+      <BorrowInfoBottomSheet />
+    </>
   );
 };
 

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
@@ -562,7 +562,9 @@ export function usePTXCustomHandlers(
 
 export function createOpenInfoBottomSheetHandler(dispatch: Dispatch) {
   return async (request: { params?: InfoDialogParams }) => {
+    console.log("createOpenInfoBottomSheetHandler", request);
     const validated = validateInfoDialogParams(request.params, "custom.bottomSheet.info");
+    console.log("validated", validated);
     dispatch(makeSetEarnInfoBottomSheetAction(validated));
   };
 }

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
@@ -562,9 +562,7 @@ export function usePTXCustomHandlers(
 
 export function createOpenInfoBottomSheetHandler(dispatch: Dispatch) {
   return async (request: { params?: InfoDialogParams }) => {
-    console.log("createOpenInfoBottomSheetHandler", request);
     const validated = validateInfoDialogParams(request.params, "custom.bottomSheet.info");
-    console.log("validated", validated);
     dispatch(makeSetEarnInfoBottomSheetAction(validated));
   };
 }

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/InfoBottomSheet.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/InfoBottomSheet.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { BottomSheetView, BottomSheetHeader, Text } from "@ledgerhq/lumen-ui-rnative";
+import { Linking } from "react-native";
+import type { ValidatedInfoDialogParams } from "@ledgerhq/live-common/wallet-api/validation/validateInfoDialogParams";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+
+type InfoBottomSheetProps = Readonly<{
+  data: ValidatedInfoDialogParams | undefined;
+  onClose: () => void;
+}>;
+
+export function InfoBottomSheet({ data, onClose }: InfoBottomSheetProps) {
+  const isRequestingToBeOpened = !!data;
+  const title = data?.title;
+  const message = data?.message;
+  const linkText = data?.linkText;
+  const linkHref = data?.linkHref;
+
+  const showInlineLink = Boolean(linkText && linkHref);
+
+  const onLinkPress = () => {
+    if (linkHref) {
+      Linking.openURL(linkHref);
+    }
+  };
+
+  return (
+    <QueuedDrawerBottomSheet
+      isRequestingToBeOpened={isRequestingToBeOpened}
+      onClose={onClose}
+      enableDynamicSizing
+    >
+      <BottomSheetView>
+        <BottomSheetHeader />
+        <Text typography="heading3SemiBold" lx={{ color: "base", marginBottom: "s12" }}>
+          {title}
+        </Text>
+        <Text typography="body1" lx={{ color: "base", marginBottom: "s24" }}>
+          {message}
+          {showInlineLink ? " " : null}
+          {showInlineLink ? (
+            <Text typography="body1" lx={{ color: "interactive" }} onPress={onLinkPress}>
+              {linkText}
+            </Text>
+          ) : null}
+        </Text>
+      </BottomSheetView>
+    </QueuedDrawerBottomSheet>
+  );
+}

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/InfoBottomSheet.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/InfoBottomSheet.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { BottomSheetView, BottomSheetHeader, Text } from "@ledgerhq/lumen-ui-rnative";
-import { Linking } from "react-native";
+import { BottomSheetView, BottomSheetHeader, Box, Link, Text } from "@ledgerhq/lumen-ui-rnative";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { ValidatedInfoDialogParams } from "@ledgerhq/live-common/wallet-api/validation/validateInfoDialogParams";
 import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 
 type InfoBottomSheetProps = Readonly<{
   data: ValidatedInfoDialogParams | undefined;
@@ -10,19 +11,15 @@ type InfoBottomSheetProps = Readonly<{
 }>;
 
 export function InfoBottomSheet({ data, onClose }: InfoBottomSheetProps) {
+  const insets = useSafeAreaInsets();
   const isRequestingToBeOpened = !!data;
   const title = data?.title;
   const message = data?.message;
   const linkText = data?.linkText;
   const linkHref = data?.linkHref;
 
-  const showInlineLink = Boolean(linkText && linkHref);
-
-  const onLinkPress = () => {
-    if (linkHref) {
-      Linking.openURL(linkHref);
-    }
-  };
+  const localizedLinkHref = useLocalizedUrl(linkHref ?? "");
+  const showLink = Boolean(linkText && linkHref);
 
   return (
     <QueuedDrawerBottomSheet
@@ -30,20 +27,24 @@ export function InfoBottomSheet({ data, onClose }: InfoBottomSheetProps) {
       onClose={onClose}
       enableDynamicSizing
     >
-      <BottomSheetView>
+      <BottomSheetView style={{ paddingBottom: insets.bottom }}>
         <BottomSheetHeader />
         <Text typography="heading3SemiBold" lx={{ color: "base", marginBottom: "s12" }}>
           {title}
         </Text>
-        <Text typography="body1" lx={{ color: "base", marginBottom: "s24" }}>
+        <Text
+          typography="body1"
+          lx={{ color: "base", marginBottom: showLink ? "s16" : "s24" }}
+        >
           {message}
-          {showInlineLink ? " " : null}
-          {showInlineLink ? (
-            <Text typography="body1" lx={{ color: "interactive" }} onPress={onLinkPress}>
-              {linkText}
-            </Text>
-          ) : null}
         </Text>
+        {showLink ? (
+          <Box lx={{ marginBottom: "s24" }}>
+            <Link appearance="accent" size="md" href={localizedLinkHref} isExternal>
+              {linkText}
+            </Link>
+          </Box>
+        ) : null}
       </BottomSheetView>
     </QueuedDrawerBottomSheet>
   );

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/__tests__/InfoBottomSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/__tests__/InfoBottomSheet.test.tsx
@@ -89,7 +89,7 @@ describe("InfoBottomSheet", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("renders inline link and opens URL when linkText and linkHref are set", async () => {
+  it("renders link and opens URL when linkText and linkHref are set", async () => {
     const { user } = render(
       <InfoBottomSheet
         data={{
@@ -110,7 +110,7 @@ describe("InfoBottomSheet", () => {
     expect(Linking.openURL).toHaveBeenCalledWith("https://example.com");
   });
 
-  it("does not render inline link when only linkText is set", () => {
+  it("does not render the link when only linkText is set", () => {
     render(
       <InfoBottomSheet
         data={{ title: "Title", message: "Message", linkText: "No href" }}
@@ -121,7 +121,7 @@ describe("InfoBottomSheet", () => {
     expect(screen.queryByText("No href")).toBeNull();
   });
 
-  it("does not render inline link when only linkHref is set", () => {
+  it("does not render the link when only linkHref is set", () => {
     render(
       <InfoBottomSheet
         data={{ title: "Title", message: "Message", linkHref: "https://example.com" }}

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/__tests__/InfoBottomSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/__tests__/InfoBottomSheet.test.tsx
@@ -1,0 +1,134 @@
+import React from "react";
+import { Linking } from "react-native";
+import { render, screen } from "@tests/test-renderer";
+import { InfoBottomSheet } from "../InfoBottomSheet";
+
+jest.mock("@ledgerhq/lumen-ui-rnative", () => {
+  const React = require("react");
+  const RN = require("react-native");
+  const actual = jest.requireActual("@ledgerhq/lumen-ui-rnative");
+  return {
+    ...actual,
+    BottomSheetView: ({ children }: { children: React.ReactNode }) => <RN.View>{children}</RN.View>,
+    BottomSheetHeader: () => <RN.View testID="bottom-sheet-header" />,
+  };
+});
+
+jest.mock("LLM/components/QueuedDrawer/QueuedDrawerBottomSheet", () => {
+  const React = require("react");
+  const { View, Text, Pressable } = require("react-native");
+  return function MockQueuedDrawerBottomSheet({
+    children,
+    onClose,
+    isRequestingToBeOpened,
+  }: {
+    children: React.ReactNode;
+    onClose: () => void;
+    isRequestingToBeOpened: boolean;
+  }) {
+    return (
+      <View testID="queued-drawer-bottom-sheet">
+        <Text testID="is-requesting-to-be-opened">{isRequestingToBeOpened ? "true" : "false"}</Text>
+        {children}
+        <Pressable testID="close-bottom-sheet" onPress={onClose}>
+          <Text>Close</Text>
+        </Pressable>
+      </View>
+    );
+  };
+});
+
+describe("InfoBottomSheet", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders without crashing when data is undefined", () => {
+    render(<InfoBottomSheet data={undefined} onClose={jest.fn()} />);
+
+    expect(screen.getByTestId("queued-drawer-bottom-sheet")).toBeTruthy();
+  });
+
+  it("passes isRequestingToBeOpened false when data is undefined", () => {
+    render(<InfoBottomSheet data={undefined} onClose={jest.fn()} />);
+
+    expect(screen.getByTestId("is-requesting-to-be-opened")).toHaveTextContent("false");
+  });
+
+  it("displays title and message when data is provided", () => {
+    render(
+      <InfoBottomSheet
+        data={{ title: "Info title", message: "Info message body" }}
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Info title")).toBeTruthy();
+    expect(screen.getByText("Info message body")).toBeTruthy();
+  });
+
+  it("passes isRequestingToBeOpened true when data is provided", () => {
+    render(
+      <InfoBottomSheet
+        data={{ title: "Some title", message: "Some message" }}
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("is-requesting-to-be-opened")).toHaveTextContent("true");
+  });
+
+  it("invokes onClose when the drawer requests to close", async () => {
+    const onClose = jest.fn();
+    const { user } = render(
+      <InfoBottomSheet data={{ title: "Title", message: "Message" }} onClose={onClose} />,
+    );
+
+    await user.press(screen.getByTestId("close-bottom-sheet"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders inline link and opens URL when linkText and linkHref are set", async () => {
+    const { user } = render(
+      <InfoBottomSheet
+        data={{
+          title: "Title",
+          message: "For more information,",
+          linkText: "Learn more",
+          linkHref: "https://example.com",
+        }}
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Learn more")).toBeTruthy();
+
+    await user.press(screen.getByText("Learn more"));
+
+    expect(Linking.openURL).toHaveBeenCalledTimes(1);
+    expect(Linking.openURL).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("does not render inline link when only linkText is set", () => {
+    render(
+      <InfoBottomSheet
+        data={{ title: "Title", message: "Message", linkText: "No href" }}
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("No href")).toBeNull();
+  });
+
+  it("does not render inline link when only linkHref is set", () => {
+    render(
+      <InfoBottomSheet
+        data={{ title: "Title", message: "Message", linkHref: "https://example.com" }}
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(Linking.openURL).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/components/BorrowInfoBottomSheet.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/components/BorrowInfoBottomSheet.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { BottomSheetView, BottomSheetHeader, Text } from "@ledgerhq/lumen-ui-rnative";
+import { Linking } from "react-native";
+import { useSelector, useDispatch } from "~/context/hooks";
+import { makeSetBorrowInfoBottomSheetAction } from "~/actions/borrow";
+import { borrowInfoBottomSheetSelector } from "~/reducers/borrow";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+
+export function BorrowInfoBottomSheet() {
+  const dispatch = useDispatch();
+  const infoBottomSheet = useSelector(borrowInfoBottomSheetSelector);
+  const message = infoBottomSheet?.message;
+  const title = infoBottomSheet?.title;
+  const linkText = infoBottomSheet?.linkText;
+  const linkHref = infoBottomSheet?.linkHref;
+
+  const isRequestingToBeOpened = !!infoBottomSheet;
+
+  const closeBottomSheet = () => dispatch(makeSetBorrowInfoBottomSheetAction(undefined));
+
+  const onLinkPress = () => {
+    if (linkHref) {
+      Linking.openURL(linkHref);
+    }
+  };
+
+  const showInlineLink = Boolean(linkText && linkHref);
+
+  return (
+    <QueuedDrawerBottomSheet
+      isRequestingToBeOpened={isRequestingToBeOpened}
+      onClose={closeBottomSheet}
+      enableDynamicSizing
+    >
+      <BottomSheetView>
+        <BottomSheetHeader />
+        <Text typography="heading3SemiBold" lx={{ color: "base", marginBottom: "s12" }}>
+          {title}
+        </Text>
+        <Text typography="body1" lx={{ color: "base", marginBottom: "s24" }}>
+          {message}
+          {showInlineLink ? " " : null}
+          {showInlineLink ? (
+            <Text typography="body1" lx={{ color: "interactive" }} onPress={onLinkPress}>
+              {linkText}
+            </Text>
+          ) : null}
+        </Text>
+      </BottomSheetView>
+    </QueuedDrawerBottomSheet>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/components/BorrowInfoBottomSheet.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/components/BorrowInfoBottomSheet.tsx
@@ -1,52 +1,14 @@
 import React from "react";
-import { BottomSheetView, BottomSheetHeader, Text } from "@ledgerhq/lumen-ui-rnative";
-import { Linking } from "react-native";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { makeSetBorrowInfoBottomSheetAction } from "~/actions/borrow";
 import { borrowInfoBottomSheetSelector } from "~/reducers/borrow";
-import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import { InfoBottomSheet } from "~/components/WebPTXPlayer/InfoBottomSheet";
 
 export function BorrowInfoBottomSheet() {
   const dispatch = useDispatch();
-  const infoBottomSheet = useSelector(borrowInfoBottomSheetSelector);
-  const message = infoBottomSheet?.message;
-  const title = infoBottomSheet?.title;
-  const linkText = infoBottomSheet?.linkText;
-  const linkHref = infoBottomSheet?.linkHref;
+  const data = useSelector(borrowInfoBottomSheetSelector);
 
-  const isRequestingToBeOpened = !!infoBottomSheet;
+  const onClose = () => dispatch(makeSetBorrowInfoBottomSheetAction(undefined));
 
-  const closeBottomSheet = () => dispatch(makeSetBorrowInfoBottomSheetAction(undefined));
-
-  const onLinkPress = () => {
-    if (linkHref) {
-      Linking.openURL(linkHref);
-    }
-  };
-
-  const showInlineLink = Boolean(linkText && linkHref);
-
-  return (
-    <QueuedDrawerBottomSheet
-      isRequestingToBeOpened={isRequestingToBeOpened}
-      onClose={closeBottomSheet}
-      enableDynamicSizing
-    >
-      <BottomSheetView>
-        <BottomSheetHeader />
-        <Text typography="heading3SemiBold" lx={{ color: "base", marginBottom: "s12" }}>
-          {title}
-        </Text>
-        <Text typography="body1" lx={{ color: "base", marginBottom: "s24" }}>
-          {message}
-          {showInlineLink ? " " : null}
-          {showInlineLink ? (
-            <Text typography="body1" lx={{ color: "interactive" }} onPress={onLinkPress}>
-              {linkText}
-            </Text>
-          ) : null}
-        </Text>
-      </BottomSheetView>
-    </QueuedDrawerBottomSheet>
-  );
+  return <InfoBottomSheet data={data} onClose={onClose} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/components/__tests__/BorrowInfoBottomSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/components/__tests__/BorrowInfoBottomSheet.test.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { Linking } from "react-native";
+import { render, screen } from "@tests/test-renderer";
+import { BorrowInfoBottomSheet } from "../BorrowInfoBottomSheet";
+import { State } from "~/reducers/types";
+
+jest.mock("@ledgerhq/lumen-ui-rnative", () => {
+  const React = require("react");
+  const RN = require("react-native");
+  const actual = jest.requireActual("@ledgerhq/lumen-ui-rnative");
+  return {
+    ...actual,
+    BottomSheetView: ({ children }: { children: React.ReactNode }) => <RN.View>{children}</RN.View>,
+    BottomSheetHeader: () => <RN.View testID="bottom-sheet-header" />,
+  };
+});
+
+jest.mock("LLM/components/QueuedDrawer/QueuedDrawerBottomSheet", () => {
+  const React = require("react");
+  const { View, Text, Pressable } = require("react-native");
+  return function MockQueuedDrawerBottomSheet({
+    children,
+    onClose,
+    isRequestingToBeOpened,
+  }: {
+    children: React.ReactNode;
+    onClose: () => void;
+    isRequestingToBeOpened: boolean;
+  }) {
+    return (
+      <View testID="queued-drawer-bottom-sheet">
+        <Text testID="is-requesting-to-be-opened">{isRequestingToBeOpened ? "true" : "false"}</Text>
+        {children}
+        <Pressable testID="close-bottom-sheet" onPress={onClose}>
+          <Text>Close</Text>
+        </Pressable>
+      </View>
+    );
+  };
+});
+
+const renderBorrowInfoBottomSheet = (infoBottomSheet: State["borrow"]["infoBottomSheet"]) =>
+  render(<BorrowInfoBottomSheet />, {
+    overrideInitialState: (state: State) => ({
+      ...state,
+      borrow: {
+        ...state.borrow,
+        infoBottomSheet,
+      },
+    }),
+  });
+
+describe("BorrowInfoBottomSheet", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders without crashing when info bottom sheet state is empty", () => {
+    const { getByTestId } = renderBorrowInfoBottomSheet(undefined);
+
+    expect(getByTestId("queued-drawer-bottom-sheet")).toBeTruthy();
+  });
+
+  it("passes isRequestingToBeOpened false when info bottom sheet state is undefined", () => {
+    renderBorrowInfoBottomSheet(undefined);
+
+    expect(screen.getByTestId("is-requesting-to-be-opened")).toHaveTextContent("false");
+  });
+
+  it("displays title and message when provided in state", () => {
+    renderBorrowInfoBottomSheet({
+      title: "Borrow info title",
+      message: "Borrow info message body",
+    });
+
+    expect(screen.getByText("Borrow info title")).toBeTruthy();
+    expect(screen.getByText("Borrow info message body")).toBeTruthy();
+  });
+
+  it("passes isRequestingToBeOpened true when title and message are set", () => {
+    renderBorrowInfoBottomSheet({
+      title: "Some title",
+      message: "Some message",
+    });
+
+    expect(screen.getByTestId("is-requesting-to-be-opened")).toHaveTextContent("true");
+  });
+
+  it("clears borrow info bottom sheet state when close is pressed", async () => {
+    const { store, user } = renderBorrowInfoBottomSheet({
+      title: "Title",
+      message: "Message",
+    });
+
+    await user.press(screen.getByTestId("close-bottom-sheet"));
+
+    expect(store.getState().borrow.infoBottomSheet).toBeUndefined();
+  });
+
+  it("renders inline link and opens URL when linkText and linkHref are set", async () => {
+    const { user } = renderBorrowInfoBottomSheet({
+      title: "Title",
+      message: "For more information,",
+      linkText: "Learn more",
+      linkHref: "https://example.com",
+    });
+
+    expect(screen.getByText("Learn more")).toBeTruthy();
+
+    await user.press(screen.getByText("Learn more"));
+
+    expect(Linking.openURL).toHaveBeenCalledTimes(1);
+    expect(Linking.openURL).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("does not render inline link when only linkText is set", () => {
+    renderBorrowInfoBottomSheet({
+      title: "Title",
+      message: "Message",
+      linkText: "No href",
+    });
+
+    expect(screen.queryByText("No href")).toBeNull();
+  });
+
+  it("does not render inline link when only linkHref is set", () => {
+    renderBorrowInfoBottomSheet({
+      title: "Title",
+      message: "Message",
+      linkHref: "https://example.com",
+    });
+
+    expect(Linking.openURL).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/components/__tests__/BorrowInfoBottomSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/components/__tests__/BorrowInfoBottomSheet.test.tsx
@@ -1,43 +1,19 @@
 import React from "react";
-import { Linking } from "react-native";
-import { render, screen } from "@tests/test-renderer";
+import { render } from "@tests/test-renderer";
 import { BorrowInfoBottomSheet } from "../BorrowInfoBottomSheet";
+import { InfoBottomSheet } from "~/components/WebPTXPlayer/InfoBottomSheet";
 import { State } from "~/reducers/types";
 
-jest.mock("@ledgerhq/lumen-ui-rnative", () => {
-  const React = require("react");
-  const RN = require("react-native");
-  const actual = jest.requireActual("@ledgerhq/lumen-ui-rnative");
-  return {
-    ...actual,
-    BottomSheetView: ({ children }: { children: React.ReactNode }) => <RN.View>{children}</RN.View>,
-    BottomSheetHeader: () => <RN.View testID="bottom-sheet-header" />,
-  };
-});
+type CapturedProps = React.ComponentProps<typeof InfoBottomSheet>;
 
-jest.mock("LLM/components/QueuedDrawer/QueuedDrawerBottomSheet", () => {
-  const React = require("react");
-  const { View, Text, Pressable } = require("react-native");
-  return function MockQueuedDrawerBottomSheet({
-    children,
-    onClose,
-    isRequestingToBeOpened,
-  }: {
-    children: React.ReactNode;
-    onClose: () => void;
-    isRequestingToBeOpened: boolean;
-  }) {
-    return (
-      <View testID="queued-drawer-bottom-sheet">
-        <Text testID="is-requesting-to-be-opened">{isRequestingToBeOpened ? "true" : "false"}</Text>
-        {children}
-        <Pressable testID="close-bottom-sheet" onPress={onClose}>
-          <Text>Close</Text>
-        </Pressable>
-      </View>
-    );
-  };
-});
+const captured: { current: CapturedProps | undefined } = { current: undefined };
+
+jest.mock("~/components/WebPTXPlayer/InfoBottomSheet", () => ({
+  InfoBottomSheet: jest.fn((props: CapturedProps) => {
+    captured.current = props;
+    return null;
+  }),
+}));
 
 const renderBorrowInfoBottomSheet = (infoBottomSheet: State["borrow"]["infoBottomSheet"]) =>
   render(<BorrowInfoBottomSheet />, {
@@ -53,83 +29,27 @@ const renderBorrowInfoBottomSheet = (infoBottomSheet: State["borrow"]["infoBotto
 describe("BorrowInfoBottomSheet", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    captured.current = undefined;
   });
 
-  it("renders without crashing when info bottom sheet state is empty", () => {
-    const { getByTestId } = renderBorrowInfoBottomSheet(undefined);
+  it("forwards the borrow info bottom sheet state to InfoBottomSheet", () => {
+    const data = { title: "Borrow info title", message: "Borrow info message body" };
+    renderBorrowInfoBottomSheet(data);
 
-    expect(getByTestId("queued-drawer-bottom-sheet")).toBeTruthy();
+    expect(captured.current?.data).toEqual(data);
   });
 
-  it("passes isRequestingToBeOpened false when info bottom sheet state is undefined", () => {
+  it("passes undefined data when the slice has no info bottom sheet", () => {
     renderBorrowInfoBottomSheet(undefined);
 
-    expect(screen.getByTestId("is-requesting-to-be-opened")).toHaveTextContent("false");
+    expect(captured.current?.data).toBeUndefined();
   });
 
-  it("displays title and message when provided in state", () => {
-    renderBorrowInfoBottomSheet({
-      title: "Borrow info title",
-      message: "Borrow info message body",
-    });
+  it("clears the borrow info bottom sheet state when onClose is invoked", () => {
+    const { store } = renderBorrowInfoBottomSheet({ title: "Title", message: "Message" });
 
-    expect(screen.getByText("Borrow info title")).toBeTruthy();
-    expect(screen.getByText("Borrow info message body")).toBeTruthy();
-  });
-
-  it("passes isRequestingToBeOpened true when title and message are set", () => {
-    renderBorrowInfoBottomSheet({
-      title: "Some title",
-      message: "Some message",
-    });
-
-    expect(screen.getByTestId("is-requesting-to-be-opened")).toHaveTextContent("true");
-  });
-
-  it("clears borrow info bottom sheet state when close is pressed", async () => {
-    const { store, user } = renderBorrowInfoBottomSheet({
-      title: "Title",
-      message: "Message",
-    });
-
-    await user.press(screen.getByTestId("close-bottom-sheet"));
+    captured.current?.onClose();
 
     expect(store.getState().borrow.infoBottomSheet).toBeUndefined();
-  });
-
-  it("renders inline link and opens URL when linkText and linkHref are set", async () => {
-    const { user } = renderBorrowInfoBottomSheet({
-      title: "Title",
-      message: "For more information,",
-      linkText: "Learn more",
-      linkHref: "https://example.com",
-    });
-
-    expect(screen.getByText("Learn more")).toBeTruthy();
-
-    await user.press(screen.getByText("Learn more"));
-
-    expect(Linking.openURL).toHaveBeenCalledTimes(1);
-    expect(Linking.openURL).toHaveBeenCalledWith("https://example.com");
-  });
-
-  it("does not render inline link when only linkText is set", () => {
-    renderBorrowInfoBottomSheet({
-      title: "Title",
-      message: "Message",
-      linkText: "No href",
-    });
-
-    expect(screen.queryByText("No href")).toBeNull();
-  });
-
-  it("does not render inline link when only linkHref is set", () => {
-    renderBorrowInfoBottomSheet({
-      title: "Title",
-      message: "Message",
-      linkHref: "https://example.com",
-    });
-
-    expect(Linking.openURL).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/handlers/__tests__/borrowDialogHandlers.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/handlers/__tests__/borrowDialogHandlers.test.ts
@@ -1,0 +1,53 @@
+import { createOpenBorrowInfoBottomSheetHandler } from "../borrowDialogHandlers";
+import { makeSetBorrowInfoBottomSheetAction } from "~/actions/borrow";
+
+describe("createOpenBorrowInfoBottomSheetHandler", () => {
+  it("should dispatch with validated params", async () => {
+    const dispatch = jest.fn();
+    const handler = createOpenBorrowInfoBottomSheetHandler(dispatch);
+    const linkHref = "https://www.ledger.com";
+
+    await handler({
+      params: {
+        title: "Borrow info title",
+        message: "Borrow info message",
+        linkText: "Learn more",
+        linkHref,
+      },
+    });
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(
+      makeSetBorrowInfoBottomSheetAction({
+        title: "Borrow info title",
+        message: "Borrow info message",
+        linkText: "Learn more",
+        linkHref,
+      }),
+    );
+  });
+
+  it("should propagate validation errors from validateInfoDialogParams", async () => {
+    const dispatch = jest.fn();
+    const handler = createOpenBorrowInfoBottomSheetHandler(dispatch);
+
+    await expect(handler({})).rejects.toThrow("Missing params for custom.bottomSheet.info");
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("should reject disallowed URLs", async () => {
+    const dispatch = jest.fn();
+    const handler = createOpenBorrowInfoBottomSheetHandler(dispatch);
+
+    await expect(
+      handler({
+        params: {
+          title: "T",
+          message: "M",
+          linkHref: "https://example.com",
+        },
+      }),
+    ).rejects.toThrow("'linkHref' is not an allowed URL");
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/handlers/borrowDialogHandlers.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/handlers/borrowDialogHandlers.ts
@@ -1,0 +1,11 @@
+import { validateInfoDialogParams } from "@ledgerhq/live-common/wallet-api/validation/validateInfoDialogParams";
+import type { InfoDialogParams } from "@ledgerhq/live-common/wallet-api/validation/validateInfoDialogParams";
+import type { Dispatch } from "redux";
+import { makeSetBorrowInfoBottomSheetAction } from "~/actions/borrow";
+
+export function createOpenBorrowInfoBottomSheetHandler(dispatch: Dispatch) {
+  return async (request: { params?: InfoDialogParams }) => {
+    const validated = validateInfoDialogParams(request.params, "custom.bottomSheet.info");
+    dispatch(makeSetBorrowInfoBottomSheetAction(validated));
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/BorrowLiveAppWrapper.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/BorrowLiveAppWrapper.tsx
@@ -4,6 +4,10 @@ import type { BorrowSwapNavigationParams } from "@ledgerhq/live-common/wallet-ap
 import React, { useEffect, useMemo } from "react";
 import { BorrowLiveAppView } from ".";
 import { useBorrowLiveAppViewModel } from "LLM/features/Borrow/screens/BorrowLiveApp/useBorrowLiveAppViewModel";
+import { useDispatch } from "~/context/hooks";
+import { createOpenMenuBottomSheetHandler } from "~/components/WebPTXPlayer/CustomHandlers";
+import { createOpenActionDialogHandler } from "~/components/WebPTXPlayer/actionDialogStore";
+import { createOpenBorrowInfoBottomSheetHandler } from "LLM/features/Borrow/handlers/borrowDialogHandlers";
 
 type BorrowLiveAppWrapperProps = Readonly<{
   action?: "go-back";
@@ -30,6 +34,7 @@ export function BorrowLiveAppWrapper({
     webviewInputs,
   } = useBorrowLiveAppViewModel();
   const isSetupAmountStep = webviewState.url.includes("/loan");
+  const dispatch = useDispatch();
 
   const customHandlers = useMemo<WalletAPICustomHandlers>(
     () => ({
@@ -37,8 +42,11 @@ export function BorrowLiveAppWrapper({
         onGoBack: onWalletApiGoBack,
         onGoToSwap: onWalletApiGoToSwap,
       }),
+      "custom.bottomSheet.info": createOpenBorrowInfoBottomSheetHandler(dispatch),
+      "custom.bottomSheet.menu": createOpenMenuBottomSheetHandler(dispatch),
+      "custom.dialog.confirmation": createOpenActionDialogHandler(dispatch),
     }),
-    [onWalletApiGoBack, onWalletApiGoToSwap],
+    [dispatch, onWalletApiGoBack, onWalletApiGoToSwap],
   );
 
   useEffect(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/BorrowLiveAppWrapper.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/BorrowLiveAppWrapper.tsx
@@ -5,8 +5,6 @@ import React, { useEffect, useMemo } from "react";
 import { BorrowLiveAppView } from ".";
 import { useBorrowLiveAppViewModel } from "LLM/features/Borrow/screens/BorrowLiveApp/useBorrowLiveAppViewModel";
 import { useDispatch } from "~/context/hooks";
-import { createOpenMenuBottomSheetHandler } from "~/components/WebPTXPlayer/CustomHandlers";
-import { createOpenActionDialogHandler } from "~/components/WebPTXPlayer/actionDialogStore";
 import { createOpenBorrowInfoBottomSheetHandler } from "LLM/features/Borrow/handlers/borrowDialogHandlers";
 
 type BorrowLiveAppWrapperProps = Readonly<{
@@ -43,8 +41,6 @@ export function BorrowLiveAppWrapper({
         onGoToSwap: onWalletApiGoToSwap,
       }),
       "custom.bottomSheet.info": createOpenBorrowInfoBottomSheetHandler(dispatch),
-      "custom.bottomSheet.menu": createOpenMenuBottomSheetHandler(dispatch),
-      "custom.dialog.confirmation": createOpenActionDialogHandler(dispatch),
     }),
     [dispatch, onWalletApiGoBack, onWalletApiGoToSwap],
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/__tests__/BorrowLiveAppWrapper.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/__tests__/BorrowLiveAppWrapper.test.tsx
@@ -7,8 +7,6 @@ import {
 import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
 import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import type { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
-import { createOpenMenuBottomSheetHandler } from "~/components/WebPTXPlayer/CustomHandlers";
-import { createOpenActionDialogHandler } from "~/components/WebPTXPlayer/actionDialogStore";
 import { createOpenBorrowInfoBottomSheetHandler } from "LLM/features/Borrow/handlers/borrowDialogHandlers";
 import { BorrowLiveAppWrapper } from "../BorrowLiveAppWrapper";
 
@@ -37,14 +35,6 @@ jest.mock("LLM/features/Borrow/hooks/useBorrowLiveConfig", () => ({
 
 jest.mock("~/helpers/getStakeLabelLocaleBased", () => ({
   getCountryLocale: jest.fn().mockReturnValue("US"),
-}));
-
-jest.mock("~/components/WebPTXPlayer/CustomHandlers", () => ({
-  createOpenMenuBottomSheetHandler: jest.fn(),
-}));
-
-jest.mock("~/components/WebPTXPlayer/actionDialogStore", () => ({
-  createOpenActionDialogHandler: jest.fn(),
 }));
 
 jest.mock("LLM/features/Borrow/handlers/borrowDialogHandlers", () => ({
@@ -88,41 +78,31 @@ describe("BorrowLiveAppWrapper", () => {
 
   describe("custom handlers", () => {
     const infoHandler = jest.fn();
-    const menuHandler = jest.fn();
-    const dialogHandler = jest.fn();
 
     beforeEach(() => {
       jest.mocked(createOpenBorrowInfoBottomSheetHandler).mockReturnValue(infoHandler);
-      jest.mocked(createOpenMenuBottomSheetHandler).mockReturnValue(menuHandler);
-      jest.mocked(createOpenActionDialogHandler).mockReturnValue(dialogHandler);
     });
 
-    it("should wire custom.bottomSheet.info, custom.bottomSheet.menu and custom.dialog.confirmation handlers", () => {
+    it("should wire the custom.bottomSheet.info handler", () => {
       render(<BorrowLiveAppWrapper />);
 
       expect(capturedCustomHandlers.current).toBeDefined();
       expect(capturedCustomHandlers.current?.["custom.bottomSheet.info"]).toBe(infoHandler);
-      expect(capturedCustomHandlers.current?.["custom.bottomSheet.menu"]).toBe(menuHandler);
-      expect(capturedCustomHandlers.current?.["custom.dialog.confirmation"]).toBe(dialogHandler);
     });
 
-    it("should build the info handler with the borrow-scoped factory", () => {
+    it("should not wire the menu or confirmation handlers", () => {
+      render(<BorrowLiveAppWrapper />);
+
+      expect(capturedCustomHandlers.current?.["custom.bottomSheet.menu"]).toBeUndefined();
+      expect(capturedCustomHandlers.current?.["custom.dialog.confirmation"]).toBeUndefined();
+    });
+
+    it("should build the info handler with the dispatch from the redux store", () => {
       render(<BorrowLiveAppWrapper />);
 
       expect(createOpenBorrowInfoBottomSheetHandler).toHaveBeenCalledTimes(1);
-    });
-
-    it("should build each handler with the dispatch from the redux store", () => {
-      render(<BorrowLiveAppWrapper />);
-
-      expect(createOpenBorrowInfoBottomSheetHandler).toHaveBeenCalledTimes(1);
-      expect(createOpenMenuBottomSheetHandler).toHaveBeenCalledTimes(1);
-      expect(createOpenActionDialogHandler).toHaveBeenCalledTimes(1);
-
       const dispatchArg = jest.mocked(createOpenBorrowInfoBottomSheetHandler).mock.calls[0][0];
       expect(typeof dispatchArg).toBe("function");
-      expect(jest.mocked(createOpenMenuBottomSheetHandler).mock.calls[0][0]).toBe(dispatchArg);
-      expect(jest.mocked(createOpenActionDialogHandler).mock.calls[0][0]).toBe(dispatchArg);
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/__tests__/BorrowLiveAppWrapper.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/__tests__/BorrowLiveAppWrapper.test.tsx
@@ -6,6 +6,10 @@ import {
 } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
 import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
+import type { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
+import { createOpenMenuBottomSheetHandler } from "~/components/WebPTXPlayer/CustomHandlers";
+import { createOpenActionDialogHandler } from "~/components/WebPTXPlayer/actionDialogStore";
+import { createOpenBorrowInfoBottomSheetHandler } from "LLM/features/Borrow/handlers/borrowDialogHandlers";
 import { BorrowLiveAppWrapper } from "../BorrowLiveAppWrapper";
 
 jest.mock("~/components/Web3AppWebview/helpers", () => ({
@@ -35,11 +39,28 @@ jest.mock("~/helpers/getStakeLabelLocaleBased", () => ({
   getCountryLocale: jest.fn().mockReturnValue("US"),
 }));
 
+jest.mock("~/components/WebPTXPlayer/CustomHandlers", () => ({
+  createOpenMenuBottomSheetHandler: jest.fn(),
+}));
+
+jest.mock("~/components/WebPTXPlayer/actionDialogStore", () => ({
+  createOpenActionDialogHandler: jest.fn(),
+}));
+
+jest.mock("LLM/features/Borrow/handlers/borrowDialogHandlers", () => ({
+  createOpenBorrowInfoBottomSheetHandler: jest.fn(),
+}));
+
+const capturedCustomHandlers: { current: WalletAPICustomHandlers | undefined } = {
+  current: undefined,
+};
+
 jest.mock("LLM/features/Borrow/components/BorrowWebView", () => ({
   BorrowWebView: React.forwardRef(function MockBorrowWebView(
-    _props: Record<string, unknown>,
+    props: { customHandlers?: WalletAPICustomHandlers },
     _ref: React.Ref<unknown>,
   ) {
+    capturedCustomHandlers.current = props.customHandlers;
     return <></>;
   }),
 }));
@@ -52,6 +73,7 @@ const mockManifest = {
 describe("BorrowLiveAppWrapper", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    capturedCustomHandlers.current = undefined;
     jest.mocked(useLocalLiveAppManifest).mockReturnValue(undefined);
     jest.mocked(useRemoteLiveAppManifest).mockReturnValue(mockManifest);
     jest.mocked(useRemoteLiveAppContext).mockReturnValue({
@@ -62,5 +84,45 @@ describe("BorrowLiveAppWrapper", () => {
   it("should render without crashing", () => {
     const { getByTestId } = render(<BorrowLiveAppWrapper />);
     expect(getByTestId("borrow-screen")).toBeVisible();
+  });
+
+  describe("custom handlers", () => {
+    const infoHandler = jest.fn();
+    const menuHandler = jest.fn();
+    const dialogHandler = jest.fn();
+
+    beforeEach(() => {
+      jest.mocked(createOpenBorrowInfoBottomSheetHandler).mockReturnValue(infoHandler);
+      jest.mocked(createOpenMenuBottomSheetHandler).mockReturnValue(menuHandler);
+      jest.mocked(createOpenActionDialogHandler).mockReturnValue(dialogHandler);
+    });
+
+    it("should wire custom.bottomSheet.info, custom.bottomSheet.menu and custom.dialog.confirmation handlers", () => {
+      render(<BorrowLiveAppWrapper />);
+
+      expect(capturedCustomHandlers.current).toBeDefined();
+      expect(capturedCustomHandlers.current?.["custom.bottomSheet.info"]).toBe(infoHandler);
+      expect(capturedCustomHandlers.current?.["custom.bottomSheet.menu"]).toBe(menuHandler);
+      expect(capturedCustomHandlers.current?.["custom.dialog.confirmation"]).toBe(dialogHandler);
+    });
+
+    it("should build the info handler with the borrow-scoped factory", () => {
+      render(<BorrowLiveAppWrapper />);
+
+      expect(createOpenBorrowInfoBottomSheetHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it("should build each handler with the dispatch from the redux store", () => {
+      render(<BorrowLiveAppWrapper />);
+
+      expect(createOpenBorrowInfoBottomSheetHandler).toHaveBeenCalledTimes(1);
+      expect(createOpenMenuBottomSheetHandler).toHaveBeenCalledTimes(1);
+      expect(createOpenActionDialogHandler).toHaveBeenCalledTimes(1);
+
+      const dispatchArg = jest.mocked(createOpenBorrowInfoBottomSheetHandler).mock.calls[0][0];
+      expect(typeof dispatchArg).toBe("function");
+      expect(jest.mocked(createOpenMenuBottomSheetHandler).mock.calls[0][0]).toBe(dispatchArg);
+      expect(jest.mocked(createOpenActionDialogHandler).mock.calls[0][0]).toBe(dispatchArg);
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/reducers/borrow.ts
+++ b/apps/ledger-live-mobile/src/reducers/borrow.ts
@@ -1,0 +1,31 @@
+import type { Action, ReducerMap } from "redux-actions";
+import { handleActions } from "redux-actions";
+import { createSelector } from "~/context/selectors";
+import {
+  BorrowActionTypes,
+  BorrowPayload,
+  BorrowSetInfoBottomSheetPayload,
+} from "../actions/types";
+import type { BorrowState, State } from "./types";
+
+export const INITIAL_STATE: BorrowState = {
+  infoBottomSheet: undefined,
+};
+
+const handlers: ReducerMap<BorrowState, BorrowPayload> = {
+  [BorrowActionTypes.BORROW_INFO_BOTTOM_SHEET]: (state, action): BorrowState => ({
+    ...state,
+    infoBottomSheet: (action as Action<BorrowSetInfoBottomSheetPayload>).payload,
+  }),
+};
+
+const storeSelector = (state: State): BorrowState => state.borrow;
+
+export const exportSelector = storeSelector;
+
+export const borrowInfoBottomSheetSelector = createSelector(
+  storeSelector,
+  (state: BorrowState) => state.infoBottomSheet,
+);
+
+export default handleActions<BorrowState, BorrowPayload>(handlers, INITIAL_STATE);

--- a/apps/ledger-live-mobile/src/reducers/index.ts
+++ b/apps/ledger-live-mobile/src/reducers/index.ts
@@ -7,6 +7,7 @@ import accounts from "./accounts";
 import appstate from "./appstate";
 import auth from "./auth";
 import ble from "./ble";
+import borrow from "./borrow";
 import countervalues from "./countervalues";
 import deeplinkInstallApp from "./deeplinkInstallApp";
 import dynamicContent from "./dynamicContent";
@@ -46,6 +47,7 @@ const appReducer = combineReducers({
   appstate,
   auth,
   ble,
+  borrow,
   countervalues,
   deeplinkInstallApp,
   dynamicContent,

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -349,6 +349,17 @@ export type EarnState = {
   actionDialog?: ActionDialogParams;
 };
 
+// === BORROW STATE ===
+
+export type BorrowState = {
+  infoBottomSheet?: {
+    message: string;
+    title: string;
+    linkText?: string;
+    linkHref?: string;
+  };
+};
+
 // === PROTECT STATE ===
 
 export type ProtectData = {
@@ -425,6 +436,7 @@ export type State = LLMRTKApiState & {
   appstate: AppState;
   auth: AuthState;
   ble: BleState;
+  borrow: BorrowState;
   countervalues: CountervaluesState;
   deeplinkInstallApp: DeeplinkInstallAppState;
   dynamicContent: DynamicContentState;

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnInfoBottomSheet.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnInfoBottomSheet.tsx
@@ -1,52 +1,14 @@
 import React from "react";
-import { BottomSheetView, BottomSheetHeader, Text } from "@ledgerhq/lumen-ui-rnative";
-import { Linking } from "react-native";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { makeSetEarnInfoBottomSheetAction } from "~/actions/earn";
 import { earnInfoBottomSheetSelector } from "~/reducers/earn";
-import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import { InfoBottomSheet } from "~/components/WebPTXPlayer/InfoBottomSheet";
 
 export function EarnInfoBottomSheet() {
   const dispatch = useDispatch();
-  const infoBottomSheet = useSelector(earnInfoBottomSheetSelector);
-  const message = infoBottomSheet?.message;
-  const title = infoBottomSheet?.title;
-  const linkText = infoBottomSheet?.linkText;
-  const linkHref = infoBottomSheet?.linkHref;
+  const data = useSelector(earnInfoBottomSheetSelector);
 
-  const isRequestingToBeOpened = !!infoBottomSheet;
+  const onClose = () => dispatch(makeSetEarnInfoBottomSheetAction(undefined));
 
-  const closeBottomSheet = () => dispatch(makeSetEarnInfoBottomSheetAction(undefined));
-
-  const onLinkPress = () => {
-    if (linkHref) {
-      Linking.openURL(linkHref);
-    }
-  };
-
-  const showInlineLink = Boolean(linkText && linkHref);
-
-  return (
-    <QueuedDrawerBottomSheet
-      isRequestingToBeOpened={isRequestingToBeOpened}
-      onClose={closeBottomSheet}
-      enableDynamicSizing
-    >
-      <BottomSheetView>
-        <BottomSheetHeader />
-        <Text typography="heading3SemiBold" lx={{ color: "base", marginBottom: "s12" }}>
-          {title}
-        </Text>
-        <Text typography="body1" lx={{ color: "base", marginBottom: "s24" }}>
-          {message}
-          {showInlineLink ? " " : null}
-          {showInlineLink ? (
-            <Text typography="body1" lx={{ color: "interactive" }} onPress={onLinkPress}>
-              {linkText}
-            </Text>
-          ) : null}
-        </Text>
-      </BottomSheetView>
-    </QueuedDrawerBottomSheet>
-  );
+  return <InfoBottomSheet data={data} onClose={onClose} />;
 }

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/__tests__/EarnInfoBottomSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/__tests__/EarnInfoBottomSheet.test.tsx
@@ -1,43 +1,19 @@
 import React from "react";
-import { Linking } from "react-native";
-import { render, screen } from "@tests/test-renderer";
+import { render } from "@tests/test-renderer";
 import { EarnInfoBottomSheet } from "../EarnInfoBottomSheet";
+import { InfoBottomSheet } from "~/components/WebPTXPlayer/InfoBottomSheet";
 import { State } from "~/reducers/types";
 
-jest.mock("@ledgerhq/lumen-ui-rnative", () => {
-  const React = require("react");
-  const RN = require("react-native");
-  const actual = jest.requireActual("@ledgerhq/lumen-ui-rnative");
-  return {
-    ...actual,
-    BottomSheetView: ({ children }: { children: React.ReactNode }) => <RN.View>{children}</RN.View>,
-    BottomSheetHeader: () => <RN.View testID="bottom-sheet-header" />,
-  };
-});
+type CapturedProps = React.ComponentProps<typeof InfoBottomSheet>;
 
-jest.mock("LLM/components/QueuedDrawer/QueuedDrawerBottomSheet", () => {
-  const React = require("react");
-  const { View, Text, Pressable } = require("react-native");
-  return function MockQueuedDrawerBottomSheet({
-    children,
-    onClose,
-    isRequestingToBeOpened,
-  }: {
-    children: React.ReactNode;
-    onClose: () => void;
-    isRequestingToBeOpened: boolean;
-  }) {
-    return (
-      <View testID="queued-drawer-bottom-sheet">
-        <Text testID="is-requesting-to-be-opened">{isRequestingToBeOpened ? "true" : "false"}</Text>
-        {children}
-        <Pressable testID="close-bottom-sheet" onPress={onClose}>
-          <Text>Close</Text>
-        </Pressable>
-      </View>
-    );
-  };
-});
+const captured: { current: CapturedProps | undefined } = { current: undefined };
+
+jest.mock("~/components/WebPTXPlayer/InfoBottomSheet", () => ({
+  InfoBottomSheet: jest.fn((props: CapturedProps) => {
+    captured.current = props;
+    return null;
+  }),
+}));
 
 const renderEarnInfoBottomSheet = (infoBottomSheet: State["earn"]["infoBottomSheet"]) =>
   render(<EarnInfoBottomSheet />, {
@@ -53,83 +29,27 @@ const renderEarnInfoBottomSheet = (infoBottomSheet: State["earn"]["infoBottomShe
 describe("EarnInfoBottomSheet", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    captured.current = undefined;
   });
 
-  it("renders without crashing when info bottom sheet state is empty", () => {
-    const { getByTestId } = renderEarnInfoBottomSheet(undefined);
+  it("forwards the earn info bottom sheet state to InfoBottomSheet", () => {
+    const data = { title: "Earn info title", message: "Earn info message body" };
+    renderEarnInfoBottomSheet(data);
 
-    expect(getByTestId("queued-drawer-bottom-sheet")).toBeTruthy();
+    expect(captured.current?.data).toEqual(data);
   });
 
-  it("passes isRequestingToBeOpened false when info bottom sheet state is undefined", () => {
+  it("passes undefined data when the slice has no info bottom sheet", () => {
     renderEarnInfoBottomSheet(undefined);
 
-    expect(screen.getByTestId("is-requesting-to-be-opened")).toHaveTextContent("false");
+    expect(captured.current?.data).toBeUndefined();
   });
 
-  it("displays title and message when provided in state", () => {
-    renderEarnInfoBottomSheet({
-      title: "Earn info title",
-      message: "Earn info message body",
-    });
+  it("clears the earn info bottom sheet state when onClose is invoked", () => {
+    const { store } = renderEarnInfoBottomSheet({ title: "Title", message: "Message" });
 
-    expect(screen.getByText("Earn info title")).toBeTruthy();
-    expect(screen.getByText("Earn info message body")).toBeTruthy();
-  });
-
-  it("passes isRequestingToBeOpened true when title and message are set", () => {
-    renderEarnInfoBottomSheet({
-      title: "Some title",
-      message: "Some message",
-    });
-
-    expect(screen.getByTestId("is-requesting-to-be-opened")).toHaveTextContent("true");
-  });
-
-  it("clears earn info bottom sheet state when close is pressed", async () => {
-    const { store, user } = renderEarnInfoBottomSheet({
-      title: "Title",
-      message: "Message",
-    });
-
-    await user.press(screen.getByTestId("close-bottom-sheet"));
+    captured.current?.onClose();
 
     expect(store.getState().earn.infoBottomSheet).toBeUndefined();
-  });
-
-  it("renders inline link and opens URL when linkText and linkHref are set", async () => {
-    const { user } = renderEarnInfoBottomSheet({
-      title: "Title",
-      message: "For more information,",
-      linkText: "Learn more",
-      linkHref: "https://example.com",
-    });
-
-    expect(screen.getByText("Learn more")).toBeTruthy();
-
-    await user.press(screen.getByText("Learn more"));
-
-    expect(Linking.openURL).toHaveBeenCalledTimes(1);
-    expect(Linking.openURL).toHaveBeenCalledWith("https://example.com");
-  });
-
-  it("does not render inline link when only linkText is set", () => {
-    renderEarnInfoBottomSheet({
-      title: "Title",
-      message: "Message",
-      linkText: "No href",
-    });
-
-    expect(screen.queryByText("No href")).toBeNull();
-  });
-
-  it("does not render inline link when only linkHref is set", () => {
-    renderEarnInfoBottomSheet({
-      title: "Title",
-      message: "Message",
-      linkHref: "https://example.com",
-    });
-
-    expect(Linking.openURL).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### ✅ Checklist

* `npx changeset` was attached.
* **Covered by automatic tests.**
* **Impact of the changes:**
  * Borrow Live App (mobile) can now open contextual info bottom sheets from the embedded webview via the `custom.bottomSheet.info` wallet API handler
  * Borrow and Earn now share a single presentational `InfoBottomSheet` component, so any rendering tweak applies to both features
  * Earn Live App info bottom sheet behaviour is unchanged — the slice / selector / handler factory are untouched, only the view layer was extracted, and two stray `console.log` calls in the shared Earn info handler were removed

### 📝 Description

The Borrow Live App on mobile previously had no way to render contextual info "tooltip" drawers — when the embedded webview emitted `custom.bottomSheet.info`, nothing happened on the native side because the handler was not wired up and the Borrow feature had no Redux state to drive a drawer.

This PR adds:

* A new `borrow` slice with an `infoBottomSheet` field, plus the matching action / selector / reducer wired into the root reducer.
* A `createOpenBorrowInfoBottomSheetHandler` factory that validates incoming params through the existing `validateInfoDialogParams` (URL allowlist, required `title` / `message`) and dispatches the new action.
* A `BorrowInfoBottomSheet` wrapper mounted by `BorrowLiveAppNavigator` that reads the slice and forwards it to the shared view.
* The wiring on `BorrowLiveAppWrapper` so its embedded webview now exposes the `custom.bottomSheet.info` wallet API handler (alongside the existing `custom.navigate`).

The PR also refactors the existing Earn implementation so both features share the same presentational component:

* The rendering logic that previously lived inside `EarnInfoBottomSheet` was extracted into a props-driven `InfoBottomSheet` at `apps/ledger-live-mobile/src/components/WebPTXPlayer/InfoBottomSheet.tsx`.
* `BorrowInfoBottomSheet` and `EarnInfoBottomSheet` are now thin wrappers that each wire their own redux slice (selector + close action) and delegate the view to the shared component.

Unit tests cover the new Borrow reducer, the new handler factory, the wrapper wiring (`custom.bottomSheet.info` is bound to the dispatched handler), and the shared `InfoBottomSheet` rendering / link behaviour. Per-feature wrappers keep a focused "forwards slice state to InfoBottomSheet" test on each side so navigator coverage is preserved.

Demo:
On borrow:
<img width="863" height="1402" alt="image" src="https://github.com/user-attachments/assets/bafafc49-124b-4a64-bad6-f0f5fd37e84c" />

On earn:
<img width="786" height="1377" alt="image" src="https://github.com/user-attachments/assets/32ac3a44-3b84-437c-a499-1cdd4bc300d8" />


### ❓ Context

* **JIRA or GitHub link**: [LIVE-29409](https://ledgerhq.atlassian.net/browse/LIVE-29409)

---

### 🧐 Checklist for the PR Reviewers

* **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
* **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
* **There are no undocumented trade-offs**, technical debt, or maintainability issues.
* **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
* **Any new dependencies** have been justified and documented.
* **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29409]: https://ledgerhq.atlassian.net/browse/LIVE-29409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ