### PR TITLE
[LWM] feat(mobile): Portfolio Stocks — section UI + integration [LIVE-31381/31382/31383]

### DIFF
--- a/.changeset/stocks-section.md
+++ b/.changeset/stocks-section.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add the Portfolio Stocks section and wire it into `AssetsSections` behind the `assetDiscoverability` flag. When the user holds stocks it renders a vertical list (max 5, mirroring the Crypto/Stablecoins sections) with a "Show more" header that opens the Crypto screen filtered to stocks — extending `CryptoVariant` with `"stocks"` and the asset-list filter accordingly. When the user holds none it renders a horizontal 2-row discovery grid of the top stocks (MediaButton pills) with an "Explore All" header that opens the Market list filtered to stocks; tapping a pill opens that stock's market detail. The 2-row grid is extracted into a shared `StockPillRows` component reused by Global Search (removing the duplicated grid). Subheader spacing: the holdings list matches the other portfolio sections, the discovery grid uses s12.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8708,7 +8708,11 @@
     "tabs": {
       "crypto": "Crypto",
       "stablecoins": "Stablecoins",
+      "stocks": "Stocks",
       "market": "Market"
+    },
+    "stocks": {
+      "exploreAll": "Explore All"
     },
     "referralProgram": "$20"
   },

--- a/apps/ledger-live-mobile/src/mvvm/components/StockPillRows/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/StockPillRows/index.tsx
@@ -1,0 +1,104 @@
+import React, { useCallback, useMemo } from "react";
+import { ScrollView } from "react-native";
+import Icon from "@ledgerhq/crypto-icons/native";
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { Box, MediaButton, Skeleton } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+
+type Props = Readonly<{
+  stocks: StockSuggestion[];
+  isLoading: boolean;
+  onStockPress: (stock: StockSuggestion) => void;
+  skeletonPillsPerRow: number;
+  testIdPrefix: string;
+}>;
+
+function splitIntoRows(stocks: StockSuggestion[]): [StockSuggestion[], StockSuggestion[]] {
+  const top: StockSuggestion[] = [];
+  const bottom: StockSuggestion[] = [];
+  stocks.forEach((stock, index) => (index % 2 === 0 ? top : bottom).push(stock));
+  return [top, bottom];
+}
+
+type StockPillProps = Readonly<{
+  stock: StockSuggestion;
+  onPress: (stock: StockSuggestion) => void;
+  testIdPrefix: string;
+}>;
+
+function StockPill({ stock, onPress, testIdPrefix }: StockPillProps) {
+  const handlePress = useCallback(() => onPress(stock), [stock, onPress]);
+
+  return (
+    <MediaButton
+      size="sm"
+      hideChevron
+      leadingContentShape="rounded"
+      leadingContent={<Icon ledgerId={stock.ledgerId} ticker={stock.ticker} size={24} />}
+      onPress={handlePress}
+      accessibilityLabel={stock.name}
+      testID={`${testIdPrefix}-${stock.ticker.toLowerCase()}`}
+    >
+      {stock.ticker.toUpperCase()}
+    </MediaButton>
+  );
+}
+
+export function StockPillRows({
+  stocks,
+  isLoading,
+  onStockPress,
+  skeletonPillsPerRow,
+  testIdPrefix,
+}: Props) {
+  const [topRow, bottomRow] = useMemo(() => splitIntoRows(stocks), [stocks]);
+
+  const renderSkeletonPills = () =>
+    Array.from({ length: skeletonPillsPerRow }, (_, index) => (
+      <Skeleton key={index} lx={pillSkeletonStyle} />
+    ));
+
+  if (isLoading) {
+    return (
+      <Box lx={gridStyle}>
+        <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
+        <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
+      </Box>
+    );
+  }
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+    >
+      <Box lx={gridStyle}>
+        <Box lx={rowStyle}>
+          {topRow.map(stock => (
+            <StockPill
+              key={stock.id}
+              stock={stock}
+              onPress={onStockPress}
+              testIdPrefix={testIdPrefix}
+            />
+          ))}
+        </Box>
+        <Box lx={rowStyle}>
+          {bottomRow.map(stock => (
+            <StockPill
+              key={stock.id}
+              stock={stock}
+              onPress={onStockPress}
+              testIdPrefix={testIdPrefix}
+            />
+          ))}
+        </Box>
+      </Box>
+    </ScrollView>
+  );
+}
+
+const gridStyle: LumenViewStyle = { gap: "s8", paddingHorizontal: "s16" };
+const rowStyle: LumenViewStyle = { flexDirection: "row", gap: "s8" };
+const pillSkeletonStyle: LumenViewStyle = { width: "s96", height: "s40", borderRadius: "full" };

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/__tests__/useCryptoViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/__tests__/useCryptoViewModel.test.ts
@@ -46,6 +46,8 @@ const emptyCategorizedAssets = () => ({
   stablecoinTickers: new Set<string>(),
   isLoadingStablecoinTickers: false,
   isStablecoinTickersError: false,
+  isLoadingStocks: false,
+  isStocksError: false,
 });
 
 describe("useCryptoViewModel", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/index.tsx
@@ -13,6 +13,7 @@ type Props = BaseComposite<StackNavigatorProps<CryptoScreenNavigator, ScreenName
 const LIST_TEST_ID_BY_VARIANT: Record<CryptoVariant, string> = {
   stablecoin: "StablecoinList",
   crypto: "CryptoList",
+  stocks: "StocksList",
   all: "CryptoList",
 };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/types.ts
@@ -1,7 +1,7 @@
 import { ScreenName } from "~/const";
 import { Asset } from "~/types/asset";
 
-export type CryptoVariant = "crypto" | "stablecoin" | "all";
+export type CryptoVariant = "crypto" | "stablecoin" | "stocks" | "all";
 
 export type CryptoScreenNavigator = {
   [ScreenName.Crypto]: {
@@ -17,5 +17,5 @@ export interface CryptoScreenViewData {
   error: Error | null;
   sourceScreenName: ScreenName | undefined;
   variant: CryptoVariant;
-  trackingType: "crypto" | "stable" | undefined;
+  trackingType: "crypto" | "stable" | "stocks" | undefined;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/useCryptoViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/useCryptoViewModel.ts
@@ -16,11 +16,13 @@ interface UseCryptoViewModelParams {
   variant?: CryptoVariant;
 }
 
-const TRACKING_TYPE_BY_VARIANT: Record<CryptoVariant, "crypto" | "stable" | undefined> = {
-  stablecoin: "stable",
-  crypto: "crypto",
-  all: undefined,
-};
+const TRACKING_TYPE_BY_VARIANT: Record<CryptoVariant, "crypto" | "stable" | "stocks" | undefined> =
+  {
+    stablecoin: "stable",
+    crypto: "crypto",
+    stocks: "stocks",
+    all: undefined,
+  };
 
 const useCryptoViewModel = ({
   sourceScreenName,
@@ -29,13 +31,25 @@ const useCryptoViewModel = ({
   const { t } = useTranslation();
   const { openFromAsset } = useAssetDetailNavigation();
 
-  const { categorizedAssets, isLoadingStablecoinTickers, isStablecoinTickersError } =
-    useCategorizedAssetsFromPortfolio();
+  const {
+    categorizedAssets,
+    isLoadingStablecoinTickers,
+    isStablecoinTickersError,
+    isLoadingStocks,
+    isStocksError,
+  } = useCategorizedAssetsFromPortfolio();
 
   const refreshAccountsOrdering = useRefreshAccountsOrdering();
   useFocusEffect(refreshAccountsOrdering);
 
   const resolvedVariant: CryptoVariant = variant ?? "all";
+
+  const dependsOnStocks = resolvedVariant === "stocks" || resolvedVariant === "all";
+  const dependsOnStablecoins = resolvedVariant !== "stocks";
+  const isLoading =
+    (dependsOnStablecoins && isLoadingStablecoinTickers) || (dependsOnStocks && isLoadingStocks);
+  const hasError =
+    (dependsOnStablecoins && isStablecoinTickersError) || (dependsOnStocks && isStocksError);
 
   const assetsToDisplay = useMemo(
     (): Asset[] => selectAssetList(categorizedAssets, resolvedVariant).map(toAsset),
@@ -64,8 +78,8 @@ const useCryptoViewModel = ({
   return {
     assetsToDisplay,
     onItemPress,
-    isLoading: isLoadingStablecoinTickers,
-    error: isStablecoinTickersError ? new Error(t("crypto.errorState")) : null,
+    isLoading,
+    error: hasError ? new Error(t("crypto.errorState")) : null,
     sourceScreenName,
     variant: resolvedVariant,
     trackingType,

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/utils.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/utils.ts
@@ -1,12 +1,25 @@
-import { CategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategorization/types";
-import { CryptoVariant } from "./types";
+import type {
+  CategorizedAssets,
+  CategorizedAssetItem,
+} from "@ledgerhq/asset-aggregation/assetCategorization/types";
+import type { CryptoVariant } from "./types";
 
-export function selectAssetList(categorizedAssets: CategorizedAssets, variant: CryptoVariant) {
+export function selectAssetList(
+  categorizedAssets: CategorizedAssets & { stocks?: CategorizedAssetItem[] },
+  variant: CryptoVariant,
+) {
   if (variant === "stablecoin") {
     return categorizedAssets.stablecoins ?? [];
   }
   if (variant === "crypto") {
     return categorizedAssets.cryptos ?? [];
   }
-  return [...(categorizedAssets.cryptos ?? []), ...(categorizedAssets.stablecoins ?? [])];
+  if (variant === "stocks") {
+    return categorizedAssets.stocks ?? [];
+  }
+  return [
+    ...(categorizedAssets.cryptos ?? []),
+    ...(categorizedAssets.stablecoins ?? []),
+    ...(categorizedAssets.stocks ?? []),
+  ];
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/StocksSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/StocksSection/index.tsx
@@ -1,17 +1,14 @@
-import React, { useCallback, useMemo } from "react";
-import { ScrollView } from "react-native";
-import Icon from "@ledgerhq/crypto-icons/native";
+import React, { useCallback } from "react";
 import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
 import {
   Box,
-  MediaButton,
-  Skeleton,
   Subheader,
   SubheaderRow,
   SubheaderShowMore,
   SubheaderTitle,
 } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { StockPillRows } from "LLM/components/StockPillRows";
 import type { GlobalSearchCategory } from "../../useGlobalSearchViewModel";
 
 const SKELETON_PILLS_PER_ROW = 4;
@@ -26,36 +23,6 @@ type Props = Readonly<{
   onStockPress: (stock: StockSuggestion) => void;
 }>;
 
-function splitIntoRows(stocks: StockSuggestion[]): [StockSuggestion[], StockSuggestion[]] {
-  const top: StockSuggestion[] = [];
-  const bottom: StockSuggestion[] = [];
-  stocks.forEach((stock, index) => (index % 2 === 0 ? top : bottom).push(stock));
-  return [top, bottom];
-}
-
-type StockPillProps = Readonly<{
-  stock: StockSuggestion;
-  onPress: (stock: StockSuggestion) => void;
-}>;
-
-function StockPill({ stock, onPress }: StockPillProps) {
-  const handlePress = useCallback(() => onPress(stock), [stock, onPress]);
-
-  return (
-    <MediaButton
-      size="sm"
-      hideChevron
-      leadingContentShape="rounded"
-      leadingContent={<Icon ledgerId={stock.ledgerId} ticker={stock.ticker} size={24} />}
-      onPress={handlePress}
-      accessibilityLabel={stock.name}
-      testID={`global-search-stock-${stock.ticker.toLowerCase()}`}
-    >
-      {stock.ticker.toUpperCase()}
-    </MediaButton>
-  );
-}
-
 export function StocksSection({
   title,
   testID,
@@ -65,15 +32,9 @@ export function StocksSection({
   onSeeAll,
   onStockPress,
 }: Props) {
-  const [topRow, bottomRow] = useMemo(() => splitIntoRows(stocks), [stocks]);
   const handleSeeAll = useCallback(() => onSeeAll(category), [onSeeAll, category]);
 
   if (!isLoading && stocks.length === 0) return null;
-
-  const renderSkeletonPills = () =>
-    Array.from({ length: SKELETON_PILLS_PER_ROW }, (_, index) => (
-      <Skeleton key={index} lx={pillSkeletonStyle} />
-    ));
 
   return (
     <Box lx={sectionStyle} testID={testID}>
@@ -89,40 +50,16 @@ export function StocksSection({
           </SubheaderRow>
         </Subheader>
       </Box>
-      {isLoading ? (
-        <Box lx={insetStyle}>
-          <Box lx={skeletonGridStyle}>
-            <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
-            <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
-          </Box>
-        </Box>
-      ) : (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          keyboardShouldPersistTaps="handled"
-        >
-          <Box lx={gridStyle}>
-            <Box lx={rowStyle}>
-              {topRow.map(stock => (
-                <StockPill key={stock.id} stock={stock} onPress={onStockPress} />
-              ))}
-            </Box>
-            <Box lx={rowStyle}>
-              {bottomRow.map(stock => (
-                <StockPill key={stock.id} stock={stock} onPress={onStockPress} />
-              ))}
-            </Box>
-          </Box>
-        </ScrollView>
-      )}
+      <StockPillRows
+        stocks={stocks}
+        isLoading={isLoading}
+        onStockPress={onStockPress}
+        skeletonPillsPerRow={SKELETON_PILLS_PER_ROW}
+        testIdPrefix="global-search-stock"
+      />
     </Box>
   );
 }
 
 const sectionStyle: LumenViewStyle = { gap: "s16", marginHorizontal: "-s16" };
 const insetStyle: LumenViewStyle = { paddingHorizontal: "s16" };
-const gridStyle: LumenViewStyle = { gap: "s8", paddingHorizontal: "s16" };
-const skeletonGridStyle: LumenViewStyle = { gap: "s8" };
-const rowStyle: LumenViewStyle = { flexDirection: "row", gap: "s8" };
-const pillSkeletonStyle: LumenViewStyle = { width: "s96", height: "s40", borderRadius: "full" };

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/constants.ts
@@ -4,3 +4,7 @@ export const READ_ONLY_MAX_ASSETS = 5;
 
 export const MAX_STABLECOINS_TO_DISPLAY = 6;
 export const EMPTY_STATE_MAX_STABLECOINS = 2;
+
+export const MAX_STOCKS_TO_DISPLAY = 5;
+export const EMPTY_STATE_MAX_STOCKS = 3;
+export const MAX_DISCOVERY_STOCKS = 20;

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/hooks/useWalletAssetsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/hooks/useWalletAssetsViewModel.ts
@@ -13,14 +13,19 @@ interface WalletAssetsViewModelResult {
   onPressShowAll: () => void;
   shouldAddBottomPadding: boolean;
   shouldDisplayAssetSection: boolean;
+  shouldDisplayAssetDiscoverability: boolean;
 }
 
 export function useWalletAssetsViewModel(): WalletAssetsViewModelResult {
   const { onPressShowAll } = usePortfolioSectionActions(false, "all");
   const { categorizedAssets } = useCategorizedAssetsFromPortfolio();
   const { walletCardsDisplayed } = useDynamicContent();
-  const { shouldDisplayOperationsList, shouldDisplayAssetSection, shouldDisplayGraphRework } =
-    useWalletFeaturesConfig("mobile");
+  const {
+    shouldDisplayOperationsList,
+    shouldDisplayAssetSection,
+    shouldDisplayGraphRework,
+    shouldDisplayAssetDiscoverability,
+  } = useWalletFeaturesConfig("mobile");
 
   const hasMore = useMemo(
     () =>
@@ -37,5 +42,6 @@ export function useWalletAssetsViewModel(): WalletAssetsViewModelResult {
     shouldAddBottomPadding:
       shouldDisplayOperationsList && walletCardsDisplayed.length === 0 && shouldDisplayGraphRework,
     shouldDisplayAssetSection,
+    shouldDisplayAssetDiscoverability,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/index.tsx
@@ -15,8 +15,13 @@ export const WalletAssetsView: React.FC<WalletAssetsViewProps> = ({
   variant = "normal",
   noPaddingHorizontal = false,
 }) => {
-  const { hasMore, onPressShowAll, shouldAddBottomPadding, shouldDisplayAssetSection } =
-    useWalletAssetsViewModel();
+  const {
+    hasMore,
+    onPressShowAll,
+    shouldAddBottomPadding,
+    shouldDisplayAssetSection,
+    shouldDisplayAssetDiscoverability,
+  } = useWalletAssetsViewModel();
   const { bottom } = useSafeAreaInsets();
 
   return (
@@ -28,7 +33,11 @@ export const WalletAssetsView: React.FC<WalletAssetsViewProps> = ({
           : undefined
       }
     >
-      <AssetsSections variant={variant} shouldDisplayAssetSection={shouldDisplayAssetSection} />
+      <AssetsSections
+        variant={variant}
+        shouldDisplayAssetSection={shouldDisplayAssetSection}
+        shouldDisplayAssetDiscoverability={shouldDisplayAssetDiscoverability}
+      />
       <AssetsButtonSection
         variant={variant}
         shouldDisplayAssetSection={shouldDisplayAssetSection}

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/usePortfolioSectionActions.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/usePortfolioSectionActions.ts
@@ -13,9 +13,18 @@ interface PortfolioSectionActions {
   onItemPress: (asset: Asset) => void;
 }
 
+type PortfolioSectionVariant = "crypto" | "stablecoin" | "stocks" | "all";
+
+const TRACKING_TYPE_BY_VARIANT: Record<PortfolioSectionVariant, "crypto" | "stable" | "stocks"> = {
+  crypto: "crypto",
+  stablecoin: "stable",
+  stocks: "stocks",
+  all: "crypto",
+};
+
 export function usePortfolioSectionActions(
   isReadOnly: boolean,
-  variant: "crypto" | "stablecoin" | "all",
+  variant: PortfolioSectionVariant,
 ): PortfolioSectionActions {
   const { shouldDisplayAssetSection } = useWalletFeaturesConfig("mobile");
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
@@ -25,7 +34,7 @@ export function usePortfolioSectionActions(
   const onPressShowAll = useCallback(() => {
     track("button_clicked", {
       button: "asset_list",
-      type: variant === "stablecoin" ? "stable" : "crypto",
+      type: TRACKING_TYPE_BY_VARIANT[variant],
       page: "Wallet",
     });
     if (!isReadOnly && shouldDisplayAssetSection) {

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/AssetsSections/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/AssetsSections/index.tsx
@@ -2,22 +2,26 @@ import React from "react";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { PortfolioCryptosSection } from "LLM/features/WalletAssets/views/CryptosSection";
 import { PortfolioStablecoinsSection } from "LLM/features/WalletAssets/views/StablecoinsSection";
+import { PortfolioStocksSection } from "LLM/features/WalletAssets/views/StocksSection";
 import { WalletAssetsVariant } from "LLM/features/WalletAssets/types";
 
 interface AssetsSectionsProps {
   variant: WalletAssetsVariant;
   shouldDisplayAssetSection: boolean;
+  shouldDisplayAssetDiscoverability: boolean;
 }
 
 export const AssetsSections: React.FC<AssetsSectionsProps> = ({
   variant,
   shouldDisplayAssetSection,
+  shouldDisplayAssetDiscoverability,
 }) => {
   if (shouldDisplayAssetSection) {
     return (
       <Box lx={{ gap: "s16" }}>
         <PortfolioCryptosSection variant={variant} />
         <PortfolioStablecoinsSection variant={variant} />
+        {shouldDisplayAssetDiscoverability && <PortfolioStocksSection variant={variant} />}
       </Box>
     );
   }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/StocksDiscoverySection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/StocksDiscoverySection.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Box, Subheader, SubheaderRow, SubheaderTitle, Text } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { useTranslation } from "~/context/Locale";
+import { StockPillRows } from "LLM/components/StockPillRows";
+import { EMPTY_STATE_MAX_STOCKS } from "LLM/features/WalletAssets/constants";
+import { useStocksDiscoverySectionViewModel } from "./useStocksDiscoverySectionViewModel";
+
+export function StocksDiscoverySection() {
+  const { t } = useTranslation();
+  const { stocks, isLoading, isError, onPressExploreAll, onItemPress } =
+    useStocksDiscoverySectionViewModel();
+
+  if (!isLoading && (isError || stocks.length === 0)) return null;
+
+  return (
+    <Box lx={sectionStyle} testID="portfolio-stocks-discovery">
+      <Box lx={insetStyle}>
+        <Subheader>
+          <SubheaderRow
+            onPress={onPressExploreAll}
+            accessibilityRole="button"
+            testID="portfolio-stocks-discovery-header"
+          >
+            <SubheaderTitle>{t("wallet.tabs.stocks")}</SubheaderTitle>
+            <Text typography="body2" lx={{ color: "interactive" }} style={exploreAllStyle}>
+              {t("wallet.stocks.exploreAll")}
+            </Text>
+          </SubheaderRow>
+        </Subheader>
+      </Box>
+      <StockPillRows
+        stocks={stocks}
+        isLoading={isLoading}
+        onStockPress={onItemPress}
+        skeletonPillsPerRow={EMPTY_STATE_MAX_STOCKS}
+        testIdPrefix="portfolio-discovery-stock"
+      />
+    </Box>
+  );
+}
+
+const exploreAllStyle = { marginLeft: "auto" as const };
+const sectionStyle: LumenViewStyle = { gap: "s12", marginHorizontal: "-s16" };
+const insetStyle: LumenViewStyle = { paddingHorizontal: "s16" };

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/__tests__/usePortfolioStocksSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/__tests__/usePortfolioStocksSectionViewModel.test.ts
@@ -1,0 +1,104 @@
+import { act } from "@testing-library/react-native";
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { NavigatorName, ScreenName } from "~/const";
+import { Asset } from "~/types/asset";
+import { MAX_STOCKS_TO_DISPLAY } from "LLM/features/WalletAssets/constants";
+import usePortfolioStocksSectionViewModel from "../usePortfolioStocksSectionViewModel";
+import { bitcoin, ethereum, createCryptoAsset } from "../../CryptosSection/__tests__/shared";
+
+const mockNavigate = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+  useRoute: () => ({ name: "Portfolio" }),
+}));
+
+const mockCategorizedAssets = jest.fn();
+
+jest.mock("LLM/hooks/useCategorizedAssetsFromPortfolio", () => ({
+  useCategorizedAssetsFromPortfolio: () => mockCategorizedAssets(),
+}));
+
+const toCategorizedItem = (asset: Asset) => ({
+  currency: asset.currency,
+  balance: asset.amount,
+  value: 0,
+  distribution: 0,
+  accounts: asset.accounts,
+});
+
+const mockPortfolioWithStocks = (stockAssets: Asset[] = []): void => {
+  mockCategorizedAssets.mockReturnValue({
+    categorizedAssets: {
+      cryptos: [],
+      stablecoins: [],
+      stocks: stockAssets.map(toCategorizedItem),
+    },
+    stablecoinTickers: new Set<string>(),
+    isLoadingStablecoinTickers: false,
+    isStablecoinTickersError: false,
+    isLoadingStocks: false,
+    isStocksError: false,
+  });
+};
+
+describe("usePortfolioStocksSectionViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPortfolioWithStocks();
+  });
+
+  it("returns no stocks when none are held", () => {
+    const { result } = renderHook(() => usePortfolioStocksSectionViewModel());
+
+    expect(result.current.stocksCount).toBe(0);
+    expect(result.current.stocksToDisplay).toHaveLength(0);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it("caps the display at MAX_STOCKS_TO_DISPLAY while reporting the full count", () => {
+    const heldCount = MAX_STOCKS_TO_DISPLAY + 2;
+    mockPortfolioWithStocks(
+      Array.from({ length: heldCount }, () => createCryptoAsset(bitcoin, 1000)),
+    );
+
+    const { result } = renderHook(() => usePortfolioStocksSectionViewModel());
+
+    expect(result.current.stocksCount).toBe(heldCount);
+    expect(result.current.stocksToDisplay).toHaveLength(MAX_STOCKS_TO_DISPLAY);
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it("navigates to the Crypto screen filtered to stocks on show all", () => {
+    const { result } = renderHook(() => usePortfolioStocksSectionViewModel(), {
+      overrideInitialState: withFlagOverrides({
+        lwmWallet40: { enabled: true, params: { assetSection: true } },
+      }),
+    });
+
+    act(() => {
+      result.current.onPressShowAll();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
+      screen: ScreenName.Crypto,
+      params: { sourceScreenName: ScreenName.Portfolio, variant: "stocks" },
+    });
+  });
+
+  it("navigates to asset detail on item press", () => {
+    mockPortfolioWithStocks([createCryptoAsset(ethereum, 5000)]);
+
+    const { result } = renderHook(() => usePortfolioStocksSectionViewModel());
+
+    act(() => {
+      result.current.onItemPress(result.current.stocksToDisplay[0]);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
+      screen: ScreenName.Asset,
+      params: { currency: ethereum },
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/__tests__/useStocksDiscoverySectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/__tests__/useStocksDiscoverySectionViewModel.test.ts
@@ -1,0 +1,68 @@
+import { act } from "@testing-library/react-native";
+import { renderHook } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { MAX_DISCOVERY_STOCKS } from "LLM/features/WalletAssets/constants";
+import { useStocksDiscoverySectionViewModel } from "../useStocksDiscoverySectionViewModel";
+
+const mockNavigate = jest.fn();
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+const mockOpenFromMarket = jest.fn();
+jest.mock("LLM/features/AssetDetail/hooks/useAssetDetailNavigation", () => ({
+  useAssetDetailNavigation: () => ({ openFromMarket: mockOpenFromMarket }),
+}));
+
+const mockDefaultStocks = jest.fn();
+jest.mock("LLM/hooks/useDefaultStocksAssets", () => ({
+  useDefaultStocksAssets: (...args: unknown[]) => mockDefaultStocks(...args),
+}));
+
+const stock = (ticker: string): StockSuggestion => ({
+  id: ticker,
+  name: ticker,
+  ticker,
+  navigationId: `${ticker}-mkt`,
+  ledgerId: `${ticker}-ledger`,
+});
+
+describe("useStocksDiscoverySectionViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDefaultStocks.mockReturnValue({
+      stocks: [stock("AAPL")],
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  it("exposes the top discovery stocks from the DADA hook", () => {
+    const { result } = renderHook(() => useStocksDiscoverySectionViewModel());
+
+    expect(result.current.stocks.map(s => s.ticker)).toEqual(["AAPL"]);
+    expect(mockDefaultStocks).toHaveBeenCalledWith(true, MAX_DISCOVERY_STOCKS);
+  });
+
+  it("navigates to the Market list filtered to stocks on Explore All", () => {
+    const { result } = renderHook(() => useStocksDiscoverySectionViewModel());
+
+    act(() => result.current.onPressExploreAll());
+
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.MarketList, { category: "stocks" });
+  });
+
+  it("opens the market detail for a tapped discovery stock", () => {
+    const { result } = renderHook(() => useStocksDiscoverySectionViewModel());
+
+    act(() => result.current.onItemPress(stock("TSLA")));
+
+    expect(mockOpenFromMarket).toHaveBeenCalledWith({
+      marketCurrencyId: "TSLA-mkt",
+      ledgerCurrencyIds: ["TSLA-ledger"],
+      source: "portfolio",
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import {
+  Box,
+  Subheader,
+  SubheaderCount,
+  SubheaderRow,
+  SubheaderShowMore,
+  SubheaderTitle,
+} from "@ledgerhq/lumen-ui-rnative";
+import { withDiscreetMode } from "~/context/DiscreetModeContext";
+import { useTranslation } from "~/context/Locale";
+import { SectionListContent } from "../../components/SectionListContent";
+import usePortfolioStocksSectionViewModel from "./usePortfolioStocksSectionViewModel";
+import { StocksDiscoverySection } from "./StocksDiscoverySection";
+import { EMPTY_STATE_MAX_STOCKS } from "LLM/features/WalletAssets/constants";
+import { WalletAssetsVariant } from "LLM/features/WalletAssets/types";
+
+interface PortfolioStocksSectionProps {
+  variant?: WalletAssetsVariant;
+}
+
+const PortfolioStocksSectionComponent: React.FC<PortfolioStocksSectionProps> = ({ variant }) => {
+  const { t } = useTranslation();
+  const { stocksCount, hasMore, stocksToDisplay, isLoading, isError, onPressShowAll, onItemPress } =
+    usePortfolioStocksSectionViewModel({ variant });
+
+  if (!isLoading && !isError && stocksCount === 0) return <StocksDiscoverySection />;
+
+  return (
+    <Box>
+      <Subheader>
+        <SubheaderRow
+          onPress={hasMore ? onPressShowAll : undefined}
+          accessibilityRole={hasMore ? "button" : undefined}
+          lx={{ marginBottom: "s4" }}
+          testID="portfolio-stocks-section-header"
+        >
+          <SubheaderTitle>{t("wallet.tabs.stocks")}</SubheaderTitle>
+          {hasMore && (
+            <>
+              <SubheaderCount value={stocksCount} />
+              <SubheaderShowMore />
+            </>
+          )}
+        </SubheaderRow>
+      </Subheader>
+      <Box testID="PortfolioStocksList">
+        <SectionListContent
+          isLoading={isLoading}
+          isError={isError}
+          assetsToDisplay={stocksToDisplay}
+          onItemPress={onItemPress}
+          skeletonCount={EMPTY_STATE_MAX_STOCKS}
+          errorMessage={t("portfolio.assetSection.connectionFailed")}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export const PortfolioStocksSection = withDiscreetMode(PortfolioStocksSectionComponent);

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/usePortfolioStocksSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/usePortfolioStocksSectionViewModel.ts
@@ -1,0 +1,50 @@
+import { useMemo } from "react";
+import type { Asset } from "~/types/asset";
+import { useCategorizedAssetsFromPortfolio } from "LLM/hooks/useCategorizedAssetsFromPortfolio";
+import { usePortfolioSectionActions } from "LLM/features/WalletAssets/shared/usePortfolioSectionActions";
+import { toAsset } from "LLM/features/WalletAssets/shared/assetUtils";
+import { MAX_STOCKS_TO_DISPLAY } from "LLM/features/WalletAssets/constants";
+import { WalletAssetsVariant } from "LLM/features/WalletAssets/types";
+
+export interface PortfolioStocksSectionViewModelResult {
+  stocksCount: number;
+  hasMore: boolean;
+  stocksToDisplay: Asset[];
+  isLoading: boolean;
+  isError: boolean;
+  onPressShowAll: () => void;
+  onItemPress: (asset: Asset) => void;
+}
+
+interface UsePortfolioStocksSectionViewModelOptions {
+  variant?: WalletAssetsVariant;
+}
+
+const usePortfolioStocksSectionViewModel = ({
+  variant,
+}: UsePortfolioStocksSectionViewModelOptions = {}): PortfolioStocksSectionViewModelResult => {
+  const isReadOnly = variant === "readOnly";
+  const { onPressShowAll, onItemPress } = usePortfolioSectionActions(isReadOnly, "stocks");
+  const { categorizedAssets, isLoadingStocks, isStocksError } = useCategorizedAssetsFromPortfolio();
+
+  const stocks = useMemo<Asset[]>(
+    () => (categorizedAssets.stocks ?? []).map(toAsset),
+    [categorizedAssets.stocks],
+  );
+
+  const stocksCount = stocks.length;
+  const stocksToDisplay = useMemo(() => stocks.slice(0, MAX_STOCKS_TO_DISPLAY), [stocks]);
+  const hasMore = stocksCount > MAX_STOCKS_TO_DISPLAY;
+
+  return {
+    stocksCount,
+    hasMore,
+    stocksToDisplay,
+    isLoading: isLoadingStocks,
+    isError: isStocksError,
+    onPressShowAll,
+    onItemPress,
+  };
+};
+
+export default usePortfolioStocksSectionViewModel;

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/useStocksDiscoverySectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/useStocksDiscoverySectionViewModel.ts
@@ -1,0 +1,44 @@
+import { useCallback } from "react";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { useAnalytics } from "~/analytics";
+import { ScreenName } from "~/const";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
+import { useDefaultStocksAssets } from "LLM/hooks/useDefaultStocksAssets";
+import { MAX_DISCOVERY_STOCKS } from "LLM/features/WalletAssets/constants";
+
+export interface StocksDiscoverySectionViewModelResult {
+  stocks: StockSuggestion[];
+  isLoading: boolean;
+  isError: boolean;
+  onPressExploreAll: () => void;
+  onItemPress: (stock: StockSuggestion) => void;
+}
+
+export function useStocksDiscoverySectionViewModel(): StocksDiscoverySectionViewModelResult {
+  const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+  const { track } = useAnalytics();
+  const { openFromMarket } = useAssetDetailNavigation();
+  const { stocks, isLoading, isError } = useDefaultStocksAssets(true, MAX_DISCOVERY_STOCKS);
+
+  const onPressExploreAll = useCallback(() => {
+    track("button_clicked", { button: "explore_all", type: "stocks", page: "Wallet" });
+    navigation.navigate(ScreenName.MarketList, { category: "stocks" });
+  }, [navigation, track]);
+
+  const onItemPress = useCallback(
+    (stock: StockSuggestion) => {
+      track("asset_clicked", { asset: stock.name, page: "Wallet" });
+      openFromMarket({
+        marketCurrencyId: stock.navigationId,
+        ledgerCurrencyIds: [stock.ledgerId],
+        source: "portfolio",
+      });
+    },
+    [openFromMarket, track],
+  );
+
+  return { stocks, isLoading, isError, onPressExploreAll, onItemPress };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Stocks section + Crypto screen suites green.
- [x] **Impact of the changes:**
  - Adds the Portfolio Stocks section (holdings list ≤5, or a 2-row discovery grid of top stocks when none held) and wires it into the Portfolio home behind `assetDiscoverability`.
  - QA: FF off → no section; FF on + 0 stocks → discovery grid; FF on + ≥1 stock → holdings list; "Show more" opens the Crypto screen filtered to stocks; no regression on Crypto/Stablecoins or Global Search.

### 📝 Description

PR **2/2** of the Portfolio Stocks section — UI + composition.

- `PortfolioStocksSection` (+ ViewModels): holdings list when the user owns stocks, discovery grid otherwise.
- Shared `StockPillRows` 2-row grid extracted and reused by Global Search (removes the duplicated grid).
- `CryptoVariant` extended with `"stocks"` so "Show more" filters the Crypto screen to stocks; tracking/test-id maps updated.
- Composed into `AssetsSections` after Stablecoins, gated by `shouldDisplayAssetDiscoverability` (threaded through `useWalletAssetsViewModel`). Threads the WalletAssets `variant` so read-only portfolios navigate correctly; Crypto screen reflects the stock query's loading/error state.

> **Note:** the integration (formerly #18471) is folded in here — knip's `files: error` rule blocks merging an unconsumed component, so the section must be wired in the same PR.


https://github.com/user-attachments/assets/ec8b4776-bb21-4fe0-8faf-806536f781b3



### ❓ Context

- **JIRA**: [LIVE-31381](https://ledgerhq.atlassian.net/browse/LIVE-31381) · [LIVE-31382](https://ledgerhq.atlassian.net/browse/LIVE-31382) · [LIVE-31383](https://ledgerhq.atlassian.net/browse/LIVE-31383) — Epic [LIVE-27854](https://ledgerhq.atlassian.net/browse/LIVE-27854)
- **Stacked series**: 2/2, based on #18469.

[LIVE-31381]: https://ledgerhq.atlassian.net/browse/LIVE-31381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ