### PR TITLE
[LWDM] feat(LIVE-30348): enable aleo auto record picking strategy

### DIFF
--- a/.changeset/rotten-otters-learn.md
+++ b/.changeset/rotten-otters-learn.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+feat: enable aleo auto record picking strategy

--- a/libs/ledger-live-common/src/apps/config.ts
+++ b/libs/ledger-live-common/src/apps/config.ts
@@ -95,6 +95,12 @@ const appConfig: Record<string, ConfigInfo> = {
       minVersion: "5.6.0",
     },
   },
+  config_nanoapp_aleo: {
+    type: "object",
+    default: {
+      minVersion: "1.1.0",
+    },
+  },
 };
 
 export { appConfig };

--- a/libs/ledger-live-common/src/families/aleo/config.ts
+++ b/libs/ledger-live-common/src/families/aleo/config.ts
@@ -39,7 +39,7 @@ const USE_ENCRYPTED_PROVE = true;
  * - "auto": records are selected automatically (manual picker step is skipped).
  * Default is "manual" to preserve existing behaviour.
  */
-const RECORD_PICKING_STRATEGY: RecordPickingStrategy = "manual";
+const RECORD_PICKING_STRATEGY: RecordPickingStrategy = "auto";
 
 /**
  * Controls whether Aleo token-related features are enabled.


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - enable Aleo auto record picking strategy + set minAppVersion to 1.1.0

### 📝 Description

This PR enables auto record picking strategy for Aleo family and sets minimum required app version to 1.1.0.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-30348

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
