### PR TITLE
ci: skip commitlint on release branches

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -26,6 +26,11 @@ permissions:
 jobs:
   lint-commits:
     runs-on: ubuntu-22.04
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.ref != 'release' &&
+       !startsWith(github.event.pull_request.head.ref, 'release/') &&
+       github.event.pull_request.head.ref != 'support/release-merge-conflicts')
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached. _(not applicable — CI-only change, no packages modified)_
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - The `lint-commits` job will be skipped for PRs where the head branch is `release` or matches `release/*`
  - All other PRs (including `workflow_dispatch` runs) are unaffected

### 📝 Description

Smartling translation bot commits merged into the `release` branch use non-conventional commit messages (e.g. `File apps/.../en/common.json was translated to es-ES locale`), which fail the `type-empty` and `subject-empty` commitlint rules. This causes the `lint-commits` CI job to fail on every `release → develop` PR, even when there are no code issues.

Added a job-level `if` condition to skip `lint-commits` when the PR head branch is `release` or `release/*`. Manual `workflow_dispatch` runs are unaffected.

### ❓ Context

- **GitHub link**: #18581 (release PR where this was first observed)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)