### PR TITLE
[LWM] fix(mobile): improve market filters drawer readability

### DIFF
--- a/.changeset/market-filters-readability.md
+++ b/.changeset/market-filters-readability.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Improve readability of the Market filters drawer by clarifying the sorting and timeframe labels and adding a divider to visually separate the two sections

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8229,8 +8229,8 @@
       "filters": {
         "accessibilityLabel": "Open asset filters",
         "title": "Filters",
-        "sorting": "Sorting",
-        "timeframe": "Timeframe",
+        "sorting": "Sort assets by",
+        "timeframe": "Choose timeframe",
         "sortingOptions": {
           "marketCap": "Market cap",
           "volume": "Volume",

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketFiltersDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketFiltersDrawer.tsx
@@ -4,6 +4,7 @@ import {
   BottomSheetHeader,
   BottomSheetView,
   Box,
+  Divider,
   ListItem,
   ListItemContent,
   ListItemLeading,
@@ -48,7 +49,7 @@ function MarketFilterSection<TValue extends string>({
 
   return (
     <Box>
-      <Text typography="body2SemiBold" lx={{ color: "muted", marginBottom: "s8" }}>
+      <Text typography="body2SemiBold" lx={{ color: "muted", marginBottom: "s4" }}>
         {title}
       </Text>
       <Box testID={testID}>
@@ -95,7 +96,7 @@ export function MarketFiltersDrawer({ filters }: MarketFiltersDrawerProps) {
     >
       <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
         <BottomSheetHeader />
-        <Box lx={{ gap: "s24", paddingHorizontal: "s16", paddingTop: "s12" }}>
+        <Box lx={{ paddingHorizontal: "s16", paddingTop: "s12" }}>
           <MarketFilterSection
             title={t("market.assets.filters.sorting")}
             items={filters.sortingOptions}
@@ -103,6 +104,7 @@ export function MarketFiltersDrawer({ filters }: MarketFiltersDrawerProps) {
             onValueChange={filters.onSelectSorting}
             testID={MARKET_SCREEN_TEST_IDS.filtersSortingList}
           />
+          <Divider orientation="horizontal" lx={{ marginVertical: "s8" }} />
           <MarketFilterSection
             title={t("market.assets.filters.timeframe")}
             items={filters.timeframeOptions}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Copy/visual-only change to the Market filters drawer (label wording, spacing, and an added divider). No behavioural logic was modified, so it is verified manually._
- [x] **Impact of the changes:**
  - Market filters drawer (sorting / timeframe sections) on Ledger Wallet Mobile
  - New section labels ("Sort assets by", "Choose timeframe") render and are translated
  - The divider correctly separates the two sections and the spacing looks balanced

### 📝 Description

On the Ledger Wallet Mobile Market list, the ordering and timeframe settings were hard to read because both sections were visually mixed together.

This PR improves the readability of the Market filters drawer by:

- Renaming the section titles to be more explicit ("Sorting" → "Sort assets by", "Timeframe" → "Choose timeframe")
- Adding a horizontal `Divider` between the sorting and timeframe sections
- Tightening the spacing between each section title and its options

> Note: the disabled "Volume" sorting option mentioned in the ticket requires a separate backend fix and is out of scope for this PR.

<img width="350" height="750" alt="Simulator Screenshot - build2 - 2026-06-17 at 09 04 45" src="https://github.com/user-attachments/assets/696fe153-7847-4166-a386-acb6a9147d0a" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32400](https://ledgerhq.atlassian.net/browse/LIVE-32400)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32400]: https://ledgerhq.atlassian.net/browse/LIVE-32400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ