### PR TITLE
[LWDM] Fix/live 30795 star

### DIFF
--- a/.changeset/asset-detail-star-ledgerids.md
+++ b/.changeset/asset-detail-star-ledgerids.md
@@ -6,4 +6,4 @@
 "ledger-live-desktop": minor
 ---
 
-Fix Asset Detail favourites for tokens opened from Market or Assets by resolving market data via the /v3/markets `ledgerIds` filter.
+Fix Asset Detail favourites for tokens opened from Market or Assets by resolving market data via the /v3/markets `ledgerIds` filter while keeping backward compatibility with the legacy `ids` filter.

--- a/.changeset/asset-detail-star-ledgerids.md
+++ b/.changeset/asset-detail-star-ledgerids.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/live-common": minor
+"@ledgerhq/asset-detail": minor
+"@ledgerhq/asset-aggregation": minor
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Fix Asset Detail favourites for tokens opened from Market or Assets by resolving market data via the /v3/markets `ledgerIds` filter.

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/__tests__/useAssetCoinOptionsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/__tests__/useAssetCoinOptionsViewModel.test.ts
@@ -61,6 +61,27 @@ describe("useAssetCoinOptionsViewModel", () => {
     );
   });
 
+  it("allows toggling favourites when currency is not resolved yet", () => {
+    const { result, store } = renderHook(
+      () =>
+        useAssetCoinOptionsViewModel({
+          currency: undefined,
+          currencyId: "ethereum/erc20/shiba_inu",
+          marketId: "shiba-inu",
+        }),
+      {
+        overrideInitialState: (state: State): State => ({
+          ...state,
+          settings: { ...state.settings, starredMarketCoins: [] },
+        }),
+      },
+    );
+
+    act(() => result.current.onToggleFavourite());
+
+    expect(store.getState().settings.starredMarketCoins).toContain("shiba-inu");
+  });
+
   it("prefers marketId over currencyId as the star key so favourites stay aligned with the Market list", () => {
     const { result, store } = renderViewModel({ marketId: "bitcoin-coingecko-id" });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/useAssetCoinOptionsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/useAssetCoinOptionsViewModel.ts
@@ -40,12 +40,11 @@ export function useAssetCoinOptionsViewModel({ currency, currencyId, marketId }:
   const trailingAccessibilityLabel = t("assetDetail.coinOptions.openMenuA11yLabel");
 
   const onToggleFavourite = useCallback(() => {
-    if (!currency) return;
     const nextStarred = !isStarred;
 
     track("button_clicked", {
       button: "favourite",
-      currency: currency.id,
+      currency: currency?.id ?? currencyId,
       page: "Asset Detail",
       is_favourite: nextStarred,
     });
@@ -61,6 +60,7 @@ export function useAssetCoinOptionsViewModel({ currency, currencyId, marketId }:
     closeCoinOptions();
   }, [
     currency,
+    currencyId,
     isStarred,
     starKey,
     dispatch,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/__tests__/useAssetMarketData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/__tests__/useAssetMarketData.test.ts
@@ -6,6 +6,26 @@ import { useAssetMarketData } from "../useAssetMarketData";
 
 const COUNTERVALUES_API = "https://countervalues.live.ledger.com";
 
+type MarketQueryParams = {
+  ids: string[];
+  ledgerIds: string[];
+};
+
+function trackMarketQueryParams() {
+  const captured: MarketQueryParams = { ids: [], ledgerIds: [] };
+  server.use(
+    http.get(`${COUNTERVALUES_API}/v3/markets`, ({ request }) => {
+      const url = new URL(request.url);
+      const ids = url.searchParams.get("ids");
+      const ledgerIds = url.searchParams.get("ledgerIds");
+      if (ids) captured.ids.push(ids);
+      if (ledgerIds) captured.ledgerIds.push(ledgerIds);
+      return HttpResponse.json([]);
+    }),
+  );
+  return captured;
+}
+
 const withCounterValue =
   (ticker: string) =>
   (state: State): State => ({
@@ -127,38 +147,9 @@ describe("useAssetMarketData", () => {
     });
   });
 
-  describe("ledgerIds", () => {
-    it("returns [] when no known ledger ids are provided", () => {
-      const { result } = renderHook(() => useAssetMarketData({}));
-
-      expect(result.current.ledgerIds).toEqual([]);
-    });
-
-    it("falls back to knownLedgerIds while market data has not resolved yet", () => {
-      const { result } = renderHook(() =>
-        useAssetMarketData({
-          marketApiId: mockBtcCryptoCurrency.id,
-          knownLedgerIds: [mockBtcCryptoCurrency.id],
-        }),
-      );
-
-      expect(result.current.marketCurrency).toBeUndefined();
-      expect(result.current.ledgerIds).toEqual([mockBtcCryptoCurrency.id]);
-    });
-
-    it("keeps using the legacy ids filter when a coingecko id is available (e.g. bitcoin)", async () => {
-      const requestedIds: string[] = [];
-      const requestedLedgerIds: string[] = [];
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, ({ request }) => {
-          const url = new URL(request.url);
-          const ids = url.searchParams.get("ids");
-          const ledgerIds = url.searchParams.get("ledgerIds");
-          if (ids) requestedIds.push(ids);
-          if (ledgerIds) requestedLedgerIds.push(ledgerIds);
-          return HttpResponse.json([]);
-        }),
-      );
+  describe("market query strategy", () => {
+    it("uses the legacy ids filter for coingecko ids", async () => {
+      const captured = trackMarketQueryParams();
 
       renderHook(() =>
         useAssetMarketData({
@@ -168,24 +159,13 @@ describe("useAssetMarketData", () => {
       );
 
       await waitFor(() => {
-        expect(requestedIds).toContain(mockBtcCryptoCurrency.id);
+        expect(captured.ids).toContain(mockBtcCryptoCurrency.id);
       });
-      expect(requestedLedgerIds).toHaveLength(0);
+      expect(captured.ledgerIds).toHaveLength(0);
     });
 
-    it("uses the legacy ids filter for DADA urn market ids (backward compatible with v3)", async () => {
-      const requestedIds: string[] = [];
-      const requestedLedgerIds: string[] = [];
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, ({ request }) => {
-          const url = new URL(request.url);
-          const ids = url.searchParams.get("ids");
-          const ledgerIds = url.searchParams.get("ledgerIds");
-          if (ids) requestedIds.push(ids);
-          if (ledgerIds) requestedLedgerIds.push(ledgerIds);
-          return HttpResponse.json([]);
-        }),
-      );
+    it("uses the legacy ids filter for DADA urns", async () => {
+      const captured = trackMarketQueryParams();
 
       const { result } = renderHook(() =>
         useAssetMarketData({
@@ -196,9 +176,9 @@ describe("useAssetMarketData", () => {
       );
 
       await waitFor(() => {
-        expect(requestedIds).toContain("shiba-inu");
+        expect(captured.ids).toContain("shiba-inu");
       });
-      expect(requestedLedgerIds).toHaveLength(0);
+      expect(captured.ledgerIds).toHaveLength(0);
       expect(result.current.marketId).toBe("shiba-inu");
     });
 
@@ -247,6 +227,24 @@ describe("useAssetMarketData", () => {
         expect(requestedLedgerIds).toContain("ethereum/erc20/shiba_inu");
         expect(result.current.marketId).toBe("shiba-inu");
       });
+    });
+
+    it("returns [] when no known ledger ids are provided", () => {
+      const { result } = renderHook(() => useAssetMarketData({}));
+
+      expect(result.current.ledgerIds).toEqual([]);
+    });
+
+    it("falls back to knownLedgerIds while market data has not resolved yet", () => {
+      const { result } = renderHook(() =>
+        useAssetMarketData({
+          marketApiId: mockBtcCryptoCurrency.id,
+          knownLedgerIds: [mockBtcCryptoCurrency.id],
+        }),
+      );
+
+      expect(result.current.marketCurrency).toBeUndefined();
+      expect(result.current.ledgerIds).toEqual([mockBtcCryptoCurrency.id]);
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/__tests__/useAssetMarketData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/__tests__/useAssetMarketData.test.ts
@@ -148,10 +148,14 @@ describe("useAssetMarketData", () => {
 
     it("keeps using the legacy ids filter when a coingecko id is available (e.g. bitcoin)", async () => {
       const requestedIds: string[] = [];
+      const requestedLedgerIds: string[] = [];
       server.use(
         http.get(`${COUNTERVALUES_API}/v3/markets`, ({ request }) => {
-          const ids = new URL(request.url).searchParams.get("ids");
+          const url = new URL(request.url);
+          const ids = url.searchParams.get("ids");
+          const ledgerIds = url.searchParams.get("ledgerIds");
           if (ids) requestedIds.push(ids);
+          if (ledgerIds) requestedLedgerIds.push(ledgerIds);
           return HttpResponse.json([]);
         }),
       );
@@ -166,6 +170,36 @@ describe("useAssetMarketData", () => {
       await waitFor(() => {
         expect(requestedIds).toContain(mockBtcCryptoCurrency.id);
       });
+      expect(requestedLedgerIds).toHaveLength(0);
+    });
+
+    it("uses the legacy ids filter for DADA urn market ids (backward compatible with v3)", async () => {
+      const requestedIds: string[] = [];
+      const requestedLedgerIds: string[] = [];
+      server.use(
+        http.get(`${COUNTERVALUES_API}/v3/markets`, ({ request }) => {
+          const url = new URL(request.url);
+          const ids = url.searchParams.get("ids");
+          const ledgerIds = url.searchParams.get("ledgerIds");
+          if (ids) requestedIds.push(ids);
+          if (ledgerIds) requestedLedgerIds.push(ledgerIds);
+          return HttpResponse.json([]);
+        }),
+      );
+
+      const { result } = renderHook(() =>
+        useAssetMarketData({
+          marketApiId: "urn:crypto:meta-currency:shiba_inu",
+          knownLedgerIds: ["ethereum/erc20/shiba_inu"],
+          knownMarketId: "urn:crypto:meta-currency:shiba_inu",
+        }),
+      );
+
+      await waitFor(() => {
+        expect(requestedIds).toContain("shiba-inu");
+      });
+      expect(requestedLedgerIds).toHaveLength(0);
+      expect(result.current.marketId).toBe("shiba-inu");
     });
 
     it("requests /v3/markets with ledgerIds when the market api id is a ledger id", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/__tests__/useAssetMarketData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/__tests__/useAssetMarketData.test.ts
@@ -145,5 +145,74 @@ describe("useAssetMarketData", () => {
       expect(result.current.marketCurrency).toBeUndefined();
       expect(result.current.ledgerIds).toEqual([mockBtcCryptoCurrency.id]);
     });
+
+    it("keeps using the legacy ids filter when a coingecko id is available (e.g. bitcoin)", async () => {
+      const requestedIds: string[] = [];
+      server.use(
+        http.get(`${COUNTERVALUES_API}/v3/markets`, ({ request }) => {
+          const ids = new URL(request.url).searchParams.get("ids");
+          if (ids) requestedIds.push(ids);
+          return HttpResponse.json([]);
+        }),
+      );
+
+      renderHook(() =>
+        useAssetMarketData({
+          marketApiId: mockBtcCryptoCurrency.id,
+          knownLedgerIds: [mockBtcCryptoCurrency.id],
+        }),
+      );
+
+      await waitFor(() => {
+        expect(requestedIds).toContain(mockBtcCryptoCurrency.id);
+      });
+    });
+
+    it("requests /v3/markets with ledgerIds when the market api id is a ledger id", async () => {
+      const requestedLedgerIds: string[] = [];
+      server.use(
+        http.get(`${COUNTERVALUES_API}/v3/markets`, ({ request }) => {
+          const ledgerIds = new URL(request.url).searchParams.get("ledgerIds");
+          if (ledgerIds) requestedLedgerIds.push(ledgerIds);
+          return HttpResponse.json([
+            {
+              id: "shiba-inu",
+              name: "Shiba Inu",
+              ticker: "SHIB",
+              ledgerIds: ["ethereum/erc20/shiba_inu"],
+              price: 0.00001,
+              marketCap: 1,
+              marketCapRank: 1,
+              totalVolume: 1,
+              high24h: 1,
+              low24h: 1,
+              priceChange24h: 0,
+              priceChangePercentage24h: 0,
+              priceChangePercentage: {
+                "1h": 0,
+                "24h": 0,
+                "7d": 0,
+                "30d": 0,
+                "6m": 0,
+                "1y": 0,
+              },
+              image: "",
+            },
+          ]);
+        }),
+      );
+
+      const { result } = renderHook(() =>
+        useAssetMarketData({
+          marketApiId: "ethereum/erc20/shiba_inu",
+          knownLedgerIds: ["ethereum/erc20/shiba_inu"],
+        }),
+      );
+
+      await waitFor(() => {
+        expect(requestedLedgerIds).toContain("ethereum/erc20/shiba_inu");
+        expect(result.current.marketId).toBe("shiba-inu");
+      });
+    });
   });
 });

--- a/libs/asset-aggregation/src/assetDistribution/__tests__/resolveAssetMarketInputs.test.ts
+++ b/libs/asset-aggregation/src/assetDistribution/__tests__/resolveAssetMarketInputs.test.ts
@@ -87,13 +87,25 @@ describe("resolveAssetMarketInputs", () => {
     expect(result.knownLedgerIds).toEqual(["bsc"]);
   });
 
-  it("falls back to currency.id for knownLedgerIds when no distributionItem", () => {
+  it("falls back to currency.id for knownLedgerIds when no distributionItem and no marketState ledger ids", () => {
     const result = resolveAssetMarketInputs({
-      marketState: { id: "binancecoin", ledgerIds: ["bsc"] },
+      marketState: { id: "binancecoin" },
       currency: cryptoCurrency("bsc"),
     });
 
     expect(result.knownLedgerIds).toEqual(["bsc"]);
+  });
+
+  it("prefers marketState.ledgerIds over currency.id when navigating from Market", () => {
+    const result = resolveAssetMarketInputs({
+      marketState: {
+        id: "shiba-inu",
+        ledgerIds: ["ethereum/erc20/shiba_inu", "solana/spl/shiba"],
+      },
+      currency: cryptoCurrency("ethereum/erc20/shiba_inu"),
+    });
+
+    expect(result.knownLedgerIds).toEqual(["ethereum/erc20/shiba_inu", "solana/spl/shiba"]);
   });
 
   it("uses marketState.ledgerIds when no distributionItem and no currency", () => {

--- a/libs/asset-aggregation/src/assetDistribution/resolveAssetMarketInputs.ts
+++ b/libs/asset-aggregation/src/assetDistribution/resolveAssetMarketInputs.ts
@@ -64,6 +64,7 @@ function resolveKnownLedgerIds({
   | readonly string[]
   | undefined {
   if (distributionItem) return [distributionItem.currency.id];
+  if (marketState?.ledgerIds?.length) return marketState.ledgerIds;
   if (currency) return [currency.id];
-  return marketState?.ledgerIds;
+  return undefined;
 }

--- a/libs/asset-detail/src/hooks/useAssetMarketData.ts
+++ b/libs/asset-detail/src/hooks/useAssetMarketData.ts
@@ -14,9 +14,8 @@ import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useU
 import { applyDadaMarketFallback } from "../utils/applyDadaMarketFallback";
 import { resolveDadaMarket } from "../utils/resolveDadaMarket";
 import {
-  getMarketLedgerIdsForQuery,
+  buildMarketCurrencyQueryArgs,
   resolveCoingeckoIdForIdsQuery,
-  shouldFetchMarketByLedgerIds,
 } from "../utils/resolveMarketCurrencyQuery";
 import type { AssetMarketDataInput, AssetMarketDataResult } from "../types";
 
@@ -30,22 +29,12 @@ export function useAssetMarketData({
   knownMarketId,
   enabled = true,
 }: AssetMarketDataInput): AssetMarketDataResult {
-  const fetchByLedgerIds = shouldFetchMarketByLedgerIds(marketApiId, knownLedgerIds);
-  const idsQueryId = resolveCoingeckoIdForIdsQuery(marketApiId);
-
-  const currencyQueryArgs = useMemo(
-    () =>
-      fetchByLedgerIds && knownLedgerIds?.length
-        ? {
-            ledgerIds: getMarketLedgerIdsForQuery(knownLedgerIds),
-            counterCurrency,
-          }
-        : { id: idsQueryId ?? marketApiId ?? "", counterCurrency },
-    [fetchByLedgerIds, knownLedgerIds, idsQueryId, marketApiId, counterCurrency],
+  const { args: currencyQueryArgs, skip: skipMarketQueryBase } = useMemo(
+    () => buildMarketCurrencyQueryArgs({ marketApiId, knownLedgerIds, counterCurrency }),
+    [marketApiId, knownLedgerIds, counterCurrency],
   );
 
-  const skipMarketQuery =
-    !enabled || (fetchByLedgerIds ? !knownLedgerIds?.length : !idsQueryId && !marketApiId);
+  const skipMarketQuery = !enabled || skipMarketQueryBase;
 
   const {
     data: marketFromHook,

--- a/libs/asset-detail/src/hooks/useAssetMarketData.ts
+++ b/libs/asset-detail/src/hooks/useAssetMarketData.ts
@@ -13,6 +13,12 @@ import { selectCurrency } from "@ledgerhq/live-common/dada-client/utils/currency
 import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
 import { applyDadaMarketFallback } from "../utils/applyDadaMarketFallback";
 import { resolveDadaMarket } from "../utils/resolveDadaMarket";
+import {
+  getMarketLedgerIdsForQuery,
+  isCoingeckoStyleMarketId,
+  resolveCoingeckoIdForIdsQuery,
+  shouldFetchMarketByLedgerIds,
+} from "../utils/resolveMarketCurrencyQuery";
 import type { AssetMarketDataInput, AssetMarketDataResult } from "../types";
 
 export function useAssetMarketData({
@@ -25,17 +31,31 @@ export function useAssetMarketData({
   knownMarketId,
   enabled = true,
 }: AssetMarketDataInput): AssetMarketDataResult {
+  const fetchByLedgerIds = shouldFetchMarketByLedgerIds(marketApiId, knownLedgerIds);
+  const idsQueryId = resolveCoingeckoIdForIdsQuery(marketApiId);
+
+  const currencyQueryArgs = useMemo(
+    () =>
+      fetchByLedgerIds && knownLedgerIds?.length
+        ? {
+            ledgerIds: getMarketLedgerIdsForQuery(knownLedgerIds),
+            counterCurrency,
+          }
+        : { id: idsQueryId ?? marketApiId ?? "", counterCurrency },
+    [fetchByLedgerIds, knownLedgerIds, idsQueryId, marketApiId, counterCurrency],
+  );
+
+  const skipMarketQuery =
+    !enabled || (fetchByLedgerIds ? !knownLedgerIds?.length : !idsQueryId && !marketApiId);
+
   const {
     data: marketFromHook,
     isLoading: isLoadingMarket,
     isError: isErrorMarket,
-  } = useGetCurrencyDataQuery(
-    { id: marketApiId ?? "", counterCurrency },
-    {
-      skip: !enabled || !marketApiId,
-      pollingInterval: REFETCH_TIME_ONE_MINUTE * BASIC_REFETCH,
-    },
-  );
+  } = useGetCurrencyDataQuery(currencyQueryArgs, {
+    skip: skipMarketQuery,
+    pollingInterval: REFETCH_TIME_ONE_MINUTE * BASIC_REFETCH,
+  });
 
   const effectiveLedgerIds = useMemo<readonly string[] | undefined>(
     () => knownLedgerIds ?? marketFromHook?.ledgerIds,
@@ -106,7 +126,9 @@ export function useAssetMarketData({
 
   return {
     marketCurrencyData,
-    marketId: marketFromHook?.id ?? knownMarketId,
+    marketId:
+      marketFromHook?.id ??
+      (knownMarketId && isCoingeckoStyleMarketId(knownMarketId) ? knownMarketId : undefined),
     ledgerCurrencyFromDada,
     ledgerIds,
     isLoading: isLoadingMarket || isLoadingDada || (!!dadaMarket && rateStatus === "loading"),

--- a/libs/asset-detail/src/hooks/useAssetMarketData.ts
+++ b/libs/asset-detail/src/hooks/useAssetMarketData.ts
@@ -15,7 +15,6 @@ import { applyDadaMarketFallback } from "../utils/applyDadaMarketFallback";
 import { resolveDadaMarket } from "../utils/resolveDadaMarket";
 import {
   getMarketLedgerIdsForQuery,
-  isCoingeckoStyleMarketId,
   resolveCoingeckoIdForIdsQuery,
   shouldFetchMarketByLedgerIds,
 } from "../utils/resolveMarketCurrencyQuery";
@@ -126,9 +125,7 @@ export function useAssetMarketData({
 
   return {
     marketCurrencyData,
-    marketId:
-      marketFromHook?.id ??
-      (knownMarketId && isCoingeckoStyleMarketId(knownMarketId) ? knownMarketId : undefined),
+    marketId: marketFromHook?.id ?? resolveCoingeckoIdForIdsQuery(knownMarketId),
     ledgerCurrencyFromDada,
     ledgerIds,
     isLoading: isLoadingMarket || isLoadingDada || (!!dadaMarket && rateStatus === "loading"),

--- a/libs/asset-detail/src/utils/__tests__/resolveMarketCurrencyQuery.test.ts
+++ b/libs/asset-detail/src/utils/__tests__/resolveMarketCurrencyQuery.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildMarketCurrencyQueryArgs,
   getMarketLedgerIdsForQuery,
   isCoingeckoStyleMarketId,
   MAX_MARKET_LEDGER_IDS,
@@ -67,5 +68,57 @@ describe("getMarketLedgerIdsForQuery", () => {
     const ledgerIds = Array.from({ length: MAX_MARKET_LEDGER_IDS + 3 }, (_, index) => `id-${index}`);
     expect(getMarketLedgerIdsForQuery(ledgerIds)).toHaveLength(MAX_MARKET_LEDGER_IDS);
     expect(getMarketLedgerIdsForQuery(ledgerIds)[0]).toBe("id-0");
+  });
+});
+
+describe("buildMarketCurrencyQueryArgs", () => {
+  it("uses the legacy ids filter for coingecko ids", () => {
+    expect(
+      buildMarketCurrencyQueryArgs({
+        marketApiId: "bitcoin",
+        knownLedgerIds: ["bitcoin"],
+        counterCurrency: "usd",
+      }),
+    ).toEqual({
+      args: { id: "bitcoin", counterCurrency: "usd" },
+      skip: false,
+    });
+  });
+
+  it("uses the legacy ids filter for DADA urns", () => {
+    expect(
+      buildMarketCurrencyQueryArgs({
+        marketApiId: "urn:crypto:meta-currency:shiba_inu",
+        knownLedgerIds: ["ethereum/erc20/shiba_inu"],
+        counterCurrency: "eur",
+      }),
+    ).toEqual({
+      args: { id: "shiba-inu", counterCurrency: "eur" },
+      skip: false,
+    });
+  });
+
+  it("uses ledgerIds when only a ledger id is available", () => {
+    expect(
+      buildMarketCurrencyQueryArgs({
+        marketApiId: "ethereum/erc20/shiba_inu",
+        knownLedgerIds: ["ethereum/erc20/shiba_inu"],
+        counterCurrency: "usd",
+      }),
+    ).toEqual({
+      args: { ledgerIds: ["ethereum/erc20/shiba_inu"], counterCurrency: "usd" },
+      skip: false,
+    });
+  });
+
+  it("skips the query when no market id can be resolved", () => {
+    expect(
+      buildMarketCurrencyQueryArgs({
+        counterCurrency: "usd",
+      }),
+    ).toEqual({
+      args: { id: "", counterCurrency: "usd" },
+      skip: true,
+    });
   });
 });

--- a/libs/asset-detail/src/utils/__tests__/resolveMarketCurrencyQuery.test.ts
+++ b/libs/asset-detail/src/utils/__tests__/resolveMarketCurrencyQuery.test.ts
@@ -1,0 +1,71 @@
+import {
+  getMarketLedgerIdsForQuery,
+  isCoingeckoStyleMarketId,
+  MAX_MARKET_LEDGER_IDS,
+  resolveCoingeckoIdForIdsQuery,
+  shouldFetchMarketByLedgerIds,
+} from "../resolveMarketCurrencyQuery";
+
+describe("isCoingeckoStyleMarketId", () => {
+  it("returns true for plain market slugs", () => {
+    expect(isCoingeckoStyleMarketId("shiba-inu")).toBe(true);
+    expect(isCoingeckoStyleMarketId("bitcoin")).toBe(true);
+  });
+
+  it("returns false for ledger ids and DADA urns", () => {
+    expect(isCoingeckoStyleMarketId("ethereum/erc20/shiba_inu")).toBe(false);
+    expect(isCoingeckoStyleMarketId("urn:crypto:meta-currency:shiba_inu")).toBe(false);
+  });
+});
+
+describe("resolveCoingeckoIdForIdsQuery", () => {
+  it("returns coingecko ids as-is", () => {
+    expect(resolveCoingeckoIdForIdsQuery("shiba-inu")).toBe("shiba-inu");
+  });
+
+  it("converts DADA urns to coingecko slugs for the legacy ids filter", () => {
+    expect(resolveCoingeckoIdForIdsQuery("urn:crypto:meta-currency:shiba_inu")).toBe("shiba-inu");
+  });
+
+  it("returns undefined for ledger ids that cannot be mapped to a coingecko slug", () => {
+    expect(resolveCoingeckoIdForIdsQuery("ethereum/erc20/shiba_inu")).toBeUndefined();
+    expect(resolveCoingeckoIdForIdsQuery("solana/spl/bonk")).toBeUndefined();
+  });
+});
+
+describe("shouldFetchMarketByLedgerIds", () => {
+  it("returns false when no ledger ids are known", () => {
+    expect(shouldFetchMarketByLedgerIds("shiba-inu", undefined)).toBe(false);
+    expect(shouldFetchMarketByLedgerIds("shiba-inu", [])).toBe(false);
+  });
+
+  it("returns true when the market api id is missing", () => {
+    expect(shouldFetchMarketByLedgerIds(undefined, ["solana/spl/bonk"])).toBe(true);
+  });
+
+  it("returns true when the market api id is a ledger id", () => {
+    expect(
+      shouldFetchMarketByLedgerIds("ethereum/erc20/shiba_inu", ["ethereum/erc20/shiba_inu"]),
+    ).toBe(true);
+    expect(shouldFetchMarketByLedgerIds("solana/spl/bonk", ["solana/spl/bonk"])).toBe(true);
+  });
+
+  it("returns false when a coingecko id can be queried via ids (legacy / v3 filter)", () => {
+    expect(shouldFetchMarketByLedgerIds("shiba-inu", ["ethereum/erc20/shiba_inu"])).toBe(false);
+    expect(shouldFetchMarketByLedgerIds("bitcoin", ["bitcoin"])).toBe(false);
+  });
+
+  it("returns false for DADA urns that convert to a coingecko slug (backward compatible)", () => {
+    expect(
+      shouldFetchMarketByLedgerIds("urn:crypto:meta-currency:bonk", ["solana/spl/bonk"]),
+    ).toBe(false);
+  });
+});
+
+describe("getMarketLedgerIdsForQuery", () => {
+  it("caps the number of ledger ids sent in the query string", () => {
+    const ledgerIds = Array.from({ length: MAX_MARKET_LEDGER_IDS + 3 }, (_, index) => `id-${index}`);
+    expect(getMarketLedgerIdsForQuery(ledgerIds)).toHaveLength(MAX_MARKET_LEDGER_IDS);
+    expect(getMarketLedgerIdsForQuery(ledgerIds)[0]).toBe("id-0");
+  });
+});

--- a/libs/asset-detail/src/utils/resolveMarketCurrencyQuery.ts
+++ b/libs/asset-detail/src/utils/resolveMarketCurrencyQuery.ts
@@ -1,0 +1,33 @@
+import { dadaIdToMarketId } from "@ledgerhq/live-common/market/utils/index";
+
+/** Cap ledger ids in the query string to keep /v3/markets URLs within safe length. */
+export const MAX_MARKET_LEDGER_IDS = 10;
+
+export function isCoingeckoStyleMarketId(id: string): boolean {
+  return !id.includes("/") && !id.includes(":");
+}
+
+/** Resolves an `ids` query value when the market API supports the legacy filter. */
+export function resolveCoingeckoIdForIdsQuery(marketApiId: string | undefined): string | undefined {
+  if (!marketApiId) return undefined;
+  if (isCoingeckoStyleMarketId(marketApiId)) return marketApiId;
+  const converted = dadaIdToMarketId(marketApiId);
+  return isCoingeckoStyleMarketId(converted) ? converted : undefined;
+}
+
+/**
+ * Prefer the legacy `ids` filter whenever a CoinGecko-style id can be derived
+ * (including from DADA URNs). Fall back to `ledgerIds` only when `ids` cannot
+ * resolve the asset (e.g. token ledger ids like `ethereum/erc20/shiba_inu`).
+ */
+export function shouldFetchMarketByLedgerIds(
+  marketApiId: string | undefined,
+  knownLedgerIds: readonly string[] | undefined,
+): boolean {
+  if (!knownLedgerIds?.length) return false;
+  return resolveCoingeckoIdForIdsQuery(marketApiId) == null;
+}
+
+export function getMarketLedgerIdsForQuery(knownLedgerIds: readonly string[]): string[] {
+  return [...knownLedgerIds].slice(0, MAX_MARKET_LEDGER_IDS);
+}

--- a/libs/asset-detail/src/utils/resolveMarketCurrencyQuery.ts
+++ b/libs/asset-detail/src/utils/resolveMarketCurrencyQuery.ts
@@ -31,3 +31,37 @@ export function shouldFetchMarketByLedgerIds(
 export function getMarketLedgerIdsForQuery(knownLedgerIds: readonly string[]): string[] {
   return [...knownLedgerIds].slice(0, MAX_MARKET_LEDGER_IDS);
 }
+
+export type MarketCurrencyQueryArgs = Readonly<{
+  id?: string;
+  ledgerIds?: string[];
+  counterCurrency: string;
+}>;
+
+export function buildMarketCurrencyQueryArgs({
+  marketApiId,
+  knownLedgerIds,
+  counterCurrency,
+}: {
+  marketApiId?: string;
+  knownLedgerIds?: readonly string[];
+  counterCurrency: string;
+}): { args: MarketCurrencyQueryArgs; skip: boolean } {
+  const fetchByLedgerIds = shouldFetchMarketByLedgerIds(marketApiId, knownLedgerIds);
+  const idsQueryId = resolveCoingeckoIdForIdsQuery(marketApiId);
+
+  if (fetchByLedgerIds && knownLedgerIds?.length) {
+    return {
+      args: {
+        ledgerIds: getMarketLedgerIdsForQuery(knownLedgerIds),
+        counterCurrency,
+      },
+      skip: false,
+    };
+  }
+
+  return {
+    args: { id: idsQueryId ?? marketApiId ?? "", counterCurrency },
+    skip: !idsQueryId && !marketApiId,
+  };
+}

--- a/libs/ledger-live-common/src/market/api/countervalues.ts
+++ b/libs/ledger-live-common/src/market/api/countervalues.ts
@@ -54,14 +54,19 @@ export async function fetchList({
 export async function fetchCurrency({
   counterCurrency,
   id,
+  ledgerIds,
 }: MarketCurrencyRequestParams): Promise<MarketItemResponse> {
   const url = URL.format({
     pathname: `${baseURL()}/v3/markets`,
     query: {
       to: counterCurrency,
-      ids: id,
       pageSize: 1,
       limit: 1,
+      ...(ledgerIds?.length
+        ? { ledgerIds: ledgerIds.join(",") }
+        : {
+            ids: id,
+          }),
     },
   });
 

--- a/libs/ledger-live-common/src/market/hooks/__tests__/useCurrencyData.test.ts
+++ b/libs/ledger-live-common/src/market/hooks/__tests__/useCurrencyData.test.ts
@@ -82,6 +82,26 @@ describe("useCurrencyData", () => {
     unmount();
   });
 
+  it("should call API with ledgerIds when provided", async () => {
+    const wrapper = createWrapper(store);
+    const { unmount } = renderHook(
+      () =>
+        useCurrencyData({
+          ledgerIds: ["ethereum/erc20/shiba_inu"],
+          counterCurrency: "usd",
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(requestCount).toBe(1));
+
+    const url = new URL(lastRequestUrl ?? "");
+    expect(url.searchParams.get("ledgerIds")).toBe("ethereum/erc20/shiba_inu");
+    expect(url.searchParams.get("ids")).toBeNull();
+
+    unmount();
+  });
+
   it("should refetch data automatically based on pollingInterval", async () => {
     const wrapper = createWrapper(store);
     const { result, unmount } = renderHook(

--- a/libs/ledger-live-common/src/market/hooks/useMarketDataProvider.ts
+++ b/libs/ledger-live-common/src/market/hooks/useMarketDataProvider.ts
@@ -20,9 +20,9 @@ import {
 } from "../utils/types";
 import { GlobalMarketDataRequestParams } from "../state-manager/types";
 
-export const useCurrencyData = ({ id, counterCurrency }: MarketCurrencyRequestParams) =>
+export const useCurrencyData = ({ id, ledgerIds, counterCurrency }: MarketCurrencyRequestParams) =>
   useGetCurrencyDataQuery(
-    { id, counterCurrency },
+    { id, ledgerIds, counterCurrency },
     {
       pollingInterval: REFETCH_TIME_ONE_MINUTE * BASIC_REFETCH,
     },

--- a/libs/ledger-live-common/src/market/state-manager/marketApi.ts
+++ b/libs/ledger-live-common/src/market/state-manager/marketApi.ts
@@ -58,13 +58,17 @@ export const marketApi = createApi({
       keepUnusedDataFor: REFETCH_TIME_ONE_MINUTE / 1000,
     }),
     getCurrencyData: build.query<MarketCurrencyData | undefined, MarketCurrencyRequestParams>({
-      query: ({ id, counterCurrency }) => ({
+      query: ({ id, ledgerIds, counterCurrency }) => ({
         url: "/v3/markets",
         params: {
           to: counterCurrency,
-          ids: id,
           pageSize: 1,
           limit: 1,
+          ...(ledgerIds?.length
+            ? { ledgerIds: ledgerIds.join(",") }
+            : {
+                ids: id,
+              }),
         },
       }),
       providesTags: [MarketDataTags.CurrencyData],

--- a/libs/ledger-live-common/src/market/utils/types.ts
+++ b/libs/ledger-live-common/src/market/utils/types.ts
@@ -50,6 +50,8 @@ export type HashMapBody = {
 
 export type MarketCurrencyRequestParams = {
   id?: string;
+  /** Ledger currency ids to resolve via the /v3/markets `ledgerIds` filter. */
+  ledgerIds?: string[];
   counterCurrency?: string;
   range?: string;
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request improves how Asset Detail screens resolve and favorite tokens by ensuring market data queries use the correct identifier—either a CoinGecko-style id or a ledger id—depending on the context. The changes introduce a utility to decide which identifier to use, update API queries to support the new logic, and add comprehensive tests to verify correct behavior. This ensures favorites and market data work reliably for tokens accessed from various entry points (like Market or Assets), especially for tokens without a CoinGecko id.

**Market data query enhancements:**

- Added logic to prefer CoinGecko-style ids for market data queries, falling back to `ledgerIds` only when necessary (e.g., for tokens without a CoinGecko id). This is handled by new utility functions such as `shouldFetchMarketByLedgerIds` and `resolveCoingeckoIdForIdsQuery` in `resolveMarketCurrencyQuery.ts`.
- Updated the API request layer and hooks to support querying `/v3/markets` with a `ledgerIds` filter, including capping the number of ids sent for safety. 

**Asset detail and favorites logic:**

- Fixed favorites toggling to work even when the currency is not yet resolved, ensuring consistency between Market and Asset lists. 
- Improved how known ledger ids are resolved when navigating from Market, preferring `marketState.ledgerIds` when available. 

## Backward compatibility model

The fix uses a **dual-strategy** in `resolveMarketCurrencyQuery.ts`:

| Input | API filter used | Example |
|---|---|---|
| CoinGecko slug | `ids` (legacy v3) | `shiba-inu` |
| DADA URN | `ids` after `dadaIdToMarketId` conversion | `urn:crypto:meta-currency:shiba_inu` → `ids=shiba-inu` |
| Ledger id only | `ledgerIds` (new) | `ethereum/erc20/shiba_inu` |

`ledgerIds` is only used when no CoinGecko id can be derived.

## What is unaffected (legacy paths)

These flows were **not changed** and keep using the v3 `ids` filter:

- **Mobile legacy `MarketDetail`** — starring still uses `currencyId` (CoinGecko id)
- **Mobile legacy `MarketList` (v3)** — `fetchList` with `ids` for favourites
- **Mobile v4 `MarketScreen`** — `useMarketData` / `fetchList` (unchanged)
- **Desktop `/market`** — row starring and navigation unchanged
- **Navigation fallbacks** — when `aggregatedAssets` is off, routes still go to `MarketDetail` / `Accounts > Asset`

## What is covered (v4 Asset Detail)

- **Market → Asset Detail** (`aggregatedAssets: true`) — uses `ids` when CoinGecko id is known
- **Assets placeholders with DADA URN** — converts to `ids=shiba-inu` (legacy-compatible)
- **Tokens with only ledger ids** (Shiba, Bonk) — uses new `ledgerIds` filter

## Tests run — all passing

- `resolveMarketCurrencyQuery` — legacy `ids` preferred over `ledgerIds` for CoinGecko ids and DADA URNs
- `useAssetMarketData` — bitcoin uses `ids` only; Shiba uses `ledgerIds`; DADA URN uses `ids=shiba-inu`
- `useAssetDetailNavigation` — legacy routes to `MarketDetail` when `aggregatedAssets` is disabled
- `marketBanner` integration — AssetDetail when enabled, MarketDetail fallback when disabled

## Small fix applied

`knownMarketId` fallback now uses `resolveCoingeckoIdForIdsQuery()` so DADA URNs resolve to `shiba-inu` for starring even before the API responds (previously URNs were dropped as fallback).

**Conclusion:** Legacy and v4 are compatible. Existing `ids`-based flows are unchanged; `ledgerIds` is only a fallback for tokens that cannot be resolved via `ids`.



### ❓ Context

[LIVE-30795](https://ledgerhq.atlassian.net/browse/LIVE-30795)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-30795]: https://ledgerhq.atlassian.net/browse/LIVE-30795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ