### PR TITLE
[LWM] feat(mobile): remove the stablecoins section from global search [LIVE-32312]

### DIFF
--- a/.changeset/lwm-remove-global-search-stablecoins.md
+++ b/.changeset/lwm-remove-global-search-stablecoins.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Remove the Stablecoins section from the mobile Global Search default view. The Cryptos section still excludes stablecoins, so they no longer appear in the search defaults.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1465,7 +1465,6 @@
     "searchPlaceholder": "Search assets",
     "sections": {
       "cryptos": "Cryptos",
-      "stablecoins": "Stablecoins",
       "stocks": "Stocks"
     }
   },

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/__tests__/useGlobalSearchDefaults.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/__tests__/useGlobalSearchDefaults.test.ts
@@ -36,8 +36,8 @@ const makeMarket = (id: string, rank: number) => ({
   priceChangePercentage24h: rank,
 });
 
-// 4 cryptos + 2 stablecoins (USDT/USDC), ordered by market cap.
-const assetIds = ["btc", "eth", "sol", "ada", "usdt", "usdc"];
+// Cryptos and stablecoins (USDT/USDC) interleaved, ordered by market cap.
+const assetIds = ["btc", "usdt", "eth", "usdc", "sol", "ada"];
 // 22 stocks (more than the 20 cap).
 const stockIds = Array.from({ length: 22 }, (_, i) => `stock${i}`);
 
@@ -62,22 +62,20 @@ describe("useGlobalSearchDefaults", () => {
     mockedStocks.mockReturnValue({ data: buildDadaData(stockIds), isLoading: false } as never);
   });
 
-  it("returns the top 3 cryptos, 2 stablecoins and 20 stocks", () => {
+  it("returns the top 3 cryptos and 20 stocks", () => {
     const { result } = renderHook(() => useGlobalSearchDefaults(true));
-    const { cryptos, stablecoins, stocks } = result.current.defaultSections;
+    const { cryptos, stocks } = result.current.defaultSections;
 
     expect(cryptos).toHaveLength(3);
-    expect(stablecoins).toHaveLength(2);
     expect(stocks).toHaveLength(20);
     expect(result.current.isLoadingDefaults).toBe(false);
   });
 
-  it("splits stablecoins out of the cryptos list by ticker", () => {
+  it("excludes stablecoins from the cryptos list by ticker", () => {
     const { result } = renderHook(() => useGlobalSearchDefaults(true));
-    const { cryptos, stablecoins } = result.current.defaultSections;
+    const { cryptos } = result.current.defaultSections;
 
     expect(cryptos.map(c => c.ticker)).toEqual(["BTC", "ETH", "SOL"]);
-    expect(stablecoins.map(s => s.ticker)).toEqual(["USDT", "USDC"]);
   });
 
   it("reports loading while the assets query is in flight", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/useGlobalSearchDefaults.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/useGlobalSearchDefaults.ts
@@ -7,7 +7,6 @@ import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useU
 import {
   selectTopAssetsByCategory,
   selectTopStocks,
-  type CategorizedDiscoveryAsset,
 } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
 import { useSelector } from "~/context/hooks";
@@ -18,7 +17,6 @@ import type { GlobalSearchDefaultSections } from "LLM/features/GlobalSearch/scre
 
 const PRODUCT = "llm";
 const MAX_CRYPTOS = 3;
-const MAX_STABLECOINS = 2;
 const MAX_STOCKS = 20;
 
 export type GlobalSearchDefaults = {
@@ -57,31 +55,21 @@ export function useGlobalSearchDefaults(enabled: boolean): GlobalSearchDefaults 
     skip,
   });
 
-  const { cryptos, stablecoins } = useMemo(() => {
-    if (!assetsData) {
-      return {
-        cryptos: [] as MarketAssetDisplayData[],
-        stablecoins: [] as MarketAssetDisplayData[],
-      };
-    }
+  const cryptos = useMemo<MarketAssetDisplayData[]>(() => {
+    if (!assetsData) return [];
 
-    const categorized = selectTopAssetsByCategory(assetsData, stablecoinTickers, {
+    const { cryptos: topCryptos } = selectTopAssetsByCategory(assetsData, stablecoinTickers, {
       maxCryptos: MAX_CRYPTOS,
-      maxStablecoins: MAX_STABLECOINS,
+      maxStablecoins: 0,
     });
-    const toDisplay = (entries: CategorizedDiscoveryAsset[]) =>
-      entries.map(({ meta, currency, market }) =>
-        mapDadaMarketToDisplayData(
-          { id: meta.id, name: meta.name, ticker: meta.ticker, ledgerId: currency.id },
-          market,
-          { counterCurrency, counterValueUnit, usdToFiatRate, locale, t },
-        ),
-      );
 
-    return {
-      cryptos: toDisplay(categorized.cryptos),
-      stablecoins: toDisplay(categorized.stablecoins),
-    };
+    return topCryptos.map(({ meta, currency, market }) =>
+      mapDadaMarketToDisplayData(
+        { id: meta.id, name: meta.name, ticker: meta.ticker, ledgerId: currency.id },
+        market,
+        { counterCurrency, counterValueUnit, usdToFiatRate, locale, t },
+      ),
+    );
   }, [assetsData, stablecoinTickers, counterCurrency, counterValueUnit, usdToFiatRate, locale, t]);
 
   const stocks = useMemo(
@@ -90,8 +78,8 @@ export function useGlobalSearchDefaults(enabled: boolean): GlobalSearchDefaults 
   );
 
   const defaultSections = useMemo<GlobalSearchDefaultSections>(
-    () => ({ cryptos, stablecoins, stocks }),
-    [cryptos, stablecoins, stocks],
+    () => ({ cryptos, stocks }),
+    [cryptos, stocks],
   );
 
   return {

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
@@ -27,7 +27,7 @@ jest.mock("LLM/features/GlobalSearch/hooks/useGlobalSearchResults");
 const mockedDefaults = jest.mocked(useGlobalSearchDefaults);
 const mockedResults = jest.mocked(useGlobalSearchResults);
 
-const EMPTY_SECTIONS = { cryptos: [], stablecoins: [], stocks: [] };
+const EMPTY_SECTIONS = { cryptos: [], stocks: [] };
 
 const resultsState = (overrides: Partial<GlobalSearchResults> = {}): GlobalSearchResults => ({
   search: "",
@@ -146,14 +146,6 @@ describe("useGlobalSearchViewModel", () => {
     act(() => result.current.onSeeAll("stocks"));
 
     expect(mockNavigate).toHaveBeenCalledWith(ScreenName.MarketList, { category: "stocks" });
-  });
-
-  it("does not navigate from the Stablecoins header (no Market category yet)", () => {
-    const { result } = renderHook(() => useGlobalSearchViewModel());
-
-    act(() => result.current.onSeeAll("stable"));
-
-    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it("opens asset detail and tracks asset_clicked from a tapped result row", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/DefaultSections/__tests__/DefaultSections.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/DefaultSections/__tests__/DefaultSections.test.tsx
@@ -26,7 +26,6 @@ const stock = (id: string, ticker: string): StockSuggestion => ({
 
 const sections = {
   cryptos: [asset("bitcoin", "BTC", "Bitcoin")],
-  stablecoins: [asset("tether", "USDT", "Tether")],
   stocks: [stock("aapl", "AAPL"), stock("tsla", "TSLA")],
 };
 
@@ -44,11 +43,10 @@ const renderSections = (overrides = {}) => {
 };
 
 describe("DefaultSections", () => {
-  it("renders crypto/stablecoin rows and stock pills", () => {
+  it("renders crypto rows and stock pills", () => {
     renderSections();
 
     expect(screen.getByTestId("global-search-asset-bitcoin")).toBeVisible();
-    expect(screen.getByTestId("global-search-asset-tether")).toBeVisible();
     expect(screen.getByTestId("global-search-stock-aapl")).toBeVisible();
     expect(screen.getByTestId("global-search-stock-tsla")).toBeVisible();
   });
@@ -57,12 +55,10 @@ describe("DefaultSections", () => {
     const { props, user } = renderSections();
 
     await user.press(screen.getByTestId(`${GLOBAL_SEARCH_TEST_IDS.cryptosSection}-header`));
-    await user.press(screen.getByTestId(`${GLOBAL_SEARCH_TEST_IDS.stablecoinsSection}-header`));
     await user.press(screen.getByTestId(`${GLOBAL_SEARCH_TEST_IDS.stocksSection}-header`));
 
     expect(props.onSeeAll).toHaveBeenNthCalledWith(1, "crypto");
-    expect(props.onSeeAll).toHaveBeenNthCalledWith(2, "stable");
-    expect(props.onSeeAll).toHaveBeenNthCalledWith(3, "stocks");
+    expect(props.onSeeAll).toHaveBeenNthCalledWith(2, "stocks");
   });
 
   it("calls onAssetPress and onStockPress on item taps", async () => {
@@ -78,7 +74,7 @@ describe("DefaultSections", () => {
   it("shows skeletons while loading", () => {
     renderSections({
       isLoading: true,
-      sections: { cryptos: [], stablecoins: [], stocks: [] },
+      sections: { cryptos: [], stocks: [] },
     });
 
     expect(screen.getAllByTestId("global-search-asset-skeleton").length).toBeGreaterThan(0);
@@ -86,7 +82,7 @@ describe("DefaultSections", () => {
   });
 
   it("shows the error state instead of the sections when the data fails", () => {
-    renderSections({ hasError: true, sections: { cryptos: [], stablecoins: [], stocks: [] } });
+    renderSections({ hasError: true, sections: { cryptos: [], stocks: [] } });
 
     expect(screen.getByTestId(GLOBAL_SEARCH_TEST_IDS.defaultsError)).toBeVisible();
     expect(screen.queryByTestId(GLOBAL_SEARCH_TEST_IDS.defaultSections)).toBeNull();
@@ -95,7 +91,7 @@ describe("DefaultSections", () => {
   it("hides empty sections when not loading", () => {
     renderSections({
       isLoading: false,
-      sections: { cryptos: [], stablecoins: [], stocks: [] },
+      sections: { cryptos: [], stocks: [] },
     });
 
     expect(screen.queryByTestId(GLOBAL_SEARCH_TEST_IDS.cryptosSection)).toBeNull();

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/DefaultSections/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/DefaultSections/index.tsx
@@ -60,16 +60,6 @@ export function DefaultSections({
           onSeeAll={onSeeAll}
           onAssetPress={onAssetPress}
         />
-        <AssetRowsSection
-          title={t("globalSearch.sections.stablecoins")}
-          testID={GLOBAL_SEARCH_TEST_IDS.stablecoinsSection}
-          assets={sections.stablecoins}
-          isLoading={isLoading}
-          skeletonCount={2}
-          category="stable"
-          onSeeAll={onSeeAll}
-          onAssetPress={onAssetPress}
-        />
         <StocksSection
           title={t("globalSearch.sections.stocks")}
           testID={GLOBAL_SEARCH_TEST_IDS.stocksSection}

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/testIds.ts
@@ -3,7 +3,6 @@ export const GLOBAL_SEARCH_TEST_IDS = {
   searchInput: "global-search-input",
   defaultSections: "global-search-default-sections",
   cryptosSection: "global-search-cryptos-section",
-  stablecoinsSection: "global-search-stablecoins-section",
   stocksSection: "global-search-stocks-section",
   searchResults: "global-search-results",
   searchSkeleton: "global-search-results-skeleton",

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/types.ts
@@ -3,6 +3,5 @@ import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
 
 export type GlobalSearchDefaultSections = {
   cryptos: MarketAssetDisplayData[];
-  stablecoins: MarketAssetDisplayData[];
   stocks: StockSuggestion[];
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
@@ -11,7 +11,7 @@ import { useGlobalSearchDefaults } from "LLM/features/GlobalSearch/hooks/useGlob
 import { useGlobalSearchResults } from "LLM/features/GlobalSearch/hooks/useGlobalSearchResults";
 import type { GlobalSearchDefaultSections } from "./types";
 
-export type GlobalSearchCategory = "crypto" | "stable" | "stocks";
+export type GlobalSearchCategory = "crypto" | "stocks";
 
 const SEARCH_FLOW = "global_search";
 
@@ -63,8 +63,6 @@ export function useGlobalSearchViewModel(): GlobalSearchViewModel {
   const onSeeAll = useCallback(
     (category: GlobalSearchCategory) => {
       track("button_clicked", { button: "See all", page: ScreenName.GlobalSearch, category });
-
-      if (category === "stable") return;
 
       navigation.navigate(ScreenName.MarketList, {
         category: category === "stocks" ? "stocks" : "all",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** GlobalSearch suite green (46 tests); updated DefaultSections / useGlobalSearchDefaults / useGlobalSearchViewModel tests.
- [x] **Impact of the changes:**
  - The **Stablecoins** section no longer appears in the LWM Global Search default view. Cryptos and Stocks sections are unchanged.

### 📝 Description

The Stablecoins section had been added to the mobile Global Search defaults but isn't wanted, so this removes it:

- Drop the stablecoins `AssetRowsSection` from `DefaultSections`, the `stablecoins` field from `GlobalSearchDefaultSections`, the `stablecoinsSection` test id, the `"stable"` member of `GlobalSearchCategory` (and its dead `onSeeAll` guard), and the now-unused `globalSearch.sections.stablecoins` i18n key.
- `useGlobalSearchDefaults` still classifies via stablecoin tickers (`maxStablecoins: 0`) so stablecoins keep being **excluded from the Cryptos list** — otherwise high-cap stablecoins (USDT/USDC) would leak into it.

<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/b9aba751-bcdb-4aec-af7f-9fa68028c750" />


### ❓ Context

- **JIRA**: [LIVE-32312](https://ledgerhq.atlassian.net/browse/LIVE-32312)


[LIVE-32312]: https://ledgerhq.atlassian.net/browse/LIVE-32312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ