### PR TITLE
[LWDM] fix(desktop): show +/- signs in LWD PnL detail modal

### DIFF
--- a/.changeset/live-31928-pnl-modal-signs.md
+++ b/.changeset/live-31928-pnl-modal-signs.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/live-currency-format": patch
+---
+
+Fix: LWD PnL detail modal now prefixes positive values with `+` (and negatives with `-`), matching Ledger Live Mobile. `formatPrice` gains an optional `alwaysShowSign` option that is forwarded to `formatCurrencyUnit`.

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/builders/__tests__/buildPnlDetail.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/builders/__tests__/buildPnlDetail.test.ts
@@ -9,7 +9,8 @@ const makeInput = (overrides: Partial<Parameters<typeof buildPnlDetail>[0]> = {}
   totalPnL: new BigNumber(100),
   unrealisedPnL: new BigNumber(60),
   realisedPnL: new BigNumber(40),
-  formatFiat: (v: BigNumber) => `formatted(${v.toString()})`,
+  formatFiat: (v: BigNumber, alwaysShowSign?: boolean) =>
+    `formatted(${v.toString()}${alwaysShowSign ? ",sign" : ""})`,
   t: fakeT,
   ...overrides,
 });
@@ -38,13 +39,13 @@ describe("buildPnlDetail", () => {
     ]);
   });
 
-  it("formats each PnL bucket through the provided fiat formatter", () => {
+  it("formats each PnL bucket through the provided fiat formatter, always showing the sign", () => {
     const detail = buildPnlDetail(makeInput());
 
     expect(detail.items.map(i => i.value)).toEqual([
-      "formatted(60)",
-      "formatted(40)",
-      "formatted(100)",
+      "formatted(60,sign)",
+      "formatted(40,sign)",
+      "formatted(100,sign)",
     ]);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/builders/buildPnlDetail.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/builders/buildPnlDetail.ts
@@ -8,7 +8,7 @@ export type BuildPnlDetailInput = {
   totalPnL: BigNumber;
   unrealisedPnL: BigNumber;
   realisedPnL: BigNumber;
-  formatFiat: (value: BigNumber) => string;
+  formatFiat: (value: BigNumber, alwaysShowSign?: boolean) => string;
   t: TFunction;
 };
 
@@ -36,17 +36,17 @@ export function buildPnlDetail({
       {
         title: t(key("unrealisedReturn.title")),
         description: t(key("unrealisedReturn.description")),
-        value: formatFiat(unrealisedPnL),
+        value: formatFiat(unrealisedPnL, true),
       },
       {
         title: t(key("realisedReturn.title")),
         description: t(key("realisedReturn.description")),
-        value: formatFiat(realisedPnL),
+        value: formatFiat(realisedPnL, true),
       },
       {
         title: t(key("totalReturn.title")),
         description: t(key("totalReturn.description")),
-        value: formatFiat(totalPnL),
+        value: formatFiat(totalPnL, true),
       },
     ],
   };

--- a/apps/ledger-live-desktop/src/mvvm/features/PnL/hooks/usePnlViewModelBase.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PnL/hooks/usePnlViewModelBase.ts
@@ -24,7 +24,7 @@ type BuildCardsContext = {
   unrealisedPnL: BigNumber;
   realisedPnL: BigNumber;
   totalPnL: BigNumber;
-  formatFiat: (value: BigNumber) => string;
+  formatFiat: (value: BigNumber, alwaysShowSign?: boolean) => string;
   openDetail: () => void;
   t: ReturnType<typeof useTranslation>["t"];
 };
@@ -62,8 +62,13 @@ export function usePnlViewModelBase({
   const { unrealisedPnL = ZERO, realisedPnL = ZERO, totalPnL = ZERO } = pnlData ?? {};
 
   const formatFiat = useCallback(
-    (value: BigNumber) =>
-      formatPrice(fiatCurrency.units[0], value, { showCode: true, locale, discreet }),
+    (value: BigNumber, alwaysShowSign?: boolean) =>
+      formatPrice(fiatCurrency.units[0], value, {
+        showCode: true,
+        locale,
+        discreet,
+        alwaysShowSign,
+      }),
     [fiatCurrency, locale, discreet],
   );
 

--- a/libs/live-currency-format/src/priceFormat.ts
+++ b/libs/live-currency-format/src/priceFormat.ts
@@ -24,13 +24,14 @@ const valueFromUnit = (valueInUnit: BigNumber, unit: Unit): BigNumber =>
 export function formatPrice(
   unit: Unit,
   value: BigNumber,
-  opts: { showCode?: boolean; locale?: string; discreet?: boolean } = {},
+  opts: { showCode?: boolean; locale?: string; discreet?: boolean; alwaysShowSign?: boolean } = {},
 ): string {
   const absFiat = value.abs().shiftedBy(-unit.magnitude).toNumber();
   return formatCurrencyUnit(unit, value, {
     showCode: opts.showCode ?? false,
     locale: opts.locale,
     discreet: opts.discreet,
+    alwaysShowSign: opts.alwaysShowSign,
     ...priceOptions(absFiat, unit),
   });
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _The PnL detail builder is unit-tested (`buildPnlDetail.test.ts`), but the new `alwaysShowSign` option on `formatPrice` and its wiring through `usePnlViewModelBase` are not directly covered._
- [x] **Impact of the changes:**
      - PnL detail modal on Ledger Live Desktop (Unrealised / Realised / Total return values)
      - Sign display: positive values prefixed with `+`, negatives with `-`
      - `formatPrice` / `formatCurrencyUnit` output where `alwaysShowSign` is used
      - Discreet mode and locale formatting still behave correctly in the modal

### 📝 Description

The PnL detail modal on Ledger Live Desktop displayed return values without an explicit sign, so positive amounts were not prefixed with `+`. This was inconsistent with Ledger Live Mobile, where PnL values always show their sign.

This PR makes the LWD PnL detail modal always show the sign on its values, matching the mobile behaviour:

- `formatPrice` (`@ledgerhq/live-currency-format`) gains an optional `alwaysShowSign` option that is forwarded to `formatCurrencyUnit`.
- `usePnlViewModelBase` exposes an `alwaysShowSign` flag on its `formatFiat` callback.
- `buildPnlDetail` calls `formatFiat(value, true)` for the Unrealised, Realised, and Total return buckets.

### 🖼 Screenshots

<img width="638" height="610" alt="Screenshot 2026-06-16 at 15 40 38" src="https://github.com/user-attachments/assets/4dd7ced6-e305-470e-9a0e-2b535f4b2f9d" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-31928](https://ledgerhq.atlassian.net/browse/LIVE-31928)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31928]: https://ledgerhq.atlassian.net/browse/LIVE-31928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ