### PR TITLE
docs(git-workflow): ban --no-verify when committing or pushing

### DIFF
--- a/.agents/skills/git-workflow/SKILL.md
+++ b/.agents/skills/git-workflow/SKILL.md
@@ -85,3 +85,4 @@ test(coin): add bitcoin integration tests
 - Never mix refactor + fix + feature
 - Rebase before PR to keep history clean
 - Squash only for trivial branches (`support/cleanup`)
+- **Never use `--no-verify` when committing or pushing** — pre-commit/pre-push hooks (lint, typecheck, tests) must run. If a hook fails, fix the underlying issue rather than skip it; if a hook is genuinely broken, surface it to the user instead of bypassing it.


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- N/A: docs-only change to an agent skill, no package affected -->
- [x] **Covered by automatic tests.** <!-- N/A: documentation only -->
- [ ] **Impact of the changes:**
  - Adds a written rule in the git-workflow skill: agents/devs must never use --no-verify when committing or pushing. No code or runtime impact.

### 📝 Description

Documents an explicit rule in the shared git-workflow skill: never bypass pre-commit/pre-push hooks (lint, typecheck, tests) via --no-verify. If a hook fails, fix the cause; if a hook is broken, surface it rather than skip it.

Chosen as checked-in advice rather than a permissions.deny rule, since the sandbox/permissions are frequently bypassed in practice and a deny rule would give false confidence.

### ❓ Context

- **JIRA or GitHub link**:
- **ADR link (if any)**:
