### PR TITLE
[LWM] feat(mobile): animate global search placeholder

### DIFF
--- a/.changeset/lwm-search-placeholder-animation.md
+++ b/.changeset/lwm-search-placeholder-animation.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Animate the global search placeholder: it now cycles through suggested phrases ("Search crypto", "Search stablecoins", "Search stock", "Search addresses") with a parallel vertical slide + fade transition (400ms, ease-out, 4s interval). The first phrase is shown at rest on screen entry, and the placeholder hides instantly while the field has a value.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1463,6 +1463,12 @@
   },
   "globalSearch": {
     "searchPlaceholder": "Search assets",
+    "searchPlaceholders": {
+      "crypto": "Search crypto",
+      "stablecoins": "Search stablecoins",
+      "stock": "Search stock",
+      "addresses": "Search addresses"
+    },
     "sections": {
       "cryptos": "Cryptos",
       "stocks": "Stocks"

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/__integrations__/globalSearch.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/__integrations__/globalSearch.integration.test.tsx
@@ -17,11 +17,13 @@ describe("GlobalSearch screen", () => {
     jest.clearAllMocks();
   });
 
-  it("renders the search input with the 'Search assets' placeholder", () => {
+  it("renders the search input with the animated placeholder", () => {
     render(<GlobalSearch />);
 
     expect(screen.getByTestId(GLOBAL_SEARCH_TEST_IDS.searchInput)).toBeVisible();
-    expect(screen.getByPlaceholderText(/search assets/i)).toBeVisible();
+    expect(screen.getByLabelText(/search assets/i)).toBeVisible();
+    expect(screen.getByTestId(GLOBAL_SEARCH_TEST_IDS.searchPlaceholder)).toBeVisible();
+    expect(screen.getByText("Search crypto")).toBeOnTheScreen();
   });
 
   it("tracks search_open on mount", () => {
@@ -41,14 +43,14 @@ describe("GlobalSearch screen", () => {
   it("reflects typed input in the search field", async () => {
     const { user } = render(<GlobalSearch />);
 
-    await user.type(screen.getByPlaceholderText(/search assets/i), "bitcoin");
+    await user.type(screen.getByTestId(GLOBAL_SEARCH_TEST_IDS.searchInput), "bitcoin");
 
     expect(screen.getByDisplayValue("bitcoin")).toBeVisible();
   });
 
   it("swaps default sections for search results when typing and restores them on clear", async () => {
     const { user } = render(<GlobalSearch />);
-    const input = screen.getByPlaceholderText(/search assets/i);
+    const input = screen.getByTestId(GLOBAL_SEARCH_TEST_IDS.searchInput);
 
     expect(screen.getByTestId(GLOBAL_SEARCH_TEST_IDS.defaultSections)).toBeVisible();
 

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/GlobalSearchView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/GlobalSearchView.tsx
@@ -6,6 +6,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import { useExperimental } from "~/experimental";
 import { useAutoFocusOnEnter } from "LLM/features/GlobalSearch/hooks/useAutoFocusOnEnter";
+import { AnimatedSearchPlaceholder } from "./components/AnimatedSearchPlaceholder";
 import { DefaultSections } from "./components/DefaultSections";
 import { SearchResults } from "./components/SearchResults";
 import { GLOBAL_SEARCH_TEST_IDS } from "./testIds";
@@ -72,10 +73,12 @@ export function GlobalSearchView({
               onChangeText={setSearch}
               onClear={clearSearch}
               hideClearButton={false}
-              placeholder={t("globalSearch.searchPlaceholder")}
+              placeholder=""
+              accessibilityLabel={t("globalSearch.searchPlaceholder")}
               autoCorrect={false}
               autoCapitalize="none"
             />
+            <AnimatedSearchPlaceholder visible={search === ""} />
           </View>
         </View>
       </View>

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/AnimatedSearchPlaceholder/__tests__/useCyclingPlaceholder.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/AnimatedSearchPlaceholder/__tests__/useCyclingPlaceholder.test.ts
@@ -1,0 +1,46 @@
+import { renderHook, act } from "@tests/test-renderer";
+import { useCyclingPlaceholder, PLACEHOLDER_INTERVAL_MS } from "../useCyclingPlaceholder";
+
+describe("useCyclingPlaceholder", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("starts on the first phrase and animates when there are several phrases", () => {
+    const { result } = renderHook(() => useCyclingPlaceholder(4, true));
+
+    expect(result.current.index).toBe(0);
+    expect(result.current.animate).toBe(true);
+  });
+
+  it("advances to the next phrase after each interval and wraps around", () => {
+    const { result } = renderHook(() => useCyclingPlaceholder(4, true));
+
+    act(() => jest.advanceTimersByTime(PLACEHOLDER_INTERVAL_MS));
+    expect(result.current.index).toBe(1);
+
+    act(() => jest.advanceTimersByTime(PLACEHOLDER_INTERVAL_MS * 3));
+    expect(result.current.index).toBe(0);
+  });
+
+  it("pauses cycling while disabled", () => {
+    const { result } = renderHook(() => useCyclingPlaceholder(4, false));
+
+    act(() => jest.advanceTimersByTime(PLACEHOLDER_INTERVAL_MS * 2));
+    expect(result.current.index).toBe(0);
+  });
+
+  it("does not cycle when there is a single phrase", () => {
+    const { result } = renderHook(() => useCyclingPlaceholder(1, true));
+
+    expect(result.current.animate).toBe(false);
+
+    act(() => jest.advanceTimersByTime(PLACEHOLDER_INTERVAL_MS * 2));
+    expect(result.current.index).toBe(0);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/AnimatedSearchPlaceholder/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/AnimatedSearchPlaceholder/index.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useMemo, useRef } from "react";
+import { StyleSheet, View } from "react-native";
+import { Text } from "@ledgerhq/lumen-ui-rnative";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
+import Animated, { Easing, Keyframe } from "react-native-reanimated";
+import { useTranslation } from "~/context/Locale";
+import { GLOBAL_SEARCH_TEST_IDS } from "../../testIds";
+import { useCyclingPlaceholder } from "./useCyclingPlaceholder";
+
+const SEARCH_ICON_SIZE = 20;
+const SLOT_HEIGHT = 48;
+const ANIMATION_DURATION_MS = 400;
+const EASING = Easing.bezier(0, 0, 0.58, 1);
+
+// The outgoing word slides up and fades out, the incoming word slides in from
+// below; both play in parallel. See LIVE-32544 spec.
+const SLIDE_IN = new Keyframe({
+  0: { opacity: 0, transform: [{ translateY: SLOT_HEIGHT }] },
+  100: { opacity: 1, transform: [{ translateY: 0 }], easing: EASING },
+}).duration(ANIMATION_DURATION_MS);
+
+const SLIDE_OUT = new Keyframe({
+  0: { opacity: 1, transform: [{ translateY: 0 }] },
+  75: { opacity: 0, transform: [{ translateY: -SLOT_HEIGHT * 0.75 }], easing: EASING },
+  100: { opacity: 0, transform: [{ translateY: -SLOT_HEIGHT }], easing: EASING },
+}).duration(ANIMATION_DURATION_MS);
+
+type Props = Readonly<{
+  /** When false (the field has a value), the placeholder hides instantly and cycling pauses. */
+  visible: boolean;
+}>;
+
+export function AnimatedSearchPlaceholder({ visible }: Props) {
+  const { t } = useTranslation();
+
+  const phrases = useMemo(
+    () => [
+      t("globalSearch.searchPlaceholders.crypto"),
+      t("globalSearch.searchPlaceholders.stablecoins"),
+      t("globalSearch.searchPlaceholders.stock"),
+      t("globalSearch.searchPlaceholders.addresses"),
+    ],
+    [t],
+  );
+
+  const { index, animate } = useCyclingPlaceholder(phrases.length, visible);
+
+  // The first phrase is shown at rest; only phrases that appear after a cycle slide in.
+  const isInitialRender = useRef(true);
+  useEffect(() => {
+    isInitialRender.current = false;
+  }, []);
+
+  const styles = useStyleSheet(
+    theme => ({
+      overlay: {
+        ...StyleSheet.absoluteFillObject,
+        overflow: "hidden",
+      },
+      layer: {
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        left: theme.spacings.s16 + SEARCH_ICON_SIZE + theme.spacings.s12,
+        right: theme.spacings.s16 + theme.spacings.s20 + theme.spacings.s12,
+        justifyContent: "center",
+      },
+    }),
+    [],
+  );
+
+  const phrase = (
+    <Text typography="body1" lx={{ color: "muted" }} numberOfLines={1}>
+      {phrases[index]}
+    </Text>
+  );
+
+  return (
+    <View
+      pointerEvents="none"
+      style={[styles.overlay, { opacity: visible ? 1 : 0 }]}
+      testID={GLOBAL_SEARCH_TEST_IDS.searchPlaceholder}
+    >
+      {animate ? (
+        <Animated.View
+          key={index}
+          style={styles.layer}
+          entering={isInitialRender.current ? undefined : SLIDE_IN}
+          exiting={SLIDE_OUT}
+        >
+          {phrase}
+        </Animated.View>
+      ) : (
+        <View style={styles.layer}>{phrase}</View>
+      )}
+    </View>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/AnimatedSearchPlaceholder/useCyclingPlaceholder.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/AnimatedSearchPlaceholder/useCyclingPlaceholder.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import { useReducedMotion } from "react-native-reanimated";
+
+export const PLACEHOLDER_INTERVAL_MS = 4000;
+
+/**
+ * Cycles through the placeholder phrases, advancing to the next one every
+ * {@link PLACEHOLDER_INTERVAL_MS}. The slide transition itself is declared by
+ * the consuming component via Reanimated entering/exiting keyframes.
+ * Cycling pauses while `enabled` is false (e.g. the field has a value), and
+ * stays on the first phrase when reduce-motion is enabled.
+ */
+export function useCyclingPlaceholder(length: number, enabled: boolean) {
+  const reduceMotion = useReducedMotion();
+  const [index, setIndex] = useState(0);
+
+  const animate = !reduceMotion && length > 1;
+
+  useEffect(() => {
+    if (!animate || !enabled) return;
+
+    const id = setInterval(() => {
+      setIndex(current => (current + 1) % length);
+    }, PLACEHOLDER_INTERVAL_MS);
+
+    return () => clearInterval(id);
+  }, [animate, enabled, length]);
+
+  return { index, animate };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/testIds.ts
@@ -1,6 +1,7 @@
 export const GLOBAL_SEARCH_TEST_IDS = {
   screen: "global-search-screen",
   searchInput: "global-search-input",
+  searchPlaceholder: "global-search-placeholder",
   defaultSections: "global-search-default-sections",
   cryptosSection: "global-search-cryptos-section",
   stocksSection: "global-search-stocks-section",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _The cycling logic (4s interval, wrap-around, pause-while-disabled, reduce-motion no-op) and rendering are unit/integration tested. The actual slide/fade visual is driven by Reanimated layout animations, which do not run under Jest, so the motion itself is verified manually on device._
- [x] **Impact of the changes:**
      - Global search screen placeholder: phrases cycle every 4s with a parallel slide-up/slide-in + fade (400ms, ease-out)
      - First phrase must be visible at rest on screen entry (no slide-in)
      - Placeholder must hide instantly (no exit animation) as soon as the user types, and reappear instantly when the field is cleared
      - Accessibility: the input still exposes the "Search assets" label to screen readers; reduce-motion shows a static first phrase with no cycling

### 📝 Description

The global search input previously used a single static native placeholder ("Search assets").

This PR replaces it with an animated placeholder that cycles through four suggested phrases — **Search crypto / Search stablecoins / Search stock / Search addresses** — following the [LIVE-32544](https://ledgerhq.atlassian.net/browse/LIVE-32544) motion spec:

- **Duration** 400ms (`--duration-medium`), **easing** `cubic-bezier(0, 0, 0.58, 1)` (ease-out)
- **Interval** between words 4000ms, **slot height** 48px (`--size-48`)
- On change, the outgoing word slides up and fades out while the incoming word slides in from below — **both in parallel**

Since React Native cannot animate a native `TextInput` placeholder, the implementation renders an absolutely-positioned, `pointerEvents="none"` overlay over the input and leaves the native placeholder empty (the "Search assets" string moves to `accessibilityLabel`). The cross-slide uses Reanimated `Keyframe` + `entering`/`exiting` on a keyed element, so React manages mount/unmount and the words overlap with no manual flicker handling. The first phrase renders at rest on entry, and visibility is gated by the overlay's opacity so it hides instantly while the field has a value (cycling pauses then too).

### 🖼️ Screenshots

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32544](https://ledgerhq.atlassian.net/browse/LIVE-32544)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32544]: https://ledgerhq.atlassian.net/browse/LIVE-32544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ