### PR TITLE
[LWD] feat: Lumen portfolio chart on Analytics

### DIFF
--- a/.changeset/lwd-analytics-lumen-chart.md
+++ b/.changeset/lwd-analytics-lumen-chart.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add Lumen portfolio chart to Analytics when PnL is enabled, with balance header and range-aware variation (first receive baseline for all-time).

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/LineChartPoints.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/LineChartPoints.tsx
@@ -19,7 +19,7 @@ export function LineChartPoints({ points, formatValue }: LineChartPointsProps) {
           key={`${marker.index}-${marker.value}-${marker.labelPosition ?? "top"}`}
           dataX={marker.index}
           dataY={marker.value}
-          label={marker.hideLabel ? undefined : marker.label ?? formatValue(marker.value)}
+          label={marker.hideLabel ? undefined : (marker.label ?? formatValue(marker.value))}
           labelPosition={marker.labelPosition ?? "top"}
           hidePoint={marker.hidePoint}
           size={LINE_CHART_POINT_SIZE}

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/utils/createFiatLineChartValueFormatter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/utils/createFiatLineChartValueFormatter.ts
@@ -6,10 +6,12 @@ import type { LineChartValueFormatter } from "../types";
 export function createFiatLineChartValueFormatter(
   fiatUnit: Unit,
   locale: string,
+  discreet = false,
 ): LineChartValueFormatter {
   return value =>
     formatPrice(fiatUnit, new BigNumber(value).times(10 ** fiatUnit.magnitude), {
       showCode: true,
       locale,
+      discreet,
     });
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/__integrations__/Analytics.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/__integrations__/Analytics.test.tsx
@@ -4,7 +4,7 @@ import Analytics from "../index";
 import useAnalyticsViewModel from "../useAnalyticsViewModel";
 import { useAllocationData } from "../hooks/useAllocationData";
 import { makeAllocationViewProps } from "../__fixtures__/allocationFixtures";
-import { mockPortfolioBalanceInfo } from "LLD/hooks/__tests__/fixtures";
+import { mockPortfolioBalanceInfo, defaultPortfolio } from "LLD/hooks/__tests__/fixtures";
 
 jest.mock("../useAnalyticsViewModel");
 const mockedUseAnalyticsViewModel = useAnalyticsViewModel as jest.Mock;
@@ -15,6 +15,10 @@ const mockedUseAllocationData = useAllocationData as jest.Mock;
 jest.mock("~/renderer/screens/dashboard/GlobalSummary", () => ({
   __esModule: true,
   default: () => <div data-testid="portfolio-balance-summary">PortfolioBalanceSummary</div>,
+}));
+
+jest.mock("../components/ChartSection", () => ({
+  ChartSection: () => <div data-testid="analytics-chart-section">ChartSection</div>,
 }));
 
 let intersectionCallback: IntersectionObserverCallback;
@@ -44,6 +48,10 @@ const defaultViewModel = {
   selectedTimeRange: "month",
   navigateToDashboard: mockNavigateToDashboard,
   balanceInfo: mockPortfolioBalanceInfo,
+  portfolio: defaultPortfolio,
+  isLoading: false,
+  shouldDisplayBalanceRefreshRework: false,
+  shouldDisplayPnl: false,
 };
 
 describe("Analytics", () => {
@@ -58,6 +66,19 @@ describe("Analytics", () => {
 
     expect(screen.getByText("Analytics")).toBeVisible();
     expect(screen.getByTestId("analytics-chart")).toBeVisible();
+    expect(screen.getByTestId("portfolio-balance-summary")).toBeVisible();
+  });
+
+  it("should render the Lumen chart section when shouldDisplayPnl is true", () => {
+    mockedUseAnalyticsViewModel.mockReturnValue({
+      ...defaultViewModel,
+      shouldDisplayPnl: true,
+    });
+
+    render(<Analytics />);
+
+    expect(screen.getByTestId("analytics-chart-section")).toBeVisible();
+    expect(screen.queryByTestId("portfolio-balance-summary")).not.toBeInTheDocument();
   });
 
   it("should call navigateToDashboard when back button is clicked", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/__tests__/useAnalyticsViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/__tests__/useAnalyticsViewModel.test.ts
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router";
 import { getFiatCurrencyByTicker } from "@ledgerhq/live-common/currencies/index";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
 import * as usePortfolioBalanceDisplayStateModule from "LLD/hooks/usePortfolioBalanceDisplayState";
-import { mockPortfolioBalanceInfo } from "LLD/hooks/__tests__/fixtures";
+import { mockPortfolioBalanceInfo, defaultPortfolio } from "LLD/hooks/__tests__/fixtures";
 import useAnalyticsViewModel from "../useAnalyticsViewModel";
 
 jest.mock("react-router", () => ({
@@ -23,6 +23,12 @@ describe("useAnalyticsViewModel", () => {
     jest.clearAllMocks();
     mockUsePortfolioBalanceDisplayState.mockReturnValue({
       balanceInfo: mockPortfolioBalanceInfo,
+      portfolio: {
+        ...defaultPortfolio,
+        countervalueChange: { percentage: 0.2, value: 200 },
+      },
+      isLoading: false,
+      shouldDisplayBalanceRefreshRework: false,
     } as ReturnType<typeof usePortfolioBalanceDisplayStateModule.usePortfolioBalanceDisplayState>);
   });
 
@@ -32,7 +38,9 @@ describe("useAnalyticsViewModel", () => {
 
     const { result } = renderHook(() => useAnalyticsViewModel(), {
       initialState: {
-        ...withFlagOverrides({ lwdWallet40: { enabled: true, params: { graphRework: true } } }),
+        ...withFlagOverrides({
+          lwdWallet40: { enabled: true, params: { graphRework: true, pnl: true } },
+        }),
         settings: {
           ...INITIAL_STATE,
           counterValue: "USD",
@@ -44,8 +52,11 @@ describe("useAnalyticsViewModel", () => {
     expect(result.current.counterValue).toBe(getFiatCurrencyByTicker("USD"));
     expect(result.current.selectedTimeRange).toBe("day");
     expect(result.current.shouldDisplayGraphRework).toBe(true);
-    expect(result.current.balanceInfo).toEqual(mockPortfolioBalanceInfo);
-    expect(mockUsePortfolioBalanceDisplayState).toHaveBeenCalledWith({ legacyRange: false });
+    expect(result.current.shouldDisplayPnl).toBe(false);
+    expect(result.current.balanceInfo.valueChange).toEqual({ percentage: 0.2, value: 200 });
+    expect(result.current.portfolio.countervalueChange).toEqual({ percentage: 0.2, value: 200 });
+    expect(result.current.isLoading).toBe(false);
+    expect(mockUsePortfolioBalanceDisplayState).toHaveBeenCalledWith({ legacyRange: true });
 
     act(() => {
       result.current.navigateToDashboard();
@@ -54,10 +65,19 @@ describe("useAnalyticsViewModel", () => {
     expect(navigate).toHaveBeenCalledWith("/");
   });
 
-  it("should use legacyRange for non-day time ranges", () => {
+  it("should derive value change from the selected portfolio range", () => {
     mockedUseNavigate.mockReturnValue(jest.fn());
+    mockUsePortfolioBalanceDisplayState.mockReturnValue({
+      balanceInfo: mockPortfolioBalanceInfo,
+      portfolio: {
+        ...defaultPortfolio,
+        countervalueChange: { percentage: 0.08, value: 80 },
+      },
+      isLoading: false,
+      shouldDisplayBalanceRefreshRework: false,
+    } as ReturnType<typeof usePortfolioBalanceDisplayStateModule.usePortfolioBalanceDisplayState>);
 
-    renderHook(() => useAnalyticsViewModel(), {
+    const { result } = renderHook(() => useAnalyticsViewModel(), {
       initialState: {
         ...withFlagOverrides({ lwdWallet40: { enabled: true, params: { graphRework: true } } }),
         settings: {
@@ -68,6 +88,6 @@ describe("useAnalyticsViewModel", () => {
       },
     });
 
-    expect(mockUsePortfolioBalanceDisplayState).toHaveBeenCalledWith({ legacyRange: true });
+    expect(result.current.balanceInfo.valueChange).toEqual({ percentage: 0.08, value: 80 });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/ChartSectionHeaderVariation.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/ChartSectionHeaderVariation.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Trend } from "@ledgerhq/lumen-ui-react";
+
+type ChartSectionHeaderVariationProps = Readonly<{
+  percentageValue: number;
+  discreet: boolean;
+  variationText: string;
+  rangeLabel: string;
+}>;
+
+export function ChartSectionHeaderVariation({
+  percentageValue,
+  discreet,
+  variationText,
+  rangeLabel,
+}: ChartSectionHeaderVariationProps) {
+  return (
+    <div className="flex items-center gap-4" data-testid="analytics-balance-trend">
+      {!discreet && (
+        <Trend value={percentageValue} size="sm" data-testid="analytics-balance-trend-percentage" />
+      )}
+      <span className="body-2 text-muted" data-testid="analytics-balance-trend-value">
+        {variationText}
+      </span>
+      <span className="body-2 text-muted">·</span>
+      <span className="body-2 text-muted">{rangeLabel}</span>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/ChartSectionHeaderView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/ChartSectionHeaderView.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { AmountDisplay, Skeleton } from "@ledgerhq/lumen-ui-react";
+import type { ChartSectionHeaderViewModel } from "./types";
+import { ChartSectionHeaderVariation } from "./ChartSectionHeaderVariation";
+
+type ChartSectionHeaderViewProps = Readonly<{
+  viewModel: ChartSectionHeaderViewModel;
+}>;
+
+export function ChartSectionHeaderView({ viewModel }: ChartSectionHeaderViewProps) {
+  const {
+    balance,
+    balanceAvailable,
+    isLoading,
+    shouldDisplayBalanceRefreshRework,
+    balanceFormatter,
+    discreet,
+    percentageValue,
+    variationText,
+    rangeLabel,
+  } = viewModel;
+
+  return (
+    <div className="flex items-end gap-12" data-testid="analytics-chart-header">
+      {balanceAvailable ? (
+        <AmountDisplay
+          value={balance}
+          formatter={balanceFormatter}
+          hidden={discreet}
+          loading={shouldDisplayBalanceRefreshRework && isLoading}
+          data-testid="analytics-balance-amount"
+        />
+      ) : (
+        <Skeleton className="h-48 w-256 rounded-md" data-testid="analytics-balance-skeleton" />
+      )}
+      {balanceAvailable && (
+        <ChartSectionHeaderVariation
+          percentageValue={percentageValue}
+          discreet={discreet}
+          variationText={variationText}
+          rangeLabel={rangeLabel}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/__tests__/ChartSectionHeaderView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/__tests__/ChartSectionHeaderView.test.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { mockPortfolioBalanceInfo } from "LLD/hooks/__tests__/fixtures";
+import { ChartSectionHeaderView } from "../ChartSectionHeaderView";
+import type { ChartSectionHeaderViewModel } from "../types";
+
+const baseViewModel: ChartSectionHeaderViewModel = {
+  balance: mockPortfolioBalanceInfo.totalBalance,
+  balanceAvailable: true,
+  isLoading: false,
+  shouldDisplayBalanceRefreshRework: true,
+  balanceFormatter: value => ({
+    currencyText: "$",
+    decimalSeparator: ".",
+    currencyPosition: "end",
+    integerPart: String(value),
+    decimalPart: "",
+  }),
+  discreet: false,
+  percentageValue: 12.34,
+  variationText: "+$567.00",
+  rangeLabel: "1 week",
+};
+
+describe("ChartSectionHeaderView", () => {
+  it("renders the balance and variation row", () => {
+    render(<ChartSectionHeaderView viewModel={baseViewModel} />);
+
+    expect(screen.getByTestId("analytics-chart-header")).toBeVisible();
+    expect(screen.getByTestId("analytics-balance-amount")).toBeVisible();
+    expect(screen.getByTestId("analytics-balance-trend-percentage")).toHaveTextContent("12.34%");
+    expect(screen.getByTestId("analytics-balance-trend-value")).toHaveTextContent("+$567.00");
+    expect(screen.getByTestId("analytics-balance-trend")).toHaveTextContent("1 week");
+  });
+
+  it("shows a skeleton when the balance is unavailable", () => {
+    render(<ChartSectionHeaderView viewModel={{ ...baseViewModel, balanceAvailable: false }} />);
+
+    expect(screen.getByTestId("analytics-balance-skeleton")).toBeVisible();
+    expect(screen.queryByTestId("analytics-balance-trend")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/__tests__/useChartSectionHeaderViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/__tests__/useChartSectionHeaderViewModel.test.ts
@@ -1,0 +1,56 @@
+import { renderHook } from "tests/testSetup";
+import { mockPortfolioBalanceInfo } from "LLD/hooks/__tests__/fixtures";
+import { useChartSectionHeaderViewModel } from "../useChartSectionHeaderViewModel";
+import { chartSectionHeaderInitialState } from "../../__tests__/fixtures";
+
+describe("useChartSectionHeaderViewModel", () => {
+  it("formats balance, trend, and range label for the selected portfolio range", () => {
+    const { result } = renderHook(
+      () =>
+        useChartSectionHeaderViewModel({
+          balanceInfo: {
+            ...mockPortfolioBalanceInfo,
+            valueChange: { percentage: 0.1234, value: 567 },
+          },
+          hoveredBalance: null,
+          isLoading: false,
+          shouldDisplayBalanceRefreshRework: true,
+        }),
+      { initialState: chartSectionHeaderInitialState },
+    );
+
+    expect(result.current.balance).toBe(mockPortfolioBalanceInfo.totalBalance);
+    expect(result.current.rangeLabel).toBe("1 week");
+    expect(result.current.percentageValue).toBe(12.34);
+  });
+
+  it("uses the hovered balance when scrubbing the chart", () => {
+    const { result } = renderHook(
+      () =>
+        useChartSectionHeaderViewModel({
+          balanceInfo: mockPortfolioBalanceInfo,
+          hoveredBalance: 1000,
+          isLoading: false,
+          shouldDisplayBalanceRefreshRework: true,
+        }),
+      { initialState: chartSectionHeaderInitialState },
+    );
+
+    expect(result.current.balance).toBe(1000);
+  });
+
+  it("exposes the loading state passed from the parent view model", () => {
+    const { result } = renderHook(
+      () =>
+        useChartSectionHeaderViewModel({
+          balanceInfo: mockPortfolioBalanceInfo,
+          hoveredBalance: null,
+          isLoading: true,
+          shouldDisplayBalanceRefreshRework: true,
+        }),
+      { initialState: chartSectionHeaderInitialState },
+    );
+
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/index.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import type { PortfolioBalanceInfo } from "LLD/hooks/usePortfolioBalanceDisplayState";
+import { ChartSectionHeaderView } from "./ChartSectionHeaderView";
+import { useChartSectionHeaderViewModel } from "./useChartSectionHeaderViewModel";
+
+export type { ChartSectionHeaderViewModel } from "./types";
+
+type ChartSectionHeaderProps = Readonly<{
+  balanceInfo: PortfolioBalanceInfo;
+  hoveredBalance: number | null;
+  isLoading: boolean;
+  shouldDisplayBalanceRefreshRework: boolean;
+}>;
+
+export function ChartSectionHeader({
+  balanceInfo,
+  hoveredBalance,
+  isLoading,
+  shouldDisplayBalanceRefreshRework,
+}: ChartSectionHeaderProps) {
+  const viewModel = useChartSectionHeaderViewModel({
+    balanceInfo,
+    hoveredBalance,
+    isLoading,
+    shouldDisplayBalanceRefreshRework,
+  });
+  return <ChartSectionHeaderView viewModel={viewModel} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/types.ts
@@ -1,0 +1,13 @@
+import type { FormattedValue } from "@ledgerhq/lumen-ui-react";
+
+export type ChartSectionHeaderViewModel = Readonly<{
+  balance: number;
+  balanceAvailable: boolean;
+  isLoading: boolean;
+  shouldDisplayBalanceRefreshRework: boolean;
+  balanceFormatter: (value: number) => FormattedValue;
+  discreet: boolean;
+  percentageValue: number;
+  variationText: string;
+  rangeLabel: string;
+}>;

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/useChartSectionHeaderViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/useChartSectionHeaderViewModel.ts
@@ -1,0 +1,68 @@
+import { useCallback, useMemo } from "react";
+import BigNumber from "bignumber.js";
+import { useTranslation } from "react-i18next";
+import { useSelector } from "LLD/hooks/redux";
+import { formatCurrencyUnitFragment } from "@ledgerhq/live-common/currencies/index";
+import { formatSignedFiatVariation } from "@ledgerhq/live-currency-format";
+import type { PortfolioBalanceInfo } from "LLD/hooks/usePortfolioBalanceDisplayState";
+import {
+  counterValueCurrencySelector,
+  discreetModeSelector,
+  localeSelector,
+  selectedTimeRangeSelector,
+} from "~/renderer/reducers/settings";
+import { PORTFOLIO_RANGE_LABEL_KEY } from "../../../utils/portfolioRangeMapping";
+import type { ChartSectionHeaderViewModel } from "./types";
+
+type UseChartSectionHeaderViewModelProps = Readonly<{
+  balanceInfo: PortfolioBalanceInfo;
+  hoveredBalance: number | null;
+  isLoading: boolean;
+  shouldDisplayBalanceRefreshRework: boolean;
+}>;
+
+export function useChartSectionHeaderViewModel({
+  balanceInfo,
+  hoveredBalance,
+  isLoading,
+  shouldDisplayBalanceRefreshRework,
+}: UseChartSectionHeaderViewModelProps): ChartSectionHeaderViewModel {
+  const { t } = useTranslation();
+  const selectedTimeRange = useSelector(selectedTimeRangeSelector);
+  const counterValue = useSelector(counterValueCurrencySelector);
+  const locale = useSelector(localeSelector);
+  const discreet = useSelector(discreetModeSelector);
+  const fiatUnit = counterValue.units[0];
+
+  const balance = hoveredBalance ?? balanceInfo.totalBalance;
+
+  const balanceFormatter = useCallback(
+    (value: number) =>
+      formatCurrencyUnitFragment(fiatUnit, new BigNumber(value), {
+        locale,
+        showCode: true,
+      }),
+    [fiatUnit, locale],
+  );
+
+  const percentageValue = (balanceInfo.valueChange.percentage ?? 0) * 100;
+
+  const variationText = useMemo(() => {
+    if (discreet) return "***";
+    return formatSignedFiatVariation(balanceInfo.valueChange.value, fiatUnit, locale);
+  }, [balanceInfo.valueChange.value, discreet, fiatUnit, locale]);
+
+  const rangeLabel = t(PORTFOLIO_RANGE_LABEL_KEY[selectedTimeRange]);
+
+  return {
+    balance,
+    balanceAvailable: balanceInfo.isAvailable,
+    isLoading,
+    shouldDisplayBalanceRefreshRework,
+    balanceFormatter,
+    discreet,
+    percentageValue,
+    variationText,
+    rangeLabel,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionView.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { LineChart } from "LLD/components/LineChart";
+import { ChartSectionHeader } from "./ChartSectionHeader";
+import type { ChartSectionViewModelResult } from "./useChartSectionViewModel";
+
+type ChartSectionViewProps = Readonly<{
+  viewModel: ChartSectionViewModelResult;
+}>;
+
+export function ChartSectionView({ viewModel }: ChartSectionViewProps) {
+  const { balanceInfo, hoveredBalance, chart, isLoading, shouldDisplayBalanceRefreshRework } =
+    viewModel;
+
+  return (
+    <div className="flex flex-col gap-24" data-testid="analytics-chart-section">
+      <ChartSectionHeader
+        balanceInfo={balanceInfo}
+        hoveredBalance={hoveredBalance}
+        isLoading={isLoading}
+        shouldDisplayBalanceRefreshRework={shouldDisplayBalanceRefreshRework}
+      />
+      <LineChart {...chart} />
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/__tests__/ChartSection.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/__tests__/ChartSection.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { mockLumenChartResizeObserver } from "tests/utils/lumenChartTestUtils";
+import { mockPortfolioBalanceInfo } from "LLD/hooks/__tests__/fixtures";
+import { ChartSection } from "../index";
+import { chartSectionInitialState, portfolioWithHistory } from "./fixtures";
+
+const ORIGINAL_RESIZE_OBSERVER = global.ResizeObserver;
+
+describe("ChartSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLumenChartResizeObserver();
+  });
+
+  afterEach(() => {
+    global.ResizeObserver = ORIGINAL_RESIZE_OBSERVER;
+  });
+
+  it("renders the portfolio balance, trend, and chart for the selected range", () => {
+    render(
+      <ChartSection
+        balanceInfo={mockPortfolioBalanceInfo}
+        portfolio={portfolioWithHistory}
+        isLoading={false}
+        shouldDisplayBalanceRefreshRework={false}
+      />,
+      { initialState: chartSectionInitialState },
+    );
+
+    expect(screen.getByTestId("analytics-chart-section")).toBeVisible();
+    expect(screen.getByTestId("analytics-chart-header")).toBeVisible();
+    expect(screen.getByTestId("analytics-balance-amount")).toBeVisible();
+    expect(screen.getByTestId("analytics-balance-trend")).toHaveTextContent("1 week");
+    expect(screen.getByTestId("line-chart-range-1w")).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("shows a skeleton when the balance is unavailable", () => {
+    render(
+      <ChartSection
+        balanceInfo={{ ...mockPortfolioBalanceInfo, isAvailable: false }}
+        portfolio={portfolioWithHistory}
+        isLoading={false}
+        shouldDisplayBalanceRefreshRework={false}
+      />,
+      { initialState: chartSectionInitialState },
+    );
+
+    expect(screen.getByTestId("analytics-balance-skeleton")).toBeVisible();
+    expect(screen.queryByTestId("analytics-balance-trend")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/__tests__/fixtures.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/__tests__/fixtures.ts
@@ -1,0 +1,29 @@
+import { withFlagOverrides } from "tests/testSetup";
+import { INITIAL_STATE } from "~/renderer/reducers/settings";
+import { defaultPortfolio, mockCounterValue } from "LLD/hooks/__tests__/fixtures";
+
+export const portfolioWithHistory = {
+  ...defaultPortfolio,
+  balanceHistory: [
+    { date: new Date("2026-01-01T00:00:00.000Z"), value: 1000 },
+    { date: new Date("2026-01-02T00:00:00.000Z"), value: 1200 },
+  ],
+  balanceAvailable: true,
+  countervalueChange: { percentage: 0.2, value: 200 },
+};
+
+export const chartSectionInitialState = {
+  settings: {
+    ...INITIAL_STATE,
+    counterValue: "USD",
+    counterValueCurrency: mockCounterValue,
+    selectedTimeRange: "week" as const,
+  },
+};
+
+export const chartSectionHeaderInitialState = {
+  ...chartSectionInitialState,
+  ...withFlagOverrides({
+    lwdWallet40: { enabled: true, params: { balanceRefreshRework: true } },
+  }),
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/__tests__/useChartSectionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/__tests__/useChartSectionViewModel.test.ts
@@ -1,0 +1,112 @@
+import { act, renderHook } from "tests/testSetup";
+import { track } from "~/renderer/analytics/segment";
+import { mockPortfolioBalanceInfo } from "LLD/hooks/__tests__/fixtures";
+import { useChartSectionViewModel } from "../useChartSectionViewModel";
+import { chartSectionInitialState, portfolioWithHistory } from "./fixtures";
+
+jest.mock("~/renderer/analytics/segment", () => ({
+  track: jest.fn(),
+}));
+
+const mockTrack = jest.mocked(track);
+
+describe("useChartSectionViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("builds chart series from portfolio balance history and maps the selected range", () => {
+    const { result } = renderHook(
+      () =>
+        useChartSectionViewModel({
+          balanceInfo: mockPortfolioBalanceInfo,
+          portfolio: portfolioWithHistory,
+          isLoading: false,
+          shouldDisplayBalanceRefreshRework: false,
+        }),
+      { initialState: chartSectionInitialState },
+    );
+
+    expect(result.current.chart.series[0].data).toEqual([1000, 1200]);
+    expect(result.current.chart.selectedRange).toBe("1w");
+    expect(result.current.balanceInfo).toBe(mockPortfolioBalanceInfo);
+    expect(result.current.hoveredBalance).toBeNull();
+  });
+
+  it("uses balanceInfo availability for the chart loading state", () => {
+    const { result } = renderHook(
+      () =>
+        useChartSectionViewModel({
+          balanceInfo: { ...mockPortfolioBalanceInfo, isAvailable: false },
+          portfolio: portfolioWithHistory,
+          isLoading: true,
+          shouldDisplayBalanceRefreshRework: true,
+        }),
+      { initialState: chartSectionInitialState },
+    );
+
+    expect(result.current.chart.isLoading).toBe(true);
+  });
+
+  it("dispatches the portfolio range and tracks when the chart range changes", () => {
+    const { result, store } = renderHook(
+      () =>
+        useChartSectionViewModel({
+          balanceInfo: mockPortfolioBalanceInfo,
+          portfolio: portfolioWithHistory,
+          isLoading: false,
+          shouldDisplayBalanceRefreshRework: false,
+        }),
+      { initialState: chartSectionInitialState },
+    );
+
+    act(() => {
+      result.current.chart.onRangeChange("1m");
+    });
+
+    expect(store.getState().settings.selectedTimeRange).toBe("month");
+    expect(mockTrack).toHaveBeenCalledWith("timeframe_clicked", { timeframe: "month" });
+  });
+
+  it("masks the chart tooltip value when discreet mode is enabled", () => {
+    const { result } = renderHook(
+      () =>
+        useChartSectionViewModel({
+          balanceInfo: mockPortfolioBalanceInfo,
+          portfolio: portfolioWithHistory,
+          isLoading: false,
+          shouldDisplayBalanceRefreshRework: false,
+        }),
+      {
+        initialState: {
+          settings: { ...chartSectionInitialState.settings, discreetMode: true },
+        },
+      },
+    );
+
+    expect(result.current.chart.formatValue?.(1000)).toBe("$***");
+  });
+
+  it("updates hoveredBalance when scrubbing the chart", () => {
+    const { result } = renderHook(
+      () =>
+        useChartSectionViewModel({
+          balanceInfo: mockPortfolioBalanceInfo,
+          portfolio: portfolioWithHistory,
+          isLoading: false,
+          shouldDisplayBalanceRefreshRework: false,
+        }),
+      { initialState: chartSectionInitialState },
+    );
+
+    act(() => {
+      result.current.chart.onScrubberPositionChange?.(0);
+    });
+    expect(result.current.hoveredBalance).toBe(1000);
+
+    act(() => {
+      result.current.chart.onScrubberPositionChange?.(undefined);
+    });
+    expect(result.current.hoveredBalance).toBeNull();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/index.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import type { Portfolio } from "@ledgerhq/types-live";
+import type { PortfolioBalanceInfo } from "LLD/hooks/usePortfolioBalanceDisplayState";
+import { ChartSectionView } from "./ChartSectionView";
+import { useChartSectionViewModel } from "./useChartSectionViewModel";
+
+type ChartSectionProps = Readonly<{
+  balanceInfo: PortfolioBalanceInfo;
+  portfolio: Portfolio;
+  isLoading: boolean;
+  shouldDisplayBalanceRefreshRework: boolean;
+}>;
+
+export function ChartSection(props: ChartSectionProps) {
+  const viewModel = useChartSectionViewModel(props);
+  return <ChartSectionView viewModel={viewModel} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/useChartSectionViewModel.ts
@@ -1,0 +1,163 @@
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import type { Portfolio } from "@ledgerhq/types-live";
+import type { PortfolioBalanceInfo } from "LLD/hooks/usePortfolioBalanceDisplayState";
+import {
+  getExtremaPointMarkers,
+  resolveLineChartColorFromPercentChange,
+  type LineChartProps,
+  type LineChartRange,
+  type LineChartScrubberPositionChange,
+  type LineChartSeries,
+} from "LLD/components/LineChart";
+import { createFiatLineChartValueFormatter } from "LLD/components/LineChart/utils/createFiatLineChartValueFormatter";
+import { createLineChartTooltipTitle } from "LLD/components/LineChart/utils/createLineChartTooltipTitle";
+import {
+  buildLineChartBottomPaddedYAxisConfig,
+  buildLineChartXAxisConfig,
+  LINE_CHART_VIEW_HEIGHT,
+} from "LLD/components/LineChart/utils/lineChartAxisConfig";
+import {
+  counterValueCurrencySelector,
+  discreetModeSelector,
+  localeSelector,
+  selectedTimeRangeSelector,
+} from "~/renderer/reducers/settings";
+import { setSelectedTimeRange } from "~/renderer/actions/settings";
+import { track } from "~/renderer/analytics/segment";
+import { useAssetChartDateFormatter } from "LLD/features/AssetDetail/hooks/useAssetChartDateFormatter";
+import {
+  ANALYTICS_CHART_RANGES,
+  lineChartRangeToPortfolioRange,
+  portfolioRangeToLineChartRange,
+} from "../../utils/portfolioRangeMapping";
+
+type UseChartSectionViewModelProps = Readonly<{
+  balanceInfo: PortfolioBalanceInfo;
+  portfolio: Portfolio;
+  isLoading: boolean;
+  shouldDisplayBalanceRefreshRework: boolean;
+}>;
+
+export type ChartSectionViewModelResult = Readonly<{
+  balanceInfo: PortfolioBalanceInfo;
+  hoveredBalance: number | null;
+  isLoading: boolean;
+  shouldDisplayBalanceRefreshRework: boolean;
+  chart: LineChartProps;
+}>;
+
+export function useChartSectionViewModel({
+  balanceInfo,
+  portfolio,
+  isLoading,
+  shouldDisplayBalanceRefreshRework,
+}: UseChartSectionViewModelProps): ChartSectionViewModelResult {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const selectedTimeRange = useSelector(selectedTimeRangeSelector);
+  const counterValue = useSelector(counterValueCurrencySelector);
+  const locale = useSelector(localeSelector);
+  const discreet = useSelector(discreetModeSelector);
+  const selectedRange = portfolioRangeToLineChartRange(selectedTimeRange);
+  const fiatUnit = counterValue.units[0];
+  const [hoveredBalance, setHoveredBalance] = useState<number | null>(null);
+
+  const { prices, timestamps } = useMemo(() => {
+    const history = portfolio.balanceHistory;
+    return {
+      prices: history.map(point => point.value),
+      timestamps: history.map(point => point.date.getTime()),
+    };
+  }, [portfolio.balanceHistory]);
+
+  const series = useMemo<LineChartSeries[]>(
+    () => [
+      {
+        id: "analytics-portfolio-balance",
+        data: prices,
+        label: t("dashboard.header"),
+        stroke: "",
+      },
+    ],
+    [prices, t],
+  );
+
+  const color = resolveLineChartColorFromPercentChange(
+    balanceInfo.valueChange.percentage == null
+      ? undefined
+      : balanceInfo.valueChange.percentage * 100,
+  );
+
+  const points = useMemo(() => getExtremaPointMarkers(series), [series]);
+
+  const formatValue = useMemo(
+    () => createFiatLineChartValueFormatter(fiatUnit, locale, discreet),
+    [fiatUnit, locale, discreet],
+  );
+
+  const formatDate = useAssetChartDateFormatter(selectedRange);
+
+  const tooltipTitle = useMemo(
+    () => createLineChartTooltipTitle(timestamps, formatDate),
+    [timestamps, formatDate],
+  );
+
+  const xAxis = useMemo(
+    () => buildLineChartXAxisConfig({ timestamps, selectedRange, formatDate }),
+    [timestamps, formatDate, selectedRange],
+  );
+
+  const yAxis = useMemo(() => buildLineChartBottomPaddedYAxisConfig(), []);
+
+  const onScrubberPositionChange = useCallback<LineChartScrubberPositionChange>(
+    index => {
+      if (index == null) {
+        setHoveredBalance(null);
+        return;
+      }
+      const value = prices[index];
+      setHoveredBalance(Number.isFinite(value) ? value : null);
+    },
+    [prices],
+  );
+
+  const onRangeChange = useCallback(
+    (range: LineChartRange) => {
+      const portfolioRange = lineChartRangeToPortfolioRange(range);
+      if (!portfolioRange || portfolioRange === selectedTimeRange) return;
+      setHoveredBalance(null);
+      dispatch(setSelectedTimeRange(portfolioRange));
+      track("timeframe_clicked", { timeframe: portfolioRange });
+    },
+    [dispatch, selectedTimeRange],
+  );
+
+  const isChartLoading = !balanceInfo.isAvailable;
+
+  return {
+    balanceInfo,
+    hoveredBalance,
+    isLoading,
+    shouldDisplayBalanceRefreshRework,
+    chart: {
+      series,
+      selectedRange,
+      onRangeChange,
+      color,
+      isLoading: isChartLoading,
+      height: LINE_CHART_VIEW_HEIGHT,
+      formatValue,
+      tooltipTitle,
+      onScrubberPositionChange,
+      showXAxis: false,
+      showYAxis: false,
+      xAxis,
+      yAxis,
+      points,
+      ranges: ANALYTICS_CHART_RANGES,
+      showScrubberTooltip: true,
+    },
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
@@ -7,6 +7,8 @@ import useAnalyticsViewModel from "./useAnalyticsViewModel";
 import type { AnalyticsViewModel } from "./types";
 import { AllocationSection } from "./components/Allocation/AllocationSection";
 import { PnLSection } from "./components/PnL";
+import { ChartSection } from "./components/ChartSection";
+import { cn } from "LLD/utils/cn";
 import { useTranslation } from "react-i18next";
 
 export default function Analytics() {
@@ -21,7 +23,11 @@ function AnalyticsView({ viewModel }: { readonly viewModel: AnalyticsViewModel }
     navigateToDashboard,
     shouldDisplayGraphRework,
     shouldDisplayAssetSection,
+    shouldDisplayPnl,
     balanceInfo,
+    portfolio,
+    isLoading,
+    shouldDisplayBalanceRefreshRework,
   } = viewModel;
 
   const { t } = useTranslation();
@@ -31,15 +37,27 @@ function AnalyticsView({ viewModel }: { readonly viewModel: AnalyticsViewModel }
       <TrackPage category="Analytics" range={selectedTimeRange} countervalue={counterValue} />
       <PageHeader title={t("analytics.title")} onBack={navigateToDashboard} />
 
-      <div className="overflow-hidden rounded-md bg-surface" data-testid="analytics-chart">
-        <PortfolioBalanceSummary
-          counterValue={counterValue}
-          chartColor={colors.wallet}
-          range={selectedTimeRange}
-          isWallet40
-          shouldDisplayGraphRework={shouldDisplayGraphRework}
-          balanceInfo={balanceInfo}
-        />
+      <div
+        className={cn("overflow-hidden", !shouldDisplayPnl && "rounded-md bg-surface")}
+        data-testid="analytics-chart"
+      >
+        {shouldDisplayPnl ? (
+          <ChartSection
+            balanceInfo={balanceInfo}
+            portfolio={portfolio}
+            isLoading={isLoading}
+            shouldDisplayBalanceRefreshRework={shouldDisplayBalanceRefreshRework}
+          />
+        ) : (
+          <PortfolioBalanceSummary
+            counterValue={counterValue}
+            chartColor={colors.wallet}
+            range={selectedTimeRange}
+            isWallet40
+            shouldDisplayGraphRework={shouldDisplayGraphRework}
+            balanceInfo={balanceInfo}
+          />
+        )}
       </div>
 
       <PnLSection />

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/types.ts
@@ -1,5 +1,5 @@
 import { CryptoOrTokenCurrency, Currency } from "@ledgerhq/types-cryptoassets";
-import { PortfolioRange } from "@ledgerhq/types-live";
+import { Portfolio, PortfolioRange } from "@ledgerhq/types-live";
 import type { PortfolioBalanceInfo } from "LLD/hooks/usePortfolioBalanceDisplayState";
 
 export type AllocationTableItem = {
@@ -20,6 +20,10 @@ export type AnalyticsViewModel = {
   counterValue: Currency;
   selectedTimeRange: PortfolioRange;
   balanceInfo: PortfolioBalanceInfo;
+  portfolio: Portfolio;
+  isLoading: boolean;
+  shouldDisplayBalanceRefreshRework: boolean;
   shouldDisplayGraphRework?: boolean;
   shouldDisplayAssetSection?: boolean;
+  shouldDisplayPnl: boolean;
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/useAnalyticsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/useAnalyticsViewModel.ts
@@ -1,24 +1,57 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useNavigate } from "react-router";
 import { useSelector } from "LLD/hooks/redux";
 import {
   counterValueCurrencySelector,
   selectedTimeRangeSelector,
 } from "~/renderer/reducers/settings";
+import { accountsSelector } from "~/renderer/reducers/accounts";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { usePortfolioBalanceDisplayState } from "LLD/hooks/usePortfolioBalanceDisplayState";
-import { DEFAULT_PORTFOLIO_RANGE } from "LLD/utils/constants";
+import { useCountervaluesState } from "@ledgerhq/live-countervalues-react";
+import { resolveAnalyticsValueChange } from "./utils/resolveAnalyticsValueChange";
 import type { AnalyticsViewModel } from "./types";
 
 export default function useAnalyticsViewModel(): AnalyticsViewModel {
   const navigate = useNavigate();
   const counterValue = useSelector(counterValueCurrencySelector);
   const selectedTimeRange = useSelector(selectedTimeRangeSelector);
-  const { shouldDisplayGraphRework, shouldDisplayAssetSection } =
-    useWalletFeaturesConfig("desktop");
-  const { balanceInfo } = usePortfolioBalanceDisplayState({
-    legacyRange: selectedTimeRange !== DEFAULT_PORTFOLIO_RANGE,
-  });
+  const accounts = useSelector(accountsSelector);
+  const cvState = useCountervaluesState();
+  const {
+    shouldDisplayGraphRework,
+    shouldDisplayAssetSection,
+    shouldDisplayPnl: isPnlFlagOn,
+  } = useWalletFeaturesConfig("desktop");
+  const {
+    balanceInfo: syncBalanceInfo,
+    portfolio,
+    isLoading,
+    shouldDisplayBalanceRefreshRework,
+  } = usePortfolioBalanceDisplayState({ legacyRange: true });
+
+  const shouldDisplayPnl = isPnlFlagOn && accounts.length > 0;
+
+  const valueChange = useMemo(
+    () =>
+      resolveAnalyticsValueChange({
+        selectedTimeRange,
+        accounts,
+        currentBalance: syncBalanceInfo.totalBalance,
+        portfolio,
+        cvState,
+        counterValue,
+      }),
+    [selectedTimeRange, accounts, syncBalanceInfo.totalBalance, portfolio, cvState, counterValue],
+  );
+
+  const balanceInfo = useMemo(
+    () => ({
+      ...syncBalanceInfo,
+      valueChange,
+    }),
+    [syncBalanceInfo, valueChange],
+  );
 
   const navigateToDashboard = useCallback(() => {
     navigate("/");
@@ -29,7 +62,11 @@ export default function useAnalyticsViewModel(): AnalyticsViewModel {
     counterValue,
     selectedTimeRange,
     balanceInfo,
+    portfolio,
+    isLoading,
+    shouldDisplayBalanceRefreshRework,
     shouldDisplayGraphRework,
     shouldDisplayAssetSection,
+    shouldDisplayPnl,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/__tests__/buildAnalyticsPortfolioChartSeries.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/__tests__/buildAnalyticsPortfolioChartSeries.test.ts
@@ -1,0 +1,28 @@
+import { buildAnalyticsPortfolioChartSeries } from "../buildAnalyticsPortfolioChartSeries";
+
+describe("buildAnalyticsPortfolioChartSeries", () => {
+  const now = new Date("2026-06-25T12:00:00.000Z").getTime();
+
+  const history = [
+    { date: new Date("2025-01-01T00:00:00.000Z"), value: 100 },
+    { date: new Date("2025-06-01T00:00:00.000Z"), value: 200 },
+    { date: new Date("2026-01-01T00:00:00.000Z"), value: 800 },
+    { date: new Date(now), value: 1000 },
+  ];
+
+  it("keeps the full month series for 1m", () => {
+    const { prices, timestamps } = buildAnalyticsPortfolioChartSeries(history, "1m", now);
+    expect(prices.length).toBe(history.length);
+    expect(timestamps[0]).toBe(history[0].date.getTime());
+  });
+
+  it("filters 6m to roughly the last six months", () => {
+    const { prices } = buildAnalyticsPortfolioChartSeries(history, "6m", now);
+    expect(prices).toEqual([800, 1000]);
+  });
+
+  it("filters 5y to roughly the last five years", () => {
+    const { prices } = buildAnalyticsPortfolioChartSeries(history, "5y", now);
+    expect(prices).toEqual([100, 200, 800, 1000]);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/__tests__/portfolioRangeMapping.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/__tests__/portfolioRangeMapping.test.ts
@@ -1,0 +1,29 @@
+import {
+  ANALYTICS_CHART_RANGES,
+  lineChartRangeToPortfolioRange,
+  portfolioRangeToLineChartRange,
+} from "../portfolioRangeMapping";
+
+describe("portfolioRangeMapping", () => {
+  it("maps portfolio ranges to line chart ranges", () => {
+    expect(portfolioRangeToLineChartRange("day")).toBe("1d");
+    expect(portfolioRangeToLineChartRange("week")).toBe("1w");
+    expect(portfolioRangeToLineChartRange("month")).toBe("1m");
+    expect(portfolioRangeToLineChartRange("year")).toBe("1y");
+    expect(portfolioRangeToLineChartRange("all")).toBe("all");
+  });
+
+  it("maps supported line chart ranges back to portfolio ranges", () => {
+    expect(lineChartRangeToPortfolioRange("1d")).toBe("day");
+    expect(lineChartRangeToPortfolioRange("1w")).toBe("week");
+    expect(lineChartRangeToPortfolioRange("1m")).toBe("month");
+    expect(lineChartRangeToPortfolioRange("1y")).toBe("year");
+    expect(lineChartRangeToPortfolioRange("all")).toBe("all");
+    expect(lineChartRangeToPortfolioRange("6m")).toBeUndefined();
+    expect(lineChartRangeToPortfolioRange("5y")).toBeUndefined();
+  });
+
+  it("exposes only portfolio-compatible analytics chart ranges", () => {
+    expect(ANALYTICS_CHART_RANGES).toEqual(["1d", "1w", "1m", "1y", "all"]);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/buildAnalyticsPortfolioChartSeries.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/buildAnalyticsPortfolioChartSeries.ts
@@ -1,0 +1,38 @@
+import { resampleChartPointsByInterval } from "@ledgerhq/live-common/market/utils/resampleChartPoints";
+import type { ChartDataPoint } from "@ledgerhq/live-common/market/utils/types";
+import type { BalanceHistory } from "@ledgerhq/types-live";
+import type { LineChartRange } from "LLD/components/LineChart";
+import { ASSET_DETAIL_RANGE_TARGET_INTERVAL_MS } from "LLD/features/AssetDetail/utils/buildAssetDetailChartSeries";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function getChartRangeStartTime(range: LineChartRange, now = Date.now()): number | undefined {
+  switch (range) {
+    case "6m":
+      return now - 182 * DAY_MS;
+    case "5y":
+      return now - 5 * 365 * DAY_MS;
+    default:
+      return undefined;
+  }
+}
+
+export function buildAnalyticsPortfolioChartSeries(
+  history: BalanceHistory,
+  selectedRange: LineChartRange,
+  now = Date.now(),
+): { prices: number[]; timestamps: number[] } {
+  const startTime = getChartRangeStartTime(selectedRange, now);
+  const filtered = startTime ? history.filter(point => point.date.getTime() >= startTime) : history;
+  const source = filtered.length > 0 ? filtered : history;
+  const points: ChartDataPoint[] = source.map(point => [point.date.getTime(), point.value]);
+  const resampled = resampleChartPointsByInterval(
+    points,
+    ASSET_DETAIL_RANGE_TARGET_INTERVAL_MS[selectedRange],
+  );
+
+  return {
+    prices: resampled.map(([, value]) => value),
+    timestamps: resampled.map(([timestamp]) => timestamp),
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/computeAllTimeValueChangeFromFirstReceive.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/computeAllTimeValueChangeFromFirstReceive.ts
@@ -48,7 +48,6 @@ export function computeAllTimeValueChangeFromFirstReceive(
 
   return {
     value,
-    percentage:
-      value === 0 ? 0 : (meaningfulPercentage(value, firstReceiveCountervalue) ?? null),
+    percentage: value === 0 ? 0 : (meaningfulPercentage(value, firstReceiveCountervalue) ?? null),
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/portfolioRangeMapping.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/utils/portfolioRangeMapping.ts
@@ -1,0 +1,36 @@
+import type { PortfolioRange } from "@ledgerhq/types-live";
+import type { LineChartRange } from "LLD/components/LineChart";
+
+export const ANALYTICS_CHART_RANGES: readonly LineChartRange[] = ["1d", "1w", "1m", "1y", "all"];
+
+export const PORTFOLIO_RANGE_LABEL_KEY: Record<PortfolioRange, string> = {
+  day: "assetDetails.day",
+  week: "assetDetails.week",
+  month: "assetDetails.month",
+  year: "assetDetails.year",
+  all: "assetDetails.allTime",
+};
+
+const PORTFOLIO_TO_LINE_CHART: Record<PortfolioRange, LineChartRange> = {
+  day: "1d",
+  week: "1w",
+  month: "1m",
+  year: "1y",
+  all: "all",
+};
+
+const LINE_CHART_TO_PORTFOLIO: Partial<Record<LineChartRange, PortfolioRange>> = {
+  "1d": "day",
+  "1w": "week",
+  "1m": "month",
+  "1y": "year",
+  all: "all",
+};
+
+export function portfolioRangeToLineChartRange(range: PortfolioRange): LineChartRange {
+  return PORTFOLIO_TO_LINE_CHART[range];
+}
+
+export function lineChartRangeToPortfolioRange(range: LineChartRange): PortfolioRange | undefined {
+  return LINE_CHART_TO_PORTFOLIO[range];
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Trend/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Trend/index.tsx
@@ -5,9 +5,9 @@ import { useTranslation } from "react-i18next";
 import { ChevronRight } from "@ledgerhq/lumen-ui-react/symbols";
 import { trendPercentageBody2Styles } from "LLD/shared/trendPercentageStyles";
 
-interface TrendProps {
-  readonly valueChange: ValueChange;
-}
+type TrendProps = Readonly<{
+  valueChange: ValueChange;
+}>;
 
 export const Trend = ({ valueChange }: TrendProps) => {
   const { percentageText, variant } = useTrendViewModel({


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Add `ChartSection` with balance header and Lumen `LineChart` on Analytics when `shouldDisplayPnl` is enabled
- Wire `useAnalyticsViewModel` for range-aware variation (first-receive baseline for all-time)
- Add portfolio ↔ line-chart range mapping for the analytics chart


https://github.com/user-attachments/assets/56f85a02-6242-42a4-80a4-bb1963d9d866

https://github.com/user-attachments/assets/bc66bdfb-98b2-4450-b526-cdc2697d57d8



### ❓ Context

[LIVE-31883](https://ledgerhq.atlassian.net/browse/LIVE-31883)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31883]: https://ledgerhq.atlassian.net/browse/LIVE-31883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ