### PR TITLE
[LWM] feat(mobile): Global Search navigation [LIVE-30048]

### DIFF
--- a/.changeset/global-search-navigation.md
+++ b/.changeset/global-search-navigation.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Wire Global Search navigation: tapping an asset row or stock pill opens its detail (`openFromMarket`), the Cryptos "See all" opens the Market list (all), and the Stocks "See all" opens it on the Stocks category. The Stablecoins "See all" stays inert until the Market list gains a stablecoins category.

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
@@ -6,10 +6,16 @@ import { useGlobalSearchDefaults } from "../useGlobalSearchDefaults";
 import { useGlobalSearchResults, type GlobalSearchResults } from "../useGlobalSearchResults";
 
 const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
+const mockOpenFromMarket = jest.fn();
 
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
-  useNavigation: () => ({ goBack: mockGoBack }),
+  useNavigation: () => ({ goBack: mockGoBack, navigate: mockNavigate }),
+}));
+
+jest.mock("LLM/features/AssetDetail/hooks/useAssetDetailNavigation", () => ({
+  useAssetDetailNavigation: () => ({ openFromMarket: mockOpenFromMarket }),
 }));
 
 jest.mock("../useGlobalSearchDefaults");
@@ -94,6 +100,60 @@ describe("useGlobalSearchViewModel", () => {
       button: "See all",
       page: ScreenName.GlobalSearch,
       category: "crypto",
+    });
+  });
+
+  it("opens the Market list on the all category from the Cryptos header", () => {
+    const { result } = renderHook(() => useGlobalSearchViewModel());
+
+    act(() => result.current.onSeeAll("crypto"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.MarketList, { category: "all" });
+  });
+
+  it("opens the Market list on the stocks category from the Stocks header", () => {
+    const { result } = renderHook(() => useGlobalSearchViewModel());
+
+    act(() => result.current.onSeeAll("stocks"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.MarketList, { category: "stocks" });
+  });
+
+  it("does not navigate from the Stablecoins header (no Market category yet)", () => {
+    const { result } = renderHook(() => useGlobalSearchViewModel());
+
+    act(() => result.current.onSeeAll("stable"));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("opens asset detail from a tapped result row", () => {
+    const { result } = renderHook(() => useGlobalSearchViewModel());
+
+    act(() => result.current.onAssetPress({ id: "bitcoin", ledgerIds: ["bitcoin"] } as never));
+
+    expect(mockOpenFromMarket).toHaveBeenCalledWith({
+      marketCurrencyId: "bitcoin",
+      ledgerCurrencyIds: ["bitcoin"],
+      source: ScreenName.GlobalSearch,
+    });
+  });
+
+  it("opens asset detail from a tapped stock pill", () => {
+    const { result } = renderHook(() => useGlobalSearchViewModel());
+
+    act(() =>
+      result.current.onStockPress({
+        id: "aapl",
+        navigationId: "aapl-market",
+        ledgerId: "aapl-ledger",
+      } as never),
+    );
+
+    expect(mockOpenFromMarket).toHaveBeenCalledWith({
+      marketCurrencyId: "aapl-market",
+      ledgerCurrencyIds: ["aapl-ledger"],
+      source: ScreenName.GlobalSearch,
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
@@ -1,9 +1,12 @@
 import { useCallback, useEffect } from "react";
 import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
 import { track } from "~/analytics";
 import { ScreenName } from "~/const";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
+import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
 import { useGlobalSearchDefaults } from "./useGlobalSearchDefaults";
 import { useGlobalSearchResults } from "./useGlobalSearchResults";
 import type { GlobalSearchDefaultSections } from "./types";
@@ -27,7 +30,8 @@ export type GlobalSearchViewModel = {
 };
 
 export function useGlobalSearchViewModel(): GlobalSearchViewModel {
-  const navigation = useNavigation();
+  const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+  const { openFromMarket } = useAssetDetailNavigation();
 
   const {
     search,
@@ -46,13 +50,38 @@ export function useGlobalSearchViewModel(): GlobalSearchViewModel {
 
   const onBack = useCallback(() => navigation.goBack(), [navigation]);
 
-  const onSeeAll = useCallback((category: GlobalSearchCategory) => {
-    track("button_clicked", { button: "See all", page: ScreenName.GlobalSearch, category });
-  }, []);
+  const onSeeAll = useCallback(
+    (category: GlobalSearchCategory) => {
+      track("button_clicked", { button: "See all", page: ScreenName.GlobalSearch, category });
 
-  // Destinations are wired in LIVE-30048.
-  const onAssetPress = useCallback((_asset: MarketAssetDisplayData) => {}, []);
-  const onStockPress = useCallback((_stock: StockSuggestion) => {}, []);
+      if (category === "stable") return;
+
+      navigation.navigate(ScreenName.MarketList, {
+        category: category === "stocks" ? "stocks" : "all",
+      });
+    },
+    [navigation],
+  );
+
+  const onAssetPress = useCallback(
+    (asset: MarketAssetDisplayData) =>
+      openFromMarket({
+        marketCurrencyId: asset.id,
+        ledgerCurrencyIds: asset.ledgerIds,
+        source: ScreenName.GlobalSearch,
+      }),
+    [openFromMarket],
+  );
+
+  const onStockPress = useCallback(
+    (stock: StockSuggestion) =>
+      openFromMarket({
+        marketCurrencyId: stock.navigationId,
+        ledgerCurrencyIds: [stock.ledgerId],
+        source: ScreenName.GlobalSearch,
+      }),
+    [openFromMarket],
+  );
 
   return {
     search,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** `useGlobalSearchViewModel` tests for each tap target: asset row → `openFromMarket`, stock pill → `openFromMarket`, Cryptos header → Market list (`all`), Stocks header → Market list (`stocks`), Stablecoins header → no-op.
- [x] **Impact of the changes:**
  - All Global Search tap targets now navigate: rows/pills open asset detail, the Cryptos/Stocks "See all" open the Market list on the matching category.
  - QA focus: tapping a result row or default-section row/pill opens the right asset detail; "See all" on Cryptos opens Market (all), on Stocks opens Market (Stocks); "See all" on Stablecoins does nothing yet (no Market category); search closes when navigating away.

### 📝 Description

Eighth and final PR of the **Global Search** feature — wires every tap target from its placeholder no-op to a real destination.

- **Asset rows & stock pills** → `useAssetDetailNavigation().openFromMarket(...)` (`marketCurrencyId` + `ledgerCurrencyIds`, `source: GlobalSearch`), the same hook the Market screen uses. Covers both search results and default-section items.
- **Section "See all" headers** → the Market list:
  - **Cryptos** → `category: "all"`
  - **Stocks** → `category: "stocks"`
  - **Stablecoins** → **no-op** for now — the Market list has no stablecoins category yet (depends on LIVE-30040). Tracking still fires.
- Navigates directly to `ScreenName.MarketList` (a route on the Base navigator), mirroring `MarketBanner` — `NavigatorName.Market` is nested several levels under the wallet-tab tree and isn't reachable from the Base-level Global Search navigator.


https://github.com/user-attachments/assets/5211802e-431a-4431-b298-f320c7f0b980



### ❓ Context

- **JIRA**: [LIVE-30048](https://ledgerhq.atlassian.net/browse/LIVE-30048) — Epic [LIVE-27854](https://ledgerhq.atlassian.net/browse/LIVE-27854)
- **Stacked PR series** (Global Search): **8/8**, based on [#18433](https://github.com/LedgerHQ/ledger-live/pull/18433) (LIVE-30047).
- **Follow-up**: the Stablecoins "See all" destination is gated on LIVE-30040 (Market list stablecoins category).

[LIVE-30048]: https://ledgerhq.atlassian.net/browse/LIVE-30048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ