### PR TITLE
[LWDM] chore(borrow): update borrow entry card copy

### DIFF
--- a/.changeset/borrow-entry-card-copy.md
+++ b/.changeset/borrow-entry-card-copy.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Update Borrow entry card copy on the Discover dashboard to "Get stablecoin" / "Get cash without selling"

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8789,8 +8789,8 @@
     },
     "borrowEntry": {
       "title": "Loans",
-      "cardTitle": "Borrow Stablecoin",
-      "cardDescription": "Unlock liquidity",
+      "cardTitle": "Get stablecoin",
+      "cardDescription": "Get cash without selling",
       "cta": "Explore"
     },
     "noDeviceTitle": "Your secure crypto wallet"

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2867,8 +2867,8 @@
     },
     "borrowEntry": {
       "title": "Loans",
-      "cardTitle": "Borrow Stablecoin",
-      "cardDescription": "Unlock liquidity",
+      "cardTitle": "Get stablecoin",
+      "cardDescription": "Get cash without selling",
       "cta": "Explore"
     },
     "recommended": {


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _Copy-only change in English i18n files; no logic affected._
- [x] **Impact of the changes:**
      - Borrow entry card on the Discover / dashboard view in Desktop
      - Borrow entry card on the Discover / dashboard view in Mobile

### Description

This PR updates the copy of the Borrow entry card on the Discover dashboard for both Desktop and Mobile, to better reflect the user-facing value of the feature.

**Problem**: The current copy ("Borrow Stablecoin" / "Unlock liquidity") is too jargon-heavy and does not clearly communicate the user benefit.

**Solution**: Updated the entry card strings under the `portfollio.borrowEntry` namespace in both apps:
- `cardTitle`: "Borrow Stablecoin" → "Get stablecoin"
- `cardDescription`: "Unlock liquidity" → "Get cash without selling"

<img width="1457" height="639" alt="image" src="https://github.com/user-attachments/assets/e32de9ce-01d1-4b2a-a1ef-66ce31549436" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-22 at 09 37 45" src="https://github.com/user-attachments/assets/89a5742d-b18c-4b79-b086-daacb0767693" />


### Context

- **JIRA or GitHub link**: _None_

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)