### PR TITLE
[LWM] feat(mobile): Portfolio Stocks — discovery grid [LIVE-31382]

### DIFF
--- a/.changeset/stocks-discovery-grid.md
+++ b/.changeset/stocks-discovery-grid.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add the Portfolio Stocks discovery section: when the user holds no stocks, render a horizontal 2-row grid of the top stocks (MediaButton pills) with an "Explore All" header that opens the Market list filtered to stocks. Tapping a pill opens that stock's market detail.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8711,6 +8711,9 @@
       "stocks": "Stocks",
       "market": "Market"
     },
+    "stocks": {
+      "exploreAll": "Explore All"
+    },
     "referralProgram": "$20"
   },
   "servicesWidget": {

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/constants.ts
@@ -7,3 +7,4 @@ export const EMPTY_STATE_MAX_STABLECOINS = 2;
 
 export const MAX_STOCKS_TO_DISPLAY = 5;
 export const EMPTY_STATE_MAX_STOCKS = 3;
+export const MAX_DISCOVERY_STOCKS = 20;

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/StocksDiscoverySection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/StocksDiscoverySection.tsx
@@ -1,0 +1,110 @@
+import React, { useCallback, useMemo } from "react";
+import { ScrollView } from "react-native";
+import Icon from "@ledgerhq/crypto-icons/native";
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import {
+  Box,
+  MediaButton,
+  Skeleton,
+  Subheader,
+  SubheaderRow,
+  SubheaderTitle,
+  Text,
+} from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { useTranslation } from "~/context/Locale";
+import { EMPTY_STATE_MAX_STOCKS } from "LLM/features/WalletAssets/constants";
+import { useStocksDiscoverySectionViewModel } from "./useStocksDiscoverySectionViewModel";
+
+function splitIntoRows(stocks: StockSuggestion[]): [StockSuggestion[], StockSuggestion[]] {
+  const top: StockSuggestion[] = [];
+  const bottom: StockSuggestion[] = [];
+  stocks.forEach((stock, index) => (index % 2 === 0 ? top : bottom).push(stock));
+  return [top, bottom];
+}
+
+type StockPillProps = Readonly<{
+  stock: StockSuggestion;
+  onPress: (stock: StockSuggestion) => void;
+}>;
+
+function StockPill({ stock, onPress }: StockPillProps) {
+  const handlePress = useCallback(() => onPress(stock), [stock, onPress]);
+
+  return (
+    <MediaButton
+      size="sm"
+      hideChevron
+      leadingContentShape="rounded"
+      leadingContent={<Icon ledgerId={stock.ledgerId} ticker={stock.ticker} size={24} />}
+      onPress={handlePress}
+      accessibilityLabel={stock.name}
+      testID={`portfolio-discovery-stock-${stock.ticker.toLowerCase()}`}
+    >
+      {stock.ticker.toUpperCase()}
+    </MediaButton>
+  );
+}
+
+export function StocksDiscoverySection() {
+  const { t } = useTranslation();
+  const { stocks, isLoading, isError, onPressExploreAll, onItemPress } =
+    useStocksDiscoverySectionViewModel();
+  const [topRow, bottomRow] = useMemo(() => splitIntoRows(stocks), [stocks]);
+
+  if (!isLoading && (isError || stocks.length === 0)) return null;
+
+  const renderSkeletonPills = () =>
+    Array.from({ length: EMPTY_STATE_MAX_STOCKS }, (_, index) => (
+      <Skeleton key={index} lx={pillSkeletonStyle} />
+    ));
+
+  return (
+    <Box lx={sectionStyle} testID="portfolio-stocks-discovery">
+      <Box lx={insetStyle}>
+        <Subheader>
+          <SubheaderRow
+            onPress={onPressExploreAll}
+            accessibilityRole="button"
+            testID="portfolio-stocks-discovery-header"
+          >
+            <SubheaderTitle>{t("wallet.tabs.stocks")}</SubheaderTitle>
+            <Text typography="body2" lx={{ color: "interactive" }} style={exploreAllStyle}>
+              {t("wallet.stocks.exploreAll")}
+            </Text>
+          </SubheaderRow>
+        </Subheader>
+      </Box>
+      {isLoading ? (
+        <Box lx={insetStyle}>
+          <Box lx={gridStyle}>
+            <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
+            <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
+          </Box>
+        </Box>
+      ) : (
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          <Box lx={gridStyle}>
+            <Box lx={rowStyle}>
+              {topRow.map(stock => (
+                <StockPill key={stock.id} stock={stock} onPress={onItemPress} />
+              ))}
+            </Box>
+            <Box lx={rowStyle}>
+              {bottomRow.map(stock => (
+                <StockPill key={stock.id} stock={stock} onPress={onItemPress} />
+              ))}
+            </Box>
+          </Box>
+        </ScrollView>
+      )}
+    </Box>
+  );
+}
+
+const exploreAllStyle = { marginLeft: "auto" as const };
+const sectionStyle: LumenViewStyle = { gap: "s12", marginHorizontal: "-s16" };
+const insetStyle: LumenViewStyle = { paddingHorizontal: "s16" };
+const gridStyle: LumenViewStyle = { gap: "s8", paddingHorizontal: "s16" };
+const rowStyle: LumenViewStyle = { flexDirection: "row", gap: "s8" };
+const pillSkeletonStyle: LumenViewStyle = { width: "s96", height: "s40", borderRadius: "full" };

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/__tests__/useStocksDiscoverySectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/__tests__/useStocksDiscoverySectionViewModel.test.ts
@@ -1,0 +1,67 @@
+import { act } from "@testing-library/react-native";
+import { renderHook } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { useStocksDiscoverySectionViewModel } from "../useStocksDiscoverySectionViewModel";
+
+const mockNavigate = jest.fn();
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+const mockOpenFromMarket = jest.fn();
+jest.mock("LLM/features/AssetDetail/hooks/useAssetDetailNavigation", () => ({
+  useAssetDetailNavigation: () => ({ openFromMarket: mockOpenFromMarket }),
+}));
+
+const mockDefaultStocks = jest.fn();
+jest.mock("LLM/hooks/useDefaultStocksAssets", () => ({
+  useDefaultStocksAssets: (...args: unknown[]) => mockDefaultStocks(...args),
+}));
+
+const stock = (ticker: string): StockSuggestion => ({
+  id: ticker,
+  name: ticker,
+  ticker,
+  navigationId: `${ticker}-mkt`,
+  ledgerId: `${ticker}-ledger`,
+});
+
+describe("useStocksDiscoverySectionViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDefaultStocks.mockReturnValue({
+      stocks: [stock("AAPL")],
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  it("exposes the top discovery stocks from the DADA hook", () => {
+    const { result } = renderHook(() => useStocksDiscoverySectionViewModel());
+
+    expect(result.current.stocks.map(s => s.ticker)).toEqual(["AAPL"]);
+    expect(mockDefaultStocks).toHaveBeenCalledWith(true, 20);
+  });
+
+  it("navigates to the Market list filtered to stocks on Explore All", () => {
+    const { result } = renderHook(() => useStocksDiscoverySectionViewModel());
+
+    act(() => result.current.onPressExploreAll());
+
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.MarketList, { category: "stocks" });
+  });
+
+  it("opens the market detail for a tapped discovery stock", () => {
+    const { result } = renderHook(() => useStocksDiscoverySectionViewModel());
+
+    act(() => result.current.onItemPress(stock("TSLA")));
+
+    expect(mockOpenFromMarket).toHaveBeenCalledWith({
+      marketCurrencyId: "TSLA-mkt",
+      ledgerCurrencyIds: ["TSLA-ledger"],
+      source: "portfolio",
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/useStocksDiscoverySectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/useStocksDiscoverySectionViewModel.ts
@@ -1,0 +1,44 @@
+import { useCallback } from "react";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { useAnalytics } from "~/analytics";
+import { ScreenName } from "~/const";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
+import { useDefaultStocksAssets } from "LLM/hooks/useDefaultStocksAssets";
+import { MAX_DISCOVERY_STOCKS } from "LLM/features/WalletAssets/constants";
+
+export interface StocksDiscoverySectionViewModelResult {
+  stocks: StockSuggestion[];
+  isLoading: boolean;
+  isError: boolean;
+  onPressExploreAll: () => void;
+  onItemPress: (stock: StockSuggestion) => void;
+}
+
+export function useStocksDiscoverySectionViewModel(): StocksDiscoverySectionViewModelResult {
+  const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+  const { track } = useAnalytics();
+  const { openFromMarket } = useAssetDetailNavigation();
+  const { stocks, isLoading, isError } = useDefaultStocksAssets(true, MAX_DISCOVERY_STOCKS);
+
+  const onPressExploreAll = useCallback(() => {
+    track("button_clicked", { button: "explore_all", type: "stocks", page: "Wallet" });
+    navigation.navigate(ScreenName.MarketList, { category: "stocks" });
+  }, [navigation, track]);
+
+  const onItemPress = useCallback(
+    (stock: StockSuggestion) => {
+      track("asset_clicked", { asset: stock.name, page: "Wallet" });
+      openFromMarket({
+        marketCurrencyId: stock.navigationId,
+        ledgerCurrencyIds: [stock.ledgerId],
+        source: "portfolio",
+      });
+    },
+    [openFromMarket, track],
+  );
+
+  return { stocks, isLoading, isError, onPressExploreAll, onItemPress };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** `useStocksDiscoverySectionViewModel` tests (stocks from DADA hook, Explore All → Market `stocks`, item → market detail).
- [x] **Impact of the changes:**
  - When a user holds no stocks (and `assetDiscoverability` is on), a horizontal 2-row discovery grid of top stocks appears (wired into the portfolio in the next PR).
  - QA focus: horizontal scroll; "Explore All" opens the Market list filtered to stocks; tapping a pill opens its market detail; loading skeletons.

### 📝 Description

Fourth PR of the **Portfolio Stocks section** (epic LIVE-27854) — the **discovery variant** (user holds 0 stocks). Figma [node-id=23273-105143](https://www.figma.com/design/QZv5fm4oJ1GUS1iIUU8lJt/Home-Production-%E2%80%A2--Wallet-4.0?node-id=23273-105143&m=dev).

- **`StocksDiscoverySection`** + **`useStocksDiscoverySectionViewModel`** — consumes `useDefaultStocksAssets` (PR 1), renders the top `MAX_DISCOVERY_STOCKS = 20` stocks as a horizontal 2-row `MediaButton` grid (even/odd split), with loading skeletons.
- **"Explore All"** → `navigation.navigate(ScreenName.MarketList, { category: "stocks" })` (mirrors `MarketBanner`); a tapped pill opens its market detail via `openFromMarket`.
- Adds the `wallet.stocks.exploreAll` i18n key.

> The 2-row pill grid mirrors the Global Search stocks grid; data-layer reuse (`useStocksData`/`selectTopStocks`/`StockSuggestion`) is shared. The grid markup is currently duplicated across the two features — a shared component could consolidate it in a follow-up.
> Not yet wired into `AssetsSections` (that lands in the final PR).

### ❓ Context

- **JIRA**: [LIVE-31382](https://ledgerhq.atlassian.net/browse/LIVE-31382) — Epic [LIVE-27854](https://ledgerhq.atlassian.net/browse/LIVE-27854)
- **Stacked PR series** (Portfolio Stocks): **4/5**, based on [#18459](https://github.com/LedgerHQ/ledger-live/pull/18459) (LIVE-31381).

[LIVE-31382]: https://ledgerhq.atlassian.net/browse/LIVE-31382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ