### PR TITLE
[LWM] feat(lwm): remove bottomsheet from flow wizard api to implement DIE

### DIFF
--- a/.changeset/friendly-jeans-cheer.md
+++ b/.changeset/friendly-jeans-cheer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat(lwm): update flow wizard removing bottomsheet from api - die will manage it itself

--- a/apps/ledger-live-mobile/src/mvvm/features/FlowWizard/FlowStackNavigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FlowWizard/FlowStackNavigator.tsx
@@ -21,7 +21,11 @@ import type {
 import type { AddAccountsNavigatorParamList } from "~/components/RootNavigator/types/AddAccountsNavigator";
 
 import type { FlowStep } from "@ledgerhq/live-common/flows/wizard/types";
-import type { FlowStackNavigatorProps, ReactNativeFlowStepConfig } from "./types";
+import type {
+  FlowStackNavigatorProps,
+  ReactNativeFlowScreenPresentation,
+  ReactNativeFlowStepConfig,
+} from "./types";
 
 type NavigationProps = BaseComposite<
   StackNavigatorProps<AddAccountsNavigatorParamList, NavigatorName.AddAccounts>
@@ -29,7 +33,7 @@ type NavigationProps = BaseComposite<
 
 const Stack = createNativeStackNavigator();
 
-const bottomSheetScreenOptions: NativeStackNavigationOptions = {
+const transparentModalScreenOptions: NativeStackNavigationOptions = {
   presentation: "transparentModal",
   animation: "none",
   headerShown: false,
@@ -42,16 +46,16 @@ const bottomSheetScreenOptions: NativeStackNavigationOptions = {
 export function getFlowStackScreenOptions({
   defaultOptions,
   customOptions,
-  isBottomSheet,
+  screenPresentation,
 }: Readonly<{
   defaultOptions: NativeStackNavigationOptions;
   customOptions?: NativeStackNavigationOptions;
-  isBottomSheet?: boolean;
+  screenPresentation?: ReactNativeFlowScreenPresentation;
 }>): NativeStackNavigationOptions {
   return {
     ...defaultOptions,
     ...customOptions,
-    ...(isBottomSheet === true ? bottomSheetScreenOptions : {}),
+    ...(screenPresentation === "transparentModal" ? transparentModalScreenOptions : {}),
   };
 }
 
@@ -163,7 +167,7 @@ export function FlowStackNavigator<
         const stepScreenOptions = getFlowStackScreenOptions({
           defaultOptions,
           customOptions,
-          isBottomSheet: stepConfig?.bottomSheet,
+          screenPresentation: stepConfig?.screenPresentation,
         });
 
         // Generate initial params

--- a/apps/ledger-live-mobile/src/mvvm/features/FlowWizard/__tests__/FlowStackNavigator.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FlowWizard/__tests__/FlowStackNavigator.test.tsx
@@ -119,7 +119,7 @@ describe("FlowStackNavigator", () => {
     expect(screen.getByText("Step 1")).toBeOnTheScreen();
   });
 
-  it("should apply transparent modal options to bottom sheet steps", () => {
+  it("should apply transparent modal options when requested by the step config", () => {
     const options = getFlowStackScreenOptions({
       defaultOptions: {
         title: "Default title",
@@ -127,7 +127,7 @@ describe("FlowStackNavigator", () => {
       customOptions: {
         title: "Custom title",
       },
-      isBottomSheet: true,
+      screenPresentation: "transparentModal",
     });
 
     expect(options).toEqual(

--- a/apps/ledger-live-mobile/src/mvvm/features/FlowWizard/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/FlowWizard/types.ts
@@ -1,5 +1,4 @@
 import type { NativeStackNavigationOptions } from "@react-navigation/native-stack";
-import type { NavigationProp, ParamListBase } from "@react-navigation/native";
 import type {
   FlowStep,
   FlowStepConfig,
@@ -9,16 +8,12 @@ import type {
 
 type ScreenComponentFunction = (props: Record<string, never>) => React.JSX.Element | null;
 
-export type ReactNativeFlowBottomSheetCloseParams = Readonly<{
-  navigation: NavigationProp<ParamListBase>;
-  close?: () => void;
-}>;
+export type ReactNativeFlowScreenPresentation = "default" | "transparentModal";
 
 export type ReactNativeFlowStepConfig<TStep extends FlowStep = FlowStep> = FlowStepConfig<TStep> &
   Readonly<{
     screenName?: string;
-    bottomSheet?: boolean;
-    onBottomSheetClose?: (params: ReactNativeFlowBottomSheetCloseParams) => void;
+    screenPresentation?: ReactNativeFlowScreenPresentation;
     screenOptions?: NativeStackNavigationOptions;
     initialParams?: Record<string, unknown>;
     listeners?: Record<string, unknown>;

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/SendFlowLayoutView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/SendFlowLayoutView.tsx
@@ -1,24 +1,12 @@
-import React, { useCallback } from "react";
+import React from "react";
 import { View } from "react-native";
-import { useNavigation } from "@react-navigation/native";
-import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
-import { BottomSheetHeader, BottomSheetView } from "@ledgerhq/lumen-ui-rnative";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
-import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
 
 import type { SendFlowLayoutProps } from "./types";
 import { SendHeader } from "./SendHeader";
-import { useSendFlowActions } from "../context/SendFlowContext";
-import { useCurrentSendFlowStep } from "../hooks/useCurrentSendFlowStep";
-import type { SendFlowNavigationProp } from "../types";
 
 export function SendFlowLayoutView({ headerRight, headerContent, children }: SendFlowLayoutProps) {
-  const navigation = useNavigation<SendFlowNavigationProp>();
-  const { bottom: bottomInset } = useSafeAreaInsets();
-  const { close } = useSendFlowActions();
-  const [, currentStepConfig] = useCurrentSendFlowStep();
-  const isBottomSheet = currentStepConfig?.bottomSheet === true;
-
   const styles = useStyleSheet(
     theme => ({
       container: {
@@ -34,57 +22,9 @@ export function SendFlowLayoutView({ headerRight, headerContent, children }: Sen
         paddingHorizontal: theme.spacings.s16,
         flex: 1,
       },
-      bottomSheetContainer: {
-        flex: 1,
-      },
-      bottomSheetContent: {
-        flex: 1,
-        paddingBottom: bottomInset + theme.spacings.s24,
-      },
-      bottomSheetBodyContent: {
-        paddingHorizontal: theme.spacings.s16,
-        paddingBottom: theme.spacings.s24,
-        flex: 1,
-      },
     }),
-    [bottomInset],
+    [],
   );
-
-  const handleBottomSheetClose = useCallback(() => {
-    if (!navigation.isFocused()) {
-      return;
-    }
-
-    if (currentStepConfig?.onBottomSheetClose) {
-      currentStepConfig.onBottomSheetClose({ navigation, close });
-      return;
-    }
-
-    if (navigation.canGoBack()) {
-      navigation.goBack();
-      return;
-    }
-
-    close();
-  }, [close, currentStepConfig, navigation]);
-
-  if (isBottomSheet) {
-    return (
-      <View style={styles.bottomSheetContainer}>
-        <QueuedDrawerBottomSheet
-          isRequestingToBeOpened
-          snapPoints="medium"
-          onClose={handleBottomSheetClose}
-        >
-          <BottomSheetView style={styles.bottomSheetContent}>
-            <BottomSheetHeader density="compact" />
-            {headerContent ? <View style={styles.headerContent}>{headerContent}</View> : null}
-            <View style={styles.bottomSheetBodyContent}>{children}</View>
-          </BottomSheetView>
-        </QueuedDrawerBottomSheet>
-      </View>
-    );
-  }
 
   return (
     <SafeAreaView style={styles.container} edges={["top", "bottom"]}>

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/SendFlowLayoutView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/SendFlowLayoutView.test.tsx
@@ -1,21 +1,9 @@
 import React from "react";
 import { Text, View } from "react-native";
 import type { StyleProp, ViewStyle } from "react-native";
-import { useNavigation } from "@react-navigation/native";
-import { fireEvent, render, screen } from "@testing-library/react-native";
-import { SEND_FLOW_STEP } from "@ledgerhq/live-common/flows/send/types";
+import { render, screen } from "@testing-library/react-native";
 
 import { SendFlowLayoutView } from "../SendFlowLayoutView";
-import { useSendFlowActions } from "../../context/SendFlowContext";
-import { useCurrentSendFlowStep } from "../../hooks/useCurrentSendFlowStep";
-import type { SendStepConfig } from "../../types";
-
-const mockQueuedDrawerBottomSheet = jest.fn();
-
-jest.mock("@react-navigation/native", () => ({
-  ...jest.requireActual("@react-navigation/native"),
-  useNavigation: jest.fn(),
-}));
 
 jest.mock("react-native-safe-area-context", () => {
   const RN = jest.requireActual<typeof import("react-native")>("react-native");
@@ -38,22 +26,8 @@ jest.mock("react-native-safe-area-context", () => {
 });
 
 jest.mock("@ledgerhq/lumen-ui-rnative", () => {
-  const RN = jest.requireActual<typeof import("react-native")>("react-native");
-
   return {
     BottomSheetModalProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-    BottomSheetHeader: () => <RN.View testID="bottom-sheet-header" />,
-    BottomSheetView: ({
-      children,
-      style,
-    }: {
-      children: React.ReactNode;
-      style?: StyleProp<ViewStyle>;
-    }) => (
-      <RN.View testID="bottom-sheet-view" style={style}>
-        {children}
-      </RN.View>
-    ),
   };
 });
 
@@ -80,178 +54,30 @@ jest.mock("@ledgerhq/lumen-ui-rnative/styles", () => ({
     }),
 }));
 
-jest.mock("LLM/components/QueuedDrawer/QueuedDrawerBottomSheet", () => {
-  const RN = jest.requireActual<typeof import("react-native")>("react-native");
-
-  return function MockQueuedDrawerBottomSheet({
-    children,
-    isRequestingToBeOpened,
-    onClose,
-    snapPoints,
-  }: {
-    children: React.ReactNode;
-    isRequestingToBeOpened?: boolean;
-    onClose?: () => void;
-    snapPoints?: string;
-  }) {
-    mockQueuedDrawerBottomSheet({ isRequestingToBeOpened, onClose, snapPoints });
-
-    if (!isRequestingToBeOpened) return null;
-
-    return (
-      <RN.View testID="queued-drawer-bottom-sheet">
-        <RN.Pressable testID="queued-drawer-close" onPress={onClose}>
-          <RN.Text>Close</RN.Text>
-        </RN.Pressable>
-        {children}
-      </RN.View>
-    );
-  };
-});
-
-jest.mock("../../context/SendFlowContext", () => ({
-  useSendFlowActions: jest.fn(),
-}));
-
-jest.mock("../../hooks/useCurrentSendFlowStep", () => ({
-  useCurrentSendFlowStep: jest.fn(),
-}));
-
-const mockClose = jest.fn();
-const mockNavigation = {
-  isFocused: jest.fn(() => true),
-  canGoBack: jest.fn(),
-  goBack: jest.fn(),
-};
-
-const bottomSheetStepConfig: SendStepConfig = {
-  id: SEND_FLOW_STEP.SIGNATURE,
-  canGoBack: false,
-  bottomSheet: true,
-};
-
-function mockCurrentStepConfig(stepConfig: SendStepConfig = bottomSheetStepConfig) {
-  jest.mocked(useCurrentSendFlowStep).mockReturnValue([SEND_FLOW_STEP.SIGNATURE, stepConfig]);
-}
-
-function mockSendFlowActions(): ReturnType<typeof useSendFlowActions> {
-  return {
-    transaction: {
-      setTransaction: jest.fn(),
-      updateTransaction: jest.fn(),
-      setRecipient: jest.fn(),
-      setAccount: jest.fn(),
-    },
-    operation: {
-      onOperationBroadcasted: jest.fn(),
-      onTransactionError: jest.fn(),
-      onSigned: jest.fn(),
-      onRetry: jest.fn(),
-    },
-    status: {
-      setStatus: jest.fn(),
-      setError: jest.fn(),
-      setSuccess: jest.fn(),
-      resetStatus: jest.fn(),
-    },
-    close: mockClose,
-    setAccountAndNavigate: jest.fn(),
-    setRecipientSearchValue: jest.fn(),
-    clearRecipientSearch: jest.fn(),
-  };
-}
-
 describe("SendFlowLayoutView", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.mocked(useNavigation).mockReturnValue(mockNavigation);
-    jest.mocked(useSendFlowActions).mockReturnValue(mockSendFlowActions());
-    mockCurrentStepConfig();
   });
 
-  it("should render bottom sheet steps in a queued drawer with safe area padding", () => {
-    render(
-      <SendFlowLayoutView>
-        <Text>Signature step</Text>
-      </SendFlowLayoutView>,
-    );
-
-    expect(screen.getByTestId("queued-drawer-bottom-sheet")).toBeOnTheScreen();
-    expect(mockQueuedDrawerBottomSheet).toHaveBeenCalledWith(
-      expect.objectContaining({
-        isRequestingToBeOpened: true,
-        snapPoints: "medium",
-      }),
-    );
-    expect(screen.getByTestId("bottom-sheet-view")).toHaveStyle({ paddingBottom: 34 });
-  });
-
-  it("should go back by default when closing a bottom sheet step without custom close handler", () => {
-    mockNavigation.canGoBack.mockReturnValue(true);
-    render(
-      <SendFlowLayoutView>
-        <Text>Signature step</Text>
-      </SendFlowLayoutView>,
-    );
-
-    fireEvent.press(screen.getByTestId("queued-drawer-close"));
-
-    expect(mockNavigation.goBack).toHaveBeenCalledTimes(1);
-    expect(mockClose).not.toHaveBeenCalled();
-  });
-
-  it("should close the flow by default when the bottom sheet step cannot go back", () => {
-    mockNavigation.canGoBack.mockReturnValue(false);
-    render(
-      <SendFlowLayoutView>
-        <Text>Signature step</Text>
-      </SendFlowLayoutView>,
-    );
-
-    fireEvent.press(screen.getByTestId("queued-drawer-close"));
-
-    expect(mockNavigation.goBack).not.toHaveBeenCalled();
-    expect(mockClose).toHaveBeenCalledTimes(1);
-  });
-
-  it("should delegate bottom sheet close to the current step config when provided", () => {
-    const onBottomSheetClose = jest.fn();
-    mockCurrentStepConfig({
-      ...bottomSheetStepConfig,
-      onBottomSheetClose,
-    });
-    mockNavigation.canGoBack.mockReturnValue(true);
-    render(
-      <SendFlowLayoutView>
-        <Text>Signature step</Text>
-      </SendFlowLayoutView>,
-    );
-
-    fireEvent.press(screen.getByTestId("queued-drawer-close"));
-
-    expect(onBottomSheetClose).toHaveBeenCalledWith({
-      navigation: mockNavigation,
-      close: mockClose,
-    });
-    expect(mockNavigation.goBack).not.toHaveBeenCalled();
-    expect(mockClose).not.toHaveBeenCalled();
-  });
-
-  it("should render the page layout for non bottom sheet steps", () => {
-    mockCurrentStepConfig({
-      id: SEND_FLOW_STEP.AMOUNT,
-      canGoBack: true,
-      bottomSheet: false,
-    });
-
+  it("should render the page layout with header content and body", () => {
     render(
       <SendFlowLayoutView headerContent={<Text>Header content</Text>}>
         <View testID="page-content" />
       </SendFlowLayoutView>,
     );
 
-    expect(screen.queryByTestId("queued-drawer-bottom-sheet")).toBeNull();
+    expect(screen.getByTestId("send-header")).toBeOnTheScreen();
     expect(screen.getByText("Header content")).toBeOnTheScreen();
     expect(screen.getByTestId("page-content")).toBeOnTheScreen();
+  });
+
+  it("should render headerRight inside the send header", () => {
+    render(
+      <SendFlowLayoutView headerRight={<Text>Right action</Text>}>
+        <View testID="page-content" />
+      </SendFlowLayoutView>,
+    );
+
+    expect(screen.getByText("Right action")).toBeOnTheScreen();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/constants.ts
@@ -72,18 +72,11 @@ export const SEND_STEP_CONFIGS: Record<SendFlowStep, SendStepConfig> = {
     showTitle: false,
     showHeaderRight: false,
     screenName: ScreenName.SendFlowSignature,
-    bottomSheet: true,
-    onBottomSheetClose: ({ navigation, close }) => {
-      if (navigation.canGoBack()) {
-        navigation.goBack();
-        return;
-      }
-      close?.();
-    },
+    screenPresentation: "transparentModal",
     screenOptions: {
       ...TransparentHeaderNavigationOptions,
-      title: "",
       gestureEnabled: false,
+      title: "",
     },
   },
   [SEND_FLOW_STEP.CONFIRMATION]: {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Removing the bottomsheet props from the FlowWizard API since the DIE is already in a Bottomsheet (avoiding imbrications)
Having a "transparentModal" instead to have a screen "on top of another" (in the logic of the new send flow architecture)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-31802)**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
