### PR TITLE
[LWD] feat(desktop): animate global search placeholder title

### DIFF
--- a/.changeset/lwd-animated-search-title.md
+++ b/.changeset/lwd-animated-search-title.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Animate the global search placeholder title: the top-bar search field now cycles its placeholder through "Search crypto / stablecoins / stock / addresses" with a parallel slide-out/slide-in transition. Cycling freezes while the search overlay is open, respects `prefers-reduced-motion`, and is gated behind the asset-discoverability feature flag.

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/AnimatedSearchPlaceholder/__tests__/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/AnimatedSearchPlaceholder/__tests__/index.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { render, screen, act } from "tests/testSetup";
+import { AnimatedSearchPlaceholder } from "..";
+import { PLACEHOLDER_INTERVAL_MS } from "../useCyclingPlaceholder";
+
+describe("AnimatedSearchPlaceholder", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("shows the first phrase at rest", () => {
+    render(<AnimatedSearchPlaceholder visible cycling testId="ph" />);
+
+    expect(screen.getByText("Search crypto")).toBeInTheDocument();
+    expect(screen.queryByText("Search stablecoins")).not.toBeInTheDocument();
+  });
+
+  it("keeps the outgoing phrase mounted while the next one slides in (no blink)", () => {
+    render(<AnimatedSearchPlaceholder visible cycling testId="ph" />);
+
+    act(() => {
+      jest.advanceTimersByTime(PLACEHOLDER_INTERVAL_MS);
+    });
+
+    expect(screen.getByText("Search stablecoins")).toBeInTheDocument();
+    expect(screen.getByText("Search crypto")).toBeInTheDocument();
+  });
+
+  it("does not cycle while the overlay is open (cycling=false)", () => {
+    render(<AnimatedSearchPlaceholder visible cycling={false} testId="ph" />);
+
+    act(() => {
+      jest.advanceTimersByTime(PLACEHOLDER_INTERVAL_MS * 2);
+    });
+
+    expect(screen.getByText("Search crypto")).toBeInTheDocument();
+    expect(screen.queryByText("Search stablecoins")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/AnimatedSearchPlaceholder/__tests__/useCyclingPlaceholder.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/AnimatedSearchPlaceholder/__tests__/useCyclingPlaceholder.test.ts
@@ -1,0 +1,54 @@
+import { renderHook, act } from "tests/testSetup";
+import { useCyclingPlaceholder, PLACEHOLDER_INTERVAL_MS } from "../useCyclingPlaceholder";
+
+describe("useCyclingPlaceholder", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("starts on the first phrase and animates when there are several phrases", () => {
+    const { result } = renderHook(() => useCyclingPlaceholder(4, true));
+
+    expect(result.current.index).toBe(0);
+    expect(result.current.animate).toBe(true);
+  });
+
+  it("advances to the next phrase after each interval and wraps around", () => {
+    const { result } = renderHook(() => useCyclingPlaceholder(4, true));
+
+    act(() => {
+      jest.advanceTimersByTime(PLACEHOLDER_INTERVAL_MS);
+    });
+    expect(result.current.index).toBe(1);
+
+    act(() => {
+      jest.advanceTimersByTime(PLACEHOLDER_INTERVAL_MS * 3);
+    });
+    expect(result.current.index).toBe(0);
+  });
+
+  it("pauses cycling while disabled", () => {
+    const { result } = renderHook(() => useCyclingPlaceholder(4, false));
+
+    act(() => {
+      jest.advanceTimersByTime(PLACEHOLDER_INTERVAL_MS * 2);
+    });
+    expect(result.current.index).toBe(0);
+  });
+
+  it("does not cycle when there is a single phrase", () => {
+    const { result } = renderHook(() => useCyclingPlaceholder(1, true));
+
+    expect(result.current.animate).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(PLACEHOLDER_INTERVAL_MS * 2);
+    });
+    expect(result.current.index).toBe(0);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/AnimatedSearchPlaceholder/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/AnimatedSearchPlaceholder/index.tsx
@@ -37,7 +37,7 @@ export function AnimatedSearchPlaceholder({ visible, cycling, testId }: Props) {
     () => [
       t("topBar.searchPlaceholders.crypto"),
       t("topBar.searchPlaceholders.stablecoins"),
-      t("topBar.searchPlaceholders.stock"),
+      t("topBar.searchPlaceholders.stocks"),
       t("topBar.searchPlaceholders.addresses"),
     ],
     [t],
@@ -49,8 +49,11 @@ export function AnimatedSearchPlaceholder({ visible, cycling, testId }: Props) {
   const [outgoingIndex, setOutgoingIndex] = useState<number | null>(null);
 
   if (prevIndexRef.current !== index) {
-    setOutgoingIndex(animate ? prevIndexRef.current : null);
+    setOutgoingIndex(prevIndexRef.current);
     prevIndexRef.current = index;
+  }
+  if (!animate && outgoingIndex !== null) {
+    setOutgoingIndex(null);
   }
 
   const transitioning = animate && outgoingIndex !== null;

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/AnimatedSearchPlaceholder/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/AnimatedSearchPlaceholder/index.tsx
@@ -1,0 +1,84 @@
+import React, { useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { cn } from "LLD/utils/cn";
+import { useCyclingPlaceholder } from "./useCyclingPlaceholder";
+
+const TEXT_INSET = "pl-[44px] pr-[16px]";
+
+type Props = Readonly<{
+  visible: boolean;
+  cycling: boolean;
+  testId?: string;
+}>;
+
+function PhraseLayer({
+  children,
+  className,
+  onAnimationEnd,
+}: Readonly<{
+  children: React.ReactNode;
+  className?: string;
+  onAnimationEnd?: () => void;
+}>) {
+  return (
+    <span
+      className={cn("absolute inset-0 flex items-center", TEXT_INSET, className)}
+      onAnimationEnd={onAnimationEnd}
+    >
+      <span className="body-1 truncate text-muted">{children}</span>
+    </span>
+  );
+}
+
+export function AnimatedSearchPlaceholder({ visible, cycling, testId }: Props) {
+  const { t } = useTranslation();
+
+  const phrases = useMemo(
+    () => [
+      t("topBar.searchPlaceholders.crypto"),
+      t("topBar.searchPlaceholders.stablecoins"),
+      t("topBar.searchPlaceholders.stock"),
+      t("topBar.searchPlaceholders.addresses"),
+    ],
+    [t],
+  );
+
+  const { index, animate } = useCyclingPlaceholder(phrases.length, visible && cycling);
+
+  const prevIndexRef = useRef(index);
+  const [outgoingIndex, setOutgoingIndex] = useState<number | null>(null);
+
+  if (prevIndexRef.current !== index) {
+    setOutgoingIndex(animate ? prevIndexRef.current : null);
+    prevIndexRef.current = index;
+  }
+
+  const transitioning = animate && outgoingIndex !== null;
+
+  return (
+    <div
+      aria-hidden
+      data-testid={testId}
+      className={cn(
+        "pointer-events-none absolute inset-0 overflow-hidden transition-opacity",
+        visible ? "opacity-100" : "opacity-0",
+      )}
+    >
+      <PhraseLayer
+        key={index}
+        className={transitioning ? "animate-search-placeholder-slide-in" : undefined}
+      >
+        {phrases[index]}
+      </PhraseLayer>
+      {transitioning && (
+        <PhraseLayer
+          key={outgoingIndex}
+          className="animate-search-placeholder-slide-out"
+          onAnimationEnd={() => setOutgoingIndex(null)}
+        >
+          {phrases[outgoingIndex]}
+        </PhraseLayer>
+      )}
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/AnimatedSearchPlaceholder/useCyclingPlaceholder.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/AnimatedSearchPlaceholder/useCyclingPlaceholder.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef, useState } from "react";
+
+export const PLACEHOLDER_INTERVAL_MS = 7000;
+
+function usePrefersReducedMotion(): boolean {
+  const queryRef = useRef<MediaQueryList | null>(null);
+  if (queryRef.current === null) {
+    queryRef.current = window.matchMedia?.("(prefers-reduced-motion: reduce)") ?? null;
+  }
+  const [reduced, setReduced] = useState(() => queryRef.current?.matches ?? false);
+
+  useEffect(() => {
+    const query = queryRef.current;
+    if (!query) return;
+    const onChange = (event: MediaQueryListEvent) => setReduced(event.matches);
+    query.addEventListener("change", onChange);
+    return () => query.removeEventListener("change", onChange);
+  }, []);
+
+  return reduced;
+}
+
+export function useCyclingPlaceholder(length: number, enabled: boolean) {
+  const reduceMotion = usePrefersReducedMotion();
+  const [index, setIndex] = useState(0);
+
+  const animate = !reduceMotion && length > 1;
+
+  useEffect(() => {
+    if (!animate || !enabled) return;
+
+    const id = setInterval(() => {
+      setIndex(current => (current + 1) % length);
+    }, PLACEHOLDER_INTERVAL_MS);
+
+    return () => clearInterval(id);
+  }, [animate, enabled, length]);
+
+  return { index, animate };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/AnimatedSearchPlaceholder/useCyclingPlaceholder.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/AnimatedSearchPlaceholder/useCyclingPlaceholder.ts
@@ -5,7 +5,7 @@ export const PLACEHOLDER_INTERVAL_MS = 7000;
 function usePrefersReducedMotion(): boolean {
   const queryRef = useRef<MediaQueryList | null>(null);
   if (queryRef.current === null) {
-    queryRef.current = window.matchMedia?.("(prefers-reduced-motion: reduce)") ?? null;
+    queryRef.current = globalThis.matchMedia?.("(prefers-reduced-motion: reduce)") ?? null;
   }
   const [reduced, setReduced] = useState(() => queryRef.current?.matches ?? false);
 

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchInputView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchInputView.tsx
@@ -7,6 +7,7 @@ import React, {
 } from "react";
 import { SearchInput } from "@ledgerhq/lumen-ui-react";
 import { cn } from "LLD/utils/cn";
+import { AnimatedSearchPlaceholder } from "./AnimatedSearchPlaceholder";
 
 type SearchInputViewProps = {
   value: string;
@@ -14,12 +15,13 @@ type SearchInputViewProps = {
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
   isOpen: boolean;
+  animatedTitle?: boolean;
   testId?: string;
 } & Omit<ComponentPropsWithoutRef<"div">, "onChange" | "onKeyDown">;
 
 export const SearchInputView = forwardRef<HTMLDivElement, SearchInputViewProps>(
   function SearchInputView(
-    { value, placeholder, onChange, onKeyDown, isOpen, testId, className, ...rest },
+    { value, placeholder, onChange, onKeyDown, isOpen, animatedTitle, testId, className, ...rest },
     ref,
   ) {
     // While the overlay is open, clicks inside the search field (the input itself or the clear
@@ -33,15 +35,27 @@ export const SearchInputView = forwardRef<HTMLDivElement, SearchInputViewProps>(
 
     return (
       <div ref={ref} className={cn("min-w-0 max-w-[450px] flex-auto mr-24", className)} {...rest}>
-        <div onClick={stopOverlayToggleWhenOpen} onPointerDown={stopOverlayToggleWhenOpen}>
+        <div
+          className="relative"
+          onClick={stopOverlayToggleWhenOpen}
+          onPointerDown={stopOverlayToggleWhenOpen}
+        >
           <SearchInput
             appearance="transparent"
             value={value}
-            placeholder={placeholder}
+            placeholder={animatedTitle ? "" : placeholder}
+            aria-label={animatedTitle ? placeholder : undefined}
             onChange={onChange}
             onKeyDown={onKeyDown}
             data-testid={testId}
           />
+          {animatedTitle && (
+            <AnimatedSearchPlaceholder
+              visible={value.length === 0}
+              cycling={!isOpen}
+              testId={testId ? `${testId}-animated-placeholder` : undefined}
+            />
+          )}
         </div>
       </div>
     );

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchInputView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchInputView.tsx
@@ -15,7 +15,7 @@ type SearchInputViewProps = {
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
   isOpen: boolean;
-  animatedTitle?: boolean;
+  animatedTitle: boolean;
   testId?: string;
 } & Omit<ComponentPropsWithoutRef<"div">, "onChange" | "onKeyDown">;
 

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/SearchOverlayView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/SearchOverlayView.tsx
@@ -20,6 +20,7 @@ type SearchOverlayViewProps = Readonly<{
   onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
   mode: SearchMode;
   contextValue: SearchOverlayContextValue;
+  animatedTitle: boolean;
 }>;
 
 type SearchOverlayContentProps = Readonly<{
@@ -48,6 +49,7 @@ export function SearchOverlayView({
   onKeyDown,
   mode,
   contextValue,
+  animatedTitle,
 }: SearchOverlayViewProps) {
   const { t } = useTranslation();
 
@@ -61,6 +63,7 @@ export function SearchOverlayView({
             onChange={onChangeQuery}
             onKeyDown={onKeyDown}
             isOpen={open}
+            animatedTitle={animatedTitle}
             testId="topbar-search-input"
           />
         }

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useSearchOverlayViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/useSearchOverlayViewModel.ts
@@ -17,7 +17,8 @@ export function useSearchOverlayViewModel() {
   const navigate = useNavigate();
   const location = useLocation();
   const dispatch = useDispatch();
-  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
+  const { shouldDisplayAggregatedAssets, shouldDisplayAssetDiscoverability } =
+    useWalletFeaturesConfig("desktop");
   const { query, onChangeQuery, isOpen, open, close, mode, suggestions, results } =
     useAssetSearchBar();
 
@@ -125,5 +126,6 @@ export function useSearchOverlayViewModel() {
     onKeyDown,
     mode: displayedMode,
     contextValue,
+    animatedTitle: shouldDisplayAssetDiscoverability,
   };
 }

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8912,7 +8912,7 @@
     "searchPlaceholders": {
       "crypto": "Search crypto",
       "stablecoins": "Search stablecoins",
-      "stock": "Search stocks",
+      "stocks": "Search stocks",
       "addresses": "Search addresses"
     },
     "search": {

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8909,6 +8909,12 @@
   },
   "topBar": {
     "searchPlaceholder": "Search assets",
+    "searchPlaceholders": {
+      "crypto": "Search crypto",
+      "stablecoins": "Search stablecoins",
+      "stock": "Search stocks",
+      "addresses": "Search addresses"
+    },
     "search": {
       "noAssetFound": "No asset found",
       "error": "Connection failed",

--- a/apps/ledger-live-desktop/tailwind.config.ts
+++ b/apps/ledger-live-desktop/tailwind.config.ts
@@ -8,6 +8,27 @@ const config = {
     "../../features/**/src/**/*.{ts,tsx}",
   ],
   presets: [ledgerLivePreset],
+  theme: {
+    extend: {
+      keyframes: {
+        "search-placeholder-slide-in": {
+          from: { transform: "translateY(48px)", opacity: "0" },
+          to: { transform: "translateY(0)", opacity: "1" },
+        },
+        "search-placeholder-slide-out": {
+          "0%": { transform: "translateY(0)", opacity: "1" },
+          "75%": { transform: "translateY(-75%)", opacity: "0" },
+          "100%": { transform: "translateY(-100%)", opacity: "0" },
+        },
+      },
+      animation: {
+        "search-placeholder-slide-in":
+          "search-placeholder-slide-in 400ms cubic-bezier(0, 0, 0.58, 1) forwards",
+        "search-placeholder-slide-out":
+          "search-placeholder-slide-out 400ms cubic-bezier(0, 0, 0.58, 1) forwards",
+      },
+    },
+  },
 } satisfies Config;
 
 export default config;

--- a/apps/ledger-live-desktop/tailwind.config.ts
+++ b/apps/ledger-live-desktop/tailwind.config.ts
@@ -1,6 +1,8 @@
 import type { Config } from "tailwindcss";
 import { ledgerLivePreset } from "@ledgerhq/lumen-design-core";
 
+const SEARCH_PLACEHOLDER_SLIDE = "400ms cubic-bezier(0, 0, 0.58, 1) forwards";
+
 const config = {
   content: [
     "./src/**/*.{js,ts,jsx,tsx}",
@@ -22,10 +24,8 @@ const config = {
         },
       },
       animation: {
-        "search-placeholder-slide-in":
-          "search-placeholder-slide-in 400ms cubic-bezier(0, 0, 0.58, 1) forwards",
-        "search-placeholder-slide-out":
-          "search-placeholder-slide-out 400ms cubic-bezier(0, 0, 0.58, 1) forwards",
+        "search-placeholder-slide-in": `search-placeholder-slide-in ${SEARCH_PLACEHOLDER_SLIDE}`,
+        "search-placeholder-slide-out": `search-placeholder-slide-out ${SEARCH_PLACEHOLDER_SLIDE}`,
       },
     },
   },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Top-bar **global search** placeholder on desktop: it now cycles through "Search crypto / stablecoins / stock / addresses" with a slide-out/slide-in transition (~7s interval, 400ms / `cubic-bezier(0,0,0.58,1)`).
  - The animation **freezes while the search overlay is open** and while the field has a value; resumes on close/clear.
  - Respects `prefers-reduced-motion` (no cycling, first phrase shown).
  - Gated behind the **asset-discoverability** feature flag — with the flag off, the static "Search assets" placeholder is unchanged.
  - Verify there's **no blink** when the word changes (the outgoing word slides out while the incoming slides in, in parallel) and that the text stays aligned with the search icon.

### 📝 Description

**Problem**: The desktop global-search field shows a static placeholder. LWM already animates its placeholder title; LWD should match.

**Solution**: Adds an `AnimatedSearchPlaceholder` overlay over the Lumen `SearchInput` that cycles the placeholder phrase with a parallel slide-out (outgoing word rises + fades) / slide-in (incoming word arrives from below) transition, per the design spec (400ms, `--easing-out`, 7s interval, 48px slot). The native placeholder is blanked while animating (with the static label preserved via `aria-label`), and cycling is paused when the overlay is open, when the field has a value, or under reduced-motion.

The keyframes are declared as Tailwind animation utilities in `apps/ledger-live-desktop/tailwind.config.ts` (`animate-search-placeholder-slide-in/out`), matching how the rest of the app expresses animations (Lumen preset), rather than raw CSS. The two phrase layers are keyed by phrase index and the transition is derived synchronously during render, so the outgoing word's element persists (no unmount/remount flicker).

https://github.com/user-attachments/assets/7cced1ff-e461-45e0-bb10-547237394e9c



### ❓ Context

- **JIRA or GitHub link**: [LIVE-29943](https://ledgerhq.atlassian.net/browse/LIVE-29943)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29943]: https://ledgerhq.atlassian.net/browse/LIVE-29943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ