### PR TITLE
[LWM] feat(mobile): refine market screen layout with sticky category tabs

### DIFF
--- a/.changeset/lwm-market-gauge-size.md
+++ b/.changeset/lwm-market-gauge-size.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Set the Market highlights gauges (Fear & Greed, Altcoin season) to a fixed 44x32 size and remove the unused per-appearance gauge sizing.

--- a/.changeset/lwm-market-gauge-size.md
+++ b/.changeset/lwm-market-gauge-size.md
@@ -1,5 +1,0 @@
----
-"live-mobile": patch
----
-
-Set the Market highlights gauges (Fear & Greed, Altcoin season) to a fixed 44x32 size and remove the unused per-appearance gauge sizing.

--- a/.changeset/lwm-market-screen-layout.md
+++ b/.changeset/lwm-market-screen-layout.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Refine the Market screen layout: the category tabs now stick to the top while scrolling the asset list, with consistent spacing under the search bar. Switching category keeps the tabs pinned and shows the new list from its first item when already scrolled (and no longer snaps back to the top for short result sets).

--- a/.changeset/lwm-market-screen-layout.md
+++ b/.changeset/lwm-market-screen-layout.md
@@ -2,4 +2,4 @@
 "live-mobile": patch
 ---
 
-Refine the Market screen layout: the category tabs now stick to the top while scrolling the asset list, with consistent spacing under the search bar. Switching category keeps the tabs pinned and shows the new list from its first item when already scrolled (and no longer snaps back to the top for short result sets).
+Refine the Market screen layout: the category tabs stick to the top while scrolling the asset list, with harmonised spacing and category-switch scroll behaviour (tabs stay pinned, the new list starts from its first item when already scrolled, and short result sets no longer snap to the top). Set the highlights gauges (Fear & Greed, Altcoin season) to a fixed 44x32. Change the Market search bar placeholder to "Search asset" (address search is no longer supported).

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8209,6 +8209,7 @@
   },
   "market": {
     "title": "Market",
+    "searchPlaceholder": "Search asset",
     "assets": {
       "title": "Assets",
       "emptyFavorites": "No favorites yet",

--- a/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/AltcoinSeasonArc.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AltcoinSeason/AltcoinSeasonArc.tsx
@@ -9,12 +9,5 @@ type Props = Readonly<{
 }>;
 
 export function AltcoinSeasonArc({ value }: Props) {
-  return (
-    <ArcGaugeIndicator
-      value={value}
-      appearance="expanded"
-      startColor={BITCOIN_COLOR}
-      endColor={ALTCOIN_COLOR}
-    />
-  );
+  return <ArcGaugeIndicator value={value} startColor={BITCOIN_COLOR} endColor={ALTCOIN_COLOR} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/ArcGaugeIndicator/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/ArcGaugeIndicator/index.tsx
@@ -27,30 +27,19 @@ const ARC_PATH =
 const ARC_START = { x: 6.75144, y: 57.6112 };
 const ARC_END = { x: 79.5754, y: 57.6082 };
 
-export type ArcGaugeAppearance = "compact" | "expanded";
-
-const SCALE_BY_APPEARANCE: Record<ArcGaugeAppearance, number> = {
-  compact: 0.5,
-  expanded: 0.65,
-};
+const SCALE = 0.5;
 
 type Props = Readonly<{
   value: number;
-  appearance?: ArcGaugeAppearance;
   startColor: string;
   endColor: string;
 }>;
 
-export default function ArcGaugeIndicator({
-  value,
-  appearance = "compact",
-  startColor,
-  endColor,
-}: Props) {
+export default function ArcGaugeIndicator({ value, startColor, endColor }: Props) {
   const { theme } = useTheme();
   // react-native-svg mis-resolves the ":" that useId emits inside url(#...) references.
   const gradientId = `arcGaugeGradient-${useId().replace(/:/g, "")}`;
-  const scale = SCALE_BY_APPEARANCE[appearance];
+  const scale = SCALE;
   const width = VIEWBOX_WIDTH * scale;
   const height = VIEWBOX_HEIGHT * scale;
   const cursorRadius = CURSOR_RADIUS * scale;

--- a/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/components/FearAndGreedArc/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/components/FearAndGreedArc/index.tsx
@@ -1,22 +1,13 @@
 import React from "react";
 import ArcGaugeIndicator from "LLM/components/ArcGaugeIndicator";
-import type { FearAndGreedAppearance } from "../../types";
 
 const FEAR_COLOR = "#F87274";
 const GREED_COLOR = "#6EC85C";
 
 type Props = Readonly<{
   value: number;
-  appearance?: FearAndGreedAppearance;
 }>;
 
-export default function FearAndGreedArc({ value, appearance = "compact" }: Props) {
-  return (
-    <ArcGaugeIndicator
-      value={value}
-      appearance={appearance}
-      startColor={FEAR_COLOR}
-      endColor={GREED_COLOR}
-    />
-  );
+export default function FearAndGreedArc({ value }: Props) {
+  return <ArcGaugeIndicator value={value} startColor={FEAR_COLOR} endColor={GREED_COLOR} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/components/FearAndGreedCard/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/components/FearAndGreedCard/index.tsx
@@ -24,7 +24,7 @@ function FearAndGreedCard({ data, onPress }: FearAndGreedCardProps) {
       testID="fear-and-greed-card"
     >
       <Box lx={{ height: "s40", justifyContent: "center", alignItems: "center" }}>
-        <FearAndGreedArc value={value} appearance="compact" />
+        <FearAndGreedArc value={value} />
       </Box>
       <TileContent>
         <TileTitle>{t("fearAndGreed.tileTitle")}</TileTitle>

--- a/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/components/FearAndGreedExpandedCard/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/components/FearAndGreedExpandedCard/index.tsx
@@ -35,7 +35,7 @@ function FearAndGreedExpandedCard({ data, width, onPress }: FearAndGreedExpanded
           </Text>
         </Box>
         <Box lx={{ flexShrink: 0 }}>
-          <FearAndGreedArc value={value} appearance="expanded" />
+          <FearAndGreedArc value={value} />
         </Box>
       </Box>
     </Pressable>

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
@@ -23,7 +23,7 @@ export function MarketScreenView({ search, highlights, assetsList, isSearchActiv
           value={search.value}
           onChangeText={search.onChangeText}
           onClear={search.onClear}
-          placeholder={t("modularDrawer.searchPlaceholder")}
+          placeholder={t("market.searchPlaceholder")}
           autoCorrect={false}
           autoCapitalize="none"
         />

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
@@ -61,4 +61,5 @@ const screenStyle: LumenViewStyle = {
 const searchBarStyle: LumenViewStyle = {
   marginTop: "s16",
   marginHorizontal: "s16",
+  marginBottom: "s12",
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/MarketAssetsEmptyState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/MarketAssetsEmptyState.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { Banner, Box, Spot, Text } from "@ledgerhq/lumen-ui-rnative";
+import { Search, StarFill } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { useTranslation } from "~/context/Locale";
+import { AssetLoadingState } from "LLM/components/AssetListItem";
+import { MARKET_SCREEN_TEST_IDS } from "../../testIds";
+
+const SKELETON_COUNT = 3;
+
+type Props = Readonly<{
+  loading: boolean;
+  error: boolean;
+  emptyState: "favorites" | "stocks" | undefined;
+  showEmptySearchState: boolean;
+}>;
+
+export function MarketAssetsEmptyState({
+  loading,
+  error,
+  emptyState,
+  showEmptySearchState,
+}: Props) {
+  const { t } = useTranslation();
+
+  if (loading) {
+    return (
+      <AssetLoadingState
+        count={SKELETON_COUNT}
+        lx={skeletonStyle}
+        skeletonTestID={MARKET_SCREEN_TEST_IDS.assetsSkeleton}
+      />
+    );
+  }
+
+  if (error) {
+    return (
+      <Banner
+        appearance="error"
+        title={t("market.assets.error.title")}
+        description={t("market.assets.error.description")}
+        testID={MARKET_SCREEN_TEST_IDS.assetsError}
+      />
+    );
+  }
+
+  if (emptyState === "favorites") {
+    return (
+      <Box lx={emptyStateStyle} style={emptyStateSize}>
+        <Spot
+          appearance="icon"
+          icon={StarFill}
+          size={72}
+          testID={MARKET_SCREEN_TEST_IDS.assetsFavoritesEmptyIcon}
+        />
+        <Text typography="heading5SemiBold" lx={{ color: "base", textAlign: "center" }}>
+          {t("market.assets.emptyFavorites")}
+        </Text>
+      </Box>
+    );
+  }
+
+  if (emptyState === "stocks") {
+    return (
+      <Box
+        lx={emptyStateStyle}
+        style={emptyStateSize}
+        testID={MARKET_SCREEN_TEST_IDS.assetsStocksEmpty}
+      >
+        <Spot appearance="icon" icon={Search} size={72} />
+        <Text typography="heading5SemiBold" lx={{ color: "base", textAlign: "center" }}>
+          {t("market.assets.emptyStocks")}
+        </Text>
+      </Box>
+    );
+  }
+
+  if (showEmptySearchState) {
+    return (
+      <Box
+        lx={emptyStateStyle}
+        style={emptyStateSize}
+        testID={MARKET_SCREEN_TEST_IDS.assetsEmptySearch}
+      >
+        <Spot appearance="icon" icon={Search} size={72} />
+        <Text typography="heading4SemiBold" lx={{ textAlign: "center", color: "base" }}>
+          {t("modularDrawer.emptyAssetList")}
+        </Text>
+      </Box>
+    );
+  }
+
+  return null;
+}
+
+const skeletonStyle: LumenViewStyle = {
+  marginHorizontal: "-s8",
+  paddingHorizontal: "s8",
+};
+
+const emptyStateStyle: LumenViewStyle = {
+  flex: 1,
+  alignItems: "center",
+  justifyContent: "center",
+  gap: "s24",
+};
+
+const emptyStateSize = { minHeight: 328 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/MarketAssetsListHeader.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/MarketAssetsListHeader.tsx
@@ -1,0 +1,63 @@
+import React, { type ReactNode } from "react";
+import type { LayoutChangeEvent } from "react-native";
+import {
+  Box,
+  IconButton,
+  Subheader,
+  SubheaderRow,
+  SubheaderTitle,
+} from "@ledgerhq/lumen-ui-rnative";
+import { SettingsAlt2 } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { useTranslation } from "~/context/Locale";
+import { MARKET_SCREEN_TEST_IDS } from "../../testIds";
+
+type Props = Readonly<{
+  header?: ReactNode;
+  showSubheader: boolean;
+  onOpenFilters: () => void;
+  onLayout: (event: LayoutChangeEvent) => void;
+}>;
+
+export function MarketAssetsListHeader({ header, showSubheader, onOpenFilters, onLayout }: Props) {
+  const { t } = useTranslation();
+
+  if (!header && !showSubheader) return null;
+
+  return (
+    <Box lx={headerStyle} onLayout={onLayout}>
+      {header}
+      {showSubheader ? (
+        <Subheader lx={subHeaderStyle} testID={MARKET_SCREEN_TEST_IDS.assetsSubHeader}>
+          <SubheaderRow lx={subHeaderRowStyle}>
+            <SubheaderTitle>{t("market.assets.title")}</SubheaderTitle>
+            <IconButton
+              accessibilityLabel={t("market.assets.filters.accessibilityLabel")}
+              appearance="no-background"
+              icon={SettingsAlt2}
+              onPress={onOpenFilters}
+              size="sm"
+              testID={MARKET_SCREEN_TEST_IDS.assetsFilterButton}
+            />
+          </SubheaderRow>
+        </Subheader>
+      ) : null}
+    </Box>
+  );
+}
+
+const headerStyle: LumenViewStyle = {
+  marginHorizontal: "-s16",
+  paddingTop: "s6",
+  paddingBottom: "s12",
+  gap: "s24",
+};
+
+const subHeaderStyle: LumenViewStyle = {
+  paddingHorizontal: "s16",
+};
+
+const subHeaderRowStyle: LumenViewStyle = {
+  alignItems: "center",
+  justifyContent: "space-between",
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/MarketCategorySwitcher.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/MarketCategorySwitcher.tsx
@@ -1,0 +1,62 @@
+import React, { useCallback } from "react";
+import { ScrollView, type ViewStyle } from "react-native";
+import { SegmentedControl, SegmentedControlButton } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "~/context/Locale";
+import type { MarketListCategory } from "~/reducers/types";
+import { MARKET_SCREEN_TEST_IDS } from "../../testIds";
+import type { MarketCategoryTab } from "../../useMarketCategories";
+
+const HORIZONTAL_PADDING = 16;
+const BOTTOM_SPACING = 12;
+
+type Props = Readonly<{
+  selectedCategory: MarketListCategory;
+  tabs: MarketCategoryTab[];
+  onSelectCategory: (category: MarketListCategory) => void;
+}>;
+
+export function MarketCategorySwitcher({ selectedCategory, tabs, onSelectCategory }: Props) {
+  const { t } = useTranslation();
+
+  const onSelectedChange = useCallback(
+    (value: string) => {
+      onSelectCategory(value);
+    },
+    [onSelectCategory],
+  );
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      style={scrollStyle}
+      contentContainerStyle={contentStyle}
+    >
+      <SegmentedControl
+        selectedValue={selectedCategory}
+        onSelectedChange={onSelectedChange}
+        accessibilityLabel={t("market.assets.categories.accessibilityLabel")}
+        testID={MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher}
+        tabLayout="fit"
+      >
+        {tabs.map(tab => (
+          <SegmentedControlButton
+            key={tab.value}
+            value={tab.value}
+            testID={`${MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher}-${tab.value}`}
+          >
+            {tab.label ?? (tab.labelKey ? t(tab.labelKey) : tab.value)}
+          </SegmentedControlButton>
+        ))}
+      </SegmentedControl>
+    </ScrollView>
+  );
+}
+
+const scrollStyle: ViewStyle = {
+  marginBottom: BOTTOM_SPACING,
+};
+
+const contentStyle: ViewStyle = {
+  paddingHorizontal: HORIZONTAL_PADDING,
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/index.tsx
@@ -1,167 +1,21 @@
-import React, { useCallback, type ReactNode } from "react";
-import { FlatList, ListRenderItemInfo, ScrollView, type ViewStyle } from "react-native";
+import React, { useCallback, useMemo, type ReactNode } from "react";
+import { SectionList, type SectionListRenderItemInfo } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import {
-  Banner,
-  Box,
-  IconButton,
-  SegmentedControl,
-  SegmentedControlButton,
-  Spot,
-  Subheader,
-  SubheaderRow,
-  SubheaderTitle,
-  Text,
-} from "@ledgerhq/lumen-ui-rnative";
-import { Search, SettingsAlt2, StarFill } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
-import { useTranslation } from "~/context/Locale";
 import type { MarketListCategory } from "~/reducers/types";
-import AssetListItem, {
-  AssetLoadingState,
-  type MarketAssetDisplayData,
-} from "LLM/components/AssetListItem";
+import AssetListItem, { type MarketAssetDisplayData } from "LLM/components/AssetListItem";
 import { BottomFadeGradient, GRADIENT_HEIGHT } from "LLM/components/BottomFadeGradient";
 import { MARKET_SCREEN_TEST_IDS } from "../../testIds";
 import type { MarketCategoryTab } from "../../useMarketCategories";
 import type { MarketFilters } from "../../useMarketFilters";
 import { MarketFiltersDrawer } from "../MarketFiltersDrawer";
+import { MarketAssetsEmptyState } from "./MarketAssetsEmptyState";
+import { MarketAssetsListHeader } from "./MarketAssetsListHeader";
+import { MarketCategorySwitcher } from "./MarketCategorySwitcher";
+import { useMarketAssetsList } from "./useMarketAssetsList";
 
 const HORIZONTAL_PADDING = 16;
-const TOP_PADDING = 24;
-const SKELETON_COUNT = 3;
-const CATEGORY_SWITCHER_BOTTOM_SPACING = 12;
-
-function MarketAssetsEmptyState({
-  loading,
-  error,
-  emptyState,
-  showEmptySearchState,
-}: Readonly<{
-  loading: boolean;
-  error: boolean;
-  emptyState: "favorites" | "stocks" | undefined;
-  showEmptySearchState: boolean;
-}>) {
-  const { t } = useTranslation();
-
-  if (loading) {
-    return (
-      <AssetLoadingState
-        count={SKELETON_COUNT}
-        lx={skeletonStyle}
-        skeletonTestID={MARKET_SCREEN_TEST_IDS.assetsSkeleton}
-      />
-    );
-  }
-
-  if (error) {
-    return (
-      <Banner
-        appearance="error"
-        title={t("market.assets.error.title")}
-        description={t("market.assets.error.description")}
-        testID={MARKET_SCREEN_TEST_IDS.assetsError}
-      />
-    );
-  }
-
-  if (emptyState === "favorites") {
-    return (
-      <Box lx={emptyStateStyle} style={emptyStateSize}>
-        <Spot
-          appearance="icon"
-          icon={StarFill}
-          size={72}
-          testID={MARKET_SCREEN_TEST_IDS.assetsFavoritesEmptyIcon}
-        />
-        <Text typography="heading5SemiBold" lx={{ color: "base", textAlign: "center" }}>
-          {t("market.assets.emptyFavorites")}
-        </Text>
-      </Box>
-    );
-  }
-
-  if (emptyState === "stocks") {
-    return (
-      <Box
-        lx={emptyStateStyle}
-        style={emptyStateSize}
-        testID={MARKET_SCREEN_TEST_IDS.assetsStocksEmpty}
-      >
-        <Spot appearance="icon" icon={Search} size={72} />
-        <Text typography="heading5SemiBold" lx={{ color: "base", textAlign: "center" }}>
-          {t("market.assets.emptyStocks")}
-        </Text>
-      </Box>
-    );
-  }
-
-  if (showEmptySearchState) {
-    return (
-      <Box
-        lx={emptyStateStyle}
-        style={emptyStateSize}
-        testID={MARKET_SCREEN_TEST_IDS.assetsEmptySearch}
-      >
-        <Spot appearance="icon" icon={Search} size={72} />
-        <Text typography="heading4SemiBold" lx={{ textAlign: "center", color: "base" }}>
-          {t("modularDrawer.emptyAssetList")}
-        </Text>
-      </Box>
-    );
-  }
-
-  return null;
-}
-
-type MarketCategorySwitcherProps = Readonly<{
-  selectedCategory: MarketListCategory;
-  tabs: MarketCategoryTab[];
-  onSelectCategory: (category: MarketListCategory) => void;
-}>;
-
-function MarketCategorySwitcher({
-  selectedCategory,
-  tabs,
-  onSelectCategory,
-}: MarketCategorySwitcherProps) {
-  const { t } = useTranslation();
-
-  const onSelectedChange = useCallback(
-    (value: string) => {
-      onSelectCategory(value as MarketListCategory);
-    },
-    [onSelectCategory],
-  );
-
-  return (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      style={categorySwitcherScrollStyle}
-      contentContainerStyle={categorySwitcherContentStyle}
-    >
-      <SegmentedControl
-        selectedValue={selectedCategory}
-        onSelectedChange={onSelectedChange}
-        accessibilityLabel={t("market.assets.categories.accessibilityLabel")}
-        testID={MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher}
-        tabLayout="fit"
-      >
-        {tabs.map(tab => (
-          <SegmentedControlButton
-            key={tab.value}
-            value={tab.value}
-            testID={`${MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher}-${tab.value}`}
-          >
-            {tab.label ?? (tab.labelKey ? t(tab.labelKey) : tab.value)}
-          </SegmentedControlButton>
-        ))}
-      </SegmentedControl>
-    </ScrollView>
-  );
-}
 
 type Props = Readonly<{
   assets: MarketAssetDisplayData[];
@@ -193,72 +47,88 @@ export function MarketAssetsList({
   header,
 }: Props) {
   const { bottom } = useSafeAreaInsets();
-  const { t } = useTranslation();
+  const {
+    listRef,
+    sections,
+    contentMinHeight,
+    footerMinHeight,
+    handleScrollEnd,
+    handleListLayout,
+    handleHeaderLayout,
+    keyExtractor,
+  } = useMarketAssetsList({ assets, selectedCategory, showSubheader });
+
+  const contentContainerStyle = useMemo(
+    () => ({
+      flexGrow: assets.length === 0 ? 1 : undefined,
+      minHeight: contentMinHeight,
+      paddingHorizontal: HORIZONTAL_PADDING,
+      paddingBottom: GRADIENT_HEIGHT + bottom,
+    }),
+    [assets.length, contentMinHeight, bottom],
+  );
 
   const renderRow = useCallback(
-    ({ item }: ListRenderItemInfo<MarketAssetDisplayData>) => (
+    ({ item }: SectionListRenderItemInfo<MarketAssetDisplayData>) => (
       <AssetListItem variant="market" market={item} onPress={onAssetPress} lx={rowStyle} />
     ),
     [onAssetPress],
   );
 
-  const listHeader =
-    header || showSubheader ? (
-      <Box lx={headerStyle}>
-        {header ? <Box lx={highlightsStyle}>{header}</Box> : null}
-        {showSubheader ? (
-          <Box lx={subHeaderGroupStyle}>
-            <Subheader lx={subHeaderStyle} testID={MARKET_SCREEN_TEST_IDS.assetsSubHeader}>
-              <SubheaderRow lx={subHeaderRowStyle}>
-                <SubheaderTitle>{t("market.assets.title")}</SubheaderTitle>
-                <IconButton
-                  accessibilityLabel={t("market.assets.filters.accessibilityLabel")}
-                  appearance="no-background"
-                  icon={SettingsAlt2}
-                  onPress={filters.onOpen}
-                  size="sm"
-                  testID={MARKET_SCREEN_TEST_IDS.assetsFilterButton}
-                />
-              </SubheaderRow>
-            </Subheader>
-            <MarketCategorySwitcher
-              selectedCategory={selectedCategory}
-              tabs={categoryTabs}
-              onSelectCategory={onSelectCategory}
-            />
-          </Box>
-        ) : null}
+  const renderCategorySwitcher = useCallback(
+    () => (
+      <Box lx={stickyCategorySwitcherStyle}>
+        <MarketCategorySwitcher
+          selectedCategory={selectedCategory}
+          tabs={categoryTabs}
+          onSelectCategory={onSelectCategory}
+        />
+      </Box>
+    ),
+    [selectedCategory, categoryTabs, onSelectCategory],
+  );
+
+  const listFooter =
+    assets.length === 0 ? (
+      <Box style={{ minHeight: footerMinHeight }}>
+        <MarketAssetsEmptyState
+          loading={loading}
+          error={error}
+          emptyState={emptyState}
+          showEmptySearchState={!showSubheader}
+        />
       </Box>
     ) : null;
 
   return (
     <>
-      <FlatList
+      <SectionList
+        ref={listRef}
         testID={MARKET_SCREEN_TEST_IDS.list}
-        data={assets}
-        keyExtractor={item => item.id}
+        sections={sections}
+        onScrollEndDrag={handleScrollEnd}
+        onMomentumScrollEnd={handleScrollEnd}
+        onLayout={handleListLayout}
+        keyExtractor={keyExtractor}
         renderItem={renderRow}
-        ListHeaderComponent={listHeader}
-        ListEmptyComponent={
-          <MarketAssetsEmptyState
-            loading={loading}
-            error={error}
-            emptyState={emptyState}
-            showEmptySearchState={!showSubheader}
+        renderSectionHeader={showSubheader ? renderCategorySwitcher : undefined}
+        stickySectionHeadersEnabled
+        ListHeaderComponent={
+          <MarketAssetsListHeader
+            header={header}
+            showSubheader={showSubheader}
+            onOpenFilters={filters.onOpen}
+            onLayout={handleHeaderLayout}
           />
         }
+        ListFooterComponent={listFooter}
         onEndReached={onEndReached}
         onEndReachedThreshold={0.5}
         showsVerticalScrollIndicator={false}
         keyboardDismissMode="on-drag"
         keyboardShouldPersistTaps="handled"
         overScrollMode="never"
-        contentContainerStyle={{
-          flexGrow: assets.length === 0 ? 1 : undefined,
-          paddingTop: listHeader ? 0 : TOP_PADDING,
-          paddingHorizontal: HORIZONTAL_PADDING,
-          paddingBottom: GRADIENT_HEIGHT + bottom,
-        }}
+        contentContainerStyle={contentContainerStyle}
       />
       {assets.length > 0 && <BottomFadeGradient />}
       <MarketFiltersDrawer filters={filters} />
@@ -266,50 +136,11 @@ export function MarketAssetsList({
   );
 }
 
-const headerStyle: LumenViewStyle = {
+const stickyCategorySwitcherStyle: LumenViewStyle = {
   marginHorizontal: "-s16",
-};
-
-const highlightsStyle: LumenViewStyle = {
-  marginTop: "s16",
-  marginBottom: "s16",
-};
-
-const subHeaderGroupStyle: LumenViewStyle = {
-  gap: "s12",
-};
-
-const subHeaderStyle: LumenViewStyle = {
-  paddingHorizontal: "s16",
-};
-
-const subHeaderRowStyle: LumenViewStyle = {
-  alignItems: "center",
-  justifyContent: "space-between",
-};
-
-const categorySwitcherScrollStyle: ViewStyle = {
-  marginBottom: CATEGORY_SWITCHER_BOTTOM_SPACING,
-};
-
-const categorySwitcherContentStyle: ViewStyle = {
-  paddingHorizontal: HORIZONTAL_PADDING,
+  backgroundColor: "canvas",
 };
 
 const rowStyle: LumenViewStyle = {
   marginHorizontal: "-s8",
 };
-
-const skeletonStyle: LumenViewStyle = {
-  marginHorizontal: "-s8",
-  paddingHorizontal: "s8",
-};
-
-const emptyStateStyle: LumenViewStyle = {
-  flex: 1,
-  alignItems: "center",
-  justifyContent: "center",
-  gap: "s24",
-};
-
-const emptyStateSize = { minHeight: 328 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/useMarketAssetsList.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/useMarketAssetsList.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  LayoutChangeEvent,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  SectionList,
+} from "react-native";
+import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
+import type { MarketListCategory } from "~/reducers/types";
+
+type UseMarketAssetsListParams = Readonly<{
+  assets: MarketAssetDisplayData[];
+  selectedCategory: MarketListCategory;
+  showSubheader: boolean;
+}>;
+
+export function useMarketAssetsList({
+  assets,
+  selectedCategory,
+  showSubheader,
+}: UseMarketAssetsListParams) {
+  const [listHeight, setListHeight] = useState(0);
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const listRef = useRef<SectionList<MarketAssetDisplayData>>(null);
+  const scrollOffsetRef = useRef(0);
+  const previousCategoryRef = useRef(selectedCategory);
+
+  const handleScrollEnd = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    scrollOffsetRef.current = event.nativeEvent.contentOffset.y;
+  }, []);
+
+  const handleListLayout = useCallback((event: LayoutChangeEvent) => {
+    setListHeight(event.nativeEvent.layout.height);
+  }, []);
+
+  const handleHeaderLayout = useCallback((event: LayoutChangeEvent) => {
+    setHeaderHeight(event.nativeEvent.layout.height);
+  }, []);
+
+  const keyExtractor = useCallback((item: MarketAssetDisplayData) => item.id, []);
+
+  const sections = useMemo(() => [{ data: assets }], [assets]);
+
+  useEffect(() => {
+    if (previousCategoryRef.current === selectedCategory) return;
+    previousCategoryRef.current = selectedCategory;
+    if (!showSubheader || headerHeight === 0) return;
+    if (scrollOffsetRef.current <= headerHeight) return;
+    listRef.current?.getScrollResponder()?.scrollTo({ y: headerHeight, animated: false });
+    scrollOffsetRef.current = headerHeight;
+  }, [headerHeight, selectedCategory, showSubheader]);
+
+  return {
+    listRef,
+    sections,
+    contentMinHeight: showSubheader ? headerHeight + listHeight : undefined,
+    footerMinHeight: listHeight,
+    handleScrollEnd,
+    handleListLayout,
+    handleHeaderLayout,
+    keyExtractor,
+  };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _The Market test suite covers the list structure — sticky header, subheader, category switching, and the loading/error/empty states. The new scroll behaviour (on-layout min-height reserve and the scroll-to-tabs on category change) relies on native layout/scroll events that don't fire in the jest renderer, so it's verified manually on device._
- [x] **Impact of the changes:**
      - Market screen scrolling: the category tabs stick to the top (under the search bar) once the highlights scroll away.
      - Spacing under the search bar, above the highlights, and around the "Assets" subheader.
      - Switching category while scrolled vs. at the top (tabs stay pinned and the new list starts from its first item; highlights stay visible when at the top).
      - Categories with few assets (favorites / filtered) must not snap back to the top.
      - Loading / error / favorites / stocks / empty-search states still render correctly.
      - Market highlights gauges (Fear & Greed, Altcoin season) sizing — now a fixed 44×32.
      - Market search bar placeholder copy.

### 📝 Description

This PR refines the Market screen list layout.

**Problem**: the category tabs scrolled away with the rest of the header, so users lost the ability to switch category while browsing the list, and the spacing around the search bar / highlights / subheader was inconsistent.

**Solution**: the asset list is now a sticky-header `SectionList` — the highlights and the "Assets" subheader scroll away while the category tabs pin to the top under the (fixed) search bar. Spacing was harmonised (consistent gap under the search bar, above the highlights, and around the subheader). Switching category keeps the tabs pinned and shows the new list from its first item when you're already scrolled (while leaving you at the top, highlights visible, when you haven't scrolled), and short result sets no longer snap the list back to the top. The component was also split into dedicated subcomponents (empty state, category switcher, list header) and a `useMarketAssetsList` hook for the list logic. The highlights gauges (Fear & Greed, Altcoin season) are also set to a fixed 44×32.

**Remove "by address" from the search bar ([LIVE-32253](https://ledgerhq.atlassian.net/browse/LIVE-32253))**: address search is no longer supported, so the Market search bar placeholder now reads **"Search asset"** (new `market.searchPlaceholder` key; the shared `modularDrawer` placeholder is left untouched).



https://github.com/user-attachments/assets/7809e7bc-045d-4f27-8cdb-536ad382c330




### ❓ Context

- **JIRA or GitHub link**: [LIVE-31985](https://ledgerhq.atlassian.net/browse/LIVE-31985) · [LIVE-32253](https://ledgerhq.atlassian.net/browse/LIVE-32253)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32253]: https://ledgerhq.atlassian.net/browse/LIVE-32253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ