### PR TITLE
[LWM] fix(mobile): resolve http proxy legacy transport id

### DIFF
--- a/.changeset/quick-proxies-approve.md
+++ b/.changeset/quick-proxies-approve.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-dmk-mobile": minor
+---
+
+Fix HTTP proxy device IDs so legacy transport resolution uses the proxy transport.

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitHTTPProxyTransport.test.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitHTTPProxyTransport.test.ts
@@ -12,7 +12,11 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { DisconnectedDevice } from "@ledgerhq/errors";
 import { DeviceManagementKitHTTPProxyTransport } from "./DeviceManagementKitHTTPProxyTransport";
-import { HTTP_PROXY_TRANSPORT_IDENTIFIER, httpProxyUrlSubject } from "./HttpProxyDmkTransport";
+import {
+  buildHttpProxyLegacyDeviceId,
+  HTTP_PROXY_TRANSPORT_IDENTIFIER,
+  httpProxyUrlSubject,
+} from "./HttpProxyDmkTransport";
 import { getDeviceManagementKit } from "../hooks/useDeviceManagementKit";
 
 jest.mock("../hooks/useDeviceManagementKit", () => ({
@@ -26,7 +30,7 @@ const aMockedDeviceSessionState: DeviceSessionState = {
 };
 
 const mockDiscoveredDevice: DiscoveredDevice = {
-  id: "http-proxy-device",
+  id: buildHttpProxyLegacyDeviceId("http://localhost:8435"),
   name: "HTTP Proxy",
   deviceModel: {
     model: DMKDeviceModelId.NANO_X,

--- a/libs/live-dmk-mobile/src/transport/HttpProxyDmkTransport.test.ts
+++ b/libs/live-dmk-mobile/src/transport/HttpProxyDmkTransport.test.ts
@@ -1,9 +1,13 @@
 import { BehaviorSubject, firstValueFrom } from "rxjs";
 import { skip } from "rxjs/operators";
 import { ApduResponse, DeviceModelId, type TransportArgs } from "@ledgerhq/device-management-kit";
-import { HTTP_PROXY_TRANSPORT_IDENTIFIER, HttpProxyDmkTransport } from "./HttpProxyDmkTransport";
+import {
+  buildHttpProxyLegacyDeviceId,
+  HTTP_PROXY_TRANSPORT_IDENTIFIER,
+  HttpProxyDmkTransport,
+} from "./HttpProxyDmkTransport";
 
-const SYNTHETIC_DEVICE_ID = "http-proxy-device";
+const SYNTHETIC_DEVICE_ID = buildHttpProxyLegacyDeviceId("http://localhost:8435");
 
 const mockDeviceModel = {
   model: DeviceModelId.NANO_X,
@@ -82,6 +86,9 @@ describe("HttpProxyDmkTransport", () => {
       const emitted = await nextEmission;
 
       expect(emitted).toHaveLength(1);
+      expect((emitted[0] as { id: string }).id).toBe(
+        buildHttpProxyLegacyDeviceId("http://other:9999"),
+      );
       expect((emitted[0] as { name: string }).name).toContain("http://other:9999");
     });
   });
@@ -348,7 +355,7 @@ describe("HttpProxyDmkTransport", () => {
       expect((emitted[0] as { name: string }).name).toContain(url);
     });
 
-    it("should use a stable id across URL changes", async () => {
+    it("should encode the current URL in the legacy-compatible device id", async () => {
       const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
       const ids: string[] = [];
 
@@ -371,7 +378,7 @@ describe("HttpProxyDmkTransport", () => {
         });
       });
 
-      expect(ids).toEqual([SYNTHETIC_DEVICE_ID, SYNTHETIC_DEVICE_ID]);
+      expect(ids).toEqual([SYNTHETIC_DEVICE_ID, buildHttpProxyLegacyDeviceId("http://other:9999")]);
     });
   });
 });

--- a/libs/live-dmk-mobile/src/transport/HttpProxyDmkTransport.ts
+++ b/libs/live-dmk-mobile/src/transport/HttpProxyDmkTransport.ts
@@ -19,7 +19,9 @@ import { ledgerToDmkDeviceIdMap } from "@ledgerhq/live-dmk-shared";
 import { DeviceModelId as LedgerDeviceModelId } from "@ledgerhq/types-devices";
 
 export const HTTP_PROXY_TRANSPORT_IDENTIFIER = "HTTP_PROXY_TRANSPORT";
-const SYNTHETIC_DEVICE_ID = "http-proxy-device";
+export const HTTP_PROXY_LEGACY_DEVICE_ID_PREFIX = "httpdebug|";
+export const buildHttpProxyLegacyDeviceId = (url: string): string =>
+  `${HTTP_PROXY_LEGACY_DEVICE_ID_PREFIX}${url}`;
 
 export const DEFAULT_HTTP_PROXY_DEVICE_MODEL_ID = DeviceModelId.NANO_X;
 
@@ -186,7 +188,7 @@ export class HttpProxyDmkTransport implements DmkTransport {
     const deviceModelId = await this.resolveDeviceModelId(url);
 
     return {
-      id: SYNTHETIC_DEVICE_ID,
+      id: buildHttpProxyLegacyDeviceId(url),
       deviceModel: this.args.deviceModelDataSource.getDeviceModel({ id: deviceModelId }),
       transport: HTTP_PROXY_TRANSPORT_IDENTIFIER,
       name: `HTTP Proxy (${url})`,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - HTTP proxy device discovery in `@ledgerhq/live-dmk-mobile`
  - LWM Device Intent Executor compatibility IDs for proxy devices
  - New send flow signing when legacy `withDevice` resolves the proxy transport

### 📝 Description

This PR fixes a device connection issue in the new send flow when using the LWM HTTP device proxy instead of BLE or HID. Previously, `HttpProxyDmkTransport` exposed proxy devices with a generic `http-proxy-device` id. When DIE passed that id as `compatDeviceId` into legacy signing code, `withDevice` could not match it to the registered `httpdebug` transport and fell back to BLE, causing `BleNotSupported`.

The HTTP proxy discovered device id now uses the legacy-compatible `httpdebug|<url>` format from the start. This makes the compat id resolve through the existing `httpdebug` transport module, while keeping the DMK transport behavior covered by updated tests.

Before:

```ts
id: "http-proxy-device"
```

After:

```ts
id: buildHttpProxyLegacyDeviceId(url)
```

Validation run locally:

- `pnpm --filter @ledgerhq/live-dmk-mobile test -- src/transport/HttpProxyDmkTransport.test.ts src/transport/DeviceManagementKitHTTPProxyTransport.test.ts`
- `pnpm --filter @ledgerhq/live-dmk-mobile lint`
- `pnpm --filter @ledgerhq/live-dmk-mobile typecheck`

### ❓ Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)