### PR TITLE
[LWD] feat(desktop): add stocks section to portfolio screen

### DIFF
--- a/.changeset/stocks-portfolio-section.md
+++ b/.changeset/stocks-portfolio-section.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add a Stocks section to the Portfolio screen, under the Stablecoins section. It reuses the search-overlay Stocks feature (DADA-sourced, ranked by market cap, horizontally scrollable two-row grid) with an "Explore" link header variant instead of the "show more" affordance, and is gated behind the Asset Discoverability flag.

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
@@ -16,6 +16,7 @@ import { Divider } from "@ledgerhq/lumen-ui-react";
 import BannerSection from "~/renderer/screens/dashboard/components/Banners/BannerSection";
 import { PortfolioBannerContent } from "~/renderer/screens/dashboard/components/Banners/PortfolioBannerContent";
 import Assets from "LLD/features/Assets";
+import { StocksSection } from "./components/StocksSection";
 import { CryptoAddressesBanner } from "LLD/features/CryptoAddresses/components/Banner";
 import { BottomCarouselContentCards } from "LLD/features/DynamicContent/components/BottomCarouselContentCards";
 
@@ -28,6 +29,7 @@ export const PortfolioView = memo(function PortfolioView({
   shouldDisplayGraphRework,
   shouldDisplayQuickActionCtas,
   shouldDisplayAssetSection,
+  shouldDisplayAssetDiscoverability,
   shouldDisplayBorrowSection,
   shouldDisplayOperationsList,
   shouldDisplayBrazePlacement,
@@ -71,6 +73,7 @@ export const PortfolioView = memo(function PortfolioView({
           <PerpsEntryPoint />
 
           {shouldDisplayAssetSection ? <Assets /> : <AssetDistribution />}
+          {shouldDisplayAssetDiscoverability && <StocksSection />}
           {shouldDisplayBorrowSection && <BorrowEntryPoint />}
           {shouldDisplayAddAccountCta && <AddAccount />}
           {shouldDisplayAssetSection && <CryptoAddressesBanner />}

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -14,8 +14,10 @@ import { createMockCategorizedAssets } from "@ledgerhq/asset-aggregation/mocks/c
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 import { track } from "~/renderer/analytics/segment";
 import { PORTFOLIO_TRACKING_PAGE_NAME } from "LLD/utils/constants";
+import { mockStocksResponse } from "@ledgerhq/live-common/dada-client/mocks/stocks.mock";
 
 const MARKET_API_ENDPOINT = "https://countervalues.live.ledger.com/v3/markets";
+const DADA_API_ENDPOINT = "https://dada.api.ledger-test.com/v1/assets";
 
 const mockNavigate = jest.fn();
 
@@ -156,6 +158,7 @@ describe("PortfolioView", () => {
     shouldDisplayGraphRework: true,
     shouldDisplayQuickActionCtas: true,
     shouldDisplayAssetSection: true,
+    shouldDisplayAssetDiscoverability: false,
     shouldDisplayOperationsList: true,
     shouldDisplayBorrowSection: false,
     shouldDisplayBrazePlacement: false,
@@ -619,6 +622,27 @@ describe("PortfolioView", () => {
       render(<PortfolioView {...defaultProps} shouldDisplayAssetSection={false} />);
 
       expect(screen.queryByTestId("crypto-addresses-banner")).toBeNull();
+    });
+  });
+
+  describe("AssetDiscoverability", () => {
+    it("should render Stocks section when shouldDisplayAssetDiscoverability is true", async () => {
+      server.use(http.get(DADA_API_ENDPOINT, () => HttpResponse.json(mockStocksResponse)));
+
+      render(<PortfolioView {...defaultProps} shouldDisplayAssetDiscoverability={true} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("stock-item-ticker-aaplx")).toBeVisible();
+      });
+
+      expect(screen.getByTestId("stocks-section")).toBeVisible();
+      expect(screen.getByTestId("stocks-explore")).toBeVisible();
+    });
+
+    it("should not render Stocks section when shouldDisplayAssetDiscoverability is false", () => {
+      render(<PortfolioView {...defaultProps} shouldDisplayAssetDiscoverability={false} />);
+
+      expect(screen.queryByTestId("stocks-section")).toBeNull();
     });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/StocksSection/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/StocksSection/index.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import Stocks from "LLD/features/Stocks";
+import { useStocksSectionViewModel } from "./useStocksSectionViewModel";
+
+const STOCKS_PORTFOLIO_LIMIT = 20;
+
+export const StocksSection = () => {
+  const { navigateToAsset, onSeeAll } = useStocksSectionViewModel();
+
+  return (
+    <Stocks
+      limit={STOCKS_PORTFOLIO_LIMIT}
+      headerVariant="explore"
+      navigateToAsset={navigateToAsset}
+      onSeeAll={onSeeAll}
+    />
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/StocksSection/useStocksSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/StocksSection/useStocksSectionViewModel.ts
@@ -1,0 +1,31 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import { setTrackingSource } from "~/renderer/analytics/TrackPage";
+import { getMarketOrAssetDetailPath } from "LLD/utils/marketAssetNavigation";
+import { setMarketCategory } from "~/renderer/actions/market";
+import { useDispatch } from "LLD/hooks/redux";
+
+const TRACKING_SOURCE = "Portfolio";
+
+export function useStocksSectionViewModel() {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
+
+  const navigateToAsset = useCallback(
+    (currencyId: string) => {
+      setTrackingSource(TRACKING_SOURCE);
+      navigate(getMarketOrAssetDetailPath(currencyId, shouldDisplayAggregatedAssets));
+    },
+    [navigate, shouldDisplayAggregatedAssets],
+  );
+
+  const onSeeAll = useCallback(() => {
+    setTrackingSource(TRACKING_SOURCE);
+    dispatch(setMarketCategory("stocks"));
+    navigate("/market");
+  }, [dispatch, navigate]);
+
+  return { navigateToAsset, onSeeAll };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/usePortfolioViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/usePortfolioViewModel.ts
@@ -21,6 +21,7 @@ export interface PortfolioViewModelResult {
   readonly shouldDisplayGraphRework: boolean;
   readonly shouldDisplayQuickActionCtas: boolean;
   readonly shouldDisplayAssetSection: boolean;
+  readonly shouldDisplayAssetDiscoverability: boolean;
   readonly shouldDisplayBorrowSection: boolean;
   readonly shouldDisplayOperationsList: boolean;
   readonly shouldDisplayBrazePlacement: boolean;
@@ -39,6 +40,7 @@ export const usePortfolioViewModel = (): PortfolioViewModelResult => {
     shouldDisplayGraphRework,
     shouldDisplayQuickActionCtas,
     shouldDisplayAssetSection,
+    shouldDisplayAssetDiscoverability,
     shouldDisplayOperationsList,
     shouldDisplayBrazePlacement,
     isEnabled: isWallet40Enabled,
@@ -87,6 +89,7 @@ export const usePortfolioViewModel = (): PortfolioViewModelResult => {
     shouldDisplayGraphRework,
     shouldDisplayQuickActionCtas,
     shouldDisplayAssetSection,
+    shouldDisplayAssetDiscoverability,
     shouldDisplayBorrowSection,
     shouldDisplayOperationsList,
     shouldDisplayBrazePlacement,

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/StocksSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/StocksSectionView.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import {
+  Link,
   Subheader,
   SubheaderRow,
   SubheaderTitle,
@@ -8,7 +9,52 @@ import {
 } from "@ledgerhq/lumen-ui-react";
 import { StockRow } from "./components/StockRow";
 import { StocksSkeleton } from "./components/StocksSkeleton";
-import { StocksSectionViewProps } from "./types";
+import { StocksHeaderVariant, StocksSectionViewProps } from "./types";
+
+function StocksHeader({
+  variant,
+  onSeeAll,
+}: {
+  variant: StocksHeaderVariant;
+  onSeeAll: () => void;
+}) {
+  const { t } = useTranslation();
+
+  if (variant === "explore") {
+    return (
+      <Subheader>
+        <div className="flex items-center gap-24">
+          <SubheaderRow className="min-w-0 flex-1">
+            <SubheaderTitle>{t("topBar.search.stocks")}</SubheaderTitle>
+          </SubheaderRow>
+          <Link
+            appearance="accent"
+            underline={false}
+            size="md"
+            onClick={onSeeAll}
+            className="cursor-pointer"
+            data-testid="stocks-explore"
+          >
+            {t("stocks.explore")}
+          </Link>
+        </div>
+      </Subheader>
+    );
+  }
+
+  return (
+    <Subheader>
+      <SubheaderRow
+        className="min-w-0 items-center gap-4"
+        onClick={onSeeAll}
+        data-testid="stocks-see-all"
+      >
+        <SubheaderTitle>{t("topBar.search.stocks")}</SubheaderTitle>
+        <SubheaderShowMore />
+      </SubheaderRow>
+    </Subheader>
+  );
+}
 
 export function StocksSectionView({
   data,
@@ -16,25 +62,15 @@ export function StocksSectionView({
   limit,
   navigateToAsset,
   onSeeAll,
+  headerVariant = "showMore",
 }: StocksSectionViewProps) {
-  const { t } = useTranslation();
-
   if (!isLoading && data.length === 0) {
     return null;
   }
 
   return (
     <div className="flex flex-col gap-8" data-testid="stocks-section">
-      <Subheader>
-        <SubheaderRow
-          className="min-w-0 items-center gap-4"
-          onClick={onSeeAll}
-          data-testid="stocks-see-all"
-        >
-          <SubheaderTitle>{t("topBar.search.stocks")}</SubheaderTitle>
-          <SubheaderShowMore />
-        </SubheaderRow>
-      </Subheader>
+      <StocksHeader variant={headerVariant} onSeeAll={onSeeAll} />
       {isLoading ? (
         <StocksSkeleton count={limit} />
       ) : (

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/__integrations__/Stocks.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/__integrations__/Stocks.integration.test.tsx
@@ -161,4 +161,36 @@ describe("Stocks section", () => {
     fireEvent.click(screen.getByTestId("stocks-see-all"));
     expect(onSeeAll).toHaveBeenCalledTimes(1);
   });
+
+  it("renders an Explore link instead of the show-more header", () => {
+    mockStocksData({ metas: [APPLE] });
+
+    render(
+      <Stocks
+        limit={2}
+        headerVariant="explore"
+        navigateToAsset={navigateToAsset}
+        onSeeAll={onSeeAll}
+      />,
+    );
+
+    expect(screen.getByTestId("stocks-explore")).toBeVisible();
+    expect(screen.queryByTestId("stocks-see-all")).not.toBeInTheDocument();
+  });
+
+  it("triggers the see-all handler from the Explore link", () => {
+    mockStocksData({ metas: [APPLE] });
+
+    render(
+      <Stocks
+        limit={2}
+        headerVariant="explore"
+        navigateToAsset={navigateToAsset}
+        onSeeAll={onSeeAll}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("stocks-explore"));
+    expect(onSeeAll).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/hooks/useStocksSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/hooks/useStocksSectionViewModel.ts
@@ -12,7 +12,6 @@ export function useStocksSectionViewModel({
   const { data, isLoading } = useStocksData({
     product: "lld",
     version: __APP_VERSION__,
-    isStaging: true,
   });
 
   const stocks = useMemo<StockSuggestion[]>(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/index.tsx
@@ -1,19 +1,22 @@
 import React from "react";
 import { StocksSectionView } from "./StocksSectionView";
 import { useStocksSectionViewModel } from "./hooks/useStocksSectionViewModel";
+import { StocksHeaderVariant } from "./types";
 
 type StocksProps = {
   limit: number;
   navigateToAsset: (currencyId: string) => void;
   onSeeAll: () => void;
+  headerVariant?: StocksHeaderVariant;
 };
 
-const Stocks = ({ limit, navigateToAsset, onSeeAll }: StocksProps) => (
+const Stocks = ({ limit, navigateToAsset, onSeeAll, headerVariant }: StocksProps) => (
   <StocksSectionView
     {...useStocksSectionViewModel({ limit })}
     limit={limit}
     navigateToAsset={navigateToAsset}
     onSeeAll={onSeeAll}
+    headerVariant={headerVariant}
   />
 );
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/types.ts
@@ -14,6 +14,9 @@ export type StocksSectionViewModelResult = {
   isLoading: boolean;
 };
 
+/** Header affordance: chevron "show more" (search) or "Explore" link (portfolio). */
+export type StocksHeaderVariant = "showMore" | "explore";
+
 export type StocksSectionViewProps = StocksSectionViewModelResult & {
   /** Number of skeleton rows rendered while loading. */
   limit: number;
@@ -21,4 +24,6 @@ export type StocksSectionViewProps = StocksSectionViewModelResult & {
   navigateToAsset: (currencyId: string) => void;
   /** Lands on the market list pre-filtered to the stocks category. */
   onSeeAll: () => void;
+  /** Header affordance to render. Defaults to "showMore". */
+  headerVariant?: StocksHeaderVariant;
 };

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8819,6 +8819,9 @@
   "cryptoAssets": {
     "title": "Crypto assets"
   },
+  "stocks": {
+    "explore": "Explore"
+  },
   "nftEntryPoint": {
     "title": "NFT (Non Fungible Tokens)",
     "entry": {

--- a/apps/ledger-live-desktop/tests/handlers/assets.ts
+++ b/apps/ledger-live-desktop/tests/handlers/assets.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from "msw";
 import jsonResponse from "./fixtures/assets/getAssets.json";
 import { RawApiResponse } from "@ledgerhq/live-common/dada-client/entities/index";
 import { mockStablecoinsResponse } from "@ledgerhq/live-common/dada-client/mocks/stablecoins.mock";
+import { mockStocksResponse } from "@ledgerhq/live-common/dada-client/mocks/stocks.mock";
 
 const handleEthereumAssets = (
   name: "ethereum" | "arbitrum" | "base" | "scroll",
@@ -132,6 +133,7 @@ const handler = ({ request }: { request: Request }) => {
   const categories = searchParams.get("categories");
 
   if (categories === "stablecoins") return HttpResponse.json(mockStablecoinsResponse);
+  if (categories === "stocks") return HttpResponse.json(mockStocksResponse);
 
   const search = searchParams.get("search")?.toLowerCase().trim();
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio screen rendering with the new Stocks section (gated behind the Asset Discoverability flag)
      - "Explore" link header variant behavior and navigation to the Market screen (stocks category)
      - Tapping a stock item navigates to the correct asset/market detail page
      - Existing search-overlay Stocks feature still renders with the "show more" header variant (no regression)

### 📝 Description

This PR adds a **Stocks** section to the Portfolio screen, displayed under the Stablecoins section.

**Problem**: Users had no entry point to discover stocks directly from their Portfolio.

**Solution**: The new section reuses the existing search-overlay `Stocks` feature (DADA-sourced, ranked by market cap, horizontally scrollable two-row grid). To fit the Portfolio context, the `Stocks` component gained a `headerVariant` prop:

- `"showMore"` (default) — the existing chevron affordance used in the search overlay
- `"explore"` — an "Explore" link header used on the Portfolio screen

Tapping a stock navigates to its asset/market detail page, and the "Explore" link routes to the Market screen pre-filtered on the `stocks` category. The whole section is gated behind the **Asset Discoverability** feature flag.

### 🖼️ Screenshots

https://github.com/user-attachments/assets/9ab73ea8-22f0-4d2c-a955-f73f8d52f670



### ❓ Context

- **JIRA or GitHub link**: [LIVE-29957](https://ledgerhq.atlassian.net/browse/LIVE-29957) · [LIVE-29958](https://ledgerhq.atlassian.net/browse/LIVE-29958)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29957]: https://ledgerhq.atlassian.net/browse/LIVE-29957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ