### PR TITLE
[LWDM] feat(LIVE-31785): support token accounts in aleo prepareTransaction

### DIFF
--- a/.changeset/light-fireants-tell.md
+++ b/.changeset/light-fireants-tell.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+feat: aleo prepareTransaction with tokens support

--- a/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.test.ts
@@ -5,8 +5,11 @@ import { estimateFees } from "../logic";
 import { calculateAmount, findBestRecordForFee } from "../logic/utils";
 import {
   getMockedAccount,
+  getMockedTokenAccount,
   mockUnspentRecord1,
   mockUnspentRecord2,
+  mockUnspentTokenRecord1,
+  mockUnspentTokenRecord2,
 } from "../__tests__/fixtures/account.fixture";
 import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import type { Transaction } from "../types";
@@ -28,6 +31,20 @@ const mockFindBestRecordForFee = jest.mocked(findBestRecordForFee);
 
 describe("prepareTransaction", () => {
   const mockAccount = getMockedAccount({ balance: new BigNumber(1000000) });
+  const mockTokenAccount = {
+    ...getMockedTokenAccount(),
+    unspentPrivateRecords: [mockUnspentTokenRecord1, mockUnspentTokenRecord2],
+  };
+  const accountWithTokenSubAccount = getMockedAccount({
+    subAccounts: [mockTokenAccount],
+    aleoResources: {
+      transparentBalance: new BigNumber(1000),
+      provableApi: null,
+      privateBalance: new BigNumber(1),
+      unspentPrivateRecords: [mockUnspentRecord1, mockUnspentRecord2],
+      lastPrivateSyncDate: new Date(),
+    },
+  });
   const mockFees = new BigNumber(5000);
   const mockAmount = new BigNumber(500000);
   const mockTransaction: Transaction = {
@@ -50,23 +67,71 @@ describe("prepareTransaction", () => {
     mockFindBestRecordForFee.mockReturnValue(null);
   });
 
-  it("should return transaction with calculated amount and fees", async () => {
+  it("should prepare public transaction with calculated amount and fees", async () => {
     const result = await prepareTransaction(mockAccount, mockTransaction);
-
-    expect(result).toMatchObject({
-      amount: mockAmount,
-      fees: mockFees,
-    });
-  });
-
-  it("should call calculateAmount", async () => {
-    await prepareTransaction(mockAccount, mockTransaction);
 
     expect(mockCalculateAmount).toHaveBeenCalledTimes(1);
     expect(mockCalculateAmount).toHaveBeenCalledWith({
       transaction: mockTransaction,
       account: mockAccount,
       estimatedFees: mockFees,
+    });
+    expect(result).toMatchObject({
+      amount: mockAmount,
+      fees: mockFees,
+      mode: TRANSACTION_TYPE.TRANSFER_PUBLIC,
+      recipient: "aleo1recipient",
+    });
+  });
+
+  it("should set recipient to freshAddress for native public shield", async () => {
+    const result = await prepareTransaction(mockAccount, {
+      ...mockTransaction,
+      mode: TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE,
+      recipient: "aleo1other",
+    });
+
+    expect(result).toMatchObject({
+      mode: TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE,
+      recipient: mockAccount.freshAddress,
+    });
+  });
+
+  it("should set recipient to freshAddress for native private unshield", async () => {
+    mockAleoConfig.getCoinConfig.mockReturnValue({
+      ...mockConfig,
+      isFeeSponsored: true,
+    });
+
+    const result = await prepareTransaction(mockAccount, {
+      ...mockTransaction,
+      mode: TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC,
+      recipient: "aleo1other",
+      properties: {
+        amountRecordCommitments: [mockUnspentRecord1.commitment],
+        feeRecordCommitment: null,
+      },
+    });
+
+    expect(result).toMatchObject({
+      mode: TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC,
+      recipient: mockAccount.freshAddress,
+    });
+  });
+
+  it("should normalize transaction mode after switching from sub-account to main account", async () => {
+    const result = await prepareTransaction(mockAccount, {
+      ...mockTransaction,
+      mode: TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC,
+    });
+
+    expect(mockEstimateFees).toHaveBeenCalledTimes(1);
+    expect(mockEstimateFees).toHaveBeenCalledWith({
+      configOrCurrencyId: mockConfig,
+      transactionType: TRANSACTION_TYPE.TRANSFER_PUBLIC,
+    });
+    expect(result).toMatchObject({
+      mode: TRANSACTION_TYPE.TRANSFER_PUBLIC,
     });
   });
 
@@ -455,6 +520,120 @@ describe("prepareTransaction", () => {
     expect(result).toMatchObject({
       properties: {
         amountRecordCommitments: [mockUnspentRecord1.commitment, mockUnspentRecord2.commitment],
+      },
+    });
+  });
+
+  it("should set transfer_token_public mode and keep recipient for token public send", async () => {
+    const result = await prepareTransaction(accountWithTokenSubAccount, {
+      ...mockTransaction,
+      subAccountId: mockTokenAccount.id,
+    });
+
+    expect(mockEstimateFees).toHaveBeenCalledTimes(1);
+    expect(mockEstimateFees).toHaveBeenCalledWith({
+      configOrCurrencyId: mockConfig,
+      transactionType: TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC,
+    });
+    expect(result).toMatchObject({
+      mode: TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC,
+      recipient: "aleo1recipient",
+    });
+  });
+
+  it("should set recipient to freshAddress for token public shield", async () => {
+    const result = await prepareTransaction(accountWithTokenSubAccount, {
+      ...mockTransaction,
+      mode: TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE,
+      subAccountId: mockTokenAccount.id,
+      recipient: "aleo1other",
+    });
+
+    expect(result).toMatchObject({
+      mode: TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE,
+      recipient: accountWithTokenSubAccount.freshAddress,
+    });
+  });
+
+  it("should set recipient to freshAddress for token private unshield", async () => {
+    mockAleoConfig.getCoinConfig.mockReturnValue({
+      ...mockConfig,
+      recordPickingStrategy: "manual",
+      isFeeSponsored: true,
+    });
+
+    const result = await prepareTransaction(accountWithTokenSubAccount, {
+      ...mockTransaction,
+      mode: TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC,
+      subAccountId: mockTokenAccount.id,
+      recipient: "aleo1other",
+      properties: {
+        amountRecordCommitments: [mockUnspentTokenRecord1.commitment],
+        feeRecordCommitment: null,
+      },
+    });
+
+    expect(result).toMatchObject({
+      mode: TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC,
+      recipient: accountWithTokenSubAccount.freshAddress,
+    });
+  });
+
+  it("should pick token amount records from subAccount and native ALEO fee record for private token transfer", async () => {
+    mockAleoConfig.getCoinConfig.mockReturnValue({
+      ...mockConfig,
+      recordPickingStrategy: "auto",
+      isFeeSponsored: false,
+    });
+    mockFindBestRecordForFee.mockReturnValue(mockUnspentRecord1);
+
+    const result = await prepareTransaction(accountWithTokenSubAccount, {
+      ...mockTransaction,
+      mode: TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE,
+      subAccountId: mockTokenAccount.id,
+      amount: new BigNumber(550000),
+      properties: {
+        amountRecordCommitments: [],
+        feeRecordCommitment: null,
+      },
+    });
+
+    expect(mockFindBestRecordForFee).toHaveBeenCalledTimes(1);
+    expect(mockFindBestRecordForFee).toHaveBeenCalledWith({
+      unspentRecords: accountWithTokenSubAccount.aleoResources?.unspentPrivateRecords ?? [],
+      selectedAmountRecordCommitments: [],
+      targetFee: mockFees,
+    });
+    expect(result).toMatchObject({
+      mode: TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE,
+      properties: {
+        amountRecordCommitments: [mockUnspentTokenRecord2.commitment],
+        feeRecordCommitment: mockUnspentRecord1.commitment,
+      },
+    });
+  });
+
+  it("should keep manual token amount records on re-prepare when mode is already transfer_token_private", async () => {
+    mockAleoConfig.getCoinConfig.mockReturnValue({
+      ...mockConfig,
+      recordPickingStrategy: "manual",
+      isFeeSponsored: true,
+    });
+
+    const result = await prepareTransaction(accountWithTokenSubAccount, {
+      ...mockTransaction,
+      mode: TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE,
+      subAccountId: mockTokenAccount.id,
+      properties: {
+        amountRecordCommitments: [mockUnspentTokenRecord1.commitment],
+        feeRecordCommitment: null,
+      },
+    });
+
+    expect(result).toMatchObject({
+      mode: TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE,
+      properties: {
+        amountRecordCommitments: [mockUnspentTokenRecord1.commitment],
       },
     });
   });

--- a/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.ts
@@ -2,39 +2,209 @@ import BigNumber from "bignumber.js";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import { updateTransaction } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
 import aleoCoinConfig from "../config";
+import { MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION, TRANSACTION_TYPE } from "../constants";
 import { estimateFees } from "../logic";
 import {
   calculateAmount,
   findBestRecordForFee,
   isPrivateTransaction,
+  isSelfTransferTransaction,
   selectPrivateRecordsForAmount,
+  getAleoSubAccount,
 } from "../logic/utils";
 import type {
   AleoAccount,
   AleoCoinConfig,
+  AleoTokenAccount,
   Transaction as AleoTransaction,
   TransactionPrivate as AleoTransactionPrivate,
   AleoUnspentRecord,
 } from "../types";
 
+// useBridgeTransaction.setAccount preserves the previous mode and only patches subAccountId,
+// so main/sub-account switches can leave a native mode on a token tx (or vice versa).
+function derivePublicTransactionMode({
+  isTokenTx,
+  isSelfTransfer,
+}: {
+  isTokenTx: boolean;
+  isSelfTransfer: boolean;
+}): AleoTransaction["mode"] {
+  if (isTokenTx) {
+    return isSelfTransfer
+      ? TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE
+      : TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC;
+  }
+
+  return isSelfTransfer
+    ? TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE
+    : TRANSACTION_TYPE.TRANSFER_PUBLIC;
+}
+
+function derivePrivateTransactionMode({
+  isTokenTx,
+  isSelfTransfer,
+}: {
+  isTokenTx: boolean;
+  isSelfTransfer: boolean;
+}): AleoTransactionPrivate["mode"] {
+  if (isTokenTx) {
+    return isSelfTransfer
+      ? TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC
+      : TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE;
+  }
+
+  return isSelfTransfer
+    ? TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC
+    : TRANSACTION_TYPE.TRANSFER_PRIVATE;
+}
+
 function getAmountRecordCommitments({
   transaction,
   config,
   unspentRecords,
+  maxRecords,
 }: {
   transaction: AleoTransactionPrivate;
   config: AleoCoinConfig;
   unspentRecords: AleoUnspentRecord[];
+  maxRecords?: number;
 }): string[] {
   if (config.recordPickingStrategy === "manual") {
     return transaction.properties.amountRecordCommitments;
   }
 
   const targetAmount = transaction.useAllAmount ? null : transaction.amount;
-  const selectedAmountRecords = selectPrivateRecordsForAmount({ unspentRecords, targetAmount });
-  const selectedAmountRecordCommitments = selectedAmountRecords.map(record => record.commitment);
+  const selectedAmountRecords = selectPrivateRecordsForAmount({
+    unspentRecords,
+    targetAmount,
+    ...(typeof maxRecords === "number" && { maxRecords }),
+  });
 
-  return selectedAmountRecordCommitments;
+  return selectedAmountRecords.map(record => record.commitment);
+}
+
+function resolveFeeRecordCommitment({
+  config,
+  amountRecordCommitments,
+  feeRecordPool,
+  isTokenTx,
+  existingFeeRecordCommitment,
+  estimatedFees,
+}: {
+  config: AleoCoinConfig;
+  amountRecordCommitments: string[];
+  feeRecordPool: AleoUnspentRecord[];
+  isTokenTx: boolean;
+  existingFeeRecordCommitment: string | null;
+  estimatedFees: BigNumber;
+}): string | null {
+  if (config.isFeeSponsored) {
+    return null;
+  }
+
+  // fees are always paid with native ALEO credits
+  // selected amount record commitments should be empty with token transactions
+  const selectedAmountRecordCommitments = isTokenTx ? [] : amountRecordCommitments;
+
+  const feeRecord = findBestRecordForFee({
+    unspentRecords: feeRecordPool,
+    selectedAmountRecordCommitments,
+    targetFee: estimatedFees,
+  });
+
+  return feeRecord?.commitment ?? existingFeeRecordCommitment;
+}
+
+function preparePublicTransaction({
+  account,
+  transaction,
+  derivedTransactionMode,
+  estimatedFees,
+  isSelfTransfer,
+}: {
+  account: AleoAccount;
+  transaction: AleoTransaction;
+  derivedTransactionMode: AleoTransaction["mode"];
+  estimatedFees: BigNumber;
+  isSelfTransfer: boolean;
+}): AleoTransaction {
+  const calculatedAmount = calculateAmount({ transaction, account, estimatedFees });
+
+  return updateTransaction(transaction, {
+    amount: calculatedAmount.amount,
+    fees: estimatedFees,
+    mode: derivedTransactionMode,
+    ...(isSelfTransfer && { recipient: account.freshAddress }),
+  });
+}
+
+function preparePrivateTransaction({
+  account,
+  transaction,
+  derivedTransactionMode,
+  config,
+  estimatedFees,
+  subAccount,
+  isTokenTx,
+  isSelfTransfer,
+}: {
+  account: AleoAccount;
+  transaction: AleoTransactionPrivate;
+  derivedTransactionMode: AleoTransactionPrivate["mode"];
+  config: AleoCoinConfig;
+  estimatedFees: BigNumber;
+  subAccount: AleoTokenAccount | undefined;
+  isTokenTx: boolean;
+  isSelfTransfer: boolean;
+}): AleoTransaction {
+  const amountRecordPool = isTokenTx
+    ? (subAccount?.unspentPrivateRecords ?? [])
+    : (account.aleoResources?.unspentPrivateRecords ?? []);
+
+  const newAmountRecordCommitments = getAmountRecordCommitments({
+    transaction,
+    config,
+    unspentRecords: amountRecordPool,
+    ...(isTokenTx && { maxRecords: MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION }),
+  });
+
+  const transactionWithRecords = updateTransaction(transaction, {
+    properties: {
+      ...transaction.properties,
+      amountRecordCommitments: newAmountRecordCommitments,
+    },
+  });
+
+  const calculatedAmount = calculateAmount({
+    transaction: transactionWithRecords,
+    account,
+    estimatedFees,
+  });
+
+  const feeRecordPool = isTokenTx
+    ? (account.aleoResources?.unspentPrivateRecords ?? [])
+    : amountRecordPool;
+
+  const feeRecordCommitment = resolveFeeRecordCommitment({
+    config,
+    amountRecordCommitments: newAmountRecordCommitments,
+    feeRecordPool,
+    isTokenTx,
+    existingFeeRecordCommitment: transactionWithRecords.properties.feeRecordCommitment,
+    estimatedFees,
+  });
+
+  return updateTransaction(transactionWithRecords, {
+    amount: calculatedAmount.amount,
+    fees: estimatedFees,
+    mode: derivedTransactionMode,
+    properties: {
+      ...transactionWithRecords.properties,
+      feeRecordCommitment,
+    },
+    ...(isSelfTransfer && { recipient: account.freshAddress }),
+  });
 }
 
 export const prepareTransaction: AccountBridge<
@@ -42,61 +212,42 @@ export const prepareTransaction: AccountBridge<
   AleoAccount
 >["prepareTransaction"] = async (account, transaction) => {
   const config = aleoCoinConfig.getCoinConfig(account.currency.id);
+  const isSelfTransfer = isSelfTransferTransaction(transaction);
+  const subAccount = getAleoSubAccount(account, transaction.subAccountId);
+  const isTokenTx = !!subAccount;
+
+  if (isPrivateTransaction(transaction)) {
+    const derivedTransactionMode = derivePrivateTransactionMode({ isTokenTx, isSelfTransfer });
+    const feeEstimation = estimateFees({
+      configOrCurrencyId: config,
+      transactionType: derivedTransactionMode,
+    });
+    const estimatedFees = new BigNumber(feeEstimation.value.toString());
+
+    return preparePrivateTransaction({
+      account,
+      transaction,
+      derivedTransactionMode,
+      config,
+      estimatedFees,
+      subAccount,
+      isTokenTx,
+      isSelfTransfer,
+    });
+  }
+
+  const derivedTransactionMode = derivePublicTransactionMode({ isTokenTx, isSelfTransfer });
   const feeEstimation = estimateFees({
     configOrCurrencyId: config,
-    transactionType: transaction.mode,
+    transactionType: derivedTransactionMode,
   });
-
   const estimatedFees = new BigNumber(feeEstimation.value.toString());
 
-  // public transactions don't use records - amount and fees are resolved directly.
-  if (!isPrivateTransaction(transaction)) {
-    const calculatedAmount = calculateAmount({ transaction, account, estimatedFees });
-
-    return updateTransaction(transaction, {
-      amount: calculatedAmount.amount,
-      fees: estimatedFees,
-    });
-  }
-
-  const unspentRecords = account.aleoResources?.unspentPrivateRecords ?? [];
-  const newAmountRecordCommitments = getAmountRecordCommitments({
-    transaction,
-    config,
-    unspentRecords,
-  });
-  const privateTransactionWithRecords = updateTransaction(transaction, {
-    properties: {
-      ...transaction.properties,
-      amountRecordCommitments: newAmountRecordCommitments,
-    },
-  });
-  const calculatedAmount = calculateAmount({
-    transaction: privateTransactionWithRecords,
+  return preparePublicTransaction({
     account,
+    transaction,
+    derivedTransactionMode,
     estimatedFees,
-  });
-
-  // when fee sponsorship is off, pick the smallest record that covers the fee
-  let selectedFeeRecordCommitment: string | null = null;
-
-  if (!config.isFeeSponsored && newAmountRecordCommitments.length > 0) {
-    const feeRecord = findBestRecordForFee({
-      unspentRecords,
-      selectedAmountRecordCommitments: newAmountRecordCommitments,
-      targetFee: estimatedFees,
-    });
-
-    selectedFeeRecordCommitment =
-      feeRecord?.commitment ?? privateTransactionWithRecords.properties.feeRecordCommitment;
-  }
-
-  return updateTransaction(privateTransactionWithRecords, {
-    amount: calculatedAmount.amount,
-    fees: estimatedFees,
-    properties: {
-      ...privateTransactionWithRecords.properties,
-      feeRecordCommitment: config.isFeeSponsored ? null : selectedFeeRecordCommitment,
-    },
+    isSelfTransfer,
   });
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - support for token accounts in prepareTransaction in `coin-aleo`
  - ensure prepareTransaction sets `tx.recipient` address with self transfers (it's currently handled by LWD hooks)

### 📝 Description

This PR adds support for token accounts to prepareTransaction method in coin-aleo module. It also ensures that `recipient` is set here to the account address when transaction mode is self transfer. Currently it is incorrectly handled by the `useHandleChangeAccount` hook from LWD. 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-31785

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
