### PR TITLE
[LWDM] fix(mobile): add displayedPosition to wallet braze carousel analytics

### DIFF
--- a/.changeset/brave-wallets-track.md
+++ b/.changeset/brave-wallets-track.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix missing displayedPosition on Wallet Braze carousel content card analytics (impression, click, dismiss)

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
@@ -353,6 +353,7 @@ describe("BottomCarouselContentCards", () => {
         page: "Portfolio",
         type: "portfolio_carousel",
         location: LocationContentCard.BottomPortfolio,
+        displayedPosition: 1,
       }),
     );
     expect(title1).not.toBeInTheDocument();
@@ -379,6 +380,7 @@ describe("BottomCarouselContentCards", () => {
         page: "Portfolio",
         type: "portfolio_carousel",
         location: LocationContentCard.BottomPortfolio,
+        displayedPosition: 0,
       }),
     );
   });

--- a/apps/ledger-live-mobile/src/components/Carousel/CarouselCard.tsx
+++ b/apps/ledger-live-mobile/src/components/Carousel/CarouselCard.tsx
@@ -15,7 +15,7 @@ type CarouselCardProps = {
   id: string;
   width: number;
   cardProps: WalletContentCard;
-  index?: number;
+  index: number;
 };
 
 const CarouselCard = ({ id, cardProps, index, width }: CarouselCardProps) => {
@@ -25,6 +25,7 @@ const CarouselCard = ({ id, cardProps, index, width }: CarouselCardProps) => {
 
   const { handleHide, handlePress, mediaHeader } = useCarouselCardModel({
     cardProps,
+    displayedPosition: index,
     logClickCard,
     dismissCard,
     trackContentCardEvent,

--- a/apps/ledger-live-mobile/src/components/Carousel/index.tsx
+++ b/apps/ledger-live-mobile/src/components/Carousel/index.tsx
@@ -53,6 +53,7 @@ const Carousel = () => {
         <LogContentCardWrapper
           key={cardProps.id + index}
           id={cardProps.id}
+          displayedPosition={index}
           location={cardProps.location}
         >
           <CarouselCard id={cardProps.id} cardProps={cardProps} index={index} width={cardsWidth} />

--- a/apps/ledger-live-mobile/src/components/Carousel/useCarouselCardModel.test.ts
+++ b/apps/ledger-live-mobile/src/components/Carousel/useCarouselCardModel.test.ts
@@ -1,0 +1,60 @@
+import { Linking } from "react-native";
+
+import { act, renderHook } from "@tests/test-renderer";
+import { ContentCardLocation, WalletContentCard } from "~/dynamicContent/types";
+import { useCarouselCardModel } from "./useCarouselCardModel";
+
+const cardProps: WalletContentCard = {
+  id: "wallet-card-1",
+  location: ContentCardLocation.Wallet,
+  link: "https://example.com",
+  createdAt: 0,
+  viewed: false,
+  extras: { location: ContentCardLocation.Wallet, order: "1" },
+};
+
+describe("useCarouselCardModel", () => {
+  it("includes displayedPosition in click and dismiss tracking", async () => {
+    const trackContentCardEvent = jest.fn().mockResolvedValue(undefined);
+    const logClickCard = jest.fn();
+    const dismissCard = jest.fn();
+    const openURLSpy = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useCarouselCardModel({
+        cardProps,
+        displayedPosition: 2,
+        logClickCard,
+        dismissCard,
+        trackContentCardEvent,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handlePress();
+    });
+    act(() => {
+      result.current.handleHide();
+    });
+
+    expect(trackContentCardEvent).toHaveBeenCalledWith("contentcard_clicked", {
+      location: ContentCardLocation.Wallet,
+      order: "1",
+      screen: ContentCardLocation.Wallet,
+      campaign: "wallet-card-1",
+      displayedPosition: 2,
+    });
+    expect(trackContentCardEvent).toHaveBeenCalledWith("contentcard_dismissed", {
+      location: ContentCardLocation.Wallet,
+      order: "1",
+      screen: ContentCardLocation.Wallet,
+      campaign: "wallet-card-1",
+      displayedPosition: 2,
+    });
+    expect(openURLSpy).toHaveBeenCalledWith("https://example.com");
+    expect(logClickCard).toHaveBeenCalledWith("wallet-card-1");
+    expect(dismissCard).toHaveBeenCalledWith("wallet-card-1");
+
+    openURLSpy.mockRestore();
+  });
+});

--- a/apps/ledger-live-mobile/src/components/Carousel/useCarouselCardModel.ts
+++ b/apps/ledger-live-mobile/src/components/Carousel/useCarouselCardModel.ts
@@ -15,6 +15,7 @@ type TrackContentCardEvent = (
 
 type Args = {
   cardProps: WalletContentCard;
+  displayedPosition: number;
   logClickCard: (cardId: string) => void;
   dismissCard: (cardId: string) => void;
   trackContentCardEvent: TrackContentCardEvent;
@@ -22,6 +23,7 @@ type Args = {
 
 export function useCarouselCardModel({
   cardProps,
+  displayedPosition,
   logClickCard,
   dismissCard,
   trackContentCardEvent,
@@ -33,20 +35,22 @@ export function useCarouselCardModel({
       ...cardProps.extras,
       screen: cardProps.location,
       campaign: cardProps.id,
+      displayedPosition,
     });
 
     logClickCard(cardProps.id);
     await Linking.openURL(cardProps.link);
-  }, [cardProps, logClickCard, trackContentCardEvent]);
+  }, [cardProps, displayedPosition, logClickCard, trackContentCardEvent]);
 
   const handleHide = useCallback(() => {
     trackContentCardEvent("contentcard_dismissed", {
       ...cardProps.extras,
       screen: cardProps.location,
       campaign: cardProps.id,
+      displayedPosition,
     });
     dismissCard(cardProps.id);
-  }, [cardProps, dismissCard, trackContentCardEvent]);
+  }, [cardProps, displayedPosition, dismissCard, trackContentCardEvent]);
 
   const mediaHeader = useMemo((): WalletCarouselMediaHeader => {
     if (cardProps.picto != null && cardProps.picto !== "") {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile Wallet Braze carousel analytics (`contentcard_impression`, `contentcard_clicked`, `contentcard_dismissed`)
  - Verify `displayedPosition` is a numeric 0-based index on all three events for `location: wallet`

### 📝 Description

**Problem**: After LIVE-27516, CRM QA found that `displayedPosition` was still missing for the mobile Wallet Braarousel (bottom of portfolio page). The Wallet placement uses a separate `components/Carousel` code path that was not updated in LIVE-27516.

**Solution**:
- Pass `displayedPosition={index}` to `LogContentCardWrapper` for impressions
- Include `displayedPosition` in `contentcard_clicked` and `contentcard_dismissed` via `useCarouselCardModel`
- Add unit test for click/dismiss tracking
- Add desktop bottom carousel regression assertions (desktop was already fixed in LIVE-27516)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30581](https://ledgerhq.atlassian.net/browse/LIVE-30581)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30581]: https://ledgerhq.atlassian.net/browse/LIVE-30581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ