### PR TITLE
feat(web-tools): revamp logsviewer UI, account sync & virtualized logs

### DIFF
--- a/.changeset/wild-logs-sparkle.md
+++ b/.changeset/wild-logs-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/web-tools": minor
+---
+
+Revamp the LogsViewer: tabbed Lumen UI (Raw logs / Accounts / Device / APDUs / Transactions / Errors), per-account sync with balance and a paginated operations list, virtualized full-width raw logs table (TanStack Table + react-virtual) replacing react-table, dark-mode-aware ObjectInspector, and clearer parse-error handling.

--- a/apps/web-tools/package.json
+++ b/apps/web-tools/package.json
@@ -57,6 +57,7 @@
     "@radix-ui/react-switch": "catalog:",
     "@radix-ui/react-tooltip": "catalog:",
     "@tanstack/react-table": "catalog:",
+    "@tanstack/react-virtual": "catalog:",
     "@ledgerhq/types-cryptoassets": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",
     "@ledgerhq/wallet-pnl": "workspace:^",

--- a/apps/web-tools/src/logic/syncAccount.ts
+++ b/apps/web-tools/src/logic/syncAccount.ts
@@ -1,0 +1,75 @@
+import { BigNumber } from "bignumber.js";
+import { decodeAccountId, emptyHistoryCache } from "@ledgerhq/live-common/account/index";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { lastValueFrom } from "rxjs";
+import { reduce } from "rxjs/operators";
+import { makeBridgeCacheSystem } from "@ledgerhq/live-common/bridge/cache";
+import {
+  getDerivationScheme,
+  runDerivationScheme,
+} from "@ledgerhq/ledger-wallet-framework/derivation";
+import type { Account, DerivationMode } from "@ledgerhq/types-live";
+
+const localCache: Record<string, unknown> = {};
+const bridgeCache = makeBridgeCacheSystem({
+  saveData(c, d) {
+    localCache[c.id] = d;
+    return Promise.resolve();
+  },
+
+  getData(c) {
+    return Promise.resolve(localCache[c.id]);
+  },
+});
+
+export function inferAccount(id: string): Account {
+  const { derivationMode, xpubOrAddress, currencyId } = decodeAccountId(id);
+  const currency = getCryptoCurrencyById(currencyId);
+  const scheme = getDerivationScheme({
+    derivationMode: derivationMode as DerivationMode,
+    currency,
+  });
+  const index = 0;
+  const freshAddressPath = runDerivationScheme(scheme, currency, {
+    account: index,
+    node: 0,
+    address: 0,
+  });
+  const account: Account = {
+    type: "Account",
+    xpub: xpubOrAddress,
+    seedIdentifier: xpubOrAddress,
+    used: true,
+    swapHistory: [],
+    id,
+    derivationMode,
+    currency,
+    index,
+    freshAddress: xpubOrAddress,
+    freshAddressPath,
+    creationDate: new Date(),
+    lastSyncDate: new Date(0),
+    blockHeight: 0,
+    balance: new BigNumber(0),
+    spendableBalance: new BigNumber(0),
+    operationsCount: 0,
+    operations: [],
+    pendingOperations: [],
+    balanceHistoryCache: emptyHistoryCache,
+  };
+  return account;
+}
+
+export async function syncAccount(id: string): Promise<Account> {
+  const account = inferAccount(id);
+  const bridge = await getAccountBridge(account);
+  await bridgeCache.prepareCurrency(account.currency);
+  const syncConfig = {
+    paginationConfig: {},
+    blacklistedTokenIds: [],
+  };
+  const observable = bridge.sync(account, syncConfig);
+  const reduced = observable.pipe(reduce((a, f) => f(a), account));
+  return lastValueFrom(reduced);
+}

--- a/apps/web-tools/src/pages/logsviewer.tsx
+++ b/apps/web-tools/src/pages/logsviewer.tsx
@@ -1,13 +1,47 @@
-import React, { Fragment, Component, useMemo, useState } from "react";
+import React, { Component, useCallback, useMemo, useRef, useState } from "react";
 import { ObjectInspector } from "react-inspector";
-// @ts-expect-error react-table v6 types don't export a module
-import ReactTable from "react-table";
-import styled from "styled-components";
-import "react-table/react-table.css";
-import { Button as LumenButton } from "@ledgerhq/lumen-ui-react";
-import { AccountRaw } from "@ledgerhq/types-live";
-import { decodeAccountId } from "@ledgerhq/ledger-wallet-framework/account/index";
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  useReactTable,
+  type ColumnFiltersState,
+} from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+  Button,
+  IconButton,
+  Tag,
+  ThemeProvider,
+  SegmentedControl,
+  SegmentedControlButton,
+  DotCount,
+  useTheme,
+} from "@ledgerhq/lumen-ui-react";
+import {
+  Copy,
+  Check,
+  ExternalLink,
+  Refresh,
+  ChevronDown,
+  ChevronUp,
+} from "@ledgerhq/lumen-ui-react/symbols";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import { Account, AccountRaw, Operation } from "@ledgerhq/types-live";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import {
+  decodeAccountId,
+  shortAddressPreview,
+} from "@ledgerhq/ledger-wallet-framework/account/index";
 import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import {
+  getAddressExplorer,
+  getDefaultExplorerView,
+  getTransactionExplorer,
+} from "@ledgerhq/live-common/explorers";
+import { syncAccount } from "../logic/syncAccount";
 
 type App = {
   name: string;
@@ -58,13 +92,6 @@ function decodeMobileAccountId(message: string) {
   return accountList;
 }
 
-const shortAddressPreview = (addr: string, target = 20) => {
-  const slice = Math.floor((target - 3) / 2);
-  return addr.length < target - 3
-    ? addr
-    : `${addr.slice(0, slice)}...${addr.slice(addr.length - slice)}`;
-};
-
 const messageLenses: Record<string, (log: Log) => string> = {
   libcore: ({ message }) => {
     const i = message.indexOf("I: ");
@@ -72,46 +99,516 @@ const messageLenses: Record<string, (log: Log) => string> = {
   },
 };
 
-const Button = styled.a<{
-  primary?: boolean;
-  danger?: boolean;
-  disabled?: boolean;
-}>`
-  cursor: pointer;
-  padding: 12px 16px;
-  border: none;
-  background: ${p => (p.danger ? "#FF483820" : p.primary ? "#6490F1" : "rgba(100, 144, 241, 0.1)")};
-  color: ${p => (p.danger ? "#FF4838" : p.primary ? "#fff" : "#6490F1")};
-  border-radius: 4px;
-  opacity: ${p => (p.disabled ? 0.3 : 1)};
-  &:hover {
-    opacity: ${p => (p.disabled ? 0.3 : 0.8)};
-  }
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  > svg {
-    padding-right: 5px;
-  }
-`;
-
-const HeaderWrapper = styled.div``;
-const HeaderRow = styled.div`
-  display: flex;
-  padding: 10px;
-  > * + * {
-    margin-right: 10px;
-  }
-`;
-
 const dmkLoggerTags = ["live-dmk-logger", "DMK"]; // "live-dmk-logger" is kept for backward compatibility
 
 function isDmkLog(log: Log): boolean {
   return typeof log.type === "string" && dmkLoggerTags.some(tag => log.type.startsWith(tag));
 }
 
-const Header = ({
+// Explorer links are built from an address. For these families the account id
+// holds an xpub / public key rather than an address, so the link can't be built.
+const NON_ADDRESS_ID_FAMILIES = new Set(["bitcoin", "cardano", "tezos", "stacks"]);
+
+function explorerDisabledReason(currency: CryptoCurrency): string | null {
+  if (!getDefaultExplorerView(currency)?.address)
+    return "No block explorer configured for this currency";
+  if (NON_ADDRESS_ID_FAMILIES.has(currency.family))
+    return "Not available for this account type (the id holds an xpub / public key, not an address)";
+  return null;
+}
+
+function explorerUrlFor(currency: CryptoCurrency, xpubOrAddress: string): string | null {
+  const url = getAddressExplorer(getDefaultExplorerView(currency), xpubOrAddress);
+  // mintscan explorers link addresses under /address, not /validators
+  return url ? url.replace("validators", "address") : null;
+}
+
+function explorerTxUrlFor(currency: CryptoCurrency, hash: string): string | null {
+  return getTransactionExplorer(getDefaultExplorerView(currency), hash) ?? null;
+}
+
+async function copyText(text: string) {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+  } catch {
+    // fall through to legacy path
+  }
+  const input = document.createElement("textarea");
+  input.value = text;
+  document.body.appendChild(input);
+  input.select();
+  document.execCommand("copy");
+  document.body.removeChild(input);
+}
+
+// react-inspector (v4) supports a `theme` prop; follow Lumen's resolved color
+// scheme via a single context so the many inspector instances in the
+// virtualized table don't each call useTheme.
+const InspectorThemeContext = React.createContext<"chromeLight" | "chromeDark">("chromeLight");
+
+function ThemedInspector(props: React.ComponentProps<typeof ObjectInspector>) {
+  const theme = React.useContext(InspectorThemeContext);
+  return <ObjectInspector {...props} theme={theme} />;
+}
+
+// Parses an exported logs file. Supports a JSON array, an object wrapping an
+// array, or newline-delimited JSON (skipping any non-JSON noise lines).
+function parseLogs(txt: string): Log[] {
+  let obj: unknown;
+  try {
+    obj = JSON.parse(txt);
+  } catch {
+    const parsed: unknown[] = [];
+    txt
+      .split(/\n/g)
+      .map(l => l.trim())
+      .filter(Boolean)
+      .forEach(line => {
+        try {
+          parsed.push(JSON.parse(line));
+        } catch {
+          // skip non-JSON lines
+        }
+      });
+    if (parsed.length === 0) {
+      throw new Error("not valid JSON nor newline-delimited JSON");
+    }
+    obj = parsed;
+  }
+  const arr = Array.isArray(obj)
+    ? obj
+    : obj && typeof obj === "object"
+      ? Object.values(obj as Record<string, unknown>).find(Array.isArray)
+      : undefined;
+  if (!Array.isArray(arr)) {
+    throw new Error("expected a JSON array of log entries");
+  }
+  return (arr as Omit<Log, "index">[]).map((l, index) => ({ index, ...l }));
+}
+
+function CopyIconButton({ value, label }: { value: string; label: string }) {
+  const [done, setDone] = useState(false);
+  return (
+    <IconButton
+      size="xs"
+      appearance="no-background"
+      aria-label={label}
+      icon={done ? Check : Copy}
+      tooltip
+      tooltipText={done ? "Copied!" : label}
+      onClick={() => {
+        copyText(value);
+        setDone(true);
+        setTimeout(() => setDone(false), 1500);
+      }}
+    />
+  );
+}
+
+const OPS_PAGE_SIZE = 20;
+
+function formatOpDate(date: Operation["date"]): string {
+  const d = new Date(date);
+  return Number.isNaN(d.getTime()) ? "—" : d.toISOString().slice(0, 19).replace("T", " ");
+}
+
+type SyncState =
+  | { status: "idle" }
+  | { status: "syncing" }
+  | { status: "done"; account: Account }
+  | { status: "error"; error: string };
+
+function AccountRow({ id }: { id: string }) {
+  const decoded = useMemo(() => {
+    try {
+      return decodeAccountId(id);
+    } catch {
+      return null;
+    }
+  }, [id]);
+  const currency = decoded ? findCryptoCurrencyById(decoded.currencyId) : undefined;
+
+  const [copied, setCopied] = useState<"id" | "address" | null>(null);
+  const [sync, setSync] = useState<SyncState>({ status: "idle" });
+  const [expanded, setExpanded] = useState(false);
+  const [opsPage, setOpsPage] = useState(0);
+
+  const explorerUrl =
+    decoded && currency && !explorerDisabledReason(currency)
+      ? explorerUrlFor(currency, decoded.xpubOrAddress)
+      : null;
+
+  const copy = (kind: "id" | "address", text: string) => {
+    copyText(text);
+    setCopied(kind);
+    setTimeout(() => setCopied(null), 1500);
+  };
+
+  const doSync = async () => {
+    setSync({ status: "syncing" });
+    try {
+      const account = await syncAccount(id);
+      setSync({ status: "done", account });
+    } catch (e) {
+      setSync({ status: "error", error: String((e as Error)?.message ?? e) });
+    }
+  };
+
+  const balanceLabel =
+    sync.status === "done" && currency
+      ? formatCurrencyUnit(currency.units[0], sync.account.balance, { showCode: true })
+      : null;
+
+  const title = currency?.name ?? decoded?.currencyId ?? "Unknown";
+
+  const operations = sync.status === "done" ? sync.account.operations : [];
+  const pageCount = Math.max(1, Math.ceil(operations.length / OPS_PAGE_SIZE));
+  const page = Math.min(opsPage, pageCount - 1);
+  const pageOps = operations.slice(page * OPS_PAGE_SIZE, (page + 1) * OPS_PAGE_SIZE);
+  const formatAmount = (value: Operation["value"]) =>
+    currency ? formatCurrencyUnit(currency.units[0], value, { showCode: true }) : String(value);
+
+  return (
+    <div className="rounded-lg border border-base bg-base">
+      <div className="flex flex-wrap items-center gap-12 px-12 py-8">
+        {currency ? (
+          <CryptoIcon ledgerId={currency.id} ticker={currency.ticker} size={24} />
+        ) : (
+          <div className="size-24 shrink-0 rounded-full bg-muted" />
+        )}
+
+        <div className="flex min-w-0 flex-1 flex-col gap-4">
+          <span className="inline-flex items-center gap-4 body-2 text-base">
+            {title}
+            {decoded ? (
+              <>
+                <span className="text-muted">·</span>
+                <IconButton
+                  size="xs"
+                  appearance="no-background"
+                  aria-label="Copy address / xpub"
+                  icon={copied === "address" ? Check : Copy}
+                  tooltip
+                  tooltipText={copied === "address" ? "Copied!" : "Copy address / xpub"}
+                  onClick={() => copy("address", decoded.xpubOrAddress)}
+                />
+                <span className="font-mono text-muted">
+                  {shortAddressPreview(decoded.xpubOrAddress)}
+                </span>
+                {explorerUrl ? (
+                  <IconButton
+                    size="xs"
+                    appearance="no-background"
+                    aria-label="Open in block explorer"
+                    icon={ExternalLink}
+                    tooltip
+                    tooltipText="Open in block explorer"
+                    onClick={() => window.open(explorerUrl, "_blank", "noopener,noreferrer")}
+                  />
+                ) : null}
+              </>
+            ) : null}
+          </span>
+          <span className="inline-flex items-center gap-4 body-4 font-mono text-muted">
+            <IconButton
+              size="xs"
+              appearance="no-background"
+              aria-label="Copy account id"
+              icon={copied === "id" ? Check : Copy}
+              tooltip
+              tooltipText={copied === "id" ? "Copied!" : "Copy account id"}
+              onClick={() => copy("id", id)}
+            />
+            <span className="truncate">{id}</span>
+          </span>
+        </div>
+
+        <div className="ml-auto flex min-w-0 items-center gap-8">
+          {sync.status === "done" && balanceLabel ? (
+            <Tag appearance="success" size="sm" label={balanceLabel} />
+          ) : sync.status === "error" ? (
+            <span className="max-w-[280px] truncate body-4 text-error" title={sync.error}>
+              {sync.error}
+            </span>
+          ) : null}
+
+          {sync.status === "done" ? (
+            <Button
+              size="sm"
+              appearance="no-background"
+              icon={expanded ? ChevronUp : ChevronDown}
+              onClick={() => setExpanded(e => !e)}
+            >
+              {operations.length} ops
+            </Button>
+          ) : null}
+
+          <Button
+            size="sm"
+            appearance={sync.status === "error" ? "red" : "gray"}
+            icon={Refresh}
+            loading={sync.status === "syncing"}
+            onClick={doSync}
+          >
+            {sync.status === "error" ? "Retry" : "Sync"}
+          </Button>
+        </div>
+      </div>
+
+      {sync.status === "done" && expanded ? (
+        operations.length ? (
+          <div className="flex flex-col gap-4 border-t border-base px-12 py-8">
+            {pageOps.map(op => {
+              const txUrl = currency ? explorerTxUrlFor(currency, op.hash) : null;
+              return (
+                <div key={op.id} className="flex items-center gap-8 body-4 font-mono">
+                  <span className="shrink-0 text-muted">{formatOpDate(op.date)}</span>
+                  <Tag size="sm" appearance="gray" label={op.type} />
+                  <span className="shrink-0">{formatAmount(op.value)}</span>
+                  <span className="truncate text-muted">{op.hash}</span>
+                  <span className="ml-auto flex shrink-0 items-center">
+                    <CopyIconButton value={op.hash} label="Copy tx hash" />
+                    {txUrl ? (
+                      <IconButton
+                        size="xs"
+                        appearance="no-background"
+                        aria-label="Open tx in explorer"
+                        icon={ExternalLink}
+                        tooltip
+                        tooltipText="Open tx in explorer"
+                        onClick={() => window.open(txUrl, "_blank", "noopener,noreferrer")}
+                      />
+                    ) : null}
+                  </span>
+                </div>
+              );
+            })}
+            {pageCount > 1 ? (
+              <div className="flex items-center gap-8 pt-4 body-4 text-muted">
+                <Button
+                  size="sm"
+                  appearance="no-background"
+                  disabled={page === 0}
+                  onClick={() => setOpsPage(page - 1)}
+                >
+                  Prev
+                </Button>
+                <span>
+                  Page {page + 1} / {pageCount}
+                </span>
+                <Button
+                  size="sm"
+                  appearance="no-background"
+                  disabled={page >= pageCount - 1}
+                  onClick={() => setOpsPage(page + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <div className="border-t border-base px-12 py-8 body-4 text-muted">No operations</div>
+        )
+      ) : null}
+    </div>
+  );
+}
+
+const PanelTitle = ({ children }: { children: React.ReactNode }) => (
+  <h2 className="heading-5 text-base">{children}</h2>
+);
+
+const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
+  <section className="flex flex-col gap-12 rounded-lg border border-base bg-base p-16">
+    <PanelTitle>{title}</PanelTitle>
+    {children}
+  </section>
+);
+
+// keys that are rendered as columns or are internal noise, not "extra data"
+const HIDDEN_CONTENT_KEYS = new Set([
+  "type",
+  "level",
+  "pname",
+  "message",
+  "timestamp",
+  "index",
+  "logIndex",
+  "id",
+  "date",
+]);
+
+function extraData(log: Log): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(log).filter(([key]) => !HIDDEN_CONTENT_KEYS.has(key)));
+}
+
+function LogContent({ log }: { log: Log }) {
+  const messageLens = messageLenses[log.type];
+  const message = messageLens ? messageLens(log) : log.message;
+  const extra = extraData(log);
+  return (
+    <>
+      <code className="whitespace-pre-wrap break-all">{message}</code>
+      {Object.keys(extra).length > 0 ? <ThemedInspector data={extra} /> : null}
+    </>
+  );
+}
+
+// mobile logs carry `date` instead of `timestamp`
+const timeAccessor = (l: Log & { date?: string }) => l.timestamp ?? l.date ?? "";
+
+const LOG_COLUMN_WIDTHS: Record<string, string> = {
+  index: "64px",
+  time: "230px",
+  process: "170px",
+  type: "180px",
+  content: "minmax(320px, 1fr)",
+};
+
+const columnHelper = createColumnHelper<Log>();
+
+// stable identity: a per-render getRowId busts TanStack's row-model memo
+const getLogRowId = (row: Log) => String(row.index);
+
+const RawLogsTable = ({ logs }: { logs: Log[] }) => {
+  const hasProcess = useMemo(() => logs.some(l => l.pname), [logs]);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor(row => String(row.index), {
+        id: "index",
+        header: "index",
+        filterFn: "includesString",
+      }),
+      columnHelper.accessor(timeAccessor, {
+        id: "time",
+        header: "time",
+        filterFn: "includesString",
+      }),
+      ...(hasProcess
+        ? [
+            columnHelper.accessor("pname", {
+              id: "process",
+              header: "process",
+              filterFn: "includesString",
+            }),
+          ]
+        : []),
+      columnHelper.accessor("type", { header: "type", filterFn: "includesString" }),
+      columnHelper.accessor("message", {
+        id: "content",
+        header: "Content",
+        filterFn: "includesString",
+        cell: info => <LogContent log={info.row.original} />,
+      }),
+    ],
+    [hasProcess],
+  );
+
+  const table = useReactTable({
+    data: logs,
+    columns,
+    state: { columnFilters },
+    onColumnFiltersChange: setColumnFilters,
+    getRowId: getLogRowId,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+  });
+
+  const rows = table.getRowModel().rows;
+  const gridTemplateColumns = table
+    .getVisibleLeafColumns()
+    .map(c => LOG_COLUMN_WIDTHS[c.id] ?? "1fr")
+    .join(" ");
+
+  // key measurements by stable row id so cached heights follow content across
+  // filtering (otherwise rows overlap when the filtered set changes)
+  const getItemKey = useCallback((index: number) => rows[index]?.id ?? index, [rows]);
+
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 44,
+    overscan: 12,
+    getItemKey,
+    measureElement: el => el?.getBoundingClientRect().height ?? 44,
+  });
+
+  return (
+    <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
+      <div className="sticky top-0 z-10 border-b border-base bg-canvas">
+        <div className="grid" style={{ gridTemplateColumns }}>
+          {table.getFlatHeaders().map(header => (
+            <div key={header.id} className="px-8 py-4 body-4 font-medium text-muted">
+              {String(header.column.columnDef.header)}
+            </div>
+          ))}
+        </div>
+        <div className="grid" style={{ gridTemplateColumns }}>
+          {table.getFlatHeaders().map(header => (
+            <div key={header.id} className="px-8 pb-4">
+              <input
+                aria-label={`Filter ${String(header.column.columnDef.header)}`}
+                value={(header.column.getFilterValue() as string) ?? ""}
+                onChange={e => header.column.setFilterValue(e.target.value)}
+                placeholder="filter"
+                className="w-full rounded border border-base bg-base px-4 py-2 body-4 text-base outline-none"
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ height: rowVirtualizer.getTotalSize(), position: "relative" }}>
+        {rowVirtualizer.getVirtualItems().map(virtualRow => {
+          const row = rows[virtualRow.index];
+          return (
+            <div
+              key={row.id}
+              data-index={virtualRow.index}
+              ref={rowVirtualizer.measureElement}
+              className="grid border-b border-muted-subtle hover:bg-muted"
+              style={{
+                gridTemplateColumns,
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                transform: `translateY(${virtualRow.start}px)`,
+              }}
+            >
+              {row.getVisibleCells().map(cell => {
+                const isContent = cell.column.id === "content";
+                const value = String(cell.getValue() ?? "");
+                return (
+                  <div
+                    key={cell.id}
+                    title={isContent ? undefined : value}
+                    className={`min-w-0 px-8 py-4 body-3 font-mono ${
+                      isContent ? "break-all" : "truncate whitespace-nowrap"
+                    }`}
+                  >
+                    {isContent ? flexRender(cell.column.columnDef.cell, cell.getContext()) : value}
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+type TabId = "device" | "accounts" | "apdus" | "transactions" | "errors" | "raw";
+
+function LogsDashboard({
   logs,
   logsMeta,
   onFiles,
@@ -119,87 +616,15 @@ const Header = ({
   logs: Log[];
   logsMeta?: LogMeta;
   onFiles: (files: FileList) => void;
-}) => {
-  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
-  const [lastClickedButton, setLastClickedButton] = useState<string | null>(null);
-
-  const handleCopyClick = (accountId: string, index: number, onlyXpubOrAddress: boolean) => {
-    try {
-      const tempInput = document.createElement("input");
-      document.body.appendChild(tempInput);
-      if (onlyXpubOrAddress) {
-        tempInput.value = decodeAccountId(accountId).xpubOrAddress;
-      } else {
-        const cmdStart = `ledger-live sync --id ${decodeAccountId(accountId).xpubOrAddress} --currency ${decodeAccountId(accountId).currencyId}`;
-        tempInput.value = decodeAccountId(accountId).derivationMode
-          ? `${cmdStart} -s ${decodeAccountId(accountId).derivationMode}`
-          : cmdStart;
-      }
-      tempInput.select();
-      document.execCommand("copy");
-      document.body.removeChild(tempInput);
-      setLastClickedButton(onlyXpubOrAddress ? "address" : "xpub");
-      setCopiedIndex(index);
-      setTimeout(() => {
-        setCopiedIndex(null);
-        setLastClickedButton(null);
-      }, 2000);
-    } catch (e) {
-      console.error(e);
-    }
-  };
-
-  const linkToExplorer = (accountId: string) => {
-    try {
-      const { currencyId, xpubOrAddress } = decodeAccountId(accountId);
-      const currency = findCryptoCurrencyById(currencyId);
-      if (currency && currency.explorerViews && currency.explorerViews.length > 0) {
-        const explorerView = currency.explorerViews[0];
-        let url: any = explorerView.address;
-        if (url) {
-          url = url.replace("$address", xpubOrAddress);
-          url = url.replace("validators", "address"); //for mintscan explorers linked as /validator
-          window.open(url, "_blank");
-        }
-      }
-    } catch (e) {
-      console.error(e);
-    }
-  };
-
-  const isValid = (accountId: string) => {
-    try {
-      const { currencyId } = decodeAccountId(accountId);
-      const currencyInfo = findCryptoCurrencyById(currencyId);
-      if (currencyInfo && currencyInfo.explorerViews && currencyInfo.explorerViews.length > 0) {
-        const explorerView = currencyInfo.explorerViews[0];
-        if (explorerView.address) {
-          const isValidFamily = ["bitcoin", "cardano", "tezos", "stacks"].includes(
-            currencyInfo.family,
-          );
-          return !isValidFamily;
-        }
-      }
-      return false;
-    } catch (e) {
-      console.error(e);
-      return false;
-    }
-  };
-
+}) {
   const apdusLogs = useMemo(
     () =>
       logs
         .slice(0)
         .reverse()
         .filter(l => l.type === "apdu" || (isDmkLog(l) && l.message.startsWith("[exchange]")))
-        // filter out live-dmk-tracer logs that are not APDUs
-        .map(l => {
-          if (isDmkLog(l)) {
-            l.message = l.message.replace(/^\[exchange\] /, ""); // remove `[exchange] ` prefix
-          }
-          return l;
-        })
+        // copy when stripping the prefix so we don't mutate the shared log objects
+        .map(l => (isDmkLog(l) ? { ...l, message: l.message.replace(/^\[exchange\] /, "") } : l))
         .sort((a, b) => a.index - b.index)
         .reduce<Log[]>((all, l) => {
           const last = all[all.length - 1];
@@ -208,6 +633,9 @@ const Header = ({
         }, []),
     [logs],
   );
+  const apdus = useMemo(() => apdusLogs.map(l => l.message).join("\n"), [apdusLogs]);
+  const apdusHref = useMemo(() => "data:text/plain;base64," + btoa(apdus), [apdus]);
+
   const txSummaryLogs = useMemo(
     () =>
       logs
@@ -216,7 +644,7 @@ const Header = ({
         .filter(l => l.type === "transaction-summary"),
     [logs],
   );
-  const apdus = apdusLogs.map(l => l.message).join("\n");
+
   const experimentalEnvs = useMemo(() => {
     const res: Array<{ key: string; value: string }> = [];
     if (logsMeta) {
@@ -229,45 +657,74 @@ const Header = ({
     return res;
   }, [logsMeta]);
 
-  const href = useMemo(() => "data:text/plain;base64," + btoa(apdus), [apdus]);
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) =>
-    e.target.files && onFiles(e.target.files);
-  const errors = logs.filter(l => l.error);
-  const accountsIds = logsMeta?.accountsIds;
+  const errors = useMemo(() => logs.filter(l => l.error), [logs]);
 
-  let accounts: { data: AccountRaw }[] | undefined;
-  try {
-    accounts = accountsIds
-      ?.map(id => {
-        const { derivationMode, xpubOrAddress, currencyId } = decodeAccountId(id);
-        const index = 0;
-        const freshAddressPath = "0'/0'/0'/0/0"; // NB this is intentionally wrong. you are not in possession of this account.
-        const data: AccountRaw = {
-          id,
-          seedIdentifier: xpubOrAddress,
-          xpub: xpubOrAddress,
-          derivationMode,
-          index,
-          freshAddress: xpubOrAddress,
-          freshAddressPath,
-          name: currencyId + " " + shortAddressPreview(xpubOrAddress),
-          starred: true,
-          balance: "0",
-          blockHeight: 0,
-          currencyId,
-          operations: [],
-          pendingOperations: [],
-          swapHistory: [],
-          lastSyncDate: "0",
-        };
-        return {
-          data,
-        };
-      })
-      .filter(Boolean);
-  } catch (e) {
-    console.error(e);
-  }
+  const { installed, deviceLog, deviceModel, deviceVersion, listAccounts } = useMemo(() => {
+    const installed = logs.find(log => log.data?.result?.installed)?.data?.result?.installed ?? [];
+    const mobileModel = logs.find(log => log.data?.result?.deviceModelId);
+    const mobileVersion = logs.find(log => log.data?.result?.firmware?.version);
+
+    let deviceLog: Data | undefined = logs.find(
+      log => log.data?.deviceModelId && log.data?.deviceVersion && log.data?.modelIdList,
+    )?.data;
+    let deviceModel: string | undefined;
+    let deviceVersion: string | undefined;
+    let listAccounts: string[] = [];
+
+    if (logsMeta?.userAgent) {
+      listAccounts = logsMeta.accountsIds ?? [];
+      if (deviceLog) {
+        deviceModel = deviceLog.deviceModelId;
+        deviceVersion = deviceLog.deviceVersion;
+      }
+    } else {
+      const scheduleLog = logs.find(
+        log => typeof log.message === "string" && log.message.startsWith("schedule js:2"),
+      );
+      if (scheduleLog) {
+        listAccounts = decodeMobileAccountId(scheduleLog.message);
+        if (mobileModel) {
+          deviceModel = mobileModel.data?.result?.deviceModelId;
+          deviceVersion = mobileVersion?.data?.result?.firmware?.version;
+          deviceLog = mobileModel.data;
+        }
+      }
+    }
+
+    return { installed, deviceLog, deviceModel, deviceVersion, listAccounts };
+  }, [logs, logsMeta]);
+
+  const accounts: { data: AccountRaw }[] | undefined = useMemo(() => {
+    try {
+      return listAccounts
+        .map(id => {
+          const { derivationMode, xpubOrAddress, currencyId } = decodeAccountId(id);
+          const data: AccountRaw = {
+            id,
+            seedIdentifier: xpubOrAddress,
+            xpub: xpubOrAddress,
+            derivationMode,
+            index: 0,
+            freshAddress: xpubOrAddress,
+            freshAddressPath: "0'/0'/0'/0/0", // intentionally wrong, account not in possession
+            name: currencyId + " " + shortAddressPreview(xpubOrAddress),
+            starred: true,
+            balance: "0",
+            blockHeight: 0,
+            currencyId,
+            operations: [],
+            pendingOperations: [],
+            swapHistory: [],
+            lastSyncDate: "0",
+          };
+          return { data };
+        })
+        .filter(Boolean);
+    } catch (e) {
+      console.error(e);
+      return undefined;
+    }
+  }, [listAccounts]);
 
   const appJsonHref = useMemo(() => {
     try {
@@ -285,332 +742,223 @@ const Header = ({
             );
     } catch (e) {
       console.error(e);
+      return "";
     }
   }, [accounts]);
 
-  const installedApps: any = logs.find(log => log.data?.result?.installed);
-  const mobileModel: any = logs.find(log => log.data?.result?.deviceModelId);
-  const mobileVersion: any = logs.find(log => log.data?.result?.firmware.version);
-  let deviceLog: any = logs.find(
-    log => log.data?.deviceModelId && log.data?.deviceVersion && log.data?.modelIdList,
-  );
-  let findMobileAccounts: any, decodedMobileAccounts: any;
-  let deviceModel: any, deviceVersion: any;
-  let listAccounts: string[] | any = [];
+  const hasDeviceInfo =
+    Boolean(deviceLog) ||
+    installed.length > 0 ||
+    experimentalEnvs.length > 0 ||
+    Boolean(logsMeta?.userAgent);
 
-  if (logsMeta?.userAgent) {
-    listAccounts = accountsIds;
-    if (deviceLog != null) {
-      deviceModel = deviceLog.deviceModelId;
-      deviceVersion = deviceLog.deviceVersion;
-    }
-  } else if (logs.find(log => log.message.startsWith("schedule js:2"))) {
-    findMobileAccounts = logs.find(log => log.message.startsWith("schedule js:2"));
-    decodedMobileAccounts = decodeMobileAccountId(findMobileAccounts.message);
-    listAccounts = decodedMobileAccounts;
-    if (mobileModel) {
-      deviceModel = mobileModel.data?.result?.deviceModelId;
-      deviceVersion = mobileVersion.data?.result?.firmware.version;
-      deviceLog = 1;
-    }
-  }
+  const tabs: { id: TabId; label: string; count?: number }[] = [
+    { id: "raw", label: "Raw logs", count: logs.length },
+    ...(listAccounts.length
+      ? [{ id: "accounts" as const, label: "Accounts", count: listAccounts.length }]
+      : []),
+    ...(hasDeviceInfo ? [{ id: "device" as const, label: "Device" }] : []),
+    ...(apdusLogs.length
+      ? [{ id: "apdus" as const, label: "APDUs", count: apdusLogs.length }]
+      : []),
+    ...(txSummaryLogs.length
+      ? [{ id: "transactions" as const, label: "Transactions", count: txSummaryLogs.length }]
+      : []),
+    ...(errors.length ? [{ id: "errors" as const, label: "Errors", count: errors.length }] : []),
+  ];
+
+  const [tab, setTab] = useState<TabId>("raw");
+  const activeTab = tabs.some(t => t.id === tab) ? tab : "raw";
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    e.target.files && onFiles(e.target.files);
+
+  const isRaw = activeTab === "raw";
+  const { colorScheme } = useTheme();
+  const inspectorTheme = colorScheme === "dark" ? "chromeDark" : "chromeLight";
 
   return (
-    <HeaderWrapper>
-      <HeaderRow>
-        <LumenButton asChild appearance="accent">
-          <label>
-            Load Logs
-            <input type="file" onChange={onChange} accept=".json" className="hidden" />
-          </label>
-        </LumenButton>
-
-        {apdusLogs.length ? (
-          <Button download="apdus" href={href}>
-            {apdusLogs.length} APDUs
-          </Button>
-        ) : null}
-
-        <Button download="app.json" href={appJsonHref}>
-          app.json with user accounts
-        </Button>
-      </HeaderRow>
-
-      {logsMeta ? (
-        <HeaderRow>
-          <strong>user is on</strong> {logsMeta.userAgent}
-        </HeaderRow>
-      ) : null}
-
-      {logs && installedApps ? (
-        <HeaderRow>
-          <details>
-            <summary>
-              <strong>
-                user has {installedApps.data?.result?.installed?.length} apps installed
-              </strong>
-            </summary>
-            <ul>
-              <pre>
-                <code style={{ color: "red" }}>NOTE </code>
-                <code>
-                  apps could be outdated if firmware is outdated, and might still say &quot;latest
-                  version&quot;
-                </code>
-              </pre>
-              {installedApps.data?.result?.installed?.map((app: App, i: number) => {
-                const isLatestVersion = app.updated;
-                const versionStatusStyle = {
-                  color: isLatestVersion ? "green" : "red",
-                };
-                return (
-                  <li key={i}>
-                    <pre>
-                      <code>
-                        {app.name} | {app.version}
-                        <span style={versionStatusStyle}>
-                          {isLatestVersion
-                            ? " - latest version"
-                            : ` - ${app.availableVersion} update available`}
-                        </span>
-                      </code>
-                    </pre>
-                  </li>
-                );
-              })}
-            </ul>
-          </details>
-        </HeaderRow>
-      ) : null}
-
-      {logs && deviceLog ? (
-        <HeaderRow>
-          <details>
-            <summary>
-              <strong>device information</strong>
-            </summary>
-            <ul>
-              <li>
-                <pre>
-                  <code>
-                    last connected: {deviceModel} | {deviceVersion}
-                  </code>
-                </pre>
-              </li>
-              {deviceLog.modelIdList && deviceLog.modelIdList.length > 0 ? (
-                <li>
-                  <code>all devices:</code>
-                  <ul>
-                    {deviceLog.modelIdList.map((id: string, i: number) => (
-                      <li key={i}>
-                        <pre>
-                          <code>{id}</code>
-                        </pre>
-                      </li>
-                    ))}
-                  </ul>
-                </li>
-              ) : null}
-            </ul>
-          </details>
-        </HeaderRow>
-      ) : null}
-
-      {listAccounts ? (
-        <HeaderRow>
-          <details>
-            <summary>
-              <strong>user have {listAccounts.length} accounts</strong>
-            </summary>
-            <ul>
-              <pre>
-                <code style={{ color: "red" }}>NOTE </code>
-                <code>
-                  explorer button <b>will not</b> work for UTXO based accounts
-                </code>
-              </pre>
-              {listAccounts.map((id: string, i: number) => (
-                <li key={i}>
-                  <pre>
-                    <button
-                      onClick={() => handleCopyClick(id, i, true)}
-                      style={{ marginRight: "2px" }}
-                    >
-                      copy
-                    </button>
-                    {copiedIndex === i && lastClickedButton === "address" && <span>Copied!</span>}
-                    <button
-                      onClick={() => handleCopyClick(id, i, false)}
-                      style={{ margin: "0 2px" }}
-                    >
-                      copy CLI
-                    </button>
-                    {copiedIndex === i && lastClickedButton === "xpub" && <span>Copied!</span>}
-                    {isValid(id) && (
-                      <button onClick={() => linkToExplorer(id)} style={{ margin: "2px 2px" }}>
-                        explorer
-                      </button>
-                    )}
-                    <code>{id}</code>
-                  </pre>
-                </li>
-              ))}
-            </ul>
-          </details>
-        </HeaderRow>
-      ) : null}
-
-      <HeaderRow>
-        <details>
-          <summary>
-            <strong>this logs have {errors.length} errors</strong>
-          </summary>
-          <ul>
-            {errors.map((e, i) => (
-              <li key={i}>
-                <ObjectInspector data={e.error} expandLevel={3} />
-              </li>
-            ))}
-          </ul>
-        </details>
-      </HeaderRow>
-
-      {txSummaryLogs.length === 0 ? null : (
-        <HeaderRow>
-          <details>
-            <summary>
-              <strong>{txSummaryLogs.length} transaction events</strong>
-            </summary>
-            <ul>
-              {txSummaryLogs.map(
-                ({ type, level, pname, message, timestamp, index: _index, ...rest }, i) => (
-                  <li key={i}>
-                    <pre>{message}</pre>
-                    {Object.keys(rest).length > 0 ? <ObjectInspector data={rest} /> : null}
-                  </li>
-                ),
-              )}
-            </ul>
-          </details>
-        </HeaderRow>
-      )}
-
-      {experimentalEnvs.length ? (
-        <HeaderRow>
-          <details>
-            <summary>
-              <strong>experimental envs ({experimentalEnvs.length})</strong>
-            </summary>
-            <ul>
-              {experimentalEnvs?.map((env, i) => (
-                <li key={i}>
-                  <pre>
-                    <code>{`${env.key}: ${env.value}`}</code>
-                  </pre>
-                </li>
-              ))}
-            </ul>
-          </details>
-        </HeaderRow>
-      ) : null}
-    </HeaderWrapper>
-  );
-};
-
-const ContentCell = (props: { original: Log }) => {
-  const log = props.original;
-  const { type, level, pname, message: _msg, timestamp, index: _index, ...rest } = log; // eslint-disable-line no-unused-vars
-  const messageLense = messageLenses[type];
-  const message = messageLense ? messageLense(log) : log.message;
-  return (
-    <Fragment>
-      <code>{message}</code>
-      {Object.keys(rest).length > 0 ? <ObjectInspector data={rest} /> : null}
-    </Fragment>
-  );
-};
-
-const columns = [
-  {
-    id: "index",
-    Header: "index",
-    accessor: "index",
-    minWidth: 80,
-    maxWidth: 80,
-  },
-  {
-    id: "time",
-    Header: "time",
-    accessor: "timestamp",
-    maxWidth: 220,
-  },
-  {
-    Header: "process",
-    accessor: "pname",
-    maxWidth: 100,
-  },
-  {
-    Header: "type",
-    accessor: "type",
-    maxWidth: 150,
-  },
-  {
-    id: "content",
-    Header: "Content",
-    accessor: "message",
-    Cell: ContentCell,
-  },
-];
-
-class Logs extends Component<{
-  logs: Log[];
-}> {
-  render() {
-    const { logs } = this.props;
-    return <ReactTable defaultPageSize={logs.length} filterable data={logs} columns={columns} />;
-  }
-}
-
-class HeaderEmptyState extends Component<{
-  onFiles: (files: FileList) => void;
-}> {
-  onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files) {
-      this.props.onFiles(e.target.files);
-    }
-  };
-  render() {
-    return (
-      <header style={{ padding: 20 }}>
-        <h1>
-          Welcome to{" "}
-          <span>
-            Ledger <strong>Live</strong>
-          </span>{" "}
-          LogsViewer
-        </h1>
-        <p>
-          Select a <code>*.json</code> or <code>*.txt</code> log exported from Ledger Live ({" "}
-          <code>Ctrl+E</code> / Export Logs )
-        </p>
-        <p>
-          <LumenButton asChild appearance="accent">
+    <InspectorThemeContext.Provider value={inspectorTheme}>
+      <div className="flex min-h-0 flex-1 flex-col gap-16">
+        <div className="flex items-center gap-12">
+          <Button asChild appearance="accent" size="sm" className="shrink-0">
             <label>
               Load Logs
-              <input type="file" onChange={this.onChange} accept=".json,.txt" className="hidden" />
+              <input type="file" onChange={onChange} accept=".json,.txt" className="hidden" />
             </label>
-          </LumenButton>
-        </p>
-      </header>
-    );
-  }
+          </Button>
+
+          <SegmentedControl
+            selectedValue={activeTab}
+            onSelectedChange={v => setTab(v as TabId)}
+            aria-label="Logs sections"
+          >
+            {tabs.map(t => (
+              <SegmentedControlButton
+                key={t.id}
+                value={t.id}
+                trailingContent={t.count != null ? <DotCount value={t.count} /> : undefined}
+              >
+                {t.label}
+              </SegmentedControlButton>
+            ))}
+          </SegmentedControl>
+        </div>
+
+        <div
+          className={isRaw ? "-mx-24 flex min-h-0 flex-1 flex-col" : "min-h-0 flex-1 overflow-auto"}
+        >
+          {activeTab === "device" ? (
+            <div className="flex flex-col gap-16">
+              {logsMeta?.userAgent ? (
+                <Section title="User agent">
+                  <p className="body-3 font-mono text-muted break-all">{logsMeta.userAgent}</p>
+                </Section>
+              ) : null}
+              {deviceLog ? (
+                <Section title="Device">
+                  <div className="body-2 text-base">
+                    Last connected: <span className="font-medium">{deviceModel}</span>
+                    {deviceVersion ? <span className="text-muted"> · {deviceVersion}</span> : null}
+                  </div>
+                  {deviceLog.modelIdList && deviceLog.modelIdList.length > 0 ? (
+                    <div className="flex flex-wrap gap-8">
+                      {deviceLog.modelIdList.map((modelId, i) => (
+                        <Tag key={i} appearance="gray" size="sm" label={modelId} />
+                      ))}
+                    </div>
+                  ) : null}
+                </Section>
+              ) : null}
+
+              {installed.length ? (
+                <Section title={`Installed apps (${installed.length})`}>
+                  <p className="body-4 text-muted">
+                    Apps may report &quot;latest version&quot; even when outdated if the firmware
+                    itself is outdated.
+                  </p>
+                  <div className="flex flex-col gap-4">
+                    {installed.map((app, i) => (
+                      <div key={i} className="flex items-center gap-8 body-3">
+                        <span className="font-mono text-base">{app.name}</span>
+                        <span className="text-muted">{app.version}</span>
+                        <Tag
+                          size="sm"
+                          appearance={app.updated ? "success" : "warning"}
+                          label={app.updated ? "latest" : `${app.availableVersion} available`}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </Section>
+              ) : null}
+
+              {experimentalEnvs.length ? (
+                <Section title={`Experimental envs (${experimentalEnvs.length})`}>
+                  <div className="flex flex-col gap-4 font-mono body-4">
+                    {experimentalEnvs.map((env, i) => (
+                      <div key={i}>
+                        <span className="text-base">{env.key}</span>
+                        <span className="text-muted">: {env.value}</span>
+                      </div>
+                    ))}
+                  </div>
+                </Section>
+              ) : null}
+            </div>
+          ) : null}
+
+          {activeTab === "accounts" ? (
+            <div className="flex flex-col gap-8">
+              {accounts?.length ? (
+                <Button asChild appearance="gray" size="sm" className="self-start">
+                  <a download="app.json" href={appJsonHref}>
+                    Export app.json with these accounts
+                  </a>
+                </Button>
+              ) : null}
+              {listAccounts.map(id => (
+                <AccountRow key={id} id={id} />
+              ))}
+            </div>
+          ) : null}
+
+          {activeTab === "apdus" ? (
+            <Section title={`APDUs (${apdusLogs.length})`}>
+              <Button asChild appearance="gray" size="sm" className="self-start">
+                <a download="apdus" href={apdusHref}>
+                  Download apdus
+                </a>
+              </Button>
+              <pre className="max-h-[60vh] overflow-auto rounded-lg border border-base bg-muted p-16 body-4 font-mono text-base">
+                <code>{apdus}</code>
+              </pre>
+            </Section>
+          ) : null}
+
+          {activeTab === "transactions" ? (
+            <div className="flex flex-col gap-8">
+              {txSummaryLogs.map(
+                ({ type, level, pname, message, timestamp, index: _index, ...rest }, i) => (
+                  <div
+                    key={i}
+                    className="flex flex-col gap-8 rounded-lg border border-base bg-base p-16"
+                  >
+                    <pre className="overflow-auto body-4 font-mono text-base">{message}</pre>
+                    {Object.keys(rest).length > 0 ? <ThemedInspector data={rest} /> : null}
+                  </div>
+                ),
+              )}
+            </div>
+          ) : null}
+
+          {activeTab === "errors" ? (
+            <div className="flex flex-col gap-8">
+              {errors.map((e, i) => (
+                <div key={i} className="rounded-lg border border-base bg-base p-16">
+                  <ThemedInspector data={e.error} expandLevel={3} />
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          {activeTab === "raw" ? <RawLogsTable logs={logs} /> : null}
+        </div>
+      </div>
+    </InspectorThemeContext.Provider>
+  );
+}
+
+function EmptyState({ onFiles }: { onFiles: (files: FileList) => void }) {
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    e.target.files && onFiles(e.target.files);
+  return (
+    <div className="flex flex-col items-center gap-16 rounded-lg border border-base bg-base p-32 text-center">
+      <h1 className="heading-3 text-base">
+        Ledger <strong>Live</strong> LogsViewer
+      </h1>
+      <p className="body-2 text-muted">
+        Drop or select a <code className="font-mono">*.json</code> /{" "}
+        <code className="font-mono">*.txt</code> log exported from Ledger Live (
+        <code className="font-mono">Ctrl+E</code> / Export Logs).
+      </p>
+      <Button asChild appearance="accent">
+        <label>
+          Load Logs
+          <input type="file" onChange={onChange} accept=".json,.txt" className="hidden" />
+        </label>
+      </Button>
+    </div>
+  );
 }
 
 class LogsViewer extends Component {
   state: {
     logs: Log[] | null;
+    error: string | null;
   } = {
     logs: null,
+    error: null,
   };
   onDragOver: React.DragEventHandler = evt => {
     evt.stopPropagation();
@@ -623,53 +971,49 @@ class LogsViewer extends Component {
     this.onFiles(evt.dataTransfer.files);
   };
   onFiles = (files: FileList) => {
-    for (let i = 0, f; (f = files[i]); i++) {
-      if (!f.type.match("application/json") && !f.type.match("text/plain")) {
-        continue;
+    const f = files[0];
+    if (!f) return;
+    const reader = new FileReader();
+    reader.onload = e => {
+      try {
+        this.setState({ logs: parseLogs(String(e.target?.result)), error: null });
+      } catch (err) {
+        this.setState({
+          logs: null,
+          error: `Could not parse "${f.name}": ${(err as Error).message}`,
+        });
       }
-      const reader = new FileReader();
-      reader.onload = e => {
-        const txt = String(e.target?.result);
-        let obj;
-        try {
-          obj = JSON.parse(txt);
-        } catch (_error) {
-          obj = txt
-            .split(/\n/g)
-            .filter(Boolean)
-            .map(str => JSON.parse(str));
-        }
-        const logs = (obj as Omit<Log, "index">[]).map((l, index) => ({
-          index,
-          ...l,
-          deviceModelId: l.data?.deviceModelId,
-          deviceVersion: l.data?.deviceVersion,
-          modelIdList: l.data?.modelIdList,
-          installed: l.data?.result?.installed,
-        }));
-        console.log({ logs }); // eslint-disable-line no-console
-        this.setState({ logs });
-      };
-      reader.readAsText(f);
-    }
+    };
+    reader.onerror = () => this.setState({ logs: null, error: `Could not read "${f.name}"` });
+    reader.readAsText(f);
   };
   render() {
-    const { logs } = this.state;
+    const { logs, error } = this.state;
     return (
-      <div style={{ minHeight: "100vh" }} onDragOver={this.onDragOver} onDrop={this.onDrop}>
-        {!logs ? (
-          <HeaderEmptyState onFiles={this.onFiles} />
-        ) : (
-          <>
-            <Header
-              onFiles={this.onFiles}
-              logs={logs}
-              logsMeta={logs.find(l => l.message === "exportLogsMeta") as LogMeta | undefined}
-            />
-            <Logs logs={logs} />
-          </>
-        )}
-      </div>
+      <ThemeProvider colorScheme="system">
+        <main
+          className="bg-canvas flex h-screen flex-col px-24 py-32 body-2 text-base"
+          onDragOver={this.onDragOver}
+          onDrop={this.onDrop}
+        >
+          <div className="flex min-h-0 w-full flex-1 flex-col gap-24">
+            {error ? (
+              <p className="rounded-lg border border-base bg-base p-12 body-2 text-error">
+                {error}
+              </p>
+            ) : null}
+            {!logs ? (
+              <EmptyState onFiles={this.onFiles} />
+            ) : (
+              <LogsDashboard
+                onFiles={this.onFiles}
+                logs={logs}
+                logsMeta={logs.find(l => l.message === "exportLogsMeta") as LogMeta | undefined}
+              />
+            )}
+          </div>
+        </main>
+      </ThemeProvider>
     );
   }
 }

--- a/apps/web-tools/src/pages/sync.tsx
+++ b/apps/web-tools/src/pages/sync.tsx
@@ -1,89 +1,11 @@
 import React, { useEffect, useState } from "react";
-import { BigNumber } from "bignumber.js";
-import {
-  encodeAccountId,
-  decodeAccountId,
-  emptyHistoryCache,
-} from "@ledgerhq/live-common/account/index";
-import {
-  findCryptoCurrencyById,
-  getCryptoCurrencyById,
-} from "@ledgerhq/live-common/currencies/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import { reduce } from "rxjs/operators";
-import { makeBridgeCacheSystem } from "@ledgerhq/live-common/bridge/cache";
-import {
-  getDerivationScheme,
-  runDerivationScheme,
-  asDerivationMode,
-} from "@ledgerhq/ledger-wallet-framework/derivation";
-import type { Account, DerivationMode } from "@ledgerhq/types-live";
+import { encodeAccountId, decodeAccountId } from "@ledgerhq/live-common/account/index";
+import { findCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { asDerivationMode } from "@ledgerhq/ledger-wallet-framework/derivation";
+import type { Account } from "@ledgerhq/types-live";
 import { Spinner, TextInput } from "@ledgerhq/lumen-ui-react";
 import { ToolPage } from "../components/ToolPage";
-
-const localCache: Record<string, unknown> = {};
-const bridgeCache = makeBridgeCacheSystem({
-  saveData(c, d) {
-    localCache[c.id] = d;
-    return Promise.resolve();
-  },
-
-  getData(c) {
-    return Promise.resolve(localCache[c.id]);
-  },
-});
-
-function inferAccount(id: string): Account {
-  const { derivationMode, xpubOrAddress, currencyId } = decodeAccountId(id);
-  const currency = getCryptoCurrencyById(currencyId);
-  const scheme = getDerivationScheme({
-    derivationMode: derivationMode as DerivationMode,
-    currency,
-  });
-  const index = 0;
-  const freshAddressPath = runDerivationScheme(scheme, currency, {
-    account: index,
-    node: 0,
-    address: 0,
-  });
-  const account: Account = {
-    type: "Account",
-    xpub: xpubOrAddress,
-    seedIdentifier: xpubOrAddress,
-    used: true,
-    swapHistory: [],
-    id,
-    derivationMode,
-    currency,
-    index,
-    freshAddress: xpubOrAddress,
-    freshAddressPath,
-    creationDate: new Date(),
-    lastSyncDate: new Date(0),
-    blockHeight: 0,
-    balance: new BigNumber(0),
-    spendableBalance: new BigNumber(0),
-    operationsCount: 0,
-    operations: [],
-    pendingOperations: [],
-    balanceHistoryCache: emptyHistoryCache,
-  };
-  return account;
-}
-
-async function syncAccount(id: string) {
-  const account = inferAccount(id);
-  const bridge = await getAccountBridge(account);
-  await bridgeCache.prepareCurrency(account.currency);
-  const syncConfig = {
-    paginationConfig: {},
-    blacklistedTokenIds: [],
-  };
-  const observable = bridge.sync(account, syncConfig);
-  const reduced = observable.pipe(reduce((a, f) => f(a), account));
-  const synced = await reduced.toPromise();
-  return synced;
-}
+import { syncAccount } from "../logic/syncAccount";
 
 function App() {
   // synchronise account with an id that is input in a input text field

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2623,6 +2623,9 @@ importers:
       '@tanstack/react-table':
         specifier: 'catalog:'
         version: 8.5.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@tanstack/react-virtual':
+        specifier: 'catalog:'
+        version: 3.13.16(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@uiw/react-codemirror':
         specifier: ^4.25.4
         version: 4.25.4(@codemirror/view@6.39.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)


### PR DESCRIPTION
> [!NOTE]
> Internal tooling only — improves the web-tools LogsViewer (live.ledger.tools/logsviewer). No production app or library is affected.

### ✅ Checklist

- [x] changeset was attached.
- [x] **Covered by automatic tests.** No unit tests for this dev-only page; verified via typecheck, lint, and manual runs. The 2 pre-existing trustchain jest failures are unrelated (ESM transform of lumen-ui-react on develop).
- [x] **Impact of the changes:** scoped to apps/web-tools (LogsViewer + sync page). QA focus: drop a desktop and a mobile exported log, check tabs, account Sync + operations, raw-logs filtering/scroll, and dark mode.

### 📝 Description

Full rewrite of the LogsViewer presentation around Lumen UI, converging on the dev-tools look.

- Tabs (SegmentedControl) replace the stacked details: Raw logs / Accounts / Device / APDUs / Transactions / Errors, each with counts; tabs appear only when they have content.
- Accounts: per-row crypto icon, copy address and copy id, explorer link (hidden when not browsable for xpub-based coins), and a Sync button that fetches the live balance and exposes a paginated operations list (date, type, amount, tx hash with copy + explorer link). Errors surface inline in red with retry.
- Raw logs: replaced the unmaintained react-table v6 with TanStack Table v8 + react-virtual. Rows are virtualized (only visible rows in the DOM), so the table renders the full log with smooth resize, sticky header, per-column filters, and a full-width layout where only the body scrolls.
- ObjectInspector is now dark-mode aware (single matchMedia listener via context).
- More robust log parsing with visible parse errors, date-to-time mapping for mobile logs, and a conditional process column.
- Extracted the bridge-sync logic into src/logic/syncAccount.ts (shared by the sync page), and reused live-common explorer/address helpers and the shared shortAddressPreview instead of local copies.

New dependency: @tanstack/react-virtual (already in the workspace catalog, used by ledger-live-desktop).

### ❓ Context

- **JIRA or GitHub link**: N/A (ad-hoc internal tooling)
- **ADR link (if any)**: N/A
