### PR TITLE
fix(e2e): restore default timeout for send success screen

### DIFF
--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -68,7 +68,7 @@ export default class CommonPage {
 
   @Step("Tap on view details")
   async successViewDetails() {
-    await waitForElementById(this.validateSuccessScreenId, 10000);
+    await waitForElementById(this.validateSuccessScreenId);
     await waitForElementById(this.successViewDetailsButtonId);
     await tapById(this.successViewDetailsButtonId);
   }


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not required: change is limited to `e2e/` (no published package affected)._
- [x] **Covered by automatic tests.** _Test-infrastructure change, exercised by the existing send e2e specs (sendBASE, sendDOT, …) that route through `CommonPage.successViewDetails`._
- [x] **Impact of the changes:**
  - Mobile e2e send flow — verify send specs reliably reach the success / operation-details screen
  - No app or functional behaviour change; this only raises a test wait timeout (10s → 60s default)
  - Affects every send spec passing through `CommonPage.successViewDetails`

### 📝 Description

**Problem:** `CommonPage.successViewDetails()` waited at most **10s** for the `validate-success-screen` element. That cap was introduced in `test: enable synchro` (`c45d0a4`), which lowered it from the 60s default. The success screen only renders after the transaction is signed on-device and broadcast, which can exceed 10s under CI/network load — producing flaky `TOBEVISIBLE … TIMEOUT(10s)` failures (observed on `sendBASE` and `sendDOT`).

**Solution:** Drop the explicit `10000` argument so the wait falls back to `DEFAULT_TIMEOUT` (60s), consistent with every other wait in `common.page.ts`. Single-line change; because `successViewDetails` is shared via `verifySendAndOperationDetails`, this fixes all send specs at once.

```diff
-    await waitForElementById(this.validateSuccessScreenId, 10000);
+    await waitForElementById(this.validateSuccessScreenId);
```

### ❓ Context

- **JIRA or GitHub link**: N/A — test-flakiness fix, no dedicated ticket.
- **Mobile CI**: https://github.com/LedgerHQ/ledger-live/actions/runs/27540110231

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)