### PR TITLE
[LWDM] feat(desktop): add total-volume sort to the markets table

### DIFF
--- a/.changeset/market-total-volume-sort.md
+++ b/.changeset/market-total-volume-sort.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+---
+
+Add a "Total volume" sort option to the desktop Market table. The Volume column header is now sortable and toggles between highest and lowest 24h volume, mapping to the new `total-volume-desc` and `total-volume` values of the `/v3/markets` `sort` parameter.

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/MarketTableHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/MarketTableHeader.tsx
@@ -17,16 +17,20 @@ export type SortDirection = "asc" | "desc" | undefined;
 type MarketTableHeaderProps = {
   marketCapSort: SortDirection;
   changeSort: SortDirection;
+  volumeSort: SortDirection;
   onToggleMarketCap: () => void;
   onToggleChange: () => void;
+  onToggleVolume: () => void;
   t: TFunction;
 };
 
 export const MarketTableHeader = memo<MarketTableHeaderProps>(function MarketTableHeader({
   marketCapSort,
   changeSort,
+  volumeSort,
   onToggleMarketCap,
   onToggleChange,
+  onToggleVolume,
   t,
 }) {
   return (
@@ -43,7 +47,12 @@ export const MarketTableHeader = memo<MarketTableHeaderProps>(function MarketTab
           {t("market.marketTable.price")}
         </TableHeaderCell>
         <TableHeaderCell align="end" className={MARKET_HEADER_CELL_END_CLASSNAME}>
-          <TableSortButton align="end" data-testid="market-sort-volume">
+          <TableSortButton
+            align="end"
+            sortDirection={volumeSort}
+            onToggleSort={onToggleVolume}
+            data-testid="market-sort-volume"
+          >
             {t("market.marketTable.volume")}
           </TableSortButton>
         </TableHeaderCell>

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/MarketTableView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/MarketTableView.tsx
@@ -30,8 +30,10 @@ export type MarketTableViewProps = {
   toggleStar: (id: string, isStarred: boolean) => void;
   marketCapSort: SortDirection;
   changeSort: SortDirection;
+  volumeSort: SortDirection;
   onToggleMarketCap: () => void;
   onToggleChange: () => void;
+  onToggleVolume: () => void;
   t: TFunction;
 };
 
@@ -52,8 +54,10 @@ export function MarketTableView({
   toggleStar,
   marketCapSort,
   changeSort,
+  volumeSort,
   onToggleMarketCap,
   onToggleChange,
+  onToggleVolume,
   t,
 }: Readonly<MarketTableViewProps>) {
   if (emptyState === "favorites") {
@@ -76,8 +80,10 @@ export function MarketTableView({
             <MarketTableHeader
               marketCapSort={marketCapSort}
               changeSort={changeSort}
+              volumeSort={volumeSort}
               onToggleMarketCap={onToggleMarketCap}
               onToggleChange={onToggleChange}
+              onToggleVolume={onToggleVolume}
               t={t}
             />
           </Table>

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/MarketTableHeader.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/MarketTableHeader.test.tsx
@@ -9,8 +9,10 @@ function createProps(overrides: Partial<HeaderProps> = {}): HeaderProps {
   return {
     marketCapSort: "desc",
     changeSort: undefined,
+    volumeSort: undefined,
     onToggleMarketCap: jest.fn(),
     onToggleChange: jest.fn(),
+    onToggleVolume: jest.fn(),
     t: mockT,
     ...overrides,
   };
@@ -45,5 +47,13 @@ describe("MarketTableHeader", () => {
 
     await user.click(screen.getByTestId("market-sort-change"));
     expect(onToggleChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onToggleVolume when the volume sort button is clicked", async () => {
+    const onToggleVolume = jest.fn();
+    const { user } = renderHeader(createProps({ onToggleVolume }));
+
+    await user.click(screen.getByTestId("market-sort-volume"));
+    expect(onToggleVolume).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/MarketTableView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/MarketTableView.test.tsx
@@ -28,8 +28,10 @@ function createProps(overrides: Partial<MarketTableViewProps> = {}): MarketTable
     toggleStar: jest.fn(),
     marketCapSort: "desc",
     changeSort: undefined,
+    volumeSort: undefined,
     onToggleMarketCap: jest.fn(),
     onToggleChange: jest.fn(),
+    onToggleVolume: jest.fn(),
     t: mockT,
     ...overrides,
   };

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/useMarketTableViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/useMarketTableViewModel.test.ts
@@ -71,11 +71,26 @@ describe("useMarketTableViewModel", () => {
     expect(losers.current.changeSort).toBe("asc");
   });
 
+  it("should derive volumeSort from the volume order", () => {
+    const { result: desc } = renderHook(() =>
+      useMarketTableViewModel(createData({ marketParams: { order: Order.VolumeDesc } })),
+    );
+    expect(desc.current.volumeSort).toBe("desc");
+    expect(desc.current.marketCapSort).toBeUndefined();
+
+    const { result: asc } = renderHook(() =>
+      useMarketTableViewModel(createData({ marketParams: { order: Order.VolumeAsc } })),
+    );
+    expect(asc.current.volumeSort).toBe("asc");
+  });
+
   it("should toggle the market cap order between desc and asc", () => {
     const refresh = jest.fn();
 
     const { result: fromDesc } = renderHook(() =>
-      useMarketTableViewModel(createData({ refresh, marketParams: { order: Order.MarketCapDesc } })),
+      useMarketTableViewModel(
+        createData({ refresh, marketParams: { order: Order.MarketCapDesc } }),
+      ),
     );
     fromDesc.current.onToggleMarketCap();
     expect(refresh).toHaveBeenCalledWith({ order: Order.MarketCapAsc });
@@ -99,10 +114,31 @@ describe("useMarketTableViewModel", () => {
 
     refresh.mockClear();
     const { result: fromOther } = renderHook(() =>
-      useMarketTableViewModel(createData({ refresh, marketParams: { order: Order.MarketCapDesc } })),
+      useMarketTableViewModel(
+        createData({ refresh, marketParams: { order: Order.MarketCapDesc } }),
+      ),
     );
     fromOther.current.onToggleChange();
     expect(refresh).toHaveBeenCalledWith({ order: Order.topGainers });
+  });
+
+  it("should toggle the volume order between desc and asc", () => {
+    const refresh = jest.fn();
+
+    const { result: fromDesc } = renderHook(() =>
+      useMarketTableViewModel(createData({ refresh, marketParams: { order: Order.VolumeDesc } })),
+    );
+    fromDesc.current.onToggleVolume();
+    expect(refresh).toHaveBeenCalledWith({ order: Order.VolumeAsc });
+
+    refresh.mockClear();
+    const { result: fromOther } = renderHook(() =>
+      useMarketTableViewModel(
+        createData({ refresh, marketParams: { order: Order.MarketCapDesc } }),
+      ),
+    );
+    fromOther.current.onToggleVolume();
+    expect(refresh).toHaveBeenCalledWith({ order: Order.VolumeDesc });
   });
 
   it("should show the skeleton while fresh loading or on error", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/useMarketTableViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/useMarketTableViewModel.ts
@@ -77,9 +77,14 @@ export function useMarketTableViewModel({
     () => onSort(order === Order.topGainers ? Order.topLosers : Order.topGainers),
     [onSort, order],
   );
+  const onToggleVolume = useCallback(
+    () => onSort(order === Order.VolumeDesc ? Order.VolumeAsc : Order.VolumeDesc),
+    [onSort, order],
+  );
 
   const marketCapSort = getSortDirection(order, Order.MarketCapDesc, Order.MarketCapAsc);
   const changeSort = getSortDirection(order, Order.topGainers, Order.topLosers);
+  const volumeSort = getSortDirection(order, Order.VolumeDesc, Order.VolumeAsc);
 
   return {
     parentRef,
@@ -98,8 +103,10 @@ export function useMarketTableViewModel({
     toggleStar,
     marketCapSort,
     changeSort,
+    volumeSort,
     onToggleMarketCap,
     onToggleChange,
+    onToggleVolume,
     t,
   };
 }

--- a/libs/ledger-live-common/src/market/utils/__tests__/index.test.ts
+++ b/libs/ledger-live-common/src/market/utils/__tests__/index.test.ts
@@ -95,6 +95,11 @@ describe("getSortParam", () => {
     expect(getSortParam(Order.topGainers, "6m")).toBe("positive-price-change-6m");
     expect(getSortParam(Order.topLosers, "6m")).toBe("negative-price-change-6m");
   });
+
+  it("maps volume orders to total-volume sort params", () => {
+    expect(getSortParam(Order.VolumeDesc, "24h")).toBe("total-volume-desc");
+    expect(getSortParam(Order.VolumeAsc, "24h")).toBe("total-volume");
+  });
 });
 
 describe("isAvailableForTrading", () => {

--- a/libs/ledger-live-common/src/market/utils/index.ts
+++ b/libs/ledger-live-common/src/market/utils/index.ts
@@ -136,5 +136,9 @@ export const getSortParam = (order: Order, range: PortfolioRange | string) => {
       return `negative-price-change-${getRange(range)}`;
     case Order.topGainers:
       return `positive-price-change-${getRange(range)}`;
+    case Order.VolumeDesc:
+      return "total-volume-desc";
+    case Order.VolumeAsc:
+      return "total-volume";
   }
 };

--- a/libs/ledger-live-common/src/market/utils/types.ts
+++ b/libs/ledger-live-common/src/market/utils/types.ts
@@ -9,6 +9,8 @@ export enum Order {
   MarketCapAsc = "asc",
   topLosers = "topLosers",
   topGainers = "topGainers",
+  VolumeDesc = "volume-desc",
+  VolumeAsc = "volume-asc",
 }
 
 export type MarketListRequestParams = {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Market page: the **Volume** column header is now sortable
  - First click sorts by highest 24h volume, second click by lowest (toggle, like Market Cap)
  - Verify the `/v3/markets` request carries `sort=total-volume-desc` then `sort=total-volume`
  - Confirm other sorts (Market Cap, Change) and search still behave correctly

### 📝 Description

The `/v3/markets` endpoint now accepts two new `sort` values — `total-volume` and `total-volume-desc` — so users can sort the market list by 24h trading volume (`total-volume-desc` = highest first, the meaningful default; `total-volume` = lowest first).

The desktop market table already rendered a **Volume** column header with a `TableSortButton`, but it was not wired to any handler and clicking it did nothing. This PR extends the shared `Order` enum and `getSortParam` mapping in `live-common`, then wires the existing Volume header button so it toggles between highest/lowest volume, mirroring the existing Market Cap column behavior.

```ts
// libs/ledger-live-common/src/market/utils/index.ts — getSortParam
case Order.VolumeDesc:
  return "total-volume-desc"; // highest volume first
case Order.VolumeAsc:
  return "total-volume";      // lowest volume first
```

### 📸 Screenshots


https://github.com/user-attachments/assets/705ac182-617a-4df2-8950-dfc628fce549



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32499](https://ledgerhq.atlassian.net/browse/LIVE-32499)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIVE-32499]: https://ledgerhq.atlassian.net/browse/LIVE-32499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ