### PR TITLE
test(e2e-mobile): allow more time for cleanup tasks

### DIFF
--- a/e2e/mobile/setup.ts
+++ b/e2e/mobile/setup.ts
@@ -16,24 +16,27 @@ beforeAll(
     await device.reverseTcpPort(52619); // To allow the android emulator to access the dummy app
     setAllureDescription();
   },
-  process.env.CI ? 150000 : 120000,
+  process.env.CI ? 150_000 : 120_000,
 );
 
-afterAll(async () => {
-  if (process.env.CI) {
-    try {
-      await app.portfolio.openViaDeeplink(5000);
-      await device.terminateApp();
-    } catch (e) {
-      log.warn(`setup afterAll terminateApp failed: ${sanitizeError(e)}`);
+afterAll(
+  async () => {
+    if (process.env.CI) {
+      try {
+        await app.portfolio.openViaDeeplink(5_000);
+        await device.terminateApp();
+      } catch (e) {
+        log.warn(`setup afterAll terminateApp failed: ${sanitizeError(e)}`);
+      }
     }
-  }
 
-  setEnv("DISABLE_TRANSACTION_BROADCAST", broadcastOriginalValue);
-  closeBridge();
-  try {
-    await app.common.removeSpeculos();
-  } catch (e) {
-    log.warn(`setup afterAll removeSpeculos failed: ${sanitizeError(e)}`);
-  }
-});
+    setEnv("DISABLE_TRANSACTION_BROADCAST", broadcastOriginalValue);
+    closeBridge();
+    try {
+      await app.common.removeSpeculos();
+    } catch (e) {
+      log.warn(`setup afterAll removeSpeculos failed: ${sanitizeError(e)}`);
+    }
+  },
+  process.env.CI ? 60_000 : 30_000,
+);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Nightly regression logs show jest cleanup timing out before it can finish:
```
The tester has not received a response within 5000ms timeout to the message:

Cleanup {
  type: 'cleanup',
  params: [Object],
  messageId: -49642
}
```
Allow more time for cleanup

[Build](https://github.com/LedgerHQ/ledger-live/actions/runs/27285854810):
- [iOS report](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/77c44fd2-694e-4d36-a3ed-e8eb32d2783b/)
- [Android report](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/0d9f8417-e8d3-457a-9cba-e751acaac099/)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/QAA-1311


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
