### PR TITLE
[LWM] fix(mobile): show Stocks title on stocks list screen

### DIFF
--- a/.changeset/stocks-screen-title.md
+++ b/.changeset/stocks-screen-title.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the assets list screen title showing "Crypto" instead of "Stocks" when navigating to the stocks list from the portfolio. The Crypto screen header now resolves its title from the route variant, including the `stocks` case.

--- a/apps/ledger-live-mobile/src/components/RootNavigator/AccountsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/AccountsNavigator.tsx
@@ -113,13 +113,19 @@ export default function AccountsNavigator() {
       route: cryptoRoute,
     }: {
       route: RouteProp<AccountsNavigatorParamList, ScreenName.Crypto>;
-    }): V4AccountsScreenOptions => ({
-      ...stackNavConfigV4Expanded,
-      title:
-        (cryptoRoute.params?.variant ?? "all") === "stablecoin"
-          ? t("crypto.stablecoinTitle")
-          : t("crypto.title"),
-    }),
+    }): V4AccountsScreenOptions => {
+      const variant = cryptoRoute.params?.variant ?? "all";
+      const titleByVariant: Record<typeof variant, string> = {
+        stablecoin: t("crypto.stablecoinTitle"),
+        stocks: t("crypto.stocksTitle"),
+        crypto: t("crypto.title"),
+        all: t("crypto.title"),
+      };
+      return {
+        ...stackNavConfigV4Expanded,
+        title: titleByVariant[variant],
+      };
+    },
     [stackNavConfigV4Expanded, t],
   );
 

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3296,6 +3296,7 @@
   "crypto": {
     "title": "Crypto",
     "stablecoinTitle": "Stablecoin",
+    "stocksTitle": "Stocks",
     "errorState": "An error occurred while loading your assets",
     "emptyState": "No assets to display"
   },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _The screen title is configured in the navigator (`getCryptoScreenOptions`), which isn't covered by unit tests. Verified manually._
- [x] **Impact of the changes:**
      - Header title of the assets list screen (`ScreenName.Crypto`) when opened from the portfolio Stocks section
      - No behaviour change for the Crypto / Stablecoin / "all" variants

### 📝 Description

**Problem**: Navigating from the portfolio to the stocks list opened the assets list screen with the title "Crypto" instead of "Stocks".

**Solution**: The screen title is built in `getCryptoScreenOptions` in `AccountsNavigator`, which only special-cased the `stablecoin` variant and fell back to `crypto.title` ("Crypto") for everything else — including `stocks`. The title is now resolved from the route `variant` via an exhaustive map, with a new `crypto.stocksTitle` ("Stocks") translation key.

Before:
```
variant = "stocks" → "Crypto"
```
After:
```
variant = "stocks" → "Stocks"
```

### 📸 Screenshots



https://github.com/user-attachments/assets/367d30f9-1709-4d1e-b5e9-1526abba5eec


### ❓ Context

- **JIRA or GitHub link**: [LIVE-32827](https://ledgerhq.atlassian.net/browse/LIVE-32827)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32827]: https://ledgerhq.atlassian.net/browse/LIVE-32827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ