### PR TITLE
feat(wallet-cli): add optional BLE transport for Flex/Stax (Node, via DMK)

### DIFF
--- a/.changeset/wallet-cli-ble-transport.md
+++ b/.changeset/wallet-cli-ble-transport.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": minor
+---
+
+Add an optional Bluetooth Low Energy (BLE) transport to wallet-cli, selectable with `WALLET_CLI_TRANSPORT=ble` (default stays `usb`, so existing flows are unchanged). The BLE transport drives Flex/Stax/Nano X over the same DMK device-action layer as USB: framing is delegated to DMK's ApduSender/ApduReceiver services and BLE service/characteristic UUIDs come from `deviceModelDataSource`, so it stays in sync with the device models DMK knows about. This lets the CLI run on hosts where the device is paired over Bluetooth rather than cabled.

--- a/apps/wallet-cli/package.json
+++ b/apps/wallet-cli/package.json
@@ -35,6 +35,7 @@
     "format:check": "oxfmt -c ../../.oxfmtrc.json src bunli.config.ts --check"
   },
   "optionalDependencies": {
+    "@abandonware/noble": "^1.9.2-26",
     "@ledgerhq/wallet-cli-darwin-arm64": "workspace:*",
     "@ledgerhq/wallet-cli-linux-arm64": "workspace:*",
     "@ledgerhq/wallet-cli-linux-x64": "workspace:*",

--- a/apps/wallet-cli/src/cli.ts
+++ b/apps/wallet-cli/src/cli.ts
@@ -11,6 +11,7 @@ import "../.bunli/commands.gen";
 import bunliConfig from "../bunli.config";
 import { getCliProcessExitCode } from "./cli-process-exit-error";
 import { disposeWalletCliDmkTransportFully } from "./device/register-dmk-transport";
+import { resolveWalletCliTransportKind, type WalletCliTransportKind } from "./device/transport-kind";
 import AccountGroup from "./commands/account/index";
 import AssetsGroup from "./commands/assets/index";
 import SessionGroup from "./commands/session/index";
@@ -51,6 +52,17 @@ function normalizeNegatedFlags(argv: string[]): string[] {
 }
 
 if (import.meta.main) {
+  // Resolve (and validate) the transport once, up front: a bad
+  // WALLET_CLI_TRANSPORT fails fast here with a clear message, before any work,
+  // rather than throwing mid-shutdown after a command already ran.
+  let transportKind: WalletCliTransportKind;
+  try {
+    transportKind = resolveWalletCliTransportKind();
+  } catch (e) {
+    process.stderr.write(`${e instanceof Error ? e.message : String(e)}\n`);
+    process.exit(2);
+  }
+
   let exitCode = 0;
   try {
     exitCode = await runMain();
@@ -62,4 +74,12 @@ if (import.meta.main) {
     await disposeWalletCliDmkTransportFully();
   }
   process.exitCode = exitCode;
+  // The BLE transport's noble backend keeps a native handle on the libuv loop
+  // that it never unrefs, so the process would hang after a command completes
+  // (the USB transport unrefs its hotplug events and drains naturally). Teardown
+  // is done by this point and all output has been written, so exit explicitly on
+  // the BLE path. Kept out of the USB path to preserve its graceful drain.
+  if (transportKind === "ble") {
+    process.exit(exitCode);
+  }
 }

--- a/apps/wallet-cli/src/device/dmk.ts
+++ b/apps/wallet-cli/src/device/dmk.ts
@@ -5,43 +5,95 @@ import {
   type TransportFactory,
 } from "@ledgerhq/device-management-kit";
 import { nodeWebUsbTransportFactory, type NodeWebUsbTransport } from "./node-webusb";
+import type { NobleAdapter, NodeBleTransport } from "./node-ble";
 import { LedgerLiveLogger } from "@ledgerhq/live-dmk-shared/services/LedgerLiveLogger";
 import { UserHashService } from "@ledgerhq/live-dmk-shared/services/UserHashService";
 import { getEnv } from "@ledgerhq/live-env";
+import type { WalletCliTransportKind } from "./transport-kind";
 
 export type WalletCliDmk = {
   dmk: DeviceManagementKit;
   /**
-   * Tear down the underlying node-webusb transport this kit was built with.
+   * Tear down the underlying transport this kit was built with.
    * Bound to *this* kit's transport — building another kit returns its own
    * `destroyTransport` rather than overwriting a shared module-level ref.
    */
   destroyTransport: () => Promise<void>;
 };
 
-export function createDeviceManagementKit(): WalletCliDmk {
-  const userId = getEnv("USER_ID") || "wallet-cli";
-  const firmwareDistributionSalt = UserHashService.compute(userId).firmwareSalt;
+type TransportSetup = {
+  factory: TransportFactory;
+  destroyTransport: () => Promise<void>;
+};
 
+function setupNodeWebUsbTransport(): TransportSetup {
   let nodeWebUsbTransport: NodeWebUsbTransport | null = null;
-  const captureTransportFactory: TransportFactory = args => {
-    const transport = nodeWebUsbTransportFactory(args) as NodeWebUsbTransport;
-    nodeWebUsbTransport = transport;
-    return transport;
-  };
-
-  const dmk = new DeviceManagementKitBuilder()
-    .addTransport(captureTransportFactory)
-    .addLogger(new LedgerLiveLogger(LogLevel.Warning))
-    .addConfig({ firmwareDistributionSalt })
-    .build();
-
   return {
-    dmk,
+    factory: args => {
+      const transport = nodeWebUsbTransportFactory(args) as NodeWebUsbTransport;
+      nodeWebUsbTransport = transport;
+      return transport;
+    },
     destroyTransport: async () => {
       const transport = nodeWebUsbTransport;
       nodeWebUsbTransport = null;
       await transport?.destroy();
     },
   };
+}
+
+/**
+ * BLE setup is async because `@abandonware/noble` initializes the platform
+ * Bluetooth stack at require time — USB runs must never load it.
+ */
+async function setupNodeBleTransport(): Promise<TransportSetup> {
+  // noble is an optionalDependency (BLE is opt-in and its native binding is
+  // platform-specific), so a USB-only install can legitimately lack it. Surface
+  // a clear, actionable error instead of a raw module-resolution failure.
+  let nobleModule: unknown;
+  try {
+    nobleModule = await import("@abandonware/noble");
+  } catch (cause) {
+    throw new Error(
+      "WALLET_CLI_TRANSPORT=ble requires the optional '@abandonware/noble' dependency, " +
+        "which is not installed. Install it to use the BLE transport, or use USB " +
+        "(WALLET_CLI_TRANSPORT=usb, the default).",
+      { cause },
+    );
+  }
+  const { nodeBleTransportFactory } = await import("./node-ble");
+  const resolved = nobleModule as { default?: unknown };
+  const noble = (resolved.default ?? nobleModule) as unknown as NobleAdapter;
+  const factory = nodeBleTransportFactory(noble);
+  let nodeBleTransport: NodeBleTransport | null = null;
+  return {
+    factory: args => {
+      const transport = factory(args) as NodeBleTransport;
+      nodeBleTransport = transport;
+      return transport;
+    },
+    destroyTransport: async () => {
+      const transport = nodeBleTransport;
+      nodeBleTransport = null;
+      await transport?.destroy();
+    },
+  };
+}
+
+export async function createDeviceManagementKit(
+  transportKind: WalletCliTransportKind = "usb",
+): Promise<WalletCliDmk> {
+  const userId = getEnv("USER_ID") || "wallet-cli";
+  const firmwareDistributionSalt = UserHashService.compute(userId).firmwareSalt;
+
+  const { factory, destroyTransport } =
+    transportKind === "ble" ? await setupNodeBleTransport() : setupNodeWebUsbTransport();
+
+  const dmk = new DeviceManagementKitBuilder()
+    .addTransport(factory)
+    .addLogger(new LedgerLiveLogger(LogLevel.Warning))
+    .addConfig({ firmwareDistributionSalt })
+    .build();
+
+  return { dmk, destroyTransport };
 }

--- a/apps/wallet-cli/src/device/node-ble/NodeBleTransport.test.ts
+++ b/apps/wallet-cli/src/device/node-ble/NodeBleTransport.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  type ApduReceiverServiceFactory,
+  type ApduSenderServiceFactory,
+  type DeviceModelDataSource,
+  type TransportArgs,
+  type TransportConnectedDevice,
+} from "@ledgerhq/device-management-kit";
+import { Just, Right } from "purify-ts";
+import { firstValueFrom, type Subscription } from "rxjs";
+import {
+  NodeBleTransport,
+  nodeBleIdentifier,
+  type NobleAdapter,
+  type NobleCharacteristic,
+  type NoblePeripheral,
+  type NobleService,
+} from "./NodeBleTransport";
+
+const SERVICE_UUID = "13d634002c97300400004c6564676572"; // Flex
+const WRITE_UUID = "13d634002c97300100004c6564676572";
+const NOTIFY_UUID = "13d634002c97300200004c6564676572";
+const DEVICE_MODEL = { id: "flex" } as never;
+
+function flushTasks(): Promise<void> {
+  return new Promise(resolve => queueMicrotask(resolve));
+}
+
+async function waitFor(assertion: () => void, attempts = 50): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await flushTasks();
+    }
+  }
+  throw lastError;
+}
+
+// The sender turns an APDU into a single raw frame; the receiver echoes the
+// payload back as a settled response on the first frame. Enough to prove the
+// transport wires noble notifications into DMK's services and back out.
+const apduSenderServiceFactory: ApduSenderServiceFactory = () => ({
+  getFrames: (apdu: Uint8Array) => [{ getRawData: () => apdu } as never],
+});
+const apduReceiverServiceFactory: ApduReceiverServiceFactory = () => ({
+  handleFrame: (frame: Uint8Array) =>
+    Right(Just({ data: frame, statusCode: new Uint8Array([0x90, 0x00]) })) as never,
+});
+
+/** Minimal DMK args: device-model BLE specs + framing services the transport delegates to. */
+function createTransportArgs(): TransportArgs {
+  const deviceModelDataSource = {
+    getBluetoothServices: () => [SERVICE_UUID],
+    getBluetoothServicesInfos: () => ({
+      [SERVICE_UUID]: {
+        deviceModel: DEVICE_MODEL,
+        serviceUuid: SERVICE_UUID,
+        writeUuid: WRITE_UUID,
+        writeCmdUuid: WRITE_UUID,
+        notifyUuid: NOTIFY_UUID,
+      },
+    }),
+  } as unknown as DeviceModelDataSource;
+
+  return {
+    deviceModelDataSource,
+    loggerServiceFactory: () => ({ debug() {}, info() {}, warn() {}, error() {} }) as never,
+    config: {} as never,
+    apduSenderServiceFactory,
+    apduReceiverServiceFactory,
+  };
+}
+
+type FakeNobleControls = {
+  noble: NobleAdapter;
+  emitStateChange(state: string): void;
+  emitDiscover(peripheral: NoblePeripheral): void;
+};
+
+function createFakeNoble(initialState = "poweredOn"): FakeNobleControls {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  let scanning = false;
+  const noble: NobleAdapter = {
+    state: initialState,
+    on(event, cb) {
+      (listeners.get(event) ?? listeners.set(event, new Set()).get(event)!).add(cb);
+    },
+    removeListener(event, cb) {
+      listeners.get(event)?.delete(cb);
+    },
+    startScanning() {
+      scanning = true;
+    },
+    stopScanning() {
+      scanning = false;
+    },
+  };
+  return {
+    noble,
+    emitStateChange: state => {
+      noble.state = state;
+      listeners.get("stateChange")?.forEach(cb => cb(state));
+    },
+    // Real noble only emits 'discover' while a scan is active.
+    emitDiscover: peripheral => {
+      if (scanning) {
+        listeners.get("discover")?.forEach(cb => cb(peripheral));
+      }
+    },
+  };
+}
+
+/** A fake Ledger peripheral whose notify characteristic answers the 0x08 MTU probe, then echoes writes. */
+function createLedgerPeripheral(id: string, localName: string): NoblePeripheral {
+  let dataListener: ((data: Buffer) => void) | null = null;
+  let mtuAnswered = false;
+  const notifyChar: NobleCharacteristic = {
+    uuid: NOTIFY_UUID,
+    subscribe: cb => cb(),
+    unsubscribe: cb => cb?.(),
+    on: (_event, cb) => {
+      dataListener = cb;
+    },
+    removeAllListeners: () => {
+      dataListener = null;
+    },
+    write: (_data, _withoutResponse, cb) => cb(),
+  };
+  const writeChar: NobleCharacteristic = {
+    uuid: WRITE_UUID,
+    subscribe: cb => cb(),
+    unsubscribe: cb => cb?.(),
+    on: () => {},
+    removeAllListeners: () => {},
+    write: (data, _withoutResponse, cb) => {
+      cb();
+      // First write is the 0x08 GET-MTU probe; answer it so connect() resolves.
+      if (!mtuAnswered && data[0] === 0x08) {
+        mtuAnswered = true;
+        queueMicrotask(() => dataListener?.(Buffer.from([0x08, 0, 0, 0, 0, 153])));
+        return;
+      }
+      // Any later write is an APDU frame; echo it straight back as the response.
+      queueMicrotask(() => dataListener?.(Buffer.from(data)));
+    },
+  };
+  const service: NobleService = {
+    uuid: SERVICE_UUID,
+    discoverCharacteristics: (_uuids, cb) => cb(null, [writeChar, notifyChar]),
+  };
+  return {
+    id,
+    state: "disconnected",
+    advertisement: { localName, serviceUuids: [SERVICE_UUID] },
+    connect(cb) {
+      this.state = "connected";
+      cb();
+    },
+    disconnect: cb => cb(),
+    discoverServices: (_uuids, cb) => cb(null, [service]),
+    once: () => {},
+    removeAllListeners: () => {},
+  };
+}
+
+const subscriptions: Subscription[] = [];
+afterEach(() => {
+  while (subscriptions.length) {
+    subscriptions.pop()?.unsubscribe();
+  }
+});
+
+describe("NodeBleTransport", () => {
+  it("identifies as NODE-BLE and supported", () => {
+    const transport = new NodeBleTransport(createTransportArgs(), createFakeNoble().noble);
+    expect(transport.getIdentifier()).toBe(nodeBleIdentifier);
+    expect(transport.isSupported()).toBe(true);
+  });
+
+  it("surfaces a Ledger peripheral on discovery and ignores non-Ledger devices", async () => {
+    const fake = createFakeNoble();
+    const transport = new NodeBleTransport(createTransportArgs(), fake.noble);
+    const discovered = firstValueFrom(transport.startDiscovering());
+
+    fake.emitDiscover({
+      id: "other",
+      state: "disconnected",
+      advertisement: { localName: "AirPods", serviceUuids: ["ffff"] },
+      connect: cb => cb(),
+      disconnect: cb => cb(),
+      discoverServices: (_u, cb) => cb(null, []),
+      once: () => {},
+      removeAllListeners: () => {},
+    });
+    fake.emitDiscover(createLedgerPeripheral("ledger-1", "Solmaria"));
+
+    const device = await discovered;
+    expect(device.id).toBe("ledger-1");
+    expect(device.name).toBe("Solmaria");
+    expect(device.transport).toBe(nodeBleIdentifier);
+  });
+
+  it("waits for poweredOn before scanning", async () => {
+    const fake = createFakeNoble("poweredOff");
+    const transport = new NodeBleTransport(createTransportArgs(), fake.noble);
+    const discovered = firstValueFrom(transport.startDiscovering());
+
+    fake.emitDiscover(createLedgerPeripheral("ledger-1", "Solmaria")); // dropped: not scanning yet
+    await flushTasks();
+    fake.emitStateChange("poweredOn");
+    fake.emitDiscover(createLedgerPeripheral("ledger-2", "Solmaria"));
+
+    expect((await discovered).id).toBe("ledger-2");
+  });
+
+  it("connects, negotiates MTU, round-trips an APDU, and reports an unknown device", async () => {
+    const fake = createFakeNoble();
+    const transport = new NodeBleTransport(createTransportArgs(), fake.noble);
+    subscriptions.push(transport.startDiscovering().subscribe());
+    fake.emitDiscover(createLedgerPeripheral("ledger-1", "Solmaria"));
+    await waitFor(() => expect(transport).toBeDefined());
+
+    const result = await transport.connect({ deviceId: "ledger-1", onDisconnect: () => {} });
+    expect(result.isRight()).toBe(true);
+    const connected = result.extract() as TransportConnectedDevice;
+    expect(connected.transport).toBe(nodeBleIdentifier);
+
+    const response = await connected.sendApdu(new Uint8Array([0xe0, 0x01, 0x00, 0x00]));
+    expect((response as { isRight(): boolean }).isRight()).toBe(true);
+
+    const unknown = await transport.connect({ deviceId: "nope", onDisconnect: () => {} });
+    expect(unknown.isLeft()).toBe(true);
+  });
+
+  it("disconnect is idempotent and tears the connection down", async () => {
+    const fake = createFakeNoble();
+    const transport = new NodeBleTransport(createTransportArgs(), fake.noble);
+    subscriptions.push(transport.startDiscovering().subscribe());
+    fake.emitDiscover(createLedgerPeripheral("ledger-1", "Solmaria"));
+    await flushTasks();
+
+    const connected = (
+      await transport.connect({ deviceId: "ledger-1", onDisconnect: () => {} })
+    ).extract() as TransportConnectedDevice;
+
+    const first = await transport.disconnect({ connectedDevice: connected });
+    const second = await transport.disconnect({ connectedDevice: connected });
+    expect(first.isRight()).toBe(true);
+    expect(second.isRight()).toBe(true); // no live connection left — still a clean Right
+  });
+});

--- a/apps/wallet-cli/src/device/node-ble/NodeBleTransport.ts
+++ b/apps/wallet-cli/src/device/node-ble/NodeBleTransport.ts
@@ -1,0 +1,554 @@
+import {
+  OpeningConnectionError,
+  TransportConnectedDevice,
+  UnknownDeviceError,
+  type ApduReceiverService,
+  type ApduSenderService,
+  type ConnectError,
+  type DeviceId,
+  type DmkError,
+  type Transport,
+  type TransportArgs,
+  type TransportConnectedDevice as TransportConnectedDeviceType,
+  type TransportDeviceModel,
+  type TransportDiscoveredDevice,
+  type TransportFactory,
+  type TransportIdentifier,
+} from "@ledgerhq/device-management-kit";
+import { Left, Maybe, Right, type Either } from "purify-ts";
+import { BehaviorSubject, Observable } from "rxjs";
+import {
+  BLE_MTU_HANDSHAKE_TIMEOUT_MS,
+  BLE_MTU_REQUEST_FRAME,
+  BLE_MTU_RESPONSE_HEADER_TAG,
+  DEFAULT_BLE_FRAME_SIZE,
+} from "./node-ble-constants";
+
+export const nodeBleIdentifier: TransportIdentifier = "NODE-BLE";
+
+/**
+ * Minimal structural surface of `@abandonware/noble` (callback API). noble does
+ * not ship its own type declarations, and the transport only relies on this
+ * subset, so we keep the contract explicit here — it also gives the tests a
+ * small, honest seam to fake.
+ */
+export type NobleCharacteristic = {
+  uuid: string;
+  write(data: Buffer, withoutResponse: boolean, cb: (error?: unknown) => void): void;
+  subscribe(cb: (error?: unknown) => void): void;
+  unsubscribe(cb?: (error?: unknown) => void): void;
+  on(event: "data", cb: (data: Buffer) => void): void;
+  removeAllListeners(event?: string): void;
+};
+export type NobleService = {
+  uuid: string;
+  discoverCharacteristics(
+    uuids: string[] | null,
+    cb: (error: unknown, characteristics: NobleCharacteristic[]) => void,
+  ): void;
+};
+export type NoblePeripheral = {
+  id: string;
+  state: string;
+  advertisement: { localName?: string; serviceUuids?: string[] };
+  connect(cb: (error?: unknown) => void): void;
+  disconnect(cb: (error?: unknown) => void): void;
+  discoverServices(uuids: string[] | null, cb: (error: unknown, services: NobleService[]) => void): void;
+  once(event: "disconnect", cb: () => void): void;
+  removeAllListeners(event?: string): void;
+};
+export type NobleAdapter = {
+  state: string;
+  on(event: string, cb: (...args: unknown[]) => void): void;
+  removeListener(event: string, cb: (...args: unknown[]) => void): void;
+  startScanning(serviceUuids: string[], allowDuplicates: boolean, cb?: (error?: unknown) => void): void;
+  stopScanning(cb?: () => void): void;
+};
+
+const normalizeUuid = (uuid: string): string => uuid.replace(/-/gu, "").toLowerCase();
+
+/** Initial notification sink before the MTU handshake claims the stream. */
+const dropNotification = (_data: Buffer): void => {};
+
+const promisify = (fn: (cb: (error?: unknown) => void) => void): Promise<void> =>
+  new Promise((resolve, reject) => fn(error => (error ? reject(error) : resolve())));
+
+type BleServiceMatch = {
+  deviceModel: TransportDeviceModel;
+  writeUuid: string;
+  notifyUuid: string;
+};
+
+type LiveConnection = {
+  peripheral: NoblePeripheral;
+  /** Suppress the DMK onDisconnect callback for a disconnect we initiated. */
+  markManual(): void;
+  /** Release the GATT subscription + data listeners exactly once. */
+  cleanup(): void;
+};
+
+type Exchange = {
+  receiver: ApduReceiverService;
+  settled: boolean;
+  abortTimer: ReturnType<typeof setTimeout> | null;
+  resolve: (value: Either<DmkError, unknown>) => void;
+};
+
+/**
+ * DMK transport for Ledger devices over Bluetooth Low Energy on Node/Bun,
+ * backed by `@abandonware/noble`.
+ *
+ * Framing is delegated to DMK's own injected ApduSender/ApduReceiver services
+ * with `channel = Maybe.zero()` and `padding = false`: with no channel DMK
+ * emits exactly the `[0x05][seq(2)][len(2) on frame 0][payload]` block layout
+ * Ledger BLE expects, so the transport writes raw frames to the GATT write
+ * characteristic and feeds notification buffers straight back to DMK — no
+ * hand-rolled framer.
+ *
+ * BLE service/characteristic UUIDs and device models come from DMK's own
+ * `deviceModelDataSource.getBluetoothServicesInfos()`, so the transport stays
+ * in sync with the device models DMK knows about (Flex, Stax, Nano X, …).
+ * The scan/connect/subscribe plumbing and the 0x08 GET-MTU handshake mirror
+ * the proven `@ledgerhq/hw-transport-node-ble` implementation.
+ */
+export class NodeBleTransport implements Transport {
+  private readonly noble: NobleAdapter;
+  private readonly args: TransportArgs;
+  /** serviceUuid (normalized) -> device model + write/notify characteristic uuids */
+  private readonly infosByService = new Map<string, BleServiceMatch>();
+  private readonly scanServiceUuids: string[];
+  /** discovered peripheral id -> peripheral + resolved model */
+  private readonly discovered = new Map<
+    string,
+    { peripheral: NoblePeripheral; deviceModel: TransportDeviceModel; name?: string }
+  >();
+  private readonly availableDevices = new BehaviorSubject<TransportDiscoveredDevice[]>([]);
+  private readonly connections = new Map<DeviceId, LiveConnection>();
+  private scanning = false;
+  private onDiscoverHandler: ((peripheral: NoblePeripheral) => void) | null = null;
+  private onStateHandler: ((state: unknown) => void) | null = null;
+
+  constructor(args: TransportArgs, noble: NobleAdapter) {
+    this.args = args;
+    this.noble = noble;
+    const servicesInfos = args.deviceModelDataSource.getBluetoothServicesInfos();
+    for (const infos of Object.values(servicesInfos)) {
+      this.infosByService.set(normalizeUuid(infos.serviceUuid), {
+        deviceModel: infos.deviceModel,
+        writeUuid: normalizeUuid(infos.writeUuid),
+        notifyUuid: normalizeUuid(infos.notifyUuid),
+      });
+    }
+    this.scanServiceUuids = args.deviceModelDataSource.getBluetoothServices().map(normalizeUuid);
+  }
+
+  getIdentifier(): TransportIdentifier {
+    return nodeBleIdentifier;
+  }
+
+  isSupported(): boolean {
+    return true;
+  }
+
+  startDiscovering(): Observable<TransportDiscoveredDevice> {
+    return new Observable(observer => {
+      const onDiscover = (peripheral: NoblePeripheral): void => {
+        const match = this.matchModelForPeripheral(peripheral);
+        if (!match) {
+          return;
+        }
+        const name = peripheral.advertisement.localName;
+        this.discovered.set(peripheral.id, { peripheral, deviceModel: match.deviceModel, name });
+        this.refreshAvailable();
+        observer.next(this.toDiscoveredDevice(peripheral.id, match.deviceModel, name));
+      };
+      this.onDiscoverHandler = onDiscover;
+      this.noble.on("discover", onDiscover as (...args: unknown[]) => void);
+      const startScan = (): void => {
+        try {
+          this.noble.startScanning(this.scanServiceUuids, false);
+          // Mark scanning only after the call succeeds, so a throw can't leave the
+          // transport believing a scan is active.
+          this.scanning = true;
+        } catch (error) {
+          this.scanning = false;
+          observer.error(error);
+        }
+      };
+      if (this.noble.state === "poweredOn") {
+        startScan();
+      } else {
+        const onState = (state: unknown): void => {
+          if (state === "poweredOn") {
+            this.detachStateHandler();
+            startScan();
+          }
+        };
+        this.onStateHandler = onState;
+        this.noble.on("stateChange", onState as (...args: unknown[]) => void);
+      }
+      return () => {
+        this.stopScanning();
+      };
+    });
+  }
+
+  stopDiscovering(): void {
+    this.stopScanning();
+  }
+
+  listenToAvailableDevices(): Observable<TransportDiscoveredDevice[]> {
+    // BLE has no cheap snapshot scan (unlike USB enumeration): peripherals are
+    // only visible while an active scan hears their advertisements. Listening
+    // therefore drives a scan for the lifetime of the subscription, mirroring
+    // how the node-webusb transport refreshes its device list on listen.
+    return new Observable(observer => {
+      const devicesSubscription = this.availableDevices.subscribe(observer);
+      const discoverySubscription = this.startDiscovering().subscribe({
+        error: error => observer.error(error),
+      });
+      return () => {
+        discoverySubscription.unsubscribe();
+        devicesSubscription.unsubscribe();
+      };
+    });
+  }
+
+  async connect(params: {
+    deviceId: DeviceId;
+    onDisconnect: (deviceId: DeviceId) => void;
+  }): Promise<Either<ConnectError, TransportConnectedDeviceType>> {
+    const entry = this.discovered.get(params.deviceId);
+    if (!entry) {
+      return Left(new UnknownDeviceError(`Unknown device ${params.deviceId}`));
+    }
+    const { peripheral, deviceModel } = entry;
+
+    // Per-connection teardown state, reachable from both the peripheral
+    // disconnect event and transport.disconnect() (via the connections map).
+    let manuallyDisconnected = false;
+    let notifyChar: NobleCharacteristic | undefined;
+    let subscribed = false;
+    let cleaned = false;
+    const cleanup = (): void => {
+      if (cleaned) {
+        return;
+      }
+      cleaned = true;
+      if (notifyChar) {
+        try {
+          notifyChar.removeAllListeners("data");
+        } catch {
+          // best-effort listener teardown
+        }
+        if (subscribed) {
+          try {
+            notifyChar.unsubscribe();
+          } catch {
+            // best-effort unsubscribe
+          }
+        }
+      }
+    };
+    const disconnectPeripheral = async (): Promise<void> => {
+      try {
+        await promisify(cb => peripheral.disconnect(cb));
+      } catch {
+        // best-effort disconnect
+      }
+    };
+
+    let connectedHere = false;
+    try {
+      if (peripheral.state !== "connected") {
+        await promisify(cb => peripheral.connect(cb));
+        connectedHere = true;
+      }
+
+      // Discover the Ledger GATT service + write/notify characteristics.
+      const services = await new Promise<NobleService[]>((resolve, reject) =>
+        peripheral.discoverServices(null, (error, s) => (error ? reject(error) : resolve(s))),
+      );
+      let infos: BleServiceMatch | undefined;
+      let service: NobleService | undefined;
+      for (const s of services) {
+        const candidate = this.infosByService.get(normalizeUuid(s.uuid));
+        if (candidate) {
+          infos = candidate;
+          service = s;
+          break;
+        }
+      }
+      if (!service || !infos) {
+        throw new Error("Ledger BLE service not found on device");
+      }
+      const matchedInfos = infos;
+      const characteristics = await new Promise<NobleCharacteristic[]>((resolve, reject) =>
+        service.discoverCharacteristics(null, (error, chs) => (error ? reject(error) : resolve(chs))),
+      );
+      let writeChar: NobleCharacteristic | undefined;
+      for (const characteristic of characteristics) {
+        const uuid = normalizeUuid(characteristic.uuid);
+        if (uuid === matchedInfos.writeUuid) {
+          writeChar = characteristic;
+        } else if (uuid === matchedInfos.notifyUuid) {
+          notifyChar = characteristic;
+        }
+      }
+      if (!writeChar || !notifyChar) {
+        throw new Error("Ledger BLE characteristics not found");
+      }
+      const boundWriteChar = writeChar;
+      const boundNotifyChar = notifyChar;
+
+      const writeFrame = (buffer: Buffer): Promise<void> =>
+        promisify(cb => boundWriteChar.write(buffer, false, cb));
+
+      // Single 'data' listener; a mutable handler lets the MTU handshake and the
+      // per-exchange APDU receiver take turns owning incoming notifications.
+      let notificationHandler: (data: Buffer) => void = dropNotification;
+      const routeNotification = (data: Buffer): void => {
+        notificationHandler(data);
+      };
+      boundNotifyChar.on("data", routeNotification);
+      await promisify(cb => boundNotifyChar.subscribe(cb));
+      subscribed = true;
+
+      // 0x08 GET-MTU handshake (mirrors hw-transport-node-ble's inferMTU).
+      const mtu = await new Promise<number>((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error("Timed out negotiating Ledger BLE MTU")),
+          BLE_MTU_HANDSHAKE_TIMEOUT_MS,
+        );
+        notificationHandler = (data: Buffer): void => {
+          if (data.length > 5 && data.readUInt8(0) === BLE_MTU_RESPONSE_HEADER_TAG) {
+            clearTimeout(timer);
+            resolve(data.readUInt8(5) + 3);
+          }
+        };
+        writeFrame(Buffer.from(BLE_MTU_REQUEST_FRAME)).catch(error => {
+          clearTimeout(timer);
+          reject(error);
+        });
+      });
+      const frameSize = mtu > 23 ? mtu - 3 : DEFAULT_BLE_FRAME_SIZE;
+
+      // DMK owns framing. No channel for BLE; no padding. The sender is stateless
+      // across exchanges (getFrames depends only on frameSize); the receiver
+      // accumulates partial frames, so a fresh one is created per exchange — a
+      // dropped/reordered BLE notification can't leave stale state that hangs the
+      // next send.
+      const apduSender: ApduSenderService = this.args.apduSenderServiceFactory({
+        frameSize,
+        channel: Maybe.zero(),
+        padding: false,
+      });
+
+      let currentExchange: Exchange | null = null;
+      const settleExchange = (exchange: Exchange, value: Either<DmkError, unknown>): void => {
+        if (exchange.settled) {
+          return;
+        }
+        exchange.settled = true;
+        if (exchange.abortTimer) {
+          clearTimeout(exchange.abortTimer);
+          exchange.abortTimer = null;
+        }
+        if (currentExchange === exchange) {
+          currentExchange = null;
+        }
+        exchange.resolve(value);
+      };
+
+      // After the handshake, route notifications to the in-flight exchange only.
+      notificationHandler = (data: Buffer): void => {
+        const exchange = currentExchange;
+        if (!exchange || exchange.settled) {
+          return; // stray notification between exchanges — ignore
+        }
+        exchange.receiver
+          .handleFrame(new Uint8Array(data))
+          .map(maybe => {
+            maybe.map(response => settleExchange(exchange, Right(response)));
+          })
+          .mapLeft(error => settleExchange(exchange, Left(error)));
+      };
+
+      const sendApdu = async (
+        apdu: Uint8Array,
+        _triggersDisconnection?: boolean,
+        abortTimeout?: number,
+      ): Promise<Either<DmkError, unknown>> => {
+        const exchange: Exchange = {
+          receiver: this.args.apduReceiverServiceFactory({ channel: Maybe.zero() }),
+          settled: false,
+          abortTimer: null,
+          resolve: () => {},
+        };
+        const responsePromise = new Promise<Either<DmkError, unknown>>(resolve => {
+          exchange.resolve = resolve;
+        });
+        currentExchange = exchange;
+        for (const frame of apduSender.getFrames(apdu)) {
+          try {
+            await writeFrame(Buffer.from(frame.getRawData()));
+          } catch (error) {
+            settleExchange(exchange, Left(new OpeningConnectionError(error)));
+            return responsePromise;
+          }
+        }
+        if (abortTimeout) {
+          exchange.abortTimer = setTimeout(() => {
+            settleExchange(exchange, Left(new OpeningConnectionError("Ledger BLE abort timeout")));
+          }, abortTimeout);
+        }
+        return responsePromise;
+      };
+
+      peripheral.once("disconnect", () => {
+        if (currentExchange) {
+          settleExchange(currentExchange, Left(new OpeningConnectionError("Device disconnected")));
+        }
+        cleanup();
+        this.connections.delete(params.deviceId);
+        this.discovered.delete(params.deviceId);
+        this.refreshAvailable();
+        // A disconnect we initiated (transport.disconnect) must NOT re-enter
+        // DMK's onDisconnect — DMK already tore the session down.
+        if (!manuallyDisconnected) {
+          params.onDisconnect(params.deviceId);
+        }
+      });
+
+      this.connections.set(params.deviceId, {
+        peripheral,
+        markManual: () => {
+          manuallyDisconnected = true;
+        },
+        cleanup,
+      });
+
+      return Right(
+        new TransportConnectedDevice({
+          id: params.deviceId,
+          deviceModel,
+          type: "BLE",
+          transport: nodeBleIdentifier,
+          sendApdu: sendApdu as TransportConnectedDeviceType["sendApdu"],
+          name: entry.name,
+        }),
+      );
+    } catch (error) {
+      // Any failure after we opened/subscribed must release the BLE resources, or
+      // a failed connect leaks a connected peripheral + active GATT subscription
+      // that DMK will never clean up (it got a Left, so it never calls disconnect).
+      cleanup();
+      if (connectedHere) {
+        await disconnectPeripheral();
+      }
+      return Left(new OpeningConnectionError(error));
+    }
+  }
+
+  async disconnect(params: {
+    connectedDevice: TransportConnectedDeviceType;
+  }): Promise<Either<DmkError, void>> {
+    const id = params.connectedDevice.id;
+    const connection = this.connections.get(id);
+    if (!connection) {
+      return Right(undefined);
+    }
+    connection.markManual();
+    connection.cleanup();
+    try {
+      await promisify(cb => connection.peripheral.disconnect(cb));
+    } catch {
+      // best-effort disconnect
+    }
+    this.connections.delete(id);
+    this.discovered.delete(id);
+    this.refreshAvailable();
+    return Right(undefined);
+  }
+
+  /** Tear down scanning and any live connections (process-exit path). */
+  async destroy(): Promise<void> {
+    this.stopScanning();
+    const open = [...this.connections.values()];
+    this.connections.clear();
+    for (const connection of open) {
+      connection.markManual();
+      connection.cleanup();
+      try {
+        await promisify(cb => connection.peripheral.disconnect(cb));
+      } catch {
+        // best-effort disconnect at teardown
+      }
+    }
+  }
+
+  private matchModelForPeripheral(
+    peripheral: NoblePeripheral,
+  ): { deviceModel: TransportDeviceModel } | null {
+    const advertised = (peripheral.advertisement.serviceUuids ?? []).map(normalizeUuid);
+    for (const uuid of advertised) {
+      const infos = this.infosByService.get(uuid);
+      if (infos) {
+        return { deviceModel: infos.deviceModel };
+      }
+    }
+    return null;
+  }
+
+  private toDiscoveredDevice(
+    id: string,
+    deviceModel: TransportDeviceModel,
+    name?: string,
+  ): TransportDiscoveredDevice {
+    return { id, deviceModel, transport: nodeBleIdentifier, name, rssi: null };
+  }
+
+  private refreshAvailable(): void {
+    this.availableDevices.next(
+      [...this.discovered.entries()].map(([id, device]) =>
+        this.toDiscoveredDevice(id, device.deviceModel, device.name),
+      ),
+    );
+  }
+
+  private detachStateHandler(): void {
+    if (this.onStateHandler) {
+      this.noble.removeListener("stateChange", this.onStateHandler as (...args: unknown[]) => void);
+      this.onStateHandler = null;
+    }
+  }
+
+  private stopScanning(): void {
+    // Always detach the stateChange listener (it may be attached while waiting
+    // for poweredOn, before scanning ever started) — it leaks on the shared
+    // noble singleton otherwise.
+    this.detachStateHandler();
+    if (this.scanning) {
+      this.scanning = false;
+      try {
+        this.noble.stopScanning();
+      } catch {
+        // best-effort scan stop
+      }
+    }
+    if (this.onDiscoverHandler) {
+      this.noble.removeListener("discover", this.onDiscoverHandler as (...args: unknown[]) => void);
+      this.onDiscoverHandler = null;
+    }
+  }
+}
+
+/**
+ * Build the BLE transport factory for `DeviceManagementKitBuilder.addTransport`.
+ * noble is injected so callers (and tests) control when the native bindings
+ * load — requiring `@abandonware/noble` initializes the platform Bluetooth
+ * stack, which USB-only runs must never pay for.
+ */
+export function nodeBleTransportFactory(noble: NobleAdapter): TransportFactory {
+  return args => new NodeBleTransport(args, noble);
+}

--- a/apps/wallet-cli/src/device/node-ble/index.ts
+++ b/apps/wallet-cli/src/device/node-ble/index.ts
@@ -1,0 +1,9 @@
+export {
+  NodeBleTransport,
+  nodeBleIdentifier,
+  nodeBleTransportFactory,
+  type NobleAdapter,
+  type NobleCharacteristic,
+  type NoblePeripheral,
+  type NobleService,
+} from "./NodeBleTransport";

--- a/apps/wallet-cli/src/device/node-ble/node-ble-constants.ts
+++ b/apps/wallet-cli/src/device/node-ble/node-ble-constants.ts
@@ -1,0 +1,11 @@
+/** Ledger BLE 0x08 GET-MTU request frame (mirrors @ledgerhq/hw-transport-node-ble). */
+export const BLE_MTU_REQUEST_FRAME: readonly number[] = [0x08, 0, 0, 0, 0];
+
+/** First byte of the GET-MTU response notification. */
+export const BLE_MTU_RESPONSE_HEADER_TAG = 0x08;
+
+/** Bound on the MTU negotiation right after subscribing to notifications. */
+export const BLE_MTU_HANDSHAKE_TIMEOUT_MS = 10_000;
+
+/** Conservative BLE payload size when MTU negotiation reports the 23-byte floor. */
+export const DEFAULT_BLE_FRAME_SIZE = 20;

--- a/apps/wallet-cli/src/device/register-dmk-transport.ts
+++ b/apps/wallet-cli/src/device/register-dmk-transport.ts
@@ -6,13 +6,14 @@ import { firstValueFrom } from "rxjs";
 import { filter, timeout } from "rxjs/operators";
 import { WalletCliDmkTransport } from "./wallet-cli-dmk-transport";
 import type { WalletCliDmk } from "./dmk";
+import { resolveWalletCliTransportKind } from "./transport-kind";
 import {
   hasWalletCliDeviceInterruptScope,
   withWalletCliDeviceInterruptScope,
 } from "./interrupt-scope";
 import { restoreTerminalCursor } from "../shared/ui";
 
-/** Device id passed to live-common `withDevice` / bridge methods for the first USB Ledger (DMK node WebUSB). */
+/** Device id passed to live-common `withDevice` / bridge methods for the first discovered Ledger (DMK node WebUSB or node BLE, per WALLET_CLI_TRANSPORT). */
 export const WALLET_CLI_DMK_DEVICE_ID = "wallet-cli-dmk";
 
 const CONNECT_TIMEOUT_MS = 60_000;
@@ -68,7 +69,9 @@ function terminateWalletCliFromSignal(code: number): void {
 
 function getOrCreatePersistentDmk(): Promise<WalletCliDmk> {
   return (persistentDmk ??= import("./dmk")
-    .then(({ createDeviceManagementKit }) => createDeviceManagementKit())
+    .then(({ createDeviceManagementKit }) =>
+      createDeviceManagementKit(resolveWalletCliTransportKind()),
+    )
     .catch(error => {
       persistentDmk = null;
       throw error;
@@ -145,7 +148,7 @@ async function teardownPersistentDmk(
   persistentDmk = null;
 }
 
-async function connectFirstUsbDevice(dmk: DeviceManagementKit): Promise<string> {
+async function connectFirstDevice(dmk: DeviceManagementKit): Promise<string> {
   const discovered = await firstValueFrom(
     dmk.listenToAvailableDevices({}).pipe(
       filter((list: DiscoveredDevice[]) => list.length > 0),
@@ -203,7 +206,7 @@ export function ensureWalletCliDmkTransport(): Promise<WalletCliDmkTransport> {
     }
 
     const kit = await getOrCreatePersistentDmk();
-    const sessionId = await connectFirstUsbDevice(kit.dmk);
+    const sessionId = await connectFirstDevice(kit.dmk);
     const transport = new WalletCliDmkTransport(kit.dmk, sessionId);
     singleton = { dmk: kit.dmk, transport, destroyTransport: kit.destroyTransport };
     return transport;

--- a/apps/wallet-cli/src/device/transport-kind.ts
+++ b/apps/wallet-cli/src/device/transport-kind.ts
@@ -1,0 +1,16 @@
+/** Which DMK transport the CLI drives the device over. */
+export type WalletCliTransportKind = "usb" | "ble";
+
+/**
+ * Resolve the transport from `WALLET_CLI_TRANSPORT` (default: usb).
+ * Throws on anything else so a typo never silently falls back to USB.
+ */
+export function resolveWalletCliTransportKind(): WalletCliTransportKind {
+  const raw = (process.env.WALLET_CLI_TRANSPORT ?? "usb").trim().toLowerCase();
+  if (raw === "usb" || raw === "ble") {
+    return raw;
+  }
+  throw new Error(
+    `Invalid WALLET_CLI_TRANSPORT "${process.env.WALLET_CLI_TRANSPORT}". Expected "usb" or "ble".`,
+  );
+}

--- a/package.json
+++ b/package.json
@@ -354,6 +354,8 @@
       }
     },
     "onlyBuiltDependencies": [
+      "@abandonware/bluetooth-hci-socket",
+      "@abandonware/noble",
       "@apollo/protobufjs",
       "@datadog/mobile-react-native",
       "@sentry/cli",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1640,7 +1640,7 @@ importers:
         version: 2.1.0(@ledgerhq/device-management-kit@1.6.0(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.16)(@ledgerhq/lumen-ui-rnative@0.1.39(ceaf05d6712be870d78aa56eadc54145))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.16)(@ledgerhq/lumen-ui-rnative@0.1.39(a034cbdcd5ac8e4541bbd8274b1ca505))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -1727,10 +1727,10 @@ importers:
         version: 0.1.16
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.39(ceaf05d6712be870d78aa56eadc54145)
+        version: 0.1.39(a034cbdcd5ac8e4541bbd8274b1ca505)
       '@ledgerhq/lumen-ui-rnative-visualization':
         specifier: 'catalog:'
-        version: 0.1.16(31872fe34de4925bfce3d2461db6a5bc)
+        version: 0.1.16(53bc6b4df3291f87e9b2593173565113)
       '@ledgerhq/native-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/native
@@ -1760,13 +1760,13 @@ importers:
         version: 5.1.1
       '@react-native-firebase/app':
         specifier: 22.2.0
-        version: 22.2.0(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+        version: 22.2.0(a2411d401a6e1c94adbccaa92f9e834b)
       '@react-native-firebase/messaging':
         specifier: 22.2.0
-        version: 22.2.0(@react-native-firebase/app@22.2.0(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))
+        version: 22.2.0(@react-native-firebase/app@22.2.0(a2411d401a6e1c94adbccaa92f9e834b))(expo@53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))
       '@react-native-firebase/remote-config':
         specifier: 22.2.0
-        version: 22.2.0(@react-native-firebase/app@22.2.0(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))
+        version: 22.2.0(@react-native-firebase/app@22.2.0(a2411d401a6e1c94adbccaa92f9e834b))
       '@react-native-masked-view/masked-view':
         specifier: 0.2.9
         version: 0.2.9(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -1844,25 +1844,25 @@ importers:
         version: 2.30.0
       expo:
         specifier: 'catalog:'
-        version: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
+        version: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       expo-crypto:
         specifier: 'catalog:'
-        version: 14.1.5(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+        version: 14.1.5(4a4fa364a565f69495ba54c8703b3b64)
       expo-file-system:
         specifier: 'catalog:'
-        version: 18.1.11(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+        version: 18.1.11(4a4fa364a565f69495ba54c8703b3b64)
       expo-haptics:
         specifier: 'catalog:'
-        version: 14.1.4(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+        version: 14.1.4(4a4fa364a565f69495ba54c8703b3b64)
       expo-image-loader:
         specifier: 'catalog:'
-        version: 5.0.0(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+        version: 5.0.0(4a4fa364a565f69495ba54c8703b3b64)
       expo-image-manipulator:
         specifier: 'catalog:'
-        version: 13.1.7(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+        version: 13.1.7(4a4fa364a565f69495ba54c8703b3b64)
       expo-keep-awake:
         specifier: 'catalog:'
-        version: 14.1.4(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+        version: 14.1.4(4a4fa364a565f69495ba54c8703b3b64)
       expo-modules-autolinking:
         specifier: 'catalog:'
         version: 2.1.14(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -2471,6 +2471,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     optionalDependencies:
+      '@abandonware/noble':
+        specifier: ^1.9.2-26
+        version: 1.9.2-26
       '@ledgerhq/wallet-cli-darwin-arm64':
         specifier: workspace:*
         version: link:npm/darwin-arm64
@@ -13111,6 +13114,16 @@ packages:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
 
+  '@abandonware/bluetooth-hci-socket@0.5.3-12':
+    resolution: {integrity: sha512-qo2cBoh94j6RPusaNXSLYI8Bzxuz01Bx3MD80a/QYzhHED/FZ6Y0k2w2kRbfIA2EEhFSCbXrBZDQlpilL4nbxA==}
+    engines: {node: '>=10.0.0'}
+    os: [linux, android, freebsd, win32]
+
+  '@abandonware/noble@1.9.2-26':
+    resolution: {integrity: sha512-dPx78rkxF+z2oR8KhVlNt3gHi5E6dMSkil6HaZuDanFlWAL/bP2oHqAtHrHZdqtKDnTiZUf7f93hpDkKWx36Lw==}
+    engines: {node: '>=16'}
+    os: [darwin, linux, freebsd, win32]
+
   '@achrinza/node-ipc@9.2.9':
     resolution: {integrity: sha512-7s0VcTwiK/0tNOVdSX9FWMeFdOEcsAOz9HesBldXxFMaGvIak7KC2z9tV9EgsQXn6KUsWsfIkViMNuIo0GoZDQ==}
     engines: {node: 8 || 9 || 10 || 11 || 12 || 13 || 14 || 15 || 16 || 17 || 18 || 19 || 20 || 21 || 22}
@@ -13185,7 +13198,7 @@ packages:
   '@apollo/server@4.12.2':
     resolution: {integrity: sha512-jKRlf+sBMMdKYrjMoiWKne42Eb6paBfDOr08KJnUaeaiyWFj+/040FjVPQI7YGLfdwnYIsl1NUUqS2UdgezJDg==}
     engines: {node: '>=14.16.0'}
-    deprecated: Apollo Server v4 is deprecated and will transition to end-of-life on January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
+    deprecated: Apollo Server v4 is end-of-life since January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
     peerDependencies:
       graphql: ^16.6.0
 
@@ -17627,6 +17640,10 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@mapbox/node-pre-gyp@1.0.11':
+    resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
+    hasBin: true
+
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
@@ -17825,12 +17842,20 @@ packages:
   '@nozbe/microfuzz@1.0.0':
     resolution: {integrity: sha512-XKIg/guk+s1tkPTkHch9hfGOWgsKojT7BqSQddXTppOfVr3SWQhhTCqbgQaPTbppf9gc2kFeG0gpBZZ612UXHA==}
 
+  '@npmcli/agent@2.2.2':
+    resolution: {integrity: sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+
   '@npmcli/fs@1.1.1':
     resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
 
   '@npmcli/fs@2.1.2':
     resolution: {integrity: sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  '@npmcli/fs@3.1.1':
+    resolution: {integrity: sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   '@npmcli/move-file@1.1.2':
     resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
@@ -21985,7 +22010,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.0.0
       react-dom: 19.0.0
-      webpack: '*'
+      webpack: ^5.89.0
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -23961,7 +23986,7 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -24047,6 +24072,10 @@ packages:
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
+  abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   abitype@1.0.8:
     resolution: {integrity: sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==}
@@ -24310,7 +24339,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -24368,6 +24397,11 @@ packages:
 
   archy@1.0.0:
     resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
+
+  are-we-there-yet@2.0.0:
+    resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
+    engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
 
   are-we-there-yet@3.0.1:
     resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
@@ -25258,6 +25292,10 @@ packages:
   cacache@16.1.3:
     resolution: {integrity: sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  cacache@18.0.4:
+    resolution: {integrity: sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==}
+    engines: {node: ^16.14.0 || >=18.0.0}
 
   cache-content-type@1.0.1:
     resolution: {integrity: sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==}
@@ -27899,7 +27937,6 @@ packages:
     peerDependencies:
       '@expo/dom-webview': '*'
       '@expo/metro-runtime': '*'
-      expo-modules-autolinking: '*'
       expo-modules-core: '*'
       react: 19.0.0
       react-native: '*'
@@ -27908,8 +27945,6 @@ packages:
       '@expo/dom-webview':
         optional: true
       '@expo/metro-runtime':
-        optional: true
-      expo-modules-autolinking:
         optional: true
       expo-modules-core:
         optional: true
@@ -28400,6 +28435,10 @@ packages:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
 
+  fs-minipass@3.0.3:
+    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   fs-monkey@1.0.5:
     resolution: {integrity: sha512-8uMbBjrhzW76TYgEV27Y5E//W2f/lTFmx78P2w19FZSxarhI/798APGQyuGCwmkNxgwGRhrLfvWyLBvNtuOmew==}
 
@@ -28452,6 +28491,11 @@ packages:
 
   fwd-stream@1.0.4:
     resolution: {integrity: sha512-q2qaK2B38W07wfPSQDKMiKOD5Nzv2XyuvQlrmh1q0pxyHNanKHq8lwQ6n9zHucAwA5EbzRJKEgds2orn88rYTg==}
+
+  gauge@3.0.2:
+    resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
+    engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
 
   gauge@4.0.4:
     resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
@@ -29701,6 +29745,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@3.1.5:
+    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
+    engines: {node: '>=18'}
 
   iso-base@4.4.0:
     resolution: {integrity: sha512-W4BJbRDBi66wcBFJ23ZlGnFOZ874CIut4y9PlsScMSYu7ckCX+MWNAaEoE0efTSYDoVEn1qy0FDVSjE8q0ieHw==}
@@ -31157,6 +31205,10 @@ packages:
     resolution: {integrity: sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  make-fetch-happen@13.0.1:
+    resolution: {integrity: sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+
   make-fetch-happen@9.1.0:
     resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
     engines: {node: '>= 10'}
@@ -31808,6 +31860,10 @@ packages:
     resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
     engines: {node: '>= 8'}
 
+  minipass-collect@2.0.1:
+    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minipass-fetch@1.4.1:
     resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
     engines: {node: '>=8'}
@@ -31815,6 +31871,10 @@ packages:
   minipass-fetch@2.1.2:
     resolution: {integrity: sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  minipass-fetch@3.0.5:
+    resolution: {integrity: sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   minipass-flush@1.0.5:
     resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
@@ -31992,6 +32052,9 @@ packages:
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     hasBin: true
 
+  napi-thread-safe-callback@0.0.6:
+    resolution: {integrity: sha512-X7uHCOCdY4u0yamDxDrv3jF2NtYc8A1nvPzBQgvpoSX+WB3jAe2cVNsY448V1ucq7Whf9Wdy02HEUoLW5rJKWg==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -32143,6 +32206,15 @@ packages:
     resolution: {integrity: sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==}
     hasBin: true
 
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
+  node-gyp@10.3.1:
+    resolution: {integrity: sha512-Pp3nFHBThHzVtNY7U6JfPjvT/DTE8+o/4xKsLQtBoU+j2HLsGlhcfzflAoUreaJbNmYnX+LlLi0qjV8kpyO6xQ==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+    hasBin: true
+
   node-gyp@8.4.1:
     resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
     engines: {node: '>= 10.12.0'}
@@ -32206,6 +32278,11 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     hasBin: true
 
+  nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
 
@@ -32251,6 +32328,10 @@ packages:
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
+
+  npmlog@5.0.1:
+    resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
+    deprecated: This package is no longer supported.
 
   npmlog@6.0.2:
     resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
@@ -35391,6 +35472,10 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
+  ssri@10.0.6:
+    resolution: {integrity: sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   ssri@8.0.1:
     resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
     engines: {node: '>= 8'}
@@ -36626,12 +36711,20 @@ packages:
     resolution: {integrity: sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  unique-filename@3.0.0:
+    resolution: {integrity: sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   unique-slug@2.0.2:
     resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
 
   unique-slug@3.0.0:
     resolution: {integrity: sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  unique-slug@4.0.0:
+    resolution: {integrity: sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
@@ -37331,6 +37424,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@4.0.0:
+    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
+    engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
 
@@ -37711,6 +37809,32 @@ snapshots:
       typescript: 6.0.2
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
+
+  '@abandonware/bluetooth-hci-socket@0.5.3-12':
+    dependencies:
+      '@mapbox/node-pre-gyp': 1.0.11
+      debug: 4.4.3
+      nan: 2.20.0
+      node-gyp: 10.3.1
+    optionalDependencies:
+      usb: 2.17.0(patch_hash=489095f60f30e6127e8077a75f64dc1962a7187d3e054910d61a8a5de45c30a5)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  '@abandonware/noble@1.9.2-26':
+    dependencies:
+      debug: 4.4.3
+      napi-thread-safe-callback: 0.0.6
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+    optionalDependencies:
+      '@abandonware/bluetooth-hci-socket': 0.5.3-12
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
 
   '@achrinza/node-ipc@9.2.9':
     dependencies:
@@ -45599,12 +45723,12 @@ snapshots:
       '@ledgerhq/lumen-ui-react': 0.1.38(@ledgerhq/lumen-design-core@0.1.16)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       react-dom: 19.0.0(react@19.0.0)
 
-  '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.16)(@ledgerhq/lumen-ui-rnative@0.1.39(ceaf05d6712be870d78aa56eadc54145))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
+  '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.16)(@ledgerhq/lumen-ui-rnative@0.1.39(a034cbdcd5ac8e4541bbd8274b1ca505))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
       '@ledgerhq/lumen-design-core': 0.1.16
-      '@ledgerhq/lumen-ui-rnative': 0.1.39(ceaf05d6712be870d78aa56eadc54145)
+      '@ledgerhq/lumen-ui-rnative': 0.1.39(a034cbdcd5ac8e4541bbd8274b1ca505)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
 
   '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.16)(@ledgerhq/lumen-ui-rnative@0.1.39(ed4a91ce2529067bcbfd78c12f2ad1cc))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)':
@@ -45933,10 +46057,10 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-rnative-visualization@0.1.16(31872fe34de4925bfce3d2461db6a5bc)':
+  '@ledgerhq/lumen-ui-rnative-visualization@0.1.16(53bc6b4df3291f87e9b2593173565113)':
     dependencies:
       '@ledgerhq/lumen-design-core': 0.1.16
-      '@ledgerhq/lumen-ui-rnative': 0.1.39(ceaf05d6712be870d78aa56eadc54145)
+      '@ledgerhq/lumen-ui-rnative': 0.1.39(a034cbdcd5ac8e4541bbd8274b1ca505)
       '@ledgerhq/lumen-utils-shared': 0.1.5(react@19.0.0)
       '@types/react': 19.0.14
       d3-array: 3.2.4
@@ -45966,6 +46090,25 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
+  '@ledgerhq/lumen-ui-rnative@0.1.39(a034cbdcd5ac8e4541bbd8274b1ca505)':
+    dependencies:
+      '@gorhom/bottom-sheet': 5.2.6(beb07f7799bea5989bf46dbe8fcef3d9)
+      '@ledgerhq/lumen-design-core': 0.1.16
+      '@ledgerhq/lumen-utils-shared': 0.1.5(react@19.0.0)
+      '@sbaiahmed1/react-native-blur': 4.5.5(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      '@types/react': 19.0.14
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      expo-haptics: 14.1.4(4a4fa364a565f69495ba54c8703b3b64)
+      i18next: 23.10.1
+      react: 19.0.0
+      react-i18next: 14.1.3(i18next@23.10.1)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
+      react-native-reanimated: 4.1.6(@babel/core@7.28.5)(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native-svg: 15.15.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+    transitivePeerDependencies:
+      - react-dom
+
   '@ledgerhq/lumen-ui-rnative@0.1.39(bd1f1ac6d53a31355451df987c1ff9ae)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -45979,25 +46122,6 @@ snapshots:
       react-native-reanimated: 4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native-svg: 15.15.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-    transitivePeerDependencies:
-      - react-dom
-
-  '@ledgerhq/lumen-ui-rnative@0.1.39(ceaf05d6712be870d78aa56eadc54145)':
-    dependencies:
-      '@gorhom/bottom-sheet': 5.2.6(beb07f7799bea5989bf46dbe8fcef3d9)
-      '@ledgerhq/lumen-design-core': 0.1.16
-      '@ledgerhq/lumen-utils-shared': 0.1.5(react@19.0.0)
-      '@sbaiahmed1/react-native-blur': 4.5.5(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      '@types/react': 19.0.14
-      expo: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
-      expo-haptics: 14.1.4(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      i18next: 23.10.1
-      react: 19.0.0
-      react-i18next: 14.1.3(i18next@23.10.1)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
-      react-native-reanimated: 4.1.6(@babel/core@7.28.5)(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      react-native-svg: 15.15.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - react-dom
 
@@ -46188,6 +46312,22 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@mapbox/node-pre-gyp@1.0.11':
+    dependencies:
+      detect-libc: 2.1.2
+      https-proxy-agent: 5.0.1
+      make-dir: 3.1.0
+      node-fetch: 2.7.0
+      nopt: 5.0.0
+      npmlog: 5.0.1
+      rimraf: 3.0.2
+      semver: 7.8.1
+      tar: 6.2.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
 
   '@marijn/find-cluster-break@1.0.2': {}
 
@@ -46521,6 +46661,17 @@ snapshots:
 
   '@nozbe/microfuzz@1.0.0': {}
 
+  '@npmcli/agent@2.2.2':
+    dependencies:
+      agent-base: 7.1.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 10.4.3
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@npmcli/fs@1.1.1':
     dependencies:
       '@gar/promisify': 1.1.3
@@ -46531,6 +46682,11 @@ snapshots:
     dependencies:
       '@gar/promisify': 1.1.3
       semver: 7.8.1
+
+  '@npmcli/fs@3.1.1':
+    dependencies:
+      semver: 7.8.1
+    optional: true
 
   '@npmcli/move-file@1.1.2':
     dependencies:
@@ -48659,25 +48815,25 @@ snapshots:
 
   '@react-native-community/slider@5.1.1': {}
 
-  '@react-native-firebase/app@22.2.0(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
+  '@react-native-firebase/app@22.2.0(a2411d401a6e1c94adbccaa92f9e834b)':
     dependencies:
       firebase: 11.3.1(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
     optionalDependencies:
-      expo: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
 
-  '@react-native-firebase/messaging@22.2.0(@react-native-firebase/app@22.2.0(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))':
+  '@react-native-firebase/messaging@22.2.0(@react-native-firebase/app@22.2.0(a2411d401a6e1c94adbccaa92f9e834b))(expo@53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))':
     dependencies:
-      '@react-native-firebase/app': 22.2.0(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      '@react-native-firebase/app': 22.2.0(a2411d401a6e1c94adbccaa92f9e834b)
     optionalDependencies:
-      expo: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
 
-  '@react-native-firebase/remote-config@22.2.0(@react-native-firebase/app@22.2.0(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))':
+  '@react-native-firebase/remote-config@22.2.0(@react-native-firebase/app@22.2.0(a2411d401a6e1c94adbccaa92f9e834b))':
     dependencies:
-      '@react-native-firebase/app': 22.2.0(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      '@react-native-firebase/app': 22.2.0(a2411d401a6e1c94adbccaa92f9e834b)
 
   '@react-native-masked-view/masked-view@0.2.9(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -55519,6 +55675,9 @@ snapshots:
 
   abbrev@1.1.1: {}
 
+  abbrev@2.0.0:
+    optional: true
+
   abitype@1.0.8(typescript@6.0.2):
     optionalDependencies:
       typescript: 6.0.2
@@ -55832,6 +55991,12 @@ snapshots:
       zip-stream: 5.0.2
 
   archy@1.0.0: {}
+
+  are-we-there-yet@2.0.0:
+    dependencies:
+      delegates: 1.0.0
+      readable-stream: 3.6.2
+    optional: true
 
   are-we-there-yet@3.0.1:
     dependencies:
@@ -57154,6 +57319,22 @@ snapshots:
       unique-filename: 2.0.1
     transitivePeerDependencies:
       - bluebird
+
+  cacache@18.0.4:
+    dependencies:
+      '@npmcli/fs': 3.1.1
+      fs-minipass: 3.0.3
+      glob: 10.4.5
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+      minipass-collect: 2.0.1
+      minipass-flush: 1.0.5
+      minipass-pipeline: 1.2.4
+      p-map: 4.0.0
+      ssri: 10.0.6
+      tar: 6.2.1
+      unique-filename: 3.0.0
+    optional: true
 
   cache-content-type@1.0.1:
     dependencies:
@@ -60002,14 +60183,14 @@ snapshots:
       jest-mock: 30.2.0
       jest-util: 30.2.0
 
-  expo-asset@11.1.7(e1114795ff87aff5695f1e215fda36c2):
+  expo-asset@11.1.7(5016f5ad50984dc7067476777bc39ad2):
     dependencies:
       '@expo/image-utils': 0.7.6
-      expo: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
     optionalDependencies:
-      expo-constants: 17.1.8(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      expo-constants: 17.1.8(4a4fa364a565f69495ba54c8703b3b64)
       expo-modules-core: 2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
 
   expo-asset@11.1.7(expo-constants@17.1.8)(expo-modules-core@2.5.0)(expo@53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0):
@@ -60022,11 +60203,11 @@ snapshots:
       expo-constants: 17.1.8(expo-modules-core@2.5.0)(expo@53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       expo-modules-core: 2.5.0(expo-constants@17.1.8)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
 
-  expo-constants@17.1.8(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
+  expo-constants@17.1.8(4a4fa364a565f69495ba54c8703b3b64):
     dependencies:
       '@expo/config': 11.0.13
       '@expo/env': 1.0.7
-      expo: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
     optionalDependencies:
       expo-modules-core: 2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -60046,21 +60227,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  expo-crypto@14.1.5(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
+  expo-crypto@14.1.5(4a4fa364a565f69495ba54c8703b3b64):
     dependencies:
       base64-js: 1.5.1
-      expo: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
     optionalDependencies:
       expo-modules-core: 2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
 
-  expo-file-system@18.1.11(e1114795ff87aff5695f1e215fda36c2):
+  expo-file-system@18.1.11(4a4fa364a565f69495ba54c8703b3b64):
     dependencies:
-      expo: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
     optionalDependencies:
-      expo-constants: 17.1.8(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      expo-modules-core: 2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+
+  expo-file-system@18.1.11(5016f5ad50984dc7067476777bc39ad2):
+    dependencies:
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
+    optionalDependencies:
+      expo-constants: 17.1.8(4a4fa364a565f69495ba54c8703b3b64)
       expo-modules-core: 2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
 
@@ -60073,21 +60262,13 @@ snapshots:
       expo-modules-core: 2.5.0(expo-constants@17.1.8)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
 
-  expo-file-system@18.1.11(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
+  expo-font@13.3.2(5016f5ad50984dc7067476777bc39ad2):
     dependencies:
-      expo: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
-      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
-    optionalDependencies:
-      expo-modules-core: 2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      react: 19.0.0
-
-  expo-font@13.3.2(e1114795ff87aff5695f1e215fda36c2):
-    dependencies:
-      expo: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       fontfaceobserver: 2.3.0
       react: 19.0.0
     optionalDependencies:
-      expo-constants: 17.1.8(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      expo-constants: 17.1.8(4a4fa364a565f69495ba54c8703b3b64)
       expo-modules-core: 2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
 
@@ -60101,9 +60282,9 @@ snapshots:
       expo-modules-core: 2.5.0(expo-constants@17.1.8)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
 
-  expo-haptics@14.1.4(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
+  expo-haptics@14.1.4(4a4fa364a565f69495ba54c8703b3b64):
     dependencies:
-      expo: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
     optionalDependencies:
       expo-modules-core: 2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
@@ -60114,37 +60295,45 @@ snapshots:
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
 
-  expo-image-loader@5.0.0(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
+  expo-image-loader@5.0.0(4a4fa364a565f69495ba54c8703b3b64):
     dependencies:
-      expo: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
     optionalDependencies:
       expo-modules-core: 2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
 
-  expo-image-loader@5.1.0(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
+  expo-image-loader@5.1.0(4a4fa364a565f69495ba54c8703b3b64):
     dependencies:
-      expo: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
     optionalDependencies:
       expo-modules-core: 2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
 
-  expo-image-manipulator@13.1.7(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
+  expo-image-manipulator@13.1.7(4a4fa364a565f69495ba54c8703b3b64):
     dependencies:
-      expo: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
-      expo-image-loader: 5.1.0(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      expo-image-loader: 5.1.0(4a4fa364a565f69495ba54c8703b3b64)
     optionalDependencies:
       expo-modules-core: 2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
 
-  expo-keep-awake@14.1.4(e1114795ff87aff5695f1e215fda36c2):
+  expo-keep-awake@14.1.4(4a4fa364a565f69495ba54c8703b3b64):
     dependencies:
-      expo: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
     optionalDependencies:
-      expo-constants: 17.1.8(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      expo-modules-core: 2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
+
+  expo-keep-awake@14.1.4(5016f5ad50984dc7067476777bc39ad2):
+    dependencies:
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      expo-constants: 17.1.8(4a4fa364a565f69495ba54c8703b3b64)
       expo-modules-core: 2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
 
@@ -60157,13 +60346,35 @@ snapshots:
       expo-modules-core: 2.5.0(expo-constants@17.1.8)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
 
-  expo-keep-awake@14.1.4(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
+  expo-modules-autolinking@2.1.14(expo-constants@17.1.8(4a4fa364a565f69495ba54c8703b3b64))(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:
-      expo: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
-      react: 19.0.0
+      '@expo/spawn-async': 1.7.2
+      chalk: 4.1.2
+      commander: 7.2.0
+      find-up: 5.0.0
+      glob: 10.4.5
+      require-from-string: 2.0.2
+      resolve-from: 5.0.0
     optionalDependencies:
+      expo-constants: 17.1.8(4a4fa364a565f69495ba54c8703b3b64)
       expo-modules-core: 2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
+
+  expo-modules-autolinking@2.1.14(expo-constants@17.1.8)(expo-modules-core@2.5.0)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@expo/spawn-async': 1.7.2
+      chalk: 4.1.2
+      commander: 7.2.0
+      find-up: 5.0.0
+      glob: 10.4.5
+      require-from-string: 2.0.2
+      resolve-from: 5.0.0
+    optionalDependencies:
+      expo-constants: 17.1.8(expo-modules-core@2.5.0)(expo@53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      expo-modules-core: 2.5.0(expo-constants@17.1.8)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
 
   expo-modules-autolinking@2.1.14(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -60194,7 +60405,7 @@ snapshots:
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
 
-  expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015):
+  expo@53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-webview@13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.28.4
       '@expo/cli': 0.24.23
@@ -60204,17 +60415,17 @@ snapshots:
       '@expo/metro-config': 0.20.18
       '@expo/vector-icons': 14.0.4
       babel-preset-expo: 13.2.4(@babel/core@7.28.5)
-      expo-asset: 11.1.7(e1114795ff87aff5695f1e215fda36c2)
-      expo-constants: 17.1.8(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(4b2c01f5a47d338b1c9e7803e0aed015))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      expo-file-system: 18.1.11(e1114795ff87aff5695f1e215fda36c2)
-      expo-font: 13.3.2(e1114795ff87aff5695f1e215fda36c2)
-      expo-keep-awake: 14.1.4(e1114795ff87aff5695f1e215fda36c2)
+      expo-asset: 11.1.7(5016f5ad50984dc7067476777bc39ad2)
+      expo-constants: 17.1.8(4a4fa364a565f69495ba54c8703b3b64)
+      expo-file-system: 18.1.11(5016f5ad50984dc7067476777bc39ad2)
+      expo-font: 13.3.2(5016f5ad50984dc7067476777bc39ad2)
+      expo-keep-awake: 14.1.4(5016f5ad50984dc7067476777bc39ad2)
+      expo-modules-autolinking: 2.1.14(expo-constants@17.1.8(4a4fa364a565f69495ba54c8703b3b64))(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
       react-native-edge-to-edge: 1.6.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       whatwg-url-without-unicode: 8.0.0-3
     optionalDependencies:
-      expo-modules-autolinking: 2.1.14(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       expo-modules-core: 2.5.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native-webview: 13.16.0(patch_hash=d6fc65af8843b53a07ea09153f9789ae0e615b957fc57a921f62f87f7dd59506)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
@@ -60240,6 +60451,7 @@ snapshots:
       expo-file-system: 18.1.11(expo-constants@17.1.8)(expo-modules-core@2.5.0)(expo@53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       expo-font: 13.3.2(expo-constants@17.1.8)(expo-modules-core@2.5.0)(expo@53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       expo-keep-awake: 14.1.4(expo-constants@17.1.8)(expo-modules-core@2.5.0)(expo@53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      expo-modules-autolinking: 2.1.14(expo-constants@17.1.8)(expo-modules-core@2.5.0)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
       react-native-edge-to-edge: 1.6.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
@@ -60916,6 +61128,11 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
+  fs-minipass@3.0.3:
+    dependencies:
+      minipass: 7.1.3
+    optional: true
+
   fs-monkey@1.0.5: {}
 
   fs.realpath@1.0.0: {}
@@ -60959,6 +61176,19 @@ snapshots:
   fwd-stream@1.0.4:
     dependencies:
       readable-stream: 1.0.34
+
+  gauge@3.0.2:
+    dependencies:
+      aproba: 2.1.0
+      color-support: 1.1.3
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      object-assign: 4.1.1
+      signal-exit: 3.0.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wide-align: 1.1.5
+    optional: true
 
   gauge@4.0.4:
     dependencies:
@@ -62368,6 +62598,9 @@ snapshots:
   isbinaryfile@5.0.0: {}
 
   isexe@2.0.0: {}
+
+  isexe@3.1.5:
+    optional: true
 
   iso-base@4.4.0:
     dependencies:
@@ -64714,6 +64947,24 @@ snapshots:
       - bluebird
       - supports-color
 
+  make-fetch-happen@13.0.1:
+    dependencies:
+      '@npmcli/agent': 2.2.2
+      cacache: 18.0.4
+      http-cache-semantics: 4.2.0
+      is-lambda: 1.0.1
+      minipass: 7.1.3
+      minipass-fetch: 3.0.5
+      minipass-flush: 1.0.5
+      minipass-pipeline: 1.2.4
+      negotiator: 0.6.4
+      proc-log: 4.2.0
+      promise-retry: 2.0.1
+      ssri: 10.0.6
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   make-fetch-happen@9.1.0:
     dependencies:
       agentkeepalive: 4.6.0
@@ -65939,6 +66190,11 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
+  minipass-collect@2.0.1:
+    dependencies:
+      minipass: 7.1.3
+    optional: true
+
   minipass-fetch@1.4.1:
     dependencies:
       minipass: 3.3.6
@@ -65955,6 +66211,15 @@ snapshots:
       minizlib: 2.1.2
     optionalDependencies:
       encoding: 0.1.13
+
+  minipass-fetch@3.0.5:
+    dependencies:
+      minipass: 7.1.3
+      minipass-sized: 1.0.3
+      minizlib: 2.1.2
+    optionalDependencies:
+      encoding: 0.1.13
+    optional: true
 
   minipass-flush@1.0.5:
     dependencies:
@@ -66111,6 +66376,9 @@ snapshots:
 
   napi-postinstall@0.3.4: {}
 
+  napi-thread-safe-callback@0.0.6:
+    optional: true
+
   natural-compare@1.4.0: {}
 
   ncp@2.0.0:
@@ -66264,6 +66532,25 @@ snapshots:
 
   node-gyp-build@4.8.0: {}
 
+  node-gyp-build@4.8.4:
+    optional: true
+
+  node-gyp@10.3.1:
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.2
+      glob: 10.4.5
+      graceful-fs: 4.2.11
+      make-fetch-happen: 13.0.1
+      nopt: 7.2.1
+      proc-log: 4.2.0
+      semver: 7.8.1
+      tar: 6.2.1
+      which: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   node-gyp@8.4.1:
     dependencies:
       env-paths: 2.2.1
@@ -66352,6 +66639,11 @@ snapshots:
     dependencies:
       abbrev: 1.1.1
 
+  nopt@7.2.1:
+    dependencies:
+      abbrev: 2.0.0
+    optional: true
+
   normalize-package-data@2.5.0:
     dependencies:
       hosted-git-info: 2.8.9
@@ -66399,6 +66691,14 @@ snapshots:
     dependencies:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
+
+  npmlog@5.0.1:
+    dependencies:
+      are-we-there-yet: 2.0.0
+      console-control-strings: 1.1.0
+      gauge: 3.0.2
+      set-blocking: 2.0.0
+    optional: true
 
   npmlog@6.0.2:
     dependencies:
@@ -70524,6 +70824,11 @@ snapshots:
       safer-buffer: 2.1.2
       tweetnacl: 0.14.5
 
+  ssri@10.0.6:
+    dependencies:
+      minipass: 7.1.3
+    optional: true
+
   ssri@8.0.1:
     dependencies:
       minipass: 3.3.6
@@ -72151,6 +72456,11 @@ snapshots:
     dependencies:
       unique-slug: 3.0.0
 
+  unique-filename@3.0.0:
+    dependencies:
+      unique-slug: 4.0.0
+    optional: true
+
   unique-slug@2.0.2:
     dependencies:
       imurmurhash: 0.1.4
@@ -72159,6 +72469,11 @@ snapshots:
   unique-slug@3.0.0:
     dependencies:
       imurmurhash: 0.1.4
+
+  unique-slug@4.0.0:
+    dependencies:
+      imurmurhash: 0.1.4
+    optional: true
 
   unique-string@2.0.0:
     dependencies:
@@ -72970,6 +73285,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  which@4.0.0:
+    dependencies:
+      isexe: 3.1.5
+    optional: true
 
   wide-align@1.1.5:
     dependencies:


### PR DESCRIPTION
Closes #18436.

## What

Adds an optional Bluetooth Low Energy transport to `wallet-cli`, selectable with `WALLET_CLI_TRANSPORT=ble`. The default stays `usb`, so nothing changes for current users.

`@ledgerhq/device-management-kit` ships a Node transport for USB-HID/WebUSB only; its BLE transports target the browser (`device-transport-kit-web-ble`) and React Native (`device-transport-kit-react-native-ble`). There is no Node BLE transport, so the CLI cannot talk to a Flex/Stax over Bluetooth today. This adds one, backed by `@abandonware/noble`.

The motivation is the agent/automation use case from the issue: the host running the CLI usually does not have the device on a cable — the device stays with the human and pairs over BLE.

## How

- `src/device/node-ble/NodeBleTransport.ts` implements the DMK `Transport` contract and is registered in `createDeviceManagementKit()` only when the BLE transport is selected.
- Framing is delegated to DMK's injected `ApduSender`/`ApduReceiver` services with `channel = Nothing` and `padding = false`. With no channel, DMK emits exactly the `[0x05][seq][len][payload]` block layout Ledger BLE expects, so the transport writes raw frames to the GATT write characteristic and feeds notification buffers straight back to DMK — no hand-rolled framer.
- BLE service/characteristic UUIDs and device models come from `deviceModelDataSource.getBluetoothServicesInfos()`, so the transport stays in sync with the device models DMK knows about. The `0x08` GET-MTU handshake mirrors `@ledgerhq/hw-transport-node-ble`.
- `noble` is imported lazily, so USB-only runs never initialize the platform Bluetooth stack.
- On the BLE path the process exits explicitly after teardown: `noble` keeps a native libuv handle that never unrefs, so without this the process hangs after a command completes. USB unrefs its hotplug events and drains naturally, so that path is left untouched.
- `@abandonware/noble` + `@abandonware/bluetooth-hci-socket` added to the root `onlyBuiltDependencies` so the native binding builds on install.

The transport reuses the existing device-action layer, so commands work over BLE with no per-command changes: discovery, unlock/open-app prompts, rejection handling, and the multi-chain signers are all the same as USB.

## Tests

- Unit tests with a fake `noble` + stubbed DMK framing services: discovery filtering (ignores non-Ledger peripherals), `poweredOn` gating before scan, connect + MTU handshake + APDU round-trip, and idempotent disconnect.
- `typecheck`, `lint` (oxlint), and the full `bun test src/` suite are green.
- Verified live against a Ledger Flex over BLE: `WALLET_CLI_TRANSPORT=ble wallet-cli genuine-check` (device attestation) and `account discover solana` (account derivation) both complete end to end.

## Scope / follow-ups (separate)

Kept intentionally to "transport only" for an easy review. Two related UX gaps are tracked separately rather than bundled here:

- Device selection: like the USB path, this connects to the first discovered device. A `--device <name|id>` selector (and "don't auto-pick when more than one is present") would help when several devices are in range. The transport already surfaces each peripheral's `id` and `localName`, so the data is there.
- `genuine-check` returning `DeviceOnDashboardExpected` instead of navigating to the dashboard via DMK.

## Notes

`@abandonware/noble` has platform-specific native bindings, so a fully bundled standalone binary needs the same native-embed handling that `usb` gets in `embed-usb-native.ts`. This PR wires the transport for the from-source/`bun run` path; standalone packaging of the BLE native bindings can be a follow-up if there is appetite for shipping BLE in the published binaries.
