### PR TITLE
[LWDM] feat(mobile): add trending categories to market

### DIFF
--- a/.changeset/market-trending-categories.md
+++ b/.changeset/market-trending-categories.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/live-common": minor
+"live-mobile": minor
+---
+
+Add trending categories to the Market screen. Trending categories are fetched from `/v3/categories/trending` and appended to the category controls (after All / Stocks / Favorites); selecting one filters the asset list via the `/v3/markets` `categories` param.
+
+Shared logic lives in `@ledgerhq/live-common/market` so desktop can reuse it: the `getTrendingCategories` RTK Query endpoint (`useGetTrendingCategoriesQuery`), the `categories` request param threaded through `fetchList`/`useMarketData`, and category helpers (widened `MarketListCategory`, `isBuiltInMarketListCategory`, `getMarketCategoriesParam`).

--- a/apps/ledger-live-mobile/__tests__/handlers/market.ts
+++ b/apps/ledger-live-mobile/__tests__/handlers/market.ts
@@ -74,6 +74,12 @@ const handlers = [
 
     return HttpResponse.json(paginatedData);
   }),
+  http.get("https://countervalues.live.ledger.com/v3/categories/trending", () => {
+    return HttpResponse.json([
+      { id: "infrastructure", name: "Infrastructure" },
+      { id: "yield-farming", name: "Yield Farming" },
+    ]);
+  }),
   http.get("https://countervalues.live.ledger.com/v3/supported/fiat", () => {
     return HttpResponse.json(["usd", "eur", "gbp"]);
   }),

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/assetsList.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/assetsList.integration.test.tsx
@@ -58,9 +58,7 @@ function installCapturedMarketHandlers(marketRequests: string[], dadaRequests: s
     {
       ...marketsMock[0],
       id: "tesla-xstock",
-      ledgerIds: [
-        "ethereum/erc20/tesla_xstock_0x8ad3c73f833d3f9a523ab01476625f269aeb7cf0",
-      ],
+      ledgerIds: ["ethereum/erc20/tesla_xstock_0x8ad3c73f833d3f9a523ab01476625f269aeb7cf0"],
       ticker: "tslax",
       name: "Tesla xStock",
       marketCapRank: 528,
@@ -88,8 +86,9 @@ function installCapturedMarketHandlers(marketRequests: string[], dadaRequests: s
       if (filter === "stock") {
         filteredData = stockMarketsMock;
       } else if (filter) {
-        filteredData = marketsMock.filter(({ name, ticker }) =>
-          ticker.toLowerCase().includes(filter) || name.toLowerCase().includes(filter),
+        filteredData = marketsMock.filter(
+          ({ name, ticker }) =>
+            ticker.toLowerCase().includes(filter) || name.toLowerCase().includes(filter),
         );
       } else if (ids.length > 0) {
         filteredData = marketsMock.filter(({ id }) => ids.includes(id));
@@ -225,9 +224,7 @@ describe("MarketScreen assets list (Block 3)", () => {
       { timeout: 5000 },
     );
 
-    fireEvent.press(
-      screen.getByTestId(`${MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher}-stocks`),
-    );
+    fireEvent.press(screen.getByTestId(`${MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher}-stocks`));
 
     await waitFor(
       () => {
@@ -250,6 +247,55 @@ describe("MarketScreen assets list (Block 3)", () => {
     expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher)).toBeVisible();
     expect(screen.queryByTestId("marketItem-bitcoin")).toBeNull();
     expect(screen.queryByTestId("marketItem-rif-token")).toBeNull();
+  });
+
+  it("renders trending categories and filters the list by the selected one", async () => {
+    const marketRequests: string[] = [];
+
+    server.use(
+      http.get("https://countervalues.live.ledger.com/v3/categories/trending", () =>
+        HttpResponse.json([{ id: "infrastructure", name: "Infrastructure" }]),
+      ),
+      http.get("https://countervalues.live.ledger.com/v3/markets", ({ request }) => {
+        marketRequests.push(request.url);
+        const searchParams = new URL(request.url).searchParams;
+        const category = searchParams.get("categories");
+        const page = parseInt(searchParams.get("page") || "0");
+        const pageSize = 10;
+
+        const data =
+          category === "infrastructure"
+            ? [{ ...marketsMock[0], id: "rif-token", ticker: "rif", name: "Rootstock Infra" }]
+            : marketsMock;
+
+        return HttpResponse.json(data.slice(page * pageSize, (page + 1) * pageSize));
+      }),
+    );
+
+    const { user } = renderWithReactQuery(<NavigatorWrapper />, {
+      overrideInitialState: enableAssetDiscoverability,
+    });
+
+    await waitFor(() => expect(screen.getByTestId("marketItem-bitcoin")).toBeVisible(), {
+      timeout: 5000,
+    });
+
+    const trendingTab = await screen.findByTestId(
+      `${MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher}-infrastructure`,
+    );
+    expect(screen.getByText("Infrastructure")).toBeVisible();
+
+    await user.press(trendingTab);
+
+    await waitFor(() => expect(screen.getByTestId("marketItem-rif-token")).toBeVisible(), {
+      timeout: 5000,
+    });
+
+    const categoryRequest = marketRequests.find(
+      url => new URL(url).searchParams.get("categories") === "infrastructure",
+    );
+    expect(categoryRequest).toBeDefined();
+    expect(screen.queryByTestId("marketItem-bitcoin")).toBeNull();
   });
 
   it("renders CVS stock rows when the Stocks category is persisted", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/index.tsx
@@ -155,7 +155,7 @@ function MarketCategorySwitcher({
             value={tab.value}
             testID={`${MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher}-${tab.value}`}
           >
-            {t(tab.labelKey)}
+            {tab.label ?? (tab.labelKey ? t(tab.labelKey) : tab.value)}
           </SegmentedControlButton>
         ))}
       </SegmentedControl>

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssetCategoryState.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssetCategoryState.ts
@@ -1,9 +1,11 @@
 import { useMemo } from "react";
+import { getMarketCategoriesParam } from "@ledgerhq/live-common/market/utils/category";
 import type { MarketListCategory } from "~/reducers/types";
 
 export type MarketAssetCategoryState = {
   isFavoritesCategory: boolean;
   isStocksCategory: boolean;
+  marketCategoriesParam: string | undefined;
   sortedFavoriteIds: string[] | undefined;
   favoriteIdsKey: string;
   hasFavoriteIds: boolean;
@@ -22,6 +24,7 @@ export function useMarketAssetCategoryState({
   const hasSearch = normalizedSearch.length > 0;
   const isFavoritesCategory = !hasSearch && category === "starred";
   const isStocksCategory = !hasSearch && category === "stocks";
+  const marketCategoriesParam = hasSearch ? undefined : getMarketCategoriesParam(category);
   const sortedFavoriteIds = useMemo(
     () => getSortedFavoriteIds(isFavoritesCategory, starredMarketCoins),
     [isFavoritesCategory, starredMarketCoins],
@@ -33,6 +36,7 @@ export function useMarketAssetCategoryState({
   return {
     isFavoritesCategory,
     isStocksCategory,
+    marketCategoriesParam,
     sortedFavoriteIds,
     favoriteIdsKey,
     hasFavoriteIds,

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssets.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssets.ts
@@ -63,6 +63,7 @@ export function useMarketAssets({
   const {
     isFavoritesCategory,
     isStocksCategory,
+    marketCategoriesParam,
     sortedFavoriteIds,
     favoriteIdsKey,
     hasFavoriteIds,
@@ -95,6 +96,7 @@ export function useMarketAssets({
     page: requestedPage,
     search: normalizedSearch,
     filter: getMarketFilter(isStocksCategory),
+    categories: marketCategoriesParam,
     starred: sortedFavoriteIds,
   });
   const marketData = getMarketDataForDisplay(result.data, shouldFetchAssets);

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketCategories.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketCategories.ts
@@ -1,14 +1,14 @@
 import { useCallback, useMemo } from "react";
+import { useGetTrendingCategoriesQuery } from "@ledgerhq/live-common/market/state-manager/api";
 import { track } from "~/analytics";
 import { useDispatch, useSelector } from "~/context/hooks";
 import { selectMarketListCategory, setMarketListCategory } from "~/reducers/market";
 import type { MarketListCategory } from "~/reducers/types";
 
-const SELECTABLE_MARKET_CATEGORIES = new Set<MarketListCategory>(["all", "stocks", "starred"]);
-
 export type MarketCategoryTab = {
   value: MarketListCategory;
-  labelKey: string;
+  labelKey?: string;
+  label?: string;
 };
 
 export type MarketCategories = {
@@ -17,15 +17,11 @@ export type MarketCategories = {
   onSelectCategory: (category: MarketListCategory) => void;
 };
 
-const categoryTabs: MarketCategoryTab[] = [
+const BUILT_IN_CATEGORY_TABS: MarketCategoryTab[] = [
   { value: "all", labelKey: "market.assets.categories.all" },
   { value: "stocks", labelKey: "market.assets.categories.stocks" },
   { value: "starred", labelKey: "market.assets.categories.favorites" },
 ];
-
-function isSelectableMarketCategory(category: MarketListCategory): boolean {
-  return SELECTABLE_MARKET_CATEGORIES.has(category);
-}
 
 function trackCategoryTap(category: MarketListCategory) {
   track("button_clicked", {
@@ -38,29 +34,43 @@ function trackCategoryTap(category: MarketListCategory) {
 export function useMarketCategories(): MarketCategories {
   const dispatch = useDispatch();
   const persistedCategory = useSelector(selectMarketListCategory);
-  const selectedCategory = isSelectableMarketCategory(persistedCategory)
-    ? persistedCategory
-    : "all";
+  const { data: trendingCategories } = useGetTrendingCategoriesQuery();
+
+  const tabs = useMemo<MarketCategoryTab[]>(
+    () => [
+      ...BUILT_IN_CATEGORY_TABS,
+      ...(trendingCategories?.map(category => ({
+        value: category.id,
+        label: category.name,
+      })) ?? []),
+    ],
+    [trendingCategories],
+  );
+
+  const selectableCategories = useMemo(() => new Set(tabs.map(tab => tab.value)), [tabs]);
+
+  // Persisted trending ids may no longer be trending after a refresh: fall back to "all".
+  const selectedCategory = selectableCategories.has(persistedCategory) ? persistedCategory : "all";
 
   const onSelectCategory = useCallback(
     (category: MarketListCategory) => {
       trackCategoryTap(category);
 
-      if (!isSelectableMarketCategory(category)) {
+      if (!selectableCategories.has(category)) {
         return;
       }
 
       dispatch(setMarketListCategory(category));
     },
-    [dispatch],
+    [dispatch, selectableCategories],
   );
 
   return useMemo(
     () => ({
       selectedCategory,
-      tabs: categoryTabs,
+      tabs,
       onSelectCategory,
     }),
-    [onSelectCategory, selectedCategory],
+    [onSelectCategory, selectedCategory, tabs],
   );
 }

--- a/apps/ledger-live-mobile/src/reducers/__tests__/marketListConfig.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/marketListConfig.test.ts
@@ -44,7 +44,7 @@ describe("marketListConfig slice", () => {
     expect(reset.network).toBeUndefined();
   });
 
-  it("rehydrates a persisted payload on top of the defaults", () => {
+  it("rehydrates persisted preferences but resets the category to the default", () => {
     const state = marketListConfigReducer(
       undefined,
       importMarketListConfig({
@@ -58,7 +58,8 @@ describe("marketListConfig slice", () => {
       sorting: "gainers",
       timeframe: "1Y",
       network: "bitcoin",
-      category: "stocks",
+      // category is not persisted across launches: always back to the default.
+      category: "all",
     });
   });
 });

--- a/apps/ledger-live-mobile/src/reducers/market.ts
+++ b/apps/ledger-live-mobile/src/reducers/market.ts
@@ -98,7 +98,8 @@ export default handleActions<MarketState, MarketPayload>(handlers, INITIAL_STATE
 
 /**
  * V4 asset list config — shared between MarketScreen and modularAssetDrawer.
- * Gated by llmAssetDiscoverability. Persisted as a user preference (never reset).
+ * Gated by llmAssetDiscoverability. Sorting/timeframe/network persist as user
+ * preferences; the selected category resets to the default on relaunch.
  */
 export const MARKET_LIST_CONFIG_INITIAL_STATE: MarketListConfigState = {
   sorting: "marketCap",
@@ -126,6 +127,9 @@ const marketListConfigSlice = createSlice({
     importMarketListConfig: (_state, action: PayloadAction<MarketListConfigState>) => ({
       ...MARKET_LIST_CONFIG_INITIAL_STATE,
       ...action.payload,
+      // The selected category is intentionally not persisted across launches:
+      // always start on the default category when the app relaunches.
+      category: MARKET_LIST_CONFIG_INITIAL_STATE.category,
     }),
   },
 });

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -5,6 +5,7 @@ import type { ActionDialogParams } from "@ledgerhq/live-common/wallet-api/valida
 import type { DeviceModelId } from "@ledgerhq/devices";
 import type { Currency, Unit } from "@ledgerhq/types-cryptoassets";
 import { MarketListRequestParams } from "@ledgerhq/live-common/market/utils/types";
+import type { MarketListCategory } from "@ledgerhq/live-common/market/utils/category";
 import { PostOnboardingState } from "@ledgerhq/types-live";
 import type { DataOfUser, NotificationPromptTarget } from "LLM/features/NotificationsPrompt/types";
 import type { RatingsHappyMoment, RatingsDataOfUser } from "../logic/ratings";
@@ -386,7 +387,7 @@ export type MarketState = {
 
 export type MarketListSorting = "marketCap" | "volume" | "gainers" | "losers";
 export type MarketListFilterTimeframe = "1D" | "7D" | "30D" | "6M" | "1Y";
-export type MarketListCategory = "all" | "starred" | "stocks";
+export type { MarketListCategory };
 
 export type MarketListConfigState = {
   sorting: MarketListSorting;

--- a/libs/ledger-live-common/src/market/api/countervalues.ts
+++ b/libs/ledger-live-common/src/market/api/countervalues.ts
@@ -22,6 +22,7 @@ export async function fetchList({
   liveCompatible = false,
   starred = [],
   range = "24",
+  categories,
 }: MarketListRequestParams): Promise<MarketItemResponse[]> {
   const hasExplicitFilter = Boolean(filter);
   const url = URL.format({
@@ -34,6 +35,7 @@ export async function fetchList({
       ...(hasExplicitFilter ? { filter } : search.length >= 2 && { filter: search }),
       ...(starred.length > 0 && { ids: starred.sort().join(",") }),
       ...(liveCompatible && { supported: liveCompatible }),
+      ...(categories && { categories }),
       ...(!hasExplicitFilter &&
         [Order.topLosers, Order.topGainers].includes(order) && { top: 100 }),
     },

--- a/libs/ledger-live-common/src/market/hooks/useMarketDataProvider.ts
+++ b/libs/ledger-live-common/src/market/hooks/useMarketDataProvider.ts
@@ -59,6 +59,7 @@ export function useMarketData(props: MarketListRequestParams): MarketListRequest
         {
           counterCurrency: props.counterCurrency,
           ...(props.filter && { filter: props.filter }),
+          ...(props.categories && { categories: props.categories }),
           ...(props.search && props.search?.length >= 2 && { search: search }),
           ...(props.starred && props.starred?.length >= 1 && { starred: props.starred }),
           ...(props.liveCompatible && { liveCompatible: props.liveCompatible }),

--- a/libs/ledger-live-common/src/market/state-manager/marketApi.test.ts
+++ b/libs/ledger-live-common/src/market/state-manager/marketApi.test.ts
@@ -189,4 +189,57 @@ describe("marketApi", () => {
       });
     });
   });
+
+  describe("[endpoint] getTrendingCategories", () => {
+    const { getTrendingCategories } = marketApi.endpoints;
+
+    const category = (id: string) => ({ id, name: `${id} name` });
+
+    it("requests /v3/categories/trending", async () => {
+      const seenUrls: string[] = [];
+      server.use(
+        http.get("*/v3/categories/trending", ({ request }) => {
+          seenUrls.push(request.url);
+          return HttpResponse.json([category("infrastructure")]);
+        }),
+      );
+
+      await store.dispatch(getTrendingCategories.initiate());
+
+      expect(seenUrls).toHaveLength(1);
+      expect(new URL(seenUrls[0]).pathname).toBe("/v3/categories/trending");
+    });
+
+    it("returns the validated trending categories", async () => {
+      const categories = [category("infrastructure"), category("yield-farming")];
+      server.use(http.get("*/v3/categories/trending", () => HttpResponse.json(categories)));
+
+      const result = await store.dispatch(getTrendingCategories.initiate());
+
+      expect(result.isSuccess).toBe(true);
+      expect(result.data).toEqual(categories);
+    });
+
+    it("keeps only the first 5 trending categories", async () => {
+      const categories = Array.from({ length: 8 }, (_, i) => category(`category-${i}`));
+      server.use(http.get("*/v3/categories/trending", () => HttpResponse.json(categories)));
+
+      const result = await store.dispatch(getTrendingCategories.initiate());
+
+      expect(result.isSuccess).toBe(true);
+      expect(result.data).toHaveLength(5);
+      expect(result.data).toEqual(categories.slice(0, 5));
+    });
+
+    it("returns isError when the response schema is invalid", async () => {
+      const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+      server.use(http.get("*/v3/categories/trending", () => HttpResponse.json([{ id: "x" }])));
+
+      const result = await store.dispatch(getTrendingCategories.initiate());
+
+      expect(result.isError).toBe(true);
+      expect(result.data).toBeUndefined();
+      consoleErrorSpy.mockRestore();
+    });
+  });
 });

--- a/libs/ledger-live-common/src/market/state-manager/marketApi.ts
+++ b/libs/ledger-live-common/src/market/state-manager/marketApi.ts
@@ -18,8 +18,12 @@ import {
   MarketChartApiResponseSchema,
   MarketDataTags,
   MarketPerformersQueryParams,
+  MarketTrendingCategory,
+  TrendingCategoriesResponseSchema,
 } from "./types";
 import { format, formatPerformer } from "../utils/currencyFormatter";
+
+const MAX_TRENDING_CATEGORIES = 5;
 
 export const marketApi = createApi({
   reducerPath: "marketApi",
@@ -31,6 +35,7 @@ export const marketApi = createApi({
     MarketDataTags.CurrencyData,
     MarketDataTags.ChartData,
     MarketDataTags.GlobalData,
+    MarketDataTags.TrendingCategories,
   ],
   endpoints: build => ({
     getMarketPerformers: build.query<MarketItemPerformer[], MarketPerformersQueryParams>({
@@ -118,6 +123,27 @@ export const marketApi = createApi({
       },
       keepUnusedDataFor: (REFETCH_TIME_ONE_MINUTE * BASIC_REFETCH) / 1000,
     }),
+    getTrendingCategories: build.query<MarketTrendingCategory[], void>({
+      query: () => ({ url: "/v3/categories/trending" }),
+      providesTags: [MarketDataTags.TrendingCategories],
+      transformResponse: (response: unknown): MarketTrendingCategory[] => {
+        const result = TrendingCategoriesResponseSchema.safeParse(response);
+
+        if (!result.success) {
+          log("market", "Invalid trending categories response schema:", {
+            errors: result.error.issues,
+          });
+          throw new Error(
+            `[Market API] Trending categories schema validation failed: ${result.error.issues
+              .map(e => `${e.path.join(".")}: ${e.message}`)
+              .join(", ")}`,
+          );
+        }
+
+        return result.data.slice(0, MAX_TRENDING_CATEGORIES);
+      },
+      keepUnusedDataFor: (REFETCH_TIME_ONE_MINUTE * BASIC_REFETCH) / 1000,
+    }),
   }),
 });
 
@@ -126,4 +152,5 @@ export const {
   useGetCurrencyDataQuery,
   useGetAssetChartDataQuery,
   useGetGlobalMarketDataQuery,
+  useGetTrendingCategoriesQuery,
 } = marketApi;

--- a/libs/ledger-live-common/src/market/state-manager/types.ts
+++ b/libs/ledger-live-common/src/market/state-manager/types.ts
@@ -6,6 +6,7 @@ export enum MarketDataTags {
   CurrencyData = "CurrencyData",
   ChartData = "ChartData",
   GlobalData = "GlobalData",
+  TrendingCategories = "TrendingCategories",
 }
 
 export interface MarketPerformersQueryParams {
@@ -42,3 +43,13 @@ export interface GlobalMarketData {
   // 24h change expressed as a percentage (e.g. -1.71), ready for display.
   changePercentage24h: number;
 }
+
+// Raw /v3/categories/trending response: a list of { id, name } categories.
+export const TrendingCategoriesResponseSchema = z.array(
+  z.object({
+    id: z.string(),
+    name: z.string(),
+  }),
+);
+
+export type MarketTrendingCategory = z.infer<typeof TrendingCategoriesResponseSchema>[number];

--- a/libs/ledger-live-common/src/market/utils/__tests__/category.test.ts
+++ b/libs/ledger-live-common/src/market/utils/__tests__/category.test.ts
@@ -1,7 +1,9 @@
 import type { MarketCurrencyData } from "../types";
 import {
   STOCK_MARKET_FILTER,
+  getMarketCategoriesParam,
   getMarketFilter,
+  isBuiltInMarketListCategory,
   isStockMarketCurrency,
   parseMarketListCategory,
 } from "../category";
@@ -30,6 +32,29 @@ describe("market category utils", () => {
     it("returns the stock filter only for the stocks category", () => {
       expect(getMarketFilter(true)).toBe(STOCK_MARKET_FILTER);
       expect(getMarketFilter(false)).toBeUndefined();
+    });
+  });
+
+  describe("isBuiltInMarketListCategory", () => {
+    it.each(["all", "starred", "stocks"] as const)("is true for the built-in %s", category => {
+      expect(isBuiltInMarketListCategory(category)).toBe(true);
+    });
+
+    it("is false for a trending category id", () => {
+      expect(isBuiltInMarketListCategory("infrastructure")).toBe(false);
+    });
+  });
+
+  describe("getMarketCategoriesParam", () => {
+    it.each(["all", "starred", "stocks"] as const)(
+      "returns undefined for the built-in %s",
+      category => {
+        expect(getMarketCategoriesParam(category)).toBeUndefined();
+      },
+    );
+
+    it("returns the id itself for a trending category", () => {
+      expect(getMarketCategoriesParam("infrastructure")).toBe("infrastructure");
     });
   });
 

--- a/libs/ledger-live-common/src/market/utils/category.ts
+++ b/libs/ledger-live-common/src/market/utils/category.ts
@@ -1,27 +1,53 @@
 import type { MarketCurrencyData } from "./types";
 
-/** Categories the Market list can be filtered by (shared by desktop & mobile). */
-export type MarketListCategory = "all" | "starred" | "stocks";
+/** The built-in (non-trending) categories the Market list can be filtered by. */
+export type BuiltInMarketListCategory = "all" | "starred" | "stocks";
 
-const MARKET_LIST_CATEGORIES = new Set<MarketListCategory>(["all", "starred", "stocks"]);
+/**
+ * Categories the Market list can be filtered by (shared by desktop & mobile).
+ * Besides the built-ins, the value can be a trending category id (e.g. "infrastructure")
+ * fetched from `/v3/categories/trending`. The `(string & {})` keeps literal autocomplete.
+ */
+export type MarketListCategory = BuiltInMarketListCategory | (string & {});
+
+const BUILT_IN_MARKET_LIST_CATEGORIES = new Set<BuiltInMarketListCategory>([
+  "all",
+  "starred",
+  "stocks",
+]);
 
 /** Backend `filter` value used to request the tokenized-stocks list. */
 export const STOCK_MARKET_FILTER = "stock";
 
-/** Parses an arbitrary value (deeplink param, persisted state…) into a known category. */
-export function parseMarketListCategory(category: unknown): MarketListCategory | undefined {
+/** Whether the category is one of the built-in filters rather than a trending category id. */
+export function isBuiltInMarketListCategory(
+  category: MarketListCategory,
+): category is BuiltInMarketListCategory {
+  return BUILT_IN_MARKET_LIST_CATEGORIES.has(category as BuiltInMarketListCategory);
+}
+
+/** Parses an arbitrary value (deeplink param, persisted state…) into a known built-in category. */
+export function parseMarketListCategory(category: unknown): BuiltInMarketListCategory | undefined {
   if (typeof category !== "string") {
     return undefined;
   }
 
-  const normalizedCategory = category.trim().toLowerCase() as MarketListCategory;
+  const normalizedCategory = category.trim().toLowerCase() as BuiltInMarketListCategory;
 
-  return MARKET_LIST_CATEGORIES.has(normalizedCategory) ? normalizedCategory : undefined;
+  return isBuiltInMarketListCategory(normalizedCategory) ? normalizedCategory : undefined;
 }
 
 /** Returns the backend `filter` param to send for the given category, if any. */
 export function getMarketFilter(isStocksCategory: boolean): string | undefined {
   return isStocksCategory ? STOCK_MARKET_FILTER : undefined;
+}
+
+/**
+ * Returns the backend `categories` param for a trending category, or undefined for built-ins.
+ * Used to filter `/v3/markets` by a trending category id.
+ */
+export function getMarketCategoriesParam(category: MarketListCategory): string | undefined {
+  return isBuiltInMarketListCategory(category) ? undefined : category;
 }
 
 /**

--- a/libs/ledger-live-common/src/market/utils/types.ts
+++ b/libs/ledger-live-common/src/market/utils/types.ts
@@ -21,6 +21,7 @@ export type MarketListRequestParams = {
   search?: string;
   filter?: string;
   liveCompatible?: boolean;
+  categories?: string;
 };
 
 export type MarketListRequestResult = {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _live-common category helpers, the marketListConfig reducer rehydration, and the Market assets-list integration suite (incl. a new trending-category test). Also manually verified on the iPhone 17 Pro Max simulator._
- [x] **Impact of the changes:**
      - Market screen category controls (All / Stocks / Favorites + trending)
      - Verify trending categories load from `/v3/categories/trending` and appear after the built-in filters
      - Verify selecting a trending category filters the list via the `/v3/markets` `categories` param, and built-ins (all/stocks/favorites) still behave as before
      - Verify the selected category resets to "All" after relaunching the app (sorting/timeframe/network still persist)
      - Shared `@ledgerhq/live-common/market` changes — confirm desktop market still builds/works

### 📝 Description

Using the `/v3/categories/trending` and `/v3/markets?categories=…` APIs, the Market screen now shows trending categories so users can navigate between them.

Trending categories are fetched and appended to the category controls after All / Stocks / Favorites; selecting one filters the asset list by that category. The shared logic lives in `@ledgerhq/live-common/market` so desktop can reuse it:

- `getTrendingCategories` RTK Query endpoint (`useGetTrendingCategoriesQuery`) with zod-validated `[{ id, name }]` response.
- `categories` request param threaded through `MarketListRequestParams` → `fetchList` → `useMarketData`.
- Category helpers: widened `MarketListCategory` (`built-in | (string & {})`), `isBuiltInMarketListCategory`, `getMarketCategoriesParam`.

The selected category is intentionally **not persisted** across relaunches: `importMarketListConfig` resets it to the default on launch, while sorting/timeframe/network keep persisting.

> Stacked on the now-merged scrollable-controls work (LIVE-31984), so trending tabs scroll horizontally.

### 🖼 Screenshots


https://github.com/user-attachments/assets/257a1bc4-da25-48e4-a135-04b5b1f43a59



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32081](https://ledgerhq.atlassian.net/browse/LIVE-32081)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32081]: https://ledgerhq.atlassian.net/browse/LIVE-32081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ