### PR TITLE
[LWDM] fix(currency-format): correct RTL currency symbol and +/- sign rendering for Arabic currencies

### DIFF
--- a/.changeset/live-31931-pnl-rtl-currency-signs.md
+++ b/.changeset/live-31931-pnl-rtl-currency-signs.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-currency-format": minor
+---
+
+Fix currency symbol and +/- sign rendering on the wrong side for right-to-left (Arabic) currencies by forcing LTR layout of formatted amounts.

--- a/libs/live-currency-format/src/formatCurrencyUnit.test.ts
+++ b/libs/live-currency-format/src/formatCurrencyUnit.test.ts
@@ -151,6 +151,41 @@ describe("formatCurrencyUnit", () => {
     });
   });
 
+  describe("RTL currencies", () => {
+    const LRI = "\u2066";
+    const PDI = "\u2069";
+    const sar: Unit = {
+      name: "Saudi Riyal",
+      code: "﷼",
+      magnitude: 2,
+      showAllDigits: true,
+      prefixCode: true,
+    };
+
+    test("wraps a negative amount in a LTR isolate keeping sign -> symbol -> value", () => {
+      expect(formatCurrencyUnit(sar, new BigNumber("-10698"), { showCode: true })).toBe(
+        `${LRI}-﷼106.98${PDI}`,
+      );
+    });
+
+    test("wraps a positive amount with alwaysShowSign", () => {
+      expect(
+        formatCurrencyUnit(sar, new BigNumber("22668"), { showCode: true, alwaysShowSign: true }),
+      ).toBe(`${LRI}+﷼226.68${PDI}`);
+    });
+
+    test("does not wrap when the symbol is hidden (no RTL character in output)", () => {
+      expect(formatCurrencyUnit(sar, new BigNumber("10698"), { showCode: false })).toBe("106.98");
+    });
+
+    test("leaves Latin-symbol currencies untouched", () => {
+      const usd: Unit = { ...sar, code: "USD" };
+      expect(formatCurrencyUnit(usd, new BigNumber("-10698"), { showCode: true })).toBe(
+        "-USD106.98",
+      );
+    });
+  });
+
   describe("formatCurrencyUnitFragment", () => {
     const unit: Unit = {
       name: "Test",

--- a/libs/live-currency-format/src/formatCurrencyUnit.ts
+++ b/libs/live-currency-format/src/formatCurrencyUnit.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from "bignumber.js";
 import { getSeparators } from "./localeUtility";
 import { toLocaleString } from "./BigNumberToLocaleString";
+import { forceLTRIfRTL } from "./rtl";
 import type { Unit } from "@ledgerhq/types-cryptoassets";
 
 const nonBreakableSpace = " ";
@@ -212,5 +213,5 @@ export const formatCurrencyUnit = (
     }
   }
 
-  return parts.join(joinFragmentsSeparator);
+  return forceLTRIfRTL(parts.join(joinFragmentsSeparator));
 };

--- a/libs/live-currency-format/src/index.ts
+++ b/libs/live-currency-format/src/index.ts
@@ -8,6 +8,7 @@ export { toLocaleString, type SupportedOptions } from "./BigNumberToLocaleString
 export { getSeparators, prefixFormat, suffixFormat, type GetSeparators } from "./localeUtility";
 export { parseCurrencyUnit } from "./parseCurrencyUnit";
 export { sanitizeValueString } from "./sanitizeValueString";
+export { containsRTL, forceLTRIfRTL } from "./rtl";
 export {
   formatPrice,
   formatPriceFragment,

--- a/libs/live-currency-format/src/priceFormat.test.ts
+++ b/libs/live-currency-format/src/priceFormat.test.ts
@@ -16,6 +16,17 @@ const usdUnit: Unit = {
   prefixCode: true,
 };
 
+const sarUnit: Unit = {
+  code: "﷼",
+  name: "Saudi Riyal",
+  magnitude: 2,
+  showAllDigits: true,
+  prefixCode: true,
+};
+
+const LRI = "\u2066";
+const PDI = "\u2069";
+
 // Convert a fiat amount (e.g. $50,000) into the unit's smallest atom (5,000,000).
 const atoms = (fiat: number): BigNumber => new BigNumber(fiat).shiftedBy(usdUnit.magnitude);
 
@@ -128,6 +139,24 @@ describe("formatSignedFiatVariation", () => {
 
     it("emits a signed '<' threshold marker for a tiny positive variation", () => {
       expect(formatSignedFiatVariation(5e-8, usdUnit, "en-US")).toBe("+<$0.000001");
+    });
+  });
+
+  describe("with RTL currency symbols", () => {
+    it("wraps a positive variation with the sign inside the LTR isolate", () => {
+      expect(formatSignedFiatVariation(1.2, sarUnit, "en-US")).toBe(`${LRI}+﷼1.20${PDI}`);
+    });
+
+    it("wraps a negative variation with the sign inside the LTR isolate", () => {
+      expect(formatSignedFiatVariation(-3.46, sarUnit, "en-US")).toBe(`${LRI}-﷼3.46${PDI}`);
+    });
+
+    it("wraps a tiny positive variation with the sign and threshold marker inside the LTR isolate", () => {
+      expect(formatSignedFiatVariation(5e-8, sarUnit, "en-US")).toBe(`${LRI}+<﷼0.000001${PDI}`);
+    });
+
+    it("wraps a tiny negative variation with the sign and threshold marker inside the LTR isolate", () => {
+      expect(formatSignedFiatVariation(-6e-9, sarUnit, "en-US")).toBe(`${LRI}-<﷼0.000001${PDI}`);
     });
   });
 });

--- a/libs/live-currency-format/src/priceFormat.ts
+++ b/libs/live-currency-format/src/priceFormat.ts
@@ -56,17 +56,23 @@ export function formatSignedFiatVariation(fiatAmount: number, unit: Unit, locale
   const abs = Math.abs(fiatAmount);
   const opts = priceOptions(abs, unit);
   const resolution = 10 ** -(unit.magnitude + opts.subMagnitude);
-  const at = (v: number): string =>
+  const at = (v: number, alwaysShowSign = false): string =>
     formatCurrencyUnit(unit, valueFromUnit(new BigNumber(v), unit), {
       locale,
       showCode: true,
       showAllDigits: true,
+      alwaysShowSign,
       ...opts,
     });
 
   if (abs === 0) return at(0);
   const sign = fiatAmount < 0 ? "-" : "+";
-  return abs < resolution ? `${sign}<${at(resolution)}` : `${sign}${at(abs)}`;
+  const signedAmount = sign === "-" ? -abs : abs;
+  const signedResolution = sign === "-" ? -resolution : resolution;
+  if (abs < resolution) {
+    return at(signedResolution, true).replace(sign, `${sign}<`);
+  }
+  return at(signedAmount, true);
 }
 
 /** Pre-round a numeric fiat price using the shared digit rule. */

--- a/libs/live-currency-format/src/rtl.test.ts
+++ b/libs/live-currency-format/src/rtl.test.ts
@@ -1,0 +1,38 @@
+import { containsRTL, forceLTRIfRTL } from "./rtl";
+
+const LRI = "\u2066";
+const PDI = "\u2069";
+
+describe("containsRTL", () => {
+  test.each([
+    ["Saudi Riyal symbol", "﷼"],
+    ["Emirati Dirham symbol", "د.إ."],
+    ["Egyptian Pound symbol", "ج.م.‏"],
+    ["Afghani symbol", "؋"],
+    ["Hebrew letter", "א"],
+    ["amount with arabic symbol", "-﷼106.98"],
+  ])("returns true for %s", (_name, value) => {
+    expect(containsRTL(value)).toBe(true);
+  });
+
+  test.each([
+    ["dollar", "$"],
+    ["euro", "€"],
+    ["pound", "£"],
+    ["ticker", "USD"],
+    ["signed latin amount", "-123.45 USD"],
+    ["empty string", ""],
+  ])("returns false for %s", (_name, value) => {
+    expect(containsRTL(value)).toBe(false);
+  });
+});
+
+describe("forceLTRIfRTL", () => {
+  test("wraps strings containing RTL characters in a LTR isolate", () => {
+    expect(forceLTRIfRTL("-﷼106.98")).toBe(`${LRI}-﷼106.98${PDI}`);
+  });
+
+  test("leaves strings without RTL characters untouched", () => {
+    expect(forceLTRIfRTL("-$106.98")).toBe("-$106.98");
+  });
+});

--- a/libs/live-currency-format/src/rtl.ts
+++ b/libs/live-currency-format/src/rtl.ts
@@ -1,0 +1,16 @@
+// Strong right-to-left scripts (Hebrew, Arabic, Arabic Supplement/Extended, Presentation Forms).
+// Some fiat symbols are strong RTL characters, e.g. SAR "﷼", AED "د.إ.", EGP "ج.م.". When such a
+// symbol is mixed with an ASCII +/- sign and Latin digits inside a single string, the Unicode
+// bidirectional algorithm reorders the run and pushes the sign/symbol to the wrong side.
+const RTL_PATTERN =
+  /[\u0590-\u05FF\u0600-\u06FF\u0700-\u074F\u0750-\u077F\u08A0-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF]/;
+
+const LRI = "\u2066"; // LEFT-TO-RIGHT ISOLATE
+const PDI = "\u2069"; // POP DIRECTIONAL ISOLATE
+
+export const containsRTL = (str: string): boolean => RTL_PATTERN.test(str);
+
+// Wrap a formatted amount in a left-to-right isolate so its sign, symbol and value keep their
+// logical order in our LTR-forced UI. No-op for strings without RTL characters.
+export const forceLTRIfRTL = (str: string): string =>
+  containsRTL(str) ? `${LRI}${str}${PDI}` : str;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - PnL and amount rendering for RTL (Arabic) fiat currencies (e.g. SAR `﷼`, AED `د.إ.`, EGP `ج.م.`, AFN `؋`)
  - Confirm the `+`/`-` sign and the currency symbol stay on the left of the value (logical order: sign → symbol → value)
  - Sanity-check that LTR / Latin-symbol currencies (USD, EUR, GBP) render exactly as before

### 📝 Description

**Problem**: On Ledger Wallet Mobile and Desktop, the PnL/currency amount for Arabic currencies displayed the currency symbol and the `+`/`-` sign on the wrong side. Several fiat symbols (SAR `﷼`, AED `د.إ.`, EGP `ج.م.`, …) are *strong right-to-left* characters. When such a symbol is mixed with an ASCII sign and Latin digits inside a single string, the Unicode bidirectional algorithm reorders the run and pushes the sign/symbol to the wrong side.

**Solution**: Added a small `rtl` utility in `@ledgerhq/live-currency-format` that:

- detects strong RTL characters (Hebrew, Arabic, Arabic Supplement/Extended and Presentation Forms ranges), and
- wraps the fully-formatted amount in a **Left-To-Right Isolate** (`U+2066 … U+2069`).

`formatCurrencyUnit` now returns the LTR-isolated string so the `sign → symbol → value` order is preserved in our LTR-forced UI. The wrapping is a **no-op** for strings without RTL characters, so Latin-symbol currencies are completely untouched.

```ts
// before
return parts.join(joinFragmentsSeparator);
// after
return forceLTRIfRTL(parts.join(joinFragmentsSeparator));
```

| Input | Before | After |
| ----- | ------ | ----- |
| SAR `-10698` | symbol/sign on wrong side | `‪-﷼106.98‬` (sign → symbol → value) |
| USD `-10698` | `-USD106.98` | `-USD106.98` (unchanged) |

### 🖼️ Screenshots

<img width="580" height="493" alt="image" src="https://github.com/user-attachments/assets/fb738593-6709-4812-997c-39f03703c8fc" />
<img width="350" height="750" alt="Simulator Screenshot - build2 - 2026-06-22 at 14 31 07" src="https://github.com/user-attachments/assets/18185885-7c6b-4d2d-a37b-fb5b26a31e23" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-31931](https://ledgerhq.atlassian.net/browse/LIVE-31931)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31931]: https://ledgerhq.atlassian.net/browse/LIVE-31931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ