### PR TITLE
chore(koda): use default snapshot

### DIFF
--- a/.koda/config.yaml
+++ b/.koda/config.yaml
@@ -1,4 +1,0 @@
-snapshot: ledger-live-desktop-agent-cde
-setup: pnpm i --frozen-lockfile
-lint: pnpm nx affected -t lint
-test: pnpm nx affected -t test


### PR DESCRIPTION
### 📝 Description

The defined koda snapshot `ledger-live-desktop-agent-cde` needs a little maintenance. 

In the meantime Koda will fail to start dev tasks. 

These changes remove the config and thereby restore a useable sandbox.

### ❓ Context

- **JIRA or GitHub link**: Previous PR: https://github.com/LedgerHQ/ledger-live/pull/18844