### PR TITLE
[LWD] fix(desktop): re-arm market list pagination and reset scroll on list change

### DIFF
--- a/.changeset/market-list-pagination-reset.md
+++ b/.changeset/market-list-pagination-reset.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix Market list pagination and scroll position when switching lists (category, sort, range, search, filter): re-arm the pagination guard and reset scroll to the top on list identity change, and detect the end of every list type by tracking whether new rows arrived

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/__integrations__/Market.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/__integrations__/Market.integration.test.tsx
@@ -41,9 +41,12 @@ jest.mock("LLD/features/Market/hooks/useMarketListVirtualization.ts", () => ({
         })),
       getTotalSize: () => (marketData?.length ?? 0) * LIST_ITEM_HEIGHT,
     });
+    const rowVirtualizer = createVirtualizer();
     return {
       parentRef: { current: null },
-      rowVirtualizer: createVirtualizer(),
+      rowVirtualizer,
+      virtualItems: rowVirtualizer.getVirtualItems(),
+      totalSize: rowVirtualizer.getTotalSize(),
     };
   },
 }));

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/ListData.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/ListData.tsx
@@ -1,10 +1,11 @@
 import React, { memo } from "react";
-import { Virtualizer } from "@tanstack/react-virtual";
+import type { VirtualItem } from "@tanstack/react-virtual";
 import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
 import { RowItem } from "./RowItem";
 
 type ListDataProps = {
-  rowVirtualizer: Virtualizer<HTMLDivElement, Element>;
+  virtualItems: VirtualItem[];
+  totalSize: number;
   marketData: MarketCurrencyData[];
   starredMarketCoins: string[];
   counterCurrency?: string;
@@ -14,7 +15,8 @@ type ListDataProps = {
 };
 
 export const ListData = memo<ListDataProps>(function ListData({
-  rowVirtualizer,
+  virtualItems,
+  totalSize,
   marketData,
   starredMarketCoins,
   counterCurrency,
@@ -25,13 +27,13 @@ export const ListData = memo<ListDataProps>(function ListData({
   return (
     <div
       style={{
-        height: `${rowVirtualizer.getTotalSize()}px`,
+        height: `${totalSize}px`,
         width: "100%",
         position: "relative",
       }}
       data-testid="market-list-data"
     >
-      {rowVirtualizer.getVirtualItems().map(virtualRow => {
+      {virtualItems.map(virtualRow => {
         const currency = marketData[virtualRow.index];
         if (!currency) return null;
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketListLegacy.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketListLegacy.tsx
@@ -11,6 +11,7 @@ export default function MarketListLegacy(props: Readonly<MarketListLegacyProps>)
     marketData: props.marketData,
     loading: props.loading,
     currenciesLength: props.currenciesLength,
+    listKey: props.listKey,
     onLoadNextPage: props.onLoadNextPage,
     checkIfDataIsStaleAndRefetch: props.checkIfDataIsStaleAndRefetch,
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/useMarketTableViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/useMarketTableViewModel.test.ts
@@ -24,6 +24,7 @@ function createData(overrides: Partial<MarketTableData> = {}): MarketTableData {
     loading: false,
     currenciesLength: MOCK_MARKET_CURRENCY_DATA.length,
     itemCount: MOCK_MARKET_CURRENCY_DATA.length,
+    listKey: "all",
     starredMarketCoins: ["bitcoin"],
     resetSearch: jest.fn(),
     refresh: jest.fn(),

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/useMarketTableViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/useMarketTableViewModel.ts
@@ -16,6 +16,7 @@ export type MarketTableData = {
   loading: boolean;
   currenciesLength: number;
   itemCount: number;
+  listKey: string;
   emptyState?: "favorites";
   starredMarketCoins: string[];
   resetSearch: () => void;
@@ -45,6 +46,7 @@ export function useMarketTableViewModel({
   loading,
   currenciesLength,
   itemCount,
+  listKey,
   emptyState,
   starredMarketCoins,
   resetSearch,
@@ -61,6 +63,7 @@ export function useMarketTableViewModel({
     marketData,
     loading,
     currenciesLength,
+    listKey,
     onLoadNextPage,
     checkIfDataIsStaleAndRefetch,
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/__tests__/ListData.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/__tests__/ListData.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { render, screen } from "tests/testSetup";
-import type { Virtualizer } from "@tanstack/react-virtual";
 import { ListData } from "../ListData";
 import { MOCK_MARKET_CURRENCY_DATA } from "@ledgerhq/live-common/market/utils/fixtures";
 
@@ -22,21 +21,6 @@ function createVirtualItem(index: number, start: number, size: number) {
   return { index, start, size, end: start + size, key: index, lane: 0 };
 }
 
-function createMockVirtualizer(
-  virtualItems: Array<ReturnType<typeof createVirtualItem>>,
-  totalSize = 1000,
-) {
-  const getVirtualItemsFn = Object.assign(() => virtualItems, {
-    updateDeps: (_newDeps: [number[], unknown[]]) => {},
-  });
-  // @ts-expect-error partial mock for testing
-  const mock: Virtualizer<HTMLDivElement, Element> = {
-    getTotalSize: () => totalSize,
-    getVirtualItems: getVirtualItemsFn,
-  };
-  return mock;
-}
-
 describe("ListData", () => {
   const starredMarketCoins: string[] = [];
   const defaultProps = {
@@ -46,6 +30,7 @@ describe("ListData", () => {
     locale: "en",
     range: "24h",
     toggleStar: jest.fn(),
+    totalSize: 1000,
   };
 
   beforeEach(() => {
@@ -53,46 +38,36 @@ describe("ListData", () => {
   });
 
   it("should render all currencies from virtualizer items", () => {
-    const rowVirtualizer = createMockVirtualizer([
-      createVirtualItem(0, 0, 50),
-      createVirtualItem(1, 50, 50),
-    ]);
+    const virtualItems = [createVirtualItem(0, 0, 50), createVirtualItem(1, 50, 50)];
 
-    render(<ListData {...defaultProps} rowVirtualizer={rowVirtualizer} />);
+    render(<ListData {...defaultProps} virtualItems={virtualItems} />);
 
     expect(screen.getByTestId("market-BTC-row")).toBeVisible();
     expect(screen.getByTestId("market-ETH-row")).toBeVisible();
   });
 
   it("should render currency name and ticker", () => {
-    const rowVirtualizer = createMockVirtualizer([createVirtualItem(0, 0, 50)]);
-
-    render(<ListData {...defaultProps} rowVirtualizer={rowVirtualizer} />);
+    render(<ListData {...defaultProps} virtualItems={[createVirtualItem(0, 0, 50)]} />);
 
     expect(screen.getByText("Bitcoin")).toBeVisible();
     expect(screen.getByText("BTC")).toBeVisible();
   });
 
   it("should skip rendering when currency is undefined", () => {
-    const rowVirtualizer = createMockVirtualizer([
-      createVirtualItem(0, 0, 50),
-      createVirtualItem(5, 50, 50),
-    ]);
+    const virtualItems = [createVirtualItem(0, 0, 50), createVirtualItem(5, 50, 50)];
 
-    render(<ListData {...defaultProps} rowVirtualizer={rowVirtualizer} />);
+    render(<ListData {...defaultProps} virtualItems={virtualItems} />);
 
     expect(screen.getByTestId("market-BTC-row")).toBeVisible();
     expect(screen.getAllByRole("row")).toHaveLength(1);
   });
 
   it("should render star button for starred currency", () => {
-    const rowVirtualizer = createMockVirtualizer([createVirtualItem(0, 0, 50)]);
-
     render(
       <ListData
         {...defaultProps}
         starredMarketCoins={["bitcoin"]}
-        rowVirtualizer={rowVirtualizer}
+        virtualItems={[createVirtualItem(0, 0, 50)]}
       />,
     );
 
@@ -100,19 +75,20 @@ describe("ListData", () => {
   });
 
   it("should render star button for non-starred currency", () => {
-    const rowVirtualizer = createMockVirtualizer([createVirtualItem(0, 0, 50)]);
-
-    render(<ListData {...defaultProps} rowVirtualizer={rowVirtualizer} />);
+    render(<ListData {...defaultProps} virtualItems={[createVirtualItem(0, 0, 50)]} />);
 
     expect(screen.getByTestId("market-BTC-star-button")).toBeVisible();
   });
 
   it("should call toggleStar with correct arguments when star button is clicked", async () => {
     const toggleStar = jest.fn();
-    const rowVirtualizer = createMockVirtualizer([createVirtualItem(0, 0, 50)]);
 
     const { user } = render(
-      <ListData {...defaultProps} toggleStar={toggleStar} rowVirtualizer={rowVirtualizer} />,
+      <ListData
+        {...defaultProps}
+        toggleStar={toggleStar}
+        virtualItems={[createVirtualItem(0, 0, 50)]}
+      />,
     );
 
     await user.click(screen.getByTestId("market-BTC-star-button"));
@@ -121,14 +97,13 @@ describe("ListData", () => {
 
   it("should call toggleStar with isStarred=true for starred coins", async () => {
     const toggleStar = jest.fn();
-    const rowVirtualizer = createMockVirtualizer([createVirtualItem(0, 0, 50)]);
 
     const { user } = render(
       <ListData
         {...defaultProps}
         starredMarketCoins={["bitcoin"]}
         toggleStar={toggleStar}
-        rowVirtualizer={rowVirtualizer}
+        virtualItems={[createVirtualItem(0, 0, 50)]}
       />,
     );
 
@@ -137,9 +112,7 @@ describe("ListData", () => {
   });
 
   it("should set container height from virtualizer total size", () => {
-    const rowVirtualizer = createMockVirtualizer([], 500);
-
-    render(<ListData {...defaultProps} rowVirtualizer={rowVirtualizer} />);
+    render(<ListData {...defaultProps} virtualItems={[]} totalSize={500} />);
 
     const container = screen.getByTestId("market-list-data");
     expect(container).toHaveStyle({ height: "500px" });

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarketListVirtualization.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarketListVirtualization.test.ts
@@ -2,9 +2,16 @@
  * @jest-environment jsdom
  */
 import { renderHook, waitFor } from "tests/testSetup";
+import type { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
 import { useMarketListVirtualization } from "../useMarketListVirtualization";
 import { mockDomMeasurements, setRefCurrent } from "LLD/features/__tests__/shared";
 import { MOCK_MARKET_CURRENCY_DATA } from "@ledgerhq/live-common/market/utils/fixtures";
+
+const buildData = (count: number): MarketCurrencyData[] =>
+  Array.from(
+    { length: count },
+    (_, index) => ({ ...MOCK_MARKET_CURRENCY_DATA[0], id: `asset-${index}` }) as MarketCurrencyData,
+  );
 
 describe("useMarketListVirtualization", () => {
   const mockOnLoadNextPage = jest.fn();
@@ -25,6 +32,7 @@ describe("useMarketListVirtualization", () => {
         marketData: MOCK_MARKET_CURRENCY_DATA,
         loading: false,
         currenciesLength: 2,
+        listKey: "all",
         onLoadNextPage: mockOnLoadNextPage,
         checkIfDataIsStaleAndRefetch: mockCheckIfDataIsStaleAndRefetch,
       }),
@@ -38,12 +46,13 @@ describe("useMarketListVirtualization", () => {
 
   it("should call onLoadNextPage when reaching the end of the list", async () => {
     const { result, rerender } = renderHook(
-      ({ itemCount, marketData, loading, currenciesLength }) =>
+      ({ itemCount, marketData, loading, currenciesLength, listKey }) =>
         useMarketListVirtualization({
           itemCount,
           marketData,
           loading,
           currenciesLength,
+          listKey,
           onLoadNextPage: mockOnLoadNextPage,
           checkIfDataIsStaleAndRefetch: mockCheckIfDataIsStaleAndRefetch,
         }),
@@ -53,6 +62,7 @@ describe("useMarketListVirtualization", () => {
           marketData: MOCK_MARKET_CURRENCY_DATA,
           loading: false,
           currenciesLength: 2,
+          listKey: "all",
         },
       },
     );
@@ -74,11 +84,107 @@ describe("useMarketListVirtualization", () => {
       marketData: MOCK_MARKET_CURRENCY_DATA,
       loading: false,
       currenciesLength: 2,
+      listKey: "all",
     });
 
     await waitFor(() => {
       expect(mockOnLoadNextPage).toHaveBeenCalled();
     });
+  });
+
+  it("should call onLoadNextPage for a category list (itemCount equals currenciesLength)", async () => {
+    const { result, rerender } = renderHook(() =>
+      useMarketListVirtualization({
+        itemCount: MOCK_MARKET_CURRENCY_DATA.length,
+        marketData: MOCK_MARKET_CURRENCY_DATA,
+        loading: false,
+        currenciesLength: MOCK_MARKET_CURRENCY_DATA.length,
+        listKey: "infrastructure",
+        onLoadNextPage: mockOnLoadNextPage,
+        checkIfDataIsStaleAndRefetch: mockCheckIfDataIsStaleAndRefetch,
+      }),
+    );
+
+    const mockParentElement = document.createElement("div");
+    Object.defineProperty(mockParentElement, "scrollTop", {
+      writable: true,
+      value: 0,
+    });
+    Object.defineProperty(mockParentElement, "scrollHeight", {
+      writable: true,
+      value: 1000,
+    });
+
+    setRefCurrent(result.current.parentRef, mockParentElement);
+    rerender();
+
+    await waitFor(() => {
+      expect(mockOnLoadNextPage).toHaveBeenCalled();
+    });
+  });
+
+  it("stops fetching once a page returns no new rows (ref guard end-detection)", async () => {
+    const { result, rerender } = renderHook(
+      ({ listKey }: { listKey: string }) =>
+        useMarketListVirtualization({
+          itemCount: MOCK_MARKET_CURRENCY_DATA.length,
+          marketData: MOCK_MARKET_CURRENCY_DATA,
+          loading: false,
+          currenciesLength: MOCK_MARKET_CURRENCY_DATA.length,
+          listKey,
+          onLoadNextPage: mockOnLoadNextPage,
+          checkIfDataIsStaleAndRefetch: mockCheckIfDataIsStaleAndRefetch,
+        }),
+      { initialProps: { listKey: "all" } },
+    );
+
+    const mockParentElement = document.createElement("div");
+    Object.defineProperty(mockParentElement, "scrollTop", { writable: true, value: 0 });
+    setRefCurrent(result.current.parentRef, mockParentElement);
+
+    rerender({ listKey: "all" });
+    await waitFor(() => expect(mockOnLoadNextPage).toHaveBeenCalledTimes(1));
+
+    // Same list, same data (no new rows arrived) -> the ref guard must not request another page.
+    rerender({ listKey: "all" });
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(mockOnLoadNextPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets scroll and re-arms pagination when the list identity changes (even for a shorter list)", async () => {
+    const longList = buildData(10);
+    const shortList = buildData(5);
+
+    const { result, rerender } = renderHook(
+      ({ marketData, listKey }: { marketData: MarketCurrencyData[]; listKey: string }) =>
+        useMarketListVirtualization({
+          itemCount: marketData.length,
+          marketData,
+          loading: false,
+          currenciesLength: marketData.length,
+          listKey,
+          onLoadNextPage: mockOnLoadNextPage,
+          checkIfDataIsStaleAndRefetch: mockCheckIfDataIsStaleAndRefetch,
+        }),
+      { initialProps: { marketData: longList, listKey: "all" } },
+    );
+
+    const mockParentElement = document.createElement("div");
+    Object.defineProperty(mockParentElement, "scrollTop", { writable: true, value: 500 });
+    setRefCurrent(result.current.parentRef, mockParentElement);
+
+    // First list: reaching the end advances the internal fetch guard.
+    rerender({ marketData: longList, listKey: "all" });
+    await waitFor(() => expect(mockOnLoadNextPage).toHaveBeenCalled());
+
+    mockOnLoadNextPage.mockClear();
+
+    // Switch list -> shorter data. The absolute index guard would stay stuck (10 < 5 is false);
+    // the list-identity change must re-arm it and reset the scroll position to the top.
+    rerender({ marketData: shortList, listKey: "infrastructure" });
+
+    await waitFor(() => expect(mockOnLoadNextPage).toHaveBeenCalled());
+    expect(mockParentElement.scrollTop).toBe(0);
   });
 
   it("should not call onLoadNextPage when loading is true", async () => {
@@ -88,6 +194,7 @@ describe("useMarketListVirtualization", () => {
         marketData: MOCK_MARKET_CURRENCY_DATA,
         loading: true,
         currenciesLength: 2,
+        listKey: "all",
         onLoadNextPage: mockOnLoadNextPage,
         checkIfDataIsStaleAndRefetch: mockCheckIfDataIsStaleAndRefetch,
       }),
@@ -105,35 +212,11 @@ describe("useMarketListVirtualization", () => {
         marketData: MOCK_MARKET_CURRENCY_DATA,
         loading: false,
         currenciesLength: 0,
+        listKey: "all",
         onLoadNextPage: mockOnLoadNextPage,
         checkIfDataIsStaleAndRefetch: mockCheckIfDataIsStaleAndRefetch,
       }),
     );
-
-    await new Promise(resolve => setTimeout(resolve, 100));
-
-    expect(mockOnLoadNextPage).not.toHaveBeenCalled();
-  });
-
-  it("should not call onLoadNextPage when itemCount equals currenciesLength", async () => {
-    const { result } = renderHook(() =>
-      useMarketListVirtualization({
-        itemCount: 2,
-        marketData: MOCK_MARKET_CURRENCY_DATA,
-        loading: false,
-        currenciesLength: 2,
-        onLoadNextPage: mockOnLoadNextPage,
-        checkIfDataIsStaleAndRefetch: mockCheckIfDataIsStaleAndRefetch,
-      }),
-    );
-
-    const mockParentElement = document.createElement("div");
-    Object.defineProperty(mockParentElement, "scrollTop", {
-      writable: true,
-      value: 0,
-    });
-
-    setRefCurrent(result.current.parentRef, mockParentElement);
 
     await new Promise(resolve => setTimeout(resolve, 100));
 
@@ -149,6 +232,7 @@ describe("useMarketListVirtualization", () => {
         marketData: MOCK_MARKET_CURRENCY_DATA,
         loading: false,
         currenciesLength: 2,
+        listKey: "all",
         onLoadNextPage: mockOnLoadNextPage,
         checkIfDataIsStaleAndRefetch: customCallback,
       }),
@@ -178,6 +262,7 @@ describe("useMarketListVirtualization", () => {
         marketData: MOCK_MARKET_CURRENCY_DATA,
         loading: false,
         currenciesLength: 2,
+        listKey: "all",
         onLoadNextPage: mockOnLoadNextPage,
         checkIfDataIsStaleAndRefetch: customCallback,
       }),

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
@@ -123,6 +123,20 @@ export function useMarket() {
   const loading = !isFavoritesEmpty && marketResult.isLoading;
   const isError = marketResult.isError;
   const freshLoading = loading && !currenciesLength;
+
+  // Identity of the underlying list (everything but the page cursor). When it changes the user
+  // switched list (category/sort/range/search/filter…), so pagination must re-arm and the scroll
+  // must jump back to the top. It intentionally excludes `page`, so paginating/refetching the same
+  // list does not trigger a reset.
+  const listKey = [
+    categories.selectedCategory,
+    order,
+    range,
+    effectiveCounterCurrency,
+    search,
+    String(shouldDisplayLiveCompatible),
+    String(starFilterOn),
+  ].join("|");
   // The extra row is the "show all" affordance, only relevant for the unfiltered list.
   const itemCount =
     starFilterOn || isStocksCategory || isTrendingCategory || search.length > 0
@@ -286,6 +300,7 @@ export function useMarket() {
     loading,
     isError,
     currenciesLength,
+    listKey,
     refreshRate: REFRESH_RATE,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketListVirtualization.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketListVirtualization.ts
@@ -8,6 +8,7 @@ type UseMarketListVirtualizationParams = {
   marketData: MarketCurrencyData[];
   loading: boolean;
   currenciesLength: number;
+  listKey: string;
   onLoadNextPage: () => void;
   checkIfDataIsStaleAndRefetch: (scrollOffset: number) => void;
 };
@@ -17,11 +18,22 @@ export const useMarketListVirtualization = ({
   marketData,
   loading,
   currenciesLength,
+  listKey,
   onLoadNextPage,
   checkIfDataIsStaleAndRefetch,
 }: UseMarketListVirtualizationParams) => {
   const parentRef = useRef<HTMLDivElement>(null);
   const lastFetchedIndexRef = useRef<number>(-1);
+
+  // When the list identity changes (category/search/sort…) jump back to the top and re-arm the
+  // pagination guard below — which is absolute and would otherwise stay stuck at the previous
+  // list's scroll depth, both blocking loading more and leaving the new list scrolled off-screen.
+  useEffect(() => {
+    lastFetchedIndexRef.current = -1;
+    if (parentRef.current) {
+      parentRef.current.scrollTop = 0;
+    }
+  }, [listKey]);
 
   const rowVirtualizer = useVirtualizer({
     count: itemCount,
@@ -37,9 +49,11 @@ export const useMarketListVirtualization = ({
   useEffect(() => {
     if (lastVirtualItemIndex === -1 || loading) return;
 
-    const hasMoreData = itemCount > marketData.length;
-    if (!hasMoreData || currenciesLength === 0) return;
+    if (currenciesLength === 0) return;
 
+    // Re-fetch only when the bottom is reached AND new rows have arrived since the last fetch.
+    // This is the actual end-detector: when a page adds nothing, the list stops growing and so
+    // does pagination. It works for every list (all, categories, stocks) regardless of itemCount.
     const shouldFetch =
       lastVirtualItemIndex >= marketData.length - 1 &&
       lastFetchedIndexRef.current < marketData.length;
@@ -48,14 +62,7 @@ export const useMarketListVirtualization = ({
       lastFetchedIndexRef.current = marketData.length;
       onLoadNextPage();
     }
-  }, [
-    itemCount,
-    marketData.length,
-    currenciesLength,
-    onLoadNextPage,
-    loading,
-    lastVirtualItemIndex,
-  ]);
+  }, [marketData.length, currenciesLength, onLoadNextPage, loading, lastVirtualItemIndex]);
 
   useEffect(() => {
     const scrollElement = parentRef.current;
@@ -72,5 +79,7 @@ export const useMarketListVirtualization = ({
   return {
     parentRef,
     rowVirtualizer,
+    virtualItems,
+    totalSize: rowVirtualizer.getTotalSize(),
   };
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/screens/MarketList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/screens/MarketList.tsx
@@ -1,6 +1,6 @@
 import React, { memo, RefObject } from "react";
 import { TFunction } from "i18next";
-import { Virtualizer } from "@tanstack/react-virtual";
+import type { Virtualizer, VirtualItem } from "@tanstack/react-virtual";
 import {
   MarketCurrencyData,
   MarketListRequestParams,
@@ -16,6 +16,8 @@ import { MarketFavoritesEmptyState } from "../components/MarketFavoritesEmptySta
 type MarketListVirtualization = {
   parentRef: RefObject<HTMLDivElement | null>;
   rowVirtualizer: Virtualizer<HTMLDivElement, Element>;
+  virtualItems: VirtualItem[];
+  totalSize: number;
 };
 
 type MarketListProps = {
@@ -52,7 +54,7 @@ function MarketList({
   t,
 }: Readonly<MarketListProps>) {
   const { order, search, starred, range, counterCurrency } = marketParams;
-  const { parentRef, rowVirtualizer } = virtualization;
+  const { parentRef, virtualItems, totalSize } = virtualization;
 
   if (emptyState === "favorites") {
     return <MarketFavoritesEmptyState t={t} />;
@@ -84,7 +86,8 @@ function MarketList({
         ) : (
           showData && (
             <ListData
-              rowVirtualizer={rowVirtualizer}
+              virtualItems={virtualItems}
+              totalSize={totalSize}
               marketData={marketData}
               starredMarketCoins={starredMarketCoins}
               counterCurrency={counterCurrency}

--- a/apps/ledger-live-desktop/src/renderer/screens/market/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/index.tsx
@@ -94,6 +94,7 @@ export default function Market() {
     marketData: marketData.marketData,
     loading: marketData.loading,
     currenciesLength: marketData.currenciesLength,
+    listKey: marketData.listKey,
     onLoadNextPage: marketData.onLoadNextPage,
     checkIfDataIsStaleAndRefetch: marketData.checkIfDataIsStaleAndRefetch,
   });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Market list pagination ("load more") across **all list types** — All, categories, and Stocks
      - Scroll position when switching category / sort / range / counter-currency / search / favorites filter (should jump back to the top)
      - End-of-list behavior: stops requesting more pages once a page returns no new rows
      - `ListData` rendering still virtualizes correctly after the `virtualItems` / `totalSize` prop refactor

### 📝 Description

**Problem**: When switching the Market list — by category, sort, range, counter-currency, search, or the favorites filter — the pagination guard (`lastFetchedIndexRef`) was absolute and stayed stuck at the previous list's scroll depth. This blocked "load more" on the new list and left it scrolled off-screen instead of starting at the top. The old end-detection (`itemCount > marketData.length`) also did not behave consistently across list types (categories/stocks).

**Solution**:

- Introduce a `listKey` derived from everything that identifies a list *except* the page cursor (`selectedCategory`, `order`, `range`, counter-currency, `search`, live-compatible flag, favorites filter). When it changes, the user switched lists, so we re-arm the pagination guard and reset `scrollTop` to `0`. Paginating/refetching the same list does **not** trigger a reset.
- Rewrite end-detection to fire only when the bottom is reached **and** new rows have arrived since the last fetch. This is the real end-detector: when a page adds nothing, the list stops growing and so does pagination — and it works for every list type regardless of `itemCount`.
- Refactor `ListData` to receive `virtualItems` and `totalSize` directly instead of the whole `Virtualizer` instance, keeping the component decoupled from the virtualizer.


https://github.com/user-attachments/assets/c7ff2b89-99bc-4291-a040-fc59eda35df2



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32274](https://ledgerhq.atlassian.net/browse/LIVE-32274)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32274]: https://ledgerhq.atlassian.net/browse/LIVE-32274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ