### PR TITLE
[LWM] test(mobile): add e2e coverage for wallet 4.0 asset discoverability

### DIFF
--- a/.changeset/slow-shoes-peel.md
+++ b/.changeset/slow-shoes-peel.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-mobile-e2e-tests": minor
+---
+
+Add mobile E2E coverage for Wallet 4.0 asset discoverability: stocks empty-discovery and holdings sections on the portfolio, and the global search categories and result ranking.

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/AnimatedSearchPlaceholder/__tests__/useCyclingPlaceholder.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/AnimatedSearchPlaceholder/__tests__/useCyclingPlaceholder.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, act } from "@tests/test-renderer";
+import Config from "react-native-config";
 import { useCyclingPlaceholder, PLACEHOLDER_INTERVAL_MS } from "../useCyclingPlaceholder";
 
 describe("useCyclingPlaceholder", () => {
@@ -9,6 +10,21 @@ describe("useCyclingPlaceholder", () => {
   afterEach(() => {
     jest.clearAllTimers();
     jest.useRealTimers();
+  });
+
+  it("does not cycle in Detox builds", () => {
+    const configMock = jest.replaceProperty(Config, "DETOX", "1");
+
+    try {
+      const { result } = renderHook(() => useCyclingPlaceholder(4, true));
+
+      expect(result.current.animate).toBe(false);
+
+      act(() => jest.advanceTimersByTime(PLACEHOLDER_INTERVAL_MS * 2));
+      expect(result.current.index).toBe(0);
+    } finally {
+      configMock.restore();
+    }
   });
 
   it("starts on the first phrase and animates when there are several phrases", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/AnimatedSearchPlaceholder/useCyclingPlaceholder.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/screens/GlobalSearch/components/AnimatedSearchPlaceholder/useCyclingPlaceholder.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useReducedMotion } from "react-native-reanimated";
+import Config from "react-native-config";
 
 export const PLACEHOLDER_INTERVAL_MS = 4000;
 
@@ -12,9 +13,10 @@ export const PLACEHOLDER_INTERVAL_MS = 4000;
  */
 export function useCyclingPlaceholder(length: number, enabled: boolean) {
   const reduceMotion = useReducedMotion();
+  const isDetox = Config.DETOX === "1";
   const [index, setIndex] = useState(0);
 
-  const animate = !reduceMotion && length > 1;
+  const animate = !reduceMotion && !isDetox && length > 1;
 
   useEffect(() => {
     if (!animate || !enabled) return;

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/SectionListContent/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/SectionListContent/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { Asset } from "~/types/asset";
 import AssetListItem from "LLM/components/AssetListItem";
 import { ListItemSkeleton } from "../ListItemSkeleton";
@@ -12,6 +13,11 @@ export type SectionListContentProps = {
   onItemPress: (asset: Asset) => void;
   skeletonCount: number;
   errorMessage: string;
+  /**
+   * Section-scoped prefix used to tag each rendered row with a `${rowTestIDPrefix}-item-${index}`
+   * testID, so e2e can count rows per section (the shared `assetItem-${name}` id can't be scoped).
+   */
+  rowTestIDPrefix?: string;
 };
 
 const NEGATIVE_MARGIN_OFFSET = { marginHorizontal: "-s8" } as const;
@@ -23,6 +29,7 @@ export const SectionListContent = ({
   onItemPress,
   skeletonCount,
   errorMessage,
+  rowTestIDPrefix,
 }: SectionListContentProps) => {
   const { precomputedData } = useSectionListContentViewModel(assetsToDisplay, isLoading || isError);
 
@@ -32,14 +39,18 @@ export const SectionListContent = ({
   if (isError) {
     return <SectionErrorState message={errorMessage} />;
   }
-  return assetsToDisplay.map(item => (
-    <AssetListItem
+  return assetsToDisplay.map((item, index) => (
+    <Box
       key={item.currency.id}
-      asset={item}
-      onPress={onItemPress}
-      precomputed={precomputedData.get(item.currency.id)!}
-      lx={NEGATIVE_MARGIN_OFFSET}
-      hideNetwork
-    />
+      testID={rowTestIDPrefix ? `${rowTestIDPrefix}-item-${index}` : undefined}
+    >
+      <AssetListItem
+        asset={item}
+        onPress={onItemPress}
+        precomputed={precomputedData.get(item.currency.id)!}
+        lx={NEGATIVE_MARGIN_OFFSET}
+        hideNetwork
+      />
+    </Box>
   ));
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/CryptosSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/CryptosSection/index.tsx
@@ -51,6 +51,7 @@ const PortfolioCryptosSectionComponent: React.FC<PortfolioCryptosSectionProps> =
           onItemPress={onItemPress}
           skeletonCount={EMPTY_STATE_MAX_ASSETS}
           errorMessage={t("portfolio.assetSection.connectionFailed")}
+          rowTestIDPrefix="PortfolioCryptosList"
         />
       </Box>
     </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StablecoinsSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StablecoinsSection/index.tsx
@@ -53,6 +53,7 @@ const PortfolioStablecoinsSectionComponent: React.FC<PortfolioStablecoinsSection
           onItemPress={onItemPress}
           skeletonCount={EMPTY_STATE_MAX_STABLECOINS}
           errorMessage={t("portfolio.assetSection.connectionFailed")}
+          rowTestIDPrefix="PortfolioStablecoinsList"
         />
       </Box>
     </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
@@ -52,6 +52,7 @@ const PortfolioStocksSectionComponent: React.FC<PortfolioStocksSectionProps> = (
           onItemPress={onItemPress}
           skeletonCount={EMPTY_STATE_MAX_STOCKS}
           errorMessage={t("portfolio.assetSection.connectionFailed")}
+          rowTestIDPrefix="PortfolioStocksList"
         />
       </Box>
     </Box>

--- a/e2e/mobile/helpers/elementHelpers.ts
+++ b/e2e/mobile/helpers/elementHelpers.ts
@@ -30,7 +30,7 @@ function hasMatcherProperty(obj: unknown): obj is WebElementWithMatcher {
 
 const scroller = new PageScroller();
 
-const DEFAULT_TIMEOUT = 60000;
+export const DEFAULT_TIMEOUT = 60000;
 const DEFAULT_WEB_ELEMENT_INTERVAL = 2000;
 
 export type WaitForElementOptions = {

--- a/e2e/mobile/page/index.ts
+++ b/e2e/mobile/page/index.ts
@@ -91,7 +91,7 @@ export class Application {
   private settingsHelpPageInstance = lazyInit(SettingsHelpPage);
   private readonly earnV2DashboardPageInstance = lazyInit(EarnV2DashboardPage);
   private modularDrawerPageInstance = lazyInit(ModularDrawer);
-  private topBarSearchPageInstance = lazyInit(TopBarSearchPage);
+  private readonly topBarSearchPageInstance = lazyInit(TopBarSearchPage);
 
   @Step("Account initialization")
   public async init(options: ApplicationOptions) {

--- a/e2e/mobile/page/index.ts
+++ b/e2e/mobile/page/index.ts
@@ -29,6 +29,7 @@ import WalletTabNavigatorPage from "./wallet/walletTabNavigator.page";
 import MainNavigationPage from "./wallet/mainNavigation.page";
 import MyWalletPage from "./wallet/myWallet.page";
 import OperationPage from "./wallet/operation.page";
+import TopBarSearchPage from "./wallet/topBarSearch.page";
 import CeloManageAssetsPage from "./trade/celoManageAssets.page";
 import TransferMenuDrawer from "./wallet/transferMenu.drawer";
 import BuySellPage from "./trade/buySell.page";
@@ -90,9 +91,11 @@ export class Application {
   private settingsHelpPageInstance = lazyInit(SettingsHelpPage);
   private readonly earnV2DashboardPageInstance = lazyInit(EarnV2DashboardPage);
   private modularDrawerPageInstance = lazyInit(ModularDrawer);
+  private topBarSearchPageInstance = lazyInit(TopBarSearchPage);
 
   @Step("Account initialization")
   public async init(options: ApplicationOptions) {
+    this.market.resetFlags();
     const userdataSpeculos = `temp-userdata-${randomUUID()}`;
     const userdataPath = getUserdataPath(userdataSpeculos);
     fs.copyFileSync(getUserdataPath(options.userdata || "skip-onboarding"), userdataPath);
@@ -241,5 +244,9 @@ export class Application {
 
   public get modularDrawer() {
     return this.modularDrawerPageInstance();
+  }
+
+  public get topBarSearch() {
+    return this.topBarSearchPageInstance();
   }
 }

--- a/e2e/mobile/page/market/market.page.ts
+++ b/e2e/mobile/page/market/market.page.ts
@@ -2,6 +2,7 @@ import { Step } from "jest-allure2-reporter/api";
 import { openDeeplink } from "../../helpers/commonHelpers";
 import { getFlags } from "../../bridge/server";
 import type { Features } from "@shared/feature-flags";
+import type { CurrencyType } from "@ledgerhq/live-common/e2e/enum/Currency";
 
 export default class MarketPage {
   marketRowTitleBaseId = "market-row-title-";
@@ -12,7 +13,8 @@ export default class MarketPage {
   starButton = () => getElementById("star-asset");
   backButtonId = "market-back-btn";
   assetDetailBackBtn = () => getElementById(this.backButtonId);
-  marketRowTitle = (ticker: string) => getElementById(`${this.marketRowTitleBaseId}${ticker}`);
+  marketRowTitle = (currency: CurrencyType) =>
+    getElementById(`${this.marketRowTitleBaseId}${currency.ticker}`);
   starMarketListButton = () => getElementById("toggle-starred-currencies");
   marketQuickActionButton = (action: "send" | "receive" | "buy" | "sell" | "swap") =>
     getElementById(`market-quick-action-button-${action}`);
@@ -22,31 +24,15 @@ export default class MarketPage {
   marketCategoryTabId = (value: string) => `${this.marketCategorySwitcherId}-${value}`;
   headerBackButtonId = "navigation-header-back-button";
 
-  // New (asset discoverability) MarketScreen / AssetDetail test ids — see
-  // apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/testIds.ts
-  // and apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
   marketScreenFilterButton = () => getElementById("market-screen-assets-filter-button");
   coinOptionsTrigger = () => getElementById("asset-detail-coin-options-trailing");
   coinOptionsFavouriteRow = () => getElementById("asset-detail-coin-options-favourite-row");
-  marketScreenRow = (ticker: string) =>
-    getElementById(`marketItem-${this.marketIdForTicker(ticker)}`);
-
-  // The new MarketScreen keys rows by ledger currency id, not ticker.
-  marketIdByTicker: Record<string, string> = {
-    BTC: "bitcoin",
-    ETH: "ethereum",
-    SOL: "solana",
-    XRP: "ripple",
-    ADA: "cardano",
-    DOT: "polkadot",
-  };
-
-  private marketIdForTicker(ticker: string): string {
-    return this.marketIdByTicker[ticker.toUpperCase()] ?? ticker.toLowerCase();
-  }
+  // The new MarketScreen keys rows by ledger currency id, the legacy list by ticker.
+  marketScreenRow = (currency: CurrencyType) => getElementById(`marketItem-${currency.id}`);
 
   private flags: Features["lwmWallet40"] | null = null;
 
+  @Step("Reset market feature flags cache")
   resetFlags(): void {
     this.flags = null;
   }
@@ -55,15 +41,13 @@ export default class MarketPage {
     this.flags ??= JSON.parse(await getFlags()).lwmWallet40;
   }
 
-  // Gates the new market list / categories / search screens.
   private async isAssetDiscoverabilityEnabled(): Promise<boolean> {
     await this.loadFlags();
     return !!this.flags?.enabled && !!this.flags?.params?.assetDiscoverability;
   }
 
-  // Gates the destination of a market row tap: the new MVVM AssetDetail screen
-  // (with coin-options) when on, the legacy MarketDetail screen when off. This is
-  // a different flag from `assetDiscoverability` (see useAssetDetailNavigation).
+  // Distinct from `assetDiscoverability`: gates the new MVVM AssetDetail (with
+  // coin-options) vs the legacy MarketDetail screen (see useAssetDetailNavigation).
   private async isAggregatedAssetsEnabled(): Promise<boolean> {
     await this.loadFlags();
     return !!this.flags?.enabled && !!this.flags?.params?.aggregatedAssets;
@@ -106,11 +90,11 @@ export default class MarketPage {
   }
 
   @Step("Open asset page")
-  async openAssetPage(ticker: string) {
+  async openAssetPage(currency: CurrencyType) {
     if (await this.isAssetDiscoverabilityEnabled()) {
-      await tapByElement(this.marketScreenRow(ticker));
+      await tapByElement(this.marketScreenRow(currency));
     } else {
-      await tapByElement(this.marketRowTitle(ticker));
+      await tapByElement(this.marketRowTitle(currency));
     }
   }
 
@@ -143,11 +127,11 @@ export default class MarketPage {
   }
 
   @Step("Expect market row title")
-  async expectMarketRowTitle(ticker: string) {
+  async expectMarketRowTitle(currency: CurrencyType) {
     if (await this.isAssetDiscoverabilityEnabled()) {
-      await detoxExpect(this.marketScreenRow(ticker)).toBeVisible();
+      await detoxExpect(this.marketScreenRow(currency)).toBeVisible();
     } else {
-      await detoxExpect(this.marketRowTitle(ticker)).toBeVisible();
+      await detoxExpect(this.marketRowTitle(currency)).toBeVisible();
     }
   }
 
@@ -173,7 +157,7 @@ export default class MarketPage {
     await detoxExpect(getElementById(this.marketCategoryTabId(value))).toBeVisible();
   }
 
-  @Step("Expect category tab $0 to be selected")
+  @Step("Expect category $0 to be selected")
   async expectCategorySelected(value: string) {
     await this.expectCategoryTabVisible(value);
   }

--- a/e2e/mobile/page/market/market.page.ts
+++ b/e2e/mobile/page/market/market.page.ts
@@ -1,5 +1,7 @@
 import { Step } from "jest-allure2-reporter/api";
 import { openDeeplink } from "../../helpers/commonHelpers";
+import { getFlags } from "../../bridge/server";
+import type { Features } from "@shared/feature-flags";
 
 export default class MarketPage {
   marketRowTitleBaseId = "market-row-title-";
@@ -16,6 +18,63 @@ export default class MarketPage {
     getElementById(`market-quick-action-button-${action}`);
   marketListHeaderLeft = () => getElementById("market-list-header-left");
 
+  marketCategorySwitcherId = "market-screen-assets-category-switcher";
+  marketCategoryTabId = (value: string) => `${this.marketCategorySwitcherId}-${value}`;
+  headerBackButtonId = "navigation-header-back-button";
+
+  // New (asset discoverability) MarketScreen / AssetDetail test ids — see
+  // apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/testIds.ts
+  // and apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
+  marketScreenFilterButton = () => getElementById("market-screen-assets-filter-button");
+  coinOptionsTrigger = () => getElementById("asset-detail-coin-options-trailing");
+  coinOptionsFavouriteRow = () => getElementById("asset-detail-coin-options-favourite-row");
+  marketScreenRow = (ticker: string) =>
+    getElementById(`marketItem-${this.marketIdForTicker(ticker)}`);
+
+  // The new MarketScreen keys rows by ledger currency id, not ticker.
+  marketIdByTicker: Record<string, string> = {
+    BTC: "bitcoin",
+    ETH: "ethereum",
+    SOL: "solana",
+    XRP: "ripple",
+    ADA: "cardano",
+    DOT: "polkadot",
+  };
+
+  private marketIdForTicker(ticker: string): string {
+    return this.marketIdByTicker[ticker.toUpperCase()] ?? ticker.toLowerCase();
+  }
+
+  private flags: Features["lwmWallet40"] | null = null;
+
+  resetFlags(): void {
+    this.flags = null;
+  }
+
+  private async loadFlags(): Promise<void> {
+    this.flags ??= JSON.parse(await getFlags()).lwmWallet40;
+  }
+
+  // Gates the new market list / categories / search screens.
+  private async isAssetDiscoverabilityEnabled(): Promise<boolean> {
+    await this.loadFlags();
+    return !!this.flags?.enabled && !!this.flags?.params?.assetDiscoverability;
+  }
+
+  // Gates the destination of a market row tap: the new MVVM AssetDetail screen
+  // (with coin-options) when on, the legacy MarketDetail screen when off. This is
+  // a different flag from `assetDiscoverability` (see useAssetDetailNavigation).
+  private async isAggregatedAssetsEnabled(): Promise<boolean> {
+    await this.loadFlags();
+    return !!this.flags?.enabled && !!this.flags?.params?.aggregatedAssets;
+  }
+
+  @Step("Go back from the market screen")
+  async goBack() {
+    await waitForElementById(this.headerBackButtonId);
+    await tapByIdAndExpectToDisappear(this.headerBackButtonId);
+  }
+
   @Step("Open market detail via deeplink")
   async openViaDeeplink(currencyId?: string) {
     await openDeeplink(currencyId ? `market/${currencyId}` : "market");
@@ -28,7 +87,11 @@ export default class MarketPage {
 
   @Step("Expect market list header left")
   async goBackToPortfolio() {
-    await tapByElement(this.marketListHeaderLeft());
+    if (await this.isAssetDiscoverabilityEnabled()) {
+      await this.goBack();
+    } else {
+      await tapByElement(this.marketListHeaderLeft());
+    }
   }
 
   @Step("Leave market detail page")
@@ -44,27 +107,48 @@ export default class MarketPage {
 
   @Step("Open asset page")
   async openAssetPage(ticker: string) {
-    await tapByElement(this.marketRowTitle(ticker));
+    if (await this.isAssetDiscoverabilityEnabled()) {
+      await tapByElement(this.marketScreenRow(ticker));
+    } else {
+      await tapByElement(this.marketRowTitle(ticker));
+    }
   }
 
   @Step("Star favorite coin")
   async starFavoriteCoin() {
-    await tapByElement(this.starButton());
+    if (await this.isAggregatedAssetsEnabled()) {
+      await tapByElement(this.coinOptionsTrigger());
+      await tapByElement(this.coinOptionsFavouriteRow());
+    } else {
+      await tapByElement(this.starButton());
+    }
   }
 
   @Step("Back to asset list")
   async backToAssetList() {
-    await tapByElement(this.assetDetailBackBtn());
+    if (await this.isAggregatedAssetsEnabled()) {
+      await this.goBack();
+    } else {
+      await tapByElement(this.assetDetailBackBtn());
+    }
   }
 
   @Step("Filter starred asset")
   async filterStaredAsset() {
-    await tapByElement(this.starMarketListButton());
+    if (await this.isAssetDiscoverabilityEnabled()) {
+      await tapById(this.marketCategoryTabId("starred"));
+    } else {
+      await tapByElement(this.starMarketListButton());
+    }
   }
 
   @Step("Expect market row title")
   async expectMarketRowTitle(ticker: string) {
-    await detoxExpect(this.marketRowTitle(ticker)).toBeVisible();
+    if (await this.isAssetDiscoverabilityEnabled()) {
+      await detoxExpect(this.marketScreenRow(ticker)).toBeVisible();
+    } else {
+      await detoxExpect(this.marketRowTitle(ticker)).toBeVisible();
+    }
   }
 
   @Step("Tap on market quick action button ")
@@ -74,8 +158,23 @@ export default class MarketPage {
 
   @Step("Expect filters visible")
   async expectFiltersVisible() {
-    await detoxExpect(this.marketFilterSortButton()).toBeVisible();
-    await detoxExpect(this.marketFilterTimeButton()).toBeVisible();
-    await detoxExpect(this.marketFilterCurrencyButton()).toBeVisible();
+    if (await this.isAssetDiscoverabilityEnabled()) {
+      await detoxExpect(this.marketScreenFilterButton()).toBeVisible();
+    } else {
+      await detoxExpect(this.marketFilterSortButton()).toBeVisible();
+      await detoxExpect(this.marketFilterTimeButton()).toBeVisible();
+      await detoxExpect(this.marketFilterCurrencyButton()).toBeVisible();
+    }
+  }
+
+  @Step("Expect category tab $0 to be visible")
+  async expectCategoryTabVisible(value: string) {
+    await waitForElementById(this.marketCategoryTabId(value));
+    await detoxExpect(getElementById(this.marketCategoryTabId(value))).toBeVisible();
+  }
+
+  @Step("Expect category tab $0 to be selected")
+  async expectCategorySelected(value: string) {
+    await this.expectCategoryTabVisible(value);
   }
 }

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -1,5 +1,6 @@
 import { Step } from "jest-allure2-reporter/api";
 import { isWallet40, openDeeplink } from "../../helpers/commonHelpers";
+import { DEFAULT_TIMEOUT } from "../../helpers/elementHelpers";
 export default class PortfolioPage {
   addNewOrExistingAccount = "add-new-account-button";
   assetsListId = "AssetsList";
@@ -63,6 +64,7 @@ export default class PortfolioPage {
   stocksSectionHeaderId = "portfolio-stocks-section-header";
   stocksDiscoveryId = "portfolio-stocks-discovery";
   stocksDiscoveryHeaderId = "portfolio-stocks-discovery-header";
+  sectionAssetItemRegExp = (sectionId: string) => new RegExp(String.raw`^${sectionId}-item-\d+$`);
 
   portfolioSettingsButton = async () => getElementById(this.portfolioSettingsId);
   assetItemId = (currencyName: string) => `${this.baseAssetItem}${currencyName}`;
@@ -444,18 +446,20 @@ export default class PortfolioPage {
     jestExpect(count).toBe(expected);
   }
 
-  @Step("Check asset item count within a section")
-  async checkSectionAssetItemCount(sectionId: string, expected: number) {
-    const count = await countElements(getElementsById(new RegExp(`^${sectionId}-item-\\d+$`)));
+  private async checkSectionAssetItemCount(sectionId: string, expected: number) {
+    const count = await countElementsById(this.sectionAssetItemRegExp(sectionId));
     jestExpect(count).toBe(expected);
+  }
+
+  @Step("Check cryptos section asset item count")
+  async checkCryptosSectionAssetItemCount(expected: number) {
+    await this.checkSectionAssetItemCount(this.portfolioCryptosListId, expected);
   }
 
   @Step("Tap first asset item (wallet 4.0) and return its currency name")
   async tapFirstAssetItemW40(): Promise<string> {
     const testId = await getIdByRegexp(this.assetItemRegExp, 0);
     const currencyName = testId.replace("assetItem-", "");
-    // The prior test may have scrolled to the bottom (e.g. add-account CTA), leaving the
-    // first asset row clipped and not hittable — scroll it back into view before tapping.
     await scrollToId(testId, this.emptyPortfolioListId);
     await tapById(testId);
     return currencyName;
@@ -498,37 +502,34 @@ export default class PortfolioPage {
     await scrollToId(this.portfolioBalanceNormal, this.accountsListView, 1000, "up");
   }
 
+  private async scrollToStocksHeader(headerId: string) {
+    await waitForElementById(headerId, DEFAULT_TIMEOUT, { checkVisibility: false });
+    await scrollToId(headerId, this.accountsListView);
+  }
+
   @Step("Check stocks discovery (empty) section is visible")
   async checkStocksDiscoverySectionVisible() {
-    // The stocks section only renders once the DADA stock-id fetch resolves, so
-    // wait for it to exist before scrolling to avoid scrolling a still-loading list.
-    await waitForElementById(this.stocksDiscoveryHeaderId, 60000, { checkVisibility: false });
-    await scrollToId(this.stocksDiscoveryHeaderId, this.accountsListView);
-    // The discovery container wraps horizontally-overflowing stock pills, so it never
-    // reaches the visibility threshold; assert on the header row (title + "Explore all").
+    await this.scrollToStocksHeader(this.stocksDiscoveryHeaderId);
     await detoxExpect(getElementById(this.stocksDiscoveryId)).toExist();
     await detoxExpect(getElementById(this.stocksDiscoveryHeaderId)).toBeVisible();
   }
 
   @Step("Tap 'Explore all' in the stocks discovery section")
   async tapStocksExploreAll() {
-    await waitForElementById(this.stocksDiscoveryHeaderId, 60000, { checkVisibility: false });
-    await scrollToId(this.stocksDiscoveryHeaderId, this.accountsListView);
+    await this.scrollToStocksHeader(this.stocksDiscoveryHeaderId);
     await tapById(this.stocksDiscoveryHeaderId);
   }
 
   @Step("Check stocks holdings section is visible")
   async checkStocksHoldingsSectionVisible() {
-    await waitForElementById(this.stocksSectionHeaderId, 60000, { checkVisibility: false });
-    await scrollToId(this.stocksSectionHeaderId, this.accountsListView);
+    await this.scrollToStocksHeader(this.stocksSectionHeaderId);
     await detoxExpect(getElementById(this.stocksSectionHeaderId)).toBeVisible();
     await detoxExpect(getElementById(this.portfolioStocksListId)).toExist();
   }
 
   @Step("Tap stocks section title")
   async tapStocksSectionTitle() {
-    await waitForElementById(this.stocksSectionHeaderId, 60000, { checkVisibility: false });
-    await scrollToId(this.stocksSectionHeaderId, this.accountsListView);
+    await this.scrollToStocksHeader(this.stocksSectionHeaderId);
     await tapById(this.stocksSectionHeaderId);
   }
 

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -58,6 +58,11 @@ export default class PortfolioPage {
   stablecoinListId = "StablecoinList";
   cryptosSectionHeaderId = "portfolio-cryptos-section-header";
   stablecoinsSectionHeaderId = "portfolio-stablecoins-section-header";
+  portfolioStocksListId = "PortfolioStocksList";
+  stocksListId = "StocksList";
+  stocksSectionHeaderId = "portfolio-stocks-section-header";
+  stocksDiscoveryId = "portfolio-stocks-discovery";
+  stocksDiscoveryHeaderId = "portfolio-stocks-discovery-header";
 
   portfolioSettingsButton = async () => getElementById(this.portfolioSettingsId);
   assetItemId = (currencyName: string) => `${this.baseAssetItem}${currencyName}`;
@@ -439,11 +444,20 @@ export default class PortfolioPage {
     jestExpect(count).toBe(expected);
   }
 
+  @Step("Check asset item count within a section")
+  async checkSectionAssetItemCount(sectionId: string, expected: number) {
+    const count = await countElements(getElementsById(new RegExp(`^${sectionId}-item-\\d+$`)));
+    jestExpect(count).toBe(expected);
+  }
+
   @Step("Tap first asset item (wallet 4.0) and return its currency name")
   async tapFirstAssetItemW40(): Promise<string> {
     const testId = await getIdByRegexp(this.assetItemRegExp, 0);
     const currencyName = testId.replace("assetItem-", "");
-    await tapByElement(getElementById(this.assetItemRegExp, 0));
+    // The prior test may have scrolled to the bottom (e.g. add-account CTA), leaving the
+    // first asset row clipped and not hittable — scroll it back into view before tapping.
+    await scrollToId(testId, this.emptyPortfolioListId);
+    await tapById(testId);
     return currencyName;
   }
 
@@ -482,5 +496,44 @@ export default class PortfolioPage {
   @Step("Scroll to the top of the portfolio page")
   async scrollToTopOfPortfolioPage() {
     await scrollToId(this.portfolioBalanceNormal, this.accountsListView, 1000, "up");
+  }
+
+  @Step("Check stocks discovery (empty) section is visible")
+  async checkStocksDiscoverySectionVisible() {
+    // The stocks section only renders once the DADA stock-id fetch resolves, so
+    // wait for it to exist before scrolling to avoid scrolling a still-loading list.
+    await waitForElementById(this.stocksDiscoveryHeaderId, 60000, { checkVisibility: false });
+    await scrollToId(this.stocksDiscoveryHeaderId, this.accountsListView);
+    // The discovery container wraps horizontally-overflowing stock pills, so it never
+    // reaches the visibility threshold; assert on the header row (title + "Explore all").
+    await detoxExpect(getElementById(this.stocksDiscoveryId)).toExist();
+    await detoxExpect(getElementById(this.stocksDiscoveryHeaderId)).toBeVisible();
+  }
+
+  @Step("Tap 'Explore all' in the stocks discovery section")
+  async tapStocksExploreAll() {
+    await waitForElementById(this.stocksDiscoveryHeaderId, 60000, { checkVisibility: false });
+    await scrollToId(this.stocksDiscoveryHeaderId, this.accountsListView);
+    await tapById(this.stocksDiscoveryHeaderId);
+  }
+
+  @Step("Check stocks holdings section is visible")
+  async checkStocksHoldingsSectionVisible() {
+    await waitForElementById(this.stocksSectionHeaderId, 60000, { checkVisibility: false });
+    await scrollToId(this.stocksSectionHeaderId, this.accountsListView);
+    await detoxExpect(getElementById(this.stocksSectionHeaderId)).toBeVisible();
+    await detoxExpect(getElementById(this.portfolioStocksListId)).toExist();
+  }
+
+  @Step("Tap stocks section title")
+  async tapStocksSectionTitle() {
+    await waitForElementById(this.stocksSectionHeaderId, 60000, { checkVisibility: false });
+    await scrollToId(this.stocksSectionHeaderId, this.accountsListView);
+    await tapById(this.stocksSectionHeaderId);
+  }
+
+  @Step("Check full stocks list page is visible")
+  async checkStocksListPageVisible() {
+    await this.checkListPageVisible(this.stocksListId);
   }
 }

--- a/e2e/mobile/page/wallet/topBarSearch.page.ts
+++ b/e2e/mobile/page/wallet/topBarSearch.page.ts
@@ -1,0 +1,63 @@
+import { Step } from "jest-allure2-reporter/api";
+
+export default class TopBarSearchPage {
+  topBarSearchButtonId = "topbar-search";
+  screenId = "global-search-screen";
+  searchInputId = "global-search-input";
+  defaultSectionsId = "global-search-default-sections";
+  cryptosSectionId = "global-search-cryptos-section";
+  cryptosSectionHeaderId = "global-search-cryptos-section-header";
+  stocksSectionId = "global-search-stocks-section";
+  stocksSectionHeaderId = "global-search-stocks-section-header";
+  searchResultsId = "global-search-results";
+  marketItemId = (currencyId: string) => `marketItem-${currencyId}`;
+
+  @Step("Open the global search screen from the portfolio top bar")
+  async open() {
+    await waitForElementById(this.topBarSearchButtonId);
+    await tapById(this.topBarSearchButtonId);
+    await waitForElementById(this.screenId);
+    await waitForElementById(this.defaultSectionsId);
+  }
+
+  @Step("Expect Cryptos and Stocks categories to be visible")
+  async expectCategoriesVisible() {
+    // Wait for the section to render before asserting: with synchronization disabled
+    // (animated screens), one-shot matchers can run mid-transition (e.g. right after
+    // navigating back from the market). Cryptos is at the top of the scroll view; the
+    // Stocks section sits below the fold (and under the keyboard), so only assert it exists.
+    await waitForElementById(this.cryptosSectionId);
+    await detoxExpect(getElementById(this.stocksSectionId)).toExist();
+  }
+
+  @Step("Select the Cryptos category")
+  async selectCryptosCategory() {
+    await tapById(this.cryptosSectionHeaderId);
+  }
+
+  @Step("Select the Stocks category")
+  async selectStocksCategory() {
+    await waitForElementById(this.defaultSectionsId);
+    await scrollToId(this.stocksSectionHeaderId, this.defaultSectionsId);
+    await tapById(this.stocksSectionHeaderId);
+  }
+
+  @Step("Search for $0")
+  async searchFor(query: string) {
+    await typeTextById(this.searchInputId, query, false);
+    // The results FlatList is largely covered by the open keyboard, so it never reaches
+    // the visibility threshold; assert it exists and let expectFirstResult check the row.
+    await waitForElementById(this.searchResultsId, 60000, { checkVisibility: false });
+  }
+
+  @Step("Clear the search field")
+  async clearSearch() {
+    await clearTextByElement(getElementById(this.searchInputId));
+  }
+
+  @Step("Expect first search result to be $0")
+  async expectFirstResult(currencyId: string) {
+    await waitForElementById(this.marketItemId(currencyId));
+    await detoxExpect(getElementById(this.marketItemId(currencyId))).toBeVisible();
+  }
+}

--- a/e2e/mobile/page/wallet/topBarSearch.page.ts
+++ b/e2e/mobile/page/wallet/topBarSearch.page.ts
@@ -1,31 +1,36 @@
 import { Step } from "jest-allure2-reporter/api";
+import { retryUntilTimeout } from "../../utils/retry";
 
 export default class TopBarSearchPage {
-  topBarSearchButtonId = "topbar-search";
-  screenId = "global-search-screen";
-  searchInputId = "global-search-input";
-  defaultSectionsId = "global-search-default-sections";
-  cryptosSectionId = "global-search-cryptos-section";
-  cryptosSectionHeaderId = "global-search-cryptos-section-header";
-  stocksSectionId = "global-search-stocks-section";
-  stocksSectionHeaderId = "global-search-stocks-section-header";
-  searchResultsId = "global-search-results";
-  marketItemId = (currencyId: string) => `marketItem-${currencyId}`;
+  private readonly topBarSearchButtonId = "topbar-search";
+  private readonly screenId = "global-search-screen";
+  private readonly searchInputId = "global-search-input";
+  private readonly defaultSectionsId = "global-search-default-sections";
+  private readonly defaultsErrorId = "global-search-defaults-error-state";
+  private readonly cryptosSectionId = "global-search-cryptos-section";
+  private readonly cryptosSectionHeaderId = "global-search-cryptos-section-header";
+  private readonly stocksSectionId = "global-search-stocks-section";
+  private readonly stocksSectionHeaderId = "global-search-stocks-section-header";
+  private readonly searchResultsId = "global-search-results";
+  private readonly marketItemId = (currencyId: string) => `marketItem-${currencyId}`;
+  private readonly marketResultRegExp = /^marketItem-.+$/;
 
   @Step("Open the global search screen from the portfolio top bar")
   async open() {
     await waitForElementById(this.topBarSearchButtonId);
-    await tapById(this.topBarSearchButtonId);
-    await waitForElementById(this.screenId);
-    await waitForElementById(this.defaultSectionsId);
+    await retryUntilTimeout(async () => {
+      if (await IsIdPresent(this.screenId)) return;
+      await tapById(this.topBarSearchButtonId);
+      await waitForElementById(this.screenId, 5000, { checkVisibility: false });
+    });
+    await waitForElementById(this.defaultSectionsId, undefined, {
+      errorElementId: this.defaultsErrorId,
+      checkVisibility: false,
+    });
   }
 
   @Step("Expect Cryptos and Stocks categories to be visible")
   async expectCategoriesVisible() {
-    // Wait for the section to render before asserting: with synchronization disabled
-    // (animated screens), one-shot matchers can run mid-transition (e.g. right after
-    // navigating back from the market). Cryptos is at the top of the scroll view; the
-    // Stocks section sits below the fold (and under the keyboard), so only assert it exists.
     await waitForElementById(this.cryptosSectionId);
     await detoxExpect(getElementById(this.stocksSectionId)).toExist();
   }
@@ -37,7 +42,9 @@ export default class TopBarSearchPage {
 
   @Step("Select the Stocks category")
   async selectStocksCategory() {
-    await waitForElementById(this.defaultSectionsId);
+    await waitForElementById(this.defaultSectionsId, undefined, {
+      checkVisibility: false,
+    });
     await scrollToId(this.stocksSectionHeaderId, this.defaultSectionsId);
     await tapById(this.stocksSectionHeaderId);
   }
@@ -45,9 +52,9 @@ export default class TopBarSearchPage {
   @Step("Search for $0")
   async searchFor(query: string) {
     await typeTextById(this.searchInputId, query, false);
-    // The results FlatList is largely covered by the open keyboard, so it never reaches
-    // the visibility threshold; assert it exists and let expectFirstResult check the row.
-    await waitForElementById(this.searchResultsId, 60000, { checkVisibility: false });
+    await waitForElementById(this.searchResultsId, 60000, {
+      checkVisibility: false,
+    });
   }
 
   @Step("Clear the search field")
@@ -57,7 +64,9 @@ export default class TopBarSearchPage {
 
   @Step("Expect first search result to be $0")
   async expectFirstResult(currencyId: string) {
-    await waitForElementById(this.marketItemId(currencyId));
-    await detoxExpect(getElementById(this.marketItemId(currencyId))).toBeVisible();
+    const expectedId = this.marketItemId(currencyId);
+    await waitForElementById(expectedId, undefined, { checkVisibility: false });
+    const firstResultId = await getIdByRegexp(this.marketResultRegExp, 0);
+    jestExpect(firstResultId).toBe(expectedId);
   }
 }

--- a/e2e/mobile/specs/buySell/buySell.ts
+++ b/e2e/mobile/specs/buySell/buySell.ts
@@ -106,8 +106,8 @@ export async function runNavigateToBuyFromMarketPageTest(
         await app.portfolio.tapWalletTabSelector("Market");
       }
       await app.market.searchAsset(buySell.crypto.currency.ticker);
-      await app.market.expectMarketRowTitle(buySell.crypto.currency.ticker);
-      await app.market.openAssetPage(buySell.crypto.currency.ticker);
+      await app.market.expectMarketRowTitle(buySell.crypto.currency);
+      await app.market.openAssetPage(buySell.crypto.currency);
       await app.market.tapOnMarketQuickActionButton("buy");
       await app.buySell.handleBuyFlow(buySell, paymentMethod);
     });

--- a/e2e/mobile/specs/market.spec.ts
+++ b/e2e/mobile/specs/market.spec.ts
@@ -13,7 +13,7 @@ const tags: string[] = [
 ];
 describe("Market page for user with no device", () => {
   const nanoApp = AppInfos.ETHEREUM;
-  const ticker = "ETH";
+  const currency = Currency.ETH;
 
   beforeAll(async () => {
     await app.init({
@@ -37,12 +37,12 @@ describe("Market page for user with no device", () => {
   tags.forEach(tag => $Tag(tag));
   it("should filter starred asset in the list", async () => {
     await app.walletTabNavigator.navigateToMarket();
-    await app.market.searchAsset(ticker);
-    await app.market.expectMarketRowTitle(ticker);
-    await app.market.openAssetPage(ticker);
+    await app.market.searchAsset(currency.ticker);
+    await app.market.expectMarketRowTitle(currency);
+    await app.market.openAssetPage(currency);
     await app.market.starFavoriteCoin();
     await app.market.backToAssetList();
     await app.market.filterStaredAsset();
-    await app.market.expectMarketRowTitle(ticker);
+    await app.market.expectMarketRowTitle(currency);
   });
 });

--- a/e2e/mobile/specs/wallet40/assetDiscoverability.spec.ts
+++ b/e2e/mobile/specs/wallet40/assetDiscoverability.spec.ts
@@ -1,0 +1,125 @@
+import { WALLET_40_FEATURE_FLAGS } from "../../utils/constants";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
+
+const TAGS = ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"];
+
+// Asset discoverability is enabled in the shared Wallet 4.0 flags; we still set it
+// explicitly here so this suite stays self-describing about the flag it relies on.
+const ASSET_DISCOVERABILITY_FEATURE_FLAGS = {
+  lwmWallet40: {
+    ...WALLET_40_FEATURE_FLAGS.lwmWallet40,
+    params: {
+      ...WALLET_40_FEATURE_FLAGS.lwmWallet40.params,
+      assetDiscoverability: true,
+    },
+  },
+};
+
+// The Wallet 4.0 market & global-search screens run continuous animations, so Detox
+// never reaches idle (iOS) and matchers time out. Disable synchronization once for the
+// whole suite (same approach as the swap specs).
+beforeAll(async () => {
+  await app.common.disableSynchronizationForiOS();
+});
+
+afterEach(async () => {
+  await app.portfolio.openViaDeeplink();
+});
+
+setTeamOwner(Team.WALLET_XP);
+describe("Asset discoverability - Stocks empty discovery state", () => {
+  beforeAll(async () => {
+    await app.init({
+      userdata: "1AccountBTC1AccountETHReadOnlyFalse",
+      featureFlags: ASSET_DISCOVERABILITY_FEATURE_FLAGS,
+    });
+    await app.portfolio.waitForPortfolioPageToLoad();
+  });
+
+  $TmsLink("B2CQA-5955");
+  TAGS.forEach(tag => $Tag(tag));
+
+  it("should explore the stocks market from the empty stocks category", async () => {
+    await app.portfolio.checkStocksDiscoverySectionVisible();
+
+    await app.portfolio.tapStocksExploreAll();
+
+    await app.market.expectCategorySelected("stocks");
+  });
+});
+
+setTeamOwner(Team.WALLET_XP);
+describe("Asset discoverability - Stocks holdings", () => {
+  beforeAll(async () => {
+    await app.init({
+      userdata: "skip-onboarding-with-last-seen-device",
+      speculosApp: Account.ETH_1.currency.speculosApp,
+      cliCommands: [liveDataCommand(Account.ETH_1)],
+      featureFlags: ASSET_DISCOVERABILITY_FEATURE_FLAGS,
+    });
+    await app.portfolio.waitForPortfolioPageToLoad();
+  });
+
+  $TmsLink("B2CQA-5956");
+  TAGS.forEach(tag => $Tag(tag));
+
+  it("should open the stocks assets page from the stocks category title", async () => {
+    await app.portfolio.checkStocksHoldingsSectionVisible();
+
+    await app.portfolio.tapStocksSectionTitle();
+
+    await app.portfolio.checkStocksListPageVisible();
+  });
+});
+
+setTeamOwner(Team.WALLET_XP);
+describe("Asset discoverability - Global search categories", () => {
+  beforeAll(async () => {
+    await app.init({
+      userdata: "skip-onboarding-with-last-seen-device",
+      featureFlags: ASSET_DISCOVERABILITY_FEATURE_FLAGS,
+    });
+    await app.portfolio.waitForPortfolioPageToLoad();
+  });
+
+  $TmsLink("B2CQA-5957");
+  TAGS.forEach(tag => $Tag(tag));
+
+  it("should navigate to the markets from the search categories", async () => {
+    await app.topBarSearch.open();
+    await app.topBarSearch.expectCategoriesVisible();
+    await app.topBarSearch.selectCryptosCategory();
+    await app.market.expectCategorySelected("all");
+
+    await app.market.goBack();
+    await app.topBarSearch.expectCategoriesVisible();
+    await app.topBarSearch.selectStocksCategory();
+    await app.market.expectCategorySelected("stocks");
+  });
+});
+
+setTeamOwner(Team.WALLET_XP);
+describe("Asset discoverability - Global search ranking", () => {
+  beforeAll(async () => {
+    await app.init({
+      userdata: "skip-onboarding-with-last-seen-device",
+      featureFlags: ASSET_DISCOVERABILITY_FEATURE_FLAGS,
+    });
+    await app.portfolio.waitForPortfolioPageToLoad();
+  });
+
+  $TmsLink("B2CQA-5958");
+  TAGS.forEach(tag => $Tag(tag));
+
+  it("should match the typed ticker to the top search result", async () => {
+    await app.topBarSearch.open();
+
+    await app.topBarSearch.searchFor("btc");
+    await app.topBarSearch.expectFirstResult("bitcoin");
+
+    await app.topBarSearch.clearSearch();
+    await app.topBarSearch.searchFor("eth");
+    await app.topBarSearch.expectFirstResult("ethereum");
+  });
+});

--- a/e2e/mobile/specs/wallet40/assetDiscoverability.spec.ts
+++ b/e2e/mobile/specs/wallet40/assetDiscoverability.spec.ts
@@ -28,7 +28,7 @@ afterEach(async () => {
 });
 
 setTeamOwner(Team.WALLET_XP);
-describe("Asset discoverability - Stocks empty discovery state", () => {
+describe("Wallet 4.0 - Asset discoverability - Stocks empty discovery state", () => {
   beforeAll(async () => {
     await app.init({
       userdata: "1AccountBTC1AccountETHReadOnlyFalse",
@@ -50,7 +50,7 @@ describe("Asset discoverability - Stocks empty discovery state", () => {
 });
 
 setTeamOwner(Team.WALLET_XP);
-describe("Asset discoverability - Stocks holdings", () => {
+describe("Wallet 4.0 - Asset discoverability - Stocks holdings", () => {
   beforeAll(async () => {
     await app.init({
       userdata: "skip-onboarding-with-last-seen-device",
@@ -74,7 +74,7 @@ describe("Asset discoverability - Stocks holdings", () => {
 });
 
 setTeamOwner(Team.WALLET_XP);
-describe("Asset discoverability - Global search categories", () => {
+describe("Wallet 4.0 - Asset discoverability - Global search categories", () => {
   beforeAll(async () => {
     await app.init({
       userdata: "skip-onboarding-with-last-seen-device",
@@ -100,7 +100,7 @@ describe("Asset discoverability - Global search categories", () => {
 });
 
 setTeamOwner(Team.WALLET_XP);
-describe("Asset discoverability - Global search ranking", () => {
+describe("Wallet 4.0 - Asset discoverability - Global search ranking", () => {
   beforeAll(async () => {
     await app.init({
       userdata: "skip-onboarding-with-last-seen-device",
@@ -115,11 +115,11 @@ describe("Asset discoverability - Global search ranking", () => {
   it("should match the typed ticker to the top search result", async () => {
     await app.topBarSearch.open();
 
-    await app.topBarSearch.searchFor("btc");
-    await app.topBarSearch.expectFirstResult("bitcoin");
+    await app.topBarSearch.searchFor(Currency.BTC.ticker.toLowerCase());
+    await app.topBarSearch.expectFirstResult(Currency.BTC.id);
 
     await app.topBarSearch.clearSearch();
-    await app.topBarSearch.searchFor("eth");
-    await app.topBarSearch.expectFirstResult("ethereum");
+    await app.topBarSearch.searchFor(Currency.ETH.ticker.toLowerCase());
+    await app.topBarSearch.expectFirstResult(Currency.ETH.id);
   });
 });

--- a/e2e/mobile/specs/wallet40/marketBanner.spec.ts
+++ b/e2e/mobile/specs/wallet40/marketBanner.spec.ts
@@ -16,7 +16,7 @@ const testConfig = {
   tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
 };
 
-const TICKER = "BTC";
+const CURRENCY = Currency.BTC;
 
 setTeamOwner(Team.WALLET_XP);
 describe("Wallet 4.0 - Market Banner", () => {
@@ -46,20 +46,20 @@ describe("Wallet 4.0 - Market Banner", () => {
 
     await app.portfolio.expectMarketBannerVisible();
     await app.portfolio.tapMarketBannerTitle();
-    await app.market.expectMarketRowTitle(TICKER);
+    await app.market.expectMarketRowTitle(CURRENCY);
     await app.market.goBackToPortfolio();
 
     await app.portfolio.expectMarketBannerVisible();
     await app.portfolio.swipeMarketBannerToViewAll();
     await app.portfolio.tapMarketBannerViewAll();
-    await app.market.expectMarketRowTitle(TICKER);
+    await app.market.expectMarketRowTitle(CURRENCY);
 
     await app.market.expectFiltersVisible();
 
-    await app.market.openAssetPage(TICKER);
+    await app.market.openAssetPage(CURRENCY);
     await app.market.starFavoriteCoin();
     await app.market.backToAssetList();
     await app.market.filterStaredAsset();
-    await app.market.expectMarketRowTitle(TICKER);
+    await app.market.expectMarketRowTitle(CURRENCY);
   });
 });

--- a/e2e/mobile/specs/wallet40/walletAssets.spec.ts
+++ b/e2e/mobile/specs/wallet40/walletAssets.spec.ts
@@ -77,7 +77,7 @@ describe("Wallet 4.0 - Portfolio-Asset/Address - Open the app with accounts", ()
   it("should cap cryptos at 6, show only cryptos when clicking section title, and list all 6 crypto assets", async () => {
     await app.portfolio.scrollToTopOfPortfolioPage();
     await app.portfolio.checkCryptosListSectionVisible();
-    await app.portfolio.checkSectionAssetItemCount(app.portfolio.portfolioCryptosListId, 6);
+    await app.portfolio.checkCryptosSectionAssetItemCount(6);
     await app.portfolio.checkAssetVisible("Ethereum");
     await app.portfolio.checkAssetVisible("Bitcoin");
     await app.portfolio.tapCryptosSectionTitle();

--- a/e2e/mobile/specs/wallet40/walletAssets.spec.ts
+++ b/e2e/mobile/specs/wallet40/walletAssets.spec.ts
@@ -77,7 +77,7 @@ describe("Wallet 4.0 - Portfolio-Asset/Address - Open the app with accounts", ()
   it("should cap cryptos at 6, show only cryptos when clicking section title, and list all 6 crypto assets", async () => {
     await app.portfolio.scrollToTopOfPortfolioPage();
     await app.portfolio.checkCryptosListSectionVisible();
-    await app.portfolio.checkTotalAssetItemCount(12);
+    await app.portfolio.checkSectionAssetItemCount(app.portfolio.portfolioCryptosListId, 6);
     await app.portfolio.checkAssetVisible("Ethereum");
     await app.portfolio.checkAssetVisible("Bitcoin");
     await app.portfolio.tapCryptosSectionTitle();

--- a/e2e/mobile/utils/constants.ts
+++ b/e2e/mobile/utils/constants.ts
@@ -17,7 +17,7 @@ export const WALLET_40_FEATURE_FLAGS = {
       aggregatedAssets: false,
       myWallet: true,
       pnl: false,
-      assetDiscoverability: true,
+      assetDiscoverability: false,
     },
   },
 } as const;

--- a/e2e/mobile/utils/constants.ts
+++ b/e2e/mobile/utils/constants.ts
@@ -17,7 +17,7 @@ export const WALLET_40_FEATURE_FLAGS = {
       aggregatedAssets: false,
       myWallet: true,
       pnl: false,
-      assetDiscoverability: false,
+      assetDiscoverability: true,
     },
   },
 } as const;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _This PR is the automated coverage: it adds Detox E2E specs for the Wallet 4.0 asset discoverability feature._
- [x] **Impact of the changes:**
  - Wallet 4.0 portfolio: stocks empty-discovery section ("Explore all" → market stocks category) and stocks holdings section (title → full stocks list page)
  - Global search: Cryptos/Stocks categories navigate to the correct market category, and typed-ticker result ranking (btc → bitcoin, eth → ethereum)
  - `assetDiscoverability` is now enabled by default in the shared `WALLET_40_FEATURE_FLAGS` e2e constant — verify other wallet40 specs are unaffected

### 📝 Description

Wallet 4.0 introduces the "asset discoverability" experience (stocks discovery/holdings sections on the portfolio and category-aware global search), but it had no end-to-end coverage.

This PR adds Detox E2E specs under `e2e/mobile/specs/wallet40/assetDiscoverability.spec.ts`, with supporting page objects:

- New `TopBarSearchPage` for the global search screen (categories, search input, results).
- `MarketPage` helpers to assert the selected market category and to go back.
- `PortfolioPage` helpers for the stocks discovery/holdings sections and the full stocks list page.
- New `portfolioWithManyStocks` userdata fixture for the holdings scenario.

The shared `WALLET_40_FEATURE_FLAGS` constant now enables `assetDiscoverability` by default; the suite also sets it explicitly so it stays self-describing about the flag it relies on. Synchronization is disabled for the suite because the Wallet 4.0 market & global-search screens run continuous animations (Detox never reaches idle on iOS).

Scenarios (TMS): `B2CQA-5955` (empty stocks discovery), `B2CQA-5956` (stocks holdings), `B2CQA-5957` (search categories), `B2CQA-5958` (search ranking).

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-32760
- e2e mobile run => https://github.com/LedgerHQ/ledger-live/actions/runs/28222643047

- e2e 2 : https://github.com/LedgerHQ/ledger-live/actions/runs/28356168992

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32761]: https://ledgerhq.atlassian.net/browse/LIVE-32761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ