### PR TITLE
fix(e2e): decouple broadcast swap spec skip gate from mutable env

### DIFF
--- a/e2e/desktop/tests/specs/token.approval.swap.spec.ts
+++ b/e2e/desktop/tests/specs/token.approval.swap.spec.ts
@@ -7,6 +7,7 @@ import {
   setupEnv,
   performSwapUntilQuoteSelectionStep,
   revokeTokenApproval,
+  isBroadcastEnabled,
 } from "tests/utils/swapUtils";
 import { liveDataWithAddressCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 import { addTmsLink } from "tests/utils/allureUtils";
@@ -28,7 +29,7 @@ const provider = pickRotatingProvider(eligibleProviders);
 
 test.describe("Token approval - flow", () => {
   test.skip(
-    process.env.DISABLE_TRANSACTION_BROADCAST !== "0",
+    !isBroadcastEnabled(),
     "Token approval flow requires broadcast to be enabled — runs on Monday nightly only",
   );
 

--- a/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
+++ b/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
@@ -9,6 +9,7 @@ import {
   performSwapUntilQuoteSelectionStep,
   revokeTokenApproval,
   ensureTokenApproval,
+  isBroadcastEnabled,
 } from "tests/utils/swapUtils";
 import { liveDataWithAddressCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 import { addTmsLink } from "tests/utils/allureUtils";
@@ -29,7 +30,7 @@ const provider = pickRotatingProvider(eligibleProviders);
 
 test.describe("Token reapproval - flow", () => {
   test.skip(
-    process.env.DISABLE_TRANSACTION_BROADCAST !== "0",
+    !isBroadcastEnabled(),
     "Token re-approval (bigger amount) flow requires broadcast to be enabled — runs on Monday nightly only",
   );
 

--- a/e2e/desktop/tests/utils/swapUtils.ts
+++ b/e2e/desktop/tests/utils/swapUtils.ts
@@ -20,13 +20,7 @@ import BigNumber from "bignumber.js";
 import { launchSpeculos, cleanSpeculos } from "./speculosUtils";
 
 /**
- * Whether the broadcast-only swap specs (real on-chain transactions) should run.
- *
- * Reads `E2E_BROADCAST_ENABLED`, an immutable gate exported once by CI (setup-e2e-env).
- * It deliberately does NOT read `DISABLE_TRANSACTION_BROADCAST`: `setupEnv()` toggles that
- * per-test, so under `fullyParallel` a `test.skip()` guard reading it observes a transient
- * "1" left by a neighbouring spec and skips non-deterministically. Falls back to the legacy
- * flag for local runs where the CI gate is unset.
+ * Broadcast-only swap specs gate: prefer E2E_BROADCAST_ENABLED (CI), fallback to DISABLE_TRANSACTION_BROADCAST (local).
  */
 export function isBroadcastEnabled(): boolean {
   if (process.env.E2E_BROADCAST_ENABLED !== undefined) {

--- a/e2e/desktop/tests/utils/swapUtils.ts
+++ b/e2e/desktop/tests/utils/swapUtils.ts
@@ -19,6 +19,22 @@ import * as allure from "allure-js-commons";
 import BigNumber from "bignumber.js";
 import { launchSpeculos, cleanSpeculos } from "./speculosUtils";
 
+/**
+ * Whether the broadcast-only swap specs (real on-chain transactions) should run.
+ *
+ * Reads `E2E_BROADCAST_ENABLED`, an immutable gate exported once by CI (setup-e2e-env).
+ * It deliberately does NOT read `DISABLE_TRANSACTION_BROADCAST`: `setupEnv()` toggles that
+ * per-test, so under `fullyParallel` a `test.skip()` guard reading it observes a transient
+ * "1" left by a neighbouring spec and skips non-deterministically. Falls back to the legacy
+ * flag for local runs where the CI gate is unset.
+ */
+export function isBroadcastEnabled(): boolean {
+  if (process.env.E2E_BROADCAST_ENABLED !== undefined) {
+    return process.env.E2E_BROADCAST_ENABLED === "true";
+  }
+  return process.env.DISABLE_TRANSACTION_BROADCAST === "0";
+}
+
 export function setupEnv(disableBroadcast: boolean = false): void {
   let originalBroadcastValue: string | undefined;
   test.beforeAll(async () => {

--- a/tools/actions/composites/setup-e2e-env/action.yml
+++ b/tools/actions/composites/setup-e2e-env/action.yml
@@ -19,9 +19,14 @@ runs:
       run: |
         if [[ "${{ inputs.enable_broadcast }}" == "true" || ("${{ github.event_name }}" == "schedule" && "$(date +%u)" == "1") ]]; then
           echo "DISABLE_TRANSACTION_BROADCAST=0" >> $GITHUB_ENV
+          echo "E2E_BROADCAST_ENABLED=true" >> $GITHUB_ENV
         else
           echo "DISABLE_TRANSACTION_BROADCAST=1" >> $GITHUB_ENV
+          echo "E2E_BROADCAST_ENABLED=false" >> $GITHUB_ENV
         fi
+        # E2E_BROADCAST_ENABLED is an immutable gate for broadcast-only specs to skip on.
+        # DISABLE_TRANSACTION_BROADCAST is toggled per-test by setupEnv(), so reading it
+        # in a test.skip() guard races under fullyParallel and skips specs non-deterministically.
 
     - name: Set SWAP_API_BASE and LEDGER_SYNC_ENVIRONMENT
       id: set-envs

--- a/tools/actions/composites/setup-e2e-env/action.yml
+++ b/tools/actions/composites/setup-e2e-env/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set DISABLE_TRANSACTION_BROADCAST
+    - name: Set DISABLE_TRANSACTION_BROADCAST and E2E_BROADCAST_ENABLED
       id: set-broadcast
       shell: bash
       run: |
@@ -24,9 +24,7 @@ runs:
           echo "DISABLE_TRANSACTION_BROADCAST=1" >> $GITHUB_ENV
           echo "E2E_BROADCAST_ENABLED=false" >> $GITHUB_ENV
         fi
-        # E2E_BROADCAST_ENABLED is an immutable gate for broadcast-only specs to skip on.
-        # DISABLE_TRANSACTION_BROADCAST is toggled per-test by setupEnv(), so reading it
-        # in a test.skip() guard races under fullyParallel and skips specs non-deterministically.
+      # Broadcast-only specs should use E2E_BROADCAST_ENABLED as an immutable gate.
 
     - name: Set SWAP_API_BASE and LEDGER_SYNC_ENVIRONMENT
       id: set-envs


### PR DESCRIPTION
### ✅ Checklist

- [x] No changeset required — changes touch an internal CI composite (`setup-e2e-env`) and the private `ledger-live-desktop-e2e-tests` package (never released).
- [ ] **Covered by automatic tests.** _Test-infra change, not unit-tested. It also can't be exercised by PR CI: all consumers pin the composite `@develop`, so `E2E_BROADCAST_ENABLED` is only set once this merges — validation is the first Monday broadcast nightly after merge._
- [x] **Impact of the changes:**
      - Desktop nightly broadcast specs `token.approval.swap` and `token.reapproval.swap` — should now run reliably when broadcast is enabled instead of skipping non-deterministically
      - No change to existing `DISABLE_TRANSACTION_BROADCAST` behaviour or to any other spec
      - `setup-e2e-env` composite gains one additive env var (`E2E_BROADCAST_ENABLED`)

### 📝 Description

**Problem:** In the desktop E2E nightly ([run 27203115751](https://github.com/LedgerHQ/ledger-live/actions/runs/27203115751)), `token.approval.swap` and `token.reapproval.swap` were **skipped** on both nanoSP and stax even though `DISABLE_TRANSACTION_BROADCAST=0` was exported in both jobs. Allure confirmed the skip reason was the specs' own `test.skip()` guard firing — i.e. it read the broadcast flag as ≠ `"0"`.

**Root cause:** `setupEnv()` mutates the **global** `process.env.DISABLE_TRANSACTION_BROADCAST` (sets `"1"` in `beforeAll`, restores in `afterAll`), and ~20 swap/earn/buySell specs call `setupEnv(true)`. The two broadcast specs gated `test.skip()` on that **same mutable variable**. Under `fullyParallel: true` + `workers: "100%"`, the guard (evaluated per-worker at file load) intermittently observes a transient `"1"` left by a neighbouring spec → non-deterministic skips (asymmetric across jobs; `retries: 2` is why approval eventually ran on stax).

**Solution:** Decouple the skip gate from the mutable flag.

- The `setup-e2e-env` composite now also exports an **immutable** `E2E_BROADCAST_ENABLED` (`true`/`false`), set once and never touched by `setupEnv`.
- A new `isBroadcastEnabled()` helper reads `E2E_BROADCAST_ENABLED` (falls back to `DISABLE_TRANSACTION_BROADCAST` for local runs where the gate is unset).
- Both broadcast specs now `test.skip(!isBroadcastEnabled(), …)`.

`DISABLE_TRANSACTION_BROADCAST` still controls actual broadcast behaviour, unchanged.

**Out of scope / follow-ups:**
- Mobile reads the same flag (via `live-env`) but runs Detox/jest (process-per-file), so the shared-worker race is desktop-specific — to be assessed separately.
- A broadcast spec could still *run* while the flag is transiently `"1"` and silently not broadcast; this is mitigated by `beforeAll` bracketing today and could be hardened later.

### ❓ Context

- **JIRA or GitHub link**: N/A — CI flakiness fix. Evidence: nightly [run 27203115751](https://github.com/LedgerHQ/ledger-live/actions/runs/27203115751).
- **Manual CI**: https://github.com/LedgerHQ/ledger-live/actions/runs/27212054046
-  NB: [swap failure](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/08fd049f-8a8d-41f5-adfd-47f052ae5bf4/#suites/7572a358a344d541f3f986d725ab185b/f43cf001e8f5673f/) has been fixed in this [pr](https://github.com/LedgerHQ/ledger-live/pull/18324)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
