### PR TITLE
[LWDM][Tezos] Scope of issues

### DIFF
--- a/.changeset/gentle-llamas-dream.md
+++ b/.changeset/gentle-llamas-dream.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update Tezos unstake-required modal copy

--- a/.changeset/lazy-pandas-march.md
+++ b/.changeset/lazy-pandas-march.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-tezos": minor
+"@ledgerhq/live-common": patch
+---
+
+Fix Tezos send "Use Max" on delegated accounts: resolve the spendable max instead of blocking the transaction

--- a/.changeset/swift-eagles-wander.md
+++ b/.changeset/swift-eagles-wander.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Tezos staking amount banner breaking the layout when the keyboard opens

--- a/apps/ledger-live-mobile/src/families/tezos/StakeFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/StakeFlow/01-Amount.tsx
@@ -31,6 +31,7 @@ import AmountInput from "~/screens/SendFunds/AmountInput";
 import SummaryRow from "~/screens/SendFunds/SummaryRow";
 import { ScreenName } from "~/const";
 import { urls } from "~/utils/urls";
+import { useKeyboardVisible } from "~/logic/keyboardVisible";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import type { TezosStakeFlowParamList } from "./types";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
@@ -48,6 +49,7 @@ export default function StakeAmount() {
   const route = useRoute<Props["route"]>();
   const { colors } = useTheme();
   const { t } = useTranslation();
+  const { isKeyboardVisible } = useKeyboardVisible();
   const { account, parentAccount } = useAccountScreen(route);
 
   invariant(account?.type === "Account", "tezos account required");
@@ -193,11 +195,13 @@ export default function StakeAmount() {
         currency="xtz"
       />
       <KeyboardView style={styles.container}>
-        <Alert
-          type="primary"
-          title={t("tezos.stake.flow.amount.disclaimer")}
-          onLearnMore={learnMore}
-        />
+        {!isKeyboardVisible && (
+          <Alert
+            type="primary"
+            title={t("tezos.stake.flow.amount.disclaimer")}
+            onLearnMore={learnMore}
+          />
+        )}
         <TouchableWithoutFeedback onPress={blur}>
           <View style={styles.amountWrapper}>
             <AmountInput

--- a/apps/ledger-live-mobile/src/families/tezos/UnstakeFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/UnstakeFlow/01-Amount.tsx
@@ -22,6 +22,7 @@ import KeyboardView from "~/components/KeyboardView";
 import AmountInput from "~/screens/SendFunds/AmountInput";
 import SummaryRow from "~/screens/SendFunds/SummaryRow";
 import { ScreenName } from "~/const";
+import { useKeyboardVisible } from "~/logic/keyboardVisible";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import type { TezosUnstakeFlowParamList } from "./types";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
@@ -34,6 +35,7 @@ export default function UnstakeAmount() {
   const route = useRoute<Props["route"]>();
   const { colors } = useTheme();
   const { t } = useTranslation();
+  const { isKeyboardVisible } = useKeyboardVisible();
   const { account, parentAccount } = useAccountScreen(route);
 
   invariant(account?.type === "Account", "tezos account required");
@@ -106,7 +108,9 @@ export default function UnstakeAmount() {
         currency="xtz"
       />
       <KeyboardView style={styles.container}>
-        <Alert type="primary" title={t("tezos.unstake.flow.amount.unbondingNotice")} />
+        {!isKeyboardVisible && (
+          <Alert type="primary" title={t("tezos.unstake.flow.amount.unbondingNotice")} />
+        )}
         <TouchableWithoutFeedback onPress={blur}>
           <View style={styles.amountWrapper}>
             <AmountInput

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -6735,15 +6735,15 @@
     "unstakeRequired": {
       "changeBaker": {
         "title": "Unstake before changing baker",
-        "description": "You have staked XTZ with your current baker. Unstake your funds before delegating to a new baker."
+        "description": "You have staked XTZ with your current baker. Unstake all your funds before delegating to a new baker."
       },
       "endDelegation": {
         "title": "Unstake before ending delegation",
-        "description": "You have staked XTZ with your current baker. Unstake your funds before ending the delegation."
+        "description": "You have staked XTZ with your current baker. Unstake all your funds before ending the delegation."
       },
       "steps": {
-        "0": "Open the Earn menu and select Unstake.",
-        "1": "Confirm the amount and submit the unstake transaction on your device.",
+        "0": "Open the Tezos Account dashboard and select the Unstake option in your staking section.",
+        "1": "Unstake the MAX amount and submit the unstake transaction on your device.",
         "2": "Wait ~4 days for the unstake period to complete.",
         "3": "Once withdrawn, you can change baker or end delegation."
       },

--- a/libs/coin-modules/coin-tezos/src/api/index.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.ts
@@ -16,7 +16,6 @@ import type {
   TransactionIntent,
 } from "@ledgerhq/coin-module-framework/api/types";
 import { craftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
-import { RecommendUndelegation } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
 import { getRevealFee } from "@taquito/taquito";
 import { getPkhfromPk, validatePublicKey, ValidationResult } from "@taquito/utils";
@@ -117,13 +116,9 @@ async function craft(
   const tokenCraftInfo =
     tezosMode === "send_token" ? parseTezosTokenAsset(transactionIntent.asset)! : undefined;
 
-  // Guard: send max is incompatible with delegated accounts (native XTZ only)
   let amountToUse = tezosMode === "finalize_unstake" ? 0n : transactionIntent.amount;
   if (tezosMode === "send" && transactionIntent.useAllAmount) {
     const senderInfo = await api.getAccountByAddress(transactionIntent.sender);
-    if (senderInfo.type === "user" && senderInfo.delegate?.address) {
-      throw new RecommendUndelegation();
-    }
     if (senderInfo.type === "user") {
       // Use the amount calculated by the estimation which includes proper buffers and adjustments
       if (estimation.parameters?.amount !== undefined) {

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
@@ -5,7 +5,6 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   AmountRequired,
   NotEnoughBalance,
-  RecommendUndelegation,
   NotEnoughBalanceToDelegate,
 } from "@ledgerhq/errors";
 import coinConfig from "../config";
@@ -235,7 +234,7 @@ describe("validateIntent", () => {
   });
 
   describe("transaction constraints", () => {
-    it("should return RecommendUndelegation when send-max native XTZ on a delegated account", async () => {
+    it("allows send-max on a delegated account with no error or warning and resolves the max amount", async () => {
       mockGetAccountByAddress.mockResolvedValue(
         makeUserAccount({
           delegate: { alias: "baker", address: validRecipient, active: true },
@@ -253,8 +252,11 @@ describe("validateIntent", () => {
         useAllAmount: true,
       });
 
-      expect(result.errors.amount).toBeInstanceOf(RecommendUndelegation);
-      expect(mockEstimateFees).not.toHaveBeenCalled();
+      expect(result.errors).toEqual({});
+      expect(result.warnings).toEqual({});
+      // balance 5_000_000 - fees 1_000
+      expect(result.amount).toBe(4999000n);
+      expect(result.totalSpent).toBe(5000000n);
     });
 
     it("should return MustDelegateBeforeStaking when stake intent has no delegate", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
@@ -5,7 +5,6 @@ import type {
 import {
   InvalidAddress,
   RecipientRequired,
-  RecommendUndelegation,
   NotEnoughBalance,
   NotEnoughBalanceToDelegate,
   AmountRequired,
@@ -80,21 +79,6 @@ function validateBasicSendParams(intent: TransactionIntent): Record<string, Erro
   return errors;
 }
 
-// send max not allowed on delegated accounts (must undelegate acc first); native XTZ only
-function validateSendConstraints(
-  intent: TransactionIntent,
-  senderInfo: APIUserAccount,
-): Record<string, Error> {
-  if (
-    intent.useAllAmount &&
-    resolveValidationOperationMode(intent) === "send" &&
-    senderInfo.delegate?.address
-  ) {
-    return { amount: new RecommendUndelegation() };
-  }
-  return {};
-}
-
 function validateStakeConstraints(
   intent: TransactionIntent,
   senderInfo: APIUserAccount,
@@ -140,8 +124,6 @@ function validateTransactionConstraints(
   finalizable: bigint,
 ): Record<string, Error> {
   switch (intent.type) {
-    case "send":
-      return validateSendConstraints(intent, senderInfo);
     case "stake":
       return validateStakeConstraints(intent, senderInfo);
     case "unstake":

--- a/libs/ledger-live-common/src/families/tezos/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/tezos/bridge/mock.ts
@@ -8,7 +8,6 @@ import {
   NotSupportedLegacyAddress,
   NotEnoughBalanceInParentAccount,
   AmountRequired,
-  RecommendUndelegation,
   RecommendSubAccountsToEmpty,
   NotEnoughBalanceToDelegate,
 } from "@ledgerhq/errors";
@@ -29,7 +28,6 @@ import {
   getSerializedAddressParameters,
   updateTransaction,
 } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
-import { isAccountDelegating } from "../staking";
 import { validateAddress } from "../../../bridge/validateAddress";
 
 const isAccountBalanceSignificant = (a: AccountLike): boolean => a.balance.gt(100);
@@ -141,9 +139,7 @@ const getTransactionStatus = (a: Account, t: Transaction) => {
     const thresholdWarning = 0.5 * 10 ** a.currency.units[0].magnitude;
 
     if (!subAcc && !errors.amount && account.balance.minus(totalSpent).lt(thresholdWarning)) {
-      if (isAccountDelegating(account)) {
-        warnings.amount = new RecommendUndelegation();
-      } else if ((a.subAccounts || []).some(isAccountBalanceSignificant)) {
+      if ((a.subAccounts || []).some(isAccountBalanceSignificant)) {
         warnings.amount = new RecommendSubAccountsToEmpty();
       }
     }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
- Tezos send: toggling Use Max on a delegated account now fills the spendable max and lets the transaction proceed — no error, no warning (previously errored with "Please undelegate…" and put 0). Affects desktop + mobile (shared coin-tezos bridge). QA: verify Use Max on delegated, non-delegated, and staked-funds accounts; confirm crafted/signed amount matches the displayed max.
- Tezos mobile stake flow: the Amount-step disclaimer banner is hidden while the keyboard is open. QA: Android 15+ (API 35) keyboard open/close on the stake Amount screen; check no layout break and the banner returns on dismiss.
- Tezos mobile unstake-required modal: copy aligned with desktop. QA: open the modal (change baker / end delegation) and proofread.

### 📝 Description

1. Send "Use Max" on delegated accounts. Previously, toggling Use Max on a delegated Tezos account blocked the send with RecommendUndelegation ("Please undelegate the account before emptying it") and forced the amount to 0, even though entering the same amount manually succeeded. The guard was a regression from the generic-bridge migration (it was a non-blocking warning before, and still is for cosmos). Per product, the recommendation is dropped entirely: validateIntent no longer emits an error or warning and resolves the spendable max, the crafting step no longer throws, and the mock bridge was aligned. Fix lives in shared coin-tezos / live-common, so it covers desktop and mobile.
2. Stake Amount banner on keyboard open (mobile). The disclaimer Alert on the stake Amount step broke the layout when the keyboard opened on Android 15+ (API 35, where KeyboardView uses behavior="height"). It's now hidden while the keyboard is visible via the existing useKeyboardVisible hook.
3. Unstake-required modal copy (mobile). Updated to match the already-revised desktop wording.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32546](https://ledgerhq.atlassian.net/browse/LIVE-32546?atlOrigin=eyJpIjoiMDM1M2Q3MTIzNmY4NGQ1MjhjY2MyMGJjMGI4NTQwMzQiLCJwIjoiaiJ9), [LIVE-32735](https://ledgerhq.atlassian.net/browse/LIVE-32735?atlOrigin=eyJpIjoiYTdlYjllZGM3MDA5NDNkNDgwOTY0OGFlMjlhMmI1NzQiLCJwIjoiaiJ9)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-32546]: https://ledgerhq.atlassian.net/browse/LIVE-32546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ