### PR TITLE
[LWDM] Fix/ethereum spendable balance update

### DIFF
--- a/.changeset/evm-send-max-pending-balance.md
+++ b/.changeset/evm-send-max-pending-balance.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix "send max" offering already-committed funds while a previous send is still pending. Optimistic pending operations are now subtracted from the spendable balance used by the generic coin framework (send max, amount and gas validation), preventing on-chain "Insufficient funds for gas * price + value" errors when sending again before the next account sync. Affects EVM and other coins built on the generic coin framework. Sponsored (gasless) pending transactions no longer lock their fee against the native balance, since the fee is paid by a third party and not by the account.

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/estimateMaxSpendable.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/estimateMaxSpendable.ts
@@ -2,7 +2,12 @@ import { AccountBridge } from "@ledgerhq/types-live";
 import { getMainAccount } from "../../account";
 import { getCoinModuleApi } from "./api";
 import { createTransaction } from "./createTransaction";
-import { bigNumberToBigIntDeep, extractBalances, transactionToIntent } from "./utils";
+import {
+  bigNumberToBigIntDeep,
+  extractBalances,
+  getPendingTokenSpent,
+  transactionToIntent,
+} from "./utils";
 import BigNumber from "bignumber.js";
 import { GenericTransaction } from "./types";
 import { getBridgeApi } from "./bridge";
@@ -13,7 +18,8 @@ export function genericEstimateMaxSpendable(
 ): AccountBridge<GenericTransaction>["estimateMaxSpendable"] {
   return async ({ account, parentAccount, transaction }) => {
     if (account.type === "TokenAccount") {
-      return account.spendableBalance;
+      const pendingSpent = getPendingTokenSpent(account.pendingOperations ?? []);
+      return BigNumber.max(0, account.spendableBalance.minus(pendingSpent));
     }
     const mainAccount = getMainAccount(account, parentAccount);
     const coinModuleApi = await getCoinModuleApi(mainAccount.currency.id, kind);

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/estimateMaxSpendable.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/estimateMaxSpendable.test.ts
@@ -78,6 +78,56 @@ describe("genericEstimateMaxSpendable", () => {
     expect(result.toString()).toBe("0");
   });
 
+  describe("TokenAccount", () => {
+    const tokenAccount = {
+      id: "token_account_id",
+      type: "TokenAccount",
+      spendableBalance: new BigNumber(6),
+      balance: new BigNumber(6),
+      pendingOperations: [],
+    } as unknown as Account;
+
+    it("returns the raw spendable balance when there is no pending op", async () => {
+      const estimate = genericEstimateMaxSpendable("testnet", "local");
+      const result = await estimate({
+        account: tokenAccount,
+        parentAccount: dummyAccount,
+        transaction: {} as any,
+      });
+
+      expect(result.toString()).toBe("6");
+    });
+
+    it("subtracts the pending token spend so the banner matches send-max", async () => {
+      const estimate = genericEstimateMaxSpendable("testnet", "local");
+      const result = await estimate({
+        account: {
+          ...tokenAccount,
+          // optimistic OUT sub-op for a pending 1-token send (fee is paid in native)
+          pendingOperations: [{ type: "OUT", value: new BigNumber(1), fee: new BigNumber(2) }],
+        } as unknown as Account,
+        parentAccount: dummyAccount,
+        transaction: {} as any,
+      });
+
+      expect(result.toString()).toBe("5");
+    });
+
+    it("never returns a negative spendable balance", async () => {
+      const estimate = genericEstimateMaxSpendable("testnet", "local");
+      const result = await estimate({
+        account: {
+          ...tokenAccount,
+          pendingOperations: [{ type: "OUT", value: new BigNumber(10), fee: new BigNumber(2) }],
+        } as unknown as Account,
+        parentAccount: dummyAccount,
+        transaction: {} as any,
+      });
+
+      expect(result.toString()).toBe("0");
+    });
+  });
+
   it("returns full spendable balance if fee is 0", async () => {
     mockedGetCoinModuleApi.mockReturnValue({
       estimateFees: estimateFeesMock.mockResolvedValue({ value: 0n }),

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/sendMaxPending.integration.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/sendMaxPending.integration.test.ts
@@ -1,0 +1,102 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions -- test fixtures use partial shapes */
+import BigNumber from "bignumber.js";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { validateIntent } from "@ledgerhq/coin-evm/logic/index";
+import type { Account, Operation } from "@ledgerhq/types-live";
+import type { FeeEstimation } from "@ledgerhq/coin-module-framework/api/types";
+import { extractBalances, transactionToIntent } from "../utils";
+import type { GenericTransaction } from "../types";
+
+/**
+ * Integration test for the "send max uses a stale balance while a previous send
+ * is still pending" bug.
+ *
+ * Unlike the unit tests in utils.test.ts (which check extractBalances in
+ * isolation) this wires together the *real* production functions across both
+ * packages: ledger-live-common's `extractBalances` + `transactionToIntent` feed
+ * coin-evm's real `validateIntent` (which runs `computeAmount`). Only the
+ * network seam is removed by passing pre-computed `customFees` (and a legacy tx
+ * type so the gas tracker is never queried), keeping the test deterministic
+ * while exercising the logic under test end to end.
+ */
+describe("[integration] EVM send-max accounts for pending operations", () => {
+  const ethereum = getCryptoCurrencyById("ethereum");
+
+  // 1 ETH balance, fully spendable, no chain reserve.
+  const ONE_ETH = new BigNumber("1000000000000000000");
+  const recipient = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+
+  // Legacy fee: 21000 gas * 20 gwei = 0.00042 ETH.
+  const GAS_LIMIT = 21_000n;
+  const GAS_PRICE = 20_000_000_000n;
+  const FEE = GAS_LIMIT * GAS_PRICE; // 420_000_000_000_000n
+
+  const customFees: FeeEstimation = {
+    value: FEE,
+    parameters: { gasLimit: GAS_LIMIT, gasPrice: GAS_PRICE },
+  };
+
+  const computeIntentType = (tx: GenericTransaction) =>
+    tx.type === 2 ? "send-eip1559" : "send-legacy";
+  const craftTransactionData = () => ({ type: "buffer" as const, value: Buffer.alloc(0) });
+
+  const makeAccount = (pendingOperations: Operation[]): Account =>
+    ({
+      id: "js:2:ethereum:0xSENDER:",
+      type: "Account",
+      currency: ethereum,
+      freshAddress: "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed",
+      balance: ONE_ETH,
+      spendableBalance: ONE_ETH,
+      subAccounts: [],
+      pendingOperations,
+    }) as unknown as Account;
+
+  const computeSendMaxAmount = async (account: Account): Promise<bigint> => {
+    const transaction = {
+      mode: "send",
+      family: "evm",
+      recipient,
+      amount: account.spendableBalance,
+      useAllAmount: true,
+    } as unknown as GenericTransaction;
+
+    const intent = transactionToIntent(account, transaction, computeIntentType, craftTransactionData);
+    const { amount } = await validateIntent(
+      ethereum,
+      intent as Parameters<typeof validateIntent>[1],
+      extractBalances(account),
+      customFees,
+    );
+    return amount;
+  };
+
+  it("offers the full balance minus fees when there is no pending operation", async () => {
+    const amount = await computeSendMaxAmount(makeAccount([]));
+    // 1 ETH - fee
+    expect(amount).toBe(BigInt(ONE_ETH.toFixed()) - FEE);
+  });
+
+  it("subtracts a pending send (amount + its fee) from the send-max amount", async () => {
+    const pendingAmount = 500_000_000_000_000_000n; // 0.5 ETH already sent
+    const pendingOp = {
+      id: "pending-out",
+      type: "OUT",
+      value: new BigNumber(pendingAmount.toString()),
+      fee: new BigNumber(FEE.toString()),
+      senders: ["0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"],
+      recipients: [recipient],
+    } as unknown as Operation;
+
+    const withoutPending = await computeSendMaxAmount(makeAccount([]));
+    const withPending = await computeSendMaxAmount(makeAccount([pendingOp]));
+
+    // The committed funds (pending value + pending fee) are removed from send-max.
+    expect(withPending).toBe(withoutPending - (pendingAmount + FEE));
+
+    // And critically: the new send-max never exceeds what will actually be
+    // available on-chain once the pending tx is mined.
+    const onChainAvailableAfterPending = BigInt(ONE_ETH.toFixed()) - pendingAmount - FEE;
+    expect(withPending + FEE).toBeLessThanOrEqual(onChainAvailableAfterPending);
+  });
+});

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -10,6 +10,7 @@ import {
   toGasOptionsFromUnknown,
   transactionToIntent,
 } from "./utils";
+import { addPendingOperation } from "@ledgerhq/ledger-wallet-framework/account/index";
 import BigNumber from "bignumber.js";
 import type { Operation as CoreOperation } from "@ledgerhq/coin-module-framework/api/types";
 import { Account } from "@ledgerhq/types-live";
@@ -829,6 +830,358 @@ describe("coin-framework utils", () => {
         },
       ]);
     });
+
+    it("locks native funds committed by a pending send (value + fee)", () => {
+      // Balance 10, a pending native send already commits amount 4 + fee 1.
+      // Spendable must drop to 5, not stay at 10.
+      expect(
+        extractBalances({
+          spendableBalance: BigNumber(10),
+          balance: BigNumber(10),
+          pendingOperations: [{ type: "OUT", value: BigNumber(4), fee: BigNumber(1) }],
+        } as unknown as Account),
+      ).toEqual([{ value: 10n, locked: 5n, asset: { type: "native" } }]);
+    });
+
+    it("stacks the chain reserve and pending spend, capped at balance", () => {
+      expect(
+        extractBalances({
+          spendableBalance: BigNumber(8),
+          balance: BigNumber(10),
+          pendingOperations: [
+            { type: "OUT", value: BigNumber(3), fee: BigNumber(1) },
+          ],
+        } as unknown as Account),
+      ).toEqual([{ value: 10n, locked: 6n, asset: { type: "native" } }]);
+
+      expect(
+        extractBalances({
+          spendableBalance: BigNumber(10),
+          balance: BigNumber(10),
+          pendingOperations: [{ type: "OUT", value: BigNumber(20), fee: BigNumber(1) }],
+        } as unknown as Account),
+      ).toEqual([{ value: 10n, locked: 10n, asset: { type: "native" } }]);
+    });
+
+    it("locks value + fee for any outgoing (OUT-family) pending op, e.g. DELEGATE", () => {
+      expect(
+        extractBalances({
+          spendableBalance: BigNumber(10),
+          balance: BigNumber(10),
+          pendingOperations: [{ type: "DELEGATE", value: BigNumber(4), fee: BigNumber(1) }],
+        } as unknown as Account),
+      ).toEqual([{ value: 10n, locked: 5n, asset: { type: "native" } }]);
+    });
+
+    it("locks the fee even for a zero-value outgoing pending op (e.g. OPT_IN)", () => {
+      expect(
+        extractBalances({
+          spendableBalance: BigNumber(10),
+          balance: BigNumber(10),
+          pendingOperations: [{ type: "OPT_IN", value: BigNumber(0), fee: BigNumber(1) }],
+        } as unknown as Account),
+      ).toEqual([{ value: 10n, locked: 1n, asset: { type: "native" } }]);
+    });
+
+    it("locks only the fee on native for staking-family ops (e.g. STAKE)", () => {
+      // STAKE is not in OPERATION_TYPE_OUT_FAMILY; only the gas fee leaves the
+      // (total) native balance, the value stays staked.
+      expect(
+        extractBalances({
+          spendableBalance: BigNumber(10),
+          balance: BigNumber(10),
+          pendingOperations: [{ type: "STAKE", value: BigNumber(4), fee: BigNumber(1) }],
+        } as unknown as Account),
+      ).toEqual([{ value: 10n, locked: 1n, asset: { type: "native" } }]);
+    });
+
+    it("locks the fee for a self-initiated incoming-family op (e.g. claim REWARD)", () => {
+      expect(
+        extractBalances({
+          spendableBalance: BigNumber(10),
+          balance: BigNumber(10),
+          pendingOperations: [{ type: "REWARD", value: BigNumber(0), fee: BigNumber(1) }],
+        } as unknown as Account),
+      ).toEqual([{ value: 10n, locked: 1n, asset: { type: "native" } }]);
+
+      expect(
+        extractBalances({
+          spendableBalance: BigNumber(10),
+          balance: BigNumber(10),
+          pendingOperations: [{ type: "REWARD", value: BigNumber(4), fee: BigNumber(1) }],
+        } as unknown as Account),
+      ).toEqual([{ value: 10n, locked: 1n, asset: { type: "native" } }]);
+    });
+
+    it("locks only the fee on native for a pending token send (FEES op)", () => {
+      expect(
+        extractBalances({
+          spendableBalance: BigNumber(10),
+          balance: BigNumber(10),
+          pendingOperations: [{ type: "FEES", value: BigNumber(1), fee: BigNumber(1) }],
+        } as unknown as Account),
+      ).toEqual([{ value: 10n, locked: 1n, asset: { type: "native" } }]);
+    });
+
+    it("locks token funds committed by a pending token send (value only, fee is native)", () => {
+      expect(
+        extractBalances(
+          {
+            spendableBalance: BigNumber(10),
+            balance: BigNumber(10),
+            subAccounts: [
+              {
+                spendableBalance: BigNumber(20),
+                balance: BigNumber(20),
+                pendingOperations: [{ type: "OUT", value: BigNumber(5), fee: BigNumber(1) }],
+                token: {
+                  tokenType: "erc20",
+                  contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                },
+              },
+            ],
+          } as unknown as Account,
+          token => ({
+            type: token.tokenType,
+            assetReference: token.contractAddress,
+          }),
+        ),
+      ).toEqual([
+        { value: 10n, locked: 0n, asset: { type: "native" } },
+        {
+          asset: {
+            assetReference: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            type: "erc20",
+          },
+          locked: 5n,
+          value: 20n,
+        },
+      ]);
+    });
+
+    it("locks token value for staking-family sub-ops (e.g. STAKE)", () => {
+      expect(
+        extractBalances(
+          {
+            spendableBalance: BigNumber(10),
+            balance: BigNumber(10),
+            subAccounts: [
+              {
+                spendableBalance: BigNumber(20),
+                balance: BigNumber(20),
+                pendingOperations: [{ type: "STAKE", value: BigNumber(8), fee: BigNumber(1) }],
+                token: {
+                  tokenType: "erc20",
+                  contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                },
+              },
+            ],
+          } as unknown as Account,
+          token => ({
+            type: token.tokenType,
+            assetReference: token.contractAddress,
+          }),
+        ),
+      ).toEqual([
+        { value: 10n, locked: 0n, asset: { type: "native" } },
+        {
+          asset: {
+            assetReference: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            type: "erc20",
+          },
+          locked: 8n,
+          value: 20n,
+        },
+      ]);
+    });
+
+    it("locks token value for non-OUT outgoing sub-ops (e.g. DELEGATE), fee stays native", () => {
+      expect(
+        extractBalances(
+          {
+            spendableBalance: BigNumber(10),
+            balance: BigNumber(10),
+            subAccounts: [
+              {
+                spendableBalance: BigNumber(20),
+                balance: BigNumber(20),
+                // buildOptimisticOperation appends the mode's type to the token sub-account.
+                pendingOperations: [{ type: "DELEGATE", value: BigNumber(7), fee: BigNumber(1) }],
+                token: {
+                  tokenType: "erc20",
+                  contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                },
+              },
+            ],
+          } as unknown as Account,
+          token => ({
+            type: token.tokenType,
+            assetReference: token.contractAddress,
+          }),
+        ),
+      ).toEqual([
+        { value: 10n, locked: 0n, asset: { type: "native" } },
+        {
+          asset: {
+            assetReference: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            type: "erc20",
+          },
+          locked: 7n,
+          value: 20n,
+        },
+      ]);
+    });
+
+    it("ignores pending incoming operations", () => {
+      expect(
+        extractBalances({
+          spendableBalance: BigNumber(10),
+          balance: BigNumber(10),
+          pendingOperations: [{ type: "IN", value: BigNumber(5), fee: BigNumber(0) }],
+        } as unknown as Account),
+      ).toEqual([{ value: 10n, locked: 0n, asset: { type: "native" } }]);
+    });
+
+    it("does not lock the fee for a sponsored (gasless) pending send, only the value", () => {
+      expect(
+        extractBalances({
+          spendableBalance: BigNumber(10),
+          balance: BigNumber(10),
+          pendingOperations: [
+            {
+              type: "OUT",
+              value: BigNumber(4),
+              fee: BigNumber(1),
+              transactionRaw: { sponsored: true },
+            },
+          ],
+        } as unknown as Account),
+      ).toEqual([{ value: 10n, locked: 4n, asset: { type: "native" } }]);
+    });
+
+    it("locks nothing on native for a sponsored pending token send (FEES op)", () => {
+      expect(
+        extractBalances({
+          spendableBalance: BigNumber(10),
+          balance: BigNumber(10),
+          pendingOperations: [
+            {
+              type: "FEES",
+              value: BigNumber(1),
+              fee: BigNumber(1),
+              transactionRaw: { sponsored: true },
+            },
+          ],
+        } as unknown as Account),
+      ).toEqual([{ value: 10n, locked: 0n, asset: { type: "native" } }]);
+    });
+
+    it("locks nothing on native for a sponsored staking-family pending op (e.g. STAKE)", () => {
+      expect(
+        extractBalances({
+          spendableBalance: BigNumber(10),
+          balance: BigNumber(10),
+          pendingOperations: [
+            {
+              type: "STAKE",
+              value: BigNumber(4),
+              fee: BigNumber(1),
+              transactionRaw: { sponsored: true },
+            },
+          ],
+        } as unknown as Account),
+      ).toEqual([{ value: 10n, locked: 0n, asset: { type: "native" } }]);
+    });
+  });
+
+  // Copilot warned that getPendingTokenSpent could lock native fees as token amount,
+  // because "FEES" is in OPERATION_TYPE_OUT_FAMILY and some fixtures/source data can
+  // attach a pending FEES op to a token sub-account.
+  // For optimistic ops produced via buildOptimisticOperation, addPendingOperation routes
+  // the FEES *parent* op to the native account and the OUT *sub*-op to the token account.
+  describe("real pending-op distribution (buildOptimisticOperation + addPendingOperation)", () => {
+    const subAccountId = "sub-account-id";
+    const buildAccount = (): Account =>
+      ({
+        id: "parent-account-id",
+        freshAddress: "account-address",
+        balance: BigNumber(100),
+        spendableBalance: BigNumber(100),
+        pendingOperations: [],
+        subAccounts: [
+          {
+            id: subAccountId,
+            balance: BigNumber(20),
+            spendableBalance: BigNumber(20),
+            pendingOperations: [],
+            token: {
+              tokenType: "erc20",
+              contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            },
+          },
+        ],
+      }) as unknown as Account;
+
+    it("routes the FEES op to the native account and the OUT op to the token sub-account", () => {
+      const account = buildAccount();
+      const optimistic = buildOptimisticOperation(
+        account,
+        {
+          mode: "send",
+          subAccountId,
+          amount: BigNumber(5),
+          fees: BigNumber(2),
+          recipient: "recipient-address",
+        } as unknown as GenericTransaction,
+        7n,
+      );
+
+      const updated = addPendingOperation(account, optimistic);
+
+      // Parent (native) account holds the FEES op, NOT the sub-account.
+      expect(updated.pendingOperations).toEqual([
+        expect.objectContaining({ type: "FEES", accountId: "parent-account-id" }),
+      ]);
+      // The token sub-account holds the OUT sub-op with the token value, no FEES op.
+      const subPending = updated.subAccounts![0].pendingOperations;
+      expect(subPending).toEqual([
+        expect.objectContaining({ type: "OUT", accountId: subAccountId, value: BigNumber(5) }),
+      ]);
+      expect(subPending.some(op => op.type === "FEES")).toBe(false);
+    });
+
+    it("locks only the token amount on the sub-account (native fee is not locked as token)", () => {
+      const account = buildAccount();
+      const optimistic = buildOptimisticOperation(
+        account,
+        {
+          mode: "send",
+          subAccountId,
+          amount: BigNumber(5),
+          fees: BigNumber(2),
+          recipient: "recipient-address",
+        } as unknown as GenericTransaction,
+        7n,
+      );
+
+      const updated = addPendingOperation(account, optimistic);
+
+      expect(
+        extractBalances(updated, token => ({
+          type: token.tokenType,
+          assetReference: token.contractAddress,
+        })),
+      ).toEqual([
+        // Native balance locks the pending fee only (2).
+        { value: 100n, locked: 2n, asset: { type: "native" } },
+        // Token balance locks the token amount only (5) — the fee (2) is NOT locked here.
+        {
+          asset: { assetReference: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", type: "erc20" },
+          locked: 5n,
+          value: 20n,
+        },
+      ]);
+    });
   });
 
   describe("extractBalance", () => {
@@ -847,9 +1200,7 @@ describe("coin-framework utils", () => {
     });
   });
 
-  jest.mock("@ledgerhq/ledger-wallet-framework/operation", () => ({
-    encodeOperationId: jest.fn((accountId, txHash, opType) => `${accountId}-${txHash}-${opType}`),
-  }));
+  // No module mock needed: encodeOperationId is deterministic in @ledgerhq/ledger-wallet-framework/operation.
 
   describe("adaptCoreOperationToLiveOperation", () => {
     const accountId = "acc_123";

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -1,4 +1,8 @@
-import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
+import {
+  encodeOperationId,
+  OPERATION_TYPE_OUT_FAMILY,
+  OPERATION_TYPE_STAKE_FAMILY,
+} from "@ledgerhq/ledger-wallet-framework/operation";
 import type { Account, Operation, OperationType } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { fromBigNumberToBigInt } from "@ledgerhq/coin-module-framework/utils";
@@ -103,17 +107,65 @@ export function extractBalance(balances: Balance[], type: string): Balance {
   );
 }
 
+// A sponsored (gasless) transaction has its fee paid by a third party, not by the
+// account, so the pending fee must not be locked against the native balance.
+function isSponsoredOperation(op: Operation): boolean {
+  const raw = op.transactionRaw;
+  return !!raw && "sponsored" in raw && raw.sponsored === true;
+}
+
+/**
+ * `pendingOperations` are optimistic and don’t affect `spendableBalance` until the next sync.
+ * Lock the native amount already committed by pending ops: fees for any non-sponsored op, plus outgoing value for OUT-family ops. See LIVE-33180.
+ */
+function getPendingNativeSpent(pendingOperations: Operation[]): BigNumber {
+  return pendingOperations.reduce((spent, op) => {
+    const withFee = isSponsoredOperation(op) ? spent : spent.plus(op.fee);
+    if (op.type === "FEES") return withFee;
+    if (OPERATION_TYPE_OUT_FAMILY.includes(op.type)) return withFee.plus(op.value);
+
+    return withFee;
+  }, new BigNumber(0));
+}
+
+// Used for token sub-accounts: lock `op.value` for pending ops that should reduce token spendable.
+// This includes OUT-family and STAKE-family types (stake-family is fee-only on native; see getOperationAmountNumber).
+function isOutgoingOperation(op: Operation): boolean {
+  return (
+    OPERATION_TYPE_OUT_FAMILY.includes(op.type) || OPERATION_TYPE_STAKE_FAMILY.includes(op.type)
+  );
+}
+
+/**
+ * Token equivalent of `getPendingNativeSpent`: returns how much of a token
+ * sub-account's balance is committed by pending operations. Fees are paid in the
+ * native currency, so only the operation `value` matters here. `buildOptimisticOperation`
+ * can append any outgoing sub-operation type to a token account (OUT, DELEGATE,
+ * STAKE, OPT_IN, ...), so we lock the value of every outgoing op rather than just
+ * plain "OUT" sends.
+ */
+export function getPendingTokenSpent(pendingOperations: Operation[]): BigNumber {
+  return pendingOperations.reduce(
+    (spent, op) => (isOutgoingOperation(op) ? spent.plus(op.value) : spent),
+    new BigNumber(0),
+  );
+}
+
 export function extractBalances(
   account: Account,
   getAssetFromToken?: (token: TokenCurrency, owner: string) => AssetInfo,
 ): Balance[] {
+  const nativeReserve = BigNumber.max(account.balance.minus(account.spendableBalance), 0);
+  const nativePending = getPendingNativeSpent(account.pendingOperations ?? []);
   const balances: Balance[] = [
     {
       // `value` is the total balance, `locked` is the non-spendable part of it.
       // Consumers must compute available funds as `value - locked`.
+      // We lock the chain reserve plus any funds already committed to pending
+      // (optimistic, not-yet-synced) transactions, capped at the total balance.
       value: BigInt(account.balance.toFixed()),
       asset: { type: "native" },
-      locked: BigInt(BigNumber.max(account.balance.minus(account.spendableBalance), 0).toFixed()),
+      locked: BigInt(BigNumber.min(nativeReserve.plus(nativePending), account.balance).toFixed()),
     },
   ];
 
@@ -123,11 +175,13 @@ export function extractBalances(
 
   for (const subAccount of account.subAccounts) {
     const asset = getAssetFromToken(subAccount.token, account.freshAddress);
+    const tokenReserve = BigNumber.max(subAccount.balance.minus(subAccount.spendableBalance), 0);
+    const tokenPending = getPendingTokenSpent(subAccount.pendingOperations ?? []);
     balances.push({
       value: BigInt(subAccount.balance.toFixed()),
       asset,
       locked: BigInt(
-        BigNumber.max(subAccount.balance.minus(subAccount.spendableBalance), 0).toFixed(),
+        BigNumber.min(tokenReserve.plus(tokenPending), subAccount.balance).toFixed(),
       ),
     });
   }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  -  If a broadcast tx gets stuck and never mines, send-max will under-offer until the optimistic op is discarded (after OPERATION_OPTIMISTIC_RETENTION) or the next sync clears it — which is the safe direction. 

### 📝 Description

We subtract pending outflows from the available balance — preserving EVM nonce-queuing (you can still send a second tx, just not more than you actually have). The fix lives in the one consistent chokepoint, extractBalances() in libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts, which now raises locked by the funds committed to pending operations:

- Native send (OUT): optimistic value excludes fees, so outflow = value + fee.
- Token send (parent FEES op on the main account): only fee leaves native.
- Staking / other: uses the canonical getOperationAmountNumber (e.g. STAKE/UNSTAKE → fee only), counting outflows only; incoming ops ignored.
- Token sub-accounts: outflow = value only (fees are paid in native, already counted on the parent).

locked is the existing chain reserve plus pending spend, capped at the total balance so it never goes negative. Because every consumer derives spendable as value - locked, this single change fixes send-max, amount validation, and gas validation at once — for EVM and all other generic-coin-framework families.


## Before  

https://github.com/user-attachments/assets/0765af16-6e33-4102-9852-89ac5d862631

## After      

https://github.com/user-attachments/assets/6bcbdae4-6913-4159-96d6-09518001e020


### ❓ Context

- **JIRA or GitHub link**:  [LIVE-33180](https://ledgerhq.atlassian.net/browse/LIVE-33180)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-33180]: https://ledgerhq.atlassian.net/browse/LIVE-33180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ