### PR TITLE
[LWD] feat(desktop): remove stablecoins section from global search

### DIFF
--- a/.changeset/short-grapes-retire.md
+++ b/.changeset/short-grapes-retire.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+remove stablecoins section in global search

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/__tests__/SearchOverlayView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/__tests__/SearchOverlayView.test.tsx
@@ -11,7 +11,6 @@ const mockedUseAssetSearchBar = jest.mocked(useAssetSearchBar);
 const EMPTY_SECTION = { data: [], isLoading: false };
 const EMPTY_SUGGESTIONS: SearchSuggestions = {
   cryptos: EMPTY_SECTION,
-  stablecoins: EMPTY_SECTION,
   stocks: EMPTY_SECTION,
 };
 const EMPTY_RESULTS: SearchResults = { data: [], isLoading: false };

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchOverlayDefault.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchOverlayDefault.tsx
@@ -3,11 +3,7 @@ import { useTranslation } from "react-i18next";
 import { StocksSectionView } from "LLD/features/Stocks/StocksSectionView";
 import { AssetSuggestionsSection } from "LLD/features/SearchAssets/AssetSuggestionsSection";
 import { useSearchOverlay } from "../SearchOverlayContext";
-import {
-  CRYPTOS_SUGGESTION_LIMIT,
-  STABLECOINS_SUGGESTION_LIMIT,
-  STOCKS_SUGGESTION_LIMIT,
-} from "../useAssetSearchBar";
+import { CRYPTOS_SUGGESTION_LIMIT, STOCKS_SUGGESTION_LIMIT } from "../useAssetSearchBar";
 
 export function SearchOverlayDefault() {
   const { t } = useTranslation();
@@ -21,14 +17,6 @@ export function SearchOverlayDefault() {
         title={t("topBar.search.cryptos")}
         testIdPrefix="cryptos"
         limit={CRYPTOS_SUGGESTION_LIMIT}
-        navigateToAsset={navigateToAsset}
-        onSeeAll={navigateToMarket}
-      />
-      <AssetSuggestionsSection
-        {...suggestions.stablecoins}
-        title={t("topBar.search.stablecoins")}
-        testIdPrefix="stablecoins"
-        limit={STABLECOINS_SUGGESTION_LIMIT}
         navigateToAsset={navigateToAsset}
         onSeeAll={navigateToMarket}
       />

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/types.ts
@@ -15,7 +15,6 @@ export type StocksSuggestionSection = {
 
 export type SearchSuggestions = {
   cryptos: AssetSuggestionSection;
-  stablecoins: AssetSuggestionSection;
   stocks: StocksSuggestionSection;
 };
 

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useAssetSearchBar.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useAssetSearchBar.ts
@@ -7,7 +7,6 @@ import { SearchMode, SearchResults, SearchSuggestions } from "./types";
 
 export const STOCKS_SUGGESTION_LIMIT = 20;
 export const CRYPTOS_SUGGESTION_LIMIT = 3;
-export const STABLECOINS_SUGGESTION_LIMIT = 2;
 
 export const SEARCH_RESULTS_LIMIT = 10;
 
@@ -35,19 +34,11 @@ export function useAssetSearchBar() {
 
   // --- Default suggestions (top market cap + stocks), shown when the query is empty. ---
   const stocks = useStocksSectionViewModel({ limit: STOCKS_SUGGESTION_LIMIT });
-  const {
-    cryptos,
-    stablecoins,
-    isError: suggestionsAssetsError,
-  } = useAssetSuggestionsViewModel({
+  const { cryptos, isError: suggestionsAssetsError } = useAssetSuggestionsViewModel({
     cryptosLimit: CRYPTOS_SUGGESTION_LIMIT,
-    stablecoinsLimit: STABLECOINS_SUGGESTION_LIMIT,
   });
 
-  const suggestions: SearchSuggestions = useMemo(
-    () => ({ cryptos, stablecoins, stocks }),
-    [cryptos, stablecoins, stocks],
-  );
+  const suggestions: SearchSuggestions = useMemo(() => ({ cryptos, stocks }), [cryptos, stocks]);
 
   // --- Live search: a single flat list from the DADA assets search, driven by the debounced query. ---
   const search = useAssetSearchResultsViewModel({

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/__integrations__/SearchAssets.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/__integrations__/SearchAssets.integration.test.tsx
@@ -16,7 +16,6 @@ const mockedUseStablecoinTickers = jest.mocked(useStablecoinTickers);
 const mockedUseUsdToFiatRate = jest.mocked(useUsdToFiatRate);
 
 const CRYPTOS_LIMIT = 3;
-const STABLECOINS_LIMIT = 2;
 
 type AssetDescriptor = {
   id: string;
@@ -113,29 +112,16 @@ const navigateToAsset = jest.fn();
 const navigateToMarket = jest.fn();
 
 function Harness() {
-  const { cryptos, stablecoins } = useAssetSuggestionsViewModel({
-    cryptosLimit: CRYPTOS_LIMIT,
-    stablecoinsLimit: STABLECOINS_LIMIT,
-  });
+  const { cryptos } = useAssetSuggestionsViewModel({ cryptosLimit: CRYPTOS_LIMIT });
   return (
-    <>
-      <AssetSuggestionsSection
-        {...cryptos}
-        title="Cryptos"
-        testIdPrefix="cryptos"
-        limit={CRYPTOS_LIMIT}
-        navigateToAsset={navigateToAsset}
-        onSeeAll={navigateToMarket}
-      />
-      <AssetSuggestionsSection
-        {...stablecoins}
-        title="Stablecoins"
-        testIdPrefix="stablecoins"
-        limit={STABLECOINS_LIMIT}
-        navigateToAsset={navigateToAsset}
-        onSeeAll={navigateToMarket}
-      />
-    </>
+    <AssetSuggestionsSection
+      {...cryptos}
+      title="Cryptos"
+      testIdPrefix="cryptos"
+      limit={CRYPTOS_LIMIT}
+      navigateToAsset={navigateToAsset}
+      onSeeAll={navigateToMarket}
+    />
   );
 }
 
@@ -143,17 +129,16 @@ describe("SearchAssets suggestion sections", () => {
   beforeEach(() => mockedUseUsdToFiatRate.mockReturnValue({ status: "ready", rate: 1 }));
   afterEach(() => jest.clearAllMocks());
 
-  it("shows cryptos and stablecoins skeletons simultaneously while loading", () => {
+  it("shows the cryptos skeleton while loading", () => {
     mockAssetsData({ isLoading: true });
     mockStablecoinTickers({ isLoading: true });
 
     render(<Harness />);
 
     expect(screen.getByTestId("cryptos-skeleton")).toBeVisible();
-    expect(screen.getByTestId("stablecoins-skeleton")).toBeVisible();
   });
 
-  it("splits market data into cryptos and stablecoins via the DADA tickers", () => {
+  it("excludes stablecoins from the cryptos list via the DADA tickers", () => {
     mockAssetsData({ data: [BTC, USDT, ETH] });
     mockStablecoinTickers({ tickers: ["USDT"] });
 
@@ -161,7 +146,6 @@ describe("SearchAssets suggestion sections", () => {
 
     expect(screen.getByTestId("cryptos-item-btc")).toBeVisible();
     expect(screen.getByTestId("cryptos-item-eth")).toBeVisible();
-    expect(screen.getByTestId("stablecoins-item-usdt")).toBeVisible();
     // A stablecoin must not leak into the cryptos list.
     expect(screen.queryByTestId("cryptos-item-usdt")).not.toBeInTheDocument();
   });
@@ -187,14 +171,13 @@ describe("SearchAssets suggestion sections", () => {
   });
 
   it("hides a section when it has no data", () => {
-    mockAssetsData({ data: [BTC] });
+    mockAssetsData({ data: [] });
     mockStablecoinTickers({ tickers: ["USDT"] });
 
     render(<Harness />);
 
-    expect(screen.getByTestId("cryptos-section")).toBeVisible();
-    // No stablecoins in the data → section is hidden.
-    expect(screen.queryByTestId("stablecoins-section")).not.toBeInTheDocument();
+    // No data → section is hidden.
+    expect(screen.queryByTestId("cryptos-section")).not.toBeInTheDocument();
   });
 
   it("caps each section to the requested limit", () => {
@@ -212,22 +195,5 @@ describe("SearchAssets suggestion sections", () => {
     expect(screen.getByTestId("cryptos-item-c0")).toBeVisible();
     expect(screen.getByTestId("cryptos-item-c2")).toBeVisible();
     expect(screen.queryByTestId("cryptos-item-c3")).not.toBeInTheDocument();
-  });
-
-  it("caps cryptos to 3 and stablecoins to 2", () => {
-    const stablecoins = Array.from({ length: 4 }, (_, i) => ({
-      id: `stable-${i}`,
-      name: `Stable ${i}`,
-      ticker: `S${i}`,
-      ledgerId: `stable-${i}`,
-    }));
-    mockAssetsData({ data: stablecoins });
-    mockStablecoinTickers({ tickers: ["S0", "S1", "S2", "S3"] });
-
-    render(<Harness />);
-
-    expect(screen.getByTestId("stablecoins-item-s0")).toBeVisible();
-    expect(screen.getByTestId("stablecoins-item-s1")).toBeVisible();
-    expect(screen.queryByTestId("stablecoins-item-s2")).not.toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSuggestionsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSuggestionsViewModel.ts
@@ -10,10 +10,8 @@ import { AssetSuggestionsViewModelResult } from "../types";
 
 export function useAssetSuggestionsViewModel({
   cryptosLimit,
-  stablecoinsLimit,
 }: {
   cryptosLimit: number;
-  stablecoinsLimit: number;
 }): AssetSuggestionsViewModelResult {
   const counterCurrency = useSelector(counterValueCurrencySelector).ticker;
 
@@ -38,28 +36,23 @@ export function useAssetSuggestionsViewModel({
   const isLoading = assetsLoading || tickersLoading || (hasData && rateStatus === "loading");
   const isError = assetsError || tickersError || (hasData && rateStatus === "error");
 
-  const { cryptos, stablecoins } = useMemo(() => {
+  const cryptos = useMemo(() => {
     const cryptosData: MarketCurrencyData[] = [];
-    const stablecoinsData: MarketCurrencyData[] = [];
 
     for (const currency of mapAssetsDataToMarketCurrencies(data, rate ?? 1)) {
-      const isStablecoin = tickers.has(currency.ticker.toUpperCase());
-      const [bucket, bucketLimit] = isStablecoin
-        ? [stablecoinsData, stablecoinsLimit]
-        : [cryptosData, cryptosLimit];
-      if (bucket.length < bucketLimit) bucket.push(currency);
-      if (cryptosData.length >= cryptosLimit && stablecoinsData.length >= stablecoinsLimit) break;
+      if (tickers.has(currency.ticker.toUpperCase())) continue;
+      cryptosData.push(currency);
+      if (cryptosData.length >= cryptosLimit) break;
     }
 
-    return { cryptos: cryptosData, stablecoins: stablecoinsData };
-  }, [data, rate, tickers, cryptosLimit, stablecoinsLimit]);
+    return cryptosData;
+  }, [data, rate, tickers, cryptosLimit]);
 
   return useMemo(
     () => ({
       cryptos: { data: cryptos, isLoading },
-      stablecoins: { data: stablecoins, isLoading },
       isError,
     }),
-    [cryptos, stablecoins, isLoading, isError],
+    [cryptos, isLoading, isError],
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/types.ts
@@ -3,8 +3,6 @@ import { AssetSuggestionSection } from "LLD/components/TopBar/components/TopBarS
 export type AssetSuggestionsViewModelResult = {
   /** Top cryptos (excluding stablecoins) ranked by market cap, capped to the limit. */
   cryptos: AssetSuggestionSection;
-  /** Top stablecoins ranked by market cap, capped to the limit. */
-  stablecoins: AssetSuggestionSection;
   isError: boolean;
 };
 
@@ -13,7 +11,7 @@ export type AssetSuggestionsSectionProps = AssetSuggestionSection & {
   title: string;
   /** Number of skeleton rows rendered while loading. */
   limit: number;
-  /** Disambiguates test ids and skeleton keys ("cryptos" | "stablecoins"). */
+  /** Disambiguates test ids and skeleton keys (e.g. "cryptos"). */
   testIdPrefix: string;
   /** Redirects to the asset detail page for the given market id. */
   navigateToAsset: (currencyId: string) => void;

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8865,7 +8865,6 @@
       "noAssetFound": "No asset found",
       "error": "Connection failed",
       "cryptos": "Cryptos",
-      "stablecoins": "Stablecoins",
       "stocks": "Stocks"
     },
     "history": {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Top-bar global search overlay (empty-query default suggestions)
  - The remaining **Cryptos** section must still exclude stablecoins (e.g. USDT/USDC should not appear in it)
  - The **Stocks** section is unaffected
  - Live search results (typed query) are unaffected

### 📝 Description

The desktop global search overlay displayed default suggestions split into three sections: **Cryptos**, **Stablecoins**, and **Stocks**. Product no longer wants the standalone **Stablecoins** section.

This PR removes the Stablecoins section from the search overlay. The suggestions view model still uses the DADA stablecoin tickers as a **filter**, so the Cryptos section keeps excluding stablecoins (no UX regression) — stablecoins simply no longer appear anywhere in the overlay. The shared `AssetSuggestionsSection` components remain, as they are reused by the Cryptos section. Scope is desktop-only: mobile global search and the Assets-page stablecoins table are untouched.


https://github.com/user-attachments/assets/8a9a4c32-2230-428d-b451-ce99ceab89b8


### ❓ Context

- **JIRA or GitHub link**: [LIVE-32415](https://ledgerhq.atlassian.net/browse/LIVE-32415)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32415]: https://ledgerhq.atlassian.net/browse/LIVE-32415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ