### PR TITLE
[LWM] fix(mobile): market banner favorites filter no longer errors [LIVE-32391]

### DIFF
--- a/.changeset/lwm-market-banner-favorites.md
+++ b/.changeset/lwm-market-banner-favorites.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the Market Banner Favorites filter erroring on mobile. The favorites request sent an invalid `pageSize` to the market endpoint (the tile count `× 2`, not one of the supported 1/5/20/50 values), which returned an error. Favorites now request a valid page size and, like desktop, show starred coins even when not buyable/swappable.

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/__integrations__/marketBanner.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/__integrations__/marketBanner.integration.test.tsx
@@ -198,6 +198,38 @@ describe("MarketBanner Integration Tests", () => {
         expect(store.getState().marketBanner.ranking).toBe("trending");
       });
     });
+
+    it("should request favorites with a valid pageSize (the /v3/markets endpoint only accepts 1/5/20/50)", async () => {
+      let favoritesPageSize: string | null = null;
+      server.use(
+        http.get(`${COUNTERVALUES_API}/v3/markets`, ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("ids")) {
+            favoritesPageSize = url.searchParams.get("pageSize");
+          }
+          return HttpResponse.json(MOCK_MARKET_PERFORMERS);
+        }),
+      );
+
+      renderWithReactQuery(<MarketBannerTest />, {
+        overrideInitialState: state => {
+          const flagged = withFlagOverrides({
+            lwmWallet40: {
+              enabled: true,
+              params: { marketBanner: true, assetDiscoverability: true },
+            },
+          })(state);
+          return {
+            ...flagged,
+            marketBanner: { ...flagged.marketBanner, ranking: "favorites" },
+            settings: { ...flagged.settings, starredMarketCoins: ["bitcoin", "ethereum"] },
+          };
+        },
+      });
+
+      await waitFor(() => expect(favoritesPageSize).not.toBeNull());
+      expect(["1", "5", "20", "50"]).toContain(favoritesPageSize);
+    });
   });
 
   describe("Loading state", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/hooks/useMarketBannerData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/hooks/useMarketBannerData.ts
@@ -23,6 +23,9 @@ import { MARKET_BANNER_TILE_COUNT } from "../constants";
 
 const LIMIT = MARKET_BANNER_TILE_COUNT * 2;
 
+/** `useMarketData` (the /v3/markets endpoint) only accepts pageSize 1 / 5 / 20 / 50. */
+const MARKET_BANNER_FAVORITES_LIMIT = 50;
+
 export type MarketBannerItems = {
   items: MarketItemPerformer[];
   isError: boolean;
@@ -92,27 +95,29 @@ export function usePerformersBannerItems(ranking: MarketBannerRanking): MarketBa
 /**
  * Favorites ranking → the user's starred assets. Backed by React Query (`useMarketData`),
  * so this hook must only be mounted when the favorites ranking is actually active.
+ * Availability filtering is bypassed so a starred coin shows even when not buyable/swappable.
  */
 export function useFavoritesBannerItems(): MarketBannerItems {
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const starredMarketCoins = useSelector(starredMarketCoinsSelector);
-  const filterItems = useMarketAvailabilityFilter();
 
   const sortedStarredIds = useMemo(
     () => [...starredMarketCoins].sort((a, b) => a.localeCompare(b)),
     [starredMarketCoins],
   );
 
-  const { data, isError } = useMarketData({
-    counterCurrency: counterValueCurrency.ticker.toLowerCase(),
-    range: "24h",
-    order: Order.MarketCapDesc,
-    limit: LIMIT,
-    liveCompatible: true,
-    starred: sortedStarredIds,
-  });
+  const { data, isError, isFetching } = useMarketData(
+    {
+      counterCurrency: counterValueCurrency.ticker.toLowerCase(),
+      range: "24h",
+      order: Order.MarketCapDesc,
+      limit: MARKET_BANNER_FAVORITES_LIMIT,
+      starred: sortedStarredIds,
+    },
+    { enabled: sortedStarredIds.length > 0 },
+  );
 
-  const items = useMemo(() => filterItems(data.map(toPerformer)), [filterItems, data]);
+  const items = useMemo(() => data.map(toPerformer).slice(0, MARKET_BANNER_TILE_COUNT), [data]);
 
-  return { items, isError };
+  return { items, isError: isError && !isFetching };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added a MarketBanner integration test asserting favorites request a valid `pageSize`; suite green (51 tests).
- [x] **Impact of the changes:**
  - The Market Banner **Favorites** filter now works on mobile (was erroring). Trending / Gainers / Losers are unchanged.

### 🐛 Description

**Bug:** add favorites → filter the Market Banner by Favorites → error state instead of the favorites (works on desktop).

**Root cause:** the favorites ranking fetches via `useMarketData` (the `/v3/markets` endpoint), whose `pageSize` only accepts **1 / 5 / 20 / 50**. Mobile passed `limit: MARKET_BANNER_TILE_COUNT * 2` (= **14**) → `pageSize=14` → the request failed → error state. Performers rankings use a different endpoint (`useMarketPerformers`) with no such constraint, so only Favorites was affected. Desktop already uses a dedicated `50` limit for favorites, which is why it works.

**Fix** (aligns mobile with the working desktop `useFavoritesBannerItems`):
- Request a valid `pageSize` (`MARKET_BANNER_FAVORITES_LIMIT = 50`), then cap to the tile count client-side.
- Bypass the availability filter and drop `liveCompatible` for favorites, so a starred coin shows even when it isn't buyable/swappable (matches desktop).


https://github.com/user-attachments/assets/f651d337-5e0a-45af-bc84-b7990e691610


### ❓ Context

- **JIRA**: [LIVE-32391](https://ledgerhq.atlassian.net/browse/LIVE-32391)


[LIVE-32391]: https://ledgerhq.atlassian.net/browse/LIVE-32391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ