### PR TITLE
[LWDM] feat(desktop): add favorites ranking to market banner

### DIFF
--- a/.changeset/afraid-rabbits-tie.md
+++ b/.changeset/afraid-rabbits-tie.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+Add a favorites ranking to the desktop Market Banner. The banner now switches between the trending performers list and the user's starred market coins, fetching favorites via `useMarketData` (availability filtering bypassed so starred coins always show) and disabling whichever query is inactive.

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/TrendingAssetsList.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/TrendingAssetsList.test.tsx
@@ -42,7 +42,9 @@ describe("TrendingAssetsList", () => {
   });
 
   it("should render assets, hide left arrow, show right arrow and handle scroll right at start position", async () => {
-    const { user } = render(<TrendingAssetsList items={MOCK_MARKET_PERFORMERS} />);
+    const { user } = render(
+      <TrendingAssetsList items={MOCK_MARKET_PERFORMERS} isLoading={false} isError={false} />,
+    );
 
     expect(screen.getByTestId("trending-assets-list")).toBeVisible();
     expect(screen.getByText("BTC")).toBeVisible();
@@ -55,7 +57,9 @@ describe("TrendingAssetsList", () => {
   });
 
   it("should navigate to asset detail page when asset is clicked", async () => {
-    const { user } = render(<TrendingAssetsList items={MOCK_MARKET_PERFORMERS} />);
+    const { user } = render(
+      <TrendingAssetsList items={MOCK_MARKET_PERFORMERS} isLoading={false} isError={false} />,
+    );
 
     await user.click(screen.getByTestId("market-banner-asset-bitcoin"));
     expect(mockSetTrackingSource).toHaveBeenCalledWith(MARKET_BANNER_TRACKING_SOURCE);
@@ -68,7 +72,9 @@ describe("TrendingAssetsList", () => {
       isAtStart: false,
     });
 
-    const { user } = render(<TrendingAssetsList items={MOCK_MARKET_PERFORMERS} />);
+    const { user } = render(
+      <TrendingAssetsList items={MOCK_MARKET_PERFORMERS} isLoading={false} isError={false} />,
+    );
 
     expect(screen.getByTestId("scroll-arrow-left")).toBeVisible();
 
@@ -82,7 +88,7 @@ describe("TrendingAssetsList", () => {
       isAtEnd: true,
     });
 
-    render(<TrendingAssetsList items={MOCK_MARKET_PERFORMERS} />);
+    render(<TrendingAssetsList items={MOCK_MARKET_PERFORMERS} isLoading={false} isError={false} />);
 
     expect(screen.queryByTestId("scroll-arrow-right")).not.toBeInTheDocument();
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/useMarketBannerViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/useMarketBannerViewModel.test.ts
@@ -1,16 +1,27 @@
 import { renderHook } from "tests/testSetup";
-import { useMarketBannerViewModel } from "../hooks/useMarketBannerViewModel";
+import {
+  usePerformersBannerItems,
+  useFavoritesBannerItems,
+  useMarketBannerViewModel,
+} from "../hooks/useMarketBannerViewModel";
 import { useMarketPerformers } from "@ledgerhq/live-common/market/hooks/useMarketPerformers";
+import { useMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
 import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
 import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
-import { MOCK_MARKET_PERFORMERS } from "@ledgerhq/live-common/market/utils/fixtures";
-import { MarketItemPerformer } from "@ledgerhq/live-common/market/utils/types";
+import {
+  MOCK_MARKET_PERFORMERS,
+  createMockMarketCurrencyData,
+} from "@ledgerhq/live-common/market/utils/fixtures";
+import { MarketItemPerformer, MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { MARKET_BANNER_ITEMS_COUNT } from "../utils/constants";
 
 jest.mock("@ledgerhq/live-common/market/hooks/useMarketPerformers");
+jest.mock("@ledgerhq/live-common/market/hooks/useMarketDataProvider");
 jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog");
 jest.mock("@ledgerhq/live-common/exchange/swap/hooks/index");
 
 const mockedUseMarketPerformers = jest.mocked(useMarketPerformers);
+const mockedUseMarketData = jest.mocked(useMarketData);
 
 function mockPerformersQuery(
   overrides: Partial<{
@@ -29,7 +40,26 @@ function mockPerformersQuery(
   } as ReturnType<typeof useMarketPerformers>);
 }
 
-describe("useMarketBannerViewModel", () => {
+function mockMarketDataQuery(
+  overrides: Partial<{
+    data: MarketCurrencyData[];
+    isLoading: boolean;
+    isFetching: boolean;
+    isError: boolean;
+  }>,
+) {
+  mockedUseMarketData.mockReturnValue({
+    data: [],
+    isPending: false,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    cachedMetadataMap: new Map(),
+    ...overrides,
+  } as ReturnType<typeof useMarketData>);
+}
+
+describe("MarketBanner view models", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -44,58 +74,186 @@ describe("useMarketBannerViewModel", () => {
     } as unknown as ReturnType<typeof useFetchCurrencyAll>);
   });
 
-  describe("isLoading", () => {
-    it("should be true during the initial load (no cached data)", () => {
-      mockPerformersQuery({ isLoading: true, isFetching: true });
+  describe("usePerformersBannerItems", () => {
+    describe("isLoading", () => {
+      it("should be true during the initial load (no cached data)", () => {
+        mockPerformersQuery({ isLoading: true, isFetching: true });
 
-      const { result } = renderHook(() => useMarketBannerViewModel());
+        const { result } = renderHook(() => usePerformersBannerItems("trending"));
 
-      expect(result.current.isLoading).toBe(true);
-      expect(result.current.data).toEqual([]);
+        expect(result.current.isLoading).toBe(true);
+        expect(result.current.items).toEqual([]);
+      });
+
+      it("should be true when fetching without any cached data", () => {
+        mockPerformersQuery({ isFetching: true });
+
+        const { result } = renderHook(() => usePerformersBannerItems("trending"));
+
+        expect(result.current.isLoading).toBe(true);
+      });
+
+      it("should be false during a background refetch when data already exists", () => {
+        mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS, isFetching: true });
+
+        const { result } = renderHook(() => usePerformersBannerItems("trending"));
+
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.items.length).toBeGreaterThan(0);
+      });
+
+      it("should be false when data is loaded and the query is idle", () => {
+        mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
+
+        const { result } = renderHook(() => usePerformersBannerItems("trending"));
+
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.items.length).toBeGreaterThan(0);
+      });
     });
 
-    it("should be true when fetching without any cached data", () => {
-      mockPerformersQuery({ isFetching: true });
+    describe("isError", () => {
+      it("should be true when the query errors and is not refetching", () => {
+        mockPerformersQuery({ isError: true });
 
-      const { result } = renderHook(() => useMarketBannerViewModel());
+        const { result } = renderHook(() => usePerformersBannerItems("trending"));
 
-      expect(result.current.isLoading).toBe(true);
+        expect(result.current.isError).toBe(true);
+      });
+
+      it("should be suppressed while a refetch is in progress", () => {
+        mockPerformersQuery({ isError: true, isFetching: true });
+
+        const { result } = renderHook(() => usePerformersBannerItems("trending"));
+
+        expect(result.current.isError).toBe(false);
+      });
     });
 
-    it("should be false during a background refetch when data already exists", () => {
-      mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS, isFetching: true });
+    describe("ranking → sort mapping", () => {
+      it.each(["trending", "gainers"] as const)(
+        "should request ascending order for %s",
+        ranking => {
+          mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
 
-      const { result } = renderHook(() => useMarketBannerViewModel());
+          renderHook(() => usePerformersBannerItems(ranking));
 
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.data.length).toBeGreaterThan(0);
-    });
+          expect(mockedUseMarketPerformers).toHaveBeenCalledWith(
+            expect.objectContaining({ sort: "asc" }),
+            expect.anything(),
+          );
+        },
+      );
 
-    it("should be false when data is loaded and the query is idle", () => {
-      mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
+      it("should request descending order for losers", () => {
+        mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
 
-      const { result } = renderHook(() => useMarketBannerViewModel());
+        renderHook(() => usePerformersBannerItems("losers"));
 
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.data.length).toBeGreaterThan(0);
+        expect(mockedUseMarketPerformers).toHaveBeenCalledWith(
+          expect.objectContaining({ sort: "desc" }),
+          expect.anything(),
+        );
+      });
     });
   });
 
-  describe("isError", () => {
-    it("should be true when the query errors and is not refetching", () => {
-      mockPerformersQuery({ isError: true });
+  describe("useFavoritesBannerItems", () => {
+    it("should bypass availability filtering and keep coins that are not tradeable", () => {
+      const available = createMockMarketCurrencyData({ id: "bitcoin", ledgerIds: ["bitcoin"] });
+      const notTradeable = createMockMarketCurrencyData({
+        id: "some-token",
+        ledgerIds: ["some-token"],
+      });
+      mockMarketDataQuery({ data: [available, notTradeable] });
 
-      const { result } = renderHook(() => useMarketBannerViewModel());
+      // Restrict availability to bitcoin only: if the favorites path ever applied
+      // filterMarketPerformersByAvailability, `some-token` would be dropped and this
+      // assertion would fail. Keeping both proves the filter is bypassed.
+      jest.mocked(useRampCatalog).mockReturnValue({
+        isCurrencyAvailable: (id: string) => id === "bitcoin",
+      } as unknown as ReturnType<typeof useRampCatalog>);
+      jest.mocked(useFetchCurrencyAll).mockReturnValue({
+        data: ["bitcoin"],
+      } as unknown as ReturnType<typeof useFetchCurrencyAll>);
 
-      expect(result.current.isError).toBe(true);
+      const { result } = renderHook(() => useFavoritesBannerItems(), {
+        initialState: { settings: { starredMarketCoins: ["bitcoin", "some-token"] } },
+      });
+
+      expect(result.current.items.map(item => item.id)).toEqual(["bitcoin", "some-token"]);
     });
 
-    it("should be suppressed while a refetch is in progress", () => {
-      mockPerformersQuery({ isError: true, isFetching: true });
+    it("should not query the list endpoint when there are no starred coins", () => {
+      mockMarketDataQuery({});
 
-      const { result } = renderHook(() => useMarketBannerViewModel());
+      const { result } = renderHook(() => useFavoritesBannerItems(), {
+        initialState: { settings: { starredMarketCoins: [] } },
+      });
 
-      expect(result.current.isError).toBe(false);
+      expect(mockedUseMarketData).toHaveBeenCalledWith(
+        expect.objectContaining({ starred: [] }),
+        expect.objectContaining({ enabled: false }),
+      );
+      expect(result.current.items).toEqual([]);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it("should cap the result to MARKET_BANNER_ITEMS_COUNT", () => {
+      const data = Array.from({ length: MARKET_BANNER_ITEMS_COUNT + 5 }, (_, i) =>
+        createMockMarketCurrencyData({ id: `coin-${i}` }),
+      );
+      mockMarketDataQuery({ data });
+
+      const { result } = renderHook(() => useFavoritesBannerItems());
+
+      expect(result.current.items).toHaveLength(MARKET_BANNER_ITEMS_COUNT);
+    });
+
+    it("should be loading on first fetch and surface errors when not refetching", () => {
+      mockMarketDataQuery({ isLoading: true });
+      const { result: loading } = renderHook(() => useFavoritesBannerItems());
+      expect(loading.current.isLoading).toBe(true);
+
+      mockMarketDataQuery({ isError: true });
+      const { result: errored } = renderHook(() => useFavoritesBannerItems());
+      expect(errored.current.isError).toBe(true);
+    });
+  });
+
+  describe("useMarketBannerViewModel", () => {
+    it("returns favorites data and skips the performers query when ranking is favorites", () => {
+      mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
+      mockMarketDataQuery({ data: [createMockMarketCurrencyData({ id: "bitcoin" })] });
+
+      const { result } = renderHook(() => useMarketBannerViewModel(), {
+        initialState: {
+          marketBanner: { ranking: "favorites" },
+          settings: { starredMarketCoins: ["bitcoin"] },
+        },
+      });
+
+      expect(mockedUseMarketPerformers).toHaveBeenCalledWith(expect.anything(), { skip: true });
+      expect(result.current.items.map(item => item.id)).toEqual(["bitcoin"]);
+    });
+
+    it("returns performers data and disables the favorites query for a performers ranking", () => {
+      mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
+      mockMarketDataQuery({});
+
+      const { result } = renderHook(() => useMarketBannerViewModel(), {
+        initialState: { marketBanner: { ranking: "losers" } },
+      });
+
+      expect(mockedUseMarketData).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ enabled: false }),
+      );
+      expect(mockedUseMarketPerformers).toHaveBeenCalledWith(
+        expect.objectContaining({ sort: "desc" }),
+        { skip: false },
+      );
+      expect(result.current.items.length).toBeGreaterThan(0);
     });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
@@ -4,6 +4,8 @@ import { MarketItemPerformer } from "@ledgerhq/live-common/market/utils/types";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { ViewAllTile } from "./ViewAllTile";
 import { TrendingAssetTile } from "./TrendingAssetTile";
+import SkeletonList from "./SkeletonList";
+import GenericError from "./GenericError";
 import { track } from "~/renderer/analytics/segment";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import FearAndGreed from "LLD/features/FearAndGreed";
@@ -15,9 +17,11 @@ import { MARKET_BANNER_TRACKING_SOURCE } from "../utils/constants";
 
 type TrendingAssetsListProps = {
   readonly items: MarketItemPerformer[];
+  readonly isLoading: boolean;
+  readonly isError: boolean;
 };
 
-export const TrendingAssetsList = ({ items }: TrendingAssetsListProps) => {
+export const TrendingAssetsList = ({ items, isLoading, isError }: TrendingAssetsListProps) => {
   const navigate = useNavigate();
   const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
   const { scrollContainerRef, isAtStart, isAtEnd, scrollLeft, scrollRight } = useHorizontalScroll();
@@ -35,8 +39,24 @@ export const TrendingAssetsList = ({ items }: TrendingAssetsListProps) => {
     [navigate, shouldDisplayAggregatedAssets],
   );
 
+  let assets: React.ReactNode = null;
+  if (isLoading) {
+    assets = <SkeletonList />;
+  } else if (isError) {
+    assets = <GenericError />;
+  } else if (items.length > 0) {
+    assets = (
+      <div data-testid="trending-assets-list" className="contents">
+        {items.map(item => (
+          <TrendingAssetTile key={item.id} item={item} onNavigate={onAssetClick} />
+        ))}
+        <ViewAllTile />
+      </div>
+    );
+  }
+
   return (
-    <div className="group relative" data-testid="trending-assets-list">
+    <div className="group relative" data-testid="market-banner-carousel">
       {!isAtStart && <ScrollArrowButton direction="left" onClick={scrollLeft} />}
       <div
         ref={scrollContainerRef}
@@ -45,10 +65,7 @@ export const TrendingAssetsList = ({ items }: TrendingAssetsListProps) => {
       >
         <div className="flex w-max items-stretch gap-8">
           <FearAndGreed />
-          {items.map(item => (
-            <TrendingAssetTile key={item.id} item={item} onNavigate={onAssetClick} />
-          ))}
-          <ViewAllTile />
+          {assets}
         </div>
       </div>
       {!isAtEnd && <ScrollArrowButton direction="right" onClick={scrollRight} />}

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
@@ -1,53 +1,145 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useMarketPerformers } from "@ledgerhq/live-common/market/hooks/useMarketPerformers";
-import { useSelector } from "LLD/hooks/redux";
-import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
-import { MARKET_BANNER_ITEMS_COUNT } from "../utils/constants";
-import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
-import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
+import { useMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
 import { filterMarketPerformersByAvailability } from "@ledgerhq/live-common/market/utils/index";
 import {
-  MARKET_BANNER_TOP,
-  MARKET_BANNER_DATA_SORT_ORDER,
-  MARKET_BANNER_REFRESH_RATE,
-  MARKET_PERFORMERS_SUPPORTED,
+  KeysPriceChange,
+  type MarketCurrencyData,
+  type MarketItemPerformer,
+  Order,
+} from "@ledgerhq/live-common/market/utils/types";
+import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
+import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
+import {
   TIME_RANGE,
+  MARKET_BANNER_TOP,
+  MARKET_PERFORMERS_SUPPORTED,
+  MARKET_BANNER_REFRESH_RATE,
 } from "@ledgerhq/live-common/market/constants";
+import { useSelector } from "LLD/hooks/redux";
+import {
+  counterValueCurrencySelector,
+  starredMarketCoinsSelector,
+} from "~/renderer/reducers/settings";
+import {
+  selectMarketBannerRanking,
+  type MarketBannerRanking,
+} from "~/renderer/reducers/marketBanner";
+import { MARKET_BANNER_ITEMS_COUNT } from "../utils/constants";
 
-export const useMarketBannerViewModel = () => {
-  const countervalue = useSelector(counterValueCurrencySelector);
+/** Valid `pageSize` values are 1 / 5 / 20 / 50; 50 covers the favorites banner item cap. */
+const MARKET_BANNER_FAVORITES_LIMIT = 50;
+
+export type MarketBannerItems = {
+  items: MarketItemPerformer[];
+  isLoading: boolean;
+  isError: boolean;
+};
+
+function toPerformer(currency: MarketCurrencyData): MarketItemPerformer {
+  const change = currency.priceChangePercentage;
+  return {
+    id: currency.id,
+    name: currency.name,
+    ticker: currency.ticker,
+    ledgerIds: currency.ledgerIds,
+    image: currency.image ?? "",
+    price: currency.price,
+    priceChangePercentage1h: change[KeysPriceChange.hour] ?? 0,
+    priceChangePercentage24h: change[KeysPriceChange.day] ?? 0,
+    priceChangePercentage7d: change[KeysPriceChange.week] ?? 0,
+    priceChangePercentage30d: change[KeysPriceChange.month] ?? 0,
+    priceChangePercentage1y: change[KeysPriceChange.year] ?? 0,
+  };
+}
+
+function useMarketAvailabilityFilter() {
   const { isCurrencyAvailable } = useRampCatalog();
-
   const { data: currenciesForSwapAll } = useFetchCurrencyAll();
   const currenciesForSwapAllSet = useMemo(
     () => new Set(currenciesForSwapAll ?? []),
     [currenciesForSwapAll],
   );
 
-  const { data, isError, isLoading, isFetching } = useMarketPerformers({
-    sort: MARKET_BANNER_DATA_SORT_ORDER,
-    counterCurrency: countervalue.ticker,
-    range: TIME_RANGE,
-    limit: MARKET_BANNER_TOP,
-    top: MARKET_BANNER_TOP,
-    supported: MARKET_PERFORMERS_SUPPORTED,
-    refreshRate: MARKET_BANNER_REFRESH_RATE,
-  });
+  return useCallback(
+    (items: MarketItemPerformer[]) =>
+      filterMarketPerformersByAvailability(
+        items,
+        isCurrencyAvailable,
+        currenciesForSwapAllSet,
+        MARKET_BANNER_ITEMS_COUNT,
+      ),
+    [isCurrencyAvailable, currenciesForSwapAllSet],
+  );
+}
 
-  const filteredItems = useMemo(() => {
-    if (!data) return [];
+export function usePerformersBannerItems(
+  ranking: MarketBannerRanking,
+  options?: { skip?: boolean },
+): MarketBannerItems {
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const filterItems = useMarketAvailabilityFilter();
 
-    return filterMarketPerformersByAvailability(
-      data,
-      isCurrencyAvailable,
-      currenciesForSwapAllSet,
-      MARKET_BANNER_ITEMS_COUNT,
-    );
-  }, [data, isCurrencyAvailable, currenciesForSwapAllSet]);
+  const { data, isError, isLoading, isFetching } = useMarketPerformers(
+    {
+      sort: ranking === "losers" ? "desc" : "asc",
+      counterCurrency: counterValueCurrency.ticker,
+      range: TIME_RANGE,
+      limit: MARKET_BANNER_TOP,
+      top: MARKET_BANNER_TOP,
+      supported: MARKET_PERFORMERS_SUPPORTED,
+      refreshRate: MARKET_BANNER_REFRESH_RATE,
+    },
+    { skip: options?.skip },
+  );
+
+  const items = useMemo(() => filterItems(data ?? []), [filterItems, data]);
 
   return {
-    data: filteredItems,
-    isError: isError && !isFetching,
+    items,
     isLoading: isLoading || (isFetching && !data),
+    isError: isError && !isFetching,
   };
-};
+}
+
+// Availability filtering is bypassed so a starred coin shows even when not swap-available.
+// The endpoint returns the whole market when no `ids` are sent, so the query is disabled when
+// there are no starred coins (or favorites is not active).
+export function useFavoritesBannerItems(options?: { skip?: boolean }): MarketBannerItems {
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const starredMarketCoins = useSelector(starredMarketCoinsSelector);
+
+  const sortedStarredIds = useMemo(
+    () => [...starredMarketCoins].sort((a, b) => a.localeCompare(b)),
+    [starredMarketCoins],
+  );
+
+  const { data, isError, isLoading, isFetching } = useMarketData(
+    {
+      counterCurrency: counterValueCurrency.ticker.toLowerCase(),
+      range: "24h",
+      order: Order.MarketCapDesc,
+      limit: MARKET_BANNER_FAVORITES_LIMIT,
+      starred: sortedStarredIds,
+    },
+    { enabled: !options?.skip && sortedStarredIds.length > 0 },
+  );
+
+  const items = useMemo(() => data.map(toPerformer).slice(0, MARKET_BANNER_ITEMS_COUNT), [data]);
+
+  return {
+    items,
+    isLoading,
+    isError: isError && !isFetching,
+  };
+}
+
+export function useMarketBannerViewModel(): MarketBannerItems {
+  const ranking = useSelector(selectMarketBannerRanking);
+  const isFavorites = ranking === "favorites";
+
+  const performers = usePerformersBannerItems(ranking, { skip: isFavorites });
+  const favorites = useFavoritesBannerItems({ skip: !isFavorites });
+
+  return isFavorites ? favorites : performers;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/index.tsx
@@ -1,8 +1,6 @@
 import React, { memo, useCallback } from "react";
-import SkeletonList from "./components/SkeletonList";
 import { useNavigate } from "react-router";
 import { useMarketBannerViewModel } from "./hooks/useMarketBannerViewModel";
-import GenericError from "./components/GenericError";
 import { MarketItemPerformer } from "@ledgerhq/live-common/market/utils/types";
 import { TrendingAssetsList } from "./components/TrendingAssetsList";
 import { MarketBannerHeader } from "./components/MarketBannerHeader";
@@ -30,27 +28,18 @@ const MarketBannerView = memo(function MarketBannerView({
     navigate("/market");
   }, [navigate]);
 
-  let content: React.ReactNode = null;
-  if (isLoading) {
-    content = <SkeletonList />;
-  } else if (isError) {
-    content = <GenericError />;
-  } else if (data && data.length > 0) {
-    content = <TrendingAssetsList items={data} />;
-  }
-
   return (
     <div className="flex flex-col gap-12">
       <MarketBannerHeader onNavigate={goToMarket} />
-      {content}
+      <TrendingAssetsList items={data ?? []} isLoading={isLoading} isError={isError} />
     </div>
   );
 });
 
 const MarketBanner = () => {
-  const { isLoading, isError, data } = useMarketBannerViewModel();
+  const { items, isLoading, isError } = useMarketBannerViewModel();
 
-  return <MarketBannerView isLoading={isLoading} isError={isError} data={data} />;
+  return <MarketBannerView isLoading={isLoading} isError={isError} data={items} />;
 };
 
 export { MarketBannerView };

--- a/libs/ledger-live-common/src/market/hooks/useMarketDataProvider.ts
+++ b/libs/ledger-live-common/src/market/hooks/useMarketDataProvider.ts
@@ -48,8 +48,12 @@ export const useGlobalMarketData = ({ counterCurrency }: GlobalMarketDataRequest
     },
   );
 
-export function useMarketData(props: MarketListRequestParams): MarketListRequestResult {
+export function useMarketData(
+  props: MarketListRequestParams,
+  options?: { enabled?: boolean },
+): MarketListRequestResult {
   const search = props.search?.toLowerCase() ?? "";
+  const enabled = options?.enabled ?? true;
   return useQueries({
     queries: Array.from({ length: props.page ?? 1 }, (_, i) => i).map(page => ({
       queryKey: [
@@ -72,6 +76,7 @@ export function useMarketData(props: MarketListRequestParams): MarketListRequest
         formattedData: currencyFormatter(data),
         page,
       }),
+      enabled,
       refetchOnMount: false,
       refetchOnReconnect: true,
       refetchOnWindowFocus: false,

--- a/libs/ledger-live-common/src/market/hooks/useMarketPerformers.ts
+++ b/libs/ledger-live-common/src/market/hooks/useMarketPerformers.ts
@@ -2,19 +2,23 @@ import { MarketPerformersParams } from "../utils/types";
 import { useGetMarketPerformersQuery } from "../state-manager/api";
 import { REFETCH_TIME_ONE_MINUTE } from "../utils/timers";
 
-export const useMarketPerformers = ({
-  counterCurrency,
-  range,
-  limit = 5,
-  top = 50,
-  sort,
-  supported,
-  refreshRate,
-}: MarketPerformersParams) =>
+export const useMarketPerformers = (
+  {
+    counterCurrency,
+    range,
+    limit = 5,
+    top = 50,
+    sort,
+    supported,
+    refreshRate,
+  }: MarketPerformersParams,
+  options?: { skip?: boolean },
+) =>
   useGetMarketPerformersQuery(
     { counterCurrency, range, limit, top, sort, supported },
     {
       pollingInterval: REFETCH_TIME_ONE_MINUTE * Number(refreshRate),
       refetchOnReconnect: true,
+      skip: options?.skip,
     },
   );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Switching the Market Banner between the **trending** performers list and the **favorites** (starred market coins) ranking
  - Starred coins must appear even when they are not swap-available (availability filtering is bypassed for favorites)
  - Empty favorites state (no starred coins → query disabled, no full-market fetch)
  - No redundant fetches: the inactive ranking query is disabled
  - Existing trending list behaviour, scroll arrows, and "View all" tile remain unchanged

### 📝 Description

The desktop Market Banner previously displayed only the trending performers list. Users had no way to surface their own starred market coins directly in the banner.

This PR adds a **favorites ranking** to the banner. `useMarketBannerViewModel` now reads the selected ranking from the `marketBanner` Redux slice and returns either:

- **trending** — the existing performers list (`usePerformersBannerItems`), or
- **favorites** — the user's starred market coins (`useFavoritesBannerItems`), fetched via `useMarketData`.

Key implementation details:

- Favorites are fetched by passing the sorted starred ids to `useMarketData`; availability filtering is intentionally **bypassed** so a starred coin shows even when it is not swap-available.
- The favorites query is **disabled** when there are no starred coins (the endpoint returns the whole market when no `ids` are sent), and whichever ranking is inactive is skipped to avoid redundant requests.
- `useMarketData` and `useMarketPerformers` gained an `enabled` / `skip` option to support disabling the inactive query.
- `TrendingAssetsList` now owns the loading / error / empty rendering (moved out of `index.tsx`) and exposes a `trending-assets-list` test id.



https://github.com/user-attachments/assets/db5dda66-ce35-44d8-a199-9ed94168637e



### ❓ Context

- **JIRA or GitHub link**: [LIVE-29885](https://ledgerhq.atlassian.net/browse/LIVE-29885) & [LIVE-29883](https://ledgerhq.atlassian.net/browse/LIVE-29883)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIVE-29885]: https://ledgerhq.atlassian.net/browse/LIVE-29885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ