### PR TITLE
[LWM] test(mobile): use real known device transport identifiers

### DIFF
--- a/.changeset/steady-foxes-mock.md
+++ b/.changeset/steady-foxes-mock.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix known devices reducer test transport mocking

--- a/apps/ledger-live-mobile/src/reducers/__tests__/knownDevices.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/knownDevices.test.ts
@@ -24,12 +24,6 @@ import reducer, {
   updateKnownDevice,
 } from "../knownDevices";
 
-jest.mock("@ledgerhq/live-dmk-mobile", () => ({
-  ...jest.requireActual("@ledgerhq/live-dmk-mobile"),
-  rnBleTransportIdentifier: "react-native-ble",
-  rnHidTransportIdentifier: "react-native-hid",
-}));
-
 describe("knownDevices reducer", () => {
   const nanoX = {
     id: "ble-id",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile known devices reducer Jest coverage
  - Transport identifier handling in reducer tests

### 📝 Description

The mobile known devices reducer test mocked `@ledgerhq/live-dmk-mobile` transport identifiers to legacy values. In CI, the reducer under test could still resolve the real runtime constants, making the fixtures and implementation compare different transport values and causing the scheduled Sonar coverage job to fail.

This PR removes that local mock so the test fixtures and reducer both use the actual runtime transport identifiers from `@ledgerhq/live-dmk-mobile`.

### ❓ Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)