### PR TITLE
[LWM] fix(mobile): pluralize global search stocks label

### DIFF
--- a/.changeset/global-search-stocks-label.md
+++ b/.changeset/global-search-stocks-label.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix global search stocks placeholder wording

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1491,7 +1491,7 @@
     "searchPlaceholders": {
       "crypto": "Search crypto",
       "stablecoins": "Search stablecoins",
-      "stock": "Search stock",
+      "stock": "Search stocks",
       "addresses": "Search addresses"
     },
     "sections": {

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/__integrations__/globalSearch.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/__integrations__/globalSearch.integration.test.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { render, screen } from "@tests/test-renderer";
+import { render, screen, act } from "@tests/test-renderer";
 import { track } from "~/analytics";
 import { ScreenName } from "~/const";
 import { GlobalSearch } from "../screens/GlobalSearch";
+import { PLACEHOLDER_INTERVAL_MS } from "../screens/GlobalSearch/components/AnimatedSearchPlaceholder/useCyclingPlaceholder";
 import { GLOBAL_SEARCH_TEST_IDS } from "../screens/GlobalSearch/testIds";
 
 const mockGoBack = jest.fn();
@@ -25,6 +26,14 @@ describe("GlobalSearch screen", () => {
     expect(screen.getByLabelText(/search assets/i)).toBeVisible();
     expect(screen.getByTestId(GLOBAL_SEARCH_TEST_IDS.searchPlaceholder)).toBeVisible();
     expect(screen.getByText("Search crypto")).toBeOnTheScreen();
+  });
+
+  it("renders the stocks placeholder in plural", () => {
+    render(<GlobalSearch />);
+
+    act(() => jest.advanceTimersByTime(PLACEHOLDER_INTERVAL_MS * 2));
+
+    expect(screen.getByText("Search stocks")).toBeOnTheScreen();
   });
 
   it("tracks search_open on mount", () => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Targeted Global Search Jest coverage passes; full mobile typecheck is currently blocked by an unrelated `LineChartView.tsx` / `@ledgerhq/lumen-ui-rnative-visualization` `loading` prop mismatch on `develop`._
- [x] **Impact of the changes:**
      - Global Search animated placeholder wording on Ledger Wallet Mobile
      - English locale copy only

### 📝 Description

The Ledger Wallet Mobile Global Search animated placeholder displayed the stocks search label in singular form: `Search stock`.

This PR updates the English translation to `Search stocks` and adds an integration assertion that advances the animated placeholder until the stocks phrase is visible, preventing the copy from regressing.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32824](https://ledgerhq.atlassian.net/browse/LIVE-32824)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-32824]: https://ledgerhq.atlassian.net/browse/LIVE-32824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ