### PR TITLE
[LWDM] fix(common): increase swap "Review transaction" device-wait budget (QAA-1322)

### DIFF
--- a/.changeset/qaa-1322-swap-review-transaction-wait.md
+++ b/.changeset/qaa-1322-swap-review-transaction-wait.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix(e2e): give swap flows a larger "Review transaction" device-wait budget (~120s) to reduce flaky "Review transaction not found" timeouts on nanoSP under heavy parallel Speculos load (QAA-1322)

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -64,6 +64,7 @@ import { sleep } from "./index";
 import { delegateMina } from "./families/mina";
 
 const isSpeculosRemote = process.env.REMOTE_SPECULOS === "true";
+const SWAP_REVIEW_TRANSACTION_MAX_ATTEMPTS = 240; // ~120s at 500ms polling
 
 export type Spec = {
   currency?: CryptoCurrency;
@@ -569,8 +570,6 @@ export async function waitFor(text: string, maxAttempts = 60): Promise<string> {
 // over the default ~30s before the device reaches "Review transaction", especially on the slower
 // nanoSP under heavy parallel Speculos load. Swap flows pass this larger budget to avoid flaky
 // "Review transaction not found" timeouts. See QAA-1322.
-const SWAP_REVIEW_TRANSACTION_MAX_ATTEMPTS = 240; // ~120s at 500ms polling
-
 export async function waitForReviewTransaction(maxAttempts = 60): Promise<void> {
   if (!isTouchDevice()) {
     await waitFor(DeviceLabels.REVIEW_TRANSACTION, maxAttempts);

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -578,18 +578,23 @@ export async function waitForReviewTransaction(maxAttempts = 60): Promise<void> 
   }
 
   const port = getEnv("SPECULOS_API_PORT");
+  let texts = "";
+  let enabled = false;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    const texts = await fetchCurrentScreenTexts(port);
+    texts = await fetchCurrentScreenTexts(port);
     if (texts.includes(DeviceLabels.REVIEW_TRANSACTION)) {
       return;
     }
-    if (texts.includes(DeviceLabels.YES_ENABLE)) {
+    if (!enabled && texts.includes(DeviceLabels.YES_ENABLE)) {
       await pressAndRelease(DeviceLabels.YES_ENABLE);
-      await waitFor(DeviceLabels.REVIEW_TRANSACTION, maxAttempts);
-      return;
+      enabled = true; // press once, then keep polling for review within the same budget
     }
     await sleep(500);
   }
+
+  throw new Error(
+    `Text "${DeviceLabels.REVIEW_TRANSACTION}" not found on device screen after ${maxAttempts} attempts. Last screen text: "${texts}"`,
+  );
 }
 
 export async function fetchCurrentScreenTexts(speculosApiPort: number): Promise<string> {

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -64,7 +64,12 @@ import { sleep } from "./index";
 import { delegateMina } from "./families/mina";
 
 const isSpeculosRemote = process.env.REMOTE_SPECULOS === "true";
-const SWAP_REVIEW_TRANSACTION_MAX_ATTEMPTS = 240; // ~120s at 500ms polling
+const SCREEN_POLL_INTERVAL_MS = 500;
+const SWAP_REVIEW_TRANSACTION_TIMEOUT_MS = 120_000;
+// Derived from timeout + interval so the budget can't silently drift if either changes.
+const SWAP_REVIEW_TRANSACTION_MAX_ATTEMPTS = Math.ceil(
+  SWAP_REVIEW_TRANSACTION_TIMEOUT_MS / SCREEN_POLL_INTERVAL_MS,
+);
 
 export type Spec = {
   currency?: CryptoCurrency;
@@ -558,7 +563,7 @@ export async function waitFor(text: string, maxAttempts = 60): Promise<string> {
       return texts;
     }
 
-    await sleep(500);
+    await sleep(SCREEN_POLL_INTERVAL_MS);
   }
 
   throw new Error(
@@ -584,7 +589,7 @@ export async function waitForReviewTransaction(maxAttempts = 60): Promise<void> 
       await pressAndRelease(DeviceLabels.YES_ENABLE);
       enabled = true; // press once, then keep polling for review within the same budget
     }
-    await sleep(500);
+    await sleep(SCREEN_POLL_INTERVAL_MS);
   }
 
   throw new Error(

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -565,21 +565,27 @@ export async function waitFor(text: string, maxAttempts = 60): Promise<string> {
   );
 }
 
-export async function waitForReviewTransaction(): Promise<void> {
+// Swap initiation (provider quote + partner signature + Exchange-app APDU handshake) can take well
+// over the default ~30s before the device reaches "Review transaction", especially on the slower
+// nanoSP under heavy parallel Speculos load. Swap flows pass this larger budget to avoid flaky
+// "Review transaction not found" timeouts. See QAA-1322.
+const SWAP_REVIEW_TRANSACTION_MAX_ATTEMPTS = 240; // ~120s at 500ms polling
+
+export async function waitForReviewTransaction(maxAttempts = 60): Promise<void> {
   if (!isTouchDevice()) {
-    await waitFor(DeviceLabels.REVIEW_TRANSACTION);
+    await waitFor(DeviceLabels.REVIEW_TRANSACTION, maxAttempts);
     return;
   }
 
   const port = getEnv("SPECULOS_API_PORT");
-  for (let attempt = 0; attempt < 60; attempt++) {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const texts = await fetchCurrentScreenTexts(port);
     if (texts.includes(DeviceLabels.REVIEW_TRANSACTION)) {
       return;
     }
     if (texts.includes(DeviceLabels.YES_ENABLE)) {
       await pressAndRelease(DeviceLabels.YES_ENABLE);
-      await waitFor(DeviceLabels.REVIEW_TRANSACTION);
+      await waitFor(DeviceLabels.REVIEW_TRANSACTION, maxAttempts);
       return;
     }
     await sleep(500);
@@ -998,7 +1004,7 @@ export const verifyAmountsAndAcceptSwap = withDeviceController(
   ({ getButtonsController }) =>
     async (swap: Swap, amount: string) => {
       const buttons = getButtonsController();
-      await waitForReviewTransaction();
+      await waitForReviewTransaction(SWAP_REVIEW_TRANSACTION_MAX_ATTEMPTS);
       const events =
         getSpeculosModel() === DeviceModelId.nanoS
           ? await pressUntilTextFound(DeviceLabels.ACCEPT_AND_SEND)
@@ -1021,12 +1027,12 @@ export const verifyAmountsAndAcceptSwapForDifferentSeed = withDeviceController(
           await waitFor(DeviceLabels.RECEIVE_ADDRESS_DOES_NOT_BELONG);
           await pressAndRelease(DeviceLabels.CONTINUE_ANYWAY);
         } else {
-          await waitFor(DeviceLabels.REVIEW_TRANSACTION);
+          await waitFor(DeviceLabels.REVIEW_TRANSACTION, SWAP_REVIEW_TRANSACTION_MAX_ATTEMPTS);
           await pressUntilTextFound(DeviceLabels.RECEIVE_ADDRESS_DOES_NOT_BELONG);
           await buttons.both();
         }
       } else {
-        await waitForReviewTransaction();
+        await waitForReviewTransaction(SWAP_REVIEW_TRANSACTION_MAX_ATTEMPTS);
       }
 
       const events = await pressUntilTextFound(DeviceLabels.SIGN_TRANSACTION);
@@ -1043,7 +1049,7 @@ export const verifyAmountsAndRejectSwap = withDeviceController(
   ({ getButtonsController }) =>
     async (swap: Swap, amount: string) => {
       const buttons = getButtonsController();
-      await waitForReviewTransaction();
+      await waitForReviewTransaction(SWAP_REVIEW_TRANSACTION_MAX_ATTEMPTS);
       let events: string[] = [];
       if (isTouchDevice()) {
         events = await pressUntilTextFound(DeviceLabels.HOLD_TO_SIGN);

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -566,10 +566,6 @@ export async function waitFor(text: string, maxAttempts = 60): Promise<string> {
   );
 }
 
-// Swap initiation (provider quote + partner signature + Exchange-app APDU handshake) can take well
-// over the default ~30s before the device reaches "Review transaction", especially on the slower
-// nanoSP under heavy parallel Speculos load. Swap flows pass this larger budget to avoid flaky
-// "Review transaction not found" timeouts. See QAA-1322.
 export async function waitForReviewTransaction(maxAttempts = 60): Promise<void> {
   if (!isTouchDevice()) {
     await waitFor(DeviceLabels.REVIEW_TRANSACTION, maxAttempts);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _E2E test-helper change in `@ledgerhq/live-common` (`src/e2e/speculos.ts`); no unit tests cover it. It is validated by the swap E2E suite itself: with `--repeat-each=4 --grep @NanoSP`, the pre-fix baseline (run 27608240388) failed `Swap USD Coin → Ethereum` 4/4 on the first try with `Review transaction not found / Exchange app is ready`._
- [x] **Impact of the changes:**
  - Desktop swap **Accept (without tx broadcast)** flow on **nanoSP** — the device must reach "Review transaction" without the premature ~30s timeout.
  - Swap **accept (different seed)** and **reject** flows — same review-wait path.
  - Regression check: EVM **send / approve / revoke** flows are unchanged (still ~30s default) and should still fail fast.

### 📝 Description

The `Swap - Accepted (without tx broadcast)` E2E suite is flaky on the slower **nanoSP**: after clicking Exchange, the device stays on "Exchange app is ready" while swap initiation (provider quote + partner signature + Exchange-app APDU handshake) completes. Under heavy parallel Speculos load (`fullyParallel`, `workers: "100%"`) this takes longer than the fixed **~30s** budget (`waitFor`: 60 attempts × 500ms), so the test times out waiting for "Review transaction" and only passes on retry.

**Fix:** `waitForReviewTransaction` is now parameterized (`maxAttempts = 60`, ~30s — default unchanged). The swap **accept/reject** device flows pass a larger `SWAP_REVIEW_TRANSACTION_MAX_ATTEMPTS = 240` (~120s) budget; the EVM **send/approve** flows keep the fast default so genuine failures there still surface quickly. Polling cadence (500ms) is unchanged, so no responsiveness is lost.

**Validation:** re-run the same harness (`--repeat-each=4 --grep @NanoSP`) and confirm the first-try `Review transaction not found` failures drop to ~0 (baseline: 4/4 first-try failures on `USD Coin → Ethereum`).

### ❓ Context

- **JIRA or GitHub link**: [QAA-1322](https://ledgerhq.atlassian.net/browse/QAA-1322)
- **Desktop Run**: https://github.com/LedgerHQ/ledger-live/actions/runs/28108353861
- **Mobile Run**: https://github.com/LedgerHQ/ledger-live/actions/runs/28108358038

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1322]: https://ledgerhq.atlassian.net/browse/QAA-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ