### PR TITLE
[LWM] fix(lwm): include testnets in global search results (LIVE-33199)

### DIFF
--- a/.changeset/globalsearch-testnets.md
+++ b/.changeset/globalsearch-testnets.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Global Search now surfaces testnets when developer mode is enabled, mirroring the Receive flow's DADA query logic (`includeTestNetworks` + staging environment). Fixes LIVE-33199.

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/__tests__/useGlobalSearchResults.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/__tests__/useGlobalSearchResults.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, act } from "@tests/test-renderer";
+import { setEnv } from "@ledgerhq/live-env";
 import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
 import { selectCurrencyForMetaId } from "@ledgerhq/live-common/dada-client/utils/currencySelection";
 import { track } from "~/analytics";
@@ -33,6 +34,10 @@ describe("useGlobalSearchResults", () => {
     mockedAssets.mockReturnValue({ data: undefined, isLoading: false } as never);
   });
 
+  afterEach(() => {
+    setEnv("MANAGER_DEV_MODE", false);
+  });
+
   it("is inactive with no results before typing", () => {
     const { result } = renderHook(() => useGlobalSearchResults());
 
@@ -50,7 +55,19 @@ describe("useGlobalSearchResults", () => {
     expect(result.current.isSearchActive).toBe(true);
     expect(result.current.searchResults.map(r => r.ticker)).toEqual(["BTC", "ETH"]);
     expect(mockedAssets).toHaveBeenLastCalledWith(
-      expect.objectContaining({ search: "b", skip: false }),
+      expect.objectContaining({ search: "b", skip: false, includeTestNetworks: false }),
+    );
+  });
+
+  it("includes testnets in the query only in developer mode", () => {
+    setEnv("MANAGER_DEV_MODE", true);
+    mockedAssets.mockReturnValue({ data: buildData(["btc"]), isLoading: false } as never);
+
+    const { result } = renderHook(() => useGlobalSearchResults());
+    act(() => result.current.setSearch("b"));
+
+    expect(mockedAssets).toHaveBeenLastCalledWith(
+      expect.objectContaining({ includeTestNetworks: true }),
     );
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/useGlobalSearchResults.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/useGlobalSearchResults.ts
@@ -5,6 +5,8 @@ import { selectCurrencyForMetaId } from "@ledgerhq/live-common/dada-client/utils
 import { useSearchCommon } from "@ledgerhq/live-common/modularDrawer/hooks/useSearch";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
+import useEnv from "@ledgerhq/live-common/hooks/useEnv";
+import { useFeature } from "@features/platform-feature-flags";
 import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
 import { mapDadaMarketToDisplayData } from "LLM/features/GlobalSearch/utils/mapDadaMarketToDisplayData";
 import { track } from "~/analytics";
@@ -36,6 +38,10 @@ export function useGlobalSearchResults(): GlobalSearchResults {
   const { rate: usdToFiatRate, status: rateStatus } = useUsdToFiatRate(counterValueCurrency.ticker);
   const version = VersionNumber.appVersion ?? "";
 
+  const modularDrawer = useFeature("llmModularDrawer");
+  const isStaging = modularDrawer?.params?.backendEnvironment === "STAGING";
+  const includeTestNetworks = useEnv("MANAGER_DEV_MODE");
+
   const handleTrackSearch = useCallback(
     (query: string) => track("search_query", { query, page: ScreenName.GlobalSearch }),
     [],
@@ -63,6 +69,8 @@ export function useGlobalSearchResults(): GlobalSearchResults {
     version,
     search: query,
     skip: query.length === 0,
+    isStaging,
+    includeTestNetworks,
   });
 
   const searchResults = useMemo<MarketAssetDisplayData[]>(() => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added a unit test asserting `useAssetsData` is queried with `includeTestNetworks` driven by `MANAGER_DEV_MODE`.
- [ ] **Impact of the changes:**
  - Global Search (Wallet 4.0, mobile). QA should verify that, with developer mode enabled, testnet assets now appear in Global Search results, and that with developer mode disabled the results are unchanged (mainnets only).

### 📝 Description

Global Search did not surface testnets because `useGlobalSearchResults` called the DADA `useAssetsData` hook **without** the `includeTestNetworks` / `isStaging` parameters, so the backend returned mainnets only.

This PR adds the same logic already used by the Receive flow (`useReceiveNetworkLedgerIds`):

- `includeTestNetworks` is set from `useEnv("MANAGER_DEV_MODE")` → testnets surface only in developer mode.
- `isStaging` is derived from the `llmModularDrawer` feature flag's `backendEnvironment` param, keeping the DADA environment consistent with the rest of the app.

No client-side filtering changed — only the DADA request now opts into testnets in dev mode.


https://github.com/user-attachments/assets/1a21eb00-ed06-46e4-907e-4baec31c3583


### ❓ Context

- **JIRA or GitHub link**: [LIVE-33199](https://ledgerhq.atlassian.net/browse/LIVE-33199)


[LIVE-33199]: https://ledgerhq.atlassian.net/browse/LIVE-33199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ