### PR TITLE
[LWD] feat(desktop): update disclaimer footnote on market cards

### DIFF
--- a/.changeset/thin-buckets-crash.md
+++ b/.changeset/thin-buckets-crash.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Update footnote on all cards on market list cards

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/GlobalMarketCapDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/GlobalMarketCapDialog.tsx
@@ -26,6 +26,7 @@ export const GlobalMarketCapDialog = ({ children }: { children: ReactNode }) => 
         />
         <DialogBody className="flex flex-col gap-24">
           <p className="body-1 text-base">{t("marketCapCard.dialog.content")}</p>
+          <p className="body-4 text-muted">{t("marketCapCard.dialog.disclaimer")}</p>
         </DialogBody>
         <DialogFooter className="justify-center">
           <Button

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/__tests__/GlobalMarketCapCard.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/__tests__/GlobalMarketCapCard.test.tsx
@@ -28,6 +28,11 @@ describe("GlobalMarketCapCard", () => {
     await user.click(card);
 
     expect(await screen.findByTestId("global-market-cap-dialog-content")).toBeVisible();
+    expect(
+      screen.getByText(
+        "Data is sourced from CoinMarketCap and provided for informational purposes only.",
+      ),
+    ).toBeVisible();
   });
 
   it("renders an error card on a scoped query error so the row stays intact", async () => {

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8773,7 +8773,7 @@
     "dialog": {
       "title": "Mood index",
       "content": "Shows overall market sentiment from 0 to 100, based notably on volatility, market momentum and social trends. Lower values indicate fear, higher values indicate greed.",
-      "disclaimer": "Data is sourced from CoinMarketCap's Fear and Greed Index and provided for informational purposes only.",
+      "disclaimer": "Data is sourced from CoinMarketCap and provided for informational purposes only.",
       "cta": "Got it"
     }
   },
@@ -8781,6 +8781,7 @@
     "dialog": {
       "title": "Total market cap",
       "content": "The total market cap represents the market capitalization of all cryptocurrencies combined.",
+      "disclaimer": "Data is sourced from CoinMarketCap and provided for informational purposes only.",
       "cta": "Got it"
     }
   },
@@ -8788,7 +8789,7 @@
     "dialog": {
       "title": "Altcoin index",
       "content": "The Altcoin index shows how Bitcoin is performing compared to alternative cryptocurrencies. The higher the number, the better altcoins are doing compared to Bitcoin.",
-      "disclaimer": "Data is sourced from CoinMarketCap's Altcoin Season Index and provided for informational purposes only.",
+      "disclaimer": "Data is sourced from CoinMarketCap. Provided for informational purposes only.",
       "cta": "Got it"
     }
   },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Market cap cards on the Market list (Global Market Cap, Fear & Greed, Altcoin Season)
      - Disclaimer text shown in each card's dialog
      - Verify the dialog footnote renders for the Altcoin Season card (newly added)

### 📝 Description

The disclaimer footnote text was inconsistent across the Market cap cards, and one card's dialog was missing a disclaimer entirely.

This PR standardizes the disclaimer copy across all Market cap card dialogs and adds the missing disclaimer paragraph to the Global Market Cap card dialog. The wording was simplified to remove index-specific references (e.g. "Fear and Greed Index", "Altcoin Season Index") for a consistent "Data is sourced from CoinMarketCap and provided for informational purposes only." message.

### 📸 Screenshots


https://github.com/user-attachments/assets/b3e12d9c-4056-4244-bffe-30cea7d5e137


### ❓ Context

- **JIRA or GitHub link**: [LIVE-32423](https://ledgerhq.atlassian.net/browse/LIVE-32423)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32423]: https://ledgerhq.atlassian.net/browse/LIVE-32423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ