### PR TITLE
docs: reboot CONTRIBUTING.md and PR template to reflect 4-stage manifesto

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,45 +1,14 @@
-<!--
-Thank you for your contribution! 👍
-Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
--->
-
-### ✅ Checklist
-
-<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->
-
-- [ ] `npx changeset` was attached.
-- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
-- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
-  - ...
+<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->
 
 ### 📝 Description
 
-_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
-_For libraries, you can add a code sample of how to use it._
-_For bug fixes, you can explain the previous behaviour and how it was fixed._
-_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._
+<!-- A clear and concise description of what this PR does and why it is needed. -->
+<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
+<!-- For features: describe the problem solved and the approach taken. -->
+<!-- For libraries: include a usage code sample. -->
+<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->
 
-<!--
-| Before        | After         |
-| ------------- | ------------- |
-|               |               |
--->
+### 🔗 Context
 
-### ❓ Context
-
-- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
-- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->
-
-
----
-
-### 🧐 Checklist for the PR Reviewers
-
-<!-- Please do not edit this if you are the PR author -->
-
-- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
-- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
-- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
-- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
-- **Any new dependencies** have been justified and documented.
-- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
+- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
+- **ADR** (if any): <!-- link to the relevant architectural decision record -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,92 +1,101 @@
-# Contributing
+# Contributing to Ledger Wallet
 
-:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+Thanks for contributing! These guidelines apply to internal and external contributors, including agents. Please read fully before opening a pull request.
 
-This file will guide you through the local setup and contains the guidelines you will need
-to follow to get your code merged.
+> [!IMPORTANT]
+> For **Ledger Wallet** we are currently accepting bug fixes and invited contributions only. Feature PRs that do not align with our roadmap or long-term goals will be closed without extensive review.
 
-## Disclaimer
+## Getting Started
 
-Regarding Ledger Applications (Ledger Live Desktop, Ledger Live Mobile) we are only accepting bugfixes for the moment.
-There is a good chance that we will reject feature based PRs based on the fact that they do not fit our roadmap or our long-term goals.
+1. External contributors should fork the repository.
+2. Create your branch from `develop`.
+3. Follow the [main README](README.md) to get started.
+4. Follow additional setup instructions in the README files of the app or lib you are working on.
 
-## Guidelines
+## Branch & Commit Conventions
 
-### Important Steps
+### Branch naming
 
-**Before submitting a pull request, please make sure the following is done:**
+| Prefix | When to use |
+|--------|-------------|
+| `feat/` | Adding a new feature |
+| `bugfix/` | Fixing a bug |
+| `support/` | Refactors, tests, CI, tooling improvements |
 
-1. Fork the repository and create your branch from `develop` (check the git conventions for the naming of the branch).
-2. Follow the main installation steps. (https://github.com/LedgerHQ/ledger-live#installation)
-3. Follow additional installation steps depending on which package you want to contribute to.
-4. Make your changes.
-5. If you’ve fixed a bug or added code that should be tested, add tests!
-6. If needed, wait for the translations to be provided by the third party service.
-7. Add an entry to the changelog (`pnpm changeset`).
-8. Make sure that the code passes linter and type checks (`pnpm lint:fix` and `pnpm typecheck`).
-9. Make sure the code passes unit and end to end tests (`pnpm test`).
-10. Cleanup your branch - unless it contains merge commits (perform atomic commits, squash tiny commits…).
-11. Profit!
+### Commit messages
 
-### Git Conventions
+We follow [Conventional Commits](https://www.conventionalcommits.org/) and enforce it with [commitlint](https://commitlint.js.org/).
 
-We use the following git conventions for the `ledger-live` monorepo.
+Use `pnpm commit` for an interactive prompt, or `pnpm commitlint --from <target-branch>` to validate your branch.
 
-#### Branch naming
+### Rebase & merge strategy
 
-Depending on the purpose every git branch should be prefixed.
+**Always prefer rebasing** unless your branch contains merge commits from sub-features.
 
-- `feat/` when adding a new feature to the application or library
-- `bugfix/` when fixing an existing bug
-- `support/` for any other changes (refactor, tests, improvements, CI…)
+- Small, self-contained branches → rebase on `develop`.
+- Branches with cross-branch merges → merge `develop` into them to stay up to date.
 
-#### Changelogs
 
-We use [**changesets**](https://github.com/changesets/changesets) to handle the versioning of our libraries and apps. A detailed guide is available on the [**wiki**](https://github.com/LedgerHQ/ledger-live/wiki/Changesets).
+## The PR Lifecycle
 
-#### Commit message
+Open your PR as a **Draft** and pass all automated checks before making it **Ready for Review**.
 
-We use the standard [**Conventional Commits**](https://www.conventionalcommits.org/) specification and enforce it using [**commitlint**](https://commitlint.js.org/).
+```mermaid
+flowchart LR
+    S0[Create draft<br>pull request] --> S1[Pass all<br>automated checks]
+    S1 --> S2[Open pull request:<br>Ready for review]
+    S2 --> S3[Pass review<br>by code-owners]
+```
 
-You can use the `pnpm commit` prompt to ensure that your commit messages are valid, as well as the `pnpm commitlint --from <target branch>` command to check that every commit on your current branch are valid.
+### Automated checks
 
-#### Rebase & Merge strategies
+Before marking your PR ready for review, ensure all of the following pass:
 
-The rule of thumb is to **always favour rebasing** as long as your branch does not contain merge commits.
+- **lint, TypeScript** — all linter and type checks must pass.
+- **unit tests, e2e** — all tests must be green. See [testing requirements](https://developers.ledger.com/docs/ledger-live/contributing/reference/testing).
+- **SonarQube** — a green state is expected: meet the quality gate (expected test coverage, no unhandled code smells). See [SonarQube Guide](docs/contributing/sonarqube-guide.md).
+- **Copilot** — request a Copilot review, address or explicitly dismiss every comment, and resolve all threads.
 
-For instance:
+### Ready for review
 
-- bugfix branches that are small and self-contained should always get rebased on top of develop
-- feature branches that have merge commit from other branches (sub-features) should merge their target into them to be kept up to date
+- Click **"Ready for review"** to convert from Draft — this automatically requests the relevant code owners via `CODEOWNERS`.
+- When a reviewer leaves feedback and you push a fix, **re-request their review** (GitHub "Re-request" button).
+- If you receive a review request for files you don't own, feel free to remove yourself from the Reviewers panel.
 
-**⚠️ Important: do not rebase a branch that is waiting for translations from a third party service.**
 
-### Pull Request Conventions
+> [!IMPORTANT]
+> If you are a code owner, see [REVIEWING.md](REVIEWING.md) for reviewer guidance, including your daily review queue.
 
-#### Description
+## Changelogs
 
-- Fill-in the PR template.
-- Write a full description of what your pull request is about and why it was needed.
-- Add some screenshots or videos if relevant.
-- _For Ledger Employees:_ Add the JIRA issue number to link the issue with the PR.
+We use [changesets](https://github.com/changesets/changesets) for versioning. Run:
 
-### Workflow
+```bash
+pnpm changeset
+```
 
-- Github actions will trigger depending on which part of the codebase is impacted.
-- Your PR must pass the required CI actions.
-- Your PR must include a changelog (`pnpm changeset`).
+A changeset is **required** for any user-facing change or library API modification. See the [wiki](https://github.com/LedgerHQ/ledger-live/wiki/Changesets) for the full guide.
 
-### Translations
+## Translations
 
-We use a third party service called [**Smartling**](https://www.smartling.com/) to automate and manage translations for the Ledger Live applications (Desktop and Mobile).
+We use [Smartling](https://www.smartling.com/) for automated translations.
 
-**⚠️ Only add or edit translation files for the english language.**
+**Only edit the English source files.** Never commit files for other locales.
 
-You can find these files at the following locations:
+See the README files of [Ledger Wallet Desktop](apps/ledger-live-desktop) and [Ledger Wallet Mobile](apps/ledger-live-mobile) for the source file paths.
 
-- Ledger Live Desktop: `apps/ledger-live-desktop/static/i18n/en/app.json`
-- Ledger Live Mobile: `apps/ledger-live-mobile/src/locales/en/common.json`
+## Developer Portal
 
-### Developer Portal
+Tools and resources for building on Ledger are at the [Ledger Developer Portal](https://developers.ledger.com/).
 
-Ledger provides the tools and resources you need to build on top of our platform. They are accessible in the [Ledger Developer Portal](https://developers.ledger.com/).
+## Appendix: Tips
+
+#### Request Copilot while still in Draft
+
+> [!TIP]
+> <img width="500" alt="Request Copilot on a Draft PR" src="https://github.com/user-attachments/assets/1326c947-61bc-4793-b70c-9e39b04eb630" />
+
+#### Re-request review after pushing fixes
+
+> [!TIP]
+> <img width="500" alt="Re-request review on a reviewer that did the review" src="https://github.com/user-attachments/assets/80f83822-0557-4375-8ed6-a4aebfcb5d10" />

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ pnpm i
 
 What to run next depends on the workspace you're targeting. See [repo commands](docs/repo-commands.md) for build, dev, lint, and test recipes, or check the README in the relevant workspace.
 
+
+### Contributing & reviewing
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — for **PR authors**: branch conventions, the PR lifecycle, and quality gates before requesting review.
+- [REVIEWING.md](REVIEWING.md) — for **code-owner reviewers**: how to scope, what to look for, and how to give feedback.
+
 ### Finding documentation
 
 1. **Repo-wide** — [AGENTS.md](AGENTS.md), then [docs/](docs/)

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -1,0 +1,55 @@
+# PR Review Guide
+
+A practical reference for **code-owner reviewers**. For automated AI review, see [`.agents/agents/code-reviewer.md`](.agents/agents/code-reviewer.md).
+
+> [!TIP]
+> Check your incoming review requests daily:
+> 👉 [my GitHub Inbox](https://github.com/pulls/inbox)
+
+## Before you review
+
+A PR should only reach your queue once all [automated checks](CONTRIBUTING.md#automated-checks) are complete (CI, SonarQube, Copilot).
+If a PR lands in your queue without meeting these, you can leave a comment and ask the author to put it back in Draft.
+
+## Reviewing
+
+### Scope your review to files you own
+
+Use GitHub's file tree to filter the diff to files your team owns. Mark files as "Viewed" as you go.
+
+> [!NOTE]
+> If you notice files in the diff that are **not covered by any `CODEOWNERS` entry**, update `CODEOWNERS` yourself to claim them. Unclaimed files get reviewed by nobody.
+
+### What to look for
+
+Focus on things automated tools cannot catch:
+
+- **Requirements** — does the code actually solve what the linked issue describes?
+- **Correctness** — is the logic sound? Are edge cases and error paths handled?
+- **Design** — does this fit the existing architecture? Are there simpler approaches?
+- **Trade-offs** — are technical decisions and any incurred debt clearly explained in the description?
+- **New dependencies** — are they justified? Check bundle size and peer compatibility.
+- **Performance** — have the changes been profiled or benchmarked where necessary?
+- **Cross-team impact** — does this touch shared APIs or contracts that affect other teams?
+
+Leave style, lint, and code-smell comments to Copilot and SonarQube.
+
+### Leaving feedback
+
+- Be specific: file path, line reference, concrete suggestion. Consider using [Conventional Comments](https://conventionalcomments.org/) to make intent clear.
+- Distinguish between blockers (must fix before merge) and suggestions (nice to have).
+- Resolve threads once addressed, or explicitly state why you disagree.
+
+## Appendix: Tips
+
+#### Scope your review to files you own
+
+> [!TIP]
+> <img width="500" alt="Only files owned by you" src="https://github.com/user-attachments/assets/1966a4eb-6921-49d5-ad01-da7a2e70cf23" />
+
+#### Remove accidental review requests
+
+If a rebase pulled in your name on files you don't own, feel free to uncheck yourself from the Reviewers panel.
+
+> [!TIP]
+> <img width="500" alt="Remove request for unwanted teams" src="https://github.com/user-attachments/assets/e9b5a5aa-d4e8-4fde-8a88-f59738924299" />

--- a/docs/contributing/sonarqube-guide.md
+++ b/docs/contributing/sonarqube-guide.md
@@ -1,0 +1,41 @@
+# SonarQube Guide
+
+SonarQube runs automatically on every PR and surfaces code quality issues, security hotspots, and test coverage gaps. All findings must be addressed before marking your PR ready for review.
+
+## 1 — Log in with GitHub
+
+SonarQube uses GitHub OAuth. Make sure you are logged in before trying to view or action any findings.
+
+<img width="463" height="377" alt="Log in to SonarQube with GitHub" src="https://github.com/user-attachments/assets/44e37480-655e-4fed-84fb-1373e301bce1" />
+
+## 2 — Handling issues (code smells, bugs, security hotspots)
+
+For **new code you introduce**, passing SonarQube quality gates is expected. For **refactored or pre-existing code** where fixing now is not practical, you have options.
+
+For every finding, pick one of these three actions — and **use the comment section to document your reasoning**:
+
+| Action | When to use |
+|--------|-------------|
+| **Fix it** | Preferred. Address the issue in this PR. |
+| **Accept / Won't Fix** | Refactoring is out of scope right now. Leave a comment explaining when or why it will be addressed. |
+| **False Positive** | The tool is wrong. Leave a comment explaining why this pattern is intentional or correct. |
+
+Leaving findings unacknowledged (no action, no comment) blocks the PR from moving forward.
+
+<img width="1552" height="1354" alt="Handle a code smell / issue on SonarQube" src="https://github.com/user-attachments/assets/9b76802a-e80b-4904-9866-3c165f95384c" />
+
+## 3 — Test coverage
+
+Code coverage is expected to stay **above the project quality gate thresholds**. SonarQube measures coverage on the new code introduced by your PR specifically — you are not responsible for pre-existing coverage gaps in files you didn't meaningfully change.
+
+- Adding new logic without tests will fail the quality gate.
+- If coverage on a touched file drops, add tests to compensate.
+
+## Common pitfalls
+
+| Situation | What to do |
+|-----------|------------|
+| SonarQube check is pending | It runs after CI — make sure CI is green first. |
+| False positive on a framework pattern | Mark as false positive with a short explanation (e.g. "React hook pattern, not a real leak"). |
+| Pre-existing issue surfaced by your PR | Mark as "Accept" with a note that it predates this PR. |
+| Coverage drops on a file you barely touched | You are not required to fix pre-existing gaps, but document it if flagged. |


### PR DESCRIPTION
### 📝 Description

Reboots contributor-facing docs to reflect the 4-stage PR process manifesto — CI, SonarQube, Copilot, human review — and introduces a daily review queue habit over channel pinging.

- [`CONTRIBUTING.md`](https://github.com/LedgerHQ/ledger-live/blob/docs/pr-process-manifesto-reboot-v2/CONTRIBUTING.md)
- [`.github/pull_request_template.md`](https://github.com/LedgerHQ/ledger-live/blob/docs/pr-process-manifesto-reboot-v2/.github/pull_request_template.md)
- [`REVIEWING.md`](https://github.com/LedgerHQ/ledger-live/blob/docs/pr-process-manifesto-reboot-v2/REVIEWING.md)
- [`docs/contributing/sonarqube-guide.md`](https://github.com/LedgerHQ/ledger-live/blob/docs/pr-process-manifesto-reboot-v2/docs/contributing/sonarqube-guide.md)

### 🎯 Goals

- **No documented PR lifecycle** — introduces a clear stage-by-stage process (CI → SonarQube → Copilot → human review) so everyone shares the same expectations
- **No explicit quality bar before requesting human review** — documents the expected level of quality around SonarQube and Copilot review before opening a PR to code owners
- **PR template simplified** — lighter description scaffold with a single pointer to `CONTRIBUTING.md`
- **Defining the minimal expectation of a reviewer** with `REVIEWING.md`

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32853](https://ledgerhq.atlassian.net/browse/LIVE-32853)

> Before opening: make sure you have gone through the [PR lifecycle stages](https://github.com/LedgerHQ/ledger-live/blob/docs/pr-process-manifesto-reboot-v2/CONTRIBUTING.md#the-pr-lifecycle) — CI green, SonarQube addressed, Copilot reviewed — before converting from Draft to Open.

### 🙏 Acknowledgements

Special thanks to @LL782 for the initial review in #18708.

[LIVE-32853]: https://ledgerhq.atlassian.net/browse/LIVE-32853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
