### PR TITLE
chore: check real affected packages on lockfile changes

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,1 @@
+domain/entity/currency-crypto/scripts/generate-currencies.mts

--- a/nx.workspace.json
+++ b/nx.workspace.json
@@ -1,12 +1,15 @@
 {
+  "pluginsConfig": {
+    "@nx/js": {
+      "projectsAffectedByDependencyUpdates": "auto"
+    }
+  },
   "namedInputs": {
     "sharedGlobals": [
       "{workspaceRoot}/nx.json",
       "{workspaceRoot}/nx.workspace.json",
       "{workspaceRoot}/nx.s3.defaults.json",
-      "{workspaceRoot}/sonar-project.properties",
       "{workspaceRoot}/tsconfig.base.json",
-      "{workspaceRoot}/pnpm-lock.yaml",
       "{workspaceRoot}/package.json",
       "{workspaceRoot}/pnpm-workspace.yaml"
     ],

--- a/package.json
+++ b/package.json
@@ -241,6 +241,7 @@
     "@ledgerhq/create-release-hash": "workspace:*",
     "@ledgerhq/lumen-design-core": "catalog:",
     "@ledgerhq/pnpm-utils": "workspace:*",
+    "@nx/js": "22.5.1",
     "@nx/s3-cache": "5.0.2",
     "@react-native-community/cli": "15.1.0",
     "@react-native-community/cli-platform-android": "15.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -604,6 +604,9 @@ importers:
       '@ledgerhq/pnpm-utils':
         specifier: workspace:*
         version: link:tools/pnpm-utils
+      '@nx/js':
+        specifier: 22.5.1
+        version: 22.5.1(nx@22.5.1)
       '@nx/s3-cache':
         specifier: 5.0.2
         version: 5.0.2(nx@22.5.1)
@@ -17896,6 +17899,19 @@ packages:
     peerDependencies:
       nx: '>= 21 <= 23 || ^22.0.0-0'
 
+  '@nx/devkit@22.5.1':
+    resolution: {integrity: sha512-1ZJ8pCB+6EWC8X6q8tfBweg92WzFAwliBhtBkOPP8Li8GQq71ulPWRdY4lDd5pH3Ea1zKqhOtBKWdOlyDPOKYA==}
+    peerDependencies:
+      nx: '>= 21 <= 23 || ^22.0.0-0'
+
+  '@nx/js@22.5.1':
+    resolution: {integrity: sha512-g/0x9P7e2KDsY5po9RxvsNR2Z8xPWpWqTs82gll1G/h5Jot2QJ6oIuZTfjdHramVXWd6pi6KoruxThnNv5DmYQ==}
+    peerDependencies:
+      verdaccio: ^6.0.5
+    peerDependenciesMeta:
+      verdaccio:
+        optional: true
+
   '@nx/key-darwin-arm64@5.0.2':
     resolution: {integrity: sha512-gIe8Cl0sE/BZQxvrmam7tZg3hKbBn7Skt25yRMzf6E8UajomG8IGefDv7wM8SVOTA8495viAnqbidM5iNzq4gQ==}
     engines: {node: '>= 10'}
@@ -18017,6 +18033,9 @@ packages:
     deprecated: This package has been deprecated. See https://nx.dev/docs/reference/deprecated/self-hosted-cache-packages for details
     peerDependencies:
       nx: '>= 18 < 23'
+
+  '@nx/workspace@22.5.1':
+    resolution: {integrity: sha512-IZJ440ITiNpswacrTGGpo46adOszLAAZM9RYYvQg5ak8kZDmmrskTm0SWWVgZCuiJazw8s23vqDLQ07TN/t1NQ==}
 
   '@octokit/auth-token@4.0.0':
     resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
@@ -24705,6 +24724,11 @@ packages:
       '@babel/core': ^7.12.0
       webpack: '>=5'
 
+  babel-plugin-const-enum@1.2.0:
+    resolution: {integrity: sha512-o1m/6iyyFnp9MRsK1dHF3bneqyf3AlM2q3A/YbgQr2pCat6B6XJVDv2TXqzfY2RYUi4mak6WAksSBPlyYGx9dg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   babel-plugin-istanbul@6.1.1:
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
     engines: {node: '>=8'}
@@ -24775,6 +24799,15 @@ packages:
 
   babel-plugin-transform-inline-environment-variables@0.4.4:
     resolution: {integrity: sha512-bJILBtn5a11SmtR2j/3mBOjX4K3weC6cq+NNZ7hG22wCAqpc3qtj/iN7dSe9HDiS46lgp1nHsQgeYrea/RUe+g==}
+
+  babel-plugin-transform-typescript-metadata@0.3.2:
+    resolution: {integrity: sha512-mWEvCQTgXQf48yDqgN7CH50waTyYBeP2Lpqx4nNWab9sxEpdXVeKgfj1qYI2/TgUPQtNFZ85i3PemRtnXVYYJg==}
+    peerDependencies:
+      '@babel/core': ^7
+      '@babel/traverse': ^7
+    peerDependenciesMeta:
+      '@babel/traverse':
+        optional: true
 
   babel-preset-current-node-syntax@1.2.0:
     resolution: {integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==}
@@ -25747,6 +25780,10 @@ packages:
 
   colorspace@1.1.4:
     resolution: {integrity: sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==}
+
+  columnify@1.6.0:
+    resolution: {integrity: sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q==}
+    engines: {node: '>=8.0.0'}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -26922,6 +26959,11 @@ packages:
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
+  detect-port@1.6.1:
+    resolution: {integrity: sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==}
+    engines: {node: '>= 4.0.0'}
+    hasBin: true
 
   detox-allure2-adapter@1.0.0-alpha.42:
     resolution: {integrity: sha512-T5JzILSvjj4ZNgb9SaswSOtJFX3q0l3IPDVNx/4S3rvPu9kawTpHjVQS58Bbd6Dt5eYhDl7kYLMctOhLA6AvMw==}
@@ -35344,6 +35386,9 @@ packages:
 
   source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
+
+  source-map-support@0.5.19:
+    resolution: {integrity: sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==}
 
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
@@ -46603,6 +46648,52 @@ snapshots:
       tslib: 2.6.2
       yargs-parser: 21.1.1
 
+  '@nx/devkit@22.5.1(nx@22.5.1)':
+    dependencies:
+      '@zkochan/js-yaml': 0.0.7
+      ejs: 3.1.10
+      enquirer: 2.3.6
+      minimatch: 10.1.1
+      nx: 22.5.1
+      semver: 7.8.1
+      tslib: 2.6.2
+      yargs-parser: 21.1.1
+
+  '@nx/js@22.5.1(nx@22.5.1)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/plugin-proposal-decorators': 7.24.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-runtime': 7.25.9(@babel/core@7.28.5)
+      '@babel/preset-env': 7.28.5(@babel/core@7.28.5)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.5)
+      '@babel/runtime': 7.28.4
+      '@nx/devkit': 22.5.1(nx@22.5.1)
+      '@nx/workspace': 22.5.1
+      '@zkochan/js-yaml': 0.0.7
+      babel-plugin-const-enum: 1.2.0(@babel/core@7.28.5)
+      babel-plugin-macros: 3.1.0
+      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.28.5)
+      chalk: 4.1.2
+      columnify: 1.6.0
+      detect-port: 1.6.1
+      ignore: 5.3.1
+      js-tokens: 4.0.0
+      jsonc-parser: 3.2.0
+      npm-run-path: 4.0.1
+      picocolors: 1.1.1
+      picomatch: 4.0.2
+      semver: 7.8.1
+      source-map-support: 0.5.19
+      tinyglobby: 0.2.15
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@babel/traverse'
+      - '@swc-node/register'
+      - '@swc/core'
+      - nx
+      - supports-color
+
   '@nx/key-darwin-arm64@5.0.2':
     optional: true
 
@@ -46693,6 +46784,21 @@ snapshots:
       tar-stream: 3.1.7
     transitivePeerDependencies:
       - aws-crt
+
+  '@nx/workspace@22.5.1':
+    dependencies:
+      '@nx/devkit': 22.5.1(nx@22.5.1)
+      '@zkochan/js-yaml': 0.0.7
+      chalk: 4.1.2
+      enquirer: 2.3.6
+      nx: 22.5.1
+      picomatch: 4.0.2
+      semver: 7.8.1
+      tslib: 2.6.2
+      yargs-parser: 21.1.1
+    transitivePeerDependencies:
+      - '@swc-node/register'
+      - '@swc/core'
 
   '@octokit/auth-token@4.0.0': {}
 
@@ -56259,6 +56365,15 @@ snapshots:
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
 
+  babel-plugin-const-enum@1.2.0(@babel/core@7.28.5):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-istanbul@6.1.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -56399,6 +56514,11 @@ snapshots:
       - '@babel/core'
 
   babel-plugin-transform-inline-environment-variables@0.4.4: {}
+
+  babel-plugin-transform-typescript-metadata@0.3.2(@babel/core@7.28.5):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   babel-preset-current-node-syntax@1.2.0:
     dependencies:
@@ -57713,6 +57833,11 @@ snapshots:
       color: 3.2.1
       text-hex: 1.0.0
 
+  columnify@1.6.0:
+    dependencies:
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -58786,6 +58911,13 @@ snapshots:
   detect-node-es@1.1.0: {}
 
   detect-node@2.1.0: {}
+
+  detect-port@1.6.1:
+    dependencies:
+      address: 1.2.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   detox-allure2-adapter@1.0.0-alpha.42(patch_hash=c0c5e6419e53a25ed902cac4ce3608f467d0332b34c90b669fed2089e2bf97ba)(detox@20.51.1(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(@jest/types@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(typescript@6.0.2))))(jest-allure2-reporter@2.2.8(@jest/reporters@30.2.0)(@jest/types@30.2.0)(jest-docblock@30.2.0)(jest-environment-node@30.2.0)(jest@30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(typescript@6.0.2)))):
     dependencies:
@@ -70436,6 +70568,11 @@ snapshots:
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.13:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map-support@0.5.19:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1

--- a/scripts/check-dependency-affected.mjs
+++ b/scripts/check-dependency-affected.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { createInterface } from "node:readline/promises";
+import { fileURLToPath } from "node:url";
+
+const defaultDependency = "react";
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const lockfilePath = path.join(repoRoot, "pnpm-lock.yaml");
+const originalLockfile = fs.readFileSync(lockfilePath, "utf8");
+const dependency = await getDependencyName();
+
+["SIGINT", "SIGTERM"].forEach(signal =>
+  process.once(signal, () => {
+    console.log(`\nRestored pnpm-lock.yaml after ${signal}`);
+    restoreAndExit(signal === "SIGINT" ? 130 : 143);
+  }),
+);
+
+try {
+  console.log(`Temporarily changing ${dependency} versions in pnpm-lock.yaml`);
+  editLockfile(bumpDep(originalLockfile, dependency));
+
+  console.log("\nRunning: pnpm nx show projects --affected --base=HEAD\n");
+  runNxAffected()
+    .on("close", exitCode => {
+      console.log("\nRestored pnpm-lock.yaml");
+      restoreAndExit(exitCode ?? 1);
+    })
+    .on("error", error => {
+      console.error(`Failed to start pnpm: ${error.message}`);
+      restoreAndExit(1);
+    });
+} catch (error) {
+  console.error(error.message);
+  restoreAndExit(1);
+}
+
+async function getDependencyName() {
+  const argDependency = process.argv[2]?.trim();
+  if (argDependency) return argDependency;
+
+  const readline = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    const answer = await readline.question(`Dependency to check (${defaultDependency}): `);
+    return answer.trim() || defaultDependency;
+  } finally {
+    readline.close();
+  }
+}
+
+function bumpDep(value, dependencyName) {
+  const escapedDep = escapeRegExp(dependencyName);
+  const depName = `(?:'${escapedDep}'|"${escapedDep}"|${escapedDep})`;
+  const oneLineRegExp = new RegExp(`^( {2}${depName}: +\\D*\\d+\\.\\d+\\.)(\\d+)$`, "gm");
+  const blockRegExp = new RegExp(
+    `^(\\s+${depName}:\\n\\s+specifier: .*\\n\\s+version: +\\D*\\d+\\.\\d+\\.)(\\d+)$`,
+    "gm",
+  );
+  const bumpPatch = (_, prefix, patch) => `${prefix}${Number(patch) + 1}`;
+
+  const bumped = value.replaceAll(oneLineRegExp, bumpPatch).replaceAll(blockRegExp, bumpPatch);
+
+  if (bumped === value) {
+    throw new Error(`Could not find a bumpable ${dependencyName} entry in pnpm-lock.yaml`);
+  }
+
+  return bumped;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function editLockfile(value) {
+  fs.writeFileSync(lockfilePath, value);
+}
+
+function restoreAndExit(code) {
+  fs.writeFileSync(lockfilePath, originalLockfile);
+  process.exit(code);
+}
+
+function runNxAffected() {
+  return spawn("pnpm", ["nx", "show", "projects", "--affected", "--base=HEAD"], {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: "inherit",
+  });
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Currently, `nx show projects --affected ...` will return all files when anything is changed in `pnpm-lock.yaml`. This PR should fix this behaviour and add a script to check which dependency affects which packages (mostly to verify the correct behaviour of the command).

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
