### PR TITLE
[LWDM] feat(xrp): surface required destination tag error in send flows

### DIFF
--- a/.changeset/xrp-destination-tag-required.md
+++ b/.changeset/xrp-destination-tag-required.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": patch
+---
+
+Block XRP send and show an error when the recipient requires a destination tag and none is provided (bumps @ledgerhq/coin-xrp to 7.23.5)

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
@@ -155,7 +155,7 @@ export function SendHeader() {
               ) : null}
             </div>
 
-            {showSkipMemo && (
+            {showSkipMemo && !transactionError && (
               <SkipMemoSection
                 currencyId={currencyId}
                 state={skipMemoState}

--- a/apps/ledger-live-desktop/src/renderer/families/xrp/SendRecipientFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/xrp/SendRecipientFields.tsx
@@ -1,17 +1,18 @@
 import React, { useCallback } from "react";
 import { BigNumber } from "bignumber.js";
 import { Account } from "@ledgerhq/types-live";
-import { Transaction } from "@ledgerhq/live-common/families/xrp/types";
+import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/xrp/types";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import MemoTagField from "LLD/features/MemoTag/components/MemoTagField";
 type Props = {
   onChange: (a: Transaction) => void;
   transaction: Transaction;
   account: Account;
+  status: TransactionStatus;
   autoFocus?: boolean;
 };
 const uint32maxPlus1 = BigNumber(2).pow(32);
-const TagField = ({ onChange, account, transaction, autoFocus }: Props) => {
+const TagField = ({ onChange, account, transaction, status, autoFocus }: Props) => {
   const bridge = useAccountBridge<Transaction>(account);
   const onChangeTag = useCallback(
     (str: string) => {
@@ -36,6 +37,8 @@ const TagField = ({ onChange, account, transaction, autoFocus }: Props) => {
     <MemoTagField
       value={String(transaction.tag ?? "")}
       onChange={onChangeTag}
+      error={status.errors.transaction}
+      warning={status.warnings.transaction}
       autoFocus={autoFocus}
     />
   );

--- a/apps/ledger-live-desktop/src/renderer/families/xrp/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/xrp/index.ts
@@ -7,6 +7,7 @@ import { Account, Operation } from "@ledgerhq/types-live";
 const family: LLDCoinFamily<Account, Transaction, TransactionStatus, Operation> = {
   operationDetails,
   sendRecipientFields,
+  sendRecipientCanNext: status => !status.errors.transaction,
 };
 
 export default family;

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7476,6 +7476,9 @@
     "InvalidXRPTag": {
       "title": "Invalid XRP Destination tag"
     },
+    "XrpDestinationTagRequired": {
+      "title": "A destination tag is required for this recipient"
+    },
     "InvalidExplorerResponse": {
       "title": "Invalid response from {{currencyName}} explorer"
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1173,6 +1173,9 @@
     "XrpInvalidMemo": {
       "title": "Memo format is wrong, it should be less than 4294967296"
     },
+    "XrpDestinationTagRequired": {
+      "title": "A destination tag is required for this recipient"
+    },
     "HederaMemoExceededSizeError": {
       "title": "Invalid memo size, maximum allowed is 100 characters"
     },

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/MemoControls.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/MemoControls.tsx
@@ -47,7 +47,7 @@ export function MemoControls({ vm }: MemoControlsProps) {
         />
       )}
 
-      {vm.showSkipMemo && (
+      {vm.showSkipMemo && !vm.memoError && (
         <SkipMemoSection
           memoLabel={vm.memoLabel}
           state={vm.skipMemoState}

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -387,11 +387,16 @@ export default function SendSelectRecipient({ route }: Props) {
                   placeholder={t("send.summary.memo.title")}
                   autoFocus={focusMemoInput}
                   onChange={memoTag.handleChange}
-                  error={status.errors.transaction?.name}
+                  error={
+                    status.errors.transaction
+                      ? t(`errors.${status.errors.transaction.name}.title`, {
+                          defaultValue: t("errors.generic.title", {
+                            message: status.errors.transaction.message,
+                          }),
+                        })
+                      : undefined
+                  }
                 />
-                <Text mt={4} pl={2} color="alert">
-                  <TranslatedError error={status.errors.transaction} />
-                </Text>
               </View>
             )}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: 3.5.1
       version: 3.5.1
     '@ledgerhq/coin-xrp':
-      specifier: 7.23.4
-      version: 7.23.4
+      specifier: 7.23.5
+      version: 7.23.5
     '@ledgerhq/crypto-icons':
       specifier: 2.0.4
       version: 2.0.4
@@ -7264,7 +7264,7 @@ importers:
         version: link:../../coin-tester
       '@ledgerhq/coin-xrp':
         specifier: 'catalog:'
-        version: 7.23.4(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)
+        version: 7.23.5(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/cryptoassets
@@ -8092,7 +8092,7 @@ importers:
         version: link:../coin-modules/coin-vechain
       '@ledgerhq/coin-xrp':
         specifier: 'catalog:'
-        version: 7.23.4(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)
+        version: 7.23.5(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../ledgerjs/packages/cryptoassets
@@ -17553,8 +17553,8 @@ packages:
     peerDependencies:
       '@ledgerhq/errors': ^6.33.0
 
-  '@ledgerhq/coin-xrp@7.23.4':
-    resolution: {integrity: sha512-hVPjIPn9Uo65Iz98JfdSgZZUwWc9XP7tmoOrnM9xe0RxNveSKPY46yJCHMsx6AiBYa4Ql4IcT6Zz5uKycCDMKg==}
+  '@ledgerhq/coin-xrp@7.23.5':
+    resolution: {integrity: sha512-aJiFFNhzg4zpn0t7rDVMwczV12otM0L5iiqM4F+zT3VhcfR4/eEphB6EpciUobh7Jv+YpjmY2YP16h1j1/rv1A==}
     peerDependencies:
       '@ledgerhq/errors': ^6.33.0
       '@ledgerhq/live-network': ^2.4.0
@@ -45655,7 +45655,7 @@ snapshots:
       '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
       bignumber.js: 9.1.2
 
-  '@ledgerhq/coin-xrp@7.23.4(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)':
+  '@ledgerhq/coin-xrp@7.23.5(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)':
     dependencies:
       '@ledgerhq/coin-module-framework': 3.5.1(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/errors': link:libs/ledgerjs/packages/errors

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -202,7 +202,7 @@ catalog:
   oxfmt: 0.36.0
   # Modules published by coin-modules
   "@ledgerhq/coin-module-framework": 3.5.1
-  "@ledgerhq/coin-xrp": 7.23.4
+  "@ledgerhq/coin-xrp": 7.23.5
   detox: 20.51.1
 
 overrides:


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _The core validation logic (returning `XrpDestinationTagRequired` when the recipient requires a tag) is unit-tested in the `@ledgerhq/coin-xrp` package (separate coin-modules PR). These changes are thin UI wiring to surface that error; no UI unit tests added._
- [x] **Impact of the changes:**
  - XRP send to a tag-required recipient (e.g. `rwnYLUsoBQX3ECa1A5bSKLdbPoHKnqf63J`) with no tag must block before broadcast and show the error.
  - Sending with a valid tag must still work.
  - Desktop old flow: error shown on the Tag/Memo field + Continue blocked at the Recipient step.
  - Desktop & mobile new (MVVM) send flow: the "skip memo" proposal must not appear when the error is present.
  - Non tag-required XRP recipients and other memo coins (stellar, cosmos, hedera, ...) must be unaffected.

### 📝 Description

Many XRP transactions fail at broadcast with `A destination tag is required` when the recipient account has the `requireDestinationTag` flag set (typically exchanges) and the user did not provide a tag. Nothing caught this beforehand.

The validation itself lives in `@ledgerhq/coin-xrp` (`validateIntent` now returns a `XrpDestinationTagRequired` error before broadcast, in a separate coin-modules PR). This PR wires that error into the send flows so the user is blocked and informed early:

- **Desktop old flow** (`families/xrp/SendRecipientFields.tsx`, `families/xrp/index.ts`): display `status.errors.transaction` on the Tag/Memo field and block the Recipient step via `sendRecipientCanNext`.
- **Desktop new flow** (`mvvm/features/Send/components/SendHeader.tsx`): hide the "skip memo" section when a transaction error is present.
- **Mobile new flow** (`mvvm/features/Send/components/Memo/MemoControls.tsx`): same skip-memo gating.
- **i18n**: add `XrpDestinationTagRequired` title (desktop `app.json` + mobile `common.json`).

> This PR bumps `@ledgerhq/coin-xrp` to **7.23.5** (catalog), which contains the `validateIntent` change ([coin-modules PR #693](https://github.com/LedgerHQ/coin-modules/pull/693)).

#### Old send flow

| Desktop | Mobile (memo flag ON) | Mobile (memo flag OFF) |
| ------- | --------------------- | ---------------------- |
| <img width="1110" height="1326" alt="OSF_Desktop" src="https://github.com/user-attachments/assets/7c1f3b37-6bb2-482b-9ba6-10281937b115" /> |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-23 at 12 21 44" src="https://github.com/user-attachments/assets/4381316d-61a6-4dfe-b053-123af3b25ff5" />| <img width="1206" height="2622" alt="OSF_Mobile_memo_flag_off" src="https://github.com/user-attachments/assets/0c5143c2-bf1a-4b22-82bb-c0f9917fae68" />|

#### New send flow

| Desktop | Mobile |
| ------- | ------ |
| <img width="447" height="293" alt="NSF_Desktop" src="https://github.com/user-attachments/assets/88f75b8a-2482-4dc3-9798-e0d8ec88252e" />| <img width="422" height="874" alt="NSF_Mobile" src="https://github.com/user-attachments/assets/44cc5a41-c52c-42ef-8eb1-27f34498d694" /> |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32987](https://ledgerhq.atlassian.net/browse/LIVE-32987)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-32987]: https://ledgerhq.atlassian.net/browse/LIVE-32987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

