### PR TITLE
chore(codeowners): own domain/ and features/ under platform team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,10 +34,10 @@ apps/ledger-live-desktop/tools/                          @ledgerhq/platform
 apps/ledger-live-desktop/scripts/                        @ledgerhq/platform
 
 # Platform — domain
-domain/entity/unit                                       @ledgerhq/platform
-domain/entity/crypto-currency                            @ledgerhq/platform
-domain/entity/crypto-asset                               @ledgerhq/platform
-domain/api/crypto-assets                                 @ledgerhq/platform
+/domain/                                                 @ledgerhq/platform
+
+# Platform — features
+/features/                                               @ledgerhq/platform
 
 # Platform — shared
 shared/feature-flags                                     @ledgerhq/platform


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached. <!-- N/A — CODEOWNERS is not a published package, no changeset needed. -->
- [x] **Covered by automatic tests.** <!-- N/A — GitHub validates CODEOWNERS syntax/ownership on push. -->
- [ ] **Impact of the changes:** Ownership only; no runtime/code impact. QA: none required.
  - PR review routing for the `domain/` and `features/` trees now goes to `@ledgerhq/platform`.

### 📝 Description

Give the **platform** team ownership of the top-level `domain/` and `features/` directories in `CODEOWNERS`.

- Consolidates the four redundant `domain/entity/*` and `domain/api/*` entries (all already `@ledgerhq/platform`) into a single root-anchored `/domain/` catch-all.
- Adds `/features/` under a new `# Platform — features` section.

Both patterns use a **leading slash** so they only match the repo-root directories. A bare `domain/` / `features/` pattern would match nested directories anywhere (e.g. `apps/ledger-live-desktop/src/mvvm/features/`, `libs/ledger-live-common/src/domain/`) and clobber their existing ownership.

```diff
 # Platform — domain
-domain/entity/unit                                       @ledgerhq/platform
-domain/entity/crypto-currency                            @ledgerhq/platform
-domain/entity/crypto-asset                               @ledgerhq/platform
-domain/api/crypto-assets                                 @ledgerhq/platform
+/domain/                                                 @ledgerhq/platform
+
+# Platform — features
+/features/                                               @ledgerhq/platform
```

### ❓ Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A
