### PR TITLE
[LWM] feat(lwm): add confirmation step to new send flow

### DIFF
--- a/.changeset/send-confirmation-step.md
+++ b/.changeset/send-confirmation-step.md
@@ -1,0 +1,9 @@
+---
+"live-mobile": minor
+---
+
+feat(lwm): add the confirmation step to the new send flow
+
+- Add the confirmation screen shown after the device signature: a single screen that renders success or error based on the send flow status.
+- Success: full-screen "Transaction signed" with "View transaction" / "Close".
+- Error: a guard on top of the device flow (e.g. broadcast failure) showing the failure reason, "Save logs" and "Try again" / "Close".

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4541,6 +4541,9 @@
           "retry": "Try again"
         }
       },
+      "confirmation": {
+        "viewTransaction": "View transaction"
+      },
       "gasOptionsSync": {
         "warningTitle": "Unable to refresh network fees",
         "warningDescription": "Fee presets may be outdated."

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/__tests__/ConfirmationScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/__tests__/ConfirmationScreen.test.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { FLOW_STATUS } from "@ledgerhq/live-common/flows/wizard/types";
+import { render, screen, fireEvent } from "@tests/test-renderer";
+import { ConfirmationScreen } from "../index";
+import * as UseConfirmationViewModelModule from "../hooks/useConfirmationViewModel";
+
+type ConfirmationViewModel = ReturnType<
+  typeof UseConfirmationViewModelModule.useConfirmationViewModel
+>;
+
+jest.mock("../hooks/useConfirmationViewModel", () => ({
+  useConfirmationViewModel: jest.fn(),
+}));
+
+const onViewTransaction = jest.fn();
+const onSaveLogs = jest.fn();
+const onRetry = jest.fn();
+const onClose = jest.fn();
+
+function buildViewModel(overrides: Partial<ConfirmationViewModel> = {}): ConfirmationViewModel {
+  return {
+    status: FLOW_STATUS.SUCCESS,
+    transactionError: null,
+    canViewTransaction: true,
+    onViewTransaction,
+    onSaveLogs,
+    onRetry,
+    onClose,
+    ...overrides,
+  };
+}
+
+function mockViewModel(overrides: Partial<ConfirmationViewModel> = {}) {
+  jest
+    .mocked(UseConfirmationViewModelModule.useConfirmationViewModel)
+    .mockReturnValue(buildViewModel(overrides));
+}
+
+describe("ConfirmationScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the success title, description and both actions", () => {
+    mockViewModel();
+    render(<ConfirmationScreen />);
+
+    expect(screen.getByText("Transaction signed")).toBeOnTheScreen();
+    expect(screen.getByText("Your transaction is being processed")).toBeOnTheScreen();
+    expect(screen.getByTestId("send-confirmation-success-gradient")).toBeOnTheScreen();
+    expect(screen.getByTestId("send-confirmation-success-view-transaction")).toBeOnTheScreen();
+    expect(screen.getByTestId("send-confirmation-success-close")).toBeOnTheScreen();
+  });
+
+  it("triggers onViewTransaction and onClose when the buttons are pressed", () => {
+    mockViewModel();
+    render(<ConfirmationScreen />);
+
+    fireEvent.press(screen.getByTestId("send-confirmation-success-view-transaction"));
+    expect(onViewTransaction).toHaveBeenCalledTimes(1);
+
+    fireEvent.press(screen.getByTestId("send-confirmation-success-close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the view transaction button when there is no operation to show", () => {
+    mockViewModel({ canViewTransaction: false });
+    render(<ConfirmationScreen />);
+
+    expect(screen.queryByTestId("send-confirmation-success-view-transaction")).toBeNull();
+    expect(screen.getByTestId("send-confirmation-success-close")).toBeOnTheScreen();
+  });
+
+  it("renders the error state with save logs/retry/close when the flow status is ERROR", () => {
+    mockViewModel({ status: FLOW_STATUS.ERROR, transactionError: new Error("broadcast failed") });
+    render(<ConfirmationScreen />);
+
+    expect(screen.queryByTestId("send-confirmation-success")).toBeNull();
+    expect(screen.getByTestId("send-confirmation-error")).toBeOnTheScreen();
+    expect(screen.getByTestId("send-confirmation-error-gradient")).toBeOnTheScreen();
+
+    fireEvent.press(screen.getByTestId("send-confirmation-error-save-logs"));
+    expect(onSaveLogs).toHaveBeenCalledTimes(1);
+
+    fireEvent.press(screen.getByTestId("send-confirmation-error-retry"));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    fireEvent.press(screen.getByTestId("send-confirmation-error-close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the success screen for a non-error status", () => {
+    mockViewModel({ status: FLOW_STATUS.IDLE });
+    render(<ConfirmationScreen />);
+
+    expect(screen.queryByTestId("send-confirmation-error")).toBeNull();
+    expect(screen.getByTestId("send-confirmation-success")).toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/components/ConfirmationErrorView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/components/ConfirmationErrorView/index.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { Button, Link } from "@ledgerhq/lumen-ui-rnative";
+import TranslatedError from "~/components/TranslatedError";
+import { ConfirmationStatusLayout } from "../ConfirmationStatusLayout";
+
+export type ConfirmationErrorViewProps = Readonly<{
+  error: Error | null;
+  saveLogsLabel: string;
+  retryLabel: string;
+  closeLabel: string;
+  onSaveLogs: () => void;
+  onRetry: () => void;
+  onClose: () => void;
+}>;
+
+export function ConfirmationErrorView({
+  error,
+  saveLogsLabel,
+  retryLabel,
+  closeLabel,
+  onSaveLogs,
+  onRetry,
+  onClose,
+}: ConfirmationErrorViewProps) {
+  return (
+    <ConfirmationStatusLayout
+      tone="error"
+      title={error ? <TranslatedError error={error} field="title" /> : undefined}
+      description={error ? <TranslatedError error={error} field="description" /> : undefined}
+      testID="send-confirmation-error"
+      belowDescription={
+        <Link
+          appearance="accent"
+          size="md"
+          underline={false}
+          onPress={onSaveLogs}
+          testID="send-confirmation-error-save-logs"
+        >
+          {saveLogsLabel}
+        </Link>
+      }
+      actions={
+        <>
+          <Button
+            appearance="base"
+            size="lg"
+            lx={{ width: "full" }}
+            onPress={onRetry}
+            testID="send-confirmation-error-retry"
+          >
+            {retryLabel}
+          </Button>
+          <Button
+            appearance="gray"
+            size="lg"
+            lx={{ width: "full" }}
+            onPress={onClose}
+            testID="send-confirmation-error-close"
+          >
+            {closeLabel}
+          </Button>
+        </>
+      }
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/components/ConfirmationScreenView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/components/ConfirmationScreenView/index.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { Button } from "@ledgerhq/lumen-ui-rnative";
+import { ConfirmationStatusLayout } from "../ConfirmationStatusLayout";
+
+export type ConfirmationScreenViewProps = Readonly<{
+  title: string;
+  description: string;
+  viewTransactionLabel: string;
+  closeLabel: string;
+  canViewTransaction: boolean;
+  onViewTransaction: () => void;
+  onClose: () => void;
+}>;
+
+export function ConfirmationScreenView({
+  title,
+  description,
+  viewTransactionLabel,
+  closeLabel,
+  canViewTransaction,
+  onViewTransaction,
+  onClose,
+}: ConfirmationScreenViewProps) {
+  return (
+    <ConfirmationStatusLayout
+      tone="success"
+      title={title}
+      description={description}
+      testID="send-confirmation-success"
+      actions={
+        <>
+          {canViewTransaction ? (
+            <Button
+              appearance="gray"
+              size="lg"
+              lx={{ width: "full" }}
+              onPress={onViewTransaction}
+              testID="send-confirmation-success-view-transaction"
+            >
+              {viewTransactionLabel}
+            </Button>
+          ) : null}
+          <Button
+            appearance="base"
+            size="lg"
+            lx={{ width: "full" }}
+            onPress={onClose}
+            testID="send-confirmation-success-close"
+          >
+            {closeLabel}
+          </Button>
+        </>
+      }
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/components/ConfirmationStatusLayout/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/components/ConfirmationStatusLayout/index.tsx
@@ -1,0 +1,80 @@
+import React, { type ReactNode } from "react";
+import { View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Box, Spot, Text } from "@ledgerhq/lumen-ui-rnative";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
+import { StatusGradient, type StatusGradientTone } from "LLM/components/StatusGradient";
+
+const SPOT_APPEARANCE_BY_TONE = { success: "check", error: "error", info: "info" } as const;
+
+export type ConfirmationStatusLayoutProps = Readonly<{
+  tone: StatusGradientTone;
+  title?: ReactNode;
+  description?: ReactNode;
+  belowDescription?: ReactNode;
+  actions: ReactNode;
+  testID?: string;
+}>;
+
+/**
+ * Full-screen status layout shared by the success and error confirmation screens:
+ * a top status glow, a centered spot with title/description, and bottom actions.
+ */
+export function ConfirmationStatusLayout({
+  tone,
+  title,
+  description,
+  belowDescription,
+  actions,
+  testID,
+}: ConfirmationStatusLayoutProps) {
+  const styles = useStyleSheet(
+    theme => ({
+      container: {
+        flex: 1,
+        backgroundColor: theme.colors.bg.base,
+      },
+      gradient: {
+        position: "absolute",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+      },
+    }),
+    [],
+  );
+
+  return (
+    <SafeAreaView style={styles.container} edges={["bottom"]} testID={testID}>
+      <View pointerEvents="none" style={styles.gradient}>
+        <StatusGradient tone={tone} testID={testID ? `${testID}-gradient` : undefined} />
+      </View>
+
+      <Box lx={{ flex: 1, paddingHorizontal: "s16", paddingVertical: "s24" }}>
+        <Box lx={{ flex: 1, alignItems: "center", justifyContent: "center", gap: "s24" }}>
+          <Spot appearance={SPOT_APPEARANCE_BY_TONE[tone]} size={72} />
+          {title || description || belowDescription ? (
+            <Box lx={{ gap: "s8", alignItems: "center" }}>
+              {title ? (
+                <Text typography="heading4SemiBold" lx={{ color: "base", textAlign: "center" }}>
+                  {title}
+                </Text>
+              ) : null}
+              {description ? (
+                <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
+                  {description}
+                </Text>
+              ) : null}
+              {belowDescription ? (
+                <Box lx={{ marginTop: "s16", alignItems: "center" }}>{belowDescription}</Box>
+              ) : null}
+            </Box>
+          ) : null}
+        </Box>
+
+        <Box lx={{ gap: "s16" }}>{actions}</Box>
+      </Box>
+    </SafeAreaView>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/hooks/useConfirmationViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/hooks/useConfirmationViewModel.ts
@@ -1,0 +1,46 @@
+import { useCallback } from "react";
+import { useNavigation } from "@react-navigation/native";
+import { ScreenName } from "~/const";
+import type { BaseNavigationComposite } from "~/components/RootNavigator/types/helpers";
+import useExportLogs from "~/components/useExportLogs";
+import { useSendFlowActions, useSendFlowData } from "../../../context/SendFlowContext";
+import type { SendFlowNavigationProp } from "../../../types";
+
+export function useConfirmationViewModel() {
+  const navigation = useNavigation<BaseNavigationComposite<SendFlowNavigationProp>>();
+  const { close, status: statusActions, operation } = useSendFlowActions();
+  const { state } = useSendFlowData();
+  const { account, parentAccount } = state.account;
+  const onSaveLogs = useExportLogs();
+
+  const optimisticOperation = state.operation.optimisticOperation;
+  const concernedOperation =
+    optimisticOperation?.subOperations?.find(op => op.accountId === account?.id) ??
+    optimisticOperation ??
+    null;
+
+  const onViewTransaction = useCallback(() => {
+    if (!account || !concernedOperation) return;
+    navigation.navigate(ScreenName.OperationDetails, {
+      accountId: account.id,
+      parentId: parentAccount?.id ?? undefined,
+      operation: concernedOperation,
+    });
+  }, [account, parentAccount, concernedOperation, navigation]);
+
+  const onRetry = useCallback(() => {
+    navigation.replace(ScreenName.SendFlowSignature);
+    operation.onRetry();
+    statusActions.resetStatus();
+  }, [navigation, operation, statusActions]);
+
+  return {
+    status: state.flowStatus,
+    transactionError: state.operation.transactionError,
+    canViewTransaction: Boolean(account && concernedOperation),
+    onViewTransaction,
+    onSaveLogs,
+    onRetry,
+    onClose: close,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/index.tsx
@@ -1,16 +1,45 @@
 import React from "react";
-import { View } from "react-native";
-import { Text } from "@ledgerhq/lumen-ui-rnative";
-import { SendFlowLayout } from "../../components/SendFlowLayout";
+import { FLOW_STATUS } from "@ledgerhq/live-common/flows/wizard/types";
+import { useTranslation } from "~/context/Locale";
+import { ConfirmationScreenView } from "./components/ConfirmationScreenView";
+import { ConfirmationErrorView } from "./components/ConfirmationErrorView";
+import { useConfirmationViewModel } from "./hooks/useConfirmationViewModel";
 
 export function ConfirmationScreen() {
+  const { t } = useTranslation();
+  const {
+    status,
+    transactionError,
+    canViewTransaction,
+    onViewTransaction,
+    onSaveLogs,
+    onRetry,
+    onClose,
+  } = useConfirmationViewModel();
+
+  if (status === FLOW_STATUS.ERROR) {
+    return (
+      <ConfirmationErrorView
+        error={transactionError}
+        saveLogsLabel={t("common.saveLogs")}
+        retryLabel={t("common.tryAgain")}
+        closeLabel={t("common.close")}
+        onSaveLogs={onSaveLogs}
+        onRetry={onRetry}
+        onClose={onClose}
+      />
+    );
+  }
+
   return (
-    <SendFlowLayout>
-      <View style={{ flex: 1 }}>
-        <Text typography="body2" lx={{ color: "muted" }}>
-          {"Confirmation screen"}
-        </Text>
-      </View>
-    </SendFlowLayout>
+    <ConfirmationScreenView
+      title={t("send.newSendFlow.transactionSigned")}
+      description={t("send.newSendFlow.processingTransaction")}
+      viewTransactionLabel={t("send.newSendFlow.confirmation.viewTransaction")}
+      closeLabel={t("common.close")}
+      canViewTransaction={canViewTransaction}
+      onViewTransaction={onViewTransaction}
+      onClose={onClose}
+    />
   );
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile new send flow: success step shown after broadcast ("Transaction signed")
  - "View transaction" opens the operation details with the right account/operation
  - "Close" exits the send flow
  - Error step shown when the broadcast fails after signing (instead of a hardcoded success), with "Save logs" + "Try again"

### 📝 Description

After the signature step, the new send flow broadcasts the transaction and must show a confirmation. On mobile the confirmation step was a placeholder, so a broadcast failure after signing would still have shown a hardcoded success.

This PR implements the confirmation step on mobile. It reads the flow status directly from the send context (`state.flowStatus`, already set by the signature core) — no re-derivation — and renders accordingly, all on the same page:

- **SUCCESS** → full-screen "Transaction signed" with a green status glow, "View transaction" + "Close".
- **ERROR** (broadcast failure after signing) → full-screen error with a red status glow, the translated reason, "Save logs", "Try again" + "Close".

Cancellation / device errors keep being handled inside the signature (DIE) sheet and never reach this screen, so the confirmation only deals with the broadcast outcome (success or failure).

Implementation (mobile only — desktop and live-common are untouched):
- `ConfirmationStatusLayout` — shared dumb shell (top status glow + spot + title/description + bottom actions) used by both states.
- `ConfirmationScreenView` (success) and `ConfirmationErrorView` (error) — dumb views.
- `useConfirmationViewModel` — exposes the flow status, the concerned operation, and the view/retry/save-logs/close handlers.

### 📸 Screenshots

| Success | Error |
| ------ | ----- |
|<img width="585" height="1266" alt="image" src="https://github.com/user-attachments/assets/7164c1df-ff0a-4365-bd9f-d596b73f450f" />|<img width="585" height="1266" alt="image" src="https://github.com/user-attachments/assets/ce2d77f3-a839-4980-847b-f0cc8cf927e4" />|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-22993](https://ledgerhq.atlassian.net/browse/LIVE-22993)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-22993]: https://ledgerhq.atlassian.net/browse/LIVE-22993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
