### PR TITLE
[LWD] feat(lld): add Market table component with tests

### DIFF
--- a/.changeset/market-table-component.md
+++ b/.changeset/market-table-component.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add MarketTable component (view, view-model, sortable header and loading skeleton) for the new asset-discoverability Market view

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/index.tsx
@@ -1,0 +1,20 @@
+import React, { memo } from "react";
+import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { MarketRowView } from "./MarketRowView";
+import { useMarketRowViewModel } from "./useMarketRowViewModel";
+
+export type MarketRowProps = {
+  size: number;
+  start: number;
+  currency: MarketCurrencyData;
+  counterCurrency?: string;
+  locale: string;
+  range?: string;
+  isStarred: boolean;
+  toggleStar: (id: string, isStarred: boolean) => void;
+};
+
+export const MarketRow = memo<MarketRowProps>(function MarketRow(props: MarketRowProps) {
+  const viewModel = useMarketRowViewModel(props);
+  return <MarketRowView {...viewModel} />;
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/MarketTableHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/MarketTableHeader.tsx
@@ -1,0 +1,74 @@
+import React, { memo } from "react";
+import { TFunction } from "i18next";
+import {
+  TableHeader,
+  TableHeaderRow,
+  TableHeaderCell,
+  TableSortButton,
+} from "@ledgerhq/lumen-ui-react";
+import {
+  MARKET_TABLE_GRID_TEMPLATE,
+  MARKET_CELL_CLASSNAME,
+  MARKET_HEADER_CELL_END_CLASSNAME,
+} from "./constants";
+
+export type SortDirection = "asc" | "desc" | undefined;
+
+type MarketTableHeaderProps = {
+  marketCapSort: SortDirection;
+  changeSort: SortDirection;
+  onToggleMarketCap: () => void;
+  onToggleChange: () => void;
+  t: TFunction;
+};
+
+export const MarketTableHeader = memo<MarketTableHeaderProps>(function MarketTableHeader({
+  marketCapSort,
+  changeSort,
+  onToggleMarketCap,
+  onToggleChange,
+  t,
+}) {
+  return (
+    <TableHeader className="grid">
+      <TableHeaderRow
+        className="grid"
+        style={{ gridTemplateColumns: MARKET_TABLE_GRID_TEMPLATE }}
+        data-testid="market-list-header"
+      >
+        <TableHeaderCell className={MARKET_CELL_CLASSNAME}>
+          {t("market.marketTable.crypto")}
+        </TableHeaderCell>
+        <TableHeaderCell align="end" className={MARKET_HEADER_CELL_END_CLASSNAME}>
+          {t("market.marketTable.price")}
+        </TableHeaderCell>
+        <TableHeaderCell align="end" className={MARKET_HEADER_CELL_END_CLASSNAME}>
+          <TableSortButton align="end" data-testid="market-sort-volume">
+            {t("market.marketTable.volume")}
+          </TableSortButton>
+        </TableHeaderCell>
+        <TableHeaderCell align="end" className={MARKET_HEADER_CELL_END_CLASSNAME}>
+          <TableSortButton
+            align="end"
+            sortDirection={marketCapSort}
+            onToggleSort={onToggleMarketCap}
+            data-testid="market-sort-marketcap"
+          >
+            {t("market.marketTable.marketCap")}
+          </TableSortButton>
+        </TableHeaderCell>
+        <TableHeaderCell align="end" className={MARKET_HEADER_CELL_END_CLASSNAME}>
+          <TableSortButton
+            align="end"
+            sortDirection={changeSort}
+            onToggleSort={onToggleChange}
+            data-testid="market-sort-change"
+          >
+            {t("market.marketTable.change")}
+          </TableSortButton>
+        </TableHeaderCell>
+        <TableHeaderCell align="end" aria-label={t("market.marketTable.actions")} />
+      </TableHeaderRow>
+    </TableHeader>
+  );
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/MarketTableSkeleton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/MarketTableSkeleton.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { listItemHeight } from "~/renderer/screens/market/components/Table";
+import { MARKET_TABLE_GRID_TEMPLATE } from "./constants";
+
+const SKELETON_ROWS = 12;
+
+export function MarketTableSkeleton() {
+  return (
+    <div data-testid="market-table-skeleton">
+      {Array.from({ length: SKELETON_ROWS }).map((_, index) => (
+        <div
+          key={index}
+          className="grid w-full items-center px-12"
+          style={{ gridTemplateColumns: MARKET_TABLE_GRID_TEMPLATE, height: listItemHeight }}
+        >
+          <div className="flex items-center gap-12">
+            <div className="size-32 shrink-0 animate-pulse rounded-full bg-muted" />
+            <div className="h-12 w-96 animate-pulse rounded-xs bg-muted" />
+          </div>
+          <div className="h-12 w-64 animate-pulse justify-self-end rounded-xs bg-muted" />
+          <div className="h-12 w-64 animate-pulse justify-self-end rounded-xs bg-muted" />
+          <div className="h-12 w-64 animate-pulse justify-self-end rounded-xs bg-muted" />
+          <div className="h-12 w-48 animate-pulse justify-self-end rounded-xs bg-muted" />
+          <div />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/MarketTableView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/MarketTableView.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { TFunction } from "i18next";
+import { Virtualizer } from "@tanstack/react-virtual";
+import { TableRoot, Table, TableBody } from "@ledgerhq/lumen-ui-react";
+import {
+  MarketCurrencyData,
+  MarketListRequestParams,
+} from "@ledgerhq/live-common/market/utils/types";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import { NoCryptoPlaceholder } from "~/renderer/screens/market/MarketList/components/NoCryptoPlaceholder";
+import { MarketFavoritesEmptyState } from "../MarketFavoritesEmptyState";
+import { MarketRow } from "../MarketRow";
+import { MarketTableHeader, SortDirection } from "./MarketTableHeader";
+import { MarketTableSkeleton } from "./MarketTableSkeleton";
+
+export type MarketTableViewProps = {
+  parentRef: React.RefObject<HTMLDivElement | null>;
+  rowVirtualizer: Virtualizer<HTMLDivElement, Element>;
+  marketData: MarketCurrencyData[];
+  marketParams: MarketListRequestParams;
+  counterCurrency?: string;
+  range?: string;
+  search?: string;
+  locale: string;
+  currenciesLength: number;
+  showSkeleton: boolean;
+  emptyState?: "favorites";
+  resetSearch: () => void;
+  isStarred: (id: string) => boolean;
+  toggleStar: (id: string, isStarred: boolean) => void;
+  marketCapSort: SortDirection;
+  changeSort: SortDirection;
+  onToggleMarketCap: () => void;
+  onToggleChange: () => void;
+  t: TFunction;
+};
+
+export function MarketTableView({
+  parentRef,
+  rowVirtualizer,
+  marketData,
+  marketParams,
+  counterCurrency,
+  range,
+  search,
+  locale,
+  currenciesLength,
+  showSkeleton,
+  emptyState,
+  resetSearch,
+  isStarred,
+  toggleStar,
+  marketCapSort,
+  changeSort,
+  onToggleMarketCap,
+  onToggleChange,
+  t,
+}: Readonly<MarketTableViewProps>) {
+  if (emptyState === "favorites") {
+    return <MarketFavoritesEmptyState t={t} />;
+  }
+
+  if (!showSkeleton && currenciesLength === 0) {
+    return <NoCryptoPlaceholder requestParams={marketParams} t={t} resetSearch={resetSearch} />;
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {search && currenciesLength > 0 && <TrackPage category="Market Search" success={true} />}
+      <TableRoot
+        appearance="plain"
+        className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg"
+      >
+        <div className="shrink-0 overflow-x-auto overflow-y-hidden">
+          <Table className="grid">
+            <MarketTableHeader
+              marketCapSort={marketCapSort}
+              changeSort={changeSort}
+              onToggleMarketCap={onToggleMarketCap}
+              onToggleChange={onToggleChange}
+              t={t}
+            />
+          </Table>
+        </div>
+        <div
+          ref={parentRef}
+          className="min-h-0 flex-1 overflow-auto scrollbar-custom [scrollbar-gutter:auto]"
+        >
+          {showSkeleton ? (
+            <MarketTableSkeleton />
+          ) : (
+            <Table className="grid">
+              <TableBody
+                className="relative block"
+                style={{ height: rowVirtualizer.getTotalSize() }}
+                data-testid="market-list-data"
+              >
+                {rowVirtualizer.getVirtualItems().map(virtualRow => {
+                  const currency = marketData[virtualRow.index];
+                  if (!currency) return null;
+
+                  return (
+                    <MarketRow
+                      key={currency.id}
+                      size={virtualRow.size}
+                      start={virtualRow.start}
+                      currency={currency}
+                      counterCurrency={counterCurrency}
+                      locale={locale}
+                      range={range}
+                      isStarred={isStarred(currency.id)}
+                      toggleStar={toggleStar}
+                    />
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </div>
+      </TableRoot>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/MarketTableHeader.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/MarketTableHeader.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { screen } from "tests/testSetup";
+import { MarketTableHeader } from "../MarketTableHeader";
+import { mockT, renderInTable } from "../../__tests__/shared";
+
+type HeaderProps = Parameters<typeof MarketTableHeader>[0];
+
+function createProps(overrides: Partial<HeaderProps> = {}): HeaderProps {
+  return {
+    marketCapSort: "desc",
+    changeSort: undefined,
+    onToggleMarketCap: jest.fn(),
+    onToggleChange: jest.fn(),
+    t: mockT,
+    ...overrides,
+  };
+}
+
+const renderHeader = (props: HeaderProps) => renderInTable(<MarketTableHeader {...props} />);
+
+describe("MarketTableHeader", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should render the column headers", () => {
+    renderHeader(createProps());
+
+    expect(screen.getByText("market.marketTable.crypto")).toBeVisible();
+    expect(screen.getByText("market.marketTable.price")).toBeVisible();
+    expect(screen.getByText("market.marketTable.volume")).toBeVisible();
+    expect(screen.getByText("market.marketTable.marketCap")).toBeVisible();
+    expect(screen.getByText("market.marketTable.change")).toBeVisible();
+  });
+
+  it("should call onToggleMarketCap when the market cap sort button is clicked", async () => {
+    const onToggleMarketCap = jest.fn();
+    const { user } = renderHeader(createProps({ onToggleMarketCap }));
+
+    await user.click(screen.getByTestId("market-sort-marketcap"));
+    expect(onToggleMarketCap).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onToggleChange when the change sort button is clicked", async () => {
+    const onToggleChange = jest.fn();
+    const { user } = renderHeader(createProps({ onToggleChange }));
+
+    await user.click(screen.getByTestId("market-sort-change"));
+    expect(onToggleChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/MarketTableSkeleton.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/MarketTableSkeleton.test.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { MarketTableSkeleton } from "../MarketTableSkeleton";
+
+describe("MarketTableSkeleton", () => {
+  it("should render the skeleton container", () => {
+    render(<MarketTableSkeleton />);
+    expect(screen.getByTestId("market-table-skeleton")).toBeVisible();
+  });
+
+  it("should render 12 skeleton rows", () => {
+    render(<MarketTableSkeleton />);
+    const skeleton = screen.getByTestId("market-table-skeleton");
+    expect(skeleton.children).toHaveLength(12);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/MarketTableView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/MarketTableView.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { Virtualizer } from "@tanstack/react-virtual";
+import { render, screen } from "tests/testSetup";
+import { MOCK_MARKET_CURRENCY_DATA } from "@ledgerhq/live-common/market/utils/fixtures";
+import { Order } from "@ledgerhq/live-common/market/utils/types";
+import { MarketTableView, MarketTableViewProps } from "../MarketTableView";
+import { mockT } from "../../__tests__/shared";
+
+const emptyVirtualizer = {
+  getVirtualItems: () => [],
+  getTotalSize: () => 0,
+} as unknown as Virtualizer<HTMLDivElement, Element>;
+
+function createProps(overrides: Partial<MarketTableViewProps> = {}): MarketTableViewProps {
+  return {
+    parentRef: { current: null },
+    rowVirtualizer: emptyVirtualizer,
+    marketData: MOCK_MARKET_CURRENCY_DATA,
+    marketParams: { order: Order.MarketCapDesc },
+    counterCurrency: "usd",
+    range: "24h",
+    search: "",
+    locale: "en",
+    currenciesLength: MOCK_MARKET_CURRENCY_DATA.length,
+    showSkeleton: false,
+    resetSearch: jest.fn(),
+    isStarred: () => false,
+    toggleStar: jest.fn(),
+    marketCapSort: "desc",
+    changeSort: undefined,
+    onToggleMarketCap: jest.fn(),
+    onToggleChange: jest.fn(),
+    t: mockT,
+    ...overrides,
+  };
+}
+
+describe("MarketTableView", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should render the favorites empty state when emptyState is 'favorites'", () => {
+    render(<MarketTableView {...createProps({ emptyState: "favorites" })} />);
+
+    expect(screen.queryByTestId("market-list-header")).toBeNull();
+    expect(screen.queryByTestId("market-list-data")).toBeNull();
+  });
+
+  it("should render the no-crypto placeholder when there are no currencies and no skeleton", () => {
+    render(<MarketTableView {...createProps({ currenciesLength: 0, showSkeleton: false })} />);
+
+    expect(screen.queryByTestId("market-list-data")).toBeNull();
+  });
+
+  it("should render the skeleton when showSkeleton is true", () => {
+    render(<MarketTableView {...createProps({ showSkeleton: true })} />);
+
+    expect(screen.getByTestId("market-table-skeleton")).toBeVisible();
+    expect(screen.queryByTestId("market-list-data")).toBeNull();
+  });
+
+  it("should render the header and table body when data is available", () => {
+    render(<MarketTableView {...createProps()} />);
+
+    expect(screen.getByTestId("market-list-header")).toBeVisible();
+    expect(screen.getByTestId("market-list-data")).toBeVisible();
+    expect(screen.queryByTestId("market-table-skeleton")).toBeNull();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/useMarketTableViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/useMarketTableViewModel.test.ts
@@ -1,0 +1,133 @@
+import { renderHook } from "tests/testSetup";
+import { MOCK_MARKET_CURRENCY_DATA } from "@ledgerhq/live-common/market/utils/fixtures";
+import { Order } from "@ledgerhq/live-common/market/utils/types";
+import { MarketTableData, useMarketTableViewModel } from "../useMarketTableViewModel";
+import { mockT } from "../../__tests__/shared";
+
+const mockParentRef = { current: null };
+const mockRowVirtualizer = { getVirtualItems: () => [], getTotalSize: () => 0 };
+
+jest.mock("../../../hooks/useMarketListVirtualization", () => ({
+  useMarketListVirtualization: () => ({
+    parentRef: mockParentRef,
+    rowVirtualizer: mockRowVirtualizer,
+  }),
+}));
+
+function createData(overrides: Partial<MarketTableData> = {}): MarketTableData {
+  return {
+    marketData: MOCK_MARKET_CURRENCY_DATA,
+    marketParams: { order: Order.MarketCapDesc, counterCurrency: "usd", range: "24h" },
+    locale: "en",
+    freshLoading: false,
+    isError: false,
+    loading: false,
+    currenciesLength: MOCK_MARKET_CURRENCY_DATA.length,
+    itemCount: MOCK_MARKET_CURRENCY_DATA.length,
+    starredMarketCoins: ["bitcoin"],
+    resetSearch: jest.fn(),
+    refresh: jest.fn(),
+    toggleStar: jest.fn(),
+    onLoadNextPage: jest.fn(),
+    checkIfDataIsStaleAndRefetch: jest.fn(),
+    t: mockT,
+    ...overrides,
+  };
+}
+
+describe("useMarketTableViewModel", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should report a currency as starred when present in starredMarketCoins", () => {
+    const { result } = renderHook(() => useMarketTableViewModel(createData()));
+
+    expect(result.current.isStarred("bitcoin")).toBe(true);
+    expect(result.current.isStarred("ethereum")).toBe(false);
+  });
+
+  it("should derive marketCapSort from the current order", () => {
+    const { result: desc } = renderHook(() =>
+      useMarketTableViewModel(createData({ marketParams: { order: Order.MarketCapDesc } })),
+    );
+    expect(desc.current.marketCapSort).toBe("desc");
+    expect(desc.current.changeSort).toBeUndefined();
+
+    const { result: asc } = renderHook(() =>
+      useMarketTableViewModel(createData({ marketParams: { order: Order.MarketCapAsc } })),
+    );
+    expect(asc.current.marketCapSort).toBe("asc");
+  });
+
+  it("should derive changeSort from gainers/losers order", () => {
+    const { result: gainers } = renderHook(() =>
+      useMarketTableViewModel(createData({ marketParams: { order: Order.topGainers } })),
+    );
+    expect(gainers.current.changeSort).toBe("desc");
+    expect(gainers.current.marketCapSort).toBeUndefined();
+
+    const { result: losers } = renderHook(() =>
+      useMarketTableViewModel(createData({ marketParams: { order: Order.topLosers } })),
+    );
+    expect(losers.current.changeSort).toBe("asc");
+  });
+
+  it("should toggle the market cap order between desc and asc", () => {
+    const refresh = jest.fn();
+
+    const { result: fromDesc } = renderHook(() =>
+      useMarketTableViewModel(createData({ refresh, marketParams: { order: Order.MarketCapDesc } })),
+    );
+    fromDesc.current.onToggleMarketCap();
+    expect(refresh).toHaveBeenCalledWith({ order: Order.MarketCapAsc });
+
+    refresh.mockClear();
+    const { result: fromAsc } = renderHook(() =>
+      useMarketTableViewModel(createData({ refresh, marketParams: { order: Order.MarketCapAsc } })),
+    );
+    fromAsc.current.onToggleMarketCap();
+    expect(refresh).toHaveBeenCalledWith({ order: Order.MarketCapDesc });
+  });
+
+  it("should toggle the change order between top gainers and top losers", () => {
+    const refresh = jest.fn();
+
+    const { result: fromGainers } = renderHook(() =>
+      useMarketTableViewModel(createData({ refresh, marketParams: { order: Order.topGainers } })),
+    );
+    fromGainers.current.onToggleChange();
+    expect(refresh).toHaveBeenCalledWith({ order: Order.topLosers });
+
+    refresh.mockClear();
+    const { result: fromOther } = renderHook(() =>
+      useMarketTableViewModel(createData({ refresh, marketParams: { order: Order.MarketCapDesc } })),
+    );
+    fromOther.current.onToggleChange();
+    expect(refresh).toHaveBeenCalledWith({ order: Order.topGainers });
+  });
+
+  it("should show the skeleton while fresh loading or on error", () => {
+    const { result: loadingResult } = renderHook(() =>
+      useMarketTableViewModel(createData({ freshLoading: true })),
+    );
+    expect(loadingResult.current.showSkeleton).toBe(true);
+
+    const { result: errorResult } = renderHook(() =>
+      useMarketTableViewModel(createData({ isError: true })),
+    );
+    expect(errorResult.current.showSkeleton).toBe(true);
+
+    const { result: idleResult } = renderHook(() => useMarketTableViewModel(createData()));
+    expect(idleResult.current.showSkeleton).toBe(false);
+  });
+
+  it("should pass through params, locale and emptyState", () => {
+    const { result } = renderHook(() =>
+      useMarketTableViewModel(createData({ emptyState: "favorites" })),
+    );
+
+    expect(result.current.counterCurrency).toBe("usd");
+    expect(result.current.range).toBe("24h");
+    expect(result.current.locale).toBe("en");
+    expect(result.current.emptyState).toBe("favorites");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/index.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { MarketTableData, useMarketTableViewModel } from "./useMarketTableViewModel";
+import { MarketTableView } from "./MarketTableView";
+
+export default function MarketTable(props: Readonly<MarketTableData>) {
+  const viewModel = useMarketTableViewModel(props);
+  return <MarketTableView {...viewModel} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/useMarketTableViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/useMarketTableViewModel.ts
@@ -1,0 +1,97 @@
+import { useCallback, useMemo } from "react";
+import { TFunction } from "i18next";
+import {
+  MarketCurrencyData,
+  MarketListRequestParams,
+  Order,
+} from "@ledgerhq/live-common/market/utils/types";
+import { useMarketListVirtualization } from "../../hooks/useMarketListVirtualization";
+
+export type MarketTableData = {
+  marketData: MarketCurrencyData[];
+  marketParams: MarketListRequestParams;
+  locale: string;
+  freshLoading: boolean;
+  isError: boolean;
+  loading: boolean;
+  currenciesLength: number;
+  itemCount: number;
+  emptyState?: "favorites";
+  starredMarketCoins: string[];
+  resetSearch: () => void;
+  refresh: (payload: MarketListRequestParams) => void;
+  toggleStar: (id: string, isStarred: boolean) => void;
+  onLoadNextPage: () => void;
+  checkIfDataIsStaleAndRefetch: (scrollOffset: number) => void;
+  t: TFunction;
+};
+
+export function useMarketTableViewModel({
+  marketData,
+  marketParams,
+  locale,
+  freshLoading,
+  isError,
+  loading,
+  currenciesLength,
+  itemCount,
+  emptyState,
+  starredMarketCoins,
+  resetSearch,
+  refresh,
+  toggleStar,
+  onLoadNextPage,
+  checkIfDataIsStaleAndRefetch,
+  t,
+}: MarketTableData) {
+  const { order, counterCurrency, range, search } = marketParams;
+
+  const { parentRef, rowVirtualizer } = useMarketListVirtualization({
+    itemCount,
+    marketData,
+    loading,
+    currenciesLength,
+    onLoadNextPage,
+    checkIfDataIsStaleAndRefetch,
+  });
+
+  const starredSet = useMemo(() => new Set(starredMarketCoins), [starredMarketCoins]);
+  const isStarred = useCallback((id: string) => starredSet.has(id), [starredSet]);
+
+  const onSort = useCallback((nextOrder: Order) => refresh({ order: nextOrder }), [refresh]);
+  const onToggleMarketCap = useCallback(
+    () => onSort(order === Order.MarketCapDesc ? Order.MarketCapAsc : Order.MarketCapDesc),
+    [onSort, order],
+  );
+  const onToggleChange = useCallback(
+    () => onSort(order === Order.topGainers ? Order.topLosers : Order.topGainers),
+    [onSort, order],
+  );
+
+  const marketCapSort: "asc" | "desc" | undefined =
+    order === Order.MarketCapDesc ? "desc" : order === Order.MarketCapAsc ? "asc" : undefined;
+  const changeSort: "asc" | "desc" | undefined =
+    order === Order.topGainers ? "desc" : order === Order.topLosers ? "asc" : undefined;
+
+  return {
+    parentRef,
+    rowVirtualizer,
+    marketData,
+    marketParams,
+    counterCurrency,
+    range,
+    search,
+    locale,
+    currenciesLength,
+    showSkeleton: freshLoading || isError,
+    emptyState,
+    resetSearch,
+    isStarred,
+    toggleStar,
+    marketCapSort,
+    changeSort,
+    onToggleMarketCap,
+    onToggleChange,
+    t,
+  };
+}


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - New `MarketTable` component (table layout for the asset-discoverability Market view). Not wired into the page yet (done in the stacked wiring PR), so no user-facing impact in isolation.

### 📝 Description

Second of 3 **stacked** PRs introducing the new asset-discoverability Market **table** UI.

> ⚠️ Stacked on top of #18466 — review/merge that one first. Base is `feat/lwm-market-row`.

This PR adds the **table** itself:
- `MarketTable` (`index.tsx`) splitting into `MarketTableView` + `useMarketTableViewModel`.
- `MarketTableHeader` (sortable columns) and `MarketTableSkeleton` (loading state).
- The table renders `MarketRow` (added in the previous PR) through the virtualizer.

Unit tests cover the ViewModel (sort toggles, sort-direction derivation, starred lookup, skeleton state) and the view branches (favorites empty state, no-crypto placeholder, skeleton, populated table) plus the header and skeleton rendering.

### ❓ Context

- **JIRA or GitHub link**: <!-- TODO: add ticket -->
- **ADR link (if any)**:

**Stacked PRs**
1. MarketRow component → `develop` (#18466)
2. **this PR** — MarketTable component → `feat/lwm-market-row`
3. Wire into Market page → `feat/lwm-market-table`

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)