### PR TITLE
refactor(e2e-mobile): reduce device interactions

### DIFF
--- a/e2e/mobile/helpers/commonHelpers.ts
+++ b/e2e/mobile/helpers/commonHelpers.ts
@@ -73,7 +73,7 @@ function createDetoxURLBlacklistRegex(): string {
   return `\\("${patterns.join('","')}"\\)`;
 }
 
-export async function launchApp() {
+export async function launchApp(customConfig: Detox.DeviceLaunchAppConfig = {}) {
   const port = await findFreePort();
   closeBridge();
   initBridge(port);
@@ -92,6 +92,7 @@ export async function launchApp() {
     permissions: {
       camera: "YES",
     },
+    ...customConfig,
   });
   return port;
 }

--- a/e2e/mobile/jest.globalTeardown.ts
+++ b/e2e/mobile/jest.globalTeardown.ts
@@ -40,7 +40,7 @@ export default async () => {
   if (process.env.CI && process.env.SHARD_INDEX === "1") {
     try {
       await initDetox();
-      await launchApp();
+      await launchApp({ newInstance: true });
       await loadConfig("1AccountBTC1AccountETHReadOnlyFalse", true);
       await NativeElementHelpers.waitForElementById("topbar-settings", 120_000);
 

--- a/e2e/mobile/setup.ts
+++ b/e2e/mobile/setup.ts
@@ -10,7 +10,7 @@ setupEnvironment();
 
 beforeAll(
   async () => {
-    const port = await launchApp();
+    const port = await launchApp({ newInstance: true });
     await device.reverseTcpPort(8081);
     await device.reverseTcpPort(port);
     await device.reverseTcpPort(52619); // To allow the android emulator to access the dummy app
@@ -21,23 +21,26 @@ beforeAll(
 
 afterAll(
   async () => {
+    setEnv("DISABLE_TRANSACTION_BROADCAST", broadcastOriginalValue);
+
     if (process.env.CI) {
       try {
-        // Workaround (QAA-1318): open modular drawer blocks the portfolio deeplink
-        await app.modularDrawer.tapDrawerCloseButton({ onlyIfVisible: true });
-        await app.mainNavigation.openPortfolioViaDeeplink(5_000);
         await device.terminateApp();
       } catch (e) {
         log.warn(`setup afterAll terminateApp failed: ${sanitizeError(e)}`);
       }
     }
 
-    setEnv("DISABLE_TRANSACTION_BROADCAST", broadcastOriginalValue);
-    closeBridge();
     try {
       await app.common.removeSpeculos();
     } catch (e) {
       log.warn(`setup afterAll removeSpeculos failed: ${sanitizeError(e)}`);
+    }
+
+    try {
+      closeBridge();
+    } catch (e) {
+      log.warn(`setup afterAll closeBridge failed: ${sanitizeError(e)}`);
     }
   },
   process.env.CI ? 60_000 : 30_000,

--- a/e2e/mobile/specs/account/accountRename.spec.ts
+++ b/e2e/mobile/specs/account/accountRename.spec.ts
@@ -41,7 +41,7 @@ describe("Account name change", () => {
     await app.accounts.openViaDeeplink();
     await app.common.expectAccountName(newAccountName);
     await device.terminateApp();
-    await launchApp();
+    await launchApp({ newInstance: true });
     await device.disableSynchronization();
     await loadConfig("skip-onboarding", true);
     await app.mainNavigation.waitForWallet40Ready();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Launch app with new instance before every test as advised [here](https://wix.github.io/Detox/docs/introduction/your-first-test/) and wherever the use case fits.

Multiple regression [builds](https://github.com/LedgerHQ/ledger-live/actions/workflows/test-mobile-e2e-reusable.yml?query=branch%3Asupport%2FQAA-1321)

- iOS [report](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/71d62d3d-37d4-4794-8231-21184c258a43/)
- Android [report](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/379dc32d-5711-4ae4-9865-cf323feffe60/)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/QAA-1321


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
