### PR TITLE
[LWDM] fix: re-adding a previously onboarded canton account

### DIFF
--- a/.changeset/violet-berries-grow.md
+++ b/.changeset/violet-berries-grow.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-canton": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+fix: re-adding a previously onboarded canton account

--- a/apps/ledger-live-desktop/src/renderer/families/canton/AddAccountDrawer/__integrations__/ModularDrawerReAddOnboarded.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/AddAccountDrawer/__integrations__/ModularDrawerReAddOnboarded.integration.test.tsx
@@ -1,0 +1,92 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions */
+import React from "react";
+import { render, screen, waitFor } from "tests/testSetup";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import type { Account } from "@ledgerhq/types-live";
+import ModularDrawerAddAccountFlowManager from "../../ModularDrawerAddAccountFlowManager";
+import { createMockAccount } from "../../__tests__/testUtils";
+
+// Drive the flow with trivial stand-ins for each step so the test exercises only the
+// flow manager's branching/dispatch (LIVE-32985), not device/scan/UI internals.
+jest.mock("../CantonDisclaimer", () => ({
+  __esModule: true,
+  default: ({ onAgree }: any) =>
+    React.createElement("button", { "data-testid": "disclaimer-agree", onClick: onAgree }, "agree"),
+}));
+
+jest.mock("LLD/features/AddAccountDrawer/screens/ConnectYourDevice", () => ({
+  __esModule: true,
+  default: ({ onConnect }: any) =>
+    React.createElement(
+      "button",
+      {
+        "data-testid": "connect-device",
+        onClick: () => onConnect({ device: { deviceId: "test-device-id" } }),
+      },
+      "connect",
+    ),
+}));
+
+jest.mock("LLD/features/AddAccountDrawer/screens/ScanAccounts", () => ({
+  __esModule: true,
+  default: ({ onComplete }: any) =>
+    React.createElement(
+      "button",
+      {
+        "data-testid": "scan-complete",
+        onClick: () => onComplete((globalThis as any).__cantonScannedAccounts ?? []),
+      },
+      "complete",
+    ),
+}));
+
+jest.mock("LLD/features/AddAccountDrawer/screens/AccountsAdded", () => ({
+  __esModule: true,
+  default: () => React.createElement("div", { "data-testid": "accounts-added" }, "added"),
+}));
+
+function cantonDevnetCurrency() {
+  const currency = getCryptoCurrencyById("canton_network_devnet");
+  if (!currency) throw new Error("canton_network_devnet is missing");
+  return currency;
+}
+
+function buildOnboardedAccount(): Account {
+  return createMockAccount({
+    id: "js:2:canton_network_devnet:onboarded-party::canton",
+    used: false,
+    xpub: "onboarded-party",
+    cantonResources: {
+      isOnboarded: true,
+      instrumentUtxoCounts: {},
+      pendingTransferProposals: [],
+    },
+  } as Partial<Account>);
+}
+
+describe("Canton MAD — re-adding an already-onboarded account (LIVE-32985)", () => {
+  afterEach(() => {
+    delete (globalThis as any).__cantonScannedAccounts;
+  });
+
+  it("persists an already-onboarded account via the non-onboarding path (no onboarding step)", async () => {
+    const onboarded = buildOnboardedAccount();
+    (globalThis as any).__cantonScannedAccounts = [onboarded];
+
+    const { user, store } = render(
+      <ModularDrawerAddAccountFlowManager currency={cantonDevnetCurrency()} />,
+      { initialState: { accounts: [] } },
+    );
+
+    await user.click(screen.getByTestId("disclaimer-agree"));
+    await user.click(screen.getByTestId("connect-device"));
+    await user.click(screen.getByTestId("scan-complete"));
+
+    // addAccountsAction was dispatched and reduced into the accounts state, and the flow
+    // landed on the success screen without routing through onboarding.
+    await waitFor(() => {
+      expect(store.getState().accounts.map((a: Account) => a.id)).toContain(onboarded.id);
+    });
+    expect(screen.getByTestId("accounts-added")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/canton/AddAccountDrawer/utils/__tests__/accountPreparation.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/AddAccountDrawer/utils/__tests__/accountPreparation.test.ts
@@ -1,0 +1,56 @@
+import type { CantonResources } from "@ledgerhq/coin-canton/types";
+import { createMockAccount } from "../../../__tests__/testUtils";
+import { getImportableAccounts } from "../accountPreparation";
+
+const cantonResources = (isOnboarded: boolean): CantonResources => ({
+  isOnboarded,
+  instrumentUtxoCounts: {},
+  pendingTransferProposals: [],
+});
+
+describe("accountPreparation (MAD)", () => {
+  describe("getImportableAccounts", () => {
+    it("returns funded (used) accounts", () => {
+      const used = createMockAccount({ id: "used", used: true });
+      const unused = createMockAccount({ id: "unused", used: false });
+
+      expect(getImportableAccounts([used, unused])).toEqual([used]);
+    });
+
+    it("includes already-onboarded Canton accounts even when unfunded (used=false)", () => {
+      // Re-adding a previously-onboarded account: the party exists on-chain (isOnboarded=true)
+      // but it is unfunded, so used=false. It must still be importable, not dropped.
+      const onboardedUnfunded = createMockAccount({
+        id: "onboarded",
+        used: false,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        cantonResources: cantonResources(true),
+      } as Partial<ReturnType<typeof createMockAccount>>);
+
+      expect(getImportableAccounts([onboardedUnfunded])).toEqual([onboardedUnfunded]);
+    });
+
+    it("excludes not-onboarded unfunded Canton accounts", () => {
+      const notOnboarded = createMockAccount({
+        id: "fresh",
+        used: false,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        cantonResources: cantonResources(false),
+      } as Partial<ReturnType<typeof createMockAccount>>);
+
+      expect(getImportableAccounts([notOnboarded])).toEqual([]);
+    });
+
+    it("keeps both funded and already-onboarded accounts", () => {
+      const used = createMockAccount({ id: "used", used: true });
+      const onboardedUnfunded = createMockAccount({
+        id: "onboarded",
+        used: false,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        cantonResources: cantonResources(true),
+      } as Partial<ReturnType<typeof createMockAccount>>);
+
+      expect(getImportableAccounts([used, onboardedUnfunded])).toEqual([used, onboardedUnfunded]);
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/canton/AddAccountDrawer/utils/accountPreparation.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/AddAccountDrawer/utils/accountPreparation.ts
@@ -1,3 +1,4 @@
+import { isCantonAccount } from "@ledgerhq/coin-canton/bridge/serialization";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account } from "@ledgerhq/types-live";
@@ -24,7 +25,10 @@ export function getCreatableAccount(
 }
 
 export function getImportableAccounts(selectedAccounts: Account[]): Account[] {
-  return selectedAccounts.filter(account => account.used);
+  // Already-onboarded Canton accounts are importable even when unfunded (used=false). LIVE-32985
+  return selectedAccounts.filter(
+    account => account.used || (isCantonAccount(account) && account.cantonResources.isOnboarded),
+  );
 }
 
 function resolveAccountName(

--- a/apps/ledger-live-desktop/src/renderer/families/canton/ModularDrawerAddAccountFlowManager.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/ModularDrawerAddAccountFlowManager.tsx
@@ -1,11 +1,12 @@
 import { AnimatePresence } from "framer-motion";
 import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch } from "LLD/hooks/redux";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
 import styled from "styled-components";
 import type { AppResult } from "@ledgerhq/live-common/hw/actions/app";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { isCantonAccount } from "@ledgerhq/coin-canton/bridge/serialization";
+import { addAccountsAction } from "@ledgerhq/live-wallet/addAccounts";
 import { Flex } from "@ledgerhq/react-ui/index";
 import type { Account } from "@ledgerhq/types-live";
 import { type ModularDrawerAddAccountStep } from "LLD/features/AddAccountDrawer/domain";
@@ -27,6 +28,7 @@ import {
   type ModularDrawerAddAccountFlowManagerProps,
 } from "LLD/features/AddAccountDrawer/ModularDrawerAddAccountFlowManager";
 import { setFlowValue } from "~/renderer/reducers/modularDialog";
+import { accountsSelector } from "~/renderer/reducers/accounts";
 import { CANTON_MODULAR_DRAWER_ADD_ACCOUNT_STEP } from "./AddAccountDrawer/domain";
 import type { CantonModularDrawerAddAccountStep } from "./AddAccountDrawer/domain";
 import { useAddAccountFlowNavigation } from "./AddAccountDrawer/hooks/useAddAccountFlowNavigation";
@@ -46,6 +48,7 @@ const ModularDrawerAddAccountFlowManager = ({
 }: ModularDrawerAddAccountFlowManagerProps) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
+  const existingAccounts = useSelector(accountsSelector);
 
   const [connectAppResult, setConnectAppResult] = useState<AppResult>();
   const [selectedAccounts, setSelectedAccounts] = useState<Account[]>([]);
@@ -99,11 +102,21 @@ const ModularDrawerAddAccountFlowManager = ({
         setCantonAccountsToOnboard(accounts);
         navigateToCantonOnboard();
       } else {
+        // Already-onboarded accounts skip onboarding; the scan defers addition for the
+        // onboarding path, so dispatch here or the re-add is silently lost. LIVE-32985
+        dispatch(
+          addAccountsAction({
+            existingAccounts,
+            scannedAccounts: accounts,
+            selectedIds: accounts.map(account => account.id),
+            renamings: {},
+          }),
+        );
         setSelectedAccounts(accounts);
         navigateToAccountsAdded();
       }
     },
-    [navigateToCantonOnboard, navigateToAccountsAdded],
+    [dispatch, existingAccounts, navigateToCantonOnboard, navigateToAccountsAdded],
   );
 
   const handleOnboardComplete = useCallback(

--- a/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/__tests__/accountPreparation.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/__tests__/accountPreparation.test.ts
@@ -1,3 +1,4 @@
+import type { CantonResources } from "@ledgerhq/coin-canton/types";
 import { createMockAccount, createMockCantonCurrency } from "../../__tests__/testUtils";
 import {
   getCreatableAccount,
@@ -49,6 +50,24 @@ describe("accountPreparation", () => {
       const unused = createMockAccount({ id: "unused", used: false });
       const result = getImportableAccounts([unused]);
       expect(result).toEqual([]);
+    });
+
+    it("should include already-onboarded Canton accounts even when unfunded (used=false)", () => {
+      const used = createMockAccount({ id: "used", used: true });
+      const cantonResources: CantonResources = {
+        isOnboarded: true,
+        instrumentUtxoCounts: {},
+        pendingTransferProposals: [],
+      };
+      const onboardedUnfunded = createMockAccount({
+        id: "onboarded",
+        used: false,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        cantonResources,
+      } as Partial<ReturnType<typeof createMockAccount>>);
+
+      const result = getImportableAccounts([used, onboardedUnfunded]);
+      expect(result).toEqual([used, onboardedUnfunded]);
     });
   });
 

--- a/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/utils/accountPreparation.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/utils/accountPreparation.ts
@@ -1,3 +1,4 @@
+import { isCantonAccount } from "@ledgerhq/coin-canton/bridge/serialization";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account } from "@ledgerhq/types-live";
@@ -24,7 +25,10 @@ export function getCreatableAccount(
 }
 
 export function getImportableAccounts(selectedAccounts: Account[]): Account[] {
-  return selectedAccounts.filter(account => account.used);
+  // Already-onboarded Canton accounts are importable even when unfunded (used=false). LIVE-32985
+  return selectedAccounts.filter(
+    account => account.used || (isCantonAccount(account) && account.cantonResources.isOnboarded),
+  );
 }
 
 function resolveAccountName(

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/__tests__/useOnboardingNavigation.test.ts
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/__tests__/useOnboardingNavigation.test.ts
@@ -99,6 +99,51 @@ describe("useOnboardingNavigation", () => {
       expect(mockParentNavigate).toHaveBeenCalled();
     });
 
+    it("should keep already-onboarded (unfunded) Canton accounts instead of dropping them", () => {
+      // Re-adding a previously-onboarded account alongside onboarding a new one: the re-added
+      // party is unfunded (used=false) but exists on-chain (isOnboarded=true) and must be kept.
+      const onboardedUnfunded = createMockAccount({
+        id: "onboarded-unfunded",
+        used: false,
+        cantonResources: {
+          isOnboarded: true,
+          instrumentUtxoCounts: {},
+          pendingTransferProposals: [],
+        },
+      } as any);
+      const accountsToAdd = [onboardedUnfunded];
+      const onboardResult = createMockOnboardResult({
+        account: createMockAccount({ id: "newly-onboarded" }),
+        partyId: "party-123",
+      });
+      const mockRoute = { params: {} };
+
+      const { result } = renderHook(() =>
+        useOnboardingNavigation({
+          navigation: mockNavigation as any,
+          route: mockRoute as any,
+          accountsToAdd,
+          cryptoCurrency: mockCryptoCurrency,
+          dispatch: mockDispatch,
+          existingAccounts: mockExistingAccounts,
+          restoreNavigationSnapshot: mockRestoreNavigationSnapshot,
+        }),
+      );
+
+      act(() => {
+        result.current.finishOnboarding(onboardResult);
+      });
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        addAccountsAction({
+          existingAccounts: mockExistingAccounts,
+          scannedAccounts: [onboardedUnfunded, onboardResult.account],
+          selectedIds: [onboardedUnfunded.id, onboardResult.account.id],
+          renamings: {},
+        }),
+      );
+    });
+
     it("should navigate to success screen for normal onboarding", () => {
       const accountsToAdd = [createMockAccount({ id: "new-1", used: true })];
       const onboardResult = createMockOnboardResult();

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/hooks/useOnboardingNavigation.ts
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/hooks/useOnboardingNavigation.ts
@@ -1,4 +1,5 @@
 import type { CantonOnboardResult } from "@ledgerhq/coin-canton/types";
+import { isCantonAccount } from "@ledgerhq/coin-canton/bridge/serialization";
 import { addAccountsAction } from "@ledgerhq/live-wallet/addAccounts";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account } from "@ledgerhq/types-live";
@@ -56,7 +57,12 @@ export function useOnboardingNavigation({
               },
             ]
           : (() => {
-              const importableAccounts = accountsToAdd.filter(account => account.used);
+              // Already-onboarded Canton accounts are importable even when unfunded (used=false). LIVE-32985
+              const importableAccounts = accountsToAdd.filter(
+                account =>
+                  account.used ||
+                  (isCantonAccount(account) && account.cantonResources.isOnboarded),
+              );
               const completedAccount = onboardResult.account;
 
               const accounts = [...importableAccounts];

--- a/libs/coin-modules/coin-canton/src/bridge/onboard.test.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/onboard.test.ts
@@ -111,6 +111,7 @@ describe("onboard", () => {
         partyId: mockPartyId,
         account: expect.objectContaining({
           xpub: mockPartyId,
+          cantonResources: expect.objectContaining({ isOnboarded: true }),
         }),
       });
 
@@ -174,6 +175,44 @@ describe("onboard", () => {
       const result = values.find((v): v is CantonOnboardResult => "partyId" in v);
       expect(result).toMatchObject({
         partyId: newPartyId,
+        account: expect.objectContaining({
+          xpub: newPartyId,
+          cantonResources: expect.objectContaining({ isOnboarded: true }),
+        }),
+      });
+    });
+
+    it("links the existing party (no submit) when prepareOnboarding reports it already exists", async () => {
+      // Re-adding a just-onboarded account during the gateway's by-public-key index lag:
+      // getPartyByPubKey still 404s, but prepareOnboarding reports the party already exists (with its id).
+      const account = createMockCantonAccount();
+      const existingPartyId =
+        "ldg::1220ac1d0368a250bc2b515a058d04a8b884cae4bb425258270ab3019b1ddd49cd1f";
+
+      mockedGateway.getPartyByPubKey.mockRejectedValue(
+        new Error('Party with public key "pk" does not exist'),
+      );
+      mockedGateway.prepareOnboarding.mockRejectedValue(
+        new Error(`Party with id "${existingPartyId}" already exists and its topology is up to date`),
+      );
+      mockedGateway.isPartyAlreadyExists.mockReturnValue(true);
+
+      const onboardObservable = buildOnboardAccount(mockSignerContext);
+      const values = await firstValueFrom(
+        onboardObservable(mockCurrency, mockDeviceId, account).pipe(toArray()),
+      );
+
+      // Linked the existing party directly — no submission, no signing.
+      expect(mockedGateway.submitOnboarding).not.toHaveBeenCalled();
+      expect(mockedSignTransaction.signTransaction).not.toHaveBeenCalled();
+
+      const result = values.find((v): v is CantonOnboardResult => "partyId" in v);
+      expect(result).toMatchObject({
+        partyId: existingPartyId,
+        account: expect.objectContaining({
+          xpub: existingPartyId,
+          cantonResources: expect.objectContaining({ isOnboarded: true }),
+        }),
       });
     });
   });

--- a/libs/coin-modules/coin-canton/src/bridge/onboard.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/onboard.ts
@@ -12,6 +12,7 @@ import {
   prepareOnboarding,
   submitOnboarding,
   getPartyByPubKey,
+  isPartyAlreadyExists,
   prepareTapRequest,
   submitTapRequest,
   preparePreApprovalTransaction,
@@ -20,7 +21,7 @@ import {
   clearIsTopologyChangeRequiredCache,
 } from "../network/gateway";
 import resolver from "../signer";
-import type { CantonSigner } from "../types";
+import type { CantonAccount, CantonSigner } from "../types";
 import {
   OnboardStatus,
   AuthorizeStatus,
@@ -44,6 +45,13 @@ export const isAccountOnboarded = async (currency: CryptoCurrency, publicKey: st
   }
 };
 
+// Matches the gateway "party already exists" error, e.g.
+// `Party with id "ldg::1220…" already exists and its topology is up to date`, and captures the id.
+const PARTY_ALREADY_EXISTS_ID_RE = /party with id\s+"?([^"\s]+)"?\s+already exists/i;
+
+const extractExistingPartyId = (error: unknown): string | undefined =>
+  error instanceof Error ? (error.message.match(PARTY_ALREADY_EXISTS_ID_RE)?.[1] ?? undefined) : undefined;
+
 export const isCantonCoinPreapproved = async (currency: CryptoCurrency, partyId: string) => {
   const { expires_at, receiver } = await getTransferPreApproval(currency, partyId);
   const isReceiver = receiver === partyId;
@@ -57,17 +65,21 @@ const createOnboardedAccount = (
   account: Account,
   partyId: string,
   currency: CryptoCurrency,
-): Account => ({
-  ...account,
-  xpub: partyId,
-  id: encodeAccountId({
-    type: "js",
-    version: "2",
-    currencyId: currency.id,
-    xpubOrAddress: partyId,
-    derivationMode: account.derivationMode,
-  }),
-});
+): CantonAccount => {
+  const cantonAccount = account as CantonAccount;
+  return {
+    ...cantonAccount,
+    xpub: partyId,
+    cantonResources: { ...cantonAccount.cantonResources, isOnboarded: true },
+    id: encodeAccountId({
+      type: "js",
+      version: "2",
+      currencyId: currency.id,
+      xpubOrAddress: partyId,
+      derivationMode: account.derivationMode,
+    }),
+  };
+};
 
 export const buildOnboardAccount =
   (signerContext: SignerContext<CantonSigner>) =>
@@ -99,7 +111,30 @@ export const buildOnboardAccount =
           return;
         }
 
-        const preparedTransaction = await prepareOnboarding(currency, publicKey);
+        const preparedTransaction = await prepareOnboarding(currency, publicKey).catch(
+          (error: unknown) => {
+            // The gateway can report the party "already exists" while getPartyByPubKey still 404s for
+            // minutes during its by-public-key indexing lag (e.g. re-adding a just-onboarded account).
+            // The party_id is in the error message, so link the existing party directly — instantly,
+            // without waiting for the index — instead of failing or creating a duplicate. LIVE-32985
+            const existingPartyId = isPartyAlreadyExists(error)
+              ? extractExistingPartyId(error)
+              : undefined;
+            if (existingPartyId) {
+              o.next({
+                partyId: existingPartyId,
+                account: createOnboardedAccount(account, existingPartyId, currency),
+              }); // success (linked existing party, no submission)
+              return undefined;
+            }
+            throw error;
+          },
+        );
+
+        if (!preparedTransaction) {
+          return; // linked an already-existing party above; nothing left to sign/submit
+        }
+
         partyId = preparedTransaction.party_id;
 
         o.next({ status: OnboardStatus.SIGN });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ledger-live-desktop
  - live-mobile

### 📝 Description

Re-adding a Canton account that was onboarded then removed could silently fail or get blocked, because the add-account flows handled Canton's "must onboard a party before use" model inconsistently.

**What changed**
- Treat an onboarded account as a real, addable account across all three flows (desktop Modular drawer, legacy modal, mobile) — keep already-onboarded accounts in the import lists instead of dropping unfunded ones.
- Dispatch the account add on the Modular drawer's non-onboarding path (it previously only persisted via the onboarding step, so it showed "success" without adding anything).
- Persist `isOnboarded: true` after onboarding so accounts don't later look un-onboarded.
- On a `409 "party already exists"`, extract the party id from the error and link the existing account directly — no re-submit, no duplicate.

**Why it happened**
- Emptiness was judged by balance/activity (`used`), so an onboarded-but-unfunded account looked like a throwaway "new" slot.
- The gateway's lookup-by-public-key lags party creation by minutes, so a quick re-add 404s → retries onboarding → 409. (Backend eventual consistency; "restart fixes it" was just elapsed time, not a cache — now worked around client-side.)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: 
- https://ledgerhq.atlassian.net/browse/LIVE-32985


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
