### PR TITLE
[LWDM] feat(LIVE-31564): aleo getTvk and signOperation integration

### DIFF
--- a/.changeset/chatty-carrots-punch.md
+++ b/.changeset/chatty-carrots-punch.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-aleo": minor
+"@ledgerhq/live-signer-aleo": minor
+---
+
+feat: aleo getTvk and signOperation integration

--- a/libs/coin-modules/coin-aleo/src/bridge/index.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/index.test.ts
@@ -22,6 +22,7 @@ describe("Bridge", () => {
     const getAddress = jest.fn().mockResolvedValue({ address: "aleo1test" });
     const getViewKey = jest.fn().mockResolvedValue({ viewKey: "view_key" });
     const getAppConfig = jest.fn().mockResolvedValue({});
+    const getTvk = jest.fn().mockResolvedValue({ tvk: new Uint8Array([0xaa]) });
 
     const mockSigner: AleoSigner = {
       signRootIntent,
@@ -30,6 +31,7 @@ describe("Bridge", () => {
       getAddress,
       getViewKey,
       getAppConfig,
+      getTvk,
     };
 
     return <T>(_deviceId: string, fn: (signer: AleoSigner) => Promise<T>): Promise<T> =>

--- a/libs/coin-modules/coin-aleo/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/signOperation.test.ts
@@ -35,6 +35,7 @@ function createMockSigner(): jest.Mocked<AleoSigner> {
     getAppConfig: jest.fn(),
     getAddress: jest.fn(),
     getViewKey: jest.fn(),
+    getTvk: jest.fn().mockResolvedValue({ tvk: new Uint8Array([0xaa]) }),
     signRootIntent: jest.fn().mockResolvedValue({ signature: "root-signature" }),
     signFeeIntent: jest.fn().mockResolvedValue({ signature: "fee-signature" }),
     signNestedCall: jest.fn().mockResolvedValue({ signature: "nested-signature" }),
@@ -440,6 +441,125 @@ describe("buildSignOperation", () => {
         }).pipe(toArray()),
       ),
     ).rejects.toThrow("device disconnected");
+  });
+
+  it("should report device-streaming progress as a 0-1 fraction when precomputing TVKs", async () => {
+    const privateTransaction = getMockedTransaction({
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      properties: {
+        amountRecordCommitments: [mockUnspentRecord1.commitment, mockUnspentRecord2.commitment],
+        feeRecordCommitment: mockUnspentRecord2.commitment,
+      },
+    });
+
+    const events = await firstValueFrom(
+      mockSignOperation({
+        account: mockAccount,
+        transaction: privateTransaction,
+        deviceId: "test-device",
+      }).pipe(toArray()),
+    );
+
+    const streamingEvents = events
+      .filter(event => event.type === "device-streaming")
+      .map(event => ({
+        progress: event.progress,
+        index: event.index,
+        total: event.total,
+      }));
+
+    expect(streamingEvents.length).toBeGreaterThan(0);
+    expect(streamingEvents.at(0)).toEqual({ progress: 0.01, index: 0, total: 3 });
+    expect(streamingEvents.at(-1)).toEqual({ progress: 1, index: 2, total: 3 });
+    expect(streamingEvents.every(event => event.progress >= 0 && event.progress <= 1)).toBe(true);
+    expect(mockSigner.getTvk).toHaveBeenCalledTimes(3);
+    expect(mockSigner.getTvk).toHaveBeenNthCalledWith(1, mockAccount.freshAddressPath);
+    expect(mockSigner.getTvk).toHaveBeenNthCalledWith(2, mockAccount.freshAddressPath, 1);
+    expect(mockSigner.getTvk).toHaveBeenNthCalledWith(3, mockAccount.freshAddressPath, 2);
+  });
+
+  it("should pass precomputed tvks to craftTransaction for multi-record private txs", async () => {
+    const privateTransaction = getMockedTransaction({
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      properties: {
+        amountRecordCommitments: [mockUnspentRecord1.commitment, mockUnspentRecord2.commitment],
+        feeRecordCommitment: mockUnspentRecord2.commitment,
+      },
+    });
+
+    await firstValueFrom(
+      mockSignOperation({
+        account: mockAccount,
+        transaction: privateTransaction,
+        deviceId: "test-device",
+      }).pipe(toArray()),
+    );
+
+    expect(mockedCraftTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tvks: ["aa", "aa", "aa"],
+      }),
+    );
+  });
+
+  it("should not precompute tvks for single-record private txs", async () => {
+    const privateTransaction = getMockedTransaction({
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      properties: {
+        amountRecordCommitments: [mockUnspentRecord1.commitment],
+        feeRecordCommitment: mockUnspentRecord2.commitment,
+      },
+    });
+
+    await firstValueFrom(
+      mockSignOperation({
+        account: mockAccount,
+        transaction: privateTransaction,
+        deviceId: "test-device",
+      }).pipe(toArray()),
+    );
+
+    expect(mockSigner.getTvk).not.toHaveBeenCalled();
+    expect(mockedCraftTransaction).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        tvks: expect.anything(),
+      }),
+    );
+  });
+
+  it("should not precompute tvks for public txs", async () => {
+    await firstValueFrom(
+      mockSignOperation({
+        account: mockAccount,
+        transaction: mockTransaction,
+        deviceId: "test-device",
+      }).pipe(toArray()),
+    );
+
+    expect(mockSigner.getTvk).not.toHaveBeenCalled();
+  });
+
+  it("should propagate getTvk errors to the observable", async () => {
+    const privateTransaction = getMockedTransaction({
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      properties: {
+        amountRecordCommitments: [mockUnspentRecord1.commitment, mockUnspentRecord2.commitment],
+        feeRecordCommitment: mockUnspentRecord2.commitment,
+      },
+    });
+    const signer = createMockSigner();
+    signer.getTvk.mockRejectedValue(new Error("tvk precompute failed"));
+    const invalidSignOperation = buildSignOperation(createMockSignerContext(signer));
+
+    await expect(
+      firstValueFrom(
+        invalidSignOperation({
+          account: mockAccount,
+          transaction: privateTransaction,
+          deviceId: "test-device",
+        }).pipe(toArray()),
+      ),
+    ).rejects.toThrow("tvk precompute failed");
   });
 
   it("should propagate an error when account id has no viewKey", async () => {

--- a/libs/coin-modules/coin-aleo/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/signOperation.ts
@@ -1,6 +1,10 @@
 import BigNumber from "bignumber.js";
 import { Observable } from "rxjs";
 import type { AccountBridge } from "@ledgerhq/types-live";
+import type {
+  MemoNotSupported,
+  TransactionIntent,
+} from "@ledgerhq/coin-module-framework/api/types";
 import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import {
   type Transaction,
@@ -10,6 +14,7 @@ import {
   type FeeConfiguration,
   PreparedRequestResponse,
   type AleoCoinConfig,
+  AleoTransactionIntentData,
 } from "../types";
 import { sdkClient } from "../network/sdk";
 import { craftTransaction } from "../logic";
@@ -32,6 +37,72 @@ interface SigningParams {
   baseFee: BigNumber;
   priorityFee: BigNumber;
   viewKey: string;
+}
+
+type DeviceStreamingCallback = (arg0: { progress: number; total: number; index: number }) => void;
+
+function createStreamingReporter(
+  onDeviceStreaming: DeviceStreamingCallback,
+  total: number,
+): {
+  reportInitialStep: () => void;
+  reportStepCompleted: () => void;
+} {
+  let completedSteps = 0;
+  return {
+    reportInitialStep: () => {
+      onDeviceStreaming({ total, index: 0, progress: 0.01 }); // show 1% to indicate that the initial step is in progress
+    },
+    reportStepCompleted: () => {
+      completedSteps += 1;
+      const index = completedSteps - 1;
+      const progress = completedSteps / total;
+      onDeviceStreaming({ total, index, progress });
+    },
+  };
+}
+
+async function getTvks({
+  signer,
+  path,
+  txIntent,
+  onDeviceStreaming,
+}: {
+  signer: AleoSigner;
+  path: string;
+  txIntent: TransactionIntent<MemoNotSupported, AleoTransactionIntentData>;
+  onDeviceStreaming: DeviceStreamingCallback;
+}): Promise<{
+  rootTvk: string;
+  nestedTvks: string[];
+  // feeTvk: string; // not used on the backend side, left just for documentation purposes
+} | null> {
+  const records = "data" in txIntent && "records" in txIntent.data ? txIntent.data.records : null;
+  const isTxWithNestedCalls = records && records.length > 1;
+
+  // TVKs are only needed for transactions with nested calls.
+  // In our case it can happen only when more than 1 record is used
+  if (!isTxWithNestedCalls) {
+    return null;
+  }
+
+  const nestedTvks: string[] = [];
+  const tvksToFetch = records.length + 1;
+  const streamingReporter = createStreamingReporter(onDeviceStreaming, tvksToFetch);
+
+  streamingReporter.reportInitialStep();
+
+  const rootResult = await signer.getTvk(path);
+  const rootTvk = Buffer.from(rootResult.tvk).toString("hex");
+  streamingReporter.reportStepCompleted();
+
+  for (let transitionIndex = 1; transitionIndex < tvksToFetch; transitionIndex++) {
+    const nestedResult = await signer.getTvk(path, transitionIndex);
+    nestedTvks.push(Buffer.from(nestedResult.tvk).toString("hex"));
+    streamingReporter.reportStepCompleted();
+  }
+
+  return { rootTvk, nestedTvks };
 }
 
 async function buildFeeAuthorization({
@@ -152,6 +223,7 @@ export const buildSignOperation =
         try {
           const viewKey = extractViewKey(account);
           const config = resolveConfig(account.currency.id);
+          const txIntent = createTransactionIntent({ account, transaction });
           const baseFee = transaction.fees;
           const priorityFee = new BigNumber(0);
 
@@ -161,21 +233,36 @@ export const buildSignOperation =
             max_priority_fee: priorityFee.toString(),
           };
 
-          const craftedRequest = await craftTransaction({
-            currency: account.currency,
-            viewKey,
-            feeConfiguration,
-            txIntent: createTransactionIntent({ account, transaction }),
-          });
+          const signedTx = await signerContext(deviceId, async signer => {
+            const tvks = await getTvks({
+              signer,
+              path: account.freshAddressPath,
+              txIntent,
+              onDeviceStreaming: ({ progress, index, total }) => {
+                o.next({
+                  type: "device-streaming",
+                  progress,
+                  index,
+                  total,
+                });
+              },
+            });
 
-          const request = fromHex<PreparedRequestResponse>(craftedRequest.transaction);
+            const craftedRequest = await craftTransaction({
+              currency: account.currency,
+              viewKey,
+              feeConfiguration,
+              txIntent,
+              ...(tvks && { tvks: [tvks.rootTvk, ...tvks.nestedTvks] }),
+            });
 
-          o.next({
-            type: "device-signature-requested",
-          });
+            const request = fromHex<PreparedRequestResponse>(craftedRequest.transaction);
 
-          const signedTx = await signerContext(deviceId, signer =>
-            executeSigningFlow({
+            o.next({
+              type: "device-signature-requested",
+            });
+
+            return executeSigningFlow({
               signer,
               onDeviceSigned: () => o.next({ type: "device-signature-granted" }),
               params: {
@@ -187,8 +274,8 @@ export const buildSignOperation =
                 priorityFee,
                 viewKey,
               },
-            }),
-          );
+            });
+          });
 
           const operation = buildOptimisticOperation({
             account,

--- a/libs/coin-modules/coin-aleo/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/craftTransaction.test.ts
@@ -3,8 +3,10 @@ import { getMockedCurrency } from "../__tests__/fixtures/currency.fixture";
 import { getMockedPreparedRequestResponse } from "../__tests__/fixtures/sdk.fixture";
 import {
   mockTxIntentFeePrivate,
+  mockTxIntentTransferPrivate2,
   mockTxIntentTransferPublic,
 } from "../__tests__/fixtures/transaction.fixture";
+import { mockUnspentRecord1, mockUnspentRecord2 } from "../__tests__/fixtures/account.fixture";
 import type { FeeConfiguration, Intent } from "../types";
 import { craftTransaction } from "./craftTransaction";
 import { mapTransactionIntentToSdkIntent, toHex } from "./utils";
@@ -18,6 +20,12 @@ const mockSdkIntent: Intent = {
   type: "transfer_public",
   amount: "1000",
   to: "aleo1recipient",
+};
+const mockMultiRecordSdkIntent: Intent = {
+  type: "transfer_private_2",
+  amount: "200",
+  to: "aleo1recipient",
+  records: [mockUnspentRecord1.decryptedData, mockUnspentRecord2.decryptedData],
 };
 const mockSdkResponse = getMockedPreparedRequestResponse({
   network_id: 0,
@@ -100,5 +108,41 @@ describe("craftTransaction", () => {
     expect(mapTransactionIntentToSdkIntent).toHaveBeenCalledWith(mockTxIntentFeePrivate);
     expect(sdkClient.createRequestFromIntent).toHaveBeenCalledTimes(1);
     expect(toHex).toHaveBeenCalledTimes(1);
+  });
+
+  it("should pass tvks to SDK for multi-record intents", async () => {
+    const tvks = ["root-tvk", "nested-tvk-1", "nested-tvk-2"];
+
+    jest.mocked(mapTransactionIntentToSdkIntent).mockReturnValue(mockMultiRecordSdkIntent);
+
+    await craftTransaction({
+      currency: mockCurrency,
+      txIntent: mockTxIntentTransferPrivate2,
+      feeConfiguration: mockFeeConfiguration,
+      viewKey: mockViewKey,
+      tvks,
+    });
+
+    expect(sdkClient.createRequestFromIntent).toHaveBeenCalledTimes(1);
+    expect(sdkClient.createRequestFromIntent).toHaveBeenCalledWith({
+      currency: mockCurrency,
+      intent: mockMultiRecordSdkIntent,
+      feeConfiguration: mockFeeConfiguration,
+      viewKey: mockViewKey,
+      tvks,
+    });
+  });
+
+  it("should require tvks for multi-record intents", async () => {
+    jest.mocked(mapTransactionIntentToSdkIntent).mockReturnValue(mockMultiRecordSdkIntent);
+
+    await expect(
+      craftTransaction({
+        currency: mockCurrency,
+        txIntent: mockTxIntentTransferPrivate2,
+        feeConfiguration: mockFeeConfiguration,
+        viewKey: mockViewKey,
+      }),
+    ).rejects.toThrow("aleo: tvks are required for transactions with nested calls");
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/craftTransaction.ts
@@ -1,3 +1,4 @@
+import invariant from "invariant";
 import type {
   CraftedTransaction,
   MemoNotSupported,
@@ -13,18 +14,26 @@ export async function craftTransaction({
   txIntent,
   feeConfiguration,
   viewKey,
+  tvks,
 }: {
   currency: CryptoCurrency;
   txIntent: TransactionIntent<MemoNotSupported, AleoTransactionIntentData>;
   feeConfiguration: FeeConfiguration | null;
   viewKey?: string;
+  tvks?: string[];
 }): Promise<CraftedTransaction> {
   const intent = mapTransactionIntentToSdkIntent(txIntent);
+
+  if ("records" in intent && intent.records.length > 1) {
+    invariant(tvks, "aleo: tvks are required for transactions with nested calls");
+  }
+
   const response = await sdkClient.createRequestFromIntent({
     currency,
     intent,
     feeConfiguration,
     ...(viewKey !== undefined && { viewKey }),
+    ...(tvks !== undefined && { tvks }),
   });
 
   const transaction = toHex(response);

--- a/libs/coin-modules/coin-aleo/src/network/sdk.ts
+++ b/libs/coin-modules/coin-aleo/src/network/sdk.ts
@@ -104,11 +104,13 @@ async function createRequestFromIntent({
   intent,
   feeConfiguration,
   viewKey,
+  tvks,
 }: {
   currency: CryptoCurrency;
   intent: Intent;
   feeConfiguration: FeeConfiguration | null;
   viewKey?: string;
+  tvks?: string[];
 }): Promise<PreparedRequestResponse> {
   const { sdkUrl } = getNetworkConfig(currency);
 
@@ -119,6 +121,7 @@ async function createRequestFromIntent({
       intent,
       fee: feeConfiguration,
       ...(viewKey && { view_key: viewKey }),
+      ...(tvks && { tvks }),
     },
   });
 

--- a/libs/coin-modules/coin-aleo/src/types/signer.ts
+++ b/libs/coin-modules/coin-aleo/src/types/signer.ts
@@ -10,6 +10,10 @@ export interface AleoViewKey {
   viewKey: string;
 }
 
+export interface AleoTvk {
+  tvk: Uint8Array<ArrayBufferLike>;
+}
+
 export interface AleoRootIntentSignature {
   signature: string;
 }
@@ -26,6 +30,7 @@ export interface AleoSigner {
   getAppConfig: () => Promise<AleoAppConfig>;
   getAddress: (path: string, display?: boolean) => Promise<AleoAddress>;
   getViewKey: (path: string) => Promise<AleoViewKey>;
+  getTvk: (path: string, transitionIndex?: number) => Promise<AleoTvk>;
   signRootIntent(path: string, rootIntent: Buffer): Promise<AleoRootIntentSignature>;
   signFeeIntent(feeIntent: Buffer): Promise<AleoFeeIntentSignature>;
   signNestedCall(nestedCallRequest: Buffer): Promise<AleoNestedCallSignature>;

--- a/libs/live-signer-aleo/src/DmkSignerAleo.ts
+++ b/libs/live-signer-aleo/src/DmkSignerAleo.ts
@@ -7,6 +7,7 @@ import type {
   AleoRootIntentSignature,
   AleoFeeIntentSignature,
   AleoNestedCallSignature,
+  AleoTvk,
 } from "@ledgerhq/coin-aleo/types/signer";
 import {
   DeviceActionState,
@@ -20,6 +21,7 @@ import {
   GetAppConfigDAError,
   GetAddressDAError,
   GetViewKeyDAError,
+  GetTvkDAError,
   SignRootIntentDAError,
   SignFeeIntentDAError,
   SignNestedCallDAError,
@@ -29,6 +31,7 @@ type DAError =
   | GetAppConfigDAError
   | GetAddressDAError
   | GetViewKeyDAError
+  | GetTvkDAError
   | SignRootIntentDAError
   | SignFeeIntentDAError
   | SignNestedCallDAError;
@@ -40,9 +43,17 @@ export class DmkSignerAleo implements AleoSigner {
     this.signer = new SignerAleoBuilder({ dmk, sessionId }).build();
   }
 
+  private _getGenericErrorMessage<E extends DAError>(error: E): string {
+    const originalError = "originalError" in error ? error.originalError : null;
+    const originalMessage = originalError instanceof Error ? originalError.message : null;
+    const tag = error._tag;
+
+    return originalMessage ? `${tag}: ${originalMessage}` : tag;
+  }
+
   private _mapError<E extends DAError>(error: E): Error {
     if (!("errorCode" in error)) {
-      return new Error(error._tag);
+      return new Error(this._getGenericErrorMessage(error));
     }
 
     switch (error.errorCode) {
@@ -51,7 +62,7 @@ export class DmkSignerAleo implements AleoSigner {
       case "69f0":
         return new UserRefusedOnDevice();
       default:
-        return new Error(error._tag);
+        return new Error(this._getGenericErrorMessage(error));
     }
   }
 
@@ -104,6 +115,26 @@ export class DmkSignerAleo implements AleoSigner {
 
     return {
       viewKey: result.viewKey,
+    };
+  }
+
+  /**
+   * GET_TVK precomputes transition view keys that are consumed by the backend during request crafting.
+   * More details can be found in ADR005.
+   * - Index 0 is a root transition
+   * - Indexes 1 to 30 are nested transitions
+   * - Index 31 is fee transition (not used on the backend side, seems unnecessary)
+   */
+  async getTvk(path: string, transitionIndex?: number): Promise<AleoTvk> {
+    const { observable } = this.signer.getTvk(path, {
+      skipOpenApp: true,
+      ...(typeof transitionIndex === "number" && { transitionIndex }),
+    });
+
+    const result = this._mapResult(await lastValueFrom(observable));
+
+    return {
+      tvk: result.tvk,
     };
   }
 

--- a/libs/live-signer-aleo/tests/DmkSignerAleo.test.ts
+++ b/libs/live-signer-aleo/tests/DmkSignerAleo.test.ts
@@ -18,6 +18,7 @@ describe("DmkSignerAleo", () => {
     getAppConfig: jest.fn(),
     getAddress: jest.fn(),
     getViewKey: jest.fn(),
+    getTvk: jest.fn(),
     signRootIntent: jest.fn(),
     signFeeIntent: jest.fn(),
     signNestedCall: jest.fn(),
@@ -248,6 +249,76 @@ describe("DmkSignerAleo", () => {
 
       // WHEN / THEN
       await expect(signer.getViewKey(mockPath)).rejects.toThrow(UserRefusedOnDevice);
+    });
+  });
+
+  describe("getTvk", () => {
+    it("should return the tvk and call signer with correct params", async () => {
+      // GIVEN
+      const getTvkMock: jest.Mock = mockSignerAleo.getTvk;
+      getTvkMock.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Completed,
+          output: { tvk: new Uint8Array([0xaa, 0xbb]) },
+        }),
+      });
+
+      // WHEN
+      const result = await signer.getTvk(mockPath);
+
+      // THEN
+      expect(result).toEqual({ tvk: new Uint8Array([0xaa, 0xbb]) });
+      expect(mockSignerAleo.getTvk).toHaveBeenCalledWith(mockPath, {
+        skipOpenApp: true,
+      });
+    });
+
+    it("should pass transitionIndex when provided", async () => {
+      // GIVEN
+      const getTvkMock: jest.Mock = mockSignerAleo.getTvk;
+      getTvkMock.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Completed,
+          output: { tvk: new Uint8Array([0xcc]) },
+        }),
+      });
+
+      // WHEN
+      await signer.getTvk(mockPath, 2);
+
+      // THEN
+      expect(mockSignerAleo.getTvk).toHaveBeenCalledWith(mockPath, {
+        skipOpenApp: true,
+        transitionIndex: 2,
+      });
+    });
+
+    it("should throw LockedDeviceError when device is locked", async () => {
+      // GIVEN
+      const getTvkMock: jest.Mock = mockSignerAleo.getTvk;
+      getTvkMock.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Error,
+          error: { _tag: "GetTvkDARejected", errorCode: "5515" },
+        }),
+      });
+
+      // WHEN / THEN
+      await expect(signer.getTvk(mockPath)).rejects.toThrow(LockedDeviceError);
+    });
+
+    it("should throw UserRefusedOnDevice when user refuses", async () => {
+      // GIVEN
+      const getTvkMock: jest.Mock = mockSignerAleo.getTvk;
+      getTvkMock.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Error,
+          error: { _tag: "GetTvkDARejected", errorCode: "69f0" },
+        }),
+      });
+
+      // WHEN / THEN
+      await expect(signer.getTvk(mockPath)).rejects.toThrow(UserRefusedOnDevice);
     });
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: 1.6.0
       version: 1.6.0
     '@ledgerhq/device-signer-kit-aleo':
-      specifier: 0.3.0
-      version: 0.3.0
+      specifier: 0.4.0
+      version: 0.4.0
     '@ledgerhq/device-signer-kit-concordium':
       specifier: 0.4.0
       version: 0.4.0
@@ -11327,7 +11327,7 @@ importers:
         version: 1.6.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-aleo':
         specifier: 'catalog:'
-        version: 0.3.0(@ledgerhq/context-module@2.1.0(@ledgerhq/device-management-kit@1.6.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.6.0(rxjs@7.8.2))
+        version: 0.4.0(@ledgerhq/context-module@2.1.0(@ledgerhq/device-management-kit@1.6.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.6.0(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -17348,11 +17348,11 @@ packages:
     peerDependencies:
       rxjs: 7.8.2
 
-  '@ledgerhq/device-signer-kit-aleo@0.3.0':
-    resolution: {integrity: sha512-yVw76991hahT2T0ob0BXWu60cz7LLFjeBC8eeXmquPYOML6HEfdHIKjV8/uzTQQ4M/X3t3L+CC0avjuW4ezmPw==}
+  '@ledgerhq/device-signer-kit-aleo@0.4.0':
+    resolution: {integrity: sha512-GeWvln9TY/EAVxnxmMTPITxOstZLD5tiwupFih2avIayoeYa3Q8Gh8gkW77wd/Sd9oQLmwLQByHdcwRmMcSLrQ==}
     peerDependencies:
       '@ledgerhq/context-module': 2.1.0
-      '@ledgerhq/device-management-kit': ^1.5.0
+      '@ledgerhq/device-management-kit': ^1.6.0
 
   '@ledgerhq/device-signer-kit-concordium@0.4.0':
     resolution: {integrity: sha512-jqVp8232dkI34ZVbsQOcGpjK9J+g8BzGD9+/0Ezy7nGtMUfX8c6AhEmn79kj3w96kJ0z1YkakaClCHxicFWtKQ==}
@@ -45651,7 +45651,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-aleo@0.3.0(@ledgerhq/context-module@2.1.0(@ledgerhq/device-management-kit@1.6.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.6.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-aleo@0.4.0(@ledgerhq/context-module@2.1.0(@ledgerhq/device-management-kit@1.6.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.6.0(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/context-module': 2.1.0(@ledgerhq/device-management-kit@1.6.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.6.0(rxjs@7.8.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ catalog:
   "@ledgerhq/context-module": 2.1.0
   "@ledgerhq/crypto-icons": "2.0.4"
   "@ledgerhq/device-management-kit": 1.6.0
-  "@ledgerhq/device-signer-kit-aleo": 0.3.0
+  "@ledgerhq/device-signer-kit-aleo": 0.4.0
   "@ledgerhq/device-signer-kit-concordium": 0.4.0
   "@ledgerhq/device-signer-kit-ethereum": 1.16.0
   "@ledgerhq/device-signer-kit-hyperliquid": 1.1.0


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - update of the Aleo signer kit with getTvk support
  - refactor `signOperation` in coin-aleo to pass TVKs coming from device to SDK backend when crafting request

### 📝 Description

This PR addresses ADR-005 by adding support for TVKs coming from the device app.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-31564
- https://ledgerhq.atlassian.net/wiki/spaces/BI/pages/7177633841/ARCH+-+ADR005+Addressing+r_hint+vulnerability

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
