### PR TITLE
[LWM] fix(lwm): position toggle button amount screen new send flow

### DIFF
--- a/.changeset/dry-bulldogs-drive.md
+++ b/.changeset/dry-bulldogs-drive.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix(lwm): position toggle button amount screen new send flow

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/AmountInputSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/AmountInputSection.tsx
@@ -21,13 +21,18 @@ export function AmountInputSection({ viewModel, message, toggleLabel }: AmountIn
         paddingBottom: theme.spacings.s16,
       },
       inputRow: {
+        width: "100%",
         flexDirection: "row",
         alignItems: "center",
+        justifyContent: "center",
         position: "relative",
       },
       toggleButton: {
         position: "absolute",
-        right: -theme.spacings.s48,
+        right: 0,
+        top: 0,
+        bottom: 0,
+        justifyContent: "center",
       },
       secondaryValue: {
         marginTop: theme.spacings.s8,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fixing a little UI tweat; switch from fiat/crypto toggle button might not be displayed on all devices

| Before        | After         |
| ------------- | ------------- |
|<img width="1032" height="1550" alt="image" src="https://github.com/user-attachments/assets/feb6c028-52bf-4274-8ca2-a65151aa6e27" />|<img width="848" height="1676" alt="image" src="https://github.com/user-attachments/assets/59cd5f81-ba9e-480f-b81e-79409eef2567" />|


### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
