### PR TITLE
[LWM] fix(mobile): correct Market filters drawer left/right spacing

### DIFF
--- a/.changeset/market-filter-spacing.md
+++ b/.changeset/market-filter-spacing.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the Market filters drawer content spacing. The inner container added its own `paddingHorizontal: 16` on top of the drawer's built-in 16px padding, double-padding the content. The redundant padding is removed so the sorting and timeframe sections sit at the expected 16px left & right.

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketFiltersDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketFiltersDrawer.tsx
@@ -96,7 +96,7 @@ export function MarketFiltersDrawer({ filters }: MarketFiltersDrawerProps) {
     >
       <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
         <BottomSheetHeader />
-        <Box lx={{ paddingHorizontal: "s16", paddingTop: "s12" }}>
+        <Box lx={{ paddingTop: "s12" }}>
           <MarketFilterSection
             title={t("market.assets.filters.sorting")}
             items={filters.sortingOptions}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Styling-only change (drawer padding); not covered by unit tests. Verified visually._
- [x] **Impact of the changes:**
      - Market screen → filters drawer (sorting & timeframe sections) left/right spacing
      - No change to filter behaviour or other drawers

### 📝 Description

**Problem**: In the Market filters drawer, the left & right spacing was off — it should be 16px on each side.

**Solution**: The drawer wrapper (`QueuedDrawerGorhom`) already applies a global `paddingHorizontal: 16` on its content container, but the filters drawer's inner `Box` added its own `paddingHorizontal: "s16"` on top of it, double-padding the content. The redundant inner padding is removed so the content relies on the drawer's standard 16px inset.

```diff
-<Box lx={{ paddingHorizontal: "s16", paddingTop: "s12" }}>
+<Box lx={{ paddingTop: "s12" }}>
```

### 📸 Screenshots

<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-06-18 at 16 13 10" src="https://github.com/user-attachments/assets/da39392c-e84c-4178-a3d3-1751ac42fb8d" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-32831](https://ledgerhq.atlassian.net/browse/LIVE-32831)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32831]: https://ledgerhq.atlassian.net/browse/LIVE-32831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ