### PR TITLE
ci: sign wallet-cli sync commits via GitHub API

### DIFF
--- a/.github/workflows/sync-wallet-cli-skill.yml
+++ b/.github/workflows/sync-wallet-cli-skill.yml
@@ -43,7 +43,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.GH_BOT_APP_ID }}
+          client-id: ${{ secrets.GH_BOT_CLIENT_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
           repositories: |
             ledger-live

--- a/.github/workflows/sync-wallet-cli-skill.yml
+++ b/.github/workflows/sync-wallet-cli-skill.yml
@@ -48,6 +48,19 @@ jobs:
           repositories: |
             ledger-live
             agent-skills
+          permission-contents: write
+          permission-pull-requests: write
+
+      # agent-skills is checked out at the workspace root because
+      # planetscale/ghcommit-action reads the working tree from $GITHUB_WORKSPACE.
+      # It is checked out first so the ledger-live checkout below can nest under
+      # it without being wiped by git clean.
+      - name: Checkout agent-skills
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          repository: ${{ env.TARGET_REPOSITORY }}
+          ref: ${{ env.TARGET_BASE }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Checkout ledger-live
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -55,21 +68,14 @@ jobs:
           ref: ${{ inputs.source_ref || github.sha }}
           token: ${{ steps.generate-token.outputs.token }}
           path: ledger-live
-
-      - name: Checkout agent-skills
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          repository: ${{ env.TARGET_REPOSITORY }}
-          ref: ${{ env.TARGET_BASE }}
-          token: ${{ steps.generate-token.outputs.token }}
-          path: agent-skills
+          persist-credentials: false
 
       - name: Export wallet-cli skill
         run: |
           set -euo pipefail
 
           source_skill_dir="$GITHUB_WORKSPACE/ledger-live/$SOURCE_SKILL_DIR"
-          target_skill_dir="$GITHUB_WORKSPACE/agent-skills/$TARGET_SKILL_DIR"
+          target_skill_dir="$GITHUB_WORKSPACE/$TARGET_SKILL_DIR"
 
           rm -rf "$target_skill_dir"
           mkdir -p "$target_skill_dir"
@@ -102,119 +108,49 @@ jobs:
             exit 1
           fi
 
-      # Commits are created through the GitHub API (not `git commit`) so that
-      # GitHub signs them server-side — agent-skills' `main` ruleset requires
-      # signed commits, which a local push from the bot token cannot satisfy.
-      #
-      # NOTE: $SYNC_BRANCH is fully managed and rewritten on every run. Do not
-      # commit to it directly — manual commits will be lost.
+      # ghcommit-action (below) commits the working tree through GitHub's API so
+      # the commit is signed server-side — agent-skills' `main` ruleset requires
+      # signed commits, which a push from the bot token cannot satisfy. The
+      # action only picks up staged changes, so stage the export here and skip
+      # the rest of the job (leaving any open sync PR untouched) when it is a
+      # no-op.
+      - name: Stage exported skill
+        id: stage
+        run: |
+          set -euo pipefail
+
+          git add -A -- "$TARGET_SKILL_DIR"
+          if git diff --cached --quiet -- "$TARGET_SKILL_DIR"; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No agent-skills changes to sync."
+            exit 0
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      # Reset the managed branch to the base tip so the single ghcommit-action
+      # commit lands on top (branch = base + one commit), matching the release
+      # workflows. NOTE: $SYNC_BRANCH is fully managed and rewritten on every
+      # run — do not commit to it directly, manual commits will be lost.
+      - name: Reset sync branch to base
+        if: steps.stage.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          git push --force origin "HEAD:refs/heads/$SYNC_BRANCH"
+
       - name: Create signed commit
         id: commit
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        if: steps.stage.outputs.changed == 'true'
+        uses: planetscale/ghcommit-action@c6125dee9e9c0daebc4adea9f68ead8293414174 # v0.2.9
         with:
-          github-token: ${{ steps.generate-token.outputs.token }}
-          script: |
-            const fs = require("fs");
-            const path = require("path");
-            const { execFileSync } = require("child_process");
-
-            const repoDir = "agent-skills";
-            const targetSkillDir = process.env.TARGET_SKILL_DIR;
-            const targetRepository = process.env.TARGET_REPOSITORY;
-            const [owner, repo] = targetRepository.split("/");
-            const syncBranch = process.env.SYNC_BRANCH;
-
-            const git = (args) =>
-              execFileSync("git", args, { cwd: repoDir, maxBuffer: 64 * 1024 * 1024 });
-
-            // Stage the exported skill so a single diff captures every addition,
-            // modification, and deletion under the target directory.
-            git(["add", "-A", "--", targetSkillDir]);
-
-            const statusZ = git([
-              "diff", "--cached", "--name-status", "-z", "--no-renames",
-            ]).toString("utf8");
-            const records = statusZ.split("\0").filter((entry) => entry.length > 0);
-
-            const additions = [];
-            const deletions = [];
-            for (let i = 0; i < records.length; i += 2) {
-              const status = records[i];
-              const filePath = records[i + 1];
-              if (status === undefined || filePath === undefined) {
-                throw new Error(
-                  `Unexpected git diff output (odd field count): ${JSON.stringify(records)}`,
-                );
-              }
-              if (status === "D") {
-                deletions.push({ path: filePath });
-              } else {
-                const contents = fs.readFileSync(path.join(repoDir, filePath)).toString("base64");
-                additions.push({ path: filePath, contents });
-              }
-            }
-
-            if (additions.length === 0 && deletions.length === 0) {
-              core.setOutput("changed", "false");
-              core.info("No agent-skills changes to sync.");
-              return;
-            }
-
-            const upsertBranchRef = async (branch, sha) => {
-              const ref = `heads/${branch}`;
-              try {
-                await github.rest.git.getRef({ owner, repo, ref });
-                await github.rest.git.updateRef({ owner, repo, ref, sha, force: true });
-              } catch (error) {
-                if (error.status !== 404) throw error;
-                await github.rest.git.createRef({ owner, repo, ref: `refs/${ref}`, sha });
-              }
-            };
-
-            // Parent the commit on the checked-out base tip — the same revision
-            // the staged diff was computed against — so the additions/deletions
-            // stay consistent with the commit base even if the remote base moves.
-            const baseSha = git(["rev-parse", "HEAD"]).toString("utf8").trim();
-
-            // Build the signed commit on a throwaway branch, then move the sync
-            // branch to it in a single update (old head -> new commit). Pointing
-            // the sync branch itself at the base tip first would briefly make its
-            // head an ancestor of the base, which auto-closes the open PR and
-            // leaves the next step creating a duplicate.
-            const buildBranch = `${syncBranch}-build`;
-            await upsertBranchRef(buildBranch, baseSha);
-
-            try {
-              const { createCommitOnBranch } = await github.graphql(
-                `mutation ($input: CreateCommitOnBranchInput!) {
-                  createCommitOnBranch(input: $input) { commit { oid } }
-                }`,
-                {
-                  input: {
-                    branch: {
-                      repositoryNameWithOwner: targetRepository,
-                      branchName: buildBranch,
-                    },
-                    expectedHeadOid: baseSha,
-                    message: { headline: "chore: sync wallet-cli skill" },
-                    fileChanges: { additions, deletions },
-                  },
-                },
-              );
-              await upsertBranchRef(syncBranch, createCommitOnBranch.commit.oid);
-            } finally {
-              await github.rest.git
-                .deleteRef({ owner, repo, ref: `heads/${buildBranch}` })
-                .catch((error) =>
-                  core.warning(`Could not delete build branch ${buildBranch}: ${error.message}`),
-                );
-            }
-
-            core.setOutput("changed", "true");
+          commit_message: "chore: sync wallet-cli skill"
+          repo: ${{ env.TARGET_REPOSITORY }}
+          branch: ${{ env.SYNC_BRANCH }}
+          file_pattern: ${{ env.TARGET_SKILL_DIR }}
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Open or update pull request
-        if: steps.commit.outputs.changed == 'true'
-        working-directory: agent-skills
+        if: steps.stage.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
@@ -228,7 +164,7 @@ jobs:
           EOF
           )
 
-          pr_number=$(gh pr list \
+          open_pr=$(gh pr list \
             --repo "$TARGET_REPOSITORY" \
             --head "$SYNC_BRANCH" \
             --base "$TARGET_BASE" \
@@ -236,10 +172,25 @@ jobs:
             --json number \
             --jq '.[0].number // empty')
 
-          if [ -n "$pr_number" ]; then
-            gh pr edit "$pr_number" \
-              --repo "$TARGET_REPOSITORY" \
-              --body "$body"
+          if [ -n "$open_pr" ]; then
+            gh pr edit "$open_pr" --repo "$TARGET_REPOSITORY" --body "$body"
+            exit 0
+          fi
+
+          # Resetting the branch to base momentarily leaves it with no commits
+          # ahead of base, which auto-closes an open sync PR. Reopen that PR
+          # instead of opening a duplicate.
+          closed_pr=$(gh pr list \
+            --repo "$TARGET_REPOSITORY" \
+            --head "$SYNC_BRANCH" \
+            --base "$TARGET_BASE" \
+            --state closed \
+            --json number,state \
+            --jq 'map(select(.state == "CLOSED")) | .[0].number // empty')
+
+          if [ -n "$closed_pr" ]; then
+            gh pr reopen "$closed_pr" --repo "$TARGET_REPOSITORY"
+            gh pr edit "$closed_pr" --repo "$TARGET_REPOSITORY" --body "$body"
           else
             gh pr create \
               --repo "$TARGET_REPOSITORY" \

--- a/.github/workflows/sync-wallet-cli-skill.yml
+++ b/.github/workflows/sync-wallet-cli-skill.yml
@@ -108,12 +108,11 @@ jobs:
             exit 1
           fi
 
-      # ghcommit-action (below) commits the working tree through GitHub's API so
-      # the commit is signed server-side — agent-skills' `main` ruleset requires
-      # signed commits, which a push from the bot token cannot satisfy. The
-      # action only picks up staged changes, so stage the export here and skip
-      # the rest of the job (leaving any open sync PR untouched) when it is a
-      # no-op.
+      # ghcommit-action (below) creates the commit through GitHub's API so it is
+      # signed server-side — agent-skills' `main` ruleset requires signed commits.
+      # Stage the export first: the action skips untracked files, so new skill
+      # files must be in the index to be committed; the staged diff also drives
+      # the no-op check that leaves any open sync PR untouched.
       - name: Stage exported skill
         id: stage
         run: |
@@ -135,7 +134,13 @@ jobs:
         if: steps.stage.outputs.changed == 'true'
         run: |
           set -euo pipefail
-          git push --force origin "HEAD:refs/heads/$SYNC_BRANCH"
+
+          remote_sha=$(git ls-remote --heads origin "$SYNC_BRANCH" | awk '{print $1}')
+          if [ -n "$remote_sha" ]; then
+            git push --force-with-lease="refs/heads/$SYNC_BRANCH:$remote_sha" origin "HEAD:refs/heads/$SYNC_BRANCH"
+          else
+            git push origin "HEAD:refs/heads/$SYNC_BRANCH"
+          fi
 
       - name: Create signed commit
         id: commit

--- a/.github/workflows/sync-wallet-cli-skill.yml
+++ b/.github/workflows/sync-wallet-cli-skill.yml
@@ -106,9 +106,8 @@ jobs:
       # GitHub signs them server-side — agent-skills' `main` ruleset requires
       # signed commits, which a local push from the bot token cannot satisfy.
       #
-      # NOTE: $SYNC_BRANCH is fully managed by this workflow: it is reset to the
-      # base branch tip and rewritten on every run. Do not commit to it
-      # directly — manual commits will be lost.
+      # NOTE: $SYNC_BRANCH is fully managed and rewritten on every run. Do not
+      # commit to it directly — manual commits will be lost.
       - name: Create signed commit
         id: commit
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -123,7 +122,6 @@ jobs:
             const targetSkillDir = process.env.TARGET_SKILL_DIR;
             const targetRepository = process.env.TARGET_REPOSITORY;
             const [owner, repo] = targetRepository.split("/");
-            const baseBranch = process.env.TARGET_BASE;
             const syncBranch = process.env.SYNC_BRANCH;
 
             const git = (args) =>
@@ -143,6 +141,11 @@ jobs:
             for (let i = 0; i < records.length; i += 2) {
               const status = records[i];
               const filePath = records[i + 1];
+              if (status === undefined || filePath === undefined) {
+                throw new Error(
+                  `Unexpected git diff output (odd field count): ${JSON.stringify(records)}`,
+                );
+              }
               if (status === "D") {
                 deletions.push({ path: filePath });
               } else {
@@ -168,9 +171,10 @@ jobs:
               }
             };
 
-            const baseSha = (
-              await github.rest.repos.getBranch({ owner, repo, branch: baseBranch })
-            ).data.commit.sha;
+            // Parent the commit on the checked-out base tip — the same revision
+            // the staged diff was computed against — so the additions/deletions
+            // stay consistent with the commit base even if the remote base moves.
+            const baseSha = git(["rev-parse", "HEAD"]).toString("utf8").trim();
 
             // Build the signed commit on a throwaway branch, then move the sync
             // branch to it in a single update (old head -> new commit). Pointing

--- a/.github/workflows/sync-wallet-cli-skill.yml
+++ b/.github/workflows/sync-wallet-cli-skill.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # 2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
@@ -157,37 +157,54 @@ jobs:
               return;
             }
 
-            // Reset the managed sync branch to the base tip, then add exactly one
-            // commit on top of it (mirrors the previous force-push semantics).
+            const upsertBranchRef = async (branch, sha) => {
+              const ref = `heads/${branch}`;
+              try {
+                await github.rest.git.getRef({ owner, repo, ref });
+                await github.rest.git.updateRef({ owner, repo, ref, sha, force: true });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.git.createRef({ owner, repo, ref: `refs/${ref}`, sha });
+              }
+            };
+
             const baseSha = (
               await github.rest.repos.getBranch({ owner, repo, branch: baseBranch })
             ).data.commit.sha;
 
-            const ref = `heads/${syncBranch}`;
-            try {
-              await github.rest.git.getRef({ owner, repo, ref });
-              await github.rest.git.updateRef({ owner, repo, ref, sha: baseSha, force: true });
-            } catch (error) {
-              if (error.status !== 404) throw error;
-              await github.rest.git.createRef({ owner, repo, ref: `refs/${ref}`, sha: baseSha });
-            }
+            // Build the signed commit on a throwaway branch, then move the sync
+            // branch to it in a single update (old head -> new commit). Pointing
+            // the sync branch itself at the base tip first would briefly make its
+            // head an ancestor of the base, which auto-closes the open PR and
+            // leaves the next step creating a duplicate.
+            const buildBranch = `${syncBranch}-build`;
+            await upsertBranchRef(buildBranch, baseSha);
 
-            await github.graphql(
-              `mutation ($input: CreateCommitOnBranchInput!) {
-                createCommitOnBranch(input: $input) { commit { oid } }
-              }`,
-              {
-                input: {
-                  branch: {
-                    repositoryNameWithOwner: targetRepository,
-                    branchName: syncBranch,
+            try {
+              const { createCommitOnBranch } = await github.graphql(
+                `mutation ($input: CreateCommitOnBranchInput!) {
+                  createCommitOnBranch(input: $input) { commit { oid } }
+                }`,
+                {
+                  input: {
+                    branch: {
+                      repositoryNameWithOwner: targetRepository,
+                      branchName: buildBranch,
+                    },
+                    expectedHeadOid: baseSha,
+                    message: { headline: "chore: sync wallet-cli skill" },
+                    fileChanges: { additions, deletions },
                   },
-                  expectedHeadOid: baseSha,
-                  message: { headline: "chore: sync wallet-cli skill" },
-                  fileChanges: { additions, deletions },
                 },
-              },
-            );
+              );
+              await upsertBranchRef(syncBranch, createCommitOnBranch.commit.oid);
+            } finally {
+              await github.rest.git
+                .deleteRef({ owner, repo, ref: `heads/${buildBranch}` })
+                .catch((error) =>
+                  core.warning(`Could not delete build branch ${buildBranch}: ${error.message}`),
+                );
+            }
 
             core.setOutput("changed", "true");
 

--- a/.github/workflows/sync-wallet-cli-skill.yml
+++ b/.github/workflows/sync-wallet-cli-skill.yml
@@ -102,35 +102,94 @@ jobs:
             exit 1
           fi
 
-      - name: Commit and push changes
+      # Commits are created through the GitHub API (not `git commit`) so that
+      # GitHub signs them server-side — agent-skills' `main` ruleset requires
+      # signed commits, which a local push from the bot token cannot satisfy.
+      #
+      # NOTE: $SYNC_BRANCH is fully managed by this workflow: it is reset to the
+      # base branch tip and rewritten on every run. Do not commit to it
+      # directly — manual commits will be lost.
+      - name: Create signed commit
         id: commit
-        working-directory: agent-skills
-        run: |
-          set -euo pipefail
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+            const { execFileSync } = require("child_process");
 
-          # NOTE: $SYNC_BRANCH is fully managed by this workflow and force-pushed on every run.
-          # Do not commit to it directly — manual commits will be lost.
-          git checkout -B "$SYNC_BRANCH"
-          git add "$TARGET_SKILL_DIR"
+            const repoDir = "agent-skills";
+            const targetSkillDir = process.env.TARGET_SKILL_DIR;
+            const targetRepository = process.env.TARGET_REPOSITORY;
+            const [owner, repo] = targetRepository.split("/");
+            const baseBranch = process.env.TARGET_BASE;
+            const syncBranch = process.env.SYNC_BRANCH;
 
-          if git diff --cached --quiet; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No agent-skills changes to sync."
-            exit 0
-          fi
+            const git = (args) =>
+              execFileSync("git", args, { cwd: repoDir, maxBuffer: 64 * 1024 * 1024 });
 
-          git config user.name "ledgerlive-bot"
-          git config user.email "ledgerlive-bot@ledger.fr"
-          git commit -m "chore: sync wallet-cli skill"
+            // Stage the exported skill so a single diff captures every addition,
+            // modification, and deletion under the target directory.
+            git(["add", "-A", "--", targetSkillDir]);
 
-          remote_sha=$(git ls-remote --heads origin "$SYNC_BRANCH" | awk '{print $1}')
-          if [ -n "$remote_sha" ]; then
-            git push --force-with-lease="refs/heads/$SYNC_BRANCH:$remote_sha" origin "HEAD:$SYNC_BRANCH"
-          else
-            git push origin "HEAD:$SYNC_BRANCH"
-          fi
+            const statusZ = git([
+              "diff", "--cached", "--name-status", "-z", "--no-renames",
+            ]).toString("utf8");
+            const records = statusZ.split("\0").filter((entry) => entry.length > 0);
 
-          echo "changed=true" >> "$GITHUB_OUTPUT"
+            const additions = [];
+            const deletions = [];
+            for (let i = 0; i < records.length; i += 2) {
+              const status = records[i];
+              const filePath = records[i + 1];
+              if (status === "D") {
+                deletions.push({ path: filePath });
+              } else {
+                const contents = fs.readFileSync(path.join(repoDir, filePath)).toString("base64");
+                additions.push({ path: filePath, contents });
+              }
+            }
+
+            if (additions.length === 0 && deletions.length === 0) {
+              core.setOutput("changed", "false");
+              core.info("No agent-skills changes to sync.");
+              return;
+            }
+
+            // Reset the managed sync branch to the base tip, then add exactly one
+            // commit on top of it (mirrors the previous force-push semantics).
+            const baseSha = (
+              await github.rest.repos.getBranch({ owner, repo, branch: baseBranch })
+            ).data.commit.sha;
+
+            const ref = `heads/${syncBranch}`;
+            try {
+              await github.rest.git.getRef({ owner, repo, ref });
+              await github.rest.git.updateRef({ owner, repo, ref, sha: baseSha, force: true });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              await github.rest.git.createRef({ owner, repo, ref: `refs/${ref}`, sha: baseSha });
+            }
+
+            await github.graphql(
+              `mutation ($input: CreateCommitOnBranchInput!) {
+                createCommitOnBranch(input: $input) { commit { oid } }
+              }`,
+              {
+                input: {
+                  branch: {
+                    repositoryNameWithOwner: targetRepository,
+                    branchName: syncBranch,
+                  },
+                  expectedHeadOid: baseSha,
+                  message: { headline: "chore: sync wallet-cli skill" },
+                  fileChanges: { additions, deletions },
+                },
+              },
+            );
+
+            core.setOutput("changed", "true");
 
       - name: Open or update pull request
         if: steps.commit.outputs.changed == 'true'


### PR DESCRIPTION
## What

The `[Wallet CLI] - Sync Skill - Push` workflow created its sync commit with a
local `git commit` and pushed it over the bot token. Commits made that way are
unsigned — see the `chore: sync wallet-cli skill` commit on
[agent-skills#16](https://github.com/LedgerHQ/agent-skills/pull/16), which shows
as Unverified. The `agent-skills` `main` branch has an active ruleset that
requires signed commits.

## Change

Replaces the "Commit and push changes" step with `planetscale/ghcommit-action`,
the same action the release workflows use (e.g. `release-create.yml`). It builds
the commit through GitHub's `createCommitOnBranch` API, which signs it
server-side, so it verifies.

The action reads the working tree from `$GITHUB_WORKSPACE` and commits only
staged changes, so the surrounding steps are arranged to match:

- **agent-skills is checked out at the workspace root** (ledger-live is nested
  under it). `file_pattern` scopes the commit to the skill directory, so the
  nested ledger-live checkout is never picked up. agent-skills is checked out
  first so the ledger-live checkout is not wiped by `git clean`.
- **The export is staged** (`git add`) before committing, and the step exits
  early with `changed=false` when the export is a no-op, leaving any open sync
  PR untouched.
- **The `sync/wallet-cli-skill` branch is reset to the base tip** before the
  commit, so the single signed commit lands on top — preserving the previous
  force-push semantics (branch = base + one commit).

Resetting the branch to base momentarily leaves it with no commits ahead of
base, which auto-closes an open sync PR. The "Open or update pull request" step
reopens that PR instead of opening a duplicate.

Also in this change:

- The bot app token is scoped to `contents: write` and `pull-requests: write`
  instead of inheriting the app's full installation permissions.
- The read-only ledger-live checkout sets `persist-credentials: false`.

## Note

API-created commits are attributed to the App's bot identity
(`ledgerlive-bot[bot]`) rather than the `ledgerlive-bot@ledger.fr` author the
old `git config` set. That is inherent to GitHub-signed API commits.

## Validation

- `actionlint` parses the workflow cleanly (the one pre-existing SC2016 in the
  unrelated Export step's `sed` is untouched).
- `zizmor` is clean apart from one `artipacked` finding on the agent-skills
  checkout, which is required — the branch-reset step runs `git push` from it
  (the same trade-off as the release workflows).
- Not run end-to-end locally (needs the bot App secrets and CI). Best verified
  with a `workflow_dispatch` run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
