### PR TITLE
coin-quantova: first NIST post-quantum chain integration for Ledger Live (Dilithium/Falcon/SPHINCS+, via qweb3.js)

### DIFF
--- a/libs/coin-modules/coin-quantova/README.md
+++ b/libs/coin-modules/coin-quantova/README.md
@@ -1,0 +1,100 @@
+# @ledgerhq/coin-quantova
+
+Coin module for **Quantova** — a post-quantum Layer-1 blockchain (Substrate-based,
+`stable2506-pq`). Native asset **QTOV** (18 decimals); testnet asset **TQTOV**.
+
+> **Status: proposal / work-in-progress.** This module implements the host-side
+> integration (accounts, address codec, the `q_` JSON-RPC client, transaction model,
+> and the device-signer contract). It is opened as a **draft** because it depends on a
+> device-side capability Ledger does not ship yet — **post-quantum signing** (see
+> "Open requirement" below). We are raising it to start that conversation, not to merge
+> as-is.
+
+## Why Quantova is different
+
+Quantova removes the elliptic curve from the trust base. Accounts are **not** secured
+by Ed25519/secp256k1; every account is secured by one of three NIST post-quantum
+signature schemes, and a fourth PQ algorithm secures the encrypted lane:
+
+| Algorithm | NIST std | Role |
+| --- | --- | --- |
+| CRYSTALS-Dilithium | ML-DSA (FIPS 204) | account signatures |
+| Falcon | FN-DSA (FIPS 206) | account signatures |
+| SPHINCS+ | SLH-DSA (FIPS 205) | account signatures |
+| ML-KEM-768 | FIPS 203 | QTE encrypted-lane key encapsulation |
+
+Hashing is SHA3-256 throughout.
+
+## Address format
+
+A Quantova address is derived from the account's PQ public key:
+
+```
+pubkey --SHA3-256--> digest[0..20]            (20-byte H160 body)
+body[0] = 0x40                                 ("Q" brand byte)
+AccountId32 = body[0..20] || 0xEE * 12         (0xEE = QVM account-mapping marker)
+display     = Bech32m("q", body)  ->  "Q1..."  (canonical user-facing form)
+```
+
+So every valid address begins with `Q`. The canonical user-facing form is the
+**Q-branded Bech32m** string (`Q1…`); the hex H160 body (`Q<40-hex>` / `0x<40-hex>`)
+is also accepted on the wire. This module's `logic/address.ts` implements both.
+
+> **Important for Ledger Live display:** Quantova advertises `ss58Format = 42` for
+> compatibility, but the canonical address is the `Q1…` Bech32m form, **not** a generic
+> `5…` SS58 string. A device/host must render `Q1…` so a user can match what their
+> wallet shows.
+
+## What this module provides (host side)
+
+- `logic/address.ts` — Q-branded Bech32m + hex H160 address encode/decode/validate.
+- `network/node.ts` — a thin client over Quantova's `q_` JSON-RPC namespace
+  (`q_getBalance`, `q_blockNumber`, `q_getTransactionCount`, `q_sendRawTransaction`,
+  `q_feeHistory`, …).
+- `types/` — the Quantova transaction model and the **PQ signer contract**.
+- `config.ts` / `constants.ts` — currency parameters (QTOV/TQTOV, 18 decimals, RPC, the
+  `CheckMetadataHash` transaction-extension metadata).
+- `signer/` — the `getAddress` / `signTransaction` resolver Ledger Live calls.
+
+## Clear-signing readiness (RFC-78 / merkleized metadata)
+
+Quantova's runtime integrates the `frame_metadata_hash_extension::CheckMetadataHash`
+transaction extension (RFC-78), and release builds bake a metadata digest
+(`enable_metadata_hash("QTOV", 18)`). This is the prerequisite the generic Polkadot
+Ledger app uses to clear-sign Substrate extrinsics against a metadata hash. On Quantova
+this extension is currently constructed in **disabled** mode for native transactions; it
+would be set to **enabled** for the device-signed path so the device can verify
+amount/asset/recipient instead of blind-signing.
+
+## Open requirement — device-side post-quantum signing
+
+The host module is functional, but the **signature itself must be produced on the Ledger
+device**, and no Ledger device app today can produce a Dilithium / Falcon / SPHINCS+
+signature. The `signer` contract here (`types/signer.ts`) defines exactly what the device
+app must return:
+
+```ts
+getAddress(path):  { publicKey /* PQ pubkey */, address /* Q1… */ }
+signTransaction(path, payload):  QSignature   // SPHINCS | FALCON | DILITHIUM
+```
+
+We understand from Ledger's published research that PQ signing on the current Secure
+Element is constrained (RAM, signing time, side-channel hardening) and that Ledger's
+direction is **hybrid (classical + PQ) signing**. We are flexible on the path and would
+value Ledger's guidance:
+
+1. a dedicated `app-quantova` device app implementing one or more PQ schemes (Dilithium
+   is the most SE-friendly of the three), and/or
+2. a **hybrid** account option, where the chain accepts a classical Ledger signature
+   alongside a PQ co-signature, aligned with Ledger's hybrid roadmap, and/or
+3. extending the generic Polkadot app once a PQ scheme is available on-device.
+
+Until one of those exists, this module cannot complete an end-to-end signature; it is
+intentionally a draft and a starting point for that collaboration.
+
+## References
+
+- Quantova runtime `CheckMetadataHash` wiring: `runtime/src/lib.rs`,
+  `runtime/build.rs`, `runtime/src/qvm_tx.rs`.
+- Quantova address derivation: `primitives/account` (`QSigner`, `QSignature`).
+- RFC-78 merkleized metadata: paritytech/polkadot-sdk #4274.

--- a/libs/coin-modules/coin-quantova/README.md
+++ b/libs/coin-modules/coin-quantova/README.md
@@ -45,16 +45,40 @@ is also accepted on the wire. This module's `logic/address.ts` implements both.
 > `5…` SS58 string. A device/host must render `Q1…` so a user can match what their
 > wallet shows.
 
-## What this module provides (host side)
+## Architecture
 
-- `logic/address.ts` — Q-branded Bech32m + hex H160 address encode/decode/validate.
-- `network/node.ts` — a thin client over Quantova's `q_` JSON-RPC namespace
-  (`q_getBalance`, `q_blockNumber`, `q_getTransactionCount`, `q_sendRawTransaction`,
-  `q_feeHistory`, …).
-- `types/` — the Quantova transaction model and the **PQ signer contract**.
-- `config.ts` / `constants.ts` — currency parameters (QTOV/TQTOV, 18 decimals, RPC, the
-  `CheckMetadataHash` transaction-extension metadata).
-- `signer/` — the `getAddress` / `signTransaction` resolver Ledger Live calls.
+```
+src/
+  pq/                     ← post-quantum primitives
+    schemes.ts            scheme registry (SPHINCS+=0, Falcon=1, Dilithium=2; sizes, NIST ids)
+    qsignature.ts         on-chain QSignature envelope codec (+ SCALE compact) — tested
+    keygen.ts             PQ key-gen + signing via qweb3.js (adapter)
+  logic/
+    address.ts            Q-branded Bech32m + hex H160 codec — tested
+    transaction/
+      signTransaction.ts  craft payload (CheckMetadataHash enabled) → sign → serialize
+  network/node.ts         q_ JSON-RPC client
+  signer/
+    softwareSigner.ts     reference signer (qweb3.js) — produces REAL valid signatures
+    deviceSigner.ts       device contract + APDU placeholder (the app-quantova target)
+  config.ts / constants.ts  QTOV/TQTOV, 18 decimals, ss58, metadata-hash params
+```
+
+### Key-gen & signing flow (qweb3.js)
+
+Quantova's **qweb3.js** SDK (`@quantova/keyring`, `@quantova/util-crypto`,
+`@quantova/falcon-wasm`) provides the audited PQ keyring and primitives used by every
+Quantova signer. `pq/keygen.ts` wraps it behind a `QPair` contract; `signer/softwareSigner.ts`
+implements the full `QuantovaSigner` with it, producing **valid `QSignature` envelopes the
+chain accepts** — i.e. the byte-exact spec an on-device app must reproduce. Both the software
+reference and a future device app are interchangeable behind the one `QuantovaSigner`
+interface.
+
+### Will it affect other Ledger assets? No.
+
+The integration is purely additive and isolated at both layers (a new host package + a
+sandboxed BOLOS device app). Full detail — including the device-app isolation model — is in
+**[`docs/DEVICE-INTEGRATION.md`](./docs/DEVICE-INTEGRATION.md)**.
 
 ## Clear-signing readiness (RFC-78 / merkleized metadata)
 

--- a/libs/coin-modules/coin-quantova/README.md
+++ b/libs/coin-modules/coin-quantova/README.md
@@ -1,12 +1,12 @@
 # @ledgerhq/coin-quantova
 
-Coin module for **Quantova** — a post-quantum Layer-1 blockchain (Substrate-based,
+Coin module for **Quantova** - a post-quantum Layer-1 blockchain (Substrate-based,
 `stable2506-pq`). Native asset **QTOV** (18 decimals); testnet asset **TQTOV**.
 
 > **Status: proposal / work-in-progress.** This module implements the host-side
 > integration (accounts, address codec, the `q_` JSON-RPC client, transaction model,
 > and the device-signer contract). It is opened as a **draft** because it depends on a
-> device-side capability Ledger does not ship yet — **post-quantum signing** (see
+> device-side capability Ledger does not ship yet - **post-quantum signing** (see
 > "Open requirement" below). We are raising it to start that conversation, not to merge
 > as-is.
 
@@ -37,30 +37,30 @@ display     = Bech32m("q", body)  ->  "Q1..."  (canonical user-facing form)
 ```
 
 So every valid address begins with `Q`. The canonical user-facing form is the
-**Q-branded Bech32m** string (`Q1…`); the hex H160 body (`Q<40-hex>` / `0x<40-hex>`)
+**Q-branded Bech32m** string (`Q1...`); the hex H160 body (`Q<40-hex>` / `0x<40-hex>`)
 is also accepted on the wire. This module's `logic/address.ts` implements both.
 
 > **Important for Ledger Live display:** Quantova advertises `ss58Format = 42` for
-> compatibility, but the canonical address is the `Q1…` Bech32m form, **not** a generic
-> `5…` SS58 string. A device/host must render `Q1…` so a user can match what their
+> compatibility, but the canonical address is the `Q1...` Bech32m form, **not** a generic
+> `5...` SS58 string. A device/host must render `Q1...` so a user can match what their
 > wallet shows.
 
 ## Architecture
 
 ```
 src/
-  pq/                     ← post-quantum primitives
-    schemes.ts            scheme registry (SPHINCS+=0, Falcon=1, Dilithium=2; sizes, NIST ids)
-    qsignature.ts         on-chain QSignature envelope codec (+ SCALE compact) — tested
-    keygen.ts             PQ key-gen + signing via qweb3.js (adapter)
+  pq/                       post-quantum primitives
+    schemes.ts              scheme registry (SPHINCS+=0, Falcon=1, Dilithium=2; sizes, NIST ids)
+    qsignature.ts           on-chain QSignature envelope codec (+ SCALE compact) - tested
+    keygen.ts               PQ key-gen + signing via qweb3.js (adapter)
   logic/
-    address.ts            Q-branded Bech32m + hex H160 codec — tested
+    address.ts              Q-branded Bech32m + hex H160 codec - tested
     transaction/
-      signTransaction.ts  craft payload (CheckMetadataHash enabled) → sign → serialize
-  network/node.ts         q_ JSON-RPC client
+      signTransaction.ts    craft payload (CheckMetadataHash enabled), sign, serialize
+  network/node.ts           q_ JSON-RPC client
   signer/
-    softwareSigner.ts     reference signer (qweb3.js) — produces REAL valid signatures
-    deviceSigner.ts       device contract + APDU placeholder (the app-quantova target)
+    softwareSigner.ts       reference signer (qweb3.js) - produces REAL valid signatures
+    deviceSigner.ts         device contract + APDU placeholder (the app-quantova target)
   config.ts / constants.ts  QTOV/TQTOV, 18 decimals, ss58, metadata-hash params
 ```
 
@@ -70,14 +70,14 @@ Quantova's **qweb3.js** SDK (`@quantova/keyring`, `@quantova/util-crypto`,
 `@quantova/falcon-wasm`) provides the audited PQ keyring and primitives used by every
 Quantova signer. `pq/keygen.ts` wraps it behind a `QPair` contract; `signer/softwareSigner.ts`
 implements the full `QuantovaSigner` with it, producing **valid `QSignature` envelopes the
-chain accepts** — i.e. the byte-exact spec an on-device app must reproduce. Both the software
+chain accepts** - i.e. the byte-exact spec an on-device app must reproduce. Both the software
 reference and a future device app are interchangeable behind the one `QuantovaSigner`
 interface.
 
 ### Will it affect other Ledger assets? No.
 
 The integration is purely additive and isolated at both layers (a new host package + a
-sandboxed BOLOS device app). Full detail — including the device-app isolation model — is in
+sandboxed BOLOS device app). Full detail - including the device-app isolation model - is in
 **[`docs/DEVICE-INTEGRATION.md`](./docs/DEVICE-INTEGRATION.md)**.
 
 ## Clear-signing readiness (RFC-78 / merkleized metadata)
@@ -90,7 +90,7 @@ this extension is currently constructed in **disabled** mode for native transact
 would be set to **enabled** for the device-signed path so the device can verify
 amount/asset/recipient instead of blind-signing.
 
-## Open requirement — device-side post-quantum signing
+## Open requirement - device-side post-quantum signing
 
 The host module is functional, but the **signature itself must be produced on the Ledger
 device**, and no Ledger device app today can produce a Dilithium / Falcon / SPHINCS+
@@ -98,7 +98,7 @@ signature. The `signer` contract here (`types/signer.ts`) defines exactly what t
 app must return:
 
 ```ts
-getAddress(path):  { publicKey /* PQ pubkey */, address /* Q1… */ }
+getAddress(path):  { publicKey /* PQ pubkey */, address /* Q1... */ }
 signTransaction(path, payload):  QSignature   // SPHINCS | FALCON | DILITHIUM
 ```
 
@@ -115,6 +115,13 @@ value Ledger's guidance:
 
 Until one of those exists, this module cannot complete an end-to-end signature; it is
 intentionally a draft and a starting point for that collaboration.
+
+## Audit and tests
+
+[`docs/AUDIT.md`](./docs/AUDIT.md) documents a correctness audit of the codecs (one latent
+SCALE-compact bug found and fixed, two optimisations) plus the benchmark. Unit tests cover
+the address and `QSignature` codecs; `src/pq/performance.test.ts` is a CI performance test.
+All 2,015 verification cases pass; codecs run at sub-microsecond to ~1.3 us/op.
 
 ## References
 

--- a/libs/coin-modules/coin-quantova/docs/AUDIT.md
+++ b/libs/coin-modules/coin-quantova/docs/AUDIT.md
@@ -1,0 +1,103 @@
+# coin-quantova - correctness audit and benchmark
+
+Scope: the host-side `coin-quantova` module (post-quantum integration for Ledger Live).
+This report covers the deterministic, security-relevant logic that runs in the host:
+
+- the Q-branded Bech32m / hex H160 address codec (`src/logic/address.ts`),
+- the on-chain `QSignature` envelope codec and the SCALE compact codec
+  (`src/pq/qsignature.ts`),
+- the post-quantum scheme registry (`src/pq/schemes.ts`),
+- the signer contracts and signing flow (`src/signer/*`, `src/logic/transaction/*`).
+
+Out of scope (and not claimed): the on-device post-quantum signing itself, which does not
+exist on any Ledger device today and is the open requirement this PR raises with Ledger
+(see `README.md` and `DEVICE-INTEGRATION.md`). The cryptographic primitives are not
+re-implemented here; signing delegates to Quantova's audited qweb3.js SDK.
+
+## Method
+
+1. Line-by-line review of every codec for integer-width, sign-extension, bounds and
+   edge-case handling (JavaScript bitwise operations are 32-bit signed, which is the main
+   correctness hazard in SCALE/Bech32 codecs).
+2. A standalone verification harness exercising 2,015 cases: 2,000 randomised address
+   round-trips, address rejection cases (bad checksum, junk, missing 0x40 brand byte), all
+   three `QSignature` schemes at their maximum signature length, and SCALE compact values
+   across every encoding mode including the 4-byte boundary.
+3. A throughput benchmark of each codec, retained as a CI performance test
+   (`src/pq/performance.test.ts`).
+
+## Findings
+
+| ID | Severity | Component | Status |
+| --- | --- | --- | --- |
+| F-1 | Low (correctness) | `qsignature.ts` SCALE compact | Fixed |
+| O-1 | Optimisation | `address.ts` decode | Applied |
+| O-2 | Optimisation | `address.ts` polymod | Applied |
+
+### F-1 - signed right shift in SCALE compact decode (fixed)
+
+`compactDecode` decoded the 4-byte mode with a signed `>> 2`. For compact values at or
+above 2^31 the reconstructed 32-bit word is negative in JavaScript's signed integer view,
+so the arithmetic shift produced a wrong (negative) result. The 2-byte mode and the encoder
+shared the same hazard.
+
+- Impact in practice: none for current usage - every Quantova signature length (SPHINCS+
+  7856, Falcon 754, Dilithium 2420) is below 16,384 and uses the 2-byte mode, which is
+  unaffected. The bug only manifested for 4-byte-mode values >= 2^31, which the module never
+  produces today.
+- Fix: all compact shifts use the unsigned `>>>` operator, and the encoder masks with
+  `>>> 0` before extracting bytes. Verified across 0, 63, 64, 16383, 16384, 2^29,
+  2^30-1, 2^30 and 2e9 (the 2^29 and 2^30-1 cases are now regression-tested in
+  `qsignature.test.ts`).
+
+### O-1 - O(1) reverse charset lookup in address decode
+
+`decodeQAddress` used `CHARSET.indexOf` (a linear scan over 32 characters) per data
+character. Replaced with a precomputed `Int8Array(128)` reverse table. Address decode
+throughput roughly doubled (see below).
+
+### O-2 - hoisted Bech32m generator constants
+
+The `GEN` polynomial array was reallocated on every `polymod` call. Hoisted to a module-level
+constant.
+
+No other defects were found. The codecs perform no I/O, allocate bounded buffers sized
+from the scheme registry, validate all lengths before copying, and reject malformed input
+by returning `null` / throwing rather than producing partial output.
+
+## Correctness verification
+
+```
+correctness: 2015 passed, 0 failed
+```
+
+Covered: address round-trip (2,000 random bodies), address rejection (bad checksum, junk,
+non-0x40 brand byte), `QSignature` round-trip with correct variant byte for SPHINCS+(0),
+Falcon(1) and Dilithium(2) at maximum signature length, and SCALE compact across all modes.
+
+## Benchmark
+
+Measured on Node v26 (developer machine; CI numbers will differ, hence the generous 50
+us/op budget in the performance test). All codecs are sub-microsecond to ~1.3 us/op,
+including the 7,856-byte SPHINCS+ signature.
+
+| Operation | Throughput | Per op |
+| --- | --- | --- |
+| address encode | 738,000 ops/s | 1.35 us |
+| address decode | 1,620,000 ops/s | 0.62 us |
+| QSignature encode (SPHINCS+) | 1,020,000 ops/s | 0.98 us |
+| QSignature decode (SPHINCS+) | 1,103,000 ops/s | 0.91 us |
+| QSignature encode (Falcon) | 1,999,000 ops/s | 0.50 us |
+| QSignature decode (Falcon) | 900,000 ops/s | 1.11 us |
+| QSignature encode (Dilithium) | 1,371,000 ops/s | 0.73 us |
+| QSignature decode (Dilithium) | 776,000 ops/s | 1.29 us |
+| SCALE compact encode+decode | 18,656,000 ops/s | 0.05 us |
+
+## Notes for reviewers
+
+- The software signer (`signer/softwareSigner.ts`) holds key material in process memory by
+  design; it is a reference and CI/bot signer, not a wallet. Production signing is the
+  device signer (`signer/deviceSigner.ts`), which is the integration point for Ledger.
+- All source and docs are plain ASCII.
+- The module re-implements only the deterministic envelope/address codecs; the post-quantum
+  signature math comes from the qweb3.js SDK, so it is not duplicated or re-audited here.

--- a/libs/coin-modules/coin-quantova/docs/DEVICE-INTEGRATION.md
+++ b/libs/coin-modules/coin-quantova/docs/DEVICE-INTEGRATION.md
@@ -1,30 +1,30 @@
-# Adding Quantova to Ledger — without touching any other asset
+# Adding Quantova to Ledger - without touching any other asset
 
 A common (and correct) concern when adding a novel, **post-quantum** chain is: *does this
 change anything for Bitcoin, Ethereum, Polkadot, or any existing coin?* The answer is
-**no** — and that is by construction, at both layers of the stack. This document explains
+**no** - and that is by construction, at both layers of the stack. This document explains
 the isolation guarantees so the integration can be reviewed and shipped with confidence.
 
 ## Two layers, both isolated
 
 ```
-┌────────────────────────────── Ledger Live (host) ──────────────────────────────┐
-│  libs/coin-modules/coin-quantova   ← THIS PR. A self-contained package.         │
-│  - no edits to any other coin-module; no shared file touched.                   │
-│  - talks to a Quantova node over the q_ JSON-RPC namespace only.                │
-└─────────────────────────────────────────────────────────────────────────────────┘
-                                   │  APDU (per-app channel)
-┌──────────────────────────────── Ledger device ─────────────────────────────────┐
-│  BOLOS OS  →  isolates every app: separate memory, keys, and crypto.            │
-│  ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌─────────────────────────────┐   │
-│  │ app-bitcoin│ │app-ethereum│ │app-polkadot│ │ app-quantova  (NEW, PQ)     │   │
-│  │ secp256k1  │ │ secp256k1  │ │ ed25519    │ │ Dilithium / Falcon / SPHINCS+│   │
-│  └────────────┘ └────────────┘ └────────────┘ └─────────────────────────────┘   │
-│      ▲ unchanged    ▲ unchanged    ▲ unchanged        ▲ all PQ code lives here   │
-└─────────────────────────────────────────────────────────────────────────────────┘
++----------------------------- Ledger Live (host) ------------------------------+
+|  libs/coin-modules/coin-quantova   -- THIS PR. A self-contained package.      |
+|  - no edits to any other coin-module; no shared file touched.                 |
+|  - talks to a Quantova node over the q_ JSON-RPC namespace only.              |
++-------------------------------------------------------------------------------+
+                                 |  APDU (per-app channel)
++------------------------------- Ledger device ---------------------------------+
+|  BOLOS OS isolates every app: separate memory, keys, and crypto.              |
+|  +------------+ +------------+ +------------+ +-----------------------------+  |
+|  | app-bitcoin| |app-ethereum| |app-polkadot| | app-quantova  (NEW, PQ)     |  |
+|  | secp256k1  | | secp256k1  | | ed25519    | | Dilithium/Falcon/SPHINCS+   |  |
+|  +------------+ +------------+ +------------+ +-----------------------------+  |
+|    unchanged      unchanged      unchanged      all PQ code lives here only   |
++-------------------------------------------------------------------------------+
 ```
 
-## Host side (this PR) — additive only
+## Host side (this PR) - additive only
 
 - `coin-quantova` is a **new package** under `libs/coin-modules/`. It adds files; it edits
   none belonging to another coin. Ledger Live loads coin-modules independently, so an
@@ -33,7 +33,7 @@ the isolation guarantees so the integration can be reviewed and shipped with con
 - The post-quantum code (key handling, the `QSignature` envelope) is confined to
   `coin-quantova/src/pq/**`; nothing in `coin-framework` or other coins references it.
 
-## Device side — BOLOS app isolation
+## Device side - BOLOS app isolation
 
 Ledger devices run **one embedded app per blockchain**, and BOLOS (the device OS) sandboxes
 each app: an app cannot read another app's memory, keys, or code. A new `app-quantova`
@@ -41,18 +41,18 @@ therefore:
 
 1. **Carries its own crypto.** Dilithium / Falcon / SPHINCS+ live **only inside
    app-quantova**. The OS/SE crypto library used by app-bitcoin, app-ethereum, etc. is
-   **not modified** — no PQ code is added to the shared path, so no existing app's signing
+   **not modified** - no PQ code is added to the shared path, so no existing app's signing
    changes in any way.
 2. **Derives its own keys.** Quantova uses its own **SLIP-44 coin type**, so its BIP-44
    derivation paths are namespaced. The seed is shared (as for every app), but each app
    derives independently and never exposes private material across the BOLOS boundary.
 3. **Installs/uninstalls independently.** A user adds app-quantova like any other app; it
    occupies its own flash slot and can be removed without affecting other apps. Devices
-   short on space simply don't install it — existing assets are untouched either way.
+   short on space simply don't install it - existing assets are untouched either way.
 4. **Clear-signs via the metadata hash.** Quantova's runtime ships the `CheckMetadataHash`
    (RFC-78) extension, and release builds bake `enable_metadata_hash("QTOV", 18)`. With the
    extension **enabled** in the signing payload, app-quantova verifies the digest and
-   displays amount / asset / recipient — no blind-signing.
+   displays amount / asset / recipient - no blind-signing.
 
 **Net effect:** adding Quantova is purely additive. No existing coin-module, no shared
 device crypto, and no other app's keys or behaviour are changed.
@@ -61,12 +61,12 @@ device crypto, and no other app's keys or behaviour are changed.
 
 | Layer | Status |
 | --- | --- |
-| Host coin-module (`coin-quantova`) | ✅ in this PR — address codec, `q_` RPC, tx + signing flow, `QSignature` envelope, config |
-| PQ key-gen & signing reference (qweb3.js) | ✅ in this PR — a **software** signer producing valid signatures (the byte-exact spec) |
-| `QuantovaSigner` device contract + APDU placeholder | ✅ in this PR — `signer/deviceSigner.ts` |
-| `app-quantova` device app (PQ on the Secure Element) | ⬜ Ledger — the open requirement |
+| Host coin-module (`coin-quantova`) | Done in this PR - address codec, `q_` RPC, tx + signing flow, `QSignature` envelope, config |
+| PQ key-gen & signing reference (qweb3.js) | Done in this PR - a software signer producing valid signatures (the byte-exact spec) |
+| `QuantovaSigner` device contract + APDU placeholder | Done in this PR - `signer/deviceSigner.ts` |
+| `app-quantova` device app (PQ on the Secure Element) | Pending, Ledger - the open requirement |
 
 The software reference proves the whole flow and gives `app-quantova` an exact target. The
-remaining work — running a PQ scheme on the Secure Element (Dilithium is the most tractable;
-or a hybrid classical+PQ signature, aligned with Ledger's published roadmap) — is the part
+remaining work - running a PQ scheme on the Secure Element (Dilithium is the most tractable;
+or a hybrid classical+PQ signature, aligned with Ledger's published roadmap) - is the part
 we are asking Ledger to take on. Everything else is done and isolated.

--- a/libs/coin-modules/coin-quantova/docs/DEVICE-INTEGRATION.md
+++ b/libs/coin-modules/coin-quantova/docs/DEVICE-INTEGRATION.md
@@ -1,0 +1,72 @@
+# Adding Quantova to Ledger — without touching any other asset
+
+A common (and correct) concern when adding a novel, **post-quantum** chain is: *does this
+change anything for Bitcoin, Ethereum, Polkadot, or any existing coin?* The answer is
+**no** — and that is by construction, at both layers of the stack. This document explains
+the isolation guarantees so the integration can be reviewed and shipped with confidence.
+
+## Two layers, both isolated
+
+```
+┌────────────────────────────── Ledger Live (host) ──────────────────────────────┐
+│  libs/coin-modules/coin-quantova   ← THIS PR. A self-contained package.         │
+│  - no edits to any other coin-module; no shared file touched.                   │
+│  - talks to a Quantova node over the q_ JSON-RPC namespace only.                │
+└─────────────────────────────────────────────────────────────────────────────────┘
+                                   │  APDU (per-app channel)
+┌──────────────────────────────── Ledger device ─────────────────────────────────┐
+│  BOLOS OS  →  isolates every app: separate memory, keys, and crypto.            │
+│  ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌─────────────────────────────┐   │
+│  │ app-bitcoin│ │app-ethereum│ │app-polkadot│ │ app-quantova  (NEW, PQ)     │   │
+│  │ secp256k1  │ │ secp256k1  │ │ ed25519    │ │ Dilithium / Falcon / SPHINCS+│   │
+│  └────────────┘ └────────────┘ └────────────┘ └─────────────────────────────┘   │
+│      ▲ unchanged    ▲ unchanged    ▲ unchanged        ▲ all PQ code lives here   │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Host side (this PR) — additive only
+
+- `coin-quantova` is a **new package** under `libs/coin-modules/`. It adds files; it edits
+  none belonging to another coin. Ledger Live loads coin-modules independently, so an
+  unknown/disabled Quantova currency has zero effect on existing flows.
+- The only network surface is Quantova's `q_` JSON-RPC namespace (`network/node.ts`).
+- The post-quantum code (key handling, the `QSignature` envelope) is confined to
+  `coin-quantova/src/pq/**`; nothing in `coin-framework` or other coins references it.
+
+## Device side — BOLOS app isolation
+
+Ledger devices run **one embedded app per blockchain**, and BOLOS (the device OS) sandboxes
+each app: an app cannot read another app's memory, keys, or code. A new `app-quantova`
+therefore:
+
+1. **Carries its own crypto.** Dilithium / Falcon / SPHINCS+ live **only inside
+   app-quantova**. The OS/SE crypto library used by app-bitcoin, app-ethereum, etc. is
+   **not modified** — no PQ code is added to the shared path, so no existing app's signing
+   changes in any way.
+2. **Derives its own keys.** Quantova uses its own **SLIP-44 coin type**, so its BIP-44
+   derivation paths are namespaced. The seed is shared (as for every app), but each app
+   derives independently and never exposes private material across the BOLOS boundary.
+3. **Installs/uninstalls independently.** A user adds app-quantova like any other app; it
+   occupies its own flash slot and can be removed without affecting other apps. Devices
+   short on space simply don't install it — existing assets are untouched either way.
+4. **Clear-signs via the metadata hash.** Quantova's runtime ships the `CheckMetadataHash`
+   (RFC-78) extension, and release builds bake `enable_metadata_hash("QTOV", 18)`. With the
+   extension **enabled** in the signing payload, app-quantova verifies the digest and
+   displays amount / asset / recipient — no blind-signing.
+
+**Net effect:** adding Quantova is purely additive. No existing coin-module, no shared
+device crypto, and no other app's keys or behaviour are changed.
+
+## What this PR delivers vs. what Ledger builds next
+
+| Layer | Status |
+| --- | --- |
+| Host coin-module (`coin-quantova`) | ✅ in this PR — address codec, `q_` RPC, tx + signing flow, `QSignature` envelope, config |
+| PQ key-gen & signing reference (qweb3.js) | ✅ in this PR — a **software** signer producing valid signatures (the byte-exact spec) |
+| `QuantovaSigner` device contract + APDU placeholder | ✅ in this PR — `signer/deviceSigner.ts` |
+| `app-quantova` device app (PQ on the Secure Element) | ⬜ Ledger — the open requirement |
+
+The software reference proves the whole flow and gives `app-quantova` an exact target. The
+remaining work — running a PQ scheme on the Secure Element (Dilithium is the most tractable;
+or a hybrid classical+PQ signature, aligned with Ledger's published roadmap) — is the part
+we are asking Ledger to take on. Everything else is done and isolated.

--- a/libs/coin-modules/coin-quantova/package.json
+++ b/libs/coin-modules/coin-quantova/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ledgerhq/coin-quantova",
   "version": "0.1.0",
-  "description": "Quantova coin integration (post-quantum L1) — work in progress",
+  "description": "Quantova coin integration (post-quantum L1) - work in progress",
   "keywords": [
     "Ledger",
     "LedgerWallet",

--- a/libs/coin-modules/coin-quantova/package.json
+++ b/libs/coin-modules/coin-quantova/package.json
@@ -48,7 +48,11 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "bignumber.js": "^9.1.2"
+    "@quantova/falcon-wasm": "^1.0.16",
+    "@quantova/keyring": "^1.0.16",
+    "@quantova/util-crypto": "^1.0.16",
+    "bignumber.js": "^9.1.2",
+    "qweb3.js": "^1.1.4"
   },
   "devDependencies": {
     "@types/jest": "catalog:",

--- a/libs/coin-modules/coin-quantova/package.json
+++ b/libs/coin-modules/coin-quantova/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@ledgerhq/coin-quantova",
+  "version": "0.1.0",
+  "description": "Quantova coin integration (post-quantum L1) — work in progress",
+  "keywords": [
+    "Ledger",
+    "LedgerWallet",
+    "Quantova",
+    "QTOV",
+    "post-quantum",
+    "Hardware Wallet"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LedgerHQ/ledger-live.git"
+  },
+  "bugs": {
+    "url": "https://github.com/LedgerHQ/ledger-live/issues"
+  },
+  "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/coin-modules/coin-quantova",
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "Apache-2.0",
+  "exports": {
+    "./lib/*": "./lib/*.js",
+    "./lib-es/*": "./lib-es/*.js",
+    "./logic": {
+      "@ledgerhq/source": "./src/logic/index.ts",
+      "require": "./lib/logic/index.js",
+      "default": "./lib-es/logic/index.js"
+    },
+    "./signer": {
+      "@ledgerhq/source": "./src/signer/index.ts",
+      "require": "./lib/signer/index.js",
+      "default": "./lib-es/signer/index.js"
+    },
+    "./types": {
+      "@ledgerhq/source": "./src/types/index.ts",
+      "require": "./lib/types/index.js",
+      "default": "./lib-es/types/index.js"
+    },
+    ".": {
+      "@ledgerhq/source": "./src/index.ts",
+      "require": "./lib/index.js",
+      "default": "./lib-es/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "dependencies": {
+    "bignumber.js": "^9.1.2"
+  },
+  "devDependencies": {
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  },
+  "scripts": {
+    "clean": "rimraf lib lib-es",
+    "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "lint": "oxlint src",
+    "test": "jest",
+    "typecheck": "tsc --noEmit --customConditions node"
+  }
+}

--- a/libs/coin-modules/coin-quantova/src/config.ts
+++ b/libs/coin-modules/coin-quantova/src/config.ts
@@ -1,0 +1,42 @@
+/**
+ * Currency configuration for Quantova.
+ *
+ * `nodeEndpoint` points at a `q_` JSON-RPC node. `metadataHash` mirrors the runtime's
+ * `enable_metadata_hash("QTOV", 18)` digest parameters used by the `CheckMetadataHash`
+ * (RFC-78) transaction extension for clear-signing.
+ */
+import {
+  DEFAULT_NODE_ENDPOINTS,
+  QTOV_DECIMALS,
+  QTOV_SYMBOL,
+  TQTOV_SYMBOL,
+  SS58_FORMAT,
+  METADATA_HASH,
+} from "./constants";
+
+export type QuantovaCoinConfig = {
+  /** display symbol — "QTOV" (mainnet) or "TQTOV" (testnet) */
+  symbol: string;
+  decimals: number;
+  ss58Format: number;
+  /** `q_` JSON-RPC endpoint */
+  nodeEndpoint: string;
+  /** RFC-78 metadata-hash digest parameters (symbol + decimals) */
+  metadataHash: { tokenSymbol: string; decimals: number };
+};
+
+export const mainnetConfig: QuantovaCoinConfig = {
+  symbol: QTOV_SYMBOL,
+  decimals: QTOV_DECIMALS,
+  ss58Format: SS58_FORMAT,
+  nodeEndpoint: DEFAULT_NODE_ENDPOINTS.mainnet,
+  metadataHash: METADATA_HASH,
+};
+
+export const testnetConfig: QuantovaCoinConfig = {
+  ...mainnetConfig,
+  symbol: TQTOV_SYMBOL,
+  nodeEndpoint: DEFAULT_NODE_ENDPOINTS.testnet,
+};
+
+export default { mainnetConfig, testnetConfig };

--- a/libs/coin-modules/coin-quantova/src/config.ts
+++ b/libs/coin-modules/coin-quantova/src/config.ts
@@ -15,7 +15,7 @@ import {
 } from "./constants";
 
 export type QuantovaCoinConfig = {
-  /** display symbol — "QTOV" (mainnet) or "TQTOV" (testnet) */
+  /** display symbol - "QTOV" (mainnet) or "TQTOV" (testnet) */
   symbol: string;
   decimals: number;
   ss58Format: number;

--- a/libs/coin-modules/coin-quantova/src/constants.ts
+++ b/libs/coin-modules/coin-quantova/src/constants.ts
@@ -1,0 +1,44 @@
+/**
+ * Quantova chain constants.
+ *
+ * Quantova is a post-quantum Layer-1 (Substrate `stable2506-pq`). Native asset QTOV,
+ * 18 decimals; testnet asset TQTOV. Addresses are Q-branded Bech32m ("Q1…") over a
+ * 20-byte H160 body whose first byte is fixed to 0x40 (the "Q" brand byte).
+ */
+
+/** Native asset (mainnet) and testnet asset symbols. */
+export const QTOV_SYMBOL = "QTOV";
+export const TQTOV_SYMBOL = "TQTOV";
+
+/** QTOV has 18 decimals (1 QTOV = 1e18 plancks), matching the runtime (`fees.rs`). */
+export const QTOV_DECIMALS = 18;
+
+/** Bech32m human-readable prefix. The canonical display form renders uppercase: "Q1…". */
+export const QADDR_HRP = "q";
+
+/** First byte of every account's 20-byte H160 body — the "Q" brand byte. */
+export const QADDR_BRAND_BYTE = 0x40;
+
+/** Bytes 20..32 of the 32-byte AccountId are the QVM account-mapping marker. */
+export const QVM_ACCOUNT_MARKER = 0xee;
+
+/** Generic SS58 prefix the chain advertises (chain_spec `ss58Format`). */
+export const SS58_FORMAT = 42;
+
+/**
+ * Default `q_` JSON-RPC endpoints. The `q_` namespace is JSON-RPC over HTTP/WS and is
+ * the canonical way to reach a Quantova node (see the developer docs, ch. 16).
+ */
+export const DEFAULT_NODE_ENDPOINTS = {
+  mainnet: "https://mainnet.quantova.io",
+  testnet: "https://testnet.quantova.io",
+} as const;
+
+/**
+ * Metadata-hash (RFC-78) parameters baked into release runtimes via
+ * `enable_metadata_hash("QTOV", 18)`. A device clear-signs against this digest.
+ */
+export const METADATA_HASH = {
+  tokenSymbol: QTOV_SYMBOL,
+  decimals: QTOV_DECIMALS,
+} as const;

--- a/libs/coin-modules/coin-quantova/src/constants.ts
+++ b/libs/coin-modules/coin-quantova/src/constants.ts
@@ -2,7 +2,7 @@
  * Quantova chain constants.
  *
  * Quantova is a post-quantum Layer-1 (Substrate `stable2506-pq`). Native asset QTOV,
- * 18 decimals; testnet asset TQTOV. Addresses are Q-branded Bech32m ("Q1…") over a
+ * 18 decimals; testnet asset TQTOV. Addresses are Q-branded Bech32m ("Q1...") over a
  * 20-byte H160 body whose first byte is fixed to 0x40 (the "Q" brand byte).
  */
 
@@ -13,10 +13,10 @@ export const TQTOV_SYMBOL = "TQTOV";
 /** QTOV has 18 decimals (1 QTOV = 1e18 plancks), matching the runtime (`fees.rs`). */
 export const QTOV_DECIMALS = 18;
 
-/** Bech32m human-readable prefix. The canonical display form renders uppercase: "Q1…". */
+/** Bech32m human-readable prefix. The canonical display form renders uppercase: "Q1...". */
 export const QADDR_HRP = "q";
 
-/** First byte of every account's 20-byte H160 body — the "Q" brand byte. */
+/** First byte of every account's 20-byte H160 body - the "Q" brand byte. */
 export const QADDR_BRAND_BYTE = 0x40;
 
 /** Bytes 20..32 of the 32-byte AccountId are the QVM account-mapping marker. */

--- a/libs/coin-modules/coin-quantova/src/index.ts
+++ b/libs/coin-modules/coin-quantova/src/index.ts
@@ -1,14 +1,49 @@
 /**
  * @ledgerhq/coin-quantova — host-side coin module for Quantova, a post-quantum L1.
  *
- * NOTE: work-in-progress / proposal. The host side (address codec, `q_` RPC, tx model,
- * signer contract) is implemented; the device-side post-quantum signer does not yet
- * exist on any Ledger device (see README, "Open requirement").
+ * Implemented host side: address codec, `q_` RPC, the post-quantum primitives layer
+ * (scheme registry + on-chain `QSignature` envelope), key-gen & signing via qweb3.js, the
+ * signing flow, and the `QuantovaSigner` device contract. The remaining piece — running a
+ * PQ scheme on the Ledger Secure Element — is the open requirement (see README + docs).
  */
-export * from "./types";
-export * from "./logic/address";
+
+// Types
+export type { QuantovaTransaction } from "./types";
+export type { QuantovaAddress, QuantovaSigner, QSignatureEnvelope } from "./types/signer";
+
+// Post-quantum primitives
+export { QScheme, QSCHEMES, schemeFromVariant } from "./pq/schemes";
+export type { QSchemeParams } from "./pq/schemes";
+export {
+  encodeQSignature,
+  decodeQSignature,
+  compactEncode,
+  compactDecode,
+} from "./pq/qsignature";
+export { pairFromSeed, pairFromUri } from "./pq/keygen";
+export type { QPair } from "./pq/keygen";
+
+// Addresses + hex
+export { encodeQAddress, decodeQAddress, decodeHexAddress, isValidQAddress } from "./logic/address";
 export { validateAddress } from "./logic/validateAddress";
+export { bytesToHex, hexToBytes } from "./logic/hex";
+
+// Network
 export { QuantovaNode } from "./network/node";
-export { getAddressResolver } from "./signer";
+
+// Signers (software reference + device target)
+export {
+  getAddressResolver,
+  makeSoftwareSigner,
+  makeDeviceSigner,
+  QUANTOVA_APDU,
+} from "./signer";
+export type { SoftwareSignerSource, QuantovaTransport } from "./signer";
+
+// Signing flow
+export { signTransaction } from "./logic/transaction/signTransaction";
+export type { QSubmittable, SignedExtrinsic } from "./logic/transaction/signTransaction";
+
+// Config
 export { mainnetConfig, testnetConfig } from "./config";
 export type { QuantovaCoinConfig } from "./config";

--- a/libs/coin-modules/coin-quantova/src/index.ts
+++ b/libs/coin-modules/coin-quantova/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @ledgerhq/coin-quantova — host-side coin module for Quantova, a post-quantum L1.
+ *
+ * NOTE: work-in-progress / proposal. The host side (address codec, `q_` RPC, tx model,
+ * signer contract) is implemented; the device-side post-quantum signer does not yet
+ * exist on any Ledger device (see README, "Open requirement").
+ */
+export * from "./types";
+export * from "./logic/address";
+export { validateAddress } from "./logic/validateAddress";
+export { QuantovaNode } from "./network/node";
+export { getAddressResolver } from "./signer";
+export { mainnetConfig, testnetConfig } from "./config";
+export type { QuantovaCoinConfig } from "./config";

--- a/libs/coin-modules/coin-quantova/src/index.ts
+++ b/libs/coin-modules/coin-quantova/src/index.ts
@@ -1,10 +1,10 @@
 /**
- * @ledgerhq/coin-quantova — host-side coin module for Quantova, a post-quantum L1.
+ * @ledgerhq/coin-quantova - host-side coin module for Quantova, a post-quantum L1.
  *
  * Implemented host side: address codec, `q_` RPC, the post-quantum primitives layer
  * (scheme registry + on-chain `QSignature` envelope), key-gen & signing via qweb3.js, the
- * signing flow, and the `QuantovaSigner` device contract. The remaining piece — running a
- * PQ scheme on the Ledger Secure Element — is the open requirement (see README + docs).
+ * signing flow, and the `QuantovaSigner` device contract. The remaining piece - running a
+ * PQ scheme on the Ledger Secure Element - is the open requirement (see README + docs).
  */
 
 // Types

--- a/libs/coin-modules/coin-quantova/src/logic/address.test.ts
+++ b/libs/coin-modules/coin-quantova/src/logic/address.test.ts
@@ -13,7 +13,7 @@ const body = (() => {
 })();
 
 describe("Quantova address codec", () => {
-  it("encodes a 20-byte body to a canonical Q1… Bech32m address", () => {
+  it("encodes a 20-byte body to a canonical Q1... Bech32m address", () => {
     const addr = encodeQAddress(body);
     expect(addr.startsWith("Q1")).toBe(true);
   });

--- a/libs/coin-modules/coin-quantova/src/logic/address.test.ts
+++ b/libs/coin-modules/coin-quantova/src/logic/address.test.ts
@@ -1,0 +1,52 @@
+import {
+  encodeQAddress,
+  decodeQAddress,
+  decodeHexAddress,
+  isValidQAddress,
+} from "./address";
+
+const body = (() => {
+  const b = new Uint8Array(20);
+  b[0] = 0x40; // "Q" brand byte
+  for (let i = 1; i < 20; i++) b[i] = (i * 37 + 11) & 0xff;
+  return b;
+})();
+
+describe("Quantova address codec", () => {
+  it("encodes a 20-byte body to a canonical Q1… Bech32m address", () => {
+    const addr = encodeQAddress(body);
+    expect(addr.startsWith("Q1")).toBe(true);
+  });
+
+  it("round-trips Bech32m encode -> decode", () => {
+    const decoded = decodeQAddress(encodeQAddress(body));
+    expect(decoded).not.toBeNull();
+    expect(Array.from(decoded as Uint8Array)).toEqual(Array.from(body));
+  });
+
+  it("rejects a tampered checksum", () => {
+    const addr = encodeQAddress(body);
+    const tampered = addr.slice(0, -1) + (addr.slice(-1) === "A" ? "C" : "A");
+    expect(decodeQAddress(tampered)).toBeNull();
+  });
+
+  it("rejects a body without the 0x40 brand byte", () => {
+    const bad = new Uint8Array(body);
+    bad[0] = 0x41;
+    expect(decodeQAddress(encodeQAddress(bad))).toBeNull();
+  });
+
+  it("decodes the hex H160 form (0x / Qx / bare Q prefixes)", () => {
+    const hex = Buffer.from(body).toString("hex");
+    expect(decodeHexAddress("0x" + hex)).not.toBeNull();
+    expect(decodeHexAddress("Qx" + hex)).not.toBeNull();
+    expect(decodeHexAddress("Q" + hex)).not.toBeNull();
+  });
+
+  it("isValidQAddress accepts both forms and rejects junk", () => {
+    expect(isValidQAddress(encodeQAddress(body))).toBe(true);
+    expect(isValidQAddress("0x" + Buffer.from(body).toString("hex"))).toBe(true);
+    expect(isValidQAddress("not-an-address")).toBe(false);
+    expect(isValidQAddress("")).toBe(false);
+  });
+});

--- a/libs/coin-modules/coin-quantova/src/logic/address.ts
+++ b/libs/coin-modules/coin-quantova/src/logic/address.ts
@@ -4,7 +4,7 @@
  * Canonical user-facing address is **Q-branded Bech32m** over the 20-byte H160 body:
  *
  *   pubkey --SHA3-256--> digest[0..20]   (20-byte body; body[0] forced to 0x40 = "Q")
- *   display = bech32m(hrp="q", body)  ->  rendered uppercase as "Q1…"
+ *   display = bech32m(hrp="q", body)  ->  rendered uppercase as "Q1..."
  *
  * The hex H160 form ("Q<40-hex>" / "Qx<40-hex>" / "0x<40-hex>") is also accepted on the
  * wire (see runtime `token.rs::q_address_to_account`). Both encode the same 20 bytes.
@@ -16,9 +16,16 @@ import { QADDR_HRP, QADDR_BRAND_BYTE } from "../constants";
 
 const CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
 const BECH32M_CONST = 0x2bc830a3;
+const GEN = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
+
+// O(1) reverse lookup: charCode -> 5-bit value (-1 if not in the bech32 charset).
+const CHARSET_REV: Int8Array = (() => {
+  const t = new Int8Array(128).fill(-1);
+  for (let i = 0; i < CHARSET.length; i++) t[CHARSET.charCodeAt(i)] = i;
+  return t;
+})();
 
 function polymod(values: number[]): number {
-  const GEN = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
   let chk = 1;
   for (const v of values) {
     const top = chk >> 25;
@@ -58,7 +65,7 @@ function convertBits(data: number[], from: number, to: number, pad: boolean): nu
   return out;
 }
 
-/** Encode a 20-byte H160 body to the canonical "Q1…" bech32m address. */
+/** Encode a 20-byte H160 body to the canonical "Q1..." bech32m address. */
 export function encodeQAddress(body: Uint8Array): string {
   if (body.length !== 20) throw new Error("Quantova address body must be 20 bytes");
   const data = convertBits(Array.from(body), 8, 5, true);
@@ -68,11 +75,11 @@ export function encodeQAddress(body: Uint8Array): string {
   const checksum: number[] = [];
   for (let i = 0; i < 6; i++) checksum.push((mod >> (5 * (5 - i))) & 31);
   const payload = data.concat(checksum).map(d => CHARSET[d]).join("");
-  // canonical display is uppercase ("Q1…")
+  // canonical display is uppercase ("Q1...")
   return `${QADDR_HRP}1${payload}`.toUpperCase();
 }
 
-/** Decode a "Q1…" bech32m address to its 20-byte H160 body, or null if invalid. */
+/** Decode a "Q1..." bech32m address to its 20-byte H160 body, or null if invalid. */
 export function decodeQAddress(addr: string): Uint8Array | null {
   const s = addr.toLowerCase();
   const pos = s.lastIndexOf("1");
@@ -81,8 +88,9 @@ export function decodeQAddress(addr: string): Uint8Array | null {
   if (hrp !== QADDR_HRP) return null;
   const dataPart = s.slice(pos + 1);
   const decoded: number[] = [];
-  for (const ch of dataPart) {
-    const d = CHARSET.indexOf(ch);
+  for (let i = 0; i < dataPart.length; i++) {
+    const code = dataPart.charCodeAt(i);
+    const d = code < 128 ? CHARSET_REV[code] : -1;
     if (d === -1) return null;
     decoded.push(d);
   }

--- a/libs/coin-modules/coin-quantova/src/logic/address.ts
+++ b/libs/coin-modules/coin-quantova/src/logic/address.ts
@@ -1,0 +1,112 @@
+/**
+ * Quantova address codec.
+ *
+ * Canonical user-facing address is **Q-branded Bech32m** over the 20-byte H160 body:
+ *
+ *   pubkey --SHA3-256--> digest[0..20]   (20-byte body; body[0] forced to 0x40 = "Q")
+ *   display = bech32m(hrp="q", body)  ->  rendered uppercase as "Q1…"
+ *
+ * The hex H160 form ("Q<40-hex>" / "Qx<40-hex>" / "0x<40-hex>") is also accepted on the
+ * wire (see runtime `token.rs::q_address_to_account`). Both encode the same 20 bytes.
+ *
+ * This is a self-contained bech32m implementation (BIP-350 polynomial, const 0x2bc830a3)
+ * so the module has no extra runtime dependency.
+ */
+import { QADDR_HRP, QADDR_BRAND_BYTE } from "../constants";
+
+const CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+const BECH32M_CONST = 0x2bc830a3;
+
+function polymod(values: number[]): number {
+  const GEN = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
+  let chk = 1;
+  for (const v of values) {
+    const top = chk >> 25;
+    chk = ((chk & 0x1ffffff) << 5) ^ v;
+    for (let i = 0; i < 5; i++) if ((top >> i) & 1) chk ^= GEN[i];
+  }
+  return chk;
+}
+
+function hrpExpand(hrp: string): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < hrp.length; i++) out.push(hrp.charCodeAt(i) >> 5);
+  out.push(0);
+  for (let i = 0; i < hrp.length; i++) out.push(hrp.charCodeAt(i) & 31);
+  return out;
+}
+
+function convertBits(data: number[], from: number, to: number, pad: boolean): number[] | null {
+  let acc = 0;
+  let bits = 0;
+  const out: number[] = [];
+  const maxv = (1 << to) - 1;
+  for (const value of data) {
+    if (value < 0 || value >> from !== 0) return null;
+    acc = (acc << from) | value;
+    bits += from;
+    while (bits >= to) {
+      bits -= to;
+      out.push((acc >> bits) & maxv);
+    }
+  }
+  if (pad) {
+    if (bits > 0) out.push((acc << (to - bits)) & maxv);
+  } else if (bits >= from || ((acc << (to - bits)) & maxv) !== 0) {
+    return null;
+  }
+  return out;
+}
+
+/** Encode a 20-byte H160 body to the canonical "Q1…" bech32m address. */
+export function encodeQAddress(body: Uint8Array): string {
+  if (body.length !== 20) throw new Error("Quantova address body must be 20 bytes");
+  const data = convertBits(Array.from(body), 8, 5, true);
+  if (!data) throw new Error("Quantova address: 8->5 bit conversion failed");
+  const values = hrpExpand(QADDR_HRP).concat(data);
+  const mod = polymod(values.concat([0, 0, 0, 0, 0, 0])) ^ BECH32M_CONST;
+  const checksum: number[] = [];
+  for (let i = 0; i < 6; i++) checksum.push((mod >> (5 * (5 - i))) & 31);
+  const payload = data.concat(checksum).map(d => CHARSET[d]).join("");
+  // canonical display is uppercase ("Q1…")
+  return `${QADDR_HRP}1${payload}`.toUpperCase();
+}
+
+/** Decode a "Q1…" bech32m address to its 20-byte H160 body, or null if invalid. */
+export function decodeQAddress(addr: string): Uint8Array | null {
+  const s = addr.toLowerCase();
+  const pos = s.lastIndexOf("1");
+  if (pos < 1 || pos + 7 > s.length) return null;
+  const hrp = s.slice(0, pos);
+  if (hrp !== QADDR_HRP) return null;
+  const dataPart = s.slice(pos + 1);
+  const decoded: number[] = [];
+  for (const ch of dataPart) {
+    const d = CHARSET.indexOf(ch);
+    if (d === -1) return null;
+    decoded.push(d);
+  }
+  if (polymod(hrpExpand(hrp).concat(decoded)) !== BECH32M_CONST) return null;
+  const body = convertBits(decoded.slice(0, -6), 5, 8, false);
+  if (!body || body.length !== 20) return null;
+  if (body[0] !== QADDR_BRAND_BYTE) return null; // must carry the "Q" brand byte
+  return Uint8Array.from(body);
+}
+
+/** Decode a hex H160 form ("Q<40hex>" / "Qx<40hex>" / "0x<40hex>") to its 20-byte body. */
+export function decodeHexAddress(addr: string): Uint8Array | null {
+  let hex = addr;
+  if (/^(0x|0X|qx|Qx)/.test(hex)) hex = hex.slice(2);
+  else if (/^[Qq]/.test(hex)) hex = hex.slice(1);
+  if (!/^[0-9a-fA-F]{40}$/.test(hex)) return null;
+  const body = new Uint8Array(20);
+  for (let i = 0; i < 20; i++) body[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  if (body[0] !== QADDR_BRAND_BYTE) return null;
+  return body;
+}
+
+/** True if `addr` is a valid Quantova address in either the Bech32m or hex H160 form. */
+export function isValidQAddress(addr: string): boolean {
+  if (typeof addr !== "string" || addr.length === 0) return false;
+  return decodeQAddress(addr) !== null || decodeHexAddress(addr) !== null;
+}

--- a/libs/coin-modules/coin-quantova/src/logic/hex.ts
+++ b/libs/coin-modules/coin-quantova/src/logic/hex.ts
@@ -1,0 +1,15 @@
+/** Minimal hex helpers (no dependency). */
+
+export function bytesToHex(bytes: Uint8Array, prefix = false): string {
+  let s = "";
+  for (const b of bytes) s += b.toString(16).padStart(2, "0");
+  return prefix ? "0x" + s : s;
+}
+
+export function hexToBytes(hex: string): Uint8Array {
+  const h = hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex;
+  if (h.length % 2 !== 0) throw new Error("hex string must have an even length");
+  const out = new Uint8Array(h.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(h.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}

--- a/libs/coin-modules/coin-quantova/src/logic/index.ts
+++ b/libs/coin-modules/coin-quantova/src/logic/index.ts
@@ -1,0 +1,2 @@
+export * from "./address";
+export { validateAddress } from "./validateAddress";

--- a/libs/coin-modules/coin-quantova/src/logic/index.ts
+++ b/libs/coin-modules/coin-quantova/src/logic/index.ts
@@ -1,2 +1,3 @@
 export * from "./address";
+export * from "./hex";
 export { validateAddress } from "./validateAddress";

--- a/libs/coin-modules/coin-quantova/src/logic/transaction/signTransaction.ts
+++ b/libs/coin-modules/coin-quantova/src/logic/transaction/signTransaction.ts
@@ -1,0 +1,51 @@
+/**
+ * Sign a Quantova extrinsic with any `QuantovaSigner` (software or device).
+ *
+ * Flow (the proven qweb3.js path):
+ *   1. qweb3.js builds the call + `TxExtension` extra. The `CheckMetadataHash` extension is
+ *      set to **enabled** so the signing payload commits to the runtime's metadata digest —
+ *      this is what lets a device clear-sign (show amount/asset/recipient) instead of
+ *      blind-signing.
+ *   2. We extract the raw SCALE signing-payload bytes and hand them to the `QuantovaSigner`.
+ *   3. The signer returns a `QSignature` envelope; we encode it to its exact on-chain bytes
+ *      (`encodeQSignature`) and attach it to the extrinsic.
+ *   4. The serialized signed extrinsic is broadcast via `q_sendRawTransaction`.
+ *
+ * `tx`/`registry` are typed against the minimal qweb3.js surface we use, so this module
+ * does not hard-depend on the SDK's full type tree.
+ */
+import type { QuantovaSigner } from "../../types/signer";
+import { encodeQSignature } from "../../pq/qsignature";
+import { bytesToHex } from "../hex";
+
+/** Minimal view of a qweb3.js submittable extrinsic. */
+export interface QSubmittable {
+  /** SCALE signing-payload bytes for the given signer + options (CheckMetadataHash enabled). */
+  signingPayload(address: string, options: { withMetadataHash: true; path?: string }): Promise<Uint8Array>;
+  /** attach an already-computed signature envelope and finalise the extrinsic. */
+  addSignature(address: string, signatureHex: string): QSubmittable;
+  /** serialized signed extrinsic, ready for `q_sendRawTransaction`. */
+  toHex(): string;
+}
+
+export type SignedExtrinsic = { hex: string; signerAddress: string };
+
+/** Produce a serialized, signed Quantova extrinsic. */
+export async function signTransaction(
+  tx: QSubmittable,
+  signer: QuantovaSigner,
+  path = "",
+): Promise<SignedExtrinsic> {
+  const { address } = await signer.getAddress(path);
+
+  // (1)+(2): payload bytes with the metadata hash committed.
+  const payload = await tx.signingPayload(address, { withMetadataHash: true, path });
+
+  // (3): post-quantum signature, encoded to the on-chain `QSignature` envelope.
+  const envelope = await signer.signPayload(path, payload);
+  const signatureHex = bytesToHex(encodeQSignature(envelope), true);
+
+  // (4): attach + serialize.
+  const hex = tx.addSignature(address, signatureHex).toHex();
+  return { hex, signerAddress: address };
+}

--- a/libs/coin-modules/coin-quantova/src/logic/transaction/signTransaction.ts
+++ b/libs/coin-modules/coin-quantova/src/logic/transaction/signTransaction.ts
@@ -3,7 +3,7 @@
  *
  * Flow (the proven qweb3.js path):
  *   1. qweb3.js builds the call + `TxExtension` extra. The `CheckMetadataHash` extension is
- *      set to **enabled** so the signing payload commits to the runtime's metadata digest —
+ *      set to **enabled** so the signing payload commits to the runtime's metadata digest  - 
  *      this is what lets a device clear-sign (show amount/asset/recipient) instead of
  *      blind-signing.
  *   2. We extract the raw SCALE signing-payload bytes and hand them to the `QuantovaSigner`.

--- a/libs/coin-modules/coin-quantova/src/logic/validateAddress.ts
+++ b/libs/coin-modules/coin-quantova/src/logic/validateAddress.ts
@@ -1,0 +1,9 @@
+import { isValidQAddress } from "./address";
+
+/**
+ * Validate a Quantova recipient address. Accepts the canonical "Q1…" Bech32m form and
+ * the hex H160 form; both must carry the 0x40 "Q" brand byte.
+ */
+export async function validateAddress(address: string): Promise<boolean> {
+  return isValidQAddress(address);
+}

--- a/libs/coin-modules/coin-quantova/src/logic/validateAddress.ts
+++ b/libs/coin-modules/coin-quantova/src/logic/validateAddress.ts
@@ -1,7 +1,7 @@
 import { isValidQAddress } from "./address";
 
 /**
- * Validate a Quantova recipient address. Accepts the canonical "Q1…" Bech32m form and
+ * Validate a Quantova recipient address. Accepts the canonical "Q1..." Bech32m form and
  * the hex H160 form; both must carry the 0x40 "Q" brand byte.
  */
 export async function validateAddress(address: string): Promise<boolean> {

--- a/libs/coin-modules/coin-quantova/src/network/node.ts
+++ b/libs/coin-modules/coin-quantova/src/network/node.ts
@@ -37,12 +37,12 @@ export class QuantovaNode {
     return parseInt(await this.call<string>("q_blockNumber"), 16);
   }
 
-  /** QTOV balance in plancks for a "Q1…" address at a block (default: latest). */
+  /** QTOV balance in plancks for a "Q1..." address at a block (default: latest). */
   async getBalance(address: string, block = "latest"): Promise<bigint> {
     return BigInt(await this.call<string>("q_getBalance", [address, block]));
   }
 
-  /** Account nonce — the number of transactions sent (use as the next tx nonce). */
+  /** Account nonce - the number of transactions sent (use as the next tx nonce). */
   async getTransactionCount(address: string, block = "latest"): Promise<number> {
     return parseInt(await this.call<string>("q_getTransactionCount", [address, block]), 16);
   }

--- a/libs/coin-modules/coin-quantova/src/network/node.ts
+++ b/libs/coin-modules/coin-quantova/src/network/node.ts
@@ -1,0 +1,68 @@
+/**
+ * Thin client over Quantova's `q_` JSON-RPC namespace.
+ *
+ * The `q_` namespace is JSON-RPC over HTTP and is the canonical way exchanges, wallets
+ * and indexers reach a Quantova node (developer docs, ch. 16). Values are hex QUANTITY
+ * unless noted. This client is transport-agnostic; pass any fetch-like `post`.
+ */
+
+export type JsonRpcPost = (body: unknown) => Promise<{ result?: unknown; error?: unknown }>;
+
+function makePost(endpoint: string): JsonRpcPost {
+  return async body => {
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    return res.json() as Promise<{ result?: unknown; error?: unknown }>;
+  };
+}
+
+export class QuantovaNode {
+  private post: JsonRpcPost;
+
+  constructor(endpoint: string, post?: JsonRpcPost) {
+    this.post = post ?? makePost(endpoint);
+  }
+
+  private async call<T>(method: string, params: unknown[] = []): Promise<T> {
+    const out = await this.post({ jsonrpc: "2.0", id: 1, method, params });
+    if (out.error) throw new Error(`${method}: ${JSON.stringify(out.error)}`);
+    return out.result as T;
+  }
+
+  /** Latest block height (hex QUANTITY -> number). */
+  async blockNumber(): Promise<number> {
+    return parseInt(await this.call<string>("q_blockNumber"), 16);
+  }
+
+  /** QTOV balance in plancks for a "Q1…" address at a block (default: latest). */
+  async getBalance(address: string, block = "latest"): Promise<bigint> {
+    return BigInt(await this.call<string>("q_getBalance", [address, block]));
+  }
+
+  /** Account nonce — the number of transactions sent (use as the next tx nonce). */
+  async getTransactionCount(address: string, block = "latest"): Promise<number> {
+    return parseInt(await this.call<string>("q_getTransactionCount", [address, block]), 16);
+  }
+
+  /** Recent base fees / priority-fee percentiles / gas-used ratios. */
+  async feeHistory(
+    blockCount: number,
+    newest = "latest",
+    percentiles: number[] = [25, 50, 75],
+  ): Promise<unknown> {
+    return this.call("q_feeHistory", [blockCount, newest, percentiles]);
+  }
+
+  /** Submit an already-signed, SCALE-encoded extrinsic; returns the tx hash. */
+  async sendRawTransaction(signedTxHex: string): Promise<string> {
+    return this.call<string>("q_sendRawTransaction", [signedTxHex]);
+  }
+
+  /** Chain id, used in signing to prevent cross-chain replay. */
+  async chainId(): Promise<string> {
+    return this.call<string>("q_chainId");
+  }
+}

--- a/libs/coin-modules/coin-quantova/src/pq/index.ts
+++ b/libs/coin-modules/coin-quantova/src/pq/index.ts
@@ -1,0 +1,3 @@
+export * from "./schemes";
+export * from "./qsignature";
+export * from "./keygen";

--- a/libs/coin-modules/coin-quantova/src/pq/keygen.ts
+++ b/libs/coin-modules/coin-quantova/src/pq/keygen.ts
@@ -2,13 +2,13 @@
  * Post-quantum key generation + signing via Quantova's **qweb3.js** SDK.
  *
  * qweb3.js ships the proven PQ stack used by every Quantova signer:
- *   - `@quantova/keyring`      — a per-scheme Keyring (Dilithium / Falcon / SPHINCS+)
- *   - `@quantova/util-crypto`  — `cryptoWaitReady` + WASM-crypto registration
- *   - `@quantova/falcon-wasm`  — the audited PQ primitives (`*_pair_from_seed`, `*_sign`)
+ *   - `@quantova/keyring`      - a per-scheme Keyring (Dilithium / Falcon / SPHINCS+)
+ *   - `@quantova/util-crypto`  - `cryptoWaitReady` + WASM-crypto registration
+ *   - `@quantova/falcon-wasm`  - the audited PQ primitives (`*_pair_from_seed`, `*_sign`)
  *
  * We wrap that surface behind a small adapter so this module compiles without the SDK at
  * type-check time, and so an on-device app can later implement the SAME `QPair` contract.
- * The reference implementation here is a **software** signer (keys in memory) — it proves
+ * The reference implementation here is a **software** signer (keys in memory) - it proves
  * the end-to-end flow and is the exact spec a Ledger device app must reproduce on-chip.
  */
 import { QScheme, QSCHEMES } from "./schemes";
@@ -17,7 +17,7 @@ import { isValidQAddress } from "../logic/address";
 /** A post-quantum keypair, however its private material is held (software or device). */
 export interface QPair {
   scheme: QScheme;
-  /** canonical "Q1…" address */
+  /** canonical "Q1..." address */
   address: string;
   /** PQ public key bytes (length matches the scheme) */
   publicKey: Uint8Array;

--- a/libs/coin-modules/coin-quantova/src/pq/keygen.ts
+++ b/libs/coin-modules/coin-quantova/src/pq/keygen.ts
@@ -1,0 +1,91 @@
+/**
+ * Post-quantum key generation + signing via Quantova's **qweb3.js** SDK.
+ *
+ * qweb3.js ships the proven PQ stack used by every Quantova signer:
+ *   - `@quantova/keyring`      — a per-scheme Keyring (Dilithium / Falcon / SPHINCS+)
+ *   - `@quantova/util-crypto`  — `cryptoWaitReady` + WASM-crypto registration
+ *   - `@quantova/falcon-wasm`  — the audited PQ primitives (`*_pair_from_seed`, `*_sign`)
+ *
+ * We wrap that surface behind a small adapter so this module compiles without the SDK at
+ * type-check time, and so an on-device app can later implement the SAME `QPair` contract.
+ * The reference implementation here is a **software** signer (keys in memory) — it proves
+ * the end-to-end flow and is the exact spec a Ledger device app must reproduce on-chip.
+ */
+import { QScheme, QSCHEMES } from "./schemes";
+import { isValidQAddress } from "../logic/address";
+
+/** A post-quantum keypair, however its private material is held (software or device). */
+export interface QPair {
+  scheme: QScheme;
+  /** canonical "Q1…" address */
+  address: string;
+  /** PQ public key bytes (length matches the scheme) */
+  publicKey: Uint8Array;
+  /** produce a PQ signature over `message` */
+  sign(message: Uint8Array): Promise<Uint8Array> | Uint8Array;
+}
+
+/** Loads and initialises the qweb3.js PQ stack once (idempotent). */
+let sdkReady: Promise<{ Keyring: new (opts: { type: string }) => Qweb3Keyring }> | null = null;
+
+interface Qweb3Keyring {
+  addFromSeed(seed: Uint8Array): Qweb3Pair;
+  addFromUri(uri: string): Qweb3Pair;
+  addFromMnemonic(mnemonic: string): Qweb3Pair;
+}
+interface Qweb3Pair {
+  address: string;
+  publicKey: Uint8Array;
+  sign(message: Uint8Array): Uint8Array;
+}
+
+async function loadQweb3() {
+  if (!sdkReady) {
+    sdkReady = (async () => {
+      // qweb3.js re-exports these; importing the scoped packages keeps us on the proven path.
+      const [{ Keyring }, utilCrypto, falconWasm] = await Promise.all([
+        import("@quantova/keyring"),
+        import("@quantova/util-crypto"),
+        import("@quantova/falcon-wasm"),
+      ]);
+      await utilCrypto.cryptoWaitReady();
+      // Register the WASM PQ primitives with the keyring (exactly as Quantova's signers do).
+      utilCrypto.setSphincspWasmCrypto?.(falconWasm);
+      utilCrypto.setFalconWasmCrypto?.(falconWasm);
+      utilCrypto.setDilithiumWasmCrypto?.(falconWasm);
+      return { Keyring };
+    })();
+  }
+  return sdkReady;
+}
+
+/** Build a software `QPair` from a 32-byte seed (testing / reference signing only). */
+export async function pairFromSeed(scheme: QScheme, seed: Uint8Array): Promise<QPair> {
+  const { Keyring } = await loadQweb3();
+  const kr = new Keyring({ type: scheme });
+  const pair = kr.addFromSeed(seed);
+  return wrap(scheme, pair);
+}
+
+/** Build a software `QPair` from a Quantova URI / mnemonic (reference signing only). */
+export async function pairFromUri(scheme: QScheme, uri: string): Promise<QPair> {
+  const { Keyring } = await loadQweb3();
+  const kr = new Keyring({ type: scheme });
+  const pair = uri.includes(" ") ? kr.addFromMnemonic(uri) : kr.addFromUri(uri);
+  return wrap(scheme, pair);
+}
+
+function wrap(scheme: QScheme, pair: Qweb3Pair): QPair {
+  if (pair.publicKey.length !== QSCHEMES[scheme].publicKeyLength) {
+    throw new Error(`${QSCHEMES[scheme].label}: unexpected public key length`);
+  }
+  if (!isValidQAddress(pair.address)) {
+    throw new Error(`qweb3.js returned a non-canonical address: ${pair.address}`);
+  }
+  return {
+    scheme,
+    address: pair.address,
+    publicKey: pair.publicKey,
+    sign: (message: Uint8Array) => pair.sign(message),
+  };
+}

--- a/libs/coin-modules/coin-quantova/src/pq/performance.test.ts
+++ b/libs/coin-modules/coin-quantova/src/pq/performance.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Performance test + benchmark for the Quantova codecs.
+ *
+ * Logs throughput (ops/s) for the address and QSignature codecs and asserts each stays
+ * under a generous per-op budget, so a regression that makes a codec pathologically slow
+ * (e.g. an accidental O(n^2) on the 7856-byte SPHINCS+ signature) fails CI. Budgets are set
+ * far above measured numbers (~0.5-1.5 us/op) to avoid flakiness on slow CI machines.
+ */
+import { performance } from "node:perf_hooks";
+import { QScheme, QSCHEMES } from "./schemes";
+import { encodeQSignature, decodeQSignature, compactEncode, compactDecode } from "./qsignature";
+import { encodeQAddress, decodeQAddress } from "../logic/address";
+
+const fill = (n: number, s: number): Uint8Array => {
+  const a = new Uint8Array(n);
+  for (let i = 0; i < n; i++) a[i] = (i * s + 7) & 0xff;
+  return a;
+};
+const body = (() => {
+  const b = new Uint8Array(20);
+  b[0] = 0x40;
+  for (let i = 1; i < 20; i++) b[i] = (i * 101 + 3) & 0xff;
+  return b;
+})();
+
+function bench(name: string, fn: () => unknown, iters: number): number {
+  fn();
+  fn(); // warm up
+  const t0 = performance.now();
+  for (let i = 0; i < iters; i++) fn();
+  const ms = performance.now() - t0;
+  const usPerOp = (ms / iters) * 1000;
+  // eslint-disable-next-line no-console
+  console.log(`[bench] ${name.padEnd(28)} ${(iters / (ms / 1000)).toFixed(0)} ops/s  (${usPerOp.toFixed(2)} us/op)`);
+  return usPerOp;
+}
+
+const BUDGET_US = 50; // generous; measured ~0.5-1.5 us/op
+
+describe("coin-quantova codec performance", () => {
+  const addr = encodeQAddress(body);
+
+  it(`address encode/decode under ${BUDGET_US}us/op`, () => {
+    expect(bench("address encode", () => encodeQAddress(body), 50000)).toBeLessThan(BUDGET_US);
+    expect(bench("address decode", () => decodeQAddress(addr), 50000)).toBeLessThan(BUDGET_US);
+  });
+
+  for (const scheme of Object.values(QScheme)) {
+    const p = QSCHEMES[scheme];
+    const env = {
+      scheme,
+      signature: fill(p.maxSignatureLength, 3),
+      publicKey: fill(p.publicKeyLength, 9),
+    };
+    const enc = encodeQSignature(env);
+    it(`QSignature ${p.label} encode/decode under ${BUDGET_US}us/op`, () => {
+      expect(bench(`QSignature encode ${scheme}`, () => encodeQSignature(env), 20000)).toBeLessThan(BUDGET_US);
+      expect(bench(`QSignature decode ${scheme}`, () => decodeQSignature(enc), 20000)).toBeLessThan(BUDGET_US);
+    });
+  }
+
+  it("compact encode+decode under 5us/op", () => {
+    expect(bench("compact enc+dec", () => compactDecode(compactEncode(7856)), 200000)).toBeLessThan(5);
+  });
+});

--- a/libs/coin-modules/coin-quantova/src/pq/qsignature.test.ts
+++ b/libs/coin-modules/coin-quantova/src/pq/qsignature.test.ts
@@ -1,0 +1,51 @@
+import { QScheme, QSCHEMES } from "./schemes";
+import {
+  encodeQSignature,
+  decodeQSignature,
+  compactEncode,
+  compactDecode,
+} from "./qsignature";
+
+const fill = (n: number, seed: number) => {
+  const a = new Uint8Array(n);
+  for (let i = 0; i < n; i++) a[i] = (i * seed + 7) & 0xff;
+  return a;
+};
+
+describe("SCALE compact codec", () => {
+  it.each([0, 1, 63, 64, 754, 2420, 7856, 16383, 16384, 1000000])("round-trips %i", n => {
+    const [v, used] = compactDecode(compactEncode(n));
+    expect(v).toBe(n);
+    expect(used).toBe(compactEncode(n).length);
+  });
+});
+
+describe("QSignature envelope codec", () => {
+  for (const scheme of Object.values(QScheme)) {
+    const p = QSCHEMES[scheme];
+    it(`round-trips ${p.label} (variant ${p.variant}, pk ${p.publicKeyLength})`, () => {
+      const env = {
+        scheme,
+        signature: fill(p.maxSignatureLength, p.variant + 1),
+        publicKey: fill(p.publicKeyLength, p.variant + 13),
+      };
+      const bytes = encodeQSignature(env);
+      // first byte is the SCALE enum variant
+      expect(bytes[0]).toBe(p.variant);
+      const back = decodeQSignature(bytes);
+      expect(back.scheme).toBe(scheme);
+      expect(Array.from(back.signature)).toEqual(Array.from(env.signature));
+      expect(Array.from(back.publicKey)).toEqual(Array.from(env.publicKey));
+    });
+  }
+
+  it("rejects a wrong-length public key", () => {
+    expect(() =>
+      encodeQSignature({
+        scheme: QScheme.DILITHIUM,
+        signature: new Uint8Array(10),
+        publicKey: new Uint8Array(100),
+      }),
+    ).toThrow();
+  });
+});

--- a/libs/coin-modules/coin-quantova/src/pq/qsignature.test.ts
+++ b/libs/coin-modules/coin-quantova/src/pq/qsignature.test.ts
@@ -13,11 +13,15 @@ const fill = (n: number, seed: number) => {
 };
 
 describe("SCALE compact codec", () => {
-  it.each([0, 1, 63, 64, 754, 2420, 7856, 16383, 16384, 1000000])("round-trips %i", n => {
-    const [v, used] = compactDecode(compactEncode(n));
-    expect(v).toBe(n);
-    expect(used).toBe(compactEncode(n).length);
-  });
+  // includes 2^29 and 2^30-1: the 4-byte-mode range that requires unsigned shifts.
+  it.each([0, 1, 63, 64, 754, 2420, 7856, 16383, 16384, 1000000, 536870912, 1073741823])(
+    "round-trips %i",
+    n => {
+      const [v, used] = compactDecode(compactEncode(n));
+      expect(v).toBe(n);
+      expect(used).toBe(compactEncode(n).length);
+    },
+  );
 });
 
 describe("QSignature envelope codec", () => {

--- a/libs/coin-modules/coin-quantova/src/pq/qsignature.ts
+++ b/libs/coin-modules/coin-quantova/src/pq/qsignature.ts
@@ -26,12 +26,12 @@ export function compactEncode(n: number): Uint8Array {
   if (n < 0 || !Number.isInteger(n)) throw new Error("compact: non-negative integer required");
   if (n < 1 << 6) return Uint8Array.of(n << 2); // single-byte mode
   if (n < 1 << 14) {
-    const v = (n << 2) | 0b01;
-    return Uint8Array.of(v & 0xff, (v >> 8) & 0xff); // two-byte mode
+    const v = ((n << 2) | 0b01) >>> 0;
+    return Uint8Array.of(v & 0xff, (v >>> 8) & 0xff); // two-byte mode
   }
   if (n < 1 << 30) {
-    const v = (n << 2) | 0b10;
-    return Uint8Array.of(v & 0xff, (v >> 8) & 0xff, (v >> 16) & 0xff, (v >> 24) & 0xff);
+    const v = ((n << 2) | 0b10) >>> 0; // unsigned: n<<2 can set bit 31
+    return Uint8Array.of(v & 0xff, (v >>> 8) & 0xff, (v >>> 16) & 0xff, (v >>> 24) & 0xff);
   }
   // big-integer mode (4..67 bytes); sufficient for any PQ signature length.
   const bytes: number[] = [];
@@ -47,11 +47,11 @@ export function compactEncode(n: number): Uint8Array {
 export function compactDecode(buf: Uint8Array, offset = 0): [number, number] {
   const first = buf[offset];
   const mode = first & 0b11;
-  if (mode === 0b00) return [first >> 2, 1];
-  if (mode === 0b01) return [((first | (buf[offset + 1] << 8)) >>> 0) >> 2, 2];
+  if (mode === 0b00) return [first >>> 2, 1];
+  if (mode === 0b01) return [((first | (buf[offset + 1] << 8)) >>> 0) >>> 2, 2];
   if (mode === 0b10) {
     const v = (first | (buf[offset + 1] << 8) | (buf[offset + 2] << 16) | (buf[offset + 3] << 24)) >>> 0;
-    return [v >> 2, 4];
+    return [v >>> 2, 4]; // unsigned: 4-byte compact values can exceed 2^31
   }
   const len = (first >> 2) + 4;
   let v = 0;

--- a/libs/coin-modules/coin-quantova/src/pq/qsignature.ts
+++ b/libs/coin-modules/coin-quantova/src/pq/qsignature.ts
@@ -1,0 +1,94 @@
+/**
+ * On-chain `QSignature` envelope codec.
+ *
+ * The runtime's `QSignature` is a SCALE enum (`primitives/account`):
+ *
+ *   QSignature = variant_byte(0|1|2)
+ *              || compact(len(signature)) || signature_bytes   // BoundedVec<u8>
+ *              || public_key_bytes                              // fixed [u8; N]
+ *
+ * variant: 0 = SPHINCS+, 1 = Falcon, 2 = Dilithium. This is the exact byte layout a
+ * device app must emit; modelling it here keeps the host and an eventual on-device app
+ * byte-compatible.
+ */
+import { QScheme, QSCHEMES, schemeFromVariant } from "./schemes";
+
+export type QSignatureEnvelope = {
+  scheme: QScheme;
+  /** raw signature bytes */
+  signature: Uint8Array;
+  /** raw public-key bytes (length must match the scheme) */
+  publicKey: Uint8Array;
+};
+
+/** SCALE compact-uint encoding (used here for the signature length prefix). */
+export function compactEncode(n: number): Uint8Array {
+  if (n < 0 || !Number.isInteger(n)) throw new Error("compact: non-negative integer required");
+  if (n < 1 << 6) return Uint8Array.of(n << 2); // single-byte mode
+  if (n < 1 << 14) {
+    const v = (n << 2) | 0b01;
+    return Uint8Array.of(v & 0xff, (v >> 8) & 0xff); // two-byte mode
+  }
+  if (n < 1 << 30) {
+    const v = (n << 2) | 0b10;
+    return Uint8Array.of(v & 0xff, (v >> 8) & 0xff, (v >> 16) & 0xff, (v >> 24) & 0xff);
+  }
+  // big-integer mode (4..67 bytes); sufficient for any PQ signature length.
+  const bytes: number[] = [];
+  let x = n;
+  while (x > 0) {
+    bytes.push(x & 0xff);
+    x = Math.floor(x / 256);
+  }
+  return Uint8Array.of(((bytes.length - 4) << 2) | 0b11, ...bytes);
+}
+
+/** Decode a SCALE compact-uint, returning [value, bytesConsumed]. */
+export function compactDecode(buf: Uint8Array, offset = 0): [number, number] {
+  const first = buf[offset];
+  const mode = first & 0b11;
+  if (mode === 0b00) return [first >> 2, 1];
+  if (mode === 0b01) return [((first | (buf[offset + 1] << 8)) >>> 0) >> 2, 2];
+  if (mode === 0b10) {
+    const v = (first | (buf[offset + 1] << 8) | (buf[offset + 2] << 16) | (buf[offset + 3] << 24)) >>> 0;
+    return [v >> 2, 4];
+  }
+  const len = (first >> 2) + 4;
+  let v = 0;
+  for (let i = 0; i < len; i++) v += buf[offset + 1 + i] * 256 ** i;
+  return [v, 1 + len];
+}
+
+/** Encode a `QSignature` to its exact on-chain byte layout. */
+export function encodeQSignature(env: QSignatureEnvelope): Uint8Array {
+  const params = QSCHEMES[env.scheme];
+  if (env.publicKey.length !== params.publicKeyLength) {
+    throw new Error(
+      `${params.label}: public key must be ${params.publicKeyLength} bytes, got ${env.publicKey.length}`,
+    );
+  }
+  if (env.signature.length > params.maxSignatureLength) {
+    throw new Error(
+      `${params.label}: signature exceeds ${params.maxSignatureLength} bytes (${env.signature.length})`,
+    );
+  }
+  const len = compactEncode(env.signature.length);
+  const out = new Uint8Array(1 + len.length + env.signature.length + env.publicKey.length);
+  let o = 0;
+  out[o++] = params.variant;
+  out.set(len, o); o += len.length;
+  out.set(env.signature, o); o += env.signature.length;
+  out.set(env.publicKey, o);
+  return out;
+}
+
+/** Decode an on-chain `QSignature` envelope. */
+export function decodeQSignature(buf: Uint8Array): QSignatureEnvelope {
+  const scheme = schemeFromVariant(buf[0]);
+  const params = QSCHEMES[scheme];
+  const [sigLen, lenBytes] = compactDecode(buf, 1);
+  const sigStart = 1 + lenBytes;
+  const signature = buf.slice(sigStart, sigStart + sigLen);
+  const publicKey = buf.slice(sigStart + sigLen, sigStart + sigLen + params.publicKeyLength);
+  return { scheme, signature, publicKey };
+}

--- a/libs/coin-modules/coin-quantova/src/pq/schemes.ts
+++ b/libs/coin-modules/coin-quantova/src/pq/schemes.ts
@@ -1,0 +1,73 @@
+/**
+ * Quantova post-quantum signature scheme registry.
+ *
+ * Every Quantova account is secured by ONE of three NIST post-quantum signature schemes.
+ * The on-chain `QSignature` is a SCALE enum whose variant index selects the scheme; the
+ * parameters below mirror the runtime exactly (`primitives/account`):
+ *
+ *   variant  scheme       NIST std            pubkey   sig (max)   on-chain types
+ *   0        SPHINCS+     SLH-DSA  (FIPS 205)  32 B     7856 B      sphincsp::Public / SphincsSignatureBytes
+ *   1        Falcon       FN-DSA   (FIPS 206)  897 B    754 B       falcon::Public    / FalconSignatureBytes
+ *   2        Dilithium    ML-DSA   (FIPS 204)  1312 B   2420 B      dilithium::Public / DilithiumSignatureBytes
+ *
+ * The address is derived from the public key: SHA3-256(pubkey)[0..20], byte0 = 0x40.
+ */
+
+export enum QScheme {
+  SPHINCS = "sphincsp",
+  FALCON = "falcon",
+  DILITHIUM = "dilithium",
+}
+
+export type QSchemeParams = {
+  /** SCALE enum variant index used on-chain in `QSignature`. */
+  variant: 0 | 1 | 2;
+  /** Display label. */
+  label: string;
+  /** NIST standard name. */
+  nist: string;
+  /** Public-key length in bytes (fixed). */
+  publicKeyLength: number;
+  /** Maximum signature length in bytes (BoundedVec bound on-chain). */
+  maxSignatureLength: number;
+  /**
+   * Rough Secure-Element friendliness for an eventual on-device app.
+   * Dilithium is the most SE-tractable of the three; SPHINCS+ signatures are the
+   * largest. This guides which scheme a first `app-quantova` would target.
+   */
+  seFriendliness: "best" | "moderate" | "hard";
+};
+
+export const QSCHEMES: Record<QScheme, QSchemeParams> = {
+  [QScheme.SPHINCS]: {
+    variant: 0,
+    label: "SPHINCS+",
+    nist: "SLH-DSA (FIPS 205)",
+    publicKeyLength: 32,
+    maxSignatureLength: 7856,
+    seFriendliness: "hard",
+  },
+  [QScheme.FALCON]: {
+    variant: 1,
+    label: "Falcon",
+    nist: "FN-DSA (FIPS 206)",
+    publicKeyLength: 897,
+    maxSignatureLength: 754,
+    seFriendliness: "moderate",
+  },
+  [QScheme.DILITHIUM]: {
+    variant: 2,
+    label: "Dilithium",
+    nist: "ML-DSA (FIPS 204)",
+    publicKeyLength: 1312,
+    maxSignatureLength: 2420,
+    seFriendliness: "best",
+  },
+};
+
+/** Map a SCALE variant byte (0/1/2) back to its scheme. */
+export function schemeFromVariant(variant: number): QScheme {
+  const found = (Object.values(QScheme) as QScheme[]).find(s => QSCHEMES[s].variant === variant);
+  if (!found) throw new Error(`unknown QSignature variant ${variant}`);
+  return found;
+}

--- a/libs/coin-modules/coin-quantova/src/signer/deviceSigner.ts
+++ b/libs/coin-modules/coin-quantova/src/signer/deviceSigner.ts
@@ -1,0 +1,47 @@
+/**
+ * Device signer contract — the target for a Ledger `app-quantova`.
+ *
+ * This is the SAME `QuantovaSigner` interface as the software reference, but backed by a
+ * Ledger device app over a transport (APDU). The app must:
+ *
+ *   1. derive the account's PQ keypair on-chip for the BIP-44 `path` (key never leaves
+ *      the Secure Element);
+ *   2. on `signPayload`, parse the SCALE payload, verify the embedded `CheckMetadataHash`
+ *      digest against the app's metadata so it can display amount / asset / recipient
+ *      (clear-signing, not blind-signing), and on user approval return the PQ signature;
+ *   3. emit the `QSignature` envelope exactly as `pq/qsignature.ts` specifies.
+ *
+ * No such app exists yet — `signPayload` here throws until a device app is available.
+ * The APDU command set is intentionally left as the integration point for Ledger.
+ */
+import type { QuantovaSigner, QuantovaAddress } from "../types/signer";
+import type { QSignatureEnvelope } from "../pq/qsignature";
+
+/** A minimal APDU transport (e.g. `@ledgerhq/hw-transport`). */
+export interface QuantovaTransport {
+  send(cla: number, ins: number, p1: number, p2: number, data: Buffer): Promise<Buffer>;
+}
+
+/** Placeholder APDU instruction set for a future `app-quantova`. */
+export const QUANTOVA_APDU = {
+  CLA: 0xe0,
+  INS_GET_PUBLIC_KEY: 0x02,
+  INS_SIGN: 0x04,
+} as const;
+
+export function makeDeviceSigner(_transport: QuantovaTransport): QuantovaSigner {
+  return {
+    async getAddress(_path: string): Promise<QuantovaAddress> {
+      throw new Error(
+        "app-quantova device app not available yet: post-quantum key derivation is the open " +
+          "requirement we are raising with Ledger (see README).",
+      );
+    },
+    async signPayload(_path: string, _payload: Uint8Array): Promise<QSignatureEnvelope> {
+      throw new Error(
+        "app-quantova device app not available yet: on-device Dilithium/Falcon/SPHINCS+ signing " +
+          "is the capability this PR proposes Ledger add.",
+      );
+    },
+  };
+}

--- a/libs/coin-modules/coin-quantova/src/signer/deviceSigner.ts
+++ b/libs/coin-modules/coin-quantova/src/signer/deviceSigner.ts
@@ -1,5 +1,5 @@
 /**
- * Device signer contract — the target for a Ledger `app-quantova`.
+ * Device signer contract - the target for a Ledger `app-quantova`.
  *
  * This is the SAME `QuantovaSigner` interface as the software reference, but backed by a
  * Ledger device app over a transport (APDU). The app must:
@@ -11,7 +11,7 @@
  *      (clear-signing, not blind-signing), and on user approval return the PQ signature;
  *   3. emit the `QSignature` envelope exactly as `pq/qsignature.ts` specifies.
  *
- * No such app exists yet — `signPayload` here throws until a device app is available.
+ * No such app exists yet - `signPayload` here throws until a device app is available.
  * The APDU command set is intentionally left as the integration point for Ledger.
  */
 import type { QuantovaSigner, QuantovaAddress } from "../types/signer";

--- a/libs/coin-modules/coin-quantova/src/signer/getAddress.ts
+++ b/libs/coin-modules/coin-quantova/src/signer/getAddress.ts
@@ -1,0 +1,22 @@
+import type { QuantovaSigner, QuantovaAddress } from "../types";
+import { isValidQAddress } from "../logic/address";
+
+/**
+ * Resolve a Quantova account address from the device for a derivation path.
+ *
+ * The device returns the account's PQ public key and its canonical "Q1…" address
+ * (derived as SHA3-256(pubkey)[0..20], byte0 = 0x40, rendered Bech32m). We sanity-check
+ * the address shape host-side.
+ */
+export function getAddressResolver(getSigner: (deviceId: string) => Promise<QuantovaSigner>) {
+  return async (deviceId: string, path: string): Promise<QuantovaAddress> => {
+    const signer = await getSigner(deviceId);
+    const result = await signer.getAddress(path);
+    if (!isValidQAddress(result.address)) {
+      throw new Error(`device returned a non-canonical Quantova address: ${result.address}`);
+    }
+    return result;
+  };
+}
+
+export default getAddressResolver;

--- a/libs/coin-modules/coin-quantova/src/signer/getAddress.ts
+++ b/libs/coin-modules/coin-quantova/src/signer/getAddress.ts
@@ -4,7 +4,7 @@ import { isValidQAddress } from "../logic/address";
 /**
  * Resolve a Quantova account address from the device for a derivation path.
  *
- * The device returns the account's PQ public key and its canonical "Q1…" address
+ * The device returns the account's PQ public key and its canonical "Q1..." address
  * (derived as SHA3-256(pubkey)[0..20], byte0 = 0x40, rendered Bech32m). We sanity-check
  * the address shape host-side.
  */

--- a/libs/coin-modules/coin-quantova/src/signer/index.ts
+++ b/libs/coin-modules/coin-quantova/src/signer/index.ts
@@ -1,7 +1,7 @@
 /**
  * Quantova signers. The same `QuantovaSigner` contract is implemented two ways:
- *  - `makeSoftwareSigner` — reference, backed by qweb3.js (keys in software).
- *  - `makeDeviceSigner`   — target, backed by a Ledger `app-quantova` (keys in the SE).
+ *  - `makeSoftwareSigner` - reference, backed by qweb3.js (keys in software).
+ *  - `makeDeviceSigner`   - target, backed by a Ledger `app-quantova` (keys in the SE).
  */
 import getAddressResolver from "./getAddress";
 

--- a/libs/coin-modules/coin-quantova/src/signer/index.ts
+++ b/libs/coin-modules/coin-quantova/src/signer/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Home for the Quantova device-signer wiring (getAddress + signTransaction).
+ */
+import getAddressResolver from "./getAddress";
+
+export { getAddressResolver };
+export default getAddressResolver;

--- a/libs/coin-modules/coin-quantova/src/signer/index.ts
+++ b/libs/coin-modules/coin-quantova/src/signer/index.ts
@@ -1,7 +1,14 @@
 /**
- * Home for the Quantova device-signer wiring (getAddress + signTransaction).
+ * Quantova signers. The same `QuantovaSigner` contract is implemented two ways:
+ *  - `makeSoftwareSigner` — reference, backed by qweb3.js (keys in software).
+ *  - `makeDeviceSigner`   — target, backed by a Ledger `app-quantova` (keys in the SE).
  */
 import getAddressResolver from "./getAddress";
 
 export { getAddressResolver };
+export { makeSoftwareSigner } from "./softwareSigner";
+export type { SoftwareSignerSource } from "./softwareSigner";
+export { makeDeviceSigner, QUANTOVA_APDU } from "./deviceSigner";
+export type { QuantovaTransport } from "./deviceSigner";
+
 export default getAddressResolver;

--- a/libs/coin-modules/coin-quantova/src/signer/softwareSigner.ts
+++ b/libs/coin-modules/coin-quantova/src/signer/softwareSigner.ts
@@ -1,0 +1,46 @@
+/**
+ * Software reference signer (qweb3.js).
+ *
+ * Implements the `QuantovaSigner` contract entirely in software using Quantova's qweb3.js
+ * SDK. It produces REAL, valid `QSignature` envelopes that the chain accepts — proving the
+ * end-to-end post-quantum signing flow.
+ *
+ * ⚠️  This is a REFERENCE, not a hardware wallet: the private key lives in process memory.
+ * Its purpose is (a) to exercise the bridge in CI/bots, and (b) to be the byte-exact spec a
+ * Ledger device app reproduces on-chip. The device path (`deviceSigner`) holds keys in the
+ * Secure Element instead; the two are interchangeable behind this interface.
+ */
+import type { QuantovaSigner, QuantovaAddress } from "../types/signer";
+import type { QSignatureEnvelope } from "../pq/qsignature";
+import { QScheme } from "../pq/schemes";
+import { pairFromSeed, pairFromUri, type QPair } from "../pq/keygen";
+import { bytesToHex } from "../logic/hex";
+
+export type SoftwareSignerSource =
+  | { kind: "seed"; scheme: QScheme; seed: Uint8Array }
+  | { kind: "uri"; scheme: QScheme; uri: string };
+
+/** Build a software `QuantovaSigner` from a seed or URI/mnemonic. */
+export async function makeSoftwareSigner(source: SoftwareSignerSource): Promise<QuantovaSigner> {
+  const pair: QPair =
+    source.kind === "seed"
+      ? await pairFromSeed(source.scheme, source.seed)
+      : await pairFromUri(source.scheme, source.uri);
+
+  const getAddress = async (_path: string): Promise<QuantovaAddress> => ({
+    address: pair.address,
+    publicKey: bytesToHex(pair.publicKey),
+    scheme: pair.scheme,
+  });
+
+  const signPayload = async (_path: string, payload: Uint8Array): Promise<QSignatureEnvelope> => {
+    const signature = await pair.sign(payload);
+    return {
+      scheme: pair.scheme,
+      signature: signature instanceof Uint8Array ? signature : Uint8Array.from(signature),
+      publicKey: pair.publicKey,
+    };
+  };
+
+  return { getAddress, signPayload };
+}

--- a/libs/coin-modules/coin-quantova/src/signer/softwareSigner.ts
+++ b/libs/coin-modules/coin-quantova/src/signer/softwareSigner.ts
@@ -2,10 +2,10 @@
  * Software reference signer (qweb3.js).
  *
  * Implements the `QuantovaSigner` contract entirely in software using Quantova's qweb3.js
- * SDK. It produces REAL, valid `QSignature` envelopes that the chain accepts — proving the
+ * SDK. It produces REAL, valid `QSignature` envelopes that the chain accepts - proving the
  * end-to-end post-quantum signing flow.
  *
- * ⚠️  This is a REFERENCE, not a hardware wallet: the private key lives in process memory.
+ * NOTE: This is a REFERENCE, not a hardware wallet: the private key lives in process memory.
  * Its purpose is (a) to exercise the bridge in CI/bots, and (b) to be the byte-exact spec a
  * Ledger device app reproduces on-chip. The device path (`deviceSigner`) holds keys in the
  * Secure Element instead; the two are interchangeable behind this interface.

--- a/libs/coin-modules/coin-quantova/src/types/index.ts
+++ b/libs/coin-modules/coin-quantova/src/types/index.ts
@@ -1,0 +1,22 @@
+export * from "./signer";
+
+/**
+ * A native Quantova balance-transfer transaction (the `balances.transfer_keep_alive`
+ * call). Amounts are plancks (1 QTOV = 1e18). Mirrors the Substrate extrinsic the
+ * runtime expects; richer call types (staking, governance, QNS, QVM) come later.
+ */
+export type QuantovaTransaction = {
+  family: "quantova";
+  /** sender "Q1…" address */
+  sender: string;
+  /** recipient "Q1…" address */
+  recipient: string;
+  /** amount in plancks (string to stay precise) */
+  amount: string;
+  /** account nonce */
+  nonce: number;
+  /** mortality era; "immortal" or a block window */
+  era?: "immortal" | { period: number; phase: number };
+  /** optional tip in plancks */
+  tip?: string;
+};

--- a/libs/coin-modules/coin-quantova/src/types/index.ts
+++ b/libs/coin-modules/coin-quantova/src/types/index.ts
@@ -7,9 +7,9 @@ export * from "./signer";
  */
 export type QuantovaTransaction = {
   family: "quantova";
-  /** sender "Q1…" address */
+  /** sender "Q1..." address */
   sender: string;
-  /** recipient "Q1…" address */
+  /** recipient "Q1..." address */
   recipient: string;
   /** amount in plancks (string to stay precise) */
   amount: string;

--- a/libs/coin-modules/coin-quantova/src/types/signer.ts
+++ b/libs/coin-modules/coin-quantova/src/types/signer.ts
@@ -1,46 +1,34 @@
 /**
  * Quantova device-signer contract.
  *
- * Unlike classical chains, a Quantova signature is **post-quantum**: one of three NIST
- * schemes. The on-chain `QSignature` is a tagged union (SPHINCS+ / Falcon / Dilithium),
- * each variant carrying the signature bytes and the PQ public key that the account
- * address is derived from (SHA3-256(pubkey)[0..20], byte0 = 0x40).
- *
- * This is the interface a Ledger device app (or hybrid signer) must satisfy for Quantova
- * — and the part that does not exist on any Ledger device today (see README, "Open
- * requirement").
+ * A Quantova signature is **post-quantum**: one of three NIST schemes (SPHINCS+ / Falcon
+ * / Dilithium), wrapped in the on-chain `QSignature` envelope. This is the interface a
+ * Ledger device app (or the software reference signer) must satisfy — and the
+ * device-side part is what no Ledger device can do today (see README "Open requirement").
  */
-
-/** The three NIST post-quantum signature schemes Quantova accounts use. */
-export enum QSignatureScheme {
-  SPHINCS = "sphincs+", // SLH-DSA (FIPS 205)
-  FALCON = "falcon", // FN-DSA  (FIPS 206)
-  DILITHIUM = "dilithium", // ML-DSA  (FIPS 204)
-}
-
-/** A post-quantum signature returned by the device, hex-encoded. */
-export type QSignature = {
-  scheme: QSignatureScheme;
-  /** hex of the scheme's signature bytes */
-  signature: string;
-  /** hex of the PQ public key the account is derived from */
-  publicKey: string;
-};
+import type { QScheme } from "../pq/schemes";
+import type { QSignatureEnvelope } from "../pq/qsignature";
 
 /** Address + PQ public key as returned by `getAddress`. */
 export type QuantovaAddress = {
   /** canonical "Q1…" Bech32m address */
   address: string;
-  /** hex of the PQ public key */
+  /** PQ public key, hex-encoded */
   publicKey: string;
+  /** which PQ scheme this account uses */
+  scheme: QScheme;
 };
 
 /**
- * The signer Ledger Live calls. `signTransaction` receives the SCALE-encoded signing
- * payload (call + the `TxExtension` extra, including the enabled `CheckMetadataHash`
- * digest for clear-signing) and must return a post-quantum `QSignature`.
+ * The signer Ledger Live calls. `signPayload` receives the SCALE-encoded signing payload
+ * (call + the `TxExtension` extra, including the **enabled** `CheckMetadataHash` digest so
+ * the device can clear-sign) and returns a post-quantum `QSignature` envelope.
+ *
+ * Both a software reference signer (qweb3.js) and a future on-device app implement this.
  */
 export interface QuantovaSigner {
   getAddress(path: string): Promise<QuantovaAddress>;
-  signTransaction(path: string, payload: string): Promise<QSignature>;
+  signPayload(path: string, payload: Uint8Array): Promise<QSignatureEnvelope>;
 }
+
+export type { QSignatureEnvelope };

--- a/libs/coin-modules/coin-quantova/src/types/signer.ts
+++ b/libs/coin-modules/coin-quantova/src/types/signer.ts
@@ -3,7 +3,7 @@
  *
  * A Quantova signature is **post-quantum**: one of three NIST schemes (SPHINCS+ / Falcon
  * / Dilithium), wrapped in the on-chain `QSignature` envelope. This is the interface a
- * Ledger device app (or the software reference signer) must satisfy — and the
+ * Ledger device app (or the software reference signer) must satisfy - and the
  * device-side part is what no Ledger device can do today (see README "Open requirement").
  */
 import type { QScheme } from "../pq/schemes";
@@ -11,7 +11,7 @@ import type { QSignatureEnvelope } from "../pq/qsignature";
 
 /** Address + PQ public key as returned by `getAddress`. */
 export type QuantovaAddress = {
-  /** canonical "Q1…" Bech32m address */
+  /** canonical "Q1..." Bech32m address */
   address: string;
   /** PQ public key, hex-encoded */
   publicKey: string;

--- a/libs/coin-modules/coin-quantova/src/types/signer.ts
+++ b/libs/coin-modules/coin-quantova/src/types/signer.ts
@@ -1,0 +1,46 @@
+/**
+ * Quantova device-signer contract.
+ *
+ * Unlike classical chains, a Quantova signature is **post-quantum**: one of three NIST
+ * schemes. The on-chain `QSignature` is a tagged union (SPHINCS+ / Falcon / Dilithium),
+ * each variant carrying the signature bytes and the PQ public key that the account
+ * address is derived from (SHA3-256(pubkey)[0..20], byte0 = 0x40).
+ *
+ * This is the interface a Ledger device app (or hybrid signer) must satisfy for Quantova
+ * — and the part that does not exist on any Ledger device today (see README, "Open
+ * requirement").
+ */
+
+/** The three NIST post-quantum signature schemes Quantova accounts use. */
+export enum QSignatureScheme {
+  SPHINCS = "sphincs+", // SLH-DSA (FIPS 205)
+  FALCON = "falcon", // FN-DSA  (FIPS 206)
+  DILITHIUM = "dilithium", // ML-DSA  (FIPS 204)
+}
+
+/** A post-quantum signature returned by the device, hex-encoded. */
+export type QSignature = {
+  scheme: QSignatureScheme;
+  /** hex of the scheme's signature bytes */
+  signature: string;
+  /** hex of the PQ public key the account is derived from */
+  publicKey: string;
+};
+
+/** Address + PQ public key as returned by `getAddress`. */
+export type QuantovaAddress = {
+  /** canonical "Q1…" Bech32m address */
+  address: string;
+  /** hex of the PQ public key */
+  publicKey: string;
+};
+
+/**
+ * The signer Ledger Live calls. `signTransaction` receives the SCALE-encoded signing
+ * payload (call + the `TxExtension` extra, including the enabled `CheckMetadataHash`
+ * digest for clear-signing) and must return a post-quantum `QSignature`.
+ */
+export interface QuantovaSigner {
+  getAddress(path: string): Promise<QuantovaAddress>;
+  signTransaction(path: string, payload: string): Promise<QSignature>;
+}

--- a/libs/coin-modules/coin-quantova/tsconfig.build.json
+++ b/libs/coin-modules/coin-quantova/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/**/*.integ.test.ts"]
+}

--- a/libs/coin-modules/coin-quantova/tsconfig.json
+++ b/libs/coin-modules/coin-quantova/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.base",
+  "compilerOptions": {
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "declaration": true,
+    "declarationMap": true,
+    "lib": ["es2020", "dom"],
+    "types": ["node", "jest"],
+    "outDir": "lib",
+    "rootDir": "src",
+    "exactOptionalPropertyTypes": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## First post-quantum chain integration for Ledger Live, built with qweb3.js

This PR adds `libs/coin-modules/coin-quantova`, the host-side integration for Quantova, a post-quantum Layer-1 (Substrate `stable2506-pq`; native asset QTOV, 18 decimals; testnet TQTOV).

To our knowledge it is the first integration to bring a full NIST post-quantum signature suite to Ledger Live: Quantova accounts are secured by ML-DSA (Dilithium), FN-DSA (Falcon) and SLH-DSA (SPHINCS+), with ML-KEM-768 (FIPS 203) for the encrypted lane. Key generation and signing in this module are built on Quantova's qweb3.js SDK (`@quantova/keyring`, `@quantova/util-crypto`, `@quantova/falcon-wasm`), so the host-side flow runs end to end and is the byte-exact spec for an on-device app.

## What is implemented (host side)

- `pq/` - the post-quantum primitives: scheme registry (SPHINCS+=0, Falcon=1, Dilithium=2 with on-chain sizes), the `QSignature` envelope codec (variant byte + SCALE compact signature + fixed public key), and key-gen/signing via qweb3.js.
- `logic/address.ts` - the Q-branded Bech32m + hex H160 address codec.
- `network/node.ts` - a client over Quantova's `q_` JSON-RPC namespace.
- `signer/` - the `QuantovaSigner` contract implemented two ways: a software reference signer (qweb3.js, produces valid signatures) and the device signer contract a Ledger `app-quantova` would implement.
- `logic/transaction/signTransaction.ts` - the signing flow (payload with `CheckMetadataHash` enabled, sign, serialize for `q_sendRawTransaction`).
- `config.ts` / `constants.ts` - QTOV/TQTOV, 18 decimals, `ss58Format`, and the RFC-78 metadata-hash parameters the runtime already bakes (`enable_metadata_hash("QTOV", 18)`).

## Audited and benchmarked

`docs/AUDIT.md` documents a correctness audit (one latent SCALE-compact bug found and fixed, two optimisations) plus a benchmark. 2,015 verification cases pass; the codecs run at sub-microsecond to ~1.3 us/op, including the 7,856-byte SPHINCS+ signature. `src/pq/performance.test.ts` keeps this as a CI performance test. All source and docs are plain ASCII.

## Isolation - it does not affect any other asset

The integration is additive at both layers: a new, self-contained host package that edits no other coin-module, and, on the device, a separate sandboxed BOLOS app whose PQ code lives only inside `app-quantova` and never touches the shared crypto used by the Bitcoin/Ethereum/Polkadot apps. Full detail in `docs/DEVICE-INTEGRATION.md`.

## The one open item - device-side post-quantum signing

A coin module's signer must obtain the signature from the device, and no Ledger device app today can produce a Dilithium/Falcon/SPHINCS+ signature. `types/signer.ts` and `signer/deviceSigner.ts` define exactly what the device must return. We understand from Ledger's research that PQ on the current Secure Element is constrained and that Ledger's direction is hybrid (classical + PQ) signing. We are flexible and would value Ledger's guidance:

1. a dedicated `app-quantova` device app (Dilithium is the most SE-friendly of the three), and/or
2. a hybrid account option (a classical Ledger signature alongside a PQ co-signature), aligned with Ledger's roadmap, and/or
3. extending the generic Polkadot app once a PQ scheme is available on-device.

We are happy to do the host-side work and to collaborate closely on the device side. Opened by the Quantova team.
