### PR TITLE
[LWM] feat(mobile): open the asset detail "see all" accounts drawer at full height

### DIFF
--- a/.changeset/tidy-spiders-clap.md
+++ b/.changeset/tidy-spiders-clap.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Open the "See all" accounts drawer on the asset detail screen at full height and lock its size so it can no longer be resized

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/components/AllAddressesDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/components/AllAddressesDrawer.tsx
@@ -58,6 +58,8 @@ export function AllAddressesDrawer({ isOpen, onClose, accountIds }: Props) {
       testID={ASSET_DETAIL_TEST_IDS.allAddressesDrawer}
       isRequestingToBeOpened={isOpen}
       onClose={onClose}
+      snapPoints="full"
+      enableHandlePanningGesture={false}
     >
       <BottomSheetHeader spacing density="expanded" title={headerTitle} />
       <BottomSheetFlatList


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _The existing AssetDetail integration test covers the "See all" flow (button visibility + drawer opening) and still passes. The full-height snap point and disabled resize gesture are layout/gesture configuration, best validated visually on device — not asserted directly._
- [x] **Impact of the changes:**
  - Asset detail screen → "See all" accounts drawer: verify it opens at **full height**.
  - Verify the drawer is **not resizable** — the handle can't be dragged to change its height.
  - Verify it can still be dismissed (close button / backdrop) and that the accounts list scrolls correctly inside it.

### 📝 Description

On the asset detail screen, the "See all" button for accounts opened the all-addresses drawer at a partial height (it inherited the default `["70%", "90%"]` snap points), so it opened at 70% and could be dragged/resized up to 90%.

This PR opens the drawer at full height using Lumen's `full` snap-point preset and disables the handle panning gesture (`enableHandlePanningGesture={false}`), so the drawer is fixed at full height and can no longer be resized. Dismissal (close button / backdrop) is unchanged.

### 📸 Screenshots

https://github.com/user-attachments/assets/395c4a90-e9c6-48d7-a664-8a88ebff306a



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32984](https://ledgerhq.atlassian.net/browse/LIVE-32984)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-32984]: https://ledgerhq.atlassian.net/browse/LIVE-32984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ