### PR TITLE
[LWD] fix(lld): polish market v2 table layout and trend display

### DIFF
--- a/.changeset/market-v2-table-polish.md
+++ b/.changeset/market-v2-table-polish.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Market V2 table polish: truncate long asset names, render "0.00%" without a trend icon for negligible price changes, add the "Assets" subheader, and adjust table grid spacing

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/MarketTopCardsSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/MarketTopCardsSection.tsx
@@ -7,7 +7,7 @@ type MarketTopCardsSectionProps = {
 export function MarketTopCardsSection({ children }: MarketTopCardsSectionProps) {
   return (
     <section
-      className="grid grid-cols-3 gap-24 mb-24"
+      className="grid grid-cols-3 gap-12 mb-24"
       data-testid="market-top-cards-section"
       aria-label="market top cards"
     >

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/MarketRowView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/MarketRowView.tsx
@@ -3,6 +3,7 @@ import { TFunction } from "i18next";
 import { TableRow, TableCell, TableCellContent, Trend, Tag } from "@ledgerhq/lumen-ui-react";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { TruncatedText } from "LLD/components/TruncatedText";
 import { MARKET_TABLE_GRID_TEMPLATE, MARKET_CELL_CLASSNAME } from "../MarketTable/constants";
 import { MarketRowActions, MarketRowActionsProps } from "./MarketRowActions";
 
@@ -49,8 +50,9 @@ export const MarketRowView = memo<MarketRowViewProps>(function MarketRowView({
       className="absolute left-0 top-0 grid w-full items-center"
       style={{ ...style, gridTemplateColumns: MARKET_TABLE_GRID_TEMPLATE }}
     >
-      <TableCell className={MARKET_CELL_CLASSNAME}>
+      <TableCell className={`${MARKET_CELL_CLASSNAME} min-w-0 [&>div]:min-w-0`}>
         <TableCellContent
+          className="overflow-hidden"
           leadingContent={
             currency.ledgerIds.length > 0 ? (
               <CryptoIcon ledgerId={currency.ledgerIds[0]} ticker={currency.ticker} size={32} />
@@ -58,7 +60,7 @@ export const MarketRowView = memo<MarketRowViewProps>(function MarketRowView({
               <img width="32px" height="32px" src={currency.image} alt={currency.name} />
             )
           }
-          title={currency.name}
+          title={<TruncatedText text={currency.name} />}
           description={
             <span className="flex items-center gap-6">
               {ticker}
@@ -83,7 +85,13 @@ export const MarketRowView = memo<MarketRowViewProps>(function MarketRowView({
       </TableCell>
 
       <TableCell align="end" className={MARKET_CELL_CLASSNAME} data-testid="market-price-change">
-        {priceChangePercentage == null ? "-" : <Trend value={priceChangePercentage} />}
+        {priceChangePercentage == null ? (
+          "-"
+        ) : Math.abs(priceChangePercentage) < 0.005 ? (
+          <span className="body-2 text-muted">0.00%</span>
+        ) : (
+          <Trend value={priceChangePercentage} />
+        )}
       </TableCell>
 
       <TableCell align="end" className={MARKET_CELL_CLASSNAME}>

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/MarketRowView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/MarketRowView.tsx
@@ -71,15 +71,15 @@ export const MarketRowView = memo<MarketRowViewProps>(function MarketRowView({
       </TableCell>
 
       <TableCell align="end" className={MARKET_CELL_CLASSNAME} data-testid="market-coin-price">
-        {formattedPrice}
+        <TableCellContent align="end" title={formattedPrice} />
       </TableCell>
 
       <TableCell align="end" className={MARKET_CELL_CLASSNAME} data-testid="market-volume">
-        {formattedVolume}
+        <TableCellContent align="end" title={formattedVolume} />
       </TableCell>
 
       <TableCell align="end" className={MARKET_CELL_CLASSNAME} data-testid="market-cap">
-        {formattedMarketCap}
+        <TableCellContent align="end" title={formattedMarketCap} />
       </TableCell>
 
       <TableCell align="end" className={MARKET_CELL_CLASSNAME} data-testid="market-price-change">

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/__tests__/MarketRowView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/__tests__/MarketRowView.test.tsx
@@ -76,6 +76,13 @@ describe("MarketRowView", () => {
     expect(screen.getByTestId("market-price-change")).not.toHaveTextContent("-");
   });
 
+  it("should render '0.00%' without a trend icon when priceChangePercentage is 0", () => {
+    renderRow(createProps({ priceChangePercentage: 0 }));
+    const cell = screen.getByTestId("market-price-change");
+    expect(cell).toHaveTextContent("0.00%");
+    expect(cell.querySelector("svg")).toBeNull();
+  });
+
   it("should call onCurrencyClick when the row is clicked", async () => {
     const onCurrencyClick = jest.fn();
     const { user } = renderRow(createProps({ onCurrencyClick }));

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/constants.ts
@@ -1,5 +1,5 @@
 export const MARKET_TABLE_GRID_TEMPLATE =
-  "minmax(200px, 2fr) minmax(110px, 1fr) minmax(100px, 1fr) minmax(110px, 1fr) minmax(96px, 0.9fr) 150px";
+  "minmax(200px, 2fr) minmax(110px, 1fr) minmax(100px, 1fr) minmax(110px, 1fr) minmax(96px, 0.9fr) 180px";
 
 export const MARKET_CELL_CLASSNAME = "flex items-center";
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { Flex, Dropdown } from "@ledgerhq/react-ui";
+import { Subheader, SubheaderRow, SubheaderTitle } from "@ledgerhq/lumen-ui-react";
 import styled from "styled-components";
 import { useMarket } from "LLD/features/Market/hooks/useMarket";
 import TrackPage from "~/renderer/analytics/TrackPage";
@@ -141,14 +142,21 @@ export default function Market() {
       </Flex>
       <MarketTopCards />
       {shouldDisplayAssetDiscoverability && (
-        <Flex mb={3} alignItems="center" justifyContent="space-between">
-          <MarketCategoryBar categories={categories} t={t} />
-          <MarketRangeSelect
-            options={timeRangeSelectOptions}
-            value={timeRangeValue}
-            onChange={updateTimeRange}
-          />
-        </Flex>
+        <div className="flex flex-col gap-12 mb-16">
+          <Subheader>
+            <SubheaderRow>
+              <SubheaderTitle>{t("market.assetsTitle")}</SubheaderTitle>
+            </SubheaderRow>
+          </Subheader>
+          <div className="flex items-center justify-between">
+            <MarketCategoryBar categories={categories} t={t} />
+            <MarketRangeSelect
+              options={timeRangeSelectOptions}
+              value={timeRangeValue}
+              onChange={updateTimeRange}
+            />
+          </div>
+        </div>
       )}
       {shouldDisplayAssetDiscoverability ? (
         <MarketTable {...marketData} />

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -1639,6 +1639,7 @@
       "applyFilters": "Apply filters",
       "clearAll": "Clear all"
     },
+    "assetsTitle": "Assets",
     "marketTable": {
       "crypto": "Name",
       "price": "Market price",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Visual/layout changes (Assets subheader, name truncation, grid spacing, top-cards gap) are not covered by automated tests. One unit test was added for the "0.00%" trend display logic._
- [x] **Impact of the changes:**
      - Market V2 table layout: long asset names now truncate instead of overflowing
      - Price change cell renders a static "0.00%" (no trend icon) when the change is negligible (< 0.005%)
      - New "Assets" subheader displayed above the market table
      - Grid template last column widened (150px → 180px) and top cards gap reduced (24 → 12)

### 📝 Description

This PR applies several layout and display fixes to the Market V2 table on Ledger Live Desktop.

**Problem**: Long asset names overflowed their cell, near-zero price changes rendered a misleading trend arrow, the table lacked a clear "Assets" section heading, and column/card spacing needed tightening.

**Solution**:
- Wrap the asset name in `TruncatedText` and add `min-w-0` / `overflow-hidden` so names truncate cleanly within the name cell.
- Render a static `0.00%` (muted, no `Trend` icon) when `|priceChangePercentage| < 0.005`, otherwise keep the existing `Trend` component.
- Add a `Subheader` with the new `market.assetsTitle` ("Assets") label above the table.
- Widen the actions column in the grid template (150px → 180px) and reduce the top cards section gap (`gap-24` → `gap-12`).

### 🖼️ Screenshots


https://github.com/user-attachments/assets/7d992eae-f2ad-44fd-acc2-3745499cb616



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32403](https://ledgerhq.atlassian.net/browse/LIVE-32403), [LIVE-32404](https://ledgerhq.atlassian.net/browse/LIVE-32404), [LIVE-32411](https://ledgerhq.atlassian.net/browse/LIVE-32411)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIVE-32403]: https://ledgerhq.atlassian.net/browse/LIVE-32403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ