### PR TITLE
[LWD] feat(desktop): reorder market category tabs

### DIFF
--- a/.changeset/few-buckets-count.md
+++ b/.changeset/few-buckets-count.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+change order of categories in market

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarketCategories.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarketCategories.test.ts
@@ -54,7 +54,7 @@ describe("useMarketCategories", () => {
     const { result } = renderCategories("all");
 
     expect(result.current.selectedCategory).toBe("all");
-    expect(result.current.tabs.map(tab => tab.value)).toEqual(["all", "stocks", "starred"]);
+    expect(result.current.tabs.map(tab => tab.value)).toEqual(["all", "starred", "stocks"]);
   });
 
   it("selects a new category and tracks the tap", () => {
@@ -87,8 +87,8 @@ describe("useMarketCategories", () => {
 
     expect(result.current.tabs.map(tab => tab.value)).toEqual([
       "all",
-      "stocks",
       "starred",
+      "stocks",
       "infrastructure",
     ]);
     expect(result.current.tabs.at(-1)).toEqual({
@@ -109,8 +109,8 @@ describe("useMarketCategories", () => {
 
     expect(result.current.tabs.map(tab => tab.value)).toEqual([
       "all",
-      "stocks",
       "starred",
+      "stocks",
       "infrastructure",
     ]);
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketCategories.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketCategories.ts
@@ -25,8 +25,8 @@ export type MarketCategories = {
 
 const BUILT_IN_CATEGORY_TABS: MarketCategoryTab[] = [
   { value: "all", labelKey: "market.assets.categories.all" },
-  { value: "stocks", labelKey: "market.assets.categories.stocks" },
   { value: "starred", labelKey: "market.assets.categories.favorites" },
+  { value: "stocks", labelKey: "market.assets.categories.stocks" },
 ];
 
 function trackCategoryTap(category: MarketListCategory) {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Order of the category tabs in the Market screen (Favorites now appears before Stocks)
      - Category selection and tracking still work as expected

### 📝 Description

The Market category tabs were displayed in the order `All → Stocks → Starred`, which did not match the expected design.

This PR reorders the built-in category tabs so that the `Starred` (Favorites) category appears before `Stocks`, giving the order `All → Starred → Stocks`. The associated unit test was updated to reflect the new ordering.



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32414](https://ledgerhq.atlassian.net/browse/LIVE-32414)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32414]: https://ledgerhq.atlassian.net/browse/LIVE-32414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ