### PR TITLE
[LWDM] fix: display 1D market variation fallback for held assets

### DIFF
--- a/.changeset/tame-stocks-shine.md
+++ b/.changeset/tame-stocks-shine.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": minor
+"ledger-live-desktop": minor
+"@ledgerhq/live-countervalues": minor
+---
+
+Display a 1D variation for held assets instead of "-": when an asset's 24h portfolio value change is unavailable (e.g. freshly-acquired positions whose 24h-ago balance was zero), fall back to the asset's 1D price change computed locally from countervalues, expressed in the user's counter-value currency. This applies uniformly to crypto, stablecoins and stocks, and is handled in the shared trend hooks so generic display components stay decoupled from any asset category. A flat price now renders a real 0% (instead of "-"), and the fallback stays neutral when a rate is missing.

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useAllCurrencyTrends.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useAllCurrencyTrends.test.ts
@@ -1,6 +1,9 @@
 import { renderHook } from "tests/testSetup";
 import { useCountervaluesState } from "@ledgerhq/live-countervalues-react";
-import { getCurrencyPortfolio } from "@ledgerhq/live-countervalues/portfolio";
+import {
+  getCurrencyPortfolio,
+  getCurrentBalanceCountervalueChange,
+} from "@ledgerhq/live-countervalues/portfolio";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
 import type { CurrencyPortfolio } from "@ledgerhq/types-live";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
@@ -22,10 +25,12 @@ jest.mock("@ledgerhq/live-countervalues-react", () => ({
 }));
 jest.mock("@ledgerhq/live-countervalues/portfolio", () => ({
   getCurrencyPortfolio: jest.fn(),
+  getCurrentBalanceCountervalueChange: jest.fn(),
 }));
 
 const mockedUseCountervaluesState = jest.mocked(useCountervaluesState);
 const mockedGetCurrencyPortfolio = jest.mocked(getCurrencyPortfolio);
+const mockedGetCurrentBalanceCountervalueChange = jest.mocked(getCurrentBalanceCountervalueChange);
 
 const mockCounterValueCurrency = getFiatCurrencyByTicker("USD");
 const mockCountervaluesState: CounterValuesState = {
@@ -62,6 +67,7 @@ describe("useAllCurrencyTrends", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedUseCountervaluesState.mockReturnValue(mockCountervaluesState);
+    mockedGetCurrentBalanceCountervalueChange.mockReturnValue({ value: 0, percentage: null });
   });
 
   it("should compute trends for all real items with one shared countervalues subscription", () => {
@@ -123,12 +129,13 @@ describe("useAllCurrencyTrends", () => {
     expect(result.current.get(cardano.id)).toBeNull();
   });
 
-  it("should return null when portfolio change percentage is undefined", () => {
+  it("should return null when both portfolio change and balance fallback are unavailable", () => {
     const bitcoinAccount = genAccount("btc-undefined-trend", {
       currency: getCryptoCurrencyById("bitcoin"),
     });
 
     mockedGetCurrencyPortfolio.mockReturnValueOnce(makePortfolio(undefined));
+    mockedGetCurrentBalanceCountervalueChange.mockReturnValueOnce({ value: 0, percentage: null });
 
     const { result } = renderHook(
       () =>
@@ -146,5 +153,65 @@ describe("useAllCurrencyTrends", () => {
     );
 
     expect(result.current.get(BITCOIN_ASSET.currency.id)).toBeNull();
+  });
+
+  it("should fall back to the current-balance price change when portfolio change is unavailable", () => {
+    const bitcoinAccount = genAccount("btc-fallback-trend", {
+      currency: getCryptoCurrencyById("bitcoin"),
+    });
+    const bitcoinAccounts = [bitcoinAccount];
+
+    mockedGetCurrencyPortfolio.mockReturnValueOnce(makePortfolio(undefined));
+    mockedGetCurrentBalanceCountervalueChange.mockReturnValueOnce({ value: 42, percentage: 3.21 });
+
+    const range = "day" as const;
+    const { result } = renderHook(
+      () =>
+        useAllCurrencyTrends(
+          [
+            {
+              ...BITCOIN_ASSET,
+              accounts: bitcoinAccounts,
+              isPlaceholder: false,
+            },
+          ],
+          range,
+        ),
+      { initialState },
+    );
+
+    expect(mockedGetCurrentBalanceCountervalueChange).toHaveBeenCalledWith(
+      bitcoinAccounts,
+      range,
+      mockCountervaluesState,
+      mockCounterValueCurrency,
+    );
+    expect(result.current.get(BITCOIN_ASSET.currency.id)).toBe(3.21);
+  });
+
+  it("should not use the balance fallback when the portfolio change is available", () => {
+    const bitcoinAccount = genAccount("btc-no-fallback-trend", {
+      currency: getCryptoCurrencyById("bitcoin"),
+    });
+
+    mockedGetCurrencyPortfolio.mockReturnValueOnce(makePortfolio(7.89));
+
+    const { result } = renderHook(
+      () =>
+        useAllCurrencyTrends(
+          [
+            {
+              ...BITCOIN_ASSET,
+              accounts: [bitcoinAccount],
+              isPlaceholder: false,
+            },
+          ],
+          "day",
+        ),
+      { initialState },
+    );
+
+    expect(mockedGetCurrentBalanceCountervalueChange).not.toHaveBeenCalled();
+    expect(result.current.get(BITCOIN_ASSET.currency.id)).toBe(7.89);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useAllCurrencyTrends.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useAllCurrencyTrends.ts
@@ -2,13 +2,20 @@ import { useMemo } from "react";
 import { useSelector } from "LLD/hooks/redux";
 import { AccountLike, PortfolioRange } from "@ledgerhq/types-live";
 import { useCountervaluesState } from "@ledgerhq/live-countervalues-react";
-import { getCurrencyPortfolio } from "@ledgerhq/live-countervalues/portfolio";
+import {
+  getCurrencyPortfolio,
+  getCurrentBalanceCountervalueChange,
+} from "@ledgerhq/live-countervalues/portfolio";
 import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
 import type { AssetTableItem } from "../types";
 
 /**
  * Computes the trend percentage for all asset items in a single pass,
  * with one shared subscription to countervalues state instead of N per cell.
+ *
+ * When the portfolio value change is unavailable (e.g. freshly-held positions whose 24h-ago
+ * balance was zero), it falls back to the asset's price change computed locally from countervalues
+ * on the current balance, so held assets show a variation instead of a placeholder.
  */
 export function useAllCurrencyTrends(
   items: AssetTableItem[],
@@ -24,8 +31,13 @@ export function useAllCurrencyTrends(
         map.set(item.currency.id, null);
         continue;
       }
-      const portfolio = getCurrencyPortfolio(item.accounts as AccountLike[], range, state, to);
-      map.set(item.currency.id, portfolio.countervalueChange.percentage ?? null);
+      const accounts = item.accounts as AccountLike[];
+      const portfolio = getCurrencyPortfolio(accounts, range, state, to);
+      const trend =
+        portfolio.countervalueChange.percentage ??
+        getCurrentBalanceCountervalueChange(accounts, range, state, to).percentage ??
+        null;
+      map.set(item.currency.id, trend);
     }
     return map;
   }, [items, to, state, range]);

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/AssetListItem.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/AssetListItem.test.tsx
@@ -78,6 +78,11 @@ describe("AssetListItem", () => {
       renderView({ countervalueChange: null });
       expect(screen.queryByText(/%/)).toBeNull();
     });
+
+    it("renders the 1D price fallback through the delta when it is supplied as the change", () => {
+      renderView({ countervalueChange: { percentage: 0.012, value: 12 } });
+      expect(screen.getByText(/1\.20%/)).toBeVisible();
+    });
   });
 
   describe("market variant", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/usePrecomputedAssetListData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/usePrecomputedAssetListData.test.ts
@@ -1,7 +1,10 @@
 import { renderHook, act } from "@tests/test-renderer";
 import { useCountervaluesState } from "@ledgerhq/live-countervalues-react";
 import { calculate } from "@ledgerhq/live-countervalues/logic";
-import { getCurrencyPortfolio } from "@ledgerhq/live-countervalues/portfolio";
+import {
+  getCurrencyPortfolio,
+  getCurrentBalanceCountervalueChange,
+} from "@ledgerhq/live-countervalues/portfolio";
 import { formatCurrencyUnit, getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { Asset } from "~/types/asset";
@@ -21,6 +24,7 @@ jest.mock("@ledgerhq/live-countervalues/logic", () => ({
 jest.mock("@ledgerhq/live-countervalues/portfolio", () => ({
   ...jest.requireActual("@ledgerhq/live-countervalues/portfolio"),
   getCurrencyPortfolio: jest.fn(),
+  getCurrentBalanceCountervalueChange: jest.fn(),
 }));
 
 jest.mock("@ledgerhq/live-common/currencies/index", () => ({
@@ -31,6 +35,7 @@ jest.mock("@ledgerhq/live-common/currencies/index", () => ({
 const mockedUseCountervaluesState = jest.mocked(useCountervaluesState);
 const mockedCalculate = jest.mocked(calculate);
 const mockedGetCurrencyPortfolio = jest.mocked(getCurrencyPortfolio);
+const mockedGetCurrentBalanceChange = jest.mocked(getCurrentBalanceCountervalueChange);
 const mockedFormatCurrencyUnit = jest.mocked(formatCurrencyUnit);
 
 const mockState: ReturnType<typeof useCountervaluesState> = { data: {}, status: {}, cache: {} };
@@ -53,6 +58,7 @@ describe("usePrecomputedAssetListData", () => {
     mockedCalculate.mockReturnValue(5000000);
     mockedFormatCurrencyUnit.mockReturnValue("$50,000.00");
     mockedGetCurrencyPortfolio.mockReturnValue(makePortfolio(0.035));
+    mockedGetCurrentBalanceChange.mockReturnValue({ value: 0, percentage: null });
   });
 
   it("should batch-compute data with a single countervalues subscription", () => {
@@ -201,6 +207,42 @@ describe("usePrecomputedAssetListData", () => {
     expect(result.current.size).toBe(0);
     expect(mockedCalculate).not.toHaveBeenCalled();
     expect(mockedGetCurrencyPortfolio).not.toHaveBeenCalled();
+  });
+
+  describe("1D price fallback", () => {
+    it("uses the local price change for any held asset when the portfolio change is unavailable", () => {
+      const btcAccount = genAccount("btc-mkt", { currency: getCryptoCurrencyById("bitcoin") });
+      mockedGetCurrencyPortfolio.mockReturnValue(makePortfolio(null));
+      mockedGetCurrentBalanceChange.mockReturnValue({ value: 12, percentage: 0.012 });
+      const assets: Asset[] = [{ ...createCryptoAsset(bitcoin, 100_000), accounts: [btcAccount] }];
+
+      const { result } = renderHook(() => usePrecomputedAssetListData(assets));
+
+      expect(mockedGetCurrentBalanceChange).toHaveBeenCalledWith(
+        [btcAccount],
+        "day",
+        mockState,
+        expect.objectContaining({ ticker: "USD" }),
+      );
+      expect(result.current.get(bitcoin.id)?.countervalueChange).toEqual({
+        value: 12,
+        percentage: 0.012,
+      });
+    });
+
+    it("keeps the portfolio change when it is available", () => {
+      const btcAccount = genAccount("btc-held", { currency: getCryptoCurrencyById("bitcoin") });
+      mockedGetCurrencyPortfolio.mockReturnValue(makePortfolio(0.035));
+      const assets: Asset[] = [{ ...createCryptoAsset(bitcoin, 100_000), accounts: [btcAccount] }];
+
+      const { result } = renderHook(() => usePrecomputedAssetListData(assets));
+
+      expect(mockedGetCurrentBalanceChange).not.toHaveBeenCalled();
+      expect(result.current.get(bitcoin.id)?.countervalueChange).toEqual({
+        percentage: 0.035,
+        value: 0,
+      });
+    });
   });
 
   it("should clean up removed currencies from cache", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/usePrecomputedAssetListData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/usePrecomputedAssetListData.ts
@@ -3,7 +3,10 @@ import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { formatPrice } from "@ledgerhq/live-currency-format";
 import { useCountervaluesState } from "@ledgerhq/live-countervalues-react";
 import { calculate } from "@ledgerhq/live-countervalues/logic";
-import { getCurrencyPortfolio } from "@ledgerhq/live-countervalues/portfolio";
+import {
+  getCurrencyPortfolio,
+  getCurrentBalanceCountervalueChange,
+} from "@ledgerhq/live-countervalues/portfolio";
 import { useThrottledValue } from "@ledgerhq/live-hooks/useThrottledFunction";
 import { ValueChange } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
@@ -72,6 +75,18 @@ function getCountervalueChange(asset: Asset, state: SharedState): ValueChange | 
     state.cvState,
     state.counterValueCurrency,
   );
+
+  // Fallback: when the 24h portfolio change is unavailable (e.g. freshly-held positions
+  // whose 24h-ago balance was zero), show the asset's 1D price change computed from countervalues.
+  if (countervalueChange.percentage == null) {
+    return getCurrentBalanceCountervalueChange(
+      asset.accounts,
+      state.range,
+      state.cvState,
+      state.counterValueCurrency,
+    );
+  }
+
   return countervalueChange;
 }
 
@@ -125,7 +140,13 @@ export function usePrecomputedAssetListData(
   const cacheRef = useRef(new Map<string, AssetListItemViewModelResult>());
 
   return useMemo(() => {
-    const state: SharedState = { cvState, counterValueCurrency, range, locale, discreet };
+    const state: SharedState = {
+      cvState,
+      counterValueCurrency,
+      range,
+      locale,
+      discreet,
+    };
     const prev = cacheRef.current;
     const next = new Map<string, AssetListItemViewModelResult>();
     let changed = prev.size !== assets.length;

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/__tests__/useCryptoViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/screens/CryptoScreen/__tests__/useCryptoViewModel.test.ts
@@ -128,6 +128,24 @@ describe("useCryptoViewModel", () => {
     });
   });
 
+  describe("assetsToDisplay — variant: stocks", () => {
+    it("returns only stock assets", () => {
+      const stockItem = makeCategorizedItem("Apple", "apple-stock", "TokenCurrency");
+
+      mockCategorizedAssets.mockReturnValue({
+        ...emptyCategorizedAssets(),
+        categorizedAssets: { cryptos: [], stablecoins: [], stocks: [stockItem] },
+      });
+
+      const { result } = renderHook(() =>
+        useCryptoViewModel({ sourceScreenName: ScreenName.Portfolio, variant: "stocks" }),
+      );
+
+      expect(result.current.assetsToDisplay).toHaveLength(1);
+      expect(result.current.assetsToDisplay[0].currency.name).toBe("Apple");
+    });
+  });
+
   describe("onItemPress", () => {
     it("should navigate to Asset screen", () => {
       const btcItem = makeCategorizedItem("Bitcoin", "bitcoin");

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
@@ -21,8 +21,15 @@ interface PortfolioStocksSectionProps {
 
 const PortfolioStocksSectionComponent: React.FC<PortfolioStocksSectionProps> = ({ variant }) => {
   const { t } = useTranslation();
-  const { stocksCount, hasMore, stocksToDisplay, isLoading, isError, onPressShowAll, onItemPress } =
-    usePortfolioStocksSectionViewModel({ variant });
+  const {
+    stocksCount,
+    hasMore,
+    stocksToDisplay,
+    isLoading,
+    isError,
+    onPressShowAll,
+    onItemPress,
+  } = usePortfolioStocksSectionViewModel({ variant });
 
   if (!isLoading && !isError && stocksCount === 0) return <StocksDiscoverySection />;
 

--- a/libs/live-countervalues/src/portfolio.test.ts
+++ b/libs/live-countervalues/src/portfolio.test.ts
@@ -2,12 +2,14 @@ import "@ledgerhq/ledger-wallet-framework/test-helpers/staticTime";
 
 import { getFiatCurrencyByTicker, getCryptoCurrencyById } from "./tests/currencies";
 import { initialState, loadCountervalues, inferTrackingPairForAccounts } from "./logic";
+import { pairId } from "./helpers";
 import {
   getPortfolioCount,
   getBalanceHistory,
   getBalanceHistoryWithCountervalue,
   getPortfolio,
   getCurrencyPortfolio,
+  getCurrentBalanceCountervalueChange,
   getAssetsDistribution,
   defaultAssetsDistribution,
   getPortfolioRangeConfig,
@@ -250,6 +252,109 @@ describe("Portfolio", () => {
       expect(portfolio).toMatchSnapshot();
     });
   });
+  describe("getCurrentBalanceCountervalueChange", () => {
+    const range: PortfolioRange = "day";
+    // Builds an account whose hourly balance history is flat (= current balance) over the range,
+    // so getCurrencyPortfolio (historical balance) reduces to the same price-only change.
+    function genFlatBalanceAccount(id = "bitcoin_1"): Account {
+      const account = genAccountBitcoin(id);
+      const balance = account.balance.toNumber();
+      return {
+        ...account,
+        balanceHistoryCache: {
+          ...account.balanceHistoryCache,
+          HOUR: {
+            latestDate: startOfHour(new Date()).getTime(),
+            balances: new Array(8 * 24).fill(balance),
+          },
+        },
+      };
+    }
+
+    it("returns a neutral change for an empty accounts list", () => {
+      const to = getFiatCurrencyByTicker("USD");
+      const state = { ...initialState, data: {} };
+      expect(getCurrentBalanceCountervalueChange([], range, state, to)).toEqual({
+        value: 0,
+        percentage: null,
+      });
+    });
+    it("returns no percentage when no rate is available for the past date", async () => {
+      const account = genAccountBitcoin();
+      const { to } = await loadCV(account);
+      const state = { ...initialState, data: {} };
+      const change = getCurrentBalanceCountervalueChange([account], range, state, to);
+      expect(change.value).toBe(0);
+      expect(change.percentage).toBeFalsy();
+    });
+    it("matches the portfolio change when the balance is constant over the range", async () => {
+      const account = genFlatBalanceAccount();
+      const { state, to } = await loadCV(account);
+      const portfolio = getCurrencyPortfolio([account], range, state, to);
+      const change = getCurrentBalanceCountervalueChange([account], range, state, to);
+      expect(typeof change.percentage).toBe("number");
+      expect(change.percentage).toBeCloseTo(portfolio.countervalueChange.percentage as number, 4);
+    });
+    it("is balance-independent (percentage unchanged when the balance scales)", async () => {
+      const account = genAccountBitcoin();
+      const { state, to } = await loadCV(account);
+      const single = getCurrentBalanceCountervalueChange([account], range, state, to);
+      const doubled = getCurrentBalanceCountervalueChange([account, account], range, state, to);
+      expect(doubled.percentage).toBeCloseTo(single.percentage as number, 8);
+    });
+
+    // Builds a state where the "now" rate comes from "latest" and the "then" rate from the fallback,
+    // so both endpoints can be controlled independently for the edge cases below.
+    function stateWithRates({ now, then }: { now?: number; then?: number }) {
+      const from = getCryptoCurrencyById("bitcoin");
+      const to = getFiatCurrencyByTicker("USD");
+      const map = new Map<string, number>();
+      if (now !== undefined) map.set("latest", now);
+      return {
+        ...initialState,
+        data: {},
+        cache: {
+          [pairId({ from, to })]: {
+            map,
+            fallback: then,
+            stats: {
+              oldest: null,
+              earliest: null,
+              oldestDate: null,
+              earliestDate: null,
+              earliestStableDate: null,
+            },
+          },
+        },
+      };
+    }
+
+    it("returns a 0% change when the price is flat over the range", () => {
+      const account = genAccountBitcoin();
+      const to = getFiatCurrencyByTicker("USD");
+      const state = stateWithRates({ now: 100, then: 100 });
+      const change = getCurrentBalanceCountervalueChange([account], range, state, to);
+      expect(change.value).toBe(0);
+      expect(change.percentage).toBe(0);
+    });
+
+    it("returns a neutral change when the past rate is missing", () => {
+      const account = genAccountBitcoin();
+      const to = getFiatCurrencyByTicker("USD");
+      const state = stateWithRates({ now: 100, then: undefined });
+      const change = getCurrentBalanceCountervalueChange([account], range, state, to);
+      expect(change).toEqual({ value: 0, percentage: null });
+    });
+
+    it("returns a neutral change when the current rate is missing", () => {
+      const account = genAccountBitcoin();
+      const to = getFiatCurrencyByTicker("USD");
+      const state = stateWithRates({ now: undefined, then: 100 });
+      const change = getCurrentBalanceCountervalueChange([account], range, state, to);
+      expect(change).toEqual({ value: 0, percentage: null });
+    });
+  });
+
   describe("getAssetsDistribution", () => {
     it("snapshot", async () => {
       const account = genAccountBitcoin();

--- a/libs/live-countervalues/src/portfolio.ts
+++ b/libs/live-countervalues/src/portfolio.ts
@@ -17,6 +17,7 @@ import type {
   Portfolio,
   CurrencyPortfolio,
   AssetsDistribution,
+  ValueChange,
 } from "@ledgerhq/types-live";
 import type { CryptoCurrency, Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 
@@ -366,6 +367,51 @@ export function getCurrencyPortfolio(
     cryptoChange,
     countervalueChange,
   };
+}
+
+/**
+ * Countervalue change of the CURRENT balance over a range, i.e. the asset's price move expressed
+ * in the counter-value currency. Unlike getCurrencyPortfolio (which weights by the historical
+ * balance and yields no percentage for freshly-held positions), this applies the current balance
+ * to both the start and end rates, so the percentage reduces to (rateNow - rateThen) / rateThen.
+ */
+export function getCurrentBalanceCountervalueChange(
+  accounts: AccountLike[],
+  range: PortfolioRange,
+  cvState: CounterValuesState,
+  cvCurrency: Currency,
+): ValueChange {
+  if (accounts.length === 0) return { value: 0, percentage: null };
+  const currency = getAccountCurrency(accounts[0]);
+  const balance = accounts.reduce((sum, a) => sum + a.balance.toNumber(), 0);
+  const dates = getDates(range, getPortfolioCount(accounts, range));
+  const valueThen = calculate(cvState, {
+    value: balance,
+    from: currency,
+    to: cvCurrency,
+    date: dates[0],
+    disableRounding: true,
+  });
+  const valueNow = calculate(cvState, {
+    value: balance,
+    from: currency,
+    to: cvCurrency,
+    disableRounding: true,
+  });
+  // Only meaningful when both rates are available; otherwise stay neutral rather than treating a
+  // missing rate as 0 (which would yield a bogus value/percentage).
+  if (typeof valueThen !== "number" || typeof valueNow !== "number") {
+    return { value: 0, percentage: null };
+  }
+
+  const value = valueNow - valueThen;
+
+  // Can't compute a percentage without a non-zero base.
+  if (valueThen === 0) return { value, percentage: null };
+  // A flat price is a real 0% change, not an unknown one.
+  if (value === 0) return { value, percentage: 0 };
+
+  return { value, percentage: meaningfulPercentage(value, valueThen) ?? null };
 }
 
 export function getAssetsDistribution(


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - 1D variation on Desktop and Mobile (Portfolio sections + Crypto/Asset list rows) — held assets now show a 1D variation instead of "-" when the 24h portfolio value change is unavailable (e.g. freshly-held positions whose 24h-ago balance was zero).
  - Applies uniformly to **crypto, stablecoins and stocks** (previously scoped to stocks only — crypto/stablecoin rows now also benefit from the fallback).
  - Asset list rendering/perf (precomputed list data memoization) on Mobile.

### 📝 Description

Held assets were displaying `-` for their 1D variation whenever the 24h portfolio value change was unavailable — typically for freshly-acquired positions whose balance 24h ago was zero, which makes `(valueNow - value24hAgo) / value24hAgo` undefined.

This PR keeps the exact same primary rule and only resolves the "missing `value24hAgo`" case: when the 24h portfolio value change is unavailable, we fall back to the asset's **1D price change computed locally from the countervalues history**, by applying the current balance to both the start and end rates (the balance cancels out, so the result reduces to `(rateNow - rate24hAgo) / rate24hAgo`), expressed in the user's counter-value currency.

The fallback is **generic by nature** — its trigger is simply "the portfolio change is unavailable for a held position", which has nothing to do with the asset being a stock. So instead of coupling it to a specific category, it is handled once in the **shared trend hooks**. As a result it applies uniformly to crypto, stablecoins and stocks, and the generic display components stay fully decoupled from any "stocks" concept.

Key points:

- **No extra network call**: we only read the already-loaded countervalues state (`calculate` is a pure in-memory lookup over the same data already used for the portfolio change). No new currency or range is requested.
- A **flat price renders a real `0%`** (instead of `-`).
- If a rate is unavailable, the row stays **neutral** (`-`) rather than showing a wrong number.

Implementation:

- New shared helper `getCurrentBalanceCountervalueChange` in `@ledgerhq/live-countervalues` computes the current balance's countervalue change over a range (the price move), reusing the existing `calculate` / `getDates` / `getPortfolioCount`. It returns a neutral `ValueChange` when either rate is missing, and a real `0%` for a flat price.
- **Desktop**: the fallback lives in the shared `useAllCurrencyTrends` hook, so every consumer (the cryptos + stablecoins assets view, the Crypto/Stablecoins/Stocks pages, and the Portfolio stocks section) benefits automatically — no per-component wiring.
- **Mobile**: the fallback lives in the shared `usePrecomputedAssetListData` hook and triggers solely on a missing portfolio change. No category-specific set is threaded through the generic components (`CryptoAssetList`, `CryptoContent`, `CryptoScreen`, `SectionListContent`); the existing `Delta` component renders it (arrow, color, %) with no special-casing.

### 📸 Screenshots

<img width="972" height="682" alt="image" src="https://github.com/user-attachments/assets/c17a99f9-e2bc-425d-a6cd-24f1cf415bc2" />

<img width="350" height="750" alt="Simulator Screenshot - build2 - 2026-06-18 at 14 26 04" src="https://github.com/user-attachments/assets/09cc21fb-517c-4c4c-9f70-812a9afff7c7" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32591](https://ledgerhq.atlassian.net/browse/LIVE-32591)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32591]: https://ledgerhq.atlassian.net/browse/LIVE-32591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ