### PR TITLE
[LWDM] fix(LIVE-31564): handle o.closed in aleo signOperation

### DIFF
--- a/.changeset/nine-penguins-double.md
+++ b/.changeset/nine-penguins-double.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+fix: handle o.closed in aleo signOperation

--- a/libs/coin-modules/coin-aleo/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/signOperation.test.ts
@@ -60,6 +60,13 @@ describe("buildSignOperation", () => {
   const mockSigner = createMockSigner();
   const mockSignerContext = createMockSignerContext(mockSigner);
   const mockSignOperation = buildSignOperation(mockSignerContext);
+  const mockMultiRecordTransaction = getMockedTransaction({
+    mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+    properties: {
+      amountRecordCommitments: [mockUnspentRecord1.commitment, mockUnspentRecord2.commitment],
+      feeRecordCommitment: mockUnspentRecord2.commitment,
+    },
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -574,5 +581,45 @@ describe("buildSignOperation", () => {
         }).pipe(toArray()),
       ),
     ).rejects.toThrow(`aleo: view key is missing in ${accountWithoutViewKey.freshAddress} account`);
+  });
+
+  it("should stop TVK fetching when subscription is cancelled after root TVK", async () => {
+    let streamingEventCount = 0;
+    const sub = mockSignOperation({
+      account: mockAccount,
+      transaction: mockMultiRecordTransaction,
+      deviceId: "test-device",
+    }).subscribe({
+      next: event => {
+        if (event.type === "device-streaming") {
+          streamingEventCount++;
+          if (streamingEventCount === 2) sub.unsubscribe();
+        }
+      },
+    });
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    expect(mockSigner.getTvk).toHaveBeenCalledTimes(1);
+    expect(mockSigner.signRootIntent).not.toHaveBeenCalled();
+  });
+
+  it("should not start signing when subscription is cancelled after all TVKs are fetched", async () => {
+    const sub = mockSignOperation({
+      account: mockAccount,
+      transaction: mockMultiRecordTransaction,
+      deviceId: "test-device",
+    }).subscribe({
+      next: event => {
+        if (event.type === "device-streaming" && event.progress === 1) {
+          sub.unsubscribe();
+        }
+      },
+    });
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    expect(mockSigner.getTvk).toHaveBeenCalledTimes(3);
+    expect(mockSigner.signRootIntent).not.toHaveBeenCalled();
   });
 });

--- a/libs/coin-modules/coin-aleo/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/signOperation.ts
@@ -66,11 +66,13 @@ async function getTvks({
   signer,
   path,
   txIntent,
+  isCancelled,
   onDeviceStreaming,
 }: {
   signer: AleoSigner;
   path: string;
   txIntent: TransactionIntent<MemoNotSupported, AleoTransactionIntentData>;
+  isCancelled: () => boolean;
   onDeviceStreaming: DeviceStreamingCallback;
 }): Promise<{
   rootTvk: string;
@@ -92,11 +94,14 @@ async function getTvks({
 
   streamingReporter.reportInitialStep();
 
+  if (isCancelled()) return null;
+
   const rootResult = await signer.getTvk(path);
   const rootTvk = Buffer.from(rootResult.tvk).toString("hex");
   streamingReporter.reportStepCompleted();
 
   for (let transitionIndex = 1; transitionIndex < tvksToFetch; transitionIndex++) {
+    if (isCancelled()) return null;
     const nestedResult = await signer.getTvk(path, transitionIndex);
     nestedTvks.push(Buffer.from(nestedResult.tvk).toString("hex"));
     streamingReporter.reportStepCompleted();
@@ -233,11 +238,12 @@ export const buildSignOperation =
             max_priority_fee: priorityFee.toString(),
           };
 
-          const signedTx = await signerContext(deviceId, async signer => {
+          const signature = await signerContext(deviceId, async signer => {
             const tvks = await getTvks({
               signer,
               path: account.freshAddressPath,
               txIntent,
+              isCancelled: () => o.closed,
               onDeviceStreaming: ({ progress, index, total }) => {
                 o.next({
                   type: "device-streaming",
@@ -248,6 +254,8 @@ export const buildSignOperation =
               },
             });
 
+            if (o.closed) return;
+
             const craftedRequest = await craftTransaction({
               currency: account.currency,
               viewKey,
@@ -257,6 +265,8 @@ export const buildSignOperation =
             });
 
             const request = fromHex<PreparedRequestResponse>(craftedRequest.transaction);
+
+            if (o.closed) return;
 
             o.next({
               type: "device-signature-requested",
@@ -277,6 +287,8 @@ export const buildSignOperation =
             });
           });
 
+          if (!signature) return;
+
           const operation = buildOptimisticOperation({
             account,
             transaction,
@@ -286,7 +298,7 @@ export const buildSignOperation =
             type: "signed",
             signedOperation: {
               operation,
-              signature: signedTx,
+              signature,
             },
           });
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - signOperation flow in coin-aleo module

### 📝 Description

During TVK fetching for multi-record private transactions, the signing flow continued even after the user closed the modal or pressed back button. The root cause was no cancellation check in the TVK loop and no teardown in the Observable. Fixed by checking o.closed before each getTvk call and before entering the signing phase, stopping the loop and preventing unnecessary APDUs from being sent to the device.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-31564?focusedCommentId=694039

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
