### PR TITLE
[LWM] feat(mobile): gate Global Search top bar icon behind asset discoverability [LIVE-30041]

### DIFF
--- a/.changeset/global-search-topbar-icon.md
+++ b/.changeset/global-search-topbar-icon.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add a Global Search entry point to the Portfolio top bar. The search icon is gated behind the `assetDiscoverability` Wallet 4.0 param (`shouldDisplayAssetDiscoverability`) and navigates to the upcoming Global Search screen.

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -679,6 +679,7 @@ export enum NavigatorName {
   Swap = "SwapNavigator",
   SwapSubScreens = "SwapSubScreensNavigator",
   Perps = "PerpsNavigator",
+  GlobalSearch = "GlobalSearchNavigator",
   Earn = "EarnNavigator",
   Borrow = "BorrowNavigator",
   Fees = "FeesNavigator",

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/TopBarView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/TopBarView/index.tsx
@@ -8,6 +8,7 @@ import {
   Settings,
   Warning,
   Clock,
+  Search,
 } from "@ledgerhq/lumen-ui-rnative/symbols";
 import {
   CustomTopBar,
@@ -33,6 +34,8 @@ export function TopBarView({
   onMyWalletPress,
   shouldDisplayMyWallet,
   shouldDisplayOperationsList,
+  shouldDisplayAssetDiscoverability,
+  onSearchPress,
   onDiscoverPress,
   onNotificationsPress,
   onSettingsPress,
@@ -69,6 +72,14 @@ export function TopBarView({
     callback: onDiscoverPress,
     testID: "topbar-discover",
     accessibilityLabel: "Discover",
+  };
+
+  const searchIcon: TopBarActionIcon = {
+    id: "search",
+    icon: Search,
+    callback: onSearchPress,
+    testID: "topbar-search",
+    accessibilityLabel: "Search",
   };
 
   const notificationsIcon: TopBarActionIcon = {
@@ -124,6 +135,7 @@ export function TopBarView({
     filterIcons([
       displayMyLedgerIconLeading && myLedgerAction,
       displayDiscoverIconLeading && discoverIcon,
+      shouldDisplayAssetDiscoverability && searchIcon,
     ]);
 
   const displaySyncStatusIcon = hasAccounts && isSyncError;

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/__integrations__/TopBar.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/__integrations__/TopBar.integration.test.tsx
@@ -102,6 +102,29 @@ describe("TopBar navigation", () => {
     });
   });
 
+  it("should not render the search icon when asset discoverability is disabled", () => {
+    const { queryByTestId } = renderWithReactQuery(<TopBar />);
+
+    expect(queryByTestId("topbar-search")).toBeNull();
+  });
+
+  it("should navigate to GlobalSearch when the search icon is pressed and asset discoverability is enabled", async () => {
+    const { user, getByTestId } = renderWithReactQuery(<TopBar />, {
+      overrideInitialState: withFlagOverrides({
+        lwmWallet40: { enabled: true, params: { assetDiscoverability: true } },
+      }),
+    });
+
+    await user.press(getByTestId("topbar-search"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(expectedNavigationParams.search.name);
+
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "Search",
+      page: ScreenName.Portfolio,
+    });
+  });
+
   it("should navigate to operations list with expected params when transaction history button is pressed", async () => {
     const { user, getByTestId } = renderWithReactQuery(<TopBar />, {
       overrideInitialState: withFlagOverrides({

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/TopBarView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/TopBarView.test.tsx
@@ -13,6 +13,7 @@ jest.mock("@ledgerhq/lumen-ui-rnative/symbols", () => {
     Settings: makeIcon("icon-settings"),
     Warning: makeIcon("icon-warning"),
     Clock: makeIcon("icon-clock"),
+    Search: makeIcon("icon-search"),
     Nano: makeIcon("device-icon-nano"),
     Flex: makeIcon("device-icon-flex"),
     Apex: makeIcon("device-icon-apex"),
@@ -29,6 +30,7 @@ describe("TopBarView", () => {
   const onMyLedgerPress = jest.fn();
   const onMyWalletPress = jest.fn();
   const onDiscoverPress = jest.fn();
+  const onSearchPress = jest.fn();
   const onNotificationsPress = jest.fn();
   const onSettingsPress = jest.fn();
   const onTransactionHistoryPress = jest.fn();
@@ -42,6 +44,8 @@ describe("TopBarView", () => {
     onMyWalletPress,
     shouldDisplayMyWallet: false,
     shouldDisplayOperationsList: false,
+    shouldDisplayAssetDiscoverability: false,
+    onSearchPress,
     onDiscoverPress,
     onNotificationsPress,
     onSettingsPress,
@@ -79,6 +83,25 @@ describe("TopBarView", () => {
     expect(onNotificationsPress).toHaveBeenCalledTimes(1);
     expect(onSettingsPress).toHaveBeenCalledTimes(1);
     expect(onTransactionHistoryPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not render the search icon when asset discoverability is disabled", () => {
+    const { queryByTestId } = renderWithReactQuery(
+      <TopBarView {...defaultProps} shouldDisplayAssetDiscoverability={false} />,
+    );
+    expect(queryByTestId("topbar-search")).toBeNull();
+  });
+
+  it("should render the search icon and call onSearchPress when asset discoverability is enabled", async () => {
+    const { user, getByTestId } = renderWithReactQuery(
+      <TopBarView {...defaultProps} shouldDisplayAssetDiscoverability />,
+    );
+
+    const searchIcon = getByTestId("topbar-search");
+    expect(searchIcon).toBeVisible();
+
+    await user.press(searchIcon);
+    expect(onSearchPress).toHaveBeenCalledTimes(1);
   });
 
   it("should not render transaction history icon when operations list is disabled", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/useTopBarViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/useTopBarViewModel.test.ts
@@ -106,6 +106,21 @@ describe("useTopBarViewModel", () => {
     );
   });
 
+  it("should navigate to GlobalSearch and track button_clicked when onSearchPress is invoked", () => {
+    const { result } = renderHook(() => useTopBarViewModel(mockNavigation as never));
+
+    act(() => {
+      result.current.onSearchPress();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(expectedNavigationParams.search.name);
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "Search",
+      page: ScreenName.Portfolio,
+    });
+  });
+
   it("should call navigate with expected params when onSettingsPress is invoked", () => {
     const { result } = renderHook(() => useTopBarViewModel(mockNavigation as never));
 

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/const.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/const.ts
@@ -22,4 +22,7 @@ export const expectedNavigationParams: TopBarNavigationParams = {
   settings: {
     name: NavigatorName.Settings,
   },
+  search: {
+    name: NavigatorName.GlobalSearch,
+  },
 };

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/index.tsx
@@ -16,6 +16,8 @@ export function TopBar({ screenName }: Readonly<TopBarProps>) {
     onMyWalletPress,
     shouldDisplayMyWallet,
     shouldDisplayOperationsList,
+    shouldDisplayAssetDiscoverability,
+    onSearchPress,
     onDiscoverPress,
     onNotificationsPress,
     onSettingsPress,
@@ -39,6 +41,8 @@ export function TopBar({ screenName }: Readonly<TopBarProps>) {
       onMyWalletPress={onMyWalletPress}
       shouldDisplayMyWallet={shouldDisplayMyWallet}
       shouldDisplayOperationsList={shouldDisplayOperationsList}
+      shouldDisplayAssetDiscoverability={shouldDisplayAssetDiscoverability}
+      onSearchPress={onSearchPress}
       onDiscoverPress={onDiscoverPress}
       onNotificationsPress={onNotificationsPress}
       onSettingsPress={onSettingsPress}

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/types.ts
@@ -3,4 +3,5 @@ export type TopBarNavigationParams = {
   discover: { name: string; params: { screen: string } };
   notifications: { name: string; params: { screen: string } };
   settings: { name: string };
+  search: { name: string };
 };

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
@@ -21,7 +21,8 @@ export function useTopBarViewModel(
 ) {
   const { notificationCards } = useDynamicContent();
   const web3hub = useFeature("web3hub");
-  const { shouldDisplayOperationsList, shouldDisplayMyWallet } = useWalletFeaturesConfig("mobile");
+  const { shouldDisplayOperationsList, shouldDisplayMyWallet, shouldDisplayAssetDiscoverability } =
+    useWalletFeaturesConfig("mobile");
   const page = screenName ?? ScreenName.Portfolio;
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
   const { navigateToRebornFlow } = useRebornFlow();
@@ -117,7 +118,14 @@ export function useTopBarViewModel(
     });
   }, [navigation, page]);
 
+  const onSearchPress = useCallback(() => {
+    track(BUTTON_CLICKED_EVENT, { button: "Search", page });
+    navigation.navigate(NavigatorName.GlobalSearch);
+  }, [navigation, page]);
+
   return {
+    shouldDisplayAssetDiscoverability,
+    onSearchPress,
     onMyLedgerPress,
     onMyWalletPress,
     shouldDisplayMyWallet,

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/__tests__/useSwapTopBarHeaderViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/__tests__/useSwapTopBarHeaderViewModel.test.ts
@@ -30,6 +30,8 @@ describe("useSwapTopBarHeaderViewModel", () => {
     mockedUseTopBarViewModel.mockImplementation(() => ({
       onMyLedgerPress: mockOnMyLedgerPress,
       onMyWalletPress: mockOnMyWalletPress,
+      shouldDisplayAssetDiscoverability: false,
+      onSearchPress: noop,
       shouldDisplayMyWallet: false,
       shouldDisplayOperationsList: false,
       onDiscoverPress: noop,
@@ -60,6 +62,8 @@ describe("useSwapTopBarHeaderViewModel", () => {
     mockedUseTopBarViewModel.mockImplementation(() => ({
       onMyLedgerPress: mockOnMyLedgerPress,
       onMyWalletPress: mockOnMyWalletPress,
+      shouldDisplayAssetDiscoverability: false,
+      onSearchPress: noop,
       shouldDisplayMyWallet: true,
       shouldDisplayOperationsList: false,
       onDiscoverPress: noop,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Unit (`TopBarView`, `useTopBarViewModel`) + integration (`TopBar.integration`) cover icon visibility per FF and navigation/tracking on press.
- [x] **Impact of the changes:**
  - Adds a **Global Search** entry-point icon to the Portfolio top bar, rendered **only** when `shouldDisplayAssetDiscoverability` is `true` (Wallet 4.0 `lwmWallet40.params.assetDiscoverability`). No change when the flag is off.
  - QA focus: confirm the search icon appears in the top bar leading area (after Discover) only with asset discoverability enabled, and that tapping it attempts to open the Global Search screen.

### 📝 Description

First PR of the **Global Search** feature (Wallet 4.0 / LWM). This change wires the entry point only:

- `useTopBarViewModel`: derives `shouldDisplayAssetDiscoverability` from `useWalletFeaturesConfig("mobile")` and adds an `onSearchPress` handler that tracks `button_clicked` (`{ button: "Search" }`) and navigates to `NavigatorName.GlobalSearch`.
- `TopBarView`: renders a new `Search` (Lumen) icon in `getLeadingIcons()`, gated on `shouldDisplayAssetDiscoverability`.
- `const/navigation.ts`: adds `NavigatorName.GlobalSearch`.

> The `GlobalSearch` navigator/screen itself is introduced in the next stacked PR (LIVE-30042); here the icon navigates to that route which lands in the follow-up.

A `button_clicked` event is fired on the icon tap to stay consistent with the other top bar icons; the dedicated `search_open` (on-mount) event arrives with the screen in LIVE-30042.


<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/1b19f5f0-a43a-423c-a14f-5afdd47d356b" />


### ❓ Context

- **JIRA**: [LIVE-30041](https://ledgerhq.atlassian.net/browse/LIVE-30041) — Epic [LIVE-27854](https://ledgerhq.atlassian.net/browse/LIVE-27854)
- **Stacked PR series** (Global Search): this is **1/8**. Subsequent PRs stack on this branch.


[LIVE-30041]: https://ledgerhq.atlassian.net/browse/LIVE-30041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ