### PR TITLE
[LWM] test(mobile): speed up NotificationsPromptStakeFlow suite by trimming render tree

### DIFF
--- a/.changeset/swift-tests-trim.md
+++ b/.changeset/swift-tests-trim.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Speed up NotificationsPromptStakeFlow integration tests by registering only the stake flow under test in each parametrized case instead of all ~37 family flow screens.

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptStakeFlow.coverage.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptStakeFlow.coverage.test.tsx
@@ -1,0 +1,27 @@
+import { stakePromptCases } from "./stakePromptFixtures";
+import { findRegisteredStakePromptFlowExports } from "./stakePromptFamilyFlows";
+
+describe("NotificationsPrompt stake flow coverage guards", () => {
+  it("covers every registered mobile family stake prompt flow", () => {
+    expect(stakePromptCases.map(c => c.familyExportKey).sort()).toEqual(
+      findRegisteredStakePromptFlowExports(),
+    );
+  });
+
+  it("uses ValidationSuccess screens for every stake prompt flow", () => {
+    expect(
+      stakePromptCases
+        .filter(c => !String(c.successScreenName).endsWith("ValidationSuccess"))
+        .map(c => c.label),
+    ).toEqual([]);
+  });
+
+  it("uses ValidationError screens for every stake prompt flow", () => {
+    expect(stakePromptCases.filter(c => !c.errorScreenName).map(c => c.label)).toEqual([]);
+    expect(
+      stakePromptCases
+        .filter(c => !String(c.errorScreenName).endsWith("ValidationError"))
+        .map(c => c.label),
+    ).toEqual([]);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptStakeFlow.part-1.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptStakeFlow.part-1.test.tsx
@@ -1,0 +1,5 @@
+import { stakePromptCaseChunks } from "./stakePromptFixtures";
+import { describeStakePromptCaseChunk } from "./stakePromptCaseTests";
+
+// Each part runs a case chunk so the test runner can parallelize the stake prompt flow.
+describeStakePromptCaseChunk(stakePromptCaseChunks[0], 1);

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptStakeFlow.part-2.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptStakeFlow.part-2.test.tsx
@@ -1,0 +1,5 @@
+import { stakePromptCaseChunks } from "./stakePromptFixtures";
+import { describeStakePromptCaseChunk } from "./stakePromptCaseTests";
+
+// Each part runs a case chunk so the test runner can parallelize the stake prompt flow.
+describeStakePromptCaseChunk(stakePromptCaseChunks[1], 2);

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/stakePromptCaseTests.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/stakePromptCaseTests.tsx
@@ -1,0 +1,78 @@
+import { AB_TESTING_VARIANTS } from "../types/variants";
+import { act, screen, waitFor } from "@tests/test-renderer";
+import { track } from "~/analytics";
+import type { StakePromptCase } from "./stakePromptFixtures";
+import { renderStakeFlow, setupStakePromptTestSuite } from "./stakePromptTestHarness";
+
+export function describeStakePromptCaseChunk(cases: StakePromptCase[], part: number) {
+  describe(`NotificationsPrompt stake flow part ${part}`, () => {
+    setupStakePromptTestSuite();
+
+    it.each(cases)(
+      "should prompt the notifications drawer when closing $label validation success",
+      async stakePromptCase => {
+        const { user } = renderStakeFlow(stakePromptCase);
+
+        expect(track).not.toHaveBeenCalledWith(
+          "attempt_to_trigger_push_notification_drawer_after_action",
+          expect.any(Object),
+        );
+
+        await waitFor(() => expect(screen.getByTestId("validate-success-screen")).toBeVisible());
+        await user.press(screen.getByTestId("enabled-success-close-button"));
+        await act(async () => {
+          await jest.runOnlyPendingTimersAsync();
+        });
+
+        await waitFor(() => expect(screen.getByText(/allow notifications/i)).toBeVisible());
+        expect(track).toHaveBeenCalledWith(
+          "attempt_to_trigger_push_notification_drawer_after_action",
+          {
+            action: "stake",
+            shouldPrompt: true,
+            variant: AB_TESTING_VARIANTS.B,
+            repromptDelay: null,
+            dismissedCount: 0,
+            skipReason: undefined,
+            drawerPromptTarget: "globalPushNotifications",
+          },
+        );
+
+        await user.press(screen.getByText(/allow notifications/i));
+        expect(track).toHaveBeenCalledWith("button_clicked", {
+          button: "allow notifications",
+          page: "Drawer push notification opt-in",
+          source: "stake",
+          drawerPromptTarget: "globalPushNotifications",
+          repromptDelay: null,
+          dismissedCount: 0,
+          variant: AB_TESTING_VARIANTS.B,
+        });
+      },
+    );
+
+    it.each(cases.filter(c => c.errorScreenName))(
+      "should not prompt the notifications drawer when closing $label validation error",
+      async stakePromptCase => {
+        const { user } = renderStakeFlow(stakePromptCase, stakePromptCase.errorScreenName!);
+
+        expect(track).not.toHaveBeenCalledWith(
+          "attempt_to_trigger_push_notification_drawer_after_action",
+          expect.any(Object),
+        );
+
+        await waitFor(() => expect(screen.getByTestId("SendErrorClose")).toBeVisible());
+        await user.press(screen.getByTestId("SendErrorClose"));
+        await act(async () => {
+          await jest.runOnlyPendingTimersAsync();
+        });
+
+        expect(track).not.toHaveBeenCalledWith(
+          "attempt_to_trigger_push_notification_drawer_after_action",
+          expect.any(Object),
+        );
+        expect(screen.queryByText(/allow notifications/i)).not.toBeOnTheScreen();
+      },
+    );
+  });
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/stakePromptFamilyFlows.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/stakePromptFamilyFlows.ts
@@ -1,0 +1,60 @@
+import type { ComponentType } from "react";
+import type { MobileFamilyFlowExport, StakePromptCase } from "./stakePromptFixtures";
+
+type MobileFamilyFlow = {
+  component: ComponentType;
+};
+
+const familyModuleNameByAccountKey: Record<StakePromptCase["accountKey"], string> = {
+  algorand: "algorand",
+  cardano: "cardano",
+  celo: "celo",
+  cosmos: "cosmos",
+  ethereum: "evm",
+  hedera: "hedera",
+  multiversx: "multiversx",
+  near: "near",
+  polkadot: "polkadot",
+  solana: "solana",
+  sui: "sui",
+  tezos: "tezos",
+};
+
+const stakePromptFlowNamePattern =
+  /(Activate|Bond|ClaimRewards|Delegation|Lock|Nominate|Rebond|Redelegation|Registration|Revoke|SimpleOperation|Staking|Unbond|Undelegation|Undelegate|Unlock|Unstaking|Vote|Withdraw|Withdrawing)Flow$/;
+
+const nonStakePromptFlowExports = new Set<MobileFamilyFlowExport>(["TronVoteFlow"]);
+
+const hasComponent = (familyExport: unknown): familyExport is MobileFamilyFlow => {
+  const component = (familyExport as { component?: unknown } | null)?.component;
+  return component !== null && (typeof component === "function" || typeof component === "object");
+};
+
+export const getMobileFamilyFlow = (stakePromptCase: StakePromptCase): MobileFamilyFlow => {
+  const moduleName = familyModuleNameByAccountKey[stakePromptCase.accountKey];
+  // Load only the family module under test instead of the full ~/families barrel.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const familyModule = require(`~/families/${moduleName}`) as Record<string, unknown>;
+  const familyExport = familyModule[stakePromptCase.familyExportKey];
+
+  if (!hasComponent(familyExport)) {
+    throw new Error(`${stakePromptCase.familyExportKey} is not a registered mobile family flow`);
+  }
+
+  return familyExport;
+};
+
+export const findRegisteredStakePromptFlowExports = (): MobileFamilyFlowExport[] => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mobileFamilies = require("~/families") as Record<string, unknown>;
+
+  return Object.entries(mobileFamilies)
+    .filter(
+      ([familyExportKey, familyExport]) =>
+        stakePromptFlowNamePattern.test(familyExportKey) &&
+        !nonStakePromptFlowExports.has(familyExportKey) &&
+        hasComponent(familyExport),
+    )
+    .map(([familyExportKey]) => familyExportKey)
+    .sort();
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/stakePromptFixtures.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/stakePromptFixtures.ts
@@ -1,36 +1,9 @@
-import React from "react";
-import type { ComponentType } from "react";
-import { View } from "react-native";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { AB_TESTING_VARIANTS } from "../types/variants";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
-import * as TezosReact from "@ledgerhq/live-common/families/tezos/react";
-import { AuthorizationStatus } from "@react-native-firebase/messaging";
-import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import {
-  act,
-  renderWithReactQuery as render,
-  screen,
-  waitFor,
-  withFlagOverrides,
-} from "@tests/test-renderer";
-import storage from "LLM/storage";
-import { MockedAccounts } from "LLM/features/Accounts/__integrations__/mockedAccounts";
-import * as MobileFamilies from "~/families";
-import GlobalDrawers from "~/GlobalDrawers";
 import { NavigatorName, ScreenName } from "~/const";
-import { track } from "~/analytics";
-import { createNotificationsPromptFeatureFlags } from "../testUtils";
 
-jest.mock("@ledgerhq/live-common/families/tezos/react", () => ({
-  __esModule: true,
-  ...jest.requireActual("@ledgerhq/live-common/families/tezos/react"),
-}));
-
-const featureFlagsForStakePrompt = createNotificationsPromptFeatureFlags();
-
-type AccountKey =
+export type AccountKey =
   | "algorand"
   | "cardano"
   | "celo"
@@ -44,24 +17,18 @@ type AccountKey =
   | "sui"
   | "tezos";
 
-type StakePromptBucket =
+export type StakePromptBucket =
   | "delegation/staking"
   | "redelegation/rebond"
   | "undelegation/unstaking"
   | "withdrawing/withdraw"
   | "revoke/claim/lifecycle";
 
-type MobileFamilyFlowExport = keyof typeof MobileFamilies;
-
-type MobileFamilyFlow = {
-  component: ComponentType;
-};
-
-type StakePromptCase = {
+export type StakePromptCase = {
   label: string;
   bucket: StakePromptBucket;
   flowName: NavigatorName;
-  familyExportKey: MobileFamilyFlowExport;
+  familyExportKey: string;
   successScreenName: ScreenName;
   errorScreenName?: ScreenName;
   accountKey: AccountKey;
@@ -70,36 +37,9 @@ type StakePromptCase = {
   params?: Record<string, unknown>;
 };
 
-const hasComponent = (familyExport: unknown): familyExport is MobileFamilyFlow => {
-  const component = (familyExport as { component?: unknown } | null)?.component;
-  return component !== null && (typeof component === "function" || typeof component === "object");
-};
+export type MobileFamilyFlowExport = StakePromptCase["familyExportKey"];
 
-const getMobileFamilyFlow = (familyExportKey: MobileFamilyFlowExport): MobileFamilyFlow => {
-  const familyExport = MobileFamilies[familyExportKey];
-  if (!hasComponent(familyExport)) {
-    throw new Error(`${familyExportKey} is not a registered mobile family flow`);
-  }
-  return familyExport;
-};
-
-const stakePromptFlowNamePattern =
-  /(Activate|Bond|ClaimRewards|Delegation|Lock|Nominate|Rebond|Redelegation|Registration|Revoke|SimpleOperation|Staking|Unbond|Undelegation|Undelegate|Unlock|Unstaking|Vote|Withdraw|Withdrawing)Flow$/;
-
-const nonStakePromptFlowExports = new Set<MobileFamilyFlowExport>(["TronVoteFlow"]);
-
-const findRegisteredStakePromptFlowExports = () =>
-  Object.entries(MobileFamilies)
-    .filter(
-      ([familyExportKey, familyExport]) =>
-        stakePromptFlowNamePattern.test(familyExportKey) &&
-        !nonStakePromptFlowExports.has(familyExportKey as MobileFamilyFlowExport) &&
-        hasComponent(familyExport),
-    )
-    .map(([familyExportKey]) => familyExportKey)
-    .sort();
-
-const accountsByKey = {
+export const accountsByKey = {
   algorand: genAccount("notifications-prompt-algorand", {
     currency: getCryptoCurrencyById("algorand"),
   }),
@@ -143,20 +83,15 @@ const accountsByKey = {
   }),
 };
 
-const createOperation = (accountId: string, type: string) => ({
+export const createOperation = (accountId: string, type: string) => ({
   id: `${accountId}-${type.toLowerCase()}-operation`,
   hash: `${type.toLowerCase()}-operation-hash`,
   type,
   accountId,
 });
 
-const stakePromptSource = { name: "NotificationsPromptStakeFlow" };
-
-function HomeScreen() {
-  return <View />;
-}
-
-const stakePromptCases: StakePromptCase[] = [
+export const stakePromptSource = { name: "NotificationsPromptStakeFlow" };
+export const stakePromptCases: StakePromptCase[] = [
   {
     label: "Algorand claim rewards",
     bucket: "revoke/claim/lifecycle",
@@ -605,252 +540,13 @@ const stakePromptCases: StakePromptCase[] = [
   },
 ];
 
-const stakePromptCasesByBucket = stakePromptCases.reduce(
-  (acc, stakePromptCase) => {
-    acc[stakePromptCase.bucket] = [...(acc[stakePromptCase.bucket] ?? []), stakePromptCase];
-    return acc;
-  },
-  {} as Record<StakePromptBucket, StakePromptCase[]>,
+export const STAKE_PROMPT_CASES_PER_CHUNK = 20;
+
+export const stakePromptCaseChunks: StakePromptCase[][] = Array.from(
+  { length: Math.ceil(stakePromptCases.length / STAKE_PROMPT_CASES_PER_CHUNK) },
+  (_, index) =>
+    stakePromptCases.slice(
+      index * STAKE_PROMPT_CASES_PER_CHUNK,
+      (index + 1) * STAKE_PROMPT_CASES_PER_CHUNK,
+    ),
 );
-
-const stakePromptErrorCasesByBucket = stakePromptCases.reduce(
-  (acc, stakePromptCase) => {
-    if (!stakePromptCase.errorScreenName) return acc;
-    acc[stakePromptCase.bucket] = [...(acc[stakePromptCase.bucket] ?? []), stakePromptCase];
-    return acc;
-  },
-  {} as Record<StakePromptBucket, StakePromptCase[]>,
-);
-
-let useTezosBakerSpy: jest.SpiedFunction<typeof TezosReact.useBaker>;
-
-describe("NotificationsPrompt stake flow", () => {
-  beforeAll(() => {
-    jest.useFakeTimers();
-    useTezosBakerSpy = jest.spyOn(TezosReact, "useBaker").mockReturnValue({
-      address: "tz1-validator",
-      name: "Tezos validator",
-      logoURL: "",
-      nominalYield: "0 %",
-      capacityStatus: "normal",
-    });
-  });
-
-  beforeEach(async () => {
-    jest.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
-    await storage.deleteAll();
-  });
-
-  afterAll(() => {
-    jest.useRealTimers();
-    useTezosBakerSpy.mockRestore();
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  const Stack = createNativeStackNavigator();
-  const HOME_SCREEN = "Home";
-  const accountsState = {
-    ...MockedAccounts,
-    active: [...MockedAccounts.active, ...Object.values(accountsByKey)],
-  };
-  const flowRoutes = Array.from(
-    new Map(
-      stakePromptCases.map(stakePromptCase => [
-        stakePromptCase.flowName,
-        {
-          flowName: stakePromptCase.flowName,
-          component: getMobileFamilyFlow(stakePromptCase.familyExportKey).component,
-        },
-      ]),
-    ).values(),
-  );
-
-  const createParams = (stakePromptCase: StakePromptCase) => {
-    const account = accountsByKey[stakePromptCase.accountKey];
-
-    return {
-      accountId: account.id,
-      deviceId: "device-id",
-      error: {
-        name: "Error",
-        message: `${stakePromptCase.label} validation failed`,
-      } as Error,
-      result: createOperation(account.id, stakePromptCase.operationType),
-      transaction: stakePromptCase.transaction,
-      ...stakePromptCase.params,
-    };
-  };
-
-  const createFlowNavigationState = (
-    stakePromptCase: StakePromptCase,
-    screenName: ScreenName = stakePromptCase.successScreenName,
-  ) => ({
-    index: 1,
-    routes: [
-      {
-        name: HOME_SCREEN,
-      },
-      {
-        name: stakePromptCase.flowName,
-        state: {
-          index: 0,
-          routes: [
-            {
-              name: screenName,
-              params: createParams(stakePromptCase),
-            },
-          ],
-        },
-      },
-    ],
-  });
-
-  function StakeFlowTestApp() {
-    return (
-      <GlobalDrawers>
-        <Stack.Navigator screenOptions={{ headerShown: false }}>
-          <Stack.Screen name={HOME_SCREEN} component={HomeScreen} />
-          {flowRoutes.map(({ flowName, component }) => (
-            <Stack.Screen key={flowName} name={flowName} component={component} />
-          ))}
-        </Stack.Navigator>
-      </GlobalDrawers>
-    );
-  }
-
-  const renderStakeFlow = (
-    stakePromptCase: StakePromptCase,
-    screenName: ScreenName = stakePromptCase.successScreenName,
-  ) =>
-    render(<StakeFlowTestApp />, {
-      navigationInitialState: createFlowNavigationState(stakePromptCase, screenName),
-      overrideInitialState: withFlagOverrides(featureFlagsForStakePrompt, state => ({
-        ...state,
-        accounts: accountsState,
-        notifications: {
-          ...state.notifications,
-          permissionStatus: AuthorizationStatus.NOT_DETERMINED,
-        },
-        settings: {
-          ...state.settings,
-          readOnlyModeEnabled: false,
-          notifications: {
-            ...state.settings.notifications,
-            areNotificationsAllowed: true,
-          },
-        },
-      })),
-    });
-
-  describe("coverage guards", () => {
-    it("covers every registered mobile family stake prompt flow", () => {
-      const flowExportsCoveredByTheseTests = stakePromptCases
-        .map(stakePromptCase => stakePromptCase.familyExportKey)
-        .sort();
-      const registeredStakePromptFlowExports = findRegisteredStakePromptFlowExports();
-
-      expect(flowExportsCoveredByTheseTests).toEqual(registeredStakePromptFlowExports);
-    });
-
-    it("uses ValidationSuccess screens for every stake prompt flow", () => {
-      const casesWithUnexpectedSuccessScreen = stakePromptCases
-        .filter(
-          stakePromptCase =>
-            !String(stakePromptCase.successScreenName).endsWith("ValidationSuccess"),
-        )
-        .map(stakePromptCase => stakePromptCase.label);
-
-      expect(casesWithUnexpectedSuccessScreen).toEqual([]);
-    });
-
-    it("uses ValidationError screens for every stake prompt flow", () => {
-      const casesMissingErrorScreen = stakePromptCases
-        .filter(stakePromptCase => !stakePromptCase.errorScreenName)
-        .map(stakePromptCase => stakePromptCase.label);
-      const casesWithUnexpectedErrorScreen = stakePromptCases
-        .filter(
-          stakePromptCase => !String(stakePromptCase.errorScreenName).endsWith("ValidationError"),
-        )
-        .map(stakePromptCase => stakePromptCase.label);
-
-      expect(casesMissingErrorScreen).toEqual([]);
-      expect(casesWithUnexpectedErrorScreen).toEqual([]);
-    });
-  });
-
-  describe.each(Object.entries(stakePromptCasesByBucket))("%s flows", (bucket, bucketCases) => {
-    it.each(bucketCases)(
-      "should prompt the notifications drawer when closing $label validation success",
-      async stakePromptCase => {
-        const { user } = renderStakeFlow(stakePromptCase);
-
-        expect(track).not.toHaveBeenCalledWith(
-          "attempt_to_trigger_push_notification_drawer_after_action",
-          expect.any(Object),
-        );
-
-        await waitFor(() => expect(screen.getByTestId("validate-success-screen")).toBeVisible());
-        await user.press(screen.getByTestId("enabled-success-close-button"));
-        await act(async () => {
-          await jest.runOnlyPendingTimersAsync();
-        });
-
-        await waitFor(() => expect(screen.getByText(/allow notifications/i)).toBeVisible());
-        expect(track).toHaveBeenCalledWith(
-          "attempt_to_trigger_push_notification_drawer_after_action",
-          {
-            action: "stake",
-            shouldPrompt: true,
-            variant: AB_TESTING_VARIANTS.B,
-            repromptDelay: null,
-            dismissedCount: 0,
-            skipReason: undefined,
-            drawerPromptTarget: "globalPushNotifications",
-          },
-        );
-
-        const allowNotificationsButton = screen.getByText(/allow notifications/i);
-        await user.press(allowNotificationsButton);
-        expect(track).toHaveBeenCalledWith("button_clicked", {
-          button: "allow notifications",
-          page: "Drawer push notification opt-in",
-          source: "stake",
-          drawerPromptTarget: "globalPushNotifications",
-          repromptDelay: null,
-          dismissedCount: 0,
-          variant: AB_TESTING_VARIANTS.B,
-        });
-      },
-    );
-
-    it.each(stakePromptErrorCasesByBucket[bucket as StakePromptBucket] ?? [])(
-      "should not prompt the notifications drawer when closing $label validation error",
-      async stakePromptCase => {
-        const { errorScreenName } = stakePromptCase;
-        if (!errorScreenName) return;
-
-        const { user } = renderStakeFlow(stakePromptCase, errorScreenName);
-
-        expect(track).not.toHaveBeenCalledWith(
-          "attempt_to_trigger_push_notification_drawer_after_action",
-          expect.any(Object),
-        );
-
-        await waitFor(() => expect(screen.getByTestId("SendErrorClose")).toBeVisible());
-        await user.press(screen.getByTestId("SendErrorClose"));
-        await act(async () => {
-          await jest.runOnlyPendingTimersAsync();
-        });
-
-        expect(track).not.toHaveBeenCalledWith(
-          "attempt_to_trigger_push_notification_drawer_after_action",
-          expect.any(Object),
-        );
-        expect(screen.queryByText(/allow notifications/i)).not.toBeOnTheScreen();
-      },
-    );
-  });
-});

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/stakePromptTestHarness.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/stakePromptTestHarness.tsx
@@ -1,0 +1,156 @@
+import React from "react";
+import { View } from "react-native";
+import * as TezosReact from "@ledgerhq/live-common/families/tezos/react";
+import { AuthorizationStatus } from "@react-native-firebase/messaging";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { renderWithReactQuery as render, withFlagOverrides } from "@tests/test-renderer";
+import storage from "LLM/storage";
+import { MockedAccounts } from "LLM/features/Accounts/__integrations__/mockedAccounts";
+import GlobalDrawers from "~/GlobalDrawers";
+import { ScreenName } from "~/const";
+import { createNotificationsPromptFeatureFlags } from "../testUtils";
+import { accountsByKey, createOperation, type StakePromptCase } from "./stakePromptFixtures";
+import { getMobileFamilyFlow } from "./stakePromptFamilyFlows";
+
+jest.mock("LLM/components/QueuedDrawer", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require("react");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { View, Pressable } = require("react-native");
+
+  function QueuedDrawerMock(props: {
+    isRequestingToBeOpened?: boolean;
+    onBackdropPress?: () => void;
+    children?: React.ReactNode;
+  }) {
+    if (!props.isRequestingToBeOpened) return <View />;
+    return (
+      <View>
+        <Pressable testID="drawer-backdrop" onPress={props.onBackdropPress} />
+        {props.children}
+      </View>
+    );
+  }
+
+  return {
+    __esModule: true,
+    default: QueuedDrawerMock,
+  };
+});
+
+jest.mock("@ledgerhq/live-common/families/tezos/react", () => ({
+  __esModule: true,
+  ...jest.requireActual("@ledgerhq/live-common/families/tezos/react"),
+}));
+
+const featureFlagsForStakePrompt = createNotificationsPromptFeatureFlags();
+const Stack = createNativeStackNavigator();
+const HOME_SCREEN = "Home";
+
+function HomeScreen() {
+  return <View />;
+}
+
+const accountsState = {
+  ...MockedAccounts,
+  active: [...MockedAccounts.active, ...Object.values(accountsByKey)],
+};
+
+const createParams = (stakePromptCase: StakePromptCase) => {
+  const account = accountsByKey[stakePromptCase.accountKey];
+
+  return {
+    accountId: account.id,
+    deviceId: "device-id",
+    error: {
+      name: "Error",
+      message: `${stakePromptCase.label} validation failed`,
+    } as Error,
+    result: createOperation(account.id, stakePromptCase.operationType),
+    transaction: stakePromptCase.transaction,
+    ...stakePromptCase.params,
+  };
+};
+
+const createFlowNavigationState = (
+  stakePromptCase: StakePromptCase,
+  screenName: ScreenName = stakePromptCase.successScreenName,
+) => ({
+  index: 1,
+  routes: [
+    { name: HOME_SCREEN },
+    {
+      name: stakePromptCase.flowName,
+      state: {
+        index: 0,
+        routes: [{ name: screenName, params: createParams(stakePromptCase) }],
+      },
+    },
+  ],
+});
+
+function StakeFlowTestApp({ stakePromptCase }: { stakePromptCase: StakePromptCase }) {
+  const Flow = getMobileFamilyFlow(stakePromptCase).component;
+
+  return (
+    <GlobalDrawers>
+      <Stack.Navigator screenOptions={{ headerShown: false }}>
+        <Stack.Screen name={HOME_SCREEN} component={HomeScreen} />
+        <Stack.Screen name={stakePromptCase.flowName} component={Flow} />
+      </Stack.Navigator>
+    </GlobalDrawers>
+  );
+}
+
+export const renderStakeFlow = (
+  stakePromptCase: StakePromptCase,
+  screenName: ScreenName = stakePromptCase.successScreenName,
+) =>
+  render(<StakeFlowTestApp stakePromptCase={stakePromptCase} />, {
+    navigationInitialState: createFlowNavigationState(stakePromptCase, screenName),
+    overrideInitialState: withFlagOverrides(featureFlagsForStakePrompt, state => ({
+      ...state,
+      accounts: accountsState,
+      notifications: {
+        ...state.notifications,
+        permissionStatus: AuthorizationStatus.NOT_DETERMINED,
+      },
+      settings: {
+        ...state.settings,
+        readOnlyModeEnabled: false,
+        notifications: {
+          ...state.settings.notifications,
+          areNotificationsAllowed: true,
+        },
+      },
+    })),
+  });
+
+let useTezosBakerSpy: jest.SpiedFunction<typeof TezosReact.useBaker>;
+
+export function setupStakePromptTestSuite() {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    useTezosBakerSpy = jest.spyOn(TezosReact, "useBaker").mockReturnValue({
+      address: "tz1-validator",
+      name: "Tezos validator",
+      logoURL: "",
+      nominalYield: "0 %",
+      capacityStatus: "normal",
+    });
+  });
+
+  beforeEach(async () => {
+    jest.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+    await storage.deleteAll();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+    useTezosBakerSpy.mockRestore();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - NotificationsPrompt stake-flow integration test runtime (~32s → ~9s locally)
  - All 79 parametrized stake cases still pass with full coverage retained
  - No production behavior changes

### 📝 Description

**Problem**: The `NotificationsPromptStakeFlow` integration suite was slow because each parametrized case registered all ~37 family flow screens in the render tree, even though only one stake flow was under test.

**Solution**: Refactored the test harness to register only the stake flow under test per case. Split fixtures/harness into dedicated modules and kept the suite split across part-1/part-2 plus a coverage test. Suite time drops from ~32s to ~9s locally with 79/79 tests still passing.


<img width="1053" height="221" alt="image" src="https://github.com/user-attachments/assets/a87bf469-081a-4876-96e9-fb32d4dc678a" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-31711](https://ledgerhq.atlassian.net/browse/LIVE-31711)

---

### 🧐 Checklist for the PR 
- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31711]: https://ledgerhq.atlassian.net/browse/LIVE-31711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ