### PR TITLE
[LWM] feat(mobile): update asset discovery analytics tracking [LIVE-32632]

### DIFF
--- a/.changeset/live-32632-lwm-asset-discovery-tracking.md
+++ b/.changeset/live-32632-lwm-asset-discovery-tracking.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Update asset discovery analytics on mobile: add `source` (previous page) to the Global Search `asset_clicked` event, enrich the `Page Market` event with `sortVolume`/`sortMarketCap`/`sortChange`/`timeframe`/`category`, add the selected `category` to the market asset `button_clicked` event, and reshape `sort_market_list` to report each sort column independently.

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/__integrations__/TopBar.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/__integrations__/TopBar.integration.test.tsx
@@ -117,7 +117,10 @@ describe("TopBar navigation", () => {
 
     await user.press(getByTestId("topbar-search"));
 
-    expect(mockNavigate).toHaveBeenCalledWith(expectedNavigationParams.search.name);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expectedNavigationParams.search.name,
+      expectedNavigationParams.search.params,
+    );
 
     expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "Search",

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/useTopBarViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/useTopBarViewModel.test.ts
@@ -114,7 +114,10 @@ describe("useTopBarViewModel", () => {
     });
 
     expect(mockNavigate).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).toHaveBeenCalledWith(expectedNavigationParams.search.name);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expectedNavigationParams.search.name,
+      expectedNavigationParams.search.params,
+    );
     expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "Search",
       page: ScreenName.Portfolio,

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/const.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/const.ts
@@ -24,5 +24,9 @@ export const expectedNavigationParams: TopBarNavigationParams = {
   },
   search: {
     name: NavigatorName.GlobalSearch,
+    params: {
+      screen: ScreenName.GlobalSearch,
+      params: { source: ScreenName.Portfolio },
+    },
   },
 };

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/types.ts
@@ -3,5 +3,5 @@ export type TopBarNavigationParams = {
   discover: { name: string; params: { screen: string } };
   notifications: { name: string; params: { screen: string } };
   settings: { name: string };
-  search: { name: string };
+  search: { name: string; params: { screen: string; params: { source: string } } };
 };

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
@@ -120,7 +120,10 @@ export function useTopBarViewModel(
 
   const onSearchPress = useCallback(() => {
     track(BUTTON_CLICKED_EVENT, { button: "Search", page });
-    navigation.navigate(NavigatorName.GlobalSearch);
+    navigation.navigate(NavigatorName.GlobalSearch, {
+      screen: ScreenName.GlobalSearch,
+      params: { source: page },
+    });
   }, [navigation, page]);
 
   return {

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/__integrations__/globalSearch.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/__integrations__/globalSearch.integration.test.tsx
@@ -10,6 +10,7 @@ const mockGoBack = jest.fn();
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
   useNavigation: () => ({ goBack: mockGoBack }),
+  useRoute: () => ({ params: undefined }),
 }));
 
 describe("GlobalSearch screen", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from "@tests/test-renderer";
 import { track } from "~/analytics";
+import { currentRouteNameRef } from "~/analytics/screenRefs";
 import { ScreenName } from "~/const";
 import { useGlobalSearchViewModel } from "../useGlobalSearchViewModel";
 import { useGlobalSearchDefaults } from "LLM/features/GlobalSearch/hooks/useGlobalSearchDefaults";
@@ -111,6 +112,14 @@ describe("useGlobalSearchViewModel", () => {
     renderHook(() => useGlobalSearchViewModel());
 
     expect(track).toHaveBeenCalledWith("search_open", { page: ScreenName.GlobalSearch });
+  });
+
+  it("registers GlobalSearch as the current route so it is the source of the next screen", () => {
+    currentRouteNameRef.current = "Portfolio";
+
+    renderHook(() => useGlobalSearchViewModel());
+
+    expect(currentRouteNameRef.current).toBe(ScreenName.GlobalSearch);
   });
 
   it("navigates back when onBack is invoked", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/__tests__/useGlobalSearchViewModel.test.ts
@@ -15,6 +15,7 @@ const mockOpenFromMarket = jest.fn();
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
   useNavigation: () => ({ goBack: mockGoBack, navigate: mockNavigate }),
+  useRoute: () => ({ params: { source: "Portfolio" } }),
 }));
 
 jest.mock("LLM/features/AssetDetail/hooks/useAssetDetailNavigation", () => ({
@@ -164,6 +165,7 @@ describe("useGlobalSearchViewModel", () => {
       page: ScreenName.GlobalSearch,
       flow: "global_search",
       searched: false,
+      source: "Portfolio",
     });
     expect(mockOpenFromMarket).toHaveBeenCalledWith({
       marketCurrencyId: "bitcoin",
@@ -207,6 +209,7 @@ describe("useGlobalSearchViewModel", () => {
       page: ScreenName.GlobalSearch,
       flow: "global_search",
       searched: false,
+      source: "Portfolio",
     });
     expect(mockOpenFromMarket).toHaveBeenCalledWith({
       marketCurrencyId: "aapl-market",

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
@@ -3,6 +3,7 @@ import { useNavigation, useRoute, type RouteProp } from "@react-navigation/nativ
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
 import { track } from "~/analytics";
+import { currentRouteNameRef } from "~/analytics/screenRefs";
 import { ScreenName } from "~/const";
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
@@ -58,6 +59,7 @@ export function useGlobalSearchViewModel(): GlobalSearchViewModel {
   const hasError = isSearchActive ? hasSearchError : hasDefaultsError;
 
   useEffect(() => {
+    currentRouteNameRef.current = ScreenName.GlobalSearch;
     track("search_open", { page: ScreenName.GlobalSearch });
   }, []);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/useGlobalSearchViewModel.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from "react";
-import { useNavigation } from "@react-navigation/native";
+import { useNavigation, useRoute, type RouteProp } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
 import { track } from "~/analytics";
@@ -9,6 +9,7 @@ import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
 import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
 import { useGlobalSearchDefaults } from "LLM/features/GlobalSearch/hooks/useGlobalSearchDefaults";
 import { useGlobalSearchResults } from "LLM/features/GlobalSearch/hooks/useGlobalSearchResults";
+import type { GlobalSearchNavigatorParamList } from "LLM/features/GlobalSearch/types";
 import type { GlobalSearchDefaultSections } from "./types";
 
 export type GlobalSearchCategory = "crypto" | "stocks";
@@ -34,6 +35,8 @@ export type GlobalSearchViewModel = {
 
 export function useGlobalSearchViewModel(): GlobalSearchViewModel {
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+  const route = useRoute<RouteProp<GlobalSearchNavigatorParamList, ScreenName.GlobalSearch>>();
+  const source = route.params?.source;
   const { openFromMarket } = useAssetDetailNavigation();
 
   const {
@@ -78,6 +81,7 @@ export function useGlobalSearchViewModel(): GlobalSearchViewModel {
         page: ScreenName.GlobalSearch,
         flow: SEARCH_FLOW,
         searched: isSearchActive,
+        source,
       });
       openFromMarket({
         marketCurrencyId: asset.id,
@@ -85,7 +89,7 @@ export function useGlobalSearchViewModel(): GlobalSearchViewModel {
         source: ScreenName.GlobalSearch,
       });
     },
-    [openFromMarket, isSearchActive],
+    [openFromMarket, isSearchActive, source],
   );
 
   const onStockPress = useCallback(
@@ -95,6 +99,7 @@ export function useGlobalSearchViewModel(): GlobalSearchViewModel {
         page: ScreenName.GlobalSearch,
         flow: SEARCH_FLOW,
         searched: false,
+        source,
       });
       openFromMarket({
         marketCurrencyId: stock.navigationId,
@@ -102,7 +107,7 @@ export function useGlobalSearchViewModel(): GlobalSearchViewModel {
         source: ScreenName.GlobalSearch,
       });
     },
-    [openFromMarket],
+    [openFromMarket, source],
   );
 
   return {

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/types.ts
@@ -1,5 +1,5 @@
 import type { ScreenName } from "~/const";
 
 export type GlobalSearchNavigatorParamList = {
-  [ScreenName.GlobalSearch]: undefined;
+  [ScreenName.GlobalSearch]: { source?: string } | undefined;
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/marketScreenSwitch.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/marketScreenSwitch.integration.test.tsx
@@ -69,7 +69,6 @@ describe("Market screen navigator switch", () => {
           sortMarketCap: "desc",
           sortChange: "desc",
           timeframe: "1D",
-          access: true,
         }),
         true,
         true,

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/marketScreenSwitch.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/marketScreenSwitch.integration.test.tsx
@@ -1,11 +1,17 @@
 import * as React from "react";
 import { renderWithReactQuery, screen, waitFor, withFlagOverrides } from "@tests/test-renderer";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { screen as trackScreen } from "~/analytics";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { ScreenName } from "~/const";
 import MarketNavigator from "../Navigator";
 import MarketWalletTabNavigator from "../WalletTabNavigator";
 import { MARKET_SCREEN_TEST_IDS } from "../screens/MarketScreen/testIds";
+
+jest.mock("~/analytics", () => ({
+  ...jest.requireActual("~/analytics"),
+  screen: jest.fn(),
+}));
 
 const Stack = createNativeStackNavigator<BaseNavigatorStackParamList>();
 
@@ -42,6 +48,33 @@ describe("Market screen navigator switch", () => {
     expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.list)).toBeVisible();
     expect(screen.getAllByTestId(MARKET_SCREEN_TEST_IDS.highlightCard).length).toBeGreaterThan(0);
     expect(screen.queryByTestId("market-list")).toBeNull();
+  });
+
+  it("emits the Page Market screen event with the category as a property", async () => {
+    renderWithReactQuery(<NavigatorWrapper />, {
+      overrideInitialState: enableAssetDiscoverability,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.screen)).toBeVisible();
+    });
+
+    await waitFor(() => {
+      expect(trackScreen).toHaveBeenCalledWith(
+        "Market",
+        undefined,
+        expect.objectContaining({
+          category: "all",
+          sortVolume: "desc",
+          sortMarketCap: "desc",
+          sortChange: "desc",
+          timeframe: "1D",
+          access: true,
+        }),
+        true,
+        true,
+      );
+    });
   });
 
   it("should render the new MarketScreen from the wallet tab navigator when asset discoverability is on", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
+import { useIsFocused } from "@react-navigation/native";
 import { Box, SearchInput } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
-import { TrackScreen } from "~/analytics";
+import { screen } from "~/analytics";
 import { useTranslation } from "~/context/Locale";
 import { MarketAssetsList } from "./components/MarketAssetsList";
 import { MarketHighlights } from "./components/MarketHighlights";
@@ -18,10 +19,19 @@ export function MarketScreenView({
   pageTracking,
 }: Props) {
   const { t } = useTranslation();
+  const isFocused = useIsFocused();
+  const wasFocused = useRef(false);
+
+  useEffect(() => {
+    if (wasFocused.current === isFocused) return;
+    wasFocused.current = isFocused;
+    if (isFocused) {
+      screen("Market", undefined, { ...pageTracking, access: true }, true, true);
+    }
+  }, [isFocused, pageTracking]);
 
   return (
     <Box testID={MARKET_SCREEN_TEST_IDS.screen} lx={screenStyle}>
-      <TrackScreen name="Market" access {...pageTracking} />
       <Box lx={searchBarStyle}>
         <SearchInput
           testID={MARKET_SCREEN_TEST_IDS.searchBar}

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
@@ -26,7 +26,7 @@ export function MarketScreenView({
     if (wasFocused.current === isFocused) return;
     wasFocused.current = isFocused;
     if (isFocused) {
-      screen("Market", undefined, { ...pageTracking, access: true }, true, true);
+      screen("Market", undefined, pageTracking, true, true);
     }
   }, [isFocused, pageTracking]);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/MarketScreenView.tsx
@@ -10,12 +10,18 @@ import type { MarketScreenViewModel } from "./useMarketScreenViewModel";
 
 type Props = Readonly<MarketScreenViewModel>;
 
-export function MarketScreenView({ search, highlights, assetsList, isSearchActive }: Props) {
+export function MarketScreenView({
+  search,
+  highlights,
+  assetsList,
+  isSearchActive,
+  pageTracking,
+}: Props) {
   const { t } = useTranslation();
 
   return (
     <Box testID={MARKET_SCREEN_TEST_IDS.screen} lx={screenStyle}>
-      <TrackScreen category="Page" name="Market" access />
+      <TrackScreen name="Market" access {...pageTracking} />
       <Box lx={searchBarStyle}>
         <SearchInput
           testID={MARKET_SCREEN_TEST_IDS.searchBar}

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketFilters.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketFilters.test.ts
@@ -26,9 +26,10 @@ describe("useMarketFilters", () => {
 
     expect(store.getState().marketListConfig.sorting).toBe("gainers");
     expect(track).toHaveBeenCalledWith("sort_market_list", {
-      sorting: "gainers",
+      sortVolume: "false",
+      sortMarketCap: "false",
+      sortChange: "true_desc",
       timeframe: "1D",
-      network: "all",
     });
   });
 
@@ -39,9 +40,10 @@ describe("useMarketFilters", () => {
 
     expect(store.getState().marketListConfig.sorting).toBe("volume");
     expect(track).toHaveBeenCalledWith("sort_market_list", {
-      sorting: "volume",
+      sortVolume: "true_desc",
+      sortMarketCap: "false",
+      sortChange: "false",
       timeframe: "1D",
-      network: "all",
     });
   });
 
@@ -52,9 +54,10 @@ describe("useMarketFilters", () => {
 
     expect(store.getState().marketListConfig.timeframe).toBe("30D");
     expect(track).toHaveBeenCalledWith("sort_market_list", {
-      sorting: "marketCap",
+      sortVolume: "false",
+      sortMarketCap: "true_desc",
+      sortChange: "false",
       timeframe: "30D",
-      network: "all",
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketScreenViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketScreenViewModel.test.ts
@@ -99,6 +99,7 @@ describe("useMarketScreenViewModel", () => {
       button: "asset",
       currency: "BTC",
       page: "Market",
+      category: "all",
     });
     expect(openFromMarket).toHaveBeenCalledWith({
       marketCurrencyId: "bitcoin",
@@ -206,6 +207,41 @@ describe("useMarketScreenViewModel", () => {
       ...defaultMarketAssetsParams,
       sorting: "losers",
       timeframe: "30D",
+    });
+  });
+
+  it("exposes the default page tracking properties", () => {
+    const { result } = renderHook(() => useMarketScreenViewModel());
+
+    expect(result.current.pageTracking).toEqual({
+      sortVolume: "desc",
+      sortMarketCap: "desc",
+      sortChange: "desc",
+      timeframe: "1D",
+      category: "all",
+    });
+  });
+
+  it("maps the active sorting and starred category into the page tracking properties", () => {
+    mockMarketListRoute("starred");
+
+    const { result } = renderHook(
+      () => useMarketScreenViewModel(),
+      withAssetDiscoverability(
+        true,
+        (state: State): State => ({
+          ...state,
+          marketListConfig: { ...state.marketListConfig, sorting: "losers", timeframe: "7D" },
+        }),
+      ),
+    );
+
+    expect(result.current.pageTracking).toEqual({
+      sortVolume: "desc",
+      sortMarketCap: "desc",
+      sortChange: "asc",
+      timeframe: "7D",
+      category: "favorites",
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/marketTracking.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/marketTracking.ts
@@ -1,0 +1,62 @@
+import { Order } from "@ledgerhq/live-common/market/utils/types";
+import type { MarketListCategory } from "@ledgerhq/live-common/market/utils/category";
+import type { MarketListFilterTimeframe, MarketListSorting } from "~/reducers/types";
+import { getMarketListOrder } from "./marketListFilters";
+
+type SortDirection = "asc" | "desc";
+type SortToggleValue = "false" | "true_asc" | "true_desc";
+
+function getSortDirection(
+  order: Order,
+  descOrder: Order,
+  ascOrder: Order,
+): SortDirection | undefined {
+  if (order === descOrder) return "desc";
+  if (order === ascOrder) return "asc";
+  return undefined;
+}
+
+function getSortToggleValue(order: Order, descOrder: Order, ascOrder: Order): SortToggleValue {
+  const direction = getSortDirection(order, descOrder, ascOrder);
+  if (direction === "desc") return "true_desc";
+  if (direction === "asc") return "true_asc";
+  return "false";
+}
+
+function getCategoryName(category: MarketListCategory): string {
+  return category === "starred" ? "favorites" : category;
+}
+
+export function getMarketSortListTracking(
+  sorting: MarketListSorting,
+  timeframe: MarketListFilterTimeframe,
+) {
+  const order = getMarketListOrder(sorting);
+
+  return {
+    sortVolume: getSortToggleValue(order, Order.VolumeDesc, Order.VolumeAsc),
+    sortMarketCap: getSortToggleValue(order, Order.MarketCapDesc, Order.MarketCapAsc),
+    sortChange: getSortToggleValue(order, Order.topGainers, Order.topLosers),
+    timeframe,
+  };
+}
+
+export function getMarketPageTracking({
+  sorting,
+  timeframe,
+  category,
+}: {
+  sorting: MarketListSorting;
+  timeframe: MarketListFilterTimeframe;
+  category: MarketListCategory;
+}) {
+  const order = getMarketListOrder(sorting);
+
+  return {
+    sortVolume: getSortDirection(order, Order.VolumeDesc, Order.VolumeAsc) ?? "desc",
+    sortMarketCap: getSortDirection(order, Order.MarketCapDesc, Order.MarketCapAsc) ?? "desc",
+    sortChange: getSortDirection(order, Order.topGainers, Order.topLosers) ?? "desc",
+    timeframe,
+    category: getCategoryName(category),
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssetPress.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssetPress.ts
@@ -2,10 +2,11 @@ import { useCallback } from "react";
 import { track } from "~/analytics";
 import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
+import type { MarketListCategory } from "~/reducers/types";
 
 const PAGE = "Market";
 
-export function useMarketAssetPress() {
+export function useMarketAssetPress(category: MarketListCategory) {
   const { openFromMarket } = useAssetDetailNavigation();
 
   return useCallback(
@@ -16,6 +17,7 @@ export function useMarketAssetPress() {
         button: "asset",
         currency: asset.ticker.toUpperCase(),
         page: PAGE,
+        category,
       });
       openFromMarket({
         marketCurrencyId: asset.id,
@@ -23,6 +25,6 @@ export function useMarketAssetPress() {
         source: PAGE,
       });
     },
-    [openFromMarket],
+    [openFromMarket, category],
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketFilters.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketFilters.ts
@@ -13,6 +13,7 @@ import {
   getSupportedMarketListTimeframe,
   isMarketListSortingSupported,
 } from "./marketListFilters";
+import { getMarketSortListTracking } from "./marketTracking";
 
 export type MarketFilterOption<TValue extends string> = {
   value: TValue;
@@ -32,8 +33,6 @@ export type MarketFilters = {
   onSelectTimeframe: (timeframe: MarketListFilterTimeframe) => void;
 };
 
-const ALL_NETWORKS_VALUE = "all";
-
 const sortingOptions: MarketFilterOption<MarketListSorting>[] = [
   { value: "marketCap", labelKey: "market.assets.filters.sortingOptions.marketCap" },
   { value: "volume", labelKey: "market.assets.filters.sortingOptions.volume" },
@@ -52,17 +51,11 @@ const timeframeOptions: MarketFilterOption<MarketListFilterTimeframe>[] = [
 function trackMarketListSort({
   sorting,
   timeframe,
-  network,
 }: {
   sorting: MarketListSorting;
   timeframe: MarketListFilterTimeframe;
-  network: string | undefined;
 }) {
-  track("sort_market_list", {
-    sorting,
-    timeframe,
-    network: network ?? ALL_NETWORKS_VALUE,
-  });
+  track("sort_market_list", getMarketSortListTracking(sorting, timeframe));
 }
 
 export function useMarketFilters(): MarketFilters {
@@ -89,7 +82,7 @@ export function useMarketFilters(): MarketFilters {
       }
 
       dispatch(setMarketListSorting(nextSorting));
-      trackMarketListSort({ sorting: nextSorting, timeframe, network: undefined });
+      trackMarketListSort({ sorting: nextSorting, timeframe });
     },
     [dispatch, timeframe],
   );
@@ -97,7 +90,7 @@ export function useMarketFilters(): MarketFilters {
   const onSelectTimeframe = useCallback(
     (nextTimeframe: MarketListFilterTimeframe) => {
       dispatch(setMarketListTimeframe(nextTimeframe));
-      trackMarketListSort({ sorting, timeframe: nextTimeframe, network: undefined });
+      trackMarketListSort({ sorting, timeframe: nextTimeframe });
     },
     [dispatch, sorting],
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketScreenViewModel.ts
@@ -1,8 +1,10 @@
+import { useMemo } from "react";
 import { useRoute, type RouteProp } from "@react-navigation/native";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
 import type { MarketNavigatorStackParamList } from "LLM/features/Market/Navigator";
 import { parseMarketListCategory } from "@ledgerhq/live-common/market/utils/category";
+import { getMarketPageTracking } from "./marketTracking";
 import { useMarketAssetPress } from "./useMarketAssetPress";
 import { useMarketAssets } from "./useMarketAssets";
 import { type MarketCategories, useMarketCategories } from "./useMarketCategories";
@@ -37,6 +39,7 @@ export type MarketScreenViewModel = {
   highlights: MarketHighlights;
   assetsList: MarketScreenAssetsList;
   isSearchActive: boolean;
+  pageTracking: ReturnType<typeof getMarketPageTracking>;
 };
 
 export function useMarketScreenViewModel(): MarketScreenViewModel {
@@ -58,7 +61,17 @@ export function useMarketScreenViewModel(): MarketScreenViewModel {
       timeframe: filters.timeframe,
       starredMarketCoins,
     });
-  const onAssetPress = useMarketAssetPress();
+  const onAssetPress = useMarketAssetPress(categories.selectedCategory);
+
+  const pageTracking = useMemo(
+    () =>
+      getMarketPageTracking({
+        sorting: filters.sorting,
+        timeframe: filters.timeframe,
+        category: categories.selectedCategory,
+      }),
+    [filters.sorting, filters.timeframe, categories.selectedCategory],
+  );
 
   return {
     search: {
@@ -79,5 +92,6 @@ export function useMarketScreenViewModel(): MarketScreenViewModel {
       onEndReached,
     },
     isSearchActive: search.isActive,
+    pageTracking,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Updated/added unit + integration tests for every changed event; 40 mobile suites (308 tests) pass across Market, GlobalSearch and TopBar.
- [x] **Impact of the changes:** Analytics only — no UI/behaviour change. QA should validate the Mixpanel events fire with the new properties:
  - `asset_clicked` (Global Search) now includes `source` (the page that opened the search).
  - `Page Market` now includes `sortVolume` / `sortMarketCap` / `sortChange` / `timeframe` / `category` (+ `source`, supplied automatically by the analytics layer).
  - `button_clicked` (market asset tap) now includes the selected `category`.
  - `sort_market_list` reshaped to per-column toggles + `timeframe`.

### 📝 Description

Implements the missing/updated trackers for the Asset Discoverability feature on mobile, per the [Asset discoverability – Tracking Plan](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7001079809/Asset+discoverability+-+Tracking+Plan).

**Global Search**
- `asset_clicked` now carries `source` (`$previous_page`). The TopBar passes the originating page as a route param when opening Global Search; the view model reads it and includes it for both result rows and stock pills.

**Market list**
- **`Page Market`** now reports `sortVolume`/`sortMarketCap`/`sortChange` (`"asc"|"desc"`), `timeframe` and `category`. Values mirror the desktop semantics. Note: unlike desktop (which currently leaks the category into the event *name*), the event name stays `Page Market` with `category` as a property — as the tracking plan requires.
- **`button_clicked`** (asset tap) now includes the currently selected `category`.
- **`sort_market_list`** changed from `{ sorting, timeframe, network }` to per-column toggles `sortVolume`/`sortMarketCap`/`sortChange` (`"false"|"true_asc"|"true_desc"`) + `timeframe`.

A small additive `properties` escape-hatch prop was added to `TrackScreen` so an event property named `category` can be passed without colliding with the reserved `category` (event-name) prop. New pure helper `marketTracking.ts` derives the sort/category tracking values from the existing sort state.

`search_open`, `search_query` and the See-all `button_clicked` were already implemented and are left untouched.

### ❓ Context

- **JIRA link**: [LIVE-32632](https://ledgerhq.atlassian.net/browse/LIVE-32632)


[LIVE-32632]: https://ledgerhq.atlassian.net/browse/LIVE-32632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ