### PR TITLE
[LWM] fix(mobile): market category defaults to all + filter tabs switchable [LIVE-32406/LIVE-32399]

### DIFF
--- a/.changeset/lwm-market-category-not-persisted.md
+++ b/.changeset/lwm-market-category-not-persisted.md
@@ -1,0 +1,8 @@
+---
+"live-mobile": patch
+---
+
+Market screen category fixes (mobile):
+
+- The selected category is no longer persisted — opening the Market list always starts on the "all" category (a route param such as "stocks" still sets the initial category for that visit). The category was removed from the persisted `marketListConfig` redux slice and is now local screen state.
+- Fixed the category filter tabs not switching when a category was pre-selected (e.g. arriving from a "stocks" link): the previous logic re-applied the route category on every change, reverting the tap. Tabs are now plain local state, so any tab can be selected.

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/assetsList.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/assetsList.integration.test.tsx
@@ -30,13 +30,12 @@ const enableAssetDiscoverability = withFlagOverrides({
   lwmWallet40: { enabled: true, params: { assetDiscoverability: true } },
 });
 
-function enableFavoritesCategory(starredMarketCoins: string[] = []) {
+function withStarredMarketCoins(starredMarketCoins: string[] = []) {
   return withFlagOverrides(
     { lwmWallet40: { enabled: true, params: { assetDiscoverability: true } } },
     (state: State): State => ({
       ...state,
       settings: { ...state.settings, starredMarketCoins },
-      marketListConfig: { ...state.marketListConfig, category: "starred" },
     }),
   );
 }
@@ -181,22 +180,37 @@ describe("MarketScreen assets list (Block 3)", () => {
   });
 
   it("renders the favorites empty state when no market coin is starred", async () => {
-    renderWithReactQuery(<NavigatorWrapper />, {
-      overrideInitialState: enableFavoritesCategory(),
+    const { user } = renderWithReactQuery(<NavigatorWrapper />, {
+      overrideInitialState: withStarredMarketCoins(),
     });
+
+    await waitFor(() => expect(screen.getByTestId("marketItem-bitcoin")).toBeVisible(), {
+      timeout: 5000,
+    });
+
+    await user.press(
+      screen.getByTestId(`${MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher}-starred`),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("No favorites yet")).toBeVisible();
     });
-
     expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsFavoritesEmptyIcon)).toBeVisible();
     expect(screen.queryByTestId("marketItem-bitcoin")).toBeNull();
   });
 
   it("renders only starred market coins in the Favorites category", async () => {
-    renderWithReactQuery(<NavigatorWrapper />, {
-      overrideInitialState: enableFavoritesCategory(["bitcoin"]),
+    const { user } = renderWithReactQuery(<NavigatorWrapper />, {
+      overrideInitialState: withStarredMarketCoins(["bitcoin"]),
     });
+
+    await waitFor(() => expect(screen.getByTestId("marketItem-ethereum")).toBeVisible(), {
+      timeout: 5000,
+    });
+
+    await user.press(
+      screen.getByTestId(`${MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher}-starred`),
+    );
 
     await waitFor(
       () => {
@@ -298,27 +312,29 @@ describe("MarketScreen assets list (Block 3)", () => {
     expect(screen.queryByTestId("marketItem-bitcoin")).toBeNull();
   });
 
-  it("renders CVS stock rows when the Stocks category is persisted", async () => {
-    renderWithReactQuery(<NavigatorWrapper />, {
-      overrideInitialState: withFlagOverrides(
-        { lwmWallet40: { enabled: true, params: { assetDiscoverability: true } } },
-        (state: State): State => ({
-          ...state,
-          marketListConfig: { ...state.marketListConfig, category: "stocks" },
-        }),
-      ),
+  it("switches categories from the tabs, including back to All", async () => {
+    const marketRequests: string[] = [];
+    const dadaRequests: string[] = [];
+    installCapturedMarketHandlers(marketRequests, dadaRequests);
+
+    const { user } = renderWithReactQuery(<NavigatorWrapper />, {
+      overrideInitialState: enableAssetDiscoverability,
     });
 
-    await waitFor(
-      () => {
-        expect(screen.getByTestId("marketItem-tesla-xstock")).toBeVisible();
-      },
-      { timeout: 5000 },
-    );
+    await waitFor(() => expect(screen.getByTestId("marketItem-bitcoin")).toBeVisible(), {
+      timeout: 5000,
+    });
 
-    expect(screen.getByText("Tesla xStock")).toBeVisible();
-    expect(screen.getByText("Stocks")).toBeVisible();
-    expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher)).toBeVisible();
+    await user.press(screen.getByTestId(`${MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher}-stocks`));
+    await waitFor(() => expect(screen.getByTestId("marketItem-tesla-xstock")).toBeVisible(), {
+      timeout: 5000,
+    });
     expect(screen.queryByTestId("marketItem-bitcoin")).toBeNull();
+
+    await user.press(screen.getByTestId(`${MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher}-all`));
+    await waitFor(() => expect(screen.getByTestId("marketItem-bitcoin")).toBeVisible(), {
+      timeout: 5000,
+    });
+    expect(screen.queryByTestId("marketItem-tesla-xstock")).toBeNull();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketScreenViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketScreenViewModel.test.ts
@@ -11,6 +11,7 @@ jest.mock("~/analytics", () => ({ track: jest.fn() }));
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
   useRoute: jest.fn(),
+  useFocusEffect: jest.fn(),
 }));
 
 const openFromMarket = jest.fn();
@@ -165,14 +166,18 @@ describe("useMarketScreenViewModel", () => {
 
   it("forwards the selected category and starred ids to the assets hook", () => {
     const starredMarketCoins = ["bitcoin"];
+    mockMarketListRoute("starred");
 
-    const { result } = renderHook(() => useMarketScreenViewModel(), {
-      overrideInitialState: (state: State): State => ({
-        ...state,
-        settings: { ...state.settings, starredMarketCoins },
-        marketListConfig: { ...state.marketListConfig, category: "starred" },
-      }),
-    });
+    const { result } = renderHook(
+      () => useMarketScreenViewModel(),
+      withAssetDiscoverability(
+        true,
+        (state: State): State => ({
+          ...state,
+          settings: { ...state.settings, starredMarketCoins },
+        }),
+      ),
+    );
 
     expect(result.current.assetsList.categories.selectedCategory).toBe("starred");
     expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({
@@ -199,8 +204,8 @@ describe("useMarketScreenViewModel", () => {
     });
   });
 
-  it("tracks and persists the stocks category", () => {
-    const { result, store } = renderHook(() => useMarketScreenViewModel());
+  it("tracks and applies the stocks category", () => {
+    const { result } = renderHook(() => useMarketScreenViewModel());
 
     act(() => result.current.assetsList.categories.onSelectCategory("stocks"));
 
@@ -209,15 +214,15 @@ describe("useMarketScreenViewModel", () => {
       category: "stocks",
       page: "Market",
     });
-    expect(store.getState().marketListConfig.category).toBe("stocks");
+    expect(result.current.assetsList.categories.selectedCategory).toBe("stocks");
     expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({
       ...defaultMarketAssetsParams,
       category: "stocks",
     });
   });
 
-  it("tracks and persists the favorites category", () => {
-    const { result, store } = renderHook(() => useMarketScreenViewModel());
+  it("tracks and applies the favorites category", () => {
+    const { result } = renderHook(() => useMarketScreenViewModel());
 
     act(() => result.current.assetsList.categories.onSelectCategory("starred"));
 
@@ -226,66 +231,66 @@ describe("useMarketScreenViewModel", () => {
       category: "starred",
       page: "Market",
     });
-    expect(store.getState().marketListConfig.category).toBe("starred");
+    expect(result.current.assetsList.categories.selectedCategory).toBe("starred");
     expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({
       ...defaultMarketAssetsParams,
       category: "starred",
     });
   });
 
-  it("should set the market list category from a valid route param", () => {
+  it("uses a valid route category as the initial category", () => {
     mockMarketListRoute("stocks");
 
-    const { store } = renderHook(() => useMarketScreenViewModel(), withAssetDiscoverability(true));
+    const { result } = renderHook(() => useMarketScreenViewModel(), withAssetDiscoverability(true));
 
-    expect(store.getState().marketListConfig.category).toBe("stocks");
+    expect(result.current.assetsList.categories.selectedCategory).toBe("stocks");
   });
 
-  it("should support the starred route category", () => {
+  it("supports the starred route category", () => {
     mockMarketListRoute("starred");
 
-    const { store } = renderHook(() => useMarketScreenViewModel(), withAssetDiscoverability(true));
+    const { result } = renderHook(() => useMarketScreenViewModel(), withAssetDiscoverability(true));
 
-    expect(store.getState().marketListConfig.category).toBe("starred");
+    expect(result.current.assetsList.categories.selectedCategory).toBe("starred");
   });
 
-  it("should preserve the persisted category when route category is missing", () => {
-    const { store } = renderHook(
-      () => useMarketScreenViewModel(),
-      withAssetDiscoverability(true, state => ({
-        ...state,
-        marketListConfig: { ...state.marketListConfig, category: "starred" },
-      })),
-    );
-
-    expect(store.getState().marketListConfig.category).toBe("starred");
-  });
-
-  it("should preserve the persisted category when route category is invalid", () => {
-    mockMarketListRoute("unknown");
-
-    const { store } = renderHook(
-      () => useMarketScreenViewModel(),
-      withAssetDiscoverability(true, state => ({
-        ...state,
-        marketListConfig: { ...state.marketListConfig, category: "starred" },
-      })),
-    );
-
-    expect(store.getState().marketListConfig.category).toBe("starred");
-  });
-
-  it("should ignore the route category when asset discoverability is disabled", () => {
+  it("allows switching category even when a category is pre-selected", () => {
     mockMarketListRoute("stocks");
 
-    const { store } = renderHook(
+    const { result } = renderHook(() => useMarketScreenViewModel(), withAssetDiscoverability(true));
+    expect(result.current.assetsList.categories.selectedCategory).toBe("stocks");
+
+    act(() => result.current.assetsList.categories.onSelectCategory("all"));
+
+    expect(result.current.assetsList.categories.selectedCategory).toBe("all");
+    expect(mockedUseMarketAssets).toHaveBeenLastCalledWith({
+      ...defaultMarketAssetsParams,
+      category: "all",
+    });
+  });
+
+  it("defaults to the all category when there is no route category", () => {
+    const { result } = renderHook(() => useMarketScreenViewModel(), withAssetDiscoverability(true));
+
+    expect(result.current.assetsList.categories.selectedCategory).toBe("all");
+  });
+
+  it("defaults to the all category when the route category is invalid", () => {
+    mockMarketListRoute("unknown");
+
+    const { result } = renderHook(() => useMarketScreenViewModel(), withAssetDiscoverability(true));
+
+    expect(result.current.assetsList.categories.selectedCategory).toBe("all");
+  });
+
+  it("ignores the route category when asset discoverability is disabled", () => {
+    mockMarketListRoute("stocks");
+
+    const { result } = renderHook(
       () => useMarketScreenViewModel(),
-      withAssetDiscoverability(false, state => ({
-        ...state,
-        marketListConfig: { ...state.marketListConfig, category: "starred" },
-      })),
+      withAssetDiscoverability(false),
     );
 
-    expect(store.getState().marketListConfig.category).toBe("starred");
+    expect(result.current.assetsList.categories.selectedCategory).toBe("all");
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketCategories.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketCategories.ts
@@ -1,8 +1,7 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { useFocusEffect } from "@react-navigation/native";
 import { useGetTrendingCategoriesQuery } from "@ledgerhq/live-common/market/state-manager/api";
 import { track } from "~/analytics";
-import { useDispatch, useSelector } from "~/context/hooks";
-import { selectMarketListCategory, setMarketListCategory } from "~/reducers/market";
 import type { MarketListCategory } from "~/reducers/types";
 
 export type MarketCategoryTab = {
@@ -16,6 +15,8 @@ export type MarketCategories = {
   tabs: MarketCategoryTab[];
   onSelectCategory: (category: MarketListCategory) => void;
 };
+
+const DEFAULT_CATEGORY: MarketListCategory = "all";
 
 const BUILT_IN_CATEGORY_TABS: MarketCategoryTab[] = [
   { value: "all", labelKey: "market.assets.categories.all" },
@@ -31,10 +32,14 @@ function trackCategoryTap(category: MarketListCategory) {
   });
 }
 
-export function useMarketCategories(): MarketCategories {
-  const dispatch = useDispatch();
-  const persistedCategory = useSelector(selectMarketListCategory);
+export function useMarketCategories({
+  routeCategory,
+}: {
+  routeCategory?: MarketListCategory;
+} = {}): MarketCategories {
   const { data: trendingCategories } = useGetTrendingCategoriesQuery();
+  const entryCategory = routeCategory ?? DEFAULT_CATEGORY;
+  const [selectedCategory, setSelectedCategory] = useState<MarketListCategory>(entryCategory);
 
   const tabs = useMemo<MarketCategoryTab[]>(
     () => [
@@ -49,8 +54,15 @@ export function useMarketCategories(): MarketCategories {
 
   const selectableCategories = useMemo(() => new Set(tabs.map(tab => tab.value)), [tabs]);
 
-  // Persisted trending ids may no longer be trending after a refresh: fall back to "all".
-  const selectedCategory = selectableCategories.has(persistedCategory) ? persistedCategory : "all";
+  useFocusEffect(
+    useCallback(() => {
+      setSelectedCategory(entryCategory);
+    }, [entryCategory]),
+  );
+
+  const effectiveCategory = selectableCategories.has(selectedCategory)
+    ? selectedCategory
+    : DEFAULT_CATEGORY;
 
   const onSelectCategory = useCallback(
     (category: MarketListCategory) => {
@@ -60,17 +72,17 @@ export function useMarketCategories(): MarketCategories {
         return;
       }
 
-      dispatch(setMarketListCategory(category));
+      setSelectedCategory(category);
     },
-    [dispatch, selectableCategories],
+    [selectableCategories],
   );
 
   return useMemo(
     () => ({
-      selectedCategory,
+      selectedCategory: effectiveCategory,
       tabs,
       onSelectCategory,
     }),
-    [onSelectCategory, selectedCategory, tabs],
+    [onSelectCategory, effectiveCategory, tabs],
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
@@ -1,4 +1,3 @@
-import { useLayoutEffect } from "react";
 import { useRoute, type RouteProp } from "@react-navigation/native";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
@@ -11,8 +10,7 @@ import { type MarketFilters, useMarketFilters } from "./useMarketFilters";
 import { useMarketHighlights, type MarketHighlights } from "./useMarketHighlights";
 import { type MarketSearch, useMarketSearch } from "./useMarketSearch";
 import { ScreenName } from "~/const";
-import { useDispatch, useSelector } from "~/context/hooks";
-import { selectMarketListCategory, setMarketListCategory } from "~/reducers/market";
+import { useSelector } from "~/context/hooks";
 import { starredMarketCoinsSelector } from "~/reducers/settings";
 
 type MarketScreenRoute = RouteProp<MarketNavigatorStackParamList, ScreenName.MarketList>;
@@ -41,14 +39,14 @@ export type MarketScreenViewModel = {
 };
 
 export function useMarketScreenViewModel(): MarketScreenViewModel {
-  const dispatch = useDispatch();
   const route = useRoute<MarketScreenRoute>();
-  const persistedCategory = useSelector(selectMarketListCategory);
   const { shouldDisplayAssetDiscoverability } = useWalletFeaturesConfig("mobile");
-  const routeCategory = parseMarketListCategory(route.params?.category);
+  const routeCategory = shouldDisplayAssetDiscoverability
+    ? parseMarketListCategory(route.params?.category)
+    : undefined;
   const search = useMarketSearch();
   const highlights = useMarketHighlights();
-  const categories = useMarketCategories();
+  const categories = useMarketCategories({ routeCategory });
   const filters = useMarketFilters();
   const starredMarketCoins = useSelector(starredMarketCoinsSelector);
   const { assets, loading, isError, emptyState, onEndReached } = useMarketAssets({
@@ -59,18 +57,6 @@ export function useMarketScreenViewModel(): MarketScreenViewModel {
     starredMarketCoins,
   });
   const onAssetPress = useMarketAssetPress();
-
-  useLayoutEffect(() => {
-    if (
-      !shouldDisplayAssetDiscoverability ||
-      !routeCategory ||
-      routeCategory === persistedCategory
-    ) {
-      return;
-    }
-
-    dispatch(setMarketListCategory(routeCategory));
-  }, [dispatch, persistedCategory, routeCategory, shouldDisplayAssetDiscoverability]);
 
   return {
     search: {

--- a/apps/ledger-live-mobile/src/reducers/__tests__/marketListConfig.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/marketListConfig.test.ts
@@ -2,11 +2,9 @@ import {
   MARKET_LIST_CONFIG_INITIAL_STATE,
   marketListConfigReducer,
   importMarketListConfig,
-  selectMarketListCategory,
   selectMarketListNetwork,
   selectMarketListSorting,
   selectMarketListTimeframe,
-  setMarketListCategory,
   setMarketListNetwork,
   setMarketListSorting,
   setMarketListTimeframe,
@@ -21,7 +19,6 @@ describe("marketListConfig slice", () => {
     expect(selectMarketListSorting(asState())).toBe("marketCap");
     expect(selectMarketListTimeframe(asState())).toBe("1D");
     expect(selectMarketListNetwork(asState())).toBeUndefined();
-    expect(selectMarketListCategory(asState())).toBe("all");
   });
 
   it("updates each preference through its action", () => {
@@ -33,9 +30,6 @@ describe("marketListConfig slice", () => {
 
     state = marketListConfigReducer(state, setMarketListNetwork("ethereum"));
     expect(state.network).toBe("ethereum");
-
-    state = marketListConfigReducer(state, setMarketListCategory("starred"));
-    expect(state.category).toBe("starred");
   });
 
   it("resets the network back to all networks", () => {
@@ -44,7 +38,7 @@ describe("marketListConfig slice", () => {
     expect(reset.network).toBeUndefined();
   });
 
-  it("rehydrates persisted preferences but resets the category to the default", () => {
+  it("rehydrates only the supported preferences and drops a legacy persisted category", () => {
     const state = marketListConfigReducer(
       undefined,
       importMarketListConfig({
@@ -52,14 +46,12 @@ describe("marketListConfig slice", () => {
         timeframe: "1Y",
         network: "bitcoin",
         category: "stocks",
-      }),
+      } as MarketListConfigState),
     );
     expect(state).toEqual({
       sorting: "gainers",
       timeframe: "1Y",
       network: "bitcoin",
-      // category is not persisted across launches: always back to the default.
-      category: "all",
     });
   });
 });

--- a/apps/ledger-live-mobile/src/reducers/market.ts
+++ b/apps/ledger-live-mobile/src/reducers/market.ts
@@ -1,7 +1,6 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import { Action, ReducerMap, handleActions } from "redux-actions";
 import {
-  MarketListCategory,
   MarketListConfigState,
   MarketListFilterTimeframe,
   MarketListSorting,
@@ -99,13 +98,12 @@ export default handleActions<MarketState, MarketPayload>(handlers, INITIAL_STATE
 /**
  * V4 asset list config — shared between MarketScreen and modularAssetDrawer.
  * Gated by llmAssetDiscoverability. Sorting/timeframe/network persist as user
- * preferences; the selected category resets to the default on relaunch.
+ * preferences. The selected category is not persisted (kept as local screen state).
  */
 export const MARKET_LIST_CONFIG_INITIAL_STATE: MarketListConfigState = {
   sorting: "marketCap",
   timeframe: "1D",
   network: undefined,
-  category: "all",
 };
 
 const marketListConfigSlice = createSlice({
@@ -121,15 +119,10 @@ const marketListConfigSlice = createSlice({
     setMarketListNetwork: (state, action: PayloadAction<string | undefined>) => {
       state.network = action.payload;
     },
-    setMarketListCategory: (state, action: PayloadAction<MarketListCategory>) => {
-      state.category = action.payload;
-    },
     importMarketListConfig: (_state, action: PayloadAction<MarketListConfigState>) => ({
-      ...MARKET_LIST_CONFIG_INITIAL_STATE,
-      ...action.payload,
-      // The selected category is intentionally not persisted across launches:
-      // always start on the default category when the app relaunches.
-      category: MARKET_LIST_CONFIG_INITIAL_STATE.category,
+      sorting: action.payload.sorting ?? MARKET_LIST_CONFIG_INITIAL_STATE.sorting,
+      timeframe: action.payload.timeframe ?? MARKET_LIST_CONFIG_INITIAL_STATE.timeframe,
+      network: action.payload.network,
     }),
   },
 });
@@ -138,7 +131,6 @@ export const {
   setMarketListSorting,
   setMarketListTimeframe,
   setMarketListNetwork,
-  setMarketListCategory,
   importMarketListConfig,
 } = marketListConfigSlice.actions;
 
@@ -148,8 +140,6 @@ export const selectMarketListTimeframe = (state: State): MarketListFilterTimefra
   state.marketListConfig.timeframe;
 export const selectMarketListNetwork = (state: State): string | undefined =>
   state.marketListConfig.network;
-export const selectMarketListCategory = (state: State): MarketListCategory =>
-  state.marketListConfig.category;
 
 export const exportMarketListConfigSelector = (state: State): MarketListConfigState =>
   state.marketListConfig;

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -395,7 +395,6 @@ export type MarketListConfigState = {
   timeframe: MarketListFilterTimeframe;
   /** Selected network id, or `undefined` for all networks (consumed by LIVE-29972). */
   network: string | undefined;
-  category: MarketListCategory;
 };
 
 // === MARKET BANNER STATE (V4) ===


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Updated `useMarketScreenViewModel` + `marketListConfig` unit tests and the Market assets-list integration tests (Market suite green, 219).
- [x] **Impact of the changes:**
  - Market list category: always starts on **All** (not the last-used one), and the category **filter tabs are now selectable** even when a category was pre-selected.

### 🐛 Description

Two related Market-screen bugs:

**Category persisted → should default to "all" ([LIVE-32406](https://ledgerhq.atlassian.net/browse/LIVE-32406))**
The selected category was stored in the persisted `marketListConfig` redux slice, so re-opening the Market list showed the last-used category instead of "all".

**Filter tabs not switching when pre-selected ([LIVE-32399](https://ledgerhq.atlassian.net/browse/LIVE-32399))**
When arriving with a category (e.g. from a "stocks" link), the route-param effect re-applied that category on every redux change, immediately reverting any tab tap — so you couldn't switch away.

**Fix:** the selected category is now **local screen state** in `useMarketCategories`:
- Defaults to `"all"`; a route param (e.g. `stocks`) sets the initial category for that visit and resets on each entry (`useFocusEffect`), so the category is not persisted.
- Tab selection updates local state directly — no effect reverts it, so all tabs are selectable.
- Removed `category` from the persisted `marketListConfig` slice (kept `sorting`/`timeframe`/`network`).


https://github.com/user-attachments/assets/6688772b-441e-4179-b25a-68eb80dca75d



### ❓ Context

- **JIRA**: [LIVE-32406](https://ledgerhq.atlassian.net/browse/LIVE-32406), [LIVE-32399](https://ledgerhq.atlassian.net/browse/LIVE-32399)


[LIVE-32406]: https://ledgerhq.atlassian.net/browse/LIVE-32406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-32399]: https://ledgerhq.atlassian.net/browse/LIVE-32399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-32406]: https://ledgerhq.atlassian.net/browse/LIVE-32406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ