### PR TITLE
[LWDM] fix(aptos): set max spendable amount with looser fee calculations [LIVE-31542]

### DIFF
--- a/.changeset/aptos-send-max-gas-reserve.md
+++ b/.changeset/aptos-send-max-gas-reserve.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aptos": patch
+---
+
+Set max spendable amount with looser fee calculations.

--- a/libs/coin-modules/coin-aptos/src/__tests__/bridge/estimateMaxSpendable.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/bridge/estimateMaxSpendable.test.ts
@@ -1,21 +1,12 @@
 import BigNumber from "bignumber.js";
 import { createFixtureAccount, createFixtureTransaction } from "../../bridge/bridge.fixture";
 import estimateMaxSpendable from "../../bridge/estimateMaxSpendable";
-import { getEstimatedGas } from "../../bridge/getFeesForTransaction";
+import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from "../../constants";
 
-jest.mock("../../bridge/getFeesForTransaction", () => ({
-  getEstimatedGas: jest.fn(() => ({
-    fees: new BigNumber(0),
-    estimate: {
-      maxGasAmount: 1,
-      gasUnitPrice: 2,
-    },
-    errors: {},
-  })),
-}));
+const DEFAULT_TOTAL_GAS = DEFAULT_GAS.multipliedBy(DEFAULT_GAS_PRICE);
 
 describe("estimateMaxSpendable Test", () => {
-  describe("spendable balance is lower than the total gas", () => {
+  describe("spendable balance is lower than the default total gas", () => {
     it("should return 0", async () => {
       const account = createFixtureAccount();
 
@@ -33,8 +24,8 @@ describe("estimateMaxSpendable Test", () => {
     });
   });
 
-  describe("spendable balance is higher than the total gas", () => {
-    it("should return spendable amount minus total gas", async () => {
+  describe("spendable balance is higher than the default total gas", () => {
+    it("should return spendable amount minus the default total gas", async () => {
       const account = createFixtureAccount();
 
       const spendableBalance = new BigNumber(100000);
@@ -45,14 +36,14 @@ describe("estimateMaxSpendable Test", () => {
         account,
       });
 
-      const expected = new BigNumber(80000);
+      const expected = spendableBalance.minus(DEFAULT_TOTAL_GAS);
 
       expect(result.isEqualTo(expected)).toBe(true);
     });
   });
 
-  describe("transaction spendable balance is higher than the total gas", () => {
-    it("should return transaction spendable amount minus total gas", async () => {
+  describe("transaction spendable balance is lower than the default total gas", () => {
+    it("should return 0", async () => {
       const account = createFixtureAccount();
       const transaction = createFixtureTransaction();
 
@@ -71,8 +62,8 @@ describe("estimateMaxSpendable Test", () => {
     });
   });
 
-  describe("transaction spendable balance is higher than the total gas", () => {
-    it("should return transaction spendable amount minus total gas", async () => {
+  describe("transaction spendable balance is higher than the default total gas", () => {
+    it("should return transaction spendable amount minus the default total gas", async () => {
       const account = createFixtureAccount();
       const transaction = createFixtureTransaction();
 
@@ -85,29 +76,25 @@ describe("estimateMaxSpendable Test", () => {
         transaction,
       });
 
-      const expected = new BigNumber(99998);
+      const expected = spendableBalance.minus(DEFAULT_TOTAL_GAS);
 
       expect(result.isEqualTo(expected)).toBe(true);
     });
   });
 
-  describe("when getEstimatedGas throws", () => {
-    it("should fall back to default gas and return spendable minus default total gas", async () => {
+  describe("when a transaction has a non-zero amount", () => {
+    it("should ignore the amount and reserve the default total gas", async () => {
       const account = createFixtureAccount();
-      const transaction = createFixtureTransaction();
+      const transaction = createFixtureTransaction({ amount: new BigNumber(12345) });
 
       const spendableBalance = new BigNumber(100000);
       account.spendableBalance = spendableBalance;
 
-      (getEstimatedGas as jest.Mock).mockRejectedValueOnce(new Error("gas estimation failed"));
+      const result = await estimateMaxSpendable({ account, transaction });
 
-      const result = await estimateMaxSpendable({
-        account,
-        transaction,
-      });
+      const expected = spendableBalance.minus(DEFAULT_TOTAL_GAS);
 
-      const expected = new BigNumber(80000);
-      expect(result).toStrictEqual(expected);
+      expect(result.isEqualTo(expected)).toBe(true);
     });
   });
 });

--- a/libs/coin-modules/coin-aptos/src/__tests__/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/bridge/prepareTransaction.test.ts
@@ -4,6 +4,8 @@ import { getMaxSendBalance } from "../../bridge/logic";
 import prepareTransaction from "../../bridge/prepareTransaction";
 import {
   APTOS_DELEGATION_RESERVE_IN_OCTAS,
+  DEFAULT_GAS,
+  DEFAULT_GAS_PRICE,
   MIN_COINS_ON_SHARES_POOL_IN_OCTAS,
 } from "../../constants";
 import { AptosAPI } from "../../network";
@@ -58,20 +60,28 @@ describe("Aptos prepareTransaction", () => {
       expect(result.fees?.isZero()).toBe(true);
     });
 
-    it("should set the amount to max sendable balance if useAllAmount is true", async () => {
+    it("should set the amount to max sendable balance using the default gas budget if useAllAmount is true", async () => {
       transaction.recipient = "test-recipient";
       transaction.useAllAmount = true;
       (getMaxSendBalance as jest.Mock).mockReturnValue(new BigNumber(900));
       (getEstimatedGas as jest.Mock).mockResolvedValue({
         fees: new BigNumber(2000),
-        estimate: { maxGasAmount: new BigNumber(200), gasUnitPrice: new BigNumber(10) },
+        estimate: { maxGasAmount: new BigNumber(10), gasUnitPrice: new BigNumber(10) },
         errors: {},
       });
 
       const result = await prepareTransaction(account, transaction);
+
+      expect(getMaxSendBalance).toHaveBeenCalledWith(
+        account,
+        undefined,
+        new BigNumber(DEFAULT_GAS),
+        new BigNumber(DEFAULT_GAS_PRICE),
+      );
       expect(result.amount.isEqualTo(new BigNumber(900))).toBe(true);
-      expect(result.fees?.isEqualTo(new BigNumber(2000))).toBe(true);
-      expect(new BigNumber(result.options.maxGasAmount).isEqualTo(new BigNumber(200))).toBe(true);
+      expect(result.fees?.isEqualTo(DEFAULT_GAS.multipliedBy(DEFAULT_GAS_PRICE))).toBe(true);
+      expect(new BigNumber(result.options.maxGasAmount).isEqualTo(DEFAULT_GAS)).toBe(true);
+      expect(new BigNumber(result.options.gasUnitPrice).isEqualTo(DEFAULT_GAS_PRICE)).toBe(true);
       expect(result.errors).toEqual({});
     });
 

--- a/libs/coin-modules/coin-aptos/src/bridge/estimateMaxSpendable.ts
+++ b/libs/coin-modules/coin-aptos/src/bridge/estimateMaxSpendable.ts
@@ -1,45 +1,24 @@
-import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/index";
 import type { AccountLike } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from "../constants";
-import { AptosAPI } from "../network";
 import type { AptosAccount, Transaction } from "../types";
-import { getEstimatedGas } from "./getFeesForTransaction";
 import { getMaxSendBalance } from "./logic";
 
 const estimateMaxSpendable = async ({
   account,
   parentAccount,
-  transaction,
 }: {
   account: AccountLike<AptosAccount>;
   parentAccount?: AptosAccount;
   transaction?: Transaction;
 }): Promise<BigNumber> => {
-  const mainAccount = getMainAccount(account, parentAccount);
-
-  const aptosClient = new AptosAPI(mainAccount.currency.id);
-
-  let maxGasAmount = new BigNumber(DEFAULT_GAS);
-  let gasUnitPrice = new BigNumber(DEFAULT_GAS_PRICE);
-
-  if (transaction) {
-    try {
-      const amount = transaction.amount.isZero() ? account.spendableBalance : transaction.amount;
-      const { estimate } = await getEstimatedGas(
-        mainAccount,
-        { ...transaction, amount },
-        aptosClient,
-      );
-
-      maxGasAmount = BigNumber(estimate.maxGasAmount);
-      gasUnitPrice = BigNumber(estimate.gasUnitPrice);
-    } catch {
-      // Fall back to defaults so getMaxSendBalance can still run without crashing the UI
-    }
-  }
-
-  return getMaxSendBalance(account, parentAccount, maxGasAmount, gasUnitPrice);
+  // Compute max spendable using the default gas budget (avoids too-tight simulation estimates).
+  return getMaxSendBalance(
+    account,
+    parentAccount,
+    new BigNumber(DEFAULT_GAS),
+    new BigNumber(DEFAULT_GAS_PRICE),
+  );
 };
 
 export default estimateMaxSpendable;

--- a/libs/coin-modules/coin-aptos/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-aptos/src/bridge/prepareTransaction.ts
@@ -3,7 +3,7 @@ import BigNumber from "bignumber.js";
 
 import { getDelegationOpMaxAmount, getStakingPosition } from "../logic/staking";
 import { AptosAPI } from "../network";
-import type { AptosAccount, Transaction } from "../types";
+import type { AptosAccount, Transaction, TransactionErrors } from "../types";
 import {
   APTOS_DELEGATION_RESERVE_IN_OCTAS,
   APTOS_MINIMUM_RESTAKE_IN_OCTAS,
@@ -13,6 +13,10 @@ import {
 } from "../constants";
 import { getEstimatedGas } from "./getFeesForTransaction";
 import { getMaxSendBalance } from "./logic";
+
+type TokenAccount = ReturnType<typeof findSubAccountById>;
+
+const DELEGATION_RESERVE_MODES = new Set<Transaction["mode"]>(["restake", "unstake", "withdraw"]);
 
 const checkSendConditions = (transaction: Transaction, account: AptosAccount) =>
   transaction.mode === "send" && transaction.amount.gt(account.spendableBalance);
@@ -50,19 +54,66 @@ const checkWithdrawConditions = (transaction: Transaction, account: AptosAccount
   return transaction.mode === "withdraw" && transaction.amount.gt(stakingPosition);
 };
 
+const shouldSkipPreparation = (transaction: Transaction, account: AptosAccount): boolean =>
+  !transaction.recipient ||
+  checkSendConditions(transaction, account) ||
+  checkStakeConditions(transaction, account) ||
+  checkRestakeConditions(transaction, account) ||
+  checkUnstakeConditions(transaction, account) ||
+  checkWithdrawConditions(transaction, account);
+
+const maxSendBalanceFor = (
+  account: AptosAccount,
+  tokenAccount: TokenAccount,
+  gas: BigNumber,
+  gasPrice: BigNumber,
+): BigNumber =>
+  tokenAccount
+    ? getMaxSendBalance(tokenAccount, account, gas, gasPrice)
+    : getMaxSendBalance(account, undefined, gas, gasPrice);
+
+// For "use max" sends, reserve the default gas limit to avoid too-tight simulation estimates.
+const applyMaxSend = (
+  transaction: Transaction,
+  account: AptosAccount,
+  tokenAccount: TokenAccount,
+  errors: TransactionErrors,
+): Transaction => {
+  const maxGas = BigNumber(DEFAULT_GAS);
+  const maxGasPrice = BigNumber(DEFAULT_GAS_PRICE);
+
+  transaction.amount = maxSendBalanceFor(account, tokenAccount, maxGas, maxGasPrice);
+  transaction.fees = maxGas.multipliedBy(maxGasPrice);
+  transaction.options = {
+    maxGasAmount: maxGas.toString(),
+    gasUnitPrice: maxGasPrice.toString(),
+  };
+  transaction.errors = errors;
+
+  return transaction;
+};
+
+// Reserve a certain amount to cover future network fees to deactivate and withdraw
+const getUseAllAmount = (
+  transaction: Transaction,
+  account: AptosAccount,
+  maxAmount: BigNumber,
+): BigNumber => {
+  if (DELEGATION_RESERVE_MODES.has(transaction.mode)) {
+    return getDelegationOpMaxAmount(account, transaction.recipient, transaction.mode);
+  }
+  if (transaction.mode === "stake") {
+    const reservedAmount = maxAmount.minus(APTOS_DELEGATION_RESERVE_IN_OCTAS);
+    return reservedAmount.isNegative() ? BigNumber(0) : reservedAmount;
+  }
+  return transaction.amount;
+};
+
 const prepareTransaction = async (
   account: AptosAccount,
   transaction: Transaction,
 ): Promise<Transaction> => {
-  if (
-    !transaction.recipient ||
-    checkSendConditions(transaction, account) ||
-    checkStakeConditions(transaction, account) ||
-    checkRestakeConditions(transaction, account) ||
-    checkUnstakeConditions(transaction, account) ||
-    checkWithdrawConditions(transaction, account)
-  )
-    return transaction;
+  if (shouldSkipPreparation(transaction, account)) return transaction;
 
   // if transaction.useAllAmount is true, then we expect transaction.amount to be 0
   // so to check that actual amount is zero or not, we also need to check if useAllAmount is false
@@ -86,47 +137,17 @@ const prepareTransaction = async (
       estimationTransaction,
       aptosClient,
     );
-    const gas = BigNumber(estimate.maxGasAmount);
-    const gasPrice = BigNumber(estimate.gasUnitPrice);
 
     if (transaction.useAllAmount) {
       if (transaction.mode === "send") {
-        // For "use max" sends, reserve the default gas limit to avoid too-tight simulation estimates.
-        const maxGas = BigNumber(DEFAULT_GAS);
-        const maxGasPrice = BigNumber(DEFAULT_GAS_PRICE);
-
-        transaction.amount = tokenAccount
-          ? getMaxSendBalance(tokenAccount, account, maxGas, maxGasPrice)
-          : getMaxSendBalance(account, undefined, maxGas, maxGasPrice);
-        transaction.fees = maxGas.multipliedBy(maxGasPrice);
-        transaction.options = {
-          maxGasAmount: maxGas.toString(),
-          gasUnitPrice: maxGasPrice.toString(),
-        };
-        transaction.errors = errors;
-
-        return transaction;
+        return applyMaxSend(transaction, account, tokenAccount, errors);
       }
 
-      const maxAmount = tokenAccount
-        ? getMaxSendBalance(tokenAccount, account, gas, gasPrice)
-        : getMaxSendBalance(account, undefined, gas, gasPrice);
+      const gas = BigNumber(estimate.maxGasAmount);
+      const gasPrice = BigNumber(estimate.gasUnitPrice);
+      const maxAmount = maxSendBalanceFor(account, tokenAccount, gas, gasPrice);
 
-      if (
-        transaction.mode === "restake" ||
-        transaction.mode === "unstake" ||
-        transaction.mode === "withdraw"
-      ) {
-        // Reserve a certain amount to cover future network fees to deactivate and withdraw
-        transaction.amount = getDelegationOpMaxAmount(
-          account,
-          transaction.recipient,
-          transaction.mode,
-        );
-      } else if (transaction.mode === "stake") {
-        // Reserve a certain amount to cover future network fees to deactivate and withdraw
-        transaction.amount = maxAmount.minus(APTOS_DELEGATION_RESERVE_IN_OCTAS);
-      }
+      transaction.amount = getUseAllAmount(transaction, account, maxAmount);
     }
 
     transaction.fees = fees;

--- a/libs/coin-modules/coin-aptos/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-aptos/src/bridge/prepareTransaction.ts
@@ -7,8 +7,10 @@ import type { AptosAccount, Transaction } from "../types";
 import {
   APTOS_DELEGATION_RESERVE_IN_OCTAS,
   APTOS_MINIMUM_RESTAKE_IN_OCTAS,
+  DEFAULT_GAS,
+  DEFAULT_GAS_PRICE,
   MIN_COINS_ON_SHARES_POOL_IN_OCTAS,
-} from "./../constants";
+} from "../constants";
 import { getEstimatedGas } from "./getFeesForTransaction";
 import { getMaxSendBalance } from "./logic";
 
@@ -88,13 +90,29 @@ const prepareTransaction = async (
     const gasPrice = BigNumber(estimate.gasUnitPrice);
 
     if (transaction.useAllAmount) {
+      if (transaction.mode === "send") {
+        // For "use max" sends, reserve the default gas limit to avoid too-tight simulation estimates.
+        const maxGas = BigNumber(DEFAULT_GAS);
+        const maxGasPrice = BigNumber(DEFAULT_GAS_PRICE);
+
+        transaction.amount = tokenAccount
+          ? getMaxSendBalance(tokenAccount, account, maxGas, maxGasPrice)
+          : getMaxSendBalance(account, undefined, maxGas, maxGasPrice);
+        transaction.fees = maxGas.multipliedBy(maxGasPrice);
+        transaction.options = {
+          maxGasAmount: maxGas.toString(),
+          gasUnitPrice: maxGasPrice.toString(),
+        };
+        transaction.errors = errors;
+
+        return transaction;
+      }
+
       const maxAmount = tokenAccount
         ? getMaxSendBalance(tokenAccount, account, gas, gasPrice)
         : getMaxSendBalance(account, undefined, gas, gasPrice);
 
-      if (transaction.mode === "send") {
-        transaction.amount = maxAmount;
-      } else if (
+      if (
         transaction.mode === "restake" ||
         transaction.mode === "unstake" ||
         transaction.mode === "withdraw"


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - @ledgerhq/coin-aptos

### 📝 Description

Fix Aptos "use max" computing a higher amount than the estimated available balance and failing on-chain with an insufficient gas error. Both the estimated available balance and the "use max" amount now reserve the default gas budget instead of the too-tight simulated estimate, so they return the same amount and the transaction is submitted with enough gas headroom.


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: LIVE-31542
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
