### PR TITLE
[LWDM] feat(desktop): add Portfolio Stocks section

### DIFF
--- a/.changeset/lwd-portfolio-stocks-section.md
+++ b/.changeset/lwd-portfolio-stocks-section.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add the Portfolio Stocks section behind the `assetDiscoverability` flag. `useCategorizedAssetsFromPortfolio` now returns a `stocks` bucket split out of `cryptos` by DADA currency id (collision-free vs ticker, so a crypto like TON isn't misclassified). When the user holds stocks the section renders a table like Cryptos/Stablecoins (max 5, "Explore all" → the `/assets?category=stocks` filtered view); otherwise it renders the discovery grid of the top default stocks ("Explore" → Market filtered to stocks). Renames the discovery `StockRow` pill to `StockPill`.

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/components/AssetsSectionHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/components/AssetsSectionHeader.tsx
@@ -6,7 +6,11 @@ import {
   SubheaderShowMore,
   SubheaderCount,
 } from "@ledgerhq/lumen-ui-react";
-import { MAX_ITEM_DISPLAYED } from "../constants";
+import {
+  ASSETS_PAGE_CATEGORY_STOCKS,
+  MAX_ITEM_DISPLAYED,
+  MAX_STOCKS_TO_DISPLAY,
+} from "../constants";
 
 type AssetSectionHeaderProps = {
   readonly sectionId: string;
@@ -21,7 +25,9 @@ export const AssetsSectionHeader = ({
   onNavigate,
   numberOfItems,
 }: AssetSectionHeaderProps) => {
-  const shouldShowMore = numberOfItems > MAX_ITEM_DISPLAYED;
+  const maxItemsDisplayed =
+    sectionId === ASSETS_PAGE_CATEGORY_STOCKS ? MAX_STOCKS_TO_DISPLAY : MAX_ITEM_DISPLAYED;
+  const shouldShowMore = numberOfItems > maxItemsDisplayed;
 
   return (
     <Subheader>

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/constants.ts
@@ -1,6 +1,7 @@
 export const MAX_ITEM_DISPLAYED = 6;
 export const EMPTY_STATE_STABLECOINS = 2;
 export const EMPTY_STATE_CRYPTOS = 4;
+export const MAX_STOCKS_TO_DISPLAY = 5;
 
 /** How often to refetch DADA assets data so discovery/default row prices stay fresh. */
 export const ASSETS_PRICE_REFRESH_INTERVAL_MS = 180_000;
@@ -9,7 +10,9 @@ export const ASSETS_PRICE_REFRESH_INTERVAL_MS = 180_000;
 export const ASSETS_PAGE_CATEGORY_QUERY = "category";
 export const ASSETS_PAGE_CATEGORY_CRYPTOS = "cryptos";
 export const ASSETS_PAGE_CATEGORY_STABLECOINS = "stablecoins";
+export const ASSETS_PAGE_CATEGORY_STOCKS = "stocks";
 
 export type AssetsPageCategory =
   | typeof ASSETS_PAGE_CATEGORY_CRYPTOS
-  | typeof ASSETS_PAGE_CATEGORY_STABLECOINS;
+  | typeof ASSETS_PAGE_CATEGORY_STABLECOINS
+  | typeof ASSETS_PAGE_CATEGORY_STOCKS;

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/utils/buildAssetsPagePath.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/utils/buildAssetsPagePath.ts
@@ -2,6 +2,7 @@ import {
   ASSETS_PAGE_CATEGORY_CRYPTOS,
   ASSETS_PAGE_CATEGORY_QUERY,
   ASSETS_PAGE_CATEGORY_STABLECOINS,
+  ASSETS_PAGE_CATEGORY_STOCKS,
   type AssetsPageCategory,
 } from "../constants";
 
@@ -14,5 +15,6 @@ export function buildAssetsPagePath(category: AssetsPageCategory): string {
 export function parseAssetsPageCategory(searchParams: URLSearchParams): AssetsPageCategory {
   const raw = searchParams.get(ASSETS_PAGE_CATEGORY_QUERY);
   if (raw === ASSETS_PAGE_CATEGORY_CRYPTOS) return ASSETS_PAGE_CATEGORY_CRYPTOS;
+  if (raw === ASSETS_PAGE_CATEGORY_STOCKS) return ASSETS_PAGE_CATEGORY_STOCKS;
   return ASSETS_PAGE_CATEGORY_STABLECOINS;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/CryptoAssetsView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/CryptoAssetsView.tsx
@@ -13,7 +13,7 @@ export type CryptoAssetsViewProps = {
   readonly isLoading: boolean;
   readonly table: Table<AssetTableItem>;
   readonly onRowClick: (row: Row<AssetTableItem>) => void;
-  readonly trackingType: "crypto" | "stable";
+  readonly trackingType: "crypto" | "stable" | "stocks";
 };
 
 export function CryptoAssetsView({

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/hooks/useCryptoAssetsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/hooks/useCryptoAssetsViewModel.ts
@@ -20,14 +20,28 @@ import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import {
   ASSETS_PAGE_CATEGORY_CRYPTOS,
   ASSETS_PAGE_CATEGORY_STABLECOINS,
+  ASSETS_PAGE_CATEGORY_STOCKS,
   ASSETS_PRICE_REFRESH_INTERVAL_MS,
   EMPTY_STATE_CRYPTOS,
   EMPTY_STATE_STABLECOINS,
+  type AssetsPageCategory,
 } from "LLD/features/Assets/constants";
 import type { AssetTableItem } from "LLD/features/Assets/types";
 import type { CryptoAssetsViewModel } from "../types";
 import { track } from "~/renderer/analytics/segment";
 import { ASSETS_TRACKING_PAGE_NAME } from "../constants";
+
+const TITLE_I18N_KEY_BY_CATEGORY: Record<AssetsPageCategory, string> = {
+  [ASSETS_PAGE_CATEGORY_CRYPTOS]: "assets.cryptos",
+  [ASSETS_PAGE_CATEGORY_STABLECOINS]: "assets.stablecoins",
+  [ASSETS_PAGE_CATEGORY_STOCKS]: "assets.stocks",
+};
+
+const TRACKING_TYPE_BY_CATEGORY: Record<AssetsPageCategory, "crypto" | "stable" | "stocks"> = {
+  [ASSETS_PAGE_CATEGORY_CRYPTOS]: "crypto",
+  [ASSETS_PAGE_CATEGORY_STABLECOINS]: "stable",
+  [ASSETS_PAGE_CATEGORY_STOCKS]: "stocks",
+};
 
 export default function useCryptoAssetsViewModel(): CryptoAssetsViewModel {
   const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
@@ -40,7 +54,7 @@ export default function useCryptoAssetsViewModel(): CryptoAssetsViewModel {
   const { hasAccount } = useAccountStatus();
   const isEmptyState = !hasOnboardedDevice || !hasAccount;
 
-  const { categorizedAssets, isLoadingStablecoinTickers, stablecoinTickers } =
+  const { categorizedAssets, isLoadingStablecoinTickers, isLoadingStocks, stablecoinTickers } =
     useCategorizedAssetsFromPortfolio();
 
   const needsCryptoPlaceholders =
@@ -68,6 +82,9 @@ export default function useCryptoAssetsViewModel(): CryptoAssetsViewModel {
   );
 
   const items = useMemo((): AssetTableItem[] => {
+    if (category === ASSETS_PAGE_CATEGORY_STOCKS) {
+      return categorizedAssets.stocks.map(item => ({ ...item, isPlaceholder: false }));
+    }
     if (category === ASSETS_PAGE_CATEGORY_CRYPTOS) {
       if (isEmptyState) {
         return padItems([], resolvedDefaults.cryptos, EMPTY_STATE_CRYPTOS);
@@ -85,6 +102,7 @@ export default function useCryptoAssetsViewModel(): CryptoAssetsViewModel {
     isEmptyState,
     categorizedAssets.cryptos,
     categorizedAssets.stablecoins,
+    categorizedAssets.stocks,
     resolvedDefaults.cryptos,
     resolvedDefaults.stablecoins,
   ]);
@@ -107,12 +125,12 @@ export default function useCryptoAssetsViewModel(): CryptoAssetsViewModel {
       ? needsCryptoPlaceholders
       : needsStablecoinPlaceholders;
 
-  const isLoading = needsPaddingForCategory
-    ? isLoadingAssetsData || isLoadingStablecoinTickers
-    : isLoadingStablecoinTickers;
+  const isLoading =
+    category === ASSETS_PAGE_CATEGORY_STOCKS
+      ? isLoadingStocks
+      : isLoadingStablecoinTickers || (needsPaddingForCategory && isLoadingAssetsData);
 
-  const title =
-    category === ASSETS_PAGE_CATEGORY_CRYPTOS ? t("assets.cryptos") : t("assets.stablecoins");
+  const title = t(TITLE_I18N_KEY_BY_CATEGORY[category]);
 
   const onBack = useCallback(() => {
     navigate("/");
@@ -143,6 +161,6 @@ export default function useCryptoAssetsViewModel(): CryptoAssetsViewModel {
     items: itemsWithTrend,
     isLoading,
     onAssetRowClick,
-    trackingType: category === ASSETS_PAGE_CATEGORY_CRYPTOS ? "crypto" : "stable",
+    trackingType: TRACKING_TYPE_BY_CATEGORY[category],
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/types.ts
@@ -17,5 +17,5 @@ export type CryptoAssetsViewModel = {
   readonly items: AssetTableItem[];
   readonly isLoading: boolean;
   readonly onAssetRowClick: (item: AssetTableItem) => void;
-  readonly trackingType: "crypto" | "stable";
+  readonly trackingType: "crypto" | "stable" | "stocks";
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -105,13 +105,21 @@ const defaultPollingMock = {
   stop: jest.fn(),
   wipe: jest.fn(),
 };
+
+const mockUseCategorizedAssetsFromPortfolio = jest.fn();
+
 jest.mock("LLD/hooks/useCategorizedAssets", () => ({
-  useCategorizedAssetsFromPortfolio: () => ({
-    categorizedAssets: createMockCategorizedAssets(),
-    isLoadingStablecoinTickers: false,
-    stablecoinTickers: new Set<string>(),
-  }),
+  useCategorizedAssetsFromPortfolio: (...args: unknown[]) =>
+    mockUseCategorizedAssetsFromPortfolio(...args),
 }));
+
+const defaultCategorizedAssetsMock = () => ({
+  categorizedAssets: createMockCategorizedAssets({ stocks: [] }),
+  isLoadingStablecoinTickers: false,
+  stablecoinTickers: new Set<string>(),
+  isLoadingStocks: false,
+  isStocksError: false,
+});
 
 jest.mock("~/renderer/hooks/usePrice", () => {
   const { getFiatCurrencyByTicker } = jest.requireActual("@ledgerhq/live-common/currencies/index");
@@ -175,6 +183,7 @@ describe("PortfolioView", () => {
     mockUsePortfolioThrottled.mockReturnValue(defaultPortfolioMock);
     mockUseCountervaluesPolling.mockReturnValue(defaultPollingMock);
     mockedUseNavigate.mockReturnValue(mockNavigate);
+    mockUseCategorizedAssetsFromPortfolio.mockReturnValue(defaultCategorizedAssetsMock());
   });
 
   afterEach(() => {
@@ -626,7 +635,7 @@ describe("PortfolioView", () => {
   });
 
   describe("AssetDiscoverability", () => {
-    it("should render Stocks section when shouldDisplayAssetDiscoverability is true", async () => {
+    it("should render Stocks discovery section when shouldDisplayAssetDiscoverability is true and user holds no stocks", async () => {
       server.use(http.get(DADA_API_ENDPOINT, () => HttpResponse.json(mockStocksResponse)));
 
       render(<PortfolioView {...defaultProps} shouldDisplayAssetDiscoverability={true} />);
@@ -637,6 +646,33 @@ describe("PortfolioView", () => {
 
       expect(screen.getByTestId("stocks-section")).toBeVisible();
       expect(screen.getByTestId("stocks-explore")).toBeVisible();
+    });
+
+    it("should render owned stocks as an asset table when user holds stocks", async () => {
+      const aaplx = mockStocksResponse.cryptoOrTokenCurrencies["solana/spl/applex"];
+      mockUseCategorizedAssetsFromPortfolio.mockReturnValue({
+        ...defaultCategorizedAssetsMock(),
+        categorizedAssets: createMockCategorizedAssets({
+          stocks: [
+            {
+              currency: aaplx,
+              balance: 100_000_000,
+              value: 226.4,
+              distribution: 0.5,
+              accounts: [],
+            },
+          ],
+        }),
+      });
+
+      render(<PortfolioView {...defaultProps} shouldDisplayAssetDiscoverability={true} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("w40-asset-row-apple-xstock-solanasplapplex")).toBeVisible();
+      });
+
+      expect(screen.getByTestId("stocks-section")).toBeVisible();
+      expect(screen.queryByTestId("stocks-explore")).toBeNull();
     });
 
     it("should not render Stocks section when shouldDisplayAssetDiscoverability is false", () => {
@@ -661,6 +697,7 @@ describe("Portfolio (Wallet V4 Tour)", () => {
     mockUseCountervaluesPolling = jest.spyOn(countervaluesReact, "useCountervaluesPolling");
     mockUsePortfolioThrottled.mockReturnValue(defaultPortfolioMock);
     mockUseCountervaluesPolling.mockReturnValue(defaultPollingMock);
+    mockUseCategorizedAssetsFromPortfolio.mockReturnValue(defaultCategorizedAssetsMock());
   });
 
   afterEach(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/StocksSection/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/StocksSection/index.tsx
@@ -1,11 +1,23 @@
 import React from "react";
+import { Skeleton } from "@ledgerhq/lumen-ui-react";
 import Stocks from "LLD/features/Stocks";
+import { AssetSection } from "LLD/features/Assets/components/AssetsSection";
 import { useStocksSectionViewModel } from "./useStocksSectionViewModel";
+import { usePortfolioStocksViewModel } from "./usePortfolioStocksViewModel";
 
 const STOCKS_PORTFOLIO_LIMIT = 20;
 
 export const StocksSection = () => {
   const { navigateToAsset, onSeeAll } = useStocksSectionViewModel();
+  const { isLoading, stocksCount, section } = usePortfolioStocksViewModel();
+
+  if (isLoading) {
+    return <Skeleton component="table" />;
+  }
+
+  if (stocksCount > 0) {
+    return <AssetSection {...section} />;
+  }
 
   return (
     <Stocks

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/StocksSection/usePortfolioStocksViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/StocksSection/usePortfolioStocksViewModel.ts
@@ -1,0 +1,77 @@
+import { useCallback, useMemo } from "react";
+import { useNavigate } from "react-router";
+import { useTranslation } from "react-i18next";
+import { useCategorizedAssetsFromPortfolio } from "LLD/hooks/useCategorizedAssets";
+import { useSelector } from "LLD/hooks/redux";
+import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
+import { useAllCurrencyTrends } from "LLD/features/Assets/hooks/useAllCurrencyTrends";
+import { useOnDemandCurrenciesCountervalues } from "~/renderer/hooks/useOnDemandCountervalues";
+import { setTrackingSource } from "~/renderer/analytics/TrackPage";
+import { track } from "~/renderer/analytics/segment";
+import { buildAssetsPagePath } from "LLD/features/Assets/utils/buildAssetsPagePath";
+import { ASSETS_PAGE_CATEGORY_STOCKS, MAX_STOCKS_TO_DISPLAY } from "LLD/features/Assets/constants";
+import type { AssetSectionData, AssetTableItem } from "LLD/features/Assets/types";
+
+const TRACKING_SOURCE = "Portfolio";
+
+type PortfolioStocksViewModelResult = {
+  isLoading: boolean;
+  isError: boolean;
+  stocksCount: number;
+  section: AssetSectionData;
+};
+
+export function usePortfolioStocksViewModel(): PortfolioStocksViewModelResult {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { categorizedAssets, isLoadingStocks, isStocksError } = useCategorizedAssetsFromPortfolio();
+
+  const items = useMemo<AssetTableItem[]>(
+    () => categorizedAssets.stocks.map(item => ({ ...item, isPlaceholder: false })),
+    [categorizedAssets.stocks],
+  );
+
+  const stocksToDisplay = useMemo(() => items.slice(0, MAX_STOCKS_TO_DISPLAY), [items]);
+
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const currencies = useMemo(() => stocksToDisplay.map(i => i.currency), [stocksToDisplay]);
+  useOnDemandCurrenciesCountervalues(currencies, counterValueCurrency);
+
+  const trends = useAllCurrencyTrends(stocksToDisplay, "day");
+  const itemsWithTrend = useMemo(
+    () => stocksToDisplay.map(item => ({ ...item, trend: trends.get(item.currency.id) ?? null })),
+    [stocksToDisplay, trends],
+  );
+
+  const onNavigate = useCallback(() => {
+    track("button_clicked", { button: "asset_list", type: "stocks", page: TRACKING_SOURCE });
+    navigate(buildAssetsPagePath(ASSETS_PAGE_CATEGORY_STOCKS));
+  }, [navigate]);
+
+  const onItemClick = useCallback(
+    (item: AssetTableItem) => {
+      setTrackingSource(TRACKING_SOURCE);
+      navigate(`/asset/${item.currency.id}`);
+    },
+    [navigate],
+  );
+
+  const section = useMemo<AssetSectionData>(
+    () => ({
+      sectionId: "stocks",
+      title: t("assets.stocks"),
+      items: itemsWithTrend,
+      totalCount: items.length,
+      onNavigate,
+      onItemClick,
+    }),
+    [t, itemsWithTrend, items.length, onNavigate, onItemClick],
+  );
+
+  return {
+    isLoading: isLoadingStocks,
+    isError: isStocksError,
+    stocksCount: items.length,
+    section,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/StocksSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/StocksSectionView.tsx
@@ -7,7 +7,7 @@ import {
   SubheaderTitle,
   SubheaderShowMore,
 } from "@ledgerhq/lumen-ui-react";
-import { StockRow } from "./components/StockRow";
+import { StockPill } from "./components/StockPill";
 import { StocksSkeleton } from "./components/StocksSkeleton";
 import { splitIntoTwoRows } from "./utils/splitIntoTwoRows";
 import { StocksHeaderVariant, StocksSectionViewProps } from "./types";
@@ -82,7 +82,7 @@ export function StocksSectionView({
             {rows.map((rowStocks, rowIndex) => (
               <div key={`${rowStocks.join("-")}-${rowIndex}`} className="flex gap-8">
                 {rowStocks.map(stock => (
-                  <StockRow key={stock.id} stock={stock} onClick={navigateToAsset} />
+                  <StockPill key={stock.id} stock={stock} onClick={navigateToAsset} />
                 ))}
               </div>
             ))}

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/components/StockPill.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/components/StockPill.tsx
@@ -3,12 +3,12 @@ import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import { MediaButton } from "@ledgerhq/lumen-ui-react";
 import { StockSuggestion } from "../types";
 
-type StockRowProps = {
+type StockPillProps = {
   stock: StockSuggestion;
   onClick: (currencyId: string) => void;
 };
 
-export function StockRow({ stock, onClick }: Readonly<StockRowProps>) {
+export function StockPill({ stock, onClick }: Readonly<StockPillProps>) {
   const { name, ticker, ledgerId, navigationId } = stock;
 
   if (!ledgerId) return null;

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useCategorizedAssets.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useCategorizedAssets.test.ts
@@ -1,10 +1,23 @@
-import { renderHook, waitFor } from "tests/testSetup";
+import { renderHook, waitFor, withFlagOverrides } from "tests/testSetup";
+import { useStockAssetIds } from "@ledgerhq/live-common/dada-client/hooks/useStockAssetIds";
 import { useCategorizedAssetsFromPortfolio } from "../useCategorizedAssets";
 import { BTC_ACCOUNT, ETH_ACCOUNT_WITH_USDC } from "LLD/features/__mocks__/accounts.mock";
+
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useStockAssetIds");
+
+const mockedUseStockAssetIds = jest.mocked(useStockAssetIds);
+
+const mockStockAssetIds = ({ ids = [] as string[], isLoading = false, isError = false } = {}) =>
+  mockedUseStockAssetIds.mockReturnValue({ ids: new Set(ids), isLoading, isError });
 
 const initialState = {
   settings: { counterValue: "USD" },
 };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockStockAssetIds();
+});
 
 describe("useCategorizedAssetsFromPortfolio", () => {
   it("should categorize store accounts into cryptos and stablecoins", async () => {
@@ -80,5 +93,92 @@ describe("useCategorizedAssetsFromPortfolio", () => {
     expect(result.current.categorizedAssets.stablecoins.map(s => s.currency.ticker)).toEqual(
       expectedStablecoinTickers,
     );
+  });
+
+  describe("stocks bucketing (assetDiscoverability on)", () => {
+    const renderWithStocks = ({
+      blacklistedTokenIds,
+      discoverability = true,
+    }: { blacklistedTokenIds?: string[]; discoverability?: boolean } = {}) =>
+      renderHook(() => useCategorizedAssetsFromPortfolio(), {
+        initialState: {
+          ...withFlagOverrides({
+            lwdWallet40: { enabled: true, params: { assetDiscoverability: discoverability } },
+          }),
+          settings: {
+            counterValue: "USD",
+            ...(blacklistedTokenIds ? { blacklistedTokenIds } : {}),
+          },
+          accounts: [BTC_ACCOUNT, ETH_ACCOUNT_WITH_USDC],
+        },
+      });
+
+    it("moves held stocks out of cryptos by DADA currency id", async () => {
+      mockStockAssetIds({ ids: ["ethereum"] });
+
+      const { result } = renderWithStocks();
+
+      await waitFor(() => {
+        expect(result.current.categorizedAssets.stablecoins).toHaveLength(1);
+      });
+      expect(result.current.categorizedAssets.cryptos.map(c => c.currency.id)).toEqual(["bitcoin"]);
+      expect(result.current.categorizedAssets.stocks.map(s => s.currency.id)).toEqual(["ethereum"]);
+    });
+
+    it("matches by currency id, not ticker, so a ticker collision is not miscategorized", async () => {
+      mockStockAssetIds({ ids: ["ETH"] });
+
+      const { result } = renderWithStocks();
+
+      await waitFor(() => {
+        expect(result.current.categorizedAssets.cryptos).toHaveLength(2);
+      });
+      expect(result.current.categorizedAssets.stocks).toEqual([]);
+    });
+
+    it("keeps stocks under cryptos when assetDiscoverability is off", async () => {
+      mockStockAssetIds({ ids: ["ethereum"] });
+
+      const { result } = renderWithStocks({ discoverability: false });
+
+      await waitFor(() => {
+        expect(result.current.categorizedAssets.cryptos).toHaveLength(2);
+      });
+      expect(result.current.categorizedAssets.stocks).toEqual([]);
+    });
+
+    it("drops a blacklisted stock instead of bucketing it", async () => {
+      mockStockAssetIds({ ids: ["ethereum"] });
+
+      const { result } = renderWithStocks({ blacklistedTokenIds: ["ethereum"] });
+
+      await waitFor(() => {
+        expect(result.current.categorizedAssets.cryptos).toHaveLength(1);
+      });
+      expect(result.current.categorizedAssets.cryptos.map(c => c.currency.id)).toEqual(["bitcoin"]);
+      expect(result.current.categorizedAssets.stocks).toEqual([]);
+    });
+  });
+
+  describe("stocks loading and error", () => {
+    it("reports stocks as loading while the stock ids are loading", () => {
+      mockStockAssetIds({ isLoading: true });
+
+      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio(), {
+        initialState: { ...initialState, accounts: [BTC_ACCOUNT] },
+      });
+
+      expect(result.current.isLoadingStocks).toBe(true);
+    });
+
+    it("surfaces the stock ids error", () => {
+      mockStockAssetIds({ isError: true });
+
+      const { result } = renderHook(() => useCategorizedAssetsFromPortfolio(), {
+        initialState: { ...initialState, accounts: [BTC_ACCOUNT] },
+      });
+
+      expect(result.current.isStocksError).toBe(true);
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useCategorizedAssets.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useCategorizedAssets.ts
@@ -1,7 +1,11 @@
 import { useMemo } from "react";
 import { useDistribution } from "~/renderer/actions/general";
 import { useStablecoinTickers } from "@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers";
-import { useCategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategorization/index";
+import { useStockAssetIds } from "@ledgerhq/live-common/dada-client/hooks/useStockAssetIds";
+import {
+  useCategorizedAssets,
+  type CategorizedAssetItem,
+} from "@ledgerhq/asset-aggregation/assetCategorization/index";
 import { useSelector } from "LLD/hooks/redux";
 import {
   blacklistedTokenIdsSelector,
@@ -10,7 +14,8 @@ import {
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 
 export function useCategorizedAssetsFromPortfolio() {
-  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
+  const { shouldDisplayAggregatedAssets, shouldDisplayAssetDiscoverability } =
+    useWalletFeaturesConfig("desktop");
   const hideEmptyTokenAccount = useSelector(hideEmptyTokenAccountsSelector);
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
 
@@ -20,24 +25,58 @@ export function useCategorizedAssetsFromPortfolio() {
     groupBy: shouldDisplayAggregatedAssets ? "asset" : undefined,
   });
 
-  const { tickers: stablecoinTickers, isLoading: isLoadingStablecoinTickers } =
-    useStablecoinTickers("lld", __APP_VERSION__);
+  const {
+    tickers: stablecoinTickers,
+    isLoading: isLoadingStablecoinTickers,
+    isError: isStablecoinTickersError,
+  } = useStablecoinTickers("lld", __APP_VERSION__);
+
+  const {
+    ids: stockAssetIds,
+    isLoading: isLoadingStockIds,
+    isError: isStockIdsError,
+  } = useStockAssetIds("lld", __APP_VERSION__, !shouldDisplayAssetDiscoverability);
+
   const rawCategorizedAssets = useCategorizedAssets(distribution, stablecoinTickers);
 
+  const blacklistedTokenIdsSet = useMemo(
+    () => new Set(blacklistedTokenIds ?? []),
+    [blacklistedTokenIds],
+  );
+
   const categorizedAssets = useMemo(() => {
-    if (!blacklistedTokenIds?.length) return rawCategorizedAssets;
-    const isVisible = (item: { currency: { id: string } }) =>
-      !blacklistedTokenIds.includes(item.currency.id);
-    return {
-      ...rawCategorizedAssets,
-      cryptos: rawCategorizedAssets.cryptos.filter(isVisible),
-      stablecoins: rawCategorizedAssets.stablecoins.filter(isVisible),
-    };
-  }, [rawCategorizedAssets, blacklistedTokenIds]);
+    const cryptos: CategorizedAssetItem[] = [];
+    const stocks: CategorizedAssetItem[] = [];
+
+    for (const item of rawCategorizedAssets.cryptos) {
+      if (blacklistedTokenIdsSet.has(item.currency.id)) {
+        continue;
+      }
+      if (shouldDisplayAssetDiscoverability && stockAssetIds.has(item.currency.id)) {
+        stocks.push(item);
+      } else {
+        cryptos.push(item);
+      }
+    }
+
+    const stablecoins = rawCategorizedAssets.stablecoins.filter(
+      ({ currency }) => !blacklistedTokenIdsSet.has(currency.id),
+    );
+
+    return { cryptos, stablecoins, stocks };
+  }, [
+    rawCategorizedAssets,
+    blacklistedTokenIdsSet,
+    stockAssetIds,
+    shouldDisplayAssetDiscoverability,
+  ]);
 
   return {
     categorizedAssets,
     isLoadingStablecoinTickers: isLoadingStablecoinTickers || distribution.isLoading,
+    isStablecoinTickersError,
     stablecoinTickers,
+    isLoadingStocks: isLoadingStockIds || distribution.isLoading,
+    isStocksError: isStockIdsError,
   };
 }

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8796,6 +8796,7 @@
   "assets": {
     "cryptos": "Crypto",
     "stablecoins": "Stablecoins",
+    "stocks": "Stocks",
     "cryptoAccounts": "Crypto accounts",
     "accountsCount_one": "{{count}} account",
     "accountsCount_other": "{{count}} accounts",

--- a/libs/asset-aggregation/src/mocks/categorizedAssets.mock.ts
+++ b/libs/asset-aggregation/src/mocks/categorizedAssets.mock.ts
@@ -30,10 +30,15 @@ export const STABLECOIN_ASSET: CategorizedAssetItem = {
   accounts: [],
 };
 
+export type MockCategorizedAssets = CategorizedAssets & {
+  stocks: CategorizedAssetItem[];
+};
+
 export const createMockCategorizedAssets = (
-  overrides?: Partial<CategorizedAssets>,
-): CategorizedAssets => ({
+  overrides?: Partial<MockCategorizedAssets>,
+): MockCategorizedAssets => ({
   cryptos: [BITCOIN_ASSET, ETHEREUM_ASSET],
   stablecoins: [STABLECOIN_ASSET],
+  stocks: [],
   ...overrides,
 });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Unit coverage added for `useCategorizedAssetsFromPortfolio` (stocks bucketing, blacklist precedence, ticker-collision safety, loading/error). The `usePortfolioStocksViewModel` wiring and the section render are exercised by the existing Stocks/Assets integration tests but not by dedicated unit tests._
- [x] **Impact of the changes:**
  - Portfolio Stocks section render: table when stocks are held, discovery grid otherwise
  - Categorization correctness: held stocks split out of cryptos by DADA id, no ticker-collision miscategorization (e.g. TON)
  - `assetDiscoverability` behavior with the `lwdWallet40` flag on vs off
  - "Explore all" navigation to the `/assets?category=stocks` filtered view

### 📝 Description

The Portfolio surface had no dedicated place for tokenized stocks: any held stock was lumped into the Cryptos bucket, and there was no entry point to discover or browse stocks from the portfolio.

This PR adds a Portfolio Stocks section behind the `lwdWallet40` `assetDiscoverability` flag. `useCategorizedAssetsFromPortfolio` now returns a `stocks` bucket split out of `cryptos` by DADA currency id (matching on id rather than ticker, so a crypto like TON isn't misclassified as a stock). When the user holds stocks the section renders a table like Cryptos/Stablecoins (max 5, "Explore all" → the `/assets?category=stocks` filtered view); otherwise it renders the discovery grid of the top default stocks ("Explore" → Market filtered to stocks). The discovery `StockRow` pill is renamed to `StockPill`.

### 📸 Screenshots





https://github.com/user-attachments/assets/c787a7a3-12bf-488a-8bf3-a835dd45c2aa


### ❓ Context

- **JIRA or GitHub link**: [LIVE-32294](https://ledgerhq.atlassian.net/browse/LIVE-32294)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32294]: https://ledgerhq.atlassian.net/browse/LIVE-32294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ