### PR TITLE
[LWDM] feat(market-banner): plug the Trending filter into the countervalues trending endpoint

### DIFF
--- a/.changeset/trending-market-banner.md
+++ b/.changeset/trending-market-banner.md
@@ -1,0 +1,12 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+feat(market-banner): back the "Trending" ranking with the countervalues `/v3/currencies/trending` endpoint
+
+The market banner "Trending" filter (desktop and mobile) now fetches the dedicated trending
+currencies list (hydrated via `/v3/markets`, preserving trending order and keeping only supported
+entries) instead of reusing the gainers performers query. Adds a `getTrendingPerformers` endpoint
+and `useTrendingPerformers` hook in live-common.

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/useMarketBannerViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/useMarketBannerViewModel.test.ts
@@ -2,21 +2,25 @@ import { renderHook, withFlagOverrides } from "tests/testSetup";
 import {
   usePerformersBannerItems,
   useFavoritesBannerItems,
+  useTrendingBannerItems,
   useMarketBannerViewModel,
 } from "../hooks/useMarketBannerViewModel";
 import { useMarketPerformers } from "@ledgerhq/live-common/market/hooks/useMarketPerformers";
+import { useTrendingPerformers } from "@ledgerhq/live-common/market/hooks/useTrendingPerformers";
 import { useMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
 import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
 import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
 import {
   MOCK_MARKET_PERFORMERS,
   createMockMarketCurrencyData,
+  createMockMarketPerformer,
 } from "@ledgerhq/live-common/market/utils/fixtures";
 import { MarketItemPerformer, MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
 import { selectMarketBannerRanking } from "~/renderer/reducers/marketBanner";
 import { MARKET_BANNER_ITEMS_COUNT } from "../utils/constants";
 
 jest.mock("@ledgerhq/live-common/market/hooks/useMarketPerformers");
+jest.mock("@ledgerhq/live-common/market/hooks/useTrendingPerformers");
 jest.mock("@ledgerhq/live-common/market/hooks/useMarketDataProvider");
 jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog");
 jest.mock("@ledgerhq/live-common/exchange/swap/hooks/index");
@@ -30,6 +34,7 @@ const assetDiscoverabilityOff = withFlagOverrides({
 });
 
 const mockedUseMarketPerformers = jest.mocked(useMarketPerformers);
+const mockedUseTrendingPerformers = jest.mocked(useTrendingPerformers);
 const mockedUseMarketData = jest.mocked(useMarketData);
 
 function mockPerformersQuery(
@@ -47,6 +52,23 @@ function mockPerformersQuery(
     isError: false,
     ...overrides,
   } as ReturnType<typeof useMarketPerformers>);
+}
+
+function mockTrendingQuery(
+  overrides: Partial<{
+    data: MarketItemPerformer[];
+    isLoading: boolean;
+    isFetching: boolean;
+    isError: boolean;
+  }>,
+) {
+  mockedUseTrendingPerformers.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    ...overrides,
+  } as ReturnType<typeof useTrendingPerformers>);
 }
 
 function mockMarketDataQuery(
@@ -72,6 +94,10 @@ describe("MarketBanner view models", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    // The view model always calls every ranking hook (skipping the inactive ones), so provide a
+    // safe default for trending to avoid destructuring an undefined query result.
+    mockTrendingQuery({});
+
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     jest.mocked(useRampCatalog).mockReturnValue({
       isCurrencyAvailable: () => true,
@@ -88,7 +114,7 @@ describe("MarketBanner view models", () => {
       it("should be true during the initial load (no cached data)", () => {
         mockPerformersQuery({ isLoading: true, isFetching: true });
 
-        const { result } = renderHook(() => usePerformersBannerItems("trending"));
+        const { result } = renderHook(() => usePerformersBannerItems("gainers"));
 
         expect(result.current.isLoading).toBe(true);
         expect(result.current.items).toEqual([]);
@@ -97,7 +123,7 @@ describe("MarketBanner view models", () => {
       it("should be true when fetching without any cached data", () => {
         mockPerformersQuery({ isFetching: true });
 
-        const { result } = renderHook(() => usePerformersBannerItems("trending"));
+        const { result } = renderHook(() => usePerformersBannerItems("gainers"));
 
         expect(result.current.isLoading).toBe(true);
       });
@@ -105,7 +131,7 @@ describe("MarketBanner view models", () => {
       it("should be false during a background refetch when data already exists", () => {
         mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS, isFetching: true });
 
-        const { result } = renderHook(() => usePerformersBannerItems("trending"));
+        const { result } = renderHook(() => usePerformersBannerItems("gainers"));
 
         expect(result.current.isLoading).toBe(false);
         expect(result.current.items.length).toBeGreaterThan(0);
@@ -114,7 +140,7 @@ describe("MarketBanner view models", () => {
       it("should be false when data is loaded and the query is idle", () => {
         mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
 
-        const { result } = renderHook(() => usePerformersBannerItems("trending"));
+        const { result } = renderHook(() => usePerformersBannerItems("gainers"));
 
         expect(result.current.isLoading).toBe(false);
         expect(result.current.items.length).toBeGreaterThan(0);
@@ -125,7 +151,7 @@ describe("MarketBanner view models", () => {
       it("should be true when the query errors and is not refetching", () => {
         mockPerformersQuery({ isError: true });
 
-        const { result } = renderHook(() => usePerformersBannerItems("trending"));
+        const { result } = renderHook(() => usePerformersBannerItems("gainers"));
 
         expect(result.current.isError).toBe(true);
       });
@@ -133,26 +159,23 @@ describe("MarketBanner view models", () => {
       it("should be suppressed while a refetch is in progress", () => {
         mockPerformersQuery({ isError: true, isFetching: true });
 
-        const { result } = renderHook(() => usePerformersBannerItems("trending"));
+        const { result } = renderHook(() => usePerformersBannerItems("gainers"));
 
         expect(result.current.isError).toBe(false);
       });
     });
 
     describe("ranking → sort mapping", () => {
-      it.each(["trending", "gainers"] as const)(
-        "should request ascending order for %s",
-        ranking => {
-          mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
+      it("should request ascending order for gainers", () => {
+        mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
 
-          renderHook(() => usePerformersBannerItems(ranking));
+        renderHook(() => usePerformersBannerItems("gainers"));
 
-          expect(mockedUseMarketPerformers).toHaveBeenCalledWith(
-            expect.objectContaining({ sort: "asc" }),
-            expect.anything(),
-          );
-        },
-      );
+        expect(mockedUseMarketPerformers).toHaveBeenCalledWith(
+          expect.objectContaining({ sort: "asc" }),
+          expect.anything(),
+        );
+      });
 
       it("should request descending order for losers", () => {
         mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
@@ -230,6 +253,49 @@ describe("MarketBanner view models", () => {
     });
   });
 
+  describe("useTrendingBannerItems", () => {
+    it("caps the result to MARKET_BANNER_ITEMS_COUNT and preserves order", () => {
+      const data = Array.from({ length: MARKET_BANNER_ITEMS_COUNT + 5 }, (_, i) =>
+        createMockMarketPerformer({ id: `coin-${i}` }),
+      );
+      mockTrendingQuery({ data });
+
+      const { result } = renderHook(() => useTrendingBannerItems());
+
+      expect(result.current.items).toHaveLength(MARKET_BANNER_ITEMS_COUNT);
+      expect(result.current.items[0].id).toBe("coin-0");
+    });
+
+    it("does not apply availability filtering", () => {
+      const notTradeable = createMockMarketPerformer({
+        id: "some-token",
+        ledgerIds: ["some-token"],
+      });
+      mockTrendingQuery({ data: [notTradeable] });
+
+      jest.mocked(useRampCatalog).mockReturnValue({
+        isCurrencyAvailable: () => false,
+      } as unknown as ReturnType<typeof useRampCatalog>);
+      jest.mocked(useFetchCurrencyAll).mockReturnValue({
+        data: [],
+      } as unknown as ReturnType<typeof useFetchCurrencyAll>);
+
+      const { result } = renderHook(() => useTrendingBannerItems());
+
+      expect(result.current.items.map(item => item.id)).toEqual(["some-token"]);
+    });
+
+    it("is loading on first fetch and surfaces errors when not refetching", () => {
+      mockTrendingQuery({ isLoading: true, isFetching: true });
+      const { result: loading } = renderHook(() => useTrendingBannerItems());
+      expect(loading.current.isLoading).toBe(true);
+
+      mockTrendingQuery({ isError: true });
+      const { result: errored } = renderHook(() => useTrendingBannerItems());
+      expect(errored.current.isError).toBe(true);
+    });
+  });
+
   describe("useMarketBannerViewModel", () => {
     it("returns favorites data and skips the performers query when ranking is favorites", () => {
       mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
@@ -247,8 +313,9 @@ describe("MarketBanner view models", () => {
       expect(result.current.items.map(item => item.id)).toEqual(["bitcoin"]);
     });
 
-    it("resets a stale favorites ranking to trending and runs the performers query when no coin is starred", () => {
-      mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
+    it("resets a stale favorites ranking to trending and runs the trending query when no coin is starred", () => {
+      mockPerformersQuery({});
+      mockTrendingQuery({ data: MOCK_MARKET_PERFORMERS });
       mockMarketDataQuery({});
 
       const { result, store } = renderHook(() => useMarketBannerViewModel(), {
@@ -260,10 +327,52 @@ describe("MarketBanner view models", () => {
       });
 
       expect(selectMarketBannerRanking(store.getState())).toBe("trending");
-      expect(mockedUseMarketPerformers).toHaveBeenCalledWith(expect.anything(), { skip: false });
+      expect(mockedUseTrendingPerformers).toHaveBeenCalledWith(expect.anything(), { skip: false });
+      expect(mockedUseMarketPerformers).toHaveBeenCalledWith(expect.anything(), { skip: true });
       expect(mockedUseMarketData).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ enabled: false }),
+      );
+      expect(result.current.items.length).toBeGreaterThan(0);
+    });
+
+    it("returns trending data and skips the performers and favorites queries when ranking is trending", () => {
+      mockPerformersQuery({});
+      mockTrendingQuery({ data: MOCK_MARKET_PERFORMERS });
+      mockMarketDataQuery({});
+
+      const { result } = renderHook(() => useMarketBannerViewModel(), {
+        initialState: {
+          ...assetDiscoverabilityOn,
+          marketBanner: { ranking: "trending" },
+        },
+      });
+
+      expect(mockedUseTrendingPerformers).toHaveBeenCalledWith(expect.anything(), { skip: false });
+      expect(mockedUseMarketPerformers).toHaveBeenCalledWith(expect.anything(), { skip: true });
+      expect(mockedUseMarketData).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ enabled: false }),
+      );
+      expect(result.current.items.length).toBeGreaterThan(0);
+    });
+
+    it("falls back to the gainers performers query when the trending query errors", () => {
+      mockTrendingQuery({ isError: true });
+      mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
+      mockMarketDataQuery({});
+
+      const { result } = renderHook(() => useMarketBannerViewModel(), {
+        initialState: {
+          ...assetDiscoverabilityOn,
+          marketBanner: { ranking: "trending" },
+        },
+      });
+
+      // Fallback active: the performers query is enabled with the ascending (gainers) sort.
+      expect(mockedUseMarketPerformers).toHaveBeenCalledWith(
+        expect.objectContaining({ sort: "asc" }),
+        { skip: false },
       );
       expect(result.current.items.length).toBeGreaterThan(0);
     });

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { useMarketPerformers } from "@ledgerhq/live-common/market/hooks/useMarketPerformers";
+import { useTrendingPerformers } from "@ledgerhq/live-common/market/hooks/useTrendingPerformers";
 import { useMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
 import { filterMarketPerformersByAvailability } from "@ledgerhq/live-common/market/utils/index";
 import {
@@ -107,6 +108,29 @@ export function usePerformersBannerItems(
   };
 }
 
+// Trending is backed by the dedicated `/v3/currencies/trending` endpoint, which already returns a
+// curated, ordered list. Availability filtering is intentionally not applied so the banner mirrors
+// what is trending in the market.
+export function useTrendingBannerItems(options?: { skip?: boolean }): MarketBannerItems {
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+
+  const { data, isError, isLoading, isFetching } = useTrendingPerformers(
+    {
+      counterCurrency: counterValueCurrency.ticker,
+      refreshRate: MARKET_BANNER_REFRESH_RATE,
+    },
+    { skip: options?.skip },
+  );
+
+  const items = useMemo(() => (data ?? []).slice(0, MARKET_BANNER_ITEMS_COUNT), [data]);
+
+  return {
+    items,
+    isLoading: isLoading || (isFetching && !data),
+    isError: isError && !isFetching,
+  };
+}
+
 // Availability filtering is bypassed so a starred coin shows even when not swap-available.
 // The endpoint returns the whole market when no `ids` are sent, so the query is disabled when
 // there are no starred coins (or favorites is not active).
@@ -153,6 +177,7 @@ export function useMarketBannerViewModel(): MarketBannerItems {
   const effectiveRanking: MarketBannerRanking =
     ranking === "favorites" && !hasStarred ? "trending" : ranking;
   const isFavorites = effectiveRanking === "favorites";
+  const isTrending = effectiveRanking === "trending";
 
   // Reset the stale persisted "favorites" so the persisted state and the dropdown match the UI.
   useEffect(() => {
@@ -161,8 +186,15 @@ export function useMarketBannerViewModel(): MarketBannerItems {
     }
   }, [dispatch, ranking, hasStarred]);
 
-  const performers = usePerformersBannerItems(effectiveRanking, { skip: isFavorites });
+  const trending = useTrendingBannerItems({ skip: !isTrending });
+  // If the trending endpoint fails, fall back to gainers (sort "asc") so the banner never breaks.
+  const trendingFailed = isTrending && trending.isError;
+  const performers = usePerformersBannerItems(effectiveRanking, {
+    skip: isFavorites || (isTrending && !trendingFailed),
+  });
   const favorites = useFavoritesBannerItems({ skip: !isFavorites });
 
-  return isFavorites ? favorites : performers;
+  if (isFavorites) return favorites;
+  if (isTrending) return trendingFailed ? performers : trending;
+  return performers;
 }

--- a/apps/ledger-live-desktop/tests/handlers/market.ts
+++ b/apps/ledger-live-desktop/tests/handlers/market.ts
@@ -30,16 +30,12 @@ const handlers = [
   http.get("https://countervalues.live.ledger.com/v3/categories/trending", () => {
     return HttpResponse.json([]);
   }),
-  // `/v3/currencies/trending` is only served by the staging countervalues API.
-  http.get("https://countervalues-service.api.ledger-test.com/v3/currencies/trending", () => {
+  http.get("https://countervalues.live.ledger.com/v3/currencies/trending", () => {
     return HttpResponse.json([
       { id: "bitcoin", supported: true },
       { id: "ethereum", supported: true },
       { id: "solana", supported: true },
     ]);
-  }),
-  http.get("https://countervalues-service.api.ledger-test.com/v3/markets", () => {
-    return HttpResponse.json(MarketMockedResponse.marketList);
   }),
 ];
 

--- a/apps/ledger-live-desktop/tests/handlers/market.ts
+++ b/apps/ledger-live-desktop/tests/handlers/market.ts
@@ -30,6 +30,17 @@ const handlers = [
   http.get("https://countervalues.live.ledger.com/v3/categories/trending", () => {
     return HttpResponse.json([]);
   }),
+  // `/v3/currencies/trending` is only served by the staging countervalues API.
+  http.get("https://countervalues-service.api.ledger-test.com/v3/currencies/trending", () => {
+    return HttpResponse.json([
+      { id: "bitcoin", supported: true },
+      { id: "ethereum", supported: true },
+      { id: "solana", supported: true },
+    ]);
+  }),
+  http.get("https://countervalues-service.api.ledger-test.com/v3/markets", () => {
+    return HttpResponse.json(MarketMockedResponse.marketList);
+  }),
 ];
 
 export default handlers;

--- a/apps/ledger-live-mobile/__tests__/handlers/market.ts
+++ b/apps/ledger-live-mobile/__tests__/handlers/market.ts
@@ -42,37 +42,42 @@ const stockMarketsMock: typeof marketsMock = [
   },
 ];
 
+const marketsResolver = ({ request }: { request: Request }) => {
+  const searchParams = new URL(request.url).searchParams;
+
+  let filteredData = marketsMock;
+
+  if (searchParams.get("categories") === "tokenized-stock") {
+    filteredData = stockMarketsMock;
+  }
+  // When we perform a search
+  else if (searchParams.get("filter")) {
+    const coins = searchParams.get("filter")?.toLowerCase().split(",") || [];
+    filteredData = marketsMock.filter(({ name, ticker }) =>
+      coins.some(coin => ticker.toLowerCase().includes(coin) || name.toLowerCase().includes(coin)),
+    );
+  }
+  // When we perform starred / trending hydration by ids
+  else if (searchParams.get("ids")) {
+    const coins = searchParams.get("ids")?.split(",") || [];
+    filteredData = marketsMock.filter(({ id }) => coins.includes(id));
+  }
+
+  const page = parseInt(searchParams.get("page") || "0");
+  const pageSize = 10;
+  const startIndex = page * pageSize;
+  const endIndex = startIndex + pageSize;
+  const paginatedData = filteredData.slice(startIndex, endIndex);
+
+  return HttpResponse.json(paginatedData);
+};
+
 const handlers = [
-  http.get("https://countervalues.live.ledger.com/v3/markets", ({ request }) => {
-    const searchParams = new URL(request.url).searchParams;
-
-    let filteredData = marketsMock;
-
-    if (searchParams.get("categories") === "tokenized-stock") {
-      filteredData = stockMarketsMock;
-    }
-    // When we perform a search
-    else if (searchParams.get("filter")) {
-      const coins = searchParams.get("filter")?.toLowerCase().split(",") || [];
-      filteredData = marketsMock.filter(({ name, ticker }) =>
-        coins.some(
-          coin => ticker.toLowerCase().includes(coin) || name.toLowerCase().includes(coin),
-        ),
-      );
-    }
-    // When we perform starred
-    else if (searchParams.get("ids")) {
-      const coins = searchParams.get("ids")?.split(",") || [];
-      filteredData = marketsMock.filter(({ id }) => coins.includes(id));
-    }
-
-    const page = parseInt(searchParams.get("page") || "0");
-    const pageSize = 10;
-    const startIndex = page * pageSize;
-    const endIndex = startIndex + pageSize;
-    const paginatedData = filteredData.slice(startIndex, endIndex);
-
-    return HttpResponse.json(paginatedData);
+  http.get("https://countervalues.live.ledger.com/v3/markets", marketsResolver),
+  // The "trending" ranking is served only by the staging countervalues API.
+  http.get("https://countervalues-service.api.ledger-test.com/v3/markets", marketsResolver),
+  http.get("https://countervalues-service.api.ledger-test.com/v3/currencies/trending", () => {
+    return HttpResponse.json(marketsMock.slice(0, 7).map(({ id }) => ({ id, supported: true })));
   }),
   http.get("https://countervalues.live.ledger.com/v3/categories/trending", () => {
     return HttpResponse.json([

--- a/apps/ledger-live-mobile/__tests__/handlers/market.ts
+++ b/apps/ledger-live-mobile/__tests__/handlers/market.ts
@@ -74,9 +74,7 @@ const marketsResolver = ({ request }: { request: Request }) => {
 
 const handlers = [
   http.get("https://countervalues.live.ledger.com/v3/markets", marketsResolver),
-  // The "trending" ranking is served only by the staging countervalues API.
-  http.get("https://countervalues-service.api.ledger-test.com/v3/markets", marketsResolver),
-  http.get("https://countervalues-service.api.ledger-test.com/v3/currencies/trending", () => {
+  http.get("https://countervalues.live.ledger.com/v3/currencies/trending", () => {
     return HttpResponse.json(marketsMock.slice(0, 7).map(({ id }) => ({ id, supported: true })));
   }),
   http.get("https://countervalues.live.ledger.com/v3/categories/trending", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/__integrations__/marketBanner.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/__integrations__/marketBanner.integration.test.tsx
@@ -30,7 +30,6 @@ jest.mock("@ledgerhq/live-common/exchange/swap/hooks/index", () => ({
   useFetchCurrencyAll: () => mockUseFetchCurrencyAll(),
 }));
 
-const COUNTERVALUES_API = "https://countervalues.live.ledger.com";
 const BUY_API = "https://buy.api.live.ledger.com/buy/v1";
 
 // Mock data for ramp catalog API
@@ -61,11 +60,7 @@ describe("MarketBanner Integration Tests", () => {
 
   describe("Feature flag handling", () => {
     it("should not render when lwmWallet40 feature flag is disabled", () => {
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, () =>
-          HttpResponse.json(MOCK_MARKET_PERFORMERS),
-        ),
-      );
+      server.use(http.get("*/v3/markets", () => HttpResponse.json(MOCK_MARKET_PERFORMERS)));
 
       renderWithReactQuery(<MarketBannerTest />, {
         overrideInitialState: withFlagOverrides({
@@ -77,11 +72,7 @@ describe("MarketBanner Integration Tests", () => {
     });
 
     it("should not render when marketBanner param is false", () => {
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, () =>
-          HttpResponse.json(MOCK_MARKET_PERFORMERS),
-        ),
-      );
+      server.use(http.get("*/v3/markets", () => HttpResponse.json(MOCK_MARKET_PERFORMERS)));
 
       renderWithReactQuery(<MarketBannerTest />, {
         overrideInitialState: withFlagOverrides({
@@ -93,11 +84,7 @@ describe("MarketBanner Integration Tests", () => {
     });
 
     it("should render when lwmWallet40 is enabled and marketBanner is true", async () => {
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, () =>
-          HttpResponse.json(MOCK_MARKET_PERFORMERS),
-        ),
-      );
+      server.use(http.get("*/v3/markets", () => HttpResponse.json(MOCK_MARKET_PERFORMERS)));
 
       renderWithReactQuery(<MarketBannerTest />, {
         overrideInitialState: withFlagOverrides({
@@ -111,11 +98,7 @@ describe("MarketBanner Integration Tests", () => {
 
   describe("Filter trigger", () => {
     const renderWithAssetDiscoverability = (assetDiscoverability: boolean) => {
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, () =>
-          HttpResponse.json(MOCK_MARKET_PERFORMERS),
-        ),
-      );
+      server.use(http.get("*/v3/markets", () => HttpResponse.json(MOCK_MARKET_PERFORMERS)));
 
       return renderWithReactQuery(<MarketBannerTest />, {
         overrideInitialState: withFlagOverrides({
@@ -178,11 +161,7 @@ describe("MarketBanner Integration Tests", () => {
     });
 
     it("should fall back to trending when favorites is active but no asset is starred", async () => {
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, () =>
-          HttpResponse.json(MOCK_MARKET_PERFORMERS),
-        ),
-      );
+      server.use(http.get("*/v3/markets", () => HttpResponse.json(MOCK_MARKET_PERFORMERS)));
 
       const { store } = renderWithReactQuery(<MarketBannerTest />, {
         overrideInitialState: state => {
@@ -208,7 +187,7 @@ describe("MarketBanner Integration Tests", () => {
     it("should request favorites with a valid pageSize (the /v3/markets endpoint only accepts 1/5/20/50)", async () => {
       let favoritesPageSize: string | null = null;
       server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, ({ request }) => {
+        http.get("*/v3/markets", ({ request }) => {
           const url = new URL(request.url);
           if (url.searchParams.get("ids")) {
             favoritesPageSize = url.searchParams.get("pageSize");
@@ -240,7 +219,7 @@ describe("MarketBanner Integration Tests", () => {
     it("ignores the persisted ranking when assetDiscoverability is off and keeps the stored preference", async () => {
       let performersSort: string | null = null;
       server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, ({ request }) => {
+        http.get("*/v3/markets", ({ request }) => {
           const sort = new URL(request.url).searchParams.get("sort");
           if (sort?.includes("price-change")) performersSort = sort;
           return HttpResponse.json(MOCK_MARKET_PERFORMERS);
@@ -271,7 +250,7 @@ describe("MarketBanner Integration Tests", () => {
   describe("Loading state", () => {
     it("should display skeleton tiles when loading", async () => {
       server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, async () => {
+        http.get("*/v3/markets", async () => {
           await new Promise(resolve => setTimeout(resolve, 1000));
           return HttpResponse.json(MOCK_MARKET_PERFORMERS);
         }),
@@ -290,9 +269,7 @@ describe("MarketBanner Integration Tests", () => {
 
   describe("Error state", () => {
     it("should display error state with icon and message when API fails", async () => {
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, () => HttpResponse.json(null, { status: 500 })),
-      );
+      server.use(http.get("*/v3/markets", () => HttpResponse.json(null, { status: 500 })));
 
       renderWithReactQuery(<MarketBannerTest />, {
         overrideInitialState: withFlagOverrides({
@@ -304,9 +281,7 @@ describe("MarketBanner Integration Tests", () => {
     });
 
     it("should not display FearAndGreed or ViewAll when in error state", async () => {
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, () => HttpResponse.json(null, { status: 500 })),
-      );
+      server.use(http.get("*/v3/markets", () => HttpResponse.json(null, { status: 500 })));
 
       renderWithReactQuery(<MarketBannerTest />, {
         overrideInitialState: withFlagOverrides({
@@ -322,11 +297,7 @@ describe("MarketBanner Integration Tests", () => {
 
   describe("Tile rendering", () => {
     it("should render market tiles with correct data", async () => {
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, () =>
-          HttpResponse.json(MOCK_MARKET_PERFORMERS),
-        ),
-      );
+      server.use(http.get("*/v3/markets", () => HttpResponse.json(MOCK_MARKET_PERFORMERS)));
 
       renderWithReactQuery(<MarketBannerTest />, {
         overrideInitialState: withFlagOverrides({
@@ -341,11 +312,7 @@ describe("MarketBanner Integration Tests", () => {
     });
 
     it("should render View All tile as the last element", async () => {
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, () =>
-          HttpResponse.json(MOCK_MARKET_PERFORMERS),
-        ),
-      );
+      server.use(http.get("*/v3/markets", () => HttpResponse.json(MOCK_MARKET_PERFORMERS)));
 
       renderWithReactQuery(<MarketBannerTest />, {
         overrideInitialState: withFlagOverrides({
@@ -358,11 +325,7 @@ describe("MarketBanner Integration Tests", () => {
     });
 
     it("should display section title", async () => {
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, () =>
-          HttpResponse.json(MOCK_MARKET_PERFORMERS),
-        ),
-      );
+      server.use(http.get("*/v3/markets", () => HttpResponse.json(MOCK_MARKET_PERFORMERS)));
 
       renderWithReactQuery(<MarketBannerTest />, {
         overrideInitialState: withFlagOverrides({
@@ -374,13 +337,56 @@ describe("MarketBanner Integration Tests", () => {
     });
   });
 
+  describe("Trending data source", () => {
+    it("requests the staging /v3/currencies/trending endpoint for the default trending ranking", async () => {
+      let trendingRequested = false;
+      server.use(
+        http.get("*/v3/currencies/trending", () => {
+          trendingRequested = true;
+          return HttpResponse.json([
+            { id: "bitcoin", supported: true },
+            { id: "ethereum", supported: true },
+          ]);
+        }),
+        http.get("*/v3/markets", () => HttpResponse.json(MOCK_MARKET_PERFORMERS)),
+      );
+
+      renderWithReactQuery(<MarketBannerTest />, {
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: {
+            enabled: true,
+            params: { marketBanner: true, assetDiscoverability: true },
+          },
+        }),
+      });
+
+      expect(await screen.findByTestId("market-banner-tile-0")).toBeVisible();
+      expect(trendingRequested).toBe(true);
+    });
+
+    it("falls back to gainers when the trending endpoint fails so the banner never breaks", async () => {
+      server.use(
+        http.get("*/v3/currencies/trending", () => HttpResponse.json(null, { status: 500 })),
+        http.get("*/v3/markets", () => HttpResponse.json(MOCK_MARKET_PERFORMERS)),
+      );
+
+      renderWithReactQuery(<MarketBannerTest />, {
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: {
+            enabled: true,
+            params: { marketBanner: true, assetDiscoverability: true },
+          },
+        }),
+      });
+
+      expect(await screen.findByTestId("market-banner-tile-0")).toBeVisible();
+      expect(screen.queryByText(/Connection failed/i)).toBeNull();
+    });
+  });
+
   describe("Analytics tracking", () => {
     it("should track tile click", async () => {
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, () =>
-          HttpResponse.json(MOCK_MARKET_PERFORMERS),
-        ),
-      );
+      server.use(http.get("*/v3/markets", () => HttpResponse.json(MOCK_MARKET_PERFORMERS)));
 
       const { user } = renderWithReactQuery(<MarketBannerTest />, {
         overrideInitialState: withFlagOverrides({
@@ -407,11 +413,7 @@ describe("MarketBanner Integration Tests", () => {
     });
 
     it("should track View All click", async () => {
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, () =>
-          HttpResponse.json(MOCK_MARKET_PERFORMERS),
-        ),
-      );
+      server.use(http.get("*/v3/markets", () => HttpResponse.json(MOCK_MARKET_PERFORMERS)));
 
       const { user } = renderWithReactQuery(<MarketBannerTest />, {
         overrideInitialState: withFlagOverrides({
@@ -428,11 +430,7 @@ describe("MarketBanner Integration Tests", () => {
     });
 
     it("should track section title click", async () => {
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, () =>
-          HttpResponse.json(MOCK_MARKET_PERFORMERS),
-        ),
-      );
+      server.use(http.get("*/v3/markets", () => HttpResponse.json(MOCK_MARKET_PERFORMERS)));
 
       const { user } = renderWithReactQuery(<MarketBannerTest />, {
         overrideInitialState: withFlagOverrides({
@@ -451,11 +449,7 @@ describe("MarketBanner Integration Tests", () => {
 
   describe("Navigation", () => {
     it("navigates to AssetDetail when aggregatedAssets is enabled", async () => {
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, () =>
-          HttpResponse.json(MOCK_MARKET_PERFORMERS),
-        ),
-      );
+      server.use(http.get("*/v3/markets", () => HttpResponse.json(MOCK_MARKET_PERFORMERS)));
 
       const { user } = renderWithReactQuery(<MarketBannerTest />, {
         overrideInitialState: withFlagOverrides({
@@ -482,11 +476,7 @@ describe("MarketBanner Integration Tests", () => {
     });
 
     it("falls back to MarketDetail when aggregatedAssets is disabled", async () => {
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, () =>
-          HttpResponse.json(MOCK_MARKET_PERFORMERS),
-        ),
-      );
+      server.use(http.get("*/v3/markets", () => HttpResponse.json(MOCK_MARKET_PERFORMERS)));
 
       const { user } = renderWithReactQuery(<MarketBannerTest />, {
         overrideInitialState: withFlagOverrides({
@@ -508,11 +498,7 @@ describe("MarketBanner Integration Tests", () => {
     });
 
     it("should navigate to market list when View All is pressed", async () => {
-      server.use(
-        http.get(`${COUNTERVALUES_API}/v3/markets`, () =>
-          HttpResponse.json(MOCK_MARKET_PERFORMERS),
-        ),
-      );
+      server.use(http.get("*/v3/markets", () => HttpResponse.json(MOCK_MARKET_PERFORMERS)));
 
       const { user } = renderWithReactQuery(<MarketBannerTest />, {
         overrideInitialState: withFlagOverrides({

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/hooks/useMarketBannerData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/hooks/useMarketBannerData.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { useMarketPerformers } from "@ledgerhq/live-common/market/hooks/useMarketPerformers";
+import { useTrendingPerformers } from "@ledgerhq/live-common/market/hooks/useTrendingPerformers";
 import { useMarketData } from "@ledgerhq/live-common/market/hooks/useMarketDataProvider";
 import { filterMarketPerformersByAvailability } from "@ledgerhq/live-common/market/utils/index";
 import {
@@ -73,21 +74,45 @@ function useMarketAvailabilityFilter() {
  * Performers-based rankings (trending / gainers → positive change, losers → negative).
  * Backed by RTK Query — no React Query dependency.
  */
-export function usePerformersBannerItems(ranking: MarketBannerRanking): MarketBannerItems {
+export function usePerformersBannerItems(
+  ranking: MarketBannerRanking,
+  options?: { skip?: boolean },
+): MarketBannerItems {
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const filterItems = useMarketAvailabilityFilter();
 
-  const { data, isError, isFetching } = useMarketPerformers({
-    sort: ranking === "losers" ? "desc" : "asc",
+  const { data, isError, isFetching } = useMarketPerformers(
+    {
+      sort: ranking === "losers" ? "desc" : "asc",
+      counterCurrency: counterValueCurrency.ticker,
+      range: TIME_RANGE,
+      limit: LIMIT,
+      top: MARKET_BANNER_TOP,
+      supported: MARKET_PERFORMERS_SUPPORTED,
+      refreshRate: MARKET_BANNER_REFRESH_RATE,
+    },
+    { skip: options?.skip },
+  );
+
+  const items = useMemo(() => filterItems(data ?? []), [filterItems, data]);
+
+  return { items, isError: isError && !isFetching };
+}
+
+/**
+ * Trending ranking → the dedicated `/v3/currencies/trending` endpoint, which returns a curated,
+ * ordered list. Availability filtering is intentionally not applied so the banner mirrors what is
+ * trending in the market. Only mounted when the trending ranking is active.
+ */
+export function useTrendingBannerItems(): MarketBannerItems {
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+
+  const { data, isError, isFetching } = useTrendingPerformers({
     counterCurrency: counterValueCurrency.ticker,
-    range: TIME_RANGE,
-    limit: LIMIT,
-    top: MARKET_BANNER_TOP,
-    supported: MARKET_PERFORMERS_SUPPORTED,
     refreshRate: MARKET_BANNER_REFRESH_RATE,
   });
 
-  const items = useMemo(() => filterItems(data ?? []), [filterItems, data]);
+  const items = useMemo(() => (data ?? []).slice(0, MARKET_BANNER_TILE_COUNT), [data]);
 
   return { items, isError: isError && !isFetching };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/index.tsx
@@ -5,7 +5,11 @@ import { useDispatch, useSelector } from "~/context/hooks";
 import { selectMarketBannerRanking, setMarketBannerRanking } from "~/reducers/marketBanner";
 import { starredMarketCoinsSelector } from "~/reducers/settings";
 import useMarketBannerViewModel from "./hooks/useMarketBannerViewModel";
-import { usePerformersBannerItems, useFavoritesBannerItems } from "./hooks/useMarketBannerData";
+import {
+  usePerformersBannerItems,
+  useFavoritesBannerItems,
+  useTrendingBannerItems,
+} from "./hooks/useMarketBannerData";
 import MarketBannerView from "./components/MarketBannerView";
 import { MarketBannerProps } from "./types";
 import { DEFAULT_RANKING_WITHOUT_DISCOVERABILITY } from "./constants";
@@ -48,6 +52,14 @@ const FavoritesBanner = ({ testID }: MarketBannerProps) => {
   return <MarketBannerSurface items={items} isError={isError} testID={testID} />;
 };
 
+const TrendingBanner = ({ testID }: MarketBannerProps) => {
+  const trending = useTrendingBannerItems();
+  // If the trending endpoint fails, fall back to gainers (sort "asc") so the banner never breaks.
+  const fallback = usePerformersBannerItems("trending", { skip: !trending.isError });
+  const { items, isError } = trending.isError ? fallback : trending;
+  return <MarketBannerSurface items={items} isError={isError} testID={testID} />;
+};
+
 const MarketBannerContent = ({ testID }: MarketBannerProps) => {
   const dispatch = useDispatch();
   const { shouldDisplayAssetDiscoverability } = useWalletFeaturesConfig("mobile");
@@ -64,11 +76,13 @@ const MarketBannerContent = ({ testID }: MarketBannerProps) => {
     }
   }, [dispatch, ranking, hasStarred]);
 
-  return ranking === "favorites" && hasStarred ? (
-    <FavoritesBanner testID={testID} />
-  ) : (
-    <PerformersBanner ranking={ranking} testID={testID} />
-  );
+  if (ranking === "favorites" && hasStarred) {
+    return <FavoritesBanner testID={testID} />;
+  }
+  if (ranking === "trending") {
+    return <TrendingBanner testID={testID} />;
+  }
+  return <PerformersBanner ranking={ranking} testID={testID} />;
 };
 
 const MarketBanner = ({ testID }: MarketBannerProps) => {

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -696,6 +696,7 @@
     "src/market/hooks/useLargeMoverCurrencies.ts",
     "src/market/hooks/useMarketDataProvider.ts",
     "src/market/hooks/useMarketPerformers.ts",
+    "src/market/hooks/useTrendingPerformers.ts",
     "src/market/state-manager/api.ts",
     "src/market/state-manager/marketApi.ts",
     "src/market/state-manager/types.ts",

--- a/libs/ledger-live-common/src/market/hooks/useTrendingPerformers.ts
+++ b/libs/ledger-live-common/src/market/hooks/useTrendingPerformers.ts
@@ -1,0 +1,16 @@
+import { TrendingPerformersParams } from "../utils/types";
+import { useGetTrendingPerformersQuery } from "../state-manager/api";
+import { REFETCH_TIME_ONE_MINUTE } from "../utils/timers";
+
+export const useTrendingPerformers = (
+  { counterCurrency, refreshRate }: TrendingPerformersParams,
+  options?: { skip?: boolean },
+) =>
+  useGetTrendingPerformersQuery(
+    { counterCurrency },
+    {
+      pollingInterval: REFETCH_TIME_ONE_MINUTE * Number(refreshRate),
+      refetchOnReconnect: true,
+      skip: options?.skip,
+    },
+  );

--- a/libs/ledger-live-common/src/market/state-manager/marketApi.test.ts
+++ b/libs/ledger-live-common/src/market/state-manager/marketApi.test.ts
@@ -5,6 +5,7 @@ import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { createTestStore } from "@tests/test-helpers/testUtils";
 import { marketApi } from "./marketApi";
+import { createMockMarketItemResponse } from "../utils/fixtures";
 
 let store: ReturnType<typeof createTestStore>;
 const server = setupServer();
@@ -236,6 +237,83 @@ describe("marketApi", () => {
       server.use(http.get("*/v3/categories/trending", () => HttpResponse.json([{ id: "x" }])));
 
       const result = await store.dispatch(getTrendingCategories.initiate());
+
+      expect(result.isError).toBe(true);
+      expect(result.data).toBeUndefined();
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe("[endpoint] getTrendingPerformers", () => {
+    const { getTrendingPerformers } = marketApi.endpoints;
+
+    const trending = (id: string, supported: boolean) => ({ id, supported });
+
+    it("hydrates only the supported trending ids and preserves the trending order", async () => {
+      const seenMarketsUrls: string[] = [];
+      server.use(
+        http.get("*/v3/currencies/trending", () =>
+          HttpResponse.json([
+            trending("solana", true),
+            trending("autonomi", false),
+            trending("bitcoin", true),
+            trending("ethereum", true),
+          ]),
+        ),
+        // Markets is returned in a different order than the trending list to prove re-ordering.
+        http.get("*/v3/markets", ({ request }) => {
+          seenMarketsUrls.push(request.url);
+          return HttpResponse.json([
+            createMockMarketItemResponse({ id: "ethereum", ticker: "ETH" }),
+            createMockMarketItemResponse({ id: "bitcoin", ticker: "BTC" }),
+            createMockMarketItemResponse({ id: "solana", ticker: "SOL" }),
+          ]);
+        }),
+      );
+
+      const result = await store.dispatch(
+        getTrendingPerformers.initiate({ counterCurrency: "usd" }),
+      );
+
+      expect(result.isSuccess).toBe(true);
+      expect(result.data?.map(item => item.id)).toEqual(["solana", "bitcoin", "ethereum"]);
+
+      expect(seenMarketsUrls).toHaveLength(1);
+      const url = new URL(seenMarketsUrls[0]);
+      expect(url.searchParams.get("to")).toBe("usd");
+      expect(url.searchParams.get("ids")).toBe("solana,bitcoin,ethereum");
+      // pageSize must be one of the discrete values the API accepts (1/5/20/50).
+      expect(url.searchParams.get("pageSize")).toBe("5");
+    });
+
+    it("returns an empty list and skips the markets call when no trending id is supported", async () => {
+      let marketsCalled = false;
+      server.use(
+        http.get("*/v3/currencies/trending", () =>
+          HttpResponse.json([trending("autonomi", false), trending("meteora", false)]),
+        ),
+        http.get("*/v3/markets", () => {
+          marketsCalled = true;
+          return HttpResponse.json([]);
+        }),
+      );
+
+      const result = await store.dispatch(
+        getTrendingPerformers.initiate({ counterCurrency: "usd" }),
+      );
+
+      expect(result.isSuccess).toBe(true);
+      expect(result.data).toEqual([]);
+      expect(marketsCalled).toBe(false);
+    });
+
+    it("returns isError when the trending response schema is invalid", async () => {
+      const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+      server.use(http.get("*/v3/currencies/trending", () => HttpResponse.json([{ id: "x" }])));
+
+      const result = await store.dispatch(
+        getTrendingPerformers.initiate({ counterCurrency: "usd" }),
+      );
 
       expect(result.isError).toBe(true);
       expect(result.data).toBeUndefined();

--- a/libs/ledger-live-common/src/market/state-manager/marketApi.test.ts
+++ b/libs/ledger-live-common/src/market/state-manager/marketApi.test.ts
@@ -283,7 +283,7 @@ describe("marketApi", () => {
       expect(url.searchParams.get("to")).toBe("usd");
       expect(url.searchParams.get("ids")).toBe("solana,bitcoin,ethereum");
       // pageSize must be one of the discrete values the API accepts (1/5/20/50).
-      expect(url.searchParams.get("pageSize")).toBe("5");
+      expect(url.searchParams.get("pageSize")).toBe("50");
     });
 
     it("returns an empty list and skips the markets call when no trending id is supported", async () => {

--- a/libs/ledger-live-common/src/market/state-manager/marketApi.ts
+++ b/libs/ledger-live-common/src/market/state-manager/marketApi.ts
@@ -27,10 +27,8 @@ import { format, formatPerformer } from "../utils/currencyFormatter";
 
 const MAX_TRENDING_CATEGORIES = 5;
 
-// The /v3/markets endpoint only accepts these discrete `pageSize` values.
-const MARKET_PAGE_SIZES = [1, 5, 20, 50];
-const resolveMarketPageSize = (count: number): number =>
-  MARKET_PAGE_SIZES.find(size => size >= count) ?? MARKET_PAGE_SIZES[MARKET_PAGE_SIZES.length - 1];
+// The /v3/markets endpoint only accepts pageSize 1 / 5 / 20 / 50; 50 covers the trending list.
+const TRENDING_MARKETS_PAGE_SIZE = 50;
 
 export const marketApi = createApi({
   reducerPath: "marketApi",
@@ -184,7 +182,7 @@ export const marketApi = createApi({
           params: {
             to: counterCurrency,
             ids: supportedIds.join(","),
-            pageSize: resolveMarketPageSize(supportedIds.length),
+            pageSize: TRENDING_MARKETS_PAGE_SIZE,
           },
         });
         if (marketsResult.error) return { error: marketsResult.error };

--- a/libs/ledger-live-common/src/market/state-manager/marketApi.ts
+++ b/libs/ledger-live-common/src/market/state-manager/marketApi.ts
@@ -157,12 +157,8 @@ export const marketApi = createApi({
       keepUnusedDataFor: (REFETCH_TIME_ONE_MINUTE * BASIC_REFETCH) / 1000,
     }),
     getTrendingPerformers: build.query<MarketItemPerformer[], TrendingPerformersQueryParams>({
-      // `/v3/currencies/trending` is only served by the staging countervalues API for now, so this
-      // endpoint targets the staging base via absolute URLs (fetchBaseQuery leaves them untouched).
       async queryFn({ counterCurrency }, _api, _extra, fetchWithBQ) {
-        const stagingBaseUrl = getEnv("LEDGER_COUNTERVALUES_API_STAGING");
-
-        const trendingResult = await fetchWithBQ(`${stagingBaseUrl}/v3/currencies/trending`);
+        const trendingResult = await fetchWithBQ("/v3/currencies/trending");
         if (trendingResult.error) return { error: trendingResult.error };
 
         const parsed = TrendingCurrenciesResponseSchema.safeParse(trendingResult.data);
@@ -184,7 +180,7 @@ export const marketApi = createApi({
         if (supportedIds.length === 0) return { data: [] };
 
         const marketsResult = await fetchWithBQ({
-          url: `${stagingBaseUrl}/v3/markets`,
+          url: "/v3/markets",
           params: {
             to: counterCurrency,
             ids: supportedIds.join(","),

--- a/libs/ledger-live-common/src/market/state-manager/marketApi.ts
+++ b/libs/ledger-live-common/src/market/state-manager/marketApi.ts
@@ -20,10 +20,17 @@ import {
   MarketPerformersQueryParams,
   MarketTrendingCategory,
   TrendingCategoriesResponseSchema,
+  TrendingCurrenciesResponseSchema,
+  TrendingPerformersQueryParams,
 } from "./types";
 import { format, formatPerformer } from "../utils/currencyFormatter";
 
 const MAX_TRENDING_CATEGORIES = 5;
+
+// The /v3/markets endpoint only accepts these discrete `pageSize` values.
+const MARKET_PAGE_SIZES = [1, 5, 20, 50];
+const resolveMarketPageSize = (count: number): number =>
+  MARKET_PAGE_SIZES.find(size => size >= count) ?? MARKET_PAGE_SIZES[MARKET_PAGE_SIZES.length - 1];
 
 export const marketApi = createApi({
   reducerPath: "marketApi",
@@ -36,6 +43,7 @@ export const marketApi = createApi({
     MarketDataTags.ChartData,
     MarketDataTags.GlobalData,
     MarketDataTags.TrendingCategories,
+    MarketDataTags.TrendingPerformers,
   ],
   endpoints: build => ({
     getMarketPerformers: build.query<MarketItemPerformer[], MarketPerformersQueryParams>({
@@ -148,6 +156,57 @@ export const marketApi = createApi({
       },
       keepUnusedDataFor: (REFETCH_TIME_ONE_MINUTE * BASIC_REFETCH) / 1000,
     }),
+    getTrendingPerformers: build.query<MarketItemPerformer[], TrendingPerformersQueryParams>({
+      // `/v3/currencies/trending` is only served by the staging countervalues API for now, so this
+      // endpoint targets the staging base via absolute URLs (fetchBaseQuery leaves them untouched).
+      async queryFn({ counterCurrency }, _api, _extra, fetchWithBQ) {
+        const stagingBaseUrl = getEnv("LEDGER_COUNTERVALUES_API_STAGING");
+
+        const trendingResult = await fetchWithBQ(`${stagingBaseUrl}/v3/currencies/trending`);
+        if (trendingResult.error) return { error: trendingResult.error };
+
+        const parsed = TrendingCurrenciesResponseSchema.safeParse(trendingResult.data);
+        if (!parsed.success) {
+          log("market", "Invalid trending currencies response schema:", {
+            errors: parsed.error.issues,
+          });
+          return {
+            error: {
+              status: "CUSTOM_ERROR",
+              error: `[Market API] Trending currencies schema validation failed: ${parsed.error.issues
+                .map(e => `${e.path.join(".")}: ${e.message}`)
+                .join(", ")}`,
+            },
+          };
+        }
+
+        const supportedIds = parsed.data.filter(currency => currency.supported).map(({ id }) => id);
+        if (supportedIds.length === 0) return { data: [] };
+
+        const marketsResult = await fetchWithBQ({
+          url: `${stagingBaseUrl}/v3/markets`,
+          params: {
+            to: counterCurrency,
+            ids: supportedIds.join(","),
+            pageSize: resolveMarketPageSize(supportedIds.length),
+          },
+        });
+        if (marketsResult.error) return { error: marketsResult.error };
+
+        const marketById = new Map(
+          (marketsResult.data as MarketItemResponse[]).map(item => [item.id, item]),
+        );
+        // Preserve the trending order returned by the API rather than the markets response order.
+        const data = supportedIds
+          .map(id => marketById.get(id))
+          .filter((item): item is MarketItemResponse => item !== undefined)
+          .map(formatPerformer);
+
+        return { data };
+      },
+      providesTags: [MarketDataTags.TrendingPerformers],
+      keepUnusedDataFor: REFETCH_TIME_ONE_MINUTE / 1000,
+    }),
   }),
 });
 
@@ -157,4 +216,5 @@ export const {
   useGetAssetChartDataQuery,
   useGetGlobalMarketDataQuery,
   useGetTrendingCategoriesQuery,
+  useGetTrendingPerformersQuery,
 } = marketApi;

--- a/libs/ledger-live-common/src/market/state-manager/types.ts
+++ b/libs/ledger-live-common/src/market/state-manager/types.ts
@@ -7,6 +7,7 @@ export enum MarketDataTags {
   ChartData = "ChartData",
   GlobalData = "GlobalData",
   TrendingCategories = "TrendingCategories",
+  TrendingPerformers = "TrendingPerformers",
 }
 
 export interface MarketPerformersQueryParams {
@@ -16,6 +17,10 @@ export interface MarketPerformersQueryParams {
   top?: number;
   sort: "asc" | "desc";
   supported: boolean;
+}
+
+export interface TrendingPerformersQueryParams {
+  counterCurrency: string;
 }
 
 export const MarketChartApiResponseSchema = z.object({
@@ -53,3 +58,13 @@ export const TrendingCategoriesResponseSchema = z.array(
 );
 
 export type MarketTrendingCategory = z.infer<typeof TrendingCategoriesResponseSchema>[number];
+
+// Raw /v3/currencies/trending response: an ordered list of { id, supported } currencies.
+export const TrendingCurrenciesResponseSchema = z.array(
+  z.object({
+    id: z.string(),
+    supported: z.boolean(),
+  }),
+);
+
+export type TrendingCurrency = z.infer<typeof TrendingCurrenciesResponseSchema>[number];

--- a/libs/ledger-live-common/src/market/utils/types.ts
+++ b/libs/ledger-live-common/src/market/utils/types.ts
@@ -112,6 +112,11 @@ export type MarketPerformersParams = {
   refreshRate?: number;
 };
 
+export type TrendingPerformersParams = {
+  counterCurrency: string;
+  refreshRate?: number;
+};
+
 export type MarketItemResponse = {
   allTimeHigh: number;
   allTimeHighDate: string;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Market banner **Trending** ranking now shows real trending coins (distinct from Gainers), in the endpoint's trending order — verify on **both desktop and mobile**
  - Only `supported` trending entries are shown
  - Gainers / Losers / Favorites rankings are unchanged
  - On trending endpoint failure, the banner falls back to Gainers (no error/empty state)

### 📝 Description

**Problem**: The market banner "Trending" ranking was a placeholder — it reused the gainers performers query (`sort: "asc"`), so "Trending" and "Gainers" displayed identical data.

**Solution**: Back "Trending" with the dedicated countervalues `/v3/currencies/trending` endpoint.

- Adds a `getTrendingPerformers` RTK Query endpoint and a `useTrendingPerformers` hook in `@ledgerhq/live-common`. The endpoint returns an ordered list of `{ id, supported }`; supported ids are hydrated via `/v3/markets`, mapped to `MarketItemPerformer`, and re-ordered to preserve the trending rank.
- Routes the **desktop** and **mobile** market banners' `trending` ranking to this source (Gainers/Losers stay on the performers query, Favorites unchanged).
- Adds the ticket-required fallback: if the trending request fails, the banner falls back to `useMarketPerformers({ sort: "asc" })` so it never breaks.

> ℹ️ The endpoint is fetched from the **production** countervalues API (the shared `marketApi` base). Until BE Core deploys `/v3/currencies/trending` to production, the request fails and the banner falls back to Gainers — no error/empty state. Once it's live in prod, Trending returns real results with no further changes.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29886](https://ledgerhq.atlassian.net/browse/LIVE-29886) (desktop) and [LIVE-32950](https://ledgerhq.atlassian.net/browse/LIVE-32950) (mobile)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29886]: https://ledgerhq.atlassian.net/browse/LIVE-29886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ