### PR TITLE
feat(common): add a mutex lock system to prevent token approval nonce races

### DIFF
--- a/.changeset/qaa-1323-eoa-broadcast-lock.md
+++ b/.changeset/qaa-1323-eoa-broadcast-lock.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-e2e-shared": patch
+---
+
+fix(e2e): serialize token approve/revoke broadcasts per EOA and retry transient nonce failures
+
+Several swap E2E specs broadcast real ERC-20 approve/revoke from the same shared ETH index-0 EOA in parallel (`fullyParallel`), causing intermittent `replacement transaction underpriced` / `not confirmed within` failures (a nonce race on the shared account). Adds a cross-worker filesystem lock keyed by the parent EOA in `approveTokenCommand`/`revokeTokenCommand` so only one broadcast per EOA runs at a time across Playwright workers, plus a retry backstop for transient underpriced/nonce/not-confirmed errors that re-drives the device prompt on each attempt. (QAA-1323)

--- a/libs/live-e2e-shared/src/cliCommandsUtils.ts
+++ b/libs/live-e2e-shared/src/cliCommandsUtils.ts
@@ -11,7 +11,11 @@ import {
   runCliGetTokenAllowance,
   runCliLiveData,
   runCliTokenApproval,
+  isRetryableError,
 } from "./runCli";
+import type { TokenApprovalOpts } from "./runCli";
+import { sleep } from "./index";
+import { runWithCrossProcessLock } from "./crossProcessLock";
 import { getCcdAccountAddress } from "./families/concordium";
 import { approveToken } from "./families/evm";
 import { getCryptoCurrencyById, parseCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
@@ -354,10 +358,10 @@ export const isTokenAllowanceSufficientCommand = async (
  * is exactly zero after a revoke). Use {@link isTokenAllowanceSufficientCommand}
  * when only a threshold check is needed.
  */
-export const getTokenAllowanceCommand = async (
+export async function getTokenAllowanceCommand(
   account: TokenAccount,
   spenderAddress: string,
-): Promise<string> => {
+): Promise<string> {
   const ownerAddress = account.parentAccount?.address ?? account.address;
   if (!ownerAddress) throw new Error("Token allowance check requires the main account address");
 
@@ -372,20 +376,78 @@ export const getTokenAllowanceCommand = async (
 
   const { allowanceStr } = parseTokenAllowanceCliOutput(output);
   return allowanceStr;
-};
+}
+
+const MAX_BROADCAST_ATTEMPTS = 3;
+const BROADCAST_RETRY_DELAY_MS = 5_000;
 
 /**
- * Runs ledger-live CLI token approval with Speculos device confirmation, managing
- * `DISABLE_TRANSACTION_BROADCAST` around the CLI call.
+ * Broadcasts one token approve/revoke and retries transient nonce/broadcast
+ * failures (underpriced, nonce too low, not confirmed). The CLI runs with
+ * `retries: 1` because each re-broadcast re-presents the device prompt, which we
+ * must drive again via {@link approveToken} — so the retry lives here, not inside
+ * the CLI helper. `DISABLE_TRANSACTION_BROADCAST` is forced to "0" per attempt.
  */
-export const approveTokenCommand = async (
-  account: TokenAccount,
-  spender: string,
-  approveAmount: string,
-) => {
-  const original = setDisableTransactionBroadcastEnv("0");
+async function runTokenApprovalWithRetry(opts: TokenApprovalOpts): Promise<string> {
+  for (let attempt = 1; attempt <= MAX_BROADCAST_ATTEMPTS; attempt++) {
+    const original = setDisableTransactionBroadcastEnv("0");
+    const result = runCliTokenApproval(opts, 1);
+    // The CLI child has already spawned and inherited the env, so restore it now:
+    // holding the flag set across the awaits below could leak it into unrelated
+    // work in the same worker process. The finally is kept as a safety net.
+    setDisableTransactionBroadcastEnv(original);
+    const cliSettled = result.catch(() => undefined);
 
-  const result = runCliTokenApproval({
+    try {
+      await approveToken();
+      return await result;
+    } catch (err) {
+      // Retry only once the previous CLI has actually exited. Its child has no
+      // timeout/kill (see runCliCommand), so cap the wait; if it's still running
+      // we must NOT spawn a second CLI on the same device — bail instead of looping.
+      const cliDidSettle = await Promise.race([
+        cliSettled.then(() => true),
+        sleep(BROADCAST_RETRY_DELAY_MS).then(() => false),
+      ]);
+      const message = err instanceof Error ? err.message : String(err);
+      if (!cliDidSettle) {
+        console.warn(
+          `⚠️ Token ${opts.mode}: previous CLI still running after ${BROADCAST_RETRY_DELAY_MS}ms – aborting retry`,
+          message,
+        );
+        throw err;
+      }
+      if (attempt === MAX_BROADCAST_ATTEMPTS || !isRetryableError(message)) throw err;
+
+      console.warn(
+        `⚠️ Token ${opts.mode} attempt ${attempt}/${MAX_BROADCAST_ATTEMPTS} failed with retryable error – retrying in ${BROADCAST_RETRY_DELAY_MS}ms…`,
+        message,
+      );
+      await sleep(BROADCAST_RETRY_DELAY_MS);
+    } finally {
+      setDisableTransactionBroadcastEnv(original);
+    }
+  }
+  throw new Error(`Token ${opts.mode} broadcast failed after ${MAX_BROADCAST_ATTEMPTS} attempts`);
+}
+
+/**
+ * Serializes the broadcast under a cross-worker lock on the parent EOA so two
+ * Playwright workers never grab the same nonce (QAA-1323).
+ */
+async function broadcastTokenApproval(
+  account: TokenAccount,
+  opts: TokenApprovalOpts,
+): Promise<string> {
+  const owner = account.parentAccount ?? account;
+  const eoa = (owner.address ?? (await getAccountAddress(owner))).toLowerCase();
+  const lockKey = `${owner.currency.id}:${eoa}`;
+  // Prevent nonce races across workers (QAA-1323).
+  return runWithCrossProcessLock(lockKey, () => runTokenApprovalWithRetry(opts));
+}
+
+export function approveTokenCommand(account: TokenAccount, spender: string, approveAmount: string) {
+  return broadcastTokenApproval(account, {
     currency: account.currency.speculosApp.name,
     index: account.index,
     spender,
@@ -394,19 +456,10 @@ export const approveTokenCommand = async (
     approveAmount,
     waitConfirmation: true,
   });
+}
 
-  try {
-    await approveToken();
-  } finally {
-    setDisableTransactionBroadcastEnv(original);
-  }
-  return await result;
-};
-
-export const revokeTokenCommand = async (account: TokenAccount, spender: string) => {
-  const original = setDisableTransactionBroadcastEnv("0");
-
-  const result = runCliTokenApproval({
+export function revokeTokenCommand(account: TokenAccount, spender: string) {
+  return broadcastTokenApproval(account, {
     currency: account.currency.speculosApp.name,
     index: account.index,
     spender,
@@ -414,14 +467,7 @@ export const revokeTokenCommand = async (account: TokenAccount, spender: string)
     mode: "revokeApproval",
     waitConfirmation: true,
   });
-
-  try {
-    await approveToken();
-  } finally {
-    setDisableTransactionBroadcastEnv(original);
-  }
-  return await result;
-};
+}
 
 const ENV_KEY = "DISABLE_TRANSACTION_BROADCAST";
 

--- a/libs/live-e2e-shared/src/crossProcessLock.ts
+++ b/libs/live-e2e-shared/src/crossProcessLock.ts
@@ -1,0 +1,116 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Cross-process mutex: run a critical section while holding an exclusive lock
+ * shared by every process on the machine.
+ *
+ * An in-memory mutex (a module-level promise chain, `async-mutex`, …) only
+ * serializes within a single process — each OS process (e.g. a Playwright or
+ * jest worker) imports its own copy with its own state. To serialize across
+ * processes the lock state must live outside any heap, on a medium all
+ * processes on the machine can see: the filesystem.
+ *
+ * The lock is a directory created with `fs.mkdir`, which is atomic and fails
+ * with `EEXIST` if it already exists — exactly the compare-and-swap we need.
+ * Whoever wins the `mkdir` holds the lock; others spin with a backoff. A
+ * heartbeat keeps the lock's mtime fresh while the holder is alive, so a
+ * slow-but-live holder (a long critical section) is never mistaken for a
+ * crashed one; a holder that dies leaves a stale mtime and the lock is
+ * reclaimed after {@link DEFAULT_STALE_MS}.
+ *
+ * Different keys are independent, so unrelated work runs in parallel.
+ */
+
+export type CrossProcessLockOptions = {
+  rootDir?: string;
+  staleMs?: number;
+  heartbeatMs?: number;
+  acquireTimeoutMs?: number;
+  backoffMs?: number;
+};
+
+export const DEFAULT_STALE_MS = 30_000;
+export const DEFAULT_HEARTBEAT_MS = 5_000;
+export const DEFAULT_ACQUIRE_TIMEOUT_MS = 600_000;
+export const DEFAULT_BACKOFF_MS = 200;
+
+// Kept local so this cross-process primitive pulls in no package-level deps.
+const delay = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
+  return typeof err === "object" && err !== null && "code" in err;
+}
+
+function defaultRootDir(): string {
+  return path.join(os.tmpdir(), "ll-e2e-locks");
+}
+
+function sanitize(key: string): string {
+  // Collision-free, filesystem-safe encoding.
+  return Buffer.from(key, "utf8").toString("base64url");
+}
+
+export function lockDirFor(key: string, rootDir: string = defaultRootDir()): string {
+  return path.join(rootDir, sanitize(key));
+}
+
+export async function runWithCrossProcessLock<T>(
+  key: string,
+  fn: () => Promise<T>,
+  options: CrossProcessLockOptions = {},
+): Promise<T> {
+  const rootDir = options.rootDir ?? defaultRootDir();
+  const staleMs = options.staleMs ?? DEFAULT_STALE_MS;
+  const heartbeatMs = options.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
+  const acquireTimeoutMs = options.acquireTimeoutMs ?? DEFAULT_ACQUIRE_TIMEOUT_MS;
+  const backoffMs = options.backoffMs ?? DEFAULT_BACKOFF_MS;
+
+  const lockDir = lockDirFor(key, rootDir);
+  await fs.promises.mkdir(rootDir, { recursive: true });
+  const start = Date.now();
+
+  for (;;) {
+    try {
+      await fs.promises.mkdir(lockDir); // non-recursive → throws EEXIST if held
+      break;
+    } catch (err) {
+      if (!isErrnoException(err) || err.code !== "EEXIST") throw err;
+
+      if (Date.now() - start > acquireTimeoutMs) {
+        throw new Error(
+          `[runWithCrossProcessLock]: timed out after ${acquireTimeoutMs}ms acquiring lock for "${key}"`,
+        );
+      }
+
+      try {
+        const { mtimeMs } = await fs.promises.stat(lockDir);
+        if (Date.now() - mtimeMs > staleMs) {
+          await fs.promises.rm(lockDir, { recursive: true, force: true });
+          continue;
+        }
+      } catch {
+        continue;
+      }
+      await delay(backoffMs);
+    }
+  }
+
+  // Hold: refresh mtime so a live-but-slow holder is never seen as stale.
+  const heartbeat = setInterval(() => {
+    const now = new Date();
+    fs.promises.utimes(lockDir, now, now).catch(() => {});
+  }, heartbeatMs);
+
+  try {
+    return await fn();
+  } finally {
+    clearInterval(heartbeat);
+    try {
+      await fs.promises.rm(lockDir, { recursive: true, force: true });
+    } catch (err) {
+      console.warn(`[runWithCrossProcessLock]: failed to release lock for "${key}"`, err);
+    }
+  }
+}

--- a/libs/live-e2e-shared/src/runCli.ts
+++ b/libs/live-e2e-shared/src/runCli.ts
@@ -115,9 +115,12 @@ function parseCliFlag(command: string, flag: string): string | undefined {
 }
 
 /**
- * Transient failures (network, Speculos, gateway) where a CLI retry may help.
+ * Transient failures where a CLI re-spawn may help:
+ *  - network / Speculos / gateway errors, and
+ *  - nonce races when several workers broadcast from the same EOA concurrently
+ * A re-spawn re-fetches the confirmed nonce and re-broadcasts.
  */
-function isRetryableError(message: string): boolean {
+export function isRetryableError(message: string): boolean {
   const retryablePatterns = [
     /503/i,
     /502/i,
@@ -128,6 +131,10 @@ function isRetryableError(message: string): boolean {
     /ECONNRESET/i,
     /socket hang up/i,
     /timeout/i,
+    /replacement transaction underpriced/i,
+    // Matches the EVM bridge's "nonce is too low" (families/evm/bridge/api.ts) and a generic "nonce too low".
+    /nonce (is )?too low/i,
+    /not confirmed within/i,
   ];
   return retryablePatterns.some(pattern => pattern.test(message));
 }
@@ -233,7 +240,12 @@ export async function runCliGetAddress(opts: GetAddressOpts): Promise<GetAddress
   return parseGetAddressCliOutput(output);
 }
 
-export function runCliTokenApproval(opts: TokenApprovalOpts): Promise<string> {
+/**
+ * `retries` defaults to 3 for standalone callers. Token-approval flows that
+ * drive the device prompt themselves pass `retries: 1` and retry one level up
+ * (see {@link approveTokenCommand}), so each re-broadcast re-drives the device.
+ */
+export function runCliTokenApproval(opts: TokenApprovalOpts, retries: number = 3): Promise<string> {
   const cliOpts = ["tokenApproval"];
   cliOpts.push(`--currency+${opts.currency}`);
   cliOpts.push(`--mode+${opts.mode}`);
@@ -242,7 +254,7 @@ export function runCliTokenApproval(opts: TokenApprovalOpts): Promise<string> {
   cliOpts.push(`--index+${opts.index}`);
   if (opts.approveAmount) cliOpts.push(`--approveAmount+${opts.approveAmount}`);
   if (opts.waitConfirmation) cliOpts.push("--wait-confirmation");
-  return runCliCommandWithRetry(cliOpts.join("+"));
+  return runCliCommandWithRetry(cliOpts.join("+"), retries);
 }
 
 export function runCliGetTokenAllowance(opts: GetTokenAllowanceOpts): Promise<string> {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**  The end-to-end nonce-race fix and the retry backstop drive real mainnet broadcasts through Speculos/CLI, so they can only be validated on the Monday nightly broadcast E2E run — not in unit CI._
- [x] **Impact of the changes:**
  - Swap token **approval / reapproval** E2E specs on the Monday nightly broadcast run (`token.approval.swap`, `token.reapproval.swap`, `provider.swap`, and `ensureTokenApproval` in `send.swap`).
  - Concurrent approve/revoke broadcasts from the shared ETH index-0 EOA are serialized — no more `replacement transaction underpriced` / `not confirmed within` on the first try.
  - Transient underpriced / nonce / not-confirmed errors recover via retry without manual reruns.
  - No regression on the default (mocked, broadcast-disabled) desktop & mobile E2E runs.

### 📝 Description

**Problem.** On the Monday nightly broadcast run, several LWD swap E2E specs broadcast **real mainnet** ERC-20 approve/revoke from the *same* externally-owned account — `Account.ETH_1` (index 0, `0xE32a…b75a`), the shared parent of `ETH_USDT_1` and `ETH_USDC_1`. They run under Playwright `fullyParallel`, and each broadcast fetches the nonce fresh (ETH mainnet uses confirmed-nonce semantics) with no cross-process coordination. Two workers grab the same nonce → the second is rejected as `replacement transaction underpriced `, or a competing same-nonce tx wins and ours never mines → `not confirmed within 120000ms`. Nothing retried it, so only Playwright's test-level ×2 retry eventually went green (flaky).

**Solution.**
- **Cross-worker lock** (`e2e/live-e2e-shared/src/crossProcessLock.ts`): `runWithCrossProcessLock(key, fn)` serializes broadcasts **across Playwright worker processes**. Workers are separate OS processes, so an in-memory mutex can't coordinate them — the lock lives on the filesystem (atomic `fs.mkdir` + mtime heartbeat + stale-lock reclaim).
- `approveTokenCommand` / `revokeTokenCommand` now run inside `runWithCrossProcessLock`, keyed by the parent EOA (`currency.id:address`), so different EOAs/chains still broadcast in parallel.
- **Retry backstop**: `isRetryableError` is extended and exported to match `replacement transaction underpriced` /  / `nonce too low` / `not confirmed within`.


### ❓ Context

- **JIRA or GitHub link**: [QAA-1323](https://ledgerhq.atlassian.net/browse/QAA-1323)
- **Desktop**:https://github.com/LedgerHQ/ledger-live/actions/runs/28107013460
- **Mobile**: https://github.com/LedgerHQ/ledger-live/actions/runs/28107029944

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1323]: https://ledgerhq.atlassian.net/browse/QAA-1323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ