### PR TITLE
[LWD] feat(desktop): add dynamic trending categories to market category bar

### DIFF
--- a/.changeset/plenty-ligers-design.md
+++ b/.changeset/plenty-ligers-design.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add dynamic trending categories to the Market category bar. Trending categories from the `/v3/categories/trending` backend endpoint are appended after the built-in categories (All / Stocks / Favorites), deduplicated against built-ins, and filter the market list when selected. The category bar now sizes each chip to its label and scrolls horizontally (scrollbar hidden) when the chips overflow.

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/__integrations__/Market.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/__integrations__/Market.integration.test.tsx
@@ -6,6 +6,7 @@ import { Order } from "@ledgerhq/live-common/market/utils/types";
 import { MOCK_MARKET_CURRENCY_DATA } from "@ledgerhq/live-common/market/utils/fixtures";
 
 const MARKET_API_ENDPOINT = "https://countervalues.live.ledger.com/v3/markets";
+const TRENDING_CATEGORIES_ENDPOINT = "https://countervalues.live.ledger.com/v3/categories/trending";
 
 const mockNavigate = jest.fn();
 
@@ -363,6 +364,43 @@ describe("Market Integration", () => {
     const sellButton = screen.getByTestId("market-BTC-sell-button");
     expect(sellButton).toBeInTheDocument();
     expect(sellButton).toBeVisible();
+  });
+
+  it("should append trending categories after the built-in tabs and filter the list when selected", async () => {
+    const marketRequests: URL[] = [];
+
+    server.use(
+      http.get(TRENDING_CATEGORIES_ENDPOINT, () => {
+        return HttpResponse.json([{ id: "infrastructure", name: "Infrastructure" }]);
+      }),
+      http.get(MARKET_API_ENDPOINT, ({ request }) => {
+        marketRequests.push(new URL(request.url));
+        return HttpResponse.json(MOCK_MARKET_CURRENCY_DATA);
+      }),
+    );
+
+    const { user } = render(<Market />, {
+      withRampCatalog: true,
+      initialState: {
+        market: createMarketState(),
+        settings: createSettingsState(),
+        ...marketWithTopCardsOn,
+      },
+    });
+
+    const trendingChip = await screen.findByTestId("market-category-switcher-infrastructure");
+    expect(trendingChip).toHaveTextContent("Infrastructure");
+    expect(screen.getByTestId("market-category-switcher-all")).toBeVisible();
+    expect(screen.getByTestId("market-category-switcher-stocks")).toBeVisible();
+    expect(screen.getByTestId("market-category-switcher-starred")).toBeVisible();
+
+    await user.click(trendingChip);
+
+    await waitFor(() => {
+      expect(
+        marketRequests.some(url => url.searchParams.get("categories") === "infrastructure"),
+      ).toBe(true);
+    });
   });
 
   it("should navigate to exchange with sell state when sell button is clicked", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketCategoryBar.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketCategoryBar.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback } from "react";
 import { SegmentedControl, SegmentedControlButton } from "@ledgerhq/lumen-ui-react";
 import { TFunction } from "i18next";
-import type { MarketListCategory } from "~/renderer/reducers/market";
 import type { MarketCategories } from "../hooks/useMarketCategories";
+import type { MarketListCategory } from "@ledgerhq/live-common/market/utils/category";
 
 type MarketCategoryBarProps = {
   categories: MarketCategories;
@@ -18,23 +18,27 @@ export function MarketCategoryBar({ categories, t }: Readonly<MarketCategoryBarP
   );
 
   return (
-    <SegmentedControl
-      selectedValue={selectedCategory}
-      onSelectedChange={onSelectedChange}
-      aria-label={t("market.assets.categories.accessibilityLabel")}
-      data-testid="market-category-switcher"
-      className="w-[50%] xl:w-[25%]"
-    >
-      {tabs.map(tab => (
-        <SegmentedControlButton
-          key={tab.value}
-          className="shrink-1"
-          value={tab.value}
-          data-testid={`market-category-switcher-${tab.value}`}
-        >
-          {t(tab.labelKey)}
-        </SegmentedControlButton>
-      ))}
-    </SegmentedControl>
+    // Reserve the row's remaining space and scroll horizontally when the trending chips overflow.
+    // Scrolling stays enabled, but the scrollbar itself is hidden across engines.
+    <div className="min-w-0 flex-1 overflow-x-auto mr-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <SegmentedControl
+        selectedValue={selectedCategory}
+        onSelectedChange={onSelectedChange}
+        tabLayout="fit"
+        aria-label={t("market.assets.categories.accessibilityLabel")}
+        data-testid="market-category-switcher"
+        className="w-fit"
+      >
+        {tabs.map(tab => (
+          <SegmentedControlButton
+            key={tab.value}
+            value={tab.value}
+            data-testid={`market-category-switcher-${tab.value}`}
+          >
+            {tab.label ?? (tab.labelKey ? t(tab.labelKey) : tab.value)}
+          </SegmentedControlButton>
+        ))}
+      </SegmentedControl>
+    </div>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/__tests__/MarketCategoryBar.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/__tests__/MarketCategoryBar.test.tsx
@@ -35,4 +35,17 @@ describe("MarketCategoryBar", () => {
 
     expect(onSelectCategory).toHaveBeenCalledWith("stocks");
   });
+
+  it("renders a trending tab's raw label as-is (no translation)", () => {
+    const categories = buildCategories({
+      tabs: [
+        { value: "all", labelKey: "market.assets.categories.all" },
+        { value: "infrastructure", label: "Infrastructure" },
+      ],
+    });
+    render(<MarketCategoryBar categories={categories} t={t} />);
+
+    const trendingTab = screen.getByTestId("market-category-switcher-infrastructure");
+    expect(trendingTab).toHaveTextContent("Infrastructure");
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarketCategories.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarketCategories.test.ts
@@ -1,8 +1,24 @@
-import { act, renderHook } from "tests/testSetup";
+import { act, renderHook, withFlagOverrides } from "tests/testSetup";
 import { Order } from "@ledgerhq/live-common/market/utils/types";
+import { useGetTrendingCategoriesQuery } from "@ledgerhq/live-common/market/state-manager/api";
 import type { MarketListCategory } from "~/renderer/reducers/market";
 import { track } from "~/renderer/analytics/segment";
 import { useMarketCategories } from "../useMarketCategories";
+
+jest.mock("@ledgerhq/live-common/market/state-manager/api", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/market/state-manager/api"),
+  useGetTrendingCategoriesQuery: jest.fn(),
+}));
+
+const mockedUseTrending = useGetTrendingCategoriesQuery as jest.Mock;
+
+const assetDiscoverabilityOn = withFlagOverrides({
+  lwdWallet40: { enabled: true, params: { assetDiscoverability: true } },
+});
+
+const assetDiscoverabilityOff = withFlagOverrides({
+  lwdWallet40: { enabled: false },
+});
 
 const createMarketState = (category: MarketListCategory = "all") => ({
   marketParams: {
@@ -20,22 +36,29 @@ const createMarketState = (category: MarketListCategory = "all") => ({
   category,
 });
 
-describe("useMarketCategories", () => {
-  beforeEach(() => jest.clearAllMocks());
+const renderCategories = (category: MarketListCategory = "all", flags = assetDiscoverabilityOn) =>
+  renderHook(() => useMarketCategories(), {
+    initialState: {
+      ...flags,
+      market: createMarketState(category),
+    },
+  });
 
-  it("exposes the persisted category and the ordered tabs", () => {
-    const { result } = renderHook(() => useMarketCategories(), {
-      initialState: { market: createMarketState("all") },
-    });
+describe("useMarketCategories", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseTrending.mockReturnValue({ data: undefined });
+  });
+
+  it("exposes the persisted category and the built-in tabs", () => {
+    const { result } = renderCategories("all");
 
     expect(result.current.selectedCategory).toBe("all");
     expect(result.current.tabs.map(tab => tab.value)).toEqual(["all", "stocks", "starred"]);
   });
 
   it("selects a new category and tracks the tap", () => {
-    const { result } = renderHook(() => useMarketCategories(), {
-      initialState: { market: createMarketState("all") },
-    });
+    const { result } = renderCategories("all");
 
     act(() => result.current.onSelectCategory("stocks"));
 
@@ -48,12 +71,80 @@ describe("useMarketCategories", () => {
   });
 
   it("does not change state when re-selecting the active category", () => {
-    const { result } = renderHook(() => useMarketCategories(), {
-      initialState: { market: createMarketState("starred") },
-    });
+    const { result } = renderCategories("starred");
 
     act(() => result.current.onSelectCategory("starred"));
 
     expect(result.current.selectedCategory).toBe("starred");
+  });
+
+  it("appends trending categories after the built-in tabs, using their raw label", () => {
+    mockedUseTrending.mockReturnValue({
+      data: [{ id: "infrastructure", name: "Infrastructure" }],
+    });
+
+    const { result } = renderCategories("all");
+
+    expect(result.current.tabs.map(tab => tab.value)).toEqual([
+      "all",
+      "stocks",
+      "starred",
+      "infrastructure",
+    ]);
+    expect(result.current.tabs.at(-1)).toEqual({
+      value: "infrastructure",
+      label: "Infrastructure",
+    });
+  });
+
+  it("deduplicates trending ids that collide with a built-in category", () => {
+    mockedUseTrending.mockReturnValue({
+      data: [
+        { id: "stocks", name: "Stocks duplicate" },
+        { id: "infrastructure", name: "Infrastructure" },
+      ],
+    });
+
+    const { result } = renderCategories("all");
+
+    expect(result.current.tabs.map(tab => tab.value)).toEqual([
+      "all",
+      "stocks",
+      "starred",
+      "infrastructure",
+    ]);
+  });
+
+  it("selects a trending category and tracks the tap", () => {
+    mockedUseTrending.mockReturnValue({
+      data: [{ id: "infrastructure", name: "Infrastructure" }],
+    });
+
+    const { result } = renderCategories("all");
+
+    act(() => result.current.onSelectCategory("infrastructure"));
+
+    expect(result.current.selectedCategory).toBe("infrastructure");
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "category",
+      category: "infrastructure",
+      page: "Market",
+    });
+  });
+
+  it("falls back to 'all' when the persisted trending id is no longer trending", () => {
+    mockedUseTrending.mockReturnValue({
+      data: [{ id: "infrastructure", name: "Infrastructure" }],
+    });
+
+    const { result } = renderCategories("gaming");
+
+    expect(result.current.selectedCategory).toBe("all");
+  });
+
+  it("skips the trending request when asset discoverability is off", () => {
+    renderCategories("all", assetDiscoverabilityOff);
+
+    expect(mockedUseTrending).toHaveBeenCalledWith(undefined, { skip: true });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
@@ -23,7 +23,9 @@ import {
 import { addStarredMarketCoins, removeStarredMarketCoins } from "~/renderer/actions/settings";
 import { useMarketCategories } from "LLD/features/Market/hooks/useMarketCategories";
 import {
+  getMarketCategoriesParam,
   getMarketFilter,
+  isBuiltInMarketListCategory,
   isStockMarketCurrency,
 } from "@ledgerhq/live-common/market/utils/category";
 
@@ -59,6 +61,8 @@ export function useMarket() {
     shouldDisplayAssetDiscoverability && categories.selectedCategory === "starred";
   const isStocksCategory =
     shouldDisplayAssetDiscoverability && categories.selectedCategory === "stocks";
+  const isTrendingCategory =
+    shouldDisplayAssetDiscoverability && !isBuiltInMarketListCategory(categories.selectedCategory);
 
   const starFilterOn = isStarredCategory || starred.length > 0;
 
@@ -77,6 +81,9 @@ export function useMarket() {
     starred: starFilterOn ? starredMarketCoins : starred,
     liveCompatible: shouldDisplayLiveCompatible,
     filter: getMarketFilter(isStocksCategory) ?? marketParams.filter,
+    categories: isTrendingCategory
+      ? getMarketCategoriesParam(categories.selectedCategory)
+      : undefined,
   });
 
   const timeRanges = useMemo(
@@ -118,7 +125,9 @@ export function useMarket() {
   const freshLoading = loading && !currenciesLength;
   // The extra row is the "show all" affordance, only relevant for the unfiltered list.
   const itemCount =
-    starFilterOn || isStocksCategory || search.length > 0 ? currenciesLength : currenciesLength + 1;
+    starFilterOn || isStocksCategory || isTrendingCategory || search.length > 0
+      ? currenciesLength
+      : currenciesLength + 1;
 
   const setCounterCurrency = useCallback(
     (ticker: string) => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketCategories.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketCategories.ts
@@ -1,4 +1,7 @@
 import { useCallback, useMemo } from "react";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import { useGetTrendingCategoriesQuery } from "@ledgerhq/live-common/market/state-manager/api";
+import { isBuiltInMarketListCategory } from "@ledgerhq/live-common/market/utils/category";
 import { track } from "~/renderer/analytics/segment";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import {
@@ -8,11 +11,10 @@ import {
 } from "~/renderer/actions/market";
 import { marketCategorySelector, type MarketListCategory } from "~/renderer/reducers/market";
 
-const SELECTABLE_MARKET_CATEGORIES = new Set<MarketListCategory>(["all", "stocks", "starred"]);
-
 export type MarketCategoryTab = {
   value: MarketListCategory;
-  labelKey: string;
+  labelKey?: string;
+  label?: string;
 };
 
 export type MarketCategories = {
@@ -21,15 +23,11 @@ export type MarketCategories = {
   onSelectCategory: (category: MarketListCategory) => void;
 };
 
-const categoryTabs: MarketCategoryTab[] = [
+const BUILT_IN_CATEGORY_TABS: MarketCategoryTab[] = [
   { value: "all", labelKey: "market.assets.categories.all" },
   { value: "stocks", labelKey: "market.assets.categories.stocks" },
   { value: "starred", labelKey: "market.assets.categories.favorites" },
 ];
-
-function isSelectableMarketCategory(category: MarketListCategory): boolean {
-  return SELECTABLE_MARKET_CATEGORIES.has(category);
-}
 
 function trackCategoryTap(category: MarketListCategory) {
   track("button_clicked", {
@@ -42,15 +40,32 @@ function trackCategoryTap(category: MarketListCategory) {
 export function useMarketCategories(): MarketCategories {
   const dispatch = useDispatch();
   const persistedCategory = useSelector(marketCategorySelector);
-  const selectedCategory = isSelectableMarketCategory(persistedCategory)
-    ? persistedCategory
-    : "all";
+  const { shouldDisplayAssetDiscoverability } = useWalletFeaturesConfig("desktop");
+
+  const { data: trendingCategories } = useGetTrendingCategoriesQuery(undefined, {
+    skip: !shouldDisplayAssetDiscoverability,
+  });
+
+  const tabs = useMemo<MarketCategoryTab[]>(
+    () => [
+      ...BUILT_IN_CATEGORY_TABS,
+      ...(trendingCategories
+        ?.filter(category => !isBuiltInMarketListCategory(category.id))
+        .map(category => ({ value: category.id, label: category.name })) ?? []),
+    ],
+    [trendingCategories],
+  );
+
+  const selectableCategories = useMemo(() => new Set(tabs.map(tab => tab.value)), [tabs]);
+
+  // Persisted trending ids may no longer be trending after a refresh: fall back to "all".
+  const selectedCategory = selectableCategories.has(persistedCategory) ? persistedCategory : "all";
 
   const onSelectCategory = useCallback(
     (category: MarketListCategory) => {
       trackCategoryTap(category);
 
-      if (!isSelectableMarketCategory(category) || category === persistedCategory) {
+      if (!selectableCategories.has(category) || category === persistedCategory) {
         return;
       }
 
@@ -59,15 +74,15 @@ export function useMarketCategories(): MarketCategories {
       dispatch(setMarketOptions({ page: 1 }));
       dispatch(setMarketCurrentPage(1));
     },
-    [dispatch, persistedCategory],
+    [dispatch, persistedCategory, selectableCategories],
   );
 
   return useMemo(
     () => ({
       selectedCategory,
-      tabs: categoryTabs,
+      tabs,
       onSelectCategory,
     }),
-    [onSelectCategory, selectedCategory],
+    [onSelectCategory, selectedCategory, tabs],
   );
 }

--- a/apps/ledger-live-desktop/src/renderer/reducers/market.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/market.ts
@@ -2,7 +2,9 @@ import { handleActions } from "redux-actions";
 import { Handlers } from "./types";
 import { MarketListRequestParams, Order } from "@ledgerhq/live-common/market/utils/types";
 
-export type MarketListCategory = "all" | "starred" | "stocks";
+import type { MarketListCategory } from "@ledgerhq/live-common/market/utils/category";
+
+export type { MarketListCategory };
 
 export type MarketState = {
   marketParams: MarketListRequestParams;

--- a/apps/ledger-live-desktop/tests/handlers/market.ts
+++ b/apps/ledger-live-desktop/tests/handlers/market.ts
@@ -27,6 +27,9 @@ const handlers = [
       percentageChanges: { "1d": 0.0214 },
     });
   }),
+  http.get("https://countervalues.live.ledger.com/v3/categories/trending", () => {
+    return HttpResponse.json([]);
+  }),
 ];
 
 export default handlers;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Market category bar rendering (built-in + trending chips, ordering, dedup against Stocks)
  - Filtering the market list when a trending category is selected (`categories` query param)
  - Graceful fallback when the trending endpoint is unavailable/empty (built-ins only)
  - Category bar layout: chips sized to their labels, horizontal scroll (scrollbar hidden) when chips overflow
  - The trending request is only fired when asset discoverability is enabled

### 📝 Description

The Market category bar on Desktop only exposed the fixed categories (All / Stocks / Favorites). Product wants the bar to also surface dynamic "trending" categories coming from Backend Core, appended after the fixed entries, filtering the list when selected.

The shared layer for this already existed in `ledger-live-common` (the `/v3/categories/trending` RTK Query endpoint, the extensible `MarketListCategory` type, and the `categories` param plumbing through `useMarketData` → `fetchList`), and mobile already shipped the feature. This PR ports that pattern to Desktop:

- Widen the desktop `MarketListCategory` type to the shared extensible type so trending ids are valid state.
- `useMarketCategories` now fetches `useGetTrendingCategoriesQuery` (skipped when asset discoverability is off), appends trending chips as `{ value: id, label: name }`, deduplicates any trending id colliding with a built-in (incl. Stocks), makes trending ids selectable, and falls back to `all` when a persisted trending id is no longer trending.
- `MarketCategoryBar` renders the raw BE label for trending chips, uses `tabLayout="fit"` so each chip sizes to its label, and scrolls horizontally (scrollbar hidden) when chips overflow.
- `useMarket` passes `getMarketCategoriesParam(selectedCategory)` to filter the list and suppresses the trailing "show all" row for a trending selection.

**BE-offline behaviour:** if the endpoint is unavailable or returns nothing, no trending chips appear and the bar shows the built-ins only.

### 📸 Screenshots


https://github.com/user-attachments/assets/d7fc89b0-71b7-4033-98ff-80eb86225fd7


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-29908

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29701]: https://ledgerhq.atlassian.net/browse/LIVE-29701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ