### PR TITLE
[LWDM] feat(swap): forward lifi data to the device

### DIFF
--- a/.changeset/wet-suits-clap.md
+++ b/.changeset/wet-suits-clap.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-solana": minor
+"@ledgerhq/live-common": minor
+---
+
+[LWDM] feat(swap): forward lifi data to the device

--- a/libs/coin-modules/coin-solana/src/__tests__/fixtures/helpers.fixture.ts
+++ b/libs/coin-modules/coin-solana/src/__tests__/fixtures/helpers.fixture.ts
@@ -166,6 +166,7 @@ export function transaction(options?: {
   subAccountId?: string;
   raw?: string;
   uiState?: Record<string, unknown>;
+  templateId?: string;
 }): Transaction {
   const kind = options?.kind ?? "transfer";
   const defaultUiState = { subAccountId: options?.subAccountId, memo: "random memo for unit test" };
@@ -190,5 +191,6 @@ export function transaction(options?: {
       },
     },
     raw: options?.raw ?? "",
+    templateId: options?.templateId ?? "",
   } as unknown as Transaction;
 }

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.test.ts
@@ -168,6 +168,51 @@ describe("testing prepareTransaction", () => {
     });
   });
 
+  it("should return a new transaction from the raw transaction and the template id when user provide it", async () => {
+    const templateId = "084c694669";
+    const estimatedFees = 0.00005;
+    const rawTransaction = transaction({
+      raw: "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDNzWs4isgmR+LEHY8ZcgBBLMnC4ckD1iuhSa2/Y+69I91oyGFaAZ/9w4srgx9KoqiHtPM6Vur7h4D6XVoSgrEhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALt5JNk+MAN8BXYrlkxMEL1C/sM3+ZFYwZw4eofBOKp4BAgIAAQwCAAAAgJaYAAAAAAA=",
+      templateId,
+    });
+    const chainAPI = api(estimatedFees);
+    const getFeeForMessageSpy = jest.spyOn(chainAPI, "getFeeForMessage");
+
+    // When
+    const preparedTransaction = await prepareTransaction(
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      {} as SolanaAccount,
+      rawTransaction,
+      chainAPI,
+    );
+
+    // Then
+    expect(preparedTransaction).not.toBe(rawTransaction);
+
+    expect(getFeeForMessageSpy).toHaveBeenCalledTimes(1);
+
+    expect(preparedTransaction).toMatchObject({
+      templateId,
+      raw: rawTransaction.raw,
+      family: "solana",
+      amount: BigNumber(0),
+      recipient: "",
+      model: {
+        kind: "raw",
+        uiState: {},
+        commandDescriptor: {
+          command: {
+            kind: "raw",
+            raw: rawTransaction.raw,
+          },
+          fee: estimatedFees,
+          warnings: {},
+          errors: {},
+        },
+      },
+    });
+  });
+
   it("should return a new transaction when user does not provide a raw one", async () => {
     const nonRawTransaction = transaction();
     const preparedTransaction = await prepareTransaction(

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.ts
@@ -126,7 +126,7 @@ const prepareTransaction = async (
   api: ChainAPI,
 ): Promise<Transaction> => {
   if (tx.raw) {
-    return toLiveTransaction(api, tx.raw);
+    return toLiveTransaction(api, tx.raw, tx.templateId);
   }
 
   const txToDeriveFrom = updateModelIfSubAccountIdPresent(tx);

--- a/libs/coin-modules/coin-solana/src/rawTransaction.test.ts
+++ b/libs/coin-modules/coin-solana/src/rawTransaction.test.ts
@@ -1,0 +1,61 @@
+import BigNumber from "bignumber.js";
+import { ChainAPI } from "./network";
+import { toLiveTransaction } from "./rawTransaction";
+
+describe("toLiveTransaction", () => {
+  it("should convert a raw transaction to a Ledger Wallet transaction", async () => {
+    const api = { getFeeForMessage: jest.fn().mockResolvedValueOnce(null) } as unknown as ChainAPI;
+    const serializedTransaction =
+      "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDNzWs4isgmR+LEHY8ZcgBBLMnC4ckD1iuhSa2/Y+69I91oyGFaAZ/9w4srgx9KoqiHtPM6Vur7h4D6XVoSgrEhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALt5JNk+MAN8BXYrlkxMEL1C/sM3+ZFYwZw4eofBOKp4BAgIAAQwCAAAAgJaYAAAAAAA=";
+    const templateId = "084c694669";
+
+    const transaction = await toLiveTransaction(api, serializedTransaction, templateId);
+    expect(transaction).toEqual({
+      templateId,
+      raw: serializedTransaction,
+      family: "solana",
+      amount: BigNumber(0),
+      recipient: "",
+      model: {
+        kind: "raw",
+        uiState: {},
+        commandDescriptor: {
+          command: {
+            kind: "raw",
+            raw: serializedTransaction,
+          },
+          fee: 0,
+          warnings: {},
+          errors: {},
+        },
+      },
+    });
+  });
+
+  it("should not include a template id field when not provided", async () => {
+    const api = { getFeeForMessage: jest.fn().mockResolvedValueOnce(null) } as unknown as ChainAPI;
+    const serializedTransaction =
+      "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDNzWs4isgmR+LEHY8ZcgBBLMnC4ckD1iuhSa2/Y+69I91oyGFaAZ/9w4srgx9KoqiHtPM6Vur7h4D6XVoSgrEhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALt5JNk+MAN8BXYrlkxMEL1C/sM3+ZFYwZw4eofBOKp4BAgIAAQwCAAAAgJaYAAAAAAA=";
+
+    const transaction = await toLiveTransaction(api, serializedTransaction);
+    expect(transaction).toEqual({
+      raw: serializedTransaction,
+      family: "solana",
+      amount: BigNumber(0),
+      recipient: "",
+      model: {
+        kind: "raw",
+        uiState: {},
+        commandDescriptor: {
+          command: {
+            kind: "raw",
+            raw: serializedTransaction,
+          },
+          fee: 0,
+          warnings: {},
+          errors: {},
+        },
+      },
+    });
+  });
+});

--- a/libs/coin-modules/coin-solana/src/rawTransaction.ts
+++ b/libs/coin-modules/coin-solana/src/rawTransaction.ts
@@ -3,8 +3,13 @@ import BigNumber from "bignumber.js";
 import { ChainAPI } from "./network";
 import { Transaction } from "./types";
 
-function buildRawTransaction(raw: string, estimatedFees: number | null): Transaction {
+function buildRawTransaction(
+  raw: string,
+  estimatedFees: number | null,
+  templateId?: string,
+): Transaction {
   return {
+    ...(templateId ? { templateId } : {}),
     raw,
     family: "solana",
     amount: BigNumber(0),
@@ -28,6 +33,7 @@ function buildRawTransaction(raw: string, estimatedFees: number | null): Transac
 export async function toLiveTransaction(
   api: ChainAPI,
   serializedTransaction: string,
+  templateId?: string,
 ): Promise<Transaction> {
   const solanaTransaction = VersionedTransaction.deserialize(
     Buffer.from(serializedTransaction, "base64"),
@@ -35,7 +41,7 @@ export async function toLiveTransaction(
 
   const estimatedFees = await api.getFeeForMessage(solanaTransaction.message);
 
-  return buildRawTransaction(serializedTransaction, estimatedFees);
+  return buildRawTransaction(serializedTransaction, estimatedFees, templateId);
 }
 
 export async function deriveRawCommandDescriptor(tx: Transaction, api: ChainAPI) {

--- a/libs/coin-modules/coin-solana/src/signOperation.test.ts
+++ b/libs/coin-modules/coin-solana/src/signOperation.test.ts
@@ -96,7 +96,7 @@ function account(): Account {
   } as Account;
 }
 
-function transaction(kind: string): Transaction {
+function transaction(kind: string, templateId?: string): Transaction {
   return {
     recipient: "any random value",
     model: {
@@ -109,7 +109,8 @@ function transaction(kind: string): Transaction {
         errors: {},
       },
     },
-    subAccountId: "any random value", // needed only for "token.transfer" kind
+    ...(kind === "token.transfer" ? { subAccountId: "any random value" } : {}), // needed only for "token.transfer" kind
+    ...(templateId ? { templateId } : {}),
   } as Transaction;
 }
 
@@ -191,6 +192,34 @@ describe("Testing signOperation", () => {
           expect(resolution.delayed).toEqual(true);
           expect(typeof resolution.fetchBlockhash).toEqual("function");
           expect(jest.mocked(testApi.getLatestBlockhash)).not.toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it("passes template id to resolution when transaction contains one", done => {
+      const { context, signTransaction } = createSignContext();
+      const testApi = api();
+
+      mockBuildVersionedTransaction.mockResolvedValueOnce([...defaultBuildTuple([])]);
+      const templateId = "084c694669";
+      const transactionToSign = transaction("transfer", templateId);
+
+      buildSignOperation(
+        context,
+        testApi,
+      )({
+        account: account(),
+        deviceId: "d1",
+        deviceModelId: DeviceModelId.blue,
+        transaction: transactionToSign,
+      }).subscribe({
+        complete: () => {
+          expect(signTransaction).toHaveBeenCalledTimes(1);
+          const resolution = signTransaction.mock.calls[0][2] as {
+            templateId?: string;
+          };
+          expect(resolution.templateId).toEqual(templateId);
           done();
         },
       });

--- a/libs/coin-modules/coin-solana/src/signOperation.ts
+++ b/libs/coin-modules/coin-solana/src/signOperation.ts
@@ -76,15 +76,20 @@ function getResolution(
   deviceModelId?: DeviceModelId,
   certificateSignatureKind?: "prod" | "test",
 ): Resolution | undefined {
-  if (!transaction.subAccountId || !transaction.model.commandDescriptor) {
-    return;
-  }
-
-  const baseResolution: Resolution = {
-    deviceModelId,
-    certificateSignatureKind,
+  let baseResolution: Resolution = {
     ...(transaction.templateId && { templateId: transaction.templateId }),
   };
+
+  if (!transaction.subAccountId || !transaction.model.commandDescriptor) {
+    return baseResolution;
+  }
+
+  baseResolution = {
+    ...baseResolution,
+    deviceModelId,
+    certificateSignatureKind,
+  };
+
   const { command } = transaction.model.commandDescriptor;
   switch (command.kind) {
     case "token.transfer": {

--- a/libs/ledger-live-common/src/exchange/swap/families/solana/types.ts
+++ b/libs/ledger-live-common/src/exchange/swap/families/solana/types.ts
@@ -1,0 +1,4 @@
+export type SolanaExtraTransactionParameters = {
+  data: string;
+  templateId: string;
+};

--- a/libs/ledger-live-common/src/exchange/swap/hasParametersForSolana.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hasParametersForSolana.test.ts
@@ -1,0 +1,19 @@
+import { hasParametersForSolana } from "./hasParametersForSolana";
+
+describe("hasParametersForSolana", () => {
+  it("should return true when parameters contains Solana parameters", () => {
+    expect(
+      hasParametersForSolana({
+        data: "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDNzWs4isgmR+LEHY8ZcgBBLMnC4ckD1iuhSa2/Y+69I91oyGFaAZ/9w4srgx9KoqiHtPM6Vur7h4D6XVoSgrEhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALt5JNk+MAN8BXYrlkxMEL1C/sM3+ZFYwZw4eofBOKp4BAgIAAQwCAAAAgJaYAAAAAAA=",
+        templateId: "084c694669",
+      }),
+    ).toEqual(true);
+  });
+
+  it.each([null, undefined, {}, { gasLimit: 1 }])(
+    "should return false when parameters (%s) do not contains Solana parameters",
+    (parameters: unknown) => {
+      expect(hasParametersForSolana(parameters)).toEqual(false);
+    },
+  );
+});

--- a/libs/ledger-live-common/src/exchange/swap/hasParametersForSolana.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hasParametersForSolana.ts
@@ -1,0 +1,15 @@
+import { SolanaExtraTransactionParameters } from "./families/solana/types";
+
+export function hasParametersForSolana(
+  params: unknown,
+): params is SolanaExtraTransactionParameters {
+  return (
+    params !== undefined &&
+    params !== null &&
+    typeof params === "object" &&
+    "data" in params &&
+    typeof params.data === "string" &&
+    "templateId" in params &&
+    typeof params.templateId === "string"
+  );
+}

--- a/libs/ledger-live-common/src/exchange/swap/transactionStrategies.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/transactionStrategies.test.ts
@@ -1,0 +1,61 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+import { FeatureId } from "@shared/feature-flags";
+import { solanaTransaction, TransactionWithCustomFee } from "./transactionStrategies";
+import BigNumber from "bignumber.js";
+import type { GetFeatureFn } from "../../wallet-api/FeatureFlags/resolver";
+
+function makeGetFeature(enabled: boolean = true): GetFeatureFn {
+  return (featureId: FeatureId) => {
+    if (featureId === "lifiSolana") {
+      return {
+        enabled,
+      };
+    }
+
+    return null;
+  };
+}
+
+describe("transactionStrategies", () => {
+  describe("solanaTransaction", () => {
+    it("should return a Solana transaction with extra parameters when LIFI feature flag is enabled", () => {
+      const extraTransactionParameters = {
+        data: "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDNzWs4isgmR+LEHY8ZcgBBLMnC4ckD1iuhSa2/Y+69I91oyGFaAZ/9w4srgx9KoqiHtPM6Vur7h4D6XVoSgrEhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALt5JNk+MAN8BXYrlkxMEL1C/sM3+ZFYwZw4eofBOKp4BAgIAAQwCAAAAgJaYAAAAAAA=",
+        templateId: "084c694669",
+      };
+      const transaction = {
+        amount: BigNumber(1),
+        recipient: "Hj69wRzkrFuf1Nby4yzPEFHdsmQdMoVYjvDKZSLjZFEp",
+        extraTransactionParameters: extraTransactionParameters as unknown as string, // Needed, wrong type in the function for the moment, will be fixed later
+      } as unknown as TransactionWithCustomFee;
+
+      expect(solanaTransaction(transaction, makeGetFeature())).toEqual({
+        family: "solana",
+        amount: transaction.amount,
+        recipient: transaction.recipient,
+        model: { kind: "transfer", uiState: {} },
+        raw: extraTransactionParameters.data,
+        templateId: extraTransactionParameters.templateId,
+      });
+    });
+
+    it("should return a Solana transaction without extra parameters when LIFI feature flag is disabled", () => {
+      const extraTransactionParameters = {
+        data: "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDNzWs4isgmR+LEHY8ZcgBBLMnC4ckD1iuhSa2/Y+69I91oyGFaAZ/9w4srgx9KoqiHtPM6Vur7h4D6XVoSgrEhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALt5JNk+MAN8BXYrlkxMEL1C/sM3+ZFYwZw4eofBOKp4BAgIAAQwCAAAAgJaYAAAAAAA=",
+        templateId: "084c694669",
+      };
+      const transaction = {
+        amount: BigNumber(1),
+        recipient: "Hj69wRzkrFuf1Nby4yzPEFHdsmQdMoVYjvDKZSLjZFEp",
+        extraTransactionParameters: extraTransactionParameters as unknown as string, // Needed, wrong type in the function for the moment, will be fixed later
+      } as unknown as TransactionWithCustomFee;
+
+      expect(solanaTransaction(transaction, makeGetFeature(false))).toEqual({
+        family: "solana",
+        amount: transaction.amount,
+        recipient: transaction.recipient,
+        model: { kind: "transfer", uiState: {} },
+      });
+    });
+  });
+});

--- a/libs/ledger-live-common/src/exchange/swap/transactionStrategies.ts
+++ b/libs/ledger-live-common/src/exchange/swap/transactionStrategies.ts
@@ -4,6 +4,7 @@ import { Transaction } from "../../coin-modules/transaction-types";
 import { TransactionCommon } from "@ledgerhq/types-live";
 import { createStepError, StepError, CustomErrorType } from "../../wallet-api/Exchange";
 import type { GetFeatureFn } from "../../wallet-api/FeatureFlags/resolver";
+import { hasParametersForSolana } from "./hasParametersForSolana";
 
 export type { SwapLiveError } from "@ledgerhq/wallet-api-exchange-module";
 
@@ -191,21 +192,12 @@ export function solanaTransaction(
   getFeature?: GetFeatureFn,
 ): Extract<Transaction, { family: "solana" }> {
   let templateId: string | undefined = undefined;
+  let raw: string | undefined = undefined;
   const lifiSolanaFeature = getFeature?.("lifiSolana");
 
-  if (lifiSolanaFeature?.enabled && extraTransactionParameters) {
-    try {
-      const parsed = JSON.parse(extraTransactionParameters);
-      if (typeof parsed?.solanaTransaction?.templateId === "string") {
-        templateId = parsed.solanaTransaction.templateId;
-      } else {
-        console.warn(
-          `Template id "${templateId}" found in extraTransactionParameters for solana transaction is not a string, ignored`,
-        );
-      }
-    } catch (e) {
-      console.warn("Failed to parse extraTransactionParameters", e);
-    }
+  if (lifiSolanaFeature?.enabled && hasParametersForSolana(extraTransactionParameters)) {
+    templateId = extraTransactionParameters.templateId;
+    raw = extraTransactionParameters.data;
   }
 
   return {
@@ -213,6 +205,7 @@ export function solanaTransaction(
     amount,
     recipient,
     model: { kind: "transfer", uiState: {} },
+    ...(raw && { raw }),
     ...(templateId && { templateId }),
   };
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

forward lifi data to the device

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) --> [LIVE-18958](https://ledgerhq.atlassian.net/browse/LIVE-18958?atlOrigin=eyJpIjoiMTA1YzAxZjViYWUxNDljODkzZTJlM2RmMzY4NjY1ZDgiLCJwIjoiaiJ9)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-18958]: https://ledgerhq.atlassian.net/browse/LIVE-18958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ