### PR TITLE
[LWDM] feat(lwm): add memo/tag input to new send flow

### DIFF
--- a/.changeset/memo-tag-new-send-flow.md
+++ b/.changeset/memo-tag-new-send-flow.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": patch
+---
+
+Add memo/tag input to the new send flow, and clear an empty memo/tag in applyMemoToTransaction instead of applying 0 or an empty string

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -64,6 +64,7 @@ import {
   SettingsIsOnboardingFlowReceiveSuccessPayload,
   SettingsIsPostOnboardingFlowPayload,
   SettingsSetHasSeenWalletV4TourPayload,
+  SettingsSetDoNotAskAgainSkipMemoPayload,
   SettingsSetProductTourCompletedPayload,
   SettingsSetAnalyticsConsentInfoPayload,
   SettingsSetHasClickedRecoverPayload,
@@ -287,6 +288,10 @@ export const setSelectedTabPortfolioAssets =
 
 export const setHasSeenWalletV4Tour = createAction<SettingsSetHasSeenWalletV4TourPayload>(
   SettingsActionTypes.SET_HAS_SEEN_WALLET_V4_TOUR,
+);
+
+export const setDoNotAskAgainSkipMemo = createAction<SettingsSetDoNotAskAgainSkipMemoPayload>(
+  SettingsActionTypes.SET_DO_NOT_ASK_AGAIN_SKIP_MEMO,
 );
 
 export const setProductTourCompleted = createAction<SettingsSetProductTourCompletedPayload>(

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -317,6 +317,7 @@ export enum SettingsActionTypes {
   REMOVE_STARRED_MARKET_COINS = "REMOVE_STARRED_MARKET_COINS",
   SET_HAS_SEEN_WALLET_V4_TOUR = "SET_HAS_SEEN_WALLET_V4_TOUR",
   SET_PRODUCT_TOUR_COMPLETED = "SET_PRODUCT_TOUR_COMPLETED",
+  SET_DO_NOT_ASK_AGAIN_SKIP_MEMO = "SET_DO_NOT_ASK_AGAIN_SKIP_MEMO",
   DEPRECATION_DO_NOT_REMIND = "DEPRECATION_DO_NOT_REMIND",
   SET_ANALYTICS_CONSENT_INFO = "SET_ANALYTICS_CONSENT_INFO",
   SET_HAS_CLICKED_RECOVER = "SET_HAS_CLICKED_RECOVER",
@@ -402,6 +403,7 @@ export type SettingsSetSupportedCounterValues = SettingsState["supportedCounterV
 export type SettingsSetHasSeenAnalyticsOptInPrompt = SettingsState["hasSeenAnalyticsOptInPrompt"];
 export type SettingsSetAnalyticsConsentInfoPayload = SettingsState["analyticsConsentInfo"];
 export type SettingsSetHasSeenWalletV4TourPayload = SettingsState["hasSeenWalletV4Tour"];
+export type SettingsSetDoNotAskAgainSkipMemoPayload = SettingsState["doNotAskAgainSkipMemo"];
 export type SettingsSetProductTourCompletedPayload = SettingsState["productTourCompleted"];
 export type SettingsSetDismissedContentCardsPayload = SettingsState["dismissedContentCards"];
 export type SettingsClearDismissedContentCardsPayload = string[];
@@ -470,6 +472,7 @@ export type SettingsPayload =
   | SettingsAddStarredMarketcoinsPayload
   | SettingsRemoveStarredMarketcoinsPayload
   | SettingsSetHasSeenWalletV4TourPayload
+  | SettingsSetDoNotAskAgainSkipMemoPayload
   | SettingsSetProductTourCompletedPayload
   | SettingsSetHasClickedRecoverPayload;
 

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4431,12 +4431,24 @@
         "walletNotExist": "Wallet doesn’t exist"
       },
       "skipMemo": {
-        "title": "Skip adding {{tag}}?",
-        "warning": "Your asset may be lost if a {{tag}} is required by your recipient"
+        "title": "Skip adding a {{tag}}?",
+        "warning": "Your asset may be lost if a {{tag}} is required by your recipient",
+        "notRequired": "{{tag}} not required by recipient?",
+        "confirm": "Yes, skip",
+        "neverAskAgain": "Don’t show this warning again"
       },
       "tagHelp": {
         "title": "What’s a {{tag}}?",
-        "description": "A {{tag}} is required when sending {{currency}} to a crypto exchange. It’s a feature used to identify the recipient of the transaction. Not including the {{tag}} memo may result in a loss of funds."
+        "description": "A {{tag}} is required when sending {{currency}} to a crypto exchange. It’s a feature used to identify the recipient of the transaction. Not including the {{tag}} may result in a loss of funds."
+      },
+      "memoLabel": {
+        "ripple": "Tag",
+        "casper": "Transfer ID",
+        "ton": "Comment",
+        "default": "Memo"
+      },
+      "memo": {
+        "transactionIdentifier": "Transaction identifier"
       },
       "networkFeesInFiat": "Network fees in {{currency}}",
       "feesAmount": "Fees amount ({{unit}})",

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/MemoControls.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/MemoControls.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
+import { MemoTypeSelect } from "./MemoTypeSelect";
+import { MemoValueInput } from "./MemoValueInput";
+import { SkipMemoSection } from "./SkipMemoSection";
+import type { useMemoViewModel } from "./hooks/useMemoViewModel";
+
+type MemoControlsProps = Readonly<{
+  vm: ReturnType<typeof useMemoViewModel>;
+}>;
+
+export function MemoControls({ vm }: MemoControlsProps) {
+  const styles = useStyleSheet(
+    theme => ({
+      root: {
+        marginTop: -theme.spacings.s12,
+        marginBottom: theme.spacings.s24,
+        gap: theme.spacings.s12,
+        paddingHorizontal: theme.spacings.s8,
+      },
+    }),
+    [],
+  );
+
+  return (
+    <Box style={styles.root}>
+      {vm.hasMemoTypeOptions && (
+        <MemoTypeSelect
+          currencyId={vm.currencyId}
+          options={vm.memoTypeOptions}
+          value={vm.memo.type}
+          onChange={vm.onMemoTypeChange}
+        />
+      )}
+
+      {vm.showMemoValueInput && (
+        <MemoValueInput
+          currencyId={vm.currencyId}
+          memoLabel={vm.memoLabel}
+          value={vm.memo.value}
+          maxLength={vm.uiConfig.memoMaxLength}
+          memoType={vm.uiConfig.memoType}
+          memoMaxValue={vm.uiConfig.memoMaxValue}
+          transactionError={vm.memoError}
+          onChange={vm.onMemoValueChange}
+        />
+      )}
+
+      {vm.showSkipMemo && (
+        <SkipMemoSection
+          memoLabel={vm.memoLabel}
+          state={vm.skipMemoState}
+          onRequestConfirm={vm.onSkipMemoRequestConfirm}
+          onConfirm={vm.onSkipMemoConfirm}
+        />
+      )}
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/MemoTypeSelect.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/MemoTypeSelect.tsx
@@ -1,0 +1,83 @@
+import {
+  BottomSheet,
+  BottomSheetHeader,
+  BottomSheetView,
+  OptionList,
+  OptionListContent,
+  OptionListItem,
+  OptionListItemContent,
+  OptionListItemText,
+  OptionListTrigger,
+  Text,
+  useBottomSheetRef,
+} from "@ledgerhq/lumen-ui-rnative";
+import React, { useCallback, useMemo } from "react";
+import { useTranslation } from "~/context/Locale";
+
+type MemoTypeSelectProps = Readonly<{
+  currencyId: string;
+  options: readonly string[];
+  value?: string;
+  onChange: (value: string) => void;
+}>;
+
+function MemoTypeSelectComponent({ currencyId, options, value, onChange }: MemoTypeSelectProps) {
+  const { t } = useTranslation();
+  const bottomSheetRef = useBottomSheetRef();
+
+  const items = useMemo(
+    () =>
+      options.map(option => ({
+        value: option,
+        label: t(`${currencyId}.memoType.${option}`),
+      })),
+    [currencyId, options, t],
+  );
+
+  const selectedItem = useMemo(() => items.find(item => item.value === value), [items, value]);
+
+  const handleOpenSheet = useCallback(() => {
+    bottomSheetRef.current?.present();
+  }, [bottomSheetRef]);
+
+  const handleValueChange = useCallback(
+    (newValue: string | null) => {
+      if (newValue != null) {
+        onChange(newValue);
+        bottomSheetRef.current?.dismiss();
+      }
+    },
+    [bottomSheetRef, onChange],
+  );
+
+  return (
+    <>
+      <OptionListTrigger onPress={handleOpenSheet}>
+        {selectedItem != null && (
+          <Text typography="body1" lx={{ color: "base" }}>
+            {selectedItem.label}
+          </Text>
+        )}
+      </OptionListTrigger>
+      <BottomSheet ref={bottomSheetRef} enableDynamicSizing snapPoints={null}>
+        <BottomSheetView>
+          <BottomSheetHeader title={t("send.newSendFlow.memo.transactionIdentifier")} />
+          <OptionList items={items} value={value ?? null} onValueChange={handleValueChange}>
+            <OptionListContent
+              lx={{ marginBottom: "s24" }}
+              renderItem={item => (
+                <OptionListItem value={item.value}>
+                  <OptionListItemContent>
+                    <OptionListItemText>{item.label}</OptionListItemText>
+                  </OptionListItemContent>
+                </OptionListItem>
+              )}
+            />
+          </OptionList>
+        </BottomSheetView>
+      </BottomSheet>
+    </>
+  );
+}
+
+export const MemoTypeSelect = React.memo(MemoTypeSelectComponent);

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/MemoValueInput.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/MemoValueInput.tsx
@@ -1,0 +1,101 @@
+import React, { useCallback } from "react";
+import { Pressable } from "react-native";
+import {
+  BottomSheet,
+  BottomSheetHeader,
+  BottomSheetView,
+  Box,
+  Text,
+  TextInput,
+  useBottomSheetRef,
+} from "@ledgerhq/lumen-ui-rnative";
+import { Information } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTranslation } from "~/context/Locale";
+import { useTranslatedBridgeError } from "../../screens/Recipient/hooks/useTranslatedBridgeError";
+
+type MemoValueInputProps = Readonly<{
+  currencyId: string;
+  memoLabel: string;
+  value: string;
+  maxLength?: number;
+  memoType?: string;
+  memoMaxValue?: number;
+  transactionError?: Error;
+  onChange: (value: string) => void;
+}>;
+
+function MemoValueInputComponent({
+  currencyId,
+  memoLabel,
+  value,
+  maxLength,
+  memoType,
+  memoMaxValue,
+  transactionError,
+  onChange,
+}: MemoValueInputProps) {
+  const { t } = useTranslation();
+  const helpSheetRef = useBottomSheetRef();
+  const translatedError = useTranslatedBridgeError(transactionError);
+  const errorMessage = translatedError?.title;
+
+  const isTagType = memoType === "tag";
+
+  const handleChangeText = useCallback(
+    (text: string) => {
+      let next = text;
+      if (isTagType) {
+        next = next.replace(/\D/g, "");
+        if (memoMaxValue != null && next !== "") {
+          const num = Number(next);
+          if (num > memoMaxValue) next = String(memoMaxValue);
+        }
+      }
+      onChange(next);
+    },
+    [isTagType, memoMaxValue, onChange],
+  );
+
+  const openHelp = useCallback(() => {
+    helpSheetRef.current?.present();
+  }, [helpSheetRef]);
+
+  return (
+    <>
+      <TextInput
+        testID="send-memo-input"
+        label={t("send.newSendFlow.enterTag", { tag: memoLabel })}
+        value={value}
+        onChangeText={handleChangeText}
+        keyboardType={isTagType ? "number-pad" : "default"}
+        maxLength={isTagType ? undefined : maxLength}
+        helperText={errorMessage}
+        status={errorMessage ? "error" : undefined}
+        suffix={
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t("send.newSendFlow.tagHelp.title", { tag: memoLabel })}
+            onPress={openHelp}
+          >
+            <Information size={20} lx={{ color: "muted" }} />
+          </Pressable>
+        }
+      />
+      <BottomSheet ref={helpSheetRef} enableDynamicSizing snapPoints={null}>
+        <BottomSheetView>
+          <BottomSheetHeader />
+          <Box lx={{ paddingHorizontal: "s16", paddingBottom: "s24", gap: "s12" }}>
+            <Text typography="heading4SemiBold" lx={{ color: "base" }}>
+              {t("send.newSendFlow.tagHelp.title", { tag: memoLabel })}
+            </Text>
+            <Text typography="body2" lx={{ color: "muted" }}>
+              {t("send.newSendFlow.tagHelp.description", { tag: memoLabel, currency: currencyId })}
+            </Text>
+          </Box>
+        </BottomSheetView>
+      </BottomSheet>
+    </>
+  );
+}
+
+export const MemoValueInput = React.memo(MemoValueInputComponent);

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/SkipMemoSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/SkipMemoSection.tsx
@@ -1,0 +1,80 @@
+import React, { useCallback, useState } from "react";
+import { Linking, Pressable } from "react-native";
+import { Banner, Box, Button, Checkbox, Link, Text } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "~/context/Locale";
+import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
+import { urls } from "~/utils/urls";
+import type { SkipMemoState } from "./hooks/useRecipientMemo";
+
+type SkipMemoSectionProps = Readonly<{
+  memoLabel: string;
+  state: SkipMemoState;
+  onRequestConfirm: () => void;
+  onConfirm: (doNotAskAgain: boolean) => void;
+}>;
+
+function SkipMemoSectionComponent({
+  memoLabel,
+  state,
+  onRequestConfirm,
+  onConfirm,
+}: SkipMemoSectionProps) {
+  const { t } = useTranslation();
+  const [doNotAskAgain, setDoNotAskAgain] = useState(false);
+  const learnMoreUrl = useLocalizedUrl(urls.memoTag);
+
+  const handleLearnMore = useCallback(() => {
+    if (learnMoreUrl) Linking.openURL(learnMoreUrl);
+  }, [learnMoreUrl]);
+
+  const handleConfirm = useCallback(() => {
+    onConfirm(doNotAskAgain);
+  }, [onConfirm, doNotAskAgain]);
+
+  if (state === "propose") {
+    return (
+      <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s4" }}>
+        <Text lx={{ color: "muted" }}>
+          {t("send.newSendFlow.skipMemo.notRequired", { tag: memoLabel })}
+        </Text>
+        <Link appearance="accent" size="sm" onPress={onRequestConfirm}>
+          {t("common.skip")}
+        </Link>
+      </Box>
+    );
+  }
+
+  return (
+    <Box lx={{ gap: "s16" }}>
+      <Banner
+        appearance="warning"
+        title={t("send.newSendFlow.skipMemo.title", { tag: memoLabel })}
+        description={t("send.newSendFlow.skipMemo.warning", { tag: memoLabel })}
+        primaryAction={
+          <Button appearance="transparent" size="sm" onPress={handleConfirm}>
+            {t("send.newSendFlow.skipMemo.confirm")}
+          </Button>
+        }
+        secondaryAction={
+          <Button appearance="no-background" size="sm" onPress={handleLearnMore}>
+            {t("common.learnMore")}
+          </Button>
+        }
+      />
+      <Pressable
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: doNotAskAgain }}
+        onPress={() => setDoNotAskAgain(prev => !prev)}
+      >
+        <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s8" }}>
+          <Box pointerEvents="none">
+            <Checkbox checked={doNotAskAgain} />
+          </Box>
+          <Text lx={{ color: "base" }}>{t("send.newSendFlow.skipMemo.neverAskAgain")}</Text>
+        </Box>
+      </Pressable>
+    </Box>
+  );
+}
+
+export const SkipMemoSection = React.memo(SkipMemoSectionComponent);

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/__tests__/shouldShowMatchedAddress.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/__tests__/shouldShowMatchedAddress.test.ts
@@ -1,0 +1,58 @@
+import { shouldShowMatchedAddress } from "../shouldShowMatchedAddress";
+
+describe("shouldShowMatchedAddress", () => {
+  it("hides the matched-address row while there is no valid recipient", () => {
+    expect(
+      shouldShowMatchedAddress({
+        showMatchedAddress: false,
+        hasMemo: true,
+        hasFilledMemo: true,
+        hasMemoError: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("shows the matched-address row immediately on chains without memo", () => {
+    expect(
+      shouldShowMatchedAddress({
+        showMatchedAddress: true,
+        hasMemo: false,
+        hasFilledMemo: false,
+        hasMemoError: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps it hidden on memo chains until the memo is filled or skipped", () => {
+    expect(
+      shouldShowMatchedAddress({
+        showMatchedAddress: true,
+        hasMemo: true,
+        hasFilledMemo: false,
+        hasMemoError: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("shows it on memo chains once the memo is filled (or skipped as NO_MEMO)", () => {
+    expect(
+      shouldShowMatchedAddress({
+        showMatchedAddress: true,
+        hasMemo: true,
+        hasFilledMemo: true,
+        hasMemoError: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps it hidden when the filled memo has an error", () => {
+    expect(
+      shouldShowMatchedAddress({
+        showMatchedAddress: true,
+        hasMemo: true,
+        hasFilledMemo: true,
+        hasMemoError: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/hooks/__tests__/useRecipientMemo.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/hooks/__tests__/useRecipientMemo.test.ts
@@ -1,0 +1,95 @@
+import { act, renderHook } from "@testing-library/react-native";
+import { useRecipientMemo } from "../useRecipientMemo";
+
+const mockSetDoNotAskAgain = jest.fn();
+let mockDoNotAskAgain = false;
+
+jest.mock("../useDoNotAskAgainSkipMemo", () => ({
+  useDoNotAskAgainSkipMemo: () => [mockDoNotAskAgain, mockSetDoNotAskAgain],
+}));
+
+function setup(overrides: Partial<Parameters<typeof useRecipientMemo>[0]> = {}) {
+  const onMemoChange = jest.fn();
+  const onMemoSkip = jest.fn();
+  const initialProps: Parameters<typeof useRecipientMemo>[0] = {
+    hasMemo: true,
+    memoType: "text",
+    memoTypeOptions: undefined,
+    memoDefaultOption: undefined,
+    onMemoChange,
+    onMemoSkip,
+    resetKey: "acc|xrp|addr",
+    ...overrides,
+  };
+  const utils = renderHook(
+    (props: Parameters<typeof useRecipientMemo>[0]) => useRecipientMemo(props),
+    { initialProps },
+  );
+  return { ...utils, onMemoChange, onMemoSkip, initialProps };
+}
+
+describe("useRecipientMemo", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDoNotAskAgain = false;
+  });
+
+  it("shows the type selector only for typed memos with options", () => {
+    const typed = setup({ memoType: "typed", memoTypeOptions: ["NO_MEMO", "MEMO_TEXT"] });
+    expect(typed.result.current.hasMemoTypeOptions).toBe(true);
+
+    const text = setup({ memoType: "text", memoTypeOptions: undefined });
+    expect(text.result.current.hasMemoTypeOptions).toBe(false);
+  });
+
+  it("propagates value changes and keeps showing the input", () => {
+    const { result, onMemoChange } = setup();
+    act(() => result.current.onMemoValueChange("123"));
+    expect(onMemoChange).toHaveBeenLastCalledWith({ value: "123", type: undefined });
+    expect(result.current.showMemoValueInput).toBe(true);
+  });
+
+  it("resets the value when the memo type changes", () => {
+    const { result, onMemoChange } = setup({
+      memoType: "typed",
+      memoTypeOptions: ["NO_MEMO", "MEMO_TEXT", "MEMO_ID"],
+    });
+    act(() => result.current.onMemoValueChange("abc"));
+    act(() => result.current.onMemoTypeChange("MEMO_ID"));
+    expect(onMemoChange).toHaveBeenLastCalledWith({ value: "", type: "MEMO_ID" });
+    expect(result.current.memo).toEqual({ value: "", type: "MEMO_ID" });
+  });
+
+  it("runs the skip flow propose -> toConfirm -> confirmed and proceeds", () => {
+    const { result, onMemoChange, onMemoSkip } = setup();
+    expect(result.current.skipMemoState).toBe("propose");
+
+    act(() => result.current.onSkipMemoRequestConfirm());
+    expect(result.current.skipMemoState).toBe("toConfirm");
+
+    act(() => result.current.onSkipMemoConfirm(false));
+    expect(result.current.skipMemoState).toBe("confirmed");
+    expect(onMemoChange).toHaveBeenLastCalledWith({ value: "", type: "NO_MEMO" });
+    expect(onMemoSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips immediately when the user opted out of the confirmation", () => {
+    mockDoNotAskAgain = true;
+    const { result, onMemoSkip } = setup();
+    act(() => result.current.onSkipMemoRequestConfirm());
+    expect(result.current.skipMemoState).toBe("confirmed");
+    expect(onMemoSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists the do-not-ask-again preference on confirm", () => {
+    const { result } = setup();
+    act(() => result.current.onSkipMemoRequestConfirm());
+    act(() => result.current.onSkipMemoConfirm(true));
+    expect(mockSetDoNotAskAgain).toHaveBeenCalledWith(true);
+  });
+
+  it("does not allow skipping when the chain has no memo", () => {
+    const { result } = setup({ hasMemo: false });
+    expect(result.current.showSkipMemo).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/hooks/useDoNotAskAgainSkipMemo.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/hooks/useDoNotAskAgainSkipMemo.ts
@@ -1,0 +1,16 @@
+import { useCallback } from "react";
+import { useDispatch, useSelector } from "~/context/hooks";
+import { setDoNotAskAgainSkipMemo } from "~/actions/settings";
+import { doNotAskAgainSkipMemoSelector } from "~/reducers/settings";
+
+export function useDoNotAskAgainSkipMemo(): [boolean, (doNotAskAgainSkipMemo: boolean) => void] {
+  const dispatch = useDispatch();
+  const value = useSelector(doNotAskAgainSkipMemoSelector);
+  const setter = useCallback(
+    (doNotAskAgainSkipMemo: boolean) => {
+      dispatch(setDoNotAskAgainSkipMemo(doNotAskAgainSkipMemo));
+    },
+    [dispatch],
+  );
+  return [value, setter];
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/hooks/useMemoViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/hooks/useMemoViewModel.ts
@@ -1,0 +1,60 @@
+import { useCallback, useMemo, useRef } from "react";
+import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
+import type { Memo } from "@ledgerhq/live-common/flows/send/types";
+import { useTranslation } from "~/context/Locale";
+import { useSendFlowActions, useSendFlowData } from "../../../context/SendFlowContext";
+import { useRecipientMemo } from "./useRecipientMemo";
+
+type UseMemoViewModelProps = Readonly<{
+  address: string;
+  onSkip: () => void;
+}>;
+
+export function useMemoViewModel({ address, onSkip }: UseMemoViewModelProps) {
+  const { t } = useTranslation();
+  const { state, uiConfig } = useSendFlowData();
+  const { transaction } = useSendFlowActions();
+
+  const currency = state.account.currency;
+  const currencyId = currency?.id ?? "";
+
+  const memoLabel = t([
+    `send.newSendFlow.memoLabel.${currencyId}`,
+    "send.newSendFlow.memoLabel.default",
+  ]);
+
+  const memoDefaultOption = useMemo(
+    () => sendFeatures.getMemoDefaultOption(currency ?? undefined),
+    [currency],
+  );
+
+  const memoTypeOptions = useMemo(() => uiConfig.memoOptions ?? [], [uiConfig.memoOptions]);
+
+  const recipientRef = useRef(state.recipient);
+  recipientRef.current = state.recipient;
+
+  const handleMemoChange = useCallback(
+    (memo: Memo) => {
+      if (!address) return;
+      const prev = recipientRef.current;
+      const ensName = prev?.address === address ? prev.ensName : undefined;
+      transaction.setRecipient({ address, ensName, memo });
+    },
+    [transaction, address],
+  );
+
+  const memo = useRecipientMemo({
+    hasMemo: uiConfig.hasMemo,
+    memoDefaultOption,
+    memoType: uiConfig.memoType,
+    memoTypeOptions,
+    onMemoChange: handleMemoChange,
+    onMemoSkip: onSkip,
+    resetKey: `${state.account.account?.id ?? ""}|${currencyId}|${address}`,
+  });
+
+  const transactionError = state.transaction.status?.errors?.transaction;
+  const memoError = transactionError instanceof Error ? transactionError : undefined;
+
+  return { ...memo, currencyId, memoLabel, memoTypeOptions, uiConfig, memoError };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/hooks/useRecipientMemo.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/hooks/useRecipientMemo.ts
@@ -1,0 +1,147 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { Memo } from "@ledgerhq/live-common/flows/send/types";
+import { useDoNotAskAgainSkipMemo } from "./useDoNotAskAgainSkipMemo";
+
+export type SkipMemoState = "propose" | "toConfirm" | "confirmed";
+
+type UseRecipientMemoProps = Readonly<{
+  hasMemo: boolean;
+  memoDefaultOption?: string;
+  memoType?: string;
+  memoTypeOptions?: readonly string[];
+  onMemoChange: (memo: Memo) => void;
+  onMemoSkip: () => void;
+  resetKey: string;
+}>;
+
+type UseRecipientMemoResult = Readonly<{
+  memo: Memo;
+  hasMemoTypeOptions: boolean;
+  showMemoValueInput: boolean;
+  showSkipMemo: boolean;
+  skipMemoState: SkipMemoState;
+  hasFilledMemo: boolean;
+  onMemoValueChange: (value: string) => void;
+  onMemoTypeChange: (type: string) => void;
+  onSkipMemoRequestConfirm: () => void;
+  onSkipMemoCancelConfirm: () => void;
+  onSkipMemoConfirm: (doNotAskAgain: boolean) => void;
+  resetViewState: () => void;
+}>;
+
+function buildDefaultMemo(memoDefaultOption?: string): Memo {
+  return { value: "", type: memoDefaultOption };
+}
+
+export function useRecipientMemo({
+  hasMemo,
+  memoDefaultOption,
+  memoType,
+  memoTypeOptions,
+  onMemoChange,
+  onMemoSkip,
+  resetKey,
+}: UseRecipientMemoProps): UseRecipientMemoResult {
+  const [memo, setMemo] = useState<Memo>(() => buildDefaultMemo(memoDefaultOption));
+  const [skipMemoState, setSkipMemoState] = useState<SkipMemoState>("propose");
+
+  const lastResetKeyRef = useRef<string>(resetKey);
+  useEffect(() => {
+    if (lastResetKeyRef.current === resetKey) return;
+    lastResetKeyRef.current = resetKey;
+    const nextDefaultMemo = buildDefaultMemo(memoDefaultOption);
+    setMemo(nextDefaultMemo);
+    setSkipMemoState("propose");
+    onMemoChange(nextDefaultMemo);
+  }, [resetKey, memoDefaultOption, onMemoChange]);
+
+  const hasMemoTypeOptions = Boolean(memoType === "typed" && memoTypeOptions?.length);
+
+  const showMemoValueInput = memo.type !== "NO_MEMO";
+
+  const showSkipMemo = hasMemo && memo.value.length === 0 && memo.type !== "NO_MEMO";
+
+  const hasFilledMemo = useMemo(() => {
+    if (!hasMemo) return true;
+    return memo.value.length > 0 || memo.type === "NO_MEMO";
+  }, [hasMemo, memo.type, memo.value.length]);
+
+  const onMemoValueChange = useCallback(
+    (value: string) => {
+      if (skipMemoState !== "propose") {
+        setSkipMemoState("propose");
+      }
+
+      const next: Memo = { ...memo, value };
+      setMemo(next);
+      onMemoChange(next);
+    },
+    [memo, onMemoChange, skipMemoState],
+  );
+
+  const onMemoTypeChange = useCallback(
+    (type: string) => {
+      if (skipMemoState !== "propose") {
+        setSkipMemoState("propose");
+      }
+
+      const next: Memo = { value: "", type };
+      setMemo(next);
+      onMemoChange(next);
+    },
+    [onMemoChange, skipMemoState],
+  );
+
+  const [doNotAskAgainSkipMemo, setDoNotAskAgainSkipMemo] = useDoNotAskAgainSkipMemo();
+
+  const onSkipMemoCancelConfirm = useCallback(() => {
+    setSkipMemoState("propose");
+  }, []);
+
+  const onSkipMemoConfirm = useCallback(
+    (doNotAskAgain: boolean) => {
+      if (doNotAskAgainSkipMemo !== doNotAskAgain) {
+        setDoNotAskAgainSkipMemo(doNotAskAgain);
+      }
+
+      setSkipMemoState("confirmed");
+      const next: Memo = { value: "", type: "NO_MEMO" };
+      setMemo(next);
+      onMemoChange(next);
+      onMemoSkip();
+    },
+    [onMemoChange, onMemoSkip, setDoNotAskAgainSkipMemo, doNotAskAgainSkipMemo],
+  );
+
+  const onSkipMemoRequestConfirm = useCallback(() => {
+    if (doNotAskAgainSkipMemo) {
+      onSkipMemoConfirm(doNotAskAgainSkipMemo);
+    } else {
+      setSkipMemoState("toConfirm");
+    }
+  }, [doNotAskAgainSkipMemo, onSkipMemoConfirm]);
+
+  const resetViewState = useCallback(() => {
+    if (skipMemoState === "confirmed") {
+      const defaultMemo = buildDefaultMemo(memoDefaultOption);
+      setMemo(defaultMemo);
+      onMemoChange(defaultMemo);
+      setSkipMemoState("propose");
+    }
+  }, [memoDefaultOption, onMemoChange, skipMemoState]);
+
+  return {
+    memo,
+    hasMemoTypeOptions,
+    showMemoValueInput,
+    showSkipMemo,
+    skipMemoState,
+    hasFilledMemo,
+    onMemoValueChange,
+    onMemoTypeChange,
+    onSkipMemoRequestConfirm,
+    onSkipMemoCancelConfirm,
+    onSkipMemoConfirm,
+    resetViewState,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/shouldShowMatchedAddress.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/shouldShowMatchedAddress.ts
@@ -1,0 +1,17 @@
+type ShouldShowMatchedAddressArgs = Readonly<{
+  showMatchedAddress: boolean;
+  hasMemo: boolean;
+  hasFilledMemo: boolean;
+  hasMemoError: boolean;
+}>;
+
+export function shouldShowMatchedAddress({
+  showMatchedAddress,
+  hasMemo,
+  hasFilledMemo,
+  hasMemoError,
+}: ShouldShowMatchedAddressArgs): boolean {
+  if (!showMatchedAddress) return false;
+  if (!hasMemo) return true;
+  return hasFilledMemo && !hasMemoError;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
@@ -4,6 +4,10 @@ import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
 import { SendFlowLayout } from "LLM/features/Send/components/SendFlowLayout";
+import { MemoControls } from "LLM/features/Send/components/Memo/MemoControls";
+import { useMemoViewModel } from "LLM/features/Send/components/Memo/hooks/useMemoViewModel";
+import { shouldShowMatchedAddress } from "LLM/features/Send/components/Memo/shouldShowMatchedAddress";
+import { useSendFlowData } from "LLM/features/Send/context/SendFlowContext";
 import React, { useCallback } from "react";
 import { useRecipientScreenView } from "../hooks/useRecipientScreenView";
 import { AddressMatchedSection } from "./AddressMatchedSection";
@@ -21,6 +25,7 @@ type RecipientScreenViewProps = Readonly<{
   currency: CryptoOrTokenCurrency;
   onAddressSelected: (address: string, ensName?: string) => void;
   recipientSupportsDomain: boolean;
+  onMemoProceed: () => void;
 }>;
 
 export const RecipientScreenView = ({
@@ -29,11 +34,10 @@ export const RecipientScreenView = ({
   currency,
   onAddressSelected,
   recipientSupportsDomain,
+  onMemoProceed,
 }: RecipientScreenViewProps) => {
   const {
     recentAddresses,
-    handleAccountSelect,
-    handleRecentAddressSelect,
     isLoading,
     showInitialState,
     showMatchedAddress,
@@ -64,6 +68,31 @@ export const RecipientScreenView = ({
     onAddressSelected,
     recipientSupportsDomain,
   });
+
+  const { uiConfig, recipientSearch } = useSendFlowData();
+  const resolvedAddress = result?.resolvedAddress ?? searchValue;
+  const showMemo = uiConfig.hasMemo && isAddressComplete;
+  const memoVm = useMemoViewModel({
+    address: showMemo ? resolvedAddress : "",
+    onSkip: onMemoProceed,
+  });
+  const showMatched = shouldShowMatchedAddress({
+    showMatchedAddress,
+    hasMemo: uiConfig.hasMemo,
+    hasFilledMemo: memoVm.hasFilledMemo,
+    hasMemoError: !!memoVm.memoError,
+  });
+
+  const revealAddress = useCallback(
+    (address: string, ensName?: string) => {
+      if (uiConfig.hasMemo) {
+        recipientSearch.setValue(address);
+      } else {
+        onAddressSelected(address, ensName);
+      }
+    },
+    [uiConfig.hasMemo, recipientSearch, onAddressSelected],
+  );
 
   const shouldShowErrorBanner =
     !isLoading &&
@@ -100,18 +129,20 @@ export const RecipientScreenView = ({
               )}
               <RecentAddressesSection
                 recentAddresses={recentAddresses}
-                onSelect={handleRecentAddressSelect}
+                onSelect={recent => revealAddress(recent.address, recent.ensName)}
                 onLongPress={handleRecentAddressLongPress}
               />
               <MyAccountsSection
                 currentAccountId={account.id}
                 currency={currency}
-                onSelect={handleAccountSelect}
+                onSelect={selectedAccount => revealAddress(selectedAccount.freshAddress)}
               />
             </>
           )}
 
-          {showMatchedAddress && (
+          {showMemo && <MemoControls vm={memoVm} />}
+
+          {showMatched && (
             <AddressMatchedSection
               searchResult={result}
               searchValue={searchValue}
@@ -131,7 +162,7 @@ export const RecipientScreenView = ({
           )}
 
           {shouldShowErrorBanner && (
-            <Box lx={{ flex: 1, paddingVertical: "s8" }}>
+            <Box lx={{ marginHorizontal: "s8", gap: "s16" }}>
               {showBridgeSenderError && (
                 <ValidationBanner type="error" error={bridgeSenderError} variant="sender" />
               )}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/index.tsx
@@ -20,17 +20,18 @@ export function RecipientScreen() {
     return account ? getAccountCurrency(account) : null;
   }, [state.account.currency, account]);
 
+  const goToAmount = useCallback(() => {
+    recipientSearch.clear();
+    navigation.navigate(ScreenName.SendFlowAmount);
+  }, [recipientSearch, navigation]);
+
   const handleAddressSelected = useCallback(
     (address: string, ensName?: string) => {
-      transaction.setRecipient({
-        address,
-        ensName,
-      });
-
+      transaction.setRecipient({ address, ensName, memo: state.recipient?.memo });
       recipientSearch.clear();
       navigation.navigate(ScreenName.SendFlowAmount);
     },
-    [transaction, recipientSearch, navigation],
+    [transaction, state.recipient?.memo, recipientSearch, navigation],
   );
 
   if (!account || !currency) {
@@ -44,6 +45,7 @@ export function RecipientScreen() {
       currency={currency}
       onAddressSelected={handleAddressSelected}
       recipientSupportsDomain={uiConfig.recipientSupportsDomain}
+      onMemoProceed={goToAmount}
     />
   );
 }

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -76,6 +76,7 @@ import type {
   SettingsIsOnboardingFlowReceiveSuccessPayload,
   SettingsIsPostOnboardingFlowPayload,
   SettingsSetHasSeenWalletV4TourPayload,
+  SettingsSetDoNotAskAgainSkipMemoPayload,
   SettingsSetProductTourCompletedPayload,
   SettingsSetAnalyticsConsentInfoPayload,
   SettingsSetHasClickedRecoverPayload,
@@ -179,6 +180,7 @@ export const INITIAL_STATE: SettingsState = {
   generalTermsVersionAccepted: undefined,
   hasSeenWalletV4Tour: false,
   productTourCompleted: false,
+  doNotAskAgainSkipMemo: false,
   hasClickedRecover: false,
   deprecationDoNotRemind: [],
   analyticsConsentInfo: {
@@ -677,6 +679,11 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
     hasSeenWalletV4Tour: (action as Action<SettingsSetHasSeenWalletV4TourPayload>).payload,
   }),
 
+  [SettingsActionTypes.SET_DO_NOT_ASK_AGAIN_SKIP_MEMO]: (state, action) => ({
+    ...state,
+    doNotAskAgainSkipMemo: (action as Action<SettingsSetDoNotAskAgainSkipMemoPayload>).payload,
+  }),
+
   [SettingsActionTypes.SET_PRODUCT_TOUR_COMPLETED]: (state, action) => ({
     ...state,
     productTourCompleted: (action as Action<SettingsSetProductTourCompletedPayload>).payload,
@@ -927,6 +934,9 @@ export const mevProtectionSelector = (state: State) => state.settings.mevProtect
 export const selectedTabPortfolioAssetsSelector = (state: State) =>
   state.settings.selectedTabPortfolioAssets;
 export const hasSeenWalletV4TourSelector = (state: State) => state.settings.hasSeenWalletV4Tour;
+
+export const doNotAskAgainSkipMemoSelector = (state: State) =>
+  state.settings.doNotAskAgainSkipMemo;
 export const productTourCompletedSelector = (state: State) => state.settings.productTourCompleted;
 export const analyticsConsentInfoSelector = (state: State) => state.settings.analyticsConsentInfo;
 export const hasClickedRecoverSelector = (state: State) => state.settings.hasClickedRecover;

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -300,6 +300,7 @@ export type SettingsState = {
   selectedTabPortfolioAssets: TabPortfolioAssetsType;
   hasSeenWalletV4Tour: boolean;
   productTourCompleted: boolean;
+  doNotAskAgainSkipMemo: boolean;
   deprecationDoNotRemind: string[];
   analyticsConsentInfo: AnalyticsConsentInfo;
   hasClickedRecover: boolean;

--- a/libs/ledger-live-common/src/bridge/descriptor/send/memo.test.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/send/memo.test.ts
@@ -1,0 +1,44 @@
+import { applyMemoToTransaction } from "./memo";
+
+describe("applyMemoToTransaction", () => {
+  describe("empty value is treated as cleared (no memo/tag)", () => {
+    it("xrp: empty string clears the tag instead of applying 0", () => {
+      expect(applyMemoToTransaction("xrp", "")).toEqual({ tag: undefined });
+    });
+
+    it("casper: empty string clears the transferId", () => {
+      expect(applyMemoToTransaction("casper", "")).toEqual({ transferId: undefined });
+    });
+
+    it("solana: empty string clears the memo", () => {
+      expect(applyMemoToTransaction("solana", "")).toEqual({
+        model: { uiState: { memo: undefined } },
+      });
+    });
+
+    it("unknown family: empty string clears the generic memo", () => {
+      expect(applyMemoToTransaction("algorand", "")).toEqual({ memo: undefined });
+    });
+  });
+
+  describe("non-empty values are applied per family", () => {
+    it("xrp: numeric tag", () => {
+      expect(applyMemoToTransaction("xrp", "123")).toEqual({ tag: 123 });
+    });
+
+    it("casper: transferId", () => {
+      expect(applyMemoToTransaction("casper", "42")).toEqual({ transferId: "42" });
+    });
+
+    it("stellar: forwards value and type", () => {
+      expect(applyMemoToTransaction("stellar", "hello", "MEMO_TEXT")).toEqual({
+        memoValue: "hello",
+        memoType: "MEMO_TEXT",
+      });
+    });
+
+    it("unknown family: generic memo", () => {
+      expect(applyMemoToTransaction("algorand", "note")).toEqual({ memo: "note" });
+    });
+  });
+});

--- a/libs/ledger-live-common/src/bridge/descriptor/send/memo.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/send/memo.ts
@@ -52,11 +52,13 @@ export function applyMemoToTransaction(
 
   const transaction = isRecord(memoTypeOrTransaction)
     ? memoTypeOrTransaction
-    : (currentTransaction ?? {});
+    : currentTransaction ?? {};
+
+  const value = memoValue === "" ? undefined : memoValue;
 
   const applyFn = memoApplicationRegistry[family];
   if (!applyFn) {
-    return { memo: memoValue };
+    return { memo: value };
   }
-  return applyFn(memoValue, memoType, transaction);
+  return applyFn(value, memoType, transaction);
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Unit tests cover the memo state machine (`useRecipientMemo`: type gating, skip flow, do-not-ask-again) and the empty-value handling in `applyMemoToTransaction` (live-common). The Lumen UI components and the Recipient-screen integration are validated manually._
- [x] **Impact of the changes:**
      - Memo/tag input on memo-capable chains in the new send flow: XRP (numeric tag, capped to UINT32_MAX), Stellar (typed memo selector: No memo / Memo text / Memo ID / Memo Hash / Memo return), Solana / Cosmos / Hedera / ICP / Cardano / Stacks / TON / Casper (text/comment/transfer-id).
      - Skip flow: warning banner + "Don't show this warning again" preference (persisted), and direct navigation to the Amount step on skip.
      - "Send to …" (Address matched) row only shows once the memo is filled or skipped, then proceeds to Amount with the memo applied.
      - Chains without memo are unaffected (no memo UI, selection navigates straight to Amount).
      - New redux setting `doNotAskAgainSkipMemo`.
      - **live-common**: `applyMemoToTransaction` now clears an empty memo/tag instead of applying tag `0` (XRP) or an empty string — restores the previous send-flow behaviour and also benefits desktop.

### 📝 Description

The new mobile Send flow had no way to enter a memo/tag, even though several chains need one (XRP tag, Stellar memo, Solana/Cosmos/…). A missing memo on an exchange deposit can lead to a loss of funds, so the flow needs proper memo support.

This adds the memo step to the Recipient screen. Once a valid recipient is entered on a memo-capable chain, a memo field appears below the address: Stellar shows a bottom-sheet type selector, `tag` chains use a numeric keyboard, and `text` memos respect their max length. An optional skip (with a persisted "don't ask again") lets the user continue without one.

It is fully descriptor-driven through live-common (`uiConfig` + `applyMemoToTransaction`), with no per-family branching, and mirrors the desktop implementation. Built with Lumen RN.

It also fixes a regression in live-common's `applyMemoToTransaction`: an empty/skipped memo now clears the field (`undefined`) instead of applying tag `0` (XRP) or an empty string, matching the behaviour of the previous send flow.

### 🖼️ Demo

https://github.com/user-attachments/assets/0fa5e1a8-9bcf-4b4b-bff6-eae0d4539a97

### ❓ Context

- **JIRA or GitHub link**: [LIVE-23000](https://ledgerhq.atlassian.net/browse/LIVE-23000)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-23000]: https://ledgerhq.atlassian.net/browse/LIVE-23000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
