### PR TITLE
[LWM] feat(mobile): Global Search default sections UI [LIVE-30046]

### DIFF
--- a/.changeset/global-search-default-sections-ui.md
+++ b/.changeset/global-search-default-sections-ui.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Render the Global Search default sections when no search is active: Cryptos (3) and Stablecoins (2) as compact asset rows (icon, name, price + 24h change on one line), and Stocks (up to 20) as pills laid out in two horizontally-scrollable rows. Each section has a pressable header (tracked via `button_clicked`) and shows skeletons while loading.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1459,7 +1459,12 @@
     "warning": "Resetting Ledger Wallet will erase your swap transaction history for all your accounts."
   },
   "globalSearch": {
-    "searchPlaceholder": "Search assets"
+    "searchPlaceholder": "Search assets",
+    "sections": {
+      "cryptos": "Cryptos",
+      "stablecoins": "Stablecoins",
+      "stocks": "Stocks"
+    }
   },
   "graph": {
     "week": "1W",

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/GlobalSearchView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/GlobalSearchView.tsx
@@ -5,12 +5,24 @@ import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import { useExperimental } from "~/experimental";
+import { DefaultSections } from "./components/DefaultSections";
 import { GLOBAL_SEARCH_TEST_IDS } from "./testIds";
 import type { GlobalSearchViewModel } from "./useGlobalSearchViewModel";
 
 type Props = Readonly<GlobalSearchViewModel>;
 
-export function GlobalSearchView({ search, setSearch, clearSearch, onBack }: Props) {
+export function GlobalSearchView({
+  search,
+  setSearch,
+  clearSearch,
+  onBack,
+  isSearchActive,
+  defaultSections,
+  isLoadingDefaults,
+  onSeeAll,
+  onAssetPress,
+  onStockPress,
+}: Props) {
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
   const hasExperimentalHeader = useExperimental();
@@ -66,6 +78,15 @@ export function GlobalSearchView({ search, setSearch, clearSearch, onBack }: Pro
           </View>
         </View>
       </View>
+      {!isSearchActive && (
+        <DefaultSections
+          sections={defaultSections}
+          isLoading={isLoadingDefaults}
+          onSeeAll={onSeeAll}
+          onAssetPress={onAssetPress}
+          onStockPress={onStockPress}
+        />
+      )}
     </View>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from "@tests/test-renderer";
 import { track } from "~/analytics";
+import { ScreenName } from "~/const";
 import { useGlobalSearchViewModel } from "../useGlobalSearchViewModel";
 import { useGlobalSearchDefaults } from "../useGlobalSearchDefaults";
 import { useGlobalSearchResults, type GlobalSearchResults } from "../useGlobalSearchResults";
@@ -82,5 +83,17 @@ describe("useGlobalSearchViewModel", () => {
     act(() => result.current.onBack());
 
     expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks button_clicked with the section category when onSeeAll is invoked", () => {
+    const { result } = renderHook(() => useGlobalSearchViewModel());
+
+    act(() => result.current.onSeeAll("crypto"));
+
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "See all",
+      page: ScreenName.GlobalSearch,
+      category: "crypto",
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/AssetRow/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/AssetRow/index.tsx
@@ -1,0 +1,54 @@
+import React, { useCallback } from "react";
+import Icon from "@ledgerhq/crypto-icons/native";
+import {
+  Box,
+  ListItem,
+  ListItemContent,
+  ListItemLeading,
+  ListItemTitle,
+  ListItemTrailing,
+  Text,
+  Trend,
+} from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
+
+type Props = Readonly<{
+  market: MarketAssetDisplayData;
+  onPress: (market: MarketAssetDisplayData) => void;
+  lx?: LumenViewStyle;
+}>;
+
+export function AssetRow({ market, onPress, lx }: Props) {
+  const handlePress = useCallback(() => onPress(market), [market, onPress]);
+
+  return (
+    <ListItem
+      density="compact"
+      onPress={handlePress}
+      testID={`global-search-asset-${market.id}`}
+      lx={lx}
+    >
+      <ListItemLeading>
+        <Icon ledgerId={market.ledgerIds[0]} ticker={market.ticker} size={24} />
+        <ListItemContent style={{ flex: 1, minWidth: 0 }}>
+          <ListItemTitle numberOfLines={1}>{market.name}</ListItemTitle>
+        </ListItemContent>
+      </ListItemLeading>
+      <ListItemTrailing>
+        <Box lx={trailingStyle}>
+          <Text
+            typography="body2SemiBold"
+            lx={{ color: "base" }}
+            testID={`global-search-asset-${market.id}-price`}
+          >
+            {market.formattedPrice}
+          </Text>
+          <Trend value={market.priceChangePercentage} size="sm" />
+        </Box>
+      </ListItemTrailing>
+    </ListItem>
+  );
+}
+
+const trailingStyle: LumenViewStyle = { flexDirection: "row", alignItems: "center", gap: "s8" };

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/AssetRowSkeleton/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/AssetRowSkeleton/index.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Box, Skeleton } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+
+export function AssetRowSkeleton({ testID }: Readonly<{ testID?: string }>) {
+  return (
+    <Box lx={rowStyle} testID={testID}>
+      <Box lx={leadingStyle}>
+        <Skeleton lx={iconStyle} />
+        <Skeleton lx={nameStyle} />
+      </Box>
+      <Skeleton lx={priceStyle} />
+    </Box>
+  );
+}
+
+const rowStyle: LumenViewStyle = {
+  flexDirection: "row",
+  alignItems: "center",
+  justifyContent: "space-between",
+  height: "s40",
+};
+const leadingStyle: LumenViewStyle = { flexDirection: "row", alignItems: "center", gap: "s8" };
+const iconStyle: LumenViewStyle = { width: "s24", height: "s24", borderRadius: "full" };
+const nameStyle: LumenViewStyle = { width: "s112", height: "s12", borderRadius: "full" };
+const priceStyle: LumenViewStyle = { width: "s48", height: "s12", borderRadius: "full" };

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/AssetRowsSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/AssetRowsSection/index.tsx
@@ -1,0 +1,66 @@
+import React, { useCallback } from "react";
+import {
+  Box,
+  Subheader,
+  SubheaderRow,
+  SubheaderShowMore,
+  SubheaderTitle,
+} from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
+import { AssetRow } from "../AssetRow";
+import { AssetRowSkeleton } from "../AssetRowSkeleton";
+import type { GlobalSearchCategory } from "../../useGlobalSearchViewModel";
+
+type Props = Readonly<{
+  title: string;
+  testID?: string;
+  assets: MarketAssetDisplayData[];
+  isLoading: boolean;
+  skeletonCount: number;
+  category: GlobalSearchCategory;
+  onSeeAll: (category: GlobalSearchCategory) => void;
+  onAssetPress: (asset: MarketAssetDisplayData) => void;
+}>;
+
+export function AssetRowsSection({
+  title,
+  testID,
+  assets,
+  isLoading,
+  skeletonCount,
+  category,
+  onSeeAll,
+  onAssetPress,
+}: Props) {
+  const handleSeeAll = useCallback(() => onSeeAll(category), [onSeeAll, category]);
+
+  if (!isLoading && assets.length === 0) return null;
+
+  return (
+    <Box lx={sectionStyle} testID={testID}>
+      <Subheader>
+        <SubheaderRow
+          onPress={handleSeeAll}
+          accessibilityRole="button"
+          testID={testID ? `${testID}-header` : undefined}
+        >
+          <SubheaderTitle>{title}</SubheaderTitle>
+          <SubheaderShowMore />
+        </SubheaderRow>
+      </Subheader>
+      <Box>
+        {isLoading
+          ? Array.from({ length: skeletonCount }, (_, index) => (
+              <AssetRowSkeleton key={index} testID="global-search-asset-skeleton" />
+            ))
+          : assets.map(asset => (
+              <AssetRow key={asset.id} market={asset} onPress={onAssetPress} lx={rowStyle} />
+            ))}
+      </Box>
+    </Box>
+  );
+}
+
+const sectionStyle: LumenViewStyle = { gap: "s4" };
+const rowStyle: LumenViewStyle = { marginHorizontal: "-s8" };

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/DefaultSections/__tests__/DefaultSections.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/DefaultSections/__tests__/DefaultSections.test.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
+import { DefaultSections } from "..";
+import { GLOBAL_SEARCH_TEST_IDS } from "../../../testIds";
+
+const asset = (id: string, ticker: string, name: string): MarketAssetDisplayData => ({
+  id,
+  name,
+  ticker,
+  ledgerIds: [id],
+  formattedMarketCap: "$1B",
+  marketcapRank: 1,
+  formattedPrice: "$1.00",
+  priceChangePercentage: 1.5,
+});
+
+const stock = (id: string, ticker: string): StockSuggestion => ({
+  id,
+  name: ticker,
+  ticker,
+  navigationId: id,
+  ledgerId: id,
+});
+
+const sections = {
+  cryptos: [asset("bitcoin", "BTC", "Bitcoin")],
+  stablecoins: [asset("tether", "USDT", "Tether")],
+  stocks: [stock("aapl", "AAPL"), stock("tsla", "TSLA")],
+};
+
+const renderSections = (overrides = {}) => {
+  const props = {
+    sections,
+    isLoading: false,
+    onSeeAll: jest.fn(),
+    onAssetPress: jest.fn(),
+    onStockPress: jest.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<DefaultSections {...props} />) };
+};
+
+describe("DefaultSections", () => {
+  it("renders crypto/stablecoin rows and stock pills", () => {
+    renderSections();
+
+    expect(screen.getByTestId("global-search-asset-bitcoin")).toBeVisible();
+    expect(screen.getByTestId("global-search-asset-tether")).toBeVisible();
+    expect(screen.getByTestId("global-search-stock-aapl")).toBeVisible();
+    expect(screen.getByTestId("global-search-stock-tsla")).toBeVisible();
+  });
+
+  it("calls onSeeAll with the category when a section header is pressed", async () => {
+    const { props, user } = renderSections();
+
+    await user.press(screen.getByTestId(`${GLOBAL_SEARCH_TEST_IDS.cryptosSection}-header`));
+    await user.press(screen.getByTestId(`${GLOBAL_SEARCH_TEST_IDS.stablecoinsSection}-header`));
+    await user.press(screen.getByTestId(`${GLOBAL_SEARCH_TEST_IDS.stocksSection}-header`));
+
+    expect(props.onSeeAll).toHaveBeenNthCalledWith(1, "crypto");
+    expect(props.onSeeAll).toHaveBeenNthCalledWith(2, "stable");
+    expect(props.onSeeAll).toHaveBeenNthCalledWith(3, "stocks");
+  });
+
+  it("calls onAssetPress and onStockPress on item taps", async () => {
+    const { props, user } = renderSections();
+
+    await user.press(screen.getByTestId("global-search-asset-bitcoin"));
+    expect(props.onAssetPress).toHaveBeenCalledWith(sections.cryptos[0]);
+
+    await user.press(screen.getByTestId("global-search-stock-aapl"));
+    expect(props.onStockPress).toHaveBeenCalledWith(sections.stocks[0]);
+  });
+
+  it("shows skeletons while loading", () => {
+    renderSections({
+      isLoading: true,
+      sections: { cryptos: [], stablecoins: [], stocks: [] },
+    });
+
+    expect(screen.getAllByTestId("global-search-asset-skeleton").length).toBeGreaterThan(0);
+    expect(screen.getByTestId(GLOBAL_SEARCH_TEST_IDS.cryptosSection)).toBeVisible();
+  });
+
+  it("hides empty sections when not loading", () => {
+    renderSections({
+      isLoading: false,
+      sections: { cryptos: [], stablecoins: [], stocks: [] },
+    });
+
+    expect(screen.queryByTestId(GLOBAL_SEARCH_TEST_IDS.cryptosSection)).toBeNull();
+    expect(screen.queryByTestId(GLOBAL_SEARCH_TEST_IDS.stocksSection)).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/DefaultSections/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/DefaultSections/index.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { ScrollView } from "react-native";
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { useTranslation } from "~/context/Locale";
+import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
+import { AssetRowsSection } from "../AssetRowsSection";
+import { StocksSection } from "../StocksSection";
+import { GLOBAL_SEARCH_TEST_IDS } from "../../testIds";
+import type { GlobalSearchCategory } from "../../useGlobalSearchViewModel";
+import type { GlobalSearchDefaultSections } from "../../types";
+
+type Props = Readonly<{
+  sections: GlobalSearchDefaultSections;
+  isLoading: boolean;
+  onSeeAll: (category: GlobalSearchCategory) => void;
+  onAssetPress: (asset: MarketAssetDisplayData) => void;
+  onStockPress: (stock: StockSuggestion) => void;
+}>;
+
+export function DefaultSections({
+  sections,
+  isLoading,
+  onSeeAll,
+  onAssetPress,
+  onStockPress,
+}: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <ScrollView
+      testID={GLOBAL_SEARCH_TEST_IDS.defaultSections}
+      keyboardShouldPersistTaps="handled"
+      keyboardDismissMode="on-drag"
+      showsVerticalScrollIndicator={false}
+    >
+      <Box lx={contentStyle}>
+        <AssetRowsSection
+          title={t("globalSearch.sections.cryptos")}
+          testID={GLOBAL_SEARCH_TEST_IDS.cryptosSection}
+          assets={sections.cryptos}
+          isLoading={isLoading}
+          skeletonCount={3}
+          category="crypto"
+          onSeeAll={onSeeAll}
+          onAssetPress={onAssetPress}
+        />
+        <AssetRowsSection
+          title={t("globalSearch.sections.stablecoins")}
+          testID={GLOBAL_SEARCH_TEST_IDS.stablecoinsSection}
+          assets={sections.stablecoins}
+          isLoading={isLoading}
+          skeletonCount={2}
+          category="stable"
+          onSeeAll={onSeeAll}
+          onAssetPress={onAssetPress}
+        />
+        <StocksSection
+          title={t("globalSearch.sections.stocks")}
+          testID={GLOBAL_SEARCH_TEST_IDS.stocksSection}
+          stocks={sections.stocks}
+          isLoading={isLoading}
+          category="stocks"
+          onSeeAll={onSeeAll}
+          onStockPress={onStockPress}
+        />
+      </Box>
+    </ScrollView>
+  );
+}
+
+const contentStyle: LumenViewStyle = {
+  paddingTop: "s24",
+  paddingHorizontal: "s16",
+  gap: "s16",
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/StocksSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/StocksSection/index.tsx
@@ -1,0 +1,128 @@
+import React, { useCallback, useMemo } from "react";
+import { ScrollView } from "react-native";
+import Icon from "@ledgerhq/crypto-icons/native";
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import {
+  Box,
+  MediaButton,
+  Skeleton,
+  Subheader,
+  SubheaderRow,
+  SubheaderShowMore,
+  SubheaderTitle,
+} from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import type { GlobalSearchCategory } from "../../useGlobalSearchViewModel";
+
+const SKELETON_PILLS_PER_ROW = 4;
+
+type Props = Readonly<{
+  title: string;
+  testID?: string;
+  stocks: StockSuggestion[];
+  isLoading: boolean;
+  category: GlobalSearchCategory;
+  onSeeAll: (category: GlobalSearchCategory) => void;
+  onStockPress: (stock: StockSuggestion) => void;
+}>;
+
+function splitIntoRows(stocks: StockSuggestion[]): [StockSuggestion[], StockSuggestion[]] {
+  const top: StockSuggestion[] = [];
+  const bottom: StockSuggestion[] = [];
+  stocks.forEach((stock, index) => (index % 2 === 0 ? top : bottom).push(stock));
+  return [top, bottom];
+}
+
+type StockPillProps = Readonly<{
+  stock: StockSuggestion;
+  onPress: (stock: StockSuggestion) => void;
+}>;
+
+function StockPill({ stock, onPress }: StockPillProps) {
+  const handlePress = useCallback(() => onPress(stock), [stock, onPress]);
+
+  return (
+    <MediaButton
+      size="sm"
+      hideChevron
+      leadingContentShape="rounded"
+      leadingContent={<Icon ledgerId={stock.ledgerId} ticker={stock.ticker} size={24} />}
+      onPress={handlePress}
+      accessibilityLabel={stock.name}
+      testID={`global-search-stock-${stock.ticker.toLowerCase()}`}
+    >
+      {stock.ticker.toUpperCase()}
+    </MediaButton>
+  );
+}
+
+export function StocksSection({
+  title,
+  testID,
+  stocks,
+  isLoading,
+  category,
+  onSeeAll,
+  onStockPress,
+}: Props) {
+  const [topRow, bottomRow] = useMemo(() => splitIntoRows(stocks), [stocks]);
+  const handleSeeAll = useCallback(() => onSeeAll(category), [onSeeAll, category]);
+
+  if (!isLoading && stocks.length === 0) return null;
+
+  const renderSkeletonPills = () =>
+    Array.from({ length: SKELETON_PILLS_PER_ROW }, (_, index) => (
+      <Skeleton key={index} lx={pillSkeletonStyle} />
+    ));
+
+  return (
+    <Box lx={sectionStyle} testID={testID}>
+      <Box lx={insetStyle}>
+        <Subheader>
+          <SubheaderRow
+            onPress={handleSeeAll}
+            accessibilityRole="button"
+            testID={testID ? `${testID}-header` : undefined}
+          >
+            <SubheaderTitle>{title}</SubheaderTitle>
+            <SubheaderShowMore />
+          </SubheaderRow>
+        </Subheader>
+      </Box>
+      {isLoading ? (
+        <Box lx={insetStyle}>
+          <Box lx={skeletonGridStyle}>
+            <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
+            <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
+          </Box>
+        </Box>
+      ) : (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          <Box lx={gridStyle}>
+            <Box lx={rowStyle}>
+              {topRow.map(stock => (
+                <StockPill key={stock.id} stock={stock} onPress={onStockPress} />
+              ))}
+            </Box>
+            <Box lx={rowStyle}>
+              {bottomRow.map(stock => (
+                <StockPill key={stock.id} stock={stock} onPress={onStockPress} />
+              ))}
+            </Box>
+          </Box>
+        </ScrollView>
+      )}
+    </Box>
+  );
+}
+
+const sectionStyle: LumenViewStyle = { gap: "s16", marginHorizontal: "-s16" };
+const insetStyle: LumenViewStyle = { paddingHorizontal: "s16" };
+const gridStyle: LumenViewStyle = { gap: "s8", paddingHorizontal: "s16" };
+const skeletonGridStyle: LumenViewStyle = { gap: "s8" };
+const rowStyle: LumenViewStyle = { flexDirection: "row", gap: "s8" };
+const pillSkeletonStyle: LumenViewStyle = { width: "s96", height: "s40", borderRadius: "full" };

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/testIds.ts
@@ -1,4 +1,8 @@
 export const GLOBAL_SEARCH_TEST_IDS = {
   screen: "global-search-screen",
   searchInput: "global-search-input",
+  defaultSections: "global-search-default-sections",
+  cryptosSection: "global-search-cryptos-section",
+  stablecoinsSection: "global-search-stablecoins-section",
+  stocksSection: "global-search-stocks-section",
 } as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
@@ -1,10 +1,14 @@
 import { useCallback, useEffect } from "react";
 import { useNavigation } from "@react-navigation/native";
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
 import { track } from "~/analytics";
+import { ScreenName } from "~/const";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
 import { useGlobalSearchDefaults } from "./useGlobalSearchDefaults";
 import { useGlobalSearchResults } from "./useGlobalSearchResults";
 import type { GlobalSearchDefaultSections } from "./types";
+
+export type GlobalSearchCategory = "crypto" | "stable" | "stocks";
 
 export type GlobalSearchViewModel = {
   search: string;
@@ -17,6 +21,9 @@ export type GlobalSearchViewModel = {
   defaultSections: GlobalSearchDefaultSections;
   searchResults: MarketAssetDisplayData[];
   onBack: () => void;
+  onSeeAll: (category: GlobalSearchCategory) => void;
+  onAssetPress: (asset: MarketAssetDisplayData) => void;
+  onStockPress: (stock: StockSuggestion) => void;
 };
 
 export function useGlobalSearchViewModel(): GlobalSearchViewModel {
@@ -39,6 +46,14 @@ export function useGlobalSearchViewModel(): GlobalSearchViewModel {
 
   const onBack = useCallback(() => navigation.goBack(), [navigation]);
 
+  const onSeeAll = useCallback((category: GlobalSearchCategory) => {
+    track("button_clicked", { button: "See all", page: ScreenName.GlobalSearch, category });
+  }, []);
+
+  // Destinations are wired in LIVE-30048.
+  const onAssetPress = useCallback((_asset: MarketAssetDisplayData) => {}, []);
+  const onStockPress = useCallback((_stock: StockSuggestion) => {}, []);
+
   return {
     search,
     setSearch,
@@ -50,5 +65,8 @@ export function useGlobalSearchViewModel(): GlobalSearchViewModel {
     defaultSections,
     searchResults,
     onBack,
+    onSeeAll,
+    onAssetPress,
+    onStockPress,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** `DefaultSections` component tests (rows + pills render, header taps fire the category callback, item/stock taps, skeletons, empty sections hidden) + updated data-hook/mapper tests.
- [x] **Impact of the changes:**
  - Global Search now shows the default sections (Cryptos / Stablecoins rows + Stocks pills) when no search is active.
  - QA focus: section header chevrons fire tracking; stocks scroll smoothly to the edges; crypto/stablecoin rows show icon + name + price + 24h change on one line.

### 📝 Description

Sixth PR of the **Global Search** feature — the default-sections UI (matches Figma `node-id=16001-35859`).

- **`DefaultSections`** lays out the three sections in a vertical scroll: Cryptos (3) and Stablecoins (2) as rows, Stocks (up to 20) as pills.
- **`AssetRow`** — a dedicated, compact Global Search row (`density="compact"`, crypto icon size 24, name on the leading side, price + 24h `Trend` on a single trailing line). Built as its own component rather than extending the shared `AssetListItem`, to keep that component simple.
- **`StocksSection`** — pills (`MediaButton` + crypto icon) laid out in two rows within a single horizontal scroll; each pill fits its ticker (no fixed-width columns). The scroll is full-bleed (escapes the section padding) so pills glide to the edges.
- **Headers** — pressable `Subheader` + chevron, firing `button_clicked` with the section `category`. (Navigation destinations land in LIVE-30048.)
- **Icon fallback fix** — the row/pill icon now falls back to the resolved `currency.id` when DADA's market entry omits `ledgerIds`; `StockSuggestion.ledgerId` is now required.
- **Perps** section omitted for now (per product decision).
- Spacing per design: s24 search→first section, s16 between sections, s4 header→first row, s0 between rows.



https://github.com/user-attachments/assets/9ed5493e-99ac-4481-b7f3-c690fe94a3d1



### ❓ Context

- **JIRA**: [LIVE-30046](https://ledgerhq.atlassian.net/browse/LIVE-30046) — Epic [LIVE-27854](https://ledgerhq.atlassian.net/browse/LIVE-27854)
- **Stacked PR series** (Global Search): **6/8**, based on [#18429](https://github.com/LedgerHQ/ledger-live/pull/18429) (LIVE-30045).


[LIVE-30046]: https://ledgerhq.atlassian.net/browse/LIVE-30046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ