### PR TITLE
[LWM] fix(mobile): restore top_wallet content card tracking on portfolio

### DIFF
--- a/.changeset/fix-top-wallet-content-card-tracking.md
+++ b/.changeset/fix-top-wallet-content-card-tracking.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix top_wallet content card tracking location (page/location) for contentcard click & dismiss events

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.test.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.test.tsx
@@ -1,0 +1,162 @@
+import React from "react";
+import { Linking, Pressable, Text } from "react-native";
+import type { ContentCard } from "@braze/react-native-sdk";
+import type { WalletFeaturesConfig } from "@features/platform-feature-flags";
+import * as useWalletFeaturesConfigModule from "@features/platform-feature-flags";
+import { render, screen } from "@tests/test-renderer";
+import {
+  CategoryContentCard,
+  ContentCardLocation,
+  ContentCardsLayout,
+  ContentCardsType,
+} from "~/dynamicContent/types";
+import useDynamicContent from "../useDynamicContent";
+import Layout from "./Layout";
+
+jest.mock("../useDynamicContent");
+jest.mock("@features/platform-feature-flags");
+jest.mock("LLM/features/DynamicContent/components/LogContentCardWrapper", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("~/contentCards/cards/utils", () => {
+  const actual = jest.requireActual<typeof import("~/contentCards/cards/utils")>(
+    "~/contentCards/cards/utils",
+  );
+
+  return {
+    ...actual,
+    contentCardItem: (
+      _component: unknown,
+      props: { metadata: { actions?: { onClick?: () => void; onDismiss?: () => void } } },
+    ) => ({
+      component: ({
+        metadata,
+      }: {
+        metadata: { actions?: { onClick?: () => void; onDismiss?: () => void } };
+      }) => (
+        <>
+          <Pressable testID="card-click" onPress={metadata.actions?.onClick}>
+            <Text>click</Text>
+          </Pressable>
+          <Pressable testID="card-dismiss" onPress={metadata.actions?.onDismiss}>
+            <Text>dismiss</Text>
+          </Pressable>
+        </>
+      ),
+      props,
+    }),
+  };
+});
+
+const mockUseDynamicContent = jest.mocked(useDynamicContent);
+const mockUseWalletFeaturesConfig = jest.mocked(
+  useWalletFeaturesConfigModule.useWalletFeaturesConfig,
+);
+
+const trackContentCardEvent = jest.fn().mockResolvedValue(undefined);
+const logClickCard = jest.fn();
+const dismissCard = jest.fn();
+
+const createBrazeActionCard = (extras: ContentCard["extras"] = {}): ContentCard => ({
+  id: "card-1",
+  created: 1_690_112_400,
+  expiresAt: -1,
+  viewed: false,
+  clicked: false,
+  pinned: false,
+  dismissed: false,
+  dismissible: true,
+  openURLInWebView: true,
+  isControl: false,
+  type: "Classic",
+  title: "Braze title",
+  cardDescription: "Action card description",
+  extras: {
+    type: "action",
+    title: "Promo title",
+    description: "Promo body",
+    link: "https://example.com",
+    order: "1",
+    ...extras,
+  },
+});
+
+const topWalletCategory: CategoryContentCard = {
+  id: "alwayson",
+  type: ContentCardsType.category,
+  location: ContentCardLocation.TopWallet,
+  cardsType: ContentCardsType.action,
+  cardsLayout: ContentCardsLayout.unique,
+  isDismissable: true,
+  createdAt: 0,
+  viewed: false,
+};
+
+const expectedTrackingBase = {
+  type: ContentCardsType.action,
+  title: "Promo title",
+  description: "Promo body",
+  link: "https://example.com",
+  order: 1,
+  page: ContentCardLocation.TopWallet,
+  location: ContentCardLocation.TopWallet,
+  campaign: "card-1",
+  contentcard: "Promo title",
+  layout: ContentCardsLayout.unique,
+  displayedPosition: 0,
+};
+
+describe("ContentCardsCategory Layout", () => {
+  let canOpenURLSpy: jest.SpyInstance;
+  let openURLSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDynamicContent.mockImplementation(
+      () =>
+        ({
+          trackContentCardEvent,
+          logClickCard,
+          dismissCard,
+        }) as unknown as ReturnType<typeof useDynamicContent>,
+    );
+    mockUseWalletFeaturesConfig.mockReturnValue({
+      shouldDisplayBrazePlacement: false,
+    } as WalletFeaturesConfig);
+    canOpenURLSpy = jest.spyOn(Linking, "canOpenURL").mockResolvedValue(true);
+    openURLSpy = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    canOpenURLSpy.mockRestore();
+    openURLSpy.mockRestore();
+  });
+
+  it("should track category location on card click", async () => {
+    const { user } = render(
+      <Layout category={topWalletCategory} cards={[createBrazeActionCard()]} />,
+    );
+
+    await user.press(screen.getByTestId("card-click"));
+
+    expect(trackContentCardEvent).toHaveBeenCalledWith("contentcard_clicked", expectedTrackingBase);
+    expect(logClickCard).toHaveBeenCalledWith("card-1");
+    expect(openURLSpy).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("should track category location on card dismiss", async () => {
+    const { user } = render(
+      <Layout category={topWalletCategory} cards={[createBrazeActionCard()]} />,
+    );
+
+    await user.press(screen.getByTestId("card-dismiss"));
+
+    expect(trackContentCardEvent).toHaveBeenCalledWith(
+      "contentcard_dismissed",
+      expectedTrackingBase,
+    );
+    expect(dismissCard).toHaveBeenCalledWith("card-1");
+  });
+});

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
@@ -88,9 +88,11 @@ const Layout = ({ category, cards }: LayoutProps) => {
     : contentCardsType.contentCardComponent;
 
   const onCardClick = async (card: AnyContentCard, displayedPosition?: number) => {
+    const page = category.location ?? card.location ?? card.extras?.location;
     await trackContentCardEvent("contentcard_clicked", {
       ...sanitizeExtras(card.extras),
-      page: card.location,
+      page,
+      location: page,
       campaign: card.id,
       contentcard: card.title,
       type: category.cardsType,
@@ -108,9 +110,11 @@ const Layout = ({ category, cards }: LayoutProps) => {
   };
 
   const onCardDismiss = (card: AnyContentCard, displayedPosition?: number) => {
+    const page = category.location ?? card.location ?? card.extras?.location;
     trackContentCardEvent("contentcard_dismissed", {
       ...sanitizeExtras(card.extras),
-      page: card.location,
+      page,
+      location: page,
       campaign: card.id,
       contentcard: card.title,
       type: category.cardsType,
@@ -121,7 +125,11 @@ const Layout = ({ category, cards }: LayoutProps) => {
   };
 
   const cardsMapped = cards
-    .map(card => contentCardsType.mappingFunction(card))
+    .map(card => {
+      const mapped = contentCardsType.mappingFunction(card);
+      if (!mapped) return null;
+      return { ...mapped, location: mapped.location ?? category.location };
+    })
     .filter(card => card);
 
   const cardsSorted = (cardsMapped as AnyContentCard[]).sort(compareCards);

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/__tests__/PortfolioBannersSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/__tests__/PortfolioBannersSection.test.tsx
@@ -59,7 +59,7 @@ describe("PortfolioBannersSection", () => {
     expect(screen.queryByTestId("mock-onboarding-widget")).toBeNull();
   });
 
-  describe("static layout (assets visible, onboarding widget not active)", () => {
+  describe("when user has assets and onboarding is hidden", () => {
     beforeEach(() => {
       mockUseViewModel.mockReturnValue({
         ...baseViewModel,
@@ -68,19 +68,19 @@ describe("PortfolioBannersSection", () => {
       });
     });
 
-    it("renders the recover banner and content cards", () => {
+    it("renders recover banner and top_wallet content cards", () => {
       renderSection({ showAssets: true });
       expect(screen.getByTestId("mock-recover-banner")).toBeVisible();
       expect(screen.getByTestId("mock-content-cards")).toBeVisible();
     });
 
-    it("does not render the onboarding widget or page indicator", () => {
+    it("does not render onboarding or the carousel page indicator", () => {
       renderSection({ showAssets: true });
       expect(screen.queryByTestId("mock-onboarding-widget")).toBeNull();
       expect(screen.queryByTestId("banners-page-indicator")).toBeNull();
     });
 
-    it("renders content cards without recover when recover banner is off", () => {
+    it("renders content cards without recover when recover is off", () => {
       mockUseViewModel.mockReturnValue({
         ...baseViewModel,
         hasAssets: true,
@@ -92,46 +92,73 @@ describe("PortfolioBannersSection", () => {
     });
   });
 
-  describe("carousel layout", () => {
-    it("renders only the onboarding widget when recover banner is not active", () => {
+  describe("when onboarding is visible", () => {
+    it("renders only the onboarding widget when recover is off", () => {
       mockUseViewModel.mockReturnValue({ ...baseViewModel, shouldShowOnboardingWidget: true });
       renderSection();
       expect(screen.getByTestId("mock-onboarding-widget")).toBeVisible();
       expect(screen.queryByTestId("mock-recover-banner")).toBeNull();
+      expect(screen.queryByTestId("mock-content-cards")).toBeNull();
     });
 
-    it("renders only the recover banner when onboarding widget is not active", () => {
+    it("does not render top_wallet content cards when user has assets", () => {
+      mockUseViewModel.mockReturnValue({
+        ...baseViewModel,
+        shouldShowOnboardingWidget: true,
+        hasAssets: true,
+      });
+      renderSection({ showAssets: true });
+      expect(screen.getByTestId("mock-onboarding-widget")).toBeVisible();
+      expect(screen.queryByTestId("mock-content-cards")).toBeNull();
+    });
+  });
+
+  describe("when recover is visible without onboarding", () => {
+    it("renders only the recover banner", () => {
       mockUseViewModel.mockReturnValue({ ...baseViewModel, shouldDisplayRecover: true });
       renderSection();
       expect(screen.getByTestId("mock-recover-banner")).toBeVisible();
       expect(screen.queryByTestId("mock-onboarding-widget")).toBeNull();
     });
+  });
 
-    it("renders both banners when both are active", () => {
+  describe("when onboarding and recover are both visible", () => {
+    beforeEach(() => {
       mockUseViewModel.mockReturnValue({
         ...baseViewModel,
         shouldShowOnboardingWidget: true,
         shouldDisplayRecover: true,
       });
+    });
+
+    it("renders both banners in the carousel", () => {
       renderSection();
       expect(screen.getByTestId("mock-onboarding-widget")).toBeVisible();
       expect(screen.getByTestId("mock-recover-banner")).toBeVisible();
     });
 
-    it("hides the page indicator when only one banner is active", () => {
-      mockUseViewModel.mockReturnValue({ ...baseViewModel, shouldShowOnboardingWidget: true });
-      renderSection();
-      expect(screen.queryByTestId("banners-page-indicator")).toBeNull();
-    });
-
-    it("shows the page indicator when both banners are active", () => {
+    it("does not render top_wallet content cards when user has assets", () => {
       mockUseViewModel.mockReturnValue({
         ...baseViewModel,
         shouldShowOnboardingWidget: true,
         shouldDisplayRecover: true,
+        hasAssets: true,
       });
+      renderSection({ showAssets: true });
+      expect(screen.queryByTestId("mock-content-cards")).toBeNull();
+    });
+
+    it("shows the page indicator", () => {
       renderSection();
       expect(screen.getByTestId("banners-page-indicator")).toBeVisible();
+    });
+  });
+
+  describe("carousel page indicator", () => {
+    it("is hidden when only onboarding is active", () => {
+      mockUseViewModel.mockReturnValue({ ...baseViewModel, shouldShowOnboardingWidget: true });
+      renderSection();
+      expect(screen.queryByTestId("banners-page-indicator")).toBeNull();
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/index.tsx
@@ -1,42 +1,106 @@
 import React from "react";
-import { FlatList, ListRenderItemInfo } from "react-native";
+import {
+  FlatList,
+  ListRenderItemInfo,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+} from "react-native";
 import { Box, PageIndicator } from "@ledgerhq/lumen-ui-rnative";
-import SectionContainer from "~/screens/WalletCentricSections/SectionContainer";
 import { LNSUpsellBanner } from "LLM/features/LNSUpsell/components/LNSUpsellBanner";
 import ContentCardsLocation from "~/dynamicContent/ContentCardsLocation";
 import { ContentCardLocation } from "~/dynamicContent/types";
+import { width } from "~/helpers/normalizeSize";
+import SectionContainer from "~/screens/WalletCentricSections/SectionContainer";
 import RecoverBanner from "../RecoverBanner";
 import { OnboardingWidget } from "../OnboardingWidget";
 import { usePortfolioBannersSectionViewModel } from "./usePortfolioBannersSectionViewModel";
-import { width } from "~/helpers/normalizeSize";
 
-const WIDTH = width - 32;
+const CAROUSEL_SLIDE_WIDTH = width - 32;
 
-const CAROUSEL_ITEMS = [
+const ONBOARDING_RECOVER_SLIDES = [
   { key: "onboarding", slide: "onboarding" as const },
   { key: "recover", slide: "recover" as const },
-];
+] as const;
 
-function OnboardingRecoverBannerSeparator() {
-  return <Box style={{ width: 12 }} />;
-}
-
-function OnboardingRecoverBannerRow({ item }: ListRenderItemInfo<(typeof CAROUSEL_ITEMS)[number]>) {
-  return (
-    <Box style={{ width: WIDTH }}>
-      {item.slide === "onboarding" ? (
-        <OnboardingWidget />
-      ) : (
-        <RecoverBanner paddingHorizontal="s0" />
-      )}
-    </Box>
-  );
-}
+type CarouselSlide = (typeof ONBOARDING_RECOVER_SLIDES)[number];
 
 interface PortfolioBannersSectionProps {
   readonly isFirst: boolean;
   readonly isLNSUpsellBannerShown: boolean;
   readonly showAssets?: boolean;
+}
+
+type BannersSectionShellProps = {
+  readonly isFirst: boolean;
+  readonly children: React.ReactNode;
+};
+
+function BannersSectionShell({ isFirst, children }: BannersSectionShellProps) {
+  return (
+    <SectionContainer
+      py="0"
+      mt={0}
+      isFirst={isFirst}
+      key="BannersSection"
+      testID="portfolio-banners-section"
+    >
+      {children}
+    </SectionContainer>
+  );
+}
+
+type PaddedBannerProps = {
+  readonly children: React.ReactNode;
+};
+
+function PaddedBanner({ children }: PaddedBannerProps) {
+  return <Box lx={{ paddingTop: "s12" }}>{children}</Box>;
+}
+
+function OnboardingRecoverCarouselSeparator() {
+  return <Box style={{ width: 12 }} />;
+}
+
+type OnboardingRecoverCarouselProps = {
+  readonly carouselIndex: number;
+  readonly onScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+};
+
+function OnboardingRecoverCarousel({ carouselIndex, onScroll }: OnboardingRecoverCarouselProps) {
+  return (
+    <Box lx={{ paddingTop: "s12", gap: "s8" }}>
+      <FlatList
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        onScroll={onScroll}
+        onMomentumScrollEnd={onScroll}
+        disableIntervalMomentum
+        snapToInterval={width}
+        decelerationRate={0}
+        scrollEventThrottle={16}
+        bounces={false}
+        data={ONBOARDING_RECOVER_SLIDES}
+        keyExtractor={item => item.key}
+        ItemSeparatorComponent={OnboardingRecoverCarouselSeparator}
+        renderItem={({ item }: ListRenderItemInfo<CarouselSlide>) => (
+          <Box style={{ width: CAROUSEL_SLIDE_WIDTH }}>
+            {item.slide === "onboarding" ? (
+              <OnboardingWidget />
+            ) : (
+              <RecoverBanner paddingHorizontal="s0" />
+            )}
+          </Box>
+        )}
+      />
+
+      <Box lx={{ alignItems: "center" }} testID="banners-page-indicator">
+        <PageIndicator
+          currentPage={Math.min(carouselIndex + 1, ONBOARDING_RECOVER_SLIDES.length)}
+          totalPages={ONBOARDING_RECOVER_SLIDES.length}
+        />
+      </Box>
+    </Box>
+  );
 }
 
 export const PortfolioBannersSection = ({
@@ -45,45 +109,32 @@ export const PortfolioBannersSection = ({
   showAssets,
 }: PortfolioBannersSectionProps) => {
   const {
-    shouldShowOnboardingWidget,
+    shouldShowOnboardingWidget: showOnboarding,
+    shouldDisplayRecover: showRecover,
     contentCardsPaddingTop,
     hasAssets,
-    shouldDisplayRecover,
     onScroll,
     carouselIndex,
-  } = usePortfolioBannersSectionViewModel({
-    showAssets,
-  });
+  } = usePortfolioBannersSectionViewModel({ showAssets });
 
   if (isLNSUpsellBannerShown) {
     return (
-      <SectionContainer
-        py="0"
-        mt={0}
-        isFirst={isFirst}
-        key="BannersSection"
-        testID="portfolio-banners-section"
-      >
+      <BannersSectionShell isFirst={isFirst}>
         <LNSUpsellBanner location="wallet" pt={4} />
-      </SectionContainer>
+      </BannersSectionShell>
     );
   }
-  if (!shouldShowOnboardingWidget && !shouldDisplayRecover && !hasAssets) return null;
 
-  if (hasAssets && !shouldShowOnboardingWidget) {
+  if (!showOnboarding && !showRecover && !hasAssets) return null;
+
+  if (hasAssets && !showOnboarding) {
     return (
-      <SectionContainer
-        py="0"
-        mt={0}
-        isFirst={isFirst}
-        key="BannersSection"
-        testID="portfolio-banners-section"
-      >
+      <BannersSectionShell isFirst={isFirst}>
         <Box>
-          {shouldDisplayRecover && (
-            <Box lx={{ paddingTop: "s12" }}>
+          {showRecover && (
+            <PaddedBanner>
               <RecoverBanner paddingHorizontal="s0" />
-            </Box>
+            </PaddedBanner>
           )}
           <Box lx={contentCardsPaddingTop ? { paddingTop: contentCardsPaddingTop } : undefined}>
             <ContentCardsLocation
@@ -93,70 +144,38 @@ export const PortfolioBannersSection = ({
             />
           </Box>
         </Box>
-      </SectionContainer>
+      </BannersSectionShell>
     );
   }
 
-  if (shouldShowOnboardingWidget && shouldDisplayRecover) {
+  // Onboarding + recover: horizontal carousel.
+  if (showOnboarding && showRecover) {
     return (
-      <SectionContainer
-        py="0"
-        mt={0}
-        isFirst={isFirst}
-        key="BannersSection"
-        testID="portfolio-banners-section"
-      >
-        <Box lx={{ paddingTop: "s12", gap: "s8" }}>
-          <FlatList
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            onScroll={onScroll}
-            onMomentumScrollEnd={onScroll}
-            disableIntervalMomentum
-            snapToInterval={width}
-            decelerationRate={0}
-            scrollEventThrottle={16}
-            bounces={false}
-            data={CAROUSEL_ITEMS}
-            keyExtractor={item => item.key}
-            ItemSeparatorComponent={OnboardingRecoverBannerSeparator}
-            renderItem={OnboardingRecoverBannerRow}
-          />
-
-          <Box lx={{ alignItems: "center" }} testID="banners-page-indicator">
-            <PageIndicator
-              currentPage={Math.min(carouselIndex + 1, CAROUSEL_ITEMS.length)}
-              totalPages={CAROUSEL_ITEMS.length}
-            />
-          </Box>
-        </Box>
-      </SectionContainer>
+      <BannersSectionShell isFirst={isFirst}>
+        <OnboardingRecoverCarousel carouselIndex={carouselIndex} onScroll={onScroll} />
+      </BannersSectionShell>
     );
   }
 
-  if (shouldShowOnboardingWidget || shouldDisplayRecover) {
+  // Single banner: onboarding and/or recover, stacked.
+  if (showOnboarding || showRecover) {
     return (
-      <SectionContainer
-        py="0"
-        mt={0}
-        isFirst={isFirst}
-        key="BannersSection"
-        testID="portfolio-banners-section"
-      >
+      <BannersSectionShell isFirst={isFirst}>
         <Box>
-          {shouldShowOnboardingWidget && (
-            <Box lx={{ paddingTop: "s12" }}>
+          {showOnboarding && (
+            <PaddedBanner>
               <OnboardingWidget />
-            </Box>
+            </PaddedBanner>
           )}
-          {shouldDisplayRecover && (
-            <Box lx={{ paddingTop: "s12" }}>
+          {showRecover && (
+            <PaddedBanner>
               <RecoverBanner paddingHorizontal="s0" />
-            </Box>
+            </PaddedBanner>
           )}
         </Box>
-      </SectionContainer>
+      </BannersSectionShell>
     );
   }
+
   return null;
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**

### 📝 Description
This pull request addresses an issue with event tracking for "top_wallet" content cards in the mobile app. The main change ensures that the correct tracking location is used when a content card is clicked, improving the accuracy of analytics data.

**Tracking improvements:**

* Updated the `onCardClick` handler in `Layout.tsx` to determine the tracking location using a fallback order: first from `category.location`, then `card.location`, and finally `card.extras?.location`. The computed value is now used for both the `page` and `location` fields in the tracking event.
* Added a changeset file to document the fix for the top_wallet contentcard_clicked tracking location.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31834](https://ledgerhq.atlassian.net/browse/LIVE-31834)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31834]: https://ledgerhq.atlassian.net/browse/LIVE-31834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ