### PR TITLE
[LWD] fix: market Change column truncation

### DIFF
--- a/.changeset/lwd-market-change-column-width.md
+++ b/.changeset/lwd-market-change-column-width.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Market Change column truncation when using 1M or 1Y time range filters

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketTable/constants.ts
@@ -1,5 +1,5 @@
 export const MARKET_TABLE_GRID_TEMPLATE =
-  "minmax(200px, 2fr) minmax(110px, 1fr) minmax(100px, 1fr) minmax(110px, 1fr) minmax(96px, 0.9fr) 180px";
+  "minmax(200px, 2fr) minmax(110px, 1fr) minmax(100px, 1fr) minmax(110px, 1fr) minmax(110px, 0.9fr) 180px";
 
 export const MARKET_CELL_CLASSNAME = "flex items-center";
 

--- a/apps/ledger-live-desktop/src/renderer/screens/market/components/Table.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/components/Table.tsx
@@ -74,7 +74,7 @@ const TableRowBase = styled((props: FlexBoxProps & { header?: boolean; disabled?
     justify-content: flex-end;
   }
   ${TableCellBaseStyled}:nth-child(5) {
-    flex: 0 0 80px;
+    flex: 0 0 110px;
     justify-content: flex-end;
   }
   ${TableCellBaseStyled}:nth-child(6) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request addresses a UI issue in the Market table of the Ledger Live Desktop app, specifically fixing the truncation of the Market Change column when using the 1M or 1Y time range filters. The main changes involve increasing the width allocation for the affected column to ensure the content displays correctly.


https://github.com/user-attachments/assets/ad88100c-f111-480c-91b8-d873c8bd0517



### ❓ Context

[LIVE-32282](https://ledgerhq.atlassian.net/browse/LIVE-32282)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-32282]: https://ledgerhq.atlassian.net/browse/LIVE-32282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ