### PR TITLE
[LWM] test(mobile): market banner filter tracking

### DIFF
--- a/.changeset/lwm-market-banner-filter-tracking-tests.md
+++ b/.changeset/lwm-market-banner-filter-tracking-tests.md
@@ -1,4 +1,5 @@
 ---
+"live-mobile": patch
 ---
 
-Add unit tests covering the market banner filter tracking event (`change_sort_market_banner`): it fires with the correct `sort` for each of the four options and is not fired when reselecting the already active option. Test-only — the tracking itself shipped with the selection drawer.
+Add unit tests covering the market banner filter tracking event (`change_sort_market_banner`): it fires with the correct `sort` for each of the four options and is not fired when reselecting the already active option.

--- a/.changeset/lwm-market-banner-filter-tracking-tests.md
+++ b/.changeset/lwm-market-banner-filter-tracking-tests.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add unit tests covering the market banner filter tracking event (`change_sort_market_banner`): it fires with the correct `sort` for each of the four options and is not fired when reselecting the already active option. Test-only — the tracking itself shipped with the selection drawer.

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/hooks/__tests__/useMarketBannerFilter.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/hooks/__tests__/useMarketBannerFilter.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from "@tests/test-renderer";
 import { track } from "~/analytics";
-import type { State } from "~/reducers/types";
+import type { MarketBannerRanking, State } from "~/reducers/types";
 import { useMarketBannerFilter } from "../useMarketBannerFilter";
 
 jest.mock("~/analytics", () => ({ track: jest.fn() }));
@@ -9,6 +9,13 @@ const withStarred = (starredMarketCoins: string[]) => (state: State) => ({
   ...state,
   settings: { ...state.settings, starredMarketCoins },
 });
+
+const withRanking = (ranking: MarketBannerRanking) => (state: State) => ({
+  ...state,
+  marketBanner: { ...state.marketBanner, ranking },
+});
+
+const ALL_RANKINGS: MarketBannerRanking[] = ["trending", "gainers", "losers", "favorites"];
 
 describe("useMarketBannerFilter", () => {
   beforeEach(() => {
@@ -75,5 +82,33 @@ describe("useMarketBannerFilter", () => {
     act(() => result.current.onSelect("trending"));
 
     expect(track).not.toHaveBeenCalledWith("change_sort_market_banner", expect.anything());
+  });
+
+  describe("change_sort_market_banner tracking", () => {
+    it.each(ALL_RANKINGS)(
+      "fires the event with sort=%s on a genuine change to that option",
+      ranking => {
+        // Start from a different ranking so selecting `ranking` is an actual change.
+        const initialRanking: MarketBannerRanking = ranking === "trending" ? "gainers" : "trending";
+        const { result } = renderHook(() => useMarketBannerFilter(), {
+          overrideInitialState: withRanking(initialRanking),
+        });
+
+        act(() => result.current.onSelect(ranking));
+
+        expect(track).toHaveBeenCalledTimes(1);
+        expect(track).toHaveBeenCalledWith("change_sort_market_banner", { sort: ranking });
+      },
+    );
+
+    it.each(ALL_RANKINGS)("does not fire when reselecting the active %s option", ranking => {
+      const { result } = renderHook(() => useMarketBannerFilter(), {
+        overrideInitialState: withRanking(ranking),
+      });
+
+      act(() => result.current.onSelect(ranking));
+
+      expect(track).not.toHaveBeenCalledWith("change_sort_market_banner", expect.anything());
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/hooks/__tests__/useMarketBannerFilter.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/hooks/__tests__/useMarketBannerFilter.test.ts
@@ -12,7 +12,7 @@ const withStarred = (starredMarketCoins: string[]) => (state: State) => ({
 
 const withRanking = (ranking: MarketBannerRanking) => (state: State) => ({
   ...state,
-  marketBanner: { ...state.marketBanner, ranking },
+  marketBanner: { ranking },
 });
 
 const ALL_RANKINGS: MarketBannerRanking[] = ["trending", "gainers", "losers", "favorites"];
@@ -91,7 +91,11 @@ describe("useMarketBannerFilter", () => {
         // Start from a different ranking so selecting `ranking` is an actual change.
         const initialRanking: MarketBannerRanking = ranking === "trending" ? "gainers" : "trending";
         const { result } = renderHook(() => useMarketBannerFilter(), {
-          overrideInitialState: withRanking(initialRanking),
+          // Favorites is only selectable with at least one starred asset, so seed one.
+          overrideInitialState: state =>
+            withRanking(initialRanking)(
+              ranking === "favorites" ? withStarred(["bitcoin"])(state) : state,
+            ),
         });
 
         act(() => result.current.onSelect(ranking));
@@ -103,7 +107,8 @@ describe("useMarketBannerFilter", () => {
 
     it.each(ALL_RANKINGS)("does not fire when reselecting the active %s option", ranking => {
       const { result } = renderHook(() => useMarketBannerFilter(), {
-        overrideInitialState: withRanking(ranking),
+        overrideInitialState: state =>
+          withRanking(ranking)(ranking === "favorites" ? withStarred(["bitcoin"])(state) : state),
       });
 
       act(() => result.current.onSelect(ranking));


### PR DESCRIPTION
> 📚 **Stacked PR** — based on [#18378](https://github.com/LedgerHQ/ledger-live/pull/18378) (selection drawer + data wiring), which is itself based on [#18358](https://github.com/LedgerHQ/ledger-live/pull/18358). Review/merge those first; the base retargets automatically as they land.

### ✅ Checklist

- [x] `npx changeset` was attached. _(empty — test-only, no version bump)_
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Test-only. No runtime behaviour change.

### 📝 Description

[LIVE-30021](https://ledgerhq.atlassian.net/browse/LIVE-30021) — the `change_sort_market_banner` tracking itself shipped with the selection drawer ([LIVE-30019](https://ledgerhq.atlassian.net/browse/LIVE-30019) in #18378). This PR adds the dedicated **test coverage** the ticket asks for:

- `it.each` over the four options (`trending` / `gainers` / `losers` / `favorites`): selecting an option on a genuine change fires `change_sort_market_banner` exactly once with the correct `sort`.
- `it.each` over the four options: reselecting the already active option fires **no** event (no duplicate on same-value selection).

These complement the existing end-to-end drawer-selection test in #18378.

> **Note:** the `sort` value is `favorites` (not `starred` as written in the Jira table) — the slice was aligned to ledger-live-desktop's `MarketBannerRanking` naming.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30021](https://ledgerhq.atlassian.net/browse/LIVE-30021)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-30021]: https://ledgerhq.atlassian.net/browse/LIVE-30021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-30019]: https://ledgerhq.atlassian.net/browse/LIVE-30019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-30021]: https://ledgerhq.atlassian.net/browse/LIVE-30021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ