### PR TITLE
[LWDM] feat(market): use dedicated CVS tokenized-stock category for stocks

### DIFF
--- a/.changeset/stocks-cvs-category.md
+++ b/.changeset/stocks-cvs-category.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Use the dedicated CVS `tokenized-stock` category for the Market stocks filter instead of the hardcoded `filter=stock` + client-side id matching, and stop firing a spurious `to=usd` market request while the supported counter-values list is still loading.

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
@@ -24,9 +24,7 @@ import { addStarredMarketCoins, removeStarredMarketCoins } from "~/renderer/acti
 import { useMarketCategories } from "LLD/features/Market/hooks/useMarketCategories";
 import {
   getMarketCategoriesParam,
-  getMarketFilter,
   isBuiltInMarketListCategory,
-  isStockMarketCurrency,
 } from "@ledgerhq/live-common/market/utils/category";
 
 export function useMarket() {
@@ -68,10 +66,13 @@ export function useMarket() {
 
   const shouldDisplayLiveCompatible = filterBySupported || marketParams.liveCompatible;
 
+  // While the supported list is still loading we keep the user's counter value, and only fall
+  // back to usd once we know it is unsupported — otherwise a request fires with usd first.
+  const isCounterValueUnsupported =
+    !!supportedCounterCurrencies && !supportedCounterCurrencies.includes(settingsCounterValue);
+  const discoverabilityCounterCurrency = isCounterValueUnsupported ? "usd" : settingsCounterValue;
   const effectiveCounterCurrency = shouldDisplayAssetDiscoverability
-    ? supportedCounterCurrencies?.includes(settingsCounterValue)
-      ? settingsCounterValue
-      : "usd"
+    ? discoverabilityCounterCurrency
     : marketParams.counterCurrency;
 
   const resolvedMarketParams = { ...marketParams, counterCurrency: effectiveCounterCurrency };
@@ -80,8 +81,8 @@ export function useMarket() {
     ...resolvedMarketParams,
     starred: starFilterOn ? starredMarketCoins : starred,
     liveCompatible: shouldDisplayLiveCompatible,
-    filter: getMarketFilter(isStocksCategory) ?? marketParams.filter,
-    categories: isTrendingCategory
+    filter: marketParams.filter,
+    categories: shouldDisplayAssetDiscoverability
       ? getMarketCategoriesParam(categories.selectedCategory)
       : undefined,
   });
@@ -112,12 +113,7 @@ export function useMarket() {
   const isFavoritesEmpty = isStarredCategory && starredMarketCoins.length === 0;
   const emptyState = isFavoritesEmpty ? ("favorites" as const) : undefined;
 
-  // The backend `stock` filter is not yet exhaustive, so narrow the list client-side.
-  const marketData = isFavoritesEmpty
-    ? []
-    : isStocksCategory
-      ? marketResult.data.filter(isStockMarketCurrency)
-      : marketResult.data;
+  const marketData = isFavoritesEmpty ? [] : marketResult.data;
 
   const currenciesLength = marketData.length;
   const loading = !isFavoritesEmpty && marketResult.isLoading;

--- a/apps/ledger-live-mobile/__tests__/handlers/market.ts
+++ b/apps/ledger-live-mobile/__tests__/handlers/market.ts
@@ -48,7 +48,7 @@ const handlers = [
 
     let filteredData = marketsMock;
 
-    if (searchParams.get("filter") === "stock") {
+    if (searchParams.get("categories") === "tokenized-stock") {
       filteredData = stockMarketsMock;
     }
     // When we perform a search

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/assetsList.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/assetsList.integration.test.tsx
@@ -52,8 +52,8 @@ function hasTestID(node: React.ReactNode, testID: string): boolean {
 }
 
 function installCapturedMarketHandlers(marketRequests: string[], dadaRequests: string[]) {
+  // The dedicated CVS `tokenized-stock` category is authoritative, so it returns only stocks.
   const stockMarketsMock: typeof marketsMock = [
-    marketsMock[0],
     {
       ...marketsMock[0],
       id: "tesla-xstock",
@@ -63,15 +63,6 @@ function installCapturedMarketHandlers(marketRequests: string[], dadaRequests: s
       marketCapRank: 528,
       price: 411.28,
     },
-    {
-      ...marketsMock[0],
-      id: "rif-token",
-      ledgerIds: ["rsk/erc20/rif"],
-      ticker: "rif",
-      name: "Rootstock Infrastructure Framework",
-      marketCapRank: 412,
-      price: 0.07,
-    },
   ];
 
   server.use(
@@ -79,10 +70,11 @@ function installCapturedMarketHandlers(marketRequests: string[], dadaRequests: s
       marketRequests.push(request.url);
       const searchParams = new URL(request.url).searchParams;
       const filter = searchParams.get("filter")?.toLowerCase();
+      const categories = searchParams.get("categories");
       const ids = searchParams.get("ids")?.split(",") ?? [];
 
       let filteredData = marketsMock;
-      if (filter === "stock") {
+      if (categories === "tokenized-stock") {
         filteredData = stockMarketsMock;
       } else if (filter) {
         filteredData = marketsMock.filter(
@@ -248,7 +240,7 @@ describe("MarketScreen assets list (Block 3)", () => {
     );
 
     const stockMarketRequest = marketRequests.find(
-      url => new URL(url).searchParams.get("filter") === "stock",
+      url => new URL(url).searchParams.get("categories") === "tokenized-stock",
     );
     const dadaStocksRequests = dadaRequests.filter(
       url => new URL(url).searchParams.get("categories") === "stocks",

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketAssets.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketAssets.test.ts
@@ -22,43 +22,10 @@ const teslaStock = createMarketCurrencyData({
   id: "tesla-xstock",
   name: "Tesla xStock",
   ticker: "tslax",
-  ledgerIds: [
-    "ethereum/erc20/tesla_xstock_0x8ad3c73f833d3f9a523ab01476625f269aeb7cf0",
-  ],
+  ledgerIds: ["ethereum/erc20/tesla_xstock_0x8ad3c73f833d3f9a523ab01476625f269aeb7cf0"],
   marketcapRank: 528,
   price: 411.28,
 });
-const nvidiaStock = createMarketCurrencyData({
-  id: "nvidia-ondo-tokenized-stock",
-  name: "NVIDIA (Ondo Tokenized Stock)",
-  ticker: "nvdaon",
-  ledgerIds: [
-    "ethereum/erc20/nvidia_ondo_tokenized_0x2d1f7226bd1f780af6b9a49dcc0ae00e8df4bdee",
-  ],
-  marketcapRank: 533,
-  price: 213.27,
-});
-const carvanaStock = createMarketCurrencyData({
-  id: "carvana-ondo-tokenized-stocks",
-  name: "Carvana (Ondo Tokenized Stock)",
-  ticker: "cvnaon",
-  ledgerIds: [
-    "ethereum/erc20/carvana_ondo_tokenized_0xfe4ec50e0413148021d2f50d114cc44de6ffbf23",
-  ],
-  marketcapRank: 12086,
-  price: 338.51,
-});
-const rootstockFalsePositive = createMarketCurrencyData({
-  id: "rif-token",
-  name: "Rootstock Infrastructure Framework",
-  ticker: "rif",
-  ledgerIds: ["rsk/erc20/rif"],
-  marketcapRank: 412,
-});
-const fullStockMarketPage = Array.from({ length: 20 }, (_, index) =>
-  createMarketCurrencyData({ id: `company-${index}-xstock`, name: `Company ${index} xStock` }),
-);
-
 function mockMarketData(overrides: Partial<MarketListRequestResult> = {}) {
   mockedUseMarketData.mockReturnValue({
     data: [bitcoin, ethereum],
@@ -222,20 +189,20 @@ describe("useMarketAssets", () => {
     expect(result.current.emptyState).toBeUndefined();
   });
 
-  it("searches all market assets without the stock filter while search is active", () => {
+  it("drops the stock category param while search is active", () => {
     renderHook(() => useMarketAssets({ search: " aapl ", category: "stocks" }));
 
     expect(mockedUseMarketData).toHaveBeenLastCalledWith(
-      expect.objectContaining({ page: 1, search: "aapl", filter: undefined }),
+      expect.objectContaining({ page: 1, search: "aapl", categories: undefined }),
     );
   });
 
-  it("requests stocks from the CVS stock filter", () => {
+  it("requests stocks from the dedicated CVS category", () => {
     mockMarketData({ data: [teslaStock] });
     const { result } = renderHook(() => useMarketAssets({ category: "stocks" }));
 
     expect(mockedUseMarketData).toHaveBeenLastCalledWith(
-      expect.objectContaining({ filter: "stock", page: 1 }),
+      expect.objectContaining({ categories: "tokenized-stock", page: 1 }),
     );
     expect(result.current.assets).toHaveLength(1);
     expect(result.current.assets[0]).toMatchObject({
@@ -245,36 +212,8 @@ describe("useMarketAssets", () => {
     });
   });
 
-  it("filters non-stock CVS rows from the stocks category", () => {
-    mockMarketData({
-      data: [bitcoin, rootstockFalsePositive, teslaStock, nvidiaStock, carvanaStock, ethereum],
-    });
-
-    const { result } = renderHook(() => useMarketAssets({ category: "stocks" }));
-
-    expect(result.current.assets.map(asset => asset.id)).toEqual([
-      "tesla-xstock",
-      "nvidia-ondo-tokenized-stock",
-      "carvana-ondo-tokenized-stocks",
-    ]);
-    expect(result.current.assets.find(asset => asset.id === "bitcoin")).toBeUndefined();
-    expect(result.current.assets.find(asset => asset.id === "rif-token")).toBeUndefined();
-  });
-
-  it("loads the next CVS page when reaching the end of the stocks list", () => {
-    mockMarketData({ data: fullStockMarketPage });
-
-    const { result } = renderHook(() => useMarketAssets({ category: "stocks" }));
-
-    act(() => result.current.onEndReached());
-
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(
-      expect.objectContaining({ filter: "stock", page: 2 }),
-    );
-  });
-
   it("shows the stocks empty state when CVS returns no stock rows", () => {
-    mockMarketData({ data: [bitcoin, ethereum, rootstockFalsePositive] });
+    mockMarketData({ data: [] });
 
     const { result } = renderHook(() => useMarketAssets({ category: "stocks" }));
 
@@ -295,15 +234,5 @@ describe("useMarketAssets", () => {
       ticker: "tslax",
       ledgerIds: [],
     });
-  });
-
-  it("maps the selected sorting and timeframe to the CVS request params for stocks", () => {
-    mockMarketData({ data: [teslaStock] });
-
-    renderHook(() => useMarketAssets({ category: "stocks", sorting: "gainers", timeframe: "7D" }));
-
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(
-      expect.objectContaining({ filter: "stock", order: Order.topGainers, range: "7d" }),
-    );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/marketAssetsHelpers.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/marketAssetsHelpers.ts
@@ -1,5 +1,4 @@
 import type { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
-import { isStockMarketCurrency } from "@ledgerhq/live-common/market/utils/category";
 import type { Unit } from "@ledgerhq/types-cryptoassets";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
 import { mapMarketCurrencyToDisplayData } from "../../utils/marketAssetDisplay";
@@ -20,7 +19,6 @@ export function getMarketDataForDisplay(
 
 export function getMarketAssets({
   marketData,
-  isStocksCategory,
   counterCurrency,
   counterValueUnit,
   displayRange,
@@ -28,17 +26,13 @@ export function getMarketAssets({
   t,
 }: {
   marketData: MarketCurrencyData[];
-  isStocksCategory: boolean;
   counterCurrency: string;
   counterValueUnit: Unit;
   displayRange: DisplayRange;
   locale: string;
   t: Translate;
 }): MarketAssetDisplayData[] {
-  const filteredMarketData = isStocksCategory
-    ? marketData.filter(isStockMarketCurrency)
-    : marketData;
-  const uniqueById = [...new Map(filteredMarketData.map(item => [item.id, item])).values()];
+  const uniqueById = [...new Map(marketData.map(item => [item.id, item])).values()];
 
   return uniqueById.map(item =>
     mapMarketCurrencyToDisplayData(item, {

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssets.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssets.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { useMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
+import { useMarketDataProvider } from "@ledgerhq/live-common/cg-client/hooks/useCoingeckoDataProvider";
 import { useLocale, useTranslation } from "~/context/Locale";
 import { useSelector } from "~/context/hooks";
 import { counterValueCurrencySelector } from "~/reducers/settings";
@@ -21,7 +22,6 @@ import {
   getMarketAssets,
   getMarketDataForDisplay,
 } from "./marketAssetsHelpers";
-import { getMarketFilter } from "@ledgerhq/live-common/market/utils/category";
 import { useMarketAssetCategoryState } from "./useMarketAssetCategoryState";
 import {
   getNextPaginationState,
@@ -56,8 +56,15 @@ export function useMarketAssets({
 }: MarketAssetsParams = {}): MarketAssetsResult {
   const { locale } = useLocale();
   const { t } = useTranslation();
+  const { supportedCounterCurrencies } = useMarketDataProvider();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
-  const counterCurrency = counterValueCurrency.ticker.toLowerCase();
+  const settingsCounterValue = counterValueCurrency.ticker.toLowerCase();
+  // While the supported list is still loading we keep the user's counter value, and only fall
+  // back to usd once we know it is unsupported — otherwise a request fires with usd first.
+  const counterCurrency =
+    supportedCounterCurrencies && !supportedCounterCurrencies.includes(settingsCounterValue)
+      ? "usd"
+      : settingsCounterValue;
   const counterValueUnit = counterValueCurrency.units[0];
   const normalizedSearch = search.trim();
   const {
@@ -95,7 +102,6 @@ export function useMarketAssets({
     liveCompatible: true,
     page: requestedPage,
     search: normalizedSearch,
-    filter: getMarketFilter(isStocksCategory),
     categories: marketCategoriesParam,
     starred: sortedFavoriteIds,
   });
@@ -105,14 +111,13 @@ export function useMarketAssets({
     () =>
       getMarketAssets({
         marketData,
-        isStocksCategory,
         counterCurrency,
         counterValueUnit,
         displayRange,
         locale,
         t,
       }),
-    [counterCurrency, counterValueUnit, displayRange, isStocksCategory, locale, marketData, t],
+    [counterCurrency, counterValueUnit, displayRange, locale, marketData, t],
   );
 
   const hasData = assets.length > 0;

--- a/libs/ledger-live-common/src/market/utils/__tests__/category.test.ts
+++ b/libs/ledger-live-common/src/market/utils/__tests__/category.test.ts
@@ -1,15 +1,9 @@
-import type { MarketCurrencyData } from "../types";
 import {
-  STOCK_MARKET_FILTER,
+  STOCK_MARKET_CATEGORY,
   getMarketCategoriesParam,
-  getMarketFilter,
   isBuiltInMarketListCategory,
-  isStockMarketCurrency,
   parseMarketListCategory,
 } from "../category";
-
-const currency = (id: string, name: string): MarketCurrencyData =>
-  ({ id, name }) as MarketCurrencyData;
 
 describe("market category utils", () => {
   describe("parseMarketListCategory", () => {
@@ -28,13 +22,6 @@ describe("market category utils", () => {
     });
   });
 
-  describe("getMarketFilter", () => {
-    it("returns the stock filter only for the stocks category", () => {
-      expect(getMarketFilter(true)).toBe(STOCK_MARKET_FILTER);
-      expect(getMarketFilter(false)).toBeUndefined();
-    });
-  });
-
   describe("isBuiltInMarketListCategory", () => {
     it.each(["all", "starred", "stocks"] as const)("is true for the built-in %s", category => {
       expect(isBuiltInMarketListCategory(category)).toBe(true);
@@ -46,29 +33,16 @@ describe("market category utils", () => {
   });
 
   describe("getMarketCategoriesParam", () => {
-    it.each(["all", "starred", "stocks"] as const)(
-      "returns undefined for the built-in %s",
-      category => {
-        expect(getMarketCategoriesParam(category)).toBeUndefined();
-      },
-    );
+    it.each(["all", "starred"] as const)("returns undefined for the built-in %s", category => {
+      expect(getMarketCategoriesParam(category)).toBeUndefined();
+    });
+
+    it("maps the stocks built-in to the dedicated CVS category", () => {
+      expect(getMarketCategoriesParam("stocks")).toBe(STOCK_MARKET_CATEGORY);
+    });
 
     it("returns the id itself for a trending category", () => {
       expect(getMarketCategoriesParam("infrastructure")).toBe("infrastructure");
-    });
-  });
-
-  describe("isStockMarketCurrency", () => {
-    it.each([
-      currency("apple-xstock", "Apple xStock"),
-      currency("tokenized-stock-tsla", "Tesla"),
-      currency("foo", "PreStocks Nvidia"),
-    ])("matches tokenized stock currency %o", item => {
-      expect(isStockMarketCurrency(item)).toBe(true);
-    });
-
-    it("does not match regular crypto currencies", () => {
-      expect(isStockMarketCurrency(currency("bitcoin", "Bitcoin"))).toBe(false);
     });
   });
 });

--- a/libs/ledger-live-common/src/market/utils/category.ts
+++ b/libs/ledger-live-common/src/market/utils/category.ts
@@ -1,5 +1,3 @@
-import type { MarketCurrencyData } from "./types";
-
 /** The built-in (non-trending) categories the Market list can be filtered by. */
 export type BuiltInMarketListCategory = "all" | "starred" | "stocks";
 
@@ -16,8 +14,8 @@ const BUILT_IN_MARKET_LIST_CATEGORIES = new Set<BuiltInMarketListCategory>([
   "stocks",
 ]);
 
-/** Backend `filter` value used to request the tokenized-stocks list. */
-export const STOCK_MARKET_FILTER = "stock";
+/** Backend `categories` value used to request the tokenized-stocks list. */
+export const STOCK_MARKET_CATEGORY = "tokenized-stock";
 
 /** Whether the category is one of the built-in filters rather than a trending category id. */
 export function isBuiltInMarketListCategory(
@@ -37,33 +35,15 @@ export function parseMarketListCategory(category: unknown): BuiltInMarketListCat
   return isBuiltInMarketListCategory(normalizedCategory) ? normalizedCategory : undefined;
 }
 
-/** Returns the backend `filter` param to send for the given category, if any. */
-export function getMarketFilter(isStocksCategory: boolean): string | undefined {
-  return isStocksCategory ? STOCK_MARKET_FILTER : undefined;
-}
-
 /**
- * Returns the backend `categories` param for a trending category, or undefined for built-ins.
- * Used to filter `/v3/markets` by a trending category id.
+ * Returns the backend `categories` param to filter `/v3/markets` by, or undefined for the
+ * `all`/`starred` built-ins. The `stocks` built-in maps to the dedicated CVS category, while
+ * trending categories pass their id through.
  */
 export function getMarketCategoriesParam(category: MarketListCategory): string | undefined {
+  if (category === "stocks") {
+    return STOCK_MARKET_CATEGORY;
+  }
+
   return isBuiltInMarketListCategory(category) ? undefined : category;
-}
-
-/**
- * Client-side guard: the backend `stock` filter is not yet exhaustive, so we
- * additionally keep only tokenized-stock currencies.
- */
-export function isStockMarketCurrency(item: MarketCurrencyData): boolean {
-  const id = item.id.toLowerCase();
-  const name = item.name.toLowerCase();
-
-  return (
-    id.includes("xstock") ||
-    id.includes("tokenized-stock") ||
-    id.includes("prestocks") ||
-    name.includes("xstock") ||
-    name.includes("tokenized stock") ||
-    name.includes("prestocks")
-  );
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Market tab → **Stocks** category on Desktop and Mobile (asset discoverability): list now comes from the dedicated CVS `categories=tokenized-stock` param. Verify the right tokenized stocks show and unrelated assets do not.
      - Network: confirm only one `/v3/markets` request fires with the user's counter value (e.g. `to=eur`) — no spurious `to=usd` request while the supported counter-values list loads.
      - Other Market categories (All / Starred / trending) and search are unaffected.

### 📝 Description

Stocks filtering in the Market list was hardcoded: the client sent `filter=stock` to `/v3/markets` and then narrowed the result client-side with substring matching on currency ids/names (`xstock`, `tokenized-stock`, `prestocks`). This was brittle and not exhaustive.

The CVS backend now exposes a dedicated `tokenized-stock` category (via `/v3/categories`) that can be passed as the `categories` param to `/v3/markets`, exactly like trending categories. This PR maps the built-in **Stocks** tab to `categories=tokenized-stock` and removes the client-side id guessing entirely — the backend is now authoritative for the stock list.

While testing, a second issue surfaced: a spurious `to=usd` request was firing on every Market load. The counter-currency resolution fell back to `usd` while the supported counter-values list was still `undefined` (loading), then re-fired with the real currency once it resolved. The fallback now only applies once the list is loaded **and** confirms the currency is unsupported, so an EUR user fires only `to=eur`. The same guard was applied to Mobile (which previously had no supported-currency guard at all).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32194](https://ledgerhq.atlassian.net/browse/LIVE-32194), [LIVE-29907](https://ledgerhq.atlassian.net/browse/LIVE-29907)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32194]: https://ledgerhq.atlassian.net/browse/LIVE-32194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ