### PR TITLE
chore(coin-modules): restrict `@ledgerhq/*` imports

### DIFF
--- a/libs/coin-modules/.oxlintrc.json
+++ b/libs/coin-modules/.oxlintrc.json
@@ -57,6 +57,31 @@
   },
   "overrides": [
     {
+      "files": ["**/src/api/**", "**/src/logic/**", "**/src/network/**"],
+      "rules": {
+        "eslint/no-restricted-imports": [
+          "warn",
+          {
+            "patterns": [
+              {
+                "group": [
+                  "@ledgerhq/**",
+                  "!@ledgerhq/errors",
+                  "!@ledgerhq/errors/**",
+                  "!@ledgerhq/logs",
+                  "!@ledgerhq/logs/**",
+                  "!@ledgerhq/live-network",
+                  "!@ledgerhq/live-network/**",
+                  "!@ledgerhq/coin-module-framework",
+                  "!@ledgerhq/coin-module-framework/**"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
       "files": [
         "**/src/**/*.test.{ts,tsx}",
         "**/src/**/__tests__/**",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The end goal is to have coin modules not importing `@ledgerhq/*` packages, so they are ready to be moved to https://github.com/LedgerHQ/coin-modules.

A few exceptions:

| Package        | Why         |
| ------------- | ------------- |
| `@ledgerhq/coin-module-framework` | Contains the Alpaca relevant types |
| `@ledgerhq/errors` | Tolerated because it is already used in the other repo |
| `@ledgerhq/live-network` | Tolerated because it is already used in the other repo |
| `@ledgerhq/logs` | Tolerated because it is already used in the other repo |

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
