### PR TITLE
[LWDM] fix(lld): preserve userId during identities migration for returning users

### DIFF
--- a/.changeset/identities-userid-migration-fix.md
+++ b/.changeset/identities-userid-migration-fix.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/client-ids": patch
+---
+
+Fix desktop userId migration so returning users keep their identity after upgrade. When `app.identities` was created by the deviceId rollout (deviceIds only, no userId), boot now recovers the legacy userId from `app.user`/localStorage instead of generating a new one, which had made returning users appear as new in Segment and Braze. `shouldUsePersistedId` is now exported from `@ledgerhq/client-ids/store`.

--- a/apps/ledger-live-desktop/src/renderer/helpers/identities.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/helpers/identities.test.ts
@@ -263,6 +263,29 @@ describe("initIdentities", () => {
     getItemSpy.mockRestore();
   });
 
+  it("when persisted has usable userId but missing datadogId and legacy user has datadogId, should keep persisted userId and recover legacy datadogId", async () => {
+    const partialPersisted = {
+      userId: "persisted-user-id",
+      deviceIds: ["device-1"],
+      pushDevicesSyncState: "synced" as const,
+      pushDevicesServiceUrl: null,
+    };
+    mockGetKey.mockImplementation(async (ns, keyPath) => {
+      if (ns === "app" && keyPath === "identities") return partialPersisted;
+      if (ns === "app" && keyPath === "user")
+        return { id: "legacy-user-id", datadogId: "legacy-dd-id" };
+      return undefined;
+    });
+
+    const store = createMockStore();
+    const result = await initIdentities(store);
+
+    expect(result).toBe(false);
+    const state = store.getState().identities;
+    expect(state.userId.exportUserIdForPersistence()).toBe("persisted-user-id");
+    expect(state.datadogId?.exportDatadogIdForPersistence()).toBe("legacy-dd-id");
+  });
+
   it("when persisted has old shape (no userId/datadogId) and legacy user, should recover the legacy userId and restore deviceIds", async () => {
     const oldShapePersisted = {
       deviceIds: ["device-old-1"],

--- a/apps/ledger-live-desktop/src/renderer/helpers/identities.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/helpers/identities.test.ts
@@ -218,6 +218,24 @@ describe("initIdentities", () => {
     getItemSpy.mockRestore();
   });
 
+  it("should not recover a legacy user whose id is the dummy value", async () => {
+    mockGetKey.mockImplementation(async (ns, keyPath) => {
+      if (ns === "app" && keyPath === "identities") return undefined;
+      if (ns === "app" && keyPath === "user") return { id: "00000000-0000-0000-0000-000000000000" };
+      return undefined;
+    });
+    const getItemSpy = jest.spyOn(Storage.prototype, "getItem").mockReturnValue(null);
+
+    const store = createMockStore();
+    const result = await initIdentities(store);
+
+    expect(result).toBe(true);
+    expect(store.getState().identities.userId.exportUserIdForPersistence()).not.toBe(
+      "00000000-0000-0000-0000-000000000000",
+    );
+    getItemSpy.mockRestore();
+  });
+
   it("when persisted has userId but no datadogId (partial-persisted), should preserve userId and generate only datadogId", async () => {
     const partialPersisted = {
       userId: "persisted-user-id-only",
@@ -245,7 +263,7 @@ describe("initIdentities", () => {
     getItemSpy.mockRestore();
   });
 
-  it("when persisted has old shape (no userId/datadogId) and legacy user, should restore deviceIds and generate new ids (persisted takes precedence)", async () => {
+  it("when persisted has old shape (no userId/datadogId) and legacy user, should recover the legacy userId and restore deviceIds", async () => {
     const oldShapePersisted = {
       deviceIds: ["device-old-1"],
       pushDevicesSyncState: "unsynced" as const,
@@ -253,7 +271,8 @@ describe("initIdentities", () => {
     };
     mockGetKey.mockImplementation(async (ns, keyPath) => {
       if (ns === "app" && keyPath === "identities") return oldShapePersisted;
-      if (ns === "app" && keyPath === "user") return { id: "legacy-user-from-app-user" };
+      if (ns === "app" && keyPath === "user")
+        return { id: "legacy-user-from-app-user", datadogId: "legacy-dd-from-app-user" };
       return undefined;
     });
 
@@ -262,13 +281,37 @@ describe("initIdentities", () => {
 
     expect(result).toBe(false);
     const state = store.getState().identities;
-    expect(state.userId.exportUserIdForPersistence()).not.toBe("legacy-user-from-app-user");
-    expect(state.userId.exportUserIdForPersistence()).not.toBe("");
-    expect(state.datadogId?.exportDatadogIdForPersistence()).toBeDefined();
+    expect(state.userId.exportUserIdForPersistence()).toBe("legacy-user-from-app-user");
+    expect(state.datadogId?.exportDatadogIdForPersistence()).toBe("legacy-dd-from-app-user");
     expect(state.deviceIds).toHaveLength(1);
     expect(state.deviceIds[0].exportDeviceIdForPersistence()).toBe("device-old-1");
     expect(state.pushDevicesSyncState).toBe("unsynced");
     expect(state.pushDevicesServiceUrl).toBe("https://push.example.com");
+  });
+
+  it("when persisted has old shape (no userId) and only localStorage userId, should recover it and restore deviceIds", async () => {
+    const oldShapePersisted = {
+      deviceIds: ["device-old-3"],
+      pushDevicesSyncState: "unsynced" as const,
+      pushDevicesServiceUrl: null,
+    };
+    mockGetKey.mockImplementation(async (ns, keyPath) => {
+      if (ns === "app" && keyPath === "identities") return oldShapePersisted;
+      return undefined;
+    });
+    const getItemSpy = jest
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation((key: string) => (key === "userId" ? "ls-legacy-user" : null));
+
+    const store = createMockStore();
+    const result = await initIdentities(store);
+
+    expect(result).toBe(false);
+    const state = store.getState().identities;
+    expect(state.userId.exportUserIdForPersistence()).toBe("ls-legacy-user");
+    expect(state.deviceIds).toHaveLength(1);
+    expect(state.deviceIds[0].exportDeviceIdForPersistence()).toBe("device-old-3");
+    getItemSpy.mockRestore();
   });
 
   it("when persisted has old shape (no userId/datadogId) and no legacy user, should restore deviceIds and generate new ids", async () => {

--- a/apps/ledger-live-desktop/src/renderer/helpers/identities.ts
+++ b/apps/ledger-live-desktop/src/renderer/helpers/identities.ts
@@ -1,8 +1,10 @@
 import { getKey } from "~/renderer/storage";
-import { identitiesSlice } from "@ledgerhq/client-ids/store";
+import { identitiesSlice, shouldUsePersistedId } from "@ledgerhq/client-ids/store";
 import type { ReduxStore } from "~/state-manager/configureStore";
 
 type LegacyUser = { id: string; datadogId?: string } | null;
+
+type LegacyIds = { userId: string; datadogId?: string };
 
 type PersistedIdentitiesShape = {
   userId?: string;
@@ -12,19 +14,49 @@ type PersistedIdentitiesShape = {
   pushDevicesServiceUrl?: string | null;
 };
 
+async function readLegacyIds(): Promise<LegacyIds | null> {
+  const legacyUser = (await getKey("app", "user")) as LegacyUser;
+  if (legacyUser && shouldUsePersistedId(legacyUser.id)) {
+    const datadogId = legacyUser.datadogId;
+    return {
+      userId: legacyUser.id,
+      datadogId: shouldUsePersistedId(datadogId) ? datadogId : undefined,
+    };
+  }
+  if (typeof localStorage !== "undefined") {
+    const legacyUserId = localStorage.getItem("userId") ?? undefined;
+    if (shouldUsePersistedId(legacyUserId)) {
+      return { userId: legacyUserId };
+    }
+  }
+  return null;
+}
+
 /**
  * Initialize identities: prefer app.identities, then legacy app.user / localStorage userId, else initFromScratch.
- * Same legacy fallback order as previous user.ts (app.user then localStorage).
+ * app.identities may exist from the deviceId rollout with deviceIds only (no userId): we still recover the
+ * legacy userId in that case, otherwise returning users get a new id and appear as new in analytics.
  * @returns true only when initFromScratch ran (no persisted, no legacy); false otherwise.
  */
 export async function initIdentities(store: ReduxStore): Promise<boolean> {
   const persisted = (await getKey("app", "identities")) as PersistedIdentitiesShape | undefined;
 
   if (persisted) {
+    let userId = persisted.userId;
+    let datadogId = persisted.datadogId;
+    if (!shouldUsePersistedId(userId)) {
+      const legacy = await readLegacyIds();
+      if (legacy) {
+        userId = legacy.userId;
+        if (!shouldUsePersistedId(datadogId)) {
+          datadogId = legacy.datadogId;
+        }
+      }
+    }
     store.dispatch(
       identitiesSlice.actions.initFromPersisted({
-        userId: persisted.userId,
-        datadogId: persisted.datadogId,
+        userId,
+        datadogId,
         deviceIds: Array.isArray(persisted.deviceIds) ? persisted.deviceIds : [],
         pushDevicesSyncState: persisted.pushDevicesSyncState ?? "synced",
         pushDevicesServiceUrl: persisted.pushDevicesServiceUrl ?? null,
@@ -33,27 +65,10 @@ export async function initIdentities(store: ReduxStore): Promise<boolean> {
     return false;
   }
 
-  const legacyUser = (await getKey("app", "user")) as LegacyUser;
-  if (legacyUser?.id) {
-    store.dispatch(
-      identitiesSlice.actions.importFromLegacy({
-        userId: legacyUser.id,
-        datadogId: legacyUser.datadogId,
-      }),
-    );
+  const legacy = await readLegacyIds();
+  if (legacy) {
+    store.dispatch(identitiesSlice.actions.importFromLegacy(legacy));
     return false;
-  }
-
-  if (typeof localStorage !== "undefined") {
-    const legacyUserId = localStorage.getItem("userId");
-    if (legacyUserId) {
-      store.dispatch(
-        identitiesSlice.actions.importFromLegacy({
-          userId: legacyUserId,
-        }),
-      );
-      return false;
-    }
   }
 
   store.dispatch(identitiesSlice.actions.initFromScratch());

--- a/apps/ledger-live-desktop/src/renderer/helpers/identities.ts
+++ b/apps/ledger-live-desktop/src/renderer/helpers/identities.ts
@@ -44,10 +44,12 @@ export async function initIdentities(store: ReduxStore): Promise<boolean> {
   if (persisted) {
     let userId = persisted.userId;
     let datadogId = persisted.datadogId;
-    if (!shouldUsePersistedId(userId)) {
+    if (!shouldUsePersistedId(userId) || !shouldUsePersistedId(datadogId)) {
       const legacy = await readLegacyIds();
       if (legacy) {
-        userId = legacy.userId;
+        if (!shouldUsePersistedId(userId)) {
+          userId = legacy.userId;
+        }
         if (!shouldUsePersistedId(datadogId)) {
           datadogId = legacy.datadogId;
         }

--- a/libs/client-ids/src/store/slice.ts
+++ b/libs/client-ids/src/store/slice.ts
@@ -4,7 +4,7 @@ import { initialIdentitiesState, DUMMY_ID_STR } from "./types";
 import { PersistedIdentities } from "./persistence";
 import { v4 as uuid } from "uuid";
 
-function shouldUsePersistedId(value: string | undefined): value is string {
+export function shouldUsePersistedId(value: string | undefined): value is string {
   return typeof value === "string" && value.trim() !== "" && value !== DUMMY_ID_STR;
 }
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Desktop analytics identity (Segment userId / Braze external_id) on app boot.
  - QA: upgrade path from a build that has `app.identities` with deviceIds but no `userId` (deviceId rollout) while `app.user.id` exists — verify Settings → Developer → userId still matches the legacy id after upgrade.

### 📝 Description

Since LLD 2.145.0, a migration bug can assign a new `userId` to existing users on upgrade, so returning users appear as new in Segment (and Braze, which shares the id).

Root cause: desktop `initIdentities` branched on the mere existence of `app.identities`. Records created by the earlier deviceId rollout (~2.140) contain `deviceIds` only — no `userId` — so the slice generated a fresh UUID and the legacy `app.user.id` was never read. The wrong id was then persisted, making it permanent.

Fix: when the persisted `userId` is unusable, recover the legacy id from `app.user` (then `localStorage.userId`) and merge it onto the persisted `deviceIds`/push state. A fresh id is only generated when no legacy id exists anywhere. This mirrors the precedence mobile already uses. `datadogId` is recovered the same way. `shouldUsePersistedId` is now exported from `@ledgerhq/client-ids/store` so the helper and the slice agree on what counts as a usable id.

Tests: the previous test that encoded the bug as intentional ("persisted takes precedence") is rewritten to assert the legacy id is recovered; a localStorage-fallback variant is added. Both new tests were confirmed to fail against the old code before the fix.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-32940
- **ADR link (if any)**: _n/a_
