### PR TITLE
test(desktop): support Asset Section OFF variant in desktop e2e

### DIFF
--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -63,6 +63,10 @@ on:
         required: false
         type: boolean
         default: false
+      enable_asset_section:
+        description: "Enable the Wallet 4.0 Asset Section"
+        type: boolean
+        default: true
       feature_flags_json:
         description: "JSON to override feature flags"
         required: false
@@ -111,6 +115,11 @@ on:
         required: false
         type: boolean
         default: false
+      enable_asset_section:
+        description: "Enable the Wallet 4.0 Asset Section"
+        required: false
+        type: boolean
+        default: true
       feature_flags_json:
         description: "JSON to override feature flags"
         required: false
@@ -297,6 +306,7 @@ jobs:
             echo "- **Triggered branch:** ${{ inputs.ref || github.ref_name }}"
             echo "- **Commit SHA:** ${{ github.sha }}"
             echo "- **Device selected:** $DEVICE"
+            echo "- **Asset Section:** ${{ (github.event_name == 'schedule' || inputs.enable_asset_section != false) && 'enabled' || 'disabled' }}"
             echo "- **Filtered pattern:** $FILTER_PATTERN"
             echo "- **Test Execution ticket ID:** $TEST_EXECUTION"
             echo "- **Firebase env to target:** $BUILD_TYPE"
@@ -330,6 +340,7 @@ jobs:
           test_filter: ${{ steps.test-filter.outputs.filter }}
           invert_filter: ${{ inputs.invert_filter || false }}
           repeat_each: ${{ inputs.repeat_each }}
+          enable_asset_section: ${{ github.event_name == 'schedule' || inputs.enable_asset_section != false }}
         env:
           SEED: ${{ secrets.SEED_QAA_B2C }}
           XRAY: ${{ matrix.is_primary && inputs.export_to_xray || false }}

--- a/e2e/desktop/README.md
+++ b/e2e/desktop/README.md
@@ -112,3 +112,14 @@ Notes:
 - Arrays, scalars, or invalid JSON are rejected.
 - `E2E_FEATURE_FLAGS_JSON` is merged with default E2E flags.
 - Per-test `featureFlags` fixture values still override env-provided values when both set the same key.
+
+### 7. Wallet 4.0 Asset Section
+
+The Wallet 4.0 Asset Section (`assetSection`) is ON by default for all desktop E2E tests.
+You can run the "Asset Section OFF" variant of the tests by setting the E2E environment variable:
+
+```bash
+export E2E_ENABLE_ASSET_SECTION=0
+```
+
+To run the Asset Section OFF variant on CI, untick the "Enable the Wallet 4.0 Asset Section" checkbox on the desktop E2E GitHub workflow.

--- a/e2e/desktop/tests/fixtures/common.ts
+++ b/e2e/desktop/tests/fixtures/common.ts
@@ -26,6 +26,7 @@ import { attachNetworkLogging } from "../utils/networkLogging";
 import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { unregisterAllTransportModules } from "@ledgerhq/live-common/hw/index";
 import { parseExtraFeatureFlags } from "@ledgerhq/live-common/e2e/featureFlagsJsonUtils";
+import { LWD_WALLET_40_FF_ENABLED } from "tests/utils/featureFlagUtils";
 
 type CliCommand = (userdataPath?: string) => Observable<unknown> | Promise<unknown> | string;
 
@@ -222,7 +223,13 @@ export const test = base.extend<TestFixtures>({
     use,
     testInfo,
   ) => {
-    const mergedFeatureFlags = merge({}, DEFAULT_FEATURE_FLAGS, EXTRA_FEATURE_FLAGS, featureFlags);
+    const mergedFeatureFlags = merge(
+      {},
+      DEFAULT_FEATURE_FLAGS,
+      EXTRA_FEATURE_FLAGS,
+      LWD_WALLET_40_FF_ENABLED, //Todo: Remove when Testing Firebase is sync with prod firebase
+      featureFlags,
+    );
     await attachMergedFeatureFlags(testInfo, mergedFeatureFlags);
 
     // default environment variables

--- a/e2e/desktop/tests/page/accounts.page.ts
+++ b/e2e/desktop/tests/page/accounts.page.ts
@@ -2,12 +2,23 @@ import { expect } from "@playwright/test";
 import { step } from "tests/misc/reporters/step";
 import { AppPage } from "./abstractClasses";
 import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
+import { isAssetSectionEnabled } from "tests/utils/featureFlagUtils";
 
 export class AccountsPage extends AppPage {
   private accountsTitle = this.page.getByRole("heading", { name: "Accounts" });
+  // Accounts-page add-account button differs per Asset Section variant:
+  //   ON  → Cryptos page header button (`crypto-add-address-button`)
+  //   OFF → legacy Accounts page header button (`accounts-add-account-button`)
   private cryptoAddAddressButton = this.page.getByTestId("crypto-add-address-button");
+  private accountsAddAccountButton = this.page.getByTestId("accounts-add-account-button");
+  // Account-list row test ids differ per Asset Section variant:
+  //   ON  → CryptoAddresses rows: `crypto-account-row-<sanitized name>`
+  //   OFF → legacy Accounts rows: `account-component-<raw name>`
+  private readonly accountRowTestIdPrefix = isAssetSectionEnabled
+    ? "crypto-account-row-"
+    : "account-component-";
   private readonly visibleAccountsList = this.page
-    .locator(`[data-testid^="crypto-account-row-"]`)
+    .locator(`[data-testid^="${this.accountRowTestIdPrefix}"]`)
     .filter({ visible: true });
 
   private readonly getSanitizedAccountName = (accountName: string) =>
@@ -15,6 +26,18 @@ export class AccountsPage extends AppPage {
 
   private cryptoAccountRow(accountName: string) {
     return this.page.getByTestId(`crypto-account-row-${this.getSanitizedAccountName(accountName)}`);
+  }
+
+  // Legacy accounts page (Asset Section OFF) row, identified by the raw (unsanitized) account name.
+  private legacyAccountRow(accountName: string) {
+    return this.page.getByTestId(`account-component-${accountName}`);
+  }
+
+  // Account-list row matching the active Asset Section variant (crypto vs legacy).
+  private accountRow(accountName: string) {
+    return isAssetSectionEnabled
+      ? this.cryptoAccountRow(accountName)
+      : this.legacyAccountRow(accountName);
   }
 
   private readonly tokenRow = (childCurrency: Currency) =>
@@ -25,7 +48,10 @@ export class AccountsPage extends AppPage {
 
   @step("Click add account button from accounts page")
   async clickAddAccountButtonFromAccountsPage() {
-    await this.cryptoAddAddressButton.click();
+    const addAccountButton = isAssetSectionEnabled
+      ? this.cryptoAddAddressButton
+      : this.accountsAddAccountButton;
+    await addAccountButton.click();
   }
 
   @step("Wait for Accounts title to be visible")
@@ -35,8 +61,7 @@ export class AccountsPage extends AppPage {
 
   @step("Open Account $0")
   async navigateToAccountByName(accountName: string) {
-    const accountRow = this.cryptoAccountRow(accountName);
-    await accountRow.click();
+    await this.accountRow(accountName).click();
   }
 
   @step("Click sync account button for: $0")
@@ -76,11 +101,7 @@ export class AccountsPage extends AppPage {
 
   @step("Check $0 account was deleted ")
   async expectAccountAbsence(accountName: string) {
-    await expect(
-      this.page
-        .getByTestId(`crypto-account-row-${this.getSanitizedAccountName(accountName)}`)
-        .filter({ visible: true }),
-    ).toHaveCount(0);
+    await expect(this.accountRow(accountName).filter({ visible: true })).toHaveCount(0);
     expect(await this.getAccountsName()).not.toContain(accountName);
   }
 
@@ -137,9 +158,9 @@ export class AccountsPage extends AppPage {
       .toBe(true);
   }
 
-  @step("Expect crypto account row for $0 to be visible")
+  @step("Expect account row for $0 to be visible")
   async expectCryptoAccountRowVisible(accountName: string) {
-    const row = this.cryptoAccountRow(accountName);
+    const row = this.accountRow(accountName);
     await row.waitFor({ state: "attached", timeout: 120_000 });
     await row.scrollIntoViewIfNeeded();
     await expect(row).toBeVisible({ timeout: 60_000 });
@@ -154,10 +175,11 @@ export class AccountsPage extends AppPage {
     const accountElements = await this.visibleAccountsList.all();
     const accountNames = [];
     for (const element of accountElements) {
-      let accountName = await element.getAttribute("data-testid");
-      if (accountName) {
-        accountName = accountName.replaceAll("crypto-account-row-", "").replaceAll("-", " ");
-        accountNames.push(accountName);
+      const testId = await element.getAttribute("data-testid");
+      if (testId) {
+        const rawName = testId.replace(this.accountRowTestIdPrefix, "");
+        // ON sanitizes spaces to dashes in the test id; OFF keeps the raw account name.
+        accountNames.push(isAssetSectionEnabled ? rawName.replaceAll("-", " ") : rawName);
       }
     }
     return accountNames;

--- a/e2e/desktop/tests/page/mainNavigation.page.ts
+++ b/e2e/desktop/tests/page/mainNavigation.page.ts
@@ -4,6 +4,7 @@ import { Drawer } from "tests/component/drawer.component";
 import { Layout } from "tests/component/layout.component";
 import { step } from "tests/misc/reporters/step";
 import { AppPage } from "./abstractClasses";
+import { isAssetSectionEnabled } from "tests/utils/featureFlagUtils";
 
 type NavigationTarget = {
   readonly expectedPath?: RegExp;
@@ -57,7 +58,8 @@ export class MainNavigationPage extends AppPage {
       },
       accounts: {
         expectActive: true,
-        expectedPath: /^\/cryptos(?:\/|$|\?)/,
+        // Asset Section ON routes to /cryptos; OFF redirects to the legacy /accounts page.
+        expectedPath: isAssetSectionEnabled ? /^\/cryptos(?:\/|$|\?)/ : /^\/accounts(?:\/|$|\?)/,
         selector: this.accountsSideBarButton,
       },
       swap: {

--- a/e2e/desktop/tests/page/portfolio.page.ts
+++ b/e2e/desktop/tests/page/portfolio.page.ts
@@ -3,6 +3,7 @@ import { AppPage } from "./abstractClasses";
 import { expect, Locator } from "@playwright/test";
 import { sanitizeAssetNameForTestId } from "~/mvvm/features/Assets/utils/assetTableHelpers";
 import { waitForAccountsPersisted, waitForIdentitiesInAppJson } from "tests/utils/userdata";
+import { isAssetSectionEnabled } from "tests/utils/featureFlagUtils";
 
 type QuickActionButton = "receive" | "buy" | "sell" | "send";
 
@@ -26,6 +27,9 @@ export class PortfolioPage extends AppPage {
     this.page
       .locator(`[data-testid^="w40-asset-row-value-${sanitizeAssetNameForTestId(asset)}-"]`)
       .first();
+  // Legacy portfolio (Asset Section OFF) AssetDistribution row, keyed by the lowercased currency name.
+  private readonly legacyAssetRow = (asset: string) =>
+    this.page.getByTestId(`asset-row-${asset.toLowerCase()}`);
   private readonly operationRows = this.page.locator("[data-testid^='operation-row-']");
 
   // Wallet 4.0 elements
@@ -122,7 +126,8 @@ export class PortfolioPage extends AppPage {
 
   @step("Click on asset row $0")
   async clickOnSelectedAssetRow(asset: string) {
-    await this.w40AssetRow(asset).click();
+    const assetRow = isAssetSectionEnabled ? this.w40AssetRow(asset) : this.legacyAssetRow(asset);
+    await assetRow.click();
   }
 
   @step("Click stake button")
@@ -181,10 +186,11 @@ export class PortfolioPage extends AppPage {
 
   @step("Expect asset row $0 to have the correct counter value $1")
   async expectAssetRowCounterValue(asset: string, counterValue: string) {
-    const rowValue = this.w40AssetRowValue(asset);
+    // ON: dedicated W40 value cell. OFF: legacy AssetDistribution row (contains price + counter value).
+    const rowValue = isAssetSectionEnabled ? this.w40AssetRowValue(asset) : this.legacyAssetRow(asset);
     await expect(rowValue).toBeVisible();
 
-    // W40 countervalue cells can render symbol and/or code (e.g. "€" and/or "EUR").
+    // Countervalue cells can render symbol and/or code (e.g. "€" and/or "EUR").
     if (counterValue === "€" || counterValue === "$") {
       await expect(rowValue).toContainText(this.getExpectedCounterValuePattern(counterValue));
     } else {

--- a/e2e/desktop/tests/specs/assets.addresses.spec.ts
+++ b/e2e/desktop/tests/specs/assets.addresses.spec.ts
@@ -5,6 +5,7 @@ import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { getModularSelector } from "tests/utils/modularSelectorUtils";
+import { isAssetSectionEnabled } from "tests/utils/featureFlagUtils";
 
 /**
  * Suite: Wallet 4.0 - Portfolio-Asset/Address
@@ -15,6 +16,14 @@ import { getModularSelector } from "tests/utils/modularSelectorUtils";
  */
 
 test.describe("Wallet 4.0 - Portfolio-Asset/Address", () => {
+  // This suite only covers the Wallet 4.0 Assets section UI (cryptos/stablecoins sections and
+  // category pages), which does not exist when the Asset Section is OFF (the portfolio renders the
+  // legacy AssetDistribution instead). Skip the whole suite in the "Asset Section OFF" variant.
+  test.skip(
+    !isAssetSectionEnabled,
+    "Asset Section disabled (E2E_ENABLE_ASSET_SECTION=0): no Assets section UI to test",
+  );
+
   /**
    * Scenario 1a: Open the app without accounts
    *

--- a/e2e/desktop/tests/specs/portfolio.spec.ts
+++ b/e2e/desktop/tests/specs/portfolio.spec.ts
@@ -4,6 +4,7 @@ import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
 import { getModularSelector } from "tests/utils/modularSelectorUtils";
+import { isAssetSectionEnabled } from "tests/utils/featureFlagUtils";
 
 test.describe("Portfolio Wallet 4.0 - Zero balance state", () => {
   test.use({
@@ -41,6 +42,15 @@ test.describe("Portfolio Wallet 4.0 - With Account", () => {
     teamOwner: Team.WALLET_XP,
     userdata: "1AccountSOL0Balance",
   });
+
+  // With the Asset Section OFF, a single zero-balance account's countervalue is not resolved,
+  // so the Wallet 4.0 balance view stays in its loading state and never renders the "$0.00"
+  // total nor the performance pill. Every assertion below depends on that resolved balance,
+  // so this scenario is only meaningful with the Asset Section enabled.
+  test.skip(
+    !isAssetSectionEnabled,
+    "Asset Section disabled (E2E_ENABLE_ASSET_SECTION=0): zero-balance total/trend not displayed",
+  );
 
   test(
     "Portfolio happy path: with zero-balance account, then verify balance and analytics",

--- a/e2e/desktop/tests/specs/settings.spec.ts
+++ b/e2e/desktop/tests/specs/settings.spec.ts
@@ -59,6 +59,7 @@ test.describe("Password", () => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
+      await app.accounts.expectCryptoAccountRowVisible(account.accountName);
       const countBeforeLock = await app.accounts.countAccounts();
       await app.mainNavigation.openSettings();
       await app.password.toggle();
@@ -69,9 +70,9 @@ test.describe("Password", () => {
       await app.LockscreenPage.checkInputErrorVisibility("visible");
       await app.LockscreenPage.login("SpeculosPassword");
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
+      await app.accounts.expectCryptoAccountRowVisible(account.accountName);
       const countAfterLock = await app.accounts.countAccounts();
       await app.accounts.compareAccountsCountFromJson(countBeforeLock, countAfterLock);
-      await app.accounts.expectCryptoAccountRowVisible(account.accountName);
       await app.accounts.navigateToAccountByName(account.accountName);
     },
   );

--- a/e2e/desktop/tests/utils/featureFlagUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagUtils.ts
@@ -8,15 +8,30 @@ export const getFeatureFlags = async (page: Page): Promise<OptionalFeatureMap> =
   return featureFlags;
 };
 
+export const isAssetSectionEnabled = process.env.E2E_ENABLE_ASSET_SECTION !== "0";
+
+const lwdWallet40BaseParams = {
+  marketBanner: true,
+  graphRework: true,
+  quickActionCtas: true,
+  mainNavigation: true,
+} as const;
+
+// The Wallet 4.0 "Asset Section" is ON by default for all desktop E2E tests.
+// Force it OFF (the "assetSection OFF" test variant) by setting E2E_ENABLE_ASSET_SECTION=0 (used by CI).
+export const LWD_WALLET_40_FF_ENABLED: OptionalFeatureMap = {
+  lwdWallet40: {
+    enabled: true,
+    params: { ...lwdWallet40BaseParams, assetSection: isAssetSectionEnabled },
+  },
+};
+
 // TODO: remove when wallet 4.0 Q2 is default
 export const LWD_WALLET_40_Q2_FF_ENABLED: OptionalFeatureMap = {
   lwdWallet40: {
     enabled: true,
     params: {
-      marketBanner: true,
-      graphRework: true,
-      quickActionCtas: true,
-      mainNavigation: true,
+      ...lwdWallet40BaseParams,
       assetSection: true,
       operationsList: true,
       myWallet: true,

--- a/tools/actions/composites/run-e2e-playwright-tests/action.yml
+++ b/tools/actions/composites/run-e2e-playwright-tests/action.yml
@@ -18,6 +18,8 @@ inputs:
     required: false
   repeat_each:
     description: "Repeat each test N times (omit to run tests once)"
+  enable_asset_section:
+    description: "Enable the Wallet 4.0 Asset Section"
     required: false
 outputs:
   passed:
@@ -91,6 +93,13 @@ runs:
         REPEAT_ARG=""
         if [ -n "${{ inputs.repeat_each }}" ]; then
           REPEAT_ARG="--repeat-each=${{ inputs.repeat_each }}"
+        fi
+        if [[ "${{ inputs.enable_asset_section }}" = "false" ]]; then
+          export E2E_ENABLE_ASSET_SECTION=0
+          echo "Asset Section disabled!"
+        else
+          export E2E_ENABLE_ASSET_SECTION=1
+          echo "Asset Section enabled!"
         fi
 
         set +e


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. — _N/A: only desktop E2E tests (private package) + CI are touched; no publishable package changes._
- [x] **Covered by automatic tests.** _The changes are the E2E tests themselves; both Asset Section variants run in CI._
- [x] **Impact of the changes:**
      - Desktop E2E with the Asset Section **enabled** (default) — must stay green
      - Desktop E2E with the Asset Section **disabled** (`E2E_ENABLE_ASSET_SECTION=0`) — new variant
      - `test-ui-e2e-only-desktop.yml` manual/scheduled dispatch — new `enable_asset_section` input

### 📝 Description

The desktop E2E suite assumed the Wallet 4.0 **Asset Section** (`lwdWallet40.assetSection`) was always on, so it only validated one of the two shipping UIs.

This PR makes the Asset Section togglable in E2E and adapts the suite to pass with the flag **on** and **off**:

- **Feature-flag plumbing** — `assetSection` is driven by `E2E_ENABLE_ASSET_SECTION` (defaults to enabled). A new `enable_asset_section` input on `test-ui-e2e-only-desktop.yml` (checked = enabled) flows through the `run-e2e-playwright-tests` composite to that env var; scheduled runs stay enabled.
- **Mode-aware page objects / specs** — branch the locators/navigation that differ between the two UIs: account-list rows (`crypto-account-row-*` vs legacy `account-component-*`), the Accounts route (`/cryptos` vs `/accounts`), the add-account button (`crypto-add-address-button` vs `accounts-add-account-button`), portfolio asset rows, and counter-value cells.
- **Scenario gating** — suites/tests that only exist with the Asset Section on are skipped in the OFF variant (`assets.addresses`, and the zero-balance single-account portfolio scenario whose balance/trend never resolve without the Asset Section).

### 🧪 Validation

Manually dispatched across the full matrix — Firebase `testing` and `js` (prod) builds × Asset Section **enabled** and **disabled** (this batch carries a temporary composite-action pin so the OFF toggle is actually applied):

- https://github.com/LedgerHQ/ledger-live/actions/runs/27213278128
- https://github.com/LedgerHQ/ledger-live/actions/runs/27213280037
- https://github.com/LedgerHQ/ledger-live/actions/runs/27213282096
- https://github.com/LedgerHQ/ledger-live/actions/runs/27213284006

> Note: this batch predates the latest commit (the `portfolio.spec.ts` zero-balance + add-account OFF fixes); those OFF-variant portfolio failures are addressed here.

### ❓ Context

- **JIRA or GitHub link**: _N/A_

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

Made with [Cursor](https://cursor.com)