### PR TITLE
[LWDM] feat(mobile): Portfolio Stocks — portfolio categorization [LIVE-31380]

### DIFF
--- a/.changeset/stocks-portfolio-categorization.md
+++ b/.changeset/stocks-portfolio-categorization.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Categorize held stocks in the portfolio: `useCategorizedAssetsFromPortfolio` now returns a `stocks` bucket (split out of `cryptos`) identified by DADA currency id via the new `useStockAssetIds` hook. Matching by id (rather than ticker) avoids symbol collisions — e.g. a crypto like TON is no longer misclassified as a stock. Adds the `MAX_STOCKS_TO_DISPLAY` / `EMPTY_STATE_MAX_STOCKS` constants.

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/constants.ts
@@ -4,3 +4,6 @@ export const READ_ONLY_MAX_ASSETS = 5;
 
 export const MAX_STABLECOINS_TO_DISPLAY = 6;
 export const EMPTY_STATE_MAX_STABLECOINS = 2;
+
+export const MAX_STOCKS_TO_DISPLAY = 5;
+export const EMPTY_STATE_MAX_STOCKS = 3;

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useCategorizedAssetsFromPortfolio.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useCategorizedAssetsFromPortfolio.test.ts
@@ -5,6 +5,7 @@ import { State } from "~/reducers/types";
 const mockUseCategorizedAssets = jest.fn();
 const mockUseDistribution = jest.fn();
 const mockUseStablecoinTickers = jest.fn();
+const mockUseStockAssetIds = jest.fn();
 
 jest.mock("@ledgerhq/asset-aggregation/assetCategorization/index", () => ({
   useCategorizedAssets: (...args: unknown[]) => mockUseCategorizedAssets(...args),
@@ -17,6 +18,16 @@ jest.mock("~/actions/general", () => ({
 
 jest.mock("@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers", () => ({
   useStablecoinTickers: (...args: unknown[]) => mockUseStablecoinTickers(...args),
+}));
+
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useStockAssetIds", () => ({
+  useStockAssetIds: (...args: unknown[]) => mockUseStockAssetIds(...args),
+}));
+
+const mockUseWalletFeaturesConfig = jest.fn();
+jest.mock("@features/platform-feature-flags", () => ({
+  ...jest.requireActual("@features/platform-feature-flags"),
+  useWalletFeaturesConfig: () => mockUseWalletFeaturesConfig(),
 }));
 
 const withBlacklistedTokens =
@@ -42,6 +53,15 @@ describe("useCategorizedAssetsFromPortfolio", () => {
       tickers: new Set<string>(),
       isLoading: false,
       isError: false,
+    });
+    mockUseStockAssetIds.mockReturnValue({
+      ids: new Set<string>(),
+      isLoading: false,
+      isError: false,
+    });
+    mockUseWalletFeaturesConfig.mockReturnValue({
+      shouldDisplayAggregatedAssets: false,
+      shouldDisplayAssetDiscoverability: true,
     });
     mockUseCategorizedAssets.mockReturnValue({ cryptos: [], stablecoins: [] });
   });
@@ -73,15 +93,85 @@ describe("useCategorizedAssetsFromPortfolio", () => {
       expect(result.current.categorizedAssets.stablecoins[0].currency.id).toBe("usdt-token");
     });
 
-    it("returns the original list unchanged when no token is blacklisted", () => {
+    it("keeps cryptos and stablecoins when no token is blacklisted", () => {
       const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
       const usdc = makeItem("USDC", "usdc-token", "TokenCurrency");
-      const source = { cryptos: [btc], stablecoins: [usdc] };
-      mockUseCategorizedAssets.mockReturnValue(source);
+      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc], stablecoins: [usdc] });
 
       const { result } = renderHook(() => useCategorizedAssetsFromPortfolio());
 
-      expect(result.current.categorizedAssets).toBe(source);
+      expect(result.current.categorizedAssets.cryptos.map(a => a.currency.id)).toEqual(["bitcoin"]);
+      expect(result.current.categorizedAssets.stablecoins.map(a => a.currency.id)).toEqual([
+        "usdc-token",
+      ]);
+      expect(result.current.categorizedAssets.stocks).toEqual([]);
+    });
+  });
+
+  describe("stocks bucketing", () => {
+    it("moves held stocks out of cryptos by DADA currency id", () => {
+      const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
+      const aapl = makeItem("Apple xStock", "aapl-x", "TokenCurrency");
+      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc, aapl], stablecoins: [] });
+      mockUseStockAssetIds.mockReturnValue({
+        ids: new Set(["aapl-x"]),
+        isLoading: false,
+        isError: false,
+      });
+
+      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio());
+
+      expect(result.current.categorizedAssets.cryptos.map(a => a.currency.id)).toEqual(["bitcoin"]);
+      expect(result.current.categorizedAssets.stocks.map(a => a.currency.id)).toEqual(["aapl-x"]);
+    });
+
+    it("does not miscategorize a crypto whose ticker collides with a stock symbol", () => {
+      // TON (crypto) must not become a stock just because a stock shares the ticker.
+      const ton = makeItem("Toncoin", "ton", "CryptoCurrency");
+      mockUseCategorizedAssets.mockReturnValue({ cryptos: [ton], stablecoins: [] });
+      mockUseStockAssetIds.mockReturnValue({
+        ids: new Set(["some-tokenized-stock"]),
+        isLoading: false,
+        isError: false,
+      });
+
+      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio());
+
+      expect(result.current.categorizedAssets.cryptos.map(a => a.currency.id)).toEqual(["ton"]);
+      expect(result.current.categorizedAssets.stocks).toEqual([]);
+    });
+
+    it("leaves cryptos untouched and stocks empty when no id matches", () => {
+      const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
+      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc], stablecoins: [] });
+
+      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio());
+
+      expect(result.current.categorizedAssets.cryptos).toHaveLength(1);
+      expect(result.current.categorizedAssets.stocks).toEqual([]);
+    });
+
+    it("keeps stocks under cryptos when assetDiscoverability is off", () => {
+      mockUseWalletFeaturesConfig.mockReturnValue({
+        shouldDisplayAggregatedAssets: false,
+        shouldDisplayAssetDiscoverability: false,
+      });
+      const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
+      const aapl = makeItem("Apple xStock", "aapl-x", "TokenCurrency");
+      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc, aapl], stablecoins: [] });
+      mockUseStockAssetIds.mockReturnValue({
+        ids: new Set(["aapl-x"]),
+        isLoading: false,
+        isError: false,
+      });
+
+      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio());
+
+      expect(result.current.categorizedAssets.stocks).toEqual([]);
+      expect(result.current.categorizedAssets.cryptos.map(a => a.currency.id)).toEqual([
+        "bitcoin",
+        "aapl-x",
+      ]);
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useCategorizedAssetsFromPortfolio.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useCategorizedAssetsFromPortfolio.ts
@@ -1,7 +1,11 @@
 import { useMemo } from "react";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useStablecoinTickers } from "@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers";
-import { useCategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategorization/index";
+import { useStockAssetIds } from "@ledgerhq/live-common/dada-client/hooks/useStockAssetIds";
+import {
+  useCategorizedAssets,
+  type CategorizedAssetItem,
+} from "@ledgerhq/asset-aggregation/assetCategorization/index";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import VersionNumber from "react-native-version-number";
 import { useDistribution } from "~/actions/general";
@@ -9,8 +13,10 @@ import { useSelector } from "~/context/hooks";
 import { blacklistedTokenIdsSelector } from "~/reducers/settings";
 
 export function useCategorizedAssetsFromPortfolio() {
-  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("mobile");
+  const { shouldDisplayAggregatedAssets, shouldDisplayAssetDiscoverability } =
+    useWalletFeaturesConfig("mobile");
   const hideEmptyTokenAccount = useEnv("HIDE_EMPTY_TOKEN_ACCOUNTS");
+  const version = VersionNumber.appVersion ?? "";
 
   const distribution = useDistribution({
     showEmptyAccounts: true,
@@ -22,30 +28,46 @@ export function useCategorizedAssetsFromPortfolio() {
     tickers: stablecoinTickers,
     isLoading: isLoadingStablecoinTickers,
     isError: isStablecoinTickersError,
-  } = useStablecoinTickers("llm", VersionNumber.appVersion ?? "");
+  } = useStablecoinTickers("llm", version);
+
+  const {
+    ids: stockAssetIds,
+    isLoading: isLoadingStockTickers,
+    isError: isStockTickersError,
+  } = useStockAssetIds("llm", version, !shouldDisplayAssetDiscoverability);
 
   const categorizedAssets = useCategorizedAssets(distribution, stablecoinTickers);
 
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
   const blacklistedTokenIdsSet = useMemo(() => new Set(blacklistedTokenIds), [blacklistedTokenIds]);
 
-  // Exclude blacklisted assets so all portfolio-derived views share the same filtering rule.
+  // Split stocks out of the cryptos bucket by DADA currency id (collision-free vs ticker), and
+  // drop blacklisted assets so all portfolio-derived views share the same filtering rule. The
+  // split is gated by the feature flag so stocks stay under cryptos (no regression) when off.
   const filteredCategorizedAssets = useMemo(() => {
-    if (blacklistedTokenIdsSet.size === 0) return categorizedAssets;
-    return {
-      cryptos: categorizedAssets.cryptos.filter(
-        ({ currency }) => !blacklistedTokenIdsSet.has(currency.id),
-      ),
-      stablecoins: categorizedAssets.stablecoins.filter(
-        ({ currency }) => !blacklistedTokenIdsSet.has(currency.id),
-      ),
-    };
-  }, [categorizedAssets, blacklistedTokenIdsSet]);
+    const cryptos: CategorizedAssetItem[] = [];
+    const stocks: CategorizedAssetItem[] = [];
+
+    for (const item of categorizedAssets.cryptos) {
+      if (blacklistedTokenIdsSet.has(item.currency.id)) continue;
+      if (shouldDisplayAssetDiscoverability && stockAssetIds.has(item.currency.id))
+        stocks.push(item);
+      else cryptos.push(item);
+    }
+
+    const stablecoins = categorizedAssets.stablecoins.filter(
+      ({ currency }) => !blacklistedTokenIdsSet.has(currency.id),
+    );
+
+    return { cryptos, stablecoins, stocks };
+  }, [categorizedAssets, blacklistedTokenIdsSet, stockAssetIds, shouldDisplayAssetDiscoverability]);
 
   return {
     categorizedAssets: filteredCategorizedAssets,
     isLoadingStablecoinTickers: isLoadingStablecoinTickers || distribution.isLoading,
     isStablecoinTickersError,
     stablecoinTickers,
+    isLoadingStockTickers: isLoadingStockTickers || distribution.isLoading,
+    isStockTickersError,
   };
 }

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -434,6 +434,7 @@
     "src/dada-client/hooks/useLazyLedgerCurrency.ts",
     "src/dada-client/hooks/useMarketByCurrencies.ts",
     "src/dada-client/hooks/useStablecoinTickers.ts",
+    "src/dada-client/hooks/useStockAssetIds.ts",
     "src/dada-client/hooks/useStocksData.ts",
     "src/dada-client/index.ts",
     "src/dada-client/state-manager/api.ts",

--- a/libs/ledger-live-common/src/dada-client/hooks/useStockAssetIds.ts
+++ b/libs/ledger-live-common/src/dada-client/hooks/useStockAssetIds.ts
@@ -1,0 +1,23 @@
+import { useMemo } from "react";
+import { useGetAssetCurrencyIdsByCategoryQuery } from "../state-manager/api";
+import { AssetCategory } from "../state-manager/types";
+
+const emptySet = new Set<string>();
+
+/**
+ * Ledger currency ids of every tokenized stock (DADA `stocks` category). Used to
+ * identify held stocks by id rather than ticker, which avoids symbol collisions
+ * (e.g. a stock whose ticker equals a crypto ticker like TON).
+ */
+export function useStockAssetIds(product: "llm" | "lld", version: string, skip?: boolean) {
+  const { data, isLoading, isError } = useGetAssetCurrencyIdsByCategoryQuery(
+    {
+      category: AssetCategory.Stocks,
+      product,
+      version,
+    },
+    { skip },
+  );
+  const ids = useMemo(() => (data ? new Set(data) : emptySet), [data]);
+  return { ids, isLoading, isError };
+}

--- a/libs/ledger-live-common/src/dada-client/state-manager/api.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/api.ts
@@ -127,12 +127,13 @@ async function fetchAssetsPage(
   };
 }
 
-export async function fetchAllAssetsByCategory(
+async function collectAllByCategory(
   queryArg: GetAssetsByCategoryParams,
+  extract: (data: RawApiResponse) => string[],
 ): Promise<QueryReturnValue<string[], FetchBaseQueryError, FetchBaseQueryMeta | undefined>> {
   try {
     const baseUrl = queryArg.isStaging ? getEnv("DADA_API_STAGING") : getEnv("DADA_API_PROD");
-    const allTickers: string[] = [];
+    const collected: string[] = [];
     let cursor: string | undefined;
 
     do {
@@ -158,11 +159,11 @@ export async function fetchAllAssetsByCategory(
       }
 
       const data: RawApiResponse = await response.json();
-      allTickers.push(...Object.values(data.cryptoAssets).map(a => a.ticker));
+      collected.push(...extract(data));
       cursor = response.headers.get("x-ledger-next") || undefined;
     } while (cursor);
 
-    return { data: allTickers };
+    return { data: collected };
   } catch (error) {
     return {
       error: {
@@ -171,6 +172,19 @@ export async function fetchAllAssetsByCategory(
       },
     };
   }
+}
+
+export function fetchAllAssetsByCategory(queryArg: GetAssetsByCategoryParams) {
+  return collectAllByCategory(queryArg, data =>
+    Object.values(data.cryptoAssets).map(a => a.ticker),
+  );
+}
+
+/** Returns the ledger currency ids of every asset in the category (collision-free vs tickers). */
+export function fetchAllAssetCurrencyIdsByCategory(queryArg: GetAssetsByCategoryParams) {
+  return collectAllByCategory(queryArg, data =>
+    Object.values(data.cryptoAssets).flatMap(meta => Object.values(meta.assetsIds)),
+  );
 }
 
 export const assetsDataApi = createApi({
@@ -213,6 +227,12 @@ export const assetsDataApi = createApi({
     getAssetsByCategory: build.query<string[], GetAssetsByCategoryParams>({
       queryFn: async queryArg => {
         return fetchAllAssetsByCategory(queryArg);
+      },
+      keepUnusedDataFor: ONE_DAY_IN_SECONDS,
+    }),
+    getAssetCurrencyIdsByCategory: build.query<string[], GetAssetsByCategoryParams>({
+      queryFn: async queryArg => {
+        return fetchAllAssetCurrencyIdsByCategory(queryArg);
       },
       keepUnusedDataFor: ONE_DAY_IN_SECONDS,
     }),
@@ -275,5 +295,6 @@ export const {
   useGetAssetsDataInfiniteQuery,
   useGetAssetDataQuery,
   useGetAssetsByCategoryQuery,
+  useGetAssetCurrencyIdsByCategoryQuery,
   useGetChunkedAssetsDataQuery,
 } = assetsDataApi;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** `useCategorizedAssetsFromPortfolio` tests (stocks bucketing by ticker, no-match, blacklist, loading) — 7 pass; full WalletAssets suite green (65).
- [x] **Impact of the changes:**
  - Held stocks are now categorized separately from cryptos (no UI yet — consumed by the upcoming portfolio Stocks section).
  - QA focus: crypto/stablecoin sections unchanged (a held tokenized stock no longer appears under Cryptos).

### 📝 Description

Second PR of the **Portfolio Stocks section** (epic LIVE-27854). Extracts the user's stock holdings from the portfolio distribution.

- **`useStockTickers(product, version)`** — new shared DADA hook returning the set of stock tickers (`AssetCategory.Stocks`), mirroring `useStablecoinTickers`. **DADA-driven** identification (no name/id heuristics).
- **`useCategorizedAssetsFromPortfolio`** now returns a `stocks` bucket split out of `cryptos` by stock ticker (+ `isLoadingStockTickers` / `isStockTickersError`), excluded from `cryptos` to avoid double-display. Blacklist filtering applies to all three buckets. The split is gated by `shouldDisplayAssetDiscoverability` so held stocks stay under cryptos (no regression) when the flag is off.
- Adds `MAX_STOCKS_TO_DISPLAY = 5` and `EMPTY_STATE_MAX_STOCKS = 3` constants.

### ❓ Context

- **JIRA**: [LIVE-31380](https://ledgerhq.atlassian.net/browse/LIVE-31380) — Epic [LIVE-27854](https://ledgerhq.atlassian.net/browse/LIVE-27854)
- **Stacked PR series** (Portfolio Stocks): **2/5**, based on [#18456](https://github.com/LedgerHQ/ledger-live/pull/18456) (LIVE-31379).

[LIVE-31380]: https://ledgerhq.atlassian.net/browse/LIVE-31380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
