### PR TITLE
[LWM] fix(mobile): hide trend icon for near-zero variations in Market list

### DIFF
--- a/.changeset/market-neutral-variation-symbol.md
+++ b/.changeset/market-neutral-variation-symbol.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix: hide the unnecessary neutral symbol displayed before a 0.00% 24h variation in the mobile Market list. A near-zero variation now renders a plain "0.00%" without the Trend minus icon, matching the desktop behavior.

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/AssetListItem.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/AssetListItem.test.tsx
@@ -94,6 +94,18 @@ describe("AssetListItem", () => {
       expect(screen.getByText(/7\.87%/)).toBeVisible();
     });
 
+    it("renders a neutral 0.00% without a trend icon when the change is zero", () => {
+      renderMarketView({ priceChangePercentage: 0 });
+      expect(screen.getByTestId("marketItem-bitcoin-change-neutral")).toHaveTextContent("0.00%");
+      expect(screen.queryByLabelText("No change, 0.00%")).toBeNull();
+    });
+
+    it("renders a neutral 0.00% for tiny negative changes that round to zero", () => {
+      renderMarketView({ priceChangePercentage: -0.003 });
+      expect(screen.getByTestId("marketItem-bitcoin-change-neutral")).toHaveTextContent("0.00%");
+      expect(screen.queryByText("-0.00%")).toBeNull();
+    });
+
     it("hides the rank tag when rank is unknown", () => {
       renderMarketView({ marketcapRank: 0 });
       expect(screen.queryByText("#0")).toBeNull();

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/components/AssetListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/components/AssetListItem.tsx
@@ -109,7 +109,17 @@ const MarketRow = memo(({ market, onPress, lx }: MarketRowProps) => {
           >
             {market.formattedPrice}
           </Text>
-          <Trend value={market.priceChangePercentage} size="sm" />
+          {Math.abs(market.priceChangePercentage) < 0.005 ? (
+            <Text
+              typography="body3"
+              lx={{ color: "muted" }}
+              testID={`marketItem-${market.id}-change-neutral`}
+            >
+              0.00%
+            </Text>
+          ) : (
+            <Trend value={market.priceChangePercentage} size="sm" />
+          )}
         </Box>
       </ListItemTrailing>
     </LumenListItem>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile Market list rendering of the 24h price variation column
  - Assets whose 24h variation is exactly `0.00%` or rounds to `0.00%` (must no longer show a leading minus / Trend icon)
  - Non-zero variations must still display the up/down Trend icon with the colored value

### 📝 Description

In the mobile Market list, an asset whose 24h variation is `0.00%` displayed an unnecessary minus symbol before the value. This comes from the shared Lumen `Trend` component, whose `neutral` variant always renders a `Minus` icon and exposes no option to hide it.

Because `Trend` is an external design-system package, the fix is applied at the call site in `AssetListItem` (market row): when `Math.abs(priceChangePercentage) < 0.005`, the row now renders a plain muted `0.00%` text without the `Trend` icon. This mirrors the existing desktop behavior in `MarketRowView` and also covers tiny negative values that round to `0.00%` (previously shown as `-0.00%` with a down arrow).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32410](https://ledgerhq.atlassian.net/browse/LIVE-32410)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32410]: https://ledgerhq.atlassian.net/browse/LIVE-32410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ