### PR TITLE
[LWDM] fix: solana withdrawable check

### DIFF
--- a/.changeset/gentle-monkeys-drive.md
+++ b/.changeset/gentle-monkeys-drive.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": patch
+---
+
+Fix: fetch withdrawable value at runtime

--- a/libs/coin-modules/coin-solana/src/logic/tests/validateIntent.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/validateIntent.unit.test.ts
@@ -501,6 +501,18 @@ describe("validateIntent", () => {
 
         expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
       });
+
+      it("keeps the returned amount clamped to 0 even when errors are set", async () => {
+        const result = await validateIntent(
+          makeWithdrawIntent({ amount: -1_000n }),
+          makeBalances(3000n, 0n),
+          { value: 5000n },
+        );
+
+        expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+        expect(result.amount).toBe(0n);
+        expect(result.totalSpent).toBe(5000n);
+      });
     });
   });
 

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.test.ts
@@ -6,6 +6,8 @@ import {
   SolanaMemoIsTooLong,
   SolanaRecipientAccountNotFunded,
   SolanaStakeAccountAmountTooLow,
+  SolanaStakeAccountNothingToWithdraw,
+  SolanaStakeNoWithdrawAuth,
 } from "./errors";
 import { estimateFeeAndSpendable } from "./estimateMaxSpendable";
 import * as logicValidateMemo from "./logic/validateMemo";
@@ -719,6 +721,127 @@ describe("testing prepareTransaction", () => {
       const amountError = preparedTransaction.model.commandDescriptor?.errors.amount;
       expect(amountError).toBeInstanceOf(SolanaStakeAccountAmountTooLow);
       expect((amountError as Error & { minimumAmount?: string })?.minimumAmount).toBe("1 SOL");
+    });
+
+    describe("stake.withdraw", () => {
+      const stakeAccAddr = "2d3BEsPXeBvSjN5WZojX4ZWnakbt6rLd1Q7LpqdLjt53";
+      const senderAddress = "Sender11111111111111111111111111111111";
+      const STALE_WITHDRAWABLE = 161_310_212_991;
+      const RENT_EXEMPT_RESERVE = 2_282_880;
+
+      const makeAccount = (overrides?: Partial<SolanaAccount>): SolanaAccount =>
+        ({
+          currency: { units: [{ magnitude: 9 }] },
+          freshAddress: senderAddress,
+          solanaResources: {
+            unstakeReserve: new BigNumber(1_000_000),
+            stakes: [
+              {
+                stakeAccAddr,
+                hasStakeAuth: true,
+                hasWithdrawAuth: true,
+                delegation: undefined,
+                stakeAccBalance: STALE_WITHDRAWABLE + RENT_EXEMPT_RESERVE,
+                rentExemptReserve: RENT_EXEMPT_RESERVE,
+                withdrawable: STALE_WITHDRAWABLE,
+                activation: { state: "inactive", active: 0, inactive: STALE_WITHDRAWABLE },
+              },
+            ],
+          },
+          ...overrides,
+        }) as unknown as SolanaAccount;
+
+      it("clamps the encoded amount to the live on-chain balance when sync data is stale", async () => {
+        mockedEstimateFeeAndSpendable.mockResolvedValueOnce({
+          fee: 5000,
+          spendable: new BigNumber(1_000_000),
+        });
+
+        const withdrawTx = transaction({
+          kind: "stake.withdraw",
+          uiState: { stakeAccAddr },
+        });
+
+        const prepared = await prepareTransaction(makeAccount(), withdrawTx, {
+          getBalance: () => Promise.resolve(RENT_EXEMPT_RESERVE),
+        } as unknown as ChainAPI);
+
+        const command = prepared.model.commandDescriptor?.command;
+        expect(command?.kind).toBe("stake.withdraw");
+        if (command?.kind === "stake.withdraw") {
+          expect(command.amount).toBe(RENT_EXEMPT_RESERVE);
+        }
+        expect(prepared.model.commandDescriptor?.errors.stakeAccAddr).toBeUndefined();
+      });
+
+      it("flags SolanaStakeAccountNothingToWithdraw when the live balance is empty", async () => {
+        mockedEstimateFeeAndSpendable.mockResolvedValueOnce({
+          fee: 5000,
+          spendable: new BigNumber(1_000_000),
+        });
+
+        const withdrawTx = transaction({
+          kind: "stake.withdraw",
+          uiState: { stakeAccAddr },
+        });
+
+        const prepared = await prepareTransaction(makeAccount(), withdrawTx, {
+          getBalance: () => Promise.resolve(0),
+        } as unknown as ChainAPI);
+
+        expect(prepared.model.commandDescriptor?.errors.stakeAccAddr).toBeInstanceOf(
+          SolanaStakeAccountNothingToWithdraw,
+        );
+        const command = prepared.model.commandDescriptor?.command;
+        if (command?.kind === "stake.withdraw") {
+          expect(command.amount).toBe(0);
+        }
+      });
+
+      it("zeroes the encoded amount when the stake account has no withdraw authority", async () => {
+        mockedEstimateFeeAndSpendable.mockResolvedValueOnce({
+          fee: 5000,
+          spendable: new BigNumber(1_000_000),
+        });
+
+        const withdrawTx = transaction({
+          kind: "stake.withdraw",
+          uiState: { stakeAccAddr },
+        });
+
+        const prepared = await prepareTransaction(
+          makeAccount({
+            solanaResources: {
+              unstakeReserve: new BigNumber(1_000_000),
+              stakes: [
+                {
+                  stakeAccAddr,
+                  hasStakeAuth: true,
+                  hasWithdrawAuth: false,
+                  delegation: undefined,
+                  stakeAccBalance: STALE_WITHDRAWABLE + RENT_EXEMPT_RESERVE,
+                  rentExemptReserve: RENT_EXEMPT_RESERVE,
+                  withdrawable: STALE_WITHDRAWABLE,
+                  activation: { state: "inactive", active: 0, inactive: STALE_WITHDRAWABLE },
+                },
+              ],
+            },
+          } as unknown as Partial<SolanaAccount>),
+          withdrawTx,
+          {
+            getBalance: () => Promise.resolve(STALE_WITHDRAWABLE + RENT_EXEMPT_RESERVE),
+          } as unknown as ChainAPI,
+        );
+
+        expect(prepared.model.commandDescriptor?.errors.stakeAccAddr).toBeInstanceOf(
+          SolanaStakeNoWithdrawAuth,
+        );
+        const command = prepared.model.commandDescriptor?.command;
+        expect(command?.kind).toBe("stake.withdraw");
+        if (command?.kind === "stake.withdraw") {
+          expect(command.amount).toBe(0);
+        }
+      });
     });
 
     it("should derive stake.split command with seed <= 32 bytes", async () => {

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.ts
@@ -44,6 +44,7 @@ import {
   decodeAccountIdWithTokenAccountAddress,
   isEd25519Address,
   isValidBase58Address,
+  withdrawableFromStake,
 } from "./logic";
 import { MAX_MEMO_LENGTH, validateMemo } from "./logic/validateMemo";
 import { ChainAPI } from "./network";
@@ -813,11 +814,25 @@ async function deriveStakeWithdrawCommandDescriptor(
 
   const stake = validateAndTryGetStakeAccount(mainAccount, uiState.stakeAccAddr, errors);
 
+  let withdrawable = stake?.withdrawable ?? 0;
+
   if (!errors.stakeAccAddr && stake !== undefined) {
     if (!stake.hasWithdrawAuth) {
+      withdrawable = 0;
       errors.stakeAccAddr = new SolanaStakeNoWithdrawAuth();
-    } else if (stake.withdrawable <= 0) {
-      errors.stakeAccAddr = new SolanaStakeAccountNothingToWithdraw();
+    } else {
+      const liveLamports = await api.getBalance(uiState.stakeAccAddr);
+      withdrawable = Math.max(
+        0,
+        withdrawableFromStake({
+          stakeAccBalance: liveLamports,
+          activation: stake.activation,
+          rentExemptReserve: stake.rentExemptReserve,
+        }),
+      );
+      if (withdrawable <= 0) {
+        errors.stakeAccAddr = new SolanaStakeAccountNothingToWithdraw();
+      }
     }
   }
 
@@ -831,7 +846,7 @@ async function deriveStakeWithdrawCommandDescriptor(
       kind: "stake.withdraw",
       authorizedAccAddr: mainAccount.freshAddress,
       stakeAccAddr: uiState.stakeAccAddr,
-      amount: stake?.withdrawable ?? 0,
+      amount: withdrawable,
       toAccAddr: mainAccount.freshAddress,
     },
     fee,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description


- The withdrawable amount of a Solana stake account was being read from the cached account state (stake.withdrawable), which can be stale relative to on-chain balance (e.g. after rewards land or after a partial withdrawal). When stale, prepare-transaction either incorrectly raised SolanaStakeAccountNothingToWithdraw or sent a withdraw command with an outdated amount.
- deriveStakeWithdrawCommandDescriptor now fetches the live lamport balance of the stake account via api.getBalance(...) and recomputes the withdrawable value with withdrawableFromStake (using the cached activation + rentExemptReserve). The recomputed value drives both the SolanaStakeAccountNothingToWithdraw error and the amount written into the command.
- Added unit tests in prepareTransaction.test.ts covering the new live-balance path.

Changes

- libs/coin-modules/coin-solana/src/prepareTransaction.ts — fetch live balance and recompute withdrawable in deriveStakeWithdrawCommandDescriptor.
- libs/coin-modules/coin-solana/src/prepareTransaction.test.ts — tests for the runtime check.
- .changeset/gentle-monkeys-drive.md — patch changeset for @ledgerhq/coin-solana.


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-32553](https://ledgerhq.atlassian.net/browse/LIVE-32553)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-32553]: https://ledgerhq.atlassian.net/browse/LIVE-32553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ