### PR TITLE
[LWD] fix(desktop): prevent default asset list flicker when clicking outside the search bar

### DIFF
--- a/.changeset/lld-search-default-list-flicker.md
+++ b/.changeset/lld-search-default-list-flicker.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix the global asset search default list flickering when clicking outside the search bar

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/__tests__/useSearchOverlayViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/__tests__/useSearchOverlayViewModel.test.ts
@@ -1,0 +1,79 @@
+import { renderHook } from "tests/testSetup";
+import { useSearchOverlayViewModel } from "../useSearchOverlayViewModel";
+import { useAssetSearchBar } from "../useAssetSearchBar";
+import { SearchMode, SearchResults, SearchSuggestions } from "../types";
+
+jest.mock("../useAssetSearchBar");
+
+const mockedUseAssetSearchBar = jest.mocked(useAssetSearchBar);
+
+const EMPTY_SECTION = { data: [], isLoading: false };
+const EMPTY_SUGGESTIONS: SearchSuggestions = {
+  cryptos: EMPTY_SECTION,
+  stocks: EMPTY_SECTION,
+};
+const EMPTY_RESULTS: SearchResults = { data: [], isLoading: false };
+
+function mockSearchBar({
+  mode,
+  isOpen,
+  query = "",
+}: {
+  mode: SearchMode;
+  isOpen: boolean;
+  query?: string;
+}) {
+  mockedUseAssetSearchBar.mockReturnValue({
+    query,
+    onChangeQuery: jest.fn(),
+    clear: jest.fn(),
+    isOpen,
+    open: jest.fn(),
+    close: jest.fn(),
+    mode,
+    suggestions: EMPTY_SUGGESTIONS,
+    results: EMPTY_RESULTS,
+  });
+}
+
+describe("useSearchOverlayViewModel", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe("displayed mode while closing", () => {
+    it("exposes the live mode while the overlay is open", () => {
+      mockSearchBar({ mode: "results", isOpen: true, query: "bit" });
+
+      const { result } = renderHook(() => useSearchOverlayViewModel());
+
+      expect(result.current.mode).toBe("results");
+      expect(result.current.contextValue.mode).toBe("results");
+    });
+
+    it("keeps the last open mode while closing so the default list never flashes", () => {
+      mockSearchBar({ mode: "results", isOpen: true, query: "bit" });
+      const { result, rerender } = renderHook(() => useSearchOverlayViewModel());
+      expect(result.current.mode).toBe("results");
+
+      // close() clears the query, so the underlying mode flips to "suggestions" while the popover
+      // is still animating closed. The view model must keep showing "results" (LIVE-32396).
+      mockSearchBar({ mode: "suggestions", isOpen: false, query: "" });
+      rerender();
+
+      expect(result.current.mode).toBe("results");
+      expect(result.current.contextValue.mode).toBe("results");
+    });
+
+    it("shows the suggestions again once the overlay reopens with an empty query", () => {
+      mockSearchBar({ mode: "results", isOpen: true, query: "bit" });
+      const { result, rerender } = renderHook(() => useSearchOverlayViewModel());
+
+      mockSearchBar({ mode: "suggestions", isOpen: false, query: "" });
+      rerender();
+      expect(result.current.mode).toBe("results");
+
+      mockSearchBar({ mode: "suggestions", isOpen: true, query: "" });
+      rerender();
+      expect(result.current.mode).toBe("suggestions");
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useSearchOverlayViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useSearchOverlayViewModel.ts
@@ -1,4 +1,4 @@
-import { KeyboardEvent, useCallback, useMemo } from "react";
+import { KeyboardEvent, useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
@@ -14,6 +14,13 @@ export function useSearchOverlayViewModel() {
   const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
   const { query, onChangeQuery, isOpen, open, close, mode, suggestions, results } =
     useAssetSearchBar();
+
+  // Keep the last mode while open so the popover fades out with its current content instead of
+  // flickering the default asset list when closing clears the query.
+  const [displayedMode, setDisplayedMode] = useState(mode);
+  if (isOpen && displayedMode !== mode) {
+    setDisplayedMode(mode);
+  }
 
   const navigateToAsset = useCallback(
     (currencyId: string) => {
@@ -65,10 +72,26 @@ export function useSearchOverlayViewModel() {
       navigateToStocksMarket,
       suggestions,
       results,
-      mode,
+      mode: displayedMode,
     }),
-    [close, navigateToAsset, navigateToMarket, navigateToStocksMarket, suggestions, results, mode],
+    [
+      close,
+      navigateToAsset,
+      navigateToMarket,
+      navigateToStocksMarket,
+      suggestions,
+      results,
+      displayedMode,
+    ],
   );
 
-  return { open: isOpen, onOpenChange, query, onChangeQuery, onKeyDown, mode, contextValue };
+  return {
+    open: isOpen,
+    onOpenChange,
+    query,
+    onChangeQuery,
+    onKeyDown,
+    mode: displayedMode,
+    contextValue,
+  };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Global asset search overlay (top bar): type a query, then click outside the search bar — the default asset list must no longer flash in/out during the popover close animation.
      - Reopening the search still shows the default suggestions (top cryptos + stocks).
      - Escape key and selecting a search result still close the overlay correctly.

### 📝 Description

**Problem**: On the global asset search, typing a query and then clicking outside the search bar caused the default asset list (top cryptos + stocks suggestions) to briefly appear and disappear during the popover's close animation.

**Root cause**: The Lumen `Popover` keeps its content mounted while it slides out (close animation). Closing the overlay also clears the query in the same callback, which flips the displayed `mode` from `"results"` to `"suggestions"` (empty query), so the default list (`SearchOverlayDefault`) is rendered for the duration of the close animation.

**Solution**: `useSearchOverlayViewModel` now freezes the displayed mode while the overlay is closing. It remembers the last `mode` seen while the overlay was open and keeps showing it during the close, so the popover fades out with its current content (the results) instead of flashing the default list. State is adjusted during render (not in a `useEffect`) to avoid painting a stale frame when the overlay reopens. `close()` is left unchanged (the input still clears and the search still stops).

### 🖼️ Screenshots

https://github.com/user-attachments/assets/7dd1aae5-84d1-4dca-96b9-adc96a456611

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32396](https://ledgerhq.atlassian.net/browse/LIVE-32396)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32396]: https://ledgerhq.atlassian.net/browse/LIVE-32396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ