### PR TITLE
[LWM] feat(lwm): add robinhood disclaimer banner on asset detail

### DIFF
--- a/.changeset/robinhood-stock-disclaimer-banner.md
+++ b/.changeset/robinhood-stock-disclaimer-banner.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@shared/feature-flags": patch
+---
+
+Add an informational disclaimer banner on the Wallet 4.0 asset detail screen for assets supported exclusively on a Robinhood chain (e.g. tokenized stocks on robinhood_testnet). The banner is gated by the `llRobinhoodDisclaimer` feature flag, which is simplified to a plain boolean flag (its unused `url` param is removed).

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9412,6 +9412,9 @@
     "fallbackBanner": {
       "title": "Swap and Buy are not supported for this asset."
     },
+    "stockDisclaimerBanner": {
+      "title": "Total balance does not include dividends or stock splits."
+    },
     "hiddenAssetBanner": {
       "title": "This asset is hidden from your portfolio.",
       "showAsset": "Show asset"

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { render, screen, waitFor, within } from "@tests/test-renderer";
+import { render, screen, waitFor, within, withFlagOverrides } from "@tests/test-renderer";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import type { Account } from "@ledgerhq/types-live";
@@ -9,7 +9,11 @@ import type { State } from "~/reducers/types";
 import AssetDetailNavigator from "../Navigator";
 import { ASSET_DETAIL_TEST_IDS } from "../testIds";
 import { QUICK_ACTIONS_TEST_IDS } from "LLM/features/QuickActions/testIds";
-import { useTradeAvailability, type TradeAvailability } from "@ledgerhq/asset-detail";
+import {
+  useReceiveNetworkLedgerIds,
+  useTradeAvailability,
+  type TradeAvailability,
+} from "@ledgerhq/asset-detail";
 
 const mockIsCurrencyAvailable = jest.fn().mockReturnValue(false);
 const mockIsAcceptedCurrency = jest.fn().mockReturnValue(false);
@@ -25,9 +29,11 @@ jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () =>
 jest.mock("@ledgerhq/asset-detail", () => ({
   ...jest.requireActual("@ledgerhq/asset-detail"),
   useTradeAvailability: jest.fn(),
+  useReceiveNetworkLedgerIds: jest.fn(),
 }));
 
 const mockedUseTradeAvailability = jest.mocked(useTradeAvailability);
+const mockedUseReceiveNetworkLedgerIds = jest.mocked(useReceiveNetworkLedgerIds);
 const setAvailability = (overrides: Partial<TradeAvailability> = {}) =>
   mockedUseTradeAvailability.mockReturnValue({
     availableOnBuy: true,
@@ -121,6 +127,10 @@ describe("AssetDetail screen layout", () => {
     mockIsCurrencyAvailable.mockReturnValue(false);
     mockIsAcceptedCurrency.mockReturnValue(false);
     setAvailability();
+    // Default passthrough: the receive network list resolves to the market fallback.
+    mockedUseReceiveNetworkLedgerIds.mockImplementation(
+      ({ fallbackLedgerIds }) => fallbackLedgerIds ?? [],
+    );
   });
 
   it("renders all section placeholders and BalanceGraph", () => {
@@ -376,6 +386,55 @@ describe("AssetDetail screen layout", () => {
         expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.hiddenAssetBanner)).toBeNull(),
       );
       expect(store.getState().settings.blacklistedTokenIds).not.toContain("bitcoin");
+    });
+  });
+
+  describe("Robinhood stock disclaimer banner", () => {
+    const ROBINHOOD_ONLY_LEDGER_IDS = [
+      "robinhood_testnet/erc20/amd_0x71178bac73cbeb415514eb542a8995b82669778d",
+    ];
+    const enableDisclaimer = () => ({
+      overrideInitialState: withFlagOverrides({ llRobinhoodDisclaimer: { enabled: true } }),
+    });
+
+    it("shows the disclaimer banner when the flag is on and the asset is exclusive to a Robinhood chain", async () => {
+      mockedUseReceiveNetworkLedgerIds.mockReturnValue(ROBINHOOD_ONLY_LEDGER_IDS);
+
+      render(<AssetDetailTestNavigator />, enableDisclaimer());
+
+      await waitFor(() =>
+        expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.stockDisclaimerBanner)).toBeVisible(),
+      );
+      expect(
+        screen.getByText("Total balance does not include dividends or stock splits."),
+      ).toBeVisible();
+    });
+
+    it("hides the disclaimer banner for a multi-network asset that also lives on Robinhood", () => {
+      mockedUseReceiveNetworkLedgerIds.mockReturnValue([
+        "ethereum/erc20/weth_0x0bd7d308f8e1639fab988df18a8011f41eacad73",
+        "robinhood/erc20/weth_0x0bd7d308f8e1639fab988df18a8011f41eacad73",
+      ]);
+
+      render(<AssetDetailTestNavigator />, enableDisclaimer());
+
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.stockDisclaimerBanner)).toBeNull();
+    });
+
+    it("hides the disclaimer banner for a standard single-chain asset", () => {
+      mockedUseReceiveNetworkLedgerIds.mockReturnValue(["bitcoin"]);
+
+      render(<AssetDetailTestNavigator />, enableDisclaimer());
+
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.stockDisclaimerBanner)).toBeNull();
+    });
+
+    it("hides the disclaimer banner when the flag is off, even for a Robinhood-exclusive asset", () => {
+      mockedUseReceiveNetworkLedgerIds.mockReturnValue(ROBINHOOD_ONLY_LEDGER_IDS);
+
+      render(<AssetDetailTestNavigator />);
+
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.stockDisclaimerBanner)).toBeNull();
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -14,6 +14,7 @@ import { Addresses } from "./components/Addresses";
 import { Transactions } from "./components/Transactions";
 import { Footer } from "./components/Footer";
 import { FallbackBanner } from "./components/FallbackBanner";
+import { StockDisclaimerBanner } from "./components/StockDisclaimerBanner";
 import { HiddenAssetBanner } from "./components/HiddenAssetBanner";
 import { MarketData } from "./components/MarketData";
 import { CTAS_HEIGHT } from "./utils/constants";
@@ -32,6 +33,7 @@ type Props = Readonly<{
   hasFooter: boolean;
   hideReceiveInBalanceGraph: boolean;
   showFallbackBanner: boolean;
+  showStockDisclaimerBanner: boolean;
   coinOptions: AssetCoinOptionsViewModel;
   isLoading: boolean;
   ledgerIds: string[];
@@ -49,6 +51,7 @@ export function AssetDetailView({
   hasFooter,
   hideReceiveInBalanceGraph,
   showFallbackBanner,
+  showStockDisclaimerBanner,
   coinOptions,
   isLoading,
   ledgerIds,
@@ -83,6 +86,7 @@ export function AssetDetailView({
             distributionItem={distributionItem}
             isLoading={isLoading}
           />
+          <StockDisclaimerBanner show={showStockDisclaimerBanner} />
           <Addresses
             currency={currency}
             distributionItem={distributionItem}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/StockDisclaimerBanner/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/StockDisclaimerBanner/index.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Banner, Box } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "~/context/Locale";
+import { ASSET_DETAIL_TEST_IDS } from "../../../../testIds";
+
+type Props = Readonly<{
+  show: boolean;
+}>;
+
+export function StockDisclaimerBanner({ show }: Props) {
+  const { t } = useTranslation();
+
+  if (!show) return null;
+
+  return (
+    <Box testID={ASSET_DETAIL_TEST_IDS.stockDisclaimerBanner}>
+      <Banner appearance="info" title={t("assetDetail.stockDisclaimerBanner.title")} />
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { useCurrencyById } from "@ledgerhq/cryptoassets/hooks";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
+import { useFeature } from "@features/platform-feature-flags";
 import { useRoute } from "@react-navigation/native";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { ScreenName } from "~/const";
@@ -14,6 +15,7 @@ import { useAssetActionsAvailability } from "./components/Footer/useFooterViewMo
 import { useAssetCoinOptionsViewModel } from "./components/CoinOptions/useAssetCoinOptionsViewModel";
 import { useAssetMarketData } from "./hooks/useAssetMarketData";
 import { useReceiveNetworkLedgerIds } from "./hooks/useReceiveNetworkLedgerIds";
+import { isRobinhoodExclusiveAsset } from "./utils/isRobinhoodExclusiveAsset";
 
 type Route = StackNavigatorProps<AssetDetailNavigatorParamsList, ScreenName.AssetDetail>["route"];
 
@@ -75,6 +77,9 @@ export function useAssetDetailViewModel() {
   const hasFooter = isBuyAvailable || secondaryButton !== null;
   const hideReceiveInBalanceGraph = !isCurrencySupported || secondaryButton === "receive";
   const showFallbackBanner = isCurrencySupported && !isBuyAvailable && !availableOnSwap;
+  const robinhoodDisclaimer = useFeature("llRobinhoodDisclaimer");
+  const showStockDisclaimerBanner =
+    !!robinhoodDisclaimer?.enabled && isRobinhoodExclusiveAsset(receiveLedgerIds);
 
   const coinOptions = useAssetCoinOptionsViewModel({ currency, currencyId, marketId });
 
@@ -90,6 +95,7 @@ export function useAssetDetailViewModel() {
     hasFooter,
     hideReceiveInBalanceGraph,
     showFallbackBanner,
+    showStockDisclaimerBanner,
     coinOptions,
     isLoading,
     ledgerIds: receiveLedgerIds,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/utils/__tests__/isRobinhoodExclusiveAsset.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/utils/__tests__/isRobinhoodExclusiveAsset.test.ts
@@ -1,0 +1,38 @@
+import { isRobinhoodExclusiveAsset } from "../isRobinhoodExclusiveAsset";
+
+describe("isRobinhoodExclusiveAsset", () => {
+  it("returns true for a token only on robinhood_testnet", () => {
+    expect(
+      isRobinhoodExclusiveAsset([
+        "robinhood_testnet/erc20/amd_0x71178bac73cbeb415514eb542a8995b82669778d",
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns true for a token only on robinhood mainnet", () => {
+    expect(isRobinhoodExclusiveAsset(["robinhood/erc20/amd_0xabc"])).toBe(true);
+  });
+
+  it("returns true when every network is a Robinhood chain", () => {
+    expect(
+      isRobinhoodExclusiveAsset(["robinhood/erc20/amd_0xabc", "robinhood_testnet/erc20/amd_0xdef"]),
+    ).toBe(true);
+  });
+
+  it("returns false for a multi-network asset that also lives on Robinhood (e.g. WETH)", () => {
+    expect(
+      isRobinhoodExclusiveAsset([
+        "ethereum/erc20/weth_0x0bd7d308f8e1639fab988df18a8011f41eacad73",
+        "robinhood/erc20/weth_0x0bd7d308f8e1639fab988df18a8011f41eacad73",
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns false for an asset on another chain only", () => {
+    expect(isRobinhoodExclusiveAsset(["ethereum"])).toBe(false);
+  });
+
+  it("returns false for an empty list", () => {
+    expect(isRobinhoodExclusiveAsset([])).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/utils/isRobinhoodExclusiveAsset.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/utils/isRobinhoodExclusiveAsset.ts
@@ -1,0 +1,18 @@
+/**
+ * Networks that make up the Robinhood chain. Tokenized stocks currently live on
+ * `robinhood_testnet` only; `robinhood` (mainnet) is included so the check keeps
+ * working once stocks ship there.
+ */
+const ROBINHOOD_NETWORK_IDS = new Set(["robinhood", "robinhood_testnet"]);
+
+/** Network segment of a ledger currency id (`robinhood_testnet/erc20/0x…` → `robinhood_testnet`). */
+const getNetworkId = (ledgerId: string): string => ledgerId.split("/")[0];
+
+/**
+ * An asset is "Robinhood-exclusive" when every network it is available on is a
+ * Robinhood chain. Multi-network assets that merely include a Robinhood network
+ * (e.g. WETH, also on Ethereum) are not exclusive and return `false`.
+ */
+export function isRobinhoodExclusiveAsset(ledgerIds: readonly string[]): boolean {
+  return ledgerIds.length > 0 && ledgerIds.every(id => ROBINHOOD_NETWORK_IDS.has(getNetworkId(id)));
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
@@ -23,6 +23,7 @@ export const ASSET_DETAIL_TEST_IDS = {
   swapButton: "asset-detail-swap-button",
   footerReceiveButton: "asset-detail-footer-receive-button",
   fallbackBanner: "asset-detail-fallback-banner",
+  stockDisclaimerBanner: "asset-detail-stock-disclaimer-banner",
   hiddenAssetBanner: "asset-detail-hidden-asset-banner",
   hiddenAssetBannerShowAsset: "asset-detail-hidden-asset-banner-show-asset",
   coinOptionsTrailing: "asset-detail-coin-options-trailing",

--- a/shared/feature-flags/src/flags/team-wallet-xp/llRobinhoodDisclaimer.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/llRobinhoodDisclaimer.ts
@@ -1,14 +1,3 @@
-import { z } from "zod";
-import { flagWith } from "../../define";
+import { flag } from "../../define";
 
-export const llRobinhoodDisclaimer = flagWith(
-  {
-    url: z.string(),
-  },
-  {
-    enabled: false,
-    params: {
-      url: "https://robinhood.com",
-    },
-  },
-);
+export const llRobinhoodDisclaimer = flag();


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Unit test for the trigger helper + integration tests for the banner (flag on/off, Robinhood-exclusive vs multi-network).
- [ ] **Impact of the changes:**
  - Wallet 4.0 asset detail screen (mobile). QA should verify the disclaimer banner appears only for assets supported exclusively on a Robinhood chain (e.g. tokenized stocks on `robinhood_testnet`), is hidden for multi-network assets (e.g. WETH), and only when the `llRobinhoodDisclaimer` flag is enabled.

> ⛓️ **Stacked on top of #18931 (LIVE-33199 Global Search testnets).** Merge that one first — this PR will then retarget to `develop` automatically. The Global Search fix is what lets you reach `robinhood_testnet` stocks via search to exercise this banner.

### 📝 Description

Adds an informational disclaimer banner to the Wallet 4.0 asset detail screen, shown for assets supported **exclusively** on a Robinhood chain.

- **Trigger** (`isRobinhoodExclusiveAsset`): the asset's resolved network list (`receiveLedgerIds`) is non-empty and **every** entry's network segment is `robinhood` / `robinhood_testnet`. Multi-network assets that merely also live on Robinhood (e.g. `robinhood/erc20/weth…`) do **not** show it; a `robinhood_testnet`-only token (e.g. `robinhood_testnet/erc20/amd…`) does.
- **Behaviour**: informational only — Lumen info `Banner`, copy _"Total balance does not include dividends or stock splits."_, placed between Balance Details and Addresses (Figma node `20919-32662`).
- **Gating**: the `llRobinhoodDisclaimer` feature flag. The flag is simplified to a plain boolean (its unused `url` param is removed).



https://github.com/user-attachments/assets/97607419-8c10-4a3d-952c-55b510a99ddc



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32758](https://ledgerhq.atlassian.net/browse/LIVE-32758)
- **Design**: [Figma — Asset / Address screens • Wallet 4.0](https://www.figma.com/design/mv0arYJWSwklM6RdyKq9Xk/Asset---Address-screens--%E2%80%A2-Wallet-4.0?node-id=20919-32662&m=dev)


[LIVE-32758]: https://ledgerhq.atlassian.net/browse/LIVE-32758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ