### PR TITLE
[LWDM] fix: persist sort per category and reset pagination

### DIFF
--- a/.changeset/lwd-market-category-sort-scope.md
+++ b/.changeset/lwd-market-category-sort-scope.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+---
+
+Fix Market list sorting bleeding across category tabs on desktop: reset sort to default when switching tabs, reset pagination when sort or filters change, and keep paginated market data ordered by page when combining results.

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/__integrations__/Market.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/__integrations__/Market.integration.test.tsx
@@ -64,6 +64,7 @@ const createMarketState = (overrides = {}) => ({
     ...overrides,
   },
   currentPage: 1,
+  category: "all" as const,
 });
 
 const createSettingsState = (starredMarketCoins: string[] = []) => ({
@@ -367,6 +368,112 @@ describe("Market Integration", () => {
     const sellButton = screen.getByTestId("market-BTC-sell-button");
     expect(sellButton).toBeInTheDocument();
     expect(sellButton).toBeVisible();
+  });
+
+  it("should reset sort to default when switching category tab", async () => {
+    const marketRequests: URL[] = [];
+
+    server.use(
+      http.get(TRENDING_CATEGORIES_ENDPOINT, () => {
+        return HttpResponse.json([]);
+      }),
+      http.get(MARKET_API_ENDPOINT, ({ request }) => {
+        marketRequests.push(new URL(request.url));
+        return HttpResponse.json(MOCK_MARKET_CURRENCY_DATA);
+      }),
+    );
+
+    const { user } = render(<Market />, {
+      withRampCatalog: true,
+      initialState: {
+        market: createMarketState(),
+        settings: createSettingsState(),
+        ...marketWithTopCardsOn,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("market-sort-volume")).toBeVisible();
+    });
+
+    await user.click(screen.getByTestId("market-sort-volume"));
+
+    await waitFor(() => {
+      expect(marketRequests.some(url => url.searchParams.get("sort") === "total-volume-desc")).toBe(
+        true,
+      );
+    });
+
+    await user.click(screen.getByTestId("market-category-switcher-stocks"));
+
+    await waitFor(() => {
+      expect(
+        marketRequests.some(
+          url =>
+            url.searchParams.get("categories") === "tokenized-stock" &&
+            url.searchParams.get("sort") === "market-cap-rank",
+        ),
+      ).toBe(true);
+    });
+
+    await user.click(screen.getByTestId("market-category-switcher-all"));
+
+    await waitFor(() => {
+      expect(
+        marketRequests.some(
+          url =>
+            !url.searchParams.get("categories") &&
+            url.searchParams.get("sort") === "market-cap-rank",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("should still show results after sorting when paginated", async () => {
+    const marketRequests: URL[] = [];
+    const pageSize = 50;
+
+    server.use(
+      http.get(TRENDING_CATEGORIES_ENDPOINT, () => {
+        return HttpResponse.json([]);
+      }),
+      http.get(MARKET_API_ENDPOINT, ({ request }) => {
+        const url = new URL(request.url);
+        marketRequests.push(url);
+        const page = Number(url.searchParams.get("page") ?? 0);
+        const start = page * pageSize;
+        return HttpResponse.json(MOCK_MARKET_CURRENCY_DATA.slice(start, start + pageSize));
+      }),
+    );
+
+    const { user } = render(<Market />, {
+      withRampCatalog: true,
+      initialState: {
+        market: createMarketState({ page: 3 }),
+        settings: createSettingsState(),
+        ...marketWithTopCardsOn,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("market-list-data")).toBeVisible();
+    });
+
+    await user.click(screen.getByTestId("market-sort-volume"));
+
+    await waitFor(() => {
+      expect(
+        marketRequests.some(
+          url =>
+            url.searchParams.get("sort") === "total-volume-desc" &&
+            url.searchParams.get("page") === "0",
+        ),
+      ).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("market-list-data")).toBeVisible();
+    });
   });
 
   it("should append trending categories after the built-in tabs and filter the list when selected", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarket.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarket.test.ts
@@ -205,6 +205,29 @@ describe("useMarket", () => {
     });
   });
 
+  describe("pagination reset", () => {
+    it("resets page and currentPage when sort order changes", async () => {
+      const initialState = {
+        ...withFlagOverrides({ lldRefreshMarketData: { enabled: false } }),
+        settings: createSettingsState([]),
+        market: {
+          ...createMarketState([]),
+          marketParams: { ...createMarketState([]).marketParams, page: 3 },
+          currentPage: 3,
+        },
+      };
+
+      const { result } = renderHook(() => useMarket(), { initialState });
+
+      await act(async () => {
+        result.current.toggleSortBy();
+      });
+
+      expect(result.current.marketParams.page).toBe(1);
+      expect(result.current.marketCurrentPage).toBe(1);
+    });
+  });
+
   describe("time range options", () => {
     it("exposes full-label range options ordered shortest to longest", () => {
       const { result } = renderHook(() => useMarket(), {

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarketCategories.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarketCategories.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook, withFlagOverrides } from "tests/testSetup";
 import { Order } from "@ledgerhq/live-common/market/utils/types";
 import { useGetTrendingCategoriesQuery } from "@ledgerhq/live-common/market/state-manager/api";
-import type { MarketListCategory } from "~/renderer/reducers/market";
+import type { MarketListCategory, MarketState } from "~/renderer/reducers/market";
 import { track } from "~/renderer/analytics/segment";
 import { useMarketCategories } from "../useMarketCategories";
 
@@ -20,27 +20,40 @@ const assetDiscoverabilityOff = withFlagOverrides({
   lwdWallet40: { enabled: false },
 });
 
-const createMarketState = (category: MarketListCategory = "all") => ({
-  marketParams: {
-    range: "24h",
-    limit: 50,
-    starred: [],
-    order: Order.MarketCapDesc,
-    search: "",
-    liveCompatible: false,
-    page: 1,
-    counterCurrency: "USD",
-  },
-  currentPage: 1,
-  hideTransactionsOnChart: false,
-  category,
-});
+const createMarketState = (
+  category: MarketListCategory = "all",
+  overrides: Partial<MarketState> = {},
+): MarketState => {
+  const { marketParams: marketParamsOverrides, ...restOverrides } = overrides;
 
-const renderCategories = (category: MarketListCategory = "all", flags = assetDiscoverabilityOn) =>
+  return {
+    marketParams: {
+      range: "24h",
+      limit: 50,
+      starred: [],
+      order: Order.MarketCapDesc,
+      search: "",
+      liveCompatible: false,
+      page: 1,
+      counterCurrency: "USD",
+      ...marketParamsOverrides,
+    },
+    currentPage: 1,
+    hideTransactionsOnChart: false,
+    category,
+    ...restOverrides,
+  };
+};
+
+const renderCategories = (
+  category: MarketListCategory = "all",
+  flags = assetDiscoverabilityOn,
+  marketOverrides: Partial<MarketState> = {},
+) =>
   renderHook(() => useMarketCategories(), {
     initialState: {
       ...flags,
-      market: createMarketState(category),
+      market: createMarketState(category, marketOverrides),
     },
   });
 
@@ -68,6 +81,32 @@ describe("useMarketCategories", () => {
       category: "stocks",
       page: "Market",
     });
+  });
+
+  it("resets pagination when switching categories", () => {
+    const { result, store } = renderCategories("all", assetDiscoverabilityOn, {
+      marketParams: { page: 3 },
+      currentPage: 3,
+    });
+
+    act(() => result.current.onSelectCategory("stocks"));
+
+    expect(store.getState().market.marketParams.page).toBe(1);
+    expect(store.getState().market.currentPage).toBe(1);
+  });
+
+  it("resets sort to default when switching categories", () => {
+    const { result, store } = renderCategories("all", assetDiscoverabilityOn, {
+      marketParams: { order: Order.VolumeDesc },
+    });
+
+    act(() => result.current.onSelectCategory("stocks"));
+
+    expect(store.getState().market.marketParams.order).toBe(Order.MarketCapDesc);
+
+    act(() => result.current.onSelectCategory("all"));
+
+    expect(store.getState().market.marketParams.order).toBe(Order.MarketCapDesc);
   });
 
   it("does not change state when re-selecting the active category", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
@@ -25,7 +25,74 @@ import { useMarketCategories } from "LLD/features/Market/hooks/useMarketCategori
 import {
   getMarketCategoriesParam,
   isBuiltInMarketListCategory,
+  type MarketListCategory,
 } from "@ledgerhq/live-common/market/utils/category";
+
+const MARKET_PAGE_RESET_KEYS = new Set<keyof MarketListRequestParams>([
+  "order",
+  "search",
+  "range",
+  "starred",
+  "liveCompatible",
+  "filter",
+]);
+
+function shouldResetMarketPage(payload: MarketListRequestParams): boolean {
+  for (const key of MARKET_PAGE_RESET_KEYS) {
+    if (key in payload) return true;
+  }
+  return false;
+}
+
+function getDiscoverabilityCategoryFlags(enabled: boolean, selectedCategory: MarketListCategory) {
+  if (!enabled) {
+    return {
+      isStarredCategory: false,
+      isStocksCategory: false,
+      isTrendingCategory: false,
+    };
+  }
+  return {
+    isStarredCategory: selectedCategory === "starred",
+    isStocksCategory: selectedCategory === "stocks",
+    isTrendingCategory: !isBuiltInMarketListCategory(selectedCategory),
+  };
+}
+
+function resolveRefreshRate(refreshTimeParam: number | undefined): number {
+  const multiplier = Number(refreshTimeParam);
+  return multiplier > 0
+    ? REFETCH_TIME_ONE_MINUTE * multiplier
+    : REFETCH_TIME_ONE_MINUTE * BASIC_REFETCH;
+}
+
+function resolveEffectiveCounterCurrency(
+  shouldDisplayAssetDiscoverability: boolean,
+  supportedCounterCurrencies: string[] | undefined,
+  settingsCounterValue: string,
+  fallbackCounterCurrency: string | undefined,
+): string | undefined {
+  if (!shouldDisplayAssetDiscoverability) {
+    return fallbackCounterCurrency;
+  }
+  const isUnsupported =
+    supportedCounterCurrencies != null &&
+    !supportedCounterCurrencies.includes(settingsCounterValue);
+  return isUnsupported ? "usd" : settingsCounterValue;
+}
+
+function getMarketItemCount(
+  currenciesLength: number,
+  starFilterOn: boolean,
+  isStocksCategory: boolean,
+  isTrendingCategory: boolean,
+  searchLength: number,
+): number {
+  if (starFilterOn || isStocksCategory || isTrendingCategory || searchLength > 0) {
+    return currenciesLength;
+  }
+  return currenciesLength + 1;
+}
 
 export function useMarket() {
   const lldRefreshMarketDataFeature = useFeature("lldRefreshMarketData");
@@ -37,10 +104,7 @@ export function useMarket() {
   const locale = useSelector(localeSelector);
   const settingsCounterValue = useSelector(counterValueCurrencySelector).ticker.toLowerCase();
 
-  const REFRESH_RATE =
-    Number(lldRefreshMarketDataFeature?.params?.refreshTime) > 0
-      ? REFETCH_TIME_ONE_MINUTE * Number(lldRefreshMarketDataFeature?.params?.refreshTime)
-      : REFETCH_TIME_ONE_MINUTE * BASIC_REFETCH;
+  const REFRESH_RATE = resolveRefreshRate(lldRefreshMarketDataFeature?.params?.refreshTime);
 
   const { range, starred = [], liveCompatible, order, search = "" } = marketParams;
 
@@ -55,12 +119,8 @@ export function useMarket() {
 
   // When asset discoverability is on, the category bar is the source of truth for
   // the starred / stocks lists; otherwise we keep the legacy `starred` param behaviour.
-  const isStarredCategory =
-    shouldDisplayAssetDiscoverability && categories.selectedCategory === "starred";
-  const isStocksCategory =
-    shouldDisplayAssetDiscoverability && categories.selectedCategory === "stocks";
-  const isTrendingCategory =
-    shouldDisplayAssetDiscoverability && !isBuiltInMarketListCategory(categories.selectedCategory);
+  const { isStarredCategory, isStocksCategory, isTrendingCategory } =
+    getDiscoverabilityCategoryFlags(shouldDisplayAssetDiscoverability, categories.selectedCategory);
 
   const starFilterOn = isStarredCategory || starred.length > 0;
 
@@ -68,12 +128,12 @@ export function useMarket() {
 
   // While the supported list is still loading we keep the user's counter value, and only fall
   // back to usd once we know it is unsupported — otherwise a request fires with usd first.
-  const isCounterValueUnsupported =
-    !!supportedCounterCurrencies && !supportedCounterCurrencies.includes(settingsCounterValue);
-  const discoverabilityCounterCurrency = isCounterValueUnsupported ? "usd" : settingsCounterValue;
-  const effectiveCounterCurrency = shouldDisplayAssetDiscoverability
-    ? discoverabilityCounterCurrency
-    : marketParams.counterCurrency;
+  const effectiveCounterCurrency = resolveEffectiveCounterCurrency(
+    shouldDisplayAssetDiscoverability,
+    supportedCounterCurrencies,
+    settingsCounterValue,
+    marketParams.counterCurrency,
+  );
 
   const resolvedMarketParams = { ...marketParams, counterCurrency: effectiveCounterCurrency };
 
@@ -118,7 +178,8 @@ export function useMarket() {
   const currenciesLength = marketData.length;
   const loading = !isFavoritesEmpty && marketResult.isLoading;
   const isError = marketResult.isError;
-  const freshLoading = loading && !currenciesLength;
+  const freshLoading =
+    !isFavoritesEmpty && (marketResult.isLoading || marketResult.isFetching) && !currenciesLength;
 
   // Identity of the underlying list (everything but the page cursor). When it changes the user
   // switched list (category/sort/range/search/filter…), so pagination must re-arm and the scroll
@@ -130,14 +191,18 @@ export function useMarket() {
     range,
     effectiveCounterCurrency,
     search,
+    marketParams.filter ?? "",
     String(shouldDisplayLiveCompatible),
     String(starFilterOn),
   ].join("|");
   // The extra row is the "show all" affordance, only relevant for the unfiltered list.
-  const itemCount =
-    starFilterOn || isStocksCategory || isTrendingCategory || search.length > 0
-      ? currenciesLength
-      : currenciesLength + 1;
+  const itemCount = getMarketItemCount(
+    currenciesLength,
+    starFilterOn,
+    isStocksCategory,
+    isTrendingCategory,
+    search.length,
+  );
 
   const setCounterCurrency = useCallback(
     (ticker: string) => {
@@ -154,7 +219,8 @@ export function useMarket() {
 
   const refresh = useCallback(
     (payload: MarketListRequestParams) => {
-      dispatch(setMarketOptions(payload));
+      const nextPayload = shouldResetMarketPage(payload) ? { ...payload, page: 1 } : payload;
+      dispatch(setMarketOptions(nextPayload));
     },
     [dispatch],
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketCategories.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketCategories.ts
@@ -4,11 +4,7 @@ import { useGetTrendingCategoriesQuery } from "@ledgerhq/live-common/market/stat
 import { isBuiltInMarketListCategory } from "@ledgerhq/live-common/market/utils/category";
 import { track } from "~/renderer/analytics/segment";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
-import {
-  setMarketCategory,
-  setMarketCurrentPage,
-  setMarketOptions,
-} from "~/renderer/actions/market";
+import { setMarketCategory } from "~/renderer/actions/market";
 import { marketCategorySelector, type MarketListCategory } from "~/renderer/reducers/market";
 import { getMarketPageCategoryAnalytics } from "LLD/features/Market/utils/marketPageAnalytics";
 
@@ -71,9 +67,6 @@ export function useMarketCategories(): MarketCategories {
       }
 
       dispatch(setMarketCategory(category));
-      // Switching categories changes the underlying list, so restart pagination.
-      dispatch(setMarketOptions({ page: 1 }));
-      dispatch(setMarketCurrentPage(1));
     },
     [dispatch, persistedCategory, selectableCategories],
   );

--- a/apps/ledger-live-desktop/src/renderer/reducers/market.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/market.test.ts
@@ -1,0 +1,109 @@
+import { Order } from "@ledgerhq/live-common/market/utils/types";
+import marketReducer, { type MarketState } from "./market";
+
+const initialState: MarketState = {
+  marketParams: {
+    range: "24h",
+    limit: 50,
+    starred: [],
+    order: Order.MarketCapDesc,
+    search: "",
+    liveCompatible: false,
+    page: 1,
+    counterCurrency: "USD",
+  },
+  currentPage: 1,
+  hideTransactionsOnChart: false,
+  category: "all",
+};
+
+describe("market reducer", () => {
+  it("resets sort to default when switching category", () => {
+    const withVolumeOnAll = marketReducer(initialState, {
+      type: "MARKET_SET_VALUES",
+      payload: { order: Order.VolumeDesc, page: 1 },
+    });
+
+    expect(withVolumeOnAll.marketParams.order).toBe(Order.VolumeDesc);
+
+    const onStocks = marketReducer(withVolumeOnAll, {
+      type: "MARKET_SET_CATEGORY",
+      payload: "stocks",
+    });
+
+    expect(onStocks.category).toBe("stocks");
+    expect(onStocks.marketParams.order).toBe(Order.MarketCapDesc);
+    expect(onStocks.marketParams.page).toBe(1);
+    expect(onStocks.currentPage).toBe(1);
+
+    const backToAll = marketReducer(onStocks, {
+      type: "MARKET_SET_CATEGORY",
+      payload: "all",
+    });
+
+    expect(backToAll.marketParams.order).toBe(Order.MarketCapDesc);
+  });
+
+  it("resets currentPage when page is set back to 1", () => {
+    const paginatedState: MarketState = {
+      ...initialState,
+      currentPage: 3,
+      marketParams: { ...initialState.marketParams, page: 3 },
+    };
+
+    const nextState = marketReducer(paginatedState, {
+      type: "MARKET_SET_VALUES",
+      payload: { order: Order.VolumeDesc, page: 1 },
+    });
+
+    expect(nextState.currentPage).toBe(1);
+    expect(nextState.marketParams.page).toBe(1);
+  });
+
+  it("does nothing when selecting the same category", () => {
+    const nextState = marketReducer(initialState, {
+      type: "MARKET_SET_CATEGORY",
+      payload: "all",
+    });
+
+    expect(nextState).toBe(initialState);
+  });
+
+  it("heals missing category when selecting the default tab", () => {
+    const partialState = {
+      marketParams: initialState.marketParams,
+      currentPage: 1,
+      hideTransactionsOnChart: false,
+    } as MarketState;
+
+    const nextState = marketReducer(partialState, {
+      type: "MARKET_SET_CATEGORY",
+      payload: "all",
+    });
+
+    expect(nextState.category).toBe("all");
+  });
+
+  it("handles partial state without category", () => {
+    const partialState = {
+      marketParams: initialState.marketParams,
+      currentPage: 1,
+      hideTransactionsOnChart: false,
+    } as MarketState;
+
+    const withSort = marketReducer(partialState, {
+      type: "MARKET_SET_VALUES",
+      payload: { order: Order.VolumeDesc, page: 1 },
+    });
+
+    expect(withSort.marketParams.order).toBe(Order.VolumeDesc);
+
+    const onStocks = marketReducer(withSort, {
+      type: "MARKET_SET_CATEGORY",
+      payload: "stocks",
+    });
+
+    expect(onStocks.category).toBe("stocks");
+    expect(onStocks.marketParams.order).toBe(Order.MarketCapDesc);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/reducers/market.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/market.ts
@@ -6,6 +6,8 @@ import type { MarketListCategory } from "@ledgerhq/live-common/market/utils/cate
 
 export type { MarketListCategory };
 
+const DEFAULT_MARKET_CATEGORY: MarketListCategory = "all";
+
 export type MarketState = {
   marketParams: MarketListRequestParams;
   currentPage: number;
@@ -26,7 +28,7 @@ const initialState: MarketState = {
   },
   currentPage: 1,
   hideTransactionsOnChart: false,
-  category: "all",
+  category: DEFAULT_MARKET_CATEGORY,
 };
 
 type HandlersPayloads = {
@@ -41,13 +43,18 @@ type HandlersPayloads = {
 type MarketHandlers<PreciseKey = true> = Handlers<MarketState, HandlersPayloads, PreciseKey>;
 
 const handlers: MarketHandlers = {
-  MARKET_SET_VALUES: (state: MarketState, { payload }: { payload: MarketListRequestParams }) => ({
-    ...state,
-    marketParams: {
+  MARKET_SET_VALUES: (state: MarketState, { payload }: { payload: MarketListRequestParams }) => {
+    const nextMarketParams = {
       ...state.marketParams,
       ...payload,
-    },
-  }),
+    };
+
+    return {
+      ...state,
+      marketParams: nextMarketParams,
+      ...(nextMarketParams.page === 1 ? { currentPage: 1 } : {}),
+    };
+  },
   MARKET_SET_CURRENT_PAGE: (state: MarketState, { payload }: { payload: number }) => ({
     ...state,
     currentPage: payload,
@@ -59,10 +66,22 @@ const handlers: MarketHandlers = {
     ...state,
     hideTransactionsOnChart: payload,
   }),
-  MARKET_SET_CATEGORY: (state: MarketState, { payload }: { payload: MarketListCategory }) => ({
-    ...state,
-    category: payload,
-  }),
+  MARKET_SET_CATEGORY: (state: MarketState, { payload }: { payload: MarketListCategory }) => {
+    if (state.category !== undefined && payload === state.category) {
+      return state;
+    }
+
+    return {
+      ...state,
+      category: payload,
+      currentPage: 1,
+      marketParams: {
+        ...state.marketParams,
+        order: Order.MarketCapDesc,
+        page: 1,
+      },
+    };
+  },
 
   MARKET_IMPORT_STATE: (state, { payload }: { payload: MarketState }) => ({
     ...state,

--- a/libs/ledger-live-common/src/market/hooks/useMarketDataProvider.ts
+++ b/libs/ledger-live-common/src/market/hooks/useMarketDataProvider.ts
@@ -106,7 +106,12 @@ function combineMarketData(
   });
 
   return {
-    data: results.flatMap(result => result.data?.formattedData ?? []),
+    data: results
+      .filter((result): result is typeof result & { data: NonNullable<typeof result.data> } =>
+        Boolean(result.data),
+      )
+      .sort((a, b) => a.data.page - b.data.page)
+      .flatMap(result => result.data.formattedData),
     isPending: results.some(result => result.isPending),
     isFetching: results.some(result => result.isFetching),
     isLoading: results.some(result => result.isLoading),


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request addresses a bug in the Market list on Ledger Live Desktop where sorting and pagination state could bleed across category tabs, leading to confusing or incorrect displays. The changes ensure that when users switch between market categories (e.g., from "all" to "stocks"), the sort order and pagination are reset to their defaults, and paginated data remains correctly ordered. The update includes new tests to verify this behavior and some code refactoring for clarity and maintainability.

Key changes include:

**Bug Fixes & State Management:**

* Resets sort order to default and pagination to the first page when switching market category tabs, preventing sort and page state from leaking between categories. 
* Ensures paginated market data remains correctly ordered and displayed when sorting or filtering is changed, and resets pagination as needed. 

**Testing Improvements:**

* Adds integration and unit tests to verify that sort order and pagination are reset when switching categories, and that paginated and sorted results display correctly. 

**Code Refactoring & Cleanup:**

* Refactors helper functions in `useMarket` for determining category flags, refresh rate, counter currency resolution, and item count, improving readability and maintainability. 
* Cleans up and simplifies category switching logic in `useMarketCategories`, removing redundant dispatches and centralizing reset logic in the reducer. 


https://github.com/user-attachments/assets/d6d7731b-5def-496f-8133-3cca0f4c12ba


### ❓ Context

[LIVE-32832](https://ledgerhq.atlassian.net/browse/LIVE-32832)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-32832]: https://ledgerhq.atlassian.net/browse/LIVE-32832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ