### PR TITLE
[LWDM] baby staking positions

### DIFF
--- a/.changeset/quiet-falcons-gather.md
+++ b/.changeset/quiet-falcons-gather.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-cosmos": minor
+---
+
+Show pending (epoch-queued) Babylon staking positions by merging the x/epoching message queue into staking positions during sync

--- a/libs/coin-modules/coin-cosmos/src/chain/Babylon.ts
+++ b/libs/coin-modules/coin-cosmos/src/chain/Babylon.ts
@@ -5,6 +5,7 @@ export default class Babylon extends CosmosBase {
   unbondingPeriod: number;
   prefix: string;
   validatorPrefix: string;
+  epochedStaking = true;
   // Provided by coin config
   ledgerValidator!: string;
   lcd!: string;

--- a/libs/coin-modules/coin-cosmos/src/chain/cosmosBase.ts
+++ b/libs/coin-modules/coin-cosmos/src/chain/cosmosBase.ts
@@ -9,6 +9,8 @@ abstract class cosmosBase {
   defaultGas = 100000;
   minGasPrice = 0.0025;
   version = "v1beta1";
+  // chain queues staking msgs until epoch end (x/epoching); sync merges the queue into positions
+  epochedStaking = false;
   public static COSMOS_FAMILY_LEDGER_VALIDATOR_ADDRESSES: string[] = [];
 }
 

--- a/libs/coin-modules/coin-cosmos/src/network/Cosmos.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/Cosmos.ts
@@ -18,6 +18,7 @@ import {
   CosmosUnbonding,
   CosmosValidatorItem,
 } from "../types";
+import { fetchQueuedStakingMessages, mergeQueuedMessages } from "./babylonEpoching";
 import * as CosmosSDKTypes from "./types";
 
 const USDC_DENOM = "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5";
@@ -78,15 +79,32 @@ export class CosmosAPI {
         this.getWithdrawAddress(address),
       ]);
 
+      let staking = { delegations, redelegations, unbondings };
+
+      if (this.chainInstance.epochedStaking) {
+        const queued = await fetchQueuedStakingMessages(
+          this.defaultEndpoint,
+          address,
+          currency.units[1].code,
+        );
+        // at or past the boundary the queued msgs have already executed into `delegations`
+        // (the queue runs in the boundary block's EndBlocker), so merging would double-count
+        if (queued && queued.messages.length > 0 && blockHeight < queued.epochBoundary) {
+          staking = mergeQueuedMessages(staking, queued.messages, {
+            blockHeight,
+            epochBoundary: queued.epochBoundary,
+            unbondingPeriodDays: this.chainInstance.unbondingPeriod,
+          });
+        }
+      }
+
       return {
         accountInfo,
         balances,
         blockHeight,
         txs,
-        delegations,
-        redelegations,
-        unbondings,
         withdrawAddress,
+        ...staking,
       };
     } catch (e) {
       const error = e as AxiosError;

--- a/libs/coin-modules/coin-cosmos/src/network/Cosmos.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/Cosmos.unit.test.ts
@@ -1,5 +1,6 @@
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import network from "@ledgerhq/live-network/network";
+import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { Operation } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import cryptoFactory from "../chain/chain";
@@ -635,6 +636,182 @@ describe("CosmosApi", () => {
           signedOperation: { operation: {} as Operation, signature: "signedOperation" },
         }),
       ).rejects.toThrow("SequenceNumberError");
+    });
+  });
+
+  describe("getAccountInfo", () => {
+    const babylonAddress = "bbn1uwpws077a0a9pclapv3f2fyj5u0mlh6ewmds8n";
+    const babylonCurrency = { id: "babylon", units: [{}, { code: "ubbn" }] } as CryptoCurrency;
+
+    const queuedDelegate = {
+      msg_type: "cosmos.staking.v1beta1.MsgDelegate",
+      msg: `delegator_address:"${babylonAddress}" validator_address:"bbnvaloper1pending" amount:<denom:"ubbn" amount:"30" >`,
+    };
+    const queuedUndelegate = {
+      msg_type: "cosmos.staking.v1beta1.MsgUndelegate",
+      msg: `delegator_address:"${babylonAddress}" validator_address:"bbnvaloper1active" amount:<denom:"ubbn" amount:"10" >`,
+    };
+    const queuedForeignDelegate = {
+      msg_type: "cosmos.staking.v1beta1.MsgDelegate",
+      msg: `delegator_address:"bbn1someoneelse" validator_address:"bbnvaloper1pending" amount:<denom:"ubbn" amount:"99" >`,
+    };
+
+    const mockAccountInfoRoutes = (opts: {
+      height?: number;
+      epochs?: string[];
+      epochBoundary?: string;
+      msgs?: { msg: string; msg_type: string }[];
+      epochingError?: boolean;
+    }) => {
+      const {
+        height = 100,
+        epochs = ["5"],
+        epochBoundary = "360",
+        msgs = [],
+        epochingError = false,
+      } = opts;
+      let currentEpochCalls = 0;
+      // @ts-expect-error method is mocked
+      network.mockImplementation(({ url }: { url: string }) => {
+        const respond = (data: unknown) => Promise.resolve({ data });
+        if (url.includes("/babylon/epoching/v1/")) {
+          if (epochingError) {
+            return Promise.reject(new Error("epoching unavailable"));
+          }
+          if (url.includes("current_epoch")) {
+            const epoch = epochs[Math.min(currentEpochCalls, epochs.length - 1)];
+            currentEpochCalls += 1;
+            return respond({ current_epoch: epoch, epoch_boundary: epochBoundary });
+          }
+          return respond({ msgs, pagination: { next_key: null, total: String(msgs.length) } });
+        }
+        if (url.includes("node_info")) {
+          return respond({ application_version: { cosmos_sdk_version: "0.50.0" } });
+        }
+        if (url.includes("blocks/latest")) {
+          return respond({ block: { header: { height: String(height) } } });
+        }
+        if (url.includes("/auth/")) {
+          return respond({
+            account: {
+              "@type": "/cosmos.auth.v1beta1.BaseAccount",
+              account_number: "1",
+              sequence: "1",
+            },
+          });
+        }
+        if (url.includes("/bank/")) {
+          return respond({ balances: [{ denom: "ubbn", amount: "70" }] });
+        }
+        if (url.includes("/tx/v1beta1/txs")) {
+          return respond({ tx_responses: [], total: "0" });
+        }
+        if (url.includes("/redelegations")) {
+          return respond({ redelegation_responses: [] });
+        }
+        if (url.includes("/unbonding_delegations")) {
+          return respond({ unbonding_responses: [] });
+        }
+        if (url.includes("/withdraw_address")) {
+          return respond({ withdraw_address: babylonAddress });
+        }
+        if (url.includes("/rewards")) {
+          return respond({ rewards: [] });
+        }
+        if (url.includes("/staking/v1beta1/delegations/")) {
+          return respond({
+            delegation_responses: [
+              {
+                delegation: { validator_address: "bbnvaloper1active" },
+                balance: { denom: "ubbn", amount: "50" },
+              },
+            ],
+          });
+        }
+        if (url.includes("/staking/v1beta1/validators/")) {
+          return respond({ validator: { status: "BOND_STATUS_BONDED" } });
+        }
+        return Promise.reject(new Error(`unmocked url: ${url}`));
+      });
+    };
+
+    it("merges queued epoching staking messages into babylon positions", async () => {
+      mockAccountInfoRoutes({ msgs: [queuedDelegate, queuedUndelegate, queuedForeignDelegate] });
+      const babylonApi = new CosmosAPI("babylon");
+      const result = await babylonApi.getAccountInfo(babylonAddress, babylonCurrency);
+
+      expect(result.delegations).toEqual([
+        expect.objectContaining({
+          validatorAddress: "bbnvaloper1active",
+          amount: new BigNumber(40),
+        }),
+        expect.objectContaining({
+          validatorAddress: "bbnvaloper1pending",
+          amount: new BigNumber(30),
+          pendingRewards: new BigNumber(0),
+          status: "bonded",
+        }),
+      ]);
+      expect(result.unbondings).toEqual([
+        expect.objectContaining({
+          validatorAddress: "bbnvaloper1active",
+          amount: new BigNumber(10),
+        }),
+      ]);
+      // enrichment only — the bank balance must be untouched (guards against double-counting)
+      expect(result.balances).toEqual(new BigNumber(70));
+    });
+
+    it("does not merge when the epoch changes during the queue fetch", async () => {
+      mockAccountInfoRoutes({ epochs: ["5", "6"], msgs: [queuedDelegate] });
+      const babylonApi = new CosmosAPI("babylon");
+      const result = await babylonApi.getAccountInfo(babylonAddress, babylonCurrency);
+
+      expect(result.delegations).toEqual([
+        expect.objectContaining({
+          validatorAddress: "bbnvaloper1active",
+          amount: new BigNumber(50),
+        }),
+      ]);
+      expect(result.unbondings).toEqual([]);
+    });
+
+    it("does not merge when the block height is past the epoch boundary", async () => {
+      mockAccountInfoRoutes({ height: 999, epochBoundary: "360", msgs: [queuedDelegate] });
+      const babylonApi = new CosmosAPI("babylon");
+      const result = await babylonApi.getAccountInfo(babylonAddress, babylonCurrency);
+
+      expect(result.delegations).toEqual([expect.objectContaining({ amount: new BigNumber(50) })]);
+    });
+
+    it("does not merge when the block height equals the epoch boundary", async () => {
+      // at the boundary block the queue has already executed into the on-chain delegations
+      mockAccountInfoRoutes({ height: 360, epochBoundary: "360", msgs: [queuedDelegate] });
+      const babylonApi = new CosmosAPI("babylon");
+      const result = await babylonApi.getAccountInfo(babylonAddress, babylonCurrency);
+
+      expect(result.delegations).toEqual([expect.objectContaining({ amount: new BigNumber(50) })]);
+    });
+
+    it("keeps the babylon sync alive when the epoching endpoint fails", async () => {
+      mockAccountInfoRoutes({ epochingError: true, msgs: [queuedDelegate] });
+      const babylonApi = new CosmosAPI("babylon");
+      const result = await babylonApi.getAccountInfo(babylonAddress, babylonCurrency);
+
+      expect(result.balances).toEqual(new BigNumber(70));
+      expect(result.delegations).toEqual([expect.objectContaining({ amount: new BigNumber(50) })]);
+    });
+
+    it("never requests epoching endpoints for non-epoched chains", async () => {
+      mockAccountInfoRoutes({});
+      await cosmosApi.getAccountInfo("cosmos1myaddress", {
+        id: "cosmos",
+        units: [{}, { code: "uatom" }],
+      } as CryptoCurrency);
+
+      const requestedUrls = mockedNetwork.mock.calls.map(([options]) => options.url);
+      expect(requestedUrls.length).toBeGreaterThan(0);
+      expect(requestedUrls.some(url => url?.includes("epoching"))).toBe(false);
     });
   });
 });

--- a/libs/coin-modules/coin-cosmos/src/network/babylonEpoching.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/babylonEpoching.ts
@@ -1,0 +1,261 @@
+import network from "@ledgerhq/live-network/network";
+import { log } from "@ledgerhq/logs";
+import BigNumber from "bignumber.js";
+import { CosmosDelegation, CosmosRedelegation, CosmosUnbonding } from "../types";
+
+// Babylon's x/epoching module queues wrapped staking msgs until the last block of the
+// epoch (~1h), so they are invisible on the standard staking endpoints until then, even
+// though MsgWrappedDelegate locks the funds at enqueue time. These helpers fetch the
+// current epoch's queue and merge it into the staking positions.
+
+export type QueuedStakingMessage =
+  | {
+      type: "delegate" | "undelegate";
+      delegatorAddress: string;
+      validatorAddress: string;
+      amount: BigNumber;
+      denom: string;
+    }
+  | {
+      type: "redelegate";
+      delegatorAddress: string;
+      validatorSrcAddress: string;
+      validatorDstAddress: string;
+      amount: BigNumber;
+      denom: string;
+    };
+
+type CurrentEpochResponse = {
+  current_epoch: string;
+  epoch_boundary: string;
+};
+
+type EpochMessagesResponse = {
+  msgs: {
+    tx_id: string;
+    msg_id: string;
+    block_height: string;
+    block_time: string;
+    // inner staking msg in gogoproto text format, e.g.
+    // delegator_address:"bbn1..." validator_address:"bbnvaloper1..." amount:<denom:"ubbn" amount:"398688" >
+    msg: string;
+    // inner (unwrapped) msg type, e.g. "cosmos.staking.v1beta1.MsgDelegate"
+    msg_type: string;
+  }[];
+  pagination: { next_key: string | null; total: string };
+};
+
+const delegatorAddressRegex = /(?:^|\s)delegator_address:\s*"([a-z0-9]+)"/;
+const validatorAddressRegex = /(?:^|\s)validator_address:\s*"([a-z0-9]+)"/;
+const validatorSrcAddressRegex = /(?:^|\s)validator_src_address:\s*"([a-z0-9]+)"/;
+const validatorDstAddressRegex = /(?:^|\s)validator_dst_address:\s*"([a-z0-9]+)"/;
+const amountRegex =
+  /(?:^|\s)amount:\s*[<{]\s*denom:\s*"([a-zA-Z0-9/\-._]+)"\s+amount:\s*"(\d+)"\s*[>}]/;
+
+export const parseQueuedMessage = (
+  msgType: string,
+  msgText: string,
+): QueuedStakingMessage | undefined => {
+  const isUndelegate = msgType.endsWith("MsgUndelegate");
+  const isRedelegate = msgType.endsWith("MsgBeginRedelegate");
+  const isDelegate = msgType.endsWith("MsgDelegate");
+  if (!isDelegate && !isUndelegate && !isRedelegate) {
+    return undefined;
+  }
+
+  // a known staking msg_type that fails to match below means the gogoproto-text format
+  // drifted — warn instead of returning a silent undefined that would under-count positions
+  const onParseFailure = (): undefined => {
+    log("warn", "babylon epoching: failed to parse known staking msg", { msgType });
+    return undefined;
+  };
+
+  const delegatorMatch = delegatorAddressRegex.exec(msgText);
+  const amountMatch = amountRegex.exec(msgText);
+  if (!delegatorMatch || !amountMatch) {
+    return onParseFailure();
+  }
+  const base = {
+    delegatorAddress: delegatorMatch[1],
+    denom: amountMatch[1],
+    amount: new BigNumber(amountMatch[2]),
+  };
+
+  if (isRedelegate) {
+    const srcMatch = validatorSrcAddressRegex.exec(msgText);
+    const dstMatch = validatorDstAddressRegex.exec(msgText);
+    if (!srcMatch || !dstMatch) {
+      return onParseFailure();
+    }
+    return {
+      type: "redelegate",
+      validatorSrcAddress: srcMatch[1],
+      validatorDstAddress: dstMatch[1],
+      ...base,
+    };
+  }
+
+  const validatorMatch = validatorAddressRegex.exec(msgText);
+  if (!validatorMatch) {
+    return onParseFailure();
+  }
+  return {
+    type: isUndelegate ? "undelegate" : "delegate",
+    validatorAddress: validatorMatch[1],
+    ...base,
+  };
+};
+
+const EPOCH_MSGS_PAGE_LIMIT = 200;
+const EPOCH_MSGS_MAX_PAGES = 10;
+const BABYLON_BLOCK_TIME_MS = 10_000;
+
+export const fetchQueuedStakingMessages = async (
+  endpoint: string,
+  address: string,
+  denom: string,
+): Promise<{ messages: QueuedStakingMessage[]; epochBoundary: number } | null> => {
+  try {
+    const getCurrentEpoch = async (): Promise<CurrentEpochResponse> => {
+      const { data } = await network<CurrentEpochResponse>({
+        method: "GET",
+        // epoching routes are versioned v1, unlike the chain's v1beta1 cosmos routes
+        url: `${endpoint}/babylon/epoching/v1/current_epoch`,
+      });
+      return data;
+    };
+
+    const { current_epoch: currentEpoch, epoch_boundary: epochBoundary } = await getCurrentEpoch();
+
+    const queued: EpochMessagesResponse["msgs"] = [];
+    let nextKey: string | null | undefined;
+    let pages = 0;
+    do {
+      const { data } = await network<EpochMessagesResponse>({
+        method: "GET",
+        url:
+          `${endpoint}/babylon/epoching/v1/epochs/${currentEpoch}/messages` +
+          `?pagination.limit=${EPOCH_MSGS_PAGE_LIMIT}` +
+          (nextKey ? `&pagination.key=${encodeURIComponent(nextKey)}` : ""),
+      });
+      queued.push(...(data.msgs ?? []));
+      nextKey = data.pagination?.next_key;
+      pages += 1;
+    } while (nextKey && pages < EPOCH_MSGS_MAX_PAGES);
+
+    if (nextKey) {
+      // merging a partial queue would under-count positions; skip the enrichment entirely
+      // rather than surface a wrong subset (fail-open, like the catch below)
+      log("warn", "babylon epoching: pagination cap reached, skipping queue merge");
+      return null;
+    }
+
+    // an epoch rollover between the reads above would make the queue inconsistent with
+    // the rest of the account data (msgs executed but still listed) — skip this sync
+    const { current_epoch: epochAfter } = await getCurrentEpoch();
+    if (epochAfter !== currentEpoch) {
+      return null;
+    }
+
+    const messages = queued
+      .map(m => parseQueuedMessage(m.msg_type, m.msg))
+      .filter((m): m is QueuedStakingMessage => m !== undefined)
+      .filter(m => m.delegatorAddress === address && m.denom === denom);
+
+    return { messages, epochBoundary: Number.parseInt(epochBoundary, 10) };
+  } catch (e) {
+    // fail open: pending positions are an enrichment, an epoching endpoint failure
+    // must not break the whole babylon sync
+    log("warn", "babylon epoching: could not fetch queued staking messages", { e });
+    return null;
+  }
+};
+
+export const mergeQueuedMessages = (
+  resources: {
+    delegations: CosmosDelegation[];
+    redelegations: CosmosRedelegation[];
+    unbondings: CosmosUnbonding[];
+  },
+  messages: QueuedStakingMessage[],
+  params: { blockHeight: number; epochBoundary: number; unbondingPeriodDays: number },
+): {
+  delegations: CosmosDelegation[];
+  redelegations: CosmosRedelegation[];
+  unbondings: CosmosUnbonding[];
+} => {
+  const delegations = resources.delegations.map(d => ({ ...d }));
+  const redelegations = [...resources.redelegations];
+  const unbondings = [...resources.unbondings];
+
+  const estimatedEpochEndMs =
+    Math.max(0, params.epochBoundary - params.blockHeight) * BABYLON_BLOCK_TIME_MS;
+  const completionDate = new Date(
+    Date.now() + estimatedEpochEndMs + params.unbondingPeriodDays * 86_400_000,
+  );
+
+  const addToDelegation = (validatorAddress: string, amount: BigNumber) => {
+    const existing = delegations.find(d => d.validatorAddress === validatorAddress);
+    if (existing) {
+      existing.amount = existing.amount.plus(amount);
+    } else {
+      delegations.push({
+        validatorAddress,
+        amount,
+        pendingRewards: new BigNumber(0),
+        status: "bonded",
+      });
+    }
+  };
+
+  // clamping to the current delegation keeps the merge balance-neutral even when the
+  // queue holds more undelegations than the delegation can cover (the chain will fail
+  // the excess ones at epoch end)
+  const removeFromDelegation = (validatorAddress: string, amount: BigNumber): BigNumber => {
+    const existing = delegations.find(d => d.validatorAddress === validatorAddress);
+    if (!existing) {
+      return new BigNumber(0);
+    }
+    const moved = BigNumber.min(amount, existing.amount);
+    existing.amount = existing.amount.minus(moved);
+    return moved;
+  };
+
+  for (const message of messages) {
+    switch (message.type) {
+      case "delegate":
+        addToDelegation(message.validatorAddress, message.amount);
+        break;
+      case "undelegate": {
+        const moved = removeFromDelegation(message.validatorAddress, message.amount);
+        if (moved.gt(0)) {
+          unbondings.push({
+            validatorAddress: message.validatorAddress,
+            amount: moved,
+            completionDate,
+          });
+        }
+        break;
+      }
+      case "redelegate": {
+        const moved = removeFromDelegation(message.validatorSrcAddress, message.amount);
+        if (moved.gt(0)) {
+          addToDelegation(message.validatorDstAddress, moved);
+          redelegations.push({
+            validatorSrcAddress: message.validatorSrcAddress,
+            validatorDstAddress: message.validatorDstAddress,
+            amount: moved,
+            completionDate,
+          });
+        }
+        break;
+      }
+    }
+  }
+
+  return {
+    delegations: delegations.filter(d => d.amount.gt(0)),
+    redelegations,
+    unbondings,
+  };
+};

--- a/libs/coin-modules/coin-cosmos/src/network/babylonEpoching.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/babylonEpoching.unit.test.ts
@@ -1,0 +1,373 @@
+import network from "@ledgerhq/live-network/network";
+import { log } from "@ledgerhq/logs";
+import BigNumber from "bignumber.js";
+import { CosmosDelegation } from "../types";
+import {
+  fetchQueuedStakingMessages,
+  mergeQueuedMessages,
+  parseQueuedMessage,
+  QueuedStakingMessage,
+} from "./babylonEpoching";
+
+jest.mock("@ledgerhq/live-network/network");
+jest.mock("@ledgerhq/logs", () => ({
+  ...jest.requireActual("@ledgerhq/logs"),
+  log: jest.fn(),
+}));
+const mockedNetwork = jest.mocked(network);
+const mockedLog = jest.mocked(log);
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("parseQueuedMessage", () => {
+  // live sample from /babylon/epoching/v1/epochs/{epoch}/messages
+  const delegateText =
+    'delegator_address:"bbn1tng3l589auzpvr6dtwujhqvkhqgrk2hwlqxe2k" validator_address:"bbnvaloper10042ualva0yqh7ccpzhg9ya2gd9xpfsrcd6m4w" amount:<denom:"ubbn" amount:"398688" >';
+
+  it("parses a queued MsgDelegate", () => {
+    expect(parseQueuedMessage("cosmos.staking.v1beta1.MsgDelegate", delegateText)).toEqual({
+      type: "delegate",
+      delegatorAddress: "bbn1tng3l589auzpvr6dtwujhqvkhqgrk2hwlqxe2k",
+      validatorAddress: "bbnvaloper10042ualva0yqh7ccpzhg9ya2gd9xpfsrcd6m4w",
+      amount: new BigNumber(398688),
+      denom: "ubbn",
+    });
+  });
+
+  it("parses a queued MsgUndelegate", () => {
+    expect(parseQueuedMessage("cosmos.staking.v1beta1.MsgUndelegate", delegateText)).toEqual(
+      expect.objectContaining({ type: "undelegate" }),
+    );
+  });
+
+  it("parses a queued MsgBeginRedelegate", () => {
+    const text =
+      'delegator_address:"bbn1delegator" validator_src_address:"bbnvaloper1src" validator_dst_address:"bbnvaloper1dst" amount:<denom:"ubbn" amount:"42" >';
+    expect(parseQueuedMessage("cosmos.staking.v1beta1.MsgBeginRedelegate", text)).toEqual({
+      type: "redelegate",
+      delegatorAddress: "bbn1delegator",
+      validatorSrcAddress: "bbnvaloper1src",
+      validatorDstAddress: "bbnvaloper1dst",
+      amount: new BigNumber(42),
+      denom: "ubbn",
+    });
+  });
+
+  it("tolerates curly-brace proto text and a leading slash in msg_type", () => {
+    const text =
+      'delegator_address:"bbn1delegator" validator_address:"bbnvaloper1val" amount:{denom:"ubbn" amount:"7"}';
+    expect(parseQueuedMessage("/cosmos.staking.v1beta1.MsgDelegate", text)).toEqual({
+      type: "delegate",
+      delegatorAddress: "bbn1delegator",
+      validatorAddress: "bbnvaloper1val",
+      amount: new BigNumber(7),
+      denom: "ubbn",
+    });
+  });
+
+  it("returns undefined for non-staking msg types", () => {
+    expect(
+      parseQueuedMessage("cosmos.staking.v1beta1.MsgCancelUnbondingDelegation", delegateText),
+    ).toBeUndefined();
+    expect(
+      parseQueuedMessage("cosmos.staking.v1beta1.MsgEditValidator", delegateText),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when expected fields are missing", () => {
+    expect(parseQueuedMessage("cosmos.staking.v1beta1.MsgDelegate", "garbage")).toBeUndefined();
+    expect(
+      parseQueuedMessage(
+        "cosmos.staking.v1beta1.MsgDelegate",
+        'delegator_address:"bbn1delegator" amount:<denom:"ubbn" amount:"7" >',
+      ),
+    ).toBeUndefined();
+    expect(
+      parseQueuedMessage(
+        "cosmos.staking.v1beta1.MsgBeginRedelegate",
+        'delegator_address:"bbn1delegator" validator_src_address:"bbnvaloper1src" amount:<denom:"ubbn" amount:"7" >',
+      ),
+    ).toBeUndefined();
+  });
+
+  it("warns on a known staking msg_type that fails to parse, stays silent for unknown types", () => {
+    expect(parseQueuedMessage("cosmos.staking.v1beta1.MsgDelegate", "garbage")).toBeUndefined();
+    expect(mockedLog).toHaveBeenCalledWith("warn", expect.stringContaining("failed to parse"), {
+      msgType: "cosmos.staking.v1beta1.MsgDelegate",
+    });
+
+    mockedLog.mockClear();
+    expect(parseQueuedMessage("cosmos.staking.v1beta1.MsgEditValidator", "garbage")).toBeUndefined();
+    expect(mockedLog).not.toHaveBeenCalled();
+  });
+});
+
+describe("mergeQueuedMessages", () => {
+  const params = { blockHeight: 100, epochBoundary: 360, unbondingPeriodDays: 2 };
+
+  const delegation = (validatorAddress: string, amount: number): CosmosDelegation => ({
+    validatorAddress,
+    amount: new BigNumber(amount),
+    pendingRewards: new BigNumber(0),
+    status: "bonded",
+  });
+  const delegate = (validatorAddress: string, amount: number): QueuedStakingMessage => ({
+    type: "delegate",
+    delegatorAddress: "bbn1me",
+    validatorAddress,
+    amount: new BigNumber(amount),
+    denom: "ubbn",
+  });
+  const undelegate = (validatorAddress: string, amount: number): QueuedStakingMessage => ({
+    type: "undelegate",
+    delegatorAddress: "bbn1me",
+    validatorAddress,
+    amount: new BigNumber(amount),
+    denom: "ubbn",
+  });
+  const redelegate = (src: string, dst: string, amount: number): QueuedStakingMessage => ({
+    type: "redelegate",
+    delegatorAddress: "bbn1me",
+    validatorSrcAddress: src,
+    validatorDstAddress: dst,
+    amount: new BigNumber(amount),
+    denom: "ubbn",
+  });
+  const sumOf = (arrays: { amount: BigNumber }[][]): BigNumber =>
+    arrays.flat().reduce((acc, item) => acc.plus(item.amount), new BigNumber(0));
+
+  it("creates a pending delegation entry for a queued delegate", () => {
+    const result = mergeQueuedMessages(
+      { delegations: [], redelegations: [], unbondings: [] },
+      [delegate("bbnvaloper1aaa", 30)],
+      params,
+    );
+    expect(result.delegations).toEqual([
+      {
+        validatorAddress: "bbnvaloper1aaa",
+        amount: new BigNumber(30),
+        pendingRewards: new BigNumber(0),
+        status: "bonded",
+      },
+    ]);
+    expect(result.unbondings).toEqual([]);
+    expect(result.redelegations).toEqual([]);
+  });
+
+  it("increments an existing delegation for a queued delegate, without mutating the input", () => {
+    const existing = [delegation("bbnvaloper1aaa", 50)];
+    const result = mergeQueuedMessages(
+      { delegations: existing, redelegations: [], unbondings: [] },
+      [delegate("bbnvaloper1aaa", 30)],
+      params,
+    );
+    expect(result.delegations).toEqual([expect.objectContaining({ amount: new BigNumber(80) })]);
+    expect(existing[0].amount).toEqual(new BigNumber(50));
+  });
+
+  it("moves a queued undelegate from delegations to unbondings", () => {
+    const result = mergeQueuedMessages(
+      { delegations: [delegation("bbnvaloper1aaa", 50)], redelegations: [], unbondings: [] },
+      [undelegate("bbnvaloper1aaa", 10)],
+      params,
+    );
+    expect(result.delegations).toEqual([expect.objectContaining({ amount: new BigNumber(40) })]);
+    expect(result.unbondings).toEqual([
+      expect.objectContaining({ validatorAddress: "bbnvaloper1aaa", amount: new BigNumber(10) }),
+    ]);
+  });
+
+  it("estimates the unbonding completion date from the epoch boundary distance", () => {
+    const before = Date.now();
+    const { unbondings } = mergeQueuedMessages(
+      { delegations: [delegation("bbnvaloper1aaa", 50)], redelegations: [], unbondings: [] },
+      [undelegate("bbnvaloper1aaa", 10)],
+      params,
+    );
+    const after = Date.now();
+    // (360 - 100) blocks of ~10s + 2 days of unbonding
+    const offsetMs = 260 * 10_000 + 2 * 86_400_000;
+    expect(unbondings[0].completionDate.getTime()).toBeGreaterThanOrEqual(before + offsetMs);
+    expect(unbondings[0].completionDate.getTime()).toBeLessThanOrEqual(after + offsetMs);
+  });
+
+  it("clamps over-undelegations so the merge stays balance-neutral", () => {
+    const initial = {
+      delegations: [delegation("bbnvaloper1aaa", 60)],
+      redelegations: [],
+      unbondings: [],
+    };
+    const result = mergeQueuedMessages(
+      initial,
+      [undelegate("bbnvaloper1aaa", 30), undelegate("bbnvaloper1aaa", 50)],
+      params,
+    );
+    // 30, then min(50, remaining 30): the delegation is consumed, nothing is invented
+    expect(result.delegations).toEqual([]);
+    expect(result.unbondings.map(u => u.amount)).toEqual([new BigNumber(30), new BigNumber(30)]);
+    expect(sumOf([result.delegations, result.unbondings])).toEqual(
+      sumOf([initial.delegations, initial.unbondings]),
+    );
+  });
+
+  it("ignores an undelegate without a matching delegation", () => {
+    const result = mergeQueuedMessages(
+      { delegations: [], redelegations: [], unbondings: [] },
+      [undelegate("bbnvaloper1aaa", 10)],
+      params,
+    );
+    expect(result.delegations).toEqual([]);
+    expect(result.unbondings).toEqual([]);
+  });
+
+  it("moves a queued redelegate between validators, clamped to the source delegation", () => {
+    const initial = {
+      delegations: [delegation("bbnvaloper1src", 50)],
+      redelegations: [],
+      unbondings: [],
+    };
+    const result = mergeQueuedMessages(
+      initial,
+      [redelegate("bbnvaloper1src", "bbnvaloper1dst", 80)],
+      params,
+    );
+    expect(result.delegations).toEqual([
+      expect.objectContaining({ validatorAddress: "bbnvaloper1dst", amount: new BigNumber(50) }),
+    ]);
+    expect(result.redelegations).toEqual([
+      expect.objectContaining({
+        validatorSrcAddress: "bbnvaloper1src",
+        validatorDstAddress: "bbnvaloper1dst",
+        amount: new BigNumber(50),
+      }),
+    ]);
+    expect(sumOf([result.delegations])).toEqual(sumOf([initial.delegations]));
+  });
+
+  it("applies messages in queue order (delegate then redelegate of the same funds)", () => {
+    const result = mergeQueuedMessages(
+      { delegations: [], redelegations: [], unbondings: [] },
+      [delegate("bbnvaloper1aaa", 30), redelegate("bbnvaloper1aaa", "bbnvaloper1bbb", 30)],
+      params,
+    );
+    expect(result.delegations).toEqual([
+      expect.objectContaining({ validatorAddress: "bbnvaloper1bbb", amount: new BigNumber(30) }),
+    ]);
+  });
+
+  it("drops delegation entries that reach zero", () => {
+    const result = mergeQueuedMessages(
+      { delegations: [delegation("bbnvaloper1aaa", 50)], redelegations: [], unbondings: [] },
+      [undelegate("bbnvaloper1aaa", 50)],
+      params,
+    );
+    expect(result.delegations).toEqual([]);
+    expect(result.unbondings).toEqual([expect.objectContaining({ amount: new BigNumber(50) })]);
+  });
+});
+
+describe("fetchQueuedStakingMessages", () => {
+  const endpoint = "https://lcd.test";
+  const address = "bbn1me";
+  const stakingMsg = (delegator: string, denom: string, amount: string) => ({
+    msg_type: "cosmos.staking.v1beta1.MsgDelegate",
+    msg: `delegator_address:"${delegator}" validator_address:"bbnvaloper1aaa" amount:<denom:"${denom}" amount:"${amount}" >`,
+  });
+
+  // network is mocked; the AxiosResponse envelope is irrelevant here, so build just `{ data }`
+  const mockNetworkByUrl = (handler: (url: string) => unknown) => {
+    mockedNetwork.mockImplementation(
+      ((opts: { url: string }) => Promise.resolve({ data: handler(opts.url) })) as any,
+    );
+  };
+
+  it("follows pagination and merges every page, url-encoding the page key", async () => {
+    const requested: string[] = [];
+    mockNetworkByUrl(url => {
+      requested.push(url);
+      if (url.includes("current_epoch")) {
+        return { current_epoch: "5", epoch_boundary: "360" };
+      }
+      const isSecondPage = url.includes("pagination.key=");
+      return {
+        msgs: [stakingMsg(address, "ubbn", isSecondPage ? "20" : "10")],
+        pagination: { next_key: isSecondPage ? null : "K/y+=", total: "2" },
+      };
+    });
+
+    const result = await fetchQueuedStakingMessages(endpoint, address, "ubbn");
+
+    expect(result?.epochBoundary).toEqual(360);
+    expect(result?.messages.map(m => m.amount)).toEqual([new BigNumber(10), new BigNumber(20)]);
+    expect(requested.some(u => u.includes("pagination.key=K%2Fy%2B%3D"))).toBe(true);
+  });
+
+  it("filters out foreign delegators and denoms", async () => {
+    mockNetworkByUrl(url => {
+      if (url.includes("current_epoch")) {
+        return { current_epoch: "5", epoch_boundary: "360" };
+      }
+      return {
+        msgs: [
+          stakingMsg(address, "ubbn", "10"),
+          stakingMsg("bbn1stranger", "ubbn", "99"),
+          stakingMsg(address, "ibc/ABC123", "77"),
+        ],
+        pagination: { next_key: null, total: "3" },
+      };
+    });
+
+    const result = await fetchQueuedStakingMessages(endpoint, address, "ubbn");
+
+    expect(result?.messages).toEqual([
+      expect.objectContaining({ delegatorAddress: address, denom: "ubbn", amount: new BigNumber(10) }),
+    ]);
+  });
+
+  it("skips the merge (returns null) when the queue exceeds the pagination cap", async () => {
+    mockNetworkByUrl(url => {
+      if (url.includes("current_epoch")) {
+        return { current_epoch: "5", epoch_boundary: "360" };
+      }
+      // next_key never clears -> the page cap is reached with more pages remaining
+      return {
+        msgs: [stakingMsg(address, "ubbn", "1")],
+        pagination: { next_key: "more", total: "9999" },
+      };
+    });
+
+    const result = await fetchQueuedStakingMessages(endpoint, address, "ubbn");
+
+    expect(result).toBeNull();
+    expect(mockedLog).toHaveBeenCalledWith("warn", expect.stringContaining("pagination cap"));
+  });
+
+  it("skips the merge (returns null) when the epoch rolls over between reads", async () => {
+    let epochCall = 0;
+    mockNetworkByUrl(url => {
+      if (url.includes("current_epoch")) {
+        const epoch = epochCall === 0 ? "5" : "6";
+        epochCall += 1;
+        return { current_epoch: epoch, epoch_boundary: "360" };
+      }
+      return {
+        msgs: [stakingMsg(address, "ubbn", "10")],
+        pagination: { next_key: null, total: "1" },
+      };
+    });
+
+    const result = await fetchQueuedStakingMessages(endpoint, address, "ubbn");
+
+    expect(result).toBeNull();
+  });
+
+  it("fails open (returns null) when the endpoint errors", async () => {
+    mockedNetwork.mockRejectedValue(new Error("404"));
+
+    const result = await fetchQueuedStakingMessages(endpoint, address, "ubbn");
+
+    expect(result).toBeNull();
+  });
+});

--- a/libs/coin-modules/coin-cosmos/src/synchronisation.integ.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/synchronisation.integ.test.ts
@@ -22,6 +22,7 @@ const testAccounts = [
     address: "cosmos1w2q5xd8nhylu4vj28vpzfgag7msfxf0vx88wfq",
     lcd: "https://cosmoshub4.coin.ledger.com",
     version: "v1beta1",
+    epochedStaking: false,
   },
   {
     id: "injective",
@@ -29,10 +30,20 @@ const testAccounts = [
     address: "inj1vmzrwxhgllkjaswzawaue7m7f9qcrc0rfth2v2",
     lcd: "https://injective-rest.publicnode.com",
     version: "v1beta1",
+    epochedStaking: false,
+  },
+  {
+    id: "babylon",
+    unit: "ubbn",
+    address: "bbn1uwpws077a0a9pclapv3f2fyj5u0mlh6ewmds8n",
+    lcd: "https://babylon.coin.ledger.com",
+    version: "v1beta1",
+    epochedStaking: true,
   },
 ];
 
-describe.each(testAccounts)("Testing synchronisation", ({ id, unit, address, lcd, version }) => {
+describe.each(testAccounts)("Testing synchronisation", testAccount => {
+  const { id, unit, address, lcd, version, epochedStaking } = testAccount;
   let result: Partial<CosmosAccount>;
 
   beforeEach(async () => {
@@ -47,6 +58,7 @@ describe.each(testAccounts)("Testing synchronisation", ({ id, unit, address, lcd
       defaultGas: 0,
       minGasPrice: 0,
       version,
+      epochedStaking,
     } as any);
     result = await getAccountShape(
       {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
- Babylon (BABY) accounts only; other cosmos chains unaffected (gated by epochedStaking, zero extra requests).
- Sync/read path only — no send, sign, type, or UI changes.
- QA focus: pending delegate/undelegate/redelegate visible immediately (before epoch end, ~1h); balance & spendable stay consistent; no double-count across the epoch boundary; sync survives an epoching-endpoint outage (fail-open).

### 📝 Description

Babylon's x/epoching module queues staking messages (MsgWrappedDelegate/Undelegate/BeginRedelegate) until epoch end (~1h). Until then they don't appear on the standard staking endpoints, and a delegate's funds have already left the bank balance — so the position vanishes from the UI for up to an hour.
 This merges the current epoch's queued messages into delegations/unbondings/redelegations during sync (CosmosAPI.getAccountInfo), gated on a new chain-class epochedStaking flag (Babylon only). The merge is balance-neutral (min-clamped) and fail-open: any epoching error skips enrichment, leaving the rest of the sync intact. Pending positions are not visually differentiated from active ones (per AC).
 Read-side only. LL-originated staking txs need the send-side wrapping (LIVE-31280); externally-enqueued positions (e.g. Keplr) show correctly regardless

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31279](https://ledgerhq.atlassian.net/browse/LIVE-31279?atlOrigin=eyJpIjoiMTE3NzQxODJkYzFjNDVmM2IxNWQyYWNiYTAzNGIyMzEiLCJwIjoiaiJ9)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31279]: https://ledgerhq.atlassian.net/browse/LIVE-31279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ