### PR TITLE
[LWD] feat(LIVE-31786): support for Aleo token accounts in LWD

### DIFF
--- a/.changeset/long-tomatoes-shave.md
+++ b/.changeset/long-tomatoes-shave.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat: support for Aleo token accounts in LWD

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/AccountBalanceSummaryFooter.test.tsx
@@ -2,12 +2,17 @@ import BigNumber from "bignumber.js";
 import React from "react";
 import { act, fireEvent, render, screen } from "tests/testSetup";
 import * as currencies from "@ledgerhq/live-common/currencies/index";
-import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
+import type {
+  AleoAccount,
+  AleoTokenAccount,
+  AleoCoinConfig,
+} from "@ledgerhq/live-common/families/aleo/types";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
 import { PRIVATE_BALANCE_PLACEHOLDER } from "./constants";
 import { useAleoPrivateSync } from "./hooks/useAleoPrivateSync";
 import { ALEO_ACCOUNT_1, ALEO_TOKEN_ACCOUNT } from "./__mocks__/account.mock";
+import { getAleoCurrencyConfig } from "./shared/utils";
 
 jest.mock("~/renderer/hooks/useAccountUnit");
 jest.mock("@ledgerhq/live-common/currencies/index", () => ({
@@ -15,9 +20,14 @@ jest.mock("@ledgerhq/live-common/currencies/index", () => ({
   ...jest.requireActual("@ledgerhq/live-common/currencies/index"),
 }));
 jest.mock("./hooks/useAleoPrivateSync");
+jest.mock("./shared/utils", () => ({
+  ...jest.requireActual("./shared/utils"),
+  getAleoCurrencyConfig: jest.fn(),
+}));
 
 const mockUseAccountUnit = jest.mocked(useAccountUnit);
 const mockUseAleoPrivateSync = jest.mocked(useAleoPrivateSync);
+const mockGetAleoCurrencyConfig = jest.mocked(getAleoCurrencyConfig);
 
 describe("AccountBalanceSummaryFooter", () => {
   const mockSpendableBalance = BigNumber(100);
@@ -38,6 +48,7 @@ describe("AccountBalanceSummaryFooter", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetAleoCurrencyConfig.mockReturnValue(undefined);
 
     mockStart = jest.fn();
     mockStop = jest.fn();
@@ -83,7 +94,7 @@ describe("AccountBalanceSummaryFooter", () => {
     expect(screen.getByText("***")).toBeInTheDocument();
   });
 
-  it("should return null when account type is not Account", () => {
+  it("should return null for token accounts when token config flag is disabled", () => {
     const { container } = render(<AccountBalanceSummaryFooter account={ALEO_TOKEN_ACCOUNT} />, {
       initialState: { accounts: [mockAccount] },
     });
@@ -97,6 +108,30 @@ describe("AccountBalanceSummaryFooter", () => {
     );
 
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should display transparent and private balances for token accounts when token config flag is enabled", () => {
+    mockGetAleoCurrencyConfig.mockReturnValue({ enableTokens: true } as AleoCoinConfig);
+
+    const tokenBalance = BigNumber(42);
+    const transparentBalance = BigNumber(30);
+    const tokenAccount: AleoTokenAccount = {
+      ...ALEO_TOKEN_ACCOUNT,
+      spendableBalance: tokenBalance,
+      balance: tokenBalance,
+      transparentBalance,
+    };
+
+    render(<AccountBalanceSummaryFooter account={tokenAccount} />, {
+      initialState: { accounts: [mockAccount] },
+    });
+
+    expect(screen.getByText("Available balance")).toBeInTheDocument();
+    expect(screen.getByText("Transparent balance")).toBeInTheDocument();
+    expect(screen.getByText(`formatted: ${tokenBalance}`)).toBeInTheDocument();
+    expect(screen.getByText(`formatted: ${transparentBalance}`)).toBeInTheDocument();
+    expect(screen.getAllByText(PRIVATE_BALANCE_PLACEHOLDER).length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: "Start sync" })).not.toBeInTheDocument();
   });
 
   describe("sync button", () => {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/AccountBalanceSummaryFooter.tsx
@@ -2,9 +2,8 @@ import React, { useEffect, useRef, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { useSelector } from "LLD/hooks/redux";
-import { getParentAccount } from "@ledgerhq/live-common/account/helpers";
-import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
-import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
+import type { formatCurrencyUnitOptions } from "@ledgerhq/live-common/currencies/index";
+import type { AleoAccount, AleoTokenAccount } from "@ledgerhq/live-common/families/aleo/types";
 import type { TokenAccount } from "@ledgerhq/types-live";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import { localeSelector } from "~/renderer/reducers/settings";
@@ -17,8 +16,9 @@ import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import { dayAndHourFormat, useDateFormatter } from "~/renderer/hooks/useDateFormatter";
 import ButtonV3 from "~/renderer/components/ButtonV3";
 import Spinner from "~/renderer/components/Spinner";
-import { PRIVATE_BALANCE_PLACEHOLDER } from "./constants";
+import { getAccountCurrency, getParentAccount } from "@ledgerhq/live-common/account/helpers";
 import { useAleoPrivateSync } from "./hooks/useAleoPrivateSync";
+import { getAleoCurrencyConfig, formatAleoBalances } from "./shared/utils";
 
 type AleoSyncState = "ready" | "running" | "complete";
 
@@ -111,6 +111,30 @@ const SyncProgress = ({
   return null;
 };
 
+const BalanceRow = ({
+  titleKey,
+  tooltipKey,
+  formattedValue,
+}: {
+  titleKey: string;
+  tooltipKey: string;
+  formattedValue: string;
+}) => (
+  <BalanceDetail>
+    <ToolTip content={<Trans i18nKey={tooltipKey} />}>
+      <TitleWrapper>
+        <Title>
+          <Trans i18nKey={titleKey} />
+        </Title>
+        <InfoCircle size={13} />
+      </TitleWrapper>
+    </ToolTip>
+    <AmountValue>
+      <Discreet>{formattedValue}</Discreet>
+    </AmountValue>
+  </BalanceDetail>
+);
+
 interface Props {
   account: AleoAccount | TokenAccount;
 }
@@ -123,6 +147,14 @@ const AccountBalanceSummaryFooter = ({ account }: Readonly<Props>) => {
 
   const mainAccount =
     account.type === "TokenAccount" ? getParentAccount(account, allAccounts) : account;
+  const config = getAleoCurrencyConfig(getAccountCurrency(account));
+  const formatConfig: formatCurrencyUnitOptions = {
+    alwaysShowSign: false,
+    showCode: true,
+    discreet,
+    disableRounding: true,
+    locale,
+  };
 
   const {
     isSyncing,
@@ -153,71 +185,72 @@ const AccountBalanceSummaryFooter = ({ account }: Readonly<Props>) => {
     };
   }, [isSyncing]);
 
+  if (account.type === "TokenAccount" && config?.enableTokens) {
+    const aleoTokenAccount = account as AleoTokenAccount;
+    const formattedBalances = formatAleoBalances({
+      unit,
+      formatConfig,
+      balances: {
+        spendableBalance: aleoTokenAccount.spendableBalance,
+        transparentBalance: aleoTokenAccount.transparentBalance,
+        privateBalance: aleoTokenAccount.privateBalance,
+      },
+    });
+
+    return (
+      <Wrapper>
+        <BalanceRow
+          titleKey="aleo.account.availableBalance"
+          tooltipKey="aleo.account.availableBalanceTooltip"
+          formattedValue={formattedBalances.available}
+        />
+        <BalanceRow
+          titleKey="aleo.account.transparentBalance"
+          tooltipKey="aleo.account.transparentBalanceTooltip"
+          formattedValue={formattedBalances.transparent}
+        />
+        <BalanceRow
+          titleKey="aleo.account.privateBalance"
+          tooltipKey="aleo.account.privateBalanceTooltip"
+          formattedValue={formattedBalances.private}
+        />
+      </Wrapper>
+    );
+  }
+
   if (account.type !== "Account" || !account.aleoResources) {
     return null;
   }
 
-  const formatConfig = {
-    alwaysShowSign: false,
-    showCode: true,
-    discreet,
-    locale,
-  };
-
-  const spendableBalance = account.spendableBalance;
-  const transparentBalance = account.aleoResources.transparentBalance;
-  const privateBalance = account.aleoResources.privateBalance;
-
-  const formattedAvailableBalance = formatCurrencyUnit(unit, spendableBalance, formatConfig);
-  const formattedTransparentBalance = formatCurrencyUnit(unit, transparentBalance, formatConfig);
-  const formattedPrivateBalance = privateBalance
-    ? formatCurrencyUnit(unit, privateBalance, formatConfig)
-    : PRIVATE_BALANCE_PLACEHOLDER;
-
   const lastSync = account.aleoResources.lastPrivateSyncDate ?? null;
   const syncState: AleoSyncState = displaySyncing ? "running" : lastSync ? "complete" : "ready";
+  const formattedBalances = formatAleoBalances({
+    unit,
+    formatConfig,
+    balances: {
+      spendableBalance: account.spendableBalance,
+      transparentBalance: account.aleoResources.transparentBalance,
+      privateBalance: account.aleoResources.privateBalance,
+    },
+  });
 
   return (
     <Wrapper>
-      <BalanceDetail>
-        <ToolTip content={<Trans i18nKey="aleo.account.availableBalanceTooltip" />}>
-          <TitleWrapper>
-            <Title>
-              <Trans i18nKey="aleo.account.availableBalance" />
-            </Title>
-            <InfoCircle size={13} />
-          </TitleWrapper>
-        </ToolTip>
-        <AmountValue>
-          <Discreet>{formattedAvailableBalance}</Discreet>
-        </AmountValue>
-      </BalanceDetail>
-      <BalanceDetail>
-        <ToolTip content={<Trans i18nKey="aleo.account.transparentBalanceTooltip" />}>
-          <TitleWrapper>
-            <Title>
-              <Trans i18nKey="aleo.account.transparentBalance" />
-            </Title>
-            <InfoCircle size={13} />
-          </TitleWrapper>
-        </ToolTip>
-        <AmountValue>
-          <Discreet>{formattedTransparentBalance}</Discreet>
-        </AmountValue>
-      </BalanceDetail>
-      <BalanceDetail>
-        <ToolTip content={<Trans i18nKey="aleo.account.privateBalanceTooltip" />}>
-          <TitleWrapper>
-            <Title>
-              <Trans i18nKey="aleo.account.privateBalance" />
-            </Title>
-            <InfoCircle size={13} />
-          </TitleWrapper>
-        </ToolTip>
-        <AmountValue>
-          <Discreet>{formattedPrivateBalance}</Discreet>
-        </AmountValue>
-      </BalanceDetail>
+      <BalanceRow
+        titleKey="aleo.account.availableBalance"
+        tooltipKey="aleo.account.availableBalanceTooltip"
+        formattedValue={formattedBalances.available}
+      />
+      <BalanceRow
+        titleKey="aleo.account.transparentBalance"
+        tooltipKey="aleo.account.transparentBalanceTooltip"
+        formattedValue={formattedBalances.transparent}
+      />
+      <BalanceRow
+        titleKey="aleo.account.privateBalance"
+        tooltipKey="aleo.account.privateBalanceTooltip"
+        formattedValue={formattedBalances.private}
+      />
       <BalanceDetail>
         <div
           style={{

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/SelfTransferModal/SelfTransferStepRecipient.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/SelfTransferModal/SelfTransferStepRecipient.test.tsx
@@ -8,7 +8,7 @@ import { trackPage } from "~/renderer/analytics/segment";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import type { StepProps } from "~/renderer/modals/Send/types";
 import { SelfTransferStepRecipient } from "./SelfTransferStepRecipient";
-import { ALEO_ACCOUNT_1 } from "../__mocks__/account.mock";
+import { ALEO_ACCOUNT_1, ALEO_MAIN_ACCOUNT, ALEO_TOKEN_ACCOUNT } from "../__mocks__/account.mock";
 import { makeAleoTransaction } from "../__mocks__/transaction.mock";
 
 jest.mock("~/renderer/hooks/useAccountUnit");
@@ -131,6 +131,58 @@ describe("SelfTransferStepRecipient", () => {
     const updaterFn = updateTransaction.mock.calls[0][0];
     const result = updaterFn(convertPrivateToPublicTransaction);
     expect(result.mode).toBe(TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE);
+    expect(result).not.toHaveProperty("properties");
+  });
+
+  it("should call updateTransaction with CONVERT_TOKEN_PRIVATE_TO_PUBLIC when token balance selector switches to private", async () => {
+    const tokenTransaction = makeAleoTransaction({
+      mode: TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE,
+      subAccountId: ALEO_TOKEN_ACCOUNT.id,
+    });
+    const updateTransaction = jest.fn();
+    const { user } = render(
+      <SelfTransferStepRecipient
+        {...defaultProps}
+        account={ALEO_TOKEN_ACCOUNT}
+        parentAccount={ALEO_MAIN_ACCOUNT}
+        transaction={tokenTransaction}
+        updateTransaction={updateTransaction}
+      />,
+    );
+
+    const switchButton = screen.getByRole("button", { name: /switch balance source/i });
+    await user.click(switchButton);
+
+    expect(updateTransaction).toHaveBeenCalledTimes(1);
+    const updaterFn = updateTransaction.mock.calls[0][0];
+    const result = updaterFn(tokenTransaction);
+    expect(result.mode).toBe(TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC);
+    expect(result.properties).toEqual({ amountRecordCommitments: [], feeRecordCommitment: null });
+  });
+
+  it("should call updateTransaction with CONVERT_TOKEN_PUBLIC_TO_PRIVATE when token balance selector switches to public", async () => {
+    const tokenTransaction = makeAleoTransaction({
+      mode: TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC,
+      subAccountId: ALEO_TOKEN_ACCOUNT.id,
+    });
+    const updateTransaction = jest.fn();
+    const { user } = render(
+      <SelfTransferStepRecipient
+        {...defaultProps}
+        account={ALEO_TOKEN_ACCOUNT}
+        parentAccount={ALEO_MAIN_ACCOUNT}
+        transaction={tokenTransaction}
+        updateTransaction={updateTransaction}
+      />,
+    );
+
+    const switchButton = screen.getByRole("button", { name: /switch balance source/i });
+    await user.click(switchButton);
+
+    expect(updateTransaction).toHaveBeenCalledTimes(1);
+    const updaterFn = updateTransaction.mock.calls[0][0];
+    const result = updaterFn(tokenTransaction);
+    expect(result.mode).toBe(TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE);
     expect(result).not.toHaveProperty("properties");
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/SelfTransferModal/SelfTransferStepRecipient.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/SelfTransferModal/SelfTransferStepRecipient.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/account/index";
-import { TRANSACTION_TYPE } from "@ledgerhq/live-common/families/aleo/constants";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import CurrencyDownStatusAlert from "~/renderer/components/CurrencyDownStatusAlert";
@@ -10,6 +9,7 @@ import SelectAccount from "~/renderer/components/SelectAccount";
 import type { StepProps } from "~/renderer/modals/Send/types";
 import type { AccountLike } from "@ledgerhq/types-live";
 import BalanceSelector from "../shared/BalanceSelector";
+import { applyAleoBalanceSourceChange, getAleoCurrencyConfig } from "../shared/utils";
 import { Trans } from "react-i18next";
 
 export const SelfTransferStepRecipient = ({
@@ -29,6 +29,7 @@ export const SelfTransferStepRecipient = ({
   }
 
   const mainAccount = getMainAccount(account, parentAccount);
+  const config = getAleoCurrencyConfig(mainAccount.currency);
 
   // show only Aleo accounts
   const accountFilter = (acc: AccountLike) => {
@@ -58,6 +59,11 @@ export const SelfTransferStepRecipient = ({
             onChange={onChangeAccount}
             value={account}
             filter={accountFilter}
+            {...(config?.enableTokens && {
+              withSubAccounts: true,
+              enforceHideEmptySubAccounts: true,
+              subAccountFilter: a => !a.balance.isZero(),
+            })}
           />
         </Box>
         <Box>
@@ -67,26 +73,11 @@ export const SelfTransferStepRecipient = ({
           <BalanceSelector
             transaction={transaction}
             mainAccount={mainAccount}
+            subAccount={account.type === "TokenAccount" ? account : undefined}
             onChange={value => {
-              updateTransaction(t => {
-                if (t.family !== "aleo") return t;
-
-                if (value === "public") {
-                  const { properties: _ignoredProperties, ...txWithoutProperties } = t;
-                  return {
-                    ...txWithoutProperties,
-                    mode: TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE,
-                  };
-                }
-
-                return {
-                  ...t,
-                  mode: TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC,
-                  properties: {
-                    amountRecordCommitments: [],
-                    feeRecordCommitment: null,
-                  },
-                };
+              updateTransaction(tx => {
+                if (tx.family !== "aleo") return tx;
+                return applyAleoBalanceSourceChange(tx, value);
               });
             }}
           />

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/SendTransferModal/AleoSendStepRecipient.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/SendTransferModal/AleoSendStepRecipient.test.tsx
@@ -8,7 +8,7 @@ import { trackPage } from "~/renderer/analytics/segment";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import type { StepProps } from "~/renderer/modals/Send/types";
 import { AleoSendStepRecipient } from "./AleoSendStepRecipient";
-import { ALEO_ACCOUNT_1 } from "../__mocks__/account.mock";
+import { ALEO_ACCOUNT_1, ALEO_MAIN_ACCOUNT, ALEO_TOKEN_ACCOUNT } from "../__mocks__/account.mock";
 import { makeAleoTransaction } from "../__mocks__/transaction.mock";
 
 jest.mock("~/renderer/hooks/useAccountUnit");
@@ -197,6 +197,58 @@ describe("AleoSendStepRecipient", () => {
     const result = updaterFn(privateTransaction);
     expect(result.mode).toBe(TRANSACTION_TYPE.TRANSFER_PUBLIC);
 
+    expect(result).not.toHaveProperty("properties");
+  });
+
+  it("should call updateTransaction with TRANSFER_TOKEN_PRIVATE when switching token account to private balance", async () => {
+    const tokenTransaction = makeAleoTransaction({
+      mode: TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC,
+      subAccountId: ALEO_TOKEN_ACCOUNT.id,
+    });
+    const updateTransaction = jest.fn();
+    const { user } = render(
+      <AleoSendStepRecipient
+        {...defaultProps}
+        account={ALEO_TOKEN_ACCOUNT}
+        parentAccount={ALEO_MAIN_ACCOUNT}
+        transaction={tokenTransaction}
+        updateTransaction={updateTransaction}
+      />,
+    );
+
+    const privateOption = screen.getByText(/Private balance/);
+    await user.click(privateOption);
+
+    expect(updateTransaction).toHaveBeenCalledTimes(1);
+    const updaterFn = updateTransaction.mock.calls[0][0];
+    const result = updaterFn(tokenTransaction);
+    expect(result.mode).toBe(TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE);
+    expect(result.properties).toEqual({ amountRecordCommitments: [], feeRecordCommitment: null });
+  });
+
+  it("should call updateTransaction with TRANSFER_TOKEN_PUBLIC when switching token account to public balance", async () => {
+    const tokenTransaction = makeAleoTransaction({
+      mode: TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE,
+      subAccountId: ALEO_TOKEN_ACCOUNT.id,
+    });
+    const updateTransaction = jest.fn();
+    const { user } = render(
+      <AleoSendStepRecipient
+        {...defaultProps}
+        account={ALEO_TOKEN_ACCOUNT}
+        parentAccount={ALEO_MAIN_ACCOUNT}
+        transaction={tokenTransaction}
+        updateTransaction={updateTransaction}
+      />,
+    );
+
+    const publicOption = screen.getByText(/Public balance/);
+    await user.click(publicOption);
+
+    expect(updateTransaction).toHaveBeenCalledTimes(1);
+    const updaterFn = updateTransaction.mock.calls[0][0];
+    const result = updaterFn(tokenTransaction);
+    expect(result.mode).toBe(TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC);
     expect(result).not.toHaveProperty("properties");
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/SendTransferModal/AleoSendStepRecipient.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/SendTransferModal/AleoSendStepRecipient.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Trans } from "react-i18next";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { TRANSACTION_TYPE } from "@ledgerhq/live-common/families/aleo/constants";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import CurrencyDownStatusAlert from "~/renderer/components/CurrencyDownStatusAlert";
@@ -12,6 +11,7 @@ import type { StepProps } from "~/renderer/modals/Send/types";
 import RecipientField from "~/renderer/modals/Send/fields/RecipientField";
 import SendRecipientFields from "~/renderer/modals/Send/SendRecipientFields";
 import BalanceSelector from "../shared/BalanceSelector";
+import { applyAleoBalanceSourceChange, getAleoCurrencyConfig } from "../shared/utils";
 
 export const AleoSendStepRecipient = ({
   t,
@@ -32,7 +32,9 @@ export const AleoSendStepRecipient = ({
     return null;
   }
 
+  const isTokenAccount = account.type === "TokenAccount";
   const mainAccount = getMainAccount(account, parentAccount);
+  const config = getAleoCurrencyConfig(mainAccount.currency);
 
   return (
     <Box flow={4}>
@@ -52,6 +54,11 @@ export const AleoSendStepRecipient = ({
             autoFocus={!openedFromAccount}
             onChange={onChangeAccount}
             value={account}
+            {...(config?.enableTokens && {
+              withSubAccounts: true,
+              enforceHideEmptySubAccounts: true,
+              subAccountFilter: a => !a.balance.isZero(),
+            })}
           />
         </Box>
         <Box>
@@ -61,26 +68,11 @@ export const AleoSendStepRecipient = ({
           <BalanceSelector
             transaction={transaction}
             mainAccount={mainAccount}
+            subAccount={isTokenAccount ? account : undefined}
             onChange={value => {
-              updateTransaction(t => {
-                if (t.family !== "aleo") return t;
-
-                if (value === "public") {
-                  const { properties: _ignoredProperties, ...txWithoutProperties } = t;
-                  return {
-                    ...txWithoutProperties,
-                    mode: TRANSACTION_TYPE.TRANSFER_PUBLIC,
-                  };
-                }
-
-                return {
-                  ...t,
-                  mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
-                  properties: {
-                    amountRecordCommitments: [],
-                    feeRecordCommitment: null,
-                  },
-                };
+              updateTransaction(tx => {
+                if (tx.family !== "aleo") return tx;
+                return applyAleoBalanceSourceChange(tx, value);
               });
             }}
           />

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepSummaryRecipientValue.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepSummaryRecipientValue.test.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import { render, screen } from "tests/testSetup";
 import { TRANSACTION_TYPE } from "@ledgerhq/live-common/families/aleo/constants";
 import { isSelfTransferTransaction } from "@ledgerhq/live-common/families/aleo/utils";
-import { ALEO_ACCOUNT_1, ALEO_ACCOUNT_2 } from "../../../__mocks__/account.mock";
+import {
+  ALEO_ACCOUNT_1,
+  ALEO_ACCOUNT_2,
+  ALEO_MAIN_ACCOUNT,
+  ALEO_TOKEN_ACCOUNT,
+} from "../../../__mocks__/account.mock";
 import { makeAleoTransaction } from "../../../__mocks__/transaction.mock";
 import StepSummaryRecipientValue from "./StepSummaryRecipientValue";
 
@@ -40,6 +45,26 @@ describe("StepSummaryRecipientValue", () => {
     expect(
       screen.getByText(`${ALEO_ACCOUNT_2.currency.name} ${ALEO_ACCOUNT_2.index + 1}`),
     ).toBeInTheDocument();
+    expect(screen.getByTestId("recipient-badge")).toBeInTheDocument();
+  });
+
+  it("should render token name and badge for token self-transfer recipient", () => {
+    mockedIsSelfTransferTransaction.mockReturnValue(true);
+
+    render(
+      <StepSummaryRecipientValue
+        account={ALEO_TOKEN_ACCOUNT}
+        parentAccount={ALEO_MAIN_ACCOUNT}
+        transaction={makeAleoTransaction({
+          mode: TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE,
+          subAccountId: ALEO_TOKEN_ACCOUNT.id,
+          recipient: ALEO_MAIN_ACCOUNT.freshAddress,
+        })}
+      />,
+      { initialState: { accounts: [ALEO_MAIN_ACCOUNT] } },
+    );
+
+    expect(screen.getByText(ALEO_TOKEN_ACCOUNT.token.name)).toBeInTheDocument();
     expect(screen.getByTestId("recipient-badge")).toBeInTheDocument();
   });
 

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepSummaryRecipientValue.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepSummaryRecipientValue.tsx
@@ -24,7 +24,8 @@ type Props = {
 };
 
 const StepSummaryRecipientValue = ({ account, parentAccount, transaction }: Props) => {
-  const currencyId = getMainAccount(account, parentAccount).currency.id;
+  const mainAccount = getMainAccount(account, parentAccount);
+  const currencyId = mainAccount.currency.id;
   const matchingRecipientAccount = useSelector((state): Account | undefined => {
     const accounts = flattenAccountsSelector(state).filter(
       (candidate): candidate is Account => candidate.type === "Account",
@@ -36,24 +37,36 @@ const StepSummaryRecipientValue = ({ account, parentAccount, transaction }: Prop
       );
     });
   });
-  const matchingRecipientAccountName = useMaybeAccountName(matchingRecipientAccount);
+
+  const isSelfTransfer = isSelfTransferTransaction(transaction);
+
+  // For self-transfers the sender IS the recipient - fall back to mainAccount when no address match
+  const recipientAccount: Account | undefined = isSelfTransfer
+    ? (matchingRecipientAccount ?? mainAccount)
+    : matchingRecipientAccount;
+
+  const recipientAccountName = useMaybeAccountName(recipientAccount);
+
+  const isTokenAccount = account.type === "TokenAccount";
+  const displayCurrency = isTokenAccount ? account.token : recipientAccount?.currency;
+  const displayName = isTokenAccount ? account.token.name : recipientAccountName;
 
   const shouldShowAccountName =
-    isSelfTransferTransaction(transaction) &&
-    Boolean(matchingRecipientAccountName) &&
-    !!matchingRecipientAccount;
+    isSelfTransfer && !!displayName && (isTokenAccount || !!recipientAccount);
 
-  if (shouldShowAccountName && matchingRecipientAccount) {
+  if (shouldShowAccountName) {
     return (
       <Box horizontal alignItems="center" style={{ minWidth: 0 }}>
-        <RecipientIconWrapper>
-          <CryptoCurrencyIcon size={22} currency={matchingRecipientAccount.currency} />
-        </RecipientIconWrapper>
+        {displayCurrency && (
+          <RecipientIconWrapper>
+            <CryptoCurrencyIcon size={22} currency={displayCurrency} />
+          </RecipientIconWrapper>
+        )}
         <Ellipsis ff="Inter" color="neutral.c100" fontSize={4} data-testid="recipient-address">
-          {matchingRecipientAccountName}
+          {displayName}
         </Ellipsis>
         <StepSummaryAddressBadge transaction={transaction} direction="to" />
-        <AccountTagDerivationMode account={matchingRecipientAccount} />
+        {recipientAccount && <AccountTagDerivationMode account={recipientAccount} />}
       </Box>
     );
   }
@@ -65,7 +78,7 @@ const StepSummaryRecipientValue = ({ account, parentAccount, transaction }: Prop
       fontSize={4}
       data-testid="recipient-address"
     >
-      {shouldShowAccountName ? matchingRecipientAccountName : transaction.recipient}
+      {transaction.recipient}
     </Ellipsis>
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/useAccountChangeGuard.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/useAccountChangeGuard.test.ts
@@ -6,9 +6,17 @@ import {
 import { TRANSACTION_TYPE } from "@ledgerhq/live-common/families/aleo/constants";
 import { useAccountChangeGuard } from "./useAccountChangeGuard";
 import { makeAleoTransaction } from "../../../__mocks__/transaction.mock";
-import { ALEO_ACCOUNT_1, ALEO_ACCOUNT_2 } from "../../../__mocks__/account.mock";
+import {
+  ALEO_ACCOUNT_1,
+  ALEO_ACCOUNT_2,
+  ALEO_TOKEN_ACCOUNT,
+} from "../../../__mocks__/account.mock";
 
-jest.mock("@ledgerhq/live-common/families/aleo/utils");
+jest.mock("@ledgerhq/live-common/families/aleo/utils", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/families/aleo/utils"),
+  isSelfTransferTransaction: jest.fn(),
+  isPrivateTransaction: jest.fn(),
+}));
 
 const mockIsSelfTransferTransaction = jest.mocked(isSelfTransferTransaction);
 const mockIsPrivateTransaction = jest.mocked(isPrivateTransaction);
@@ -81,6 +89,25 @@ describe("useAccountChangeGuard", () => {
     const nextTx = updater(tx);
 
     expect(nextTx.mode).toBe(TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE);
+    expect(nextTx.properties).toBeUndefined();
+  });
+
+  it("should reset a private token self-transfer to CONVERT_TOKEN_PUBLIC_TO_PRIVATE", () => {
+    mockIsPrivateTransaction.mockReturnValue(true);
+    mockIsSelfTransferTransaction.mockReturnValue(true);
+    const { result } = renderHook(() => useAccountChangeGuard(onChangeAccount, updateTransaction));
+
+    result.current(ALEO_ACCOUNT_2, null);
+
+    const updater = updateTransaction.mock.calls[0][0];
+    const tx = makeAleoTransaction({
+      mode: TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC,
+      subAccountId: ALEO_TOKEN_ACCOUNT.id,
+      properties: { amountRecordCommitments: ["abc"], feeRecordCommitment: null },
+    });
+    const nextTx = updater(tx);
+
+    expect(nextTx.mode).toBe(TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE);
     expect(nextTx.properties).toBeUndefined();
   });
 

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/useAccountChangeGuard.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/useAccountChangeGuard.ts
@@ -1,9 +1,9 @@
 import { useCallback } from "react";
 import {
-  isSelfTransferTransaction,
+  derivePublicTransactionMode,
   isPrivateTransaction,
+  isSelfTransferTransaction,
 } from "@ledgerhq/live-common/families/aleo/utils";
-import { TRANSACTION_TYPE } from "@ledgerhq/live-common/families/aleo/constants";
 import type { StepProps } from "~/renderer/modals/Send/types";
 
 /**
@@ -24,11 +24,14 @@ export const useAccountChangeGuard = (
       onChangeAccount(nextAccount, nextParentAccount);
       updateTransaction(tx => {
         if (tx.family !== "aleo" || !isPrivateTransaction(tx)) return tx;
-        const defaultMode = isSelfTransferTransaction(tx)
-          ? TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE
-          : TRANSACTION_TYPE.TRANSFER_PUBLIC;
+
+        const publicMode = derivePublicTransactionMode({
+          isTokenTx: !!tx.subAccountId,
+          isSelfTransfer: isSelfTransferTransaction(tx),
+        });
         const { properties: _drop, ...publicTx } = tx;
-        return { ...publicTx, mode: defaultMode };
+
+        return { ...publicTx, mode: publicMode };
       });
     },
     [onChangeAccount, updateTransaction],

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/BalanceSelector.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/BalanceSelector.tsx
@@ -12,12 +12,14 @@ import {
   isSelfTransferTransaction,
 } from "@ledgerhq/live-common/families/aleo/utils";
 import type { AleoAccount, Transaction } from "@ledgerhq/live-common/families/aleo/types";
+import type { AccountLike } from "@ledgerhq/types-live";
 import StepRecipientSeparator from "~/renderer/components/StepRecipientSeparator";
-import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import { useAccountUnit, useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import { useSelector } from "LLD/hooks/redux";
 import { localeSelector } from "~/renderer/reducers/settings";
 import { dayFormat, hourFormat, useDateFormatter } from "~/renderer/hooks/useDateFormatter";
 import { PRIVATE_BALANCE_PLACEHOLDER } from "../constants";
+import { isAleoAccount } from "./utils";
 import { BalanceOption } from "./BalanceOption";
 import BalanceOptionsSwitch from "./BalanceOptionsSwitch";
 
@@ -26,12 +28,15 @@ type Source = "public" | "private";
 interface Props {
   transaction: Transaction;
   mainAccount: AleoAccount;
+  subAccount?: AccountLike | null;
   onChange: (value: Source) => void;
 }
 
-const BalanceSelector = ({ mainAccount, transaction, onChange }: Props) => {
+const BalanceSelector = ({ mainAccount, subAccount, transaction, onChange }: Props) => {
   const { t } = useTranslation();
-  const unit = useAccountUnit(mainAccount);
+  const mainUnit = useAccountUnit(mainAccount);
+  const subAccountUnit = useMaybeAccountUnit(subAccount);
+  const unit = subAccountUnit ?? mainUnit;
   const locale = useSelector(localeSelector);
   const formatDate = useDateFormatter(dayFormat);
   const formatTime = useDateFormatter(hourFormat);
@@ -42,13 +47,21 @@ const BalanceSelector = ({ mainAccount, transaction, onChange }: Props) => {
     locale,
   };
 
-  const privateBalance = mainAccount?.aleoResources?.privateBalance ?? null;
-  const transparentBalance = mainAccount?.aleoResources?.transparentBalance ?? new BigNumber(0);
+  const aleoTokenAccount =
+    subAccount?.type === "TokenAccount" && isAleoAccount(subAccount) ? subAccount : null;
+
+  const transparentBalance =
+    aleoTokenAccount?.transparentBalance ??
+    mainAccount?.aleoResources?.transparentBalance ??
+    new BigNumber(0);
+  const privateBalance =
+    aleoTokenAccount?.privateBalance ?? mainAccount?.aleoResources?.privateBalance ?? null;
+
+  const formattedTransparentBalance = formatCurrencyUnit(unit, transparentBalance, formatConfig);
   const formattedPrivateBalance =
     privateBalance !== null
       ? formatCurrencyUnit(unit, privateBalance, formatConfig)
       : PRIVATE_BALANCE_PLACEHOLDER;
-  const formattedTransparentBalance = formatCurrencyUnit(unit, transparentBalance, formatConfig);
 
   const publicSyncDate = t("aleo.shared.balanceSelector.recently");
   const privateSyncDate = mainAccount.aleoResources?.lastPrivateSyncDate

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/QuickAmountSelector.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/QuickAmountSelector.tsx
@@ -126,10 +126,12 @@ const QuickAmountSelector = ({ account, transaction, updateTransaction, onSelect
       .filter(r => new BigNumber(r.microcredits).isGreaterThan(0))
       .sort((a, b) => new BigNumber(b.microcredits).comparedTo(a.microcredits));
   }, [account]);
+
   const spendableRecords = useMemo(
     () => sortedRecords.slice(0, MAX_PRIVATE_RECORDS_PER_TRANSACTION),
     [sortedRecords],
   );
+
   const totalSpendableBalance = sumPrivateRecords(spendableRecords);
   const totalRecords = sortedRecords.length;
   const selectedRecordsCount =

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.test.ts
@@ -114,6 +114,10 @@ describe("isAleoAccount", () => {
   it("should return true for a plain Aleo account without aleoResources", () => {
     expect(isAleoAccount(ALEO_ACCOUNT_1)).toBe(true);
   });
+
+  it("should return true for token account", () => {
+    expect(isAleoAccount(ALEO_TOKEN_ACCOUNT)).toBe(true);
+  });
 });
 
 describe("isAleoTransaction", () => {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.test.ts
@@ -3,7 +3,7 @@ import { getCurrencyConfiguration } from "@ledgerhq/live-common/config/index";
 import { TRANSACTION_TYPE } from "@ledgerhq/live-common/families/aleo/constants";
 import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { ALEO_ACCOUNT_1 } from "../__mocks__/account.mock";
+import { ALEO_ACCOUNT_1, ALEO_TOKEN_ACCOUNT } from "../__mocks__/account.mock";
 import { mockAleoCoinConfig } from "../__mocks__/config.mock";
 import { aleoCurrency } from "../__mocks__/currency.mock";
 import { makeAleoTransaction } from "../__mocks__/transaction.mock";
@@ -12,7 +12,10 @@ import {
   getAleoCurrencyConfig,
   isAleoAccount,
   isAleoTransaction,
+  applyAleoBalanceSourceChange,
+  formatAleoBalances,
 } from "./utils";
+import { PRIVATE_BALANCE_PLACEHOLDER } from "../constants";
 
 jest.mock("@ledgerhq/live-common/config/index");
 
@@ -123,5 +126,129 @@ describe("isAleoTransaction", () => {
       // @ts-expect-error - testing invalid family
       isAleoTransaction({ ...makeAleoTransaction(), family: "bitcoin" }),
     ).toBe(false);
+  });
+});
+
+describe("applyAleoBalanceSourceChange", () => {
+  it.each([
+    [
+      "native send to public",
+      TRANSACTION_TYPE.TRANSFER_PUBLIC,
+      "public",
+      makeAleoTransaction({ mode: TRANSACTION_TYPE.TRANSFER_PUBLIC }),
+      false,
+    ],
+    [
+      "native send to private",
+      TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      "private",
+      makeAleoTransaction({ mode: TRANSACTION_TYPE.TRANSFER_PUBLIC }),
+      true,
+    ],
+    [
+      "native self-transfer to public",
+      TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE,
+      "public",
+      makeAleoTransaction({ mode: TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE }),
+      false,
+    ],
+    [
+      "native self-transfer to private",
+      TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC,
+      "private",
+      makeAleoTransaction({ mode: TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE }),
+      true,
+    ],
+    [
+      "token send to public",
+      TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC,
+      "public",
+      makeAleoTransaction({
+        mode: TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC,
+        subAccountId: ALEO_TOKEN_ACCOUNT.id,
+      }),
+      false,
+    ],
+    [
+      "token send to private",
+      TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE,
+      "private",
+      makeAleoTransaction({
+        mode: TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC,
+        subAccountId: ALEO_TOKEN_ACCOUNT.id,
+      }),
+      true,
+    ],
+    [
+      "token self-transfer to public",
+      TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE,
+      "public",
+      makeAleoTransaction({
+        mode: TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE,
+        subAccountId: ALEO_TOKEN_ACCOUNT.id,
+      }),
+      false,
+    ],
+    [
+      "token self-transfer to private",
+      TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC,
+      "private",
+      makeAleoTransaction({
+        mode: TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE,
+        subAccountId: ALEO_TOKEN_ACCOUNT.id,
+      }),
+      true,
+    ],
+  ] as const)(
+    "%s sets mode to %s and %s properties",
+    (_label, expectedMode, source, transaction, expectProperties) => {
+      const result = applyAleoBalanceSourceChange(transaction, source);
+
+      expect(result.mode).toBe(expectedMode);
+
+      if (expectProperties) {
+        expect(result.properties).toEqual({
+          amountRecordCommitments: [],
+          feeRecordCommitment: null,
+        });
+      } else {
+        expect(result).not.toHaveProperty("properties");
+      }
+    },
+  );
+});
+
+describe("formatAleoBalances", () => {
+  const unit = aleoCurrency.units[0];
+  const formatConfig = { showCode: true, locale: "en-US" };
+
+  it("returns formatted strings for all balances when privateBalance is known", () => {
+    const result = formatAleoBalances({
+      unit,
+      formatConfig,
+      balances: {
+        spendableBalance: new BigNumber(1_000_000),
+        transparentBalance: new BigNumber(500_000),
+        privateBalance: new BigNumber(250_000),
+      },
+    });
+
+    expect(result.available).toContain(unit.code);
+    expect(result.transparent).toContain(unit.code);
+    expect(result.private).toContain(unit.code);
+  });
+
+  it("returns placeholder for private when privateBalance is null", () => {
+    const result = formatAleoBalances({
+      unit,
+      formatConfig,
+      balances: {
+        spendableBalance: new BigNumber(1_000_000),
+        transparentBalance: new BigNumber(500_000),
+        privateBalance: null,
+      },
+    });
+
+    expect(result.private).toBe(PRIVATE_BALANCE_PLACEHOLDER);
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.ts
@@ -1,7 +1,17 @@
+import type { BigNumber } from "bignumber.js";
 import { getCurrencyConfiguration } from "@ledgerhq/live-common/config/index";
 import { isCryptoCurrency } from "@ledgerhq/live-common/currencies/helpers";
+import {
+  formatCurrencyUnit,
+  type formatCurrencyUnitOptions,
+} from "@ledgerhq/live-common/currencies/index";
 import { TRANSACTION_TYPE } from "@ledgerhq/live-common/families/aleo/constants";
-import { isPrivateTransaction } from "@ledgerhq/live-common/families/aleo/utils";
+import {
+  derivePrivateTransactionMode,
+  derivePublicTransactionMode,
+  isPrivateTransaction,
+  isSelfTransferTransaction,
+} from "@ledgerhq/live-common/families/aleo/utils";
 import type {
   AleoAccount,
   AleoCoinConfig,
@@ -9,9 +19,10 @@ import type {
   Transaction as AleoTransaction,
 } from "@ledgerhq/live-common/families/aleo/types";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
-import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoCurrency, TokenCurrency, Unit } from "@ledgerhq/types-cryptoassets";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import type { AccountLike } from "@ledgerhq/types-live";
+import { PRIVATE_BALANCE_PLACEHOLDER } from "../constants";
 
 export const getAleoCurrencyConfig = (
   currency: CryptoCurrency | TokenCurrency,
@@ -53,4 +64,52 @@ export function getAleoAddressBadgeI18nKey(
     direction === "from" ? isPrivateTransaction(transaction) : isPrivateDestination(transaction);
 
   return isPrivate ? "aleo.operations.type.private" : "aleo.operations.type.public";
+}
+
+export function applyAleoBalanceSourceChange(
+  transaction: AleoTransaction,
+  source: "public" | "private",
+): AleoTransaction {
+  const isSelfTransfer = isSelfTransferTransaction(transaction);
+  const isTokenTx = !!transaction.subAccountId;
+
+  if (source === "public") {
+    const { properties: _ignoredProperties, ...txWithoutProperties } = transaction;
+
+    return {
+      ...txWithoutProperties,
+      mode: derivePublicTransactionMode({ isTokenTx, isSelfTransfer }),
+    };
+  }
+
+  return {
+    ...transaction,
+    mode: derivePrivateTransactionMode({ isTokenTx, isSelfTransfer }),
+    properties: {
+      amountRecordCommitments: [],
+      feeRecordCommitment: null,
+    },
+  };
+}
+
+export function formatAleoBalances({
+  unit,
+  balances,
+  formatConfig,
+}: {
+  unit: Unit;
+  formatConfig: formatCurrencyUnitOptions;
+  balances: {
+    spendableBalance: BigNumber;
+    transparentBalance: BigNumber;
+    privateBalance: BigNumber | null;
+  };
+}) {
+  return {
+    available: formatCurrencyUnit(unit, balances.spendableBalance, formatConfig),
+    transparent: formatCurrencyUnit(unit, balances.transparentBalance, formatConfig),
+    private: balances.privateBalance
+      ? formatCurrencyUnit(unit, balances.privateBalance, formatConfig)
+      : PRIVATE_BALANCE_PLACEHOLDER,
+  };
 }

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
@@ -8,7 +8,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
-import { isCryptoCurrency } from "@ledgerhq/live-common/currencies/helpers";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
@@ -224,9 +223,8 @@ const Body = ({
   const [signed, setSigned] = useState(false);
   const currency = account ? getAccountCurrency(account) : undefined;
   const currencyName = currency ? currency.name : undefined;
-  const specific = useLLDCoinFamily(
-    currency && isCryptoCurrency(currency) ? currency.family : undefined,
-  );
+  const mainAccount = account ? getMainAccount(account, parentAccount) : null;
+  const specific = useLLDCoinFamily(mainAccount?.currency.family);
 
   const [defaultSteps] = useState(() => defaultCreateSteps(params.disableBacks));
   const customSteps = useMemo(() => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Aleo token accounts should be handled properly in LWD (tokens are not enabled yet)

### 📝 Description

This PR adds Aleo token account support to the LWD:
- AccountBalanceSummaryFooter now handles TokenAccount in addition to the main Aleo account, rendering the same three balance rows (available, transparent, private) by reading balances from the token account's fields. The repeated JSX for each row was extracted into a local BalanceRow component. Balance formatting was extracted into a shared formatAleoBalances helper in shared/utils.ts.
- BalanceSelector now accepts an optional subAccount prop and reads transparent/private balances from it when present, falling back to the main account's aleoResources. It also picks the correct currency unit from the sub-account when one is passed.
- Both AleoSendStepRecipient and SelfTransferStepRecipient gained token account awareness: when enableTokens is set in currency config they pass withSubAccounts, enforceHideEmptySubAccounts, and a filter to the account selector, and they pass the resolved sub-account down to BalanceSelector. The inline mode-switching logic in onChange was replaced with a call to the new applyAleoBalanceSourceChange helper, eliminating duplicated code between the two modals.
- useAccountChangeGuard replaced its hardcoded TRANSACTION_TYPE constant with a call to derivePublicTransactionMode, passing isTokenTx derived from subAccountId.
- StepSummaryRecipientValue now handles the case where the active account is a TokenAccount: it uses the token's name and icon as the display currency, and resolves
  the self-transfer recipient account correctly even when no address match is found.
- Send/Body.tsx was fixed to derive specific (coin-family overrides) from the main account's currency family rather than the active account's currency, so token
  accounts don't lose their family-specific UI steps. A small parenthesisation fix was also included there.
- Two new shared helpers were added to shared/utils.ts: applyAleoBalanceSourceChange (centralises public/private mode switching for both send and self-transfer) and formatAleoBalances (centralises formatting of the three balance values). Tests were expanded across all touched components.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-31786

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
