### PR TITLE
[LWD] fix(desktop): use Settings countervalue in Market list when asset discoverability is enabled

### DIFF
--- a/.changeset/proud-experts-argue.md
+++ b/.changeset/proud-experts-argue.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix(market): use the Settings countervalue in the Market list when asset discoverability is enabled
+
+When the asset discoverability feature flag is enabled, the per-market countervalue selector is hidden, so the Market list now follows the app-wide Settings countervalue (validated against the supported list, defaulting to USD) for both fetching and displaying prices. When the flag is off, the market store remains the source of truth and the dropdown still drives the list.

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
@@ -9,7 +9,11 @@ import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { setMarketCurrentPage, setMarketOptions } from "~/renderer/actions/market";
 import { useInitSupportedCounterValues } from "~/renderer/hooks/useInitSupportedCounterValues";
 import { marketCurrentPageSelector, marketParamsSelector } from "~/renderer/reducers/market";
-import { localeSelector, starredMarketCoinsSelector } from "~/renderer/reducers/settings";
+import {
+  counterValueCurrencySelector,
+  localeSelector,
+  starredMarketCoinsSelector,
+} from "~/renderer/reducers/settings";
 import {
   BASIC_REFETCH,
   REFETCH_TIME_ONE_MINUTE,
@@ -31,6 +35,7 @@ export function useMarket() {
   const marketCurrentPage = useSelector(marketCurrentPageSelector);
   const starredMarketCoins: string[] = useSelector(starredMarketCoinsSelector);
   const locale = useSelector(localeSelector);
+  const settingsCounterValue = useSelector(counterValueCurrencySelector).ticker.toLowerCase();
 
   const REFRESH_RATE =
     Number(lldRefreshMarketDataFeature?.params?.refreshTime) > 0
@@ -59,8 +64,16 @@ export function useMarket() {
 
   const shouldDisplayLiveCompatible = filterBySupported || marketParams.liveCompatible;
 
+  const effectiveCounterCurrency = shouldDisplayAssetDiscoverability
+    ? supportedCounterCurrencies?.includes(settingsCounterValue)
+      ? settingsCounterValue
+      : "usd"
+    : marketParams.counterCurrency;
+
+  const resolvedMarketParams = { ...marketParams, counterCurrency: effectiveCounterCurrency };
+
   const marketResult = useMarketDataHook({
-    ...marketParams,
+    ...resolvedMarketParams,
     starred: starFilterOn ? starredMarketCoins : starred,
     liveCompatible: shouldDisplayLiveCompatible,
     filter: getMarketFilter(isStocksCategory) ?? marketParams.filter,
@@ -256,7 +269,7 @@ export function useMarket() {
     starredMarketCoins,
     timeRanges,
     timeRangeSelectOptions,
-    marketParams,
+    marketParams: resolvedMarketParams,
     marketCurrentPage,
     timeRangeValue,
     itemCount,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No automated tests added — there is no existing `useMarket` test harness, and the change is a small flag-gated read-path override. Validated via typecheck and manual testing._
- [x] **Impact of the changes:**
      - Market list price values/currency when the asset discoverability FF (`lwdWallet40` + `assetDiscoverability`) is **enabled** — should follow the global Settings countervalue
      - Switching the Settings countervalue should re-fetch and re-format the Market list and TopCards consistently
      - Regression check with the FF **disabled**: the per-market countervalue dropdown must reappear and still drive the list independently of Settings
      - Fallback to USD when the Settings currency is not in the market's supported countervalues

### 📝 Description

**Problem**: When the asset discoverability feature flag is enabled, the Market screen hides its dedicated per-market countervalue selector. However, the Market list still fetched and displayed prices using `counterCurrency` from the market Redux store (default `USD`), independently of the app-wide countervalue chosen in Settings. This was inconsistent with the rest of that screen — the Global Market Cap TopCard already reads the Settings countervalue — and left users with no way to change the market's countervalue.

**Solution**: In `useMarket`, when `shouldDisplayAssetDiscoverability` is enabled, the Market list now derives its `counterCurrency` from the Settings countervalue (`counterValueCurrencySelector`), validated against the supported list and defaulting to `usd` (mirroring the existing `setCounterCurrency` logic). The resolved value is used both for the data fetch (`useMarketData`) and for the returned `marketParams`, so the rows and `TrackPage` display the same currency that was fetched. When the flag is off, behavior is unchanged: the market store remains the source of truth and the dropdown still works.


https://github.com/user-attachments/assets/f3dd8dc3-22f8-4542-b442-7a934b60cca5


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-32176

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)