### PR TITLE
[LWDM] fix(transport): transport device id model assign

### DIFF
--- a/.changeset/speculos-explicit-device-model.md
+++ b/.changeset/speculos-explicit-device-model.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-dmk-speculos": minor
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Allow passing an explicit device model to the Speculos DMK transport. The underlying transport cannot infer the emulated device and defaults to Stax, so the e2e setups now forward the real model (e.g. nanoX) when opening the transport.

--- a/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
+++ b/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
@@ -15,6 +15,8 @@ import type { State } from "~/renderer/reducers";
 import { setDeviceMode } from "@ledgerhq/live-common/hw/actions/app";
 import { DeviceManagementKitTransport } from "@ledgerhq/live-dmk-desktop";
 import { DeviceManagementKitTransportSpeculos } from "@ledgerhq/live-dmk-speculos";
+import { ledgerToDmkDeviceIdMap } from "@ledgerhq/live-dmk-shared";
+import { DeviceModelId } from "@ledgerhq/types-devices";
 import IPCTransport from "./IPCTransport";
 
 enum RendererTransportModule {
@@ -22,6 +24,22 @@ enum RendererTransportModule {
   DeviceManagementKitSpeculos,
   IPC,
   Vault,
+}
+
+// Speculos cannot tell the DMK transport which device it emulates (it defaults
+// to Stax), so we map the SPECULOS_DEVICE name set by the e2e setup to the model.
+const SPECULOS_DEVICE_TO_MODEL: Record<string, DeviceModelId> = {
+  nanoS: DeviceModelId.nanoS,
+  nanoSP: DeviceModelId.nanoSP,
+  nanoX: DeviceModelId.nanoX,
+  stax: DeviceModelId.stax,
+  flex: DeviceModelId.europa,
+  nanoGen5: DeviceModelId.apex,
+};
+
+function getSpeculosDmkModel() {
+  const model = SPECULOS_DEVICE_TO_MODEL[getEnv("SPECULOS_DEVICE")];
+  return model ? ledgerToDmkDeviceIdMap[model] : undefined;
 }
 
 /**
@@ -103,6 +121,7 @@ export function registerTransportModules(store: Store<State>) {
           DeviceManagementKitTransportSpeculos.open({
             apiPort: speculosApiPort ? String(speculosApiPort) : undefined,
             timeout: timeoutMs,
+            model: getSpeculosDmkModel(),
           }),
         {
           interval: 500,

--- a/apps/ledger-live-mobile/e2e/bridge/client.ts
+++ b/apps/ledger-live-mobile/e2e/bridge/client.ts
@@ -24,6 +24,7 @@ import Config from "react-native-config";
 import type { FeatureId, Feature, PartialFeatures } from "@shared/feature-flags";
 import { bleDevicesSelector } from "~/reducers/ble";
 import { DeviceManagementKitTransportSpeculos } from "@ledgerhq/live-dmk-speculos";
+import { setSpeculosDeviceModel } from "~/services/registerTransports";
 
 export const e2eBridgeClient = new Subject<MessageData>();
 
@@ -162,6 +163,7 @@ async function onMessage(event: WebSocketMessageEvent) {
       }
       case "addKnownSpeculos": {
         const { address, model } = JSON.parse(msg.payload);
+        setSpeculosDeviceModel(model);
         await disconnectAllSpeculosSessions();
         const knownSpeculosIds = bleDevicesSelector(store.getState())
           .map(device => device.id)
@@ -189,6 +191,7 @@ async function onMessage(event: WebSocketMessageEvent) {
       }
       case "removeKnownSpeculos": {
         const address = msg.payload;
+        setSpeculosDeviceModel(undefined);
         await disconnectAllSpeculosSessions();
         store.dispatch(removeKnownBleDevice(`speculos|${address}`));
         setEnv("DEVICE_PROXY_URL", "");

--- a/apps/ledger-live-mobile/src/services/registerTransports.ts
+++ b/apps/ledger-live-mobile/src/services/registerTransports.ts
@@ -12,9 +12,19 @@ import {
   DeviceManagementKitHTTPProxyTransport,
 } from "@ledgerhq/live-dmk-mobile";
 import { DeviceManagementKitTransportSpeculos } from "@ledgerhq/live-dmk-speculos";
+import { ledgerToDmkDeviceIdMap } from "@ledgerhq/live-dmk-shared";
 import { retry } from "@ledgerhq/live-common/promise";
 
 const SPECULOS_PREFIX = "speculos|";
+
+// Speculos cannot tell the DMK transport which device it emulates (it defaults
+// to Stax). The e2e bridge sends the real model via `setSpeculosDeviceModel`,
+// which we then forward when opening the transport so the app behaves like it.
+let speculosDeviceModel: DeviceModelId | undefined;
+
+export function setSpeculosDeviceModel(model?: DeviceModelId) {
+  speculosDeviceModel = model;
+}
 
 /**
  * Registers transport modules for different connection types (BLE, HID, HTTP Debug, Speculos).
@@ -43,7 +53,8 @@ export const registerTransports = () => {
       open: id => {
         if (!id.startsWith(SPECULOS_PREFIX)) return null;
         const baseURL = id.slice(SPECULOS_PREFIX.length);
-        return retry(() => DeviceManagementKitTransportSpeculos.open({ baseURL }));
+        const model = speculosDeviceModel ? ledgerToDmkDeviceIdMap[speculosDeviceModel] : undefined;
+        return retry(() => DeviceManagementKitTransportSpeculos.open({ baseURL, model }));
       },
       disconnect: id => (id.startsWith(SPECULOS_PREFIX) ? Promise.resolve() : null),
     });

--- a/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.ts
+++ b/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.ts
@@ -5,6 +5,7 @@ import { filter, timeout as rxTimeout } from "rxjs/operators";
 import {
   DeviceManagementKitBuilder,
   DeviceManagementKit,
+  DeviceModelId,
   type DiscoveredDevice,
 } from "@ledgerhq/device-management-kit";
 import {
@@ -19,6 +20,12 @@ export type SpeculosHttpTransportOpts = {
   apiPort?: string;
   timeout?: number;
   baseURL?: string;
+  /**
+   * Device model emulated by Speculos. The underlying DMK Speculos transport
+   * cannot infer it and defaults to {@link DeviceModelId.STAX}, so tests must
+   * pass it explicitly (e.g. nanoX) for the app to behave like the right model.
+   */
+  model?: DeviceModelId;
 };
 
 export enum SpeculosButton {
@@ -139,11 +146,15 @@ export default class SpeculosHttpTransport extends Transport {
     return resolvedBaseUrl;
   }
 
-  private static ensureEntry(baseUrl: string, connectionTimeoutMs: number): DmkEntry {
+  private static ensureEntry(
+    baseUrl: string,
+    connectionTimeoutMs: number,
+    model?: DeviceModelId,
+  ): DmkEntry {
     let deviceManagementEntry = this.byBase.get(baseUrl);
     if (!deviceManagementEntry) {
       const deviceManagementKit = new DeviceManagementKitBuilder()
-        .addTransport(speculosTransportFactory(baseUrl, true))
+        .addTransport(speculosTransportFactory(baseUrl, true, model))
         .build();
 
       deviceManagementEntry = {
@@ -201,7 +212,7 @@ export default class SpeculosHttpTransport extends Transport {
   static async open(options: SpeculosHttpTransportOpts = {}): Promise<SpeculosHttpTransport> {
     const baseUrl = this.resolveBaseFromEnv(options);
     const connectTimeoutMs = options.timeout ?? 10_000;
-    const entry = this.ensureEntry(baseUrl, connectTimeoutMs);
+    const entry = this.ensureEntry(baseUrl, connectTimeoutMs, options.model);
 
     await this.ensureSession(entry);
 
@@ -249,6 +260,7 @@ export default class SpeculosHttpTransport extends Transport {
       const deviceManagementEntry = SpeculosHttpTransport.ensureEntry(
         this.baseUrl,
         this.options.timeout ?? 10_000,
+        this.options.model,
       );
       deviceManagementEntry.sessionId = undefined;
       await SpeculosHttpTransport.ensureSession(deviceManagementEntry);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Allow passing an explicit device model to the Speculos DMK transport. The underlying transport cannot infer the emulated device and defaults to Stax, so the e2e setups now forward the real model (e.g. nanoX) when opening the transport.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
