### PR TITLE
[LWDM] feat(broadcast): add intentType to telemetry

### DIFF
--- a/.changeset/broadcast-intent-type.md
+++ b/.changeset/broadcast-intent-type.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+feat(broadcast): add intentType to broadcast telemetry to segment broadcast health by transaction intent

--- a/apps/ledger-live-desktop/src/datadog/logs.test.ts
+++ b/apps/ledger-live-desktop/src/datadog/logs.test.ts
@@ -184,6 +184,7 @@ describe("datadog logs", () => {
         family: "bitcoin",
         isTestnet: false,
         isSendMax: true,
+        intentType: "send",
         source: { type: "coin-module", name: "ledger-live-desktop", flags: { newSendFlow: true } },
       });
 
@@ -195,6 +196,7 @@ describe("datadog logs", () => {
           family: "bitcoin",
           isTestnet: false,
           isSendMax: true,
+          intentType: "send",
           source: {
             type: "coin-module",
             name: "ledger-live-desktop",
@@ -217,6 +219,7 @@ describe("datadog logs", () => {
         family: "evm",
         isTestnet: false,
         isSendMax: false,
+        intentType: "delegate",
         source: { type: "coin-module", name: "ledger-live-desktop", flags: { newSendFlow: false } },
       });
 
@@ -231,6 +234,7 @@ describe("datadog logs", () => {
             family: "evm",
             isTestnet: false,
             isSendMax: false,
+            intentType: "delegate",
             source: {
               type: "coin-module",
               name: "ledger-live-desktop",

--- a/apps/ledger-live-mobile/src/datadog.test.ts
+++ b/apps/ledger-live-mobile/src/datadog.test.ts
@@ -49,6 +49,7 @@ describe("broadcastLogger", () => {
       family: "family",
       isTestnet: false,
       isSendMax: true,
+      intentType: "send",
       source: { type: "coin-module", name: "ledger-live-mobile", flags: { newSendFlow: true } },
     });
 
@@ -60,6 +61,7 @@ describe("broadcastLogger", () => {
         family: "family",
         isTestnet: false,
         isSendMax: true,
+        intentType: "send",
         source: { type: "coin-module", name: "ledger-live-mobile", flags: { newSendFlow: true } },
       },
     });
@@ -79,6 +81,7 @@ describe("broadcastLogger", () => {
       family: "family",
       isTestnet: false,
       isSendMax: false,
+      intentType: "delegate",
       source: { type: "coin-module", name: "ledger-live-mobile", flags: { newSendFlow: false } },
     });
 
@@ -96,6 +99,7 @@ describe("broadcastLogger", () => {
           family: "family",
           isTestnet: false,
           isSendMax: false,
+          intentType: "delegate",
           source: {
             type: "coin-module",
             name: "ledger-live-mobile",

--- a/libs/ledger-live-common/src/hooks/useBroadcast.test.ts
+++ b/libs/ledger-live-common/src/hooks/useBroadcast.test.ts
@@ -53,7 +53,7 @@ describe("useBroadcast", () => {
       "token-id",
     ],
   ])("%s", (_s, account, parentAccount, expectedTokenId) => {
-    const transaction = { useAllAmount: true } as any;
+    const transaction = { useAllAmount: true, mode: "delegate" } as any;
 
     it("logs on success", async () => {
       const logger = jest.fn();
@@ -85,6 +85,7 @@ describe("useBroadcast", () => {
         appVersion: "llc/test",
         isTestnet: false,
         isSendMax: true,
+        intentType: "delegate",
         source: { type: "coin-module", name: "ledger-live-desktop" },
       });
       expect(value).toEqual({ id: "operation-id", date: new Date(2026, 3, 24) });
@@ -125,6 +126,7 @@ describe("useBroadcast", () => {
         appVersion: "llc/test",
         isTestnet: false,
         isSendMax: true,
+        intentType: "delegate",
         source: { type: "coin-module", name: "ledger-live-desktop" },
         txPayload: { signature: "signed-transaction", rawData: { raw_hex: "raw-hex" } },
       });
@@ -152,11 +154,38 @@ describe("useBroadcast", () => {
     );
 
     await act(async () => {
-      await result.current({} as any);
+      await result.current({ operation: { type: "OUT" } } as any);
     });
 
     expect(logger).toHaveBeenCalledWith(
       expect.objectContaining({ currencyId: "ethereum_sepolia", isTestnet: true }),
     );
+  });
+
+  it("falls back to the operation type when the transaction has no mode", async () => {
+    const logger = jest.fn();
+    mockBroadcast.mockResolvedValue({ id: "operation-id", date: new Date(2026, 3, 24) });
+    setEnv("LEDGER_CLIENT_VERSION", "llc/test");
+    setEnv("DISABLE_TRANSACTION_BROADCAST", false);
+
+    const account = {
+      id: "main-account-id",
+      type: "Account",
+      currency: { id: "bitcoin", family: "bitcoin" },
+    };
+
+    const { result } = renderHook(() =>
+      useBroadcast({
+        account,
+        parentAccount: account,
+        logger,
+      } as any),
+    );
+
+    await act(async () => {
+      await result.current({ operation: { type: "OUT" } } as any);
+    });
+
+    expect(logger).toHaveBeenCalledWith(expect.objectContaining({ intentType: "OUT" }));
   });
 });

--- a/libs/ledger-live-common/src/hooks/useBroadcast.ts
+++ b/libs/ledger-live-common/src/hooks/useBroadcast.ts
@@ -22,6 +22,7 @@ type CommonLogEvent = {
   tokenId?: string;
   isTestnet: boolean;
   isSendMax: boolean;
+  intentType: string;
 };
 
 type ErrorLogEvent = {
@@ -72,6 +73,11 @@ export const useBroadcast = ({
         return Promise.resolve(signedOperation.operation);
       }
 
+      const mode =
+        transaction && "mode" in transaction && typeof transaction.mode === "string"
+          ? transaction.mode
+          : undefined;
+
       const commonLogEvent: CommonLogEvent = {
         appVersion: getEnv("LEDGER_CLIENT_VERSION"),
         source: broadcastConfig?.source,
@@ -79,6 +85,7 @@ export const useBroadcast = ({
         family: mainAccount.currency.family,
         isTestnet: Boolean(mainAccount.currency.isTestnetFor),
         isSendMax: Boolean(transaction?.useAllAmount),
+        intentType: mode ?? signedOperation.operation.type,
         ...(account.type === "TokenAccount" ? { tokenId: account.token.id } : {}),
       };
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Transaction broadcast on mobile and desktop (success and failure paths)
      - `broadcast_success` / `broadcast_failure` Datadog logs and the Broadcast Health dashboard

### 📝 Description

Broadcast logs (`broadcast_success` / `broadcast_failure`) feeding the Datadog "Broadcast Health" dashboard don't tell us what the transaction does (send, delegate, claim reward...).

This PR adds an `intentType` (string) field to the broadcast payload so broadcast health can be segmented by transaction intent. It is derived in the shared `useBroadcast` hook (both apps, success and failure paths): prefer the family transaction `mode` (`"send"`, `"delegate"`, `"claimReward"`...), falling back to `operation.type` (`"OUT"`, `"REWARD"`...) when there is no mode (bitcoin, evm, swap/edge call sites). `intentType` is therefore always a non-empty string. No existing field is changed.

```ts
const mode =
  transaction && "mode" in transaction && typeof transaction.mode === "string"
    ? transaction.mode
    : undefined;
// ...
intentType: mode ?? signedOperation.operation.type,
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33126](https://ledgerhq.atlassian.net/browse/LIVE-33126)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33126]: https://ledgerhq.atlassian.net/browse/LIVE-33126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ