### PR TITLE
refactor: finish types-live FF migration — repoint consumers + deprecate feature.ts

### DIFF
--- a/.changeset/ff-deprecate-typeslive-feature.md
+++ b/.changeset/ff-deprecate-typeslive-feature.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/types-live": minor
+---
+
+Deprecate the legacy feature-flag types in `feature.ts` (`Feature`, `Features`, `FeatureId`, `FeatureMap`, `OptionalFeatureMap`, `FeatureParam`, and all `Feature_*`). The Ledger Live feature-flag registry has moved to `@shared/feature-flags`; every export now carries a `@deprecated` annotation pointing to its replacement (e.g. `Feature_Noah` → `Features["noah"]`). The types stay exported for backward compatibility and are slated for removal in a future major.

--- a/.changeset/ff-shared-types-cleanup.md
+++ b/.changeset/ff-shared-types-cleanup.md
@@ -1,0 +1,9 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-dmk-desktop": minor
+"ledger-live-desktop-e2e-tests": minor
+"ledger-live-mobile-e2e-tests": minor
+---
+
+Repoint the remaining `@ledgerhq/types-live` feature-type consumers (desktop app + desktop/mobile e2e) onto `@shared/feature-flags`, taking in-repo usage of the legacy types-live feature types to zero. Also drop now-dead feature-flag tooling config: the `@ledgerhq/live-common/featureFlags/index` `unimported` entry in `live-dmk-desktop`, and the deleted `FeatureFlagsContextBridge` eslint-guardrail exemptions in both apps (the block rules against re-introducing the deleted module are kept).

--- a/apps/ledger-live-desktop/.eslintrc.guardrails.js
+++ b/apps/ledger-live-desktop/.eslintrc.guardrails.js
@@ -56,12 +56,6 @@ module.exports = {
     },
     {
       files: ["src/**/*.ts", "src/**/*.tsx", "tests/**/*.ts", "tests/**/*.tsx"],
-      // Sanctioned bridge (+ its test) between live-common's FeatureFlagsContext and the
-      // slice. Temporary — removed once live-common's internal hooks migrate off the Context.
-      excludedFiles: [
-        "src/renderer/components/FeatureFlagsContextBridge.tsx",
-        "src/renderer/components/FeatureFlagsContextBridge.test.tsx",
-      ],
       rules: {
         "no-restricted-imports": ["error", featureFlagsRestrictions],
       },

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/types/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/types/index.ts
@@ -1,4 +1,4 @@
-import { Feature_LldNanoSUpsellBanners } from "@ledgerhq/types-live";
+import type { Features } from "@shared/feature-flags";
 
 export type LNSBannerState = {
   isShown: boolean;
@@ -12,4 +12,4 @@ export type LNSBannerLocation = Extract<
 >;
 
 type Tracking = "opted_in" | "opted_out";
-type FFParams = Required<Feature_LldNanoSUpsellBanners>["params"];
+type FFParams = Required<Features["lldNanoSUpsellBanners"]>["params"];

--- a/apps/ledger-live-desktop/tests/fixtures/common.ts
+++ b/apps/ledger-live-desktop/tests/fixtures/common.ts
@@ -2,7 +2,7 @@ import { test as base, Page, ElectronApplication } from "@playwright/test";
 import fsPromises from "fs/promises";
 import merge from "lodash/merge";
 import * as path from "path";
-import { OptionalFeatureMap } from "@ledgerhq/types-live";
+import { OptionalFeatureMap } from "@shared/feature-flags";
 
 import { Application } from "tests/page";
 import { safeAppendFile } from "tests/utils/fileUtils";

--- a/apps/ledger-live-desktop/tests/fixtures/common.ts
+++ b/apps/ledger-live-desktop/tests/fixtures/common.ts
@@ -2,7 +2,7 @@ import { test as base, Page, ElectronApplication } from "@playwright/test";
 import fsPromises from "fs/promises";
 import merge from "lodash/merge";
 import * as path from "path";
-import { OptionalFeatureMap } from "@shared/feature-flags";
+import type { OptionalFeatureMap } from "@shared/feature-flags";
 
 import { Application } from "tests/page";
 import { safeAppendFile } from "tests/utils/fileUtils";

--- a/apps/ledger-live-mobile/.eslintrc.guardrails.js
+++ b/apps/ledger-live-mobile/.eslintrc.guardrails.js
@@ -37,12 +37,6 @@ module.exports = {
   overrides: [
     {
       files: ["src/**/*.ts", "src/**/*.tsx", "__tests__/**/*.ts", "__tests__/**/*.tsx"],
-      // Sanctioned bridge (+ its test) between live-common's FeatureFlagsContext and the
-      // slice. Temporary — removed once live-common's internal hooks migrate off the Context.
-      excludedFiles: [
-        "src/components/FeatureFlagsContextBridge.tsx",
-        "src/components/__tests__/FeatureFlagsContextBridge.test.tsx",
-      ],
       rules: {
         "no-restricted-imports": ["error", featureFlagsRestrictions],
       },

--- a/e2e/desktop/package.json
+++ b/e2e/desktop/package.json
@@ -23,7 +23,6 @@
     "@ledgerhq/live-wallet": "workspace:^",
     "@ledgerhq/logs": "workspace:^",
     "@ledgerhq/types-devices": "workspace:^",
-    "@ledgerhq/types-live": "workspace:^",
     "@playwright/test": "catalog:",
     "@shared/feature-flags": "workspace:*",
     "@types/node": "catalog:",

--- a/e2e/desktop/package.json
+++ b/e2e/desktop/package.json
@@ -25,6 +25,7 @@
     "@ledgerhq/types-devices": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",
     "@playwright/test": "catalog:",
+    "@shared/feature-flags": "workspace:*",
     "@types/node": "catalog:",
     "allure-js-commons": "catalog:",
     "allure-playwright": "catalog:",

--- a/e2e/desktop/tests/fixtures/common.ts
+++ b/e2e/desktop/tests/fixtures/common.ts
@@ -2,7 +2,7 @@ import { test as base, Page, ElectronApplication, ChromiumBrowserContext } from 
 import { mkdir, readFile, writeFile } from "fs/promises";
 import merge from "lodash/merge";
 import * as path from "path";
-import { OptionalFeatureMap } from "@shared/feature-flags";
+import type { OptionalFeatureMap } from "@shared/feature-flags";
 import { setEnv } from "@ledgerhq/live-env";
 
 import { Application } from "tests/page";

--- a/e2e/desktop/tests/fixtures/common.ts
+++ b/e2e/desktop/tests/fixtures/common.ts
@@ -2,7 +2,7 @@ import { test as base, Page, ElectronApplication, ChromiumBrowserContext } from 
 import { mkdir, readFile, writeFile } from "fs/promises";
 import merge from "lodash/merge";
 import * as path from "path";
-import { OptionalFeatureMap } from "@ledgerhq/types-live";
+import { OptionalFeatureMap } from "@shared/feature-flags";
 import { setEnv } from "@ledgerhq/live-env";
 
 import { Application } from "tests/page";

--- a/e2e/desktop/tests/specs/delegate.spec.ts
+++ b/e2e/desktop/tests/specs/delegate.spec.ts
@@ -11,7 +11,7 @@ import { getModularSelector } from "tests/utils/modularSelectorUtils";
 import { liveDataCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 import { FF_STAKE_PROGRAMS_MODAL } from "tests/utils/featureFlagUtils";
 
-import type { OptionalFeatureMap } from "@ledgerhq/types-live";
+import type { OptionalFeatureMap } from "@shared/feature-flags";
 
 function setupEnv(disableBroadcast?: boolean) {
   const originalBroadcastValue = process.env.DISABLE_TRANSACTION_BROADCAST;

--- a/e2e/desktop/tests/utils/featureFlagUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagUtils.ts
@@ -1,4 +1,4 @@
-import { OptionalFeatureMap } from "@ledgerhq/types-live";
+import { OptionalFeatureMap } from "@shared/feature-flags";
 import { Page } from "@playwright/test";
 
 export const getFeatureFlags = async (page: Page): Promise<OptionalFeatureMap> => {

--- a/e2e/desktop/tests/utils/featureFlagUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagUtils.ts
@@ -1,4 +1,4 @@
-import { OptionalFeatureMap } from "@shared/feature-flags";
+import type { OptionalFeatureMap } from "@shared/feature-flags";
 import { Page } from "@playwright/test";
 
 export const getFeatureFlags = async (page: Page): Promise<OptionalFeatureMap> => {

--- a/e2e/desktop/tsconfig.json
+++ b/e2e/desktop/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "paths": {
       "*": ["./*"],
-      "~/*": ["../../apps/ledger-live-desktop/src/*"]
+      "~/*": ["../../apps/ledger-live-desktop/src/*"],
+      "@shared/feature-flags": ["../../shared/feature-flags/src"]
     }
   },
   "include": ["./**/*.ts", "../../apps/ledger-live-desktop/index-types.d.ts"],

--- a/e2e/mobile/page/drawer/modular.drawer.ts
+++ b/e2e/mobile/page/drawer/modular.drawer.ts
@@ -1,5 +1,5 @@
 import { Step } from "jest-allure2-reporter/api";
-import { Feature_ModularDrawer } from "@ledgerhq/types-live";
+import type { Features } from "@shared/feature-flags";
 import { getFlags } from "../../bridge/server";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { isIos } from "../../helpers/commonHelpers";
@@ -38,7 +38,7 @@ export default class ModularDrawer {
   assetItemByTicker = (ticker: string) => new RegExp(`asset-item-${ticker}`, "i");
   networkItemIdMAD = (networkId: string) => new RegExp(`network-item-${networkId}`, "i");
 
-  private flags: Feature_ModularDrawer | null = null;
+  private flags: Features["llmModularDrawer"] | null = null;
 
   resetFlags(): void {
     this.flags = null;
@@ -48,7 +48,7 @@ export default class ModularDrawer {
     this.flags ??= JSON.parse(await getFlags()).llmModularDrawer;
   }
 
-  async isFlowEnabled<K extends keyof NonNullable<Feature_ModularDrawer["params"]>>(
+  async isFlowEnabled<K extends keyof NonNullable<Features["llmModularDrawer"]["params"]>>(
     flow: K,
   ): Promise<boolean> {
     await this.loadFlags();

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -1,7 +1,7 @@
 import { Step } from "jest-allure2-reporter/api";
 import { isWallet40, openDeeplink } from "../../helpers/commonHelpers";
 import { getFlags } from "../../bridge/server";
-import { Feature_Noah } from "@ledgerhq/types-live";
+import type { Features } from "@shared/feature-flags";
 export default class PortfolioPage {
   addNewOrExistingAccount = "add-new-account-button";
   assetsListId = "AssetsList";
@@ -76,7 +76,7 @@ export default class PortfolioPage {
       ? getElementByIdWithDescendantTexts(this.operationRowBody, accountName, operationType)
       : getElementByIdWithDescendantTexts(this.operationRowBody, operationType);
 
-  private flags: Feature_Noah | null = null;
+  private flags: Features["noah"] | null = null;
 
   private async loadFlags(): Promise<void> {
     this.flags ??= JSON.parse(await getFlags()).noah;

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -1,3 +1,6 @@
+// Legacy Ledger Live feature-flag types. The registry now lives in `@shared/feature-flags`
+// (each export below points to its replacement). Retained as published surface only; slated
+// for removal in a future `@ledgerhq/types-live` major.
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { ABTestingVariants } from "./ABTesting";
 import { ChainwatchNetwork } from "./chainwatch";
@@ -9,6 +12,7 @@ import { WalletSyncEnvironment, WalletSyncWatchConfig } from "./walletSync";
  * Feature type.
  *
  * @dev We use objects instead of direct booleans for potential future improvements.
+ * @deprecated Moved to `@shared/feature-flags`. Use `Feature` from `@shared/feature-flags` instead.
  */
 export type Feature<T = unknown> = {
   /**
@@ -69,11 +73,13 @@ export type Feature<T = unknown> = {
 
 /**
  * Default Feature type.
+ * @deprecated Moved to `@shared/feature-flags`. Use `Feature` from `@shared/feature-flags` instead.
  */
 export type DefaultFeature = Feature<unknown>;
 
 /**
  * Currency Features type.
+ * @deprecated Part of the legacy Ledger Live feature-flag types. Moved to `@shared/feature-flags`.
  */
 export type CurrencyFeatures = {
   currencyAvalancheCChain: DefaultFeature;
@@ -173,6 +179,7 @@ export type CurrencyFeatures = {
  * Features type.
  *
  * @dev Add features here.
+ * @deprecated Moved to `@shared/feature-flags`. Use `Features` from `@shared/feature-flags` instead.
  */
 export type Features = CurrencyFeatures & {
   nanoOnboardingFundWallet: DefaultFeature;
@@ -346,16 +353,19 @@ export type Features = CurrencyFeatures & {
 
 /**
  * FeatureId type.
+ * @deprecated Moved to `@shared/feature-flags`. Use `FeatureId` from `@shared/feature-flags` instead.
  */
 export type FeatureId = keyof Features;
 
 /**
  * EthStakingProvider category type.
+ * @deprecated Part of the legacy Ledger Live feature-flag types. Moved to `@shared/feature-flags`.
  */
 export type EthStakingProviderCategory = "liquid" | "pooling" | "protocol" | "restaking";
 
 /**
  * EthStakingProvider rewards strategy.
+ * @deprecated Part of the legacy Ledger Live feature-flag types. Moved to `@shared/feature-flags`.
  */
 export type EthStakingProviderRewardsStrategy =
   | "basic"
@@ -366,6 +376,7 @@ export type EthStakingProviderRewardsStrategy =
 
 /**
  * EthStakingProvider.
+ * @deprecated Part of the legacy Ledger Live feature-flag types. Moved to `@shared/feature-flags`.
  */
 export interface EthStakingProvider {
   id: string;
@@ -385,16 +396,19 @@ export interface EthStakingProvider {
 
 /**
  * Features types.
+ * @deprecated Moved to `@shared/feature-flags`. Use `Features["ethStakingProviders"]` from `@shared/feature-flags` instead.
  */
 export type Feature_EthStakingProviders = Feature<{
   listProvider: EthStakingProvider[];
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["transactionsAlerts"]` from `@shared/feature-flags` instead. */
 export type Feature_TransactionsAlerts = Feature<{
   chainwatchBaseUrl: string;
   networks: ChainwatchNetwork[];
 }>;
 
+/** @deprecated Part of the legacy Ledger Live feature-flag types. Moved to `@shared/feature-flags`. */
 export type NotificationsPromptAfterActionSource =
   | "onboarding"
   | "send"
@@ -404,6 +418,7 @@ export type NotificationsPromptAfterActionSource =
   | "stake"
   | "add_favorite_coin";
 
+/** @deprecated Part of the legacy Ledger Live feature-flag types. Moved to `@shared/feature-flags`. */
 export type NotificationsCategoryConfig = {
   displayed: boolean;
   category: string;
@@ -411,30 +426,36 @@ export type NotificationsCategoryConfig = {
   drawerPromptActions?: NotificationsPromptAfterActionSource[];
 };
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["swapWalletApiPartnerList"]` from `@shared/feature-flags` instead. */
 export type Feature_SwapWalletApiPartnerList = Feature<{
   list: string[];
 }>;
 
+/** @deprecated Part of the legacy Ledger Live feature-flag types. Moved to `@shared/feature-flags`. */
 export type PlatformManifestId = "stakekit" | "kiln-widget" | "earn";
 
+/** @deprecated Part of the legacy Ledger Live feature-flag types. Moved to `@shared/feature-flags`. */
 export type RedirectQueryParam<M extends PlatformManifestId> = "stakekit" extends M
   ? {
       yieldId: string;
     }
   : unknown;
 
+/** @deprecated Part of the legacy Ledger Live feature-flag types. Moved to `@shared/feature-flags`. */
 export type Redirect<M extends PlatformManifestId> = {
   platform: PlatformManifestId;
   name: string;
   queryParams?: Record<string, string> & RedirectQueryParam<M>;
 };
 
+/** @deprecated Part of the legacy Ledger Live feature-flag types. Moved to `@shared/feature-flags`. */
 export type VersionedRedirect = {
   desktop_version?: string;
   mobile_version?: string;
   redirects: Record<string, Redirect<PlatformManifestId>>;
 };
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["stakePrograms"]` from `@shared/feature-flags` instead. */
 export type Feature_StakePrograms = Feature<{
   list: string[];
   /** redirects is a dictionary of crypto asset ids to partner app params for overriding flows for specific tokens. */
@@ -442,14 +463,17 @@ export type Feature_StakePrograms = Feature<{
   versions?: VersionedRedirect[];
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["stakeAccountBanner"]` from `@shared/feature-flags` instead. */
 export type Feature_StakeAccountBanner = Feature<{ [blockchainName: string]: any }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["referralProgramDesktopSidebar"]` from `@shared/feature-flags` instead. */
 export type Feature_ReferralProgramDesktopSidebar = Feature<{
   path: string;
   isNew: boolean;
   amount: string;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["brazePushNotifications"]` from `@shared/feature-flags` instead. */
 export type Feature_BrazePushNotifications = Feature<{
   reprompt_schedule: Array<{
     months: number;
@@ -503,6 +527,7 @@ export type Feature_BrazePushNotifications = Feature<{
   notificationsCategories: NotificationsCategoryConfig[];
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["receiveStakingFlowConfigDesktop"]` from `@shared/feature-flags` instead. */
 export type Feature_ReceiveStakingFlowConfigDesktop = Feature<{
   [blockchainName: string]: {
     enabled: boolean;
@@ -511,17 +536,20 @@ export type Feature_ReceiveStakingFlowConfigDesktop = Feature<{
   };
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["storyly"]` from `@shared/feature-flags` instead. */
 export type Feature_Storyly = Feature<{
   stories: {
     [key in StorylyInstanceID]: StorylyInstanceType;
   };
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["newsfeedPage"]` from `@shared/feature-flags` instead. */
 export type Feature_NewsfeedPage = Feature<{
   cryptopanicApiKey: string;
   whitelistedLocales: string[];
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["protectServicesMobile"]` from `@shared/feature-flags` instead. */
 export type Feature_ProtectServicesMobile = Feature<{
   deeplink: string;
   bannerSubscriptionNotification: boolean;
@@ -544,6 +572,7 @@ export type Feature_ProtectServicesMobile = Feature<{
   protectId: string;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["protectServicesDesktop"]` from `@shared/feature-flags` instead. */
 export type Feature_ProtectServicesDesktop = Feature<{
   openWithDevTools: boolean;
   availableOnDesktop: boolean;
@@ -561,53 +590,65 @@ export type Feature_ProtectServicesDesktop = Feature<{
   protectId: string;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["recoverUpsellPostOnboarding"]` from `@shared/feature-flags` instead. */
 export type Feature_RecoverUpsellPostOnboarding = Feature<{
   deviceIds: DeviceModelId[];
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["deviceInitialApps"]` from `@shared/feature-flags` instead. */
 export type Feature_DeviceInitialApps = Feature<{
   apps: string[];
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["buyDeviceFromLive"]` from `@shared/feature-flags` instead. */
 export type Feature_BuyDeviceFromLive = Feature<{
   debug: boolean;
   url: string | null;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["concordiumIdAppLinks"]` from `@shared/feature-flags` instead. */
 export type Feature_ConcordiumIdAppLinks = Feature<{
   appStore: string;
   playStore: string;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["discover"]` from `@shared/feature-flags` instead. */
 export type Feature_Discover = Feature<{
   version: string;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["domainInputResolution"]` from `@shared/feature-flags` instead. */
 export type Feature_DomainInputResolution = Feature<{
   supportedCurrencyIds: string[];
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["editEvmTx"]` from `@shared/feature-flags` instead. */
 export type Feature_EditEvmTx = Feature<{
   supportedCurrencyIds: string[];
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["evmNativeStaking"]` from `@shared/feature-flags` instead. */
 export type Feature_EvmNativeStaking = Feature<{
   supportedCurrencyIds: string[];
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["editBitcoinTx"]` from `@shared/feature-flags` instead. */
 export type Feature_EditBitcoinTx = Feature<{
   supportedCurrencyIds: string[];
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["firebaseEnvironmentReadOnly"]` from `@shared/feature-flags` instead. */
 export type Feature_FirebaseEnvironmentReadOnly = Feature<{
   comment: string;
   project: string;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["ldmkTransport"]` from `@shared/feature-flags` instead. */
 export type Feature_LdmkTransport = Feature<{
   warningVisible: boolean;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["npsRatingsPrompt"]` from `@shared/feature-flags` instead. */
 export type Feature_NpsRatingsPrompt = Feature<{
   conditions: {
     disappointed_delay: {
@@ -635,6 +676,7 @@ export type Feature_NpsRatingsPrompt = Feature<{
   typeform_url: string;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["ratingsPrompt"]` from `@shared/feature-flags` instead. */
 export type Feature_RatingsPrompt = Feature<{
   conditions: {
     disappointed_delay: {
@@ -662,68 +704,83 @@ export type Feature_RatingsPrompt = Feature<{
   typeform_url: string;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["ptxSwapLiveApp"]` from `@shared/feature-flags` instead. */
 export type Feature_PtxSwapLiveApp = Feature<{
   manifest_id: string;
   currencies?: string[];
   families?: string[];
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["ptxPerpsLiveAppMobile"]` from `@shared/feature-flags` instead. */
 export type Feature_PtxPerpsLiveApp = Feature<{
   manifest_id: string;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["ptxBorrowLiveApp"]` from `@shared/feature-flags` instead. */
 export type Feature_PtxBorrowLiveApp = Feature<{
   manifest_id: string;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["ptxEarnLiveApp"]` from `@shared/feature-flags` instead. */
 export type Feature_PtxEarnLiveApp = Feature<{
   manifest_id: string;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["fetchAdditionalCoins"]` from `@shared/feature-flags` instead. */
 export type Feature_FetchAdditionalCoins = Feature<{
   batch: number;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["llmAnalyticsOptInPrompt"]` from `@shared/feature-flags` instead. */
 export type Feature_LlmAnalyticsOptInPrompt = Feature<{
   variant: ABTestingVariants;
   entryPoints: Array<string>;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["lldAnalyticsOptInPrompt"]` from `@shared/feature-flags` instead. */
 export type Feature_LldAnalyticsOptInPrompt = Feature<{
   variant: ABTestingVariants;
   entryPoints: Array<string>;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["lldActionCarousel"]` from `@shared/feature-flags` instead. */
 export type Feature_lldActionCarousel = Feature<{
   variant: ABTestingVariants;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["lldRefreshMarketData"]` from `@shared/feature-flags` instead. */
 export type Feature_LldRefreshMarketData = Feature<{
   refreshTime: number;
 }>;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["llmRefreshMarketData"]` from `@shared/feature-flags` instead. */
 export type Feature_LlmRefreshMarketData = Feature<{
   refreshTime: number;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["buySellUi"]` from `@shared/feature-flags` instead. */
 export type Feature_BuySellUiManifest = Feature<{
   manifestId: string; // id of the app to use for the Buy/Sell UI, e.g. "buy-sell-ui"
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["buySellLoader"]` from `@shared/feature-flags` instead. */
 export type Feature_BuySellLoader = Feature<{
   durationMs: number;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["lldWalletSync"]` from `@shared/feature-flags` instead. */
 export type Feature_LldWalletSync = Feature<{
   environment: WalletSyncEnvironment;
   watchConfig: WalletSyncWatchConfig;
   learnMoreLink: string;
 }>;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["llmWalletSync"]` from `@shared/feature-flags` instead. */
 export type Feature_LlmWalletSync = Feature<{
   environment: WalletSyncEnvironment;
   watchConfig: WalletSyncWatchConfig;
   learnMoreLink: string;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["llmLedgerSyncEntryPoints"]` from `@shared/feature-flags` instead. */
 export type Feature_LlmLedgerSyncEntryPoints = Feature<{
   manager: boolean;
   accounts: boolean;
@@ -731,6 +788,7 @@ export type Feature_LlmLedgerSyncEntryPoints = Feature<{
   onboarding: boolean;
   postOnboarding: boolean;
 }>;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["lldLedgerSyncEntryPoints"]` from `@shared/feature-flags` instead. */
 export type Feature_LldLedgerSyncEntryPoints = Feature<{
   manager: boolean;
   accounts: boolean;
@@ -739,21 +797,25 @@ export type Feature_LldLedgerSyncEntryPoints = Feature<{
   postOnboarding: boolean;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["llNftEntryPoint"]` from `@shared/feature-flags` instead. */
 export type Feature_LlNftEntryPoint = Feature<{
   magiceden: boolean;
   opensea: boolean;
   chains: string[];
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["llCounterValueGranularitiesRates"]` from `@shared/feature-flags` instead. */
 export type Feature_LlCounterValueGranularitiesRates = Feature<{
   daily: number;
   hourly: number;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["llmMmkvMigration"]` from `@shared/feature-flags` instead. */
 export type Feature_LlmMmkvMigration = Feature<{
   shouldRollback: boolean | null;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["llmModularDrawer"]` from `@shared/feature-flags` instead. */
 export type Feature_ModularDrawer = Feature<{
   add_account: boolean;
   live_app: boolean;
@@ -767,40 +829,61 @@ export type Feature_ModularDrawer = Feature<{
   enableDialogDesktop?: boolean;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["noah"]` from `@shared/feature-flags` instead. */
 export type Feature_Noah = Feature<{
   activeCurrencyIds: string[];
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["newSendFlow"]` from `@shared/feature-flags` instead. */
 export type Feature_NewSendFlow = Feature<{
   families?: string[];
   excludedCurrencyIds?: string[];
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["addressPoisoningOperationsFilter"]` from `@shared/feature-flags` instead. */
 export type Feature_AddressPoisoningOperationsFilter = Feature<{
   families: string[];
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["lldHideSmallValueTokenOperations"]` from `@shared/feature-flags` instead. */
 export type Feature_LldHideSmallValueTokenOperations = Feature<{
   /** USD threshold below which incoming token operations are hidden. Defaults to $0.5. */
   thresholdUsd: number;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["counterValue"]` from `@shared/feature-flags` instead. */
 export type Feature_CounterValue = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["mockFeature"]` from `@shared/feature-flags` instead. */
 export type Feature_MockFeature = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["disableNftSend"]` from `@shared/feature-flags` instead. */
 export type Feature_DisableNftSend = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["disableNftLedgerMarket"]` from `@shared/feature-flags` instead. */
 export type Feature_DisableNftLedgerMarket = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["disableNftRaribleOpensea"]` from `@shared/feature-flags` instead. */
 export type Feature_DisableNftRaribleOpensea = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["ptxServiceCtaExchangeDrawer"]` from `@shared/feature-flags` instead. */
 export type Feature_PtxServiceCtaExchangeDrawer = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["ptxServiceCtaScreens"]` from `@shared/feature-flags` instead. */
 export type Feature_PtxServiceCtaScreens = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["portfolioExchangeBanner"]` from `@shared/feature-flags` instead. */
 export type Feature_PortfolioExchangeBanner = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["ptxSwapReceiveTRC20WithoutTrx"]` from `@shared/feature-flags` instead. */
 export type Feature_PtxSwapReceiveTRC20WithoutTrx = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["flexibleContentCards"]` from `@shared/feature-flags` instead. */
 export type Feature_FlexibleContentCards = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["myLedgerDisplayAppDeveloperName"]` from `@shared/feature-flags` instead. */
 export type Feature_MyLedgerDisplayAppDeveloperName = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["lldChatbotSupport"]` from `@shared/feature-flags` instead. */
 export type Feature_LldChatbotSupport = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["llmChatbotSupport"]` from `@shared/feature-flags` instead. */
 export type Feature_LlmChatbotSupport = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["enableAppsBackup"]` from `@shared/feature-flags` instead. */
 export type Feature_EnableAppsBackup = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["web3hub"]` from `@shared/feature-flags` instead. */
 export type Feature_web3hub = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["lldMemoTag"]` from `@shared/feature-flags` instead. */
 export type Feature_MemoTag = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["ptxEarnDrawerConfiguration"]` from `@shared/feature-flags` instead. */
 export type Feature_PtxEarnDrawerConfiguration = Feature<{
   assets?: {
     filter?: "topNetworks" | "undefined";
@@ -812,30 +895,38 @@ export type Feature_PtxEarnDrawerConfiguration = Feature<{
     rightElement?: "balance" | "undefined";
   };
 }>;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["ptxEarnUi"]` from `@shared/feature-flags` instead. */
 export type Feature_PtxEarnUi = Feature<{
   value: string;
 }>;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["ptxSwapMoonpayProvider"]` from `@shared/feature-flags` instead. */
 export type Feature_PtxSwapMoonpayProvider = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["ptxSwapExodusProvider"]` from `@shared/feature-flags` instead. */
 export type Feature_PtxSwapExodusProvider = DefaultFeature;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["ptxSwapDetailedView"]` from `@shared/feature-flags` instead. */
 export type Feature_PtxSwapDetailedView = Feature<{
   variant: ABTestingVariants;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["llmRebornLP"]` from `@shared/feature-flags` instead. */
 export type Feature_LlmRebornLP = Feature<{
   variant: ABTestingVariants;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["lldNanoSUpsellBanners"]` from `@shared/feature-flags` instead. */
 export type Feature_LldNanoSUpsellBanners = Feature<{
   opted_in: LldNanoSUpsellBannersConfig;
   opted_out: LldNanoSUpsellBannersConfig & { portfolio: boolean };
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["llmNanoSUpsellBanners"]` from `@shared/feature-flags` instead. */
 export type Feature_LlmNanoSUpsellBanners = Feature<{
   opted_in: LlmNanoSUpsellBannersConfig;
   opted_out: LlmNanoSUpsellBannersConfig;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["llmTransferButtonCopyVariant"]` from `@shared/feature-flags` instead. */
 export type Feature_LlmTransferButtonCopyVariant = Feature<{
   variantId: string;
   buttonLabel?: string;
@@ -846,9 +937,12 @@ export type Feature_LlmTransferButtonCopyVariant = Feature<{
   rowCashToStableDescription?: string;
 }>;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["llmHomescreen"]` from `@shared/feature-flags` instead. */
 export type Feature_LlmHomescreen = DefaultFeature;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["supportDeviceApex"]` from `@shared/feature-flags` instead. */
 export type Feature_SupportDeviceApex = DefaultFeature;
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["lldOnboardingEnableSync"]` from `@shared/feature-flags` instead. */
 export type Feature_OnboardingEnableSync = Feature<{
   nanos: boolean;
   touchscreens: boolean;
@@ -856,13 +950,17 @@ export type Feature_OnboardingEnableSync = Feature<{
 
 /**
  * Array of firmware versions that are ignored for the given device model
+ * @deprecated Part of the legacy Ledger Live feature-flag types. Moved to `@shared/feature-flags`.
  */
 export type IgnoredOSUpdates = Array<string>;
 
+/** @deprecated Part of the legacy Ledger Live feature-flag types. Moved to `@shared/feature-flags`. */
 export type Platform = "ios" | "android" | "macos" | "windows" | "linux";
 
+/** @deprecated Part of the legacy Ledger Live feature-flag types. Moved to `@shared/feature-flags`. */
 export type IgnoredOSUpdatesByPlatform = { [M in DeviceModelId]?: IgnoredOSUpdates };
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["onboardingIgnoredOsUpdates"]` from `@shared/feature-flags` instead. */
 export type Feature_OnboardingIgnoredOSUpdates = Feature<{
   [P in Platform]?: IgnoredOSUpdatesByPlatform;
 }>;
@@ -888,19 +986,25 @@ type Feature_Wallet40_Params = {
   earnSimulator?: boolean;
 };
 
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["lwmWallet40"]` from `@shared/feature-flags` instead. */
 export type Feature_LwmWallet40 = Feature<Feature_Wallet40_Params>;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["lwdWallet40"]` from `@shared/feature-flags` instead. */
 export type Feature_LwdWallet40 = Feature<
   {
     newReceiveDialog: boolean;
   } & Feature_Wallet40_Params
 >;
+/** @deprecated Moved to `@shared/feature-flags`. Use `Features["lwmNewWordingOptInNotificationsDrawer"]` from `@shared/feature-flags` instead. */
 export type Feature_LwmNewWordingOptInNotificationsDrawer = Feature<{
   variant: ABTestingVariants;
 }>;
 
 /**
  * Utils types.
+ * @deprecated Moved to `@shared/feature-flags`. Use `FeatureMap` from `@shared/feature-flags` instead.
  */
 export type FeatureMap<T = Feature> = { [key in FeatureId]: T };
+/** @deprecated Moved to `@shared/feature-flags`. Use `OptionalFeatureMap` from `@shared/feature-flags` instead. */
 export type OptionalFeatureMap<T = Feature> = { [key in FeatureId]?: T };
+/** @deprecated Part of the legacy Ledger Live feature-flag types. Moved to `@shared/feature-flags`. */
 export type FeatureParam<T extends FeatureId> = Features[T]["params"];

--- a/libs/live-dmk-desktop/.unimportedrc.json
+++ b/libs/live-dmk-desktop/.unimportedrc.json
@@ -14,7 +14,6 @@
   "ignoreUnresolved": [
     "@jest/expect-utils",
     "@jest/get-type",
-    "jest-util",
-    "@ledgerhq/live-common/featureFlags/index"
+    "jest-util"
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3196,9 +3196,6 @@ importers:
       '@ledgerhq/types-devices':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/types-devices
-      '@ledgerhq/types-live':
-        specifier: workspace:^
-        version: link:../../libs/ledgerjs/packages/types-live
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3202,6 +3202,9 @@ importers:
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
+      '@shared/feature-flags':
+        specifier: workspace:*
+        version: link:../../shared/feature-flags
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.0
@@ -13185,7 +13188,7 @@ packages:
   '@apollo/server@4.12.2':
     resolution: {integrity: sha512-jKRlf+sBMMdKYrjMoiWKne42Eb6paBfDOr08KJnUaeaiyWFj+/040FjVPQI7YGLfdwnYIsl1NUUqS2UdgezJDg==}
     engines: {node: '>=14.16.0'}
-    deprecated: Apollo Server v4 is end-of-life since January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
+    deprecated: Apollo Server v4 is deprecated and will transition to end-of-life on January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
     peerDependencies:
       graphql: ^16.6.0
 
@@ -21985,7 +21988,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.0.0
       react-dom: 19.0.0
-      webpack: '*'
+      webpack: ^5.89.0
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -23961,7 +23964,7 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
+    deprecated: this version is no longer supported, please update to at least 0.8.*
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -24310,7 +24313,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:


### PR DESCRIPTION
## ✅ Checklist

Feature-flags monorepo migration — post-merge cleanup. Finishes the job started in #18237 ([LIVE-31640](https://ledgerhq.atlassian.net/browse/LIVE-31640)): removes the last in-repo usage of `@ledgerhq/types-live` feature types **and** deprecates the legacy types-live feature surface in favour of `@shared/feature-flags`.

Tracking: [LIVE-30965](https://ledgerhq.atlassian.net/browse/LIVE-30965) (folds in [LIVE-30187](https://ledgerhq.atlassian.net/browse/LIVE-30187)).

## E2E Runs

- [Desktop](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/ddcaeb8f-de8b-4214-8ae8-25a92bb378dc/)
- Mobile
  - Android
  - [iOS](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/47301fdf-388a-46a5-9597-69194c5140f7/)

## 📝 Description

### 1. Repoint remaining consumers → `@shared` (`24d19cc`)
Repoints the **7** remaining in-repo consumers of `@ledgerhq/types-live` feature types (all type-only):
- `apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/types/index.ts` — `Feature_LldNanoSUpsellBanners` → `Features["lldNanoSUpsellBanners"]`
- `apps/ledger-live-desktop/tests/fixtures/common.ts` + `e2e/desktop/tests/{fixtures/common,specs/delegate,utils/featureFlagUtils}` — `OptionalFeatureMap` (adds `@shared/feature-flags` workspace dep + tsconfig path to `e2e/desktop`, mirroring `e2e/mobile`)
- `e2e/mobile/page/drawer/modular.drawer.ts` — `Feature_ModularDrawer` → `Features["llmModularDrawer"]`
- `e2e/mobile/page/wallet/portfolio.page.ts` — `Feature_Noah` → `Features["noah"]`

Plus dead config removed: stale `@ledgerhq/live-common/featureFlags/index` `unimported` entry in `live-dmk-desktop`, and the deleted `FeatureFlagsContextBridge` eslint-guardrail exemptions in both apps (the block rules preventing re-introduction are kept).

**Result:** repo-wide grep for types-live feature-type imports → **zero**.

### 2. Deprecate the legacy types-live feature surface (`da1c0c8`)
Every export in `libs/ledgerjs/packages/types-live/src/feature.ts` now carries a `@deprecated` JSDoc pointing to its `@shared/feature-flags` replacement — **all 81 `Feature_*` → `Features["<id>"]`** (via the authoritative registry, incl. renames like `ptxPerpsLiveAppMobile`, `buySellUi`, `lldMemoTag`), and the foundational types (`Feature`, `Features`, `FeatureId`, `FeatureMap`, `OptionalFeatureMap`) → their `@shared` equivalents. Types stay exported for backward compatibility.

#### Why deprecate and not delete / privatize?
- **Can't privatize types-live:** **40 published packages** depend on it at runtime (the whole coin stack, `cryptoassets`, `device-core`, `hw-app-eth`, `live-countervalues`, `live-wallet`, …). A published package can't depend on a private one, so types-live must stay published.
- **Don't delete yet:** `@ledgerhq/types-live` is published (`6.110.0`); removing exports is a breaking change → a deliberate, owner-coordinated **major** bump. Deprecation ships the migration signal now without breaking external consumers. (Note: `no-deprecated` is `off` for `libs/ledgerjs/packages`, so feature.ts's internal self-references don't fail lint; in-repo consumers no longer import these types at all.)

## 🔜 Future (separate, owner-coordinated)
Delete `feature.ts` + its `export * from "./feature"` barrel line in a types-live **major** bump once external consumers have migrated.


[LIVE-31640]: https://ledgerhq.atlassian.net/browse/LIVE-31640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-30965]: https://ledgerhq.atlassian.net/browse/LIVE-30965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-30187]: https://ledgerhq.atlassian.net/browse/LIVE-30187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ