### PR TITLE
[LWDM] test(e2e): use dynamic minimum sell amount for buy/sell flows

### DIFF
--- a/.changeset/buysell-dynamic-min-sell-amount.md
+++ b/.changeset/buysell-dynamic-min-sell-amount.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop-e2e-tests": patch
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Use a dynamic minimum sell amount in the buy/sell E2E specs: fetch the live per-currency `maxOfMin` from the sell `cryptoLimitations` API (with a USD-countervalues fallback) instead of hardcoded amounts, so sell flows always clear every provider's threshold. Extract `getAmountFromUSD` into a shared `currencyUtils` helper.

--- a/e2e/desktop/tests/specs/buySell.spec.ts
+++ b/e2e/desktop/tests/specs/buySell.spec.ts
@@ -13,6 +13,7 @@ import { BuySellProvider } from "@ledgerhq/live-common/e2e/enum/Provider";
 import { OperationType } from "@ledgerhq/live-common/e2e/enum/OperationType";
 import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/helpers";
 import { liveDataCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
+import { getMinimumSellAmount } from "@ledgerhq/live-common/e2e/buySell";
 
 const assets: Array<{ buySell: BuySell; xrayTicket: string; provider: BuySellProvider }> = [
   {
@@ -189,11 +190,14 @@ for (const asset of assets) {
   });
 }
 
-const sellAsset: { buySell: BuySell; xrayTicket: string; provider: BuySellProvider } = {
+const sellAsset: {
+  buySell: Omit<BuySell, "amount">;
+  xrayTicket: string;
+  provider: BuySellProvider;
+} = {
   buySell: {
     crypto: Account.BTC_NATIVE_SEGWIT_1,
     fiat: { locale: "fr-FR", currencyTicker: "EUR" },
-    amount: "0.0003",
     operation: OperationType.Sell,
   },
   xrayTicket: "B2CQA-3524",
@@ -203,7 +207,7 @@ const sellAsset: { buySell: BuySell; xrayTicket: string; provider: BuySellProvid
 test.describe("Sell flow - ", () => {
   setupEnv(true);
 
-  const { crypto, fiat, amount, operation } = sellAsset.buySell;
+  const { crypto, fiat, operation } = sellAsset.buySell;
 
   test.use({
     teamOwner: Team.BUY_AND_SELL,
@@ -241,12 +245,14 @@ test.describe("Sell flow - ", () => {
       await app.buyAndSell.verifyProviderInfoIsNotVisible();
       await app.buyAndSell.changeRegionAndCurrency(fiat);
       await app.buyAndSell.verifyFiatAssetSelector(fiat.currencyTicker);
+      const amount = await getMinimumSellAmount(crypto.currency.id);
+      const buySell = { ...sellAsset.buySell, amount };
       await app.buyAndSell.setAmountToPay(amount, operation);
       await app.buyAndSell.selectProviderQuote(operation, sellAsset.provider.uiName);
       await app.buyAndSell.selectQuote();
       await app.buyAndSell.verifyProviderUrl(
         sellAsset.provider.uiName,
-        sellAsset.buySell,
+        buySell,
         userdataDestinationPath,
       );
     },

--- a/e2e/mobile/specs/buySell/buySell.ts
+++ b/e2e/mobile/specs/buySell/buySell.ts
@@ -6,6 +6,7 @@ import { getParentAccountName } from "@ledgerhq/live-common/e2e/enum/Account";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { isWallet40 } from "../../helpers/commonHelpers";
 import { setTeamOwner } from "../../helpers/allure/allure-helper";
+import { getMinimumSellAmount } from "@ledgerhq/live-common/e2e/buySell";
 
 setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
@@ -141,7 +142,7 @@ export async function runNavigateToBuyFromAssetPageTest(
 }
 
 export async function runSellFlowTest(
-  buySell: BuySell,
+  buySell: Omit<BuySell, "amount">,
   provider: BuySellProvider,
   paymentMethod: string,
   tmsLinks: string[],
@@ -160,8 +161,9 @@ export async function runSellFlowTest(
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     test(`Sell [${buySell.crypto.currency.name}] flow via deeplink`, async () => {
+      const amount = await getMinimumSellAmount(buySell.crypto.currency.id);
       await app.buySell.openViaDeeplink(buySell.operation);
-      await app.buySell.handleSellFlow(buySell, paymentMethod, provider);
+      await app.buySell.handleSellFlow({ ...buySell, amount }, paymentMethod, provider);
     });
   });
 }

--- a/e2e/mobile/specs/buySell/sellFlow_BTC.spec.ts
+++ b/e2e/mobile/specs/buySell/sellFlow_BTC.spec.ts
@@ -7,7 +7,6 @@ const testConfig = {
   buySell: {
     crypto: Account.BTC_NATIVE_SEGWIT_1,
     fiat: { locale: "en-US", currencyTicker: "USD" },
-    amount: "0",
     operation: OperationType.Sell,
   },
   tmsLinks: ["B2CQA-3524"],

--- a/e2e/mobile/specs/swap/otherTestCases/swapDexNativeFlow.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDexNativeFlow.ts
@@ -4,7 +4,7 @@ import { SwapProvider } from "@ledgerhq/live-common/e2e/enum/Provider";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { setEnv } from "@ledgerhq/live-env";
 import { beforeAllFunctionSwap } from "../swap.setup";
-import { getAmountFromUSD } from "@ledgerhq/live-common/e2e/swap";
+import { getAmountFromUSD } from "@ledgerhq/live-common/e2e/currencyUtils";
 import { setTeamOwner } from "../../../helpers/allure/allure-helper";
 
 setEnv("DISABLE_TRANSACTION_BROADCAST", true);

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalFlow.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalFlow.ts
@@ -3,7 +3,7 @@ import { performSwapUntilQuoteSelectionStep, revokeTokenApproval } from "../../.
 import { SwapProvider } from "@ledgerhq/live-common/e2e/enum/Provider";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { beforeAllFunctionSwap } from "../swap.setup";
-import { getAmountFromUSD } from "@ledgerhq/live-common/e2e/swap";
+import { getAmountFromUSD } from "@ledgerhq/live-common/e2e/currencyUtils";
 import { setTeamOwner } from "../../../helpers/allure/allure-helper";
 
 export function runSwapTokenApprovalFlow(

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -65,6 +65,7 @@
     "src/domain/getTotalStakeableAssets.ts",
     "src/e2e/data/assetsDrawer.ts",
     "src/e2e/data/regexes.ts",
+    "src/e2e/buySell.ts",
     "src/e2e/cliCommandsUtils.ts",
     "src/e2e/featureFlagsJsonUtils.ts",
     "src/e2e/index.ts",

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -67,6 +67,7 @@
     "src/e2e/data/regexes.ts",
     "src/e2e/buySell.ts",
     "src/e2e/cliCommandsUtils.ts",
+    "src/e2e/currencyUtils.ts",
     "src/e2e/featureFlagsJsonUtils.ts",
     "src/e2e/index.ts",
     "src/e2e/runCli.ts",

--- a/libs/ledger-live-common/src/e2e/buySell.ts
+++ b/libs/ledger-live-common/src/e2e/buySell.ts
@@ -22,7 +22,9 @@ export async function getMinimumSellAmount(currencyId: string): Promise<string> 
   if (amount === null) {
     throw new Error(`Could not determine minimum sell amount for "${currencyId}"`);
   }
-  return Number.parseFloat(amount.toFixed(6)).toString();
+  const factor = 10 ** 6;
+  const roundedUp = Math.ceil((amount - Number.EPSILON) * factor) / factor;
+  return roundedUp.toString();
 }
 
 async function fetchMinimumSellAmount(currencyId: string): Promise<number | null> {

--- a/libs/ledger-live-common/src/e2e/buySell.ts
+++ b/libs/ledger-live-common/src/e2e/buySell.ts
@@ -1,0 +1,70 @@
+import { getAmountFromUSD } from "./currencyUtils";
+import { sanitizeError } from "./index";
+import axios, { AxiosRequestConfig } from "axios";
+
+const BUY_SELL_BASE_URL = "https://buy.api.aws.prd.ldg-tech.com";
+const SELL_CRYPTO_LIMITATION_ENDPOINT = "/sell/v1/cryptoLimitations";
+const FALLBACK_TARGET_USD = 10;
+
+type CryptoLimitation = {
+  min: string;
+  maxOfMin: string;
+  minOfMax: string;
+  maxOfMax: string;
+};
+
+type CryptoLimitationsResponse = {
+  value?: Record<string, CryptoLimitation>;
+};
+
+/**
+ * Returns the minimum amount to sell `currencyId`, formatted as an input-ready string.
+ *
+ * Formatting (trim to 6 decimals, drop trailing zeros) lives here so every consumer
+ * (desktop + mobile E2E) enters the exact same value — avoiding the per-POM drift the
+ * swap helpers suffer from (desktop rounds to 6dp, mobile uses full precision).
+ *
+ * @throws if the minimum cannot be determined from the API or the countervalues fallback.
+ */
+export async function getMinimumSellAmount(currencyId: string): Promise<string> {
+  const amount = await fetchMinimumSellAmount(currencyId);
+  if (amount === null) {
+    throw new Error(`Could not determine minimum sell amount for "${currencyId}"`);
+  }
+  return Number.parseFloat(amount.toFixed(6)).toString();
+}
+
+async function fetchMinimumSellAmount(currencyId: string): Promise<number | null> {
+  try {
+    const requestConfig: AxiosRequestConfig = {
+      method: "GET",
+      url: BUY_SELL_BASE_URL + SELL_CRYPTO_LIMITATION_ENDPOINT,
+      headers: { accept: "application/json" },
+    };
+
+    const { data } = await axios<CryptoLimitationsResponse>(requestConfig);
+
+    const rawMaxOfMin = data?.value?.[currencyId]?.maxOfMin;
+    const maxOfMin = rawMaxOfMin !== undefined ? Number.parseFloat(rawMaxOfMin) : Number.NaN;
+
+    if (!Number.isNaN(maxOfMin) && maxOfMin > 0) {
+      return maxOfMin;
+    }
+
+    console.warn(
+      `No sell limitation found for "${currencyId}", ` +
+        `computing fallback from countervalues (~$${FALLBACK_TARGET_USD} USD)`,
+    );
+    return await getAmountFromUSD(currencyId, FALLBACK_TARGET_USD);
+  } catch (error: unknown) {
+    const sanitizedError = sanitizeError(error);
+    console.warn("Error fetching sell minimum amount:", sanitizedError);
+
+    // Last resort: try to compute a sensible amount even if the limitations call failed entirely.
+    try {
+      return await getAmountFromUSD(currencyId, FALLBACK_TARGET_USD);
+    } catch {
+      return null;
+    }
+  }
+}

--- a/libs/ledger-live-common/src/e2e/buySell.ts
+++ b/libs/ledger-live-common/src/e2e/buySell.ts
@@ -17,15 +17,6 @@ type CryptoLimitationsResponse = {
   value?: Record<string, CryptoLimitation>;
 };
 
-/**
- * Returns the minimum amount to sell `currencyId`, formatted as an input-ready string.
- *
- * Formatting (trim to 6 decimals, drop trailing zeros) lives here so every consumer
- * (desktop + mobile E2E) enters the exact same value — avoiding the per-POM drift the
- * swap helpers suffer from (desktop rounds to 6dp, mobile uses full precision).
- *
- * @throws if the minimum cannot be determined from the API or the countervalues fallback.
- */
 export async function getMinimumSellAmount(currencyId: string): Promise<string> {
   const amount = await fetchMinimumSellAmount(currencyId);
   if (amount === null) {

--- a/libs/ledger-live-common/src/e2e/currencyUtils.ts
+++ b/libs/ledger-live-common/src/e2e/currencyUtils.ts
@@ -1,0 +1,33 @@
+import { sanitizeError } from "./index";
+import axios from "axios";
+
+const COUNTERVALUES_URL = "https://countervalues.live.ledger.com/v3/spot/simple";
+
+/**
+ * Fetches the current USD price for a currency from the Ledger countervalues API
+ * and converts a target USD value into the equivalent crypto amount.
+ */
+export async function getAmountFromUSD(
+  currencyId: string,
+  targetUSD: number,
+): Promise<number | null> {
+  try {
+    const { data } = await axios.get(COUNTERVALUES_URL, {
+      params: {
+        froms: currencyId,
+        to: "USD",
+      },
+    });
+
+    const price = data?.[currencyId];
+    if (!price || price <= 0) {
+      console.warn(`No USD price found for ${currencyId}`);
+      return null;
+    }
+
+    return targetUSD / price;
+  } catch (error: unknown) {
+    console.warn(`Failed to fetch countervalue for ${currencyId}:`, sanitizeError(error));
+    return null;
+  }
+}

--- a/libs/ledger-live-common/src/e2e/swap.ts
+++ b/libs/ledger-live-common/src/e2e/swap.ts
@@ -2,11 +2,11 @@ import { Account } from "./enum/Account";
 import { sanitizeError } from "./index";
 import axios, { AxiosRequestConfig } from "axios";
 import { SwapProvider } from "./enum/Provider";
+import { getAmountFromUSD } from "./currencyUtils";
 
 // Target a sensible USD amount that works for most pairs
 const FALLBACK_TARGET_USD = 50;
 
-const COUNTERVALUES_URL = "https://countervalues.live.ledger.com/v3/spot/simple";
 const SWAP_QUOTE_URL = "https://swap-stg.ledger-test.com/v5/quote";
 
 /** Smallest amount sent to the quote API to discover minimum thresholds. */
@@ -25,35 +25,6 @@ type QuoteErrorItem = {
 
 function isQuoteErrorItem(item: unknown): item is QuoteErrorItem {
   return typeof item === "object" && item !== null && "parameter" in item;
-}
-
-/**
- * Fetches the current USD price for a currency from the Ledger countervalues API
- * and converts a target USD value into the equivalent crypto amount.
- */
-export async function getAmountFromUSD(
-  currencyId: string,
-  targetUSD: number,
-): Promise<number | null> {
-  try {
-    const { data } = await axios.get(COUNTERVALUES_URL, {
-      params: {
-        froms: currencyId,
-        to: "USD",
-      },
-    });
-
-    const price = data?.[currencyId];
-    if (!price || price <= 0) {
-      console.warn(`No USD price found for ${currencyId}`);
-      return null;
-    }
-
-    return targetUSD / price;
-  } catch (error: unknown) {
-    console.warn(`Failed to fetch countervalue for ${currencyId}:`, sanitizeError(error));
-    return null;
-  }
 }
 
 export async function getMinimumSwapAmount(


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This PR is E2E test tooling; the new `getMinimumSellAmount` helper is exercised by the desktop and mobile buy/sell **sell** specs (Speculos-backed), not by a dedicated unit test._
- [x] **Impact of the changes:**
  - Desktop & mobile **sell** flows: the entered amount is now fetched live (sell `cryptoLimitations` → `maxOfMin`) instead of hardcoded, so it always clears every provider's minimum. Verify quotes appear and the provider URL `cryptoAmount` matches the entered amount.
  - Fallback path: when a currency is absent from the limitations response or the API is unreachable, the amount is derived from USD countervalues (`getAmountFromUSD`).
  - Swap specs must still resolve `getAmountFromUSD` after it moved to `currencyUtils` (mobile DEX-native flow + token-approval flow).

### 📝 Description

Hardcoded sell amounts in the buy/sell E2E specs were brittle: a fixed value (e.g. BTC `0.0003`) could sit above the global minimum yet below a specific provider's threshold (e.g. MoonPay), so no quote was returned and the test failed.

This PR makes the sell amount dynamic. A new `getMinimumSellAmount(currencyId)` helper (in `@ledgerhq/live-common/e2e`) fetches the per-currency `maxOfMin` from the sell `cryptoLimitations` endpoint — the highest of all providers' minimums — guaranteeing the amount clears every provider, and returns it as an input-ready string (a single source of precision shared by desktop and mobile). If the currency is missing or the request fails, it falls back to a USD-equivalent amount via countervalues. The shared `getAmountFromUSD` helper was extracted from `swap.ts` into `currencyUtils.ts`, and the desktop + mobile sell specs now fetch the amount at test time and build the full `BuySell` object from it.

### ❓ Context

- **JIRA or GitHub link**: [QAA-1071](https://ledgerhq.atlassian.net/browse/QAA-1071)
- Desktop CI: [nano](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/ac026ee0-ef96-478b-9d99-4eee4dca9830/) / [stax](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/f05761bf-1892-4d2e-a677-af12be56d6e4/)
- Mobile CI: [iOS]() / [android](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/d9709de6-74a1-4594-b505-137781fd3d1d/#)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1071]: https://ledgerhq.atlassian.net/browse/QAA-1071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ