### PR TITLE
[LWD] fix(desktop): revert market banner favorites filter when last starred coin is removed

### DIFF
--- a/.changeset/quick-favorites-revert.md
+++ b/.changeset/quick-favorites-revert.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix the portfolio Market Banner staying stuck on an empty "favorites" filter after the last starred coin is removed; it now reverts to the trending ranking

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/useMarketBannerViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/useMarketBannerViewModel.test.ts
@@ -13,6 +13,7 @@ import {
   createMockMarketCurrencyData,
 } from "@ledgerhq/live-common/market/utils/fixtures";
 import { MarketItemPerformer, MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { selectMarketBannerRanking } from "~/renderer/reducers/marketBanner";
 import { MARKET_BANNER_ITEMS_COUNT } from "../utils/constants";
 
 jest.mock("@ledgerhq/live-common/market/hooks/useMarketPerformers");
@@ -244,6 +245,42 @@ describe("MarketBanner view models", () => {
 
       expect(mockedUseMarketPerformers).toHaveBeenCalledWith(expect.anything(), { skip: true });
       expect(result.current.items.map(item => item.id)).toEqual(["bitcoin"]);
+    });
+
+    it("resets a stale favorites ranking to trending and runs the performers query when no coin is starred", () => {
+      mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
+      mockMarketDataQuery({});
+
+      const { result, store } = renderHook(() => useMarketBannerViewModel(), {
+        initialState: {
+          ...assetDiscoverabilityOn,
+          marketBanner: { ranking: "favorites" },
+          settings: { starredMarketCoins: [] },
+        },
+      });
+
+      expect(selectMarketBannerRanking(store.getState())).toBe("trending");
+      expect(mockedUseMarketPerformers).toHaveBeenCalledWith(expect.anything(), { skip: false });
+      expect(mockedUseMarketData).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ enabled: false }),
+      );
+      expect(result.current.items.length).toBeGreaterThan(0);
+    });
+
+    it("keeps the favorites ranking when at least one coin is starred", () => {
+      mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
+      mockMarketDataQuery({ data: [createMockMarketCurrencyData({ id: "bitcoin" })] });
+
+      const { store } = renderHook(() => useMarketBannerViewModel(), {
+        initialState: {
+          ...assetDiscoverabilityOn,
+          marketBanner: { ranking: "favorites" },
+          settings: { starredMarketCoins: ["bitcoin"] },
+        },
+      });
+
+      expect(selectMarketBannerRanking(store.getState())).toBe("favorites");
     });
 
     it("returns performers data and disables the favorites query for a performers ranking", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useMarketPerformers } from "@ledgerhq/live-common/market/hooks/useMarketPerformers";
 import { useMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
 import { filterMarketPerformersByAvailability } from "@ledgerhq/live-common/market/utils/index";
@@ -16,13 +16,14 @@ import {
   MARKET_PERFORMERS_SUPPORTED,
   MARKET_BANNER_REFRESH_RATE,
 } from "@ledgerhq/live-common/market/constants";
-import { useSelector } from "LLD/hooks/redux";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
 import {
   counterValueCurrencySelector,
   starredMarketCoinsSelector,
 } from "~/renderer/reducers/settings";
 import {
   selectMarketBannerRanking,
+  setMarketBannerRanking,
   type MarketBannerRanking,
 } from "~/renderer/reducers/marketBanner";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
@@ -139,14 +140,28 @@ export function useFavoritesBannerItems(options?: { skip?: boolean }): MarketBan
 }
 
 export function useMarketBannerViewModel(): MarketBannerItems {
+  const dispatch = useDispatch();
   const { shouldDisplayAssetDiscoverability } = useWalletFeaturesConfig("desktop");
   const persistedRanking = useSelector(selectMarketBannerRanking);
+  const hasStarred = useSelector(starredMarketCoinsSelector).length > 0;
   const ranking = shouldDisplayAssetDiscoverability
     ? persistedRanking
     : DEFAULT_RANKING_WITHOUT_DISCOVERABILITY;
-  const isFavorites = ranking === "favorites";
 
-  const performers = usePerformersBannerItems(ranking, { skip: isFavorites });
+  // A persisted "favorites" ranking is only valid while the user has starred coins; once the
+  // last one is removed, fall back to trending performers (and reset the stale value below).
+  const effectiveRanking: MarketBannerRanking =
+    ranking === "favorites" && !hasStarred ? "trending" : ranking;
+  const isFavorites = effectiveRanking === "favorites";
+
+  // Reset the stale persisted "favorites" so the persisted state and the dropdown match the UI.
+  useEffect(() => {
+    if (ranking === "favorites" && !hasStarred) {
+      dispatch(setMarketBannerRanking("trending"));
+    }
+  }, [dispatch, ranking, hasStarred]);
+
+  const performers = usePerformersBannerItems(effectiveRanking, { skip: isFavorites });
   const favorites = useFavoritesBannerItems({ skip: !isFavorites });
 
   return isFavorites ? favorites : performers;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio Market Banner: with the filter on "Favorites" and at least one starred coin, remove all favorites → the banner must revert to "Trending" instead of showing an empty favorites view (including after navigating away and back to the portfolio).
      - The ranking dropdown should reflect "Trending" after the reset.
      - Regular filter switching (Trending / Gainers / Losers / Favorites) still works and persists.
      - Behaviour with the asset discoverability flag both ON and OFF.

### 📝 Description

**Problem**: When the portfolio Market Banner filter is set to "Favorites" and the user removes their last starred coin, the banner stays stuck on an empty "Favorites" view. The ranking is persisted to disk, so the stale `"favorites"` value survives navigation (and app restarts) and the banner never recovers on its own.

**Solution**: `useMarketBannerViewModel` now resets the persisted ranking to `"trending"` when `"favorites"` is active but no coin is starred, and gates `isFavorites` on `hasStarred` so the trending performers render immediately (no blank banner while the reset propagates). The ranking dropdown reads the same persisted value, so it reflects "Trending" automatically. This mirrors the fix already shipped on mobile and follows the existing `useResetTimeRangeOnGraphRework` precedent on desktop.

### Before / After


https://github.com/user-attachments/assets/fd58656d-8d10-462b-95a0-31208364300c



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32628](https://ledgerhq.atlassian.net/browse/LIVE-32628)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32628]: https://ledgerhq.atlassian.net/browse/LIVE-32628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ