### PR TITLE
[LWDM] feat(lkrp): per-application close on Wallet Sync deactivation

### DIFF
--- a/.changeset/lkrp-destroy-application.md
+++ b/.changeset/lkrp-destroy-application.md
@@ -1,0 +1,18 @@
+---
+"@ledgerhq/hw-ledger-key-ring-protocol": minor
+"@ledgerhq/ledger-key-ring-protocol": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/web-tools": minor
+---
+
+feat(lkrp): per-application close on Wallet Sync deactivation
+
+Deactivating Wallet Sync now closes only the current application's stream instead of destroying the whole trustchain root, so other applications sharing the same root (e.g. wallet-cli `ring`) keep working. If the application being closed is the last open one, the whole trustchain is still destroyed (previous behaviour).
+
+- `CommandStreamResolver` now observes `CloseStream` (`ResolvedCommandStream.isClosed()`).
+- `StreamTree.getApplicationStreams()` / `hasAnotherOpenApplication()` enumerate application streams to detect the last open application.
+- New `TrustchainSDK.destroyApplication()` primitive, software-key signed (no hardware device): closes only the current application's stream, or destroys the whole trustchain when it is the last open application (`{ trustchainDestroyed }`).
+- `restoreTrustchain` throws `TrustchainEjected` when the application stream is closed, and `getOrCreateTrustchain` reopens on the next index after a close.
+- LLD/LLM `useDestroyTrustchain` hooks now call `destroyApplication`.
+- web-tools trustchain playground exposes a `sdk.destroyApplication` action to exercise the per-application close.

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/manageYourBackup.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/manageYourBackup.test.tsx
@@ -6,7 +6,9 @@ import * as ReactQuery from "@tanstack/react-query";
 
 jest.mock("../hooks/useTrustchainSdk", () => ({
   useTrustchainSdk: () => ({
-    destroyTrustchain: (mockedSdk.destroyTrustchain = jest.fn()),
+    destroyApplication: (mockedSdk.destroyApplication = jest
+      .fn()
+      .mockResolvedValue({ trustchainDestroyed: true })),
     getMembers: (mockedSdk.getMembers = jest.fn()),
     initMemberCredentials: (mockedSdk.initMemberCredentials = jest.fn()),
   }),

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useDestroyTrustchain.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useDestroyTrustchain.ts
@@ -26,7 +26,7 @@ export function useDestroyTrustchain() {
         return;
       }
       await cloudSyncSDK.destroy(trustchain, memberCredentials);
-      await sdk.destroyTrustchain(trustchain, memberCredentials);
+      await sdk.destroyApplication(trustchain, memberCredentials);
     },
     mutationKey: [QueryKey.destroyTrustchain, trustchain],
     onSuccess: () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useDestroyTrustchain.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useDestroyTrustchain.ts
@@ -28,7 +28,7 @@ export function useDestroyTrustchain() {
         return;
       }
       await cloudSyncSDK.destroy(trustchain, memberCredentials);
-      await sdk.destroyTrustchain(trustchain, memberCredentials);
+      await sdk.destroyApplication(trustchain, memberCredentials);
     },
     mutationKey: [QueryKey.destroyTrustchain, trustchain],
     onSuccess: () => {

--- a/apps/web-tools/src/trustchain/components/App.tsx
+++ b/apps/web-tools/src/trustchain/components/App.tsx
@@ -27,6 +27,7 @@ import { AppMemberRow } from "./AppMemberRow";
 import { AppDecryptUserData } from "./AppDecryptUserData";
 import { AppEncryptUserData } from "./AppEncryptUserData";
 import { AppDestroyTrustchain } from "./AppDestroyTrustchain";
+import { AppDestroyApplication } from "./AppDestroyApplication";
 import { AppGetMembers } from "./AppGetMembers";
 import { AppGetOrCreateTrustchain } from "./AppGetOrCreateTrustchain";
 import { AppInitLiveCredentials } from "./AppInitLiveCredentials";
@@ -262,6 +263,12 @@ const App = () => {
               <AppEncryptUserData trustchain={trustchain} />
 
               <AppDecryptUserData trustchain={trustchain} />
+
+              <AppDestroyApplication
+                trustchain={trustchain}
+                setTrustchain={setTrustchain}
+                memberCredentials={memberCredentials}
+              />
 
               <AppDestroyTrustchain
                 trustchain={trustchain}

--- a/apps/web-tools/src/trustchain/components/AppDestroyApplication.tsx
+++ b/apps/web-tools/src/trustchain/components/AppDestroyApplication.tsx
@@ -1,0 +1,40 @@
+import React, { useCallback, useState } from "react";
+import { MemberCredentials, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
+import { Actionable } from "./Actionable";
+import { useTrustchainSDK } from "../context";
+
+export function AppDestroyApplication({
+  trustchain,
+  setTrustchain,
+  memberCredentials,
+}: {
+  trustchain: Trustchain | null;
+  setTrustchain: (trustchain: Trustchain | null) => void;
+  memberCredentials: MemberCredentials | null;
+}) {
+  const sdk = useTrustchainSDK();
+  const [value, setValue] = useState<{ trustchainDestroyed: boolean } | null>(null);
+  const action = useCallback(
+    (trustchain: Trustchain, memberCredentials: MemberCredentials) =>
+      sdk.destroyApplication(trustchain, memberCredentials).then(result => {
+        setTrustchain(null);
+        return result;
+      }),
+    [sdk, setTrustchain],
+  );
+
+  return (
+    <Actionable
+      buttonTitle="sdk.destroyApplication"
+      inputs={trustchain && memberCredentials ? [trustchain, memberCredentials] : null}
+      action={action}
+      value={value}
+      setValue={setValue}
+      valueDisplay={value =>
+        value.trustchainDestroyed
+          ? "last application: whole trustchain destroyed"
+          : "application stream closed (trustchain root kept)"
+      }
+    />
+  );
+}

--- a/libs/hw-ledger-key-ring-protocol/src/CommandStreamResolver.ts
+++ b/libs/hw-ledger-key-ring-protocol/src/CommandStreamResolver.ts
@@ -27,6 +27,7 @@ type MemberData = {
 
 class ResolvedCommandStreamInternals {
   public isCreated: boolean = false;
+  public isClosed: boolean = false;
   public members: Uint8Array[] = [];
   public membersData: MemberData[] = [];
   public topic: Uint8Array | null = null;
@@ -49,6 +50,10 @@ export class ResolvedCommandStream {
 
   public isCreated(): boolean {
     return this._internals.isCreated;
+  }
+
+  public isClosed(): boolean {
+    return this._internals.isClosed;
   }
 
   public getMembers(): Uint8Array[] {
@@ -235,6 +240,10 @@ export default class CommandStreamResolver {
           issuer: block.issuer,
           initialiationVector: (command as PublishKey).initializationVector,
         });
+        break;
+      case CommandType.CloseStream:
+        this.assertStreamIsCreated(internals);
+        internals.isClosed = true;
         break;
     }
     return internals;

--- a/libs/hw-ledger-key-ring-protocol/src/StreamTree.ts
+++ b/libs/hw-ledger-key-ring-protocol/src/StreamTree.ts
@@ -98,6 +98,53 @@ export class StreamTree {
   }
 
   /**
+   * Enumerate the current (highest index) stream of each application branch
+   * derived under the tree root (m/{treeIndex}'/{applicationId}'/{index}').
+   * Used to decide, on deactivation, whether the application being closed is
+   * the last open one of the trustchain.
+   */
+  public getApplicationStreams(): {
+    applicationId: number;
+    index: number;
+    stream: CommandStream;
+  }[] {
+    // tree index is always 0 in the current implementation
+    const treeIndex = 0;
+    const applicationsNode = this.tree.getChild(DerivationPath.hardenedIndex(treeIndex));
+    if (!applicationsNode) return [];
+    const result: { applicationId: number; index: number; stream: CommandStream }[] = [];
+    for (const [applicationHardened, applicationNode] of applicationsNode.getChildren()) {
+      const highestIndex = applicationNode.getHighestIndex();
+      const stream = applicationNode.getChild(highestIndex)?.getValue();
+      if (stream) {
+        result.push({
+          applicationId: DerivationPath.reverseHardenedIndex(applicationHardened),
+          index: DerivationPath.reverseHardenedIndex(highestIndex),
+          stream,
+        });
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Returns true if an application other than `applicationId` still has an open (not closed) stream.
+   * Stops at the first open application found. A stream that fails to resolve is treated as open, so an
+   * unrelated broken application never causes the caller to destroy the whole trustchain on uncertainty.
+   */
+  public async hasAnotherOpenApplication(applicationId: number): Promise<boolean> {
+    for (const application of this.getApplicationStreams()) {
+      if (application.applicationId === applicationId) continue;
+      try {
+        if (!(await application.stream.resolve()).isClosed()) return true;
+      } catch {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Share a private key with a member
    */
   public async share(

--- a/libs/hw-ledger-key-ring-protocol/src/__tests__/units/StreamTree.test.ts
+++ b/libs/hw-ledger-key-ring-protocol/src/__tests__/units/StreamTree.test.ts
@@ -1,0 +1,65 @@
+import { StreamTree } from "../../StreamTree";
+import { device } from "../..";
+import { Permissions } from "../../CommandBlock";
+
+const APP_LEDGER_SYNC = 16;
+const APP_RING = 17;
+
+async function streamAt(tree: StreamTree, applicationId: number) {
+  const stream = tree.getChild(tree.getApplicationRootPath(applicationId));
+  if (!stream) throw new Error("missing stream for application " + applicationId);
+  return stream.resolve();
+}
+
+describe("StreamTree application enumeration + closure", () => {
+  it("has no application stream on a freshly created tree", async () => {
+    const tree = await StreamTree.createNewTree(await device.software());
+    expect(tree.getApplicationStreams()).toEqual([]);
+    expect(await tree.hasAnotherOpenApplication(APP_LEDGER_SYNC)).toBe(false);
+  });
+
+  it("enumerates application streams and detects other open applications", async () => {
+    const alice = await device.software();
+    const bob = await device.software();
+    const bobKey = (await bob.getPublicKey()).publicKey;
+
+    let tree = await StreamTree.createNewTree(alice);
+    tree = await tree.share(
+      tree.getApplicationRootPath(APP_LEDGER_SYNC),
+      alice,
+      bobKey,
+      "Bob",
+      Permissions.OWNER,
+    );
+    tree = await tree.share(
+      tree.getApplicationRootPath(APP_RING),
+      alice,
+      bobKey,
+      "Bob",
+      Permissions.OWNER,
+    );
+
+    expect(
+      tree
+        .getApplicationStreams()
+        .map(a => a.applicationId)
+        .sort(),
+    ).toEqual([APP_LEDGER_SYNC, APP_RING]);
+
+    // both applications are open
+    expect(await streamAt(tree, APP_LEDGER_SYNC).then(r => r.isClosed())).toBe(false);
+    expect(await tree.hasAnotherOpenApplication(APP_LEDGER_SYNC)).toBe(true); // ring is open
+    expect(await tree.hasAnotherOpenApplication(999)).toBe(true); // both are "other" and open
+
+    // close the ring application
+    tree = await tree.close(tree.getApplicationRootPath(APP_RING), alice);
+
+    // the closed stream is now observable as closed
+    expect(await streamAt(tree, APP_RING).then(r => r.isClosed())).toBe(true);
+    expect(await streamAt(tree, APP_LEDGER_SYNC).then(r => r.isClosed())).toBe(false);
+
+    // ledger sync is now the last open application; ring still sees ledger sync open
+    expect(await tree.hasAnotherOpenApplication(APP_LEDGER_SYNC)).toBe(false);
+    expect(await tree.hasAnotherOpenApplication(APP_RING)).toBe(true);
+  });
+});

--- a/libs/ledger-key-ring-protocol/mocks/scenarios/destroyApplicationKeepsOtherApps.json
+++ b/libs/ledger-key-ring-protocol/mocks/scenarios/destroyApplicationKeepsOtherApps.json
@@ -1,0 +1,1294 @@
+{
+  "apdus": "=> e0050000c201010702010012100a76d6fb6a104c9807bd21ad9d2664cd1401011546304402200f5375c842245c1018fe359a0d82170e1007380b457da75edb18a69ad1129e9202201ad8b842ff8e9707bfc1255607ebb8a0ce67227ca9307c04fb377e5328771b4616046a3e94dc202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\n<= 002101210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1463044022054c7637fb9574eb049f84472c215a4262233d03428b68bbb76e6c932831d9530022015c1866e6ab67903f5e570933870299e82989d01ab52aa3a38d84b5e6d691fa3000021012103cce710b4ace62a3597e5b9853463b6bbc45a7d198bf7b698dd885c4fedf98f9d473045022100bf4f23a2b7d9921917edb342f8b5ee4b098d9982e357c11b489d26e318a6480302202cdf330dbc5fa485e95b8a1cd0fe37e613252540f3b65c9b83e5840a7fd977bc9000\n=> e0060000210288c02fcf330f52af0ff37bd6e20246b735b399fcf9f2a1d090a83ba4781a088a\n<= 9000\n=> e00700004b0101010220f166bcfcdc4d36408d0fba0622db61f36f9c2aa579af28cc4fb8b57de71b49b20621030000000000000000000000000000000000000000000000000000000000000000010101\n<= 00103d6bc39e5616b0412fb8f10b75003d4a8131900bfed361357ebde4699658ffd7b55b9618bca63ca6713e266ff7368dc6124aad6d4dc5103dbe284a0ae46234d4d46d249000\n=> e0070100a210a005000102000006210000000000000000000000000000000000000000000000000000000000000000000510000000000000000000000000000000000540000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000621000000000000000000000000000000000000000000000000000000000000000000\n<= 0010e51274fca6b32614a01d8cb615e2a3528260943766facbc557c54fe56a3da6f615621b9e1a5918f798f26f5feb091a9b0a6ad1b3531c9ba19f94df9b8996b280e23d7b00538ae9f037385a21e1fab20bc5f9c4308272fac2c67cca2afa1dde87791fc1f7909b5cc87d3a8e9ecbd340f17316032102fcf7f06caa9cad9b66b24f3437d0a926ca138647fd6e95598b293824c5e6dc850410a27ad49c974cb99ac315b3e55978704605210365b8b5c293c88a9a92e76c972e2a701d4329ac9957087d6818cd18539c7dd4949000\n=> e007020000\n<= 473045022100b6966fae40eec5314e5f79c0b1abe975728c59d4d8a172c07928bbf6aeb7efb3022034761b3d6eb6a9b622a6bf317754f5c6c8ba260138ea8351689440fcd490ea200002fa71dfa0643201ff4ff366937553ddb5c11d191504f73b958910718637f924309000\n=> e0060000210280a10bf5c43c18e3ab3a3e1d8d8f90b2ea394461ab55f08fa75b658e926e64d1\n<= 9000\n=> e00800004b0101010220f166bcfcdc4d36408d0fba0622db61f36f9c2aa579af28cc4fb8b57de71b49b206210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1010101\n<= 9000\n=> e0080101b210b005000102000006210365b8b5c293c88a9a92e76c972e2a701d4329ac9957087d6818cd18539c7dd4940510a27ad49c974cb99ac315b3e5597870460550828a0011cdbbcec16d4d99a232392476b8c1cb78dce4e860c7895458ec469e5e45b3437bad012247b1409879f098789d22e8220c5bf46db3bacb9d88efe62c9b5cf0dc95347618b63b04357f04a88f6b062102fcf7f06caa9cad9b66b24f3437d0a926ca138647fd6e95598b293824c5e6dc85\n<= 9000\n=> e00802004903473045022100b6966fae40eec5314e5f79c0b1abe975728c59d4d8a172c07928bbf6aeb7efb3022034761b3d6eb6a9b622a6bf317754f5c6c8ba260138ea8351689440fcd490ea20\n<= 9000\n=> e00700004b0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c072330621030000000000000000000000000000000000000000000000000000000000000000010103\n<= 0010eb50bdf41eaf30da9fa1ea66db895f3f8131e8e85794646c415cf25d7f8de9637dab5dd78b029757a00a02a627aa4ecb84a1c389d122187bd3af0318367618d4dc09319000\n=> e0070100181516050c8000000080000010800000000600050005000600\n<= 00100c47006217f96c1ac30df012f2d217dd82600f02ff86c56ea5f33ae81d6ef5ab7784a71fab898bd701595e4223b18e0e5839cf033ce4061a8682ffa06bfc9da560a56672d909f5b4a87a898bc45368266f2aa11bc913baa7e2d0ea4b01810d15c1be015e3fbec6a86b4898a0f3e66f1385e4032102090a9e0d14223a123e02135110696fe514f325866511629eb92c4473dfff8e4d041022d4d24083021b23a405897f8ee8be9a052102e4d26559702654f1d73fdc2c2ca8864a24e787ba835888da5f20062ccd67fbb29000\n=> e00701003c113a040f53796e6320696e7374616e636520310621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0104ffffffff\n<= 0010b3d1d20b2f829432bfb1f7c7f2256e1786446b0dfc4ee78cce729006e13b5b8faa03bf67870fd1caf1629984fbf8ce6abf993bdce44de6b904b754f85c3cfc6bdcf9d0f12d0e5468eb9d362a093297b26137dd31b1299000\n=> e00701002b1229050005000621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0600\n<= 00107e44d3e88c4578dc44f20bf8c4de03f382605f01eb81929d7e8861a3177c13afcbcb3a2aafa3274c8769586e232215e126d3c15b19615b60594a1fe2e6d9853bf123597453d135ff3c1b682539a8fc1386643c3d20acfcb151ad21e3b9ee80544491421033098709fb6ed1d8c22294375600032102c4f6cd3c601b3cabdfbb2584fc81171d55da209c45473b7e9fc8b3a466b98a5c04106097251f481ce73a4155517c31c7e2af86202648cf49eb56b2a1623490e08900c14c4575722610931a8b4e71f3e1567243219000\n=> e007020000\n<= 46304402207adaafd52abecbd56f24caea2a62bf41970815b22acdfcbe6062b3d0d08a72fd02207943cf2d14730931d5356660325849e9e009942e28c8be54228d104afd95923001029424eba3e5d5ca7547d08191a96b415d5100012fde2d92dc6af9eca755157d759000\n=> e0050000c301010702010012107b48c81f4c291c2d680e282c0d231c8c14010115473045022100bf48aad8ee87f04ccc3b1d1f68ed1c642aa0edac06db18f940cba7cdc68a34ac02206b9a1cbbfecf7a838049cb9fe37f3af27b0f33f5404154074531959170f9a20616046a3e94df202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\n<= 002101210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1473045022100de21fa960201db9646d36b6ebbc80217a545be4b9d07a53839e97c1646038a2f022039ae3d5c379b90b987a693aa62f0e3c2f465bae90352e7897a980b540c19be09000021012103cce710b4ace62a3597e5b9853463b6bbc45a7d198bf7b698dd885c4fedf98f9d463044022028aa59c90eb9c8e0d885ad57172b48bcfae98db08765af8baea637d94cb9e35802204bbde9d5f720b6f438487b25c133f83cc50ac21a2bc4e6a2dbc528671199eee69000\n=> e006000021035f28a667eefd4a743e30caf1b2d2eb50a3f0cbcef60248b2a14eb61bf15b6318\n<= 9000\n=> e00800004b0101010220f166bcfcdc4d36408d0fba0622db61f36f9c2aa579af28cc4fb8b57de71b49b206210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1010101\n<= 9000\n=> e0080101b210b005000102000006210365b8b5c293c88a9a92e76c972e2a701d4329ac9957087d6818cd18539c7dd4940510a27ad49c974cb99ac315b3e5597870460550828a0011cdbbcec16d4d99a232392476b8c1cb78dce4e860c7895458ec469e5e45b3437bad012247b1409879f098789d22e8220c5bf46db3bacb9d88efe62c9b5cf0dc95347618b63b04357f04a88f6b062102fcf7f06caa9cad9b66b24f3437d0a926ca138647fd6e95598b293824c5e6dc85\n<= 9000\n=> e00802004903473045022100b6966fae40eec5314e5f79c0b1abe975728c59d4d8a172c07928bbf6aeb7efb3022034761b3d6eb6a9b622a6bf317754f5c6c8ba260138ea8351689440fcd490ea20\n<= 9000\n=> e00800004b0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1010103\n<= 9000\n=> e0080101ba15b8050c800000008000001080000000062102e4d26559702654f1d73fdc2c2ca8864a24e787ba835888da5f20062ccd67fbb2051022d4d24083021b23a405897f8ee8be9a0550abf072e72037ef826ca505b67288113296058a81900d35fd6c275b4061d9e5daf4a26744c3771c83cec1bfdccceec236fc1f3fb0ff3dce3ed5c860bcea2b9595f2a4709f96c7efd26a53dbc0c00b7a2e062102090a9e0d14223a123e02135110696fe514f325866511629eb92c4473dfff8e4d\n<= 9000\n=> e00801013c113a040f53796e6320696e7374616e636520310621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0104ffffffff\n<= 00104b721d7833ed2d914372cb5c9db35fd5864497bde396efd599c674daa16592abd034835b9baf29bd44451302d85f8885328c594c790d06fa0f425c194370f17a138e3ae1e02ea4743db6f479121b802c3e6251cac42f9000\n=> e0080101ac12aa05106097251f481ce73a4155517c31c7e2af055019de01d731d72b1342c2d6e0ab68e8283023c8493c16582429eb4383c5308c1160c774ae3d3038eb74f72534fbef8d19547503090023831554513fd7a0ee1374fdcc29b0e491dc969f5ef14c38f3a7a50621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec062102c4f6cd3c601b3cabdfbb2584fc81171d55da209c45473b7e9fc8b3a466b98a5c\n<= 00107cbc3f70a57a86a8e50927307b44a9ae86449a62b05879273d0ca180b759969a0c4624c2010b60010ee67c7326d4423d67f49e988dbc857c69ab31f4d001497421afb97ff5e9caf0b5ab9128930126c7ef0d011ccc9f9000\n=> e0080200480346304402207adaafd52abecbd56f24caea2a62bf41970815b22acdfcbe6062b3d0d08a72fd02207943cf2d14730931d5356660325849e9e009942e28c8be54228d104afd959230\n<= 9000\n=> e00700004b0101010220e565551a516e69d0d73036a30162b78bff1687cd0bcdf2e0be739ee769eb58ae0621030000000000000000000000000000000000000000000000000000000000000000010102\n<= 001085a3f828c6fd672da2adf45fa920c5f5813128f736a5dfb027194dc1fde9542c75fd5c0d7d0fb45bc11603cbaa3186882b69a1772893808e695c5f2396d67bc851c00f9000\n=> e00701003c113a040f53796e6320696e7374616e63652032062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b0060104ffffffff\n<= 00101c02bc9eede1d57f48178403b2dbc73786441d25f2fb0bfb66b2c3c6bd2cd76e2502c6ee4619b9f5cd295f6935d7b97be2b6adc5d689aa3c8744274291048113050b6fdf67dd1b57aa4b38be8c7d4ab29fcb89986b7e9000\n=> e00701002b122905000500062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b0060600\n<= 0010bcc6725e7367be1d878312a486ce42738260573494064886f279146ef26e43dcdc291b4a99adf40ada9a89ab28645a87c868229064bf9b0a19bb403d65fed215cad844508a487d5e4ead893dc06caebe5a0bcef011ddfee4e3f595912e705f77ff00a5858a27484aa409c9b96d898106cd10032102d7ef2c2c212f43de3df3120f02879d7e7efae7329f96044f2501535439824a310410b017f2f82f76fbe152c219d18278163e86204156e85ff39368f719fdd1d49c5a3bd436ff4902d5248e5d1a1777277fdb54689000\n=> e007020000\n<= 4630440220320342953b66a108d166c2e854512bbad259110de3bfbe651efc6c2c86d4a5c30220204175b1b33bbbfb25356add307237e1b6678331efdc94af169e8d40d840ed180002bf0974f221aa9951986280cd5beed2626f05a753d31548d4cdc365f1a5d8ceb29000\n=> e0050000c401010702010012101d7a27d6a6ee4beb3a9896bcd9793a0c14010115483046022100b73de6f3f9dea2bafadce908e33d900716acad4fd98e2fcc9f9fad275d0cdb3b0221008fd5b20889c53ccfd51ffcbd4765d685352431961a361e13e6f7dcf3aa41ab0216046a3e94e1202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\n<= 002101210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce147304502210083292e192c14c1f00f5398aeeaf2ae24af51f60cc78d781755b0c9d0b385cbb70220664fdf79a9bb085eb3c5bcb0658f74175af2140bf214fc3de8350b4232998b01000021012103cce710b4ace62a3597e5b9853463b6bbc45a7d198bf7b698dd885c4fedf98f9d473045022100de802ac2327142a32e414b75681dc31eb17d2297808c82f933e5193fc752398e02203f79890167b6eb885788fabb90aab1a3705f1e34a12664739ebcee85c8c1c65c9000\n=> e006000021036295359c1468730f3e79affc22ab0cabfcfc8514a65ec44f18cf95ad9a66aa1f\n<= 9000\n=> e00800004b0101010220f166bcfcdc4d36408d0fba0622db61f36f9c2aa579af28cc4fb8b57de71b49b206210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1010101\n<= 9000\n=> e0080101b210b005000102000006210365b8b5c293c88a9a92e76c972e2a701d4329ac9957087d6818cd18539c7dd4940510a27ad49c974cb99ac315b3e5597870460550828a0011cdbbcec16d4d99a232392476b8c1cb78dce4e860c7895458ec469e5e45b3437bad012247b1409879f098789d22e8220c5bf46db3bacb9d88efe62c9b5cf0dc95347618b63b04357f04a88f6b062102fcf7f06caa9cad9b66b24f3437d0a926ca138647fd6e95598b293824c5e6dc85\n<= 9000\n=> e00802004903473045022100b6966fae40eec5314e5f79c0b1abe975728c59d4d8a172c07928bbf6aeb7efb3022034761b3d6eb6a9b622a6bf317754f5c6c8ba260138ea8351689440fcd490ea20\n<= 9000\n=> e00700004b0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c072330621030000000000000000000000000000000000000000000000000000000000000000010103\n<= 0010da4edc0b70bdc5922e2bb32f9cb6c48e813152f99b632985ca2f7cee5de8dd1940c349c1b5ecc8bf5949e41385b7e79422f97201fe6123b0691f88df98e84addae709d9000\n=> e0070100181516050c8000000080000011800000000600050005000600\n<= 0010009b6811f147ce0b8bdcf762014894dc82608b52ba3bba0c0d73c9f398991e6af1d3cb33c22ff4a2e6829a1dfc7c062d1e57b3ba9d496356566ae5d8efea5cc05e760bdd7a7b1af174ef35d4c9511714bc7086ae18258ced537436cb3bea554688520ce4c5b8ed8cd39aa6bddc678637bab6032103153b00fe9d979e263db26a24ead4c7d80163df473a4ba0533ef1f2d69f69280704109670e7072dad995bd84d8b74034f03040521034439851b65a8a8670e6b57aaeb1735bc276634dc014f69152ba8bd8cf550610c9000\n=> e0070100381136040b52696e67206d656d6265720621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b750104ffffffff\n<= 0010562b3d0642abe0f476ee6c02fa0a729a86448c8c5d612527d48b432aabf408df07114aa79fc3fffb819e3397256418642a2d4c0c4d5d426b6f1d76dcb0b7bffe5ace3c9b14100690905bf3770d805ebbda13b6d1b4179000\n=> e00701002b1229050005000621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b750600\n<= 0010c7b149e7cb6ec92847338c9d5ecaa3a18260c885ed292307bfb932da0620f0e6effb95e2c6386462e35af9ba9abf96e2a78e3b12aeaca58bc38d0f44040267f25e0fa48352ef78fbb494b7668614d32f408cbcda5b1586c4cba0e8ddeb4388d8202625f26ecd6bbfa131252b9d79aa17b31f032103d0a0747aa0b55ffa04c23927666fa2904369e2945b34b6d138231b412bd0efac0410758495eb7201ee6d0b60073977544f3e86200f96d7d682791113f516fad5ea1cb2eb36896e8ea7cf871b6cc1ce65ca64d4749000\n=> e007020000\n<= 463044022063520eb3505db188808837e16e0902c074397d00d77fda94de9be4bae214e96402204b2c6266750dc4771faadc3174612b61268c1fe7e7ed8debc6eab02c400d67ad010207b0440e63b49acdef76324ace270061685300b0f0fff7bd5867b830364f15f19000\n=> e0050000c301010702010012105b6c0f233881c8eef0302e38e2cf460714010115473045022100a29e2e79b09ece4a5b3185829813a2ff3209e734a771224086dafac64eef727402204d69bc7561ba42749928e41156673d195a3135aa34cafc494108ca72cbc5cc7e16046a3e94e5202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\n<= 002101210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1463044022004cb06e205f5cdca00510bac328a15ea8d8442900068da494d243ff5a326bee7022051c8d3b0c222a782bdbc5b6c07fab8053682fc0d1f30c721b6720a53cb6de19b000021012103cce710b4ace62a3597e5b9853463b6bbc45a7d198bf7b698dd885c4fedf98f9d463044022070541798a3871822841638205a1daf119de5d3c2f32f5306e6c61b672d43062e0220543783e16dcc6bc4d2a98e4a1b90efeb9680aad2e2d0dbb3bbf7264a988e9adb9000\n=> e0060000210391474144b74c5629fb1072aadcf49cc905576cd73cfb06c3ef310c8dc18daa37\n<= 9000\n=> e00800004b0101010220f166bcfcdc4d36408d0fba0622db61f36f9c2aa579af28cc4fb8b57de71b49b206210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1010101\n<= 9000\n=> e0080101b210b005000102000006210365b8b5c293c88a9a92e76c972e2a701d4329ac9957087d6818cd18539c7dd4940510a27ad49c974cb99ac315b3e5597870460550828a0011cdbbcec16d4d99a232392476b8c1cb78dce4e860c7895458ec469e5e45b3437bad012247b1409879f098789d22e8220c5bf46db3bacb9d88efe62c9b5cf0dc95347618b63b04357f04a88f6b062102fcf7f06caa9cad9b66b24f3437d0a926ca138647fd6e95598b293824c5e6dc85\n<= 9000\n=> e00802004903473045022100b6966fae40eec5314e5f79c0b1abe975728c59d4d8a172c07928bbf6aeb7efb3022034761b3d6eb6a9b622a6bf317754f5c6c8ba260138ea8351689440fcd490ea20\n<= 9000\n=> e00700004b0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c072330621030000000000000000000000000000000000000000000000000000000000000000010103\n<= 001071ef4917f9a0e96525455166cddc9c2e8131bd8baef71362fe28517b933c2b0bf715fbaf8beffe32fd4a111a0b20fe55f93cee5c8a22fe646689c982e87e03cfda49ae9000\n=> e0070100181516050c8000000080000010800000010600050005000600\n<= 00109ce3cd12ba94a7f6e275f62afe17bb7082604e3df7dd226d668c4c4ac948c3423b4428d6ed242121baee6b4533fd5435904d61d34f6ee765fcc69a9609b73f24539e2c67faa86fe6ba5ad8bda2adec620f4b882753b88e39a34f1ea4ef410d2f74a25fe0e7ccfebde91f67c1dcab6ad260b2032102e741c74b785c676ebd5b8c1a5c8891f6d81fb7425ccc2ecaf91c22a7d252e640041006048700a47065cab5b7308393ccb12f052102ce6d1b891e00a3f747cb14739e083282471ecf42f1749f4bde5bff96b44536a39000\n=> e00701003c113a040f53796e6320696e7374616e636520310621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0104ffffffff\n<= 001093b1bfc60c7bce87fa2203b329aa2b118644fea5d1f5d17fc3ceabc313fd64f6b9050c69e62b84fbb58fc1323ef41340c57eb62995e3d0c4690bbf03535872a8e66f538b674aa882ebd35dc1ed410f987887808a55239000\n=> e00701002b1229050005000621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0600\n<= 00108b4bd7c66003d3fdb4cd41477f000d8b826052b37aad2e0dec2671b5f64d5361329f716b7038a80128be7ab5070022910891b3f083903079e24812b1d1e09aedf41d0f713f81eeae3011821286f468f19275de3c4b180d7ef92d16d2e37cee9df4fc7b643feb730eff4a58315f3e0e2fefa80321036782b97e4bf6b949c77433fde40a4fcab1527e639b4cd8e90c6c06307f7d236204107bdb1276fe162927c05538174548add086208adb535e06671990d52f02ebc25c5829cf2cf0d440e02235136839ba072614c99000\n=> e007020000\n<= 46304402200893e3e0b069bbc0147d09a97d9b3e4a5e05464a8bf5aed4087f1a389e83eaf6022055668e4916e80374e692d2aea53e053410a46705ab63f8dd8f127c8d5738dc3200020df83ed54b851bd7825c36bf8a4dba7ee468331ee99b094e9f4d0c59cbc2ff089000\n",
+  "crypto": {
+    "randomBytesOutputs": [
+      "b88afa7449629a78792de3219b7a619065fe3d9029e41c0c8524c2a32d78e5d0",
+      "f166bcfcdc4d36408d0fba0622db61f36f9c2aa579af28cc4fb8b57de71b49b2"
+    ],
+    "randomKeypairOutputs": [
+      "15b796e5c96ad4c19211ef2b12cf8072c0798c9a150a94445b7a3ca40ef4e3ba",
+      "2452ba86e26575f411a8204765cc72ccebbcde4e1f651a77c6c35e64ea2666fb",
+      "d8877b780e68bb6496d698320711b39f9237246ba477c2feb34bda5427d54dcb",
+      "ab162e4fd47e3e5046484c3c4db5eb13f0f3c768484798bd3195798408ec0d92",
+      "5c26bc078625d249d906f0d23386a81f9747e2606760bff4afd6866880a49a73",
+      "44f167c54ee4a9ba84db8edc002ba8857ab9440019f6fc9d7f84f9dea030f70c",
+      "d78a3ca0ce4789766e278bd70e22a9e165d374285d2d16141920f976123a9cab",
+      "1e332e44fa3569297f440ed49e1324a81c7b8476e639dfc398fcb39350234ac1",
+      "a7cce02f397d6735fa613c5a8ea8abf866aa3f14b9870ee7d3ba644f3d38bc56",
+      "2e21de0f37596a21a849770fefb616fee5022e24c0d0d161810802f0f892b94c",
+      "d08f5e6cb0528d3a1b48088b08cf1a63e03f4c9da1dfc1ea5f16b82584e9a774",
+      "69165ab16aec8aa8a2133308e0ca230d6df50d0ecce507b8b50e08b3b01b43c4"
+    ]
+  },
+  "http": {
+    "transactions": [
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/challenge",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:33:55 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"json\":{\"version\":0,\"challenge\":{\"data\":\"0a76d6fb6a104c9807bd21ad9d2664cd\",\"expiry\":\"2026-06-26T15:03:56Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"304402200f5375c842245c1018fe359a0d82170e1007380b457da75edb18a69ad1129e9202201ad8b842ff8e9707bfc1255607ebb8a0ce67227ca9307c04fb377e5328771b46\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"tlv\":\"01010702010012100a76d6fb6a104c9807bd21ad9d2664cd1401011546304402200f5375c842245c1018fe359a0d82170e1007380b457da75edb18a69ad1129e9202201ad8b842ff8e9707bfc1255607ebb8a0ce67227ca9307c04fb377e5328771b4616046a3e94dc202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/authenticate",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "content-length": "1066",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "{\"challenge\":{\"version\":0,\"challenge\":{\"data\":\"0a76d6fb6a104c9807bd21ad9d2664cd\",\"expiry\":\"2026-06-26T15:03:56Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"304402200f5375c842245c1018fe359a0d82170e1007380b457da75edb18a69ad1129e9202201ad8b842ff8e9707bfc1255607ebb8a0ce67227ca9307c04fb377e5328771b46\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"signature\":{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"0235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1\"},\"signature\":\"3044022054c7637fb9574eb049f84472c215a4262233d03428b68bbb76e6c932831d9530022015c1866e6ab67903f5e570933870299e82989d01ab52aa3a38d84b5e6d691fa3\",\"attestation\":\"000021012103cce710b4ace62a3597e5b9853463b6bbc45a7d198bf7b698dd885c4fedf98f9d473045022100bf4f23a2b7d9921917edb342f8b5ee4b098d9982e357c11b489d26e318a6480302202cdf330dbc5fa485e95b8a1cd0fe37e613252540f3b65c9b83e5840a7fd977bc\"}}"
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:33:55 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDczNiwiaWF0IjoxNzgyNDg0NDM1LCJqdGkiOiIyZjFiMzY5NS0xMGU1LTQ4NzUtOGNhYS1lNWFjOWYyZTkyNTgiLCJwZXJtaXNzaW9ucyI6e30sImRldmljZSI6dHJ1ZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjMzOjU2WiJ9.Y-xDTWBvAp73kVBl__u9lmjGz_X8LA1ujjk58QUJ8QukGZEAhb6fBahu8DUttJjxVozii7b2L_AXjKcMMrlYHQ\",\"permissions\":{}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchains",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDczNiwiaWF0IjoxNzgyNDg0NDM1LCJqdGkiOiIyZjFiMzY5NS0xMGU1LTQ4NzUtOGNhYS1lNWFjOWYyZTkyNTgiLCJwZXJtaXNzaW9ucyI6e30sImRldmljZSI6dHJ1ZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjMzOjU2WiJ9.Y-xDTWBvAp73kVBl__u9lmjGz_X8LA1ujjk58QUJ8QukGZEAhb6fBahu8DUttJjxVozii7b2L_AXjKcMMrlYHQ",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:33:56 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/seed",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDczNiwiaWF0IjoxNzgyNDg0NDM1LCJqdGkiOiIyZjFiMzY5NS0xMGU1LTQ4NzUtOGNhYS1lNWFjOWYyZTkyNTgiLCJwZXJtaXNzaW9ucyI6e30sImRldmljZSI6dHJ1ZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjMzOjU2WiJ9.Y-xDTWBvAp73kVBl__u9lmjGz_X8LA1ujjk58QUJ8QukGZEAhb6fBahu8DUttJjxVozii7b2L_AXjKcMMrlYHQ",
+            "connection": "close",
+            "content-length": "654",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "\"0101010220f166bcfcdc4d36408d0fba0622db61f36f9c2aa579af28cc4fb8b57de71b49b206210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010110b005000102000006210365b8b5c293c88a9a92e76c972e2a701d4329ac9957087d6818cd18539c7dd4940510a27ad49c974cb99ac315b3e5597870460550828a0011cdbbcec16d4d99a232392476b8c1cb78dce4e860c7895458ec469e5e45b3437bad012247b1409879f098789d22e8220c5bf46db3bacb9d88efe62c9b5cf0dc95347618b63b04357f04a88f6b062102fcf7f06caa9cad9b66b24f3437d0a926ca138647fd6e95598b293824c5e6dc8503473045022100b6966fae40eec5314e5f79c0b1abe975728c59d4d8a172c07928bbf6aeb7efb3022034761b3d6eb6a9b622a6bf317754f5c6c8ba260138ea8351689440fcd490ea20\""
+        },
+        "response": {
+          "status": 204,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "date": "Fri, 26 Jun 2026 14:33:56 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains"
+          }
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/refresh",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDczNiwiaWF0IjoxNzgyNDg0NDM1LCJqdGkiOiIyZjFiMzY5NS0xMGU1LTQ4NzUtOGNhYS1lNWFjOWYyZTkyNTgiLCJwZXJtaXNzaW9ucyI6e30sImRldmljZSI6dHJ1ZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjMzOjU2WiJ9.Y-xDTWBvAp73kVBl__u9lmjGz_X8LA1ujjk58QUJ8QukGZEAhb6fBahu8DUttJjxVozii7b2L_AXjKcMMrlYHQ",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:33:56 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDczNywiaWF0IjoxNzgyNDg0NDM2LCJqdGkiOiI5ZWFkYmViYi04ZjUxLTQzN2ItOTNjZC04MWY5OTRlODhkZGUiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzM6NTZaIn0.ulSszAwQ4b_ZRvF7WxqovziKFpoi0cTcX7nFta0XiIlmT3B-i_UBG4K887Pts7wnPKxLZmJZX8MufC4KqxrB0w\",\"permissions\":{\"00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233\":{\"m/\":\"ffffffff\"}}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchains",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDczNywiaWF0IjoxNzgyNDg0NDM2LCJqdGkiOiI5ZWFkYmViYi04ZjUxLTQzN2ItOTNjZC04MWY5OTRlODhkZGUiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzM6NTZaIn0.ulSszAwQ4b_ZRvF7WxqovziKFpoi0cTcX7nFta0XiIlmT3B-i_UBG4K887Pts7wnPKxLZmJZX8MufC4KqxrB0w",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:33:56 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233\":{\"m/\":\"ffffffff\"}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDczNywiaWF0IjoxNzgyNDg0NDM2LCJqdGkiOiI5ZWFkYmViYi04ZjUxLTQzN2ItOTNjZC04MWY5OTRlODhkZGUiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzM6NTZaIn0.ulSszAwQ4b_ZRvF7WxqovziKFpoi0cTcX7nFta0XiIlmT3B-i_UBG4K887Pts7wnPKxLZmJZX8MufC4KqxrB0w",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:33:56 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"m/\":\"0101010220f166bcfcdc4d36408d0fba0622db61f36f9c2aa579af28cc4fb8b57de71b49b206210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010110b005000102000006210365b8b5c293c88a9a92e76c972e2a701d4329ac9957087d6818cd18539c7dd4940510a27ad49c974cb99ac315b3e5597870460550828a0011cdbbcec16d4d99a232392476b8c1cb78dce4e860c7895458ec469e5e45b3437bad012247b1409879f098789d22e8220c5bf46db3bacb9d88efe62c9b5cf0dc95347618b63b04357f04a88f6b062102fcf7f06caa9cad9b66b24f3437d0a926ca138647fd6e95598b293824c5e6dc8503473045022100b6966fae40eec5314e5f79c0b1abe975728c59d4d8a172c07928bbf6aeb7efb3022034761b3d6eb6a9b622a6bf317754f5c6c8ba260138ea8351689440fcd490ea20\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233/derivation",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDczNywiaWF0IjoxNzgyNDg0NDM2LCJqdGkiOiI5ZWFkYmViYi04ZjUxLTQzN2ItOTNjZC04MWY5OTRlODhkZGUiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzM6NTZaIn0.ulSszAwQ4b_ZRvF7WxqovziKFpoi0cTcX7nFta0XiIlmT3B-i_UBG4K887Pts7wnPKxLZmJZX8MufC4KqxrB0w",
+            "connection": "close",
+            "content-length": "1132",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c800000008000001080000000062102e4d26559702654f1d73fdc2c2ca8864a24e787ba835888da5f20062ccd67fbb2051022d4d24083021b23a405897f8ee8be9a0550abf072e72037ef826ca505b67288113296058a81900d35fd6c275b4061d9e5daf4a26744c3771c83cec1bfdccceec236fc1f3fb0ff3dce3ed5c860bcea2b9595f2a4709f96c7efd26a53dbc0c00b7a2e062102090a9e0d14223a123e02135110696fe514f325866511629eb92c4473dfff8e4d113a040f53796e6320696e7374616e636520310621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0104ffffffff12aa05106097251f481ce73a4155517c31c7e2af055019de01d731d72b1342c2d6e0ab68e8283023c8493c16582429eb4383c5308c1160c774ae3d3038eb74f72534fbef8d19547503090023831554513fd7a0ee1374fdcc29b0e491dc969f5ef14c38f3a7a50621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec062102c4f6cd3c601b3cabdfbb2584fc81171d55da209c45473b7e9fc8b3a466b98a5c0346304402207adaafd52abecbd56f24caea2a62bf41970815b22acdfcbe6062b3d0d08a72fd02207943cf2d14730931d5356660325849e9e009942e28c8be54228d104afd959230\""
+        },
+        "response": {
+          "status": 204,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "date": "Fri, 26 Jun 2026 14:33:58 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains"
+          }
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/challenge",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:33:58 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"json\":{\"version\":0,\"challenge\":{\"data\":\"7b48c81f4c291c2d680e282c0d231c8c\",\"expiry\":\"2026-06-26T15:03:59Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"3045022100bf48aad8ee87f04ccc3b1d1f68ed1c642aa0edac06db18f940cba7cdc68a34ac02206b9a1cbbfecf7a838049cb9fe37f3af27b0f33f5404154074531959170f9a206\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"tlv\":\"01010702010012107b48c81f4c291c2d680e282c0d231c8c14010115473045022100bf48aad8ee87f04ccc3b1d1f68ed1c642aa0edac06db18f940cba7cdc68a34ac02206b9a1cbbfecf7a838049cb9fe37f3af27b0f33f5404154074531959170f9a20616046a3e94df202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/authenticate",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "content-length": "1068",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "{\"challenge\":{\"version\":0,\"challenge\":{\"data\":\"7b48c81f4c291c2d680e282c0d231c8c\",\"expiry\":\"2026-06-26T15:03:59Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"3045022100bf48aad8ee87f04ccc3b1d1f68ed1c642aa0edac06db18f940cba7cdc68a34ac02206b9a1cbbfecf7a838049cb9fe37f3af27b0f33f5404154074531959170f9a206\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"signature\":{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"0235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1\"},\"signature\":\"3045022100de21fa960201db9646d36b6ebbc80217a545be4b9d07a53839e97c1646038a2f022039ae3d5c379b90b987a693aa62f0e3c2f465bae90352e7897a980b540c19be09\",\"attestation\":\"000021012103cce710b4ace62a3597e5b9853463b6bbc45a7d198bf7b698dd885c4fedf98f9d463044022028aa59c90eb9c8e0d885ad57172b48bcfae98db08765af8baea637d94cb9e35802204bbde9d5f720b6f438487b25c133f83cc50ac21a2bc4e6a2dbc528671199eee6\"}}"
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:33:58 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDczOSwiaWF0IjoxNzgyNDg0NDM4LCJqdGkiOiJkNGQzYTM2ZS0zOWRhLTQwNmItOGJiNS03NWNkZTI1YWMxNDIiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzM6NTlaIn0.ZfG-LN8CpyTdgLj2x3-gbmILzQJ80ERIg-wyrwQYVFkAjAczSdlSrnulxM4bim3t5mfDXtsao4xpNLJ4M-UCqA\",\"permissions\":{\"00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233\":{\"m/\":\"ffffffff\"}}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchains",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDczOSwiaWF0IjoxNzgyNDg0NDM4LCJqdGkiOiJkNGQzYTM2ZS0zOWRhLTQwNmItOGJiNS03NWNkZTI1YWMxNDIiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzM6NTlaIn0.ZfG-LN8CpyTdgLj2x3-gbmILzQJ80ERIg-wyrwQYVFkAjAczSdlSrnulxM4bim3t5mfDXtsao4xpNLJ4M-UCqA",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:33:58 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233\":{\"m/\":\"ffffffff\"}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDczOSwiaWF0IjoxNzgyNDg0NDM4LCJqdGkiOiJkNGQzYTM2ZS0zOWRhLTQwNmItOGJiNS03NWNkZTI1YWMxNDIiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzM6NTlaIn0.ZfG-LN8CpyTdgLj2x3-gbmILzQJ80ERIg-wyrwQYVFkAjAczSdlSrnulxM4bim3t5mfDXtsao4xpNLJ4M-UCqA",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:33:59 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"m/\":\"0101010220f166bcfcdc4d36408d0fba0622db61f36f9c2aa579af28cc4fb8b57de71b49b206210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010110b005000102000006210365b8b5c293c88a9a92e76c972e2a701d4329ac9957087d6818cd18539c7dd4940510a27ad49c974cb99ac315b3e5597870460550828a0011cdbbcec16d4d99a232392476b8c1cb78dce4e860c7895458ec469e5e45b3437bad012247b1409879f098789d22e8220c5bf46db3bacb9d88efe62c9b5cf0dc95347618b63b04357f04a88f6b062102fcf7f06caa9cad9b66b24f3437d0a926ca138647fd6e95598b293824c5e6dc8503473045022100b6966fae40eec5314e5f79c0b1abe975728c59d4d8a172c07928bbf6aeb7efb3022034761b3d6eb6a9b622a6bf317754f5c6c8ba260138ea8351689440fcd490ea20\",\"m/16'\":\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c800000008000001080000000062102e4d26559702654f1d73fdc2c2ca8864a24e787ba835888da5f20062ccd67fbb2051022d4d24083021b23a405897f8ee8be9a0550abf072e72037ef826ca505b67288113296058a81900d35fd6c275b4061d9e5daf4a26744c3771c83cec1bfdccceec236fc1f3fb0ff3dce3ed5c860bcea2b9595f2a4709f96c7efd26a53dbc0c00b7a2e062102090a9e0d14223a123e02135110696fe514f325866511629eb92c4473dfff8e4d113a040f53796e6320696e7374616e636520310621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0104ffffffff12aa05106097251f481ce73a4155517c31c7e2af055019de01d731d72b1342c2d6e0ab68e8283023c8493c16582429eb4383c5308c1160c774ae3d3038eb74f72534fbef8d19547503090023831554513fd7a0ee1374fdcc29b0e491dc969f5ef14c38f3a7a50621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec062102c4f6cd3c601b3cabdfbb2584fc81171d55da209c45473b7e9fc8b3a466b98a5c0346304402207adaafd52abecbd56f24caea2a62bf41970815b22acdfcbe6062b3d0d08a72fd02207943cf2d14730931d5356660325849e9e009942e28c8be54228d104afd959230\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233/commands",
+          "method": "PUT",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDczOSwiaWF0IjoxNzgyNDg0NDM4LCJqdGkiOiJkNGQzYTM2ZS0zOWRhLTQwNmItOGJiNS03NWNkZTI1YWMxNDIiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzM6NTlaIn0.ZfG-LN8CpyTdgLj2x3-gbmILzQJ80ERIg-wyrwQYVFkAjAczSdlSrnulxM4bim3t5mfDXtsao4xpNLJ4M-UCqA",
+            "connection": "close",
+            "content-length": "794",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "{\"path\":\"m/0'/16'/0'\",\"blocks\":[\"0101010220e565551a516e69d0d73036a30162b78bff1687cd0bcdf2e0be739ee769eb58ae06210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1010102113a040f53796e6320696e7374616e63652032062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b0060104ffffffff12aa0510b017f2f82f76fbe152c219d18278163e0550a6758ea19463616f5f513a6b5dfef1c3434f6a81f6265498aef6efb343ed2c1431d9d030ae575dc0d30f26c7cd0e0f61035ebeaf8be10331a1d6132b1fd6660c338b34400ec4ec2db677d5ba4a651c3b062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b006062102d7ef2c2c212f43de3df3120f02879d7e7efae7329f96044f2501535439824a31034630440220320342953b66a108d166c2e854512bbad259110de3bfbe651efc6c2c86d4a5c30220204175b1b33bbbfb25356add307237e1b6678331efdc94af169e8d40d840ed18\"]}"
+        },
+        "response": {
+          "status": 204,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "date": "Fri, 26 Jun 2026 14:34:00 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains"
+          }
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/challenge",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:00 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"json\":{\"version\":0,\"challenge\":{\"data\":\"1d7a27d6a6ee4beb3a9896bcd9793a0c\",\"expiry\":\"2026-06-26T15:04:01Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"3046022100b73de6f3f9dea2bafadce908e33d900716acad4fd98e2fcc9f9fad275d0cdb3b0221008fd5b20889c53ccfd51ffcbd4765d685352431961a361e13e6f7dcf3aa41ab02\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"tlv\":\"01010702010012101d7a27d6a6ee4beb3a9896bcd9793a0c14010115483046022100b73de6f3f9dea2bafadce908e33d900716acad4fd98e2fcc9f9fad275d0cdb3b0221008fd5b20889c53ccfd51ffcbd4765d685352431961a361e13e6f7dcf3aa41ab0216046a3e94e1202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/authenticate",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "content-length": "1072",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "{\"challenge\":{\"version\":0,\"challenge\":{\"data\":\"1d7a27d6a6ee4beb3a9896bcd9793a0c\",\"expiry\":\"2026-06-26T15:04:01Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"3046022100b73de6f3f9dea2bafadce908e33d900716acad4fd98e2fcc9f9fad275d0cdb3b0221008fd5b20889c53ccfd51ffcbd4765d685352431961a361e13e6f7dcf3aa41ab02\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"signature\":{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"0235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1\"},\"signature\":\"304502210083292e192c14c1f00f5398aeeaf2ae24af51f60cc78d781755b0c9d0b385cbb70220664fdf79a9bb085eb3c5bcb0658f74175af2140bf214fc3de8350b4232998b01\",\"attestation\":\"000021012103cce710b4ace62a3597e5b9853463b6bbc45a7d198bf7b698dd885c4fedf98f9d473045022100de802ac2327142a32e414b75681dc31eb17d2297808c82f933e5193fc752398e02203f79890167b6eb885788fabb90aab1a3705f1e34a12664739ebcee85c8c1c65c\"}}"
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:01 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0MiwiaWF0IjoxNzgyNDg0NDQxLCJqdGkiOiI2NDRlZWRlMi0xZWM0LTRlNDItYTFlZS1iMDZkMzVjNjliMTgiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzQ6MDJaIn0.YXck6qFmujKRVJeR2_6EBmuCln47QGj7Vyg6-4lh9U3-6okXIvMgacy5hejUAVl-6EgR_F_f3zSlR0_53U5N4A\",\"permissions\":{\"00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233\":{\"m/\":\"ffffffff\"}}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchains",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0MiwiaWF0IjoxNzgyNDg0NDQxLCJqdGkiOiI2NDRlZWRlMi0xZWM0LTRlNDItYTFlZS1iMDZkMzVjNjliMTgiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzQ6MDJaIn0.YXck6qFmujKRVJeR2_6EBmuCln47QGj7Vyg6-4lh9U3-6okXIvMgacy5hejUAVl-6EgR_F_f3zSlR0_53U5N4A",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:01 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233\":{\"m/\":\"ffffffff\"}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0MiwiaWF0IjoxNzgyNDg0NDQxLCJqdGkiOiI2NDRlZWRlMi0xZWM0LTRlNDItYTFlZS1iMDZkMzVjNjliMTgiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzQ6MDJaIn0.YXck6qFmujKRVJeR2_6EBmuCln47QGj7Vyg6-4lh9U3-6okXIvMgacy5hejUAVl-6EgR_F_f3zSlR0_53U5N4A",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:01 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"m/\":\"0101010220f166bcfcdc4d36408d0fba0622db61f36f9c2aa579af28cc4fb8b57de71b49b206210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010110b005000102000006210365b8b5c293c88a9a92e76c972e2a701d4329ac9957087d6818cd18539c7dd4940510a27ad49c974cb99ac315b3e5597870460550828a0011cdbbcec16d4d99a232392476b8c1cb78dce4e860c7895458ec469e5e45b3437bad012247b1409879f098789d22e8220c5bf46db3bacb9d88efe62c9b5cf0dc95347618b63b04357f04a88f6b062102fcf7f06caa9cad9b66b24f3437d0a926ca138647fd6e95598b293824c5e6dc8503473045022100b6966fae40eec5314e5f79c0b1abe975728c59d4d8a172c07928bbf6aeb7efb3022034761b3d6eb6a9b622a6bf317754f5c6c8ba260138ea8351689440fcd490ea20\",\"m/16'\":\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c800000008000001080000000062102e4d26559702654f1d73fdc2c2ca8864a24e787ba835888da5f20062ccd67fbb2051022d4d24083021b23a405897f8ee8be9a0550abf072e72037ef826ca505b67288113296058a81900d35fd6c275b4061d9e5daf4a26744c3771c83cec1bfdccceec236fc1f3fb0ff3dce3ed5c860bcea2b9595f2a4709f96c7efd26a53dbc0c00b7a2e062102090a9e0d14223a123e02135110696fe514f325866511629eb92c4473dfff8e4d113a040f53796e6320696e7374616e636520310621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0104ffffffff12aa05106097251f481ce73a4155517c31c7e2af055019de01d731d72b1342c2d6e0ab68e8283023c8493c16582429eb4383c5308c1160c774ae3d3038eb74f72534fbef8d19547503090023831554513fd7a0ee1374fdcc29b0e491dc969f5ef14c38f3a7a50621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec062102c4f6cd3c601b3cabdfbb2584fc81171d55da209c45473b7e9fc8b3a466b98a5c0346304402207adaafd52abecbd56f24caea2a62bf41970815b22acdfcbe6062b3d0d08a72fd02207943cf2d14730931d5356660325849e9e009942e28c8be54228d104afd9592300101010220e565551a516e69d0d73036a30162b78bff1687cd0bcdf2e0be739ee769eb58ae06210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1010102113a040f53796e6320696e7374616e63652032062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b0060104ffffffff12aa0510b017f2f82f76fbe152c219d18278163e0550a6758ea19463616f5f513a6b5dfef1c3434f6a81f6265498aef6efb343ed2c1431d9d030ae575dc0d30f26c7cd0e0f61035ebeaf8be10331a1d6132b1fd6660c338b34400ec4ec2db677d5ba4a651c3b062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b006062102d7ef2c2c212f43de3df3120f02879d7e7efae7329f96044f2501535439824a31034630440220320342953b66a108d166c2e854512bbad259110de3bfbe651efc6c2c86d4a5c30220204175b1b33bbbfb25356add307237e1b6678331efdc94af169e8d40d840ed18\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233/derivation",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0MiwiaWF0IjoxNzgyNDg0NDQxLCJqdGkiOiI2NDRlZWRlMi0xZWM0LTRlNDItYTFlZS1iMDZkMzVjNjliMTgiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzQ6MDJaIn0.YXck6qFmujKRVJeR2_6EBmuCln47QGj7Vyg6-4lh9U3-6okXIvMgacy5hejUAVl-6EgR_F_f3zSlR0_53U5N4A",
+            "connection": "close",
+            "content-length": "1124",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c8000000080000011800000000621034439851b65a8a8670e6b57aaeb1735bc276634dc014f69152ba8bd8cf550610c05109670e7072dad995bd84d8b74034f0304055043c9e820ed171f2aa1452932fffce776cc1862720b0da1fd7a6f740e8a1f0a32089c46fce1bb0c8cf4c485756e816824805dc65f3df78832d77ccf6aeed68e1ce8f92640899ec06bd119bb7949df935e062103153b00fe9d979e263db26a24ead4c7d80163df473a4ba0533ef1f2d69f6928071136040b52696e67206d656d6265720621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b750104ffffffff12aa0510758495eb7201ee6d0b60073977544f3e0550b297af14d37f40c7ccacfbcc6dae122e90a497f28dbdbaacba4fd44ec529cdebc56b5a3c88a1a9acda92af303fd419540d868b9c646d84a3464d229270f09d6badd9038f6bf033fb09a871d8647ba27e0621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b75062103d0a0747aa0b55ffa04c23927666fa2904369e2945b34b6d138231b412bd0efac03463044022063520eb3505db188808837e16e0902c074397d00d77fda94de9be4bae214e96402204b2c6266750dc4771faadc3174612b61268c1fe7e7ed8debc6eab02c400d67ad\""
+        },
+        "response": {
+          "status": 204,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "date": "Fri, 26 Jun 2026 14:34:02 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains"
+          }
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/challenge",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:02 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"json\":{\"version\":0,\"challenge\":{\"data\":\"3aeedbd65bd9568fba791677c3024a41\",\"expiry\":\"2026-06-26T15:04:03Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"3046022100f40d32405d7be52c9416eb6022a3940b69ed54a0b690d4be989f95d11ea08816022100e9fee9b94fdf0b2083c6cad83dcd292b35c7802331499a0ab8da5834616f3de2\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"tlv\":\"01010702010012103aeedbd65bd9568fba791677c3024a4114010115483046022100f40d32405d7be52c9416eb6022a3940b69ed54a0b690d4be989f95d11ea08816022100e9fee9b94fdf0b2083c6cad83dcd292b35c7802331499a0ab8da5834616f3de216046a3e94e3202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/authenticate",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "content-length": "988",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "{\"challenge\":{\"version\":0,\"challenge\":{\"data\":\"3aeedbd65bd9568fba791677c3024a41\",\"expiry\":\"2026-06-26T15:04:03Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"3046022100f40d32405d7be52c9416eb6022a3940b69ed54a0b690d4be989f95d11ea08816022100e9fee9b94fdf0b2083c6cad83dcd292b35c7802331499a0ab8da5834616f3de2\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"signature\":{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec\"},\"signature\":\"3045022100bcc00fef48d4bb5e0de29590c3886848ab86f3235572260bb31e2e54e092492c02203a85977074a79a3004b37b92fc7c06d73bddf868e8b8cdd18e17c91a363bd973\",\"attestation\":\"0242303031363763653162353736336335653438306265306439353466333233616130623034663364616162393164386135326563663661373836646138633037323333\"}}"
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:02 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIyODc2MzUxYTU2MDk4NzRiYWU1MzgwZDc0ODI0YTZjMGE3NjIwYWQ5MzFlNDExMjlkYWNiMGFkZmFjYTI1MGVjIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0MywiaWF0IjoxNzgyNDg0NDQyLCJqdGkiOiI0YzVjY2JkZi1iYWFmLTQwYjAtYmUwMS02OTZiYmU5ZDlkYzUiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjAzWiJ9.yK1WG0wN5REdoWaterDFBU8uxvnf317LW3Fol54-9D7ZVw0OOTamnSXMlNbvpMTbouHMTJEQ0BF8i0XDyt2VbQ\",\"permissions\":{\"00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233\":{\"m/0'/16'/0'\":\"ffffffff\"}}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIyODc2MzUxYTU2MDk4NzRiYWU1MzgwZDc0ODI0YTZjMGE3NjIwYWQ5MzFlNDExMjlkYWNiMGFkZmFjYTI1MGVjIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0MywiaWF0IjoxNzgyNDg0NDQyLCJqdGkiOiI0YzVjY2JkZi1iYWFmLTQwYjAtYmUwMS02OTZiYmU5ZDlkYzUiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjAzWiJ9.yK1WG0wN5REdoWaterDFBU8uxvnf317LW3Fol54-9D7ZVw0OOTamnSXMlNbvpMTbouHMTJEQ0BF8i0XDyt2VbQ",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:02 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"m/\":\"0101010220f166bcfcdc4d36408d0fba0622db61f36f9c2aa579af28cc4fb8b57de71b49b206210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010110b005000102000006210365b8b5c293c88a9a92e76c972e2a701d4329ac9957087d6818cd18539c7dd4940510a27ad49c974cb99ac315b3e5597870460550828a0011cdbbcec16d4d99a232392476b8c1cb78dce4e860c7895458ec469e5e45b3437bad012247b1409879f098789d22e8220c5bf46db3bacb9d88efe62c9b5cf0dc95347618b63b04357f04a88f6b062102fcf7f06caa9cad9b66b24f3437d0a926ca138647fd6e95598b293824c5e6dc8503473045022100b6966fae40eec5314e5f79c0b1abe975728c59d4d8a172c07928bbf6aeb7efb3022034761b3d6eb6a9b622a6bf317754f5c6c8ba260138ea8351689440fcd490ea20\",\"m/16'\":\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c800000008000001080000000062102e4d26559702654f1d73fdc2c2ca8864a24e787ba835888da5f20062ccd67fbb2051022d4d24083021b23a405897f8ee8be9a0550abf072e72037ef826ca505b67288113296058a81900d35fd6c275b4061d9e5daf4a26744c3771c83cec1bfdccceec236fc1f3fb0ff3dce3ed5c860bcea2b9595f2a4709f96c7efd26a53dbc0c00b7a2e062102090a9e0d14223a123e02135110696fe514f325866511629eb92c4473dfff8e4d113a040f53796e6320696e7374616e636520310621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0104ffffffff12aa05106097251f481ce73a4155517c31c7e2af055019de01d731d72b1342c2d6e0ab68e8283023c8493c16582429eb4383c5308c1160c774ae3d3038eb74f72534fbef8d19547503090023831554513fd7a0ee1374fdcc29b0e491dc969f5ef14c38f3a7a50621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec062102c4f6cd3c601b3cabdfbb2584fc81171d55da209c45473b7e9fc8b3a466b98a5c0346304402207adaafd52abecbd56f24caea2a62bf41970815b22acdfcbe6062b3d0d08a72fd02207943cf2d14730931d5356660325849e9e009942e28c8be54228d104afd9592300101010220e565551a516e69d0d73036a30162b78bff1687cd0bcdf2e0be739ee769eb58ae06210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1010102113a040f53796e6320696e7374616e63652032062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b0060104ffffffff12aa0510b017f2f82f76fbe152c219d18278163e0550a6758ea19463616f5f513a6b5dfef1c3434f6a81f6265498aef6efb343ed2c1431d9d030ae575dc0d30f26c7cd0e0f61035ebeaf8be10331a1d6132b1fd6660c338b34400ec4ec2db677d5ba4a651c3b062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b006062102d7ef2c2c212f43de3df3120f02879d7e7efae7329f96044f2501535439824a31034630440220320342953b66a108d166c2e854512bbad259110de3bfbe651efc6c2c86d4a5c30220204175b1b33bbbfb25356add307237e1b6678331efdc94af169e8d40d840ed18\",\"m/17'\":\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c8000000080000011800000000621034439851b65a8a8670e6b57aaeb1735bc276634dc014f69152ba8bd8cf550610c05109670e7072dad995bd84d8b74034f0304055043c9e820ed171f2aa1452932fffce776cc1862720b0da1fd7a6f740e8a1f0a32089c46fce1bb0c8cf4c485756e816824805dc65f3df78832d77ccf6aeed68e1ce8f92640899ec06bd119bb7949df935e062103153b00fe9d979e263db26a24ead4c7d80163df473a4ba0533ef1f2d69f6928071136040b52696e67206d656d6265720621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b750104ffffffff12aa0510758495eb7201ee6d0b60073977544f3e0550b297af14d37f40c7ccacfbcc6dae122e90a497f28dbdbaacba4fd44ec529cdebc56b5a3c88a1a9acda92af303fd419540d868b9c646d84a3464d229270f09d6badd9038f6bf033fb09a871d8647ba27e0621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b75062103d0a0747aa0b55ffa04c23927666fa2904369e2945b34b6d138231b412bd0efac03463044022063520eb3505db188808837e16e0902c074397d00d77fda94de9be4bae214e96402204b2c6266750dc4771faadc3174612b61268c1fe7e7ed8debc6eab02c400d67ad\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/refresh",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIyODc2MzUxYTU2MDk4NzRiYWU1MzgwZDc0ODI0YTZjMGE3NjIwYWQ5MzFlNDExMjlkYWNiMGFkZmFjYTI1MGVjIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0MywiaWF0IjoxNzgyNDg0NDQyLCJqdGkiOiI0YzVjY2JkZi1iYWFmLTQwYjAtYmUwMS02OTZiYmU5ZDlkYzUiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjAzWiJ9.yK1WG0wN5REdoWaterDFBU8uxvnf317LW3Fol54-9D7ZVw0OOTamnSXMlNbvpMTbouHMTJEQ0BF8i0XDyt2VbQ",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:02 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIyODc2MzUxYTU2MDk4NzRiYWU1MzgwZDc0ODI0YTZjMGE3NjIwYWQ5MzFlNDExMjlkYWNiMGFkZmFjYTI1MGVjIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0MywiaWF0IjoxNzgyNDg0NDQyLCJqdGkiOiIyOTc0NDVkZi01NmU4LTRiOTQtOTZkOS1kZjE4N2VhY2E2YjEiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjAzWiJ9.MKNR_ZIaqVj0MXnMNwXcaVNLJ-4m6AiuDYyrDGa62Le0Nh4KXyRr5RiBsFzg9-YZtwR48l-BJsdttzlFLEHTsg\",\"permissions\":{\"00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233\":{\"m/0'/16'/0'\":\"ffffffff\"}}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233/commands",
+          "method": "PUT",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIyODc2MzUxYTU2MDk4NzRiYWU1MzgwZDc0ODI0YTZjMGE3NjIwYWQ5MzFlNDExMjlkYWNiMGFkZmFjYTI1MGVjIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0MywiaWF0IjoxNzgyNDg0NDQyLCJqdGkiOiIyOTc0NDVkZi01NmU4LTRiOTQtOTZkOS1kZjE4N2VhY2E2YjEiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjAzWiJ9.MKNR_ZIaqVj0MXnMNwXcaVNLJ-4m6AiuDYyrDGa62Le0Nh4KXyRr5RiBsFzg9-YZtwR48l-BJsdttzlFLEHTsg",
+            "connection": "close",
+            "content-length": "336",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "{\"path\":\"m/0'/16'/0'\",\"blocks\":[\"01010102205d1f25f95886955eebb7b081a6e8fd76ed83fd25ff818a116005942323bb7c950621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec01010113000347304502210083dd3ec8ced962e216010a130c76c1a5adaafbfe366f6721529a44df2e78988a022026aa3be9a833f6fc52b99cd4119f3067ac10a9bb2aee2c3b636fe94040bb48cd\"]}"
+        },
+        "response": {
+          "status": 204,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "date": "Fri, 26 Jun 2026 14:34:03 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains"
+          }
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/challenge",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:03 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"json\":{\"version\":0,\"challenge\":{\"data\":\"acb9f4a738b3ffebf77de8cb0299a14e\",\"expiry\":\"2026-06-26T15:04:04Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"304402203cdaa53cf0007d85816463df9b70dd58e3022d8ad9c095d76bc9965cee0cbe5c0220320f771ef6384abea0ea1ff42c48afbc8fb240fef66a0f9730dba3586d68e633\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"tlv\":\"0101070201001210acb9f4a738b3ffebf77de8cb0299a14e1401011546304402203cdaa53cf0007d85816463df9b70dd58e3022d8ad9c095d76bc9965cee0cbe5c0220320f771ef6384abea0ea1ff42c48afbc8fb240fef66a0f9730dba3586d68e63316046a3e94e4202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/authenticate",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "content-length": "984",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "{\"challenge\":{\"version\":0,\"challenge\":{\"data\":\"acb9f4a738b3ffebf77de8cb0299a14e\",\"expiry\":\"2026-06-26T15:04:04Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"304402203cdaa53cf0007d85816463df9b70dd58e3022d8ad9c095d76bc9965cee0cbe5c0220320f771ef6384abea0ea1ff42c48afbc8fb240fef66a0f9730dba3586d68e633\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"signature\":{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec\"},\"signature\":\"3045022100964c3d8f6c16b0c41d652b36e581b196a8e4ad2b1048cdefdc5c5c2a16a8cc6b02206b26d4d946c6141fd8fbbe1855e6201619e3a22020c8551b59ae8db124bd395b\",\"attestation\":\"0242303031363763653162353736336335653438306265306439353466333233616130623034663364616162393164386135326563663661373836646138633037323333\"}}"
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:03 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIyODc2MzUxYTU2MDk4NzRiYWU1MzgwZDc0ODI0YTZjMGE3NjIwYWQ5MzFlNDExMjlkYWNiMGFkZmFjYTI1MGVjIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NCwiaWF0IjoxNzgyNDg0NDQzLCJqdGkiOiJhYzQ2ZjNmMC1mYzI2LTQwMDctYjkyMy02NWExMjJkY2E3ZDUiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjA0WiJ9.0R1qOetyFZJJE1XfojOZGx_co32Vs3XWmhGwmo0GCdg-vqFmHXEdeQbHJfEUx9LevtSCwPLGOlVlVquKALbdYA\",\"permissions\":{\"00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233\":{\"m/0'/16'/0'\":\"ffffffff\"}}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIyODc2MzUxYTU2MDk4NzRiYWU1MzgwZDc0ODI0YTZjMGE3NjIwYWQ5MzFlNDExMjlkYWNiMGFkZmFjYTI1MGVjIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NCwiaWF0IjoxNzgyNDg0NDQzLCJqdGkiOiJhYzQ2ZjNmMC1mYzI2LTQwMDctYjkyMy02NWExMjJkY2E3ZDUiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjA0WiJ9.0R1qOetyFZJJE1XfojOZGx_co32Vs3XWmhGwmo0GCdg-vqFmHXEdeQbHJfEUx9LevtSCwPLGOlVlVquKALbdYA",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:03 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"m/\":\"0101010220f166bcfcdc4d36408d0fba0622db61f36f9c2aa579af28cc4fb8b57de71b49b206210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010110b005000102000006210365b8b5c293c88a9a92e76c972e2a701d4329ac9957087d6818cd18539c7dd4940510a27ad49c974cb99ac315b3e5597870460550828a0011cdbbcec16d4d99a232392476b8c1cb78dce4e860c7895458ec469e5e45b3437bad012247b1409879f098789d22e8220c5bf46db3bacb9d88efe62c9b5cf0dc95347618b63b04357f04a88f6b062102fcf7f06caa9cad9b66b24f3437d0a926ca138647fd6e95598b293824c5e6dc8503473045022100b6966fae40eec5314e5f79c0b1abe975728c59d4d8a172c07928bbf6aeb7efb3022034761b3d6eb6a9b622a6bf317754f5c6c8ba260138ea8351689440fcd490ea20\",\"m/16'\":\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c800000008000001080000000062102e4d26559702654f1d73fdc2c2ca8864a24e787ba835888da5f20062ccd67fbb2051022d4d24083021b23a405897f8ee8be9a0550abf072e72037ef826ca505b67288113296058a81900d35fd6c275b4061d9e5daf4a26744c3771c83cec1bfdccceec236fc1f3fb0ff3dce3ed5c860bcea2b9595f2a4709f96c7efd26a53dbc0c00b7a2e062102090a9e0d14223a123e02135110696fe514f325866511629eb92c4473dfff8e4d113a040f53796e6320696e7374616e636520310621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0104ffffffff12aa05106097251f481ce73a4155517c31c7e2af055019de01d731d72b1342c2d6e0ab68e8283023c8493c16582429eb4383c5308c1160c774ae3d3038eb74f72534fbef8d19547503090023831554513fd7a0ee1374fdcc29b0e491dc969f5ef14c38f3a7a50621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec062102c4f6cd3c601b3cabdfbb2584fc81171d55da209c45473b7e9fc8b3a466b98a5c0346304402207adaafd52abecbd56f24caea2a62bf41970815b22acdfcbe6062b3d0d08a72fd02207943cf2d14730931d5356660325849e9e009942e28c8be54228d104afd9592300101010220e565551a516e69d0d73036a30162b78bff1687cd0bcdf2e0be739ee769eb58ae06210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1010102113a040f53796e6320696e7374616e63652032062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b0060104ffffffff12aa0510b017f2f82f76fbe152c219d18278163e0550a6758ea19463616f5f513a6b5dfef1c3434f6a81f6265498aef6efb343ed2c1431d9d030ae575dc0d30f26c7cd0e0f61035ebeaf8be10331a1d6132b1fd6660c338b34400ec4ec2db677d5ba4a651c3b062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b006062102d7ef2c2c212f43de3df3120f02879d7e7efae7329f96044f2501535439824a31034630440220320342953b66a108d166c2e854512bbad259110de3bfbe651efc6c2c86d4a5c30220204175b1b33bbbfb25356add307237e1b6678331efdc94af169e8d40d840ed1801010102205d1f25f95886955eebb7b081a6e8fd76ed83fd25ff818a116005942323bb7c950621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec01010113000347304502210083dd3ec8ced962e216010a130c76c1a5adaafbfe366f6721529a44df2e78988a022026aa3be9a833f6fc52b99cd4119f3067ac10a9bb2aee2c3b636fe94040bb48cd\",\"m/17'\":\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c8000000080000011800000000621034439851b65a8a8670e6b57aaeb1735bc276634dc014f69152ba8bd8cf550610c05109670e7072dad995bd84d8b74034f0304055043c9e820ed171f2aa1452932fffce776cc1862720b0da1fd7a6f740e8a1f0a32089c46fce1bb0c8cf4c485756e816824805dc65f3df78832d77ccf6aeed68e1ce8f92640899ec06bd119bb7949df935e062103153b00fe9d979e263db26a24ead4c7d80163df473a4ba0533ef1f2d69f6928071136040b52696e67206d656d6265720621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b750104ffffffff12aa0510758495eb7201ee6d0b60073977544f3e0550b297af14d37f40c7ccacfbcc6dae122e90a497f28dbdbaacba4fd44ec529cdebc56b5a3c88a1a9acda92af303fd419540d868b9c646d84a3464d229270f09d6badd9038f6bf033fb09a871d8647ba27e0621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b75062103d0a0747aa0b55ffa04c23927666fa2904369e2945b34b6d138231b412bd0efac03463044022063520eb3505db188808837e16e0902c074397d00d77fda94de9be4bae214e96402204b2c6266750dc4771faadc3174612b61268c1fe7e7ed8debc6eab02c400d67ad\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/refresh",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIyODc2MzUxYTU2MDk4NzRiYWU1MzgwZDc0ODI0YTZjMGE3NjIwYWQ5MzFlNDExMjlkYWNiMGFkZmFjYTI1MGVjIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NCwiaWF0IjoxNzgyNDg0NDQzLCJqdGkiOiJhYzQ2ZjNmMC1mYzI2LTQwMDctYjkyMy02NWExMjJkY2E3ZDUiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjA0WiJ9.0R1qOetyFZJJE1XfojOZGx_co32Vs3XWmhGwmo0GCdg-vqFmHXEdeQbHJfEUx9LevtSCwPLGOlVlVquKALbdYA",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:03 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIyODc2MzUxYTU2MDk4NzRiYWU1MzgwZDc0ODI0YTZjMGE3NjIwYWQ5MzFlNDExMjlkYWNiMGFkZmFjYTI1MGVjIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NCwiaWF0IjoxNzgyNDg0NDQzLCJqdGkiOiIyZmFiZjdmYy1kOWE0LTRmY2YtYjIyNC03YTE3OTQ3NWJlODMiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjA0WiJ9.BbNWQC70VfVevjJJ7pIm3i-7gigoFeEX8ylMvW4qVplcnlDnG07EYRZFNuuUbPufnIRWNL7sCDPHyBYZiBL3Qg\",\"permissions\":{\"00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233\":{\"m/0'/16'/0'\":\"ffffffff\"}}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIyODc2MzUxYTU2MDk4NzRiYWU1MzgwZDc0ODI0YTZjMGE3NjIwYWQ5MzFlNDExMjlkYWNiMGFkZmFjYTI1MGVjIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NCwiaWF0IjoxNzgyNDg0NDQzLCJqdGkiOiIyZmFiZjdmYy1kOWE0LTRmY2YtYjIyNC03YTE3OTQ3NWJlODMiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjA0WiJ9.BbNWQC70VfVevjJJ7pIm3i-7gigoFeEX8ylMvW4qVplcnlDnG07EYRZFNuuUbPufnIRWNL7sCDPHyBYZiBL3Qg",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:03 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"m/\":\"0101010220f166bcfcdc4d36408d0fba0622db61f36f9c2aa579af28cc4fb8b57de71b49b206210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010110b005000102000006210365b8b5c293c88a9a92e76c972e2a701d4329ac9957087d6818cd18539c7dd4940510a27ad49c974cb99ac315b3e5597870460550828a0011cdbbcec16d4d99a232392476b8c1cb78dce4e860c7895458ec469e5e45b3437bad012247b1409879f098789d22e8220c5bf46db3bacb9d88efe62c9b5cf0dc95347618b63b04357f04a88f6b062102fcf7f06caa9cad9b66b24f3437d0a926ca138647fd6e95598b293824c5e6dc8503473045022100b6966fae40eec5314e5f79c0b1abe975728c59d4d8a172c07928bbf6aeb7efb3022034761b3d6eb6a9b622a6bf317754f5c6c8ba260138ea8351689440fcd490ea20\",\"m/16'\":\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c800000008000001080000000062102e4d26559702654f1d73fdc2c2ca8864a24e787ba835888da5f20062ccd67fbb2051022d4d24083021b23a405897f8ee8be9a0550abf072e72037ef826ca505b67288113296058a81900d35fd6c275b4061d9e5daf4a26744c3771c83cec1bfdccceec236fc1f3fb0ff3dce3ed5c860bcea2b9595f2a4709f96c7efd26a53dbc0c00b7a2e062102090a9e0d14223a123e02135110696fe514f325866511629eb92c4473dfff8e4d113a040f53796e6320696e7374616e636520310621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0104ffffffff12aa05106097251f481ce73a4155517c31c7e2af055019de01d731d72b1342c2d6e0ab68e8283023c8493c16582429eb4383c5308c1160c774ae3d3038eb74f72534fbef8d19547503090023831554513fd7a0ee1374fdcc29b0e491dc969f5ef14c38f3a7a50621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec062102c4f6cd3c601b3cabdfbb2584fc81171d55da209c45473b7e9fc8b3a466b98a5c0346304402207adaafd52abecbd56f24caea2a62bf41970815b22acdfcbe6062b3d0d08a72fd02207943cf2d14730931d5356660325849e9e009942e28c8be54228d104afd9592300101010220e565551a516e69d0d73036a30162b78bff1687cd0bcdf2e0be739ee769eb58ae06210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1010102113a040f53796e6320696e7374616e63652032062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b0060104ffffffff12aa0510b017f2f82f76fbe152c219d18278163e0550a6758ea19463616f5f513a6b5dfef1c3434f6a81f6265498aef6efb343ed2c1431d9d030ae575dc0d30f26c7cd0e0f61035ebeaf8be10331a1d6132b1fd6660c338b34400ec4ec2db677d5ba4a651c3b062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b006062102d7ef2c2c212f43de3df3120f02879d7e7efae7329f96044f2501535439824a31034630440220320342953b66a108d166c2e854512bbad259110de3bfbe651efc6c2c86d4a5c30220204175b1b33bbbfb25356add307237e1b6678331efdc94af169e8d40d840ed1801010102205d1f25f95886955eebb7b081a6e8fd76ed83fd25ff818a116005942323bb7c950621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec01010113000347304502210083dd3ec8ced962e216010a130c76c1a5adaafbfe366f6721529a44df2e78988a022026aa3be9a833f6fc52b99cd4119f3067ac10a9bb2aee2c3b636fe94040bb48cd\",\"m/17'\":\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c8000000080000011800000000621034439851b65a8a8670e6b57aaeb1735bc276634dc014f69152ba8bd8cf550610c05109670e7072dad995bd84d8b74034f0304055043c9e820ed171f2aa1452932fffce776cc1862720b0da1fd7a6f740e8a1f0a32089c46fce1bb0c8cf4c485756e816824805dc65f3df78832d77ccf6aeed68e1ce8f92640899ec06bd119bb7949df935e062103153b00fe9d979e263db26a24ead4c7d80163df473a4ba0533ef1f2d69f6928071136040b52696e67206d656d6265720621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b750104ffffffff12aa0510758495eb7201ee6d0b60073977544f3e0550b297af14d37f40c7ccacfbcc6dae122e90a497f28dbdbaacba4fd44ec529cdebc56b5a3c88a1a9acda92af303fd419540d868b9c646d84a3464d229270f09d6badd9038f6bf033fb09a871d8647ba27e0621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b75062103d0a0747aa0b55ffa04c23927666fa2904369e2945b34b6d138231b412bd0efac03463044022063520eb3505db188808837e16e0902c074397d00d77fda94de9be4bae214e96402204b2c6266750dc4771faadc3174612b61268c1fe7e7ed8debc6eab02c400d67ad\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/challenge",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:03 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"json\":{\"version\":0,\"challenge\":{\"data\":\"da5adb10d0e448d72d137c1fa76313f4\",\"expiry\":\"2026-06-26T15:04:04Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"3046022100b3fa4ae6f5166e58c9cf1092142876e4e44b9221c13bc82f6c1c31f7e15a4c43022100d99ae625fb25f8c44e363c8ac7f901dd0c0269876fd4671d636bd8becc646812\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"tlv\":\"0101070201001210da5adb10d0e448d72d137c1fa76313f414010115483046022100b3fa4ae6f5166e58c9cf1092142876e4e44b9221c13bc82f6c1c31f7e15a4c43022100d99ae625fb25f8c44e363c8ac7f901dd0c0269876fd4671d636bd8becc64681216046a3e94e4202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/authenticate",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "content-length": "988",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "{\"challenge\":{\"version\":0,\"challenge\":{\"data\":\"da5adb10d0e448d72d137c1fa76313f4\",\"expiry\":\"2026-06-26T15:04:04Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"3046022100b3fa4ae6f5166e58c9cf1092142876e4e44b9221c13bc82f6c1c31f7e15a4c43022100d99ae625fb25f8c44e363c8ac7f901dd0c0269876fd4671d636bd8becc646812\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"signature\":{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"02577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b006\"},\"signature\":\"30450221009bb4e58c2b36023de575dc2cc3cd2fbcceb48906d765f82ea349e36b8c5e8317022053da5295f1330d024b069ebf2cf86f7c44e98403b343e788f36614d4e64d26b3\",\"attestation\":\"0242303031363763653162353736336335653438306265306439353466333233616130623034663364616162393164386135326563663661373836646138633037323333\"}}"
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:03 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI1NzdlZWE1ODMyMWY3MjkzZWVlN2E1MzFjYmM3YzBhN2ZlMWJiYTM5ZTA4OTcxZWU1ODFhODQ5Yjg1MTNiMDA2IiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NCwiaWF0IjoxNzgyNDg0NDQzLCJqdGkiOiI0NzkyZjRjNC1hYTQwLTQ5YmMtYjU4Zi02OThmN2YzNTE4ZTMiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjA0WiJ9.zUxWKmbYvdbtiqrlXT_dsXH9jtp7cCzrgcFuaZaUqc7Vc4IbsoDdUuSkO74CeqoPkYuGnqC6gwN9pEiMp_WTlg\",\"permissions\":{\"00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233\":{\"m/0'/16'/0'\":\"ffffffff\"}}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI1NzdlZWE1ODMyMWY3MjkzZWVlN2E1MzFjYmM3YzBhN2ZlMWJiYTM5ZTA4OTcxZWU1ODFhODQ5Yjg1MTNiMDA2IiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NCwiaWF0IjoxNzgyNDg0NDQzLCJqdGkiOiI0NzkyZjRjNC1hYTQwLTQ5YmMtYjU4Zi02OThmN2YzNTE4ZTMiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjA0WiJ9.zUxWKmbYvdbtiqrlXT_dsXH9jtp7cCzrgcFuaZaUqc7Vc4IbsoDdUuSkO74CeqoPkYuGnqC6gwN9pEiMp_WTlg",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:03 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"m/\":\"0101010220f166bcfcdc4d36408d0fba0622db61f36f9c2aa579af28cc4fb8b57de71b49b206210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010110b005000102000006210365b8b5c293c88a9a92e76c972e2a701d4329ac9957087d6818cd18539c7dd4940510a27ad49c974cb99ac315b3e5597870460550828a0011cdbbcec16d4d99a232392476b8c1cb78dce4e860c7895458ec469e5e45b3437bad012247b1409879f098789d22e8220c5bf46db3bacb9d88efe62c9b5cf0dc95347618b63b04357f04a88f6b062102fcf7f06caa9cad9b66b24f3437d0a926ca138647fd6e95598b293824c5e6dc8503473045022100b6966fae40eec5314e5f79c0b1abe975728c59d4d8a172c07928bbf6aeb7efb3022034761b3d6eb6a9b622a6bf317754f5c6c8ba260138ea8351689440fcd490ea20\",\"m/16'\":\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c800000008000001080000000062102e4d26559702654f1d73fdc2c2ca8864a24e787ba835888da5f20062ccd67fbb2051022d4d24083021b23a405897f8ee8be9a0550abf072e72037ef826ca505b67288113296058a81900d35fd6c275b4061d9e5daf4a26744c3771c83cec1bfdccceec236fc1f3fb0ff3dce3ed5c860bcea2b9595f2a4709f96c7efd26a53dbc0c00b7a2e062102090a9e0d14223a123e02135110696fe514f325866511629eb92c4473dfff8e4d113a040f53796e6320696e7374616e636520310621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0104ffffffff12aa05106097251f481ce73a4155517c31c7e2af055019de01d731d72b1342c2d6e0ab68e8283023c8493c16582429eb4383c5308c1160c774ae3d3038eb74f72534fbef8d19547503090023831554513fd7a0ee1374fdcc29b0e491dc969f5ef14c38f3a7a50621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec062102c4f6cd3c601b3cabdfbb2584fc81171d55da209c45473b7e9fc8b3a466b98a5c0346304402207adaafd52abecbd56f24caea2a62bf41970815b22acdfcbe6062b3d0d08a72fd02207943cf2d14730931d5356660325849e9e009942e28c8be54228d104afd9592300101010220e565551a516e69d0d73036a30162b78bff1687cd0bcdf2e0be739ee769eb58ae06210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1010102113a040f53796e6320696e7374616e63652032062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b0060104ffffffff12aa0510b017f2f82f76fbe152c219d18278163e0550a6758ea19463616f5f513a6b5dfef1c3434f6a81f6265498aef6efb343ed2c1431d9d030ae575dc0d30f26c7cd0e0f61035ebeaf8be10331a1d6132b1fd6660c338b34400ec4ec2db677d5ba4a651c3b062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b006062102d7ef2c2c212f43de3df3120f02879d7e7efae7329f96044f2501535439824a31034630440220320342953b66a108d166c2e854512bbad259110de3bfbe651efc6c2c86d4a5c30220204175b1b33bbbfb25356add307237e1b6678331efdc94af169e8d40d840ed1801010102205d1f25f95886955eebb7b081a6e8fd76ed83fd25ff818a116005942323bb7c950621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec01010113000347304502210083dd3ec8ced962e216010a130c76c1a5adaafbfe366f6721529a44df2e78988a022026aa3be9a833f6fc52b99cd4119f3067ac10a9bb2aee2c3b636fe94040bb48cd\",\"m/17'\":\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c8000000080000011800000000621034439851b65a8a8670e6b57aaeb1735bc276634dc014f69152ba8bd8cf550610c05109670e7072dad995bd84d8b74034f0304055043c9e820ed171f2aa1452932fffce776cc1862720b0da1fd7a6f740e8a1f0a32089c46fce1bb0c8cf4c485756e816824805dc65f3df78832d77ccf6aeed68e1ce8f92640899ec06bd119bb7949df935e062103153b00fe9d979e263db26a24ead4c7d80163df473a4ba0533ef1f2d69f6928071136040b52696e67206d656d6265720621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b750104ffffffff12aa0510758495eb7201ee6d0b60073977544f3e0550b297af14d37f40c7ccacfbcc6dae122e90a497f28dbdbaacba4fd44ec529cdebc56b5a3c88a1a9acda92af303fd419540d868b9c646d84a3464d229270f09d6badd9038f6bf033fb09a871d8647ba27e0621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b75062103d0a0747aa0b55ffa04c23927666fa2904369e2945b34b6d138231b412bd0efac03463044022063520eb3505db188808837e16e0902c074397d00d77fda94de9be4bae214e96402204b2c6266750dc4771faadc3174612b61268c1fe7e7ed8debc6eab02c400d67ad\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/challenge",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:03 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"json\":{\"version\":0,\"challenge\":{\"data\":\"2b59ab01bee00762f8aea5f7ac4e8019\",\"expiry\":\"2026-06-26T15:04:04Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"304402206ca46a85dedb18ddef36fe89921135c8f86bcab8d70b331ed6ef47726a7c5b6b02206a1c9d95ee921df2fde5ce5166e9ea83c83f34a2a279c33afa9882e929997183\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"tlv\":\"01010702010012102b59ab01bee00762f8aea5f7ac4e80191401011546304402206ca46a85dedb18ddef36fe89921135c8f86bcab8d70b331ed6ef47726a7c5b6b02206a1c9d95ee921df2fde5ce5166e9ea83c83f34a2a279c33afa9882e92999718316046a3e94e4202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/authenticate",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "content-length": "982",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "{\"challenge\":{\"version\":0,\"challenge\":{\"data\":\"2b59ab01bee00762f8aea5f7ac4e8019\",\"expiry\":\"2026-06-26T15:04:04Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"304402206ca46a85dedb18ddef36fe89921135c8f86bcab8d70b331ed6ef47726a7c5b6b02206a1c9d95ee921df2fde5ce5166e9ea83c83f34a2a279c33afa9882e929997183\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"signature\":{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b75\"},\"signature\":\"30440220630410a81f22ff0dbc7a824facb88b6cebd2502158027617647f6fd063b34e8c02201a63ef303f0857540ca25f542cba67da7dde5f8cd3bce7b257ec654a995b9653\",\"attestation\":\"0242303031363763653162353736336335653438306265306439353466333233616130623034663364616162393164386135326563663661373836646138633037323333\"}}"
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:04 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIyY2M4NTQ0YTYyNWZhYTQ2ZDY3Y2JkNzM2OGUzODJiYTA4MTFhYTM2ZWY2YjM2MzA1YTk1NzMwN2Q1MzUxYjc1IiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NSwiaWF0IjoxNzgyNDg0NDQ0LCJqdGkiOiJjZTVjNTljYy00Y2E1LTQ2YjAtYmJiNS1kODM2M2Y1Y2I5ZWYiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNycvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjA1WiJ9.gfe54_YnjDNz8hMAV6bZ-7aYpX2LZuhRnLV9A456IHw9N3yYNasKFma8j02nsJ4MNtrTHoKkF-SxIYdEgd3QPQ\",\"permissions\":{\"00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233\":{\"m/0'/17'/0'\":\"ffffffff\"}}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIyY2M4NTQ0YTYyNWZhYTQ2ZDY3Y2JkNzM2OGUzODJiYTA4MTFhYTM2ZWY2YjM2MzA1YTk1NzMwN2Q1MzUxYjc1IiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NSwiaWF0IjoxNzgyNDg0NDQ0LCJqdGkiOiJjZTVjNTljYy00Y2E1LTQ2YjAtYmJiNS1kODM2M2Y1Y2I5ZWYiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNycvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjA1WiJ9.gfe54_YnjDNz8hMAV6bZ-7aYpX2LZuhRnLV9A456IHw9N3yYNasKFma8j02nsJ4MNtrTHoKkF-SxIYdEgd3QPQ",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:04 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"m/\":\"0101010220f166bcfcdc4d36408d0fba0622db61f36f9c2aa579af28cc4fb8b57de71b49b206210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010110b005000102000006210365b8b5c293c88a9a92e76c972e2a701d4329ac9957087d6818cd18539c7dd4940510a27ad49c974cb99ac315b3e5597870460550828a0011cdbbcec16d4d99a232392476b8c1cb78dce4e860c7895458ec469e5e45b3437bad012247b1409879f098789d22e8220c5bf46db3bacb9d88efe62c9b5cf0dc95347618b63b04357f04a88f6b062102fcf7f06caa9cad9b66b24f3437d0a926ca138647fd6e95598b293824c5e6dc8503473045022100b6966fae40eec5314e5f79c0b1abe975728c59d4d8a172c07928bbf6aeb7efb3022034761b3d6eb6a9b622a6bf317754f5c6c8ba260138ea8351689440fcd490ea20\",\"m/16'\":\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c800000008000001080000000062102e4d26559702654f1d73fdc2c2ca8864a24e787ba835888da5f20062ccd67fbb2051022d4d24083021b23a405897f8ee8be9a0550abf072e72037ef826ca505b67288113296058a81900d35fd6c275b4061d9e5daf4a26744c3771c83cec1bfdccceec236fc1f3fb0ff3dce3ed5c860bcea2b9595f2a4709f96c7efd26a53dbc0c00b7a2e062102090a9e0d14223a123e02135110696fe514f325866511629eb92c4473dfff8e4d113a040f53796e6320696e7374616e636520310621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0104ffffffff12aa05106097251f481ce73a4155517c31c7e2af055019de01d731d72b1342c2d6e0ab68e8283023c8493c16582429eb4383c5308c1160c774ae3d3038eb74f72534fbef8d19547503090023831554513fd7a0ee1374fdcc29b0e491dc969f5ef14c38f3a7a50621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec062102c4f6cd3c601b3cabdfbb2584fc81171d55da209c45473b7e9fc8b3a466b98a5c0346304402207adaafd52abecbd56f24caea2a62bf41970815b22acdfcbe6062b3d0d08a72fd02207943cf2d14730931d5356660325849e9e009942e28c8be54228d104afd9592300101010220e565551a516e69d0d73036a30162b78bff1687cd0bcdf2e0be739ee769eb58ae06210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1010102113a040f53796e6320696e7374616e63652032062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b0060104ffffffff12aa0510b017f2f82f76fbe152c219d18278163e0550a6758ea19463616f5f513a6b5dfef1c3434f6a81f6265498aef6efb343ed2c1431d9d030ae575dc0d30f26c7cd0e0f61035ebeaf8be10331a1d6132b1fd6660c338b34400ec4ec2db677d5ba4a651c3b062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b006062102d7ef2c2c212f43de3df3120f02879d7e7efae7329f96044f2501535439824a31034630440220320342953b66a108d166c2e854512bbad259110de3bfbe651efc6c2c86d4a5c30220204175b1b33bbbfb25356add307237e1b6678331efdc94af169e8d40d840ed1801010102205d1f25f95886955eebb7b081a6e8fd76ed83fd25ff818a116005942323bb7c950621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec01010113000347304502210083dd3ec8ced962e216010a130c76c1a5adaafbfe366f6721529a44df2e78988a022026aa3be9a833f6fc52b99cd4119f3067ac10a9bb2aee2c3b636fe94040bb48cd\",\"m/17'\":\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c8000000080000011800000000621034439851b65a8a8670e6b57aaeb1735bc276634dc014f69152ba8bd8cf550610c05109670e7072dad995bd84d8b74034f0304055043c9e820ed171f2aa1452932fffce776cc1862720b0da1fd7a6f740e8a1f0a32089c46fce1bb0c8cf4c485756e816824805dc65f3df78832d77ccf6aeed68e1ce8f92640899ec06bd119bb7949df935e062103153b00fe9d979e263db26a24ead4c7d80163df473a4ba0533ef1f2d69f6928071136040b52696e67206d656d6265720621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b750104ffffffff12aa0510758495eb7201ee6d0b60073977544f3e0550b297af14d37f40c7ccacfbcc6dae122e90a497f28dbdbaacba4fd44ec529cdebc56b5a3c88a1a9acda92af303fd419540d868b9c646d84a3464d229270f09d6badd9038f6bf033fb09a871d8647ba27e0621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b75062103d0a0747aa0b55ffa04c23927666fa2904369e2945b34b6d138231b412bd0efac03463044022063520eb3505db188808837e16e0902c074397d00d77fda94de9be4bae214e96402204b2c6266750dc4771faadc3174612b61268c1fe7e7ed8debc6eab02c400d67ad\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/challenge",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:04 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"json\":{\"version\":0,\"challenge\":{\"data\":\"5b6c0f233881c8eef0302e38e2cf4607\",\"expiry\":\"2026-06-26T15:04:05Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"3045022100a29e2e79b09ece4a5b3185829813a2ff3209e734a771224086dafac64eef727402204d69bc7561ba42749928e41156673d195a3135aa34cafc494108ca72cbc5cc7e\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"tlv\":\"01010702010012105b6c0f233881c8eef0302e38e2cf460714010115473045022100a29e2e79b09ece4a5b3185829813a2ff3209e734a771224086dafac64eef727402204d69bc7561ba42749928e41156673d195a3135aa34cafc494108ca72cbc5cc7e16046a3e94e5202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/authenticate",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "content-length": "1066",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "{\"challenge\":{\"version\":0,\"challenge\":{\"data\":\"5b6c0f233881c8eef0302e38e2cf4607\",\"expiry\":\"2026-06-26T15:04:05Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"3045022100a29e2e79b09ece4a5b3185829813a2ff3209e734a771224086dafac64eef727402204d69bc7561ba42749928e41156673d195a3135aa34cafc494108ca72cbc5cc7e\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"signature\":{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"0235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1\"},\"signature\":\"3044022004cb06e205f5cdca00510bac328a15ea8d8442900068da494d243ff5a326bee7022051c8d3b0c222a782bdbc5b6c07fab8053682fc0d1f30c721b6720a53cb6de19b\",\"attestation\":\"000021012103cce710b4ace62a3597e5b9853463b6bbc45a7d198bf7b698dd885c4fedf98f9d463044022070541798a3871822841638205a1daf119de5d3c2f32f5306e6c61b672d43062e0220543783e16dcc6bc4d2a98e4a1b90efeb9680aad2e2d0dbb3bbf7264a988e9adb\"}}"
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:05 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NiwiaWF0IjoxNzgyNDg0NDQ1LCJqdGkiOiI1YjM2ZTc4Mi0yZDM3LTQxNDktODcxOS0wZmJhZTE2NTgxOWYiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzQ6MDZaIn0.9D4Ht8HvuzwqfYgwohmdHFbXG9fw-TIuy7S8a7IyjtwDbXkZ3u_dwruxBpRK269xCDtfyhoaP8SwR6cmQkpRHg\",\"permissions\":{\"00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233\":{\"m/\":\"ffffffff\"}}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchains",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NiwiaWF0IjoxNzgyNDg0NDQ1LCJqdGkiOiI1YjM2ZTc4Mi0yZDM3LTQxNDktODcxOS0wZmJhZTE2NTgxOWYiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzQ6MDZaIn0.9D4Ht8HvuzwqfYgwohmdHFbXG9fw-TIuy7S8a7IyjtwDbXkZ3u_dwruxBpRK269xCDtfyhoaP8SwR6cmQkpRHg",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:05 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233\":{\"m/\":\"ffffffff\"}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NiwiaWF0IjoxNzgyNDg0NDQ1LCJqdGkiOiI1YjM2ZTc4Mi0yZDM3LTQxNDktODcxOS0wZmJhZTE2NTgxOWYiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzQ6MDZaIn0.9D4Ht8HvuzwqfYgwohmdHFbXG9fw-TIuy7S8a7IyjtwDbXkZ3u_dwruxBpRK269xCDtfyhoaP8SwR6cmQkpRHg",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:05 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"m/\":\"0101010220f166bcfcdc4d36408d0fba0622db61f36f9c2aa579af28cc4fb8b57de71b49b206210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010110b005000102000006210365b8b5c293c88a9a92e76c972e2a701d4329ac9957087d6818cd18539c7dd4940510a27ad49c974cb99ac315b3e5597870460550828a0011cdbbcec16d4d99a232392476b8c1cb78dce4e860c7895458ec469e5e45b3437bad012247b1409879f098789d22e8220c5bf46db3bacb9d88efe62c9b5cf0dc95347618b63b04357f04a88f6b062102fcf7f06caa9cad9b66b24f3437d0a926ca138647fd6e95598b293824c5e6dc8503473045022100b6966fae40eec5314e5f79c0b1abe975728c59d4d8a172c07928bbf6aeb7efb3022034761b3d6eb6a9b622a6bf317754f5c6c8ba260138ea8351689440fcd490ea20\",\"m/16'\":\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c800000008000001080000000062102e4d26559702654f1d73fdc2c2ca8864a24e787ba835888da5f20062ccd67fbb2051022d4d24083021b23a405897f8ee8be9a0550abf072e72037ef826ca505b67288113296058a81900d35fd6c275b4061d9e5daf4a26744c3771c83cec1bfdccceec236fc1f3fb0ff3dce3ed5c860bcea2b9595f2a4709f96c7efd26a53dbc0c00b7a2e062102090a9e0d14223a123e02135110696fe514f325866511629eb92c4473dfff8e4d113a040f53796e6320696e7374616e636520310621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0104ffffffff12aa05106097251f481ce73a4155517c31c7e2af055019de01d731d72b1342c2d6e0ab68e8283023c8493c16582429eb4383c5308c1160c774ae3d3038eb74f72534fbef8d19547503090023831554513fd7a0ee1374fdcc29b0e491dc969f5ef14c38f3a7a50621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec062102c4f6cd3c601b3cabdfbb2584fc81171d55da209c45473b7e9fc8b3a466b98a5c0346304402207adaafd52abecbd56f24caea2a62bf41970815b22acdfcbe6062b3d0d08a72fd02207943cf2d14730931d5356660325849e9e009942e28c8be54228d104afd9592300101010220e565551a516e69d0d73036a30162b78bff1687cd0bcdf2e0be739ee769eb58ae06210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce1010102113a040f53796e6320696e7374616e63652032062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b0060104ffffffff12aa0510b017f2f82f76fbe152c219d18278163e0550a6758ea19463616f5f513a6b5dfef1c3434f6a81f6265498aef6efb343ed2c1431d9d030ae575dc0d30f26c7cd0e0f61035ebeaf8be10331a1d6132b1fd6660c338b34400ec4ec2db677d5ba4a651c3b062102577eea58321f7293eee7a531cbc7c0a7fe1bba39e08971ee581a849b8513b006062102d7ef2c2c212f43de3df3120f02879d7e7efae7329f96044f2501535439824a31034630440220320342953b66a108d166c2e854512bbad259110de3bfbe651efc6c2c86d4a5c30220204175b1b33bbbfb25356add307237e1b6678331efdc94af169e8d40d840ed1801010102205d1f25f95886955eebb7b081a6e8fd76ed83fd25ff818a116005942323bb7c950621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec01010113000347304502210083dd3ec8ced962e216010a130c76c1a5adaafbfe366f6721529a44df2e78988a022026aa3be9a833f6fc52b99cd4119f3067ac10a9bb2aee2c3b636fe94040bb48cd\",\"m/17'\":\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c8000000080000011800000000621034439851b65a8a8670e6b57aaeb1735bc276634dc014f69152ba8bd8cf550610c05109670e7072dad995bd84d8b74034f0304055043c9e820ed171f2aa1452932fffce776cc1862720b0da1fd7a6f740e8a1f0a32089c46fce1bb0c8cf4c485756e816824805dc65f3df78832d77ccf6aeed68e1ce8f92640899ec06bd119bb7949df935e062103153b00fe9d979e263db26a24ead4c7d80163df473a4ba0533ef1f2d69f6928071136040b52696e67206d656d6265720621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b750104ffffffff12aa0510758495eb7201ee6d0b60073977544f3e0550b297af14d37f40c7ccacfbcc6dae122e90a497f28dbdbaacba4fd44ec529cdebc56b5a3c88a1a9acda92af303fd419540d868b9c646d84a3464d229270f09d6badd9038f6bf033fb09a871d8647ba27e0621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b75062103d0a0747aa0b55ffa04c23927666fa2904369e2945b34b6d138231b412bd0efac03463044022063520eb3505db188808837e16e0902c074397d00d77fda94de9be4bae214e96402204b2c6266750dc4771faadc3174612b61268c1fe7e7ed8debc6eab02c400d67ad\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233/derivation",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIzNWUyZDBiYjlkN2RhM2RmMjU4MjExZmVhYWEwOTIwMTYxMWY2MjAzZjdhODhjZWYwN2JhNzZhZWRhYWJkY2UxIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NiwiaWF0IjoxNzgyNDg0NDQ1LCJqdGkiOiI1YjM2ZTc4Mi0yZDM3LTQxNDktODcxOS0wZmJhZTE2NTgxOWYiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzQ6MDZaIn0.9D4Ht8HvuzwqfYgwohmdHFbXG9fw-TIuy7S8a7IyjtwDbXkZ3u_dwruxBpRK269xCDtfyhoaP8SwR6cmQkpRHg",
+            "connection": "close",
+            "content-length": "1132",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c800000008000001080000001062102ce6d1b891e00a3f747cb14739e083282471ecf42f1749f4bde5bff96b44536a3051006048700a47065cab5b7308393ccb12f0550e55d6f4782d05d39236c8f163470894a13f0ac284cd6ba012eb6c7845c26e09ab388e91f9e6c0b34087f708c5aaada7edf4d4aad65683f463e691f1f1e5d6a90831e791fba5c239baaf53521b711e4a0062102e741c74b785c676ebd5b8c1a5c8891f6d81fb7425ccc2ecaf91c22a7d252e640113a040f53796e6320696e7374616e636520310621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0104ffffffff12aa05107bdb1276fe162927c05538174548add00550a3b33b85d67cdc9164cfccb1d475c76649d1938b5085c14f61d3065507c3348b84457d04c6e61e61edb12b8fc5f710dd6df8cee93f551d342a6a412f99c286bdc684a72866adeb3837c8a6e95ca9071b0621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0621036782b97e4bf6b949c77433fde40a4fcab1527e639b4cd8e90c6c06307f7d23620346304402200893e3e0b069bbc0147d09a97d9b3e4a5e05464a8bf5aed4087f1a389e83eaf6022055668e4916e80374e692d2aea53e053410a46705ab63f8dd8f127c8d5738dc32\""
+        },
+        "response": {
+          "status": 204,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "date": "Fri, 26 Jun 2026 14:34:06 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains"
+          }
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/challenge",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:06 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"json\":{\"version\":0,\"challenge\":{\"data\":\"78e7a6b4842fbcc329d4efdfd879e684\",\"expiry\":\"2026-06-26T15:04:07Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"30450221009b9a5b4f37b09df40e1fe364300f37de10e218459a38b848e324e7d95f4b6d4602207a34041726694cb64a65bf7d0b654dac7abd1b971285934203f982784579c6fb\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"tlv\":\"010107020100121078e7a6b4842fbcc329d4efdfd879e684140101154730450221009b9a5b4f37b09df40e1fe364300f37de10e218459a38b848e324e7d95f4b6d4602207a34041726694cb64a65bf7d0b654dac7abd1b971285934203f982784579c6fb16046a3e94e7202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/authenticate",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "content-length": "984",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "{\"challenge\":{\"version\":0,\"challenge\":{\"data\":\"78e7a6b4842fbcc329d4efdfd879e684\",\"expiry\":\"2026-06-26T15:04:07Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"30450221009b9a5b4f37b09df40e1fe364300f37de10e218459a38b848e324e7d95f4b6d4602207a34041726694cb64a65bf7d0b654dac7abd1b971285934203f982784579c6fb\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"signature\":{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec\"},\"signature\":\"3044022002b7ae69add75da8ee273888260213a5ac374bc2a7d725977e880f951af093550220353c1651a23e1f751acf037c0b6c36fbc14d4fb0664b7123acad3bf2cbf85727\",\"attestation\":\"0242303031363763653162353736336335653438306265306439353466333233616130623034663364616162393164386135326563663661373836646138633037323333\"}}"
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:06 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIyODc2MzUxYTU2MDk4NzRiYWU1MzgwZDc0ODI0YTZjMGE3NjIwYWQ5MzFlNDExMjlkYWNiMGFkZmFjYTI1MGVjIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NywiaWF0IjoxNzgyNDg0NDQ2LCJqdGkiOiJkMjg5NzZkZi1jYTUwLTRjNDMtOTg0MC1mMmJiYTk5YWExM2IiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNicvMSciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjA3WiJ9.8kDZic0btlNPvghwgFZyU2F-0sFtM2HdqXKQ1NXQxJhrrV1LOiKCwt4gx6PO4HDej4LKxVzLWIYtQoNdpeFtXg\",\"permissions\":{\"00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233\":{\"m/0'/16'/1'\":\"ffffffff\"}}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIyODc2MzUxYTU2MDk4NzRiYWU1MzgwZDc0ODI0YTZjMGE3NjIwYWQ5MzFlNDExMjlkYWNiMGFkZmFjYTI1MGVjIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NywiaWF0IjoxNzgyNDg0NDQ2LCJqdGkiOiJkMjg5NzZkZi1jYTUwLTRjNDMtOTg0MC1mMmJiYTk5YWExM2IiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNicvMSciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjA3WiJ9.8kDZic0btlNPvghwgFZyU2F-0sFtM2HdqXKQ1NXQxJhrrV1LOiKCwt4gx6PO4HDej4LKxVzLWIYtQoNdpeFtXg",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:06 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"m/\":\"0101010220f166bcfcdc4d36408d0fba0622db61f36f9c2aa579af28cc4fb8b57de71b49b206210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010110b005000102000006210365b8b5c293c88a9a92e76c972e2a701d4329ac9957087d6818cd18539c7dd4940510a27ad49c974cb99ac315b3e5597870460550828a0011cdbbcec16d4d99a232392476b8c1cb78dce4e860c7895458ec469e5e45b3437bad012247b1409879f098789d22e8220c5bf46db3bacb9d88efe62c9b5cf0dc95347618b63b04357f04a88f6b062102fcf7f06caa9cad9b66b24f3437d0a926ca138647fd6e95598b293824c5e6dc8503473045022100b6966fae40eec5314e5f79c0b1abe975728c59d4d8a172c07928bbf6aeb7efb3022034761b3d6eb6a9b622a6bf317754f5c6c8ba260138ea8351689440fcd490ea20\",\"m/16'\":\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c800000008000001080000001062102ce6d1b891e00a3f747cb14739e083282471ecf42f1749f4bde5bff96b44536a3051006048700a47065cab5b7308393ccb12f0550e55d6f4782d05d39236c8f163470894a13f0ac284cd6ba012eb6c7845c26e09ab388e91f9e6c0b34087f708c5aaada7edf4d4aad65683f463e691f1f1e5d6a90831e791fba5c239baaf53521b711e4a0062102e741c74b785c676ebd5b8c1a5c8891f6d81fb7425ccc2ecaf91c22a7d252e640113a040f53796e6320696e7374616e636520310621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0104ffffffff12aa05107bdb1276fe162927c05538174548add00550a3b33b85d67cdc9164cfccb1d475c76649d1938b5085c14f61d3065507c3348b84457d04c6e61e61edb12b8fc5f710dd6df8cee93f551d342a6a412f99c286bdc684a72866adeb3837c8a6e95ca9071b0621022876351a5609874bae5380d74824a6c0a7620ad931e41129dacb0adfaca250ec0621036782b97e4bf6b949c77433fde40a4fcab1527e639b4cd8e90c6c06307f7d23620346304402200893e3e0b069bbc0147d09a97d9b3e4a5e05464a8bf5aed4087f1a389e83eaf6022055668e4916e80374e692d2aea53e053410a46705ab63f8dd8f127c8d5738dc32\",\"m/17'\":\"0101010220167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c0723306210235e2d0bb9d7da3df258211feaaa09201611f6203f7a88cef07ba76aedaabdce101010315b8050c8000000080000011800000000621034439851b65a8a8670e6b57aaeb1735bc276634dc014f69152ba8bd8cf550610c05109670e7072dad995bd84d8b74034f0304055043c9e820ed171f2aa1452932fffce776cc1862720b0da1fd7a6f740e8a1f0a32089c46fce1bb0c8cf4c485756e816824805dc65f3df78832d77ccf6aeed68e1ce8f92640899ec06bd119bb7949df935e062103153b00fe9d979e263db26a24ead4c7d80163df473a4ba0533ef1f2d69f6928071136040b52696e67206d656d6265720621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b750104ffffffff12aa0510758495eb7201ee6d0b60073977544f3e0550b297af14d37f40c7ccacfbcc6dae122e90a497f28dbdbaacba4fd44ec529cdebc56b5a3c88a1a9acda92af303fd419540d868b9c646d84a3464d229270f09d6badd9038f6bf033fb09a871d8647ba27e0621022cc8544a625faa46d67cbd7368e382ba0811aa36ef6b36305a957307d5351b75062103d0a0747aa0b55ffa04c23927666fa2904369e2945b34b6d138231b412bd0efac03463044022063520eb3505db188808837e16e0902c074397d00d77fda94de9be4bae214e96402204b2c6266750dc4771faadc3174612b61268c1fe7e7ed8debc6eab02c400d67ad\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/refresh",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI1NzdlZWE1ODMyMWY3MjkzZWVlN2E1MzFjYmM3YzBhN2ZlMWJiYTM5ZTA4OTcxZWU1ODFhODQ5Yjg1MTNiMDA2IiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NCwiaWF0IjoxNzgyNDg0NDQzLCJqdGkiOiI0NzkyZjRjNC1hYTQwLTQ5YmMtYjU4Zi02OThmN2YzNTE4ZTMiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjA0WiJ9.zUxWKmbYvdbtiqrlXT_dsXH9jtp7cCzrgcFuaZaUqc7Vc4IbsoDdUuSkO74CeqoPkYuGnqC6gwN9pEiMp_WTlg",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:06 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI1NzdlZWE1ODMyMWY3MjkzZWVlN2E1MzFjYmM3YzBhN2ZlMWJiYTM5ZTA4OTcxZWU1ODFhODQ5Yjg1MTNiMDA2IiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NywiaWF0IjoxNzgyNDg0NDQ2LCJqdGkiOiJmODE3NzEyMC1hMzA1LTQ2ZTMtYmIzNC0yOThlMjU0Y2VhODciLCJwZXJtaXNzaW9ucyI6e30sImRldmljZSI6ZmFsc2UsInJlZnJlc2hFeHBpcmF0aW9uIjoiMjAyNi0wNi0yNlQxNTozNDowNFoifQ.vFq01f0GsBhXfiWY3mK7lLmLQjsiwCObwIrkCA3d9mHDWH7KcmGDD-2v204uZ877SrBJe_qGhleOcuQr9WkYyw\",\"permissions\":{}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI1NzdlZWE1ODMyMWY3MjkzZWVlN2E1MzFjYmM3YzBhN2ZlMWJiYTM5ZTA4OTcxZWU1ODFhODQ5Yjg1MTNiMDA2IiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NywiaWF0IjoxNzgyNDg0NDQ2LCJqdGkiOiJmODE3NzEyMC1hMzA1LTQ2ZTMtYmIzNC0yOThlMjU0Y2VhODciLCJwZXJtaXNzaW9ucyI6e30sImRldmljZSI6ZmFsc2UsInJlZnJlc2hFeHBpcmF0aW9uIjoiMjAyNi0wNi0yNlQxNTozNDowNFoifQ.vFq01f0GsBhXfiWY3mK7lLmLQjsiwCObwIrkCA3d9mHDWH7KcmGDD-2v204uZ877SrBJe_qGhleOcuQr9WkYyw",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 401,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:06 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"time\":\"2026-06-26T14:34:06.902192Z\",\"cause\":\"JWT contains no permission\",\"status\":401,\"type\":\"UNAUTHORIZED\",\"message\":\"Unauthorized: JWT contains no permission\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00167ce1b5763c5e480be0d954f323aa0b04f3daab91d8a52ecf6a786da8c07233",
+          "method": "DELETE",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDIyODc2MzUxYTU2MDk4NzRiYWU1MzgwZDc0ODI0YTZjMGE3NjIwYWQ5MzFlNDExMjlkYWNiMGFkZmFjYTI1MGVjIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc0NywiaWF0IjoxNzgyNDg0NDQ2LCJqdGkiOiJkMjg5NzZkZi1jYTUwLTRjNDMtOTg0MC1mMmJiYTk5YWExM2IiLCJwZXJtaXNzaW9ucyI6eyIwMDE2N2NlMWI1NzYzYzVlNDgwYmUwZDk1NGYzMjNhYTBiMDRmM2RhYWI5MWQ4YTUyZWNmNmE3ODZkYThjMDcyMzMiOnsibS8wJy8xNicvMSciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjA3WiJ9.8kDZic0btlNPvghwgFZyU2F-0sFtM2HdqXKQ1NXQxJhrrV1LOiKCwt4gx6PO4HDej4LKxVzLWIYtQoNdpeFtXg",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": ""
+        },
+        "response": {
+          "status": 204,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "date": "Fri, 26 Jun 2026 14:34:07 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/libs/ledger-key-ring-protocol/mocks/scenarios/destroyLastApplicationDestroysTrustchain.json
+++ b/libs/ledger-key-ring-protocol/mocks/scenarios/destroyLastApplicationDestroysTrustchain.json
@@ -1,0 +1,668 @@
+{
+  "apdus": "=> e0050000c3010107020100121082544f240411e680c8dc5aca12d382121401011547304502202afdc88023ac84ce50746894c1a0d5ae1483d12f2f8a92cf70a54f3f6cc52409022100b5f38d2199d54ddab7713e4ee3edbac633a93a46e1e6add2e39cd5c850b0fa6816046a3e94e9202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\n<= 00210121028f47628cd48b351a7a2761b820ec2de3cb5a2de12ae0c68a0cff4c3bb2332d4a473045022100c801c52dc4254fc3256b9950cc981e9fb427939826c699045c58ea89d2cf232b02200ae021d2562fd66d412cc1e26cf30c858eb29dc29f8c77dd98631854208f0ccb000021012103cce710b4ace62a3597e5b9853463b6bbc45a7d198bf7b698dd885c4fedf98f9d463044022000bd629dd8639c023899ef8aa372ab6445825d5e0644e7596902bc7d8d766646022048528575246a1d58667041ea1ab909eea75eda649970112ed34c53a2de45ef629000\n=> e00600002102f7a6eee7e6503bddfcf0ac494fff54d1dc2cb8836a6a2ead6cb91443e1456d26\n<= 9000\n=> e00700004b0101010220ad95d3536069ea05d44dfa96d0d937d6a6593f9cb65b82deb7a95b0b4647b69a0621030000000000000000000000000000000000000000000000000000000000000000010101\n<= 0010d06e12b5eb3a7d0638630172b2b5cdab8131797b073be2cdd2065ee5f2c0a9a691334fefc48272bcf1eda64c893835c89a8262f8a6505b3af5b3ad6985385c1b57bdec9000\n=> e0070100a210a005000102000006210000000000000000000000000000000000000000000000000000000000000000000510000000000000000000000000000000000540000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000621000000000000000000000000000000000000000000000000000000000000000000\n<= 00106c3e86d0ed2fed727ffb2a06d8c5d8a882609555d6718f86106bb906385611ef05a3892773452ca5cfeeba51acdd62dbe3ab924c168268c676dba569c33c5c94363f1d6289819fb711757ec64fe54a4bc65efb478380f8f2bb6dbbc7882880a10714e946ce673c293a903243584f91cbd7d90321024a6c3946cb5146ea25bf67097ce87f366c678ddf1b6c0ac3009edf8edde00aa704104c726f28a0480e80976a22ef5e713b13052102be3f54506f01e4cd4207fa1e04d72c748126863b69cdb252fe94dd87364de64e9000\n=> e007020000\n<= 463044022044252801fb9f40a25731bcaad6984db1e174925d136ed238f8a76760151b05fb02205fd84515a2f2a88c62e598d153796aa092b4a34c74fdcabf7f8084187f74fe3a0002ddf7ad5bb242192396f06cd223c5a6c34ed2e45c0725526ad0a8aa42e5b1ee129000\n=> e00600002102d075a1d6618f5f5207cd3cdadf24ed14e286ce7e288644dc189a741538ef2e36\n<= 9000\n=> e00800004b0101010220ad95d3536069ea05d44dfa96d0d937d6a6593f9cb65b82deb7a95b0b4647b69a0621028f47628cd48b351a7a2761b820ec2de3cb5a2de12ae0c68a0cff4c3bb2332d4a010101\n<= 9000\n=> e0080101b210b0050001020000062102be3f54506f01e4cd4207fa1e04d72c748126863b69cdb252fe94dd87364de64e05104c726f28a0480e80976a22ef5e713b130550c42111c04ab5c8618650631da9b33d6302327db47e4da308c2d7fdd2ea4e502814b43fdc216bc5285c39c154698caa3f93f4323c91942ec355f3767466ad8a9882fb420bb979bcb405e29270b4a2dfad0621024a6c3946cb5146ea25bf67097ce87f366c678ddf1b6c0ac3009edf8edde00aa7\n<= 9000\n=> e00802004803463044022044252801fb9f40a25731bcaad6984db1e174925d136ed238f8a76760151b05fb02205fd84515a2f2a88c62e598d153796aa092b4a34c74fdcabf7f8084187f74fe3a\n<= 9000\n=> e00700004b0101010220c25575543a800b9eee0b0541cbe7a69e69048545f369311562f0eb9c69a9d3180621030000000000000000000000000000000000000000000000000000000000000000010103\n<= 00102292381c75a0827b70d434f2c1443ab48131d39bb1bc175450f1a7f59aa934f7712f8d8ca4d289cb726d89a597ff1da25843065b004d93267780ed1049a2f121ca3aaa9000\n=> e0070100181516050c8000000080000010800000000600050005000600\n<= 00106ca1954f94795134ecd1506386eb53a982604c6922d05b67b216e0348b40548f2c68f211e021166f9bba18a78a502c45b826a2befa5b9f20f09555a4c3297ae89e367794c2193b643d0331a68d46c85b14fc06742d9c582665f67ba41a6490a2b890e8ceae4b36c8732838c4cbc68c2dae05032102cf30210425398c8f2cc14f6657663a302b45cee0bf8e6c5be26dc1da0280603204107e8bc5f32b476e9b1ca38ddde7c8925305210277f4d0f2328e5bb19c2b87667986b695120ab9b75c91970f188630a3a521b54b9000\n=> e0070100381136040b536f6c65206d656d62657206210300ca023ba0f472f50d4d66bf4cc07dc87594407a925a4aacfcc000ab36b04b1e0104ffffffff\n<= 0010744728543027ac2cff2078222a5e9d2d86440e0fef29d70987eb56fa957d1f729ccfc688a540a03f9e5861a5d4a398e2fe9b8b1e874c8c3c531d563c119345d7bf954f9b9eeecafdc759ded89d243e92948e8c60c2a89000\n=> e00701002b12290500050006210300ca023ba0f472f50d4d66bf4cc07dc87594407a925a4aacfcc000ab36b04b1e0600\n<= 00106f4e922cd1687ae8088ad67cd1fed0028260971df80e8a52f8f9e084483f8fc9844437792e1eb7e0d9cc23d1384a750d1af5416c41aa0de89aed537d32e12197eb255262f99e9b160d873d60c5ea7e2a6bea3fdfffe0774dadc6952dd66c24df99d1e529bb7b6ec7740d7e121726895a749a032103dec41596b34664fbf8057e36ca2225219c19dee7217a4c35060b0fe63ba90d730410267d2e259da648c705e5f412b205132186209084c9e9d71f82bbb332d254af14d05d05cf880c7138b8ec03b1c8f9799b2a0b9000\n=> e007020000\n<= 46304402203f296555658145096e70e05669d650f8016f292b09f2a4a749db13afbdf38f470220447d3bb8ff5a5b2449264ca2a4f7731584d55046107dbd6e090a01309aa953260103b745f4be667cb01999de7c26949194592d6016a61bc108c9b14893d06b255a279000\n=> e0050000c30101070201001210385a88c534ca500680c533b472269bd81401011547304502204ec2b746ebfd7e4cc4a4830388c2197c24f01acad4a8ecec6fe6de534d9b3e1c022100eb60a0299183d125a0292124b3477f35fd88a5c76b0252bd8f2e3bdad47df8f216046a3e94ed202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\n<= 00210121028f47628cd48b351a7a2761b820ec2de3cb5a2de12ae0c68a0cff4c3bb2332d4a473045022100bda21bdd309f8b171b040bf36c4c37884c88eabc964a143b8e822aebc99ba56202203fdadb6c226774eecb4753ded128f8a6c18354e1b5445ff955509292297c3e92000021012103cce710b4ace62a3597e5b9853463b6bbc45a7d198bf7b698dd885c4fedf98f9d473045022100903635c4975309cebf9787fddffeadfa2be2c60218c34375601df819bce7cb4f02207b58c98f89d0a63bd83537d679038b0d5cb33b8b623558ce8f095e82479ffaf79000\n=> e0060000210245e5538d429ec478d7ad63fb4a68f3f1f423f6e3db43d947b77b11a349c96b17\n<= 9000\n=> e00700004b01010102201fe9b5bf971b8f51a3b1bb2f15fa65fb0eca69ce1154b09db75033de09f1b1730621030000000000000000000000000000000000000000000000000000000000000000010101\n<= 001017b24129b9762275e7ee3fb720dc990d81312c9dff911b40ae0a6cacd51ac77cef571363e41caf9ac260ac8f79bb1a89edfca2c350f72cd0b6ff70c9444a7624351e409000\n=> e0070100a210a005000102000006210000000000000000000000000000000000000000000000000000000000000000000510000000000000000000000000000000000540000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000621000000000000000000000000000000000000000000000000000000000000000000\n<= 0010ba7b9882625932a622fece8a3a2ffc518260cc077d5e7a44ae4f444c278da868afcae5b60c90a167e62f2c0cd19fd3c6a60a227e7e0740007401475b29c18af25f47136ba4fc518966230ea036c970cca6c613615ffeddd0871261526544906d3812cdb50bfb3e52aa3155a4f98a76eeca6403210336169eeb3931462eb4824a7fa6e736fb9a5303b174b82e168c3f89181eca1228041058380cf7253d42d12185de8a797d9faa052102450dd8d4ffb51f8cda156e2ea89f1079ae35b00cc21faff2e8b995b64c43191d9000\n=> e007020000\n<= 473045022100cfb98318102baa332abcec7aefba367d352fd243e83f48fad27e31395caa95b702205db71ac1f15252a4e41fd895933ce4b0734f1bf85c41211f82b769ed96efb7bc00039dc072b0dee5e127aa98707fccf9008026bd28555c552f9eba7aeab1ab5b375d9000\n=> e00600002103ca05d498fa04f6f350c81175c80b8c204ae6a51d2d723853fe574eab1981b18c\n<= 9000\n=> e00800004b01010102201fe9b5bf971b8f51a3b1bb2f15fa65fb0eca69ce1154b09db75033de09f1b1730621028f47628cd48b351a7a2761b820ec2de3cb5a2de12ae0c68a0cff4c3bb2332d4a010101\n<= 9000\n=> e0080101b210b0050001020000062102450dd8d4ffb51f8cda156e2ea89f1079ae35b00cc21faff2e8b995b64c43191d051058380cf7253d42d12185de8a797d9faa0550a24d97685b6d77d2f59de31159e3dbd5c1d9d1156d225f7e5144746ae1e3918c25ea9d2433a30314d5e65b803dd73ec854bb72fe365cd1a103a32d942685a7e51908e65339694c5860d9a4210256a4e306210336169eeb3931462eb4824a7fa6e736fb9a5303b174b82e168c3f89181eca1228\n<= 9000\n=> e00802004903473045022100cfb98318102baa332abcec7aefba367d352fd243e83f48fad27e31395caa95b702205db71ac1f15252a4e41fd895933ce4b0734f1bf85c41211f82b769ed96efb7bc\n<= 9000\n=> e00700004b0101010220f3b855867788423941d65888e27015f28b8fc90b54349e743c0b9b581eded68d0621030000000000000000000000000000000000000000000000000000000000000000010103\n<= 00102e734e6e4950b24acdf8fafe0d007b0d8131d06a3f0f2c9910e0c579f7e4ad3414fd9c98da9c7dd8e8503400fb9bfab85236d103e2ba33a3ead5a7aa79af98bba60b4e9000\n=> e0070100181516050c8000000080000010800000000600050005000600\n<= 001072db764aa064666410908ca261aab98f8260db1d6bc4c7195dcfecc4fd615d9ac35d20849ffa8a0a69fc095f99388c01fe98720b119c8bbd8cce0d8bad7cd6947d157adf7723d5a74e1843deea40250351d5d8a461b20fd602ba3d8096e75441afd1b7570741e4396aafd2ab51e4736871470321039944e0ebf0415ad7ab8db75e6c719d61841500b4e195f547cab98663c9b7dba304101d08fe6658b0b025a8ab24b5ab9fc21d0521032fbdb53d7b4446a5d26b3252a685bb8185953bfdbb9bc26becce5a831bf1e9779000\n=> e0070100381136040b536f6c65206d656d62657206210300ca023ba0f472f50d4d66bf4cc07dc87594407a925a4aacfcc000ab36b04b1e0104ffffffff\n<= 00106f71d203870d4bd01b5bf1463805629c86442eb208cd8e4233107cc74e5ee6958b5e2a059cbcb5219038503f7dce3ff5aff677c2e16dcf0b98e769902c3d2b42c005309702a8fe9d4552d244431544bdb9a5372c96659000\n=> e00701002b12290500050006210300ca023ba0f472f50d4d66bf4cc07dc87594407a925a4aacfcc000ab36b04b1e0600\n<= 00102aada76e1729fd15ca79aa39ea7d3d71826012502b46e4d3d61b0059f301f335966e32fa81872cc8b7647db74024bb087f9bca93b6b043526a3da8ed85185a5e6d6d5a4f41444e0abe0a9f9fd6ac137e1d0d7c94004e141344590425aacd6b1242a30a0b4dd4f2e3cc963cde48605021234d032102133712720b3f060406522b8a53d583d230587f2c4b539a86a58fa0fee377c16104108a8842a6e333ec1b384eb8aee83ac3128620e8573ff817a55806d0e0e56aecdfe9b5cc96033601fca94cbd4b42a6b3957be09000\n=> e007020000\n<= 46304402207080834699d596a680295a173c48811e2c55aefa69aa246c9537e1fc514dc41c02206afa71bcf5de4ceb0ffdd7d67fd30b1fca8f91e6dee9ea93251d1a8ec919831801020431f41e5d56ee55c67243be3b1ccdc95dca4b781d4d7c7c4e48f4b1ff99a7789000\n",
+  "crypto": {
+    "randomBytesOutputs": [
+      "4820dc91605c9cbf539b6f976e46cff12c9beb23eb1950f94bfb4870fac14cfb",
+      "ad95d3536069ea05d44dfa96d0d937d6a6593f9cb65b82deb7a95b0b4647b69a",
+      "c9787d9cb6483dd229beff679efb3acbb58eb0d44309ad7bad696db56509af9e",
+      "1fe9b5bf971b8f51a3b1bb2f15fa65fb0eca69ce1154b09db75033de09f1b173"
+    ],
+    "randomKeypairOutputs": [
+      "7785f9364db409a74c915b0c52c5e9d9443d77f8b68a73a3034660614f5a145d",
+      "e2c600e1eafa5bf063714e47f6f91123973f4ae6460f17ee85e5dcccf3973c85",
+      "215b9e38ed5760161c9227eb0894091249c57c11fbc354e9fba16eeacad4ed6f",
+      "a4be48ed9f9fc44aeab97c9b975f6b12287e103be8e0c54dc00c570272ffaf86",
+      "2b455dda745fd4bd2535c9be1a99e18df38eba8fe838c23dfa8c02b57e4ab15d",
+      "9e3d96acf98a6959d2b36d3de0b391620dcb203ac661466dbceead120ddae4db",
+      "2c554f00aec780a3e15d58d0ac64d5352edc62d492d9436016346bca546da7b7"
+    ]
+  },
+  "http": {
+    "transactions": [
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/challenge",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:08 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"json\":{\"version\":0,\"challenge\":{\"data\":\"82544f240411e680c8dc5aca12d38212\",\"expiry\":\"2026-06-26T15:04:09Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"304502202afdc88023ac84ce50746894c1a0d5ae1483d12f2f8a92cf70a54f3f6cc52409022100b5f38d2199d54ddab7713e4ee3edbac633a93a46e1e6add2e39cd5c850b0fa68\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"tlv\":\"010107020100121082544f240411e680c8dc5aca12d382121401011547304502202afdc88023ac84ce50746894c1a0d5ae1483d12f2f8a92cf70a54f3f6cc52409022100b5f38d2199d54ddab7713e4ee3edbac633a93a46e1e6add2e39cd5c850b0fa6816046a3e94e9202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/authenticate",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "content-length": "1068",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "{\"challenge\":{\"version\":0,\"challenge\":{\"data\":\"82544f240411e680c8dc5aca12d38212\",\"expiry\":\"2026-06-26T15:04:09Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"304502202afdc88023ac84ce50746894c1a0d5ae1483d12f2f8a92cf70a54f3f6cc52409022100b5f38d2199d54ddab7713e4ee3edbac633a93a46e1e6add2e39cd5c850b0fa68\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"signature\":{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"028f47628cd48b351a7a2761b820ec2de3cb5a2de12ae0c68a0cff4c3bb2332d4a\"},\"signature\":\"3045022100c801c52dc4254fc3256b9950cc981e9fb427939826c699045c58ea89d2cf232b02200ae021d2562fd66d412cc1e26cf30c858eb29dc29f8c77dd98631854208f0ccb\",\"attestation\":\"000021012103cce710b4ace62a3597e5b9853463b6bbc45a7d198bf7b698dd885c4fedf98f9d463044022000bd629dd8639c023899ef8aa372ab6445825d5e0644e7596902bc7d8d766646022048528575246a1d58667041ea1ab909eea75eda649970112ed34c53a2de45ef62\"}}"
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:09 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI4ZjQ3NjI4Y2Q0OGIzNTFhN2EyNzYxYjgyMGVjMmRlM2NiNWEyZGUxMmFlMGM2OGEwY2ZmNGMzYmIyMzMyZDRhIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1MCwiaWF0IjoxNzgyNDg0NDQ5LCJqdGkiOiJkM2Y5MWUwNS1lNmE0LTQ1Y2MtOGVlYy0zODgxYzQwMjljMmQiLCJwZXJtaXNzaW9ucyI6e30sImRldmljZSI6dHJ1ZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjEwWiJ9.gBMuRm7gNpybowvp5tVC2DT7I1LnlaIP_-tgnHw_R8JsPLAPiYzQ4xBiXAAJubkjNqBVSnTFXMAnHZWhK6mjfA\",\"permissions\":{}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchains",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI4ZjQ3NjI4Y2Q0OGIzNTFhN2EyNzYxYjgyMGVjMmRlM2NiNWEyZGUxMmFlMGM2OGEwY2ZmNGMzYmIyMzMyZDRhIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1MCwiaWF0IjoxNzgyNDg0NDQ5LCJqdGkiOiJkM2Y5MWUwNS1lNmE0LTQ1Y2MtOGVlYy0zODgxYzQwMjljMmQiLCJwZXJtaXNzaW9ucyI6e30sImRldmljZSI6dHJ1ZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjEwWiJ9.gBMuRm7gNpybowvp5tVC2DT7I1LnlaIP_-tgnHw_R8JsPLAPiYzQ4xBiXAAJubkjNqBVSnTFXMAnHZWhK6mjfA",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:09 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/seed",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI4ZjQ3NjI4Y2Q0OGIzNTFhN2EyNzYxYjgyMGVjMmRlM2NiNWEyZGUxMmFlMGM2OGEwY2ZmNGMzYmIyMzMyZDRhIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1MCwiaWF0IjoxNzgyNDg0NDQ5LCJqdGkiOiJkM2Y5MWUwNS1lNmE0LTQ1Y2MtOGVlYy0zODgxYzQwMjljMmQiLCJwZXJtaXNzaW9ucyI6e30sImRldmljZSI6dHJ1ZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjEwWiJ9.gBMuRm7gNpybowvp5tVC2DT7I1LnlaIP_-tgnHw_R8JsPLAPiYzQ4xBiXAAJubkjNqBVSnTFXMAnHZWhK6mjfA",
+            "connection": "close",
+            "content-length": "652",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "\"0101010220ad95d3536069ea05d44dfa96d0d937d6a6593f9cb65b82deb7a95b0b4647b69a0621028f47628cd48b351a7a2761b820ec2de3cb5a2de12ae0c68a0cff4c3bb2332d4a01010110b0050001020000062102be3f54506f01e4cd4207fa1e04d72c748126863b69cdb252fe94dd87364de64e05104c726f28a0480e80976a22ef5e713b130550c42111c04ab5c8618650631da9b33d6302327db47e4da308c2d7fdd2ea4e502814b43fdc216bc5285c39c154698caa3f93f4323c91942ec355f3767466ad8a9882fb420bb979bcb405e29270b4a2dfad0621024a6c3946cb5146ea25bf67097ce87f366c678ddf1b6c0ac3009edf8edde00aa703463044022044252801fb9f40a25731bcaad6984db1e174925d136ed238f8a76760151b05fb02205fd84515a2f2a88c62e598d153796aa092b4a34c74fdcabf7f8084187f74fe3a\""
+        },
+        "response": {
+          "status": 204,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "date": "Fri, 26 Jun 2026 14:34:10 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains"
+          }
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/refresh",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI4ZjQ3NjI4Y2Q0OGIzNTFhN2EyNzYxYjgyMGVjMmRlM2NiNWEyZGUxMmFlMGM2OGEwY2ZmNGMzYmIyMzMyZDRhIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1MCwiaWF0IjoxNzgyNDg0NDQ5LCJqdGkiOiJkM2Y5MWUwNS1lNmE0LTQ1Y2MtOGVlYy0zODgxYzQwMjljMmQiLCJwZXJtaXNzaW9ucyI6e30sImRldmljZSI6dHJ1ZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjEwWiJ9.gBMuRm7gNpybowvp5tVC2DT7I1LnlaIP_-tgnHw_R8JsPLAPiYzQ4xBiXAAJubkjNqBVSnTFXMAnHZWhK6mjfA",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:10 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI4ZjQ3NjI4Y2Q0OGIzNTFhN2EyNzYxYjgyMGVjMmRlM2NiNWEyZGUxMmFlMGM2OGEwY2ZmNGMzYmIyMzMyZDRhIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1MSwiaWF0IjoxNzgyNDg0NDUwLCJqdGkiOiJjNzZmMjgyYS0zYWQ4LTQ3MGYtOGQ4ZS1hMDU2M2QzNzYzMmEiLCJwZXJtaXNzaW9ucyI6eyIwMGMyNTU3NTU0M2E4MDBiOWVlZTBiMDU0MWNiZTdhNjllNjkwNDg1NDVmMzY5MzExNTYyZjBlYjljNjlhOWQzMTgiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzQ6MTBaIn0.zFy-1qovAbYiTfige0ZTFr1cVEcSgoNQNVu723S-uJ51iMV5_ua9z-9JYmRIdz9vyZhpPkT0-5PqygoRJqd3TQ\",\"permissions\":{\"00c25575543a800b9eee0b0541cbe7a69e69048545f369311562f0eb9c69a9d318\":{\"m/\":\"ffffffff\"}}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchains",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI4ZjQ3NjI4Y2Q0OGIzNTFhN2EyNzYxYjgyMGVjMmRlM2NiNWEyZGUxMmFlMGM2OGEwY2ZmNGMzYmIyMzMyZDRhIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1MSwiaWF0IjoxNzgyNDg0NDUwLCJqdGkiOiJjNzZmMjgyYS0zYWQ4LTQ3MGYtOGQ4ZS1hMDU2M2QzNzYzMmEiLCJwZXJtaXNzaW9ucyI6eyIwMGMyNTU3NTU0M2E4MDBiOWVlZTBiMDU0MWNiZTdhNjllNjkwNDg1NDVmMzY5MzExNTYyZjBlYjljNjlhOWQzMTgiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzQ6MTBaIn0.zFy-1qovAbYiTfige0ZTFr1cVEcSgoNQNVu723S-uJ51iMV5_ua9z-9JYmRIdz9vyZhpPkT0-5PqygoRJqd3TQ",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:10 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"00c25575543a800b9eee0b0541cbe7a69e69048545f369311562f0eb9c69a9d318\":{\"m/\":\"ffffffff\"}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00c25575543a800b9eee0b0541cbe7a69e69048545f369311562f0eb9c69a9d318",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI4ZjQ3NjI4Y2Q0OGIzNTFhN2EyNzYxYjgyMGVjMmRlM2NiNWEyZGUxMmFlMGM2OGEwY2ZmNGMzYmIyMzMyZDRhIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1MSwiaWF0IjoxNzgyNDg0NDUwLCJqdGkiOiJjNzZmMjgyYS0zYWQ4LTQ3MGYtOGQ4ZS1hMDU2M2QzNzYzMmEiLCJwZXJtaXNzaW9ucyI6eyIwMGMyNTU3NTU0M2E4MDBiOWVlZTBiMDU0MWNiZTdhNjllNjkwNDg1NDVmMzY5MzExNTYyZjBlYjljNjlhOWQzMTgiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzQ6MTBaIn0.zFy-1qovAbYiTfige0ZTFr1cVEcSgoNQNVu723S-uJ51iMV5_ua9z-9JYmRIdz9vyZhpPkT0-5PqygoRJqd3TQ",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:10 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"m/\":\"0101010220ad95d3536069ea05d44dfa96d0d937d6a6593f9cb65b82deb7a95b0b4647b69a0621028f47628cd48b351a7a2761b820ec2de3cb5a2de12ae0c68a0cff4c3bb2332d4a01010110b0050001020000062102be3f54506f01e4cd4207fa1e04d72c748126863b69cdb252fe94dd87364de64e05104c726f28a0480e80976a22ef5e713b130550c42111c04ab5c8618650631da9b33d6302327db47e4da308c2d7fdd2ea4e502814b43fdc216bc5285c39c154698caa3f93f4323c91942ec355f3767466ad8a9882fb420bb979bcb405e29270b4a2dfad0621024a6c3946cb5146ea25bf67097ce87f366c678ddf1b6c0ac3009edf8edde00aa703463044022044252801fb9f40a25731bcaad6984db1e174925d136ed238f8a76760151b05fb02205fd84515a2f2a88c62e598d153796aa092b4a34c74fdcabf7f8084187f74fe3a\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00c25575543a800b9eee0b0541cbe7a69e69048545f369311562f0eb9c69a9d318/derivation",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI4ZjQ3NjI4Y2Q0OGIzNTFhN2EyNzYxYjgyMGVjMmRlM2NiNWEyZGUxMmFlMGM2OGEwY2ZmNGMzYmIyMzMyZDRhIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1MSwiaWF0IjoxNzgyNDg0NDUwLCJqdGkiOiJjNzZmMjgyYS0zYWQ4LTQ3MGYtOGQ4ZS1hMDU2M2QzNzYzMmEiLCJwZXJtaXNzaW9ucyI6eyIwMGMyNTU3NTU0M2E4MDBiOWVlZTBiMDU0MWNiZTdhNjllNjkwNDg1NDVmMzY5MzExNTYyZjBlYjljNjlhOWQzMTgiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzQ6MTBaIn0.zFy-1qovAbYiTfige0ZTFr1cVEcSgoNQNVu723S-uJ51iMV5_ua9z-9JYmRIdz9vyZhpPkT0-5PqygoRJqd3TQ",
+            "connection": "close",
+            "content-length": "1124",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "\"0101010220c25575543a800b9eee0b0541cbe7a69e69048545f369311562f0eb9c69a9d3180621028f47628cd48b351a7a2761b820ec2de3cb5a2de12ae0c68a0cff4c3bb2332d4a01010315b8050c80000000800000108000000006210277f4d0f2328e5bb19c2b87667986b695120ab9b75c91970f188630a3a521b54b05107e8bc5f32b476e9b1ca38ddde7c892530550e7eaf8acaf35115788e0fa106f50076cf518649a533356206e340dacffed8fdf0c3b0a13293dede88185ede5d3c72e7675e7fdfc64c2999a1cbbfc58232248d8cdb304ee278faf2b7117e1e5e87b800f062102cf30210425398c8f2cc14f6657663a302b45cee0bf8e6c5be26dc1da028060321136040b536f6c65206d656d62657206210300ca023ba0f472f50d4d66bf4cc07dc87594407a925a4aacfcc000ab36b04b1e0104ffffffff12aa0510267d2e259da648c705e5f412b2051321055021e41fc2c0eb328556536e7992d84738dcbdb737c7ccc1c68ff98df02b3bc8d2bcc177015fcef7f2770d4a4368bda3313a33660fefbb44523d59dfe9e8fb4cd8956bb269340aef06a6b6fc00cd59839506210300ca023ba0f472f50d4d66bf4cc07dc87594407a925a4aacfcc000ab36b04b1e062103dec41596b34664fbf8057e36ca2225219c19dee7217a4c35060b0fe63ba90d730346304402203f296555658145096e70e05669d650f8016f292b09f2a4a749db13afbdf38f470220447d3bb8ff5a5b2449264ca2a4f7731584d55046107dbd6e090a01309aa95326\""
+        },
+        "response": {
+          "status": 204,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "date": "Fri, 26 Jun 2026 14:34:11 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains"
+          }
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/challenge",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:11 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"json\":{\"version\":0,\"challenge\":{\"data\":\"389686318aad961b224fa08f1298b425\",\"expiry\":\"2026-06-26T15:04:12Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"3045022100b9f89c89693005b1a6973796d4bff90eb0dacdaf210c0445b6f00e6d69c31afb022057126c32dad1d15532be66469ee726fc5f2ad67f8dcee7bf600f5b1ec91d8b89\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"tlv\":\"0101070201001210389686318aad961b224fa08f1298b42514010115473045022100b9f89c89693005b1a6973796d4bff90eb0dacdaf210c0445b6f00e6d69c31afb022057126c32dad1d15532be66469ee726fc5f2ad67f8dcee7bf600f5b1ec91d8b8916046a3e94ec202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/authenticate",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "content-length": "986",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "{\"challenge\":{\"version\":0,\"challenge\":{\"data\":\"389686318aad961b224fa08f1298b425\",\"expiry\":\"2026-06-26T15:04:12Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"3045022100b9f89c89693005b1a6973796d4bff90eb0dacdaf210c0445b6f00e6d69c31afb022057126c32dad1d15532be66469ee726fc5f2ad67f8dcee7bf600f5b1ec91d8b89\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"signature\":{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"0300ca023ba0f472f50d4d66bf4cc07dc87594407a925a4aacfcc000ab36b04b1e\"},\"signature\":\"304502210089803d2e3fe4e033475ced1c0619a1890c63da86c7a065e6e4cc25227bf78d42022067329ac70ca955fd3f61c6d4624fa91de01b2e7a166ef3c698516780d476142e\",\"attestation\":\"0242303063323535373535343361383030623965656530623035343163626537613639653639303438353435663336393331313536326630656239633639613964333138\"}}"
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:12 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDMwMGNhMDIzYmEwZjQ3MmY1MGQ0ZDY2YmY0Y2MwN2RjODc1OTQ0MDdhOTI1YTRhYWNmY2MwMDBhYjM2YjA0YjFlIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1MywiaWF0IjoxNzgyNDg0NDUyLCJqdGkiOiJmMzQwMDc2Yi01NTBjLTQ3MGYtOThlYi0wMjI4MzQ4Y2U4ZWMiLCJwZXJtaXNzaW9ucyI6eyIwMGMyNTU3NTU0M2E4MDBiOWVlZTBiMDU0MWNiZTdhNjllNjkwNDg1NDVmMzY5MzExNTYyZjBlYjljNjlhOWQzMTgiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjEzWiJ9._HuS9BVBPvFp_kF1PYLcTjyYzr0vTlIFUb9-tym7-TD32PlEwxD5k74r3AMRuVxuZIHTnC5KUYuSjpWlKuEnxQ\",\"permissions\":{\"00c25575543a800b9eee0b0541cbe7a69e69048545f369311562f0eb9c69a9d318\":{\"m/0'/16'/0'\":\"ffffffff\"}}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00c25575543a800b9eee0b0541cbe7a69e69048545f369311562f0eb9c69a9d318",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDMwMGNhMDIzYmEwZjQ3MmY1MGQ0ZDY2YmY0Y2MwN2RjODc1OTQ0MDdhOTI1YTRhYWNmY2MwMDBhYjM2YjA0YjFlIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1MywiaWF0IjoxNzgyNDg0NDUyLCJqdGkiOiJmMzQwMDc2Yi01NTBjLTQ3MGYtOThlYi0wMjI4MzQ4Y2U4ZWMiLCJwZXJtaXNzaW9ucyI6eyIwMGMyNTU3NTU0M2E4MDBiOWVlZTBiMDU0MWNiZTdhNjllNjkwNDg1NDVmMzY5MzExNTYyZjBlYjljNjlhOWQzMTgiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjEzWiJ9._HuS9BVBPvFp_kF1PYLcTjyYzr0vTlIFUb9-tym7-TD32PlEwxD5k74r3AMRuVxuZIHTnC5KUYuSjpWlKuEnxQ",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:12 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"m/\":\"0101010220ad95d3536069ea05d44dfa96d0d937d6a6593f9cb65b82deb7a95b0b4647b69a0621028f47628cd48b351a7a2761b820ec2de3cb5a2de12ae0c68a0cff4c3bb2332d4a01010110b0050001020000062102be3f54506f01e4cd4207fa1e04d72c748126863b69cdb252fe94dd87364de64e05104c726f28a0480e80976a22ef5e713b130550c42111c04ab5c8618650631da9b33d6302327db47e4da308c2d7fdd2ea4e502814b43fdc216bc5285c39c154698caa3f93f4323c91942ec355f3767466ad8a9882fb420bb979bcb405e29270b4a2dfad0621024a6c3946cb5146ea25bf67097ce87f366c678ddf1b6c0ac3009edf8edde00aa703463044022044252801fb9f40a25731bcaad6984db1e174925d136ed238f8a76760151b05fb02205fd84515a2f2a88c62e598d153796aa092b4a34c74fdcabf7f8084187f74fe3a\",\"m/16'\":\"0101010220c25575543a800b9eee0b0541cbe7a69e69048545f369311562f0eb9c69a9d3180621028f47628cd48b351a7a2761b820ec2de3cb5a2de12ae0c68a0cff4c3bb2332d4a01010315b8050c80000000800000108000000006210277f4d0f2328e5bb19c2b87667986b695120ab9b75c91970f188630a3a521b54b05107e8bc5f32b476e9b1ca38ddde7c892530550e7eaf8acaf35115788e0fa106f50076cf518649a533356206e340dacffed8fdf0c3b0a13293dede88185ede5d3c72e7675e7fdfc64c2999a1cbbfc58232248d8cdb304ee278faf2b7117e1e5e87b800f062102cf30210425398c8f2cc14f6657663a302b45cee0bf8e6c5be26dc1da028060321136040b536f6c65206d656d62657206210300ca023ba0f472f50d4d66bf4cc07dc87594407a925a4aacfcc000ab36b04b1e0104ffffffff12aa0510267d2e259da648c705e5f412b2051321055021e41fc2c0eb328556536e7992d84738dcbdb737c7ccc1c68ff98df02b3bc8d2bcc177015fcef7f2770d4a4368bda3313a33660fefbb44523d59dfe9e8fb4cd8956bb269340aef06a6b6fc00cd59839506210300ca023ba0f472f50d4d66bf4cc07dc87594407a925a4aacfcc000ab36b04b1e062103dec41596b34664fbf8057e36ca2225219c19dee7217a4c35060b0fe63ba90d730346304402203f296555658145096e70e05669d650f8016f292b09f2a4a749db13afbdf38f470220447d3bb8ff5a5b2449264ca2a4f7731584d55046107dbd6e090a01309aa95326\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00c25575543a800b9eee0b0541cbe7a69e69048545f369311562f0eb9c69a9d318",
+          "method": "DELETE",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDMwMGNhMDIzYmEwZjQ3MmY1MGQ0ZDY2YmY0Y2MwN2RjODc1OTQ0MDdhOTI1YTRhYWNmY2MwMDBhYjM2YjA0YjFlIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1MywiaWF0IjoxNzgyNDg0NDUyLCJqdGkiOiJmMzQwMDc2Yi01NTBjLTQ3MGYtOThlYi0wMjI4MzQ4Y2U4ZWMiLCJwZXJtaXNzaW9ucyI6eyIwMGMyNTU3NTU0M2E4MDBiOWVlZTBiMDU0MWNiZTdhNjllNjkwNDg1NDVmMzY5MzExNTYyZjBlYjljNjlhOWQzMTgiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjEzWiJ9._HuS9BVBPvFp_kF1PYLcTjyYzr0vTlIFUb9-tym7-TD32PlEwxD5k74r3AMRuVxuZIHTnC5KUYuSjpWlKuEnxQ",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": ""
+        },
+        "response": {
+          "status": 204,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "date": "Fri, 26 Jun 2026 14:34:12 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains"
+          }
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/challenge",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:12 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"json\":{\"version\":0,\"challenge\":{\"data\":\"385a88c534ca500680c533b472269bd8\",\"expiry\":\"2026-06-26T15:04:13Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"304502204ec2b746ebfd7e4cc4a4830388c2197c24f01acad4a8ecec6fe6de534d9b3e1c022100eb60a0299183d125a0292124b3477f35fd88a5c76b0252bd8f2e3bdad47df8f2\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"tlv\":\"0101070201001210385a88c534ca500680c533b472269bd81401011547304502204ec2b746ebfd7e4cc4a4830388c2197c24f01acad4a8ecec6fe6de534d9b3e1c022100eb60a0299183d125a0292124b3477f35fd88a5c76b0252bd8f2e3bdad47df8f216046a3e94ed202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/authenticate",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "content-length": "1070",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "{\"challenge\":{\"version\":0,\"challenge\":{\"data\":\"385a88c534ca500680c533b472269bd8\",\"expiry\":\"2026-06-26T15:04:13Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"304502204ec2b746ebfd7e4cc4a4830388c2197c24f01acad4a8ecec6fe6de534d9b3e1c022100eb60a0299183d125a0292124b3477f35fd88a5c76b0252bd8f2e3bdad47df8f2\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"signature\":{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"028f47628cd48b351a7a2761b820ec2de3cb5a2de12ae0c68a0cff4c3bb2332d4a\"},\"signature\":\"3045022100bda21bdd309f8b171b040bf36c4c37884c88eabc964a143b8e822aebc99ba56202203fdadb6c226774eecb4753ded128f8a6c18354e1b5445ff955509292297c3e92\",\"attestation\":\"000021012103cce710b4ace62a3597e5b9853463b6bbc45a7d198bf7b698dd885c4fedf98f9d473045022100903635c4975309cebf9787fddffeadfa2be2c60218c34375601df819bce7cb4f02207b58c98f89d0a63bd83537d679038b0d5cb33b8b623558ce8f095e82479ffaf7\"}}"
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:13 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI4ZjQ3NjI4Y2Q0OGIzNTFhN2EyNzYxYjgyMGVjMmRlM2NiNWEyZGUxMmFlMGM2OGEwY2ZmNGMzYmIyMzMyZDRhIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1NCwiaWF0IjoxNzgyNDg0NDUzLCJqdGkiOiI4NTk2NTE3Mi1lMTNkLTQyNTgtOGM3Zi0xZTA1MTdiYzc3MGYiLCJwZXJtaXNzaW9ucyI6e30sImRldmljZSI6dHJ1ZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjE0WiJ9.vsTP4dYvFhEH7AhvVtQDTN72LcylI2H3UZ222amTLe0TRu-2grpKl9XoPMS1t1fac6cYNDBrSDcgXsIa5X-C1A\",\"permissions\":{}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchains",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI4ZjQ3NjI4Y2Q0OGIzNTFhN2EyNzYxYjgyMGVjMmRlM2NiNWEyZGUxMmFlMGM2OGEwY2ZmNGMzYmIyMzMyZDRhIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1NCwiaWF0IjoxNzgyNDg0NDUzLCJqdGkiOiI4NTk2NTE3Mi1lMTNkLTQyNTgtOGM3Zi0xZTA1MTdiYzc3MGYiLCJwZXJtaXNzaW9ucyI6e30sImRldmljZSI6dHJ1ZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjE0WiJ9.vsTP4dYvFhEH7AhvVtQDTN72LcylI2H3UZ222amTLe0TRu-2grpKl9XoPMS1t1fac6cYNDBrSDcgXsIa5X-C1A",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:13 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/seed",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI4ZjQ3NjI4Y2Q0OGIzNTFhN2EyNzYxYjgyMGVjMmRlM2NiNWEyZGUxMmFlMGM2OGEwY2ZmNGMzYmIyMzMyZDRhIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1NCwiaWF0IjoxNzgyNDg0NDUzLCJqdGkiOiI4NTk2NTE3Mi1lMTNkLTQyNTgtOGM3Zi0xZTA1MTdiYzc3MGYiLCJwZXJtaXNzaW9ucyI6e30sImRldmljZSI6dHJ1ZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjE0WiJ9.vsTP4dYvFhEH7AhvVtQDTN72LcylI2H3UZ222amTLe0TRu-2grpKl9XoPMS1t1fac6cYNDBrSDcgXsIa5X-C1A",
+            "connection": "close",
+            "content-length": "654",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "\"01010102201fe9b5bf971b8f51a3b1bb2f15fa65fb0eca69ce1154b09db75033de09f1b1730621028f47628cd48b351a7a2761b820ec2de3cb5a2de12ae0c68a0cff4c3bb2332d4a01010110b0050001020000062102450dd8d4ffb51f8cda156e2ea89f1079ae35b00cc21faff2e8b995b64c43191d051058380cf7253d42d12185de8a797d9faa0550a24d97685b6d77d2f59de31159e3dbd5c1d9d1156d225f7e5144746ae1e3918c25ea9d2433a30314d5e65b803dd73ec854bb72fe365cd1a103a32d942685a7e51908e65339694c5860d9a4210256a4e306210336169eeb3931462eb4824a7fa6e736fb9a5303b174b82e168c3f89181eca122803473045022100cfb98318102baa332abcec7aefba367d352fd243e83f48fad27e31395caa95b702205db71ac1f15252a4e41fd895933ce4b0734f1bf85c41211f82b769ed96efb7bc\""
+        },
+        "response": {
+          "status": 204,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "date": "Fri, 26 Jun 2026 14:34:13 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains"
+          }
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/refresh",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI4ZjQ3NjI4Y2Q0OGIzNTFhN2EyNzYxYjgyMGVjMmRlM2NiNWEyZGUxMmFlMGM2OGEwY2ZmNGMzYmIyMzMyZDRhIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1NCwiaWF0IjoxNzgyNDg0NDUzLCJqdGkiOiI4NTk2NTE3Mi1lMTNkLTQyNTgtOGM3Zi0xZTA1MTdiYzc3MGYiLCJwZXJtaXNzaW9ucyI6e30sImRldmljZSI6dHJ1ZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjE0WiJ9.vsTP4dYvFhEH7AhvVtQDTN72LcylI2H3UZ222amTLe0TRu-2grpKl9XoPMS1t1fac6cYNDBrSDcgXsIa5X-C1A",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:13 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI4ZjQ3NjI4Y2Q0OGIzNTFhN2EyNzYxYjgyMGVjMmRlM2NiNWEyZGUxMmFlMGM2OGEwY2ZmNGMzYmIyMzMyZDRhIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1NCwiaWF0IjoxNzgyNDg0NDUzLCJqdGkiOiJiNTk4MzYxYS0xMDUyLTQ1ZWUtYjRiNS1jZjRjYmNhYTVhYmYiLCJwZXJtaXNzaW9ucyI6eyIwMGYzYjg1NTg2Nzc4ODQyMzk0MWQ2NTg4OGUyNzAxNWYyOGI4ZmM5MGI1NDM0OWU3NDNjMGI5YjU4MWVkZWQ2OGQiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzQ6MTRaIn0.i4Zou8ZTC1YqnveJhdm4T-5B0OIbWzlavp_L-56OZxqurfBh8BhrzclVxAvcogHh0F_dLknF5uQvIqY1uw-S0g\",\"permissions\":{\"00f3b855867788423941d65888e27015f28b8fc90b54349e743c0b9b581eded68d\":{\"m/\":\"ffffffff\"}}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchains",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI4ZjQ3NjI4Y2Q0OGIzNTFhN2EyNzYxYjgyMGVjMmRlM2NiNWEyZGUxMmFlMGM2OGEwY2ZmNGMzYmIyMzMyZDRhIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1NCwiaWF0IjoxNzgyNDg0NDUzLCJqdGkiOiJiNTk4MzYxYS0xMDUyLTQ1ZWUtYjRiNS1jZjRjYmNhYTVhYmYiLCJwZXJtaXNzaW9ucyI6eyIwMGYzYjg1NTg2Nzc4ODQyMzk0MWQ2NTg4OGUyNzAxNWYyOGI4ZmM5MGI1NDM0OWU3NDNjMGI5YjU4MWVkZWQ2OGQiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzQ6MTRaIn0.i4Zou8ZTC1YqnveJhdm4T-5B0OIbWzlavp_L-56OZxqurfBh8BhrzclVxAvcogHh0F_dLknF5uQvIqY1uw-S0g",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:13 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"00f3b855867788423941d65888e27015f28b8fc90b54349e743c0b9b581eded68d\":{\"m/\":\"ffffffff\"}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00f3b855867788423941d65888e27015f28b8fc90b54349e743c0b9b581eded68d",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI4ZjQ3NjI4Y2Q0OGIzNTFhN2EyNzYxYjgyMGVjMmRlM2NiNWEyZGUxMmFlMGM2OGEwY2ZmNGMzYmIyMzMyZDRhIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1NCwiaWF0IjoxNzgyNDg0NDUzLCJqdGkiOiJiNTk4MzYxYS0xMDUyLTQ1ZWUtYjRiNS1jZjRjYmNhYTVhYmYiLCJwZXJtaXNzaW9ucyI6eyIwMGYzYjg1NTg2Nzc4ODQyMzk0MWQ2NTg4OGUyNzAxNWYyOGI4ZmM5MGI1NDM0OWU3NDNjMGI5YjU4MWVkZWQ2OGQiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzQ6MTRaIn0.i4Zou8ZTC1YqnveJhdm4T-5B0OIbWzlavp_L-56OZxqurfBh8BhrzclVxAvcogHh0F_dLknF5uQvIqY1uw-S0g",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:14 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"m/\":\"01010102201fe9b5bf971b8f51a3b1bb2f15fa65fb0eca69ce1154b09db75033de09f1b1730621028f47628cd48b351a7a2761b820ec2de3cb5a2de12ae0c68a0cff4c3bb2332d4a01010110b0050001020000062102450dd8d4ffb51f8cda156e2ea89f1079ae35b00cc21faff2e8b995b64c43191d051058380cf7253d42d12185de8a797d9faa0550a24d97685b6d77d2f59de31159e3dbd5c1d9d1156d225f7e5144746ae1e3918c25ea9d2433a30314d5e65b803dd73ec854bb72fe365cd1a103a32d942685a7e51908e65339694c5860d9a4210256a4e306210336169eeb3931462eb4824a7fa6e736fb9a5303b174b82e168c3f89181eca122803473045022100cfb98318102baa332abcec7aefba367d352fd243e83f48fad27e31395caa95b702205db71ac1f15252a4e41fd895933ce4b0734f1bf85c41211f82b769ed96efb7bc\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00f3b855867788423941d65888e27015f28b8fc90b54349e743c0b9b581eded68d/derivation",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDI4ZjQ3NjI4Y2Q0OGIzNTFhN2EyNzYxYjgyMGVjMmRlM2NiNWEyZGUxMmFlMGM2OGEwY2ZmNGMzYmIyMzMyZDRhIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1NCwiaWF0IjoxNzgyNDg0NDUzLCJqdGkiOiJiNTk4MzYxYS0xMDUyLTQ1ZWUtYjRiNS1jZjRjYmNhYTVhYmYiLCJwZXJtaXNzaW9ucyI6eyIwMGYzYjg1NTg2Nzc4ODQyMzk0MWQ2NTg4OGUyNzAxNWYyOGI4ZmM5MGI1NDM0OWU3NDNjMGI5YjU4MWVkZWQ2OGQiOnsibS8iOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjp0cnVlLCJyZWZyZXNoRXhwaXJhdGlvbiI6IjIwMjYtMDYtMjZUMTU6MzQ6MTRaIn0.i4Zou8ZTC1YqnveJhdm4T-5B0OIbWzlavp_L-56OZxqurfBh8BhrzclVxAvcogHh0F_dLknF5uQvIqY1uw-S0g",
+            "connection": "close",
+            "content-length": "1124",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "\"0101010220f3b855867788423941d65888e27015f28b8fc90b54349e743c0b9b581eded68d0621028f47628cd48b351a7a2761b820ec2de3cb5a2de12ae0c68a0cff4c3bb2332d4a01010315b8050c8000000080000010800000000621032fbdb53d7b4446a5d26b3252a685bb8185953bfdbb9bc26becce5a831bf1e97705101d08fe6658b0b025a8ab24b5ab9fc21d05505c90536e5f026316924ce1f7a29136434ceddf3678a972024abf86b4310579f67fa1cbf8cc8c84b01c1f976e5b0a9e641d0869287bd3f55834800329c7f40e7e83c1093f3c799e060d814ac6ff09a7610621039944e0ebf0415ad7ab8db75e6c719d61841500b4e195f547cab98663c9b7dba31136040b536f6c65206d656d62657206210300ca023ba0f472f50d4d66bf4cc07dc87594407a925a4aacfcc000ab36b04b1e0104ffffffff12aa05108a8842a6e333ec1b384eb8aee83ac3120550708f561810456206e8f7aec5f7d0bcc9831d66d0ddbfa1471160fc94bd83991774f053bcd8322b0c417157b8536231917d9d62f3f171a20afe84ab054ad91adfa9d1a8da15bc48790ea3b679c544bab906210300ca023ba0f472f50d4d66bf4cc07dc87594407a925a4aacfcc000ab36b04b1e062102133712720b3f060406522b8a53d583d230587f2c4b539a86a58fa0fee377c1610346304402207080834699d596a680295a173c48811e2c55aefa69aa246c9537e1fc514dc41c02206afa71bcf5de4ceb0ffdd7d67fd30b1fca8f91e6dee9ea93251d1a8ec9198318\""
+        },
+        "response": {
+          "status": 204,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "date": "Fri, 26 Jun 2026 14:34:15 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains"
+          }
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/challenge",
+          "method": "GET",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:15 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"json\":{\"version\":0,\"challenge\":{\"data\":\"7dc31ec4c8a7ff29cb73b73e958bc873\",\"expiry\":\"2026-06-26T15:04:16Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"3045022042fde0a366f7c76b163dbc828474a2830b4da6cdcb6cccef4555dc89a88a55b60221008a1849cda4594373b7ab38c658aa8bfa9ef13467700c85864be407400c7b990b\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"tlv\":\"01010702010012107dc31ec4c8a7ff29cb73b73e958bc87314010115473045022042fde0a366f7c76b163dbc828474a2830b4da6cdcb6cccef4555dc89a88a55b60221008a1849cda4594373b7ab38c658aa8bfa9ef13467700c85864be407400c7b990b16046a3e94f0202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000\"}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/authenticate",
+          "method": "POST",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "connection": "close",
+            "content-length": "984",
+            "content-type": "application/json",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": "{\"challenge\":{\"version\":0,\"challenge\":{\"data\":\"7dc31ec4c8a7ff29cb73b73e958bc873\",\"expiry\":\"2026-06-26T15:04:16Z\"},\"host\":\"trustchain-backend.api.aws.stg.ldg-tech.com\",\"rp\":[{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"03cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2\"},\"signature\":\"3045022042fde0a366f7c76b163dbc828474a2830b4da6cdcb6cccef4555dc89a88a55b60221008a1849cda4594373b7ab38c658aa8bfa9ef13467700c85864be407400c7b990b\"}],\"protocolVersion\":{\"major\":1,\"minor\":0,\"patch\":0}},\"signature\":{\"credential\":{\"version\":0,\"curveId\":33,\"signAlgorithm\":1,\"publicKey\":\"0300ca023ba0f472f50d4d66bf4cc07dc87594407a925a4aacfcc000ab36b04b1e\"},\"signature\":\"304402201ddfe9a92a501c1fb09bdaa9a345503a8d03ac2e7750ab44ae1026648e957faa022037ef1e9de89e752529bd18d9e20d62610101a68b05aa663f8534579fe963b4fc\",\"attestation\":\"0242303066336238353538363737383834323339343164363538383865323730313566323862386663393062353433343965373433633062396235383165646564363864\"}}"
+        },
+        "response": {
+          "status": 200,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "content-type": "application/json",
+            "date": "Fri, 26 Jun 2026 14:34:15 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains",
+            "transfer-encoding": "chunked"
+          },
+          "body": "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDMwMGNhMDIzYmEwZjQ3MmY1MGQ0ZDY2YmY0Y2MwN2RjODc1OTQ0MDdhOTI1YTRhYWNmY2MwMDBhYjM2YjA0YjFlIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1NiwiaWF0IjoxNzgyNDg0NDU1LCJqdGkiOiIwOWNiMGEyZC0yM2ViLTQ3NjQtOTk3MC03NjUzNjE3NDI2ODQiLCJwZXJtaXNzaW9ucyI6eyIwMGYzYjg1NTg2Nzc4ODQyMzk0MWQ2NTg4OGUyNzAxNWYyOGI4ZmM5MGI1NDM0OWU3NDNjMGI5YjU4MWVkZWQ2OGQiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjE2WiJ9.k17aVMVM8zT_Cz2pHiyhGEi6-d19YhGej9i8g6FCkYvD4jAy7o9GDk2gpX9CGHZmq-h99INIgwtkcRscI8FYVg\",\"permissions\":{\"00f3b855867788423941d65888e27015f28b8fc90b54349e743c0b9b581eded68d\":{\"m/0'/16'/0'\":\"ffffffff\"}}}"
+        }
+      },
+      {
+        "request": {
+          "url": "https://trustchain-backend.api.aws.stg.ldg-tech.com/v1/trustchain/00f3b855867788423941d65888e27015f28b8fc90b54349e743c0b9b581eded68d",
+          "method": "DELETE",
+          "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-encoding": "gzip, compress, deflate, br",
+            "authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJ0cnVzdGNoYWluLWJhY2tlbmQuYXBpLmF3cy5zdGcubGRnLXRlY2guY29tIiwic3ViIjoiMDMwMGNhMDIzYmEwZjQ3MmY1MGQ0ZDY2YmY0Y2MwN2RjODc1OTQ0MDdhOTI1YTRhYWNmY2MwMDBhYjM2YjA0YjFlIiwiYXVkIjpbIkNsb3VkU3luYyIsIkVuY3J5cHRpb25DTEkiLCJ0cnVzdGNoYWluIl0sImV4cCI6MTc4MjQ4NDc1NiwiaWF0IjoxNzgyNDg0NDU1LCJqdGkiOiIwOWNiMGEyZC0yM2ViLTQ3NjQtOTk3MC03NjUzNjE3NDI2ODQiLCJwZXJtaXNzaW9ucyI6eyIwMGYzYjg1NTg2Nzc4ODQyMzk0MWQ2NTg4OGUyNzAxNWYyOGI4ZmM5MGI1NDM0OWU3NDNjMGI5YjU4MWVkZWQ2OGQiOnsibS8wJy8xNicvMCciOiJmZmZmZmZmZiJ9fSwiZGV2aWNlIjpmYWxzZSwicmVmcmVzaEV4cGlyYXRpb24iOiIyMDI2LTA2LTI2VDE1OjM0OjE2WiJ9.k17aVMVM8zT_Cz2pHiyhGEi6-d19YhGej9i8g6FCkYvD4jAy7o9GDk2gpX9CGHZmq-h99INIgwtkcRscI8FYVg",
+            "connection": "close",
+            "host": "trustchain-backend.api.aws.stg.ldg-tech.com",
+            "user-agent": "axios/1.13.5"
+          },
+          "body": ""
+        },
+        "response": {
+          "status": 204,
+          "headers": {
+            "cache-control": "no-store, no-cache, max-age=0",
+            "connection": "close",
+            "date": "Fri, 26 Jun 2026 14:34:15 GMT",
+            "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "pragma": "no-cache",
+            "strict-transport-security": "max-age=31536000; includeSubDomains"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/libs/ledger-key-ring-protocol/src/__tests__/integration/mock.sdk.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/integration/mock.sdk.test.ts
@@ -14,7 +14,7 @@ const nonMockableScenarios = [
   "tokenExpires", // can't simulate token expiration
   "userRefusesAuth", // can't simulate device interaction at the moment
   "userRefusesRemoveMember", // can't simulate device interaction at the moment
-  "ringInitPreservesLedgerSyncMember", // mock SDK does not model per-app member eviction
+  "ringInitPreservesLedgerSyncMember", // scenario does not clean up its trustchain (shared in-memory mock state)
 ];
 
 const scenarioFolder = path.join(__dirname, "../../../tests/scenarios");

--- a/libs/ledger-key-ring-protocol/src/mockSdk.ts
+++ b/libs/ledger-key-ring-protocol/src/mockSdk.ts
@@ -15,9 +15,10 @@ import { TrustchainEjected } from "./errors";
 import getApi from "./api";
 
 const mockedLiveCredentialsPrivateKey = "mock-private-key";
+const ROOT_ID = "mock-root-id";
 
 function assertTrustchain(trustchain: Trustchain) {
-  if (!trustchain.rootId.startsWith("mock-root-id")) {
+  if (!trustchain.rootId.startsWith(ROOT_ID)) {
     throw new Error("in mock context, trustchain must be the mocked trustchain");
   }
 }
@@ -28,22 +29,42 @@ function assertLiveCredentials(memberCredentials: MemberCredentials) {
   }
 }
 
-function assertAllowedPermissions(trustchainId: string, memberId: string) {
-  const members = trustchainMembers.get(trustchainId) || [];
-  const member = members.find(m => m.id === memberId);
-  if (!member) {
-    throw new TrustchainEjected();
-  }
-}
-
 const mockedLiveJWT = {
   accessToken: "mock-live-jwt",
   permissions: {},
 };
 
+/**
+ * The mock models the backend as a tree of applications under a single root.
+ * Each application has its own derivation index (bumped on key rotation or reopen),
+ * its own members and an open/closed state, so a close on one application leaves the
+ * others (and the root) untouched.
+ */
+type MockAppState = {
+  index: number;
+  closed: boolean;
+  members: TrustchainMember[];
+};
+type MockRoot = {
+  apps: Map<number, MockAppState>;
+};
+
 // global states in memory
-const trustchains = new Map<string, Trustchain>();
-const trustchainMembers = new Map<string, TrustchainMember[]>();
+const roots = new Map<string, MockRoot>();
+
+function keyForIndex(index: number): string {
+  return index === 0
+    ? "mock-wallet-sync-encryption-key"
+    : "mock-wallet-sync-encryption-key-" + index;
+}
+
+function buildTrustchain(rootId: string, applicationId: number, app: MockAppState): Trustchain {
+  return {
+    rootId,
+    walletSyncEncryptionKey: keyForIndex(app.index),
+    applicationPath: `m/0'/${applicationId}'/${app.index}'`,
+  };
+}
 
 /**
  * to mock the encryption/decryption, we just xor the data with 0xff
@@ -95,16 +116,21 @@ export class MockSDK implements TrustchainSDK {
   ): Promise<TrustchainResult> {
     this.invalidateJwt();
     assertLiveCredentials(memberCredentials);
-    let type = trustchains.has("mock-root-id")
-      ? TrustchainResultType.restored
-      : TrustchainResultType.created;
+    const applicationId = this.context.applicationId;
 
-    const trustchain: Trustchain = trustchains.get("mock-root-id") || {
-      rootId: "mock-root-id",
-      walletSyncEncryptionKey: "mock-wallet-sync-encryption-key",
-      applicationPath: "m/0'/16'/0'",
-    };
-    trustchains.set(trustchain.rootId, trustchain);
+    let type = roots.has(ROOT_ID) ? TrustchainResultType.restored : TrustchainResultType.created;
+    const root = roots.get(ROOT_ID) ?? { apps: new Map<number, MockAppState>() };
+    roots.set(ROOT_ID, root);
+
+    let app = root.apps.get(applicationId);
+    if (!app) {
+      app = { index: 0, closed: false, members: [] };
+      root.apps.set(applicationId, app);
+    } else if (app.closed) {
+      // the application was deactivated (stream closed): reopen it on the next index
+      app = { index: app.index + 1, closed: false, members: [] };
+      root.apps.set(applicationId, app);
+    }
 
     if (!this.deviceJwtAcquired) {
       callbacks?.onStartRequestUserInteraction?.();
@@ -112,39 +138,49 @@ export class MockSDK implements TrustchainSDK {
       callbacks?.onEndRequestUserInteraction?.();
     }
 
-    const currentMembers = trustchainMembers.get(trustchain.rootId) || [];
     // add itself if not yet here
-    if (!currentMembers.some(m => m.id === memberCredentials.pubkey)) {
+    if (!app.members.some(m => m.id === memberCredentials.pubkey)) {
       if (type === TrustchainResultType.restored) type = TrustchainResultType.updated;
       callbacks?.onStartRequestUserInteraction?.();
       // simulate device add interaction
       callbacks?.onEndRequestUserInteraction?.();
-      currentMembers.push({
+      app.members.push({
         id: memberCredentials.pubkey,
         name: this.context.name,
         permissions: Permissions.OWNER,
       });
-      trustchainMembers.set(trustchain.rootId, currentMembers);
     }
-    return Promise.resolve({ type, trustchain });
+    return { type, trustchain: buildTrustchain(ROOT_ID, applicationId, app) };
   }
 
   async refreshAuth(jwt: JWT): Promise<JWT> {
     return jwt;
   }
 
+  /**
+   * Resolve the current application of an active member, or throw TrustchainEjected when the member
+   * is no longer part of the application (removed, application closed, or trustchain gone).
+   */
+  private getActiveContext(
+    trustchain: Trustchain,
+    memberCredentials: MemberCredentials,
+  ): { root: MockRoot; app: MockAppState } {
+    assertTrustchain(trustchain);
+    assertLiveCredentials(memberCredentials);
+    const root = roots.get(trustchain.rootId);
+    const app = root?.apps.get(this.context.applicationId);
+    if (!root || !app || app.closed || !app.members.some(m => m.id === memberCredentials.pubkey)) {
+      throw new TrustchainEjected();
+    }
+    return { root, app };
+  }
+
   async restoreTrustchain(
     trustchain: Trustchain,
     memberCredentials: MemberCredentials,
   ): Promise<Trustchain> {
-    assertTrustchain(trustchain);
-    assertLiveCredentials(memberCredentials);
-    assertAllowedPermissions(trustchain.rootId, memberCredentials.pubkey);
-    const latest = trustchains.get(trustchain.rootId);
-    if (!latest) {
-      throw new Error("trustchain not found");
-    }
-    return Promise.resolve(latest);
+    const { app } = this.getActiveContext(trustchain, memberCredentials);
+    return buildTrustchain(trustchain.rootId, this.context.applicationId, app);
   }
 
   async getMembers(
@@ -153,9 +189,12 @@ export class MockSDK implements TrustchainSDK {
   ): Promise<TrustchainMember[]> {
     assertTrustchain(trustchain);
     assertLiveCredentials(memberCredentials);
-    assertAllowedPermissions(trustchain.rootId, memberCredentials.pubkey);
-    const currentMembers = trustchainMembers.get(trustchain.rootId) || [];
-    return Promise.resolve([...currentMembers]);
+    // a closed application still exposes its members (matching the real SDK); only a removed member is ejected
+    const app = roots.get(trustchain.rootId)?.apps.get(this.context.applicationId);
+    if (!app?.members.some(m => m.id === memberCredentials.pubkey)) {
+      throw new TrustchainEjected();
+    }
+    return [...app.members];
   }
 
   async removeMember(
@@ -166,9 +205,8 @@ export class MockSDK implements TrustchainSDK {
     callbacks?: TrustchainDeviceCallbacks,
   ): Promise<Trustchain> {
     this.invalidateJwt();
-    assertTrustchain(trustchain);
-    assertLiveCredentials(memberCredentials);
-    assertAllowedPermissions(trustchain.rootId, memberCredentials.pubkey);
+    const { app } = this.getActiveContext(trustchain, memberCredentials);
+    const applicationId = this.context.applicationId;
     if (member.id === memberCredentials.pubkey) {
       throw new Error("cannot remove self");
     }
@@ -192,22 +230,14 @@ export class MockSDK implements TrustchainSDK {
     // simulate device interaction
     callbacks?.onEndRequestUserInteraction?.();
 
-    const currentMembers = (trustchainMembers.get(trustchain.rootId) || []).filter(
-      m => m.id !== member.id,
-    );
-    trustchainMembers.set(trustchain.rootId, currentMembers);
-    // we extract the index part to increment it and recreate a path
-    const index = 1 + parseInt(trustchain.applicationPath.split("/")[3].split("'")[0]);
-    const newTrustchain = {
-      rootId: trustchain.rootId,
-      walletSyncEncryptionKey: "mock-wallet-sync-encryption-key-" + index,
-      applicationPath: "m/0'/16'/" + index + "'",
-    };
-    trustchains.set(newTrustchain.rootId, newTrustchain);
+    // rotate the application: bump the index and drop the removed member
+    app.members = app.members.filter(m => m.id !== member.id);
+    app.index += 1;
+    const newTrustchain = buildTrustchain(trustchain.rootId, applicationId, app);
 
     if (afterRotation) await afterRotation(newTrustchain);
 
-    return Promise.resolve(newTrustchain);
+    return newTrustchain;
   }
 
   async destroyTrustchain(
@@ -216,9 +246,37 @@ export class MockSDK implements TrustchainSDK {
   ): Promise<void> {
     assertTrustchain(trustchain);
     assertLiveCredentials(memberCredentials);
-    trustchains.delete(trustchain.rootId);
-    trustchainMembers.delete(trustchain.rootId);
+    roots.delete(trustchain.rootId);
     return;
+  }
+
+  async destroyApplication(
+    trustchain: Trustchain,
+    memberCredentials: MemberCredentials,
+  ): Promise<{ trustchainDestroyed: boolean }> {
+    this.invalidateJwt();
+    assertTrustchain(trustchain);
+    assertLiveCredentials(memberCredentials);
+    const applicationId = this.context.applicationId;
+    const root = roots.get(trustchain.rootId);
+    const app = root?.apps.get(applicationId);
+    if (!root || !app?.members.some(m => m.id === memberCredentials.pubkey)) {
+      throw new TrustchainEjected();
+    }
+    if (app.closed) {
+      return { trustchainDestroyed: false }; // already deactivated
+    }
+
+    const anotherApplicationIsOpen = [...root.apps.entries()].some(
+      ([id, a]) => id !== applicationId && !a.closed,
+    );
+    if (!anotherApplicationIsOpen) {
+      // last open application: destroy the whole trustchain, as before
+      roots.delete(trustchain.rootId);
+      return { trustchainDestroyed: true };
+    }
+    app.closed = true;
+    return { trustchainDestroyed: false };
   }
 
   addMember(
@@ -228,12 +286,18 @@ export class MockSDK implements TrustchainSDK {
   ): Promise<void> {
     assertTrustchain(trustchain);
     assertLiveCredentials(memberCredentials);
-    const currentMembers = trustchainMembers.get(trustchain.rootId) || [];
-    if (currentMembers.find(m => m.id === member.id)) {
+    const applicationId = this.context.applicationId;
+    const root = roots.get(trustchain.rootId) ?? { apps: new Map<number, MockAppState>() };
+    roots.set(trustchain.rootId, root);
+    let app = root.apps.get(applicationId);
+    if (!app) {
+      app = { index: 0, closed: false, members: [] };
+      root.apps.set(applicationId, app);
+    }
+    if (app.members.some(m => m.id === member.id)) {
       return Promise.resolve();
     }
-    currentMembers.push(member);
-    trustchainMembers.set(trustchain.rootId, currentMembers);
+    app.members.push(member);
     return Promise.resolve();
   }
 

--- a/libs/ledger-key-ring-protocol/src/sdk.ts
+++ b/libs/ledger-key-ring-protocol/src/sdk.ts
@@ -162,14 +162,18 @@ export class SDK implements TrustchainSDK {
 
     // make a stream tree from all the trustchains associated to this root id
     let { streamTree } = await withJwt(jwt => this.fetchTrustchain(jwt, trustchainRootId));
-    const path = streamTree.getApplicationRootPath(this.context.applicationId);
-    const child = streamTree.getChild(path);
+    let path = streamTree.getApplicationRootPath(this.context.applicationId);
+    let resolved = (await streamTree.getChild(path)?.resolve()) ?? null;
+
+    // if the current application stream was closed (deactivated), reopen it on the next index
+    if (resolved?.isClosed()) {
+      path = streamTree.getApplicationRootPath(this.context.applicationId, 1);
+      resolved = null; // the reopened stream does not exist yet; pushMember will derive it
+    }
+
     let shouldShare = true;
-
-    if (child) {
-      const resolved = await child.resolve();
+    if (resolved) {
       const members = resolved.getMembers();
-
       shouldShare = !members.some(m => crypto.to_hex(m) === memberCredentials.pubkey); // not already a member
     }
     if (shouldShare) {
@@ -196,13 +200,16 @@ export class SDK implements TrustchainSDK {
     trustchain: Trustchain,
     memberCredentials: MemberCredentials,
   ): Promise<Trustchain> {
-    const { streamTree, applicationRootPath } = await this.withAuth(
+    const { streamTree, applicationRootPath, resolved } = await this.withAuth(
       trustchain,
       memberCredentials,
       jwt => this.fetchTrustchainAndResolve(jwt, trustchain.rootId, this.context.applicationId),
       "refresh",
       true,
     );
+    if (resolved.isClosed()) {
+      throw new TrustchainEjected("application stream is closed");
+    }
     const walletSyncEncryptionKey = await extractEncryptionKey(
       streamTree,
       applicationRootPath,
@@ -355,6 +362,48 @@ export class SDK implements TrustchainSDK {
       this.api.deleteTrustchain(jwt, trustchain.rootId),
     );
     this.invalidateJwt();
+  }
+
+  async destroyApplication(
+    trustchain: Trustchain,
+    memberCredentials: MemberCredentials,
+  ): Promise<{ trustchainDestroyed: boolean }> {
+    this.invalidateJwt();
+
+    const applicationId = this.context.applicationId;
+    const trustchainId = trustchain.rootId;
+    const withJwt: WithJwt = job =>
+      this.withAuth(trustchain, memberCredentials, job, "refresh", true);
+
+    const { streamTree, applicationRootPath, resolved } = await withJwt(jwt =>
+      this.fetchTrustchainAndResolve(jwt, trustchainId, applicationId),
+    );
+
+    // already deactivated: closing again would push a redundant CloseStream
+    if (resolved.isClosed()) {
+      return { trustchainDestroyed: false };
+    }
+
+    // if this is the last open application, closing its stream would leave an empty
+    // trustchain: destroy the whole root instead, preserving the previous deactivation behaviour.
+    if (!(await streamTree.hasAnotherOpenApplication(applicationId))) {
+      await this.destroyTrustchain(trustchain, memberCredentials);
+      return { trustchainDestroyed: true };
+    }
+
+    // otherwise close only the current application stream, signed with the member's software key (no device)
+    const softwareDevice = getSoftwareDevice(memberCredentials);
+    const withSw = (job: (device: Device) => Promise<StreamTree>) => job(softwareDevice);
+    const sendCloseStreamToAPI = await this.closeStream(
+      streamTree,
+      applicationRootPath,
+      trustchainId,
+      withJwt,
+      withSw,
+    );
+    await sendCloseStreamToAPI();
+    this.invalidateJwt();
+    return { trustchainDestroyed: false };
   }
 
   async encryptUserData(trustchain: Trustchain, input: Uint8Array): Promise<Uint8Array> {

--- a/libs/ledger-key-ring-protocol/src/types.ts
+++ b/libs/ledger-key-ring-protocol/src/types.ts
@@ -220,6 +220,18 @@ export interface TrustchainSDK {
   destroyTrustchain(trustchain: Trustchain, memberCredentials: MemberCredentials): Promise<void>;
 
   /**
+   * Deactivate the current application for this member.
+   * Normally this closes only the current application's stream (signed with the member's software key,
+   * no hardware device), preserving the other applications and the trustchain root.
+   * If the current application is the last open one, the whole trustchain is destroyed instead.
+   * @returns `trustchainDestroyed` true when the whole trustchain was destroyed (last open application).
+   */
+  destroyApplication(
+    trustchain: Trustchain,
+    memberCredentials: MemberCredentials,
+  ): Promise<{ trustchainDestroyed: boolean }>;
+
+  /**
    * encrypt data with the trustchain encryption key
    */
   encryptUserData(trustchain: Trustchain, obj: object): Promise<Uint8Array>;

--- a/libs/ledger-key-ring-protocol/tests/scenarios/destroyApplicationKeepsOtherApps.ts
+++ b/libs/ledger-key-ring-protocol/tests/scenarios/destroyApplicationKeepsOtherApps.ts
@@ -1,0 +1,68 @@
+import { TrustchainEjected, TrustchainNotAllowed } from "../../src/errors";
+import { ScenarioOptions } from "../test-helpers/types";
+
+// Deactivating one application (Ledger Sync, app 16) must close only that
+// application's stream: the ring application (app 17) and the trustchain root
+// must survive, and every Ledger Sync instance must reconcile to "ejected".
+// destroyApplication only destroys the whole trustchain when closing the last open application.
+export async function scenario(deviceId: string, { sdkForName }: ScenarioOptions) {
+  // two Ledger Sync instances (app 16) of the same trustchain
+  const sdkSync1 = sdkForName("Sync instance 1");
+  const sync1creds = await sdkSync1.initMemberCredentials();
+  const { trustchain: syncTrustchain } = await sdkSync1.getOrCreateTrustchain(deviceId, sync1creds);
+
+  const sdkSync2 = sdkForName("Sync instance 2");
+  const sync2creds = await sdkSync2.initMemberCredentials();
+  await sdkSync2.getOrCreateTrustchain(deviceId, sync2creds);
+
+  // a ring application (app 17) shares the same trustchain root
+  const sdkRing = sdkForName("Ring member", { applicationId: 17 });
+  const ringCreds = await sdkRing.initMemberCredentials();
+  const { trustchain: ringTrustchain } = await sdkRing.getOrCreateTrustchain(deviceId, ringCreds);
+
+  // instance 1 deactivates Ledger Sync
+  const { trustchainDestroyed } = await sdkSync1.destroyApplication(syncTrustchain, sync1creds);
+  expect(trustchainDestroyed).toBe(false); // the ring application is still open, the root is preserved
+
+  // deactivating an already-closed application is a no-op (idempotent, no second CloseStream)
+  const secondClose = await sdkSync1.destroyApplication(syncTrustchain, sync1creds);
+  expect(secondClose.trustchainDestroyed).toBe(false);
+
+  // both Ledger Sync instances reconcile to ejected
+  await expect(sdkSync1.restoreTrustchain(syncTrustchain, sync1creds)).rejects.toThrow(
+    TrustchainEjected,
+  );
+  sdkSync2.invalidateJwt();
+  await expect(sdkSync2.restoreTrustchain(syncTrustchain, sync2creds)).rejects.toThrow(
+    TrustchainEjected,
+  );
+
+  // the ring application still works
+  sdkRing.invalidateJwt();
+  const ringMembers = await sdkRing.getMembers(ringTrustchain, ringCreds);
+  expect(ringMembers.some(m => m.id === ringCreds.pubkey)).toBe(true);
+
+  // re-activating Ledger Sync reopens the application within the same trustchain, on a new index
+  const reactivated = await sdkSync1.getOrCreateTrustchain(deviceId, sync1creds);
+  expect(reactivated.type).toBe("updated"); // reopened inside the existing trustchain, instance 1 re-added as member
+  expect(reactivated.trustchain.applicationPath).not.toBe(syncTrustchain.applicationPath);
+  const membersAfter = await sdkSync1.getMembers(reactivated.trustchain, sync1creds);
+  expect(membersAfter.some(m => m.id === sync1creds.pubkey)).toBe(true); // instance 1 is a member again
+
+  // instance 2 was not re-added to the reopened stream. The real backend has no permission for it on
+  // the new stream (TrustchainNotAllowed); the in-memory mock surfaces the same lock-out as TrustchainEjected.
+  // Both are handled identically (resetLedgerSync) by the apps.
+  const sync2RestoreError = await sdkSync2
+    .restoreTrustchain(reactivated.trustchain, sync2creds)
+    .then(
+      () => null,
+      (e: unknown) => e,
+    );
+  expect(
+    sync2RestoreError instanceof TrustchainNotAllowed ||
+      sync2RestoreError instanceof TrustchainEjected,
+  ).toBe(true);
+
+  // cleanup
+  await sdkSync1.destroyTrustchain(reactivated.trustchain, sync1creds);
+}

--- a/libs/ledger-key-ring-protocol/tests/scenarios/destroyLastApplicationDestroysTrustchain.ts
+++ b/libs/ledger-key-ring-protocol/tests/scenarios/destroyLastApplicationDestroysTrustchain.ts
@@ -1,0 +1,19 @@
+import { ScenarioOptions } from "../test-helpers/types";
+
+// When the application being deactivated is the last open one of the trustchain,
+// destroyApplication destroys the whole trustchain (the previous behaviour).
+export async function scenario(deviceId: string, { sdkForName }: ScenarioOptions) {
+  const sdk = sdkForName("Sole member");
+  const creds = await sdk.initMemberCredentials();
+  const { trustchain } = await sdk.getOrCreateTrustchain(deviceId, creds);
+
+  const { trustchainDestroyed } = await sdk.destroyApplication(trustchain, creds);
+  expect(trustchainDestroyed).toBe(true);
+
+  // the trustchain no longer exists: a new getOrCreateTrustchain recreates it
+  const recreated = await sdk.getOrCreateTrustchain(deviceId, creds);
+  expect(recreated.type).toBe("created");
+
+  // cleanup
+  await sdk.destroyTrustchain(recreated.trustchain, creds);
+}


### PR DESCRIPTION

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** New e2e scenarios `destroyApplicationKeepsOtherApps` and `destroyLastApplicationDestroysTrustchain`; existing replay (18) and mock (14) suites stay green.
- i've been able to manually test and we have end 2 end tests on this PR too.
- [x] **Impact of the changes:** Ledger Sync deactivation (LLD + LLM).
  - QA: deactivate Ledger Sync on one instance with another instance active → both must show "not activated", and the trustchain root must survive if another application (e.g. wallet-cli `ring`) is open. Re-activation after deactivation must work.

### 📝 Description

Trustchain (LKRP) is one cryptographic root shared by several applications, each on its own path `m/0'/{applicationId}'/{index}'` (Ledger Sync = 16, wallet-cli ring = 17). Today both deactivate via `destroyTrustchain` → `DELETE /trustchain/{rootId}`, which destroys the **whole root** (all applications). So "Delete Sync" wipes the ring and `ring destroy` wipes Ledger Sync.

This closes only the current application's stream on deactivation, signed with the member's **software key** (no hardware device, matching today's UX). When the closed application is the last open one, the whole trustchain is still destroyed (previous behaviour).

The foundation is making a closed stream observable client-side: `CommandStreamResolver` previously ignored `CloseStream`, so a closed stream resolved identically to an open one. With `isClosed()` exposed, the existing reconciliation (watch loop → `onTrustchainRefreshNeeded` → `resetTrustchainStore`) handles the "ejected" case with no UI changes.

Consumer side after merge:

```diff
- await sdk.destroyTrustchain(trustchain, memberCredentials);
+ const { trustchainDestroyed } = await sdk.destroyApplication(trustchain, memberCredentials);
```

`destroyApplication` decides close-vs-destroy internally; `trustchainDestroyed` reports whether the whole trustchain was destroyed (last open application).

Breakdown:
- resolver observes `CloseStream` (`ResolvedCommandStream.isClosed()`)
- `StreamTree.getApplicationStreams()` / `hasAnotherOpenApplication()` enumerate application streams
- new `TrustchainSDK.destroyApplication()` primitive (generic, so the wallet-cli ring PR can adopt it)
- `restoreTrustchain` and `getMembers` reject a closed stream with `TrustchainEjected`
- `getOrCreateTrustchain` reopens on the next index after a close
- LLD/LLM `useDestroyTrustchain` hooks call `destroyApplication`

### ❓ Context

- **JIRA or GitHub link**:  https://ledgerhq.atlassian.net/browse/LIVE-32995
- **ADR link (if any)**:
