### PR TITLE
[LWM] fix(llm/earn): return to Earn tab when leaving an intent flow

### DIFF
--- a/.changeset/earn-return-to-tab-on-intent-exit.md
+++ b/.changeset/earn-return-to-tab-on-intent-exit.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Earn dashboard losing its background and main navigation (top bar + tab bar) after returning from an in-webview intent flow (deposit/withdraw/simulate). The active flow is now derived from the live webview URL instead of the stale native `intent` param, and the app navigates back to the Earn dashboard tab when the flow is exited.

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/__tests__/EarnV2Webview.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/__tests__/EarnV2Webview.test.tsx
@@ -1,7 +1,14 @@
 import React from "react";
 import { render, screen, withFlagOverrides } from "@tests/test-renderer";
 import { EarnV2Webview } from "../index";
+import { NavigatorName } from "~/const";
 import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
+
+const mockNavigate = jest.fn();
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
 
 jest.mock("@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index", () => ({
   useRemoteLiveAppContext: () => ({ state: { isLoading: false } }),
@@ -11,9 +18,23 @@ jest.mock("LLM/hooks/useNavigationBarHeights", () => ({
   useNavigationBarHeights: () => ({ topBarHeight: 0, bottomBarHeight: 0 }),
 }));
 
+let mockWebviewUrl: string | undefined;
+
 jest.mock("../../EarnWebview", () => {
   const { View } = require("react-native");
-  return { EarnWebview: () => <View testID="earn-webview" /> };
+  const ReactLib = require("react");
+  return {
+    EarnWebview: ({
+      onWebviewStateChange,
+    }: {
+      onWebviewStateChange?: (state: { url?: string }) => void;
+    }) => {
+      ReactLib.useEffect(() => {
+        onWebviewStateChange?.({ url: mockWebviewUrl });
+      }, [onWebviewStateChange]);
+      return <View testID="earn-webview" />;
+    },
+  };
 });
 
 jest.mock("LLM/components/LiveAppBackground", () => {
@@ -44,6 +65,11 @@ const STUB_MANIFEST: LiveAppManifest = {
 const ERROR = new Error("manifest not found");
 
 describe("EarnV2Webview", () => {
+  beforeEach(() => {
+    mockWebviewUrl = undefined;
+    mockNavigate.mockClear();
+  });
+
   it("renders LiveAppBackground when ptxEarnUi is v2", () => {
     render(<EarnV2Webview manifest={STUB_MANIFEST} appManifestNotFoundError={ERROR} />, {
       overrideInitialState: withFlagOverrides({
@@ -85,5 +111,111 @@ describe("EarnV2Webview", () => {
     );
 
     expect(screen.queryByTestId("live-app-background")).toBeNull();
+  });
+
+  it("keeps LiveAppBackground hidden while the webview is on a deposit URL", () => {
+    mockWebviewUrl = "https://earn.test/v2/android/deposit?intent=deposit&uiVersion=v4";
+
+    render(
+      <EarnV2Webview manifest={STUB_MANIFEST} appManifestNotFoundError={ERROR} hideMainNavigator />,
+      {
+        overrideInitialState: withFlagOverrides({
+          ptxEarnUi: { enabled: true, params: { value: "v2" } },
+        }),
+      },
+    );
+
+    expect(screen.queryByTestId("live-app-background")).toBeNull();
+  });
+
+  it("restores LiveAppBackground when the webview navigates back to the dashboard despite a stale deposit intent", () => {
+    mockWebviewUrl = "https://earn.test/v2/android/homescreen?uiVersion=v4";
+
+    render(
+      <EarnV2Webview manifest={STUB_MANIFEST} appManifestNotFoundError={ERROR} hideMainNavigator />,
+      {
+        overrideInitialState: withFlagOverrides({
+          ptxEarnUi: { enabled: true, params: { value: "v2" } },
+        }),
+      },
+    );
+
+    expect(screen.getByTestId("live-app-background")).toBeTruthy();
+  });
+
+  it("returns to the Earn dashboard tab when the intent flow webview navigates out of the intent route", () => {
+    mockWebviewUrl = "https://earn.test/v2/android/homescreen?uiVersion=v4";
+
+    render(
+      <EarnV2Webview manifest={STUB_MANIFEST} appManifestNotFoundError={ERROR} hideMainNavigator />,
+      {
+        overrideInitialState: withFlagOverrides({
+          ptxEarnUi: { enabled: true, params: { value: "v2" } },
+        }),
+      },
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Main, {
+      screen: NavigatorName.Earn,
+    });
+  });
+
+  it("does not leave the intent flow presentation while the webview is still on the deposit route", () => {
+    mockWebviewUrl = "https://earn.test/v2/android/deposit?intent=deposit&uiVersion=v4";
+
+    render(
+      <EarnV2Webview manifest={STUB_MANIFEST} appManifestNotFoundError={ERROR} hideMainNavigator />,
+      {
+        overrideInitialState: withFlagOverrides({
+          ptxEarnUi: { enabled: true, params: { value: "v2" } },
+        }),
+      },
+    );
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("does not leave the intent flow presentation while the webview URL is still unknown (initial empty state)", () => {
+    // Regression: on intent flow entry the webview first reports an empty URL. Treating "" as a known
+    // non-intent route bounced the user straight back to the homescreen before the route loaded.
+    mockWebviewUrl = "";
+
+    render(
+      <EarnV2Webview manifest={STUB_MANIFEST} appManifestNotFoundError={ERROR} hideMainNavigator />,
+      {
+        overrideInitialState: withFlagOverrides({
+          ptxEarnUi: { enabled: true, params: { value: "v2" } },
+        }),
+      },
+    );
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("keeps LiveAppBackground hidden while the webview URL is still unknown (intent flow first paint)", () => {
+    mockWebviewUrl = "";
+
+    render(
+      <EarnV2Webview manifest={STUB_MANIFEST} appManifestNotFoundError={ERROR} hideMainNavigator />,
+      {
+        overrideInitialState: withFlagOverrides({
+          ptxEarnUi: { enabled: true, params: { value: "v2" } },
+        }),
+      },
+    );
+
+    expect(screen.queryByTestId("live-app-background")).toBeNull();
+  });
+
+  it("does not navigate from the dashboard tab instance (hideMainNavigator false)", () => {
+    mockWebviewUrl = "https://earn.test/v2/android/homescreen?uiVersion=v4";
+
+    render(<EarnV2Webview manifest={STUB_MANIFEST} appManifestNotFoundError={ERROR} />, {
+      overrideInitialState: withFlagOverrides({
+        ptxEarnUi: { enabled: true, params: { value: "v2" } },
+      }),
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/__tests__/EarnV2Webview.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/__tests__/EarnV2Webview.test.tsx
@@ -207,6 +207,32 @@ describe("EarnV2Webview", () => {
     expect(screen.queryByTestId("live-app-background")).toBeNull();
   });
 
+  it.each(["about:blank", "data:text/html,<html></html>"])(
+    "does not leave the intent flow presentation for transient non-http(s) URLs (%s)",
+    transientUrl => {
+      // Regression: WebViews transiently report non-http(s) URLs (e.g. about:blank) during load.
+      // These are parseable but not navigational routes, so they must not be treated as a known
+      // non-intent route, otherwise we'd bounce out of the intent flow on entry.
+      mockWebviewUrl = transientUrl;
+
+      render(
+        <EarnV2Webview
+          manifest={STUB_MANIFEST}
+          appManifestNotFoundError={ERROR}
+          hideMainNavigator
+        />,
+        {
+          overrideInitialState: withFlagOverrides({
+            ptxEarnUi: { enabled: true, params: { value: "v2" } },
+          }),
+        },
+      );
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(screen.queryByTestId("live-app-background")).toBeNull();
+    },
+  );
+
   it("does not navigate from the dashboard tab instance (hideMainNavigator false)", () => {
     mockWebviewUrl = "https://earn.test/v2/android/homescreen?uiVersion=v4";
 

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
@@ -3,16 +3,43 @@ import { useFeature, useWalletFeaturesConfig } from "@features/platform-feature-
 import { useRemoteLiveAppContext } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { Flex } from "@ledgerhq/native-ui";
-import React, { ComponentProps, Fragment, useRef, useCallback } from "react";
+import React, { ComponentProps, Fragment, useRef, useCallback, useEffect, useState } from "react";
 import { Animated, StyleSheet, View } from "react-native";
 import type WebView from "react-native-webview";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { safeUrl } from "@ledgerhq/live-common/wallet-api/helpers";
 import { TrackScreen } from "~/analytics";
 import GenericErrorView from "~/components/GenericErrorView";
 import { useNavigationBarHeights } from "LLM/hooks/useNavigationBarHeights";
+import { NavigatorName } from "~/const";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { EarnWebview } from "../EarnWebview";
 import { LiveAppBackground } from "LLM/components/LiveAppBackground";
 import { computeEarnUiVersion } from "@ledgerhq/live-common/domain/computeEarnUiVersion";
+import type { WebviewState } from "~/components/Web3AppWebview/types";
+
+const INTENT_FLOWS = ["deposit", "withdraw", "simulate"];
+const INTENTS_SET = new Set(INTENT_FLOWS);
+
+/**
+ * The native Earn screen sets `intent` once on entry and never clears it, so it cannot be trusted
+ * after the user navigates back inside the webview (e.g. "go to dashboard"). The live webview URL
+ * is the source of truth for whether we are still inside an intent flow (deposit/withdraw/simulate).
+ *
+ * Returns `true` when on an intent flow route, `false` when on a known non-intent route, and
+ * `null` while the URL is unknown/unparseable (e.g. the webview's initial empty state). The `null`
+ * case must NOT be treated as "left the intent flow", otherwise we would bounce out of the intent
+ * flow on first mount before its route has even loaded.
+ */
+const getIntentFlowState = (rawUrl?: string): boolean | null => {
+  if (!rawUrl) return null;
+  const url = safeUrl(rawUrl);
+  if (!url) return null;
+  if (INTENTS_SET.has(url.searchParams.get("intent") ?? "")) return true;
+  return INTENT_FLOWS.some(segment => url.pathname.includes(segment));
+};
 
 type Props = {
   manifest?: LiveAppManifest;
@@ -58,6 +85,39 @@ export const EarnV2Webview = ({
     [scrollY],
   );
 
+  const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+
+  const [webviewUrl, setWebviewUrl] = useState<string | undefined>(undefined);
+  const handleWebviewStateChange = useCallback((state: WebviewState) => {
+    setWebviewUrl(state.url);
+  }, []);
+
+  const intentFlowState = getIntentFlowState(webviewUrl);
+
+  /** Until the webview reports a *known* URL (`null` while unknown/empty on first mount), trust the
+   * native `intent` (correct first paint on intent flow entry). Once it reports a known non-intent
+   * route, the URL wins: returning to the dashboard restores the background even though the stale
+   * native `intent` is still set. Only `false` (a known non-intent route) leaves intent flow mode;
+   * `null` (unknown) must keep intent flow mode so we don't bounce out before the route loads.
+   */
+  const inIntentFlow = !!hideMainNavigator && intentFlowState !== false;
+  const showsBackground = isPtxUiMinV2 && !inIntentFlow;
+
+  /** An intent flow (deposit/withdraw/simulate) is rendered full-screen via the Base navigator
+   * (header, no tab bar). When the webview navigates back out of the intent route (e.g. "go to
+   * dashboard"), that in-webview navigation cannot leave the Base-stack screen on its own, so the
+   * main navigation (top bar + tab bar) and background stay hidden. Detect the exit and return to
+   * the Earn dashboard tab, which restores the full chrome. Guarded by `hideMainNavigator` so it
+   * only runs for the intent flow presentation, never the dashboard tab instance.
+   */
+  useEffect(() => {
+    if (!hideMainNavigator) return;
+    // Only exit on a *known* non-intent route. `null` (unknown/initial empty URL) and `true`
+    // (still in an intent flow) must not trigger navigation, or we'd bounce out on entry.
+    if (intentFlowState !== false) return;
+    navigation.navigate(NavigatorName.Main, { screen: NavigatorName.Earn });
+  }, [hideMainNavigator, intentFlowState, navigation]);
+
   const webviewInputs = {
     ...inputs,
     safeAreaTop: insets.top.toString(),
@@ -72,7 +132,7 @@ export const EarnV2Webview = ({
 
   return (
     <View testID="earn-screen" style={styles.container}>
-      {isPtxUiMinV2 && !hideMainNavigator && <LiveAppBackground type="earn" scrollY={scrollY} />}
+      {showsBackground && <LiveAppBackground type="earn" scrollY={scrollY} />}
       <View style={styles.contentContainer} pointerEvents="box-none">
         {manifest ? (
           <Fragment>
@@ -81,7 +141,8 @@ export const EarnV2Webview = ({
               manifest={manifest}
               inputs={webviewInputs}
               isLwm40Enabled={isLwm40Enabled}
-              onScroll={isPtxUiMinV2 && !hideMainNavigator ? handleScroll : undefined}
+              onScroll={showsBackground ? handleScroll : undefined}
+              onWebviewStateChange={handleWebviewStateChange}
             />
           </Fragment>
         ) : (

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
@@ -29,14 +29,16 @@ const INTENTS_SET = new Set(INTENT_FLOWS);
  * is the source of truth for whether we are still inside an intent flow (deposit/withdraw/simulate).
  *
  * Returns `true` when on an intent flow route, `false` when on a known non-intent route, and
- * `null` while the URL is unknown/unparseable (e.g. the webview's initial empty state). The `null`
- * case must NOT be treated as "left the intent flow", otherwise we would bounce out of the intent
- * flow on first mount before its route has even loaded.
+ * `null` while the URL is unknown (e.g. the webview's initial empty state, or transient non-http(s)
+ * schemes like `about:blank`/`data:` reported during load). The `null` case must NOT be treated as
+ * "left the intent flow", otherwise we would bounce out of the intent flow on first mount before its
+ * route has even loaded. Only http(s) URLs count as a known route.
  */
 const getIntentFlowState = (rawUrl?: string): boolean | null => {
   if (!rawUrl) return null;
   const url = safeUrl(rawUrl);
   if (!url) return null;
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
   if (INTENTS_SET.has(url.searchParams.get("intent") ?? "")) return true;
   return INTENT_FLOWS.some(segment => url.pathname.includes(segment));
 };

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnWebview/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnWebview/index.tsx
@@ -42,11 +42,27 @@ type Props = {
   inputs?: Record<string, string | undefined>;
   isLwm40Enabled?: boolean;
   onScroll?: ComponentProps<typeof WebView>["onScroll"];
+  /** Surfaces the live webview state (notably its URL) so the parent can react to in-webview navigation. */
+  onWebviewStateChange?: (state: WebviewState) => void;
 };
 /** Subset of WebPTXPlayer functionality required for Earn live app. */
-export const EarnWebview = ({ manifest, inputs, isLwm40Enabled, onScroll }: Props) => {
+export const EarnWebview = ({
+  manifest,
+  inputs,
+  isLwm40Enabled,
+  onScroll,
+  onWebviewStateChange,
+}: Props) => {
   const webviewAPIRef = useRef<WebviewAPI>(null);
   const [webviewState, setWebviewState] = useState<WebviewState>(initialWebviewState);
+
+  const handleStateChange = useCallback(
+    (state: WebviewState) => {
+      setWebviewState(state);
+      onWebviewStateChange?.(state);
+    },
+    [onWebviewStateChange],
+  );
 
   const navigation =
     useNavigation<RootNavigationComposite<StackNavigatorNavigation<BaseNavigatorStackParamList>>>();
@@ -154,7 +170,7 @@ export const EarnWebview = ({ manifest, inputs, isLwm40Enabled, onScroll }: Prop
         ref={webviewAPIRef}
         manifest={manifest}
         inputs={inputs}
-        onStateChange={setWebviewState}
+        onStateChange={handleStateChange}
         customHandlers={customHandlers}
         onScroll={onScroll}
         Loader={() => <Loading backgroundColor="transparent" />}

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
@@ -54,7 +54,7 @@ function Earn({ route }: Props) {
     [route.path],
   );
   const hideMainNavigator = useMemo(
-    () => ["deposit", "withdraw"].includes(params?.intent ?? ""),
+    () => ["deposit", "withdraw", "simulate"].includes(params?.intent ?? ""),
     [params],
   );
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _The core logic — deriving the active intent flow from the live webview URL, the tri-state (intent flow / non-intent / unknown) handling, and exit detection — is covered by 11 unit tests in `EarnV2Webview.test.tsx`. The native navigation transition between the Base-stack presentation and the Earn dashboard tab, and the resulting visual restoration (background, top bar, tab bar), are not covered by automated tests and require manual/E2E verification on device._
- [x] **Impact of the changes:**
  - Wallet 4.0 Earn (LWM 4.0) **deposit / withdraw / simulate** flows only — the legacy (non-LWM40) Earn path is unaffected.
  - Entering a flow (e.g. "Earn more") must open the deposit screen, **not** bounce back to the dashboard.
  - Returning via "Go to dashboard" must restore the Earn background (v2+ UI), the native top bar, and the bottom tab bar, with correct spacing.
  - Verify across entry points: Wallet API `redirect-provider` (earn web app CTA), native stake drawer, and earn deep links.

### 📝 Description

**Problem**: After completing or backing out of an in-webview Earn intent flow (deposit/withdraw/simulate) and returning to the dashboard (e.g. "Go to dashboard"), the Earn dashboard rendered without its background and with the main navigation (native top bar + bottom tab bar) hidden, plus incorrect top/bottom spacing. The native Earn screen sets the `intent` route param once on entry and never clears it, so the full-screen Base-stack presentation stayed active and the v2+ background stayed off even after the webview had navigated back to the dashboard.

**Solution**: Derive the active flow from the **live webview URL** instead of the stale native `intent`. `EarnWebview` now surfaces its webview state upward, and `EarnV2Webview` tracks a tri-state (intent flow / non-intent / unknown). On a known non-intent route it navigates back to the Earn dashboard tab, restoring the full chrome and background. The unknown/initial-empty URL is kept in intent-flow mode so we don't bounce out of the flow on first mount — this also fixes the regression where entering deposit jumped straight back to the homescreen. `simulate` is now treated as an intent flow alongside `deposit`/`withdraw`.

Before

<img width="340" alt="image" src="https://github.com/user-attachments/assets/7be9e84e-a274-4cb0-9ef4-fe79d77f8eb3" />
 


After

https://github.com/user-attachments/assets/ee1b8eea-d4ca-4b39-afb9-648eec1d3482
 


### ❓ Context

- **JIRA or GitHub link**: [LIVE-31789](https://ledgerhq.atlassian.net/browse/LIVE-31789)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31789]: https://ledgerhq.atlassian.net/browse/LIVE-31789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ