### PR TITLE
[LWD] feat(desktop): add market & asset discoverability analytics

### DIFF
--- a/.changeset/perfect-sloths-provide.md
+++ b/.changeset/perfect-sloths-provide.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add analytics tracking for the Market page and global asset discoverability. Tracks search open/query/asset-clicked events from the global search overlay, sort and "see all" interactions, market banner ranking changes, and a dedicated discoverability TrackPage payload. Introduces a shared `marketPageAnalytics` util and `screenRefs` helpers for resolving current/previous tracking page names.

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/__tests__/useAssetSearchBar.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/__tests__/useAssetSearchBar.test.ts
@@ -1,0 +1,54 @@
+import { ChangeEvent } from "react";
+import { renderHook, act } from "tests/testSetup";
+import { track } from "~/renderer/analytics/segment";
+import { useAssetSearchBar } from "../useAssetSearchBar";
+
+jest.mock("@ledgerhq/live-common/hooks/useDebounce", () => ({
+  useDebounce: <T>(value: T) => value,
+}));
+
+jest.mock("LLD/features/Stocks/hooks/useStocksSectionViewModel", () => ({
+  useStocksSectionViewModel: () => ({ data: [], isLoading: false, isError: false }),
+}));
+
+jest.mock("LLD/features/SearchAssets/hooks/useAssetSuggestionsViewModel", () => ({
+  useAssetSuggestionsViewModel: () => ({ cryptos: { data: [], isLoading: false }, isError: false }),
+}));
+
+jest.mock("LLD/features/SearchAssets/hooks/useAssetSearchResultsViewModel", () => ({
+  useAssetSearchResultsViewModel: () => ({ data: [], isLoading: false, isError: false }),
+}));
+
+// getCurrentTrackingPage reads a module-level navigation ref that leaks across the full suite.
+// Mock it so the tracked page is deterministic here.
+jest.mock("~/renderer/analytics/screenRefs", () => ({
+  getCurrentTrackingPage: () => "",
+  getPreviousTrackingPage: () => "",
+}));
+
+const mockedTrack = jest.mocked(track);
+
+const changeQuery = (value: string) => ({ target: { value } }) as ChangeEvent<HTMLInputElement>;
+
+describe("useAssetSearchBar", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("tracks the debounced query once it reaches the minimum search length", () => {
+    const { result } = renderHook(() => useAssetSearchBar());
+
+    act(() => result.current.onChangeQuery(changeQuery("bit")));
+
+    expect(mockedTrack).toHaveBeenCalledWith("Query global search", {
+      search_query: "bit",
+      page: "",
+    });
+  });
+
+  it("does not track a query shorter than the minimum search length", () => {
+    const { result } = renderHook(() => useAssetSearchBar());
+
+    act(() => result.current.onChangeQuery(changeQuery("b")));
+
+    expect(mockedTrack).not.toHaveBeenCalledWith("Query global search", expect.anything());
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/__tests__/useSearchOverlayViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/__tests__/useSearchOverlayViewModel.test.ts
@@ -1,11 +1,21 @@
-import { renderHook } from "tests/testSetup";
+import { renderHook, act } from "tests/testSetup";
+import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { track } from "~/renderer/analytics/segment";
 import { useSearchOverlayViewModel } from "../useSearchOverlayViewModel";
 import { useAssetSearchBar } from "../useAssetSearchBar";
 import { SearchMode, SearchResults, SearchSuggestions } from "../types";
 
 jest.mock("../useAssetSearchBar");
 
+// getCurrentTrackingPage/getPreviousTrackingPage read module-level navigation refs that leak
+// across the full suite. Mock them so the tracked page/source are deterministic here.
+jest.mock("~/renderer/analytics/screenRefs", () => ({
+  getCurrentTrackingPage: () => "",
+  getPreviousTrackingPage: () => "",
+}));
+
 const mockedUseAssetSearchBar = jest.mocked(useAssetSearchBar);
+const mockedTrack = jest.mocked(track);
 
 const EMPTY_SECTION = { data: [], isLoading: false };
 const EMPTY_SUGGESTIONS: SearchSuggestions = {
@@ -74,6 +84,57 @@ describe("useSearchOverlayViewModel", () => {
       mockSearchBar({ mode: "suggestions", isOpen: true, query: "" });
       rerender();
       expect(result.current.mode).toBe("suggestions");
+    });
+  });
+
+  describe("navigateToAsset tracking", () => {
+    it("tracks asset_clicked with searched=true when clicking a search result", () => {
+      mockSearchBar({ mode: "results", isOpen: true, query: "bit" });
+      const { result } = renderHook(() => useSearchOverlayViewModel());
+
+      act(() => {
+        result.current.contextValue.navigateToAsset("bitcoin", {
+          name: "Bitcoin",
+        } as MarketCurrencyData);
+      });
+
+      expect(mockedTrack).toHaveBeenCalledWith("asset_clicked", {
+        asset: "Bitcoin",
+        page: "",
+        flow: "global_search",
+        source: "",
+        searched: true,
+      });
+    });
+
+    it("tracks asset_clicked with searched=false when clicking the default suggestions list", () => {
+      mockSearchBar({ mode: "suggestions", isOpen: true, query: "" });
+      const { result } = renderHook(() => useSearchOverlayViewModel());
+
+      act(() => {
+        result.current.contextValue.navigateToAsset("bitcoin", {
+          name: "Bitcoin",
+        } as MarketCurrencyData);
+      });
+
+      expect(mockedTrack).toHaveBeenCalledWith(
+        "asset_clicked",
+        expect.objectContaining({ asset: "Bitcoin", flow: "global_search", searched: false }),
+      );
+    });
+
+    it("falls back to the currency id when no market state is provided", () => {
+      mockSearchBar({ mode: "suggestions", isOpen: true, query: "" });
+      const { result } = renderHook(() => useSearchOverlayViewModel());
+
+      act(() => {
+        result.current.contextValue.navigateToAsset("aaplx");
+      });
+
+      expect(mockedTrack).toHaveBeenCalledWith(
+        "asset_clicked",
+        expect.objectContaining({ asset: "aaplx", searched: false }),
+      );
     });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useAssetSearchBar.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useAssetSearchBar.ts
@@ -1,9 +1,11 @@
-import { ChangeEvent, useCallback, useMemo, useState } from "react";
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { useStocksSectionViewModel } from "LLD/features/Stocks/hooks/useStocksSectionViewModel";
 import { useAssetSuggestionsViewModel } from "LLD/features/SearchAssets/hooks/useAssetSuggestionsViewModel";
 import { useAssetSearchResultsViewModel } from "LLD/features/SearchAssets/hooks/useAssetSearchResultsViewModel";
 import { SearchMode, SearchResults, SearchSuggestions } from "./types";
+import { track } from "~/renderer/analytics/segment";
+import { getCurrentTrackingPage } from "~/renderer/analytics/screenRefs";
 
 export const STOCKS_SUGGESTION_LIMIT = 20;
 export const CRYPTOS_SUGGESTION_LIMIT = 3;
@@ -22,7 +24,10 @@ export function useAssetSearchBar() {
   }, []);
 
   const clear = useCallback(() => setQuery(""), []);
-  const open = useCallback(() => setIsOpen(true), []);
+  const open = useCallback(() => {
+    setIsOpen(true);
+    track("search_open", { page: getCurrentTrackingPage() });
+  }, []);
   const close = useCallback(() => {
     setIsOpen(false);
     setQuery("");
@@ -31,6 +36,15 @@ export function useAssetSearchBar() {
   const trimmedQuery = query.trim();
   const debouncedQuery = useDebounce(trimmedQuery, SEARCH_DEBOUNCE_MS);
   const searchEnabled = debouncedQuery.length >= MIN_SEARCH_LENGTH;
+
+  // Track the search once the debounce settles on a searchable query.
+  useEffect(() => {
+    if (debouncedQuery.length < MIN_SEARCH_LENGTH) return;
+    track("Query global search", {
+      search_query: debouncedQuery,
+      page: getCurrentTrackingPage(),
+    });
+  }, [debouncedQuery]);
 
   // --- Default suggestions (top market cap + stocks), shown when the query is empty. ---
   const stocks = useStocksSectionViewModel({ limit: STOCKS_SUGGESTION_LIMIT });

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useSearchOverlayViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useSearchOverlayViewModel.ts
@@ -2,12 +2,13 @@ import { KeyboardEvent, useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
-import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { getMarketOrAssetDetailPath } from "LLD/utils/marketAssetNavigation";
 import { setMarketCategory } from "~/renderer/actions/market";
 import { useAssetSearchBar } from "./useAssetSearchBar";
 import { SearchOverlayContextValue } from "./types";
 import { useDispatch } from "LLD/hooks/redux";
+import { track } from "~/renderer/analytics/segment";
+import { getCurrentTrackingPage, getPreviousTrackingPage } from "~/renderer/analytics/screenRefs";
 
 export function useSearchOverlayViewModel() {
   const navigate = useNavigate();
@@ -25,28 +26,39 @@ export function useSearchOverlayViewModel() {
 
   const navigateToAsset = useCallback(
     (currencyId: string, marketState?: MarketCurrencyData) => {
-      setTrackingSource("Global Search");
+      track("asset_clicked", {
+        asset: marketState?.name ?? currencyId,
+        page: getCurrentTrackingPage(),
+        flow: "global_search",
+        source: getPreviousTrackingPage(),
+        // true when clicked from the search results list, false from the default suggestions list.
+        searched: displayedMode === "results",
+      });
       navigate(getMarketOrAssetDetailPath(currencyId, shouldDisplayAggregatedAssets), {
         state: marketState,
       });
       close();
     },
-    [navigate, shouldDisplayAggregatedAssets, close],
+    [navigate, shouldDisplayAggregatedAssets, close, displayedMode],
   );
 
-  const navigateToMarket = useCallback(() => {
-    setTrackingSource("Global Search");
-    dispatch(setMarketCategory("all"));
-    navigate("/market");
-    close();
-  }, [dispatch, navigate, close]);
+  const goToMarket = useCallback(
+    (marketCategory: Parameters<typeof setMarketCategory>[0], trackCategory: string) => {
+      dispatch(setMarketCategory(marketCategory));
+      navigate("/market");
+      track("button_clicked", {
+        button: "see all",
+        flow: "global_search",
+        page: getCurrentTrackingPage(),
+        category: trackCategory,
+      });
+      close();
+    },
+    [dispatch, navigate, close],
+  );
 
-  const navigateToStocksMarket = useCallback(() => {
-    setTrackingSource("Global Search");
-    dispatch(setMarketCategory("stocks"));
-    navigate("/market");
-    close();
-  }, [dispatch, navigate, close]);
+  const navigateToMarket = useCallback(() => goToMarket("all", "crypto"), [goToMarket]);
+  const navigateToStocksMarket = useCallback(() => goToMarket("stocks", "stocks"), [goToMarket]);
 
   const onOpenChange = useCallback(
     (next: boolean) => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/AltSeasonIndexCard/hooks/useAltSeasonIndexViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/AltSeasonIndexCard/hooks/useAltSeasonIndexViewModel.ts
@@ -16,7 +16,7 @@ export const useAltSeasonIndexViewModel = () => {
 
   const onClick = () => {
     track("button_clicked", {
-      button: "altcoin_index",
+      button: "alt_season_index_definition",
     });
   };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/hooks/useGlobalMarketCapViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/hooks/useGlobalMarketCapViewModel.ts
@@ -12,7 +12,7 @@ export const useGlobalMarketCapViewModel = () => {
 
   const onClick = () => {
     track("button_clicked", {
-      button: "market_cap",
+      button: "market_cap_definition",
     });
   };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/MoodIndexCard/hooks/useMoodIndexCardViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/MoodIndexCard/hooks/useMoodIndexCardViewModel.ts
@@ -6,7 +6,7 @@ export const useMoodIndexCardViewModel = () => {
 
   const onClick = () => {
     track("button_clicked", {
-      button: "mood_index",
+      button: "mood_index_definition",
     });
   };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/useMarketTableViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/__tests__/useMarketTableViewModel.test.ts
@@ -1,8 +1,11 @@
 import { renderHook } from "tests/testSetup";
 import { MOCK_MARKET_CURRENCY_DATA } from "@ledgerhq/live-common/market/utils/fixtures";
 import { Order } from "@ledgerhq/live-common/market/utils/types";
+import { track } from "~/renderer/analytics/segment";
 import { MarketTableData, useMarketTableViewModel } from "../useMarketTableViewModel";
 import { mockT } from "../../__tests__/shared";
+
+const mockedTrack = jest.mocked(track);
 
 const mockParentRef = { current: null };
 const mockRowVirtualizer = { getVirtualItems: () => [], getTotalSize: () => 0 };
@@ -140,6 +143,25 @@ describe("useMarketTableViewModel", () => {
     );
     fromOther.current.onToggleVolume();
     expect(refresh).toHaveBeenCalledWith({ order: Order.VolumeDesc });
+  });
+
+  it("should track sort_market_list with the resulting sort state and timeframe on toggle", () => {
+    const { result } = renderHook(() =>
+      useMarketTableViewModel(
+        createData({
+          marketParams: { order: Order.MarketCapDesc, range: "7d" },
+        }),
+      ),
+    );
+
+    result.current.onToggleVolume();
+
+    expect(mockedTrack).toHaveBeenCalledWith("sort_market_list", {
+      sortVolume: "true_desc",
+      sortMarketCap: "false",
+      sortChange: "false",
+      timeframe: "7D",
+    });
   });
 
   it("should show the skeleton while fresh loading or on error", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/useMarketTableViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/useMarketTableViewModel.ts
@@ -6,6 +6,11 @@ import {
   Order,
 } from "@ledgerhq/live-common/market/utils/types";
 import { useMarketListVirtualization } from "../../hooks/useMarketListVirtualization";
+import {
+  getMarketSortDirection,
+  getMarketSortListAnalytics,
+} from "../../utils/marketPageAnalytics";
+import { track } from "~/renderer/analytics/segment";
 
 export type MarketTableData = {
   marketData: MarketCurrencyData[];
@@ -26,16 +31,6 @@ export type MarketTableData = {
   checkIfDataIsStaleAndRefetch: (scrollOffset: number) => void;
   t: TFunction;
 };
-
-function getSortDirection(
-  order: Order | undefined,
-  descOrder: Order,
-  ascOrder: Order,
-): "asc" | "desc" | undefined {
-  if (order === descOrder) return "desc";
-  if (order === ascOrder) return "asc";
-  return undefined;
-}
 
 export function useMarketTableViewModel({
   marketData,
@@ -71,7 +66,13 @@ export function useMarketTableViewModel({
   const starredSet = useMemo(() => new Set(starredMarketCoins), [starredMarketCoins]);
   const isStarred = useCallback((id: string) => starredSet.has(id), [starredSet]);
 
-  const onSort = useCallback((nextOrder: Order) => refresh({ order: nextOrder }), [refresh]);
+  const onSort = useCallback(
+    (nextOrder: Order) => {
+      refresh({ order: nextOrder });
+      track("sort_market_list", getMarketSortListAnalytics({ order: nextOrder, range }));
+    },
+    [refresh, range],
+  );
   const onToggleMarketCap = useCallback(
     () => onSort(order === Order.MarketCapDesc ? Order.MarketCapAsc : Order.MarketCapDesc),
     [onSort, order],
@@ -85,9 +86,9 @@ export function useMarketTableViewModel({
     [onSort, order],
   );
 
-  const marketCapSort = getSortDirection(order, Order.MarketCapDesc, Order.MarketCapAsc);
-  const changeSort = getSortDirection(order, Order.topGainers, Order.topLosers);
-  const volumeSort = getSortDirection(order, Order.VolumeDesc, Order.VolumeAsc);
+  const marketCapSort = getMarketSortDirection(order, Order.MarketCapDesc, Order.MarketCapAsc);
+  const changeSort = getMarketSortDirection(order, Order.topGainers, Order.topLosers);
+  const volumeSort = getMarketSortDirection(order, Order.VolumeDesc, Order.VolumeAsc);
 
   return {
     parentRef,

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import { Flex, Dropdown } from "@ledgerhq/react-ui";
 import { Subheader, SubheaderRow, SubheaderTitle } from "@ledgerhq/lumen-ui-react";
 import styled from "styled-components";
@@ -14,6 +14,7 @@ import MarketTable from "./components/MarketTable";
 import MarketTopCards from "./TopCards";
 import { MarketCategoryBar } from "./components/MarketCategoryBar";
 import { MarketRangeSelect } from "./components/MarketRangeSelect";
+import { getMarketDiscoverabilityPageAnalytics } from "./utils/marketPageAnalytics";
 
 const Container = styled(Flex).attrs({
   flex: "1",
@@ -72,13 +73,27 @@ export default function Market() {
 
   const { order, range, counterCurrency, search = "", liveCompatible } = marketParams;
 
+  const discoverabilityPageAnalytics = useMemo(
+    () =>
+      getMarketDiscoverabilityPageAnalytics({
+        order,
+        range,
+        category: categories.selectedCategory,
+      }),
+    [categories.selectedCategory, order, range],
+  );
+
   return (
     <Container>
       <TrackPage
-        category="Market"
-        sort={order !== "desc"}
-        timeframe={range}
-        countervalue={counterCurrency}
+        {...(shouldDisplayAssetDiscoverability
+          ? discoverabilityPageAnalytics
+          : {
+              sort: order !== "desc",
+              timeframe: range,
+              countervalue: counterCurrency,
+              category: "Market",
+            })}
       />
       <PageHeader title={t("market.title")} onBack={() => navigate("/")} />
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/utils/__tests__/marketPageAnalytics.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/utils/__tests__/marketPageAnalytics.test.ts
@@ -1,0 +1,127 @@
+import { Order } from "@ledgerhq/live-common/market/utils/types";
+import {
+  getMarketDiscoverabilityPageAnalytics,
+  getMarketPageCategoryAnalytics,
+  getMarketPageSortAnalytics,
+  getMarketPageTimeframeAnalytics,
+  getMarketSortDirection,
+  getMarketSortListAnalytics,
+  getMarketSortToggleValue,
+} from "../marketPageAnalytics";
+
+describe("marketPageAnalytics", () => {
+  describe("getMarketSortDirection", () => {
+    it("returns desc when order matches the desc order", () => {
+      expect(
+        getMarketSortDirection(Order.MarketCapDesc, Order.MarketCapDesc, Order.MarketCapAsc),
+      ).toBe("desc");
+    });
+
+    it("returns asc when order matches the asc order", () => {
+      expect(getMarketSortDirection(Order.VolumeAsc, Order.VolumeDesc, Order.VolumeAsc)).toBe(
+        "asc",
+      );
+    });
+
+    it("returns undefined when order does not match either sort order", () => {
+      expect(
+        getMarketSortDirection(Order.MarketCapDesc, Order.VolumeDesc, Order.VolumeAsc),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("getMarketPageTimeframeAnalytics", () => {
+    it.each([
+      ["24h", "1D"],
+      ["7d", "7D"],
+      ["30d", "30D"],
+      ["6m", "6M"],
+      ["1y", "1Y"],
+    ] as const)("maps %s to %s", (range, expected) => {
+      expect(getMarketPageTimeframeAnalytics(range)).toBe(expected);
+    });
+
+    it("returns undefined when range is missing", () => {
+      expect(getMarketPageTimeframeAnalytics(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("getMarketPageCategoryAnalytics", () => {
+    it("maps starred to favorites", () => {
+      expect(getMarketPageCategoryAnalytics("starred")).toBe("favorites");
+    });
+
+    it("keeps other built-in categories unchanged", () => {
+      expect(getMarketPageCategoryAnalytics("all")).toBe("all");
+      expect(getMarketPageCategoryAnalytics("stocks")).toBe("stocks");
+    });
+
+    it("keeps trending category ids unchanged", () => {
+      expect(getMarketPageCategoryAnalytics("infrastructure")).toBe("infrastructure");
+    });
+  });
+
+  describe("getMarketPageSortAnalytics", () => {
+    it("returns desc as the default when the column is not actively sorted", () => {
+      expect(
+        getMarketPageSortAnalytics(Order.MarketCapDesc, Order.VolumeDesc, Order.VolumeAsc),
+      ).toBe("desc");
+    });
+
+    it("returns asc when the column is actively sorted ascending", () => {
+      expect(getMarketPageSortAnalytics(Order.VolumeAsc, Order.VolumeDesc, Order.VolumeAsc)).toBe(
+        "asc",
+      );
+    });
+  });
+
+  describe("getMarketSortToggleValue", () => {
+    it("returns true_desc when the column is sorted descending", () => {
+      expect(getMarketSortToggleValue(Order.VolumeDesc, Order.VolumeDesc, Order.VolumeAsc)).toBe(
+        "true_desc",
+      );
+    });
+
+    it("returns true_asc when the column is sorted ascending", () => {
+      expect(getMarketSortToggleValue(Order.VolumeAsc, Order.VolumeDesc, Order.VolumeAsc)).toBe(
+        "true_asc",
+      );
+    });
+
+    it("returns false when the column is not the active sort", () => {
+      expect(getMarketSortToggleValue(Order.MarketCapDesc, Order.VolumeDesc, Order.VolumeAsc)).toBe(
+        "false",
+      );
+    });
+  });
+
+  describe("getMarketSortListAnalytics", () => {
+    it("marks only the active column and maps the timeframe", () => {
+      expect(getMarketSortListAnalytics({ order: Order.topLosers, range: "24h" })).toEqual({
+        sortVolume: "false",
+        sortMarketCap: "false",
+        sortChange: "true_asc",
+        timeframe: "1D",
+      });
+    });
+  });
+
+  describe("getMarketDiscoverabilityPageAnalytics", () => {
+    it("returns sort directions and mapped filters", () => {
+      expect(
+        getMarketDiscoverabilityPageAnalytics({
+          order: Order.MarketCapDesc,
+          range: "7d",
+          category: "starred",
+        }),
+      ).toEqual({
+        sortVolume: "desc",
+        sortMarketCap: "desc",
+        sortChange: "desc",
+        timeframe: "7D",
+        category: "favorites",
+        name: "Market",
+      });
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/utils/marketPageAnalytics.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/utils/marketPageAnalytics.ts
@@ -1,0 +1,87 @@
+import type { MarketListCategory } from "@ledgerhq/live-common/market/utils/category";
+import { KeysPriceChange, Order } from "@ledgerhq/live-common/market/utils/types";
+
+export type MarketSortDirection = "asc" | "desc";
+
+export function getMarketSortDirection(
+  order: Order | undefined,
+  descOrder: Order,
+  ascOrder: Order,
+): MarketSortDirection | undefined {
+  if (order === descOrder) return "desc";
+  if (order === ascOrder) return "asc";
+  return undefined;
+}
+
+export function getMarketPageSortAnalytics(
+  order: Order | undefined,
+  descOrder: Order,
+  ascOrder: Order,
+): MarketSortDirection {
+  return getMarketSortDirection(order, descOrder, ascOrder) ?? "desc";
+}
+
+const MARKET_RANGE_TO_TIMEFRAME: Record<string, string> = {
+  [KeysPriceChange.day]: "1D",
+  [KeysPriceChange.week]: "7D",
+  [KeysPriceChange.month]: "30D",
+  [KeysPriceChange.sixMonths]: "6M",
+  [KeysPriceChange.year]: "1Y",
+};
+
+export function getMarketPageTimeframeAnalytics(range: string | undefined): string | undefined {
+  if (!range) return undefined;
+  return MARKET_RANGE_TO_TIMEFRAME[range] ?? range;
+}
+
+export type MarketSortToggleValue = "false" | "true_asc" | "true_desc";
+
+export function getMarketSortToggleValue(
+  order: Order | undefined,
+  descOrder: Order,
+  ascOrder: Order,
+): MarketSortToggleValue {
+  const direction = getMarketSortDirection(order, descOrder, ascOrder);
+  if (direction === "desc") return "true_desc";
+  if (direction === "asc") return "true_asc";
+  return "false";
+}
+
+export function getMarketSortListAnalytics({
+  order,
+  range,
+}: {
+  order: Order | undefined;
+  range: string | undefined;
+}) {
+  return {
+    sortVolume: getMarketSortToggleValue(order, Order.VolumeDesc, Order.VolumeAsc),
+    sortMarketCap: getMarketSortToggleValue(order, Order.MarketCapDesc, Order.MarketCapAsc),
+    sortChange: getMarketSortToggleValue(order, Order.topGainers, Order.topLosers),
+    timeframe: getMarketPageTimeframeAnalytics(range),
+  };
+}
+
+export function getMarketPageCategoryAnalytics(category: MarketListCategory): string {
+  if (category === "starred") return "favorites";
+  return category;
+}
+
+export function getMarketDiscoverabilityPageAnalytics({
+  order,
+  range,
+  category,
+}: {
+  order: Order | undefined;
+  range: string | undefined;
+  category: MarketListCategory;
+}) {
+  return {
+    sortVolume: getMarketPageSortAnalytics(order, Order.VolumeDesc, Order.VolumeAsc),
+    sortMarketCap: getMarketPageSortAnalytics(order, Order.MarketCapDesc, Order.MarketCapAsc),
+    sortChange: getMarketPageSortAnalytics(order, Order.topGainers, Order.topLosers),
+    timeframe: getMarketPageTimeframeAnalytics(range),
+    category: getMarketPageCategoryAnalytics(category),
+    name: "Market",
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/MarketBannerRankingSelect/useMarketBannerRankingSelectViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/MarketBannerRankingSelect/useMarketBannerRankingSelectViewModel.ts
@@ -7,6 +7,7 @@ import {
   setMarketBannerRanking,
 } from "~/renderer/reducers/marketBanner";
 import { starredMarketCoinsSelector } from "~/renderer/reducers/settings";
+import { track } from "~/renderer/analytics/segment";
 
 const RANKINGS: readonly MarketBannerRanking[] = ["trending", "gainers", "losers", "favorites"];
 
@@ -41,6 +42,7 @@ export function useMarketBannerRankingSelectViewModel() {
     (option: MarketBannerRankingSelectItem | null) => {
       if (option == null) return;
       dispatch(setMarketBannerRanking(option.value));
+      track("change_sort_market_banner", { sort: option.value });
     },
     [dispatch],
   );

--- a/apps/ledger-live-desktop/src/renderer/analytics/screenRefs.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/screenRefs.ts
@@ -2,3 +2,7 @@ import React, { type RefObject } from "react";
 
 export const previousRouteNameRef: RefObject<string | null | undefined> = React.createRef();
 export const currentRouteNameRef: RefObject<string | null | undefined> = React.createRef();
+
+/** Route names for analytics, normalized to "" when unknown. */
+export const getCurrentTrackingPage = (): string => currentRouteNameRef.current ?? "";
+export const getPreviousTrackingPage = (): string => previousRouteNameRef.current ?? "";


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Global search analytics: `search_open`, `Query global search`, and `asset_clicked` events fire from the search overlay (verify payloads: `page`, `flow`, `source`, `searched`, `search_query`)
      - "See all" navigation from search to Market (crypto vs stocks) tracks `button_clicked` with the right `category`
      - Market table sort interactions emit `sort_market_list` with correct sort/timeframe values
      - Market banner ranking change emits `change_sort_market_banner`
      - Market `TrackPage` payload switches correctly between the discoverability variant and the legacy variant depending on the feature flag
      - Top cards definition buttons (`alt_season_index_definition`, `market_cap_definition`, `mood_index_definition`) track with updated names

### 📝 Description

This PR adds analytics tracking across the Market page and the global asset discoverability experience.

**Problem**: The Market page and the global search overlay lacked the analytics events needed to measure asset discoverability interactions (search usage, sorting, navigation, and ranking changes).

**Solution**:

- Added a shared `marketPageAnalytics` util that centralizes sort-direction, timeframe, category, and toggle-value mapping for analytics payloads, plus a dedicated `getMarketDiscoverabilityPageAnalytics` payload builder.
- Added `getCurrentTrackingPage` / `getPreviousTrackingPage` helpers in `screenRefs` to resolve the current/previous route names for analytics.
- Wired tracking into the search overlay (`search_open`, `Query global search`, `asset_clicked`, `button_clicked`), the market table sort (`sort_market_list`), and the market banner ranking select (`change_sort_market_banner`).
- The Market `TrackPage` now emits the discoverability payload when the feature flag is enabled, falling back to the previous payload otherwise.
- Renamed top-card definition button analytics values for consistency (`*_definition`).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29978](https://ledgerhq.atlassian.net/browse/LIVE-29978)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29978]: https://ledgerhq.atlassian.net/browse/LIVE-29978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ