### PR TITLE
[LWM] feat(mobile): Portfolio Stocks — holdings list variant [LIVE-31381]

### DIFF
--- a/.changeset/stocks-portfolio-list-variant.md
+++ b/.changeset/stocks-portfolio-list-variant.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add the Portfolio Stocks section (holdings variant): when the user holds stocks, render a vertical list (max 5, mirroring the Crypto/Stablecoins sections) with a "Show more" header that opens the Crypto screen filtered to stocks. Extends `CryptoVariant` with `"stocks"` and the asset-list filter accordingly.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8708,6 +8708,7 @@
     "tabs": {
       "crypto": "Crypto",
       "stablecoins": "Stablecoins",
+      "stocks": "Stocks",
       "market": "Market"
     },
     "referralProgram": "$20"

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/index.tsx
@@ -13,6 +13,7 @@ type Props = BaseComposite<StackNavigatorProps<CryptoScreenNavigator, ScreenName
 const LIST_TEST_ID_BY_VARIANT: Record<CryptoVariant, string> = {
   stablecoin: "StablecoinList",
   crypto: "CryptoList",
+  stocks: "StocksList",
   all: "CryptoList",
 };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/types.ts
@@ -1,7 +1,7 @@
 import { ScreenName } from "~/const";
 import { Asset } from "~/types/asset";
 
-export type CryptoVariant = "crypto" | "stablecoin" | "all";
+export type CryptoVariant = "crypto" | "stablecoin" | "stocks" | "all";
 
 export type CryptoScreenNavigator = {
   [ScreenName.Crypto]: {
@@ -17,5 +17,5 @@ export interface CryptoScreenViewData {
   error: Error | null;
   sourceScreenName: ScreenName | undefined;
   variant: CryptoVariant;
-  trackingType: "crypto" | "stable" | undefined;
+  trackingType: "crypto" | "stable" | "stocks" | undefined;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/useCryptoViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/useCryptoViewModel.ts
@@ -16,11 +16,13 @@ interface UseCryptoViewModelParams {
   variant?: CryptoVariant;
 }
 
-const TRACKING_TYPE_BY_VARIANT: Record<CryptoVariant, "crypto" | "stable" | undefined> = {
-  stablecoin: "stable",
-  crypto: "crypto",
-  all: undefined,
-};
+const TRACKING_TYPE_BY_VARIANT: Record<CryptoVariant, "crypto" | "stable" | "stocks" | undefined> =
+  {
+    stablecoin: "stable",
+    crypto: "crypto",
+    stocks: "stocks",
+    all: undefined,
+  };
 
 const useCryptoViewModel = ({
   sourceScreenName,

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/utils.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/utils.ts
@@ -1,12 +1,25 @@
-import { CategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategorization/types";
+import {
+  CategorizedAssets,
+  CategorizedAssetItem,
+} from "@ledgerhq/asset-aggregation/assetCategorization/types";
 import { CryptoVariant } from "./types";
 
-export function selectAssetList(categorizedAssets: CategorizedAssets, variant: CryptoVariant) {
+export function selectAssetList(
+  categorizedAssets: CategorizedAssets & { stocks?: CategorizedAssetItem[] },
+  variant: CryptoVariant,
+) {
   if (variant === "stablecoin") {
     return categorizedAssets.stablecoins ?? [];
   }
   if (variant === "crypto") {
     return categorizedAssets.cryptos ?? [];
   }
-  return [...(categorizedAssets.cryptos ?? []), ...(categorizedAssets.stablecoins ?? [])];
+  if (variant === "stocks") {
+    return categorizedAssets.stocks ?? [];
+  }
+  return [
+    ...(categorizedAssets.cryptos ?? []),
+    ...(categorizedAssets.stablecoins ?? []),
+    ...(categorizedAssets.stocks ?? []),
+  ];
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/usePortfolioSectionActions.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/usePortfolioSectionActions.ts
@@ -15,7 +15,7 @@ interface PortfolioSectionActions {
 
 export function usePortfolioSectionActions(
   isReadOnly: boolean,
-  variant: "crypto" | "stablecoin" | "all",
+  variant: "crypto" | "stablecoin" | "stocks" | "all",
 ): PortfolioSectionActions {
   const { shouldDisplayAssetSection } = useWalletFeaturesConfig("mobile");
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
@@ -25,7 +25,7 @@ export function usePortfolioSectionActions(
   const onPressShowAll = useCallback(() => {
     track("button_clicked", {
       button: "asset_list",
-      type: variant === "stablecoin" ? "stable" : "crypto",
+      type: variant === "stablecoin" ? "stable" : variant === "stocks" ? "stocks" : "crypto",
       page: "Wallet",
     });
     if (!isReadOnly && shouldDisplayAssetSection) {

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/__tests__/usePortfolioStocksSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/__tests__/usePortfolioStocksSectionViewModel.test.ts
@@ -1,0 +1,100 @@
+import { act } from "@testing-library/react-native";
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { NavigatorName, ScreenName } from "~/const";
+import { Asset } from "~/types/asset";
+import usePortfolioStocksSectionViewModel from "../usePortfolioStocksSectionViewModel";
+import { bitcoin, ethereum, createCryptoAsset } from "../../CryptosSection/__tests__/shared";
+
+const mockNavigate = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+  useRoute: () => ({ name: "Portfolio" }),
+}));
+
+const mockCategorizedAssets = jest.fn();
+
+jest.mock("LLM/hooks/useCategorizedAssetsFromPortfolio", () => ({
+  useCategorizedAssetsFromPortfolio: () => mockCategorizedAssets(),
+}));
+
+const toCategorizedItem = (asset: Asset) => ({
+  currency: asset.currency,
+  balance: asset.amount,
+  value: 0,
+  distribution: 0,
+  accounts: asset.accounts,
+});
+
+const mockPortfolioWithStocks = (stockAssets: Asset[] = []): void => {
+  mockCategorizedAssets.mockReturnValue({
+    categorizedAssets: {
+      cryptos: [],
+      stablecoins: [],
+      stocks: stockAssets.map(toCategorizedItem),
+    },
+    stablecoinTickers: new Set<string>(),
+    isLoadingStablecoinTickers: false,
+    isStablecoinTickersError: false,
+    isLoadingStockTickers: false,
+    isStockTickersError: false,
+  });
+};
+
+describe("usePortfolioStocksSectionViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPortfolioWithStocks();
+  });
+
+  it("returns no stocks when none are held", () => {
+    const { result } = renderHook(() => usePortfolioStocksSectionViewModel());
+
+    expect(result.current.stocksCount).toBe(0);
+    expect(result.current.stocksToDisplay).toHaveLength(0);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it("caps the display at 5 while reporting the full count", () => {
+    mockPortfolioWithStocks(Array.from({ length: 7 }, () => createCryptoAsset(bitcoin, 1000)));
+
+    const { result } = renderHook(() => usePortfolioStocksSectionViewModel());
+
+    expect(result.current.stocksCount).toBe(7);
+    expect(result.current.stocksToDisplay).toHaveLength(5);
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it("navigates to the Crypto screen filtered to stocks on show all", () => {
+    const { result } = renderHook(() => usePortfolioStocksSectionViewModel(), {
+      overrideInitialState: withFlagOverrides({
+        lwmWallet40: { enabled: true, params: { assetSection: true } },
+      }),
+    });
+
+    act(() => {
+      result.current.onPressShowAll();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
+      screen: ScreenName.Crypto,
+      params: { sourceScreenName: ScreenName.Portfolio, variant: "stocks" },
+    });
+  });
+
+  it("navigates to asset detail on item press", () => {
+    mockPortfolioWithStocks([createCryptoAsset(ethereum, 5000)]);
+
+    const { result } = renderHook(() => usePortfolioStocksSectionViewModel());
+
+    act(() => {
+      result.current.onItemPress(result.current.stocksToDisplay[0]);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
+      screen: ScreenName.Asset,
+      params: { currency: ethereum },
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import {
+  Box,
+  Subheader,
+  SubheaderCount,
+  SubheaderRow,
+  SubheaderShowMore,
+  SubheaderTitle,
+} from "@ledgerhq/lumen-ui-rnative";
+import { withDiscreetMode } from "~/context/DiscreetModeContext";
+import { useTranslation } from "~/context/Locale";
+import { SectionListContent } from "../../components/SectionListContent";
+import usePortfolioStocksSectionViewModel from "./usePortfolioStocksSectionViewModel";
+import { EMPTY_STATE_MAX_STOCKS } from "LLM/features/WalletAssets/constants";
+
+const PortfolioStocksSectionComponent: React.FC = () => {
+  const { t } = useTranslation();
+  const { stocksCount, hasMore, stocksToDisplay, isLoading, isError, onPressShowAll, onItemPress } =
+    usePortfolioStocksSectionViewModel();
+
+  if (!isLoading && !isError && stocksCount === 0) return null;
+
+  return (
+    <Box>
+      <Subheader>
+        <SubheaderRow
+          onPress={hasMore ? onPressShowAll : undefined}
+          accessibilityRole={hasMore ? "button" : undefined}
+          lx={{ marginBottom: "s4" }}
+          testID="portfolio-stocks-section-header"
+        >
+          <SubheaderTitle>{t("wallet.tabs.stocks")}</SubheaderTitle>
+          {hasMore && (
+            <>
+              <SubheaderCount value={stocksCount} />
+              <SubheaderShowMore />
+            </>
+          )}
+        </SubheaderRow>
+      </Subheader>
+      <Box testID="PortfolioStocksList">
+        <SectionListContent
+          isLoading={isLoading}
+          isError={isError}
+          assetsToDisplay={stocksToDisplay}
+          onItemPress={onItemPress}
+          skeletonCount={EMPTY_STATE_MAX_STOCKS}
+          errorMessage={t("portfolio.assetSection.connectionFailed")}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export const PortfolioStocksSection = withDiscreetMode(PortfolioStocksSectionComponent);

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/usePortfolioStocksSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/usePortfolioStocksSectionViewModel.ts
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+import { Asset } from "~/types/asset";
+import { useCategorizedAssetsFromPortfolio } from "LLM/hooks/useCategorizedAssetsFromPortfolio";
+import { usePortfolioSectionActions } from "LLM/features/WalletAssets/shared/usePortfolioSectionActions";
+import { toAsset } from "LLM/features/WalletAssets/shared/assetUtils";
+import { MAX_STOCKS_TO_DISPLAY } from "LLM/features/WalletAssets/constants";
+
+export interface PortfolioStocksSectionViewModelResult {
+  stocksCount: number;
+  hasMore: boolean;
+  stocksToDisplay: Asset[];
+  isLoading: boolean;
+  isError: boolean;
+  onPressShowAll: () => void;
+  onItemPress: (asset: Asset) => void;
+}
+
+const usePortfolioStocksSectionViewModel = (): PortfolioStocksSectionViewModelResult => {
+  const { onPressShowAll, onItemPress } = usePortfolioSectionActions(false, "stocks");
+  const { categorizedAssets, isLoadingStockTickers, isStockTickersError } =
+    useCategorizedAssetsFromPortfolio();
+
+  const stocks = useMemo<Asset[]>(
+    () => categorizedAssets.stocks.map(toAsset),
+    [categorizedAssets.stocks],
+  );
+
+  const stocksCount = stocks.length;
+  const stocksToDisplay = useMemo(() => stocks.slice(0, MAX_STOCKS_TO_DISPLAY), [stocks]);
+  const hasMore = stocksCount > MAX_STOCKS_TO_DISPLAY;
+
+  return {
+    stocksCount,
+    hasMore,
+    stocksToDisplay,
+    isLoading: isLoadingStockTickers,
+    isError: isStockTickersError,
+    onPressShowAll,
+    onItemPress,
+  };
+};
+
+export default usePortfolioStocksSectionViewModel;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** `usePortfolioStocksSectionViewModel` tests (count/cap-5/hasMore, show-all nav to Crypto `stocks`, item → asset detail); full Crypto + WalletAssets suites green (111).
- [x] **Impact of the changes:**
  - When a user holds stocks (and `assetDiscoverability` is on), a Stocks section appears on the portfolio home (max 5, "Show more").
  - QA focus: crypto/stablecoin sections unchanged; "Show more" opens the Crypto screen filtered to held stocks; tapping a stock opens its detail; discreet mode hides balances.

### 📝 Description

Third PR of the **Portfolio Stocks section** (epic LIVE-27854) — the **holdings variant** (user holds ≥ 1 stock), mirroring `CryptosSection`. Figma [node-id=23282-39903](https://www.figma.com/design/QZv5fm4oJ1GUS1iIUU8lJt/Home-Production-%E2%80%A2--Wallet-4.0?node-id=23282-39903&m=dev).

- **`PortfolioStocksSection`** + **`usePortfolioStocksSectionViewModel`** under `WalletAssets/views/StocksSection/` — consumes the `stocks` bucket from `useCategorizedAssetsFromPortfolio`, caps at `MAX_STOCKS_TO_DISPLAY = 5`, `withDiscreetMode`, returns `null` when no stocks (discovery handled in the next PR). Reuses `usePortfolioSectionActions("stocks")` for navigation + tracking.
- Extends `CryptoVariant` with `"stocks"`, `selectAssetList` (and `"all"` now includes the stocks bucket), and `usePortfolioSectionActions`/`useCryptoViewModel` accordingly, so "Show more" opens the Crypto screen filtered to the user's stocks.
- Adds the `wallet.tabs.stocks` i18n key.

> Not yet wired into `AssetsSections` (that + the discovery grid land in the next PRs).

### ❓ Context

- **JIRA**: [LIVE-31381](https://ledgerhq.atlassian.net/browse/LIVE-31381) — Epic [LIVE-27854](https://ledgerhq.atlassian.net/browse/LIVE-27854)
- **Stacked PR series** (Portfolio Stocks): **3/5**, based on [#18457](https://github.com/LedgerHQ/ledger-live/pull/18457) (LIVE-31380).

[LIVE-31381]: https://ledgerhq.atlassian.net/browse/LIVE-31381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ