### PR TITLE
[LWDM] feat(zcash): add Transfer from source selector to send Recipient step [LIVE-27237]

### DIFF
--- a/.changeset/zcash-shielded-transfer-from-selector.md
+++ b/.changeset/zcash-shielded-transfer-from-selector.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/coin-bitcoin": patch
+---
+
+Add a "Transfer from" source selector (Public / Private) to the Zcash send Recipient step, behind the zcashShielded feature flag

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZcashTransferFromSelector.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZcashTransferFromSelector.tsx
@@ -1,0 +1,169 @@
+import React, { useEffect } from "react";
+import styled from "styled-components";
+import { Trans } from "react-i18next";
+import BigNumber from "bignumber.js";
+import { useFeature } from "@features/platform-feature-flags";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import type { Account } from "@ledgerhq/types-live";
+import type { Transaction, ZcashAccount } from "@ledgerhq/live-common/families/bitcoin/types";
+import type { ZcashTransaction } from "@ledgerhq/coin-bitcoin/chain-adapters/zcash/types";
+import { useSelector } from "LLD/hooks/redux";
+import { localeSelector } from "~/renderer/reducers/settings";
+import Box from "~/renderer/components/Box/Box";
+import Text from "~/renderer/components/Text";
+import Label from "~/renderer/components/Label";
+import Discreet, { useDiscreetMode } from "~/renderer/components/Discreet";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+
+type Sender = "public" | "private";
+
+type Props = {
+  account: Account;
+  transaction: Transaction;
+  onChange: (t: Transaction) => void;
+};
+
+const Card = styled(Box).attrs(() => ({
+  flex: "1 1 0",
+  p: 3,
+}))<{ $active: boolean }>`
+  appearance: none;
+  width: 100%;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 8px;
+  border: 1px solid ${p => (p.$active ? p.theme.colors.primary.c80 : p.theme.colors.neutral.c40)};
+  background-color: ${p => (p.$active ? p.theme.colors.primary.c10 : p.theme.colors.neutral.c00)};
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${p => p.theme.colors.primary.c80};
+    outline-offset: 2px;
+  }
+`;
+
+const CardTitle = styled(Text).attrs(() => ({
+  ff: "Inter|SemiBold",
+  fontSize: 4,
+  color: "neutral.c100",
+}))``;
+
+const CardSubtitle = styled(Text).attrs(() => ({
+  ff: "Inter|Regular",
+  fontSize: 3,
+  color: "neutral.c70",
+}))``;
+
+const CardAmount = styled(Text).attrs(() => ({
+  ff: "Inter|Medium",
+  fontSize: 3,
+  color: "neutral.c80",
+}))``;
+
+const Unavailable = styled(Text).attrs(() => ({
+  ff: "Inter|Regular",
+  fontSize: 2,
+  color: "warning.c70",
+}))``;
+
+const ZcashTransferFromSelector = ({ account, transaction, onChange }: Props) => {
+  const shieldedEnabled = useFeature("zcashShielded")?.enabled ?? false;
+  const isZcash = account.type === "Account" && account.currency.id === "zcash";
+  const active = isZcash && shieldedEnabled;
+
+  const bridge = useAccountBridge<ZcashTransaction>(account);
+  const discreet = useDiscreetMode();
+  const locale = useSelector(localeSelector);
+  const unit = useAccountUnit(account);
+
+  const tx = transaction as ZcashTransaction;
+
+  useEffect(() => {
+    if (!active) return;
+    if (tx.sender !== undefined) return;
+    onChange(bridge.updateTransaction(tx, { sender: "public" }) as Transaction);
+  }, [active, tx.sender, bridge, onChange, tx]);
+
+  if (!active) return null;
+
+  const sender: Sender = tx.sender ?? "public";
+
+  const privateInfo = (account as ZcashAccount).privateInfo;
+  const fvkAvailable = Boolean(privateInfo?.ufvk);
+  const orchardBalance = privateInfo?.orchardBalance ?? BigNumber(0);
+  const saplingBalance = privateInfo?.saplingBalance ?? BigNumber(0);
+
+  const totalBalance = account.balance ?? BigNumber(0);
+  const privateBalance = orchardBalance.plus(saplingBalance);
+  const transparentBalance = totalBalance.minus(privateBalance);
+
+  const formatConfig = { showCode: true, discreet, locale };
+  const transparentLabel = formatCurrencyUnit(unit, transparentBalance, formatConfig);
+  const privateLabel = formatCurrencyUnit(unit, privateBalance, formatConfig);
+
+  const select = (next: Sender) => {
+    if (next === sender) return;
+    onChange(bridge.updateTransaction(tx, { sender: next }) as Transaction);
+  };
+
+  return (
+    <Box flow={1} data-testid="zcash-transfer-from-selector">
+      <Label>
+        <Trans i18nKey="zcash.shielded.send.transferFrom.label" />
+      </Label>
+      <Box horizontal flow={3}>
+        <Card
+          as="button"
+          type="button"
+          $active={sender === "public"}
+          aria-pressed={sender === "public"}
+          onClick={() => select("public")}
+          data-testid="transfer-from-public"
+        >
+          <CardTitle>
+            <Trans i18nKey="zcash.shielded.send.transferFrom.public.title" />
+          </CardTitle>
+          <CardSubtitle>
+            <Trans i18nKey="zcash.shielded.send.transferFrom.public.subtitle" />
+          </CardSubtitle>
+          <CardAmount>
+            <Discreet>{transparentLabel}</Discreet>
+          </CardAmount>
+        </Card>
+
+        <Card
+          as="button"
+          type="button"
+          $active={sender === "private"}
+          aria-pressed={sender === "private"}
+          disabled={!fvkAvailable}
+          onClick={() => select("private")}
+          data-testid="transfer-from-private"
+        >
+          <CardTitle>
+            <Trans i18nKey="zcash.shielded.send.transferFrom.private.title" />
+          </CardTitle>
+          <CardSubtitle>
+            <Trans i18nKey="zcash.shielded.send.transferFrom.private.subtitle" />
+          </CardSubtitle>
+          <CardAmount>
+            <Discreet>{privateLabel}</Discreet>
+          </CardAmount>
+          {!fvkAvailable ? (
+            <Unavailable data-testid="transfer-from-private-unavailable">
+              <Trans i18nKey="zcash.shielded.send.transferFrom.private.unavailable" />
+            </Unavailable>
+          ) : null}
+        </Card>
+      </Box>
+    </Box>
+  );
+};
+
+export default ZcashTransferFromSelector;

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/ZcashTransferFromSelector.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/ZcashTransferFromSelector.test.tsx
@@ -61,9 +61,9 @@ describe("ZcashTransferFromSelector", () => {
   it("renders both cards with Public active by default and persists the default to the transaction", () => {
     const onChange = renderSelector(buildAccount(), {});
 
-    expect(screen.getByTestId("zcash-transfer-from-selector")).toBeInTheDocument();
-    expect(screen.getByTestId("transfer-from-public")).toBeInTheDocument();
-    expect(screen.getByTestId("transfer-from-private")).toBeInTheDocument();
+    expect(screen.getByTestId("zcash-transfer-from-selector")).toBeVisible();
+    expect(screen.getByTestId("transfer-from-public")).toBeVisible();
+    expect(screen.getByTestId("transfer-from-private")).toBeVisible();
 
     // Public default is written to the transaction state once on mount.
     expect(onChange).toHaveBeenCalledTimes(1);

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/ZcashTransferFromSelector.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/ZcashTransferFromSelector.test.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { DEFAULT_ZCASH_PRIVATE_INFO } from "@ledgerhq/coin-bitcoin/chain-adapters/zcash/constants";
+import { render, screen, fireEvent, withFlagOverrides } from "tests/testSetup";
+import { createFixtureAccount } from "@ledgerhq/coin-bitcoin/fixtures/common.fixtures";
+import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { Account } from "@ledgerhq/types-live";
+import { Transaction } from "@ledgerhq/live-common/families/bitcoin/types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import ZcashTransferFromSelector from "../ZcashTransferFromSelector";
+
+jest.mock("~/renderer/hooks/useAccountUnit");
+const mockedUseAccountUnit = jest.mocked(useAccountUnit);
+
+// The bridge's updateTransaction merges the patch onto the transaction
+// (see libs/ledger-wallet-framework/.../jsHelpers.ts). Replicate that here.
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: () => ({
+    updateTransaction: (tx: Transaction, patch: Partial<Transaction>) => ({ ...tx, ...patch }),
+  }),
+}));
+
+const baseAccount = createFixtureAccount();
+
+const buildAccount = (overrides: Partial<typeof DEFAULT_ZCASH_PRIVATE_INFO> = {}, isZcash = true) =>
+  ({
+    ...baseAccount,
+    balance: new BigNumber(100_000_000),
+    currency: { id: isZcash ? "zcash" : "bitcoin" } as CryptoCurrency,
+    privateInfo: {
+      ...DEFAULT_ZCASH_PRIVATE_INFO,
+      ...overrides,
+    },
+  }) as unknown as Account;
+
+const renderSelector = (
+  account: Account,
+  transaction: Partial<Transaction>,
+  onChange = jest.fn(),
+  flagEnabled = true,
+) => {
+  render(
+    <ZcashTransferFromSelector
+      account={account}
+      transaction={transaction as Transaction}
+      onChange={onChange}
+    />,
+    {
+      initialState: withFlagOverrides({ zcashShielded: { enabled: flagEnabled } }),
+    },
+  );
+  return onChange;
+};
+
+describe("ZcashTransferFromSelector", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseAccountUnit.mockReturnValue({ code: "ZEC", name: "Zcash", magnitude: 8 });
+  });
+
+  it("renders both cards with Public active by default and persists the default to the transaction", () => {
+    const onChange = renderSelector(buildAccount(), {});
+
+    expect(screen.getByTestId("zcash-transfer-from-selector")).toBeInTheDocument();
+    expect(screen.getByTestId("transfer-from-public")).toBeInTheDocument();
+    expect(screen.getByTestId("transfer-from-private")).toBeInTheDocument();
+
+    // Public default is written to the transaction state once on mount.
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ sender: "public" }));
+  });
+
+  it("does not rewrite the default when a sender is already set", () => {
+    const onChange = renderSelector(buildAccount(), { sender: "private" } as Partial<Transaction>);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("selects Private when the Private card is clicked", () => {
+    const onChange = renderSelector(buildAccount({ ufvk: "uview-test" }), {});
+    onChange.mockClear(); // ignore the on-mount default write
+
+    fireEvent.click(screen.getByTestId("transfer-from-private"));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ sender: "private" }));
+  });
+
+  it("selects Public when the Public card is clicked from a Private selection", () => {
+    const onChange = renderSelector(buildAccount({ ufvk: "uview-test" }), {
+      sender: "private",
+    } as Partial<Transaction>);
+
+    fireEvent.click(screen.getByTestId("transfer-from-public"));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ sender: "public" }));
+  });
+
+  it("keeps the Private card clickable in every sync state (never disabled)", () => {
+    const onChange = renderSelector(buildAccount({ syncState: "disabled", ufvk: "uview-test" }), {
+      sender: "public",
+    } as Partial<Transaction>);
+    onChange.mockClear();
+
+    fireEvent.click(screen.getByTestId("transfer-from-private"));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ sender: "private" }));
+  });
+
+  it("shows the unavailable hint on the Private card when no FVK is available", () => {
+    renderSelector(buildAccount({ ufvk: null }), { sender: "public" } as Partial<Transaction>);
+    expect(screen.getByTestId("transfer-from-private-unavailable")).toBeInTheDocument();
+  });
+
+  it("hides the unavailable hint when an FVK is available", () => {
+    renderSelector(buildAccount({ ufvk: "uview-test" }), {
+      sender: "public",
+    } as Partial<Transaction>);
+    expect(screen.queryByTestId("transfer-from-private-unavailable")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the zcashShielded feature flag is off", () => {
+    renderSelector(buildAccount(), {}, jest.fn(), false);
+    expect(screen.queryByTestId("zcash-transfer-from-selector")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for a non-Zcash account", () => {
+    renderSelector(buildAccount({}, false), {});
+    expect(screen.queryByTestId("zcash-transfer-from-selector")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/index.ts
@@ -2,6 +2,7 @@ import "./live-common-setup";
 import sendAmountFields from "./SendAmountFields";
 import sendRecipientFields from "./SendRecipientFields";
 import StepReceiveFundsPostAlert from "./StepReceiveFundsPostAlert";
+import SendStepRecipientFromSelector from "./ZcashTransferFromSelector";
 import accountHeaderManageActions from "./AccountHeaderManageActions";
 import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
 import operationDetails from "./operationDetails";
@@ -12,6 +13,7 @@ const family: BitcoinFamily = {
   sendAmountFields,
   sendRecipientFields,
   StepReceiveFundsPostAlert,
+  SendStepRecipientFromSelector,
   accountHeaderManageActions,
   AccountBalanceSummaryFooter,
   operationDetails,

--- a/apps/ledger-live-desktop/src/renderer/families/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/types.ts
@@ -326,6 +326,18 @@ export type LLDCoinFamily<
   SendStepAmount?: React.ComponentType<SendStepProps>;
 
   /**
+   * Allow to add a family-specific component above the recipient field in the
+   * Send modal (e.g. Zcash transparent/shielded "transfer from" selector).
+   * The component is responsible for its own gating (feature flags, currency
+   * checks) and should render nothing when it does not apply.
+   */
+  SendStepRecipientFromSelector?: React.ComponentType<{
+    account: A;
+    transaction: T;
+    onChange: (t: T) => void;
+  }>;
+
+  /**
    * Allow to add component below recipient field
    *
    * FIXME: account will have to be A | TokenAccount

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
@@ -37,7 +37,8 @@ import { openURL } from "~/renderer/linking";
 import { urls } from "~/config/urls";
 import { useLLDCoinFamily } from "~/renderer/families";
 import { useNewSendFlowFeature } from "LLD/features/Send/hooks/useNewSendFlowFeature";
-import { Account } from "@ledgerhq/types-live";
+import { Account, Operation } from "@ledgerhq/types-live";
+import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
 
 const openSplTokenExtensionsArticle = () => openURL(urls.solana.splTokenExtensions);
 
@@ -60,6 +61,10 @@ export const DefaultStepRecipient = ({
   const lldMemoTag = useFeature("lldMemoTag");
   const { isEnabledForFamily } = useNewSendFlowFeature();
   const bridge = useAccountBridgeOrNull(account ?? null, parentAccount);
+  const mainAccount = account ? getMainAccount(account, parentAccount) : null;
+  const specific = useLLDCoinFamily<Account, Transaction, TransactionStatus, Operation>(
+    mainAccount?.currency.family,
+  );
 
   const accountFilter = useMemo(
     () => (acc: Account) => {
@@ -69,13 +74,15 @@ export const DefaultStepRecipient = ({
     [isEnabledForFamily],
   );
 
-  if (!status || !account) return null;
+  if (!status || !account || !mainAccount) return null;
 
-  const mainAccount = getMainAccount(account, parentAccount);
   const extensions = getTokenExtensions(account);
 
   // check if there is a stuck transaction. If so, display a warning panel with "speed up or cancel" button
   const stuckAccountAndOperation = bridge?.getStuckAccountAndOperation(account, parentAccount);
+
+  const isReady = account && transaction && mainAccount;
+  const SendStepRecipientFromSelector = specific?.SendStepRecipientFromSelector;
 
   return (
     <Box flow={4}>
@@ -105,6 +112,14 @@ export const DefaultStepRecipient = ({
             />
           </Box>
 
+          {SendStepRecipientFromSelector && transaction ? (
+            <SendStepRecipientFromSelector
+              account={mainAccount}
+              transaction={transaction}
+              onChange={onChangeTransaction}
+            />
+          ) : null}
+
           {extensions && hasProblematicExtension(extensions) ? (
             <Alert data-testid="spl-2022-problematic-extension" type="warning" small={true}>
               <Trans i18nKey="send.steps.details.splExtensionsWarning">
@@ -120,7 +135,7 @@ export const DefaultStepRecipient = ({
             />
           ) : null}
           <StepRecipientSeparator />
-          {account && transaction && mainAccount && (
+          {isReady && (
             <>
               <RecipientField
                 status={status}

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
@@ -37,10 +37,177 @@ import { openURL } from "~/renderer/linking";
 import { urls } from "~/config/urls";
 import { useLLDCoinFamily } from "~/renderer/families";
 import { useNewSendFlowFeature } from "LLD/features/Send/hooks/useNewSendFlowFeature";
-import { Account, Operation } from "@ledgerhq/types-live";
+import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
 
 const openSplTokenExtensionsArticle = () => openURL(urls.solana.splTokenExtensions);
+
+type StuckAccountAndOperation = {
+  account: AccountLike;
+  parentAccount: Account | undefined;
+  operation: Operation;
+};
+
+type SendStepRecipientFromSelectorComponent = React.ComponentType<{
+  account: Account;
+  transaction: Transaction;
+  onChange: (t: Transaction) => void;
+}>;
+
+const SenderErrorBanner = ({ error }: { error: Error }) => (
+  <div data-testid="sender-error-container">
+    <ErrorBanner dataTestId="sender-error" error={error} />
+  </div>
+);
+
+const SplProblematicExtensionWarning = ({ account }: { account: AccountLike }) => {
+  const extensions = getTokenExtensions(account);
+  if (!extensions || !hasProblematicExtension(extensions)) return null;
+
+  return (
+    <Alert data-testid="spl-2022-problematic-extension" type="warning" small={true}>
+      <Trans i18nKey="send.steps.details.splExtensionsWarning">
+        <Link type="color" onClick={openSplTokenExtensionsArticle} />
+      </Trans>
+    </Alert>
+  );
+};
+
+type RecipientFormFieldsProps = {
+  t: StepProps["t"];
+  mainAccount: Account;
+  parentAccount: StepProps["parentAccount"];
+  transaction: Transaction;
+  status: TransactionStatus;
+  openedFromAccount: boolean;
+  forceAutoFocusOnMemoField: boolean;
+  onChangeTransaction: StepProps["onChangeTransaction"];
+  maybeRecipient?: string;
+  onResetMaybeRecipient: () => void;
+};
+
+const RecipientFormFields = ({
+  t,
+  mainAccount,
+  parentAccount,
+  transaction,
+  status,
+  openedFromAccount,
+  forceAutoFocusOnMemoField,
+  onChangeTransaction,
+  maybeRecipient,
+  onResetMaybeRecipient,
+}: RecipientFormFieldsProps) => (
+  <>
+    <RecipientField
+      status={status}
+      autoFocus={openedFromAccount && !forceAutoFocusOnMemoField}
+      account={mainAccount}
+      transaction={transaction}
+      onChangeTransaction={onChangeTransaction}
+      t={t}
+      initValue={maybeRecipient}
+      resetInitValue={onResetMaybeRecipient}
+    />
+    <SendRecipientFields
+      account={mainAccount}
+      parentAccount={parentAccount}
+      status={status}
+      transaction={transaction}
+      onChange={onChangeTransaction}
+      autoFocus={forceAutoFocusOnMemoField}
+    />
+  </>
+);
+
+type RecipientStepContentProps = {
+  t: StepProps["t"];
+  account: AccountLike;
+  mainAccount: Account;
+  parentAccount: StepProps["parentAccount"];
+  transaction: StepProps["transaction"];
+  status: TransactionStatus;
+  error: StepProps["error"];
+  openedFromAccount: boolean;
+  forceAutoFocusOnMemoField: boolean;
+  accountFilter: (acc: Account) => boolean;
+  stuckAccountAndOperation: StuckAccountAndOperation | undefined;
+  SendStepRecipientFromSelector?: SendStepRecipientFromSelectorComponent;
+  onChangeAccount: StepProps["onChangeAccount"];
+  onChangeTransaction: StepProps["onChangeTransaction"];
+  maybeRecipient?: string;
+  onResetMaybeRecipient: () => void;
+};
+
+const RecipientStepContent = ({
+  t,
+  account,
+  mainAccount,
+  parentAccount,
+  transaction,
+  status,
+  error,
+  openedFromAccount,
+  forceAutoFocusOnMemoField,
+  accountFilter,
+  stuckAccountAndOperation,
+  SendStepRecipientFromSelector,
+  onChangeAccount,
+  onChangeTransaction,
+  maybeRecipient,
+  onResetMaybeRecipient,
+}: RecipientStepContentProps) => (
+  <>
+    <CurrencyDownStatusAlert currencies={[mainAccount.currency]} />
+    {error ? <ErrorBanner error={error} /> : null}
+    {status.errors?.sender ? <SenderErrorBanner error={status.errors.sender} /> : null}
+
+    <Box flow={1}>
+      <Label>{t("send.steps.details.selectAccountDebit")}</Label>
+      <SelectAccount
+        id="account-debit-placeholder"
+        withSubAccounts
+        enforceHideEmptySubAccounts
+        autoFocus={!openedFromAccount && !forceAutoFocusOnMemoField}
+        onChange={onChangeAccount}
+        value={account}
+        filter={accountFilter}
+      />
+    </Box>
+
+    {SendStepRecipientFromSelector && transaction ? (
+      <SendStepRecipientFromSelector
+        account={mainAccount}
+        transaction={transaction}
+        onChange={onChangeTransaction}
+      />
+    ) : null}
+
+    <SplProblematicExtensionWarning account={account} />
+    {stuckAccountAndOperation ? (
+      <EditOperationPanel
+        operation={stuckAccountAndOperation.operation}
+        account={stuckAccountAndOperation.account}
+        parentAccount={stuckAccountAndOperation.parentAccount}
+      />
+    ) : null}
+    <StepRecipientSeparator />
+    {transaction ? (
+      <RecipientFormFields
+        t={t}
+        mainAccount={mainAccount}
+        parentAccount={parentAccount}
+        transaction={transaction}
+        status={status}
+        openedFromAccount={openedFromAccount}
+        forceAutoFocusOnMemoField={forceAutoFocusOnMemoField}
+        onChangeTransaction={onChangeTransaction}
+        maybeRecipient={maybeRecipient}
+        onResetMaybeRecipient={onResetMaybeRecipient}
+      />
+    ) : null}
+  </>
+);
 
 export const DefaultStepRecipient = ({
   t,
@@ -76,13 +243,8 @@ export const DefaultStepRecipient = ({
 
   if (!status || !account || !mainAccount) return null;
 
-  const extensions = getTokenExtensions(account);
-
   // check if there is a stuck transaction. If so, display a warning panel with "speed up or cancel" button
   const stuckAccountAndOperation = bridge?.getStuckAccountAndOperation(account, parentAccount);
-
-  const isReady = account && transaction && mainAccount;
-  const SendStepRecipientFromSelector = specific?.SendStepRecipientFromSelector;
 
   return (
     <Box flow={4}>
@@ -90,74 +252,24 @@ export const DefaultStepRecipient = ({
       {isMemoTagBoxVisibile && lldMemoTag?.enabled ? (
         <MemoTagSendInfo />
       ) : (
-        <>
-          {mainAccount ? <CurrencyDownStatusAlert currencies={[mainAccount.currency]} /> : null}
-          {error ? <ErrorBanner error={error} /> : null}
-          {status.errors && status.errors.sender ? (
-            <div data-testid="sender-error-container">
-              <ErrorBanner dataTestId="sender-error" error={status.errors.sender} />
-            </div>
-          ) : null}
-
-          <Box flow={1}>
-            <Label>{t("send.steps.details.selectAccountDebit")}</Label>
-            <SelectAccount
-              id="account-debit-placeholder"
-              withSubAccounts
-              enforceHideEmptySubAccounts
-              autoFocus={!openedFromAccount && !forceAutoFocusOnMemoField}
-              onChange={onChangeAccount}
-              value={account}
-              filter={accountFilter}
-            />
-          </Box>
-
-          {SendStepRecipientFromSelector && transaction ? (
-            <SendStepRecipientFromSelector
-              account={mainAccount}
-              transaction={transaction}
-              onChange={onChangeTransaction}
-            />
-          ) : null}
-
-          {extensions && hasProblematicExtension(extensions) ? (
-            <Alert data-testid="spl-2022-problematic-extension" type="warning" small={true}>
-              <Trans i18nKey="send.steps.details.splExtensionsWarning">
-                <Link type="color" onClick={openSplTokenExtensionsArticle} />
-              </Trans>
-            </Alert>
-          ) : null}
-          {stuckAccountAndOperation ? (
-            <EditOperationPanel
-              operation={stuckAccountAndOperation.operation}
-              account={stuckAccountAndOperation.account}
-              parentAccount={stuckAccountAndOperation.parentAccount}
-            />
-          ) : null}
-          <StepRecipientSeparator />
-          {isReady && (
-            <>
-              <RecipientField
-                status={status}
-                autoFocus={openedFromAccount && !forceAutoFocusOnMemoField}
-                account={mainAccount}
-                transaction={transaction}
-                onChangeTransaction={onChangeTransaction}
-                t={t}
-                initValue={maybeRecipient}
-                resetInitValue={onResetMaybeRecipient}
-              />
-              <SendRecipientFields
-                account={mainAccount}
-                parentAccount={parentAccount}
-                status={status}
-                transaction={transaction}
-                onChange={onChangeTransaction}
-                autoFocus={forceAutoFocusOnMemoField}
-              />
-            </>
-          )}
-        </>
+        <RecipientStepContent
+          t={t}
+          account={account}
+          mainAccount={mainAccount}
+          parentAccount={parentAccount}
+          transaction={transaction}
+          status={status}
+          error={error}
+          openedFromAccount={openedFromAccount}
+          forceAutoFocusOnMemoField={forceAutoFocusOnMemoField}
+          accountFilter={accountFilter}
+          stuckAccountAndOperation={stuckAccountAndOperation}
+          SendStepRecipientFromSelector={specific?.SendStepRecipientFromSelector}
+          onChangeAccount={onChangeAccount}
+          onChangeTransaction={onChangeTransaction}
+          maybeRecipient={maybeRecipient}
+          onResetMaybeRecipient={onResetMaybeRecipient}
+        />
       )}
     </Box>
   );

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8910,6 +8910,20 @@
       "privateBalanceTooltip": "Balance that is hidden from the public"
     },
     "shielded": {
+      "send": {
+        "transferFrom": {
+          "label": "Transfer from",
+          "public": {
+            "title": "Public balance",
+            "subtitle": "Transparent"
+          },
+          "private": {
+            "title": "Private balance",
+            "subtitle": "Orchard",
+            "unavailable": "Private balance unavailable"
+          }
+        }
+      },
       "state": {
         "showBalance": "Show balance",
         "startSync": "Start sync",

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8919,7 +8919,7 @@
           },
           "private": {
             "title": "Private balance",
-            "subtitle": "Orchard",
+            "subtitle": "Shielded",
             "unavailable": "Private balance unavailable"
           }
         }

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/types.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/types.ts
@@ -186,6 +186,8 @@ export type ZcashTransferType =
 
 export type ZcashTransaction = Transaction & {
   transferType: ZcashTransferType;
+  /** Source balance pool selected on the Recipient step. */
+  sender?: "public" | "private";
   /** Optional 512-byte memo field for shielded outputs. */
   memo?: string;
   // Coin selection results (populated by prepareTransaction)


### PR DESCRIPTION
Add a Zcash-specific "Transfer from" selector that lets the user choose between their Public (transparent) and Private (Orchard) balance on the send Recipient step. The selection is stored on the transaction as `sender` and drives the downstream transfer type.

- New self-gating ZcashTransferFromSelector (zcash + zcashShielded flag)
- Rendered between "Account to debit" and the recipient address
- Public selected by default; Private never disabled; FVK-absent hint
- Extend ZcashTransaction with an optional `sender` field

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ledger-live-desktop
  - @ledgerhq/coin-bitcoin

### 📝 Description

Add a "Transfer from" source selector (Public / Private) to the Zcash send Recipient step

Video:

https://github.com/user-attachments/assets/69f9ad6b-f0bf-4fef-a4c7-4a083c0c594f



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-27237


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
