### PR TITLE
[LWD] fix(desktop): stop global searches from stacking in navigation history

### DIFF
--- a/.changeset/lld-search-detail-back-history.md
+++ b/.changeset/lld-search-detail-back-history.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix: searching from the global search overlay while already on an asset or market detail page now replaces the current history entry instead of pushing a new one. A single Back press returns to the page visited before the first search, so repeated searches no longer stack up in the navigation history.

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/__tests__/useSearchOverlayViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/__tests__/useSearchOverlayViewModel.test.ts
@@ -1,9 +1,15 @@
 import { renderHook, act } from "tests/testSetup";
+import { useNavigate } from "react-router";
 import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
 import { track } from "~/renderer/analytics/segment";
 import { useSearchOverlayViewModel } from "../useSearchOverlayViewModel";
 import { useAssetSearchBar } from "../useAssetSearchBar";
 import { SearchMode, SearchResults, SearchSuggestions } from "../types";
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: jest.fn(),
+}));
 
 jest.mock("../useAssetSearchBar");
 
@@ -16,6 +22,8 @@ jest.mock("~/renderer/analytics/screenRefs", () => ({
 
 const mockedUseAssetSearchBar = jest.mocked(useAssetSearchBar);
 const mockedTrack = jest.mocked(track);
+const mockNavigate = jest.fn();
+const mockUseNavigate = jest.mocked(useNavigate);
 
 const EMPTY_SECTION = { data: [], isLoading: false };
 const EMPTY_SUGGESTIONS: SearchSuggestions = {
@@ -47,6 +55,10 @@ function mockSearchBar({
 }
 
 describe("useSearchOverlayViewModel", () => {
+  beforeEach(() => {
+    mockUseNavigate.mockReturnValue(mockNavigate);
+  });
+
   afterEach(() => jest.clearAllMocks());
 
   describe("displayed mode while closing", () => {
@@ -136,5 +148,40 @@ describe("useSearchOverlayViewModel", () => {
         expect.objectContaining({ asset: "aaplx", searched: false }),
       );
     });
+  });
+
+  describe("navigation history", () => {
+    beforeEach(() => mockSearchBar({ mode: "results", isOpen: true, query: "bit" }));
+
+    // Every search navigation shares the same decision: replace the current entry only when
+    // already on an asset/market detail page, so repeated searches don't stack in history.
+    it.each<[string, boolean]>([
+      ["/", false],
+      ["/market", false],
+      ["/asset/bitcoin", true],
+      ["/market/bitcoin", true],
+    ])("navigates from %s with replace=%s", (pathname, replace) => {
+      const { result } = renderHook(() => useSearchOverlayViewModel(), { initialRoute: pathname });
+
+      act(() => result.current.contextValue.navigateToAsset("ethereum"));
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ replace }),
+      );
+    });
+
+    it.each(["navigateToMarket", "navigateToStocksMarket"] as const)(
+      "%s navigates to /market and forwards the replace flag",
+      methodName => {
+        const { result } = renderHook(() => useSearchOverlayViewModel(), {
+          initialRoute: "/asset/bitcoin",
+        });
+
+        act(() => result.current.contextValue[methodName]());
+
+        expect(mockNavigate).toHaveBeenCalledWith("/market", { replace: true });
+      },
+    );
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useSearchOverlayViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useSearchOverlayViewModel.ts
@@ -1,8 +1,11 @@
 import { KeyboardEvent, useCallback, useMemo, useState } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
-import { getMarketOrAssetDetailPath } from "LLD/utils/marketAssetNavigation";
+import {
+  getMarketOrAssetDetailPath,
+  isAssetOrMarketDetailPath,
+} from "LLD/utils/marketAssetNavigation";
 import { setMarketCategory } from "~/renderer/actions/market";
 import { useAssetSearchBar } from "./useAssetSearchBar";
 import { SearchOverlayContextValue } from "./types";
@@ -12,6 +15,7 @@ import { getCurrentTrackingPage, getPreviousTrackingPage } from "~/renderer/anal
 
 export function useSearchOverlayViewModel() {
   const navigate = useNavigate();
+  const location = useLocation();
   const dispatch = useDispatch();
   const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
   const { query, onChangeQuery, isOpen, open, close, mode, suggestions, results } =
@@ -23,6 +27,10 @@ export function useSearchOverlayViewModel() {
   if (isOpen && displayedMode !== mode) {
     setDisplayedMode(mode);
   }
+
+  // Searching while already on a detail page replaces the entry instead of pushing, so repeated
+  // searches don't stack in history and a single Back returns to the page before the first search.
+  const replace = isAssetOrMarketDetailPath(location.pathname);
 
   const navigateToAsset = useCallback(
     (currencyId: string, marketState?: MarketCurrencyData) => {
@@ -36,16 +44,17 @@ export function useSearchOverlayViewModel() {
       });
       navigate(getMarketOrAssetDetailPath(currencyId, shouldDisplayAggregatedAssets), {
         state: marketState,
+        replace,
       });
       close();
     },
-    [navigate, shouldDisplayAggregatedAssets, close, displayedMode],
+    [navigate, shouldDisplayAggregatedAssets, close, displayedMode, replace],
   );
 
   const goToMarket = useCallback(
     (marketCategory: Parameters<typeof setMarketCategory>[0], trackCategory: string) => {
       dispatch(setMarketCategory(marketCategory));
-      navigate("/market");
+      navigate("/market", { replace });
       track("button_clicked", {
         button: "see all",
         flow: "global_search",
@@ -54,7 +63,7 @@ export function useSearchOverlayViewModel() {
       });
       close();
     },
-    [dispatch, navigate, close],
+    [dispatch, navigate, close, replace],
   );
 
   const navigateToMarket = useCallback(() => goToMarket("all", "crypto"), [goToMarket]);

--- a/apps/ledger-live-desktop/src/mvvm/utils/__tests__/marketAssetNavigation.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/utils/__tests__/marketAssetNavigation.test.ts
@@ -1,6 +1,7 @@
 import {
   getAssetDetailPath,
   getMarketOrAssetDetailPath,
+  isAssetOrMarketDetailPath,
   resolveLegacyCryptoCurrencyId,
 } from "../marketAssetNavigation";
 
@@ -31,6 +32,40 @@ describe("marketAssetNavigation", () => {
 
     it("does not double-encode segments already percent-encoded from deeplink pathname", () => {
       expect(getAssetDetailPath("a%2Fb")).toBe("/asset/a%2Fb");
+    });
+  });
+
+  describe("isAssetOrMarketDetailPath", () => {
+    it("returns true for an asset detail path", () => {
+      expect(isAssetOrMarketDetailPath("/asset/bitcoin")).toBe(true);
+    });
+
+    it("returns true for a legacy market detail path", () => {
+      expect(isAssetOrMarketDetailPath("/market/bitcoin")).toBe(true);
+    });
+
+    it("returns false for the home path", () => {
+      expect(isAssetOrMarketDetailPath("/")).toBe(false);
+    });
+
+    it("returns false for the market list path", () => {
+      expect(isAssetOrMarketDetailPath("/market")).toBe(false);
+    });
+
+    it("returns false for the market list path with a trailing slash", () => {
+      expect(isAssetOrMarketDetailPath("/market/")).toBe(false);
+    });
+
+    it("returns false for the bare asset path", () => {
+      expect(isAssetOrMarketDetailPath("/asset")).toBe(false);
+    });
+
+    it("returns false for the bare asset path with a trailing slash", () => {
+      expect(isAssetOrMarketDetailPath("/asset/")).toBe(false);
+    });
+
+    it("returns false for an unrelated path", () => {
+      expect(isAssetOrMarketDetailPath("/accounts")).toBe(false);
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/utils/marketAssetNavigation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/utils/marketAssetNavigation.ts
@@ -29,6 +29,11 @@ export function getAssetDetailPath(currencyId: string): string {
   return `/asset/${encodePathSegment(currencyId)}`;
 }
 
+/** True for asset (`/asset/:id`) or legacy market (`/market/:id`) detail pages (not the `/market` list). */
+export function isAssetOrMarketDetailPath(pathname: string): boolean {
+  return /^\/(asset|market)\/[^/]+(?:\/|$)/.test(pathname);
+}
+
 /**
  * Resolves a deeplink path segment to a canonical Ledger crypto currency id.
  * Used when Wallet 4.0 aggregated assets is off (legacy market/asset screens).


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Global search overlay back-button / navigation history behavior
  - Searching from Home/Portfolio, the Market list, and asset/market detail pages
  - Repeated searches (e.g. searching BTC several times) should now require a single Back press to return to the pre-search page
  - Navigating from search to an asset detail, the Market list (all), and the Stocks market

### 📝 Description

**Problem**: In the global search overlay, every search pushed a new entry onto the navigation history. Searching for Bitcoin then Ethereum — or searching the same asset multiple times — meant the Back arrow stepped through each intermediate search result instead of returning to the page the user started from (e.g. Home/Portfolio). Searching 10 times required 10 Back presses to get home.

**Solution**: When a search is triggered while already on an asset (`/asset/:id`) or legacy market (`/market/:id`) detail page, navigation now **replaces** the current history entry instead of pushing a new one. A single Back press returns to the page visited before the first search. Added an `isAssetOrMarketDetailPath` helper (with unit tests) and wired the `replace` flag into `navigateToAsset`, `navigateToMarket`, and `navigateToStocksMarket`.

https://github.com/user-attachments/assets/622ef5ac-0574-4131-a26b-40bc6d78072f

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32392](https://ledgerhq.atlassian.net/browse/LIVE-32392)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32392]: https://ledgerhq.atlassian.net/browse/LIVE-32392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ