### PR TITLE
[LWDM] style: apply oxfmt formatting to files that landed unformatted

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/useMarketPriceSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/useMarketPriceSectionViewModel.ts
@@ -94,7 +94,7 @@ export function useMarketPriceSectionViewModel({
   const hasPriceData = Number.isFinite(data?.price);
   const showSkeleton = Boolean(
     marketAssetId &&
-      resolveAssetDetailSectionLoading(isDistributionLoading, marketData.isLoading, hasPriceData),
+    resolveAssetDetailSectionLoading(isDistributionLoading, marketData.isLoading, hasPriceData),
   );
 
   const { percentage: normalizedPercentage, variationFiat } = resolveRangePriceChange({

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/index.tsx
@@ -2,10 +2,7 @@ import React from "react";
 import { useFeature } from "@features/platform-feature-flags";
 import { AnalyticsConsentDialog } from "LLD/features/AnalyticsConsentDialog";
 import { ProductTourDialog, useProductTourDialogViewModel } from "LLD/features/ProductTour/Drawer";
-import {
-  Q2TourDialog,
-  useQ2TourDrawerViewModel,
-} from "LLD/features/Q2Tour";
+import { Q2TourDialog, useQ2TourDrawerViewModel } from "LLD/features/Q2Tour";
 import {
   useWalletV4TourDrawerViewModel,
   WalletV4TourDialog,

--- a/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/Drawer/Q2TourDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/Drawer/Q2TourDialog.tsx
@@ -34,7 +34,7 @@ export const Q2TourDialog = ({
   );
 
   return (
-    <Dialog open={isOpen} onOpenChange={() => { }}>
+    <Dialog open={isOpen} onOpenChange={() => {}}>
       <DialogContent
         className="flex h-screen min-h-0 flex-col"
         onPointerDownOutside={onDismiss}
@@ -42,7 +42,11 @@ export const Q2TourDialog = ({
       >
         <DialogHeader density="compact" onClose={onHeaderClose} />
         <DialogBody className="flex min-h-0 flex-1 flex-col gap-24 overflow-hidden">
-          <Slides key={isOpen ? "open" : "closed"} initialSlideIndex={0} onSlideChange={onSlideChange}>
+          <Slides
+            key={isOpen ? "open" : "closed"}
+            initialSlideIndex={0}
+            onSlideChange={onSlideChange}
+          >
             <Slides.Content>{slideItems}</Slides.Content>
 
             <Slides.ProgressIndicator>

--- a/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/Drawer/assets.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/Drawer/assets.ts
@@ -11,18 +11,6 @@ import earnSimulatorLight from "./assets/light/Q2_PRODUCT_TOUR_LIGHT_MODE_EARN_S
 import earnUpsellingLight from "./assets/light/Q2_PRODUCT_TOUR_LIGHT_MODE_UPSELLING.webp";
 
 export const SLIDE_IMAGES = {
-  dark: [
-    welcomeDark,
-    aggregatedBalanceDark,
-    pnlDark,
-    earnSimulatorDark,
-    earnUpsellingDark,
-  ],
-  light: [
-    welcomeLight,
-    aggregatedBalanceLight,
-    pnlLight,
-    earnSimulatorLight,
-    earnUpsellingLight,
-  ],
+  dark: [welcomeDark, aggregatedBalanceDark, pnlDark, earnSimulatorDark, earnUpsellingDark],
+  light: [welcomeLight, aggregatedBalanceLight, pnlLight, earnSimulatorLight, earnUpsellingLight],
 } as const;

--- a/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/Drawer/hooks/__tests__/useQ2TourDrawerViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/Drawer/hooks/__tests__/useQ2TourDrawerViewModel.test.ts
@@ -52,39 +52,35 @@ describe("useQ2TourDrawerViewModel", () => {
 
   describe("auto-open on Portfolio", () => {
     it("should not auto-open when not on Portfolio page", () => {
-      const { result } = renderHook(
-        () => useQ2TourDrawerViewModel({ isOnPortfolioPage: false }),
-        { initialState: getInitialState() },
-      );
+      const { result } = renderHook(() => useQ2TourDrawerViewModel({ isOnPortfolioPage: false }), {
+        initialState: getInitialState(),
+      });
 
       expect(result.current.isDialogOpen).toBe(false);
       expect(trackQ2TourInitialStep).not.toHaveBeenCalled();
     });
 
     it("should auto-open when tour is enabled, not seen, and onboarding is complete", () => {
-      const { result } = renderHook(
-        () => useQ2TourDrawerViewModel({ isOnPortfolioPage: true }),
-        { initialState: getInitialState() },
-      );
+      const { result } = renderHook(() => useQ2TourDrawerViewModel({ isOnPortfolioPage: true }), {
+        initialState: getInitialState(),
+      });
 
       expect(result.current.isDialogOpen).toBe(true);
       expect(trackQ2TourInitialStep).toHaveBeenCalledTimes(1);
     });
 
     it("should not auto-open when tour has already been seen", () => {
-      const { result } = renderHook(
-        () => useQ2TourDrawerViewModel({ isOnPortfolioPage: true }),
-        { initialState: getInitialState({ hasSeenQ2Tour: true }) },
-      );
+      const { result } = renderHook(() => useQ2TourDrawerViewModel({ isOnPortfolioPage: true }), {
+        initialState: getInitialState({ hasSeenQ2Tour: true }),
+      });
 
       expect(result.current.isDialogOpen).toBe(false);
     });
 
     it("should not auto-open when onboarding is incomplete", () => {
-      const { result } = renderHook(
-        () => useQ2TourDrawerViewModel({ isOnPortfolioPage: true }),
-        { initialState: getInitialState({ hasCompletedOnboarding: false }) },
-      );
+      const { result } = renderHook(() => useQ2TourDrawerViewModel({ isOnPortfolioPage: true }), {
+        initialState: getInitialState({ hasCompletedOnboarding: false }),
+      });
 
       expect(result.current.isDialogOpen).toBe(false);
     });
@@ -92,10 +88,9 @@ describe("useQ2TourDrawerViewModel", () => {
 
   describe("handleOpenDialog", () => {
     it("should open dialog and track initial step when tour is enabled and not seen", () => {
-      const { result } = renderHook(
-        () => useQ2TourDrawerViewModel({ isOnPortfolioPage: false }),
-        { initialState: getInitialState() },
-      );
+      const { result } = renderHook(() => useQ2TourDrawerViewModel({ isOnPortfolioPage: false }), {
+        initialState: getInitialState(),
+      });
 
       act(() => {
         result.current.handleOpenDialog();
@@ -106,10 +101,9 @@ describe("useQ2TourDrawerViewModel", () => {
     });
 
     it("should not open when hasSeenTour is true", () => {
-      const { result } = renderHook(
-        () => useQ2TourDrawerViewModel({ isOnPortfolioPage: false }),
-        { initialState: getInitialState({ hasSeenQ2Tour: true }) },
-      );
+      const { result } = renderHook(() => useQ2TourDrawerViewModel({ isOnPortfolioPage: false }), {
+        initialState: getInitialState({ hasSeenQ2Tour: true }),
+      });
 
       act(() => {
         result.current.handleOpenDialog();
@@ -119,16 +113,13 @@ describe("useQ2TourDrawerViewModel", () => {
     });
 
     it("should not open when q2Tour flag is disabled", () => {
-      const { result } = renderHook(
-        () => useQ2TourDrawerViewModel({ isOnPortfolioPage: false }),
-        {
-          initialState: getInitialState({
-            featureFlagOverrides: {
-              lwdWallet40: { enabled: true, params: { q2Tour: false } },
-            },
-          }),
-        },
-      );
+      const { result } = renderHook(() => useQ2TourDrawerViewModel({ isOnPortfolioPage: false }), {
+        initialState: getInitialState({
+          featureFlagOverrides: {
+            lwdWallet40: { enabled: true, params: { q2Tour: false } },
+          },
+        }),
+      });
 
       act(() => {
         result.current.handleOpenDialog();
@@ -158,10 +149,9 @@ describe("useQ2TourDrawerViewModel", () => {
 
   describe("closeDrawer", () => {
     it("should track close click and close dialog", () => {
-      const { result } = renderHook(
-        () => useQ2TourDrawerViewModel({ isOnPortfolioPage: true }),
-        { initialState: getInitialState() },
-      );
+      const { result } = renderHook(() => useQ2TourDrawerViewModel({ isOnPortfolioPage: true }), {
+        initialState: getInitialState(),
+      });
 
       act(() => {
         result.current.closeDrawer();
@@ -172,10 +162,9 @@ describe("useQ2TourDrawerViewModel", () => {
     });
 
     it("should not track close twice when called repeatedly", () => {
-      const { result } = renderHook(
-        () => useQ2TourDrawerViewModel({ isOnPortfolioPage: true }),
-        { initialState: getInitialState() },
-      );
+      const { result } = renderHook(() => useQ2TourDrawerViewModel({ isOnPortfolioPage: true }), {
+        initialState: getInitialState(),
+      });
 
       act(() => {
         result.current.closeDrawer();
@@ -188,10 +177,9 @@ describe("useQ2TourDrawerViewModel", () => {
 
   describe("dismissDrawer", () => {
     it("should track drawer dismissed and close dialog", () => {
-      const { result } = renderHook(
-        () => useQ2TourDrawerViewModel({ isOnPortfolioPage: true }),
-        { initialState: getInitialState() },
-      );
+      const { result } = renderHook(() => useQ2TourDrawerViewModel({ isOnPortfolioPage: true }), {
+        initialState: getInitialState(),
+      });
 
       act(() => {
         result.current.dismissDrawer();
@@ -204,27 +192,23 @@ describe("useQ2TourDrawerViewModel", () => {
 
   describe("onSlideChange", () => {
     it("should track step navigation", () => {
-      const { result } = renderHook(
-        () => useQ2TourDrawerViewModel({ isOnPortfolioPage: false }),
-        { initialState: getInitialState() },
-      );
+      const { result } = renderHook(() => useQ2TourDrawerViewModel({ isOnPortfolioPage: false }), {
+        initialState: getInitialState(),
+      });
 
       act(() => {
         result.current.onSlideChange(2);
       });
 
-      expect(trackQ2TourStepNavigation).toHaveBeenCalledWith(
-        expect.objectContaining({ step: 3 }),
-      );
+      expect(trackQ2TourStepNavigation).toHaveBeenCalledWith(expect.objectContaining({ step: 3 }));
     });
   });
 
   describe("onContinueClick", () => {
     it("should track continue click on non-last slide", () => {
-      const { result } = renderHook(
-        () => useQ2TourDrawerViewModel({ isOnPortfolioPage: false }),
-        { initialState: getInitialState() },
-      );
+      const { result } = renderHook(() => useQ2TourDrawerViewModel({ isOnPortfolioPage: false }), {
+        initialState: getInitialState(),
+      });
 
       act(() => {
         result.current.onContinueClick(0, false);
@@ -235,10 +219,9 @@ describe("useQ2TourDrawerViewModel", () => {
     });
 
     it("should track tour completed on last slide", () => {
-      const { result } = renderHook(
-        () => useQ2TourDrawerViewModel({ isOnPortfolioPage: false }),
-        { initialState: getInitialState() },
-      );
+      const { result } = renderHook(() => useQ2TourDrawerViewModel({ isOnPortfolioPage: false }), {
+        initialState: getInitialState(),
+      });
 
       act(() => {
         result.current.onContinueClick(Q2_TOUR_LAST_SLIDE_INDEX, true);

--- a/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/Drawer/hooks/useQ2TourDrawerViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/Drawer/hooks/useQ2TourDrawerViewModel.ts
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
-import { hasCompletedOnboardingSelector, hasSeenQ2TourSelector } from "~/renderer/reducers/settings";
+import {
+  hasCompletedOnboardingSelector,
+  hasSeenQ2TourSelector,
+} from "~/renderer/reducers/settings";
 import { setHasSeenQ2Tour } from "~/renderer/actions/settings";
 import {
   getQ2TourAnalyticsContext,

--- a/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/Drawer/hooks/useQ2TourSlideItemViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/Drawer/hooks/useQ2TourSlideItemViewModel.ts
@@ -2,10 +2,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "LLD/hooks/redux";
 import { themeSelector } from "~/renderer/actions/general";
-import {
-  Q2_TOUR_LAST_SLIDE_INDEX,
-  Q2_TOUR_SLIDES,
-} from "../const";
+import { Q2_TOUR_LAST_SLIDE_INDEX, Q2_TOUR_SLIDES } from "../const";
 import { SLIDE_IMAGES } from "../assets";
 
 interface UseQ2TourSlideItemViewModelProps {
@@ -25,8 +22,7 @@ export function useQ2TourSlideItemViewModel({
   const theme = useSelector(themeSelector);
 
   return useMemo(() => {
-    const safeIndex =
-      slideIndex >= 0 && slideIndex <= Q2_TOUR_LAST_SLIDE_INDEX ? slideIndex : 0;
+    const safeIndex = slideIndex >= 0 && slideIndex <= Q2_TOUR_LAST_SLIDE_INDEX ? slideIndex : 0;
     const slide = Q2_TOUR_SLIDES[safeIndex];
     const imageSrc = SLIDE_IMAGES[theme][safeIndex] ?? SLIDE_IMAGES[theme][0];
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/Drawer/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/Drawer/index.ts
@@ -4,4 +4,3 @@ export type {
   UseQ2TourDrawerViewModelOptions,
 } from "./hooks/useQ2TourDrawerViewModel";
 export { useQ2TourDrawerViewModel } from "./hooks/useQ2TourDrawerViewModel";
-

--- a/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/analytics/__tests__/q2TourCarouselAnalytics.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/analytics/__tests__/q2TourCarouselAnalytics.test.ts
@@ -27,9 +27,7 @@ describe("q2TourCarouselAnalytics", () => {
       totalSteps: Q2_TOUR_SLIDES.length,
     });
 
-    trackQ2TourInitialStep(
-      getQ2TourAnalyticsContext(0, Q2_TOUR_SLIDES[0].titleKey),
-    );
+    trackQ2TourInitialStep(getQ2TourAnalyticsContext(0, Q2_TOUR_SLIDES[0].titleKey));
 
     expect(trackPage).toHaveBeenCalledWith(
       PAGE_TRACKING_Q2_TOUR,

--- a/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/analytics/q2TourCarouselAnalytics.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/analytics/q2TourCarouselAnalytics.ts
@@ -38,13 +38,7 @@ const getQ2TourInteractionProperties = (context: Q2TourAnalyticsContext) => ({
 });
 
 const trackQ2TourStepPage = (context: Q2TourAnalyticsContext): void => {
-  trackPage(
-    PAGE_TRACKING_Q2_TOUR,
-    undefined,
-    getQ2TourPageProperties(context),
-    true,
-    false,
-  );
+  trackPage(PAGE_TRACKING_Q2_TOUR, undefined, getQ2TourPageProperties(context), true, false);
 };
 
 export const trackQ2TourContinueClick = (context: Q2TourAnalyticsContext): void => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/index.ts
@@ -1,4 +1,1 @@
-export {
-  Q2TourDialog,
-  useQ2TourDrawerViewModel,
-} from "./Drawer";
+export { Q2TourDialog, useQ2TourDrawerViewModel } from "./Drawer";

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/Details/DetailRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/Details/DetailRow.tsx
@@ -10,7 +10,12 @@ export function DetailRow({ label, value, testId }: DetailRowProps) {
   return (
     <>
       <dt className="whitespace-nowrap body-3 text-muted">{label}</dt>
-      <dd data-testid={testId} className="min-w-0 justify-self-end text-right body-3-semi-bold text-base">{value}</dd>
+      <dd
+        data-testid={testId}
+        className="min-w-0 justify-self-end text-right body-3-semi-bold text-base"
+      >
+        {value}
+      </dd>
     </>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/Details/DetailsSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/Details/DetailsSection.tsx
@@ -74,7 +74,10 @@ export function DetailsSection({
                   <ProviderIcon name={provider} size="XXS" borderRadius={4} />
                 </button>
               ) : (
-                <div data-testid="swap-transaction-details-provider" className="inline-flex items-center gap-6">
+                <div
+                  data-testid="swap-transaction-details-provider"
+                  className="inline-flex items-center gap-6"
+                >
                   <span className="body-3-semi-bold">{providerName}</span>
                   <ProviderIcon name={provider} size="XXS" borderRadius={4} />
                 </div>
@@ -86,7 +89,9 @@ export function DetailsSection({
           label={t("swap2.modals.transactionStatus.sections.details.swapId")}
           value={
             <div className="inline-flex items-center gap-6">
-              <span data-testid="swap-transaction-details-swap-id" className="body-3-semi-bold">{truncateMiddle(swapId)}</span>
+              <span data-testid="swap-transaction-details-swap-id" className="body-3-semi-bold">
+                {truncateMiddle(swapId)}
+              </span>
               <CopyIconButton text={swapId} />
             </div>
           }

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/Status/StatusRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/Status/StatusRow.tsx
@@ -58,7 +58,12 @@ export function StatusRow({
         <StatusIcon status={status} />
       </div>
       <span className="col-start-2 row-start-1 body-2-semi-bold text-base">{titleContent}</span>
-      <span data-testid={testId ? `${testId}-amount` : undefined} className="col-start-3 row-start-1 body-2-semi-bold text-base">{value}</span>
+      <span
+        data-testid={testId ? `${testId}-amount` : undefined}
+        className="col-start-3 row-start-1 body-2-semi-bold text-base"
+      >
+        {value}
+      </span>
       <div className="col-start-1 row-start-2 flex justify-center group-last/status-row:hidden">
         <StatusLine status={lineStatus ?? status} />
       </div>

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/SwapTransactionStatusDialogView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/SwapTransactionStatusDialogView.tsx
@@ -27,7 +27,10 @@ export function SwapTransactionStatusDialogView({
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange} height="fit">
-      <DialogContent data-testid="swap-transaction-status-dialog" className="max-h-[calc(100vh-16px)] w-[400px] bg-base p-0">
+      <DialogContent
+        data-testid="swap-transaction-status-dialog"
+        className="max-h-[calc(100vh-16px)] w-[400px] bg-base p-0"
+      >
         <DialogHeader density="compact" onClose={onClose} />
         <DialogBody className="flex flex-col px-24 pb-24 gap-24">
           <SwapTransactionStatusDialogContent key={contentKey} params={params} />

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/TransactionHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/TransactionHeader.tsx
@@ -61,7 +61,9 @@ export function TransactionHeader({
         <Skeleton className="h-24 w-176 rounded-sm" />
       )}
       {createdAt ? (
-        <p data-testid="swap-transaction-date" className="body-2 text-muted">{formatCreatedAt(createdAt, locale)}</p>
+        <p data-testid="swap-transaction-date" className="body-2 text-muted">
+          {formatCreatedAt(createdAt, locale)}
+        </p>
       ) : (
         <Skeleton className="mt-8 h-16 w-176 rounded-sm" />
       )}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/WalletFeaturesDevToolContent.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/WalletFeaturesDevToolContent.tsx
@@ -16,10 +16,7 @@ import {
   useWalletV4TourDrawerViewModel,
   WalletV4TourDialog,
 } from "LLD/features/WalletV4Tour/Drawer";
-import {
-  Q2TourDialog,
-  useQ2TourDrawerViewModel,
-} from "LLD/features/Q2Tour";
+import { Q2TourDialog, useQ2TourDrawerViewModel } from "LLD/features/Q2Tour";
 export const WalletFeaturesDevToolContent = ({ expanded }: WalletFeaturesDevToolContentProps) => {
   const { t } = useTranslation();
   const {

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/components/Q2TourSection.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/components/Q2TourSection.tsx
@@ -9,11 +9,7 @@ interface Q2TourSectionProps {
   readonly onOpenDrawer: () => void;
 }
 
-export const Q2TourSection = ({
-  hasSeen,
-  onToggleHasSeen,
-  onOpenDrawer,
-}: Q2TourSectionProps) => {
+export const Q2TourSection = ({ hasSeen, onToggleHasSeen, onOpenDrawer }: Q2TourSectionProps) => {
   const { t } = useTranslation();
 
   return (

--- a/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.test.tsx
@@ -13,8 +13,7 @@ const mockGetRouteParamsForPlatformApp = jest.fn().mockReturnValue(null);
 
 jest.mock("LLM/hooks/useStake/useStake", () => ({
   useStake: () => ({
-    getRouteParamsForPlatformApp: (...args: unknown[]) =>
-      mockGetRouteParamsForPlatformApp(...args),
+    getRouteParamsForPlatformApp: (...args: unknown[]) => mockGetRouteParamsForPlatformApp(...args),
   }),
 }));
 

--- a/apps/ledger-live-mobile/src/datadog.test.ts
+++ b/apps/ledger-live-mobile/src/datadog.test.ts
@@ -96,7 +96,11 @@ describe("broadcastLogger", () => {
           family: "family",
           isTestnet: false,
           isSendMax: false,
-          source: { type: "coin-module", name: "ledger-live-mobile", flags: { newSendFlow: false } },
+          source: {
+            type: "coin-module",
+            name: "ledger-live-mobile",
+            flags: { newSendFlow: false },
+          },
         },
       },
     );

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
@@ -383,7 +383,7 @@ export function useBalanceGraphViewModel({
   // distinct from a genuine 0% (flat or scrubbed back to the range start).
   const displayedPriceChangePercentage = scrubVariation
     ? scrubVariation.percentage
-    : priceChangePercentage ?? Number.NaN;
+    : (priceChangePercentage ?? Number.NaN);
 
   const displayedFormattedPriceChange = useMemo(() => {
     if (scrubVariation == null) return formattedPriceChange;

--- a/apps/ledger-live-mobile/src/mvvm/features/Q2WalletV4Tour/Debug/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Q2WalletV4Tour/Debug/index.tsx
@@ -27,7 +27,7 @@ function Q2WalletV4TourScreenDebug() {
         key: WALLET_40_FLAG,
         value: {
           ...lwmWallet40,
-          enabled: next ? true : lwmWallet40?.enabled ?? false,
+          enabled: next ? true : (lwmWallet40?.enabled ?? false),
           params: { ...(lwmWallet40?.params ?? {}), q2Tour: next },
         },
       }),

--- a/apps/ledger-live-mobile/src/mvvm/features/Q2WalletV4Tour/Drawer/__integrations__/q2WalletV4TourDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Q2WalletV4Tour/Drawer/__integrations__/q2WalletV4TourDrawer.test.tsx
@@ -11,8 +11,7 @@ const SLIDES = [
   },
   {
     title: "One balance for each asset",
-    subtitle:
-      "Multi-chain assets like USDT are now shown as one total. Simple, accurate, clear.",
+    subtitle: "Multi-chain assets like USDT are now shown as one total. Simple, accurate, clear.",
   },
   {
     title: "Your returns, front and center",
@@ -24,7 +23,8 @@ const SLIDES = [
   },
   {
     title: "More protocols, more rewards",
-    subtitle: "Stablecoins and top picks, surfaced right in your wallet. Less searching. More deciding.",
+    subtitle:
+      "Stablecoins and top picks, surfaced right in your wallet. Less searching. More deciding.",
   },
 ] as const;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Q2WalletV4Tour/Drawer/hooks/useQ2WalletV4TourDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Q2WalletV4Tour/Drawer/hooks/useQ2WalletV4TourDrawerViewModel.ts
@@ -25,13 +25,7 @@ export const useQ2WalletV4TourDrawerViewModel = (): Q2WalletV4TourDrawerViewMode
     isClosingRef.current = false;
     currentIndexRef.current = 0;
     setIsDrawerOpen(true);
-    screen(
-      PAGE_TRACKING_Q2_WALLET_V4_TOUR,
-      undefined,
-      { source: "Debug" },
-      true,
-      false,
-    );
+    screen(PAGE_TRACKING_Q2_WALLET_V4_TOUR, undefined, { source: "Debug" }, true, false);
     track("product_tour_card", {
       page: PAGE_TRACKING_Q2_WALLET_V4_TOUR,
       card: 1,

--- a/apps/wallet-cli/src/live-common-setup.ts
+++ b/apps/wallet-cli/src/live-common-setup.ts
@@ -56,10 +56,7 @@ const walletCliLoaders: CoinModuleLoader[] = [
       import("@ledgerhq/live-common/families/evm/platformAdapter").then(m => m.default),
     loadValidateAddress: () =>
       import("@ledgerhq/coin-evm/logic/validateAddress").then(m => m.validateAddress),
-    loadSigner: () =>
-      import("@ledgerhq/live-common/families/evm/signer").then(
-        m => m.default,
-      ),
+    loadSigner: () => import("@ledgerhq/live-common/families/evm/signer").then(m => m.default),
     loadBridgeApi: () =>
       import("@ledgerhq/live-common/families/evm/bridge/api").then(m => m.default),
     loadAccountRawAssign: () =>
@@ -83,14 +80,13 @@ const walletCliLoaders: CoinModuleLoader[] = [
       import("@ledgerhq/coin-solana/deviceTransactionConfig").then(m => m.default),
     loadWalletApiAdapter: () =>
       import("@ledgerhq/live-common/families/solana/walletApiAdapter").then(m => m.default),
-    loadSigner: () =>
-      import("@ledgerhq/live-common/families/solana/signer").then(
-        m => m.default,
-      ),
+    loadSigner: () => import("@ledgerhq/live-common/families/solana/signer").then(m => m.default),
     loadBridgeApi: () =>
       import("@ledgerhq/live-common/families/solana/bridge/api").then(m => m.default),
     loadLocalApi: () =>
-      import("@ledgerhq/live-common/families/solana/coinModuleApi").then(m => m.createLocalSolanaApi),
+      import("@ledgerhq/live-common/families/solana/coinModuleApi").then(
+        m => m.createLocalSolanaApi,
+      ),
   },
 ];
 

--- a/apps/wallet-cli/src/test/commands/swap/execute.test.ts
+++ b/apps/wallet-cli/src/test/commands/swap/execute.test.ts
@@ -126,7 +126,9 @@ const runFullSwapPipelineMock = mock((_input: FullSwapPipelineInput) =>
   Promise.resolve({ ...mockPipelineResult }),
 );
 
-const findTokenByIdMock = mock(async (id: string) => (id === USDT_TOKEN_ID ? usdtToken : undefined));
+const findTokenByIdMock = mock(async (id: string) =>
+  id === USDT_TOKEN_ID ? usdtToken : undefined,
+);
 
 async function runExecuteSwapCommand(flags: SwapExecuteFlags = baseFlags) {
   const writes: string[] = [];

--- a/libs/asset-detail/src/utils/__tests__/resolveMarketCurrencyQuery.test.ts
+++ b/libs/asset-detail/src/utils/__tests__/resolveMarketCurrencyQuery.test.ts
@@ -57,15 +57,18 @@ describe("shouldFetchMarketByLedgerIds", () => {
   });
 
   it("returns false for DADA urns that convert to a coingecko slug (backward compatible)", () => {
-    expect(
-      shouldFetchMarketByLedgerIds("urn:crypto:meta-currency:bonk", ["solana/spl/bonk"]),
-    ).toBe(false);
+    expect(shouldFetchMarketByLedgerIds("urn:crypto:meta-currency:bonk", ["solana/spl/bonk"])).toBe(
+      false,
+    );
   });
 });
 
 describe("getMarketLedgerIdsForQuery", () => {
   it("caps the number of ledger ids sent in the query string", () => {
-    const ledgerIds = Array.from({ length: MAX_MARKET_LEDGER_IDS + 3 }, (_, index) => `id-${index}`);
+    const ledgerIds = Array.from(
+      { length: MAX_MARKET_LEDGER_IDS + 3 },
+      (_, index) => `id-${index}`,
+    );
     expect(getMarketLedgerIdsForQuery(ledgerIds)).toHaveLength(MAX_MARKET_LEDGER_IDS);
     expect(getMarketLedgerIdsForQuery(ledgerIds)[0]).toBe("id-0");
   });

--- a/libs/coin-modules/coin-cosmos/src/network/babylonEpoching.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/babylonEpoching.unit.test.ts
@@ -99,7 +99,9 @@ describe("parseQueuedMessage", () => {
     });
 
     mockedLog.mockClear();
-    expect(parseQueuedMessage("cosmos.staking.v1beta1.MsgEditValidator", "garbage")).toBeUndefined();
+    expect(
+      parseQueuedMessage("cosmos.staking.v1beta1.MsgEditValidator", "garbage"),
+    ).toBeUndefined();
     expect(mockedLog).not.toHaveBeenCalled();
   });
 });
@@ -278,9 +280,8 @@ describe("fetchQueuedStakingMessages", () => {
 
   // network is mocked; the AxiosResponse envelope is irrelevant here, so build just `{ data }`
   const mockNetworkByUrl = (handler: (url: string) => unknown) => {
-    mockedNetwork.mockImplementation(
-      ((opts: { url: string }) => Promise.resolve({ data: handler(opts.url) })) as any,
-    );
+    mockedNetwork.mockImplementation(((opts: { url: string }) =>
+      Promise.resolve({ data: handler(opts.url) })) as any);
   };
 
   it("follows pagination and merges every page, url-encoding the page key", async () => {
@@ -322,7 +323,11 @@ describe("fetchQueuedStakingMessages", () => {
     const result = await fetchQueuedStakingMessages(endpoint, address, "ubbn");
 
     expect(result?.messages).toEqual([
-      expect.objectContaining({ delegatorAddress: address, denom: "ubbn", amount: new BigNumber(10) }),
+      expect.objectContaining({
+        delegatorAddress: address,
+        denom: "ubbn",
+        amount: new BigNumber(10),
+      }),
     ]);
   });
 

--- a/libs/ledger-live-common/src/coin-modules/loaders.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.ts
@@ -59,7 +59,8 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     family: "canton",
     supportedCoins: ["canton_network", "canton_network_devnet", "canton_network_testnet"],
     loadSetup: () => import("../families/canton/setup"),
-    loadLocalApi: () => import("../families/canton/coinModuleApi").then(m => m.createLocalCantonApi),
+    loadLocalApi: () =>
+      import("../families/canton/coinModuleApi").then(m => m.createLocalCantonApi),
     loadTransaction: () => import("@ledgerhq/coin-canton/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-canton/deviceTransactionConfig").then(m => m.default),
@@ -304,7 +305,8 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     family: "solana",
     supportedCoins: ["solana", "solana_testnet", "solana_devnet"],
     loadSetup: () => import("../families/solana/setup"),
-    loadLocalApi: () => import("../families/solana/coinModuleApi").then(m => m.createLocalSolanaApi),
+    loadLocalApi: () =>
+      import("../families/solana/coinModuleApi").then(m => m.createLocalSolanaApi),
     loadTransaction: () => import("@ledgerhq/coin-solana/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-solana/deviceTransactionConfig").then(m => m.default),
@@ -329,7 +331,8 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     family: "stellar",
     supportedCoins: ["stellar"],
     loadSetup: () => import("../families/stellar/setup"),
-    loadLocalApi: () => import("../families/stellar/coinModuleApi").then(m => m.createLocalStellarApi),
+    loadLocalApi: () =>
+      import("../families/stellar/coinModuleApi").then(m => m.createLocalStellarApi),
     loadTransaction: () => import("../families/stellar/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("../families/stellar/deviceTransactionConfig").then(m => m.default),

--- a/libs/ledger-live-common/src/genericAwarenessModal/__tests__/resolveThemedImageUrl.test.ts
+++ b/libs/ledger-live-common/src/genericAwarenessModal/__tests__/resolveThemedImageUrl.test.ts
@@ -1,4 +1,8 @@
-import { createThemedImageUrls, hasThemedImage, resolveThemedImageUrl } from "../resolveThemedImageUrl";
+import {
+  createThemedImageUrls,
+  hasThemedImage,
+  resolveThemedImageUrl,
+} from "../resolveThemedImageUrl";
 
 describe("createThemedImageUrls", () => {
   it("should map a single url to both light and dark themed fields", () => {


### PR DESCRIPTION
> [!WARNING]
> **Something is off in the toolchain, not just author setup.** I hit this drift on my own commits *with `mise` correctly installed and the `hk` pre-commit hook active* — so "just run `mise install`" isn't a full explanation. The hook can still be silently bypassed: when a commit runs inside sandboxed/automated tooling, `oxfmt` fails to write its fix (`Operation not permitted`), the hook errors, and the commit gets retried with `--no-verify` — landing unformatted code despite a correct setup. We should harden this (e.g. don't auto-`--no-verify` on hook failure, run git outside the sandbox, and/or add a CI `oxfmt --check` gate that blocks merge) so a working `mise` setup is actually sufficient.

### ✅ Checklist

- [x] `npx changeset` was attached. <!-- empty changeset: formatting-only, no functional change -->
- [x] **Covered by automatic tests.** <!-- formatting-only change; `oxfmt --check` runs in CI -->
- [x] **Impact of the changes:** none functional — whitespace/line-wrapping only. No QA needed.

### 📝 Description

Pure `oxfmt` reformatting. A number of files landed on `develop` not matching the repo's `oxfmt` (oxc) style — `npm run format` (`nx run-many -t format`) rewraps them. This PR ships only that reformatting: **no functional change**, whitespace/line-wrapping only.

The affected lines trace back to these merged PRs:

- #18620 (@jiyuzhuang)
- #18594 (@kentoforik)
- #18629 (@gre-ledger)
- #18574 (@amaslakov)
- #17760 (@gre-ledger)
- #18011 (@hhumphrey-ledger)
- #18552 (@claudiiafg)
- #16835 (@gre-ledger)
- #18363 (@sarneijim)
- #18670 (@CremaFR)
- #18603 (@YazhuEth)
- #18604 (@RobinVncnt)
- #18676 (@RobinVncnt)

> [!NOTE]
> Gentle heads-up to the authors above — formatting is enforced by an `hk` **pre-commit hook** that runs `oxfmt`. Unformatted code can only land if that hook didn't run. Two common reasons:
> 1. **The toolchain/hooks aren't installed.** Run `mise install` from the repo root so `mise` provisions the pinned tools and `hk` installs the git hooks — see the [README › Mise](https://github.com/LedgerHQ/ledger-live#mise) section.
> 2. **The hook was bypassed** at commit time (`git commit --no-verify`, or `HK=0`). Avoid bypassing it; if it fails, fix the cause rather than skipping. Note that committing through some automated/sandboxed tooling can silently force a `--no-verify` when the hook errors.
>
> Either way: `mise install` + don't bypass the hook = no more drift like this.

### ❓ Context

- **JIRA or GitHub link**: N/A — repo hygiene
- **ADR link (if any)**: N/A
