### PR TITLE
[LWDM] feat(tezos): craft raw operations for arbitrary signing

### DIFF
--- a/.changeset/tezos-craft-raw-transaction.md
+++ b/.changeset/tezos-craft-raw-transaction.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": minor
+---
+
+Implement `craftRawTransaction`: forge arbitrary Tezos operations (transfers, contract calls, delegations, batches) from partial operation contents, with fee/gas/storage estimation and reveal handling.

--- a/libs/coin-modules/coin-tezos/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.test.ts
@@ -16,12 +16,14 @@ const logicCraftTransactionMock = jest.fn(
     return { type: undefined, contents: undefined };
   },
 );
+const logicCraftRawOperationsMock = jest.fn();
 
 jest.mock("../logic", () => ({
   listOperations: async () => logicGetTransactions(),
   estimateFees: (...args: unknown[]) => logicEstimateFees(...args),
   craftTransaction: (account: unknown, transaction: { fee: { fees: string } }) =>
     logicCraftTransactionMock(account, transaction),
+  craftRawOperations: (...args: unknown[]) => logicCraftRawOperationsMock(...args),
   rawEncode: () => Promise.resolve("tz1heMGVHQnx7ALDcDKqez8fan64Eyicw4DJ"),
 }));
 
@@ -61,6 +63,27 @@ const api = createApi({
     minFees: 1,
     minEstimatedFees: 2,
   },
+});
+
+describe("craftRawTransaction", () => {
+  afterEach(() => {
+    logicCraftRawOperationsMock.mockClear();
+  });
+
+  it("delegates to craftRawOperations and wraps the result", async () => {
+    logicCraftRawOperationsMock.mockResolvedValue("03deadbeef");
+    const rawTransaction = '[{"kind":"transaction","destination":"tz1recipient","amount":"1000"}]';
+
+    const result = await api.craftRawTransaction(rawTransaction, "tz1sender", "edpkpublickey", 5n);
+
+    expect(logicCraftRawOperationsMock).toHaveBeenCalledWith(
+      rawTransaction,
+      "tz1sender",
+      "edpkpublickey",
+      5n,
+    );
+    expect(result).toEqual({ transaction: "03deadbeef" });
+  });
 });
 
 describe("get operations", () => {

--- a/libs/coin-modules/coin-tezos/src/api/index.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.ts
@@ -24,6 +24,7 @@ import coinConfig, { type TezosConfig } from "../config";
 import {
   broadcast,
   combine,
+  craftRawOperations,
   craftTransaction,
   estimateFees,
   getBalance,
@@ -56,13 +57,14 @@ export function createApi(config: TezosConfig): CoinModuleApi {
     broadcast,
     combine,
     craftTransaction: craft,
-    craftRawTransaction: (
-      _transaction: string,
-      _sender: string,
-      _publicKey: string,
-      _sequence: bigint,
+    craftRawTransaction: async (
+      transaction: string,
+      sender: string,
+      publicKey: string,
+      sequence: bigint,
     ): Promise<CraftedTransaction> => {
-      throw new Error("craftRawTransaction is not supported");
+      const tx = await craftRawOperations(transaction, sender, publicKey, sequence);
+      return { transaction: tx };
     },
     estimateFees: estimate,
     getBalance: (address: string, options?: BalanceOptions) =>

--- a/libs/coin-modules/coin-tezos/src/logic/craftRawOperations.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/craftRawOperations.test.ts
@@ -1,0 +1,344 @@
+import { OpKind } from "@taquito/rpc";
+import { getPkhfromPk } from "@taquito/utils";
+import coinConfig from "../config";
+import { UnsupportedOperationKind } from "../types/errors";
+import { craftRawOperations } from "./craftRawOperations";
+import { getTezosToolkit } from "./tezosToolkit";
+
+jest.mock("./tezosToolkit");
+jest.mock("../config", () => ({
+  getCoinConfig: jest.fn(),
+}));
+// Keep real validatePublicKey/normalize, override only the pkh derivation so we can
+// pair an arbitrary valid edpk with our test sender in the reveal path.
+jest.mock("@taquito/utils", () => ({
+  ...jest.requireActual("@taquito/utils"),
+  getPkhfromPk: jest.fn(),
+}));
+
+// Real, valid Tezos addresses — validateOperation rejects malformed ones.
+const SENDER = "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx";
+const RECIPIENT = "tz2TaTpo31sAiX2HBJUTLLdUnqVJR4QjLy1V";
+const CONTRACT = "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU";
+const BAKER = "tz3Vq38qYD3GEbWcXHMLt5PaASZrkDtEiA8D";
+// A valid ed25519 public key (edpk…) so normalizePublicKeyForAddress/validatePublicKey accept it.
+const PUBLIC_KEY = "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav";
+
+describe("craftRawOperations", () => {
+  const mockTezosToolkit = {
+    rpc: {
+      getManagerKey: jest.fn(),
+      getBlock: jest.fn(),
+      forgeOperations: jest.fn(),
+    },
+    estimate: {
+      batch: jest.fn(),
+      reveal: jest.fn(),
+    },
+    setProvider: jest.fn(),
+  };
+
+  // Helper: the OperationContents[] that were forged in this call.
+  const forgedContents = () => {
+    expect(mockTezosToolkit.rpc.forgeOperations).toHaveBeenCalled();
+    return mockTezosToolkit.rpc.forgeOperations.mock.calls[0][0].contents;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getTezosToolkit as jest.Mock).mockReturnValue(mockTezosToolkit);
+    mockTezosToolkit.rpc.getBlock.mockResolvedValue({ hash: "BLockHash" });
+    mockTezosToolkit.rpc.forgeOperations.mockResolvedValue("deadbeef");
+    // Default: account already revealed (no leading reveal op).
+    mockTezosToolkit.rpc.getManagerKey.mockResolvedValue(PUBLIC_KEY);
+    // One estimate per operation (1:1 with the params passed to estimate.batch).
+    mockTezosToolkit.estimate.batch.mockResolvedValue([
+      { suggestedFeeMutez: 500, gasLimit: 1400, storageLimit: 0 },
+    ]);
+    (coinConfig.getCoinConfig as jest.Mock).mockReturnValue({
+      fees: { minFees: 100, minRevealGasLimit: 0, minStorageLimit: 0 },
+    });
+  });
+
+  it("forges a plain transfer, estimating the missing limits", async () => {
+    const ops = [{ kind: "transaction", destination: RECIPIENT, amount: "1000" }];
+
+    const result = await craftRawOperations(JSON.stringify(ops), SENDER, PUBLIC_KEY, 5n);
+
+    expect(result).toBe("03deadbeef"); // 0x03 watermark + forged bytes
+    expect(mockTezosToolkit.estimate.batch).toHaveBeenCalledWith([
+      { kind: OpKind.TRANSACTION, source: SENDER, to: RECIPIENT, amount: 1000, mutez: true },
+    ]);
+    expect(forgedContents()).toEqual([
+      {
+        kind: OpKind.TRANSACTION,
+        source: SENDER,
+        destination: RECIPIENT,
+        amount: "1000",
+        counter: "5",
+        fee: "500",
+        gas_limit: "1400",
+        storage_limit: "0",
+      },
+    ]);
+  });
+
+  it("forges a contract call, passing the entrypoint/parameters to the estimate and contents", async () => {
+    const parameters = { entrypoint: "transfer", value: { prim: "Unit" } };
+    const ops = [{ kind: "transaction", destination: CONTRACT, amount: "0", parameters }];
+
+    await craftRawOperations(JSON.stringify(ops), SENDER, PUBLIC_KEY, 7n);
+
+    expect(mockTezosToolkit.estimate.batch).toHaveBeenCalledWith([
+      { kind: OpKind.TRANSACTION, source: SENDER, to: CONTRACT, amount: 0, mutez: true, parameter: parameters },
+    ]);
+    expect(forgedContents()[0]).toMatchObject({
+      kind: OpKind.TRANSACTION,
+      destination: CONTRACT,
+      counter: "7",
+      parameters,
+    });
+  });
+
+  it("forges a delegation", async () => {
+    mockTezosToolkit.estimate.batch.mockResolvedValue([
+      { suggestedFeeMutez: 400, gasLimit: 1000, storageLimit: 0 },
+    ]);
+    const ops = [{ kind: "delegation", delegate: BAKER }];
+
+    await craftRawOperations(JSON.stringify(ops), SENDER, PUBLIC_KEY, 3n);
+
+    expect(mockTezosToolkit.estimate.batch).toHaveBeenCalledWith([
+      { kind: OpKind.DELEGATION, source: SENDER, delegate: BAKER },
+    ]);
+    expect(forgedContents()).toEqual([
+      {
+        kind: OpKind.DELEGATION,
+        source: SENDER,
+        counter: "3",
+        fee: "400",
+        gas_limit: "1000",
+        storage_limit: "0",
+        delegate: BAKER,
+      },
+    ]);
+  });
+
+  it("forges a multi-op batch with sequential counters from a single batch estimate", async () => {
+    mockTezosToolkit.estimate.batch.mockResolvedValue([
+      { suggestedFeeMutez: 500, gasLimit: 1400, storageLimit: 0 },
+      { suggestedFeeMutez: 900, gasLimit: 5000, storageLimit: 10 },
+    ]);
+    const ops = [
+      { kind: "transaction", destination: RECIPIENT, amount: "10" },
+      { kind: "transaction", destination: CONTRACT, amount: "0", parameters: { entrypoint: "foo", value: { prim: "Unit" } } },
+    ];
+
+    await craftRawOperations(JSON.stringify(ops), SENDER, PUBLIC_KEY, 9n);
+
+    expect(mockTezosToolkit.estimate.batch).toHaveBeenCalledTimes(1);
+    const contents = forgedContents();
+    expect(contents).toHaveLength(2);
+    expect(contents[0].counter).toBe("9");
+    expect(contents[1]).toMatchObject({ counter: "10", gas_limit: "5000", storage_limit: "10" });
+  });
+
+  it("uses the trailing op estimate when a reveal estimate is prepended for an unrevealed source", async () => {
+    mockTezosToolkit.rpc.getManagerKey.mockResolvedValue(null);
+    (getPkhfromPk as jest.Mock).mockReturnValue(SENDER);
+    mockTezosToolkit.estimate.reveal.mockResolvedValue({
+      suggestedFeeMutez: 374,
+      gasLimit: 1000,
+      storageLimit: 0,
+    });
+    // batch returns [reveal, op]; the leading reveal estimate is dropped, op uses the trailing one.
+    mockTezosToolkit.estimate.batch.mockResolvedValue([
+      { suggestedFeeMutez: 374, gasLimit: 1000, storageLimit: 0 },
+      { suggestedFeeMutez: 800, gasLimit: 2000, storageLimit: 5 },
+    ]);
+    const ops = [{ kind: "transaction", destination: RECIPIENT, amount: "1000" }];
+
+    await craftRawOperations(JSON.stringify(ops), SENDER, PUBLIC_KEY, 5n);
+
+    const contents = forgedContents();
+    expect(contents[0].kind).toBe(OpKind.REVEAL);
+    expect(contents[1]).toMatchObject({
+      kind: OpKind.TRANSACTION,
+      fee: "800",
+      gas_limit: "2000",
+      storage_limit: "5",
+    });
+  });
+
+  it("throws when the batch estimate count doesn't match (revealed source, extra estimate)", async () => {
+    // Revealed source ⇒ expect exactly N estimates; N+1 is a contract violation, not a silent slice.
+    mockTezosToolkit.estimate.batch.mockResolvedValue([
+      { suggestedFeeMutez: 374, gasLimit: 1000, storageLimit: 0 },
+      { suggestedFeeMutez: 800, gasLimit: 2000, storageLimit: 5 },
+    ]);
+    const ops = [{ kind: "transaction", destination: RECIPIENT, amount: "1000" }];
+
+    await expect(
+      craftRawOperations(JSON.stringify(ops), SENDER, PUBLIC_KEY, 5n),
+    ).rejects.toThrow("expected 1 estimate(s)");
+  });
+
+  it("honours caller-provided fee/gas/storage without estimating", async () => {
+    const ops = [
+      {
+        kind: "transaction",
+        destination: RECIPIENT,
+        amount: "1000",
+        fee: "1234",
+        gas_limit: "2000",
+        storage_limit: "10",
+      },
+    ];
+
+    await craftRawOperations(JSON.stringify(ops), SENDER, PUBLIC_KEY, 5n);
+
+    expect(mockTezosToolkit.estimate.batch).not.toHaveBeenCalled();
+    expect(forgedContents()[0]).toMatchObject({ fee: "1234", gas_limit: "2000", storage_limit: "10" });
+  });
+
+  it("prepends a reveal when the sender is not revealed", async () => {
+    mockTezosToolkit.rpc.getManagerKey.mockResolvedValue(null);
+    (getPkhfromPk as jest.Mock).mockReturnValue(SENDER);
+    mockTezosToolkit.estimate.reveal.mockResolvedValue({
+      suggestedFeeMutez: 374,
+      gasLimit: 1000,
+      storageLimit: 0,
+    });
+
+    const ops = [{ kind: "transaction", destination: RECIPIENT, amount: "1000" }];
+
+    await craftRawOperations(JSON.stringify(ops), SENDER, PUBLIC_KEY, 5n);
+
+    const contents = forgedContents();
+    expect(contents).toHaveLength(2);
+    expect(contents[0]).toMatchObject({
+      kind: OpKind.REVEAL,
+      source: SENDER,
+      counter: "5",
+      public_key: PUBLIC_KEY,
+    });
+    expect(contents[1]).toMatchObject({ kind: OpKind.TRANSACTION, counter: "6" });
+  });
+
+  it("falls back to SDK reveal helpers when estimate.reveal throws", async () => {
+    mockTezosToolkit.rpc.getManagerKey.mockResolvedValue(null);
+    (getPkhfromPk as jest.Mock).mockReturnValue(SENDER);
+    mockTezosToolkit.estimate.reveal.mockRejectedValue(new Error("inconsistent_hash"));
+
+    const ops = [{ kind: "transaction", destination: RECIPIENT, amount: "1000" }];
+
+    await craftRawOperations(JSON.stringify(ops), SENDER, PUBLIC_KEY, 5n);
+
+    const reveal = forgedContents()[0];
+    expect(reveal.kind).toBe(OpKind.REVEAL);
+    // Reveal limits came from the SDK fallback (getRevealFee/getRevealGasLimit), not a thrown error.
+    expect(reveal.fee).toMatch(/^\d+$/);
+    expect(reveal.gas_limit).toMatch(/^\d+$/);
+  });
+
+  it("rejects a reveal whose public key does not match the sender", async () => {
+    mockTezosToolkit.rpc.getManagerKey.mockResolvedValue(null);
+    (getPkhfromPk as jest.Mock).mockReturnValue("tz1someoneElse");
+
+    const ops = [{ kind: "transaction", destination: RECIPIENT, amount: "1000" }];
+
+    await expect(
+      craftRawOperations(JSON.stringify(ops), SENDER, PUBLIC_KEY, 5n),
+    ).rejects.toThrow("does not match the sender");
+  });
+
+  it("throws on an unsupported operation kind", async () => {
+    const ops = [{ kind: "origination", balance: "0" }];
+
+    await expect(
+      craftRawOperations(JSON.stringify(ops), SENDER, PUBLIC_KEY, 5n),
+    ).rejects.toBeInstanceOf(UnsupportedOperationKind);
+  });
+
+  describe("input validation", () => {
+    it("throws on malformed JSON or an empty array", async () => {
+      await expect(craftRawOperations("not-json", SENDER, PUBLIC_KEY, 5n)).rejects.toThrow(
+        "must be a JSON array",
+      );
+      await expect(craftRawOperations("[]", SENDER, PUBLIC_KEY, 5n)).rejects.toThrow(
+        "non-empty array",
+      );
+    });
+
+    it("throws on a non-integer amount", async () => {
+      const ops = [{ kind: "transaction", destination: RECIPIENT, amount: "1.5" }];
+      await expect(
+        craftRawOperations(JSON.stringify(ops), SENDER, PUBLIC_KEY, 5n),
+      ).rejects.toThrow("`amount` must be a non-negative integer string");
+    });
+
+    it("throws on a missing or invalid destination", async () => {
+      await expect(
+        craftRawOperations(JSON.stringify([{ kind: "transaction", amount: "1000" }]), SENDER, PUBLIC_KEY, 5n),
+      ).rejects.toThrow("valid `destination`");
+      await expect(
+        craftRawOperations(
+          JSON.stringify([{ kind: "transaction", destination: "not-an-address", amount: "1000" }]),
+          SENDER,
+          PUBLIC_KEY,
+          5n,
+        ),
+      ).rejects.toThrow("valid `destination`");
+    });
+
+    it("throws on a non-numeric fee", async () => {
+      const ops = [{ kind: "transaction", destination: RECIPIENT, amount: "1000", fee: "abc" }];
+      await expect(
+        craftRawOperations(JSON.stringify(ops), SENDER, PUBLIC_KEY, 5n),
+      ).rejects.toThrow("`fee` must be a non-negative integer string");
+    });
+
+    it("rejects an empty or invalid delegate (must not be treated as undelegation)", async () => {
+      await expect(
+        craftRawOperations(JSON.stringify([{ kind: "delegation", delegate: "" }]), SENDER, PUBLIC_KEY, 5n),
+      ).rejects.toThrow("`delegate` must be a valid implicit account address");
+      await expect(
+        craftRawOperations(JSON.stringify([{ kind: "delegation", delegate: 123 }]), SENDER, PUBLIC_KEY, 5n),
+      ).rejects.toThrow("`delegate` must be a valid implicit account address");
+    });
+
+    it("rejects a contract (KT1) delegate (delegates must be implicit accounts)", async () => {
+      await expect(
+        craftRawOperations(JSON.stringify([{ kind: "delegation", delegate: CONTRACT }]), SENDER, PUBLIC_KEY, 5n),
+      ).rejects.toThrow("`delegate` must be a valid implicit account address");
+    });
+
+    it("allows a delegation with no delegate (undelegation)", async () => {
+      mockTezosToolkit.estimate.batch.mockResolvedValue([
+        { suggestedFeeMutez: 400, gasLimit: 1000, storageLimit: 0 },
+      ]);
+      await craftRawOperations(JSON.stringify([{ kind: "delegation" }]), SENDER, PUBLIC_KEY, 5n);
+
+      const content = forgedContents()[0];
+      expect(content.kind).toBe(OpKind.DELEGATION);
+      expect(content).not.toHaveProperty("delegate");
+    });
+
+    it("throws when the sequence is out of safe integer range", async () => {
+      const ops = [{ kind: "transaction", destination: RECIPIENT, amount: "1000" }];
+      await expect(
+        craftRawOperations(JSON.stringify(ops), SENDER, PUBLIC_KEY, BigInt(Number.MAX_SAFE_INTEGER) + 1n),
+      ).rejects.toThrow("out of the safe integer range");
+    });
+
+    it("throws on an invalid or contract (KT1) sender address", async () => {
+      const ops = [{ kind: "transaction", destination: RECIPIENT, amount: "1000" }];
+      await expect(
+        craftRawOperations(JSON.stringify(ops), "not-an-address", PUBLIC_KEY, 5n),
+      ).rejects.toThrow("`sender` must be a valid implicit account address");
+      await expect(
+        craftRawOperations(JSON.stringify(ops), CONTRACT, PUBLIC_KEY, 5n),
+      ).rejects.toThrow("`sender` must be a valid implicit account address");
+    });
+  });
+});

--- a/libs/coin-modules/coin-tezos/src/logic/craftRawOperations.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/craftRawOperations.ts
@@ -1,0 +1,302 @@
+import { type MichelsonV1Expression, type OperationContents, OpKind } from "@taquito/rpc";
+import { type Estimate, type ParamsWithKind } from "@taquito/taquito";
+import {
+  getPkhfromPk,
+  validateAddress,
+  validateKeyHash,
+  validatePublicKey,
+  ValidationResult,
+} from "@taquito/utils";
+import coinConfig from "../config";
+import { UnsupportedOperationKind } from "../types/errors";
+import { createMockSigner, normalizePublicKeyForAddress } from "../utils";
+import { rawEncode } from "./craftTransaction";
+import { estimateRevealLimits } from "./estimateRevealLimits";
+import { getTezosToolkit } from "./tezosToolkit";
+
+/**
+ * Partial Tezos operation contents: RPC operation contents without `source`,
+ * `counter` or `branch`, and with optional `fee`/`gas_limit`/`storage_limit`. This
+ * module fills the missing fields (`source`, a sequential `counter`, and — when
+ * absent — `fee`/`gas`/`storage` via estimation). Supports `transaction` (transfers
+ * and contract calls) and `delegation`; other kinds raise UnsupportedOperationKind.
+ */
+export type PartialTezosTransactionOperation = {
+  kind: "transaction";
+  destination: string;
+  amount: string;
+  parameters?: { entrypoint: string; value: MichelsonV1Expression };
+  fee?: string;
+  gas_limit?: string;
+  storage_limit?: string;
+};
+export type PartialTezosDelegationOperation = {
+  kind: "delegation";
+  delegate?: string;
+  fee?: string;
+  gas_limit?: string;
+  storage_limit?: string;
+};
+export type PartialTezosOperation =
+  | PartialTezosTransactionOperation
+  | PartialTezosDelegationOperation;
+
+type ResolvedLimits = { fee: string; gasLimit: string; storageLimit: string };
+
+/**
+ * Craft a forged (but unsigned) Tezos operation from a JSON-serialized array of
+ * partial operation contents ({@link PartialTezosOperation}).
+ *
+ * Fills the fields a caller cannot specify up front: `source`, a sequential `counter`
+ * starting at `sequence`, and any missing `fee`/`gas_limit`/`storage_limit` (estimated
+ * against the node). Prepends a REVEAL when the sender's manager key is not yet
+ * revealed on-chain.
+ *
+ * Returns the `0x03`-watermarked forged hex produced by {@link rawEncode} — the same
+ * format the structured `craft()` path returns and broadcasts, so the existing
+ * `signer.signTransaction` + `combine` + broadcast path applies to it unchanged.
+ */
+export async function craftRawOperations(
+  rawTransaction: string,
+  sender: string,
+  publicKey: string,
+  sequence: bigint,
+): Promise<string> {
+  if (sequence < 0n || sequence > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error("craftRawOperations: sequence is out of the safe integer range");
+  }
+  if (!isImplicitAddress(sender)) {
+    throw new Error("craftRawOperations: `sender` must be a valid implicit account address");
+  }
+  const operations = parseOperations(rawTransaction);
+
+  const tezosToolkit = getTezosToolkit();
+  const normalizedPk = normalizePublicKeyForAddress(publicKey, sender);
+  // Mock signer lets Taquito estimate without a connected device.
+  tezosToolkit.setProvider({ signer: createMockSigner(sender, normalizedPk ?? "") });
+
+  const feesConfig = coinConfig.getCoinConfig().fees;
+  const minFees = feesConfig.minFees;
+
+  let counter = Number(sequence);
+  const contents: OperationContents[] = [];
+
+  // A manager key that is not yet revealed on-chain requires a leading REVEAL op.
+  const managerKey = await tezosToolkit.rpc.getManagerKey(sender);
+  const needsReveal = !managerKey;
+  if (needsReveal) {
+    if (!normalizedPk || validatePublicKey(normalizedPk) !== ValidationResult.VALID) {
+      throw new Error("craftRawOperations: a valid public key is required to reveal the sender");
+    }
+    // The key must belong to the sender, otherwise the node rejects it as inconsistent_hash.
+    if (getPkhfromPk(normalizedPk) !== sender) {
+      throw new Error("craftRawOperations: public key does not match the sender address");
+    }
+    const reveal = await estimateRevealLimits(tezosToolkit, sender, feesConfig);
+    contents.push({
+      kind: OpKind.REVEAL,
+      source: sender,
+      counter: counter.toString(),
+      fee: reveal.fee.toString(),
+      gas_limit: reveal.gasLimit.toString(),
+      storage_limit: reveal.storageLimit.toString(),
+      public_key: normalizedPk,
+    });
+    counter += 1;
+  }
+
+  const estimates = await estimateOperations(operations, sender, needsReveal, tezosToolkit);
+  operations.forEach((op, index) => {
+    contents.push(buildOperationContent(op, sender, counter, minFees, estimates?.[index]));
+    counter += 1;
+  });
+
+  return rawEncode(contents);
+}
+
+function parseOperations(rawTransaction: string): PartialTezosOperation[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawTransaction);
+  } catch {
+    throw new Error("craftRawOperations: rawTransaction must be a JSON array of operations");
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error("craftRawOperations: expected a non-empty array of operations");
+  }
+  return parsed.map(validateOperation);
+}
+
+function validateOperation(op: unknown): PartialTezosOperation {
+  if (!op || typeof op !== "object") {
+    throw new Error("craftRawOperations: invalid operation");
+  }
+  const candidate = op as Record<string, unknown>;
+  assertOptionalLimits(candidate);
+  switch (candidate.kind) {
+    case "transaction":
+      if (!isValidAddress(candidate.destination)) {
+        throw new Error("craftRawOperations: a transaction requires a valid `destination` address");
+      }
+      assertMutezAmount(candidate.amount);
+      return candidate as PartialTezosTransactionOperation;
+    case "delegation":
+      // A delegation with no `delegate` is an undelegation; when present it must be a valid
+      // implicit account (an empty/invalid string must not be silently treated as absent).
+      if (candidate.delegate !== undefined && !isImplicitAddress(candidate.delegate)) {
+        throw new Error(
+          "craftRawOperations: `delegate` must be a valid implicit account address when present",
+        );
+      }
+      return candidate as unknown as PartialTezosDelegationOperation;
+    default:
+      throw new UnsupportedOperationKind("unsupported operation kind", {
+        kind: String(candidate.kind),
+      });
+  }
+}
+
+function isValidAddress(value: unknown): value is string {
+  return typeof value === "string" && validateAddress(value) === ValidationResult.VALID;
+}
+
+function isImplicitAddress(value: unknown): value is string {
+  return typeof value === "string" && validateKeyHash(value) === ValidationResult.VALID;
+}
+
+function assertMutezAmount(amount: unknown): void {
+  if (typeof amount !== "string" || !/^\d+$/.test(amount)) {
+    throw new Error("craftRawOperations: `amount` must be a non-negative integer string (mutez)");
+  }
+  if (BigInt(amount) > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error("craftRawOperations: `amount` exceeds the safe integer range");
+  }
+}
+
+function assertOptionalLimits(candidate: Record<string, unknown>): void {
+  for (const field of ["fee", "gas_limit", "storage_limit"] as const) {
+    const value = candidate[field];
+    if (value !== undefined && (typeof value !== "string" || !/^\d+$/.test(value))) {
+      throw new Error(`craftRawOperations: \`${field}\` must be a non-negative integer string`);
+    }
+  }
+}
+
+/**
+ * Estimate the whole batch in a single simulation so that gas/storage for operations
+ * that depend on earlier ones in the same batch are accounted for (a per-op estimate
+ * would simulate each against head state and can under-estimate). Returns one estimate
+ * per operation, or `undefined` when every operation already carries all three limits.
+ */
+async function estimateOperations(
+  operations: PartialTezosOperation[],
+  sender: string,
+  needsReveal: boolean,
+  tezosToolkit: ReturnType<typeof getTezosToolkit>,
+): Promise<Estimate[] | undefined> {
+  const needsEstimation = operations.some(
+    op => op.fee === undefined || op.gas_limit === undefined || op.storage_limit === undefined,
+  );
+  if (!needsEstimation) return undefined;
+
+  const params: ParamsWithKind[] = operations.map(op => toBatchParam(op, sender));
+  const estimates = await tezosToolkit.estimate.batch(params);
+  // Taquito may prepend a single reveal estimate when the source is unrevealed. Accept N
+  // (no prepend) or N+1 (prepended) only in that case; for a revealed source require
+  // exactly N so a stray estimate fails loudly instead of silently misaligning per-op.
+  const maxExpected = operations.length + (needsReveal ? 1 : 0);
+  if (estimates.length < operations.length || estimates.length > maxExpected) {
+    const expected = needsReveal ? `${operations.length} or ${maxExpected}` : `${operations.length}`;
+    throw new Error(
+      `craftRawOperations: expected ${expected} estimate(s) for ${operations.length} operation(s), got ${estimates.length}`,
+    );
+  }
+  // Keep the trailing N estimates, dropping a prepended reveal estimate if present. The
+  // REVEAL op itself uses estimateRevealLimits (config-clamped, consistent with
+  // craftTransaction) rather than this batch-prepended value, which is discarded.
+  return estimates.slice(estimates.length - operations.length);
+}
+
+function toBatchParam(op: PartialTezosOperation, sender: string): ParamsWithKind {
+  switch (op.kind) {
+    case "transaction":
+      return {
+        kind: OpKind.TRANSACTION,
+        source: sender,
+        to: op.destination,
+        amount: Number(op.amount),
+        mutez: true,
+        ...(op.parameters ? { parameter: op.parameters } : {}),
+      };
+    case "delegation":
+      return {
+        kind: OpKind.DELEGATION,
+        source: sender,
+        ...(op.delegate === undefined ? {} : { delegate: op.delegate }),
+      };
+    default:
+      return assertNever(op);
+  }
+}
+
+function buildOperationContent(
+  op: PartialTezosOperation,
+  sender: string,
+  counter: number,
+  minFees: number,
+  estimate?: Estimate,
+): OperationContents {
+  const limits = resolveLimits(op, minFees, estimate);
+  switch (op.kind) {
+    case "transaction":
+      return {
+        kind: OpKind.TRANSACTION,
+        source: sender,
+        destination: op.destination,
+        amount: op.amount,
+        counter: counter.toString(),
+        fee: limits.fee,
+        gas_limit: limits.gasLimit,
+        storage_limit: limits.storageLimit,
+        ...(op.parameters ? { parameters: op.parameters } : {}),
+      };
+    case "delegation":
+      return {
+        kind: OpKind.DELEGATION,
+        source: sender,
+        counter: counter.toString(),
+        fee: limits.fee,
+        gas_limit: limits.gasLimit,
+        storage_limit: limits.storageLimit,
+        ...(op.delegate === undefined ? {} : { delegate: op.delegate }),
+      };
+    default:
+      return assertNever(op);
+  }
+}
+
+// Compile-time exhaustiveness guard: a new PartialTezosOperation kind becomes a type error
+// here. validateOperation already rejects unknown kinds at runtime before crafting.
+function assertNever(op: never): never {
+  throw new UnsupportedOperationKind("unsupported operation kind", {
+    kind: String((op as { kind?: unknown }).kind),
+  });
+}
+
+/**
+ * Honour any fee/gas/storage the caller already provided; fall back to the batch
+ * estimate for the missing ones.
+ */
+function resolveLimits(op: PartialTezosOperation, minFees: number, estimate?: Estimate): ResolvedLimits {
+  if (op.fee !== undefined && op.gas_limit !== undefined && op.storage_limit !== undefined) {
+    return { fee: op.fee, gasLimit: op.gas_limit, storageLimit: op.storage_limit };
+  }
+  if (!estimate) {
+    throw new Error("craftRawOperations: missing fee estimation for operation");
+  }
+  return {
+    fee: op.fee ?? Math.max(minFees, estimate.suggestedFeeMutez).toString(),
+    gasLimit: op.gas_limit ?? estimate.gasLimit.toString(),
+    storageLimit: op.storage_limit ?? estimate.storageLimit.toString(),
+  };
+}

--- a/libs/coin-modules/coin-tezos/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/craftTransaction.ts
@@ -1,9 +1,8 @@
-import { log } from "@ledgerhq/logs";
 import { type OperationContents, OpKind } from "@taquito/rpc";
-import { getRevealFee, getRevealGasLimit } from "@taquito/taquito";
 import coinConfig from "../config";
 import { UnsupportedTransactionMode } from "../types/errors";
 import { createMockSigner } from "../utils";
+import { estimateRevealLimits } from "./estimateRevealLimits";
 import { getTezosToolkit } from "./tezosToolkit";
 
 export type TransactionFee = {
@@ -68,42 +67,13 @@ export async function craftTransaction(
 
   if (publicKey !== undefined) {
     const feesConfig = coinConfig.getCoinConfig().fees;
-
-    type RevealEstimate = { gasLimit?: number; storageLimit?: number; suggestedFeeMutez?: number };
-    let revealEstimate: RevealEstimate | undefined;
-    try {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      revealEstimate = (await tezosToolkit.estimate.reveal()) as RevealEstimate;
-    } catch (error) {
-      // for some unknown reason, on some addresses the estimation fails with "inconsistent_hash" error, we fall back to
-      // another method from the SDK
-      log("estimate-error", "error estimating reveal fees, trying using getRevealGasLimit", {
-        error,
-      });
-      revealEstimate = {
-        gasLimit: getRevealGasLimit(address),
-        suggestedFeeMutez: getRevealFee(address),
-      };
-    }
-
-    const revealFee = Math.max(
-      feesConfig.minFees ?? 0,
-      revealEstimate?.suggestedFeeMutez ?? getRevealFee(address) ?? 0,
-    );
-    const revealGasLimit = Math.max(
-      feesConfig.minRevealGasLimit ?? 0,
-      revealEstimate?.gasLimit ?? 0,
-    );
-    const revealStorageLimit = Math.max(
-      feesConfig.minStorageLimit ?? 0,
-      revealEstimate?.storageLimit ?? 0,
-    );
+    const reveal = await estimateRevealLimits(tezosToolkit, address, feesConfig);
 
     contents.push({
       kind: OpKind.REVEAL,
-      fee: revealFee.toString(),
-      gas_limit: revealGasLimit.toString(),
-      storage_limit: revealStorageLimit.toString(),
+      fee: reveal.fee.toString(),
+      gas_limit: reveal.gasLimit.toString(),
+      storage_limit: reveal.storageLimit.toString(),
       source: publicKey.publicKeyHash,
       counter: (counter + 1 + contents.length).toString(),
       public_key: publicKey.publicKey,

--- a/libs/coin-modules/coin-tezos/src/logic/estimateRevealLimits.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/estimateRevealLimits.ts
@@ -1,0 +1,32 @@
+import { log } from "@ledgerhq/logs";
+import { getRevealFee, getRevealGasLimit } from "@taquito/taquito";
+import type { TezosConfig } from "../config";
+import { getTezosToolkit } from "./tezosToolkit";
+
+type RevealLimits = { fee: number; gasLimit: number; storageLimit: number };
+
+/**
+ * Estimate the reveal-operation limits for an unrevealed manager account, clamped to
+ * the configured minimums. Falls back to the SDK helpers when node estimation fails
+ * (some addresses error with "inconsistent_hash").
+ */
+export async function estimateRevealLimits(
+  tezosToolkit: ReturnType<typeof getTezosToolkit>,
+  address: string,
+  feesConfig: TezosConfig["fees"],
+): Promise<RevealLimits> {
+  type RevealEstimate = { gasLimit?: number; storageLimit?: number; suggestedFeeMutez?: number };
+  let revealEstimate: RevealEstimate | undefined;
+  try {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    revealEstimate = (await tezosToolkit.estimate.reveal()) as RevealEstimate | undefined;
+  } catch (error) {
+    log("estimate-error", "error estimating reveal fees, trying to use getRevealGasLimit", { error });
+    revealEstimate = { gasLimit: getRevealGasLimit(address), suggestedFeeMutez: getRevealFee(address) };
+  }
+  return {
+    fee: Math.max(feesConfig.minFees, revealEstimate?.suggestedFeeMutez ?? getRevealFee(address)),
+    gasLimit: Math.max(feesConfig.minRevealGasLimit, revealEstimate?.gasLimit ?? 0),
+    storageLimit: Math.max(feesConfig.minStorageLimit, revealEstimate?.storageLimit ?? 0),
+  };
+}

--- a/libs/coin-modules/coin-tezos/src/logic/index.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/index.ts
@@ -1,6 +1,7 @@
 export { broadcast } from "./broadcast";
 export { combine } from "./combine";
 export { craftTransaction, rawEncode } from "./craftTransaction";
+export { craftRawOperations } from "./craftRawOperations";
 export { estimateFees } from "./estimateFees";
 export { getBalance } from "./getBalance";
 export { getBlock } from "./getBlock";

--- a/libs/coin-modules/coin-tezos/src/types/errors.ts
+++ b/libs/coin-modules/coin-tezos/src/types/errors.ts
@@ -8,5 +8,9 @@ export const UnsupportedTransactionMode = createCustomErrorClass<
   { mode: string },
   LedgerErrorConstructor<{ mode: string }>
 >("UnsupportedTransactionMode");
+export const UnsupportedOperationKind = createCustomErrorClass<
+  { kind: string },
+  LedgerErrorConstructor<{ kind: string }>
+>("UnsupportedOperationKind");
 export const MustDelegateBeforeStaking = createCustomErrorClass("MustDelegateBeforeStaking");
 export const TezosNotEnoughStaked = createCustomErrorClass("TezosNotEnoughStaked");


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Unit tests for `craftRawOperations` (transfer, contract call, delegation, batch, reveal, validation) and the `craftRawTransaction` api wrapper; existing `craftTransaction` suite still green after the shared-helper extraction.
- [x] **Impact of the changes:** library-only addition to `@ledgerhq/coin-tezos`; no user-facing surface consumes it yet.
  - `craftRawTransaction` was a throwing stub and is now implemented — net-new capability, no behavior change to existing flows.
  - Reveal-limit estimation was extracted into a shared `estimateRevealLimits` helper used by both `craftTransaction` and `craftRawOperations` (behavior-preserving).
  - QA focus: none device-facing yet; relevant once the Wallet API `transaction.signRaw` path is wired for Tezos.

### 📝 Description

Implements `craftRawTransaction` in `coin-tezos` (previously a throwing stub) so the Alpaca api can craft and sign **arbitrary, under-specified Tezos operations** — the foundation for signing Tezos transactions coming from external sources (e.g. WalletConnect) via the Wallet API `transaction.signRaw` path.

`logic/craftRawOperations.ts` takes a JSON array of partial operation contents (`transaction` — transfers and contract calls — and `delegation`), then:

- fills `source` and a sequential `counter` (from the provided `sequence`);
- estimates any missing `fee`/`gas_limit`/`storage_limit` in a single whole-batch Taquito simulation (so operations that depend on earlier ones in the batch are accounted for);
- prepends a `REVEAL` when the sender's manager key is unrevealed, verifying the public key matches the sender;
- forges via the existing `rawEncode`, returning the `0x03`-watermarked hex the structured `craft()` path already produces — so it round-trips through the existing signer + `combine` + broadcast unchanged.

Input is validated at the api boundary (operation kind, destination, mutez amount, delegate, fee/gas/storage); unsupported operation kinds raise `UnsupportedOperationKind`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32113](https://ledgerhq.atlassian.net/browse/LIVE-32113)
- **ADR link (if any)**: —


[LIVE-32113]: https://ledgerhq.atlassian.net/browse/LIVE-32113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ