### PR TITLE
[LWM] feat(mobile): Portfolio Stocks section [LIVE-31379/31380/31381/31382/31383]

### DIFF
--- a/.changeset/stocks-data-layer.md
+++ b/.changeset/stocks-data-layer.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Add the Portfolio Stocks data layer. `useDefaultStocksAssets` fetches the top stocks (market-cap ordered) from the DADA stocks category via `useStocksData` + `selectTopStocks` for the discovery scenario (no-op when disabled). `useCategorizedAssetsFromPortfolio` now returns a `stocks` bucket split out of `cryptos`, identified by DADA currency id via the new `useStockAssetIds` hook — matching by id rather than ticker avoids symbol collisions (e.g. a crypto like TON is no longer misclassified as a stock).

--- a/.changeset/stocks-section.md
+++ b/.changeset/stocks-section.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add the Portfolio Stocks section and wire it into `AssetsSections` behind the `assetDiscoverability` flag. When the user holds stocks it renders a vertical list (max 5, mirroring the Crypto/Stablecoins sections) with a "Show more" header that opens the Crypto screen filtered to stocks — extending `CryptoVariant` with `"stocks"` and the asset-list filter accordingly. When the user holds none it renders a horizontal 2-row discovery grid of the top stocks (MediaButton pills) with an "Explore All" header that opens the Market list filtered to stocks; tapping a pill opens that stock's market detail. The 2-row grid is extracted into a shared `StockPillRows` component reused by Global Search (removing the duplicated grid). Subheader spacing: the holdings list matches the other portfolio sections, the discovery grid uses s12.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8708,7 +8708,11 @@
     "tabs": {
       "crypto": "Crypto",
       "stablecoins": "Stablecoins",
+      "stocks": "Stocks",
       "market": "Market"
+    },
+    "stocks": {
+      "exploreAll": "Explore All"
     },
     "referralProgram": "$20"
   },

--- a/apps/ledger-live-mobile/src/mvvm/components/StockPillRows/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/StockPillRows/index.tsx
@@ -1,0 +1,104 @@
+import React, { useCallback, useMemo } from "react";
+import { ScrollView } from "react-native";
+import Icon from "@ledgerhq/crypto-icons/native";
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { Box, MediaButton, Skeleton } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+
+type Props = Readonly<{
+  stocks: StockSuggestion[];
+  isLoading: boolean;
+  onStockPress: (stock: StockSuggestion) => void;
+  skeletonPillsPerRow: number;
+  testIdPrefix: string;
+}>;
+
+function splitIntoRows(stocks: StockSuggestion[]): [StockSuggestion[], StockSuggestion[]] {
+  const top: StockSuggestion[] = [];
+  const bottom: StockSuggestion[] = [];
+  stocks.forEach((stock, index) => (index % 2 === 0 ? top : bottom).push(stock));
+  return [top, bottom];
+}
+
+type StockPillProps = Readonly<{
+  stock: StockSuggestion;
+  onPress: (stock: StockSuggestion) => void;
+  testIdPrefix: string;
+}>;
+
+function StockPill({ stock, onPress, testIdPrefix }: StockPillProps) {
+  const handlePress = useCallback(() => onPress(stock), [stock, onPress]);
+
+  return (
+    <MediaButton
+      size="sm"
+      hideChevron
+      leadingContentShape="rounded"
+      leadingContent={<Icon ledgerId={stock.ledgerId} ticker={stock.ticker} size={24} />}
+      onPress={handlePress}
+      accessibilityLabel={stock.name}
+      testID={`${testIdPrefix}-${stock.ticker.toLowerCase()}`}
+    >
+      {stock.ticker.toUpperCase()}
+    </MediaButton>
+  );
+}
+
+export function StockPillRows({
+  stocks,
+  isLoading,
+  onStockPress,
+  skeletonPillsPerRow,
+  testIdPrefix,
+}: Props) {
+  const [topRow, bottomRow] = useMemo(() => splitIntoRows(stocks), [stocks]);
+
+  const renderSkeletonPills = () =>
+    Array.from({ length: skeletonPillsPerRow }, (_, index) => (
+      <Skeleton key={index} lx={pillSkeletonStyle} />
+    ));
+
+  if (isLoading) {
+    return (
+      <Box lx={gridStyle}>
+        <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
+        <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
+      </Box>
+    );
+  }
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+    >
+      <Box lx={gridStyle}>
+        <Box lx={rowStyle}>
+          {topRow.map(stock => (
+            <StockPill
+              key={stock.id}
+              stock={stock}
+              onPress={onStockPress}
+              testIdPrefix={testIdPrefix}
+            />
+          ))}
+        </Box>
+        <Box lx={rowStyle}>
+          {bottomRow.map(stock => (
+            <StockPill
+              key={stock.id}
+              stock={stock}
+              onPress={onStockPress}
+              testIdPrefix={testIdPrefix}
+            />
+          ))}
+        </Box>
+      </Box>
+    </ScrollView>
+  );
+}
+
+const gridStyle: LumenViewStyle = { gap: "s8", paddingHorizontal: "s16" };
+const rowStyle: LumenViewStyle = { flexDirection: "row", gap: "s8" };
+const pillSkeletonStyle: LumenViewStyle = { width: "s96", height: "s40", borderRadius: "full" };

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/__tests__/useCryptoViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/__tests__/useCryptoViewModel.test.ts
@@ -46,6 +46,8 @@ const emptyCategorizedAssets = () => ({
   stablecoinTickers: new Set<string>(),
   isLoadingStablecoinTickers: false,
   isStablecoinTickersError: false,
+  isLoadingStocks: false,
+  isStocksError: false,
 });
 
 describe("useCryptoViewModel", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/index.tsx
@@ -13,6 +13,7 @@ type Props = BaseComposite<StackNavigatorProps<CryptoScreenNavigator, ScreenName
 const LIST_TEST_ID_BY_VARIANT: Record<CryptoVariant, string> = {
   stablecoin: "StablecoinList",
   crypto: "CryptoList",
+  stocks: "StocksList",
   all: "CryptoList",
 };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/types.ts
@@ -1,7 +1,7 @@
 import { ScreenName } from "~/const";
 import { Asset } from "~/types/asset";
 
-export type CryptoVariant = "crypto" | "stablecoin" | "all";
+export type CryptoVariant = "crypto" | "stablecoin" | "stocks" | "all";
 
 export type CryptoScreenNavigator = {
   [ScreenName.Crypto]: {
@@ -17,5 +17,5 @@ export interface CryptoScreenViewData {
   error: Error | null;
   sourceScreenName: ScreenName | undefined;
   variant: CryptoVariant;
-  trackingType: "crypto" | "stable" | undefined;
+  trackingType: "crypto" | "stable" | "stocks" | undefined;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/useCryptoViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/useCryptoViewModel.ts
@@ -16,11 +16,13 @@ interface UseCryptoViewModelParams {
   variant?: CryptoVariant;
 }
 
-const TRACKING_TYPE_BY_VARIANT: Record<CryptoVariant, "crypto" | "stable" | undefined> = {
-  stablecoin: "stable",
-  crypto: "crypto",
-  all: undefined,
-};
+const TRACKING_TYPE_BY_VARIANT: Record<CryptoVariant, "crypto" | "stable" | "stocks" | undefined> =
+  {
+    stablecoin: "stable",
+    crypto: "crypto",
+    stocks: "stocks",
+    all: undefined,
+  };
 
 const useCryptoViewModel = ({
   sourceScreenName,
@@ -29,13 +31,25 @@ const useCryptoViewModel = ({
   const { t } = useTranslation();
   const { openFromAsset } = useAssetDetailNavigation();
 
-  const { categorizedAssets, isLoadingStablecoinTickers, isStablecoinTickersError } =
-    useCategorizedAssetsFromPortfolio();
+  const {
+    categorizedAssets,
+    isLoadingStablecoinTickers,
+    isStablecoinTickersError,
+    isLoadingStocks,
+    isStocksError,
+  } = useCategorizedAssetsFromPortfolio();
 
   const refreshAccountsOrdering = useRefreshAccountsOrdering();
   useFocusEffect(refreshAccountsOrdering);
 
   const resolvedVariant: CryptoVariant = variant ?? "all";
+
+  const dependsOnStocks = resolvedVariant === "stocks" || resolvedVariant === "all";
+  const dependsOnStablecoins = resolvedVariant !== "stocks";
+  const isLoading =
+    (dependsOnStablecoins && isLoadingStablecoinTickers) || (dependsOnStocks && isLoadingStocks);
+  const hasError =
+    (dependsOnStablecoins && isStablecoinTickersError) || (dependsOnStocks && isStocksError);
 
   const assetsToDisplay = useMemo(
     (): Asset[] => selectAssetList(categorizedAssets, resolvedVariant).map(toAsset),
@@ -64,8 +78,8 @@ const useCryptoViewModel = ({
   return {
     assetsToDisplay,
     onItemPress,
-    isLoading: isLoadingStablecoinTickers,
-    error: isStablecoinTickersError ? new Error(t("crypto.errorState")) : null,
+    isLoading,
+    error: hasError ? new Error(t("crypto.errorState")) : null,
     sourceScreenName,
     variant: resolvedVariant,
     trackingType,

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/utils.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/utils.ts
@@ -1,12 +1,25 @@
-import { CategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategorization/types";
-import { CryptoVariant } from "./types";
+import type {
+  CategorizedAssets,
+  CategorizedAssetItem,
+} from "@ledgerhq/asset-aggregation/assetCategorization/types";
+import type { CryptoVariant } from "./types";
 
-export function selectAssetList(categorizedAssets: CategorizedAssets, variant: CryptoVariant) {
+export function selectAssetList(
+  categorizedAssets: CategorizedAssets & { stocks?: CategorizedAssetItem[] },
+  variant: CryptoVariant,
+) {
   if (variant === "stablecoin") {
     return categorizedAssets.stablecoins ?? [];
   }
   if (variant === "crypto") {
     return categorizedAssets.cryptos ?? [];
   }
-  return [...(categorizedAssets.cryptos ?? []), ...(categorizedAssets.stablecoins ?? [])];
+  if (variant === "stocks") {
+    return categorizedAssets.stocks ?? [];
+  }
+  return [
+    ...(categorizedAssets.cryptos ?? []),
+    ...(categorizedAssets.stablecoins ?? []),
+    ...(categorizedAssets.stocks ?? []),
+  ];
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/StocksSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/StocksSection/index.tsx
@@ -1,17 +1,14 @@
-import React, { useCallback, useMemo } from "react";
-import { ScrollView } from "react-native";
-import Icon from "@ledgerhq/crypto-icons/native";
+import React, { useCallback } from "react";
 import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
 import {
   Box,
-  MediaButton,
-  Skeleton,
   Subheader,
   SubheaderRow,
   SubheaderShowMore,
   SubheaderTitle,
 } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { StockPillRows } from "LLM/components/StockPillRows";
 import type { GlobalSearchCategory } from "../../useGlobalSearchViewModel";
 
 const SKELETON_PILLS_PER_ROW = 4;
@@ -26,36 +23,6 @@ type Props = Readonly<{
   onStockPress: (stock: StockSuggestion) => void;
 }>;
 
-function splitIntoRows(stocks: StockSuggestion[]): [StockSuggestion[], StockSuggestion[]] {
-  const top: StockSuggestion[] = [];
-  const bottom: StockSuggestion[] = [];
-  stocks.forEach((stock, index) => (index % 2 === 0 ? top : bottom).push(stock));
-  return [top, bottom];
-}
-
-type StockPillProps = Readonly<{
-  stock: StockSuggestion;
-  onPress: (stock: StockSuggestion) => void;
-}>;
-
-function StockPill({ stock, onPress }: StockPillProps) {
-  const handlePress = useCallback(() => onPress(stock), [stock, onPress]);
-
-  return (
-    <MediaButton
-      size="sm"
-      hideChevron
-      leadingContentShape="rounded"
-      leadingContent={<Icon ledgerId={stock.ledgerId} ticker={stock.ticker} size={24} />}
-      onPress={handlePress}
-      accessibilityLabel={stock.name}
-      testID={`global-search-stock-${stock.ticker.toLowerCase()}`}
-    >
-      {stock.ticker.toUpperCase()}
-    </MediaButton>
-  );
-}
-
 export function StocksSection({
   title,
   testID,
@@ -65,15 +32,9 @@ export function StocksSection({
   onSeeAll,
   onStockPress,
 }: Props) {
-  const [topRow, bottomRow] = useMemo(() => splitIntoRows(stocks), [stocks]);
   const handleSeeAll = useCallback(() => onSeeAll(category), [onSeeAll, category]);
 
   if (!isLoading && stocks.length === 0) return null;
-
-  const renderSkeletonPills = () =>
-    Array.from({ length: SKELETON_PILLS_PER_ROW }, (_, index) => (
-      <Skeleton key={index} lx={pillSkeletonStyle} />
-    ));
 
   return (
     <Box lx={sectionStyle} testID={testID}>
@@ -89,40 +50,16 @@ export function StocksSection({
           </SubheaderRow>
         </Subheader>
       </Box>
-      {isLoading ? (
-        <Box lx={insetStyle}>
-          <Box lx={skeletonGridStyle}>
-            <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
-            <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
-          </Box>
-        </Box>
-      ) : (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          keyboardShouldPersistTaps="handled"
-        >
-          <Box lx={gridStyle}>
-            <Box lx={rowStyle}>
-              {topRow.map(stock => (
-                <StockPill key={stock.id} stock={stock} onPress={onStockPress} />
-              ))}
-            </Box>
-            <Box lx={rowStyle}>
-              {bottomRow.map(stock => (
-                <StockPill key={stock.id} stock={stock} onPress={onStockPress} />
-              ))}
-            </Box>
-          </Box>
-        </ScrollView>
-      )}
+      <StockPillRows
+        stocks={stocks}
+        isLoading={isLoading}
+        onStockPress={onStockPress}
+        skeletonPillsPerRow={SKELETON_PILLS_PER_ROW}
+        testIdPrefix="global-search-stock"
+      />
     </Box>
   );
 }
 
 const sectionStyle: LumenViewStyle = { gap: "s16", marginHorizontal: "-s16" };
 const insetStyle: LumenViewStyle = { paddingHorizontal: "s16" };
-const gridStyle: LumenViewStyle = { gap: "s8", paddingHorizontal: "s16" };
-const skeletonGridStyle: LumenViewStyle = { gap: "s8" };
-const rowStyle: LumenViewStyle = { flexDirection: "row", gap: "s8" };
-const pillSkeletonStyle: LumenViewStyle = { width: "s96", height: "s40", borderRadius: "full" };

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/constants.ts
@@ -4,3 +4,7 @@ export const READ_ONLY_MAX_ASSETS = 5;
 
 export const MAX_STABLECOINS_TO_DISPLAY = 6;
 export const EMPTY_STATE_MAX_STABLECOINS = 2;
+
+export const MAX_STOCKS_TO_DISPLAY = 5;
+export const EMPTY_STATE_MAX_STOCKS = 3;
+export const MAX_DISCOVERY_STOCKS = 20;

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/hooks/useWalletAssetsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/hooks/useWalletAssetsViewModel.ts
@@ -13,14 +13,19 @@ interface WalletAssetsViewModelResult {
   onPressShowAll: () => void;
   shouldAddBottomPadding: boolean;
   shouldDisplayAssetSection: boolean;
+  shouldDisplayAssetDiscoverability: boolean;
 }
 
 export function useWalletAssetsViewModel(): WalletAssetsViewModelResult {
   const { onPressShowAll } = usePortfolioSectionActions(false, "all");
   const { categorizedAssets } = useCategorizedAssetsFromPortfolio();
   const { walletCardsDisplayed } = useDynamicContent();
-  const { shouldDisplayOperationsList, shouldDisplayAssetSection, shouldDisplayGraphRework } =
-    useWalletFeaturesConfig("mobile");
+  const {
+    shouldDisplayOperationsList,
+    shouldDisplayAssetSection,
+    shouldDisplayGraphRework,
+    shouldDisplayAssetDiscoverability,
+  } = useWalletFeaturesConfig("mobile");
 
   const hasMore = useMemo(
     () =>
@@ -37,5 +42,6 @@ export function useWalletAssetsViewModel(): WalletAssetsViewModelResult {
     shouldAddBottomPadding:
       shouldDisplayOperationsList && walletCardsDisplayed.length === 0 && shouldDisplayGraphRework,
     shouldDisplayAssetSection,
+    shouldDisplayAssetDiscoverability,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/index.tsx
@@ -15,8 +15,13 @@ export const WalletAssetsView: React.FC<WalletAssetsViewProps> = ({
   variant = "normal",
   noPaddingHorizontal = false,
 }) => {
-  const { hasMore, onPressShowAll, shouldAddBottomPadding, shouldDisplayAssetSection } =
-    useWalletAssetsViewModel();
+  const {
+    hasMore,
+    onPressShowAll,
+    shouldAddBottomPadding,
+    shouldDisplayAssetSection,
+    shouldDisplayAssetDiscoverability,
+  } = useWalletAssetsViewModel();
   const { bottom } = useSafeAreaInsets();
 
   return (
@@ -28,7 +33,11 @@ export const WalletAssetsView: React.FC<WalletAssetsViewProps> = ({
           : undefined
       }
     >
-      <AssetsSections variant={variant} shouldDisplayAssetSection={shouldDisplayAssetSection} />
+      <AssetsSections
+        variant={variant}
+        shouldDisplayAssetSection={shouldDisplayAssetSection}
+        shouldDisplayAssetDiscoverability={shouldDisplayAssetDiscoverability}
+      />
       <AssetsButtonSection
         variant={variant}
         shouldDisplayAssetSection={shouldDisplayAssetSection}

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/usePortfolioSectionActions.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/usePortfolioSectionActions.ts
@@ -13,9 +13,18 @@ interface PortfolioSectionActions {
   onItemPress: (asset: Asset) => void;
 }
 
+type PortfolioSectionVariant = "crypto" | "stablecoin" | "stocks" | "all";
+
+const TRACKING_TYPE_BY_VARIANT: Record<PortfolioSectionVariant, "crypto" | "stable" | "stocks"> = {
+  crypto: "crypto",
+  stablecoin: "stable",
+  stocks: "stocks",
+  all: "crypto",
+};
+
 export function usePortfolioSectionActions(
   isReadOnly: boolean,
-  variant: "crypto" | "stablecoin" | "all",
+  variant: PortfolioSectionVariant,
 ): PortfolioSectionActions {
   const { shouldDisplayAssetSection } = useWalletFeaturesConfig("mobile");
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
@@ -25,7 +34,7 @@ export function usePortfolioSectionActions(
   const onPressShowAll = useCallback(() => {
     track("button_clicked", {
       button: "asset_list",
-      type: variant === "stablecoin" ? "stable" : "crypto",
+      type: TRACKING_TYPE_BY_VARIANT[variant],
       page: "Wallet",
     });
     if (!isReadOnly && shouldDisplayAssetSection) {

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/AssetsSections/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/AssetsSections/index.tsx
@@ -2,22 +2,26 @@ import React from "react";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { PortfolioCryptosSection } from "LLM/features/WalletAssets/views/CryptosSection";
 import { PortfolioStablecoinsSection } from "LLM/features/WalletAssets/views/StablecoinsSection";
+import { PortfolioStocksSection } from "LLM/features/WalletAssets/views/StocksSection";
 import { WalletAssetsVariant } from "LLM/features/WalletAssets/types";
 
 interface AssetsSectionsProps {
   variant: WalletAssetsVariant;
   shouldDisplayAssetSection: boolean;
+  shouldDisplayAssetDiscoverability: boolean;
 }
 
 export const AssetsSections: React.FC<AssetsSectionsProps> = ({
   variant,
   shouldDisplayAssetSection,
+  shouldDisplayAssetDiscoverability,
 }) => {
   if (shouldDisplayAssetSection) {
     return (
       <Box lx={{ gap: "s16" }}>
         <PortfolioCryptosSection variant={variant} />
         <PortfolioStablecoinsSection variant={variant} />
+        {shouldDisplayAssetDiscoverability && <PortfolioStocksSection variant={variant} />}
       </Box>
     );
   }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/StocksDiscoverySection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/StocksDiscoverySection.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Box, Subheader, SubheaderRow, SubheaderTitle, Text } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { useTranslation } from "~/context/Locale";
+import { StockPillRows } from "LLM/components/StockPillRows";
+import { EMPTY_STATE_MAX_STOCKS } from "LLM/features/WalletAssets/constants";
+import { useStocksDiscoverySectionViewModel } from "./useStocksDiscoverySectionViewModel";
+
+export function StocksDiscoverySection() {
+  const { t } = useTranslation();
+  const { stocks, isLoading, isError, onPressExploreAll, onItemPress } =
+    useStocksDiscoverySectionViewModel();
+
+  if (!isLoading && (isError || stocks.length === 0)) return null;
+
+  return (
+    <Box lx={sectionStyle} testID="portfolio-stocks-discovery">
+      <Box lx={insetStyle}>
+        <Subheader>
+          <SubheaderRow
+            onPress={onPressExploreAll}
+            accessibilityRole="button"
+            testID="portfolio-stocks-discovery-header"
+          >
+            <SubheaderTitle>{t("wallet.tabs.stocks")}</SubheaderTitle>
+            <Text typography="body2" lx={{ color: "interactive" }} style={exploreAllStyle}>
+              {t("wallet.stocks.exploreAll")}
+            </Text>
+          </SubheaderRow>
+        </Subheader>
+      </Box>
+      <StockPillRows
+        stocks={stocks}
+        isLoading={isLoading}
+        onStockPress={onItemPress}
+        skeletonPillsPerRow={EMPTY_STATE_MAX_STOCKS}
+        testIdPrefix="portfolio-discovery-stock"
+      />
+    </Box>
+  );
+}
+
+const exploreAllStyle = { marginLeft: "auto" as const };
+const sectionStyle: LumenViewStyle = { gap: "s12", marginHorizontal: "-s16" };
+const insetStyle: LumenViewStyle = { paddingHorizontal: "s16" };

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/__tests__/usePortfolioStocksSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/__tests__/usePortfolioStocksSectionViewModel.test.ts
@@ -1,0 +1,104 @@
+import { act } from "@testing-library/react-native";
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { NavigatorName, ScreenName } from "~/const";
+import { Asset } from "~/types/asset";
+import { MAX_STOCKS_TO_DISPLAY } from "LLM/features/WalletAssets/constants";
+import usePortfolioStocksSectionViewModel from "../usePortfolioStocksSectionViewModel";
+import { bitcoin, ethereum, createCryptoAsset } from "../../CryptosSection/__tests__/shared";
+
+const mockNavigate = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+  useRoute: () => ({ name: "Portfolio" }),
+}));
+
+const mockCategorizedAssets = jest.fn();
+
+jest.mock("LLM/hooks/useCategorizedAssetsFromPortfolio", () => ({
+  useCategorizedAssetsFromPortfolio: () => mockCategorizedAssets(),
+}));
+
+const toCategorizedItem = (asset: Asset) => ({
+  currency: asset.currency,
+  balance: asset.amount,
+  value: 0,
+  distribution: 0,
+  accounts: asset.accounts,
+});
+
+const mockPortfolioWithStocks = (stockAssets: Asset[] = []): void => {
+  mockCategorizedAssets.mockReturnValue({
+    categorizedAssets: {
+      cryptos: [],
+      stablecoins: [],
+      stocks: stockAssets.map(toCategorizedItem),
+    },
+    stablecoinTickers: new Set<string>(),
+    isLoadingStablecoinTickers: false,
+    isStablecoinTickersError: false,
+    isLoadingStocks: false,
+    isStocksError: false,
+  });
+};
+
+describe("usePortfolioStocksSectionViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPortfolioWithStocks();
+  });
+
+  it("returns no stocks when none are held", () => {
+    const { result } = renderHook(() => usePortfolioStocksSectionViewModel());
+
+    expect(result.current.stocksCount).toBe(0);
+    expect(result.current.stocksToDisplay).toHaveLength(0);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it("caps the display at MAX_STOCKS_TO_DISPLAY while reporting the full count", () => {
+    const heldCount = MAX_STOCKS_TO_DISPLAY + 2;
+    mockPortfolioWithStocks(
+      Array.from({ length: heldCount }, () => createCryptoAsset(bitcoin, 1000)),
+    );
+
+    const { result } = renderHook(() => usePortfolioStocksSectionViewModel());
+
+    expect(result.current.stocksCount).toBe(heldCount);
+    expect(result.current.stocksToDisplay).toHaveLength(MAX_STOCKS_TO_DISPLAY);
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it("navigates to the Crypto screen filtered to stocks on show all", () => {
+    const { result } = renderHook(() => usePortfolioStocksSectionViewModel(), {
+      overrideInitialState: withFlagOverrides({
+        lwmWallet40: { enabled: true, params: { assetSection: true } },
+      }),
+    });
+
+    act(() => {
+      result.current.onPressShowAll();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
+      screen: ScreenName.Crypto,
+      params: { sourceScreenName: ScreenName.Portfolio, variant: "stocks" },
+    });
+  });
+
+  it("navigates to asset detail on item press", () => {
+    mockPortfolioWithStocks([createCryptoAsset(ethereum, 5000)]);
+
+    const { result } = renderHook(() => usePortfolioStocksSectionViewModel());
+
+    act(() => {
+      result.current.onItemPress(result.current.stocksToDisplay[0]);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
+      screen: ScreenName.Asset,
+      params: { currency: ethereum },
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/__tests__/useStocksDiscoverySectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/__tests__/useStocksDiscoverySectionViewModel.test.ts
@@ -1,0 +1,68 @@
+import { act } from "@testing-library/react-native";
+import { renderHook } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { MAX_DISCOVERY_STOCKS } from "LLM/features/WalletAssets/constants";
+import { useStocksDiscoverySectionViewModel } from "../useStocksDiscoverySectionViewModel";
+
+const mockNavigate = jest.fn();
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+const mockOpenFromMarket = jest.fn();
+jest.mock("LLM/features/AssetDetail/hooks/useAssetDetailNavigation", () => ({
+  useAssetDetailNavigation: () => ({ openFromMarket: mockOpenFromMarket }),
+}));
+
+const mockDefaultStocks = jest.fn();
+jest.mock("LLM/hooks/useDefaultStocksAssets", () => ({
+  useDefaultStocksAssets: (...args: unknown[]) => mockDefaultStocks(...args),
+}));
+
+const stock = (ticker: string): StockSuggestion => ({
+  id: ticker,
+  name: ticker,
+  ticker,
+  navigationId: `${ticker}-mkt`,
+  ledgerId: `${ticker}-ledger`,
+});
+
+describe("useStocksDiscoverySectionViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDefaultStocks.mockReturnValue({
+      stocks: [stock("AAPL")],
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  it("exposes the top discovery stocks from the DADA hook", () => {
+    const { result } = renderHook(() => useStocksDiscoverySectionViewModel());
+
+    expect(result.current.stocks.map(s => s.ticker)).toEqual(["AAPL"]);
+    expect(mockDefaultStocks).toHaveBeenCalledWith(true, MAX_DISCOVERY_STOCKS);
+  });
+
+  it("navigates to the Market list filtered to stocks on Explore All", () => {
+    const { result } = renderHook(() => useStocksDiscoverySectionViewModel());
+
+    act(() => result.current.onPressExploreAll());
+
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.MarketList, { category: "stocks" });
+  });
+
+  it("opens the market detail for a tapped discovery stock", () => {
+    const { result } = renderHook(() => useStocksDiscoverySectionViewModel());
+
+    act(() => result.current.onItemPress(stock("TSLA")));
+
+    expect(mockOpenFromMarket).toHaveBeenCalledWith({
+      marketCurrencyId: "TSLA-mkt",
+      ledgerCurrencyIds: ["TSLA-ledger"],
+      source: "portfolio",
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import {
+  Box,
+  Subheader,
+  SubheaderCount,
+  SubheaderRow,
+  SubheaderShowMore,
+  SubheaderTitle,
+} from "@ledgerhq/lumen-ui-rnative";
+import { withDiscreetMode } from "~/context/DiscreetModeContext";
+import { useTranslation } from "~/context/Locale";
+import { SectionListContent } from "../../components/SectionListContent";
+import usePortfolioStocksSectionViewModel from "./usePortfolioStocksSectionViewModel";
+import { StocksDiscoverySection } from "./StocksDiscoverySection";
+import { EMPTY_STATE_MAX_STOCKS } from "LLM/features/WalletAssets/constants";
+import { WalletAssetsVariant } from "LLM/features/WalletAssets/types";
+
+interface PortfolioStocksSectionProps {
+  variant?: WalletAssetsVariant;
+}
+
+const PortfolioStocksSectionComponent: React.FC<PortfolioStocksSectionProps> = ({ variant }) => {
+  const { t } = useTranslation();
+  const { stocksCount, hasMore, stocksToDisplay, isLoading, isError, onPressShowAll, onItemPress } =
+    usePortfolioStocksSectionViewModel({ variant });
+
+  if (!isLoading && !isError && stocksCount === 0) return <StocksDiscoverySection />;
+
+  return (
+    <Box>
+      <Subheader>
+        <SubheaderRow
+          onPress={hasMore ? onPressShowAll : undefined}
+          accessibilityRole={hasMore ? "button" : undefined}
+          lx={{ marginBottom: "s4" }}
+          testID="portfolio-stocks-section-header"
+        >
+          <SubheaderTitle>{t("wallet.tabs.stocks")}</SubheaderTitle>
+          {hasMore && (
+            <>
+              <SubheaderCount value={stocksCount} />
+              <SubheaderShowMore />
+            </>
+          )}
+        </SubheaderRow>
+      </Subheader>
+      <Box testID="PortfolioStocksList">
+        <SectionListContent
+          isLoading={isLoading}
+          isError={isError}
+          assetsToDisplay={stocksToDisplay}
+          onItemPress={onItemPress}
+          skeletonCount={EMPTY_STATE_MAX_STOCKS}
+          errorMessage={t("portfolio.assetSection.connectionFailed")}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export const PortfolioStocksSection = withDiscreetMode(PortfolioStocksSectionComponent);

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/usePortfolioStocksSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/usePortfolioStocksSectionViewModel.ts
@@ -1,0 +1,50 @@
+import { useMemo } from "react";
+import type { Asset } from "~/types/asset";
+import { useCategorizedAssetsFromPortfolio } from "LLM/hooks/useCategorizedAssetsFromPortfolio";
+import { usePortfolioSectionActions } from "LLM/features/WalletAssets/shared/usePortfolioSectionActions";
+import { toAsset } from "LLM/features/WalletAssets/shared/assetUtils";
+import { MAX_STOCKS_TO_DISPLAY } from "LLM/features/WalletAssets/constants";
+import { WalletAssetsVariant } from "LLM/features/WalletAssets/types";
+
+export interface PortfolioStocksSectionViewModelResult {
+  stocksCount: number;
+  hasMore: boolean;
+  stocksToDisplay: Asset[];
+  isLoading: boolean;
+  isError: boolean;
+  onPressShowAll: () => void;
+  onItemPress: (asset: Asset) => void;
+}
+
+interface UsePortfolioStocksSectionViewModelOptions {
+  variant?: WalletAssetsVariant;
+}
+
+const usePortfolioStocksSectionViewModel = ({
+  variant,
+}: UsePortfolioStocksSectionViewModelOptions = {}): PortfolioStocksSectionViewModelResult => {
+  const isReadOnly = variant === "readOnly";
+  const { onPressShowAll, onItemPress } = usePortfolioSectionActions(isReadOnly, "stocks");
+  const { categorizedAssets, isLoadingStocks, isStocksError } = useCategorizedAssetsFromPortfolio();
+
+  const stocks = useMemo<Asset[]>(
+    () => (categorizedAssets.stocks ?? []).map(toAsset),
+    [categorizedAssets.stocks],
+  );
+
+  const stocksCount = stocks.length;
+  const stocksToDisplay = useMemo(() => stocks.slice(0, MAX_STOCKS_TO_DISPLAY), [stocks]);
+  const hasMore = stocksCount > MAX_STOCKS_TO_DISPLAY;
+
+  return {
+    stocksCount,
+    hasMore,
+    stocksToDisplay,
+    isLoading: isLoadingStocks,
+    isError: isStocksError,
+    onPressShowAll,
+    onItemPress,
+  };
+};
+
+export default usePortfolioStocksSectionViewModel;

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/useStocksDiscoverySectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/useStocksDiscoverySectionViewModel.ts
@@ -1,0 +1,44 @@
+import { useCallback } from "react";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { useAnalytics } from "~/analytics";
+import { ScreenName } from "~/const";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
+import { useDefaultStocksAssets } from "LLM/hooks/useDefaultStocksAssets";
+import { MAX_DISCOVERY_STOCKS } from "LLM/features/WalletAssets/constants";
+
+export interface StocksDiscoverySectionViewModelResult {
+  stocks: StockSuggestion[];
+  isLoading: boolean;
+  isError: boolean;
+  onPressExploreAll: () => void;
+  onItemPress: (stock: StockSuggestion) => void;
+}
+
+export function useStocksDiscoverySectionViewModel(): StocksDiscoverySectionViewModelResult {
+  const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+  const { track } = useAnalytics();
+  const { openFromMarket } = useAssetDetailNavigation();
+  const { stocks, isLoading, isError } = useDefaultStocksAssets(true, MAX_DISCOVERY_STOCKS);
+
+  const onPressExploreAll = useCallback(() => {
+    track("button_clicked", { button: "explore_all", type: "stocks", page: "Wallet" });
+    navigation.navigate(ScreenName.MarketList, { category: "stocks" });
+  }, [navigation, track]);
+
+  const onItemPress = useCallback(
+    (stock: StockSuggestion) => {
+      track("asset_clicked", { asset: stock.name, page: "Wallet" });
+      openFromMarket({
+        marketCurrencyId: stock.navigationId,
+        ledgerCurrencyIds: [stock.ledgerId],
+        source: "portfolio",
+      });
+    },
+    [openFromMarket, track],
+  );
+
+  return { stocks, isLoading, isError, onPressExploreAll, onItemPress };
+}

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useCategorizedAssetsFromPortfolio.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useCategorizedAssetsFromPortfolio.test.ts
@@ -1,10 +1,11 @@
-import { renderHook } from "@tests/test-renderer";
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { useCategorizedAssetsFromPortfolio } from "LLM/hooks/useCategorizedAssetsFromPortfolio";
 import { State } from "~/reducers/types";
 
 const mockUseCategorizedAssets = jest.fn();
 const mockUseDistribution = jest.fn();
 const mockUseStablecoinTickers = jest.fn();
+const mockUseStockAssetIds = jest.fn();
 
 jest.mock("@ledgerhq/asset-aggregation/assetCategorization/index", () => ({
   useCategorizedAssets: (...args: unknown[]) => mockUseCategorizedAssets(...args),
@@ -19,11 +20,31 @@ jest.mock("@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers", () => 
   useStablecoinTickers: (...args: unknown[]) => mockUseStablecoinTickers(...args),
 }));
 
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useStockAssetIds", () => ({
+  useStockAssetIds: (...args: unknown[]) => mockUseStockAssetIds(...args),
+}));
+
 const withBlacklistedTokens =
   (tokenIds: string[]) =>
   (state: State): State => ({
     ...state,
     settings: { ...state.settings, blacklistedTokenIds: tokenIds },
+  });
+
+const renderCategorized = (options?: {
+  discoverability?: boolean;
+  blacklistedTokenIds?: string[];
+}) =>
+  renderHook(() => useCategorizedAssetsFromPortfolio(), {
+    overrideInitialState: withFlagOverrides(
+      {
+        lwmWallet40: {
+          enabled: true,
+          params: { assetDiscoverability: options?.discoverability ?? true },
+        },
+      },
+      options?.blacklistedTokenIds ? withBlacklistedTokens(options.blacklistedTokenIds) : undefined,
+    ),
   });
 
 const makeItem = (name: string, id: string, type: "CryptoCurrency" | "TokenCurrency") => ({
@@ -43,6 +64,11 @@ describe("useCategorizedAssetsFromPortfolio", () => {
       isLoading: false,
       isError: false,
     });
+    mockUseStockAssetIds.mockReturnValue({
+      ids: new Set<string>(),
+      isLoading: false,
+      isError: false,
+    });
     mockUseCategorizedAssets.mockReturnValue({ cryptos: [], stablecoins: [] });
   });
 
@@ -52,9 +78,7 @@ describe("useCategorizedAssetsFromPortfolio", () => {
       const eth = makeItem("Ethereum", "ethereum", "CryptoCurrency");
       mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc, eth], stablecoins: [] });
 
-      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio(), {
-        overrideInitialState: withBlacklistedTokens(["ethereum"]),
-      });
+      const { result } = renderCategorized({ blacklistedTokenIds: ["ethereum"] });
 
       expect(result.current.categorizedAssets.cryptos).toHaveLength(1);
       expect(result.current.categorizedAssets.cryptos[0].currency.id).toBe("bitcoin");
@@ -65,23 +89,86 @@ describe("useCategorizedAssetsFromPortfolio", () => {
       const usdt = makeItem("USDT", "usdt-token", "TokenCurrency");
       mockUseCategorizedAssets.mockReturnValue({ cryptos: [], stablecoins: [usdc, usdt] });
 
-      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio(), {
-        overrideInitialState: withBlacklistedTokens(["usdc-token"]),
-      });
+      const { result } = renderCategorized({ blacklistedTokenIds: ["usdc-token"] });
 
       expect(result.current.categorizedAssets.stablecoins).toHaveLength(1);
       expect(result.current.categorizedAssets.stablecoins[0].currency.id).toBe("usdt-token");
     });
 
-    it("returns the original list unchanged when no token is blacklisted", () => {
+    it("keeps cryptos and stablecoins when no token is blacklisted", () => {
       const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
       const usdc = makeItem("USDC", "usdc-token", "TokenCurrency");
-      const source = { cryptos: [btc], stablecoins: [usdc] };
-      mockUseCategorizedAssets.mockReturnValue(source);
+      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc], stablecoins: [usdc] });
 
-      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio());
+      const { result } = renderCategorized();
 
-      expect(result.current.categorizedAssets).toBe(source);
+      expect(result.current.categorizedAssets.cryptos.map(a => a.currency.id)).toEqual(["bitcoin"]);
+      expect(result.current.categorizedAssets.stablecoins.map(a => a.currency.id)).toEqual([
+        "usdc-token",
+      ]);
+      expect(result.current.categorizedAssets.stocks).toEqual([]);
+    });
+  });
+
+  describe("stocks bucketing", () => {
+    it("moves held stocks out of cryptos by DADA currency id", () => {
+      const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
+      const aapl = makeItem("Apple xStock", "aapl-x", "TokenCurrency");
+      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc, aapl], stablecoins: [] });
+      mockUseStockAssetIds.mockReturnValue({
+        ids: new Set(["aapl-x"]),
+        isLoading: false,
+        isError: false,
+      });
+
+      const { result } = renderCategorized();
+
+      expect(result.current.categorizedAssets.cryptos.map(a => a.currency.id)).toEqual(["bitcoin"]);
+      expect(result.current.categorizedAssets.stocks.map(a => a.currency.id)).toEqual(["aapl-x"]);
+    });
+
+    it("does not miscategorize a crypto whose ticker collides with a stock symbol", () => {
+      const ton = makeItem("Toncoin", "ton", "CryptoCurrency");
+      mockUseCategorizedAssets.mockReturnValue({ cryptos: [ton], stablecoins: [] });
+      mockUseStockAssetIds.mockReturnValue({
+        ids: new Set(["some-tokenized-stock"]),
+        isLoading: false,
+        isError: false,
+      });
+
+      const { result } = renderCategorized();
+
+      expect(result.current.categorizedAssets.cryptos.map(a => a.currency.id)).toEqual(["ton"]);
+      expect(result.current.categorizedAssets.stocks).toEqual([]);
+    });
+
+    it("leaves cryptos untouched and stocks empty when no id matches", () => {
+      const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
+      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc], stablecoins: [] });
+
+      const { result } = renderCategorized();
+
+      expect(result.current.categorizedAssets.cryptos).toHaveLength(1);
+      expect(result.current.categorizedAssets.stocks).toEqual([]);
+    });
+
+    it("keeps stocks under cryptos when assetDiscoverability is off", () => {
+      const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
+      const aapl = makeItem("Apple xStock", "aapl-x", "TokenCurrency");
+      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc, aapl], stablecoins: [] });
+      mockUseStockAssetIds.mockReturnValue({
+        ids: new Set(["aapl-x"]),
+        isLoading: false,
+        isError: false,
+      });
+
+      const { result } = renderCategorized({ discoverability: false });
+
+      expect(result.current.categorizedAssets.stocks).toEqual([]);
+      expect(result.current.categorizedAssets.cryptos.map(a => a.currency.id)).toEqual([
+        "bitcoin",
+        "aapl-x",
+      ]);
     });
   });
 
@@ -89,7 +176,7 @@ describe("useCategorizedAssetsFromPortfolio", () => {
     it("reports loading when distribution is loading", () => {
       mockUseDistribution.mockReturnValue({ isAvailable: true, list: [], isLoading: true });
 
-      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio());
+      const { result } = renderCategorized();
 
       expect(result.current.isLoadingStablecoinTickers).toBe(true);
     });
@@ -101,7 +188,7 @@ describe("useCategorizedAssetsFromPortfolio", () => {
         isError: false,
       });
 
-      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio());
+      const { result } = renderCategorized();
 
       expect(result.current.isLoadingStablecoinTickers).toBe(true);
     });

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useDefaultStocksAssets.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useDefaultStocksAssets.test.ts
@@ -1,0 +1,65 @@
+import { renderHook } from "@tests/test-renderer";
+import { useStocksData } from "@ledgerhq/live-common/dada-client/hooks/useStocksData";
+import {
+  selectTopStocks,
+  type StockSuggestion,
+} from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { useDefaultStocksAssets } from "../useDefaultStocksAssets";
+
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useStocksData");
+jest.mock("@ledgerhq/live-common/dada-client/utils/assetDiscovery");
+
+const mockedStocks = jest.mocked(useStocksData);
+const mockedSelectTopStocks = jest.mocked(selectTopStocks);
+
+const stock = (ticker: string): StockSuggestion => ({
+  id: ticker,
+  name: ticker,
+  ticker,
+  navigationId: ticker,
+  ledgerId: ticker,
+});
+
+describe("useDefaultStocksAssets", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedStocks.mockReturnValue({
+      data: { stocks: true },
+      isLoading: false,
+      isError: false,
+    } as never);
+    mockedSelectTopStocks.mockReturnValue([stock("AAPL"), stock("TSLA")]);
+  });
+
+  it("returns the top stocks (capped at maxStocks) from the DADA stocks data", () => {
+    const { result } = renderHook(() => useDefaultStocksAssets(true, 20));
+
+    expect(result.current.stocks.map(s => s.ticker)).toEqual(["AAPL", "TSLA"]);
+    expect(mockedSelectTopStocks).toHaveBeenCalledWith(expect.anything(), 20);
+  });
+
+  it("reports loading while the query is in flight", () => {
+    mockedStocks.mockReturnValue({ data: undefined, isLoading: true, isError: false } as never);
+
+    const { result } = renderHook(() => useDefaultStocksAssets(true, 20));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.stocks).toEqual([]);
+  });
+
+  it("flags isError on failure", () => {
+    mockedStocks.mockReturnValue({ data: undefined, isLoading: false, isError: true } as never);
+
+    const { result } = renderHook(() => useDefaultStocksAssets(true, 20));
+
+    expect(result.current.isError).toBe(true);
+  });
+
+  it("is a no-op when disabled (skips the query, empty result)", () => {
+    const { result } = renderHook(() => useDefaultStocksAssets(false, 20));
+
+    expect(result.current.stocks).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(mockedStocks).toHaveBeenCalledWith(expect.objectContaining({ skip: true }));
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useCategorizedAssetsFromPortfolio.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useCategorizedAssetsFromPortfolio.ts
@@ -1,7 +1,11 @@
 import { useMemo } from "react";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useStablecoinTickers } from "@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers";
-import { useCategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategorization/index";
+import { useStockAssetIds } from "@ledgerhq/live-common/dada-client/hooks/useStockAssetIds";
+import {
+  useCategorizedAssets,
+  type CategorizedAssetItem,
+} from "@ledgerhq/asset-aggregation/assetCategorization/index";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import VersionNumber from "react-native-version-number";
 import { useDistribution } from "~/actions/general";
@@ -9,8 +13,10 @@ import { useSelector } from "~/context/hooks";
 import { blacklistedTokenIdsSelector } from "~/reducers/settings";
 
 export function useCategorizedAssetsFromPortfolio() {
-  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("mobile");
+  const { shouldDisplayAggregatedAssets, shouldDisplayAssetDiscoverability } =
+    useWalletFeaturesConfig("mobile");
   const hideEmptyTokenAccount = useEnv("HIDE_EMPTY_TOKEN_ACCOUNTS");
+  const version = VersionNumber.appVersion ?? "";
 
   const distribution = useDistribution({
     showEmptyAccounts: true,
@@ -22,30 +28,43 @@ export function useCategorizedAssetsFromPortfolio() {
     tickers: stablecoinTickers,
     isLoading: isLoadingStablecoinTickers,
     isError: isStablecoinTickersError,
-  } = useStablecoinTickers("llm", VersionNumber.appVersion ?? "");
+  } = useStablecoinTickers("llm", version);
+
+  const {
+    ids: stockAssetIds,
+    isLoading: isLoadingStockIds,
+    isError: isStockIdsError,
+  } = useStockAssetIds("llm", version, !shouldDisplayAssetDiscoverability);
 
   const categorizedAssets = useCategorizedAssets(distribution, stablecoinTickers);
 
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
   const blacklistedTokenIdsSet = useMemo(() => new Set(blacklistedTokenIds), [blacklistedTokenIds]);
 
-  // Exclude blacklisted assets so all portfolio-derived views share the same filtering rule.
   const filteredCategorizedAssets = useMemo(() => {
-    if (blacklistedTokenIdsSet.size === 0) return categorizedAssets;
-    return {
-      cryptos: categorizedAssets.cryptos.filter(
-        ({ currency }) => !blacklistedTokenIdsSet.has(currency.id),
-      ),
-      stablecoins: categorizedAssets.stablecoins.filter(
-        ({ currency }) => !blacklistedTokenIdsSet.has(currency.id),
-      ),
-    };
-  }, [categorizedAssets, blacklistedTokenIdsSet]);
+    const cryptos: CategorizedAssetItem[] = [];
+    const stocks: CategorizedAssetItem[] = [];
+
+    for (const item of categorizedAssets.cryptos) {
+      if (blacklistedTokenIdsSet.has(item.currency.id)) continue;
+      if (shouldDisplayAssetDiscoverability && stockAssetIds.has(item.currency.id))
+        stocks.push(item);
+      else cryptos.push(item);
+    }
+
+    const stablecoins = categorizedAssets.stablecoins.filter(
+      ({ currency }) => !blacklistedTokenIdsSet.has(currency.id),
+    );
+
+    return { cryptos, stablecoins, stocks };
+  }, [categorizedAssets, blacklistedTokenIdsSet, stockAssetIds, shouldDisplayAssetDiscoverability]);
 
   return {
     categorizedAssets: filteredCategorizedAssets,
     isLoadingStablecoinTickers: isLoadingStablecoinTickers || distribution.isLoading,
     isStablecoinTickersError,
     stablecoinTickers,
+    isLoadingStocks: isLoadingStockIds || distribution.isLoading,
+    isStocksError: isStockIdsError,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useDefaultStocksAssets.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useDefaultStocksAssets.ts
@@ -1,0 +1,31 @@
+import { useMemo } from "react";
+import { useStocksData } from "@ledgerhq/live-common/dada-client/hooks/useStocksData";
+import {
+  selectTopStocks,
+  type StockSuggestion,
+} from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import VersionNumber from "react-native-version-number";
+
+interface DefaultStocksAssets {
+  stocks: StockSuggestion[];
+  isLoading: boolean;
+  isError: boolean;
+}
+
+const EMPTY: DefaultStocksAssets = { stocks: [], isLoading: false, isError: false };
+
+export function useDefaultStocksAssets(enabled: boolean, maxStocks: number): DefaultStocksAssets {
+  const appVersion = VersionNumber.appVersion ?? "";
+
+  const { data, isLoading, isError } = useStocksData({
+    product: "llm",
+    version: appVersion,
+    skip: !enabled,
+  });
+
+  const stocks = useMemo(() => (data ? selectTopStocks(data, maxStocks) : []), [data, maxStocks]);
+
+  if (!enabled) return EMPTY;
+
+  return { stocks, isLoading, isError };
+}

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -434,6 +434,7 @@
     "src/dada-client/hooks/useLazyLedgerCurrency.ts",
     "src/dada-client/hooks/useMarketByCurrencies.ts",
     "src/dada-client/hooks/useStablecoinTickers.ts",
+    "src/dada-client/hooks/useStockAssetIds.ts",
     "src/dada-client/hooks/useStocksData.ts",
     "src/dada-client/index.ts",
     "src/dada-client/state-manager/api.ts",

--- a/libs/ledger-live-common/src/dada-client/hooks/useStockAssetIds.ts
+++ b/libs/ledger-live-common/src/dada-client/hooks/useStockAssetIds.ts
@@ -1,0 +1,18 @@
+import { useMemo } from "react";
+import { useGetAssetCurrencyIdsByCategoryQuery } from "../state-manager/api";
+import { AssetCategory } from "../state-manager/types";
+
+const emptySet = new Set<string>();
+
+export function useStockAssetIds(product: "llm" | "lld", version: string, skip?: boolean) {
+  const { data, isLoading, isError } = useGetAssetCurrencyIdsByCategoryQuery(
+    {
+      category: AssetCategory.Stocks,
+      product,
+      version,
+    },
+    { skip },
+  );
+  const ids = useMemo(() => (data ? new Set(data) : emptySet), [data]);
+  return { ids, isLoading, isError };
+}

--- a/libs/ledger-live-common/src/dada-client/state-manager/__tests__/api.test.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/__tests__/api.test.ts
@@ -1,4 +1,8 @@
-import { fetchAllAssetsByCategory, buildAssetsQueryParams } from "../api";
+import {
+  fetchAllAssetsByCategory,
+  fetchAllAssetCurrencyIdsByCategory,
+  buildAssetsQueryParams,
+} from "../api";
 import { AssetCategory } from "../types";
 import type { RawApiResponse } from "../../entities";
 import { getEnv } from "@ledgerhq/live-env";
@@ -151,5 +155,85 @@ describe("fetchAllAssetsByCategory", () => {
       },
     });
     expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+function makePageWithIds(
+  assets: { key: string; assetsIds: Record<string, string> }[],
+): RawApiResponse {
+  const cryptoAssets: RawApiResponse["cryptoAssets"] = {};
+  for (const { key, assetsIds } of assets) {
+    cryptoAssets[key] = { id: key, ticker: key.toUpperCase(), name: key, assetsIds };
+  }
+  return {
+    cryptoAssets,
+    networks: {},
+    cryptoOrTokenCurrencies: {},
+    interestRates: {},
+    markets: {},
+    currenciesOrder: { key: "marketCap", order: "desc", metaCurrencyIds: [] },
+  };
+}
+
+const stocksArgs = { ...defaultArgs, category: AssetCategory.Stocks };
+
+describe("fetchAllAssetCurrencyIdsByCategory", () => {
+  beforeEach(() => {
+    getEnvMock.mockReturnValue("https://dada.api.ledger.com/v1");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should aggregate and flatten currency ids across pages", async () => {
+    const spy = jest.spyOn(globalThis, "fetch");
+    spy.mockResolvedValueOnce(
+      okResponse(
+        makePageWithIds([{ key: "aapl", assetsIds: { ethereum: "eth/aapl", solana: "sol/aapl" } }]),
+        "cursor-2",
+      ),
+    );
+    spy.mockResolvedValueOnce(
+      okResponse(makePageWithIds([{ key: "tsla", assetsIds: { ethereum: "eth/tsla" } }])),
+    );
+
+    const result = await fetchAllAssetCurrencyIdsByCategory(stocksArgs);
+
+    expect(result).toEqual({ data: ["eth/aapl", "sol/aapl", "eth/tsla"] });
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it("should skip assets that have no assetsIds", async () => {
+    jest.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      okResponse(
+        makePageWithIds([
+          { key: "aapl", assetsIds: {} },
+          { key: "tsla", assetsIds: { ethereum: "eth/tsla" } },
+        ]),
+      ),
+    );
+
+    const result = await fetchAllAssetCurrencyIdsByCategory(stocksArgs);
+
+    expect(result).toEqual({ data: ["eth/tsla"] });
+  });
+
+  it("should return error and stop when a page fails", async () => {
+    const spy = jest.spyOn(globalThis, "fetch");
+    spy.mockResolvedValueOnce(
+      okResponse(
+        makePageWithIds([{ key: "aapl", assetsIds: { ethereum: "eth/aapl" } }]),
+        "cursor-2",
+      ),
+    );
+    spy.mockResolvedValueOnce(errorResponse(502, "Bad Gateway"));
+
+    const result = await fetchAllAssetCurrencyIdsByCategory(stocksArgs);
+
+    expect(result).toEqual({
+      error: { status: 502, data: "Failed to fetch assets by category: Bad Gateway" },
+    });
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 });

--- a/libs/ledger-live-common/src/dada-client/state-manager/api.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/api.ts
@@ -127,12 +127,13 @@ async function fetchAssetsPage(
   };
 }
 
-export async function fetchAllAssetsByCategory(
+async function collectAllByCategory(
   queryArg: GetAssetsByCategoryParams,
+  extract: (data: RawApiResponse) => string[],
 ): Promise<QueryReturnValue<string[], FetchBaseQueryError, FetchBaseQueryMeta | undefined>> {
   try {
     const baseUrl = queryArg.isStaging ? getEnv("DADA_API_STAGING") : getEnv("DADA_API_PROD");
-    const allTickers: string[] = [];
+    const collected: string[] = [];
     let cursor: string | undefined;
 
     do {
@@ -158,11 +159,11 @@ export async function fetchAllAssetsByCategory(
       }
 
       const data: RawApiResponse = await response.json();
-      allTickers.push(...Object.values(data.cryptoAssets).map(a => a.ticker));
+      collected.push(...extract(data));
       cursor = response.headers.get("x-ledger-next") || undefined;
     } while (cursor);
 
-    return { data: allTickers };
+    return { data: collected };
   } catch (error) {
     return {
       error: {
@@ -171,6 +172,18 @@ export async function fetchAllAssetsByCategory(
       },
     };
   }
+}
+
+export function fetchAllAssetsByCategory(queryArg: GetAssetsByCategoryParams) {
+  return collectAllByCategory(queryArg, data =>
+    Object.values(data.cryptoAssets).map(a => a.ticker),
+  );
+}
+
+export function fetchAllAssetCurrencyIdsByCategory(queryArg: GetAssetsByCategoryParams) {
+  return collectAllByCategory(queryArg, data =>
+    Object.values(data.cryptoAssets).flatMap(meta => Object.values(meta.assetsIds)),
+  );
 }
 
 export const assetsDataApi = createApi({
@@ -213,6 +226,12 @@ export const assetsDataApi = createApi({
     getAssetsByCategory: build.query<string[], GetAssetsByCategoryParams>({
       queryFn: async queryArg => {
         return fetchAllAssetsByCategory(queryArg);
+      },
+      keepUnusedDataFor: ONE_DAY_IN_SECONDS,
+    }),
+    getAssetCurrencyIdsByCategory: build.query<string[], GetAssetsByCategoryParams>({
+      queryFn: async queryArg => {
+        return fetchAllAssetCurrencyIdsByCategory(queryArg);
       },
       keepUnusedDataFor: ONE_DAY_IN_SECONDS,
     }),
@@ -275,5 +294,6 @@ export const {
   useGetAssetsDataInfiniteQuery,
   useGetAssetDataQuery,
   useGetAssetsByCategoryQuery,
+  useGetAssetCurrencyIdsByCategoryQuery,
   useGetChunkedAssetsDataQuery,
 } = assetsDataApi;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Unit tests for the discovery hook, portfolio categorization (incl. the TON ticker-collision guard), the DADA currency-ids query, and the holdings + discovery ViewModels.
- [x] **Impact of the changes:**
  - Adds the **Portfolio Stocks section** behind the `assetDiscoverability` flag. FF off → no section, no regression on Crypto/Stablecoins. FF on + 0 stocks → discovery grid of the top stocks. FF on + ≥1 stock → list of your stocks (max 5, "Explore all" → filtered asset view).

### 📝 Description

The full Portfolio Stocks section for Wallet 4.0 (epic LIVE-27854), gated by `assetDiscoverability`. Previously split across stacked PRs — now a single PR (#18470 merged in).

**Data layer**
- `useDefaultStocksAssets` — top stocks for the discovery scenario (`useStocksData` + `selectTopStocks`).
- `useStockAssetIds` (common) + `getAssetCurrencyIdsByCategory` query — ledger currency ids of the DADA `stocks` category.
- `useCategorizedAssetsFromPortfolio` returns a `stocks` bucket split out of `cryptos` **by currency id** (collision-free vs ticker, so a crypto like TON isn't misclassified), gated by `shouldDisplayAssetDiscoverability`.

**Section UI**
- `PortfolioStocksSection`: holdings list (max 5, "Show more" opens the Crypto screen filtered to stocks) when the user owns stocks; otherwise a horizontal 2-row discovery grid of the top stocks ("Explore All" opens the Market list filtered to stocks, tapping a pill opens its market detail).
- Shared `StockPillRows` grid extracted and reused by Global Search (removes the duplicated grid).
- `CryptoVariant` extended with `"stocks"` for the filtered asset view.

**Integration**
- Wired into `AssetsSections` after Stablecoins, behind `shouldDisplayAssetDiscoverability` (threaded through `useWalletAssetsViewModel`). The section threads the WalletAssets `variant` so read-only portfolios navigate correctly, and the Crypto screen reflects the stock query's loading/error state.


https://github.com/user-attachments/assets/3417aed2-9edb-4b5c-bfa4-d471f4503a4d



### ❓ Context

- **JIRA**: [LIVE-31379](https://ledgerhq.atlassian.net/browse/LIVE-31379) · [LIVE-31380](https://ledgerhq.atlassian.net/browse/LIVE-31380) · [LIVE-31381](https://ledgerhq.atlassian.net/browse/LIVE-31381) · [LIVE-31382](https://ledgerhq.atlassian.net/browse/LIVE-31382) · [LIVE-31383](https://ledgerhq.atlassian.net/browse/LIVE-31383) — Epic [LIVE-27854](https://ledgerhq.atlassian.net/browse/LIVE-27854)


[LIVE-31379]: https://ledgerhq.atlassian.net/browse/LIVE-31379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ