### PR TITLE
[LWDM] feat(live-common): handle wallet-api account.getPublicKey for tezos

### DIFF
--- a/.changeset/tezos-walletapi-account-getpublickey.md
+++ b/.changeset/tezos-walletapi-account-getpublickey.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Handle the Wallet API `account.getPublicKey` method. The wallet resolves the account public key per family, fail-closed: Tezos returns its base58 public key (from `seedIdentifier`) and every other family rejects with "not implemented". Enables dApp flows that need the public key up front (e.g. `tezos_getAccounts`).

--- a/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
@@ -32,6 +32,7 @@ const methods = [
   "bitcoin.getAddress",
   "bitcoin.getAddresses",
   "bitcoin.getPublicKey",
+  "account.getPublicKey",
   "bitcoin.getXPub",
   "exchange.start",
   "exchange.complete",

--- a/libs/ledger-live-common/src/wallet-api/logic.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/logic.test.ts
@@ -1,4 +1,5 @@
 import {
+  accountGetPublicKeyLogic,
   bitcoinFamilyAccountGetAddressLogic,
   bitcoinFamilyAccountGetAddressesLogic,
   bitcoinFamilyAccountGetPublicKeyLogic,
@@ -915,6 +916,129 @@ describe("bitcoinFamilyAccountGetPublicKeyLogic", () => {
   });
 });
 
+describe("accountGetPublicKeyLogic", () => {
+  // Given
+  const mockAccountGetPublicKeyRequested = jest.fn();
+  const mockAccountGetPublicKeyFail = jest.fn();
+  const mockAccountGetPublicKeySuccess = jest.fn();
+
+  const tezosCrypto = cryptocurrenciesById["tezos"];
+  const tezosAccountId = "js:2:tezos:0x013:";
+  const tezosPublicKey = "edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav";
+
+  const context = createContextContainingAccountId({
+    tracking: {
+      accountGetPublicKeyRequested: mockAccountGetPublicKeyRequested,
+      accountGetPublicKeyFail: mockAccountGetPublicKeyFail,
+      accountGetPublicKeySuccess: mockAccountGetPublicKeySuccess,
+    },
+    accountsParams: [{ id: "11" }, { id: "12" }, { id: "13", currency: tezosCrypto }],
+  });
+
+  beforeEach(() => {
+    mockAccountGetPublicKeyRequested.mockClear();
+    mockAccountGetPublicKeyFail.mockClear();
+    mockAccountGetPublicKeySuccess.mockClear();
+    mockedGetAccountIdFromWalletAccountId.mockClear();
+    // seedIdentifier holds the base58 public key for a scanned tezos account
+    const tezosAccount = context.accounts.find(a => a.id === tezosAccountId);
+    if (tezosAccount?.type === "Account") tezosAccount.seedIdentifier = tezosPublicKey;
+  });
+
+  const walletAccountId = "806ea21d-f5f0-425a-add3-39d4b78209f1";
+
+  it.each([
+    {
+      desc: "receive unknown accountId",
+      accountId: undefined,
+      errorMessage: `accountId ${walletAccountId} unknown`,
+    },
+    {
+      desc: "account not found",
+      accountId: "js:2:ethereum:0x010:",
+      errorMessage: "account not found",
+    },
+    {
+      desc: "account family has no resolver",
+      accountId: "js:2:ethereum:0x012:",
+      errorMessage: "account.getPublicKey not implemented",
+    },
+  ])("returns an error when $desc", async ({ accountId, errorMessage }) => {
+    // Given
+    mockedGetAccountIdFromWalletAccountId.mockReturnValueOnce(accountId);
+
+    // When
+    await expect(async () => {
+      await accountGetPublicKeyLogic(context, walletAccountId);
+    }).rejects.toThrow(errorMessage);
+
+    // Then
+    expect(mockAccountGetPublicKeyRequested).toHaveBeenCalledTimes(1);
+    expect(mockAccountGetPublicKeyFail).toHaveBeenCalledTimes(1);
+    expect(mockAccountGetPublicKeySuccess).toHaveBeenCalledTimes(0);
+  });
+
+  it("returns the public key for a tezos account", async () => {
+    // Given
+    mockedGetAccountIdFromWalletAccountId.mockReturnValueOnce(tezosAccountId);
+
+    // When
+    const result = await accountGetPublicKeyLogic(context, walletAccountId);
+
+    // Then
+    expect(result).toEqual(tezosPublicKey);
+    expect(mockAccountGetPublicKeyRequested).toHaveBeenCalledTimes(1);
+    expect(mockAccountGetPublicKeyFail).toHaveBeenCalledTimes(0);
+    expect(mockAccountGetPublicKeySuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the parent public key for a tezos token account", async () => {
+    // Given a token account whose parent is the tezos main account
+    const tokenAccountId = "js:2:tezos:0x013:+token";
+    context.accounts = [createTokenAccount(tokenAccountId, tezosAccountId), ...context.accounts];
+    mockedGetAccountIdFromWalletAccountId.mockReturnValueOnce(tokenAccountId);
+
+    // When
+    const result = await accountGetPublicKeyLogic(context, walletAccountId);
+
+    // Then
+    expect(result).toEqual(tezosPublicKey);
+    expect(mockAccountGetPublicKeyFail).toHaveBeenCalledTimes(0);
+    expect(mockAccountGetPublicKeySuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects (and tracks failure) when seedIdentifier is not a tezos public key", async () => {
+    // Given a tezos account whose seedIdentifier is not a base58 public key
+    const tezosAccount = context.accounts.find(a => a.id === tezosAccountId);
+    if (tezosAccount?.type === "Account") tezosAccount.seedIdentifier = "0x01";
+    mockedGetAccountIdFromWalletAccountId.mockReturnValueOnce(tezosAccountId);
+
+    // When / Then
+    await expect(accountGetPublicKeyLogic(context, walletAccountId)).rejects.toThrow(
+      "account.getPublicKey not implemented",
+    );
+    expect(mockAccountGetPublicKeyFail).toHaveBeenCalledTimes(1);
+    expect(mockAccountGetPublicKeySuccess).toHaveBeenCalledTimes(0);
+  });
+
+  it("rejects (and tracks failure) when a token account's parent is missing", async () => {
+    // Given a token account whose parent is not in the accounts list
+    const tokenAccountId = "js:2:tezos:0xorphan:+token";
+    context.accounts = [
+      createTokenAccount(tokenAccountId, "js:2:tezos:0xmissing:"),
+      ...context.accounts,
+    ];
+    mockedGetAccountIdFromWalletAccountId.mockReturnValueOnce(tokenAccountId);
+
+    // When / Then — getParentAccount throws; it must surface as a rejection, not a sync throw
+    await expect(accountGetPublicKeyLogic(context, walletAccountId)).rejects.toThrow(
+      "account not found",
+    );
+    expect(mockAccountGetPublicKeyFail).toHaveBeenCalledTimes(1);
+    expect(mockAccountGetPublicKeySuccess).toHaveBeenCalledTimes(0);
+  });
+});
+
 describe("bitcoinFamilyAccountGetAddressesLogic", () => {
   const mockBitcoinFamilyAccountAddressesRequested = jest.fn();
   const mockBitcoinFamilyAccountAddressesFail = jest.fn();
@@ -1450,11 +1574,11 @@ function createMessageData() {
   };
 }
 
-function createTokenAccount(id = "32"): TokenAccount {
+function createTokenAccount(id = "32", parentId = "whatever"): TokenAccount {
   return {
     type: "TokenAccount",
     id,
-    parentId: "whatever",
+    parentId,
     token: createTokenCurrency(),
     balance: new BigNumber(0),
     spendableBalance: new BigNumber(0),

--- a/libs/ledger-live-common/src/wallet-api/logic.ts
+++ b/libs/ledger-live-common/src/wallet-api/logic.ts
@@ -28,6 +28,7 @@ import { Exchange } from "../exchange/types";
 import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { WalletState } from "@ledgerhq/live-wallet/store";
 import { getWalletAccount } from "@ledgerhq/coin-bitcoin/wallet-btc/index";
+import { normalizePublicKeyForAddress } from "@ledgerhq/coin-tezos/utils";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 
 export function translateContent(content: string | TranslatableString, locale = "en"): string {
@@ -349,6 +350,49 @@ export const bitcoinFamilyAccountGetPublicKeyLogic = async (
   );
   tracking.bitcoinFamilyAccountPublicKeySuccess(manifest);
   return publicKey.toString("hex");
+};
+
+type AccountPublicKeyResolver = (account: Account) => string | null;
+
+const ACCOUNT_PUBLIC_KEY_RESOLVERS: Record<string, AccountPublicKeyResolver> = {
+  tezos: account =>
+    normalizePublicKeyForAddress(account.seedIdentifier, account.freshAddress) ?? null,
+};
+
+export const accountGetPublicKeyLogic = async (
+  { manifest, accounts, tracking }: WalletAPIContext,
+  walletAccountId: string,
+): Promise<string> => {
+  tracking.accountGetPublicKeyRequested(manifest);
+
+  const accountId = getAccountIdFromWalletAccountId(walletAccountId);
+  if (!accountId) {
+    tracking.accountGetPublicKeyFail(manifest);
+    throw new Error(`accountId ${walletAccountId} unknown`);
+  }
+
+  const account = accounts.find(account => account.id === accountId);
+  if (account === undefined) {
+    tracking.accountGetPublicKeyFail(manifest);
+    throw new Error("account not found");
+  }
+
+  let mainAccount;
+  try {
+    mainAccount = getMainAccount(account, getParentAccount(account, accounts));
+  } catch {
+    tracking.accountGetPublicKeyFail(manifest);
+    throw new Error("account not found");
+  }
+
+  const publicKey = ACCOUNT_PUBLIC_KEY_RESOLVERS[mainAccount.currency.family]?.(mainAccount);
+  if (!publicKey) {
+    tracking.accountGetPublicKeyFail(manifest);
+    throw new Error("account.getPublicKey not implemented");
+  }
+
+  tracking.accountGetPublicKeySuccess(manifest);
+  return publicKey;
 };
 
 export const bitcoinFamilyAccountGetXPubLogic = (

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -49,6 +49,7 @@ import {
   signTransactionLogic,
   bitcoinFamilyAccountGetAddressLogic,
   bitcoinFamilyAccountGetAddressesLogic,
+  accountGetPublicKeyLogic,
   bitcoinFamilyAccountGetPublicKeyLogic,
   signRawTransactionLogic,
   protectStorageLogic,
@@ -1211,6 +1212,12 @@ export function useWalletAPIServer({
         accountId,
         derivationPath,
       );
+    });
+  }, [accounts, manifest, server, tracking]);
+
+  useEffect(() => {
+    server.setHandler("account.getPublicKey", ({ accountId }) => {
+      return accountGetPublicKeyLogic({ manifest, accounts, tracking }, accountId);
     });
   }, [accounts, manifest, server, tracking]);
 

--- a/libs/ledger-live-common/src/wallet-api/tracking.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/tracking.test.ts
@@ -107,6 +107,18 @@ describe("trackingWrapper", () => {
       method: "signMessageUserRefused",
       message: "WalletAPI sign message user refused",
     },
+    {
+      method: "accountGetPublicKeyRequested",
+      message: "WalletAPI account getPublicKey requested",
+    },
+    {
+      method: "accountGetPublicKeyFail",
+      message: "WalletAPI account getPublicKey fail",
+    },
+    {
+      method: "accountGetPublicKeySuccess",
+      message: "WalletAPI account getPublicKey success",
+    },
   ])(
     "calls once inner trackWalletAPI function $method with event named: $message",
     ({ method, message }) => {

--- a/libs/ledger-live-common/src/wallet-api/tracking.ts
+++ b/libs/ledger-live-common/src/wallet-api/tracking.ts
@@ -264,6 +264,15 @@ export default function trackingWrapper(trackCall: TrackWalletAPI) {
     bitcoinFamilyAccountPublicKeySuccess: (manifest: AppManifest) => {
       track("WalletAPI bitcoin family account publicKey success", getEventData(manifest));
     },
+    accountGetPublicKeyRequested: (manifest: AppManifest) => {
+      track("WalletAPI account getPublicKey requested", getEventData(manifest));
+    },
+    accountGetPublicKeyFail: (manifest: AppManifest) => {
+      track("WalletAPI account getPublicKey fail", getEventData(manifest));
+    },
+    accountGetPublicKeySuccess: (manifest: AppManifest) => {
+      track("WalletAPI account getPublicKey success", getEventData(manifest));
+    },
     bitcoinFamilyAccountXpubRequested: (manifest: AppManifest) => {
       track("WalletAPI bitcoin family account xpub requested", getEventData(manifest));
     },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Unit tests for `accountGetPublicKeyLogic`: Tezos returns its public key; unknown account id, missing account, and non-resolver families all reject.
- [x] **Impact of the changes:** library-only addition; no behaviour change for existing families.
  - Registers the `account.getPublicKey` Wallet API handler. Tezos returns its base58 public key (from `seedIdentifier`); every other family rejects with "not implemented" (fail-closed). Unblocks `tezos_getAccounts` (Taquito's `getPK()`).
  - No device interaction and no UI — the handler returns cached account data, like `bitcoin.getPublicKey`.

### 📝 Description

Adds `accountGetPublicKeyLogic` and registers it as the `account.getPublicKey` Wallet API handler (`wallet-api/react.ts`). Dispatch is per-family and fail-closed: Tezos returns `account.seedIdentifier` (its base58 public key), and any family without a resolver rejects — so no key-shaped value is exposed by default. Tracking events (`accountGetPublicKey{Requested,Success,Fail}`) mirror the existing handlers.

This supersedes the earlier approach of exposing a `publicKey` field on the account list: per team review, the public key is delivered on demand through the generic `account.getPublicKey` method rather than as a default field sourced from `seedIdentifier`.

Stacked on #18601 (`chore/wallet-api-update`), which bumps the Wallet API packages to the versions exposing the method (`@ledgerhq/wallet-api-core@^1.33.0`, `-client@^1.15.0`, `-server@^3.4.0`). This PR carries only the live-common handler; it should be retargeted to `develop` once #18601 merges.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32115](https://ledgerhq.atlassian.net/browse/LIVE-32115)
- **ADR link (if any)**: —
- Consumes the `account.getPublicKey` method added in `@ledgerhq/wallet-api-core@1.33.0` (LedgerHQ/wallet-api#587). Part of the Tezos WalletConnect epic.


[LIVE-32115]: https://ledgerhq.atlassian.net/browse/LIVE-32115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
