### PR TITLE
[LWD] feat(desktop): add cryptos and stablecoins sections to search overlay

### DIFF
--- a/.changeset/famous-cars-camp.md
+++ b/.changeset/famous-cars-camp.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add Cryptos and Stablecoins suggestion sections to the global Search overlay. Both sections are sourced from DADA market data (shared single fetch, split in-memory by DADA stablecoin tickers), ranked by market cap and capped to a per-section limit, with loading skeletons and click-through to the asset detail / market list.

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchOverlayDefault.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchOverlayDefault.tsx
@@ -1,14 +1,37 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { StocksSectionView } from "LLD/features/Stocks/StocksSectionView";
+import { AssetSuggestionsSection } from "LLD/features/SearchAssets/AssetSuggestionsSection";
 import { useSearchOverlay } from "../SearchOverlayContext";
-import { STOCKS_SUGGESTION_LIMIT } from "../useAssetSearchBar";
+import {
+  CRYPTOS_SUGGESTION_LIMIT,
+  STABLECOINS_SUGGESTION_LIMIT,
+  STOCKS_SUGGESTION_LIMIT,
+} from "../useAssetSearchBar";
 
 export function SearchOverlayDefault() {
-  const { suggestions, navigateToAsset, navigateToStocksMarket } = useSearchOverlay();
+  const { t } = useTranslation();
+  const { suggestions, navigateToAsset, navigateToMarket, navigateToStocksMarket } =
+    useSearchOverlay();
 
   return (
     <div className="flex flex-col gap-24" data-testid="search-overlay-default">
-      {/* CryptoList section (LIVE-29945): cryptos + stablecoins */}
+      <AssetSuggestionsSection
+        {...suggestions.cryptos}
+        title={t("topBar.search.cryptos")}
+        testIdPrefix="cryptos"
+        limit={CRYPTOS_SUGGESTION_LIMIT}
+        navigateToAsset={navigateToAsset}
+        onSeeAll={navigateToMarket}
+      />
+      <AssetSuggestionsSection
+        {...suggestions.stablecoins}
+        title={t("topBar.search.stablecoins")}
+        testIdPrefix="stablecoins"
+        limit={STABLECOINS_SUGGESTION_LIMIT}
+        navigateToAsset={navigateToAsset}
+        onSeeAll={navigateToMarket}
+      />
       <StocksSectionView
         {...suggestions.stocks}
         limit={STOCKS_SUGGESTION_LIMIT}

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/types.ts
@@ -27,6 +27,7 @@ export type SearchResults = {
 export type SearchOverlayContextValue = {
   close: () => void;
   navigateToAsset: (currencyId: string) => void;
+  navigateToMarket: () => void;
   navigateToStocksMarket: () => void;
   suggestions: SearchSuggestions;
   results: SearchResults;

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useAssetSearchBar.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useAssetSearchBar.ts
@@ -1,11 +1,13 @@
 import { ChangeEvent, useCallback, useMemo, useState } from "react";
 import { useStocksSectionViewModel } from "LLD/features/Stocks/hooks/useStocksSectionViewModel";
-import { AssetSuggestionSection, SearchMode, SearchResults, SearchSuggestions } from "./types";
+import { useAssetSuggestionsViewModel } from "LLD/features/SearchAssets/hooks/useAssetSuggestionsViewModel";
+import { SearchMode, SearchResults, SearchSuggestions } from "./types";
 
-const EMPTY_SECTION: AssetSuggestionSection = { data: [], isLoading: false };
 const EMPTY_RESULTS: SearchResults = { data: [], isLoading: false };
 
 export const STOCKS_SUGGESTION_LIMIT = 20;
+export const CRYPTOS_SUGGESTION_LIMIT = 3;
+export const STABLECOINS_SUGGESTION_LIMIT = 2;
 
 export function useAssetSearchBar() {
   const [query, setQuery] = useState("");
@@ -23,10 +25,14 @@ export function useAssetSearchBar() {
   }, []);
 
   const stocks = useStocksSectionViewModel({ limit: STOCKS_SUGGESTION_LIMIT });
+  const { cryptos, stablecoins } = useAssetSuggestionsViewModel({
+    cryptosLimit: CRYPTOS_SUGGESTION_LIMIT,
+    stablecoinsLimit: STABLECOINS_SUGGESTION_LIMIT,
+  });
 
   const suggestions: SearchSuggestions = useMemo(
-    () => ({ cryptos: EMPTY_SECTION, stablecoins: EMPTY_SECTION, stocks }),
-    [stocks],
+    () => ({ cryptos, stablecoins, stocks }),
+    [cryptos, stablecoins, stocks],
   );
   const results = EMPTY_RESULTS;
 

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useSearchOverlayViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useSearchOverlayViewModel.ts
@@ -24,6 +24,13 @@ export function useSearchOverlayViewModel() {
     [navigate, shouldDisplayAggregatedAssets, close],
   );
 
+  const navigateToMarket = useCallback(() => {
+    setTrackingSource("Global Search");
+    dispatch(setMarketCategory("all"));
+    navigate("/market");
+    close();
+  }, [dispatch, navigate, close]);
+
   const navigateToStocksMarket = useCallback(() => {
     setTrackingSource("Global Search");
     dispatch(setMarketCategory("stocks"));
@@ -51,8 +58,16 @@ export function useSearchOverlayViewModel() {
   );
 
   const contextValue = useMemo<SearchOverlayContextValue>(
-    () => ({ close, navigateToAsset, navigateToStocksMarket, suggestions, results, mode }),
-    [close, navigateToAsset, navigateToStocksMarket, suggestions, results, mode],
+    () => ({
+      close,
+      navigateToAsset,
+      navigateToMarket,
+      navigateToStocksMarket,
+      suggestions,
+      results,
+      mode,
+    }),
+    [close, navigateToAsset, navigateToMarket, navigateToStocksMarket, suggestions, results, mode],
   );
 
   return { open: isOpen, onOpenChange, query, onChangeQuery, onKeyDown, mode, contextValue };

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/AssetSuggestionsSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/AssetSuggestionsSection.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { AssetSuggestionsSectionView } from "./AssetSuggestionsSectionView";
+import { useAssetSuggestionsSectionViewModel } from "./hooks/useAssetSuggestionsSectionViewModel";
+import { AssetSuggestionsSectionProps } from "./types";
+
+export function AssetSuggestionsSection(props: Readonly<AssetSuggestionsSectionProps>) {
+  const { locale, counterCurrency } = useAssetSuggestionsSectionViewModel();
+
+  return (
+    <AssetSuggestionsSectionView {...props} locale={locale} counterCurrency={counterCurrency} />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/AssetSuggestionsSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/AssetSuggestionsSectionView.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import {
+  Subheader,
+  SubheaderRow,
+  SubheaderTitle,
+  SubheaderShowMore,
+} from "@ledgerhq/lumen-ui-react";
+import { AssetSuggestionRow } from "./components/AssetSuggestionRow";
+import { AssetSuggestionsSkeleton } from "./components/AssetSuggestionsSkeleton";
+import { AssetSuggestionsSectionViewProps } from "./types";
+
+export function AssetSuggestionsSectionView({
+  data,
+  isLoading,
+  title,
+  limit,
+  testIdPrefix,
+  navigateToAsset,
+  onSeeAll,
+  locale,
+  counterCurrency,
+}: Readonly<AssetSuggestionsSectionViewProps>) {
+  // Hide empty sections (e.g. backend returned nothing) once loading is done.
+  if (!isLoading && data.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-8" data-testid={`${testIdPrefix}-section`}>
+      <Subheader>
+        <SubheaderRow
+          className="min-w-0 items-center gap-4"
+          onClick={onSeeAll}
+          data-testid={`${testIdPrefix}-see-all`}
+        >
+          <SubheaderTitle>{title}</SubheaderTitle>
+          <SubheaderShowMore />
+        </SubheaderRow>
+      </Subheader>
+      {isLoading ? (
+        <AssetSuggestionsSkeleton count={limit} testIdPrefix={testIdPrefix} />
+      ) : (
+        <div className="flex flex-col -mx-8" data-testid={`${testIdPrefix}-list`}>
+          {data.map(currency => (
+            <AssetSuggestionRow
+              key={currency.id}
+              currency={currency}
+              counterCurrency={counterCurrency}
+              locale={locale}
+              testIdPrefix={testIdPrefix}
+              onClick={navigateToAsset}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/__integrations__/SearchAssets.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/__integrations__/SearchAssets.integration.test.tsx
@@ -1,0 +1,216 @@
+import React from "react";
+import { render, screen, fireEvent } from "tests/testSetup";
+import { useMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
+import { useStablecoinTickers } from "@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers";
+import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { useAssetSuggestionsViewModel } from "../hooks/useAssetSuggestionsViewModel";
+import { AssetSuggestionsSection } from "../AssetSuggestionsSection";
+
+jest.mock("@ledgerhq/live-common/market/hooks/useMarketDataProvider");
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers");
+
+const mockedUseMarketData = jest.mocked(useMarketData);
+const mockedUseStablecoinTickers = jest.mocked(useStablecoinTickers);
+
+const CRYPTOS_LIMIT = 3;
+const STABLECOINS_LIMIT = 2;
+
+function buildCurrency(overrides: Partial<MarketCurrencyData>): MarketCurrencyData {
+  return {
+    id: "bitcoin",
+    ledgerIds: ["bitcoin"],
+    name: "Bitcoin",
+    ticker: "BTC",
+    price: 100,
+    marketcap: 1000,
+    marketcapRank: 1,
+    totalVolume: 0,
+    high24h: 0,
+    low24h: 0,
+    priceChangePercentage: { "1h": 0, "24h": 1.23, "7d": 0, "30d": 0, "6m": 0, "1y": 0 },
+    marketCapChangePercentage24h: 0,
+    circulatingSupply: 0,
+    ath: 0,
+    athDate: new Date(),
+    atl: 0,
+    atlDate: new Date(),
+    chartData: {} as MarketCurrencyData["chartData"],
+    ...overrides,
+  } as MarketCurrencyData;
+}
+
+const BTC = buildCurrency({
+  id: "bitcoin",
+  name: "Bitcoin",
+  ticker: "BTC",
+  ledgerIds: ["bitcoin"],
+});
+const ETH = buildCurrency({
+  id: "ethereum",
+  name: "Ethereum",
+  ticker: "ETH",
+  ledgerIds: ["ethereum"],
+});
+const USDT = buildCurrency({
+  id: "tether",
+  name: "Tether",
+  ticker: "USDT",
+  ledgerIds: ["ethereum/erc20/usd_tether__erc20_"],
+});
+
+function mockMarketData({
+  data = [],
+  isLoading = false,
+}: {
+  data?: MarketCurrencyData[];
+  isLoading?: boolean;
+}) {
+  mockedUseMarketData.mockReturnValue({
+    data,
+    isLoading,
+    isPending: isLoading,
+    isError: false,
+    isFetching: false,
+    cachedMetadataMap: new Map(),
+  } as unknown as ReturnType<typeof useMarketData>);
+}
+
+function mockStablecoinTickers({
+  tickers = [],
+  isLoading = false,
+}: {
+  tickers?: string[];
+  isLoading?: boolean;
+}) {
+  mockedUseStablecoinTickers.mockReturnValue({
+    tickers: new Set(tickers),
+    isLoading,
+    isError: false,
+  });
+}
+
+const navigateToAsset = jest.fn();
+const navigateToMarket = jest.fn();
+
+function Harness() {
+  const { cryptos, stablecoins } = useAssetSuggestionsViewModel({
+    cryptosLimit: CRYPTOS_LIMIT,
+    stablecoinsLimit: STABLECOINS_LIMIT,
+  });
+  return (
+    <>
+      <AssetSuggestionsSection
+        {...cryptos}
+        title="Cryptos"
+        testIdPrefix="cryptos"
+        limit={CRYPTOS_LIMIT}
+        navigateToAsset={navigateToAsset}
+        onSeeAll={navigateToMarket}
+      />
+      <AssetSuggestionsSection
+        {...stablecoins}
+        title="Stablecoins"
+        testIdPrefix="stablecoins"
+        limit={STABLECOINS_LIMIT}
+        navigateToAsset={navigateToAsset}
+        onSeeAll={navigateToMarket}
+      />
+    </>
+  );
+}
+
+describe("SearchAssets suggestion sections", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("shows cryptos and stablecoins skeletons simultaneously while loading", () => {
+    mockMarketData({ isLoading: true });
+    mockStablecoinTickers({ isLoading: true });
+
+    render(<Harness />);
+
+    expect(screen.getByTestId("cryptos-skeleton")).toBeVisible();
+    expect(screen.getByTestId("stablecoins-skeleton")).toBeVisible();
+  });
+
+  it("splits market data into cryptos and stablecoins via the DADA tickers", () => {
+    mockMarketData({ data: [BTC, USDT, ETH] });
+    mockStablecoinTickers({ tickers: ["USDT"] });
+
+    render(<Harness />);
+
+    expect(screen.getByTestId("cryptos-item-btc")).toBeVisible();
+    expect(screen.getByTestId("cryptos-item-eth")).toBeVisible();
+    expect(screen.getByTestId("stablecoins-item-usdt")).toBeVisible();
+    // A stablecoin must not leak into the cryptos list.
+    expect(screen.queryByTestId("cryptos-item-usdt")).not.toBeInTheDocument();
+  });
+
+  it("navigates to the asset detail when a row is clicked", () => {
+    mockMarketData({ data: [BTC] });
+    mockStablecoinTickers({ tickers: ["USDT"] });
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByTestId("cryptos-item-btc"));
+    expect(navigateToAsset).toHaveBeenCalledWith(BTC.id);
+  });
+
+  it("triggers the see-all handler from the section header", () => {
+    mockMarketData({ data: [BTC] });
+    mockStablecoinTickers({ tickers: ["USDT"] });
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByTestId("cryptos-see-all"));
+    expect(navigateToMarket).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides a section when it has no data", () => {
+    mockMarketData({ data: [BTC] });
+    mockStablecoinTickers({ tickers: ["USDT"] });
+
+    render(<Harness />);
+
+    expect(screen.getByTestId("cryptos-section")).toBeVisible();
+    // No stablecoins in the data → section is hidden.
+    expect(screen.queryByTestId("stablecoins-section")).not.toBeInTheDocument();
+  });
+
+  it("caps each section to the requested limit", () => {
+    const extraCryptos = Array.from({ length: 5 }, (_, i) =>
+      buildCurrency({
+        id: `coin-${i}`,
+        name: `Coin ${i}`,
+        ticker: `C${i}`,
+        ledgerIds: ["bitcoin"],
+      }),
+    );
+    mockMarketData({ data: extraCryptos });
+    mockStablecoinTickers({ tickers: [] });
+
+    render(<Harness />);
+
+    expect(screen.getByTestId("cryptos-item-c0")).toBeVisible();
+    expect(screen.getByTestId("cryptos-item-c2")).toBeVisible();
+    expect(screen.queryByTestId("cryptos-item-c3")).not.toBeInTheDocument();
+  });
+
+  it("caps cryptos to 3 and stablecoins to 2", () => {
+    const stablecoins = Array.from({ length: 4 }, (_, i) =>
+      buildCurrency({
+        id: `stable-${i}`,
+        name: `Stable ${i}`,
+        ticker: `S${i}`,
+        ledgerIds: ["ethereum"],
+      }),
+    );
+    mockMarketData({ data: stablecoins });
+    mockStablecoinTickers({ tickers: ["S0", "S1", "S2", "S3"] });
+
+    render(<Harness />);
+
+    expect(screen.getByTestId("stablecoins-item-s0")).toBeVisible();
+    expect(screen.getByTestId("stablecoins-item-s1")).toBeVisible();
+    expect(screen.queryByTestId("stablecoins-item-s2")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/components/AssetSuggestionRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/components/AssetSuggestionRow.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import {
+  ListItem,
+  ListItemContent,
+  ListItemLeading,
+  ListItemTitle,
+  ListItemTrailing,
+  Trend,
+} from "@ledgerhq/lumen-ui-react";
+import { MarketCurrencyData, KeysPriceChange } from "@ledgerhq/live-common/market/utils/types";
+import counterValueFormatter from "@ledgerhq/live-common/market/utils/countervalueFormatter";
+import { roundFiatPrice } from "@ledgerhq/live-currency-format";
+
+const ICON_SIZE = 24;
+
+type AssetSuggestionRowProps = {
+  currency: MarketCurrencyData;
+  counterCurrency: string;
+  locale: string;
+  testIdPrefix: string;
+  onClick: (currencyId: string) => void;
+};
+
+export function AssetSuggestionRow({
+  currency,
+  counterCurrency,
+  locale,
+  testIdPrefix,
+  onClick,
+}: Readonly<AssetSuggestionRowProps>) {
+  const priceChange = currency.priceChangePercentage[KeysPriceChange.day];
+
+  return (
+    <ListItem
+      density="compact"
+      className="cursor-pointer"
+      onClick={() => onClick(currency.id)}
+      aria-label={currency.name}
+      data-testid={`${testIdPrefix}-item-${currency.ticker.toLowerCase()}`}
+    >
+      <ListItemLeading>
+        {currency.ledgerIds?.length && currency.ticker ? (
+          <CryptoIcon ledgerId={currency.ledgerIds[0]} ticker={currency.ticker} size={ICON_SIZE} />
+        ) : (
+          <img width={ICON_SIZE} height={ICON_SIZE} src={currency.image} alt={currency.name} />
+        )}
+        <ListItemContent>
+          <ListItemTitle>{currency.name}</ListItemTitle>
+        </ListItemContent>
+      </ListItemLeading>
+      <ListItemTrailing>
+        <div className="flex items-center gap-8">
+          <ListItemTitle>
+            {counterValueFormatter({
+              value: roundFiatPrice(currency.price ?? 0),
+              currency: counterCurrency,
+              locale,
+            })}
+          </ListItemTitle>
+          {priceChange != null ? <Trend value={priceChange} size="md" /> : null}
+        </div>
+      </ListItemTrailing>
+    </ListItem>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/components/AssetSuggestionsSkeleton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/components/AssetSuggestionsSkeleton.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Skeleton } from "@ledgerhq/lumen-ui-react";
+
+type AssetSuggestionsSkeletonProps = {
+  count: number;
+  testIdPrefix: string;
+};
+
+export function AssetSuggestionsSkeleton({
+  count,
+  testIdPrefix,
+}: Readonly<AssetSuggestionsSkeletonProps>) {
+  return (
+    <div className="flex flex-col gap-8" data-testid={`${testIdPrefix}-skeleton`} aria-hidden>
+      {Array.from({ length: count }, (_, index) => `${testIdPrefix}-skeleton-${index}`).map(key => (
+        <Skeleton key={key} component="list-item" />
+      ))}
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSuggestionsSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSuggestionsSectionViewModel.ts
@@ -1,0 +1,9 @@
+import { useSelector } from "LLD/hooks/redux";
+import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
+
+export function useAssetSuggestionsSectionViewModel() {
+  const locale = useSelector(localeSelector);
+  const counterCurrency = useSelector(counterValueCurrencySelector).ticker;
+
+  return { locale, counterCurrency };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSuggestionsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSuggestionsViewModel.ts
@@ -1,0 +1,55 @@
+import { useMemo } from "react";
+import { useMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
+import { useStablecoinTickers } from "@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers";
+import { MarketCurrencyData, Order } from "@ledgerhq/live-common/market/utils/types";
+import { useSelector } from "LLD/hooks/redux";
+import { marketParamsSelector } from "~/renderer/reducers/market";
+import { AssetSuggestionsViewModelResult } from "../types";
+
+const MARKET_FETCH_LIMIT = 50;
+
+export function useAssetSuggestionsViewModel({
+  cryptosLimit,
+  stablecoinsLimit,
+}: {
+  cryptosLimit: number;
+  stablecoinsLimit: number;
+}): AssetSuggestionsViewModelResult {
+  const { counterCurrency } = useSelector(marketParamsSelector);
+
+  const market = useMarketData({
+    counterCurrency,
+    range: "24h",
+    order: Order.MarketCapDesc,
+    page: 1,
+    limit: MARKET_FETCH_LIMIT,
+  });
+
+  const { tickers, isLoading: tickersLoading } = useStablecoinTickers("lld", __APP_VERSION__);
+
+  const isLoading = market.isLoading || tickersLoading;
+
+  const { cryptos, stablecoins } = useMemo(() => {
+    const cryptosData: MarketCurrencyData[] = [];
+    const stablecoinsData: MarketCurrencyData[] = [];
+
+    for (const currency of market.data) {
+      const isStablecoin = tickers.has(currency.ticker.toUpperCase());
+      const [bucket, bucketLimit] = isStablecoin
+        ? [stablecoinsData, stablecoinsLimit]
+        : [cryptosData, cryptosLimit];
+      if (bucket.length < bucketLimit) bucket.push(currency);
+      if (cryptosData.length >= cryptosLimit && stablecoinsData.length >= stablecoinsLimit) break;
+    }
+
+    return { cryptos: cryptosData, stablecoins: stablecoinsData };
+  }, [market.data, tickers, cryptosLimit, stablecoinsLimit]);
+
+  return useMemo(
+    () => ({
+      cryptos: { data: cryptos, isLoading },
+      stablecoins: { data: stablecoins, isLoading },
+    }),
+    [cryptos, stablecoins, isLoading],
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/types.ts
@@ -1,0 +1,26 @@
+import { AssetSuggestionSection } from "LLD/components/TopBar/components/TopBarSearch/SearchOverlay/types";
+
+export type AssetSuggestionsViewModelResult = {
+  /** Top cryptos (excluding stablecoins) ranked by market cap, capped to the limit. */
+  cryptos: AssetSuggestionSection;
+  /** Top stablecoins ranked by market cap, capped to the limit. */
+  stablecoins: AssetSuggestionSection;
+};
+
+export type AssetSuggestionsSectionProps = AssetSuggestionSection & {
+  /** Section header label. */
+  title: string;
+  /** Number of skeleton rows rendered while loading. */
+  limit: number;
+  /** Disambiguates test ids and skeleton keys ("cryptos" | "stablecoins"). */
+  testIdPrefix: string;
+  /** Redirects to the asset detail page for the given market id. */
+  navigateToAsset: (currencyId: string) => void;
+  /** Lands on the market list. */
+  onSeeAll: () => void;
+};
+
+export type AssetSuggestionsSectionViewProps = AssetSuggestionsSectionProps & {
+  locale: string;
+  counterCurrency: string;
+};

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8830,6 +8830,8 @@
     "searchPlaceholder": "Search assets",
     "search": {
       "noResults": "No results for \"{{query}}\"",
+      "cryptos": "Cryptos",
+      "stablecoins": "Stablecoins",
       "stocks": "Stocks"
     },
     "history": {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Cryptos / Stablecoins suggestion sections in the Search overlay (market-cap order, per-section limit, stablecoin split)
  - Click-through navigation: suggestion row → asset/market detail, "See all" → market list

### 📝 Description

The global Search overlay only surfaced a Stocks section. Users had no entry point to discover top cryptos and stablecoins directly from Search.

This PR adds two suggestion sections — **Cryptos** and **Stablecoins** — to the Search overlay. Both are sourced from a single shared DADA market-data fetch, split in-memory by DADA stablecoin tickers, ranked by market cap and capped to a per-section limit. Each row shows the asset and its DADA price, with loading skeletons while data resolves and click-through to the asset detail page (or "See all" to the market list).

### 📸 Screenshots

https://github.com/user-attachments/assets/0d290d28-30a7-4bc4-af4e-84838bcd46b5



### ❓ Context

- **JIRA or GitHub link**: [LIVE-29945](https://ledgerhq.atlassian.net/browse/LIVE-29945)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29945]: https://ledgerhq.atlassian.net/browse/LIVE-29945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ