### PR TITLE
[LWM] fix(mobile): use performance chart illustration for onboarding notification prompt

### DIFF
--- a/.changeset/calm-onboarding-chart.md
+++ b/.changeset/calm-onboarding-chart.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Use performance chart illustration for onboarding notification prompt and add NotificationsPrompt component tests

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/components/NotificationsDrawerIllustration.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/components/NotificationsDrawerIllustration.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import type { NotificationsState } from "~/reducers/types";
 import Illustration from "~/images/illustration/Illustration";
 import NotificationsBellDark from "~/images/illustration/Dark/_NotificationsBell.webp";
 import NotificationsBellLight from "~/images/illustration/Light/_NotificationsBell.webp";
@@ -11,35 +10,31 @@ import { isTransactionsAlertsPromptTarget } from "../utils/getNotificationsPromp
 const WIDTH = 300;
 const HEIGHT = 141;
 
+export type NotificationsDrawerIllustrationSources = {
+  lightSource: typeof NotificationsBellLight;
+  darkSource: typeof NotificationsBellDark;
+};
+
+export const resolveNotificationsDrawerIllustrationSources = (
+  promptTarget?: NotificationPromptTarget,
+): NotificationsDrawerIllustrationSources =>
+  isTransactionsAlertsPromptTarget(promptTarget)
+    ? { lightSource: NotificationsBellLight, darkSource: NotificationsBellDark }
+    : {
+        lightSource: NotificationsPerformanceChartLight,
+        darkSource: NotificationsPerformanceChartDark,
+      };
+
 export type NotificationsDrawerIllustrationProps = {
-  readonly type: NotificationsState["drawerSource"];
   readonly promptTarget?: NotificationPromptTarget;
 };
 
 export function NotificationsDrawerIllustration({
-  type,
   promptTarget,
 }: NotificationsDrawerIllustrationProps) {
-  const useBellIllustration =
-    type === "onboarding" || isTransactionsAlertsPromptTarget(promptTarget);
-
-  if (useBellIllustration) {
-    return (
-      <Illustration
-        lightSource={NotificationsBellLight}
-        darkSource={NotificationsBellDark}
-        width={WIDTH}
-        height={HEIGHT}
-      />
-    );
-  }
+  const { lightSource, darkSource } = resolveNotificationsDrawerIllustrationSources(promptTarget);
 
   return (
-    <Illustration
-      lightSource={NotificationsPerformanceChartLight}
-      darkSource={NotificationsPerformanceChartDark}
-      width={WIDTH}
-      height={HEIGHT}
-    />
+    <Illustration lightSource={lightSource} darkSource={darkSource} width={WIDTH} height={HEIGHT} />
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/components/__tests__/NotificationsDrawerIllustration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/components/__tests__/NotificationsDrawerIllustration.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render } from "@tests/test-renderer";
+import NotificationsBellDark from "~/images/illustration/Dark/_NotificationsBell.webp";
+import NotificationsBellLight from "~/images/illustration/Light/_NotificationsBell.webp";
+import NotificationsPerformanceChartDark from "~/images/illustration/Dark/_NotificationsPerformanceChart.webp";
+import NotificationsPerformanceChartLight from "~/images/illustration/Light/_NotificationsPerformanceChart.webp";
+import {
+  NotificationsDrawerIllustration,
+  resolveNotificationsDrawerIllustrationSources,
+} from "../NotificationsDrawerIllustration";
+
+jest.mock("~/images/illustration/Illustration", () => "Illustration");
+
+describe("resolveNotificationsDrawerIllustrationSources", () => {
+  it("should return performance chart assets for global push", () => {
+    expect(resolveNotificationsDrawerIllustrationSources("globalPushNotifications")).toEqual({
+      lightSource: NotificationsPerformanceChartLight,
+      darkSource: NotificationsPerformanceChartDark,
+    });
+  });
+
+  it("should return performance chart assets during onboarding", () => {
+    expect(resolveNotificationsDrawerIllustrationSources()).toEqual({
+      lightSource: NotificationsPerformanceChartLight,
+      darkSource: NotificationsPerformanceChartDark,
+    });
+  });
+
+  it("should return bell assets for transaction alerts", () => {
+    expect(resolveNotificationsDrawerIllustrationSources("transactionsAlertsCategory")).toEqual({
+      lightSource: NotificationsBellLight,
+      darkSource: NotificationsBellDark,
+    });
+  });
+});
+
+describe("NotificationsDrawerIllustration", () => {
+  it("should render without crashing", () => {
+    render(<NotificationsDrawerIllustration promptTarget="globalPushNotifications" />);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/components/__tests__/NotificationsPromptContent.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/components/__tests__/NotificationsPromptContent.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render, screen, withFlagOverrides } from "@tests/test-renderer";
+import { NotificationsPromptContent } from "../NotificationsPromptContent";
+import { AB_TESTING_VARIANTS } from "../../types/variants";
+import { createNotificationsPromptFeatureFlags } from "../../testUtils";
+
+const renderContent = (
+  props: React.ComponentProps<typeof NotificationsPromptContent> = {},
+  featureFlags = createNotificationsPromptFeatureFlags(),
+) =>
+  render(<NotificationsPromptContent {...props} />, {
+    overrideInitialState: withFlagOverrides(featureFlags),
+  });
+
+describe("NotificationsPromptContent", () => {
+  it("should render variant A global push copy when the wording flag uses variant A", () => {
+    renderContent({}, createNotificationsPromptFeatureFlags({ variant: AB_TESTING_VARIANTS.A }));
+
+    expect(screen.getByText("Turn notifications on")).toBeOnTheScreen();
+    expect(
+      screen.getByText(
+        "Get the latest updates on Ledger Wallet, Ledger products, the market, and personalised recommendations. Opt-out anytime in the settings",
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it("should render variant B global push copy when the wording flag uses variant B", () => {
+    renderContent({}, createNotificationsPromptFeatureFlags({ variant: AB_TESTING_VARIANTS.B }));
+
+    expect(screen.getByText("Don't miss what matters")).toBeOnTheScreen();
+    expect(
+      screen.getByText(
+        "Get real-time alerts on new tokens, earning opportunities, and market shifts. Opt out at any time.",
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it("should render default global push copy when the wording feature flag is disabled", () => {
+    renderContent(
+      {},
+      {
+        ...createNotificationsPromptFeatureFlags({ variant: AB_TESTING_VARIANTS.B }),
+        lwmNewWordingOptInNotificationsDrawer: {
+          enabled: false,
+          params: { variant: AB_TESTING_VARIANTS.B },
+        },
+      },
+    );
+
+    expect(screen.getByText("Turn notifications on")).toBeOnTheScreen();
+    expect(screen.queryByText("Don't miss what matters")).not.toBeOnTheScreen();
+  });
+
+  it("should render transaction alerts copy regardless of wording variant", () => {
+    renderContent(
+      { promptTarget: "transactionsAlertsCategory" },
+      createNotificationsPromptFeatureFlags({ variant: AB_TESTING_VARIANTS.B }),
+    );
+
+    expect(screen.getByText("Know the status of your money")).toBeOnTheScreen();
+    expect(
+      screen.getByText(
+        "Receive real-time alerts when your crypto is sent or received. Opt out at anytime via Settings.",
+      ),
+    ).toBeOnTheScreen();
+    expect(screen.queryByText("Don't miss what matters")).not.toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawer.tsx
@@ -82,10 +82,7 @@ export const NotificationsPromptDrawer = () => {
 
       <Flex mb={4}>
         <Flex alignItems={"center"}>
-          <NotificationsDrawerIllustration
-            type={displayedDrawerSource}
-            promptTarget={displayedDrawerPromptTarget}
-          />
+          <NotificationsDrawerIllustration promptTarget={displayedDrawerPromptTarget} />
           <NotificationsPromptContent promptTarget={displayedDrawerPromptTarget} />
         </Flex>
         <Button


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Onboarding notification prompt drawer illustration (performance chart vs bell)
  - Transaction alerts notification prompt illustration (bell unchanged)
  - Global push prompts after send/receive/inactivity (performance chart unchanged)

### 📝 Description

**Problem:** The onboarding notification prompt drawer incorrectly showed the bell illustration. Only transaction alerts should use the bell; onboarding and other global push prompts should use the performance chart.

**Solution:**
- Illustration selection is now driven only by `drawerPromptTarget` (bell for `transactionsAlertsCategory`, performance chart otherwise).
- Removhe `drawerSource`-based onboarding override that forced the bell.
- Extracted `resolveNotificationsDrawerIllustrationSources()` for testable selection logic.
- Added unit tests for `NotificationsDrawerIllustration` and `NotificationsPromptContent`.

| Prompt | Illustration |
|--------|----------------|
| Onboarding | Performance chart |
| Global push (send, receive, inactivity, …) | Performance chart |
| Transaction alerts | Bell |

https://github.com/user-attachments/assets/279d3517-ec83-41fc-a517-0be05f462652

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32111](https://ledgerhq.atlassian.net/browse/LIVE-32111)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** han justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32111]: https://ledgerhq.atlassian.net/browse/LIVE-32111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ