### PR TITLE
[LWD] refactor: use effect usage sync onboarding

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__tests__/useSyncOnboardingCompanionViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__tests__/useSyncOnboardingCompanionViewModel.test.tsx
@@ -132,7 +132,6 @@ describe("useSyncOnboardingCompanionViewModel", () => {
           onLostDevice: jest.fn(),
           notifySyncOnboardingShouldReset: jest.fn(),
           parentRef: createRef(),
-          setCompanionStep: jest.fn(),
         }),
       {
         minimal: false,
@@ -146,7 +145,7 @@ describe("useSyncOnboardingCompanionViewModel", () => {
     expect(result.current.deviceName).toBe("Ledger Stax");
     expect(result.current.steps).toHaveLength(5);
     expect(result.current.stepKey).toBe(StepKey.Paired);
-    expect(result.current.analyticsSeedConfiguration.current).toBeUndefined();
+    expect(result.current.seedConfiguration).toBeUndefined();
     expect(result.current.isNewSeed).toBe(false);
   });
 
@@ -176,7 +175,6 @@ describe("useSyncOnboardingCompanionViewModel", () => {
             onLostDevice: jest.fn(),
             notifySyncOnboardingShouldReset: jest.fn(),
             parentRef: createRef(),
-            setCompanionStep: jest.fn(),
           }),
         hookState,
       );
@@ -188,7 +186,7 @@ describe("useSyncOnboardingCompanionViewModel", () => {
       expect(result.current.deviceName).toBe("Ledger Stax");
       expect(result.current.steps).toHaveLength(3);
       expect(result.current.stepKey).toBe(StepKey.Paired);
-      expect(result.current.analyticsSeedConfiguration.current).toBeUndefined();
+      expect(result.current.seedConfiguration).toBeUndefined();
       expect(result.current.isNewSeed).toBe(false);
     });
 
@@ -217,7 +215,6 @@ describe("useSyncOnboardingCompanionViewModel", () => {
             onLostDevice: jest.fn(),
             notifySyncOnboardingShouldReset: jest.fn(),
             parentRef: createRef(),
-            setCompanionStep: jest.fn(),
           }),
         hookState,
       );
@@ -253,14 +250,13 @@ describe("useSyncOnboardingCompanionViewModel", () => {
             onLostDevice: jest.fn(),
             notifySyncOnboardingShouldReset: jest.fn(),
             parentRef: createRef(),
-            setCompanionStep: jest.fn(),
           }),
         hookState,
       );
 
       expect(result.current.stepKey).toBe(StepKey.Pin);
       expect(result.current.isNewSeed).toBe(false);
-      expect(result.current.analyticsSeedConfiguration.current).toBeUndefined();
+      expect(result.current.seedConfiguration).toBeUndefined();
       expect(result.current.steps.findIndex(step => step.status === "active")).toBe(1);
     });
 
@@ -293,14 +289,13 @@ describe("useSyncOnboardingCompanionViewModel", () => {
             onLostDevice: jest.fn(),
             notifySyncOnboardingShouldReset: jest.fn(),
             parentRef: createRef(),
-            setCompanionStep: jest.fn(),
           }),
         hookState,
       );
 
       expect(result.current.stepKey).toBe(StepKey.Seed);
       expect(result.current.isNewSeed).toBe(false);
-      expect(result.current.analyticsSeedConfiguration.current).toBeUndefined();
+      expect(result.current.seedConfiguration).toBeUndefined();
       expect(result.current.steps.findIndex(step => step.status === "active")).toBe(2);
     });
 
@@ -333,14 +328,13 @@ describe("useSyncOnboardingCompanionViewModel", () => {
             onLostDevice: jest.fn(),
             notifySyncOnboardingShouldReset: jest.fn(),
             parentRef: createRef(),
-            setCompanionStep: jest.fn(),
           }),
         hookState,
       );
 
       expect(result.current.stepKey).toBe(StepKey.Seed);
       expect(result.current.isNewSeed).toBe(true);
-      expect(result.current.analyticsSeedConfiguration.current).toBe("new_seed");
+      expect(result.current.seedConfiguration).toBe("new_seed");
       expect(result.current.steps.findIndex(step => step.status === "active")).toBe(2);
     });
 
@@ -373,14 +367,13 @@ describe("useSyncOnboardingCompanionViewModel", () => {
             onLostDevice: jest.fn(),
             notifySyncOnboardingShouldReset: jest.fn(),
             parentRef: createRef(),
-            setCompanionStep: jest.fn(),
           }),
         hookState,
       );
 
       expect(result.current.stepKey).toBe(StepKey.Seed);
       expect(result.current.isNewSeed).toBe(false);
-      expect(result.current.analyticsSeedConfiguration.current).toBeUndefined();
+      expect(result.current.seedConfiguration).toBeUndefined();
       expect(result.current.steps.findIndex(step => step.status === "active")).toBe(2);
     });
 
@@ -413,14 +406,13 @@ describe("useSyncOnboardingCompanionViewModel", () => {
             onLostDevice: jest.fn(),
             notifySyncOnboardingShouldReset: jest.fn(),
             parentRef: createRef(),
-            setCompanionStep: jest.fn(),
           }),
         hookState,
       );
 
       expect(result.current.stepKey).toBe(StepKey.Seed);
       expect(result.current.isNewSeed).toBe(false);
-      expect(result.current.analyticsSeedConfiguration.current).toBe("restore_seed");
+      expect(result.current.seedConfiguration).toBe("restore_seed");
       expect(result.current.steps.findIndex(step => step.status === "active")).toBe(2);
     });
 
@@ -453,14 +445,13 @@ describe("useSyncOnboardingCompanionViewModel", () => {
             onLostDevice: jest.fn(),
             notifySyncOnboardingShouldReset: jest.fn(),
             parentRef: createRef(),
-            setCompanionStep: jest.fn(),
           }),
         hookState,
       );
 
       expect(result.current.stepKey).toBe(StepKey.Seed);
       expect(result.current.isNewSeed).toBe(false);
-      expect(result.current.analyticsSeedConfiguration.current).toBe("recover_seed");
+      expect(result.current.seedConfiguration).toBe("recover_seed");
       expect(result.current.steps.findIndex(step => step.status === "active")).toBe(2);
     });
 
@@ -493,14 +484,13 @@ describe("useSyncOnboardingCompanionViewModel", () => {
             onLostDevice: jest.fn(),
             notifySyncOnboardingShouldReset: jest.fn(),
             parentRef: createRef(),
-            setCompanionStep: jest.fn(),
           }),
         hookState,
       );
 
       expect(result.current.stepKey).toBe(StepKey.Seed);
       expect(result.current.isNewSeed).toBe(false);
-      expect(result.current.analyticsSeedConfiguration.current).toBeUndefined();
+      expect(result.current.seedConfiguration).toBeUndefined();
       expect(result.current.steps.findIndex(step => step.status === "active")).toBe(2);
     });
 
@@ -533,14 +523,13 @@ describe("useSyncOnboardingCompanionViewModel", () => {
             onLostDevice: jest.fn(),
             notifySyncOnboardingShouldReset: jest.fn(),
             parentRef: createRef(),
-            setCompanionStep: jest.fn(),
           }),
         hookState,
       );
 
       expect(result.current.stepKey).toBe(StepKey.Seed);
       expect(result.current.isNewSeed).toBe(false);
-      expect(result.current.analyticsSeedConfiguration.current).toBe("restore_charon");
+      expect(result.current.seedConfiguration).toBe("restore_charon");
       expect(result.current.steps.findIndex(step => step.status === "active")).toBe(2);
     });
 
@@ -574,14 +563,13 @@ describe("useSyncOnboardingCompanionViewModel", () => {
               onLostDevice: jest.fn(),
               notifySyncOnboardingShouldReset: jest.fn(),
               parentRef: createRef(),
-              setCompanionStep: jest.fn(),
             }),
           hookState,
         );
 
         expect(result.current.stepKey).toBe(StepKey.Sync);
         expect(result.current.isNewSeed).toBe(false);
-        expect(result.current.analyticsSeedConfiguration.current).toBeUndefined();
+        expect(result.current.seedConfiguration).toBeUndefined();
         expect(result.current.steps.findIndex(step => step.status === "active")).toBe(3);
       });
 
@@ -614,14 +602,13 @@ describe("useSyncOnboardingCompanionViewModel", () => {
               onLostDevice: jest.fn(),
               notifySyncOnboardingShouldReset: jest.fn(),
               parentRef: createRef(),
-              setCompanionStep: jest.fn(),
             }),
           hookState,
         );
 
         expect(result.current.stepKey).toBe(StepKey.Success);
         expect(result.current.isNewSeed).toBe(false);
-        expect(result.current.analyticsSeedConfiguration.current).toBeUndefined();
+        expect(result.current.seedConfiguration).toBeUndefined();
         expect(result.current.steps.findIndex(step => step.status === "active")).toBe(-1);
       });
 
@@ -658,7 +645,6 @@ describe("useSyncOnboardingCompanionViewModel", () => {
                 onLostDevice: jest.fn(),
                 notifySyncOnboardingShouldReset: jest.fn(),
                 parentRef: createRef(),
-                setCompanionStep: jest.fn(),
               }),
             hookState,
           );
@@ -669,7 +655,7 @@ describe("useSyncOnboardingCompanionViewModel", () => {
 
           expect(result.current.stepKey).toBe(StepKey.Apps);
           expect(result.current.isNewSeed).toBe(false);
-          expect(result.current.analyticsSeedConfiguration.current).toBeUndefined();
+          expect(result.current.seedConfiguration).toBeUndefined();
           expect(result.current.steps.findIndex(step => step.status === "active")).toBe(-1);
         } finally {
           jest.useRealTimers();

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/index.tsx
@@ -8,6 +8,13 @@ import useSyncOnboardingCompanionViewModel, {
   SyncOnboardingCompanionProps,
 } from "./useSyncOnboardingCompanionViewModel";
 
+type SyncOnboardingCompanionViewModel = ReturnType<typeof useSyncOnboardingCompanionViewModel>;
+type SyncOnboardingCompanionContainerProps = SyncOnboardingCompanionProps & {
+  renderHeader?: (
+    companionHeaderStep: SyncOnboardingCompanionViewModel["companionHeaderStep"],
+  ) => React.ReactNode;
+};
+
 const View = ({
   isDesyncOverlayOpen,
   desyncOverlayDelay,
@@ -18,8 +25,8 @@ const View = ({
   stepKey,
   companionSteps,
   isNewSeed,
-  analyticsSeedConfiguration,
-}: ReturnType<typeof useSyncOnboardingCompanionViewModel>) => {
+  seedConfiguration,
+}: SyncOnboardingCompanionViewModel) => {
   const { t } = useTranslation();
 
   return (
@@ -52,7 +59,7 @@ const View = ({
               installStep={companionSteps.installStep}
               isNewSeed={isNewSeed}
               handleComplete={companionSteps.handleAppStepComplete}
-              seedConfiguration={analyticsSeedConfiguration.current}
+              seedConfiguration={seedConfiguration}
               hasSyncStep={companionSteps.hasSyncStep}
             />
           ) : (
@@ -67,8 +74,18 @@ const View = ({
 /**
  * Component rendering the synchronous onboarding companion
  */
-const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = props => (
-  <View {...useSyncOnboardingCompanionViewModel(props)} />
-);
+const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionContainerProps> = ({
+  renderHeader,
+  ...props
+}) => {
+  const viewModel = useSyncOnboardingCompanionViewModel(props);
+
+  return (
+    <>
+      {renderHeader?.(viewModel.companionHeaderStep)}
+      <View {...viewModel} />
+    </>
+  );
+};
 
 export default SyncOnboardingCompanion;

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/useSyncOnboardingCompanionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/useSyncOnboardingCompanionViewModel.ts
@@ -1,10 +1,19 @@
-import { type RefObject, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useReducer,
+  useRef,
+} from "react";
 import { useNavigate } from "react-router";
-import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { useSelector } from "LLD/hooks/redux";
 import { useOnboardingStatePolling } from "@ledgerhq/live-common/onboarding/hooks/useOnboardingStatePolling";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { SeedOriginType, SeedPhraseType } from "@ledgerhq/types-live";
 import {
+  type OnboardingState,
   OnboardingStep as DeviceOnboardingStep,
   fromSeedPhraseTypeToNbOfSeedWords,
 } from "@ledgerhq/live-common/hw/extractOnboardingState";
@@ -23,11 +32,7 @@ import { LockedDeviceError } from "@ledgerhq/errors";
 import { useRecoverRestoreOnboarding } from "~/renderer/hooks/useRecoverRestoreOnboarding";
 import { useTrackOnboardingFlow } from "~/renderer/analytics/hooks/useTrackOnboardingFlow";
 import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
-import useCompanionSteps, {
-  READY_REDIRECT_DELAY_MS,
-  Step,
-  StepKey,
-} from "./hooks/useCompanionSteps";
+import useCompanionSteps, { READY_REDIRECT_DELAY_MS, StepKey } from "./hooks/useCompanionSteps";
 import { analyticsFlowName } from "./utils/constants/analytics";
 
 const POLLING_PERIOD_MS = 1000;
@@ -43,6 +48,229 @@ const fromSeedPhraseTypeToAnalyticsPropertyString = new Map<SeedPhraseType, stri
   [SeedPhraseType.Eighteen, "Eighteen"],
   [SeedPhraseType.Twelve, "Twelve"],
 ]);
+
+type CompanionTransition = {
+  stepKey?: StepKey;
+  shouldRestoreApps?: boolean;
+  seedPathStatus?: SeedPathStatus;
+  isNewSeed?: boolean;
+  seedConfiguration?: SeedOriginType;
+  shouldNotifyReset?: boolean;
+  shouldMarkSeededDeviceHandled?: boolean;
+};
+
+type CompanionState = {
+  stepKey: StepKey;
+  shouldRestoreApps: boolean;
+  seedPathStatus: SeedPathStatus;
+  isNewSeed: boolean;
+  deviceInitiallyOnboarded: boolean | undefined;
+  seedPhraseType: SeedPhraseType | undefined;
+  seedConfiguration: SeedOriginType | undefined;
+  seededDeviceHandled: boolean;
+  isPollingOn: boolean;
+  desyncOverlayDelay: number;
+  isDesyncOverlayOpen: boolean;
+  desyncTimeout: number;
+};
+
+type CompanionAction =
+  | {
+      type: "DEVICE_ONBOARDING_STATE_CHANGED";
+      deviceOnboardingState: OnboardingState;
+      transition: CompanionTransition | null;
+      shouldExtendDesyncTiming: boolean;
+    }
+  | { type: "GO_TO_STEP"; stepKey: StepKey }
+  | { type: "COMPLETE_SUCCESS_STEP" }
+  | { type: "STOP_POLLING" }
+  | { type: "START_DESYNC_WARNING" }
+  | { type: "CLEAR_DESYNC_WARNING" };
+
+const initialCompanionState: CompanionState = {
+  stepKey: StepKey.Paired,
+  shouldRestoreApps: false,
+  seedPathStatus: "choice_new_or_restore",
+  isNewSeed: false,
+  deviceInitiallyOnboarded: undefined,
+  seedPhraseType: undefined,
+  seedConfiguration: undefined,
+  seededDeviceHandled: false,
+  isPollingOn: true,
+  desyncOverlayDelay: DESYNC_OVERLAY_DELAY_MS,
+  isDesyncOverlayOpen: false,
+  desyncTimeout: DESYNC_TIMEOUT_MS,
+};
+
+function getCompanionHeaderStep(stepKey: StepKey): "first-step" | "second-step" {
+  return stepKey > StepKey.Seed ? "second-step" : "first-step";
+}
+
+function companionReducer(state: CompanionState, action: CompanionAction): CompanionState {
+  switch (action.type) {
+    case "DEVICE_ONBOARDING_STATE_CHANGED": {
+      const { deviceOnboardingState, shouldExtendDesyncTiming, transition } = action;
+      const nextDeviceInitiallyOnboarded =
+        state.deviceInitiallyOnboarded ?? deviceOnboardingState.isOnboarded;
+      const nextSeedPhraseType =
+        !deviceOnboardingState.isOnboarded && deviceOnboardingState.seedPhraseType
+          ? deviceOnboardingState.seedPhraseType
+          : state.seedPhraseType;
+      const nextSeedConfiguration = transition?.seedConfiguration ?? state.seedConfiguration;
+      const nextDesyncOverlayDelay = shouldExtendDesyncTiming
+        ? LONG_DESYNC_OVERLAY_DELAY_MS
+        : state.desyncOverlayDelay;
+      const nextDesyncTimeout = shouldExtendDesyncTiming
+        ? LONG_DESYNC_TIMEOUT_MS
+        : state.desyncTimeout;
+      const nextStepKey = transition?.stepKey ?? state.stepKey;
+      const nextShouldRestoreApps = transition?.shouldRestoreApps ?? state.shouldRestoreApps;
+      const nextSeedPathStatus = transition?.seedPathStatus ?? state.seedPathStatus;
+      const nextIsNewSeed = transition?.isNewSeed ?? state.isNewSeed;
+      const nextSeededDeviceHandled =
+        state.seededDeviceHandled || transition?.shouldMarkSeededDeviceHandled === true;
+
+      if (
+        nextDeviceInitiallyOnboarded === state.deviceInitiallyOnboarded &&
+        nextSeedPhraseType === state.seedPhraseType &&
+        nextSeedConfiguration === state.seedConfiguration &&
+        nextDesyncOverlayDelay === state.desyncOverlayDelay &&
+        nextDesyncTimeout === state.desyncTimeout &&
+        nextStepKey === state.stepKey &&
+        nextShouldRestoreApps === state.shouldRestoreApps &&
+        nextSeedPathStatus === state.seedPathStatus &&
+        nextIsNewSeed === state.isNewSeed &&
+        nextSeededDeviceHandled === state.seededDeviceHandled
+      ) {
+        return state;
+      }
+
+      return {
+        ...state,
+        stepKey: nextStepKey,
+        shouldRestoreApps: nextShouldRestoreApps,
+        seedPathStatus: nextSeedPathStatus,
+        isNewSeed: nextIsNewSeed,
+        deviceInitiallyOnboarded: nextDeviceInitiallyOnboarded,
+        seedPhraseType: nextSeedPhraseType,
+        seedConfiguration: nextSeedConfiguration,
+        seededDeviceHandled: nextSeededDeviceHandled,
+        desyncOverlayDelay: nextDesyncOverlayDelay,
+        desyncTimeout: nextDesyncTimeout,
+      };
+    }
+    case "GO_TO_STEP":
+      return { ...state, stepKey: action.stepKey };
+    case "COMPLETE_SUCCESS_STEP":
+      return { ...state, stepKey: StepKey.Apps };
+    case "STOP_POLLING":
+      return { ...state, isPollingOn: false };
+    case "START_DESYNC_WARNING":
+      return { ...state, isDesyncOverlayOpen: true };
+    case "CLEAR_DESYNC_WARNING":
+      return { ...state, isDesyncOverlayOpen: false };
+    default:
+      return state;
+  }
+}
+
+function getCompanionTransitionFromOnboardingState({
+  deviceOnboardingState,
+  isSyncIncr1Enabled,
+  hasSyncStep,
+  seededDeviceAlreadyHandled,
+}: {
+  deviceOnboardingState?: OnboardingState | null;
+  isSyncIncr1Enabled: boolean;
+  hasSyncStep: boolean;
+  seededDeviceAlreadyHandled: boolean;
+}): CompanionTransition | null {
+  if (
+    deviceOnboardingState?.isOnboarded &&
+    !seededDeviceAlreadyHandled &&
+    [DeviceOnboardingStep.Ready, DeviceOnboardingStep.WelcomeScreen1].includes(
+      deviceOnboardingState.currentOnboardingStep,
+    )
+  ) {
+    return {
+      stepKey: isSyncIncr1Enabled ? (hasSyncStep ? StepKey.Sync : StepKey.Success) : StepKey.Apps,
+      shouldMarkSeededDeviceHandled: true,
+    };
+  }
+
+  switch (deviceOnboardingState?.currentOnboardingStep) {
+    // Those cases could happen if the device restarted
+    case DeviceOnboardingStep.WelcomeScreen1:
+    case DeviceOnboardingStep.WelcomeScreen2:
+    case DeviceOnboardingStep.WelcomeScreen3:
+    case DeviceOnboardingStep.WelcomeScreen4:
+    case DeviceOnboardingStep.WelcomeScreenReminder:
+    case DeviceOnboardingStep.OnboardingEarlyCheck:
+      return { shouldNotifyReset: true };
+
+    case DeviceOnboardingStep.ChooseName:
+      return { stepKey: StepKey.Paired };
+    case DeviceOnboardingStep.SetupChoice:
+      return { stepKey: StepKey.Seed, seedPathStatus: "choice_new_or_restore" };
+    case DeviceOnboardingStep.NewDevice:
+    case DeviceOnboardingStep.NewDeviceConfirming:
+      return {
+        shouldRestoreApps: false,
+        stepKey: StepKey.Seed,
+        seedPathStatus: "new_seed",
+        isNewSeed: true,
+        seedConfiguration: "new_seed",
+      };
+    case DeviceOnboardingStep.SetupChoiceRestore:
+      return { stepKey: StepKey.Seed, seedPathStatus: "choice_restore_direct_or_recover" };
+    case DeviceOnboardingStep.RestoreSeed:
+      return {
+        shouldRestoreApps: true,
+        stepKey: StepKey.Seed,
+        seedPathStatus: "restore_seed",
+        isNewSeed: false,
+        seedConfiguration: "restore_seed",
+      };
+    case DeviceOnboardingStep.RecoverRestore:
+      return {
+        shouldRestoreApps: true,
+        stepKey: StepKey.Seed,
+        seedPathStatus: "recover_seed",
+        isNewSeed: false,
+        seedConfiguration: "recover_seed",
+      };
+    case DeviceOnboardingStep.BackupCharon:
+      return { stepKey: StepKey.Seed, seedPathStatus: "backup_charon" };
+    case DeviceOnboardingStep.RestoreCharon:
+      return {
+        stepKey: StepKey.Seed,
+        seedPathStatus: "restore_charon",
+        isNewSeed: false,
+        seedConfiguration: "restore_charon",
+      };
+    case DeviceOnboardingStep.Pin:
+      return { stepKey: StepKey.Pin };
+    default:
+      return null;
+  }
+}
+
+function shouldExtendDesyncTimingForSeedGeneration(
+  deviceOnboardingState: OnboardingState,
+): boolean {
+  if (
+    !deviceOnboardingState.seedPhraseType ||
+    ![DeviceOnboardingStep.NewDeviceConfirming, DeviceOnboardingStep.RestoreSeed].includes(
+      deviceOnboardingState.currentOnboardingStep,
+    )
+  ) {
+    return false;
+  }
+
+  const nbOfSeedWords = fromSeedPhraseTypeToNbOfSeedWords.get(deviceOnboardingState.seedPhraseType);
+
+  return !!nbOfSeedWords && deviceOnboardingState.currentSeedWordIndex >= nbOfSeedWords - 2;
+}
 
 export type SyncOnboardingCompanionProps = {
   /**
@@ -64,11 +292,6 @@ export type SyncOnboardingCompanionProps = {
    * The ref of parent container so we can scroll components into view
    */
   parentRef: RefObject<HTMLDivElement | null>;
-
-  /**
-   * Set state to control header
-   */
-  setCompanionStep: (currentStep: "first-step" | "second-step") => void;
 };
 
 /**
@@ -79,19 +302,31 @@ const useSyncOnboardingCompanionViewModel = ({
   onLostDevice,
   notifySyncOnboardingShouldReset,
   parentRef,
-  setCompanionStep,
 }: SyncOnboardingCompanionProps) => {
   const navigate = useNavigate();
-  const dispatch = useDispatch();
   const isSyncIncr1Enabled = useFeature("lldSyncOnboardingIncr1")?.enabled || false;
   const servicesConfig = useFeature("protectServicesDesktop");
   const recoverRestoreStaxPath = useCustomPath(servicesConfig, "restore", "lld-onboarding-24");
 
-  const [stepKey, setStepKey] = useState<StepKey>(StepKey.Paired);
-  const [shouldRestoreApps, setShouldRestoreApps] = useState<boolean>(false);
+  const [state, companionDispatch] = useReducer(companionReducer, initialCompanionState);
+  const {
+    stepKey,
+    shouldRestoreApps,
+    seedPathStatus,
+    isNewSeed,
+    isPollingOn,
+    desyncOverlayDelay,
+    isDesyncOverlayOpen,
+    desyncTimeout,
+    deviceInitiallyOnboarded,
+    seedPhraseType,
+    seedConfiguration,
+    seededDeviceHandled,
+  } = state;
   const lastCompanionStepKey = useRef<StepKey>(undefined);
-  const [seedPathStatus, setSeedPathStatus] = useState<SeedPathStatus>("choice_new_or_restore");
-  const [isNewSeed, setIsNewSeed] = useState<boolean>(false);
+  const setStepKey = useCallback((nextStepKey: StepKey) => {
+    companionDispatch({ type: "GO_TO_STEP", stepKey: nextStepKey });
+  }, []);
 
   useTrackOnboardingFlow({
     location: HOOKS_TRACKING_LOCATIONS.onboardingFlow,
@@ -104,29 +339,6 @@ const useSyncOnboardingCompanionViewModel = ({
     ? getDeviceModel(device.modelId).productName || device.modelId
     : "Ledger Device";
   const deviceName = device?.deviceName || productName;
-
-  const [isPollingOn, setIsPollingOn] = useState<boolean>(true);
-
-  const [desyncOverlayDelay, setDesyncOverlayDelay] = useState<number>(DESYNC_OVERLAY_DELAY_MS);
-  const [isDesyncOverlayOpen, setIsDesyncOverlayOpen] = useState<boolean>(false);
-  const [desyncTimeout, setDesyncTimeout] = useState<number>(DESYNC_TIMEOUT_MS);
-
-  /**
-   * True if the device was initially onboarded/seeded when this component got
-   * mounted. False otherwise.
-   * Value is undefined until the onboarding state polling returns a first
-   * result.
-   * */
-  const deviceInitiallyOnboarded = useRef<boolean>(undefined);
-  /**
-   * Variable holding the seed phrase type (number of words) until we are
-   * ready to track the event (when the seeding step finishes).
-   * Should only be maintained if the device is not onboarded/not seeded as the
-   * onboarding flags can only be trusted for a non-onboarded device.
-   */
-  const analyticsSeedPhraseType = useRef<SeedPhraseType>(undefined);
-
-  const analyticsSeedConfiguration = useRef<SeedOriginType>(undefined);
 
   const {
     onboardingState: deviceOnboardingState,
@@ -151,43 +363,42 @@ const useSyncOnboardingCompanionViewModel = ({
     charonStatus: deviceOnboardingState?.charonStatus,
     charonSupported: deviceOnboardingState?.charonSupported,
     isTwoStep: isSyncIncr1Enabled,
-    seedConfiguration: analyticsSeedConfiguration.current,
+    seedConfiguration,
   });
 
-  const [steps, setSteps] = useState<Step[]>(companionSteps.defaultSteps);
+  const steps = useMemo(
+    () =>
+      companionSteps.defaultSteps.map(step => {
+        let stepStatus = step.status;
+
+        if (stepStatus !== "completed") {
+          stepStatus =
+            step.key > stepKey ? "inactive" : step.key < stepKey ? "completed" : "active";
+        }
+        const title = (stepStatus === "completed" && step.titleCompleted) || step.title;
+
+        return {
+          ...step,
+          title,
+          status: stepStatus,
+        };
+      }),
+    [companionSteps.defaultSteps, stepKey],
+  );
 
   const handleDeviceReady = useCallback(() => {
     navigate("/onboarding/sync/completion", {
       state: {
-        seedConfiguration: analyticsSeedConfiguration.current,
+        seedConfiguration,
       },
     });
-  }, [navigate]);
+  }, [navigate, seedConfiguration]);
 
   const handleDesyncTimerRunsOut = useCallback(() => {
-    setIsDesyncOverlayOpen(false);
+    companionDispatch({ type: "CLEAR_DESYNC_WARNING" });
     onLostDevice();
-    setIsPollingOn(false);
+    companionDispatch({ type: "STOP_POLLING" });
   }, [onLostDevice]);
-
-  useEffect(() => {
-    if (stepKey > StepKey.Seed) {
-      setCompanionStep("second-step");
-    } else {
-      setCompanionStep("first-step");
-    }
-  }, [stepKey, setCompanionStep]);
-
-  useEffect(() => {
-    if (!deviceOnboardingState) return;
-    if (deviceInitiallyOnboarded.current === undefined)
-      deviceInitiallyOnboarded.current = deviceOnboardingState.isOnboarded;
-    if (
-      !deviceOnboardingState.isOnboarded && // onboarding state flags can only be trusted for a non-onboarded/non-seeded device
-      deviceOnboardingState.seedPhraseType
-    )
-      analyticsSeedPhraseType.current = deviceOnboardingState.seedPhraseType;
-  }, [deviceOnboardingState]);
 
   const analyticsSeedingTracked = useRef(false);
   /**
@@ -197,7 +408,7 @@ const useSyncOnboardingCompanionViewModel = ({
    */
   useLayoutEffect(() => {
     if (
-      deviceInitiallyOnboarded.current === false && // can't just use ! operator because value can be undefined
+      deviceInitiallyOnboarded === false && // can't just use ! operator because value can be undefined
       lastCompanionStepKey.current !== undefined &&
       lastCompanionStepKey.current <= StepKey.Seed &&
       stepKey === StepKey.Seed &&
@@ -218,10 +429,10 @@ const useSyncOnboardingCompanionViewModel = ({
         `Set up ${productName}: Step 3 Seed Success`,
         undefined,
         {
-          seedPhraseType: analyticsSeedPhraseType.current
-            ? fromSeedPhraseTypeToAnalyticsPropertyString.get(analyticsSeedPhraseType.current)
+          seedPhraseType: seedPhraseType
+            ? fromSeedPhraseTypeToAnalyticsPropertyString.get(seedPhraseType)
             : undefined,
-          seedConfiguration: analyticsSeedConfiguration.current,
+          seedConfiguration,
         },
         true,
         true,
@@ -230,7 +441,15 @@ const useSyncOnboardingCompanionViewModel = ({
       analyticsSeedingTracked.current = true;
     }
     lastCompanionStepKey.current = stepKey;
-  }, [deviceOnboardingState?.isOnboarded, productName, seedPathStatus, stepKey]);
+  }, [
+    deviceInitiallyOnboarded,
+    deviceOnboardingState?.isOnboarded,
+    productName,
+    seedConfiguration,
+    seedPathStatus,
+    seedPhraseType,
+    stepKey,
+  ]);
 
   useEffect(() => {
     if (lockedDevice) {
@@ -248,121 +467,50 @@ const useSyncOnboardingCompanionViewModel = ({
     return () => setDrawer();
   }, [device.modelId, navigate, lockedDevice]);
 
-  const seededDeviceHandled = useRef(false);
+  const lastProcessedDeviceOnboardingState = useRef<OnboardingState | null>(null);
 
   useEffect(() => {
+    if (
+      !deviceOnboardingState ||
+      lastProcessedDeviceOnboardingState.current === deviceOnboardingState
+    ) {
+      return;
+    }
+    lastProcessedDeviceOnboardingState.current = deviceOnboardingState;
+
     // When the device is seeded, there are 2 cases before triggering the application install step:
     // - the user came to the sync onboarding with an non-seeded device and did a full onboarding: onboarding flag `Ready`
     // - the user came to the sync onboarding with an already seeded device: onboarding flag `WelcomeScreen1`
-    if (
-      deviceOnboardingState?.isOnboarded &&
-      !seededDeviceHandled.current &&
-      [DeviceOnboardingStep.Ready, DeviceOnboardingStep.WelcomeScreen1].includes(
-        deviceOnboardingState.currentOnboardingStep,
-      )
-    ) {
-      let nextStepKey = StepKey.Apps;
-      if (isSyncIncr1Enabled) {
-        nextStepKey = companionSteps.hasSyncStep ? StepKey.Sync : StepKey.Success;
-      }
-      setStepKey(nextStepKey);
-      seededDeviceHandled.current = true;
-      return;
-    }
-
     // case DeviceOnboardingStep.SafetyWarning not handled so the previous step (new seed, restore, recover) is kept
-    switch (deviceOnboardingState?.currentOnboardingStep) {
-      // Those cases could happen if the device restarted
-      case DeviceOnboardingStep.WelcomeScreen1:
-      case DeviceOnboardingStep.WelcomeScreen2:
-      case DeviceOnboardingStep.WelcomeScreen3:
-      case DeviceOnboardingStep.WelcomeScreen4:
-      case DeviceOnboardingStep.WelcomeScreenReminder:
-      case DeviceOnboardingStep.OnboardingEarlyCheck:
-        notifySyncOnboardingShouldReset();
-        break;
+    const transition = getCompanionTransitionFromOnboardingState({
+      deviceOnboardingState,
+      isSyncIncr1Enabled,
+      hasSyncStep: companionSteps.hasSyncStep,
+      seededDeviceAlreadyHandled: seededDeviceHandled,
+    });
 
-      case DeviceOnboardingStep.ChooseName:
-        setStepKey(StepKey.Paired);
-        break;
-      case DeviceOnboardingStep.SetupChoice:
-        setStepKey(StepKey.Seed);
-        setSeedPathStatus("choice_new_or_restore");
-        break;
-      case DeviceOnboardingStep.NewDevice:
-      case DeviceOnboardingStep.NewDeviceConfirming:
-        setShouldRestoreApps(false);
-        setStepKey(StepKey.Seed);
-        setSeedPathStatus("new_seed");
-        setIsNewSeed(true);
-        analyticsSeedConfiguration.current = "new_seed";
-        break;
-      case DeviceOnboardingStep.SetupChoiceRestore:
-        setStepKey(StepKey.Seed);
-        setSeedPathStatus("choice_restore_direct_or_recover");
-        break;
-      case DeviceOnboardingStep.RestoreSeed:
-        setShouldRestoreApps(true);
-        setStepKey(StepKey.Seed);
-        setSeedPathStatus("restore_seed");
-        setIsNewSeed(false);
-        analyticsSeedConfiguration.current = "restore_seed";
-        break;
-      case DeviceOnboardingStep.RecoverRestore:
-        setShouldRestoreApps(true);
-        setStepKey(StepKey.Seed);
-        setSeedPathStatus("recover_seed");
-        setIsNewSeed(false);
-        analyticsSeedConfiguration.current = "recover_seed";
-        break;
-      case DeviceOnboardingStep.BackupCharon:
-        setStepKey(StepKey.Seed);
-        setSeedPathStatus("backup_charon");
-        break;
-      case DeviceOnboardingStep.RestoreCharon:
-        setStepKey(StepKey.Seed);
-        setSeedPathStatus("restore_charon");
-        setIsNewSeed(false);
-        analyticsSeedConfiguration.current = "restore_charon";
-        break;
-      case DeviceOnboardingStep.Pin:
-        setStepKey(StepKey.Pin);
-        break;
-      default:
-        break;
+    if (transition?.shouldNotifyReset) {
+      notifySyncOnboardingShouldReset();
     }
+
+    companionDispatch({
+      type: "DEVICE_ONBOARDING_STATE_CHANGED",
+      deviceOnboardingState,
+      transition,
+      shouldExtendDesyncTiming: shouldExtendDesyncTimingForSeedGeneration(deviceOnboardingState),
+    });
   }, [
     deviceOnboardingState,
     notifySyncOnboardingShouldReset,
     isSyncIncr1Enabled,
     companionSteps.hasSyncStep,
+    seededDeviceHandled,
   ]);
-
-  // When the user gets close to the seed generation step, sets the lost synchronization delay
-  // and timers to a higher value. It avoids having a warning message while the connection is lost
-  // because the device is generating the seed.
-  useEffect(() => {
-    if (
-      deviceOnboardingState?.seedPhraseType &&
-      [DeviceOnboardingStep.NewDeviceConfirming, DeviceOnboardingStep.RestoreSeed].includes(
-        deviceOnboardingState?.currentOnboardingStep,
-      )
-    ) {
-      const nbOfSeedWords = fromSeedPhraseTypeToNbOfSeedWords.get(
-        deviceOnboardingState.seedPhraseType,
-      );
-
-      if (nbOfSeedWords && deviceOnboardingState?.currentSeedWordIndex >= nbOfSeedWords - 2) {
-        setDesyncOverlayDelay(LONG_DESYNC_OVERLAY_DELAY_MS);
-        setDesyncTimeout(LONG_DESYNC_TIMEOUT_MS);
-      }
-    }
-  }, [deviceOnboardingState]);
 
   useEffect(() => {
     const properties = {
       flow: analyticsFlowName,
-      seedConfiguration: analyticsSeedConfiguration.current,
+      seedConfiguration,
     };
 
     if (isSyncIncr1Enabled ? stepKey === StepKey.Success : stepKey === StepKey.Exit) {
@@ -376,48 +524,40 @@ const useSyncOnboardingCompanionViewModel = ({
     } else if (isSyncIncr1Enabled && stepKey === StepKey.Apps) {
       trackPage(`Set up ${productName}: Secure your crypto`, undefined, properties, true, true);
     }
-  }, [stepKey, productName, isSyncIncr1Enabled]);
+  }, [stepKey, productName, isSyncIncr1Enabled, seedConfiguration]);
 
   useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
     if (stepKey >= StepKey.Sync) {
-      setIsPollingOn(false);
+      companionDispatch({ type: "STOP_POLLING" });
     }
 
-    if (stepKey === StepKey.Ready) {
-      // Only app install route will go to this step
+    if (stepKey === StepKey.Success) {
+      timer = setTimeout(() => {
+        companionDispatch({ type: "COMPLETE_SUCCESS_STEP" });
+      }, 2000);
+    } else if (stepKey === StepKey.Ready) {
+      // Only app install route will go to this step.
       if (isSyncIncr1Enabled) {
-        setTimeout(() => setStepKey(StepKey.Exit), READY_REDIRECT_DELAY_MS);
+        timer = setTimeout(() => setStepKey(StepKey.Exit), READY_REDIRECT_DELAY_MS);
       } else {
         setStepKey(StepKey.Exit);
       }
-    }
-
-    if (stepKey === StepKey.Exit) {
+    } else if (stepKey === StepKey.Exit) {
       if (isSyncIncr1Enabled) {
         handleDeviceReady();
       } else {
-        setTimeout(handleDeviceReady, READY_REDIRECT_DELAY_MS);
+        timer = setTimeout(handleDeviceReady, READY_REDIRECT_DELAY_MS);
       }
     }
 
-    setSteps(
-      companionSteps.defaultSteps.map(step => {
-        let stepStatus = step.status;
-
-        if (stepStatus !== "completed") {
-          stepStatus =
-            step.key > stepKey ? "inactive" : step.key < stepKey ? "completed" : "active";
-        }
-        const title = (stepStatus === "completed" && step.titleCompleted) || step.title;
-
-        return {
-          ...step,
-          title,
-          status: stepStatus,
-        };
-      }),
-    );
-  }, [stepKey, companionSteps.defaultSteps, handleDeviceReady, productName, isSyncIncr1Enabled]);
+    return () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    };
+  }, [stepKey, handleDeviceReady, isSyncIncr1Enabled, setStepKey]);
 
   // Fatal error from the polling is not recoverable automatically
   useEffect(() => {
@@ -425,18 +565,18 @@ const useSyncOnboardingCompanionViewModel = ({
       return;
     }
     onLostDevice();
-    setIsPollingOn(false);
+    companionDispatch({ type: "STOP_POLLING" });
   }, [fatalError, onLostDevice]);
 
   useEffect(() => {
     let desyncTimer: NodeJS.Timeout | null = null;
 
     if (allowedError && !(allowedError instanceof LockedDeviceError)) {
-      setIsDesyncOverlayOpen(true);
+      companionDispatch({ type: "START_DESYNC_WARNING" });
       desyncTimer = setTimeout(handleDesyncTimerRunsOut, desyncTimeout);
     } else {
       // desyncTimer is cleared in the useEffect cleanup function
-      setIsDesyncOverlayOpen(false);
+      companionDispatch({ type: "CLEAR_DESYNC_WARNING" });
     }
 
     return () => {
@@ -457,7 +597,7 @@ const useSyncOnboardingCompanionViewModel = ({
         state: { fromOnboarding: true },
       });
     }
-  }, [dispatch, navigate, recoverRestoreStaxPath, seedPathStatus]);
+  }, [navigate, recoverRestoreStaxPath, seedPathStatus]);
 
   useEffect(() => {
     if (stepKey === StepKey.Success) {
@@ -467,20 +607,6 @@ const useSyncOnboardingCompanionViewModel = ({
     }
   }, [seedPathStatus, stepKey, parentRef]);
 
-  useEffect(() => {
-    if (stepKey === StepKey.Success) {
-      const timer = setTimeout(() => {
-        setStepKey(StepKey.Apps);
-      }, 2000);
-
-      return () => {
-        if (timer) {
-          clearTimeout(timer);
-        }
-      };
-    }
-  }, [stepKey]);
-
   return {
     isDesyncOverlayOpen,
     desyncOverlayDelay,
@@ -489,8 +615,9 @@ const useSyncOnboardingCompanionViewModel = ({
     deviceName,
     steps,
     stepKey,
+    companionHeaderStep: getCompanionHeaderStep(stepKey),
     companionSteps,
-    analyticsSeedConfiguration,
+    seedConfiguration,
     isNewSeed,
   };
 };

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
@@ -1,11 +1,15 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { Flex, InfiniteLoader } from "@ledgerhq/react-ui";
 import { useSelector } from "LLD/hooks/redux";
 import { Result } from "@ledgerhq/live-common/hw/actions/manager";
 import { useOnboardingStatePolling } from "@ledgerhq/live-common/onboarding/hooks/useOnboardingStatePolling";
 import { useToggleOnboardingEarlyCheck } from "@ledgerhq/live-common/deviceSDK/hooks/useToggleOnboardingEarlyChecks";
-import { OnboardingStep } from "@ledgerhq/live-common/hw/extractOnboardingState";
+import type { ToggleOnboardingEarlyCheckActionState } from "@ledgerhq/live-common/deviceSDK/actions/toggleOnboardingEarlyCheck";
+import {
+  OnboardingStep,
+  type OnboardingState,
+} from "@ledgerhq/live-common/hw/extractOnboardingState";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { stringToDeviceModelId } from "@ledgerhq/devices/helpers";
@@ -28,6 +32,9 @@ import { useConnectManagerAction } from "~/renderer/hooks/useConnectAppAction";
 const POLLING_PERIOD_MS = 1000;
 const DESYNC_TIMEOUT_MS = 20000;
 
+type CurrentStep = "loading" | "early-security-check" | "companion";
+type ToggleOnboardingEarlyCheckType = null | "enter" | "exit";
+
 export type SyncOnboardingScreenProps = {
   /**
    * A device model used to render the animation and text.
@@ -36,6 +43,203 @@ export type SyncOnboardingScreenProps = {
    * Should be DeviceModelId. react-router 5 seems to only handle [K in keyof Params]?: string props
    */
   deviceModelId: string;
+};
+
+type SyncOnboardingScreenState = {
+  currentStep: CurrentStep;
+  isPollingOn: boolean;
+  toggleOnboardingEarlyCheckType: ToggleOnboardingEarlyCheckType;
+  deviceDetectedOnboarded: boolean;
+  mustRecoverIfBootloader: boolean;
+  isBootloader: boolean;
+  isTroubleshootingDrawerOpen: boolean;
+  lastSeenDevice: Device | null;
+};
+
+type SyncOnboardingTransition = Partial<SyncOnboardingScreenState>;
+
+type SyncOnboardingScreenAction =
+  | {
+      type: "pollingSnapshot";
+      device: Device | null;
+      onboardingState: OnboardingState | null;
+      fatalError: Error | null;
+      shouldApplyOnboardingState: boolean;
+      shouldApplyFatalError: boolean;
+    }
+  | { type: "applyTransition"; transition: SyncOnboardingTransition | null }
+  | { type: "earlySecurityCheckEnded" }
+  | { type: "resetChecks" }
+  | { type: "openTroubleshootingDrawer" }
+  | { type: "setBootloader"; isBootloader: boolean };
+
+const WELCOME_ONBOARDING_STEPS = new Set<OnboardingStep>([
+  OnboardingStep.WelcomeScreen1,
+  OnboardingStep.WelcomeScreen2,
+  OnboardingStep.WelcomeScreen3,
+  OnboardingStep.WelcomeScreen4,
+  OnboardingStep.WelcomeScreenReminder,
+]);
+
+const createInitialSyncOnboardingState = (device: Device | null): SyncOnboardingScreenState => ({
+  currentStep: "loading",
+  isPollingOn: true,
+  toggleOnboardingEarlyCheckType: null,
+  deviceDetectedOnboarded: false,
+  mustRecoverIfBootloader: true,
+  isBootloader: false,
+  isTroubleshootingDrawerOpen: false,
+  lastSeenDevice: device,
+});
+
+const getTransitionFromOnboardingState = (
+  onboardingState: OnboardingState | null,
+): SyncOnboardingTransition | null => {
+  if (!onboardingState) {
+    return null;
+  }
+
+  const { currentOnboardingStep, isOnboarded } = onboardingState;
+
+  if (!isOnboarded && WELCOME_ONBOARDING_STEPS.has(currentOnboardingStep)) {
+    return {
+      isPollingOn: false,
+      toggleOnboardingEarlyCheckType: "enter",
+    };
+  }
+
+  if (!isOnboarded && currentOnboardingStep === OnboardingStep.OnboardingEarlyCheck) {
+    return {
+      isPollingOn: false,
+      // Reset the toggle hook result before showing ESC.
+      toggleOnboardingEarlyCheckType: null,
+      currentStep: "early-security-check",
+      mustRecoverIfBootloader: false,
+    };
+  }
+
+  if (isOnboarded) {
+    // Force ESC so the genuine check runs, without sending the toggle APDU.
+    return {
+      isPollingOn: false,
+      toggleOnboardingEarlyCheckType: null,
+      deviceDetectedOnboarded: true,
+      currentStep: "early-security-check",
+      mustRecoverIfBootloader: false,
+    };
+  }
+
+  return {
+    isPollingOn: false,
+    currentStep: "companion",
+  };
+};
+
+const getTransitionFromToggleResult = (
+  toggleState: ToggleOnboardingEarlyCheckActionState,
+  toggleType: ToggleOnboardingEarlyCheckType,
+): SyncOnboardingTransition | null => {
+  if (toggleState.toggleStatus === "none") {
+    return null;
+  }
+
+  if (toggleState.toggleStatus === "failure") {
+    // Older firmware may not support toggling ESC; companion is the safe fallback.
+    return {
+      toggleOnboardingEarlyCheckType: null,
+      currentStep: "companion",
+    };
+  }
+
+  if (toggleType !== null && toggleState.toggleStatus === "success") {
+    // Restart polling without forcing loading, to avoid a UI flash.
+    return {
+      toggleOnboardingEarlyCheckType: null,
+      isPollingOn: true,
+    };
+  }
+
+  return null;
+};
+
+const getTransitionFromFatalError = (fatalError: Error | null): SyncOnboardingTransition | null => {
+  if (fatalError instanceof UnexpectedBootloader) {
+    return {
+      isBootloader: true,
+    };
+  }
+
+  if (fatalError) {
+    return {
+      isPollingOn: false,
+      isTroubleshootingDrawerOpen: true,
+    };
+  }
+
+  return null;
+};
+
+const syncOnboardingScreenReducer = (
+  state: SyncOnboardingScreenState,
+  action: SyncOnboardingScreenAction,
+): SyncOnboardingScreenState => {
+  switch (action.type) {
+    case "pollingSnapshot": {
+      let nextState =
+        action.device && state.lastSeenDevice !== action.device
+          ? { ...state, lastSeenDevice: action.device }
+          : state;
+
+      if (action.shouldApplyOnboardingState) {
+        const transition = getTransitionFromOnboardingState(action.onboardingState);
+        nextState = transition ? { ...nextState, ...transition } : nextState;
+      }
+
+      if (action.shouldApplyFatalError) {
+        const transition = getTransitionFromFatalError(action.fatalError);
+        nextState = transition ? { ...nextState, ...transition } : nextState;
+      }
+
+      return nextState;
+    }
+
+    case "applyTransition":
+      return action.transition ? { ...state, ...action.transition } : state;
+
+    case "earlySecurityCheckEnded":
+      if (state.deviceDetectedOnboarded) {
+        // The device was never put into ESC mode via toggle, so there is nothing to exit.
+        return {
+          ...state,
+          currentStep: "companion",
+        };
+      }
+
+      return {
+        ...state,
+        toggleOnboardingEarlyCheckType: "exit",
+      };
+
+    case "resetChecks":
+      return {
+        ...state,
+        isPollingOn: true,
+        currentStep: "loading",
+        mustRecoverIfBootloader: true,
+      };
+
+    case "openTroubleshootingDrawer":
+      return {
+        ...state,
+        isTroubleshootingDrawerOpen: true,
+      };
+
+    case "setBootloader":
+      return {
+        ...state,
+        isBootloader: action.isBootloader,
+      };
+  }
 };
 
 /**
@@ -55,31 +259,21 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
   const device = useSelector(getCurrentDevice);
   const deviceModelId = stringToDeviceModelId(strDeviceModelId, DeviceModelId.stax);
 
-  const [mustRecoverIfBootloader, setMustRecoverIfBootloader] = useState(true);
-  const [isBootloader, setIsBootloader] = useState(false);
-  // Needed because `device` object can be null or changed if disconnected/reconnected
-  const [lastSeenDevice, setLastSeenDevice] = useState<Device | null>(device ?? null);
-  useEffect(() => {
-    if (device) {
-      setLastSeenDevice(device);
-    }
-  }, [device]);
-
-  const [isTroubleshootingDrawerOpen, setTroubleshootingDrawerOpen] = useState<boolean>(false);
-
-  const [currentStep, setCurrentStep] = useState<"loading" | "early-security-check" | "companion">(
-    "loading",
+  const [syncOnboardingScreenState, dispatchSyncOnboardingScreenAction] = useReducer(
+    syncOnboardingScreenReducer,
+    device ?? null,
+    createInitialSyncOnboardingState,
   );
-  const [companionStep, setCompanionStep] = useState<"first-step" | "second-step">("first-step");
-  const [isPollingOn, setIsPollingOn] = useState<boolean>(true);
-  const [toggleOnboardingEarlyCheckType, setToggleOnboardingEarlyCheckType] = useState<
-    null | "enter" | "exit"
-  >(null);
+  const {
+    currentStep,
+    isPollingOn,
+    toggleOnboardingEarlyCheckType,
+    mustRecoverIfBootloader,
+    isBootloader,
+    isTroubleshootingDrawerOpen,
+    lastSeenDevice,
+  } = syncOnboardingScreenState;
   const [fwUpdateInterrupted, setFwUpdateInterrupted] = useState<FinalFirmware | null>(null);
-
-  // True when the device reported isOnboarded=true during polling. Used to bypass
-  // the exit toggle after ESC (the device was never put into ESC mode via toggle).
-  const [deviceDetectedOnboarded, setDeviceDetectedOnboarded] = useState<boolean>(false);
 
   /* The early security checks are run again after a firmware update. */
   const [isInitialRunOfSecurityChecks, setIsInitialRunOfSecurityChecks] = useState(true);
@@ -102,23 +296,18 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
     toggleType: toggleOnboardingEarlyCheckType,
   });
 
+  const previousOnboardingStateRef = useRef(onboardingState);
+  const previousFatalErrorRef = useRef(fatalError);
+
   // Called when the ESC is complete
   const notifyOnboardingEarlyCheckEnded = useCallback(() => {
-    if (deviceDetectedOnboarded) {
-      // The device was not put into ESC mode via the toggle APDU, so there is
-      // nothing to exit. Go directly to the companion step.
-      setCurrentStep("companion");
-    } else {
-      setToggleOnboardingEarlyCheckType("exit");
-    }
-  }, [deviceDetectedOnboarded]);
+    dispatchSyncOnboardingScreenAction({ type: "earlySecurityCheckEnded" });
+  }, []);
 
   // Called when the companion component thinks the device is not in a correct state anymore
   const notifyOnboardingEarlyCheckShouldReset = useCallback(() => {
-    setIsPollingOn(true);
-    setCurrentStep("loading");
+    dispatchSyncOnboardingScreenAction({ type: "resetChecks" });
     resetPollingStates();
-    setMustRecoverIfBootloader(true);
   }, [resetPollingStates]);
 
   const restartChecksAfterUpdate = useCallback(() => {
@@ -159,55 +348,19 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
     return () => setDrawer();
   }, [deviceModelId, navigate, isTroubleshootingDrawerOpen, lockedDevice]);
 
-  // Handles current step and toggling onboarding early check logics
+  // Keep the latest non-null device because the current device can become null on disconnect/reconnect.
   useEffect(() => {
-    if (!onboardingState) {
-      return;
-    }
-    const { currentOnboardingStep, isOnboarded } = onboardingState;
-
-    if (
-      !isOnboarded &&
-      [
-        OnboardingStep.WelcomeScreen1,
-        OnboardingStep.WelcomeScreen2,
-        OnboardingStep.WelcomeScreen3,
-        OnboardingStep.WelcomeScreen4,
-        OnboardingStep.WelcomeScreenReminder,
-      ].includes(currentOnboardingStep)
-    ) {
-      setIsPollingOn(false);
-      setToggleOnboardingEarlyCheckType("enter");
-    } else if (!isOnboarded && currentOnboardingStep === OnboardingStep.OnboardingEarlyCheck) {
-      setIsPollingOn(false);
-      // Resets the `useToggleOnboardingEarlyCheck` hook. Avoids having a case where for ex
-      // check type == "exit" and toggle status still being == "success" from the previous toggle
-      setToggleOnboardingEarlyCheckType(null);
-      setCurrentStep("early-security-check");
-      setMustRecoverIfBootloader(false);
-    } else if (isOnboarded) {
-      // Device reports itself as already onboarded, force the ESC so the genuine check always
-      // runs. We skip the toggle APDU because the device is not in its onboarding state machine.
-      setIsPollingOn(false);
-      setToggleOnboardingEarlyCheckType(null);
-      setDeviceDetectedOnboarded(true);
-      setCurrentStep("early-security-check");
-      setMustRecoverIfBootloader(false);
-    } else {
-      setIsPollingOn(false);
-      setCurrentStep("companion");
-    }
-  }, [onboardingState]);
-
-  // A fatal error during polling triggers directly an error message
-  useEffect(() => {
-    if ((fatalError as unknown) instanceof UnexpectedBootloader) {
-      setIsBootloader(true);
-    } else if (fatalError) {
-      setIsPollingOn(false);
-      setTroubleshootingDrawerOpen(true);
-    }
-  }, [fatalError]);
+    dispatchSyncOnboardingScreenAction({
+      type: "pollingSnapshot",
+      device: device ?? null,
+      onboardingState,
+      fatalError,
+      shouldApplyOnboardingState: previousOnboardingStateRef.current !== onboardingState,
+      shouldApplyFatalError: previousFatalErrorRef.current !== fatalError,
+    });
+    previousOnboardingStateRef.current = onboardingState;
+    previousFatalErrorRef.current = fatalError;
+  }, [device, fatalError, onboardingState]);
 
   // An allowed error during polling (which makes the polling retry) only triggers an error message after a timeout
   useEffect(() => {
@@ -215,8 +368,13 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
 
     if (allowedError && !(allowedError instanceof LockedDeviceError)) {
       timeout = setTimeout(() => {
-        setIsPollingOn(false);
-        setTroubleshootingDrawerOpen(true);
+        dispatchSyncOnboardingScreenAction({
+          type: "applyTransition",
+          transition: {
+            isPollingOn: false,
+            isTroubleshootingDrawerOpen: true,
+          },
+        });
       }, DESYNC_TIMEOUT_MS);
     }
 
@@ -229,25 +387,13 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
 
   // Handles onboarding early check toggle result
   useEffect(() => {
-    if (toggleOnboardingEarlyCheckState.toggleStatus === "none") return;
-
-    if (toggleOnboardingEarlyCheckState.toggleStatus === "failure") {
-      // If an error occurred during the toggling the safe backup is to bring the device to the "companion" step
-      // This will happen for older firmware that does not handle this new action.
-      setToggleOnboardingEarlyCheckType(null);
-      setCurrentStep("companion");
-    }
-
-    // After a successful "enter" or "exit", the polling is restarted to know the device state
-    if (
-      toggleOnboardingEarlyCheckType !== null &&
-      toggleOnboardingEarlyCheckState.toggleStatus === "success"
-    ) {
-      // Resets the toggle hook
-      setToggleOnboardingEarlyCheckType(null);
-      setIsPollingOn(true);
-      // Not setting the `currentStep` to "loading" here to avoid UI flash
-    }
+    dispatchSyncOnboardingScreenAction({
+      type: "applyTransition",
+      transition: getTransitionFromToggleResult(
+        toggleOnboardingEarlyCheckState,
+        toggleOnboardingEarlyCheckType,
+      ),
+    });
   }, [toggleOnboardingEarlyCheckState, toggleOnboardingEarlyCheckType]);
 
   useChangeLanguagePrompt({
@@ -255,7 +401,7 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
   });
 
   const onLostDevice = useCallback(() => {
-    setTroubleshootingDrawerOpen(true);
+    dispatchSyncOnboardingScreenAction({ type: "openTroubleshootingDrawer" });
   }, []);
 
   const isEarlySecurityChecks = currentStep === "early-security-check" && lastSeenDevice;
@@ -289,6 +435,18 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
       setContentScroll(scrollTop);
     }
   };
+
+  const renderCompanionHeader = useCallback(
+    (companionStep: "first-step" | "second-step") => (
+      <Header
+        device={lastSeenDevice}
+        onClose={handleClose}
+        displayTitle={currentStep === "companion" && lastSeenDevice && contentScroll > 30}
+        companionStep={companionStep}
+      />
+    ),
+    [contentScroll, currentStep, handleClose, lastSeenDevice],
+  );
 
   let stepContent = (
     <Flex height="100%" width="100%" justifyContent="center" alignItems="center">
@@ -327,13 +485,13 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
         notifySyncOnboardingShouldReset={notifyOnboardingEarlyCheckShouldReset}
         onLostDevice={onLostDevice}
         parentRef={ref}
-        setCompanionStep={setCompanionStep}
+        renderHeader={renderCompanionHeader}
       />
     );
   }
 
   const onDeviceActionResult = useCallback(({ deviceInfo: { isBootloader } }: Result) => {
-    setIsBootloader(isBootloader);
+    dispatchSyncOnboardingScreenAction({ type: "setBootloader", isBootloader });
   }, []);
 
   return (
@@ -353,13 +511,15 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
          * user to finish the update.
          * */
         <DeviceAction onResult={onDeviceActionResult} action={action} request={null} />
+      ) : currentStep === "companion" && lastSeenDevice ? (
+        stepContent
       ) : (
         <>
           <Header
             device={lastSeenDevice}
             onClose={handleClose}
             displayTitle={currentStep === "companion" && lastSeenDevice && contentScroll > 30}
-            companionStep={companionStep}
+            companionStep="first-step"
           />
           {stepContent}
         </>


### PR DESCRIPTION
## Summary
- Refactored Sync Onboarding companion state into reducer-driven transitions.
- Collapsed polling snapshot and companion step lifecycle handling into clearer transition paths.
- Refactored Manual Sync Onboarding screen with reducer state and pure transition helpers.
- Derived companion header state instead of syncing it through parent callback state.

## Why this is better
- Reduces chained `useEffect` state updates and scattered `setState` calls.
- Keeps effects focused on external synchronization like timers, drawers, navigation, analytics, and polling.
- Makes onboarding transitions more atomic, testable, and easier to debug.
- Lowers risk of transient UI states during polling, ESC toggles, reconnects, and error handling.

## Test plan
- `ReadLints` on changed files: clean, except pre-existing warnings in `Manual/index.tsx`.
- `pnpm desktop typecheck`: attempted, blocked by existing workspace missing module/declaration errors outside these changes.