### PR TITLE
[LWDM] fix(aptos): skip non-write_resource changes when scanning accounts

### DIFF
--- a/.changeset/aptos-skip-null-data-changes.md
+++ b/.changeset/aptos-skip-null-data-changes.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aptos": minor
+---
+
+Fix account creation failing with a TypeError on Aptos accounts that have a coin to fungible-asset migration transaction in their history.

--- a/libs/coin-modules/coin-aptos/src/__tests__/logic/getResourceAddress.unit.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/logic/getResourceAddress.unit.test.ts
@@ -238,4 +238,48 @@ describe("getResourceAddress", () => {
     const result = getResourceAddress(tx, event, "withdraw_events", getEventFAAddress);
     expect(result).toEqual(null);
   });
+
+  it("should skip non-write_resource changes (write_table_item with null data)", () => {
+    const nullDataChange = {
+      type: "write_table_item",
+      data: null,
+    } as unknown as WriteSetChange;
+
+    const validChange = {
+      type: "write_resource",
+      data: {
+        type: APTOS_COIN_CHANGE,
+        data: {
+          withdraw_events: {
+            guid: {
+              id: {
+                addr: "0x11",
+                creation_num: "2",
+              },
+            },
+          },
+        },
+      },
+    } as unknown as WriteSetChange;
+
+    const tx: AptosTransaction = {
+      hash: "0x123",
+      block: { hash: "0xabc", height: 1 },
+      timestamp: "1000000",
+      sequence_number: "1",
+      version: "1",
+      changes: [nullDataChange, validChange],
+    } as unknown as AptosTransaction;
+
+    const event = {
+      guid: {
+        account_address: "0x11",
+        creation_number: "2",
+      },
+      type: "0x1::coin::WithdrawEvent",
+    } as Event;
+
+    const result = getResourceAddress(tx, event, "withdraw_events", getEventCoinAddress);
+    expect(result).toEqual(APTOS_ASSET_ID);
+  });
 });

--- a/libs/coin-modules/coin-aptos/src/logic/isWriteSetChangeWriteResource.ts
+++ b/libs/coin-modules/coin-aptos/src/logic/isWriteSetChangeWriteResource.ts
@@ -1,7 +1,8 @@
 import { WriteSetChange, WriteSetChangeWriteResource } from "@aptos-labs/ts-sdk";
+import { WRITE_RESOURCE } from "../constants";
 
 export function isWriteSetChangeWriteResource(
   change: WriteSetChange,
 ): change is WriteSetChangeWriteResource {
-  return (change as WriteSetChangeWriteResource).data !== undefined;
+  return change.type === WRITE_RESOURCE;
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added a regression test in `getResourceAddress.unit.test.ts` (a `write_table_item` change with `null` data is skipped without throwing). Full coin-aptos unit suite green (210/210), so non-regression is covered.
- [x] **Impact of the changes:** Aptos account synchronization / raw-tx -> `Operation` parsing.
  - QA focus: **adding an Aptos mainnet account**, especially accounts whose history contains a **coin -> fungible-asset migration** transaction (e.g. any account that has held/transferred APT after its FA migration).
  - Verify the account is added (no error) and that its **transaction history and amounts are correct** (send/receive, fees).

### 📝 Description

**Previous behaviour:** Adding an Aptos mainnet account failed at "checking blockchain" with an unmapped `TypeError`, blocking account creation. Reproducible in the official Ledger Live 4.7.0. It affects any account whose history contains a coin -> fungible-asset migration transaction.

**Root cause:** During sync, `getCoinAndAmounts` walks `tx.changes` to resolve the coin/FA address for withdraw/deposit events. The type guard `isWriteSetChangeWriteResource` classified a change as a "write resource" by checking that the `data` field is `!== undefined`. The Aptos node returns `write_table_item` changes (e.g. the APT total-supply aggregator) with `data: null`, which passed that check and reached `getEventCoinAddress`, where dereferencing `null.data` threw - rejecting the whole `getAccountShape` and blocking import.

**Fix:** Classify the change by its `type` discriminator instead of by the presence of `data`:

```ts
return change.type === WRITE_RESOURCE_CHANGE_TYPE; // "write_resource"
```

This is a root-cause fix: it excludes every non-resource change type (`write_table_item`, `delete_resource`, `write_module`, ...) by category, and the SDK types `write_resource.data` as a non-null `MoveResource`, so the dereference is safe. A single helper covers both parsing paths (`txsToOps` and `transactionsToOperations`).

**Verification:** Confirmed on-device (Nano S Plus, Aptos app 0.10.0) - the previously-failing account now adds. Ran the real parser (`getCoinAndAmounts` + `txsToOps`) on the offending tx and confirmed the resulting `Operation` is correct (OUT, 0.015 APT, correct recipient and fee) - the skipped `write_table_item` is the global supply counter and carries no account-level information, so nothing is lost.

Repro tx (mainnet, version `5665942236`):
`https://apt.coin.ledger.com/node/v1/transactions/by_version/5665942236` -> `changes[11].data == null`

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-32448
- **ADR link (if any)**: N/A