### PR TITLE
[LWM] refactor(mobile): share the stocks pill grid (Global Search + Portfolio)

### DIFF
--- a/.changeset/shared-stock-pill-rows.md
+++ b/.changeset/shared-stock-pill-rows.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Extract a shared `StockPillRows` component (two horizontally-scrollable rows of stock pills) used by both Global Search and the Portfolio Stocks discovery section, removing the duplicated grid. Finalize the Stocks subheader spacing: the holdings list matches the other portfolio sections, the discovery grid uses s12.

--- a/apps/ledger-live-mobile/src/mvvm/components/StockPillRows/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/StockPillRows/index.tsx
@@ -1,0 +1,108 @@
+import React, { useCallback, useMemo } from "react";
+import { ScrollView } from "react-native";
+import Icon from "@ledgerhq/crypto-icons/native";
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { Box, MediaButton, Skeleton } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+
+type Props = Readonly<{
+  stocks: StockSuggestion[];
+  isLoading: boolean;
+  onStockPress: (stock: StockSuggestion) => void;
+  skeletonPillsPerRow: number;
+  testIdPrefix: string;
+}>;
+
+function splitIntoRows(stocks: StockSuggestion[]): [StockSuggestion[], StockSuggestion[]] {
+  const top: StockSuggestion[] = [];
+  const bottom: StockSuggestion[] = [];
+  stocks.forEach((stock, index) => (index % 2 === 0 ? top : bottom).push(stock));
+  return [top, bottom];
+}
+
+type StockPillProps = Readonly<{
+  stock: StockSuggestion;
+  onPress: (stock: StockSuggestion) => void;
+  testIdPrefix: string;
+}>;
+
+function StockPill({ stock, onPress, testIdPrefix }: StockPillProps) {
+  const handlePress = useCallback(() => onPress(stock), [stock, onPress]);
+
+  return (
+    <MediaButton
+      size="sm"
+      hideChevron
+      leadingContentShape="rounded"
+      leadingContent={<Icon ledgerId={stock.ledgerId} ticker={stock.ticker} size={24} />}
+      onPress={handlePress}
+      accessibilityLabel={stock.name}
+      testID={`${testIdPrefix}-${stock.ticker.toLowerCase()}`}
+    >
+      {stock.ticker.toUpperCase()}
+    </MediaButton>
+  );
+}
+
+/**
+ * Top stocks laid out as two horizontally-scrollable rows of pills (even/odd split).
+ * Shared by Global Search and the Portfolio Stocks discovery section.
+ */
+export function StockPillRows({
+  stocks,
+  isLoading,
+  onStockPress,
+  skeletonPillsPerRow,
+  testIdPrefix,
+}: Props) {
+  const [topRow, bottomRow] = useMemo(() => splitIntoRows(stocks), [stocks]);
+
+  const renderSkeletonPills = () =>
+    Array.from({ length: skeletonPillsPerRow }, (_, index) => (
+      <Skeleton key={index} lx={pillSkeletonStyle} />
+    ));
+
+  if (isLoading) {
+    return (
+      <Box lx={gridStyle}>
+        <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
+        <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
+      </Box>
+    );
+  }
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+    >
+      <Box lx={gridStyle}>
+        <Box lx={rowStyle}>
+          {topRow.map(stock => (
+            <StockPill
+              key={stock.id}
+              stock={stock}
+              onPress={onStockPress}
+              testIdPrefix={testIdPrefix}
+            />
+          ))}
+        </Box>
+        <Box lx={rowStyle}>
+          {bottomRow.map(stock => (
+            <StockPill
+              key={stock.id}
+              stock={stock}
+              onPress={onStockPress}
+              testIdPrefix={testIdPrefix}
+            />
+          ))}
+        </Box>
+      </Box>
+    </ScrollView>
+  );
+}
+
+const gridStyle: LumenViewStyle = { gap: "s8", paddingHorizontal: "s16" };
+const rowStyle: LumenViewStyle = { flexDirection: "row", gap: "s8" };
+const pillSkeletonStyle: LumenViewStyle = { width: "s96", height: "s40", borderRadius: "full" };

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/StocksSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/StocksSection/index.tsx
@@ -1,17 +1,14 @@
-import React, { useCallback, useMemo } from "react";
-import { ScrollView } from "react-native";
-import Icon from "@ledgerhq/crypto-icons/native";
+import React, { useCallback } from "react";
 import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
 import {
   Box,
-  MediaButton,
-  Skeleton,
   Subheader,
   SubheaderRow,
   SubheaderShowMore,
   SubheaderTitle,
 } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { StockPillRows } from "LLM/components/StockPillRows";
 import type { GlobalSearchCategory } from "../../useGlobalSearchViewModel";
 
 const SKELETON_PILLS_PER_ROW = 4;
@@ -26,36 +23,6 @@ type Props = Readonly<{
   onStockPress: (stock: StockSuggestion) => void;
 }>;
 
-function splitIntoRows(stocks: StockSuggestion[]): [StockSuggestion[], StockSuggestion[]] {
-  const top: StockSuggestion[] = [];
-  const bottom: StockSuggestion[] = [];
-  stocks.forEach((stock, index) => (index % 2 === 0 ? top : bottom).push(stock));
-  return [top, bottom];
-}
-
-type StockPillProps = Readonly<{
-  stock: StockSuggestion;
-  onPress: (stock: StockSuggestion) => void;
-}>;
-
-function StockPill({ stock, onPress }: StockPillProps) {
-  const handlePress = useCallback(() => onPress(stock), [stock, onPress]);
-
-  return (
-    <MediaButton
-      size="sm"
-      hideChevron
-      leadingContentShape="rounded"
-      leadingContent={<Icon ledgerId={stock.ledgerId} ticker={stock.ticker} size={24} />}
-      onPress={handlePress}
-      accessibilityLabel={stock.name}
-      testID={`global-search-stock-${stock.ticker.toLowerCase()}`}
-    >
-      {stock.ticker.toUpperCase()}
-    </MediaButton>
-  );
-}
-
 export function StocksSection({
   title,
   testID,
@@ -65,15 +32,9 @@ export function StocksSection({
   onSeeAll,
   onStockPress,
 }: Props) {
-  const [topRow, bottomRow] = useMemo(() => splitIntoRows(stocks), [stocks]);
   const handleSeeAll = useCallback(() => onSeeAll(category), [onSeeAll, category]);
 
   if (!isLoading && stocks.length === 0) return null;
-
-  const renderSkeletonPills = () =>
-    Array.from({ length: SKELETON_PILLS_PER_ROW }, (_, index) => (
-      <Skeleton key={index} lx={pillSkeletonStyle} />
-    ));
 
   return (
     <Box lx={sectionStyle} testID={testID}>
@@ -89,40 +50,16 @@ export function StocksSection({
           </SubheaderRow>
         </Subheader>
       </Box>
-      {isLoading ? (
-        <Box lx={insetStyle}>
-          <Box lx={skeletonGridStyle}>
-            <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
-            <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
-          </Box>
-        </Box>
-      ) : (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          keyboardShouldPersistTaps="handled"
-        >
-          <Box lx={gridStyle}>
-            <Box lx={rowStyle}>
-              {topRow.map(stock => (
-                <StockPill key={stock.id} stock={stock} onPress={onStockPress} />
-              ))}
-            </Box>
-            <Box lx={rowStyle}>
-              {bottomRow.map(stock => (
-                <StockPill key={stock.id} stock={stock} onPress={onStockPress} />
-              ))}
-            </Box>
-          </Box>
-        </ScrollView>
-      )}
+      <StockPillRows
+        stocks={stocks}
+        isLoading={isLoading}
+        onStockPress={onStockPress}
+        skeletonPillsPerRow={SKELETON_PILLS_PER_ROW}
+        testIdPrefix="global-search-stock"
+      />
     </Box>
   );
 }
 
 const sectionStyle: LumenViewStyle = { gap: "s16", marginHorizontal: "-s16" };
 const insetStyle: LumenViewStyle = { paddingHorizontal: "s16" };
-const gridStyle: LumenViewStyle = { gap: "s8", paddingHorizontal: "s16" };
-const skeletonGridStyle: LumenViewStyle = { gap: "s8" };
-const rowStyle: LumenViewStyle = { flexDirection: "row", gap: "s8" };
-const pillSkeletonStyle: LumenViewStyle = { width: "s96", height: "s40", borderRadius: "full" };

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/StocksDiscoverySection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/StocksDiscoverySection.tsx
@@ -1,63 +1,17 @@
-import React, { useCallback, useMemo } from "react";
-import { ScrollView } from "react-native";
-import Icon from "@ledgerhq/crypto-icons/native";
-import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
-import {
-  Box,
-  MediaButton,
-  Skeleton,
-  Subheader,
-  SubheaderRow,
-  SubheaderTitle,
-  Text,
-} from "@ledgerhq/lumen-ui-rnative";
+import React from "react";
+import { Box, Subheader, SubheaderRow, SubheaderTitle, Text } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useTranslation } from "~/context/Locale";
+import { StockPillRows } from "LLM/components/StockPillRows";
 import { EMPTY_STATE_MAX_STOCKS } from "LLM/features/WalletAssets/constants";
 import { useStocksDiscoverySectionViewModel } from "./useStocksDiscoverySectionViewModel";
-
-function splitIntoRows(stocks: StockSuggestion[]): [StockSuggestion[], StockSuggestion[]] {
-  const top: StockSuggestion[] = [];
-  const bottom: StockSuggestion[] = [];
-  stocks.forEach((stock, index) => (index % 2 === 0 ? top : bottom).push(stock));
-  return [top, bottom];
-}
-
-type StockPillProps = Readonly<{
-  stock: StockSuggestion;
-  onPress: (stock: StockSuggestion) => void;
-}>;
-
-function StockPill({ stock, onPress }: StockPillProps) {
-  const handlePress = useCallback(() => onPress(stock), [stock, onPress]);
-
-  return (
-    <MediaButton
-      size="sm"
-      hideChevron
-      leadingContentShape="rounded"
-      leadingContent={<Icon ledgerId={stock.ledgerId} ticker={stock.ticker} size={24} />}
-      onPress={handlePress}
-      accessibilityLabel={stock.name}
-      testID={`portfolio-discovery-stock-${stock.ticker.toLowerCase()}`}
-    >
-      {stock.ticker.toUpperCase()}
-    </MediaButton>
-  );
-}
 
 export function StocksDiscoverySection() {
   const { t } = useTranslation();
   const { stocks, isLoading, isError, onPressExploreAll, onItemPress } =
     useStocksDiscoverySectionViewModel();
-  const [topRow, bottomRow] = useMemo(() => splitIntoRows(stocks), [stocks]);
 
   if (!isLoading && (isError || stocks.length === 0)) return null;
-
-  const renderSkeletonPills = () =>
-    Array.from({ length: EMPTY_STATE_MAX_STOCKS }, (_, index) => (
-      <Skeleton key={index} lx={pillSkeletonStyle} />
-    ));
 
   return (
     <Box lx={sectionStyle} testID="portfolio-stocks-discovery">
@@ -75,29 +29,13 @@ export function StocksDiscoverySection() {
           </SubheaderRow>
         </Subheader>
       </Box>
-      {isLoading ? (
-        <Box lx={insetStyle}>
-          <Box lx={gridStyle}>
-            <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
-            <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
-          </Box>
-        </Box>
-      ) : (
-        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-          <Box lx={gridStyle}>
-            <Box lx={rowStyle}>
-              {topRow.map(stock => (
-                <StockPill key={stock.id} stock={stock} onPress={onItemPress} />
-              ))}
-            </Box>
-            <Box lx={rowStyle}>
-              {bottomRow.map(stock => (
-                <StockPill key={stock.id} stock={stock} onPress={onItemPress} />
-              ))}
-            </Box>
-          </Box>
-        </ScrollView>
-      )}
+      <StockPillRows
+        stocks={stocks}
+        isLoading={isLoading}
+        onStockPress={onItemPress}
+        skeletonPillsPerRow={EMPTY_STATE_MAX_STOCKS}
+        testIdPrefix="portfolio-discovery-stock"
+      />
     </Box>
   );
 }
@@ -105,6 +43,3 @@ export function StocksDiscoverySection() {
 const exploreAllStyle = { marginLeft: "auto" as const };
 const sectionStyle: LumenViewStyle = { gap: "s12", marginHorizontal: "-s16" };
 const insetStyle: LumenViewStyle = { paddingHorizontal: "s16" };
-const gridStyle: LumenViewStyle = { gap: "s8", paddingHorizontal: "s16" };
-const rowStyle: LumenViewStyle = { flexDirection: "row", gap: "s8" };
-const pillSkeletonStyle: LumenViewStyle = { width: "s96", height: "s40", borderRadius: "full" };

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
@@ -28,7 +28,7 @@ const PortfolioStocksSectionComponent: React.FC = () => {
         <SubheaderRow
           onPress={hasMore ? onPressShowAll : undefined}
           accessibilityRole={hasMore ? "button" : undefined}
-          lx={{ marginBottom: "s12" }}
+          lx={{ marginBottom: "s4" }}
           testID="portfolio-stocks-section-header"
         >
           <SubheaderTitle>{t("wallet.tabs.stocks")}</SubheaderTitle>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Existing Global Search + Portfolio StocksSection suites pass unchanged (46) — same testIDs/behaviour.
- [x] **Impact of the changes:**
  - Pure refactor + spacing polish; no behavioural change.
  - QA focus: Global Search stocks pills and the Portfolio discovery grid look/behave identically; subheader→content spacing (list vs grid).

### 📝 Description

Follow-up to the Portfolio Stocks epic: the 2-row stocks pill grid existed in **both** Global Search and the new Portfolio discovery section. This extracts the shared markup and removes the duplication.

- **New `LLM/components/StockPillRows`** — two horizontally-scrollable rows of `MediaButton` stock pills (even/odd split) + loading skeleton, parameterised by `stocks` / `isLoading` / `onStockPress` / `skeletonPillsPerRow` / `testIdPrefix`.
- Rewires **Global Search `StocksSection`** and **Portfolio `StocksDiscoverySection`** to render it (each keeps its own Subheader). Existing testIDs preserved (`global-search-stock-*`, `portfolio-discovery-stock-*`).
- **Spacing finalised** per design: the holdings **list** uses the same subheader spacing as the other portfolio sections (`s4`), the discovery **grid** uses `s12`.

### ❓ Context

- **Epic**: [LIVE-27854](https://ledgerhq.atlassian.net/browse/LIVE-27854)
- **Stacked on** [#18462](https://github.com/LedgerHQ/ledger-live/pull/18462) (LIVE-31383), the final Portfolio Stocks PR.

[LIVE-27854]: https://ledgerhq.atlassian.net/browse/LIVE-27854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ