### PR TITLE
[LWM] feat(mobile): Global Search results via DADA search [LIVE-30045]

### DIFF
--- a/.changeset/global-search-search-logic.md
+++ b/.changeset/global-search-search-logic.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Wire Global Search results: as the user types (debounced), search across all asset types via DADA and expose `searchResults`, `isLoadingSearch`, and `hasNoResults`. Input handling and the `search_query` tracking event use the shared `useSearchCommon` hook.

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchResults.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchResults.test.ts
@@ -1,0 +1,98 @@
+import { renderHook, act } from "@tests/test-renderer";
+import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
+import { selectCurrencyForMetaId } from "@ledgerhq/live-common/dada-client/utils/currencySelection";
+import { track } from "~/analytics";
+import { useGlobalSearchResults } from "../useGlobalSearchResults";
+
+jest.mock("@ledgerhq/live-common/hooks/useDebounce", () => ({
+  useDebounce: (value: string) => value,
+}));
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useAssetsData");
+jest.mock("@ledgerhq/live-common/dada-client/utils/currencySelection");
+
+const mockedAssets = jest.mocked(useAssetsData);
+const mockedSelectCurrency = jest.mocked(selectCurrencyForMetaId);
+
+const buildData = (ids: string[]) =>
+  ({
+    currenciesOrder: { metaCurrencyIds: ids, key: "marketCap", order: "desc" },
+    cryptoAssets: Object.fromEntries(
+      ids.map(id => [id, { id, name: id, ticker: id.toUpperCase(), assetsIds: { ethereum: id } }]),
+    ),
+    markets: Object.fromEntries(ids.map((id, i) => [id, { id, marketCapRank: i + 1, price: 1 }])),
+  }) as never;
+
+describe("useGlobalSearchResults", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedSelectCurrency.mockImplementation((metaId: string) => ({ id: metaId }) as never);
+    mockedAssets.mockReturnValue({ data: undefined, isLoading: false } as never);
+  });
+
+  it("is inactive with no results before typing", () => {
+    const { result } = renderHook(() => useGlobalSearchResults());
+
+    expect(result.current.isSearchActive).toBe(false);
+    expect(result.current.searchResults).toEqual([]);
+    expect(result.current.hasNoResults).toBe(false);
+  });
+
+  it("fetches and maps results for the typed query", () => {
+    mockedAssets.mockReturnValue({ data: buildData(["btc", "eth"]), isLoading: false } as never);
+
+    const { result } = renderHook(() => useGlobalSearchResults());
+    act(() => result.current.setSearch("b"));
+
+    expect(result.current.isSearchActive).toBe(true);
+    expect(result.current.searchResults.map(r => r.ticker)).toEqual(["BTC", "ETH"]);
+    expect(mockedAssets).toHaveBeenLastCalledWith(
+      expect.objectContaining({ search: "b", skip: false }),
+    );
+  });
+
+  it("tracks search_query when the debounced query changes", () => {
+    const { result } = renderHook(() => useGlobalSearchResults());
+
+    act(() => result.current.setSearch("bitcoin"));
+
+    expect(track).toHaveBeenCalledWith("search_query", { query: "bitcoin" });
+  });
+
+  it("flags hasNoResults when the query returns nothing", () => {
+    mockedAssets.mockReturnValue({ data: buildData([]), isLoading: false } as never);
+
+    const { result } = renderHook(() => useGlobalSearchResults());
+    act(() => result.current.setSearch("zzz"));
+
+    expect(result.current.hasNoResults).toBe(true);
+  });
+
+  it("reports loading while the search query is in flight", () => {
+    mockedAssets.mockReturnValue({ data: undefined, isLoading: true } as never);
+
+    const { result } = renderHook(() => useGlobalSearchResults());
+    act(() => result.current.setSearch("btc"));
+
+    expect(result.current.isLoadingSearch).toBe(true);
+    expect(result.current.hasNoResults).toBe(false);
+  });
+
+  it("does not flag hasNoResults on an error / undefined response", () => {
+    mockedAssets.mockReturnValue({ data: undefined, isLoading: false, isError: true } as never);
+
+    const { result } = renderHook(() => useGlobalSearchResults());
+    act(() => result.current.setSearch("btc"));
+
+    expect(result.current.hasNoResults).toBe(false);
+  });
+
+  it("clears the search", () => {
+    const { result } = renderHook(() => useGlobalSearchResults());
+
+    act(() => result.current.setSearch("btc"));
+    expect(result.current.isSearchActive).toBe(true);
+
+    act(() => result.current.clearSearch());
+    expect(result.current.isSearchActive).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act } from "@tests/test-renderer";
 import { track } from "~/analytics";
 import { useGlobalSearchViewModel } from "../useGlobalSearchViewModel";
 import { useGlobalSearchDefaults } from "../useGlobalSearchDefaults";
+import { useGlobalSearchResults, type GlobalSearchResults } from "../useGlobalSearchResults";
 
 const mockGoBack = jest.fn();
 
@@ -11,46 +12,62 @@ jest.mock("@react-navigation/native", () => ({
 }));
 
 jest.mock("../useGlobalSearchDefaults");
+jest.mock("../useGlobalSearchResults");
 
-const mockedUseGlobalSearchDefaults = jest.mocked(useGlobalSearchDefaults);
+const mockedDefaults = jest.mocked(useGlobalSearchDefaults);
+const mockedResults = jest.mocked(useGlobalSearchResults);
 
 const EMPTY_SECTIONS = { cryptos: [], stablecoins: [], stocks: [] };
+
+const resultsState = (overrides: Partial<GlobalSearchResults> = {}): GlobalSearchResults => ({
+  search: "",
+  setSearch: jest.fn(),
+  clearSearch: jest.fn(),
+  isSearchActive: false,
+  searchResults: [],
+  isLoadingSearch: false,
+  hasNoResults: false,
+  ...overrides,
+});
 
 describe("useGlobalSearchViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedUseGlobalSearchDefaults.mockReturnValue({
-      defaultSections: EMPTY_SECTIONS,
-      isLoadingDefaults: false,
+    mockedDefaults.mockReturnValue({ defaultSections: EMPTY_SECTIONS, isLoadingDefaults: false });
+    mockedResults.mockReturnValue(resultsState());
+  });
+
+  it("composes default sections and search results from the data hooks", () => {
+    const cryptos = [{ id: "btc" }] as never;
+    const searchResults = [{ id: "eth" }] as never;
+    mockedDefaults.mockReturnValue({
+      defaultSections: { ...EMPTY_SECTIONS, cryptos },
+      isLoadingDefaults: true,
     });
-  });
+    mockedResults.mockReturnValue(resultsState({ searchResults, isLoadingSearch: true }));
 
-  it("starts inactive and exposes the default sections from the data hook", () => {
     const { result } = renderHook(() => useGlobalSearchViewModel());
 
-    expect(result.current.isSearchActive).toBe(false);
-    expect(result.current.searchResults).toEqual([]);
-    expect(result.current.defaultSections).toEqual(EMPTY_SECTIONS);
+    expect(result.current.defaultSections.cryptos).toBe(cryptos);
+    expect(result.current.isLoadingDefaults).toBe(true);
+    expect(result.current.searchResults).toBe(searchResults);
+    expect(result.current.isLoadingSearch).toBe(true);
   });
 
-  it("flips isSearchActive when typing and back to false when cleared", () => {
-    const { result } = renderHook(() => useGlobalSearchViewModel());
+  it("enables default fetching while no search is active", () => {
+    mockedResults.mockReturnValue(resultsState({ isSearchActive: false }));
 
-    act(() => result.current.setSearch("btc"));
-    expect(result.current.isSearchActive).toBe(true);
+    renderHook(() => useGlobalSearchViewModel());
 
-    act(() => result.current.clearSearch());
-    expect(result.current.search).toBe("");
-    expect(result.current.isSearchActive).toBe(false);
+    expect(mockedDefaults).toHaveBeenLastCalledWith(true);
   });
 
-  it("enables default fetching only while no search is active", () => {
-    const { result } = renderHook(() => useGlobalSearchViewModel());
+  it("disables default fetching while a search is active", () => {
+    mockedResults.mockReturnValue(resultsState({ isSearchActive: true }));
 
-    expect(mockedUseGlobalSearchDefaults).toHaveBeenLastCalledWith(true);
+    renderHook(() => useGlobalSearchViewModel());
 
-    act(() => result.current.setSearch("btc"));
-    expect(mockedUseGlobalSearchDefaults).toHaveBeenLastCalledWith(false);
+    expect(mockedDefaults).toHaveBeenLastCalledWith(false);
   });
 
   it("tracks search_open on mount", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchResults.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchResults.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import VersionNumber from "react-native-version-number";
+import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
+import { selectCurrencyForMetaId } from "@ledgerhq/live-common/dada-client/utils/currencySelection";
+import { useSearchCommon } from "@ledgerhq/live-common/modularDrawer/hooks/useSearch";
+import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
+import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
+import { mapDadaMarketToDisplayData } from "LLM/features/GlobalSearch/utils/mapDadaMarketToDisplayData";
+import { track } from "~/analytics";
+import { useSelector } from "~/context/hooks";
+import { counterValueCurrencySelector } from "~/reducers/settings";
+import { useLocale, useTranslation } from "~/context/Locale";
+
+const PRODUCT = "llm";
+const SEARCH_DEBOUNCE_MS = 300;
+
+export type GlobalSearchResults = {
+  search: string;
+  setSearch: (value: string) => void;
+  clearSearch: () => void;
+  isSearchActive: boolean;
+  searchResults: MarketAssetDisplayData[];
+  isLoadingSearch: boolean;
+  hasNoResults: boolean;
+};
+
+export function useGlobalSearchResults(): GlobalSearchResults {
+  const { t } = useTranslation();
+  const { locale } = useLocale();
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const counterCurrency = counterValueCurrency.ticker.toLowerCase();
+  const counterValueUnit = counterValueCurrency.units[0];
+  const version = VersionNumber.appVersion ?? "";
+
+  const handleTrackSearch = useCallback((query: string) => track("search_query", { query }), []);
+  const { handleSearch, handleDebouncedChange, displayedValue } = useSearchCommon({
+    onTrackSearch: handleTrackSearch,
+  });
+
+  const search = displayedValue ?? "";
+  const normalized = search.trim();
+  const isSearchActive = normalized.length > 0;
+
+  const debounced = useDebounce(search, SEARCH_DEBOUNCE_MS);
+  const query = isSearchActive ? debounced.trim() : "";
+  const isDebouncing = isSearchActive && query !== normalized;
+
+  const previousQuery = useRef("");
+  useEffect(() => {
+    handleDebouncedChange(query, previousQuery.current);
+    previousQuery.current = query;
+  }, [query, handleDebouncedChange]);
+
+  const { data, isLoading, isError } = useAssetsData({
+    product: PRODUCT,
+    version,
+    search: query,
+    skip: query.length === 0,
+  });
+
+  const searchResults = useMemo<MarketAssetDisplayData[]>(() => {
+    if (!data || query.length === 0) return [];
+
+    return data.currenciesOrder.metaCurrencyIds.flatMap(id => {
+      const meta = data.cryptoAssets[id];
+      if (!meta) return [];
+      const currency = selectCurrencyForMetaId(id, data);
+      if (!currency) return [];
+
+      return [
+        mapDadaMarketToDisplayData(
+          { id: meta.id, name: meta.name, ticker: meta.ticker, ledgerId: currency.id },
+          data.markets[currency.id],
+          { counterCurrency, counterValueUnit, locale, t },
+        ),
+      ];
+    });
+  }, [data, query, counterCurrency, counterValueUnit, locale, t]);
+
+  const isLoadingSearch = isSearchActive && (isDebouncing || isLoading);
+  const clearSearch = useCallback(() => handleSearch(""), [handleSearch]);
+
+  return {
+    search,
+    setSearch: handleSearch,
+    clearSearch,
+    isSearchActive,
+    searchResults,
+    isLoadingSearch,
+    hasNoResults:
+      isSearchActive &&
+      !isLoadingSearch &&
+      !isError &&
+      data !== undefined &&
+      searchResults.length === 0,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { useNavigation } from "@react-navigation/native";
 import { track } from "~/analytics";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
 import { useGlobalSearchDefaults } from "./useGlobalSearchDefaults";
+import { useGlobalSearchResults } from "./useGlobalSearchResults";
 import type { GlobalSearchDefaultSections } from "./types";
 
 export type GlobalSearchViewModel = {
@@ -18,20 +19,24 @@ export type GlobalSearchViewModel = {
   onBack: () => void;
 };
 
-const EMPTY_RESULTS: MarketAssetDisplayData[] = [];
-
 export function useGlobalSearchViewModel(): GlobalSearchViewModel {
   const navigation = useNavigation();
-  const [search, setSearch] = useState("");
-  const isSearchActive = search.length > 0;
 
+  const {
+    search,
+    setSearch,
+    clearSearch,
+    isSearchActive,
+    searchResults,
+    isLoadingSearch,
+    hasNoResults,
+  } = useGlobalSearchResults();
   const { defaultSections, isLoadingDefaults } = useGlobalSearchDefaults(!isSearchActive);
 
   useEffect(() => {
     track("search_open");
   }, []);
 
-  const clearSearch = useCallback(() => setSearch(""), []);
   const onBack = useCallback(() => navigation.goBack(), [navigation]);
 
   return {
@@ -40,10 +45,10 @@ export function useGlobalSearchViewModel(): GlobalSearchViewModel {
     clearSearch,
     isSearchActive,
     isLoadingDefaults,
-    isLoadingSearch: false,
-    hasNoResults: false,
+    isLoadingSearch,
+    hasNoResults,
     defaultSections,
-    searchResults: EMPTY_RESULTS,
+    searchResults,
     onBack,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** `useGlobalSearchResults` unit tests (maps results for a query, `search_query` tracking, `hasNoResults`, `isLoadingSearch`, clear) + updated ViewModel composition tests.
- [x] **Impact of the changes:** As the user types, Global Search returns cross-category results (debounced). No results rendering yet — that's the next PR (LIVE-30047). Default sections stop fetching while a search is active.

### 📝 Description

Fifth PR of the **Global Search** feature. Wires the search logic in the ViewModel:

- **`useGlobalSearchResults`** uses `useSearchCommon` (`@ledgerhq/live-common/modularDrawer/hooks/useSearch`) for the input value and the debounced `search_query` tracking. The Lumen `SearchInput` doesn't debounce, so the query is debounced with `useDebounce` (300ms, same as the Market screen).
- The debounced query drives a **DADA** search (`useAssetsData({ search })`, `product: "llm"`) across all asset types, mapped to `MarketAssetDisplayData` rows (reusing `mapDadaMarketToDisplayData` + `selectCurrencyForMetaId`).
- Exposes `searchResults`, `isLoadingSearch` (debouncing or fetching), and `hasNoResults`. The ViewModel now composes the results + defaults hooks; default fetching is disabled while searching.

> Search-result selection stays mobile-side for now (desktop search isn't built yet); it reuses the shared `selectCurrencyForMetaId` and the Task 4 display mapper.

### ❓ Context

- **JIRA**: [LIVE-30045](https://ledgerhq.atlassian.net/browse/LIVE-30045) — Epic [LIVE-27854](https://ledgerhq.atlassian.net/browse/LIVE-27854)
- **Stacked PR series** (Global Search): **5/8**, based on [#18428](https://github.com/LedgerHQ/ledger-live/pull/18428) (LIVE-30044).


[LIVE-30045]: https://ledgerhq.atlassian.net/browse/LIVE-30045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ