### PR TITLE
[LWD] fix(desktop): gate market banner ranking behind asset discoverability flag

### DIFF
--- a/.changeset/hot-lamps-fail.md
+++ b/.changeset/hot-lamps-fail.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Gate the desktop market banner ranking behind the asset discoverability feature flag and default the ranking to gainers when the flag is off

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/useMarketBannerViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/useMarketBannerViewModel.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "tests/testSetup";
+import { renderHook, withFlagOverrides } from "tests/testSetup";
 import {
   usePerformersBannerItems,
   useFavoritesBannerItems,
@@ -19,6 +19,14 @@ jest.mock("@ledgerhq/live-common/market/hooks/useMarketPerformers");
 jest.mock("@ledgerhq/live-common/market/hooks/useMarketDataProvider");
 jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog");
 jest.mock("@ledgerhq/live-common/exchange/swap/hooks/index");
+
+const assetDiscoverabilityOn = withFlagOverrides({
+  lwdWallet40: { enabled: true, params: { assetDiscoverability: true } },
+});
+
+const assetDiscoverabilityOff = withFlagOverrides({
+  lwdWallet40: { enabled: false },
+});
 
 const mockedUseMarketPerformers = jest.mocked(useMarketPerformers);
 const mockedUseMarketData = jest.mocked(useMarketData);
@@ -228,6 +236,7 @@ describe("MarketBanner view models", () => {
 
       const { result } = renderHook(() => useMarketBannerViewModel(), {
         initialState: {
+          ...assetDiscoverabilityOn,
           marketBanner: { ranking: "favorites" },
           settings: { starredMarketCoins: ["bitcoin"] },
         },
@@ -242,7 +251,10 @@ describe("MarketBanner view models", () => {
       mockMarketDataQuery({});
 
       const { result } = renderHook(() => useMarketBannerViewModel(), {
-        initialState: { marketBanner: { ranking: "losers" } },
+        initialState: {
+          ...assetDiscoverabilityOn,
+          marketBanner: { ranking: "losers" },
+        },
       });
 
       expect(mockedUseMarketData).toHaveBeenCalledWith(
@@ -254,6 +266,51 @@ describe("MarketBanner view models", () => {
         { skip: false },
       );
       expect(result.current.items.length).toBeGreaterThan(0);
+    });
+
+    describe("asset discoverability feature flag", () => {
+      it("uses the persisted ranking when the flag is enabled", () => {
+        mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
+        mockMarketDataQuery({ data: [createMockMarketCurrencyData({ id: "bitcoin" })] });
+
+        renderHook(() => useMarketBannerViewModel(), {
+          initialState: {
+            ...assetDiscoverabilityOn,
+            marketBanner: { ranking: "favorites" },
+            settings: { starredMarketCoins: ["bitcoin"] },
+          },
+        });
+
+        // favorites ranking is honored: performers query is skipped, favorites query runs
+        expect(mockedUseMarketPerformers).toHaveBeenCalledWith(expect.anything(), { skip: true });
+        expect(mockedUseMarketData).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({ enabled: true }),
+        );
+      });
+
+      it("falls back to the default ranking and ignores the persisted ranking when the flag is disabled", () => {
+        mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
+        mockMarketDataQuery({ data: [createMockMarketCurrencyData({ id: "bitcoin" })] });
+
+        const { result } = renderHook(() => useMarketBannerViewModel(), {
+          initialState: {
+            ...assetDiscoverabilityOff,
+            marketBanner: { ranking: "favorites" },
+            settings: { starredMarketCoins: ["bitcoin"] },
+          },
+        });
+
+        expect(mockedUseMarketPerformers).toHaveBeenCalledWith(
+          expect.objectContaining({ sort: "asc" }),
+          { skip: false },
+        );
+        expect(mockedUseMarketData).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({ enabled: false }),
+        );
+        expect(result.current.items.length).toBeGreaterThan(0);
+      });
     });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
@@ -25,7 +25,11 @@ import {
   selectMarketBannerRanking,
   type MarketBannerRanking,
 } from "~/renderer/reducers/marketBanner";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { MARKET_BANNER_ITEMS_COUNT } from "../utils/constants";
+
+/** Ranking shown when the asset discoverability flag is off. */
+const DEFAULT_RANKING_WITHOUT_DISCOVERABILITY: MarketBannerRanking = "gainers";
 
 /** Valid `pageSize` values are 1 / 5 / 20 / 50; 50 covers the favorites banner item cap. */
 const MARKET_BANNER_FAVORITES_LIMIT = 50;
@@ -135,7 +139,11 @@ export function useFavoritesBannerItems(options?: { skip?: boolean }): MarketBan
 }
 
 export function useMarketBannerViewModel(): MarketBannerItems {
-  const ranking = useSelector(selectMarketBannerRanking);
+  const { shouldDisplayAssetDiscoverability } = useWalletFeaturesConfig("desktop");
+  const persistedRanking = useSelector(selectMarketBannerRanking);
+  const ranking = shouldDisplayAssetDiscoverability
+    ? persistedRanking
+    : DEFAULT_RANKING_WITHOUT_DISCOVERABILITY;
   const isFavorites = ranking === "favorites";
 
   const performers = usePerformersBannerItems(ranking, { skip: isFavorites });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Market banner ranking on the desktop portfolio/market views
  - Behavior when the asset discoverability feature flag is **on** vs **off**
  - Default ranking value (now `gainers`)

### 📝 Description

The desktop market banner persisted the user's selected ranking (including `favorites`) regardless of whether the asset discoverability experience was enabled. This leaked the new ranking behavior to users who should not yet see it and used `trending` as the default.

This PR gates the banner ranking behind the `shouldDisplayAssetDiscoverability` feature flag:

- When the flag is **enabled**, the persisted ranking from the `marketBanner` store is applied as before.
- When the flag is **disabled**, the banner falls back to the initial ranking and ignores the persisted value.
- The default initial ranking is changed from `trending` to `gainers`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32270](https://ledgerhq.atlassian.net/browse/LIVE-32270) & [LIVE-32279](https://ledgerhq.atlassian.net/browse/LIVE-32279) https://ledgerhq.atlassian.net/browse/LIVE-32408

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32270]: https://ledgerhq.atlassian.net/browse/LIVE-32270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ