### PR TITLE
docs(skills): add run-e2e-ci skill for triggering E2E/Coin Tester on CI

### DIFF
--- a/.agents/skills/run-e2e-ci/SKILL.md
+++ b/.agents/skills/run-e2e-ci/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: run-e2e-ci
+description: Trigger the on-demand E2E / Coin Tester CI workflows (Desktop E2E, Mobile E2E, Coin Tester) on a branch and post a PR comment. Use when asked to "run e2e", "trigger e2e on CI", or "run coin testers" for a PR/branch.
+---
+
+# Run E2E / Coin Tester on CI
+
+**When:** for changes that impact the e2e apps (desktop/mobile/coin logic), once the PR is getting ready for review. Desktop & Mobile E2E only run on a schedule + manual dispatch, so trigger them deliberately. Coin Tester already auto-runs on PRs for affected coins — only dispatch it to force a chain or re-run.
+
+**First scope it down.** Study the PR diff and its impact, then run only the subset that's truly needed instead of the full suite: choose which surfaces to run at all (desktop / mobile / coin), narrow with `test_filter` tags (`@bitcoin`, `@family-evm`, `@solana`, `@generic-coin-framework`, …), set Coin Tester `chain`, and limit Mobile `tests_type`. Full suite is slow and expensive — reserve it for broad/cross-cutting changes.
+
+These are `workflow_dispatch` workflows — **no slash-command triggers them**. Dispatch with `gh`, which must run **outside the sandbox** (`dangerouslyDisableSandbox: true`).
+
+`gh workflow run --ref <branch>` is all you need: the workflows checkout `inputs.ref || github.sha`, so the optional "Specify branch" (`ref`) field can stay blank — it falls back to the commit `--ref` points to, which is the code actually pulled and tested. Run-names echo the branch, so use `gh run list` to confirm.
+
+```bash
+BR=<branch>   # PR head branch
+gh workflow run test-ui-e2e-only-desktop.yml --ref "$BR"
+gh workflow run test-mobile-e2e-reusable.yml --ref "$BR" -f tests_type="iOS & Android" -f speculos_device=nanoX
+gh workflow run test-coin-tester.yml --ref "$BR"
+gh run list --branch "$BR" --limit 6   # grab the 3 run IDs
+```
+
+Mobile **requires** `tests_type` (`Android Only`|`iOS Only`|`iOS & Android`) and `speculos_device` (`nanoS`|`nanoSP`|`nanoX`|`stax`|`flex`|`nanoGen5`). Desktop defaults to Speculos nanoSP. Coin Tester auto-detects affected coins (or `-f chain="evm,solana"`). Optional Desktop/Mobile filter: `-f test_filter="@bitcoin,@family-evm"`.
+
+Then post the run on the PR (`gh pr comment <pr> --body ...`, use `--edit-last` to update):
+
+```markdown
+## 🧪 Triggered test workflows
+
+Manually dispatched on `<branch>` (commit <short-sha>, `git rev-parse --short HEAD`), full suite:
+
+| Workflow | Scope | Run |
+|---|---|---|
+| [Desktop] E2E Only | full suite, Speculos nanoSP | [run <id>](https://github.com/LedgerHQ/ledger-live/actions/runs/<id>) |
+| [Mobile] E2E Only | full suite, iOS & Android, nanoX | [run <id>](https://github.com/LedgerHQ/ledger-live/actions/runs/<id>) |
+| [Coin] Test Coin modules | affected coins (auto-detected) | [run <id>](https://github.com/LedgerHQ/ledger-live/actions/runs/<id>) |
+```


### PR DESCRIPTION
### ✅ Checklist

- [x] npx changeset was attached. <!-- N/A: adds an agent skill doc under .agents/skills, no package change -->
- [x] Covered by automatic tests. <!-- N/A: documentation-only skill file -->
- [ ] Impact of the changes:
  - Adds a new agent skill only. No runtime/app/library code is touched, so no QA impact.

### 📝 Description

<img width="1264" height="1061" alt="Screenshot 2026-06-12 at 15 14 05" src="https://github.com/user-attachments/assets/30fe03d5-9159-43be-be13-b506332de5ba" />

<img width="907" height="384" alt="Screenshot 2026-06-12 at 15 14 00" src="https://github.com/user-attachments/assets/a3edb6d1-29c6-4b33-9e68-53fc6a112e94" />

also when doubt on what is impacted:

<img width="1183" height="278" alt="Screenshot 2026-06-12 at 18 34 43" src="https://github.com/user-attachments/assets/8ef58fb0-e084-4484-832c-1de88b80803d" />



Adds a new agent skill run-e2e-ci documenting how to trigger the on-demand E2E and Coin Tester CI workflows on a branch and report the runs on the PR.

It captures, in condensed form, the knowledge needed to do this reliably:
- These are workflow_dispatch workflows (Desktop E2E, Mobile E2E, Coin Tester); no slash-command triggers them.
- gh must run outside the sandbox.
- gh workflow run --ref <branch> is enough: the workflows checkout inputs.ref || github.ref_name, so the optional ref field can stay blank and the branch code is still pulled and tested.
- Mobile requires tests_type and speculos_device; Desktop/Coin Tester have sensible defaults.
- When to run: for changes impacting the e2e apps, once the PR is getting ready for review.
- A standard PR comment template to summarize the dispatched runs.

### ❓ Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A