### PR TITLE
[LWD] feat(desktop): make asset detail add-account network-aware

### DIFF
--- a/.changeset/asset-detail-network-add-account.md
+++ b/.changeset/asset-detail-network-add-account.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Asset Detail: the "Add" account action now lets you choose the network for multi-network assets (e.g. Ethereum, Base, Arbitrum, Optimism), matching the mobile behavior, instead of defaulting to the canonical network.

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/__tests__/useAddressListViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/__tests__/useAddressListViewModel.test.ts
@@ -17,12 +17,22 @@ jest.mock("react-router", () => ({
   useLocation: () => ({ pathname: "/asset/bitcoin" }),
 }));
 
+const mockOpenAddAccountFlow = jest.fn();
+const mockOpenAssetFlow = jest.fn();
+
 /** Stubs the add-account flow so this suite does not load the full drawer/modal dependency graph. */
 jest.mock("LLD/features/ModularDialog/hooks/useOpenAssetFlow", () => ({
   useOpenAssetFlow: () => ({
-    openAddAccountFlow: jest.fn(),
-    openAssetFlow: jest.fn(),
+    openAddAccountFlow: mockOpenAddAccountFlow,
+    openAssetFlow: mockOpenAssetFlow,
   }),
+}));
+
+const mockNetworkLedgerIds = jest.fn<string[], []>(() => []);
+
+/** Stubs the DADA network resolution so this suite does not hit the assets catalog. */
+jest.mock("LLD/features/AssetDetail/hooks/useReceiveNetworkLedgerIds", () => ({
+  useReceiveNetworkLedgerIds: () => mockNetworkLedgerIds(),
 }));
 
 describe("useAddressListViewModel", () => {
@@ -30,6 +40,9 @@ describe("useAddressListViewModel", () => {
 
   beforeEach(() => {
     mockNavigate.mockClear();
+    mockOpenAddAccountFlow.mockClear();
+    mockOpenAssetFlow.mockClear();
+    mockNetworkLedgerIds.mockReturnValue([]);
   });
 
   it("exposes address section labels", () => {
@@ -112,4 +125,39 @@ describe("useAddressListViewModel", () => {
       expect(mockNavigate).toHaveBeenCalledWith(getAccountsSidebarPath(shouldDisplayAssetSection));
     },
   );
+
+  it("opens the network-aware asset flow with the resolved network ledger ids", () => {
+    mockNetworkLedgerIds.mockReturnValue(["ethereum", "base", "arbitrum", "optimism"]);
+
+    const { result } = renderHook(() =>
+      useAddressListViewModel(buildDistributionItem({ currency: btc, accounts: [] })),
+    );
+
+    act(() => {
+      result.current.onAddAddress();
+    });
+
+    expect(mockOpenAssetFlow).toHaveBeenCalledWith(undefined, [
+      "ethereum",
+      "base",
+      "arbitrum",
+      "optimism",
+    ]);
+    expect(mockOpenAddAccountFlow).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the single-currency add-account flow when no networks are resolved", () => {
+    mockNetworkLedgerIds.mockReturnValue([]);
+
+    const { result } = renderHook(() =>
+      useAddressListViewModel(buildDistributionItem({ currency: btc, accounts: [] })),
+    );
+
+    act(() => {
+      result.current.onAddAddress();
+    });
+
+    expect(mockOpenAddAccountFlow).toHaveBeenCalledWith(btc);
+    expect(mockOpenAssetFlow).not.toHaveBeenCalled();
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/useAddressListViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/useAddressListViewModel.ts
@@ -17,6 +17,7 @@ import { track } from "~/renderer/analytics/segment";
 import { buildMainAccountByIdMap } from "@ledgerhq/asset-aggregation/assetDistribution/index";
 import { ASSET_DETAIL_TRACKING_PAGE_NAME } from "LLD/features/AssetDetail/constants";
 import { buildNavigationBackState } from "LLD/utils/navigationBackPath";
+import { useReceiveNetworkLedgerIds } from "LLD/features/AssetDetail/hooks/useReceiveNetworkLedgerIds";
 import { MAX_ADDRESSES_PREVIEW } from "../constants";
 
 export function useAddressListViewModel(distributionItem: DistributionItem) {
@@ -58,10 +59,20 @@ export function useAddressListViewModel(distributionItem: DistributionItem) {
     setIsAllAddressesDialogOpen(open);
   };
 
-  const { openAddAccountFlow } = useOpenAssetFlow(
+  const { openAddAccountFlow, openAssetFlow } = useOpenAssetFlow(
     { location: ModularDrawerLocation.ADD_ACCOUNT },
     MAD_SOURCE_PAGES.ASSET_DETAIL,
   );
+
+  // Resolve the asset's full multi-network list so the add-account flow can offer
+  // every network (e.g. ETH on Ethereum/Base/Arbitrum/Optimism), mirroring mobile.
+  const networkLedgerIds = useReceiveNetworkLedgerIds({
+    metaCurrencyId: distributionItem.metaCurrencyId,
+    marketApiId: distributionItem.marketId,
+    ticker: distributionItem.currency.ticker,
+    currencyId: distributionItem.currency.id,
+    fallbackLedgerIds: [],
+  });
 
   const onAddAddress = () => {
     track("button_clicked", {
@@ -69,13 +80,17 @@ export function useAddressListViewModel(distributionItem: DistributionItem) {
       currency: distributionItem.currency.id,
       page: ASSET_DETAIL_TRACKING_PAGE_NAME,
     });
-    openAddAccountFlow(distributionItem.currency);
+    if (networkLedgerIds.length > 1) {
+      openAssetFlow(undefined, networkLedgerIds);
+    } else {
+      openAddAccountFlow(distributionItem.currency);
+    }
   };
 
   const onAccountClick = (account: AccountLike, parentAccount?: Account | null) => {
     const mainAccount =
       account.type === "TokenAccount"
-        ? (parentAccount ?? lookupParentAccount(account.parentId))
+        ? parentAccount ?? lookupParentAccount(account.parentId)
         : account;
     setTrackingSource(ASSET_DETAIL_TRACKING_PAGE_NAME);
     track("button_clicked", {

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useReceiveNetworkLedgerIds.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useReceiveNetworkLedgerIds.ts
@@ -1,0 +1,23 @@
+import { useReceiveNetworkLedgerIds as useSharedReceiveNetworkLedgerIds } from "@ledgerhq/asset-detail";
+import type { ReceiveNetworkLedgerIdsInput } from "@ledgerhq/asset-detail";
+import useEnv from "@ledgerhq/live-common/hooks/useEnv";
+import { useFeature } from "@features/platform-feature-flags";
+
+type Params = Omit<
+  ReceiveNetworkLedgerIdsInput,
+  "product" | "version" | "isStaging" | "includeTestNetworks"
+>;
+
+export function useReceiveNetworkLedgerIds(params: Params): string[] {
+  const modularDrawerFeature = useFeature("lldModularDrawer");
+  const devMode = useEnv("MANAGER_DEV_MODE");
+  const isStaging = modularDrawerFeature?.params?.backendEnvironment === "STAGING";
+
+  return useSharedReceiveNetworkLedgerIds({
+    ...params,
+    product: "lld",
+    version: __APP_VERSION__,
+    isStaging,
+    includeTestNetworks: devMode,
+  });
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useOpenAssetFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useOpenAssetFlow.test.tsx
@@ -27,6 +27,32 @@ describe("useOpenAssetFlow", () => {
     expect(store.getState().modularDialog.dialogParams?.currencies?.length).toBe(0);
   });
 
+  it("should open the dialog filtered to the provided network currency ids", () => {
+    const { result, store } = renderHook(
+      () => useOpenAssetFlow({ location: ModularDrawerLocation.LIVE_APP, liveAppId: "" }, "test"),
+      {
+        initialState: withFlagOverrides({
+          lldModularDrawer: {
+            enabled: true,
+            params: {
+              [ModularDrawerLocation.LIVE_APP]: true,
+            },
+          },
+        }),
+      },
+    );
+
+    result.current.openAssetFlow(undefined, ["ethereum", "base", "arbitrum"]);
+
+    expect(store.getState().modularDialog.isOpen).toBe(true);
+    expect(store.getState().modularDialog.dialogParams?.currencies).toEqual([
+      "ethereum",
+      "base",
+      "arbitrum",
+    ]);
+    expect(store.getState().modularDialog.dialogParams?.areCurrenciesFiltered).toBe(true);
+  });
+
   it("should handle openAssetFlow to accountFlow", () => {
     const { result, store } = renderHook(
       () => useOpenAssetFlow({ location: ModularDrawerLocation.LIVE_APP, liveAppId: "" }, "test"),

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useOpenAssetFlow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useOpenAssetFlow.tsx
@@ -27,15 +27,16 @@ import { useFeature } from "@features/platform-feature-flags";
 function selectCurrencyDialog(
   dispatch: ReturnType<typeof useDispatch>,
   onAssetSelected: (currency: CryptoOrTokenCurrency) => void,
-  currencies?: CryptoOrTokenCurrency[],
+  currencyIds?: string[],
   onClose?: () => void,
   dialogConfiguration?: EnhancedModularDrawerConfiguration,
 ): void {
-  const filteredCurrencies = currencies?.map(currency => currency.id) ?? [];
+  const filteredCurrencies = currencyIds ?? [];
 
   dispatch(
     openDialog({
       currencies: filteredCurrencies,
+      areCurrenciesFiltered: filteredCurrencies.length > 0,
       onAssetSelected,
       dialogConfiguration: dialogConfiguration ?? {
         assets: { leftElement: "undefined", rightElement: "balance" },
@@ -127,14 +128,14 @@ export function useOpenAssetFlow(
   );
 
   const openAssetFlow = useCallback(
-    (dialogConfiguration?: EnhancedModularDrawerConfiguration) => {
+    (dialogConfiguration?: EnhancedModularDrawerConfiguration, currencyIds?: string[]) => {
       if (isModularDrawerVisible(modularDrawerVisibleParams)) {
         dispatch(setFlowValue(modularDrawerVisibleParams.location));
         dispatch(setSourceValue(source));
         selectCurrencyDialog(
           dispatch,
           openAddAccountFlow,
-          undefined,
+          currencyIds,
           handleClose,
           dialogConfiguration,
         );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset Detail page → "Add" account action for multi-network assets (e.g. ETH on Ethereum/Base/Arbitrum/Optimism)
  - Single-network assets still fall back to the existing single-currency add-account flow
  - The Modular Drawer / asset-selection flow opened with a filtered network list (`areCurrenciesFiltered`)

### 📝 Description

On the Asset Detail page, the "Add" account action defaulted to the asset's canonical network, so users could not add an account on an alternative network for multi-network assets directly from that screen.

This PR makes the action network-aware: it resolves the asset's full multi-network list via `useReceiveNetworkLedgerIds` and, when more than one network is available, opens the network-aware asset flow filtered to those networks (mirroring the mobile behavior). When no networks are resolved, it falls back to the existing single-currency add-account flow.

To support this, `useOpenAssetFlow`'s `openAssetFlow` now accepts a list of currency ids to filter on and sets `areCurrenciesFiltered` when a filter is applied.

### 📸 Screenshots

| Before | After |


https://github.com/user-attachments/assets/da8a866e-2ab7-4a09-962e-cac9d31ef721




### ❓ Context

- **JIRA or GitHub link**: [LIVE-32896](https://ledgerhq.atlassian.net/browse/LIVE-32896)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32896]: https://ledgerhq.atlassian.net/browse/LIVE-32896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ