### PR TITLE
[LWDM] feat(tezos): add message signing for WalletConnect tezos_sign

### DIFF
--- a/.changeset/tezos-sign-message.md
+++ b/.changeset/tezos-sign-message.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-tezos": minor
+"@ledgerhq/live-common": minor
+---
+
+Add Tezos message signing: a `signMessage` that signs an already-watermarked payload verbatim (normalising the device signature to raw r||s), and wire it as the `tezos` family `messageSigner`.

--- a/libs/coin-modules/coin-tezos/.unimportedrc.json
+++ b/libs/coin-modules/coin-tezos/.unimportedrc.json
@@ -3,6 +3,7 @@
   "entry": [
     "src/api/index.ts",
     "src/bridge/deviceTransactionConfig.ts",
+    "src/hw-signMessage.ts",
     "src/index.ts",
     "src/signer/getAddress.ts",
     "src/signer/index.ts",

--- a/libs/coin-modules/coin-tezos/src/hw-signMessage.test.ts
+++ b/libs/coin-modules/coin-tezos/src/hw-signMessage.test.ts
@@ -1,0 +1,94 @@
+import type { Account } from "@ledgerhq/types-live";
+import { signMessage } from "./hw-signMessage";
+import type { TezosSigner } from "./types/signer";
+
+const DEVICE_ID = "device-1";
+const RAW_SIG = "ab".repeat(64);
+
+function makeAccount(freshAddress: string): Account {
+  return {
+    freshAddress,
+    freshAddressPath: "44'/1729'/0'/0'",
+  } as unknown as Account;
+}
+
+function setup(signOperationResult: { signature: string }) {
+  const signOperation = jest.fn().mockResolvedValue(signOperationResult);
+  const signer = { signOperation } as unknown as TezosSigner;
+  const signerContext = jest.fn((_deviceId: string, fn: (s: TezosSigner) => unknown) =>
+    Promise.resolve(fn(signer)),
+  );
+  return { signOperation, signerContext };
+}
+
+describe("hw-signMessage / signMessage", () => {
+  it("signs the payload verbatim without prepending a magic byte", async () => {
+    const { signOperation, signerContext } = setup({ signature: RAW_SIG });
+    const payload = "05010000000568656c";
+
+    const result = await signMessage(signerContext)(DEVICE_ID, makeAccount("tz1abc"), {
+      message: payload,
+    });
+
+    expect(signOperation).toHaveBeenCalledWith("44'/1729'/0'/0'", payload, { curve: 0x00 });
+    expect(result).toEqual({ signature: RAW_SIG });
+  });
+
+  it("selects the curve from the address prefix (tz1→ed25519, tz2→secp256k1, tz3→p256)", async () => {
+    for (const [prefix, expected] of [
+      ["tz1abc", 0x00],
+      ["tz2abc", 0x01],
+      ["tz3abc", 0x02],
+    ] as const) {
+      const { signOperation, signerContext } = setup({ signature: RAW_SIG });
+      await signMessage(signerContext)(DEVICE_ID, makeAccount(prefix), { message: "0501" });
+      expect(signOperation).toHaveBeenCalledWith("44'/1729'/0'/0'", "0501", { curve: expected });
+    }
+  });
+
+  it("normalises a DER secp256k1 signature to raw r||s", async () => {
+    // DER: 30 06 02 01 0a 02 01 0b → r=0x0a, s=0x0b (each padded to 32 bytes)
+    const der = "300602010a02010b";
+    const { signerContext } = setup({ signature: der });
+
+    const { signature } = await signMessage(signerContext)(DEVICE_ID, makeAccount("tz2abc"), {
+      message: "0501",
+    });
+
+    expect(signature).toBe("0a".padStart(64, "0") + "0b".padStart(64, "0"));
+  });
+
+  it.each([
+    ["empty", ""],
+    ["odd length", "abc"],
+    ["non-hex", "05zz"],
+  ])("throws on an invalid (%s) payload", async (_label, payload) => {
+    const { signerContext } = setup({ signature: RAW_SIG });
+    await expect(
+      signMessage(signerContext)(DEVICE_ID, makeAccount("tz1abc"), { message: payload }),
+    ).rejects.toThrow("must be a non-empty hex-encoded payload");
+  });
+
+  it.each([
+    ["a contract (KT1)", "KT1abc"],
+    ["an empty", ""],
+  ])("throws on %s address", async (_label, address) => {
+    const { signerContext } = setup({ signature: RAW_SIG });
+    await expect(
+      signMessage(signerContext)(DEVICE_ID, makeAccount(address), { message: "0501" }),
+    ).rejects.toThrow("must be a tz1/tz2/tz3 implicit address");
+  });
+
+  it.each([
+    ["empty", ""],
+    ["non-hex", "zz"],
+    ["truncated DER", "3006"],
+    // 33-byte r without a leading 0x00 is not valid DER and must not normalise to 33 bytes
+    ["33-byte r without 0x00 pad", "302502210a" + "11".repeat(32) + "020401020304"],
+  ])("throws when the device returns an invalid (%s) signature", async (_label, signature) => {
+    const { signerContext } = setup({ signature });
+    await expect(
+      signMessage(signerContext)(DEVICE_ID, makeAccount("tz2abc"), { message: "0501" }),
+    ).rejects.toThrow("device returned an invalid signature");
+  });
+});

--- a/libs/coin-modules/coin-tezos/src/hw-signMessage.ts
+++ b/libs/coin-modules/coin-tezos/src/hw-signMessage.ts
@@ -1,0 +1,42 @@
+import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
+import { Account, AnyMessage, DeviceId } from "@ledgerhq/types-live";
+import { Curve, TezosSigner } from "./types/signer";
+import { convertSecp256k1DERToRaw } from "./utils";
+
+// Curve tag (matching hw-app-tezos `TezosCurves`) from the implicit-address prefix.
+function curveForAddress(address: string): Curve {
+  if (address.startsWith("tz1")) return 0x00;
+  if (address.startsWith("tz2")) return 0x01;
+  if (address.startsWith("tz3")) return 0x02;
+  throw new Error("Tezos signMessage: account must be a tz1/tz2/tz3 implicit address");
+}
+
+/**
+ * Sign an arbitrary, already-watermarked payload (`message` is its hex string). The first
+ * byte is the magic byte the firmware reads as a dispatch tag and hashes with the rest, so
+ * the bytes are signed verbatim — nothing is prepended. Returns the signature as raw 64-byte hex.
+ */
+export const signMessage =
+  (signerContext: SignerContext<TezosSigner>) =>
+  async (
+    deviceId: DeviceId,
+    account: Account,
+    messageOptions: AnyMessage,
+  ): Promise<{ signature: string }> => {
+    const payloadHex = messageOptions.message;
+    if (
+      typeof payloadHex !== "string" ||
+      payloadHex.length === 0 ||
+      payloadHex.length % 2 !== 0 ||
+      !/^[0-9a-fA-F]+$/.test(payloadHex)
+    ) {
+      throw new Error("Tezos signMessage: `message` must be a non-empty hex-encoded payload");
+    }
+
+    const curve = curveForAddress(account.freshAddress);
+    const { signature } = await signerContext(deviceId, signer =>
+      signer.signOperation(account.freshAddressPath, payloadHex, { curve }),
+    );
+
+    return { signature: convertSecp256k1DERToRaw(signature) };
+  };

--- a/libs/coin-modules/coin-tezos/src/utils.ts
+++ b/libs/coin-modules/coin-tezos/src/utils.ts
@@ -166,6 +166,59 @@ export function normalizePublicKeyForAddress(
 }
 
 /**
+ * Converts a DER-encoded secp256k1/P-256 ECDSA signature (returned by the Tezos Ledger
+ * app for tz2/tz3 accounts) to the raw 64-byte r||s format the Tezos protocol expects.
+ * Format: 0x30 <totalLen> 0x02 <rLen> <r_bytes> 0x02 <sLen> <s_bytes>
+ */
+export function convertSecp256k1DERToRaw(derHex: string): string {
+  if (!/^[0-9a-fA-F]+$/.test(derHex) || derHex.length % 2 !== 0) {
+    throw new Error("Tezos: device returned an invalid signature");
+  }
+  const buf = Buffer.from(derHex, "hex");
+  if (buf.length === 64) return derHex; // already raw r||s
+
+  const rStart = 4;
+  const rLen = buf[3];
+  const sLenIdx = rStart + rLen + 1;
+  const sLen = buf[sLenIdx];
+  const sStart = sLenIdx + 1;
+  const malformed =
+    buf.length < 8 ||
+    buf[0] !== 0x30 ||
+    buf[2] !== 0x02 ||
+    buf[sLenIdx - 1] !== 0x02 ||
+    rLen === 0 ||
+    sLen === 0 ||
+    rLen > 33 ||
+    sLen > 33 ||
+    sStart + sLen !== buf.length;
+  if (malformed) {
+    throw new Error("Tezos: device returned an invalid signature");
+  }
+
+  const raw = Buffer.concat([
+    normalizeTo32Bytes(buf.slice(rStart, rStart + rLen)),
+    normalizeTo32Bytes(buf.slice(sStart, sStart + sLen)),
+  ]).toString("hex");
+  // A 33-byte r/s is only valid DER when left-padded with 0x00; anything else normalises
+  // to a non-64-byte result and is not a usable signature.
+  if (raw.length !== 128) {
+    throw new Error("Tezos: device returned an invalid signature");
+  }
+  return raw;
+}
+
+export function normalizeTo32Bytes(bytes: Buffer): Buffer {
+  if (bytes.length === 33 && bytes[0] === 0x00) return bytes.slice(1);
+  if (bytes.length < 32) {
+    const padded = Buffer.alloc(32, 0);
+    bytes.copy(padded, 32 - bytes.length);
+    return padded;
+  }
+  return bytes;
+}
+
+/**
  * Creates default fallback estimation values
  */
 export function createFallbackEstimation() {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/families/tezos/signer.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/families/tezos/signer.ts
@@ -1,39 +1,13 @@
 import Tezos, { TezosCurves, type Curve } from "@ledgerhq/hw-app-tezos";
 import Transport from "@ledgerhq/hw-transport";
-import { normalizePublicKeyForAddress } from "@ledgerhq/coin-tezos/utils";
+import { convertSecp256k1DERToRaw, normalizePublicKeyForAddress } from "@ledgerhq/coin-tezos/utils";
 import type { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
 import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type { CoinFrameworkSigner } from "../../types";
 import { CreateSigner, executeWithSigner } from "../../../setup";
 
-/**
- * Converts a DER-encoded secp256k1 ECDSA signature (returned by the Tezos Ledger app)
- * to the raw 64-byte r||s format expected by the Tezos protocol.
- * Format: 0x30/0x31 <totalLen> 0x02 <rLen> <r_bytes> 0x02 <sLen> <s_bytes>
- */
-export function convertSecp256k1DERToRaw(derHex: string): string {
-  const buf = Buffer.from(derHex, "hex");
-  if (buf.length === 64) return derHex; // already raw 64-byte format
-  const rLen = buf[3];
-  const rStart = 4;
-  const sLenIdx = rStart + rLen + 1;
-  const sLen = buf[sLenIdx];
-  const sStart = sLenIdx + 1;
-  return Buffer.concat([
-    normalizeTo32Bytes(buf.slice(rStart, rStart + rLen)),
-    normalizeTo32Bytes(buf.slice(sStart, sStart + sLen)),
-  ]).toString("hex");
-}
-
-export function normalizeTo32Bytes(bytes: Buffer): Buffer {
-  if (bytes.length === 33 && bytes[0] === 0x00) return bytes.slice(1);
-  if (bytes.length < 32) {
-    const padded = Buffer.alloc(32, 0);
-    bytes.copy(padded, 32 - bytes.length);
-    return padded;
-  }
-  return bytes;
-}
+// Re-exported from coin-tezos (single source of truth) so existing importers keep working.
+export { convertSecp256k1DERToRaw, normalizeTo32Bytes } from "@ledgerhq/coin-tezos/utils";
 
 function curveForDerivationMode(derivationMode?: string): Curve {
   return derivationMode === "tezosSecp256k1" ? TezosCurves.SECP256K1 : TezosCurves.ED25519;

--- a/libs/ledger-live-common/src/families/tezos/setup.ts
+++ b/libs/ledger-live-common/src/families/tezos/setup.ts
@@ -1,12 +1,13 @@
 // Goal of this file is to inject all necessary device/signer dependency to coin-modules
 
 import type { TezosSigner } from "@ledgerhq/coin-tezos/types/index";
+import { signMessage } from "@ledgerhq/coin-tezos/hw-signMessage";
 import makeCliTools from "@ledgerhq/coin-tezos/test/cli";
 import type { CliTools } from "@ledgerhq/coin-tezos/test/cli";
 import tezosResolver from "./getAddress";
 import Xtz, { Curve } from "@ledgerhq/hw-app-tezos";
 import Transport from "@ledgerhq/hw-transport";
-import { createResolver, CreateSigner } from "../../bridge/setup";
+import { createMessageSigner, createResolver, CreateSigner } from "../../bridge/setup";
 import { Resolver } from "../../hw/getAddress/types";
 
 const createSigner: CreateSigner<TezosSigner> = (transport: Transport) => {
@@ -33,6 +34,10 @@ const createSigner: CreateSigner<TezosSigner> = (transport: Transport) => {
 
 const resolver: Resolver = createResolver(createSigner, tezosResolver);
 
+const messageSigner = {
+  signMessage: createMessageSigner(createSigner, signMessage),
+};
+
 const cliTools: CliTools = makeCliTools();
 
-export { cliTools, resolver };
+export { cliTools, messageSigner, resolver };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Unit tests for `signMessage` (verbatim signing, curve selection per address prefix, DER→raw normalisation, payload/signature/address validation); existing `convertSecp256k1DERToRaw` suite still green after the shared-helper move.
- [x] **Impact of the changes:** library-only addition to `@ledgerhq/coin-tezos` and `@ledgerhq/live-common`; no user-facing surface consumes it yet.
  - The `tezos` family had no `messageSigner` (`hw/signMessage` threw); it now resolves — net-new capability, no behaviour change to existing flows.
  - `convertSecp256k1DERToRaw`/`normalizeTo32Bytes` were moved into `coin-tezos/utils` (single source of truth, re-exported from the generic-coin-framework signer) and now reject malformed device signatures instead of returning a silent bad signature.
  - QA focus: none device-facing yet; relevant once the live-app `tezos_sign` handler is wired (follow-up PR).

### 📝 Description

Adds Tezos message signing in `coin-tezos`, the building block behind the Wallet API `message.sign` used by WalletConnect `tezos_sign`.

`hw-signMessage.ts` signs an already-watermarked payload **verbatim**: the payload's first byte is the firmware dispatch tag (`0x05` Micheline / `0x03` operation / `0x80…` raw) and is hashed with the rest, so nothing is prepended. The curve is selected from the implicit-address prefix (tz1→Ed25519, tz2→secp256k1, tz3→P-256), and the device signature is normalised to the raw `r‖s` hex the protocol expects. `messageSigner` is then wired into `families/tezos/setup.ts`.

The signature handling was verified against app-tezos firmware, hw-app-tezos, Taquito and Beacon: the dApp pre-includes the magic byte, so signing verbatim is correct — prepending would double-watermark and yield an invalid signature. The payload is carried as a hex **string** through `message.sign` so it survives the Wallet API's UTF-8 round-trip; the dApp-facing base58 encoding is applied by the live-app layer in a follow-up PR.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32114](https://ledgerhq.atlassian.net/browse/LIVE-32114)
- **ADR link (if any)**: —
- Stacked on #18359 ([LIVE-32113](https://ledgerhq.atlassian.net/browse/LIVE-32113)); base branch is that PR's branch, not `develop`.


[LIVE-32114]: https://ledgerhq.atlassian.net/browse/LIVE-32114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ