### PR TITLE
docs: refine comments skill

### DIFF
--- a/.agents/skills/comments/SKILL.md
+++ b/.agents/skills/comments/SKILL.md
@@ -9,11 +9,13 @@ description: |
 
 ## 🧀 Avoid comments
 
-Comments are a _code smell_ because:
+Comments are a _code smell_ because comments can go out of date, leading to confusion and bugs.
 
-- Comments can go out of date, leading to confusion and bugs
-- They often don't add value beyond what the code already conveys
-- Good code should explain itself
+**Reference this guidance rather than the codebase.**
+
+- **Avoid adding comments** – always prefer good naming
+- **Use test names to describe behaviour** – unit tests are living documentation
+- **Good code explains itself** – don't add comments that duplicate what the code already conveys
 
 ## 💡 Treatments
 
@@ -27,8 +29,9 @@ When code isn't clear we should try to make it clearer:
 
 When comments are necessary we should follow these guidelines:
 
-- **Be concise**: Use as few words as possible to convey the necessary information
-- **Prefer a link**: If the comment is explaining a workaround for a known issue, link to the issue or docs
+- **Be concise**: Use as few words as possible to convey the necessary information.
+- **Use JSDocs**: Only when describing a shared function.
+- **Prefer a link**: If the comment is explaining a workaround for a known issue, link to the issue or docs.
 
 **❌ Bad**
 
@@ -74,4 +77,19 @@ it("resets the state of every line when the diff is resolved", () => {
   act(() => result.current.setDiffTarget("resolved"));
   expect(result.current.diffJson.every(l => l.state === "none")).toBe(true);
 });
+```
+
+Avoid clearly unnecessary comments:
+
+**❌ Bad**
+
+```ts
+/* Whether the filter trigger should be displayed */
+showFilter: boolean;
+```
+
+**✅ Good**
+
+```ts
+showFilter: boolean;
 ```


### PR DESCRIPTION
### 📝 Description

Refine the `/comments` skill to try to reduce the number of comments.
- Be clearer about avoiding comments
- Mention JSDocs, because these are an exception to the rule
- Add an example to simple not include a comment

### ❓ Context

> I’ve noticed that Claude/Cursor have been adding a lot of comments recently (and most of them aren’t really relevant)
> For e.g:
> ```ts
> /** Whether the filter trigger should be displayed */
> showFilter: boolean;
> ```


_[Slack thread](https://ledger.slack.com/archives/C0A9U3M66UF/p1781022942482269)_
