### PR TITLE
test: fix legacy open portfolio with w40

### DIFF
--- a/e2e/mobile/helpers/elementHelpers.ts
+++ b/e2e/mobile/helpers/elementHelpers.ts
@@ -327,6 +327,14 @@ export const NativeElementHelpers = {
     return (!("elements" in attributes) ? attributes.text : attributes.elements[index].text) || "";
   },
 
+  async getLabelOfElement(id: string | RegExp, index = 0): Promise<string> {
+    const attributes = await retryUntilTimeout(async () =>
+      NativeElementHelpers.getElementById(id, index).getAttributes(),
+    );
+    const rawLabel = "elements" in attributes ? attributes.elements[index].label : attributes.label;
+    return rawLabel != null ? String(rawLabel) : "";
+  },
+
   async getIdOfElement(elem: NativeElement, index = 0): Promise<string> {
     const attributes = await retryUntilTimeout(async () => elem.getAttributes());
     return (

--- a/e2e/mobile/jest.environment.ts
+++ b/e2e/mobile/jest.environment.ts
@@ -181,6 +181,7 @@ export default class TestEnvironment extends DetoxEnvironment {
       getIdByRegexp: NativeElementHelpers.getIdByRegexp,
       getIdOfElement: NativeElementHelpers.getIdOfElement,
       getTextOfElement: NativeElementHelpers.getTextOfElement,
+      getLabelOfElement: NativeElementHelpers.getLabelOfElement,
       IsIdPresent: NativeElementHelpers.isIdPresent,
       IsIdVisible: NativeElementHelpers.isIdVisible,
       scrollToId: NativeElementHelpers.scrollToId,

--- a/e2e/mobile/page/settings/settingsGeneral.page.ts
+++ b/e2e/mobile/page/settings/settingsGeneral.page.ts
@@ -76,7 +76,11 @@ export default class SettingsGeneralPage {
   @Step("Change counter value to $0")
   async changeCounterValue(currency: string) {
     await this.clickOnCountervalueSettingsRow();
-    await scrollToId(this.compactSettingsRowId(currency), this.counterValueSettingsFlatListId);
+    await scrollToId(
+      this.compactSettingsRowId(currency),
+      this.counterValueSettingsFlatListId,
+      2000,
+    );
     await tapById(this.compactSettingsRowId(currency));
   }
 

--- a/e2e/mobile/page/wallet/mainNavigation.page.ts
+++ b/e2e/mobile/page/wallet/mainNavigation.page.ts
@@ -34,8 +34,8 @@ export default class MainNavigationPage {
   // =====================
 
   @Step("Wait for Wallet 4.0 navigation to be ready")
-  async waitForWallet40Ready() {
-    await waitForElementById(this.topBarMyWalletId);
+  async waitForWallet40Ready(timeout = 60000) {
+    await waitForElementById(this.topBarMyWalletId, timeout);
   }
 
   @Step("Wait for Legacy navigation to be ready")
@@ -143,9 +143,9 @@ export default class MainNavigationPage {
   // =====================
 
   @Step("Open Portfolio via deeplink (W40)")
-  async openPortfolioViaDeeplink() {
+  async openPortfolioViaDeeplink(timeout = 60000) {
     await openDeeplink("portfolio");
-    await this.waitForWallet40Ready();
+    await this.waitForWallet40Ready(timeout);
   }
 
   @Step("Expect Portfolio page visible")

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -39,7 +39,6 @@ export default class PortfolioPage {
   selectAssetsPageTitle = "select-crypto-header-step1-title";
   baseBigCurrency = "big-currency";
   bigCurrencyRowRegex = new RegExp(`^${this.baseBigCurrency}-row-.*$`);
-  graphCardBalanceDiffId = "graphCard-balance-delta";
   tabBarEarnButton = "tab-bar-earn";
   marketBannerList = "market-banner-list";
   marketBannerTileBase = "market-banner-tile-";
@@ -54,7 +53,9 @@ export default class PortfolioPage {
   quickActionBuyButtonV4 = "quick-action-buy";
   portfolioBalanceNoAccount = "portfolio-balance-noAccounts";
   portfolioBalanceNormal = "portfolio-balance-normal";
+  portfolioBalanceAmount = "portfolio-balance-amount";
   portfolioBalanceAnalyticsPill = "portfolio-balance-analytics-pill";
+  portfolioBalanceDelta = "portfolio-balance-delta";
   transferBottomSheetReceiveButton = "transfer-action-receive";
   transferBottomSheetSendButton = "transfer-action-send";
   transferBottomSheetBankTransferButton = "transfer-action-bank-transfer";
@@ -118,7 +119,7 @@ export default class PortfolioPage {
 
   @Step("Expect asset row to have the correct counter value")
   async expectAssetRowCounterValue(asset: string, counterValue: string) {
-    await this.expectAssetRowToBeVisible(asset);
+    await scrollToId(this.assetItemBalanceId(asset), this.accountsListView);
     const text = await getTextOfElement(this.assetItemBalanceId(asset));
     jestExpect(text).toContain(counterValue);
   }
@@ -130,20 +131,13 @@ export default class PortfolioPage {
 
   @Step("Expect total balance value")
   async expectTotalBalanceCounterValue(counterValue: string) {
-    const text = await getTextOfElement(this.graphCardBalanceId);
-    jestExpect(text).toContain(counterValue);
+    const label = await getLabelOfElement(this.portfolioBalanceAmount);
+    jestExpect(label).toContain(counterValue);
   }
 
   @Step("Expect balance diff to be visible")
   async expectBalanceDiffToBeVisible() {
-    await waitForElementById(this.graphCardBalanceDiffId);
-  }
-
-  @Step("Expect balance diff to have the correct counter value")
-  async expectBalanceDiffCounterValue(counterValue: string) {
-    await this.expectBalanceDiffToBeVisible();
-    const text = await getTextOfElement(this.graphCardBalanceDiffId);
-    jestExpect(text).toContain(counterValue);
+    await waitForElementById(this.portfolioBalanceDelta);
   }
 
   @Step("Expect operation row to be visible")

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -22,11 +22,6 @@ export default class PortfolioPage {
   addAccountCta = "add-account-cta";
   allocationSectionTitleId = "portfolio-allocation-section";
   transactionHistorySectionTitleId = "portfolio-transaction-history-section";
-  quickActionBuyButton = "portfolio-quick-action-button-buy";
-  quickActionSwapButton = "portfolio-quick-action-button-swap";
-  quickActionSendButton = "portfolio-quick-action-button-send";
-  quickActionReceiveButton = "portfolio-quick-action-button-receive";
-  quickActionEarnButton = "portfolio-quick-action-button-earn";
   showAllAssetsButton = "assets-button";
   showAllAccountsButton = "show-all-accounts-button";
   seeAllTransactionsButton = "portfolio-seeAll-transaction";
@@ -202,16 +197,9 @@ export default class PortfolioPage {
 
   @Step("Check quick action buttons visibility")
   async checkQuickActionButtonsVisibility() {
-    await detoxExpect(getElementById(this.quickActionBuyButton)).toBeVisible();
-    await detoxExpect(getElementById(this.quickActionSwapButton)).toBeVisible();
-    await detoxExpect(getElementById(this.quickActionSendButton)).toBeVisible();
-    await detoxExpect(getElementById(this.quickActionReceiveButton)).toBeVisible();
-    await detoxExpect(getElementById(this.quickActionEarnButton)).toBeVisible();
-  }
-
-  @Step("Check chart visibility")
-  async checkChartVisibility() {
-    await detoxExpect(getElementById(this.graphCardChart)).toBeVisible();
+    await detoxExpect(getElementById(this.quickActionTransferButtonV4)).toBeVisible();
+    await detoxExpect(getElementById(this.quickActionSwapButtonV4)).toBeVisible();
+    await detoxExpect(getElementById(this.quickActionBuyButtonV4)).toBeVisible();
   }
 
   @Step("Check asset allocation section")
@@ -298,11 +286,6 @@ export default class PortfolioPage {
   @Step("Open Earn tab from navigation bar")
   async openEarnTab() {
     await tapById(this.tabBarEarnButton);
-  }
-
-  @Step("Tap quick action receive button")
-  async tapQuickActionReceiveButton() {
-    await tapById(this.quickActionReceiveButton);
   }
 
   @Step("Tap on (Add new or existing account) button")

--- a/e2e/mobile/setup.ts
+++ b/e2e/mobile/setup.ts
@@ -25,7 +25,7 @@ afterAll(
       try {
         // Workaround (QAA-1318): open modular drawer blocks the portfolio deeplink
         await app.modularDrawer.tapDrawerCloseButton({ onlyIfVisible: true });
-        await app.portfolio.openViaDeeplink(5_000);
+        await app.mainNavigation.openPortfolioViaDeeplink(5_000);
         await device.terminateApp();
       } catch (e) {
         log.warn(`setup afterAll terminateApp failed: ${sanitizeError(e)}`);

--- a/e2e/mobile/specs/account/accountRename.spec.ts
+++ b/e2e/mobile/specs/account/accountRename.spec.ts
@@ -28,7 +28,7 @@ describe("Account name change", () => {
       speculosApp: account.currency.speculosApp,
       cliCommands: [liveDataCommand(account)],
     });
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.waitForWallet40Ready();
   });
 
   it("should persist Account name change after app restart", async () => {
@@ -44,7 +44,7 @@ describe("Account name change", () => {
     await launchApp();
     await device.disableSynchronization();
     await loadConfig("skip-onboarding", true);
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.waitForWallet40Ready();
     await device.enableSynchronization();
     await app.portfolio.goToSpecificAsset(account.currency.name);
     await app.common.expectAccountName(newAccountName);

--- a/e2e/mobile/specs/addAccount/addAccount.ts
+++ b/e2e/mobile/specs/addAccount/addAccount.ts
@@ -11,7 +11,7 @@ export function runAddAccountTest(currency: CurrencyType, tmsLinks: string[], ta
         userdata: "skip-onboarding",
         speculosApp: currency.speculosApp,
       });
-      await app.portfolio.waitForPortfolioPageToLoad();
+      await app.mainNavigation.waitForWallet40Ready();
     });
 
     setTeamOwner(BST_ADD_ACCOUNT_CURRENCIES.has(currency.id) ? Team.BST : Team.COIN_INTEGRATION);

--- a/e2e/mobile/specs/buySell/buySell.ts
+++ b/e2e/mobile/specs/buySell/buySell.ts
@@ -17,7 +17,7 @@ export async function beforeAllFunction(options: ApplicationOptions) {
     cliCommands: options.cliCommands,
     featureFlags: options.featureFlags,
   });
-  await app.portfolio.waitForPortfolioPageToLoad();
+  await app.mainNavigation.waitForWallet40Ready();
 }
 
 export async function runNavigateToBuyFromPortfolioPageTest(

--- a/e2e/mobile/specs/deeplinks.spec.ts
+++ b/e2e/mobile/specs/deeplinks.spec.ts
@@ -30,7 +30,7 @@ describe("DeepLinks Tests", () => {
         },
       },
     });
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.waitForWallet40Ready();
   });
 
   beforeEach(async () => {
@@ -111,8 +111,7 @@ describe("DeepLinks Tests", () => {
   (isSmokeTestRun ? it.skip : it)("should open Send pages", async () => {
     await app.send.openViaDeeplink();
     await app.send.expectFirstStep();
-    await app.portfolio.openViaDeeplink();
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.openPortfolioViaDeeplink();
     await app.send.sendViaDeeplink(ethereumLong);
     await app.send.expectFirstStep();
     await app.common.expectSearch(ethereumLong);
@@ -142,8 +141,7 @@ describe("DeepLinks Tests", () => {
     });
 
     it("should open from Receive in a selected account", async () => {
-      await app.portfolio.openViaDeeplink();
-      await app.portfolio.waitForPortfolioPageToLoad();
+      await app.mainNavigation.openPortfolioViaDeeplink();
       await app.receive.receiveViaDeeplink(ethereumLong);
       await app.modularDrawer.validateAccountsScreen([account.accountName]);
     });

--- a/e2e/mobile/specs/delegate/delegate.ts
+++ b/e2e/mobile/specs/delegate/delegate.ts
@@ -13,7 +13,7 @@ const beforeAllFunction = async (delegation: DelegateType) => {
     cliCommands: [liveDataWithAddressCommand(delegation.account)],
   });
 
-  await app.portfolio.waitForPortfolioPageToLoad();
+  await app.mainNavigation.waitForWallet40Ready();
 };
 
 export function runDelegateTest(delegation: DelegateType, tmsLinks: string[], tags: string[]) {

--- a/e2e/mobile/specs/deleteAccount/deleteAccount.ts
+++ b/e2e/mobile/specs/deleteAccount/deleteAccount.ts
@@ -9,7 +9,7 @@ export function runDeleteAccountTest(account: AccountType, tmsLinks: string[], t
         speculosApp: account.currency.speculosApp,
         cliCommands: [liveDataCommand(account)],
       });
-      await app.portfolio.waitForPortfolioPageToLoad();
+      await app.mainNavigation.waitForWallet40Ready();
     });
 
     setTeamOwner(Team.WALLET_XP);

--- a/e2e/mobile/specs/deposit/deposit.ts
+++ b/e2e/mobile/specs/deposit/deposit.ts
@@ -15,7 +15,7 @@ async function beforeAllFunction(options: ApplicationOptions) {
     cliCommands: options.cliCommands,
   });
 
-  await app.portfolio.waitForPortfolioPageToLoad();
+  await app.mainNavigation.waitForWallet40Ready();
 }
 
 export async function runSelectCryptoNetworkTest(

--- a/e2e/mobile/specs/deposit/deposit.ts
+++ b/e2e/mobile/specs/deposit/deposit.ts
@@ -1,8 +1,6 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
-import { ReceiveFundsOptions } from "@ledgerhq/live-common/e2e/enum/ReceiveFundsOptions";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { setEnv } from "@ledgerhq/live-env";
-import { isWallet40 } from "../../helpers/commonHelpers";
 import { setTeamOwner } from "../../helpers/allure/allure-helper";
 import { ApplicationOptions } from "page";
 
@@ -42,17 +40,9 @@ export async function runSelectCryptoNetworkTest(
     it(`should select crypto network with ${withAccount ? "account" : "no account"} for ${
       account.currency.ticker
     }`, async () => {
-      if (isWallet40) {
-        await app.portfolio.pressQuickActionTransferButton();
-        await app.portfolio.pressTransferBottomSheetReceiveButton();
-      } else {
-        if (withAccount) {
-          await app.portfolio.tapQuickActionReceiveButton();
-        } else {
-          await app.portfolioEmptyState.navigateToReceive();
-        }
-        await app.receive.selectReceiveFundsOption(ReceiveFundsOptions.CRYPTO);
-      }
+      await app.portfolio.pressQuickActionTransferButton();
+      await app.portfolio.pressTransferBottomSheetReceiveButton();
+
       await app.modularDrawer.performSearchByTicker(account.currency.ticker);
       await app.modularDrawer.selectCurrencyByTicker(account.currency.ticker);
       await app.modularDrawer.validateNetworksScreen(networks);
@@ -79,13 +69,8 @@ export async function runSelectCryptoWithoutNetworkAndAccountTest(
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`should select crypto without network and account for ${account.currency.ticker}`, async () => {
-      if (isWallet40) {
-        await app.portfolio.pressQuickActionTransferButton();
-        await app.portfolio.pressTransferBottomSheetReceiveButton();
-      } else {
-        await app.portfolioEmptyState.navigateToReceive();
-        await app.receive.selectReceiveFundsOption(ReceiveFundsOptions.CRYPTO);
-      }
+      await app.portfolio.pressQuickActionTransferButton();
+      await app.portfolio.pressTransferBottomSheetReceiveButton();
 
       await app.modularDrawer.validateAssetsScreen([account.currency.ticker]);
       await app.modularDrawer.performSearchByTicker(account.currency.ticker);

--- a/e2e/mobile/specs/earn/earnV2.ts
+++ b/e2e/mobile/specs/earn/earnV2.ts
@@ -59,7 +59,7 @@ async function navigateToEarn() {
 
 async function beforeAllFunction(options: ApplicationOptions) {
   await app.init(options);
-  await app.portfolio.waitForPortfolioPageToLoad();
+  await app.mainNavigation.waitForWallet40Ready();
   earnReady = waitEarnReady();
 }
 

--- a/e2e/mobile/specs/languageChange.spec.ts
+++ b/e2e/mobile/specs/languageChange.spec.ts
@@ -59,7 +59,7 @@ describe("Change Language", () => {
         },
       ],
     });
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.waitForWallet40Ready();
   });
 
   it("should go to General Settings", async () => {

--- a/e2e/mobile/specs/ledgerSync/ledgerSync.spec.ts
+++ b/e2e/mobile/specs/ledgerSync/ledgerSync.spec.ts
@@ -22,7 +22,7 @@ describeIfNotNanoS(`Ledger Sync Accounts`, () => {
           }),
       ],
     });
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.waitForWallet40Ready();
   });
 
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
@@ -30,7 +30,7 @@ describeIfNotNanoS(`Ledger Sync Accounts`, () => {
   it(`Synchronize one instance then delete the backup`, async () => {
     await app.accounts.openViaDeeplink();
     await app.accounts.expectNoAccount();
-    await app.portfolio.openViaDeeplink();
+    await app.mainNavigation.openPortfolioViaDeeplink();
     await app.portfolio.navigateToSettings();
     await app.settings.navigateToGeneralSettings();
     await app.settingsGeneral.navigateToLedgerSync();
@@ -44,7 +44,7 @@ describeIfNotNanoS(`Ledger Sync Accounts`, () => {
     await app.portfolio.waitForPortfolioWithAccounts();
     await app.accounts.openViaDeeplink();
     await app.accounts.expectAccountsNumber(2, app.ledgerSync.ledgerSyncPushDataArgs.data);
-    await app.portfolio.openViaDeeplink();
+    await app.mainNavigation.openPortfolioViaDeeplink();
     await app.portfolio.navigateToSettings();
     await app.settings.navigateToGeneralSettings();
     await device.disableSynchronization(); // TODO: Remove line when LIVE-15405 is fixed

--- a/e2e/mobile/specs/market.spec.ts
+++ b/e2e/mobile/specs/market.spec.ts
@@ -29,7 +29,7 @@ describe("Market page for user with no device", () => {
         },
       ],
     });
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.waitForWallet40Ready();
   });
 
   setTeamOwner(Team.WALLET_XP);

--- a/e2e/mobile/specs/portfolio/portfolio.ts
+++ b/e2e/mobile/specs/portfolio/portfolio.ts
@@ -1,5 +1,4 @@
 import { ApplicationOptions } from "page";
-import { isWallet40 } from "../../helpers/commonHelpers";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { setTeamOwner } from "../../helpers/allure/allure-helper";
@@ -39,7 +38,7 @@ export function runPortfolioTransactionsHistoryTest(
 }
 
 export function runPortfolioChartsAndAssetsTest(tmsLinks: string[], tags: string[]) {
-  (isWallet40 ? describe.skip : describe)("Portfolio charts and assets", () => {
+  describe("Portfolio charts and assets", () => {
     beforeAll(async () => {
       await beforeAllFunction({
         userdata: "speculos-tests-app",
@@ -52,7 +51,6 @@ export function runPortfolioChartsAndAssetsTest(tmsLinks: string[], tags: string
     it("Charts and assets section are displayed when user added his accounts", async () => {
       await app.mainNavigation.openPortfolioViaDeeplink();
       await app.portfolio.checkQuickActionButtonsVisibility();
-      await app.portfolio.checkChartVisibility();
       await app.portfolio.checkAssetAllocationSection();
     });
   });

--- a/e2e/mobile/specs/portfolio/portfolio.ts
+++ b/e2e/mobile/specs/portfolio/portfolio.ts
@@ -10,7 +10,7 @@ async function beforeAllFunction(options: ApplicationOptions) {
     speculosApp: options.speculosApp,
     cliCommands: options.cliCommands,
   });
-  await app.portfolio.waitForPortfolioPageToLoad();
+  await app.mainNavigation.waitForWallet40Ready();
 }
 export function runPortfolioTransactionsHistoryTest(
   account: Account,
@@ -50,7 +50,7 @@ export function runPortfolioChartsAndAssetsTest(tmsLinks: string[], tags: string
     tmsLinks.forEach(link => $TmsLink(link));
     tags.forEach(tag => $Tag(tag));
     it("Charts and assets section are displayed when user added his accounts", async () => {
-      await app.portfolio.openViaDeeplink();
+      await app.mainNavigation.openPortfolioViaDeeplink();
       await app.portfolio.checkQuickActionButtonsVisibility();
       await app.portfolio.checkChartVisibility();
       await app.portfolio.checkAssetAllocationSection();

--- a/e2e/mobile/specs/portfolio/portfolioTabs.spec.ts
+++ b/e2e/mobile/specs/portfolio/portfolioTabs.spec.ts
@@ -9,7 +9,7 @@ describe("Wallet Page", () => {
     await app.init({
       userdata: "speculos-tests-app",
     });
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.waitForWallet40Ready();
   });
 
   ["B2CQA-2869", "B2CQA-2870"].forEach(link => $TmsLink(link));
@@ -21,7 +21,7 @@ describe("Wallet Page", () => {
   ["B2CQA-2874"].forEach(link => $TmsLink(link));
   tags.forEach(tag => $Tag(tag));
   it("Portfolio Add Account - LLM", async () => {
-    await app.portfolio.openViaDeeplink();
+    await app.mainNavigation.openPortfolioViaDeeplink();
     await app.portfolio.tapTabSelector("Accounts");
     await app.portfolio.tapAddNewOrExistingAccountButton();
     await app.addAccount.importWithYourLedger();
@@ -39,7 +39,7 @@ describe("Wallet Page", () => {
   ["B2CQA-2871", "B2CQA-2873", "B2CQA-3060"].forEach(link => $TmsLink(link));
   tags.forEach(tag => $Tag(tag));
   it("Portfolio Accounts Tab - LLM", async () => {
-    await app.portfolio.openViaDeeplink();
+    await app.mainNavigation.openPortfolioViaDeeplink();
     await app.portfolio.checkAccountsSection();
     const isModularDrawer = await app.modularDrawer.isFlowEnabled("add_account");
     if (isModularDrawer) {

--- a/e2e/mobile/specs/send/send.ts
+++ b/e2e/mobile/specs/send/send.ts
@@ -37,7 +37,7 @@ const beforeAllFunction = async (transaction: TransactionType, options?: SendTes
     ],
   });
 
-  await app.portfolio.waitForPortfolioPageToLoad();
+  await app.mainNavigation.waitForWallet40Ready();
 };
 
 const beforeAllInvalidAddressFunction = async (
@@ -69,7 +69,7 @@ const beforeAllInvalidAddressFunction = async (
     ],
   });
 
-  await app.portfolio.waitForPortfolioPageToLoad();
+  await app.mainNavigation.waitForWallet40Ready();
 };
 
 export async function verifySendAndOperationDetails(

--- a/e2e/mobile/specs/settings/settings.ts
+++ b/e2e/mobile/specs/settings/settings.ts
@@ -1,7 +1,6 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { ApplicationOptions } from "page";
-import { isWallet40 } from "../../helpers/commonHelpers";
 import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
 async function initApp(options: ApplicationOptions) {
@@ -87,33 +86,30 @@ export function runUserCanSelectCounterValueToDisplayAmountInLedgerLive(
   tmsLinks: string[],
   tags: string[],
 ) {
-  (isWallet40 ? describe.skip : describe)(
-    "User can select counter value to display amount in Ledger Live",
-    () => {
-      beforeAll(async () => {
-        await initApp({
-          userdata: "skip-onboarding",
-          cliCommands: [liveDataCommand(account)],
-          speculosApp: account.currency.speculosApp,
-        });
+  describe("User can select counter value to display amount in Ledger Live", () => {
+    beforeAll(async () => {
+      await initApp({
+        userdata: "skip-onboarding",
+        cliCommands: [liveDataCommand(account)],
+        speculosApp: account.currency.speculosApp,
       });
+    });
 
-      setTeamOwner(Team.WALLET_XP);
-      tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
-      tags.forEach(tag => $Tag(tag));
-      test("Verify that user can select counter value to display amount in Ledger Live", async () => {
-        await app.portfolio.navigateToSettings();
-        await app.settings.navigateToGeneralSettings();
-        await app.settingsGeneral.changeCounterValue("Euro - EUR");
-        await app.settingsGeneral.expectCounterValue("EUR");
-        await app.mainNavigation.openPortfolioViaDeeplink();
-        await app.portfolio.expectTotalBalanceCounterValue("€");
-        await app.portfolio.expectBalanceDiffCounterValue("€");
-        await app.portfolio.expectAssetRowCounterValue(account.currency.name, "€");
-        await app.portfolio.expectOperationCounterValue("€");
-      });
-    },
-  );
+    setTeamOwner(Team.WALLET_XP);
+    tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+    tags.forEach(tag => $Tag(tag));
+    test("Verify that user can select counter value to display amount in Ledger Live", async () => {
+      await app.portfolio.navigateToSettings();
+      await app.settings.navigateToGeneralSettings();
+      await app.settingsGeneral.changeCounterValue("Euro - EUR");
+      await app.settingsGeneral.expectCounterValue("EUR");
+      await app.mainNavigation.openPortfolioViaDeeplink();
+      await app.portfolio.expectTotalBalanceCounterValue("€");
+      await app.portfolio.expectBalanceDiffToBeVisible();
+      await app.portfolio.expectAssetRowCounterValue(account.currency.name, "€");
+      await app.portfolio.expectOperationCounterValue("€");
+    });
+  });
 }
 
 async function initPasswordTest() {

--- a/e2e/mobile/specs/settings/settings.ts
+++ b/e2e/mobile/specs/settings/settings.ts
@@ -10,7 +10,7 @@ async function initApp(options: ApplicationOptions) {
     cliCommands: options.cliCommands,
     speculosApp: options.speculosApp,
   });
-  await app.portfolio.waitForPortfolioPageToLoad();
+  await app.mainNavigation.waitForWallet40Ready();
 }
 
 export function runUserClearApplicationCacheTest(
@@ -39,7 +39,7 @@ export function runUserClearApplicationCacheTest(
       await app.settingsHelp.clickOnClearCacheRow();
       await app.settingsHelp.checkClearCacheModalIsDisplayed();
       await app.settingsHelp.clickOnClearCacheButton();
-      await app.portfolio.waitForPortfolioPageToLoad();
+      await app.mainNavigation.waitForWallet40Ready();
       const countAfterClearingCache = await app.portfolio.countAccounts();
       await app.portfolio.compareAccountsCount(countBeforeClearingCache, countAfterClearingCache);
     });
@@ -106,8 +106,7 @@ export function runUserCanSelectCounterValueToDisplayAmountInLedgerLive(
         await app.settings.navigateToGeneralSettings();
         await app.settingsGeneral.changeCounterValue("Euro - EUR");
         await app.settingsGeneral.expectCounterValue("EUR");
-        await app.portfolio.openViaDeeplink();
-        await app.portfolio.waitForPortfolioPageToLoad();
+        await app.mainNavigation.openPortfolioViaDeeplink();
         await app.portfolio.expectTotalBalanceCounterValue("€");
         await app.portfolio.expectBalanceDiffCounterValue("€");
         await app.portfolio.expectAssetRowCounterValue(account.currency.name, "€");
@@ -132,7 +131,7 @@ async function initPasswordTest() {
       },
     ],
   });
-  await app.portfolio.waitForPortfolioPageToLoad();
+  await app.mainNavigation.waitForWallet40Ready();
 }
 
 export function runPasswordUnlockTest(tmsLinks: string[], tags: string[]) {

--- a/e2e/mobile/specs/subAccount/subAccount.ts
+++ b/e2e/mobile/specs/subAccount/subAccount.ts
@@ -32,7 +32,7 @@ const beforeAllFunction = async (transaction: TransactionType, setAccountToCredi
     ],
   });
 
-  await app.portfolio.waitForPortfolioPageToLoad();
+  await app.mainNavigation.waitForWallet40Ready();
 };
 
 export function runSendSPL(transaction: TransactionType, tmsLinks: string[], tags: string[]) {
@@ -141,7 +141,7 @@ export function runAddSubAccountTest(testConfig: {
         userdata: "skip-onboarding",
         speculosApp: asset.currency.speculosApp,
       });
-      await app.portfolio.waitForPortfolioPageToLoad();
+      await app.mainNavigation.waitForWallet40Ready();
     });
 
     setTeamOwner(Team.COIN_INTEGRATION);

--- a/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
@@ -170,7 +170,7 @@ export function runSwapLandingPageTest(
       await app.swapLiveApp.checkFirstQuoteContainerInfos(providerList);
       await app.swapLiveApp.checkBestOffer(providerList);
 
-      await app.portfolio.openViaDeeplink();
+      await app.mainNavigation.openPortfolioViaDeeplink();
       await app.swap.openViaDeeplink();
       await app.swapLiveApp.expectSwapLiveAppForm();
       await app.swapLiveApp.checkAssetFromMatchesAccount(fromAccount);
@@ -527,7 +527,7 @@ async function validateSwapAssetsPage(accountFrom: string, accountTo: string) {
 }
 
 async function openSwapFromPortfolioEntryPoint() {
-  await app.portfolio.openViaDeeplink();
+  await app.mainNavigation.openPortfolioViaDeeplink();
   if (isWallet40) {
     await app.mainNavigation.tapWallet40Tab("swap");
   } else {
@@ -557,7 +557,7 @@ export function runSwapEntryPoints(account: Account, tmsLinks: string[], tags: s
       await app.account.tapSwap();
       await validateSwapAssetsPage("", account.currency.ticker);
 
-      await app.portfolio.openViaDeeplink();
+      await app.mainNavigation.openPortfolioViaDeeplink();
       await app.portfolio.goToSpecificAsset(account.currency.name);
       await app.assetAccountsPage.tapOnAssetQuickActionButton("swap");
       await validateSwapAssetsPage("", account.currency.ticker);

--- a/e2e/mobile/specs/swap/swap.setup.ts
+++ b/e2e/mobile/specs/swap/swap.setup.ts
@@ -24,7 +24,7 @@ export async function beforeAllFunctionSwap(options: ApplicationOptions) {
     },
     cliCommandsOnApp: options.cliCommandsOnApp,
   });
-  await app.portfolio.waitForPortfolioPageToLoad();
+  await app.mainNavigation.waitForWallet40Ready();
   await swapSetup();
   await app.swap.openViaDeeplink();
   await app.swapLiveApp.expectSwapLiveApp();

--- a/e2e/mobile/specs/verifyAddress/receiveFlow.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/receiveFlow.spec.ts
@@ -22,12 +22,11 @@ describe("Receive Flow", () => {
       },
     });
 
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.waitForWallet40Ready();
   });
 
   beforeEach(async () => {
-    await app.portfolio.openViaDeeplink();
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.openPortfolioViaDeeplink();
     if (isWallet40) {
       await app.portfolio.pressQuickActionTransferButton();
       await app.portfolio.pressTransferBottomSheetReceiveButton();

--- a/e2e/mobile/specs/verifyAddress/receiveFlow.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/receiveFlow.spec.ts
@@ -1,8 +1,6 @@
 import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
-import { ReceiveFundsOptions } from "@ledgerhq/live-common/e2e/enum/ReceiveFundsOptions";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
-import { isWallet40 } from "../../helpers/commonHelpers";
 import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
 const isSmokeTestRun = process.env.INPUTS_TEST_FILTER?.includes("@smoke");
@@ -27,13 +25,8 @@ describe("Receive Flow", () => {
 
   beforeEach(async () => {
     await app.mainNavigation.openPortfolioViaDeeplink();
-    if (isWallet40) {
-      await app.portfolio.pressQuickActionTransferButton();
-      await app.portfolio.pressTransferBottomSheetReceiveButton();
-    } else {
-      await app.portfolio.tapQuickActionReceiveButton();
-      await app.receive.selectReceiveFundsOption(ReceiveFundsOptions.CRYPTO);
-    }
+    await app.portfolio.pressQuickActionTransferButton();
+    await app.portfolio.pressTransferBottomSheetReceiveButton();
   });
 
   afterEach(async () => {
@@ -77,13 +70,8 @@ describe("Receive Flow", () => {
     await app.receive.verifyAddress(address);
     await app.common.closePage();
 
-    if (isWallet40) {
-      await app.portfolio.pressQuickActionTransferButton();
-      await app.portfolio.pressTransferBottomSheetReceiveButton();
-    } else {
-      await app.portfolio.tapQuickActionReceiveButton();
-      await app.receive.selectReceiveFundsOption(ReceiveFundsOptions.CRYPTO);
-    }
+    await app.portfolio.pressQuickActionTransferButton();
+    await app.portfolio.pressTransferBottomSheetReceiveButton();
 
     await app.modularDrawer.selectCurrencyByTicker(Account.ETH_1.currency.ticker);
     await app.modularDrawer.selectNetwork(Currency.BASE.name);

--- a/e2e/mobile/specs/verifyAddress/verifyAddress.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddress.ts
@@ -9,7 +9,7 @@ export function runVerifyAddressTest(account: AccountType, tmsLinks: string[], t
         speculosApp: account.currency.speculosApp,
         cliCommands: [liveDataCommand(account)],
       });
-      await app.portfolio.waitForPortfolioPageToLoad();
+      await app.mainNavigation.waitForWallet40Ready();
     });
 
     setTeamOwner(Team.COIN_INTEGRATION);

--- a/e2e/mobile/specs/verifyAddress/verifyAddressWarning.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressWarning.ts
@@ -21,7 +21,7 @@ export function runVerifyAddressWarningTest(
         speculosApp: account.currency.speculosApp,
         cliCommands: [liveDataCommand(account)],
       });
-      await app.portfolio.waitForPortfolioPageToLoad();
+      await app.mainNavigation.waitForWallet40Ready();
     });
 
     setTeamOwner(Team.COIN_INTEGRATION);

--- a/e2e/mobile/specs/verifyAddress/verifyEmptyAddressTRX.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyEmptyAddressTRX.spec.ts
@@ -11,7 +11,7 @@ describe("Verify Address warnings", () => {
       speculosApp: account.currency.speculosApp,
       cliCommands: [liveDataCommand(account)],
     });
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.waitForWallet40Ready();
   });
 
   $TmsLink("B2CQA-1551");

--- a/e2e/mobile/specs/wallet40/marketBanner.spec.ts
+++ b/e2e/mobile/specs/wallet40/marketBanner.spec.ts
@@ -29,7 +29,7 @@ describe("Wallet 4.0 - Market Banner", () => {
       //todo: remove feature flag when market banner is enabled for all users
       featureFlags: WALLET_40_FEATURE_FLAGS,
     });
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.waitForWallet40Ready();
   });
 
   it("should display and interact with market banner", async () => {

--- a/e2e/mobile/specs/wallet40/portfolio.spec.ts
+++ b/e2e/mobile/specs/wallet40/portfolio.spec.ts
@@ -31,7 +31,7 @@ describe("Wallet 4.0 - Portfolio", () => {
         ...WALLET_40_FEATURE_FLAGS,
       },
     });
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.waitForWallet40Ready();
   });
 
   testConfig.tmsLinks.forEach(link => $TmsLink(link));
@@ -76,16 +76,14 @@ describe("Wallet 4.0 - Portfolio", () => {
 
   setTeamOwner(Team.SWAP);
   it("navigates to the swap screen", async () => {
-    await app.portfolio.openViaDeeplink();
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.openPortfolioViaDeeplink();
 
     await app.portfolio.pressQuickActionSwapButton();
     await app.swapLiveApp.expectSwapLiveApp();
   });
 
   it("performs the transfer bottom sheet actions", async () => {
-    await app.portfolio.openViaDeeplink();
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.openPortfolioViaDeeplink();
     await app.portfolio.pressQuickActionTransferButton();
     await app.portfolio.checkTransferBottomSheetReceiveButtonVisibility();
     await app.portfolio.checkTransferBottomSheetSendButtonVisibility();

--- a/e2e/mobile/specs/wallet40/walletAssets.spec.ts
+++ b/e2e/mobile/specs/wallet40/walletAssets.spec.ts
@@ -15,7 +15,7 @@ describe("Wallet 4.0 - Portfolio-Asset/Address - Onboard without accounts", () =
       speculosApp: currency.speculosApp,
       featureFlags: WALLET_40_FEATURE_FLAGS,
     });
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.waitForWallet40Ready();
   });
 
   tmsLinks.forEach(link => $TmsLink(link));
@@ -32,7 +32,7 @@ describe("Wallet 4.0 - Portfolio-Asset/Address - Onboard without accounts", () =
     await app.portfolio.tapFirstAssetItemW40();
     await app.market.expectMarketDetailPage();
     await app.market.leaveMarketDetailPage();
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.waitForWallet40Ready();
   });
 });
 
@@ -45,7 +45,7 @@ describe("Wallet 4.0 - Portfolio-Asset/Address - With fewer accounts than sectio
       userdata: "wallet40-btc-only",
       featureFlags: WALLET_40_FEATURE_FLAGS,
     });
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.waitForWallet40Ready();
   });
 
   tmsLinks.forEach(link => $TmsLink(link));
@@ -68,7 +68,7 @@ describe("Wallet 4.0 - Portfolio-Asset/Address - Open the app with accounts", ()
       userdata: "wallet40-many-stablecoins",
       featureFlags: WALLET_40_FEATURE_FLAGS,
     });
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.waitForWallet40Ready();
   });
 
   tmsLinks.forEach(link => $TmsLink(link));
@@ -83,7 +83,7 @@ describe("Wallet 4.0 - Portfolio-Asset/Address - Open the app with accounts", ()
     await app.portfolio.tapCryptosSectionTitle();
     await app.portfolio.checkCryptoListPageVisible();
     await app.common.goToPreviousPage();
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.waitForWallet40Ready();
   });
 
   it("should cap stablecoins at 6, show only stablecoins when clicking section title, and list all stablecoin assets", async () => {
@@ -93,6 +93,6 @@ describe("Wallet 4.0 - Portfolio-Asset/Address - Open the app with accounts", ()
     await app.portfolio.tapStablecoinsSectionTitle();
     await app.portfolio.checkStablecoinListPageVisible();
     await app.common.goToPreviousPage();
-    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.mainNavigation.waitForWallet40Ready();
   });
 });

--- a/e2e/mobile/types/global.d.ts
+++ b/e2e/mobile/types/global.d.ts
@@ -72,6 +72,7 @@ declare global {
   var getIdByRegexp: typeof NativeElementHelpers.getIdByRegexp;
   var getIdOfElement: typeof NativeElementHelpers.getIdOfElement;
   var getTextOfElement: typeof NativeElementHelpers.getTextOfElement;
+  var getLabelOfElement: typeof NativeElementHelpers.getLabelOfElement;
   var IsIdPresent: typeof NativeElementHelpers.isIdPresent;
   var IsIdVisible: typeof NativeElementHelpers.isIdVisible;
   var scrollToId: typeof NativeElementHelpers.scrollToId;

--- a/e2e/mobile/utils/initUtil.ts
+++ b/e2e/mobile/utils/initUtil.ts
@@ -303,7 +303,9 @@ export class InitializationManager {
     userdataPath: string,
     userdataSpeculos: string,
   ): Promise<void> {
-    const { speculosApp, cliCommands = [], cliCommandsOnApp = [], featureFlags } = options;
+    const { speculosApp, cliCommands = [], cliCommandsOnApp = [], featureFlags = {} } = options;
+
+    await InitializationManager.setFeatureFlags(featureFlags);
 
     // Group commands by app name
     const commandsByAppMap = new Map<string, { app: SpeculosAppType; cmds: CliCommand[] }>();
@@ -345,6 +347,9 @@ export class InitializationManager {
 
     // Finalize setup only after successful global CLI run
     await loadConfig(userdataSpeculos, true);
+  }
+
+  static async setFeatureFlags(featureFlags: PartialFeatures) {
     const defaultFlags = {
       lwmWallet40: {
         enabled: isWallet40,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - E2E Mobile tests

### 📝 Description

Fixing wait for portfolio to wait for wallet 4.0 screen
Fixing skipped tests on W40
Initializing FF on app launch to prevent unstable behaviour (crash) on W40 enabling

Crash in swap screen will be fixed by RN upgrade :
> Error: Web element 'number-of-quotes' not found after 60000ms: ❌ [retryUntilTimeout] Timed out after 60000ms
> 🧪 The app has crashed, see the details below:

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [Run1](https://github.com/LedgerHQ/ledger-live/actions/runs/27930677612)
- [Run2](https://github.com/LedgerHQ/ledger-live/actions/runs/27930687780)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
