### PR TITLE
docs(features): add sub-layer READMEs for platform and flow

### DIFF
--- a/features/flow/README.md
+++ b/features/flow/README.md
@@ -1,0 +1,39 @@
+# features/flow/
+
+User-facing feature packages shared across desktop and mobile apps. Each subdirectory is an independent pnpm workspace package providing the UI building blocks that each app assembles into its own screens.
+
+## Scope
+
+`@features/flow-<name>` (e.g. `@features/flow-market-banner`, `@features/flow-wallet`)
+
+## Responsibility
+
+- Provide **UI components** with business context, using `.web.tsx` / `.native.tsx` extensions for platform-specific variants
+- Own **feature-local state** (local Redux slices, thunks) when the feature requires it
+- Expose **feature-local routing** when the feature contains multiple steps or sub-views
+- Must NOT contain app-specific screen composition — that belongs in `apps/`
+
+## Conventions
+
+- One flow package per user-facing feature
+- Package name: `@features/flow-<name>`
+- Directory name: `features/flow/<name>/`
+- `package.json` must have `"private": true`
+- May depend on `type:feature-platform`, `scope:domain`, and `scope:shared`
+- Nx tag inferred automatically: `type:feature-flow`
+- Platform-specific files use `.web.tsx` / `.native.tsx` suffixes; shared logic uses `.ts` / `.tsx`
+- Barrel export via `src/index.ts`
+
+## File Structure
+
+Each package follows this layout inside `src/`:
+
+```
+components/          # UI components with business context (.web.tsx / .native.tsx)
+hooks/               # Feature-local hooks (optional)
+router/              # Local routing when the feature has multiple views (optional)
+steps/               # Individual steps in a multi-step flow (optional)
+state/               # Feature-local Redux slice or thunks (optional)
+utils/               # Feature-local helpers (optional)
+index.ts             # Barrel exports (required)
+```

--- a/features/platform/README.md
+++ b/features/platform/README.md
@@ -1,0 +1,37 @@
+# features/platform/
+
+Non-functional requirement (NFR) packages at the features layer. Each subdirectory is an independent pnpm workspace package providing hooks, selectors, and cross-feature helpers that are invisible to users but required for the system to deliver user-facing features reliably.
+
+## Scope
+
+`@features/platform-<name>` (e.g. `@features/platform-feature-flags`, `@features/platform-coin-loader`)
+
+## Responsibility
+
+- Provide **hooks** and **selectors** that resolve domain state for use in flow packages
+- Implement **cross-feature domain-aware helpers** and React glue (e.g. context providers, non-rendering components)
+- Enforce **NFR business rules** that apply across multiple features (feature flags, coin loading, etc.)
+
+## Conventions
+
+- One platform package per concern
+- Package name: `@features/platform-<name>`
+- Directory name: `features/platform/<name>/`
+- `package.json` must have `"private": true`
+- May depend on `scope:domain` and `scope:shared`; must NOT depend on `type:feature-flow`
+- Nx tag inferred automatically: `type:feature-platform`
+- Does not contain component/screen-specific rendering — only non-visual components (e.g. `<FeatureToggle>`), generic or small reusable building blocks for flow packages, and no app-specific logic
+- Barrel export via `src/index.ts`
+
+## File Structure
+
+Each package follows this layout inside `src/`:
+
+```
+components/          # Non-visual components (e.g. <FeatureToggle>) and generic reusable building blocks for flow packages
+hooks/               # Hooks and selectors exposing domain state or NFR logic to flow packages
+helpers/             # Cross-feature domain-aware helpers (optional)
+index.ts             # Barrel exports (required)
+```
+
+Files that do not fit a subdirectory (e.g. a single-file integration adapter) live directly under `src/`.


### PR DESCRIPTION
## Summary

- Adds `features/platform/README.md` documenting the NFR sub-layer: naming conventions, responsibilities (hooks, selectors, non-visual components, cross-feature helpers), Nx tags, and file structure
- Adds `features/flow/README.md` documenting the user-facing features sub-layer: naming conventions, responsibilities (UI components with `.web`/`.native` variants, local state, local routing), Nx tags, and file structure
- Mirrors the structure and tone of the existing `domain/entity/README.md` and `domain/api/README.md`

Closes [LIVE-32011](https://ledgerhq.atlassian.net/browse/LIVE-32011)

## Test plan

- [ ] Visual review of both READMEs against the [Data Layer Structure & Flow guideline](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6111232117)
- [ ] Confirm structure is consistent with `domain/entity/README.md` and `domain/api/README.md`

[LIVE-32011]: https://ledgerhq.atlassian.net/browse/LIVE-32011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ