### PR TITLE
[LWD] feat(desktop): truncate asset names in analytics allocation table

### DIFF
--- a/.changeset/analytics-allocation-truncated-names.md
+++ b/.changeset/analytics-allocation-truncated-names.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add truncated text to asset names in the Analytics Asset Allocation table, matching the Assets section behavior (ellipsis with a tooltip showing the full name on hover)

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/hooks/useAllocationTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/hooks/useAllocationTable.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import { ColumnDef } from "@tanstack/react-table";
 import { BalanceCell } from "LLD/components/Cells/BalanceCell";
 import { CounterValueCell } from "LLD/components/Cells/CounterValueCell";
+import { TruncatedText } from "LLD/components/TruncatedText";
 import { useSelector } from "LLD/hooks/redux";
 import { localeSelector } from "~/renderer/reducers/settings";
 import type { AllocationTableItem } from "../types";
@@ -36,7 +37,7 @@ export const useAllocationTable = (items: AllocationTableItem[]) => {
                 <CryptoCurrencyIcon currency={row.original.currency} size={32} />
               )
             }
-            title={row.original.currency.name}
+            title={<TruncatedText text={row.original.currency.name} />}
             description={row.original.currency.ticker}
           />
         ),


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Visual/styling change covered by the shared `TruncatedText` component already used (and tested) in the Assets table; verified manually._
- [x] **Impact of the changes:**
      - Analytics page → Asset Allocation table, name column rendering
      - Long currency names truncate with an ellipsis and show the full name in a tooltip on hover
      - Short names render unchanged

### 📝 Description

On the desktop Analytics page, the **Asset Allocation** table rendered the currency name as a raw string. Long names could overflow and did not match the truncation behavior used elsewhere in the app.

This PR wraps the currency name in the shared `TruncatedText` component — the same pattern already used in the **Assets** section (`useTable.tsx`). Long names are now ellipsized and reveal the full name in a tooltip on hover, bringing the Asset Allocation table in line with the Assets table for consistent behavior.

### Before / After


https://github.com/user-attachments/assets/34f2d92c-b2f9-46ec-a54b-bceb0ba5f5e3



### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-32829

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)