### PR TITLE
[LWDM] baby staking craft transaction

### DIFF
--- a/.changeset/lazy-otters-wander.md
+++ b/.changeset/lazy-otters-wander.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-cosmos": minor
+---
+
+Build Babylon (BABY) staking transactions by wrapping delegate/undelegate/redelegate messages in the x/epoching MsgWrapped* envelope (amino + proto). Chain-specific staking message types now live on the chain classes (Babylon, Zenrock) instead of inline currency-id checks.

--- a/libs/coin-modules/coin-cosmos/src/buildTransaction.ts
+++ b/libs/coin-modules/coin-cosmos/src/buildTransaction.ts
@@ -1,10 +1,9 @@
+import { AminoMsgSend, AminoMsgWithdrawDelegatorReward } from "@cosmjs/stargate";
 import {
-  AminoMsgBeginRedelegate,
-  AminoMsgDelegate,
-  AminoMsgSend,
-  AminoMsgUndelegate,
-  AminoMsgWithdrawDelegatorReward,
-} from "@cosmjs/stargate";
+  MsgWrappedBeginRedelegate,
+  MsgWrappedDelegate,
+  MsgWrappedUndelegate,
+} from "@keplr-wallet/proto-types/babylon/epoching/v1/tx";
 import { PubKey } from "@keplr-wallet/proto-types/cosmos/crypto/secp256k1/keys";
 import { AuthInfo, Fee } from "@keplr-wallet/proto-types/cosmos/tx/v1beta1/tx";
 import type { Account } from "@ledgerhq/types-live";
@@ -17,6 +16,7 @@ import {
 } from "cosmjs-types/cosmos/staking/v1beta1/tx";
 import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
 import { TxBody, TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import CosmosBase, { StakingMessageType } from "./chain/cosmosBase";
 import { Transaction } from "./types";
 
 type ProtoMsg = {
@@ -29,24 +29,34 @@ type AminoMsg = {
   readonly value: any;
 };
 
-export interface AminoZenrockMsgDelegate extends Omit<AminoMsgDelegate, "type"> {
-  readonly type: "zrchain/MsgDelegate";
-}
-
-export interface AminoZenrockMsgBeginRedelegate extends Omit<AminoMsgBeginRedelegate, "type"> {
-  readonly type: "zrchain/MsgBeginRedelegate";
-}
-
-export interface AminoZenrockMsgUndelegate extends Omit<AminoMsgUndelegate, "type"> {
-  readonly type: "zrchain/MsgUndelegate";
-}
-
 export const txToMessages = (
   account: Account,
   transaction: Transaction,
+  chain: CosmosBase,
 ): { aminoMsgs: AminoMsg[]; protoMsgs: ProtoMsg[] } => {
   const aminoMsgs: Array<AminoMsg> = [];
   const protoMsgs: Array<ProtoMsg> = [];
+  const { stakingMessages } = chain;
+
+  const pushStakingMsg = <T>(
+    { aminoType, protoTypeUrl }: StakingMessageType,
+    aminoValue: object,
+    protoValue: T,
+    encodeInner: (value: T) => { finish: () => Uint8Array },
+    encodeWrapped: (value: { msg: T }) => { finish: () => Uint8Array },
+  ): void => {
+    aminoMsgs.push({
+      type: aminoType,
+      value: stakingMessages.wrapped ? { msg: aminoValue } : aminoValue,
+    });
+    protoMsgs.push({
+      typeUrl: protoTypeUrl,
+      value: stakingMessages.wrapped
+        ? encodeWrapped({ msg: protoValue }).finish()
+        : encodeInner(protoValue).finish(),
+    });
+  };
+
   switch (transaction.mode) {
     case "send":
       if (transaction.recipient && transaction.amount.gt(0)) {
@@ -85,35 +95,25 @@ export const txToMessages = (
       if (transaction.validators && transaction.validators.length > 0) {
         const validator = transaction.validators[0];
         if (validator && validator.address && transaction.amount.gt(0)) {
-          const aminoMsg: AminoMsgDelegate | AminoZenrockMsgDelegate = {
-            type:
-              account.currency.id === "zenrock" ? "zrchain/MsgDelegate" : "cosmos-sdk/MsgDelegate",
-            value: {
+          const amount = {
+            denom: account.currency.units[1].code,
+            amount: transaction.amount.toFixed(),
+          };
+          pushStakingMsg(
+            stakingMessages.delegate,
+            {
               delegator_address: account.freshAddress,
               validator_address: validator.address,
-              amount: {
-                denom: account.currency.units[1].code,
-                amount: transaction.amount.toFixed(),
-              },
+              amount,
             },
-          };
-          aminoMsgs.push(aminoMsg);
-
-          // PROTO MESSAGE
-          protoMsgs.push({
-            typeUrl:
-              account.currency.id === "zenrock"
-                ? "/zrchain.validation.MsgDelegate"
-                : "/cosmos.staking.v1beta1.MsgDelegate",
-            value: MsgDelegate.encode({
+            {
               delegatorAddress: account.freshAddress,
               validatorAddress: validator.address,
-              amount: {
-                denom: account.currency.units[1].code,
-                amount: transaction.amount.toFixed(),
-              },
-            }).finish(),
-          });
+              amount,
+            },
+            MsgDelegate.encode,
+            MsgWrappedDelegate.encode,
+          );
         }
       }
       break;
@@ -127,39 +127,27 @@ export const txToMessages = (
         transaction.validators[0].amount.gt(0)
       ) {
         const validator = transaction.validators[0];
-        const aminoMsg: AminoMsgBeginRedelegate | AminoZenrockMsgBeginRedelegate = {
-          type:
-            account.currency.id === "zenrock"
-              ? "zrchain/MsgBeginRedelegate"
-              : "cosmos-sdk/MsgBeginRedelegate",
-          value: {
+        const amount = {
+          denom: account.currency.units[1].code,
+          amount: validator.amount.toFixed(),
+        };
+        pushStakingMsg(
+          stakingMessages.beginRedelegate,
+          {
             delegator_address: account.freshAddress,
             validator_src_address: transaction.sourceValidator,
             validator_dst_address: validator.address,
-            amount: {
-              denom: account.currency.units[1].code,
-              amount: validator.amount.toFixed(),
-            },
+            amount,
           },
-        };
-        aminoMsgs.push(aminoMsg);
-
-        // PROTO MESSAGE
-        protoMsgs.push({
-          typeUrl:
-            account.currency.id === "zenrock"
-              ? "/zrchain.validation.MsgBeginRedelegate"
-              : "/cosmos.staking.v1beta1.MsgBeginRedelegate",
-          value: MsgBeginRedelegate.encode({
+          {
             delegatorAddress: account.freshAddress,
             validatorSrcAddress: transaction.sourceValidator,
             validatorDstAddress: validator.address,
-            amount: {
-              denom: account.currency.units[1].code,
-              amount: validator.amount.toFixed(),
-            },
-          }).finish(),
-        });
+            amount,
+          },
+          MsgBeginRedelegate.encode,
+          MsgWrappedBeginRedelegate.encode,
+        );
       }
       break;
 
@@ -167,37 +155,25 @@ export const txToMessages = (
       if (transaction.validators && transaction.validators.length > 0) {
         const validator = transaction.validators[0];
         if (validator && validator.address && validator.amount.gt(0)) {
-          const aminoMsg: AminoMsgUndelegate | AminoZenrockMsgUndelegate = {
-            type:
-              account.currency.id === "zenrock"
-                ? "zrchain/MsgUndelegate"
-                : "cosmos-sdk/MsgUndelegate",
-            value: {
+          const amount = {
+            denom: account.currency.units[1].code,
+            amount: validator.amount.toFixed(),
+          };
+          pushStakingMsg(
+            stakingMessages.undelegate,
+            {
               delegator_address: account.freshAddress,
               validator_address: validator.address,
-              amount: {
-                denom: account.currency.units[1].code,
-                amount: validator.amount.toFixed(),
-              },
+              amount,
             },
-          };
-          aminoMsgs.push(aminoMsg);
-
-          // PROTO MESSAGE
-          protoMsgs.push({
-            typeUrl:
-              account.currency.id === "zenrock"
-                ? "/zrchain.validation.MsgUndelegate"
-                : "/cosmos.staking.v1beta1.MsgUndelegate",
-            value: MsgUndelegate.encode({
+            {
               delegatorAddress: account.freshAddress,
               validatorAddress: validator.address,
-              amount: {
-                denom: account.currency.units[1].code,
-                amount: validator.amount.toFixed(),
-              },
-            }).finish(),
-          });
+              amount,
+            },
+            MsgUndelegate.encode,
+            MsgWrappedUndelegate.encode,
+          );
         }
       }
       break;
@@ -235,6 +211,11 @@ export const txToMessages = (
         transaction.validators[0].amount.gt(0)
       ) {
         const validator = transaction.validators[0];
+        if (stakingMessages.wrapped) {
+          // compound's embedded delegate isn't epoching-wrapped yet (LIVE-31837); fail fast on
+          // babylon rather than sign a bare cosmos-sdk delegate the chain rejects.
+          throw new Error(`claimRewardCompound is not supported on ${account.currency.id}`);
+        }
         // AMINO MESSAGES
         const aminoWithdrawRewardMsg: AminoMsgWithdrawDelegatorReward = {
           type: "cosmos-sdk/MsgWithdrawDelegationReward",
@@ -243,9 +224,8 @@ export const txToMessages = (
             validator_address: validator.address,
           },
         };
-        const aminoDelegateMsg: AminoMsgDelegate | AminoZenrockMsgDelegate = {
-          type:
-            account.currency.id === "zenrock" ? "zrchain/MsgDelegate" : "cosmos-sdk/MsgDelegate",
+        const aminoDelegateMsg: AminoMsg = {
+          type: stakingMessages.delegate.aminoType,
           value: {
             delegator_address: account.freshAddress,
             validator_address: validator.address,
@@ -266,10 +246,7 @@ export const txToMessages = (
           }).finish(),
         });
         protoMsgs.push({
-          typeUrl:
-            account.currency.id === "zenrock"
-              ? "/zrchain.validation.MsgDelegate"
-              : "/cosmos.staking.v1beta1.MsgDelegate",
+          typeUrl: stakingMessages.delegate.protoTypeUrl,
           value: MsgDelegate.encode({
             delegatorAddress: account.freshAddress,
             validatorAddress: validator.address,

--- a/libs/coin-modules/coin-cosmos/src/buildTransaction.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/buildTransaction.unit.test.ts
@@ -1,3 +1,11 @@
+import { AminoMsg, makeSignDoc, serializeSignDoc } from "@cosmjs/amino";
+import { ExtendedSecp256k1Signature, Secp256k1, sha256 } from "@cosmjs/crypto";
+import {
+  MsgWrappedBeginRedelegate,
+  MsgWrappedDelegate,
+  MsgWrappedUndelegate,
+  protobufPackage as epochingPackage,
+} from "@keplr-wallet/proto-types/babylon/epoching/v1/tx";
 import { Fee } from "@keplr-wallet/proto-types/cosmos/tx/v1beta1/tx";
 import BigNumber from "bignumber.js";
 import { MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx";
@@ -10,9 +18,13 @@ import {
 import { TxBody, TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
 
 import { buildTransaction, txToMessages } from "./buildTransaction";
+import Babylon, { BABYLON_STAKING_MESSAGES } from "./chain/Babylon";
+import Cosmos from "./chain/Cosmos";
+import Zenrock from "./chain/Zenrock";
 import { CosmosAccount, CosmosDelegationInfo, Transaction } from "./types";
 
 const veryBigNumber = new BigNumber(3333300000000000000000);
+const cosmos = new Cosmos();
 
 describe("txToMessages", () => {
   const transaction: Transaction = {} as Transaction;
@@ -30,7 +42,7 @@ describe("txToMessages", () => {
       it("should return a MsgSend message if transaction is complete", () => {
         transaction.recipient = "address";
         transaction.amount = new BigNumber(1000);
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         const [aminoMsg] = aminoMsgs;
         expect(aminoMsg.type).toContain("MsgSend");
         expect(aminoMsg.value.to_address).toEqual(transaction.recipient);
@@ -42,7 +54,7 @@ describe("txToMessages", () => {
       it("should not include exponential part on big numbers", () => {
         transaction.recipient = "address";
         transaction.amount = veryBigNumber;
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         const [aminoMsg] = aminoMsgs;
         expect(aminoMsg.value.amount[0].amount.includes("e")).toEqual(false);
       });
@@ -50,25 +62,19 @@ describe("txToMessages", () => {
       it("should return no message if recipient isn't defined", () => {
         transaction.amount = new BigNumber(10);
         transaction.recipient = "";
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
 
       it("should return no message if amount is zero", () => {
         transaction.amount = new BigNumber(0);
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
 
       it("should return no message if amount is negative", () => {
         transaction.amount = new BigNumber(-10);
-        const { aminoMsgs } = txToMessages(account, transaction);
-        expect(aminoMsgs.length).toEqual(0);
-      });
-
-      it("should return no message if amount is negative", () => {
-        transaction.amount = new BigNumber(-10);
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
     });
@@ -77,7 +83,7 @@ describe("txToMessages", () => {
       it("should return a MsgSend message if transaction is complete", () => {
         transaction.recipient = "address";
         transaction.amount = new BigNumber(1000);
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         const [protoMsg] = protoMsgs;
         const value = MsgSend.decode(protoMsg.value);
         expect(protoMsg.typeUrl).toContain("MsgSend");
@@ -90,7 +96,7 @@ describe("txToMessages", () => {
       it("should not include exponential part on big numbers", () => {
         transaction.recipient = "address";
         transaction.amount = veryBigNumber;
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         const [protoMsg] = protoMsgs;
         const value = MsgSend.decode(protoMsg.value);
         expect(value.amount[0].amount?.includes("e")).toEqual(false);
@@ -99,19 +105,19 @@ describe("txToMessages", () => {
       it("should return no message if recipient isn't defined", () => {
         transaction.amount = new BigNumber(10);
         transaction.recipient = "";
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
 
       it("should return no message if amount is zero", () => {
         transaction.amount = new BigNumber(0);
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
 
       it("should return no message if amount is negative", () => {
         transaction.amount = new BigNumber(-10);
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
     });
@@ -131,7 +137,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(100),
           } as CosmosDelegationInfo,
         ];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         const [message] = aminoMsgs;
         expect(message.type).toContain("MsgDelegate");
         expect(message.value.validator_address).toEqual(transaction.validators[0].address);
@@ -149,7 +155,7 @@ describe("txToMessages", () => {
             amount: veryBigNumber,
           } as CosmosDelegationInfo,
         ];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         const [message] = aminoMsgs;
         expect(message.value.amount?.amount.includes("e")).toEqual(false);
       });
@@ -157,26 +163,26 @@ describe("txToMessages", () => {
       it("should return no message if tx has a 0 amount", () => {
         transaction.amount = new BigNumber(0);
         transaction.validators = [{ address: "realAddressTrustMe" } as CosmosDelegationInfo];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
 
       it("should return no message if tx has a negative amount", () => {
         transaction.amount = new BigNumber(-1);
         transaction.validators = [{ address: "realAddressTrustMe" } as CosmosDelegationInfo];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
 
       it("should return no message if validators has no address", () => {
         transaction.validators = [{} as CosmosDelegationInfo];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
 
       it("should return no message if validators aren't defined", () => {
         transaction.validators = [];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
     });
@@ -190,7 +196,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(100),
           } as CosmosDelegationInfo,
         ];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         const [message] = protoMsgs;
         expect(message.typeUrl).toContain("MsgDelegate");
         const value = MsgDelegate.decode(message.value);
@@ -208,7 +214,7 @@ describe("txToMessages", () => {
             amount: veryBigNumber,
           } as CosmosDelegationInfo,
         ];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         const [message] = protoMsgs;
         const value = MsgDelegate.decode(message.value);
         expect(value.amount?.amount.includes("e")).toEqual(false);
@@ -217,26 +223,26 @@ describe("txToMessages", () => {
       it("should return no message if tx has a 0 amount", () => {
         transaction.amount = new BigNumber(0);
         transaction.validators = [{ address: "realAddressTrustMe" } as CosmosDelegationInfo];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
 
       it("should return no message if tx has a negative amount", () => {
         transaction.amount = new BigNumber(-1);
         transaction.validators = [{ address: "realAddressTrustMe" } as CosmosDelegationInfo];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
 
       it("should return no message if validators has no address", () => {
         transaction.validators = [{} as CosmosDelegationInfo];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
 
       it("should return no message if validators aren't defined", () => {
         transaction.validators = [];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
     });
@@ -256,7 +262,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(100),
           } as CosmosDelegationInfo,
         ];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         const [message] = aminoMsgs;
         expect(message.type).toContain("MsgUndelegate");
         expect(message.value.validator_address).toEqual(transaction.validators[0].address);
@@ -273,14 +279,14 @@ describe("txToMessages", () => {
             amount: veryBigNumber,
           } as CosmosDelegationInfo,
         ];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         const [message] = aminoMsgs;
         expect(message.value.amount?.amount.includes("e")).toEqual(false);
       });
 
       it("should return no message if validators aren't defined", () => {
         transaction.validators = [];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
 
@@ -291,7 +297,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(100),
           } as CosmosDelegationInfo,
         ];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
 
@@ -302,7 +308,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(0),
           } as CosmosDelegationInfo,
         ];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
 
@@ -313,7 +319,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(-10),
           } as CosmosDelegationInfo,
         ];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
     });
@@ -327,7 +333,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(100),
           } as CosmosDelegationInfo,
         ];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         const [message] = protoMsgs;
         expect(message.typeUrl).toContain("MsgUndelegate");
         const value = MsgUndelegate.decode(message.value);
@@ -345,7 +351,7 @@ describe("txToMessages", () => {
             amount: veryBigNumber,
           } as CosmosDelegationInfo,
         ];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         const [message] = protoMsgs;
         const value = MsgUndelegate.decode(message.value);
         expect(value.amount?.amount.includes("e")).toEqual(false);
@@ -353,7 +359,7 @@ describe("txToMessages", () => {
 
       it("should return no message if validators aren't defined", () => {
         transaction.validators = [];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
 
@@ -364,7 +370,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(100),
           } as CosmosDelegationInfo,
         ];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
 
@@ -375,7 +381,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(0),
           } as CosmosDelegationInfo,
         ];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
 
@@ -386,7 +392,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(-10),
           } as CosmosDelegationInfo,
         ];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
     });
@@ -406,7 +412,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(100),
           } as CosmosDelegationInfo,
         ];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         const [message] = aminoMsgs;
         expect(message.type).toContain("MsgBeginRedelegate");
         expect(message.value.validator_src_address).toEqual(transaction.sourceValidator);
@@ -424,7 +430,7 @@ describe("txToMessages", () => {
             amount: veryBigNumber,
           } as CosmosDelegationInfo,
         ];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         const [message] = aminoMsgs;
         expect(message.value.amount.amount.includes("e")).toEqual(false);
       });
@@ -437,7 +443,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(100),
           } as CosmosDelegationInfo,
         ];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
 
@@ -448,7 +454,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(100),
           } as CosmosDelegationInfo,
         ];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
       it("should return no message if validator amount is 0", () => {
@@ -458,7 +464,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(0),
           } as CosmosDelegationInfo,
         ];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
       it("should return no message if validator amount is negative", () => {
@@ -468,7 +474,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(-10),
           } as CosmosDelegationInfo,
         ];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
     });
@@ -482,7 +488,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(100),
           } as CosmosDelegationInfo,
         ];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         const [message] = protoMsgs;
         expect(message.typeUrl).toContain("MsgBeginRedelegate");
         const value = MsgBeginRedelegate.decode(message.value);
@@ -501,7 +507,7 @@ describe("txToMessages", () => {
             amount: veryBigNumber,
           } as CosmosDelegationInfo,
         ];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         const [message] = protoMsgs;
         const value = MsgBeginRedelegate.decode(message.value);
         expect(value.amount?.amount.includes("e")).toEqual(false);
@@ -515,7 +521,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(100),
           } as CosmosDelegationInfo,
         ];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
 
@@ -526,7 +532,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(100),
           } as CosmosDelegationInfo,
         ];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
       it("should return no message if validator amount is 0", () => {
@@ -536,7 +542,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(0),
           } as CosmosDelegationInfo,
         ];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
       it("should return no message if validator amount is negative", () => {
@@ -546,7 +552,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(-10),
           } as CosmosDelegationInfo,
         ];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
     });
@@ -565,7 +571,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(1000),
           } as CosmosDelegationInfo,
         ];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         const [message] = aminoMsgs;
         expect(message.type).toContain("MsgWithdrawDelegationReward");
         expect(message.value.validator_address).toEqual(transaction.validators[0].address);
@@ -574,7 +580,7 @@ describe("txToMessages", () => {
 
       it("should return no message if validator isn't defined", () => {
         transaction.validators = [];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
 
@@ -585,7 +591,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(1000),
           } as CosmosDelegationInfo,
         ];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
     });
@@ -598,7 +604,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(1000),
           } as CosmosDelegationInfo,
         ];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         const [message] = protoMsgs;
         expect(message.typeUrl).toContain("MsgWithdrawDelegatorReward");
         const value = MsgWithdrawDelegatorReward.decode(message.value);
@@ -608,7 +614,7 @@ describe("txToMessages", () => {
 
       it("should return no message if validator isn't defined", () => {
         transaction.validators = [];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
 
@@ -619,7 +625,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(1000),
           } as CosmosDelegationInfo,
         ];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
     });
@@ -638,7 +644,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(1000),
           } as CosmosDelegationInfo,
         ];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         const [withDrawMessage, delegateMessage] = aminoMsgs;
         expect(withDrawMessage.type).toContain("MsgWithdrawDelegationReward");
         expect(withDrawMessage.value.validator_address).toEqual(transaction.validators[0].address);
@@ -659,7 +665,7 @@ describe("txToMessages", () => {
             amount: veryBigNumber,
           } as CosmosDelegationInfo,
         ];
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         const [, delegateMessage] = aminoMsgs;
         expect(delegateMessage.value.amount.amount.includes("e")).toEqual(false);
       });
@@ -673,7 +679,7 @@ describe("txToMessages", () => {
             amount: new BigNumber(1000),
           } as CosmosDelegationInfo,
         ];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         const [withDrawMessage, delegateMessage] = protoMsgs;
         expect(withDrawMessage.typeUrl).toContain("MsgWithdrawDelegatorReward");
         const withDrawMessageValue = MsgWithdrawDelegatorReward.decode(withDrawMessage.value);
@@ -696,7 +702,7 @@ describe("txToMessages", () => {
             amount: veryBigNumber,
           } as CosmosDelegationInfo,
         ];
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         const [, delegateMessage] = protoMsgs;
         const delegateMessageValue = MsgDelegate.decode(delegateMessage.value);
         expect(delegateMessageValue.amount?.amount.includes("e")).toEqual(false);
@@ -709,7 +715,7 @@ describe("txToMessages", () => {
       it("should return no message", () => {
         // @ts-expect-error Random mode that isn't listed in typescript type
         transaction.mode = "RandomModeThatICreatedMyself";
-        const { aminoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs } = txToMessages(account, transaction, cosmos);
         expect(aminoMsgs.length).toEqual(0);
       });
     });
@@ -717,10 +723,307 @@ describe("txToMessages", () => {
       it("should return no message", () => {
         // @ts-expect-error Random mode that isn't listed in typescript type
         transaction.mode = "RandomModeThatICreatedMyself";
-        const { protoMsgs } = txToMessages(account, transaction);
+        const { protoMsgs } = txToMessages(account, transaction, cosmos);
         expect(protoMsgs.length).toEqual(0);
       });
     });
+  });
+});
+
+describe("txToMessages — babylon epoching wrapping", () => {
+  const babylon = new Babylon();
+  const delegatorAddress = "bbn1uwpws077a0a9pclapv3f2fyj5u0mlh6ewmds8n";
+  const validatorAddress = "bbnvaloper1004qg6w9zr3mc7yhd0ms9ar7l5x4tt00llac4t";
+  const account = {
+    freshAddress: delegatorAddress,
+    currency: { id: "babylon", units: [{ code: "BABY" }, { code: "ubbn" }] },
+  } as CosmosAccount;
+
+  describe("delegate", () => {
+    const transaction = {
+      mode: "delegate",
+      amount: new BigNumber(399180),
+      validators: [
+        { address: validatorAddress, amount: new BigNumber(399180) } as CosmosDelegationInfo,
+      ],
+    } as Transaction;
+
+    it("amino: type /babylon.epoching.v1.MsgWrappedDelegate with the inner MsgDelegate nested under `msg`", () => {
+      const { aminoMsgs } = txToMessages(account, transaction, babylon);
+      expect(aminoMsgs).toHaveLength(1);
+      const [msg] = aminoMsgs;
+      expect(msg.type).toEqual("/babylon.epoching.v1.MsgWrappedDelegate");
+      expect(msg.value.msg).toEqual({
+        delegator_address: delegatorAddress,
+        validator_address: validatorAddress,
+        amount: { denom: "ubbn", amount: "399180" },
+      });
+    });
+
+    it("proto: typeUrl /babylon.epoching.v1.MsgWrappedDelegate carrying the inner MsgDelegate", () => {
+      const { protoMsgs } = txToMessages(account, transaction, babylon);
+      expect(protoMsgs).toHaveLength(1);
+      const [msg] = protoMsgs;
+      expect(msg.typeUrl).toEqual("/babylon.epoching.v1.MsgWrappedDelegate");
+      const decoded = MsgWrappedDelegate.decode(msg.value);
+      expect(decoded.msg?.delegatorAddress).toEqual(delegatorAddress);
+      expect(decoded.msg?.validatorAddress).toEqual(validatorAddress);
+      expect(decoded.msg?.amount).toEqual({ denom: "ubbn", amount: "399180" });
+    });
+
+    it("proto: matches the exact wire bytes cross-checked against the live chain", () => {
+      const { protoMsgs } = txToMessages(account, transaction, babylon);
+      expect(Buffer.from(protoMsgs[0].value).toString("hex")).toEqual(
+        "0a6f0a2a62626e3175777077733037376130613970636c61707633663266796a3575306d6c683665776d6473386e123162626e76616c6f7065723130303471673677397a72336d6337796864306d73396172376c357834747430306c6c616334741a0e0a047562626e1206333939313830",
+      );
+    });
+  });
+
+  describe("undelegate", () => {
+    const transaction = {
+      mode: "undelegate",
+      amount: new BigNumber(500),
+      validators: [
+        { address: validatorAddress, amount: new BigNumber(500) } as CosmosDelegationInfo,
+      ],
+    } as Transaction;
+
+    it("amino: type /babylon.epoching.v1.MsgWrappedUndelegate with the inner nested under `msg`", () => {
+      const { aminoMsgs } = txToMessages(account, transaction, babylon);
+      const [msg] = aminoMsgs;
+      expect(msg.type).toEqual("/babylon.epoching.v1.MsgWrappedUndelegate");
+      expect(msg.value.msg).toEqual({
+        delegator_address: delegatorAddress,
+        validator_address: validatorAddress,
+        amount: { denom: "ubbn", amount: "500" },
+      });
+    });
+
+    it("proto: typeUrl /babylon.epoching.v1.MsgWrappedUndelegate carrying the inner MsgUndelegate", () => {
+      const { protoMsgs } = txToMessages(account, transaction, babylon);
+      const [msg] = protoMsgs;
+      expect(msg.typeUrl).toEqual("/babylon.epoching.v1.MsgWrappedUndelegate");
+      const decoded = MsgWrappedUndelegate.decode(msg.value);
+      expect(decoded.msg?.validatorAddress).toEqual(validatorAddress);
+      expect(decoded.msg?.amount).toEqual({ denom: "ubbn", amount: "500" });
+    });
+  });
+
+  describe("redelegate", () => {
+    const sourceValidator = "bbnvaloper1srcsrcsrcsrcsrcsrcsrcsrcsrcsrcsrcsrcsrc";
+    const transaction = {
+      mode: "redelegate",
+      sourceValidator,
+      amount: new BigNumber(700),
+      validators: [
+        { address: validatorAddress, amount: new BigNumber(700) } as CosmosDelegationInfo,
+      ],
+    } as Transaction;
+
+    it("amino: type /babylon.epoching.v1.MsgWrappedBeginRedelegate with the inner nested under `msg`", () => {
+      const { aminoMsgs } = txToMessages(account, transaction, babylon);
+      const [msg] = aminoMsgs;
+      expect(msg.type).toEqual("/babylon.epoching.v1.MsgWrappedBeginRedelegate");
+      expect(msg.value.msg).toEqual({
+        delegator_address: delegatorAddress,
+        validator_src_address: sourceValidator,
+        validator_dst_address: validatorAddress,
+        amount: { denom: "ubbn", amount: "700" },
+      });
+    });
+
+    it("proto: typeUrl /babylon.epoching.v1.MsgWrappedBeginRedelegate carrying the inner msg", () => {
+      const { protoMsgs } = txToMessages(account, transaction, babylon);
+      const [msg] = protoMsgs;
+      expect(msg.typeUrl).toEqual("/babylon.epoching.v1.MsgWrappedBeginRedelegate");
+      const decoded = MsgWrappedBeginRedelegate.decode(msg.value);
+      expect(decoded.msg?.validatorSrcAddress).toEqual(sourceValidator);
+      expect(decoded.msg?.validatorDstAddress).toEqual(validatorAddress);
+      expect(decoded.msg?.amount).toEqual({ denom: "ubbn", amount: "700" });
+    });
+  });
+
+  it("claimReward stays on the standard distribution msg (never wrapped)", () => {
+    const transaction = {
+      mode: "claimReward",
+      validators: [{ address: validatorAddress, amount: new BigNumber(0) } as CosmosDelegationInfo],
+    } as Transaction;
+    const { aminoMsgs, protoMsgs } = txToMessages(account, transaction, babylon);
+    expect(aminoMsgs[0].type).toEqual("cosmos-sdk/MsgWithdrawDelegationReward");
+    expect(protoMsgs[0].typeUrl).toEqual("/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward");
+  });
+
+  it("claimRewardCompound throws instead of building an unwrapped (chain-rejected) delegate", () => {
+    const transaction = {
+      mode: "claimRewardCompound",
+      validators: [
+        { address: validatorAddress, amount: new BigNumber(1000) } as CosmosDelegationInfo,
+      ],
+    } as Transaction;
+    expect(() => txToMessages(account, transaction, babylon)).toThrow(/not supported on babylon/);
+  });
+
+  it("uses the canonical x/epoching proto type URLs for all three staking msgs (anchored to the keplr package)", () => {
+    const canonical = (name: string) => `/${epochingPackage}.${name}`;
+    expect(BABYLON_STAKING_MESSAGES.delegate.protoTypeUrl).toEqual(canonical("MsgWrappedDelegate"));
+    expect(BABYLON_STAKING_MESSAGES.undelegate.protoTypeUrl).toEqual(
+      canonical("MsgWrappedUndelegate"),
+    );
+    expect(BABYLON_STAKING_MESSAGES.beginRedelegate.protoTypeUrl).toEqual(
+      canonical("MsgWrappedBeginRedelegate"),
+    );
+    // amino type == proto URL for all three (see Babylon.ts; proven for delegate by the fixture below).
+    expect(BABYLON_STAKING_MESSAGES.delegate.aminoType).toEqual(
+      BABYLON_STAKING_MESSAGES.delegate.protoTypeUrl,
+    );
+    expect(BABYLON_STAKING_MESSAGES.undelegate.aminoType).toEqual(
+      BABYLON_STAKING_MESSAGES.undelegate.protoTypeUrl,
+    );
+    expect(BABYLON_STAKING_MESSAGES.beginRedelegate.aminoType).toEqual(
+      BABYLON_STAKING_MESSAGES.beginRedelegate.protoTypeUrl,
+    );
+  });
+});
+
+describe("txToMessages — zenrock relabels staking msgs without wrapping", () => {
+  const zenrock = new Zenrock();
+  const validatorAddress = "zenvaloper1validatorvalidatorvalidatorvalida";
+  const account = {
+    freshAddress: "zen1delegatordelegatordelegatordelegator",
+    currency: { id: "zenrock", units: [{ code: "ZEN" }, { code: "uzen" }] },
+  } as CosmosAccount;
+
+  it("delegate: zrchain labels and a bare (non-wrapped) value", () => {
+    const transaction = {
+      mode: "delegate",
+      amount: new BigNumber(100),
+      validators: [
+        { address: validatorAddress, amount: new BigNumber(100) } as CosmosDelegationInfo,
+      ],
+    } as Transaction;
+    const { aminoMsgs, protoMsgs } = txToMessages(account, transaction, zenrock);
+    expect(aminoMsgs[0].type).toEqual("zrchain/MsgDelegate");
+    expect(aminoMsgs[0].value.msg).toBeUndefined();
+    expect(aminoMsgs[0].value.validator_address).toEqual(validatorAddress);
+    expect(protoMsgs[0].typeUrl).toEqual("/zrchain.validation.MsgDelegate");
+    const decoded = MsgDelegate.decode(protoMsgs[0].value);
+    expect(decoded.validatorAddress).toEqual(validatorAddress);
+    expect(decoded.amount).toEqual({ denom: "uzen", amount: "100" });
+  });
+
+  it("undelegate: zrchain labels and a bare (non-wrapped) value", () => {
+    const transaction = {
+      mode: "undelegate",
+      validators: [
+        { address: validatorAddress, amount: new BigNumber(100) } as CosmosDelegationInfo,
+      ],
+    } as Transaction;
+    const { aminoMsgs, protoMsgs } = txToMessages(account, transaction, zenrock);
+    expect(aminoMsgs[0].type).toEqual("zrchain/MsgUndelegate");
+    expect(aminoMsgs[0].value.msg).toBeUndefined();
+    expect(aminoMsgs[0].value.validator_address).toEqual(validatorAddress);
+    expect(protoMsgs[0].typeUrl).toEqual("/zrchain.validation.MsgUndelegate");
+    const decoded = MsgUndelegate.decode(protoMsgs[0].value);
+    expect(decoded.validatorAddress).toEqual(validatorAddress);
+    expect(decoded.amount).toEqual({ denom: "uzen", amount: "100" });
+  });
+
+  it("redelegate: zrchain labels and a bare (non-wrapped) value", () => {
+    const sourceValidator = "zenvaloper1sourcesourcesourcesourcesourcesrc";
+    const transaction = {
+      mode: "redelegate",
+      sourceValidator,
+      validators: [
+        { address: validatorAddress, amount: new BigNumber(100) } as CosmosDelegationInfo,
+      ],
+    } as Transaction;
+    const { aminoMsgs, protoMsgs } = txToMessages(account, transaction, zenrock);
+    expect(aminoMsgs[0].type).toEqual("zrchain/MsgBeginRedelegate");
+    expect(aminoMsgs[0].value.msg).toBeUndefined();
+    expect(aminoMsgs[0].value.validator_src_address).toEqual(sourceValidator);
+    expect(aminoMsgs[0].value.validator_dst_address).toEqual(validatorAddress);
+    expect(protoMsgs[0].typeUrl).toEqual("/zrchain.validation.MsgBeginRedelegate");
+    const decoded = MsgBeginRedelegate.decode(protoMsgs[0].value);
+    expect(decoded.validatorSrcAddress).toEqual(sourceValidator);
+    expect(decoded.validatorDstAddress).toEqual(validatorAddress);
+    expect(decoded.amount).toEqual({ denom: "uzen", amount: "100" });
+  });
+});
+
+describe("txToMessages — the cosmos chain uses standard cosmos-sdk staking msgs (no wrapping)", () => {
+  const account = {
+    freshAddress: "cosmos1delegator",
+    currency: { id: "cosmos", units: [{ code: "ATOM" }, { code: "uatom" }] },
+  } as CosmosAccount;
+
+  it("delegate: cosmos-sdk labels and a bare (non-wrapped) value", () => {
+    const transaction = {
+      mode: "delegate",
+      amount: new BigNumber(100),
+      validators: [
+        { address: "cosmosvaloper1x", amount: new BigNumber(100) } as CosmosDelegationInfo,
+      ],
+    } as Transaction;
+    const { aminoMsgs, protoMsgs } = txToMessages(account, transaction, cosmos);
+    expect(aminoMsgs[0].type).toEqual("cosmos-sdk/MsgDelegate");
+    expect(aminoMsgs[0].value.msg).toBeUndefined();
+    expect(protoMsgs[0].typeUrl).toEqual("/cosmos.staking.v1beta1.MsgDelegate");
+  });
+});
+
+describe("txToMessages — babylon amino sign-doc verifies against a real on-chain signature", () => {
+  // Fixture: a real Keplr+Ledger delegation on bbn-1 (tx D3D17ECC4C04DB4EDBA145EF68691DF103B6CB2D24D7F24618887AA528045FEC).
+  // It proves the wrapped-msg amino `type` is the proto type URL, not the legacy "epoching/WrappedDelegate" name.
+  it("recovers the signer pubkey of a real mainnet WrappedDelegate tx", () => {
+    const account = {
+      freshAddress: "bbn12v96axyv2cj28hp468haw2rzg8a35lj758yvkx",
+      currency: { id: "babylon", units: [{ code: "BABY" }, { code: "ubbn" }] },
+    } as CosmosAccount;
+    const transaction = {
+      mode: "delegate",
+      amount: new BigNumber(1000000),
+      validators: [
+        {
+          address: "bbnvaloper1u9w7kfngrsr2defextqf5fscypw8dys50pdza4",
+          amount: new BigNumber(1000000),
+        } as CosmosDelegationInfo,
+      ],
+    } as Transaction;
+    const { aminoMsgs } = txToMessages(account, transaction, new Babylon());
+
+    // mirror signOperation: wrap the amino msgs in the StdSignDoc the device signs
+    const signDoc = makeSignDoc(
+      aminoMsgs as AminoMsg[],
+      { amount: [{ denom: "ubbn", amount: "2057" }], gas: "293764" },
+      "bbn-1",
+      "",
+      "364419",
+      "0",
+    );
+    const hash = sha256(serializeSignDoc(signDoc));
+    const pubkey = Uint8Array.from(
+      Buffer.from("An8LLu9QjqdCpcVa3Dw6HGzeR5IcBlIZ4Im/3FcypWW0", "base64"),
+    );
+    const sig = Uint8Array.from(
+      Buffer.from(
+        "s30u2an5XITNhKmMxAo5IOjp4U4WwlwBuh4xadzrpcovUqkEV2lYm/eKTmgv6VDpF/2wmt1PsrTNsysD/hlqYw==",
+        "base64",
+      ),
+    );
+    const r = sig.slice(0, 32);
+    const s = sig.slice(32, 64);
+    const recovered = [0, 1, 2, 3].some(rec => {
+      try {
+        return Buffer.from(
+          Secp256k1.compressPubkey(
+            Secp256k1.recoverPubkey(new ExtendedSecp256k1Signature(r, s, rec), hash),
+          ),
+        ).equals(Buffer.from(pubkey));
+      } catch {
+        return false;
+      }
+    });
+    expect(recovered).toBe(true);
   });
 });
 

--- a/libs/coin-modules/coin-cosmos/src/chain/Babylon.ts
+++ b/libs/coin-modules/coin-cosmos/src/chain/Babylon.ts
@@ -1,4 +1,23 @@
-import CosmosBase from "./cosmosBase";
+import CosmosBase, { StakingMessages } from "./cosmosBase";
+
+// The amino `type` is the proto type URL, not the legacy `epoching/WrappedDelegate` codec name:
+// the x/epoching MsgWrapped* protos set no `(amino.name)`, so amino-JSON falls back to the URL.
+// Matches Keplr and babylon's own SDK (@babylonlabs-io/babylon-proto-ts).
+export const BABYLON_STAKING_MESSAGES: StakingMessages = {
+  delegate: {
+    aminoType: "/babylon.epoching.v1.MsgWrappedDelegate",
+    protoTypeUrl: "/babylon.epoching.v1.MsgWrappedDelegate",
+  },
+  undelegate: {
+    aminoType: "/babylon.epoching.v1.MsgWrappedUndelegate",
+    protoTypeUrl: "/babylon.epoching.v1.MsgWrappedUndelegate",
+  },
+  beginRedelegate: {
+    aminoType: "/babylon.epoching.v1.MsgWrappedBeginRedelegate",
+    protoTypeUrl: "/babylon.epoching.v1.MsgWrappedBeginRedelegate",
+  },
+  wrapped: true,
+};
 
 export default class Babylon extends CosmosBase {
   stakingDocUrl: string;
@@ -6,6 +25,7 @@ export default class Babylon extends CosmosBase {
   prefix: string;
   validatorPrefix: string;
   epochedStaking = true;
+  stakingMessages = BABYLON_STAKING_MESSAGES;
   // Provided by coin config
   ledgerValidator!: string;
   lcd!: string;

--- a/libs/coin-modules/coin-cosmos/src/chain/Zenrock.ts
+++ b/libs/coin-modules/coin-cosmos/src/chain/Zenrock.ts
@@ -1,10 +1,27 @@
-import CosmosBase from "./cosmosBase";
+import CosmosBase, { StakingMessages } from "./cosmosBase";
+
+export const ZENROCK_STAKING_MESSAGES: StakingMessages = {
+  delegate: {
+    aminoType: "zrchain/MsgDelegate",
+    protoTypeUrl: "/zrchain.validation.MsgDelegate",
+  },
+  undelegate: {
+    aminoType: "zrchain/MsgUndelegate",
+    protoTypeUrl: "/zrchain.validation.MsgUndelegate",
+  },
+  beginRedelegate: {
+    aminoType: "zrchain/MsgBeginRedelegate",
+    protoTypeUrl: "/zrchain.validation.MsgBeginRedelegate",
+  },
+  wrapped: false,
+};
 
 class Zenrock extends CosmosBase {
   stakingDocUrl: string;
   unbondingPeriod: number;
   prefix: string;
   validatorPrefix: string;
+  stakingMessages = ZENROCK_STAKING_MESSAGES;
   // Provided by coin config
   ledgerValidator!: string;
   lcd!: string;

--- a/libs/coin-modules/coin-cosmos/src/chain/cosmosBase.ts
+++ b/libs/coin-modules/coin-cosmos/src/chain/cosmosBase.ts
@@ -1,3 +1,32 @@
+export type StakingMessageType = {
+  aminoType: string;
+  protoTypeUrl: string;
+};
+
+export type StakingMessages = {
+  delegate: StakingMessageType;
+  undelegate: StakingMessageType;
+  beginRedelegate: StakingMessageType;
+  // babylon x/epoching nests each staking msg in a wrapper (amino: under `msg`; proto: MsgWrapped*)
+  wrapped: boolean;
+};
+
+export const COSMOS_STAKING_MESSAGES: StakingMessages = {
+  delegate: {
+    aminoType: "cosmos-sdk/MsgDelegate",
+    protoTypeUrl: "/cosmos.staking.v1beta1.MsgDelegate",
+  },
+  undelegate: {
+    aminoType: "cosmos-sdk/MsgUndelegate",
+    protoTypeUrl: "/cosmos.staking.v1beta1.MsgUndelegate",
+  },
+  beginRedelegate: {
+    aminoType: "cosmos-sdk/MsgBeginRedelegate",
+    protoTypeUrl: "/cosmos.staking.v1beta1.MsgBeginRedelegate",
+  },
+  wrapped: false,
+};
+
 abstract class cosmosBase {
   abstract lcd: string;
   abstract stakingDocUrl: string;
@@ -11,6 +40,7 @@ abstract class cosmosBase {
   version = "v1beta1";
   // chain queues staking msgs until epoch end (x/epoching); sync merges the queue into positions
   epochedStaking = false;
+  stakingMessages: StakingMessages = COSMOS_STAKING_MESSAGES;
   public static COSMOS_FAMILY_LEDGER_VALIDATOR_ADDRESSES: string[] = [];
 }
 

--- a/libs/coin-modules/coin-cosmos/src/prepareTransaction.ts
+++ b/libs/coin-modules/coin-cosmos/src/prepareTransaction.ts
@@ -54,7 +54,7 @@ export const getEstimatedFees = async (
   let gasUsed = new BigNumber(chainInstance.defaultGas);
 
   const cosmosAPI = new CosmosAPI(account.currency.id);
-  const { protoMsgs } = txToMessages(account, transaction);
+  const { protoMsgs } = txToMessages(account, transaction, chainInstance);
   const { sequence, pubKey, pubKeyType } = await cosmosAPI.getAccount(account.freshAddress);
 
   const unsignedTx = buildTransaction({

--- a/libs/coin-modules/coin-cosmos/src/signOperation.ts
+++ b/libs/coin-modules/coin-cosmos/src/signOperation.ts
@@ -28,7 +28,7 @@ export const buildSignOperation =
           account.freshAddress,
         );
         o.next({ type: "device-signature-requested" });
-        const { aminoMsgs, protoMsgs } = txToMessages(account, transaction);
+        const { aminoMsgs, protoMsgs } = txToMessages(account, transaction, chainInstance);
         if (!BigNumber.isBigNumber(transaction.fees) || !BigNumber.isBigNumber(transaction.gas)) {
           throw new Error("Transaction misses gas information");
         }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Refactors the **shared** staking-message build path (`txToMessages`) used by **every** cosmos-family chain. QA should regression-check delegate / undelegate / redelegate / claim-reward / claim-compound on **Cosmos and Zenrock** — output is expected to be unchanged (bare for cosmos, `zrchain` relabel for zenrock).
  - **Babylon delegation stays disabled in config** (the enable is LIVE-31837, not in this PR), so there is **no user-facing Babylon change yet**; the wrapped-build path is exercised by unit tests only (incl. a byte-for-byte check against a real mainnet tx).
  - `claimRewardCompound` now **throws** on Babylon by design — its embedded delegate isn't epoching-wrapped yet (LIVE-31837).

### 📝 Description

Babylon's x/epoching module rejects bare cosmos-sdk staking messages: delegate/undelegate/redelegate must be wrapped in a `/babylon.epoching.v1.MsgWrapped*` envelope, with the inner staking msg nested under `msg` (amino + proto). This PR builds that envelope for Babylon — the send-side counterpart to the read-side positions work (LIVE-31279).

Chain-specific message types (cosmos-sdk vs `zrchain` vs epoching, and whether they're wrapped) now live as data on the chain classes (`COSMOS_/ZENROCK_/BABYLON_STAKING_MESSAGES`) instead of inline `currency.id` branches.

**Amino type:** the wrapped msgs use the proto type URL as the amino `type`, not a short `epoching/*` name — the protos set no `(amino.name)`, so amino-JSON falls back to the URL. Matches [Keplr](https://github.com/chainapsis/keplr-wallet/blob/master/packages/stores/src/account/babylon.ts) and Babylon's own SDK [`babylon-proto-ts`](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-proto-ts/src/lib/utils/amino.ts)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31280](https://ledgerhq.atlassian.net/browse/LIVE-31280?atlOrigin=eyJpIjoiNDUwNzBmZWE3MGMyNDUxNGFhMDg0Zjc4MDkyYWI1NWQiLCJwIjoiaiJ9)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31280]: https://ledgerhq.atlassian.net/browse/LIVE-31280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ