### PR TITLE
fix(mobile): resize long portfolio balances

### DIFF
--- a/.changeset/calm-lemons-smile.md
+++ b/.changeset/calm-lemons-smile.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Set the Wallet 4.0 portfolio balance amount display to small for long balances.

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/PortfolioBalanceSectionView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/PortfolioBalanceSectionView.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import { AmountDisplay, Box, Pressable, Skeleton, Text } from "@ledgerhq/lumen-ui-rnative";
 import { DiscreetModeIcon } from "./DiscreetModeIcon";
-import type { FormattedValue } from "@ledgerhq/lumen-ui-rnative";
+import type { AmountDisplaySize, FormattedValue } from "@ledgerhq/lumen-ui-rnative";
 import { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { formatCurrencyUnitFragment } from "@ledgerhq/live-common/currencies/index";
 import { BigNumber } from "bignumber.js";
@@ -14,6 +14,17 @@ import { AnalyticPill } from "./AnalyticPill";
 const containerStyle: LumenViewStyle = {
   alignItems: "center",
   justifyContent: "center",
+};
+
+const MAX_MEDIUM_BALANCE_DIGITS = 9;
+
+const getAmountDisplaySize = (value: number): AmountDisplaySize => {
+  const integerDigitCount = new BigNumber(value)
+    .abs()
+    .integerValue(BigNumber.ROUND_FLOOR)
+    .toFixed(0).length;
+
+  return integerDigitCount > MAX_MEDIUM_BALANCE_DIGITS ? "sm" : "md";
 };
 
 export const PortfolioBalanceSectionView = ({
@@ -79,6 +90,7 @@ export const PortfolioBalanceSectionView = ({
                 key={unit.code}
                 value={balance}
                 formatter={formatter}
+                size={getAmountDisplaySize(balance)}
                 hidden={discreet}
                 loading={shouldDisplayBalanceRefreshRework && isLoading}
                 testID="portfolio-balance-amount"

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/PortfolioBalanceSectionView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/PortfolioBalanceSectionView.test.tsx
@@ -4,6 +4,21 @@ import { getFiatCurrencyByTicker } from "@ledgerhq/live-common/currencies/index"
 import { PortfolioBalanceSectionView } from "../PortfolioBalanceSectionView";
 import { PortfolioBalanceSectionViewProps } from "../types";
 
+let mockAmountDisplaySize: "sm" | "md" | undefined;
+jest.mock("@ledgerhq/lumen-ui-rnative", () => {
+  const actual = jest.requireActual("@ledgerhq/lumen-ui-rnative");
+  const ReactActual = jest.requireActual("react");
+  const { Text } = jest.requireActual("react-native");
+
+  return {
+    ...actual,
+    AmountDisplay: ({ size, testID }: { size?: "sm" | "md"; testID?: string }) => {
+      mockAmountDisplaySize = size;
+      return ReactActual.createElement(Text, { testID }, "amount");
+    },
+  };
+});
+
 const usd = getFiatCurrencyByTicker("USD");
 
 const baseProps: PortfolioBalanceSectionViewProps = {
@@ -22,13 +37,25 @@ const renderView = (overrides: Partial<PortfolioBalanceSectionViewProps> = {}) =
   render(<PortfolioBalanceSectionView {...baseProps} {...overrides} />);
 
 describe("PortfolioBalanceSectionView", () => {
+  beforeEach(() => {
+    mockAmountDisplaySize = undefined;
+  });
+
   describe("state rendering", () => {
     it("should render balance and analytics pill when state is normal and balance is available", () => {
       renderView();
 
       expect(screen.getByTestId("portfolio-balance-normal")).toBeVisible();
       expect(screen.getByTestId("portfolio-balance-amount")).toBeVisible();
+      expect(mockAmountDisplaySize).toBe("md");
       expect(screen.getByTestId("portfolio-balance-analytics-pill")).toBeVisible();
+    });
+
+    it("should use small amount size when balance has more than nine integer digits", () => {
+      renderView({ balance: 1_000_000_000 });
+
+      expect(screen.getByTestId("portfolio-balance-amount")).toBeVisible();
+      expect(mockAmountDisplaySize).toBe("sm");
     });
 
     it("should render noSigner text when state is noSigner", () => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Wallet 4.0 portfolio balance header rendering
      - Mobile portfolio amount display sizing for long balances

### 📝 Description

This PR updates the Wallet 4.0 portfolio balance header on mobile so the main balance keeps the normal `AmountDisplay` size for balances with 9 integer digits or fewer, and switches to `sm` only when the balance has more than 9 integer digits.

It also adds test coverage for both the normal size and the long-balance small size behavior.
<img width="350" height="750" alt="Simulator Screenshot - build2 - 2026-06-24 at 14 23 31" src="https://github.com/user-attachments/assets/89023cfd-375b-4968-b749-f02eaafd84ad" />

<img width="350" height="750" alt="Simulator Screenshot - build2 - 2026-06-24 at 14 23 03" src="https://github.com/user-attachments/assets/10cf6086-f0c3-4e4f-8de4-59e9bb342fd4" />


### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
