### PR TITLE
[LWM] fix(mobile): prevent Market total market cap card overflow in French [LIVE-32158]

### DIFF
--- a/.changeset/live-32158-market-cap-card-overflow.md
+++ b/.changeset/live-32158-market-cap-card-overflow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the Market screen "Total market cap" highlight card overflowing in locales with longer compact-number suffixes (e.g. French "billions"). The value now shrinks to fit the card width while the trend indicator keeps its size.

--- a/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/MarketCapCardView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/MarketCapCardView.tsx
@@ -59,10 +59,19 @@ export function MarketCapCardView({
           {t("marketCapCard.title")}
         </Text>
         <Box lx={valueStyle}>
-          <Text typography="body1SemiBold" numberOfLines={1} lx={{ color: "base" }}>
+          <Text
+            typography="body1SemiBold"
+            numberOfLines={1}
+            adjustsFontSizeToFit
+            lx={{ color: "base", flexShrink: 1 }}
+          >
             {value}
           </Text>
-          {changePercentage !== undefined ? <Trend value={changePercentage} size="md" /> : null}
+          {changePercentage !== undefined ? (
+            <Box lx={{ flexShrink: 0 }}>
+              <Trend value={changePercentage} size="md" />
+            </Box>
+          ) : null}
         </Box>
       </Pressable>
       <MarketInsightDefinitionSheet


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Existing MarketCapCard integration test (render value + 24h variation, drawer, error) stays green. The fix itself is a layout constraint (not unit-assertable in jsdom).
- [x] **Impact of the changes:** Market screen "Total market cap" highlight card only. QA should switch the app to **French** and check the Market screen: the total market cap value (e.g. "X,XX billions USD") now stays inside the card instead of overflowing, and the trend (24h %) keeps its size.

### 📝 Description

On the Wallet 4.0 Market screen, the "Total market cap" highlight card value overflowed the card in locales whose compact-number suffix is longer than English — French uses "billions" (≈8 chars) vs English "tn" (2 chars), so a value like "X,XX billions USD" pushed past the fixed-width card.

The value `Text` (in a row with the trend indicator) had no flex constraint, unlike the sibling Fear & Greed / Altcoin Season cards. This adds:

- `flexShrink: 1` + `adjustsFontSizeToFit` on the value text — it shrinks to fit the available width without truncating the number (same pattern used for the portfolio balance).
- `flexShrink: 0` on the trend wrapper so the 24h indicator keeps its intrinsic size and the value yields space instead.

https://github.com/user-attachments/assets/fec9b662-cf55-45b1-8222-606264ca67b9


### ❓ Context

- **JIRA link**: [LIVE-32158](https://ledgerhq.atlassian.net/browse/LIVE-32158)


[LIVE-32158]: https://ledgerhq.atlassian.net/browse/LIVE-32158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ