### PR TITLE
[LWD] feat(desktop): add stocks section to search overlay

### DIFF
--- a/.changeset/thick-pants-hope.md
+++ b/.changeset/thick-pants-hope.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add a Stocks section to the global search overlay default view. Stocks are sourced from DADA, ranked by market cap, rendered in a horizontally scrollable two-row grid with skeleton loading, and link to the asset/market detail page (with a "see all" entry to the stocks market category).

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchOverlayDefault.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchOverlayDefault.tsx
@@ -1,15 +1,21 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { StocksSectionView } from "LLD/features/Stocks/StocksSectionView";
+import { useSearchOverlay } from "../SearchOverlayContext";
+import { STOCKS_SUGGESTION_LIMIT } from "../useAssetSearchBar";
 
 export function SearchOverlayDefault() {
-  const { t } = useTranslation();
+  const { suggestions, navigateToAsset, navigateToStocksMarket } = useSearchOverlay();
 
   return (
     <div className="flex flex-col gap-24" data-testid="search-overlay-default">
       {/* CryptoList section (LIVE-29945): cryptos + stablecoins */}
-      {/* Stocks section (LIVE-29946) */}
+      <StocksSectionView
+        {...suggestions.stocks}
+        limit={STOCKS_SUGGESTION_LIMIT}
+        navigateToAsset={navigateToAsset}
+        onSeeAll={navigateToStocksMarket}
+      />
       {/* Perps section (LIVE-29947) */}
-      <span className="body-2 text-muted">{t("topBar.searchEmptyState")}</span>
     </div>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/types.ts
@@ -1,4 +1,5 @@
 import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { StockSuggestion } from "LLD/features/Stocks/types";
 
 export type SearchMode = "suggestions" | "results" | "noResults";
 
@@ -7,10 +8,15 @@ export type AssetSuggestionSection = {
   isLoading: boolean;
 };
 
+export type StocksSuggestionSection = {
+  data: StockSuggestion[];
+  isLoading: boolean;
+};
+
 export type SearchSuggestions = {
   cryptos: AssetSuggestionSection;
   stablecoins: AssetSuggestionSection;
-  stocks: AssetSuggestionSection;
+  stocks: StocksSuggestionSection;
 };
 
 export type SearchResults = {
@@ -21,6 +27,7 @@ export type SearchResults = {
 export type SearchOverlayContextValue = {
   close: () => void;
   navigateToAsset: (currencyId: string) => void;
+  navigateToStocksMarket: () => void;
   suggestions: SearchSuggestions;
   results: SearchResults;
   mode: SearchMode;

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useAssetSearchBar.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useAssetSearchBar.ts
@@ -1,8 +1,11 @@
 import { ChangeEvent, useCallback, useMemo, useState } from "react";
+import { useStocksSectionViewModel } from "LLD/features/Stocks/hooks/useStocksSectionViewModel";
 import { AssetSuggestionSection, SearchMode, SearchResults, SearchSuggestions } from "./types";
 
 const EMPTY_SECTION: AssetSuggestionSection = { data: [], isLoading: false };
 const EMPTY_RESULTS: SearchResults = { data: [], isLoading: false };
+
+export const STOCKS_SUGGESTION_LIMIT = 20;
 
 export function useAssetSearchBar() {
   const [query, setQuery] = useState("");
@@ -19,9 +22,11 @@ export function useAssetSearchBar() {
     setQuery("");
   }, []);
 
+  const stocks = useStocksSectionViewModel({ limit: STOCKS_SUGGESTION_LIMIT });
+
   const suggestions: SearchSuggestions = useMemo(
-    () => ({ cryptos: EMPTY_SECTION, stablecoins: EMPTY_SECTION, stocks: EMPTY_SECTION }),
-    [],
+    () => ({ cryptos: EMPTY_SECTION, stablecoins: EMPTY_SECTION, stocks }),
+    [stocks],
   );
   const results = EMPTY_RESULTS;
 

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useSearchOverlayViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useSearchOverlayViewModel.ts
@@ -3,11 +3,14 @@ import { useNavigate } from "react-router";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { getMarketOrAssetDetailPath } from "LLD/utils/marketAssetNavigation";
+import { setMarketCategory } from "~/renderer/actions/market";
 import { useAssetSearchBar } from "./useAssetSearchBar";
 import { SearchOverlayContextValue } from "./types";
+import { useDispatch } from "LLD/hooks/redux";
 
 export function useSearchOverlayViewModel() {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
   const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
   const { query, onChangeQuery, isOpen, open, close, mode, suggestions, results } =
     useAssetSearchBar();
@@ -20,6 +23,13 @@ export function useSearchOverlayViewModel() {
     },
     [navigate, shouldDisplayAggregatedAssets, close],
   );
+
+  const navigateToStocksMarket = useCallback(() => {
+    setTrackingSource("Global Search");
+    dispatch(setMarketCategory("stocks"));
+    navigate("/market");
+    close();
+  }, [dispatch, navigate, close]);
 
   const onOpenChange = useCallback(
     (next: boolean) => {
@@ -41,8 +51,8 @@ export function useSearchOverlayViewModel() {
   );
 
   const contextValue = useMemo<SearchOverlayContextValue>(
-    () => ({ close, navigateToAsset, suggestions, results, mode }),
-    [close, navigateToAsset, suggestions, results, mode],
+    () => ({ close, navigateToAsset, navigateToStocksMarket, suggestions, results, mode }),
+    [close, navigateToAsset, navigateToStocksMarket, suggestions, results, mode],
   );
 
   return { open: isOpen, onOpenChange, query, onChangeQuery, onKeyDown, mode, contextValue };

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/StocksSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/StocksSectionView.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Subheader,
+  SubheaderRow,
+  SubheaderTitle,
+  SubheaderShowMore,
+} from "@ledgerhq/lumen-ui-react";
+import { StockRow } from "./components/StockRow";
+import { StocksSkeleton } from "./components/StocksSkeleton";
+import { StocksSectionViewProps } from "./types";
+
+export function StocksSectionView({
+  data,
+  isLoading,
+  limit,
+  navigateToAsset,
+  onSeeAll,
+}: StocksSectionViewProps) {
+  const { t } = useTranslation();
+
+  if (!isLoading && data.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-8" data-testid="stocks-section">
+      <Subheader>
+        <SubheaderRow
+          className="min-w-0 items-center gap-4"
+          onClick={onSeeAll}
+          data-testid="stocks-see-all"
+        >
+          <SubheaderTitle>{t("topBar.search.stocks")}</SubheaderTitle>
+          <SubheaderShowMore />
+        </SubheaderRow>
+      </Subheader>
+      {isLoading ? (
+        <StocksSkeleton count={limit} />
+      ) : (
+        <div
+          className="scrollbar-none grid grid-flow-col grid-rows-2 gap-8 overflow-x-auto"
+          data-testid="stocks-list"
+        >
+          {data.map(stock => (
+            <StockRow key={stock.id} stock={stock} onClick={navigateToAsset} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/__integrations__/Stocks.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/__integrations__/Stocks.integration.test.tsx
@@ -1,0 +1,164 @@
+import React from "react";
+import { render, screen, fireEvent } from "tests/testSetup";
+import { useStocksData } from "@ledgerhq/live-common/dada-client/hooks/useStocksData";
+import Stocks from "..";
+
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useStocksData");
+
+const mockedUseStocksData = jest.mocked(useStocksData);
+
+type MetaInput = {
+  id: string;
+  name: string;
+  ticker: string;
+  ledgerId?: string;
+  marketId?: string;
+};
+
+function buildStocksData(metas: MetaInput[]) {
+  const cryptoAssets: Record<string, unknown> = {};
+  const cryptoOrTokenCurrencies: Record<string, unknown> = {};
+  const markets: Record<string, unknown> = {};
+  const metaCurrencyIds: string[] = [];
+
+  metas.forEach(({ id, name, ticker, ledgerId, marketId }) => {
+    cryptoAssets[id] = { id, name, ticker, assetsIds: ledgerId ? { solana: ledgerId } : {} };
+    if (ledgerId) {
+      cryptoOrTokenCurrencies[ledgerId] = { id: ledgerId, type: "TokenCurrency", name, ticker };
+      markets[ledgerId] = { id: marketId, currencyId: ledgerId, price: 1, marketCap: 1 };
+    }
+    metaCurrencyIds.push(id);
+  });
+
+  return {
+    cryptoAssets,
+    networks: {},
+    cryptoOrTokenCurrencies,
+    interestRates: {},
+    markets,
+    currenciesOrder: { key: "marketCap", order: "desc", metaCurrencyIds },
+    pagination: {},
+  };
+}
+
+function mockStocksData({
+  metas,
+  isLoading = false,
+}: {
+  metas?: MetaInput[];
+  isLoading?: boolean;
+}) {
+  mockedUseStocksData.mockReturnValue({
+    data: metas ? buildStocksData(metas) : undefined,
+    isLoading,
+  } as unknown as ReturnType<typeof useStocksData>);
+}
+
+const APPLE = {
+  id: "urn:crypto:meta-currency:applex",
+  name: "Apple xStock",
+  ticker: "AAPLX",
+  ledgerId: "solana/spl/applex",
+  marketId: "apple-xstock",
+};
+const TESLA = {
+  id: "urn:crypto:meta-currency:teslax",
+  name: "Tesla xStock",
+  ticker: "TSLAX",
+  ledgerId: "solana/spl/teslax",
+};
+const NVIDIA = {
+  id: "urn:crypto:meta-currency:nvidiax",
+  name: "Nvidia xStock",
+  ticker: "NVDAX",
+  ledgerId: "solana/spl/nvidiax",
+};
+
+describe("Stocks section", () => {
+  const navigateToAsset = jest.fn();
+  const onSeeAll = jest.fn();
+
+  afterEach(() => jest.clearAllMocks());
+
+  it("renders the top stocks in market-cap order, capped to the limit", () => {
+    mockStocksData({ metas: [APPLE, TESLA, NVIDIA] });
+
+    render(<Stocks limit={2} navigateToAsset={navigateToAsset} onSeeAll={onSeeAll} />);
+
+    expect(screen.getByTestId("stocks-section")).toBeVisible();
+    expect(screen.getByTestId("stocks-list")).toBeVisible();
+    expect(screen.getByTestId("stock-item-ticker-aaplx")).toBeVisible();
+    expect(screen.getByTestId("stock-item-ticker-tslax")).toBeVisible();
+    expect(screen.queryByTestId("stock-item-ticker-nvdax")).not.toBeInTheDocument();
+  });
+
+  it("shows skeleton rows while loading", () => {
+    mockStocksData({ isLoading: true });
+
+    render(<Stocks limit={2} navigateToAsset={navigateToAsset} onSeeAll={onSeeAll} />);
+
+    expect(screen.getByTestId("stocks-skeleton")).toBeVisible();
+  });
+
+  it("hides the section when there are no stocks", () => {
+    mockStocksData({ metas: [] });
+
+    render(<Stocks limit={2} navigateToAsset={navigateToAsset} onSeeAll={onSeeAll} />);
+
+    expect(screen.queryByTestId("stocks-section")).not.toBeInTheDocument();
+  });
+
+  it("navigates to the asset detail when a row is clicked", () => {
+    mockStocksData({ metas: [APPLE] });
+
+    render(<Stocks limit={2} navigateToAsset={navigateToAsset} onSeeAll={onSeeAll} />);
+
+    fireEvent.click(screen.getByTestId("stock-item-ticker-aaplx"));
+    expect(navigateToAsset).toHaveBeenCalledWith(APPLE.marketId);
+  });
+
+  it("navigates using the meta-currency slug when DADA omits the market id", () => {
+    mockStocksData({ metas: [TESLA] });
+
+    render(<Stocks limit={2} navigateToAsset={navigateToAsset} onSeeAll={onSeeAll} />);
+
+    fireEvent.click(screen.getByTestId("stock-item-ticker-tslax"));
+    expect(navigateToAsset).toHaveBeenCalledWith("teslax");
+  });
+
+  it("skips stocks that have no ledger id", () => {
+    mockStocksData({
+      metas: [{ id: "urn:crypto:meta-currency:noledger", name: "No Ledger", ticker: "NOLX" }],
+    });
+
+    render(<Stocks limit={2} navigateToAsset={navigateToAsset} onSeeAll={onSeeAll} />);
+
+    expect(screen.queryByTestId("stocks-section")).not.toBeInTheDocument();
+  });
+
+  it("backfills the limit with the next valid stock when some entries have no ledger id", () => {
+    mockStocksData({
+      metas: [
+        { id: "urn:crypto:meta-currency:noledger", name: "No Ledger", ticker: "NOLX" },
+        APPLE,
+        TESLA,
+        NVIDIA,
+      ],
+    });
+
+    render(<Stocks limit={2} navigateToAsset={navigateToAsset} onSeeAll={onSeeAll} />);
+
+    expect(screen.getByTestId("stock-item-ticker-aaplx")).toBeVisible();
+    expect(screen.getByTestId("stock-item-ticker-tslax")).toBeVisible();
+    expect(screen.queryByTestId("stock-item-ticker-nvdax")).not.toBeInTheDocument();
+  });
+
+  it("triggers the see-all handler from the section header", () => {
+    mockStocksData({ metas: [APPLE] });
+
+    render(<Stocks limit={2} navigateToAsset={navigateToAsset} onSeeAll={onSeeAll} />);
+
+    fireEvent.click(screen.getByTestId("stocks-see-all"));
+    expect(onSeeAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/components/StockRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/components/StockRow.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import { MediaButton } from "@ledgerhq/lumen-ui-react";
+import { StockSuggestion } from "../types";
+
+type StockRowProps = {
+  stock: StockSuggestion;
+  onClick: (currencyId: string) => void;
+};
+
+export function StockRow({ stock, onClick }: Readonly<StockRowProps>) {
+  const { name, ticker, ledgerId, navigationId } = stock;
+
+  if (!ledgerId) return null;
+
+  const leadingContent = <CryptoIcon ledgerId={ledgerId} ticker={ticker} size={24} />;
+
+  return (
+    <MediaButton
+      size="sm"
+      hideChevron
+      leadingContent={leadingContent}
+      leadingContentShape="rounded"
+      className="shrink-0"
+      onClick={() => onClick(navigationId)}
+      aria-label={name}
+      data-testid={`stock-item-ticker-${ticker.toLowerCase()}`}
+    >
+      {ticker.toUpperCase()}
+    </MediaButton>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/components/StocksSkeleton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/components/StocksSkeleton.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Skeleton } from "@ledgerhq/lumen-ui-react";
+
+type StocksSkeletonProps = {
+  count: number;
+};
+
+export function StocksSkeleton({ count }: Readonly<StocksSkeletonProps>) {
+  return (
+    <div
+      className="scrollbar-none grid grid-flow-col grid-rows-2 gap-8 overflow-x-auto"
+      data-testid="stocks-skeleton"
+      aria-hidden
+    >
+      {Array.from({ length: count }, (_, index) => `stocks-skeleton-${index}`).map(key => (
+        <Skeleton key={key} component="list-item" className="w-[160px] shrink-0" />
+      ))}
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/hooks/useStocksSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/hooks/useStocksSectionViewModel.ts
@@ -1,0 +1,45 @@
+import { useMemo } from "react";
+import { useStocksData } from "@ledgerhq/live-common/dada-client/hooks/useStocksData";
+import { selectCurrencyForMetaId } from "@ledgerhq/live-common/dada-client/utils/currencySelection";
+import { dadaIdToMarketId } from "@ledgerhq/live-common/market/utils/index";
+import { StockSuggestion, StocksSectionViewModelResult } from "../types";
+
+export function useStocksSectionViewModel({
+  limit,
+}: {
+  limit: number;
+}): StocksSectionViewModelResult {
+  const { data, isLoading } = useStocksData({
+    product: "lld",
+    version: __APP_VERSION__,
+    isStaging: true,
+  });
+
+  const stocks = useMemo<StockSuggestion[]>(() => {
+    if (!data) return [];
+    const { cryptoAssets, markets, currenciesOrder } = data;
+    return currenciesOrder.metaCurrencyIds
+      .flatMap(id => {
+        const meta = cryptoAssets[id];
+        if (!meta) return [];
+
+        const currency = selectCurrencyForMetaId(id, data);
+        const ledgerId = currency?.id ?? Object.values(meta.assetsIds)[0];
+        if (!ledgerId) return [];
+        const market = currency ? markets[currency.id] : undefined;
+
+        const stock: StockSuggestion = {
+          id: meta.id,
+          name: meta.name,
+          ticker: meta.ticker,
+
+          navigationId: dadaIdToMarketId(market?.id ?? meta.id),
+          ledgerId,
+        };
+        return [stock];
+      })
+      .slice(0, limit);
+  }, [data, limit]);
+
+  return useMemo(() => ({ data: stocks, isLoading }), [stocks, isLoading]);
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/index.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { StocksSectionView } from "./StocksSectionView";
+import { useStocksSectionViewModel } from "./hooks/useStocksSectionViewModel";
+
+type StocksProps = {
+  limit: number;
+  navigateToAsset: (currencyId: string) => void;
+  onSeeAll: () => void;
+};
+
+const Stocks = ({ limit, navigateToAsset, onSeeAll }: StocksProps) => (
+  <StocksSectionView
+    {...useStocksSectionViewModel({ limit })}
+    limit={limit}
+    navigateToAsset={navigateToAsset}
+    onSeeAll={onSeeAll}
+  />
+);
+
+export default Stocks;

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/types.ts
@@ -1,0 +1,24 @@
+export type StockSuggestion = {
+  /** DADA meta-currency id — stable React key. */
+  id: string;
+  name: string;
+  ticker: string;
+  navigationId: string;
+  /** Underlying ledger currency id (first network), for the crypto icon. */
+  ledgerId?: string;
+};
+
+export type StocksSectionViewModelResult = {
+  /** Stocks ranked by market cap, already capped to the requested limit. */
+  data: StockSuggestion[];
+  isLoading: boolean;
+};
+
+export type StocksSectionViewProps = StocksSectionViewModelResult & {
+  /** Number of skeleton rows rendered while loading. */
+  limit: number;
+  /** Redirects to the asset detail page for the given market id. */
+  navigateToAsset: (currencyId: string) => void;
+  /** Lands on the market list pre-filtered to the stocks category. */
+  onSeeAll: () => void;
+};

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8828,9 +8828,9 @@
   },
   "topBar": {
     "searchPlaceholder": "Search assets",
-    "searchEmptyState": "Start typing to search for an asset",
     "search": {
-      "noResults": "No results for \"{{query}}\""
+      "noResults": "No results for \"{{query}}\"",
+      "stocks": "Stocks"
     },
     "history": {
       "cta": "Transactions"


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Search overlay default view (empty-query suggestions) on Ledger Live Desktop
  - Stocks section rendering: market-cap ordering, limit capping, skeleton loading state, and hidden state when no stocks
  - Navigation from a stock row to the asset/market detail page
  - "See all" header action routing to the stocks market category
  - Stocks without a ledger id are correctly skipped

### 📝 Description

The global search overlay default view previously showed only a static "Start typing to search for an asset" placeholder. There was no entry point to discover top stocks from search.

This PR introduces a **Stocks** section in the search overlay default view, following the MVVM pattern:

- `useStocksSectionViewModel` sources stocks from DADA (`useStocksData`), keeps the market-cap ordering, caps the list to the requested limit, and maps each meta-currency to the fields a row needs (name, ticker, icon, navigation slug).
- `StocksSectionView` renders a `Subheader` with a "see all" action and a horizontally scrollable two-row grid of `StockRow`s, with a `StocksSkeleton` while loading. The section is hidden entirely when there are no stocks.
- Rows navigate to the asset/market detail page; the header "see all" routes to the stocks market category.


https://github.com/user-attachments/assets/ba8486b7-11b4-46d0-a287-fb935656c0ff



### ❓ Context

- **JIRA or GitHub link**: [LIVE-29946](https://ledgerhq.atlassian.net/browse/LIVE-29946)


---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29946]: https://ledgerhq.atlassian.net/browse/LIVE-29946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ