### PR TITLE
fix(mobile): market banner filter — text+chevron UI + reset ranking when discoverability off [LIVE-32413/LIVE-32359]

### DIFF
--- a/.changeset/lwm-market-banner-filter-text-chevron.md
+++ b/.changeset/lwm-market-banner-filter-text-chevron.md
@@ -2,4 +2,7 @@
 "live-mobile": patch
 ---
 
-Improve the Market Banner filter trigger on the Home screen: replace the MediaButton with a right-aligned text + chevron control using the text-muted color (and its pressed token), keeping a clean 12px gap below the section title.
+Market Banner improvements on the Home screen:
+
+- Replace the filter MediaButton with a right-aligned text + chevron control using the text-muted color (and its pressed token), keeping a clean 12px gap below the section title.
+- Ignore the persisted ranking filter when asset discoverability is off (fall back to the default ranking), instead of keeping the previously selected filter applied. The stored preference is preserved for when the feature is re-enabled.

--- a/.changeset/lwm-market-banner-filter-text-chevron.md
+++ b/.changeset/lwm-market-banner-filter-text-chevron.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Improve the Market Banner filter trigger on the Home screen: replace the MediaButton with a right-aligned text + chevron control using the text-muted color (and its pressed token), keeping a clean 12px gap below the section title.

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/__integrations__/marketBanner.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/__integrations__/marketBanner.integration.test.tsx
@@ -230,6 +230,36 @@ describe("MarketBanner Integration Tests", () => {
       await waitFor(() => expect(favoritesPageSize).not.toBeNull());
       expect(["1", "5", "20", "50"]).toContain(favoritesPageSize);
     });
+
+    it("ignores the persisted ranking when assetDiscoverability is off and keeps the stored preference", async () => {
+      let performersSort: string | null = null;
+      server.use(
+        http.get(`${COUNTERVALUES_API}/v3/markets`, ({ request }) => {
+          const sort = new URL(request.url).searchParams.get("sort");
+          if (sort?.includes("price-change")) performersSort = sort;
+          return HttpResponse.json(MOCK_MARKET_PERFORMERS);
+        }),
+      );
+
+      const { store } = renderWithReactQuery(<MarketBannerTest />, {
+        overrideInitialState: state => {
+          const flagged = withFlagOverrides({
+            lwmWallet40: {
+              enabled: true,
+              params: { marketBanner: true, assetDiscoverability: false },
+            },
+          })(state);
+          return {
+            ...flagged,
+            marketBanner: { ...flagged.marketBanner, ranking: "losers" },
+          };
+        },
+      });
+
+      await waitFor(() => expect(performersSort).not.toBeNull());
+      expect(performersSort).toContain("positive-price-change");
+      expect(store.getState().marketBanner.ranking).toBe("losers");
+    });
   });
 
   describe("Loading state", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketBannerFilterTrigger/__tests__/MarketBannerFilterTrigger.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketBannerFilterTrigger/__tests__/MarketBannerFilterTrigger.test.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { render, screen, fireEvent } from "@tests/test-renderer";
+import { MarketBannerFilterTrigger } from "..";
+
+describe("MarketBannerFilterTrigger", () => {
+  it("renders the label and calls onPress when pressed", () => {
+    const onPress = jest.fn();
+    render(<MarketBannerFilterTrigger label="Trending" onPress={onPress} testID="trigger" />);
+
+    expect(screen.getByText("Trending")).toBeVisible();
+
+    fireEvent.press(screen.getByTestId("trigger"));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketBannerFilterTrigger/__tests__/MarketBannerFilterTrigger.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketBannerFilterTrigger/__tests__/MarketBannerFilterTrigger.test.tsx
@@ -1,15 +1,17 @@
 import React from "react";
-import { render, screen, fireEvent } from "@tests/test-renderer";
+import { render, screen } from "@tests/test-renderer";
 import { MarketBannerFilterTrigger } from "..";
 
 describe("MarketBannerFilterTrigger", () => {
-  it("renders the label and calls onPress when pressed", () => {
+  it("renders the label and calls onPress when pressed", async () => {
     const onPress = jest.fn();
-    render(<MarketBannerFilterTrigger label="Trending" onPress={onPress} testID="trigger" />);
+    const { user } = render(
+      <MarketBannerFilterTrigger label="Trending" onPress={onPress} testID="trigger" />,
+    );
 
     expect(screen.getByText("Trending")).toBeVisible();
 
-    fireEvent.press(screen.getByTestId("trigger"));
+    await user.press(screen.getByTestId("trigger"));
 
     expect(onPress).toHaveBeenCalledTimes(1);
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketBannerFilterTrigger/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketBannerFilterTrigger/index.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Box, Pressable, Text } from "@ledgerhq/lumen-ui-rnative";
+import { ChevronDown } from "@ledgerhq/lumen-ui-rnative/symbols";
+
+interface MarketBannerFilterTriggerProps {
+  label: string;
+  onPress: () => void;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
+  testID?: string;
+}
+
+const CHEVRON_SIZE = 16;
+
+export const MarketBannerFilterTrigger = ({
+  label,
+  onPress,
+  accessibilityLabel,
+  accessibilityHint,
+  testID,
+}: MarketBannerFilterTriggerProps) => (
+  <Pressable
+    onPress={onPress}
+    accessibilityRole="button"
+    accessibilityLabel={accessibilityLabel}
+    accessibilityHint={accessibilityHint}
+    testID={testID}
+    hitSlop={8}
+    style={{ marginLeft: "auto" }}
+  >
+    {({ pressed }) => {
+      const color = pressed ? "mutedPressed" : "muted";
+      return (
+        <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s4" }}>
+          <Text typography="body2SemiBold" lx={{ color }}>
+            {label}
+          </Text>
+          <ChevronDown size={CHEVRON_SIZE} color={color} />
+        </Box>
+      );
+    }}
+  </Pressable>
+);

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketBannerView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketBannerView/index.tsx
@@ -6,7 +6,6 @@ import {
   SubheaderTitle,
   SubheaderShowMore,
   Box,
-  MediaButton,
 } from "@ledgerhq/lumen-ui-rnative";
 import { useTranslation } from "~/context/Locale";
 import { MarketItemPerformer } from "@ledgerhq/live-common/market/utils/types";
@@ -17,6 +16,7 @@ import ViewAllTile from "../ViewAllTile";
 import { ErrorState } from "../ErrorState";
 import { SkeletonState } from "../SkeletonState";
 import { MarketBannerFilterDrawer } from "../MarketBannerFilterDrawer";
+import { MarketBannerFilterTrigger } from "../MarketBannerFilterTrigger";
 import { MARKET_BANNER_FILTER_LABEL_KEYS, MARKET_BANNER_TEST_IDS } from "../../constants";
 import type { MarketBannerFilterController } from "../../hooks/useMarketBannerFilter";
 
@@ -70,17 +70,13 @@ const MarketBannerView = ({
           <SubheaderTitle>{t("marketBanner.title")}</SubheaderTitle>
           <SubheaderShowMore />
           {showFilter ? (
-            <MediaButton
-              size="sm"
-              appearance="no-background"
+            <MarketBannerFilterTrigger
+              label={t(MARKET_BANNER_FILTER_LABEL_KEYS[bannerFilter.filter])}
               onPress={bannerFilter.onOpen}
               accessibilityLabel={t("marketBanner.filter.accessibilityLabel")}
               accessibilityHint={t("marketBanner.filter.accessibilityHint")}
               testID={MARKET_BANNER_TEST_IDS.filterButton}
-              style={{ marginLeft: "auto" }}
-            >
-              {t(MARKET_BANNER_FILTER_LABEL_KEYS[bannerFilter.filter])}
-            </MediaButton>
+            />
           ) : null}
         </SubheaderRow>
       </Subheader>

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/constants.ts
@@ -2,6 +2,8 @@ import type { MarketBannerRanking } from "~/reducers/types";
 
 export const MARKET_BANNER_TILE_COUNT = 7;
 
+export const DEFAULT_RANKING_WITHOUT_DISCOVERABILITY: MarketBannerRanking = "gainers";
+
 export const PAGE_NAME = "Wallet";
 export const BANNER_NAME = "Market Banner";
 

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/index.tsx
@@ -8,6 +8,7 @@ import useMarketBannerViewModel from "./hooks/useMarketBannerViewModel";
 import { usePerformersBannerItems, useFavoritesBannerItems } from "./hooks/useMarketBannerData";
 import MarketBannerView from "./components/MarketBannerView";
 import { MarketBannerProps } from "./types";
+import { DEFAULT_RANKING_WITHOUT_DISCOVERABILITY } from "./constants";
 import type { MarketBannerRanking } from "~/reducers/types";
 
 type MarketBannerSurfaceProps = MarketBannerProps & {
@@ -49,17 +50,20 @@ const FavoritesBanner = ({ testID }: MarketBannerProps) => {
 
 const MarketBannerContent = ({ testID }: MarketBannerProps) => {
   const dispatch = useDispatch();
-  const ranking = useSelector(selectMarketBannerRanking);
+  const { shouldDisplayAssetDiscoverability } = useWalletFeaturesConfig("mobile");
+  const persistedRanking = useSelector(selectMarketBannerRanking);
   const hasStarred = useSelector(starredMarketCoinsSelector).length > 0;
 
-  // Favorites with no starred asset left → fall back to trending and reset the ranking.
+  const ranking = shouldDisplayAssetDiscoverability
+    ? persistedRanking
+    : DEFAULT_RANKING_WITHOUT_DISCOVERABILITY;
+
   useEffect(() => {
     if (ranking === "favorites" && !hasStarred) {
       dispatch(setMarketBannerRanking("trending"));
     }
   }, [dispatch, ranking, hasStarred]);
 
-  // Only mount the React Query-backed favorites fetch when favorites is actually active.
   return ranking === "favorites" && hasStarred ? (
     <FavoritesBanner testID={testID} />
   ) : (


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** New `MarketBannerFilterTrigger` unit test + a persistence integration test; MarketBanner suite green (52).
- [x] **Impact of the changes:**
  - Market Banner on Home: filter control restyled; and the ranking filter no longer persists once asset discoverability is disabled.

### 📝 Description

Two Market Banner fixes (Home screen):

**1. Filter trigger — text + chevron ([LIVE-32413](https://ledgerhq.atlassian.net/browse/LIVE-32413))**
- New `MarketBannerFilterTrigger`: a right-aligned text + `ChevronDown` (Lumen `Pressable`/`Box`/`Text`) using the **text-muted** color and its **pressed** token (native equivalent of the design's hover). Being compact, it keeps a clean **12px** gap below the section title. Behaviour (label, drawer, testID, a11y) unchanged.

**2. Ranking persists after disabling asset discoverability ([LIVE-32359](https://ledgerhq.atlassian.net/browse/LIVE-32359))**
- The ranking filter belongs to asset discoverability, but the persisted ranking still drove the banner data after the flag was turned off — so the last-selected filter kept applying. Mirrors the desktop fix: `MarketBannerContent` computes an **effective ranking** that falls back to the default (`gainers`) when `shouldDisplayAssetDiscoverability` is false, **without** mutating the stored preference (kept for when the feature returns).


https://github.com/user-attachments/assets/db88e454-733e-428b-96da-0b1349aaede2



### ❓ Context

- **JIRA**: [LIVE-32413](https://ledgerhq.atlassian.net/browse/LIVE-32413), [LIVE-32359](https://ledgerhq.atlassian.net/browse/LIVE-32359)


[LIVE-32413]: https://ledgerhq.atlassian.net/browse/LIVE-32413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-32359]: https://ledgerhq.atlassian.net/browse/LIVE-32359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-32413]: https://ledgerhq.atlassian.net/browse/LIVE-32413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ