### PR TITLE
[LWM] chore(lwm): add a Hermes REPL to quickly check compatibilities

### DIFF
--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -10,6 +10,7 @@
     "start:android": "WITH_ROZENITE=true react-native start --platform android",
     "start:msw": "MSW_ENABLED=true react-native start",
     "conf": "react-native config",
+    "hermes": "node ./scripts/hermes.mjs",
     "doc": "react-native doctor",
     "doctor": "NODE_OPTIONS=--max-old-space-size=8192 RSDOCTOR=1 react-native bundle --platform ios --entry-file index.js --dev false --bundle-output main.jsbundle",
     "doctor:open": "open ../../rsdoctor/mobile/report.html",

--- a/apps/ledger-live-mobile/scripts/hermes.mjs
+++ b/apps/ledger-live-mobile/scripts/hermes.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+// Hermes ships a per-platform VM binary inside react-native's sdks/hermesc.
+// Resolve it via react-native's package.json so it follows the pnpm symlink.
+const require = createRequire(import.meta.url);
+const reactNativeRoot = dirname(require.resolve("react-native/package.json"));
+
+const platformDir = {
+  darwin: "osx-bin",
+  linux: "linux64-bin",
+  win32: "win64-bin",
+}[process.platform];
+
+if (!platformDir) {
+  console.error(`Unsupported platform for Hermes: ${process.platform}`);
+  process.exit(1);
+}
+
+const binName = process.platform === "win32" ? "hermes.exe" : "hermes";
+const hermesBin = join(reactNativeRoot, "sdks", "hermesc", platformDir, binName);
+
+// Forward any extra args (e.g. a script file). With no args, Hermes opens a REPL.
+const { status } = spawnSync(hermesBin, process.argv.slice(2), { stdio: "inherit" });
+process.exit(status ?? 0);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

#### Context

As of now, it is difficult to know which parts of ECMAscript are supported by the Hermes engine (used by React Native).

The REPL added in this PR is intended to allow quick checking of the features supported by the repository version of Hermes.

#### Usage:

```shell
pnpm mobile hermes
```

#### Example
<img width="641" height="453" alt="image" src="https://github.com/user-attachments/assets/8344995e-4cc3-4021-a4ce-8c495c080ab7" />


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
