### PR TITLE
[LWDM] docs: deprecate live-common, steer new code to DDD layout

### DIFF
--- a/.agents/agents/code-architect.md
+++ b/.agents/agents/code-architect.md
@@ -14,6 +14,9 @@ Follow architectural skills in `.agents/skills/` where applicable. Pay special a
 
 ## Core Process
 
+**0. Placement**
+Decide where new code lives before designing it: add a new `libs/*` package for new shared code; never add new features/folders to `libs/ledger-live-common`. State the chosen target package(s) up front.
+
 **1. Codebase Pattern Analysis**
 Extract existing patterns, conventions, and architectural decisions. Identify the technology stack, module boundaries, abstraction layers, and project rules. Find similar features to understand established approaches.
 

--- a/.agents/agents/code-reviewer.md
+++ b/.agents/agents/code-reviewer.md
@@ -39,6 +39,7 @@ By default, review unstaged changes from `git diff`. The user may specify differ
 - **New dependency in `package.json`**: must not duplicate an existing capability; peer compatibility must be verified; link to [bundlephobia](https://bundlephobia.com) with size impact.
 - **`pnpm-lock.yaml` diff**: Flag unrelated version bumps, mass reformatting, or entries not explained by the PR's `package.json` changes. The lockfile diff should be entirely explainable by the stated dependency changes.
 - **Translations**: Only edit `apps/ledger-live-desktop/static/i18n/en/app.json` (desktop) or `apps/ledger-live-mobile/src/locales/en/common.json` (mobile). No other locale files.
+- **Don't add to live-common**: `libs/ledger-live-common/` is maintenance-only — bugfixes and edits to existing code are fine, but flag new features/folders/top-level modules added there. New shared code goes to a new `libs/*` package; that is expected, not a smell.
 - **`domain/` packages**: no `@ledgerhq/` scope, every `package.json` must have `"private": true`, no subdirectories other than `entity/` and `api/`. For the full conventions, also read `domain/entity/README.md` and `domain/api/README.md`.
 - **`shared/` packages**: no `@ledgerhq/` scope, `"private": true`, no dependencies on `domain/` packages. For the full conventions, also read `shared/README.md`.
 - Sonar issues: complexity, duplication, security hotspots

--- a/.agents/skills/feature-dev/SKILL.md
+++ b/.agents/skills/feature-dev/SKILL.md
@@ -17,6 +17,8 @@ You are helping a developer implement a new feature for Ledger Wallet applicatio
 
 New features must be implemented in `src/mvvm/` following the MVVM architecture (`.agents/skills/mvvm-architecture/SKILL.md`).
 
+Shared logic extracted out of an app goes to a new `libs/*` package; never add new features/folders to `libs/ledger-live-common`.
+
 ## Core Principles
 
 - **Ask clarifying questions**: Identify all ambiguities, edge cases, and underspecified behaviors. Ask specific, concrete questions rather than making assumptions. Wait for user answers before proceeding with implementation. Ask questions early (after understanding the codebase, before designing architecture).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@
 
 We are working towards consistency across all those packages but each workspace has it's own details. Read local README files relevant to where you are working.
 
+## Where to add new code
+
+New shared code goes in a new `libs/*` package; `libs/ledger-live-common` is maintenance-only (no new features/folders). See [libs/README.md](./libs/README.md).
+
 ## Repo Commands
 
 Prefer commands given in local README files. For example appls like [Ledger Wallet Desktop](./apps/ledger-live-desktop/README.md) and [Ledger Wallet Mobile](./apps/ledger-live-mobile/README.md) have very specific commands for setup, dev and build commands.

--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ What to run next depends on the workspace you're targeting. See [repo commands](
 | `domain/`   | Domain packages (`entity/`, `api/`)\*                                                                      |
 | `e2e/`      | E2E tests using [Detox](https://wix.github.io/Detox/) and [Speculos](https://github.com/LedgerHQ/speculos) |
 | `features/` | Features shared across apps\*                                                                              |
-| `libs/`     | Legacy shared code\*                                                                                       |
+| `libs/`     | Shared libraries — the home for new shared code; `ledger-live-common` is maintenance-only\*               |
 | `patches/`  | `patchedDependencies` auto-applied during pnpm install                                                     |
 | `scripts/`  | Repo-level utility scripts                                                                                 |
 | `shared/`   | Cross-cutting packages used in domain/, features/ and apps/\*                                              |
 | `tests/`    | Dummy apps for testing (dapps, wallet)                                                                     |
 | `tools/`    | CI actions, GitHub bots and Nx plugins                                                                     |
 
-\*Prefer `domain/`, `features/` and `shared/` over the legacy `libs/` directory.
+\*Adding new code? See [libs/README.md](./libs/README.md).
 
 ## Nightly releases
 

--- a/domain/README.md
+++ b/domain/README.md
@@ -1,0 +1,24 @@
+# domain/
+
+Business domain packages — the foundation of the emerging DDD layout. This model is still maturing and is not yet the default home for new code: use it only when the work clearly fits, otherwise add a new `libs/*` package.
+
+## Layers
+
+| Path | Purpose | README |
+| --- | --- | --- |
+| `entity/` | Canonical data models (Zod schemas), entity Redux slices, selectors | [entity/README.md](entity/README.md) |
+| `api/` | RTK Query `createApi` endpoints / `createAsyncThunk` actions for a domain | [api/README.md](api/README.md) |
+
+## Dependency direction
+
+Dependencies flow one way:
+
+```
+domain/entity → domain/api → features/platform → features/flow → apps/
+```
+
+- `domain/api-<name>` depends on `domain/entity-<name>` (never the reverse).
+- `domain/*` may depend on `shared/*`; `shared/*` must not depend on `domain/*`.
+- `domain/*` must not depend on `features/*` or `apps/*`.
+
+Package naming: `@domain/entity-<name>`, `@domain/api-<name>`. All packages are `"private": true`.

--- a/features/README.md
+++ b/features/README.md
@@ -1,0 +1,22 @@
+# features/
+
+Feature packages shared across desktop and mobile apps — part of the emerging DDD layout. This model is still maturing and is not yet the default home for new code: use it only when the work clearly fits, otherwise add a new `libs/*` package.
+
+## Layers
+
+| Path | Purpose | README |
+| --- | --- | --- |
+| `platform/` | Non-functional, cross-feature hooks/selectors/NFR glue — no rendering | [platform/README.md](platform/README.md) |
+| `flow/` | User-facing UI shared across apps (`.web.tsx` / `.native.tsx`) | [flow/README.md](flow/README.md) |
+
+## Dependency direction
+
+```
+domain/entity → domain/api → features/platform → features/flow → apps/
+```
+
+- `features/flow/*` may depend on `features/platform/*`, `domain/*` and `shared/*`.
+- `features/platform/*` may depend on `domain/*` and `shared/*`; it must **not** depend on `features/flow/*`.
+- App-specific screen composition stays in `apps/`, not here.
+
+Package naming: `@features/platform-<name>`, `@features/flow-<name>`. All packages are `"private": true`.

--- a/libs/README.md
+++ b/libs/README.md
@@ -1,0 +1,10 @@
+# libs/
+
+Shared library packages — the home for new shared code today.
+
+## Adding new code?
+
+1. **A new dedicated `libs/*` package** — for new shared code (e.g. a self-contained library, a coin module under `libs/coin-modules/`).
+2. **Never grow `libs/ledger-live-common`** — it is in maintenance mode. Bugfixes and edits to existing code are fine; new features, folders or top-level modules are not.
+
+The repo is moving toward a DDD layout (`domain/`, `features/`, `shared/`); it is not yet the default for new code.

--- a/libs/ledger-live-common/README.md
+++ b/libs/ledger-live-common/README.md
@@ -1,5 +1,10 @@
 # @ledgerhq/live-common
 
+> [!WARNING]
+> **`@ledgerhq/live-common` is in maintenance mode and is being progressively dismantled.**
+> Do **not** add new features, folders or top-level modules here. Bugfixes and edits to existing
+> code are welcome. New shared logic belongs in a dedicated `libs/*` package.
+
 `@ledgerhq/live-common` contains shared Ledger Wallet business logic used by
 Ledger Live Desktop, Ledger Live Mobile, CLI tooling, tests, and coin
 integrations.


### PR DESCRIPTION
> [!NOTE]
> Documentation-only change. No package source touched, so no changeset.

### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- N/A: docs/agent-markdown only, no package behavior change -->
- [x] **Covered by automatic tests.** <!-- N/A: documentation only -->
- [ ] **Impact of the changes:**
  - No runtime impact. Affects guidance only: where contributors and agents add new code.

### 📝 Description

Steers new code away from libs/ledger-live-common and documents where new shared code goes today.

A single canonical placement guide now lives in AGENTS.md "Where to add new code"; the other docs state it self-contained (no cross-references):

1. A new libs/* package — the home for new shared code today
2. libs/ledger-live-common — maintenance only; no new features/folders/top-level modules (bugfixes and edits to existing code are fine)

The DDD layout (domain/, features/, shared/) is mentioned only as a future direction, not a default for new code.

Changes:
- AGENTS.md — new "Where to add new code" section (the source of truth)
- libs/ledger-live-common/README.md — maintenance-mode WARNING banner
- README.md — libs/ row + footnote describe the placement
- new libs/README.md, domain/README.md, features/README.md overviews (map + dependency direction)
- code-reviewer agent — flags new code added to live-common (a new libs/* package is expected, not a smell)
- code-architect agent — adds a placement step before design
- feature-dev skill — placement note for extracted shared logic

Not included: an optional CI/Danger check (using the existing type:live-common nx tag) that warns when a PR adds new top-level files under libs/ledger-live-common/src/. Can follow up if wanted.

### ❓ Context

- **JIRA or GitHub link**: _none_
- **ADR link (if any)**: _none_
