### PR TITLE
[LWD] fix(cosmos): align reward from row in operation details

### DIFF
--- a/.changeset/cosmos-reward-row-align.md
+++ b/.changeset/cosmos-reward-row-align.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Cosmos "Reward from" row layout in transaction details so the validator name and amount display inline with the other rows

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/operationDetails.tsx
@@ -261,47 +261,38 @@ const OperationDetailsExtra = ({
         break;
       }
       case "REWARD": {
-        const { validators } = extra;
-        ret = !validators ? null : (
+        ret = (
           <OpDetailsSection>
             <OpDetailsTitle>
               <Trans i18nKey={"operationDetails.extra.rewardFrom"} />
             </OpDetailsTitle>
-            <OpDetailsData>
-              <Box flex={1} style={{ minWidth: 0 }}>
-                {validators.map((validatorReward: { amount: BigNumber; address: string }) => (
-                  <Box
-                    horizontal
-                    key={validatorReward.address}
-                    alignItems="center"
-                    justifyContent="flex-end"
-                    style={{ gap: 8, width: "100%" }}
+            <Box flex={1} style={{ minWidth: 0 }}>
+              {validators.map((validatorReward: CosmosDelegationInfo) => (
+                <OpDetailsData key={validatorReward.address} style={{ gap: 8, width: "100%" }}>
+                  <Address
+                    onClick={redirectAddress(currency, validatorReward.address)}
+                    style={{
+                      wordBreak: "keep-all",
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      minWidth: 0,
+                      flexShrink: 1,
+                    }}
                   >
-                    <Address
-                      onClick={redirectAddress(currency, validatorReward.address)}
-                      style={{
-                        wordBreak: "keep-all",
-                        whiteSpace: "nowrap",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        minWidth: 0,
-                        flexShrink: 1,
-                      }}
-                    >
-                      {getValidatorName(validatorReward.address)}
-                    </Address>
-                    <Box style={{ flexShrink: 0 }}>
-                      <FormattedVal
-                        unit={unit}
-                        showCode
-                        val={validatorReward.amount}
-                        color="neutral.c80"
-                      />
-                    </Box>
+                    {getValidatorName(validatorReward.address)}
+                  </Address>
+                  <Box style={{ flexShrink: 0 }}>
+                    <FormattedVal
+                      unit={unit}
+                      showCode
+                      val={validatorReward.amount}
+                      color="neutral.c80"
+                    />
                   </Box>
-                ))}
-              </Box>
-            </OpDetailsData>
+                </OpDetailsData>
+              ))}
+            </Box>
           </OpDetailsSection>
         );
 

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/operationDetails.tsx
@@ -268,13 +268,14 @@ const OperationDetailsExtra = ({
               <Trans i18nKey={"operationDetails.extra.rewardFrom"} />
             </OpDetailsTitle>
             <OpDetailsData>
-              <Box flex={1} alignItems="flex-end">
+              <Box flex={1} style={{ minWidth: 0 }}>
                 {validators.map((validatorReward: { amount: BigNumber; address: string }) => (
                   <Box
                     horizontal
                     key={validatorReward.address}
                     alignItems="center"
-                    style={{ gap: 8 }}
+                    justifyContent="flex-end"
+                    style={{ gap: 8, width: "100%" }}
                   >
                     <Address
                       onClick={redirectAddress(currency, validatorReward.address)}
@@ -283,17 +284,20 @@ const OperationDetailsExtra = ({
                         whiteSpace: "nowrap",
                         overflow: "hidden",
                         textOverflow: "ellipsis",
-                        maxWidth: "100%",
+                        minWidth: 0,
+                        flexShrink: 1,
                       }}
                     >
                       {getValidatorName(validatorReward.address)}
                     </Address>
-                    <FormattedVal
-                      unit={unit}
-                      showCode
-                      val={validatorReward.amount}
-                      color="neutral.c80"
-                    />
+                    <Box style={{ flexShrink: 0 }}>
+                      <FormattedVal
+                        unit={unit}
+                        showCode
+                        val={validatorReward.amount}
+                        color="neutral.c80"
+                      />
+                    </Box>
                   </Box>
                 ))}
               </Box>

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/operationDetails.tsx
@@ -263,20 +263,29 @@ const OperationDetailsExtra = ({
       case "REWARD": {
         const { validators } = extra;
         ret = !validators ? null : (
-          <>
-            <OpDetailsSection>
-              <OpDetailsTitle>
-                <Trans i18nKey={"operationDetails.extra.rewardFrom"} />
-              </OpDetailsTitle>
-            </OpDetailsSection>
-            {validators.map((validatorReward: { amount: BigNumber; address: string }) => (
-              <>
-                <OpDetailsSection
-                  key={validatorReward.address}
-                  style={{ justifyContent: "flex-end" }}
-                >
-                  <OpDetailsData style={{ maxWidth: "fit-content" }}>
-                    <Address onClick={redirectAddress(currency, validatorReward.address)}>
+          <OpDetailsSection>
+            <OpDetailsTitle>
+              <Trans i18nKey={"operationDetails.extra.rewardFrom"} />
+            </OpDetailsTitle>
+            <OpDetailsData>
+              <Box flex={1} alignItems="flex-end">
+                {validators.map((validatorReward: { amount: BigNumber; address: string }) => (
+                  <Box
+                    horizontal
+                    key={validatorReward.address}
+                    alignItems="center"
+                    style={{ gap: 8 }}
+                  >
+                    <Address
+                      onClick={redirectAddress(currency, validatorReward.address)}
+                      style={{
+                        wordBreak: "keep-all",
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        maxWidth: "100%",
+                      }}
+                    >
                       {getValidatorName(validatorReward.address)}
                     </Address>
                     <FormattedVal
@@ -285,11 +294,11 @@ const OperationDetailsExtra = ({
                       val={validatorReward.amount}
                       color="neutral.c80"
                     />
-                  </OpDetailsData>
-                </OpDetailsSection>
-              </>
-            ))}
-          </>
+                  </Box>
+                ))}
+              </Box>
+            </OpDetailsData>
+          </OpDetailsSection>
         );
 
         break;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Pure layout fix in the operation details drawer; no automated visual test exists for this view._
- [x] **Impact of the changes:**
      - Cosmos-family (Osmosis, Cosmos, etc.) "Claimed reward" transaction details drawer on Desktop
      - "Reward from" row rendering (single and multiple validators)

### 📝 Description

In Ledger Live Desktop, the operation details drawer for a Cosmos-family "Claimed reward" operation rendered the **"Reward from"** row incorrectly: the validator name (e.g. `Ledger by Figment`) and amount (e.g. `0 OSMO`) appeared **below** the label and pushed to the right, instead of inline on the same row like every other row (Amount, Fee, Type, Status, Account, Date).

The root cause was in the `REWARD` case of the cosmos `OperationDetailsExtra` component: the `OpDetailsTitle` lived in its own `OpDetailsSection` with no sibling `OpDetailsData`, and each validator was rendered in a separate right-aligned section below it.

This PR restructures the `REWARD` case so the title and validator data live in a single `OpDetailsSection` (matching the `UNDELEGATE` / `REDELEGATE` pattern). The validator name and amount now render inline, right-aligned, and the validator name no longer breaks mid-word. Multiple validators stack one per line.

### 📸 Screenshots

| Before | After |
| ------ | ----- |
| <img width="597" height="840" alt="image" src="https://github.com/user-attachments/assets/bfb94043-3420-4be1-a8bb-1565ebf18e73" /> | <img width="500" height="633" alt="Screenshot 2026-06-24 at 11 20 30" src="https://github.com/user-attachments/assets/7d14ef8e-cf4b-439b-8e85-b9a0dfe85e62" /> |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33121](https://ledgerhq.atlassian.net/browse/LIVE-33121)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33121]: https://ledgerhq.atlassian.net/browse/LIVE-33121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ