### PR TITLE
[LWD] feat(lld): migrate asset suggestions to DADA & refactor stocks layout

### DIFF
--- a/.changeset/lld-dada-suggestions-stocks-migration.md
+++ b/.changeset/lld-dada-suggestions-stocks-migration.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Migrate the search-overlay asset suggestions to the DADA assets endpoint (`useAssetsData` + `useUsdToFiatRate`) instead of `useMarketData`, exposing an `isError` state for cryptos/stablecoins and stocks. The Stocks section also moves from a CSS grid to an explicit two-row layout (shared `splitIntoTwoRows` helper) to keep the column-major scroll order.

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/AssetSuggestionsSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/AssetSuggestionsSectionView.tsx
@@ -20,7 +20,6 @@ export function AssetSuggestionsSectionView({
   locale,
   counterCurrency,
 }: Readonly<AssetSuggestionsSectionViewProps>) {
-  // Hide empty sections (e.g. backend returned nothing) once loading is done.
   if (!isLoading && data.length === 0) {
     return null;
   }
@@ -38,7 +37,7 @@ export function AssetSuggestionsSectionView({
         </SubheaderRow>
       </Subheader>
       {isLoading ? (
-        <AssetSuggestionsSkeleton count={limit} testIdPrefix={testIdPrefix} />
+        <AssetSuggestionsSkeleton count={limit} testIdPrefix={testIdPrefix} className="-mx-8" />
       ) : (
         <div className="flex flex-col -mx-8" data-testid={`${testIdPrefix}-list`}>
           {data.map(currency => (

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/__integrations__/SearchAssets.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/__integrations__/SearchAssets.integration.test.tsx
@@ -1,78 +1,98 @@
 import React from "react";
 import { render, screen, fireEvent } from "tests/testSetup";
-import { useMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
+import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
 import { useStablecoinTickers } from "@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers";
-import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
+import { AssetsDataWithPagination } from "@ledgerhq/live-common/dada-client/state-manager/types";
 import { useAssetSuggestionsViewModel } from "../hooks/useAssetSuggestionsViewModel";
 import { AssetSuggestionsSection } from "../AssetSuggestionsSection";
 
-jest.mock("@ledgerhq/live-common/market/hooks/useMarketDataProvider");
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useAssetsData");
 jest.mock("@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers");
+jest.mock("@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate");
 
-const mockedUseMarketData = jest.mocked(useMarketData);
+const mockedUseAssetsData = jest.mocked(useAssetsData);
 const mockedUseStablecoinTickers = jest.mocked(useStablecoinTickers);
+const mockedUseUsdToFiatRate = jest.mocked(useUsdToFiatRate);
 
 const CRYPTOS_LIMIT = 3;
 const STABLECOINS_LIMIT = 2;
 
-function buildCurrency(overrides: Partial<MarketCurrencyData>): MarketCurrencyData {
-  return {
-    id: "bitcoin",
-    ledgerIds: ["bitcoin"],
-    name: "Bitcoin",
-    ticker: "BTC",
-    price: 100,
-    marketcap: 1000,
-    marketcapRank: 1,
-    totalVolume: 0,
-    high24h: 0,
-    low24h: 0,
-    priceChangePercentage: { "1h": 0, "24h": 1.23, "7d": 0, "30d": 0, "6m": 0, "1y": 0 },
-    marketCapChangePercentage24h: 0,
-    circulatingSupply: 0,
-    ath: 0,
-    athDate: new Date(),
-    atl: 0,
-    atlDate: new Date(),
-    chartData: {} as MarketCurrencyData["chartData"],
-    ...overrides,
-  } as MarketCurrencyData;
-}
+type AssetDescriptor = {
+  id: string;
+  name: string;
+  ticker: string;
+  ledgerId: string;
+};
 
-const BTC = buildCurrency({
+const BTC: AssetDescriptor = {
   id: "bitcoin",
   name: "Bitcoin",
   ticker: "BTC",
-  ledgerIds: ["bitcoin"],
-});
-const ETH = buildCurrency({
+  ledgerId: "bitcoin",
+};
+const ETH: AssetDescriptor = {
   id: "ethereum",
   name: "Ethereum",
   ticker: "ETH",
-  ledgerIds: ["ethereum"],
-});
-const USDT = buildCurrency({
+  ledgerId: "ethereum",
+};
+const USDT: AssetDescriptor = {
   id: "tether",
   name: "Tether",
   ticker: "USDT",
-  ledgerIds: ["ethereum/erc20/usd_tether__erc20_"],
-});
+  ledgerId: "ethereum/erc20/usd_tether__erc20_",
+};
 
-function mockMarketData({
+/** Builds a minimal DADA assets-data payload from a list of assets, preserving order. */
+function buildAssetsData(assets: AssetDescriptor[]): AssetsDataWithPagination {
+  const cryptoAssets: Record<string, unknown> = {};
+  const cryptoOrTokenCurrencies: Record<string, unknown> = {};
+  const markets: Record<string, unknown> = {};
+
+  for (const asset of assets) {
+    cryptoAssets[asset.id] = {
+      id: asset.id,
+      ticker: asset.ticker,
+      name: asset.name,
+      assetsIds: { network: asset.ledgerId },
+    };
+    cryptoOrTokenCurrencies[asset.ledgerId] = {
+      id: asset.ledgerId,
+      type: "CryptoCurrency",
+      ticker: asset.ticker,
+      name: asset.name,
+    };
+    markets[asset.ledgerId] = {
+      id: asset.id,
+      price: 100,
+      priceChangePercentage24h: 1.23,
+    };
+  }
+
+  return {
+    cryptoAssets,
+    cryptoOrTokenCurrencies,
+    markets,
+    networks: {},
+    interestRates: {},
+    currenciesOrder: { key: "marketCap", order: "desc", metaCurrencyIds: assets.map(a => a.id) },
+    pagination: {},
+  } as unknown as AssetsDataWithPagination;
+}
+
+function mockAssetsData({
   data = [],
   isLoading = false,
 }: {
-  data?: MarketCurrencyData[];
+  data?: AssetDescriptor[];
   isLoading?: boolean;
 }) {
-  mockedUseMarketData.mockReturnValue({
-    data,
+  mockedUseAssetsData.mockReturnValue({
+    data: isLoading ? undefined : buildAssetsData(data),
     isLoading,
-    isPending: isLoading,
     isError: false,
-    isFetching: false,
-    cachedMetadataMap: new Map(),
-  } as unknown as ReturnType<typeof useMarketData>);
+  } as unknown as ReturnType<typeof useAssetsData>);
 }
 
 function mockStablecoinTickers({
@@ -120,10 +140,11 @@ function Harness() {
 }
 
 describe("SearchAssets suggestion sections", () => {
+  beforeEach(() => mockedUseUsdToFiatRate.mockReturnValue({ status: "ready", rate: 1 }));
   afterEach(() => jest.clearAllMocks());
 
   it("shows cryptos and stablecoins skeletons simultaneously while loading", () => {
-    mockMarketData({ isLoading: true });
+    mockAssetsData({ isLoading: true });
     mockStablecoinTickers({ isLoading: true });
 
     render(<Harness />);
@@ -133,7 +154,7 @@ describe("SearchAssets suggestion sections", () => {
   });
 
   it("splits market data into cryptos and stablecoins via the DADA tickers", () => {
-    mockMarketData({ data: [BTC, USDT, ETH] });
+    mockAssetsData({ data: [BTC, USDT, ETH] });
     mockStablecoinTickers({ tickers: ["USDT"] });
 
     render(<Harness />);
@@ -146,7 +167,7 @@ describe("SearchAssets suggestion sections", () => {
   });
 
   it("navigates to the asset detail when a row is clicked", () => {
-    mockMarketData({ data: [BTC] });
+    mockAssetsData({ data: [BTC] });
     mockStablecoinTickers({ tickers: ["USDT"] });
 
     render(<Harness />);
@@ -156,7 +177,7 @@ describe("SearchAssets suggestion sections", () => {
   });
 
   it("triggers the see-all handler from the section header", () => {
-    mockMarketData({ data: [BTC] });
+    mockAssetsData({ data: [BTC] });
     mockStablecoinTickers({ tickers: ["USDT"] });
 
     render(<Harness />);
@@ -166,7 +187,7 @@ describe("SearchAssets suggestion sections", () => {
   });
 
   it("hides a section when it has no data", () => {
-    mockMarketData({ data: [BTC] });
+    mockAssetsData({ data: [BTC] });
     mockStablecoinTickers({ tickers: ["USDT"] });
 
     render(<Harness />);
@@ -177,15 +198,13 @@ describe("SearchAssets suggestion sections", () => {
   });
 
   it("caps each section to the requested limit", () => {
-    const extraCryptos = Array.from({ length: 5 }, (_, i) =>
-      buildCurrency({
-        id: `coin-${i}`,
-        name: `Coin ${i}`,
-        ticker: `C${i}`,
-        ledgerIds: ["bitcoin"],
-      }),
-    );
-    mockMarketData({ data: extraCryptos });
+    const extraCryptos = Array.from({ length: 5 }, (_, i) => ({
+      id: `coin-${i}`,
+      name: `Coin ${i}`,
+      ticker: `C${i}`,
+      ledgerId: `coin-${i}`,
+    }));
+    mockAssetsData({ data: extraCryptos });
     mockStablecoinTickers({ tickers: [] });
 
     render(<Harness />);
@@ -196,15 +215,13 @@ describe("SearchAssets suggestion sections", () => {
   });
 
   it("caps cryptos to 3 and stablecoins to 2", () => {
-    const stablecoins = Array.from({ length: 4 }, (_, i) =>
-      buildCurrency({
-        id: `stable-${i}`,
-        name: `Stable ${i}`,
-        ticker: `S${i}`,
-        ledgerIds: ["ethereum"],
-      }),
-    );
-    mockMarketData({ data: stablecoins });
+    const stablecoins = Array.from({ length: 4 }, (_, i) => ({
+      id: `stable-${i}`,
+      name: `Stable ${i}`,
+      ticker: `S${i}`,
+      ledgerId: `stable-${i}`,
+    }));
+    mockAssetsData({ data: stablecoins });
     mockStablecoinTickers({ tickers: ["S0", "S1", "S2", "S3"] });
 
     render(<Harness />);

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/components/AssetSuggestionsSkeleton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/components/AssetSuggestionsSkeleton.tsx
@@ -1,20 +1,36 @@
 import React from "react";
 import { Skeleton } from "@ledgerhq/lumen-ui-react";
+import { cn } from "LLD/utils/cn";
 
 type AssetSuggestionsSkeletonProps = {
   count: number;
   testIdPrefix: string;
+  className?: string;
+  density?: "compact" | "default";
 };
 
 export function AssetSuggestionsSkeleton({
   count,
   testIdPrefix,
+  className,
+  density = "compact",
 }: Readonly<AssetSuggestionsSkeletonProps>) {
   return (
-    <div className="flex flex-col gap-8" data-testid={`${testIdPrefix}-skeleton`} aria-hidden>
-      {Array.from({ length: count }, (_, index) => `${testIdPrefix}-skeleton-${index}`).map(key => (
-        <Skeleton key={key} component="list-item" />
-      ))}
+    <div
+      className={cn("flex flex-col", className)}
+      data-testid={`${testIdPrefix}-skeleton`}
+      aria-hidden
+    >
+      {Array.from({ length: count }, (_, index) => `${testIdPrefix}-skeleton-${index}`).map(key =>
+        density === "compact" ? (
+          <div key={key} className="flex h-40 w-full items-center gap-16 px-8">
+            <Skeleton className="size-24 shrink-0 rounded-full" />
+            <Skeleton className="h-12 w-176 rounded-full" />
+          </div>
+        ) : (
+          <Skeleton key={key} component="list-item" className="w-full" />
+        ),
+      )}
     </div>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSuggestionsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSuggestionsViewModel.ts
@@ -1,12 +1,12 @@
 import { useMemo } from "react";
-import { useMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
+import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
 import { useStablecoinTickers } from "@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers";
-import { MarketCurrencyData, Order } from "@ledgerhq/live-common/market/utils/types";
+import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
+import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
 import { useSelector } from "LLD/hooks/redux";
-import { marketParamsSelector } from "~/renderer/reducers/market";
+import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
+import { mapAssetsDataToMarketCurrencies } from "../utils/mapAssetsDataToMarketCurrencies";
 import { AssetSuggestionsViewModelResult } from "../types";
-
-const MARKET_FETCH_LIMIT = 50;
 
 export function useAssetSuggestionsViewModel({
   cryptosLimit,
@@ -15,25 +15,34 @@ export function useAssetSuggestionsViewModel({
   cryptosLimit: number;
   stablecoinsLimit: number;
 }): AssetSuggestionsViewModelResult {
-  const { counterCurrency } = useSelector(marketParamsSelector);
+  const counterCurrency = useSelector(counterValueCurrencySelector).ticker;
 
-  const market = useMarketData({
-    counterCurrency,
-    range: "24h",
-    order: Order.MarketCapDesc,
-    page: 1,
-    limit: MARKET_FETCH_LIMIT,
+  const {
+    data,
+    isLoading: assetsLoading,
+    isError: assetsError,
+  } = useAssetsData({
+    product: "lld",
+    version: __APP_VERSION__,
   });
 
-  const { tickers, isLoading: tickersLoading } = useStablecoinTickers("lld", __APP_VERSION__);
+  const {
+    tickers,
+    isLoading: tickersLoading,
+    isError: tickersError,
+  } = useStablecoinTickers("lld", __APP_VERSION__);
 
-  const isLoading = market.isLoading || tickersLoading;
+  const { status: rateStatus, rate } = useUsdToFiatRate(counterCurrency);
+
+  const hasData = !!data;
+  const isLoading = assetsLoading || tickersLoading || (hasData && rateStatus === "loading");
+  const isError = assetsError || tickersError || (hasData && rateStatus === "error");
 
   const { cryptos, stablecoins } = useMemo(() => {
     const cryptosData: MarketCurrencyData[] = [];
     const stablecoinsData: MarketCurrencyData[] = [];
 
-    for (const currency of market.data) {
+    for (const currency of mapAssetsDataToMarketCurrencies(data, rate ?? 1)) {
       const isStablecoin = tickers.has(currency.ticker.toUpperCase());
       const [bucket, bucketLimit] = isStablecoin
         ? [stablecoinsData, stablecoinsLimit]
@@ -43,13 +52,14 @@ export function useAssetSuggestionsViewModel({
     }
 
     return { cryptos: cryptosData, stablecoins: stablecoinsData };
-  }, [market.data, tickers, cryptosLimit, stablecoinsLimit]);
+  }, [data, rate, tickers, cryptosLimit, stablecoinsLimit]);
 
   return useMemo(
     () => ({
       cryptos: { data: cryptos, isLoading },
       stablecoins: { data: stablecoins, isLoading },
+      isError,
     }),
-    [cryptos, stablecoins, isLoading],
+    [cryptos, stablecoins, isLoading, isError],
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/types.ts
@@ -5,6 +5,7 @@ export type AssetSuggestionsViewModelResult = {
   cryptos: AssetSuggestionSection;
   /** Top stablecoins ranked by market cap, capped to the limit. */
   stablecoins: AssetSuggestionSection;
+  isError: boolean;
 };
 
 export type AssetSuggestionsSectionProps = AssetSuggestionSection & {

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/utils/buildSearchMarketCurrencyData.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/utils/buildSearchMarketCurrencyData.ts
@@ -1,0 +1,54 @@
+import { KeysPriceChange, MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+
+const EMPTY_PRICE_CHANGE: Record<KeysPriceChange, number> = {
+  [KeysPriceChange.hour]: 0,
+  [KeysPriceChange.day]: 0,
+  [KeysPriceChange.week]: 0,
+  [KeysPriceChange.month]: 0,
+  [KeysPriceChange.sixMonths]: 0,
+  [KeysPriceChange.year]: 0,
+};
+
+type BuildSearchMarketCurrencyDataParams = {
+  id: string;
+  name: string;
+  ticker: string;
+  ledgerIds: string[];
+  image?: string;
+  price: number;
+  priceChangePercentage24h?: number;
+};
+
+export function buildSearchMarketCurrencyData({
+  id,
+  name,
+  ticker,
+  ledgerIds,
+  image,
+  price,
+  priceChangePercentage24h,
+}: BuildSearchMarketCurrencyDataParams): MarketCurrencyData {
+  return {
+    id,
+    name,
+    ticker,
+    ledgerIds,
+    image,
+    price,
+    marketcapRank: 0,
+    totalVolume: 0,
+    high24h: 0,
+    low24h: 0,
+    priceChangePercentage: {
+      ...EMPTY_PRICE_CHANGE,
+      [KeysPriceChange.day]: priceChangePercentage24h ?? 0,
+    },
+    marketCapChangePercentage24h: 0,
+    circulatingSupply: 0,
+    ath: 0,
+    athDate: new Date(0),
+    atl: 0,
+    atlDate: new Date(0),
+    chartData: {},
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/utils/mapAssetsDataToMarketCurrencies.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/utils/mapAssetsDataToMarketCurrencies.ts
@@ -1,0 +1,40 @@
+import { selectCurrencyForMetaId } from "@ledgerhq/live-common/dada-client/utils/currencySelection";
+import { AssetsDataWithPagination } from "@ledgerhq/live-common/dada-client/state-manager/types";
+import { dadaIdToMarketId } from "@ledgerhq/live-common/market/utils/index";
+import { applyUsdRateToMarket } from "@ledgerhq/live-common/market/utils/applyUsdRateToMarket";
+import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { buildSearchMarketCurrencyData } from "./buildSearchMarketCurrencyData";
+
+/** DADA prices are USD-denominated; `usdToFiatRate` converts them into the counter currency (1 = no-op). */
+export function mapAssetsDataToMarketCurrencies(
+  data: AssetsDataWithPagination | undefined,
+  usdToFiatRate = 1,
+): MarketCurrencyData[] {
+  if (!data) return [];
+  const { cryptoAssets, markets, currenciesOrder } = data;
+
+  return currenciesOrder.metaCurrencyIds.flatMap(id => {
+    const meta = cryptoAssets[id];
+    if (!meta) return [];
+
+    const currency = selectCurrencyForMetaId(id, data);
+    const ledgerId = currency?.id ?? Object.values(meta.assetsIds)[0];
+    if (!ledgerId) return [];
+    const market = currency ? markets[currency.id] : undefined;
+
+    return [
+      applyUsdRateToMarket(
+        buildSearchMarketCurrencyData({
+          id: dadaIdToMarketId(market?.id ?? meta.id),
+          name: meta.name,
+          ticker: meta.ticker,
+          ledgerIds: [ledgerId],
+          image: market?.image,
+          price: market?.price ?? 0,
+          priceChangePercentage24h: market?.priceChangePercentage24h,
+        }),
+        usdToFiatRate,
+      ),
+    ];
+  });
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/StocksSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/StocksSectionView.tsx
@@ -9,15 +9,16 @@ import {
 } from "@ledgerhq/lumen-ui-react";
 import { StockRow } from "./components/StockRow";
 import { StocksSkeleton } from "./components/StocksSkeleton";
+import { splitIntoTwoRows } from "./utils/splitIntoTwoRows";
 import { StocksHeaderVariant, StocksSectionViewProps } from "./types";
 
 function StocksHeader({
   variant,
   onSeeAll,
-}: {
+}: Readonly<{
   variant: StocksHeaderVariant;
   onSeeAll: () => void;
-}) {
+}>) {
   const { t } = useTranslation();
 
   if (variant === "explore") {
@@ -63,10 +64,12 @@ export function StocksSectionView({
   navigateToAsset,
   onSeeAll,
   headerVariant = "showMore",
-}: StocksSectionViewProps) {
+}: Readonly<StocksSectionViewProps>) {
   if (!isLoading && data.length === 0) {
     return null;
   }
+
+  const rows = splitIntoTwoRows(data);
 
   return (
     <div className="flex flex-col gap-8" data-testid="stocks-section">
@@ -74,13 +77,16 @@ export function StocksSectionView({
       {isLoading ? (
         <StocksSkeleton count={limit} />
       ) : (
-        <div
-          className="scrollbar-none grid grid-flow-col grid-rows-2 gap-8 overflow-x-auto"
-          data-testid="stocks-list"
-        >
-          {data.map(stock => (
-            <StockRow key={stock.id} stock={stock} onClick={navigateToAsset} />
-          ))}
+        <div className="scrollbar-none overflow-x-auto" data-testid="stocks-list">
+          <div className="flex w-max flex-col gap-8">
+            {rows.map((rowStocks, rowIndex) => (
+              <div key={`${rowStocks.join("-")}-${rowIndex}`} className="flex gap-8">
+                {rowStocks.map(stock => (
+                  <StockRow key={stock.id} stock={stock} onClick={navigateToAsset} />
+                ))}
+              </div>
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/components/StocksSkeleton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/components/StocksSkeleton.tsx
@@ -1,20 +1,26 @@
 import React from "react";
 import { Skeleton } from "@ledgerhq/lumen-ui-react";
+import { splitIntoTwoRows } from "../utils/splitIntoTwoRows";
 
 type StocksSkeletonProps = {
   count: number;
 };
 
 export function StocksSkeleton({ count }: Readonly<StocksSkeletonProps>) {
+  const keys = Array.from({ length: count }, (_, index) => `stocks-skeleton-${index}`);
+  const rows = splitIntoTwoRows(keys);
+
   return (
-    <div
-      className="scrollbar-none grid grid-flow-col grid-rows-2 gap-8 overflow-x-auto"
-      data-testid="stocks-skeleton"
-      aria-hidden
-    >
-      {Array.from({ length: count }, (_, index) => `stocks-skeleton-${index}`).map(key => (
-        <Skeleton key={key} component="list-item" className="w-[160px] shrink-0" />
-      ))}
+    <div className="scrollbar-none overflow-x-auto" data-testid="stocks-skeleton" aria-hidden>
+      <div className="flex w-max flex-col gap-8">
+        {rows.map((rowKeys, rowIndex) => (
+          <div key={`${rowKeys.join("-")}-${rowIndex}`} className="flex gap-8">
+            {rowKeys.map(key => (
+              <Skeleton key={key} component="list-item" className="w-[160px] shrink-0" />
+            ))}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/hooks/useStocksSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/hooks/useStocksSectionViewModel.ts
@@ -8,12 +8,12 @@ export function useStocksSectionViewModel({
 }: {
   limit: number;
 }): StocksSectionViewModelResult {
-  const { data, isLoading } = useStocksData({
+  const { data, isLoading, isError } = useStocksData({
     product: "lld",
     version: __APP_VERSION__,
   });
 
   const stocks = useMemo(() => (data ? selectTopStocks(data, limit) : []), [data, limit]);
 
-  return useMemo(() => ({ data: stocks, isLoading }), [stocks, isLoading]);
+  return useMemo(() => ({ data: stocks, isLoading, isError }), [stocks, isLoading, isError]);
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/types.ts
@@ -2,16 +2,20 @@ import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/as
 
 export type { StockSuggestion };
 
-export type StocksSectionViewModelResult = {
+export type StocksSection = {
   /** Stocks ranked by market cap, already capped to the requested limit. */
   data: StockSuggestion[];
   isLoading: boolean;
 };
 
+export type StocksSectionViewModelResult = StocksSection & {
+  isError: boolean;
+};
+
 /** Header affordance: chevron "show more" (search) or "Explore" link (portfolio). */
 export type StocksHeaderVariant = "showMore" | "explore";
 
-export type StocksSectionViewProps = StocksSectionViewModelResult & {
+export type StocksSectionViewProps = StocksSection & {
   /** Number of skeleton rows rendered while loading. */
   limit: number;
   /** Redirects to the asset detail page for the given market id. */

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/utils/splitIntoTwoRows.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/utils/splitIntoTwoRows.ts
@@ -1,0 +1,7 @@
+/** Splits a list into two rows (even indices on top, odd on the bottom) for the column-scrolling grid. */
+export function splitIntoTwoRows<T>(items: T[]): [T[], T[]] {
+  const top: T[] = [];
+  const bottom: T[] = [];
+  items.forEach((item, index) => (index % 2 === 0 ? top : bottom).push(item));
+  return [top, bottom];
+}


### PR DESCRIPTION
## Context

Part 1/2 of the search-overlay work (split from LIVE-29941). This is the data-layer refactor that the live-search feature (PR 2) stacks on top of.

## What

- **Suggestions migrated to DADA**: `useAssetSuggestionsViewModel` now uses `useAssetsData` + `useUsdToFiatRate` instead of `useMarketData`, via a shared `mapAssetsDataToMarketCurrencies` helper. Adds an `isError` state for cryptos/stablecoins.
- **`buildSearchMarketCurrencyData`**: builds a `MarketCurrencyData` from a sparse DADA asset.
- **Stocks**: `useStocksSectionViewModel` exposes `isError`; the section moves from a CSS grid (`grid-flow-col grid-rows-2`) to an explicit two-row layout via a shared `splitIntoTwoRows` helper (column-major scroll order preserved). `StocksSkeleton` follows the same structure.
- `AssetSuggestionsSkeleton` gains `className`/`density` props (density unused here, consumed by PR 2).

## Tests

`SearchAssets` integration tests updated to mock `useAssetsData` / `useUsdToFiatRate`. All green.
