### PR TITLE
[LWM] fix(LIVE-32789): preserve nav header through earn simulator <-> deposit

### DIFF
--- a/.changeset/fifty-chefs-yell.md
+++ b/.changeset/fifty-chefs-yell.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Ensure navigation header is set correctly when navigating between earn simulator and earn deposit flows via deeplinks.

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "~/context/Locale";
 import { RouteProp, useRoute } from "@react-navigation/native";
 import { useTheme } from "styled-components/native";
 import { useSelector } from "~/context/hooks";
-import { ScreenName, NavigatorName } from "~/const";
+import { ScreenName, NavigatorName, BASE_NAVIGATOR_ID } from "~/const";
 import * as families from "~/families";
 import OperationDetails from "~/screens/OperationDetails";
 import EditDeviceName from "~/screens/EditDeviceName";
@@ -108,7 +108,7 @@ import { getEarnScreenOptions } from "./getEarnScreenOptions";
 import SignRawTransactionNavigator from "./SignRawTransactionNavigator";
 import LiveAppModalScreen from "LLM/features/LiveAppModal";
 
-const Stack = createNativeStackNavigator<BaseNavigatorStackParamList>();
+const Stack = createNativeStackNavigator<BaseNavigatorStackParamList, typeof BASE_NAVIGATOR_ID>();
 
 type OperationDetailsRouteProp = RouteProp<
   BaseNavigatorStackParamList,
@@ -196,7 +196,7 @@ export default function BaseNavigator() {
   return (
     <>
       <RootDrawer drawer={route.params?.drawer} />
-      <Stack.Navigator screenOptions={nativeStackScreenOptions}>
+      <Stack.Navigator id={BASE_NAVIGATOR_ID} screenOptions={nativeStackScreenOptions}>
         <Stack.Screen name={NavigatorName.Main} component={Main} options={{ headerShown: false }} />
         <Stack.Screen
           name={NavigatorName.MyLedger}
@@ -592,6 +592,9 @@ export default function BaseNavigator() {
         <Stack.Screen
           name={NavigatorName.Earn}
           component={EarnLiveAppNavigator}
+          // Initial header from the entry `intent` param (first paint). Once the live-app loads,
+          // `useEarnIntentFlowPresentation` becomes the live owner and overrides this imperatively
+          // via `getParent(BASE_NAVIGATOR_ID).setOptions` as the webview route changes.
           options={props =>
             getEarnScreenOptions(props.route?.params?.params?.intent, t, liveAppCanvasColor)
           }

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/EarnLiveAppNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/EarnLiveAppNavigator.ts
@@ -20,5 +20,7 @@ export type EarnLiveAppNavigatorParamList = {
     platform?: string;
     intent?: "deposit" | "withdraw" | "simulate";
     cryptoAssetId?: TokenCurrency["id"]; // Only for deposit/withdraw flows
+    customDappURL?: string;
+    customDappUrl?: string;
   };
 };

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -1,3 +1,10 @@
+/**
+ * `id` for the Base navigator (the root native stack). Lets descendants reach it deterministically
+ * with `navigation.getParent(BASE_NAVIGATOR_ID)` instead of by tree position (which silently
+ * no-ops if a navigator level is inserted between them).
+ */
+export const BASE_NAVIGATOR_ID = "BaseNavigator";
+
 export enum ScreenName {
   Analytics = "Analytics",
   AnalyticsPreferencesSettings = "AnalyticsPreferencesSettings",

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/Navigator.tsx
@@ -25,11 +25,15 @@ export type MarketNavigatorStackParamList = {
   };
 };
 
-interface NavigatorProps {
-  Stack: ReturnType<typeof createNativeStackNavigator<BaseNavigatorStackParamList>>;
+interface NavigatorProps<NavId extends string | undefined = string | undefined> {
+  // Generic over the navigator id so any Base stack works regardless of whether it sets an id
+  // (e.g. the production stack now carries BASE_NAVIGATOR_ID, test stacks do not).
+  Stack: ReturnType<typeof createNativeStackNavigator<BaseNavigatorStackParamList, NavId>>;
 }
 
-export default function MarketNavigator({ Stack }: NavigatorProps) {
+export default function MarketNavigator<NavId extends string | undefined = string | undefined>({
+  Stack,
+}: Readonly<NavigatorProps<NavId>>) {
   const { t } = useTranslation();
   const { theme } = useLumenTheme();
   const { shouldDisplayAssetDiscoverability } = useWalletFeaturesConfig("mobile");

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/__tests__/EarnV2Webview.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/__tests__/EarnV2Webview.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { StyleSheet } from "react-native";
 import { render, screen, withFlagOverrides } from "@tests/test-renderer";
 import { EarnV2Webview } from "../index";
-import { NavigatorName } from "~/const";
+import { BASE_NAVIGATOR_ID, NavigatorName } from "~/const";
 import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 
 const mockNavigate = jest.fn();
@@ -190,7 +190,13 @@ describe("EarnV2Webview", () => {
     // The header is driven imperatively via the parent navigator's options — NOT by mutating
     // route params (a cross-navigator merge-navigate wipes them and blanks the screen).
     expect(mockNavigate).not.toHaveBeenCalled();
-    expect(mockSetOptions).toHaveBeenCalledWith(expect.objectContaining({ headerShown: true }));
+    expect(mockGetParent).toHaveBeenCalledWith(BASE_NAVIGATOR_ID);
+    const options = mockSetOptions.mock.calls.at(-1)?.[0];
+    // Deposit-specific header: titled, non-closable, and (unlike simulate) no canvas headerStyle —
+    // proving the header tracked the webview's deposit route, not the entry simulate intent.
+    expect(options).toEqual(expect.objectContaining({ headerShown: true, closable: false }));
+    expect(options.headerTitle).toBeTruthy();
+    expect(options.headerStyle).toBeUndefined();
   });
 
   it("does not leave the intent flow presentation while the webview is still on the deposit route", () => {

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/__tests__/EarnV2Webview.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/__tests__/EarnV2Webview.test.tsx
@@ -6,9 +6,11 @@ import { NavigatorName } from "~/const";
 import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 
 const mockNavigate = jest.fn();
+const mockSetOptions = jest.fn();
+const mockGetParent = jest.fn(() => ({ setOptions: mockSetOptions }));
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
-  useNavigation: () => ({ navigate: mockNavigate }),
+  useNavigation: () => ({ navigate: mockNavigate, getParent: mockGetParent }),
 }));
 
 jest.mock("@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index", () => ({
@@ -69,6 +71,7 @@ describe("EarnV2Webview", () => {
   beforeEach(() => {
     mockWebviewUrl = undefined;
     mockNavigate.mockClear();
+    mockSetOptions.mockClear();
   });
 
   it("renders LiveAppBackground when ptxEarnUi is v2", () => {
@@ -145,6 +148,7 @@ describe("EarnV2Webview", () => {
   });
 
   it("returns to the Earn dashboard tab when the intent flow webview navigates out of the intent route", () => {
+    jest.useFakeTimers();
     mockWebviewUrl = "https://earn.test/v2/android/homescreen?uiVersion=v4";
 
     render(
@@ -156,16 +160,49 @@ describe("EarnV2Webview", () => {
       },
     );
 
+    expect(mockNavigate).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(500);
+
     expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Main, {
       screen: NavigatorName.Earn,
     });
+
+    jest.useRealTimers();
+  });
+
+  it("syncs the Base-stack native header (not route params) when the webview navigates from simulate to deposit", () => {
+    mockWebviewUrl = "https://earn.test/v2/android/deposit?intent=deposit&uiVersion=v4";
+
+    render(
+      <EarnV2Webview
+        manifest={STUB_MANIFEST}
+        appManifestNotFoundError={ERROR}
+        hideMainNavigator
+        inputs={{ intent: "simulate" }}
+      />,
+      {
+        overrideInitialState: withFlagOverrides({
+          ptxEarnUi: { enabled: true, params: { value: "v2" } },
+        }),
+      },
+    );
+
+    // The header is driven imperatively via the parent navigator's options — NOT by mutating
+    // route params (a cross-navigator merge-navigate wipes them and blanks the screen).
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockSetOptions).toHaveBeenCalledWith(expect.objectContaining({ headerShown: true }));
   });
 
   it("does not leave the intent flow presentation while the webview is still on the deposit route", () => {
     mockWebviewUrl = "https://earn.test/v2/android/deposit?intent=deposit&uiVersion=v4";
 
     render(
-      <EarnV2Webview manifest={STUB_MANIFEST} appManifestNotFoundError={ERROR} hideMainNavigator />,
+      <EarnV2Webview
+        manifest={STUB_MANIFEST}
+        appManifestNotFoundError={ERROR}
+        hideMainNavigator
+        inputs={{ intent: "deposit" }}
+      />,
       {
         overrideInitialState: withFlagOverrides({
           ptxEarnUi: { enabled: true, params: { value: "v2" } },

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
@@ -3,29 +3,19 @@ import { useFeature, useWalletFeaturesConfig } from "@features/platform-feature-
 import { useRemoteLiveAppContext } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { Flex } from "@ledgerhq/native-ui";
-import React, { ComponentProps, Fragment, useRef, useCallback, useEffect, useState } from "react";
+import React, { ComponentProps, Fragment, useRef, useCallback, useState } from "react";
 import { Animated, StyleSheet, View } from "react-native";
 import type WebView from "react-native-webview";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useNavigation } from "@react-navigation/native";
-import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { TrackScreen } from "~/analytics";
 import GenericErrorView from "~/components/GenericErrorView";
 import { useNavigationBarHeights } from "LLM/hooks/useNavigationBarHeights";
-import { useTranslation } from "~/context/Locale";
-import { NavigatorName } from "~/const";
-import { getEarnScreenOptions } from "~/components/RootNavigator/getEarnScreenOptions";
-import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { EarnWebview } from "../EarnWebview";
 import { LiveAppBackground } from "LLM/components/LiveAppBackground";
 import { useTheme as useLumenTheme } from "@ledgerhq/lumen-ui-rnative/styles";
 import { computeEarnUiVersion } from "@ledgerhq/live-common/domain/computeEarnUiVersion";
 import type { WebviewState } from "~/components/Web3AppWebview/types";
-import { getIntentFlowState, getWebviewIntent } from "../getWebviewIntent";
-
-/** Debounce before leaving the Base-stack intent presentation — avoids bouncing to the Earn tab
- * when the webview briefly reports a dashboard URL while transitioning (e.g. simulate → deposit). */
-const EXIT_INTENT_FLOW_DEBOUNCE_MS = 500;
+import { useEarnIntentFlowPresentation } from "../useEarnIntentFlowPresentation";
 
 type Props = {
   manifest?: LiveAppManifest;
@@ -51,7 +41,6 @@ export const EarnV2Webview = ({
   const insets = useSafeAreaInsets();
   const { theme: lumenTheme } = useLumenTheme();
   const canvasColor = lumenTheme.colors.bg.canvas;
-  const { t } = useTranslation();
   const isSimulateIntent = inputs?.intent === "simulate";
   const { topBarHeight, bottomBarHeight } = useNavigationBarHeights();
   const { shouldDisplayEarnUpselling, shouldDisplayEarnSimulator } =
@@ -75,8 +64,6 @@ export const EarnV2Webview = ({
     [scrollY],
   );
 
-  const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
-
   const [webviewUrl, setWebviewUrl] = useState<string | undefined>(undefined);
   const webviewUrlRef = useRef<string | undefined>(undefined);
   const handleWebviewStateChange = useCallback((state: WebviewState) => {
@@ -84,38 +71,15 @@ export const EarnV2Webview = ({
     setWebviewUrl(state.url);
   }, []);
 
-  const intentFlowState = getIntentFlowState(webviewUrl);
-  const webviewIntent = getWebviewIntent(webviewUrl);
+  const { intentFlowState } = useEarnIntentFlowPresentation({
+    hideMainNavigator,
+    webviewUrl,
+    webviewUrlRef,
+    canvasColor,
+  });
 
   const inIntentFlow = !!hideMainNavigator && intentFlowState !== false;
   const showsBackground = isPtxUiMinV2 && !inIntentFlow;
-
-  /**
-   * Single source of truth for the intent-flow presentation, driven by the webview's own route.
-   * We deliberately DO NOT mutate navigation params here: a cross-navigator `navigate({ merge })`
-   * wipes the Base `EarnNavigator` route params (params: undefined), which blanks the screen and
-   * drops the header. Instead we set the Base header imperatively via the parent navigator.
-   *
-   * - Webview back on a dashboard route → return to the Earn tab (debounced to ignore the
-   *   transient dashboard URL seen while transitioning, e.g. simulate → deposit).
-   * - Still in an intent flow → keep the Base native header in sync with the webview intent.
-   */
-  useEffect(() => {
-    if (!hideMainNavigator) return;
-
-    if (intentFlowState === false) {
-      const timeout = setTimeout(() => {
-        if (getIntentFlowState(webviewUrlRef.current) !== false) return;
-        navigation.navigate(NavigatorName.Main, { screen: NavigatorName.Earn });
-      }, EXIT_INTENT_FLOW_DEBOUNCE_MS);
-
-      return () => clearTimeout(timeout);
-    }
-
-    if (webviewIntent) {
-      navigation.getParent()?.setOptions(getEarnScreenOptions(webviewIntent, t, canvasColor));
-    }
-  }, [hideMainNavigator, intentFlowState, webviewIntent, navigation, t, canvasColor]);
 
   const webviewInputs = {
     ...inputs,

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
@@ -9,40 +9,23 @@ import type WebView from "react-native-webview";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import { safeUrl } from "@ledgerhq/live-common/wallet-api/helpers";
 import { TrackScreen } from "~/analytics";
 import GenericErrorView from "~/components/GenericErrorView";
 import { useNavigationBarHeights } from "LLM/hooks/useNavigationBarHeights";
+import { useTranslation } from "~/context/Locale";
 import { NavigatorName } from "~/const";
+import { getEarnScreenOptions } from "~/components/RootNavigator/getEarnScreenOptions";
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { EarnWebview } from "../EarnWebview";
 import { LiveAppBackground } from "LLM/components/LiveAppBackground";
 import { useTheme as useLumenTheme } from "@ledgerhq/lumen-ui-rnative/styles";
 import { computeEarnUiVersion } from "@ledgerhq/live-common/domain/computeEarnUiVersion";
 import type { WebviewState } from "~/components/Web3AppWebview/types";
+import { getIntentFlowState, getWebviewIntent } from "../getWebviewIntent";
 
-const INTENT_FLOWS = ["deposit", "withdraw", "simulate"];
-const INTENTS_SET = new Set(INTENT_FLOWS);
-
-/**
- * The native Earn screen sets `intent` once on entry and never clears it, so it cannot be trusted
- * after the user navigates back inside the webview (e.g. "go to dashboard"). The live webview URL
- * is the source of truth for whether we are still inside an intent flow (deposit/withdraw/simulate).
- *
- * Returns `true` when on an intent flow route, `false` when on a known non-intent route, and
- * `null` while the URL is unknown (e.g. the webview's initial empty state, or transient non-http(s)
- * schemes like `about:blank`/`data:` reported during load). The `null` case must NOT be treated as
- * "left the intent flow", otherwise we would bounce out of the intent flow on first mount before its
- * route has even loaded. Only http(s) URLs count as a known route.
- */
-const getIntentFlowState = (rawUrl?: string): boolean | null => {
-  if (!rawUrl) return null;
-  const url = safeUrl(rawUrl);
-  if (!url) return null;
-  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
-  if (INTENTS_SET.has(url.searchParams.get("intent") ?? "")) return true;
-  return INTENT_FLOWS.some(segment => url.pathname.includes(segment));
-};
+/** Debounce before leaving the Base-stack intent presentation — avoids bouncing to the Earn tab
+ * when the webview briefly reports a dashboard URL while transitioning (e.g. simulate → deposit). */
+const EXIT_INTENT_FLOW_DEBOUNCE_MS = 500;
 
 type Props = {
   manifest?: LiveAppManifest;
@@ -66,12 +49,9 @@ export const EarnV2Webview = ({
 }: Props) => {
   const { state: remoteLiveAppState } = useRemoteLiveAppContext();
   const insets = useSafeAreaInsets();
-  // The simulator uses the live-app canvas (pure black in Wallet 4.0 dark) for the whole screen.
-  // Paint the area behind the webview so the loading state matches the content and native header
-  // (no gray flash before the webview paints). Scoped to `simulate` so deposit/withdraw keep the
-  // default background.
   const { theme: lumenTheme } = useLumenTheme();
   const canvasColor = lumenTheme.colors.bg.canvas;
+  const { t } = useTranslation();
   const isSimulateIntent = inputs?.intent === "simulate";
   const { topBarHeight, bottomBarHeight } = useNavigationBarHeights();
   const { shouldDisplayEarnUpselling, shouldDisplayEarnSimulator } =
@@ -98,35 +78,44 @@ export const EarnV2Webview = ({
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
 
   const [webviewUrl, setWebviewUrl] = useState<string | undefined>(undefined);
+  const webviewUrlRef = useRef<string | undefined>(undefined);
   const handleWebviewStateChange = useCallback((state: WebviewState) => {
+    webviewUrlRef.current = state.url;
     setWebviewUrl(state.url);
   }, []);
 
   const intentFlowState = getIntentFlowState(webviewUrl);
+  const webviewIntent = getWebviewIntent(webviewUrl);
 
-  /** Until the webview reports a *known* URL (`null` while unknown/empty on first mount), trust the
-   * native `intent` (correct first paint on intent flow entry). Once it reports a known non-intent
-   * route, the URL wins: returning to the dashboard restores the background even though the stale
-   * native `intent` is still set. Only `false` (a known non-intent route) leaves intent flow mode;
-   * `null` (unknown) must keep intent flow mode so we don't bounce out before the route loads.
-   */
   const inIntentFlow = !!hideMainNavigator && intentFlowState !== false;
   const showsBackground = isPtxUiMinV2 && !inIntentFlow;
 
-  /** An intent flow (deposit/withdraw/simulate) is rendered full-screen via the Base navigator
-   * (header, no tab bar). When the webview navigates back out of the intent route (e.g. "go to
-   * dashboard"), that in-webview navigation cannot leave the Base-stack screen on its own, so the
-   * main navigation (top bar + tab bar) and background stay hidden. Detect the exit and return to
-   * the Earn dashboard tab, which restores the full chrome. Guarded by `hideMainNavigator` so it
-   * only runs for the intent flow presentation, never the dashboard tab instance.
+  /**
+   * Single source of truth for the intent-flow presentation, driven by the webview's own route.
+   * We deliberately DO NOT mutate navigation params here: a cross-navigator `navigate({ merge })`
+   * wipes the Base `EarnNavigator` route params (params: undefined), which blanks the screen and
+   * drops the header. Instead we set the Base header imperatively via the parent navigator.
+   *
+   * - Webview back on a dashboard route → return to the Earn tab (debounced to ignore the
+   *   transient dashboard URL seen while transitioning, e.g. simulate → deposit).
+   * - Still in an intent flow → keep the Base native header in sync with the webview intent.
    */
   useEffect(() => {
     if (!hideMainNavigator) return;
-    // Only exit on a *known* non-intent route. `null` (unknown/initial empty URL) and `true`
-    // (still in an intent flow) must not trigger navigation, or we'd bounce out on entry.
-    if (intentFlowState !== false) return;
-    navigation.navigate(NavigatorName.Main, { screen: NavigatorName.Earn });
-  }, [hideMainNavigator, intentFlowState, navigation]);
+
+    if (intentFlowState === false) {
+      const timeout = setTimeout(() => {
+        if (getIntentFlowState(webviewUrlRef.current) !== false) return;
+        navigation.navigate(NavigatorName.Main, { screen: NavigatorName.Earn });
+      }, EXIT_INTENT_FLOW_DEBOUNCE_MS);
+
+      return () => clearTimeout(timeout);
+    }
+
+    if (webviewIntent) {
+      navigation.getParent()?.setOptions(getEarnScreenOptions(webviewIntent, t, canvasColor));
+    }
+  }, [hideMainNavigator, intentFlowState, webviewIntent, navigation, t, canvasColor]);
 
   const webviewInputs = {
     ...inputs,
@@ -159,7 +148,7 @@ export const EarnV2Webview = ({
             />
           </Fragment>
         ) : (
-          !remoteLiveAppState.isLoading && ( // if the manifest is not found, show the error screen
+          !remoteLiveAppState.isLoading && (
             <Flex flex={1} p={10} justifyContent="center" alignItems="center">
               <GenericErrorView error={appManifestNotFoundError} />
             </Flex>

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/buildEarnGoToURL.test.ts
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/buildEarnGoToURL.test.ts
@@ -1,0 +1,37 @@
+import { buildEarnGoToURL } from "./buildEarnGoToURL";
+
+describe("buildEarnGoToURL", () => {
+  it("merges init params into the dapp URL, preserving existing query params", () => {
+    const result = buildEarnGoToURL("https://dapp.test/stake?foo=1", {
+      intent: "deposit",
+      uiVersion: "v4",
+    });
+
+    const url = new URL(result);
+    expect(url.origin + url.pathname).toBe("https://dapp.test/stake");
+    expect(url.searchParams.get("foo")).toBe("1");
+    expect(url.searchParams.get("intent")).toBe("deposit");
+    expect(url.searchParams.get("uiVersion")).toBe("v4");
+  });
+
+  it("skips undefined params", () => {
+    const result = buildEarnGoToURL("https://dapp.test/stake", {
+      intent: "deposit",
+      accountId: undefined,
+    });
+
+    const url = new URL(result);
+    expect(url.searchParams.get("intent")).toBe("deposit");
+    expect(url.searchParams.has("accountId")).toBe(false);
+  });
+
+  it("overwrites an existing param with the merged value", () => {
+    const result = buildEarnGoToURL("https://dapp.test/stake?intent=stale", { intent: "withdraw" });
+
+    expect(new URL(result).searchParams.get("intent")).toBe("withdraw");
+  });
+
+  it("returns the original string when the URL cannot be parsed", () => {
+    expect(buildEarnGoToURL("not a url", { intent: "deposit" })).toBe("not a url");
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/buildEarnGoToURL.ts
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/buildEarnGoToURL.ts
@@ -1,0 +1,15 @@
+import { addParamsToURL } from "@ledgerhq/live-common/wallet-api/helpers";
+
+/** Merges Earn init params into a partner dapp URL (getInitialURL does not merge `inputs` when goToURL is set). */
+export function buildEarnGoToURL(
+  customDappUrl: string,
+  initParams: Record<string, string | undefined>,
+): string {
+  try {
+    const url = new URL(customDappUrl);
+    addParamsToURL(url, initParams);
+    return url.toString();
+  } catch {
+    return customDappUrl;
+  }
+}

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/getWebviewIntent.test.ts
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/getWebviewIntent.test.ts
@@ -1,0 +1,36 @@
+import { getIntentFlowState, getWebviewIntent } from "./getWebviewIntent";
+
+describe("getWebviewIntent", () => {
+  it("reads intent from the query string", () => {
+    expect(getWebviewIntent("https://earn.test/v2/ios/deposit?intent=deposit&uiVersion=v4")).toBe(
+      "deposit",
+    );
+    expect(getWebviewIntent("https://earn.test/v2/ios/earn-simulator?intent=simulate")).toBe(
+      "simulate",
+    );
+  });
+
+  it("infers intent from the pathname when the query param is absent", () => {
+    expect(getWebviewIntent("https://earn.test/v2/android/deposit")).toBe("deposit");
+    expect(getWebviewIntent("https://earn.test/v2/ios/earn-simulator")).toBe("simulate");
+  });
+
+  it("returns undefined for dashboard routes", () => {
+    expect(getWebviewIntent("https://earn.test/v2/ios/homescreen")).toBeUndefined();
+  });
+});
+
+describe("getIntentFlowState", () => {
+  it("returns true for intent flow routes", () => {
+    expect(getIntentFlowState("https://earn.test/v2/android/deposit?intent=deposit")).toBe(true);
+  });
+
+  it("returns false for the dashboard", () => {
+    expect(getIntentFlowState("https://earn.test/v2/android/homescreen")).toBe(false);
+  });
+
+  it("returns null for unknown URLs", () => {
+    expect(getIntentFlowState(undefined)).toBeNull();
+    expect(getIntentFlowState("about:blank")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/getWebviewIntent.test.ts
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/getWebviewIntent.test.ts
@@ -33,4 +33,17 @@ describe("getIntentFlowState", () => {
     expect(getIntentFlowState(undefined)).toBeNull();
     expect(getIntentFlowState("about:blank")).toBeNull();
   });
+
+  it("returns true for the simulator route without an intent query param", () => {
+    expect(getIntentFlowState("https://earn.test/v2/android/earn-simulator")).toBe(true);
+  });
+
+  it("stays in lockstep with getWebviewIntent for routes that merely contain an intent word", () => {
+    // Regression: getIntentFlowState used to match a bare "deposit"/"simulate" substring, so a
+    // route like /predeposit-info read as "in flow" while getWebviewIntent saw no intent. The two
+    // are now derived from the same source and must never disagree.
+    const url = "https://earn.test/v2/ios/predeposit-info";
+    expect(getWebviewIntent(url)).toBeUndefined();
+    expect(getIntentFlowState(url)).toBe(false);
+  });
 });

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/getWebviewIntent.ts
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/getWebviewIntent.ts
@@ -1,0 +1,34 @@
+import { safeUrl } from "@ledgerhq/live-common/wallet-api/helpers";
+
+export type EarnWebviewIntent = "deposit" | "withdraw" | "simulate";
+
+const INTENT_FLOWS = ["deposit", "withdraw", "simulate"] as const;
+const INTENTS_SET = new Set<string>(INTENT_FLOWS);
+
+export const isEarnWebviewIntent = (value: string | null | undefined): value is EarnWebviewIntent =>
+  INTENTS_SET.has(value ?? "");
+
+/** Reads the earn flow intent from a live-app webview URL (query param, then pathname). */
+export const getWebviewIntent = (rawUrl?: string): EarnWebviewIntent | undefined => {
+  if (!rawUrl) return undefined;
+  const url = safeUrl(rawUrl);
+  if (!url || (url.protocol !== "http:" && url.protocol !== "https:")) return undefined;
+
+  const queryIntent = url.searchParams.get("intent");
+  if (isEarnWebviewIntent(queryIntent)) return queryIntent;
+
+  if (url.pathname.includes("/deposit")) return "deposit";
+  if (url.pathname.includes("/withdraw")) return "withdraw";
+  if (url.pathname.includes("/earn-simulator")) return "simulate";
+
+  return undefined;
+};
+
+export const getIntentFlowState = (rawUrl?: string): boolean | null => {
+  if (!rawUrl) return null;
+  const url = safeUrl(rawUrl);
+  if (!url) return null;
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+  if (isEarnWebviewIntent(url.searchParams.get("intent"))) return true;
+  return INTENT_FLOWS.some(segment => url.pathname.includes(segment));
+};

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/getWebviewIntent.ts
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/getWebviewIntent.ts
@@ -24,11 +24,23 @@ export const getWebviewIntent = (rawUrl?: string): EarnWebviewIntent | undefined
   return undefined;
 };
 
+/**
+ * Tri-state view of whether the webview is currently inside an earn intent flow.
+ *
+ * The intent is derived from {@link getWebviewIntent} so the two never disagree (a divergence here
+ * could bounce the user out of a flow the header still thinks it is in).
+ *
+ * - `true`  → on an intent route (deposit/withdraw/simulate).
+ * - `false` → on a known non-intent route (e.g. the dashboard) — the only signal that the user
+ *             has *left* the flow.
+ * - `null`  → route not yet known: no URL yet, or a non-http(s) URL (e.g. `about:blank` during
+ *             load). Callers must NOT treat `null` as "left the flow" — doing so bounces the user
+ *             out before the first real URL arrives.
+ */
 export const getIntentFlowState = (rawUrl?: string): boolean | null => {
   if (!rawUrl) return null;
   const url = safeUrl(rawUrl);
   if (!url) return null;
   if (url.protocol !== "http:" && url.protocol !== "https:") return null;
-  if (isEarnWebviewIntent(url.searchParams.get("intent"))) return true;
-  return INTENT_FLOWS.some(segment => url.pathname.includes(segment));
+  return getWebviewIntent(rawUrl) !== undefined;
 };

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
@@ -29,6 +29,7 @@ import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/s
 import { EarnWebview } from "./EarnWebview";
 import { useVersionedStakePrograms } from "LLM/hooks/useStake/useVersionedStakePrograms";
 import { EarnV2Webview } from "./EarnV2Webview";
+import { buildEarnGoToURL } from "./buildEarnGoToURL";
 
 export type Props = StackNavigatorProps<EarnLiveAppNavigatorParamList, ScreenName.Earn>;
 
@@ -89,8 +90,11 @@ function Earn({ route }: Props) {
   }
   const Container = hideMainNavigator ? Fragment : TabBarSafeAreaView;
 
-  const webviewInputs = useMemo(
-    () => ({
+  const webviewInputs = useMemo(() => {
+    const { customDappURL, customDappUrl, ...restParams } = params;
+    const dappUrl = customDappURL ?? customDappUrl;
+
+    const earnInitParams: Record<string, string | undefined> = {
       theme,
       lang: language,
       locale: language,
@@ -105,23 +109,27 @@ function Earn({ route }: Props) {
       OS: Platform.OS,
       ethDepositCohort,
       uiVersion: "v1",
-      ...params,
+      ...restParams,
       ...Object.fromEntries(searchParams.entries()),
-    }),
-    [
-      theme,
-      language,
-      countryLocale,
-      currencyTicker,
-      devMode,
-      discreet,
-      stakeProgramsParam,
-      stakeCurrenciesParam,
-      ethDepositCohort,
-      params,
-      searchParams,
-    ],
-  );
+    };
+
+    return {
+      ...earnInitParams,
+      goToURL: dappUrl ? buildEarnGoToURL(dappUrl, earnInitParams) : undefined,
+    };
+  }, [
+    theme,
+    language,
+    countryLocale,
+    currencyTicker,
+    devMode,
+    discreet,
+    stakeProgramsParam,
+    stakeCurrenciesParam,
+    ethDepositCohort,
+    params,
+    searchParams,
+  ]);
 
   /** V2: single shell (background + content). Use lastKnownManifest whenever manifest is missing so remount (e.g. dev Strict Mode) keeps showing webview instead of loader. */
   if (isLwm40Enabled) {

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/useEarnIntentFlowPresentation.test.ts
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/useEarnIntentFlowPresentation.test.ts
@@ -1,0 +1,98 @@
+import { renderHook } from "@testing-library/react-native";
+import { useNavigation } from "@react-navigation/native";
+import { BASE_NAVIGATOR_ID, NavigatorName } from "~/const";
+import { useEarnIntentFlowPresentation } from "./useEarnIntentFlowPresentation";
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: jest.fn(),
+}));
+jest.mock("~/context/Locale", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const DEPOSIT_URL = "https://earn.test/v2/android/deposit?intent=deposit&uiVersion=v4";
+const DASHBOARD_URL = "https://earn.test/v2/android/homescreen?uiVersion=v4";
+
+const mockNavigate = jest.fn();
+const mockSetOptions = jest.fn();
+const mockGetParent = jest.fn(() => ({ setOptions: mockSetOptions }));
+const mockedUseNavigation = jest.mocked(useNavigation);
+
+type PresentationProps = Parameters<typeof useEarnIntentFlowPresentation>[0];
+
+const renderPresentation = (webviewUrl?: string, webviewUrlRef = { current: webviewUrl }) =>
+  renderHook((props: PresentationProps) => useEarnIntentFlowPresentation(props), {
+    initialProps: {
+      hideMainNavigator: true,
+      webviewUrl,
+      webviewUrlRef,
+      canvasColor: "#000000",
+    },
+  });
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  mockSetOptions.mockClear();
+  mockGetParent.mockClear();
+  mockedUseNavigation.mockReturnValue({
+    navigate: mockNavigate,
+    getParent: mockGetParent,
+  } as never);
+});
+
+describe("useEarnIntentFlowPresentation", () => {
+  it("syncs the Base navigator header for the current webview intent", () => {
+    renderPresentation(DEPOSIT_URL);
+
+    expect(mockGetParent).toHaveBeenCalledWith(BASE_NAVIGATOR_ID);
+    const options = mockSetOptions.mock.calls.at(-1)?.[0];
+    expect(options).toEqual(expect.objectContaining({ headerShown: true, closable: false }));
+    // Deposit header has a title and, unlike the simulate intent, no canvas headerStyle.
+    expect(options.headerTitle).toBeTruthy();
+    expect(options.headerStyle).toBeUndefined();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("does not touch presentation outside the intent flow (hideMainNavigator false)", () => {
+    renderHook((props: PresentationProps) => useEarnIntentFlowPresentation(props), {
+      initialProps: {
+        hideMainNavigator: false,
+        webviewUrl: DASHBOARD_URL,
+        webviewUrlRef: { current: DASHBOARD_URL },
+        canvasColor: "#000000",
+      },
+    });
+
+    expect(mockSetOptions).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  describe("debounced return to the Earn tab", () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    it("returns to the Earn tab when the webview stays on a non-intent route", () => {
+      renderPresentation(DASHBOARD_URL);
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(500);
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Main, {
+        screen: NavigatorName.Earn,
+      });
+    });
+
+    it("cancels the return when the webview is back on an intent route before the debounce fires", () => {
+      // Transient dashboard URL seen mid-transition (e.g. simulate → deposit): the scheduled exit
+      // must re-check the live URL at fire time and abort, rather than bouncing to the Earn tab.
+      const webviewUrlRef = { current: DASHBOARD_URL };
+      renderPresentation(DASHBOARD_URL, webviewUrlRef);
+
+      webviewUrlRef.current = DEPOSIT_URL;
+      jest.advanceTimersByTime(500);
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/useEarnIntentFlowPresentation.ts
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/useEarnIntentFlowPresentation.ts
@@ -1,0 +1,78 @@
+import { useEffect } from "react";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { useTranslation } from "~/context/Locale";
+import { BASE_NAVIGATOR_ID, NavigatorName } from "~/const";
+import { getEarnScreenOptions } from "~/components/RootNavigator/getEarnScreenOptions";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { getIntentFlowState, getWebviewIntent } from "./getWebviewIntent";
+
+/** Debounce before leaving the Base-stack intent presentation — avoids bouncing to the Earn tab
+ * when the webview briefly reports a dashboard URL while transitioning (e.g. simulate → deposit). */
+const EXIT_INTENT_FLOW_DEBOUNCE_MS = 500;
+
+/** Navigation typed with {@link BASE_NAVIGATOR_ID} so `getParent(BASE_NAVIGATOR_ID)` is type-safe. */
+type EarnBaseNavigation = NativeStackNavigationProp<
+  BaseNavigatorStackParamList,
+  keyof BaseNavigatorStackParamList,
+  typeof BASE_NAVIGATOR_ID
+>;
+
+type Params = {
+  hideMainNavigator?: boolean;
+  webviewUrl?: string;
+  webviewUrlRef: React.MutableRefObject<string | undefined>;
+  canvasColor: string;
+};
+
+/**
+ * Drives the Base-stack presentation for an earn intent flow from the live webview's own route.
+ *
+ * The native header lives on the Base navigator (the earn live-app stack is `headerShown: false`),
+ * so we update it imperatively on the parent. We deliberately do not mutate route params via a
+ * cross-navigator `navigate({ merge })` — that wipes the Earn route params (see LIVE-32789).
+ */
+export function useEarnIntentFlowPresentation({
+  hideMainNavigator,
+  webviewUrl,
+  webviewUrlRef,
+  canvasColor,
+}: Params) {
+  const navigation = useNavigation<EarnBaseNavigation>();
+  const { t } = useTranslation();
+
+  const intentFlowState = getIntentFlowState(webviewUrl);
+  const webviewIntent = getWebviewIntent(webviewUrl);
+
+  useEffect(() => {
+    if (!hideMainNavigator) return;
+
+    // Webview is back on a dashboard route → return to the Earn tab (debounced to ignore the
+    // transient dashboard URL seen while transitioning, e.g. simulate → deposit).
+    if (intentFlowState === false) {
+      const timeout = setTimeout(() => {
+        if (getIntentFlowState(webviewUrlRef.current) !== false) return;
+        navigation.navigate(NavigatorName.Main, { screen: NavigatorName.Earn });
+      }, EXIT_INTENT_FLOW_DEBOUNCE_MS);
+
+      return () => clearTimeout(timeout);
+    }
+
+    // Still in an intent flow → keep the Base native header in sync with the webview intent.
+    if (webviewIntent) {
+      navigation
+        .getParent(BASE_NAVIGATOR_ID)
+        ?.setOptions(getEarnScreenOptions(webviewIntent, t, canvasColor));
+    }
+  }, [
+    hideMainNavigator,
+    intentFlowState,
+    webviewIntent,
+    navigation,
+    t,
+    canvasColor,
+    webviewUrlRef,
+  ]);
+
+  return { intentFlowState, webviewIntent };
+}


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Enable `earnSimulator`
  - Navigate to "Simulate my rewards" on mobile
  - Select "Start earning Ethereum"
  - Deposit flow now loads smoothly

### 📝 Description


Ensure react native navigation header (title + back button) appears correctly when navigating between earn simulator and earn deposit flows via deeplinks.

Instead of reshuffling/deleting query params, the react native wrapper now watches the window's address bar, sees it's on /deposit, and directly sets the top-bar options via the parent navigator. 

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-32789](https://ledgerhq.atlassian.net/browse/LIVE-32789)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-32789]: https://ledgerhq.atlassian.net/browse/LIVE-32789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ