### PR TITLE
[LWM] feat(mobile): Global Search results view + empty state [LIVE-30047]

### DIFF
--- a/.changeset/global-search-navigation.md
+++ b/.changeset/global-search-navigation.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Wire Global Search navigation: tapping an asset row or stock pill opens its detail (`openFromMarket`), the Cryptos "See all" opens the Market list (all), and the Stocks "See all" opens it on the Stocks category. The Stablecoins "See all" stays inert until the Market list gains a stablecoins category.

--- a/.changeset/global-search-results-view.md
+++ b/.changeset/global-search-results-view.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Render the Global Search results when a search is active: matching assets as shared `AssetListItem` market rows (with the Market screen's bottom fade gradient), three list skeletons while the query is loading, and a "No assets found" empty state (reusing the Market screen pattern) when the query returns nothing. Default sections are hidden while searching and restored when the input is cleared.

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/__integrations__/globalSearch.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/__integrations__/globalSearch.integration.test.tsx
@@ -44,4 +44,20 @@ describe("GlobalSearch screen", () => {
 
     expect(screen.getByDisplayValue("bitcoin")).toBeVisible();
   });
+
+  it("swaps default sections for search results when typing and restores them on clear", async () => {
+    const { user } = render(<GlobalSearch />);
+    const input = screen.getByPlaceholderText(/search assets/i);
+
+    expect(screen.getByTestId(GLOBAL_SEARCH_TEST_IDS.defaultSections)).toBeVisible();
+
+    await user.type(input, "b");
+
+    expect(screen.queryByTestId(GLOBAL_SEARCH_TEST_IDS.defaultSections)).toBeNull();
+    expect(screen.getAllByTestId(GLOBAL_SEARCH_TEST_IDS.searchSkeleton).length).toBeGreaterThan(0);
+
+    await user.clear(input);
+
+    expect(screen.getByTestId(GLOBAL_SEARCH_TEST_IDS.defaultSections)).toBeVisible();
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/GlobalSearchView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/GlobalSearchView.tsx
@@ -6,6 +6,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import { useExperimental } from "~/experimental";
 import { DefaultSections } from "./components/DefaultSections";
+import { SearchResults } from "./components/SearchResults";
 import { GLOBAL_SEARCH_TEST_IDS } from "./testIds";
 import type { GlobalSearchViewModel } from "./useGlobalSearchViewModel";
 
@@ -19,6 +20,9 @@ export function GlobalSearchView({
   isSearchActive,
   defaultSections,
   isLoadingDefaults,
+  searchResults,
+  isLoadingSearch,
+  hasNoResults,
   onSeeAll,
   onAssetPress,
   onStockPress,
@@ -78,7 +82,14 @@ export function GlobalSearchView({
           </View>
         </View>
       </View>
-      {!isSearchActive && (
+      {isSearchActive ? (
+        <SearchResults
+          results={searchResults}
+          isLoading={isLoadingSearch}
+          hasNoResults={hasNoResults}
+          onAssetPress={onAssetPress}
+        />
+      ) : (
         <DefaultSections
           sections={defaultSections}
           isLoading={isLoadingDefaults}

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
@@ -6,10 +6,16 @@ import { useGlobalSearchDefaults } from "../useGlobalSearchDefaults";
 import { useGlobalSearchResults, type GlobalSearchResults } from "../useGlobalSearchResults";
 
 const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
+const mockOpenFromMarket = jest.fn();
 
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
-  useNavigation: () => ({ goBack: mockGoBack }),
+  useNavigation: () => ({ goBack: mockGoBack, navigate: mockNavigate }),
+}));
+
+jest.mock("LLM/features/AssetDetail/hooks/useAssetDetailNavigation", () => ({
+  useAssetDetailNavigation: () => ({ openFromMarket: mockOpenFromMarket }),
 }));
 
 jest.mock("../useGlobalSearchDefaults");
@@ -94,6 +100,60 @@ describe("useGlobalSearchViewModel", () => {
       button: "See all",
       page: ScreenName.GlobalSearch,
       category: "crypto",
+    });
+  });
+
+  it("opens the Market list on the all category from the Cryptos header", () => {
+    const { result } = renderHook(() => useGlobalSearchViewModel());
+
+    act(() => result.current.onSeeAll("crypto"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.MarketList, { category: "all" });
+  });
+
+  it("opens the Market list on the stocks category from the Stocks header", () => {
+    const { result } = renderHook(() => useGlobalSearchViewModel());
+
+    act(() => result.current.onSeeAll("stocks"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.MarketList, { category: "stocks" });
+  });
+
+  it("does not navigate from the Stablecoins header (no Market category yet)", () => {
+    const { result } = renderHook(() => useGlobalSearchViewModel());
+
+    act(() => result.current.onSeeAll("stable"));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("opens asset detail from a tapped result row", () => {
+    const { result } = renderHook(() => useGlobalSearchViewModel());
+
+    act(() => result.current.onAssetPress({ id: "bitcoin", ledgerIds: ["bitcoin"] } as never));
+
+    expect(mockOpenFromMarket).toHaveBeenCalledWith({
+      marketCurrencyId: "bitcoin",
+      ledgerCurrencyIds: ["bitcoin"],
+      source: ScreenName.GlobalSearch,
+    });
+  });
+
+  it("opens asset detail from a tapped stock pill", () => {
+    const { result } = renderHook(() => useGlobalSearchViewModel());
+
+    act(() =>
+      result.current.onStockPress({
+        id: "aapl",
+        navigationId: "aapl-market",
+        ledgerId: "aapl-ledger",
+      } as never),
+    );
+
+    expect(mockOpenFromMarket).toHaveBeenCalledWith({
+      marketCurrencyId: "aapl-market",
+      ledgerCurrencyIds: ["aapl-ledger"],
+      source: ScreenName.GlobalSearch,
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/SearchResults/__tests__/SearchResults.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/SearchResults/__tests__/SearchResults.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
+import { SearchResults } from "..";
+import { GLOBAL_SEARCH_TEST_IDS } from "../../../testIds";
+
+const asset = (id: string, ticker: string, name: string): MarketAssetDisplayData => ({
+  id,
+  name,
+  ticker,
+  ledgerIds: [id],
+  formattedMarketCap: "$1B",
+  marketcapRank: 1,
+  formattedPrice: "$1.00",
+  priceChangePercentage: 1.5,
+});
+
+const results = [asset("bitcoin", "BTC", "Bitcoin"), asset("ethereum", "ETH", "Ethereum")];
+
+const renderResults = (overrides = {}) => {
+  const props = {
+    results,
+    isLoading: false,
+    hasNoResults: false,
+    onAssetPress: jest.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<SearchResults {...props} />) };
+};
+
+describe("SearchResults", () => {
+  it("renders a market row per result with the bottom fade gradient", () => {
+    renderResults();
+
+    expect(screen.getByTestId("marketItem-bitcoin")).toBeVisible();
+    expect(screen.getByTestId("marketItem-ethereum")).toBeVisible();
+    expect(screen.getByTestId("bottom-fade-gradient")).toBeVisible();
+  });
+
+  it("shows three skeletons while loading", () => {
+    renderResults({ isLoading: true, results: [] });
+
+    expect(screen.getAllByTestId(GLOBAL_SEARCH_TEST_IDS.searchSkeleton)).toHaveLength(3);
+    expect(screen.queryByTestId("marketItem-bitcoin")).toBeNull();
+  });
+
+  it("shows the empty state when there are no results", () => {
+    renderResults({ hasNoResults: true, results: [] });
+
+    expect(screen.getByTestId(GLOBAL_SEARCH_TEST_IDS.searchEmptyState)).toBeVisible();
+    expect(screen.queryByTestId(GLOBAL_SEARCH_TEST_IDS.searchResults)).toBeNull();
+  });
+
+  it("calls onAssetPress when a row is tapped", async () => {
+    const { props, user } = renderResults();
+
+    await user.press(screen.getByTestId("marketItem-bitcoin"));
+
+    expect(props.onAssetPress).toHaveBeenCalledWith(results[0]);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/SearchResults/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/SearchResults/index.tsx
@@ -1,0 +1,91 @@
+import React, { useCallback } from "react";
+import { FlatList, View, type ListRenderItemInfo } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Box, Spot, Text } from "@ledgerhq/lumen-ui-rnative";
+import { Search } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { useTranslation } from "~/context/Locale";
+import AssetListItem, {
+  AssetLoadingState,
+  type MarketAssetDisplayData,
+} from "LLM/components/AssetListItem";
+import { BottomFadeGradient, GRADIENT_HEIGHT } from "LLM/components/BottomFadeGradient";
+import { GLOBAL_SEARCH_TEST_IDS } from "../../testIds";
+
+const SKELETON_COUNT = 3;
+
+type Props = Readonly<{
+  results: MarketAssetDisplayData[];
+  isLoading: boolean;
+  hasNoResults: boolean;
+  onAssetPress: (asset: MarketAssetDisplayData) => void;
+}>;
+
+export function SearchResults({ results, isLoading, hasNoResults, onAssetPress }: Props) {
+  const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
+
+  const renderRow = useCallback(
+    ({ item }: ListRenderItemInfo<MarketAssetDisplayData>) => (
+      <AssetListItem variant="market" market={item} onPress={onAssetPress} lx={rowStyle} />
+    ),
+    [onAssetPress],
+  );
+
+  if (isLoading) {
+    return (
+      <AssetLoadingState
+        count={SKELETON_COUNT}
+        lx={skeletonStyle}
+        skeletonTestID={GLOBAL_SEARCH_TEST_IDS.searchSkeleton}
+      />
+    );
+  }
+
+  if (hasNoResults) {
+    return (
+      <Box lx={emptyStateStyle} testID={GLOBAL_SEARCH_TEST_IDS.searchEmptyState}>
+        <View style={topSpacerStyle} />
+        <Spot appearance="icon" icon={Search} size={72} />
+        <Text
+          typography="heading4SemiBold"
+          lx={{ color: "base", textAlign: "center", marginTop: "s24" }}
+        >
+          {t("modularDrawer.emptyAssetList")}
+        </Text>
+      </Box>
+    );
+  }
+
+  return (
+    <View style={listContainerStyle}>
+      <FlatList
+        testID={GLOBAL_SEARCH_TEST_IDS.searchResults}
+        style={listStyle}
+        data={results}
+        keyExtractor={item => item.id}
+        renderItem={renderRow}
+        showsVerticalScrollIndicator={false}
+        keyboardDismissMode="on-drag"
+        keyboardShouldPersistTaps="handled"
+        contentContainerStyle={{
+          ...contentContainerStyle,
+          paddingBottom: GRADIENT_HEIGHT + bottom,
+        }}
+      />
+      <BottomFadeGradient />
+    </View>
+  );
+}
+
+const listContainerStyle = { flex: 1 };
+const listStyle = { flex: 1 };
+const contentContainerStyle = { paddingTop: 8, paddingHorizontal: 16 };
+const rowStyle: LumenViewStyle = { marginHorizontal: "-s8" };
+const skeletonStyle: LumenViewStyle = { paddingTop: "s8", paddingHorizontal: "s16" };
+const emptyStateStyle: LumenViewStyle = {
+  flex: 1,
+  alignItems: "center",
+  paddingHorizontal: "s16",
+};
+const topSpacerStyle = { height: "30%" } as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/testIds.ts
@@ -5,4 +5,7 @@ export const GLOBAL_SEARCH_TEST_IDS = {
   cryptosSection: "global-search-cryptos-section",
   stablecoinsSection: "global-search-stablecoins-section",
   stocksSection: "global-search-stocks-section",
+  searchResults: "global-search-results",
+  searchSkeleton: "global-search-results-skeleton",
+  searchEmptyState: "global-search-empty-state",
 } as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
@@ -1,9 +1,12 @@
 import { useCallback, useEffect } from "react";
 import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
 import { track } from "~/analytics";
 import { ScreenName } from "~/const";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
+import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
 import { useGlobalSearchDefaults } from "./useGlobalSearchDefaults";
 import { useGlobalSearchResults } from "./useGlobalSearchResults";
 import type { GlobalSearchDefaultSections } from "./types";
@@ -27,7 +30,8 @@ export type GlobalSearchViewModel = {
 };
 
 export function useGlobalSearchViewModel(): GlobalSearchViewModel {
-  const navigation = useNavigation();
+  const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+  const { openFromMarket } = useAssetDetailNavigation();
 
   const {
     search,
@@ -46,13 +50,38 @@ export function useGlobalSearchViewModel(): GlobalSearchViewModel {
 
   const onBack = useCallback(() => navigation.goBack(), [navigation]);
 
-  const onSeeAll = useCallback((category: GlobalSearchCategory) => {
-    track("button_clicked", { button: "See all", page: ScreenName.GlobalSearch, category });
-  }, []);
+  const onSeeAll = useCallback(
+    (category: GlobalSearchCategory) => {
+      track("button_clicked", { button: "See all", page: ScreenName.GlobalSearch, category });
 
-  // Destinations are wired in LIVE-30048.
-  const onAssetPress = useCallback((_asset: MarketAssetDisplayData) => {}, []);
-  const onStockPress = useCallback((_stock: StockSuggestion) => {}, []);
+      if (category === "stable") return;
+
+      navigation.navigate(ScreenName.MarketList, {
+        category: category === "stocks" ? "stocks" : "all",
+      });
+    },
+    [navigation],
+  );
+
+  const onAssetPress = useCallback(
+    (asset: MarketAssetDisplayData) =>
+      openFromMarket({
+        marketCurrencyId: asset.id,
+        ledgerCurrencyIds: asset.ledgerIds,
+        source: ScreenName.GlobalSearch,
+      }),
+    [openFromMarket],
+  );
+
+  const onStockPress = useCallback(
+    (stock: StockSuggestion) =>
+      openFromMarket({
+        marketCurrencyId: stock.navigationId,
+        ledgerCurrencyIds: [stock.ledgerId],
+        source: ScreenName.GlobalSearch,
+      }),
+    [openFromMarket],
+  );
 
   return {
     search,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** `SearchResults` component tests (market rows + bottom gradient, 3 loading skeletons, empty state, row tap) + integration test (typing swaps default sections → results, clearing restores them).
- [x] **Impact of the changes:**
  - Global Search now shows results when a search is active, hiding the default sections; clearing the input restores them.
  - QA focus: results appear as you type (debounced); 3 skeletons during loading; "No assets found" empty state when nothing matches; the bottom fade gradient sits above the last rows; behaviour with the keyboard open.

### 📝 Description

Seventh PR of the **Global Search** feature — the results view, loading and empty states (matches Figma [`node-id=10608-18809`](https://www.figma.com/design/DBIUYjCCk5Uxvb27jFyY8v/Global-Search-Production-%E2%80%A2-Wallet-4.0?node-id=10608-18809) / empty state [`node-id=16004-11980`](https://www.figma.com/design/DBIUYjCCk5Uxvb27jFyY8v/Global-Search-Production-%E2%80%A2-Wallet-4.0?node-id=16004-11980)).

- **`SearchResults`** is rendered when `isSearchActive` (otherwise `DefaultSections`):
  - **Results** — matching assets as the **shared `AssetListItem`** (`variant="market"`) in a `FlatList`, with the Market screen's **`BottomFadeGradient`** below it (`paddingBottom: GRADIENT_HEIGHT + safeArea.bottom` so the last rows clear it).
  - **Loading** — 3 shared `AssetListItem` skeletons (`AssetLoadingState count={3}`) while `isLoadingSearch`.
  - **Empty** — when `hasNoResults`, the Market screen's empty search state (`Spot` size 72 + `heading4SemiBold`, reusing the `modularDrawer.emptyAssetList` "No assets found" copy), anchored ~30% from the top.
- **`GlobalSearchView`** now switches between `SearchResults` (searching) and `DefaultSections` (idle).


https://github.com/user-attachments/assets/e2c0477d-ee83-4842-849b-8e1fded3fb26



### ❓ Context

- **JIRA**: [LIVE-30047](https://ledgerhq.atlassian.net/browse/LIVE-30047) — Epic [LIVE-27854](https://ledgerhq.atlassian.net/browse/LIVE-27854)
- **Stacked PR series** (Global Search): **7/8**, based on [#18431](https://github.com/LedgerHQ/ledger-live/pull/18431) (LIVE-30046).

[LIVE-30047]: https://ledgerhq.atlassian.net/browse/LIVE-30047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ