### PR TITLE
docs(errors): deprecate @ledgerhq/errors and document the modern pattern

### DIFF
--- a/.agents/skills/errors/SKILL.md
+++ b/.agents/skills/errors/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: errors
+description: |
+  How to define and check error classes in Ledger Live. Read when adding a new
+  error, creating an errors.ts file, or checking an error's type. Replaces the
+  deprecated @ledgerhq/errors lib (createCustomErrorClass + serialize/deserialize).
+globs: ["**/errors.ts", "**/errors/**/*.ts"]
+---
+
+# Errors
+
+Each package owns its errors in its own `src/errors.ts`, as plain native classes.
+Do **not** add new errors to `@ledgerhq/errors` (`libs/ledgerjs/packages/errors`) —
+that lib is deprecated and frozen (see its `DEPRECATED.md`).
+
+## Define errors
+
+A package groups its errors in `src/errors.ts`. Extend `Error` directly and set a
+stable `name`. The `name` string is the contract — keep it stable, it is what
+survives across process/serialization boundaries.
+
+```ts
+// message-only
+export class FooNotFound extends Error {
+  override name = "FooNotFound";
+}
+
+// with a default message
+export class InvalidChallenge extends Error {
+  override name = "InvalidChallenge";
+  constructor() {
+    super("backend returned an invalid challenge");
+  }
+}
+
+// with extra fields
+export class HttpError extends Error {
+  override name = "HttpError";
+  readonly status: number | undefined;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.status = status;
+  }
+}
+```
+
+Group a family under a per-package base class so callers can catch the whole set:
+
+```ts
+export class WalletAuthError extends Error {
+  override name = "WalletAuthError";
+}
+export class WalletAuthSignatureError extends WalletAuthError {
+  override name = "WalletAuthSignatureError";
+  constructor(cause: unknown) {
+    super("failed to sign challenge", { cause });
+  }
+}
+```
+
+See `libs/ledger-auth/src/errors.ts` for a full reference.
+
+### `cause`
+
+Use the native second argument: `super(message, { cause })`. Error `cause` was
+standardized in ES2022 and is supported by modern runtimes; its TypeScript typing
+(`ErrorOptions`) requires `lib: es2022.error` (i.e. `es2022`). Coin modules and
+some older packages still target `es2020` — there, declare and assign manually:
+
+```ts
+export class BroadcastError extends Error {
+  override name = "BroadcastError";
+  cause?: unknown;
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.cause = cause;
+  }
+}
+```
+
+## Check error type: prefer `error.name`
+
+Prefer `error.name === "FooNotFound"` over `instanceof FooNotFound`.
+
+`instanceof` breaks once an error crosses a boundary — desktop/mobile IPC, worker
+messaging, or the external `@ledgerhq/coin-module-framework` — because the object
+is rebuilt and loses its prototype. The `name` string always survives.
+
+```ts
+// ✅ survives serialization
+if (error instanceof Error && error.name === "FooNotFound") { … }
+
+// ⚠️ only works in-process, before any serialization
+if (error instanceof FooNotFound) { … }
+```
+
+Use `instanceof` only when you are certain the error has not crossed a boundary
+(e.g. caught in the same module that threw it) and you need the typed fields.
+
+## Where errors live
+
+- Logic in one package → that package's `src/errors.ts`.
+- Used only by an app → the app's `src/errors.ts` (`apps/ledger-live-desktop`,
+  `apps/ledger-live-mobile`).
+- Shared by several coin modules → for now stay in `@ledgerhq/errors` (no editable
+  shared package sits below the coin layer); do not add new ones there.

--- a/.changeset/errors-lib-deprecation-notice.md
+++ b/.changeset/errors-lib-deprecation-notice.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/errors": patch
+---
+
+Document the package as deprecated: add a frozen-lib banner, `@deprecated` JSDoc on `createCustomErrorClass` and the serialize/deserialize helpers, a DEPRECATED.md, and a README notice. No runtime change.

--- a/libs/ledgerjs/packages/errors/DEPRECATED.md
+++ b/libs/ledgerjs/packages/errors/DEPRECATED.md
@@ -1,0 +1,29 @@
+# @ledgerhq/errors is deprecated
+
+This package is **frozen** and being sunset. It stays published for backward
+compatibility (it is consumed externally, including by `@ledgerhq/coin-module-framework`),
+but it must not grow.
+
+## Do not
+
+- ❌ Add new error classes here (whether via `createCustomErrorClass` or hand-written).
+- ❌ Use `createCustomErrorClass` in any package.
+- ❌ Use the serialization stack — `serializeError`, `deserializeError`,
+  `addCustomErrorDeserializer`. Send a plain `{ name, message }` shape over a
+  boundary and branch on `error.name` at the consumer.
+
+## Do instead
+
+Define errors as plain native classes in your own package's `src/errors.ts`, and
+check their type with `error.name === "X"` rather than `instanceof` (the name
+survives serialization across IPC / workers / external frameworks).
+
+In the ledger-live repo, the `errors` skill documents the full how-to, and
+`libs/ledger-auth/src/errors.ts` is a reference implementation.
+
+## Why it can't just be deleted
+
+- The public API is consumed by external packages and apps; removal is future work.
+- ~22 errors are shared by several sibling coin modules and have no editable home
+  package below the coin layer yet. They stay here for now; future owner is the
+  `coin-module-framework` repo.

--- a/libs/ledgerjs/packages/errors/README.md
+++ b/libs/ledgerjs/packages/errors/README.md
@@ -2,6 +2,11 @@
 
 ## @ledgerhq/errors
 
+> ⚠️ **Deprecated and frozen.** Do not add new errors here and do not use
+> `createCustomErrorClass` or the serialize/deserialize stack. Define errors as
+> plain native classes in your own package's `src/errors.ts` and check them with
+> `error.name === "X"`. See [DEPRECATED.md](./DEPRECATED.md).
+
 Hodl all possible errors of Ledger (live, ledgerjs) so we can deal with them in a unified way (share between libraries, `instanceof` them,...)
 
 ## API

--- a/libs/ledgerjs/packages/errors/src/helpers.ts
+++ b/libs/ledgerjs/packages/errors/src/helpers.ts
@@ -6,17 +6,43 @@
 const errorClasses = {};
 const deserializers = {};
 
+/**
+ * @ignore
+ * @deprecated Part of the error serialization stack being sunset. Do not register
+ * new deserializers. Prefer checking `error.name === "X"` over rebuilding classes —
+ * a name comparison works the same before and after a value crosses a boundary.
+ */
 export const addCustomErrorDeserializer = (name: string, deserializer: (obj: any) => any): void => {
   deserializers[name] = deserializer;
 };
 
-export interface LedgerErrorConstructor<F extends { [key: string]: unknown }>
-  extends ErrorConstructor {
+/**
+ * @ignore
+ * @deprecated Type of the legacy `createCustomErrorClass` factory, which is itself
+ * deprecated. Do not type new code against it.
+ */
+export interface LedgerErrorConstructor<
+  F extends { [key: string]: unknown },
+> extends ErrorConstructor {
   new (message?: string, fields?: F, options?: any): Error & F;
   (message?: string, fields?: F, options?: any): Error & F;
   readonly prototype: Error & F;
 }
 
+/**
+ * @ignore
+ * @deprecated Do not create new error classes with this factory. Define a plain
+ * native class instead, in your own package's `src/errors.ts`:
+ *
+ * ```ts
+ * export class MyError extends Error {
+ *   override name = "MyError";
+ * }
+ * ```
+ *
+ * Check the type with `error.name === "MyError"` (survives serialization) rather
+ * than `instanceof`.
+ */
 export const createCustomErrorClass = <
   F extends { [key: string]: unknown },
   T extends LedgerErrorConstructor<F> = LedgerErrorConstructor<F>,
@@ -61,6 +87,13 @@ function isObject(value) {
   return typeof value === "object";
 }
 
+/**
+ * @ignore
+ * @deprecated The serialize/deserialize stack is being sunset. Rebuilding a class
+ * from a wire object is brittle (it silently degrades to a plain Error for unknown
+ * names). Pass `{ name, message }` and branch on `error.name` at the consumer
+ * instead.
+ */
 // inspired from https://github.com/programble/errio/blob/master/index.js
 export const deserializeError = (object: any): Error | undefined => {
   if (object && typeof object === "object") {
@@ -121,6 +154,11 @@ export const deserializeError = (object: any): Error | undefined => {
   return new Error(String(object));
 };
 
+/**
+ * @ignore
+ * @deprecated The serialize/deserialize stack is being sunset. Send a plain
+ * `{ name, message }` shape and branch on `error.name` at the consumer instead.
+ */
 // inspired from https://github.com/sindresorhus/serialize-error/blob/master/index.js
 export const serializeError = (
   value: undefined | To | string | (() => unknown),

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -1,3 +1,18 @@
+/*
+ * ⚠️ DEPRECATED LIBRARY — DO NOT ADD NEW ERRORS HERE.
+ *
+ * `@ledgerhq/errors` is frozen and being sunset. Do not add new error classes,
+ * and do not use `createCustomErrorClass` or the serialize/deserialize stack in
+ * new code.
+ *
+ * Instead, define errors as plain native classes in your own package's
+ * `src/errors.ts`, and check types with `error.name === "X"` (survives
+ * serialization) rather than `instanceof`.
+ *
+ * The existing exports below stay for backward compatibility (this lib is
+ * published and consumed externally), but must not grow.
+ */
+
 import {
   serializeError,
   deserializeError,


### PR DESCRIPTION
> [!NOTE]
> Documentation-only change. No runtime behavior is modified. It freezes the published `@ledgerhq/errors` lib and documents the pattern we want instead.

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** N/A — docs, JSDoc and a skill only. No code path changes.
- [ ] **Impact of the changes:**
  - None at runtime. New `@deprecated` JSDoc may surface editor hints at existing call sites (the repo's `@typescript-eslint/no-deprecated` rule is disabled, so CI is unaffected).

### 📝 Description

Follow-up to #18733, where we tried to move errors out of `@ledgerhq/errors` and got stuck: the lib is published and used outside this repo (incl. `@ledgerhq/coin-module-framework`), so we cannot remove it yet. What we can do now is write down the pattern we want and stop the lib from growing.

**Why now.** The lib is still actively growing — the factory now has 145 `createCustomErrorClass` declarations, and recent commits keep adding more:

<img width="1177" height="717" alt="recent commits still adding errors to the errors pkg" src="https://github.com/user-attachments/assets/f3e79f5d-c56c-4be0-b759-e4bfc6b757cb" />

This PR makes it explicit that the lib is frozen, and points contributors to the right pattern.

**The pattern we document instead** — plain native classes in each package's own `src/errors.ts`, type-checked by name:

```ts
// libs/<pkg>/src/errors.ts
export class FooNotFound extends Error {
  override name = "FooNotFound";
}

// prefer error.name over instanceof — the name survives serialization
// across IPC / workers / coin-module-framework, instanceof does not
if (error instanceof Error && error.name === "FooNotFound") { ... }
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32915](https://ledgerhq.atlassian.net/browse/LIVE-32915) — follow-up to #18733
- **ADR link (if any)**: N/A



[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35075