### PR TITLE
[LWDM] fix: rename crypto category label from "Cryptos" to "Crypto"

### DIFF
--- a/.changeset/global-search-crypto-label.md
+++ b/.changeset/global-search-crypto-label.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"ledger-live-desktop": patch
+---
+
+Rename the global search crypto category label from "Cryptos" to "Crypto" on mobile and desktop.

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/__integrations__/SearchAssets.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/__integrations__/SearchAssets.integration.test.tsx
@@ -116,7 +116,7 @@ function Harness() {
   return (
     <AssetSuggestionsSection
       {...cryptos}
-      title="Cryptos"
+      title="Crypto"
       testIdPrefix="cryptos"
       limit={CRYPTOS_LIMIT}
       navigateToAsset={navigateToAsset}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8908,7 +8908,7 @@
     "search": {
       "noAssetFound": "No asset found",
       "error": "Connection failed",
-      "cryptos": "Cryptos",
+      "cryptos": "Crypto",
       "stocks": "Stocks"
     },
     "history": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1495,7 +1495,7 @@
       "addresses": "Search addresses"
     },
     "sections": {
-      "cryptos": "Cryptos",
+      "cryptos": "Crypto",
       "stocks": "Stocks"
     }
   },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request updates the global search crypto category label from "Cryptos" to "Crypto" across both the mobile and desktop applications. This ensures consistency in the naming of the crypto category throughout the user interface.

Label renaming for consistency:

* Changed the label from "Cryptos" to "Crypto" in the global search section for both mobile and desktop English locales
* Updated the `AssetSuggestionsSection` component in the desktop integration test to use the new "Crypto" label
* Added a changeset documenting the label rename for both platforms 

### ❓ Context

[LIVE-32825](https://ledgerhq.atlassian.net/browse/LIVE-32825)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-32825]: https://ledgerhq.atlassian.net/browse/LIVE-32825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ