### PR TITLE
[LWM] feat(mobile): Portfolio Stocks — wire into AssetsSections [LIVE-31383]

### DIFF
--- a/.changeset/shared-stock-pill-rows.md
+++ b/.changeset/shared-stock-pill-rows.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Extract a shared `StockPillRows` component (two horizontally-scrollable rows of stock pills) used by both Global Search and the Portfolio Stocks discovery section, removing the duplicated grid. Finalize the Stocks subheader spacing: the holdings list matches the other portfolio sections, the discovery grid uses s12.

--- a/.changeset/stocks-discovery-grid.md
+++ b/.changeset/stocks-discovery-grid.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add the Portfolio Stocks discovery section: when the user holds no stocks, render a horizontal 2-row grid of the top stocks (MediaButton pills) with an "Explore All" header that opens the Market list filtered to stocks. Tapping a pill opens that stock's market detail.

--- a/.changeset/stocks-discovery-hook.md
+++ b/.changeset/stocks-discovery-hook.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add the `useDefaultStocksAssets` hook for the Portfolio Stocks discovery scenario — fetches the top stocks (market-cap ordered) from the DADA stocks category via `useStocksData` + `selectTopStocks`, no-op when disabled.

--- a/.changeset/stocks-portfolio-categorization.md
+++ b/.changeset/stocks-portfolio-categorization.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Categorize held stocks in the portfolio: `useCategorizedAssetsFromPortfolio` now returns a `stocks` bucket (split out of `cryptos`) identified by DADA currency id via the new `useStockAssetIds` hook. Matching by id (rather than ticker) avoids symbol collisions — e.g. a crypto like TON is no longer misclassified as a stock. Adds the `MAX_STOCKS_TO_DISPLAY` / `EMPTY_STATE_MAX_STOCKS` constants.

--- a/.changeset/stocks-portfolio-list-variant.md
+++ b/.changeset/stocks-portfolio-list-variant.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add the Portfolio Stocks section (holdings variant): when the user holds stocks, render a vertical list (max 5, mirroring the Crypto/Stablecoins sections) with a "Show more" header that opens the Crypto screen filtered to stocks. Extends `CryptoVariant` with `"stocks"` and the asset-list filter accordingly.

--- a/.changeset/stocks-section-integration.md
+++ b/.changeset/stocks-section-integration.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Wire the Portfolio Stocks section into `AssetsSections` behind the `assetDiscoverability` flag: it renders the holdings list when the user owns stocks and the discovery grid otherwise. Subheader-to-content spacing set to s12.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8708,7 +8708,11 @@
     "tabs": {
       "crypto": "Crypto",
       "stablecoins": "Stablecoins",
+      "stocks": "Stocks",
       "market": "Market"
+    },
+    "stocks": {
+      "exploreAll": "Explore All"
     },
     "referralProgram": "$20"
   },

--- a/apps/ledger-live-mobile/src/mvvm/components/StockPillRows/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/StockPillRows/index.tsx
@@ -1,0 +1,108 @@
+import React, { useCallback, useMemo } from "react";
+import { ScrollView } from "react-native";
+import Icon from "@ledgerhq/crypto-icons/native";
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { Box, MediaButton, Skeleton } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+
+type Props = Readonly<{
+  stocks: StockSuggestion[];
+  isLoading: boolean;
+  onStockPress: (stock: StockSuggestion) => void;
+  skeletonPillsPerRow: number;
+  testIdPrefix: string;
+}>;
+
+function splitIntoRows(stocks: StockSuggestion[]): [StockSuggestion[], StockSuggestion[]] {
+  const top: StockSuggestion[] = [];
+  const bottom: StockSuggestion[] = [];
+  stocks.forEach((stock, index) => (index % 2 === 0 ? top : bottom).push(stock));
+  return [top, bottom];
+}
+
+type StockPillProps = Readonly<{
+  stock: StockSuggestion;
+  onPress: (stock: StockSuggestion) => void;
+  testIdPrefix: string;
+}>;
+
+function StockPill({ stock, onPress, testIdPrefix }: StockPillProps) {
+  const handlePress = useCallback(() => onPress(stock), [stock, onPress]);
+
+  return (
+    <MediaButton
+      size="sm"
+      hideChevron
+      leadingContentShape="rounded"
+      leadingContent={<Icon ledgerId={stock.ledgerId} ticker={stock.ticker} size={24} />}
+      onPress={handlePress}
+      accessibilityLabel={stock.name}
+      testID={`${testIdPrefix}-${stock.ticker.toLowerCase()}`}
+    >
+      {stock.ticker.toUpperCase()}
+    </MediaButton>
+  );
+}
+
+/**
+ * Top stocks laid out as two horizontally-scrollable rows of pills (even/odd split).
+ * Shared by Global Search and the Portfolio Stocks discovery section.
+ */
+export function StockPillRows({
+  stocks,
+  isLoading,
+  onStockPress,
+  skeletonPillsPerRow,
+  testIdPrefix,
+}: Props) {
+  const [topRow, bottomRow] = useMemo(() => splitIntoRows(stocks), [stocks]);
+
+  const renderSkeletonPills = () =>
+    Array.from({ length: skeletonPillsPerRow }, (_, index) => (
+      <Skeleton key={index} lx={pillSkeletonStyle} />
+    ));
+
+  if (isLoading) {
+    return (
+      <Box lx={gridStyle}>
+        <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
+        <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
+      </Box>
+    );
+  }
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+    >
+      <Box lx={gridStyle}>
+        <Box lx={rowStyle}>
+          {topRow.map(stock => (
+            <StockPill
+              key={stock.id}
+              stock={stock}
+              onPress={onStockPress}
+              testIdPrefix={testIdPrefix}
+            />
+          ))}
+        </Box>
+        <Box lx={rowStyle}>
+          {bottomRow.map(stock => (
+            <StockPill
+              key={stock.id}
+              stock={stock}
+              onPress={onStockPress}
+              testIdPrefix={testIdPrefix}
+            />
+          ))}
+        </Box>
+      </Box>
+    </ScrollView>
+  );
+}
+
+const gridStyle: LumenViewStyle = { gap: "s8", paddingHorizontal: "s16" };
+const rowStyle: LumenViewStyle = { flexDirection: "row", gap: "s8" };
+const pillSkeletonStyle: LumenViewStyle = { width: "s96", height: "s40", borderRadius: "full" };

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/index.tsx
@@ -13,6 +13,7 @@ type Props = BaseComposite<StackNavigatorProps<CryptoScreenNavigator, ScreenName
 const LIST_TEST_ID_BY_VARIANT: Record<CryptoVariant, string> = {
   stablecoin: "StablecoinList",
   crypto: "CryptoList",
+  stocks: "StocksList",
   all: "CryptoList",
 };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/types.ts
@@ -1,7 +1,7 @@
 import { ScreenName } from "~/const";
 import { Asset } from "~/types/asset";
 
-export type CryptoVariant = "crypto" | "stablecoin" | "all";
+export type CryptoVariant = "crypto" | "stablecoin" | "stocks" | "all";
 
 export type CryptoScreenNavigator = {
   [ScreenName.Crypto]: {
@@ -17,5 +17,5 @@ export interface CryptoScreenViewData {
   error: Error | null;
   sourceScreenName: ScreenName | undefined;
   variant: CryptoVariant;
-  trackingType: "crypto" | "stable" | undefined;
+  trackingType: "crypto" | "stable" | "stocks" | undefined;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/useCryptoViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/useCryptoViewModel.ts
@@ -16,11 +16,13 @@ interface UseCryptoViewModelParams {
   variant?: CryptoVariant;
 }
 
-const TRACKING_TYPE_BY_VARIANT: Record<CryptoVariant, "crypto" | "stable" | undefined> = {
-  stablecoin: "stable",
-  crypto: "crypto",
-  all: undefined,
-};
+const TRACKING_TYPE_BY_VARIANT: Record<CryptoVariant, "crypto" | "stable" | "stocks" | undefined> =
+  {
+    stablecoin: "stable",
+    crypto: "crypto",
+    stocks: "stocks",
+    all: undefined,
+  };
 
 const useCryptoViewModel = ({
   sourceScreenName,

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/utils.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/utils.ts
@@ -1,12 +1,25 @@
-import { CategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategorization/types";
+import {
+  CategorizedAssets,
+  CategorizedAssetItem,
+} from "@ledgerhq/asset-aggregation/assetCategorization/types";
 import { CryptoVariant } from "./types";
 
-export function selectAssetList(categorizedAssets: CategorizedAssets, variant: CryptoVariant) {
+export function selectAssetList(
+  categorizedAssets: CategorizedAssets & { stocks?: CategorizedAssetItem[] },
+  variant: CryptoVariant,
+) {
   if (variant === "stablecoin") {
     return categorizedAssets.stablecoins ?? [];
   }
   if (variant === "crypto") {
     return categorizedAssets.cryptos ?? [];
   }
-  return [...(categorizedAssets.cryptos ?? []), ...(categorizedAssets.stablecoins ?? [])];
+  if (variant === "stocks") {
+    return categorizedAssets.stocks ?? [];
+  }
+  return [
+    ...(categorizedAssets.cryptos ?? []),
+    ...(categorizedAssets.stablecoins ?? []),
+    ...(categorizedAssets.stocks ?? []),
+  ];
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/StocksSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/StocksSection/index.tsx
@@ -1,17 +1,14 @@
-import React, { useCallback, useMemo } from "react";
-import { ScrollView } from "react-native";
-import Icon from "@ledgerhq/crypto-icons/native";
+import React, { useCallback } from "react";
 import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
 import {
   Box,
-  MediaButton,
-  Skeleton,
   Subheader,
   SubheaderRow,
   SubheaderShowMore,
   SubheaderTitle,
 } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { StockPillRows } from "LLM/components/StockPillRows";
 import type { GlobalSearchCategory } from "../../useGlobalSearchViewModel";
 
 const SKELETON_PILLS_PER_ROW = 4;
@@ -26,36 +23,6 @@ type Props = Readonly<{
   onStockPress: (stock: StockSuggestion) => void;
 }>;
 
-function splitIntoRows(stocks: StockSuggestion[]): [StockSuggestion[], StockSuggestion[]] {
-  const top: StockSuggestion[] = [];
-  const bottom: StockSuggestion[] = [];
-  stocks.forEach((stock, index) => (index % 2 === 0 ? top : bottom).push(stock));
-  return [top, bottom];
-}
-
-type StockPillProps = Readonly<{
-  stock: StockSuggestion;
-  onPress: (stock: StockSuggestion) => void;
-}>;
-
-function StockPill({ stock, onPress }: StockPillProps) {
-  const handlePress = useCallback(() => onPress(stock), [stock, onPress]);
-
-  return (
-    <MediaButton
-      size="sm"
-      hideChevron
-      leadingContentShape="rounded"
-      leadingContent={<Icon ledgerId={stock.ledgerId} ticker={stock.ticker} size={24} />}
-      onPress={handlePress}
-      accessibilityLabel={stock.name}
-      testID={`global-search-stock-${stock.ticker.toLowerCase()}`}
-    >
-      {stock.ticker.toUpperCase()}
-    </MediaButton>
-  );
-}
-
 export function StocksSection({
   title,
   testID,
@@ -65,15 +32,9 @@ export function StocksSection({
   onSeeAll,
   onStockPress,
 }: Props) {
-  const [topRow, bottomRow] = useMemo(() => splitIntoRows(stocks), [stocks]);
   const handleSeeAll = useCallback(() => onSeeAll(category), [onSeeAll, category]);
 
   if (!isLoading && stocks.length === 0) return null;
-
-  const renderSkeletonPills = () =>
-    Array.from({ length: SKELETON_PILLS_PER_ROW }, (_, index) => (
-      <Skeleton key={index} lx={pillSkeletonStyle} />
-    ));
 
   return (
     <Box lx={sectionStyle} testID={testID}>
@@ -89,40 +50,16 @@ export function StocksSection({
           </SubheaderRow>
         </Subheader>
       </Box>
-      {isLoading ? (
-        <Box lx={insetStyle}>
-          <Box lx={skeletonGridStyle}>
-            <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
-            <Box lx={rowStyle}>{renderSkeletonPills()}</Box>
-          </Box>
-        </Box>
-      ) : (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          keyboardShouldPersistTaps="handled"
-        >
-          <Box lx={gridStyle}>
-            <Box lx={rowStyle}>
-              {topRow.map(stock => (
-                <StockPill key={stock.id} stock={stock} onPress={onStockPress} />
-              ))}
-            </Box>
-            <Box lx={rowStyle}>
-              {bottomRow.map(stock => (
-                <StockPill key={stock.id} stock={stock} onPress={onStockPress} />
-              ))}
-            </Box>
-          </Box>
-        </ScrollView>
-      )}
+      <StockPillRows
+        stocks={stocks}
+        isLoading={isLoading}
+        onStockPress={onStockPress}
+        skeletonPillsPerRow={SKELETON_PILLS_PER_ROW}
+        testIdPrefix="global-search-stock"
+      />
     </Box>
   );
 }
 
 const sectionStyle: LumenViewStyle = { gap: "s16", marginHorizontal: "-s16" };
 const insetStyle: LumenViewStyle = { paddingHorizontal: "s16" };
-const gridStyle: LumenViewStyle = { gap: "s8", paddingHorizontal: "s16" };
-const skeletonGridStyle: LumenViewStyle = { gap: "s8" };
-const rowStyle: LumenViewStyle = { flexDirection: "row", gap: "s8" };
-const pillSkeletonStyle: LumenViewStyle = { width: "s96", height: "s40", borderRadius: "full" };

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/constants.ts
@@ -4,3 +4,7 @@ export const READ_ONLY_MAX_ASSETS = 5;
 
 export const MAX_STABLECOINS_TO_DISPLAY = 6;
 export const EMPTY_STATE_MAX_STABLECOINS = 2;
+
+export const MAX_STOCKS_TO_DISPLAY = 5;
+export const EMPTY_STATE_MAX_STOCKS = 3;
+export const MAX_DISCOVERY_STOCKS = 20;

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/hooks/useWalletAssetsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/hooks/useWalletAssetsViewModel.ts
@@ -13,14 +13,19 @@ interface WalletAssetsViewModelResult {
   onPressShowAll: () => void;
   shouldAddBottomPadding: boolean;
   shouldDisplayAssetSection: boolean;
+  shouldDisplayAssetDiscoverability: boolean;
 }
 
 export function useWalletAssetsViewModel(): WalletAssetsViewModelResult {
   const { onPressShowAll } = usePortfolioSectionActions(false, "all");
   const { categorizedAssets } = useCategorizedAssetsFromPortfolio();
   const { walletCardsDisplayed } = useDynamicContent();
-  const { shouldDisplayOperationsList, shouldDisplayAssetSection, shouldDisplayGraphRework } =
-    useWalletFeaturesConfig("mobile");
+  const {
+    shouldDisplayOperationsList,
+    shouldDisplayAssetSection,
+    shouldDisplayGraphRework,
+    shouldDisplayAssetDiscoverability,
+  } = useWalletFeaturesConfig("mobile");
 
   const hasMore = useMemo(
     () =>
@@ -37,5 +42,6 @@ export function useWalletAssetsViewModel(): WalletAssetsViewModelResult {
     shouldAddBottomPadding:
       shouldDisplayOperationsList && walletCardsDisplayed.length === 0 && shouldDisplayGraphRework,
     shouldDisplayAssetSection,
+    shouldDisplayAssetDiscoverability,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/index.tsx
@@ -15,8 +15,13 @@ export const WalletAssetsView: React.FC<WalletAssetsViewProps> = ({
   variant = "normal",
   noPaddingHorizontal = false,
 }) => {
-  const { hasMore, onPressShowAll, shouldAddBottomPadding, shouldDisplayAssetSection } =
-    useWalletAssetsViewModel();
+  const {
+    hasMore,
+    onPressShowAll,
+    shouldAddBottomPadding,
+    shouldDisplayAssetSection,
+    shouldDisplayAssetDiscoverability,
+  } = useWalletAssetsViewModel();
   const { bottom } = useSafeAreaInsets();
 
   return (
@@ -28,7 +33,11 @@ export const WalletAssetsView: React.FC<WalletAssetsViewProps> = ({
           : undefined
       }
     >
-      <AssetsSections variant={variant} shouldDisplayAssetSection={shouldDisplayAssetSection} />
+      <AssetsSections
+        variant={variant}
+        shouldDisplayAssetSection={shouldDisplayAssetSection}
+        shouldDisplayAssetDiscoverability={shouldDisplayAssetDiscoverability}
+      />
       <AssetsButtonSection
         variant={variant}
         shouldDisplayAssetSection={shouldDisplayAssetSection}

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/usePortfolioSectionActions.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/usePortfolioSectionActions.ts
@@ -15,7 +15,7 @@ interface PortfolioSectionActions {
 
 export function usePortfolioSectionActions(
   isReadOnly: boolean,
-  variant: "crypto" | "stablecoin" | "all",
+  variant: "crypto" | "stablecoin" | "stocks" | "all",
 ): PortfolioSectionActions {
   const { shouldDisplayAssetSection } = useWalletFeaturesConfig("mobile");
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
@@ -25,7 +25,7 @@ export function usePortfolioSectionActions(
   const onPressShowAll = useCallback(() => {
     track("button_clicked", {
       button: "asset_list",
-      type: variant === "stablecoin" ? "stable" : "crypto",
+      type: variant === "stablecoin" ? "stable" : variant === "stocks" ? "stocks" : "crypto",
       page: "Wallet",
     });
     if (!isReadOnly && shouldDisplayAssetSection) {

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/AssetsSections/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/AssetsSections/index.tsx
@@ -2,22 +2,26 @@ import React from "react";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { PortfolioCryptosSection } from "LLM/features/WalletAssets/views/CryptosSection";
 import { PortfolioStablecoinsSection } from "LLM/features/WalletAssets/views/StablecoinsSection";
+import { PortfolioStocksSection } from "LLM/features/WalletAssets/views/StocksSection";
 import { WalletAssetsVariant } from "LLM/features/WalletAssets/types";
 
 interface AssetsSectionsProps {
   variant: WalletAssetsVariant;
   shouldDisplayAssetSection: boolean;
+  shouldDisplayAssetDiscoverability: boolean;
 }
 
 export const AssetsSections: React.FC<AssetsSectionsProps> = ({
   variant,
   shouldDisplayAssetSection,
+  shouldDisplayAssetDiscoverability,
 }) => {
   if (shouldDisplayAssetSection) {
     return (
       <Box lx={{ gap: "s16" }}>
         <PortfolioCryptosSection variant={variant} />
         <PortfolioStablecoinsSection variant={variant} />
+        {shouldDisplayAssetDiscoverability && <PortfolioStocksSection />}
       </Box>
     );
   }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/StocksDiscoverySection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/StocksDiscoverySection.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Box, Subheader, SubheaderRow, SubheaderTitle, Text } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { useTranslation } from "~/context/Locale";
+import { StockPillRows } from "LLM/components/StockPillRows";
+import { EMPTY_STATE_MAX_STOCKS } from "LLM/features/WalletAssets/constants";
+import { useStocksDiscoverySectionViewModel } from "./useStocksDiscoverySectionViewModel";
+
+export function StocksDiscoverySection() {
+  const { t } = useTranslation();
+  const { stocks, isLoading, isError, onPressExploreAll, onItemPress } =
+    useStocksDiscoverySectionViewModel();
+
+  if (!isLoading && (isError || stocks.length === 0)) return null;
+
+  return (
+    <Box lx={sectionStyle} testID="portfolio-stocks-discovery">
+      <Box lx={insetStyle}>
+        <Subheader>
+          <SubheaderRow
+            onPress={onPressExploreAll}
+            accessibilityRole="button"
+            testID="portfolio-stocks-discovery-header"
+          >
+            <SubheaderTitle>{t("wallet.tabs.stocks")}</SubheaderTitle>
+            <Text typography="body2" lx={{ color: "interactive" }} style={exploreAllStyle}>
+              {t("wallet.stocks.exploreAll")}
+            </Text>
+          </SubheaderRow>
+        </Subheader>
+      </Box>
+      <StockPillRows
+        stocks={stocks}
+        isLoading={isLoading}
+        onStockPress={onItemPress}
+        skeletonPillsPerRow={EMPTY_STATE_MAX_STOCKS}
+        testIdPrefix="portfolio-discovery-stock"
+      />
+    </Box>
+  );
+}
+
+const exploreAllStyle = { marginLeft: "auto" as const };
+const sectionStyle: LumenViewStyle = { gap: "s12", marginHorizontal: "-s16" };
+const insetStyle: LumenViewStyle = { paddingHorizontal: "s16" };

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/__tests__/usePortfolioStocksSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/__tests__/usePortfolioStocksSectionViewModel.test.ts
@@ -1,0 +1,100 @@
+import { act } from "@testing-library/react-native";
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { NavigatorName, ScreenName } from "~/const";
+import { Asset } from "~/types/asset";
+import usePortfolioStocksSectionViewModel from "../usePortfolioStocksSectionViewModel";
+import { bitcoin, ethereum, createCryptoAsset } from "../../CryptosSection/__tests__/shared";
+
+const mockNavigate = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+  useRoute: () => ({ name: "Portfolio" }),
+}));
+
+const mockCategorizedAssets = jest.fn();
+
+jest.mock("LLM/hooks/useCategorizedAssetsFromPortfolio", () => ({
+  useCategorizedAssetsFromPortfolio: () => mockCategorizedAssets(),
+}));
+
+const toCategorizedItem = (asset: Asset) => ({
+  currency: asset.currency,
+  balance: asset.amount,
+  value: 0,
+  distribution: 0,
+  accounts: asset.accounts,
+});
+
+const mockPortfolioWithStocks = (stockAssets: Asset[] = []): void => {
+  mockCategorizedAssets.mockReturnValue({
+    categorizedAssets: {
+      cryptos: [],
+      stablecoins: [],
+      stocks: stockAssets.map(toCategorizedItem),
+    },
+    stablecoinTickers: new Set<string>(),
+    isLoadingStablecoinTickers: false,
+    isStablecoinTickersError: false,
+    isLoadingStockTickers: false,
+    isStockTickersError: false,
+  });
+};
+
+describe("usePortfolioStocksSectionViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPortfolioWithStocks();
+  });
+
+  it("returns no stocks when none are held", () => {
+    const { result } = renderHook(() => usePortfolioStocksSectionViewModel());
+
+    expect(result.current.stocksCount).toBe(0);
+    expect(result.current.stocksToDisplay).toHaveLength(0);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it("caps the display at 5 while reporting the full count", () => {
+    mockPortfolioWithStocks(Array.from({ length: 7 }, () => createCryptoAsset(bitcoin, 1000)));
+
+    const { result } = renderHook(() => usePortfolioStocksSectionViewModel());
+
+    expect(result.current.stocksCount).toBe(7);
+    expect(result.current.stocksToDisplay).toHaveLength(5);
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it("navigates to the Crypto screen filtered to stocks on show all", () => {
+    const { result } = renderHook(() => usePortfolioStocksSectionViewModel(), {
+      overrideInitialState: withFlagOverrides({
+        lwmWallet40: { enabled: true, params: { assetSection: true } },
+      }),
+    });
+
+    act(() => {
+      result.current.onPressShowAll();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
+      screen: ScreenName.Crypto,
+      params: { sourceScreenName: ScreenName.Portfolio, variant: "stocks" },
+    });
+  });
+
+  it("navigates to asset detail on item press", () => {
+    mockPortfolioWithStocks([createCryptoAsset(ethereum, 5000)]);
+
+    const { result } = renderHook(() => usePortfolioStocksSectionViewModel());
+
+    act(() => {
+      result.current.onItemPress(result.current.stocksToDisplay[0]);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
+      screen: ScreenName.Asset,
+      params: { currency: ethereum },
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/__tests__/useStocksDiscoverySectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/__tests__/useStocksDiscoverySectionViewModel.test.ts
@@ -1,0 +1,67 @@
+import { act } from "@testing-library/react-native";
+import { renderHook } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { useStocksDiscoverySectionViewModel } from "../useStocksDiscoverySectionViewModel";
+
+const mockNavigate = jest.fn();
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+const mockOpenFromMarket = jest.fn();
+jest.mock("LLM/features/AssetDetail/hooks/useAssetDetailNavigation", () => ({
+  useAssetDetailNavigation: () => ({ openFromMarket: mockOpenFromMarket }),
+}));
+
+const mockDefaultStocks = jest.fn();
+jest.mock("LLM/hooks/useDefaultStocksAssets", () => ({
+  useDefaultStocksAssets: (...args: unknown[]) => mockDefaultStocks(...args),
+}));
+
+const stock = (ticker: string): StockSuggestion => ({
+  id: ticker,
+  name: ticker,
+  ticker,
+  navigationId: `${ticker}-mkt`,
+  ledgerId: `${ticker}-ledger`,
+});
+
+describe("useStocksDiscoverySectionViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDefaultStocks.mockReturnValue({
+      stocks: [stock("AAPL")],
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  it("exposes the top discovery stocks from the DADA hook", () => {
+    const { result } = renderHook(() => useStocksDiscoverySectionViewModel());
+
+    expect(result.current.stocks.map(s => s.ticker)).toEqual(["AAPL"]);
+    expect(mockDefaultStocks).toHaveBeenCalledWith(true, 20);
+  });
+
+  it("navigates to the Market list filtered to stocks on Explore All", () => {
+    const { result } = renderHook(() => useStocksDiscoverySectionViewModel());
+
+    act(() => result.current.onPressExploreAll());
+
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.MarketList, { category: "stocks" });
+  });
+
+  it("opens the market detail for a tapped discovery stock", () => {
+    const { result } = renderHook(() => useStocksDiscoverySectionViewModel());
+
+    act(() => result.current.onItemPress(stock("TSLA")));
+
+    expect(mockOpenFromMarket).toHaveBeenCalledWith({
+      marketCurrencyId: "TSLA-mkt",
+      ledgerCurrencyIds: ["TSLA-ledger"],
+      source: "portfolio",
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import {
+  Box,
+  Subheader,
+  SubheaderCount,
+  SubheaderRow,
+  SubheaderShowMore,
+  SubheaderTitle,
+} from "@ledgerhq/lumen-ui-rnative";
+import { withDiscreetMode } from "~/context/DiscreetModeContext";
+import { useTranslation } from "~/context/Locale";
+import { SectionListContent } from "../../components/SectionListContent";
+import usePortfolioStocksSectionViewModel from "./usePortfolioStocksSectionViewModel";
+import { StocksDiscoverySection } from "./StocksDiscoverySection";
+import { EMPTY_STATE_MAX_STOCKS } from "LLM/features/WalletAssets/constants";
+
+const PortfolioStocksSectionComponent: React.FC = () => {
+  const { t } = useTranslation();
+  const { stocksCount, hasMore, stocksToDisplay, isLoading, isError, onPressShowAll, onItemPress } =
+    usePortfolioStocksSectionViewModel();
+
+  // No holdings → discovery grid (top stocks); holdings → vertical list.
+  if (!isLoading && !isError && stocksCount === 0) return <StocksDiscoverySection />;
+
+  return (
+    <Box>
+      <Subheader>
+        <SubheaderRow
+          onPress={hasMore ? onPressShowAll : undefined}
+          accessibilityRole={hasMore ? "button" : undefined}
+          lx={{ marginBottom: "s4" }}
+          testID="portfolio-stocks-section-header"
+        >
+          <SubheaderTitle>{t("wallet.tabs.stocks")}</SubheaderTitle>
+          {hasMore && (
+            <>
+              <SubheaderCount value={stocksCount} />
+              <SubheaderShowMore />
+            </>
+          )}
+        </SubheaderRow>
+      </Subheader>
+      <Box testID="PortfolioStocksList">
+        <SectionListContent
+          isLoading={isLoading}
+          isError={isError}
+          assetsToDisplay={stocksToDisplay}
+          onItemPress={onItemPress}
+          skeletonCount={EMPTY_STATE_MAX_STOCKS}
+          errorMessage={t("portfolio.assetSection.connectionFailed")}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export const PortfolioStocksSection = withDiscreetMode(PortfolioStocksSectionComponent);

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/usePortfolioStocksSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/usePortfolioStocksSectionViewModel.ts
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+import { Asset } from "~/types/asset";
+import { useCategorizedAssetsFromPortfolio } from "LLM/hooks/useCategorizedAssetsFromPortfolio";
+import { usePortfolioSectionActions } from "LLM/features/WalletAssets/shared/usePortfolioSectionActions";
+import { toAsset } from "LLM/features/WalletAssets/shared/assetUtils";
+import { MAX_STOCKS_TO_DISPLAY } from "LLM/features/WalletAssets/constants";
+
+export interface PortfolioStocksSectionViewModelResult {
+  stocksCount: number;
+  hasMore: boolean;
+  stocksToDisplay: Asset[];
+  isLoading: boolean;
+  isError: boolean;
+  onPressShowAll: () => void;
+  onItemPress: (asset: Asset) => void;
+}
+
+const usePortfolioStocksSectionViewModel = (): PortfolioStocksSectionViewModelResult => {
+  const { onPressShowAll, onItemPress } = usePortfolioSectionActions(false, "stocks");
+  const { categorizedAssets, isLoadingStockTickers, isStockTickersError } =
+    useCategorizedAssetsFromPortfolio();
+
+  const stocks = useMemo<Asset[]>(
+    () => categorizedAssets.stocks.map(toAsset),
+    [categorizedAssets.stocks],
+  );
+
+  const stocksCount = stocks.length;
+  const stocksToDisplay = useMemo(() => stocks.slice(0, MAX_STOCKS_TO_DISPLAY), [stocks]);
+  const hasMore = stocksCount > MAX_STOCKS_TO_DISPLAY;
+
+  return {
+    stocksCount,
+    hasMore,
+    stocksToDisplay,
+    isLoading: isLoadingStockTickers,
+    isError: isStockTickersError,
+    onPressShowAll,
+    onItemPress,
+  };
+};
+
+export default usePortfolioStocksSectionViewModel;

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/useStocksDiscoverySectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/useStocksDiscoverySectionViewModel.ts
@@ -1,0 +1,44 @@
+import { useCallback } from "react";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { useAnalytics } from "~/analytics";
+import { ScreenName } from "~/const";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
+import { useDefaultStocksAssets } from "LLM/hooks/useDefaultStocksAssets";
+import { MAX_DISCOVERY_STOCKS } from "LLM/features/WalletAssets/constants";
+
+export interface StocksDiscoverySectionViewModelResult {
+  stocks: StockSuggestion[];
+  isLoading: boolean;
+  isError: boolean;
+  onPressExploreAll: () => void;
+  onItemPress: (stock: StockSuggestion) => void;
+}
+
+export function useStocksDiscoverySectionViewModel(): StocksDiscoverySectionViewModelResult {
+  const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+  const { track } = useAnalytics();
+  const { openFromMarket } = useAssetDetailNavigation();
+  const { stocks, isLoading, isError } = useDefaultStocksAssets(true, MAX_DISCOVERY_STOCKS);
+
+  const onPressExploreAll = useCallback(() => {
+    track("button_clicked", { button: "explore_all", type: "stocks", page: "Wallet" });
+    navigation.navigate(ScreenName.MarketList, { category: "stocks" });
+  }, [navigation, track]);
+
+  const onItemPress = useCallback(
+    (stock: StockSuggestion) => {
+      track("asset_clicked", { asset: stock.name, page: "Wallet" });
+      openFromMarket({
+        marketCurrencyId: stock.navigationId,
+        ledgerCurrencyIds: [stock.ledgerId],
+        source: "portfolio",
+      });
+    },
+    [openFromMarket, track],
+  );
+
+  return { stocks, isLoading, isError, onPressExploreAll, onItemPress };
+}

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useCategorizedAssetsFromPortfolio.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useCategorizedAssetsFromPortfolio.test.ts
@@ -5,6 +5,7 @@ import { State } from "~/reducers/types";
 const mockUseCategorizedAssets = jest.fn();
 const mockUseDistribution = jest.fn();
 const mockUseStablecoinTickers = jest.fn();
+const mockUseStockAssetIds = jest.fn();
 
 jest.mock("@ledgerhq/asset-aggregation/assetCategorization/index", () => ({
   useCategorizedAssets: (...args: unknown[]) => mockUseCategorizedAssets(...args),
@@ -17,6 +18,16 @@ jest.mock("~/actions/general", () => ({
 
 jest.mock("@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers", () => ({
   useStablecoinTickers: (...args: unknown[]) => mockUseStablecoinTickers(...args),
+}));
+
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useStockAssetIds", () => ({
+  useStockAssetIds: (...args: unknown[]) => mockUseStockAssetIds(...args),
+}));
+
+const mockUseWalletFeaturesConfig = jest.fn();
+jest.mock("@features/platform-feature-flags", () => ({
+  ...jest.requireActual("@features/platform-feature-flags"),
+  useWalletFeaturesConfig: () => mockUseWalletFeaturesConfig(),
 }));
 
 const withBlacklistedTokens =
@@ -42,6 +53,15 @@ describe("useCategorizedAssetsFromPortfolio", () => {
       tickers: new Set<string>(),
       isLoading: false,
       isError: false,
+    });
+    mockUseStockAssetIds.mockReturnValue({
+      ids: new Set<string>(),
+      isLoading: false,
+      isError: false,
+    });
+    mockUseWalletFeaturesConfig.mockReturnValue({
+      shouldDisplayAggregatedAssets: false,
+      shouldDisplayAssetDiscoverability: true,
     });
     mockUseCategorizedAssets.mockReturnValue({ cryptos: [], stablecoins: [] });
   });
@@ -73,15 +93,85 @@ describe("useCategorizedAssetsFromPortfolio", () => {
       expect(result.current.categorizedAssets.stablecoins[0].currency.id).toBe("usdt-token");
     });
 
-    it("returns the original list unchanged when no token is blacklisted", () => {
+    it("keeps cryptos and stablecoins when no token is blacklisted", () => {
       const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
       const usdc = makeItem("USDC", "usdc-token", "TokenCurrency");
-      const source = { cryptos: [btc], stablecoins: [usdc] };
-      mockUseCategorizedAssets.mockReturnValue(source);
+      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc], stablecoins: [usdc] });
 
       const { result } = renderHook(() => useCategorizedAssetsFromPortfolio());
 
-      expect(result.current.categorizedAssets).toBe(source);
+      expect(result.current.categorizedAssets.cryptos.map(a => a.currency.id)).toEqual(["bitcoin"]);
+      expect(result.current.categorizedAssets.stablecoins.map(a => a.currency.id)).toEqual([
+        "usdc-token",
+      ]);
+      expect(result.current.categorizedAssets.stocks).toEqual([]);
+    });
+  });
+
+  describe("stocks bucketing", () => {
+    it("moves held stocks out of cryptos by DADA currency id", () => {
+      const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
+      const aapl = makeItem("Apple xStock", "aapl-x", "TokenCurrency");
+      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc, aapl], stablecoins: [] });
+      mockUseStockAssetIds.mockReturnValue({
+        ids: new Set(["aapl-x"]),
+        isLoading: false,
+        isError: false,
+      });
+
+      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio());
+
+      expect(result.current.categorizedAssets.cryptos.map(a => a.currency.id)).toEqual(["bitcoin"]);
+      expect(result.current.categorizedAssets.stocks.map(a => a.currency.id)).toEqual(["aapl-x"]);
+    });
+
+    it("does not miscategorize a crypto whose ticker collides with a stock symbol", () => {
+      // TON (crypto) must not become a stock just because a stock shares the ticker.
+      const ton = makeItem("Toncoin", "ton", "CryptoCurrency");
+      mockUseCategorizedAssets.mockReturnValue({ cryptos: [ton], stablecoins: [] });
+      mockUseStockAssetIds.mockReturnValue({
+        ids: new Set(["some-tokenized-stock"]),
+        isLoading: false,
+        isError: false,
+      });
+
+      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio());
+
+      expect(result.current.categorizedAssets.cryptos.map(a => a.currency.id)).toEqual(["ton"]);
+      expect(result.current.categorizedAssets.stocks).toEqual([]);
+    });
+
+    it("leaves cryptos untouched and stocks empty when no id matches", () => {
+      const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
+      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc], stablecoins: [] });
+
+      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio());
+
+      expect(result.current.categorizedAssets.cryptos).toHaveLength(1);
+      expect(result.current.categorizedAssets.stocks).toEqual([]);
+    });
+
+    it("keeps stocks under cryptos when assetDiscoverability is off", () => {
+      mockUseWalletFeaturesConfig.mockReturnValue({
+        shouldDisplayAggregatedAssets: false,
+        shouldDisplayAssetDiscoverability: false,
+      });
+      const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
+      const aapl = makeItem("Apple xStock", "aapl-x", "TokenCurrency");
+      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc, aapl], stablecoins: [] });
+      mockUseStockAssetIds.mockReturnValue({
+        ids: new Set(["aapl-x"]),
+        isLoading: false,
+        isError: false,
+      });
+
+      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio());
+
+      expect(result.current.categorizedAssets.stocks).toEqual([]);
+      expect(result.current.categorizedAssets.cryptos.map(a => a.currency.id)).toEqual([
+        "bitcoin",
+        "aapl-x",
+      ]);
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useDefaultStocksAssets.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useDefaultStocksAssets.test.ts
@@ -1,0 +1,65 @@
+import { renderHook } from "@tests/test-renderer";
+import { useStocksData } from "@ledgerhq/live-common/dada-client/hooks/useStocksData";
+import {
+  selectTopStocks,
+  type StockSuggestion,
+} from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { useDefaultStocksAssets } from "../useDefaultStocksAssets";
+
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useStocksData");
+jest.mock("@ledgerhq/live-common/dada-client/utils/assetDiscovery");
+
+const mockedStocks = jest.mocked(useStocksData);
+const mockedSelectTopStocks = jest.mocked(selectTopStocks);
+
+const stock = (ticker: string): StockSuggestion => ({
+  id: ticker,
+  name: ticker,
+  ticker,
+  navigationId: ticker,
+  ledgerId: ticker,
+});
+
+describe("useDefaultStocksAssets", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedStocks.mockReturnValue({
+      data: { stocks: true },
+      isLoading: false,
+      isError: false,
+    } as never);
+    mockedSelectTopStocks.mockReturnValue([stock("AAPL"), stock("TSLA")]);
+  });
+
+  it("returns the top stocks (capped at maxStocks) from the DADA stocks data", () => {
+    const { result } = renderHook(() => useDefaultStocksAssets(true, 20));
+
+    expect(result.current.stocks.map(s => s.ticker)).toEqual(["AAPL", "TSLA"]);
+    expect(mockedSelectTopStocks).toHaveBeenCalledWith(expect.anything(), 20);
+  });
+
+  it("reports loading while the query is in flight", () => {
+    mockedStocks.mockReturnValue({ data: undefined, isLoading: true, isError: false } as never);
+
+    const { result } = renderHook(() => useDefaultStocksAssets(true, 20));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.stocks).toEqual([]);
+  });
+
+  it("flags isError on failure", () => {
+    mockedStocks.mockReturnValue({ data: undefined, isLoading: false, isError: true } as never);
+
+    const { result } = renderHook(() => useDefaultStocksAssets(true, 20));
+
+    expect(result.current.isError).toBe(true);
+  });
+
+  it("is a no-op when disabled (skips the query, empty result)", () => {
+    const { result } = renderHook(() => useDefaultStocksAssets(false, 20));
+
+    expect(result.current.stocks).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(mockedStocks).toHaveBeenCalledWith(expect.objectContaining({ skip: true }));
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useCategorizedAssetsFromPortfolio.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useCategorizedAssetsFromPortfolio.ts
@@ -1,7 +1,11 @@
 import { useMemo } from "react";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useStablecoinTickers } from "@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers";
-import { useCategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategorization/index";
+import { useStockAssetIds } from "@ledgerhq/live-common/dada-client/hooks/useStockAssetIds";
+import {
+  useCategorizedAssets,
+  type CategorizedAssetItem,
+} from "@ledgerhq/asset-aggregation/assetCategorization/index";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import VersionNumber from "react-native-version-number";
 import { useDistribution } from "~/actions/general";
@@ -9,8 +13,10 @@ import { useSelector } from "~/context/hooks";
 import { blacklistedTokenIdsSelector } from "~/reducers/settings";
 
 export function useCategorizedAssetsFromPortfolio() {
-  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("mobile");
+  const { shouldDisplayAggregatedAssets, shouldDisplayAssetDiscoverability } =
+    useWalletFeaturesConfig("mobile");
   const hideEmptyTokenAccount = useEnv("HIDE_EMPTY_TOKEN_ACCOUNTS");
+  const version = VersionNumber.appVersion ?? "";
 
   const distribution = useDistribution({
     showEmptyAccounts: true,
@@ -22,30 +28,46 @@ export function useCategorizedAssetsFromPortfolio() {
     tickers: stablecoinTickers,
     isLoading: isLoadingStablecoinTickers,
     isError: isStablecoinTickersError,
-  } = useStablecoinTickers("llm", VersionNumber.appVersion ?? "");
+  } = useStablecoinTickers("llm", version);
+
+  const {
+    ids: stockAssetIds,
+    isLoading: isLoadingStockTickers,
+    isError: isStockTickersError,
+  } = useStockAssetIds("llm", version, !shouldDisplayAssetDiscoverability);
 
   const categorizedAssets = useCategorizedAssets(distribution, stablecoinTickers);
 
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
   const blacklistedTokenIdsSet = useMemo(() => new Set(blacklistedTokenIds), [blacklistedTokenIds]);
 
-  // Exclude blacklisted assets so all portfolio-derived views share the same filtering rule.
+  // Split stocks out of the cryptos bucket by DADA currency id (collision-free vs ticker), and
+  // drop blacklisted assets so all portfolio-derived views share the same filtering rule. The
+  // split is gated by the feature flag so stocks stay under cryptos (no regression) when off.
   const filteredCategorizedAssets = useMemo(() => {
-    if (blacklistedTokenIdsSet.size === 0) return categorizedAssets;
-    return {
-      cryptos: categorizedAssets.cryptos.filter(
-        ({ currency }) => !blacklistedTokenIdsSet.has(currency.id),
-      ),
-      stablecoins: categorizedAssets.stablecoins.filter(
-        ({ currency }) => !blacklistedTokenIdsSet.has(currency.id),
-      ),
-    };
-  }, [categorizedAssets, blacklistedTokenIdsSet]);
+    const cryptos: CategorizedAssetItem[] = [];
+    const stocks: CategorizedAssetItem[] = [];
+
+    for (const item of categorizedAssets.cryptos) {
+      if (blacklistedTokenIdsSet.has(item.currency.id)) continue;
+      if (shouldDisplayAssetDiscoverability && stockAssetIds.has(item.currency.id))
+        stocks.push(item);
+      else cryptos.push(item);
+    }
+
+    const stablecoins = categorizedAssets.stablecoins.filter(
+      ({ currency }) => !blacklistedTokenIdsSet.has(currency.id),
+    );
+
+    return { cryptos, stablecoins, stocks };
+  }, [categorizedAssets, blacklistedTokenIdsSet, stockAssetIds, shouldDisplayAssetDiscoverability]);
 
   return {
     categorizedAssets: filteredCategorizedAssets,
     isLoadingStablecoinTickers: isLoadingStablecoinTickers || distribution.isLoading,
     isStablecoinTickersError,
     stablecoinTickers,
+    isLoadingStockTickers: isLoadingStockTickers || distribution.isLoading,
+    isStockTickersError,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useDefaultStocksAssets.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useDefaultStocksAssets.ts
@@ -1,0 +1,35 @@
+import { useMemo } from "react";
+import { useStocksData } from "@ledgerhq/live-common/dada-client/hooks/useStocksData";
+import {
+  selectTopStocks,
+  type StockSuggestion,
+} from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import VersionNumber from "react-native-version-number";
+
+interface DefaultStocksAssets {
+  stocks: StockSuggestion[];
+  isLoading: boolean;
+  isError: boolean;
+}
+
+const EMPTY: DefaultStocksAssets = { stocks: [], isLoading: false, isError: false };
+
+/**
+ * Fetches the top stocks (market-cap ordered) from the DADA stocks category for
+ * the discovery scenario (user holds no stocks).
+ */
+export function useDefaultStocksAssets(enabled: boolean, maxStocks: number): DefaultStocksAssets {
+  const appVersion = VersionNumber.appVersion ?? "";
+
+  const { data, isLoading, isError } = useStocksData({
+    product: "llm",
+    version: appVersion,
+    skip: !enabled,
+  });
+
+  const stocks = useMemo(() => (data ? selectTopStocks(data, maxStocks) : []), [data, maxStocks]);
+
+  if (!enabled) return EMPTY;
+
+  return { stocks, isLoading, isError };
+}

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -434,6 +434,7 @@
     "src/dada-client/hooks/useLazyLedgerCurrency.ts",
     "src/dada-client/hooks/useMarketByCurrencies.ts",
     "src/dada-client/hooks/useStablecoinTickers.ts",
+    "src/dada-client/hooks/useStockAssetIds.ts",
     "src/dada-client/hooks/useStocksData.ts",
     "src/dada-client/index.ts",
     "src/dada-client/state-manager/api.ts",

--- a/libs/ledger-live-common/src/dada-client/hooks/useStockAssetIds.ts
+++ b/libs/ledger-live-common/src/dada-client/hooks/useStockAssetIds.ts
@@ -1,0 +1,23 @@
+import { useMemo } from "react";
+import { useGetAssetCurrencyIdsByCategoryQuery } from "../state-manager/api";
+import { AssetCategory } from "../state-manager/types";
+
+const emptySet = new Set<string>();
+
+/**
+ * Ledger currency ids of every tokenized stock (DADA `stocks` category). Used to
+ * identify held stocks by id rather than ticker, which avoids symbol collisions
+ * (e.g. a stock whose ticker equals a crypto ticker like TON).
+ */
+export function useStockAssetIds(product: "llm" | "lld", version: string, skip?: boolean) {
+  const { data, isLoading, isError } = useGetAssetCurrencyIdsByCategoryQuery(
+    {
+      category: AssetCategory.Stocks,
+      product,
+      version,
+    },
+    { skip },
+  );
+  const ids = useMemo(() => (data ? new Set(data) : emptySet), [data]);
+  return { ids, isLoading, isError };
+}

--- a/libs/ledger-live-common/src/dada-client/state-manager/api.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/api.ts
@@ -127,12 +127,13 @@ async function fetchAssetsPage(
   };
 }
 
-export async function fetchAllAssetsByCategory(
+async function collectAllByCategory(
   queryArg: GetAssetsByCategoryParams,
+  extract: (data: RawApiResponse) => string[],
 ): Promise<QueryReturnValue<string[], FetchBaseQueryError, FetchBaseQueryMeta | undefined>> {
   try {
     const baseUrl = queryArg.isStaging ? getEnv("DADA_API_STAGING") : getEnv("DADA_API_PROD");
-    const allTickers: string[] = [];
+    const collected: string[] = [];
     let cursor: string | undefined;
 
     do {
@@ -158,11 +159,11 @@ export async function fetchAllAssetsByCategory(
       }
 
       const data: RawApiResponse = await response.json();
-      allTickers.push(...Object.values(data.cryptoAssets).map(a => a.ticker));
+      collected.push(...extract(data));
       cursor = response.headers.get("x-ledger-next") || undefined;
     } while (cursor);
 
-    return { data: allTickers };
+    return { data: collected };
   } catch (error) {
     return {
       error: {
@@ -171,6 +172,19 @@ export async function fetchAllAssetsByCategory(
       },
     };
   }
+}
+
+export function fetchAllAssetsByCategory(queryArg: GetAssetsByCategoryParams) {
+  return collectAllByCategory(queryArg, data =>
+    Object.values(data.cryptoAssets).map(a => a.ticker),
+  );
+}
+
+/** Returns the ledger currency ids of every asset in the category (collision-free vs tickers). */
+export function fetchAllAssetCurrencyIdsByCategory(queryArg: GetAssetsByCategoryParams) {
+  return collectAllByCategory(queryArg, data =>
+    Object.values(data.cryptoAssets).flatMap(meta => Object.values(meta.assetsIds)),
+  );
 }
 
 export const assetsDataApi = createApi({
@@ -213,6 +227,12 @@ export const assetsDataApi = createApi({
     getAssetsByCategory: build.query<string[], GetAssetsByCategoryParams>({
       queryFn: async queryArg => {
         return fetchAllAssetsByCategory(queryArg);
+      },
+      keepUnusedDataFor: ONE_DAY_IN_SECONDS,
+    }),
+    getAssetCurrencyIdsByCategory: build.query<string[], GetAssetsByCategoryParams>({
+      queryFn: async queryArg => {
+        return fetchAllAssetCurrencyIdsByCategory(queryArg);
       },
       keepUnusedDataFor: ONE_DAY_IN_SECONDS,
     }),
@@ -275,5 +295,6 @@ export const {
   useGetAssetsDataInfiniteQuery,
   useGetAssetDataQuery,
   useGetAssetsByCategoryQuery,
+  useGetAssetCurrencyIdsByCategoryQuery,
   useGetChunkedAssetsDataQuery,
 } = assetsDataApi;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** WalletAssets suite green.
- [x] **Impact of the changes:**
  - Turns the Stocks section on: it appears on the Portfolio home behind `assetDiscoverability`.
  - QA focus: FF off → no section; FF on + 0 stocks → discovery grid; FF on + ≥1 stock → holdings list; no regression on Crypto/Stablecoins.

### 📝 Description

PR **3/3** of the Portfolio Stocks section — composition + gating.

- `AssetsSections` renders `<PortfolioStocksSection />` after Stablecoins, gated by `shouldDisplayAssetDiscoverability` (threaded through `useWalletAssetsViewModel`). The section picks the holdings vs discovery variant internally.

### ❓ Context

- **JIRA**: [LIVE-31383](https://ledgerhq.atlassian.net/browse/LIVE-31383) — Epic [LIVE-27854](https://ledgerhq.atlassian.net/browse/LIVE-27854)
- **Stacked series**: 3/3, based on #18470.

[LIVE-31383]: https://ledgerhq.atlassian.net/browse/LIVE-31383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-27854]: https://ledgerhq.atlassian.net/browse/LIVE-27854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ