### PR TITLE
[LWM] fix(mobile): improve discover catalog back transition

### DIFF
--- a/.changeset/quick-wallet-return.md
+++ b/.changeset/quick-wallet-return.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix slow mobile transition from Discover catalog to Wallet.

--- a/apps/ledger-live-mobile/src/actions/general.test.tsx
+++ b/apps/ledger-live-mobile/src/actions/general.test.tsx
@@ -1,0 +1,89 @@
+import { InteractionManager } from "react-native";
+import { act, renderHook, waitFor } from "@tests/test-renderer";
+import { useRefreshAccountsOrderingAfterInteractions } from "./general";
+
+const mockDispatch = jest.fn();
+
+jest.mock("~/context/hooks", () => ({
+  ...jest.requireActual("~/context/hooks"),
+  useDispatch: () => mockDispatch,
+}));
+
+describe("useRefreshAccountsOrderingAfterInteractions", () => {
+  let runAfterInteractionsSpy: jest.SpyInstance;
+  let scheduledInteractions: { callback: () => void; cancelled: boolean }[];
+
+  const flushScheduledInteractions = () => {
+    scheduledInteractions.forEach(interaction => {
+      if (!interaction.cancelled) {
+        interaction.callback();
+      }
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    scheduledInteractions = [];
+    runAfterInteractionsSpy = jest
+      .spyOn(InteractionManager, "runAfterInteractions")
+      .mockImplementation(
+        (task?: Parameters<typeof InteractionManager.runAfterInteractions>[0]) => {
+          const interactionTask = Promise.resolve() as unknown as ReturnType<
+            typeof InteractionManager.runAfterInteractions
+          >;
+          interactionTask.done = jest.fn();
+
+          if (typeof task === "function") {
+            const interaction = {
+              callback: task,
+              cancelled: false,
+            };
+            scheduledInteractions.push(interaction);
+            interactionTask.cancel = () => {
+              interaction.cancelled = true;
+            };
+          } else {
+            interactionTask.cancel = jest.fn();
+          }
+
+          return interactionTask;
+        },
+      );
+  });
+
+  afterEach(() => {
+    runAfterInteractionsSpy.mockRestore();
+  });
+
+  it("should defer accounts ordering refresh until interactions finish", async () => {
+    const { result } = renderHook(() => useRefreshAccountsOrderingAfterInteractions());
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+
+    act(() => {
+      flushScheduledInteractions();
+    });
+
+    await waitFor(() => expect(mockDispatch).toHaveBeenCalledTimes(1));
+  });
+
+  it("should not refresh accounts ordering when cleaning up before interactions finish", () => {
+    const { result } = renderHook(() => useRefreshAccountsOrderingAfterInteractions());
+
+    let cleanup: (() => void) | undefined;
+    act(() => {
+      cleanup = result.current();
+    });
+    cleanup?.();
+
+    act(() => {
+      flushScheduledInteractions();
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/actions/general.ts
+++ b/apps/ledger-live-mobile/src/actions/general.ts
@@ -1,4 +1,5 @@
 import { useMemo, useCallback, useEffect, useState } from "react";
+import { InteractionManager } from "react-native";
 import { useSelector, useDispatch } from "~/context/hooks";
 import {
   flattenSortAccounts,
@@ -89,6 +90,17 @@ export function useRefreshAccountsOrdering() {
   return useCallback(() => {
     setIsRefreshing(true);
   }, []);
+}
+export function useRefreshAccountsOrderingAfterInteractions() {
+  const refreshAccountsOrdering = useRefreshAccountsOrdering();
+
+  return useCallback(() => {
+    const interactionTask = InteractionManager.runAfterInteractions(refreshAccountsOrdering);
+
+    return () => {
+      interactionTask.cancel();
+    };
+  }, [refreshAccountsOrdering]);
 }
 export function useRefreshAccountsOrderingEffect({
   onMount = false,

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
@@ -8,7 +8,7 @@ import { useSharedValue } from "react-native-reanimated";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import type { Features } from "@shared/feature-flags";
 
-import { useRefreshAccountsOrdering } from "~/actions/general";
+import { useRefreshAccountsOrderingAfterInteractions } from "~/actions/general";
 import { track } from "~/analytics";
 import { usePortfolioBalance } from "LLM/hooks/usePortfolioBalance";
 import { useBorrowLiveConfig } from "LLM/features/Borrow/hooks/useBorrowLiveConfig";
@@ -100,6 +100,9 @@ const usePortfolioViewModel = (navigation: {
 
   usePortfolioAnalyticsOptInPrompt();
 
+  const refreshAccountsOrdering = useRefreshAccountsOrderingAfterInteractions();
+  useFocusEffect(refreshAccountsOrdering);
+
   const openAddModal = useCallback(() => {
     track("button_clicked", {
       button: "Add Account",
@@ -108,8 +111,6 @@ const usePortfolioViewModel = (navigation: {
   }, []);
 
   const closeAddModal = useCallback(() => setAddModalOpened(false), []);
-  const refreshAccountsOrdering = useRefreshAccountsOrdering();
-  useFocusEffect(refreshAccountsOrdering);
 
   useEffect(() => {
     if (!llmDatadog?.enabled) return;

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/useReadOnlyPortfolioViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/useReadOnlyPortfolioViewModel.ts
@@ -2,7 +2,7 @@ import { useCallback, useContext } from "react";
 import { useFocusEffect } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-import { useRefreshAccountsOrdering } from "~/actions/general";
+import { useRefreshAccountsOrderingAfterInteractions } from "~/actions/general";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import usePortfolioAnalyticsOptInPrompt from "~/hooks/analyticsOptInPrompt/usePortfolioAnalyticsOptInPrompt";
 import { AnalyticsContext } from "~/analytics/AnalyticsContext";
@@ -28,7 +28,7 @@ const useReadOnlyPortfolioViewModel = (navigation: {
 
   usePortfolioAnalyticsOptInPrompt();
 
-  const refreshAccountsOrdering = useRefreshAccountsOrdering();
+  const refreshAccountsOrdering = useRefreshAccountsOrderingAfterInteractions();
   useFocusEffect(refreshAccountsOrdering);
 
   const onBackFromUpdate = useCallback(() => {

--- a/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/index.tsx
@@ -19,6 +19,7 @@ import { RecentlyUsed } from "./RecentlyUsed";
 import { CatalogSection } from "./CatalogSection";
 import { DAppDisclaimer } from "./DAppDisclaimer";
 import { LocalLiveApp } from "./LocalLiveApp";
+import { goBackFromWallet40Catalog } from "./navigation";
 
 const SAFE_AREA_EDGES_WALLET40 = ["top", "left", "right"] as const;
 const SAFE_AREA_EDGES_LEGACY = ["top", "bottom", "left", "right"] as const;
@@ -76,7 +77,7 @@ function CatalogContent({
                 <TouchableOpacity
                   hitSlop={{ bottom: 10, left: 24, right: 24, top: 10 }}
                   style={{ paddingVertical: 16 }}
-                  onPress={() => navigation.goBack()}
+                  onPress={() => goBackFromWallet40Catalog(navigation)}
                   accessibilityLabel={t("common.back")}
                   accessibilityRole="button"
                 >

--- a/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/navigation.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/navigation.test.ts
@@ -1,0 +1,46 @@
+import { goBackFromWallet40Catalog } from "./navigation";
+
+describe("goBackFromWallet40Catalog", () => {
+  it("should leave the Discover navigator through its parent when possible", () => {
+    const parentGoBack = jest.fn();
+    const navigationGoBack = jest.fn();
+
+    goBackFromWallet40Catalog({
+      getParent: () => ({
+        canGoBack: () => true,
+        goBack: parentGoBack,
+      }),
+      goBack: navigationGoBack,
+    });
+
+    expect(parentGoBack).toHaveBeenCalledTimes(1);
+    expect(navigationGoBack).not.toHaveBeenCalled();
+  });
+
+  it("should fall back to the current navigator when the parent cannot go back", () => {
+    const parentGoBack = jest.fn();
+    const navigationGoBack = jest.fn();
+
+    goBackFromWallet40Catalog({
+      getParent: () => ({
+        canGoBack: () => false,
+        goBack: parentGoBack,
+      }),
+      goBack: navigationGoBack,
+    });
+
+    expect(parentGoBack).not.toHaveBeenCalled();
+    expect(navigationGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("should fall back to the current navigator without a parent", () => {
+    const navigationGoBack = jest.fn();
+
+    goBackFromWallet40Catalog({
+      getParent: () => undefined,
+      goBack: navigationGoBack,
+    });
+
+    expect(navigationGoBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/navigation.ts
+++ b/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/navigation.ts
@@ -1,0 +1,20 @@
+type CatalogBackParentNavigation = {
+  canGoBack: () => boolean;
+  goBack: () => void;
+};
+
+type CatalogBackNavigation = {
+  getParent: () => CatalogBackParentNavigation | undefined;
+  goBack: () => void;
+};
+
+export function goBackFromWallet40Catalog(navigation: CatalogBackNavigation) {
+  const parentNavigation = navigation.getParent();
+
+  if (parentNavigation?.canGoBack()) {
+    parentNavigation.goBack();
+    return;
+  }
+
+  navigation.goBack();
+}

--- a/apps/ledger-live-mobile/src/screens/Portfolio/ReadOnly/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/ReadOnly/index.tsx
@@ -7,7 +7,7 @@ import { useSelector } from "~/context/hooks";
 import { Box, Button, Flex } from "@ledgerhq/native-ui";
 import { useTheme } from "styled-components/native";
 import { Currency } from "@ledgerhq/types-cryptoassets";
-import { useRefreshAccountsOrdering } from "~/actions/general";
+import { useRefreshAccountsOrderingAfterInteractions } from "~/actions/general";
 import { counterValueCurrencySelector, hasOrderedNanoSelector } from "~/reducers/settings";
 import { usePortfolioAllAccounts } from "~/hooks/portfolio";
 import GraphCardContainer from "../GraphCardContainer";
@@ -61,7 +61,7 @@ function ReadOnlyPortfolio({ navigation }: NavigationProps) {
 
   usePortfolioAnalyticsOptInPrompt();
 
-  const refreshAccountsOrdering = useRefreshAccountsOrdering();
+  const refreshAccountsOrdering = useRefreshAccountsOrderingAfterInteractions();
   useFocusEffect(refreshAccountsOrdering);
 
   const [graphCardEndPosition, setGraphCardEndPosition] = useState(0);

--- a/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
@@ -9,7 +9,7 @@ import { useTheme } from "styled-components/native";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 
 import WalletTabSafeAreaView from "~/components/WalletTab/WalletTabSafeAreaView";
-import { useDistribution, useRefreshAccountsOrdering } from "~/actions/general";
+import { useDistribution, useRefreshAccountsOrderingAfterInteractions } from "~/actions/general";
 import Carousel from "~/components/Carousel";
 import { ScreenName } from "~/const";
 import FirmwareUpdateBanner from "LLM/features/FirmwareUpdate/components/UpdateBanner";
@@ -107,7 +107,7 @@ function PortfolioScreen({ navigation }: NavigationProps) {
   }, [setAddModalOpened]);
 
   const closeAddModal = useCallback(() => setAddModalOpened(false), [setAddModalOpened]);
-  const refreshAccountsOrdering = useRefreshAccountsOrdering();
+  const refreshAccountsOrdering = useRefreshAccountsOrderingAfterInteractions();
   useFocusEffect(refreshAccountsOrdering);
 
   useEffect(() => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added a focused Jest test for the deferred Portfolio ordering hook and reran the Portfolio integration test.
- [x] **Impact of the changes:**
      Wallet 4.0 Discover catalog back navigation to Wallet/Home.
      Portfolio focus account-ordering refresh after returning to Home.
      Account ordering refresh cleanup on blur/unmount.

### 📝 Description

LIVE-33018 reports a slow transition in Ledger Wallet Mobile when users press the top-left back arrow from the Wallet 4.0 Discover provider catalog to return to Wallet/Home.

This PR updates the Wallet 4.0 catalog back action to leave `DiscoverNavigator` through the parent navigator when available, and defers Portfolio account ordering refresh until after React Native interactions complete. This keeps the back transition responsive while preserving account ordering refresh shortly after landing on Home.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33018](https://ledgerhq.atlassian.net/browse/LIVE-33018)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-33018]: https://ledgerhq.atlassian.net/browse/LIVE-33018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ