### PR TITLE
[LWD] fix(desktop): align market card disclaimer wording

### DIFF
--- a/.changeset/healthy-lies-wonder.md
+++ b/.changeset/healthy-lies-wonder.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+align footer note in market cards

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/__tests__/GlobalMarketCapCard.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/__tests__/GlobalMarketCapCard.test.tsx
@@ -30,7 +30,7 @@ describe("GlobalMarketCapCard", () => {
     expect(await screen.findByTestId("global-market-cap-dialog-content")).toBeVisible();
     expect(
       screen.getByText(
-        "Data is sourced from CoinMarketCap and provided for informational purposes only.",
+        "Data is sourced from CoinMarketCap. Provided for informational purposes only.",
       ),
     ).toBeVisible();
   });

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8774,7 +8774,7 @@
     "dialog": {
       "title": "Mood index",
       "content": "Shows overall market sentiment from 0 to 100, based notably on volatility, market momentum and social trends. Lower values indicate fear, higher values indicate greed.",
-      "disclaimer": "Data is sourced from CoinMarketCap and provided for informational purposes only.",
+      "disclaimer": "Data is sourced from CoinMarketCap. Provided for informational purposes only.",
       "cta": "Got it"
     }
   },
@@ -8782,7 +8782,7 @@
     "dialog": {
       "title": "Total market cap",
       "content": "The total market cap represents the market capitalization of all cryptocurrencies combined.",
-      "disclaimer": "Data is sourced from CoinMarketCap and provided for informational purposes only.",
+      "disclaimer": "Data is sourced from CoinMarketCap. Provided for informational purposes only.",
       "cta": "Got it"
     }
   },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Market Top Cards (Global Market Cap card) disclaimer footer text rendering

### 📝 Description

The disclaimer footer note shown in the Market top cards was a run-on sentence: `"Data is sourced from CoinMarketCap and provided for informational purposes only."`

This PR splits it into two cleaner sentences — `"Data is sourced from CoinMarketCap. Provided for informational purposes only."` — updating both the `en` i18n string and the matching test assertion in `GlobalMarketCapCard.test.tsx`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32524](https://ledgerhq.atlassian.net/browse/LIVE-32524)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32524]: https://ledgerhq.atlassian.net/browse/LIVE-32524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ