### PR TITLE
fix(wallet-cli): allow swaps into new token accounts

### DIFF
--- a/.changeset/brave-tokens-swap.md
+++ b/.changeset/brave-tokens-swap.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": minor
+---
+
+Fix swap execution into token accounts that do not exist yet

--- a/apps/wallet-cli/src/commands/swap/execute.ts
+++ b/apps/wallet-cli/src/commands/swap/execute.ts
@@ -3,6 +3,7 @@ import { BigNumber } from "bignumber.js";
 import { z } from "zod";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { makeBridgeCacheSystem } from "@ledgerhq/live-common/bridge/cache";
+import { makeEmptyTokenAccount } from "@ledgerhq/live-common/account/index";
 import { findCryptoCurrencyById, parseCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getCurrencyForAccount, type AccountLike } from "@ledgerhq/types-live";
@@ -24,6 +25,7 @@ import { resolveSwapProvider, WALLET_CLI_DEFAULT_SWAP_PROVIDERS } from "./provid
 type RunFullSwapPipeline = typeof runFullSwapPipelineDefault;
 
 type CryptoOrTokenCurrency = CryptoCurrency | TokenCurrency;
+type FindTokenById = (id: string) => Promise<TokenCurrency | null | undefined>;
 
 function resolveSwapAccountForCurrency(
   parentAccount: AccountLike,
@@ -58,6 +60,9 @@ function resolveSwapAccountForCurrency(
   );
 
   if (!tokenSub) {
+    if (flag === "to") {
+      return makeEmptyTokenAccount(parentAccount, currency);
+    }
     throw new Error(`${flag} account has no token sub-account for ${userCurrencyId}.`);
   }
   return tokenSub;
@@ -82,6 +87,7 @@ export type SwapExecuteDependencies = {
   integrateNewAccountDescriptor?: typeof integrateNewAccountDescriptor;
   getAccountBridge?: typeof getAccountBridge;
   makeBridgeCacheSystem?: typeof makeBridgeCacheSystem;
+  findTokenById?: FindTokenById;
 };
 
 export async function executeSwapCommand({
@@ -92,15 +98,14 @@ export async function executeSwapCommand({
   integrateNewAccountDescriptor: integrateDescriptor = integrateNewAccountDescriptor,
   getAccountBridge: getBridge = getAccountBridge,
   makeBridgeCacheSystem: makeCacheSystem = makeBridgeCacheSystem,
+  findTokenById = id => getCryptoAssetsStore().findTokenById(id),
 }: {
   flags: SwapExecuteFlags;
   positional: readonly string[];
 } & SwapExecuteDependencies): Promise<void> {
   const fromDescriptor = await resolveDescriptor(resolveAccountArg(flags.account, positional));
-  const fromCurrency =
-    findCryptoCurrencyById(flags.from) ?? (await getCryptoAssetsStore().findTokenById(flags.from));
-  const toCurrency =
-    findCryptoCurrencyById(flags.to) ?? (await getCryptoAssetsStore().findTokenById(flags.to));
+  const fromCurrency = findCryptoCurrencyById(flags.from) ?? (await findTokenById(flags.from));
+  const toCurrency = findCryptoCurrencyById(flags.to) ?? (await findTokenById(flags.to));
 
   if (!fromCurrency) {
     throw new Error(`Unknown source currency (--from): ${flags.from}`);

--- a/apps/wallet-cli/src/test/commands/swap/execute.test.ts
+++ b/apps/wallet-cli/src/test/commands/swap/execute.test.ts
@@ -4,10 +4,12 @@ import "../../../live-common-setup";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { BigNumber } from "bignumber.js";
 import type { Account } from "@ledgerhq/types-live";
+import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { getAccountBridge as getLiveAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { installOutputCapture } from "../../../shared/ui";
 import type { AccountDescriptor } from "../../../wallet/models";
 import { MOCK_ETH_DESCRIPTOR } from "../../../test/helpers/constants";
+import { USDT_CONTRACT } from "../../helpers/cal-fixtures";
 import { executeSwapCommand, type SwapExecuteFlags } from "../../../commands/swap/execute";
 import type { FullSwapPipelineInput } from "../../../commands/swap/cli-swap-pipeline";
 
@@ -42,6 +44,30 @@ const toDescriptor: AccountDescriptor = {
   derivationMode: "",
   index: 1,
 };
+
+const ethToDescriptor: AccountDescriptor = {
+  id: "js:2:ethereum:to:",
+  currencyId: "ethereum",
+  freshAddress: "0x000000000000000000000000000000000000000e",
+  seedIdentifier: "",
+  derivationMode: "",
+  index: 1,
+};
+
+const USDT_TOKEN_ID = "ethereum/erc20/usd_tether__erc20_";
+const usdtToken = {
+  type: "TokenCurrency",
+  id: USDT_TOKEN_ID,
+  parentCurrencyId: "ethereum",
+  contractAddress: USDT_CONTRACT,
+  tokenType: "erc20",
+  ticker: "USDT",
+  name: "Tether USD",
+  units: [
+    { code: "USDT", name: "USDT", magnitude: 6 },
+    { code: "uUSDT", name: "micro USDT", magnitude: 0 },
+  ],
+} as unknown as TokenCurrency;
 
 const baseFlags: SwapExecuteFlags = {
   from: "ethereum",
@@ -80,7 +106,13 @@ function makeAccount(descriptor: AccountDescriptor): Account {
 }
 
 const resolveAccountDescriptorMock = mock(async (input: string) => {
-  return input === baseFlags.account ? fromDescriptor : toDescriptor;
+  if (input === baseFlags.account) {
+    return fromDescriptor;
+  }
+  if (input === "ethereum-destination-account") {
+    return ethToDescriptor;
+  }
+  return toDescriptor;
 });
 
 const integrateNewAccountDescriptorMock = mock(async (descriptor: AccountDescriptor) => {
@@ -93,6 +125,8 @@ const getAccountBridgeMock = getAccountBridgeMockFn as unknown as typeof getLive
 const runFullSwapPipelineMock = mock((_input: FullSwapPipelineInput) =>
   Promise.resolve({ ...mockPipelineResult }),
 );
+
+const findTokenByIdMock = mock(async (id: string) => (id === USDT_TOKEN_ID ? usdtToken : undefined));
 
 async function runExecuteSwapCommand(flags: SwapExecuteFlags = baseFlags) {
   const writes: string[] = [];
@@ -108,6 +142,7 @@ async function runExecuteSwapCommand(flags: SwapExecuteFlags = baseFlags) {
       integrateNewAccountDescriptor: integrateNewAccountDescriptorMock,
       getAccountBridge: getAccountBridgeMock,
       runFullSwapPipeline: runFullSwapPipelineMock,
+      findTokenById: findTokenByIdMock,
     });
   } finally {
     restoreCapture();
@@ -124,6 +159,7 @@ describe("swap execute command", () => {
     integrateNewAccountDescriptorMock.mockClear();
     getAccountBridgeMockFn.mockClear();
     runFullSwapPipelineMock.mockClear();
+    findTokenByIdMock.mockClear();
     server.start();
   });
 
@@ -158,6 +194,43 @@ describe("swap execute command", () => {
     expect(pipelineInput.getAccountBridge).toBe(getAccountBridgeMock);
   });
 
+  it("creates an empty destination token account when the token sub-account is missing", async () => {
+    const data = await runExecuteSwapCommand({
+      ...baseFlags,
+      to: USDT_TOKEN_ID,
+      "to-account": "ethereum-destination-account",
+    });
+
+    expect(data.to).toBe(USDT_TOKEN_ID);
+    expect(runFullSwapPipelineMock).toHaveBeenCalledTimes(1);
+    const pipelineInput = runFullSwapPipelineMock.mock.calls[0][0];
+    expect(pipelineInput.toParentAccount?.id).toBe(ethToDescriptor.id);
+
+    if (pipelineInput.toAccount.type !== "TokenAccount") {
+      throw new Error(`Expected destination TokenAccount, got ${pipelineInput.toAccount.type}`);
+    }
+
+    expect(pipelineInput.toAccount.parentId).toBe(ethToDescriptor.id);
+    expect(pipelineInput.toAccount.token.id).toBe(USDT_TOKEN_ID);
+    expect(pipelineInput.toAccount.balance.toFixed()).toBe("0");
+    expect(pipelineInput.toAccount.spendableBalance.toFixed()).toBe("0");
+  });
+
+  it("still rejects a source token when the token sub-account is missing", async () => {
+    await expect(
+      executeSwapCommand({
+        flags: { ...baseFlags, from: USDT_TOKEN_ID, output: undefined },
+        positional: [],
+        resolveAccountDescriptor: resolveAccountDescriptorMock,
+        integrateNewAccountDescriptor: integrateNewAccountDescriptorMock,
+        getAccountBridge: getAccountBridgeMock,
+        runFullSwapPipeline: runFullSwapPipelineMock,
+        findTokenById: findTokenByIdMock,
+      }),
+    ).rejects.toThrow(`from account has no token sub-account for ${USDT_TOKEN_ID}.`);
+    expect(runFullSwapPipelineMock).not.toHaveBeenCalled();
+  });
+
   it("rejects an unsupported --provider before running the pipeline", async () => {
     await expect(
       runExecuteSwapCommand({ ...baseFlags, provider: "unknown_provider" }),
@@ -179,6 +252,7 @@ describe("swap execute command", () => {
         integrateNewAccountDescriptor: integrateNewAccountDescriptorMock,
         getAccountBridge: getAccountBridgeMock,
         runFullSwapPipeline: runFullSwapPipelineMock,
+        findTokenById: findTokenByIdMock,
       }),
     ).rejects.toThrow("Unknown source currency (--from): test");
   });
@@ -192,6 +266,7 @@ describe("swap execute command", () => {
         integrateNewAccountDescriptor: integrateNewAccountDescriptorMock,
         getAccountBridge: getAccountBridgeMock,
         runFullSwapPipeline: runFullSwapPipelineMock,
+        findTokenById: findTokenByIdMock,
       }),
     ).rejects.toThrow("Unknown destination currency (--to): test");
   });
@@ -205,6 +280,7 @@ describe("swap execute command", () => {
         integrateNewAccountDescriptor: integrateNewAccountDescriptorMock,
         getAccountBridge: getAccountBridgeMock,
         runFullSwapPipeline: runFullSwapPipelineMock,
+        findTokenById: findTokenByIdMock,
       }),
     ).rejects.toThrow("--from account is ethereum but --from is bitcoin.");
   });
@@ -218,6 +294,7 @@ describe("swap execute command", () => {
         integrateNewAccountDescriptor: integrateNewAccountDescriptorMock,
         getAccountBridge: getAccountBridgeMock,
         runFullSwapPipeline: runFullSwapPipelineMock,
+        findTokenById: findTokenByIdMock,
       }),
     ).rejects.toThrow("--to account is bitcoin but --to is ethereum.");
   });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - wallet-cli swap execution from ETH into ERC-20 tokens without an existing destination token sub-account
      - Source-token swap validation when the source token sub-account is missing
      - Chain mismatch validation for destination accounts

### 📝 Description

`wallet-cli swap execute` previously failed when swapping into a token that the destination account had never held, because the CLI required the token sub-account to already exist before starting the swap pipeline.

This PR mirrors the Ledger Live wallet-api behavior by creating an empty destination token account with `makeEmptyTokenAccount` when the destination token sub-account is missing. Source token swaps still require an existing source token sub-account, so spending validation remains unchanged.

Inspired by current swap 

```
let newTokenAccount: TokenAccount | undefined;
          if (params.tokenCurrency) {
            const currency = await getCryptoAssetsStore().findTokenById(params.tokenCurrency);
            if (!currency) {
              throw new ServerError(createCurrencyNotFound(params.tokenCurrency));
            }
            if (toAccount.type === "Account") {
              newTokenAccount = makeEmptyTokenAccount(toAccount, currency);
              toParentAccount = toAccount;
            } else {
              newTokenAccount = makeEmptyTokenAccount(toParentAccount, currency);
            }
          }
```



Validated with:

<img width="4032" height="2268" alt="image" src="https://github.com/user-attachments/assets/2bb4507c-cead-4c62-b2b9-e0da8e7a3c7a" />


### ❓ Context

- **JIRA or GitHub link**: No ticket

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)