### PR TITLE
[LWM] fix(mobile): fix privacy policy render error

### DIFF
--- a/.changeset/calm-links-wrap.md
+++ b/.changeset/calm-links-wrap.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix analytics consent privacy policy footer link wrapping with inline Trans markup

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8992,8 +8992,7 @@
     "setPreferencesCTA": "Set preferences",
     "refuseCTA": "Refuse all",
     "acceptCTA": "Accept all",
-    "privacyPolicy": "You can revoke your consent anytime in settings.",
-    "privacyPolicyCTA": "Privacy policy",
+    "privacyPolicy": "You can revoke your consent anytime in settings. <PrivacyPolicy>Privacy policy</PrivacyPolicy>",
     "setPreferences": {
       "title": "Set preferences",
       "performance": "App performance",

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsent/components/PrivacyPolicyLink.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsent/components/PrivacyPolicyLink.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { StyleSheet, Text as RNText } from "react-native";
 import { Trans } from "~/context/Locale";
 import { Text } from "@ledgerhq/lumen-ui-rnative";
 
@@ -14,18 +13,17 @@ const PrivacyPolicyLink = ({ onPrivacyPolicyPress }: PrivacyPolicyLinkProps) => 
         i18nKey="analyticsConsent.privacyPolicy"
         components={{
           PrivacyPolicy: (
-            <RNText style={styles.link} onPress={onPrivacyPolicyPress} accessibilityRole="link" />
+            <Text
+              typography="body3"
+              onPress={onPrivacyPolicyPress}
+              accessibilityRole="link"
+              style={{ textDecorationLine: "underline" }}
+            />
           ),
         }}
       />
     </Text>
   );
 };
-
-const styles = StyleSheet.create({
-  link: {
-    textDecorationLine: "underline",
-  },
-});
 
 export default PrivacyPolicyLink;

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsent/components/PrivacyPolicyLink.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsent/components/PrivacyPolicyLink.tsx
@@ -1,37 +1,31 @@
 import React from "react";
-import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
-import { useTranslation } from "~/context/Locale";
+import { StyleSheet, Text as RNText } from "react-native";
+import { Trans } from "~/context/Locale";
+import { Text } from "@ledgerhq/lumen-ui-rnative";
 
 interface PrivacyPolicyLinkProps {
   onPrivacyPolicyPress: () => void;
 }
 
 const PrivacyPolicyLink = ({ onPrivacyPolicyPress }: PrivacyPolicyLinkProps) => {
-  const { t } = useTranslation();
-
   return (
-    <Box
-      lx={{
-        flexDirection: "row",
-        flexWrap: "wrap",
-        justifyContent: "center",
-        alignItems: "center",
-      }}
-    >
-      <Text typography="body3" lx={{ color: "muted" }}>
-        {t("analyticsConsent.privacyPolicy")}{" "}
-      </Text>
-      <Text
-        typography="body3"
-        lx={{ color: "base" }}
-        style={{ textDecorationLine: "underline" }}
-        onPress={onPrivacyPolicyPress}
-        accessibilityRole="link"
-      >
-        {t("analyticsConsent.privacyPolicyCTA")}
-      </Text>
-    </Box>
+    <Text typography="body3" lx={{ color: "muted", textAlign: "center" }}>
+      <Trans
+        i18nKey="analyticsConsent.privacyPolicy"
+        components={{
+          PrivacyPolicy: (
+            <RNText style={styles.link} onPress={onPrivacyPolicyPress} accessibilityRole="link" />
+          ),
+        }}
+      />
+    </Text>
   );
 };
+
+const styles = StyleSheet.create({
+  link: {
+    textDecorationLine: "underline",
+  },
+});
 
 export default PrivacyPolicyLink;

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsent/components/__tests__/PrivacyPolicyLink.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsent/components/__tests__/PrivacyPolicyLink.test.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import PrivacyPolicyLink from "../PrivacyPolicyLink";
+
+describe("PrivacyPolicyLink", () => {
+  it("should render the privacy policy disclaimer with an inline link", () => {
+    render(<PrivacyPolicyLink onPrivacyPolicyPress={jest.fn()} />);
+
+    expect(screen.getByText(/You can revoke your consent anytime in settings\./)).toBeVisible();
+    expect(screen.getByRole("link", { name: "Privacy policy" })).toBeVisible();
+  });
+
+  it("should call onPrivacyPolicyPress when the privacy policy link is pressed", async () => {
+    const onPrivacyPolicyPress = jest.fn();
+    const { user } = render(<PrivacyPolicyLink onPrivacyPolicyPress={onPrivacyPolicyPress} />);
+
+    await user.press(screen.getByRole("link", { name: "Privacy policy" }));
+
+    expect(onPrivacyPolicyPress).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### ✅ Checklist
- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Analytics consent screen footer (main + Set preferences)
  - Privacy policy link text wrapping on narrow screens
  - Privacy policy link tap / URL open behavior
### 📝 Description
**Problem:** On the analytics consent screen, the privacy policy footer used two separate `Text` nodes in a flex row. On small screens the disclaimer and link did not wrap correctly, breaking layout and readability ([LIVE-33005](https://ledgerhq.atlassian.net/browse/LIVE-33005)).
**Solution:** Aligned with the Welcome footer pattern — a single `Trans` block with an inline `<PrivacyPolicy>` pressable link inside one parent `Text`. Updated `analyticsConsent.privacyPolicy` copy in **en** and **fr** to embed the link tag; remaining locales will be handled by the localization team.

<img width="1080" height="2400" alt="Screenshot_20260623-160149" src="https://github.com/user-attachments/assets/ddfdf81d-07aa-480f-8c48-6d14b343635a" />


### ❓ Context
- **JIRA or GitHub link**: [LIVE-33005](https://ledgerhq.atlassian.net/browse/LIVE-33005)
---
### 🧐 Checklist for the PR Reviewers
- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33005]: https://ledgerhq.atlassian.net/browse/LIVE-33005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-33005]: https://ledgerhq.atlassian.net/browse/LIVE-33005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ