### PR TITLE
feat(mobile): Portfolio Stocks — DADA discovery hook [LIVE-31379]

### DIFF
--- a/.changeset/stocks-discovery-hook.md
+++ b/.changeset/stocks-discovery-hook.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add the `useDefaultStocksAssets` hook for the Portfolio Stocks discovery scenario — fetches the top stocks (market-cap ordered) from the DADA stocks category via `useStocksData` + `selectTopStocks`, no-op when disabled.

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useDefaultStocksAssets.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useDefaultStocksAssets.test.ts
@@ -1,0 +1,65 @@
+import { renderHook } from "@tests/test-renderer";
+import { useStocksData } from "@ledgerhq/live-common/dada-client/hooks/useStocksData";
+import {
+  selectTopStocks,
+  type StockSuggestion,
+} from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { useDefaultStocksAssets } from "../useDefaultStocksAssets";
+
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useStocksData");
+jest.mock("@ledgerhq/live-common/dada-client/utils/assetDiscovery");
+
+const mockedStocks = jest.mocked(useStocksData);
+const mockedSelectTopStocks = jest.mocked(selectTopStocks);
+
+const stock = (ticker: string): StockSuggestion => ({
+  id: ticker,
+  name: ticker,
+  ticker,
+  navigationId: ticker,
+  ledgerId: ticker,
+});
+
+describe("useDefaultStocksAssets", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedStocks.mockReturnValue({
+      data: { stocks: true },
+      isLoading: false,
+      isError: false,
+    } as never);
+    mockedSelectTopStocks.mockReturnValue([stock("AAPL"), stock("TSLA")]);
+  });
+
+  it("returns the top stocks (capped at maxStocks) from the DADA stocks data", () => {
+    const { result } = renderHook(() => useDefaultStocksAssets(true, 20));
+
+    expect(result.current.stocks.map(s => s.ticker)).toEqual(["AAPL", "TSLA"]);
+    expect(mockedSelectTopStocks).toHaveBeenCalledWith(expect.anything(), 20);
+  });
+
+  it("reports loading while the query is in flight", () => {
+    mockedStocks.mockReturnValue({ data: undefined, isLoading: true, isError: false } as never);
+
+    const { result } = renderHook(() => useDefaultStocksAssets(true, 20));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.stocks).toEqual([]);
+  });
+
+  it("flags isError on failure", () => {
+    mockedStocks.mockReturnValue({ data: undefined, isLoading: false, isError: true } as never);
+
+    const { result } = renderHook(() => useDefaultStocksAssets(true, 20));
+
+    expect(result.current.isError).toBe(true);
+  });
+
+  it("is a no-op when disabled (skips the query, empty result)", () => {
+    const { result } = renderHook(() => useDefaultStocksAssets(false, 20));
+
+    expect(result.current.stocks).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(mockedStocks).toHaveBeenCalledWith(expect.objectContaining({ skip: true }));
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useDefaultStocksAssets.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useDefaultStocksAssets.ts
@@ -1,0 +1,35 @@
+import { useMemo } from "react";
+import { useStocksData } from "@ledgerhq/live-common/dada-client/hooks/useStocksData";
+import {
+  selectTopStocks,
+  type StockSuggestion,
+} from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import VersionNumber from "react-native-version-number";
+
+interface DefaultStocksAssets {
+  stocks: StockSuggestion[];
+  isLoading: boolean;
+  isError: boolean;
+}
+
+const EMPTY: DefaultStocksAssets = { stocks: [], isLoading: false, isError: false };
+
+/**
+ * Fetches the top stocks (market-cap ordered) from the DADA stocks category for
+ * the discovery scenario (user holds no stocks).
+ */
+export function useDefaultStocksAssets(enabled: boolean, maxStocks: number): DefaultStocksAssets {
+  const appVersion = VersionNumber.appVersion ?? "";
+
+  const { data, isLoading, isError } = useStocksData({
+    product: "llm",
+    version: appVersion,
+    skip: !enabled,
+  });
+
+  const stocks = useMemo(() => (data ? selectTopStocks(data, maxStocks) : []), [data, maxStocks]);
+
+  if (!enabled) return EMPTY;
+
+  return { stocks, isLoading, isError };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** `useDefaultStocksAssets` unit test (top stocks, loading, error, disabled no-op).
- [x] **Impact of the changes:**
  - Adds a data hook only; no UI yet. Consumed by the upcoming Stocks discovery section.
  - QA focus: none (no user-facing change in this PR).

### 📝 Description

First PR of the **Portfolio Stocks section** (epic LIVE-27854). Adds the data hook for the **discovery scenario** (user holds no stocks).

- **`useDefaultStocksAssets(enabled, maxStocks)`** → `{ stocks: StockSuggestion[]; isLoading; isError }`, reusing the shared `useStocksData` (DADA `category = stocks`) + `selectTopStocks` built for Global Search. No-op when `enabled` is `false`.
- Mirrors the existing `useDefaultAssetsByCategory` pattern.

> The `assetDiscoverability` feature flag task (LIVE-31378) was already shipped with the Global Search epic, so this is the first new task.

### ❓ Context

- **JIRA**: [LIVE-31379](https://ledgerhq.atlassian.net/browse/LIVE-31379) — Epic [LIVE-27854](https://ledgerhq.atlassian.net/browse/LIVE-27854)
- **Stacked PR series** (Portfolio Stocks): **1/5**, base `develop`.

[LIVE-31379]: https://ledgerhq.atlassian.net/browse/LIVE-31379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-27854]: https://ledgerhq.atlassian.net/browse/LIVE-27854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ