### PR TITLE
[LWD] feat(desktop): add stocks preset to mock account generator

### DIFF
--- a/.changeset/lwd-debug-stocks-generator.md
+++ b/.changeset/lwd-debug-stocks-generator.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add a "Stocks preset" generator to the developer mock-accounts tooling (dev-only tooling, no user-facing change). It fetches the top tokenized stocks from DADA (category=stocks) and injects them as sub-accounts grouped under their network.

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/MockAccountGeneratorSection.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/MockAccountGeneratorSection.tsx
@@ -7,6 +7,7 @@ import MockAccountGenerator from "./MockAccountGenerator";
 import CustomMockAccountGenerator from "./CustomMockAccountGenerator";
 import EmptyAccountGenerator from "./EmptyAccountGenerator";
 import StablecoinMockAccountGenerator from "./StablecoinMockAccountGenerator";
+import StocksMockAccountGenerator from "./StocksMockAccountGenerator";
 
 type MockAccountGeneratorSectionContentProps = {
   expanded: boolean;
@@ -38,6 +39,10 @@ export const MockAccountGeneratorSectionContent = ({
           <StablecoinMockAccountGenerator
             title={t("settings.developer.mockAccounts.stablecoinGenerate.title")}
             desc={t("settings.developer.mockAccounts.stablecoinGenerate.desc")}
+          />
+          <StocksMockAccountGenerator
+            title={t("settings.developer.mockAccounts.stocksGenerate.title")}
+            desc={t("settings.developer.mockAccounts.stocksGenerate.desc")}
           />
         </Flex>
       )}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/StocksMockAccountGenerator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/StocksMockAccountGenerator.tsx
@@ -1,0 +1,50 @@
+import React, { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { SettingsSectionRow } from "~/renderer/screens/settings/SettingsSection";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import { generateStockAccounts, injectMockAccounts } from "./utils";
+import { useStockTokens } from "./useStockTokens";
+
+type Props = {
+  title: string;
+  desc: string;
+};
+
+export default function StocksMockAccountGenerator({ title, desc }: Props) {
+  const { t } = useTranslation();
+  const [loading, setLoading] = useState(false);
+  const { tokensByParent, loading: stocksLoading } = useStockTokens();
+
+  const stocksCount = tokensByParent.reduce((sum, { tokens }) => sum + tokens.length, 0);
+
+  const handleGenerate = useCallback(async () => {
+    if (!window.confirm(t("settings.developer.mockAccounts.alerts.confirmErase"))) return;
+    setLoading(true);
+    try {
+      const accounts = generateStockAccounts(tokensByParent);
+      await injectMockAccounts(accounts, true);
+    } catch (error) {
+      console.error("Failed to generate stock accounts:", error);
+      alert(t("settings.developer.mockAccounts.alerts.generateError"));
+    } finally {
+      setLoading(false);
+    }
+  }, [t, tokensByParent]);
+
+  return (
+    <SettingsSectionRow title={title} desc={desc}>
+      <Button
+        appearance="accent"
+        size="sm"
+        disabled={loading || stocksLoading || stocksCount === 0}
+        onClick={handleGenerate}
+      >
+        {stocksLoading
+          ? t("settings.developer.mockAccounts.buttons.loadingStocks")
+          : t("settings.developer.mockAccounts.buttons.generateStockAccounts", {
+              count: stocksCount,
+            })}
+      </Button>
+    </SettingsSectionRow>
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/useStockTokens.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/useStockTokens.ts
@@ -1,0 +1,35 @@
+import { useMemo } from "react";
+import { useStocksData } from "@ledgerhq/live-common/dada-client/hooks/useStocksData";
+import { selectTopStocks } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+
+export const MAX_STOCK_TOKENS = 20;
+
+export interface StockTokensResult {
+  tokensByParent: { parentId: string; tokens: TokenCurrency[] }[];
+  loading: boolean;
+}
+
+export function useStockTokens(enabled = true): StockTokensResult {
+  const { data, isLoading } = useStocksData({
+    product: "lld",
+    version: __APP_VERSION__,
+    skip: !enabled,
+  });
+
+  const tokensByParent = useMemo(() => {
+    if (!data) return [];
+
+    const groups = new Map<string, TokenCurrency[]>();
+    for (const { ledgerId } of selectTopStocks(data, MAX_STOCK_TOKENS)) {
+      const currency = data.cryptoOrTokenCurrencies[ledgerId];
+      if (!currency || currency.type !== "TokenCurrency") continue;
+      const parentId = currency.parentCurrency.id;
+      groups.set(parentId, [...(groups.get(parentId) ?? []), currency]);
+    }
+
+    return Array.from(groups, ([parentId, tokens]) => ({ parentId, tokens }));
+  }, [data]);
+
+  return { tokensByParent, loading: enabled && isLoading };
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/utils.ts
@@ -165,3 +165,20 @@ export async function generateStablecoinAccounts(): Promise<[Account, AccountUse
 
   return results;
 }
+
+export function generateStockAccounts(
+  tokensByParent: { parentId: string; tokens: TokenCurrency[] }[],
+): [Account, AccountUserData][] {
+  const results: [Account, AccountUserData][] = [];
+
+  for (const { parentId, tokens } of tokensByParent) {
+    if (tokens.length === 0) continue;
+    const currency = getCryptoCurrencyById(parentId);
+    const account = genAccount(uuidv4(), { currency });
+    account.subAccounts = tokens.map((token, i) => genTokenAccount(i, account, token));
+    const userData = accountUserDataExportSelector(liveWalletInitialState, { account });
+    results.push([account, userData]);
+  }
+
+  return results;
+}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -5116,6 +5116,10 @@
           "title": "Stablecoin preset",
           "desc": "Generate Ethereum, Arbitrum, Optimism, Base, Solana, Tron and Algorand accounts with top stablecoins (max 5 per network)"
         },
+        "stocksGenerate": {
+          "title": "Stocks preset",
+          "desc": "Generate accounts with the top tokenized stocks from DADA (category=stocks) as sub-accounts under their network"
+        },
         "currencySelector": {
           "placeholder": "Choose currencies...",
           "searchPlaceholder": "Search",
@@ -5134,7 +5138,10 @@
           "generateAccountsQuick": "Generate {{count}} accounts",
           "generateEmptyAccount": "Generate empty account",
           "generateStablecoinAccounts": "Generate {{count}} stablecoin account",
-          "generateStablecoinAccounts_other": "Generate {{count}} stablecoin accounts"
+          "generateStablecoinAccounts_other": "Generate {{count}} stablecoin accounts",
+          "generateStockAccounts": "Generate {{count}} stock account",
+          "generateStockAccounts_other": "Generate {{count}} stock accounts",
+          "loadingStocks": "Loading stock data…"
         },
         "alerts": {
           "selectCurrency": "Please select at least one currency",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Dev-only tooling (Developer settings mock-account generator); not covered by automated tests._
- [x] **Impact of the changes:**
  - New "Stocks preset" button in **Settings → Developer → Generate Mock Accounts** (dev-only build)
  - Verify the button fetches the top tokenized stocks from DADA (category=stocks) and generates accounts with stock tokens as sub-accounts grouped under their parent network
  - Verify the button is disabled while stock data is loading and when no stocks are returned
  - Confirm no impact on existing mock-account generators (standard / stablecoin)

### 📝 Description

The developer mock-accounts tooling lets engineers quickly inject mock accounts for testing, but there was no way to generate accounts populated with tokenized stocks.

This PR adds a dev-only **"Stocks preset"** generator. It fetches the top tokenized stocks from DADA (`category=stocks`) via the existing `useStocksData` hook, groups the resulting token currencies under their parent network, and injects them as sub-accounts. The generate button shows the number of stock tokens that will be created and is disabled while data is loading or when none are available.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32338](https://ledgerhq.atlassian.net/browse/LIVE-32338)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32338]: https://ledgerhq.atlassian.net/browse/LIVE-32338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ