### PR TITLE
[LWD] fix(desktop): restyle market banner ranking select trigger

### DIFF
--- a/.changeset/twenty-avocados-carry.md
+++ b/.changeset/twenty-avocados-carry.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix the Market Banner ranking select trigger styling by replacing the MediaButton with a styled trigger and a ChevronDown symbol

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/MarketBannerRankingSelect/MarketBannerRankingSelectView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/MarketBannerRankingSelect/MarketBannerRankingSelectView.tsx
@@ -1,6 +1,5 @@
 import React, { memo } from "react";
 import {
-  MediaButton,
   Select,
   SelectContent,
   SelectItem,
@@ -10,6 +9,7 @@ import {
 } from "@ledgerhq/lumen-ui-react";
 import type { MarketBannerRankingSelectItem } from "./useMarketBannerRankingSelectViewModel";
 import { MARKET_BANNER_RANKING_SELECT_TESTID } from "../../utils/constants";
+import { ChevronDown } from "@ledgerhq/lumen-ui-react/symbols";
 
 type MarketBannerRankingSelectViewProps = Readonly<{
   options: MarketBannerRankingSelectItem[];
@@ -28,13 +28,13 @@ export const MarketBannerRankingSelectView = memo(function MarketBannerRankingSe
     <Select items={options} value={selectedValue} onValueChange={onValueChange}>
       <SelectTrigger
         render={() => (
-          <MediaButton
-            appearance="no-background"
-            size="sm"
+          <div
+            className="flex items-center gap-2 text-muted hover:text-muted-pressed cursor-pointer body-2-semi-bold"
             data-testid={MARKET_BANNER_RANKING_SELECT_TESTID}
           >
             {selectedLabel}
-          </MediaButton>
+            <ChevronDown size={16} />
+          </div>
         )}
       />
       <SelectContent className="min-w-176 bg-muted" align="end">


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _UI-only styling change on the Market Banner ranking select trigger; no automated test coverage added._
- [x] **Impact of the changes:**
  - Market Banner ranking select: trigger appearance (label + chevron), hover state, and click-to-open behavior
  - Dropdown still opens and lets you switch ranking options

### 📝 Description

The Market Banner ranking select previously rendered its trigger with a `MediaButton`, which did not match the intended visual treatment for the ranking selector.

This PR replaces the `MediaButton` with a styled trigger element (`flex` layout, muted text with a pressed hover state, `body-2-semi-bold` typography) and adds a `ChevronDown` symbol to clearly indicate it is a dropdown. Behavior is unchanged — the select still opens its content and reports value changes via `onValueChange`.

### 🖼️ Screenshots


https://github.com/user-attachments/assets/50ffb2f4-7e85-43dc-8f0b-7d6d9596ca15



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32412](https://ledgerhq.atlassian.net/browse/LIVE-32412)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32412]: https://ledgerhq.atlassian.net/browse/LIVE-32412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ