### PR TITLE
[LWM] feat(mobile): enable volume sorting in the market filters

### DIFF
--- a/.changeset/lwm-market-volume-sort.md
+++ b/.changeset/lwm-market-volume-sort.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Enable the "Volume" sorting option in the Market filters: it is no longer greyed out and now sorts the asset list by total volume (descending), using the total-volume endpoint support.

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketAssets.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketAssets.test.ts
@@ -134,11 +134,11 @@ describe("useMarketAssets", () => {
     );
   });
 
-  it("falls back to market cap sorting while volume is unavailable", () => {
+  it("maps volume sorting to the total-volume order", () => {
     renderHook(() => useMarketAssets({ sorting: "volume" }));
 
     expect(mockedUseMarketData).toHaveBeenLastCalledWith(
-      expect.objectContaining({ order: Order.MarketCapDesc }),
+      expect.objectContaining({ order: Order.VolumeDesc }),
     );
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketFilters.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketFilters.test.ts
@@ -32,13 +32,17 @@ describe("useMarketFilters", () => {
     });
   });
 
-  it("blocks volume sorting while the API does not support it", () => {
+  it("persists volume sorting and tracks the selection", () => {
     const { result, store } = renderHook(() => useMarketFilters());
 
     act(() => result.current.onSelectSorting("volume"));
 
-    expect(store.getState().marketListConfig.sorting).toBe("marketCap");
-    expect(track).not.toHaveBeenCalled();
+    expect(store.getState().marketListConfig.sorting).toBe("volume");
+    expect(track).toHaveBeenCalledWith("sort_market_list", {
+      sorting: "volume",
+      timeframe: "1D",
+      network: "all",
+    });
   });
 
   it("persists timeframe values and tracks them with the current sorting", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/marketListFilters.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/marketListFilters.ts
@@ -1,7 +1,7 @@
 import { KeysPriceChange, Order } from "@ledgerhq/live-common/market/utils/types";
 import type { MarketListFilterTimeframe, MarketListSorting } from "~/reducers/types";
 
-const SUPPORTED_SORTINGS = new Set<MarketListSorting>(["marketCap", "gainers", "losers"]);
+const SUPPORTED_SORTINGS = new Set<MarketListSorting>(["marketCap", "volume", "gainers", "losers"]);
 const SUPPORTED_TIMEFRAMES = new Set<MarketListFilterTimeframe>(["1D", "7D", "30D", "6M", "1Y"]);
 
 export function isMarketListSortingSupported(sorting: MarketListSorting): boolean {
@@ -24,8 +24,9 @@ export function getMarketListOrder(sorting: MarketListSorting): Order {
       return Order.topGainers;
     case "losers":
       return Order.topLosers;
-    case "marketCap":
     case "volume":
+      return Order.VolumeDesc;
+    case "marketCap":
     default:
       return Order.MarketCapDesc;
   }

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketFilters.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketFilters.ts
@@ -36,7 +36,7 @@ const ALL_NETWORKS_VALUE = "all";
 
 const sortingOptions: MarketFilterOption<MarketListSorting>[] = [
   { value: "marketCap", labelKey: "market.assets.filters.sortingOptions.marketCap" },
-  { value: "volume", labelKey: "market.assets.filters.sortingOptions.volume", disabled: true },
+  { value: "volume", labelKey: "market.assets.filters.sortingOptions.volume" },
   { value: "gainers", labelKey: "market.assets.filters.sortingOptions.gainers" },
   { value: "losers", labelKey: "market.assets.filters.sortingOptions.losers" },
 ];


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _`useMarketFilters` (volume now persists + tracks) and `useMarketAssets` (volume maps to the total-volume order) tests updated._
- [x] **Impact of the changes:**
      - Market filter drawer: the "Volume" sort option is now enabled (no longer greyed out) and selectable.
      - Selecting Volume sorts the asset list by total volume (descending).

### 📝 Description

**Problem**: Volume is a sorting method (not a category) and should be selectable, but it was greyed out in the Market filter drawer because the endpoint didn't support it yet.

**Solution**: now that the total-volume sort is available in `live-common` (added for LWD in #18541, `Order.VolumeDesc` → `total-volume-desc`), this enables it for LWM:
- `volume` is added to the supported sortings and mapped to `Order.VolumeDesc` in `getMarketListOrder`.
- the `disabled` flag is removed from the Volume option in the filter drawer.


https://github.com/user-attachments/assets/4b0e28c1-e876-4a5d-8591-30013670858b



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32096](https://ledgerhq.atlassian.net/browse/LIVE-32096)
- Builds on the LWD total-volume sort: #18541

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-32096]: https://ledgerhq.atlassian.net/browse/LIVE-32096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ