### PR TITLE
[LWDM] fix(mobile): fix content card tracking properties

### DIFF
--- a/.changeset/fix-top-wallet-canvas-tracking.md
+++ b/.changeset/fix-top-wallet-canvas-tracking.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": patch
+"live-mobile": patch
+---
+
+Fix top_wallet content card canvas_name and canvas_step_name tracking

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
@@ -13,6 +13,7 @@ import {
 } from "../types";
 import { Flex } from "@ledgerhq/native-ui";
 import { ContentCardMetadata, ContentCardProps } from "~/contentCards/cards/types";
+import { buildContentCardTrackingProperties } from "@ledgerhq/live-common/braze/contentCardExtras";
 import { contentCardItem } from "~/contentCards/cards/utils";
 import {
   compareCards,
@@ -21,7 +22,6 @@ import {
   mapAsMediumSquareContentCard,
   mapAsBigSquareContentCard,
   mapAsHeroContentCard,
-  sanitizeExtras,
 } from "~/dynamicContent/utils";
 import Carousel from "../../contentCards/layouts/carousel";
 import { WidthFactor } from "~/contentCards/layouts/types";
@@ -88,11 +88,12 @@ const Layout = ({ category, cards }: LayoutProps) => {
     : contentCardsType.contentCardComponent;
 
   const onCardClick = async (card: AnyContentCard, displayedPosition?: number) => {
-    const page = category.location ?? card.location ?? card.extras?.location;
     await trackContentCardEvent("contentcard_clicked", {
-      ...sanitizeExtras(card.extras),
-      page,
-      location: page,
+      ...buildContentCardTrackingProperties({
+        cardExtras: card.extras,
+        categoryExtras: category.extras,
+        categoryLocation: category.location,
+      }),
       campaign: card.id,
       contentcard: card.title,
       type: category.cardsType,
@@ -110,11 +111,12 @@ const Layout = ({ category, cards }: LayoutProps) => {
   };
 
   const onCardDismiss = (card: AnyContentCard, displayedPosition?: number) => {
-    const page = category.location ?? card.location ?? card.extras?.location;
     trackContentCardEvent("contentcard_dismissed", {
-      ...sanitizeExtras(card.extras),
-      page,
-      location: page,
+      ...buildContentCardTrackingProperties({
+        cardExtras: card.extras,
+        categoryExtras: category.extras,
+        categoryLocation: category.location,
+      }),
       campaign: card.id,
       contentcard: card.title,
       type: category.cardsType,
@@ -184,7 +186,7 @@ const Layout = ({ category, cards }: LayoutProps) => {
         <LogContentCardWrapper
           id={item.props.metadata.id}
           displayedPosition={item.props.metadata.displayedPosition}
-          location={card?.location}
+          location={category.location ?? card?.location}
         >
           <Flex mx={6}>{item.component(item.props)}</Flex>
         </LogContentCardWrapper>

--- a/apps/ledger-live-mobile/src/dynamicContent/brazeContentCard.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/brazeContentCard.ts
@@ -5,7 +5,10 @@ import { track } from "~/analytics";
 import { setDismissedContentCard } from "~/actions/settings";
 import { trackingEnabledSelector } from "~/reducers/settings";
 import { localMobileCardsSelector, localWalletCardsSelector } from "~/reducers/dynamicContent";
-import { sanitizeExtras } from "~/dynamicContent/utils";
+import {
+  buildContentCardTrackingProperties,
+  isCategoryContentCardExtras,
+} from "@ledgerhq/live-common/braze/contentCardExtras";
 
 const isLocalCard = (
   cardId: string,
@@ -21,7 +24,19 @@ export const useBrazeContentCard = (mobileCards: Braze.ContentCard[]) => {
     () => new Set(localWalletCards.map(c => c.id)),
     [localWalletCards],
   );
-  const mobileCardRef = useRef(mobileCards);
+  const cardIndex = useMemo(() => {
+    const byId = new Map<string, Braze.ContentCard>();
+    const categoryExtrasById = new Map<string, Record<string, string>>();
+    for (const card of mobileCards) {
+      byId.set(card.id, card);
+      if (isCategoryContentCardExtras(card.extras) && card.extras.id) {
+        categoryExtrasById.set(card.extras.id, card.extras);
+      }
+    }
+    return { byId, categoryExtrasById };
+  }, [mobileCards]);
+  const cardIndexRef = useRef(cardIndex);
+  cardIndexRef.current = cardIndex;
   const dispatch = useDispatch();
 
   const logDismissCard = useCallback(
@@ -49,20 +64,18 @@ export const useBrazeContentCard = (mobileCards: Braze.ContentCard[]) => {
 
   const logImpressionCard = useCallback(
     (cardId: string, displayedPosition?: number) => {
-      if (!isTrackedUser) return;
+      if (!isTrackedUser || isLocalCard(cardId, localMobileCards, localWalletCardIds)) return;
 
-      const card = mobileCardRef.current.find(card => card.id === cardId);
-
-      const isLocal = isLocalCard(cardId, localMobileCards, localWalletCardIds);
-
-      if (isLocal) return;
+      const card = cardIndexRef.current.byId.get(cardId);
+      if (!card || isCategoryContentCardExtras(card.extras)) return;
 
       Braze.logContentCardImpression(cardId);
 
-      if (!card) return;
+      const categoryExtras = card.extras.categoryId
+        ? cardIndexRef.current.categoryExtrasById.get(card.extras.categoryId)
+        : undefined;
       track("contentcard_impression", {
-        ...sanitizeExtras(card.extras),
-        page: card.extras.location,
+        ...buildContentCardTrackingProperties({ cardExtras: card.extras, categoryExtras }),
         displayedPosition,
       });
     },

--- a/libs/ledger-live-common/src/braze/contentCardExtras.test.ts
+++ b/libs/ledger-live-common/src/braze/contentCardExtras.test.ts
@@ -1,4 +1,9 @@
-import { parseOrder, sanitizeExtras } from "./contentCardExtras";
+import {
+  parseOrder,
+  sanitizeExtras,
+  buildContentCardTrackingProperties,
+  isCategoryContentCardExtras,
+} from "./contentCardExtras";
 
 describe("parseOrder", () => {
   it("should parse a valid numeric string", () => {
@@ -82,5 +87,100 @@ describe("sanitizeExtras", () => {
   it("should handle order of zero", () => {
     const result = sanitizeExtras({ order: "0" });
     expect(result).toEqual({ order: 0 });
+  });
+});
+
+describe("buildContentCardTrackingProperties", () => {
+  it("should inherit canvas_name from category and keep child canvas_step_name", () => {
+    expect(
+      buildContentCardTrackingProperties({
+        cardExtras: {
+          title: "Buy",
+          canvas_step_name: "Buy step",
+          categoryId: "alwayson",
+        },
+        categoryExtras: {
+          id: "alwayson",
+          type: "category",
+          canvas_name: "Wallet canvas",
+          canvas_step_name: "Category step",
+        },
+        categoryLocation: "top_wallet",
+      }),
+    ).toEqual({
+      title: "Buy",
+      categoryId: "alwayson",
+      page: "top_wallet",
+      location: "top_wallet",
+      canvas_name: "Wallet canvas",
+      canvas_step_name: "Buy step",
+    });
+  });
+
+  it("should not use category canvas_step_name when child has none", () => {
+    expect(
+      buildContentCardTrackingProperties({
+        cardExtras: { title: "Buy", categoryId: "alwayson" },
+        categoryExtras: {
+          id: "alwayson",
+          type: "category",
+          canvas_name: "Wallet canvas",
+          canvas_step_name: "Category step",
+        },
+        categoryLocation: "top_wallet",
+      }),
+    ).toEqual({
+      title: "Buy",
+      categoryId: "alwayson",
+      page: "top_wallet",
+      location: "top_wallet",
+      canvas_name: "Wallet canvas",
+    });
+  });
+
+  it("should resolve alwayson category to top_wallet when categoryLocation is omitted", () => {
+    expect(
+      buildContentCardTrackingProperties({
+        cardExtras: { title: "Buy", categoryId: "alwayson" },
+        categoryExtras: {
+          id: "alwayson",
+          type: "category",
+          canvas_name: "Wallet canvas",
+        },
+      }),
+    ).toEqual({
+      title: "Buy",
+      categoryId: "alwayson",
+      page: "top_wallet",
+      location: "top_wallet",
+      canvas_name: "Wallet canvas",
+    });
+  });
+
+  it("should fall back to categoryExtras.location when categoryLocation is omitted", () => {
+    expect(
+      buildContentCardTrackingProperties({
+        cardExtras: { title: "Promo", categoryId: "earn" },
+        categoryExtras: {
+          id: "earn",
+          type: "category",
+          location: "portfolio",
+          canvas_name: "Earn canvas",
+        },
+      }),
+    ).toEqual({
+      title: "Promo",
+      categoryId: "earn",
+      page: "portfolio",
+      location: "portfolio",
+      canvas_name: "Earn canvas",
+    });
+  });
+});
+
+describe("isCategoryContentCardExtras", () => {
+  it("should detect category cards", () => {
+    expect(isCategoryContentCardExtras({ type: "category" })).toBe(true);
+    expect(isCategoryContentCardExtras({ type: "action" })).toBe(false);
   });
 });

--- a/libs/ledger-live-common/src/braze/contentCardExtras.ts
+++ b/libs/ledger-live-common/src/braze/contentCardExtras.ts
@@ -17,3 +17,45 @@ export const sanitizeExtras = (
   const parsed = parseOrder(order);
   return parsed !== undefined ? { ...rest, order: parsed } : { ...rest };
 };
+
+const TOP_WALLET_ALWAYS_ON_CATEGORY_ID = "alwayson";
+
+export const resolveCategoryLocation = (
+  categoryExtras: Record<string, string> | undefined,
+): string | undefined => {
+  if (!categoryExtras) return undefined;
+  if (categoryExtras.id === TOP_WALLET_ALWAYS_ON_CATEGORY_ID) return "top_wallet";
+  return categoryExtras.location;
+};
+
+export const isCategoryContentCardExtras = (extras: Record<string, string> | undefined): boolean =>
+  extras?.type === "category";
+
+export type ContentCardTrackingContext = {
+  cardExtras?: Record<string, string>;
+  categoryExtras?: Record<string, string>;
+  categoryLocation?: string;
+};
+
+export const buildContentCardTrackingProperties = ({
+  cardExtras,
+  categoryExtras,
+  categoryLocation,
+}: ContentCardTrackingContext): Record<string, string | number> => {
+  const {
+    canvas_name: _cn,
+    canvas_step_name: _csn,
+    location: _loc,
+    ...rest
+  } = sanitizeExtras(cardExtras);
+  const page = categoryLocation ?? resolveCategoryLocation(categoryExtras) ?? cardExtras?.location;
+  const canvas_name = cardExtras?.canvas_name ?? categoryExtras?.canvas_name;
+  const canvas_step_name = cardExtras?.canvas_step_name;
+
+  return {
+    ...rest,
+    ...(page && { page, location: page }),
+    ...(canvas_name && { canvas_name }),
+    ...(canvas_step_name && { canvas_step_name }),
+  };
+};


### PR DESCRIPTION
### ✅ Checklist
- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Top wallet Braze content card analytics (`contentcard_impression`, `contentcard_clicked`, `contentcard_dismissed`)
  - `page` / `location` values for always-on wallet category cards
  - `canvas_name` inheritance from parent category cards
  - `canvas_step_name` on child action cards only

### 📝 Description

**Problem**: Analytics events for top_wallet Braze content cards were missing or incorrect tracking properties. Child action cards did not inherit `canvas_name` from their parent category card, `page`/`location` was not resolved to `top_wallet` for the always-on category, and impression/click/dismiss events used inconsistent property building.

**Solution**: Centralized content card tracking property building in `@ledgerhq/live-common/braze/contentCardExtras`:

- `buildContentCardTrackingProperties` merges card and category extras, inheriting `canvas_name` from the category while keeping each child's own `canvas_step_name`
- `resolveCategoryLocation` maps the `alwayson` category id to `top_wallet`
- Mobile impression tracking (`useBrazeContentCard`) indexes cards once per render for O(1) lookups and skips category cards
- `ContentCardsCategory/Layout` uses the same helper for click and dismiss events

**Before**: `contentcard_impression` on a top_wallet child card could lack `canvas_name`, `page`, and `location`.

**After**: Events include `page: "top_wallet"`, `location: "top_wallet"`, `canvas_name` from the category, and `canvas_step_name` from the child card.
### ❓ Context
- **JIRA or GitHub link**: [LIVE-31835](https://ledgerhq.atlassian.net/browse/LIVE-31835)
---
### 🧐 Checklist for the PR Reviewers
- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31835]: https://ledgerhq.atlassian.net/browse/LIVE-31835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ