### PR TITLE
[LWD] fix(desktop): hide legacy account star when Wallet 4.0 asset discoverability is enabled

### DIFF
--- a/.changeset/lwd-hide-legacy-star-wallet40.md
+++ b/.changeset/lwd-hide-legacy-star-wallet40.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Hide the legacy per-account/token star button on the account screen when Wallet 4.0 asset discoverability is enabled. The legacy star wrote to a separate store (`starredAccountIds`) that the W4.0 portfolio favourites (`starredMarketCoins`) never read, so favouriting a token there never showed in the portfolio. Users now favourite assets from the asset detail page, which correctly feeds the portfolio "Starred" banner.

--- a/apps/ledger-live-desktop/src/renderer/components/TokenRow.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TokenRow.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { render, withFlagOverrides } from "tests/testSetup";
+import { ETH_ACCOUNT_WITH_USDC } from "LLD/features/__mocks__/accounts.mock";
+import TokenRow from "./TokenRow";
+
+const parentAccount = ETH_ACCOUNT_WITH_USDC;
+const tokenAccount = ETH_ACCOUNT_WITH_USDC.subAccounts![0];
+
+const assetDiscoverabilityState = withFlagOverrides({
+  lwdWallet40: { enabled: true, params: { assetDiscoverability: true } },
+});
+
+describe("TokenRow — legacy star visibility", () => {
+  const renderRow = (options?: Parameters<typeof render>[1]) =>
+    render(
+      <TokenRow
+        account={tokenAccount}
+        parentAccount={parentAccount}
+        onClick={jest.fn()}
+        range="day"
+      />,
+      options,
+    );
+
+  it("renders the legacy star when asset discoverability is off", () => {
+    const { container } = renderRow();
+    expect(container.querySelector("#account-star-button")).toBeInTheDocument();
+  });
+
+  it("hides the legacy star when asset discoverability is on", () => {
+    const { container } = renderRow({ initialState: assetDiscoverabilityState });
+    expect(container.querySelector("#account-star-button")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/components/TokenRow.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TokenRow.tsx
@@ -8,6 +8,7 @@ import Balance from "~/renderer/screens/accounts/AccountRowItem/Balance";
 import Delta from "~/renderer/screens/accounts/AccountRowItem/Delta";
 import Countervalue from "~/renderer/screens/accounts/AccountRowItem/Countervalue";
 import Star from "~/renderer/components/Stars/Star";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { TableRow } from "./TableContainer";
 import { useAccountUnit } from "../hooks/useAccountUnit";
 
@@ -42,6 +43,7 @@ function TokenRow(props: Props) {
   const onClickRow = () => onClick(account, parentAccount);
   const unit = useAccountUnit(account);
   const currency = getAccountCurrency(account);
+  const { shouldDisplayAssetDiscoverability } = useWalletFeaturesConfig("desktop");
   const Row = nested ? NestedRow : TableRow;
   return (
     <Row
@@ -53,7 +55,7 @@ function TokenRow(props: Props) {
       <Balance unit={unit} balance={account.balance} disableRounding={disableRounding} />
       <Countervalue account={account} currency={currency} range={range} />
       <Delta account={account} range={range} />
-      <Star accountId={account.id} />
+      {!shouldDisplayAssetDiscoverability && <Star accountId={account.id} />}
     </Row>
   );
 }

--- a/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.test.tsx
@@ -4,10 +4,17 @@ import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import type { Account } from "@ledgerhq/types-live";
 import { useLLDCoinFamily } from "~/renderer/families";
-import AccountHeaderActions from "./AccountHeaderActions";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import AccountHeaderActions, { AccountHeaderSettingsButton } from "./AccountHeaderActions";
 
 jest.mock("~/renderer/families");
 const mockFamily = jest.mocked(useLLDCoinFamily);
+
+jest.mock("@features/platform-feature-flags", () => ({
+  ...jest.requireActual("@features/platform-feature-flags"),
+  useWalletFeaturesConfig: jest.fn(),
+}));
+const mockWalletConfig = jest.mocked(useWalletFeaturesConfig);
 
 jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
   useAccountBridge: () => ({
@@ -71,7 +78,40 @@ jest.mock("~/renderer/screens/exchange/Swap2/utils/index", () => ({
 const btc = getCryptoCurrencyById("bitcoin");
 const account = genAccount("test-btc-account", { currency: btc }) as Account;
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockWalletConfig.mockReturnValue({
+    shouldDisplayAssetDiscoverability: false,
+  } as ReturnType<typeof useWalletFeaturesConfig>);
+});
+
+describe("AccountHeaderSettingsButton — legacy star visibility", () => {
+  it("renders the legacy star when asset discoverability is off", async () => {
+    mockFamily.mockReturnValue({} as never);
+
+    const { container } = render(
+      <AccountHeaderSettingsButton account={account} parentAccount={undefined} />,
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector("#account-star-button")).toBeInTheDocument(),
+    );
+  });
+
+  it("hides the legacy star when asset discoverability is on", async () => {
+    mockFamily.mockReturnValue({} as never);
+    mockWalletConfig.mockReturnValue({
+      shouldDisplayAssetDiscoverability: true,
+    } as ReturnType<typeof useWalletFeaturesConfig>);
+
+    const { container } = render(
+      <AccountHeaderSettingsButton account={account} parentAccount={undefined} />,
+    );
+
+    await waitFor(() => expect(container.firstChild).toBeInTheDocument());
+    expect(container.querySelector("#account-star-button")).not.toBeInTheDocument();
+  });
+});
 
 describe("AccountHeaderActions — family slot / fallback logic", () => {
   it("renders the custom SendAction when the family provides one", async () => {

--- a/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
@@ -16,6 +16,7 @@ import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { RECEIVE_SOURCE_PAGE } from "LLD/features/Receive/types";
 import Box, { Tabbable } from "~/renderer/components/Box";
 import Star from "~/renderer/components/Stars/Star";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import Tooltip from "~/renderer/components/Tooltip";
 import useTheme from "~/renderer/hooks/useTheme";
 import IconAccountSettings from "~/renderer/icons/AccountSettings";
@@ -136,6 +137,7 @@ const AccountHeaderSettingsButtonComponent = ({ account, parentAccount, openModa
   const mainAccount = getMainAccount(account, parentAccount);
   const currency = getAccountCurrency(account);
   const navigate = useNavigate();
+  const { shouldDisplayAssetDiscoverability } = useWalletFeaturesConfig("desktop");
   const onWalletConnectLiveApp = useCallback(() => {
     setTrackingSource("account header actions");
     const params = {
@@ -150,9 +152,11 @@ const AccountHeaderSettingsButtonComponent = ({ account, parentAccount, openModa
 
   return (
     <Box horizontal alignItems="center" justifyContent="flex-end" flow={2}>
-      <Tooltip content={t("stars.tooltip")}>
-        <Star accountId={account.id} yellow rounded />
-      </Tooltip>
+      {!shouldDisplayAssetDiscoverability && (
+        <Tooltip content={t("stars.tooltip")}>
+          <Star accountId={account.id} yellow rounded />
+        </Tooltip>
+      )}
       {isWalletConnectActionDisplayable ? (
         <Tooltip content={t("walletconnect.titleAccount")}>
           <ButtonSettings onClick={onWalletConnectLiveApp}>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Account screen header: the legacy star button no longer renders when Wallet 4.0 asset discoverability is enabled, and still renders when it is disabled.
      - Token rows in the account list: same gating on the per-token legacy star.
      - Verify favouriting an asset from the asset detail page correctly feeds the portfolio "Starred" banner.

### 📝 Description

**Problem**: The legacy per-account/token star button wrote to a separate store (`starredAccountIds`) that the Wallet 4.0 portfolio favourites (`starredMarketCoins`) never read. As a result, favouriting a token via the legacy star never showed up in the portfolio "Starred" section, creating a confusing dual-favourites experience.

**Solution**: Hide the legacy star button on the account screen (both the header action and the token rows) when Wallet 4.0 asset discoverability is enabled, gating on `shouldDisplayAssetDiscoverability` from `useWalletFeaturesConfig`. Users now favourite assets from the asset detail page, which correctly feeds the portfolio "Starred" banner. When asset discoverability is disabled, the legacy star behaves exactly as before.

| Before | After |



https://github.com/user-attachments/assets/a6f61138-83b7-4443-a354-4b37729ece53



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32828](https://ledgerhq.atlassian.net/browse/LIVE-32828)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32828]: https://ledgerhq.atlassian.net/browse/LIVE-32828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ