### PR TITLE
fix(ci): keep playwright result counts single-valued for $GITHUB_OUTPUT

### DIFF
--- a/tools/actions/composites/run-e2e-playwright-tests/action.yml
+++ b/tools/actions/composites/run-e2e-playwright-tests/action.yml
@@ -112,10 +112,10 @@ runs:
         TEST_EXIT_CODE=${PIPESTATUS[0]}
         set -e
 
-        PASSED=$(grep -oP '\d+ passed' /tmp/playwright-output.log | grep -oP '\d+' || echo "0")
-        FAILED=$(grep -oP '\d+ failed' /tmp/playwright-output.log | grep -oP '\d+' || echo "0")
-        SKIPPED=$(grep -oP '\d+ skipped' /tmp/playwright-output.log | grep -oP '\d+' || echo "0")
-        FLAKY=$(grep -oP '\d+ flaky' /tmp/playwright-output.log | grep -oP '\d+' || echo "0")
+        PASSED=$(grep -oP '\d+ passed' /tmp/playwright-output.log | grep -oP '\d+' | tail -1 || echo "0")
+        FAILED=$(grep -oP '\d+ failed' /tmp/playwright-output.log | grep -oP '\d+' | tail -1 || echo "0")
+        SKIPPED=$(grep -oP '\d+ skipped' /tmp/playwright-output.log | grep -oP '\d+' | tail -1 || echo "0")
+        FLAKY=$(grep -oP '\d+ flaky' /tmp/playwright-output.log | grep -oP '\d+' | tail -1 || echo "0")
         TOTAL=$((PASSED + FAILED + SKIPPED + FLAKY))
 
         echo "passed=${PASSED}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- N/A: change is in a CI composite action, no published package affected. -->
- [x] **Covered by automatic tests.** <!-- Validated by the desktop E2E smoke job on push, which currently fails without this fix. -->
- [x] **Impact of the changes:** CI only — desktop E2E result reporting.
  - QA: no app impact. Verify the desktop E2E smoke job summary/comment shows correct pass/fail counts.

### 📝 Description

#18451 added the Playwright `["github"]` reporter. It prints its own end-of-run summary in addition to the `["list"]` reporter, so the composite action that scrapes stdout matched each count twice:

```
grep -oP '\d+ passed' | grep -oP '\d+'   →   10\n10
```

That multiline value was written to `$GITHUB_OUTPUT`, so the runner read `passed=10` then choked on the stray `10` line, failing the step with `Unable to process file command 'output' successfully. Invalid format '10'`.

Fix: take the last match (`tail -1`) so each count stays single-valued, and default to `0` when there is no match (previously handled by `|| echo "0"`, which no longer fires once `tail` ends the pipe).

Not caught on the original PR because the desktop E2E job is affected-gated on PRs and the changed files live outside the `ledger-live-desktop` project; on push to `develop` the job runs unconditionally and surfaced the break.

### ❓ Context

- **JIRA or GitHub link**: follow-up to #18451
- **ADR link (if any)**: n/a
