### PR TITLE
[LWDM] feat(e2e): run CLI commands in-process instead of spawning apps/cli

### DIFF
--- a/.changeset/e2e-cli-inprocess.md
+++ b/.changeset/e2e-cli-inprocess.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+e2e: run the 4 CLI commands (getAddress, liveData, token approval, tokenAllowance) in-process instead of spawning `apps/cli`, keeping the same `runCli*` signatures

--- a/libs/ledger-live-common/src/e2e/commands/bootstrap.ts
+++ b/libs/ledger-live-common/src/e2e/commands/bootstrap.ts
@@ -1,0 +1,16 @@
+import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
+import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
+import { registerAllCoins } from "../../coin-modules/load-all-coins";
+import { liveConfig } from "../../config/sharedConfig";
+
+let ready = false;
+
+// The Speculos transport is intentionally not registered here: it is owned by
+// the app's e2e harness, keeping live-common free of any device dependency.
+export function ensureE2ERuntime(): void {
+  if (ready) return;
+  registerAllCoins();
+  LiveConfig.setConfig(liveConfig);
+  setupCalClientStore();
+  ready = true;
+}

--- a/libs/ledger-live-common/src/e2e/commands/getAddress.ts
+++ b/libs/ledger-live-common/src/e2e/commands/getAddress.ts
@@ -1,0 +1,26 @@
+import { firstValueFrom, from } from "rxjs";
+import type { GetAddressResult } from "@ledgerhq/ledger-wallet-framework/derivation";
+import { asDerivationMode } from "@ledgerhq/ledger-wallet-framework/derivation";
+import { withDevice } from "../../hw/deviceAccess";
+import getAddress from "../../hw/getAddress/index";
+import { findCryptoCurrencyByKeyword } from "../../currencies/index";
+import type { GetAddressOpts } from "../runCli";
+
+export async function cmdGetAddress(opts: GetAddressOpts): Promise<GetAddressResult> {
+  const currency = opts.currency ? findCryptoCurrencyByKeyword(opts.currency) : undefined;
+  if (!currency) throw new Error("no currency provided");
+  if (!opts.path) throw new Error("--path is required");
+
+  return firstValueFrom(
+    withDevice(opts.device || "")(t =>
+      from(
+        getAddress(t, {
+          currency,
+          path: opts.path as string,
+          derivationMode: asDerivationMode(opts.derivationMode || ""),
+          verify: opts.verify,
+        }),
+      ),
+    ),
+  );
+}

--- a/libs/ledger-live-common/src/e2e/commands/liveData.ts
+++ b/libs/ledger-live-common/src/e2e/commands/liveData.ts
@@ -1,0 +1,53 @@
+import fs from "fs";
+import { lastValueFrom } from "rxjs";
+import { reduce } from "rxjs/operators";
+import type { Account } from "@ledgerhq/types-live";
+import { getReduxStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
+import {
+  extractTokensFromState,
+  PERSISTENCE_VERSION,
+  type PersistedCAL,
+} from "@ledgerhq/cryptoassets/cal-client/persistence";
+import { toAccountRaw } from "../../account/serialization";
+import type { LiveDataOpts } from "../runCli";
+import { scan } from "./scan";
+
+export async function cmdLiveData(opts: LiveDataOpts): Promise<string> {
+  if (!opts.currency) throw new Error("--currency is required");
+
+  const accounts = await lastValueFrom(
+    scan({
+      currency: opts.currency,
+      scheme: opts.scheme,
+      index: opts.index,
+    }).pipe(reduce<Account, Account[]>((acc, account) => acc.concat(account), [])),
+    { defaultValue: [] as Account[] },
+  );
+
+  const appjsondata = opts.appjson
+    ? JSON.parse(fs.readFileSync(opts.appjson, "utf-8"))
+    : { data: { accounts: [] } };
+
+  if (typeof appjsondata.data.accounts === "string") {
+    throw new Error("encrypted ledger live data is not supported");
+  }
+
+  const existingIds = appjsondata.data.accounts.map((a: { data: { id: string } }) => a.data.id);
+  const append = await Promise.all(
+    accounts
+      .filter(a => !existingIds.includes(a.id))
+      .map(async account => ({ data: await toAccountRaw(account), version: 1 })),
+  );
+  appjsondata.data.accounts = appjsondata.data.accounts.concat(append);
+
+  const state = getReduxStore().getState();
+  const tokens = extractTokensFromState(state);
+  const persistedTokens: PersistedCAL = { version: PERSISTENCE_VERSION, tokens };
+  appjsondata.data.cryptoAssets = persistedTokens;
+
+  if (opts.appjson) {
+    fs.writeFileSync(opts.appjson, JSON.stringify(appjsondata), "utf-8");
+    return append.length + " accounts added.";
+  }
+  return JSON.stringify(appjsondata);
+}

--- a/libs/ledger-live-common/src/e2e/commands/scan.ts
+++ b/libs/ledger-live-common/src/e2e/commands/scan.ts
@@ -1,0 +1,48 @@
+import { Observable, defer, from } from "rxjs";
+import { filter, map, mergeMap, skip, take } from "rxjs/operators";
+import type { Account, SyncConfig } from "@ledgerhq/types-live";
+import { asDerivationMode } from "@ledgerhq/ledger-wallet-framework/derivation";
+import { findCryptoCurrencyByKeyword } from "../../currencies/index";
+import { getCurrencyBridge } from "../../bridge/index";
+import { makeBridgeCacheSystem } from "../../bridge/cache";
+
+export type ScanOpts = {
+  currency: string;
+  device?: string;
+  scheme?: string;
+  index?: number;
+  length?: number;
+};
+
+const localCache: Record<string, unknown> = {};
+const cache = makeBridgeCacheSystem({
+  saveData(c, d) {
+    localCache[c.id] = d;
+    return Promise.resolve();
+  },
+  getData(c) {
+    return Promise.resolve(localCache[c.id]);
+  },
+});
+
+export function scan({ currency, device, scheme, index, length }: ScanOpts): Observable<Account> {
+  const cur = findCryptoCurrencyByKeyword(currency);
+  if (!cur) throw new Error(`Unknown currency: ${currency}`);
+
+  const syncConfig: SyncConfig = { paginationConfig: {} };
+
+  return defer(() => from(cache.prepareCurrency(cur).then(() => getCurrencyBridge(cur)))).pipe(
+    mergeMap(bridge =>
+      bridge.scanAccounts({
+        currency: cur,
+        deviceId: device || "",
+        scheme: scheme !== undefined ? asDerivationMode(scheme) : undefined,
+        syncConfig,
+      }),
+    ),
+    filter(e => e.type === "discovered"),
+    map(e => e.account),
+    skip(index || 0),
+    take(length === undefined ? (index !== undefined ? 1 : Infinity) : length),
+  );
+}

--- a/libs/ledger-live-common/src/e2e/commands/tokenAllowance.ts
+++ b/libs/ledger-live-common/src/e2e/commands/tokenAllowance.ts
@@ -1,0 +1,93 @@
+import { BigNumber } from "bignumber.js";
+import type { Account, DerivationMode } from "@ledgerhq/types-live";
+import {
+  asDerivationMode,
+  getDerivationScheme,
+  runDerivationScheme,
+} from "@ledgerhq/ledger-wallet-framework/derivation";
+import { getEvmTokenAllowance } from "../../families/evm/getTokenAllowance";
+import { decodeAccountId, emptyHistoryCache, encodeAccountId } from "../../account/index";
+import { findCryptoCurrencyByKeyword, getCryptoCurrencyById } from "../../currencies/index";
+import type { GetTokenAllowanceOpts } from "../runCli";
+
+function buildMinimalEvmAccount(params: {
+  currencyId: string;
+  address: string;
+  derivationMode: DerivationMode;
+  index: number;
+}): Account {
+  const { currencyId, address, derivationMode, index } = params;
+  const id = encodeAccountId({
+    type: "js",
+    version: "2",
+    currencyId,
+    xpubOrAddress: address.trim(),
+    derivationMode,
+  });
+  const { derivationMode: dm, xpubOrAddress, currencyId: decodedCurrencyId } = decodeAccountId(id);
+  const currency = getCryptoCurrencyById(decodedCurrencyId);
+  const resolvedDerivationMode = asDerivationMode(dm);
+  const derivationScheme = getDerivationScheme({
+    derivationMode: resolvedDerivationMode,
+    currency,
+  });
+  const freshAddressPath = runDerivationScheme(derivationScheme, currency, {
+    account: index,
+    node: 0,
+    address: 0,
+  });
+
+  return {
+    type: "Account",
+    xpub: xpubOrAddress,
+    seedIdentifier: xpubOrAddress,
+    used: true,
+    swapHistory: [],
+    id,
+    derivationMode: resolvedDerivationMode,
+    currency,
+    index,
+    freshAddress: xpubOrAddress,
+    freshAddressPath,
+    creationDate: new Date(),
+    lastSyncDate: new Date(0),
+    blockHeight: 0,
+    balance: new BigNumber(0),
+    spendableBalance: new BigNumber(0),
+    operationsCount: 0,
+    operations: [],
+    pendingOperations: [],
+    balanceHistoryCache: emptyHistoryCache,
+  };
+}
+
+// Returns the same JSON string the CLI printed, so existing parsing is unchanged.
+export async function cmdGetTokenAllowance(opts: GetTokenAllowanceOpts): Promise<string> {
+  const currency = findCryptoCurrencyByKeyword(opts.currency);
+  if (!currency) throw new Error(`Unknown currency: ${opts.currency}`);
+  if (currency.family !== "evm") {
+    throw new Error(`tokenAllowance only supports EVM chains. Got family ${currency.family}.`);
+  }
+
+  const index =
+    typeof opts.index === "number" ? opts.index : Number.parseInt(String(opts.index), 10);
+
+  const mainAccount = buildMinimalEvmAccount({
+    currencyId: currency.id,
+    address: opts.ownerAddress,
+    derivationMode: asDerivationMode(""),
+    index: Number.isFinite(index) ? index : 0,
+  });
+
+  const result = await getEvmTokenAllowance(mainAccount, opts.token, opts.spenderAddress);
+
+  return JSON.stringify({
+    allowance: result.allowance.toFixed(0),
+    unitMagnitude: result.unit.magnitude,
+    symbol: result.symbol,
+    tokenId: result.tokenId,
+    owner: result.owner,
+    spender: result.spender,
+    contractAddress: result.contractAddress,
+  });
+}

--- a/libs/ledger-live-common/src/e2e/commands/tokenApproval.ts
+++ b/libs/ledger-live-common/src/e2e/commands/tokenApproval.ts
@@ -1,0 +1,80 @@
+import { firstValueFrom } from "rxjs";
+import { filter } from "rxjs/operators";
+import { getEnv } from "@ledgerhq/live-env";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Transaction } from "../../generated/types";
+import { loadSetupForFamily } from "../../coin-modules/registry";
+import { getAccountBridge } from "../../bridge/index";
+import { waitForTransactionConfirmation } from "../../families/evm/waitForConfirmation";
+import type { TokenApprovalOpts } from "../runCli";
+import { scan } from "./scan";
+
+type Inferred = { account: AccountLike; mainAccount: Account; transaction: Transaction };
+
+type CliTools = {
+  inferAccounts?: (account: Account, opts: Record<string, unknown>) => AccountLike[];
+  inferTransactions: (
+    transactions: Inferred[],
+    opts: Partial<Record<string, string | string[]>>,
+  ) => Promise<Transaction[]>;
+};
+
+export async function cmdTokenApproval(opts: TokenApprovalOpts): Promise<string> {
+  const mainAccount = await firstValueFrom(
+    scan({ currency: opts.currency, index: opts.index, length: 1 }),
+  );
+
+  const bridge = await getAccountBridge(mainAccount);
+  const setup = await loadSetupForFamily(mainAccount.currency.family);
+  const cliTools: CliTools | undefined = setup?.cliTools;
+
+  if (!cliTools?.inferTransactions) {
+    throw new Error(`No cli tools for family ${mainAccount.currency.family}`);
+  }
+
+  const cliOpts: Record<string, string | string[]> = {
+    mode: opts.mode,
+    spender: opts.spender,
+    token: opts.token,
+  };
+  if (opts.approveAmount) cliOpts.approveAmount = opts.approveAmount;
+
+  const accounts = cliTools.inferAccounts?.(mainAccount, cliOpts) ?? [mainAccount];
+  const base: Inferred[] = accounts.map(account => ({
+    account,
+    mainAccount,
+    transaction: bridge.createTransaction(mainAccount),
+  }));
+
+  const inferred = await cliTools.inferTransactions(base, cliOpts);
+  const broadcastDisabled = !!getEnv("DISABLE_TRANSACTION_BROADCAST");
+  const hashes: string[] = [];
+
+  for (const tx of inferred) {
+    const prepared = await bridge.prepareTransaction(mainAccount, tx);
+    const status = await bridge.getTransactionStatus(mainAccount, prepared);
+    const errorKeys = Object.keys(status.errors);
+    if (errorKeys.length) throw status.errors[errorKeys[0]];
+
+    const signed = await firstValueFrom(
+      bridge
+        .signOperation({ account: mainAccount, transaction: prepared, deviceId: "" })
+        .pipe(filter(e => e.type === "signed")),
+    );
+    if (signed.type !== "signed") throw new Error("transaction was not signed");
+
+    if (broadcastDisabled) continue;
+
+    const op = await bridge.broadcast({
+      account: mainAccount,
+      signedOperation: signed.signedOperation,
+    });
+    if (op.hash) hashes.push(op.hash);
+
+    if (opts.waitConfirmation && op.hash && mainAccount.currency.family === "evm") {
+      await waitForTransactionConfirmation(mainAccount, op.hash);
+    }
+  }
+
+  return hashes.join(",");
+}

--- a/libs/ledger-live-common/src/e2e/runCli.ts
+++ b/libs/ledger-live-common/src/e2e/runCli.ts
@@ -1,9 +1,10 @@
-import path from "path";
-import { spawn } from "child_process";
 import type { GetAddressResult } from "@ledgerhq/ledger-wallet-framework/derivation";
 import { sanitizeError, sleep } from "./index";
-
-export const LEDGER_LIVE_CLI_BIN = path.resolve(__dirname, "../../../../apps/cli/bin/index.js");
+import { ensureE2ERuntime } from "./commands/bootstrap";
+import { cmdGetAddress } from "./commands/getAddress";
+import { cmdLiveData } from "./commands/liveData";
+import { cmdGetTokenAllowance } from "./commands/tokenAllowance";
+import { cmdTokenApproval } from "./commands/tokenApproval";
 
 export type LedgerKeyRingProtocolOpts = {
   initMemberCredentials?: boolean;
@@ -72,51 +73,6 @@ export type GetTokenAllowanceOpts = {
   ownerAddress: string;
 };
 
-function parseGetAddressCliOutput(output: string): GetAddressResult {
-  const lines = output
-    .split("\n")
-    .map(line => line.trim())
-    .filter(line => line.length > 0);
-
-  if (lines.length === 0) {
-    throw new Error("CLI getAddress returned empty output");
-  }
-
-  const jsonLine =
-    [...lines].reverse().find(line => line.startsWith("{") || line.startsWith("[")) ?? "";
-
-  if (!jsonLine) {
-    throw new Error("CLI getAddress output does not contain JSON");
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(jsonLine);
-  } catch {
-    throw new Error("Failed to parse CLI getAddress output");
-  }
-
-  if (typeof parsed !== "object" || parsed === null) {
-    throw new Error(`CLI getAddress output is not an object. Raw output:\n${output}`);
-  }
-
-  const { address, path, publicKey } = parsed as Record<string, unknown>;
-  if (typeof address !== "string" || typeof path !== "string" || typeof publicKey !== "string") {
-    throw new Error(`CLI getAddress output missing address/path/publicKey. Raw output:\n${output}`);
-  }
-
-  return parsed as GetAddressResult;
-}
-
-function parseCliFlag(command: string, flag: string): string | undefined {
-  const parts = command.split("+");
-  const idx = parts.findIndex(p => p === `--${flag}`);
-  return idx !== -1 && idx + 1 < parts.length ? parts[idx + 1] : undefined;
-}
-
-/**
- * Transient failures (network, Speculos, gateway) where a CLI retry may help.
- */
 function isRetryableError(message: string): boolean {
   const retryablePatterns = [
     /503/i,
@@ -132,65 +88,19 @@ function isRetryableError(message: string): boolean {
   return retryablePatterns.some(pattern => pattern.test(message));
 }
 
-export function runCliCommand(command: string): Promise<string> {
-  console.warn(`[CLI] Executing: ledger-live ${command.replace(/\+/g, " ")}`);
-
-  return new Promise((resolve, reject) => {
-    const args = command.split("+");
-    const child = spawn("node", [LEDGER_LIVE_CLI_BIN, ...args], {
-      stdio: "pipe",
-      env: process.env,
-    });
-
-    let output = "";
-    let errorOutput = "";
-
-    child.stdout.on("data", data => {
-      output += data.toString();
-    });
-
-    child.stderr.on("data", data => {
-      errorOutput += data.toString();
-    });
-
-    child.on("exit", code => {
-      if (code === 0) {
-        resolve(output);
-      } else {
-        const currency = parseCliFlag(command, "currency");
-        const index = parseCliFlag(command, "index");
-        const indexText = index && index !== "undefined" ? index : "N/A";
-
-        const errorDetails = [
-          `❌ Failed to execute CLI command`,
-          `🔍 Command: ${command}`,
-          `💱 Currency: ${currency}`,
-          `🔢 Index: ${indexText}`,
-          `🔢 Exit Code: ${code}`,
-          errorOutput ? `🧾 CLI Error : ${errorOutput.trim()}` : "",
-        ].join("\n");
-
-        reject(sanitizeError(errorDetails));
-      }
-    });
-
-    child.on("error", error => {
-      reject(new Error(`Error executing CLI command: ${sanitizeError(error)}`));
-    });
-  });
-}
-
-export async function runCliCommandWithRetry(
-  command: string,
-  retries: number = 3,
-  delayMs: number = 3000,
-): Promise<string> {
+async function runWithRetry<T>(
+  label: string,
+  fn: () => Promise<T>,
+  ctx: { currency?: string } = {},
+  retries = 3,
+  delayMs = 3000,
+): Promise<T> {
+  ensureE2ERuntime();
   let lastError: Error | null = null;
-  const currency = parseCliFlag(command, "currency");
 
   for (let attempt = 1; attempt <= retries; attempt++) {
     try {
-      return await runCliCommand(command);
+      return await fn();
     } catch (err: unknown) {
       lastError = err instanceof Error ? err : new Error(String(err));
       const willRetry = attempt < retries && isRetryableError(lastError.message);
@@ -200,7 +110,7 @@ export async function runCliCommandWithRetry(
       }
 
       console.warn(
-        `⚠️ CLI attempt ${attempt}/${retries}${currency ? ` for ${currency}` : ""} failed with retryable error – retrying in ${delayMs}ms…`,
+        `⚠️ ${label} attempt ${attempt}/${retries}${ctx.currency ? ` for ${ctx.currency}` : ""} failed with retryable error – retrying in ${delayMs}ms…`,
         lastError.message,
       );
 
@@ -212,45 +122,19 @@ export async function runCliCommandWithRetry(
 }
 
 export function runCliLiveData(opts: LiveDataOpts): Promise<string> {
-  const cliOpts = ["liveData"];
-  if (opts.currency) cliOpts.push(`--currency+${opts.currency}`);
-  if (opts.index !== undefined) cliOpts.push(`--index+${opts.index}`);
-  if (opts.appjson) cliOpts.push(`--appjson+${opts.appjson}`);
-  if (opts.scheme) cliOpts.push(`--scheme+${opts.scheme}`);
-  if (opts.add) cliOpts.push("--add");
-  return runCliCommandWithRetry(cliOpts.join("+"));
+  return runWithRetry("liveData", () => cmdLiveData(opts), { currency: opts.currency });
 }
 
-export async function runCliGetAddress(opts: GetAddressOpts): Promise<GetAddressResult> {
-  const cliOpts = ["getAddress"];
-  if (opts.currency) cliOpts.push(`--currency+${opts.currency}`);
-  if (opts.device) cliOpts.push(`--device+${opts.device}`);
-  if (opts.path) cliOpts.push(`--path+${opts.path}`);
-  if (opts.derivationMode) cliOpts.push(`--derivationMode+${opts.derivationMode}`);
-  if (opts.verify) cliOpts.push("--verify");
-  const output = await runCliCommandWithRetry(cliOpts.join("+"));
-  return parseGetAddressCliOutput(output);
+export function runCliGetAddress(opts: GetAddressOpts): Promise<GetAddressResult> {
+  return runWithRetry("getAddress", () => cmdGetAddress(opts), { currency: opts.currency });
 }
 
 export function runCliTokenApproval(opts: TokenApprovalOpts): Promise<string> {
-  const cliOpts = ["send"];
-  cliOpts.push(`--currency+${opts.currency}`);
-  cliOpts.push(`--mode+${opts.mode}`);
-  cliOpts.push(`--token+${opts.token}`);
-  cliOpts.push(`--spender+${opts.spender}`);
-  cliOpts.push(`--index+${opts.index}`);
-  if (opts.approveAmount) cliOpts.push(`--approveAmount+${opts.approveAmount}`);
-  if (opts.waitConfirmation) cliOpts.push("--wait-confirmation");
-  return runCliCommandWithRetry(cliOpts.join("+"));
+  return runWithRetry("tokenApproval", () => cmdTokenApproval(opts), { currency: opts.currency });
 }
 
 export function runCliGetTokenAllowance(opts: GetTokenAllowanceOpts): Promise<string> {
-  const cliOpts = ["tokenAllowance"];
-  cliOpts.push(`--currency+${opts.currency}`);
-  cliOpts.push(`--spender+${opts.spenderAddress}`);
-  cliOpts.push(`--token+${opts.token}`);
-  cliOpts.push(`--index+${opts.index}`);
-  if (opts.format === "json") cliOpts.push("--format+json");
-  if (opts.ownerAddress) cliOpts.push(`--ownerAddress+${opts.ownerAddress}`);
-  return runCliCommandWithRetry(cliOpts.join("+"));
+  return runWithRetry("tokenAllowance", () => cmdGetTokenAllowance(opts), {
+    currency: opts.currency,
+  });
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Validated by the existing Desktop & Mobile E2E suites (manually dispatched on this branch, scoped to `@family-evm,@bitcoin`); no new unit tests added since the public `runCli*` signatures are unchanged.
- [ ] **Impact of the changes:** e2e infrastructure only — no app runtime code.
  - QA: focus on E2E account setup (receive/getAddress, multi-account `liveData`) and EVM token approval / allowance flows (swap reapproval).

### 📝 Description

The e2e suites only used 4 `apps/cli` commands — `getAddress`, `liveData`, `send` (token approval/revoke) and `tokenAllowance` — through `libs/ledger-live-common/src/e2e/runCli.ts`, which `spawn`ed `node apps/cli/bin/index.js`. This coupled e2e to building `apps/cli`, made every call a Node cold-start with stdout parsing, and blocked sunsetting the CLI.

#### Before — CLI indirection

```
┌───────────┐   spawn    ┌─────────────────────────┐        ┌────────────────────┐     device /
│ e2e tests │ ─────────▶ │ apps/cli (built bundle) │ ─────▶ │  live-common stack │ ──▶ network
└───────────┘  + stdout  └─────────────────────────┘        └────────────────────┘
```

#### After (this PR) — direct use of the libs stack

```
┌───────────┐  in-process   ┌────────────────────┐     device /
│ e2e tests │ ────────────▶ │  live-common stack │ ──▶ network
└───────────┘               └────────────────────┘
```

#### Future (post re-architecture)

```
┌───────────┐        ┌────────────────────────────────────┐
│ e2e tests │ ─────▶ │  /features, /entities, … (direct)   │
└───────────┘        └────────────────────────────────────┘
```

This PR reimplements those 4 commands **in-process** against live-common primitives (bridges, `hw/getAddress`, `account/serialization`, `families/evm`), in the existing shared `e2e/` module. The public `runCli*` helper signatures are kept identical, so `cliCommandsUtils.ts`, `families/*` and all desktop/mobile specs are unchanged. The retry/`sanitize` semantics are preserved.

> [!CAUTION]
> **Dead end today — this does not run in Node.** Executing the commands in-process surfaces the fact that live-common's published `lib-es` is **bundler-only ESM**, not directly Node-runnable.
>
> - relative imports are **extensionless** (`./foo`, not `./foo.js`) — Node's ESM resolver requires explicit extensions;
> - there is **no `"type": "module"`** marker, so Node parses the `.js` as CommonJS → `Cannot use import statement outside a module`;
> - some imports target deep CJS subpaths with no `exports` map (e.g. `lodash/isEqual`), unresolvable by Node ESM;
> - a few modules still use raw `require()` (e.g. `require("https")` in live-network), which is undefined under pure ESM.
>
> The e2e runners (Playwright, Detox + jest) transpile their **static** import graph, so most of this is papered over — but `registerAllCoins()` performs a **runtime dynamic `import()`** that escapes the transpiler and hits Node directly on `lib-es`, surfacing all of the above. Everywhere else live-common runs through a bundler/transpiler (rspack, Metro, jest, Bun, the old `apps/cli` bundle), so this never showed up until this pure-Node, in-process usage.
>
> **Two ways forward:**
>
> - **A — make `lib-es` Node-loadable** (`"type": "module"` + explicit `.js` extensions, NodeNext build). Fixes `import()` everywhere, but it's a **repo-wide change** touching every `@ledgerhq` lib in the graph and all their consumers/tooling — high blast radius.
> - **B — bundle the e2e commands** (esbuild → a single Node-valid artifact, consumed in-process). Localized to e2e, **zero change** to live-common's output or its consumers. Prototyped in the stacked branch `feat/live-32455-e2e-cli-bundle` — it works, but at the cost of shipping a ~38 MB bundle and per-runner workarounds (CJS bundle to dodge `import.meta`, jest `.js`→`.ts` mapper), which confirms the friction.

### 🧭 Decision — stay on the CLI status quo

Making the live-common stack run via a Node ESM `import()` (in-process, today) is a **dead end**: it only "works" behind a bundler/transpiler, and forcing it Node-native means either a high-risk repo-wide ESM migration (**A**) or a heavy, workaround-laden e2e bundle (**B**).

**Decision: keep the CLI status quo for now** — do not migrate e2e off the CLI; instead trim the CLI down to only the commands documented as used:

- **[LIVE-32458](https://ledgerhq.atlassian.net/browse/LIVE-32458)** — *Replace CLI commands usages (Part 1)* (epic)
- **[LIVE-32477](https://ledgerhq.atlassian.net/browse/LIVE-32477)** — *Drop all commands except those documented as used in the Study*

This PR (and the stacked `…-bundle` branch) are therefore **not merged**; they remain as documented exploration and proof of the constraint. Tracked under epic **[LIVE-32455](https://ledgerhq.atlassian.net/browse/LIVE-32455)**:

- **[LIVE-32910](https://ledgerhq.atlassian.net/browse/LIVE-32910)** — *Study: move e2e CLI commands in-process to live-common* — **abandoned** (this PR is its outcome).
- **[LIVE-32911](https://ledgerhq.atlassian.net/browse/LIVE-32911)** — *Reboot* once the re-architecture lands (see below).

### 🔭 Future solution

The clean fix is **not** to make today's `lib-es` Node-loadable, but to consume the **new monorepo architecture** directly — the *Future* schema above (`e2e tests → /features, /entities, …`). Once the families and the account model live in their own properly-published packages, there is no live-common monolith with bundler-only ESM + runtime coin `import()`, so e2e can import them natively and the constraint disappears.

This depends on the broader re-architecture, to be solved first; once it lands, the e2e direct-usage approach should be revisited and is expected to work out of the box:

- **[LIVE-29793](https://ledgerhq.atlassian.net/browse/LIVE-29793)** — *[CORE Wallet] Ledger Wallet Foundations* (initiative — new monorepo architecture)
- **[LIVE-32095](https://ledgerhq.atlassian.net/browse/LIVE-32095)** — *Account – Monorepo Architecture* (denormalized account/operation slices + a legacy-bridge abstraction layer)
- **[LIVE-32690](https://ledgerhq.atlassian.net/browse/LIVE-32690)** — *Exploratory: Coin Modules Family Features* (extract `families/<name>/` into `@features/coin-family-*`, consumed directly by apps so live-common no longer compiles family-specific code)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32455](https://ledgerhq.atlassian.net/browse/LIVE-32455)
- **ADR link (if any)**: N/A


[LIVE-32455]: https://ledgerhq.atlassian.net/browse/LIVE-32455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[LIVE-32458]: https://ledgerhq.atlassian.net/browse/LIVE-32458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ