### PR TITLE
[LWDM] feat(mobile): Global Search default sections data via DADA [LIVE-30044]

### DIFF
--- a/.changeset/global-search-default-sections-data.md
+++ b/.changeset/global-search-default-sections-data.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/live-common": minor
+"live-mobile": minor
+"ledger-live-desktop": patch
+---
+
+Add the Global Search default-sections data on mobile, fed by DADA. Cryptos (top 3) and stablecoins (top 2) render as market rows; stocks (top 10) as pills.
+
+Share the DADA asset-discovery selection in `@ledgerhq/live-common` (`selectTopStocks`, `selectTopAssetsByCategory`, `StockSuggestion`) so desktop and mobile use one implementation; desktop's stocks section now consumes `selectTopStocks` instead of its own copy.

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/hooks/useStocksSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/hooks/useStocksSectionViewModel.ts
@@ -1,8 +1,7 @@
 import { useMemo } from "react";
 import { useStocksData } from "@ledgerhq/live-common/dada-client/hooks/useStocksData";
-import { selectCurrencyForMetaId } from "@ledgerhq/live-common/dada-client/utils/currencySelection";
-import { dadaIdToMarketId } from "@ledgerhq/live-common/market/utils/index";
-import { StockSuggestion, StocksSectionViewModelResult } from "../types";
+import { selectTopStocks } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { StocksSectionViewModelResult } from "../types";
 
 export function useStocksSectionViewModel({
   limit,
@@ -14,31 +13,7 @@ export function useStocksSectionViewModel({
     version: __APP_VERSION__,
   });
 
-  const stocks = useMemo<StockSuggestion[]>(() => {
-    if (!data) return [];
-    const { cryptoAssets, markets, currenciesOrder } = data;
-    return currenciesOrder.metaCurrencyIds
-      .flatMap(id => {
-        const meta = cryptoAssets[id];
-        if (!meta) return [];
-
-        const currency = selectCurrencyForMetaId(id, data);
-        const ledgerId = currency?.id ?? Object.values(meta.assetsIds)[0];
-        if (!ledgerId) return [];
-        const market = currency ? markets[currency.id] : undefined;
-
-        const stock: StockSuggestion = {
-          id: meta.id,
-          name: meta.name,
-          ticker: meta.ticker,
-
-          navigationId: dadaIdToMarketId(market?.id ?? meta.id),
-          ledgerId,
-        };
-        return [stock];
-      })
-      .slice(0, limit);
-  }, [data, limit]);
+  const stocks = useMemo(() => (data ? selectTopStocks(data, limit) : []), [data, limit]);
 
   return useMemo(() => ({ data: stocks, isLoading }), [stocks, isLoading]);
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/types.ts
@@ -1,12 +1,6 @@
-export type StockSuggestion = {
-  /** DADA meta-currency id — stable React key. */
-  id: string;
-  name: string;
-  ticker: string;
-  navigationId: string;
-  /** Underlying ledger currency id (first network), for the crypto icon. */
-  ledgerId?: string;
-};
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+
+export type { StockSuggestion };
 
 export type StocksSectionViewModelResult = {
   /** Stocks ranked by market cap, already capped to the requested limit. */

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchDefaults.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchDefaults.test.ts
@@ -1,0 +1,102 @@
+import { renderHook } from "@tests/test-renderer";
+import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
+import { useStocksData } from "@ledgerhq/live-common/dada-client/hooks/useStocksData";
+import { useStablecoinTickers } from "@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers";
+import { selectCurrencyForMetaId } from "@ledgerhq/live-common/dada-client/utils/currencySelection";
+import { useGlobalSearchDefaults } from "../useGlobalSearchDefaults";
+
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useAssetsData");
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useStocksData");
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers");
+jest.mock("@ledgerhq/live-common/dada-client/utils/currencySelection");
+
+const mockedAssets = jest.mocked(useAssetsData);
+const mockedStocks = jest.mocked(useStocksData);
+const mockedStablecoinTickers = jest.mocked(useStablecoinTickers);
+const mockedSelectCurrency = jest.mocked(selectCurrencyForMetaId);
+
+const makeMeta = (id: string, ticker: string) => ({
+  id,
+  name: ticker,
+  ticker,
+  assetsIds: { ethereum: `${id}-ledger` },
+});
+
+const makeMarket = (id: string, rank: number) => ({
+  id,
+  name: id,
+  ticker: id.toUpperCase(),
+  ledgerIds: [`${id}-ledger`],
+  price: 100 + rank,
+  marketCap: 1_000_000 - rank,
+  marketCapRank: rank,
+  priceChangePercentage24h: rank,
+});
+
+// 4 cryptos + 2 stablecoins (USDT/USDC), ordered by market cap.
+const assetIds = ["btc", "eth", "sol", "ada", "usdt", "usdc"];
+// 22 stocks (more than the 20 cap).
+const stockIds = Array.from({ length: 22 }, (_, i) => `stock${i}`);
+
+function buildDadaData(ids: string[]) {
+  return {
+    currenciesOrder: { metaCurrencyIds: ids, key: "marketCap", order: "desc" },
+    cryptoAssets: Object.fromEntries(ids.map(id => [id, makeMeta(id, id.toUpperCase())])),
+    markets: Object.fromEntries(ids.map((id, i) => [id, makeMarket(id, i + 1)])),
+  };
+}
+
+describe("useGlobalSearchDefaults", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedSelectCurrency.mockImplementation((metaId: string) => ({ id: metaId }) as never);
+    mockedStablecoinTickers.mockReturnValue({
+      tickers: new Set(["USDT", "USDC"]),
+      isLoading: false,
+      isError: false,
+    } as never);
+    mockedAssets.mockReturnValue({ data: buildDadaData(assetIds), isLoading: false } as never);
+    mockedStocks.mockReturnValue({ data: buildDadaData(stockIds), isLoading: false } as never);
+  });
+
+  it("returns the top 3 cryptos, 2 stablecoins and 20 stocks", () => {
+    const { result } = renderHook(() => useGlobalSearchDefaults(true));
+    const { cryptos, stablecoins, stocks } = result.current.defaultSections;
+
+    expect(cryptos).toHaveLength(3);
+    expect(stablecoins).toHaveLength(2);
+    expect(stocks).toHaveLength(20);
+    expect(result.current.isLoadingDefaults).toBe(false);
+  });
+
+  it("splits stablecoins out of the cryptos list by ticker", () => {
+    const { result } = renderHook(() => useGlobalSearchDefaults(true));
+    const { cryptos, stablecoins } = result.current.defaultSections;
+
+    expect(cryptos.map(c => c.ticker)).toEqual(["BTC", "ETH", "SOL"]);
+    expect(stablecoins.map(s => s.ticker)).toEqual(["USDT", "USDC"]);
+  });
+
+  it("reports loading while the assets query is in flight", () => {
+    mockedAssets.mockReturnValue({ data: undefined, isLoading: true } as never);
+
+    const { result } = renderHook(() => useGlobalSearchDefaults(true));
+
+    expect(result.current.isLoadingDefaults).toBe(true);
+  });
+
+  it("still returns cryptos when the stocks query fails (independent fetches)", () => {
+    mockedStocks.mockReturnValue({ data: undefined, isLoading: false, isError: true } as never);
+
+    const { result } = renderHook(() => useGlobalSearchDefaults(true));
+
+    expect(result.current.defaultSections.cryptos).toHaveLength(3);
+    expect(result.current.defaultSections.stocks).toHaveLength(0);
+  });
+
+  it("does nothing when disabled", () => {
+    const { result } = renderHook(() => useGlobalSearchDefaults(false));
+
+    expect(result.current.isLoadingDefaults).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act } from "@tests/test-renderer";
 import { track } from "~/analytics";
 import { useGlobalSearchViewModel } from "../useGlobalSearchViewModel";
+import { useGlobalSearchDefaults } from "../useGlobalSearchDefaults";
 
 const mockGoBack = jest.fn();
 
@@ -9,21 +10,27 @@ jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({ goBack: mockGoBack }),
 }));
 
+jest.mock("../useGlobalSearchDefaults");
+
+const mockedUseGlobalSearchDefaults = jest.mocked(useGlobalSearchDefaults);
+
+const EMPTY_SECTIONS = { cryptos: [], stablecoins: [], stocks: [] };
+
 describe("useGlobalSearchViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockedUseGlobalSearchDefaults.mockReturnValue({
+      defaultSections: EMPTY_SECTIONS,
+      isLoadingDefaults: false,
+    });
   });
 
-  it("starts inactive with empty default sections and results", () => {
+  it("starts inactive and exposes the default sections from the data hook", () => {
     const { result } = renderHook(() => useGlobalSearchViewModel());
 
     expect(result.current.isSearchActive).toBe(false);
     expect(result.current.searchResults).toEqual([]);
-    expect(result.current.defaultSections).toEqual({
-      cryptos: [],
-      stablecoins: [],
-      stocks: [],
-    });
+    expect(result.current.defaultSections).toEqual(EMPTY_SECTIONS);
   });
 
   it("flips isSearchActive when typing and back to false when cleared", () => {
@@ -35,6 +42,15 @@ describe("useGlobalSearchViewModel", () => {
     act(() => result.current.clearSearch());
     expect(result.current.search).toBe("");
     expect(result.current.isSearchActive).toBe(false);
+  });
+
+  it("enables default fetching only while no search is active", () => {
+    const { result } = renderHook(() => useGlobalSearchViewModel());
+
+    expect(mockedUseGlobalSearchDefaults).toHaveBeenLastCalledWith(true);
+
+    act(() => result.current.setSearch("btc"));
+    expect(mockedUseGlobalSearchDefaults).toHaveBeenLastCalledWith(false);
   });
 
   it("tracks search_open on mount", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/types.ts
@@ -1,0 +1,8 @@
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
+
+export type GlobalSearchDefaultSections = {
+  cryptos: MarketAssetDisplayData[];
+  stablecoins: MarketAssetDisplayData[];
+  stocks: StockSuggestion[];
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchDefaults.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchDefaults.ts
@@ -1,0 +1,94 @@
+import { useMemo } from "react";
+import VersionNumber from "react-native-version-number";
+import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
+import { useStocksData } from "@ledgerhq/live-common/dada-client/hooks/useStocksData";
+import { useStablecoinTickers } from "@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers";
+import {
+  selectTopAssetsByCategory,
+  selectTopStocks,
+  type CategorizedDiscoveryAsset,
+} from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
+import { useSelector } from "~/context/hooks";
+import { counterValueCurrencySelector } from "~/reducers/settings";
+import { useLocale, useTranslation } from "~/context/Locale";
+import { mapDadaMarketToDisplayData } from "../../utils/mapDadaMarketToDisplayData";
+import type { GlobalSearchDefaultSections } from "./types";
+
+const PRODUCT = "llm";
+const MAX_CRYPTOS = 3;
+const MAX_STABLECOINS = 2;
+const MAX_STOCKS = 20;
+
+export type GlobalSearchDefaults = {
+  defaultSections: GlobalSearchDefaultSections;
+  isLoadingDefaults: boolean;
+};
+
+export function useGlobalSearchDefaults(enabled: boolean): GlobalSearchDefaults {
+  const { t } = useTranslation();
+  const { locale } = useLocale();
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const counterCurrency = counterValueCurrency.ticker.toLowerCase();
+  const counterValueUnit = counterValueCurrency.units[0];
+  const version = VersionNumber.appVersion ?? "";
+  const skip = !enabled;
+
+  const { tickers: stablecoinTickers, isLoading: loadingTickers } = useStablecoinTickers(
+    PRODUCT,
+    version,
+    skip,
+  );
+  const { data: assetsData, isLoading: loadingAssets } = useAssetsData({
+    product: PRODUCT,
+    version,
+    skip,
+  });
+  const { data: stocksData, isLoading: loadingStocks } = useStocksData({
+    product: PRODUCT,
+    version,
+    skip,
+  });
+
+  const { cryptos, stablecoins } = useMemo(() => {
+    if (!assetsData) {
+      return {
+        cryptos: [] as MarketAssetDisplayData[],
+        stablecoins: [] as MarketAssetDisplayData[],
+      };
+    }
+
+    const categorized = selectTopAssetsByCategory(assetsData, stablecoinTickers, {
+      maxCryptos: MAX_CRYPTOS,
+      maxStablecoins: MAX_STABLECOINS,
+    });
+    const toDisplay = (entries: CategorizedDiscoveryAsset[]) =>
+      entries.map(({ meta, currency, market }) =>
+        mapDadaMarketToDisplayData(
+          { id: meta.id, name: meta.name, ticker: meta.ticker, ledgerId: currency.id },
+          market,
+          { counterCurrency, counterValueUnit, locale, t },
+        ),
+      );
+
+    return {
+      cryptos: toDisplay(categorized.cryptos),
+      stablecoins: toDisplay(categorized.stablecoins),
+    };
+  }, [assetsData, stablecoinTickers, counterCurrency, counterValueUnit, locale, t]);
+
+  const stocks = useMemo(
+    () => (stocksData ? selectTopStocks(stocksData, MAX_STOCKS) : []),
+    [stocksData],
+  );
+
+  const defaultSections = useMemo<GlobalSearchDefaultSections>(
+    () => ({ cryptos, stablecoins, stocks }),
+    [cryptos, stablecoins, stocks],
+  );
+
+  return {
+    defaultSections,
+    isLoadingDefaults: enabled && (loadingTickers || loadingAssets || loadingStocks),
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
@@ -2,12 +2,8 @@ import { useCallback, useEffect, useState } from "react";
 import { useNavigation } from "@react-navigation/native";
 import { track } from "~/analytics";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
-
-export type GlobalSearchDefaultSections = {
-  cryptos: MarketAssetDisplayData[];
-  stablecoins: MarketAssetDisplayData[];
-  stocks: MarketAssetDisplayData[];
-};
+import { useGlobalSearchDefaults } from "./useGlobalSearchDefaults";
+import type { GlobalSearchDefaultSections } from "./types";
 
 export type GlobalSearchViewModel = {
   search: string;
@@ -22,17 +18,14 @@ export type GlobalSearchViewModel = {
   onBack: () => void;
 };
 
-const EMPTY_DEFAULT_SECTIONS: GlobalSearchDefaultSections = {
-  cryptos: [],
-  stablecoins: [],
-  stocks: [],
-};
-
 const EMPTY_RESULTS: MarketAssetDisplayData[] = [];
 
 export function useGlobalSearchViewModel(): GlobalSearchViewModel {
   const navigation = useNavigation();
   const [search, setSearch] = useState("");
+  const isSearchActive = search.length > 0;
+
+  const { defaultSections, isLoadingDefaults } = useGlobalSearchDefaults(!isSearchActive);
 
   useEffect(() => {
     track("search_open");
@@ -45,11 +38,11 @@ export function useGlobalSearchViewModel(): GlobalSearchViewModel {
     search,
     setSearch,
     clearSearch,
-    isSearchActive: search.length > 0,
-    isLoadingDefaults: false,
+    isSearchActive,
+    isLoadingDefaults,
     isLoadingSearch: false,
     hasNoResults: false,
-    defaultSections: EMPTY_DEFAULT_SECTIONS,
+    defaultSections,
     searchResults: EMPTY_RESULTS,
     onBack,
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/utils/__tests__/mapDadaMarketToDisplayData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/utils/__tests__/mapDadaMarketToDisplayData.test.ts
@@ -1,0 +1,46 @@
+import type { Unit } from "@ledgerhq/types-cryptoassets";
+import { mapDadaMarketToDisplayData } from "../mapDadaMarketToDisplayData";
+
+const usd = { name: "US Dollar", code: "USD", magnitude: 2 } as Unit;
+const t = ((key: string) => key) as never;
+const options = { counterCurrency: "usd", counterValueUnit: usd, locale: "en", t };
+const meta = { id: "meta:bitcoin", name: "Bitcoin", ticker: "btc", ledgerId: "bitcoin" };
+
+describe("mapDadaMarketToDisplayData", () => {
+  it("maps market fields and uppercases the ticker", () => {
+    const result = mapDadaMarketToDisplayData(
+      meta,
+      {
+        id: "bitcoin",
+        name: "Bitcoin",
+        ticker: "BTC",
+        ledgerIds: ["bitcoin"],
+        price: 92000,
+        marketCap: 1_800_000_000_000,
+        marketCapRank: 1,
+        priceChangePercentage24h: 7.87,
+      },
+      options,
+    );
+
+    expect(result.id).toBe("bitcoin");
+    expect(result.ticker).toBe("BTC");
+    expect(result.ledgerIds).toEqual(["bitcoin"]);
+    expect(result.marketcapRank).toBe(1);
+    expect(result.priceChangePercentage).toBeCloseTo(7.87);
+    expect(result.formattedMarketCap).not.toBe("-");
+    expect(result.formattedPrice).toMatch(/\d/);
+  });
+
+  it("falls back to meta and safe defaults when market data is missing", () => {
+    const result = mapDadaMarketToDisplayData(meta, undefined, options);
+
+    expect(result.id).toBe("bitcoin");
+    expect(result.name).toBe("Bitcoin");
+    expect(result.ticker).toBe("BTC");
+    expect(result.ledgerIds).toEqual(["bitcoin"]);
+    expect(result.marketcapRank).toBe(0);
+    expect(result.priceChangePercentage).toBe(0);
+    expect(result.formattedMarketCap).toBe("-");
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/utils/mapDadaMarketToDisplayData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/utils/mapDadaMarketToDisplayData.ts
@@ -1,0 +1,55 @@
+import BigNumber from "bignumber.js";
+import type { TFunction } from "i18next";
+import type { Unit } from "@ledgerhq/types-cryptoassets";
+import type { PartialMarketItemResponse } from "@ledgerhq/live-common/market/utils/types";
+import { dadaIdToMarketId } from "@ledgerhq/live-common/market/utils/index";
+import { formatPrice } from "@ledgerhq/live-currency-format";
+import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
+import { counterValueFormatter } from "LLM/features/Market/utils";
+
+type AssetMeta = {
+  id: string;
+  name: string;
+  ticker: string;
+  /** Resolved ledger currency id, used for the crypto icon when the market omits ledgerIds. */
+  ledgerId: string;
+};
+
+type MapOptions = {
+  counterCurrency: string;
+  counterValueUnit: Unit;
+  locale: string;
+  t: TFunction;
+};
+
+export function mapDadaMarketToDisplayData(
+  meta: AssetMeta,
+  market: PartialMarketItemResponse | undefined,
+  { counterCurrency, counterValueUnit, locale, t }: MapOptions,
+): MarketAssetDisplayData {
+  const change = market?.priceChangePercentage24h;
+  const priceChangePercentage = typeof change === "number" && Number.isFinite(change) ? change : 0;
+  const priceAtoms = new BigNumber(market?.price ?? 0).times(
+    new BigNumber(10).pow(counterValueUnit.magnitude),
+  );
+
+  return {
+    id: dadaIdToMarketId(market?.id ?? meta.id),
+    name: market?.name ?? meta.name,
+    ticker: (market?.ticker ?? meta.ticker).toUpperCase(),
+    ledgerIds: market?.ledgerIds?.length ? market.ledgerIds : [meta.ledgerId],
+    formattedMarketCap:
+      market?.marketCap == null
+        ? "-"
+        : counterValueFormatter({
+            currency: counterCurrency,
+            value: market.marketCap,
+            shorten: true,
+            locale,
+            t,
+          }),
+    marketcapRank: market?.marketCapRank ?? 0,
+    formattedPrice: formatPrice(counterValueUnit, priceAtoms, { locale, showCode: true }),
+    priceChangePercentage,
+  };
+}

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -437,6 +437,7 @@
     "src/dada-client/state-manager/api.ts",
     "src/dada-client/state-manager/types.ts",
     "src/dada-client/types/trend.ts",
+    "src/dada-client/utils/assetDiscovery.ts",
     "src/dada-client/utils/chunkCurrencyIds.ts",
     "src/dada-client/utils/currencySelection.ts",
     "src/dada-client/utils/deepMergeCryptoAssets.ts",

--- a/libs/ledger-live-common/src/dada-client/utils/__test__/assetDiscovery.test.ts
+++ b/libs/ledger-live-common/src/dada-client/utils/__test__/assetDiscovery.test.ts
@@ -1,0 +1,59 @@
+import { selectTopStocks, selectTopAssetsByCategory } from "../assetDiscovery";
+import type { AssetsDataWithPagination } from "../../state-manager/types";
+
+function makeData(ids: string[]): AssetsDataWithPagination {
+  return {
+    currenciesOrder: { key: "marketCap", order: "desc", metaCurrencyIds: ids },
+    cryptoAssets: Object.fromEntries(
+      ids.map(id => [id, { id, name: id, ticker: id.toUpperCase(), assetsIds: { ethereum: id } }]),
+    ),
+    cryptoOrTokenCurrencies: Object.fromEntries(
+      ids.map(id => [id, { id, type: "CryptoCurrency", name: id }]),
+    ),
+    markets: Object.fromEntries(ids.map((id, i) => [id, { id, marketCapRank: i + 1 }])),
+    networks: {},
+    interestRates: {},
+    pagination: {},
+  } as unknown as AssetsDataWithPagination;
+}
+
+describe("selectTopStocks", () => {
+  it("returns up to `limit` stocks in market-cap order", () => {
+    const stocks = selectTopStocks(makeData(["aapl", "tsla", "msft", "amzn"]), 2);
+
+    expect(stocks).toHaveLength(2);
+    expect(stocks.map(s => s.ticker)).toEqual(["AAPL", "TSLA"]);
+    expect(stocks[0]).toMatchObject({ id: "aapl", navigationId: "aapl", ledgerId: "aapl" });
+  });
+
+  it("skips meta-currencies without a resolvable ledger id", () => {
+    const data = makeData(["aapl"]);
+    data.cryptoAssets["aapl"].assetsIds = {};
+    data.cryptoOrTokenCurrencies = {};
+
+    expect(selectTopStocks(data, 5)).toHaveLength(0);
+  });
+});
+
+describe("selectTopAssetsByCategory", () => {
+  it("splits cryptos and stablecoins by ticker, respecting the per-category caps", () => {
+    const data = makeData(["btc", "eth", "sol", "ada", "usdt", "usdc"]);
+
+    const { cryptos, stablecoins } = selectTopAssetsByCategory(data, new Set(["USDT", "USDC"]), {
+      maxCryptos: 3,
+      maxStablecoins: 2,
+    });
+
+    expect(cryptos.map(c => c.meta.ticker)).toEqual(["BTC", "ETH", "SOL"]);
+    expect(stablecoins.map(s => s.meta.ticker)).toEqual(["USDT", "USDC"]);
+  });
+
+  it("attaches the market entry for each selected asset", () => {
+    const { cryptos } = selectTopAssetsByCategory(makeData(["btc"]), new Set(), {
+      maxCryptos: 1,
+      maxStablecoins: 0,
+    });
+
+    expect(cryptos[0].market).toMatchObject({ id: "btc", marketCapRank: 1 });
+  });
+});

--- a/libs/ledger-live-common/src/dada-client/utils/assetDiscovery.ts
+++ b/libs/ledger-live-common/src/dada-client/utils/assetDiscovery.ts
@@ -1,0 +1,107 @@
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { PartialMarketItemResponse } from "../../market/utils/types";
+import { dadaIdToMarketId } from "../../market/utils/index";
+import type { CryptoAssetMeta } from "../entities/index";
+import type { AssetsDataWithPagination } from "../state-manager/types";
+import { selectCurrencyForMetaId } from "./currencySelection";
+
+/**
+ * A stock entry derived from DADA asset data, ready to render as a pill/row.
+ * Shared by the desktop and mobile asset-discovery surfaces (Global Search,
+ * portfolio stocks section).
+ */
+export type StockSuggestion = {
+  /** DADA meta-currency id — stable key. */
+  id: string;
+  name: string;
+  ticker: string;
+  /** Market id used for asset-detail navigation. */
+  navigationId: string;
+  /** Underlying ledger currency id (first network), for the crypto icon. */
+  ledgerId: string;
+};
+
+/**
+ * A categorized crypto/stablecoin entry: the raw DADA pieces an app needs to
+ * build its own display model (price, market cap, icon…).
+ */
+export type CategorizedDiscoveryAsset = {
+  metaId: string;
+  meta: CryptoAssetMeta;
+  currency: CryptoOrTokenCurrency;
+  market?: PartialMarketItemResponse;
+};
+
+export type CategorizedDiscoveryAssets = {
+  cryptos: CategorizedDiscoveryAsset[];
+  stablecoins: CategorizedDiscoveryAsset[];
+};
+
+/**
+ * Picks the top `limit` stocks from DADA asset data, preserving the API's
+ * market-cap ordering.
+ */
+export function selectTopStocks(data: AssetsDataWithPagination, limit: number): StockSuggestion[] {
+  const stocks: StockSuggestion[] = [];
+
+  for (const metaId of data.currenciesOrder.metaCurrencyIds) {
+    if (stocks.length >= limit) break;
+
+    const meta = data.cryptoAssets[metaId];
+    if (!meta) continue;
+
+    const currency = selectCurrencyForMetaId(metaId, data);
+    const ledgerId = currency?.id ?? Object.values(meta.assetsIds)[0];
+    if (!ledgerId) continue;
+
+    const market = currency ? data.markets[currency.id] : undefined;
+    stocks.push({
+      id: meta.id,
+      name: meta.name,
+      ticker: meta.ticker,
+      navigationId: dadaIdToMarketId(market?.id ?? meta.id),
+      ledgerId,
+    });
+  }
+
+  return stocks;
+}
+
+/**
+ * Walks the market-cap-ordered DADA list once and splits it into the top
+ * `maxCryptos` cryptos and top `maxStablecoins` stablecoins, classifying each
+ * asset by its ticker against `stablecoinTickers` (expected uppercase).
+ */
+export function selectTopAssetsByCategory(
+  data: AssetsDataWithPagination,
+  stablecoinTickers: Set<string>,
+  { maxCryptos, maxStablecoins }: { maxCryptos: number; maxStablecoins: number },
+): CategorizedDiscoveryAssets {
+  const cryptos: CategorizedDiscoveryAsset[] = [];
+  const stablecoins: CategorizedDiscoveryAsset[] = [];
+
+  for (const metaId of data.currenciesOrder.metaCurrencyIds) {
+    if (cryptos.length >= maxCryptos && stablecoins.length >= maxStablecoins) break;
+
+    const meta = data.cryptoAssets[metaId];
+    if (!meta) continue;
+
+    const currency = selectCurrencyForMetaId(metaId, data);
+    if (!currency) continue;
+
+    const entry: CategorizedDiscoveryAsset = {
+      metaId,
+      meta,
+      currency,
+      market: data.markets[currency.id],
+    };
+
+    if (stablecoinTickers.has(meta.ticker?.toUpperCase() ?? "")) {
+      if (stablecoins.length < maxStablecoins) stablecoins.push(entry);
+    } else if (cryptos.length < maxCryptos) {
+      cryptos.push(entry);
+    }
+  }
+
+  return { cryptos, stablecoins };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Common: `selectTopStocks` / `selectTopAssetsByCategory` unit tests. Mobile: `useGlobalSearchDefaults` (3/2/10 counts, ticker split, loading, independent failure) + `mapDadaMarketToDisplayData` unit tests. Desktop stocks integration tests still pass against the shared selector (10/10).
- [x] **Impact of the changes:**
  - Mobile Global Search default sections now show real data. No user-facing desktop change (internal refactor to a shared selector).
  - QA focus (desktop): the portfolio/search **stocks** section should behave exactly as before.

### 📝 Description

Fourth PR of the **Global Search** feature. Wires the default-sections data, sourced from **DADA** (parity with desktop), and centralizes the shared selection logic.

**Common (`@ledgerhq/live-common/dada-client/utils/assetDiscovery`)** — new, shared by both apps:
- `selectTopStocks(data, limit)` → `StockSuggestion[]` (market-cap order, slug-fallback nav id, skips entries without a ledger id).
- `selectTopAssetsByCategory(data, stablecoinTickers, { maxCryptos, maxStablecoins })` → categorized neutral entries (`{ meta, currency, market }`) so each app maps to its own display model.
- `StockSuggestion` type.

**Mobile** — `useGlobalSearchDefaults` fetches via `useAssetsData` + `useStocksData` + `useStablecoinTickers` (`product: "llm"`), then:
- cryptos (top 3) + stablecoins (top 2) → `MarketAssetDisplayData` rows via `mapDadaMarketToDisplayData` (reusing the Market screen's `counterValueFormatter` + `formatPrice`);
- stocks (top 10) → `StockSuggestion` pills.
The ViewModel exposes `defaultSections` + `isLoadingDefaults`; fetching is enabled only while no search is active.

**Desktop** — `useStocksSectionViewModel` now consumes the shared `selectTopStocks` instead of its own inline mapping (dedup), and its `StockSuggestion` type re-exports the common one.

> Per review feedback: shared logic lives in the common lib so desktop and mobile don't diverge. Stocks render as pills (2 rows of up to 10), cryptos/stablecoins as rows — matching the production design.

### ❓ Context

- **JIRA**: [LIVE-30044](https://ledgerhq.atlassian.net/browse/LIVE-30044) — Epic [LIVE-27854](https://ledgerhq.atlassian.net/browse/LIVE-27854)
- **Stacked PR series** (Global Search): **4/8**, based on [#18417](https://github.com/LedgerHQ/ledger-live/pull/18417) (LIVE-30043).


[LIVE-30044]: https://ledgerhq.atlassian.net/browse/LIVE-30044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ