### PR TITLE
docs(skills): add knip-migration skill and Copilot reviewer check

### DIFF
--- a/.agents/agents/code-reviewer.md
+++ b/.agents/agents/code-reviewer.md
@@ -19,6 +19,7 @@ Pay special attention to:
 - `.agents/skills/react-general/SKILL.md` — Canonical React review guidance; use for component patterns, hooks, rendering, and React architecture rules
 - `.agents/skills/coin-families-contract/SKILL.md` — Coin-families contract: no coin-specific branches (`if (family === "evm")` etc.) in generic UI; extend the families contract and implement in `families/<family>/` instead
 - `.agents/skills/codeownership/SKILL.md` — Team-split convention: multi-team files should be split into `[foo]/index.ts` and `[foo]/team-[team]/*.ts`; suggest this when a touched file clearly involves many teams
+- `.agents/skills/knip-migration/SKILL.md` — Dead-code detection is moving to `knip`, which needs explicit (non-`./*`) `package.json#exports`; new packages must use explicit exports + knip, not `.unimportedrc.json`
 
 ## Review Scope
 
@@ -45,6 +46,7 @@ By default, review unstaged changes from `git diff`. The user may specify differ
 - Lumen UI compliance: verify new UI in `src/mvvm/` uses design-system components
 - **Coin-families contract:** In generic code (outside `families/<family>/`), flag new `if (family === "…")` or coin-specific hooks; suggest extending the families contract and implementing in the family folder instead.
 - **Cross-team files:** When a PR touches a file owned by multiple teams, suggest the team-split convention: split into `[foo]/index.ts` and `[foo]/team-[team]/*.ts`; one file or small set per team; index re-exports all. CODEOWNERS defines the allowed `team-*` slugs.
+- **Dead-code tooling — explicit exports + knip (new packages):** For a **new** package, flag either (a) a `.unimportedrc.json` or a script running the bare `unimported` binary (`"unimported": "unimported"`), or (b) a `./*` wildcard in `package.json#exports`. New packages must enumerate explicit, minimal `exports` (no `./*`, so knip can detect unused files) and use `knip` via a root `knip.json` `workspaces` entry. The repo is migrating dead-code detection off `unimported` (see `.agents/skills/knip-migration/SKILL.md`).
 
 ## Confidence Scoring
 

--- a/.agents/skills/knip-migration/SKILL.md
+++ b/.agents/skills/knip-migration/SKILL.md
@@ -9,8 +9,8 @@ description: |
 # Dead-code detection: explicit exports + knip (not unimported)
 
 The repo is migrating dead-code / unused-dependency detection from the legacy **`unimported`**
-tool to **`knip`**, one package at a time (initiative **LIVE-32873**). knip is configured
-centrally in the root [`knip.json`](../../../knip.json) (one `workspaces` entry per package).
+tool to **`knip`**, one package at a time. knip is configured centrally in the root
+[`knip.json`](../../../knip.json) (one `workspaces` entry per package).
 
 ## Why this isn't just "swap the tool"
 

--- a/.agents/skills/knip-migration/SKILL.md
+++ b/.agents/skills/knip-migration/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: knip-migration
+description: |
+  Dead-code / unused-dependency detection is migrating from the legacy `unimported` tool to
+  `knip`, which requires each package to expose an explicit, minimal `package.json#exports`
+  (no `./*` wildcard). Read this when adding a new package or migrating an existing one.
+---
+
+# Dead-code detection: explicit exports + knip (not unimported)
+
+The repo is migrating dead-code / unused-dependency detection from the legacy **`unimported`**
+tool to **`knip`**, one package at a time (initiative **LIVE-32873**). knip is configured
+centrally in the root [`knip.json`](../../../knip.json) (one `workspaces` entry per package).
+
+## Why this isn't just "swap the tool"
+
+knip treats everything listed in a package's `package.json#exports` as an **entry point**.
+Today every package exports a `./*` wildcard mapped to `./src/*.ts` (via the `@ledgerhq/source`
+custom condition declared in `tsconfig.base.json`):
+
+```jsonc
+"./*": {
+  "@ledgerhq/source": "./src/*.ts",
+  "import": "./lib-es/*.js",
+  "require": "./lib/*.js",
+  "default": "./lib/*.js"
+}
+```
+
+Because of this wildcard, knip considers **every top-level `src/*.ts` file "used"** and cannot
+detect unused ("zombie") top-level source files — the exact thing `unimported` caught (it
+ignored `exports` and diffed against a curated entry list). So real knip parity for a package
+requires **replacing the `./*` wildcard with explicit, minimal subpath exports** that enumerate
+the package's true public API.
+
+> The few libs already pointed at knip (e.g. `libs/env`, `libs/promise`) still keep the `./*`
+> wildcard, so they are only *partially* migrated — **do not** copy them as the template.
+
+## New package = born migrated
+
+A new package has no consumers, so it should start in the target state — no `.unimportedrc.json`:
+
+1. **Explicit `exports` only.** Enumerate the real public API; do **not** add a `./*` wildcard.
+   Mirror the `.` root entry per subpath, keeping the conditions:
+   ```jsonc
+   "exports": {
+     ".":        { "@ledgerhq/source": "./src/index.ts",  "import": "./lib-es/index.js",  "require": "./lib/index.js",  "default": "./lib/index.js" },
+     "./logic":  { "@ledgerhq/source": "./src/logic.ts",  "import": "./lib-es/logic.js",  "require": "./lib/logic.js",  "default": "./lib/logic.js" },
+     "./lib-es/*": "./lib-es/*.js",
+     "./lib/*": "./lib/*.js",
+     "./package.json": "./package.json"
+   }
+   ```
+2. **Register in `knip.json`** — add a `workspaces` entry (`entry`, `ignore`, `ignoreDependencies`).
+3. **Use knip, not unimported** — add a script that runs knip scoped to the workspace:
+   `pnpm knip --directory <relative-hop-to-root> -W <workspace-path>`
+   (`--directory` is the hop back to the repo root — `../..` for `libs/<x>`,
+   `../../..` for `libs/coin-modules/<x>`; `-W` is the workspace path from root).
+
+## Migrating an existing package off `unimported`
+
+1. **Audit** the real consumers of the package's deep imports.
+2. **Replace** the `./*` wildcard export with explicit subpath exports (the legit public API).
+3. **Refactor** consumers that relied on now-removed arbitrary entry points.
+4. **Switch** the dead-code script `unimported` → knip, delete `.unimportedrc.json`, and verify
+   a deliberately-unused top-level `src` file is now reported.
+
+Start with leaf / low-dependency packages; `ledger-live-common` (largest surface) comes last.
+
+### Notes
+
+- `unimported` stays until a package reaches knip parity — don't bulk-delete it.
+- Unifying the script / nx-target name (`unimported` → `knip-check`) is tracked separately, so
+  matching the surrounding package's existing script name is fine.
+
+## Reviewing
+
+For a **new** package, flag either of these and point here:
+
+- a `.unimportedrc.json` or a script running the **bare `unimported` binary**
+  (`"unimported": "unimported"`) — it must use knip via a root `knip.json` `workspaces` entry; or
+- a **`./*` wildcard** in `package.json#exports` — new packages must enumerate explicit exports
+  so knip can detect zombie files.


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- N/A: changes are limited to `.agents/` (agent skills + reviewer config); no published package code, so no changeset applies. -->
- [x] **Covered by automatic tests.** <!-- Verified via a `code-reviewer` dry-run (see Description). Markdown skill/agent config has no unit tests. -->
- [ ] **Impact of the changes:**
  - Adds agent-only docs/config under `.agents/`. No runtime, build, CI, `knip.json`, nx-target, or package-export changes.

### 📝 Description

The team is migrating dead-code / unused-dependency detection from the legacy `unimported` tool to `knip`, package by package ([LIVE-32873](https://ledgerhq.atlassian.net/browse/LIVE-32873)). A recently merged new package ([PR #18191](https://github.com/LedgerHQ/ledger-live/pull/18191)) shipped a `.unimportedrc.json`, showing new packages don't yet know the intended approach.

This PR documents the approach and lets the Copilot automated reviewer catch regressions:

- **New skill** `.agents/skills/knip-migration/SKILL.md` — explains why this isn't a simple tool swap (every package's `./*` wildcard `package.json#exports` makes knip treat all top-level `src/*` files as used, so it can't detect unused "zombie" files), the **born-migrated** setup for new packages (explicit minimal `exports` + knip, no `.unimportedrc.json`), and the per-package migration steps for existing packages.
- **Reviewer check** in `.agents/agents/code-reviewer.md` — flags a new package that adds a `.unimportedrc.json` / bare `unimported` script, or ships a `./*` wildcard export.

Tooling/docs only — it migrates no package and changes no exports, `knip.json`, nx targets, or CI.

**Verification:** ran the `code-reviewer` agent against a throwaway new package containing both a `.unimportedrc.json` and a `./*` wildcard export; it flagged every expected issue (🔴) with pointers to the new skill.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32979](https://ledgerhq.atlassian.net/browse/LIVE-32979) — relates to initiative [LIVE-32873](https://ledgerhq.atlassian.net/browse/LIVE-32873)
- **ADR link (if any)**: n/a


[LIVE-32873]: https://ledgerhq.atlassian.net/browse/LIVE-32873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-32979]: https://ledgerhq.atlassian.net/browse/LIVE-32979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ