### PR TITLE
chore(codeowners): add desktop device ownership paths

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -266,6 +266,8 @@ libs/ledger-live-common/src/customImage/                            @ledgerhq/li
 apps/**/components/DeviceAction/                                   @ledgerhq/live-devices
 apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/     @ledgerhq/live-devices
 apps/ledger-live-mobile/src/mvvm/components/DeviceActionContent/   @ledgerhq/live-devices
+apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/ @ledgerhq/live-devices
+apps/ledger-live-desktop/src/mvvm/components/DeviceActionContent/  @ledgerhq/live-devices
 apps/ledger-live-mobile/src/components/ValidateMessageOnDevice.tsx @ledgerhq/live-devices
 apps/ledger-live-mobile/android/**/LocationHelperModule.kt         @ledgerhq/live-devices
 apps/ledger-live-mobile/src/components/RequiresBLE/                @ledgerhq/live-devices
@@ -279,6 +281,8 @@ apps/ledger-live-mobile/src/transport/                             @ledgerhq/liv
 apps/ledger-live-mobile/src/react-native-hw-transport-ble/         @ledgerhq/live-devices
 apps/ledger-live-mobile/src/screens/FirmwareUpdate/                @ledgerhq/live-devices
 apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/ @ledgerhq/live-devices
+apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceIntentExecutorDevTool/ @ledgerhq/live-devices
+apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceActionContentDevTool/  @ledgerhq/live-devices
 apps/ledger-live-mobile/src/screens/MyLedger*/             	       @ledgerhq/live-devices
 apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/       @ledgerhq/live-devices
 apps/ledger-live-mobile/ios/BluetoothHelperModule.swift            @ledgerhq/live-devices


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not needed: CODEOWNERS-only change with no package release impact._
- [ ] **Covered by automatic tests.** _Not applicable: ownership metadata only; code checks intentionally skipped._
- [x] **Impact of the changes:**
  - Future Ledger Wallet Desktop `DeviceIntentExecutor` ownership
  - Future Ledger Wallet Desktop `DeviceActionContent` ownership
  - Future Developer settings debug tools for both components

### 📝 Description

This PR adds future Ledger Wallet Desktop device component paths to the Devices team CODEOWNERS scope before the components are introduced.

We will work on new `DeviceIntentExecutor` and `DeviceActionContent` components that belong in the Devices team scope. Doing this early ensures future PRs request review from the correct team as soon as those paths are created, including the matching Developer settings debug tools.

No code checks were run for this PR because it only changes CODEOWNERS metadata.

### ❓ Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)