### PR TITLE
[LWDM] feat(LIVE-30376): add public token transfer intents to craftTransaction

### DIFF
--- a/.changeset/cool-flowers-smile.md
+++ b/.changeset/cool-flowers-smile.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+Add public token transfer intent mapping for Aleo craftTransaction (`transfer_token_public`, `transfer_token_public_to_private`).

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/transaction.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/transaction.fixture.ts
@@ -2,6 +2,7 @@ import BigNumber from "bignumber.js";
 import { TRANSACTION_TYPE } from "../../constants";
 import type { AleoTransactionIntent, Transaction, TransactionRaw } from "../../types";
 import { mockUnspentRecord1, mockUnspentRecord2 } from "./account.fixture";
+import { MOCK_TOKEN_PROGRAM_ID } from "./currency.fixture";
 
 export const getMockedTransaction = (overrides?: Partial<Transaction>): Transaction => {
   return {
@@ -108,5 +109,25 @@ export const mockTxIntentFeePrivate: AleoTransactionIntent = {
       "7287422539927885800585937944314327552710698933416219800491628782750554575326field",
     priorityFee: 6000n,
     record: mockUnspentRecord2.decryptedData,
+  },
+};
+
+export const mockTxIntentTransferTokenPublic: AleoTransactionIntent = {
+  ...baseTxIntentFields,
+  amount: 100n,
+  type: TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC,
+  data: {
+    type: TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC,
+    programId: MOCK_TOKEN_PROGRAM_ID,
+  },
+};
+
+export const mockTxIntentConvertTokenPublicToPrivate: AleoTransactionIntent = {
+  ...baseTxIntentFields,
+  amount: 300n,
+  type: TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE,
+  data: {
+    type: TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE,
+    programId: MOCK_TOKEN_PROGRAM_ID,
   },
 };

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -38,6 +38,8 @@ import {
   mockTxIntentTransferPrivate,
   mockTxIntentTransferPrivate2,
   mockTxIntentTransferPublic,
+  mockTxIntentTransferTokenPublic,
+  mockTxIntentConvertTokenPublicToPrivate,
 } from "../__tests__/fixtures/transaction.fixture";
 import type { AleoOperationExtra, ProvableApi } from "../types";
 import {
@@ -1190,6 +1192,44 @@ describe("mapTransactionIntentToSdkIntent", () => {
     );
   });
 
+  it("should map transfer_token_public intent to SDK intent with correct fields", () => {
+    const intent = mockTxIntentTransferTokenPublic;
+
+    const result = mapTransactionIntentToSdkIntent(intent);
+
+    expect(result).toEqual({
+      type: "transfer_token_public",
+      amount: intent.amount.toString(),
+      to: intent.recipient,
+      program_id: MOCK_TOKEN_PROGRAM_ID,
+    });
+  });
+
+  it("should map convert_token_public_to_private intent to SDK intent with correct fields", () => {
+    const intent = mockTxIntentConvertTokenPublicToPrivate;
+
+    const result = mapTransactionIntentToSdkIntent(intent);
+
+    expect(result).toEqual({
+      type: "transfer_token_public_to_private",
+      amount: intent.amount.toString(),
+      to: intent.recipient,
+      program_id: MOCK_TOKEN_PROGRAM_ID,
+    });
+  });
+
+  it.each([
+    [TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC, mockTxIntentTransferTokenPublic],
+    [TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE, mockTxIntentConvertTokenPublicToPrivate],
+  ] as const)("should throw when %s intent has no matching data", (type, baseIntent) => {
+    const intent = { ...baseIntent, type };
+    delete (intent as { data?: unknown }).data;
+
+    expect(() => mapTransactionIntentToSdkIntent(intent)).toThrow(
+      `aleo: intent data is required for ${type}`,
+    );
+  });
+
   it("should throw for unsupported intent type", () => {
     const intent = {
       ...mockTxIntentTransferPublic,
@@ -1513,6 +1553,57 @@ describe("createTransactionIntent", () => {
 
     expect(() => createTransactionIntent({ account: mockAccount, transaction })).toThrow(
       `aleo: too many amount records selected (max: ${MAX_PRIVATE_RECORDS_PER_TRANSACTION})`,
+    );
+  });
+
+  it.each([
+    TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC,
+    TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE,
+  ] as const)("should create a public token transaction intent with programId for %s", mode => {
+    const tokenSubAccount = getMockedTokenAccount();
+    const account = getMockedAccount({ subAccounts: [tokenSubAccount] });
+    const transaction = getMockedTransaction({
+      mode,
+      subAccountId: tokenSubAccount.id,
+      amount: new BigNumber(500000),
+      recipient: "aleo1recipient",
+    });
+
+    const result = createTransactionIntent({ account, transaction });
+
+    expect(result).toEqual({
+      intentType: "transaction",
+      asset: { type: "native" },
+      type: mode,
+      amount: BigInt(transaction.amount.toString()),
+      recipient: transaction.recipient,
+      sender: account.freshAddress,
+      data: {
+        type: mode,
+        programId: tokenSubAccount.token.contractAddress,
+      },
+    });
+  });
+
+  it("should throw when public token transaction has no matching sub-account", () => {
+    const transaction = getMockedTransaction({
+      mode: TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC,
+      subAccountId: "non-existent-sub-account-id",
+    });
+
+    expect(() => createTransactionIntent({ account: mockAccount, transaction })).toThrow(
+      "aleo: token sub-account is required for public token transaction",
+    );
+  });
+
+  it.each([
+    TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE,
+    TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC,
+  ] as const)("should throw for private token transaction mode %s", mode => {
+    const transaction = getMockedTransaction({ mode });
+
+    expect(() => createTransactionIntent({ account: mockAccount, transaction })).toThrow(
+      "aleo: private token transactions are not supported yet",
     );
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -606,6 +606,24 @@ export function mapTransactionIntentToSdkIntent(
         record: txIntent.data.record,
       };
     }
+    case TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC: {
+      invariant(hasSpecificIntentData(txIntent, type), `aleo: intent data is required for ${type}`);
+      return {
+        type: "transfer_token_public",
+        amount,
+        to,
+        program_id: txIntent.data.programId,
+      };
+    }
+    case TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE: {
+      invariant(hasSpecificIntentData(txIntent, type), `aleo: intent data is required for ${type}`);
+      return {
+        type: "transfer_token_public_to_private",
+        amount,
+        to,
+        program_id: txIntent.data.programId,
+      };
+    }
     default: {
       throw new Error(`aleo: unsupported intent type: ${type}`);
     }
@@ -744,8 +762,8 @@ export function createTransactionIntent({
 }): AleoTransactionIntent {
   const base = buildTransactionIntentBase(account, transaction);
 
-  if (isTokenTransaction(transaction)) {
-    throw new Error("aleo: tokens are not supported yet");
+  if (isPrivateTokenTransaction(transaction)) {
+    throw new Error("aleo: private token transactions are not supported yet");
   }
 
   switch (transaction.mode) {
@@ -767,6 +785,22 @@ export function createTransactionIntent({
           }),
         },
       };
+
+    case TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC:
+    case TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE: {
+      const tokenSubAccount = getAleoSubAccount(account, transaction.subAccountId);
+      invariant(
+        tokenSubAccount,
+        "aleo: token sub-account is required for public token transaction",
+      );
+      return {
+        ...base,
+        data: {
+          type: transaction.mode,
+          programId: tokenSubAccount.token.contractAddress,
+        },
+      };
+    }
 
     default:
       throw new Error(`aleo: unsupported tx mode for transaction intent: ${transaction.mode}`);

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -62,6 +62,14 @@ export type AleoTransactionIntentData =
       priorityFee?: bigint;
       executionId: string;
       record: AleoDecryptedRecordResponse;
+    }
+  | {
+      type: typeof TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC;
+      programId: string;
+    }
+  | {
+      type: typeof TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE;
+      programId: string;
     };
 
 export type AleoTransactionIntent = TransactionIntent<MemoNotSupported, AleoTransactionIntentData>;

--- a/libs/coin-modules/coin-aleo/src/types/sdk.ts
+++ b/libs/coin-modules/coin-aleo/src/types/sdk.ts
@@ -76,11 +76,27 @@ interface FeePublicIntent {
   execution_id: string;
 }
 
+interface TransferTokenPublicIntent {
+  type: "transfer_token_public";
+  amount: string;
+  to: string;
+  program_id: string;
+}
+
+interface TransferTokenPublicToPrivateIntent {
+  type: "transfer_token_public_to_private";
+  amount: string;
+  to: string;
+  program_id: string;
+}
+
 export type Intent =
   | TransferPrivateIntent
   | TransferPublicIntent
   | TransferPrivateToPublicIntent
   | TransferPublicToPrivateIntent
+  | TransferTokenPublicIntent
+  | TransferTokenPublicToPrivateIntent
   | FeePrivateIntent
   | FeePublicIntent;
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - This PR adds public token transfer intent mapping for Aleo craftTransaction (`transfer_token_public`, `transfer_token_public_to_private`).

### 📝 Description

Add public token transfer intent mapping for Aleo craftTransaction (`transfer_token_public`, `transfer_token_public_to_private`).

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-30376

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
