### PR TITLE
[LWDM] test(e2e): skip EVM recipient/ENS validation on all devices until LIVE-28070 is fixed

### DIFF
--- a/libs/ledger-live-common/src/e2e/families/evm.ts
+++ b/libs/ledger-live-common/src/e2e/families/evm.ts
@@ -29,14 +29,11 @@ function formatEventsForError(events: string[], maxLength = 1000): string {
 }
 
 // TODO: remove once LIVE-28070 is fixed
-function shouldSkipTouchValidation(tx: Transaction): boolean {
-  const isPolOrBase =
+function shouldSkipRecipientDisplayValidation(tx: Transaction): boolean {
+  return (
     tx.accountToCredit.currency.id === Currency.POL.id ||
-    tx.accountToCredit.currency.id === Currency.BASE.id;
-  const isStaxOrFlex =
-    process.env.SPECULOS_DEVICE === Device.STAX.name ||
-    process.env.SPECULOS_DEVICE === Device.FLEX.name;
-  return isStaxOrFlex && isPolOrBase;
+    tx.accountToCredit.currency.id === Currency.BASE.id
+  );
 }
 
 function validateTransactionData(tx: Transaction, events: string[]) {
@@ -46,6 +43,10 @@ function validateTransactionData(tx: Transaction, events: string[]) {
     throw new Error(
       `Expected amount "${tx.amount}" to be displayed on Speculos device, but it was not found.\nEvents:\n${formattedEvents}`,
     );
+  }
+
+  if (shouldSkipRecipientDisplayValidation(tx)) {
+    return;
   }
 
   if (tx.accountToCredit.ensName && process.env.SPECULOS_DEVICE !== Device.LNS.name) {
@@ -71,16 +72,14 @@ function validateTransactionData(tx: Transaction, events: string[]) {
 async function sendEvmTouchDevices(tx: Transaction) {
   await waitForReviewTransaction();
 
-  const skipValidation = shouldSkipTouchValidation(tx);
   const events: string[] = [];
   if (tx.accountToCredit.ensName) {
     const ensEvents = await getEnsScreenTexts(tx.accountToCredit.ensName);
     events.push(...ensEvents);
   }
   events.push(...(await pressUntilTextFound(DeviceLabels.HOLD_TO_SIGN)));
-  if (!skipValidation) {
-    validateTransactionData(tx, events);
-  }
+  validateTransactionData(tx, events);
+
   await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);
 }
 


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- N/A: e2e test helper change only, no impact on published library behaviour -->
- [x] **Covered by automatic tests.** This change *is* the e2e test adaptation.
- [x] **Impact of the changes:** EVM e2e send tests only. The recipient address / ENS display validation is now skipped for POL and BASE across all device types; transaction amount is still validated.

### 📝 Description

[LIVE-28070](https://ledgerhq.atlassian.net/browse/LIVE-28070) (the device displays the ENS name instead of the raw recipient address when the address is entered manually) now also reproduces on **button devices**, not only on Stax/Flex touch devices.

Previously the workaround (`shouldSkipTouchValidation`) only skipped recipient validation for POL/BASE on touch devices. This generalizes it to `shouldSkipValidation` and moves the skip into `validateTransactionData` (after the amount assertion), so it applies to all device types (touch, button, nanoS). The transaction **amount is still validated** — only the recipient address / ENS display assertion is skipped.

This skip must be removed once LIVE-28070 is fixed (tracked by QAA-1345, `// TODO: remove once LIVE-28070 is fixed`).

### ❓ Context

- **JIRA or GitHub link**: [QAA-1345](https://ledgerhq.atlassian.net/browse/QAA-1345) — blocked by [LIVE-28070](https://ledgerhq.atlassian.net/browse/LIVE-28070)


[LIVE-28070]: https://ledgerhq.atlassian.net/browse/LIVE-28070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QAA-1345]: https://ledgerhq.atlassian.net/browse/QAA-1345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ