### PR TITLE
[LWM] fix(market): show footer spinner while loading next page in mobile Market list

### DIFF
--- a/.changeset/lwm-market-footer-spinner.md
+++ b/.changeset/lwm-market-footer-spinner.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix missing footer spinner in the mobile Market list while loading the next page on scroll

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/assetsList.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/assetsList.integration.test.tsx
@@ -304,6 +304,53 @@ describe("MarketScreen assets list (Block 3)", () => {
     expect(screen.queryByTestId("marketItem-bitcoin")).toBeNull();
   });
 
+  it("shows the footer spinner while loading the next page of assets", async () => {
+    let resolveSecondPage: (() => void) | undefined;
+    const secondPageLoaded = new Promise<void>(resolve => {
+      resolveSecondPage = resolve;
+    });
+
+    server.use(
+      http.get("https://countervalues.live.ledger.com/v3/markets", async ({ request }) => {
+        const searchParams = new URL(request.url).searchParams;
+        const page = parseInt(searchParams.get("page") || "0");
+        const pageSize = parseInt(searchParams.get("pageSize") || "20");
+
+        // Hold the next page in flight so the footer spinner stays visible.
+        if (page >= 1) {
+          await secondPageLoaded;
+        }
+
+        return HttpResponse.json(marketsMock.slice(page * pageSize, page * pageSize + pageSize));
+      }),
+    );
+
+    renderWithReactQuery(<NavigatorWrapper />, {
+      overrideInitialState: enableAssetDiscoverability,
+    });
+
+    await waitFor(() => expect(screen.getByTestId("marketItem-bitcoin")).toBeVisible(), {
+      timeout: 5000,
+    });
+    expect(screen.queryByTestId(MARKET_SCREEN_TEST_IDS.assetsFooterSpinner)).toBeNull();
+
+    act(() => {
+      screen.getByTestId(MARKET_SCREEN_TEST_IDS.list).props.onEndReached();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsFooterSpinner)).toBeVisible();
+    });
+
+    act(() => {
+      resolveSecondPage?.();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId(MARKET_SCREEN_TEST_IDS.assetsFooterSpinner)).toBeNull();
+    });
+  }, 30000);
+
   it("switches categories from the tabs, including back to All", async () => {
     const marketRequests: string[] = [];
     const dadaRequests: string[] = [];

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
@@ -31,6 +31,7 @@ export function MarketScreenView({ search, highlights, assetsList, isSearchActiv
       <MarketAssetsList
         assets={assetsList.assets}
         loading={assetsList.assetsLoading}
+        fetchingNextPage={assetsList.assetsFetchingNextPage}
         error={assetsList.assetsError}
         emptyState={assetsList.assetsEmptyState}
         selectedCategory={assetsList.categories.selectedCategory}

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketAssets.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketAssets.test.ts
@@ -66,8 +66,12 @@ describe("useMarketAssets", () => {
     mockMarketData({ data: fullMarketPage, isFetching: true });
     const { result } = renderHook(() => useMarketAssets());
 
+    // The first page is fetching, but it is not a "next page" load yet.
+    expect(result.current.isFetchingNextPage).toBe(false);
+
     act(() => result.current.onEndReached());
     expect(mockedUseMarketData).toHaveBeenLastCalledWith(expect.objectContaining({ page: 2 }));
+    expect(result.current.isFetchingNextPage).toBe(true);
 
     act(() => result.current.onEndReached());
     expect(mockedUseMarketData).not.toHaveBeenCalledWith(expect.objectContaining({ page: 3 }));

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketScreenViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketScreenViewModel.test.ts
@@ -39,6 +39,7 @@ function mockMarketAssets(overrides: Partial<ReturnType<typeof useMarketAssets>>
   mockedUseMarketAssets.mockReturnValue({
     assets: [createMarketAssetDisplayData()],
     loading: false,
+    isFetchingNextPage: false,
     isError: false,
     emptyState: undefined,
     onEndReached: jest.fn(),
@@ -80,11 +81,12 @@ describe("useMarketScreenViewModel", () => {
     expect(result.current.highlights.highlightCards.length).toBeGreaterThan(0);
   });
 
-  it("forwards the assets and their loading / error flags", () => {
-    mockMarketAssets({ loading: true, isError: false });
+  it("forwards the assets and their loading / fetching / error flags", () => {
+    mockMarketAssets({ loading: true, isFetchingNextPage: true, isError: false });
     const { result } = renderHook(() => useMarketScreenViewModel());
     expect(result.current.assetsList.assets).toHaveLength(1);
     expect(result.current.assetsList.assetsLoading).toBe(true);
+    expect(result.current.assetsList.assetsFetchingNextPage).toBe(true);
     expect(result.current.assetsList.assetsError).toBe(false);
   });
 
@@ -121,6 +123,7 @@ describe("useMarketScreenViewModel", () => {
 
   it("collapses sections immediately and debounces the asset search query", () => {
     jest.useFakeTimers();
+    mockMarketAssets({ isFetchingNextPage: true });
     const { result } = renderHook(() => useMarketScreenViewModel());
 
     expect(mockedUseMarketAssets).toHaveBeenLastCalledWith(defaultMarketAssetsParams);
@@ -130,6 +133,8 @@ describe("useMarketScreenViewModel", () => {
     expect(result.current.isSearchActive).toBe(true);
     expect(result.current.assetsList.assets).toEqual([]);
     expect(result.current.assetsList.assetsLoading).toBe(true);
+    // The footer spinner must stay hidden while the new query is debouncing.
+    expect(result.current.assetsList.assetsFetchingNextPage).toBe(false);
     expect(mockedUseMarketAssets).toHaveBeenLastCalledWith(defaultMarketAssetsParams);
 
     act(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/__tests__/MarketAssetsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/__tests__/MarketAssetsList.test.tsx
@@ -30,6 +30,7 @@ const filters: MarketFilters = {
 const defaultProps = {
   assets: [asset],
   loading: false,
+  fetchingNextPage: false,
   error: false,
   emptyState: undefined,
   selectedCategory: "all",
@@ -101,5 +102,17 @@ describe("MarketAssetsList", () => {
     render(<MarketAssetsList {...defaultProps} assets={[]} error />);
 
     expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsError)).toBeVisible();
+  });
+
+  it("should render the footer spinner while fetching the next page", () => {
+    render(<MarketAssetsList {...defaultProps} fetchingNextPage />);
+
+    expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsFooterSpinner)).toBeVisible();
+  });
+
+  it("should not render the footer spinner while the list is empty", () => {
+    render(<MarketAssetsList {...defaultProps} assets={[]} fetchingNextPage />);
+
+    expect(screen.queryByTestId(MARKET_SCREEN_TEST_IDS.assetsFooterSpinner)).toBeNull();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, type ReactNode } from "react";
 import { SectionList, type SectionListRenderItemInfo } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { Box, Spinner } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import type { MarketListCategory } from "~/reducers/types";
 import AssetListItem, { type MarketAssetDisplayData } from "LLM/components/AssetListItem";
@@ -20,6 +20,7 @@ const HORIZONTAL_PADDING = 16;
 type Props = Readonly<{
   assets: MarketAssetDisplayData[];
   loading: boolean;
+  fetchingNextPage: boolean;
   error: boolean;
   emptyState: "favorites" | "stocks" | undefined;
   selectedCategory: MarketListCategory;
@@ -35,6 +36,7 @@ type Props = Readonly<{
 export function MarketAssetsList({
   assets,
   loading,
+  fetchingNextPage,
   error,
   emptyState,
   selectedCategory,
@@ -98,6 +100,13 @@ export function MarketAssetsList({
           showEmptySearchState={!showSubheader}
         />
       </Box>
+    ) : fetchingNextPage ? (
+      <Spinner
+        size={24}
+        color="base"
+        lx={footerSpinnerStyle}
+        testID={MARKET_SCREEN_TEST_IDS.assetsFooterSpinner}
+      />
     ) : null;
 
   return (
@@ -143,4 +152,9 @@ const stickyCategorySwitcherStyle: LumenViewStyle = {
 
 const rowStyle: LumenViewStyle = {
   marginHorizontal: "-s8",
+};
+
+const footerSpinnerStyle: LumenViewStyle = {
+  marginVertical: "s24",
+  alignSelf: "center",
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/index.tsx
@@ -90,6 +90,15 @@ export function MarketAssetsList({
     [selectedCategory, categoryTabs, onSelectCategory],
   );
 
+  const footerSpinner = fetchingNextPage ? (
+    <Spinner
+      size={24}
+      color="base"
+      lx={footerSpinnerStyle}
+      testID={MARKET_SCREEN_TEST_IDS.assetsFooterSpinner}
+    />
+  ) : null;
+
   const listFooter =
     assets.length === 0 ? (
       <Box style={{ minHeight: footerMinHeight }}>
@@ -100,14 +109,9 @@ export function MarketAssetsList({
           showEmptySearchState={!showSubheader}
         />
       </Box>
-    ) : fetchingNextPage ? (
-      <Spinner
-        size={24}
-        color="base"
-        lx={footerSpinnerStyle}
-        testID={MARKET_SCREEN_TEST_IDS.assetsFooterSpinner}
-      />
-    ) : null;
+    ) : (
+      footerSpinner
+    );
 
   return (
     <>

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssets.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssets.ts
@@ -42,6 +42,7 @@ export type MarketAssetsParams = {
 export interface MarketAssetsResult {
   assets: MarketAssetDisplayData[];
   loading: boolean;
+  isFetchingNextPage: boolean;
   isError: boolean;
   emptyState: EmptyState;
   onEndReached: () => void;
@@ -152,6 +153,7 @@ export function useMarketAssets({
   return {
     assets,
     loading,
+    isFetchingNextPage,
     isError: shouldFetchAssets && result.isError,
     emptyState: getEmptyState({ isFavoritesCategory, hasFavoriteIds, isStocksCategory }),
     onEndReached,

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
@@ -23,6 +23,7 @@ export type { MarketFilters, MarketFilterOption } from "./useMarketFilters";
 export type MarketScreenAssetsList = {
   assets: MarketAssetDisplayData[];
   assetsLoading: boolean;
+  assetsFetchingNextPage: boolean;
   assetsError: boolean;
   assetsEmptyState: "favorites" | "stocks" | undefined;
   categories: MarketCategories;
@@ -49,13 +50,14 @@ export function useMarketScreenViewModel(): MarketScreenViewModel {
   const categories = useMarketCategories({ routeCategory });
   const filters = useMarketFilters();
   const starredMarketCoins = useSelector(starredMarketCoinsSelector);
-  const { assets, loading, isError, emptyState, onEndReached } = useMarketAssets({
-    search: search.query,
-    category: categories.selectedCategory,
-    sorting: filters.sorting,
-    timeframe: filters.timeframe,
-    starredMarketCoins,
-  });
+  const { assets, loading, isFetchingNextPage, isError, emptyState, onEndReached } =
+    useMarketAssets({
+      search: search.query,
+      category: categories.selectedCategory,
+      sorting: filters.sorting,
+      timeframe: filters.timeframe,
+      starredMarketCoins,
+    });
   const onAssetPress = useMarketAssetPress();
 
   return {
@@ -68,6 +70,7 @@ export function useMarketScreenViewModel(): MarketScreenViewModel {
     assetsList: {
       assets: search.isDebouncing ? [] : assets,
       assetsLoading: search.isDebouncing || loading,
+      assetsFetchingNextPage: !search.isDebouncing && isFetchingNextPage,
       assetsError: isError,
       assetsEmptyState: search.isDebouncing ? undefined : emptyState,
       categories,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Scroll the Market list (Wallet 4.0) to the bottom and confirm a spinner appears while the next page loads, then disappears once the new rows are in.
  - Confirm no footer spinner shows during the search debounce, when the list is empty (skeleton / empty state instead), or on error.
  - Verify the behavior across categories (All / trending) and that scrolling performance is unaffected.

### 📝 Description

When scrolling through the mobile Market list, the loading spinner at the bottom was missing while the next page of assets was being fetched, leaving the user without feedback during pagination.

The pagination loading state (`isFetchingNextPage`) was already computed in `useMarketAssets` but never surfaced to the UI, and the list footer only rendered content for the empty state. This PR exposes the flag through the view model (`assetsFetchingNextPage`) and the view, and renders a Lumen `Spinner` in the `SectionList` footer while a subsequent page is loading — reusing the pre-existing `assetsFooterSpinner` test ID and following the existing `OperationsListFooter` convention. The spinner is intentionally suppressed during the search debounce and when the list is empty.

Covered by unit (hook + view model), component, and end-to-end integration tests (deferred second-page response asserting the spinner appears then disappears).


https://github.com/user-attachments/assets/65902447-e527-4026-8b2e-d187a5338669



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32571](https://ledgerhq.atlassian.net/browse/LIVE-32571)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32571]: https://ledgerhq.atlassian.net/browse/LIVE-32571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ