### PR TITLE
fix(wallet-pnl): correct average entry price for cross-network asset groups

### DIFF
--- a/.changeset/pnl-mixed-magnitude-entry-price.md
+++ b/.changeset/pnl-mixed-magnitude-entry-price.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-pnl": patch
+---
+
+Fix the asset-detail average entry price for assets that span networks with different token decimals (e.g. USDC: 6 on Ethereum, 18 on BNB Chain). `computeAssetGroupPnL` now converts each account's balance to full units using its own currency magnitude before summing, instead of dividing the mixed-magnitude total by the magnitude read from `accounts[0]`. Previously a zero-balance account in another magnitude (e.g. an empty BNB USDC) could land at `accounts[0]` and inflate the average entry price by orders of magnitude (e.g. ~$10¹²).

--- a/libs/wallet-pnl/src/__tests__/assetGroupPnL.test.ts
+++ b/libs/wallet-pnl/src/__tests__/assetGroupPnL.test.ts
@@ -2,8 +2,18 @@ import BigNumber from "bignumber.js";
 import { computeAssetGroupPnL } from "../assetGroupPnL";
 import { computeAssetPnL } from "../assetPnL";
 import { invalidatePnLCache } from "../costBasisCache";
-import { makeAccount } from "../scenarios/accounts";
-import { BTC, ETH, USD, SAT, WEI } from "../scenarios/currencies";
+import { makeAccount, makeTokenAccount } from "../scenarios/accounts";
+import {
+  BTC,
+  ETH,
+  USD,
+  SAT,
+  WEI,
+  USDC,
+  USDC_BSC,
+  USDC_UNIT,
+  USDC_BSC_UNIT,
+} from "../scenarios/currencies";
 import { buy, resetOperationIdCounter } from "../scenarios/operations";
 import { buildMultiCV } from "../scenarios/countervalues";
 import { expectBN } from "./helpers/bn";
@@ -106,6 +116,53 @@ describe("computeAssetGroupPnL", () => {
 
       const expectedUsd = new BigNumber(40000);
       expectBN(group.averageEntryPrice).toBeCloseToBN(expectedUsd.times(FIAT_MAJOR_TO_MINOR), 0);
+    });
+  });
+
+  describe("mixed-magnitude group (cross-network USDC)", () => {
+    const BUY_DATE = new Date(Date.UTC(2025, 0, 10));
+    const ONE_USD = new BigNumber(1).times(FIAT_MAJOR_TO_MINOR);
+
+    const makeEthUsdc = (units: number) =>
+      makeTokenAccount(USDC, {
+        id: "js:2:ethereum:eth-a:+ethereum/erc20/usd_coin",
+        operations: units > 0 ? [buy(USDC_UNIT.times(units), BUY_DATE)] : [],
+        balance: USDC_UNIT.times(units),
+      });
+
+    const makeBscUsdc = (units: number) =>
+      makeTokenAccount(USDC_BSC, {
+        id: "js:2:bsc:bsc-a:+bsc/bep20/binance_peg_usd_coin",
+        operations: units > 0 ? [buy(USDC_BSC_UNIT.times(units), BUY_DATE)] : [],
+        balance: USDC_BSC_UNIT.times(units),
+      });
+
+    const buildCV = () =>
+      buildMultiCV([
+        { pair: { from: USDC, to: USD }, history: { "2025-01-10": 1 }, latest: 1 },
+        { pair: { from: USDC_BSC, to: USD }, history: { "2025-01-10": 1 }, latest: 1 },
+      ]);
+
+    it("a zero-balance account in another magnitude does not inflate averageEntryPrice", () => {
+      // Reproduces the bug: empty BNB USDC (18 decimals) sitting at accounts[0]
+      // used to make the divisor 10^18 while only the ETH USDC (6 decimals)
+      // contributed, yielding a ~10^12-too-big entry price.
+      const group = computeAssetGroupPnL([makeBscUsdc(0), makeEthUsdc(1000)], buildCV(), USD)!;
+
+      expectBN(group.averageEntryPrice).toBeCloseToBN(ONE_USD, 0);
+    });
+
+    it("is independent of account ordering", () => {
+      const group = computeAssetGroupPnL([makeEthUsdc(1000), makeBscUsdc(0)], buildCV(), USD)!;
+
+      expectBN(group.averageEntryPrice).toBeCloseToBN(ONE_USD, 0);
+    });
+
+    it("sums two funded accounts that use different magnitudes", () => {
+      // 1000 USDC @ $1 on Ethereum + 1000 USDC @ $1 on BNB Chain ⇒ $1 average.
+      const group = computeAssetGroupPnL([makeBscUsdc(1000), makeEthUsdc(1000)], buildCV(), USD)!;
+
+      expectBN(group.averageEntryPrice).toBeCloseToBN(ONE_USD, 0);
     });
   });
 

--- a/libs/wallet-pnl/src/assetGroupPnL.ts
+++ b/libs/wallet-pnl/src/assetGroupPnL.ts
@@ -30,6 +30,7 @@ export function computeAssetGroupPnL(
   let costBasis = ZERO;
   let lifetimeCost = ZERO;
   let totalAmount = ZERO;
+  let totalAmountInFullUnits = ZERO;
   let contributed = false;
 
   for (const account of accounts) {
@@ -42,12 +43,19 @@ export function computeAssetGroupPnL(
     costBasis = costBasis.plus(pnl.costBasis);
     lifetimeCost = lifetimeCost.plus(pnl.lifetimeCost);
     totalAmount = totalAmount.plus(pnl.reconciliation.onChainBalance);
+    // Convert each account's balance to full units with ITS OWN magnitude before
+    // summing. The same asset can span networks with different decimals (e.g.
+    // USDC: 6 on Ethereum, 18 on BNB Chain), so a single group-level magnitude
+    // would corrupt the total — and reading it from `accounts[0]` let a zero-
+    // balance account in another magnitude skew the result.
+    const magnitude = getAccountCurrency(account).units[0].magnitude;
+    totalAmountInFullUnits = totalAmountInFullUnits.plus(
+      pnl.reconciliation.onChainBalance.shiftedBy(-magnitude),
+    );
   }
 
   if (!contributed) return null;
 
-  const magnitude = getAccountCurrency(accounts[0]).units[0].magnitude;
-  const totalAmountInFullUnits = totalAmount.shiftedBy(-magnitude);
   const averageEntryPrice = totalAmountInFullUnits.isZero()
     ? ZERO
     : costBasis.div(totalAmountInFullUnits);

--- a/libs/wallet-pnl/src/scenarios/currencies.ts
+++ b/libs/wallet-pnl/src/scenarios/currencies.ts
@@ -25,8 +25,28 @@ export const USDC: TokenCurrency = {
   ],
 };
 
+// Binance-Peg USDC on BNB Chain uses 18 decimals, unlike Ethereum USDC's 6.
+// Same asset, different magnitude — used to cover cross-network aggregation.
+export const USDC_BSC: TokenCurrency = {
+  type: "TokenCurrency",
+  id: "bsc/bep20/binance_peg_usd_coin",
+  contractAddress: "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d",
+  parentCurrencyId: "bsc",
+  tokenType: "bep20",
+  ticker: "USDC",
+  name: "Binance-Peg USD Coin",
+  units: [
+    {
+      name: "USDC",
+      code: "USDC",
+      magnitude: 18,
+    },
+  ],
+};
+
 // Atomic-unit magnitudes (1 unit = 10^magnitude atoms). Centralised here so
 // scenarios don't redeclare them.
 export const SAT = new BigNumber(10).pow(BTC.units[0].magnitude); // 1e8
 export const WEI = new BigNumber(10).pow(ETH.units[0].magnitude); // 1e18
 export const USDC_UNIT = new BigNumber(10).pow(USDC.units[0].magnitude); // 1e6
+export const USDC_BSC_UNIT = new BigNumber(10).pow(USDC_BSC.units[0].magnitude); // 1e18


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset-detail **Average entry price** (PnL section) on **mobile and desktop**.
  - Focus on tokens that exist on **multiple networks with different decimals** — primarily **USDC** (6 decimals on Ethereum, 18 on BNB Chain). Reproduce with a wallet holding USDC on both chains (incl. the case where one chain's account is empty / 0 balance).
  - Sanity-check single-network assets are unchanged: native coins (BTC/ETH) and single-chain ERC-20s.
  - Verify the value is now independent of account ordering.

### 📝 Description

**Problem**: On the asset page, the **Average entry price** for USDC was wildly wrong (e.g. **$999,617,016,932** for a 1.40 USDC balance). It only happened with a BNB USDC account present, and only on mobile.

`computeAssetGroupPnL` (in `@ledgerhq/wallet-pnl`) computes `averageEntryPrice = costBasis / totalTokenAmount`, but it built the token amount like this:

```ts
totalAmount = Σ account.onChainBalance               // each in its OWN minor units
const magnitude = getAccountCurrency(accounts[0]).units[0].magnitude;  // ONE account's decimals
const totalAmountInFullUnits = totalAmount.shiftedBy(-magnitude);
```

Two issues: it summed balances expressed in **different** minor units (USDC is 6 decimals on Ethereum, 18 on BNB Chain), and it divided that mixed total by a **single** magnitude taken from `accounts[0]` — even when that account contributed nothing. A zero-balance BNB USDC (18 decimals) sitting at `accounts[0]` made the divisor `10^18` while the only real amount was the ETH USDC (`10^6`), inflating the result by ~`10^12`. Desktop was only accidentally correct because its `accounts[0]` happened to be the 6-decimal ETH USDC.

**Solution**: Normalize each account to full units with **its own** magnitude before summing, so mixed decimals aggregate correctly and a non-contributing account can never set the divisor:

```ts
const magnitude = getAccountCurrency(account).units[0].magnitude;
totalAmountInFullUnits = totalAmountInFullUnits.plus(
  pnl.reconciliation.onChainBalance.shiftedBy(-magnitude),
);
// ...
const averageEntryPrice = totalAmountInFullUnits.isZero()
  ? ZERO
  : costBasis.div(totalAmountInFullUnits);
```

Added regression tests covering a cross-network USDC group (empty 18-decimal account first, reversed order, and two funded accounts of different magnitudes). The "empty account first" test fails before the fix with `100000000000000` (= $10¹²) and passes after.

https://github.com/user-attachments/assets/53cffcf5-5608-4bbb-b7fd-1886d2acebb8


https://github.com/user-attachments/assets/f4361cdd-535b-4ac0-b48f-4e48086f6977



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32525](https://ledgerhq.atlassian.net/browse/LIVE-32525)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-32525]: https://ledgerhq.atlassian.net/browse/LIVE-32525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ