### PR TITLE
[LWM] fix(mobile): enable notification opt-in directly

### DIFF
--- a/.changeset/brave-badgers-enable.md
+++ b/.changeset/brave-badgers-enable.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix mobile notification opt-in to enable app notification categories directly

--- a/apps/ledger-live-mobile/__tests__/jest-setup.js
+++ b/apps/ledger-live-mobile/__tests__/jest-setup.js
@@ -279,7 +279,19 @@ jest.mock("~/firebase/remoteConfig", () => ({
   whenReady: jest.fn().mockResolvedValue(undefined),
 }));
 
-jest.mock("@braze/react-native-sdk", () => ({}));
+jest.mock("@braze/react-native-sdk", () => ({
+  __esModule: true,
+  default: {
+    changeUser: jest.fn(),
+    setCustomUserAttribute: jest.fn(),
+    logContentCardDismissed: jest.fn(),
+    logContentCardClicked: jest.fn(),
+    logContentCardImpression: jest.fn(),
+    requestContentCardsRefresh: jest.fn(),
+    getContentCards: jest.fn().mockResolvedValue([]),
+    getInitialPushPayload: jest.fn(),
+  },
+}));
 
 jest.mock("react-native-webview", () => jest.fn());
 

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPrompt.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPrompt.test.tsx
@@ -9,10 +9,12 @@ import {
 
 import storage from "LLM/storage";
 import { notificationsDataOfUserSelector } from "~/reducers/notifications";
+import { notificationsSelector } from "~/reducers/settings";
 import { add, sub, type Duration } from "date-fns";
 import { Button, Text } from "@ledgerhq/lumen-ui-rnative";
 import { AB_TESTING_VARIANTS, type ABTestingVariants } from "../types/variants";
-import { NotificationsState } from "~/reducers/types";
+import { NotificationsSettings, NotificationsState } from "~/reducers/types";
+import Braze from "@braze/react-native-sdk";
 import { createNotificationsPromptFeatureFlags } from "../testUtils";
 
 // Mock QueuedDrawer to bypass animation issues with Reanimated 4 in tests
@@ -54,7 +56,6 @@ const mockRequestPermission = jest.fn<Promise<AuthorizationStatusType>, []>(() =
 const mockHasPermission = jest.fn<Promise<AuthorizationStatusType>, []>(() =>
   Promise.resolve(AuthorizationStatus.AUTHORIZED),
 );
-
 jest.mock("@react-native-firebase/messaging", () => {
   const AuthorizationStatus = {
     NOT_DETERMINED: -1,
@@ -76,6 +77,21 @@ const REPROMPT_SCHEDULE = [{ days: 7 }, { days: 30 }, { days: 90 }] as const;
 const INACTIVITY_REPROMPT = { months: 6 } as const;
 
 describe("NotificationsPrompt Integration", () => {
+  const expectAppNotificationsSyncedWithBraze = () => {
+    expect(jest.mocked(Braze.setCustomUserAttribute)).toHaveBeenCalledWith(
+      "notificationsAllowed",
+      true,
+    );
+    expect(jest.mocked(Braze.setCustomUserAttribute)).toHaveBeenCalledWith(
+      "optInAnnouncements",
+      true,
+    );
+    expect(jest.mocked(Braze.setCustomUserAttribute)).toHaveBeenCalledWith(
+      "optInLargeMovers",
+      true,
+    );
+  };
+
   async function setup({
     actionSource = "onboarding",
     osPermission,
@@ -84,6 +100,7 @@ describe("NotificationsPrompt Integration", () => {
     dateOfNextAllowedRequest,
     alreadyDelayedToLater,
     dismissedOptInDrawerAtList,
+    notificationSettings = {},
     variant = AB_TESTING_VARIANTS.B,
     skipStorageSetup = false,
   }: {
@@ -94,6 +111,7 @@ describe("NotificationsPrompt Integration", () => {
     dateOfNextAllowedRequest?: Date;
     alreadyDelayedToLater?: boolean;
     dismissedOptInDrawerAtList?: number[];
+    notificationSettings?: Partial<NotificationsSettings>;
     variant?: ABTestingVariants;
     skipStorageSetup?: boolean;
   }) {
@@ -191,6 +209,7 @@ describe("NotificationsPrompt Integration", () => {
               ...state.settings,
               notifications: {
                 ...state.settings.notifications,
+                ...notificationSettings,
                 areNotificationsAllowed: appNotifications,
               },
             },
@@ -501,6 +520,87 @@ describe("NotificationsPrompt Integration", () => {
         await tryTriggerDrawer();
         expect(screen.queryByText(/allow notifications/i)).not.toBeOnTheScreen();
       });
+
+      it("should enable app notifications directly when OS permission is already allowed", async () => {
+        const { store, tryTriggerDrawer, user } = await setup({
+          actionSource: "add_favorite_coin",
+          osPermission: AuthorizationStatus.AUTHORIZED,
+          appNotifications: false,
+          notificationSettings: {
+            announcementsCategory: false,
+            largeMoverCategory: false,
+          },
+        });
+
+        await tryTriggerDrawer();
+        const allowNotificationsButton = screen.getByText(/allow notifications/i);
+        expect(allowNotificationsButton).toBeOnTheScreen();
+
+        await user.press(allowNotificationsButton);
+        await waitFor(() => expect(allowNotificationsButton).not.toBeOnTheScreen());
+
+        expect(mockRequestPermission).not.toHaveBeenCalled();
+        expect(notificationsSelector(store.getState())).toEqual(
+          expect.objectContaining({
+            areNotificationsAllowed: true,
+            announcementsCategory: true,
+            largeMoverCategory: true,
+          }),
+        );
+        expectAppNotificationsSyncedWithBraze();
+
+        advanceTime({
+          years: 999,
+        });
+        await tryTriggerDrawer();
+        expect(screen.queryByText(/allow notifications/i)).not.toBeOnTheScreen();
+      });
+
+      it.each([
+        ["denied", AuthorizationStatus.DENIED],
+        ["not determined", AuthorizationStatus.NOT_DETERMINED],
+      ])(
+        "should enable app notifications when they are off and OS permission is %s",
+        async (_, osPermission) => {
+          const { store, tryTriggerDrawer, user } = await setup({
+            osPermission,
+            appNotifications: false,
+            notificationSettings: {
+              announcementsCategory: false,
+              largeMoverCategory: false,
+            },
+          });
+
+          expect(notificationsSelector(store.getState())).toEqual(
+            expect.objectContaining({
+              areNotificationsAllowed: false,
+              announcementsCategory: false,
+              largeMoverCategory: false,
+            }),
+          );
+
+          if (osPermission === AuthorizationStatus.DENIED) {
+            advanceTime(REPROMPT_SCHEDULE[0]);
+          }
+
+          await tryTriggerDrawer();
+          const allowNotificationsButton = screen.getByText(/allow notifications/i);
+          expect(allowNotificationsButton).toBeOnTheScreen();
+
+          await user.press(allowNotificationsButton);
+
+          await waitFor(() =>
+            expect(notificationsSelector(store.getState())).toEqual(
+              expect.objectContaining({
+                areNotificationsAllowed: true,
+                announcementsCategory: true,
+                largeMoverCategory: true,
+              }),
+            ),
+          );
+          expectAppNotificationsSyncedWithBraze();
+        },
+      );
 
       it("should reprompt after each delay when user opts out notifications by clicking on maybe later text", async () => {
         const { tryTriggerDrawer, user } = await setup({

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotifications.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotifications.ts
@@ -13,6 +13,7 @@ const useNotifications = () => {
   const {
     notifications,
     pushNotificationsDataOfUser,
+    enableAppNotifications,
     markUserAsOptIn,
     markUserAsOptOut,
     initializeNotificationSettingsState,
@@ -41,7 +42,6 @@ const useNotifications = () => {
     handleCloseFromBackdropPress,
   } = useNotificationsDrawer({
     permissionStatus,
-    areNotificationsAllowed: notifications.areNotificationsAllowed,
     pushNotificationsDataOfUser,
     nextRepromptDelay,
     shouldPromptOptInDrawerAfterAction,
@@ -49,6 +49,7 @@ const useNotifications = () => {
     checkIsInactive,
     markUserAsOptOut,
     markUserAsOptIn,
+    enableAppNotifications,
     requestPushNotificationsPermission,
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsData.ts
@@ -11,6 +11,7 @@ import { setPushNotificationsDataOfUserInStorage } from "../utils/storage";
 import { buildOptOutUserData } from "../utils/buildOptOutUserData";
 import { type DataOfUser, type NotificationPromptTarget } from "../types";
 import { updateIdentify } from "~/analytics";
+import { updateUserPreferences } from "~/notifications/braze";
 
 const notificationSettingsKeys: Array<keyof NotificationsSettings> = [
   "areNotificationsAllowed",
@@ -45,6 +46,18 @@ export const useNotificationsData = () => {
     });
     updateIdentify();
   }, [updatePushNotificationsDataOfUserInStateAndStore, pushNotificationsDataOfUser]);
+
+  const enableAppNotifications = useCallback(() => {
+    const updatedNotifications = {
+      ...notifications,
+      areNotificationsAllowed: true,
+      announcementsCategory: true,
+      largeMoverCategory: true,
+    };
+
+    dispatch(setNotifications(updatedNotifications));
+    updateUserPreferences(updatedNotifications);
+  }, [dispatch, notifications]);
 
   const markUserAsOptOut = useCallback(
     (promptTarget?: NotificationPromptTarget) => {
@@ -168,6 +181,7 @@ export const useNotificationsData = () => {
     notifications,
     pushNotificationsDataOfUser,
     updatePushNotificationsDataOfUserInStateAndStore,
+    enableAppNotifications,
     markUserAsOptIn,
     markUserAsOptOut,
     initializeNotificationSettingsState,

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
@@ -1,7 +1,6 @@
 import { useCallback, useRef } from "react";
 import { InteractionManager } from "react-native";
 import { useSelector, useDispatch } from "~/context/hooks";
-import { useNavigation } from "@react-navigation/core";
 import { AuthorizationStatus } from "@react-native-firebase/messaging";
 import { useFeature } from "@features/platform-feature-flags";
 import {
@@ -11,7 +10,6 @@ import {
 } from "~/actions/notifications";
 import { setNotifications } from "~/actions/settings";
 import { track } from "~/analytics";
-import { NavigatorName, ScreenName } from "~/const/navigation";
 import { updateUserPreferences } from "~/notifications/braze";
 import {
   notificationsDrawerPromptTarget,
@@ -28,16 +26,16 @@ import { isTransactionsAlertsPromptTarget } from "../utils/getNotificationsPromp
 
 type UseNotificationsDrawerParams = {
   permissionStatus:
-  | (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus]
-  | null
-  | undefined;
-  areNotificationsAllowed: boolean | undefined;
+    | (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus]
+    | null
+    | undefined;
   pushNotificationsDataOfUser: DataOfUser | null | undefined;
   nextRepromptDelay: { days?: number; hours?: number; minutes?: number } | null;
   shouldPromptOptInDrawerAfterAction: () => boolean;
   checkIsInactive: (lastActionAt?: number) => boolean;
   markUserAsOptIn: () => void;
   markUserAsOptOut: (promptTarget?: NotificationPromptTarget) => void;
+  enableAppNotifications: () => void;
   updateUserLastInactiveTime: () => void;
   requestPushNotificationsPermission: () => Promise<
     void | (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus]
@@ -46,13 +44,13 @@ type UseNotificationsDrawerParams = {
 
 export const useNotificationsDrawer = ({
   permissionStatus,
-  areNotificationsAllowed,
   pushNotificationsDataOfUser,
   nextRepromptDelay,
   shouldPromptOptInDrawerAfterAction,
   checkIsInactive,
   markUserAsOptIn,
   markUserAsOptOut,
+  enableAppNotifications,
   requestPushNotificationsPermission,
   updateUserLastInactiveTime,
 }: UseNotificationsDrawerParams) => {
@@ -67,7 +65,6 @@ export const useNotificationsDrawer = ({
   const notifications = useSelector(notificationsSelector);
 
   const dispatch = useDispatch();
-  const navigation = useNavigation();
   const eventTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const openDrawer = useCallback(
@@ -89,15 +86,15 @@ export const useNotificationsDrawer = ({
     (
       data:
         | {
-          status: "success";
-          storedUserData: DataOfUser | null;
-          osPermissionStatus: (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus];
-          areAppNotificationsEnabled: boolean;
-        }
+            status: "success";
+            storedUserData: DataOfUser | null;
+            osPermissionStatus: (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus];
+            areAppNotificationsEnabled: boolean;
+          }
         | {
-          status: "error";
-          reason: string;
-        },
+            status: "error";
+            reason: string;
+          },
     ) => {
       if (!featureBrazePushNotifications?.enabled || isRatingsModalOpen) {
         return;
@@ -339,21 +336,23 @@ export const useNotificationsDrawer = ({
       return;
     }
 
+    enableAppNotifications();
+
+    let permission = permissionStatus;
     if (permissionStatus !== AuthorizationStatus.AUTHORIZED) {
-      const permission = await requestPushNotificationsPermission();
-      if (permission === AuthorizationStatus.DENIED) {
-        trackButtonClicked("os_notifications_deny");
-        markUserAsOptOut(promptTargetAtDismiss);
-      } else if (permission === AuthorizationStatus.AUTHORIZED) {
-        trackButtonClicked("os_notifications_allow");
-        markUserAsOptIn();
-      }
+      const requestedPermission = await requestPushNotificationsPermission();
+      permission = requestedPermission ?? permissionStatus;
     }
 
-    if (!areNotificationsAllowed) {
-      navigation.navigate(NavigatorName.Settings, {
-        screen: ScreenName.NotificationsSettings,
-      });
+    if (permission === AuthorizationStatus.DENIED) {
+      trackButtonClicked("os_notifications_deny");
+      markUserAsOptOut(promptTargetAtDismiss);
+      return;
+    }
+
+    if (permission === AuthorizationStatus.AUTHORIZED) {
+      trackButtonClicked("os_notifications_allow");
+      markUserAsOptIn();
     }
   }, [
     trackButtonClicked,
@@ -363,12 +362,11 @@ export const useNotificationsDrawer = ({
     dispatch,
     notifications,
     permissionStatus,
-    areNotificationsAllowed,
     requestPushNotificationsPermission,
     drawerSource,
+    enableAppNotifications,
     markUserAsOptIn,
     markUserAsOptOut,
-    navigation,
   ]);
 
   return {

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/hooks/useNotificationsPromptTriggers.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/hooks/useNotificationsPromptTriggers.ts
@@ -89,10 +89,7 @@ export function useNotificationsPromptTriggers() {
 
       trackInactivityDecision(decision);
 
-      if (
-        decision.kind !== "show" ||
-        decision.drawerPromptTarget !== "globalPushNotifications"
-      ) {
+      if (decision.kind !== "show" || decision.drawerPromptTarget !== "globalPushNotifications") {
         return;
       }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawer.tsx
@@ -89,14 +89,14 @@ export const NotificationsPromptDrawer = () => {
           type={"main"}
           mt={8}
           mb={7}
-          onPressIn={handleAllowNotificationsPress}
+          onPress={handleAllowNotificationsPress}
           testID="notifications-prompt-allow"
         >
           {t(allowKey)}
         </Button>
         <TextLink
           type={"shade"}
-          onPressIn={handleDelayLaterPress}
+          onPress={handleDelayLaterPress}
           testID="notifications-prompt-later"
         >
           {t(laterKey)}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile notification opt-in drawer
  - App notification category settings
  - OS notification permission flows

### 📝 Description

This PR fixes the mobile notification opt-in flow when app notifications are disabled.

Previously, pressing **Allow notifications** could redirect users to the notification settings screen. The flow now enables app notification settings directly from the prompt, including announcements and large mover categories, while preserving OS permission tracking and opt-in/opt-out behavior.


https://github.com/user-attachments/assets/1a620108-8a28-41dc-af14-0b4be6ced947



Validation:
- `pnpm mobile test:jest apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPrompt.test.tsx` passed.
- `pnpm mobile typecheck` was attempted but failed on missing generated mobile family files unrelate this change.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32195](https://ledgerhq.atlassian.net/browse/LIVE-32195)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32195]: https://ledgerhq.atlassian.net/browse/LIVE-32195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ