### PR TITLE
[LWDM] fix(common): compare app versions for manager updates

### DIFF
--- a/.changeset/calm-ravens-compare.md
+++ b/.changeset/calm-ravens-compare.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix My Ledger app update detection across provider catalogs

--- a/libs/ledger-live-common/src/apps/listApps.test.ts
+++ b/libs/ledger-live-common/src/apps/listApps.test.ts
@@ -1,4 +1,4 @@
-import { from } from "rxjs";
+import { from, lastValueFrom } from "rxjs";
 import { UnexpectedBootloader } from "@ledgerhq/errors";
 import { aTransportBuilder } from "@ledgerhq/hw-transport-mocker";
 import { listApps } from "./listApps";
@@ -37,6 +37,7 @@ const mockedListInstalledAppEvent: ListInstalledAppsEvent = {
 describe("listApps", () => {
   let mockedManagerApiRepository: ManagerApiRepository;
   let listAppsWithManagerApiSpy: jest.SpyInstance;
+  const appName = "Concordium";
 
   beforeEach(() => {
     mockedManagerApiRepository = new StubManagerApiRepository();
@@ -48,6 +49,81 @@ describe("listApps", () => {
       .spyOn(ManagerAPI, "listInstalledApps")
       .mockReturnValue(from([mockedListInstalledAppEvent]));
   });
+
+  const runListApps = async () => {
+    const transport = aTransportBuilder();
+    const deviceInfo = aDeviceInfoBuilder({
+      isOSU: false,
+      isBootloader: false,
+      managerAllowed: true,
+      targetId: 0x33200000,
+    });
+
+    const event = await lastValueFrom(
+      listApps({
+        managerDevModeEnabled: false,
+        transport,
+        deviceInfo,
+        managerApiRepository: mockedManagerApiRepository,
+        forceProvider: 1,
+      }),
+    );
+
+    if (event.type !== "result") {
+      throw new Error("Expected listApps to emit a result");
+    }
+
+    return event.result;
+  };
+
+  const mockInstalledAppAndCatalog = ({
+    installedVersion,
+    catalogVersion,
+    installedHash = "installed-hash",
+    catalogHash = "catalog-hash",
+  }: {
+    installedVersion: string;
+    catalogVersion: string;
+    installedHash?: string;
+    catalogHash?: string;
+  }) => {
+    mockedManagerApiRepository = {
+      ...new StubManagerApiRepository(),
+      catalogForDevice: () =>
+        Promise.resolve([
+          makeAppV2Mock({
+            versionName: appName,
+            versionDisplayName: appName,
+            version: catalogVersion,
+            hash: catalogHash,
+            currencyId: undefined,
+          }),
+        ]),
+      getAppsByHash: hashes =>
+        Promise.resolve(
+          hashes.map(hash =>
+            hash === installedHash
+              ? makeAppV2Mock({
+                  versionName: appName,
+                  versionDisplayName: appName,
+                  version: installedVersion,
+                  hash: installedHash,
+                  currencyId: undefined,
+                })
+              : null,
+          ),
+        ),
+    };
+
+    listAppsWithManagerApiSpy.mockReturnValue(
+      from([
+        {
+          type: "result",
+          payload: [{ hash: installedHash, hash_code_data: "hash_code_data", name: appName }],
+        },
+      ]),
+    );
+  };
 
   afterEach(() => {
     jest.clearAllTimers();
@@ -431,5 +507,68 @@ describe("listApps", () => {
     });
 
     jest.advanceTimersByTime(1);
+  });
+
+  it("GIVEN an installed app with a newer semver than the catalog WHEN listing apps THEN it should not mark the app as updatable", async () => {
+    // GIVEN
+    mockInstalledAppAndCatalog({
+      installedVersion: "5.6.2",
+      catalogVersion: "5.4.1",
+    });
+
+    // WHEN
+    const result = await runListApps();
+
+    // THEN
+    expect(result.installed).toEqual([
+      expect.objectContaining({
+        name: appName,
+        updated: true,
+        version: "5.6.2",
+        availableVersion: "5.4.1",
+      }),
+    ]);
+  });
+
+  it("GIVEN an installed app with an older semver than the catalog WHEN listing apps THEN it should mark the app as updatable", async () => {
+    // GIVEN
+    mockInstalledAppAndCatalog({
+      installedVersion: "5.4.1",
+      catalogVersion: "5.6.2",
+    });
+
+    // WHEN
+    const result = await runListApps();
+
+    // THEN
+    expect(result.installed).toEqual([
+      expect.objectContaining({
+        name: appName,
+        updated: false,
+        version: "5.4.1",
+        availableVersion: "5.6.2",
+      }),
+    ]);
+  });
+
+  it("GIVEN an installed app with a non-semver version WHEN hashes differ THEN it should mark the app as updatable", async () => {
+    // GIVEN
+    mockInstalledAppAndCatalog({
+      installedVersion: "blue",
+      catalogVersion: "green",
+    });
+
+    // WHEN
+    const result = await runListApps();
+
+    // THEN
+    expect(result.installed).toEqual([
+      expect.objectContaining({
+        name: appName,
+        updated: false,
+        version: "blue",
+        availableVersion: "green",
+      }),
+    ]);
   });
 });

--- a/libs/ledger-live-common/src/apps/listApps.ts
+++ b/libs/ledger-live-common/src/apps/listApps.ts
@@ -4,6 +4,7 @@ import { UnexpectedBootloader } from "@ledgerhq/errors";
 import { Observable, throwError, Subscription } from "rxjs";
 import { App, DeviceInfo, idsToLanguage, languageIds } from "@ledgerhq/types-live";
 import { LocalTracer } from "@ledgerhq/logs";
+import semver from "semver";
 import type { ListAppsEvent, ListAppsResult, ListAppResponse } from "./types";
 import customLockScreenFetchSize from "../hw/customLockScreenFetchSize";
 import { listCryptoCurrencies, currenciesByMarketcap, findCryptoCurrencyById } from "../currencies";
@@ -19,10 +20,31 @@ import { DeviceId } from "@ledgerhq/client-ids/ids";
 
 // Hash discrepancies for these apps do NOT indicate a potential update,
 // these apps have a mechanism that makes their hash change every time.
-const appsWithDynamicHashes = ["Fido U2F", "Security Key"];
+const appsWithDynamicHashes = new Set(["Fido U2F", "Security Key"]);
 
 // Empty hash data means we won't have information on the app.
 const emptyHashData = "0".repeat(64);
+
+const isUpdateAvailable = ({
+  installedVersion,
+  availableVersion,
+  installedHash,
+  availableHash,
+}: {
+  installedVersion?: string;
+  availableVersion?: string;
+  installedHash: string;
+  availableHash?: string;
+}): boolean => {
+  const installedSemver = semver.valid(installedVersion);
+  const availableSemver = semver.valid(availableVersion);
+
+  if (installedSemver && availableSemver) {
+    return semver.gt(availableSemver, installedSemver);
+  }
+
+  return availableHash !== installedHash;
+};
 
 type ListAppsParams = {
   transport: Transport;
@@ -247,8 +269,13 @@ export const listApps = ({
       const installed = installedList.map(({ name, hash, bytes, version }) => {
         installedAppNames[name] = true;
         const appInCatalog = appByName[name];
-        const updateAvailable = appInCatalog?.hash !== hash;
-        const ignoreUpdate = appsWithDynamicHashes.includes(name);
+        const updateAvailable = isUpdateAvailable({
+          installedVersion: version,
+          availableVersion: appInCatalog?.version,
+          installedHash: hash,
+          availableHash: appInCatalog?.hash,
+        });
+        const ignoreUpdate = appsWithDynamicHashes.has(name);
         const updated = ignoreUpdate || !updateAvailable;
         const availableVersion = appInCatalog?.version || "";
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - My Ledger installed-app update detection
  - Experimental provider switching scenarios
  - Non-semver app versions that still rely on hash comparison

### 📝 Description

My Ledger was marking installed apps as updatable whenever the installed app hash differed from the active provider catalog hash. This caused a false downgrade prompt when an app was installed from one provider, then My Ledger was reopened with another provider selected.

The update detection now compares app version strings when both installed and catalog versions are valid semver values. If either side is not valid semver, it keeps the previous hash comparison behavior so non-standard app versions still rely on binary hash differences.

**Before**: installing Tezos `3.2.0` from P1 and switching to P4 could show an update to `3.1.0` because 3.1.0 is the latest on P4 and the hashes differed.

<img width="1624" height="1002" alt="Screenshot 2026-06-12 at 15 37 51" src="https://github.com/user-attachments/assets/f999c0cb-98a7-450c-9868-cb933b355291" />

**After**: the app is only marked updatable when the selected provider offers a greater semver version; hash comparison remains the fallback for non-semver versions.

<img width="1624" height="1001" alt="Screenshot 2026-06-12 at 15 55 16" src="https://github.com/user-attachments/assets/e70bb416-64aa-44a1-8358-3531fa373b5d" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-32156](https://ledgerhq.atlassian.net/browse/LIVE-32156)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32156]: https://ledgerhq.atlassian.net/browse/LIVE-32156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ