### PR TITLE
[LWDM] feat: shared LineChart utils and analytics value-change helpers

### DIFF
--- a/.changeset/lwd-linechart-foundation.md
+++ b/.changeset/lwd-linechart-foundation.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/live-countervalues": patch
+---
+
+Add shared LineChart axis/formatters utilities, custom ranges prop, and chart label inset fix. Refactor AssetDetail chart VM to use shared helpers. Add Analytics all-time value change helpers and export `meaningfulPercentage` from live-countervalues.

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/LineChartPlotContent.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/LineChartPlotContent.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { LineChart as LumenLineChart } from "@ledgerhq/lumen-ui-react-visualization";
-import { LUMEN_CHART_OVERFLOW_MARGIN } from "./constants";
+import { LINE_CHART_DRAWING_INSET } from "./constants";
 import { LineChartPoints } from "./LineChartPoints";
 import { LineChartScrubber } from "./LineChartScrubber";
 import type {
@@ -54,17 +54,14 @@ export function LineChartPlotContent({
   yAxis,
 }: LineChartPlotContentProps) {
   return (
-    <div
-      data-testid="line-chart-plot"
-      className="w-full min-w-0"
-      style={{ paddingTop: LUMEN_CHART_OVERFLOW_MARGIN }}
-    >
+    <div data-testid="line-chart-plot" className="w-full min-w-0">
       <LumenLineChart
         series={chartSeries}
         loading={isLoading}
         emptyLabel={emptyLabel}
         height={height}
         width="100%"
+        inset={LINE_CHART_DRAWING_INSET}
         showArea={showArea}
         enableScrubbing={enableScrubber}
         onScrubberPositionChange={onScrubberPositionChange}

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/LineChartPoints.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/LineChartPoints.tsx
@@ -19,7 +19,7 @@ export function LineChartPoints({ points, formatValue }: LineChartPointsProps) {
           key={`${marker.index}-${marker.value}-${marker.labelPosition ?? "top"}`}
           dataX={marker.index}
           dataY={marker.value}
-          label={marker.hideLabel ? undefined : (marker.label ?? formatValue(marker.value))}
+          label={marker.hideLabel ? undefined : marker.label ?? formatValue(marker.value)}
           labelPosition={marker.labelPosition ?? "top"}
           hidePoint={marker.hidePoint}
           size={LINE_CHART_POINT_SIZE}

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/__tests__/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/__tests__/index.test.tsx
@@ -81,4 +81,13 @@ describe("LineChart", () => {
       "Failed to fetch prices",
     );
   });
+
+  it("renders only the provided custom ranges", () => {
+    renderLineChart({ ranges: ["1d", "1w", "all"] });
+
+    expect(screen.getByTestId("line-chart-range-1d")).toBeVisible();
+    expect(screen.getByTestId("line-chart-range-1w")).toBeVisible();
+    expect(screen.getByTestId("line-chart-range-all")).toBeVisible();
+    expect(screen.queryByTestId("line-chart-range-6m")).not.toBeInTheDocument();
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/__tests__/lineChartAxisConfig.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/__tests__/lineChartAxisConfig.test.ts
@@ -1,0 +1,52 @@
+import { getEvenlySpacedTicks } from "../utils/getEvenlySpacedTicks";
+import {
+  buildLineChartBottomPaddedYAxisConfig,
+  buildLineChartXAxisConfig,
+} from "../utils/lineChartAxisConfig";
+
+describe("getEvenlySpacedTicks", () => {
+  it("returns an empty array when length is zero", () => {
+    expect(getEvenlySpacedTicks(0, 5)).toEqual([]);
+  });
+
+  it("returns all indices when length is below minTicks", () => {
+    expect(getEvenlySpacedTicks(3, 5)).toEqual([0, 1, 2]);
+  });
+
+  it("returns evenly spaced ticks including first and last indices", () => {
+    expect(getEvenlySpacedTicks(10, 5)).toEqual([0, 2, 5, 7, 9]);
+  });
+
+  it("falls back to first and last indices when minTicks is below 2", () => {
+    expect(getEvenlySpacedTicks(10, 1)).toEqual([0, 9]);
+    expect(getEvenlySpacedTicks(10, 0)).toEqual([0, 9]);
+  });
+});
+
+describe("buildLineChartXAxisConfig", () => {
+  it("formats tick labels from timestamps", () => {
+    const timestamps = [1_000, 2_000, 3_000];
+    const config = buildLineChartXAxisConfig({
+      timestamps,
+      selectedRange: "1w",
+      formatDate: timestamp => `date-${timestamp}`,
+    });
+
+    expect(config.tickLabelFormatter?.(1)).toBe("date-2000");
+    expect(config.ticks).toEqual([0, 1, 2]);
+  });
+});
+
+describe("buildLineChartBottomPaddedYAxisConfig", () => {
+  it("extends the min domain below the data range", () => {
+    const config = buildLineChartBottomPaddedYAxisConfig(240, 50);
+    const domainFn = config.domain;
+    if (typeof domainFn !== "function") {
+      throw new Error("Expected y-axis domain to be a function");
+    }
+    const domain = domainFn({ min: 100, max: 200 });
+
+    expect(domain.max).toBe(200);
+    expect(domain.min).toBeCloseTo(79.16666666666667);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/constants.ts
@@ -16,6 +16,10 @@ export const DEFAULT_LINE_CHART_HEIGHT = 240;
 /** Matches @ledgerhq/lumen-ui-react-visualization CartesianChart overflow margins. */
 export const LUMEN_CHART_OVERFLOW_MARGIN = 30;
 
+export const LINE_CHART_DRAWING_INSET = {
+  top: LUMEN_CHART_OVERFLOW_MARGIN,
+} as const;
+
 export const LINE_CHART_COLOR_TO_STROKE = {
   success: cssVar("var(--color-background-success-strong)"),
   error: cssVar("var(--color-background-error-strong)"),

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/types.ts
@@ -79,4 +79,6 @@ export type LineChartProps = Readonly<{
   yAxis?: LineChartYAxisConfig;
   /** Optional control rendered inline at the end of the range-selector row (e.g. a chart options menu). */
   rangeSelectorTrailing?: ReactNode;
+  /** Subset of ranges to show in the selector. Defaults to all supported ranges. */
+  ranges?: readonly LineChartRange[];
 }>;

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/useLineChartViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/useLineChartViewModel.ts
@@ -68,6 +68,7 @@ export function useLineChartViewModel({
   xAxis,
   yAxis,
   rangeSelectorTrailing,
+  ranges,
 }: LineChartProps): LineChartViewModelResult {
   const { t } = useTranslation();
   const stroke = LINE_CHART_COLOR_TO_STROKE[color];
@@ -101,9 +102,10 @@ export function useLineChartViewModel({
     return map;
   }, [resolvedPoints]);
 
+  const effectiveRanges = ranges ?? LINE_CHART_RANGES;
   const rangeButtons = useMemo(
-    () => LINE_CHART_RANGES.map(range => ({ value: range, label: t(`lineChart.range.${range}`) })),
-    [t],
+    () => effectiveRanges.map(range => ({ value: range, label: t(`lineChart.range.${range}`) })),
+    [effectiveRanges, t],
   );
 
   return {

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/utils/createFiatLineChartValueFormatter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/utils/createFiatLineChartValueFormatter.ts
@@ -1,0 +1,15 @@
+import BigNumber from "bignumber.js";
+import { formatPrice } from "@ledgerhq/live-currency-format";
+import type { Unit } from "@ledgerhq/types-cryptoassets";
+import type { LineChartValueFormatter } from "../types";
+
+export function createFiatLineChartValueFormatter(
+  fiatUnit: Unit,
+  locale: string,
+): LineChartValueFormatter {
+  return value =>
+    formatPrice(fiatUnit, new BigNumber(value).times(10 ** fiatUnit.magnitude), {
+      showCode: true,
+      locale,
+    });
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/utils/createLineChartTooltipTitle.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/utils/createLineChartTooltipTitle.ts
@@ -1,0 +1,12 @@
+import type { LineChartTooltipTitle } from "../types";
+
+export function createLineChartTooltipTitle(
+  timestamps: number[],
+  formatDate: (timestamp: number) => string,
+): LineChartTooltipTitle {
+  return dataIndex => {
+    const timestamp = timestamps[dataIndex];
+    if (timestamp == null) return undefined;
+    return formatDate(timestamp);
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/utils/getEvenlySpacedTicks.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/utils/getEvenlySpacedTicks.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns evenly spaced data indices (always including the first and last point)
+ * so the x-axis renders at least `minTicks` labels when enough data is available.
+ */
+export function getEvenlySpacedTicks(length: number, minTicks: number): number[] {
+  if (length <= 0) return [];
+  const effectiveMinTicks = Math.max(2, minTicks);
+  if (length <= effectiveMinTicks) return Array.from({ length }, (_, index) => index);
+
+  const ticks = Array.from({ length: effectiveMinTicks }, (_, index) =>
+    Math.round((index * (length - 1)) / (effectiveMinTicks - 1)),
+  );
+  return Array.from(new Set(ticks));
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/utils/lineChartAxisConfig.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/utils/lineChartAxisConfig.ts
@@ -1,0 +1,49 @@
+import type { LineChartRange, LineChartXAxisConfig, LineChartYAxisConfig } from "../types";
+import { DEFAULT_LINE_CHART_HEIGHT } from "../constants";
+import { getEvenlySpacedTicks } from "./getEvenlySpacedTicks";
+
+const MIN_X_AXIS_TICKS = 5;
+const MIN_X_AXIS_TICKS_1D = 8;
+
+export const LINE_CHART_Y_AXIS_BOTTOM_OFFSET_PX = 50;
+
+export const LINE_CHART_VIEW_HEIGHT =
+  DEFAULT_LINE_CHART_HEIGHT + LINE_CHART_Y_AXIS_BOTTOM_OFFSET_PX;
+
+export function buildLineChartXAxisConfig({
+  timestamps,
+  selectedRange,
+  formatDate,
+}: {
+  readonly timestamps: number[];
+  readonly selectedRange: LineChartRange;
+  readonly formatDate: (timestamp: number) => string;
+}): LineChartXAxisConfig {
+  return {
+    showLine: false,
+    ticks: getEvenlySpacedTicks(
+      timestamps.length,
+      selectedRange === "1d" ? MIN_X_AXIS_TICKS_1D : MIN_X_AXIS_TICKS,
+    ),
+    tickLabelFormatter: value => {
+      const timestamp = timestamps[Number(value)];
+      return timestamp == null ? "" : formatDate(timestamp);
+    },
+  };
+}
+
+export function buildLineChartBottomPaddedYAxisConfig(
+  chartBaseHeight = DEFAULT_LINE_CHART_HEIGHT,
+  bottomOffsetPx = LINE_CHART_Y_AXIS_BOTTOM_OFFSET_PX,
+): LineChartYAxisConfig {
+  return {
+    domain: ({ min, max }) => {
+      const range = max - min || Math.abs(max) || 1;
+      const valuePerPx = range / chartBaseHeight;
+      return {
+        min: min - bottomOffsetPx * valuePerPx,
+        max,
+      };
+    },
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/__tests__/computeAllTimeValueChangeFromFirstReceive.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/__tests__/computeAllTimeValueChangeFromFirstReceive.test.ts
@@ -1,0 +1,89 @@
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import {
+  getCryptoCurrencyById,
+  getFiatCurrencyByTicker,
+} from "@ledgerhq/live-common/currencies/index";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { calculate } from "@ledgerhq/live-countervalues/logic";
+import BigNumber from "bignumber.js";
+import type { Account } from "@ledgerhq/types-live";
+import { computeAllTimeValueChangeFromFirstReceive } from "../computeAllTimeValueChangeFromFirstReceive";
+
+jest.mock("@ledgerhq/live-countervalues/logic", () => ({
+  calculate: jest.fn(),
+}));
+
+const mockCalculate = jest.mocked(calculate);
+
+const btc = getCryptoCurrencyById("bitcoin");
+const usd = getFiatCurrencyByTicker("USD");
+const mockCvState = { data: {}, status: {}, cache: {} } as CounterValuesState;
+
+function accountWithReceive(id: string, receiveDate: Date, receiveValue: number): Account {
+  const account = genAccount(id, { currency: btc });
+  account.operations = [
+    {
+      ...account.operations[0],
+      id: `${id}-receive`,
+      type: "IN",
+      date: receiveDate,
+      value: new BigNumber(receiveValue),
+    },
+  ];
+  return account;
+}
+
+describe("computeAllTimeValueChangeFromFirstReceive", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns null percentage when there are no receive operations", () => {
+    const account = genAccount("empty", { currency: btc });
+    account.operations = [];
+
+    const result = computeAllTimeValueChangeFromFirstReceive([account], 1000, mockCvState, usd);
+
+    expect(result).toEqual({ value: 0, percentage: null });
+  });
+
+  it("uses the earliest receive operation as the all-time baseline", () => {
+    const earlier = accountWithReceive("btc-1", new Date("2020-01-01"), 1_000_000);
+    const later = accountWithReceive("btc-2", new Date("2021-01-01"), 2_000_000);
+    mockCalculate.mockReturnValue(100);
+
+    const result = computeAllTimeValueChangeFromFirstReceive(
+      [later, earlier],
+      250,
+      mockCvState,
+      usd,
+    );
+
+    expect(mockCalculate).toHaveBeenCalledWith(
+      mockCvState,
+      expect.objectContaining({
+        date: earlier.operations[0].date,
+      }),
+    );
+    expect(result.value).toBe(150);
+    expect(result.percentage).toBe(1.5);
+  });
+
+  it("returns a neutral value change when the first receive countervalue is unavailable", () => {
+    const account = accountWithReceive("btc-1", new Date("2020-01-01"), 1_000_000);
+    mockCalculate.mockReturnValue(undefined);
+
+    const result = computeAllTimeValueChangeFromFirstReceive([account], 1000, mockCvState, usd);
+
+    expect(result).toEqual({ value: 0, percentage: null });
+  });
+
+  it("returns zero percentage when the all-time delta is exactly zero", () => {
+    const account = accountWithReceive("btc-1", new Date("2020-01-01"), 1_000_000);
+    mockCalculate.mockReturnValue(1000);
+
+    const result = computeAllTimeValueChangeFromFirstReceive([account], 1000, mockCvState, usd);
+
+    expect(result).toEqual({ value: 0, percentage: 0 });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/__tests__/resolveAnalyticsValueChange.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/__tests__/resolveAnalyticsValueChange.test.ts
@@ -1,0 +1,43 @@
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import { resolveAnalyticsValueChange } from "../resolveAnalyticsValueChange";
+import { defaultPortfolio, mockCounterValue } from "LLD/hooks/__tests__/fixtures";
+
+const mockCvState = { data: {}, status: {}, cache: {} } as CounterValuesState;
+
+describe("resolveAnalyticsValueChange", () => {
+  it("uses the selected portfolio range change for non-all ranges", () => {
+    const portfolio = {
+      ...defaultPortfolio,
+      countervalueChange: { percentage: 0.12, value: 120 },
+    };
+
+    const result = resolveAnalyticsValueChange({
+      selectedTimeRange: "week",
+      accounts: [],
+      currentBalance: 1000,
+      portfolio,
+      cvState: mockCvState,
+      counterValue: mockCounterValue,
+    });
+
+    expect(result).toEqual(portfolio.countervalueChange);
+  });
+
+  it("uses the first receive baseline for the all-time range", () => {
+    const portfolio = {
+      ...defaultPortfolio,
+      countervalueChange: { percentage: 0.5, value: 500 },
+    };
+
+    const result = resolveAnalyticsValueChange({
+      selectedTimeRange: "all",
+      accounts: [],
+      currentBalance: 1000,
+      portfolio,
+      cvState: mockCvState,
+      counterValue: mockCounterValue,
+    });
+
+    expect(result).toEqual({ value: 0, percentage: null });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/computeAllTimeValueChangeFromFirstReceive.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/computeAllTimeValueChangeFromFirstReceive.ts
@@ -1,0 +1,54 @@
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { getOperationAmountNumber } from "@ledgerhq/live-common/operation";
+import { calculate } from "@ledgerhq/live-countervalues/logic";
+import { meaningfulPercentage } from "@ledgerhq/live-countervalues/portfolio";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import { flattenAccounts } from "@ledgerhq/ledger-wallet-framework/account";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import type { AccountLike, ValueChange } from "@ledgerhq/types-live";
+
+export function computeAllTimeValueChangeFromFirstReceive(
+  accounts: AccountLike[],
+  currentBalance: number,
+  cvState: CounterValuesState,
+  cvCurrency: Currency,
+): ValueChange {
+  let firstReceiveDate: Date | undefined;
+  let firstReceiveAmount = 0;
+  let firstReceiveCurrency: Currency | undefined;
+
+  for (const account of flattenAccounts(accounts)) {
+    for (const operation of account.operations) {
+      if (operation.type !== "IN") continue;
+      if (!firstReceiveDate || operation.date < firstReceiveDate) {
+        firstReceiveDate = operation.date;
+        firstReceiveAmount = getOperationAmountNumber(operation).toNumber();
+        firstReceiveCurrency = getAccountCurrency(account);
+      }
+    }
+  }
+
+  if (!firstReceiveDate || !firstReceiveCurrency) {
+    return { value: 0, percentage: null };
+  }
+
+  const firstReceiveCountervalue = calculate(cvState, {
+    from: firstReceiveCurrency,
+    to: cvCurrency,
+    value: firstReceiveAmount,
+    date: firstReceiveDate,
+    disableRounding: true,
+  });
+
+  if (typeof firstReceiveCountervalue !== "number") {
+    return { value: 0, percentage: null };
+  }
+
+  const value = currentBalance - firstReceiveCountervalue;
+
+  return {
+    value,
+    percentage:
+      value === 0 ? 0 : (meaningfulPercentage(value, firstReceiveCountervalue) ?? null),
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/resolveAnalyticsValueChange.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/resolveAnalyticsValueChange.ts
@@ -1,0 +1,31 @@
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import type { AccountLike, Portfolio, PortfolioRange, ValueChange } from "@ledgerhq/types-live";
+import { computeAllTimeValueChangeFromFirstReceive } from "./computeAllTimeValueChangeFromFirstReceive";
+
+export function resolveAnalyticsValueChange({
+  selectedTimeRange,
+  accounts,
+  currentBalance,
+  portfolio,
+  cvState,
+  counterValue,
+}: {
+  readonly selectedTimeRange: PortfolioRange;
+  readonly accounts: AccountLike[];
+  readonly currentBalance: number;
+  readonly portfolio: Portfolio;
+  readonly cvState: CounterValuesState;
+  readonly counterValue: Currency;
+}): ValueChange {
+  if (selectedTimeRange === "all") {
+    return computeAllTimeValueChangeFromFirstReceive(
+      accounts,
+      currentBalance,
+      cvState,
+      counterValue,
+    );
+  }
+
+  return portfolio.countervalueChange;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
@@ -8,7 +8,6 @@ import {
   type TransactionInput,
 } from "@ledgerhq/asset-detail";
 import type { DistributionItem } from "@ledgerhq/types-live";
-import { formatPrice } from "@ledgerhq/live-currency-format";
 import { track } from "~/renderer/analytics/segment";
 import { ASSET_DETAIL_TRACKING_PAGE_NAME } from "LLD/features/AssetDetail/constants";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
@@ -25,9 +24,14 @@ import {
   type LineChartSeries,
   type LineChartTooltipTitle,
   type LineChartValueFormatter,
-  type LineChartXAxisConfig,
-  type LineChartYAxisConfig,
 } from "LLD/components/LineChart";
+import { createFiatLineChartValueFormatter } from "LLD/components/LineChart/utils/createFiatLineChartValueFormatter";
+import { createLineChartTooltipTitle } from "LLD/components/LineChart/utils/createLineChartTooltipTitle";
+import {
+  buildLineChartBottomPaddedYAxisConfig,
+  buildLineChartXAxisConfig,
+  LINE_CHART_VIEW_HEIGHT,
+} from "LLD/components/LineChart/utils/lineChartAxisConfig";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import {
   counterValueCurrencySelector,
@@ -47,27 +51,6 @@ import { useAssetDetailChartSeries } from "../../hooks/useAssetDetailChartSeries
 import { useAssetChartDateFormatter } from "../../hooks/useAssetChartDateFormatter";
 import { useScrubbedPrice } from "../../context/ScrubbedPriceContext";
 import { buildTransactionPointMarker } from "./utils/buildTransactionPointMarker";
-
-const MIN_X_AXIS_TICKS = 5;
-const MIN_X_AXIS_TICKS_1D = 8;
-
-const CHART_BASE_HEIGHT = 240;
-const Y_AXIS_OFFSET_BOTTOM_PX = 50;
-const CHART_HEIGHT = CHART_BASE_HEIGHT + Y_AXIS_OFFSET_BOTTOM_PX;
-
-/**
- * Returns evenly spaced data indices (always including the first and last point)
- * so the x-axis renders at least `minTicks` labels when enough data is available.
- */
-function getEvenlySpacedTicks(length: number, minTicks: number): number[] {
-  if (length <= 0) return [];
-  if (length <= minTicks) return Array.from({ length }, (_, index) => index);
-
-  const ticks = Array.from({ length: minTicks }, (_, index) =>
-    Math.round((index * (length - 1)) / (minTicks - 1)),
-  );
-  return Array.from(new Set(ticks));
-}
 
 type UseChartSectionViewModelProps = Readonly<{
   marketData: AssetMarketData;
@@ -91,8 +74,8 @@ export type ChartSectionViewModelResult = Readonly<{
   onScrubberPositionChange: LineChartScrubberPositionChange;
   showXAxis: boolean;
   showYAxis: boolean;
-  xAxis: LineChartXAxisConfig;
-  yAxis: LineChartYAxisConfig;
+  xAxis: ReturnType<typeof buildLineChartXAxisConfig>;
+  yAxis: ReturnType<typeof buildLineChartBottomPaddedYAxisConfig>;
   points: LineChartPointMarker[];
   currencyId?: string;
 }>;
@@ -250,54 +233,24 @@ export function useChartSectionViewModel({
     selectedRange,
   ]);
 
-  const formatValue = useCallback<LineChartValueFormatter>(
-    value =>
-      formatPrice(fiatUnit, new BigNumber(value).times(10 ** fiatUnit.magnitude), {
-        showCode: true,
-        locale,
-      }),
+  const formatValue = useMemo(
+    () => createFiatLineChartValueFormatter(fiatUnit, locale),
     [fiatUnit, locale],
   );
 
   const formatDate = useAssetChartDateFormatter(selectedRange);
 
-  const tooltipTitle = useCallback<LineChartTooltipTitle>(
-    dataIndex => {
-      const timestamp = timestamps[dataIndex];
-      if (timestamp == null) return undefined;
-      return formatDate(timestamp);
-    },
+  const tooltipTitle = useMemo(
+    () => createLineChartTooltipTitle(timestamps, formatDate),
     [timestamps, formatDate],
   );
 
-  const xAxis = useMemo<LineChartXAxisConfig>(
-    () => ({
-      showLine: false,
-      ticks: getEvenlySpacedTicks(
-        timestamps.length,
-        selectedRange === "1d" ? MIN_X_AXIS_TICKS_1D : MIN_X_AXIS_TICKS,
-      ),
-      tickLabelFormatter: value => {
-        const timestamp = timestamps[Number(value)];
-        return timestamp == null ? "" : formatDate(timestamp);
-      },
-    }),
+  const xAxis = useMemo(
+    () => buildLineChartXAxisConfig({ timestamps, selectedRange, formatDate }),
     [timestamps, formatDate, selectedRange],
   );
 
-  const yAxis = useMemo<LineChartYAxisConfig>(
-    () => ({
-      domain: ({ min, max }) => {
-        const range = max - min || Math.abs(max) || 1;
-        const valuePerPx = range / CHART_BASE_HEIGHT;
-        return {
-          min: min - Y_AXIS_OFFSET_BOTTOM_PX * valuePerPx,
-          max,
-        };
-      },
-    }),
-    [],
-  );
+  const yAxis = useMemo(() => buildLineChartBottomPaddedYAxisConfig(), []);
 
   const { setSelection } = useScrubbedPrice();
 
@@ -335,7 +288,7 @@ export function useChartSectionViewModel({
 
   return {
     series,
-    height: CHART_HEIGHT,
+    height: LINE_CHART_VIEW_HEIGHT,
     selectedRange,
     onRangeChange: handleRangeChange,
     color,

--- a/libs/live-countervalues/src/portfolio.ts
+++ b/libs/live-countervalues/src/portfolio.ts
@@ -219,7 +219,7 @@ function getBalanceHistoryWithChanges(
   };
 }
 
-function meaningfulPercentage(
+export function meaningfulPercentage(
   deltaChange: number | null | undefined,
   balanceDivider: number | null | undefined,
   percentageHighThreshold = 100000,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Extract shared `LineChart` axis/formatters utilities, custom `ranges` prop, and chart label inset fix
- Refactor AssetDetail chart view model to use the shared helpers (no behavior change)
- Add Analytics all-time value change helpers (`computeAllTimeValueChangeFromFirstReceive`, `resolveAnalyticsValueChange`)
- Export `meaningfulPercentage` from `@ledgerhq/live-countervalues`


### ❓ Context

[LIVE-31883](https://ledgerhq.atlassian.net/browse/LIVE-31883)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)



[LIVE-31883]: https://ledgerhq.atlassian.net/browse/LIVE-31883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ