### PR TITLE
test(e2e): increase timeout for Uniswap Permit2 approval step

### DIFF
--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -13,6 +13,10 @@ import { FileUtils } from "tests/utils/fileUtils";
 import { getMinimumSwapAmount } from "@ledgerhq/live-common/e2e/swap";
 import { getTokenAllowanceCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 
+// Uniswap's Permit2 "Approve token access" step can take 1-5 min to confirm on-chain
+// before the sign-permit button appears (the app shows a "1-5 mins" estimate).
+const APPROVAL_PROCESSING_TIMEOUT = 300_000;
+
 export class SwapPage extends WebViewAppPage {
   protected readonly webviewIdentifier = "swap";
   private static readonly EXPORT_SOURCE_PATH = path.resolve("./ledgerwallet-swap-history.csv");
@@ -597,7 +601,7 @@ export class SwapPage extends WebViewAppPage {
   async clickGiveAuthorizationButton() {
     const webview = await this.getWebView();
     const authorizationButton = webview.getByTestId(this.signPermitButton);
-    await expect(authorizationButton).toBeVisible();
+    await expect(authorizationButton).toBeVisible({ timeout: APPROVAL_PROCESSING_TIMEOUT });
     await expect(authorizationButton).toBeEnabled();
     await authorizationButton.click();
   }

--- a/e2e/desktop/tests/specs/token.approval.swap.spec.ts
+++ b/e2e/desktop/tests/specs/token.approval.swap.spec.ts
@@ -66,6 +66,8 @@ test.describe("Token approval - flow", () => {
       ],
     },
     async ({ app }) => {
+      // Uniswap's Permit2 approval (Step 1) can take 1-5 min; extend beyond the 400s CI default.
+      test.setTimeout(480_000);
       await app.swap.logSelectedProvider(provider.uiName);
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await revokeTokenApproval(fromAccount, provider);

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -5,6 +5,10 @@ import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { retryUntilTimeout } from "../../utils/retry";
 import { floatNumberRegex } from "@ledgerhq/live-common/e2e/data/regexes";
 
+// Uniswap's Permit2 "Approve token access" step can take 1-5 min to confirm on-chain
+// before the sign-permit button (Step 2) appears (the app shows a "1-5 mins" estimate).
+const APPROVAL_PROCESSING_TIMEOUT = 300_000;
+
 export default class SwapLiveAppPage {
   fromSelector = "from-account-coin-selector";
   fromAmount = "from-account";
@@ -464,7 +468,7 @@ export default class SwapLiveAppPage {
 
   @Step("Tap Give Authorization button")
   async tapGiveAuthorizationButton() {
-    await waitWebElementByTestId(this.signPermitButton);
+    await waitWebElementByTestId(this.signPermitButton, { timeout: APPROVAL_PROCESSING_TIMEOUT });
     await waitForWebElementToBeEnabled(this.signPermitButton);
     await tapWebElementByTestId(this.signPermitButton);
   }

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalFlow.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalFlow.ts
@@ -68,6 +68,6 @@ export function runSwapTokenApprovalFlow(
         await app.speculos.signTypedMessage();
       }
       await app.swapLiveApp.expectExecuteSwapOnStepApproval();
-    });
+    }, 480_000);
   });
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] No changeset required — changes are confined to the private `ledger-live-mobile-e2e-tests` and `ledger-live-desktop-e2e-tests` packages (never released).
- [x] **Covered by automatic tests.** _These approval specs are broadcast-gated (`DISABLE_TRANSACTION_BROADCAST=0`) and run only in the Monday nightly; they are skipped in standard PR CI._
- [x] **Impact of the changes:**
      - Uniswap token approval (Permit2) swap flow on mobile (Detox) and desktop (Playwright)
      - The `sign-permit-button` ("Authorize") wait that follows the 1–5 min "Approve token access" step
      - Per-test timeout budgets for the approval specs

### 📝 Description

The Uniswap token-approval swap flow uses Permit2, whose **Step 1 "Approve token access"** is an on-chain transaction the app itself estimates at **1–5 minutes**. The `sign-permit-button` (Step 2) only appears once that approval confirms. The existing waits — 60s on mobile and Playwright's 41s `expect` timeout on desktop — time out well before that, so the approval flow fails whenever the weekly provider rotation lands on Uniswap.

This PR lengthens the relevant waits and the per-test budgets on both platforms:

- **Mobile** (`swapLiveApp.ts`, `swapTokenApprovalFlow.ts`): `tapGiveAuthorizationButton` waits up to 5 min (`APPROVAL_PROCESSING_TIMEOUT`) for `sign-permit-button`, and the approval `it(...)` gets an 8-min per-test timeout (the 5-min default would otherwise kill the test before the wait completes).
- **Desktop** (`swap.page.ts`, `token.approval.swap.spec.ts`): `clickGiveAuthorizationButton` uses `toBeVisible({ timeout: 300_000 })`, and the test calls `test.setTimeout(480_000)` to clear the 400s CI per-test cap.

### ❓ Context

- **JIRA or GitHub link**: [B2CQA-5632](https://ledgerhq.atlassian.net/browse/B2CQA-5632)
- **Manual CI**: [desktop](https://github.com/LedgerHQ/ledger-live/actions/runs/27203115751) / [mobile](https://github.com/LedgerHQ/ledger-live/actions/runs/27203130124)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[B2CQA-5632]: https://ledgerhq.atlassian.net/browse/B2CQA-5632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ