### PR TITLE
[LWD] fix: standardize market favourite analytics tracking

### DIFF
--- a/.changeset/market-favourite-analytics.md
+++ b/.changeset/market-favourite-analytics.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Track market favourite toggles with the same `button_clicked` analytics event used on asset detail

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/useMarketRowViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/useMarketRowViewModel.ts
@@ -77,10 +77,6 @@ export function useMarketRowViewModel({
 
   const onToggleStar = useCallback(() => {
     toggleStar(currency.id, isStarred);
-    track("button_clicked", {
-      asset: currency.id,
-      button: isStarred ? "unstar" : "star",
-    });
   }, [toggleStar, currency.id, isStarred]);
 
   // Defer the favourite toggle until the menu has closed, so the open menu never

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarket.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarket.test.ts
@@ -3,6 +3,7 @@ import { Order } from "@ledgerhq/live-common/market/utils/types";
 import { useMarket } from "../useMarket";
 import { addStarredMarketCoins } from "~/renderer/actions/settings";
 import { INITIAL_STATE as SETTINGS_INITIAL_STATE } from "~/renderer/reducers/settings";
+import { track } from "~/renderer/analytics/segment";
 
 jest.mock("@ledgerhq/live-common/market/hooks/useMarketDataProvider", () => ({
   useMarketData: () => ({
@@ -149,6 +150,38 @@ describe("useMarket", () => {
 
       await waitFor(() => {
         expect(result.current.starredMarketCoins).not.toContain("ethereum");
+      });
+    });
+
+    it("toggleStar tracks favourite button clicks", async () => {
+      const { result } = renderHook(() => useMarket(), {
+        initialState: {
+          ...withFlagOverrides({ lldRefreshMarketData: { enabled: false } }),
+          settings: createSettingsState([]),
+          market: createMarketState([]),
+        },
+      });
+
+      await act(async () => {
+        result.current.toggleStar("ethereum", false);
+      });
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "favourite",
+        currency: "ethereum",
+        page: "",
+        is_favourite: true,
+      });
+
+      await act(async () => {
+        result.current.toggleStar("ethereum", true);
+      });
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "favourite",
+        currency: "ethereum",
+        page: "",
+        is_favourite: false,
       });
     });
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarketCoin.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarketCoin.test.ts
@@ -4,6 +4,7 @@ import { http, HttpResponse } from "msw";
 import { useMarketCoin } from "../useMarketCoin";
 import { Order } from "@ledgerhq/live-common/market/utils/types";
 import { MARKET_API, DADA_API, EMPTY_DADA_RESPONSE } from "./shared";
+import { track } from "~/renderer/analytics/segment";
 
 const mockOnBuy = jest.fn();
 const mockOnSwap = jest.fn();
@@ -119,6 +120,36 @@ describe("useMarketCoin", () => {
     });
 
     expect(store.getState().settings.starredMarketCoins).toContain("bitcoin");
+  });
+
+  it("toggleStar tracks favourite button clicks", async () => {
+    const { result } = renderMarketCoinHook();
+
+    await waitFor(() => {
+      expect(result.current.currency).toBeDefined();
+    });
+
+    await act(async () => {
+      result.current.toggleStar();
+    });
+
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "favourite",
+      currency: "bitcoin",
+      page: "",
+      is_favourite: true,
+    });
+
+    await act(async () => {
+      result.current.toggleStar();
+    });
+
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "favourite",
+      currency: "bitcoin",
+      page: "",
+      is_favourite: false,
+    });
   });
 
   it("should be no-op when currency data is unavailable", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
@@ -21,6 +21,8 @@ import {
   isDataStale,
 } from "~/renderer/screens/market/utils";
 import { addStarredMarketCoins, removeStarredMarketCoins } from "~/renderer/actions/settings";
+import { track } from "~/renderer/analytics/segment";
+import { getCurrentTrackingPage } from "~/renderer/analytics/screenRefs";
 import { useMarketCategories } from "LLD/features/Market/hooks/useMarketCategories";
 import {
   getMarketCategoriesParam,
@@ -213,6 +215,12 @@ export function useMarket() {
 
   const toggleStar = useCallback(
     (id: string, isStarred: boolean) => {
+      track("button_clicked", {
+        button: "favourite",
+        currency: id,
+        page: getCurrentTrackingPage(),
+        is_favourite: !isStarred,
+      });
       if (isStarred) {
         dispatch(removeStarredMarketCoins(id));
       } else {

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketCoin.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketCoin.ts
@@ -15,6 +15,8 @@ import { localeSelector, starredMarketCoinsSelector } from "~/renderer/reducers/
 import { removeStarredMarketCoins, addStarredMarketCoins } from "~/renderer/actions/settings";
 import { selectCurrency } from "@ledgerhq/live-common/dada-client/utils/currencySelection";
 import { assetsDataApi } from "@ledgerhq/live-common/dada-client/state-manager/api";
+import { track } from "~/renderer/analytics/segment";
+import { getCurrentTrackingPage } from "~/renderer/analytics/screenRefs";
 
 export const useMarketCoin = () => {
   const marketParams = useSelector(marketParamsSelector);
@@ -77,6 +79,12 @@ export const useMarketCoin = () => {
 
   const toggleStar = useCallback(() => {
     if (!id) return;
+    track("button_clicked", {
+      button: "favourite",
+      currency: id,
+      page: getCurrentTrackingPage(),
+      is_favourite: !isStarred,
+    });
     dispatch(isStarred ? removeStarredMarketCoins(id) : addStarredMarketCoins(id));
   }, [dispatch, isStarred, id]);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request updates how analytics are tracked when users toggle the "favourite" (star) button in the Market feature. The main change is to ensure that all market favourite toggles use a consistent `button_clicked` analytics event, matching the tracking already used on the asset detail page. Tests have also been added to verify this behavior.

### ❓ Context

[LIVE-32826](https://ledgerhq.atlassian.net/browse/LIVE-32826)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-32826]: https://ledgerhq.atlassian.net/browse/LIVE-32826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ