### PR TITLE
[LWD] feat: add resume of add account after lazy onboarding flow

### DIFF
--- a/.changeset/eight-clocks-guess.md
+++ b/.changeset/eight-clocks-guess.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Resume Add Account flow after device-connection onboarding

--- a/apps/ledger-live-desktop/src/mvvm/features/BuyDevice/__tests__/useBuyDeviceViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/BuyDevice/__tests__/useBuyDeviceViewModel.test.ts
@@ -1,7 +1,13 @@
-import { renderHook } from "tests/testSetup";
+import { renderHook, act } from "tests/testSetup";
 import useBuyDeviceViewModel from "../useBuyDeviceViewModel";
 import * as originFlow from "~/renderer/analytics/originFlow";
 import * as segment from "~/renderer/analytics/segment";
+import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
+import { shouldResumeAddAccountAfterOnboardingSelector } from "~/renderer/reducers/onboarding";
+
+jest.mock("LLD/hooks/useLazyOnboardingActions", () => ({
+  useLazyOnboardingActions: () => ({ handleConnect: jest.fn(), handleBuyDevice: jest.fn() }),
+}));
 
 const mockTrack = jest.mocked(segment.track);
 const mockGetOriginFlow = jest.mocked(originFlow.getOriginFlow);
@@ -26,5 +32,39 @@ describe("useBuyDeviceViewModel", () => {
       modal: "BuyDeviceModal",
       trigger: "Send Modal",
     });
+  });
+
+  it("flags the Add Account flow to resume after onboarding when Connect comes from add account", () => {
+    mockGetOriginFlow.mockReturnValue(HOOKS_TRACKING_LOCATIONS.addAccountModal);
+
+    const { result, store } = renderHook(() => useBuyDeviceViewModel(), {
+      initialState: {
+        dialogs: { BUY_DEVICE: true },
+        settings: { lastOnboardedDevice: null },
+      },
+    });
+
+    act(() => {
+      result.current.handleConnect();
+    });
+
+    expect(shouldResumeAddAccountAfterOnboardingSelector(store.getState())).toBe(true);
+  });
+
+  it("does not flag a resume when Connect comes from another flow", () => {
+    mockGetOriginFlow.mockReturnValue(HOOKS_TRACKING_LOCATIONS.receiveModal);
+
+    const { result, store } = renderHook(() => useBuyDeviceViewModel(), {
+      initialState: {
+        dialogs: { BUY_DEVICE: true },
+        settings: { lastOnboardedDevice: null },
+      },
+    });
+
+    act(() => {
+      result.current.handleConnect();
+    });
+
+    expect(shouldResumeAddAccountAfterOnboardingSelector(store.getState())).toBe(false);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/BuyDevice/useBuyDeviceViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/BuyDevice/useBuyDeviceViewModel.ts
@@ -4,7 +4,9 @@ import { useCallback, useEffect } from "react";
 import { useLazyOnboardingActions } from "LLD/hooks/useLazyOnboardingActions";
 import { track } from "~/renderer/analytics/segment";
 import { hasOnboardedDeviceSelector } from "~/renderer/reducers/settings";
+import { setShouldResumeAddAccountAfterOnboarding } from "~/renderer/reducers/onboarding";
 import { getOriginFlow } from "~/renderer/analytics/originFlow";
+import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
 
 export interface BuyDeviceViewProps {
   isOpen: boolean;
@@ -51,9 +53,13 @@ const useBuyDeviceViewModel = (): BuyDeviceViewProps => {
       button: "Connect",
       page: ANALYTICS_PAGE,
     });
+
+    if (getOriginFlow() === HOOKS_TRACKING_LOCATIONS.addAccountModal) {
+      dispatch(setShouldResumeAddAccountAfterOnboarding(true));
+    }
     handleConnectDevice();
     onClose();
-  }, [onClose, handleConnectDevice]);
+  }, [dispatch, onClose, handleConnectDevice]);
 
   return {
     isOpen,

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__tests__/NewSeedPanel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__tests__/NewSeedPanel.test.tsx
@@ -23,6 +23,7 @@ const getInitialState = (isOnboardingReceiveSuccess: boolean = false): Partial<S
     isOnboardingReceiveSuccess,
     onboardingSyncFlow: null,
     isSkipDrawerOpen: false,
+    shouldResumeAddAccountAfterOnboarding: false,
   },
 });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/usePortfolioViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/usePortfolioViewModel.test.ts
@@ -6,6 +6,13 @@ import { BigNumber } from "bignumber.js";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
 import { usePortfolioViewModel } from "../usePortfolioViewModel";
 
+// usePortfolioViewModel consumes useResumeAddAccountAfterOnboarding, which pulls in the Add Account
+// flow (useOpenAssetFlow). Mock it so this suite stays focused on the portfolio view-model.
+// The resume behaviour itself is covered by useResumeAddAccountAfterOnboarding.test.ts.
+jest.mock("LLD/features/ModularDialog/hooks/useOpenAssetFlow", () => ({
+  useOpenAssetFlow: () => ({ openAssetFlow: jest.fn(), openAddAccountFlow: jest.fn() }),
+}));
+
 const bitcoinCurrency = getCryptoCurrencyById("bitcoin");
 const ethereumCurrency = getCryptoCurrencyById("ethereum");
 const wallet40AndExchangeFeatureFlags = withFlagOverrides({

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useResumeAddAccountAfterOnboarding.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useResumeAddAccountAfterOnboarding.test.ts
@@ -1,0 +1,49 @@
+import { renderHook } from "tests/testSetup";
+import { AFTER_ONBOARDING_STATE, INITIAL_STATE } from "~/renderer/reducers/settings";
+import { shouldResumeAddAccountAfterOnboardingSelector } from "~/renderer/reducers/onboarding";
+import { useResumeAddAccountAfterOnboarding } from "../useResumeAddAccountAfterOnboarding";
+
+const mockOpenAssetFlow = jest.fn();
+jest.mock("LLD/features/ModularDialog/hooks/useOpenAssetFlow", () => ({
+  useOpenAssetFlow: () => ({ openAssetFlow: mockOpenAssetFlow, openAddAccountFlow: jest.fn() }),
+}));
+
+// Onboarding slice with a pending "resume Add Account" intent (set when the user was sent to
+// device onboarding from the Add Account flow).
+const resumeOnboardingState = {
+  onboardingSyncFlow: null,
+  isOnboardingReceiveFlow: false,
+  isOnboardingReceiveSuccess: false,
+  isSkipDrawerOpen: false,
+  shouldResumeAddAccountAfterOnboarding: true,
+};
+
+describe("useResumeAddAccountAfterOnboarding", () => {
+  beforeEach(() => {
+    mockOpenAssetFlow.mockClear();
+  });
+
+  it("resumes the Add Account flow once a device is onboarded and clears the intent", () => {
+    const { store } = renderHook(() => useResumeAddAccountAfterOnboarding(), {
+      initialState: {
+        settings: AFTER_ONBOARDING_STATE,
+        onboarding: resumeOnboardingState,
+      },
+    });
+
+    expect(mockOpenAssetFlow).toHaveBeenCalledTimes(1);
+    expect(shouldResumeAddAccountAfterOnboardingSelector(store.getState())).toBe(false);
+  });
+
+  it("keeps the resume intent and does not open Add Account while no device is onboarded", () => {
+    const { store } = renderHook(() => useResumeAddAccountAfterOnboarding(), {
+      initialState: {
+        settings: INITIAL_STATE,
+        onboarding: resumeOnboardingState,
+      },
+    });
+
+    expect(mockOpenAssetFlow).not.toHaveBeenCalled();
+    expect(shouldResumeAddAccountAfterOnboardingSelector(store.getState())).toBe(true);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/usePortfolioViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/usePortfolioViewModel.ts
@@ -11,6 +11,7 @@ import { useFilterTokenOperationsZeroAmount } from "~/renderer/actions/settings"
 import { showClearCacheBannerSelector } from "~/renderer/reducers/settings";
 import { useAddressPoisoningOperationsFamilies } from "@ledgerhq/live-common/hooks/useAddressPoisoningOperationsFamilies";
 import { useBorrowLiveConfig } from "LLD/features/Borrow/hooks/useBorrowLiveConfig";
+import { useResumeAddAccountAfterOnboarding } from "./useResumeAddAccountAfterOnboarding";
 
 export interface PortfolioViewModelResult {
   readonly totalAccounts: number;
@@ -35,6 +36,10 @@ export interface PortfolioViewModelResult {
 export const usePortfolioViewModel = (): PortfolioViewModelResult => {
   const accounts = useSelector(accountsSelector);
   const portfolioExchangeBanner = useFeature("portfolioExchangeBanner");
+
+  // Resume the Add Account flow that was interrupted to send the user through device onboarding.
+  useResumeAddAccountAfterOnboarding();
+
   const {
     shouldDisplayMarketBanner,
     shouldDisplayGraphRework,

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useResumeAddAccountAfterOnboarding.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useResumeAddAccountAfterOnboarding.ts
@@ -1,0 +1,47 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { ModularDrawerLocation } from "@ledgerhq/live-common/modularDrawer/enums";
+import { hasOnboardedDeviceSelector } from "~/renderer/reducers/settings";
+import {
+  setShouldResumeAddAccountAfterOnboarding,
+  shouldResumeAddAccountAfterOnboardingSelector,
+} from "~/renderer/reducers/onboarding";
+import { useOpenAssetFlow } from "LLD/features/ModularDialog/hooks/useOpenAssetFlow";
+import { useShouldRedirect } from "~/renderer/hooks/useAutoRedirectToPostOnboarding/useShouldRedirect";
+import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
+import { setOriginFlow } from "~/renderer/analytics/originFlow";
+
+/**
+ * Resumes the Add Account flow that was interrupted to send the user through device onboarding.
+ */
+export const useResumeAddAccountAfterOnboarding = (): void => {
+  const dispatch = useDispatch();
+  const shouldResumeAddAccount = useSelector(shouldResumeAddAccountAfterOnboardingSelector);
+  const hasOnboardedDevice = useSelector(hasOnboardedDeviceSelector);
+  const { shouldRedirectToRecoverUpsell, shouldRedirectToPostOnboarding } = useShouldRedirect();
+  const { openAssetFlow } = useOpenAssetFlow(
+    { location: ModularDrawerLocation.ADD_ACCOUNT },
+    "portfolio_add_account",
+  );
+
+  useEffect(() => {
+    if (
+      !shouldResumeAddAccount ||
+      !hasOnboardedDevice ||
+      shouldRedirectToRecoverUpsell ||
+      shouldRedirectToPostOnboarding
+    ) {
+      return;
+    }
+    dispatch(setShouldResumeAddAccountAfterOnboarding(false));
+    setOriginFlow(HOOKS_TRACKING_LOCATIONS.addAccountModal);
+    openAssetFlow();
+  }, [
+    dispatch,
+    hasOnboardedDevice,
+    openAssetFlow,
+    shouldRedirectToPostOnboarding,
+    shouldRedirectToRecoverUpsell,
+    shouldResumeAddAccount,
+  ]);
+};

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -635,7 +635,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     // NB Until we find a better way, remap the error if it's 6d06 (LNS, LNSP, LNX) or 6d07 (Stax) and we haven't fallen
     // into another handled case.
     if (isDeviceNotOnboardedError(e)) {
-      return <DeviceNotOnboardedErrorComponent t={t} device={device} />;
+      return <DeviceNotOnboardedErrorComponent t={t} device={device} location={location} />;
     }
 
     if (e instanceof NoSuchAppOnProvider) {
@@ -842,7 +842,7 @@ function DeviceActionInner<R, H extends States, P>({
 export default function DeviceAction<R, H extends States, P>(
   props: InnerProps<P> & { action: Action<R, H, P>; request: R },
 ): React.JSX.Element | null {
-  const shouldShowContent = useBuyDeviceIntercept();
+  const shouldShowContent = useBuyDeviceIntercept(props.location);
 
   if (!shouldShowContent) {
     return null;

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -58,6 +58,8 @@ import { isCounterfeitError } from "@ledgerhq/live-common/hw/isCounterfeitError"
 import { urls } from "~/config/urls";
 import { closeAllModal } from "~/renderer/actions/modals";
 import { closePlatformAppDrawer } from "~/renderer/actions/UI";
+import { setShouldResumeAddAccountAfterOnboarding } from "~/renderer/reducers/onboarding";
+import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
 import { track } from "~/renderer/analytics/segment";
 import TrackPage, { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import Animation from "~/renderer/animations";
@@ -748,7 +750,15 @@ export const renderAlreadySendingApduError = ({
 };
 
 export const DeviceNotOnboardedErrorComponent = withV3StyleProvider(
-  ({ t, device }: { t: TFunction; device?: Device | null }) => {
+  ({
+    t,
+    device,
+    location,
+  }: {
+    t: TFunction;
+    device?: Device | null;
+    location?: HOOKS_TRACKING_LOCATIONS;
+  }) => {
     const productName = device ? getDeviceModel(device.modelId).productName : null;
     const navigate = useNavigate();
     const { setDrawer } = useContext(context);
@@ -756,6 +766,11 @@ export const DeviceNotOnboardedErrorComponent = withV3StyleProvider(
 
     const redirectToOnboarding = useCallback(() => {
       setTrackingSource("device action open onboarding button");
+      // The Add Account flow brought the user here without a usable device. Remember the
+      // intent so we can resume it once the user lands back on the portfolio after onboarding.
+      if (location === HOOKS_TRACKING_LOCATIONS.addAccountModal) {
+        dispatch(setShouldResumeAddAccountAfterOnboarding(true));
+      }
       dispatch(closeAllModal());
       setDrawer(undefined);
       if (!device?.modelId) {
@@ -767,7 +782,7 @@ export const DeviceNotOnboardedErrorComponent = withV3StyleProvider(
             : "/onboarding",
         );
       }
-    }, [device?.modelId, dispatch, navigate, setDrawer]);
+    }, [device?.modelId, dispatch, location, navigate, setDrawer]);
 
     return (
       <Wrapper id="error-device-not-onboarded">

--- a/apps/ledger-live-desktop/src/renderer/hooks/useBuyDeviceIntercept.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useBuyDeviceIntercept.test.ts
@@ -1,8 +1,11 @@
 import { renderHook } from "tests/testSetup";
 import { useBuyDeviceIntercept } from "./useBuyDeviceIntercept";
 import { AFTER_ONBOARDING_STATE, INITIAL_STATE } from "~/renderer/reducers/settings";
+import * as originFlow from "~/renderer/analytics/originFlow";
+import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
 
 const mockOpenBuyDeviceModal = jest.fn();
+const mockSetOriginFlow = jest.mocked(originFlow.setOriginFlow);
 
 let mockPathname = "/manager";
 jest.mock("react-router", () => ({
@@ -51,5 +54,25 @@ describe("useBuyDeviceIntercept", () => {
 
     expect(result.current).toBe(false);
     expect(mockOpenBuyDeviceModal).toHaveBeenCalled();
+  });
+
+  it("records the provided location as origin flow when opening the Buy Device modal", () => {
+    renderHook(() => useBuyDeviceIntercept(HOOKS_TRACKING_LOCATIONS.addAccountModal), {
+      initialState: { settings: INITIAL_STATE },
+      minimal: false,
+    });
+
+    expect(mockOpenBuyDeviceModal).toHaveBeenCalled();
+    expect(mockSetOriginFlow).toHaveBeenCalledWith(HOOKS_TRACKING_LOCATIONS.addAccountModal);
+  });
+
+  it("does not record an origin flow when no location is provided", () => {
+    renderHook(() => useBuyDeviceIntercept(), {
+      initialState: { settings: INITIAL_STATE },
+      minimal: false,
+    });
+
+    expect(mockOpenBuyDeviceModal).toHaveBeenCalled();
+    expect(mockSetOriginFlow).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/hooks/useBuyDeviceIntercept.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useBuyDeviceIntercept.ts
@@ -6,13 +6,18 @@ import { context } from "~/renderer/drawers/Provider";
 import { setDrawerVisibility } from "~/renderer/actions/walletSync";
 import useBuyDeviceDialog from "LLD/features/BuyDevice/hooks/useBuyDeviceDialog";
 import { closeBuyDevice } from "LLD/features/BuyDevice/buyDeviceDialog";
+import { setOriginFlow } from "~/renderer/analytics/originFlow";
+import type { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
 
 /**
  * When user has no onboarded device and no device connected (and is not on a device-setup
  * route), opens the Buy Device modal and returns false so the caller can return null.
  * Otherwise returns true (show the device action content).
+ *
+ * @param location the originating flow (e.g. Add Account), recorded as the origin flow so the
+ * Buy Device modal knows where it was triggered from (analytics trigger + resume-after-onboarding).
  */
-export function useBuyDeviceIntercept(): boolean {
+export function useBuyDeviceIntercept(location?: HOOKS_TRACKING_LOCATIONS): boolean {
   const hasOnboardedDevice = useSelector(hasOnboardedDeviceSelector);
   const { pathname } = useLocation();
   const dispatch = useDispatch();
@@ -28,11 +33,12 @@ export function useBuyDeviceIntercept(): boolean {
       dispatch(closeBuyDevice());
     } else if (!didOpenRef.current) {
       didOpenRef.current = true;
+      if (location) setOriginFlow(location);
       setDrawer();
       dispatch(setDrawerVisibility(false));
       openBuyDeviceModal();
     }
-  }, [shouldShowContent, dispatch, setDrawer, openBuyDeviceModal]);
+  }, [shouldShowContent, dispatch, setDrawer, openBuyDeviceModal, location]);
 
   return shouldShowContent;
 }

--- a/apps/ledger-live-desktop/src/renderer/reducers/__tests__/onboarding.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/__tests__/onboarding.test.ts
@@ -1,0 +1,36 @@
+import onboardingReducer, {
+  setShouldResumeAddAccountAfterOnboarding,
+  shouldResumeAddAccountAfterOnboardingSelector,
+  type OnboardingState,
+} from "../onboarding";
+import type { State } from "..";
+
+describe("onboarding reducer - shouldResumeAddAccountAfterOnboarding", () => {
+  const getInitialState = (): OnboardingState => onboardingReducer(undefined, { type: "@@INIT" });
+
+  it("defaults to false", () => {
+    expect(getInitialState().shouldResumeAddAccountAfterOnboarding).toBe(false);
+  });
+
+  it("sets the flag to true", () => {
+    const state = onboardingReducer(
+      getInitialState(),
+      setShouldResumeAddAccountAfterOnboarding(true),
+    );
+    expect(state.shouldResumeAddAccountAfterOnboarding).toBe(true);
+  });
+
+  it("clears the flag back to false", () => {
+    const enabled = onboardingReducer(
+      getInitialState(),
+      setShouldResumeAddAccountAfterOnboarding(true),
+    );
+    const cleared = onboardingReducer(enabled, setShouldResumeAddAccountAfterOnboarding(false));
+    expect(cleared.shouldResumeAddAccountAfterOnboarding).toBe(false);
+  });
+
+  it("selector reads the flag from state", () => {
+    const state = { onboarding: { shouldResumeAddAccountAfterOnboarding: true } } as State;
+    expect(shouldResumeAddAccountAfterOnboardingSelector(state)).toBe(true);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/reducers/onboarding.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/onboarding.ts
@@ -9,6 +9,7 @@ export interface OnboardingState {
   isOnboardingReceiveFlow: boolean;
   isOnboardingReceiveSuccess: boolean;
   isSkipDrawerOpen: boolean;
+  shouldResumeAddAccountAfterOnboarding: boolean;
 }
 
 /*
@@ -20,6 +21,7 @@ const initialState: OnboardingState = {
   isOnboardingReceiveFlow: false,
   isOnboardingReceiveSuccess: false,
   isSkipDrawerOpen: false,
+  shouldResumeAddAccountAfterOnboarding: false,
 };
 
 const onboardingSlice = createSlice({
@@ -39,6 +41,9 @@ const onboardingSlice = createSlice({
     setSkipDrawerVisibility: (state, action: PayloadAction<boolean>) => {
       state.isSkipDrawerOpen = action.payload;
     },
+    setShouldResumeAddAccountAfterOnboarding: (state, action: PayloadAction<boolean>) => {
+      state.shouldResumeAddAccountAfterOnboarding = action.payload;
+    },
   },
 });
 
@@ -52,8 +57,14 @@ export const onboardingReceiveFlowSelector = (state: State) =>
   state.onboarding.isOnboardingReceiveFlow;
 export const onboardingReceiveSuccessSelector = (state: State) =>
   state.onboarding.isOnboardingReceiveSuccess;
+export const shouldResumeAddAccountAfterOnboardingSelector = (state: State) =>
+  state.onboarding.shouldResumeAddAccountAfterOnboarding;
 
-export const { setIsOnboardingReceiveFlow, setOnboardingSyncFlow, setSkipDrawerVisibility } =
-  onboardingSlice.actions;
+export const {
+  setIsOnboardingReceiveFlow,
+  setOnboardingSyncFlow,
+  setSkipDrawerVisibility,
+  setShouldResumeAddAccountAfterOnboarding,
+} = onboardingSlice.actions;
 
 export default onboardingSlice.reducer;


### PR DESCRIPTION
feat: add test coverage

feat: move resume add logic to own hook

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Stores add account intent for lazy onboarding so that add account flow re-opens when the user has completed onboarding.

With recover upsell:

https://github.com/user-attachments/assets/92245310-bc56-47cd-b592-f1baa692c8ed

Without recover upsell:

https://github.com/user-attachments/assets/59b4d36a-bdf6-4ec4-ac79-62e40bcd9224



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-31404


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
