### PR TITLE
[LWD] fix(desktop): forward market state from global search to asset detail

### DIFF
--- a/.changeset/global-search-asset-not-found.md
+++ b/.changeset/global-search-asset-not-found.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Global Search navigating to "asset not found" for assets without a market-provider entry (e.g. Canton). The search now forwards the full market currency (with its `ledgerIds`) as navigation state, so the Asset Detail screen can resolve such assets via the DADA fallback — matching the behaviour of the Market table rows and mobile.

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchResultRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchResultRow.tsx
@@ -6,7 +6,7 @@ type SearchResultRowProps = {
   currency: MarketCurrencyData;
   counterCurrency: string;
   locale: string;
-  onClick: (currencyId: string) => void;
+  onClick: (currencyId: string, marketState?: MarketCurrencyData) => void;
 };
 
 export function SearchResultRow({

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/types.ts
@@ -25,7 +25,7 @@ export type SearchResults = {
 
 export type SearchOverlayContextValue = {
   close: () => void;
-  navigateToAsset: (currencyId: string) => void;
+  navigateToAsset: (currencyId: string, marketState?: MarketCurrencyData) => void;
   navigateToMarket: () => void;
   navigateToStocksMarket: () => void;
   suggestions: SearchSuggestions;

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useSearchOverlayViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useSearchOverlayViewModel.ts
@@ -1,6 +1,7 @@
 import { KeyboardEvent, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { getMarketOrAssetDetailPath } from "LLD/utils/marketAssetNavigation";
 import { setMarketCategory } from "~/renderer/actions/market";
@@ -16,9 +17,11 @@ export function useSearchOverlayViewModel() {
     useAssetSearchBar();
 
   const navigateToAsset = useCallback(
-    (currencyId: string) => {
+    (currencyId: string, marketState?: MarketCurrencyData) => {
       setTrackingSource("Global Search");
-      navigate(getMarketOrAssetDetailPath(currencyId, shouldDisplayAggregatedAssets));
+      navigate(getMarketOrAssetDetailPath(currencyId, shouldDisplayAggregatedAssets), {
+        state: marketState,
+      });
       close();
     },
     [navigate, shouldDisplayAggregatedAssets, close],

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/__integrations__/SearchAssets.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/__integrations__/SearchAssets.integration.test.tsx
@@ -157,7 +157,7 @@ describe("SearchAssets suggestion sections", () => {
     render(<Harness />);
 
     fireEvent.click(screen.getByTestId("cryptos-item-btc"));
-    expect(navigateToAsset).toHaveBeenCalledWith(BTC.id);
+    expect(navigateToAsset).toHaveBeenCalledWith(BTC.id, expect.objectContaining({ id: BTC.id }));
   });
 
   it("triggers the see-all handler from the section header", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/components/AssetSuggestionRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/components/AssetSuggestionRow.tsx
@@ -25,7 +25,7 @@ type AssetSuggestionRowProps = {
   counterCurrency: string;
   locale: string;
   testIdPrefix: string;
-  onClick: (currencyId: string) => void;
+  onClick: (currencyId: string, marketState?: MarketCurrencyData) => void;
   density?: AssetSuggestionRowDensity;
 };
 
@@ -64,7 +64,7 @@ export function AssetSuggestionRow({
     <ListItem
       density={isExpanded ? "expanded" : "compact"}
       className="cursor-pointer"
-      onClick={() => onClick(currency.id)}
+      onClick={() => onClick(currency.id, currency)}
       aria-label={currency.name}
       data-testid={`${testIdPrefix}-item-${currency.ticker.toLowerCase()}`}
     >

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/types.ts
@@ -1,3 +1,4 @@
+import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
 import { AssetSuggestionSection } from "LLD/components/TopBar/components/TopBarSearch/SearchOverlay/types";
 
 export type AssetSuggestionsViewModelResult = {
@@ -14,7 +15,7 @@ export type AssetSuggestionsSectionProps = AssetSuggestionSection & {
   /** Disambiguates test ids and skeleton keys (e.g. "cryptos"). */
   testIdPrefix: string;
   /** Redirects to the asset detail page for the given market id. */
-  navigateToAsset: (currencyId: string) => void;
+  navigateToAsset: (currencyId: string, marketState?: MarketCurrencyData) => void;
   /** Lands on the market list. */
   onSeeAll: () => void;
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Integration test updated to assert the full market currency (with `ledgerIds`) is forwarded on click. The viewmodel's one-line `{ state }` forwarding mirrors the already-tested Market table-row pattern and is not covered by a dedicated test (no existing test scaffolding for the TopBar search overlay)._
- [x] **Impact of the changes:**
  - Global Search (top bar): searching an asset and clicking a result now opens the Asset Detail page instead of "asset not found".
  - Focus on assets the user does **not** hold and that have **no** market-provider (CoinGecko) entry — e.g. **Canton (CC)** — which were the broken case.
  - Regression check: assets the user owns, and assets with a market entry (BTC, ETH), still open correctly.
  - Crypto **suggestions** list and **stocks** rows in the search overlay still navigate correctly.

### 📝 Description

On Ledger Live Desktop, typing an asset (e.g. "canton") in the top-bar Global Search and clicking the result landed on the Asset Detail page showing **"asset not found"**. The same asset opens correctly on mobile.

**Problem:** The Asset Detail screen reads a `marketState` hint from react-router's `location.state` to obtain the asset's `ledgerIds`. Those `ledgerIds` are required to run the DADA per-asset fallback — the only resolution path for an asset the user doesn't own **and** that has no market-provider entry (Canton's situation). Global Search navigated with **only a path string and no state**, so `ledgerIds` was lost and the screen fell through to `not-found`. The Market table rows and mobile already pass `{ state: currency }`, which is why those flows worked.

**Solution:** Forward the full `MarketCurrencyData` (which already carries `ledgerIds`) as navigation state from Global Search, mirroring the existing Market-row pattern. The selected currency is threaded through the search row `onClick` and passed as `navigate(path, { state: currency })`. The stocks path is unaffected (it resolves via market id; the added param is optional/assignable).

### Before / After


https://github.com/user-attachments/assets/3ef93fc7-aab6-40d3-ac15-6c119ffdb5cc



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32537](https://ledgerhq.atlassian.net/browse/LIVE-32537), [LIVE-32539](https://ledgerhq.atlassian.net/browse/LIVE-32539)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32537]: https://ledgerhq.atlassian.net/browse/LIVE-32537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ