### PR TITLE
[LWM] refactor(mobile): improve notification prompt drawer architecture

### DIFF
--- a/.changeset/steady-drawers-clean.md
+++ b/.changeset/steady-drawers-clean.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Improve mobile notification prompt drawer architecture

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/useCompletePostOnboarding.ts
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/useCompletePostOnboarding.ts
@@ -4,7 +4,7 @@ import { useDispatch } from "~/context/hooks";
 import { useNavigation } from "@react-navigation/native";
 import { postOnboardingSetFinished } from "@ledgerhq/live-common/postOnboarding/actions";
 import { NavigatorName } from "~/const";
-import { useNotifications } from "LLM/features/NotificationsPrompt";
+import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
 
 export type CompletePostOnboardingOptions = {
   readonly skipPortfolioNavigation?: boolean;
@@ -14,11 +14,11 @@ export function useCompletePostOnboarding() {
   const dispatch = useDispatch();
   const navigation = useNavigation();
 
-  const { tryTriggerPushNotificationDrawerAfterAction } = useNotifications();
+  const { notifyFlowCompleted } = useNotificationsContext();
 
   const closePostOnboarding = useCallback(
     (options?: CompletePostOnboardingOptions) => {
-      tryTriggerPushNotificationDrawerAfterAction("onboarding");
+      notifyFlowCompleted("onboarding");
 
       dispatch(postOnboardingSetFinished());
 
@@ -29,7 +29,7 @@ export function useCompletePostOnboarding() {
         });
       }
     },
-    [dispatch, navigation, tryTriggerPushNotificationDrawerAfterAction],
+    [dispatch, navigation, notifyFlowCompleted],
   );
 
   return closePostOnboarding;

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/QueuedDrawerBottomSheet.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/QueuedDrawerBottomSheet.tsx
@@ -1,9 +1,8 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { Platform } from "react-native";
-import { BottomSheet, BottomSheetProps } from "@ledgerhq/lumen-ui-rnative";
+import { BottomSheet, BottomSheetProps, Box } from "@ledgerhq/lumen-ui-rnative";
 import { IsInDrawerProvider } from "~/context/IsInDrawerContext";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { Box } from "@ledgerhq/native-ui";
 import { BottomSheetBackgroundContext } from "LLM/contexts/BottomSheetBackgroundContext";
 import useQueuedDrawerBottomSheet from "./useQueuedDrawerBottomSheet";
 
@@ -22,6 +21,8 @@ export type QueuedDrawerBottomSheetProps = {
   onBack?: () => void;
   /** Callback when the drawer is closed. */
   onClose?: () => void;
+  /** Callback when the backdrop is pressed. */
+  onBackdropPress?: () => void;
   /** Callback after the drawer is fully hidden. */
   onModalHide?: () => void;
   /** Prevent closing via backdrop press. */
@@ -48,6 +49,7 @@ const QueuedDrawerBottomSheet = ({
   isRequestingToBeOpened = false,
   isForcingToBeOpened = false,
   onClose,
+  onBackdropPress,
   onBack,
   hasBackButton,
   onModalHide,
@@ -82,6 +84,11 @@ const QueuedDrawerBottomSheet = ({
     preventBackdropClick,
   });
 
+  const handleBackdropPress = useCallback(() => {
+    onBackdropPress?.();
+    handleUserClose();
+  }, [handleUserClose, onBackdropPress]);
+
   return (
     <BottomSheet
       ref={bottomSheetRef}
@@ -98,7 +105,7 @@ const QueuedDrawerBottomSheet = ({
       onAnimate={handleCloseAnimationStart}
       onDismiss={handleDismiss}
       backdropPressBehavior={preventBackdropClick || areDrawersLocked ? "none" : "close"}
-      onBackdropPress={handleUserClose}
+      onBackdropPress={handleBackdropPress}
       backgroundComponent={backgroundComponent}
     >
       <BottomSheetBackgroundContext.Provider value={backgroundContextValue}>
@@ -111,7 +118,7 @@ const QueuedDrawerBottomSheet = ({
 
 const OnscreenNavigationSafeArea = () => {
   const insets = useSafeAreaInsets();
-  return <Box height={Platform.OS === "android" ? insets.bottom : 0} />;
+  return <Box style={{ height: Platform.OS === "android" ? insets.bottom : 0 }} />;
 };
 
 export default React.memo(QueuedDrawerBottomSheet);

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/__tests__/useAssetCoinOptionsViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/__tests__/useAssetCoinOptionsViewModel.test.tsx
@@ -1,16 +1,19 @@
-import { act, renderHook } from "@tests/test-renderer";
+import React from "react";
+import { act, renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { track } from "~/analytics";
 import type { State } from "~/reducers/types";
+import { NotificationsPromptProvider } from "LLM/features/NotificationsPrompt";
+import { createNotificationsPromptFeatureFlags } from "LLM/features/NotificationsPrompt/testUtils";
 import { useAssetCoinOptionsViewModel } from "../useAssetCoinOptionsViewModel";
-
-jest.mock("LLM/features/NotificationsPrompt", () => ({
-  useNotifications: () => ({ tryTriggerPushNotificationDrawerAfterAction: jest.fn() }),
-}));
 
 jest.mock("~/analytics", () => ({ track: jest.fn() }));
 
 const bitcoin = getCryptoCurrencyById("bitcoin");
+
+const innerWrapper = ({ children }: { children?: React.ReactNode }) => (
+  <NotificationsPromptProvider>{children}</NotificationsPromptProvider>
+);
 
 function renderViewModel({
   blacklistedTokenIds = [],
@@ -24,10 +27,18 @@ function renderViewModel({
   return renderHook(
     () => useAssetCoinOptionsViewModel({ currency: bitcoin, currencyId: bitcoin.id, marketId }),
     {
-      overrideInitialState: (state: State): State => ({
-        ...state,
-        settings: { ...state.settings, blacklistedTokenIds, starredMarketCoins },
-      }),
+      innerWrapper,
+      overrideInitialState: withFlagOverrides(
+        createNotificationsPromptFeatureFlags(),
+        (state: State): State => ({
+          ...state,
+          settings: {
+            ...state.settings,
+            blacklistedTokenIds,
+            starredMarketCoins,
+          },
+        }),
+      ),
     },
   );
 }
@@ -42,11 +53,19 @@ describe("useAssetCoinOptionsViewModel", () => {
 
     act(() => result.current.onToggleFavourite());
     expect(store.getState().settings.starredMarketCoins).toContain(bitcoin.id);
-    expect(track).toHaveBeenLastCalledWith(
+    expect(track).toHaveBeenCalledWith(
       "button_clicked",
       expect.objectContaining({
         button: "favourite",
         is_favourite: true,
+      }),
+    );
+    act(() => jest.runOnlyPendingTimers());
+    expect(store.getState().notifications).toEqual(
+      expect.objectContaining({
+        drawerSource: "add_favorite_coin",
+        drawerPromptTarget: "globalPushNotifications",
+        isPushNotificationsModalOpen: true,
       }),
     );
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketDetail/useMarketDetailViewModel.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketDetail/useMarketDetailViewModel.tsx
@@ -4,7 +4,7 @@ import { readOnlyModeEnabledSelector } from "~/reducers/settings";
 import { accountsSelector } from "~/reducers/accounts";
 import { screen, track } from "~/analytics";
 import { ScreenName } from "~/const";
-import { useNotifications } from "LLM/features/NotificationsPrompt";
+import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
 import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { MarketNavigatorStackParamList } from "LLM/features/Market/Navigator";
 
@@ -42,7 +42,7 @@ function useMarketDetailViewModel({ navigation, route }: NavigationProps) {
   );
 
   const dispatch = useDispatch();
-  const { tryTriggerPushNotificationDrawerAfterAction } = useNotifications();
+  const { notifyFlowCompleted } = useNotificationsContext();
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
 
   const { starredMarketCoins, updateMarketParams } = useMarket();
@@ -99,8 +99,8 @@ function useMarketDetailViewModel({ navigation, route }: NavigationProps) {
     const action = isStarred ? removeStarredMarketCoins : addStarredMarketCoins;
     dispatch(action(currencyId));
 
-    if (!isStarred) tryTriggerPushNotificationDrawerAfterAction("add_favorite_coin");
-  }, [dispatch, isStarred, currencyId, tryTriggerPushNotificationDrawerAfterAction]);
+    if (!isStarred) notifyFlowCompleted("add_favorite_coin");
+  }, [dispatch, isStarred, currencyId, notifyFlowCompleted]);
 
   return {
     defaultAccount,

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPrompt.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPrompt.test.tsx
@@ -5,6 +5,7 @@ import {
   NotificationsPromptWrapper,
   setPushNotificationsDataOfUserInStorage,
   useNotifications,
+  useNotificationsContext,
 } from "LLM/features/NotificationsPrompt";
 
 import storage from "LLM/storage";
@@ -112,11 +113,9 @@ describe("NotificationsPrompt Integration", () => {
       const [isReady, setIsReady] = useState(false);
       const [reloadCount, reload] = useReducer(x => x + 1, 0);
 
-      const {
-        tryTriggerPushNotificationDrawerAfterAction,
-        initPushNotificationsData,
-        tryTriggerPushNotificationDrawerAfterInactivity,
-      } = useNotifications();
+      const { initPushNotificationsData } = useNotifications();
+      const { notifyFlowCompleted, tryTriggerPushNotificationDrawerAfterInactivity } =
+        useNotificationsContext();
 
       useEffect(() => {
         initPushNotificationsData()
@@ -133,76 +132,84 @@ describe("NotificationsPrompt Integration", () => {
 
       return (
         <>
-          <Button onPress={() => tryTriggerPushNotificationDrawerAfterAction(actionSource)}>
-            Trigger drawer
-          </Button>
+          <Button onPress={() => notifyFlowCompleted(actionSource)}>Trigger drawer</Button>
           <Button onPress={reload}>Reload app</Button>
         </>
       );
     }
 
-    const rendered = render(
+    const ui = (
       <NotificationsPromptProvider>
         <SetupComponent />
         <NotificationsPromptWrapper />
-      </NotificationsPromptProvider>,
-      {
-        overrideInitialState: withFlagOverrides(
-          createNotificationsPromptFeatureFlags({
-            variant,
-            repromptSchedule: REPROMPT_SCHEDULE.map(s => ({
-              months: 0,
-              hours: 0,
-              minutes: 0,
-              seconds: 0,
-              days: "days" in s ? s.days : 0,
-            })),
-            notificationsCategories: [
-              {
-                displayed: true,
-                category: "announcementsCategory",
-              },
-              {
-                displayed: true,
-                category: "recommendationsCategory",
-              },
-              {
-                displayed: true,
-                category: "largeMoverCategory",
-              },
-              {
-                displayed: true,
-                category: "transactionsAlertsCategory",
-              },
-              {
-                displayed: true,
-                category: "totalMarketCap",
-              },
-              {
-                displayed: true,
-                category: "topGainersLosers",
-              },
-            ],
-            inactivityEnabled: true,
-          }),
-          state => ({
-            ...state,
-            settings: {
-              ...state.settings,
-              notifications: {
-                ...state.settings.notifications,
-                areNotificationsAllowed: appNotifications,
-              },
-            },
-          }),
-        ),
-      },
+      </NotificationsPromptProvider>
     );
+
+    const rendered = render(ui, {
+      overrideInitialState: withFlagOverrides(
+        createNotificationsPromptFeatureFlags({
+          variant,
+          repromptSchedule: REPROMPT_SCHEDULE.map(s => ({
+            months: 0,
+            hours: 0,
+            minutes: 0,
+            seconds: 0,
+            days: "days" in s ? s.days : 0,
+          })),
+          notificationsCategories: [
+            {
+              displayed: true,
+              category: "announcementsCategory",
+            },
+            {
+              displayed: true,
+              category: "recommendationsCategory",
+            },
+            {
+              displayed: true,
+              category: "largeMoverCategory",
+            },
+            {
+              displayed: true,
+              category: "transactionsAlertsCategory",
+            },
+            {
+              displayed: true,
+              category: "totalMarketCap",
+            },
+            {
+              displayed: true,
+              category: "topGainersLosers",
+            },
+          ],
+          inactivityEnabled: true,
+        }),
+        state => ({
+          ...state,
+          settings: {
+            ...state.settings,
+            hasCompletedOnboarding: true,
+            notifications: {
+              ...state.settings.notifications,
+              areNotificationsAllowed: appNotifications,
+            },
+          },
+        }),
+      ),
+    });
 
     const tryTriggerDrawer = async () => {
       const triggerDrawerButton = await screen.findByRole("button", { name: /trigger drawer/i });
       await rendered.user.press(triggerDrawerButton);
-      act(() => jest.runOnlyPendingTimers());
+      await act(async () => {
+        jest.runAllTimers();
+      });
+      if (rendered.store.getState().notifications.isPushNotificationsModalOpen) {
+        rendered.rerender(ui);
+        await waitFor(() =>
+          expect(screen.getByTestId("notifications-prompt-allow")).toBeOnTheScreen(),
+        );
+      }
     };
 
     await waitFor(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/components/NotificationsPromptContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/components/NotificationsPromptContent.tsx
@@ -1,39 +1,26 @@
 import React from "react";
-import { Text } from "@ledgerhq/native-ui";
-import { useTranslation } from "~/context/Locale";
-import { useFeature } from "@features/platform-feature-flags";
-import { AB_TESTING_VARIANTS } from "../types/variants";
-import type { NotificationPromptTarget } from "../types";
-import { getNotificationsPromptCopy } from "../utils/getNotificationsPromptCopy";
+import { Text } from "@ledgerhq/lumen-ui-rnative";
 
 type NotificationsPromptContentProps = {
-  promptTarget?: NotificationPromptTarget;
+  readonly title: string;
+  readonly description: string;
 };
 
-export const NotificationsPromptContent = ({ promptTarget }: NotificationsPromptContentProps) => {
-  const { t } = useTranslation();
-  const featureNewWordingNotificationsDrawer = useFeature("lwmNewWordingOptInNotificationsDrawer");
-
-  const isVariantB =
-    featureNewWordingNotificationsDrawer?.enabled === true &&
-    featureNewWordingNotificationsDrawer?.params?.variant === AB_TESTING_VARIANTS.B;
-
-  const { titleKey, descriptionKey } = getNotificationsPromptCopy(promptTarget, isVariantB);
-
+export const NotificationsPromptContent = ({
+  title,
+  description,
+}: NotificationsPromptContentProps) => {
   return (
     <>
-      <Text textAlign="center" variant="h4" fontWeight="semiBold" color="neutral.c100" mt={5}>
-        {t(titleKey)}
+      <Text
+        typography="heading4SemiBold"
+        lx={{ color: "base", marginTop: "s20", textAlign: "center" }}
+      >
+        {title}
       </Text>
 
-      <Text
-        variant="bodyLineHeight"
-        fontWeight="medium"
-        color="neutral.c70"
-        textAlign="center"
-        mt={3}
-      >
-        {t(descriptionKey)}
+      <Text typography="body2" lx={{ color: "muted", marginTop: "s12", textAlign: "center" }}>
+        {description}
       </Text>
     </>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/components/__tests__/NotificationsPromptContent.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/components/__tests__/NotificationsPromptContent.test.tsx
@@ -1,20 +1,17 @@
 import React from "react";
-import { render, screen, withFlagOverrides } from "@tests/test-renderer";
+import { render, screen } from "@tests/test-renderer";
 import { NotificationsPromptContent } from "../NotificationsPromptContent";
-import { AB_TESTING_VARIANTS } from "../../types/variants";
-import { createNotificationsPromptFeatureFlags } from "../../testUtils";
 
-const renderContent = (
-  props: React.ComponentProps<typeof NotificationsPromptContent> = {},
-  featureFlags = createNotificationsPromptFeatureFlags(),
-) =>
-  render(<NotificationsPromptContent {...props} />, {
-    overrideInitialState: withFlagOverrides(featureFlags),
-  });
+const renderContent = (props: React.ComponentProps<typeof NotificationsPromptContent>) =>
+  render(<NotificationsPromptContent {...props} />);
 
 describe("NotificationsPromptContent", () => {
-  it("should render variant A global push copy when the wording flag uses variant A", () => {
-    renderContent({}, createNotificationsPromptFeatureFlags({ variant: AB_TESTING_VARIANTS.A }));
+  it("should render the given title and description", () => {
+    renderContent({
+      title: "Turn notifications on",
+      description:
+        "Get the latest updates on Ledger Wallet, Ledger products, the market, and personalised recommendations. Opt-out anytime in the settings",
+    });
 
     expect(screen.getByText("Turn notifications on")).toBeOnTheScreen();
     expect(
@@ -22,47 +19,5 @@ describe("NotificationsPromptContent", () => {
         "Get the latest updates on Ledger Wallet, Ledger products, the market, and personalised recommendations. Opt-out anytime in the settings",
       ),
     ).toBeOnTheScreen();
-  });
-
-  it("should render variant B global push copy when the wording flag uses variant B", () => {
-    renderContent({}, createNotificationsPromptFeatureFlags({ variant: AB_TESTING_VARIANTS.B }));
-
-    expect(screen.getByText("Don't miss what matters")).toBeOnTheScreen();
-    expect(
-      screen.getByText(
-        "Get real-time alerts on new tokens, earning opportunities, and market shifts. Opt out at any time.",
-      ),
-    ).toBeOnTheScreen();
-  });
-
-  it("should render default global push copy when the wording feature flag is disabled", () => {
-    renderContent(
-      {},
-      {
-        ...createNotificationsPromptFeatureFlags({ variant: AB_TESTING_VARIANTS.B }),
-        lwmNewWordingOptInNotificationsDrawer: {
-          enabled: false,
-          params: { variant: AB_TESTING_VARIANTS.B },
-        },
-      },
-    );
-
-    expect(screen.getByText("Turn notifications on")).toBeOnTheScreen();
-    expect(screen.queryByText("Don't miss what matters")).not.toBeOnTheScreen();
-  });
-
-  it("should render transaction alerts copy regardless of wording variant", () => {
-    renderContent(
-      { promptTarget: "transactionsAlertsCategory" },
-      createNotificationsPromptFeatureFlags({ variant: AB_TESTING_VARIANTS.B }),
-    );
-
-    expect(screen.getByText("Know the status of your money")).toBeOnTheScreen();
-    expect(
-      screen.getByText(
-        "Receive real-time alerts when your crypto is sent or received. Opt out at anytime via Settings.",
-      ),
-    ).toBeOnTheScreen();
-    expect(screen.queryByText("Don't miss what matters")).not.toBeOnTheScreen();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotifications.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotifications.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import { getNotificationPermissionStatus } from "~/logic/getNotificationPermissionStatus";
 import { useNotificationsPermission } from "LLM/hooks/useNotificationsPermission";
 import { useNotificationsData } from "./useNotificationsData";
@@ -21,32 +21,27 @@ const useNotifications = () => {
     updateUserLastInactiveTime,
   } = useNotificationsData();
 
-  const { nextRepromptDelay, shouldPromptOptInDrawerAfterAction, checkIsInactive } =
-    useNotificationsPrompt({
-      permissionStatus,
-      areNotificationsAllowed: notifications.areNotificationsAllowed,
-      transactionsAlertsCategory: notifications.transactionsAlertsCategory,
-      pushNotificationsDataOfUser,
-    });
+  const { nextRepromptDelay } = useNotificationsPrompt({
+    permissionStatus,
+    areNotificationsAllowed: notifications.areNotificationsAllowed,
+    transactionsAlertsCategory: notifications.transactionsAlertsCategory,
+    pushNotificationsDataOfUser,
+  });
 
   const {
     isPushNotificationsModalOpen,
     drawerSource,
     drawerPromptTarget,
-    eventTimeoutRef,
-    tryTriggerPushNotificationDrawerAfterAction,
-    tryTriggerPushNotificationDrawerAfterInactivity,
     handleAllowNotificationsPress,
     handleDelayLaterPress,
     handleCloseFromBackdropPress,
+    handleModalHide,
   } = useNotificationsDrawer({
     permissionStatus,
     areNotificationsAllowed: notifications.areNotificationsAllowed,
     pushNotificationsDataOfUser,
     nextRepromptDelay,
-    shouldPromptOptInDrawerAfterAction,
     updateUserLastInactiveTime,
-    checkIsInactive,
     markUserAsOptOut,
     markUserAsOptIn,
     requestPushNotificationsPermission,
@@ -120,15 +115,6 @@ const useNotifications = () => {
     updatePushNotificationsDataOfUserInStateAndStore,
   ]);
 
-  useEffect(() => {
-    return () => {
-      if (eventTimeoutRef.current) {
-        clearTimeout(eventTimeoutRef.current);
-        eventTimeoutRef.current = null;
-      }
-    };
-  }, [eventTimeoutRef]);
-
   const permission = {
     permissionStatus,
     requestPushNotificationsPermission,
@@ -141,15 +127,12 @@ const useNotifications = () => {
     handleAllowNotificationsPress,
     handleDelayLaterPress,
     handleCloseFromBackdropPress,
+    handleModalHide,
   };
 
   const prompt = {
     nextRepromptDelay,
     pushNotificationsDataOfUser,
-    shouldPromptOptInDrawerAfterAction,
-    tryTriggerPushNotificationDrawerAfterAction,
-    // Call only on stack navigators where onboarding is already complete.
-    tryTriggerPushNotificationDrawerAfterInactivity,
   };
 
   const userState = {

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
@@ -1,5 +1,4 @@
-import { useCallback, useRef } from "react";
-import { InteractionManager } from "react-native";
+import { useCallback } from "react";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { useNavigation } from "@react-navigation/core";
 import { AuthorizationStatus } from "@react-native-firebase/messaging";
@@ -18,24 +17,19 @@ import {
   notificationsDrawerSource,
   notificationsModalOpenSelector,
 } from "~/reducers/notifications";
-import { ratingsModalOpenSelector } from "~/reducers/ratings";
 import { notificationsSelector } from "~/reducers/settings";
-import { type NotificationsState } from "~/reducers/types";
 import { type DataOfUser, type NotificationPromptTarget } from "../types";
-import { AB_TESTING_VARIANTS } from "../types/variants";
 import { resolveDrawerPromptTargetForAnalytics } from "../new/notificationsPromptAnalytics";
 import { isTransactionsAlertsPromptTarget } from "../utils/getNotificationsPromptCopy";
 
 type UseNotificationsDrawerParams = {
   permissionStatus:
-  | (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus]
-  | null
-  | undefined;
+    | (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus]
+    | null
+    | undefined;
   areNotificationsAllowed: boolean | undefined;
   pushNotificationsDataOfUser: DataOfUser | null | undefined;
   nextRepromptDelay: { days?: number; hours?: number; minutes?: number } | null;
-  shouldPromptOptInDrawerAfterAction: () => boolean;
-  checkIsInactive: (lastActionAt?: number) => boolean;
   markUserAsOptIn: () => void;
   markUserAsOptOut: (promptTarget?: NotificationPromptTarget) => void;
   updateUserLastInactiveTime: () => void;
@@ -49,204 +43,20 @@ export const useNotificationsDrawer = ({
   areNotificationsAllowed,
   pushNotificationsDataOfUser,
   nextRepromptDelay,
-  shouldPromptOptInDrawerAfterAction,
-  checkIsInactive,
   markUserAsOptIn,
   markUserAsOptOut,
   requestPushNotificationsPermission,
   updateUserLastInactiveTime,
 }: UseNotificationsDrawerParams) => {
-  const featureBrazePushNotifications = useFeature("brazePushNotifications");
   const featureNewWordingNotificationsDrawer = useFeature("lwmNewWordingOptInNotificationsDrawer");
-  const actionEvents = featureBrazePushNotifications?.params?.action_events;
 
   const isPushNotificationsModalOpen = useSelector(notificationsModalOpenSelector);
-  const isRatingsModalOpen = useSelector(ratingsModalOpenSelector);
   const drawerSource = useSelector(notificationsDrawerSource);
   const drawerPromptTarget = useSelector(notificationsDrawerPromptTarget);
   const notifications = useSelector(notificationsSelector);
 
   const dispatch = useDispatch();
   const navigation = useNavigation();
-  const eventTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-  const openDrawer = useCallback(
-    (drawerSource: Exclude<NotificationsState["drawerSource"], undefined>, timer = 0) => {
-      if (eventTimeoutRef.current) {
-        clearTimeout(eventTimeoutRef.current);
-        eventTimeoutRef.current = null;
-      }
-
-      eventTimeoutRef.current = setTimeout(() => {
-        dispatch(setNotificationsModalOpen(true));
-        dispatch(setNotificationsDrawerSource(drawerSource));
-      }, timer);
-    },
-    [dispatch],
-  );
-
-  const tryTriggerPushNotificationDrawerAfterInactivity = useCallback(
-    (
-      data:
-        | {
-          status: "success";
-          storedUserData: DataOfUser | null;
-          osPermissionStatus: (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus];
-          areAppNotificationsEnabled: boolean;
-        }
-        | {
-          status: "error";
-          reason: string;
-        },
-    ) => {
-      if (!featureBrazePushNotifications?.enabled || isRatingsModalOpen) {
-        return;
-      }
-      if (data.status === "error") {
-        return;
-      }
-
-      // Group A (variant A) never sees inactivity drawer
-      const variant = featureNewWordingNotificationsDrawer?.params?.variant;
-      const isVariantA =
-        featureNewWordingNotificationsDrawer?.enabled && variant === AB_TESTING_VARIANTS.A;
-      if (isVariantA) {
-        return;
-      }
-
-      const isOptOut =
-        data.osPermissionStatus !== AuthorizationStatus.AUTHORIZED ||
-        !data.areAppNotificationsEnabled;
-      if (!isOptOut) {
-        return;
-      }
-
-      const isInactive = checkIsInactive(data.storedUserData?.lastActionAt);
-      if (isInactive) {
-        openDrawer("inactivity", 1000);
-      }
-    },
-    [
-      featureBrazePushNotifications?.enabled,
-      isRatingsModalOpen,
-      featureNewWordingNotificationsDrawer?.enabled,
-      featureNewWordingNotificationsDrawer?.params?.variant,
-      openDrawer,
-      checkIsInactive,
-    ],
-  );
-
-  const tryTriggerPushNotificationDrawerAfterAction = useCallback(
-    (actionSource: Exclude<NotificationsState["drawerSource"], undefined | "inactivity">) => {
-      if (!featureBrazePushNotifications?.enabled || isRatingsModalOpen || !actionEvents) {
-        return;
-      }
-
-      const shouldPrompt = shouldPromptOptInDrawerAfterAction();
-
-      track("attempt_to_trigger_push_notification_drawer_after_action", {
-        action: actionSource,
-        shouldPrompt,
-        variant: featureNewWordingNotificationsDrawer?.params?.variant,
-        repromptDelay: nextRepromptDelay,
-        dismissedCount: pushNotificationsDataOfUser?.dismissedOptInDrawerAtList?.length ?? 0,
-        drawerPromptTarget: shouldPrompt
-          ? resolveDrawerPromptTargetForAnalytics(undefined)
-          : undefined,
-      });
-
-      if (!shouldPrompt) {
-        return;
-      }
-
-      const variant = featureNewWordingNotificationsDrawer?.params?.variant;
-      const isVariantA =
-        featureNewWordingNotificationsDrawer?.enabled && variant === AB_TESTING_VARIANTS.A;
-
-      // For non-onboarding actions, Group A (variant A) never shows drawer
-      if (actionSource !== "onboarding" && isVariantA) {
-        return;
-      }
-
-      const openDrawerCallback = (...args: Parameters<typeof openDrawer>) => {
-        InteractionManager.runAfterInteractions(() => openDrawer(...args));
-      };
-
-      switch (actionSource) {
-        case "onboarding": {
-          const onboardingParams = actionEvents?.complete_onboarding;
-          if (!onboardingParams?.enabled) {
-            return;
-          }
-          openDrawerCallback("onboarding", onboardingParams?.timer);
-          break;
-        }
-        case "add_favorite_coin": {
-          const addFavoriteCoinParams = actionEvents?.add_favorite_coin;
-          if (!addFavoriteCoinParams?.enabled) {
-            return;
-          }
-          openDrawerCallback("add_favorite_coin", addFavoriteCoinParams?.timer);
-          break;
-        }
-        case "send": {
-          const sendParams = actionEvents?.send;
-          if (!sendParams?.enabled) {
-            return;
-          }
-          openDrawerCallback("send", sendParams?.timer);
-          break;
-        }
-        case "dapp_complete": {
-          const dAppCompleteParams = actionEvents?.dapp_complete;
-          if (!dAppCompleteParams?.enabled) {
-            return;
-          }
-          openDrawerCallback("dapp_complete", dAppCompleteParams?.timer);
-          break;
-        }
-        case "receive": {
-          const receiveParams = actionEvents?.receive;
-          if (!receiveParams?.enabled) {
-            return;
-          }
-          openDrawerCallback("receive", receiveParams?.timer);
-          break;
-        }
-        case "swap": {
-          const swapParams = actionEvents?.swap;
-          if (!swapParams?.enabled) {
-            return;
-          }
-          openDrawerCallback("swap", swapParams?.timer);
-          break;
-        }
-        case "stake": {
-          const stakeParams = actionEvents?.stake;
-          if (!stakeParams?.enabled) {
-            return;
-          }
-          openDrawerCallback("stake", stakeParams?.timer);
-          break;
-        }
-        default: {
-          console.error(`Unknown action source: ${actionSource}`);
-          break;
-        }
-      }
-    },
-    [
-      featureBrazePushNotifications?.enabled,
-      isRatingsModalOpen,
-      actionEvents,
-      shouldPromptOptInDrawerAfterAction,
-      featureNewWordingNotificationsDrawer?.enabled,
-      featureNewWordingNotificationsDrawer?.params?.variant,
-      openDrawer,
-      nextRepromptDelay,
-      pushNotificationsDataOfUser?.dismissedOptInDrawerAtList?.length,
-    ],
-  );
 
   const trackButtonClicked = useCallback(
     (eventName: string) => {
@@ -274,6 +84,10 @@ export const useNotificationsDrawer = ({
 
   const closeDrawer = useCallback(() => {
     dispatch(setNotificationsModalOpen(false));
+  }, [dispatch]);
+
+  const handleModalHide = useCallback(() => {
+    // Keep source/target stable while the close animation renders.
     dispatch(setNotificationsDrawerSource(undefined));
     dispatch(setNotificationsDrawerPromptTarget(undefined));
   }, [dispatch]);
@@ -375,11 +189,9 @@ export const useNotificationsDrawer = ({
     isPushNotificationsModalOpen,
     drawerSource,
     drawerPromptTarget,
-    eventTimeoutRef,
-    tryTriggerPushNotificationDrawerAfterAction,
     handleAllowNotificationsPress,
     handleDelayLaterPress,
     handleCloseFromBackdropPress,
-    tryTriggerPushNotificationDrawerAfterInactivity,
+    handleModalHide,
   };
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawer.tsx
@@ -1,107 +1,68 @@
-import React, { useCallback, useRef } from "react";
-import { useTranslation } from "~/context/Locale";
-import { Flex, Link as TextLink, Button } from "@ledgerhq/native-ui";
-import { useNotifications } from "LLM/features/NotificationsPrompt";
-import QueuedDrawer from "LLM/components/QueuedDrawer";
+import React from "react";
+import { BottomSheetView, Box, Button, Link } from "@ledgerhq/lumen-ui-rnative";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
 import { NotificationsDrawerIllustration } from "LLM/features/NotificationsPrompt/components/NotificationsDrawerIllustration";
 import { NotificationsPromptContent } from "LLM/features/NotificationsPrompt/components/NotificationsPromptContent";
-import { resolveDrawerPromptTargetForAnalytics } from "LLM/features/NotificationsPrompt/new/notificationsPromptAnalytics";
-import { getNotificationsPromptCopy } from "LLM/features/NotificationsPrompt/utils/getNotificationsPromptCopy";
-import type { NotificationPromptTarget } from "LLM/features/NotificationsPrompt/types";
 import { TrackScreen } from "~/analytics";
-import { useFeature } from "@features/platform-feature-flags";
-import { AB_TESTING_VARIANTS } from "LLM/features/NotificationsPrompt/types/variants";
-import type { NotificationsState } from "~/reducers/types";
+import { useNotificationsPromptDrawerViewModel } from "./useNotificationsPromptDrawerViewModel";
 
-type DrawerDisplayState = {
-  drawerSource: NotificationsState["drawerSource"];
-  drawerPromptTarget: NotificationPromptTarget | undefined;
+type NotificationsPromptDrawerViewProps = ReturnType<typeof useNotificationsPromptDrawerViewModel>;
+
+const NotificationsPromptDrawerView = ({
+  isOpen,
+  promptTarget,
+  title,
+  description,
+  allowLabel,
+  laterLabel,
+  onAllowNotificationsPress,
+  onDelayLaterPress,
+  onCloseFromBackdropPress,
+  onModalHide,
+  trackScreenProps,
+}: NotificationsPromptDrawerViewProps) => {
+  return (
+    <QueuedDrawerBottomSheet
+      isRequestingToBeOpened={isOpen}
+      enableDynamicSizing
+      noCloseButton
+      onBackdropPress={onCloseFromBackdropPress}
+      onModalHide={onModalHide}
+    >
+      <TrackScreen {...trackScreenProps} />
+
+      <BottomSheetView style={{ paddingHorizontal: 16, paddingTop: 16, paddingBottom: 16 }}>
+        <Box lx={{ alignItems: "center" }}>
+          <NotificationsDrawerIllustration promptTarget={promptTarget} />
+          <NotificationsPromptContent title={title} description={description} />
+        </Box>
+        <Button
+          appearance="base"
+          size="lg"
+          lx={{ width: "full", marginTop: "s32", marginBottom: "s24" }}
+          onPress={onAllowNotificationsPress}
+          testID="notifications-prompt-allow"
+        >
+          {allowLabel}
+        </Button>
+        <Box lx={{ alignItems: "center" }}>
+          <Link
+            appearance="base"
+            underline={false}
+            size="md"
+            onPress={onDelayLaterPress}
+            testID="notifications-prompt-later"
+          >
+            {laterLabel}
+          </Link>
+        </Box>
+      </BottomSheetView>
+    </QueuedDrawerBottomSheet>
+  );
 };
 
 export const NotificationsPromptDrawer = () => {
-  const { t } = useTranslation();
-  const {
-    drawerSource,
-    drawerPromptTarget,
-    isPushNotificationsModalOpen,
-    handleAllowNotificationsPress,
-    handleDelayLaterPress,
-    handleCloseFromBackdropPress,
-    nextRepromptDelay,
-    pushNotificationsDataOfUser,
-  } = useNotifications();
+  const viewModel = useNotificationsPromptDrawerViewModel();
 
-  const featureNewWordingNotificationsDrawer = useFeature("lwmNewWordingOptInNotificationsDrawer");
-
-  const drawerDisplayStateRef = useRef<DrawerDisplayState>({
-    drawerSource: undefined,
-    drawerPromptTarget: undefined,
-  });
-
-  if (isPushNotificationsModalOpen) {
-    drawerDisplayStateRef.current = {
-      drawerSource,
-      drawerPromptTarget,
-    };
-  }
-
-  const { drawerSource: displayedDrawerSource, drawerPromptTarget: displayedDrawerPromptTarget } =
-    drawerDisplayStateRef.current;
-
-  const handleModalHide = useCallback(() => {
-    drawerDisplayStateRef.current = {
-      drawerSource: undefined,
-      drawerPromptTarget: undefined,
-    };
-  }, []);
-
-  const canShowVariant = featureNewWordingNotificationsDrawer?.enabled;
-  const isVariantB =
-    featureNewWordingNotificationsDrawer?.enabled === true &&
-    featureNewWordingNotificationsDrawer?.params?.variant === AB_TESTING_VARIANTS.B;
-  const { allowKey, laterKey } = getNotificationsPromptCopy(
-    displayedDrawerPromptTarget,
-    isVariantB,
-  );
-
-  return (
-    <QueuedDrawer
-      isRequestingToBeOpened={isPushNotificationsModalOpen}
-      noCloseButton
-      onBackdropPress={handleCloseFromBackdropPress}
-      onModalHide={handleModalHide}
-    >
-      <TrackScreen
-        category="Drawer push notification opt-in"
-        source={displayedDrawerSource}
-        drawerPromptTarget={resolveDrawerPromptTargetForAnalytics(displayedDrawerPromptTarget)}
-        repromptDelay={nextRepromptDelay}
-        dismissedCount={pushNotificationsDataOfUser?.dismissedOptInDrawerAtList?.length ?? 0}
-        variant={canShowVariant ? featureNewWordingNotificationsDrawer?.params?.variant : undefined}
-      />
-
-      <Flex mb={4}>
-        <Flex alignItems={"center"}>
-          <NotificationsDrawerIllustration promptTarget={displayedDrawerPromptTarget} />
-          <NotificationsPromptContent promptTarget={displayedDrawerPromptTarget} />
-        </Flex>
-        <Button
-          type={"main"}
-          mt={8}
-          mb={7}
-          onPressIn={handleAllowNotificationsPress}
-          testID="notifications-prompt-allow"
-        >
-          {t(allowKey)}
-        </Button>
-        <TextLink
-          type={"shade"}
-          onPressIn={handleDelayLaterPress}
-          testID="notifications-prompt-later"
-        >
-          {t(laterKey)}
-        </TextLink>
-      </Flex>
-    </QueuedDrawer>
-  );
+  return <NotificationsPromptDrawerView {...viewModel} />;
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/useNotificationsPromptDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/useNotificationsPromptDrawerViewModel.ts
@@ -1,0 +1,69 @@
+import { useFeature } from "@features/platform-feature-flags";
+import { useTranslation } from "~/context/Locale";
+import { useNotifications } from "LLM/features/NotificationsPrompt";
+import { resolveDrawerPromptTargetForAnalytics } from "LLM/features/NotificationsPrompt/new/notificationsPromptAnalytics";
+import { resolveDismissedPromptCount } from "LLM/features/NotificationsPrompt/utils/dismissedPrompts";
+import { getNotificationsPromptCopy } from "LLM/features/NotificationsPrompt/utils/getNotificationsPromptCopy";
+import type { ABTestingVariants } from "LLM/features/NotificationsPrompt/types/variants";
+import { AB_TESTING_VARIANTS } from "LLM/features/NotificationsPrompt/types/variants";
+
+type WordingFeature = {
+  readonly enabled?: boolean;
+  readonly params?: {
+    readonly variant?: ABTestingVariants;
+  };
+};
+
+const getEnabledVariant = (featureNewWordingNotificationsDrawer?: WordingFeature | null) =>
+  featureNewWordingNotificationsDrawer?.enabled === true
+    ? featureNewWordingNotificationsDrawer?.params?.variant
+    : undefined;
+
+export const useNotificationsPromptDrawerViewModel = () => {
+  const { t } = useTranslation();
+  const {
+    drawerSource,
+    drawerPromptTarget,
+    isPushNotificationsModalOpen,
+    handleAllowNotificationsPress,
+    handleDelayLaterPress,
+    handleCloseFromBackdropPress,
+    handleModalHide,
+    nextRepromptDelay,
+    pushNotificationsDataOfUser,
+  } = useNotifications();
+  const featureNewWordingNotificationsDrawer = useFeature("lwmNewWordingOptInNotificationsDrawer");
+
+  const enabledVariant = getEnabledVariant(featureNewWordingNotificationsDrawer);
+  const isVariantB = enabledVariant === AB_TESTING_VARIANTS.B;
+  const { titleKey, descriptionKey, allowKey, laterKey } = getNotificationsPromptCopy(
+    drawerPromptTarget,
+    isVariantB,
+  );
+  const drawerPromptTargetForAnalytics = resolveDrawerPromptTargetForAnalytics(drawerPromptTarget);
+  const dismissedCount = resolveDismissedPromptCount(
+    pushNotificationsDataOfUser,
+    drawerPromptTargetForAnalytics,
+  );
+
+  return {
+    isOpen: isPushNotificationsModalOpen,
+    promptTarget: drawerPromptTarget,
+    title: t(titleKey),
+    description: t(descriptionKey),
+    allowLabel: t(allowKey),
+    laterLabel: t(laterKey),
+    onAllowNotificationsPress: handleAllowNotificationsPress,
+    onDelayLaterPress: handleDelayLaterPress,
+    onCloseFromBackdropPress: handleCloseFromBackdropPress,
+    onModalHide: handleModalHide,
+    trackScreenProps: {
+      category: "Drawer push notification opt-in",
+      source: drawerSource,
+      drawerPromptTarget: drawerPromptTargetForAnalytics,
+      repromptDelay: nextRepromptDelay,
+      dismissedCount,
+      variant: enabledVariant,
+    },
+  };
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/buildOptOutUserData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/buildOptOutUserData.ts
@@ -1,24 +1,8 @@
 import type { DataOfUser, NotificationPromptTarget } from "../types";
-
-const GLOBAL_PUSH_NOTIFICATIONS_PROMPT_TARGET = "globalPushNotifications" as const;
-
-const getExistingDismissals = (
-  pushNotificationsDataOfUser: DataOfUser | null | undefined,
-  promptTarget: NotificationPromptTarget,
-): number[] => {
-  const dismissedPromptAtListByTarget =
-    pushNotificationsDataOfUser?.dismissedPromptAtListByTarget ?? {};
-
-  if (promptTarget === GLOBAL_PUSH_NOTIFICATIONS_PROMPT_TARGET) {
-    return (
-      dismissedPromptAtListByTarget.globalPushNotifications ??
-      pushNotificationsDataOfUser?.dismissedOptInDrawerAtList ??
-      []
-    );
-  }
-
-  return dismissedPromptAtListByTarget[promptTarget] ?? [];
-};
+import {
+  GLOBAL_PUSH_NOTIFICATIONS_PROMPT_TARGET,
+  resolveDismissedPromptAtList,
+} from "./dismissedPrompts";
 
 export const buildOptOutUserData = ({
   pushNotificationsDataOfUser,
@@ -29,7 +13,10 @@ export const buildOptOutUserData = ({
   promptTarget?: NotificationPromptTarget;
   now?: number;
 }): DataOfUser => {
-  const existingDismissals = getExistingDismissals(pushNotificationsDataOfUser, promptTarget);
+  const existingDismissals = resolveDismissedPromptAtList(
+    pushNotificationsDataOfUser,
+    promptTarget,
+  );
   const dismissedPromptAtListByTarget = {
     ...pushNotificationsDataOfUser?.dismissedPromptAtListByTarget,
     [promptTarget]: [...existingDismissals, now],

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/dismissedPrompts.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/dismissedPrompts.ts
@@ -1,0 +1,32 @@
+import type { DataOfUser, NotificationPromptTarget } from "../types";
+
+export const GLOBAL_PUSH_NOTIFICATIONS_PROMPT_TARGET = "globalPushNotifications" as const;
+
+export const resolveDismissedPromptAtList = (
+  pushNotificationsDataOfUser: DataOfUser | null | undefined,
+  promptTarget: NotificationPromptTarget,
+): number[] => {
+  const dismissedPromptAtListByTarget =
+    pushNotificationsDataOfUser?.dismissedPromptAtListByTarget ?? {};
+
+  if (promptTarget === GLOBAL_PUSH_NOTIFICATIONS_PROMPT_TARGET) {
+    return (
+      dismissedPromptAtListByTarget.globalPushNotifications ??
+      pushNotificationsDataOfUser?.dismissedOptInDrawerAtList ??
+      []
+    );
+  }
+
+  return dismissedPromptAtListByTarget[promptTarget] ?? [];
+};
+
+export const resolveDismissedPromptCount = (
+  pushNotificationsDataOfUser: DataOfUser | null | undefined,
+  promptTarget: NotificationPromptTarget | null | undefined,
+): number => {
+  if (!promptTarget) {
+    return 0;
+  }
+
+  return resolveDismissedPromptAtList(pushNotificationsDataOfUser, promptTarget).length;
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/notificationsPromptEngine.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/notificationsPromptEngine.ts
@@ -4,6 +4,7 @@ import type { Features } from "@shared/feature-flags";
 import { AB_TESTING_VARIANTS, type ABTestingVariants } from "../types/variants";
 import type { NotificationsState } from "~/reducers/types";
 import type { DataOfUser, NotificationPromptTarget } from "../types";
+import { resolveDismissedPromptAtList, resolveDismissedPromptCount } from "./dismissedPrompts";
 
 type BrazePushNotifications = Features["brazePushNotifications"];
 type LwmNewWordingOptInNotificationsDrawer = Features["lwmNewWordingOptInNotificationsDrawer"];
@@ -176,23 +177,6 @@ export const canPromptTransactionsAlertsForAction = (
   return transactionsAlertsCategoryConfig.drawerPromptActions?.includes(source) ?? false;
 };
 
-const getDismissedPromptAtList = (
-  pushNotificationsDataOfUser: DataOfUser | null | undefined,
-  promptTarget: NotificationPromptTarget,
-): number[] | undefined => {
-  const dismissedPromptAtListByTarget =
-    pushNotificationsDataOfUser?.dismissedPromptAtListByTarget ?? {};
-
-  if (promptTarget === "globalPushNotifications") {
-    return (
-      dismissedPromptAtListByTarget.globalPushNotifications ??
-      pushNotificationsDataOfUser?.dismissedOptInDrawerAtList
-    );
-  }
-
-  return dismissedPromptAtListByTarget[promptTarget];
-};
-
 const hasRepromptDelayElapsed = ({
   pushNotificationsDataOfUser,
   promptTarget,
@@ -204,7 +188,10 @@ const hasRepromptDelayElapsed = ({
   repromptSchedule: NotificationsPromptRepromptDelay[] | null | undefined;
   now: number;
 }): { canShow: boolean; nextRepromptDelay: NotificationsPromptRepromptDelay | null } => {
-  const dismissedPromptAtList = getDismissedPromptAtList(pushNotificationsDataOfUser, promptTarget);
+  const dismissedPromptAtList = resolveDismissedPromptAtList(
+    pushNotificationsDataOfUser,
+    promptTarget,
+  );
 
   if (!dismissedPromptAtList?.length) {
     return { canShow: true, nextRepromptDelay: null };
@@ -230,17 +217,6 @@ const hasRepromptDelayElapsed = ({
   };
 };
 
-const getDismissedCount = (
-  pushNotificationsDataOfUser: DataOfUser | null | undefined,
-  promptTarget: NotificationPromptTarget | null,
-) => {
-  if (!promptTarget) {
-    return 0;
-  }
-
-  return getDismissedPromptAtList(pushNotificationsDataOfUser, promptTarget)?.length ?? 0;
-};
-
 const getDecisionBase = <TSource extends NotificationsPromptSource>(
   source: TSource,
   pushNotificationsDataOfUser: DataOfUser | null | undefined,
@@ -249,7 +225,7 @@ const getDecisionBase = <TSource extends NotificationsPromptSource>(
   wordingFeature: WordingFeature,
 ): NotificationsPromptDecisionBase<TSource> => ({
   source,
-  dismissedCount: getDismissedCount(pushNotificationsDataOfUser, promptTarget),
+  dismissedCount: resolveDismissedPromptCount(pushNotificationsDataOfUser, promptTarget),
   nextRepromptDelay,
   variant: getVariant(wordingFeature),
 });
@@ -319,7 +295,10 @@ export const getNextRepromptDelay = ({
     return null;
   }
 
-  const dismissedPromptAtList = getDismissedPromptAtList(pushNotificationsDataOfUser, promptTarget);
+  const dismissedPromptAtList = resolveDismissedPromptAtList(
+    pushNotificationsDataOfUser,
+    promptTarget,
+  );
   if (!repromptSchedule?.length || !dismissedPromptAtList?.length) {
     return null;
   }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/WalletSyncNavigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/WalletSyncNavigator.tsx
@@ -21,7 +21,7 @@ import { AnalyticsPage } from "./hooks/useLedgerSyncAnalytics";
 import { NavigationHeaderBackButton } from "~/components/NavigationHeaderBackButton";
 import { hasCompletedOnboardingSelector } from "~/reducers/settings";
 import { useSelector } from "~/context/hooks";
-import { useNotifications } from "LLM/features/NotificationsPrompt";
+import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
 
 const Stack = createNativeStackNavigator<WalletSyncNavigatorStackParamList>();
 
@@ -41,12 +41,12 @@ export default function WalletSyncNavigator() {
     navigation.goBack();
   }, []);
 
-  const { tryTriggerPushNotificationDrawerAfterAction } = useNotifications();
+  const { notifyFlowCompleted } = useNotificationsContext();
 
   const onCloseFromLedgerSyncOnboarding = useCallback(() => {
     close();
-    tryTriggerPushNotificationDrawerAfterAction("onboarding");
-  }, [close, tryTriggerPushNotificationDrawerAfterAction]);
+    notifyFlowCompleted("onboarding");
+  }, [close, notifyFlowCompleted]);
 
   return (
     <Stack.Navigator screenOptions={stackNavConfig}>

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Activation/ActivationSuccess.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Activation/ActivationSuccess.tsx
@@ -8,7 +8,7 @@ import { AnalyticsButton, AnalyticsFlow, AnalyticsPage } from "../../hooks/useLe
 import { track } from "~/analytics";
 import { useClose } from "../../hooks/useClose";
 import { useFeature, useWalletFeaturesConfig } from "@features/platform-feature-flags";
-import { useNotifications } from "LLM/features/NotificationsPrompt";
+import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
 
 type Props = BaseComposite<
   StackNavigatorProps<WalletSyncNavigatorStackParamList, ScreenName.WalletSyncSuccess>
@@ -17,7 +17,7 @@ type Props = BaseComposite<
 export function ActivationSuccess({ route }: Props) {
   const { t } = useTranslation();
   const ledgerSyncOptimisationFlag = useFeature("lwmLedgerSyncOptimisation");
-  const { tryTriggerPushNotificationDrawerAfterAction } = useNotifications();
+  const { notifyFlowCompleted } = useNotificationsContext();
 
   const { created } = route.params;
   const title = ledgerSyncOptimisationFlag?.enabled
@@ -48,7 +48,7 @@ export function ActivationSuccess({ route }: Props) {
     // so we always try to trigger the notification drawer
     // however since with the lazy onboarding, there will be no more onboarding flow, so we don't need to trigger the notification drawer
     if (!shouldUseLazyOnboarding) {
-      tryTriggerPushNotificationDrawerAfterAction("onboarding");
+      notifyFlowCompleted("onboarding");
     }
   }
 

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/PairNew.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/PairNew.tsx
@@ -13,7 +13,7 @@ import {
   setIsReborn,
   setOnboardingHasDevice,
 } from "~/actions/settings";
-import { useNotifications } from "LLM/features/NotificationsPrompt";
+import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
 import {
   RootComposite,
   StackNavigatorNavigation,
@@ -44,16 +44,16 @@ const StyledSafeAreaView = styled(SafeAreaView)`
   background-color: ${p => p.theme.colors.background.main};
 `;
 
+function renderArrowLeft() {
+  return <Icons.ArrowLeft />;
+}
+
+function renderInformation() {
+  return <Icons.Information />;
+}
+
 const ImageHeader = ({ showSlideIndicator }: { showSlideIndicator: boolean }) => {
   const navigation = useNavigation<NavigationProps["navigation"]>();
-
-  function renderArrowLeft() {
-    return <Icons.ArrowLeft />;
-  }
-
-  function renderInformation() {
-    return <Icons.Information />;
-  }
 
   return (
     <Flex
@@ -80,7 +80,7 @@ export default memo(function () {
   const route = useRoute<NavigationProps["route"]>();
 
   const dispatch = useDispatch();
-  const { tryTriggerPushNotificationDrawerAfterAction } = useNotifications();
+  const { notifyFlowCompleted } = useNotificationsContext();
 
   const { deviceModelId, showSeedWarning, isProtectFlow, fromAccessExistingWallet, isRestoreSeed } =
     route.params;
@@ -140,7 +140,7 @@ export default memo(function () {
       dispatch(setHasBeenRedirectedToPostOnboarding(false));
     }
 
-    tryTriggerPushNotificationDrawerAfterAction("onboarding");
+    notifyFlowCompleted("onboarding");
   }, [
     isProtectFlow,
     deviceModelId,
@@ -148,7 +148,7 @@ export default memo(function () {
     hasCompletedOnboarding,
     navigation,
     fromAccessExistingWallet,
-    tryTriggerPushNotificationDrawerAfterAction,
+    notifyFlowCompleted,
     isFundWalletNewSetup,
     seedConfiguration,
   ]);

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/discoverLiveInfo.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/discoverLiveInfo.tsx
@@ -24,7 +24,7 @@ import {
 import { OnboardingNavigatorParamList } from "~/components/RootNavigator/types/OnboardingNavigator";
 import { BaseOnboardingNavigatorParamList } from "~/components/RootNavigator/types/BaseOnboardingNavigator";
 import { DETOX_ENABLED } from "~/utils/constants";
-import { useNotifications } from "LLM/features/NotificationsPrompt";
+import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
 
 const slidesImages = [
   require("../../../../assets/images/onboarding/stories/slide1.webp"),
@@ -64,7 +64,7 @@ const Item = ({
 
   const screenName = useMemo(() => `Reborn Story Step ${currentIndex}`, [currentIndex]);
 
-  const { tryTriggerPushNotificationDrawerAfterAction } = useNotifications();
+  const { notifyFlowCompleted } = useNotificationsContext();
 
   const onClick = useCallback(
     (value: string) => {
@@ -97,8 +97,8 @@ const Item = ({
     dispatch(setIsReborn(true));
     dispatch(setOnboardingHasDevice(false));
     onClick("Explore without a device");
-    tryTriggerPushNotificationDrawerAfterAction("onboarding");
-  }, [dispatch, exploreLedger, onClick, tryTriggerPushNotificationDrawerAfterAction]);
+    notifyFlowCompleted("onboarding");
+  }, [dispatch, exploreLedger, notifyFlowCompleted, onClick]);
 
   const pressBuy = useCallback(() => {
     buyLedger();


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
 - Notification prompt drawer now uses the Lumen RN implementation with the queued BottomSheet wrapper.
 - Dismissed prompt counting is centralized and reused by the view model, prompt engine, and opt-out payload builder.
 - Focused tests cover prompt copy, analytics target fallback, dismissed counts, and notification prompt flows.
 - Branch diff is clean of accidental gitlink entries; only untracked local `.review-worktrees/` and `.worktrees/` remain outside the commit.

### 📝 Description

Refactors the mobile notification prompt drawer around the shared queued drawer BottomSheet and Lumen RN components, while extracting dismissed-prompt counting into a shared helper. This keeps the drawer presentation, analytics fallback behavior, prompt engine decisions, and opt-out user data in sync with focused coverage around the new view model beor.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

### 🧪 Validation

- Scoped Jest passed: 4 suites, 31 tests.
- `pnpm mobile lint` passed.
- `ReadLints` had no diagnostics in edited files.
- `pnpm mobile typecheck` was run but failed on unrelated pre-existing files: `MarketQuickA`, `AssetDetail/CoinOptions`, `Send/CustomFees`.