### PR TITLE
[LWM] chore(mobile): add stocks to the debug "accounts by type" generator [LIVE-32307]

### DIFF
--- a/.changeset/lwm-debug-stocks-generator.md
+++ b/.changeset/lwm-debug-stocks-generator.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add a Stocks toggle to the "Accounts by type" debug account generator (dev-only tooling).

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/GenerateMockAccountsByType/constants.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/GenerateMockAccountsByType/constants.ts
@@ -31,6 +31,8 @@ export const ALL_STABLECOIN_IDS = [
   ...STABLECOIN_TOKENS_BY_NETWORK.algorand,
 ] as const;
 
+export const MAX_STOCK_TOKENS = 20;
+
 const allCurrencies = listSupportedCurrencies();
 
 export const MAINNET_CURRENCIES = allCurrencies.filter(c => !c.isTestnetFor);

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/GenerateMockAccountsByType/hooks/useGenerateMockAccountsByTypeViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/GenerateMockAccountsByType/hooks/useGenerateMockAccountsByTypeViewModel.ts
@@ -5,19 +5,23 @@ import { useDispatch } from "~/context/hooks";
 import { replaceAccounts } from "~/actions/accounts";
 import { reboot } from "~/actions/appstate";
 import { useStablecoinTokens } from "./useStablecoinTokens";
-import { MAINNET_CURRENCIES, TESTNET_CURRENCIES, findCurrencyById } from "../constants";
-import { generateCryptoAccounts, generateNetworkStablecoinAccount } from "../utils";
+import { useStockTokens } from "./useStockTokens";
+import { MAINNET_CURRENCIES, TESTNET_CURRENCIES } from "../constants";
+import { generateCryptoAccounts, buildNetworkTokenAccounts } from "../utils";
 
 export interface GenerateMockAccountsByTypeViewModelResult {
   includeCryptos: boolean;
   includeStablecoins: boolean;
+  includeStocks: boolean;
   includeTestnet: boolean;
   countInput: string;
   stablecoinsLoading: boolean;
+  stocksLoading: boolean;
   isValid: boolean;
   isReady: boolean;
   onToggleCryptos: (v: boolean) => void;
   setIncludeStablecoins: (v: boolean) => void;
+  setIncludeStocks: (v: boolean) => void;
   onToggleTestnet: (v: boolean) => void;
   setCountInput: (v: string) => void;
   onGenerate: () => void;
@@ -28,6 +32,7 @@ export function useGenerateMockAccountsByTypeViewModel(): GenerateMockAccountsBy
 
   const [includeCryptos, setIncludeCryptos] = useState(true);
   const [includeStablecoins, setIncludeStablecoins] = useState(true);
+  const [includeStocks, setIncludeStocks] = useState(true);
   const [includeTestnet, setIncludeTestnet] = useState(false);
   const [countInput, setCountInput] = useState("10");
 
@@ -38,8 +43,12 @@ export function useGenerateMockAccountsByTypeViewModel(): GenerateMockAccountsBy
     loading: stablecoinsLoading,
   } = useStablecoinTokens(includeStablecoins);
 
-  const isValid = includeCryptos || includeStablecoins;
-  const isReady = isValid && (!includeStablecoins || !stablecoinsLoading);
+  const { tokensByParent: stockTokensByParent, loading: stocksLoading } =
+    useStockTokens(includeStocks);
+
+  const isValid = includeCryptos || includeStablecoins || includeStocks;
+  const isReady =
+    isValid && (!includeStablecoins || !stablecoinsLoading) && (!includeStocks || !stocksLoading);
 
   const onToggleCryptos = useCallback((v: boolean) => {
     setIncludeCryptos(v);
@@ -66,28 +75,23 @@ export function useGenerateMockAccountsByTypeViewModel(): GenerateMockAccountsBy
       }
 
       if (includeStablecoins) {
-        // One account per supported network, each with all its stablecoin sub-accounts.
-        // This produces 10 unique stablecoin types across ETH · Tron · Algorand.
-        const eth = findCurrencyById("ethereum");
-        if (eth && ethereumTokens.length > 0) {
-          accounts.push(generateNetworkStablecoinAccount(eth, ethereumTokens));
-        }
+        accounts.push(
+          ...buildNetworkTokenAccounts([
+            { parentId: "ethereum", tokens: ethereumTokens },
+            { parentId: "tron", tokens: tronTokens },
+            { parentId: "algorand", tokens: algorandTokens },
+          ]),
+        );
+      }
 
-        const tron = findCurrencyById("tron");
-        if (tron && tronTokens.length > 0) {
-          accounts.push(generateNetworkStablecoinAccount(tron, tronTokens));
-        }
-
-        const algorand = findCurrencyById("algorand");
-        if (algorand && algorandTokens.length > 0) {
-          accounts.push(generateNetworkStablecoinAccount(algorand, algorandTokens));
-        }
+      if (includeStocks) {
+        accounts.push(...buildNetworkTokenAccounts(stockTokensByParent));
       }
 
       if (accounts.length === 0) {
         Confirm.alert(
           "No accounts generated",
-          "Stablecoin data could not be loaded. Please try again.",
+          "Account data could not be loaded. Please try again.",
         );
         return;
       }
@@ -113,20 +117,25 @@ export function useGenerateMockAccountsByTypeViewModel(): GenerateMockAccountsBy
     ethereumTokens,
     includeCryptos,
     includeStablecoins,
+    includeStocks,
     includeTestnet,
+    stockTokensByParent,
     tronTokens,
   ]);
 
   return {
     includeCryptos,
     includeStablecoins,
+    includeStocks,
     includeTestnet,
     countInput,
     stablecoinsLoading,
+    stocksLoading,
     isValid,
     isReady,
     onToggleCryptos,
     setIncludeStablecoins,
+    setIncludeStocks,
     onToggleTestnet,
     setCountInput,
     onGenerate,

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/GenerateMockAccountsByType/hooks/useStockTokens.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/GenerateMockAccountsByType/hooks/useStockTokens.ts
@@ -1,0 +1,32 @@
+import { useMemo } from "react";
+import VersionNumber from "react-native-version-number";
+import { useStocksData } from "@ledgerhq/live-common/dada-client/hooks/useStocksData";
+import { selectTopStocks } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { MAX_STOCK_TOKENS } from "../constants";
+
+export interface StockTokensResult {
+  tokensByParent: { parentId: string; tokens: TokenCurrency[] }[];
+  loading: boolean;
+}
+
+export function useStockTokens(enabled = true): StockTokensResult {
+  const version = VersionNumber.appVersion ?? "";
+  const { data, isLoading } = useStocksData({ product: "llm", version, skip: !enabled });
+
+  const tokensByParent = useMemo(() => {
+    if (!data) return [];
+
+    const groups = new Map<string, TokenCurrency[]>();
+    for (const { ledgerId } of selectTopStocks(data, MAX_STOCK_TOKENS)) {
+      const currency = data.cryptoOrTokenCurrencies[ledgerId];
+      if (currency?.type !== "TokenCurrency") continue;
+      const parentId = currency.parentCurrency.id;
+      groups.set(parentId, [...(groups.get(parentId) ?? []), currency]);
+    }
+
+    return Array.from(groups, ([parentId, tokens]) => ({ parentId, tokens }));
+  }, [data]);
+
+  return { tokensByParent, loading: enabled && isLoading };
+}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/GenerateMockAccountsByType/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/GenerateMockAccountsByType/index.tsx
@@ -10,13 +10,16 @@ export default function GenerateMockAccountsByType() {
   const {
     includeCryptos,
     includeStablecoins,
+    includeStocks,
     includeTestnet,
     countInput,
     stablecoinsLoading,
+    stocksLoading,
     isValid,
     isReady,
     onToggleCryptos,
     setIncludeStablecoins,
+    setIncludeStocks,
     onToggleTestnet,
     setCountInput,
     onGenerate,
@@ -38,6 +41,12 @@ export default function GenerateMockAccountsByType() {
           description="1 account per network (ETH · Tron · Algorand) with 10 stablecoin sub-accounts"
           value={includeStablecoins}
           onValueChange={setIncludeStablecoins}
+        />
+        <ToggleRow
+          label="Stocks"
+          description="Tokenized stocks from DADA (category=stocks) as sub-accounts under their network"
+          value={includeStocks}
+          onValueChange={setIncludeStocks}
         />
         <ToggleRow
           label="Testnets"
@@ -69,6 +78,15 @@ export default function GenerateMockAccountsByType() {
               <Spinner size={16} />
               <Text typography="body2" lx={{ color: "muted", marginLeft: "s8" }}>
                 Loading stablecoin data…
+              </Text>
+            </Box>
+          )}
+
+          {includeStocks && stocksLoading && (
+            <Box lx={{ flexDirection: "row", alignItems: "center", marginTop: "s8" }}>
+              <Spinner size={16} />
+              <Text typography="body2" lx={{ color: "muted", marginLeft: "s8" }}>
+                Loading stock data…
               </Text>
             </Box>
           )}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/GenerateMockAccountsByType/utils.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/GenerateMockAccountsByType/utils.ts
@@ -3,6 +3,12 @@ import { genAccount } from "@ledgerhq/live-common/mock/account";
 import sample from "lodash/sample";
 import { Account } from "@ledgerhq/types-live";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { findCurrencyById } from "./constants";
+
+export interface NetworkTokenGroup {
+  parentId: string;
+  tokens: TokenCurrency[];
+}
 
 export function generateCryptoAccounts(currencies: CryptoCurrency[], count: number): Account[] {
   return new Array(count)
@@ -10,13 +16,21 @@ export function generateCryptoAccounts(currencies: CryptoCurrency[], count: numb
     .map(() => genAccount(uuid(), { currency: sample(currencies) }));
 }
 
-export function generateNetworkStablecoinAccount(
+export function generateNetworkTokenAccount(
   currency: CryptoCurrency,
   tokensData: TokenCurrency[],
 ): Account {
   return genAccount(uuid(), {
     currency,
     tokensData,
+    tokenIds: tokensData.map(t => t.id),
     subAccountsCount: tokensData.length,
+  });
+}
+
+export function buildNetworkTokenAccounts(groups: NetworkTokenGroup[]): Account[] {
+  return groups.flatMap(({ parentId, tokens }) => {
+    const currency = findCurrencyById(parentId);
+    return currency && tokens.length > 0 ? [generateNetworkTokenAccount(currency, tokens)] : [];
   });
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/index.tsx
@@ -90,7 +90,7 @@ export default function Generators() {
       />
       <SettingsRow
         title="Accounts by type"
-        desc="Generate accounts filtered by crypto/stablecoin/testnet"
+        desc="Generate accounts filtered by crypto/stablecoin/stocks/testnet"
         iconLeft={<IconsLegacy.FiltersMedium size={24} color="black" />}
         onPress={() => navigation.navigate(ScreenName.DebugMockGenerateAccountsByType)}
       />


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached (empty — dev-only tooling, no release).
- [x] **Covered by automatic tests.** N/A — debug-only screen; typecheck + lint green.
- [x] **Impact of the changes:**
  - Dev-only. Adds a **Stocks** toggle to the debug account generator. No production/user-facing change.

### 📝 Description

Adds a **Stocks** toggle to **Settings → Debug → Generators → "Accounts by type"**, next to Cryptos / Stablecoins / Testnets.

When enabled it fetches tokenized stocks from the DADA `stocks` category (`useStocksData` — the same source the portfolio categorization uses) and generates one account per parent network holding them as sub-accounts, so the generated holdings are bucketed into the portfolio **Stocks** section. This makes it easy to QA both Stocks scenarios:

- toggle **on** → held stocks (list of 5 + "Explore all" → filtered view),
- toggle **off** → no stocks → discovery grid.

`tokenIds` is passed to `genAccount` so the stock sub-accounts survive the mock framework's `hardcodedMarketcap` filter (their ids aren't hardcoded, unlike stablecoins).

### ❓ Context

- **JIRA**: [LIVE-32307](https://ledgerhq.atlassian.net/browse/LIVE-32307)
- Companion tooling for the Portfolio Stocks section (#18469).


[LIVE-32307]: https://ledgerhq.atlassian.net/browse/LIVE-32307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ