### PR TITLE
[LWM] fix(mobile): set market highlights gauge margins to 16

### DIFF
--- a/.changeset/lwm-market-gauge-margins.md
+++ b/.changeset/lwm-market-gauge-margins.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Market screen spacing: set the top and bottom margins around the highlights gauge row to 16

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/index.tsx
@@ -205,9 +205,9 @@ export function MarketAssetsList({
   const listHeader =
     header || showSubheader ? (
       <Box lx={headerStyle}>
-        {header}
+        {header ? <Box lx={highlightsStyle}>{header}</Box> : null}
         {showSubheader ? (
-          <>
+          <Box lx={subHeaderGroupStyle}>
             <Subheader lx={subHeaderStyle} testID={MARKET_SCREEN_TEST_IDS.assetsSubHeader}>
               <SubheaderRow lx={subHeaderRowStyle}>
                 <SubheaderTitle>{t("market.assets.title")}</SubheaderTitle>
@@ -226,7 +226,7 @@ export function MarketAssetsList({
               tabs={categoryTabs}
               onSelectCategory={onSelectCategory}
             />
-          </>
+          </Box>
         ) : null}
       </Box>
     ) : null;
@@ -268,7 +268,14 @@ export function MarketAssetsList({
 
 const headerStyle: LumenViewStyle = {
   marginHorizontal: "-s16",
-  paddingTop: "s24",
+};
+
+const highlightsStyle: LumenViewStyle = {
+  marginTop: "s16",
+  marginBottom: "s16",
+};
+
+const subHeaderGroupStyle: LumenViewStyle = {
   gap: "s12",
 };
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Style-only change (vertical margins). No existing test asserts on these layout styles, and adding a snapshot/layout test for a spacing token is not warranted._
- [x] **Impact of the changes:**
      - Vertical spacing around the highlights/gauge row at the top of the Market screen
      - Spacing between the "Market" subheader and the category switcher (must remain unchanged at 12)

### 📝 Description

The gauge highlights row (Fear & Greed / Altcoin Season / Market Cap cards) at the top of the Market screen had inconsistent vertical spacing: a 24px top margin (`paddingTop: s24`) and a 12px bottom margin (`gap: s12`). Per design, both the top and bottom margins should be 16.

The bottom spacing came from a `gap` on the header container that was shared with the subheader/category-switcher spacing (which must stay at 12). The fix decouples the spacing: the highlights row now gets its own `marginTop: 16` / `marginBottom: 16`, while the subheader and category switcher are grouped to preserve their internal 12px gap.

### 📸 Screenshots

<img width="350" height="750" alt="Simulator Screenshot - build2 - 2026-06-15 at 10 25 42" src="https://github.com/user-attachments/assets/5dd8194d-5a87-49b7-83ca-1c2785a5c5e0" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-32402](https://ledgerhq.atlassian.net/browse/LIVE-32402)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32402]: https://ledgerhq.atlassian.net/browse/LIVE-32402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ