### PR TITLE
test(mobile-e2e): repoint Kiln deeplink test to kiln-widget and reset app state after it

### DIFF
--- a/e2e/mobile/page/discover/discover.page.ts
+++ b/e2e/mobile/page/discover/discover.page.ts
@@ -6,7 +6,7 @@ import { openDeeplink } from "../../helpers/commonHelpers";
 const discoverApps = [
   { name: "MoonPay", url: "https://www.moonpay.com/" },
   { name: "Ramp", url: "https://rampnetwork.com/buy-crypto" },
-  { name: "Kiln", url: "https://kiln.fi" },
+  { name: "Kiln-Widget", url: "https://ledger-defi.widget.kiln.fi/earn" },
   { name: "Lido", url: "https://lido.fi/" },
   { name: "1inch", url: "https://1inch.com" },
   { name: "Zerion", url: "https://zerion.io/" },
@@ -14,6 +14,8 @@ const discoverApps = [
 ] as const;
 
 export type DiscoverAppName = (typeof discoverApps)[number]["name"];
+
+const randomPoolExcludedApps = new Set<DiscoverAppName>(["1inch", "Kiln-Widget"]);
 
 export default class DiscoverPage {
   discoverApps = discoverApps;
@@ -29,7 +31,7 @@ export default class DiscoverPage {
 
   @Step("Get live App")
   getRandomLiveApp(): DiscoverAppName {
-    const pool = this.discoverApps.filter(a => a.name !== "1inch");
+    const pool = this.discoverApps.filter(a => !randomPoolExcludedApps.has(a.name));
     const app = pool[randomInt(0, pool.length)].name;
     log.info(`Selected Live app: ${app}`);
     return app;

--- a/e2e/mobile/specs/deeplinks.spec.ts
+++ b/e2e/mobile/specs/deeplinks.spec.ts
@@ -1,7 +1,8 @@
+import { device } from "detox";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { swapSetup } from "../bridge/server";
-import { isWallet40 } from "../helpers/commonHelpers";
+import { isWallet40, launchApp } from "../helpers/commonHelpers";
 import { setTeamOwner } from "../helpers/allure/allure-helper";
 
 const isSmokeTestRun = process.env.INPUTS_TEST_FILTER?.includes("@smoke");
@@ -86,9 +87,15 @@ describe("DeepLinks Tests", () => {
     },
   );
 
-  (isSmokeTestRun ? it.skip : it)("should open discovery to Kiln live App", async () => {
-    await app.discover.openViaDeeplink("Kiln");
-    await app.discover.expectApp("Kiln");
+  (isSmokeTestRun ? it.skip : it)("should open discovery to Kiln Widget live App", async () => {
+    await app.discover.openViaDeeplink("Kiln-Widget");
+    await app.discover.expectApp("Kiln-Widget");
+    // the Kiln widget opens the account drawer over the navigator; restart to reset UI state
+    await device.terminateApp();
+    await launchApp();
+    await device.disableSynchronization();
+    await app.portfolio.waitForPortfolioPageToLoad();
+    await device.enableSynchronization();
   });
 
   setTeamOwner(Team.SWAP);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached. <!-- not needed: test-only change, no published package affected -->
- [x] **Covered by automatic tests.** <!-- this PR fixes the mobile e2e deeplinks spec itself -->
- [x] **Impact of the changes:**
  - Mobile e2e only (`e2e/mobile`): deeplinks spec and discover page object. No production code touched.

### 📝 Description

The nightly Mobile E2E run fails on `DeepLinks Tests > should open discovery to Kiln live App` on both platforms since 2026-06-10 (e.g. [run 27253390841](https://github.com/LedgerHQ/ledger-live/actions/runs/27253390841)).

**Root cause:** the `kiln` manifest was removed from the live-app catalog (Kiln services deprecation — `kiln-app` now points to a "Kiln services unavailable" support article). `ledgerlive://discover/Kiln` no longer resolves a manifest, and `DeeplinksProvider` silently drops unresolved deeplinks, so the webview kept showing the previous test's app (MoonPay) or nothing.

**Fix (test-only):**
- Repoint the dedicated Kiln test to the `kiln-widget` manifest (Kiln DeFi, stable branch) and assert its homepage URL in the live app header.
- Keep `Kiln-Widget` out of the random discover pool: catalog search and card testIDs are based on the manifest *name* (`Kiln DeFi`), which does not match the *id* used by the deeplink.
- Restart the app after the assertion: on load the Kiln widget requests an account via wallet-api, which opens the global account drawer over the navigator; deeplinks navigate underneath it, which cascaded 1-minute visibility timeouts into the five following tests on iOS. The restart (same pattern as `accountRename.spec.ts`) resets UI state deterministically; accounts/settings/flag overrides are persisted so no config reload is needed. Costs ~13s on this one test.

**Validation:**
- Local iOS debug: Kiln Widget test green, post-Kiln cascade (Swap/Market/Send/Asset BTC) green.
- CI (`test_filter=deeplinks`): Android 16/16 green across attempts; iOS validation run on this exact commit: [run 27279506555](https://github.com/LedgerHQ/ledger-live/actions/runs/27279506555).

### ❓ Context

- **JIRA or GitHub link**: QAA-1225 (original Kiln deeplink coverage)
- **ADR link (if any)**: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)