### PR TITLE
[LWDM] style: apply oxfmt formatting to files that landed unformatted

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/useAddressListItemViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/useAddressListItemViewModel.ts
@@ -34,12 +34,12 @@ export function useAddressListItemViewModel(
     account.type === "TokenAccount" ? lookupParentAccount(account.parentId) : undefined;
   const networkCurrency =
     account.type === "TokenAccount"
-      ? parentAccount?.currency ?? getCryptoCurrencyById(account.token.parentCurrencyId)
+      ? (parentAccount?.currency ?? getCryptoCurrencyById(account.token.parentCurrencyId))
       : currency;
 
   const accountForDisplayName =
     account.type === "TokenAccount"
-      ? parentAccount ?? lookupParentAccount(account.parentId)
+      ? (parentAccount ?? lookupParentAccount(account.parentId))
       : account;
   const displayName = useAccountName(accountForDisplayName ?? account);
   const rawAddress = getCryptoAccountAddress(account, lookupParentAccount);

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/handlers/borrowErrorBottomSheetStore.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/handlers/borrowErrorBottomSheetStore.ts
@@ -39,9 +39,9 @@ export function resolveBorrowErrorBottomSheet(confirmed: boolean) {
 }
 
 export function createOpenBorrowErrorBottomSheetHandler(dispatch: Dispatch) {
-  return async (
-    request: { params?: BorrowErrorBottomSheetParams },
-  ): Promise<{ confirmed: boolean }> => {
+  return async (request: {
+    params?: BorrowErrorBottomSheetParams;
+  }): Promise<{ confirmed: boolean }> => {
     const validated = sanitizeBorrowErrorBottomSheetParams(request.params, HANDLER_NAME);
 
     // If a previous sheet is still pending, resolve it as dismissed before opening the new one.

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
@@ -143,7 +143,6 @@ describe("Send flow integration tests", () => {
     throw new Error(`No TextInput found near label "${String(labelText)}"`);
   }
 
-
   describe("Stellar (memo flow)", () => {
     it("Should walk through Recipient → Amount and reach the Signature step", async () => {
       const { user } = renderForAccount(accountStellar);
@@ -281,7 +280,10 @@ describe("Send flow integration tests", () => {
       };
 
       beforeAll(async () => {
-        const bridge = (await getAccountBridge(accountEthereum, null)) as unknown as PreparableBridge;
+        const bridge = (await getAccountBridge(
+          accountEthereum,
+          null,
+        )) as unknown as PreparableBridge;
         const original = bridge.prepareTransaction.bind(bridge);
         bridge.prepareTransaction = async (account, tx) => {
           const next = await original(account, tx);

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/index.tsx
@@ -21,15 +21,8 @@ interface PortfolioStocksSectionProps {
 
 const PortfolioStocksSectionComponent: React.FC<PortfolioStocksSectionProps> = ({ variant }) => {
   const { t } = useTranslation();
-  const {
-    stocksCount,
-    hasMore,
-    stocksToDisplay,
-    isLoading,
-    isError,
-    onPressShowAll,
-    onItemPress,
-  } = usePortfolioStocksSectionViewModel({ variant });
+  const { stocksCount, hasMore, stocksToDisplay, isLoading, isError, onPressShowAll, onItemPress } =
+    usePortfolioStocksSectionViewModel({ variant });
 
   if (!isLoading && !isError && stocksCount === 0) return <StocksDiscoverySection />;
 

--- a/apps/ledger-live-mobile/src/reducers/__tests__/borrow.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/borrow.test.ts
@@ -17,10 +17,7 @@ describe("borrow slice", () => {
     });
 
     it("clears infoBottomSheet when payload is undefined", () => {
-      const seeded = reducer(
-        INITIAL_STATE,
-        setInfoBottomSheet({ title: "Info", message: "Help" }),
-      );
+      const seeded = reducer(INITIAL_STATE, setInfoBottomSheet({ title: "Info", message: "Help" }));
       const state = reducer(seeded, setInfoBottomSheet(undefined));
 
       expect(state.infoBottomSheet).toBeUndefined();

--- a/libs/coin-modules/coin-stellar/src/api/index_error.test.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index_error.test.ts
@@ -24,9 +24,9 @@ describe("Stellar Api", () => {
 
   describe("listOperations propagates 429 errors to caller", () => {
     it("throws LedgerAPI4xx on rate limit", async () => {
-      await expect(
-        module.listOperations(ADDRESS, { minHeight: 0, order: "asc" }),
-      ).rejects.toThrow(LedgerAPI4xx);
+      await expect(module.listOperations(ADDRESS, { minHeight: 0, order: "asc" })).rejects.toThrow(
+        LedgerAPI4xx,
+      );
     });
   });
 });


### PR DESCRIPTION
> [!WARNING]
> **Something is off in the toolchain, not just author setup.** Unformatted code keeps landing on `develop` even though formatting is enforced by an `hk` **pre-commit hook** that runs `oxfmt`. The hook can be silently bypassed: when a commit runs inside sandboxed/automated tooling, `oxfmt` fails to write its fix (`Operation not permitted`), the hook errors, and the commit gets retried with `--no-verify` — landing unformatted code despite a correct `mise` setup. We should harden this (e.g. don't auto-`--no-verify` on hook failure, run git outside the sandbox, and/or add a CI `oxfmt --check` gate that blocks merge) so a working setup is actually sufficient. Follow-up to #18698.

### ✅ Checklist

- [x] No changeset needed. <!-- formatting-only change, no package release -->
- [x] **Covered by automatic tests.** <!-- formatting-only change; `oxfmt --check` runs in CI -->
- [x] **Impact of the changes:** none functional — whitespace/line-wrapping only. No QA needed.

### 📝 Description

Pure `oxfmt` reformatting. A number of files landed on `develop` not matching the repo's `oxfmt` (oxc) style — `npm run format` (`nx run-many -t format`) rewraps them. This PR ships only that reformatting: **no functional change**, whitespace/line-wrapping only.

The affected lines trace back to these merged PRs:

- #18621 (@mcayuelas-ledger)
- #18614 (@Valentin-Ledger)
- #18656 (@qperrot)
- #18654 (@deepyjr)
- #18706 (@estrauser-ledger)

> [!NOTE]
> Gentle heads-up to the authors above — formatting is enforced by an `hk` **pre-commit hook** that runs `oxfmt`. Unformatted code can only land if that hook didn't run. Two common reasons:
> 1. **The toolchain/hooks aren't installed.** Run `mise install` from the repo root so `mise` provisions the pinned tools and `hk` installs the git hooks — see the [README › Mise](https://github.com/LedgerHQ/ledger-live#mise) section.
> 2. **The hook was bypassed** at commit time (`git commit --no-verify`, or `HK=0`). Avoid bypassing it; if it fails, fix the cause rather than skipping. Note that committing through some automated/sandboxed tooling can silently force a `--no-verify` when the hook errors.
>
> Either way: `mise install` + don't bypass the hook = no more drift like this.

### ❓ Context

- **JIRA or GitHub link**: N/A — repo hygiene
- **ADR link (if any)**: N/A
