### PR TITLE
fix(desktop): prevent DISABLE_TRANSACTION_BROADCAST env leak between e2e tests

### DIFF
--- a/e2e/desktop/tests/specs/delegate.spec.ts
+++ b/e2e/desktop/tests/specs/delegate.spec.ts
@@ -14,16 +14,8 @@ import { FF_STAKE_PROGRAMS_MODAL } from "tests/utils/featureFlagUtils";
 import type { OptionalFeatureMap } from "@ledgerhq/types-live";
 
 function setupEnv(disableBroadcast?: boolean) {
-  const originalBroadcastValue = process.env.DISABLE_TRANSACTION_BROADCAST;
-  test.beforeAll(async () => {
-    if (disableBroadcast) process.env.DISABLE_TRANSACTION_BROADCAST = "1";
-  });
-  test.afterAll(async () => {
-    if (originalBroadcastValue !== undefined) {
-      process.env.DISABLE_TRANSACTION_BROADCAST = originalBroadcastValue;
-    } else {
-      delete process.env.DISABLE_TRANSACTION_BROADCAST;
-    }
+  test.use({
+    env: disableBroadcast ? { DISABLE_TRANSACTION_BROADCAST: "1" } : {},
   });
 }
 

--- a/e2e/desktop/tests/specs/earn.spec.ts
+++ b/e2e/desktop/tests/specs/earn.spec.ts
@@ -13,16 +13,8 @@ import {
 import { EARN_V1_DESKTOP_FLAGS, FF_STAKE_PROGRAMS_MODAL } from "tests/utils/featureFlagUtils";
 
 function setupEnv(disableBroadcast?: boolean) {
-  const originalBroadcastValue = process.env.DISABLE_TRANSACTION_BROADCAST;
-  test.beforeAll(async () => {
-    if (disableBroadcast) process.env.DISABLE_TRANSACTION_BROADCAST = "1";
-  });
-  test.afterAll(async () => {
-    if (originalBroadcastValue !== undefined) {
-      process.env.DISABLE_TRANSACTION_BROADCAST = originalBroadcastValue;
-    } else {
-      delete process.env.DISABLE_TRANSACTION_BROADCAST;
-    }
+  test.use({
+    env: disableBroadcast ? { DISABLE_TRANSACTION_BROADCAST: "1" } : {},
   });
 }
 

--- a/e2e/desktop/tests/specs/earn.v2.spec.ts
+++ b/e2e/desktop/tests/specs/earn.v2.spec.ts
@@ -28,11 +28,8 @@ function getTags(account: Account) {
 }
 
 function setupEnv(disableBroadcast?: boolean) {
-  test.beforeAll(async () => {
-    if (disableBroadcast) process.env.DISABLE_TRANSACTION_BROADCAST = "1";
-  });
-  test.afterAll(async () => {
-    delete process.env.DISABLE_TRANSACTION_BROADCAST;
+  test.use({
+    env: disableBroadcast ? { DISABLE_TRANSACTION_BROADCAST: "1" } : {},
   });
 }
 

--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -552,8 +552,6 @@ test.describe("Send flows", () => {
     });
   }
 
-  const originalValue = process.env.DISABLE_TRANSACTION_BROADCAST;
-
   test.describe("User sends funds to ENS address", () => {
     const transactionEnsAddress = new Transaction(
       Account.ETH_1,
@@ -562,15 +560,12 @@ test.describe("Send flows", () => {
       Fee.MEDIUM,
     );
 
-    test.beforeAll(async () => {
-      process.env.DISABLE_TRANSACTION_BROADCAST = "1";
-    });
-
     test.use({
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "skip-onboarding-with-last-seen-device",
       speculosApp: transactionEnsAddress.accountToDebit.currency.speculosApp,
       cliCommands: [liveDataWithRecipientAddressCommand(transactionEnsAddress)],
+      env: { DISABLE_TRANSACTION_BROADCAST: "1" },
     });
 
     const family = getFamilyByCurrencyId(transactionEnsAddress.accountToDebit.currency.id);
@@ -614,14 +609,6 @@ test.describe("Send flows", () => {
         await app.drawer.closeDrawer();
       },
     );
-
-    test.afterAll(() => {
-      if (originalValue !== undefined) {
-        process.env.DISABLE_TRANSACTION_BROADCAST = originalValue;
-      } else {
-        delete process.env.DISABLE_TRANSACTION_BROADCAST;
-      }
-    });
   });
 
   // TODO: LIVE-30321 - Until app-concordium 5.6.0 is released, the test is skipped as it requires a specific app version

--- a/e2e/desktop/tests/utils/swapUtils.ts
+++ b/e2e/desktop/tests/utils/swapUtils.ts
@@ -20,19 +20,11 @@ import BigNumber from "bignumber.js";
 import { launchSpeculos, cleanSpeculos } from "./speculosUtils";
 
 export function setupEnv(disableBroadcast: boolean = false): void {
-  let originalBroadcastValue: string | undefined;
-  test.beforeAll(async () => {
-    originalBroadcastValue = process.env.DISABLE_TRANSACTION_BROADCAST;
-    process.env.SWAP_DISABLE_APPS_INSTALL = "true";
-    if (disableBroadcast) process.env.DISABLE_TRANSACTION_BROADCAST = "1";
-  });
-  test.afterAll(async () => {
-    delete process.env.SWAP_DISABLE_APPS_INSTALL;
-    if (originalBroadcastValue !== undefined) {
-      process.env.DISABLE_TRANSACTION_BROADCAST = originalBroadcastValue;
-    } else {
-      delete process.env.DISABLE_TRANSACTION_BROADCAST;
-    }
+  test.use({
+    env: {
+      SWAP_DISABLE_APPS_INSTALL: "true",
+      ...(disableBroadcast ? { DISABLE_TRANSACTION_BROADCAST: "1" } : {}),
+    },
   });
 }
 


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not required: changes are confined to the private `ledger-live-desktop-e2e-tests` package (test-only, not published)._
- [x] **Covered by automatic tests.** _These are E2E test-infrastructure changes; correctness is exercised by the existing Playwright suites._
- [x] **Impact of the changes:**
  - Desktop E2E runs with transaction broadcast **enabled** (`enable_broadcast: true` / Monday nightly)
  - Send / Delegate / Earn / SubAccount specs that previously showed `DISABLE TRANSACTION BROADCAST: TRUE` unexpectedly
  - Swap, Earn v2, "Delegate without Broadcasting", and "Send to ENS" suites must still run **without** broadcast

### 📝 Description

**Problem**: On a Desktop E2E run triggered with broadcasting enabled (`DISABLE_TRANSACTION_BROADCAST=0`), several failed **Send** tests showed `DISABLE TRANSACTION BROADCAST: TRUE` in their screenshots. Evidence from the Allure report confirmed it was non-deterministic: the first attempt of `Send from Tron 1 to Tron 2` correctly showed `FALSE` (18:27:03), but its retries showed `TRUE` (18:29:40, 18:32:04) — after a "without broadcast" suite had run in the same worker.

**Root cause**: The "without broadcast" suites (swap `setupEnv`, plus near-identical local helpers in `delegate`, `earn`, `earn.v2`, and the inline `send-to-ENS` suite) mutated the **shared, per-worker** `process.env.DISABLE_TRANSACTION_BROADCAST` in `beforeAll`/`afterAll`. Because Playwright reuses workers and reschedules retries, those mutations leaked into unrelated tests running later in the same worker. The app-launch fixture defaults to `"1"` when the value is falsy (`common.ts:253` → `process.env.DISABLE_TRANSACTION_BROADCAST || "1"`), and `earn.v2`'s helper even `delete`d the var unconditionally — so leaked tests launched with broadcast disabled. The leak also corrupted direct `process.env` reads such as `subAccount.spec.ts:258`.

**Solution**: Scope the broadcast override to each suite via the per-test, **app-only `env` fixture** (`test.use({ env: { DISABLE_TRANSACTION_BROADCAST: "1" } })`) instead of mutating the shared `process.env`. No test mutates the shared worker env anymore, so:
- the intentional "without broadcast" suites still disable broadcast — but only for their own app;
- Send/Delegate/SubAccount tests can no longer be corrupted by a sibling test or a retry and now honor the run's actual `DISABLE_TRANSACTION_BROADCAST=0`.

This only affects broadcast-enabled runs (where the leak is observable); normal nightly runs (`=1` everywhere) are unchanged.

### ❓ Context

- **JIRA or GitHub link**: N/A — diagnosed from CI run [27226649996](https://github.com/LedgerHQ/ledger-live/actions/runs/27226649996)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

