### PR TITLE
[LWDM] chore(mock): stub setTimeout to win some execution time

### DIFF
--- a/.changeset/wild-timers-rest.md
+++ b/.changeset/wild-timers-rest.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/coin-stellar": patch
+"@ledgerhq/live-common": patch
+---
+
+test: remove un-faked real timers from two unit suites (no production change)
+
+- coin-stellar: stub `setTimeout` in `api/index_error.test.ts` so the 429-retry path no longer sleeps a real 4s, which raced Jest's 5s default timeout and intermittently failed CI (mirrors the existing `operationsFromHeight.unit.test.ts` stub).
+- ledger-live-common: forward `global.setTimeout` with a 0ms delay in the `mock-bridges` suite, eliminating the ~78s of idle wall-clock spent on the mock bridge's simulated device latency (`scanAccounts`/`signOperation`/`sync`) while preserving async ordering.

--- a/libs/coin-modules/coin-stellar/src/api/index_error.test.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index_error.test.ts
@@ -7,14 +7,17 @@ describe("Stellar Api", () => {
   const ADDRESS = "GBAUZBDXMVV7HII4JWBGFMLVKVJ6OLQAKOCGXM5E2FM4TAZB6C7JO2L7";
 
   // The 429-retry path sleeps on a real 4s setTimeout (logic/operationsFromHeight.ts),
-  // which races Jest's 5s default timeout and flakes CI. Fire timer callbacks
-  // synchronously so the retry happens with zero real delay.
+  // which races Jest's 5s default timeout and flakes CI. Forward setTimeout to the real
+  // timer with a 0ms delay: this removes the wall-clock wait while keeping the callback
+  // on a future tick, so retry ordering/recursion match production (unlike a synchronous
+  // stub, which would turn the scheduled retry into immediate in-stack recursion).
+  const realSetTimeout = global.setTimeout;
   let setTimeoutSpy: jest.SpyInstance;
   beforeEach(() => {
-    setTimeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation((fn: TimerHandler) => {
-      if (typeof fn === "function") (fn as () => void)();
-      return 0 as unknown as NodeJS.Timeout;
-    });
+    setTimeoutSpy = jest
+      .spyOn(global, "setTimeout")
+      .mockImplementation(((fn: TimerHandler, _ms?: number, ...args: unknown[]) =>
+        realSetTimeout(fn, 0, ...args)) as typeof setTimeout);
   });
   afterEach(() => {
     setTimeoutSpy.mockRestore();

--- a/libs/coin-modules/coin-stellar/src/api/index_error.test.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index_error.test.ts
@@ -6,6 +6,20 @@ describe("Stellar Api", () => {
   let module: CoinModuleApi<StellarMemo>;
   const ADDRESS = "GBAUZBDXMVV7HII4JWBGFMLVKVJ6OLQAKOCGXM5E2FM4TAZB6C7JO2L7";
 
+  // The 429-retry path sleeps on a real 4s setTimeout (logic/operationsFromHeight.ts),
+  // which races Jest's 5s default timeout and flakes CI. Fire timer callbacks
+  // synchronously so the retry happens with zero real delay.
+  let setTimeoutSpy: jest.SpyInstance;
+  beforeEach(() => {
+    setTimeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation((fn: TimerHandler) => {
+      if (typeof fn === "function") (fn as () => void)();
+      return 0 as unknown as NodeJS.Timeout;
+    });
+  });
+  afterEach(() => {
+    setTimeoutSpy.mockRestore();
+  });
+
   beforeAll(() => {
     nock("https://horizon-testnet.stellar.org")
       .get(/.*/)

--- a/libs/ledger-live-common/src/__tests__/mock-bridges.ts
+++ b/libs/ledger-live-common/src/__tests__/mock-bridges.ts
@@ -12,6 +12,23 @@ import { CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 import { firstValueFrom } from "rxjs";
 jest.setTimeout(120000);
 
+// The mock bridge (bridge/mockHelpers.ts) simulates device latency with real timers
+// (delay() in scanAccounts/signOperation + a raw setTimeout in sync), costing ~78s of
+// idle wall-clock across the 8 currencies below. Every wait bottoms out in
+// global.setTimeout, so forwarding it with a 0ms delay zeros the wall-clock while
+// preserving async ordering (callbacks still run on a future tick, not synchronously).
+const realSetTimeout = global.setTimeout;
+let setTimeoutSpy: jest.SpyInstance;
+beforeAll(() => {
+  setTimeoutSpy = jest
+    .spyOn(global, "setTimeout")
+    .mockImplementation(((fn: TimerHandler, _ms?: number, ...args: unknown[]) =>
+      realSetTimeout(fn, 0, ...args)) as typeof setTimeout);
+});
+afterAll(() => {
+  setTimeoutSpy.mockRestore();
+});
+
 const mockedCoins: CryptoCurrencyId[] = [
   "bitcoin",
   "zcash",

--- a/libs/ledger-live-common/src/__tests__/mock-bridges.ts
+++ b/libs/ledger-live-common/src/__tests__/mock-bridges.ts
@@ -12,11 +12,7 @@ import { CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 import { firstValueFrom } from "rxjs";
 jest.setTimeout(120000);
 
-// The mock bridge (bridge/mockHelpers.ts) simulates device latency with real timers
-// (delay() in scanAccounts/signOperation + a raw setTimeout in sync), costing ~78s of
-// idle wall-clock across the 8 currencies below. Every wait bottoms out in
-// global.setTimeout, so forwarding it with a 0ms delay zeros the wall-clock while
-// preserving async ordering (callbacks still run on a future tick, not synchronously).
+// Speed up mock bridge tests by forcing all setTimeout delays to 0ms while preserving async ordering.
 const realSetTimeout = global.setTimeout;
 let setTimeoutSpy: jest.SpyInstance;
 beforeAll(() => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** 

### 📝 Description

test: remove un-faked real timers from two unit suites (no production change)

- coin-stellar: stub `setTimeout` in `api/index_error.test.ts` so the 429-retry path no longer sleeps a real 4s, which raced Jest's 5s default timeout and intermittently failed CI (mirrors the existing `operationsFromHeight.unit.test.ts` stub).

- ledger-live-common: forward `global.setTimeout` with a 0ms delay in the `mock-bridges` suite, eliminating the ~78s of idle wall-clock spent on the mock bridge's simulated device latency (`scanAccounts`/`signOperation`/`sync`) while preserving async ordering.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
