### PR TITLE
[LWDM] fix(LIVE-32625): hedera getBlock inconsistencies with listOperations

### DIFF
--- a/.changeset/orange-rice-remember.md
+++ b/.changeset/orange-rice-remember.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+fix: hedera getBlock inconsistencies with listOperations on framework level

--- a/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
@@ -687,27 +687,27 @@ describe("createApi", () => {
       expect(delegateOperations).toEqual([
         {
           type: "other",
-          operationType: "DELEGATE",
-          stakedNodeId: 34,
-          previousStakedNodeId: null,
+          ledgerOpType: "DELEGATE",
+          targetStakingNodeId: 34,
+          previousStakingNodeId: null,
           stakedAmount: BigInt(21083322293),
         },
       ]);
       expect(undelegateOperations).toEqual([
         {
           type: "other",
-          operationType: "UNDELEGATE",
-          stakedNodeId: null,
-          previousStakedNodeId: 22,
+          ledgerOpType: "UNDELEGATE",
+          targetStakingNodeId: null,
+          previousStakingNodeId: 22,
           stakedAmount: BigInt(21083441623),
         },
       ]);
       expect(redelegateOperations).toEqual([
         {
           type: "other",
-          operationType: "REDELEGATE",
-          stakedNodeId: 6,
-          previousStakedNodeId: 34,
+          ledgerOpType: "REDELEGATE",
+          targetStakingNodeId: 6,
+          previousStakingNodeId: 34,
           stakedAmount: BigInt(21083202902),
         },
       ]);

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.test.ts
@@ -11,6 +11,7 @@ import { getMockedERC20TokenTransfer } from "../test/fixtures/hgraph.fixture";
 import {
   getMockedMirrorAccount,
   getMockedMirrorContractCallResult,
+  getMockedMirrorToken,
   getMockedMirrorTransaction,
 } from "../test/fixtures/mirror.fixture";
 import type { StakingAnalysis } from "../types";
@@ -314,6 +315,11 @@ describe("getBlockV2", () => {
         amount: BigInt(-mockERC20Transfer.amount),
       },
     ]);
+    expect(result.transactions[0].details).toMatchObject({
+      gasUsed: mockContractCallResult.gas_used,
+      gasLimit: mockContractCallResult.gas_limit,
+      gasConsumed: mockContractCallResult.gas_consumed,
+    });
   });
 
   it("should deduplicate CONTRACT_CALL when matching ERC20 transfer exists", async () => {
@@ -547,9 +553,9 @@ describe("getBlockV2", () => {
     expect(result.transactions[0].operations).toHaveLength(1);
     expect(result.transactions[0].operations[0]).toEqual({
       type: "other",
-      operationType: mockStakingAnalysis.operationType,
-      stakedNodeId: mockStakingAnalysis.targetStakingNodeId,
-      previousStakedNodeId: mockStakingAnalysis.previousStakingNodeId,
+      ledgerOpType: mockStakingAnalysis.operationType,
+      targetStakingNodeId: mockStakingAnalysis.targetStakingNodeId,
+      previousStakingNodeId: mockStakingAnalysis.previousStakingNodeId,
       stakedAmount: mockStakingAnalysis.stakedAmount,
     });
   });
@@ -581,9 +587,9 @@ describe("getBlockV2", () => {
 
     expect(result.transactions[0].operations[0]).toEqual({
       type: "other",
-      operationType: mockStakingAnalysis.operationType,
-      stakedNodeId: mockStakingAnalysis.targetStakingNodeId,
-      previousStakedNodeId: mockStakingAnalysis.previousStakingNodeId,
+      ledgerOpType: mockStakingAnalysis.operationType,
+      targetStakingNodeId: mockStakingAnalysis.targetStakingNodeId,
+      previousStakingNodeId: mockStakingAnalysis.previousStakingNodeId,
       stakedAmount: mockStakingAnalysis.stakedAmount,
     });
   });
@@ -616,9 +622,9 @@ describe("getBlockV2", () => {
     expect(result.transactions[0].operations).toEqual([
       {
         type: "other",
-        operationType: mockStakingAnalysis.operationType,
-        stakedNodeId: mockStakingAnalysis.targetStakingNodeId,
-        previousStakedNodeId: mockStakingAnalysis.previousStakingNodeId,
+        ledgerOpType: mockStakingAnalysis.operationType,
+        targetStakingNodeId: mockStakingAnalysis.targetStakingNodeId,
+        previousStakingNodeId: mockStakingAnalysis.previousStakingNodeId,
         stakedAmount: mockStakingAnalysis.stakedAmount,
       },
     ]);
@@ -726,14 +732,16 @@ describe("getBlockV2", () => {
     ]);
   });
 
-  it("should emit ASSOCIATE_TOKEN operation with associatedTokenId for TOKENASSOCIATE transaction", async () => {
+  it("should emit ASSOCIATE_TOKEN operation with correct token id for TOKENASSOCIATE transaction", async () => {
+    const consensusTimestamp = "1764932745.835883000";
     const mockTx = getMockedMirrorTransaction({
       transaction_id: "0.0.999-1234567890-000000000",
       transaction_hash: "hash_token_associate",
       name: HEDERA_TRANSACTION_NAMES.TokenAssociate,
       result: "SUCCESS",
       charged_tx_fee: 51871165,
-      entity_id: "0.0.456858",
+      consensus_timestamp: consensusTimestamp,
+      entity_id: "0.0.999",
       staking_reward_transfers: [],
       transfers: [
         { account: "0.0.802", amount: 51871165 },
@@ -742,21 +750,58 @@ describe("getBlockV2", () => {
       token_transfers: [],
     });
 
+    const mockToken = getMockedMirrorToken({
+      token_id: "0.0.8279134",
+      created_timestamp: consensusTimestamp,
+    });
+
+    (hgraphClient.getERC20TransfersByTimestampRange as jest.Mock).mockResolvedValue([]);
+    (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
+    (apiClient.getAccountTokens as jest.Mock).mockResolvedValue([mockToken]);
+
+    const result = await getBlockV2({ configOrCurrencyId, height: 100 });
+
+    expect(apiClient.getAccountTokens).toHaveBeenCalledTimes(1);
+    expect(apiClient.getAccountTokens).toHaveBeenCalledWith({
+      configOrCurrencyId,
+      address: "0.0.999",
+    });
+    expect(result.transactions).toHaveLength(1);
+    expect(result.transactions[0].operations).toEqual([
+      {
+        type: "other",
+        ledgerOpType: "ASSOCIATE_TOKEN",
+        associatedTokenId: mockToken.token_id,
+      },
+    ]);
+    expect(result.transactions[0].details).toMatchObject({
+      consensusTimestamp,
+      transactionId: mockTx.transaction_id,
+    });
+    expect(result.transactions[0].fees).toBe(BigInt(51871165));
+    expect(result.transactions[0].feesPayer).toBe("0.0.999");
+  });
+
+  it("should include consensusTimestamp and transactionId in tx.details", async () => {
+    const mockTx = getMockedMirrorTransaction({
+      transaction_id: "0.0.999-1704067210-123456789",
+      transaction_hash: "hash_tx",
+      name: "CRYPTOTRANSFER",
+      consensus_timestamp: "1704067210.123456789",
+      staking_reward_transfers: [],
+      transfers: [],
+      token_transfers: [],
+    });
+
     (hgraphClient.getERC20TransfersByTimestampRange as jest.Mock).mockResolvedValue([]);
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([mockTx]);
 
     const result = await getBlockV2({ configOrCurrencyId, height: 100 });
 
-    expect(result.transactions).toHaveLength(1);
-    expect(result.transactions[0].operations).toEqual([
-      {
-        type: "other",
-        operationType: "ASSOCIATE_TOKEN",
-        associatedTokenId: "0.0.456858",
-      },
-    ]);
-    expect(result.transactions[0].fees).toBe(BigInt(51871165));
-    expect(result.transactions[0].feesPayer).toBe("0.0.999");
+    expect(result.transactions[0].details).toMatchObject({
+      consensusTimestamp: mockTx.consensus_timestamp,
+      transactionId: mockTx.transaction_id,
+    });
   });
 
   it("should handle CRYPTOUPDATEACCOUNT if it's not related to staking", async () => {

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.ts
@@ -4,6 +4,7 @@ import type {
   BlockOperation,
   BlockTransaction,
 } from "@ledgerhq/coin-module-framework/api/types";
+import { promiseAllBatched } from "@ledgerhq/live-promise";
 import type { HederaCoinConfig } from "../config";
 import { FINALITY_MS, HEDERA_TRANSACTION_NAMES } from "../constants";
 import { apiClient } from "../network/api";
@@ -202,8 +203,10 @@ export async function getBlockV2({
 
   // analyze CRYPTOUPDATEACCOUNT transactions to distinguish staking operations from regular account updates.
   // this creates a map of transaction_hash -> StakingAnalysis to avoid repeated lookups.
-  const stakingAnalyses = await Promise.all(
-    mergeResult.merged.filter(isStakingTransactionType).map(async item => {
+  const stakingAnalyses = await promiseAllBatched(
+    4,
+    mergeResult.merged.filter(isStakingTransactionType),
+    async item => {
       const payerAccount = extractFeesPayer(item.data);
       const analysis = await analyzeStakingOperation({
         configOrCurrencyId,
@@ -212,12 +215,32 @@ export async function getBlockV2({
       });
 
       return [item.data.transaction_hash, analysis] as const;
-    }),
+    },
   );
   const stakingAnalysisMap = new Map(stakingAnalyses);
 
+  // prepare map with token IDs for TOKENASSOCIATE transactions by fetching payerAccount tokens and matching created_timestamp
+  const tokenAssociateEntries = await promiseAllBatched(
+    4,
+    mergeResult.merged.filter(isTokenAssociateTransactionType),
+    async item => {
+      const mirrorTx = item.data;
+      const payerAccount = extractFeesPayer(mirrorTx);
+      const tokens = await apiClient.getAccountTokens({
+        configOrCurrencyId,
+        address: payerAccount,
+      });
+      const relatedToken = tokens.find(t => t.created_timestamp === mirrorTx.consensus_timestamp);
+      const tokenId = relatedToken?.token_id ?? null;
+
+      return [mirrorTx.transaction_hash, tokenId] as const;
+    },
+  );
+  const tokenAssociateMap = new Map(tokenAssociateEntries);
+
   const blockTransactions: BlockTransaction[] = mergeResult.merged.map(item => {
     const mirrorTx = getMirrorTransaction(item);
+    const memo = getMemoFromBase64(mirrorTx.memo_base64);
     const payerAccount = extractFeesPayer(mirrorTx);
     const stakingAnalysis = stakingAnalysisMap.get(mirrorTx.transaction_hash);
 
@@ -227,18 +250,20 @@ export async function getBlockV2({
       operations = [
         {
           type: "other",
-          operationType: stakingAnalysis.operationType,
-          stakedNodeId: stakingAnalysis.targetStakingNodeId,
-          previousStakedNodeId: stakingAnalysis.previousStakingNodeId,
+          ledgerOpType: stakingAnalysis.operationType,
+          targetStakingNodeId: stakingAnalysis.targetStakingNodeId,
+          previousStakingNodeId: stakingAnalysis.previousStakingNodeId,
           stakedAmount: stakingAnalysis.stakedAmount,
         },
       ];
     } else if (isTokenAssociateTransactionType(item)) {
+      const associatedTokenId = tokenAssociateMap.get(mirrorTx.transaction_hash) ?? null;
+
       operations = [
         {
           type: "other",
-          operationType: "ASSOCIATE_TOKEN",
-          associatedTokenId: mirrorTx.entity_id ?? null,
+          ledgerOpType: "ASSOCIATE_TOKEN",
+          ...(associatedTokenId && { associatedTokenId }),
         },
       ];
     } else {
@@ -278,7 +303,16 @@ export async function getBlockV2({
       operations,
       fees: BigInt(mirrorTx.charged_tx_fee),
       feesPayer: payerAccount,
-      details: { memo: getMemoFromBase64(mirrorTx.memo_base64) },
+      details: {
+        consensusTimestamp: mirrorTx.consensus_timestamp,
+        transactionId: mirrorTx.transaction_id,
+        ...(memo && { memo }),
+        ...(item.type === "erc20" && {
+          gasUsed: item.data.contractCallResult.gas_used,
+          gasLimit: item.data.contractCallResult.gas_limit,
+          gasConsumed: item.data.contractCallResult.gas_consumed,
+        }),
+      },
     };
   });
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - align fields between getBlock and listOperations in coin-hedera module

### 📝 Description

This PR fixes some inconsistencies between getBlock and listOperations on framework level:
-  The TOKENASSOCIATE operation was using mirrorTx.entity_id as the associated token ID, which is actually the payer account address, not the token. It now correctly fetches account tokens via getAccountTokens and matches by created_timestamp equal to the consensus timestamp, using the same logic as listOperations.
- Staking operation field names were also misaligned between the two endpoints. The block response used operationType, stakedNodeId, and previousStakedNodeId while listOperations used ledgerOpType, targetStakingNodeId, and previousStakingNodeId.
- `blockTx.details` now always includes consensusTimestamp and transactionId for every transaction type
- ERC20 transactions additionally expose gasUsed, gasLimit, and gasConsumed in `blockTx.details`
- empty memo is excluded from `blockTx.details`

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-32625


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
