### PR TITLE
[LWM] feat(mobile): Portfolio Stocks — wire into AssetsSections [LIVE-31383]

### DIFF
--- a/.changeset/stocks-section-integration.md
+++ b/.changeset/stocks-section-integration.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Wire the Portfolio Stocks section into `AssetsSections` behind the `assetDiscoverability` flag: it renders the holdings list when the user owns stocks and the discovery grid otherwise. Subheader-to-content spacing set to s12.

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/hooks/useWalletAssetsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/hooks/useWalletAssetsViewModel.ts
@@ -13,14 +13,19 @@ interface WalletAssetsViewModelResult {
   onPressShowAll: () => void;
   shouldAddBottomPadding: boolean;
   shouldDisplayAssetSection: boolean;
+  shouldDisplayAssetDiscoverability: boolean;
 }
 
 export function useWalletAssetsViewModel(): WalletAssetsViewModelResult {
   const { onPressShowAll } = usePortfolioSectionActions(false, "all");
   const { categorizedAssets } = useCategorizedAssetsFromPortfolio();
   const { walletCardsDisplayed } = useDynamicContent();
-  const { shouldDisplayOperationsList, shouldDisplayAssetSection, shouldDisplayGraphRework } =
-    useWalletFeaturesConfig("mobile");
+  const {
+    shouldDisplayOperationsList,
+    shouldDisplayAssetSection,
+    shouldDisplayGraphRework,
+    shouldDisplayAssetDiscoverability,
+  } = useWalletFeaturesConfig("mobile");
 
   const hasMore = useMemo(
     () =>
@@ -37,5 +42,6 @@ export function useWalletAssetsViewModel(): WalletAssetsViewModelResult {
     shouldAddBottomPadding:
       shouldDisplayOperationsList && walletCardsDisplayed.length === 0 && shouldDisplayGraphRework,
     shouldDisplayAssetSection,
+    shouldDisplayAssetDiscoverability,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/index.tsx
@@ -15,8 +15,13 @@ export const WalletAssetsView: React.FC<WalletAssetsViewProps> = ({
   variant = "normal",
   noPaddingHorizontal = false,
 }) => {
-  const { hasMore, onPressShowAll, shouldAddBottomPadding, shouldDisplayAssetSection } =
-    useWalletAssetsViewModel();
+  const {
+    hasMore,
+    onPressShowAll,
+    shouldAddBottomPadding,
+    shouldDisplayAssetSection,
+    shouldDisplayAssetDiscoverability,
+  } = useWalletAssetsViewModel();
   const { bottom } = useSafeAreaInsets();
 
   return (
@@ -28,7 +33,11 @@ export const WalletAssetsView: React.FC<WalletAssetsViewProps> = ({
           : undefined
       }
     >
-      <AssetsSections variant={variant} shouldDisplayAssetSection={shouldDisplayAssetSection} />
+      <AssetsSections
+        variant={variant}
+        shouldDisplayAssetSection={shouldDisplayAssetSection}
+        shouldDisplayAssetDiscoverability={shouldDisplayAssetDiscoverability}
+      />
       <AssetsButtonSection
         variant={variant}
         shouldDisplayAssetSection={shouldDisplayAssetSection}

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/AssetsSections/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/AssetsSections/index.tsx
@@ -2,22 +2,26 @@ import React from "react";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { PortfolioCryptosSection } from "LLM/features/WalletAssets/views/CryptosSection";
 import { PortfolioStablecoinsSection } from "LLM/features/WalletAssets/views/StablecoinsSection";
+import { PortfolioStocksSection } from "LLM/features/WalletAssets/views/StocksSection";
 import { WalletAssetsVariant } from "LLM/features/WalletAssets/types";
 
 interface AssetsSectionsProps {
   variant: WalletAssetsVariant;
   shouldDisplayAssetSection: boolean;
+  shouldDisplayAssetDiscoverability: boolean;
 }
 
 export const AssetsSections: React.FC<AssetsSectionsProps> = ({
   variant,
   shouldDisplayAssetSection,
+  shouldDisplayAssetDiscoverability,
 }) => {
   if (shouldDisplayAssetSection) {
     return (
       <Box lx={{ gap: "s16" }}>
         <PortfolioCryptosSection variant={variant} />
         <PortfolioStablecoinsSection variant={variant} />
+        {shouldDisplayAssetDiscoverability && <PortfolioStocksSection />}
       </Box>
     );
   }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
@@ -11,6 +11,7 @@ import { withDiscreetMode } from "~/context/DiscreetModeContext";
 import { useTranslation } from "~/context/Locale";
 import { SectionListContent } from "../../components/SectionListContent";
 import usePortfolioStocksSectionViewModel from "./usePortfolioStocksSectionViewModel";
+import { StocksDiscoverySection } from "./StocksDiscoverySection";
 import { EMPTY_STATE_MAX_STOCKS } from "LLM/features/WalletAssets/constants";
 
 const PortfolioStocksSectionComponent: React.FC = () => {
@@ -18,7 +19,8 @@ const PortfolioStocksSectionComponent: React.FC = () => {
   const { stocksCount, hasMore, stocksToDisplay, isLoading, isError, onPressShowAll, onItemPress } =
     usePortfolioStocksSectionViewModel();
 
-  if (!isLoading && !isError && stocksCount === 0) return null;
+  // No holdings → discovery grid (top stocks); holdings → vertical list.
+  if (!isLoading && !isError && stocksCount === 0) return <StocksDiscoverySection />;
 
   return (
     <Box>
@@ -26,7 +28,7 @@ const PortfolioStocksSectionComponent: React.FC = () => {
         <SubheaderRow
           onPress={hasMore ? onPressShowAll : undefined}
           accessibilityRole={hasMore ? "button" : undefined}
-          lx={{ marginBottom: "s4" }}
+          lx={{ marginBottom: "s12" }}
           testID="portfolio-stocks-section-header"
         >
           <SubheaderTitle>{t("wallet.tabs.stocks")}</SubheaderTitle>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Full WalletAssets suite green (72); section VMs covered in the prior PRs.
- [x] **Impact of the changes:**
  - The Portfolio home now shows a Stocks section (behind `assetDiscoverability`): holdings list when the user owns stocks, discovery grid otherwise.
  - QA focus: FF off → no section; FF on + 0 stocks → discovery grid; FF on + ≥1 stock → holdings list; no regression on Crypto/Stablecoins; s12 subheader→content spacing.

### 📝 Description

Final PR of the **Portfolio Stocks section** (epic LIVE-27854) — composition + gating. Figma [node-id=23273-105057](https://www.figma.com/design/QZv5fm4oJ1GUS1iIUU8lJt/Home-Production-%E2%80%A2--Wallet-4.0?node-id=23273-105057&m=dev).

- **`AssetsSections`** renders `<PortfolioStocksSection />` after Stablecoins, gated by `shouldDisplayAssetDiscoverability` (threaded through `useWalletAssetsViewModel`).
- **`PortfolioStocksSection`** picks the variant internally: holdings list when `stocksCount > 0`, otherwise the discovery grid.
- Subheader→content spacing set to **s12** for both variants.

### ❓ Context

- **JIRA**: [LIVE-31383](https://ledgerhq.atlassian.net/browse/LIVE-31383) — Epic [LIVE-27854](https://ledgerhq.atlassian.net/browse/LIVE-27854)
- **Stacked PR series** (Portfolio Stocks): **5/5**, based on [#18460](https://github.com/LedgerHQ/ledger-live/pull/18460) (LIVE-31382).

[LIVE-31383]: https://ledgerhq.atlassian.net/browse/LIVE-31383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ