### PR TITLE
[LWDM] fix(LIVE-27999): remove CAL dependency from framework level in coin-hedera

### DIFF
--- a/.changeset/fast-pets-mix.md
+++ b/.changeset/fast-pets-mix.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+fix: remove cal dependency from framework level in coin-hedera

--- a/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
@@ -10,7 +10,6 @@ import {
   ContractFunctionParameters,
 } from "@hashgraph/sdk";
 import type { FeeEstimation } from "@ledgerhq/coin-module-framework/api/types";
-import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
 import { getEnv } from "@ledgerhq/live-env";
 import invariant from "invariant";
 import { createApi } from "../api";
@@ -32,11 +31,6 @@ describe("createApi", () => {
     },
     "hedera",
   );
-
-  beforeAll(() => {
-    // Setup CAL client store (automatically set as global store)
-    setupCalClientStore();
-  });
 
   afterAll(async () => {
     await rpcClient._resetInstance();

--- a/libs/coin-modules/coin-hedera/src/api/index.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.ts
@@ -125,7 +125,7 @@ export function createApi(
         ...(typeof cursor === "string" && { cursor }),
         ...(typeof limit === "number" && { limit }),
         ...(typeof order === "string" && { order }),
-        erc20Tokens: erc20TokenBalances,
+        tokenEvmAddresses: erc20TokenBalances.map(t => t.contractAddress.toLowerCase()),
         fetchAllPages: false,
         skipFeesForTokenOperations: true,
         useEncodedHash: false,

--- a/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
@@ -17,7 +17,14 @@ import { resolveConfig } from "../logic/utils";
 import { apiClient } from "../network/api";
 import { getERC20BalancesForAccountV2, toEVMAddress } from "../network/utils";
 import type { HederaAccount } from "../types";
-import { getSubAccounts, prepareOperations, applyPendingExtras, mergeSubAccounts } from "./utils";
+import {
+  buildCalTokenMap,
+  resolveBridgeOperations,
+  getSubAccounts,
+  prepareOperations,
+  applyPendingExtras,
+  mergeSubAccounts,
+} from "./utils";
 
 export const getAccountShape: GetAccountShape<HederaAccount> = async (
   info,
@@ -64,12 +71,20 @@ export const getAccountShape: GetAccountShape<HederaAccount> = async (
     latestOperationTimestamp = new BigNumber(timestamp).toFixed(9);
   }
 
+  const calTokenByAddress = await buildCalTokenMap({
+    erc20Tokens,
+    mirrorTokens,
+    currencyId: currency.id,
+  });
+
   const latestAccountOperations = await listOperationsV2({
     currencyId: currency.id,
     address,
     evmAddress,
     mirrorTokens,
-    erc20Tokens,
+    tokenEvmAddresses: [...calTokenByAddress.values()]
+      .filter(token => token.tokenType === "erc20")
+      .map(token => token.contractAddress.toLowerCase()),
     ...(latestOperationTimestamp && { cursor: latestOperationTimestamp }),
     fetchAllPages: true,
     skipFeesForTokenOperations: false,
@@ -77,10 +92,14 @@ export const getAccountShape: GetAccountShape<HederaAccount> = async (
     useSyntheticBlocks: false,
   });
 
-  const newOperations = await prepareOperations(
-    latestAccountOperations.coinOperations,
-    latestAccountOperations.tokenOperations,
-  );
+  const { bridgeCoinOperations, bridgeTokenOperations } = resolveBridgeOperations({
+    coinOperations: latestAccountOperations.coinOperations,
+    tokenOperations: latestAccountOperations.tokenOperations,
+    ledgerAccountId: liveAccountId,
+    calTokenByAddress,
+  });
+
+  const newOperations = await prepareOperations(bridgeCoinOperations, bridgeTokenOperations);
   const enrichedNewOperations = applyPendingExtras(newOperations, pendingOperations);
   const operations = shouldSyncFromScratch
     ? enrichedNewOperations
@@ -97,9 +116,10 @@ export const getAccountShape: GetAccountShape<HederaAccount> = async (
 
   const newSubAccounts = await getSubAccounts({
     ledgerAccountId: liveAccountId,
-    latestTokenOperations: latestAccountOperations.tokenOperations,
+    latestTokenOperations: bridgeTokenOperations,
     mirrorTokens,
     erc20Tokens,
+    calTokenByAddress,
   });
 
   const subAccounts = shouldSyncFromScratch

--- a/libs/coin-modules/coin-hedera/src/bridge/utils.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/utils.integ.test.ts
@@ -15,7 +15,7 @@ import { getMockedMirrorToken } from "../test/fixtures/mirror.fixture";
 import { getMockedOperation } from "../test/fixtures/operation.fixture";
 import { getMockedTransaction } from "../test/fixtures/transaction.fixture";
 import type { EstimateFeesResult } from "../types";
-import { calculateAmount, getSubAccounts } from "./utils";
+import { buildCalTokenMap, calculateAmount, getSubAccounts } from "./utils";
 
 describe("utils", () => {
   const address = "0.0.12345";
@@ -195,6 +195,7 @@ describe("utils", () => {
         latestTokenOperations: [mockedOperation1, mockedOperation2],
         mirrorTokens: [mockedMirrorToken1, mockedMirrorToken2],
         erc20Tokens: [],
+        calTokenByAddress: new Map(),
       });
       const uniqueSubAccountIds = new Set(result.map(sa => sa.id));
 
@@ -225,6 +226,7 @@ describe("utils", () => {
         latestTokenOperations: [mockedOperation],
         mirrorTokens: [],
         erc20Tokens: [],
+        calTokenByAddress: new Map(),
       });
 
       expect(result).toEqual([]);
@@ -237,11 +239,18 @@ describe("utils", () => {
         balance: 42,
       });
 
+      const calTokenByAddress = await buildCalTokenMap({
+        erc20Tokens: [],
+        mirrorTokens: [mockedTokenHTS],
+        currencyId: "hedera",
+      });
+
       const result = await getSubAccounts({
         ledgerAccountId: mockedAccount.id,
         latestTokenOperations: [],
         mirrorTokens: [mockedTokenHTS],
         erc20Tokens: [],
+        calTokenByAddress,
       });
 
       expect(result).toMatchObject([
@@ -255,12 +264,22 @@ describe("utils", () => {
 
     it("returns sub account for erc20 token with no operations yet", async () => {
       const tokenCurrencyFromCAL = getTokenCurrencyFromCALByType("erc20");
+      const erc20Tokens = [
+        { balance: new BigNumber(42), contractAddress: tokenCurrencyFromCAL.contractAddress },
+      ];
+
+      const calTokenByAddress = await buildCalTokenMap({
+        erc20Tokens,
+        mirrorTokens: [],
+        currencyId: "hedera",
+      });
 
       const result = await getSubAccounts({
         ledgerAccountId: mockedAccount.id,
         latestTokenOperations: [],
         mirrorTokens: [],
-        erc20Tokens: [{ balance: new BigNumber(42), token: tokenCurrencyFromCAL }],
+        erc20Tokens,
+        calTokenByAddress,
       });
 
       expect(result).toMatchObject([
@@ -270,6 +289,44 @@ describe("utils", () => {
           balance: new BigNumber(42),
         },
       ]);
+    });
+
+    it("resolves erc20 sub-account balance from erc20Tokens when token operations exist", async () => {
+      const tokenCurrencyFromCAL = getTokenCurrencyFromCALByType("erc20");
+      const operation = getMockedOperation({
+        accountId: encodeTokenAccountId(mockedAccount.id, tokenCurrencyFromCAL),
+      });
+
+      const result = await getSubAccounts({
+        ledgerAccountId: mockedAccount.id,
+        latestTokenOperations: [operation],
+        mirrorTokens: [],
+        erc20Tokens: [
+          { contractAddress: tokenCurrencyFromCAL.contractAddress, balance: new BigNumber(999) },
+        ],
+        calTokenByAddress: new Map(),
+      });
+
+      expect(result).toMatchObject([
+        { token: tokenCurrencyFromCAL, balance: new BigNumber(999), operations: [operation] },
+      ]);
+    });
+
+    it("drops erc20 sub-account when balance entry is missing in erc20Tokens", async () => {
+      const tokenCurrencyFromCAL = getTokenCurrencyFromCALByType("erc20");
+      const operation = getMockedOperation({
+        accountId: encodeTokenAccountId(mockedAccount.id, tokenCurrencyFromCAL),
+      });
+
+      const result = await getSubAccounts({
+        ledgerAccountId: mockedAccount.id,
+        latestTokenOperations: [operation],
+        mirrorTokens: [],
+        erc20Tokens: [],
+        calTokenByAddress: new Map(),
+      });
+
+      expect(result).toEqual([]);
     });
   });
 });

--- a/libs/coin-modules/coin-hedera/src/bridge/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/utils.test.ts
@@ -1,8 +1,10 @@
 import { setupMockCryptoAssetsStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
 import { encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account";
+import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import BigNumber from "bignumber.js";
 import { getMockedAccount, getMockedTokenAccount } from "../test/fixtures/account.fixture";
 import {
+  getMockedERC20TokenCurrency,
   getMockedHTSTokenCurrency,
   getTokenCurrencyFromCALByType,
 } from "../test/fixtures/currency.fixture";
@@ -10,10 +12,13 @@ import { getMockedOperation } from "../test/fixtures/operation.fixture";
 import type { HederaOperationExtra } from "../types";
 import {
   applyPendingExtras,
+  buildCalTokenMap,
   mergeSubAccounts,
   patchOperationWithExtra,
   prepareOperations,
+  resolveBridgeOperations,
 } from "./utils";
+import { getMockedMirrorToken } from "../test/fixtures/mirror.fixture";
 
 describe("bridge utils", () => {
   describe("prepareOperations", () => {
@@ -144,6 +149,197 @@ describe("bridge utils", () => {
       const result = applyPendingExtras([mockedOperation], [mockedPendingOperation]);
       expect(result).toHaveLength(1);
       expect(result[0].extra).toEqual(mockedOperation.extra);
+    });
+  });
+
+  describe("buildCalTokenMap", () => {
+    it("returns empty map for empty input", async () => {
+      const result = await buildCalTokenMap({
+        erc20Tokens: [],
+        mirrorTokens: [],
+        currencyId: "hedera",
+      });
+
+      expect(result.size).toBe(0);
+    });
+
+    it("resolves erc20 and hts tokens, skips addresses not in CAL", async () => {
+      const erc20Token = getMockedERC20TokenCurrency({ contractAddress: "0xabc" });
+      const htsToken = getMockedHTSTokenCurrency({ contractAddress: "0.0.1001" });
+      const mockMirrorToken = getMockedMirrorToken({
+        token_id: htsToken.contractAddress,
+        balance: 500,
+      });
+
+      setupMockCryptoAssetsStore({
+        findTokenByAddressInCurrency: jest.fn().mockImplementation(async (address: string) => {
+          if (address === erc20Token.contractAddress) return erc20Token;
+          if (address === htsToken.contractAddress) return htsToken;
+          return undefined;
+        }),
+      });
+
+      const result = await buildCalTokenMap({
+        erc20Tokens: [
+          { contractAddress: erc20Token.contractAddress, balance: new BigNumber(100) },
+          { contractAddress: "0x999", balance: new BigNumber(50) },
+        ],
+        mirrorTokens: [mockMirrorToken],
+        currencyId: "hedera",
+      });
+
+      expect(result.size).toBe(2);
+      expect(result.get(erc20Token.contractAddress)).toBe(erc20Token);
+      expect(result.get(htsToken.contractAddress)).toBe(htsToken);
+    });
+
+    it("deduplicates addresses case-insensitively", async () => {
+      const mockToken = getMockedERC20TokenCurrency({ contractAddress: "0xABC" });
+      const findMock = jest.fn().mockResolvedValue(mockToken);
+
+      setupMockCryptoAssetsStore({ findTokenByAddressInCurrency: findMock });
+
+      await buildCalTokenMap({
+        erc20Tokens: [
+          { contractAddress: "0xABC", balance: new BigNumber(1) },
+          { contractAddress: "0xabc", balance: new BigNumber(2) },
+        ],
+        mirrorTokens: [],
+        currencyId: "hedera",
+      });
+
+      expect(findMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("resolveBridgeOperations", () => {
+    const ledgerAccountId = "js:2:hedera:0.0.12345:";
+
+    it("re-encodes coin operation accountId and id to ledgerAccountId", () => {
+      const coinOp = getMockedOperation({ hash: "h1", type: "OUT" });
+
+      const { bridgeCoinOperations } = resolveBridgeOperations({
+        coinOperations: [coinOp],
+        tokenOperations: [],
+        ledgerAccountId,
+        calTokenByAddress: new Map(),
+      });
+
+      expect(bridgeCoinOperations).toEqual([
+        expect.objectContaining({
+          accountId: ledgerAccountId,
+          id: encodeOperationId(ledgerAccountId, coinOp.hash, coinOp.type),
+        }),
+      ]);
+    });
+
+    it("drops token operations without a contract address", () => {
+      const tokenOp = getMockedOperation({ hash: "h1", type: "IN" });
+
+      const { bridgeTokenOperations } = resolveBridgeOperations({
+        coinOperations: [],
+        tokenOperations: [tokenOp],
+        ledgerAccountId,
+        calTokenByAddress: new Map(),
+      });
+
+      expect(bridgeTokenOperations).toEqual([]);
+    });
+
+    it("drops token operations for addresses not in calTokenByAddress", () => {
+      const tokenOp = getMockedOperation({ hash: "h1", type: "OUT", contract: "0x999" });
+
+      const { bridgeTokenOperations } = resolveBridgeOperations({
+        coinOperations: [],
+        tokenOperations: [tokenOp],
+        ledgerAccountId,
+        calTokenByAddress: new Map(),
+      });
+
+      expect(bridgeTokenOperations).toEqual([]);
+    });
+
+    it("re-encodes token operation accountId and id using encodeTokenAccountId", () => {
+      const mockToken = getMockedHTSTokenCurrency({ contractAddress: "0.0.1001" });
+      const tokenOp = getMockedOperation({
+        hash: "txhash",
+        type: "IN",
+        contract: mockToken.contractAddress,
+      });
+
+      const { bridgeTokenOperations } = resolveBridgeOperations({
+        coinOperations: [],
+        tokenOperations: [tokenOp],
+        ledgerAccountId,
+        calTokenByAddress: new Map([[mockToken.contractAddress.toLowerCase(), mockToken]]),
+      });
+
+      const expectedTokenAccountId = encodeTokenAccountId(ledgerAccountId, mockToken);
+      expect(bridgeTokenOperations).toEqual([
+        expect.objectContaining({
+          accountId: expectedTokenAccountId,
+          id: encodeOperationId(expectedTokenAccountId, tokenOp.hash, tokenOp.type),
+        }),
+      ]);
+    });
+
+    it("filters mixed batch — keeps only tokens present in calTokenByAddress", () => {
+      const erc20Token = getMockedERC20TokenCurrency({ contractAddress: "0xabc" });
+      const htsToken = getMockedHTSTokenCurrency({ contractAddress: "0.0.1001" });
+
+      const { bridgeTokenOperations } = resolveBridgeOperations({
+        coinOperations: [],
+        tokenOperations: [
+          getMockedOperation({ hash: "h1", type: "IN", contract: erc20Token.contractAddress }),
+          getMockedOperation({ hash: "h2", type: "IN", contract: htsToken.contractAddress }),
+          getMockedOperation({ hash: "h3", type: "OUT", contract: "0.0.9999" }),
+          getMockedOperation({ hash: "h4", type: "IN" }),
+        ],
+        ledgerAccountId,
+        calTokenByAddress: new Map([
+          [erc20Token.contractAddress.toLowerCase(), erc20Token],
+          [htsToken.contractAddress, htsToken],
+        ]),
+      });
+
+      expect(bridgeTokenOperations).toEqual([
+        expect.objectContaining({ contract: erc20Token.contractAddress }),
+        expect.objectContaining({ contract: htsToken.contractAddress }),
+      ]);
+    });
+
+    it("drops FEES coin op when its token op is not in calTokenByAddress", () => {
+      const tokenOp = getMockedOperation({ hash: "h1", type: "OUT", contract: "0x999" });
+      const feesOp = getMockedOperation({ hash: "h1", type: "FEES" });
+
+      const { bridgeCoinOperations, bridgeTokenOperations } = resolveBridgeOperations({
+        coinOperations: [feesOp],
+        tokenOperations: [tokenOp],
+        ledgerAccountId,
+        calTokenByAddress: new Map(),
+      });
+
+      expect(bridgeTokenOperations).toEqual([]);
+      expect(bridgeCoinOperations).toEqual([]);
+    });
+
+    it("keeps FEES coin op when at least one token op for that hash is kept", () => {
+      const keptToken = getMockedHTSTokenCurrency({ contractAddress: "0.0.1001" });
+      const tokenOp = getMockedOperation({
+        hash: "h1",
+        type: "OUT",
+        contract: keptToken.contractAddress,
+      });
+      const feesOp = getMockedOperation({ hash: "h1", type: "FEES" });
+
+      const { bridgeCoinOperations } = resolveBridgeOperations({
+        coinOperations: [feesOp],
+        tokenOperations: [tokenOp],
+        ledgerAccountId,
+        calTokenByAddress: new Map([[keptToken.contractAddress, keptToken]]),
+      });
+
+      expect(bridgeCoinOperations).toEqual([expect.objectContaining({ hash: "h1", type: "FEES" })]);
     });
   });
 

--- a/libs/coin-modules/coin-hedera/src/bridge/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/utils.ts
@@ -1,4 +1,5 @@
 import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
+import { promiseAllBatched } from "@ledgerhq/live-promise";
 import {
   decodeTokenAccountId,
   emptyHistoryCache,
@@ -87,16 +88,95 @@ export const calculateAmount = ({
   return calculateCoinAmount({ account, transaction, operationType });
 };
 
+export async function buildCalTokenMap({
+  erc20Tokens,
+  mirrorTokens,
+  currencyId,
+}: {
+  erc20Tokens: HederaERC20TokenBalance[];
+  mirrorTokens: HederaMirrorToken[];
+  currencyId: string;
+}): Promise<Map<string, TokenCurrency>> {
+  const uniqueAddresses = [
+    ...new Set([
+      ...erc20Tokens.map(t => t.contractAddress.toLowerCase()),
+      ...mirrorTokens.map(t => t.token_id),
+    ]),
+  ];
+  const tokenByAddress = new Map<string, TokenCurrency>();
+
+  if (uniqueAddresses.length === 0) return tokenByAddress;
+
+  const store = getCryptoAssetsStore();
+  await promiseAllBatched(4, uniqueAddresses, async address => {
+    const token = await store.findTokenByAddressInCurrency(address, currencyId);
+    if (token) tokenByAddress.set(address, token);
+  });
+
+  return tokenByAddress;
+}
+
+/**
+ * Re-encodes id and accountId for both coin and token operations into the bridge's format.
+ * Token operations: accountId becomes encodeTokenAccountId, filtered to CAL-listed tokens only.
+ * Coin operations: accountId becomes ledgerAccountId.
+ */
+export function resolveBridgeOperations({
+  coinOperations,
+  tokenOperations,
+  ledgerAccountId,
+  calTokenByAddress,
+}: {
+  coinOperations: Operation<HederaOperationExtra>[];
+  tokenOperations: Operation<HederaOperationExtra>[];
+  ledgerAccountId: string;
+  calTokenByAddress: Map<string, TokenCurrency>;
+}): {
+  bridgeCoinOperations: Operation<HederaOperationExtra>[];
+  bridgeTokenOperations: Operation<HederaOperationExtra>[];
+} {
+  const keptTokenOperationHashes = new Set<string>();
+
+  const bridgeTokenOperations = tokenOperations.flatMap(operation => {
+    const tokenAddress = operation.contract?.toLowerCase();
+    const token = tokenAddress ? calTokenByAddress.get(tokenAddress) : undefined;
+    if (!token) return [];
+
+    keptTokenOperationHashes.add(operation.hash);
+    const tokenAccountId = encodeTokenAccountId(ledgerAccountId, token);
+    return [
+      {
+        ...operation,
+        accountId: tokenAccountId,
+        id: encodeOperationId(tokenAccountId, operation.hash, operation.type),
+      },
+    ];
+  });
+
+  // persist only FEES ops for token transfers that are in CAL
+  const bridgeCoinOperations = coinOperations
+    .filter(op => (op.type !== "FEES" ? true : keptTokenOperationHashes.has(op.hash)))
+    .map(op => ({
+      ...op,
+      id: encodeOperationId(ledgerAccountId, op.hash, op.type),
+      accountId: ledgerAccountId,
+    }));
+
+  return { bridgeCoinOperations, bridgeTokenOperations };
+}
+
 export const getSubAccounts = async ({
   ledgerAccountId,
   latestTokenOperations,
   mirrorTokens,
   erc20Tokens,
+  calTokenByAddress,
 }: {
   ledgerAccountId: string;
   latestTokenOperations: Operation[];
   mirrorTokens: HederaMirrorToken[];
   erc20Tokens: HederaERC20TokenBalance[];
+  calTokenByAddress: Map<string, TokenCurrency>;
 }): Promise<TokenAccount[]> => {
   // Creating a Map of Operations by TokenCurrencies in order to know which TokenAccounts should be synced as well
   const operationsByToken = new Map<TokenCurrency, Operation[]>();
@@ -105,12 +185,6 @@ export const getSubAccounts = async ({
   for (const tokenOperation of latestTokenOperations) {
     const { token } = await decodeTokenAccountId(tokenOperation.accountId);
     if (!token) continue;
-
-    const isTokenListedInCAL = await getCryptoAssetsStore().findTokenByAddressInCurrency(
-      token.contractAddress,
-      token.parentCurrencyId,
-    );
-    if (!isTokenListedInCAL) continue;
 
     if (!operationsByToken.has(token)) {
       operationsByToken.set(token, []);
@@ -125,7 +199,9 @@ export const getSubAccounts = async ({
     let balance: BigNumber | null = null;
 
     if (token.tokenType === "erc20") {
-      const rawBalance = erc20Tokens.find(t => t.token.contractAddress === token.contractAddress);
+      const rawBalance = erc20Tokens.find(
+        t => t.contractAddress.toLowerCase() === token.contractAddress.toLowerCase(),
+      );
       balance = rawBalance === undefined ? null : new BigNumber(rawBalance.balance);
     } else {
       const rawBalance = mirrorTokens.find(t => t.token_id === token.contractAddress)?.balance;
@@ -160,9 +236,9 @@ export const getSubAccounts = async ({
     const parentAccountId = ledgerAccountId;
     const rawBalance = rawToken.balance;
     const balance = new BigNumber(rawBalance);
-    const isERC20 = "token" in rawToken;
-    const tokenAddress = isERC20 ? rawToken.token.contractAddress : rawToken.token_id;
-    const token = await getCryptoAssetsStore().findTokenByAddressInCurrency(tokenAddress, "hedera");
+    const isERC20 = "contractAddress" in rawToken;
+    const tokenAddress = isERC20 ? rawToken.contractAddress : rawToken.token_id;
+    const token = calTokenByAddress.get(tokenAddress.toLowerCase());
 
     if (!token) {
       continue;

--- a/libs/coin-modules/coin-hedera/src/constants.ts
+++ b/libs/coin-modules/coin-hedera/src/constants.ts
@@ -89,38 +89,6 @@ export const BASE_USD_FEE_BY_OPERATION_TYPE = {
   [HEDERA_OPERATION_TYPES.ContractCall]: 0, // Contract call fees are based on gas used and are handled separately
 } as const satisfies Record<HEDERA_OPERATION_TYPES, number>;
 
-/**
- * Array of supported ERC20 token IDs for Hedera.
- *
- * This is a temporary solution to allow bypassing deprecated methods.
- * It is essential to update this list in the future to ensure support
- * for other erc20 tokens.
- *
- * task that should remove this: https://ledgerhq.atlassian.net/browse/LIVE-24948
- */
-export const SUPPORTED_ERC20_TOKENS = [
-  {
-    id: "hedera/erc20/weth_0xca367694cdac8f152e33683bb36cc9d6a73f1ef2",
-    contractAddress: "0xca367694cdac8f152e33683bb36cc9d6a73f1ef2",
-    tokenId: "0.0.9470869",
-  },
-  {
-    id: "hedera/erc20/bonzo_atoken_usdc_0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
-    contractAddress: "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
-    tokenId: "0.0.7308496",
-  },
-  {
-    id: "hedera/erc20/audd_0x39ceba2b467fa987546000eb5d1373acf1f3a2e1",
-    contractAddress: "0x39ceba2b467fa987546000eb5d1373acf1f3a2e1",
-    tokenId: "0.0.8317070",
-  },
-  {
-    id: "hedera/erc20/wrapped_btc_0xd7d4d91d64a6061fa00a94e2b3a2d2a5fb677849",
-    contractAddress: "0xd7d4d91d64a6061fa00a94e2b3a2d2a5fb677849",
-    tokenId: "0.0.10047837",
-  },
-];
-
 export const MAP_STAKING_MODE_TO_MEMO: Record<string, string> = {
   [HEDERA_TRANSACTION_MODES.ClaimRewards]: "Collect Staking Rewards",
   [HEDERA_TRANSACTION_MODES.Delegate]: "Stake",

--- a/libs/coin-modules/coin-hedera/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBalance.test.ts
@@ -1,17 +1,11 @@
-import { setupMockCryptoAssetsStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
 import { LedgerAPI4xx } from "@ledgerhq/errors";
-import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import BigNumber from "bignumber.js";
 import hederaCoinConfig from "../config";
 import { HederaAddAccountError } from "../errors";
 import { apiClient } from "../network/api";
 import * as networkUtils from "../network/utils";
 import { getMockedConfig } from "../test/fixtures/config.fixture";
-import {
-  getMockedCurrency,
-  getMockedERC20TokenCurrency,
-  getMockedHTSTokenCurrency,
-} from "../test/fixtures/currency.fixture";
+import { getMockedCurrency } from "../test/fixtures/currency.fixture";
 import type { HederaERC20TokenBalance } from "../types";
 import { getBalance } from "./getBalance";
 
@@ -61,35 +55,19 @@ describe("getBalance", () => {
     ]);
   });
 
-  it("should return native balance and token balances", async () => {
+  it("should return native balance and raw token balances", async () => {
     const mockMirrorTokens = [
       {
         token_id: "0.0.7890",
         balance: "5000",
       },
     ];
-    const mockTokenHTS = getMockedHTSTokenCurrency({ contractAddress: "0.0.7890" });
-    const mockTokenERC20 = getMockedERC20TokenCurrency({ contractAddress: "0x12345" });
     const mockERC20Balances: HederaERC20TokenBalance[] = [
       {
+        contractAddress: "0x12345",
         balance: new BigNumber(100),
-        token: mockTokenERC20,
       },
     ];
-
-    const findTokenByAddressInCurrencyMock = jest
-      .fn()
-      .mockImplementation(
-        async (tokenId: string, _currencyId: string): Promise<TokenCurrency | undefined> => {
-          if (tokenId === mockTokenHTS.contractAddress) return mockTokenHTS;
-          if (tokenId === mockTokenERC20.contractAddress) return mockTokenERC20;
-          return undefined;
-        },
-      );
-
-    setupMockCryptoAssetsStore({
-      findTokenByAddressInCurrency: findTokenByAddressInCurrencyMock,
-    });
 
     (apiClient.getAccount as jest.Mock).mockResolvedValue(mockMirrorAccount);
     (apiClient.getAccountTokens as jest.Mock).mockResolvedValue(mockMirrorTokens);
@@ -109,9 +87,6 @@ describe("getBalance", () => {
       configOrCurrencyId: mockConfig,
       address,
     });
-    expect(findTokenByAddressInCurrencyMock).toHaveBeenCalledTimes(2);
-    expect(findTokenByAddressInCurrencyMock).toHaveBeenCalledWith("0.0.7890", "hedera");
-    expect(findTokenByAddressInCurrencyMock).toHaveBeenCalledWith("0x12345", "hedera");
     expect(result).toEqual(
       expect.arrayContaining([
         {
@@ -121,21 +96,17 @@ describe("getBalance", () => {
         {
           value: BigInt("5000"),
           asset: {
-            type: mockTokenHTS.tokenType,
-            assetReference: mockTokenHTS.contractAddress,
+            type: "hts",
+            assetReference: "0.0.7890",
             assetOwner: address,
-            name: mockTokenHTS.name,
-            unit: mockTokenHTS.units[0],
           },
         },
         {
           value: BigInt("100"),
           asset: {
-            type: mockTokenERC20.tokenType,
-            assetReference: mockTokenERC20.contractAddress,
+            type: "erc20",
+            assetReference: "0x12345",
             assetOwner: address,
-            name: mockTokenERC20.name,
-            unit: mockTokenERC20.units[0],
           },
         },
       ]),
@@ -191,7 +162,7 @@ describe("getBalance", () => {
     });
   });
 
-  it("should skip tokens without units or not found in CAL", async () => {
+  it("should return all token balances without CAL filtering", async () => {
     const mockMirrorTokens = [
       {
         token_id: "0.0.7890",
@@ -202,56 +173,16 @@ describe("getBalance", () => {
         balance: "10000",
       },
     ];
-    const mockTokenHTS1: TokenCurrency = {
-      type: "TokenCurrency",
-      id: "token1",
-      contractAddress: "0.0.7890",
-      tokenType: "hts",
-      name: "Test Token 1",
-      ticker: "TT1",
-      parentCurrencyId: "hedera",
-      units: [{ name: "TT1", code: "tt1", magnitude: 6 }],
-      delisted: false,
-      disableCountervalue: false,
-    };
-    const mockTokenHTS2: TokenCurrency = {
-      type: "TokenCurrency",
-      id: "token2",
-      contractAddress: "0.0.1111",
-      tokenType: "hts",
-      name: "Test Token 2",
-      ticker: "TT1",
-      parentCurrencyId: "hedera",
-      units: [],
-      delisted: false,
-      disableCountervalue: false,
-    };
-    const mockTokenERC20 = getMockedERC20TokenCurrency({ contractAddress: "0x12345" });
     const mockERC20Balances: HederaERC20TokenBalance[] = [
       {
+        contractAddress: "0x12345",
         balance: new BigNumber(100),
-        token: mockTokenERC20,
       },
       {
+        contractAddress: "0x54321",
         balance: new BigNumber(200),
-        token: getMockedERC20TokenCurrency({ contractAddress: "0x54321" }),
       },
     ];
-
-    const findTokenByAddressInCurrencyMock = jest
-      .fn()
-      .mockImplementation(
-        async (tokenId: string, _currencyId: string): Promise<TokenCurrency | undefined> => {
-          if (tokenId === mockTokenHTS1.contractAddress) return mockTokenHTS1;
-          if (tokenId === mockTokenHTS2.contractAddress) return mockTokenHTS2;
-          if (tokenId === mockTokenERC20.contractAddress) return mockTokenERC20;
-          return undefined;
-        },
-      );
-
-    setupMockCryptoAssetsStore({
-      findTokenByAddressInCurrency: findTokenByAddressInCurrencyMock,
-    });
 
     (apiClient.getAccount as jest.Mock).mockResolvedValue(mockMirrorAccount);
     (apiClient.getAccountTokens as jest.Mock).mockResolvedValue(mockMirrorTokens);
@@ -259,32 +190,23 @@ describe("getBalance", () => {
 
     const result = await getBalance({ currencyId: mockCurrency.id, address });
 
-    expect(result).toEqual([
-      {
-        asset: { type: "native" },
-        value: BigInt("1000000000"),
-      },
-      {
-        value: BigInt("5000"),
-        asset: {
-          type: mockTokenHTS1.tokenType,
-          assetReference: mockTokenHTS1.contractAddress,
-          assetOwner: address,
-          name: mockTokenHTS1.name,
-          unit: mockTokenHTS1.units[0],
-        },
-      },
-      {
-        value: BigInt("100"),
-        asset: {
-          type: mockTokenERC20.tokenType,
-          assetReference: mockTokenERC20.contractAddress,
-          assetOwner: address,
-          name: mockTokenERC20.name,
-          unit: mockTokenERC20.units[0],
-        },
-      },
-    ]);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { asset: { type: "native" }, value: BigInt("1000000000") },
+        expect.objectContaining({
+          asset: { type: "hts", assetReference: "0.0.7890", assetOwner: address },
+        }),
+        expect.objectContaining({
+          asset: { type: "hts", assetReference: "0.0.9876", assetOwner: address },
+        }),
+        expect.objectContaining({
+          asset: { type: "erc20", assetReference: "0x12345", assetOwner: address },
+        }),
+        expect.objectContaining({
+          asset: { type: "erc20", assetReference: "0x54321", assetOwner: address },
+        }),
+      ]),
+    );
   });
 
   it("should throw when failing to getAccount data", async () => {

--- a/libs/coin-modules/coin-hedera/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBalance.ts
@@ -1,13 +1,34 @@
 import type { Balance } from "@ledgerhq/coin-module-framework/api/types";
-import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { LedgerAPI4xx } from "@ledgerhq/errors";
-import { promiseAllBatched } from "@ledgerhq/live-promise";
 import BigNumber from "bignumber.js";
 import { type HederaCoinConfig } from "../config";
 import { HederaAddAccountError } from "../errors";
-import { resolveConfig } from "./utils";
 import { apiClient } from "../network/api";
 import { getERC20BalancesForAccountV2 } from "../network/utils";
+import type { HederaERC20TokenBalance, HederaMirrorToken } from "../types";
+import { resolveConfig } from "./utils";
+
+function mapMirrorTokenToBalance(token: HederaMirrorToken, address: string): Balance {
+  return {
+    value: BigInt(new BigNumber(token.balance).toFixed(0)),
+    asset: {
+      type: "hts",
+      assetReference: token.token_id,
+      assetOwner: address,
+    },
+  };
+}
+
+function mapErc20TokenToBalance(token: HederaERC20TokenBalance, address: string): Balance {
+  return {
+    value: BigInt(token.balance.toFixed(0)),
+    asset: {
+      type: "erc20",
+      assetReference: token.contractAddress,
+      assetOwner: address,
+    },
+  };
+}
 
 export async function getBalance({
   config,
@@ -38,8 +59,6 @@ export async function getBalance({
       validatorPromise,
     ]);
 
-    const mixedTokens = [...mirrorTokens, ...erc20TokenBalances];
-
     const nativeBalance: Balance = {
       asset: { type: "native" },
       value: BigInt(mirrorAccount.balance.balance),
@@ -61,40 +80,12 @@ export async function getBalance({
       }),
     };
 
-    const tokenBalances = await promiseAllBatched(
-      3,
-      mixedTokens,
-      async (item): Promise<Balance | null> => {
-        const tokenAddress = "token_id" in item ? item.token_id : item.token.contractAddress;
-        const calToken = await getCryptoAssetsStore().findTokenByAddressInCurrency(
-          tokenAddress,
-          currencyId,
-        );
+    const tokenBalances: Balance[] = [
+      ...mirrorTokens.map(token => mapMirrorTokenToBalance(token, address)),
+      ...erc20TokenBalances.map(token => mapErc20TokenToBalance(token, address)),
+    ];
 
-        if (!calToken || !calToken.units.length) {
-          return null;
-        }
-
-        const roundedValue = new BigNumber(item.balance).toFixed(0);
-
-        return {
-          value: BigInt(roundedValue),
-          asset: {
-            type: calToken.tokenType,
-            assetReference: calToken.contractAddress,
-            assetOwner: address,
-            name: calToken.name,
-            unit: calToken.units[0],
-          },
-        };
-      },
-    );
-
-    const balances: Balance[] = [nativeBalance, ...tokenBalances].filter(
-      (balance): balance is Balance => balance !== null,
-    );
-
-    return balances;
+    return [nativeBalance, ...tokenBalances];
   } catch (err) {
     const isNonExistentAccount =
       err instanceof HederaAddAccountError || (err instanceof LedgerAPI4xx && err.status === 404);

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
@@ -96,7 +96,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -154,7 +154,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -217,7 +217,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -265,6 +265,7 @@ describe("listOperationsV2", () => {
       transfers: [{ account: mockMirrorAccount.account, amount: -300000 }],
     });
     const mockERC20Transfer = getMockedERC20TokenTransfer({
+      token_evm_address: mockTokenERC20.contractAddress,
       transaction_hash: sharedHash,
       consensus_timestamp: Number(sharedTimestamp.split(".")[0]) * 10 ** 9,
       sender_account_id: 12345,
@@ -307,7 +308,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [{ token: mockTokenERC20, balance: new BigNumber(10000000) }],
+      tokenEvmAddresses: [mockTokenERC20.contractAddress],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -360,6 +361,7 @@ describe("listOperationsV2", () => {
       transfers: [{ account: mockMirrorAccount.account, amount: -300000 }],
     });
     const mockERC20Transfer = getMockedERC20TokenTransfer({
+      token_evm_address: mockTokenERC20.contractAddress,
       transaction_hash: sharedHash,
       consensus_timestamp: Number(sharedTimestamp.split(".")[0]) * 10 ** 9,
       sender_account_id: null,
@@ -397,7 +399,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [{ token: mockTokenERC20, balance: new BigNumber(10000000) }],
+      tokenEvmAddresses: [mockTokenERC20.contractAddress],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -423,6 +425,7 @@ describe("listOperationsV2", () => {
       transfers: [{ account: mockMirrorAccount.account, amount: -300000 }],
     });
     const mockERC20Transfer = getMockedERC20TokenTransfer({
+      token_evm_address: mockTokenERC20.contractAddress,
       transaction_hash: sharedHash,
       consensus_timestamp: Number(sharedTimestamp.split(".")[0]) * 10 ** 9,
       sender_account_id: null,
@@ -460,7 +463,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [{ token: mockTokenERC20, balance: new BigNumber(10000000) }],
+      tokenEvmAddresses: [mockTokenERC20.contractAddress],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -495,7 +498,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -549,7 +552,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [mockMirrorToken],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -568,7 +571,7 @@ describe("listOperationsV2", () => {
     ]);
   });
 
-  it("should skip token operations when token is not found in cryptoassets", async () => {
+  it("should return raw token operations even when token is not in CAL", async () => {
     const tokenId = "0.0.7890";
     const mockTransaction = getMockedMirrorTransaction({
       consensus_timestamp: "1625097600.000000000",
@@ -589,8 +592,52 @@ describe("listOperationsV2", () => {
       nextCursor: null,
     });
 
-    setupMockCryptoAssetsStore({
-      findTokenByAddressInCurrency: jest.fn().mockResolvedValue(null),
+    const result = await listOperations({
+      limit: mockLimit,
+      order: mockOrder,
+      currencyId: mockCurrency.id,
+      address: mockMirrorAccount.account,
+      evmAddress: mockMirrorAccount.evm_address,
+      mirrorTokens: [],
+      tokenEvmAddresses: [],
+      fetchAllPages: true,
+      skipFeesForTokenOperations: false,
+      useEncodedHash: false,
+      useSyntheticBlocks: false,
+    });
+
+    expect(result.tokenOperations).toEqual([
+      expect.objectContaining({
+        contract: tokenId,
+        standard: "hts",
+        type: "OUT",
+      }),
+    ]);
+    expect(result.coinOperations).toEqual([
+      expect.objectContaining({
+        type: "FEES",
+      }),
+    ]);
+  });
+
+  it("should not emit FEES coin op for child HTS token transfer (nonce > 0)", async () => {
+    const tokenId = "0.0.7890";
+    const mockTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1625097600.000000000",
+      transaction_hash: "hash1",
+      nonce: 1,
+      charged_tx_fee: 0,
+      token_transfers: [
+        { token_id: tokenId, account: mockMirrorAccount.account, amount: -1000 },
+        { token_id: tokenId, account: "0.0.67890", amount: 1000 },
+      ],
+      transfers: [],
+      name: "CRYPTOTRANSFER",
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [mockTransaction],
+      nextCursor: null,
     });
 
     const result = await listOperations({
@@ -600,7 +647,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -608,7 +655,9 @@ describe("listOperationsV2", () => {
     });
 
     expect(result.coinOperations).toEqual([]);
-    expect(result.tokenOperations).toEqual([]);
+    expect(result.tokenOperations).toEqual([
+      expect.objectContaining({ contract: tokenId, standard: "hts", type: "OUT" }),
+    ]);
   });
 
   it("should use pagination parameters correctly", async () => {
@@ -629,7 +678,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -675,7 +724,7 @@ describe("listOperationsV2", () => {
       evmAddress: mockMirrorAccount.evm_address,
       currencyId: mockCurrency.id,
       mirrorTokens: [],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -715,7 +764,7 @@ describe("listOperationsV2", () => {
       evmAddress: mockMirrorAccount.evm_address,
       currencyId: mockCurrency.id,
       mirrorTokens: [],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -757,7 +806,7 @@ describe("listOperationsV2", () => {
       evmAddress: mockMirrorAccount.evm_address,
       currencyId: mockCurrency.id,
       mirrorTokens: [],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -801,6 +850,7 @@ describe("listOperationsV2", () => {
     });
 
     const mockERC20Transfer = getMockedERC20TokenTransfer({
+      token_evm_address: mockTokenERC20.contractAddress,
       transaction_hash: mockMirrorTransaction.transaction_hash,
       consensus_timestamp:
         Number(mockMirrorTransaction.consensus_timestamp.split(".")[0]) * 10 ** 9,
@@ -840,7 +890,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [{ token: mockTokenERC20, balance: new BigNumber(10000000) }],
+      tokenEvmAddresses: [mockTokenERC20.contractAddress],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -903,7 +953,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -958,7 +1008,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -1016,7 +1066,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -1042,6 +1092,7 @@ describe("listOperationsV2", () => {
       transfers: [],
     });
     const mockERC20Transfer = getMockedERC20TokenTransfer({
+      token_evm_address: mockTokenERC20.contractAddress,
       transaction_hash: sharedHash,
       consensus_timestamp: Number(sharedTimestamp.split(".")[0]) * 10 ** 9,
       sender_account_id: 67890,
@@ -1079,7 +1130,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [{ token: mockTokenERC20, balance: new BigNumber(10000000) }],
+      tokenEvmAddresses: [mockTokenERC20.contractAddress],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -1148,10 +1199,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [
-        { token: mockTokenA, balance: new BigNumber(10000) },
-        { token: mockTokenB, balance: new BigNumber(20000) },
-      ],
+      tokenEvmAddresses: [mockTokenA.contractAddress, mockTokenB.contractAddress],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -1201,7 +1249,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: true,
       useEncodedHash: false,
@@ -1241,7 +1289,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: true,
@@ -1280,7 +1328,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -1311,6 +1359,7 @@ describe("listOperationsV2", () => {
       transfers: [{ account: mockMirrorAccount.account, amount: -300000 }],
     });
     const mockERC20Transfer = getMockedERC20TokenTransfer({
+      token_evm_address: mockTokenERC20.contractAddress,
       transaction_hash: sharedHash,
       consensus_timestamp: Number(sharedTimestamp.split(".")[0]) * 10 ** 9,
       sender_account_id: 12345,
@@ -1350,7 +1399,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [{ token: mockTokenERC20, balance: new BigNumber(10000000) }],
+      tokenEvmAddresses: [mockTokenERC20.contractAddress],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -1383,6 +1432,7 @@ describe("listOperationsV2", () => {
       token_transfers: [],
     });
     const mockERC20Transfer = getMockedERC20TokenTransfer({
+      token_evm_address: mockTokenERC20.contractAddress,
       transaction_hash: sharedHash,
       consensus_timestamp: Number(sharedTimestamp) * 10 ** 9,
       sender_account_id: 1234,
@@ -1419,7 +1469,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [{ token: mockTokenERC20, balance: new BigNumber(5000000) }],
+      tokenEvmAddresses: [mockTokenERC20.contractAddress],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -1476,7 +1526,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -1551,7 +1601,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [{ token: mockTokenERC20, balance: new BigNumber(10000000) }],
+      tokenEvmAddresses: [mockTokenERC20.contractAddress],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,
@@ -1587,7 +1637,7 @@ describe("listOperationsV2", () => {
       address: mockMirrorAccount.account,
       evmAddress: mockMirrorAccount.evm_address,
       mirrorTokens: [],
-      erc20Tokens: [],
+      tokenEvmAddresses: [],
       fetchAllPages: true,
       skipFeesForTokenOperations: false,
       useEncodedHash: false,

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
@@ -1,9 +1,4 @@
-import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
-import {
-  encodeAccountId,
-  encodeTokenAccountId,
-} from "@ledgerhq/ledger-wallet-framework/account/accountId";
-import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
+import { encodeAccountId } from "@ledgerhq/ledger-wallet-framework/account/accountId";
 import { getEnv } from "@ledgerhq/live-env";
 import type { Operation, OperationType } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
@@ -18,7 +13,6 @@ import { hgraphClient } from "../network/hgraph";
 import { parseTransfers, enrichERC20Transfers, analyzeStakingOperation } from "../network/utils";
 import type {
   EnrichedERC20Transfer,
-  HederaERC20TokenBalance,
   HederaMirrorToken,
   HederaMirrorTransaction,
   HederaOperationExtra,
@@ -97,7 +91,7 @@ function createStakingRewardOperation({
   const stakingRewardTimestamp = new Date(date.getTime() + 1);
 
   return {
-    id: encodeOperationId(ledgerAccountId, stakingRewardHash, stakingRewardType),
+    id: `${stakingRewardHash}:${stakingRewardType}`,
     accountId: ledgerAccountId,
     type: stakingRewardType,
     value: stakingReward,
@@ -145,13 +139,7 @@ async function processERC20TokenTransfer({
   const tokenOperations: Operation<HederaOperationExtra>[] = [];
 
   for (const transfer of enrichedERC20Transfer.transfers) {
-    const token = await getCryptoAssetsStore().findTokenByAddressInCurrency(
-      transfer.token_evm_address,
-      "hedera",
-    );
-
-    if (!token) continue;
-
+    const tokenEvmAddress = transfer.token_evm_address;
     const senderEvmAddress = transfer.sender_evm_address;
     const senderAddress = transfer.sender_account_id
       ? toEntityId({ num: transfer.sender_account_id })
@@ -161,7 +149,7 @@ async function processERC20TokenTransfer({
       : transfer.receiver_evm_address;
 
     // meaningful operation cannot be created without correct addresses, so we skip it
-    if (!senderEvmAddress || !senderAddress || !recipientAddress) continue;
+    if (!tokenEvmAddress || !senderEvmAddress || !senderAddress || !recipientAddress) continue;
 
     const commonFields = {
       ...commonData,
@@ -170,7 +158,7 @@ async function processERC20TokenTransfer({
         senderEvmAddress,
         evmAddress,
       }),
-      contract: token.contractAddress,
+      contract: tokenEvmAddress,
       standard: "erc20",
       blockHeight: commonData.blockHeight,
       blockHash: commonData.blockHash,
@@ -186,17 +174,10 @@ async function processERC20TokenTransfer({
       },
     } satisfies Partial<Operation<HederaOperationExtra>>;
 
-    const encodedTokenAccountId = encodeTokenAccountId(ledgerAccountId, token);
-    const encodedOperationId = encodeOperationId(
-      encodedTokenAccountId,
-      commonFields.hash,
-      commonFields.type,
-    );
-
     const tokenOperation = {
       ...commonFields,
-      id: encodedOperationId,
-      accountId: encodedTokenAccountId,
+      id: `${commonFields.hash}:${commonFields.type}:${tokenEvmAddress}`,
+      accountId: ledgerAccountId,
     } satisfies Operation<HederaOperationExtra>;
 
     tokenOperations.push(tokenOperation);
@@ -207,7 +188,7 @@ async function processERC20TokenTransfer({
   if (outgoingTransfer) {
     coinOperation = {
       ...commonData,
-      id: encodeOperationId(ledgerAccountId, commonData.hash, "FEES"),
+      id: `${commonData.hash}:FEES`,
       accountId: ledgerAccountId,
       type: "FEES",
       ...(outgoingTransfer.contract && { contract: outgoingTransfer.contract }),
@@ -231,13 +212,11 @@ async function processERC20TokenTransfer({
 async function processHTSTokenTransfers({
   rawTx,
   address,
-  currencyId,
   ledgerAccountId,
   commonData,
 }: {
   rawTx: HederaMirrorTransaction;
   address: string;
-  currencyId: string;
   ledgerAccountId: string;
   commonData: ReturnType<typeof getCommonMirrorOperationData>;
 }): Promise<{
@@ -248,20 +227,16 @@ async function processHTSTokenTransfers({
   if (tokenTransfers.length === 0) return null;
 
   const tokenId = tokenTransfers[0].token_id;
-  const token = await getCryptoAssetsStore().findTokenByAddressInCurrency(tokenId, currencyId);
-  if (!token) return null;
-
-  const encodedTokenId = encodeTokenAccountId(ledgerAccountId, token);
   const { type, value, senders, recipients } = parseTransfers(tokenTransfers, address);
   const { hash, fee, date, blockHeight, blockHash, hasFailed } = commonData;
   const extra = { ...commonData.extra };
 
   let coinOperation: Operation<HederaOperationExtra> | undefined;
 
-  // Add main FEES coin operation for send token transfer
-  if (type === "OUT") {
+  // Add main FEES coin operation for parent tx representing a token transfer (nonce > 0 means child transaction like TOKENWIPE)
+  if (type === "OUT" && rawTx.nonce === 0) {
     coinOperation = {
-      id: encodeOperationId(ledgerAccountId, hash, "FEES"),
+      id: `${hash}:FEES`,
       accountId: ledgerAccountId,
       type: "FEES",
       value: fee,
@@ -278,9 +253,9 @@ async function processHTSTokenTransfers({
   }
 
   const tokenOperation = {
-    id: encodeOperationId(encodedTokenId, hash, type),
-    accountId: encodedTokenId,
-    contract: token.contractAddress,
+    id: `${hash}:${type}:${tokenId}`,
+    accountId: ledgerAccountId,
+    contract: tokenId,
     standard: "hts",
     type,
     value,
@@ -358,7 +333,7 @@ function processCoinTransfers({
   }
 
   coinOperations.push({
-    id: encodeOperationId(ledgerAccountId, hash, operationType),
+    id: `${hash}:${operationType}`,
     accountId: ledgerAccountId,
     type: operationType,
     value,
@@ -428,7 +403,6 @@ async function processTransactionItem({
     const htsTokenResult = await processHTSTokenTransfers({
       rawTx: mirrorTx,
       address,
-      currencyId,
       ledgerAccountId,
       commonData,
     });
@@ -469,7 +443,7 @@ export async function listOperationsV2({
   address,
   evmAddress,
   mirrorTokens,
-  erc20Tokens,
+  tokenEvmAddresses,
   cursor,
   limit = 100,
   order = "desc",
@@ -483,7 +457,7 @@ export async function listOperationsV2({
   address: string;
   evmAddress: string;
   mirrorTokens: HederaMirrorToken[];
-  erc20Tokens: HederaERC20TokenBalance[];
+  tokenEvmAddresses: string[];
   cursor?: string;
   limit?: number;
   order?: "asc" | "desc";
@@ -526,7 +500,7 @@ export async function listOperationsV2({
           order,
           limit,
           fetchAllPages,
-          tokenEvmAddresses: erc20Tokens.map(t => t.token.contractAddress.toLowerCase()),
+          tokenEvmAddresses,
           ...(cursor && { timestamp: cursor }),
         })
         .then(erc20Transfers =>

--- a/libs/coin-modules/coin-hedera/src/network/hgraph.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/hgraph.test.ts
@@ -94,12 +94,14 @@ describe("hgraphClient", () => {
       const mockBalances = [
         {
           token_id: "0.0.5001",
+          token_evm_address: "0xabc123",
           balance: "1000000",
           balance_timestamp: "1234567890.123456789",
           created_timestamp: "1234567800.000000000",
         },
         {
           token_id: "0.0.5002",
+          token_evm_address: "0xabc321",
           balance: "2000000",
           balance_timestamp: "1234567890.123456789",
           created_timestamp: "1234567800.000000000",

--- a/libs/coin-modules/coin-hedera/src/network/hgraph.ts
+++ b/libs/coin-modules/coin-hedera/src/network/hgraph.ts
@@ -80,6 +80,7 @@ async function getERC20Balances({
               }
           ) {
               token_id
+              token_evm_address
               balance
               balance_timestamp
               created_timestamp

--- a/libs/coin-modules/coin-hedera/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.test.ts
@@ -1,15 +1,9 @@
-import { setupMockCryptoAssetsStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
 import { InvalidAddress } from "@ledgerhq/errors";
 import { getEnv } from "@ledgerhq/live-env";
 import BigNumber from "bignumber.js";
-import { SUPPORTED_ERC20_TOKENS } from "../constants";
 import { HederaRecipientInvalidChecksum } from "../errors";
 import { getMockedAccount } from "../test/fixtures/account.fixture";
-import {
-  getMockedCurrency,
-  getMockedERC20TokenCurrency,
-  getMockedHTSTokenCurrency,
-} from "../test/fixtures/currency.fixture";
+import { getMockedCurrency, getMockedHTSTokenCurrency } from "../test/fixtures/currency.fixture";
 import {
   getMockedERC20TokenBalance,
   getMockedERC20TokenTransfer,
@@ -302,19 +296,17 @@ describe("network utils", () => {
   });
 
   describe("getERC20BalancesForAccountV2", () => {
-    it("returns balances only for supported ERC20 tokens and calls hgraphClient.getERC20Balances accordingly", async () => {
+    it("returns token balances and calls hgraphClient.getERC20Balances accordingly", async () => {
       const mockAccount = getMockedAccount();
-      const erc20Token = getMockedERC20TokenCurrency();
+      const mockRawToken1 = { token_id: 1, token_evm_address: "0x000000001" };
+      const mockRawToken2 = { token_id: 2, token_evm_address: "0x000000002" };
+      const mockRawToken3 = { token_id: 3, token_evm_address: "0x000000003" };
 
       (hgraphClient.getERC20Balances as jest.Mock).mockResolvedValue([
-        getMockedERC20TokenBalance({ token_id: 0, balance: 100 }),
-        getMockedERC20TokenBalance({ token_id: 2, balance: 200 }),
-        // token id from SUPPORTED_ERC20_TOKENS
-        getMockedERC20TokenBalance({ token_id: 9470869, balance: 300 }),
+        getMockedERC20TokenBalance({ ...mockRawToken1, balance: 100 }),
+        getMockedERC20TokenBalance({ ...mockRawToken2, balance: 200 }),
+        getMockedERC20TokenBalance({ ...mockRawToken3, balance: 300 }),
       ]);
-      setupMockCryptoAssetsStore({
-        findTokenById: jest.fn().mockReturnValue(erc20Token),
-      });
 
       const res = await getERC20BalancesForAccountV2({
         configOrCurrencyId: mockCurrency.id,
@@ -328,10 +320,16 @@ describe("network utils", () => {
       });
       expect(res).toEqual([
         {
+          balance: new BigNumber(100),
+          contractAddress: mockRawToken1.token_evm_address,
+        },
+        {
+          balance: new BigNumber(200),
+          contractAddress: mockRawToken2.token_evm_address,
+        },
+        {
           balance: new BigNumber(300),
-          token: expect.objectContaining({
-            contractAddress: erc20Token.contractAddress,
-          }),
+          contractAddress: mockRawToken3.token_evm_address,
         },
       ]);
     });
@@ -339,7 +337,7 @@ describe("network utils", () => {
 
   describe("enrichERC20Transfers", () => {
     const payerAccountId = 1234;
-    const erc20Token = SUPPORTED_ERC20_TOKENS[0];
+    const erc20Token = { tokenId: "0.0.1", contractAddress: "0x000000001" };
     const mockMirrorTransaction = getMockedMirrorTransaction({
       entity_id: erc20Token.tokenId,
       consensus_timestamp: "1704067200.000000000",

--- a/libs/coin-modules/coin-hedera/src/network/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.ts
@@ -2,7 +2,6 @@ import invariant from "invariant";
 import { AccountId, TransactionId } from "@hashgraph/sdk";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import { getFiatCurrencyByTicker } from "@ledgerhq/cryptoassets/fiats";
-import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { InvalidAddress } from "@ledgerhq/errors";
 import cvsApi from "@ledgerhq/live-countervalues/api/index";
 import { getEnv } from "@ledgerhq/live-env";
@@ -11,7 +10,6 @@ import type { Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Operation, OperationType } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import type { HederaCoinConfig } from "../config";
-import { SUPPORTED_ERC20_TOKENS } from "../constants";
 import { HederaRecipientInvalidChecksum } from "../errors";
 import { getChecksum, nanosToSeconds, toEntityId, toTimestamp } from "../logic/utils";
 import type {
@@ -123,24 +121,9 @@ export async function getERC20BalancesForAccountV2({
   const rawBalances = await hgraphClient.getERC20Balances({ configOrCurrencyId, address });
 
   for (const rawBalance of rawBalances) {
-    const rawBalanceTokenId = toEntityId({ num: rawBalance.token_id });
-
-    const supportedToken = SUPPORTED_ERC20_TOKENS.find(token => {
-      return token.tokenId === rawBalanceTokenId;
-    });
-
-    if (!supportedToken) {
-      continue;
-    }
-
-    const calToken = await getCryptoAssetsStore().findTokenById(supportedToken.id);
-
-    if (!calToken) {
-      continue;
-    }
-
+    if (!rawBalance?.token_evm_address) continue;
     balances.push({
-      token: calToken,
+      contractAddress: rawBalance.token_evm_address,
       balance: new BigNumber(rawBalance.balance),
     });
   }

--- a/libs/coin-modules/coin-hedera/src/test/fixtures/hgraph.fixture.ts
+++ b/libs/coin-modules/coin-hedera/src/test/fixtures/hgraph.fixture.ts
@@ -5,6 +5,7 @@ export const getMockedERC20TokenBalance = (
 ): ERC20TokenAccount => {
   return {
     token_id: 12345,
+    token_evm_address: "0x12345",
     balance: 1_000_000,
     balance_timestamp: 1764932745835883000,
     created_timestamp: 1760932745835883000,

--- a/libs/coin-modules/coin-hedera/src/types/hgraph.ts
+++ b/libs/coin-modules/coin-hedera/src/types/hgraph.ts
@@ -15,6 +15,7 @@ export interface LatestIndexedConsensusTimestamp {
 
 export interface ERC20TokenAccount {
   token_id: number;
+  token_evm_address: string | null;
   balance: number;
   balance_timestamp: number;
   created_timestamp: number;

--- a/libs/coin-modules/coin-hedera/src/types/logic.ts
+++ b/libs/coin-modules/coin-hedera/src/types/logic.ts
@@ -1,5 +1,4 @@
 import type { TransactionIntent } from "@ledgerhq/coin-module-framework/api/types";
-import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { OperationType } from "@ledgerhq/types-live";
 import type BigNumber from "bignumber.js";
 import type { HederaCoinConfig } from "../config";
@@ -24,7 +23,7 @@ export interface EstimateFeesResult {
 }
 
 export interface HederaERC20TokenBalance {
-  token: TokenCurrency;
+  contractAddress: string;
   balance: BigNumber;
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - hedera framework methods like listOperations, getBalance or getBlock shouldn't be dependent on CAL

### 📝 Description

This PR removes CAL dependency from framework level in coin-hedera module:
  - getBalance returns all raw token balances (HTS and ERC20) keyed by contract address, without CAL enrichment.
  - listOperations has changed `operation.id` shape and token operations are no longer filtered or enriched by CAL.
  - accountId and id are re-encoded at the bridge level.
  - SUPPORTED_ERC20_TOKENS hardcoded allowlist was removed, bridge-level filtering is now properly based on CAL.

It also makes the sync process faster by refactoring the way data is fetched from CAL. Previously it was duplicated in `getSubAccounts` utility, right now there is a single `calTokenByAddress` map.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-27999
- https://ledgerhq.atlassian.net/browse/LIVE-24948

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
