### PR TITLE
[LWDM] fix(desktop, mobile): use base color for unread operation dot indicator

### DIFF
--- a/.changeset/five-horses-taste.md
+++ b/.changeset/five-horses-taste.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Use base color instead of red for the unread operation dot indicator

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/HistoryButton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/HistoryButton.tsx
@@ -17,7 +17,7 @@ export function HistoryButton() {
   );
 
   return hasUnread ? (
-    <DotIndicator appearance="red" size="lg" data-testid="unread-indicator">
+    <DotIndicator appearance="base" size="lg" data-testid="unread-indicator">
       {button}
     </DotIndicator>
   ) : (

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationRow.tsx
@@ -64,7 +64,7 @@ function OperationRow({ row, onRowClick }: OperationRowProps) {
             <div className="inline-flex items-center gap-12">
               {typeLabel}
               {isUnread && (
-                <DotIndicator appearance="red" size="lg" data-testid="unread-indicator" />
+                <DotIndicator appearance="base" size="lg" data-testid="unread-indicator" />
               )}
             </div>
           }

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/TopBarView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/TopBarView/index.tsx
@@ -94,7 +94,7 @@ export function TopBarView({
     () =>
       hasUnreadOperations
         ? (children: React.ReactElement) => (
-            <DotIndicator appearance="red" size="xl" testID="unread-indicator">
+            <DotIndicator appearance="base" size="xl" testID="unread-indicator">
               {children}
             </DotIndicator>
           )

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/index.tsx
@@ -85,7 +85,7 @@ function OperationsListItem({
         <ListItemContent>
           <Box lx={titleRowStyle}>
             <ListItemTitle>{title}</ListItemTitle>
-            {isUnread && <DotIndicator appearance="red" testID="unread-indicator" />}
+            {isUnread && <DotIndicator appearance="base" testID="unread-indicator" />}
           </Box>
           <ListItemDescription>{subtitle}</ListItemDescription>
         </ListItemContent>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Pure visual/style change (DotIndicator color), not covered by automated tests._
- [x] **Impact of the changes:**
  - Unread indicator dot color on the desktop top bar history button and operation history rows
  - Unread indicator dot color on the mobile top bar and operations list items
  - Verify the dot now renders with the `base` appearance instead of `red` in both light and dark themes

### 📝 Description

The unread operation indicator dot was displayed using the `red` appearance, which read as an error/alert state rather than a neutral "unread" notification.

This PR switches the `DotIndicator` from `appearance="red"` to `appearance="base"` for all unread operation indicators across desktop and mobile:

- `apps/ledger-live-desktop` — `TopBar/components/HistoryButton.tsx`, `History/components/OperationRow.tsx`
- `apps/ledger-live-mobile` — `TopBar/TopBarView/index.tsx`, `OperationsHistory/.../OperationsListItem/index.tsx`

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31738](https://ledgerhq.atlassian.net/browse/LIVE-31738)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31738]: https://ledgerhq.atlassian.net/browse/LIVE-31738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ