### PR TITLE
[LWDM] fix(coin-sui): pay gas from coin objects to avoid balance overdraw

### DIFF
--- a/.changeset/dull-kiwis-vanish.md
+++ b/.changeset/dull-kiwis-vanish.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-sui": minor
+---
+
+fix(coin-sui): pay gas from coin objects to avoid SIP-58 address-balance overdraw

--- a/libs/coin-modules/coin-sui/src/bridge/estimateMaxSpendable.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/estimateMaxSpendable.ts
@@ -2,9 +2,10 @@ import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/index"
 import type { AccountBridge } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import { ONE_SUI } from "../constants";
-import type { Transaction } from "../types";
+import type { SuiAccount, Transaction } from "../types";
 import createTransaction from "./createTransaction";
 import getFeesForTransaction from "./getFeesForTransaction";
+import { addressBalanceSpendCap } from "./utils";
 
 /**
  * Returns the maximum possible amount for transaction
@@ -41,6 +42,9 @@ export const estimateMaxSpendable: AccountBridge<Transaction>["estimateMaxSpenda
         });
         if (gasBudget) {
           spendableBalance = spendableBalance.minus(gasBudget);
+          // SIP-58: bound the max by the address balance minus gas when real coins can't cover gas.
+          const cap = addressBalanceSpendCap(mainAccount as SuiAccount, new BigNumber(gasBudget));
+          if (cap !== null) spendableBalance = BigNumber.min(spendableBalance, cap);
         }
       }
     }

--- a/libs/coin-modules/coin-sui/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/getTransactionStatus.test.ts
@@ -89,6 +89,42 @@ describe("getTransactionStatus", () => {
 
     expect(result.errors.amount).toEqual(new NotEnoughBalance());
   });
+  it("flags NotEnoughBalance when the address balance can't cover amount + gas and real coins are too small for gas (SIP-58)", async () => {
+    // Real coins can't cover the gas budget, so gas is withdrawn from the address balance
+    // alongside the transfer. The address balance can't cover amount + gas even though the total
+    // can — so the send must be blocked before signing (it would otherwise fail at broadcast with
+    // "Invalid withdraw reservation").
+    const acc = createFixtureAccount({
+      balance: BigNumber(100_001_000_000),
+      spendableBalance: BigNumber(100_001_000_000),
+      suiResources: { fundsInAddressBalance: BigNumber(100_000_000_000) },
+    });
+    const transaction = createFixtureTransaction({
+      amount: BigNumber(99_999_000_000),
+      fees: BigNumber(1_000_000),
+      gasBudget: BigNumber(2_000_000),
+    });
+    const result = await getTransactionStatus(acc, transaction);
+
+    expect(result.errors.amount).toEqual(new NotEnoughBalance());
+  });
+  it("does not apply the SIP-58 guard when real coins cover the gas budget", async () => {
+    // Same near-address-balance amount, but real coins (5 SUI) comfortably cover gas, so gas is
+    // paid from them and the address balance only funds the transfer — the send is valid.
+    const acc = createFixtureAccount({
+      balance: BigNumber(105_000_000_000),
+      spendableBalance: BigNumber(105_000_000_000),
+      suiResources: { fundsInAddressBalance: BigNumber(100_000_000_000) },
+    });
+    const transaction = createFixtureTransaction({
+      amount: BigNumber(99_999_000_000),
+      fees: BigNumber(1_000_000),
+      gasBudget: BigNumber(2_000_000),
+    });
+    const result = await getTransactionStatus(acc, transaction);
+
+    expect(result.errors.amount).toBeUndefined();
+  });
   it("should return errors if not enought balance for fees", async () => {
     const transaction = createFixtureTransaction({
       subAccountId: "subAccountId",

--- a/libs/coin-modules/coin-sui/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/getTransactionStatus.ts
@@ -21,6 +21,7 @@ import {
 } from "../errors";
 import type { SuiAccount, Transaction, TransactionStatus } from "../types";
 import { ensureAddressFormat } from "../utils";
+import { addressBalanceSpendCap } from "./utils";
 /**
  * Get the status of a transaction.
  * @function getTransactionStatus
@@ -101,6 +102,17 @@ export const getTransactionStatus: AccountBridge<
 
     if (requiredBalance.gt(accountBalance) && !errors.amount) {
       errors.amount = new NotEnoughBalance();
+    }
+
+    // SIP-58 safety net: when real coin objects can't cover the gas budget, gas is withdrawn from
+    // the address balance together with the transfer — so the address balance, not the total, must
+    // cover `amount + gasBudget`. Without this the tx builds and dry-runs fine but the node rejects
+    // the withdrawal reservation at broadcast ("Invalid withdraw reservation").
+    if (!transaction.subAccountId && !errors.amount) {
+      const cap = addressBalanceSpendCap(account, gasBudget);
+      if (cap !== null && amount.gt(cap)) {
+        errors.amount = new NotEnoughBalance();
+      }
     }
   }
   if (transaction.mode === "delegate") {

--- a/libs/coin-modules/coin-sui/src/bridge/synchronisation.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/synchronisation.test.ts
@@ -109,6 +109,7 @@ describe("getAccountShape", () => {
       operationsCount: 0,
       suiResources: {
         stakes: [],
+        fundsInAddressBalance: new BigNumber(0),
       },
       subAccounts: [],
       syncHash: undefined,
@@ -448,6 +449,7 @@ describe("getAccountShape", () => {
       // THEN
       expect(shape.suiResources).toEqual({
         stakes: [],
+        fundsInAddressBalance: new BigNumber(0),
       });
     });
 
@@ -500,6 +502,7 @@ describe("getAccountShape", () => {
       // THEN
       expect(shape.suiResources).toEqual({
         stakes: mockStakes,
+        fundsInAddressBalance: new BigNumber(0),
       });
     });
 
@@ -749,7 +752,7 @@ describe("getAccountShape", () => {
       );
 
       // THEN
-      expect(shape.suiResources).toEqual({ stakes: null });
+      expect(shape.suiResources).toEqual({ stakes: null, fundsInAddressBalance: new BigNumber(0) });
     });
   });
 });

--- a/libs/coin-modules/coin-sui/src/bridge/synchronisation.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/synchronisation.ts
@@ -43,8 +43,11 @@ export const getAccountShape: GetAccountShape<SuiAccount> = async (info, syncCon
   );
 
   const accountBalances = await getAccountBalances(address, currency.id);
-  const balance =
-    accountBalances.find(({ coinType }) => coinType === DEFAULT_COIN_TYPE)?.balance ?? BigNumber(0);
+  const suiBalance = accountBalances.find(({ coinType }) => coinType === DEFAULT_COIN_TYPE);
+  const balance = suiBalance?.balance ?? BigNumber(0);
+  // SIP-58 address-balance portion of the native SUI balance — kept so the bridge can validate
+  // a spend against it (gas is withdrawn from it when real coins can't cover the budget).
+  const fundsInAddressBalance = suiBalance?.fundsInAddressBalance ?? BigNumber(0);
 
   // `buildSubAccounts` batches `findTokenByAddressInCurrency` lookups internally
   // (concurrency 3); pre-filtering here would only serialise the same work.
@@ -68,6 +71,7 @@ export const getAccountShape: GetAccountShape<SuiAccount> = async (info, syncCon
     subAccounts,
     suiResources: {
       stakes,
+      fundsInAddressBalance,
     },
     operations: mainAccountOperations,
   };

--- a/libs/coin-modules/coin-sui/src/bridge/utils.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/utils.ts
@@ -25,6 +25,22 @@ export function getAccountUnit(account: AccountLike): {
 }
 
 /**
+ * SIP-58 spend cap: when the account's real coin objects can't cover the gas budget, gas is
+ * withdrawn from the address balance alongside the transfer, so a native-SUI spend is bounded by
+ * `addressBalance − gasBudget` (not the total minus gas). Returns `null` when real coins cover the
+ * gas budget — then gas is paid from them and the full balance is spendable, so no extra bound.
+ * Shared by `calculateMaxSend`, `estimateMaxSpendable`, and `getTransactionStatus`.
+ */
+export const addressBalanceSpendCap = (
+  account: SuiAccount,
+  gasBudget: BigNumber,
+): BigNumber | null => {
+  const addressBalance = account.suiResources?.fundsInAddressBalance ?? new BigNumber(0);
+  if (account.spendableBalance.minus(addressBalance).gte(gasBudget)) return null;
+  return addressBalance.minus(gasBudget);
+};
+
+/**
  * Calculate the maximum amount that can be sent from the account after deducting fees.
  *
  * @param {SuiAccount} account - The account from which the amount is being sent.
@@ -34,7 +50,10 @@ export function getAccountUnit(account: AccountLike): {
 const calculateMaxSend = (account: SuiAccount, transaction: Transaction): BigNumber => {
   // Reserve the gas BUDGET (not the smaller actual fee) so a max-send leaves enough to cover the
   // network's gas reservation — otherwise the send could fail at execution.
-  const amount = account.spendableBalance.minus(transaction.gasBudget || transaction.fees || 0);
+  const gasBudget = new BigNumber(transaction.gasBudget || transaction.fees || 0);
+  let amount = account.spendableBalance.minus(gasBudget);
+  const cap = addressBalanceSpendCap(account, gasBudget);
+  if (cap !== null) amount = BigNumber.min(amount, cap);
   return amount.lt(0) ? new BigNumber(0) : amount;
 };
 

--- a/libs/coin-modules/coin-sui/src/network/sdk.test.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.test.ts
@@ -993,6 +993,37 @@ describe("SDK Functions", () => {
     expect(mockTxInstance.setGasPayment).toHaveBeenCalledWith([]);
   });
 
+  test("createTransaction does not force empty gas payment when real coins exist alongside an address balance", async () => {
+    // SIP-58 regression guard: with BOTH real coin objects and an address balance, gas must be
+    // paid from the real coins (SDK auto-selection) so the full address balance stays available
+    // for the transfer. Forcing setGasPayment([]) here is what overdrew the address balance at
+    // broadcast ("Invalid withdraw reservation": amount + gasBudget > addressBalance).
+    mockApi.getAllBalances.mockResolvedValueOnce([
+      {
+        coinType: sdk.DEFAULT_COIN_TYPE,
+        coinObjectCount: 1,
+        totalBalance: mist(10),
+        lockedBalance: {},
+        fundsInAddressBalance: mist(8),
+      },
+    ]);
+
+    const address = "0x6e143fe0a8ca010a86580dafac44298e5b1b7d73efc345356a59a15f0d7824f0";
+    const transaction = {
+      mode: "send" as const,
+      coinType: sdk.DEFAULT_COIN_TYPE,
+      // Amount == address balance: the window that previously overdrew it.
+      amount: new BigNumber(mist(8)),
+      recipient: "0x33444cf803c690db96527cec67e3c9ab512596f4ba2d4eace43f0b4f716e0164",
+    };
+
+    const tx = await sdk.createTransaction(address, transaction);
+    expect(tx).toEqual({ unsigned: { transactionBlock: expect.any(Uint8Array) } });
+    const MockTransaction = Transaction as unknown as jest.Mock;
+    const mockTxInstance = MockTransaction.mock.results.at(-1)!.value;
+    expect(mockTxInstance.setGasPayment).not.toHaveBeenCalled();
+  });
+
   test("createTransaction uses coinWithBalance fallback for token with no coin objects", async () => {
     mockApi.getCoins.mockReset();
     mockApi.getCoins.mockResolvedValue({ data: [], hasNextPage: false });

--- a/libs/coin-modules/coin-sui/src/network/sdk.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.ts
@@ -1376,24 +1376,48 @@ export const getCoinsForAmount = async (
   return coins;
 };
 
+type SuiFundingModel = {
+  /** SIP-58 address-balance portion of the SUI balance. */
+  addressBalance: bigint;
+  /** Real SUI coin objects (the SDK's `coinBalance` = total − address balance). */
+  realCoinBalance: bigint;
+  /**
+   * Source gas from the address balance via `setGasPayment([])`. Only when there
+   * are no real coin objects — otherwise let the SDK auto-select a real coin for
+   * gas so the *entire* address balance stays available for the transfer.
+   */
+  gasFromAddressBalance: boolean;
+  /**
+   * Split the transfer straight out of `tx.gas`. Only for the classic
+   * coin-object-only account (no address balance); when an address balance
+   * exists the transfer is resolved via `coinWithBalance` instead.
+   */
+  transferFromGasCoin: boolean;
+};
+
 /**
- * Check whether the sender should fund gas from a real SUI coin object
- * (vs. from the SIP-58 address balance via `setGasPayment([])`).
+ * Decide how a send funds its gas vs. its transfer (`getCoins` is unusable post-SIP-58 — it
+ * returns synthetic "fake coins" for the address balance, so we read `client.core.getBalance`).
  *
- * Post SIP-58 the RPC's `getCoins` returns synthetic "fake coin" objects
- * representing address-balance reservations alongside real coins, so we cannot
- * rely on its result to decide. Instead we read `fundsInAddressBalance` from
- * `getAllBalances`: if any address-balance funds exist, prefer them for gas —
- * this avoids picking a real coin object that may be too small for the auto-
- * computed gas budget.
+ * Gas comes from real coin objects whenever any exist, keeping the full address balance free for
+ * the transfer — forcing `setGasPayment([])` while the transfer also drains the address balance is
+ * what overdrew it (`amount + gasBudget > addressBalance`) and failed at broadcast. Only with no
+ * real coins do we fall back to address-balance gas (then `total === addressBalance`, so the
+ * existing `amount + gasBudget ≤ total` check already prevents an overdraw).
  */
-async function hasGasCoinObjects(client: ClientWithCoreApi, address: string): Promise<boolean> {
-  // `client.core.getBalance` returns a single SDK-normalized `Balance` —
-  // `addressBalance` is the SIP-58 address-balance reservation, `balance` is
-  // the total. If any address-balance funds exist, prefer them for gas.
+async function getSuiFundingModel(
+  client: ClientWithCoreApi,
+  address: string,
+): Promise<SuiFundingModel> {
   const { balance } = await client.core.getBalance({ owner: address, coinType: DEFAULT_COIN_TYPE });
-  if (BigInt(balance.addressBalance ?? "0") > 0n) return false;
-  return BigInt(balance.balance ?? "0") > 0n;
+  const addressBalance = BigInt(balance.addressBalance);
+  const realCoinBalance = BigInt(balance.coinBalance);
+  return {
+    addressBalance,
+    realCoinBalance,
+    gasFromAddressBalance: realCoinBalance === 0n,
+    transferFromGasCoin: addressBalance === 0n && realCoinBalance > 0n,
+  };
 }
 
 /**
@@ -1475,17 +1499,17 @@ const buildDelegateBody = async (
   const sender = ensureAddressFormat(address);
   tx.setSender(sender);
 
-  const senderHasGasCoins = await hasGasCoinObjects(client, sender);
-  if (!senderHasGasCoins) {
+  const { gasFromAddressBalance, transferFromGasCoin } = await getSuiFundingModel(client, sender);
+  if (gasFromAddressBalance) {
     tx.setGasPayment([]);
   }
 
   const { amount } = transaction;
-  // When gas is paid from the SIP-58 address balance (`setGasPayment([])`),
-  // `tx.gas` is sized only for the auto-computed gas budget, so we can't
-  // split the stake amount out of it. Resolve it via `coinWithBalance`,
-  // which the SDK turns into a FundsWithdrawal sized for the stake amount.
-  const stakeCoin = senderHasGasCoins
+  // When the stake is funded from the SIP-58 address balance, `tx.gas` is sized
+  // only for the gas budget, so we can't split the stake amount out of it.
+  // Resolve it via `coinWithBalance`, which the SDK turns into a FundsWithdrawal
+  // sized for the stake amount. Only split from `tx.gas` for coin-object-only accounts.
+  const stakeCoin = transferFromGasCoin
     ? tx.splitCoins(tx.gas, [BigInt(amount.toFixed())])[0]
     : coinWithBalance({ balance: BigInt(amount.toFixed()) })(tx);
 
@@ -1524,7 +1548,7 @@ const buildUndelegateBody = async (
   const sender = ensureAddressFormat(address);
   tx.setSender(sender);
 
-  if (!(await hasGasCoinObjects(client, sender))) {
+  if ((await getSuiFundingModel(client, sender)).gasFromAddressBalance) {
     tx.setGasPayment([]);
   }
 
@@ -1565,8 +1589,10 @@ const createTransactionForUndelegate = (
 /**
  * SIP-58 transfer builder:
  *
- * - **Native SUI**: uses `tx.gas` for the transfer. When the sender has no coin
- *   objects `setGasPayment([])` lets the network source gas from address balance.
+ * - **Native SUI**: when the account has only coin objects (no address balance), splits the
+ *   transfer out of `tx.gas`. When an address balance exists, resolves the transfer via
+ *   `coinWithBalance` (FundsWithdrawal from the address balance) while gas is paid from real
+ *   coin objects — see {@link getSuiFundingModel}.
  *
  * - **Non-SUI tokens**: first tries `getCoinsForAmount` (which may return fake
  *   coins).  If no coin objects are available at all, falls back to
@@ -1583,8 +1609,8 @@ const buildOthersBody = async (
   const sender = ensureAddressFormat(address);
   tx.setSender(sender);
 
-  const senderHasGasCoins = await hasGasCoinObjects(client, sender);
-  if (!senderHasGasCoins) {
+  const { gasFromAddressBalance, transferFromGasCoin } = await getSuiFundingModel(client, sender);
+  if (gasFromAddressBalance) {
     tx.setGasPayment([]);
   }
 
@@ -1609,15 +1635,14 @@ const buildOthersBody = async (
       })(tx);
       tx.transferObjects([coin], transaction.recipient);
     }
-  } else if (senderHasGasCoins) {
+  } else if (transferFromGasCoin) {
     const [coin] = tx.splitCoins(tx.gas, [BigInt(transaction.amount.toFixed())]);
     tx.transferObjects([coin], transaction.recipient);
   } else {
-    // SIP-58 native SUI path: gas is paid from address balance via
-    // `setGasPayment([])`, so the gas reservation is sized only for fees.
-    // We can't split the transfer amount out of `tx.gas`; instead resolve
-    // the transfer via `coinWithBalance`, which the SDK turns into a
-    // FundsWithdrawal sized for the transfer amount itself.
+    // SIP-58 native SUI path: the transfer is drawn from the address balance via
+    // `coinWithBalance` (a FundsWithdrawal sized for the transfer amount). Gas is paid from
+    // real coin objects when present (see `getSuiFundingModel`), so the transfer can consume
+    // the full address balance without the gas reservation overdrawing it.
     const coin = coinWithBalance({ balance: BigInt(transaction.amount.toFixed()) })(tx);
     tx.transferObjects([coin], transaction.recipient);
   }

--- a/libs/coin-modules/coin-sui/src/types/bridge.ts
+++ b/libs/coin-modules/coin-sui/src/types/bridge.ts
@@ -24,6 +24,13 @@ export type MappedStake = StakeObject & {
 export type SuiResources = {
   stakes?: DelegatedStake[];
   cachedOps?: Record<string, Record<string, string>>;
+  /**
+   * SIP-58 address-balance portion of the native SUI balance (in MIST). When real coin objects
+   * can't cover the gas budget, gas is withdrawn from this address balance alongside the
+   * transfer, so `getTransactionStatus`/`calculateMaxSend` must validate the spend against it
+   * (not just the total) to avoid a broadcast-time "Invalid withdraw reservation".
+   */
+  fundsInAddressBalance?: BigNumber;
 };
 
 /**


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - coin-sui

### 📝 Description

Root cause (deterministic): when `addressBalance > 0`, the old code forced `setGasPayment([])`, pinning gas to the address balance. The `coinWithBalance` transfer also drew from the address balance. So for any amount in the window (`addressBalance − gas, addressBalance`), the node needed `amount + gas` but only `addressBalance` was reservable. 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
