### PR TITLE
[LWDM] fix(market): keep category coins with top gainers/losers filter

### DIFF
--- a/.changeset/market-category-top-gainers-losers.md
+++ b/.changeset/market-category-top-gainers-losers.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix(market): stop excluding most coins when combining a trending category with the top gainers/losers filter. The `top=100` restriction is no longer sent alongside a `categories` filter, since the backend intersects both sets and category coins rarely rank in the global top 100.

--- a/libs/ledger-live-common/src/market/api/countervalues.test.ts
+++ b/libs/ledger-live-common/src/market/api/countervalues.test.ts
@@ -59,4 +59,12 @@ describe("market countervalues API", () => {
 
     expect(getLastRequestUrl().searchParams.get("top")).toBeNull();
   });
+
+  it("does not send the top parameter when top gainers are scoped to a category", async () => {
+    await fetchList({ counterCurrency: "usd", order: Order.topGainers, categories: "privacy" });
+
+    const url = getLastRequestUrl();
+    expect(url.searchParams.get("top")).toBeNull();
+    expect(url.searchParams.get("categories")).toBe("privacy");
+  });
 });

--- a/libs/ledger-live-common/src/market/api/countervalues.ts
+++ b/libs/ledger-live-common/src/market/api/countervalues.ts
@@ -36,7 +36,9 @@ export async function fetchList({
       ...(starred.length > 0 && { ids: starred.sort().join(",") }),
       ...(liveCompatible && { supported: liveCompatible }),
       ...(categories && { categories }),
+      // Only apply `top=100` for global gainers/losers (LIVE-32164).
       ...(!hasExplicitFilter &&
+        !categories &&
         [Order.topLosers, Order.topGainers].includes(order) && { top: 100 }),
     },
   });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Market screen (new mobile MarketScreen **and** desktop Market): select a trending category (e.g. Privacy, Derivatives) then apply **Top gainers** and **Top losers** — coins from the category must now appear, sorted by price change (previously an empty/near-empty list).
  - Verify the **global** Top gainers / Top losers view (no category / "All") is unchanged — still capped to the top 100 coins by market cap.
  - Verify built-in categories (All, Starred, Stocks) combined with gainers/losers still behave correctly.

### 📝 Description

**Problem**: On the new Market screen, selecting a trending category together with the **Top gainers** (or **Top losers**) filter excluded almost every coin from the category — usually showing an empty list.

**Root cause**: The `/v3/markets` request appended `top=100` whenever the gainers/losers sort was active. That parameter restricts results to the top 100 coins **by market cap** before sorting by price change — desirable for the global list (it stops obscure microcaps from dominating). But when a `categories` filter is also present, the backend intersects both sets, and trending-category coins rarely rank in the global top 100, so the response came back (almost) empty.

**Solution**: Only send `top=100` when **no** `categories` filter is present.

```ts
// libs/ledger-live-common/src/market/api/countervalues.ts
...(!hasExplicitFilter &&
  !categories &&
  [Order.topLosers, Order.topGainers].includes(order) && { top: 100 }),
```

This is safe because `getMarketCategoriesParam()` returns `undefined` for the built-in categories ("all"/"starred"/"stocks"), so the global gainers/losers list is byte-for-byte unchanged — only trending-category combinations are affected. The change lives in shared `@ledgerhq/live-common`, so both mobile and desktop Market screens are fixed.

Verified against the live countervalues API (`privacy` category + top gainers): `top=100` → **0** coins, without it → **27** coins, correctly sorted.

https://github.com/user-attachments/assets/6416e726-eac4-432b-87d3-91290d3813d0




### ❓ Context

- **JIRA or GitHub link**: [LIVE-32164](https://ledgerhq.atlassian.net/browse/LIVE-32164)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32164]: https://ledgerhq.atlassian.net/browse/LIVE-32164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ