### PR TITLE
[LWM] fix(mobile): handle uncommon market countervalues

### DIFF
--- a/.changeset/bright-maps-resolve.md
+++ b/.changeset/bright-maps-resolve.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix mobile market countervalue fallback and formatting for unsupported fiats and crypto units.

--- a/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/__integrations__/MarketCapCard.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/__integrations__/MarketCapCard.test.tsx
@@ -5,6 +5,7 @@ import { http, HttpResponse } from "msw";
 import { MarketCapCard } from "../index";
 
 const API_ENDPOINT = "https://countervalues.live.ledger.com/v3/markets/global";
+const SPOT_SIMPLE_URL = "https://countervalues.live.ledger.com/v3/spot/simple";
 
 // percentageChanges are ratios (0.1 => +10.00%).
 const createMockResponse = (marketCap: number, dailyChangeRatio: number) => ({
@@ -34,6 +35,23 @@ describe("MarketCapCard Integration", () => {
     expect(card.getByText("Total market cap")).toBeVisible();
     expect(card.getByText(/3.*T/i)).toBeVisible();
     expect(card.getByText("10.00%")).toBeVisible();
+  });
+
+  it("should rescale the USD global market cap into a crypto countervalue", async () => {
+    server.use(
+      http.get(API_ENDPOINT, () => HttpResponse.json(createMockResponse(3_000_000_000_000, 0.1))),
+      http.get(SPOT_SIMPLE_URL, () => HttpResponse.json({ USD: 0.00001 })),
+    );
+
+    render(<MarketCapCard width={276} />, {
+      overrideInitialState: state => ({
+        ...state,
+        settings: { ...state.settings, counterValue: "BTC" },
+      }),
+    });
+
+    const card = within(await screen.findByTestId("market-cap-card"));
+    expect(card.getByText(/₿30.*M/i)).toBeVisible();
   });
 
   it("should open definition drawer when card is pressed", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/useMarketCapCardViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/MarketCapCard/useMarketCapCardViewModel.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import { useGlobalMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
+import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
 import { useSelector } from "~/context/hooks";
 import { counterValueCurrencySelector } from "~/reducers/settings";
 import { useLocale, useTranslation } from "~/context/Locale";
@@ -21,7 +22,8 @@ export function useMarketCapCardViewModel(): MarketCapCardViewModel {
   const { locale } = useLocale();
   const counterCurrency = useSelector(counterValueCurrencySelector).ticker.toLowerCase();
 
-  const { data, isLoading, isError } = useGlobalMarketData({ counterCurrency });
+  const { data, isLoading, isError } = useGlobalMarketData({ counterCurrency: "usd" });
+  const { rate, status: rateStatus } = useUsdToFiatRate(counterCurrency);
 
   const handleOpenDrawer = useCallback(() => {
     trackDefinitionPressed();
@@ -31,20 +33,21 @@ export function useMarketCapCardViewModel(): MarketCapCardViewModel {
   const handleCloseDrawer = useCallback(() => {
     setIsDrawerOpen(false);
   }, []);
+  const marketCap = data && rate != null ? data.marketCap * rate : undefined;
 
   return {
-    value: data
+    value: marketCap
       ? counterValueFormatter({
           currency: counterCurrency,
-          value: data.marketCap,
+          value: marketCap,
           shorten: true,
           locale,
           t,
         })
       : "",
     changePercentage: data?.changePercentage24h,
-    isLoading,
-    isError: isError || !data,
+    isLoading: isLoading || rateStatus === "loading",
+    isError: isError || rateStatus === "error" || !data,
     isDrawerOpen,
     handleOpenDrawer,
     handleCloseDrawer,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
@@ -6,6 +6,8 @@ import {
   useGetAssetChartDataQuery,
 } from "@ledgerhq/live-common/market/state-manager/marketApi";
 import { useOpenReceiveDrawer } from "LLM/features/Receive";
+import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
+import { useSupportedCounterCurrencies } from "@ledgerhq/live-common/cg-client/hooks/useCoingeckoDataProvider";
 import {
   mockBtcCryptoCurrency,
   mockEthCryptoCurrency,
@@ -22,10 +24,18 @@ jest.mock("@ledgerhq/live-common/market/state-manager/marketApi", () => ({
   useGetCurrencyDataQuery: jest.fn(),
   useGetAssetChartDataQuery: jest.fn(),
 }));
+jest.mock("@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate", () => ({
+  useUsdToFiatRate: jest.fn(() => ({ status: "ready", rate: 1 })),
+}));
+jest.mock("@ledgerhq/live-common/cg-client/hooks/useCoingeckoDataProvider", () => ({
+  useSupportedCounterCurrencies: jest.fn(() => ({ data: ["usd", "eur", "btc"] })),
+}));
 jest.mock("LLM/features/Receive");
 
 const mockUseGetCurrencyDataQuery = jest.mocked(useGetCurrencyDataQuery);
 const mockUseGetAssetChartDataQuery = jest.mocked(useGetAssetChartDataQuery);
+const mockUseUsdToFiatRate = jest.mocked(useUsdToFiatRate);
+const mockUseSupportedCounterCurrencies = jest.mocked(useSupportedCounterCurrencies);
 const mockUseOpenReceiveDrawer = jest.mocked(useOpenReceiveDrawer);
 const handleOpenReceiveDrawer = jest.fn();
 
@@ -130,6 +140,10 @@ describe("useBalanceGraphViewModel", () => {
     jest.clearAllMocks();
     mockCurrency({ data: marketCurrencyData });
     mockChart({ data: CHART_DATA_BY_RANGE });
+    mockUseUsdToFiatRate.mockReturnValue({ status: "ready", rate: 1 });
+    mockUseSupportedCounterCurrencies.mockReturnValue({
+      data: ["usd", "eur", "btc"],
+    } as unknown as ReturnType<typeof useSupportedCounterCurrencies>);
     mockUseOpenReceiveDrawer.mockReturnValue({ handleOpenReceiveDrawer });
   });
 
@@ -428,6 +442,43 @@ describe("useBalanceGraphViewModel", () => {
       const { result } = renderVM();
 
       expect(result.current.chartColor).toBe("muted");
+    });
+  });
+
+  describe("crypto countervalue (BTC)", () => {
+    const withBtcCounterValue: StateOption = {
+      overrideInitialState: (state: State): State => ({
+        ...state,
+        settings: { ...state.settings, counterValue: "BTC" },
+      }),
+    };
+
+    it("fetches the chart in USD (not the crypto ticker)", () => {
+      mockUseUsdToFiatRate.mockReturnValue({ status: "ready", rate: 0.5 });
+
+      renderVM({ currency: mockBtcCryptoCurrency }, withBtcCounterValue);
+
+      expect(mockUseGetAssetChartDataQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ counterCurrency: "usd" }),
+        expect.anything(),
+      );
+    });
+
+    it("rescales the USD chart by the USD→BTC rate so the series is populated", () => {
+      const rate = 0.5;
+      mockUseUsdToFiatRate.mockReturnValue({ status: "ready", rate });
+
+      const { result } = renderVM({ currency: mockBtcCryptoCurrency }, withBtcCounterValue);
+
+      expect(result.current.series[0]?.data).toEqual([100, 110, 120].map(value => value * rate));
+    });
+
+    it("withholds the series (empty, not stale USD values) while the rate is unavailable", () => {
+      mockUseUsdToFiatRate.mockReturnValue({ status: "error", rate: null });
+
+      const { result } = renderVM({ currency: mockBtcCryptoCurrency }, withBtcCounterValue);
+
+      expect(result.current.series[0]?.data).toEqual([]);
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
@@ -7,7 +7,7 @@ import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { getOperationAmountNumber } from "@ledgerhq/live-common/operation";
 import { flattenAccounts } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
-import { useAssetChartData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
+import { useAssetChartDataInCounterValue } from "@ledgerhq/live-common/market/hooks/useAssetChartDataInCounterValue";
 import { buildMarketChartSeries } from "@ledgerhq/live-common/market/utils/buildMarketChartSeries";
 import { calculate } from "@ledgerhq/live-countervalues/logic";
 import {
@@ -147,7 +147,7 @@ export function useBalanceGraphViewModel({
     currentData: chartData,
     isLoading: isChartLoading,
     isFetching: isChartFetching,
-  } = useAssetChartData({ id, counterCurrency, range }, { skip: !id });
+  } = useAssetChartDataInCounterValue({ id, counterCurrency, range }, { skip: !id });
 
   const ranges = useMemo(
     () =>

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/__integrations__/largeMoverLandingPage.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/__integrations__/largeMoverLandingPage.integration.test.tsx
@@ -239,7 +239,9 @@ describe("LargeMoverLandingPage Integration Tests", () => {
       },
     );
 
-    expect(await screen.findByText("£47,123.00")).toBeOnTheScreen();
+    const gbpPrices = await screen.findAllByText("£47,123.00");
+    expect(gbpPrices.length).toBeGreaterThan(0);
+    expect(screen.queryByText("$47,123.00")).toBeNull();
     expect(captured.to?.toLowerCase()).toBe("gbp");
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/hooks/__tests__/useMarketCoinData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/hooks/__tests__/useMarketCoinData.test.ts
@@ -1,8 +1,55 @@
-import { renderHook, waitFor } from "@tests/test-renderer";
+import { renderHook } from "@tests/test-renderer";
+import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
+import { useAssetChartDataInCounterValue } from "@ledgerhq/live-common/market/hooks/useAssetChartDataInCounterValue";
+import { useResolveMarketCounterCurrency } from "@ledgerhq/live-common/market/hooks/useResolveMarketCounterCurrency";
+import { useCurrencyData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
 import { useMarketCoinData, useMarketCoinDataWithChart } from "../useMarketCoinData";
-import { withMarketState } from "../../__tests__/helpers";
+import { createMarketCurrencyData, withMarketState } from "../../__tests__/helpers";
+
+jest.mock("@ledgerhq/live-common/market/hooks/useMarketDataProvider");
+jest.mock("@ledgerhq/live-common/market/hooks/useAssetChartDataInCounterValue");
+jest.mock("@ledgerhq/live-common/market/hooks/useResolveMarketCounterCurrency");
+jest.mock("@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate");
+
+const mockedUseCurrencyData = jest.mocked(useCurrencyData);
+const mockedUseAssetChartDataInCounterValue = jest.mocked(useAssetChartDataInCounterValue);
+const mockedUseResolveMarketCounterCurrency = jest.mocked(useResolveMarketCounterCurrency);
+const mockedUseUsdToFiatRate = jest.mocked(useUsdToFiatRate);
+
+const refetch = jest.fn();
+
+function mockCurrencyData(
+  overrides: Partial<ReturnType<typeof useCurrencyData>> = {},
+): ReturnType<typeof useCurrencyData> {
+  return {
+    data: createMarketCurrencyData(),
+    isFetching: false,
+    refetch,
+    ...overrides,
+  } as unknown as ReturnType<typeof useCurrencyData>;
+}
 
 describe("useMarketCoinData hooks", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseResolveMarketCounterCurrency.mockImplementation(({ counterCurrency }) => ({
+      requestCounterCurrency: counterCurrency?.toLowerCase(),
+      displayCounterCurrency: counterCurrency?.toLowerCase(),
+      needsUsdFallback: false,
+      isResolutionLoading: false,
+      supportedCounterCurrencies: ["usd", "eur"],
+    }));
+    mockedUseUsdToFiatRate.mockReturnValue({ status: "ready", rate: 1 });
+    mockedUseCurrencyData.mockReturnValue(mockCurrencyData());
+    mockedUseAssetChartDataInCounterValue.mockReturnValue({
+      data: { prices: [[1, 2]] },
+      currentData: { prices: [[1, 2]] },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    });
+  });
+
   it.each([
     { counterCurrency: "eur", expected: "eur" },
     { counterCurrency: undefined, expected: "usd" },
@@ -33,14 +80,11 @@ describe("useMarketCoinData hooks", () => {
     },
   );
 
-  it("useMarketCoinData should expose loading state and refetch", async () => {
+  it("useMarketCoinData should expose loading state and refetch", () => {
     const { result } = renderHook(() => useMarketCoinData({ currencyId: "bitcoin" }));
 
-    await waitFor(() => {
-      expect(result.current.loading).toBe(false);
-    });
-
-    expect(result.current.refetch).toBeInstanceOf(Function);
+    expect(result.current.loading).toBe(false);
+    expect(typeof result.current.refetch).toBe("function");
   });
 
   it("useMarketCoinDataWithChart should expose marketParams and counterCurrency from Redux", () => {
@@ -50,8 +94,82 @@ describe("useMarketCoinData hooks", () => {
     );
 
     expect(result.current.counterCurrency).toBe("eur");
+    expect(mockedUseAssetChartDataInCounterValue).toHaveBeenCalledWith({
+      counterCurrency: "eur",
+      id: "bitcoin",
+      range: "24h",
+    });
     expect(result.current.marketParams).toEqual(
       expect.objectContaining({ counterCurrency: "eur" }),
     );
+  });
+
+  it("useMarketCoinData should request USD and rescale coin data for crypto countervalues", () => {
+    mockedUseResolveMarketCounterCurrency.mockReturnValue({
+      requestCounterCurrency: "usd",
+      displayCounterCurrency: "btc",
+      needsUsdFallback: true,
+      isResolutionLoading: false,
+      supportedCounterCurrencies: undefined,
+    });
+    mockedUseUsdToFiatRate.mockReturnValue({ status: "ready", rate: 0.00001 });
+    mockedUseCurrencyData.mockReturnValue(
+      mockCurrencyData({
+        data: createMarketCurrencyData({
+          price: 100,
+          marketcap: 200,
+          totalVolume: 300,
+          high24h: 120,
+          low24h: 90,
+          ath: 150,
+          atl: 50,
+        }),
+      }),
+    );
+
+    const { result } = renderHook(
+      () => useMarketCoinData({ currencyId: "bitcoin" }),
+      withMarketState({ marketParams: { counterCurrency: "btc" } }),
+    );
+
+    expect(mockedUseCurrencyData).toHaveBeenCalledWith({
+      counterCurrency: "usd",
+      id: "bitcoin",
+    }, { skip: false });
+    expect(mockedUseUsdToFiatRate).toHaveBeenCalledWith("btc", { skip: false });
+    expect(result.current.counterCurrency).toBe("btc");
+    expect(result.current.currency?.price).toBeCloseTo(0.001);
+    expect(result.current.currency?.marketcap).toBeCloseTo(0.002);
+    expect(result.current.currency?.totalVolume).toBeCloseTo(0.003);
+    expect(result.current.currency?.high24h).toBeCloseTo(0.0012);
+    expect(result.current.currency?.low24h).toBeCloseTo(0.0009);
+    expect(result.current.currency?.ath).toBeCloseTo(0.0015);
+    expect(result.current.currency?.atl).toBeCloseTo(0.0005);
+  });
+
+  it("useMarketCoinData should skip the native request while countervalue resolution is loading", () => {
+    mockedUseResolveMarketCounterCurrency.mockReturnValue({
+      requestCounterCurrency: "cop",
+      displayCounterCurrency: "cop",
+      needsUsdFallback: false,
+      isResolutionLoading: true,
+      supportedCounterCurrencies: undefined,
+    });
+
+    const { result } = renderHook(
+      () => useMarketCoinData({ currencyId: "bitcoin" }),
+      withMarketState({ marketParams: { counterCurrency: "cop" } }),
+    );
+
+    expect(mockedUseCurrencyData).toHaveBeenCalledWith(
+      {
+        counterCurrency: "cop",
+        id: "bitcoin",
+      },
+      { skip: true },
+    );
+    expect(mockedUseUsdToFiatRate).toHaveBeenCalledWith("usd", { skip: true });
+    expect(result.current.loading).toBe(true);
+    expect(result.current.currency).toBeUndefined();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/hooks/useMarketCoinData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/hooks/useMarketCoinData.ts
@@ -1,7 +1,9 @@
-import {
-  useAssetChartData,
-  useCurrencyData,
-} from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
+import { useMemo } from "react";
+import { useCurrencyData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
+import { useAssetChartDataInCounterValue } from "@ledgerhq/live-common/market/hooks/useAssetChartDataInCounterValue";
+import { useResolveMarketCounterCurrency } from "@ledgerhq/live-common/market/hooks/useResolveMarketCounterCurrency";
+import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
+import { applyUsdRateToMarket } from "@ledgerhq/live-common/market/utils/applyUsdRateToMarket";
 
 import { useSelector } from "~/context/hooks";
 import { marketParamsSelector } from "~/reducers/market";
@@ -13,21 +15,42 @@ type HookProps = {
 export const useMarketCoinData = ({ currencyId }: HookProps) => {
   const marketParams = useSelector(marketParamsSelector);
 
-  const { counterCurrency = "usd" } = marketParams;
-
+  const { counterCurrency: settingsCounterCurrency = "usd" } = marketParams;
   const {
-    data: currency,
-    isFetching,
-    refetch,
-  } = useCurrencyData({
-    counterCurrency,
-    id: currencyId,
+    requestCounterCurrency,
+    displayCounterCurrency = settingsCounterCurrency,
+    needsUsdFallback,
+    isResolutionLoading,
+  } = useResolveMarketCounterCurrency({
+    counterCurrency: settingsCounterCurrency,
+    fallbackForCryptoCountervalues: true,
   });
+  const shouldFetchCurrency = !isResolutionLoading;
+
+  const { data, isFetching, refetch } = useCurrencyData(
+    {
+      counterCurrency: requestCounterCurrency,
+      id: currencyId,
+    },
+    { skip: !shouldFetchCurrency },
+  );
+  const { rate: usdToCounterValueRate, status: rateStatus } = useUsdToFiatRate(
+    needsUsdFallback ? displayCounterCurrency : "usd",
+    { skip: !shouldFetchCurrency },
+  );
+
+  const rate = needsUsdFallback ? usdToCounterValueRate : 1;
+  const currency = useMemo(() => {
+    if (isResolutionLoading || rate == null || !data) return undefined;
+    return applyUsdRateToMarket(data, rate);
+  }, [data, isResolutionLoading, rate]);
+
+  const isRateLoading = needsUsdFallback && rateStatus === "loading";
 
   return {
-    counterCurrency,
+    counterCurrency: displayCounterCurrency,
     currency,
-    loading: isFetching,
+    loading: isResolutionLoading || isFetching || isRateLoading,
     refetch,
   };
 };
@@ -37,7 +60,7 @@ export const useMarketCoinDataWithChart = ({ currencyId }: HookProps) => {
 
   const { counterCurrency = "usd", range = "24h" } = marketParams;
 
-  const { data: dataChart, isFetching: loadingChart } = useAssetChartData({
+  const { currentData: dataChart, isFetching: loadingChart } = useAssetChartDataInCounterValue({
     counterCurrency,
     id: currencyId,
     range,

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketAssets.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketAssets.test.ts
@@ -1,11 +1,22 @@
 import { act, renderHook, waitFor } from "@tests/test-renderer";
 import { useMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
-import { Order, type MarketListRequestResult } from "@ledgerhq/live-common/market/utils/types";
+import { useSupportedCounterCurrencies } from "@ledgerhq/live-common/cg-client/hooks/useCoingeckoDataProvider";
+import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
+import {
+  Order,
+  type MarketListRequestParams,
+  type MarketListRequestResult,
+} from "@ledgerhq/live-common/market/utils/types";
+import type { State } from "~/reducers/types";
 import { createMarketCurrencyData } from "../../../__tests__/helpers";
 import { useMarketAssets } from "../useMarketAssets";
 
 jest.mock("@ledgerhq/live-common/market/hooks/useMarketDataProvider");
+jest.mock("@ledgerhq/live-common/cg-client/hooks/useCoingeckoDataProvider");
+jest.mock("@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate");
 const mockedUseMarketData = jest.mocked(useMarketData);
+const mockedUseSupportedCounterCurrencies = jest.mocked(useSupportedCounterCurrencies);
+const mockedUseUsdToFiatRate = jest.mocked(useUsdToFiatRate);
 
 const bitcoin = createMarketCurrencyData({ id: "bitcoin", name: "Bitcoin" });
 const ethereum = createMarketCurrencyData({ id: "ethereum", name: "Ethereum", ticker: "eth" });
@@ -38,10 +49,45 @@ function mockMarketData(overrides: Partial<MarketListRequestResult> = {}) {
   });
 }
 
+function mockSupportedCounterCurrencies(supportedCounterCurrencies?: string[]) {
+  mockedUseSupportedCounterCurrencies.mockReturnValue({
+    data: supportedCounterCurrencies,
+  } as unknown as ReturnType<typeof useSupportedCounterCurrencies>);
+}
+
+function mockUsdToFiatRate(rate: ReturnType<typeof useUsdToFiatRate>) {
+  mockedUseUsdToFiatRate.mockReturnValue(rate);
+}
+
+function expectMarketDataLastCalledWith(
+  params: Partial<MarketListRequestParams>,
+  options = { enabled: true },
+) {
+  expect(mockedUseMarketData).toHaveBeenLastCalledWith(expect.objectContaining(params), options);
+}
+
+function expectMarketDataNotCalledWith(
+  params: Partial<MarketListRequestParams>,
+  options = { enabled: true },
+) {
+  expect(mockedUseMarketData).not.toHaveBeenCalledWith(expect.objectContaining(params), options);
+}
+
+// Force the locale so the expected formatted price is deterministic.
+const withCounterValue = (ticker: string) => ({
+  overrideInitialState: (state: State) => ({
+    ...state,
+    settings: { ...state.settings, counterValue: ticker, language: "en" },
+  }),
+});
+
 describe("useMarketAssets", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockMarketData();
+    // Defaults: supported list not yet loaded + a no-op rate, i.e. no USD fallback.
+    mockSupportedCounterCurrencies(undefined);
+    mockUsdToFiatRate({ status: "ready", rate: 1 });
   });
 
   it("maps market data into display rows", () => {
@@ -70,18 +116,18 @@ describe("useMarketAssets", () => {
     expect(result.current.isFetchingNextPage).toBe(false);
 
     act(() => result.current.onEndReached());
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(expect.objectContaining({ page: 2 }));
+    expectMarketDataLastCalledWith({ page: 2 });
     expect(result.current.isFetchingNextPage).toBe(true);
 
     act(() => result.current.onEndReached());
-    expect(mockedUseMarketData).not.toHaveBeenCalledWith(expect.objectContaining({ page: 3 }));
+    expectMarketDataNotCalledWith({ page: 3 });
   });
 
   it("requests the next page on end reached", () => {
     mockMarketData({ data: fullMarketPage });
     const { result } = renderHook(() => useMarketAssets());
     act(() => result.current.onEndReached());
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(expect.objectContaining({ page: 2 }));
+    expectMarketDataLastCalledWith({ page: 2 });
   });
 
   it("does not request the next page when the current page is incomplete", () => {
@@ -89,7 +135,7 @@ describe("useMarketAssets", () => {
 
     act(() => result.current.onEndReached());
 
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(expect.objectContaining({ page: 1 }));
+    expectMarketDataLastCalledWith({ page: 1 });
   });
 
   it("uses the fetched item count to decide whether the next page can load", () => {
@@ -100,13 +146,13 @@ describe("useMarketAssets", () => {
 
     act(() => result.current.onEndReached());
 
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(expect.objectContaining({ page: 2 }));
+    expectMarketDataLastCalledWith({ page: 2 });
   });
 
   it("passes the trimmed search query", () => {
     renderHook(() => useMarketAssets({ search: " b " }));
 
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(expect.objectContaining({ search: "b" }));
+    expectMarketDataLastCalledWith({ search: "b" });
   });
 
   it("resets the page when the search query changes", async () => {
@@ -115,41 +161,33 @@ describe("useMarketAssets", () => {
     const { result, rerender } = renderHook(() => useMarketAssets({ search }));
 
     act(() => result.current.onEndReached());
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(expect.objectContaining({ page: 2 }));
+    expectMarketDataLastCalledWith({ page: 2 });
 
     search = "eth";
     rerender(undefined);
 
     await waitFor(() => {
-      expect(mockedUseMarketData).toHaveBeenLastCalledWith(
-        expect.objectContaining({ page: 1, search: "eth" }),
-      );
+      expectMarketDataLastCalledWith({ page: 1, search: "eth" });
     });
-    expect(mockedUseMarketData).not.toHaveBeenCalledWith(
-      expect.objectContaining({ page: 2, search: "eth" }),
-    );
+    expectMarketDataNotCalledWith({ page: 2, search: "eth" });
   });
 
   it("maps sorting and timeframe to the market request params", () => {
     renderHook(() => useMarketAssets({ sorting: "gainers", timeframe: "7D" }));
 
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(
-      expect.objectContaining({ order: Order.topGainers, range: "7d" }),
-    );
+    expectMarketDataLastCalledWith({ order: Order.topGainers, range: "7d" });
   });
 
   it("maps volume sorting to the total-volume order", () => {
     renderHook(() => useMarketAssets({ sorting: "volume" }));
 
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(
-      expect.objectContaining({ order: Order.VolumeDesc }),
-    );
+    expectMarketDataLastCalledWith({ order: Order.VolumeDesc });
   });
 
   it("maps the six-month timeframe to the market request params", () => {
     renderHook(() => useMarketAssets({ timeframe: "6M" }));
 
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(expect.objectContaining({ range: "6m" }));
+    expectMarketDataLastCalledWith({ range: "6m" });
   });
 
   it("requests favorite assets with the starred ids sorted", () => {
@@ -157,9 +195,7 @@ describe("useMarketAssets", () => {
       useMarketAssets({ category: "starred", starredMarketCoins: ["ethereum", "bitcoin"] }),
     );
 
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(
-      expect.objectContaining({ page: 1, starred: ["bitcoin", "ethereum"] }),
-    );
+    expectMarketDataLastCalledWith({ page: 1, starred: ["bitcoin", "ethereum"] });
     expect(result.current.emptyState).toBeUndefined();
   });
 
@@ -168,18 +204,14 @@ describe("useMarketAssets", () => {
       useMarketAssets({ category: "starred", starredMarketCoins: [] }),
     );
 
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(
-      expect.objectContaining({ page: 0, starred: [] }),
-    );
+    expectMarketDataLastCalledWith({ page: 0, starred: [] }, { enabled: false });
     expect(result.current.assets).toEqual([]);
     expect(result.current.loading).toBe(false);
     expect(result.current.emptyState).toBe("favorites");
 
     act(() => result.current.onEndReached());
 
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(
-      expect.objectContaining({ page: 0, starred: [] }),
-    );
+    expectMarketDataLastCalledWith({ page: 0, starred: [] }, { enabled: false });
   });
 
   it("searches all market assets while search is active", () => {
@@ -187,27 +219,21 @@ describe("useMarketAssets", () => {
       useMarketAssets({ search: " eth ", category: "starred", starredMarketCoins: [] }),
     );
 
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(
-      expect.objectContaining({ page: 1, search: "eth", starred: undefined }),
-    );
+    expectMarketDataLastCalledWith({ page: 1, search: "eth", starred: undefined });
     expect(result.current.emptyState).toBeUndefined();
   });
 
   it("drops the stock category param while search is active", () => {
     renderHook(() => useMarketAssets({ search: " aapl ", category: "stocks" }));
 
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(
-      expect.objectContaining({ page: 1, search: "aapl", categories: undefined }),
-    );
+    expectMarketDataLastCalledWith({ page: 1, search: "aapl", categories: undefined });
   });
 
   it("requests stocks from the dedicated CVS category", () => {
     mockMarketData({ data: [teslaStock] });
     const { result } = renderHook(() => useMarketAssets({ category: "stocks" }));
 
-    expect(mockedUseMarketData).toHaveBeenLastCalledWith(
-      expect.objectContaining({ categories: "tokenized-stock", page: 1 }),
-    );
+    expectMarketDataLastCalledWith({ categories: "tokenized-stock", page: 1 });
     expect(result.current.assets).toHaveLength(1);
     expect(result.current.assets[0]).toMatchObject({
       id: "tesla-xstock",
@@ -237,6 +263,99 @@ describe("useMarketAssets", () => {
       name: "Tesla xStock",
       ticker: "tslax",
       ledgerIds: [],
+    });
+  });
+
+  describe("unsupported fiat countervalue (COP)", () => {
+    const SUPPORTED_WITHOUT_COP = ["usd", "eur", "vnd"];
+
+    it("disables the market request while countervalue support is unresolved", () => {
+      mockSupportedCounterCurrencies(undefined);
+
+      const { result } = renderHook(() => useMarketAssets(), withCounterValue("COP"));
+
+      expectMarketDataLastCalledWith({ counterCurrency: "cop" }, { enabled: false });
+      expect(mockedUseUsdToFiatRate).toHaveBeenCalledWith("usd", { skip: true });
+      expect(result.current.assets).toEqual([]);
+      expect(result.current.loading).toBe(true);
+    });
+
+    it("requests in USD and rescales each row by the USD->COP rate", () => {
+      mockSupportedCounterCurrencies(["usd", "cop"]);
+      mockUsdToFiatRate({ status: "ready", rate: 1 });
+      mockMarketData({ data: [createMarketCurrencyData({ id: "bitcoin", price: 400_000 })] });
+      const control = renderHook(() => useMarketAssets(), withCounterValue("COP"));
+      expectMarketDataLastCalledWith({ counterCurrency: "cop" });
+      const expectedCopPrice = control.result.current.assets[0].formattedPrice;
+
+      mockSupportedCounterCurrencies(SUPPORTED_WITHOUT_COP);
+      mockUsdToFiatRate({ status: "ready", rate: 4000 });
+      mockMarketData({ data: [createMarketCurrencyData({ id: "bitcoin", price: 100 })] });
+      const { result } = renderHook(() => useMarketAssets(), withCounterValue("COP"));
+
+      expectMarketDataLastCalledWith({ counterCurrency: "usd" });
+      expect(mockedUseUsdToFiatRate).toHaveBeenCalledWith("cop", { skip: false });
+      expect(result.current.assets[0].formattedPrice).toBe(expectedCopPrice);
+    });
+
+    it("withholds rows and stays loading until the rate resolves", () => {
+      mockSupportedCounterCurrencies(SUPPORTED_WITHOUT_COP);
+      mockUsdToFiatRate({ status: "loading", rate: null });
+
+      const { result } = renderHook(() => useMarketAssets(), withCounterValue("COP"));
+
+      expect(result.current.assets).toEqual([]);
+      expect(result.current.loading).toBe(true);
+    });
+
+    it("surfaces an error when the rate request fails", () => {
+      mockSupportedCounterCurrencies(SUPPORTED_WITHOUT_COP);
+      mockUsdToFiatRate({ status: "error", rate: null });
+
+      const { result } = renderHook(() => useMarketAssets(), withCounterValue("COP"));
+
+      expect(result.current.assets).toEqual([]);
+      expect(result.current.isError).toBe(true);
+    });
+
+    it("does not request the next page when the rate request fails", () => {
+      mockSupportedCounterCurrencies(SUPPORTED_WITHOUT_COP);
+      mockUsdToFiatRate({ status: "error", rate: null });
+      mockMarketData({ data: fullMarketPage });
+
+      const { result } = renderHook(() => useMarketAssets(), withCounterValue("COP"));
+
+      act(() => result.current.onEndReached());
+
+      expectMarketDataNotCalledWith({ page: 2 });
+    });
+
+    it("requests the countervalue natively once it is known to be supported", () => {
+      mockSupportedCounterCurrencies(["usd", "eur", "cop"]);
+      mockMarketData({ data: [createMarketCurrencyData({ id: "bitcoin", price: 100 })] });
+
+      renderHook(() => useMarketAssets(), withCounterValue("COP"));
+
+      expectMarketDataLastCalledWith({ counterCurrency: "cop" });
+      expect(mockedUseUsdToFiatRate).toHaveBeenCalledWith("usd", { skip: false });
+    });
+  });
+
+  describe("crypto countervalue (BTC)", () => {
+    it("requests in USD and rescales rows without waiting for the supported fiat list", () => {
+      mockSupportedCounterCurrencies(undefined);
+      mockUsdToFiatRate({ status: "ready", rate: 0.00001 });
+      mockMarketData({
+        data: [createMarketCurrencyData({ id: "bitcoin", price: 100, marketcap: 200 })],
+      });
+
+      const { result } = renderHook(() => useMarketAssets(), withCounterValue("BTC"));
+
+      expectMarketDataLastCalledWith({ counterCurrency: "usd" });
+      expect(mockedUseUsdToFiatRate).toHaveBeenCalledWith("btc", { skip: false });
+      expect(result.current.loading).toBe(false);
+      expect(result.current.assets[0].formattedPrice).toContain("₿");
+      expect(result.current.assets[0].formattedMarketCap).toContain("₿");
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/marketAssetsHelpers.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/marketAssetsHelpers.ts
@@ -1,4 +1,5 @@
 import type { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { applyUsdRateToMarket } from "@ledgerhq/live-common/market/utils/applyUsdRateToMarket";
 import type { Unit } from "@ledgerhq/types-cryptoassets";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
 import { mapMarketCurrencyToDisplayData } from "../../utils/marketAssetDisplay";
@@ -21,6 +22,7 @@ export function getMarketAssets({
   marketData,
   counterCurrency,
   counterValueUnit,
+  rate = 1,
   displayRange,
   locale,
   t,
@@ -28,6 +30,7 @@ export function getMarketAssets({
   marketData: MarketCurrencyData[];
   counterCurrency: string;
   counterValueUnit: Unit;
+  rate?: number;
   displayRange: DisplayRange;
   locale: string;
   t: Translate;
@@ -35,7 +38,7 @@ export function getMarketAssets({
   const uniqueById = [...new Map(marketData.map(item => [item.id, item])).values()];
 
   return uniqueById.map(item =>
-    mapMarketCurrencyToDisplayData(item, {
+    mapMarketCurrencyToDisplayData(applyUsdRateToMarket(item, rate), {
       counterCurrency,
       counterValueUnit,
       range: displayRange,

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssets.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssets.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { useMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
-import { useMarketDataProvider } from "@ledgerhq/live-common/cg-client/hooks/useCoingeckoDataProvider";
+import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
+import { useResolveMarketCounterCurrency } from "@ledgerhq/live-common/market/hooks/useResolveMarketCounterCurrency";
 import { useLocale, useTranslation } from "~/context/Locale";
 import { useSelector } from "~/context/hooks";
 import { counterValueCurrencySelector } from "~/reducers/settings";
@@ -57,15 +58,17 @@ export function useMarketAssets({
 }: MarketAssetsParams = {}): MarketAssetsResult {
   const { locale } = useLocale();
   const { t } = useTranslation();
-  const { supportedCounterCurrencies } = useMarketDataProvider();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const settingsCounterValue = counterValueCurrency.ticker.toLowerCase();
-  // While the supported list is still loading we keep the user's counter value, and only fall
-  // back to usd once we know it is unsupported — otherwise a request fires with usd first.
-  const counterCurrency =
-    supportedCounterCurrencies && !supportedCounterCurrencies.includes(settingsCounterValue)
-      ? "usd"
-      : settingsCounterValue;
+  const {
+    requestCounterCurrency,
+    displayCounterCurrency = settingsCounterValue,
+    needsUsdFallback,
+    isResolutionLoading,
+  } = useResolveMarketCounterCurrency({
+    counterCurrency: settingsCounterValue,
+    fallbackForCryptoCountervalues: true,
+  });
   const counterValueUnit = counterValueCurrency.units[0];
   const normalizedSearch = search.trim();
   const {
@@ -94,36 +97,53 @@ export function useMarketAssets({
   const requestRange = getMarketListRequestRange(timeframe);
   const displayRange = getMarketListDisplayRange(timeframe);
   const order = getMarketListOrder(sorting);
+  const shouldFetchMarketData = shouldFetchAssets && !isResolutionLoading;
+  const { rate: usdToCounterValueRate, status: rateStatus } = useUsdToFiatRate(
+    needsUsdFallback ? displayCounterCurrency : "usd",
+    { skip: !shouldFetchAssets || isResolutionLoading },
+  );
+  const rate = needsUsdFallback ? usdToCounterValueRate : 1;
 
-  const result = useMarketData({
-    counterCurrency,
-    range: requestRange,
-    order,
-    limit: PAGE_SIZE,
-    liveCompatible: true,
-    page: requestedPage,
-    search: normalizedSearch,
-    categories: marketCategoriesParam,
-    starred: sortedFavoriteIds,
-  });
-  const marketData = getMarketDataForDisplay(result.data, shouldFetchAssets);
+  const result = useMarketData(
+    {
+      counterCurrency: requestCounterCurrency,
+      range: requestRange,
+      order,
+      limit: PAGE_SIZE,
+      liveCompatible: true,
+      page: requestedPage,
+      search: normalizedSearch,
+      categories: marketCategoriesParam,
+      starred: sortedFavoriteIds,
+    },
+    { enabled: shouldFetchMarketData },
+  );
+  const marketData = getMarketDataForDisplay(result.data, shouldFetchMarketData);
 
   const assets = useMemo(
     () =>
-      getMarketAssets({
-        marketData,
-        counterCurrency,
-        counterValueUnit,
-        displayRange,
-        locale,
-        t,
-      }),
-    [counterCurrency, counterValueUnit, displayRange, locale, marketData, t],
+      rate == null
+        ? []
+        : getMarketAssets({
+            marketData,
+            counterCurrency: displayCounterCurrency,
+            counterValueUnit,
+            rate,
+            displayRange,
+            locale,
+            t,
+          }),
+    [counterValueUnit, displayCounterCurrency, displayRange, locale, marketData, rate, t],
   );
 
   const hasData = assets.length > 0;
   const canLoadMore = shouldFetchAssets && marketData.length >= page * PAGE_SIZE;
-  const loading = shouldFetchAssets && (result.isLoading || result.isPending) && !hasData;
+  const isRateLoading = needsUsdFallback && rateStatus === "loading";
+  const isRateError = needsUsdFallback && rateStatus === "error";
+  const loading =
+    shouldFetchAssets &&
+    (isResolutionLoading || result.isLoading || result.isPending || isRateLoading) &&
+    !hasData;
   const isFetchingNextPage = shouldFetchAssets && page > 1 && result.isFetching && hasData;
 
   const onEndReached = useCallback(() => {
@@ -133,7 +153,7 @@ export function useMarketAssets({
         canLoadMore,
         loading,
         isFetchingNextPage,
-        isError: result.isError,
+        isError: result.isError || isRateError,
       })
     ) {
       return;
@@ -143,6 +163,7 @@ export function useMarketAssets({
   }, [
     canLoadMore,
     isFetchingNextPage,
+    isRateError,
     loading,
     paginationParams,
     result.isError,
@@ -154,7 +175,7 @@ export function useMarketAssets({
     assets,
     loading,
     isFetchingNextPage,
-    isError: shouldFetchAssets && result.isError,
+    isError: shouldFetchAssets && (result.isError || isRateError),
     emptyState: getEmptyState({ isFavoritesCategory, hasFavoriteIds, isStocksCategory }),
     onEndReached,
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.test.ts
@@ -61,6 +61,65 @@ describe("counterValueFormatter", () => {
       expect(result).toContain("$");
     });
 
+    it("normalizes lower-case currency codes before formatting", () => {
+      const lowerCase = counterValueFormatter({
+        value: 1234.56,
+        locale: "en-US",
+        currency: "usd",
+      });
+      const upperCase = counterValueFormatter({
+        value: 1234.56,
+        locale: "en-US",
+        currency: "USD",
+      });
+
+      expect(lowerCase).toBe(upperCase);
+    });
+
+    it("uses the Ledger fiat sign instead of Intl's locale-dependent symbol", () => {
+      expect(
+        counterValueFormatter({
+          value: 1234.56,
+          locale: "en-US",
+          currency: "CAD",
+        }),
+      ).toBe("CA$1,234.56");
+      expect(
+        counterValueFormatter({
+          value: 1234.56,
+          locale: "en-CA",
+          currency: "CAD",
+        }),
+      ).toBe("CA$1,234.56");
+    });
+
+    it("keeps the minus sign before prefixed units", () => {
+      expect(
+        counterValueFormatter({
+          value: -1234.56,
+          locale: "en-US",
+          currency: "USD",
+        }),
+      ).toBe("-$1,234.56");
+    });
+
+    it("formats crypto countervalues with the Ledger unit instead of Intl currency style", () => {
+      expect(
+        counterValueFormatter({
+          value: 0.00001,
+          locale: "en-US",
+          currency: "BTC",
+        }),
+      ).toContain("₿");
+      expect(
+        counterValueFormatter({
+          value: 0.12345678,
+          locale: "en-US",
+          currency: "ETH",
+        }),
+      ).toBe("0.12345678 ETH");
+    });
+
     it("formats a value with ticker", () => {
       const result = counterValueFormatter({
         value: 123.456,
@@ -148,6 +207,20 @@ describe("counterValueFormatter", () => {
       expect(result).toMatch(/T|trillion/i);
     });
 
+    it("formats shortened crypto countervalues with the Ledger unit instead of Intl currency code", () => {
+      const result = counterValueFormatter({
+        value: 35_700_000,
+        locale: "en-US",
+        currency: "BTC",
+        shorten: true,
+        t: i18next.t,
+      });
+
+      expect(result).toMatch(/^₿/);
+      expect(result).toMatch(/m/i);
+      expect(result).not.toContain("BTC");
+    });
+
     it("handles negative values in shortened format", () => {
       const result = counterValueFormatter({
         value: -5000000,
@@ -158,6 +231,19 @@ describe("counterValueFormatter", () => {
       });
       expect(result).toContain("-");
       expect(result).toContain("5");
+    });
+
+    it("does not prefix zero with a minus sign in shortened format", () => {
+      const result = counterValueFormatter({
+        value: 0,
+        locale: "en-US",
+        currency: "USD",
+        shorten: true,
+        t: i18next.t,
+        allowZeroValue: true,
+      });
+
+      expect(result).toBe("$0");
     });
 
     it("formats small values without shortening", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.ts
@@ -1,6 +1,11 @@
 import { MarketListRequestParams } from "@ledgerhq/live-common/market/utils/types";
 import { getSortParam } from "@ledgerhq/live-common/market/utils/index";
 import { rangeDataTable } from "@ledgerhq/live-common/cg-client/utils/rangeDataTable";
+import {
+  findCryptoCurrencyByTicker,
+  findFiatCurrencyByTicker,
+} from "@ledgerhq/live-common/currencies/index";
+import type { Unit } from "@ledgerhq/types-cryptoassets";
 import type { TFunction } from "i18next";
 
 export const RANGES = Object.keys(rangeDataTable).filter(key => key !== "1h");
@@ -18,6 +23,22 @@ const indexes: [string, number][] = [
 const dateFormatters: Record<string, { [key: string]: Intl.DateTimeFormat }> = {};
 
 const formatters: Record<string, { [key: string]: Intl.NumberFormat }> = {};
+
+const MAXIMUM_FRACTION_DIGITS = 8;
+
+const getFractionDigitOptions = (
+  unit: Unit | undefined,
+  shorten: boolean | undefined,
+): Pick<Intl.NumberFormatOptions, "maximumFractionDigits" | "minimumFractionDigits"> => {
+  const maximumFractionDigits = shorten ? 3 : MAXIMUM_FRACTION_DIGITS;
+
+  if (!unit) return { maximumFractionDigits };
+
+  return {
+    maximumFractionDigits,
+    minimumFractionDigits: shorten ? 0 : Math.min(unit.magnitude, maximumFractionDigits),
+  };
+};
 
 export const getDateFormatter = (locale: string, interval: string) => {
   if (!dateFormatters[locale]) {
@@ -47,6 +68,73 @@ export const getDateFormatter = (locale: string, interval: string) => {
   return dateFormatters[locale][interval] || dateFormatters[locale].default;
 };
 
+type NumberFormatterResult = {
+  formatter: Intl.NumberFormat;
+  unit?: Unit;
+};
+
+const getNumberFormatter = (
+  locale: string,
+  currency?: string,
+  shorten?: boolean,
+): NumberFormatterResult => {
+  if (!currency) return { formatter: new Intl.NumberFormat(locale) };
+
+  const normalizedCurrency = currency.toUpperCase();
+  const fiat = findFiatCurrencyByTicker(normalizedCurrency);
+  const crypto = findCryptoCurrencyByTicker(normalizedCurrency);
+  const unit = fiat?.units[0] ?? crypto?.units[0];
+  const formatterKey = `${normalizedCurrency}:${shorten ? "short" : "full"}`;
+
+  if (!formatters[locale]) formatters[locale] = {};
+  if (!formatters[locale][formatterKey]) {
+    formatters[locale][formatterKey] = new Intl.NumberFormat(
+      locale,
+      unit
+        ? {
+            style: "decimal",
+            ...getFractionDigitOptions(unit, shorten),
+          }
+        : {
+            style: "currency",
+            currency: normalizedCurrency,
+            ...getFractionDigitOptions(undefined, shorten),
+            maximumSignificantDigits: 8,
+          },
+    );
+  }
+
+  return { formatter: formatters[locale][formatterKey], unit };
+};
+
+const formatWithUnit = (value: string, unit?: Unit): string => {
+  if (!unit) return value;
+  if (unit.prefixCode && value.startsWith("-")) return `-${unit.code}${value.slice(1)}`;
+  return unit.prefixCode ? `${unit.code}${value}` : `${value} ${unit.code}`;
+};
+
+const formatShortenedValue = (
+  formatter: Intl.NumberFormat,
+  value: number,
+  t: TFunction,
+  unit?: Unit,
+): string => {
+  const sign = value < 0 ? "-" : "";
+  const v = Math.abs(value);
+  const index = Math.min(Math.floor(Math.log(v + 1) / Math.log(10) / 3) || 0, indexes.length - 1);
+
+  const [i, n] = indexes[index];
+
+  const roundedValue = Math.floor((v / n) * 1000) / 1000;
+  const number = formatter.format(roundedValue);
+
+  const I = t(`numberCompactNotation.${i}`);
+  const suffix = I ? ` ${I}` : "";
+  const signedNumber = number.replace(/([0-9,. ]+)/, `${sign}$1${suffix}`);
+
+  return formatWithUnit(signedNumber, unit);
+};
+
 export const counterValueFormatter = ({
   currency,
   value,
@@ -68,41 +156,14 @@ export const counterValueFormatter = ({
     return "-";
   }
 
-  if (currency) {
-    if (!formatters[locale]) formatters[locale] = {};
-    if (!formatters[locale][currency]) {
-      formatters[locale][currency] = new Intl.NumberFormat(locale, {
-        style: "currency",
-        currency,
-        maximumFractionDigits: 8,
-        maximumSignificantDigits: 8,
-      });
-    }
-  }
-
-  const formatter = currency ? formatters[locale][currency] : new Intl.NumberFormat(locale);
-  const upperCaseTicker = ticker.trim().toLocaleUpperCase();
+  const { formatter, unit } = getNumberFormatter(locale, currency, shorten);
+  const upperCaseTicker = ticker.trim().toUpperCase();
 
   if (shorten && t) {
-    const sign = value > 0 ? "" : "-";
-    const v = Math.abs(value);
-    const index = Math.min(Math.floor(Math.log(v + 1) / Math.log(10) / 3) || 0, indexes.length - 1);
-
-    const [i, n] = indexes[index];
-
-    const roundedValue = Math.floor((v / n) * 1000) / 1000;
-
-    const number = formatter.format(roundedValue);
-
-    const I = t(`numberCompactNotation.${i}`);
-
-    const suffix = I ? ` ${I}` : "";
-    const formattedNumber = number.replace(/([0-9,. ]+)/, `${sign}$1${suffix}`);
-
-    return `${formattedNumber} ${upperCaseTicker}`.trim();
+    return `${formatShortenedValue(formatter, value, t, unit)} ${upperCaseTicker}`.trim();
   }
 
-  return `${formatter.format(value)} ${upperCaseTicker}`.trim();
+  return `${formatWithUnit(formatter.format(value), unit)} ${upperCaseTicker}`.trim();
 };
 
 export function getAnalyticsProperties<P extends object>(


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile Asset Detail BalanceGraph price chart
  - Mobile Market list pagination, formatting, and fallback values
  - Mobile Market Detail and Global Market Cap cards

### 📝 Description

This PR applies the shared market countervalue fallback from the base PR to mobile screens. Mobile now avoids speculative unsupported-fiat requests, fetches USD where the markets APIs cannot serve the selected countervalue, and rescales display values using the USD→countervalue spot rate.

It also keeps Ledger fiat/crypto units in mobile market formatting, so crypto countervalues such as BTC/ETH do not fall back to locale-dependent `Intl` currency codes and compact values do not render as stale USD numbers with a different symbol.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32591](https://ledgerhq.atlassian.net/browse/LIVE-32591)
- **Stacked on**: https://github.com/LedgerHQ/ledger-live/pull/18773

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32591]: https://ledgerhq.atlassian.net/browse/LIVE-32591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ