### PR TITLE
[LWM] fix(mobile): keep PnL card titles on one line

### DIFF
--- a/.changeset/small-cards-shrink.md
+++ b/.changeset/small-cards-shrink.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix PnL card title wrapping on mobile

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/__integrations__/pnlCard.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/__integrations__/pnlCard.integration.test.tsx
@@ -50,6 +50,26 @@ describe("PnlCard integration", () => {
 
       expect(onPress).toHaveBeenCalledTimes(1);
     });
+
+    it("keeps long titles on one line", () => {
+      const longTitle = "Unrealised return across the full portfolio";
+
+      render(
+        <PnlCard
+          type="interactive"
+          title={longTitle}
+          value={VALUE}
+          trend="up"
+          onPress={jest.fn()}
+        />,
+        { overrideInitialState: withPnl(true) },
+      );
+
+      expect(screen.getByText(longTitle).props).toMatchObject({
+        numberOfLines: 1,
+        ellipsizeMode: "tail",
+      });
+    });
   });
 
   describe("info variant", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlCard/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlCard/index.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import {
-  Box,
   Card,
   CardContent,
+  CardContentDescription,
+  CardContentRow,
+  CardContentTitle,
   CardHeader,
   CardLeading,
   CardTrailing,
-  Text,
 } from "@ledgerhq/lumen-ui-rnative";
 import { ChevronRight, Information } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { PnlCardProps } from "./types";
@@ -33,18 +34,14 @@ export function PnlCard(props: Readonly<PnlCardProps>) {
       <CardHeader>
         <CardLeading>
           <CardContent>
-            <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s4" }}>
-              <Text typography="body3" lx={{ color: "muted" }}>
-                {title}
-              </Text>
+            <CardContentRow lx={{ gap: "s4" }}>
+              <CardContentDescription>{title}</CardContentDescription>
               {showInfoIcon ? <Information size={16} color="muted" /> : null}
-            </Box>
-            <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s4" }}>
+            </CardContentRow>
+            <CardContentRow lx={{ gap: "s4" }}>
               {TrendIcon ? <TrendIcon size={16} color={trendColor} /> : null}
-              <Text typography="body2SemiBold" lx={{ color: "base" }}>
-                {displayedValue}
-              </Text>
-            </Box>
+              <CardContentTitle>{displayedValue}</CardContentTitle>
+            </CardContentRow>
           </CardContent>
         </CardLeading>
         {showChevron ? (


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset detail PnL cards on narrow mobile widths
  - Portfolio analytics PnL cards with long or localized labels
  - PnL card title truncation, value alignment, trend icon, info icon, and chevron layout

### 📝 Description

This PR fixes LIVE-32934, where the Ledger Wallet Mobile unrealized return card could become oversized when its title wrapped to two lines in a half-width card layout.

The PnL card now uses Lumen card text primitives for its title and value rows. These components keep card text on a single line with tail truncation, matching the design-system behavior and preventing the card header from growing vertically when the title is long. A regression test covers the long-title case.

<img width="350" height="750" alt="simulator_screenshot_D2F3D22B-2F35-4588-8981-34A6F4478447" src="https://github.com/user-attachments/assets/d1a64a3c-9d28-4426-94ed-0faf39eb7e3e" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-32934](https://ledgerhq.atlassian.net/browse/LIVE-32934)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-32934]: https://ledgerhq.atlassian.net/browse/LIVE-32934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ