### PR TITLE
[LWM] fix(mobile): track DIE drawer close from header/backdrop press

### DIFF
--- a/.changeset/die-lwm-drawer-close-tracking.md
+++ b/.changeset/die-lwm-drawer-close-tracking.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Track Device Intent Executor drawer close clicks only from explicit header close and backdrop press interactions

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/index.tsx
@@ -56,13 +56,21 @@ export function DeviceIntentExecutorLWM<JobState, Input, ExtraProps>(
   props: Props<JobState, Input, ExtraProps>,
 ): React.ReactElement {
   const { bottom: bottomInset } = useSafeAreaInsets();
-  const { sourceFlow, wrappedProps, hasHeaderOverride, headerContextValue } =
-    useDeviceIntentExecutorLWMViewModel(props);
+  const {
+    sourceFlow,
+    wrappedProps,
+    hasHeaderOverride,
+    headerContextValue,
+    onHeaderClosePressed,
+    onBackdropPress,
+  } = useDeviceIntentExecutorLWMViewModel(props);
 
   return (
     <QueuedDrawerBottomSheet
       isRequestingToBeOpened={wrappedProps.enabled}
       onClose={wrappedProps.onUserCancel}
+      onHeaderClosePressed={onHeaderClosePressed}
+      onBackdropPress={onBackdropPress}
       hideHandle
       enableDynamicSizing
     >

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.test.tsx
@@ -316,8 +316,44 @@ describe("useDeviceIntentExecutorLWMViewModel", () => {
     });
   });
 
-  describe("GIVEN a ViewModel that has not yet completed", () => {
-    it("WHEN the user cancels THEN it tracks the Close button click", () => {
+  describe("GIVEN the drawer close interaction is triggered", () => {
+    it("WHEN the header close button is pressed THEN it tracks the Close button click", () => {
+      // GIVEN
+      const { result } = renderViewModel();
+      mockedTrack.mockClear();
+
+      // WHEN
+      act(() => {
+        result.current.onHeaderClosePressed();
+      });
+
+      // THEN
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        button: "Close",
+      });
+    });
+
+    it("WHEN the backdrop is pressed THEN it tracks the Close button click", () => {
+      // GIVEN
+      const { result } = renderViewModel();
+      mockedTrack.mockClear();
+
+      // WHEN
+      act(() => {
+        result.current.onBackdropPress();
+      });
+
+      // THEN
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        button: "Close",
+      });
+    });
+
+    it("WHEN the user cancels (onClose) THEN it does NOT track the Close button click", () => {
       // GIVEN
       const { result } = renderViewModel();
       mockedTrack.mockClear();
@@ -328,13 +364,11 @@ describe("useDeviceIntentExecutorLWMViewModel", () => {
       });
 
       // THEN
-      expect(mockedTrack).toHaveBeenNthCalledWith(1, "button_clicked", {
-        ...layerABaseProperties,
-        sourceFlow: "swap",
-        button: "Close",
-      });
+      expect(mockedTrack).not.toHaveBeenCalledWith("button_clicked", expect.anything());
     });
+  });
 
+  describe("GIVEN a ViewModel that has not yet completed", () => {
     it("WHEN the user cancels from a non-blocking page THEN it fires deviceflow_aborted and forwards to the original onUserCancel", () => {
       // GIVEN
       const onUserCancel = jest.fn();

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
@@ -38,13 +38,13 @@ export type DeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps> = {
   /**
    * Tracks the "Close" `button_clicked` event when the drawer header close button is pressed.
    * Wired to the drawer's `onHeaderClosePressed` so tracking reflects real user intent, unlike
-   * `onClose` which fires once the close animation finishes for any closing reason.
+   * `onClose` which can fire for any closing reason.
    */
   onHeaderClosePressed: () => void;
   /**
    * Tracks the "Close" `button_clicked` event when the drawer backdrop is pressed.
    * Wired to the drawer's `onBackdropPress` so tracking reflects real user intent, unlike
-   * `onClose` which fires once the close animation finishes for any closing reason.
+   * `onClose` which can fire for any closing reason.
    */
   onBackdropPress: () => void;
 };

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
@@ -35,6 +35,18 @@ export type DeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps> = {
   wrappedProps: Props<JobState, Input, ExtraProps>;
   hasHeaderOverride: boolean;
   headerContextValue: DeviceIntentExecutorHeaderContextValue;
+  /**
+   * Tracks the "Close" `button_clicked` event when the drawer header close button is pressed.
+   * Wired to the drawer's `onHeaderClosePressed` so tracking reflects real user intent, unlike
+   * `onClose` which fires once the close animation finishes for any closing reason.
+   */
+  onHeaderClosePressed: () => void;
+  /**
+   * Tracks the "Close" `button_clicked` event when the drawer backdrop is pressed.
+   * Wired to the drawer's `onBackdropPress` so tracking reflects real user intent, unlike
+   * `onClose` which fires once the close animation finishes for any closing reason.
+   */
+  onBackdropPress: () => void;
 };
 
 type ConnectionTrackingInfo = {
@@ -56,7 +68,7 @@ export function useDeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps>
 
   const flowStartedRef = useRef(false);
   const initializationCompletedRef = useRef(false);
-  const closeTrackedRef = useRef(false);
+  const cancelTrackedRef = useRef(false);
   const { hasHeaderOverride, headerContextValue } = useDeviceIntentExecutorHeaderOverrideRequests();
 
   useKeepScreenAwake(enabled);
@@ -65,7 +77,7 @@ export function useDeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps>
     if (!enabled) {
       flowStartedRef.current = false;
       initializationCompletedRef.current = false;
-      closeTrackedRef.current = false;
+      cancelTrackedRef.current = false;
       return;
     }
 
@@ -88,10 +100,13 @@ export function useDeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps>
     [enabled, onExecutorStateChanged, sourceFlow],
   );
 
+  const trackClose = useCallback(() => {
+    trackDrawerCloseButtonClicked({ sourceFlow });
+  }, [sourceFlow]);
+
   const wrappedOnUserCancel = useCallback(() => {
-    if (!closeTrackedRef.current) {
-      closeTrackedRef.current = true;
-      trackDrawerCloseButtonClicked({ sourceFlow });
+    if (!cancelTrackedRef.current) {
+      cancelTrackedRef.current = true;
       if (!initializationCompletedRef.current) {
         trackDeviceflowCanceled({ sourceFlow });
       }
@@ -103,6 +118,8 @@ export function useDeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps>
     sourceFlow,
     hasHeaderOverride,
     headerContextValue,
+    onHeaderClosePressed: trackClose,
+    onBackdropPress: trackClose,
     wrappedProps: {
       ...props,
       onExecutorStateChanged: wrappedOnExecutorStateChanged,

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/QueuedDrawerBottomSheet.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/QueuedDrawerBottomSheet.tsx
@@ -22,6 +22,17 @@ export type QueuedDrawerBottomSheetProps = {
   onBack?: () => void;
   /** Callback when the drawer is closed. */
   onClose?: () => void;
+  /**
+   * Callback when the header close button (X) is pressed. Unlike {@link onClose}, which fires
+   * once the close animation finishes for any closing reason, this fires only on an explicit
+   * header close press. Use it to track close intent accurately.
+   */
+  onHeaderClosePressed?: () => void;
+  /**
+   * Callback when the backdrop is pressed. Fires only on an explicit backdrop press, before the
+   * drawer is dismissed. Use it to track close intent accurately.
+   */
+  onBackdropPress?: () => void;
   /** Callback after the drawer is fully hidden. */
   onModalHide?: () => void;
   /** Prevent closing via backdrop press. */
@@ -48,6 +59,8 @@ const QueuedDrawerBottomSheet = ({
   isRequestingToBeOpened = false,
   isForcingToBeOpened = false,
   onClose,
+  onHeaderClosePressed,
+  onBackdropPress,
   onBack,
   hasBackButton,
   onModalHide,
@@ -66,7 +79,7 @@ const QueuedDrawerBottomSheet = ({
   const {
     bottomSheetRef,
     areDrawersLocked,
-    handleUserClose,
+    handleBackdropPress,
     handleDismiss,
     handleCloseAnimationStart,
     onBack: hookOnBack,
@@ -78,6 +91,7 @@ const QueuedDrawerBottomSheet = ({
     isForcingToBeOpened,
     onClose,
     onBack,
+    onBackdropPress,
     onModalHide,
     preventBackdropClick,
   });
@@ -97,8 +111,9 @@ const QueuedDrawerBottomSheet = ({
       onBack={hasBackButton ? hookOnBack : undefined}
       onAnimate={handleCloseAnimationStart}
       onDismiss={handleDismiss}
+      onHeaderClosePressed={onHeaderClosePressed}
       backdropPressBehavior={preventBackdropClick || areDrawersLocked ? "none" : "close"}
-      onBackdropPress={handleUserClose}
+      onBackdropPress={handleBackdropPress}
       backgroundComponent={backgroundComponent}
     >
       <BottomSheetBackgroundContext.Provider value={backgroundContextValue}>

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/QueuedDrawerBottomSheet.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/QueuedDrawerBottomSheet.tsx
@@ -23,9 +23,9 @@ export type QueuedDrawerBottomSheetProps = {
   /** Callback when the drawer is closed. */
   onClose?: () => void;
   /**
-   * Callback when the header close button (X) is pressed. Unlike {@link onClose}, which fires
-   * once the close animation finishes for any closing reason, this fires only on an explicit
-   * header close press. Use it to track close intent accurately.
+   * Callback when the header close button (X) is pressed. Unlike {@link onClose}, which can fire
+   * for any closing reason (header, backdrop, gestures, or programmatic dismiss), this fires only
+   * on an explicit header close press. Use it to track close intent accurately.
    */
   onHeaderClosePressed?: () => void;
   /**

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/useQueuedDrawerBottomSheet.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/useQueuedDrawerBottomSheet.ts
@@ -14,6 +14,7 @@ interface UseQueuedDrawerBottomSheetProps {
   isForcingToBeOpened?: boolean;
   onClose?: () => void;
   onBack?: () => void;
+  onBackdropPress?: () => void;
   onModalHide?: () => void;
   preventBackdropClick?: boolean;
 }
@@ -25,6 +26,7 @@ const useQueuedDrawerBottomSheet = ({
   isForcingToBeOpened = false,
   onClose,
   onBack,
+  onBackdropPress,
   onModalHide,
   preventBackdropClick,
 }: UseQueuedDrawerBottomSheetProps) => {
@@ -40,6 +42,9 @@ const useQueuedDrawerBottomSheet = ({
 
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
+
+  const onBackdropPressRef = useRef(onBackdropPress);
+  onBackdropPressRef.current = onBackdropPress;
 
   const onModalHideRef = useRef(onModalHide);
   onModalHideRef.current = onModalHide;
@@ -104,6 +109,14 @@ const useQueuedDrawerBottomSheet = ({
     logDrawer("User initiated close");
     bottomSheetRef.current?.dismiss();
   }, [bottomSheetRef]);
+
+  // Notifies the consumer of the explicit backdrop press before dismissing. Unlike onClose
+  // (which fires for any closing reason), this reflects a real user close interaction.
+  const handleBackdropPress = useCallback(() => {
+    logDrawer("Backdrop pressed");
+    onBackdropPressRef.current?.();
+    handleUserClose();
+  }, [handleUserClose]);
 
   // Fired at the START of an animation. A close animation targets index -1, so this is the
   // earliest deterministic signal that the sheet is closing — for the X (close) button, the
@@ -178,6 +191,7 @@ const useQueuedDrawerBottomSheet = ({
     bottomSheetRef,
     areDrawersLocked,
     handleUserClose,
+    handleBackdropPress,
     handleDismiss,
     handleCloseAnimationStart,
     onBack,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Device Intent Executor drawer close tracking on Ledger Wallet Mobile
  - Header close button and backdrop press analytics
  - Device flow cancellation and abort analytics behavior

### 📝 Description

This PR fixes Device Intent Executor close tracking on Ledger Wallet Mobile. Previously, the `Close` button analytics were tied to the drawer close lifecycle, which can run after the close animation for different dismissal reasons instead of representing a specific user close interaction.

The drawer now exposes explicit callbacks for header close presses and backdrop presses, and the Device Intent Executor view model tracks `button_clicked` `Close` events from those user interactions only. The existing `onClose` cancellation path remains responsible for device flow abort/failure tracking without emitting the close-button click event.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31856](https://ledgerhq.atlassian.net/browse/LIVE-31856)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31856]: https://ledgerhq.atlassian.net/browse/LIVE-31856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ