### PR TITLE
[LWD] fix: pass detailed market state for asset navigation

### DIFF
--- a/.changeset/lwd-empty-state-stocks-navigation.md
+++ b/.changeset/lwd-empty-state-stocks-navigation.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix portfolio empty-state stock pill navigation to asset detail by passing ledger ids in router state.

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchResultRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchResultRow.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import type { AssetNavigationMarketState } from "LLD/features/Assets/types";
 import { AssetSuggestionRow } from "LLD/features/SearchAssets/components/AssetSuggestionRow";
 
 type SearchResultRowProps = {
   currency: MarketCurrencyData;
   counterCurrency: string;
   locale: string;
-  onClick: (currencyId: string, marketState?: MarketCurrencyData) => void;
+  onClick: (currencyId: string, marketState?: AssetNavigationMarketState) => void;
 };
 
 export function SearchResultRow({

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/types.ts
@@ -1,5 +1,6 @@
 import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
-import { StockSuggestion } from "LLD/features/Stocks/types";
+import type { AssetNavigationMarketState } from "LLD/features/Assets/types";
+import type { StockSuggestion } from "LLD/features/Stocks/types";
 
 export type SearchMode = "suggestions" | "results" | "noResults" | "error";
 
@@ -28,7 +29,7 @@ export type SearchResults = {
 
 export type SearchOverlayContextValue = {
   close: () => void;
-  navigateToAsset: (currencyId: string, marketState?: MarketCurrencyData) => void;
+  navigateToAsset: (currencyId: string, marketState?: AssetNavigationMarketState) => void;
   navigateToMarket: () => void;
   navigateToStocksMarket: () => void;
   suggestions: SearchSuggestions;

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useSearchOverlayViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useSearchOverlayViewModel.ts
@@ -1,7 +1,7 @@
 import { KeyboardEvent, useCallback, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
-import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import type { AssetNavigationMarketState } from "LLD/features/Assets/types";
 import {
   getMarketOrAssetDetailPath,
   isAssetOrMarketDetailPath,
@@ -33,9 +33,17 @@ export function useSearchOverlayViewModel() {
   const replace = isAssetOrMarketDetailPath(location.pathname);
 
   const navigateToAsset = useCallback(
-    (currencyId: string, marketState?: MarketCurrencyData) => {
+    (currencyId: string, marketState?: AssetNavigationMarketState) => {
+      const assetName =
+        marketState &&
+        "name" in marketState &&
+        typeof marketState.name === "string" &&
+        marketState.name
+          ? marketState.name
+          : currencyId;
+
       track("asset_clicked", {
-        asset: marketState?.name ?? currencyId,
+        asset: assetName,
         page: getCurrentTrackingPage(),
         flow: "global_search",
         source: getPreviousTrackingPage(),

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/types.ts
@@ -1,4 +1,8 @@
 import { CategorizedAssetItem } from "@ledgerhq/asset-aggregation/assetCategorization/types";
+import type { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+
+/** Router state hint so asset detail can resolve ledger id ≠ market id (e.g. xStocks). */
+export type AssetNavigationMarketState = Pick<MarketCurrencyData, "id" | "ledgerIds">;
 
 export type AssetTableItem = CategorizedAssetItem & {
   isPlaceholder: boolean;

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/StocksSection/__tests__/useStocksSectionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/StocksSection/__tests__/useStocksSectionViewModel.test.ts
@@ -1,0 +1,53 @@
+import { act, renderHook, withFlagOverrides } from "tests/testSetup";
+import { useStocksSectionViewModel } from "../useStocksSectionViewModel";
+
+const mockNavigate = jest.fn();
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: () => mockNavigate,
+}));
+
+describe("useStocksSectionViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("navigates to asset detail with market state when a stock is selected", () => {
+    const { result } = renderHook(() => useStocksSectionViewModel(), {
+      initialState: withFlagOverrides({
+        lwdWallet40: { enabled: true, params: { aggregatedAssets: true } },
+      }),
+    });
+
+    act(() => {
+      result.current.navigateToAsset("spacex-xstock", {
+        id: "spacex-xstock",
+        ledgerIds: ["solana/spl/spacex"],
+      });
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/asset/spacex-xstock", {
+      state: { id: "spacex-xstock", ledgerIds: ["solana/spl/spacex"] },
+    });
+  });
+
+  it("navigates to market detail when aggregated assets is disabled", () => {
+    const { result } = renderHook(() => useStocksSectionViewModel(), {
+      initialState: withFlagOverrides({
+        lwdWallet40: { enabled: true, params: { aggregatedAssets: false } },
+      }),
+    });
+
+    act(() => {
+      result.current.navigateToAsset("spacex-xstock", {
+        id: "spacex-xstock",
+        ledgerIds: ["solana/spl/spacex"],
+      });
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/market/spacex-xstock", {
+      state: { id: "spacex-xstock", ledgerIds: ["solana/spl/spacex"] },
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/StocksSection/useStocksSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/StocksSection/useStocksSectionViewModel.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { useNavigate } from "react-router";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
+import type { AssetNavigationMarketState } from "LLD/features/Assets/types";
 import { getMarketOrAssetDetailPath } from "LLD/utils/marketAssetNavigation";
 import { setMarketCategory } from "~/renderer/actions/market";
 import { useDispatch } from "LLD/hooks/redux";
@@ -14,9 +15,11 @@ export function useStocksSectionViewModel() {
   const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
 
   const navigateToAsset = useCallback(
-    (currencyId: string) => {
+    (currencyId: string, marketState?: AssetNavigationMarketState) => {
       setTrackingSource(TRACKING_SOURCE);
-      navigate(getMarketOrAssetDetailPath(currencyId, shouldDisplayAggregatedAssets));
+      navigate(getMarketOrAssetDetailPath(currencyId, shouldDisplayAggregatedAssets), {
+        state: marketState,
+      });
     },
     [navigate, shouldDisplayAggregatedAssets],
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/components/AssetSuggestionRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/components/AssetSuggestionRow.tsx
@@ -10,6 +10,7 @@ import {
   Trend,
 } from "@ledgerhq/lumen-ui-react";
 import { MarketCurrencyData, KeysPriceChange } from "@ledgerhq/live-common/market/utils/types";
+import type { AssetNavigationMarketState } from "LLD/features/Assets/types";
 import counterValueFormatter from "@ledgerhq/live-common/market/utils/countervalueFormatter";
 import { roundFiatPrice } from "@ledgerhq/live-currency-format";
 
@@ -25,7 +26,7 @@ type AssetSuggestionRowProps = {
   counterCurrency: string;
   locale: string;
   testIdPrefix: string;
-  onClick: (currencyId: string, marketState?: MarketCurrencyData) => void;
+  onClick: (currencyId: string, marketState?: AssetNavigationMarketState) => void;
   density?: AssetSuggestionRowDensity;
 };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/types.ts
@@ -1,5 +1,5 @@
-import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
 import { AssetSuggestionSection } from "LLD/components/TopBar/components/TopBarSearch/SearchOverlay/types";
+import type { AssetNavigationMarketState } from "LLD/features/Assets/types";
 
 export type AssetSuggestionsViewModelResult = {
   /** Top cryptos (excluding stablecoins) ranked by market cap, capped to the limit. */
@@ -15,7 +15,7 @@ export type AssetSuggestionsSectionProps = AssetSuggestionSection & {
   /** Disambiguates test ids and skeleton keys (e.g. "cryptos"). */
   testIdPrefix: string;
   /** Redirects to the asset detail page for the given market id. */
-  navigateToAsset: (currencyId: string, marketState?: MarketCurrencyData) => void;
+  navigateToAsset: (currencyId: string, marketState?: AssetNavigationMarketState) => void;
   /** Lands on the market list. */
   onSeeAll: () => void;
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/StocksSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/StocksSectionView.tsx
@@ -11,6 +11,7 @@ import { HorizontalScroll } from "LLD/components/HorizontalScroll";
 import { StockPill } from "./components/StockPill";
 import { StocksSkeleton } from "./components/StocksSkeleton";
 import { splitIntoTwoRows } from "./utils/splitIntoTwoRows";
+import type { AssetNavigationMarketState } from "LLD/features/Assets/types";
 import type { StockSuggestion, StocksHeaderVariant, StocksSectionViewProps } from "./types";
 
 function StocksHeader({
@@ -66,7 +67,7 @@ function StocksList({
   hideListGradient,
 }: Readonly<{
   data: StockSuggestion[];
-  navigateToAsset: (currencyId: string) => void;
+  navigateToAsset: (currencyId: string, marketState?: AssetNavigationMarketState) => void;
   listClassName?: string;
   scrollContainerClassName?: string;
   hideListGradient?: boolean;

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/__integrations__/Stocks.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/__integrations__/Stocks.integration.test.tsx
@@ -130,7 +130,10 @@ describe("Stocks section", () => {
     render(<Stocks limit={2} navigateToAsset={navigateToAsset} onSeeAll={onSeeAll} />);
 
     fireEvent.click(screen.getByTestId("stock-item-ticker-aaplx"));
-    expect(navigateToAsset).toHaveBeenCalledWith(APPLE.marketId);
+    expect(navigateToAsset).toHaveBeenCalledWith(APPLE.marketId, {
+      id: APPLE.marketId,
+      ledgerIds: [APPLE.ledgerId],
+    });
   });
 
   it("navigates using the meta-currency slug when DADA omits the market id", () => {
@@ -139,7 +142,10 @@ describe("Stocks section", () => {
     render(<Stocks limit={2} navigateToAsset={navigateToAsset} onSeeAll={onSeeAll} />);
 
     fireEvent.click(screen.getByTestId("stock-item-ticker-tslax"));
-    expect(navigateToAsset).toHaveBeenCalledWith("teslax");
+    expect(navigateToAsset).toHaveBeenCalledWith("teslax", {
+      id: "teslax",
+      ledgerIds: [TESLA.ledgerId],
+    });
   });
 
   it("skips stocks that have no ledger id", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/components/StockPill.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/components/StockPill.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import { MediaButton } from "@ledgerhq/lumen-ui-react";
 import { StockSuggestion } from "../types";
+import type { AssetNavigationMarketState } from "LLD/features/Assets/types";
 
 type StockPillProps = {
   stock: StockSuggestion;
-  onClick: (currencyId: string) => void;
+  onClick: (currencyId: string, marketState?: AssetNavigationMarketState) => void;
 };
 
 export function StockPill({ stock, onClick }: Readonly<StockPillProps>) {
@@ -22,7 +23,7 @@ export function StockPill({ stock, onClick }: Readonly<StockPillProps>) {
       leadingContent={leadingContent}
       leadingContentShape="rounded"
       className="shrink-0"
-      onClick={() => onClick(navigationId)}
+      onClick={() => onClick(navigationId, { id: navigationId, ledgerIds: [ledgerId] })}
       aria-label={name}
       data-testid={`stock-item-ticker-${ticker.toLowerCase()}`}
     >

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/index.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { StocksSectionView } from "./StocksSectionView";
 import { useStocksSectionViewModel } from "./hooks/useStocksSectionViewModel";
+import type { AssetNavigationMarketState } from "LLD/features/Assets/types";
 import { StocksHeaderVariant } from "./types";
 
 type StocksProps = {
   limit: number;
-  navigateToAsset: (currencyId: string) => void;
+  navigateToAsset: (currencyId: string, marketState?: AssetNavigationMarketState) => void;
   onSeeAll: () => void;
   headerVariant?: StocksHeaderVariant;
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Stocks/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Stocks/types.ts
@@ -1,4 +1,5 @@
 import type { StockSuggestion } from "@ledgerhq/live-common/dada-client/utils/assetDiscovery";
+import type { AssetNavigationMarketState } from "LLD/features/Assets/types";
 
 export type { StockSuggestion };
 
@@ -19,7 +20,7 @@ export type StocksSectionViewProps = StocksSection & {
   /** Number of skeleton rows rendered while loading. */
   limit: number;
   /** Redirects to the asset detail page for the given market id. */
-  navigateToAsset: (currencyId: string) => void;
+  navigateToAsset: (currencyId: string, marketState?: AssetNavigationMarketState) => void;
   /** Lands on the market list pre-filtered to the stocks category. */
   onSeeAll: () => void;
   /** Header affordance to render. Defaults to "showMore". */


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request improves the navigation experience for stocks in the portfolio empty state and throughout the app by ensuring that navigation to asset detail pages correctly passes both the asset's market id and its ledger ids. This change clarifies asset identification, especially for xStocks where the ledger id and market id may differ. The update also refactors related types and props to consistently use the new `AssetNavigationMarketState` structure, and adds comprehensive tests to verify correct navigation behavior.

**Navigation and State Passing Improvements:**

* Updated all navigation handlers and related props (such as `navigateToAsset` and `onClick`) across stocks and asset suggestion components to accept and pass an `AssetNavigationMarketState` object containing both `id` and `ledgerIds`, rather than just a market id. This ensures the asset detail page receives all necessary identifiers. 

* Introduced the `AssetNavigationMarketState` type in `LLD/features/Stocks/types` and replaced previous usages of `MarketCurrencyData` in navigation-related props and functions to ensure type safety and clarity. 

**Portfolio Empty-State Fix:**

* Fixed the portfolio empty-state stock pill navigation so that clicking a stock pill now routes to the asset detail page with the correct ledger ids passed in the router state, resolving issues for assets where ledger id and market id differ.


https://github.com/user-attachments/assets/206991ed-c29b-490f-b4c5-7532091624ef


### ❓ Context

[LIVE-32823](https://ledgerhq.atlassian.net/browse/LIVE-32823)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-32823]: https://ledgerhq.atlassian.net/browse/LIVE-32823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ