### PR TITLE
[LWM] fix(mobile): auto-open the global search keyboard on android [LIVE-32339]

### DIFF
--- a/.changeset/lwm-global-search-android-keyboard.md
+++ b/.changeset/lwm-global-search-android-keyboard.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Global Search (mobile): auto-open the keyboard on Android. The search input now focuses once the screen's fade-in transition has finished, so the soft keyboard reliably appears on Android (iOS behaviour is unchanged).

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/__tests__/useAutoFocusOnEnter.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/__tests__/useAutoFocusOnEnter.test.ts
@@ -1,0 +1,105 @@
+import { renderHook } from "@tests/test-renderer";
+import { InteractionManager, Platform } from "react-native";
+import { useAutoFocusOnEnter } from "../useAutoFocusOnEnter";
+
+const mockAddListener = jest.fn();
+const mockGetParent = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ addListener: mockAddListener, getParent: mockGetParent }),
+}));
+
+const makeRef = (focus: jest.Mock) => ({ current: { focus } });
+
+type TransitionEndHandler = (e: { data: { closing: boolean } }) => void;
+
+describe("useAutoFocusOnEnter", () => {
+  const originalOS = Platform.OS;
+
+  beforeEach(() => {
+    mockGetParent.mockReturnValue(undefined);
+    mockAddListener.mockReturnValue(jest.fn());
+  });
+
+  afterEach(() => {
+    Platform.OS = originalOS;
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe("on iOS", () => {
+    beforeEach(() => {
+      Platform.OS = "ios";
+    });
+
+    it("focuses via InteractionManager, without a transition listener", () => {
+      const runAfterInteractions = jest.spyOn(InteractionManager, "runAfterInteractions");
+
+      renderHook(() => useAutoFocusOnEnter(makeRef(jest.fn())));
+
+      expect(runAfterInteractions).toHaveBeenCalledTimes(1);
+      expect(mockAddListener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("on Android", () => {
+    beforeEach(() => {
+      Platform.OS = "android";
+    });
+
+    it("focuses once when the enter transition ends, then unsubscribes", () => {
+      const focus = jest.fn();
+      const unsubscribe = jest.fn();
+      let handler: TransitionEndHandler = () => {};
+      mockAddListener.mockImplementation((event: string, cb: TransitionEndHandler) => {
+        if (event === "transitionEnd") handler = cb;
+        return unsubscribe;
+      });
+
+      renderHook(() => useAutoFocusOnEnter(makeRef(focus)));
+
+      expect(mockAddListener).toHaveBeenCalledWith("transitionEnd", expect.any(Function));
+      expect(focus).not.toHaveBeenCalled();
+
+      handler({ data: { closing: false } });
+
+      expect(focus).toHaveBeenCalledTimes(1);
+      expect(unsubscribe).toHaveBeenCalled();
+    });
+
+    it("does not focus while the screen is closing", () => {
+      const focus = jest.fn();
+      let handler: TransitionEndHandler = () => {};
+      mockAddListener.mockImplementation((_event: string, cb: TransitionEndHandler) => {
+        handler = cb;
+        return jest.fn();
+      });
+
+      renderHook(() => useAutoFocusOnEnter(makeRef(focus)));
+      handler({ data: { closing: true } });
+
+      expect(focus).not.toHaveBeenCalled();
+    });
+
+    it("listens on the parent stack (where the transition runs) when present", () => {
+      const parentAddListener = jest.fn(() => jest.fn());
+      mockGetParent.mockReturnValue({ addListener: parentAddListener });
+
+      renderHook(() => useAutoFocusOnEnter(makeRef(jest.fn())));
+
+      expect(parentAddListener).toHaveBeenCalledWith("transitionEnd", expect.any(Function));
+      expect(mockAddListener).not.toHaveBeenCalled();
+    });
+
+    it("unsubscribes from the transition listener on unmount", () => {
+      const unsubscribe = jest.fn();
+      mockAddListener.mockReturnValue(unsubscribe);
+
+      const { unmount } = renderHook(() => useAutoFocusOnEnter(makeRef(jest.fn())));
+      unmount();
+
+      expect(unsubscribe).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/useAutoFocusOnEnter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/useAutoFocusOnEnter.ts
@@ -1,0 +1,31 @@
+import { useEffect, type RefObject } from "react";
+import { InteractionManager, Platform, type TextInput } from "react-native";
+import { useNavigation, type ParamListBase } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+
+export function useAutoFocusOnEnter(ref: RefObject<Pick<TextInput, "focus"> | null>) {
+  const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>();
+
+  useEffect(() => {
+    const focusInput = () => ref.current?.focus();
+
+    if (Platform.OS === "ios") {
+      const task = InteractionManager.runAfterInteractions(focusInput);
+      return () => task.cancel();
+    }
+
+    // Android only opens the soft keyboard once the enter transition has finished,
+    // so focus on transitionEnd (the fade runs on the parent stack) rather than
+    // guessing a delay. Unsubscribe after the first focus so the screen, which
+    // stays mounted in history, isn't re-focused on later transitions.
+    const stack = navigation.getParent<NativeStackNavigationProp<ParamListBase>>() ?? navigation;
+    let unsubscribe = () => {};
+    unsubscribe = stack.addListener("transitionEnd", e => {
+      if (!e.data.closing) {
+        focusInput();
+        unsubscribe();
+      }
+    });
+    return () => unsubscribe();
+  }, [navigation, ref]);
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/GlobalSearchView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/GlobalSearchView.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useRef } from "react";
-import { InteractionManager, TextInput, View } from "react-native";
+import React, { useRef } from "react";
+import { TextInput, View } from "react-native";
 import { NavBarBackButton, SearchInput } from "@ledgerhq/lumen-ui-rnative";
 import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import { useExperimental } from "~/experimental";
+import { useAutoFocusOnEnter } from "LLM/features/GlobalSearch/hooks/useAutoFocusOnEnter";
 import { DefaultSections } from "./components/DefaultSections";
 import { SearchResults } from "./components/SearchResults";
 import { GLOBAL_SEARCH_TEST_IDS } from "./testIds";
@@ -32,6 +33,7 @@ export function GlobalSearchView({
   const insets = useSafeAreaInsets();
   const hasExperimentalHeader = useExperimental();
   const inputRef = useRef<TextInput>(null);
+  useAutoFocusOnEnter(inputRef);
 
   const styles = useStyleSheet(
     theme => ({
@@ -56,13 +58,6 @@ export function GlobalSearchView({
   );
 
   const topPadding = hasExperimentalHeader ? 0 : insets.top;
-
-  useEffect(() => {
-    const task = InteractionManager.runAfterInteractions(() => {
-      inputRef.current?.focus();
-    });
-    return () => task.cancel();
-  }, []);
 
   return (
     <View testID={GLOBAL_SEARCH_TEST_IDS.screen} style={styles.container}>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** New `useAutoFocusOnEnter` unit tests (iOS + Android branches); GlobalSearch suite green.
- [x] **Impact of the changes:**
  - On **Android**, opening Global Search now auto-opens the keyboard. **iOS** behaviour is unchanged.

### 📝 Description

On Android the soft keyboard didn't auto-open when entering Global Search. Focus ran via `InteractionManager.runAfterInteractions`, which resolves as soon as JS interactions settle — but the screen's **fade-in transition** (`animation: "fade"`, set on the GlobalSearch screen in `BaseNavigator`) is a native animation that isn't a JS interaction. So `focus()` fired mid-transition: the input got the cursor but Android didn't raise the keyboard. iOS raises it regardless, which is why it worked there.

Extracted the focus logic into a `useAutoFocusOnEnter` hook with platform-specific behaviour:
- **iOS** — keep focusing once interactions settle (unchanged).
- **Android** — focus on the navigation **`transitionEnd`** event (listened on the parent stack that runs the fade), so it fires exactly when the animation finishes rather than after a guessed delay.

Android:

https://github.com/user-attachments/assets/7115c349-f83e-4c28-bc23-be03089ba868

IOS (no change): 

https://github.com/user-attachments/assets/8968b7a0-a8eb-48bc-9bf0-af0f438077dc




### ❓ Context

- **JIRA**: [LIVE-32339](https://ledgerhq.atlassian.net/browse/LIVE-32339)


[LIVE-32339]: https://ledgerhq.atlassian.net/browse/LIVE-32339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ