### PR TITLE
[LWDM] fix(assets): display zero trend for zero-balance assets

### DIFF
--- a/.changeset/brave-links-glow.md
+++ b/.changeset/brave-links-glow.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-countervalues": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Fix zero-balance asset trend display

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/TrendCell/__tests__/useTrendCellViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/TrendCell/__tests__/useTrendCellViewModel.test.ts
@@ -30,11 +30,11 @@ describe("useTrendCellViewModel", () => {
     expect(result.current.colorClass).toBe("text-muted");
   });
 
-  it("should return 0.00% with success color for zero percentage", () => {
+  it("should return 0.00% with muted color for zero percentage", () => {
     const { result } = renderHook(() => useTrendCellViewModel(0));
 
     expect(result.current.formattedTrend).toBe("0.00%");
-    expect(result.current.colorClass).toBe("text-success");
+    expect(result.current.colorClass).toBe("text-muted");
   });
 
   it("should return '***' when discreet mode is enabled", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/TrendCell/useTrendCellViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/TrendCell/useTrendCellViewModel.ts
@@ -9,7 +9,12 @@ export function useTrendCellViewModel(trend: number | null | undefined) {
 
   const sign = trend > 0 ? "+" : "";
   const formattedTrend = discreet ? "***" : `${sign}${(trend * 100).toFixed(2)}%`;
-  const colorClass = trend === 0 ? "text-muted" : trend > 0 ? "text-success" : "text-error";
+  let colorClass = "text-error";
+  if (trend === 0) {
+    colorClass = "text-muted";
+  } else if (trend > 0) {
+    colorClass = "text-success";
+  }
 
   return { formattedTrend, colorClass };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/TrendCell/useTrendCellViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/TrendCell/useTrendCellViewModel.ts
@@ -9,7 +9,7 @@ export function useTrendCellViewModel(trend: number | null | undefined) {
 
   const sign = trend > 0 ? "+" : "";
   const formattedTrend = discreet ? "***" : `${sign}${(trend * 100).toFixed(2)}%`;
-  const colorClass = trend >= 0 ? "text-success" : "text-error";
+  const colorClass = trend === 0 ? "text-muted" : trend > 0 ? "text-success" : "text-error";
 
   return { formattedTrend, colorClass };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useAllCurrencyTrends.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useAllCurrencyTrends.test.ts
@@ -189,6 +189,31 @@ describe("useAllCurrencyTrends", () => {
     expect(result.current.get(BITCOIN_ASSET.currency.id)).toBe(3.21);
   });
 
+  it("should return zero trend for zero-value assets without using the balance fallback", () => {
+    const bitcoinAccount = genAccount("btc-zero-value-trend", {
+      currency: getCryptoCurrencyById("bitcoin"),
+    });
+
+    const { result } = renderHook(
+      () =>
+        useAllCurrencyTrends(
+          [
+            makeAssetItem({
+              accounts: [bitcoinAccount],
+              balance: 100,
+              value: 0,
+            }),
+          ],
+          "day",
+        ),
+      { initialState },
+    );
+
+    expect(mockedGetCurrencyPortfolio).not.toHaveBeenCalled();
+    expect(mockedGetCurrentBalanceCountervalueChange).not.toHaveBeenCalled();
+    expect(result.current.get(BITCOIN_ASSET.currency.id)).toBe(0);
+  });
+
   it("should not use the balance fallback when the portfolio change is available", () => {
     const bitcoinAccount = genAccount("btc-no-fallback-trend", {
       currency: getCryptoCurrencyById("bitcoin"),

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useAllCurrencyTrends.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useAllCurrencyTrends.ts
@@ -31,6 +31,10 @@ export function useAllCurrencyTrends(
         map.set(item.currency.id, null);
         continue;
       }
+      if (item.value <= 0) {
+        map.set(item.currency.id, 0);
+        continue;
+      }
       const accounts = item.accounts as AccountLike[];
       const portfolio = getCurrencyPortfolio(accounts, range, state, to);
       const trend =

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/AssetListItem.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/AssetListItem.test.tsx
@@ -83,6 +83,12 @@ describe("AssetListItem", () => {
       renderView({ countervalueChange: { percentage: 0.012, value: 12 } });
       expect(screen.getByText(/1\.20%/)).toBeVisible();
     });
+
+    it("should render 0.00% for a zero countervalue change", () => {
+      renderView({ countervalueChange: { percentage: 0, value: 0 } });
+      expect(screen.getByText(/0\.00%/)).toBeVisible();
+      expect(screen.queryByText(/1\.59%/)).toBeNull();
+    });
   });
 
   describe("market variant", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/usePrecomputedAssetListData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/usePrecomputedAssetListData.test.ts
@@ -210,7 +210,7 @@ describe("usePrecomputedAssetListData", () => {
   });
 
   describe("1D price fallback", () => {
-    it("uses the local price change for any held asset when the portfolio change is unavailable", () => {
+    it("uses the local price change for positive-balance assets when the portfolio change is unavailable", () => {
       const btcAccount = genAccount("btc-mkt", { currency: getCryptoCurrencyById("bitcoin") });
       mockedGetCurrencyPortfolio.mockReturnValue(makePortfolio(null));
       mockedGetCurrentBalanceChange.mockReturnValue({ value: 12, percentage: 0.012 });
@@ -227,6 +227,41 @@ describe("usePrecomputedAssetListData", () => {
       expect(result.current.get(bitcoin.id)?.countervalueChange).toEqual({
         value: 12,
         percentage: 0.012,
+      });
+    });
+
+    it("returns a zero change for zero-amount assets instead of using the local price change", () => {
+      const btcAccount = genAccount("btc-empty", { currency: getCryptoCurrencyById("bitcoin") });
+      mockedGetCurrencyPortfolio.mockReturnValue(makePortfolio(null));
+      mockedGetCurrentBalanceChange.mockReturnValue({ value: -12, percentage: -0.0159 });
+      const assets: Asset[] = [{ ...createCryptoAsset(bitcoin, 0), accounts: [btcAccount] }];
+
+      const { result } = renderHook(() => usePrecomputedAssetListData(assets));
+
+      expect(mockedGetCurrencyPortfolio).not.toHaveBeenCalled();
+      expect(mockedGetCurrentBalanceChange).not.toHaveBeenCalled();
+      expect(result.current.get(bitcoin.id)?.countervalueChange).toEqual({
+        value: 0,
+        percentage: 0,
+      });
+    });
+
+    it("returns a zero change for positive-amount assets with a zero countervalue", () => {
+      const btcAccount = genAccount("btc-zero-countervalue", {
+        currency: getCryptoCurrencyById("bitcoin"),
+      });
+      mockedCalculate.mockReturnValue(0);
+      mockedGetCurrencyPortfolio.mockReturnValue(makePortfolio(null));
+      mockedGetCurrentBalanceChange.mockReturnValue({ value: -12, percentage: -0.0159 });
+      const assets: Asset[] = [{ ...createCryptoAsset(bitcoin, 1), accounts: [btcAccount] }];
+
+      const { result } = renderHook(() => usePrecomputedAssetListData(assets));
+
+      expect(mockedGetCurrencyPortfolio).not.toHaveBeenCalled();
+      expect(mockedGetCurrentBalanceChange).not.toHaveBeenCalled();
+      expect(result.current.get(bitcoin.id)?.countervalueChange).toEqual({
+        value: 0,
+        percentage: 0,
       });
     });
 

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/components/AssetListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/components/AssetListItem.tsx
@@ -72,6 +72,7 @@ const PortfolioRow = memo(({ asset, onPress, precomputed, lx, hideNetwork }: Por
             <Delta
               valueChange={countervalueChange}
               percent
+              show0Delta
               fallbackToPercentPlaceholder
               isArrowDisplayed
             />

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/usePrecomputedAssetListData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/usePrecomputedAssetListData.ts
@@ -41,18 +41,14 @@ interface SharedState {
 
 type FmtOpts = { locale: string; showCode: boolean; discreet: boolean };
 
-function formatCounterValue(
+function getCounterValue(
   asset: Asset,
   balance: BigNumber,
   cvState: SharedState["cvState"],
   counterValueCurrency: SharedState["counterValueCurrency"],
-  fmtOpts: FmtOpts,
-): string | null {
-  const cvUnit = counterValueCurrency.units?.[0];
-  if (!cvUnit) return null;
-
+): number | null {
   if (asset.isPlaceholder) {
-    return formatPrice(cvUnit, new BigNumber(0), fmtOpts);
+    return 0;
   }
 
   const cv = calculate(cvState, {
@@ -63,11 +59,28 @@ function formatCounterValue(
   });
 
   if (typeof cv !== "number") return null;
-  return formatPrice(cvUnit, new BigNumber(cv), fmtOpts);
+  return cv;
 }
 
-function getCountervalueChange(asset: Asset, state: SharedState): ValueChange | null {
+function formatCounterValue(
+  counterValue: number | null,
+  counterValueCurrency: SharedState["counterValueCurrency"],
+  fmtOpts: FmtOpts,
+): string | null {
+  const cvUnit = counterValueCurrency.units?.[0];
+  if (!cvUnit || counterValue == null) return null;
+  return formatPrice(cvUnit, new BigNumber(counterValue), fmtOpts);
+}
+
+function getCountervalueChange(
+  asset: Asset,
+  state: SharedState,
+  currentCounterValue: number | null,
+): ValueChange | null {
   if (asset.isPlaceholder || asset.accounts.length === 0) return null;
+  if (asset.amount <= 0 || (currentCounterValue != null && currentCounterValue <= 0)) {
+    return { value: 0, percentage: 0 };
+  }
 
   const { countervalueChange } = getCurrencyPortfolio(
     asset.accounts,
@@ -96,14 +109,14 @@ function computeAssetItemData(asset: Asset, state: SharedState): AssetListItemVi
 
   const unit = asset.currency.units?.[0];
   const formattedBalance = unit ? formatCurrencyUnit(unit, balance, fmtOpts) : "";
-  const formattedCounterValue = formatCounterValue(
+  const counterValue = getCounterValue(
     asset,
     balance,
     state.cvState,
     state.counterValueCurrency,
-    fmtOpts,
   );
-  const countervalueChange = getCountervalueChange(asset, state);
+  const formattedCounterValue = formatCounterValue(counterValue, state.counterValueCurrency, fmtOpts);
+  const countervalueChange = getCountervalueChange(asset, state, counterValue);
 
   return { formattedBalance, formattedCounterValue, countervalueChange };
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/Delta/useDelta.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/Delta/useDelta.ts
@@ -3,12 +3,12 @@ import { PortfolioRange, ValueChange } from "@ledgerhq/types-live";
 import { useTranslation } from "~/context/Locale";
 
 type ColorType = "success" | "error" | "base";
-type SignType = "+" | "-";
+type SignType = "+" | "-" | "";
 
 const getColorAndSign = (value: number): readonly [ColorType, SignType] => {
   if (value > 0) return ["success", "+"] as const;
   if (value < 0) return ["error", "-"] as const;
-  return ["base", "-"] as const;
+  return ["base", ""] as const;
 };
 
 type UseDeltaParams = {
@@ -52,8 +52,6 @@ export const useDelta = ({
 
   const roundedDelta = Number.parseFloat(delta.toFixed(2));
 
-  if (roundedDelta === 0) return null;
-
   if (
     percent &&
     ((valueChange.percentage === 0 && !show0Delta) ||
@@ -64,6 +62,7 @@ export const useDelta = ({
   }
 
   if (Number.isNaN(delta)) return null;
+  if (roundedDelta === 0 && !show0Delta) return null;
 
   const [color, sign] = getColorAndSign(roundedDelta);
   const absDelta = Math.abs(delta);

--- a/libs/live-countervalues/src/portfolio.test.ts
+++ b/libs/live-countervalues/src/portfolio.test.ts
@@ -338,6 +338,20 @@ describe("Portfolio", () => {
       expect(change.percentage).toBe(0);
     });
 
+    it("returns a neutral change for a zero current balance even when rates are available", () => {
+      const account = genAccountBitcoin();
+      const zeroBalance = account.balance.minus(account.balance);
+      const emptyAccount = {
+        ...account,
+        balance: zeroBalance,
+        spendableBalance: zeroBalance,
+      };
+      const to = getFiatCurrencyByTicker("USD");
+      const state = stateWithRates({ now: 100, then: 80 });
+      const change = getCurrentBalanceCountervalueChange([emptyAccount], range, state, to);
+      expect(change).toEqual({ value: 0, percentage: null });
+    });
+
     it("returns a neutral change when the past rate is missing", () => {
       const account = genAccountBitcoin();
       const to = getFiatCurrencyByTicker("USD");

--- a/libs/live-countervalues/src/portfolio.ts
+++ b/libs/live-countervalues/src/portfolio.ts
@@ -382,8 +382,9 @@ export function getCurrentBalanceCountervalueChange(
   cvCurrency: Currency,
 ): ValueChange {
   if (accounts.length === 0) return { value: 0, percentage: null };
-  const currency = getAccountCurrency(accounts[0]);
   const balance = accounts.reduce((sum, a) => sum + a.balance.toNumber(), 0);
+  if (balance === 0) return { value: 0, percentage: null };
+  const currency = getAccountCurrency(accounts[0]);
   const dates = getDates(range, getPortfolioCount(accounts, range));
   const valueThen = calculate(cvState, {
     value: balance,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Zero-balance asset rows now show `0.00%` instead of a market trend.
  - Positive-balance assets still use the 1D price fallback when portfolio change is unavailable.
  - Desktop and Mobile asset trend behavior stays aligned.
  - The shared countervalues helper explicitly keeps zero current balances neutral.

### 📝 Description

This PR fixes a regression introduced after #18654 where an asset row displayed with a zero balance, such as `0 LINK` / `€0.00`, could still show the asset's 1D market movement, for example `-1.59%`.

The fix makes zero-balance rows explicit in the Desktop and Mobile asset trend view models: placeholders and accountless assets stay neutral, zero-balance real rows display `0.00%`, and positive-balance rows keep the portfolio-change-then-price-fallback behavior added in #18654. The shared `@ledgerhq/live-countervalues` helper now also explicitly returns a neutral change for zero aggregate current balances.

 
<img width="1264" height="661" alt="image" src="https://github.com/user-attachments/assets/e16eccdc-f6d8-4eee-8e04-2999ae7e94fc" />

### ❓ Context

- **JIRA or GitHub link**: #18654

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
