### PR TITLE
[LWM] feat(mobile): add bottom fade gradient to assets, stablecoins and stocks lists

### DIFF
--- a/.changeset/brave-otters-fade.md
+++ b/.changeset/brave-otters-fade.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add the bottom fade gradient (same as the transactions history) at the bottom of the Assets, Stablecoins and Stocks lists so content fades out at the bottom of the screen

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/components/CryptoAssetList/useCryptoAssetListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/components/CryptoAssetList/useCryptoAssetListViewModel.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { GRADIENT_HEIGHT } from "LLM/components/BottomFadeGradient";
 
 const HORIZONTAL_PADDING = 8;
 
@@ -11,7 +12,7 @@ export function useCryptoAssetListViewModel(): CryptoAssetListViewModelResult {
   const { bottom } = useSafeAreaInsets();
 
   const contentContainerStyle = useMemo(
-    () => ({ paddingHorizontal: HORIZONTAL_PADDING, paddingBottom: bottom }),
+    () => ({ paddingHorizontal: HORIZONTAL_PADDING, paddingBottom: GRADIENT_HEIGHT + bottom }),
     [bottom],
   );
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/components/CryptoContent/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/components/CryptoContent/index.tsx
@@ -4,6 +4,7 @@ import { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { Asset } from "~/types/asset";
 import { useTranslation } from "~/context/Locale";
 import { AssetLoadingState, AssetStatusState } from "LLM/components/AssetListItem";
+import { BottomFadeGradient } from "LLM/components/BottomFadeGradient";
 import { CryptoAssetList } from "../CryptoAssetList";
 
 interface CryptoContentProps {
@@ -52,6 +53,7 @@ export const CryptoContent: React.FC<CryptoContentProps> = ({
   return (
     <Box lx={listContainerStyle}>
       <CryptoAssetList assets={assetsToDisplay} onItemPress={onItemPress} testID={listTestID} />
+      <BottomFadeGradient />
     </Box>
   );
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _The CryptoScreen integration test covers the Assets/Stablecoins/Stocks lists and still passes; the gradient reuses the already-tested `BottomFadeGradient` component. The fade itself is visual and should be checked on device._
- [x] **Impact of the changes:**
  - Assets, Stablecoins and Stocks "see all" lists (`CryptoScreen` variants): a bottom fade gradient now appears at the bottom of the list.
  - Verify the last rows scroll fully clear of the fade (extra bottom padding reserved) and safe-area spacing is correct on notched devices.
  - Light & dark themes: the gradient must fade to the correct screen background color.
  - Empty / loading / error states show no gradient (unchanged).

### 📝 Description

The Assets, Stablecoins and Stocks lists ended abruptly at the bottom of the screen, without the soft fade used elsewhere in Wallet 4.0.

This PR adds the same bottom fade gradient already used on the transactions history (the shared `BottomFadeGradient` component) at the bottom of those lists, rendered in `CryptoContent` only when a list is shown, and reserves `GRADIENT_HEIGHT + safe-area bottom` padding on the list so the last rows clear the fade.

### 📸 Screenshots


https://github.com/user-attachments/assets/6aa816af-6797-44fe-bf18-6216dc672f3c



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32991](https://ledgerhq.atlassian.net/browse/LIVE-32991)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-32991]: https://ledgerhq.atlassian.net/browse/LIVE-32991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ