### PR TITLE
[LWD] feat(lld): wire Market table into the Market page

### DIFF
--- a/.changeset/market-table-component.md
+++ b/.changeset/market-table-component.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add MarketTable component (view, view-model, sortable header and loading skeleton) for the new asset-discoverability Market view

--- a/.changeset/market-table-row-component.md
+++ b/.changeset/market-table-row-component.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add MarketRow component (view, view-model and row actions) for the new asset-discoverability Market table

--- a/.changeset/market-table-wiring.md
+++ b/.changeset/market-table-wiring.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Display the new Market table on the Market page when asset discoverability is enabled, keeping the legacy list otherwise

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketListLegacy.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketListLegacy.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { useMarketListVirtualization } from "../hooks/useMarketListVirtualization";
+import { useMarket } from "../hooks/useMarket";
+import MarketList from "../screens/MarketList";
+
+type MarketListLegacyProps = ReturnType<typeof useMarket>;
+
+export default function MarketListLegacy(props: Readonly<MarketListLegacyProps>) {
+  const virtualization = useMarketListVirtualization({
+    itemCount: props.itemCount,
+    marketData: props.marketData,
+    loading: props.loading,
+    currenciesLength: props.currenciesLength,
+    onLoadNextPage: props.onLoadNextPage,
+    checkIfDataIsStaleAndRefetch: props.checkIfDataIsStaleAndRefetch,
+  });
+
+  return <MarketList {...props} virtualization={virtualization} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/MarketRowActions.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/MarketRowActions.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { TFunction } from "i18next";
+import {
+  Button,
+  IconButton,
+  Menu,
+  MenuTrigger,
+  MenuContent,
+  MenuItem,
+} from "@ledgerhq/lumen-ui-react";
+import { MoreVertical, Plus, Chart5, Star, StarFill } from "@ledgerhq/lumen-ui-react/symbols";
+
+type RowAction = {
+  available: boolean;
+  onClick: (e: React.SyntheticEvent) => void;
+};
+
+export type MarketRowActionsProps = {
+  ticker: string;
+  swapAction: RowAction;
+  buySellAction: RowAction;
+  earnAction: RowAction & { label: string };
+  isStarred: boolean;
+  onFavouriteSelect: () => void;
+  onMenuOpenChange: (open: boolean) => void;
+  t: TFunction;
+};
+
+export function MarketRowActions({
+  ticker,
+  swapAction,
+  buySellAction,
+  earnAction,
+  isStarred,
+  onFavouriteSelect,
+  onMenuOpenChange,
+  t,
+}: MarketRowActionsProps) {
+  return (
+    <div
+      className="flex items-center justify-end gap-8"
+      onClick={e => e.stopPropagation()}
+      role="presentation"
+    >
+      {swapAction.available && (
+        <Button
+          size="sm"
+          appearance="base"
+          onClick={swapAction.onClick}
+          data-testid={`market-${ticker}-swap-button`}
+        >
+          {t("accounts.contextMenu.swap")}
+        </Button>
+      )}
+      <Menu onOpenChange={onMenuOpenChange}>
+        <MenuTrigger
+          render={
+            <IconButton
+              icon={MoreVertical}
+              size="sm"
+              appearance="transparent"
+              aria-label={t("market.marketTable.menu.more")}
+              data-testid={`market-${ticker}-actions-menu`}
+            />
+          }
+        />
+        <MenuContent>
+          {buySellAction.available && (
+            <MenuItem className="cursor-pointer" onClick={buySellAction.onClick}>
+              <Plus size={20} />
+              {t("market.marketTable.menu.buySell")}
+            </MenuItem>
+          )}
+          {earnAction.available && (
+            <MenuItem className="cursor-pointer" onClick={earnAction.onClick}>
+              <Chart5 size={20} />
+              {earnAction.label}
+            </MenuItem>
+          )}
+          <MenuItem className="cursor-pointer" onClick={onFavouriteSelect}>
+            {isStarred ? <StarFill size={20} /> : <Star size={20} />}
+            {isStarred
+              ? t("market.marketTable.menu.removeFromFavourites")
+              : t("market.marketTable.menu.addToFavourites")}
+          </MenuItem>
+        </MenuContent>
+      </Menu>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/MarketRowView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/MarketRowView.tsx
@@ -1,0 +1,103 @@
+import React, { memo } from "react";
+import { TFunction } from "i18next";
+import { TableRow, TableCell, TableCellContent, Trend, Tag } from "@ledgerhq/lumen-ui-react";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { MARKET_TABLE_GRID_TEMPLATE, MARKET_CELL_CLASSNAME } from "../MarketTable/constants";
+import { MarketRowActions, MarketRowActionsProps } from "./MarketRowActions";
+
+export type MarketRowViewProps = {
+  style: React.CSSProperties;
+  currency: MarketCurrencyData;
+  isStarred: boolean;
+  priceChangePercentage: number | undefined;
+  formattedPrice: string;
+  formattedVolume: string;
+  formattedMarketCap: string;
+  onCurrencyClick: () => void;
+  swapAction: MarketRowActionsProps["swapAction"];
+  buySellAction: MarketRowActionsProps["buySellAction"];
+  earnAction: MarketRowActionsProps["earnAction"];
+  onFavouriteSelect: () => void;
+  onMenuOpenChange: (open: boolean) => void;
+  t: TFunction;
+};
+
+export const MarketRowView = memo<MarketRowViewProps>(function MarketRowView({
+  style,
+  currency,
+  isStarred,
+  priceChangePercentage,
+  formattedPrice,
+  formattedVolume,
+  formattedMarketCap,
+  onCurrencyClick,
+  swapAction,
+  buySellAction,
+  earnAction,
+  onFavouriteSelect,
+  onMenuOpenChange,
+  t,
+}: MarketRowViewProps) {
+  const ticker = currency.ticker.toUpperCase();
+
+  return (
+    <TableRow
+      clickable
+      onClick={onCurrencyClick}
+      data-testid={`market-${currency.ticker}-row`}
+      className="absolute left-0 top-0 grid w-full items-center"
+      style={{ ...style, gridTemplateColumns: MARKET_TABLE_GRID_TEMPLATE }}
+    >
+      <TableCell className={MARKET_CELL_CLASSNAME}>
+        <TableCellContent
+          leadingContent={
+            currency.ledgerIds.length > 0 ? (
+              <CryptoIcon ledgerId={currency.ledgerIds[0]} ticker={currency.ticker} size={32} />
+            ) : (
+              <img width="32px" height="32px" src={currency.image} alt={currency.name} />
+            )
+          }
+          title={currency.name}
+          description={
+            <span className="flex items-center gap-6">
+              {ticker}
+              {currency.marketcapRank ? (
+                <Tag size="sm" appearance="gray" label={`#${currency.marketcapRank}`} />
+              ) : null}
+            </span>
+          }
+        />
+      </TableCell>
+
+      <TableCell align="end" className={MARKET_CELL_CLASSNAME} data-testid="market-coin-price">
+        {formattedPrice}
+      </TableCell>
+
+      <TableCell align="end" className={MARKET_CELL_CLASSNAME} data-testid="market-volume">
+        {formattedVolume}
+      </TableCell>
+
+      <TableCell align="end" className={MARKET_CELL_CLASSNAME} data-testid="market-cap">
+        {formattedMarketCap}
+      </TableCell>
+
+      <TableCell align="end" className={MARKET_CELL_CLASSNAME} data-testid="market-price-change">
+        {priceChangePercentage != null ? <Trend value={priceChangePercentage} /> : "-"}
+      </TableCell>
+
+      <TableCell align="end" className={MARKET_CELL_CLASSNAME}>
+        <MarketRowActions
+          ticker={currency.ticker}
+          swapAction={swapAction}
+          buySellAction={buySellAction}
+          earnAction={earnAction}
+          isStarred={isStarred}
+          onFavouriteSelect={onFavouriteSelect}
+          onMenuOpenChange={onMenuOpenChange}
+          t={t}
+        />
+      </TableCell>
+    </TableRow>
+  );
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/__tests__/MarketRowActions.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/__tests__/MarketRowActions.test.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { MarketRowActions, MarketRowActionsProps } from "../MarketRowActions";
+import { mockT } from "../../__tests__/shared";
+
+const mockOnSwap = jest.fn();
+const mockOnBuySell = jest.fn();
+const mockOnStake = jest.fn();
+const mockOnFavouriteSelect = jest.fn();
+const mockOnMenuOpenChange = jest.fn();
+
+function createProps(overrides: Partial<MarketRowActionsProps> = {}): MarketRowActionsProps {
+  return {
+    ticker: "BTC",
+    swapAction: { available: true, onClick: mockOnSwap },
+    buySellAction: { available: true, onClick: mockOnBuySell },
+    earnAction: { available: true, onClick: mockOnStake, label: "Earn" },
+    isStarred: false,
+    onFavouriteSelect: mockOnFavouriteSelect,
+    onMenuOpenChange: mockOnMenuOpenChange,
+    t: mockT,
+    ...overrides,
+  };
+}
+
+describe("MarketRowActions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render the swap button when swap is available", () => {
+    render(<MarketRowActions {...createProps()} />);
+    expect(screen.getByTestId("market-BTC-swap-button")).toBeVisible();
+  });
+
+  it("should hide the swap button when swap is unavailable", () => {
+    render(
+      <MarketRowActions
+        {...createProps({ swapAction: { available: false, onClick: mockOnSwap } })}
+      />,
+    );
+    expect(screen.queryByTestId("market-BTC-swap-button")).toBeNull();
+  });
+
+  it("should call swap onClick when the swap button is pressed", async () => {
+    const { user } = render(<MarketRowActions {...createProps()} />);
+    await user.click(screen.getByTestId("market-BTC-swap-button"));
+    expect(mockOnSwap).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render the actions menu trigger", () => {
+    render(<MarketRowActions {...createProps()} />);
+    expect(screen.getByTestId("market-BTC-actions-menu")).toBeVisible();
+  });
+
+  it("should show buy/sell, earn and favourite items when the menu is opened", async () => {
+    const { user } = render(<MarketRowActions {...createProps()} />);
+
+    await user.click(screen.getByTestId("market-BTC-actions-menu"));
+
+    expect(await screen.findByText("market.marketTable.menu.buySell")).toBeVisible();
+    expect(screen.getByText("Earn")).toBeVisible();
+    expect(screen.getByText("market.marketTable.menu.addToFavourites")).toBeVisible();
+  });
+
+  it("should hide the buy/sell item when buy/sell is unavailable", async () => {
+    const { user } = render(
+      <MarketRowActions
+        {...createProps({ buySellAction: { available: false, onClick: mockOnBuySell } })}
+      />,
+    );
+
+    await user.click(screen.getByTestId("market-BTC-actions-menu"));
+    expect(screen.queryByText("market.marketTable.menu.buySell")).toBeNull();
+  });
+
+  it("should hide the earn item when earn is unavailable", async () => {
+    const { user } = render(
+      <MarketRowActions
+        {...createProps({ earnAction: { available: false, onClick: mockOnStake, label: "Earn" } })}
+      />,
+    );
+
+    await user.click(screen.getByTestId("market-BTC-actions-menu"));
+    expect(screen.queryByText("Earn")).toBeNull();
+  });
+
+  it("should show the remove-from-favourites label when starred", async () => {
+    const { user } = render(<MarketRowActions {...createProps({ isStarred: true })} />);
+
+    await user.click(screen.getByTestId("market-BTC-actions-menu"));
+    expect(await screen.findByText("market.marketTable.menu.removeFromFavourites")).toBeVisible();
+    expect(screen.queryByText("market.marketTable.menu.addToFavourites")).toBeNull();
+  });
+
+  it("should call buySell onClick when the buy/sell item is selected", async () => {
+    const { user } = render(<MarketRowActions {...createProps()} />);
+
+    await user.click(screen.getByTestId("market-BTC-actions-menu"));
+    await user.click(await screen.findByText("market.marketTable.menu.buySell"));
+    expect(mockOnBuySell).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call earn onClick when the earn item is selected", async () => {
+    const { user } = render(<MarketRowActions {...createProps()} />);
+
+    await user.click(screen.getByTestId("market-BTC-actions-menu"));
+    await user.click(await screen.findByText("Earn"));
+    expect(mockOnStake).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onFavouriteSelect when the favourite item is selected", async () => {
+    const { user } = render(<MarketRowActions {...createProps()} />);
+
+    await user.click(screen.getByTestId("market-BTC-actions-menu"));
+    await user.click(await screen.findByText("market.marketTable.menu.addToFavourites"));
+    expect(mockOnFavouriteSelect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/__tests__/MarketRowView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/__tests__/MarketRowView.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { screen } from "tests/testSetup";
+import { MOCK_MARKET_CURRENCY_DATA } from "@ledgerhq/live-common/market/utils/fixtures";
+import { MarketRowView, MarketRowViewProps } from "../MarketRowView";
+import { mockT, renderInTable } from "../../__tests__/shared";
+
+const mockCurrency = MOCK_MARKET_CURRENCY_DATA[0];
+
+const renderRow = (props: MarketRowViewProps) =>
+  renderInTable(<MarketRowView {...props} />, { withBody: true });
+
+function createProps(overrides: Partial<MarketRowViewProps> = {}): MarketRowViewProps {
+  return {
+    style: {},
+    currency: mockCurrency,
+    isStarred: false,
+    priceChangePercentage: 2.5,
+    formattedPrice: "$50,000.00",
+    formattedVolume: "$50M",
+    formattedMarketCap: "$1B",
+    onCurrencyClick: jest.fn(),
+    swapAction: { available: false, onClick: jest.fn() },
+    buySellAction: { available: false, onClick: jest.fn() },
+    earnAction: { available: false, onClick: jest.fn(), label: "Earn" },
+    onFavouriteSelect: jest.fn(),
+    onMenuOpenChange: jest.fn(),
+    t: mockT,
+    ...overrides,
+  };
+}
+
+describe("MarketRowView", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render currency name and uppercased ticker", () => {
+    renderRow(createProps());
+
+    expect(screen.getByText("Bitcoin")).toBeVisible();
+    expect(screen.getByText("BTC")).toBeVisible();
+  });
+
+  it("should render the marketcap rank tag", () => {
+    renderRow(createProps());
+    expect(screen.getByText("#1")).toBeVisible();
+  });
+
+  it("should not render the rank tag when marketcapRank is absent", () => {
+    const currency = { ...mockCurrency, marketcapRank: 0 };
+    renderRow(createProps({ currency }));
+    expect(screen.queryByText("#1")).toBeNull();
+  });
+
+  it("should render formatted price, volume and market cap", () => {
+    renderRow(createProps());
+
+    expect(screen.getByTestId("market-coin-price")).toHaveTextContent("$50,000.00");
+    expect(screen.getByTestId("market-volume")).toHaveTextContent("$50M");
+    expect(screen.getByTestId("market-cap")).toHaveTextContent("$1B");
+  });
+
+  it("should render the image fallback when ledgerIds is empty", () => {
+    const currency = { ...mockCurrency, ledgerIds: [] };
+    renderRow(createProps({ currency }));
+    expect(screen.getByAltText("Bitcoin")).toBeVisible();
+  });
+
+  it("should render '-' when priceChangePercentage is undefined", () => {
+    renderRow(createProps({ priceChangePercentage: undefined }));
+    expect(screen.getByTestId("market-price-change")).toHaveTextContent("-");
+  });
+
+  it("should render the trend when priceChangePercentage is defined", () => {
+    renderRow(createProps({ priceChangePercentage: 5.5 }));
+    expect(screen.getByTestId("market-price-change")).not.toHaveTextContent("-");
+  });
+
+  it("should call onCurrencyClick when the row is clicked", async () => {
+    const onCurrencyClick = jest.fn();
+    const { user } = renderRow(createProps({ onCurrencyClick }));
+
+    await user.click(screen.getByTestId("market-BTC-row"));
+    expect(onCurrencyClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/__tests__/useMarketRowViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/__tests__/useMarketRowViewModel.test.ts
@@ -1,0 +1,197 @@
+import { renderHook, act } from "tests/testSetup";
+import { MOCK_MARKET_CURRENCY_DATA } from "@ledgerhq/live-common/market/utils/fixtures";
+import { KeysPriceChange } from "@ledgerhq/live-common/market/utils/types";
+import { useMarketRowViewModel } from "../useMarketRowViewModel";
+import { useMarketActions } from "LLD/features/Market/hooks/useMarketActions";
+
+const mockNavigate = jest.fn();
+const mockOnBuy = jest.fn();
+const mockOnSell = jest.fn();
+const mockOnSwap = jest.fn();
+const mockOnStake = jest.fn();
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock("LLD/features/Market/hooks/useMarketActions", () => ({
+  Page: { Market: "Page Market", MarketCoin: "Page Market Coin" },
+  useMarketActions: jest.fn(),
+}));
+
+jest.mock("~/renderer/hooks/useGetStakeLabelLocaleBased", () => ({
+  useGetStakeLabelLocaleBased: () => "Earn",
+}));
+
+const mockShouldDisplayAggregatedAssets = jest.fn(() => true);
+jest.mock("@features/platform-feature-flags", () => ({
+  ...jest.requireActual("@features/platform-feature-flags"),
+  useWalletFeaturesConfig: () => ({
+    shouldDisplayAggregatedAssets: mockShouldDisplayAggregatedAssets(),
+    shouldDisplayAssetSection: true,
+    shouldDisplayWallet40MainNav: true,
+  }),
+}));
+
+const mockedUseMarketActions = jest.mocked(useMarketActions);
+
+const bitcoinCurrency = MOCK_MARKET_CURRENCY_DATA[0];
+
+const allActionsAvailable = {
+  onBuy: mockOnBuy,
+  onSell: mockOnSell,
+  onSwap: mockOnSwap,
+  onStake: mockOnStake,
+  availableOnBuy: true,
+  availableOnSell: true,
+  availableOnSwap: true,
+  availableOnStake: true,
+};
+
+function renderViewModel(overrides: Partial<Parameters<typeof useMarketRowViewModel>[0]> = {}) {
+  return renderHook(() =>
+    useMarketRowViewModel({
+      size: 56,
+      start: 112,
+      currency: bitcoinCurrency,
+      counterCurrency: "usd",
+      locale: "en",
+      range: "24h",
+      isStarred: false,
+      toggleStar: jest.fn(),
+      ...overrides,
+    }),
+  );
+}
+
+describe("useMarketRowViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockShouldDisplayAggregatedAssets.mockReturnValue(true);
+    mockedUseMarketActions.mockReturnValue(allActionsAvailable);
+  });
+
+  it("should build the absolute-positioning style from size and start", () => {
+    const { result } = renderViewModel({ size: 56, start: 112 });
+
+    expect(result.current.style).toEqual({
+      height: "56px",
+      transform: "translateY(112px)",
+    });
+  });
+
+  it("should keep a stable style reference across re-renders with same size/start", () => {
+    const { result, rerender } = renderViewModel();
+
+    const firstStyle = result.current.style;
+    rerender();
+    expect(result.current.style).toBe(firstStyle);
+  });
+
+  it("should select priceChangePercentage based on range", () => {
+    const { result } = renderViewModel({ range: "24h" });
+
+    expect(result.current.priceChangePercentage).toBe(
+      bitcoinCurrency.priceChangePercentage[KeysPriceChange.day],
+    );
+  });
+
+  it("should format price, volume and market cap as non-empty strings", () => {
+    const { result } = renderViewModel();
+
+    expect(typeof result.current.formattedPrice).toBe("string");
+    expect(result.current.formattedPrice.length).toBeGreaterThan(0);
+    expect(result.current.formattedVolume.length).toBeGreaterThan(0);
+    expect(result.current.formattedMarketCap.length).toBeGreaterThan(0);
+  });
+
+  it("should navigate to /asset/ when shouldDisplayAggregatedAssets is true", () => {
+    mockShouldDisplayAggregatedAssets.mockReturnValue(true);
+    const { result } = renderViewModel();
+
+    act(() => result.current.onCurrencyClick());
+
+    expect(mockNavigate).toHaveBeenCalledWith(`/asset/${bitcoinCurrency.id}`, {
+      state: bitcoinCurrency,
+    });
+  });
+
+  it("should navigate to /market/ when shouldDisplayAggregatedAssets is false", () => {
+    mockShouldDisplayAggregatedAssets.mockReturnValue(false);
+    const { result } = renderViewModel();
+
+    act(() => result.current.onCurrencyClick());
+
+    expect(mockNavigate).toHaveBeenCalledWith(`/market/${bitcoinCurrency.id}`, {
+      state: bitcoinCurrency,
+    });
+  });
+
+  it("should route buySellAction to onBuy when buy is available", () => {
+    const { result } = renderViewModel();
+
+    expect(result.current.buySellAction.available).toBe(true);
+    expect(result.current.buySellAction.onClick).toBe(mockOnBuy);
+  });
+
+  it("should route buySellAction to onSell when only sell is available", () => {
+    mockedUseMarketActions.mockReturnValue({ ...allActionsAvailable, availableOnBuy: false });
+    const { result } = renderViewModel();
+
+    expect(result.current.buySellAction.available).toBe(true);
+    expect(result.current.buySellAction.onClick).toBe(mockOnSell);
+  });
+
+  it("should mark buySellAction unavailable when neither buy nor sell is available", () => {
+    mockedUseMarketActions.mockReturnValue({
+      ...allActionsAvailable,
+      availableOnBuy: false,
+      availableOnSell: false,
+    });
+    const { result } = renderViewModel();
+
+    expect(result.current.buySellAction.available).toBe(false);
+  });
+
+  it("should expose swap and earn actions reflecting availability and label", () => {
+    const { result } = renderViewModel();
+
+    expect(result.current.swapAction).toEqual({ available: true, onClick: mockOnSwap });
+    expect(result.current.earnAction).toEqual({
+      available: true,
+      onClick: mockOnStake,
+      label: "Earn",
+    });
+  });
+
+  it("should defer the favourite toggle until the menu closes", () => {
+    const toggleStar = jest.fn();
+    const { result } = renderViewModel({ toggleStar, isStarred: false });
+
+    // Selecting the favourite item should not toggle immediately.
+    act(() => result.current.onFavouriteSelect());
+    expect(toggleStar).not.toHaveBeenCalled();
+
+    // Toggling fires once the menu finishes closing.
+    act(() => result.current.onMenuOpenChange(false));
+    expect(toggleStar).toHaveBeenCalledWith(bitcoinCurrency.id, false);
+  });
+
+  it("should not toggle the favourite when the menu closes without a pending selection", () => {
+    const toggleStar = jest.fn();
+    const { result } = renderViewModel({ toggleStar });
+
+    act(() => result.current.onMenuOpenChange(false));
+    expect(toggleStar).not.toHaveBeenCalled();
+  });
+
+  it("should not toggle the favourite while the menu is still open", () => {
+    const toggleStar = jest.fn();
+    const { result } = renderViewModel({ toggleStar });
+
+    act(() => result.current.onFavouriteSelect());
+    act(() => result.current.onMenuOpenChange(true));
+    expect(toggleStar).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/index.tsx
@@ -1,0 +1,20 @@
+import React, { memo } from "react";
+import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { MarketRowView } from "./MarketRowView";
+import { useMarketRowViewModel } from "./useMarketRowViewModel";
+
+export type MarketRowProps = {
+  size: number;
+  start: number;
+  currency: MarketCurrencyData;
+  counterCurrency?: string;
+  locale: string;
+  range?: string;
+  isStarred: boolean;
+  toggleStar: (id: string, isStarred: boolean) => void;
+};
+
+export const MarketRow = memo<MarketRowProps>(function MarketRow(props: MarketRowProps) {
+  const viewModel = useMarketRowViewModel(props);
+  return <MarketRowView {...viewModel} />;
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/useMarketRowViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/useMarketRowViewModel.ts
@@ -1,0 +1,127 @@
+import { type CSSProperties, useCallback, useMemo, useRef } from "react";
+import { useNavigate } from "react-router";
+import { useTranslation } from "react-i18next";
+import counterValueFormatter from "@ledgerhq/live-common/market/utils/countervalueFormatter";
+import { roundFiatPrice } from "@ledgerhq/live-currency-format";
+import { setTrackingSource } from "~/renderer/analytics/TrackPage";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import { MarketCurrencyData, KeysPriceChange } from "@ledgerhq/live-common/market/utils/types";
+import { getMarketOrAssetDetailPath } from "LLD/utils/marketAssetNavigation";
+import { Page, useMarketActions } from "LLD/features/Market/hooks/useMarketActions";
+import { useGetStakeLabelLocaleBased } from "~/renderer/hooks/useGetStakeLabelLocaleBased";
+
+type UseMarketRowViewModelProps = {
+  size: number;
+  start: number;
+  currency: MarketCurrencyData;
+  counterCurrency?: string;
+  locale: string;
+  range?: string;
+  isStarred: boolean;
+  toggleStar: (id: string, isStarred: boolean) => void;
+};
+
+export function useMarketRowViewModel({
+  size,
+  start,
+  currency,
+  counterCurrency,
+  locale,
+  range,
+  isStarred,
+  toggleStar,
+}: UseMarketRowViewModelProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
+
+  const {
+    onBuy,
+    onSell,
+    onStake,
+    onSwap,
+    availableOnBuy,
+    availableOnSell,
+    availableOnSwap,
+    availableOnStake,
+  } = useMarketActions({ currency, page: Page.Market });
+
+  const earnLabel = useGetStakeLabelLocaleBased();
+
+  // Build the absolute-positioning style from primitive props so a row that stays
+  // visible while scrolling keeps a stable `style` reference and `memo` holds.
+  const style = useMemo<CSSProperties>(
+    () => ({ height: `${size}px`, transform: `translateY(${start}px)` }),
+    [size, start],
+  );
+
+  const onCurrencyClick = useCallback(() => {
+    setTrackingSource("Page Market");
+    navigate(getMarketOrAssetDetailPath(currency.id, shouldDisplayAggregatedAssets), {
+      state: currency,
+    });
+  }, [currency, navigate, shouldDisplayAggregatedAssets]);
+
+  const onToggleStar = useCallback(
+    () => toggleStar(currency.id, isStarred),
+    [toggleStar, currency.id, isStarred],
+  );
+
+  // Defer the favourite toggle until the menu has closed, so the open menu never
+  // shows the updated label/icon before disappearing (avoids a flicker).
+  const pendingFavouriteToggle = useRef(false);
+  const onFavouriteSelect = useCallback(() => {
+    pendingFavouriteToggle.current = true;
+  }, []);
+  const onMenuOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open && pendingFavouriteToggle.current) {
+        pendingFavouriteToggle.current = false;
+        onToggleStar();
+      }
+    },
+    [onToggleStar],
+  );
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const priceChangePercentage = currency.priceChangePercentage[range as KeysPriceChange];
+
+  const formattedPrice = counterValueFormatter({
+    value: roundFiatPrice(currency.price ?? 0),
+    currency: counterCurrency,
+    locale,
+  });
+  const formattedVolume = counterValueFormatter({
+    shorten: true,
+    currency: counterCurrency,
+    value: currency.totalVolume,
+    locale,
+  });
+  const formattedMarketCap = counterValueFormatter({
+    shorten: true,
+    currency: counterCurrency,
+    value: currency.marketcap,
+    locale,
+  });
+
+  return {
+    t,
+    style,
+    currency,
+    isStarred,
+    onCurrencyClick,
+    priceChangePercentage,
+    formattedPrice,
+    formattedVolume,
+    formattedMarketCap,
+    swapAction: { available: availableOnSwap, onClick: onSwap },
+    // Single "Buy/Sell" entry: route to buy when buy is available, otherwise sell.
+    buySellAction: {
+      available: availableOnBuy || availableOnSell,
+      onClick: availableOnBuy ? onBuy : onSell,
+    },
+    earnAction: { available: availableOnStake, onClick: onStake, label: earnLabel },
+    onFavouriteSelect,
+    onMenuOpenChange,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/MarketTableHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/MarketTableHeader.tsx
@@ -1,0 +1,74 @@
+import React, { memo } from "react";
+import { TFunction } from "i18next";
+import {
+  TableHeader,
+  TableHeaderRow,
+  TableHeaderCell,
+  TableSortButton,
+} from "@ledgerhq/lumen-ui-react";
+import {
+  MARKET_TABLE_GRID_TEMPLATE,
+  MARKET_CELL_CLASSNAME,
+  MARKET_HEADER_CELL_END_CLASSNAME,
+} from "./constants";
+
+export type SortDirection = "asc" | "desc" | undefined;
+
+type MarketTableHeaderProps = {
+  marketCapSort: SortDirection;
+  changeSort: SortDirection;
+  onToggleMarketCap: () => void;
+  onToggleChange: () => void;
+  t: TFunction;
+};
+
+export const MarketTableHeader = memo<MarketTableHeaderProps>(function MarketTableHeader({
+  marketCapSort,
+  changeSort,
+  onToggleMarketCap,
+  onToggleChange,
+  t,
+}) {
+  return (
+    <TableHeader className="grid">
+      <TableHeaderRow
+        className="grid"
+        style={{ gridTemplateColumns: MARKET_TABLE_GRID_TEMPLATE }}
+        data-testid="market-list-header"
+      >
+        <TableHeaderCell className={MARKET_CELL_CLASSNAME}>
+          {t("market.marketTable.crypto")}
+        </TableHeaderCell>
+        <TableHeaderCell align="end" className={MARKET_HEADER_CELL_END_CLASSNAME}>
+          {t("market.marketTable.price")}
+        </TableHeaderCell>
+        <TableHeaderCell align="end" className={MARKET_HEADER_CELL_END_CLASSNAME}>
+          <TableSortButton align="end" data-testid="market-sort-volume">
+            {t("market.marketTable.volume")}
+          </TableSortButton>
+        </TableHeaderCell>
+        <TableHeaderCell align="end" className={MARKET_HEADER_CELL_END_CLASSNAME}>
+          <TableSortButton
+            align="end"
+            sortDirection={marketCapSort}
+            onToggleSort={onToggleMarketCap}
+            data-testid="market-sort-marketcap"
+          >
+            {t("market.marketTable.marketCap")}
+          </TableSortButton>
+        </TableHeaderCell>
+        <TableHeaderCell align="end" className={MARKET_HEADER_CELL_END_CLASSNAME}>
+          <TableSortButton
+            align="end"
+            sortDirection={changeSort}
+            onToggleSort={onToggleChange}
+            data-testid="market-sort-change"
+          >
+            {t("market.marketTable.change")}
+          </TableSortButton>
+        </TableHeaderCell>
+        <TableHeaderCell align="end" aria-label={t("market.marketTable.actions")} />
+      </TableHeaderRow>
+    </TableHeader>
+  );
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/MarketTableSkeleton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/MarketTableSkeleton.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { listItemHeight } from "~/renderer/screens/market/components/Table";
+import { MARKET_TABLE_GRID_TEMPLATE } from "./constants";
+
+const SKELETON_ROWS = 12;
+
+export function MarketTableSkeleton() {
+  return (
+    <div data-testid="market-table-skeleton">
+      {Array.from({ length: SKELETON_ROWS }).map((_, index) => (
+        <div
+          key={index}
+          className="grid w-full items-center px-12"
+          style={{ gridTemplateColumns: MARKET_TABLE_GRID_TEMPLATE, height: listItemHeight }}
+        >
+          <div className="flex items-center gap-12">
+            <div className="size-32 shrink-0 animate-pulse rounded-full bg-muted" />
+            <div className="h-12 w-96 animate-pulse rounded-xs bg-muted" />
+          </div>
+          <div className="h-12 w-64 animate-pulse justify-self-end rounded-xs bg-muted" />
+          <div className="h-12 w-64 animate-pulse justify-self-end rounded-xs bg-muted" />
+          <div className="h-12 w-64 animate-pulse justify-self-end rounded-xs bg-muted" />
+          <div className="h-12 w-48 animate-pulse justify-self-end rounded-xs bg-muted" />
+          <div />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/MarketTableView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/MarketTableView.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { TFunction } from "i18next";
+import { Virtualizer } from "@tanstack/react-virtual";
+import { TableRoot, Table, TableBody } from "@ledgerhq/lumen-ui-react";
+import {
+  MarketCurrencyData,
+  MarketListRequestParams,
+} from "@ledgerhq/live-common/market/utils/types";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import { NoCryptoPlaceholder } from "~/renderer/screens/market/MarketList/components/NoCryptoPlaceholder";
+import { MarketFavoritesEmptyState } from "../MarketFavoritesEmptyState";
+import { MarketRow } from "../MarketRow";
+import { MarketTableHeader, SortDirection } from "./MarketTableHeader";
+import { MarketTableSkeleton } from "./MarketTableSkeleton";
+
+export type MarketTableViewProps = {
+  parentRef: React.RefObject<HTMLDivElement | null>;
+  rowVirtualizer: Virtualizer<HTMLDivElement, Element>;
+  marketData: MarketCurrencyData[];
+  marketParams: MarketListRequestParams;
+  counterCurrency?: string;
+  range?: string;
+  search?: string;
+  locale: string;
+  currenciesLength: number;
+  showSkeleton: boolean;
+  emptyState?: "favorites";
+  resetSearch: () => void;
+  isStarred: (id: string) => boolean;
+  toggleStar: (id: string, isStarred: boolean) => void;
+  marketCapSort: SortDirection;
+  changeSort: SortDirection;
+  onToggleMarketCap: () => void;
+  onToggleChange: () => void;
+  t: TFunction;
+};
+
+export function MarketTableView({
+  parentRef,
+  rowVirtualizer,
+  marketData,
+  marketParams,
+  counterCurrency,
+  range,
+  search,
+  locale,
+  currenciesLength,
+  showSkeleton,
+  emptyState,
+  resetSearch,
+  isStarred,
+  toggleStar,
+  marketCapSort,
+  changeSort,
+  onToggleMarketCap,
+  onToggleChange,
+  t,
+}: Readonly<MarketTableViewProps>) {
+  if (emptyState === "favorites") {
+    return <MarketFavoritesEmptyState t={t} />;
+  }
+
+  if (!showSkeleton && currenciesLength === 0) {
+    return <NoCryptoPlaceholder requestParams={marketParams} t={t} resetSearch={resetSearch} />;
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {search && currenciesLength > 0 && <TrackPage category="Market Search" success={true} />}
+      <TableRoot
+        appearance="plain"
+        className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg"
+      >
+        <div className="shrink-0 overflow-x-auto overflow-y-hidden">
+          <Table className="grid">
+            <MarketTableHeader
+              marketCapSort={marketCapSort}
+              changeSort={changeSort}
+              onToggleMarketCap={onToggleMarketCap}
+              onToggleChange={onToggleChange}
+              t={t}
+            />
+          </Table>
+        </div>
+        <div
+          ref={parentRef}
+          className="min-h-0 flex-1 overflow-auto scrollbar-custom [scrollbar-gutter:auto]"
+        >
+          {showSkeleton ? (
+            <MarketTableSkeleton />
+          ) : (
+            <Table className="grid">
+              <TableBody
+                className="relative block"
+                style={{ height: rowVirtualizer.getTotalSize() }}
+                data-testid="market-list-data"
+              >
+                {rowVirtualizer.getVirtualItems().map(virtualRow => {
+                  const currency = marketData[virtualRow.index];
+                  if (!currency) return null;
+
+                  return (
+                    <MarketRow
+                      key={currency.id}
+                      size={virtualRow.size}
+                      start={virtualRow.start}
+                      currency={currency}
+                      counterCurrency={counterCurrency}
+                      locale={locale}
+                      range={range}
+                      isStarred={isStarred(currency.id)}
+                      toggleStar={toggleStar}
+                    />
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </div>
+      </TableRoot>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/MarketTableHeader.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/MarketTableHeader.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { screen } from "tests/testSetup";
+import { MarketTableHeader } from "../MarketTableHeader";
+import { mockT, renderInTable } from "../../__tests__/shared";
+
+type HeaderProps = Parameters<typeof MarketTableHeader>[0];
+
+function createProps(overrides: Partial<HeaderProps> = {}): HeaderProps {
+  return {
+    marketCapSort: "desc",
+    changeSort: undefined,
+    onToggleMarketCap: jest.fn(),
+    onToggleChange: jest.fn(),
+    t: mockT,
+    ...overrides,
+  };
+}
+
+const renderHeader = (props: HeaderProps) => renderInTable(<MarketTableHeader {...props} />);
+
+describe("MarketTableHeader", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should render the column headers", () => {
+    renderHeader(createProps());
+
+    expect(screen.getByText("market.marketTable.crypto")).toBeVisible();
+    expect(screen.getByText("market.marketTable.price")).toBeVisible();
+    expect(screen.getByText("market.marketTable.volume")).toBeVisible();
+    expect(screen.getByText("market.marketTable.marketCap")).toBeVisible();
+    expect(screen.getByText("market.marketTable.change")).toBeVisible();
+  });
+
+  it("should call onToggleMarketCap when the market cap sort button is clicked", async () => {
+    const onToggleMarketCap = jest.fn();
+    const { user } = renderHeader(createProps({ onToggleMarketCap }));
+
+    await user.click(screen.getByTestId("market-sort-marketcap"));
+    expect(onToggleMarketCap).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onToggleChange when the change sort button is clicked", async () => {
+    const onToggleChange = jest.fn();
+    const { user } = renderHeader(createProps({ onToggleChange }));
+
+    await user.click(screen.getByTestId("market-sort-change"));
+    expect(onToggleChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/MarketTableSkeleton.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/MarketTableSkeleton.test.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { MarketTableSkeleton } from "../MarketTableSkeleton";
+
+describe("MarketTableSkeleton", () => {
+  it("should render the skeleton container", () => {
+    render(<MarketTableSkeleton />);
+    expect(screen.getByTestId("market-table-skeleton")).toBeVisible();
+  });
+
+  it("should render 12 skeleton rows", () => {
+    render(<MarketTableSkeleton />);
+    const skeleton = screen.getByTestId("market-table-skeleton");
+    expect(skeleton.children).toHaveLength(12);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/MarketTableView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/MarketTableView.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { Virtualizer } from "@tanstack/react-virtual";
+import { render, screen } from "tests/testSetup";
+import { MOCK_MARKET_CURRENCY_DATA } from "@ledgerhq/live-common/market/utils/fixtures";
+import { Order } from "@ledgerhq/live-common/market/utils/types";
+import { MarketTableView, MarketTableViewProps } from "../MarketTableView";
+import { mockT } from "../../__tests__/shared";
+
+const emptyVirtualizer = {
+  getVirtualItems: () => [],
+  getTotalSize: () => 0,
+} as unknown as Virtualizer<HTMLDivElement, Element>;
+
+function createProps(overrides: Partial<MarketTableViewProps> = {}): MarketTableViewProps {
+  return {
+    parentRef: { current: null },
+    rowVirtualizer: emptyVirtualizer,
+    marketData: MOCK_MARKET_CURRENCY_DATA,
+    marketParams: { order: Order.MarketCapDesc },
+    counterCurrency: "usd",
+    range: "24h",
+    search: "",
+    locale: "en",
+    currenciesLength: MOCK_MARKET_CURRENCY_DATA.length,
+    showSkeleton: false,
+    resetSearch: jest.fn(),
+    isStarred: () => false,
+    toggleStar: jest.fn(),
+    marketCapSort: "desc",
+    changeSort: undefined,
+    onToggleMarketCap: jest.fn(),
+    onToggleChange: jest.fn(),
+    t: mockT,
+    ...overrides,
+  };
+}
+
+describe("MarketTableView", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should render the favorites empty state when emptyState is 'favorites'", () => {
+    render(<MarketTableView {...createProps({ emptyState: "favorites" })} />);
+
+    expect(screen.queryByTestId("market-list-header")).toBeNull();
+    expect(screen.queryByTestId("market-list-data")).toBeNull();
+  });
+
+  it("should render the no-crypto placeholder when there are no currencies and no skeleton", () => {
+    render(<MarketTableView {...createProps({ currenciesLength: 0, showSkeleton: false })} />);
+
+    expect(screen.queryByTestId("market-list-data")).toBeNull();
+  });
+
+  it("should render the skeleton when showSkeleton is true", () => {
+    render(<MarketTableView {...createProps({ showSkeleton: true })} />);
+
+    expect(screen.getByTestId("market-table-skeleton")).toBeVisible();
+    expect(screen.queryByTestId("market-list-data")).toBeNull();
+  });
+
+  it("should render the header and table body when data is available", () => {
+    render(<MarketTableView {...createProps()} />);
+
+    expect(screen.getByTestId("market-list-header")).toBeVisible();
+    expect(screen.getByTestId("market-list-data")).toBeVisible();
+    expect(screen.queryByTestId("market-table-skeleton")).toBeNull();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/useMarketTableViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/useMarketTableViewModel.test.ts
@@ -1,0 +1,133 @@
+import { renderHook } from "tests/testSetup";
+import { MOCK_MARKET_CURRENCY_DATA } from "@ledgerhq/live-common/market/utils/fixtures";
+import { Order } from "@ledgerhq/live-common/market/utils/types";
+import { MarketTableData, useMarketTableViewModel } from "../useMarketTableViewModel";
+import { mockT } from "../../__tests__/shared";
+
+const mockParentRef = { current: null };
+const mockRowVirtualizer = { getVirtualItems: () => [], getTotalSize: () => 0 };
+
+jest.mock("../../../hooks/useMarketListVirtualization", () => ({
+  useMarketListVirtualization: () => ({
+    parentRef: mockParentRef,
+    rowVirtualizer: mockRowVirtualizer,
+  }),
+}));
+
+function createData(overrides: Partial<MarketTableData> = {}): MarketTableData {
+  return {
+    marketData: MOCK_MARKET_CURRENCY_DATA,
+    marketParams: { order: Order.MarketCapDesc, counterCurrency: "usd", range: "24h" },
+    locale: "en",
+    freshLoading: false,
+    isError: false,
+    loading: false,
+    currenciesLength: MOCK_MARKET_CURRENCY_DATA.length,
+    itemCount: MOCK_MARKET_CURRENCY_DATA.length,
+    starredMarketCoins: ["bitcoin"],
+    resetSearch: jest.fn(),
+    refresh: jest.fn(),
+    toggleStar: jest.fn(),
+    onLoadNextPage: jest.fn(),
+    checkIfDataIsStaleAndRefetch: jest.fn(),
+    t: mockT,
+    ...overrides,
+  };
+}
+
+describe("useMarketTableViewModel", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should report a currency as starred when present in starredMarketCoins", () => {
+    const { result } = renderHook(() => useMarketTableViewModel(createData()));
+
+    expect(result.current.isStarred("bitcoin")).toBe(true);
+    expect(result.current.isStarred("ethereum")).toBe(false);
+  });
+
+  it("should derive marketCapSort from the current order", () => {
+    const { result: desc } = renderHook(() =>
+      useMarketTableViewModel(createData({ marketParams: { order: Order.MarketCapDesc } })),
+    );
+    expect(desc.current.marketCapSort).toBe("desc");
+    expect(desc.current.changeSort).toBeUndefined();
+
+    const { result: asc } = renderHook(() =>
+      useMarketTableViewModel(createData({ marketParams: { order: Order.MarketCapAsc } })),
+    );
+    expect(asc.current.marketCapSort).toBe("asc");
+  });
+
+  it("should derive changeSort from gainers/losers order", () => {
+    const { result: gainers } = renderHook(() =>
+      useMarketTableViewModel(createData({ marketParams: { order: Order.topGainers } })),
+    );
+    expect(gainers.current.changeSort).toBe("desc");
+    expect(gainers.current.marketCapSort).toBeUndefined();
+
+    const { result: losers } = renderHook(() =>
+      useMarketTableViewModel(createData({ marketParams: { order: Order.topLosers } })),
+    );
+    expect(losers.current.changeSort).toBe("asc");
+  });
+
+  it("should toggle the market cap order between desc and asc", () => {
+    const refresh = jest.fn();
+
+    const { result: fromDesc } = renderHook(() =>
+      useMarketTableViewModel(createData({ refresh, marketParams: { order: Order.MarketCapDesc } })),
+    );
+    fromDesc.current.onToggleMarketCap();
+    expect(refresh).toHaveBeenCalledWith({ order: Order.MarketCapAsc });
+
+    refresh.mockClear();
+    const { result: fromAsc } = renderHook(() =>
+      useMarketTableViewModel(createData({ refresh, marketParams: { order: Order.MarketCapAsc } })),
+    );
+    fromAsc.current.onToggleMarketCap();
+    expect(refresh).toHaveBeenCalledWith({ order: Order.MarketCapDesc });
+  });
+
+  it("should toggle the change order between top gainers and top losers", () => {
+    const refresh = jest.fn();
+
+    const { result: fromGainers } = renderHook(() =>
+      useMarketTableViewModel(createData({ refresh, marketParams: { order: Order.topGainers } })),
+    );
+    fromGainers.current.onToggleChange();
+    expect(refresh).toHaveBeenCalledWith({ order: Order.topLosers });
+
+    refresh.mockClear();
+    const { result: fromOther } = renderHook(() =>
+      useMarketTableViewModel(createData({ refresh, marketParams: { order: Order.MarketCapDesc } })),
+    );
+    fromOther.current.onToggleChange();
+    expect(refresh).toHaveBeenCalledWith({ order: Order.topGainers });
+  });
+
+  it("should show the skeleton while fresh loading or on error", () => {
+    const { result: loadingResult } = renderHook(() =>
+      useMarketTableViewModel(createData({ freshLoading: true })),
+    );
+    expect(loadingResult.current.showSkeleton).toBe(true);
+
+    const { result: errorResult } = renderHook(() =>
+      useMarketTableViewModel(createData({ isError: true })),
+    );
+    expect(errorResult.current.showSkeleton).toBe(true);
+
+    const { result: idleResult } = renderHook(() => useMarketTableViewModel(createData()));
+    expect(idleResult.current.showSkeleton).toBe(false);
+  });
+
+  it("should pass through params, locale and emptyState", () => {
+    const { result } = renderHook(() =>
+      useMarketTableViewModel(createData({ emptyState: "favorites" })),
+    );
+
+    expect(result.current.counterCurrency).toBe("usd");
+    expect(result.current.range).toBe("24h");
+    expect(result.current.locale).toBe("en");
+    expect(result.current.emptyState).toBe("favorites");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/constants.ts
@@ -1,0 +1,6 @@
+export const MARKET_TABLE_GRID_TEMPLATE =
+  "minmax(200px, 2fr) minmax(110px, 1fr) minmax(100px, 1fr) minmax(110px, 1fr) minmax(96px, 0.9fr) 150px";
+
+export const MARKET_CELL_CLASSNAME = "flex items-center";
+
+export const MARKET_HEADER_CELL_END_CLASSNAME = "flex items-center justify-end";

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/index.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { MarketTableData, useMarketTableViewModel } from "./useMarketTableViewModel";
+import { MarketTableView } from "./MarketTableView";
+
+export default function MarketTable(props: Readonly<MarketTableData>) {
+  const viewModel = useMarketTableViewModel(props);
+  return <MarketTableView {...viewModel} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/useMarketTableViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/useMarketTableViewModel.ts
@@ -1,0 +1,97 @@
+import { useCallback, useMemo } from "react";
+import { TFunction } from "i18next";
+import {
+  MarketCurrencyData,
+  MarketListRequestParams,
+  Order,
+} from "@ledgerhq/live-common/market/utils/types";
+import { useMarketListVirtualization } from "../../hooks/useMarketListVirtualization";
+
+export type MarketTableData = {
+  marketData: MarketCurrencyData[];
+  marketParams: MarketListRequestParams;
+  locale: string;
+  freshLoading: boolean;
+  isError: boolean;
+  loading: boolean;
+  currenciesLength: number;
+  itemCount: number;
+  emptyState?: "favorites";
+  starredMarketCoins: string[];
+  resetSearch: () => void;
+  refresh: (payload: MarketListRequestParams) => void;
+  toggleStar: (id: string, isStarred: boolean) => void;
+  onLoadNextPage: () => void;
+  checkIfDataIsStaleAndRefetch: (scrollOffset: number) => void;
+  t: TFunction;
+};
+
+export function useMarketTableViewModel({
+  marketData,
+  marketParams,
+  locale,
+  freshLoading,
+  isError,
+  loading,
+  currenciesLength,
+  itemCount,
+  emptyState,
+  starredMarketCoins,
+  resetSearch,
+  refresh,
+  toggleStar,
+  onLoadNextPage,
+  checkIfDataIsStaleAndRefetch,
+  t,
+}: MarketTableData) {
+  const { order, counterCurrency, range, search } = marketParams;
+
+  const { parentRef, rowVirtualizer } = useMarketListVirtualization({
+    itemCount,
+    marketData,
+    loading,
+    currenciesLength,
+    onLoadNextPage,
+    checkIfDataIsStaleAndRefetch,
+  });
+
+  const starredSet = useMemo(() => new Set(starredMarketCoins), [starredMarketCoins]);
+  const isStarred = useCallback((id: string) => starredSet.has(id), [starredSet]);
+
+  const onSort = useCallback((nextOrder: Order) => refresh({ order: nextOrder }), [refresh]);
+  const onToggleMarketCap = useCallback(
+    () => onSort(order === Order.MarketCapDesc ? Order.MarketCapAsc : Order.MarketCapDesc),
+    [onSort, order],
+  );
+  const onToggleChange = useCallback(
+    () => onSort(order === Order.topGainers ? Order.topLosers : Order.topGainers),
+    [onSort, order],
+  );
+
+  const marketCapSort: "asc" | "desc" | undefined =
+    order === Order.MarketCapDesc ? "desc" : order === Order.MarketCapAsc ? "asc" : undefined;
+  const changeSort: "asc" | "desc" | undefined =
+    order === Order.topGainers ? "desc" : order === Order.topLosers ? "asc" : undefined;
+
+  return {
+    parentRef,
+    rowVirtualizer,
+    marketData,
+    marketParams,
+    counterCurrency,
+    range,
+    search,
+    locale,
+    currenciesLength,
+    showSkeleton: freshLoading || isError,
+    emptyState,
+    resetSearch,
+    isStarred,
+    toggleStar,
+    marketCapSort,
+    changeSort,
+    onToggleMarketCap,
+    onToggleChange,
+    t,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/__tests__/shared.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/__tests__/shared.tsx
@@ -1,0 +1,20 @@
+import React, { ReactNode } from "react";
+import { TFunction } from "i18next";
+import { TableRoot, Table, TableBody } from "@ledgerhq/lumen-ui-react";
+import { render } from "tests/testSetup";
+
+/** Identity translation function for component tests (returns the key as-is). */
+export const mockT = ((key: string) => key) as unknown as TFunction;
+
+/**
+ * Lumen TableRow / TableHeaderRow must live inside a Table. This renders a
+ * component under test in the same hierarchy MarketTableView uses, optionally
+ * wrapping it in a TableBody for row-level components.
+ */
+export function renderInTable(ui: ReactNode, { withBody = false }: { withBody?: boolean } = {}) {
+  return render(
+    <TableRoot>
+      <Table>{withBody ? <TableBody>{ui}</TableBody> : ui}</Table>
+    </TableRoot>,
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketActions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketActions.ts
@@ -58,7 +58,7 @@ export const useMarketActions = ({ currency, page }: MarketActionsProps) => {
   );
 
   const onBuy = useCallback(
-    async (e: React.SyntheticEvent<HTMLButtonElement>) => {
+    async (e: React.SyntheticEvent) => {
       e.preventDefault();
       e.stopPropagation();
 
@@ -77,7 +77,7 @@ export const useMarketActions = ({ currency, page }: MarketActionsProps) => {
   );
 
   const onSell = useCallback(
-    async (e: React.SyntheticEvent<HTMLButtonElement>) => {
+    async (e: React.SyntheticEvent) => {
       e.preventDefault();
       e.stopPropagation();
 
@@ -96,7 +96,7 @@ export const useMarketActions = ({ currency, page }: MarketActionsProps) => {
   );
 
   const onSwap = useCallback(
-    async (e: React.SyntheticEvent<HTMLButtonElement>) => {
+    async (e: React.SyntheticEvent) => {
       e.preventDefault();
       e.stopPropagation();
 
@@ -117,7 +117,7 @@ export const useMarketActions = ({ currency, page }: MarketActionsProps) => {
   );
 
   const onStake = useCallback(
-    async (e: React.SyntheticEvent<HTMLButtonElement>) => {
+    async (e: React.SyntheticEvent) => {
       e.preventDefault();
       e.stopPropagation();
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/index.tsx
@@ -6,10 +6,10 @@ import TrackPage from "~/renderer/analytics/TrackPage";
 import SearchInputComponent from "./components/SearchInputComponent";
 import SideDrawerFilter from "~/renderer/screens/market/components/SideDrawerFilter";
 import CounterValueSelect from "~/renderer/screens/market/components/CountervalueSelect";
-import { useMarketListVirtualization } from "LLD/features/Market/hooks/useMarketListVirtualization";
 import PageHeader from "LLD/components/PageHeader";
 import { useNavigate } from "react-router";
-import MarketList from "./screens/MarketList";
+import MarketListLegacy from "./components/MarketListLegacy";
+import MarketTable from "./components/MarketTable";
 import MarketTopCards from "./TopCards";
 import { MarketCategoryBar } from "./components/MarketCategoryBar";
 import { MarketRangeSelect } from "./components/MarketRangeSelect";
@@ -70,15 +70,6 @@ export default function Market() {
   }, [marketCurrentPage, refetchData, refreshRate]);
 
   const { order, range, counterCurrency, search = "", liveCompatible } = marketParams;
-
-  const virtualization = useMarketListVirtualization({
-    itemCount: marketData.itemCount,
-    marketData: marketData.marketData,
-    loading: marketData.loading,
-    currenciesLength: marketData.currenciesLength,
-    onLoadNextPage: marketData.onLoadNextPage,
-    checkIfDataIsStaleAndRefetch: marketData.checkIfDataIsStaleAndRefetch,
-  });
 
   return (
     <Container>
@@ -159,7 +150,11 @@ export default function Market() {
           />
         </Flex>
       )}
-      <MarketList {...marketData} virtualization={virtualization} />
+      {shouldDisplayAssetDiscoverability ? (
+        <MarketTable {...marketData} />
+      ) : (
+        <MarketListLegacy {...marketData} />
+      )}
     </Container>
   );
 }

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8842,7 +8842,7 @@
     "title": "Crypto assets"
   },
   "stocks": {
-    "explore": "Explore"
+    "explore": "Explore all"
   },
   "nftEntryPoint": {
     "title": "NFT (Non Fungible Tokens)",

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -1639,6 +1639,20 @@
       "applyFilters": "Apply filters",
       "clearAll": "Clear all"
     },
+    "marketTable": {
+      "crypto": "Name",
+      "price": "Market price",
+      "volume": "Volume",
+      "change": "Change",
+      "marketCap": "Market cap",
+      "actions": "Actions",
+      "menu": {
+        "more": "More",
+        "buySell": "Buy/Sell",
+        "addToFavourites": "Add to favorites",
+        "removeFromFavourites": "Remove from favorites"
+      }
+    },
     "marketList": {
       "crypto": "Crypto",
       "price": "Price",


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - Wires the new Market table into the Market page behind the asset-discoverability flag. QA should focus on the Market screen: table vs legacy list rendering, sorting, search, favourites, and row actions (buy/sell, swap, earn).

### 📝 Description

Last of 3 **stacked** PRs introducing the new asset-discoverability Market **table** UI.

> ⚠️ Stacked on top of #18467 — review/merge that one first. Base is `feat/lwm-market-table`.

This PR does the wiring:
- `Market/index.tsx` renders `MarketTable` when asset-discoverability is enabled, otherwise the new `MarketListLegacy` wrapper.
- `MarketListLegacy` extracts the legacy list + virtualization into its own component.
- Minor unrelated i18n copy tweak (`stocks.explore`) that was part of this change set.

### ❓ Context

- **JIRA or GitHub link**: <!-- TODO: add ticket -->
- **ADR link (if any)**:

**Stacked PRs**
1. MarketRow component → `develop` (#18466)
2. MarketTable component → `feat/lwm-market-row` (#18467)
3. **this PR** — Wire into Market page → `feat/lwm-market-table`

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)