### PR TITLE
[LWDM] fix: cardano do not  reconstructing the contractAddress in api token …

### DIFF
--- a/.changeset/cardano-token-lookup-by-address.md
+++ b/.changeset/cardano-token-lookup-by-address.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-cardano": minor
+"@ledgerhq/cryptoassets": minor
+---
+
+Look up Cardano native tokens via findTokenByAddressInCurrency(policyId, parentCurrencyId, assetName) instead of reconstructing the contractAddress from policyId + tokenIdentifier

--- a/libs/coin-modules/coin-cardano/src/buildSubAccounts.ts
+++ b/libs/coin-modules/coin-cardano/src/buildSubAccounts.ts
@@ -30,9 +30,6 @@ export const decodeTokenAssetId = (id: string): { policyId: string; assetName: s
   return { policyId, assetName };
 };
 
-const encodeTokenCurrencyId = (parentCurrency: CryptoCurrency, assetId: string): string =>
-  `${parentCurrency.id}/native/${assetId}`;
-
 export const decodeTokenCurrencyId = (
   id: string,
 ): { parentCurrencyId: string; type: string; assetId: string } => {
@@ -63,12 +60,11 @@ const mapTxToTokenAccountOperation = async ({
   for (const tx of newTransactions) {
     const accountChange = getAccountChange(tx, accountCredentialsMap);
     for (const token of accountChange.tokens) {
-      const assetId = getTokenAssetId({
-        policyId: token.policyId,
-        assetName: token.assetName,
-      });
-      const tokenCurrencyId = encodeTokenCurrencyId(parentCurrency, assetId);
-      const tokenCurrency = await getCryptoAssetsStore().findTokenById(tokenCurrencyId);
+      const tokenCurrency = await getCryptoAssetsStore().findTokenByAddressInCurrency(
+        token.policyId,
+        parentCurrency.id,
+        token.assetName === "" ? undefined : token.assetName,
+      );
       // skip the unsupported tokens by ledger-live
       if (tokenCurrency === null || tokenCurrency === undefined) {
         continue;
@@ -151,8 +147,10 @@ export async function buildSubAccounts({
     const operations = mergeOps(oldOperations, newOperations);
     const { token: tokenCurrency } = await decodeTokenAccountId(tokenAccountId);
     if (tokenCurrency) {
-      const accountBalance =
-        tokensBalanceByAssetId[tokenCurrency.contractAddress]?.amount || new BigNumber(0);
+      const { assetId } = decodeTokenCurrencyId(tokenCurrency.id);
+      const { policyId, assetName } = decodeTokenAssetId(assetId);
+      const contractAddress = policyId + assetName;
+      const accountBalance = tokensBalanceByAssetId[contractAddress]?.amount || new BigNumber(0);
       const tokenAccount: TokenAccount = {
         type: "TokenAccount",
         id: tokenAccountId,

--- a/libs/coin-modules/coin-cardano/src/buildSubAccounts.unit.test.ts
+++ b/libs/coin-modules/coin-cardano/src/buildSubAccounts.unit.test.ts
@@ -1,0 +1,240 @@
+import { setupMockCryptoAssetsStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
+import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import BigNumber from "bignumber.js";
+
+import { APITransaction } from "./api/api-types";
+import {
+  buildSubAccounts,
+  decodeTokenAssetId,
+  decodeTokenCurrencyId,
+  getTokenAssetId,
+} from "./buildSubAccounts";
+import { PaymentCredential } from "./types";
+
+const POLICY_ID = "a".repeat(56);
+const ASSET_NAME = "deadbeef";
+const ASSET_ID = POLICY_ID + ASSET_NAME;
+const PARENT_CURRENCY_ID = "cardano";
+const TOKEN_CURRENCY_ID = `${PARENT_CURRENCY_ID}/native/${ASSET_ID}`;
+const PAYMENT_KEY = "key";
+
+const parentCurrency = { id: PARENT_CURRENCY_ID } as CryptoCurrency;
+
+const tokenCurrency: TokenCurrency = {
+  type: "TokenCurrency",
+  id: TOKEN_CURRENCY_ID,
+  contractAddress: POLICY_ID,
+  parentCurrency,
+  tokenType: "native",
+  name: "Test Token",
+  ticker: "TEST",
+  delisted: false,
+  disableCountervalue: false,
+  units: [{ name: "Test Token", code: "TEST", magnitude: 0 }],
+};
+
+const accountCredentialsMap: Record<string, PaymentCredential> = {
+  [PAYMENT_KEY]: { key: PAYMENT_KEY } as PaymentCredential,
+};
+
+function makeTxWithToken({
+  hash,
+  amount,
+  direction,
+  assetName = ASSET_NAME,
+}: {
+  hash: string;
+  amount: string;
+  direction: "IN" | "OUT";
+  assetName?: string;
+}): APITransaction {
+  const tokenEntry = {
+    assetName,
+    policyId: POLICY_ID,
+    value: amount,
+  };
+  return {
+    hash,
+    fees: "0",
+    blockHeight: 1,
+    timestamp: "2024-01-01T00:00:00.000Z",
+    certificate: { stakeRegistrations: [], stakeDeRegistrations: [], stakeDelegations: [] },
+    inputs:
+      direction === "OUT"
+        ? [
+            {
+              index: 0,
+              txId: "txIn",
+              address: "addr",
+              value: "0",
+              tokens: [tokenEntry],
+              paymentKey: PAYMENT_KEY,
+            },
+          ]
+        : [],
+    outputs:
+      direction === "IN"
+        ? [
+            {
+              address: "addr",
+              value: "0",
+              tokens: [tokenEntry],
+              paymentKey: PAYMENT_KEY,
+            },
+          ]
+        : [],
+  };
+}
+
+describe("buildSubAccounts helpers", () => {
+  describe("getTokenAssetId", () => {
+    it("concatenates policyId and assetName", () => {
+      expect(getTokenAssetId({ policyId: POLICY_ID, assetName: ASSET_NAME })).toBe(ASSET_ID);
+    });
+
+    it("returns just policyId when assetName is empty", () => {
+      expect(getTokenAssetId({ policyId: POLICY_ID, assetName: "" })).toBe(POLICY_ID);
+    });
+  });
+
+  describe("decodeTokenAssetId", () => {
+    it("splits the asset id into 56-char policyId and remaining assetName", () => {
+      expect(decodeTokenAssetId(ASSET_ID)).toEqual({
+        policyId: POLICY_ID,
+        assetName: ASSET_NAME,
+      });
+    });
+
+    it("returns empty assetName when only the policyId is present", () => {
+      expect(decodeTokenAssetId(POLICY_ID)).toEqual({
+        policyId: POLICY_ID,
+        assetName: "",
+      });
+    });
+  });
+
+  describe("decodeTokenCurrencyId", () => {
+    it("splits the token currency id into its three segments", () => {
+      expect(decodeTokenCurrencyId(TOKEN_CURRENCY_ID)).toEqual({
+        parentCurrencyId: PARENT_CURRENCY_ID,
+        type: "native",
+        assetId: ASSET_ID,
+      });
+    });
+  });
+});
+
+describe("buildSubAccounts", () => {
+  let findTokenByAddressInCurrency: jest.Mock;
+
+  beforeEach(() => {
+    findTokenByAddressInCurrency = jest
+      .fn()
+      .mockImplementation(async (address: string, currencyId: string, identifier?: string) => {
+        if (
+          address === POLICY_ID &&
+          currencyId === PARENT_CURRENCY_ID &&
+          identifier === ASSET_NAME
+        ) {
+          return tokenCurrency;
+        }
+        return undefined;
+      });
+
+    setupMockCryptoAssetsStore({
+      findTokenByAddressInCurrency,
+      findTokenById: async (id: string) => (id === TOKEN_CURRENCY_ID ? tokenCurrency : undefined),
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("looks up tokens by (policyId, parentCurrencyId, assetName) via findTokenByAddressInCurrency", async () => {
+    const tx = makeTxWithToken({ hash: "tx1", amount: "100", direction: "IN" });
+
+    await buildSubAccounts({
+      initialAccount: undefined,
+      parentAccountId: "parent-account-id",
+      parentCurrency,
+      newTransactions: [tx],
+      tokens: [{ policyId: POLICY_ID, assetName: ASSET_NAME, amount: new BigNumber(100) }],
+      accountCredentialsMap,
+    });
+
+    expect(findTokenByAddressInCurrency).toHaveBeenCalledWith(
+      POLICY_ID,
+      PARENT_CURRENCY_ID,
+      ASSET_NAME,
+    );
+  });
+
+  it("passes undefined (not an empty string) as token identifier when assetName is empty", async () => {
+    const tx = makeTxWithToken({ hash: "tx1", amount: "100", direction: "IN", assetName: "" });
+
+    await buildSubAccounts({
+      initialAccount: undefined,
+      parentAccountId: "parent-account-id",
+      parentCurrency,
+      newTransactions: [tx],
+      tokens: [{ policyId: POLICY_ID, assetName: "", amount: new BigNumber(100) }],
+      accountCredentialsMap,
+    });
+
+    expect(findTokenByAddressInCurrency).toHaveBeenCalledWith(
+      POLICY_ID,
+      PARENT_CURRENCY_ID,
+      undefined,
+    );
+  });
+
+  it("skips tokens that are not supported by ledger-live", async () => {
+    findTokenByAddressInCurrency.mockResolvedValue(undefined);
+
+    const tx = makeTxWithToken({ hash: "tx1", amount: "100", direction: "IN" });
+    const subAccounts = await buildSubAccounts({
+      initialAccount: undefined,
+      parentAccountId: "parent-account-id",
+      parentCurrency,
+      newTransactions: [tx],
+      tokens: [{ policyId: POLICY_ID, assetName: ASSET_NAME, amount: new BigNumber(100) }],
+      accountCredentialsMap,
+    });
+
+    expect(subAccounts).toEqual([]);
+  });
+
+  it("matches the on-chain balance by decoding assetId from tokenCurrency.id", async () => {
+    const tx = makeTxWithToken({ hash: "tx1", amount: "42", direction: "IN" });
+
+    const subAccounts = await buildSubAccounts({
+      initialAccount: undefined,
+      parentAccountId: "parent-account-id",
+      parentCurrency,
+      newTransactions: [tx],
+      tokens: [{ policyId: POLICY_ID, assetName: ASSET_NAME, amount: new BigNumber(42) }],
+      accountCredentialsMap,
+    });
+
+    expect(subAccounts).toHaveLength(1);
+    expect(subAccounts[0].balance).toEqual(new BigNumber(42));
+    expect(subAccounts[0].spendableBalance).toEqual(new BigNumber(42));
+  });
+
+  it("falls back to zero balance when no matching token balance is provided", async () => {
+    const tx = makeTxWithToken({ hash: "tx1", amount: "10", direction: "IN" });
+
+    const subAccounts = await buildSubAccounts({
+      initialAccount: undefined,
+      parentAccountId: "parent-account-id",
+      parentCurrency,
+      newTransactions: [tx],
+      tokens: [],
+      accountCredentialsMap,
+    });
+
+    expect(subAccounts).toHaveLength(1);
+    expect(subAccounts[0].balance).toEqual(new BigNumber(0));
+  });
+});

--- a/libs/ledgerjs/packages/cryptoassets/src/api-token-converter.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/api-token-converter.test.ts
@@ -2,23 +2,6 @@ import { convertApiToken, type ApiTokenData } from "./api-token-converter";
 
 describe("convertApiToken", () => {
   describe("Cardano transformation", () => {
-    it("should reconstruct contractAddress from policyId + tokenIdentifier", () => {
-      const apiToken: ApiTokenData = {
-        id: "cardano/native/policyId.assetName",
-        contractAddress: "policyId",
-        name: "Test Token",
-        ticker: "TEST",
-        units: [{ code: "TEST", name: "Test Token", magnitude: 6 }],
-        standard: "native",
-        tokenIdentifier: ".assetName",
-      };
-
-      const result = convertApiToken(apiToken);
-
-      expect(result?.contractAddress).toBe("policyId.assetName");
-      expect(result?.tokenType).toBe("native");
-    });
-
     it("should not reconstruct if tokenIdentifier is missing", () => {
       const apiToken: ApiTokenData = {
         id: "cardano/native/policyId",

--- a/libs/ledgerjs/packages/cryptoassets/src/api-token-converter.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/api-token-converter.ts
@@ -21,7 +21,6 @@ export interface ApiTokenData {
  * This function applies client-side transformations to reconcile differences between
  * backend APIs (CAL/DaDa) and Ledger Live's expected token format:
  *
- * - Cardano: Reconstructs contractAddress from policyId + tokenIdentifier [LIVE-22559]
  * - Sui: Transforms tokenType from "coin" to "sui" [LIVE-22560]
  *
  * @param apiToken - Token data from backend API
@@ -36,12 +35,10 @@ export function convertApiToken(apiToken: ApiTokenData): TokenCurrency | undefin
     ticker,
     units,
     delisted = false,
-    tokenIdentifier,
     ledgerSignature,
   } = apiToken;
 
   // Apply client-side patches to reconcile CAL format with LL format
-  let patchedContractAddress = contractAddress;
   let patchedStandard = standard;
 
   const parentCurrencyId = id.split("/")[0];
@@ -49,11 +46,6 @@ export function convertApiToken(apiToken: ApiTokenData): TokenCurrency | undefin
 
   if (!parentCurrency) {
     return undefined;
-  }
-
-  // LIVE-22559: Cardano - Reconstruct full assetId (policyId + assetName)
-  if (standard === "native" && tokenIdentifier) {
-    patchedContractAddress = contractAddress + tokenIdentifier;
   }
 
   // LIVE-22560: Sui - Transform "coin" standard to "sui" tokenType (LL format)
@@ -65,7 +57,7 @@ export function convertApiToken(apiToken: ApiTokenData): TokenCurrency | undefin
   const tokenCurrency: TokenCurrency = {
     type: "TokenCurrency",
     id,
-    contractAddress: patchedContractAddress,
+    contractAddress: contractAddress,
     parentCurrency,
     tokenType: patchedStandard,
     name,


### PR DESCRIPTION
…converter

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Cardano native tokens via findTokenByAddressInCurrency(policyId, assetName) instead of reconstructing the contractAddress from policyId + tokenIdentifier

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-22559](https://ledgerhq.atlassian.net/browse/LIVE-22559)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-22559]: https://ledgerhq.atlassian.net/browse/LIVE-22559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ