### PR TITLE
[LWM] fix(mobile): update footnote on market highlight cards

### DIFF
--- a/.changeset/lwm-market-card-footnotes.md
+++ b/.changeset/lwm-market-card-footnotes.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Update the footnote on the Market highlight cards (Mood index, Altcoin index, Total market cap) to "Data is sourced from CoinMarketCap. Provided for informational purposes only.", and add the missing footnote to the Total market cap card.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9806,7 +9806,7 @@
   "fearAndGreed": {
     "title": "Mood index",
     "description": "Shows overall market sentiment from 0 to 100, based notably on volatility, market momentum and social trends. Lower values indicate fear, higher values indicate greed.",
-    "disclaimer": "Data is sourced from CoinMarketCap's Fear and Greed Index and provided for informational purposes only.",
+    "disclaimer": "Data is sourced from CoinMarketCap. Provided for informational purposes only.",
     "levels": {
       "fearPlus": "Fear+",
       "fear": "Fear",
@@ -9820,7 +9820,7 @@
     "title": "Season",
     "definitionTitle": "Altcoin index",
     "description": "The Altcoin index shows how Bitcoin is performing compared to alternative cryptocurrencies. The higher the number, the better altcoins are doing compared to Bitcoin.",
-    "disclaimer": "Data is sourced from CoinMarketCap's Fear and Greed Index and provided for informational purposes only.",
+    "disclaimer": "Data is sourced from CoinMarketCap. Provided for informational purposes only.",
     "levels": {
       "bitcoin": "Bitcoin",
       "altcoin": "Altcoin"
@@ -9828,7 +9828,8 @@
   },
   "marketCapCard": {
     "title": "Total market cap",
-    "description": "The total market cap represents the market capitalization of all cryptocurrencies combined."
+    "description": "The total market cap represents the market capitalization of all cryptocurrencies combined.",
+    "disclaimer": "Data is sourced from CoinMarketCap. Provided for informational purposes only."
   },
   "analyticsAllocation": {
     "header": {

--- a/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/__integrations__/FearAndGreed.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/__integrations__/FearAndGreed.test.tsx
@@ -95,7 +95,7 @@ describe("FearAndGreed Integration", () => {
 
       expect(
         screen.getByText(
-          /Data is sourced from CoinMarketCap's Fear and Greed Index and provided for informational purposes only./i,
+          /Data is sourced from CoinMarketCap. Provided for informational purposes only./i,
         ),
       ).toBeVisible();
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/MarketCapCardView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/MarketCapCardView.tsx
@@ -68,6 +68,7 @@ export function MarketCapCardView({
       <MarketInsightDefinitionSheet
         title={t("marketCapCard.title")}
         description={t("marketCapCard.description")}
+        disclaimer={t("marketCapCard.disclaimer")}
         isOpen={isDrawerOpen}
         onClose={handleCloseDrawer}
       />


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _The FearAndGreed integration test asserts the updated footnote; the AltcoinSeason and MarketCapCard suites cover their cards._
- [x] **Impact of the changes:**
      - Market highlight cards' detail sheets (Mood index, Altcoin index, Total market cap) — the footnote text.
      - The Total market cap card now shows a footnote in its detail sheet (previously none).

### 📝 Description

Updates the footnote shown on the Market highlight cards' detail sheets.

**Problem**: the Mood index and Altcoin index footnotes referenced "CoinMarketCap's Fear and Greed Index" (incorrect for the Altcoin card), and the Total market cap card had no footnote at all.

**Solution**: all three footnotes now read **"Data is sourced from CoinMarketCap. Provided for informational purposes only."** — `fearAndGreed.disclaimer` and `altcoinSeason.disclaimer` were updated, and a new `marketCapCard.disclaimer` was added and wired into the Total market cap detail sheet.

https://github.com/user-attachments/assets/6ddea63b-cdf6-4519-9431-3f2690cd1843


### ❓ Context

- **JIRA or GitHub link**: [LIVE-32385](https://ledgerhq.atlassian.net/browse/LIVE-32385)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32385]: https://ledgerhq.atlassian.net/browse/LIVE-32385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ