### PR TITLE
[LWD] fix(lld): gate main-process Sentry on lldDatadog feature flag

### DIFF
--- a/.changeset/lld-datadog-main-process-gating.md
+++ b/.changeset/lld-datadog-main-process-gating.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Make the `lldDatadog` feature flag an exclusive (XOR) switch between Datadog and Sentry crash monitoring for A/B testing. When the flag is on, telemetry goes to Datadog (renderer only) and Sentry is muted; when off, Sentry stays on. The flag is resolved only in the renderer, so it is mirrored to the main process over IPC to also mute the main-process Sentry. Both backends remain gated by the user's "Bug reports" opt-in (`sentryLogs`).

--- a/apps/ledger-live-desktop/src/main/index.ts
+++ b/apps/ledger-live-desktop/src/main/index.ts
@@ -116,9 +116,20 @@ app.on("ready", async () => {
   const user = (await db.getKey("app", "user")) as { id?: string } | undefined;
   console.timeEnd("T-db");
   const userId = identities?.userId ?? user?.id;
+  // lldDatadog is resolved only in the renderer (Firebase) and acts as an XOR switch between the two
+  // crash-monitoring backends for A/B testing: when the flag is on, telemetry goes to Datadog (renderer
+  // only) and Sentry is muted; when off, Sentry stays active. Both stay gated by the sentryLogs opt-in.
+  // The renderer reports the flag over the lldDatadogChanged IPC; until then it is false, so Sentry is
+  // the active backend during startup.
+  let lldDatadogEnabled = false;
   if (userId) {
-    sentry(() => settings?.sentryLogs, userId);
+    sentry(() => settings?.sentryLogs === true && !lldDatadogEnabled, userId);
   }
+  // The main process can't resolve the flag itself, so the renderer mirrors it over IPC; this mutes the
+  // main-process Sentry once the flag resolves. Datadog has no main-process integration (renderer only).
+  ipcMain.on("lldDatadogChanged", (_event, enabled: boolean) => {
+    lldDatadogEnabled = enabled === true;
+  });
 
   // Set up transport handlers for Speculos and HTTP proxy in main process
   setupTransportHandlers();

--- a/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToDatadog.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToDatadog.test.tsx
@@ -1,6 +1,9 @@
 import React from "react";
+import { ipcRenderer } from "electron";
 import { render, withFlagOverrides } from "tests/testSetup";
 import { ConnectEnvsToDatadog } from "./ConnectEnvsToDatadog";
+
+const ipcSend = jest.mocked(ipcRenderer.send);
 
 jest.mock("~/datadog/renderer", () => ({
   initDatadog: jest.fn().mockResolvedValue(true),
@@ -87,5 +90,25 @@ describe("ConnectEnvsToDatadog", () => {
     expect(shouldSend()).toBe(true);
     store.dispatch({ type: "SAVE_SETTINGS", payload: { sentryLogs: false } });
     expect(shouldSend()).toBe(false);
+  });
+
+  it("mirrors lldDatadog.enabled to the main process over IPC, regardless of sentryLogs", () => {
+    render(<ConnectEnvsToDatadog />, {
+      initialState: {
+        ...withFlagOverrides({ lldDatadog: { enabled: true, params: {} } }),
+        settings: { sentryLogs: false },
+      },
+    });
+    expect(ipcSend).toHaveBeenCalledWith("lldDatadogChanged", true);
+  });
+
+  it("reports the flag as disabled when lldDatadog is off", () => {
+    render(<ConnectEnvsToDatadog />, {
+      initialState: {
+        ...withFlagOverrides({ lldDatadog: { enabled: false, params: {} } }),
+        settings: { sentryLogs: true },
+      },
+    });
+    expect(ipcSend).toHaveBeenCalledWith("lldDatadogChanged", false);
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToDatadog.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToDatadog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { ipcRenderer } from "electron";
 import { useSelector, useStore } from "LLD/hooks/redux";
 import { EnvName, getEnv } from "@ledgerhq/live-env";
 import {
@@ -41,6 +42,12 @@ export const ConnectEnvsToDatadog = () => {
   const lldDatadog = isLldDatadogFeature(rawLldDatadog) ? rawLldDatadog : null;
   const [datadogInitialized, setDatadogInitialized] = useState(false);
   const initInFlightRef = useRef(false);
+
+  // The main process can't resolve the lldDatadog flag itself, so mirror it over IPC; the main
+  // process uses this signal to mute its own Sentry when Datadog is the active backend.
+  useEffect(() => {
+    ipcRenderer.send("lldDatadogChanged", lldDatadog?.enabled === true);
+  }, [lldDatadog?.enabled]);
 
   useEffect(() => {
     if (!lldDatadog?.enabled || !sentryLogs || !isDatadogAvailable() || datadogInitialized) return;

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -180,7 +180,15 @@ async function init() {
   }
   // Initialize identities before Sentry so Sentry user id (datadogId) is set correctly
   await initIdentities(store);
-  sentry(() => sentryLogsSelector(store.getState()), store);
+  // lldDatadog XOR-switches the crash backend (see main/index.ts): when the flag is on, Datadog is
+  // active and Sentry is muted; both stay gated by the sentryLogs opt-in. Read live from the store
+  // so the backend flips as soon as the flag resolves.
+  sentry(
+    () =>
+      sentryLogsSelector(store.getState()) &&
+      !selectFeature(store.getState(), "lldDatadog").enabled,
+    store,
+  );
   let notifiedSentryLogs = false;
   store.subscribe(() => {
     const next = sentryLogsSelector(store.getState());


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** A unit test covers the renderer mirroring the `lldDatadog` flag to the main process over IPC (regardless of `sentryLogs`). The Sentry/Datadog XOR gate is a one-line predicate in the bootstrap entry points (`init.tsx` / `main/index.ts`), verified by typecheck.
- [ ] **Impact of the changes:**
  - Crash-monitoring A/B test. With "Bug reports" (sentryLogs) ON, QA should verify: lldDatadog ON sends to Datadog only (Sentry silenced), lldDatadog OFF sends to Sentry only (Datadog silenced). With "Bug reports" OFF, nothing is sent to either backend, in both the renderer and the main process.

### 📝 Description

Datadog crash monitoring lives only in the renderer; the main process reports exclusively to Sentry. The `lldDatadog` feature flag previously gated only the renderer Datadog integration, while the main-process Sentry stayed active solely on the `sentryLogs` opt-in — so when Datadog was the chosen backend, the main process kept sending to Sentry in parallel.

To A/B test the migration from Sentry to Datadog, `lldDatadog` now acts as an exclusive (XOR) switch between the two crash-monitoring backends, both still gated by the user opt-in (`sentryLogs`, the Settings > General "Bug reports" toggle):

| Bug reports (sentryLogs) | lldDatadog | Datadog (renderer only) | Sentry (renderer + main) |
| --- | --- | --- | --- |
| ON | ON | ✅ active | 🔕 silenced |
| ON | OFF | 🔕 silenced | ✅ active |
| OFF | any | 🔕 silenced | 🔕 silenced |

(✅ = reports are sent · 🔕 = integration silenced / no data sent)

The flag is resolved only in the renderer (Firebase). In the renderer, the Sentry gate reads it live from the store. The main process can't resolve the flag itself, so the renderer mirrors it over a new IPC channel (`lldDatadogChanged`), where it is used solely to mute the main-process Sentry when Datadog is the active backend. During the brief startup window before the flag is received, the default (flag off) path applies: Sentry active.

Notes:
- Sentry switches dynamically — its gate is evaluated per event in both processes, so the backend flips as soon as the flag resolves. Datadog (renderer) has no live mid-session teardown, so enabling it fully takes effect on next launch.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33062](https://ledgerhq.atlassian.net/browse/LIVE-33062)
- **ADR link (if any)**: N/A


[LIVE-33062]: https://ledgerhq.atlassian.net/browse/LIVE-33062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
