### PR TITLE
[LWDM] feat(broadcast): add isTestnet and isSendMax to telemetry

### DIFF
--- a/.changeset/broadcast-telemetry-enrich.md
+++ b/.changeset/broadcast-telemetry-enrich.md
@@ -1,0 +1,13 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+feat(broadcast): add isTestnet and isSendMax to telemetry
+
+Adds two fields to the `broadcast_success` and `broadcast_failure` Datadog events, on both success and failure paths:
+- `isTestnet`: derived from the currency model (`isTestnetFor`)
+- `isSendMax`: derived from `transaction.useAllAmount`
+
+Existing fields are left unchanged.

--- a/apps/ledger-live-desktop/src/datadog/logs.test.ts
+++ b/apps/ledger-live-desktop/src/datadog/logs.test.ts
@@ -182,6 +182,9 @@ describe("datadog logs", () => {
         appVersion: "1.0.0",
         currencyId: "bitcoin",
         family: "bitcoin",
+        isTestnet: false,
+        isSendMax: true,
+        source: { type: "coin-module", name: "ledger-live-desktop", flags: { newSendFlow: true } },
       });
 
       expect(datadogLogs.logger.info).toHaveBeenCalledWith("broadcast_success", {
@@ -190,6 +193,13 @@ describe("datadog logs", () => {
           appVersion: "1.0.0",
           currencyId: "bitcoin",
           family: "bitcoin",
+          isTestnet: false,
+          isSendMax: true,
+          source: {
+            type: "coin-module",
+            name: "ledger-live-desktop",
+            flags: { newSendFlow: true },
+          },
         },
       });
     });
@@ -205,6 +215,9 @@ describe("datadog logs", () => {
         appVersion: "1.0.0",
         currencyId: "ethereum",
         family: "evm",
+        isTestnet: false,
+        isSendMax: false,
+        source: { type: "coin-module", name: "ledger-live-desktop", flags: { newSendFlow: false } },
       });
 
       expect(datadogLogs.logger.error).toHaveBeenCalledWith(
@@ -216,6 +229,13 @@ describe("datadog logs", () => {
             appVersion: "1.0.0",
             currencyId: "ethereum",
             family: "evm",
+            isTestnet: false,
+            isSendMax: false,
+            source: {
+              type: "coin-module",
+              name: "ledger-live-desktop",
+              flags: { newSendFlow: false },
+            },
           },
         },
         error,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Signature/hooks/useSignatureViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Signature/hooks/useSignatureViewModel.ts
@@ -53,9 +53,11 @@ export function useSignatureViewModel() {
 
   const action = useTransactionAction();
   const mevProtected = useSelector(mevProtectionSelector);
+
   const broadcast = useBroadcast({
     account,
     parentAccount,
+    transaction,
     broadcastConfig: {
       mevProtected,
       source: { type: "coin-module", name: "ledger-live-desktop", flags: { newSendFlow: true } },

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/GenericStepConnectDevice.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/GenericStepConnectDevice.tsx
@@ -75,6 +75,7 @@ export default function StepConnectDevice({
   const broadcast = useBroadcast({
     account,
     parentAccount,
+    transaction,
     broadcastConfig,
     logger: broadcastLogger,
   });

--- a/apps/ledger-live-mobile/src/datadog.test.ts
+++ b/apps/ledger-live-mobile/src/datadog.test.ts
@@ -47,10 +47,21 @@ describe("broadcastLogger", () => {
       appVersion: "1.0.0",
       currencyId: "bitcoin",
       family: "family",
+      isTestnet: false,
+      isSendMax: true,
+      source: { type: "coin-module", name: "ledger-live-mobile", flags: { newSendFlow: true } },
     });
 
     expect(infoSpy).toHaveBeenCalledWith("broadcast_success", {
-      event: { status: "success", appVersion: "1.0.0", currencyId: "bitcoin", family: "family" },
+      event: {
+        status: "success",
+        appVersion: "1.0.0",
+        currencyId: "bitcoin",
+        family: "family",
+        isTestnet: false,
+        isSendMax: true,
+        source: { type: "coin-module", name: "ledger-live-mobile", flags: { newSendFlow: true } },
+      },
     });
   });
 
@@ -66,6 +77,9 @@ describe("broadcastLogger", () => {
       appVersion: "1.0.0",
       currencyId: "ethereum",
       family: "family",
+      isTestnet: false,
+      isSendMax: false,
+      source: { type: "coin-module", name: "ledger-live-mobile", flags: { newSendFlow: false } },
     });
 
     expect(errorSpy).toHaveBeenCalledWith(
@@ -80,6 +94,9 @@ describe("broadcastLogger", () => {
           appVersion: "1.0.0",
           currencyId: "ethereum",
           family: "family",
+          isTestnet: false,
+          isSendMax: false,
+          source: { type: "coin-module", name: "ledger-live-mobile", flags: { newSendFlow: false } },
         },
       },
     );

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -307,9 +307,11 @@ export const broadcastSignedTx = async (
 export function useSignedTxHandler({
   account,
   parentAccount,
+  transaction,
 }: SignTransactionArgs & {
   account: AccountLike;
   parentAccount: Account | null | undefined;
+  transaction?: Transaction | null;
 }) {
   const mevProtected = useSelector(mevProtectionSelector);
   const navigation = useNavigation();
@@ -320,6 +322,7 @@ export function useSignedTxHandler({
   const broadcast = useBroadcast({
     account,
     parentAccount,
+    transaction,
     broadcastConfig: {
       mevProtected,
       source: { type: "coin-module", name: "ledger-live-mobile", flags: { newSendFlow } },

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/hooks/useSignatureViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/hooks/useSignatureViewModel.ts
@@ -43,6 +43,7 @@ export function useSignatureViewModel() {
   const broadcast = useBroadcast({
     account,
     parentAccount,
+    transaction,
     broadcastConfig: {
       mevProtected,
       source: { type: "coin-module", name: "ledger-live-mobile", flags: { newSendFlow: true } },

--- a/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
@@ -157,6 +157,7 @@ export default function ConnectDevice({ route, navigation }: Props) {
   const handleTx = useSignedTxHandler({
     account,
     parentAccount,
+    transaction,
   });
   // `renderOnResult` is invoked on every render of the DeviceAction result state,
   // so guard the broadcast side-effect to fire only once per mount. Without this,

--- a/libs/ledger-live-common/src/hooks/useBroadcast.test.ts
+++ b/libs/ledger-live-common/src/hooks/useBroadcast.test.ts
@@ -53,6 +53,8 @@ describe("useBroadcast", () => {
       "token-id",
     ],
   ])("%s", (_s, account, parentAccount, expectedTokenId) => {
+    const transaction = { useAllAmount: true } as any;
+
     it("logs on success", async () => {
       const logger = jest.fn();
       mockBroadcast.mockResolvedValue({ id: "operation-id", date: new Date(2026, 3, 24) });
@@ -64,6 +66,7 @@ describe("useBroadcast", () => {
         useBroadcast({
           account,
           parentAccount,
+          transaction,
           broadcastConfig: { source: { type: "coin-module", name: "ledger-live-desktop" } },
           logger,
         } as any),
@@ -80,6 +83,8 @@ describe("useBroadcast", () => {
         tokenId: expectedTokenId,
         family: "family",
         appVersion: "llc/test",
+        isTestnet: false,
+        isSendMax: true,
         source: { type: "coin-module", name: "ledger-live-desktop" },
       });
       expect(value).toEqual({ id: "operation-id", date: new Date(2026, 3, 24) });
@@ -96,6 +101,7 @@ describe("useBroadcast", () => {
         useBroadcast({
           account,
           parentAccount,
+          transaction,
           broadcastConfig: { source: { type: "coin-module", name: "ledger-live-desktop" } },
           logger,
         } as any),
@@ -117,9 +123,40 @@ describe("useBroadcast", () => {
         tokenId: expectedTokenId,
         family: "family",
         appVersion: "llc/test",
+        isTestnet: false,
+        isSendMax: true,
         source: { type: "coin-module", name: "ledger-live-desktop" },
         txPayload: { signature: "signed-transaction", rawData: { raw_hex: "raw-hex" } },
       });
     });
+  });
+
+  it("derives isTestnet from the currency model (true for a testnet currency)", async () => {
+    const logger = jest.fn();
+    mockBroadcast.mockResolvedValue({ id: "operation-id", date: new Date(2026, 3, 24) });
+    setEnv("LEDGER_CLIENT_VERSION", "llc/test");
+    setEnv("DISABLE_TRANSACTION_BROADCAST", false);
+
+    const account = {
+      id: "main-account-id",
+      type: "Account",
+      currency: { id: "ethereum_sepolia", family: "evm", isTestnetFor: "ethereum" },
+    };
+
+    const { result } = renderHook(() =>
+      useBroadcast({
+        account,
+        parentAccount: account,
+        logger,
+      } as any),
+    );
+
+    await act(async () => {
+      await result.current({} as any);
+    });
+
+    expect(logger).toHaveBeenCalledWith(
+      expect.objectContaining({ currencyId: "ethereum_sepolia", isTestnet: true }),
+    );
   });
 });

--- a/libs/ledger-live-common/src/hooks/useBroadcast.ts
+++ b/libs/ledger-live-common/src/hooks/useBroadcast.ts
@@ -7,6 +7,7 @@ import type {
   Account,
   BroadcastConfig,
   TransactionSource,
+  TransactionCommon,
 } from "@ledgerhq/types-live";
 import { getEnv } from "@ledgerhq/live-env";
 import { formatOperation, getMainAccount } from "../account/index";
@@ -19,6 +20,8 @@ type CommonLogEvent = {
   currencyId: string;
   family: string;
   tokenId?: string;
+  isTestnet: boolean;
+  isSendMax: boolean;
 };
 
 type ErrorLogEvent = {
@@ -39,6 +42,7 @@ export type SignTransactionArgs = {
   parentAccount?: Account | null;
   broadcastConfig?: BroadcastConfig;
   logger?: (event: LogEvent) => void;
+  transaction?: TransactionCommon | null;
 };
 
 function toError(err: unknown): Error {
@@ -56,6 +60,7 @@ export const useBroadcast = ({
   parentAccount,
   broadcastConfig,
   logger,
+  transaction,
 }: SignTransactionArgs) => {
   const broadcast = useCallback(
     async (signedOperation: SignedOperation): Promise<Operation> => {
@@ -72,6 +77,8 @@ export const useBroadcast = ({
         source: broadcastConfig?.source,
         currencyId: mainAccount.currency.id,
         family: mainAccount.currency.family,
+        isTestnet: Boolean(mainAccount.currency.isTestnetFor),
+        isSendMax: Boolean(transaction?.useAllAmount),
         ...(account.type === "TokenAccount" ? { tokenId: account.token.id } : {}),
       };
 
@@ -110,7 +117,7 @@ export const useBroadcast = ({
         }
       });
     },
-    [account, parentAccount, broadcastConfig, logger],
+    [account, parentAccount, broadcastConfig, logger, transaction],
   );
 
   return broadcast;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - `broadcast_success` / `broadcast_failure` events on every send flow (mobile legacy + new send flow, desktop legacy + new send flow)
      - `isTestnet` is correct (`true` for testnet currencies e.g. `ethereum_sepolia`, `false` for mainnet e.g. `bitcoin`)
      - `isSendMax` reflects the "send max" toggle
      - No regression on existing broadcast fields (dashboard / log-based metrics keep working)

### 📝 Description

The "Broadcast Health" Datadog dashboard and the log-based metrics (`broadcast.success` / `broadcast.failure`) are fed by `broadcast_success` / `broadcast_failure` log events. We want to enrich those events without breaking any existing field.

This PR adds two pieces of information to the event, on **both** success and failure paths, built once in the shared hook `useBroadcast` (so LLM and LLD stay consistent):

- **`isTestnet`** (boolean): derived from the currency model (`Boolean(currency.isTestnetFor)`), not from id string matching.
- **`isSendMax`** (boolean): derived from `transaction.useAllAmount`.

No existing field is renamed or removed (`appVersion`, `currencyId`, `family`, `status`, `source.name`, `source.type`, `source.flags.newSendFlow` are untouched).

> Note: the transaction amount (decimal and USD value) is intentionally **not** exported, as it is considered sensitive data.

> Note: the Datadog side (new metric dimensions `event.istestnet` / `event.issendmax`, dashboard widgets) is handled separately, out of scope for this PR.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32623](https://ledgerhq.atlassian.net/browse/LIVE-32623)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32623]: https://ledgerhq.atlassian.net/browse/LIVE-32623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
