### PR TITLE
[LWDM] POC DO NOT MERGE: Authenticate swap quote queries

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
@@ -187,6 +187,7 @@ export function usePTXCustomHandlers(manifest: WebviewProps["manifest"], account
         locale,
         counterValueCurrency: counterValueCurrency.ticker,
         deviceModelId: lastSeenDevice?.modelId,
+        fetchQuoteDispatch: dispatch,
         uiHooks: {
           "custom.exchange.start": ({ exchangeParams, onSuccess, onCancel }) => {
             dispatch(

--- a/apps/ledger-live-desktop/src/renderer/reducers/rtkQueryApi.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/rtkQueryApi.ts
@@ -7,6 +7,7 @@ import { cryptoAssetsApi } from "@ledgerhq/cryptoassets/cal-client/state-manager
 import { pushDevicesApi } from "@ledgerhq/client-ids/api";
 import { cmcApi } from "@ledgerhq/live-common/cmc-client/state-manager/api";
 import { counterValuesApi } from "@ledgerhq/live-common/counterValues/state-manager/api";
+import { swapQuotesApi } from "@ledgerhq/live-common/wallet-api/Exchange/quotes/state-manager/api";
 
 // Add new RTK Query API here:
 const APIs = {
@@ -18,6 +19,7 @@ const APIs = {
   [cgApi.reducerPath]: cgApi,
   [ofacGeoBlockApi.reducerPath]: ofacGeoBlockApi,
   [pushDevicesApi.reducerPath]: pushDevicesApi,
+  [swapQuotesApi.reducerPath]: swapQuotesApi,
 };
 
 /*

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
@@ -4,6 +4,7 @@ import {
   handlers as exchangeHandlers,
   ExchangeType,
 } from "@ledgerhq/live-common/wallet-api/Exchange/server";
+import type { FetchQuotesDispatch } from "@ledgerhq/live-common/wallet-api/Exchange/quotes/state-manager/api";
 import trackingWrapper from "@ledgerhq/live-common/wallet-api/Exchange/tracking";
 import {
   WalletAPICustomHandlers,
@@ -107,6 +108,7 @@ export function useCustomExchangeHandlers({
   const deviceRef = useRef<Device | undefined>(undefined);
   const syncAccountById = useSyncAccountById();
   const dispatch = useDispatch();
+  const fetchQuoteDispatch = dispatch as unknown as FetchQuotesDispatch;
   const { isEnabled } = useWalletFeaturesConfig("mobile");
   const flags = useMemo(() => ({ wallet40Ux: isEnabled }), [isEnabled]);
   const featureFlagsMap = useFeatureFlags();
@@ -346,6 +348,7 @@ export function useCustomExchangeHandlers({
         locale,
         counterValueCurrency: counterValueCurrency.ticker,
         deviceModelId: lastSeenDevice?.modelId,
+        fetchQuoteDispatch,
         uiHooks: {
           "custom.exchange.start": ({ exchangeParams, onSuccess, onCancel }) => {
             const promiseId = `start-${Date.now()}`;
@@ -550,6 +553,7 @@ export function useCustomExchangeHandlers({
     getManifestById,
     getAccount,
     dispatch,
+    fetchQuoteDispatch,
     route.name,
     returnToPreviousScreenOnClose,
   ]);

--- a/apps/ledger-live-mobile/src/context/rtkQueryApi.ts
+++ b/apps/ledger-live-mobile/src/context/rtkQueryApi.ts
@@ -7,6 +7,7 @@ import { cryptoAssetsApi } from "@ledgerhq/cryptoassets/cal-client/state-manager
 import { pushDevicesApi } from "@ledgerhq/client-ids/api";
 import { cmcApi } from "@ledgerhq/live-common/cmc-client/state-manager/api";
 import { counterValuesApi } from "@ledgerhq/live-common/counterValues/state-manager/api";
+import { swapQuotesApi } from "@ledgerhq/live-common/wallet-api/Exchange/quotes/state-manager/api";
 // Add new RTK Query API here:
 const APIs = {
   [assetsDataApi.reducerPath]: assetsDataApi,
@@ -17,6 +18,7 @@ const APIs = {
   [marketApi.reducerPath]: marketApi,
   [ofacGeoBlockApi.reducerPath]: ofacGeoBlockApi,
   [pushDevicesApi.reducerPath]: pushDevicesApi,
+  [swapQuotesApi.reducerPath]: swapQuotesApi,
 };
 
 /*

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -263,6 +263,7 @@
     "@ledgerhq/live-signer-cosmos": "workspace:^",
     "@ledgerhq/live-wallet": "workspace:^",
     "@ledgerhq/logs": "workspace:^",
+    "@ledgerhq/rtk-query-auth": "workspace:^",
     "@ledgerhq/speculos-device-controller": "catalog:",
     "@ledgerhq/speculos-transport": "workspace:^",
     "@ledgerhq/wallet-api-acre-module": "workspace:^",

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/getQuotes.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/getQuotes.test.ts
@@ -1,10 +1,12 @@
 import BigNumber from "bignumber.js";
 
 import { getQuotes, type GetQuotesContext } from "./getQuotes";
+import { fetchAuthenticatedQuotes } from "./service/fetchAuthenticatedQuotes";
 import { fetchQuotes } from "./service/fetchQuotes";
 import { fetchAndMergeProviderData } from "../../../exchange/providers/swap";
 import { fetchNetworkFeeContext } from "./fetchNetworkFeeContext";
 import { computeFeeEstimate } from "./normalizer/networkFeeEstimate";
+import type { FetchQuotesDispatch } from "./state-manager/api";
 import type { RawQuote, RawQuoteError } from "./service/types";
 import {
   ProviderErrorCodes,
@@ -16,6 +18,10 @@ import {
 
 jest.mock("./service/fetchQuotes", () => ({
   fetchQuotes: jest.fn(),
+}));
+
+jest.mock("./service/fetchAuthenticatedQuotes", () => ({
+  fetchAuthenticatedQuotes: jest.fn(),
 }));
 
 jest.mock("../../../exchange/providers/swap", () => ({
@@ -46,6 +52,7 @@ jest.mock("@ledgerhq/live-env", () => ({
 }));
 
 const fetchQuotesMock = jest.mocked(fetchQuotes);
+const fetchAuthenticatedQuotesMock = jest.mocked(fetchAuthenticatedQuotes);
 const fetchAndMergeProviderDataMock = jest.mocked(fetchAndMergeProviderData);
 const fetchNetworkFeeContextMock = jest.mocked(fetchNetworkFeeContext);
 const computeFeeEstimateMock = jest.mocked(computeFeeEstimate);
@@ -107,6 +114,34 @@ describe("getQuotes", () => {
     jest.clearAllMocks();
     fetchAndMergeProviderDataMock.mockResolvedValue({});
     fetchNetworkFeeContextMock.mockResolvedValue(null);
+  });
+
+  it("uses the Axios quote service when no authenticated dispatch is available", async () => {
+    fetchQuotesMock.mockResolvedValue({ rawQuotes: [], providerErrors: [] });
+
+    await getQuotes(makeArgs("ethereum", "bitcoin"), emptyContext);
+
+    expect(fetchQuotesMock).toHaveBeenCalledTimes(1);
+    expect(fetchQuotesMock).toHaveBeenCalledWith(expect.any(Object), "usd");
+    expect(fetchAuthenticatedQuotesMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the authenticated quote service when dispatch is available", async () => {
+    const fetchQuoteDispatch = jest.fn() as unknown as FetchQuotesDispatch;
+    fetchAuthenticatedQuotesMock.mockResolvedValue({ rawQuotes: [], providerErrors: [] });
+
+    await getQuotes(makeArgs("ethereum", "bitcoin"), {
+      ...emptyContext,
+      fetchQuoteDispatch,
+    });
+
+    expect(fetchAuthenticatedQuotesMock).toHaveBeenCalledTimes(1);
+    expect(fetchAuthenticatedQuotesMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      "usd",
+      fetchQuoteDispatch,
+    );
+    expect(fetchQuotesMock).not.toHaveBeenCalled();
   });
 
   it("returns a global error when quote input cannot be resolved", async () => {
@@ -417,10 +452,8 @@ describe("getQuotes", () => {
       fetchQuotesMock.mockResolvedValue({ rawQuotes: [makeRawQuote()], providerErrors: [] });
 
       await getQuotes(makeArgs("ethereum", "bitcoin", { amount: "1.5" }), {
+        ...emptyContext,
         accounts: [],
-        spotPrices: {},
-        locale: "en",
-        counterValueCurrency: "usd",
       });
 
       expect(fetchNetworkFeeContextMock).toHaveBeenCalledTimes(1);

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/getQuotes.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/getQuotes.ts
@@ -8,7 +8,9 @@ import { computeLedgerLiveVersionCompatibilityError } from "./computeLedgerLiveV
 import { computeQuotesErrors } from "./computeQuotesErrors";
 import { computeQuotesWarnings } from "./computeQuotesWarnings";
 import { fetchNetworkFeeContext } from "./fetchNetworkFeeContext";
+import { fetchAuthenticatedQuotes } from "./service/fetchAuthenticatedQuotes";
 import { fetchQuotes } from "./service/fetchQuotes";
+import type { FetchQuotesDispatch } from "./state-manager/api";
 import { computeFeeEstimate } from "./normalizer/networkFeeEstimate";
 import { buildFormatContext } from "./normalizer/buildFormatContext";
 import { normalizeQuote } from "./normalizer";
@@ -54,6 +56,8 @@ import { resolveQuotesInput } from "./resolveQuotesInput";
  *     quote warnings can include device-specific incompatibility signals.
  *   - `appVersion`: optional caller platform/version. When present, quote
  *     errors can include Ledger Live version incompatibility signals.
+ *   - `fetchQuoteDispatch`: optional Redux dispatch from the host store.
+ *     When present, quotes are fetched through the authenticated RTK Query endpoint.
  *   - `highValueLossThreshold`: optional ratio used to flag quotes whose
  *     receive-side fiat value is below the configured send-side threshold.
  */
@@ -67,6 +71,7 @@ export type GetQuotesContext = {
     platform: QuotesAppPlatform;
     version: string | null;
   };
+  fetchQuoteDispatch?: FetchQuotesDispatch;
   highValueLossThreshold?: number;
 };
 
@@ -119,10 +124,13 @@ export async function getQuotes(
     receiveParentCurrencyId,
   });
 
-  const { rawQuotes, providerErrors } = await fetchQuotes(
-    resolvedArgs,
-    context.counterValueCurrency,
-  );
+  const { rawQuotes, providerErrors } = context.fetchQuoteDispatch
+    ? await fetchAuthenticatedQuotes(
+        resolvedArgs,
+        context.counterValueCurrency,
+        context.fetchQuoteDispatch,
+      )
+    : await fetchQuotes(resolvedArgs, context.counterValueCurrency);
 
   // Drop every successful quote when the pair is on the wallet-side blocklist
   // and skip the provider-data fetch (CAL + CDN) entirely since nothing would

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/service/fetchAuthenticatedQuotes.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/service/fetchAuthenticatedQuotes.test.ts
@@ -1,0 +1,148 @@
+import { ProviderErrorCodes } from "../types";
+import { swapQuotesApi, type FetchQuotesDispatch } from "../state-manager/api";
+import { fetchAuthenticatedQuotes } from "./fetchAuthenticatedQuotes";
+import type { RawQuote, RawQuoteAPIResponse, RawQuoteError } from "./types";
+
+jest.mock(
+  "@ledgerhq/rtk-query-auth",
+  () => ({
+    createAuthenticatedBaseQuery: jest.fn(() => jest.fn()),
+  }),
+  { virtual: true },
+);
+
+function makeArgs(): Parameters<typeof fetchAuthenticatedQuotes>[0] {
+  return {
+    providers: ["lifi", "okx"],
+    data: {
+      amount: "100000000",
+      sendAccountId: "send-account",
+      receiveAccountId: "receive-account",
+      sendAddress: "0xfrom",
+      receiveAddress: "0xto",
+      sendCurrencyId: "bitcoin",
+      receiveCurrencyId: "ethereum",
+      networkFeesCurrencyId: "ethereum",
+      slippage: 0.5,
+    },
+    headers: [["x-custom-header", "custom-value"]],
+  };
+}
+
+const rawQuote: RawQuote = {
+  provider: "lifi",
+  providerType: "DEX",
+  amountFrom: 1,
+  amountTo: 0.99,
+  exchangeRate: 0.99,
+  slippage: 1,
+  type: "float",
+  networkFees: { currency: "ethereum" },
+  tags: { isRegistrationRequired: false, isTokenApprovalRequired: false },
+  key: "lifi-key",
+  liquiditySource: "AMM",
+};
+
+const providerError: RawQuoteError = {
+  code: ProviderErrorCodes.AMOUNT_OFF_LIMITS,
+  type: "float",
+  provider: "okx",
+  message: "amount out of range",
+  parameter: { minAmount: "200000000" },
+};
+
+function makeQueryResult({
+  data,
+  error,
+}: {
+  data?: RawQuoteAPIResponse;
+  error?: unknown;
+}): ReturnType<FetchQuotesDispatch> {
+  return {
+    abort: jest.fn(),
+    unsubscribe: jest.fn(),
+    unwrap: jest.fn(() => (error ? Promise.reject(error) : Promise.resolve(data ?? []))),
+  };
+}
+
+function makeDispatch(
+  queryResult: ReturnType<FetchQuotesDispatch>,
+): jest.MockedFunction<FetchQuotesDispatch> {
+  return jest.fn<ReturnType<FetchQuotesDispatch>, Parameters<FetchQuotesDispatch>>(
+    () => queryResult,
+  );
+}
+
+describe("fetchAuthenticatedQuotes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("splits successful quote rows from provider error rows", async () => {
+    const initiateSpy = jest.spyOn(swapQuotesApi.endpoints.getSwapQuotes, "initiate");
+    const queryResult = makeQueryResult({ data: [rawQuote, providerError] });
+    const dispatch = makeDispatch(queryResult);
+
+    const result = await fetchAuthenticatedQuotes(makeArgs(), "usd", dispatch);
+
+    expect(result).toEqual({
+      rawQuotes: [rawQuote],
+      providerErrors: [providerError],
+    });
+    expect(initiateSpy).toHaveBeenCalledWith(
+      {
+        headers: {
+          Accept: "application/json",
+          "x-custom-header": "custom-value",
+        },
+        params: expect.any(URLSearchParams),
+      },
+      { forceRefetch: true, subscribe: false },
+    );
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(queryResult.unsubscribe).toHaveBeenCalledTimes(1);
+
+    const request = initiateSpy.mock.calls[0][0];
+    expect(request.params.get("from")).toBe("bitcoin");
+    expect(request.params.get("to")).toBe("ethereum");
+    expect(request.params.get("providers-whitelist")).toBe("lifi,okx");
+    expect(request.params.get("fiatForCounterValue")).toBe("usd");
+    expect(request.params.get("currencyTicker")).toBe("usd");
+    expect(request.params.get("networkFeesCurrency")).toBe("ethereum");
+    expect(request.params.get("slippage")).toBe("0.5");
+  });
+
+  it("returns an empty result when the authenticated query response is not OK", async () => {
+    const queryResult = makeQueryResult({ error: { status: 500 } });
+    const dispatch = makeDispatch(queryResult);
+
+    await expect(fetchAuthenticatedQuotes(makeArgs(), "usd", dispatch)).resolves.toEqual({
+      rawQuotes: [],
+      providerErrors: [],
+    });
+    expect(queryResult.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows aborted requests", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const abortError = { name: "AbortError", message: "cancelled" };
+    const queryResult = makeQueryResult({ error: abortError });
+    const dispatch = makeDispatch(queryResult);
+
+    await expect(
+      fetchAuthenticatedQuotes({ ...makeArgs(), signal: controller.signal }, "usd", dispatch),
+    ).rejects.toBe(abortError);
+    expect(queryResult.abort).toHaveBeenCalledTimes(1);
+    expect(queryResult.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows network failures without an HTTP status", async () => {
+    const networkError = { status: "FETCH_ERROR", error: "network failure" };
+    const queryResult = makeQueryResult({ error: networkError });
+    const dispatch = makeDispatch(queryResult);
+
+    await expect(fetchAuthenticatedQuotes(makeArgs(), "usd", dispatch)).rejects.toBe(networkError);
+    expect(queryResult.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/service/fetchAuthenticatedQuotes.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/service/fetchAuthenticatedQuotes.ts
@@ -1,0 +1,103 @@
+import type { GetQuotesArgs } from "../types";
+import type { ResolvedQuotesInput } from "../resolveQuotesInput";
+import type { FetchQuotesResult, RawQuote, RawQuoteError } from "./types";
+import { swapQuotesApi, type FetchQuotesDispatch } from "../state-manager/api";
+
+type FetchAuthenticatedQuotesArgs = Omit<GetQuotesArgs, "data"> & {
+  data: ResolvedQuotesInput;
+};
+
+function isSwapQuotesAbortError(error: unknown): boolean {
+  return (
+    typeof error === "object" && error !== null && "name" in error && error.name === "AbortError"
+  );
+}
+
+function isSwapQuotesHttpError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof error.status === "number"
+  );
+}
+
+export async function fetchAuthenticatedQuotes(
+  args: FetchAuthenticatedQuotesArgs,
+  counterValueCurrency: string,
+  dispatch: FetchQuotesDispatch,
+): Promise<FetchQuotesResult> {
+  const { providers, data: quotesInput, headers: customHeaders, signal } = args;
+
+  const searchParams = new URLSearchParams();
+  const requiredParams: Record<string, string> = {
+    amountFrom: quotesInput.amount,
+    displayLanguage: "en",
+    lang: "en",
+    theme: "dark",
+    "providers-whitelist": providers.join(","),
+    fiatForCounterValue: counterValueCurrency,
+    currencyTicker: counterValueCurrency,
+    networkFees: "0",
+    uniswapOrderType: quotesInput.uniswapOrderType ?? "classic",
+    from: quotesInput.sendCurrencyId,
+    to: quotesInput.receiveCurrencyId,
+    fromAccountId: quotesInput.sendAccountId,
+    addressFrom: quotesInput.sendAddress,
+    addressTo: quotesInput.receiveAddress,
+  };
+  for (const [key, value] of Object.entries(requiredParams)) {
+    searchParams.set(key, value);
+  }
+
+  if (quotesInput.networkFeesCurrencyId) {
+    searchParams.set("networkFeesCurrency", quotesInput.networkFeesCurrencyId);
+  }
+
+  if (quotesInput.slippage != null) {
+    searchParams.set("slippage", quotesInput.slippage.toString());
+  }
+
+  const requestHeaders: Record<string, string> = {
+    Accept: "application/json",
+    ...(customHeaders ? Object.fromEntries(customHeaders) : {}),
+  };
+
+  const queryResult = dispatch(
+    swapQuotesApi.endpoints.getSwapQuotes.initiate(
+      { params: searchParams, headers: requestHeaders },
+      {
+        forceRefetch: true,
+        subscribe: false,
+      },
+    ),
+  );
+  const abortQuery = () => queryResult.abort();
+
+  if (signal?.aborted) {
+    abortQuery();
+  } else {
+    signal?.addEventListener("abort", abortQuery, { once: true });
+  }
+
+  try {
+    const data: Array<RawQuote | RawQuoteError> = (await queryResult.unwrap()) ?? [];
+    const rawQuotes = data.filter((q): q is RawQuote => !("code" in q));
+    const providerErrors = data.filter((q): q is RawQuoteError => "code" in q);
+
+    return { rawQuotes, providerErrors };
+  } catch (error) {
+    if (isSwapQuotesAbortError(error)) {
+      throw error;
+    }
+
+    if (isSwapQuotesHttpError(error)) {
+      return { rawQuotes: [], providerErrors: [] };
+    }
+
+    throw error;
+  } finally {
+    signal?.removeEventListener("abort", abortQuery);
+    queryResult.unsubscribe();
+  }
+}

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/service/fetchQuotes.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/service/fetchQuotes.test.ts
@@ -3,11 +3,12 @@ import axios from "axios";
 import { getSwapAPIBaseURL } from "../../../../exchange/swap";
 import { ProviderErrorCodes } from "../types";
 import { fetchQuotes } from "./fetchQuotes";
+import type { RawQuote, RawQuoteError } from "./types";
 
 jest.mock("axios");
 
 jest.mock("../../../../exchange/swap", () => ({
-  getSwapAPIBaseURL: jest.fn(),
+  getSwapAPIBaseURL: jest.fn(() => "https://swap.test"),
 }));
 
 const axiosGetMock = jest.mocked(axios.get);
@@ -26,9 +27,34 @@ function makeArgs(): Parameters<typeof fetchQuotes>[0] {
       receiveAddress: "0xto",
       sendCurrencyId: "bitcoin",
       receiveCurrencyId: "ethereum",
+      networkFeesCurrencyId: "ethereum",
+      slippage: 0.5,
     },
+    headers: [["x-custom-header", "custom-value"]],
   };
 }
+
+const rawQuote: RawQuote = {
+  provider: "lifi",
+  providerType: "DEX",
+  amountFrom: 1,
+  amountTo: 0.99,
+  exchangeRate: 0.99,
+  slippage: 1,
+  type: "float",
+  networkFees: { currency: "ethereum" },
+  tags: { isRegistrationRequired: false, isTokenApprovalRequired: false },
+  key: "lifi-key",
+  liquiditySource: "AMM",
+};
+
+const providerError: RawQuoteError = {
+  code: ProviderErrorCodes.AMOUNT_OFF_LIMITS,
+  type: "float",
+  provider: "okx",
+  message: "amount out of range",
+  parameter: { minAmount: "200000000" },
+};
 
 describe("fetchQuotes", () => {
   beforeEach(() => {
@@ -39,26 +65,6 @@ describe("fetchQuotes", () => {
   });
 
   it("splits successful quote rows from provider error rows", async () => {
-    const rawQuote = {
-      provider: "lifi",
-      providerType: "DEX",
-      amountFrom: 1,
-      amountTo: 0.99,
-      exchangeRate: 0.99,
-      slippage: 1,
-      type: "float",
-      networkFees: { currency: "ethereum" },
-      tags: { isRegistrationRequired: false, isTokenApprovalRequired: false },
-      key: "lifi-key",
-      liquiditySource: "AMM",
-    };
-    const providerError = {
-      code: ProviderErrorCodes.AMOUNT_OFF_LIMITS,
-      type: "float",
-      provider: "okx",
-      message: "amount out of range",
-      parameter: { minAmount: "200000000" },
-    };
     axiosGetMock.mockResolvedValue({ data: [rawQuote, providerError] });
 
     const result = await fetchQuotes(makeArgs(), "usd");
@@ -70,7 +76,10 @@ describe("fetchQuotes", () => {
     expect(axiosGetMock).toHaveBeenCalledWith(
       "https://swap.test/quote",
       expect.objectContaining({
-        headers: expect.objectContaining({ Accept: "application/json" }),
+        headers: expect.objectContaining({
+          Accept: "application/json",
+          "x-custom-header": "custom-value",
+        }),
         params: expect.any(URLSearchParams),
       }),
     );
@@ -81,6 +90,11 @@ describe("fetchQuotes", () => {
     }
     expect(requestParams.get("from")).toBe("bitcoin");
     expect(requestParams.get("to")).toBe("ethereum");
+    expect(requestParams.get("providers-whitelist")).toBe("lifi,okx");
+    expect(requestParams.get("fiatForCounterValue")).toBe("usd");
+    expect(requestParams.get("currencyTicker")).toBe("usd");
+    expect(requestParams.get("networkFeesCurrency")).toBe("ethereum");
+    expect(requestParams.get("slippage")).toBe("0.5");
   });
 
   it("returns an empty result when the quote HTTP response is not OK", async () => {

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/state-manager/api.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/state-manager/api.ts
@@ -1,0 +1,37 @@
+import { createApi } from "@reduxjs/toolkit/query/react";
+import { createAuthenticatedBaseQuery } from "@ledgerhq/rtk-query-auth";
+
+import { getSwapAPIBaseURL } from "../../../../exchange/swap";
+import type { RawQuoteAPIResponse } from "../service/types";
+
+export type FetchSwapQuotesRequest = {
+  params: URLSearchParams;
+  headers: Record<string, string>;
+};
+
+export const swapQuotesApi = createApi({
+  reducerPath: "swapQuotesApi",
+  baseQuery: createAuthenticatedBaseQuery({
+    baseUrl: getSwapAPIBaseURL(),
+  }),
+  endpoints: build => ({
+    getSwapQuotes: build.query<RawQuoteAPIResponse, FetchSwapQuotesRequest>({
+      query: request => ({
+        url: `quote?${request.params.toString()}`,
+        method: "GET",
+        headers: request.headers,
+      }),
+      keepUnusedDataFor: 0,
+    }),
+  }),
+});
+
+export type FetchSwapQuotesQueryResult = {
+  abort(): void;
+  unsubscribe(): void;
+  unwrap(): Promise<RawQuoteAPIResponse | undefined>;
+};
+
+export type FetchQuotesDispatch = (
+  action: ReturnType<typeof swapQuotesApi.endpoints.getSwapQuotes.initiate>,
+) => FetchSwapQuotesQueryResult;

--- a/libs/ledger-live-common/src/wallet-api/Exchange/server.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/server.ts
@@ -66,6 +66,7 @@ import { SwapError } from "./SwapError";
 import { getQuotes } from "./quotes";
 import { resolveQuotesInput } from "./quotes/resolveQuotesInput";
 import { fetchSpotPrices } from "./quotes/service/fetchSpotPrices";
+import type { FetchQuotesDispatch } from "./quotes/state-manager/api";
 import {
   getTransactionStatus,
   type GetTransactionStatusResponse,
@@ -197,6 +198,7 @@ export const handlers = ({
   locale,
   counterValueCurrency,
   deviceModelId,
+  fetchQuoteDispatch,
   uiHooks: {
     "custom.exchange.start": uiExchangeStart,
     "custom.exchange.complete": uiExchangeComplete,
@@ -213,6 +215,7 @@ export const handlers = ({
   locale: string;
   counterValueCurrency: string;
   deviceModelId?: DeviceModelId;
+  fetchQuoteDispatch?: FetchQuotesDispatch;
   uiHooks: ExchangeUiHooks;
 }) =>
   ({
@@ -800,6 +803,7 @@ export const handlers = ({
           locale,
           counterValueCurrency,
           deviceModelId,
+          fetchQuoteDispatch,
         });
       },
     ),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8124,6 +8124,9 @@ importers:
       '@ledgerhq/logs':
         specifier: workspace:^
         version: link:../ledgerjs/packages/logs
+      '@ledgerhq/rtk-query-auth':
+        specifier: workspace:^
+        version: link:../../shared/rtk-query-auth
       '@ledgerhq/speculos-device-controller':
         specifier: 'catalog:'
         version: 0.3.0(@ledgerhq/device-management-kit@1.6.0(rxjs@7.8.2))


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This is just a POC (stacked on #18790) to test the authentication and the createAuthenticatedBaseQuery before [LIVE-31805] is implemented.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31805]: https://ledgerhq.atlassian.net/browse/LIVE-31805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ