### PR TITLE
chore(koda): add koda config, setting snapshot, setup and lint

### DIFF
--- a/.koda/config.yaml
+++ b/.koda/config.yaml
@@ -1,3 +1,5 @@
 snapshot: ledger-live-desktop-agent-cde
-setup: pnpm i --frozen-lockfile
+setup: |
+  mise install
+  pnpm i --frozen-lockfile
 lint: pnpm nx affected -t lint

--- a/.koda/config.yaml
+++ b/.koda/config.yaml
@@ -1,0 +1,3 @@
+snapshot: ledger-live-desktop-agent-cde
+setup: pnpm i --frozen-lockfile
+lint: pnpm nx affected -t lint


### PR DESCRIPTION
### 📝 Description

Here we introduce the custom koda snapshot `ledger-live-desktop-agent-cde` along with a setup and lint tasks.

| Before        | After         |
| ------------- | ------------- |
| No Koda specific config in repo | Koda config added with first draft snapshot, setup and lint |

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-29499

### 🔍  Details

#### Previous PRs

- First introduction of Koda config: https://github.com/LedgerHQ/ledger-live/pull/18844
- Rollback of Koda config due to problem with the snapshot: https://github.com/LedgerHQ/ledger-live/pull/18876

The problem has now been resolved.

#### Cairn > Actions > Repo-readiness

<details><summary>This branch has passed the Repo-readiness check (expand for details)</summary>
<img width="867" height="599" alt="Screenshot 2026-06-24 at 13 29 40" src="https://github.com/user-attachments/assets/b0d84b50-61ba-49a8-9754-feb1c7cf31c2" />

https://github.com/LedgerHQ/cairn/actions/runs/28098057528

</details> 

However, results from the check are nothing like as accurate as result from triggering in Slack, so I'd like to merge and test again from Slack.

#### No test command

We do not have a single available command for the `test` config, so we have omitted this.

Developer agents should still validate their own work assuming they follow guidance like [validate-before-finishing.md](https://github.com/LedgerHQ/ledger-live/blob/develop/docs/validate-before-finishing.md) but we will not have the deterministic shell evocation coming from the main Koda agent.
