### PR TITLE
[LWDM] feat(devices): expose getProductName and deprecate app-level utils

### DIFF
--- a/.changeset/quick-brooms-grin.md
+++ b/.changeset/quick-brooms-grin.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/devices": minor
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Add `getProductName` to `@ledgerhq/devices` returning the plain, canonical device product name (e.g. "Ledger Flex"), and deprecate the app-level `getProductName` utils that strip the "Ledger" prefix.

--- a/apps/ledger-live-desktop/src/mvvm/utils/getProductName.ts
+++ b/apps/ledger-live-desktop/src/mvvm/utils/getProductName.ts
@@ -1,4 +1,10 @@
 import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
 
+/**
+ * @deprecated Do not use. This strips the "Ledger" prefix from the official
+ * product name, which is not allowed: product names are brand assets and must
+ * be displayed as-is. Use `getProductName` from `@ledgerhq/devices` to get the
+ * plain, canonical product name (e.g. "Ledger Flex") instead.
+ */
 export const getProductName = (modelId: DeviceModelId) =>
   getDeviceModel(modelId)?.productName.replace("Ledger", "").trimStart() || modelId;

--- a/apps/ledger-live-mobile/src/mvvm/utils/getProductName.ts
+++ b/apps/ledger-live-mobile/src/mvvm/utils/getProductName.ts
@@ -1,5 +1,11 @@
 import { getDeviceModel } from "@ledgerhq/devices";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 
+/**
+ * @deprecated Do not use. This strips the "Ledger" prefix from the official
+ * product name, which is not allowed: product names are brand assets and must
+ * be displayed as-is. Use `getProductName` from `@ledgerhq/devices` to get the
+ * plain, canonical product name (e.g. "Ledger Flex") instead.
+ */
 export const getProductName = (modelId: DeviceModelId) =>
   getDeviceModel(modelId)?.productName.replace("Ledger", "").trimStart() || modelId;

--- a/libs/ledgerjs/packages/devices/README.md
+++ b/libs/ledgerjs/packages/devices/README.md
@@ -21,13 +21,15 @@ Logic for all Ledger devices.
 *   [ledgerUSBVendorId](#ledgerusbvendorid)
 *   [getDeviceModel](#getdevicemodel)
     *   [Parameters](#parameters)
-*   [identifyTargetId](#identifytargetid)
+*   [getProductName](#getproductname)
     *   [Parameters](#parameters-1)
-*   [identifyUSBProductId](#identifyusbproductid)
+*   [identifyTargetId](#identifytargetid)
     *   [Parameters](#parameters-2)
+*   [identifyUSBProductId](#identifyusbproductid)
+    *   [Parameters](#parameters-3)
 *   [getBluetoothServiceUuids](#getbluetoothserviceuuids)
 *   [getInfosForServiceUuid](#getinfosforserviceuuid)
-    *   [Parameters](#parameters-3)
+    *   [Parameters](#parameters-4)
 *   [DeviceModel](#devicemodel)
 *   [BluetoothInfos](#bluetoothinfos)
 
@@ -102,6 +104,20 @@ Type: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
 *   `id` **DeviceModelId**&#x20;
 
 Returns **[DeviceModel](#devicemodel)**&#x20;
+
+### getProductName
+
+Return the official, full product name of a device model
+(e.g. "Ledger Flex", "Ledger Nano X").
+
+This is the canonical name and must be used as-is: do not strip the
+"Ledger" prefix, reword, or otherwise transform it.
+
+#### Parameters
+
+*   `id` **DeviceModelId**&#x20;
+
+Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**&#x20;
 
 ### identifyTargetId
 

--- a/libs/ledgerjs/packages/devices/src/index.ts
+++ b/libs/ledgerjs/packages/devices/src/index.ts
@@ -170,6 +170,15 @@ export const getDeviceModel = (id: DeviceModelId): DeviceModel => {
 };
 
 /**
+ * Return the official, full product name of a device model
+ * (e.g. "Ledger Flex", "Ledger Nano X").
+ *
+ * This is the canonical name and must be used as-is: do not strip the
+ * "Ledger" prefix, reword, or otherwise transform it.
+ */
+export const getProductName = (id: DeviceModelId): string => getDeviceModel(id).productName;
+
+/**
  * Given a `targetId`, return the deviceModel associated to it,
  * based on the first two bytes.
  */

--- a/libs/ledgerjs/packages/devices/tests/getProductName.test.ts
+++ b/libs/ledgerjs/packages/devices/tests/getProductName.test.ts
@@ -1,0 +1,21 @@
+import { DeviceModelId, getProductName } from "../src";
+
+describe("getProductName", () => {
+  it.each([
+    [DeviceModelId.blue, "Ledger\u00A0Blue"],
+    [DeviceModelId.nanoS, "Ledger\u00A0Nano\u00A0S"],
+    [DeviceModelId.nanoX, "Ledger\u00A0Nano\u00A0X"],
+    [DeviceModelId.nanoSP, "Ledger Nano S Plus"],
+    [DeviceModelId.stax, "Ledger\u00A0Stax"],
+    [DeviceModelId.europa, "Ledger\u00A0Flex"],
+    [DeviceModelId.apex, "Ledger\u00A0Nano\u00A0Gen5"],
+  ])("should return the canonical product name for %s", (modelId, expectedProductName) => {
+    expect(getProductName(modelId)).toBe(expectedProductName);
+  });
+
+  it("should throw for an unknown device model", () => {
+    expect(() => getProductName("does-not-exist" as DeviceModelId)).toThrow(
+      "device 'does-not-exist' does not exist",
+    );
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - `@ledgerhq/devices`: new `getProductName(id)` export, returns the plain product name (`getDeviceModel(id).productName`). No existing behaviour changed.
  - Desktop & Mobile MVVM `getProductName` utils: marked `@deprecated` (TSDoc only). Current call sites are intentionally left untouched.

### 📝 Description

The app-level `getProductName` utils (desktop + mobile MVVM) transform the official device product name by stripping the `"Ledger"` prefix (e.g. `"Ledger Flex"` → `"Flex"`). Product names are brand assets and should be displayed as-is, so this kind of manipulation should be avoided.

The problem is that agents tend to use this util by default so we should **stop the propagation of this bad pattern in the codebase**.

This PR:

- Deprecates the desktop and mobile MVVM `getProductName` utils with a TSDoc `@deprecated` note pointing to the new helper.

- Adds a canonical `getProductName` to `@ledgerhq/devices`, next to `getDeviceModel`, returning the plain product name:

```ts
import { getProductName } from "@ledgerhq/devices";

getProductName(DeviceModelId.europa); // "Ledger Flex"
```


Existing call sites are deliberately **not** migrated in this PR to keep it low-risk; they can be migrated incrementally now that the deprecation is in place.

### ❓ Context

- **JIRA or GitHub link**: _N/A_
- **ADR link (if any)**: _N/A_

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)