### PR TITLE
[LWM] feat(mobile): keep screen awake while device intent executor is open

### DIFF
--- a/.changeset/die-lwm-wakelock.md
+++ b/.changeset/die-lwm-wakelock.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Keep the screen awake while the Device Intent Executor (DIE) is open, so the phone does not sleep during a device flow

--- a/apps/ledger-live-mobile/src/hooks/useKeepScreenAwake.test.ts
+++ b/apps/ledger-live-mobile/src/hooks/useKeepScreenAwake.test.ts
@@ -1,0 +1,86 @@
+import { renderHook } from "@testing-library/react-native";
+import { activateKeepAwakeAsync, deactivateKeepAwake } from "expo-keep-awake";
+import { useKeepScreenAwake } from "./useKeepScreenAwake";
+
+jest.mock("expo-keep-awake", () => ({
+  activateKeepAwakeAsync: jest.fn(() => Promise.resolve()),
+  deactivateKeepAwake: jest.fn(() => Promise.resolve()),
+}));
+
+let tagCounter = 0;
+jest.mock("uuid", () => ({
+  v4: jest.fn(() => `tag-${++tagCounter}`),
+}));
+
+const mockedActivate = jest.mocked(activateKeepAwakeAsync);
+const mockedDeactivate = jest.mocked(deactivateKeepAwake);
+
+describe("useKeepScreenAwake", () => {
+  beforeEach(() => {
+    tagCounter = 0;
+    jest.clearAllMocks();
+  });
+
+  it("GIVEN enabled is true WHEN mounting THEN it activates keep awake with a tag", () => {
+    // WHEN
+    renderHook(() => useKeepScreenAwake(true));
+
+    // THEN
+    expect(mockedActivate).toHaveBeenCalledTimes(1);
+    expect(mockedActivate).toHaveBeenCalledWith("tag-1");
+    expect(mockedDeactivate).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN enabled is false WHEN mounting THEN it does not activate keep awake", () => {
+    // WHEN
+    renderHook(() => useKeepScreenAwake(false));
+
+    // THEN
+    expect(mockedActivate).not.toHaveBeenCalled();
+    expect(mockedDeactivate).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN an active keep awake WHEN unmounting THEN it deactivates the same tag", () => {
+    // GIVEN
+    const { unmount } = renderHook(() => useKeepScreenAwake(true));
+
+    // WHEN
+    unmount();
+
+    // THEN
+    expect(mockedDeactivate).toHaveBeenCalledTimes(1);
+    expect(mockedDeactivate).toHaveBeenCalledWith("tag-1");
+  });
+
+  it("GIVEN an active keep awake WHEN enabled flips to false THEN it deactivates the same tag", () => {
+    // GIVEN
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => useKeepScreenAwake(enabled),
+      { initialProps: { enabled: true } },
+    );
+
+    // WHEN
+    rerender({ enabled: false });
+
+    // THEN
+    expect(mockedActivate).toHaveBeenCalledTimes(1);
+    expect(mockedDeactivate).toHaveBeenCalledTimes(1);
+    expect(mockedDeactivate).toHaveBeenCalledWith("tag-1");
+  });
+
+  it("GIVEN keep awake was disabled WHEN enabled flips to true THEN it activates with a fresh tag", () => {
+    // GIVEN
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => useKeepScreenAwake(enabled),
+      { initialProps: { enabled: true } },
+    );
+    rerender({ enabled: false });
+
+    // WHEN
+    rerender({ enabled: true });
+
+    // THEN
+    expect(mockedActivate).toHaveBeenCalledTimes(2);
+    expect(mockedActivate).toHaveBeenLastCalledWith("tag-2");
+  });
+});

--- a/apps/ledger-live-mobile/src/hooks/useKeepScreenAwake.ts
+++ b/apps/ledger-live-mobile/src/hooks/useKeepScreenAwake.ts
@@ -1,38 +1,33 @@
-import { useCallback, useEffect, useRef } from "react";
-import {
-  activateKeepAwakeAsync,
-  deactivateKeepAwake as deactivateKeepAwakeExpo,
-} from "expo-keep-awake";
+import { useEffect } from "react";
+import { activateKeepAwakeAsync, deactivateKeepAwake } from "expo-keep-awake";
 import { v4 as uuid_v4 } from "uuid";
 
+/**
+ * Prevents the screen from sleeping while `enabled` is `true`, releasing the
+ * lock as soon as `enabled` becomes `false` or the owner component unmounts.
+ *
+ * Prefer this over expo-keep-awake's `useKeepAwake` when you need to toggle the
+ * wake lock at runtime from a boolean (e.g. only while a device flow, signing or
+ * firmware update is in progress). Use `useKeepAwake` directly when the screen
+ * should simply stay awake for the whole lifetime of the mounted component.
+ *
+ * Note: this only keeps the screen awake while the app is in the foreground.
+ *
+ * @param enabled Whether the screen should be kept awake.
+ */
 export function useKeepScreenAwake(enabled: boolean) {
-  const blockerId = useRef("");
-
-  const deactivateKeepScreenAwake = useCallback(async () => {
-    if (blockerId.current) {
-      await deactivateKeepAwakeExpo(blockerId.current);
-      blockerId.current = "";
-    }
-  }, []);
-
-  const activateKeepScreenAwake = useCallback(async () => {
-    if (!blockerId.current) {
-      blockerId.current = uuid_v4();
-      await activateKeepAwakeAsync(blockerId.current);
-    }
-  }, []);
-
   useEffect(() => {
-    if (enabled) {
-      activateKeepScreenAwake();
-    } else {
-      deactivateKeepScreenAwake();
-    }
-  }, [activateKeepScreenAwake, deactivateKeepScreenAwake, enabled]);
+    if (!enabled) return;
 
-  useEffect(() => {
+    const tag = uuid_v4();
+    activateKeepAwakeAsync(tag).catch(error => {
+      console.warn("useKeepScreenAwake: failed to activate keep awake", error);
+    });
+
     return () => {
-      deactivateKeepScreenAwake();
+      deactivateKeepAwake(tag).catch(error => {
+        console.warn("useKeepScreenAwake: failed to deactivate keep awake", error);
+      });
     };
-  }, [deactivateKeepScreenAwake]);
+  }, [enabled]);
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.test.tsx
@@ -9,6 +9,7 @@ import { DeviceModelId as DMKDeviceModelId } from "@ledgerhq/device-management-k
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/analytics";
 import { currentRouteNameRef } from "~/analytics/screenRefs";
+import { useKeepScreenAwake } from "~/hooks/useKeepScreenAwake";
 import type { InitializerConfig } from "./DeviceContextInitializerComponentLWM";
 import type { InitializationInput } from "./types";
 import { PAGE_CONNECT_APP } from "./utils/trackDeviceIntent";
@@ -22,7 +23,12 @@ jest.mock("~/analytics", () => {
   };
 });
 
+jest.mock("~/hooks/useKeepScreenAwake", () => ({
+  useKeepScreenAwake: jest.fn(),
+}));
+
 const mockedTrack = jest.mocked(track);
+const mockedUseKeepScreenAwake = jest.mocked(useKeepScreenAwake);
 
 const layerABaseProperties = {
   deviceUxV2: true,
@@ -387,5 +393,21 @@ describe("useDeviceIntentExecutorLWMViewModel", () => {
       expect(mockedTrack).not.toHaveBeenCalledWith("deviceflow_aborted", expect.anything());
       expect(onUserCancel).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("GIVEN the flow is enabled WHEN the ViewModel renders THEN it keeps the screen awake", () => {
+    // WHEN
+    renderViewModel({ enabled: true });
+
+    // THEN
+    expect(mockedUseKeepScreenAwake).toHaveBeenCalledWith(true);
+  });
+
+  it("GIVEN the flow is disabled WHEN the ViewModel renders THEN it does not keep the screen awake", () => {
+    // WHEN
+    renderViewModel({ enabled: false });
+
+    // THEN
+    expect(mockedUseKeepScreenAwake).toHaveBeenCalledWith(false);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
@@ -15,6 +15,7 @@ import {
 } from "./utils/trackDeviceIntent";
 import type { InitializerConfig } from "./DeviceContextInitializerComponentLWM";
 import type { InitializationInput } from "./types";
+import { useKeepScreenAwake } from "~/hooks/useKeepScreenAwake";
 import { useDeviceIntentExecutorHeaderOverrideRequests } from "./hooks/useDeviceIntentExecutorHeaderOverrideRequests";
 import type { DeviceIntentExecutorHeaderContextValue } from "./utils/DeviceIntentExecutorHeaderContext";
 import type { SourceFlow } from "./utils/SourceFlowContext";
@@ -57,6 +58,8 @@ export function useDeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps>
   const initializationCompletedRef = useRef(false);
   const closeTrackedRef = useRef(false);
   const { hasHeaderOverride, headerContextValue } = useDeviceIntentExecutorHeaderOverrideRequests();
+
+  useKeepScreenAwake(enabled);
 
   useEffect(() => {
     if (!enabled) {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added unit tests for the `useKeepScreenAwake` hook and mocked it in the `DeviceIntentExecutorLWM` view model test.
- [x] **Impact of the changes:**
  - The phone screen now stays awake for the entire duration of a Device Intent Executor (DIE) flow on mobile (device discovery, connection, unlock, app open and intent execution).
  - The screen wake lock is released as soon as the DIE closes or the component unmounts.
  - Wake lock only applies while the app is in the foreground (expected platform behavior).

### 📝 Description

As long as the Device Intent Executor (DIE) is open, the phone's screen should be kept awake so it does not sleep in the middle of a device flow.

This wires `useKeepScreenAwake(enabled)` into `useDeviceIntentExecutorLWMViewModel`, driven by the existing `enabled` flag that already controls the DIE drawer. The wake lock therefore follows the whole flow and is cleaned up automatically when the flow ends.

While at it, the `useKeepScreenAwake` hook was simplified to a single `useEffect` (activate on `enabled`, deactivate the same tag in cleanup), removing the previous refs and callbacks which were totally useless. Added a TSDoc explaining when to use it over expo-keep-awake's `useKeepAwake`, plus unit tests.


#### Demo: (a very boring one)

0. Device is setup to go to sleep after 15 seconds.
1. Wait 15 seconds with DIE closed, no activity -> device goes to sleep
2. Wait over 20 seconds with DIE opened, no activity -> device stays awake
3. Close DIE, wait 15 seconds, no activity -> device goes to sleep

https://github.com/user-attachments/assets/afd8b739-ea6e-4eb4-b32e-3d6c324fbac7



### ❓ Context

- **JIRA or GitHub link**: [LIVE-31871](https://ledgerhq.atlassian.net/browse/LIVE-31871)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31871]: https://ledgerhq.atlassian.net/browse/LIVE-31871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ