### PR TITLE
[LWDM] fix(common): paginate unfiltered market gainers/losers

### DIFF
--- a/.changeset/market-list-change-full-pagination.md
+++ b/.changeset/market-list-change-full-pagination.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Fix the Market list "% change" sort (top gainers/losers) being stuck on the first page: the global, unfiltered gainers/losers request no longer sends `top=100`, so the list now paginates through all coins like the market-cap and stocks lists. The Market Banner top performers are unaffected (they use the separate `getMarketPerformers` endpoint with its own `top` cap).

--- a/libs/ledger-live-common/src/market/api/countervalues.test.ts
+++ b/libs/ledger-live-common/src/market/api/countervalues.test.ts
@@ -48,14 +48,14 @@ describe("market countervalues API", () => {
     expect(getLastRequestUrl().searchParams.get("filter")).toBe("stock");
   });
 
-  it("keeps the top parameter for unfiltered top gainers", async () => {
+  it("does not send the top parameter for unfiltered top gainers", async () => {
     await fetchList({ counterCurrency: "usd", order: Order.topGainers });
 
-    expect(getLastRequestUrl().searchParams.get("top")).toBe("100");
+    expect(getLastRequestUrl().searchParams.get("top")).toBeNull();
   });
 
-  it("does not send the top parameter when top gainers use an explicit filter", async () => {
-    await fetchList({ counterCurrency: "usd", order: Order.topGainers, filter: "stock" });
+  it("does not send the top parameter for unfiltered top losers", async () => {
+    await fetchList({ counterCurrency: "usd", order: Order.topLosers });
 
     expect(getLastRequestUrl().searchParams.get("top")).toBeNull();
   });

--- a/libs/ledger-live-common/src/market/api/countervalues.ts
+++ b/libs/ledger-live-common/src/market/api/countervalues.ts
@@ -36,10 +36,6 @@ export async function fetchList({
       ...(starred.length > 0 && { ids: starred.sort().join(",") }),
       ...(liveCompatible && { supported: liveCompatible }),
       ...(categories && { categories }),
-      // Only apply `top=100` for global gainers/losers (LIVE-32164).
-      ...(!hasExplicitFilter &&
-        !categories &&
-        [Order.topLosers, Order.topGainers].includes(order) && { top: 100 }),
     },
   });
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Market list sorted by % change (top gainers/losers): scroll and confirm it loads beyond the first page
  - Market Banner top performers still display correctly (uses the separate `getMarketPerformers` endpoint)
  - Filtered, category, and search lists still paginate and behave as before
  - Market-cap and stocks list pagination is unaffected

### 📝 Description

The Market list "% change" sort (top gainers/losers) was stuck on the first page. The global, unfiltered gainers/losers request sent `top=100`, which capped the result set and prevented pagination from loading further coins.

This PR removes the `top=100` cap from the global, unfiltered gainers/losers request so the list now paginates through all coins like the market-cap and stocks lists. The Market Banner top performers are unaffected — they use the separate `getMarketPerformers` endpoint with its own `top` cap.



https://github.com/user-attachments/assets/8b09a9bb-0e55-4dd2-9fc4-fd820a3cfed1




### ❓ Context

- **JIRA or GitHub link**: [LIVE-32955](https://ledgerhq.atlassian.net/browse/LIVE-32955)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32955]: https://ledgerhq.atlassian.net/browse/LIVE-32955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ