### PR TITLE
[LWD] feat(lld): live asset search results in the top-bar overlay [LIVE-29941]

### DIFF
--- a/.changeset/live-29941-live-asset-search-results.md
+++ b/.changeset/live-29941-live-asset-search-results.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add live asset search results to the top-bar search overlay. Typing a query (debounced, min 2 chars) fetches matching assets from DADA via `useAssetSearchResultsViewModel` and renders them as a flat list, with dedicated empty ("No asset found") and error ("Connection failed") states. The asset row gains a `default` density for the expanded results layout, and the clear button no longer toggles the overlay.

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchInputView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchInputView.tsx
@@ -1,4 +1,10 @@
-import React, { ChangeEvent, ComponentPropsWithoutRef, KeyboardEvent, forwardRef } from "react";
+import React, {
+  ChangeEvent,
+  ComponentPropsWithoutRef,
+  KeyboardEvent,
+  SyntheticEvent,
+  forwardRef,
+} from "react";
 import { SearchInput } from "@ledgerhq/lumen-ui-react";
 import { cn } from "LLD/utils/cn";
 
@@ -10,6 +16,12 @@ type SearchInputViewProps = {
   testId?: string;
 } & Omit<ComponentPropsWithoutRef<"div">, "onChange" | "onKeyDown">;
 
+function stopClearButtonFromTogglingOverlay(e: SyntheticEvent) {
+  if (e.target instanceof Element && e.target.closest("button")) {
+    e.stopPropagation();
+  }
+}
+
 export const SearchInputView = forwardRef<HTMLDivElement, SearchInputViewProps>(
   function SearchInputView(
     { value, placeholder, onChange, onKeyDown, testId, className, ...rest },
@@ -17,14 +29,19 @@ export const SearchInputView = forwardRef<HTMLDivElement, SearchInputViewProps>(
   ) {
     return (
       <div ref={ref} className={cn("min-w-0 max-w-[450px] flex-auto mr-24", className)} {...rest}>
-        <SearchInput
-          appearance="transparent"
-          value={value}
-          placeholder={placeholder}
-          onChange={onChange}
-          onKeyDown={onKeyDown}
-          data-testid={testId}
-        />
+        <div
+          onClick={stopClearButtonFromTogglingOverlay}
+          onPointerDown={stopClearButtonFromTogglingOverlay}
+        >
+          <SearchInput
+            appearance="transparent"
+            value={value}
+            placeholder={placeholder}
+            onChange={onChange}
+            onKeyDown={onKeyDown}
+            data-testid={testId}
+          />
+        </div>
       </div>
     );
   },

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/SearchOverlayView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/SearchOverlayView.tsx
@@ -6,6 +6,7 @@ import SearchOverlayContext from "./SearchOverlayContext";
 import { SearchOverlayDefault } from "./content/SearchOverlayDefault";
 import { SearchResultsList } from "./content/SearchResultsList";
 import { SearchEmptyState } from "./content/SearchEmptyState";
+import { SearchErrorState } from "./content/SearchErrorState";
 import { SearchMode, SearchOverlayContextValue } from "./types";
 
 const side = "bottom";
@@ -23,15 +24,16 @@ type SearchOverlayViewProps = Readonly<{
 
 type SearchOverlayContentProps = Readonly<{
   mode: SearchMode;
-  query: string;
 }>;
 
-function SearchOverlayContent({ mode, query }: SearchOverlayContentProps) {
+function SearchOverlayContent({ mode }: SearchOverlayContentProps) {
   switch (mode) {
     case "results":
       return <SearchResultsList />;
     case "noResults":
-      return <SearchEmptyState query={query} />;
+      return <SearchEmptyState />;
+    case "error":
+      return <SearchErrorState />;
     case "suggestions":
     default:
       return <SearchOverlayDefault />;
@@ -70,7 +72,7 @@ export function SearchOverlayView({
       >
         <SearchOverlayContext.Provider value={contextValue}>
           <div className="flex flex-col gap-12" data-testid="topbar-search-popover">
-            <SearchOverlayContent mode={mode} query={query} />
+            <SearchOverlayContent mode={mode} />
           </div>
         </SearchOverlayContext.Provider>
       </PopoverContent>

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/__tests__/SearchOverlayView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/__tests__/SearchOverlayView.test.tsx
@@ -9,16 +9,17 @@ jest.mock("../useAssetSearchBar");
 const mockedUseAssetSearchBar = jest.mocked(useAssetSearchBar);
 
 const EMPTY_SECTION = { data: [], isLoading: false };
-const SUGGESTIONS: SearchSuggestions = {
+const EMPTY_SUGGESTIONS: SearchSuggestions = {
   cryptos: EMPTY_SECTION,
   stablecoins: EMPTY_SECTION,
   stocks: EMPTY_SECTION,
 };
+const EMPTY_RESULTS: SearchResults = { data: [], isLoading: false };
 
 function mockSearchBar({
   mode,
   query = "",
-  results = { data: [], isLoading: false },
+  results = EMPTY_RESULTS,
 }: {
   mode: SearchMode;
   query?: string;
@@ -32,7 +33,7 @@ function mockSearchBar({
     open: jest.fn(),
     close: jest.fn(),
     mode,
-    suggestions: SUGGESTIONS,
+    suggestions: EMPTY_SUGGESTIONS,
     results,
   });
 }
@@ -49,12 +50,37 @@ describe("SearchOverlayView", () => {
     expect(screen.getByTestId("search-overlay-default")).toBeInTheDocument();
   });
 
-  it("renders the results list (skeletons while loading) in `results` mode", () => {
+  it("renders the general skeleton while the results are loading in `results` mode", () => {
     mockSearchBar({ mode: "results", query: "bit", results: { data: [], isLoading: true } });
 
     render(<SearchOverlay />);
 
     expect(screen.getByTestId("search-results-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders the flat results list once loaded in `results` mode", () => {
+    mockSearchBar({
+      mode: "results",
+      query: "bit",
+      results: {
+        data: [
+          {
+            id: "bitcoin",
+            name: "Bitcoin",
+            ticker: "BTC",
+            ledgerIds: ["bitcoin"],
+            price: 100,
+            priceChangePercentage: { "24h": 1.2 },
+          } as unknown as SearchResults["data"][number],
+        ],
+        isLoading: false,
+      },
+    });
+
+    render(<SearchOverlay />);
+
+    expect(screen.getByTestId("search-results-list")).toBeInTheDocument();
+    expect(screen.getByTestId("search-result-item-btc")).toBeInTheDocument();
   });
 
   it("renders the empty state in `noResults` mode", () => {
@@ -63,6 +89,15 @@ describe("SearchOverlayView", () => {
     render(<SearchOverlay />);
 
     expect(screen.getByTestId("search-empty-state")).toBeInTheDocument();
-    expect(screen.getByText('No results for "zzzz"')).toBeInTheDocument();
+    expect(screen.getByText("No asset found")).toBeInTheDocument();
+  });
+
+  it("renders the error state in `error` mode", () => {
+    mockSearchBar({ mode: "error", query: "bit" });
+
+    render(<SearchOverlay />);
+
+    expect(screen.getByTestId("search-error-state")).toBeInTheDocument();
+    expect(screen.getByText("Connection failed")).toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchErrorState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchErrorState.tsx
@@ -1,18 +1,17 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { Spot } from "@ledgerhq/lumen-ui-react";
-import { Search } from "@ledgerhq/lumen-ui-react/symbols";
 
-export function SearchEmptyState() {
+export function SearchErrorState() {
   const { t } = useTranslation();
 
   return (
     <div
       className="flex flex-col items-center justify-center gap-16 py-40"
-      data-testid="search-empty-state"
+      data-testid="search-error-state"
     >
-      <Spot appearance="icon" icon={Search} />
-      <span className="heading-4-semi-bold text-base">{t("topBar.search.noAssetFound")}</span>
+      <Spot appearance="error" />
+      <span className="heading-4-semi-bold text-base">{t("topBar.search.error")}</span>
     </div>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchResultRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchResultRow.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { AssetSuggestionRow } from "LLD/features/SearchAssets/components/AssetSuggestionRow";
+
+type SearchResultRowProps = {
+  currency: MarketCurrencyData;
+  counterCurrency: string;
+  locale: string;
+  onClick: (currencyId: string) => void;
+};
+
+export function SearchResultRow({
+  currency,
+  counterCurrency,
+  locale,
+  onClick,
+}: Readonly<SearchResultRowProps>) {
+  return (
+    <AssetSuggestionRow
+      currency={currency}
+      counterCurrency={counterCurrency}
+      locale={locale}
+      testIdPrefix="search-result"
+      onClick={onClick}
+      density="default"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchResultsList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchResultsList.tsx
@@ -1,16 +1,36 @@
 import React from "react";
+import { AssetSuggestionsSkeleton } from "LLD/features/SearchAssets/components/AssetSuggestionsSkeleton";
+import { useAssetSuggestionsSectionViewModel } from "LLD/features/SearchAssets/hooks/useAssetSuggestionsSectionViewModel";
 import { useSearchOverlay } from "../SearchOverlayContext";
+import { SearchResultRow } from "./SearchResultRow";
+
+const SKELETON_COUNT = 6;
 
 export function SearchResultsList() {
-  const { results } = useSearchOverlay();
+  const { results, navigateToAsset } = useSearchOverlay();
+  const { locale, counterCurrency } = useAssetSuggestionsSectionViewModel();
 
   if (results.isLoading) {
-    return <div className="flex flex-col gap-12" data-testid="search-results-skeleton" />;
+    return (
+      <AssetSuggestionsSkeleton
+        count={SKELETON_COUNT}
+        testIdPrefix="search-results"
+        density="default"
+      />
+    );
   }
 
   return (
-    <div className="flex flex-col gap-12" data-testid="search-results-list">
-      {/* Result rows wired by the section tickets via `results.data`. */}
+    <div className="flex flex-col -mx-8" data-testid="search-results-list">
+      {results.data.map(currency => (
+        <SearchResultRow
+          key={currency.id}
+          currency={currency}
+          counterCurrency={counterCurrency}
+          locale={locale}
+          onClick={navigateToAsset}
+        />
+      ))}
     </div>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/types.ts
@@ -1,7 +1,7 @@
 import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
 import { StockSuggestion } from "LLD/features/Stocks/types";
 
-export type SearchMode = "suggestions" | "results" | "noResults";
+export type SearchMode = "suggestions" | "results" | "noResults" | "error";
 
 export type AssetSuggestionSection = {
   data: MarketCurrencyData[];

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useAssetSearchBar.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useAssetSearchBar.ts
@@ -1,13 +1,18 @@
 import { ChangeEvent, useCallback, useMemo, useState } from "react";
+import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { useStocksSectionViewModel } from "LLD/features/Stocks/hooks/useStocksSectionViewModel";
 import { useAssetSuggestionsViewModel } from "LLD/features/SearchAssets/hooks/useAssetSuggestionsViewModel";
+import { useAssetSearchResultsViewModel } from "LLD/features/SearchAssets/hooks/useAssetSearchResultsViewModel";
 import { SearchMode, SearchResults, SearchSuggestions } from "./types";
-
-const EMPTY_RESULTS: SearchResults = { data: [], isLoading: false };
 
 export const STOCKS_SUGGESTION_LIMIT = 20;
 export const CRYPTOS_SUGGESTION_LIMIT = 3;
 export const STABLECOINS_SUGGESTION_LIMIT = 2;
+
+export const SEARCH_RESULTS_LIMIT = 10;
+
+const SEARCH_DEBOUNCE_MS = 300;
+const MIN_SEARCH_LENGTH = 2;
 
 export function useAssetSearchBar() {
   const [query, setQuery] = useState("");
@@ -24,8 +29,17 @@ export function useAssetSearchBar() {
     setQuery("");
   }, []);
 
+  const trimmedQuery = query.trim();
+  const debouncedQuery = useDebounce(trimmedQuery, SEARCH_DEBOUNCE_MS);
+  const searchEnabled = debouncedQuery.length >= MIN_SEARCH_LENGTH;
+
+  // --- Default suggestions (top market cap + stocks), shown when the query is empty. ---
   const stocks = useStocksSectionViewModel({ limit: STOCKS_SUGGESTION_LIMIT });
-  const { cryptos, stablecoins } = useAssetSuggestionsViewModel({
+  const {
+    cryptos,
+    stablecoins,
+    isError: suggestionsAssetsError,
+  } = useAssetSuggestionsViewModel({
     cryptosLimit: CRYPTOS_SUGGESTION_LIMIT,
     stablecoinsLimit: STABLECOINS_SUGGESTION_LIMIT,
   });
@@ -34,13 +48,32 @@ export function useAssetSearchBar() {
     () => ({ cryptos, stablecoins, stocks }),
     [cryptos, stablecoins, stocks],
   );
-  const results = EMPTY_RESULTS;
+
+  // --- Live search: a single flat list from the DADA assets search, driven by the debounced query. ---
+  const search = useAssetSearchResultsViewModel({
+    search: debouncedQuery,
+    skip: !searchEnabled,
+    limit: SEARCH_RESULTS_LIMIT,
+  });
+
+  // While the debounce settles, keep the list in its loading (skeleton) state so the overlay never
+  // flashes "no results" between keystrokes.
+  const searchSettling = trimmedQuery.length > 0 && trimmedQuery !== debouncedQuery;
+
+  const results: SearchResults = useMemo(
+    () => ({ data: search.data, isLoading: search.isLoading || searchSettling }),
+    [search.data, search.isLoading, searchSettling],
+  );
+
+  const suggestionsError = suggestionsAssetsError || stocks.isError;
+  const searchError = searchEnabled && search.isError;
 
   const mode: SearchMode = useMemo(() => {
-    if (query.trim().length === 0) return "suggestions";
-    if (results.isLoading || results.data.length > 0) return "results";
-    return "noResults";
-  }, [query, results]);
+    if (trimmedQuery.length === 0) return suggestionsError ? "error" : "suggestions";
+    if (searchError) return "error";
+    if (results.isLoading) return "results";
+    return results.data.length > 0 ? "results" : "noResults";
+  }, [trimmedQuery, suggestionsError, searchError, results]);
 
   return { query, onChangeQuery, clear, isOpen, open, close, mode, suggestions, results };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/__integrations__/SearchResults.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/__integrations__/SearchResults.integration.test.tsx
@@ -1,0 +1,168 @@
+import React from "react";
+import { render, renderHook, screen } from "tests/testSetup";
+import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
+import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
+import { AssetsDataWithPagination } from "@ledgerhq/live-common/dada-client/state-manager/types";
+import { useAssetSearchResultsViewModel } from "../hooks/useAssetSearchResultsViewModel";
+import { buildSearchMarketCurrencyData } from "../utils/buildSearchMarketCurrencyData";
+import { AssetSuggestionRow } from "../components/AssetSuggestionRow";
+
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useAssetsData");
+jest.mock("@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate");
+
+const mockedUseAssetsData = jest.mocked(useAssetsData);
+const mockedUseUsdToFiatRate = jest.mocked(useUsdToFiatRate);
+
+type AssetDescriptor = {
+  id: string;
+  name: string;
+  ticker: string;
+  ledgerId: string;
+  price: number;
+};
+
+function buildAssetsData(assets: AssetDescriptor[]): AssetsDataWithPagination {
+  const cryptoAssets: Record<string, unknown> = {};
+  const cryptoOrTokenCurrencies: Record<string, unknown> = {};
+  const markets: Record<string, unknown> = {};
+
+  for (const asset of assets) {
+    cryptoAssets[asset.id] = {
+      id: asset.id,
+      ticker: asset.ticker,
+      name: asset.name,
+      assetsIds: { network: asset.ledgerId },
+    };
+    cryptoOrTokenCurrencies[asset.ledgerId] = {
+      id: asset.ledgerId,
+      type: "CryptoCurrency",
+      ticker: asset.ticker,
+      name: asset.name,
+    };
+    markets[asset.ledgerId] = { id: asset.id, price: asset.price, priceChangePercentage24h: 1.23 };
+  }
+
+  return {
+    cryptoAssets,
+    cryptoOrTokenCurrencies,
+    markets,
+    networks: {},
+    interestRates: {},
+    currenciesOrder: { key: "marketCap", order: "desc", metaCurrencyIds: assets.map(a => a.id) },
+    pagination: {},
+  } as unknown as AssetsDataWithPagination;
+}
+
+function mockAssetsData({
+  data,
+  isLoading = false,
+  isError = false,
+}: {
+  data?: AssetDescriptor[];
+  isLoading?: boolean;
+  isError?: boolean;
+}) {
+  mockedUseAssetsData.mockReturnValue({
+    data: data ? buildAssetsData(data) : undefined,
+    isLoading,
+    isError,
+  } as unknown as ReturnType<typeof useAssetsData>);
+}
+
+const BTC: AssetDescriptor = {
+  id: "bitcoin",
+  name: "Bitcoin",
+  ticker: "BTC",
+  ledgerId: "bitcoin",
+  price: 100,
+};
+
+describe("search results integration", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe("useAssetSearchResultsViewModel", () => {
+    it("converts USD DADA prices into the counter currency via the usd→fiat rate", () => {
+      mockAssetsData({ data: [BTC] });
+      mockedUseUsdToFiatRate.mockReturnValue({ status: "ready", rate: 0.9 });
+
+      const { result } = renderHook(() =>
+        useAssetSearchResultsViewModel({ search: "bit", limit: 10 }),
+      );
+
+      expect(result.current.data).toHaveLength(1);
+      expect(result.current.data[0].price).toBeCloseTo(90);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isError).toBe(false);
+    });
+
+    it("caps results to the requested limit", () => {
+      const assets = Array.from({ length: 5 }, (_, i) => ({
+        id: `coin-${i}`,
+        name: `Coin ${i}`,
+        ticker: `C${i}`,
+        ledgerId: `coin-${i}`,
+        price: 10,
+      }));
+      mockAssetsData({ data: assets });
+      mockedUseUsdToFiatRate.mockReturnValue({ status: "ready", rate: 1 });
+
+      const { result } = renderHook(() =>
+        useAssetSearchResultsViewModel({ search: "c", limit: 3 }),
+      );
+
+      expect(result.current.data).toHaveLength(3);
+    });
+
+    it("stays loading and shows the unconverted USD price while the rate resolves", () => {
+      mockAssetsData({ data: [BTC] });
+      mockedUseUsdToFiatRate.mockReturnValue({ status: "loading", rate: null });
+
+      const { result } = renderHook(() =>
+        useAssetSearchResultsViewModel({ search: "bit", limit: 10 }),
+      );
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.data[0].price).toBe(100);
+    });
+
+    it("surfaces an error when the rate fails to resolve", () => {
+      mockAssetsData({ data: [BTC] });
+      mockedUseUsdToFiatRate.mockReturnValue({ status: "error", rate: null });
+
+      const { result } = renderHook(() =>
+        useAssetSearchResultsViewModel({ search: "bit", limit: 10 }),
+      );
+
+      expect(result.current.isError).toBe(true);
+    });
+  });
+
+  describe("expanded search row", () => {
+    it("renders the asset name, ticker and 24h trend", () => {
+      const currency = buildSearchMarketCurrencyData({
+        id: "bitcoin",
+        name: "Bitcoin",
+        ticker: "BTC",
+        ledgerIds: ["bitcoin"],
+        price: 1858.08,
+        priceChangePercentage24h: 2.34,
+      });
+
+      render(
+        <AssetSuggestionRow
+          currency={currency}
+          counterCurrency="USD"
+          locale="en"
+          testIdPrefix="search-result"
+          onClick={jest.fn()}
+          density="default"
+        />,
+      );
+
+      expect(screen.getByTestId("search-result-item-btc")).toBeInTheDocument();
+      expect(screen.getByText("Bitcoin")).toBeInTheDocument();
+      expect(screen.getByText("BTC")).toBeInTheDocument();
+      expect(screen.getByText("2.34%")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/components/AssetSuggestionRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/components/AssetSuggestionRow.tsx
@@ -3,6 +3,7 @@ import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import {
   ListItem,
   ListItemContent,
+  ListItemDescription,
   ListItemLeading,
   ListItemTitle,
   ListItemTrailing,
@@ -12,7 +13,12 @@ import { MarketCurrencyData, KeysPriceChange } from "@ledgerhq/live-common/marke
 import counterValueFormatter from "@ledgerhq/live-common/market/utils/countervalueFormatter";
 import { roundFiatPrice } from "@ledgerhq/live-currency-format";
 
-const ICON_SIZE = 24;
+export type AssetSuggestionRowDensity = "compact" | "default";
+
+const ICON_SIZE = {
+  compact: 24,
+  default: 48,
+} as const satisfies Record<AssetSuggestionRowDensity, number>;
 
 type AssetSuggestionRowProps = {
   currency: MarketCurrencyData;
@@ -20,6 +26,7 @@ type AssetSuggestionRowProps = {
   locale: string;
   testIdPrefix: string;
   onClick: (currencyId: string) => void;
+  density?: AssetSuggestionRowDensity;
 };
 
 export function AssetSuggestionRow({
@@ -28,12 +35,34 @@ export function AssetSuggestionRow({
   locale,
   testIdPrefix,
   onClick,
+  density = "compact",
 }: Readonly<AssetSuggestionRowProps>) {
   const priceChange = currency.priceChangePercentage[KeysPriceChange.day];
+  const isExpanded = density === "default";
+  const iconSize = ICON_SIZE[density];
+
+  const formattedPrice = counterValueFormatter({
+    value: roundFiatPrice(currency.price ?? 0),
+    currency: counterCurrency,
+    locale,
+  });
+
+  const trailing = (
+    <>
+      <ListItemTitle>{formattedPrice}</ListItemTitle>
+      {priceChange && (
+        <Trend
+          value={priceChange}
+          size={isExpanded ? "sm" : "md"}
+          className={isExpanded ? "self-end" : undefined}
+        />
+      )}
+    </>
+  );
 
   return (
     <ListItem
-      density="compact"
+      density={isExpanded ? "expanded" : "compact"}
       className="cursor-pointer"
       onClick={() => onClick(currency.id)}
       aria-label={currency.name}
@@ -41,25 +70,21 @@ export function AssetSuggestionRow({
     >
       <ListItemLeading>
         {currency.ledgerIds?.length && currency.ticker ? (
-          <CryptoIcon ledgerId={currency.ledgerIds[0]} ticker={currency.ticker} size={ICON_SIZE} />
+          <CryptoIcon ledgerId={currency.ledgerIds[0]} ticker={currency.ticker} size={iconSize} />
         ) : (
-          <img width={ICON_SIZE} height={ICON_SIZE} src={currency.image} alt={currency.name} />
+          <img width={iconSize} height={iconSize} src={currency.image} alt={currency.name} />
         )}
         <ListItemContent>
           <ListItemTitle>{currency.name}</ListItemTitle>
+          {isExpanded ? <ListItemDescription>{currency.ticker}</ListItemDescription> : null}
         </ListItemContent>
       </ListItemLeading>
       <ListItemTrailing>
-        <div className="flex items-center gap-8">
-          <ListItemTitle>
-            {counterValueFormatter({
-              value: roundFiatPrice(currency.price ?? 0),
-              currency: counterCurrency,
-              locale,
-            })}
-          </ListItemTitle>
-          {priceChange != null ? <Trend value={priceChange} size="md" /> : null}
-        </div>
+        {isExpanded ? (
+          <ListItemContent>{trailing}</ListItemContent>
+        ) : (
+          <div className="flex items-center gap-8">{trailing}</div>
+        )}
       </ListItemTrailing>
     </ListItem>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSearchResultsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSearchResultsViewModel.ts
@@ -1,0 +1,48 @@
+import { useMemo } from "react";
+import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
+import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
+import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { useSelector } from "LLD/hooks/redux";
+import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
+import { mapAssetsDataToMarketCurrencies } from "../utils/mapAssetsDataToMarketCurrencies";
+
+type Params = {
+  search?: string;
+  skip?: boolean;
+  limit: number;
+};
+
+type Result = {
+  data: MarketCurrencyData[];
+  isLoading: boolean;
+  isError: boolean;
+};
+
+export function useAssetSearchResultsViewModel({ search, skip, limit }: Params): Result {
+  const counterCurrency = useSelector(counterValueCurrencySelector).ticker;
+
+  const { data, isLoading, isError } = useAssetsData({
+    product: "lld",
+    version: __APP_VERSION__,
+    search,
+    skip,
+  });
+
+  const { status: rateStatus, rate } = useUsdToFiatRate(counterCurrency);
+
+  const results = useMemo<MarketCurrencyData[]>(
+    () => mapAssetsDataToMarketCurrencies(data, rate ?? 1).slice(0, limit),
+    [data, rate, limit],
+  );
+
+  const hasData = !!data;
+
+  return useMemo(
+    () => ({
+      data: results,
+      isLoading: isLoading || (hasData && rateStatus === "loading"),
+      isError: isError || (hasData && rateStatus === "error"),
+    }),
+    [results, isLoading, isError, hasData, rateStatus],
+  );
+}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8840,7 +8840,8 @@
   "topBar": {
     "searchPlaceholder": "Search assets",
     "search": {
-      "noResults": "No results for \"{{query}}\"",
+      "noAssetFound": "No asset found",
+      "error": "Connection failed",
       "cryptos": "Cryptos",
       "stablecoins": "Stablecoins",
       "stocks": "Stocks"


### PR DESCRIPTION
## Context

Part 2/2 of the search-overlay work (LIVE-29941). **Stacked on #18449** — review/merge that first; the base will retarget to `develop` once #18449 lands.

## What

- **Live search**: `useAssetSearchBar` wires in `useAssetSearchResultsViewModel` with a debounced (300ms), min-2-char query; results come from DADA and render as a flat list (`SearchResultsList` / `SearchResultRow`).
- **States**: dedicated `SearchEmptyState` ("No asset found") and new `SearchErrorState` ("Connection failed"); new `"error"` `SearchMode`.
- **Row**: `AssetSuggestionRow` gains a `"default"` density for the expanded results layout (ticker as description, larger icon).
- **Input**: clear button no longer toggles the overlay.

## Tests

New `SearchResults` integration tests (rate conversion, limit, loading/error gating, expanded row) + updated `SearchOverlayView` tests. All green (27 passing across the affected suites).



https://github.com/user-attachments/assets/06641ae4-dc4e-4a2e-bc7f-0063da2986cd



JIRA => https://ledgerhq.atlassian.net/browse/LIVE-29941

## Notes for reviewers

- Two known follow-ups flagged in review and left out of scope: (1) `suggestionsError` currently conflates a stocks failure with an assets failure (full-screen error when query is empty even if one source succeeded); (2) `mapAssetsDataToMarketCurrencies` skips the market lookup when `selectCurrencyForMetaId` falls back, yielding `price: 0`. Happy to address in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)