### PR TITLE
[LWDM] feat(celo): deprecate Ledger by Figment validator

### DIFF
--- a/.changeset/celo-deprecate-figment-validator.md
+++ b/.changeset/celo-deprecate-figment-validator.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-celo": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+celo: deprecate the "Ledger by Figment" validator. It is no longer shown or selectable in the vote flow and is never the default — the validator list is now ranked by TVL with none selected by default. Existing delegations remain fully manageable (unvote / unlock / withdraw).

--- a/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/Body.tsx
@@ -3,7 +3,7 @@ import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
 import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { connect } from "react-redux";
@@ -21,8 +21,6 @@ import { getCurrentDevice } from "~/renderer/reducers/devices";
 import StepAmount, { StepAmountFooter } from "./steps/StepAmount";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import StepValidatorGroup, { StepValidatorGroupFooter } from "./steps/StepValidatorGroup";
-import { defaultValidatorGroupAddress } from "@ledgerhq/live-common/families/celo/logic";
-import { useValidatorGroups } from "@ledgerhq/live-common/families/celo/react";
 import { CeloAccount, Transaction } from "@ledgerhq/live-common/families/celo/types";
 import { Operation, Account, TokenAccount } from "@ledgerhq/types-live";
 import { St, StepProps, StepId } from "./types";
@@ -88,7 +86,6 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const dispatch = useDispatch();
   const { account, source } = params;
   const bridge = useAccountBridge<Transaction>(account, undefined);
-  const validatorGroups = useValidatorGroups();
   const {
     transaction,
     setTransaction,
@@ -100,7 +97,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   } = useBridgeTransaction(bridge, () => {
     const transaction = bridge.updateTransaction(bridge.createTransaction(account), {
       mode: "vote",
-      recipient: validatorGroups[0]?.address ?? defaultValidatorGroupAddress(),
+      recipient: "",
     });
     return {
       account,
@@ -108,17 +105,6 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
       transaction,
     };
   });
-
-  // Auto-select the first eligible validator group when the current recipient is no longer in the list
-  // (e.g. after preload filters out an ineligible default group like Ledger by Figment)
-  useEffect(() => {
-    if (!transaction || !validatorGroups.length) return;
-    if (!validatorGroups.find(vg => vg.address === transaction.recipient)) {
-      setTransaction(
-        bridge.updateTransaction(transaction, { recipient: validatorGroups[0].address }),
-      );
-    }
-  }, [validatorGroups, transaction, account, setTransaction, bridge]);
 
   const handleStepChange = useCallback((e: St) => onChangeStepId(e.id), [onChangeStepId]);
   const handleRetry = useCallback(() => {

--- a/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/fields/ValidatorGroupsField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/fields/ValidatorGroupsField.tsx
@@ -31,7 +31,7 @@ const ValidatorGroupsField = ({
 }: Props) => {
   invariant(account && account.celoResources, "celo account and resources required");
   const [search, setSearch] = useState("");
-  const [showAll, setShowAll] = useState(false);
+  const [showAll, setShowAll] = useState(true);
   const unit = useAccountUnit(account);
   const validatorGroups = useValidatorGroups(search);
   const onSearch = useCallback(
@@ -50,12 +50,12 @@ const ValidatorGroupsField = ({
     containerRef.current?.querySelector("input")?.focus();
   }, []);
   if (!status) return null;
-  const renderItem = (validatorGroup: CeloValidatorGroup, validatorGroupIdx: number) => {
+  const renderItem = (validatorGroup: CeloValidatorGroup) => {
     return (
       <ValidatorGroupRow
         currency={account.currency}
         active={chosenValidatorGroupAddress === validatorGroup.address}
-        showStake={validatorGroupIdx !== 0}
+        showStake={true}
         onClick={onChangeValidatorGroup}
         key={validatorGroup.address}
         validatorGroup={validatorGroup}

--- a/apps/ledger-live-mobile/src/families/celo/VoteFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/VoteFlow/02-Summary.tsx
@@ -2,7 +2,6 @@ import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/accoun
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
-import { useValidatorGroups } from "@ledgerhq/live-common/families/celo/react";
 import {
   CeloValidatorGroup,
   Transaction as CeloTransaction,
@@ -13,7 +12,7 @@ import { Text, Icons } from "@ledgerhq/native-ui";
 import { useTheme } from "@react-navigation/native";
 import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useCallback, useEffect } from "react";
 import { Trans } from "~/context/Locale";
 import { Animated, StyleSheet, View } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
@@ -48,17 +47,10 @@ export default function VoteSummary({ navigation, route }: Props) {
 
   invariant(account, "account must be defined");
 
-  const validators = useValidatorGroups();
   const mainAccount = getMainAccount(account, parentAccount);
   const bridge = useAccountBridge<CeloTransaction>(account, undefined);
 
-  const chosenValidator = useMemo(() => {
-    if (validator !== undefined) {
-      return validator;
-    }
-
-    return validators[0];
-  }, [validators, validator]);
+  const chosenValidator = validator;
 
   const { transaction, updateTransaction, setTransaction, status, bridgePending, bridgeError } =
     useBridgeTransaction(bridge, () => {
@@ -71,7 +63,7 @@ export default function VoteSummary({ navigation, route }: Props) {
           account,
           transaction: bridge.updateTransaction(t, {
             mode: "vote",
-            recipient: validators[0]?.address ?? defaultValidatorGroupAddress(),
+            recipient: "",
             amount: route.params.amount ?? new BigNumber(0),
           }),
         };
@@ -87,7 +79,7 @@ export default function VoteSummary({ navigation, route }: Props) {
     setTransaction(
       bridge.updateTransaction(transaction, {
         amount: new BigNumber(route.params.amount ?? new BigNumber(0)),
-        recipient: chosenValidator.address,
+        recipient: chosenValidator?.address ?? "",
       }),
     );
     // oxlint-disable-next-line react-hooks/exhaustive-deps
@@ -151,7 +143,7 @@ export default function VoteSummary({ navigation, route }: Props) {
                   }}
                 >
                   <ValidatorImage
-                    isLedger={chosenValidator.address === defaultValidatorGroupAddress()}
+                    isLedger={chosenValidator?.address === defaultValidatorGroupAddress()}
                     name={chosenValidator?.name ?? chosenValidator?.address}
                   />
                 </Animated.View>

--- a/e2e/mobile/specs/delegate/voteCELO.spec.ts
+++ b/e2e/mobile/specs/delegate/voteCELO.spec.ts
@@ -1,5 +1,5 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runVoteCelo } from "./delegate";
 
-const delegation = new Delegate(Account.CELO_1, "0.001", "Ledger by Figment");
+const delegation = new Delegate(Account.CELO_1, "0.001", "cLabs");
 runVoteCelo(delegation, ["B2CQA-201"]);

--- a/libs/coin-modules/coin-celo/src/network/hubble.ts
+++ b/libs/coin-modules/coin-celo/src/network/hubble.ts
@@ -72,16 +72,7 @@ export const getValidatorGroups = async (): Promise<CeloValidatorGroup[]> => {
   return customValidatorGroupsOrder(result);
 };
 
-const customValidatorGroupsOrder = (
-  validatorGroups: CeloValidatorGroup[],
-): CeloValidatorGroup[] => {
-  const defaultValidatorGroup = validatorGroups.find(isDefaultValidatorGroup);
-
-  const sortedValidatorGroups = [...validatorGroups]
-    .sort((a, b) => b.votes.comparedTo(a.votes))
-    .filter(group => !isDefaultValidatorGroup(group));
-
-  return defaultValidatorGroup
-    ? [defaultValidatorGroup, ...sortedValidatorGroups]
-    : sortedValidatorGroups;
-};
+const customValidatorGroupsOrder = (validatorGroups: CeloValidatorGroup[]): CeloValidatorGroup[] =>
+  [...validatorGroups]
+    .filter(group => !isDefaultValidatorGroup(group)) // Excludes the deprecated "Ledger by Figment"
+    .sort((a, b) => b.votes.comparedTo(a.votes));


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Unit tests added for the shared filtering/ranking logic (`coin-celo`). The LLD/LLM vote-flow UI changes are validated manually and via the updated `voteCELO` e2e spec, not by unit tests._
- [x] **Impact of the changes:**
      - **Celo Vote flow (LLD)**: validator list opens expanded, ranked by TVL, "Ledger by Figment" absent, none selected by default, Continue disabled until a validator is picked.
      - **Celo Vote flow (LLM)**: summary shows no default validator, Continue disabled until a validator is chosen.
      - **Existing delegations**: accounts that already voted for Figment must still be able to revoke / activate / unlock / withdraw.

### 📝 Description

Figment is retiring its Celo (CELO) staking validator. The "Ledger by Figment" group was hardcoded as the default in the vote flow (forced to the top of the list and pre-selected), so users were still being directed to a validator that is being shut down.

This PR deprecates that group, mirroring the prior deprecation in LIVE-28172 (Axelar / MANTRA / EGLD):

- `coin-celo` excludes the "Ledger by Figment" group from the preloaded validator list and ranks the rest by TVL (votes desc).
- **LLD**: the list opens expanded (ranked by TVL) with no validator pre-selected; the empty default keeps Continue disabled until the user picks one.
- **LLM**: the default validator is empty.
- Existing delegations are unaffected: they are rendered from the account's own votes via `fallbackValidatorGroup`, independently of the preloaded list, so revoke / activate / unlock / withdraw keep working.

Note: "Figment Networks" is a separate third-party group (not a "Ledger by …" default) and is intentionally kept, consistent with LIVE-28172 where only the "Ledger by X" defaults were removed.

### 🖼️ Screenshots

| Before | After |
| ------ | ----- |
| <img width="584" height="420" alt="Screenshot 2026-06-24 at 12 06 02" src="https://github.com/user-attachments/assets/05969687-7d90-40b1-a6d5-f14dd736237e" /> | <img width="649" height="675" alt="Screenshot 2026-06-24 at 11 56 37" src="https://github.com/user-attachments/assets/6476a793-a78e-4cb5-8e22-9c43c6f03c29" /> |
| note :  Figment is already hidden by the eligibility check (validator shut down 19 Jun 2026); the visible change here is "no default selected + TVL-ranked expanded list" | <img width="388" height="844" alt="Screenshot 2026-06-24 at 13 24 50" src="https://github.com/user-attachments/assets/8832c7e0-3373-489b-b99d-07320781cc1a" />|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33087](https://ledgerhq.atlassian.net/browse/LIVE-33087)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33087]: https://ledgerhq.atlassian.net/browse/LIVE-33087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ