### PR TITLE
[LWDM] chore: remove auto-paging for stellar on empty page

### DIFF
--- a/.changeset/slow-panthers-sing.md
+++ b/.changeset/slow-panthers-sing.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-stellar": minor
+---
+
+fetchOperations no longer loops internally on empty pages. Returns empty results + cursor, lets caller paginate.

--- a/libs/coin-modules/coin-stellar/src/network/horizon.ts
+++ b/libs/coin-modules/coin-stellar/src/network/horizon.ts
@@ -466,48 +466,30 @@ export async function fetchOperations({
   }
 
   const requestedLimit = limit ?? coinConfig.getCoinConfig().explorer.fetchLimit ?? FETCH_LIMIT;
-  const MAX_SKIP_PAGES = 50;
-  let currentCursor = cursor;
-  let lastNextCursor = "";
 
   try {
-    for (let skip = 0; skip < MAX_SKIP_PAGES; skip++) {
-      const rawOperations = await getServer()
-        .operations()
-        .forAccount(addr)
-        .limit(requestedLimit)
-        .order(order)
-        .cursor(currentCursor ?? "")
-        .includeFailed(true)
-        .join("transactions")
-        .call();
+    const rawOperations = await getServer()
+      .operations()
+      .forAccount(addr)
+      .limit(requestedLimit)
+      .order(order)
+      .cursor(cursor ?? "")
+      .includeFailed(true)
+      .join("transactions")
+      .call();
 
-      if (!rawOperations || !rawOperations.records.length) {
-        return noResult;
-      }
-
-      const rawOps = rawOperations.records as RawOperation[];
-      const filteredOps = await rawOperationsToOperations(rawOps, addr, accountId, minHeight);
-
-      // Stop only when Horizon returns fewer records than requested (end of history).
-      // Don't use filteredOps.length — ops can be filtered by type, not just minHeight.
-      const isLastPage = rawOps.length < requestedLimit;
-      const nextCursor = isLastPage ? "" : rawOps[rawOps.length - 1].paging_token;
-      lastNextCursor = nextCursor;
-
-      // If a full page produced zero items (all filtered by unsupported type or minHeight),
-      // skip ahead to the next page instead of returning empty results.
-      if (filteredOps.length === 0 && !isLastPage) {
-        currentCursor = nextCursor;
-        continue;
-      }
-
-      return { items: filteredOps, next: nextCursor };
+    if (!rawOperations || !rawOperations.records.length) {
+      return noResult;
     }
 
-    // Safety: bail out after MAX_SKIP_PAGES consecutive empty pages.
-    // The caller's pagination loop will pick up from the returned cursor.
-    return { items: [], next: lastNextCursor };
+    const rawOps = rawOperations.records as RawOperation[];
+    const filteredOps = await rawOperationsToOperations(rawOps, addr, accountId, minHeight);
+
+    // Always return the cursor so the caller can continue pagination,
+    // even when filteredOps is empty (e.g. page of unsupported types).
+    const nextCursor = rawOps.length < requestedLimit ? "" : rawOps[rawOps.length - 1].paging_token;
+
+    return { items: filteredOps, next: nextCursor };
   } catch (e: unknown) {
     // FIXME: terrible hacks, because Stellar SDK fails to cast network failures to typed errors in react-native...
     // (https://github.com/stellar/js-stellar-sdk/issues/638)

--- a/libs/coin-modules/coin-stellar/src/network/horizon.unit.test.ts
+++ b/libs/coin-modules/coin-stellar/src/network/horizon.unit.test.ts
@@ -286,52 +286,14 @@ describe("horizon.ts (unit, spies)", () => {
         expect(page.items).toHaveLength(1);
       });
 
-      it("skips to next page when all ops on a full page are filtered out", async () => {
-        const rawA = opBuilder({ paging_token: "pt-a", id: "1" });
-        const rawB = opBuilder({ paging_token: "pt-b", id: "2" });
-        const rawC = opBuilder({ paging_token: "pt-c", id: "3" });
-
-        // First call: full page (2 ops), all filtered → recurse
-        // Second call: partial page (1 op), 1 survives → return
-        rawOperationsToOperationsMock
-          .mockResolvedValueOnce([])
-          .mockResolvedValueOnce([{ type: "mock-op" } as never]);
-
-        const callMock = jest
-          .fn()
-          .mockResolvedValueOnce({ records: [rawA, rawB] })
-          .mockResolvedValueOnce({ records: [rawC] });
-
-        jest.spyOn(Horizon.Server.prototype, "operations").mockReturnValue({
-          forAccount: jest.fn().mockReturnThis(),
-          limit: jest.fn().mockReturnThis(),
-          order: jest.fn().mockReturnThis(),
-          cursor: jest.fn().mockReturnThis(),
-          includeFailed: jest.fn().mockReturnThis(),
-          join: jest.fn().mockReturnValue({ call: callMock }),
-        } as unknown as ReturnType<Horizon.Server["operations"]>);
-
-        const page = await fetchOperations({
-          accountId: "aid",
-          addr: "GADDRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          minHeight: 999999,
-          order: "desc",
-          cursor: undefined,
-        });
-        // Skipped the empty first page, returned the second page's result
-        expect(page.items).toHaveLength(1);
-        expect(page.next).toBe("");
-        expect(callMock).toHaveBeenCalledTimes(2);
-      });
-
-      it("bails out after MAX_SKIP_PAGES consecutive empty pages", async () => {
+      it("returns empty items with cursor when all ops on a full page are filtered out", async () => {
         const rawA = opBuilder({ paging_token: "pt-a", id: "1" });
         const rawB = opBuilder({ paging_token: "pt-b", id: "2" });
 
-        // Every page returns zero filtered ops
+        // All ops filtered out (e.g. unsupported types or below minHeight)
         rawOperationsToOperationsMock.mockResolvedValue([]);
 
-        const callMock = jest.fn().mockResolvedValue({ records: [rawA, rawB] });
+        const callMock = jest.fn().mockResolvedValueOnce({ records: [rawA, rawB] });
 
         jest.spyOn(Horizon.Server.prototype, "operations").mockReturnValue({
           forAccount: jest.fn().mockReturnThis(),
@@ -349,11 +311,10 @@ describe("horizon.ts (unit, spies)", () => {
           order: "desc",
           cursor: undefined,
         });
-        // Exhausted skip budget: returns empty items with cursor for caller to resume
+        // Returns empty items with cursor — caller handles pagination
         expect(page.items).toHaveLength(0);
         expect(page.next).toBe("pt-b");
-        // MAX_SKIP_PAGES = 50 iterations
-        expect(callMock).toHaveBeenCalledTimes(50);
+        expect(callMock).toHaveBeenCalledTimes(1);
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description

fetchOperations no longer loops internally on empty pages. Returns empty results + cursor, lets caller paginate.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
