### PR TITLE
[LWM] feat(mobile): Global Search polish [LIVE-32202]

### DIFF
--- a/.changeset/global-search-polish.md
+++ b/.changeset/global-search-polish.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Polish the Global Search feature: prices and market caps now follow the user's counter-value currency setting (converting DADA's USD values via the USD→fiat rate, matching the Modular Asset Drawer), the results and default views show an error state when their data fails to load, the header back button aligns with the other screens, and the GlobalSearch analytics events (`search_open`, `search_query`, `asset_clicked`) are wired per the tracking plan. Data hooks moved to a feature-level `hooks/` folder to match the MVVM architecture.

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/__integrations__/globalSearch.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/__integrations__/globalSearch.integration.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { render, screen } from "@tests/test-renderer";
 import { track } from "~/analytics";
+import { ScreenName } from "~/const";
 import { GlobalSearch } from "../screens/GlobalSearch";
 import { GLOBAL_SEARCH_TEST_IDS } from "../screens/GlobalSearch/testIds";
 
@@ -26,7 +27,7 @@ describe("GlobalSearch screen", () => {
   it("tracks search_open on mount", () => {
     render(<GlobalSearch />);
 
-    expect(track).toHaveBeenCalledWith("search_open");
+    expect(track).toHaveBeenCalledWith("search_open", { page: ScreenName.GlobalSearch });
   });
 
   it("navigates back when the back button is pressed", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/__tests__/useGlobalSearchDefaults.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/__tests__/useGlobalSearchDefaults.test.ts
@@ -9,6 +9,9 @@ jest.mock("@ledgerhq/live-common/dada-client/hooks/useAssetsData");
 jest.mock("@ledgerhq/live-common/dada-client/hooks/useStocksData");
 jest.mock("@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers");
 jest.mock("@ledgerhq/live-common/dada-client/utils/currencySelection");
+jest.mock("@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate", () => ({
+  useUsdToFiatRate: () => ({ rate: 1, status: "ready" }),
+}));
 
 const mockedAssets = jest.mocked(useAssetsData);
 const mockedStocks = jest.mocked(useStocksData);
@@ -94,9 +97,18 @@ describe("useGlobalSearchDefaults", () => {
     expect(result.current.defaultSections.stocks).toHaveLength(0);
   });
 
+  it("flags hasError when the assets query fails", () => {
+    mockedAssets.mockReturnValue({ data: undefined, isLoading: false, isError: true } as never);
+
+    const { result } = renderHook(() => useGlobalSearchDefaults(true));
+
+    expect(result.current.hasError).toBe(true);
+  });
+
   it("does nothing when disabled", () => {
     const { result } = renderHook(() => useGlobalSearchDefaults(false));
 
     expect(result.current.isLoadingDefaults).toBe(false);
+    expect(result.current.hasError).toBe(false);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/__tests__/useGlobalSearchResults.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/__tests__/useGlobalSearchResults.test.ts
@@ -2,10 +2,14 @@ import { renderHook, act } from "@tests/test-renderer";
 import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
 import { selectCurrencyForMetaId } from "@ledgerhq/live-common/dada-client/utils/currencySelection";
 import { track } from "~/analytics";
+import { ScreenName } from "~/const";
 import { useGlobalSearchResults } from "../useGlobalSearchResults";
 
 jest.mock("@ledgerhq/live-common/hooks/useDebounce", () => ({
   useDebounce: (value: string) => value,
+}));
+jest.mock("@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate", () => ({
+  useUsdToFiatRate: () => ({ rate: 1, status: "ready" }),
 }));
 jest.mock("@ledgerhq/live-common/dada-client/hooks/useAssetsData");
 jest.mock("@ledgerhq/live-common/dada-client/utils/currencySelection");
@@ -55,7 +59,10 @@ describe("useGlobalSearchResults", () => {
 
     act(() => result.current.setSearch("bitcoin"));
 
-    expect(track).toHaveBeenCalledWith("search_query", { query: "bitcoin" });
+    expect(track).toHaveBeenCalledWith("search_query", {
+      query: "bitcoin",
+      page: ScreenName.GlobalSearch,
+    });
   });
 
   it("flags hasNoResults when the query returns nothing", () => {
@@ -77,13 +84,14 @@ describe("useGlobalSearchResults", () => {
     expect(result.current.hasNoResults).toBe(false);
   });
 
-  it("does not flag hasNoResults on an error / undefined response", () => {
+  it("flags hasError (not hasNoResults) on an error response", () => {
     mockedAssets.mockReturnValue({ data: undefined, isLoading: false, isError: true } as never);
 
     const { result } = renderHook(() => useGlobalSearchResults());
     act(() => result.current.setSearch("btc"));
 
     expect(result.current.hasNoResults).toBe(false);
+    expect(result.current.hasError).toBe(true);
   });
 
   it("clears the search", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/useGlobalSearchDefaults.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/useGlobalSearchDefaults.ts
@@ -3,6 +3,7 @@ import VersionNumber from "react-native-version-number";
 import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
 import { useStocksData } from "@ledgerhq/live-common/dada-client/hooks/useStocksData";
 import { useStablecoinTickers } from "@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers";
+import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
 import {
   selectTopAssetsByCategory,
   selectTopStocks,
@@ -12,8 +13,8 @@ import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
 import { useSelector } from "~/context/hooks";
 import { counterValueCurrencySelector } from "~/reducers/settings";
 import { useLocale, useTranslation } from "~/context/Locale";
-import { mapDadaMarketToDisplayData } from "../../utils/mapDadaMarketToDisplayData";
-import type { GlobalSearchDefaultSections } from "./types";
+import { mapDadaMarketToDisplayData } from "LLM/features/GlobalSearch/utils/mapDadaMarketToDisplayData";
+import type { GlobalSearchDefaultSections } from "LLM/features/GlobalSearch/screens/GlobalSearch/types";
 
 const PRODUCT = "llm";
 const MAX_CRYPTOS = 3;
@@ -23,6 +24,7 @@ const MAX_STOCKS = 20;
 export type GlobalSearchDefaults = {
   defaultSections: GlobalSearchDefaultSections;
   isLoadingDefaults: boolean;
+  hasError: boolean;
 };
 
 export function useGlobalSearchDefaults(enabled: boolean): GlobalSearchDefaults {
@@ -31,6 +33,7 @@ export function useGlobalSearchDefaults(enabled: boolean): GlobalSearchDefaults 
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const counterCurrency = counterValueCurrency.ticker.toLowerCase();
   const counterValueUnit = counterValueCurrency.units[0];
+  const { rate: usdToFiatRate, status: rateStatus } = useUsdToFiatRate(counterValueCurrency.ticker);
   const version = VersionNumber.appVersion ?? "";
   const skip = !enabled;
 
@@ -39,7 +42,11 @@ export function useGlobalSearchDefaults(enabled: boolean): GlobalSearchDefaults 
     version,
     skip,
   );
-  const { data: assetsData, isLoading: loadingAssets } = useAssetsData({
+  const {
+    data: assetsData,
+    isLoading: loadingAssets,
+    isError: assetsError,
+  } = useAssetsData({
     product: PRODUCT,
     version,
     skip,
@@ -67,7 +74,7 @@ export function useGlobalSearchDefaults(enabled: boolean): GlobalSearchDefaults 
         mapDadaMarketToDisplayData(
           { id: meta.id, name: meta.name, ticker: meta.ticker, ledgerId: currency.id },
           market,
-          { counterCurrency, counterValueUnit, locale, t },
+          { counterCurrency, counterValueUnit, usdToFiatRate, locale, t },
         ),
       );
 
@@ -75,7 +82,7 @@ export function useGlobalSearchDefaults(enabled: boolean): GlobalSearchDefaults 
       cryptos: toDisplay(categorized.cryptos),
       stablecoins: toDisplay(categorized.stablecoins),
     };
-  }, [assetsData, stablecoinTickers, counterCurrency, counterValueUnit, locale, t]);
+  }, [assetsData, stablecoinTickers, counterCurrency, counterValueUnit, usdToFiatRate, locale, t]);
 
   const stocks = useMemo(
     () => (stocksData ? selectTopStocks(stocksData, MAX_STOCKS) : []),
@@ -89,6 +96,8 @@ export function useGlobalSearchDefaults(enabled: boolean): GlobalSearchDefaults 
 
   return {
     defaultSections,
-    isLoadingDefaults: enabled && (loadingTickers || loadingAssets || loadingStocks),
+    isLoadingDefaults:
+      enabled && (loadingTickers || loadingAssets || loadingStocks || rateStatus === "loading"),
+    hasError: enabled && assetsError,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/useGlobalSearchResults.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/useGlobalSearchResults.ts
@@ -4,9 +4,11 @@ import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssets
 import { selectCurrencyForMetaId } from "@ledgerhq/live-common/dada-client/utils/currencySelection";
 import { useSearchCommon } from "@ledgerhq/live-common/modularDrawer/hooks/useSearch";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
+import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
 import { mapDadaMarketToDisplayData } from "LLM/features/GlobalSearch/utils/mapDadaMarketToDisplayData";
 import { track } from "~/analytics";
+import { ScreenName } from "~/const";
 import { useSelector } from "~/context/hooks";
 import { counterValueCurrencySelector } from "~/reducers/settings";
 import { useLocale, useTranslation } from "~/context/Locale";
@@ -22,6 +24,7 @@ export type GlobalSearchResults = {
   searchResults: MarketAssetDisplayData[];
   isLoadingSearch: boolean;
   hasNoResults: boolean;
+  hasError: boolean;
 };
 
 export function useGlobalSearchResults(): GlobalSearchResults {
@@ -30,9 +33,13 @@ export function useGlobalSearchResults(): GlobalSearchResults {
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const counterCurrency = counterValueCurrency.ticker.toLowerCase();
   const counterValueUnit = counterValueCurrency.units[0];
+  const { rate: usdToFiatRate, status: rateStatus } = useUsdToFiatRate(counterValueCurrency.ticker);
   const version = VersionNumber.appVersion ?? "";
 
-  const handleTrackSearch = useCallback((query: string) => track("search_query", { query }), []);
+  const handleTrackSearch = useCallback(
+    (query: string) => track("search_query", { query, page: ScreenName.GlobalSearch }),
+    [],
+  );
   const { handleSearch, handleDebouncedChange, displayedValue } = useSearchCommon({
     onTrackSearch: handleTrackSearch,
   });
@@ -71,13 +78,13 @@ export function useGlobalSearchResults(): GlobalSearchResults {
         mapDadaMarketToDisplayData(
           { id: meta.id, name: meta.name, ticker: meta.ticker, ledgerId: currency.id },
           data.markets[currency.id],
-          { counterCurrency, counterValueUnit, locale, t },
+          { counterCurrency, counterValueUnit, usdToFiatRate, locale, t },
         ),
       ];
     });
-  }, [data, query, counterCurrency, counterValueUnit, locale, t]);
+  }, [data, query, counterCurrency, counterValueUnit, usdToFiatRate, locale, t]);
 
-  const isLoadingSearch = isSearchActive && (isDebouncing || isLoading);
+  const isLoadingSearch = isSearchActive && (isDebouncing || isLoading || rateStatus === "loading");
   const clearSearch = useCallback(() => handleSearch(""), [handleSearch]);
 
   return {
@@ -87,6 +94,7 @@ export function useGlobalSearchResults(): GlobalSearchResults {
     isSearchActive,
     searchResults,
     isLoadingSearch,
+    hasError: isSearchActive && !isLoadingSearch && isError,
     hasNoResults:
       isSearchActive &&
       !isLoadingSearch &&

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/GlobalSearchView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/GlobalSearchView.tsx
@@ -23,6 +23,7 @@ export function GlobalSearchView({
   searchResults,
   isLoadingSearch,
   hasNoResults,
+  hasError,
   onSeeAll,
   onAssetPress,
   onStockPress,
@@ -42,7 +43,8 @@ export function GlobalSearchView({
         flexDirection: "row",
         alignItems: "center",
         minHeight: theme.sizes.s64,
-        paddingHorizontal: theme.spacings.s16,
+        paddingLeft: theme.spacings.s4,
+        paddingRight: theme.spacings.s16,
         paddingVertical: theme.spacings.s8,
         gap: theme.spacings.s8,
       },
@@ -87,12 +89,14 @@ export function GlobalSearchView({
           results={searchResults}
           isLoading={isLoadingSearch}
           hasNoResults={hasNoResults}
+          hasError={hasError}
           onAssetPress={onAssetPress}
         />
       ) : (
         <DefaultSections
           sections={defaultSections}
           isLoading={isLoadingDefaults}
+          hasError={hasError}
           onSeeAll={onSeeAll}
           onAssetPress={onAssetPress}
           onStockPress={onStockPress}

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
@@ -2,8 +2,11 @@ import { renderHook, act } from "@tests/test-renderer";
 import { track } from "~/analytics";
 import { ScreenName } from "~/const";
 import { useGlobalSearchViewModel } from "../useGlobalSearchViewModel";
-import { useGlobalSearchDefaults } from "../useGlobalSearchDefaults";
-import { useGlobalSearchResults, type GlobalSearchResults } from "../useGlobalSearchResults";
+import { useGlobalSearchDefaults } from "LLM/features/GlobalSearch/hooks/useGlobalSearchDefaults";
+import {
+  useGlobalSearchResults,
+  type GlobalSearchResults,
+} from "LLM/features/GlobalSearch/hooks/useGlobalSearchResults";
 
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
@@ -18,8 +21,8 @@ jest.mock("LLM/features/AssetDetail/hooks/useAssetDetailNavigation", () => ({
   useAssetDetailNavigation: () => ({ openFromMarket: mockOpenFromMarket }),
 }));
 
-jest.mock("../useGlobalSearchDefaults");
-jest.mock("../useGlobalSearchResults");
+jest.mock("LLM/features/GlobalSearch/hooks/useGlobalSearchDefaults");
+jest.mock("LLM/features/GlobalSearch/hooks/useGlobalSearchResults");
 
 const mockedDefaults = jest.mocked(useGlobalSearchDefaults);
 const mockedResults = jest.mocked(useGlobalSearchResults);
@@ -34,13 +37,18 @@ const resultsState = (overrides: Partial<GlobalSearchResults> = {}): GlobalSearc
   searchResults: [],
   isLoadingSearch: false,
   hasNoResults: false,
+  hasError: false,
   ...overrides,
 });
 
 describe("useGlobalSearchViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedDefaults.mockReturnValue({ defaultSections: EMPTY_SECTIONS, isLoadingDefaults: false });
+    mockedDefaults.mockReturnValue({
+      defaultSections: EMPTY_SECTIONS,
+      isLoadingDefaults: false,
+      hasError: false,
+    });
     mockedResults.mockReturnValue(resultsState());
   });
 
@@ -50,6 +58,7 @@ describe("useGlobalSearchViewModel", () => {
     mockedDefaults.mockReturnValue({
       defaultSections: { ...EMPTY_SECTIONS, cryptos },
       isLoadingDefaults: true,
+      hasError: false,
     });
     mockedResults.mockReturnValue(resultsState({ searchResults, isLoadingSearch: true }));
 
@@ -59,6 +68,26 @@ describe("useGlobalSearchViewModel", () => {
     expect(result.current.isLoadingDefaults).toBe(true);
     expect(result.current.searchResults).toBe(searchResults);
     expect(result.current.isLoadingSearch).toBe(true);
+  });
+
+  it("surfaces the defaults error when no search is active", () => {
+    mockedDefaults.mockReturnValue({
+      defaultSections: EMPTY_SECTIONS,
+      isLoadingDefaults: false,
+      hasError: true,
+    });
+
+    const { result } = renderHook(() => useGlobalSearchViewModel());
+
+    expect(result.current.hasError).toBe(true);
+  });
+
+  it("surfaces the search error when a search is active", () => {
+    mockedResults.mockReturnValue(resultsState({ isSearchActive: true, hasError: true }));
+
+    const { result } = renderHook(() => useGlobalSearchViewModel());
+
+    expect(result.current.hasError).toBe(true);
   });
 
   it("enables default fetching while no search is active", () => {
@@ -80,7 +109,7 @@ describe("useGlobalSearchViewModel", () => {
   it("tracks search_open on mount", () => {
     renderHook(() => useGlobalSearchViewModel());
 
-    expect(track).toHaveBeenCalledWith("search_open");
+    expect(track).toHaveBeenCalledWith("search_open", { page: ScreenName.GlobalSearch });
   });
 
   it("navigates back when onBack is invoked", () => {
@@ -127,11 +156,23 @@ describe("useGlobalSearchViewModel", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("opens asset detail from a tapped result row", () => {
+  it("opens asset detail and tracks asset_clicked from a tapped result row", () => {
     const { result } = renderHook(() => useGlobalSearchViewModel());
 
-    act(() => result.current.onAssetPress({ id: "bitcoin", ledgerIds: ["bitcoin"] } as never));
+    act(() =>
+      result.current.onAssetPress({
+        id: "bitcoin",
+        name: "Bitcoin",
+        ledgerIds: ["bitcoin"],
+      } as never),
+    );
 
+    expect(track).toHaveBeenCalledWith("asset_clicked", {
+      asset: "Bitcoin",
+      page: ScreenName.GlobalSearch,
+      flow: "global_search",
+      searched: false,
+    });
     expect(mockOpenFromMarket).toHaveBeenCalledWith({
       marketCurrencyId: "bitcoin",
       ledgerCurrencyIds: ["bitcoin"],
@@ -139,17 +180,42 @@ describe("useGlobalSearchViewModel", () => {
     });
   });
 
-  it("opens asset detail from a tapped stock pill", () => {
+  it("marks the asset as searched when a search is active", () => {
+    mockedResults.mockReturnValue(resultsState({ isSearchActive: true }));
+    const { result } = renderHook(() => useGlobalSearchViewModel());
+
+    act(() =>
+      result.current.onAssetPress({
+        id: "bitcoin",
+        name: "Bitcoin",
+        ledgerIds: ["bitcoin"],
+      } as never),
+    );
+
+    expect(track).toHaveBeenCalledWith(
+      "asset_clicked",
+      expect.objectContaining({ asset: "Bitcoin", searched: true }),
+    );
+  });
+
+  it("opens asset detail and tracks asset_clicked from a tapped stock pill", () => {
     const { result } = renderHook(() => useGlobalSearchViewModel());
 
     act(() =>
       result.current.onStockPress({
         id: "aapl",
+        name: "Apple",
         navigationId: "aapl-market",
         ledgerId: "aapl-ledger",
       } as never),
     );
 
+    expect(track).toHaveBeenCalledWith("asset_clicked", {
+      asset: "Apple",
+      page: ScreenName.GlobalSearch,
+      flow: "global_search",
+      searched: false,
+    });
     expect(mockOpenFromMarket).toHaveBeenCalledWith({
       marketCurrencyId: "aapl-market",
       ledgerCurrencyIds: ["aapl-ledger"],

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/DefaultSections/__tests__/DefaultSections.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/DefaultSections/__tests__/DefaultSections.test.tsx
@@ -34,6 +34,7 @@ const renderSections = (overrides = {}) => {
   const props = {
     sections,
     isLoading: false,
+    hasError: false,
     onSeeAll: jest.fn(),
     onAssetPress: jest.fn(),
     onStockPress: jest.fn(),
@@ -82,6 +83,13 @@ describe("DefaultSections", () => {
 
     expect(screen.getAllByTestId("global-search-asset-skeleton").length).toBeGreaterThan(0);
     expect(screen.getByTestId(GLOBAL_SEARCH_TEST_IDS.cryptosSection)).toBeVisible();
+  });
+
+  it("shows the error state instead of the sections when the data fails", () => {
+    renderSections({ hasError: true, sections: { cryptos: [], stablecoins: [], stocks: [] } });
+
+    expect(screen.getByTestId(GLOBAL_SEARCH_TEST_IDS.defaultsError)).toBeVisible();
+    expect(screen.queryByTestId(GLOBAL_SEARCH_TEST_IDS.defaultSections)).toBeNull();
   });
 
   it("hides empty sections when not loading", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/DefaultSections/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/DefaultSections/index.tsx
@@ -2,11 +2,13 @@ import React from "react";
 import { ScrollView } from "react-native";
 import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { Warning } from "@ledgerhq/lumen-ui-rnative/symbols";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useTranslation } from "~/context/Locale";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
 import { AssetRowsSection } from "../AssetRowsSection";
 import { StocksSection } from "../StocksSection";
+import { StatusView } from "../StatusView";
 import { GLOBAL_SEARCH_TEST_IDS } from "../../testIds";
 import type { GlobalSearchCategory } from "../../useGlobalSearchViewModel";
 import type { GlobalSearchDefaultSections } from "../../types";
@@ -14,6 +16,7 @@ import type { GlobalSearchDefaultSections } from "../../types";
 type Props = Readonly<{
   sections: GlobalSearchDefaultSections;
   isLoading: boolean;
+  hasError: boolean;
   onSeeAll: (category: GlobalSearchCategory) => void;
   onAssetPress: (asset: MarketAssetDisplayData) => void;
   onStockPress: (stock: StockSuggestion) => void;
@@ -22,11 +25,22 @@ type Props = Readonly<{
 export function DefaultSections({
   sections,
   isLoading,
+  hasError,
   onSeeAll,
   onAssetPress,
   onStockPress,
 }: Props) {
   const { t } = useTranslation();
+
+  if (hasError) {
+    return (
+      <StatusView
+        icon={Warning}
+        message={t("market.assets.error.title")}
+        testID={GLOBAL_SEARCH_TEST_IDS.defaultsError}
+      />
+    );
+  }
 
   return (
     <ScrollView

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/SearchResults/__tests__/SearchResults.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/SearchResults/__tests__/SearchResults.test.tsx
@@ -22,6 +22,7 @@ const renderResults = (overrides = {}) => {
     results,
     isLoading: false,
     hasNoResults: false,
+    hasError: false,
     onAssetPress: jest.fn(),
     ...overrides,
   };
@@ -48,6 +49,13 @@ describe("SearchResults", () => {
     renderResults({ hasNoResults: true, results: [] });
 
     expect(screen.getByTestId(GLOBAL_SEARCH_TEST_IDS.searchEmptyState)).toBeVisible();
+    expect(screen.queryByTestId(GLOBAL_SEARCH_TEST_IDS.searchResults)).toBeNull();
+  });
+
+  it("shows the error state when the query fails", () => {
+    renderResults({ hasError: true, results: [] });
+
+    expect(screen.getByTestId(GLOBAL_SEARCH_TEST_IDS.searchError)).toBeVisible();
     expect(screen.queryByTestId(GLOBAL_SEARCH_TEST_IDS.searchResults)).toBeNull();
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/SearchResults/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/SearchResults/index.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback } from "react";
 import { FlatList, View, type ListRenderItemInfo } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { Box, Spot, Text } from "@ledgerhq/lumen-ui-rnative";
-import { Search } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { Search, Warning } from "@ledgerhq/lumen-ui-rnative/symbols";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useTranslation } from "~/context/Locale";
 import AssetListItem, {
@@ -10,6 +9,7 @@ import AssetListItem, {
   type MarketAssetDisplayData,
 } from "LLM/components/AssetListItem";
 import { BottomFadeGradient, GRADIENT_HEIGHT } from "LLM/components/BottomFadeGradient";
+import { StatusView } from "../StatusView";
 import { GLOBAL_SEARCH_TEST_IDS } from "../../testIds";
 
 const SKELETON_COUNT = 3;
@@ -18,10 +18,11 @@ type Props = Readonly<{
   results: MarketAssetDisplayData[];
   isLoading: boolean;
   hasNoResults: boolean;
+  hasError: boolean;
   onAssetPress: (asset: MarketAssetDisplayData) => void;
 }>;
 
-export function SearchResults({ results, isLoading, hasNoResults, onAssetPress }: Props) {
+export function SearchResults({ results, isLoading, hasNoResults, hasError, onAssetPress }: Props) {
   const { t } = useTranslation();
   const { bottom } = useSafeAreaInsets();
 
@@ -31,6 +32,16 @@ export function SearchResults({ results, isLoading, hasNoResults, onAssetPress }
     ),
     [onAssetPress],
   );
+
+  if (hasError) {
+    return (
+      <StatusView
+        icon={Warning}
+        message={t("market.assets.error.title")}
+        testID={GLOBAL_SEARCH_TEST_IDS.searchError}
+      />
+    );
+  }
 
   if (isLoading) {
     return (
@@ -44,16 +55,11 @@ export function SearchResults({ results, isLoading, hasNoResults, onAssetPress }
 
   if (hasNoResults) {
     return (
-      <Box lx={emptyStateStyle} testID={GLOBAL_SEARCH_TEST_IDS.searchEmptyState}>
-        <View style={topSpacerStyle} />
-        <Spot appearance="icon" icon={Search} size={72} />
-        <Text
-          typography="heading4SemiBold"
-          lx={{ color: "base", textAlign: "center", marginTop: "s24" }}
-        >
-          {t("modularDrawer.emptyAssetList")}
-        </Text>
-      </Box>
+      <StatusView
+        icon={Search}
+        message={t("modularDrawer.emptyAssetList")}
+        testID={GLOBAL_SEARCH_TEST_IDS.searchEmptyState}
+      />
     );
   }
 
@@ -83,9 +89,3 @@ const listStyle = { flex: 1 };
 const contentContainerStyle = { paddingTop: 8, paddingHorizontal: 16 };
 const rowStyle: LumenViewStyle = { marginHorizontal: "-s8" };
 const skeletonStyle: LumenViewStyle = { paddingTop: "s8", paddingHorizontal: "s16" };
-const emptyStateStyle: LumenViewStyle = {
-  flex: 1,
-  alignItems: "center",
-  paddingHorizontal: "s16",
-};
-const topSpacerStyle = { height: "30%" } as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/StatusView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/StatusView/index.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { View } from "react-native";
+import { Box, Spot, Text } from "@ledgerhq/lumen-ui-rnative";
+import type { SpotProps } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+
+type Props = Readonly<{
+  icon: Extract<SpotProps, { appearance: "icon" }>["icon"];
+  message: string;
+  testID?: string;
+}>;
+
+export function StatusView({ icon, message, testID }: Props) {
+  return (
+    <Box lx={statusStyle} testID={testID}>
+      <View style={topSpacerStyle} />
+      <Spot appearance="icon" icon={icon} size={72} />
+      <Text
+        typography="heading4SemiBold"
+        lx={{ color: "base", textAlign: "center", marginTop: "s24" }}
+      >
+        {message}
+      </Text>
+    </Box>
+  );
+}
+
+const statusStyle: LumenViewStyle = { flex: 1, alignItems: "center", paddingHorizontal: "s16" };
+const topSpacerStyle = { height: "30%" } as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/testIds.ts
@@ -8,4 +8,6 @@ export const GLOBAL_SEARCH_TEST_IDS = {
   searchResults: "global-search-results",
   searchSkeleton: "global-search-results-skeleton",
   searchEmptyState: "global-search-empty-state",
+  searchError: "global-search-error-state",
+  defaultsError: "global-search-defaults-error-state",
 } as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
@@ -7,11 +7,13 @@ import { ScreenName } from "~/const";
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
 import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
-import { useGlobalSearchDefaults } from "./useGlobalSearchDefaults";
-import { useGlobalSearchResults } from "./useGlobalSearchResults";
+import { useGlobalSearchDefaults } from "LLM/features/GlobalSearch/hooks/useGlobalSearchDefaults";
+import { useGlobalSearchResults } from "LLM/features/GlobalSearch/hooks/useGlobalSearchResults";
 import type { GlobalSearchDefaultSections } from "./types";
 
 export type GlobalSearchCategory = "crypto" | "stable" | "stocks";
+
+const SEARCH_FLOW = "global_search";
 
 export type GlobalSearchViewModel = {
   search: string;
@@ -21,6 +23,7 @@ export type GlobalSearchViewModel = {
   isLoadingDefaults: boolean;
   isLoadingSearch: boolean;
   hasNoResults: boolean;
+  hasError: boolean;
   defaultSections: GlobalSearchDefaultSections;
   searchResults: MarketAssetDisplayData[];
   onBack: () => void;
@@ -41,11 +44,18 @@ export function useGlobalSearchViewModel(): GlobalSearchViewModel {
     searchResults,
     isLoadingSearch,
     hasNoResults,
+    hasError: hasSearchError,
   } = useGlobalSearchResults();
-  const { defaultSections, isLoadingDefaults } = useGlobalSearchDefaults(!isSearchActive);
+  const {
+    defaultSections,
+    isLoadingDefaults,
+    hasError: hasDefaultsError,
+  } = useGlobalSearchDefaults(!isSearchActive);
+
+  const hasError = isSearchActive ? hasSearchError : hasDefaultsError;
 
   useEffect(() => {
-    track("search_open");
+    track("search_open", { page: ScreenName.GlobalSearch });
   }, []);
 
   const onBack = useCallback(() => navigation.goBack(), [navigation]);
@@ -64,22 +74,36 @@ export function useGlobalSearchViewModel(): GlobalSearchViewModel {
   );
 
   const onAssetPress = useCallback(
-    (asset: MarketAssetDisplayData) =>
+    (asset: MarketAssetDisplayData) => {
+      track("asset_clicked", {
+        asset: asset.name,
+        page: ScreenName.GlobalSearch,
+        flow: SEARCH_FLOW,
+        searched: isSearchActive,
+      });
       openFromMarket({
         marketCurrencyId: asset.id,
         ledgerCurrencyIds: asset.ledgerIds,
         source: ScreenName.GlobalSearch,
-      }),
-    [openFromMarket],
+      });
+    },
+    [openFromMarket, isSearchActive],
   );
 
   const onStockPress = useCallback(
-    (stock: StockSuggestion) =>
+    (stock: StockSuggestion) => {
+      track("asset_clicked", {
+        asset: stock.name,
+        page: ScreenName.GlobalSearch,
+        flow: SEARCH_FLOW,
+        searched: false,
+      });
       openFromMarket({
         marketCurrencyId: stock.navigationId,
         ledgerCurrencyIds: [stock.ledgerId],
         source: ScreenName.GlobalSearch,
-      }),
+      });
+    },
     [openFromMarket],
   );
 
@@ -91,6 +115,7 @@ export function useGlobalSearchViewModel(): GlobalSearchViewModel {
     isLoadingDefaults,
     isLoadingSearch,
     hasNoResults,
+    hasError,
     defaultSections,
     searchResults,
     onBack,

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/utils/__tests__/mapDadaMarketToDisplayData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/utils/__tests__/mapDadaMarketToDisplayData.test.ts
@@ -3,8 +3,25 @@ import { mapDadaMarketToDisplayData } from "../mapDadaMarketToDisplayData";
 
 const usd = { name: "US Dollar", code: "USD", magnitude: 2 } as Unit;
 const t = ((key: string) => key) as never;
-const options = { counterCurrency: "usd", counterValueUnit: usd, locale: "en", t };
+const options = {
+  counterCurrency: "usd",
+  counterValueUnit: usd,
+  usdToFiatRate: 1,
+  locale: "en",
+  t,
+};
 const meta = { id: "meta:bitcoin", name: "Bitcoin", ticker: "btc", ledgerId: "bitcoin" };
+
+const market = {
+  id: "bitcoin",
+  name: "Bitcoin",
+  ticker: "BTC",
+  ledgerIds: ["bitcoin"],
+  price: 92000,
+  marketCap: 1_800_000_000_000,
+  marketCapRank: 1,
+  priceChangePercentage24h: 7.87,
+};
 
 describe("mapDadaMarketToDisplayData", () => {
   it("maps market fields and uppercases the ticker", () => {
@@ -41,6 +58,21 @@ describe("mapDadaMarketToDisplayData", () => {
     expect(result.ledgerIds).toEqual(["bitcoin"]);
     expect(result.marketcapRank).toBe(0);
     expect(result.priceChangePercentage).toBe(0);
+    expect(result.formattedMarketCap).toBe("-");
+  });
+
+  it("converts the USD price and market cap by the usd→fiat rate", () => {
+    const atRate1 = mapDadaMarketToDisplayData(meta, market, { ...options, usdToFiatRate: 1 });
+    const atRate2 = mapDadaMarketToDisplayData(meta, market, { ...options, usdToFiatRate: 2 });
+
+    expect(atRate2.formattedPrice).not.toBe(atRate1.formattedPrice);
+    expect(atRate2.formattedMarketCap).not.toBe(atRate1.formattedMarketCap);
+  });
+
+  it("shows '-' while the usd→fiat rate is unresolved", () => {
+    const result = mapDadaMarketToDisplayData(meta, market, { ...options, usdToFiatRate: null });
+
+    expect(result.formattedPrice).toBe("-");
     expect(result.formattedMarketCap).toBe("-");
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/utils/mapDadaMarketToDisplayData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/utils/mapDadaMarketToDisplayData.ts
@@ -18,6 +18,8 @@ type AssetMeta = {
 type MapOptions = {
   counterCurrency: string;
   counterValueUnit: Unit;
+  /** USD → counter-value spot rate (DADA prices are in USD). `null` while it resolves. */
+  usdToFiatRate: number | null;
   locale: string;
   t: TFunction;
 };
@@ -25,13 +27,19 @@ type MapOptions = {
 export function mapDadaMarketToDisplayData(
   meta: AssetMeta,
   market: PartialMarketItemResponse | undefined,
-  { counterCurrency, counterValueUnit, locale, t }: MapOptions,
+  { counterCurrency, counterValueUnit, usdToFiatRate, locale, t }: MapOptions,
 ): MarketAssetDisplayData {
   const change = market?.priceChangePercentage24h;
   const priceChangePercentage = typeof change === "number" && Number.isFinite(change) ? change : 0;
-  const priceAtoms = new BigNumber(market?.price ?? 0).times(
-    new BigNumber(10).pow(counterValueUnit.magnitude),
-  );
+
+  const marketCap =
+    usdToFiatRate != null && market?.marketCap != null ? market.marketCap * usdToFiatRate : null;
+  const priceAtoms =
+    usdToFiatRate == null
+      ? null
+      : new BigNumber(market?.price ?? 0)
+          .times(usdToFiatRate)
+          .times(new BigNumber(10).pow(counterValueUnit.magnitude));
 
   return {
     id: dadaIdToMarketId(market?.id ?? meta.id),
@@ -39,17 +47,20 @@ export function mapDadaMarketToDisplayData(
     ticker: (market?.ticker ?? meta.ticker).toUpperCase(),
     ledgerIds: market?.ledgerIds?.length ? market.ledgerIds : [meta.ledgerId],
     formattedMarketCap:
-      market?.marketCap == null
+      marketCap == null
         ? "-"
         : counterValueFormatter({
             currency: counterCurrency,
-            value: market.marketCap,
+            value: marketCap,
             shorten: true,
             locale,
             t,
           }),
     marketcapRank: market?.marketCapRank ?? 0,
-    formattedPrice: formatPrice(counterValueUnit, priceAtoms, { locale, showCode: true }),
+    formattedPrice:
+      priceAtoms == null
+        ? "-"
+        : formatPrice(counterValueUnit, priceAtoms, { locale, showCode: true }),
     priceChangePercentage,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Updated mapper/hook/VM/component tests + integration: USD→fiat conversion, error states (results + default views), tracking payloads, hook relocation. 47 GlobalSearch tests pass.
- [x] **Impact of the changes:**
  - Prices in Global Search now match the user's counter-value currency.
  - Results and default views show an error state on failure (no more blank screen).
  - QA focus: switch counter-value currency in settings → search/default prices update; back button alignment vs other screens; error state when offline; `search_open`/`search_query`/`asset_clicked` events.

### 📝 Description

Polish pass on **Global Search**.

- **Countervalues from settings** — DADA prices are in USD; we now convert price + market cap via `useUsdToFiatRate(counterValueCurrency.ticker)` before formatting, mirroring the Modular Asset Drawer (`useRightMarketTrendModule`). Rows show skeletons until the rate resolves and `-` if it can't.
- **Error state** — `useGlobalSearchResults` and `useGlobalSearchDefaults` expose `hasError`; the results and default views render a shared `StatusView` (Warning + "Couldn't load assets") on failure.
- **Back button position** — header aligns to the standard NavBar left offset (`paddingLeft: s4`) instead of `s16`.
- **Tracking** (GlobalSearch only, per the [tracking plan](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7001079809/Asset+discoverability+-+Tracking+Plan)) — `search_open` + `page`, `search_query` + `page`, and `asset_clicked` on row/pill tap (`asset`, `page`, `flow: "global_search"`, `searched`). The category-header `button_clicked` already lands in LIVE-30048.
- **MVVM** — moved `useGlobalSearchResults` / `useGlobalSearchDefaults` to a feature-level `hooks/` folder; the screen keeps `useGlobalSearchViewModel`.


https://github.com/user-attachments/assets/40f3b826-c58d-4d4e-be8e-df61742d8fca


error state:


https://github.com/user-attachments/assets/fe447f32-9046-4f00-a92a-56b7e55a9ce1



### ❓ Context

- **JIRA**: [LIVE-32202](https://ledgerhq.atlassian.net/browse/LIVE-32202) — Epic [LIVE-27854](https://ledgerhq.atlassian.net/browse/LIVE-27854)
- **Stacked on** [#18433](https://github.com/LedgerHQ/ledger-live/pull/18433) (LIVE-30047, which now also contains the LIVE-30048 navigation).
- **Note**: the Stablecoins "See all" stays a no-op (no Market stablecoins category yet — LIVE-30040).

[LIVE-32202]: https://ledgerhq.atlassian.net/browse/LIVE-32202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ