### PR TITLE
[LWM] feat(mobile): add bottom fade gradient on wallet 4.0 accounts screen

### DIFF
--- a/.changeset/tall-pandas-fade.md
+++ b/.changeset/tall-pandas-fade.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add a bottom fade gradient behind the "Add account" CTA on the Wallet 4.0 accounts screen so the button stands out from the list, via a new reusable `BottomGradientFooter` component (also adopted by the asset detail footer)

--- a/apps/ledger-live-mobile/src/mvvm/components/BottomGradientFooter/__tests__/BottomGradientFooter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/BottomGradientFooter/__tests__/BottomGradientFooter.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Text } from "react-native";
+import { render, screen } from "@tests/test-renderer";
+import { BottomGradientFooter } from "../index";
+
+describe("BottomGradientFooter", () => {
+  it("renders children and forwards testID", () => {
+    render(
+      <BottomGradientFooter testID="bottom-gradient-footer">
+        <Text>Add account</Text>
+      </BottomGradientFooter>,
+    );
+
+    expect(screen.getByTestId("bottom-gradient-footer")).toBeVisible();
+    expect(screen.getByText("Add account")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/BottomGradientFooter/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/BottomGradientFooter/index.tsx
@@ -1,0 +1,56 @@
+import React, { type ReactNode } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Box, LinearGradient } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+
+/**
+ * Approximate footer height, excluding the safe-area inset. Reserve
+ * `BOTTOM_GRADIENT_FOOTER_HEIGHT + safeArea.bottom` as `paddingBottom` on the
+ * scrollable content so the last rows clear the footer.
+ */
+export const BOTTOM_GRADIENT_FOOTER_HEIGHT = 80;
+
+type Props = Readonly<{
+  children: ReactNode;
+  /** Extra layout for the inner content row, e.g. `{ alignItems: "center" }`. */
+  contentStyle?: LumenViewStyle;
+  testID?: string;
+}>;
+
+/**
+ * Floating bottom bar that fades the scroll content behind it into the screen
+ * background, keeping its CTA(s) visible. Render it as the last sibling of a
+ * `flex: 1` screen and reserve bottom padding on the scrollable content with
+ * {@link BOTTOM_GRADIENT_FOOTER_HEIGHT}.
+ */
+export function BottomGradientFooter({ children, contentStyle, testID }: Props) {
+  const { bottom } = useSafeAreaInsets();
+
+  return (
+    <LinearGradient
+      stops={[
+        { color: "base", opacity: 0 },
+        { offset: 1, color: "base", opacity: 1 },
+      ]}
+      direction="to-bottom"
+      testID={testID}
+      lx={containerStyle}
+    >
+      <Box lx={{ ...rowStyle, ...contentStyle }} style={{ paddingBottom: bottom + 16 }}>
+        {children}
+      </Box>
+    </LinearGradient>
+  );
+}
+
+const containerStyle: LumenViewStyle = {
+  position: "absolute",
+  bottom: "s0",
+  left: "s0",
+  right: "s0",
+};
+
+const rowStyle: LumenViewStyle = {
+  paddingHorizontal: "s16",
+  paddingTop: "s16",
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/FooterView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/FooterView.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { Box, Button, LinearGradient } from "@ledgerhq/lumen-ui-rnative";
+import { Box, Button } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useTranslation } from "~/context/Locale";
+import { BottomGradientFooter } from "LLM/components/BottomGradientFooter";
 import type { SecondaryButtonType } from "./useFooterViewModel";
 import { ASSET_DETAIL_TEST_IDS } from "../../../../testIds";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 type Props = Readonly<{
   isBuyAvailable: boolean;
@@ -21,80 +21,60 @@ export function FooterView({
   onSwapPress,
   onReceivePress,
 }: Props) {
-  const { bottom } = useSafeAreaInsets();
   const { t } = useTranslation();
 
   if (!isBuyAvailable && !secondaryButton) return null;
 
   return (
-    <LinearGradient
-      stops={[
-        { color: "base", opacity: 0 },
-        { offset: 1, color: "base", opacity: 1 },
-      ]}
-      direction="to-bottom"
-      testID={ASSET_DETAIL_TEST_IDS.ctas}
-      lx={containerStyle}
-    >
-      <Box lx={rowStyle} style={{ paddingBottom: bottom + 16 }}>
-        {isBuyAvailable && (
-          <Box lx={buttonSlotStyle}>
-            <Button
-              appearance="gray"
-              size="lg"
-              isFull
-              onPress={onBuyPress}
-              testID={ASSET_DETAIL_TEST_IDS.buyButton}
-            >
-              {t("exchange.buy.tabTitle")}
-            </Button>
-          </Box>
-        )}
+    <BottomGradientFooter testID={ASSET_DETAIL_TEST_IDS.ctas} contentStyle={rowStyle}>
+      {isBuyAvailable && (
+        <Box lx={buttonSlotStyle}>
+          <Button
+            appearance="gray"
+            size="lg"
+            isFull
+            onPress={onBuyPress}
+            testID={ASSET_DETAIL_TEST_IDS.buyButton}
+          >
+            {t("exchange.buy.tabTitle")}
+          </Button>
+        </Box>
+      )}
 
-        {secondaryButton === "swap" && (
-          <Box lx={buttonSlotStyle}>
-            <Button
-              appearance="base"
-              size="lg"
-              isFull
-              onPress={onSwapPress}
-              testID={ASSET_DETAIL_TEST_IDS.swapButton}
-            >
-              {t("transfer.swap.title")}
-            </Button>
-          </Box>
-        )}
+      {secondaryButton === "swap" && (
+        <Box lx={buttonSlotStyle}>
+          <Button
+            appearance="base"
+            size="lg"
+            isFull
+            onPress={onSwapPress}
+            testID={ASSET_DETAIL_TEST_IDS.swapButton}
+          >
+            {t("transfer.swap.title")}
+          </Button>
+        </Box>
+      )}
 
-        {secondaryButton === "receive" && (
-          <Box lx={buttonSlotStyle}>
-            <Button
-              appearance="base"
-              size="lg"
-              isFull
-              onPress={onReceivePress}
-              testID={ASSET_DETAIL_TEST_IDS.footerReceiveButton}
-            >
-              {t("transfer.receive.title")}
-            </Button>
-          </Box>
-        )}
-      </Box>
-    </LinearGradient>
+      {secondaryButton === "receive" && (
+        <Box lx={buttonSlotStyle}>
+          <Button
+            appearance="base"
+            size="lg"
+            isFull
+            onPress={onReceivePress}
+            testID={ASSET_DETAIL_TEST_IDS.footerReceiveButton}
+          >
+            {t("transfer.receive.title")}
+          </Button>
+        </Box>
+      )}
+    </BottomGradientFooter>
   );
 }
 
 const rowStyle: LumenViewStyle = {
-  paddingHorizontal: "s16",
-  paddingTop: "s16",
   flexDirection: "row",
   gap: "s8",
-};
-
-const containerStyle: LumenViewStyle = {
-  position: "absolute",
-  bottom: "s0",
-  left: "s0",
-  right: "s0",
 };
 
 const buttonSlotStyle: LumenViewStyle = {

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/components/CryptoAddressesFooter.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/components/CryptoAddressesFooter.tsx
@@ -1,23 +1,21 @@
 import React from "react";
-import { StyleSheet } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { Box, Button } from "@ledgerhq/lumen-ui-rnative";
+import { Button } from "@ledgerhq/lumen-ui-rnative";
 import { Plus } from "@ledgerhq/lumen-ui-rnative/symbols";
+import {
+  BottomGradientFooter,
+  BOTTOM_GRADIENT_FOOTER_HEIGHT,
+} from "LLM/components/BottomGradientFooter";
 
 type Props = Readonly<{
   label: string;
   onPress: () => void;
 }>;
 
-const PADDING_BOTTOM = 16;
-
-export const FOOTER_HEIGHT = 80;
+export const FOOTER_HEIGHT = BOTTOM_GRADIENT_FOOTER_HEIGHT;
 
 export default function CryptoAddressesFooter({ label, onPress }: Props) {
-  const { bottom } = useSafeAreaInsets();
-
   return (
-    <Box style={[styles.container, { paddingBottom: bottom + PADDING_BOTTOM }]}>
+    <BottomGradientFooter contentStyle={{ alignItems: "center" }}>
       <Button
         appearance="base"
         size="lg"
@@ -27,18 +25,6 @@ export default function CryptoAddressesFooter({ label, onPress }: Props) {
       >
         {label}
       </Button>
-    </Box>
+    </BottomGradientFooter>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    position: "absolute",
-    bottom: 0,
-    left: 0,
-    right: 0,
-    alignItems: "center",
-    paddingHorizontal: 16,
-    paddingTop: 16,
-  },
-});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _New `BottomGradientFooter` has a unit test; both consumers (CryptoAddresses footer + AssetDetail footer) are covered by their existing unit and integration tests. The gradient itself is visual and should be checked manually._
- [x] **Impact of the changes:**
  - Wallet 4.0 accounts screen (`CryptoAddresses`): the "Add account" CTA now has a fade gradient behind it — verify the button stands out, the last list rows scroll clear of it, and safe-area spacing is correct on notched devices.
  - Asset detail footer: verify Buy / Swap / Receive still render and behave correctly (refactored onto the shared component), including when only some buttons are available.
  - Light & dark themes: the gradient must fade to the correct screen background color.

### 📝 Description

On the Wallet 4.0 accounts screen (`CryptoAddresses`), the "Add account" CTA sits in a sticky footer over the scrollable accounts list. With no visual separation, list rows run right up behind the button, making the CTA hard to distinguish from the content.

This PR adds a bottom fade gradient behind that footer (transparent → screen background), so content fades out beneath the CTA — matching the pattern already used on the asset detail screen. The gradient + sticky-footer logic is extracted into a reusable `BottomGradientFooter` component under `apps/ledger-live-mobile/src/mvvm/components`, and the asset detail footer is migrated onto it to remove the duplicated gradient code. Inner layout (a centered button vs. a row of buttons) stays per-screen via a `contentStyle` prop, and the component exports `BOTTOM_GRADIENT_FOOTER_HEIGHT` so screens can reserve the matching scroll padding.

### 📸 Screenshots

https://github.com/user-attachments/assets/b343343b-ef34-40f8-83eb-bfe5322af7f1

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32981](https://ledgerhq.atlassian.net/browse/LIVE-32981)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-32981]: https://ledgerhq.atlassian.net/browse/LIVE-32981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ