### PR TITLE
[LWDM] test(stellar): stabilize flaky integration test on mainnet

### DIFF
--- a/libs/coin-modules/coin-stellar/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index.integ.test.ts
@@ -4,16 +4,16 @@ import { StellarMemo } from "../types";
 import { createApi, envelopeFromAnyXDR } from ".";
 
 /**
- * Testnet scan: https://testnet.lumenscan.io/
+ * Mainnet explorer: https://stellar.expert/explorer/public
  */
 describe("Stellar Api", () => {
   let module: CoinModuleApi<StellarMemo>;
-  const ADDRESS = "GBAUZBDXMVV7HII4JWBGFMLVKVJ6OLQAKOCGXM5E2FM4TAZB6C7JO2L7";
+  const ADDRESS = "GBAMU3EJX6KLW2JEIAIEAYNLPKHFPJR6OYQYX5HPYB3CVQ6QD4XUJ23J";
 
   beforeAll(() => {
     module = createApi({
       explorer: {
-        url: "https://horizon-testnet.stellar.org/",
+        url: "https://stellar.coin.ledger.com",
       },
     });
   });
@@ -34,8 +34,7 @@ describe("Stellar Api", () => {
         memo: { type: "NO_MEMO" },
       });
 
-      // Then
-      expect(result).toEqual({ value: BigInt(100) });
+      expect(result.value).toBeGreaterThanOrEqual(100n);
     });
   });
 
@@ -43,7 +42,10 @@ describe("Stellar Api", () => {
     let txs: Operation[];
 
     beforeAll(async () => {
-      const result = await module.listOperations(ADDRESS, { minHeight: 0, order: "asc" });
+      const result = await module.listOperations(ADDRESS, {
+        minHeight: 0,
+        order: "asc",
+      });
       txs = result.items;
     });
 
@@ -65,7 +67,7 @@ describe("Stellar Api", () => {
 
     it("returns all operations", async () => {
       expect(txs.length).toBeGreaterThanOrEqual(100);
-      const checkSet = new Set(txs.map(elt => elt.tx.hash));
+      const checkSet = new Set(txs.map(elt => elt.id));
       expect(checkSet.size).toEqual(txs.length);
     });
 


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not needed: test-only change, no published package behavior is affected._
- [x] **Covered by automatic tests.** _This PR is itself the integration test fix._
- [x] **Impact of the changes:**
      - Stellar coin-module integration tests (`coin-stellar/src/api/index.integ.test.ts`)

### 📝 Description

The Stellar integration test was flaky: `estimateFees` asserted `toEqual({ value: 100n })`, but the value comes from the live network (`fee_charged.mode`) and varies (e.g. `45475n`). The suite also ran against testnet (`horizon-testnet.stellar.org`), which is unstable.

This PR:
- runs the suite on mainnet (`stellar.coin.ledger.com`) with a stable, funded account;
- relaxes the `estimateFees` assertion to `value >= 100n` (100 stroops is the protocol minimum base fee);
- deduplicates operations on `operation.id` (the real unique key) instead of `tx.hash`, which only held for single-operation transactions.

No production code is changed.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32751](https://ledgerhq.atlassian.net/browse/LIVE-32751)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-32751]: https://ledgerhq.atlassian.net/browse/LIVE-32751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ