### PR TITLE
[LWDM] fix(mobile): gate asset detail CTAs for view-only assets [LIVE-32523]

### DIFF
--- a/.changeset/live-32523-lwm-asset-quick-actions-gating.md
+++ b/.changeset/live-32523-lwm-asset-quick-actions-gating.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": patch
+"ledger-live-desktop": patch
+"@ledgerhq/asset-detail": minor
+---
+
+Share the Asset Detail trade-availability gating between mobile and desktop. Extracted `useTradeAvailability` and the ramp ledger-id resolution helpers (`resolveRampLedgerIds`, `ledgerIdsFromLedgerCurrency`, `isAvailableOnBuy`, `isAvailableOnSwap`) into `@ledgerhq/asset-detail`, and refactored desktop to consume them. Mobile now gates the Asset Detail CTAs (Buy/Swap/Receive) on the same logic: a currency that is not supported by the build or deactivated by a feature flag exposes no transfer actions (footer and in-page), while supported assets without buy/swap show the existing "Swap and Buy are not supported for this asset." banner.

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/__tests__/useRightPanelSwapAvailability.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/__tests__/useRightPanelSwapAvailability.test.ts
@@ -1,10 +1,13 @@
 import { renderHook } from "tests/testSetup";
 import { useRightPanelSwapAvailability } from "../useRightPanelSwapAvailability";
 import { useAssetRouteLedgerIds } from "LLD/features/AssetDetail/hooks/useAssetRouteLedgerIds";
-import { useTradeAvailability } from "LLD/features/AssetDetail/hooks/useTradeAvailability";
+import { useTradeAvailability } from "@ledgerhq/asset-detail";
 
 jest.mock("LLD/features/AssetDetail/hooks/useAssetRouteLedgerIds");
-jest.mock("LLD/features/AssetDetail/hooks/useTradeAvailability");
+jest.mock("@ledgerhq/asset-detail", () => ({
+  ...jest.requireActual("@ledgerhq/asset-detail"),
+  useTradeAvailability: jest.fn(),
+}));
 
 const mockLedgerIds = (ledgerIds: string[], isLoading = false) =>
   jest.mocked(useAssetRouteLedgerIds).mockReturnValue({ ledgerIds, isLoading });

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/useRightPanelSwapAvailability.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/useRightPanelSwapAvailability.ts
@@ -1,4 +1,4 @@
-import { useTradeAvailability } from "LLD/features/AssetDetail/hooks/useTradeAvailability";
+import { useTradeAvailability } from "@ledgerhq/asset-detail";
 import { useAssetRouteLedgerIds } from "LLD/features/AssetDetail/hooks/useAssetRouteLedgerIds";
 import { getRightPanelRouteAssetId } from "./useRightPanelViewModel";
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/FallbackBanner/__tests__/FallbackBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/FallbackBanner/__tests__/FallbackBanner.test.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 import { render, screen } from "tests/testSetup";
 import { FallbackBanner } from "../index";
-import { useTradeAvailability } from "LLD/features/AssetDetail/hooks/useTradeAvailability";
+import { useTradeAvailability } from "@ledgerhq/asset-detail";
 
-jest.mock("LLD/features/AssetDetail/hooks/useTradeAvailability");
+jest.mock("@ledgerhq/asset-detail", () => ({
+  ...jest.requireActual("@ledgerhq/asset-detail"),
+  useTradeAvailability: jest.fn(),
+}));
 
 const BANNER_TEST_ID = "asset-detail-fallback-banner";
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/FallbackBanner/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/FallbackBanner/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Banner } from "@ledgerhq/lumen-ui-react";
 import { useTranslation } from "react-i18next";
-import { useTradeAvailability } from "LLD/features/AssetDetail/hooks/useTradeAvailability";
+import { useTradeAvailability } from "@ledgerhq/asset-detail";
 
 type FallbackBannerProps = Readonly<{
   ledgerIds: readonly string[];

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useTradeAvailability.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useTradeAvailability.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from "tests/testSetup";
 import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
 import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
 import { useCurrenciesUnderFeatureFlag } from "@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag";
-import { useTradeAvailability } from "../useTradeAvailability";
+import { useTradeAvailability } from "@ledgerhq/asset-detail";
 
 jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog");
 jest.mock("@ledgerhq/live-common/exchange/swap/hooks/index");

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/ledgerIdsFromCurrency.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/ledgerIdsFromCurrency.ts
@@ -1,9 +1,0 @@
-import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
-
-export function ledgerIdsFromLedgerCurrency(ledgerCurrency: CryptoOrTokenCurrency): string[] {
-  const ids = new Set<string>([ledgerCurrency.id]);
-  if (ledgerCurrency.type === "TokenCurrency") {
-    ids.add(ledgerCurrency.parentCurrencyId);
-  }
-  return [...ids];
-}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/resolveRampLedgerIds.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/resolveRampLedgerIds.ts
@@ -2,7 +2,7 @@ import type { AccountLike, DistributionItem } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
-import { ledgerIdsFromLedgerCurrency } from "./ledgerIdsFromCurrency";
+import { ledgerIdsFromLedgerCurrency } from "@ledgerhq/asset-detail";
 
 function collectLedgerIdsForRampFromAccounts(accounts: AccountLike[]): string[] {
   const ids = new Set<string>();

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -9,6 +9,7 @@ import type { State } from "~/reducers/types";
 import AssetDetailNavigator from "../Navigator";
 import { ASSET_DETAIL_TEST_IDS } from "../testIds";
 import { QUICK_ACTIONS_TEST_IDS } from "LLM/features/QuickActions/testIds";
+import { useTradeAvailability, type TradeAvailability } from "@ledgerhq/asset-detail";
 
 const mockIsCurrencyAvailable = jest.fn().mockReturnValue(false);
 const mockIsAcceptedCurrency = jest.fn().mockReturnValue(false);
@@ -20,6 +21,21 @@ jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampC
 jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
   useAcceptedCurrency: () => mockIsAcceptedCurrency,
 }));
+
+jest.mock("@ledgerhq/asset-detail", () => ({
+  ...jest.requireActual("@ledgerhq/asset-detail"),
+  useTradeAvailability: jest.fn(),
+}));
+
+const mockedUseTradeAvailability = jest.mocked(useTradeAvailability);
+const setAvailability = (overrides: Partial<TradeAvailability> = {}) =>
+  mockedUseTradeAvailability.mockReturnValue({
+    availableOnBuy: true,
+    availableOnSwap: true,
+    isCurrencySupported: true,
+    isResolved: true,
+    ...overrides,
+  });
 
 // useAccountBridgeMany suspends on the dynamic coin-module import — bypass it
 // so tests don't need a Suspense boundary and don't depend on import resolution timing.
@@ -104,6 +120,7 @@ describe("AssetDetail screen layout", () => {
   beforeEach(() => {
     mockIsCurrencyAvailable.mockReturnValue(false);
     mockIsAcceptedCurrency.mockReturnValue(false);
+    setAvailability();
   });
 
   it("renders all section placeholders and BalanceGraph", () => {
@@ -250,31 +267,8 @@ describe("AssetDetail screen layout", () => {
   });
 
   describe("floating bar CTAs", () => {
-    it("shows Receive button when wallet has no funds (no Buy, no Swap)", () => {
-      render(<AssetDetailTestNavigator />);
-
-      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.ctas)).toBeVisible();
-      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeVisible();
-      expect(screen.getByText("Receive")).toBeVisible();
-      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.buyButton)).toBeNull();
-      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeNull();
-      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.fallbackBanner)).toBeNull();
-    });
-
-    it("shows Buy + Receive when Buy is available but wallet has no funds", () => {
-      mockIsCurrencyAvailable.mockReturnValue(true);
-
-      render(<AssetDetailTestNavigator />);
-
-      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.ctas)).toBeVisible();
-      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.buyButton)).toBeVisible();
-      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeVisible();
-      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeNull();
-    });
-
-    it("shows Buy + Swap when Buy available and asset has funds with swap available", () => {
-      mockIsCurrencyAvailable.mockReturnValue(true);
-      mockIsAcceptedCurrency.mockReturnValue(true);
+    it("shows Buy + Swap when buyable, swappable and the asset has funds", () => {
+      setAvailability({ availableOnBuy: true, availableOnSwap: true });
 
       render(
         <AssetDetailTestNavigator />,
@@ -284,59 +278,61 @@ describe("AssetDetail screen layout", () => {
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.ctas)).toBeVisible();
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.buyButton)).toBeVisible();
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeVisible();
-      expect(screen.getByText("Swap")).toBeVisible();
-      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeNull();
-    });
-
-    it("shows only Buy when wallet has funds but swap is unavailable", () => {
-      mockIsCurrencyAvailable.mockReturnValue(true);
-
-      render(
-        <AssetDetailTestNavigator />,
-        withAccounts([{ seed: "btc-0", currencyId: "bitcoin", balance: 1000 }]),
-      );
-
-      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.ctas)).toBeVisible();
-      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.buyButton)).toBeVisible();
-      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeNull();
       expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeNull();
       expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.fallbackBanner)).toBeNull();
     });
 
-    it("shows fallback banner instead of floating bar when wallet has funds but Buy and Swap both unavailable", () => {
+    it("shows Buy + Receive when buyable but the wallet has no funds", () => {
+      setAvailability({ availableOnBuy: true, availableOnSwap: true });
+
+      render(<AssetDetailTestNavigator />);
+
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.buyButton)).toBeVisible();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeVisible();
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeNull();
+    });
+
+    it("shows Receive and the fallback banner when supported but neither buyable nor swappable", () => {
+      setAvailability({ availableOnBuy: false, availableOnSwap: false });
+
+      render(<AssetDetailTestNavigator />);
+
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeVisible();
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.buyButton)).toBeNull();
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeNull();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.fallbackBanner)).toBeVisible();
+      expect(screen.getByText("Swap and Buy are not supported for this asset.")).toBeVisible();
+    });
+
+    it("hides every CTA and the banner when the currency is not supported (view-only)", () => {
+      setAvailability({
+        isCurrencySupported: false,
+        availableOnBuy: false,
+        availableOnSwap: false,
+      });
+
       render(
         <AssetDetailTestNavigator />,
         withAccounts([{ seed: "btc-0", currencyId: "bitcoin", balance: 1000 }]),
       );
 
       expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.ctas)).toBeNull();
-      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.fallbackBanner)).toBeVisible();
-      expect(screen.getByText("Swap and Buy are not supported for this asset.")).toBeVisible();
-    });
-
-    it("shows Swap when another asset has funds and swap is available (no Buy)", () => {
-      mockIsAcceptedCurrency.mockReturnValue(true);
-
-      render(
-        <AssetDetailTestNavigator />,
-        withAccounts([{ seed: "eth-0", currencyId: "ethereum", balance: 500 }]),
-      );
-
-      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.ctas)).toBeVisible();
-      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeVisible();
-      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.buyButton)).toBeNull();
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeNull();
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.receiveButton)).toBeNull();
       expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.fallbackBanner)).toBeNull();
     });
 
-    it("hides BalanceGraph Receive when footer shows Receive (no funds)", () => {
+    it("hides the BalanceGraph Receive when the footer shows Receive (no funds)", () => {
+      setAvailability({ availableOnBuy: false, availableOnSwap: false });
+
       render(<AssetDetailTestNavigator />);
 
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeVisible();
       expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.receiveButton)).toBeNull();
     });
 
-    it("shows BalanceGraph Receive when footer shows Swap (funds elsewhere)", () => {
-      mockIsAcceptedCurrency.mockReturnValue(true);
+    it("shows the BalanceGraph Receive when the footer shows Swap (funds elsewhere)", () => {
+      setAvailability({ availableOnSwap: true });
 
       render(
         <AssetDetailTestNavigator />,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/__tests__/useFooterViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/__tests__/useFooterViewModel.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from "@tests/test-renderer";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { useTradeAvailability, type TradeAvailability } from "@ledgerhq/asset-detail";
 import { track } from "~/analytics";
 import { useFooterViewModel } from "../useFooterViewModel";
 
@@ -7,15 +8,10 @@ const mockHandleOpenBuySell = jest.fn();
 const mockHandleOpenSwap = jest.fn();
 const mockHandleOpenReceiveDrawer = jest.fn();
 const mockUseOpenReceiveDrawer = jest.fn();
-const mockIsCurrencyAvailable = jest.fn();
-const mockIsAcceptedCurrency = jest.fn().mockReturnValue(true);
 
-jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog", () => ({
-  useRampCatalog: () => ({ isCurrencyAvailable: mockIsCurrencyAvailable }),
-}));
-
-jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
-  useAcceptedCurrency: () => mockIsAcceptedCurrency,
+jest.mock("@ledgerhq/asset-detail", () => ({
+  ...jest.requireActual("@ledgerhq/asset-detail"),
+  useTradeAvailability: jest.fn(),
 }));
 
 jest.mock("LLM/features/Buy", () => ({
@@ -33,25 +29,42 @@ jest.mock("LLM/features/Receive", () => ({
   },
 }));
 
+const mockedUseTradeAvailability = jest.mocked(useTradeAvailability);
+const setAvailability = (overrides: Partial<TradeAvailability> = {}) =>
+  mockedUseTradeAvailability.mockReturnValue({
+    availableOnBuy: true,
+    availableOnSwap: true,
+    isCurrencySupported: true,
+    isResolved: true,
+    ...overrides,
+  });
+
 const bitcoin = getCryptoCurrencyById("bitcoin");
 
 describe("useFooterViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    setAvailability();
   });
 
   describe("isBuyAvailable", () => {
-    it("returns true when the ramp catalog supports the currency", () => {
-      mockIsCurrencyAvailable.mockReturnValue(true);
-      const { result } = renderHook(() => useFooterViewModel(bitcoin));
+    it("returns true when the asset is supported and buyable", () => {
+      setAvailability({ availableOnBuy: true });
+      const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
 
       expect(result.current.isBuyAvailable).toBe(true);
-      expect(mockIsCurrencyAvailable).toHaveBeenCalledWith("bitcoin", "onRamp");
     });
 
-    it("returns false when the ramp catalog does not support the currency", () => {
-      mockIsCurrencyAvailable.mockReturnValue(false);
-      const { result } = renderHook(() => useFooterViewModel(bitcoin));
+    it("returns false when the asset is not buyable", () => {
+      setAvailability({ availableOnBuy: false });
+      const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
+
+      expect(result.current.isBuyAvailable).toBe(false);
+    });
+
+    it("returns false when the currency is not supported, even if buyable", () => {
+      setAvailability({ availableOnBuy: true, isCurrencySupported: false });
+      const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
 
       expect(result.current.isBuyAvailable).toBe(false);
     });
@@ -63,10 +76,24 @@ describe("useFooterViewModel", () => {
     });
   });
 
+  describe("secondaryButton", () => {
+    it("is null when the currency is not supported", () => {
+      setAvailability({ isCurrencySupported: false });
+      const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
+
+      expect(result.current.secondaryButton).toBeNull();
+    });
+
+    it("is receive when supported and the wallet has no funds", () => {
+      const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
+
+      expect(result.current.secondaryButton).toBe("receive");
+    });
+  });
+
   describe("press handlers", () => {
     it("onBuyPress fires tracking and opens buy flow", () => {
-      mockIsCurrencyAvailable.mockReturnValue(true);
-      const { result } = renderHook(() => useFooterViewModel(bitcoin));
+      const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
 
       act(() => result.current.onBuyPress());
 
@@ -79,7 +106,7 @@ describe("useFooterViewModel", () => {
     });
 
     it("onSwapPress fires tracking and opens swap flow", () => {
-      const { result } = renderHook(() => useFooterViewModel(bitcoin));
+      const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
 
       act(() => result.current.onSwapPress());
 
@@ -92,7 +119,7 @@ describe("useFooterViewModel", () => {
     });
 
     it("onReceivePress fires tracking and opens receive flow", () => {
-      const { result } = renderHook(() => useFooterViewModel(bitcoin));
+      const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
 
       act(() => result.current.onReceivePress());
 
@@ -110,14 +137,6 @@ describe("useFooterViewModel", () => {
 
       expect(mockUseOpenReceiveDrawer).toHaveBeenCalledWith(
         expect.objectContaining({ currency: bitcoin, currencyIds: ledgerIds }),
-      );
-    });
-
-    it("forwards currencyIds: undefined when no ledgerIds are provided", () => {
-      renderHook(() => useFooterViewModel(bitcoin));
-
-      expect(mockUseOpenReceiveDrawer).toHaveBeenCalledWith(
-        expect.objectContaining({ currency: bitcoin, currencyIds: undefined }),
       );
     });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/useFooterViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/useFooterViewModel.ts
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from "react";
-import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
-import { useAcceptedCurrency } from "@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency";
+import { useTradeAvailability } from "@ledgerhq/asset-detail";
 import { useSelector } from "~/context/hooks";
 import { shallowAccountsSelector } from "~/reducers/accounts";
 import { track } from "~/analytics";
@@ -11,27 +10,46 @@ import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
 
 export type SecondaryButtonType = "swap" | "receive" | null;
 
-export function useIsBuyAvailable(currency: AssetDetailCurrencyProps): boolean {
-  const { isCurrencyAvailable } = useRampCatalog();
+export type AssetActionsAvailability = Readonly<{
+  isCurrencySupported: boolean;
+  isBuyAvailable: boolean;
+  availableOnSwap: boolean;
+  secondaryButton: SecondaryButtonType;
+}>;
 
-  return !!currency && isCurrencyAvailable(currency.id, "onRamp");
-}
-
-export function useSecondaryButtonType(currency: AssetDetailCurrencyProps): SecondaryButtonType {
+/**
+ * Resolves which footer actions an asset exposes, sharing the gating logic with
+ * desktop via `useTradeAvailability`. A currency that is not supported (unknown
+ * to the build or deactivated by a feature flag) exposes no actions at all.
+ */
+export function useAssetActionsAvailability(
+  currency: AssetDetailCurrencyProps,
+  ledgerIds?: string[],
+): AssetActionsAvailability {
   const accounts = useSelector(shallowAccountsSelector);
-  const isAcceptedCurrency = useAcceptedCurrency();
+  const { availableOnBuy, availableOnSwap, isCurrencySupported } = useTradeAvailability(ledgerIds);
 
   return useMemo(() => {
-    if (!currency) return null;
-
-    const walletHasFunds = accounts.some(a => a.balance.gt(0));
-
-    if (walletHasFunds) {
-      return isAcceptedCurrency(currency) ? "swap" : null;
+    if (!currency || !isCurrencySupported) {
+      return {
+        isCurrencySupported: false,
+        isBuyAvailable: false,
+        availableOnSwap: false,
+        secondaryButton: null,
+      };
     }
 
-    return "receive";
-  }, [accounts, currency, isAcceptedCurrency]);
+    const walletHasFunds = accounts.some(a => a.balance.gt(0));
+    const secondaryButton: SecondaryButtonType =
+      walletHasFunds && availableOnSwap ? "swap" : "receive";
+
+    return {
+      isCurrencySupported,
+      isBuyAvailable: availableOnBuy,
+      availableOnSwap,
+      secondaryButton,
+    };
+  }, [currency, isCurrencySupported, availableOnBuy, availableOnSwap, accounts]);
 }
 
 export function useFooterViewModel(currency: AssetDetailCurrencyProps, ledgerIds?: string[]) {
@@ -51,8 +69,7 @@ export function useFooterViewModel(currency: AssetDetailCurrencyProps, ledgerIds
     sourceScreenName: "Asset Detail",
   });
 
-  const isBuyAvailable = useIsBuyAvailable(currency);
-  const secondaryButton = useSecondaryButtonType(currency);
+  const { isBuyAvailable, secondaryButton } = useAssetActionsAvailability(currency, ledgerIds);
 
   const onBuyPress = useCallback(() => {
     if (!currency) return;

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -4,15 +4,13 @@ import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useRoute } from "@react-navigation/native";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { ScreenName } from "~/const";
-import { useSelector } from "~/context/hooks";
-import { shallowAccountsSelector } from "~/reducers/accounts";
 import { useDistribution } from "~/actions/general";
 import {
   resolveAssetMarketInputs,
   resolveDistributionItem,
 } from "@ledgerhq/asset-aggregation/assetDistribution/index";
 import type { AssetDetailNavigatorParamsList } from "../../types";
-import { useIsBuyAvailable, useSecondaryButtonType } from "./components/Footer/useFooterViewModel";
+import { useAssetActionsAvailability } from "./components/Footer/useFooterViewModel";
 import { useAssetCoinOptionsViewModel } from "./components/CoinOptions/useAssetCoinOptionsViewModel";
 import { useAssetMarketData } from "./hooks/useAssetMarketData";
 import { useReceiveNetworkLedgerIds } from "./hooks/useReceiveNetworkLedgerIds";
@@ -56,14 +54,6 @@ export function useAssetDetailViewModel() {
     setIsRefreshing(false);
   }, []);
 
-  const isBuyAvailable = useIsBuyAvailable(currency);
-  const secondaryButton = useSecondaryButtonType(currency);
-  const hasFooter = isBuyAvailable || secondaryButton !== null;
-  const hideReceiveInBalanceGraph = secondaryButton === "receive";
-
-  const accounts = useSelector(shallowAccountsSelector);
-  const walletHasFunds = useMemo(() => accounts.some(a => a.balance.gt(0)), [accounts]);
-  const showFallbackBanner = !hasFooter && walletHasFunds && !!currency;
   const { marketId, ledgerIds, marketCurrency } = useAssetMarketData({
     marketApiId,
     knownLedgerIds,
@@ -80,6 +70,12 @@ export function useAssetDetailViewModel() {
     currencyId: currency?.id,
     fallbackLedgerIds: ledgerIds,
   });
+  const { isBuyAvailable, availableOnSwap, isCurrencySupported, secondaryButton } =
+    useAssetActionsAvailability(currency, receiveLedgerIds);
+  const hasFooter = isBuyAvailable || secondaryButton !== null;
+  const hideReceiveInBalanceGraph = !isCurrencySupported || secondaryButton === "receive";
+  const showFallbackBanner = isCurrencySupported && !isBuyAvailable && !availableOnSwap;
+
   const coinOptions = useAssetCoinOptionsViewModel({ currency, currencyId, marketId });
 
   return {

--- a/libs/asset-detail/src/hooks/useTradeAvailability.ts
+++ b/libs/asset-detail/src/hooks/useTradeAvailability.ts
@@ -6,7 +6,7 @@ import {
   isAvailableOnBuy,
   isAvailableOnSwap,
   type MarketCurrencyRampLedgerIds,
-} from "LLD/features/Market/utils/rampCatalogAvailability";
+} from "../utils/tradeAvailability";
 
 export type TradeAvailability = Readonly<{
   availableOnBuy: boolean;
@@ -15,6 +15,11 @@ export type TradeAvailability = Readonly<{
   isResolved: boolean;
 }>;
 
+/**
+ * Resolves which transfer actions are available for an asset from its ledger ids.
+ * `isCurrencySupported` is false when every ledger id is deactivated by a feature
+ * flag (or none is provided) — gate every CTA on it so view-only assets expose none.
+ */
 export function useTradeAvailability(ledgerIds: readonly string[] | undefined): TradeAvailability {
   const { isCurrencyAvailable, getSupportedCryptoCurrencyIds } = useRampCatalog();
   const { data: currenciesForSwapAll } = useFetchCurrencyAll();

--- a/libs/asset-detail/src/index.ts
+++ b/libs/asset-detail/src/index.ts
@@ -1,7 +1,9 @@
 export * from "./hooks/useAssetMarketData";
 export * from "./hooks/useReceiveNetworkLedgerIds";
+export * from "./hooks/useTradeAvailability";
 export * from "./utils/assetDetailMarketInfo";
 export * from "./utils/resolveMaxSupplyDisplay";
+export * from "./utils/tradeAvailability";
 export type {
   AssetDetailMarketInfo,
   AssetMarketData,

--- a/libs/asset-detail/src/utils/__tests__/tradeAvailability.test.ts
+++ b/libs/asset-detail/src/utils/__tests__/tradeAvailability.test.ts
@@ -1,0 +1,57 @@
+import {
+  isAvailableOnBuy,
+  isAvailableOnSwap,
+  ledgerIdsFromLedgerCurrency,
+} from "../tradeAvailability";
+
+describe("tradeAvailability", () => {
+  describe("isAvailableOnBuy", () => {
+    it("returns false when the currency is nullish", () => {
+      expect(isAvailableOnBuy(undefined, () => true)).toBe(false);
+    });
+
+    it("returns true when any ledger id is available on ramp", () => {
+      expect(
+        isAvailableOnBuy({ ledgerIds: ["bitcoin", "ethereum"] }, id => id === "ethereum"),
+      ).toBe(true);
+    });
+
+    it("returns false when no ledger id is available on ramp", () => {
+      expect(isAvailableOnBuy({ ledgerIds: ["bitcoin"] }, () => false)).toBe(false);
+    });
+  });
+
+  describe("isAvailableOnSwap", () => {
+    it("returns false when the currency is nullish", () => {
+      expect(isAvailableOnSwap(undefined, new Set(["bitcoin"]))).toBe(false);
+    });
+
+    it("returns true when any ledger id is in the swap set", () => {
+      expect(isAvailableOnSwap({ ledgerIds: ["bitcoin", "solana"] }, new Set(["solana"]))).toBe(
+        true,
+      );
+    });
+
+    it("returns false when no ledger id is in the swap set", () => {
+      expect(isAvailableOnSwap({ ledgerIds: ["bitcoin"] }, new Set(["solana"]))).toBe(false);
+    });
+  });
+
+  describe("ledgerIdsFromLedgerCurrency", () => {
+    it("returns the currency id for a coin", () => {
+      expect(
+        ledgerIdsFromLedgerCurrency({ type: "CryptoCurrency", id: "bitcoin" } as never),
+      ).toEqual(["bitcoin"]);
+    });
+
+    it("includes the parent currency id for a token", () => {
+      expect(
+        ledgerIdsFromLedgerCurrency({
+          type: "TokenCurrency",
+          id: "ethereum/erc20/usd__coin",
+          parentCurrencyId: "ethereum",
+        } as never),
+      ).toEqual(["ethereum/erc20/usd__coin", "ethereum"]);
+    });
+  });
+});

--- a/libs/asset-detail/src/utils/tradeAvailability.ts
+++ b/libs/asset-detail/src/utils/tradeAvailability.ts
@@ -1,0 +1,29 @@
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+
+/** Minimal shape for ramp on/off-ramp checks (full `MarketCurrencyData` is assignable). */
+export type MarketCurrencyRampLedgerIds = Pick<MarketCurrencyData, "ledgerIds">;
+
+export function isAvailableOnBuy(
+  currency: MarketCurrencyRampLedgerIds | null | undefined,
+  isCurrencyAvailable: (currencyId: string, mode: "onRamp") => boolean,
+): boolean {
+  if (!currency) return false;
+  return currency.ledgerIds.some(lrId => isCurrencyAvailable(lrId, "onRamp"));
+}
+
+export function isAvailableOnSwap(
+  currency: MarketCurrencyRampLedgerIds | null | undefined,
+  currenciesForSwapAllSet: Set<string>,
+): boolean {
+  if (!currency) return false;
+  return currency.ledgerIds.some(lrId => currenciesForSwapAllSet.has(lrId));
+}
+
+export function ledgerIdsFromLedgerCurrency(ledgerCurrency: CryptoOrTokenCurrency): string[] {
+  const ids = new Set<string>([ledgerCurrency.id]);
+  if (ledgerCurrency.type === "TokenCurrency") {
+    ids.add(ledgerCurrency.parentCurrencyId);
+  }
+  return [...ids];
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** asset-detail pure helpers (8), desktop hook/right-panel/fallback (20) and mobile footer + AssetDetail integration (38) all green.
- [x] **Impact of the changes:** New mobile Asset Detail screen (behind the asset-discoverability flag) + the shared `@ledgerhq/asset-detail` gating used by desktop. QA should check a view-only asset (e.g. TAO/Bittensor, or any currency disabled via a `currencyXxx` feature flag):
  - No Buy / Swap / Receive in the footer, and no in-page Receive.
  - A supported asset that just isn't buyable/swappable still shows Receive + the existing "Swap and Buy are not supported for this asset." banner.
  - Desktop asset detail unchanged in behaviour (refactor only).

### 📝 Description

Implements LIVE-32523 by **sharing the Asset Detail trade-availability gating between mobile and desktop**, mirroring #18590.

- Extracted `useTradeAvailability` (+ `isAvailableOnBuy` / `isAvailableOnSwap` / `ledgerIdsFromLedgerCurrency`) into **`@ledgerhq/asset-detail`** (already consumed by both apps). Desktop now imports the shared hook/helpers; its app-local copies were removed. `resolveRampLedgerIds` stays desktop-local (it needs `@ledgerhq/types-live` and is only used by desktop), importing the shared `ledgerIdsFromLedgerCurrency`.
- Mobile gates the Asset Detail CTAs on the shared `useTradeAvailability` via a new `useAssetActionsAvailability`: `isCurrencySupported === false` (unsupported / feature-flag deactivated) hides **all** actions incl. Receive and the in-page Receive; Buy is gated on `availableOnBuy`, Swap on `availableOnSwap`; the existing "Swap and Buy are not supported for this asset." banner shows for supported assets without buy/swap — same semantics as desktop.


https://github.com/user-attachments/assets/1909f56c-0c71-4b71-9fcb-62b894a1c494




### ❓ Context

- **JIRA link**: [LIVE-32523](https://ledgerhq.atlassian.net/browse/LIVE-32523)
- **Mirrors**: #18590 (LWD)


[LIVE-32523]: https://ledgerhq.atlassian.net/browse/LIVE-32523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ