### PR TITLE
[LWD] fix: clear transaction history filters on navigation

### DIFF
--- a/.changeset/lwd-history-topbar-clear-filter.md
+++ b/.changeset/lwd-history-topbar-clear-filter.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix transaction history staying filtered by asset when opening Transactions from the top bar while already on a scoped history view

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useHistory.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useHistory.test.ts
@@ -47,10 +47,10 @@ describe("useHistory", () => {
       result.current.handleHistory();
     });
 
-    expect(mockNavigate).toHaveBeenCalledWith("/history");
+    expect(mockNavigate).toHaveBeenCalledWith("/history", { replace: false });
   });
 
-  it("does not navigate when already on history page", () => {
+  it("does not navigate when already on unfiltered history page", () => {
     const { result } = renderHook(() => useHistory());
 
     act(() => {
@@ -58,6 +58,20 @@ describe("useHistory", () => {
     });
 
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("navigates to unfiltered history when already on filtered history page", () => {
+    mockUseLocation.mockReturnValueOnce(
+      createLocation("/history", "?accountIds=account-1,account-2"),
+    );
+
+    const { result } = renderHook(() => useHistory());
+
+    act(() => {
+      result.current.handleHistory();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/history", { replace: true });
   });
 
   describe("hasUnread", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useHistory.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useHistory.ts
@@ -20,15 +20,16 @@ export const useHistory = (): {
 
   const handleHistory = useCallback(() => {
     const url = "/history";
-    if (location.pathname !== url) {
-      setTrackingSource("topbar");
-      track("button_clicked", {
-        button: "operation_list",
-        page: location.pathname,
-      });
-      navigate(url);
-    }
-  }, [navigate, location.pathname]);
+    const isOnUnfilteredHistory = location.pathname === url && location.search === "";
+    if (isOnUnfilteredHistory) return;
+
+    setTrackingSource("topbar");
+    track("button_clicked", {
+      button: "operation_list",
+      page: location.pathname,
+    });
+    navigate(url, { replace: location.pathname === url });
+  }, [navigate, location.pathname, location.search]);
 
   return {
     handleHistory,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request addresses an issue where the transaction history view remained filtered by asset when accessed from the top bar, even if the user was already viewing a scoped (filtered) history. The changes ensure that opening the history from the top bar always resets any filters, providing a consistent and expected user experience. Additionally, the tests have been updated to cover this behavior.

Behavioral fix:

* Updated the `useHistory` hook to detect if the user is already on a filtered history page and navigate to the unfiltered history view, replacing the current entry in the navigation stack if necessary. This ensures that filters are cleared when accessing history from the top bar.

https://github.com/user-attachments/assets/be6c4003-ae54-4a40-b510-efff96a20d54


### ❓ Context

[LIVE-31320](https://ledgerhq.atlassian.net/browse/LIVE-31320)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31320]: https://ledgerhq.atlassian.net/browse/LIVE-31320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ