### PR TITLE
[LWD] fix(desktop): prevent search overlay from closing on re-clicking the search bar

### DIFF
--- a/.changeset/live-32395-search-bar-reclick.md
+++ b/.changeset/live-32395-search-bar-reclick.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix: re-clicking the global search bar no longer closes the search overlay. Clicks inside the open search field are now prevented from toggling the Popover trigger, so the overlay stays open and the typed query is preserved.

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/__tests__/TopBarView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/__tests__/TopBarView.test.tsx
@@ -115,5 +115,28 @@ describe("TopBarView", () => {
       await user.type(input, "{Escape}");
       expect(input).toHaveValue("");
     });
+
+    it("should keep the popover open and preserve the query when the search input is re-clicked", async () => {
+      const { user } = render(
+        <TopBarView
+          {...defaultProps}
+          shouldShowFirmwareUpdateBanner={false}
+          shouldDisplayAssetDiscoverability
+        />,
+        { initialState: assetDiscoverabilityState, initialRoute: "/" },
+      );
+
+      const input = screen.getByRole("textbox");
+
+      await user.click(input);
+      expect(screen.getByTestId("topbar-search-popover")).toBeInTheDocument();
+
+      await user.type(input, "bitcoin");
+      expect(input).toHaveValue("bitcoin");
+
+      await user.click(input);
+      expect(screen.getByTestId("topbar-search-popover")).toBeInTheDocument();
+      expect(input).toHaveValue("bitcoin");
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchInputView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchInputView.tsx
@@ -13,26 +13,27 @@ type SearchInputViewProps = {
   placeholder: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
+  isOpen: boolean;
   testId?: string;
 } & Omit<ComponentPropsWithoutRef<"div">, "onChange" | "onKeyDown">;
 
-function stopClearButtonFromTogglingOverlay(e: SyntheticEvent) {
-  if (e.target instanceof Element && e.target.closest("button")) {
-    e.stopPropagation();
-  }
-}
-
 export const SearchInputView = forwardRef<HTMLDivElement, SearchInputViewProps>(
   function SearchInputView(
-    { value, placeholder, onChange, onKeyDown, testId, className, ...rest },
+    { value, placeholder, onChange, onKeyDown, isOpen, testId, className, ...rest },
     ref,
   ) {
+    // While the overlay is open, clicks inside the search field (the input itself or the clear
+    // button) must not bubble to the Popover trigger, which would otherwise toggle it closed and
+    // reset the query. The first click (overlay closed) still propagates so it can open the overlay.
+    const stopOverlayToggleWhenOpen = (e: SyntheticEvent) => {
+      if (isOpen) {
+        e.stopPropagation();
+      }
+    };
+
     return (
       <div ref={ref} className={cn("min-w-0 max-w-[450px] flex-auto mr-24", className)} {...rest}>
-        <div
-          onClick={stopClearButtonFromTogglingOverlay}
-          onPointerDown={stopClearButtonFromTogglingOverlay}
-        >
+        <div onClick={stopOverlayToggleWhenOpen} onPointerDown={stopOverlayToggleWhenOpen}>
           <SearchInput
             appearance="transparent"
             value={value}

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/SearchOverlayView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/SearchOverlayView.tsx
@@ -60,6 +60,7 @@ export function SearchOverlayView({
             placeholder={t("topBar.searchPlaceholder")}
             onChange={onChangeQuery}
             onKeyDown={onKeyDown}
+            isOpen={open}
             testId="topbar-search-input"
           />
         }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Global search bar in the desktop top bar
  - Opening / re-clicking the search input while the overlay is open
  - Preservation of the typed query when interacting with the input and clear button

### 📝 Description

**Problem**: When the global search overlay was open, re-clicking the search bar bubbled the click up to the Popover trigger, which toggled the overlay closed and reset the typed query.

**Solution**: The `SearchInputView` now receives an `isOpen` prop and, while the overlay is open, stops click / pointer-down events from propagating to the Popover trigger. The first click (overlay closed) still propagates so it can open the overlay. This replaces the previous logic that only stopped propagation for the clear button.

As a result, clicking inside the open search field (input or clear button) keeps the overlay open and preserves the current query.


https://github.com/user-attachments/assets/8b2d1710-40a6-494f-b39c-94841d4dfc37



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32395](https://ledgerhq.atlassian.net/browse/LIVE-32395)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32395]: https://ledgerhq.atlassian.net/browse/LIVE-32395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ