### PR TITLE
[LWDM] fix(BACK-11641): missing hedera operation in getBlock

### DIFF
--- a/.changeset/mean-eyes-complain.md
+++ b/.changeset/mean-eyes-complain.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+fix: missing associate_token operation in getBlock

--- a/libs/coin-modules/coin-hedera/src/constants.ts
+++ b/libs/coin-modules/coin-hedera/src/constants.ts
@@ -20,6 +20,7 @@ export enum HEDERA_TRANSACTION_MODES {
 export enum HEDERA_TRANSACTION_NAMES {
   ContractCall = "CONTRACTCALL",
   UpdateAccount = "CRYPTOUPDATEACCOUNT",
+  TokenAssociate = "TOKENASSOCIATE",
 }
 
 /**
@@ -160,3 +161,9 @@ export const OP_TYPES_EXCLUDING_FEES: OperationType[] = [
  * Since staking rewards on Hedera are not represented as separate transactions, we need to create synthetic operations for them.
  */
 export const STAKING_REWARD_HASH_SUFFIX = "-staking-reward";
+
+export const MAP_TX_NAME_TO_CUSTOM_OPERATION_TYPE: Record<string, OperationType> = {
+  [HEDERA_TRANSACTION_NAMES.TokenAssociate]: "ASSOCIATE_TOKEN",
+  [HEDERA_TRANSACTION_NAMES.ContractCall]: "CONTRACT_CALL",
+  [HEDERA_TRANSACTION_NAMES.UpdateAccount]: "UPDATE_ACCOUNT",
+};

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.test.ts
@@ -726,6 +726,39 @@ describe("getBlockV2", () => {
     ]);
   });
 
+  it("should emit ASSOCIATE_TOKEN operation with associatedTokenId for TOKENASSOCIATE transaction", async () => {
+    const mockTx = getMockedMirrorTransaction({
+      transaction_id: "0.0.999-1234567890-000000000",
+      transaction_hash: "hash_token_associate",
+      name: HEDERA_TRANSACTION_NAMES.TokenAssociate,
+      result: "SUCCESS",
+      charged_tx_fee: 51871165,
+      entity_id: "0.0.456858",
+      staking_reward_transfers: [],
+      transfers: [
+        { account: "0.0.802", amount: 51871165 },
+        { account: "0.0.999", amount: 0 },
+      ],
+      token_transfers: [],
+    });
+
+    (hgraphClient.getERC20TransfersByTimestampRange as jest.Mock).mockResolvedValue([]);
+    (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
+
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
+
+    expect(result.transactions).toHaveLength(1);
+    expect(result.transactions[0].operations).toEqual([
+      {
+        type: "other",
+        operationType: "ASSOCIATE_TOKEN",
+        associatedTokenId: "0.0.456858",
+      },
+    ]);
+    expect(result.transactions[0].fees).toBe(BigInt(51871165));
+    expect(result.transactions[0].feesPayer).toBe("0.0.999");
+  });
+
   it("should handle CRYPTOUPDATEACCOUNT if it's not related to staking", async () => {
     const mockTx = getMockedMirrorTransaction({
       transaction_id: "0.0.999-1234567890-000000000",

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.ts
@@ -33,6 +33,12 @@ function isStakingTransactionType(
   return item.type === "mirror" && item.data.name === HEDERA_TRANSACTION_NAMES.UpdateAccount;
 }
 
+function isTokenAssociateTransactionType(
+  item: MergedTransaction,
+): item is Extract<MergedTransaction, { type: "mirror" }> {
+  return item.type === "mirror" && item.data.name === HEDERA_TRANSACTION_NAMES.TokenAssociate;
+}
+
 function getMirrorTransaction(item: MergedTransaction): HederaMirrorTransaction {
   return item.type === "mirror" ? item.data : item.data.mirrorTransaction;
 }
@@ -225,6 +231,14 @@ export async function getBlockV2({
           stakedNodeId: stakingAnalysis.targetStakingNodeId,
           previousStakedNodeId: stakingAnalysis.previousStakingNodeId,
           stakedAmount: stakingAnalysis.stakedAmount,
+        },
+      ];
+    } else if (isTokenAssociateTransactionType(item)) {
+      operations = [
+        {
+          type: "other",
+          operationType: "ASSOCIATE_TOKEN",
+          associatedTokenId: mirrorTx.entity_id ?? null,
         },
       ];
     } else {

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.ts
@@ -8,7 +8,7 @@ import { getEnv } from "@ledgerhq/live-env";
 import type { Operation, OperationType } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import type { HederaCoinConfig } from "../config";
-import { HEDERA_TRANSACTION_NAMES } from "../constants";
+import { HEDERA_TRANSACTION_NAMES, MAP_TX_NAME_TO_CUSTOM_OPERATION_TYPE } from "../constants";
 import { apiClient } from "../network/api";
 import { parseTransfers, analyzeStakingOperation } from "../network/utils";
 import type {
@@ -24,12 +24,6 @@ import {
   getMemoFromBase64,
   getSyntheticBlock,
 } from "./utils";
-
-const txNameToCustomOperationType: Record<string, OperationType> = {
-  TOKENASSOCIATE: "ASSOCIATE_TOKEN",
-  CONTRACTCALL: "CONTRACT_CALL",
-  CRYPTOUPDATEACCOUNT: "UPDATE_ACCOUNT",
-};
 
 function getCommonOperationData(
   rawTx: HederaMirrorTransaction,
@@ -164,7 +158,7 @@ function processTransfers({
   const { type, value, senders, recipients } = parseTransfers(transfers, address);
   const { hash, fee, timestamp, blockHeight, blockHash, hasFailed } = commonData;
   const extra = { ...commonData.extra };
-  let operationType = txNameToCustomOperationType[rawTx.name] ?? type;
+  let operationType = MAP_TX_NAME_TO_CUSTOM_OPERATION_TYPE[rawTx.name] ?? type;
 
   // update operation type and extra fields if staking analysis is available
   if (stakingAnalysis) {

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
@@ -8,7 +8,11 @@ import { getEnv } from "@ledgerhq/live-env";
 import type { Operation, OperationType } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import type { HederaCoinConfig } from "../config";
-import { HARDCODED_BLOCK_HEIGHT, HEDERA_TRANSACTION_NAMES } from "../constants";
+import {
+  HARDCODED_BLOCK_HEIGHT,
+  HEDERA_TRANSACTION_NAMES,
+  MAP_TX_NAME_TO_CUSTOM_OPERATION_TYPE,
+} from "../constants";
 import { apiClient } from "../network/api";
 import { hgraphClient } from "../network/hgraph";
 import { parseTransfers, enrichERC20Transfers, analyzeStakingOperation } from "../network/utils";
@@ -30,12 +34,6 @@ import {
   mergeTransactionsFromDifferentSources,
   toEntityId,
 } from "./utils";
-
-const txNameToCustomOperationType: Record<string, OperationType> = {
-  TOKENASSOCIATE: "ASSOCIATE_TOKEN",
-  CONTRACTCALL: "CONTRACT_CALL",
-  CRYPTOUPDATEACCOUNT: "UPDATE_ACCOUNT",
-};
 
 function getCommonMirrorOperationData(
   rawTx: HederaMirrorTransaction,
@@ -331,7 +329,7 @@ function processCoinTransfers({
 
   const { hash, fee, date, blockHeight, blockHash, hasFailed } = commonData;
   const extra = { ...commonData.extra };
-  let operationType = txNameToCustomOperationType[rawTx.name] ?? type;
+  let operationType = MAP_TX_NAME_TO_CUSTOM_OPERATION_TYPE[rawTx.name] ?? type;
 
   // update operation type and extra fields if staking analysis is available
   if (stakingAnalysis) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - added missing ASSOCIATE_TOKEN operations to coin-hedera getBlock

### 📝 Description

This PR fixes missing `ASSOCIATE_TOKEN` details in the getBlock output for Hedera (v2 only, v1 is going to be removed soon). Previously, TOKENASSOCIATE transactions were falling through to the generic coin-transfer path, discarding the operation type and the associated token ID carried in entity_id. 

The fix adds a dedicated branch that emits an OtherBlockOperation with operationType `ASSOCIATE_TOKEN` and associatedTokenId, making the block path consistent with what listOperations already produces for the same transaction type. 

As a minor cleanup, the tx-name-to-operation-type lookup map that was duplicated in both listOperations files is extracted to constants and shared.


| Before        | After         |
| ------------- | ------------- |
|        <img width="607" height="502" alt="before" src="https://github.com/user-attachments/assets/f8a90cb4-9dbf-48d5-8c8d-e3fed1db8df2" />  |       <img width="706" height="302" alt="after" src="https://github.com/user-attachments/assets/7a169308-30e4-47ff-9483-cc691d2b965e" /> |


### ❓ Context

- https://ledgerhq.atlassian.net/browse/BACK-11641

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
