### PR TITLE
[LWM] feat(mobile): add Global Search screen scaffold [LIVE-30042]

### DIFF
--- a/.changeset/global-search-screen-scaffold.md
+++ b/.changeset/global-search-screen-scaffold.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add the Global Search screen scaffold. Registers the `GlobalSearch` navigator in the base navigator with a fade entrance, and renders a custom header (back button + "Search assets" input) that auto-focuses after the transition. Fires the `search_open` tracking event on open.

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -33,6 +33,7 @@ import PasswordModifyFlowNavigator from "./PasswordModifyFlowNavigator";
 import SwapNavigator from "./SwapNavigator";
 import SwapSubScreensNavigator from "./SwapSubScreensNavigator";
 import PerpsNavigator from "./PerpsNavigator";
+import GlobalSearchNavigator from "LLM/features/GlobalSearch/Navigator";
 import NotificationCenterNavigator from "./NotificationCenterNavigator";
 import AnalyticsAllocation from "~/screens/Analytics/Allocation";
 import AnalyticsOperations from "~/screens/Analytics/Operations";
@@ -353,6 +354,11 @@ export default function BaseNavigator() {
           name={NavigatorName.Perps}
           component={PerpsNavigator}
           options={{ headerShown: false }}
+        />
+        <Stack.Screen
+          name={NavigatorName.GlobalSearch}
+          component={GlobalSearchNavigator}
+          options={{ headerShown: false, animation: "fade" }}
         />
         <Stack.Screen
           name={NavigatorName.Freeze}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -91,6 +91,7 @@ import type { StakeNavigatorParamList } from "./StakeNavigator";
 import type { SwapNavigatorParamList } from "./SwapNavigator";
 import type { SwapSubScreensNavigatorParamList } from "./SwapSubScreensNavigator";
 import type { PerpsNavigatorParamList } from "./PerpsNavigator";
+import type { GlobalSearchNavigatorParamList } from "LLM/features/GlobalSearch/types";
 import type { UnfreezeNavigatorParamList } from "./UnfreezeNavigator";
 import type { WalletConnectLiveAppNavigatorParamList } from "./WalletConnectLiveAppNavigator";
 import type { WalletSyncNavigatorStackParamList } from "./WalletSyncNavigator";
@@ -232,6 +233,7 @@ export type BaseNavigatorStackParamList = {
   };
   [NavigatorName.Swap]?: NavigatorScreenParams<SwapNavigatorParamList>;
   [NavigatorName.Perps]?: NavigatorScreenParams<PerpsNavigatorParamList>;
+  [NavigatorName.GlobalSearch]?: NavigatorScreenParams<GlobalSearchNavigatorParamList>;
   [NavigatorName.Earn]?: NavigatorScreenParams<EarnLiveAppNavigatorParamList>;
   [NavigatorName.Borrow]?: NavigatorScreenParams<BorrowLiveAppNavigatorParamList>;
   [NavigatorName.Freeze]: NavigatorScreenParams<FreezeNavigatorParamList>;

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -172,6 +172,7 @@ export enum ScreenName {
   SwapSelectProvider = "SelectProvider",
   SwapTab = "SwapTab",
   PerpsTab = "PerpsTab",
+  GlobalSearch = "GlobalSearch",
   Earn = "Earn",
   Borrow = "Borrow",
   Transfer = "Transfer",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1458,6 +1458,9 @@
     "button": "Reset",
     "warning": "Resetting Ledger Wallet will erase your swap transaction history for all your accounts."
   },
+  "globalSearch": {
+    "searchPlaceholder": "Search assets"
+  },
   "graph": {
     "week": "1W",
     "month": "1M",

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/Navigator.tsx
@@ -1,0 +1,29 @@
+import React, { useMemo } from "react";
+import { Platform } from "react-native";
+import { useTheme } from "@ledgerhq/lumen-ui-rnative/styles";
+import {
+  createLumenNativeStackNavigator,
+  getStackNavigationConfigV4,
+} from "LLM/components/Navigation";
+import { ScreenName } from "~/const";
+import { GlobalSearch } from "./screens/GlobalSearch";
+import type { GlobalSearchNavigatorParamList } from "./types";
+
+const Stack = createLumenNativeStackNavigator<GlobalSearchNavigatorParamList>();
+
+export default function GlobalSearchNavigator() {
+  const { theme } = useTheme();
+  const stackNavigationConfig = useMemo(() => getStackNavigationConfigV4(theme), [theme]);
+
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        ...stackNavigationConfig,
+        headerShown: false,
+        gestureEnabled: Platform.OS === "ios",
+      }}
+    >
+      <Stack.Screen name={ScreenName.GlobalSearch} component={GlobalSearch} />
+    </Stack.Navigator>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/__integrations__/globalSearch.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/__integrations__/globalSearch.integration.test.tsx
@@ -20,7 +20,7 @@ describe("GlobalSearch screen", () => {
     render(<GlobalSearch />);
 
     expect(screen.getByTestId(GLOBAL_SEARCH_TEST_IDS.searchInput)).toBeVisible();
-    expect(screen.getByPlaceholderText("Search assets")).toBeVisible();
+    expect(screen.getByPlaceholderText(/search assets/i)).toBeVisible();
   });
 
   it("tracks search_open on mount", () => {
@@ -32,7 +32,7 @@ describe("GlobalSearch screen", () => {
   it("navigates back when the back button is pressed", async () => {
     const { user } = render(<GlobalSearch />);
 
-    await user.press(screen.getByLabelText("Back"));
+    await user.press(screen.getByLabelText(/back/i));
 
     expect(mockGoBack).toHaveBeenCalledTimes(1);
   });
@@ -40,7 +40,7 @@ describe("GlobalSearch screen", () => {
   it("reflects typed input in the search field", async () => {
     const { user } = render(<GlobalSearch />);
 
-    await user.type(screen.getByPlaceholderText("Search assets"), "bitcoin");
+    await user.type(screen.getByPlaceholderText(/search assets/i), "bitcoin");
 
     expect(screen.getByDisplayValue("bitcoin")).toBeVisible();
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/__integrations__/globalSearch.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/__integrations__/globalSearch.integration.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { track } from "~/analytics";
+import { GlobalSearch } from "../screens/GlobalSearch";
+import { GLOBAL_SEARCH_TEST_IDS } from "../screens/GlobalSearch/testIds";
+
+const mockGoBack = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ goBack: mockGoBack }),
+}));
+
+describe("GlobalSearch screen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the search input with the 'Search assets' placeholder", () => {
+    render(<GlobalSearch />);
+
+    expect(screen.getByTestId(GLOBAL_SEARCH_TEST_IDS.searchInput)).toBeVisible();
+    expect(screen.getByPlaceholderText("Search assets")).toBeVisible();
+  });
+
+  it("tracks search_open on mount", () => {
+    render(<GlobalSearch />);
+
+    expect(track).toHaveBeenCalledWith("search_open");
+  });
+
+  it("navigates back when the back button is pressed", async () => {
+    const { user } = render(<GlobalSearch />);
+
+    await user.press(screen.getByLabelText("Back"));
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("reflects typed input in the search field", async () => {
+    const { user } = render(<GlobalSearch />);
+
+    await user.type(screen.getByPlaceholderText("Search assets"), "bitcoin");
+
+    expect(screen.getByDisplayValue("bitcoin")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/index.tsx
@@ -41,10 +41,8 @@ export function GlobalSearch() {
   const topPadding = hasExperimentalHeader ? 0 : insets.top;
 
   useEffect(() => {
-    // page is auto-injected by track() as the originating route name
     track("search_open");
 
-    // focus after the fade-in so the keyboard doesn't interrupt the animation
     const task = InteractionManager.runAfterInteractions(() => {
       inputRef.current?.focus();
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/index.tsx
@@ -26,7 +26,9 @@ export function GlobalSearch() {
       header: {
         flexDirection: "row",
         alignItems: "center",
+        minHeight: theme.sizes.s64,
         paddingHorizontal: theme.spacings.s16,
+        paddingVertical: theme.spacings.s8,
         gap: theme.spacings.s8,
       },
       searchInputContainer: {
@@ -51,23 +53,25 @@ export function GlobalSearch() {
 
   return (
     <View testID={GLOBAL_SEARCH_TEST_IDS.screen} style={styles.container}>
-      <View style={[styles.header, { paddingTop: topPadding }]}>
-        <NavBarBackButton
-          onPress={() => navigation.goBack()}
-          accessibilityLabel={t("common.back")}
-        />
-        <View style={styles.searchInputContainer}>
-          <SearchInput
-            ref={inputRef}
-            testID={GLOBAL_SEARCH_TEST_IDS.searchInput}
-            value={search}
-            onChangeText={setSearch}
-            onClear={() => setSearch("")}
-            hideClearButton={false}
-            placeholder={t("globalSearch.searchPlaceholder")}
-            autoCorrect={false}
-            autoCapitalize="none"
+      <View style={{ paddingTop: topPadding }}>
+        <View style={styles.header}>
+          <NavBarBackButton
+            onPress={() => navigation.goBack()}
+            accessibilityLabel={t("common.back")}
           />
+          <View style={styles.searchInputContainer}>
+            <SearchInput
+              ref={inputRef}
+              testID={GLOBAL_SEARCH_TEST_IDS.searchInput}
+              value={search}
+              onChangeText={setSearch}
+              onClear={() => setSearch("")}
+              hideClearButton={false}
+              placeholder={t("globalSearch.searchPlaceholder")}
+              autoCorrect={false}
+              autoCapitalize="none"
+            />
+          </View>
         </View>
       </View>
     </View>

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/index.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useRef, useState } from "react";
+import { InteractionManager, TextInput, View } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import { NavBarBackButton, SearchInput } from "@ledgerhq/lumen-ui-rnative";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { track } from "~/analytics";
+import { useTranslation } from "~/context/Locale";
+import { useExperimental } from "~/experimental";
+import { GLOBAL_SEARCH_TEST_IDS } from "./testIds";
+
+export function GlobalSearch() {
+  const { t } = useTranslation();
+  const navigation = useNavigation();
+  const insets = useSafeAreaInsets();
+  const hasExperimentalHeader = useExperimental();
+  const inputRef = useRef<TextInput>(null);
+  const [search, setSearch] = useState("");
+
+  const styles = useStyleSheet(
+    theme => ({
+      container: {
+        flex: 1,
+        backgroundColor: theme.colors.bg.base,
+      },
+      header: {
+        flexDirection: "row",
+        alignItems: "center",
+        paddingHorizontal: theme.spacings.s16,
+        gap: theme.spacings.s8,
+      },
+      searchInputContainer: {
+        flex: 1,
+      },
+    }),
+    [],
+  );
+
+  const topPadding = hasExperimentalHeader ? 0 : insets.top;
+
+  useEffect(() => {
+    // page is auto-injected by track() as the originating route name
+    track("search_open");
+
+    // focus after the fade-in so the keyboard doesn't interrupt the animation
+    const task = InteractionManager.runAfterInteractions(() => {
+      inputRef.current?.focus();
+    });
+    return () => task.cancel();
+  }, []);
+
+  return (
+    <View testID={GLOBAL_SEARCH_TEST_IDS.screen} style={styles.container}>
+      <View style={[styles.header, { paddingTop: topPadding }]}>
+        <NavBarBackButton
+          onPress={() => navigation.goBack()}
+          accessibilityLabel={t("common.back")}
+        />
+        <View style={styles.searchInputContainer}>
+          <SearchInput
+            ref={inputRef}
+            testID={GLOBAL_SEARCH_TEST_IDS.searchInput}
+            value={search}
+            onChangeText={setSearch}
+            onClear={() => setSearch("")}
+            hideClearButton={false}
+            placeholder={t("globalSearch.searchPlaceholder")}
+            autoCorrect={false}
+            autoCapitalize="none"
+          />
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/testIds.ts
@@ -1,0 +1,4 @@
+export const GLOBAL_SEARCH_TEST_IDS = {
+  screen: "global-search-screen",
+  searchInput: "global-search-input",
+} as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/types.ts
@@ -1,0 +1,5 @@
+import type { ScreenName } from "~/const";
+
+export type GlobalSearchNavigatorParamList = {
+  [ScreenName.GlobalSearch]: undefined;
+};


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Integration test (`__integrations__/globalSearch.integration.test.tsx`): renders the header/input with the "Search assets" placeholder, fires `search_open` on mount, navigates back, and reflects typed input.
- [x] **Impact of the changes:**
  - Adds the `GlobalSearch` screen (behind the existing search icon from #18410). No user-facing change unless `assetDiscoverability` is enabled and the icon is tapped.
  - QA focus: tapping the top-bar search icon fades the screen in, the input auto-focuses after the animation, the back button returns, and the clear (✕) button shows when the input has content.

### 📝 Description

Second PR of the **Global Search** feature. Builds the screen shell:

- **Navigator**: `GlobalSearchNavigator` (`createLumenNativeStackNavigator` + `getStackNavigationConfigV4`), registered in `BaseNavigator` as `NavigatorName.GlobalSearch` with `{ headerShown: false, animation: "fade" }`.
- **Custom header** (screen owns it): `NavBarBackButton` + a flex `SearchInput` (placeholder `"Search assets"`, `hideClearButton={false}`). Top padding mirrors `NavBarHeader` (uses `useExperimental()` / safe-area insets). Lumen-only components.
- **Auto-focus**: `InteractionManager.runAfterInteractions` focuses the input after the fade completes so the keyboard doesn't interrupt the entrance.
- **Tracking**: `search_open` on mount. `page` is auto-injected by `track()` as the originating route, which satisfies the "previous page" property (the screen renders no `TrackScreen`, so the current-route ref still points at the opener).

> The screen owns its state inline (`useState`) for now. The next stacked PR (LIVE-30043) extracts a `useGlobalSearchViewModel`, moving navigation/state out of the View per the MVVM pattern.

https://github.com/user-attachments/assets/3380f4f2-ca83-407b-8607-bb66d6123cda




### ❓ Context

- **JIRA**: [LIVE-30042](https://ledgerhq.atlassian.net/browse/LIVE-30042) — Epic [LIVE-27854](https://ledgerhq.atlassian.net/browse/LIVE-27854)
- **Stacked PR series** (Global Search): **2/8**, based on [#18410](https://github.com/LedgerHQ/ledger-live/pull/18410) (LIVE-30041).


[LIVE-30042]: https://ledgerhq.atlassian.net/browse/LIVE-30042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ