### PR TITLE
[LWD] feat(desktop): add InfoState component

### DIFF
--- a/.changeset/gentle-pandas-build.md
+++ b/.changeset/gentle-pandas-build.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add desktop InfoState component with dialog gradient support

--- a/apps/ledger-live-desktop/src/mvvm/components/DialogBackgroundGradient/DialogBackgroundGradient.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DialogBackgroundGradient/DialogBackgroundGradient.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { useDialogBackgroundTone } from "LLD/hooks/useDialogBackgroundTone";
+import type { DialogBackgroundTone } from "LLD/contexts/DialogBackgroundContext";
+import { DialogBackgroundToneProvider } from ".";
+
+const statusGradientTones = ["error", "info", "success"] as const;
+
+function BackgroundToneRequester({ tone }: { tone?: DialogBackgroundTone }) {
+  useDialogBackgroundTone(tone);
+
+  return <div>Background tone requester</div>;
+}
+
+function expectNoStatusGradient() {
+  statusGradientTones.forEach(tone => {
+    expect(screen.queryByTestId(`dialog-status-gradient-${tone}`)).toBeNull();
+  });
+}
+
+describe("DialogBackgroundToneProvider", () => {
+  it.each(statusGradientTones)(
+    "GIVEN a component inside the provider WHEN it requests the %s tone THEN the matching background gradient is displayed",
+    tone => {
+      // GIVEN / WHEN
+      render(
+        <DialogBackgroundToneProvider>
+          <BackgroundToneRequester tone={tone} />
+        </DialogBackgroundToneProvider>,
+      );
+
+      // THEN
+      expect(screen.getByTestId(`dialog-status-gradient-${tone}`)).toBeVisible();
+    },
+  );
+
+  it("GIVEN a component inside the provider WHEN it requests an undefined tone THEN no background gradient is displayed", () => {
+    // GIVEN / WHEN
+    render(
+      <DialogBackgroundToneProvider>
+        <BackgroundToneRequester tone={undefined} />
+      </DialogBackgroundToneProvider>,
+    );
+
+    // THEN
+    expectNoStatusGradient();
+  });
+
+  it("GIVEN a component requested a defined tone WHEN that component unmounts THEN the background gradient is cleared", () => {
+    // GIVEN
+    const { rerender } = render(
+      <DialogBackgroundToneProvider>
+        <BackgroundToneRequester tone="success" />
+      </DialogBackgroundToneProvider>,
+    );
+    expect(screen.getByTestId("dialog-status-gradient-success")).toBeVisible();
+
+    // WHEN
+    rerender(<DialogBackgroundToneProvider>{null}</DialogBackgroundToneProvider>);
+
+    // THEN
+    expectNoStatusGradient();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DialogBackgroundGradient/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DialogBackgroundGradient/index.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { cn } from "LLD/utils/cn";
+import { DialogBackgroundContext } from "LLD/contexts/DialogBackgroundContext";
+import type { DialogBackgroundTone } from "LLD/contexts/DialogBackgroundContext";
+import { useDialogBackgroundToneRequests } from "LLD/hooks/useDialogBackgroundToneRequests";
+
+type DialogBackgroundGradientProps = Readonly<{
+  tone: DialogBackgroundTone;
+}>;
+
+const GRADIENT_CLASS_NAME_BY_TONE: Record<DialogBackgroundTone, string> = {
+  error: "bg-gradient-error",
+  info: "bg-gradient-muted",
+  success: "bg-gradient-success",
+};
+
+export function DialogBackgroundGradient({ tone }: DialogBackgroundGradientProps) {
+  return (
+    <div
+      className={cn(
+        "pointer-events-none absolute inset-x-0 top-0 h-full",
+        GRADIENT_CLASS_NAME_BY_TONE[tone],
+      )}
+      data-testid={`dialog-status-gradient-${tone}`}
+    />
+  );
+}
+
+export function DialogBackgroundToneProvider({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  const { backgroundTone, backgroundContextValue } = useDialogBackgroundToneRequests();
+
+  return (
+    <DialogBackgroundContext.Provider value={backgroundContextValue}>
+      {backgroundTone ? <DialogBackgroundGradient tone={backgroundTone} /> : null}
+      {children}
+    </DialogBackgroundContext.Provider>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/InfoState/InfoState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/InfoState/InfoState.test.tsx
@@ -1,0 +1,207 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { Search } from "@ledgerhq/lumen-ui-react/symbols";
+import { DialogBackgroundContext } from "LLD/contexts/DialogBackgroundContext";
+import { InfoState } from ".";
+import type { InfoStatePreset } from "./types";
+
+type VisualInfoStatePreset = Exclude<InfoStatePreset, "text">;
+
+describe("InfoState", () => {
+  it("GIVEN an InfoState configured with title, description, banner and CTAs WHEN it is rendered THEN it displays all of them", () => {
+    // GIVEN / WHEN
+    render(
+      <InfoState
+        preset="success"
+        title="State title"
+        description="State description"
+        banner={{ title: "Banner title", description: "Banner description" }}
+        primaryCta={{
+          label: "Primary action",
+          onPress: jest.fn(),
+          testID: "info-state-primary",
+        }}
+        secondaryCta={{
+          label: "Secondary action",
+          onPress: jest.fn(),
+          testID: "info-state-secondary",
+        }}
+      />,
+    );
+
+    // THEN
+    expect(screen.getByText("State title")).toBeVisible();
+    expect(screen.getByText("State description")).toBeVisible();
+    expect(screen.getByText("Banner title")).toBeVisible();
+    expect(screen.getByText("Banner description")).toBeVisible();
+  });
+
+  it("GIVEN a rendered InfoState with primary and secondary CTAs WHEN the user clicks each CTA THEN the matching onPress handler is invoked", async () => {
+    // GIVEN
+    const onPrimaryPress = jest.fn();
+    const onSecondaryPress = jest.fn();
+    const { user } = render(
+      <InfoState
+        preset="success"
+        title="State title"
+        primaryCta={{
+          label: "Primary action",
+          onPress: onPrimaryPress,
+          testID: "info-state-primary",
+        }}
+        secondaryCta={{
+          label: "Secondary action",
+          onPress: onSecondaryPress,
+          testID: "info-state-secondary",
+        }}
+      />,
+    );
+
+    // WHEN
+    await user.click(screen.getByTestId("info-state-primary"));
+    await user.click(screen.getByTestId("info-state-secondary"));
+
+    // THEN
+    expect(onPrimaryPress).toHaveBeenCalledTimes(1);
+    expect(onSecondaryPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN an InfoState with no optional props WHEN it is rendered THEN it does not display title, description, banner or actions", () => {
+    // GIVEN / WHEN
+    render(<InfoState preset="info" testID="info-state" />);
+
+    // THEN
+    expect(screen.getByTestId("info-state")).toBeVisible();
+    expect(screen.queryByText("State title")).toBeNull();
+    expect(screen.queryByText("State description")).toBeNull();
+    expect(screen.queryByText("Banner title")).toBeNull();
+    expect(screen.queryByText("Primary action")).toBeNull();
+    expect(screen.queryByText("Secondary action")).toBeNull();
+  });
+
+  it.each(["success", "error", "info", "spot", "illustration"] as const)(
+    "GIVEN the %s preset WHEN the InfoState is rendered THEN the preset visual and title are visible",
+    preset => {
+      // GIVEN / WHEN
+      render(
+        <InfoState
+          {...getPresetProps(preset)}
+          title={`${preset} title`}
+          testID={`info-state-${preset}`}
+        />,
+      );
+
+      // THEN
+      expect(screen.getByTestId(`info-state-${preset}`)).toBeVisible();
+      expect(screen.getByText(`${preset} title`)).toBeVisible();
+    },
+  );
+
+  it("GIVEN the text preset WHEN the InfoState is rendered THEN the title is visible without a preset visual gap", () => {
+    // GIVEN / WHEN
+    render(<InfoState preset="text" title="Text-only title" testID="info-state-text" />);
+
+    // THEN
+    expect(screen.getByText("Text-only title")).toBeVisible();
+    expect(screen.getByTestId("info-state-text")).toBeVisible();
+  });
+
+  it.each(["success", "error", "info"] as const)(
+    "GIVEN the %s preset inside a DialogBackgroundContext provider WHEN the InfoState mounts THEN it requests the matching background tone",
+    preset => {
+      // GIVEN
+      const requestBackgroundTone = jest.fn(() => jest.fn());
+
+      // WHEN
+      render(
+        <DialogBackgroundContext.Provider value={{ requestBackgroundTone }}>
+          <InfoState preset={preset} title={`${preset} title`} />
+        </DialogBackgroundContext.Provider>,
+      );
+
+      // THEN
+      expect(requestBackgroundTone).toHaveBeenCalledWith(preset);
+    },
+  );
+
+  it.each(["success", "error", "info"] as const)(
+    "GIVEN a mounted InfoState with the %s preset WHEN it unmounts THEN its background tone registration cleanup runs",
+    preset => {
+      // GIVEN
+      const cleanup = jest.fn();
+      const requestBackgroundTone = jest.fn(() => cleanup);
+      const { unmount } = render(
+        <DialogBackgroundContext.Provider value={{ requestBackgroundTone }}>
+          <InfoState preset={preset} title={`${preset} title`} />
+        </DialogBackgroundContext.Provider>,
+      );
+
+      // WHEN
+      unmount();
+
+      // THEN
+      expect(cleanup).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(["illustration", "spot", "text"] as const)(
+    "GIVEN the non-status %s preset inside a DialogBackgroundContext provider WHEN the InfoState renders THEN it does not request a background tone",
+    preset => {
+      // GIVEN
+      const requestBackgroundTone = jest.fn(() => jest.fn());
+
+      // WHEN
+      render(
+        <DialogBackgroundContext.Provider value={{ requestBackgroundTone }}>
+          {renderInfoStateForPreset(preset)}
+        </DialogBackgroundContext.Provider>,
+      );
+
+      // THEN
+      expect(requestBackgroundTone).not.toHaveBeenCalled();
+    },
+  );
+});
+
+function getPresetProps(preset: VisualInfoStatePreset): React.ComponentProps<typeof InfoState> {
+  switch (preset) {
+    case "illustration":
+      return {
+        preset,
+        illustration: <div data-testid="info-state-illustration-visual" />,
+      };
+    case "spot":
+      return {
+        preset,
+        spotProps: { icon: Search },
+      };
+    case "success":
+    case "error":
+    case "info":
+      return { preset };
+    default:
+      return assertNever(preset);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled info state preset: ${JSON.stringify(value)}`);
+}
+
+function renderInfoStateForPreset(preset: "illustration" | "spot" | "text") {
+  switch (preset) {
+    case "illustration":
+      return (
+        <InfoState
+          preset="illustration"
+          illustration={<div data-testid="info-state-illustration-visual" />}
+        />
+      );
+    case "spot":
+      return <InfoState preset="spot" spotProps={{ icon: Search }} />;
+    case "text":
+      return <InfoState preset="text" />;
+    default:
+      return assertNever(preset);
+  }
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/InfoState/components/InfoStateButton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/InfoState/components/InfoStateButton.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import type { InfoStateCta } from "../types";
+
+export function InfoStateButton({
+  cta,
+  appearance,
+}: Readonly<{
+  cta: InfoStateCta;
+  appearance: "base" | "gray";
+}>) {
+  return (
+    <Button
+      appearance={appearance}
+      size="lg"
+      isFull
+      onClick={cta.onPress}
+      disabled={cta.disabled}
+      data-testid={cta.testID}
+    >
+      {cta.label}
+    </Button>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/InfoState/components/PresetVisual.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/InfoState/components/PresetVisual.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Spot } from "@ledgerhq/lumen-ui-react";
+import type { InfoStateProps } from "../types";
+
+const SPOT_SIZE = 72;
+
+export function PresetVisual(props: InfoStateProps) {
+  switch (props.preset) {
+    case "illustration":
+      return (
+        <div className="flex h-[208px] w-[208px] items-center justify-center overflow-hidden rounded-sm">
+          {props.illustration}
+        </div>
+      );
+    case "spot":
+      return <Spot appearance="icon" size={SPOT_SIZE} icon={props.spotProps.icon} />;
+    case "success":
+      return <Spot appearance="check" size={SPOT_SIZE} />;
+    case "error":
+      return <Spot appearance="error" size={SPOT_SIZE} />;
+    case "info":
+      return <Spot appearance="info" size={SPOT_SIZE} />;
+    case "text":
+      return null;
+    default:
+      return assertNever(props);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled info state preset: ${JSON.stringify(value)}`);
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/InfoState/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/InfoState/index.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { Banner } from "@ledgerhq/lumen-ui-react";
+import { useDialogBackgroundTone } from "LLD/hooks/useDialogBackgroundTone";
+import { cn } from "LLD/utils/cn";
+import type { InfoStateProps } from "./types";
+import { InfoStateButton } from "./components/InfoStateButton";
+import { PresetVisual } from "./components/PresetVisual";
+import { getInfoStateDialogTone } from "./utils/getInfoStateDialogTone";
+
+/**
+ * Shared desktop state layout for informational, success, and error screens.
+ */
+export function InfoState(props: InfoStateProps) {
+  const {
+    title,
+    description,
+    primaryCta,
+    secondaryCta,
+    banner,
+    size = "full-height",
+    testID,
+  } = props;
+  const isTextPreset = props.preset === "text";
+  const isFullHeight = size === "full-height";
+  useDialogBackgroundTone(getInfoStateDialogTone(props.preset));
+
+  return (
+    <div className={cn("w-full", isFullHeight && "flex flex-1")} data-testid={testID}>
+      <div
+        className={cn(
+          "flex w-full flex-col items-center gap-32 overflow-hidden px-16 py-24",
+          isFullHeight && "min-h-[480px] flex-1",
+        )}
+      >
+        <div
+          className={cn(
+            "flex w-full flex-col items-center justify-center",
+            isFullHeight && "flex-1",
+            isTextPreset ? "gap-0" : "gap-24",
+          )}
+        >
+          <PresetVisual {...props} />
+          {title || description ? (
+            <div className="flex w-full flex-col items-center gap-8 text-center">
+              {title ? <h3 className="heading-4-semi-bold text-base">{title}</h3> : null}
+              {description ? <p className="body-2 text-muted">{description}</p> : null}
+            </div>
+          ) : null}
+        </div>
+
+        {banner ? (
+          <div className="w-full">
+            <Banner
+              appearance={banner.appearance ?? "info"}
+              title={banner.title}
+              description={banner.description}
+            />
+          </div>
+        ) : null}
+
+        {primaryCta || secondaryCta ? (
+          <div className="flex w-full flex-col gap-16">
+            {primaryCta ? <InfoStateButton cta={primaryCta} appearance="base" /> : null}
+            {secondaryCta ? <InfoStateButton cta={secondaryCta} appearance="gray" /> : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/InfoState/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/InfoState/types.ts
@@ -1,0 +1,89 @@
+import type { ComponentProps, ReactNode } from "react";
+
+type LumenSpotProps = ComponentProps<(typeof import("@ledgerhq/lumen-ui-react"))["Spot"]>;
+type LumenIconSpotProps = Extract<LumenSpotProps, { icon?: unknown }>;
+
+/** Preset that controls the visual rendered above the title and description. */
+export type InfoStatePreset = "illustration" | "spot" | "success" | "error" | "info" | "text";
+
+/** CTA displayed in the action stack below the content and optional banner. */
+export type InfoStateCta = Readonly<{
+  /** Button label. */
+  label: ReactNode;
+
+  /** Called when the button is pressed. */
+  onPress: () => void;
+
+  /** Optional test identifier forwarded to the button. */
+  testID?: string;
+
+  /** Whether the button is disabled. */
+  disabled?: boolean;
+}>;
+
+/** Lumen banner displayed between content and actions. */
+export type InfoStateBanner = Readonly<{
+  /** Banner title. */
+  title: string;
+
+  /** Optional banner body copy. */
+  description?: ReactNode;
+
+  /** Visual treatment for the banner. Defaults to info. */
+  appearance?: "info" | "warning" | "error" | "success";
+}>;
+
+/** Props forwarded to the Lumen Spot for the custom spot preset. */
+export type InfoStateSpotProps = Pick<LumenIconSpotProps, "icon">;
+
+type InfoStateBaseProps = Readonly<{
+  /** Optional centered heading. */
+  title?: ReactNode;
+
+  /** Optional centered explanatory copy below the title. */
+  description?: ReactNode;
+
+  /** Primary action rendered first in the action stack. */
+  primaryCta?: InfoStateCta;
+
+  /** Secondary action rendered below the primary action. */
+  secondaryCta?: InfoStateCta;
+
+  /** Optional banner rendered before the action stack. */
+  banner?: InfoStateBanner;
+
+  /** Layout sizing mode. Full-height expands the content area. Defaults to full-height. */
+  size?: "hug" | "full-height";
+
+  /** Optional test identifier applied to the root container. */
+  testID?: string;
+}>;
+
+/** Props for the shared desktop InfoState layout. */
+export type InfoStateProps =
+  | (InfoStateBaseProps & {
+      /** Renders a caller-provided illustration in a 208px visual slot. */
+      preset: "illustration";
+      illustration: ReactNode;
+    })
+  | (InfoStateBaseProps & {
+      /** Renders a Lumen Spot with caller-provided icon props. */
+      preset: "spot";
+      spotProps: InfoStateSpotProps;
+    })
+  | (InfoStateBaseProps & {
+      /** Renders a success status Spot. */
+      preset: "success";
+    })
+  | (InfoStateBaseProps & {
+      /** Renders an error status Spot. */
+      preset: "error";
+    })
+  | (InfoStateBaseProps & {
+      /** Renders an info status Spot. */
+      preset: "info";
+    })
+  | (InfoStateBaseProps & {
+      /** Renders only title, description, banner, and actions without visual spacing. */
+      preset: "text";
+    });

--- a/apps/ledger-live-desktop/src/mvvm/components/InfoState/utils/getInfoStateDialogTone.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/InfoState/utils/getInfoStateDialogTone.ts
@@ -1,0 +1,25 @@
+import type { DialogBackgroundTone } from "LLD/contexts/DialogBackgroundContext";
+import type { InfoStateProps } from "../types";
+
+export function getInfoStateDialogTone(
+  preset: InfoStateProps["preset"],
+): DialogBackgroundTone | undefined {
+  switch (preset) {
+    case "error":
+      return "error";
+    case "info":
+      return "info";
+    case "success":
+      return "success";
+    case "illustration":
+    case "spot":
+    case "text":
+      return undefined;
+    default:
+      return assertNever(preset);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled info state preset: ${JSON.stringify(value)}`);
+}

--- a/apps/ledger-live-desktop/src/mvvm/contexts/DialogBackgroundContext.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/contexts/DialogBackgroundContext.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+export type DialogBackgroundTone = "error" | "info" | "success";
+
+type CleanupDialogBackgroundTone = () => void;
+
+export type DialogBackgroundContextValue = Readonly<{
+  /**
+   * Registers a status gradient tone for the owning dialog.
+   *
+   * The returned cleanup function unregisters this exact request. Return it from
+   * the caller's effect so the dialog can restore the previous tone, or clear the
+   * gradient, when the caller unmounts or changes tone.
+   */
+  requestBackgroundTone: (tone: DialogBackgroundTone) => CleanupDialogBackgroundTone;
+}>;
+
+export const DialogBackgroundContext = React.createContext<
+  DialogBackgroundContextValue | undefined
+>(undefined);

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useDialogBackgroundTone.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useDialogBackgroundTone.test.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { renderHook } from "tests/testSetup";
+import {
+  DialogBackgroundContext,
+  type DialogBackgroundContextValue,
+  type DialogBackgroundTone,
+} from "LLD/contexts/DialogBackgroundContext";
+import { useDialogBackgroundTone } from "../useDialogBackgroundTone";
+
+describe("useDialogBackgroundTone", () => {
+  it("GIVEN no DialogBackgroundContext provider WHEN the hook is called THEN it does not throw", () => {
+    // GIVEN
+    // (no provider)
+
+    // WHEN / THEN
+    expect(() => {
+      renderHook(() => useDialogBackgroundTone("success"));
+    }).not.toThrow();
+  });
+
+  it("GIVEN a provider is wired WHEN the hook is called with undefined THEN it does not call requestBackgroundTone", () => {
+    // GIVEN
+    const requestBackgroundTone = jest.fn(() => jest.fn());
+
+    // WHEN
+    renderHook(() => useDialogBackgroundTone(undefined), {
+      wrapper: buildWrapper({ requestBackgroundTone }),
+    });
+
+    // THEN
+    expect(requestBackgroundTone).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN a provider is wired WHEN the hook mounts with a tone THEN it requests that tone", () => {
+    // GIVEN
+    const requestBackgroundTone = jest.fn(() => jest.fn());
+
+    // WHEN
+    renderHook(() => useDialogBackgroundTone("success"), {
+      wrapper: buildWrapper({ requestBackgroundTone }),
+    });
+
+    // THEN
+    expect(requestBackgroundTone).toHaveBeenCalledWith("success");
+  });
+
+  it("GIVEN the hook has mounted with a tone WHEN the tone changes THEN the previous registration is cleaned up and the new tone is requested", () => {
+    // GIVEN
+    const successCleanup = jest.fn();
+    const errorCleanup = jest.fn();
+    const requestBackgroundTone = jest.fn((tone: DialogBackgroundTone) =>
+      tone === "success" ? successCleanup : errorCleanup,
+    );
+    let tone: DialogBackgroundTone = "success";
+    const { rerender } = renderHook(() => useDialogBackgroundTone(tone), {
+      wrapper: buildWrapper({ requestBackgroundTone }),
+    });
+
+    // WHEN
+    tone = "error";
+    rerender(undefined);
+
+    // THEN
+    expect(successCleanup).toHaveBeenCalledTimes(1);
+    expect(requestBackgroundTone).toHaveBeenCalledWith("error");
+  });
+
+  it("GIVEN the hook is mounted with a tone WHEN it unmounts THEN the registration cleanup runs", () => {
+    // GIVEN
+    const cleanup = jest.fn();
+    const requestBackgroundTone = jest.fn(() => cleanup);
+    const { unmount } = renderHook(() => useDialogBackgroundTone("success"), {
+      wrapper: buildWrapper({ requestBackgroundTone }),
+    });
+
+    // WHEN
+    unmount();
+
+    // THEN
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});
+
+function buildWrapper(value: DialogBackgroundContextValue) {
+  return function DialogBackgroundWrapper({
+    children,
+  }: Readonly<{
+    children: React.ReactNode;
+  }>) {
+    return (
+      <DialogBackgroundContext.Provider value={value}>{children}</DialogBackgroundContext.Provider>
+    );
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useDialogBackgroundTone.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useDialogBackgroundTone.ts
@@ -1,0 +1,25 @@
+import { useContext, useLayoutEffect } from "react";
+import {
+  DialogBackgroundContext,
+  type DialogBackgroundTone,
+} from "LLD/contexts/DialogBackgroundContext";
+
+/**
+ * Tints the enclosing dialog with the given status tone.
+ *
+ * - Call from any descendant of a dialog that provides `DialogBackgroundContext`.
+ * - Pass `undefined` to opt out without unmounting (no gradient is drawn).
+ * - The tone is registered before the next paint, so the gradient appears in
+ *   the same frame as the requester.
+ * - The request is automatically cleared on unmount or tone change.
+ * - No-op outside a `DialogBackgroundContext` provider.
+ */
+export function useDialogBackgroundTone(tone: DialogBackgroundTone | undefined): void {
+  const context = useContext(DialogBackgroundContext);
+
+  useLayoutEffect(() => {
+    if (!context || !tone) return;
+
+    return context.requestBackgroundTone(tone);
+  }, [context, tone]);
+}

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useDialogBackgroundToneRequests.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useDialogBackgroundToneRequests.ts
@@ -1,0 +1,43 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import type {
+  DialogBackgroundContextValue,
+  DialogBackgroundTone,
+} from "LLD/contexts/DialogBackgroundContext";
+
+type UseDialogBackgroundToneRequestsReturn = Readonly<{
+  backgroundTone: DialogBackgroundTone | undefined;
+  backgroundContextValue: DialogBackgroundContextValue;
+}>;
+
+export function useDialogBackgroundToneRequests(): UseDialogBackgroundToneRequestsReturn {
+  const [backgroundTone, setBackgroundTone] = useState<DialogBackgroundTone>();
+  const requestsRef = useRef(new Map<number, DialogBackgroundTone>());
+  const nextRequestIdRef = useRef(0);
+
+  const requestBackgroundTone = useCallback<DialogBackgroundContextValue["requestBackgroundTone"]>(
+    tone => {
+      const requestId = nextRequestIdRef.current;
+      nextRequestIdRef.current += 1;
+      requestsRef.current.set(requestId, tone);
+      setBackgroundTone(tone);
+
+      return () => {
+        requestsRef.current.delete(requestId);
+        const remainingTones = Array.from(requestsRef.current.values());
+
+        setBackgroundTone(remainingTones[remainingTones.length - 1]);
+      };
+    },
+    [],
+  );
+
+  const backgroundContextValue = useMemo<DialogBackgroundContextValue>(
+    () => ({ requestBackgroundTone }),
+    [requestBackgroundTone],
+  );
+
+  return {
+    backgroundTone,
+    backgroundContextValue,
+  };
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/InfoStateDevTool/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/InfoStateDevTool/index.tsx
@@ -1,0 +1,25 @@
+import React, { useCallback } from "react";
+import { useNavigate } from "react-router";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import { SettingsSectionRow } from "~/renderer/screens/settings/SettingsSection";
+
+const COPY = {
+  rowTitle: "InfoState playground",
+  rowDesc: "Open a screen to test the shared desktop InfoState component.",
+  open: "Open",
+} as const;
+
+export default function InfoStateDevTool() {
+  const navigate = useNavigate();
+  const onOpen = useCallback(() => {
+    navigate("/settings/developer/info-state-qa");
+  }, [navigate]);
+
+  return (
+    <SettingsSectionRow title={COPY.rowTitle} desc={COPY.rowDesc}>
+      <Button size="sm" appearance="accent" onClick={onOpen}>
+        {COPY.open}
+      </Button>
+    </SettingsSectionRow>
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/InfoStateDevTool/screens/InfoStateDevScreen/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/InfoStateDevTool/screens/InfoStateDevScreen/index.tsx
@@ -1,0 +1,350 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router";
+import { Button, Dialog, DialogBody, DialogContent, DialogHeader } from "@ledgerhq/lumen-ui-react";
+import { ArrowLeft, Search } from "@ledgerhq/lumen-ui-react/symbols";
+import { DialogBackgroundToneProvider } from "LLD/components/DialogBackgroundGradient";
+import { InfoState } from "LLD/components/InfoState";
+import type { InfoStatePreset, InfoStateProps } from "LLD/components/InfoState/types";
+
+const presetOptions: InfoStatePreset[] = [
+  "illustration",
+  "spot",
+  "success",
+  "error",
+  "info",
+  "text",
+];
+const sizeOptions: Array<NonNullable<InfoStateProps["size"]>> = ["full-height", "hug"];
+const cyclePresets: InfoStatePreset[] = ["error", "info", "success", "text"];
+
+export default function InfoStateDevScreen() {
+  const navigate = useNavigate();
+  const [preset, setPreset] = useState<InfoStatePreset>("success");
+  const [size, setSize] = useState<NonNullable<InfoStateProps["size"]>>("full-height");
+  const [showTitle, setShowTitle] = useState(true);
+  const [showDescription, setShowDescription] = useState(true);
+  const [showBanner, setShowBanner] = useState(false);
+  const [showPrimaryCta, setShowPrimaryCta] = useState(true);
+  const [showSecondaryCta, setShowSecondaryCta] = useState(true);
+  const [useLongTitle, setUseLongTitle] = useState(false);
+  const [useLongDescription, setUseLongDescription] = useState(false);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const [isCyclePreviewOpen, setIsCyclePreviewOpen] = useState(false);
+  const [cycleIndex, setCycleIndex] = useState(0);
+
+  const title = useLongTitle ? longTitle : `${formatPresetLabel(preset)} state title`;
+  const description = useLongDescription
+    ? longDescription
+    : "Use this component for focused feedback and next-step guidance.";
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col p-8 pb-16" data-testid="info-state-dev-screen">
+      <header className="mb-14 grid grid-cols-[1fr_auto_1fr] items-center gap-x-3 py-6">
+        <div className="flex min-w-0 justify-start">
+          <Button
+            size="sm"
+            appearance="no-background"
+            onClick={() => navigate("/settings/developer")}
+            icon={ArrowLeft}
+          >
+            Back
+          </Button>
+        </div>
+        <span className="heading-2-semi-bold max-w-[min(100vw-8rem,28rem)] text-center text-base">
+          InfoState playground
+        </span>
+        <div aria-hidden className="min-w-0" />
+      </header>
+
+      <main className="mx-auto flex w-full max-w-3xl flex-col gap-16 px-4">
+        <p className="body-2 text-muted">
+          Local playground for the reusable desktop info-state component.
+        </p>
+
+        <section className="flex w-full flex-col gap-16 rounded-lg bg-surface p-16">
+          <h2 className="body-2-semi-bold text-base">Playground controls</h2>
+
+          <SettingSection title="Preset">
+            {presetOptions.map(presetOption => (
+              <ChoiceButton
+                key={presetOption}
+                label={formatPresetLabel(presetOption)}
+                selected={presetOption === preset}
+                onPress={() => setPreset(presetOption)}
+              />
+            ))}
+          </SettingSection>
+
+          <SettingSection title="Size">
+            {sizeOptions.map(sizeOption => (
+              <ChoiceButton
+                key={sizeOption}
+                label={sizeOption}
+                selected={sizeOption === size}
+                onPress={() => setSize(sizeOption)}
+              />
+            ))}
+          </SettingSection>
+
+          <SettingSection title="Visibility">
+            <ToggleButton
+              label="Title"
+              enabled={showTitle}
+              onPress={() => setShowTitle(value => !value)}
+            />
+            <ToggleButton
+              label="Description"
+              enabled={showDescription}
+              onPress={() => setShowDescription(value => !value)}
+            />
+            <ToggleButton
+              label="Banner"
+              enabled={showBanner}
+              onPress={() => setShowBanner(value => !value)}
+            />
+            <ToggleButton
+              label="Primary CTA"
+              enabled={showPrimaryCta}
+              onPress={() => setShowPrimaryCta(value => !value)}
+            />
+            <ToggleButton
+              label="Secondary CTA"
+              enabled={showSecondaryCta}
+              onPress={() => setShowSecondaryCta(value => !value)}
+            />
+          </SettingSection>
+
+          <SettingSection title="Copy stress">
+            <ToggleButton
+              label="Long title"
+              enabled={useLongTitle}
+              onPress={() => setUseLongTitle(value => !value)}
+            />
+            <ToggleButton
+              label="Long description"
+              enabled={useLongDescription}
+              onPress={() => setUseLongDescription(value => !value)}
+            />
+          </SettingSection>
+
+          <Button
+            appearance="base"
+            size="lg"
+            onClick={() => setIsPreviewOpen(true)}
+            data-testid="info-state-open-preview"
+          >
+            Open preview
+          </Button>
+
+          <Button
+            appearance="gray"
+            size="lg"
+            onClick={() => {
+              setCycleIndex(0);
+              setIsCyclePreviewOpen(true);
+            }}
+            data-testid="info-state-open-cycle-preview"
+          >
+            Open tone cycle preview
+          </Button>
+        </section>
+      </main>
+
+      <Dialog open={isPreviewOpen} onOpenChange={setIsPreviewOpen}>
+        <DialogContent
+          className="max-w-[480px] overflow-hidden"
+          data-testid="info-state-preview-dialog"
+        >
+          <DialogBackgroundToneProvider>
+            <DialogHeader density="compact" onClose={() => setIsPreviewOpen(false)} />
+            <DialogBody className="px-24 pb-24">
+              {renderInfoStatePreview({
+                preset,
+                size,
+                title: showTitle ? title : undefined,
+                description: showDescription ? description : undefined,
+                banner: showBanner
+                  ? {
+                      title: "Important information",
+                      description: "This optional banner sits before the action stack.",
+                      appearance: "info",
+                    }
+                  : undefined,
+                primaryCta: showPrimaryCta
+                  ? {
+                      label: "Primary action",
+                      onPress: () => undefined,
+                      testID: "info-state-primary-cta",
+                    }
+                  : undefined,
+                secondaryCta: showSecondaryCta
+                  ? {
+                      label: "Secondary action",
+                      onPress: () => undefined,
+                      testID: "info-state-secondary-cta",
+                    }
+                  : undefined,
+              })}
+            </DialogBody>
+          </DialogBackgroundToneProvider>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isCyclePreviewOpen} onOpenChange={setIsCyclePreviewOpen}>
+        <DialogContent
+          className="max-w-[480px] overflow-hidden"
+          data-testid="info-state-cycle-preview-dialog"
+        >
+          <DialogBackgroundToneProvider>
+            <DialogHeader density="compact" onClose={() => setIsCyclePreviewOpen(false)} />
+            <DialogBody className="px-24 pb-24">
+              {renderCycleInfoState({
+                preset: cyclePresets[cycleIndex],
+                nextPreset: cyclePresets[(cycleIndex + 1) % cyclePresets.length],
+                onNext: () => setCycleIndex(index => (index + 1) % cyclePresets.length),
+              })}
+            </DialogBody>
+          </DialogBackgroundToneProvider>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function renderCycleInfoState({
+  preset,
+  nextPreset,
+  onNext,
+}: Readonly<{
+  preset: InfoStatePreset;
+  nextPreset: InfoStatePreset;
+  onNext: () => void;
+}>) {
+  const commonProps: Pick<InfoStateProps, "size" | "title" | "description" | "primaryCta"> = {
+    size: "hug",
+    title: `${formatPresetLabel(preset)} state`,
+    description: "Tap the primary action to cycle to the next tone without closing the dialog.",
+    primaryCta: {
+      label: `Next: ${formatPresetLabel(nextPreset)}`,
+      onPress: onNext,
+      testID: "info-state-cycle-next-cta",
+    },
+  };
+
+  switch (preset) {
+    case "success":
+      return <InfoState {...commonProps} preset="success" testID="info-state-cycle-preview" />;
+    case "error":
+      return <InfoState {...commonProps} preset="error" testID="info-state-cycle-preview" />;
+    case "info":
+      return <InfoState {...commonProps} preset="info" testID="info-state-cycle-preview" />;
+    case "text":
+      return <InfoState {...commonProps} preset="text" testID="info-state-cycle-preview" />;
+    default:
+      throw new Error(`Unsupported cycle preset: ${preset}`);
+  }
+}
+
+function renderInfoStatePreview({
+  preset,
+  ...commonProps
+}: Readonly<
+  Pick<
+    InfoStateProps,
+    "banner" | "description" | "primaryCta" | "secondaryCta" | "size" | "title"
+  > & {
+    preset: InfoStatePreset;
+  }
+>) {
+  switch (preset) {
+    case "illustration":
+      return (
+        <InfoState
+          {...commonProps}
+          preset="illustration"
+          illustration={<div className="h-full w-full rounded-sm bg-muted" />}
+          testID="info-state-preview"
+        />
+      );
+    case "spot":
+      return (
+        <InfoState
+          {...commonProps}
+          preset="spot"
+          spotProps={{ icon: Search }}
+          testID="info-state-preview"
+        />
+      );
+    case "success":
+      return <InfoState {...commonProps} preset="success" testID="info-state-preview" />;
+    case "error":
+      return <InfoState {...commonProps} preset="error" testID="info-state-preview" />;
+    case "info":
+      return <InfoState {...commonProps} preset="info" testID="info-state-preview" />;
+    case "text":
+      return <InfoState {...commonProps} preset="text" testID="info-state-preview" />;
+    default:
+      return assertNever(preset);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled info state preset: ${value}`);
+}
+
+function SettingSection({
+  title,
+  children,
+}: Readonly<{
+  title: string;
+  children: React.ReactNode;
+}>) {
+  return (
+    <div className="flex flex-col gap-8">
+      <span className="body-2 text-muted">{title}</span>
+      <div className="flex flex-row flex-wrap gap-8">{children}</div>
+    </div>
+  );
+}
+
+function ChoiceButton({
+  label,
+  selected,
+  onPress,
+}: Readonly<{
+  label: string;
+  selected: boolean;
+  onPress: () => void;
+}>) {
+  return (
+    <Button appearance={selected ? "base" : "gray"} size="sm" onClick={onPress}>
+      {label}
+    </Button>
+  );
+}
+
+function ToggleButton({
+  label,
+  enabled,
+  onPress,
+}: Readonly<{
+  label: string;
+  enabled: boolean;
+  onPress: () => void;
+}>) {
+  return (
+    <Button appearance={enabled ? "base" : "gray"} size="sm" onClick={onPress}>
+      {label}: {enabled ? "On" : "Off"}
+    </Button>
+  );
+}
+
+function formatPresetLabel(preset: InfoStatePreset): string {
+  return preset.charAt(0).toUpperCase() + preset.slice(1);
+}
+
+const longTitle =
+  "A longer title that validates the centered heading behavior when the info state is used in compact desktop surfaces";
+
+const longDescription =
+  "This longer description intentionally spans several lines in constrained desktop dialogs. It helps validate the body copy line height, centered alignment, vertical rhythm, and the transition into banners and actions.";

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/index.tsx
@@ -42,6 +42,8 @@ import AnalyticsConsentOptInDevTool from "./AnalyticsConsentOptInDevTool";
 import { AnalyticsConsentOptInDevScreen } from "./AnalyticsConsentOptInDevTool/AnalyticsConsentOptInDevScreen";
 import GenericAwarenessModalDevTool from "./GenericAwarenessModalDevTool";
 import GenericAwarenessModalDevScreen from "./GenericAwarenessModalDevTool/screens/GenericAwarenessModalDevScreen";
+import InfoStateDevTool from "./InfoStateDevTool";
+import InfoStateDevScreen from "./InfoStateDevTool/screens/InfoStateDevScreen";
 
 const Default = () => {
   const { t } = useTranslation();
@@ -147,6 +149,7 @@ const Default = () => {
       <FeaturesAndFlowsDevTool />
       <AnalyticsConsentOptInDevTool />
       <GenericAwarenessModalDevTool />
+      <InfoStateDevTool />
       <ModularDrawerDevTool />
       <CryptoAssetsListDevTool />
       <MockAccountGeneratorSection />
@@ -161,6 +164,7 @@ const SectionDeveloper = () => (
       <Route path="custom-locksscreen-assets" element={<CustomLockScreenAssets />} />
       <Route path="analytics-consent-opt-in-qa" element={<AnalyticsConsentOptInDevScreen />} />
       <Route path="generic-awareness-modal-qa" element={<GenericAwarenessModalDevScreen />} />
+      <Route path="info-state-qa" element={<InfoStateDevScreen />} />
       <Route path="*" element={<Default />} />
     </Routes>
   </>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - New component `InfoState`
  - Developer settings InfoState playground for validation

### 📝 Description

`InfoState` already exists on mobile and is used to render focused feedback screens (success, error, info, illustration, spot, and text states). It did not exist on desktop yet.

This PR adds the desktop version of `InfoState`, mirroring the mobile file structure, prop types, and tests. It is built with Lumen and lives in `mvvm/components`.

**Background gradient.** Some presets (success, error, info) need the surrounding dialog to be tinted with a matching status gradient. On desktop, the Lumen `Dialog` has no `backgroundComponent` prop like the mobile bottom sheet, so the component can't paint that background itself. To solve this, `InfoState` requests a tone through a `DialogBackgroundContext` + `useDialogBackgroundTone` hook (a `useLayoutEffect` registers the tone before paint and clears it on unmount), and a `DialogBackgroundToneProvider` renders the gradient inside `DialogContent`. This reproduces the mobile background tone behaviour while keeping the gradient decoupled from the component itself, so any dialog content can opt in without changing Lumen.

It also adds a section in the Developer settings to test the component the same way as the mobile debug screen.

https://github.com/user-attachments/assets/66ec5fd7-f4e5-422d-aebc-b4cb6000b6df

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32996](https://ledgerhq.atlassian.net/browse/LIVE-32996) [Figma](https://www.figma.com/design/JxaLVMTWirCpU0rsbZ30k7/2.-Components-Library?node-id=8804-3160&m=dev)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32996]: https://ledgerhq.atlassian.net/browse/LIVE-32996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ