### PR TITLE
[LWDM] fix: tezos fees

### DIFF
--- a/.changeset/ten-baboons-nail.md
+++ b/.changeset/ten-baboons-nail.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": minor
+---
+
+Fix native balance double-counting in listOperations by filtering out internal contract sub-transactions and zeroing token op fees

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
@@ -388,6 +388,38 @@ describe("listOperations", () => {
     });
   });
 
+  it("filters out internal sub-transactions where account is neither sender nor target", async () => {
+    const contractAddress = "KT1WPEis2WhAc2FciM2tZVn8qe6pCBe9HkDp";
+    const thirdPartyAddress = "tz1Pci9FqMTqADRXqgD3ZDsdfEFcPqMTqA8D";
+
+    // Top-level: user sends to contract
+    const topLevelTx: APITransactionType = {
+      ...transfer,
+      id: 700,
+      amount: 100000,
+      target: { address: contractAddress },
+    };
+
+    // Internal: contract forwards to a third party (neither sender nor target is our account)
+    const internalTx: APITransactionType = {
+      ...transfer,
+      id: 701,
+      amount: 90000,
+      initiator: { address: someSenderAddress },
+      sender: { address: contractAddress },
+      target: { address: thirdPartyAddress },
+    };
+
+    mockGetAccountOperations.mockResolvedValue([topLevelTx, internalTx]);
+    const [results] = await listOperations(someSenderAddress, options);
+
+    // Only the top-level tx should be kept; the internal sub-tx is filtered out
+    expect(results).toHaveLength(1);
+    expect(results[0].senders).toEqual([someSenderAddress]);
+    expect(results[0].recipients).toEqual([contractAddress]);
+    expect(results[0].value).toEqual(100000n);
+  });
+
   it("FA2 token transfers (tokenId 0), attributes fees from parent tx", async () => {
     const fa2: APITokenTransfer & { hash: string } = {
       id: 9001,

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
@@ -168,6 +168,7 @@ describe("listOperations", () => {
     id: 333,
     initiator: null,
     type: "transaction",
+    status: "applied",
     target: { address: someDestinationAddress },
   };
 
@@ -188,8 +189,8 @@ describe("listOperations", () => {
     async (_label, operation, expectedType, expectedLedgerOpType, expectedAmount) => {
       // Given
       mockGetAccountOperations.mockResolvedValue([operation]);
-      // When
-      const [results] = await listOperations("any address", options);
+      // When — use someSenderAddress so transaction ops pass the sender/target filter
+      const [results] = await listOperations(someSenderAddress, options);
       // Then
       expect(results).toEqual([
         {
@@ -237,7 +238,7 @@ describe("listOperations", () => {
       // Given
       mockGetAccountOperations.mockResolvedValue([operation]);
       // When
-      const [results, token] = await listOperations("any address", {
+      const [results, token] = await listOperations(someSenderAddress, {
         ...options,
         limit: 1,
         sort: "Descending",
@@ -264,7 +265,7 @@ describe("listOperations", () => {
       // Given
       mockGetAccountOperations.mockResolvedValue([operation]);
       // When
-      const [results, _] = await listOperations("any address", options);
+      const [results, _] = await listOperations(someSenderAddress, options);
       // Then
       expect(results.length).toEqual(1);
       expect(results[0].details).toEqual({
@@ -283,7 +284,7 @@ describe("listOperations", () => {
     // Given
     mockGetAccountOperations.mockResolvedValue([operation]);
     // When
-    const [results, token] = await listOperations("any address", options);
+    const [results, token] = await listOperations(someSenderAddress, options);
     // Then
     expect(results.length).toEqual(1);
     expect(results[0].recipients).toEqual([]);
@@ -298,7 +299,7 @@ describe("listOperations", () => {
     // Given
     mockGetAccountOperations.mockResolvedValue([operation]);
     // When
-    const [results, _] = await listOperations("any address", options);
+    const [results, _] = await listOperations(someSenderAddress, options);
     // Then
     expect(results.length).toEqual(1);
     expect(results[0].tx.fees).toEqual(BigInt(6));
@@ -336,7 +337,7 @@ describe("listOperations", () => {
         target: { address: someDestinationAddress },
       };
       mockGetAccountOperations.mockResolvedValue([internalTx]);
-      const [results] = await listOperations("any address", options);
+      const [results] = await listOperations(someDestinationAddress, options);
       expect(results[0]).toMatchObject({
         tx: {
           feesPayer: initiatorAddress,
@@ -354,7 +355,7 @@ describe("listOperations", () => {
         sender: null,
       };
       mockGetAccountOperations.mockResolvedValue([txNoSender]);
-      const [results] = await listOperations("any address", options);
+      const [results] = await listOperations(someDestinationAddress, options);
       expect(results[0].tx.feesPayer).toBeUndefined();
       expect(results[0]).toMatchObject({
         senders: [],
@@ -434,7 +435,7 @@ describe("listOperations", () => {
       },
       tx: {
         hash: someHash,
-        fees: 6n,
+        fees: 0n,
         feesPayer: someSenderAddress,
         failed: false,
         block: { hash: "BMJ1ZQ6", height: 100, time: new Date(fa2.timestamp) },

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
@@ -236,6 +236,16 @@ function keepNativeOp(
       return false;
     }
   }
+  // Filter out internal (contract-to-contract/contract-to-third-party) transactions:
+  // TzKT returns these under the initiator's account, but they don't impact the
+  // initiator's native balance — the top-level operation already accounts for it.
+  if (isAPITransactionType(op)) {
+    const isSender = op.sender?.address === address;
+    const isTarget = op.target?.address === address;
+    if (!isSender && !isTarget) {
+      return false;
+    }
+  }
   return true;
 }
 
@@ -556,11 +566,6 @@ function convertTokenOperation(
     type = "IN";
   }
 
-  const fee = parent
-    ? BigInt(parent.storageFee ?? 0) +
-      BigInt(parent.bakerFee ?? 0) +
-      BigInt(parent.allocationFee ?? 0)
-    : 0n;
   const feesPayer = parent?.initiator?.address ?? parent?.sender?.address;
 
   const tokenId = transfer.token.tokenId ?? "0";
@@ -584,7 +589,9 @@ function convertTokenOperation(
     },
     tx: {
       hash: transfer.hash,
-      fees: fee,
+      // Fee is already on the parent native operation; setting 0 avoids
+      // double-counting when A4 sums fees across sub-operations (FeeAggregationMode.Sum).
+      fees: 0n,
       ...(feesPayer ? { feesPayer } : {}),
       block: {
         hash: transfer.block ?? parent?.block ?? "",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Accounts with smart contract interactions (e.g. sending XTZ to a contract that forwards it) had inflated native balances. Two issues in `listOperations`:

1. **Internal sub-transactions counted as account OUTs:** When a user sends XTZ to a contract, TzKT returns both the top-level tx (user → contract) and the internal txs (contract → third    party) under the user's operations. `listOperations` included all of them, double-counting the spent amount.

2. **Token ops duplicated parent fees:** Token transfer operations copied `tx.fees` from the parent native transaction. When fees were summed across sub-operations per tx hash, the same fee was counted twice (once on the native op, once on the token op).

#### Before

For an account sending 100,000 mutez to a contract that forwards 90,000 + 10,000:

| Operation | type | value | fees | source |
|-----------|------|-------|------|--------|
| user → contract | OUT | 100,000 | 17,873 | top-level |
| contract → addr1 | OUT | 90,000 | 0 | internal |
| contract → addr2 | OUT | 10,000 | 0 | internal |

Native impact: -(100,000 + 90,000 + 10,000) - 17,873 = **-217,873** (wrong — should be -117,873)
#### After

| Operation | type | value | fees | source |
|-----------|------|-------|------|--------|
| user → contract | OUT | 100,000 | 17,873 | top-level |
| ~~contract → addr1~~ | — | — | — | filtered |
| ~~contract → addr2~~ | — | — | — | filtered |

Native impact: -100,000 - 17,873 = **-117,873** (correct)

#### Changes

- **`keepNativeOp`**: Filter out transactions where the account is neither sender nor target (internal contract sub-operations)
- **`convertTokenOperation`**: Set `fees: 0n` — the fee is already on the parent native operation
- **Tests**: Use realistic addresses so transaction ops pass the new sender/target filter; add `status: "applied"` to the base `transfer` fixture


### ❓ Context

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
