### PR TITLE
[LWM] fix(mobile): correct button_clicked event for average price definition

### DIFF
--- a/.changeset/market-stat-definition-event.md
+++ b/.changeset/market-stat-definition-event.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the analytics event fired when opening the average entry price definition drawer. It now emits a `button_clicked` event with `button: market_stat_definition`, matching the market stat tooltip convention, instead of an event named `market_stat_definition`.

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/__tests__/useAssetPnlViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/__tests__/useAssetPnlViewModel.test.ts
@@ -95,7 +95,7 @@ describe("useAssetPnlViewModel", () => {
       });
     });
 
-    it("fires a market_stat_definition track event when the secondary drawer opens", () => {
+    it("fires a button_clicked track event with the market_stat_definition button when the secondary drawer opens", () => {
       const { result } = renderHook(
         () => useAssetPnlViewModel({ distributionItem, enabled: true }),
         { overrideInitialState: withPnlFlag(true) },

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/const.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/const.ts
@@ -1,6 +1,6 @@
 export const PNL_BUTTON = "Pnl details";
 export const PNL_DETAIL_PAGE = "Detailed PnL";
 export const AVERAGE_PRICE_PAGE = "Average Price";
-export const AVERAGE_PRICE_EVENT = "market_stat_definition";
-export const AVERAGE_PRICE_BUTTON = "average_price";
+export const AVERAGE_PRICE_EVENT = "button_clicked";
+export const AVERAGE_PRICE_BUTTON = "market_stat_definition";
 export const AVERAGE_PRICE_TYPE = "average price";


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Analytics event emitted when opening the "average entry price" definition drawer in the Asset Detail PnL section

### 📝 Description

**Problem**: When clicking on the average entry price definition, the app fired an analytics event *named* `market_stat_definition` (with `button: average_price`). The expected behaviour is a standard `button_clicked` event carrying `button: market_stat_definition`, consistent with the market stat tooltip on the Asset Detail screen.

**Solution**: Corrected the tracking constants in `apps/ledger-live-mobile/src/mvvm/features/Pnl/const.ts` so the `track` call in `usePnlViewModelBase` now emits:

```ts
track("button_clicked", {
  button: "market_stat_definition",
  page: source,
  type: "average price",
});
```

Before:
```
event: "market_stat_definition", button: "average_price"
```
After:
```
event: "button_clicked", button: "market_stat_definition"
```

The existing unit test asserts against these constants and continues to pass; its description was updated to reflect the corrected event.

https://github.com/user-attachments/assets/95428936-8685-45d1-83e8-e93bc9ccaf39


### ❓ Context

- **JIRA or GitHub link**: [LIVE-32822](https://ledgerhq.atlassian.net/browse/LIVE-32822)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32822]: https://ledgerhq.atlassian.net/browse/LIVE-32822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ