### PR TITLE
[LWD] Tezos staking missing texts

### DIFF
--- a/.changeset/proud-camels-shine.md
+++ b/.changeset/proud-camels-shine.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix missing Tezos staking texts: family-scoped UNSTAKE/FINALIZE_UNSTAKE operation labels, neutral unsigned amount for pending unstakes, stake-success CTA opening the account dashboard, and updated unstake-required modal copy

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationRow.tsx
@@ -6,6 +6,7 @@ import TransactionalIcon from "LLD/components/TransactionalIcon";
 import { SquaredCryptoIcon } from "LLD/components/SquaredCryptoIcon";
 import { BalanceCell } from "LLD/components/Cells/BalanceCell";
 import { CounterValueCell } from "LLD/components/Cells/CounterValueCell";
+import { getOperationTypeI18nKey } from "~/renderer/helpers/operationTypeI18nKey";
 import { getAddressDirection } from "../utils/getOperationCounterpartyAddress";
 import { OperationCounterpartyLabel } from "./OperationCounterpartyLabel";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
@@ -23,16 +24,17 @@ function OperationRow({ row, onRowClick }: OperationRowProps) {
   const item = row.original;
   const { operation, currency, amount, address, type, isUnread } = item;
 
-  const typeLabel = operation.hasFailed
-    ? t("operationDetails.failed")
-    : t(`operation.type.${operation.type}`);
-
-  const direction = getAddressDirection(type);
-  const addressPrefix = address ? t(`history.address.${direction}`) : undefined;
-
   const cryptoCurrency: CryptoCurrency | TokenCurrency | undefined =
     currency.type === "FiatCurrency" ? undefined : currency;
   const isToken = cryptoCurrency?.type === "TokenCurrency";
+  const family = isToken ? cryptoCurrency.parentCurrency.family : cryptoCurrency?.family;
+
+  const typeLabel = operation.hasFailed
+    ? t("operationDetails.failed")
+    : t(getOperationTypeI18nKey(operation.type, family));
+
+  const direction = getAddressDirection(type);
+  const addressPrefix = address ? t(`history.address.${direction}`) : undefined;
   const iconCurrency =
     isToken && shouldDisplayAggregatedAssets ? cryptoCurrency.parentCurrency : cryptoCurrency;
   const iconNetwork =

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/__tests__/OperationRow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/__tests__/OperationRow.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { fireEvent, render, screen } from "tests/testSetup";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import type { Operation } from "@ledgerhq/types-live";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import { OperationRow } from "../OperationRow";
+import type { OperationRow as OperationRowType, OperationTableItem } from "../../types";
+
+jest.mock("@features/platform-feature-flags", () => ({
+  useWalletFeaturesConfig: () => ({ shouldDisplayAggregatedAssets: false }),
+}));
+jest.mock("LLD/components/TransactionalIcon", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("LLD/components/SquaredCryptoIcon", () => ({
+  SquaredCryptoIcon: () => null,
+}));
+jest.mock("LLD/components/Cells/BalanceCell", () => ({
+  BalanceCell: () => null,
+}));
+jest.mock("LLD/components/Cells/CounterValueCell", () => ({
+  CounterValueCell: () => null,
+}));
+jest.mock("../OperationCounterpartyLabel", () => ({
+  OperationCounterpartyLabel: () => null,
+}));
+
+const tezosCurrency = getCryptoCurrencyById("tezos");
+const bitcoinCurrency = getCryptoCurrencyById("bitcoin");
+const tokenCurrency = {
+  type: "TokenCurrency",
+  id: "ethereum/erc20/usd__coin",
+  ticker: "USDC",
+  parentCurrency: getCryptoCurrencyById("ethereum"),
+} as unknown as Currency;
+
+const makeOperation = (overrides: Partial<Operation> = {}): Operation =>
+  ({
+    id: "op-1",
+    type: "UNSTAKE",
+    hasFailed: false,
+    date: new Date("2026-01-01T10:00:00Z"),
+    ...overrides,
+  }) as Operation;
+
+const makeRow = (overrides: Partial<OperationTableItem> = {}): OperationRowType =>
+  ({
+    original: {
+      id: "item-1",
+      operation: makeOperation(),
+      account: {} as OperationTableItem["account"],
+      date: new Date("2026-01-01T10:00:00Z"),
+      type: "OUT",
+      address: "",
+      amount: new BigNumber(100),
+      currency: tezosCurrency,
+      isPending: false,
+      isUnread: false,
+      ...overrides,
+    },
+  }) as unknown as OperationRowType;
+
+const renderRow = (row: OperationRowType, onRowClick = jest.fn()) => {
+  render(
+    <table>
+      <tbody>
+        <OperationRow row={row} onRowClick={onRowClick} />
+      </tbody>
+    </table>,
+  );
+  return onRowClick;
+};
+
+describe("History/OperationRow", () => {
+  it("uses the family-scoped label for a coin currency with an override", () => {
+    renderRow(makeRow());
+    expect(screen.getByText("Unstaking")).toBeInTheDocument();
+  });
+
+  it("resolves the family from the parent currency for token operations", () => {
+    renderRow(
+      makeRow({
+        currency: tokenCurrency,
+        type: "IN",
+        address: "0xabc",
+        operation: makeOperation({ type: "IN" }),
+      }),
+    );
+    expect(screen.getByText("Received")).toBeInTheDocument();
+  });
+
+  it("shows the failed label for failed operations", () => {
+    renderRow(
+      makeRow({
+        currency: bitcoinCurrency,
+        operation: makeOperation({ type: "OUT", hasFailed: true }),
+      }),
+    );
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+  });
+
+  it("forwards row clicks", () => {
+    const row = makeRow();
+    const onRowClick = renderRow(row);
+    fireEvent.click(screen.getByTestId("history-operation-row-op-1"));
+    expect(onRowClick).toHaveBeenCalledWith(row);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/__tests__/OperationRow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/__tests__/OperationRow.test.tsx
@@ -1,22 +1,12 @@
 import React from "react";
 import BigNumber from "bignumber.js";
-import { fireEvent, render, screen } from "tests/testSetup";
+import { render, screen } from "tests/testSetup";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import type { Operation } from "@ledgerhq/types-live";
 import type { Currency } from "@ledgerhq/types-cryptoassets";
 import { OperationRow } from "../OperationRow";
 import type { OperationRow as OperationRowType, OperationTableItem } from "../../types";
 
-jest.mock("@features/platform-feature-flags", () => ({
-  useWalletFeaturesConfig: () => ({ shouldDisplayAggregatedAssets: false }),
-}));
-jest.mock("LLD/components/TransactionalIcon", () => ({
-  __esModule: true,
-  default: () => null,
-}));
-jest.mock("LLD/components/SquaredCryptoIcon", () => ({
-  SquaredCryptoIcon: () => null,
-}));
 jest.mock("LLD/components/Cells/BalanceCell", () => ({
   BalanceCell: () => null,
 }));
@@ -32,6 +22,7 @@ const bitcoinCurrency = getCryptoCurrencyById("bitcoin");
 const tokenCurrency = {
   type: "TokenCurrency",
   id: "ethereum/erc20/usd__coin",
+  name: "USD Coin",
   ticker: "USDC",
   parentCurrency: getCryptoCurrencyById("ethereum"),
 } as unknown as Currency;
@@ -63,14 +54,14 @@ const makeRow = (overrides: Partial<OperationTableItem> = {}): OperationRowType 
   }) as unknown as OperationRowType;
 
 const renderRow = (row: OperationRowType, onRowClick = jest.fn()) => {
-  render(
+  const { user } = render(
     <table>
       <tbody>
         <OperationRow row={row} onRowClick={onRowClick} />
       </tbody>
     </table>,
   );
-  return onRowClick;
+  return { user, onRowClick };
 };
 
 describe("History/OperationRow", () => {
@@ -101,10 +92,10 @@ describe("History/OperationRow", () => {
     expect(screen.getByText("Failed")).toBeInTheDocument();
   });
 
-  it("forwards row clicks", () => {
+  it("forwards row clicks", async () => {
     const row = makeRow();
-    const onRowClick = renderRow(row);
-    fireEvent.click(screen.getByTestId("history-operation-row-op-1"));
+    const { user, onRowClick } = renderRow(row);
+    await user.click(screen.getByTestId("history-operation-row-op-1"));
     expect(onRowClick).toHaveBeenCalledWith(row);
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/DateCell.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/DateCell.tsx
@@ -4,6 +4,7 @@ import { TFunction } from "i18next";
 import React from "react";
 import styled from "styled-components";
 import Box from "~/renderer/components/Box";
+import { getOperationTypeI18nKey } from "~/renderer/helpers/operationTypeI18nKey";
 import OperationDate from "./OperationDate";
 
 const Cell = styled(Box).attrs(() => ({
@@ -23,6 +24,7 @@ type Props = {
   compact?: boolean;
   editable?: boolean;
   isStuck?: boolean;
+  family?: string;
 };
 
 const PendingLoadingIcon = ({ displayWarning }: { displayWarning: boolean }): React.JSX.Element => {
@@ -37,7 +39,15 @@ const PendingLoadingIcon = ({ displayWarning }: { displayWarning: boolean }): Re
   return <InfiniteLoader size={12} style={{ verticalAlign: "middle" }} />;
 };
 
-const DateCell = ({ t, operation, compact, text, editable, isStuck }: Props): React.JSX.Element => {
+const DateCell = ({
+  t,
+  operation,
+  compact,
+  text,
+  editable,
+  isStuck,
+  family,
+}: Props): React.JSX.Element => {
   const ellipsis = {
     display: "block",
     textOverflow: "ellipsis",
@@ -55,7 +65,9 @@ const DateCell = ({ t, operation, compact, text, editable, isStuck }: Props): Re
         data-testid={`operation-status-${operation.id}`}
       >
         {text ||
-          t(operation.hasFailed ? "operationDetails.failed" : `operation.type.${operation.type}`)}
+          (operation.hasFailed
+            ? t("operationDetails.failed")
+            : t(getOperationTypeI18nKey(operation.type, family)))}
       </Box>
       {editable ? (
         <Box fontSize={3} color="neutral.c80">

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/Operation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/Operation.tsx
@@ -95,6 +95,7 @@ function OperationComponent({
         editable={editable}
         isStuck={bridge.isStuckOperation(operation)}
         t={t}
+        family={cryptoCurrency.family}
       />
       {withAccount && <AccountCell accountName={accountName} currency={currency} />}
       {withAddress ? <AddressCell operation={operation} currency={currency} /> : <Box flex="1" />}

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/tests/DateCell.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/tests/DateCell.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { render, screen } from "tests/testSetup";
+import type { Operation } from "@ledgerhq/types-live";
+import DateCell from "../DateCell";
+
+const makeOperation = (overrides: Partial<Operation> = {}): Operation =>
+  ({
+    id: "op-1",
+    type: "UNSTAKE",
+    hasFailed: false,
+    date: new Date("2026-01-01T10:00:00Z"),
+    ...overrides,
+  }) as Operation;
+
+const DateCellHarness = ({ operation, family }: { operation: Operation; family?: string }) => {
+  const { t } = useTranslation();
+  return <DateCell t={t} operation={operation} family={family} />;
+};
+
+describe("OperationsList/DateCell", () => {
+  it("uses the family-scoped label when the family overrides the operation type", () => {
+    render(<DateCellHarness operation={makeOperation()} family="tezos" />);
+    expect(screen.getByText("Unstaking")).toBeInTheDocument();
+  });
+
+  it("falls back to the shared label for families without an override", () => {
+    render(<DateCellHarness operation={makeOperation()} family="aptos" />);
+    expect(screen.getByText("Unstaked")).toBeInTheDocument();
+  });
+
+  it("falls back to the shared label when no family is provided", () => {
+    render(<DateCellHarness operation={makeOperation()} />);
+    expect(screen.getByText("Unstaked")).toBeInTheDocument();
+  });
+
+  it("shows the failed label for failed operations", () => {
+    render(<DateCellHarness operation={makeOperation({ hasFailed: true })} family="tezos" />);
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
@@ -51,6 +51,7 @@ import OperationComponent from "~/renderer/components/OperationsList/Operation";
 import Text, { TextProps } from "~/renderer/components/Text";
 import ToolTip from "~/renderer/components/Tooltip";
 import { getLLDCoinFamily } from "~/renderer/families";
+import { getOperationTypeI18nKey } from "~/renderer/helpers/operationTypeI18nKey";
 import IconChevronRight from "~/renderer/icons/ChevronRight";
 import IconExternalLink from "~/renderer/icons/ExternalLink";
 import InfoCircle from "~/renderer/icons/InfoCircle";
@@ -426,7 +427,9 @@ const OperationD = (props: Props) => {
         mb={1}
         data-testid="transaction-type"
       >
-        <Trans i18nKey={`operation.type.${editable ? "SENDING" : operation.type}`} />
+        {editable
+          ? t("operation.type.SENDING")
+          : t(getOperationTypeI18nKey(operation.type, cryptoCurrency.family))}
       </Text>
 
       <Box alignItems="center" mt={0}>
@@ -586,7 +589,7 @@ const OperationD = (props: Props) => {
             fontSize={4}
             color="neutral.c70"
           >
-            <Trans i18nKey={`operation.type.${operation.type}`} />
+            {t(getOperationTypeI18nKey(operation.type, cryptoCurrency.family))}
           </Text>
         </OpDetailsData>
       </OpDetailsSection>

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepConfirmation.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepConfirmation.test.tsx
@@ -25,6 +25,11 @@ jest.mock("~/renderer/hooks/useLocalizedUrls", () => ({
   useLocalizedUrl: () => "https://stake.example",
 }));
 jest.mock("~/renderer/linking", () => ({ __esModule: true, openURL: jest.fn() }));
+const mockNavigate = jest.fn();
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: () => mockNavigate,
+}));
 jest.mock("@ledgerhq/live-common/bridge/react/index", () => ({
   __esModule: true,
   SyncOneAccountOnMount: () => null,
@@ -121,6 +126,10 @@ const makeOp = (): Operation =>
   }) as unknown as Operation;
 
 describe("StakeFlowModal/StepConfirmation", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
   it("renders success when the operation has been broadcasted", () => {
     const props = makeProps({ optimisticOperation: makeOp() });
     act(() => {
@@ -171,17 +180,33 @@ describe("StakeFlowModal/StepConfirmation", () => {
     expect(props.transitionTo).toHaveBeenCalledWith("amount");
   });
 
-  it("footer success CTA closes the modal", () => {
+  it("footer success CTA closes the modal and navigates to the account page", () => {
     const props = makeProps({ optimisticOperation: makeOp() });
     let result: ReturnType<typeof render>;
     act(() => {
       result = render(<StepConfirmationFooter {...props} />);
     });
-    const cta = result!.container.querySelector("#tezos-stake-confirmation-visit-earn-button");
+    const cta = result!.container.querySelector("#tezos-stake-confirmation-visit-account-button");
     expect(cta).toBeInTheDocument();
     act(() => {
       fireEvent.click(cta!);
     });
     expect(props.onClose).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(`/account/${props.account?.id}`);
+  });
+
+  it("footer success CTA falls back to the operation's account id when account is missing", () => {
+    const operation = makeOp();
+    const props = makeProps({ optimisticOperation: operation, account: null });
+    let result: ReturnType<typeof render>;
+    act(() => {
+      result = render(<StepConfirmationFooter {...props} />);
+    });
+    const cta = result!.container.querySelector("#tezos-stake-confirmation-visit-account-button");
+    act(() => {
+      fireEvent.click(cta!);
+    });
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(`/account/${operation.accountId}`);
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepConfirmation.tsx
@@ -107,6 +107,8 @@ const StepConfirmation = ({
 };
 
 export const StepConfirmationFooter = ({
+  account,
+  parentAccount,
   transitionTo,
   onRetry,
   optimisticOperation,
@@ -117,11 +119,16 @@ export const StepConfirmationFooter = ({
   const navigate = useNavigate();
   const stakingUrl = useLocalizedUrl(urls.stakingTezos);
 
-  const onVisitEarnDashboard = useCallback(() => {
+  const onVisitAccountDashboard = useCallback(() => {
     onClose();
     setTrackingSource("stake flow");
-    navigate("/earn");
-  }, [navigate, onClose]);
+    const accountId = account
+      ? getMainAccount(account, parentAccount).id
+      : optimisticOperation?.accountId;
+    if (accountId) {
+      navigate(`/account/${accountId}`);
+    }
+  }, [account, parentAccount, optimisticOperation, navigate, onClose]);
 
   const onRetryClick = useCallback(() => {
     onRetry();
@@ -133,9 +140,9 @@ export const StepConfirmationFooter = ({
     action = (
       <Button
         ml={2}
-        id="tezos-stake-confirmation-visit-earn-button"
+        id="tezos-stake-confirmation-visit-account-button"
         primary
-        onClick={onVisitEarnDashboard}
+        onClick={onVisitAccountDashboard}
       >
         <Trans i18nKey="tezos.stake.flow.steps.confirmation.success.cta" />
       </Button>

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeRequiredModal/__tests__/Body.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeRequiredModal/__tests__/Body.test.tsx
@@ -16,7 +16,7 @@ describe("UnstakeRequiredModal/Body", () => {
     render(<Body onClose={jest.fn()} params={{ reason: "changeBaker" }} />);
     expect(screen.getByText("Unstake before changing baker")).toBeInTheDocument();
     expect(
-      screen.getByText(/Unstake your funds before delegating to a new baker/i),
+      screen.getByText(/Unstake all your funds before delegating to a new baker/i),
     ).toBeInTheDocument();
   });
 
@@ -24,14 +24,14 @@ describe("UnstakeRequiredModal/Body", () => {
     render(<Body onClose={jest.fn()} params={{ reason: "endDelegation" }} />);
     expect(screen.getByText("Unstake before ending delegation")).toBeInTheDocument();
     expect(
-      screen.getByText(/Unstake your funds before ending the delegation/i),
+      screen.getByText(/Unstake all your funds before ending the delegation/i),
     ).toBeInTheDocument();
   });
 
   it("renders all four step descriptions and numbered badges", () => {
     render(<Body onClose={jest.fn()} params={{ reason: "changeBaker" }} />);
-    expect(screen.getByText(/Open the Earn menu/i)).toBeInTheDocument();
-    expect(screen.getByText(/Confirm the amount/i)).toBeInTheDocument();
+    expect(screen.getByText(/Open the Tezos Account dashboard/i)).toBeInTheDocument();
+    expect(screen.getByText(/Unstake the MAX amount/i)).toBeInTheDocument();
     expect(screen.getByText(/Wait ~4 days/i)).toBeInTheDocument();
     expect(screen.getByText(/Once withdrawn/i)).toBeInTheDocument();
     [1, 2, 3, 4].forEach(n => {

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/__tests__/operationDetails.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/__tests__/operationDetails.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
-import { act, render, screen } from "tests/testSetup";
+import { render, screen } from "tests/testSetup";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import {
   getCryptoCurrencyById,
@@ -46,21 +47,11 @@ const renderDrawer = (account: TezosAccount) =>
   });
 
 describe("Tezos OperationDetails drawer", () => {
-  // The first OperationDetails mount in a fresh jest module registry never paints (a one-shot
-  // module-level async init keeps it suspended); mount and discard until a mount paints so the
-  // real tests below render deterministically.
+  // Warm the module-level account-bridge promise cache: the first mount otherwise
+  // suspends on the pending promise (useAccountBridge → use()) and never repaints.
   beforeAll(async () => {
-    for (let attempt = 0; attempt < 3; attempt++) {
-      const account = makeAccount(id => makeOperation(id, "OUT"));
-      const r = renderDrawer(account);
-      await act(async () => {
-        await new Promise(res => setTimeout(res, 1000));
-      });
-      const painted = r.container.innerHTML.length > 0;
-      r.unmount();
-      if (painted) return;
-    }
-  }, 30000);
+    await getAccountBridge(makeAccount(id => makeOperation(id, "OUT")));
+  });
 
   it("shows the tezos-scoped label for an UNSTAKE operation", async () => {
     const account = makeAccount(id => makeOperation(id, "UNSTAKE"));

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/__tests__/operationDetails.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/__tests__/operationDetails.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { act, render, screen } from "tests/testSetup";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import {
+  getCryptoCurrencyById,
+  setSupportedCurrencies,
+} from "@ledgerhq/live-common/currencies/index";
+import type { Operation } from "@ledgerhq/types-live";
+import type { TezosAccount } from "@ledgerhq/live-common/families/tezos/types";
+import { OperationDetails } from "~/renderer/drawers/OperationDetails";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+
+setSupportedCurrencies(["tezos"]);
+const currency = getCryptoCurrencyById("tezos");
+
+const makeOperation = (accountId: string, type: Operation["type"]): Operation =>
+  ({
+    id: `${accountId}-${type}`,
+    hash: "opHash",
+    type,
+    value: new BigNumber(2_000_000),
+    fee: new BigNumber(300),
+    senders: ["tz1sender"],
+    recipients: ["tz1recipient"],
+    blockHash: "blockHash",
+    blockHeight: 100,
+    accountId,
+    date: new Date("2026-01-01T10:00:00Z"),
+    extra: {},
+  }) as Operation;
+
+const makeAccount = (operation: (accountId: string) => Operation): TezosAccount => {
+  const account = { ...genAccount("tezos-opdetails", { currency }) } as TezosAccount;
+  account.operations = [operation(account.id)];
+  account.pendingOperations = [];
+  return account;
+};
+
+const renderDrawer = (account: TezosAccount) =>
+  render(<OperationDetails operationId={account.operations[0].id} accountId={account.id} />, {
+    initialState: {
+      accounts: [account],
+      settings: AFTER_ONBOARDING_STATE,
+    },
+  });
+
+describe("Tezos OperationDetails drawer", () => {
+  // The first OperationDetails mount in a fresh jest module registry never paints (a one-shot
+  // module-level async init keeps it suspended); mount and discard until a mount paints so the
+  // real tests below render deterministically.
+  beforeAll(async () => {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const account = makeAccount(id => makeOperation(id, "OUT"));
+      const r = renderDrawer(account);
+      await act(async () => {
+        await new Promise(res => setTimeout(res, 1000));
+      });
+      const painted = r.container.innerHTML.length > 0;
+      r.unmount();
+      if (painted) return;
+    }
+  }, 30000);
+
+  it("shows the tezos-scoped label for an UNSTAKE operation", async () => {
+    const account = makeAccount(id => makeOperation(id, "UNSTAKE"));
+    renderDrawer(account);
+    expect(await screen.findByTestId("transaction-type")).toHaveTextContent("Unstaking");
+    expect(screen.getByTestId("operation-type")).toHaveTextContent("Unstaking");
+  });
+
+  it("shows the tezos-scoped label for a FINALIZE_UNSTAKE operation", async () => {
+    const account = makeAccount(id => makeOperation(id, "FINALIZE_UNSTAKE"));
+    renderDrawer(account);
+    expect(await screen.findByTestId("transaction-type")).toHaveTextContent("Unstaked");
+    expect(screen.getByTestId("operation-type")).toHaveTextContent("Unstaked");
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/operationDetails.tsx
@@ -1,8 +1,11 @@
 /* eslint-disable consistent-return */
+import React from "react";
 import { BigNumber } from "bignumber.js";
 import { getOperationAmountNumber } from "@ledgerhq/live-common/operation";
 import { Operation } from "@ledgerhq/types-live";
-import type { OperationDetailsExtraProps } from "../types";
+import CounterValue from "~/renderer/components/CounterValue";
+import FormattedVal from "~/renderer/components/FormattedVal";
+import type { AmountCellProps, OperationDetailsExtraProps } from "../types";
 import type { TezosAccount, TezosOperation } from "@ledgerhq/live-common/families/tezos/types";
 const helpURL = "https://support.ledger.com/article/360010653260-zd";
 function getURLFeesInfo({ op }: { op: Operation; currencyId: string }): string | undefined | null {
@@ -41,9 +44,34 @@ const getAmount = (operation: TezosOperation): BigNumber => {
   }
 };
 
+// Unstaking returns funds only after a ~4-day delay, so it is not an immediate credit: render it in
+// neutral text with no +/- sign to avoid reading as a gain. The real credit shows on FINALIZE_UNSTAKE.
+const UnstakeAmountCell = ({
+  amount,
+  operation,
+  currency,
+  unit,
+}: AmountCellProps<TezosOperation>) => (
+  <>
+    <FormattedVal val={amount} unit={unit} showCode fontSize={4} color="neutral.c100" />
+    <CounterValue
+      color="neutral.c70"
+      fontSize={3}
+      date={operation.date}
+      currency={currency}
+      value={amount}
+    />
+  </>
+);
+
+const amountCell = {
+  UNSTAKE: UnstakeAmountCell,
+};
+
 export default {
   getURLFeesInfo,
   getURLWhatIsThis,
   OperationDetailsExtra,
   getAmount,
+  amountCell,
 };

--- a/apps/ledger-live-desktop/src/renderer/helpers/operationTypeI18nKey.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/helpers/operationTypeI18nKey.test.ts
@@ -1,0 +1,21 @@
+import { getOperationTypeI18nKey } from "./operationTypeI18nKey";
+
+describe("getOperationTypeI18nKey", () => {
+  it("prefers the family-scoped key, then falls back to the shared key", () => {
+    expect(getOperationTypeI18nKey("UNSTAKE", "tezos")).toEqual([
+      "tezos.operationTypes.UNSTAKE",
+      "operation.type.UNSTAKE",
+    ]);
+  });
+
+  it("builds the same fallback shape for any family, so families without an override resolve the shared label", () => {
+    expect(getOperationTypeI18nKey("UNSTAKE", "aptos")).toEqual([
+      "aptos.operationTypes.UNSTAKE",
+      "operation.type.UNSTAKE",
+    ]);
+  });
+
+  it("returns the shared key directly when no family is provided", () => {
+    expect(getOperationTypeI18nKey("IN")).toBe("operation.type.IN");
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/helpers/operationTypeI18nKey.ts
+++ b/apps/ledger-live-desktop/src/renderer/helpers/operationTypeI18nKey.ts
@@ -1,0 +1,14 @@
+import type { OperationType } from "@ledgerhq/types-live";
+
+/**
+ * Operation-type labels resolve from the shared `operation.type.<TYPE>` map. When a family needs a
+ * different wording for an otherwise-shared type — e.g. Tezos renders `UNSTAKE` as "Unstaking" (it
+ * stays pending ~4 days) while Aptos/Near keep the shared "Unstaked" — it defines
+ * `<family>.operationTypes.<TYPE>`. We try that family key first and fall back to the shared label,
+ * so every other family is unaffected.
+ */
+export function getOperationTypeI18nKey(type: OperationType, family?: string): string | string[] {
+  return family
+    ? [`${family}.operationTypes.${type}`, `operation.type.${type}`]
+    : `operation.type.${type}`;
+}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4657,6 +4657,10 @@
     }
   },
   "tezos": {
+    "operationTypes": {
+      "UNSTAKE": "Unstaking",
+      "FINALIZE_UNSTAKE": "Unstaked"
+    },
     "earnChoice": {
       "title": "Earn Tezos Rewards: Delegate or Stake",
       "description": "Earn rewards on your Tezos (XTZ) by delegating to a Baker, keeping full control. For higher returns, stake your XTZ, understanding the low associated risk. Choose the best way to grow your assets.",
@@ -4735,7 +4739,7 @@
             "success": {
               "title": "You have successfully staked your assets",
               "text": "You staked {{amount}}. Your account balance will be updated when the blockchain confirms the transaction.",
-              "cta": "Visit Earn Dashboard"
+              "cta": "Visit Account Dashboard"
             },
             "broadcastError": "Your transaction may have failed. Please wait a moment then check the transaction history before trying again.",
             "howItWorks": "How staking works"
@@ -4746,15 +4750,15 @@
     "unstakeRequired": {
       "changeBaker": {
         "title": "Unstake before changing baker",
-        "description": "You have staked XTZ with your current baker. Unstake your funds before delegating to a new baker."
+        "description": "You have staked XTZ with your current baker. Unstake all your funds before delegating to a new baker."
       },
       "endDelegation": {
         "title": "Unstake before ending delegation",
-        "description": "You have staked XTZ with your current baker. Unstake your funds before ending the delegation."
+        "description": "You have staked XTZ with your current baker. Unstake all your funds before ending the delegation."
       },
       "steps": {
-        "0": "Open the Earn menu and select Unstake.",
-        "1": "Confirm the amount and submit the unstake transaction on your device.",
+        "0": "Open the Tezos Account dashboard and select the Unstake option in your staking section.",
+        "1": "Unstake the MAX amount and submit the unstake transaction on your device.",
         "2": "Wait ~4 days for the unstake period to complete.",
         "3": "Once withdrawn, you can change baker or end delegation."
       },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Operation-type label resolution in shared components (OperationsList, History table, OperationDetails drawer) now tries a family-scoped key first — all coin families go through it; only tezos defines overrides today.
  - Tezos UNSTAKE rows render an unsigned, neutral amount in the operations list (family amountCell override).
  - Tezos stake-success CTA navigates to the account page (was Earn dashboard).
  - Tezos unstake-required modal copy updated (change-baker / end-delegation variants and steps).
  - Shared operation.type.FINALIZE_UNSTAKE stays "Withdrawn" for non-tezos families; tezos sees "Unstaked".
  - QA focus: on a tezos account with staking ops, check pending-unstake vs finalized labels are consistent across the classic operations list, the new History table and the details drawer; riskiest is the shared label-resolution path — spot-check operation labels on non-tezos accounts (must be unchanged).

### 📝 Description

Fix missing Tezos staking texts on LWD: tezos-scoped operation labels (UNSTAKE → "Unstaking", FINALIZE_UNSTAKE → "Unstaked") in the operations list, History table and operation-details drawer, a neutral unsigned amount for pending unstakes, updated unstake-required modal copy, and the stake-success CTA now opens the account page instead of Earn. Labels resolve via a new <family>.operationTypes.<TYPE> → operation.type.<TYPE> i18n fallback, so other families keep their existing wording.


https://github.com/user-attachments/assets/c9c8c7e8-a2b6-4436-b5e8-0004428457ce



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31826](https://ledgerhq.atlassian.net/browse/LIVE-31826?atlOrigin=eyJpIjoiZDI1YzA4OGIxMzBhNDdjM2EyNGNlZDlkMjFkMmU3OGQiLCJwIjoiaiJ9)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31826]: https://ledgerhq.atlassian.net/browse/LIVE-31826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ