### PR TITLE
[LWDM] chore(llc): force `msg.value: 0` when swapping from Arc on Dex

### DIFF
--- a/.changeset/afraid-trainers-lick.md
+++ b/.changeset/afraid-trainers-lick.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+chore(llc): force `msg.value: 0` when swapping from Arc on Dex

--- a/libs/ledger-live-common/src/exchange/swap/completeExchange.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/completeExchange.test.ts
@@ -1,0 +1,21 @@
+import { shouldForceZeroAmountForDexSwap } from "./completeExchange";
+
+describe("shouldForceZeroAmountForDexSwap", () => {
+  const base = {
+    isDex: true,
+    family: "evm",
+    hasSubAccountId: false,
+    fromCurrencyId: "ethereum",
+  };
+
+  it.each([
+    ["EVM DEX swap from arc_testnet", { fromCurrencyId: "arc_testnet" }, true],
+    ["EVM DEX swap from arc", { fromCurrencyId: "arc" }, true],
+    ["EVM DEX swap from a token sub-account", { hasSubAccountId: true }, true],
+    ["provider is not a DEX", { isDex: false, fromCurrencyId: "arc_testnet" }, false],
+    ["family is not evm", { family: "bitcoin", fromCurrencyId: "arc" }, false],
+    ["non-Arc native coin without sub-account", {}, false],
+  ])("%s", (_case, params, expected) => {
+    expect(shouldForceZeroAmountForDexSwap({ ...base, ...params })).toBe(expected);
+  });
+});

--- a/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
+++ b/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
@@ -35,6 +35,23 @@ import { getCryptoCurrencyById } from "../../currencies";
 const COMPLETE_EXCHANGE_LOG = "SWAP-CompleteExchange";
 const LIFI_GAS_LIMIT_BUFFER_MULTIPLIER = 1.3;
 
+const ARC_CURRENCY_IDS = new Set(["arc", "arc_testnet"]);
+
+export function shouldForceZeroAmountForDexSwap({
+  isDex,
+  family,
+  hasSubAccountId,
+  fromCurrencyId,
+}: {
+  isDex: boolean;
+  family: string;
+  hasSubAccountId: boolean;
+  fromCurrencyId: string;
+}): boolean {
+  if (!isDex || family !== "evm") return false;
+  return hasSubAccountId || ARC_CURRENCY_IDS.has(fromCurrencyId);
+}
+
 const completeExchange = (
   input: CompleteExchangeInputSwap,
 ): Observable<CompleteExchangeRequestEvent> => {
@@ -107,7 +124,17 @@ const completeExchange = (
         // - This workaround can't be applied earlier in the flow as the amount is used for display purposes and checks.
         //   We must set the amount to 0 at this stage to avoid issues during the transaction.
         // - This ensures proper handling of Thorswap/LiFi ERC20-specific transactions.
-        if (isDex && transaction.subAccountId && transaction.family === "evm") {
+        // - Arc's native coin is itself spent through an ERC20 alias by the LiFi router, so the
+        //   swap calldata must also be sent with amount 0 even though it has no subAccountId.
+        // See https://ledgerhq.atlassian.net/browse/LIVE-32179
+        if (
+          shouldForceZeroAmountForDexSwap({
+            isDex,
+            family: transaction.family,
+            hasSubAccountId: Boolean(transaction.subAccountId),
+            fromCurrencyId: mainRefundCurrency.id,
+          })
+        ) {
           const transactionFixed = {
             ...transaction,
             subAccountId: undefined,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Swap on Dex

### 📝 Description

Fix Arc native-coin swaps failing fee estimation on the Exchange (completeExchange) path.

On Arc, the native coin (USDC) is spent through an ERC20 alias by the LiFi router, so the swap transaction must be sent with `value: 0`.
A workaround already exists when the source is a token sub-account. However Arc's source is the native coin, so it fell through and prepares a transaction with value = amount > 0. That value hits the non-payable `swapTokensMultipleV3ERC20ToERC20`, which reverted with empty data.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-32179
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
