### PR TITLE
[LWDM] test: LKRP wallet-cli ring + per-application close integration [do not merge]

### DIFF
--- a/.agents/skills/ledger-wallet-cli/SKILL.md
+++ b/.agents/skills/ledger-wallet-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ledger-wallet-cli
-description: Official Ledger wallet-cli - USB-based CLI for Ledger hardware wallet flows (account discover, receive, balances, operations, send, swap quote/execute/status, genuine-check, assets token / token-by-id). Use for any wallet-cli command execution and for mapping informal requests to the right command.
+description: Official Ledger wallet-cli - USB-based CLI for Ledger hardware wallet flows (account discover, receive, balances, operations, send, swap quote/execute/status, genuine-check, assets token / token-by-id) and the Ledger Key Ring (ring init/encrypt/decrypt/keys/destroy — LKRP-backed encryption of files and text). Use for any wallet-cli command execution and for mapping informal requests to the right command.
 ---
 
 # wallet-cli
@@ -37,6 +37,9 @@ Map informal phrasings to commands. Account references use a session label (e.g.
 | "send X to Y", "transfer", "pay", "withdraw to an exchange"                         | `send <account> --to <address> --amount '<amount> <ticker>'` |
 | "swap A to B", "convert", "trade ETH for BTC", "exchange"                           | `swap quote` -> `swap execute` -> `swap status`              |
 | "is this Ledger real", "verify authenticity", "I bought this off eBay"              | `genuine-check`                                              |
+| "encrypt this file / these env vars / publish tokens", "GPG alternative", "secret manager", "decrypt anywhere with my Ledger" | `ring init` -> `ring encrypt --key <name>` / `ring decrypt --key <name>` |
+| "what keys do I have on my ring", "list domains/projects I've encrypted under"       | `ring keys`                                                  |
+| "wipe my key ring", "destroy the ring", "tear down LKRP membership"                 | `ring destroy`                                               |
 | "start over", "clear my session", "I switched devices"                              | `session reset`                                              |
 
 ---
@@ -46,7 +49,7 @@ Map informal phrasings to commands. Account references use a session label (e.g.
 If the user asks for any of the following, surface that wallet-cli does not support it yet rather than constructing a command:
 
 - NFTs (mint, transfer, view).
-- Encryption / OpenPGP / key-share operations.
+- OpenPGP-compatible output or key-share / multi-recipient encryption (the `ring` commands encrypt with a per-user Ledger Key Ring, not a sharable key).
 - `send`, `receive`, `operations`, or `swap execute` on testnets and layer 2s (e.g. Base).
 - Custom chains not listed in the Networks line above.
 
@@ -62,21 +65,26 @@ All `--account` flags accept a session label (e.g. `ethereum-1`). Run `account d
 
 ## Commands
 
-| Command              | Device | Sandbox      |
-| -------------------- | ------ | ------------ |
-| `session view`       | No     | No           |
-| `session reset`      | No     | No           |
-| `account discover`   | Yes    | **Required** |
-| `receive`            | Yes    | **Required** |
-| `send`               | Yes\*  | **Required** |
-| `genuine-check`      | Yes    | **Required** |
-| `balances`           | No     | No           |
-| `operations`         | No     | No           |
-| `swap quote`         | No     | No           |
-| `swap execute`       | Yes    | **Required** |
-| `swap status`        | No     | No           |
-| `assets token`       | No     | No           |
-| `assets token-by-id` | No     | No           |
+| Command              | Device | Sandbox      | Network |
+| -------------------- | ------ | ------------ | ------- |
+| `session view`       | No     | No           | No      |
+| `session reset`      | No     | No           | No      |
+| `account discover`   | Yes    | **Required** | Yes     |
+| `receive`            | Yes    | **Required** | No      |
+| `send`               | Yes\*  | **Required** | Yes     |
+| `genuine-check`      | Yes    | **Required** | Yes     |
+| `balances`           | No     | No           | Yes     |
+| `operations`         | No     | No           | Yes     |
+| `swap quote`         | No     | No           | Yes     |
+| `swap execute`       | Yes    | **Required** | Yes     |
+| `swap status`        | No     | No           | Yes     |
+| `assets token`       | No     | No           | No      |
+| `assets token-by-id` | No     | No           | No      |
+| `ring init`          | Yes    | **Required** | Yes     |
+| `ring encrypt`       | No     | No           | Yes     |
+| `ring decrypt`       | No     | No           | Yes     |
+| `ring keys`          | No     | No           | No      |
+| `ring destroy`       | No     | No           | Yes     |
 
 \*`send --dry-run` needs no device and no sandbox bypass.
 
@@ -202,6 +210,32 @@ Use `token` when you have the contract address; use `token-by-id` when you have 
 For non-EVM chains pass `--identifier`.
 
 The `id` printed here is the same id accepted by `swap quote --from` / `--to` and `swap execute --from` / `--to`.
+
+### ring — Ledger Key Ring (LKRP)
+
+Trustless, hardware-rooted encryption for files and text. The key ring is provisioned once on your Ledger via the Ledger Sync app; afterwards `encrypt`/`decrypt` run **without** the device — keys derive deterministically via HKDF-SHA256 from the LKRP-shared root and never leave AES-256-GCM. `encrypt`/`decrypt` still call the LKRP backend to restore the trustchain on each invocation, so network access is required. The ring is recoverable from your seed on any new machine.
+
+```bash
+# One-time provisioning (device required). Prompts for password; --unsecure-no-password skips it.
+pnpm --silent wallet-cli start ring init
+pnpm --silent wallet-cli start ring init --name my-laptop --unsecure-no-password
+
+# File round-trip (no device after init):
+pnpm --silent wallet-cli start ring encrypt --key my-oss-project -i .publish-tokens -o .publish-tokens.enc
+pnpm --silent wallet-cli start ring decrypt --key my-oss-project -i .publish-tokens.enc -o .publish-tokens
+
+# Text via stdin/stdout (clipboard pattern):
+pbpaste | pnpm --silent wallet-cli start ring encrypt --key personal-notes | pbcopy
+pbpaste | pnpm --silent wallet-cli start ring decrypt --key personal-notes | pbcopy
+
+# List the keys this machine has used; tear down the ring:
+pnpm --silent wallet-cli start ring keys
+pnpm --silent wallet-cli start ring destroy
+```
+
+`--key <name>` derives a per-name AES-256-GCM key; matching name at decrypt time is mandatory. Names are free-form (max 253 chars, no whitespace) — common patterns: project slugs (`my-oss-project`), env tags (`openClaw-prod`), notebooks (`personal-notes`).
+
+**Non-TTY (CI / agentic) password injection:** export `WALLET_PASS` from your OS keychain before invocation — never pass the password via flag. Example: `WALLET_PASS=$(security find-generic-password -a default -s wallet-cli -w) wallet-cli ring encrypt …`.
 
 ---
 

--- a/.changeset/lkrp-destroy-application.md
+++ b/.changeset/lkrp-destroy-application.md
@@ -1,0 +1,16 @@
+---
+"@ledgerhq/hw-ledger-key-ring-protocol": minor
+"@ledgerhq/ledger-key-ring-protocol": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+feat(lkrp): per-application close on Wallet Sync deactivation
+
+Deactivating Wallet Sync now closes only the current application's stream instead of destroying the whole trustchain root, so other applications sharing the same root (e.g. wallet-cli `ring`) keep working. If the application being closed is the last open one, the whole trustchain is still destroyed (previous behaviour).
+
+- `CommandStreamResolver` now observes `CloseStream` (`ResolvedCommandStream.isClosed()`).
+- `StreamTree.getApplicationStreams()` / `hasAnotherOpenApplication()` enumerate application streams to detect the last open application.
+- New `TrustchainSDK.destroyApplication()` primitive, software-key signed (no hardware device): closes only the current application's stream, or destroys the whole trustchain when it is the last open application (`{ trustchainDestroyed }`).
+- `restoreTrustchain` throws `TrustchainEjected` when the application stream is closed, and `getOrCreateTrustchain` reopens on the next index after a close.
+- LLD/LLM `useDestroyTrustchain` hooks now call `destroyApplication`.

--- a/.changeset/wallet-cli-key-ring.md
+++ b/.changeset/wallet-cli-key-ring.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/wallet-cli": minor
+---
+
+Add `ring` command group: a developer surface to your Ledger Key Ring (LKRP) for trustless, hardware-rooted encryption of files and text.
+
+Commands: `ring init`, `ring encrypt`, `ring decrypt`, `ring keys`, `ring destroy`. Files via `-i/-o`, text via stdin/stdout. Keys are AES-256-GCM, derived per-name with HKDF-SHA256 from the LKRP-shared root key; the ring is recoverable from your Ledger.

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/manageYourBackup.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/manageYourBackup.test.tsx
@@ -6,7 +6,9 @@ import * as ReactQuery from "@tanstack/react-query";
 
 jest.mock("../hooks/useTrustchainSdk", () => ({
   useTrustchainSdk: () => ({
-    destroyTrustchain: (mockedSdk.destroyTrustchain = jest.fn()),
+    destroyApplication: (mockedSdk.destroyApplication = jest
+      .fn()
+      .mockResolvedValue({ trustchainDestroyed: true })),
     getMembers: (mockedSdk.getMembers = jest.fn()),
     initMemberCredentials: (mockedSdk.initMemberCredentials = jest.fn()),
   }),

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useDestroyTrustchain.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useDestroyTrustchain.ts
@@ -26,7 +26,7 @@ export function useDestroyTrustchain() {
         return;
       }
       await cloudSyncSDK.destroy(trustchain, memberCredentials);
-      await sdk.destroyTrustchain(trustchain, memberCredentials);
+      await sdk.destroyApplication(trustchain, memberCredentials);
     },
     mutationKey: [QueryKey.destroyTrustchain, trustchain],
     onSuccess: () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useDestroyTrustchain.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useDestroyTrustchain.ts
@@ -28,7 +28,7 @@ export function useDestroyTrustchain() {
         return;
       }
       await cloudSyncSDK.destroy(trustchain, memberCredentials);
-      await sdk.destroyTrustchain(trustchain, memberCredentials);
+      await sdk.destroyApplication(trustchain, memberCredentials);
     },
     mutationKey: [QueryKey.destroyTrustchain, trustchain],
     onSuccess: () => {

--- a/apps/wallet-cli/THIRD_PARTY_NOTICES.md
+++ b/apps/wallet-cli/THIRD_PARTY_NOTICES.md
@@ -10,6 +10,7 @@ The wallet-cli source code itself is licensed under Apache License 2.0; see the 
 
 | Package | Version | License | Copyright |
 |---|---|---|---|
+| @napi-rs/keyring | 1.3.0 | MIT | Copyright (c) 2020 N-API for Rust |
 | bignumber.js | 9.1.2 | MIT | Copyright (c) 2023 Michael Mclaughlin |
 | debug | 4.4.3 | MIT | Copyright (c) 2014-2017 TJ Holowaychuk; Copyright (c) 2018-2021 Josh Junon |
 | purify-ts | 2.1.0 | ISC | Copyright (c) 2018, Stanislav Iliev |

--- a/apps/wallet-cli/package.json
+++ b/apps/wallet-cli/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@bunli/core": "0.9.1",
     "@bunli/utils": "0.6.0",
+    "@napi-rs/keyring": "1.3.0",
     "@ledgerhq/coin-bitcoin": "workspace:^",
     "@ledgerhq/coin-evm": "workspace:^",
     "@ledgerhq/coin-module-framework": "catalog:",
@@ -53,6 +54,8 @@
     "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-app-exchange": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",
+    "@ledgerhq/hw-ledger-key-ring-protocol": "workspace:^",
+    "@ledgerhq/ledger-key-ring-protocol": "workspace:^",
     "@ledgerhq/ledger-wallet-framework": "workspace:^",
     "@ledgerhq/live-common": "workspace:^",
     "@ledgerhq/live-config": "workspace:^",

--- a/apps/wallet-cli/src/cli.ts
+++ b/apps/wallet-cli/src/cli.ts
@@ -20,6 +20,7 @@ import ReceiveCommand from "./commands/receive";
 import SendCommand from "./commands/send";
 import SwapGroup from "./commands/swap/index";
 import GenuineCheckCommand from "./commands/genuine-check";
+import RingGroup from "./commands/ring/index";
 
 emitTestingBuildBannerIfNeeded();
 
@@ -41,6 +42,7 @@ export async function runMain(argv: string[] = process.argv.slice(2)): Promise<n
   cli.command(SendCommand);
   cli.command(SwapGroup);
   cli.command(GenuineCheckCommand);
+  cli.command(RingGroup);
   const code = await cli.run(normalizeNegatedFlags(argv), { noExit: true });
   return code ?? 0;
 }

--- a/apps/wallet-cli/src/commands/inputs.ts
+++ b/apps/wallet-cli/src/commands/inputs.ts
@@ -1,11 +1,17 @@
 import { option } from "@bunli/core";
 import { z } from "zod";
+import { resolve } from "node:path";
 import { DEFAULT_DEVICE_TIMEOUT_MS } from "../device/connect-ledger-app";
 import { OutputFormatSchema, parseAccountDescriptor } from "../wallet/models";
 import type { AccountDescriptor } from "../wallet/models";
 import { parseV1 } from "../shared/accountDescriptor";
 import type { AccountDescriptorV1 } from "../shared/accountDescriptor";
 import { Session } from "../session/session-store";
+
+/** Resolve a user-supplied path against the directory where pnpm/npm was invoked (INIT_CWD), not the package dir. */
+export function resolveUserPath(p: string): string {
+  return resolve(process.env.INIT_CWD ?? process.cwd(), p);
+}
 
 /**
  * Shared --output option used by all commands. If omitted, the CLI keeps

--- a/apps/wallet-cli/src/commands/ring/decrypt.ts
+++ b/apps/wallet-cli/src/commands/ring/decrypt.ts
@@ -1,0 +1,67 @@
+import { defineCommand, option } from "@bunli/core";
+import { z } from "zod";
+import { chmod } from "node:fs/promises";
+import { loadDomainKeyInteractive } from "../../key-ring/load-key-ring";
+import { decryptData } from "../../key-ring/crypto";
+import { outputOption, resolveOutputFormat, resolveUserPath } from "../inputs";
+import { createCommandOutput } from "../../output";
+
+export default defineCommand({
+  name: "decrypt",
+  description:
+    "Decrypt data with a key from your Ledger Key Ring. Files via -i/-o, text via stdin/stdout.",
+  options: {
+    key: option(z.string().min(1).max(253).regex(/^\S+$/, "key name must not contain whitespace"), {
+      description: "Key name used to derive the scoped decryption key (must match encrypt)",
+      short: "k",
+    }),
+    input: option(z.string().optional(), {
+      description: "Input file (default: stdin)",
+      short: "i",
+    }),
+    out: option(z.string().optional(), {
+      description: "Output file (default: stdout)",
+      short: "o",
+    }),
+    output: outputOption,
+  },
+  handler: async ({ flags }) => {
+    const format = resolveOutputFormat(flags.output);
+    const out = createCommandOutput(format, { command: "ring decrypt", network: "all" });
+    await out.run(async () => {
+      if (format === "json" && !flags.out) {
+        throw new Error(
+          "--output json requires --out <file>: binary plaintext cannot be written as JSON to stdout.",
+        );
+      }
+      if (!flags.input && process.stdin.isTTY) {
+        throw new Error("No input: provide --input FILE or pipe data to stdin.");
+      }
+
+      const fetchSpin = out.spin("Fetching key from your Ledger Key Ring…");
+      const { session, domainKey } = await loadDomainKeyInteractive(flags.key);
+      fetchSpin?.success("Key retrieved");
+
+      const ciphertext = new Uint8Array(
+        flags.input
+          ? await Bun.file(resolveUserPath(flags.input)).arrayBuffer()
+          : await Bun.stdin.arrayBuffer(),
+      );
+      const decSpin = out.spin(`Decrypting with key "${flags.key}"…`);
+      const plaintext = await decryptData(domainKey, ciphertext);
+      decSpin?.success("Decrypted");
+
+      if (flags.out) {
+        const dest = resolveUserPath(flags.out);
+        await Bun.write(dest, plaintext);
+        await chmod(dest, 0o600).catch(() => {});
+        out.ringDecrypt({ dest });
+      } else {
+        process.stdout.write(Buffer.from(plaintext));
+      }
+
+      session.trackDomain(flags.key);
+      session.write();
+    });
+  },
+});

--- a/apps/wallet-cli/src/commands/ring/destroy.ts
+++ b/apps/wallet-cli/src/commands/ring/destroy.ts
@@ -1,0 +1,91 @@
+import { defineCommand } from "@bunli/core";
+import { createInterface } from "node:readline";
+import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
+import { Session, trustchainFromMeta } from "../../session/session-store";
+import { loadMemberCredentials, deletePrivateKey } from "../../key-ring/keychain";
+import { createLkrpSdk } from "../../key-ring/lkrp-sdk";
+import { deriveWrappingKey } from "../../key-ring/crypto";
+import { promptHidden } from "../../key-ring/prompt";
+import { outputOption, resolveOutputFormat } from "../inputs";
+import { createCommandOutput } from "../../output";
+
+async function readConfirmation(): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  return new Promise(resolve => {
+    rl.question('Type "destroy" to confirm: ', answer => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+export default defineCommand({
+  name: "destroy",
+  description: "Tear down your Ledger Key Ring on LKRP and wipe local member credentials.",
+  options: {
+    output: outputOption,
+  },
+  handler: async ({ flags }) => {
+    const out = createCommandOutput(resolveOutputFormat(flags.output), {
+      command: "ring destroy",
+      network: "all",
+    });
+    await out.run(async () => {
+      const session = await Session.read();
+      const trustchainMeta = session.trustchain;
+      if (!trustchainMeta) {
+        throw new Error("Nothing to destroy — Ledger Key Ring is not initialized.");
+      }
+
+      const answer = await readConfirmation();
+      if (answer !== "destroy") {
+        out.ringDestroyCancelled();
+        return;
+      }
+
+      let wrappingKey: CryptoKey | undefined;
+      if (session.passwordSalt) {
+        try {
+          const password = await promptHidden("Password (Enter to skip remote destroy): ");
+          if (password) wrappingKey = await deriveWrappingKey(password, session.passwordSalt);
+        } catch {
+          // Ctrl-C or no-TTY/no-WALLET_PASS — proceed with local wipe only
+        }
+      }
+
+      let memberCredentials: MemberCredentials | null = null;
+      let credentialsError: string | undefined;
+      try {
+        memberCredentials = await loadMemberCredentials(wrappingKey);
+      } catch (e) {
+        credentialsError = e instanceof Error ? e.message : String(e);
+      }
+
+      const sdk = createLkrpSdk();
+      const destroySpin = out.spin("Tearing down your Ledger Key Ring…");
+      let remoteDestroySucceeded = false;
+      if (memberCredentials) {
+        try {
+          const latest = await sdk.restoreTrustchain(
+            trustchainFromMeta(trustchainMeta),
+            memberCredentials,
+          );
+          await sdk.destroyTrustchain(latest, memberCredentials);
+          remoteDestroySucceeded = true;
+          destroySpin?.success("Ledger Key Ring destroyed");
+        } catch {
+          destroySpin?.error("Remote teardown failed (continuing with local wipe)");
+        }
+      } else {
+        destroySpin?.error(
+          `${credentialsError ?? "No credentials found in keychain"} (continuing with local wipe)`,
+        );
+      }
+
+      await deletePrivateKey();
+      session.wipeRing();
+      session.write();
+      out.ringDestroy(remoteDestroySucceeded);
+    });
+  },
+});

--- a/apps/wallet-cli/src/commands/ring/destroy.ts
+++ b/apps/wallet-cli/src/commands/ring/destroy.ts
@@ -70,9 +70,13 @@ export default defineCommand({
             trustchainFromMeta(trustchainMeta),
             memberCredentials,
           );
-          await sdk.destroyTrustchain(latest, memberCredentials);
+          const { trustchainDestroyed } = await sdk.destroyApplication(latest, memberCredentials);
           remoteDestroySucceeded = true;
-          destroySpin?.success("Ledger Key Ring destroyed");
+          destroySpin?.success(
+            trustchainDestroyed
+              ? "Ledger Key Ring destroyed"
+              : "wallet-cli application deactivated (Ledger Key Ring kept for other apps)",
+          );
         } catch {
           destroySpin?.error("Remote teardown failed (continuing with local wipe)");
         }

--- a/apps/wallet-cli/src/commands/ring/destroy.ts
+++ b/apps/wallet-cli/src/commands/ring/destroy.ts
@@ -86,7 +86,7 @@ export default defineCommand({
         );
       }
 
-      await deletePrivateKey();
+      deletePrivateKey();
       session.wipeRing();
       session.write();
       out.ringDestroy(remoteDestroySucceeded);

--- a/apps/wallet-cli/src/commands/ring/encrypt.ts
+++ b/apps/wallet-cli/src/commands/ring/encrypt.ts
@@ -1,0 +1,69 @@
+import { defineCommand, option } from "@bunli/core";
+import { z } from "zod";
+import { loadDomainKeyInteractive } from "../../key-ring/load-key-ring";
+import { encryptData } from "../../key-ring/crypto";
+import { outputOption, resolveOutputFormat, resolveUserPath } from "../inputs";
+import { createCommandOutput } from "../../output";
+
+export default defineCommand({
+  name: "encrypt",
+  description:
+    "Encrypt data with a key from your Ledger Key Ring. Files via -i/-o, text via stdin/stdout.",
+  options: {
+    key: option(
+      z.string().min(1).max(253).regex(/^\S+$/, "key name must not contain whitespace"),
+      {
+        description:
+          "Key name used to derive a scoped encryption key (e.g. my-oss-project, openClaw-prod)",
+        short: "k",
+      },
+    ),
+    input: option(z.string().optional(), {
+      description: "Input file (default: stdin)",
+      short: "i",
+    }),
+    out: option(z.string().optional(), {
+      description: "Output file (default: stdout)",
+      short: "o",
+    }),
+    output: outputOption,
+  },
+  handler: async ({ flags }) => {
+    const format = resolveOutputFormat(flags.output);
+    const out = createCommandOutput(format, { command: "ring encrypt", network: "all" });
+    await out.run(async () => {
+      if (format === "json" && !flags.out) {
+        throw new Error(
+          "--output json requires --out <file>: binary ciphertext cannot be written as JSON to stdout.",
+        );
+      }
+      if (!flags.input && process.stdin.isTTY) {
+        throw new Error("No input: provide --input FILE or pipe data to stdin.");
+      }
+
+      const fetchSpin = out.spin("Fetching key from your Ledger Key Ring…");
+      const { session, domainKey } = await loadDomainKeyInteractive(flags.key);
+      fetchSpin?.success("Key retrieved");
+
+      const plaintext = new Uint8Array(
+        flags.input
+          ? await Bun.file(resolveUserPath(flags.input)).arrayBuffer()
+          : await Bun.stdin.arrayBuffer(),
+      );
+      const encSpin = out.spin(`Encrypting with key "${flags.key}"…`);
+      const ciphertext = await encryptData(domainKey, plaintext);
+      encSpin?.success(`Encrypted (${ciphertext.byteLength} bytes, AES-256-GCM)`);
+
+      if (flags.out) {
+        const dest = resolveUserPath(flags.out);
+        await Bun.write(dest, ciphertext);
+        out.ringEncrypt({ dest, bytes: ciphertext.byteLength });
+      } else {
+        process.stdout.write(Buffer.from(ciphertext));
+      }
+
+      session.trackDomain(flags.key);
+      session.write();
+    });
+  },
+});

--- a/apps/wallet-cli/src/commands/ring/encrypt.ts
+++ b/apps/wallet-cli/src/commands/ring/encrypt.ts
@@ -1,5 +1,6 @@
 import { defineCommand, option } from "@bunli/core";
 import { z } from "zod";
+import { chmod } from "node:fs/promises";
 import { loadDomainKeyInteractive } from "../../key-ring/load-key-ring";
 import { encryptData } from "../../key-ring/crypto";
 import { outputOption, resolveOutputFormat, resolveUserPath } from "../inputs";
@@ -10,14 +11,11 @@ export default defineCommand({
   description:
     "Encrypt data with a key from your Ledger Key Ring. Files via -i/-o, text via stdin/stdout.",
   options: {
-    key: option(
-      z.string().min(1).max(253).regex(/^\S+$/, "key name must not contain whitespace"),
-      {
-        description:
-          "Key name used to derive a scoped encryption key (e.g. my-oss-project, openClaw-prod)",
-        short: "k",
-      },
-    ),
+    key: option(z.string().min(1).max(253).regex(/^\S+$/, "key name must not contain whitespace"), {
+      description:
+        "Key name used to derive a scoped encryption key (e.g. my-oss-project, openClaw-prod)",
+      short: "k",
+    }),
     input: option(z.string().optional(), {
       description: "Input file (default: stdin)",
       short: "i",
@@ -57,6 +55,7 @@ export default defineCommand({
       if (flags.out) {
         const dest = resolveUserPath(flags.out);
         await Bun.write(dest, ciphertext);
+        await chmod(dest, 0o600).catch(() => {});
         out.ringEncrypt({ dest, bytes: ciphertext.byteLength });
       } else {
         process.stdout.write(Buffer.from(ciphertext));

--- a/apps/wallet-cli/src/commands/ring/index.ts
+++ b/apps/wallet-cli/src/commands/ring/index.ts
@@ -1,0 +1,13 @@
+import { defineGroup } from "@bunli/core";
+import InitCommand from "./init";
+import EncryptCommand from "./encrypt";
+import DecryptCommand from "./decrypt";
+import KeysCommand from "./keys";
+import DestroyCommand from "./destroy";
+
+export default defineGroup({
+  name: "ring",
+  description:
+    "Ledger Key Ring — trustless, hardware-rooted encryption for files and text (LKRP)",
+  commands: [InitCommand, EncryptCommand, DecryptCommand, KeysCommand, DestroyCommand],
+});

--- a/apps/wallet-cli/src/commands/ring/init.ts
+++ b/apps/wallet-cli/src/commands/ring/init.ts
@@ -1,0 +1,88 @@
+import { defineCommand, option } from "@bunli/core";
+import { z } from "zod";
+import os from "node:os";
+import { Session } from "../../session/session-store";
+import { createLkrpSdk } from "../../key-ring/lkrp-sdk";
+import { savePrivateKey } from "../../key-ring/keychain";
+import { generatePasswordSalt, deriveWrappingKey } from "../../key-ring/crypto";
+import { promptHidden } from "../../key-ring/prompt";
+import { WALLET_CLI_DMK_DEVICE_ID } from "../../device/register-dmk-transport";
+import { withLkrpDeviceSession } from "../../session/bridge-device-session";
+import { MEMBER_NAME_MAX_LENGTH } from "../../key-ring/constants";
+import { outputOption, resolveOutputFormat } from "../inputs";
+import { createCommandOutput } from "../../output";
+
+function defaultMemberName(): string {
+  const raw = `${os.hostname()} (${os.platform()})`;
+  return raw.slice(0, MEMBER_NAME_MAX_LENGTH);
+}
+
+export default defineCommand({
+  name: "init",
+  description:
+    "Provision this device as a Ledger Key Ring member (device required). Idempotent — also recovers an existing ring.",
+  options: {
+    name: option(z.string().min(1).max(MEMBER_NAME_MAX_LENGTH).optional(), {
+      description: `Member name (default: hostname + platform, max ${MEMBER_NAME_MAX_LENGTH} chars)`,
+      short: "n",
+    }),
+    "unsecure-no-password": option(z.boolean().default(false), {
+      description: "Skip password protection (stores private key unencrypted in the OS keychain)",
+      argumentKind: "flag",
+    }),
+    output: outputOption,
+  },
+  handler: async ({ flags }) => {
+    const out = createCommandOutput(resolveOutputFormat(flags.output), {
+      command: "ring init",
+      network: "all",
+    });
+    await out.run(async () => {
+      const session = await Session.read();
+      if (session.trustchain) {
+        throw new Error(
+          "Ledger Key Ring already initialized. Run `wallet-cli ring destroy` to reset.",
+        );
+      }
+
+      let wrappingKey: CryptoKey | undefined;
+      let passwordSalt: string | undefined;
+
+      if (!flags["unsecure-no-password"]) {
+        const password = await promptHidden("Password: ");
+        if (!password) throw new Error("Password must not be empty.");
+        const confirm = await promptHidden("Confirm password: ");
+        if (password !== confirm) throw new Error("Passwords do not match.");
+        passwordSalt = generatePasswordSalt();
+        wrappingKey = await deriveWrappingKey(password, passwordSalt);
+      }
+
+      const memberName = flags.name ?? defaultMemberName();
+      const sdk = createLkrpSdk(memberName);
+
+      const memberCredentials = await out.withActivity(
+        "Generating member credentials…",
+        "Member credentials created",
+        () => sdk.initMemberCredentials(),
+      );
+
+      const deviceSpin = out.spin(
+        "Connect device, open Ledger Sync app — provisioning your Ledger Key Ring…",
+      );
+      const { trustchain } = await withLkrpDeviceSession(() =>
+        sdk.getOrCreateTrustchain(WALLET_CLI_DMK_DEVICE_ID, memberCredentials),
+      );
+      deviceSpin?.success("Ledger Key Ring ready");
+
+      await savePrivateKey(memberCredentials.privatekey, memberCredentials.pubkey, wrappingKey);
+      session.setTrustchain({
+        rootId: trustchain.rootId,
+        applicationPath: trustchain.applicationPath,
+      });
+      if (passwordSalt) session.setPasswordSalt(passwordSalt);
+      session.write();
+
+      out.ringInit({ memberName, rootId: trustchain.rootId });
+    });
+  },
+});

--- a/apps/wallet-cli/src/commands/ring/keys.ts
+++ b/apps/wallet-cli/src/commands/ring/keys.ts
@@ -1,0 +1,25 @@
+import { defineCommand } from "@bunli/core";
+import { Session } from "../../session/session-store";
+import { outputOption, resolveOutputFormat } from "../inputs";
+import { createCommandOutput } from "../../output";
+
+export default defineCommand({
+  name: "keys",
+  description: "List the keys you've used on your Ledger Key Ring (local cache, no network).",
+  options: {
+    output: outputOption,
+  },
+  handler: async ({ flags }) => {
+    const out = createCommandOutput(resolveOutputFormat(flags.output), {
+      command: "ring keys",
+      network: "all",
+    });
+    await out.run(async () => {
+      const session = await Session.read();
+      if (!session.trustchain) {
+        throw new Error("Ledger Key Ring not initialized. Run `wallet-cli ring init` first.");
+      }
+      out.ringKeys(session.domains);
+    });
+  },
+});

--- a/apps/wallet-cli/src/key-ring/constants.ts
+++ b/apps/wallet-cli/src/key-ring/constants.ts
@@ -1,0 +1,3 @@
+export const LKRP_APPLICATION_ID = 17;
+
+export const MEMBER_NAME_MAX_LENGTH = 64;

--- a/apps/wallet-cli/src/key-ring/crypto.test.ts
+++ b/apps/wallet-cli/src/key-ring/crypto.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "bun:test";
+import { hexToBytes, pubkeyFromPrivatekey, deriveDomainKey, encryptData, decryptData } from "./crypto";
+
+const KEY_HEX = "cafe".repeat(16);
+
+describe("hexToBytes", () => {
+  it("converts valid hex", () => expect(hexToBytes("ff00ab")).toEqual(new Uint8Array([0xff, 0x00, 0xab])));
+  it("handles empty string", () => expect(hexToBytes("")).toEqual(new Uint8Array(0)));
+  it("throws on odd-length hex", () => expect(() => hexToBytes("abc")).toThrow());
+  it("throws on non-hex characters", () => expect(() => hexToBytes("zz")).toThrow());
+});
+
+describe("pubkeyFromPrivatekey", () => {
+  const PRIVATE = "0101010101010101010101010101010101010101010101010101010101010101";
+  it("returns a 66-char compressed pubkey hex", () =>
+    expect(pubkeyFromPrivatekey(PRIVATE)).toMatch(/^[0-9a-f]{66}$/));
+  it("is deterministic", () => expect(pubkeyFromPrivatekey(PRIVATE)).toBe(pubkeyFromPrivatekey(PRIVATE)));
+  it("throws on invalid hex", () => expect(() => pubkeyFromPrivatekey("not-hex")).toThrow());
+});
+
+describe("encryptData / decryptData", () => {
+  it("round-trip restores plaintext", async () => {
+    const key = await deriveDomainKey(KEY_HEX, "domain");
+    const pt = new TextEncoder().encode("hello world");
+    const ct = await encryptData(key, pt);
+    expect(ct.length).toBe(12 + pt.length + 16); // IV + plaintext + GCM tag
+    expect(new TextDecoder().decode(await decryptData(key, ct))).toBe("hello world");
+  });
+
+  it("different domains produce different keys", async () => {
+    const k1 = await deriveDomainKey(KEY_HEX, "domain-a");
+    const k2 = await deriveDomainKey(KEY_HEX, "domain-b");
+    const ct = await encryptData(k1, new TextEncoder().encode("secret"));
+    await expect(decryptData(k2, ct)).rejects.toThrow("Decryption failed");
+  });
+
+  it("decryptData throws on truncated ciphertext", async () =>
+    expect(decryptData(await deriveDomainKey(KEY_HEX, "x"), new Uint8Array(5))).rejects.toThrow(
+      "too short",
+    ));
+});

--- a/apps/wallet-cli/src/key-ring/crypto.ts
+++ b/apps/wallet-cli/src/key-ring/crypto.ts
@@ -1,0 +1,97 @@
+import { crypto as lkrpCrypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
+
+const PBKDF2_ITERATIONS = 100_000;
+const PBKDF2_SALT_BYTES = 16;
+
+export function generatePasswordSalt(): string {
+  return Buffer.from(globalThis.crypto.getRandomValues(new Uint8Array(PBKDF2_SALT_BYTES))).toString(
+    "hex",
+  );
+}
+
+export async function deriveWrappingKey(password: string, saltHex: string): Promise<CryptoKey> {
+  const keyMaterial = await globalThis.crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(password),
+    "PBKDF2",
+    false,
+    ["deriveKey"],
+  );
+  return globalThis.crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: hexToBytes(saltHex),
+      iterations: PBKDF2_ITERATIONS,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+export function pubkeyFromPrivatekey(privateHex: string): string {
+  return lkrpCrypto.to_hex(lkrpCrypto.keypairFromSecretKey(hexToBytes(privateHex)).publicKey);
+}
+
+export function hexToBytes(hex: string): Uint8Array<ArrayBuffer> {
+  if (hex.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(hex)) {
+    throw new Error(`Invalid hex string (length=${hex.length}): expected even-length hex digits.`);
+  }
+  const result = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < result.length; i++) {
+    result[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return result;
+}
+
+const DOMAIN_SALT = new TextEncoder().encode("wallet-cli-domain-v1");
+
+export async function deriveDomainKey(
+  walletSyncEncryptionKey: string,
+  domain: string,
+): Promise<CryptoKey> {
+  const ikm = hexToBytes(walletSyncEncryptionKey);
+  const hkdfKey = await globalThis.crypto.subtle.importKey("raw", ikm, "HKDF", false, [
+    "deriveBits",
+  ]);
+  const bits = await globalThis.crypto.subtle.deriveBits(
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: DOMAIN_SALT,
+      info: new TextEncoder().encode(domain),
+    },
+    hkdfKey,
+    256,
+  );
+  return globalThis.crypto.subtle.importKey("raw", bits, { name: "AES-GCM" }, false, [
+    "encrypt",
+    "decrypt",
+  ]);
+}
+
+/** Wire format: [iv (12 bytes)][ciphertext] */
+export async function encryptData(key: CryptoKey, plaintext: Uint8Array<ArrayBuffer>): Promise<Uint8Array<ArrayBuffer>> {
+  const iv = globalThis.crypto.getRandomValues(new Uint8Array(12));
+  const ct = await globalThis.crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, plaintext);
+  const result = new Uint8Array(12 + ct.byteLength);
+  result.set(iv, 0);
+  result.set(new Uint8Array(ct), 12);
+  return result;
+}
+
+export async function decryptData(key: CryptoKey, ciphertext: Uint8Array<ArrayBuffer>): Promise<Uint8Array<ArrayBuffer>> {
+  if (ciphertext.length < 12) {
+    throw new Error("Invalid ciphertext: too short to contain IV.");
+  }
+  const iv = ciphertext.slice(0, 12);
+  const ct = ciphertext.slice(12);
+  try {
+    const pt = await globalThis.crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ct);
+    return new Uint8Array(pt);
+  } catch {
+    throw new Error("Decryption failed: wrong key or corrupted data.");
+  }
+}

--- a/apps/wallet-cli/src/key-ring/keychain.ts
+++ b/apps/wallet-cli/src/key-ring/keychain.ts
@@ -42,7 +42,7 @@ export async function savePrivateKey(
   } else {
     firstLine = hex;
   }
-  const entry = await getEntry();
+  const entry = getEntry();
   entry.setPassword(pubkey ? `${firstLine}\n${pubkey}` : firstLine);
 }
 
@@ -51,7 +51,7 @@ export async function loadMemberCredentials(
 ): Promise<MemberCredentials | null> {
   let stored: string | null;
   try {
-    stored = (await getEntry()).getPassword();
+    stored = getEntry().getPassword();
   } catch {
     return null;
   }
@@ -63,7 +63,8 @@ export async function loadMemberCredentials(
 
   let privatekey: string;
   if (firstLine.startsWith(ENC_PREFIX)) {
-    if (!wrappingKey) throw new Error("Private key is password-protected but no password provided.");
+    if (!wrappingKey)
+      throw new Error("Private key is password-protected but no password provided.");
     const ct = hexToBytes(firstLine.slice(ENC_PREFIX.length));
     try {
       privatekey = new TextDecoder().decode(await decryptData(wrappingKey, ct));
@@ -78,8 +79,8 @@ export async function loadMemberCredentials(
   return { privatekey, pubkey };
 }
 
-export async function deletePrivateKey(): Promise<void> {
+export function deletePrivateKey(): void {
   try {
-    (await getEntry()).deletePassword();
+    getEntry().deletePassword();
   } catch {}
 }

--- a/apps/wallet-cli/src/key-ring/keychain.ts
+++ b/apps/wallet-cli/src/key-ring/keychain.ts
@@ -1,0 +1,85 @@
+import { Entry } from "@napi-rs/keyring";
+import { APP_NAME } from "../session/session-store";
+import { pubkeyFromPrivatekey, encryptData, decryptData, hexToBytes } from "./crypto";
+import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
+
+const SERVICE = APP_NAME;
+const ENC_PREFIX = "ENC:";
+
+/**
+ * When XDG_STATE_HOME is set (standard on Linux, also used by tests to point at a temp dir),
+ * derive a unique account name per state directory so parallel workers don't clobber each other's keychain entries.
+ */
+function keychainAccount(): string {
+  const xdg = process.env.XDG_STATE_HOME;
+  if (xdg) {
+    const suffix = xdg.replaceAll(/[^a-z0-9]/gi, "").slice(-12);
+    return `member-private-key-${suffix}`;
+  }
+  return "member-private-key";
+}
+
+function getEntry() {
+  return new Entry(SERVICE, keychainAccount());
+}
+
+/**
+ * Save credentials to the OS keychain.
+ * If wrappingKey is provided the private key hex is AES-256-GCM encrypted and prefixed with
+ * "ENC:" so the entry is self-describing regardless of session state.
+ * pubkey is stored on a second line when supplied, to avoid re-deriving it later
+ * (the mock LKRP SDK uses non-hex private keys that cannot be used for secp256k1 derivation).
+ */
+export async function savePrivateKey(
+  hex: string,
+  pubkey?: string,
+  wrappingKey?: CryptoKey,
+): Promise<void> {
+  let firstLine: string;
+  if (wrappingKey) {
+    const ct = await encryptData(wrappingKey, new TextEncoder().encode(hex));
+    firstLine = `${ENC_PREFIX}${Buffer.from(ct).toString("hex")}`;
+  } else {
+    firstLine = hex;
+  }
+  const entry = await getEntry();
+  entry.setPassword(pubkey ? `${firstLine}\n${pubkey}` : firstLine);
+}
+
+export async function loadMemberCredentials(
+  wrappingKey?: CryptoKey,
+): Promise<MemberCredentials | null> {
+  let stored: string | null;
+  try {
+    stored = (await getEntry()).getPassword();
+  } catch {
+    return null;
+  }
+  if (!stored) return null;
+
+  const lines = stored.trim().split("\n");
+  const firstLine = lines[0];
+  if (!firstLine) return null;
+
+  let privatekey: string;
+  if (firstLine.startsWith(ENC_PREFIX)) {
+    if (!wrappingKey) throw new Error("Private key is password-protected but no password provided.");
+    const ct = hexToBytes(firstLine.slice(ENC_PREFIX.length));
+    try {
+      privatekey = new TextDecoder().decode(await decryptData(wrappingKey, ct));
+    } catch {
+      throw new Error("Wrong password: failed to decrypt private key.");
+    }
+  } else {
+    privatekey = firstLine;
+  }
+
+  const pubkey = lines[1] || pubkeyFromPrivatekey(privatekey);
+  return { privatekey, pubkey };
+}
+
+export async function deletePrivateKey(): Promise<void> {
+  try {
+    (await getEntry()).deletePassword();
+  } catch {}
+}

--- a/apps/wallet-cli/src/key-ring/lkrp-sdk.ts
+++ b/apps/wallet-cli/src/key-ring/lkrp-sdk.ts
@@ -1,0 +1,16 @@
+import { getSdk } from "@ledgerhq/ledger-key-ring-protocol/index";
+import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
+import { getEnv } from "@ledgerhq/live-env";
+import { LKRP_APPLICATION_ID } from "./constants";
+
+export function createLkrpSdk(memberName = "wallet-cli") {
+  return getSdk(
+    !!process.env.MOCK,
+    {
+      applicationId: LKRP_APPLICATION_ID,
+      name: memberName,
+      apiBaseUrl: getEnv("TRUSTCHAIN_API_PROD"),
+    },
+    withDevice,
+  );
+}

--- a/apps/wallet-cli/src/key-ring/load-key-ring.ts
+++ b/apps/wallet-cli/src/key-ring/load-key-ring.ts
@@ -1,0 +1,64 @@
+import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
+import { Session, type TrustchainMeta, trustchainFromMeta } from "../session/session-store";
+import { loadMemberCredentials } from "./keychain";
+import { createLkrpSdk } from "./lkrp-sdk";
+import { deriveDomainKey, deriveWrappingKey } from "./crypto";
+import { promptHidden } from "./prompt";
+
+export type LoadedKeyRing = {
+  session: Session;
+  trustchainMeta: TrustchainMeta;
+  memberCredentials: MemberCredentials;
+};
+
+export async function loadKeyRing(wrappingKey?: CryptoKey): Promise<LoadedKeyRing> {
+  const [session, memberCredentials] = await Promise.all([
+    Session.read(),
+    loadMemberCredentials(wrappingKey),
+  ]);
+  const trustchainMeta = session.trustchain;
+  if (!trustchainMeta) {
+    throw new Error("Ledger Key Ring not initialized. Run `wallet-cli ring init` first.");
+  }
+  if (!memberCredentials) {
+    throw new Error(
+      "Member credentials not found in the OS keychain. Run `wallet-cli ring destroy` then `init` to reset.",
+    );
+  }
+  return { session, trustchainMeta, memberCredentials };
+}
+
+async function resolveWrappingKey(session: Session): Promise<CryptoKey | undefined> {
+  if (!session.passwordSalt) return undefined;
+  const password = await promptHidden("Password: ");
+  if (!password) throw new Error("Password must not be empty.");
+  return deriveWrappingKey(password, session.passwordSalt);
+}
+
+export async function loadDomainKey(
+  domain: string,
+  wrappingKey?: CryptoKey,
+): Promise<{ session: Session; domainKey: CryptoKey }> {
+  const { session, trustchainMeta, memberCredentials } = await loadKeyRing(wrappingKey);
+  const sdk = createLkrpSdk();
+  const restored = await sdk.restoreTrustchain(
+    trustchainFromMeta(trustchainMeta),
+    memberCredentials,
+  );
+  if (restored.applicationPath !== trustchainMeta.applicationPath) {
+    session.setTrustchain({
+      rootId: trustchainMeta.rootId,
+      applicationPath: restored.applicationPath,
+    });
+    session.write();
+  }
+  return { session, domainKey: await deriveDomainKey(restored.walletSyncEncryptionKey, domain) };
+}
+
+export async function loadDomainKeyInteractive(
+  domain: string,
+): Promise<{ session: Session; domainKey: CryptoKey }> {
+  const session = await Session.read();
+  const wrappingKey = await resolveWrappingKey(session);
+  return loadDomainKey(domain, wrappingKey);
+}

--- a/apps/wallet-cli/src/key-ring/prompt.ts
+++ b/apps/wallet-cli/src/key-ring/prompt.ts
@@ -1,0 +1,45 @@
+export async function promptHidden(label: string): Promise<string> {
+  const envPass = process.env.WALLET_PASS;
+  if (envPass !== undefined) return envPass;
+
+  if (process.stdin.isTTY) {
+    process.stderr.write(label);
+    return new Promise((resolve, reject) => {
+      let value = "";
+      process.stdin.setRawMode(true);
+      process.stdin.resume();
+      process.stdin.setEncoding("utf8");
+
+      const onData = (ch: string) => {
+        if (ch === "\r" || ch === "\n") {
+          teardown();
+          resolve(value);
+        } else if (ch === "") {
+          teardown();
+          reject(new Error("Cancelled"));
+        } else if (ch === "" || ch === "\b") {
+          value = value.slice(0, -1);
+        } else {
+          value += ch;
+        }
+      };
+
+      const teardown = () => {
+        process.stdin.setRawMode(false);
+        process.stdin.pause();
+        process.stdin.off("data", onData);
+        process.stderr.write("\n");
+      };
+
+      process.stdin.on("data", onData);
+    });
+  }
+
+  throw new Error(
+    "Password required but no TTY available and WALLET_PASS is not set.\n" +
+      "Inject it from your OS keychain before running the command:\n" +
+      "  macOS : WALLET_PASS=$(security find-generic-password -a default -s wallet-cli -w) wallet-cli ...\n" +
+      "  Linux : WALLET_PASS=$(secret-tool lookup service wallet-cli account default) wallet-cli ...\n" +
+      "  Win   : $env:WALLET_PASS=(Get-StoredCredential -Target wallet-cli).GetNetworkCredential().Password",
+  );
+}

--- a/apps/wallet-cli/src/output-json.test.ts
+++ b/apps/wallet-cli/src/output-json.test.ts
@@ -237,6 +237,110 @@ describe("JsonCommandOutput", () => {
     });
   });
 
+  it("ringInit emits member and rootId in envelope", () => {
+    try {
+      const out = createCommandOutput("json", { command: "ring init", network: "all" });
+      out.ringInit({ memberName: "my-machine (darwin)", rootId: "root-abc" });
+    } finally {
+      restore();
+    }
+    const [line] = writes.join("").trim().split("\n").map(l => JSON.parse(l));
+    expect(line).toMatchObject({
+      status: "success",
+      command: "ring init",
+      network: "all",
+      member: "my-machine (darwin)",
+      rootId: "root-abc",
+    });
+  });
+
+  it("ringKeys emits keys array in envelope", () => {
+    try {
+      const out = createCommandOutput("json", { command: "ring keys", network: "all" });
+      out.ringKeys([
+        { domain: "prod", firstUsed: "2026-04-27T00:00:00.000Z" },
+        { domain: "staging", firstUsed: "2026-04-28T00:00:00.000Z" },
+      ]);
+    } finally {
+      restore();
+    }
+    const [line] = writes.join("").trim().split("\n").map(l => JSON.parse(l));
+    expect(line).toMatchObject({
+      status: "success",
+      command: "ring keys",
+      keys: [
+        { domain: "prod", firstUsed: "2026-04-27T00:00:00.000Z" },
+        { domain: "staging", firstUsed: "2026-04-28T00:00:00.000Z" },
+      ],
+    });
+  });
+
+  it("ringKeys emits empty keys array when no keys tracked", () => {
+    try {
+      const out = createCommandOutput("json", { command: "ring keys", network: "all" });
+      out.ringKeys([]);
+    } finally {
+      restore();
+    }
+    const [line] = writes.join("").trim().split("\n").map(l => JSON.parse(l));
+    expect(line).toMatchObject({ status: "success", keys: [] });
+  });
+
+  it("ringDestroy emits destroyed=true when remote succeeded", () => {
+    try {
+      const out = createCommandOutput("json", { command: "ring destroy", network: "all" });
+      out.ringDestroy(true);
+    } finally {
+      restore();
+    }
+    const [line] = writes.join("").trim().split("\n").map(l => JSON.parse(l));
+    expect(line).toMatchObject({ status: "success", destroyed: true, local_wiped: true });
+  });
+
+  it("ringDestroy emits destroyed=false when only local wipe", () => {
+    try {
+      const out = createCommandOutput("json", { command: "ring destroy", network: "all" });
+      out.ringDestroy(false);
+    } finally {
+      restore();
+    }
+    const [line] = writes.join("").trim().split("\n").map(l => JSON.parse(l));
+    expect(line).toMatchObject({ status: "success", destroyed: false, local_wiped: true });
+  });
+
+  it("ringDestroyCancelled emits cancelled:true envelope", () => {
+    try {
+      const out = createCommandOutput("json", { command: "ring destroy", network: "all" });
+      out.ringDestroyCancelled();
+    } finally {
+      restore();
+    }
+    const [line] = writes.join("").trim().split("\n").map(l => JSON.parse(l));
+    expect(line).toMatchObject({ status: "success", cancelled: true });
+  });
+
+  it("ringEncrypt emits output path and byte count", () => {
+    try {
+      const out = createCommandOutput("json", { command: "ring encrypt", network: "all" });
+      out.ringEncrypt({ dest: "/tmp/out.enc", bytes: 64 });
+    } finally {
+      restore();
+    }
+    const [line] = writes.join("").trim().split("\n").map(l => JSON.parse(l));
+    expect(line).toMatchObject({ status: "success", output: "/tmp/out.enc", bytes: 64 });
+  });
+
+  it("ringDecrypt emits output path", () => {
+    try {
+      const out = createCommandOutput("json", { command: "ring decrypt", network: "all" });
+      out.ringDecrypt({ dest: "/tmp/out.txt" });
+    } finally {
+      restore();
+    }
+    const [line] = writes.join("").trim().split("\n").map(l => JSON.parse(l));
+    expect(line).toMatchObject({ status: "success", output: "/tmp/out.txt" });
+  });
+
   it("emits swap quote unavailability as an NDJSON error envelope", () => {
     try {
       const out = createCommandOutput("json", {

--- a/apps/wallet-cli/src/output.test.ts
+++ b/apps/wallet-cli/src/output.test.ts
@@ -1,5 +1,6 @@
 import "./live-common-setup";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { installOutputCapture } from "./shared/ui";
 
 type MockSpinner = {
   text: string;
@@ -143,5 +144,68 @@ describe("HumanCommandOutput", () => {
     expect(joined).toContain(USDT_TOKEN_INFO.id);
     expect(joined).toContain(USDT_TOKEN_INFO.ticker);
     expect(joined).toContain(USDT_TOKEN_INFO.contractAddress);
+  });
+
+  describe("ring human output", () => {
+    let writes: string[] = [];
+    let stderrWrites: string[] = [];
+    let restore: () => void;
+
+    beforeEach(() => {
+      writes = [];
+      stderrWrites = [];
+      restore = installOutputCapture({
+        stdout: chunk => writes.push(chunk),
+        stderr: chunk => stderrWrites.push(chunk),
+      });
+    });
+
+    afterEach(() => restore());
+
+    const ctx = { command: "ring", network: "all" };
+
+    it("ringKeys renders a table with key and date columns", () => {
+      createCommandOutput("human", ctx).ringKeys([
+        { domain: "prod", firstUsed: "2026-04-27T12:00:00.000Z" },
+        { domain: "staging", firstUsed: "2026-04-28T12:00:00.000Z" },
+      ]);
+      const out = writes.join("");
+      expect(out).toContain("prod");
+      expect(out).toContain("staging");
+      expect(out).toContain("2026-04-27");
+      expect(out).toContain("2026-04-28");
+    });
+
+    it("ringKeys renders dim message when empty", () => {
+      createCommandOutput("human", ctx).ringKeys([]);
+      expect(writes.join("")).toContain("No keys");
+    });
+
+    it("ringDestroy shows destroyed message when remote succeeded", () => {
+      createCommandOutput("human", ctx).ringDestroy(true);
+      expect(writes.join("")).toContain("Ledger Key Ring destroyed");
+    });
+
+    it("ringDestroy shows local-wipe message when remote failed", () => {
+      createCommandOutput("human", ctx).ringDestroy(false);
+      expect(writes.join("")).toContain("local credentials wiped");
+    });
+
+    it("ringDestroyCancelled writes Cancelled to stderr", () => {
+      createCommandOutput("human", ctx).ringDestroyCancelled();
+      expect(stderrWrites.join("")).toContain("Cancelled");
+    });
+
+    it("ringEncrypt shows written path and byte count", () => {
+      createCommandOutput("human", ctx).ringEncrypt({ dest: "/tmp/out.enc", bytes: 128 });
+      const out = writes.join("");
+      expect(out).toContain("/tmp/out.enc");
+      expect(out).toContain("128");
+    });
+
+    it("ringDecrypt shows written path", () => {
+      createCommandOutput("human", ctx).ringDecrypt({ dest: "/tmp/out.txt" });
+      expect(writes.join("")).toContain("/tmp/out.txt");
+    });
   });
 });

--- a/apps/wallet-cli/src/output.ts
+++ b/apps/wallet-cli/src/output.ts
@@ -118,6 +118,7 @@ export interface CommandOutput {
    * WalletCliDeviceError handling in run()/fail().
    */
   deviceState(state: DeviceState): void;
+
   /** Print one progress line for swap execute long-running steps. */
   swapExecuteProgress(line: string): void;
   /** Print payload-only swap execute result. */
@@ -140,6 +141,19 @@ export interface CommandOutput {
     amountExpectedTo?: string;
     magnitudeAwareRate?: string;
   }): void;
+
+  /** Output ring init result (human: member + rootId lines; json: envelope). */
+  ringInit(result: { memberName: string; rootId: string }): void;
+  /** Output key names table (human: table or empty message; json: envelope with keys array). */
+  ringKeys(domains: ReadonlyArray<{ domain: string; firstUsed: string }>): void;
+  /** Output ring destroy result (human: colored message; json: envelope). */
+  ringDestroy(remoteSucceeded: boolean): void;
+  /** User cancelled destroy confirmation (human: stderr line; json: envelope with cancelled:true). */
+  ringDestroyCancelled(): void;
+  /** Output encrypt-to-file result (human: ✔ line; json: envelope with output path + bytes). */
+  ringEncrypt(result: { dest: string; bytes: number }): void;
+  /** Output decrypt-to-file result (human: ✔ line; json: envelope with output path). */
+  ringDecrypt(result: { dest: string }): void;
 }
 
 // ---------------------------------------------------------------------------
@@ -383,7 +397,6 @@ class HumanCommandOutput implements CommandOutput {
 
   deviceState(state: DeviceState): void {
     if (isTerminalDeviceState(state)) {
-      // Terminal states are surfaced via thrown WalletCliDeviceError; avoid double-render.
       return;
     }
     const { glyph, message } = renderDeviceState(state);
@@ -445,6 +458,46 @@ class HumanCommandOutput implements CommandOutput {
     if (args.operationHash) {
       writeStdout(`${colors.bold("Operation hash:")} ${args.operationHash}\n`);
     }
+  }
+
+  ringInit({ memberName, rootId }: { memberName: string; rootId: string }): void {
+    writeStdout("");
+    writeStdout(`${colors.bold("Member:")}  ${memberName}`);
+    writeStdout(`${colors.bold("Root ID:")} ${rootId}`);
+    writeStdout(colors.dim("Encrypt/decrypt with: wallet-cli ring encrypt --key <name>"));
+  }
+
+  ringKeys(domains: ReadonlyArray<{ domain: string; firstUsed: string }>): void {
+    if (domains.length === 0) {
+      writeStdout(colors.dim("No keys yet. Use `ring encrypt --key <name>` to create one."));
+      return;
+    }
+    const w = Math.max(3, ...domains.map(d => d.domain.length));
+    writeStdout(`${colors.bold("Key".padEnd(w))}  ${colors.bold("First Used")}`);
+    writeStdout("─".repeat(w + 2 + 10));
+    for (const { domain, firstUsed } of domains) {
+      writeStdout(`${domain.padEnd(w)}  ${firstUsed.slice(0, 10)}`);
+    }
+  }
+
+  ringDestroy(remoteSucceeded: boolean): void {
+    writeStdout(
+      remoteSucceeded
+        ? `${colors.green("✔")} Ledger Key Ring destroyed.`
+        : `${colors.green("✔")} Ledger Key Ring local credentials wiped.`,
+    );
+  }
+
+  ringDestroyCancelled(): void {
+    writeStderr("Cancelled.\n");
+  }
+
+  ringEncrypt({ dest, bytes }: { dest: string; bytes: number }): void {
+    writeStdout(`${colors.green("✔")} Written to ${dest} (${bytes} bytes, AES-256-GCM)`);
+  }
+
+  ringDecrypt({ dest }: { dest: string }): void {
+    writeStdout(`${colors.green("✔")} Written to ${dest}`);
   }
 }
 
@@ -695,6 +748,30 @@ class JsonCommandOutput implements CommandOutput {
         magnitudeAwareRate: args.magnitudeAwareRate,
       }),
     );
+  }
+
+  ringInit({ memberName, rootId }: { memberName: string; rootId: string }): void {
+    this._writeNdjson(this._envelope({ member: memberName, rootId }));
+  }
+
+  ringKeys(domains: ReadonlyArray<{ domain: string; firstUsed: string }>): void {
+    this._writeNdjson(this._envelope({ keys: domains.map(d => ({ domain: d.domain, firstUsed: d.firstUsed })) }));
+  }
+
+  ringDestroy(remoteSucceeded: boolean): void {
+    this._writeNdjson(this._envelope({ destroyed: remoteSucceeded, local_wiped: true }));
+  }
+
+  ringDestroyCancelled(): void {
+    this._writeNdjson(this._envelope({ cancelled: true }));
+  }
+
+  ringEncrypt({ dest, bytes }: { dest: string; bytes: number }): void {
+    this._writeNdjson(this._envelope({ output: dest, bytes }));
+  }
+
+  ringDecrypt({ dest }: { dest: string }): void {
+    this._writeNdjson(this._envelope({ output: dest }));
   }
 }
 

--- a/apps/wallet-cli/src/session/bridge-device-session.ts
+++ b/apps/wallet-cli/src/session/bridge-device-session.ts
@@ -1,4 +1,5 @@
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { TRUSTCHAIN_APP_NAME } from "@ledgerhq/hw-ledger-key-ring-protocol/ApduDevice";
 import { connectLedgerApp } from "../device/connect-ledger-app";
 import type { DeviceState } from "../device/device-state";
 import { WalletCliDeviceError } from "../device/wallet-cli-device-error";
@@ -60,6 +61,27 @@ export function withDmkDeviceSession<T>(fn: () => Promise<T>): Promise<T> {
       throw WalletCliDeviceError.fromUnknown(e, { expectedApp: "Ledger dashboard" });
     }
     walletCliDebug("DMK device session ready.");
+    try {
+      return await fn();
+    } finally {
+      walletCliDebug("Resetting device session…");
+      await resetWalletCliDmkSession();
+    }
+  });
+}
+
+/** Open the Ledger Sync app and run a function that sends LKRP APDUs. No currency required. */
+export function withLkrpDeviceSession<T>(fn: () => Promise<T>): Promise<T> {
+  return withWalletCliDeviceInterruptScope(async () => {
+    walletCliDebug("Ensuring DMK transport for LKRP…");
+    try {
+      const transport = await ensureWalletCliDmkTransport();
+      walletCliDebug("Connecting Ledger Sync app…");
+      await connectLedgerApp(transport.dmk, transport.sessionId, TRUSTCHAIN_APP_NAME);
+    } catch (e) {
+      throw WalletCliDeviceError.fromUnknown(e, { expectedApp: TRUSTCHAIN_APP_NAME });
+    }
+    walletCliDebug("Ledger Sync app open.");
     try {
       return await fn();
     } finally {

--- a/apps/wallet-cli/src/session/session-store.ts
+++ b/apps/wallet-cli/src/session/session-store.ts
@@ -3,6 +3,7 @@ import { stateDir } from "@bunli/utils";
 import { join } from "node:path";
 import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import { z } from "zod";
+import type { Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
 import type { AccountDescriptorV1 } from "../shared/accountDescriptor";
 import { serializeV1 } from "../shared/accountDescriptor";
 
@@ -17,19 +18,39 @@ const SessionEntrySchema = z.object({
   descriptor: z.string(),
 });
 
+const TrustchainMetaSchema = z.object({
+  rootId: z.string(),
+  applicationPath: z.string(),
+});
+
+const DomainEntrySchema = z.object({
+  domain: z.string(),
+  firstUsed: z.string(),
+});
+
 const SessionDataSchema = z.object({
   accounts: z.array(SessionEntrySchema).default([]),
+  trustchain: TrustchainMetaSchema.optional(),
+  domains: z.array(DomainEntrySchema).default([]),
+  passwordSalt: z.string().optional(),
 });
 
 export type SessionEntry = z.infer<typeof SessionEntrySchema>;
+export type TrustchainMeta = z.infer<typeof TrustchainMetaSchema>;
+export type DomainEntry = z.infer<typeof DomainEntrySchema>;
 
 export function getSessionPath(): string {
   return join(stateDir(APP_NAME), SESSION_FILE);
 }
 
-function parseSessionData(raw: string): SessionEntry[] {
+/** Construct a Trustchain from metadata; walletSyncEncryptionKey is left empty (sufficient for auth-only LKRP calls). */
+export function trustchainFromMeta(meta: TrustchainMeta): Trustchain {
+  return { ...meta, walletSyncEncryptionKey: "" };
+}
+
+function parseSessionData(raw: string): z.infer<typeof SessionDataSchema> {
   try {
-    return SessionDataSchema.parse(YAML.parse(raw) ?? {}).accounts;
+    return SessionDataSchema.parse(YAML.parse(raw) ?? {});
   } catch {
     throw new Error(
       `Invalid session file at ${getSessionPath()}. Run \`wallet-cli session reset\` to clear it.`,
@@ -37,24 +58,25 @@ function parseSessionData(raw: string): SessionEntry[] {
   }
 }
 
-async function readEntries(): Promise<SessionEntry[]> {
+async function readData(): Promise<z.infer<typeof SessionDataSchema>> {
   let content: string;
   try {
     content = await Bun.file(getSessionPath()).text();
   } catch (err) {
-    if (err instanceof Error && "code" in err && err.code === "ENOENT") return [];
+    if (err instanceof Error && "code" in err && err.code === "ENOENT")
+      return SessionDataSchema.parse({});
     throw err;
   }
   return parseSessionData(content);
 }
 
-function writeEntries(entries: SessionEntry[]): void {
+function writeSessionData(data: Record<string, unknown>): void {
   const dir = stateDir(APP_NAME);
   mkdirSync(dir, { recursive: true, mode: 0o700 });
-  chmodSync(dir, 0o700); // enforce on existing dirs created by prior versions
+  chmodSync(dir, 0o700);
   const sessionPath = getSessionPath();
-  writeFileSync(sessionPath, YAML.stringify({ accounts: entries }), { mode: 0o600 });
-  chmodSync(sessionPath, 0o600); // enforce on existing files created by prior versions
+  writeFileSync(sessionPath, YAML.stringify(data), { mode: 0o600 });
+  chmodSync(sessionPath, 0o600);
 }
 
 function derivationLabel(path: string): string {
@@ -90,21 +112,59 @@ export function generateLabel(
 }
 
 export class Session {
-  private constructor(private entries: SessionEntry[]) {}
+  private constructor(
+    private entries: SessionEntry[],
+    private _trustchain: TrustchainMeta | undefined,
+    private _domains: DomainEntry[],
+    private _passwordSalt: string | undefined,
+  ) {}
 
   static async read(): Promise<Session> {
-    return new Session(await readEntries());
+    const data = await readData();
+    return new Session(data.accounts, data.trustchain, data.domains, data.passwordSalt);
   }
 
   static from(entries: SessionEntry[]): Session {
-    return new Session([...entries]);
+    return new Session([...entries], undefined, [], undefined);
   }
 
   get accounts(): ReadonlyArray<SessionEntry> {
     return this.entries;
   }
 
-  /** Remove all entries. Returns count of entries that were present. */
+  get trustchain(): TrustchainMeta | undefined {
+    return this._trustchain;
+  }
+
+  get passwordSalt(): string | undefined {
+    return this._passwordSalt;
+  }
+
+  setPasswordSalt(salt: string): void {
+    this._passwordSalt = salt;
+  }
+
+  setTrustchain(t: TrustchainMeta): void {
+    this._trustchain = t;
+  }
+
+  get domains(): ReadonlyArray<DomainEntry> {
+    return this._domains;
+  }
+
+  trackDomain(domain: string): void {
+    if (!this._domains.some(d => d.domain === domain)) {
+      this._domains.push({ domain, firstUsed: new Date().toISOString() });
+    }
+  }
+
+  /** Clears Ledger Key Ring state (trustchain, tracked keys, password salt). Keeps discovered accounts. */
+  wipeRing(): void {
+    this._trustchain = undefined;
+    this._domains = [];
+    this._passwordSalt = undefined;
+  }
+
   clear(): number {
     const count = this.entries.length;
     this.entries = [];
@@ -135,6 +195,10 @@ export class Session {
   }
 
   write(): void {
-    writeEntries(this.entries);
+    const data: Record<string, unknown> = { accounts: this.entries };
+    if (this._trustchain) data.trustchain = this._trustchain;
+    if (this._domains.length > 0) data.domains = this._domains;
+    if (this._passwordSalt) data.passwordSalt = this._passwordSalt;
+    writeSessionData(data);
   }
 }

--- a/apps/wallet-cli/src/test/commands/ring.test.ts
+++ b/apps/wallet-cli/src/test/commands/ring.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeAll, afterAll, mock } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Readable } from "node:stream";
+import { runCli, type RunResult } from "../helpers/cli-runner";
+
+function runCliWithStdin(
+  args: string[],
+  env: Record<string, string>,
+  stdinLines: string[],
+): Promise<RunResult> {
+  const origDesc = Object.getOwnPropertyDescriptor(process, "stdin");
+  const fakeStdin = new Readable({ read() {} });
+  for (const line of stdinLines) fakeStdin.push(`${line}\n`);
+  fakeStdin.push(null);
+  Object.defineProperty(process, "stdin", { get: () => fakeStdin, configurable: true });
+  return runCli(args, env).finally(() => {
+    if (origDesc) Object.defineProperty(process, "stdin", origDesc);
+  });
+}
+
+// Mock OS keychain so tests never touch macOS Keychain / libsecret.
+// Must be declared before any runCli() call that triggers a keychain import.
+const _store = new Map<string, string>();
+mock.module("@napi-rs/keyring", () => ({
+  Entry: class {
+    #k: string;
+    constructor(svc: string, acc: string) {
+      this.#k = `${svc}:${acc}`;
+    }
+    setPassword(v: string) {
+      _store.set(this.#k, v);
+    }
+    getPassword() {
+      return _store.get(this.#k) ?? null;
+    }
+    deletePassword() {
+      _store.delete(this.#k);
+    }
+  },
+}));
+
+const MOCK_ENV = { MOCK: "1" };
+const MOCK_ENV_DMK = { ...MOCK_ENV, WALLET_CLI_MOCK_DMK: "1" };
+
+function makeTmpDir(): { env: Record<string, string>; dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "wallet-cli-ring-test-"));
+  return {
+    dir,
+    env: { XDG_STATE_HOME: dir, ...MOCK_ENV },
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("ring — not initialized", () => {
+  const { env, cleanup } = makeTmpDir();
+  afterAll(cleanup);
+
+  it("keys exits 1", async () => {
+    expect((await runCli(["ring", "keys"], env)).exitCode).toBe(1);
+  });
+
+  it("encrypt exits 1", async () => {
+    expect((await runCli(["ring", "encrypt", "--key", "x"], env)).exitCode).toBe(1);
+  });
+
+  it("decrypt exits 1", async () => {
+    expect((await runCli(["ring", "decrypt", "--key", "x"], env)).exitCode).toBe(1);
+  });
+
+  it("destroy exits 1", async () => {
+    expect((await runCli(["ring", "destroy"], env)).exitCode).toBe(1);
+  });
+});
+
+describe("ring — happy path", () => {
+  let dir: string;
+  let env: Record<string, string>;
+  let initResult: RunResult;
+  let plainFile: string;
+  let encFile: string;
+  let decFile: string;
+
+  beforeAll(async () => {
+    ({ dir, env } = makeTmpDir());
+    plainFile = join(dir, "plain.txt");
+    encFile = join(dir, "test.enc");
+    decFile = join(dir, "test.dec");
+    await Bun.write(plainFile, "hello key ring");
+
+    initResult = await runCli(
+      ["ring", "init", "--name", "test-member", "--unsecure-no-password"],
+      { ...env, ...MOCK_ENV_DMK },
+    );
+    expect(initResult.exitCode, `init failed: ${initResult.stderr}`).toBe(0);
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("init outputs member name and root id", () => {
+    expect(initResult.stdout).toContain("test-member");
+    expect(initResult.stdout).toContain("mock-root-id");
+  });
+
+  it("init fails when already initialized", async () => {
+    const r = await runCli(["ring", "init"], { ...env, ...MOCK_ENV_DMK });
+    expect(r.exitCode).toBe(1);
+  });
+
+  it("keys shows no keys after init", async () => {
+    const r = await runCli(["ring", "keys"], env);
+    expect(r.exitCode, r.stderr).toBe(0);
+    expect(r.stdout).toMatch(/no keys/i);
+  });
+
+  it("keys --output json returns empty keys array", async () => {
+    const r = await runCli(["ring", "keys", "--output", "json"], env);
+    expect(r.exitCode, r.stderr).toBe(0);
+    const data = JSON.parse(r.stdout);
+    expect(data.command).toBe("ring keys");
+    expect(data.keys).toHaveLength(0);
+  });
+
+  it("encrypt writes ciphertext to file", async () => {
+    const r = await runCli(
+      ["ring", "encrypt", "--key", "prod", "--input", plainFile, "--out", encFile],
+      env,
+    );
+    expect(r.exitCode, r.stderr).toBe(0);
+    const ct = await Bun.file(encFile).arrayBuffer();
+    expect(ct.byteLength).toBeGreaterThan("hello key ring".length);
+  });
+
+  it("keys shows key after encrypt", async () => {
+    const r = await runCli(["ring", "keys"], env);
+    expect(r.exitCode, r.stderr).toBe(0);
+    expect(r.stdout).toContain("prod");
+  });
+
+  it("encrypt --output json reports dest and bytes", async () => {
+    const r = await runCli(
+      ["ring", "encrypt", "--key", "prod", "--input", plainFile, "--out", encFile, "--output", "json"],
+      env,
+    );
+    expect(r.exitCode, r.stderr).toBe(0);
+    const data = JSON.parse(r.stdout);
+    expect(data.output).toBe(encFile);
+    expect(data.bytes).toBeGreaterThan(0);
+  });
+
+  it("decrypt round-trips plaintext from file", async () => {
+    const r = await runCli(
+      ["ring", "decrypt", "--key", "prod", "--input", encFile, "--out", decFile],
+      env,
+    );
+    expect(r.exitCode, r.stderr).toBe(0);
+    expect(await Bun.file(decFile).text()).toBe("hello key ring");
+  });
+
+  it("decrypt --output json reports dest", async () => {
+    const r = await runCli(
+      ["ring", "decrypt", "--key", "prod", "--input", encFile, "--out", decFile, "--output", "json"],
+      env,
+    );
+    expect(r.exitCode, r.stderr).toBe(0);
+    const data = JSON.parse(r.stdout);
+    expect(data.output).toBe(decFile);
+  });
+
+  it("decrypt with wrong key name fails", async () => {
+    const r = await runCli(
+      ["ring", "decrypt", "--key", "wrong", "--input", encFile, "--out", decFile],
+      env,
+    );
+    expect(r.exitCode).toBe(1);
+  });
+
+  it("destroy wipes credentials after confirmation", async () => {
+    const r = await runCliWithStdin(["ring", "destroy"], env, ["destroy"]);
+    expect(r.exitCode, r.stderr).toBe(0);
+  });
+
+  it("keys exits 1 after destroy", async () => {
+    const r = await runCli(["ring", "keys"], env);
+    expect(r.exitCode).toBe(1);
+  });
+});
+
+describe("ring — with password", () => {
+  let dir: string;
+  let env: Record<string, string>;
+  let plainFile: string;
+  let encFile: string;
+
+  beforeAll(async () => {
+    ({ dir, env } = makeTmpDir());
+    plainFile = join(dir, "plain.txt");
+    encFile = join(dir, "test.enc");
+    await Bun.write(plainFile, "hello password");
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("init stores password-wrapped key", async () => {
+    const r = await runCli(
+      ["ring", "init", "--name", "pw-member"],
+      { ...env, ...MOCK_ENV_DMK, WALLET_PASS: "testpw" },
+    );
+    expect(r.exitCode, r.stderr).toBe(0);
+    expect(r.stdout).toContain("pw-member");
+  });
+
+  it("init rejects empty password", async () => {
+    const { dir: d2, env: e2 } = makeTmpDir();
+    const r = await runCli(
+      ["ring", "init", "--name", "pw-member", "--output", "json"],
+      { ...e2, ...MOCK_ENV_DMK, WALLET_PASS: "" },
+    );
+    rmSync(d2, { recursive: true, force: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toMatch(/must not be empty/i);
+  });
+
+  it("keychain stores encrypted private key", () => {
+    const allValues = [..._store.values()];
+    expect(allValues.some(v => v.startsWith("ENC:"))).toBe(true);
+  });
+
+  it("encrypt with correct password decrypts member credentials", async () => {
+    const r = await runCli(
+      ["ring", "encrypt", "--key", "prod", "--input", plainFile, "--out", encFile, "--output", "json"],
+      { ...env, WALLET_PASS: "testpw" },
+    );
+    expect(r.exitCode, r.stderr).toBe(0);
+    expect(r.stdout).not.toMatch(/[Ww]rong password/);
+    expect(r.stdout).not.toMatch(/[Mm]ember credentials not found/);
+  });
+
+  it("encrypt with wrong password fails at decryption", async () => {
+    const r = await runCli(
+      ["ring", "encrypt", "--key", "prod", "--input", plainFile, "--out", encFile, "--output", "json"],
+      { ...env, WALLET_PASS: "wrongpw" },
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toMatch(/[Ww]rong password/);
+  });
+
+  it("destroy with correct password fully destroys the ring", async () => {
+    const r = await runCliWithStdin(["ring", "destroy"], { ...env, WALLET_PASS: "testpw" }, ["destroy"]);
+    expect(r.exitCode, r.stderr).toBe(0);
+  });
+
+  it("keys exits 1 after destroy", async () => {
+    const r = await runCli(["ring", "keys"], env);
+    expect(r.exitCode).toBe(1);
+  });
+});
+

--- a/apps/wallet-cli/src/test/commands/ring.test.ts
+++ b/apps/wallet-cli/src/test/commands/ring.test.ts
@@ -83,16 +83,17 @@ describe("ring — happy path", () => {
   let decFile: string;
 
   beforeAll(async () => {
+    _store.clear();
     ({ dir, env } = makeTmpDir());
     plainFile = join(dir, "plain.txt");
     encFile = join(dir, "test.enc");
     decFile = join(dir, "test.dec");
     await Bun.write(plainFile, "hello key ring");
 
-    initResult = await runCli(
-      ["ring", "init", "--name", "test-member", "--unsecure-no-password"],
-      { ...env, ...MOCK_ENV_DMK },
-    );
+    initResult = await runCli(["ring", "init", "--name", "test-member", "--unsecure-no-password"], {
+      ...env,
+      ...MOCK_ENV_DMK,
+    });
     expect(initResult.exitCode, `init failed: ${initResult.stderr}`).toBe(0);
   });
 
@@ -140,7 +141,18 @@ describe("ring — happy path", () => {
 
   it("encrypt --output json reports dest and bytes", async () => {
     const r = await runCli(
-      ["ring", "encrypt", "--key", "prod", "--input", plainFile, "--out", encFile, "--output", "json"],
+      [
+        "ring",
+        "encrypt",
+        "--key",
+        "prod",
+        "--input",
+        plainFile,
+        "--out",
+        encFile,
+        "--output",
+        "json",
+      ],
       env,
     );
     expect(r.exitCode, r.stderr).toBe(0);
@@ -160,7 +172,18 @@ describe("ring — happy path", () => {
 
   it("decrypt --output json reports dest", async () => {
     const r = await runCli(
-      ["ring", "decrypt", "--key", "prod", "--input", encFile, "--out", decFile, "--output", "json"],
+      [
+        "ring",
+        "decrypt",
+        "--key",
+        "prod",
+        "--input",
+        encFile,
+        "--out",
+        decFile,
+        "--output",
+        "json",
+      ],
       env,
     );
     expect(r.exitCode, r.stderr).toBe(0);
@@ -194,6 +217,7 @@ describe("ring — with password", () => {
   let encFile: string;
 
   beforeAll(async () => {
+    _store.clear();
     ({ dir, env } = makeTmpDir());
     plainFile = join(dir, "plain.txt");
     encFile = join(dir, "test.enc");
@@ -203,20 +227,22 @@ describe("ring — with password", () => {
   afterAll(() => rmSync(dir, { recursive: true, force: true }));
 
   it("init stores password-wrapped key", async () => {
-    const r = await runCli(
-      ["ring", "init", "--name", "pw-member"],
-      { ...env, ...MOCK_ENV_DMK, WALLET_PASS: "testpw" },
-    );
+    const r = await runCli(["ring", "init", "--name", "pw-member"], {
+      ...env,
+      ...MOCK_ENV_DMK,
+      WALLET_PASS: "testpw",
+    });
     expect(r.exitCode, r.stderr).toBe(0);
     expect(r.stdout).toContain("pw-member");
   });
 
   it("init rejects empty password", async () => {
     const { dir: d2, env: e2 } = makeTmpDir();
-    const r = await runCli(
-      ["ring", "init", "--name", "pw-member", "--output", "json"],
-      { ...e2, ...MOCK_ENV_DMK, WALLET_PASS: "" },
-    );
+    const r = await runCli(["ring", "init", "--name", "pw-member", "--output", "json"], {
+      ...e2,
+      ...MOCK_ENV_DMK,
+      WALLET_PASS: "",
+    });
     rmSync(d2, { recursive: true, force: true });
     expect(r.exitCode).toBe(1);
     expect(r.stdout).toMatch(/must not be empty/i);
@@ -229,7 +255,18 @@ describe("ring — with password", () => {
 
   it("encrypt with correct password decrypts member credentials", async () => {
     const r = await runCli(
-      ["ring", "encrypt", "--key", "prod", "--input", plainFile, "--out", encFile, "--output", "json"],
+      [
+        "ring",
+        "encrypt",
+        "--key",
+        "prod",
+        "--input",
+        plainFile,
+        "--out",
+        encFile,
+        "--output",
+        "json",
+      ],
       { ...env, WALLET_PASS: "testpw" },
     );
     expect(r.exitCode, r.stderr).toBe(0);
@@ -239,7 +276,18 @@ describe("ring — with password", () => {
 
   it("encrypt with wrong password fails at decryption", async () => {
     const r = await runCli(
-      ["ring", "encrypt", "--key", "prod", "--input", plainFile, "--out", encFile, "--output", "json"],
+      [
+        "ring",
+        "encrypt",
+        "--key",
+        "prod",
+        "--input",
+        plainFile,
+        "--out",
+        encFile,
+        "--output",
+        "json",
+      ],
       { ...env, WALLET_PASS: "wrongpw" },
     );
     expect(r.exitCode).toBe(1);
@@ -247,7 +295,9 @@ describe("ring — with password", () => {
   });
 
   it("destroy with correct password fully destroys the ring", async () => {
-    const r = await runCliWithStdin(["ring", "destroy"], { ...env, WALLET_PASS: "testpw" }, ["destroy"]);
+    const r = await runCliWithStdin(["ring", "destroy"], { ...env, WALLET_PASS: "testpw" }, [
+      "destroy",
+    ]);
     expect(r.exitCode, r.stderr).toBe(0);
   });
 
@@ -256,4 +306,3 @@ describe("ring — with password", () => {
     expect(r.exitCode).toBe(1);
   });
 });
-

--- a/libs/hw-ledger-key-ring-protocol/src/CommandStreamResolver.ts
+++ b/libs/hw-ledger-key-ring-protocol/src/CommandStreamResolver.ts
@@ -27,6 +27,7 @@ type MemberData = {
 
 class ResolvedCommandStreamInternals {
   public isCreated: boolean = false;
+  public isClosed: boolean = false;
   public members: Uint8Array[] = [];
   public membersData: MemberData[] = [];
   public topic: Uint8Array | null = null;
@@ -49,6 +50,10 @@ export class ResolvedCommandStream {
 
   public isCreated(): boolean {
     return this._internals.isCreated;
+  }
+
+  public isClosed(): boolean {
+    return this._internals.isClosed;
   }
 
   public getMembers(): Uint8Array[] {
@@ -235,6 +240,10 @@ export default class CommandStreamResolver {
           issuer: block.issuer,
           initialiationVector: (command as PublishKey).initializationVector,
         });
+        break;
+      case CommandType.CloseStream:
+        this.assertStreamIsCreated(internals);
+        internals.isClosed = true;
         break;
     }
     return internals;

--- a/libs/hw-ledger-key-ring-protocol/src/StreamTree.ts
+++ b/libs/hw-ledger-key-ring-protocol/src/StreamTree.ts
@@ -98,6 +98,53 @@ export class StreamTree {
   }
 
   /**
+   * Enumerate the current (highest index) stream of each application branch
+   * derived under the tree root (m/{treeIndex}'/{applicationId}'/{index}').
+   * Used to decide, on deactivation, whether the application being closed is
+   * the last open one of the trustchain.
+   */
+  public getApplicationStreams(): {
+    applicationId: number;
+    index: number;
+    stream: CommandStream;
+  }[] {
+    // tree index is always 0 in the current implementation
+    const treeIndex = 0;
+    const applicationsNode = this.tree.getChild(DerivationPath.hardenedIndex(treeIndex));
+    if (!applicationsNode) return [];
+    const result: { applicationId: number; index: number; stream: CommandStream }[] = [];
+    for (const [applicationHardened, applicationNode] of applicationsNode.getChildren()) {
+      const highestIndex = applicationNode.getHighestIndex();
+      const stream = applicationNode.getChild(highestIndex)?.getValue();
+      if (stream) {
+        result.push({
+          applicationId: DerivationPath.reverseHardenedIndex(applicationHardened),
+          index: DerivationPath.reverseHardenedIndex(highestIndex),
+          stream,
+        });
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Returns true if an application other than `applicationId` still has an open (not closed) stream.
+   * Stops at the first open application found. A stream that fails to resolve is treated as open, so an
+   * unrelated broken application never causes the caller to destroy the whole trustchain on uncertainty.
+   */
+  public async hasAnotherOpenApplication(applicationId: number): Promise<boolean> {
+    for (const application of this.getApplicationStreams()) {
+      if (application.applicationId === applicationId) continue;
+      try {
+        if (!(await application.stream.resolve()).isClosed()) return true;
+      } catch {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Share a private key with a member
    */
   public async share(

--- a/libs/hw-ledger-key-ring-protocol/src/__tests__/units/StreamTree.test.ts
+++ b/libs/hw-ledger-key-ring-protocol/src/__tests__/units/StreamTree.test.ts
@@ -1,0 +1,65 @@
+import { StreamTree } from "../../StreamTree";
+import { device } from "../..";
+import { Permissions } from "../../CommandBlock";
+
+const APP_LEDGER_SYNC = 16;
+const APP_RING = 17;
+
+async function streamAt(tree: StreamTree, applicationId: number) {
+  const stream = tree.getChild(tree.getApplicationRootPath(applicationId));
+  if (!stream) throw new Error("missing stream for application " + applicationId);
+  return stream.resolve();
+}
+
+describe("StreamTree application enumeration + closure", () => {
+  it("has no application stream on a freshly created tree", async () => {
+    const tree = await StreamTree.createNewTree(await device.software());
+    expect(tree.getApplicationStreams()).toEqual([]);
+    expect(await tree.hasAnotherOpenApplication(APP_LEDGER_SYNC)).toBe(false);
+  });
+
+  it("enumerates application streams and detects other open applications", async () => {
+    const alice = await device.software();
+    const bob = await device.software();
+    const bobKey = (await bob.getPublicKey()).publicKey;
+
+    let tree = await StreamTree.createNewTree(alice);
+    tree = await tree.share(
+      tree.getApplicationRootPath(APP_LEDGER_SYNC),
+      alice,
+      bobKey,
+      "Bob",
+      Permissions.OWNER,
+    );
+    tree = await tree.share(
+      tree.getApplicationRootPath(APP_RING),
+      alice,
+      bobKey,
+      "Bob",
+      Permissions.OWNER,
+    );
+
+    expect(
+      tree
+        .getApplicationStreams()
+        .map(a => a.applicationId)
+        .sort(),
+    ).toEqual([APP_LEDGER_SYNC, APP_RING]);
+
+    // both applications are open
+    expect(await streamAt(tree, APP_LEDGER_SYNC).then(r => r.isClosed())).toBe(false);
+    expect(await tree.hasAnotherOpenApplication(APP_LEDGER_SYNC)).toBe(true); // ring is open
+    expect(await tree.hasAnotherOpenApplication(999)).toBe(true); // both are "other" and open
+
+    // close the ring application
+    tree = await tree.close(tree.getApplicationRootPath(APP_RING), alice);
+
+    // the closed stream is now observable as closed
+    expect(await streamAt(tree, APP_RING).then(r => r.isClosed())).toBe(true);
+    expect(await streamAt(tree, APP_LEDGER_SYNC).then(r => r.isClosed())).toBe(false);
+
+    // ledger sync is now the last open application; ring still sees ledger sync open
+    expect(await tree.hasAnotherOpenApplication(APP_LEDGER_SYNC)).toBe(false);
+    expect(await tree.hasAnotherOpenApplication(APP_RING)).toBe(true);
+  });
+});

--- a/libs/ledger-key-ring-protocol/src/__tests__/integration/mock.sdk.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/integration/mock.sdk.test.ts
@@ -14,7 +14,7 @@ const nonMockableScenarios = [
   "tokenExpires", // can't simulate token expiration
   "userRefusesAuth", // can't simulate device interaction at the moment
   "userRefusesRemoveMember", // can't simulate device interaction at the moment
-  "ringInitPreservesLedgerSyncMember", // mock SDK does not model per-app member eviction
+  "ringInitPreservesLedgerSyncMember", // scenario does not clean up its trustchain (shared in-memory mock state)
 ];
 
 const scenarioFolder = path.join(__dirname, "../../../tests/scenarios");

--- a/libs/ledger-key-ring-protocol/src/mockSdk.ts
+++ b/libs/ledger-key-ring-protocol/src/mockSdk.ts
@@ -101,7 +101,7 @@ export class MockSDK implements TrustchainSDK {
 
     const trustchain: Trustchain = trustchains.get("mock-root-id") || {
       rootId: "mock-root-id",
-      walletSyncEncryptionKey: "mock-wallet-sync-encryption-key",
+      walletSyncEncryptionKey: "cafe".repeat(16),
       applicationPath: "m/0'/16'/0'",
     };
     trustchains.set(trustchain.rootId, trustchain);
@@ -200,7 +200,7 @@ export class MockSDK implements TrustchainSDK {
     const index = 1 + parseInt(trustchain.applicationPath.split("/")[3].split("'")[0]);
     const newTrustchain = {
       rootId: trustchain.rootId,
-      walletSyncEncryptionKey: "mock-wallet-sync-encryption-key-" + index,
+      walletSyncEncryptionKey: index.toString(16).padStart(64, "0"),
       applicationPath: "m/0'/16'/" + index + "'",
     };
     trustchains.set(newTrustchain.rootId, newTrustchain);

--- a/libs/ledger-key-ring-protocol/src/mockSdk.ts
+++ b/libs/ledger-key-ring-protocol/src/mockSdk.ts
@@ -15,9 +15,10 @@ import { TrustchainEjected } from "./errors";
 import getApi from "./api";
 
 const mockedLiveCredentialsPrivateKey = "mock-private-key";
+const ROOT_ID = "mock-root-id";
 
 function assertTrustchain(trustchain: Trustchain) {
-  if (!trustchain.rootId.startsWith("mock-root-id")) {
+  if (!trustchain.rootId.startsWith(ROOT_ID)) {
     throw new Error("in mock context, trustchain must be the mocked trustchain");
   }
 }
@@ -28,22 +29,42 @@ function assertLiveCredentials(memberCredentials: MemberCredentials) {
   }
 }
 
-function assertAllowedPermissions(trustchainId: string, memberId: string) {
-  const members = trustchainMembers.get(trustchainId) || [];
-  const member = members.find(m => m.id === memberId);
-  if (!member) {
-    throw new TrustchainEjected();
-  }
-}
-
 const mockedLiveJWT = {
   accessToken: "mock-live-jwt",
   permissions: {},
 };
 
+/**
+ * The mock models the backend as a tree of applications under a single root.
+ * Each application has its own derivation index (bumped on key rotation or reopen),
+ * its own members and an open/closed state, so a close on one application leaves the
+ * others (and the root) untouched.
+ */
+type MockAppState = {
+  index: number;
+  closed: boolean;
+  members: TrustchainMember[];
+};
+type MockRoot = {
+  apps: Map<number, MockAppState>;
+};
+
 // global states in memory
-const trustchains = new Map<string, Trustchain>();
-const trustchainMembers = new Map<string, TrustchainMember[]>();
+const roots = new Map<string, MockRoot>();
+
+function keyForIndex(index: number): string {
+  return index === 0
+    ? "mock-wallet-sync-encryption-key"
+    : "mock-wallet-sync-encryption-key-" + index;
+}
+
+function buildTrustchain(rootId: string, applicationId: number, app: MockAppState): Trustchain {
+  return {
+    rootId,
+    walletSyncEncryptionKey: keyForIndex(app.index),
+    applicationPath: `m/0'/${applicationId}'/${app.index}'`,
+  };
+}
 
 /**
  * to mock the encryption/decryption, we just xor the data with 0xff
@@ -95,16 +116,21 @@ export class MockSDK implements TrustchainSDK {
   ): Promise<TrustchainResult> {
     this.invalidateJwt();
     assertLiveCredentials(memberCredentials);
-    let type = trustchains.has("mock-root-id")
-      ? TrustchainResultType.restored
-      : TrustchainResultType.created;
+    const applicationId = this.context.applicationId;
 
-    const trustchain: Trustchain = trustchains.get("mock-root-id") || {
-      rootId: "mock-root-id",
-      walletSyncEncryptionKey: "cafe".repeat(16),
-      applicationPath: "m/0'/16'/0'",
-    };
-    trustchains.set(trustchain.rootId, trustchain);
+    let type = roots.has(ROOT_ID) ? TrustchainResultType.restored : TrustchainResultType.created;
+    const root = roots.get(ROOT_ID) ?? { apps: new Map<number, MockAppState>() };
+    roots.set(ROOT_ID, root);
+
+    let app = root.apps.get(applicationId);
+    if (!app) {
+      app = { index: 0, closed: false, members: [] };
+      root.apps.set(applicationId, app);
+    } else if (app.closed) {
+      // the application was deactivated (stream closed): reopen it on the next index
+      app = { index: app.index + 1, closed: false, members: [] };
+      root.apps.set(applicationId, app);
+    }
 
     if (!this.deviceJwtAcquired) {
       callbacks?.onStartRequestUserInteraction?.();
@@ -112,39 +138,49 @@ export class MockSDK implements TrustchainSDK {
       callbacks?.onEndRequestUserInteraction?.();
     }
 
-    const currentMembers = trustchainMembers.get(trustchain.rootId) || [];
     // add itself if not yet here
-    if (!currentMembers.some(m => m.id === memberCredentials.pubkey)) {
+    if (!app.members.some(m => m.id === memberCredentials.pubkey)) {
       if (type === TrustchainResultType.restored) type = TrustchainResultType.updated;
       callbacks?.onStartRequestUserInteraction?.();
       // simulate device add interaction
       callbacks?.onEndRequestUserInteraction?.();
-      currentMembers.push({
+      app.members.push({
         id: memberCredentials.pubkey,
         name: this.context.name,
         permissions: Permissions.OWNER,
       });
-      trustchainMembers.set(trustchain.rootId, currentMembers);
     }
-    return Promise.resolve({ type, trustchain });
+    return { type, trustchain: buildTrustchain(ROOT_ID, applicationId, app) };
   }
 
   async refreshAuth(jwt: JWT): Promise<JWT> {
     return jwt;
   }
 
+  /**
+   * Resolve the current application of an active member, or throw TrustchainEjected when the member
+   * is no longer part of the application (removed, application closed, or trustchain gone).
+   */
+  private getActiveContext(
+    trustchain: Trustchain,
+    memberCredentials: MemberCredentials,
+  ): { root: MockRoot; app: MockAppState } {
+    assertTrustchain(trustchain);
+    assertLiveCredentials(memberCredentials);
+    const root = roots.get(trustchain.rootId);
+    const app = root?.apps.get(this.context.applicationId);
+    if (!root || !app || app.closed || !app.members.some(m => m.id === memberCredentials.pubkey)) {
+      throw new TrustchainEjected();
+    }
+    return { root, app };
+  }
+
   async restoreTrustchain(
     trustchain: Trustchain,
     memberCredentials: MemberCredentials,
   ): Promise<Trustchain> {
-    assertTrustchain(trustchain);
-    assertLiveCredentials(memberCredentials);
-    assertAllowedPermissions(trustchain.rootId, memberCredentials.pubkey);
-    const latest = trustchains.get(trustchain.rootId);
-    if (!latest) {
-      throw new Error("trustchain not found");
-    }
-    return Promise.resolve(latest);
+    const { app } = this.getActiveContext(trustchain, memberCredentials);
+    return buildTrustchain(trustchain.rootId, this.context.applicationId, app);
   }
 
   async getMembers(
@@ -153,9 +189,12 @@ export class MockSDK implements TrustchainSDK {
   ): Promise<TrustchainMember[]> {
     assertTrustchain(trustchain);
     assertLiveCredentials(memberCredentials);
-    assertAllowedPermissions(trustchain.rootId, memberCredentials.pubkey);
-    const currentMembers = trustchainMembers.get(trustchain.rootId) || [];
-    return Promise.resolve([...currentMembers]);
+    // a closed application still exposes its members (matching the real SDK); only a removed member is ejected
+    const app = roots.get(trustchain.rootId)?.apps.get(this.context.applicationId);
+    if (!app?.members.some(m => m.id === memberCredentials.pubkey)) {
+      throw new TrustchainEjected();
+    }
+    return [...app.members];
   }
 
   async removeMember(
@@ -166,9 +205,8 @@ export class MockSDK implements TrustchainSDK {
     callbacks?: TrustchainDeviceCallbacks,
   ): Promise<Trustchain> {
     this.invalidateJwt();
-    assertTrustchain(trustchain);
-    assertLiveCredentials(memberCredentials);
-    assertAllowedPermissions(trustchain.rootId, memberCredentials.pubkey);
+    const { app } = this.getActiveContext(trustchain, memberCredentials);
+    const applicationId = this.context.applicationId;
     if (member.id === memberCredentials.pubkey) {
       throw new Error("cannot remove self");
     }
@@ -192,22 +230,14 @@ export class MockSDK implements TrustchainSDK {
     // simulate device interaction
     callbacks?.onEndRequestUserInteraction?.();
 
-    const currentMembers = (trustchainMembers.get(trustchain.rootId) || []).filter(
-      m => m.id !== member.id,
-    );
-    trustchainMembers.set(trustchain.rootId, currentMembers);
-    // we extract the index part to increment it and recreate a path
-    const index = 1 + parseInt(trustchain.applicationPath.split("/")[3].split("'")[0]);
-    const newTrustchain = {
-      rootId: trustchain.rootId,
-      walletSyncEncryptionKey: index.toString(16).padStart(64, "0"),
-      applicationPath: "m/0'/16'/" + index + "'",
-    };
-    trustchains.set(newTrustchain.rootId, newTrustchain);
+    // rotate the application: bump the index and drop the removed member
+    app.members = app.members.filter(m => m.id !== member.id);
+    app.index += 1;
+    const newTrustchain = buildTrustchain(trustchain.rootId, applicationId, app);
 
     if (afterRotation) await afterRotation(newTrustchain);
 
-    return Promise.resolve(newTrustchain);
+    return newTrustchain;
   }
 
   async destroyTrustchain(
@@ -216,9 +246,37 @@ export class MockSDK implements TrustchainSDK {
   ): Promise<void> {
     assertTrustchain(trustchain);
     assertLiveCredentials(memberCredentials);
-    trustchains.delete(trustchain.rootId);
-    trustchainMembers.delete(trustchain.rootId);
+    roots.delete(trustchain.rootId);
     return;
+  }
+
+  async destroyApplication(
+    trustchain: Trustchain,
+    memberCredentials: MemberCredentials,
+  ): Promise<{ trustchainDestroyed: boolean }> {
+    this.invalidateJwt();
+    assertTrustchain(trustchain);
+    assertLiveCredentials(memberCredentials);
+    const applicationId = this.context.applicationId;
+    const root = roots.get(trustchain.rootId);
+    const app = root?.apps.get(applicationId);
+    if (!root || !app?.members.some(m => m.id === memberCredentials.pubkey)) {
+      throw new TrustchainEjected();
+    }
+    if (app.closed) {
+      return { trustchainDestroyed: false }; // already deactivated
+    }
+
+    const anotherApplicationIsOpen = [...root.apps.entries()].some(
+      ([id, a]) => id !== applicationId && !a.closed,
+    );
+    if (!anotherApplicationIsOpen) {
+      // last open application: destroy the whole trustchain, as before
+      roots.delete(trustchain.rootId);
+      return { trustchainDestroyed: true };
+    }
+    app.closed = true;
+    return { trustchainDestroyed: false };
   }
 
   addMember(
@@ -228,12 +286,18 @@ export class MockSDK implements TrustchainSDK {
   ): Promise<void> {
     assertTrustchain(trustchain);
     assertLiveCredentials(memberCredentials);
-    const currentMembers = trustchainMembers.get(trustchain.rootId) || [];
-    if (currentMembers.find(m => m.id === member.id)) {
+    const applicationId = this.context.applicationId;
+    const root = roots.get(trustchain.rootId) ?? { apps: new Map<number, MockAppState>() };
+    roots.set(trustchain.rootId, root);
+    let app = root.apps.get(applicationId);
+    if (!app) {
+      app = { index: 0, closed: false, members: [] };
+      root.apps.set(applicationId, app);
+    }
+    if (app.members.some(m => m.id === member.id)) {
       return Promise.resolve();
     }
-    currentMembers.push(member);
-    trustchainMembers.set(trustchain.rootId, currentMembers);
+    app.members.push(member);
     return Promise.resolve();
   }
 

--- a/libs/ledger-key-ring-protocol/src/sdk.ts
+++ b/libs/ledger-key-ring-protocol/src/sdk.ts
@@ -162,14 +162,18 @@ export class SDK implements TrustchainSDK {
 
     // make a stream tree from all the trustchains associated to this root id
     let { streamTree } = await withJwt(jwt => this.fetchTrustchain(jwt, trustchainRootId));
-    const path = streamTree.getApplicationRootPath(this.context.applicationId);
-    const child = streamTree.getChild(path);
+    let path = streamTree.getApplicationRootPath(this.context.applicationId);
+    let resolved = (await streamTree.getChild(path)?.resolve()) ?? null;
+
+    // if the current application stream was closed (deactivated), reopen it on the next index
+    if (resolved?.isClosed()) {
+      path = streamTree.getApplicationRootPath(this.context.applicationId, 1);
+      resolved = null; // the reopened stream does not exist yet; pushMember will derive it
+    }
+
     let shouldShare = true;
-
-    if (child) {
-      const resolved = await child.resolve();
+    if (resolved) {
       const members = resolved.getMembers();
-
       shouldShare = !members.some(m => crypto.to_hex(m) === memberCredentials.pubkey); // not already a member
     }
     if (shouldShare) {
@@ -196,13 +200,16 @@ export class SDK implements TrustchainSDK {
     trustchain: Trustchain,
     memberCredentials: MemberCredentials,
   ): Promise<Trustchain> {
-    const { streamTree, applicationRootPath } = await this.withAuth(
+    const { streamTree, applicationRootPath, resolved } = await this.withAuth(
       trustchain,
       memberCredentials,
       jwt => this.fetchTrustchainAndResolve(jwt, trustchain.rootId, this.context.applicationId),
       "refresh",
       true,
     );
+    if (resolved.isClosed()) {
+      throw new TrustchainEjected("application stream is closed");
+    }
     const walletSyncEncryptionKey = await extractEncryptionKey(
       streamTree,
       applicationRootPath,
@@ -355,6 +362,48 @@ export class SDK implements TrustchainSDK {
       this.api.deleteTrustchain(jwt, trustchain.rootId),
     );
     this.invalidateJwt();
+  }
+
+  async destroyApplication(
+    trustchain: Trustchain,
+    memberCredentials: MemberCredentials,
+  ): Promise<{ trustchainDestroyed: boolean }> {
+    this.invalidateJwt();
+
+    const applicationId = this.context.applicationId;
+    const trustchainId = trustchain.rootId;
+    const withJwt: WithJwt = job =>
+      this.withAuth(trustchain, memberCredentials, job, "refresh", true);
+
+    const { streamTree, applicationRootPath, resolved } = await withJwt(jwt =>
+      this.fetchTrustchainAndResolve(jwt, trustchainId, applicationId),
+    );
+
+    // already deactivated: closing again would push a redundant CloseStream
+    if (resolved.isClosed()) {
+      return { trustchainDestroyed: false };
+    }
+
+    // if this is the last open application, closing its stream would leave an empty
+    // trustchain: destroy the whole root instead, preserving the previous deactivation behaviour.
+    if (!(await streamTree.hasAnotherOpenApplication(applicationId))) {
+      await this.destroyTrustchain(trustchain, memberCredentials);
+      return { trustchainDestroyed: true };
+    }
+
+    // otherwise close only the current application stream, signed with the member's software key (no device)
+    const softwareDevice = getSoftwareDevice(memberCredentials);
+    const withSw = (job: (device: Device) => Promise<StreamTree>) => job(softwareDevice);
+    const sendCloseStreamToAPI = await this.closeStream(
+      streamTree,
+      applicationRootPath,
+      trustchainId,
+      withJwt,
+      withSw,
+    );
+    await sendCloseStreamToAPI();
+    this.invalidateJwt();
+    return { trustchainDestroyed: false };
   }
 
   async encryptUserData(trustchain: Trustchain, input: Uint8Array): Promise<Uint8Array> {

--- a/libs/ledger-key-ring-protocol/src/types.ts
+++ b/libs/ledger-key-ring-protocol/src/types.ts
@@ -220,6 +220,18 @@ export interface TrustchainSDK {
   destroyTrustchain(trustchain: Trustchain, memberCredentials: MemberCredentials): Promise<void>;
 
   /**
+   * Deactivate the current application for this member.
+   * Normally this closes only the current application's stream (signed with the member's software key,
+   * no hardware device), preserving the other applications and the trustchain root.
+   * If the current application is the last open one, the whole trustchain is destroyed instead.
+   * @returns `trustchainDestroyed` true when the whole trustchain was destroyed (last open application).
+   */
+  destroyApplication(
+    trustchain: Trustchain,
+    memberCredentials: MemberCredentials,
+  ): Promise<{ trustchainDestroyed: boolean }>;
+
+  /**
    * encrypt data with the trustchain encryption key
    */
   encryptUserData(trustchain: Trustchain, obj: object): Promise<Uint8Array>;

--- a/libs/ledger-key-ring-protocol/tests/scenarios/destroyApplicationKeepsOtherApps.ts
+++ b/libs/ledger-key-ring-protocol/tests/scenarios/destroyApplicationKeepsOtherApps.ts
@@ -1,0 +1,58 @@
+import { TrustchainEjected } from "../../src/errors";
+import { ScenarioOptions } from "../test-helpers/types";
+
+// Deactivating one application (Ledger Sync, app 16) must close only that
+// application's stream: the ring application (app 17) and the trustchain root
+// must survive, and every Ledger Sync instance must reconcile to "ejected".
+// destroyApplication only destroys the whole trustchain when closing the last open application.
+export async function scenario(deviceId: string, { sdkForName }: ScenarioOptions) {
+  // two Ledger Sync instances (app 16) of the same trustchain
+  const sdkSync1 = sdkForName("Sync instance 1");
+  const sync1creds = await sdkSync1.initMemberCredentials();
+  const { trustchain: syncTrustchain } = await sdkSync1.getOrCreateTrustchain(deviceId, sync1creds);
+
+  const sdkSync2 = sdkForName("Sync instance 2");
+  const sync2creds = await sdkSync2.initMemberCredentials();
+  await sdkSync2.getOrCreateTrustchain(deviceId, sync2creds);
+
+  // a ring application (app 17) shares the same trustchain root
+  const sdkRing = sdkForName("Ring member", { applicationId: 17 });
+  const ringCreds = await sdkRing.initMemberCredentials();
+  const { trustchain: ringTrustchain } = await sdkRing.getOrCreateTrustchain(deviceId, ringCreds);
+
+  // instance 1 deactivates Ledger Sync
+  const { trustchainDestroyed } = await sdkSync1.destroyApplication(syncTrustchain, sync1creds);
+  expect(trustchainDestroyed).toBe(false); // the ring application is still open, the root is preserved
+
+  // deactivating an already-closed application is a no-op (idempotent, no second CloseStream)
+  const secondClose = await sdkSync1.destroyApplication(syncTrustchain, sync1creds);
+  expect(secondClose.trustchainDestroyed).toBe(false);
+
+  // both Ledger Sync instances reconcile to ejected
+  await expect(sdkSync1.restoreTrustchain(syncTrustchain, sync1creds)).rejects.toThrow(
+    TrustchainEjected,
+  );
+  sdkSync2.invalidateJwt();
+  await expect(sdkSync2.restoreTrustchain(syncTrustchain, sync2creds)).rejects.toThrow(
+    TrustchainEjected,
+  );
+
+  // the ring application still works
+  sdkRing.invalidateJwt();
+  const ringMembers = await sdkRing.getMembers(ringTrustchain, ringCreds);
+  expect(ringMembers.some(m => m.id === ringCreds.pubkey)).toBe(true);
+
+  // re-activating Ledger Sync reopens the application on a new index
+  const reactivated = await sdkSync1.getOrCreateTrustchain(deviceId, sync1creds);
+  expect(reactivated.trustchain.applicationPath).not.toBe(syncTrustchain.applicationPath);
+  const membersAfter = await sdkSync1.getMembers(reactivated.trustchain, sync1creds);
+  expect(membersAfter.some(m => m.id === sync1creds.pubkey)).toBe(true);
+
+  // instance 2 was not re-added, it stays ejected from the reopened stream
+  await expect(sdkSync2.restoreTrustchain(reactivated.trustchain, sync2creds)).rejects.toThrow(
+    TrustchainEjected,
+  );
+
+  // cleanup
+  await sdkSync1.destroyTrustchain(reactivated.trustchain, sync1creds);
+}

--- a/libs/ledger-key-ring-protocol/tests/scenarios/destroyLastApplicationDestroysTrustchain.ts
+++ b/libs/ledger-key-ring-protocol/tests/scenarios/destroyLastApplicationDestroysTrustchain.ts
@@ -1,0 +1,19 @@
+import { ScenarioOptions } from "../test-helpers/types";
+
+// When the application being deactivated is the last open one of the trustchain,
+// destroyApplication destroys the whole trustchain (the previous behaviour).
+export async function scenario(deviceId: string, { sdkForName }: ScenarioOptions) {
+  const sdk = sdkForName("Sole member");
+  const creds = await sdk.initMemberCredentials();
+  const { trustchain } = await sdk.getOrCreateTrustchain(deviceId, creds);
+
+  const { trustchainDestroyed } = await sdk.destroyApplication(trustchain, creds);
+  expect(trustchainDestroyed).toBe(true);
+
+  // the trustchain no longer exists: a new getOrCreateTrustchain recreates it
+  const recreated = await sdk.getOrCreateTrustchain(deviceId, creds);
+  expect(recreated.type).toBe("created");
+
+  // cleanup
+  await sdk.destroyTrustchain(recreated.trustchain, creds);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2350,9 +2350,15 @@ importers:
       '@ledgerhq/hw-app-exchange':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/hw-app-exchange
+      '@ledgerhq/hw-ledger-key-ring-protocol':
+        specifier: workspace:^
+        version: link:../../libs/hw-ledger-key-ring-protocol
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../../libs/ledgerjs/packages/hw-transport
+      '@ledgerhq/ledger-key-ring-protocol':
+        specifier: workspace:^
+        version: link:../../libs/ledger-key-ring-protocol
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../libs/ledger-wallet-framework
@@ -2383,6 +2389,9 @@ importers:
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/types-live
+      '@napi-rs/keyring':
+        specifier: 1.3.0
+        version: 1.3.0
       '@oxlint/binding-darwin-arm64':
         specifier: 1.51.0
         version: 1.51.0
@@ -17922,6 +17931,87 @@ packages:
 
   '@mysten/utils@0.3.1':
     resolution: {integrity: sha512-36KhxG284uhDdSnlkyNaS6fzKTX9FpP2WQWOwUKIRsqQFFIm2ooCf2TP1IuqrtMpkairwpiWkAS0eg7cpemVzg==}
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    resolution: {integrity: sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    resolution: {integrity: sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    resolution: {integrity: sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    resolution: {integrity: sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    resolution: {integrity: sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    resolution: {integrity: sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    resolution: {integrity: sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    resolution: {integrity: sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    resolution: {integrity: sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    resolution: {integrity: sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    resolution: {integrity: sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    resolution: {integrity: sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/keyring@1.3.0':
+    resolution: {integrity: sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -46580,6 +46670,57 @@ snapshots:
   '@mysten/utils@0.3.1':
     dependencies:
       '@scure/base': 2.0.0
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring@1.3.0':
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.3.0
+      '@napi-rs/keyring-darwin-x64': 1.3.0
+      '@napi-rs/keyring-freebsd-x64': 1.3.0
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.3.0
+      '@napi-rs/keyring-linux-arm64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-arm64-musl': 1.3.0
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-musl': 1.3.0
+      '@napi-rs/keyring-win32-arm64-msvc': 1.3.0
+      '@napi-rs/keyring-win32-ia32-msvc': 1.3.0
+      '@napi-rs/keyring-win32-x64-msvc': 1.3.0
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:


### PR DESCRIPTION
Integration test branch combining #17743 (wallet-cli `ring` LKRP commands) and #18568 (per-application close on Wallet Sync deactivation), rebased on develop, plus a 3rd commit wiring wallet-cli `ring destroy` to the new `destroyApplication` soft destroy. For testing the two PRs together — not for merge.