### PR TITLE
[LWM] fix(LIVE-28726): route swap success back to input on native back

### DIFF
--- a/.changeset/fix-swap-success-back-endless-loading.md
+++ b/.changeset/fix-swap-success-back-endless-loading.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the endless loading state when navigating back from the Swap success screen. React Navigation v7 pushed a new SwapPendingOperation on top of SwapLoading instead of reusing the existing one, leaving SwapLoading beneath the success screen. Any back gesture — Android system back, iOS swipe-back, or the close (X) button — would pop to SwapLoading and get stuck. The fix replaces the SwapSubScreensNavigator via BaseNavigator so the success screen always starts with a clean [SwapPendingOperation] stack, making all back paths (back button, close button, and via Swap history) return correctly to the Swap input.

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SwapNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SwapNavigator.tsx
@@ -18,7 +18,6 @@ import { SwapNavigatorParamList } from "./types/SwapNavigator";
 import { NavigationHeaderBackButton } from "../NavigationHeaderBackButton";
 import SwapCustomError from "~/screens/Swap/SubScreens/SwapCustomError";
 import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
-import { isGoingToSwapHistory } from "~/screens/Swap/navigation/navigateBackToSwapTab";
 
 const TRACKING_SOURCES = {
   Accounts: "Account",
@@ -115,14 +114,6 @@ export default function SwapNavigator(
         options={{
           headerTitle: t("transfer.swap.title"),
           headerLeft: NullHeader,
-        }}
-        listeners={{
-          beforeRemove: ({ data }) => {
-            if (isGoingToSwapHistory(data.action.payload)) {
-              return;
-            }
-            notifyFlowCompleted("swap");
-          },
         }}
       />
 

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SwapSubScreensNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SwapSubScreensNavigator.tsx
@@ -9,10 +9,7 @@ import SwapHistory from "~/screens/Swap/History";
 import { OperationDetails, PendingOperation, SwapLoading } from "~/screens/Swap/index";
 import SwapCustomError from "~/screens/Swap/SubScreens/SwapCustomError";
 import { SwapSubScreensNavigatorParamList } from "./types/SwapSubScreensNavigator";
-import {
-  isGoingToSwapHistory,
-  navigateBackToSwapTab,
-} from "~/screens/Swap/navigation/navigateBackToSwapTab";
+import { navigateBackToSwapTab } from "~/screens/Swap/navigation/navigateBackToSwapTab";
 import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
 
 const Stack = createNativeStackNavigator<SwapSubScreensNavigatorParamList>();
@@ -65,14 +62,6 @@ export default function SwapSubScreensNavigator() {
         options={{
           headerTitle: t("transfer.swap.title"),
           headerLeft: NullHeader,
-        }}
-        listeners={{
-          beforeRemove: ({ data }) => {
-            if (isGoingToSwapHistory(data.action.payload)) {
-              return;
-            }
-            notifyFlowCompleted("swap");
-          },
         }}
       />
       <Stack.Screen

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/SwapLiveAppWallet40.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/SwapLiveAppWallet40.tsx
@@ -22,6 +22,7 @@ type SwapWebviewContentProps = {
   params: DefaultAccountSwapParamList | null;
   webviewRef: RefObject<WebviewAPI | null>;
   setWebviewState: (state: WebviewState) => void;
+  resetWebview: () => void;
 };
 
 function SwapWebviewContent({
@@ -29,8 +30,9 @@ function SwapWebviewContent({
   params,
   webviewRef,
   setWebviewState,
+  resetWebview,
 }: Readonly<SwapWebviewContentProps>) {
-  const { customHandlers, inputs } = useSwapWebviewProps({ manifest, params });
+  const { customHandlers, inputs } = useSwapWebviewProps({ manifest, params, resetWebview });
 
   return (
     <Web3AppWebview
@@ -57,8 +59,17 @@ export function SwapLiveAppWallet40({
 
   const { theme: lumenTheme } = useLumenTheme();
 
-  const { manifest, error, isLoading, webviewRef, webviewState, setWebviewState, defaultParams } =
-    useSwapLiveAppState(params);
+  const {
+    manifest,
+    error,
+    isLoading,
+    webviewRef,
+    webviewState,
+    setWebviewState,
+    defaultParams,
+    webviewResetKey,
+    resetWebview,
+  } = useSwapLiveAppState(params);
 
   const updateWallet40HeaderState = useSwapWallet40HeaderStateUpdater(webviewRef);
 
@@ -94,10 +105,12 @@ export function SwapLiveAppWallet40({
       <View style={styles.contentContainer} pointerEvents="box-none">
         {manifest && (
           <SwapWebviewContent
+            key={webviewResetKey}
             manifest={manifest}
             params={defaultParams}
             webviewRef={webviewRef}
             setWebviewState={handleWebviewStateChange}
+            resetWebview={resetWebview}
           />
         )}
       </View>

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/__tests__/useSwapCustomHandlers.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/__tests__/useSwapCustomHandlers.test.ts
@@ -1,0 +1,226 @@
+import { CompleteExchangeUiRequest } from "@ledgerhq/live-common/wallet-api/Exchange/server";
+import { StackActions, useNavigation } from "@react-navigation/native";
+import BigNumber from "bignumber.js";
+import { renderHook } from "@tests/test-renderer";
+import { useCustomExchangeHandlers } from "~/components/WebPTXPlayer/CustomHandlers";
+import { BASE_NAVIGATOR_ID, NavigatorName, ScreenName } from "~/const";
+import { useSwapCustomHandlers } from "../index";
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: jest.fn(),
+}));
+
+jest.mock("~/components/WebPTXPlayer/CustomHandlers", () => ({
+  useCustomExchangeHandlers: jest.fn(() => ({})),
+}));
+
+jest.mock("~/e2e/bridge/client", () => ({
+  sendSwapLiveAppReady: jest.fn(),
+}));
+
+jest.mock("../getFee", () => ({
+  getFee: jest.fn(() => jest.fn()),
+}));
+
+jest.mock("../getTransactionByHash", () => ({
+  getTransactionByHash: jest.fn(() => jest.fn()),
+}));
+
+jest.mock("../saveSwapToHistory", () => ({
+  saveSwapToHistory: jest.fn(() => jest.fn()),
+}));
+
+const mockParentDispatch = jest.fn();
+const mockDispatch = jest.fn();
+const mockNavigate = jest.fn();
+const mockGetParent = jest.fn();
+
+const MOCK_EXCHANGE_PARAMS = {
+  provider: "lifi",
+  swapId: "swap-123",
+  transaction: { recipient: "0xabc", amount: BigNumber(1) },
+  exchange: { toCurrency: { id: "ethereum" }, fromCurrency: { id: "bitcoin" } },
+  amountExpectedTo: 2,
+  isEmbeddedSwap: false,
+  sponsored: false,
+} as unknown as CompleteExchangeUiRequest;
+
+const MOCK_MANIFEST = { id: "swap" } as never;
+const MOCK_ACCOUNTS = [] as never[];
+const MOCK_DISPATCH = jest.fn() as never;
+
+describe("useSwapCustomHandlers", () => {
+  let capturedOnCompleteResult: (
+    params: CompleteExchangeUiRequest,
+    hash: string,
+  ) => void = () => {};
+  let capturedOnCompleteError: (error: Error) => void = () => {};
+  let capturedHandleLoaderDrawer: () => void = () => {};
+  let mockResetWebview: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockResetWebview = jest.fn();
+
+    jest.mocked(useNavigation).mockReturnValue({
+      dispatch: mockDispatch,
+      navigate: mockNavigate,
+      getParent: mockGetParent,
+    } as never);
+
+    jest
+      .mocked(useCustomExchangeHandlers)
+      .mockImplementation(({ onCompleteResult, onCompleteError, handleLoaderDrawer }) => {
+        capturedOnCompleteResult = onCompleteResult as (
+          params: CompleteExchangeUiRequest,
+          hash: string,
+        ) => void;
+        capturedOnCompleteError = onCompleteError as (error: Error) => void;
+        capturedHandleLoaderDrawer = handleLoaderDrawer as () => void;
+        return {};
+      });
+  });
+
+  function render() {
+    return renderHook(() =>
+      useSwapCustomHandlers(MOCK_MANIFEST, MOCK_ACCOUNTS, MOCK_DISPATCH, mockResetWebview),
+    );
+  }
+
+  describe("navigateToSwapPendingOperation (via onCompleteResult)", () => {
+    it("dispatches StackActions.replace to parent when parent navigator is found", () => {
+      mockGetParent.mockReturnValue({ dispatch: mockParentDispatch });
+
+      render();
+
+      capturedOnCompleteResult(MOCK_EXCHANGE_PARAMS, "hash-abc");
+
+      expect(mockGetParent).toHaveBeenCalledWith(BASE_NAVIGATOR_ID);
+      expect(mockParentDispatch).toHaveBeenCalledWith(
+        StackActions.replace(NavigatorName.SwapSubScreens, {
+          screen: ScreenName.SwapPendingOperation,
+          params: {
+            swapOperation: {
+              provider: "lifi",
+              swapId: "swap-123",
+              status: "pending",
+              receiverAccountId: "0xabc",
+              toCurrency: { id: "ethereum" },
+              fromCurrency: { id: "bitcoin" },
+              operationId: "hash-abc",
+              fromAmount: BigNumber(1),
+              toAmount: BigNumber(2),
+            },
+            isEmbeddedSwap: false,
+            sponsored: false,
+          },
+        }),
+      );
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it("calls navigation.navigate directly when parent navigator is not found", () => {
+      mockGetParent.mockReturnValue(undefined);
+
+      render();
+
+      capturedOnCompleteResult(MOCK_EXCHANGE_PARAMS, "hash-xyz");
+
+      expect(mockGetParent).toHaveBeenCalledWith(BASE_NAVIGATOR_ID);
+      expect(mockParentDispatch).not.toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SwapSubScreens, {
+        screen: ScreenName.SwapPendingOperation,
+        params: {
+          swapOperation: {
+            provider: "lifi",
+            swapId: "swap-123",
+            status: "pending",
+            receiverAccountId: "0xabc",
+            toCurrency: { id: "ethereum" },
+            fromCurrency: { id: "bitcoin" },
+            operationId: "hash-xyz",
+            fromAmount: BigNumber(1),
+            toAmount: BigNumber(2),
+          },
+          isEmbeddedSwap: false,
+          sponsored: false,
+        },
+      });
+    });
+
+    it("calls resetWebview after navigation when parent is found", () => {
+      mockGetParent.mockReturnValue({ dispatch: mockParentDispatch });
+
+      render();
+
+      capturedOnCompleteResult(MOCK_EXCHANGE_PARAMS, "hash-abc");
+
+      expect(mockResetWebview).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls resetWebview after navigation when parent is not found", () => {
+      mockGetParent.mockReturnValue(undefined);
+
+      render();
+
+      capturedOnCompleteResult(MOCK_EXCHANGE_PARAMS, "hash-xyz");
+
+      expect(mockResetWebview).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("navigateToSwapCustomError (via onCompleteError)", () => {
+    it("navigates to SwapCustomError with the error", () => {
+      render();
+
+      const error = new Error("swap failed");
+      capturedOnCompleteError(error);
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SwapSubScreens, {
+        screen: ScreenName.SwapCustomError,
+        params: { error },
+      });
+    });
+  });
+
+  describe("handleShowLoadingDrawer (via handleLoaderDrawer)", () => {
+    it("navigates to SwapLoading", () => {
+      render();
+
+      capturedHandleLoaderDrawer();
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SwapSubScreens, {
+        screen: ScreenName.SwapLoading,
+      });
+    });
+  });
+
+  describe("navigateToSwapHistory", () => {
+    it("navigates to SwapHistory when swapRedirectToHistory handler is called", () => {
+      const { result } = render();
+
+      const handler = (result.current as Record<string, unknown>)["custom.swapRedirectToHistory"];
+      expect(typeof handler).toBe("function");
+
+      (handler as () => void)();
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SwapSubScreens, {
+        screen: ScreenName.SwapHistory,
+      });
+    });
+  });
+
+  describe("returned handlers shape", () => {
+    it("includes custom.getFee, custom.getTransactionByHash, custom.saveSwapToHistory, custom.swapRedirectToHistory", () => {
+      const { result } = render();
+
+      const handlers = result.current as Record<string, unknown>;
+      expect(typeof handlers["custom.getFee"]).toBe("function");
+      expect(typeof handlers["custom.getTransactionByHash"]).toBe("function");
+      expect(typeof handlers["custom.saveSwapToHistory"]).toBe("function");
+      expect(typeof handlers["custom.swapRedirectToHistory"]).toBe("function");
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/index.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/index.ts
@@ -1,14 +1,19 @@
 import { CompleteExchangeUiRequest } from "@ledgerhq/live-common/wallet-api/Exchange/server";
 import { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
 import type { AccountLike } from "@ledgerhq/types-live";
-import { NavigationProp, NavigationState, useNavigation } from "@react-navigation/native";
+import {
+  NavigationProp,
+  NavigationState,
+  StackActions,
+  useNavigation,
+} from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import BigNumber from "bignumber.js";
 import { useCallback } from "react";
 import { Dispatch } from "redux";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
-import { StackNavigatorNavigation } from "~/components/RootNavigator/types/helpers";
 import { WebviewProps } from "~/components/Web3AppWebview/types";
-import { NavigatorName, ScreenName } from "~/const";
+import { BASE_NAVIGATOR_ID, NavigatorName, ScreenName } from "~/const";
 import { sendSwapLiveAppReady } from "~/e2e/bridge/client";
 import { getFee } from "./getFee";
 import { getTransactionByHash } from "./getTransactionByHash";
@@ -20,12 +25,20 @@ export type NavigationType = Omit<NavigationProp<ReactNavigation.RootParamList>,
   getState(): NavigationState | undefined;
 };
 
+/** Navigation typed with {@link BASE_NAVIGATOR_ID} so `getParent(BASE_NAVIGATOR_ID)` is type-safe. */
+type SwapBaseNavigation = NativeStackNavigationProp<
+  BaseNavigatorStackParamList,
+  keyof BaseNavigatorStackParamList,
+  typeof BASE_NAVIGATOR_ID
+>;
+
 export function useSwapCustomHandlers(
   manifest: WebviewProps["manifest"],
   accounts: AccountLike[],
   dispatch: Dispatch,
+  resetWebview: () => void,
 ) {
-  const navigation = useNavigation<StackNavigatorNavigation<BaseNavigatorStackParamList>>();
+  const navigation = useNavigation<SwapBaseNavigation>();
 
   const navigateToSwapPendingOperation = useCallback(
     (exchangeParams: CompleteExchangeUiRequest, operationHash: string) => {
@@ -45,12 +58,33 @@ export function useSwapCustomHandlers(
         sponsored: exchangeParams.sponsored,
       };
 
-      navigation.navigate(NavigatorName.SwapSubScreens, {
-        screen: ScreenName.SwapPendingOperation,
-        params,
-      });
+      // React Navigation v7 pushes a new screen even if one already exists lower
+      // in the stack. Dispatching replace to BaseNavigator gives SwapSubScreensNavigator
+      // a clean [SwapPendingOperation] stack with no SwapLoading beneath it, so
+      // any back gesture returns to SwapTab instead of revealing SwapLoading.
+      const baseNavigation = navigation.getParent(BASE_NAVIGATOR_ID);
+      if (baseNavigation) {
+        baseNavigation.dispatch(
+          StackActions.replace(NavigatorName.SwapSubScreens, {
+            screen: ScreenName.SwapPendingOperation,
+            params,
+          }),
+        );
+      } else {
+        navigation.navigate(NavigatorName.SwapSubScreens, {
+          screen: ScreenName.SwapPendingOperation,
+          params,
+        });
+      }
+
+      // Remount the webview to its initial URL while the user reads the success
+      // screen so they see a clean swap form when they navigate back to SwapTab.
+      // loadURL(initialURL) would be a no-op because React sees no state change
+      // when currentURI already equals initialURL (the webview navigated internally
+      // without updating React state). Incrementing the key forces a true remount.
+      resetWebview();
     },
-    [navigation],
+    [navigation, resetWebview],
   );
 
   const navigateToSwapCustomError = useCallback(

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/__tests__/useSwapLiveAppState.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/__tests__/useSwapLiveAppState.test.ts
@@ -1,0 +1,204 @@
+import { act, renderHook, withFlagOverrides } from "@tests/test-renderer";
+import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
+import { useNetInfo } from "@react-native-community/netinfo";
+import { initialWebviewState } from "~/components/Web3AppWebview/helpers";
+import { useSwapLiveAppState } from "../useSwapLiveAppState";
+
+jest.mock("~/context/Locale", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const STUB_MANIFEST: LiveAppManifest = {
+  id: "swap-test",
+  name: "Swap Test",
+  url: "https://swap.test",
+  homepageUrl: "https://swap.test",
+  platforms: ["ios", "android"],
+  apiVersion: "2.0.0",
+  manifestVersion: "2",
+  branch: "stable",
+  permissions: [],
+  domains: [],
+  categories: [],
+  currencies: "*",
+  highlight: false,
+  visibility: "complete",
+  content: {
+    shortDescription: { en: "Swap assets" },
+    description: { en: "Swap assets on Ledger Live" },
+  },
+};
+
+const mockUseLocalLiveAppManifest = jest.fn(() => STUB_MANIFEST as LiveAppManifest | undefined);
+const mockUseRemoteLiveAppManifest = jest.fn(() => undefined as LiveAppManifest | undefined);
+const mockRemoteLiveAppState = { isLoading: false };
+
+jest.mock("@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index", () => ({
+  useLocalLiveAppManifest: (_id: string | undefined) => mockUseLocalLiveAppManifest(),
+}));
+
+jest.mock("@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index", () => ({
+  useRemoteLiveAppManifest: (_id: string | undefined) => mockUseRemoteLiveAppManifest(),
+  useRemoteLiveAppContext: () => ({ state: mockRemoteLiveAppState }),
+}));
+
+const mockedUseNetInfo = jest.mocked(useNetInfo);
+
+describe("useSwapLiveAppState", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseLocalLiveAppManifest.mockReturnValue(STUB_MANIFEST);
+    mockUseRemoteLiveAppManifest.mockReturnValue(undefined);
+    mockedUseNetInfo.mockReturnValue({ isConnected: true } as ReturnType<typeof useNetInfo>);
+  });
+
+  it("should return manifest and no error when manifest is available and network is up", () => {
+    const { result } = renderHook(() => useSwapLiveAppState(null));
+
+    expect(result.current.manifest).toBe(STUB_MANIFEST);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("should prefer local manifest over remote manifest", () => {
+    mockUseRemoteLiveAppManifest.mockReturnValue({
+      ...STUB_MANIFEST,
+      id: "swap-remote",
+    } as LiveAppManifest);
+
+    const { result } = renderHook(() => useSwapLiveAppState(null));
+
+    expect(result.current.manifest?.id).toBe("swap-test");
+  });
+
+  it("should fall back to remote manifest when local manifest is not available", () => {
+    const remoteManifest = { ...STUB_MANIFEST, id: "swap-remote" } as LiveAppManifest;
+    mockUseLocalLiveAppManifest.mockReturnValue(undefined);
+    mockUseRemoteLiveAppManifest.mockReturnValue(remoteManifest);
+
+    const { result } = renderHook(() => useSwapLiveAppState(null));
+
+    expect(result.current.manifest?.id).toBe("swap-remote");
+  });
+
+  it("should return an error when no manifest is available", () => {
+    mockUseLocalLiveAppManifest.mockReturnValue(undefined);
+    mockUseRemoteLiveAppManifest.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useSwapLiveAppState(null));
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.manifest).toBeUndefined();
+  });
+
+  it("should return a network error when offline", () => {
+    mockedUseNetInfo.mockReturnValue({ isConnected: false } as ReturnType<typeof useNetInfo>);
+
+    const { result } = renderHook(() => useSwapLiveAppState(null));
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe("errors.WebPTXPlayerNetworkFail.title");
+  });
+
+  it("should increment webviewResetKey when resetWebview is called", () => {
+    const { result } = renderHook(() => useSwapLiveAppState(null));
+
+    expect(result.current.webviewResetKey).toBe(0);
+
+    act(() => {
+      result.current.resetWebview();
+    });
+
+    expect(result.current.webviewResetKey).toBe(1);
+
+    act(() => {
+      result.current.resetWebview();
+    });
+
+    expect(result.current.webviewResetKey).toBe(2);
+  });
+
+  it("should return null defaultParams when params are invalid", () => {
+    const { result } = renderHook(() => useSwapLiveAppState(null));
+    expect(result.current.defaultParams).toBeNull();
+  });
+
+  it("should return null defaultParams when params is an empty object", () => {
+    const { result } = renderHook(() => useSwapLiveAppState({}));
+    expect(result.current.defaultParams).toBeNull();
+  });
+
+  it("should return defaultParams when at least one valid swap param key is present", () => {
+    const params = { fromCurrencyId: "bitcoin", toCurrencyId: "ethereum" };
+    const { result } = renderHook(() => useSwapLiveAppState(params));
+    expect(result.current.defaultParams).toStrictEqual(params);
+  });
+
+  it("should return defaultParams when only one valid swap param key is set", () => {
+    const params = { currency: "bitcoin" };
+    const { result } = renderHook(() => useSwapLiveAppState(params));
+    expect(result.current.defaultParams).toStrictEqual(params);
+  });
+
+  it("should return null defaultParams when all swap param values are undefined", () => {
+    const params = { fromCurrencyId: undefined, toCurrencyId: undefined };
+    const { result } = renderHook(() => useSwapLiveAppState(params));
+    expect(result.current.defaultParams).toBeNull();
+  });
+
+  it("should return no error when isConnected is null and manifest is available (QAA edge case)", () => {
+    // isConnected=null causes hasError=true (via !isConnected) but none of the specific
+    // error conditions apply, so the error memo falls through to `return null`.
+    mockedUseNetInfo.mockReturnValue({ isConnected: null } as ReturnType<typeof useNetInfo>);
+
+    const { result } = renderHook(() => useSwapLiveAppState(null));
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.manifest).toBe(STUB_MANIFEST);
+  });
+
+  it("should expose webviewRef and initial webviewState", () => {
+    const { result } = renderHook(() => useSwapLiveAppState(null));
+
+    expect(result.current.webviewRef).toBeDefined();
+    expect(result.current.webviewState).toBeDefined();
+    expect(result.current.webviewState.url).toBe("");
+    expect(result.current.webviewState.loading).toBe(false);
+  });
+
+  it("should return APP_FAILED_TO_LOAD error when webview navigates to an error URL", () => {
+    const { result } = renderHook(() => useSwapLiveAppState(null));
+
+    act(() => {
+      result.current.setWebviewState({ ...initialWebviewState, url: "/unknown-error" });
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe("errors.AppManifestNotFoundError.title");
+  });
+
+  it("should use manifest_id from ptxSwapLiveAppMobile feature flag when provided", () => {
+    const { result } = renderHook(() => useSwapLiveAppState(null), {
+      overrideInitialState: withFlagOverrides({
+        ptxSwapLiveAppMobile: { enabled: true, params: { manifest_id: "custom-swap-manifest" } },
+      }),
+    });
+
+    expect(result.current.manifest).toBe(STUB_MANIFEST);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("should pass undefined to manifest hooks when manifest_id is an empty string", () => {
+    // An empty string manifest_id is not nullish so the ?? fallback doesn't apply,
+    // but `"" || undefined` converts it to undefined before passing to the hooks.
+    const { result } = renderHook(() => useSwapLiveAppState(null), {
+      overrideInitialState: withFlagOverrides({
+        ptxSwapLiveAppMobile: { params: { manifest_id: "" } },
+      }),
+    });
+
+    // Our mock always returns STUB_MANIFEST regardless of the id argument
+    expect(result.current.manifest).toBe(STUB_MANIFEST);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/__tests__/useSwapWebviewProps.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/__tests__/useSwapWebviewProps.test.ts
@@ -1,0 +1,160 @@
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { Platform } from "react-native";
+import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
+import { currentRouteNameRef } from "~/analytics/screenRefs";
+import { useSwapWebviewProps } from "../useSwapWebviewProps";
+import { useSwapCustomHandlers } from "../../customHandlers";
+import { useDeeplinkCustomHandlers } from "~/components/WebPlatformPlayer/CustomHandlers";
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: jest.fn(() => ({
+    navigate: jest.fn(),
+    dispatch: jest.fn(),
+    getParent: jest.fn(),
+  })),
+}));
+
+jest.mock("../../customHandlers", () => ({
+  useSwapCustomHandlers: jest.fn(() => ({ "custom.getFee": jest.fn() })),
+}));
+
+jest.mock("~/components/WebPlatformPlayer/CustomHandlers", () => ({
+  useDeeplinkCustomHandlers: jest.fn(() => ({ "custom.deeplink": jest.fn() })),
+}));
+
+jest.mock("~/analytics/screenRefs", () => ({
+  currentRouteNameRef: { current: "SwapTab" },
+}));
+
+const STUB_MANIFEST = {
+  id: "swap-test",
+  url: "https://swap.test",
+} as unknown as LiveAppManifest;
+
+const mockedUseSwapCustomHandlers = jest.mocked(useSwapCustomHandlers);
+const mockedUseDeeplinkCustomHandlers = jest.mocked(useDeeplinkCustomHandlers);
+
+describe("useSwapWebviewProps", () => {
+  const mockResetWebview = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (currentRouteNameRef as { current: string | null }).current = "SwapTab";
+    mockedUseSwapCustomHandlers.mockReturnValue({ "custom.getFee": jest.fn() } as never);
+    mockedUseDeeplinkCustomHandlers.mockReturnValue({ "custom.deeplink": jest.fn() } as never);
+  });
+
+  it("should pass resetWebview to useSwapCustomHandlers", () => {
+    renderHook(() =>
+      useSwapWebviewProps({
+        manifest: STUB_MANIFEST,
+        params: null,
+        resetWebview: mockResetWebview,
+      }),
+    );
+
+    expect(mockedUseSwapCustomHandlers).toHaveBeenCalledWith(
+      STUB_MANIFEST,
+      expect.any(Array),
+      expect.any(Function),
+      mockResetWebview,
+    );
+  });
+
+  it("should merge swap and deeplink handlers in customHandlers", () => {
+    const swapHandler = jest.fn();
+    const deeplinkHandler = jest.fn();
+    mockedUseSwapCustomHandlers.mockReturnValue({ "custom.getFee": swapHandler } as never);
+    mockedUseDeeplinkCustomHandlers.mockReturnValue({
+      "custom.deeplink": deeplinkHandler,
+    } as never);
+
+    const { result } = renderHook(() =>
+      useSwapWebviewProps({
+        manifest: STUB_MANIFEST,
+        params: null,
+        resetWebview: mockResetWebview,
+      }),
+    );
+
+    expect(
+      result.current.customHandlers["custom.getFee" as keyof typeof result.current.customHandlers],
+    ).toBe(swapHandler);
+    expect(
+      result.current.customHandlers[
+        "custom.deeplink" as keyof typeof result.current.customHandlers
+      ],
+    ).toBe(deeplinkHandler);
+  });
+
+  it("should return inputs with required platform fields", () => {
+    const { result } = renderHook(() =>
+      useSwapWebviewProps({
+        manifest: STUB_MANIFEST,
+        params: null,
+        resetWebview: mockResetWebview,
+      }),
+    );
+
+    const { inputs } = result.current;
+    expect(inputs.OS).toBe(Platform.OS);
+    expect(inputs.platform).toBe("LLM");
+    expect(inputs.lwm40enabled).toBe("true");
+  });
+
+  it("should include source from currentRouteNameRef in inputs", () => {
+    const { result } = renderHook(() =>
+      useSwapWebviewProps({
+        manifest: STUB_MANIFEST,
+        params: null,
+        resetWebview: mockResetWebview,
+      }),
+    );
+
+    expect(result.current.inputs.source).toBe("SwapTab");
+  });
+
+  it("should return both customHandlers and inputs", () => {
+    const { result } = renderHook(() =>
+      useSwapWebviewProps({
+        manifest: STUB_MANIFEST,
+        params: null,
+        resetWebview: mockResetWebview,
+      }),
+    );
+
+    expect(result.current).toHaveProperty("customHandlers");
+    expect(result.current).toHaveProperty("inputs");
+  });
+
+  it("should use empty string as source when currentRouteNameRef is null", () => {
+    (currentRouteNameRef as { current: string | null }).current = null;
+    const { result } = renderHook(() =>
+      useSwapWebviewProps({
+        manifest: STUB_MANIFEST,
+        params: null,
+        resetWebview: mockResetWebview,
+      }),
+    );
+    expect(result.current.inputs.source).toBe("");
+  });
+
+  it("should set isModularDrawer to 'true' when llmModularDrawer is enabled with live_app", () => {
+    const { result } = renderHook(
+      () =>
+        useSwapWebviewProps({
+          manifest: STUB_MANIFEST,
+          params: null,
+          resetWebview: mockResetWebview,
+        }),
+      {
+        overrideInitialState: withFlagOverrides({
+          llmModularDrawer: { enabled: true, params: { live_app: true } },
+        }),
+      },
+    );
+
+    expect(result.current.inputs.isModularDrawer).toBe("true");
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/useSwapLiveAppState.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/useSwapLiveAppState.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { FEATURE_FLAGS_DEFAULTS } from "@shared/feature-flags";
 import { useFeature } from "@features/platform-feature-flags";
 import {
@@ -60,6 +60,11 @@ export function useSwapLiveAppState(params: unknown) {
 
   const webviewRef = useRef<WebviewAPI>(null);
 
+  // Incrementing this key remounts SwapWebviewContent, resetting the webview to
+  // its initial URL regardless of where it has navigated internally.
+  const [webviewResetKey, setWebviewResetKey] = useState(0);
+  const resetWebview = useCallback(() => setWebviewResetKey(k => k + 1), []);
+
   const swapLiveAppManifestID = ptxSwapLiveAppMobile?.params?.manifest_id ?? DEFAULT_MANIFEST_ID;
 
   const localManifest: LiveAppManifest | undefined = useLocalLiveAppManifest(
@@ -105,5 +110,7 @@ export function useSwapLiveAppState(params: unknown) {
     webviewState,
     setWebviewState,
     defaultParams,
+    webviewResetKey,
+    resetWebview,
   };
 }

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/useSwapWebviewProps.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/useSwapWebviewProps.ts
@@ -26,6 +26,7 @@ import { DefaultAccountSwapParamList } from "../../types";
 type UseSwapWebviewPropsParams = {
   manifest: LiveAppManifest;
   params: DefaultAccountSwapParamList | null;
+  resetWebview: () => void;
 };
 
 /**
@@ -33,19 +34,11 @@ type UseSwapWebviewPropsParams = {
  * - Custom handlers (swap + deeplink)
  * - Webview inputs (theme, language, env vars, swap params, etc.)
  */
-export function useSwapWebviewProps({ manifest, params }: UseSwapWebviewPropsParams) {
+export function useSwapWebviewProps({ manifest, params, resetWebview }: UseSwapWebviewPropsParams) {
   // Swap duplicated the Custom Handlers due to different needs compared to the rest of the platform apps,
   // to avoid complexifying the logic in the shared custom handlers.
   const accounts = useSelector(flattenAccountsSelector);
   const dispatch = useDispatch();
-  const customSwapHandlers = useSwapCustomHandlers(manifest, accounts, dispatch);
-  const customDeeplinkHandlers = useDeeplinkCustomHandlers();
-  const customHandlers = useMemo<WalletAPICustomHandlers>(() => {
-    return {
-      ...customSwapHandlers,
-      ...customDeeplinkHandlers,
-    };
-  }, [customSwapHandlers, customDeeplinkHandlers]);
 
   const { theme } = useTheme();
   const { language } = useSettings();
@@ -115,6 +108,15 @@ export function useSwapWebviewProps({ manifest, params }: UseSwapWebviewPropsPar
       swapParams,
     ],
   );
+
+  const customSwapHandlers = useSwapCustomHandlers(manifest, accounts, dispatch, resetWebview);
+  const customDeeplinkHandlers = useDeeplinkCustomHandlers();
+  const customHandlers = useMemo<WalletAPICustomHandlers>(() => {
+    return {
+      ...customSwapHandlers,
+      ...customDeeplinkHandlers,
+    };
+  }, [customSwapHandlers, customDeeplinkHandlers]);
 
   return {
     customHandlers,

--- a/apps/ledger-live-mobile/src/screens/Swap/SubScreens/PendingOperation.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/SubScreens/PendingOperation.tsx
@@ -1,5 +1,5 @@
 import { CommonActions, useTheme } from "@react-navigation/native";
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { Trans } from "~/context/Locale";
 import { StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -17,7 +17,12 @@ import { useSyncAllAccounts } from "../LiveApp/hooks/useSyncAllAccounts";
 import { PendingOperationParamList } from "../types";
 import { SWAP_VERSION } from "../utils";
 import { NavigationHeaderCloseButton } from "~/components/NavigationHeaderCloseButton";
-import { hasSwapTabRoute, navigateBackToSwapTab } from "../navigation/navigateBackToSwapTab";
+import {
+  handlePendingOperationBeforeRemove,
+  hasSwapTabRoute,
+  navigateBackToSwapTab,
+} from "../navigation/navigateBackToSwapTab";
+import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
 
 export function PendingOperation({ route, navigation }: PendingOperationParamList) {
   const { colors } = useTheme();
@@ -26,18 +31,39 @@ export function PendingOperation({ route, navigation }: PendingOperationParamLis
   const { isEmbeddedSwap, sponsored } = route.params;
   const syncAccounts = useSyncAllAccounts();
   const supportsSwapTabRoute = hasSwapTabRoute(navigation.getState());
+  const { notifyFlowCompleted } = useNotificationsContext();
+  const allowRemovalRef = useRef(false);
+  const completeSwapFlow = useCallback(() => {
+    notifyFlowCompleted("swap");
+  }, [notifyFlowCompleted]);
 
   const navigateToSwapForm = useCallback(() => {
+    if (allowRemovalRef.current) return;
+
     track("button_clicked", {
       button: "SwapCloseSuccess",
       page: ScreenName.SwapPendingOperation,
       swapVersion: SWAP_VERSION,
     });
 
+    allowRemovalRef.current = true;
+    completeSwapFlow();
     navigateBackToSwapTab({
       navigation,
     });
-  }, [navigation]);
+  }, [completeSwapFlow, navigation]);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener("beforeRemove", event => {
+      handlePendingOperationBeforeRemove({
+        event,
+        allowRemovalRef,
+        onFlowCompleted: completeSwapFlow,
+      });
+    });
+
+    return unsubscribe;
+  }, [completeSwapFlow, navigation]);
 
   useEffect(() => {
     navigation.setOptions({

--- a/apps/ledger-live-mobile/src/screens/Swap/SubScreens/__tests__/PendingOperation.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/SubScreens/__tests__/PendingOperation.test.tsx
@@ -2,15 +2,37 @@ import React from "react";
 import BigNumber from "bignumber.js";
 import { CommonActions } from "@react-navigation/native";
 import { render, screen, waitFor } from "@tests/test-renderer";
-import { ScreenName } from "~/const";
+import { BASE_NAVIGATOR_ID, ScreenName } from "~/const";
+import { track } from "~/analytics";
 import type { State } from "~/reducers/types";
 import { PendingOperation } from "../PendingOperation";
 
-function buildNavigation(routeNames: string[]) {
+const mockNotifyFlowCompleted = jest.fn();
+
+jest.mock("LLM/features/NotificationsPrompt", () => ({
+  useNotificationsContext: () => ({
+    notifyFlowCompleted: mockNotifyFlowCompleted,
+  }),
+}));
+
+function getCloseOnPress(navigation: ReturnType<typeof buildNavigation>): () => void {
+  const opts = navigation.setOptions.mock.calls
+    .map(([o]) => o as Record<string, unknown>)
+    .find(o => typeof o?.headerRight === "function");
+  const element = (opts?.headerRight as () => React.ReactElement<{ onPress: () => void }>)();
+  return element.props.onPress;
+}
+
+function buildNavigation(routeNames: string[], parentGoBack = jest.fn()) {
   return {
     dispatch: jest.fn(),
     getState: () => ({ routeNames }),
     setOptions: jest.fn(),
+    addListener: jest.fn().mockReturnValue(() => {}),
+    getParent: jest.fn((id?: string) =>
+      id === BASE_NAVIGATOR_ID ? { dispatch: jest.fn(), goBack: parentGoBack } : undefined,
+    ),
+    goBack: jest.fn(),
   };
 }
 
@@ -28,9 +50,27 @@ const route = {
   },
 };
 
+const routeWithOptionalParams = {
+  params: {
+    isEmbeddedSwap: true,
+    sponsored: true,
+    swapOperation: {
+      swapId: "swap-2",
+      provider: "changelly",
+      status: "pending",
+      receiverAccountId: "ethereum-account",
+      operationId: "operation-2",
+      fromAmount: new BigNumber(1),
+      toAmount: new BigNumber(2),
+      toCurrency: { id: "ethereum", name: "Ethereum" },
+    },
+  },
+};
+
 describe("PendingOperation", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockNotifyFlowCompleted.mockClear();
   });
 
   it("should navigate to swap history and open transaction status details", async () => {
@@ -85,5 +125,88 @@ describe("PendingOperation", () => {
         },
       });
     });
+  });
+
+  it("should call notifyFlowCompleted and navigate to SwapTab when close button is pressed", async () => {
+    const navigation = buildNavigation([ScreenName.SwapTab, ScreenName.SwapHistory]);
+    render(<PendingOperation route={route as never} navigation={navigation as never} />);
+
+    getCloseOnPress(navigation)();
+
+    expect(mockNotifyFlowCompleted).toHaveBeenCalledWith("swap");
+    expect(navigation.dispatch).toHaveBeenCalledWith(
+      CommonActions.reset({ index: 0, routes: [{ name: ScreenName.SwapTab }] }),
+    );
+  });
+
+  it("should track analytics when close button is pressed", () => {
+    const navigation = buildNavigation([ScreenName.SwapTab, ScreenName.SwapHistory]);
+    render(<PendingOperation route={route as never} navigation={navigation as never} />);
+
+    getCloseOnPress(navigation)();
+
+    expect(jest.mocked(track)).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "SwapCloseSuccess" }),
+    );
+  });
+
+  it("should guard against double-tap on close button", () => {
+    const navigation = buildNavigation([ScreenName.SwapTab, ScreenName.SwapHistory]);
+    render(<PendingOperation route={route as never} navigation={navigation as never} />);
+
+    const onPress = getCloseOnPress(navigation);
+    onPress();
+    onPress();
+
+    expect(mockNotifyFlowCompleted).toHaveBeenCalledTimes(1);
+    expect(navigation.dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call notifyFlowCompleted on native back gesture", () => {
+    const navigation = buildNavigation([ScreenName.SwapTab, ScreenName.SwapHistory]);
+    render(<PendingOperation route={route as never} navigation={navigation as never} />);
+
+    const beforeRemoveListener = navigation.addListener.mock.calls.find(
+      ([event]: [string]) => event === "beforeRemove",
+    )?.[1];
+
+    expect(beforeRemoveListener).toBeDefined();
+    beforeRemoveListener({
+      preventDefault: jest.fn(),
+      data: { action: CommonActions.goBack() },
+    });
+
+    expect(mockNotifyFlowCompleted).toHaveBeenCalledWith("swap");
+  });
+
+  it("should render with isEmbeddedSwap, sponsored, and toCurrency when provided", async () => {
+    const navigation = buildNavigation([ScreenName.SwapTab, ScreenName.SwapHistory]);
+    render(
+      <PendingOperation
+        route={routeWithOptionalParams as never}
+        navigation={navigation as never}
+      />,
+    );
+
+    expect(screen.getByTestId("swap-success-title")).toBeTruthy();
+  });
+
+  it("should not call notifyFlowCompleted on native back when close button already fired it", () => {
+    const navigation = buildNavigation([ScreenName.SwapTab, ScreenName.SwapHistory]);
+    render(<PendingOperation route={route as never} navigation={navigation as never} />);
+
+    getCloseOnPress(navigation)();
+
+    const beforeRemoveListener = navigation.addListener.mock.calls.find(
+      ([event]: [string]) => event === "beforeRemove",
+    )?.[1];
+    beforeRemoveListener({
+      preventDefault: jest.fn(),
+      data: { action: CommonActions.goBack() },
+    });
+
+    // Only one call — from the close button; beforeRemove skips because allowRemovalRef is true
+    expect(mockNotifyFlowCompleted).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-mobile/src/screens/Swap/navigation/__tests__/navigateBackToSwapTab.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/navigation/__tests__/navigateBackToSwapTab.test.ts
@@ -1,6 +1,11 @@
 import { CommonActions } from "@react-navigation/native";
 import { BASE_NAVIGATOR_ID, ScreenName } from "~/const";
-import { hasSwapTabRoute, navigateBackToSwapTab } from "../navigateBackToSwapTab";
+import {
+  handlePendingOperationBeforeRemove,
+  hasSwapTabRoute,
+  isGoingToSwapHistory,
+  navigateBackToSwapTab,
+} from "../navigateBackToSwapTab";
 
 describe("navigateBackToSwapTab", () => {
   const createNavigation = ({
@@ -30,6 +35,8 @@ describe("navigateBackToSwapTab", () => {
   it("should detect when the current navigator contains SwapTab", () => {
     expect(hasSwapTabRoute({ routeNames: [ScreenName.SwapTab] } as const)).toBe(true);
     expect(hasSwapTabRoute({ routeNames: [ScreenName.SwapHistory] } as const)).toBe(false);
+    expect(hasSwapTabRoute(undefined)).toBe(false);
+    expect(hasSwapTabRoute({})).toBe(false);
   });
 
   it("should reset locally to SwapTab when the current navigator contains SwapTab", () => {
@@ -81,5 +88,134 @@ describe("navigateBackToSwapTab", () => {
 
     expect(dispatch).not.toHaveBeenCalled();
     expect(goBack).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("handlePendingOperationBeforeRemove", () => {
+  it("should call flow completed on native back from swap success", () => {
+    const allowRemovalRef = { current: false };
+    const preventDefault = jest.fn();
+    const onFlowCompleted = jest.fn();
+
+    handlePendingOperationBeforeRemove({
+      event: {
+        preventDefault,
+        data: {
+          action: CommonActions.goBack(),
+        },
+      },
+      allowRemovalRef,
+      onFlowCompleted,
+    });
+
+    // With a clean [SwapPendingOperation] stack, default back already returns to
+    // SwapTab — no redirect needed, just notify flow completion.
+    expect(onFlowCompleted).toHaveBeenCalledTimes(1);
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(allowRemovalRef.current).toBe(false);
+  });
+
+  it("should allow the removal it triggered itself (close button)", () => {
+    const allowRemovalRef = { current: true };
+    const preventDefault = jest.fn();
+    const onFlowCompleted = jest.fn();
+
+    handlePendingOperationBeforeRemove({
+      event: {
+        preventDefault,
+        data: {
+          action: CommonActions.goBack(),
+        },
+      },
+      allowRemovalRef,
+      onFlowCompleted,
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(onFlowCompleted).not.toHaveBeenCalled();
+  });
+
+  it("should allow swap success to navigate to history", () => {
+    const allowRemovalRef = { current: false };
+    const preventDefault = jest.fn();
+    const onFlowCompleted = jest.fn();
+
+    handlePendingOperationBeforeRemove({
+      event: {
+        preventDefault,
+        data: {
+          action: CommonActions.reset({
+            index: 0,
+            routes: [{ name: ScreenName.SwapHistory }],
+          }),
+        },
+      },
+      allowRemovalRef,
+      onFlowCompleted,
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(onFlowCompleted).not.toHaveBeenCalled();
+  });
+
+  it("should call flow completed when action payload has routes not going to SwapHistory", () => {
+    const allowRemovalRef = { current: false };
+    const onFlowCompleted = jest.fn();
+
+    handlePendingOperationBeforeRemove({
+      event: {
+        preventDefault: jest.fn(),
+        data: {
+          action: CommonActions.reset({
+            index: 0,
+            routes: [{ name: ScreenName.SwapTab }],
+          }),
+        },
+      },
+      allowRemovalRef,
+      onFlowCompleted,
+    });
+
+    expect(onFlowCompleted).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("isGoingToSwapHistory", () => {
+  it("should return false for falsy payloads", () => {
+    expect(isGoingToSwapHistory(null)).toBe(false);
+    expect(isGoingToSwapHistory(undefined)).toBe(false);
+    expect(isGoingToSwapHistory(0)).toBe(false);
+    expect(isGoingToSwapHistory("")).toBe(false);
+  });
+
+  it("should return false for non-object payload", () => {
+    expect(isGoingToSwapHistory("some string")).toBe(false);
+    expect(isGoingToSwapHistory(42)).toBe(false);
+    expect(isGoingToSwapHistory(true)).toBe(false);
+  });
+
+  it("should return false for object without routes key", () => {
+    expect(isGoingToSwapHistory({ type: "GO_BACK" })).toBe(false);
+    expect(isGoingToSwapHistory({})).toBe(false);
+  });
+
+  it("should return false when routes is not an array", () => {
+    expect(isGoingToSwapHistory({ routes: "not-an-array" })).toBe(false);
+    expect(isGoingToSwapHistory({ routes: null })).toBe(false);
+    expect(isGoingToSwapHistory({ routes: { name: ScreenName.SwapHistory } })).toBe(false);
+  });
+
+  it("should return false when routes array does not contain SwapHistory", () => {
+    expect(isGoingToSwapHistory({ routes: [] })).toBe(false);
+    expect(isGoingToSwapHistory({ routes: [{ name: ScreenName.SwapTab }] })).toBe(false);
+  });
+
+  it("should return true when routes array contains SwapHistory", () => {
+    expect(isGoingToSwapHistory({ routes: [{ name: ScreenName.SwapHistory }] })).toBe(true);
+    expect(
+      isGoingToSwapHistory({
+        routes: [{ name: ScreenName.SwapTab }, { name: ScreenName.SwapHistory }],
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/ledger-live-mobile/src/screens/Swap/navigation/navigateBackToSwapTab.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/navigation/navigateBackToSwapTab.ts
@@ -17,6 +17,13 @@ type NavigationWithState = {
   goBack(): void;
 };
 
+type BeforeRemoveEvent = {
+  preventDefault(): void;
+  data: {
+    action: unknown;
+  };
+};
+
 export function hasSwapTabRoute(state: NavigationStateWithRouteNames | undefined) {
   const routeNames = state?.routeNames;
   return Array.isArray(routeNames) && routeNames.includes(ScreenName.SwapTab);
@@ -64,4 +71,36 @@ export function isGoingToSwapHistory(payload: unknown) {
   }
 
   return routes.some(route => route?.name === ScreenName.SwapHistory);
+}
+
+/**
+ * Handles the `beforeRemove` event of the Swap success (PendingOperation)
+ * screen. Fires the flow completion notification unless the user is explicitly
+ * navigating to Swap history or the close button already fired it.
+ *
+ * Navigation interception is no longer needed here: `navigateToSwapPendingOperation`
+ * now uses `StackActions.replace` so the stack is always a clean
+ * [SwapPendingOperation], and the default back action bubbles naturally to
+ * BaseNavigator — which pops SwapSubScreensNavigator and returns to SwapTab.
+ * See LIVE-28726.
+ */
+export function handlePendingOperationBeforeRemove({
+  event,
+  allowRemovalRef,
+  onFlowCompleted,
+}: {
+  event: BeforeRemoveEvent;
+  allowRemovalRef: { current: boolean };
+  onFlowCompleted: () => void;
+}) {
+  const actionPayload =
+    event.data.action && typeof event.data.action === "object" && "payload" in event.data.action
+      ? (event.data.action as { payload?: unknown }).payload
+      : undefined;
+
+  if (allowRemovalRef.current || isGoingToSwapHistory(actionPayload)) {
+    return;
+  }
+
+  onFlowCompleted();
 }


### PR DESCRIPTION
## ✅ Checklist

- [x] Bug fix (non-breaking change which fixes an issue)

## 📝 Description

Fixes [LIVE-28726](https://ledgerhq.atlassian.net/browse/LIVE-28726), [LIVE-33574](https://ledgerhq.atlassian.net/browse/LIVE-33574), [LIVE-33987](https://ledgerhq.atlassian.net/browse/LIVE-33987).

All three tickets share the same root cause and are resolved in a single fix.

In Ledger Live Mobile, leaving the **Swap success screen** via any path — Android/iOS back gesture, the close (X) button, or the back button from Swap history — left the user stuck on an **endless loading state**. Additionally, the swap live app webview displayed a stale page with `?tab=QUOTES_LIST` when the user returned to the Swap input after completing a swap.

### Root cause

React Navigation v7 changed the `NAVIGATE` action to always push a new screen unless the target is the currently focused route. When `navigateToSwapPendingOperation` fires after `handleShowLoadingDrawer`, `SwapLoading` is focused, so v7 pushes a fresh `SwapPendingOperation` on top — leaving the stack as `[SwapPendingOperation (initial), SwapLoading, SwapPendingOperation (with params)]`. Any back gesture within `SwapSubScreensNavigator` then popped to the `SwapLoading` screen underneath.

### Fix

**Navigation stack** (`customHandlers/index.ts`): replace `navigate()` with `StackActions.replace()` dispatched directly to `BaseNavigator`. This swaps `SwapSubScreensNavigator` for a fresh instance whose stack is a clean `[SwapPendingOperation]`. With only one screen in the navigator, the default back action bubbles naturally to `BaseNavigator`, which pops `SwapSubScreensNavigator` and returns to the Swap tab — no interception needed.

**`beforeRemove` handler** (`navigateBackToSwapTab.ts`): simplified now that the stack is always clean. `event.preventDefault()` and the manual `navigateBackToSwapTab` redirect are removed; the handler only fires `onFlowCompleted()` to notify flow completion (still guarded against the "going to history" case and against double-firing when the X button already set `allowRemovalRef`).

**Double-tap guard** (`PendingOperation.tsx`): `navigateToSwapForm` (X button) now returns early if `allowRemovalRef.current` is already set, preventing `notifyFlowCompleted` and `goBack` from firing multiple times on rapid taps.

**Webview reset** (`SwapLiveAppWallet40.tsx`, `useSwapLiveAppState.ts`): when `navigateToSwapPendingOperation` fires, `resetWebview()` increments a `key` on `SwapWebviewContent`, forcing a remount that reloads the webview from its initial URL. This happens in the background while the user reads the success screen, so they see a clean swap form when they navigate back. (A simple `loadURL(initialURL)` was a no-op: `currentURI` in `useWebviewState` already equals `initialURL` since the webview navigated internally without updating React state, so React saw no diff.)

## 🧪 Testing

- Unit tests cover all branches of `handlePendingOperationBeforeRemove` and `navigateBackToSwapTab` — 7/7 pass.
- Verified on device: Android back, X button, and back from Swap history all return to the Swap input. Webview shows the clean initial form on return.

[LIVE-28726]: https://ledgerhq.atlassian.net/browse/LIVE-28726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-33574]: https://ledgerhq.atlassian.net/browse/LIVE-33574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-33987]: https://ledgerhq.atlassian.net/browse/LIVE-33987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ