### PR TITLE
feat(cryptoassets): make findCryptoCurrencyByTicker order-independent for ambiguous tickers (LIVE-33115)

### DIFF
--- a/.changeset/brave-owls-win.md
+++ b/.changeset/brave-owls-win.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/cryptoassets": minor
+---
+
+Fix dead keyword tiebreak in registerCurrencyInStore: case-insensitive comparison so findCryptoCurrencyByTicker resolves ambiguous tickers (ETH, BNB, DOT, XTZ, CRO) order-independently

--- a/domain/entity/currency-crypto/src/currencies/crypto_org.ts
+++ b/domain/entity/currency-crypto/src/currencies/crypto_org.ts
@@ -9,6 +9,7 @@ export const crypto_org = currency({
   ticker: "CRO",
   scheme: "crypto_org",
   color: "#0e1c37",
+  keywords: ["cro", "cronos pos chain"],
   family: "cosmos",
   units: [
     {

--- a/domain/entity/currency-crypto/src/currencies/tezos.ts
+++ b/domain/entity/currency-crypto/src/currencies/tezos.ts
@@ -9,6 +9,7 @@ export const tezos = currency({
   ticker: "XTZ",
   scheme: "tezos",
   color: "#007BFF",
+  keywords: ["xtz", "tezos"],
   family: "tezos",
   blockAvgTime: 60,
   units: [

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies-store.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies-store.ts
@@ -52,7 +52,9 @@ export function registerCurrencyInStore(
 
   if (!currency.isTestnetFor) {
     const currencyAlreadySet = store.cryptocurrenciesByTicker[currency.ticker];
-    const currencyHasTickerInKeywords = Boolean(currency?.keywords?.includes(currency.ticker));
+    const currencyHasTickerInKeywords = Boolean(
+      currency.keywords?.some(k => k.toLowerCase() === currency.ticker.toLowerCase()),
+    );
 
     if (
       !currencyAlreadySet ||

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies-store.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies-store.ts
@@ -52,8 +52,9 @@ export function registerCurrencyInStore(
 
   if (!currency.isTestnetFor) {
     const currencyAlreadySet = store.cryptocurrenciesByTicker[currency.ticker];
+    const tickerLower = currency.ticker.toLowerCase();
     const currencyHasTickerInKeywords = Boolean(
-      currency.keywords?.some(k => k.toLowerCase() === currency.ticker.toLowerCase()),
+      currency.keywords?.some(k => k.toLowerCase() === tickerLower),
     );
 
     if (

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.domain-parity.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.domain-parity.test.ts
@@ -1,6 +1,11 @@
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { CRYPTO_CURRENCIES_REGISTRY } from "@domain/entity-currency-crypto";
-import { listCryptoCurrencies } from "./currencies";
+import {
+  findCryptoCurrencyByScheme,
+  findCryptoCurrencyByTicker,
+  listCryptoCurrencies,
+} from "./currencies";
+import { setCryptoCurrenciesStore } from "./currencies-store";
 
 /**
  * Parity guard between the legacy bundled registry (`@ledgerhq/cryptoassets`) and the
@@ -34,5 +39,55 @@ describe("@domain/entity-currency-crypto parity with @ledgerhq/cryptoassets", ()
 
   it.each(sortedLegacyIds)("matches the legacy definition for %s", id => {
     expect(CRYPTO_CURRENCIES_REGISTRY[id]).toEqual(legacyById.get(id));
+  });
+});
+
+// Snapshot bundled lookup results at module-eval time (before any store injection).
+const bundledSchemeById = new Map(
+  legacyCurrencies.map(c => [c.scheme, findCryptoCurrencyByScheme(c.scheme)?.id]),
+);
+
+// Reversed domain array — proves that resolution is order-independent after the fix.
+const domainArrayReversed = [...Object.values(CRYPTO_CURRENCIES_REGISTRY)].reverse();
+
+const AMBIGUOUS_TICKERS = [
+  { ticker: "ETH", expectedId: "ethereum" },
+  { ticker: "BNB", expectedId: "bsc" },
+  { ticker: "DOT", expectedId: "polkadot" },
+  { ticker: "XTZ", expectedId: "tezos" },
+  { ticker: "CRO", expectedId: "crypto_org" },
+] as const;
+
+function clearInjectedStore() {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  (globalThis as Record<string, unknown>).__ledgerCryptoCurrenciesStore = undefined;
+}
+
+describe("lookup parity: bundled store vs injected domain array", () => {
+  describe("bundled store", () => {
+    it.each(AMBIGUOUS_TICKERS)(
+      'findCryptoCurrencyByTicker("$ticker") → $expectedId',
+      ({ ticker, expectedId }) => {
+        expect(findCryptoCurrencyByTicker(ticker)?.id).toBe(expectedId);
+      },
+    );
+  });
+
+  describe("injected domain store (reversed — proves order-independence)", () => {
+    beforeEach(() => setCryptoCurrenciesStore(domainArrayReversed));
+    afterEach(clearInjectedStore);
+
+    it.each(AMBIGUOUS_TICKERS)(
+      'findCryptoCurrencyByTicker("$ticker") → $expectedId',
+      ({ ticker, expectedId }) => {
+        expect(findCryptoCurrencyByTicker(ticker)?.id).toBe(expectedId);
+      },
+    );
+
+    it("findCryptoCurrencyByScheme is identical to bundled for all currencies", () => {
+      for (const [scheme, bundledId] of bundledSchemeById) {
+        expect(findCryptoCurrencyByScheme(scheme)?.id).toBe(bundledId);
+      }
+    });
   });
 });

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.domain-parity.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.domain-parity.test.ts
@@ -47,8 +47,10 @@ const bundledIdByScheme = new Map(
   legacyCurrencies.map(c => [c.scheme, findCryptoCurrencyByScheme(c.scheme)?.id]),
 );
 
-// Reversed domain array — proves that resolution is order-independent after the fix.
-const domainArrayReversed = [...Object.values(CRYPTO_CURRENCIES_REGISTRY)].reverse();
+// Domain array in the order LIVE-32900 will inject (alphabetical by id — the regression scenario).
+const domainArray = Object.values(CRYPTO_CURRENCIES_REGISTRY);
+// Reversed to exercise the opposite ordering and confirm full order-independence.
+const domainArrayReversed = [...domainArray].reverse();
 
 const AMBIGUOUS_TICKERS = [
   { ticker: "ETH", expectedId: "ethereum" },
@@ -73,8 +75,11 @@ describe("lookup parity: bundled store vs injected domain array", () => {
     );
   });
 
-  describe("injected domain store (reversed — proves order-independence)", () => {
-    beforeEach(() => setCryptoCurrenciesStore(domainArrayReversed));
+  describe.each([
+    ["alphabetical order (real injection scenario)", domainArray],
+    ["reversed order (order-independence check)", domainArrayReversed],
+  ] as const)("injected domain store — %s", (_, currencies) => {
+    beforeEach(() => setCryptoCurrenciesStore([...currencies]));
     afterEach(clearInjectedStore);
 
     it.each(AMBIGUOUS_TICKERS)(

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.domain-parity.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.domain-parity.test.ts
@@ -43,7 +43,7 @@ describe("@domain/entity-currency-crypto parity with @ledgerhq/cryptoassets", ()
 });
 
 // Snapshot bundled lookup results at module-eval time (before any store injection).
-const bundledSchemeById = new Map(
+const bundledIdByScheme = new Map(
   legacyCurrencies.map(c => [c.scheme, findCryptoCurrencyByScheme(c.scheme)?.id]),
 );
 
@@ -85,7 +85,7 @@ describe("lookup parity: bundled store vs injected domain array", () => {
     );
 
     it("findCryptoCurrencyByScheme is identical to bundled for all currencies", () => {
-      for (const [scheme, bundledId] of bundledSchemeById) {
+      for (const [scheme, bundledId] of bundledIdByScheme) {
         expect(findCryptoCurrencyByScheme(scheme)?.id).toBe(bundledId);
       }
     });

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.domain-parity.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.domain-parity.test.ts
@@ -47,10 +47,14 @@ const bundledIdByScheme = new Map(
   legacyCurrencies.map(c => [c.scheme, findCryptoCurrencyByScheme(c.scheme)?.id]),
 );
 
-// Domain array in the order LIVE-32900 will inject (alphabetical by id — the regression scenario).
-const domainArray = Object.values(CRYPTO_CURRENCIES_REGISTRY);
+// id-sorted (deterministic, unlike Object.values insertion order) puts the non-canonical currency
+// first for every ambiguous ticker (arbitrum < ethereum, cronos < crypto_org), so this pass fails
+// if the keyword tiebreak regresses to first-in-array-wins.
+const domainArraySortedById = [...Object.values(CRYPTO_CURRENCIES_REGISTRY)].sort((a, b) =>
+  a.id.localeCompare(b.id),
+);
 // Reversed to exercise the opposite ordering and confirm full order-independence.
-const domainArrayReversed = [...domainArray].reverse();
+const domainArrayReversed = [...domainArraySortedById].reverse();
 
 const AMBIGUOUS_TICKERS = [
   { ticker: "ETH", expectedId: "ethereum" },
@@ -76,7 +80,7 @@ describe("lookup parity: bundled store vs injected domain array", () => {
   });
 
   describe.each([
-    ["alphabetical order (real injection scenario)", domainArray],
+    ["id-sorted order (non-canonical currency first)", domainArraySortedById],
     ["reversed order (order-independence check)", domainArrayReversed],
   ] as const)("injected domain store — %s", (_, currencies) => {
     beforeEach(() => setCryptoCurrenciesStore([...currencies]));

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.domain-parity.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.domain-parity.test.ts
@@ -42,10 +42,10 @@ describe("@domain/entity-currency-crypto parity with @ledgerhq/cryptoassets", ()
   });
 });
 
-// Snapshot bundled lookup results at module-eval time (before any store injection).
-const bundledIdByScheme = new Map(
-  legacyCurrencies.map(c => [c.scheme, findCryptoCurrencyByScheme(c.scheme)?.id]),
-);
+// Authoritative scheme → id mapping built straight from the legacy data, not via
+// findCryptoCurrencyByScheme — otherwise a regression in that accessor would be baked into the
+// expected values and the injected-store assertion below could still pass.
+const bundledIdByScheme = new Map(legacyCurrencies.map(c => [c.scheme, c.id]));
 
 // id-sorted (deterministic, unlike Object.values insertion order) puts the non-canonical currency
 // first for every ambiguous ticker (arbitrum < ethereum, cronos < crypto_org), so this pass fails

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -2911,6 +2911,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ticker: "XTZ",
     scheme: "tezos",
     color: "#007BFF",
+    keywords: ["xtz", "tezos"],
     family: "tezos",
     blockAvgTime: 60,
     units: [
@@ -3325,6 +3326,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ticker: "CRO",
     scheme: "crypto_org",
     color: "#0e1c37",
+    keywords: ["cro", "cronos pos chain"],
     family: "cosmos",
     units: [
       {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Lookup-parity guard in `currencies.domain-parity.test.ts` asserts the 5 ambiguous tickers + full scheme parity under an id-sorted **and** reversed injected array; full suite 1229 pass.
- [ ] **Impact of the changes:**
  - **No behavioural change today.** Apps still read the bundled, hand-ordered `currencies.ts`, so `findCryptoCurrencyByTicker` already returns the right currency. This PR makes that resolution *order-independent* so it stays correct once the domain registry is injected.
  - `registerCurrencyInStore` (`@ledgerhq/cryptoassets`) — keyword tiebreak made case-insensitive; no API change.
  - `tezos` / `crypto_org` gain `keywords` (legacy `currencies.ts` + domain registry). Minor side effect: both become findable by those terms in add-account search via `findCryptoCurrencyByKeyword`.

### 📝 Description

This is the **final preparatory step before [LIVE-32900](https://ledgerhq.atlassian.net/browse/LIVE-32900)** injects the domain currency registry (`setCryptoCurrenciesStore(Object.values(CRYPTO_CURRENCIES_REGISTRY))`). It belongs with the domain-registry seed work merged in #18867 (LIVE-31915) and is split out as the explicit, self-contained prerequisite so the injection PR stays clean.

**There is no live regression.** Apps today consume the bundled `currencies.ts`, which is hand-authored with the canonical currency first, so ambiguous tickers already resolve correctly. The problem is latent: the keyword tiebreak in `registerCurrencyInStore` that is *supposed* to guarantee this is dead code — it compares `keywords.includes(currency.ticker)`, but `ticker` is UPPERCASE (e.g. `"ETH"`) while `keywords` are lowercase (`["eth","ethereum"]`), so it never matches. Resolution therefore silently depends on array order.

**Why it matters before LIVE-32900:** that injection passes the domain registry in a *different* order than the hand-authored bundle. Under that order, 5 ambiguous tickers would resolve to the wrong currency:

| Ticker | Bundled (today, correct) | Injected domain order (without this fix) |
|--------|--------------------------|------------------------------------------|
| ETH    | ethereum                 | arbitrum                                 |
| BNB    | bsc                      | binance_beacon_chain                     |
| DOT    | polkadot                 | assethub_polkadot                        |
| XTZ    | tezos                    | etherlink                                |
| CRO    | crypto_org               | cronos                                   |

The ETH case would be the most visible: `counterValueCurrencyLocalSelector` resolves a crypto countervalue via `findCryptoCurrencyByTicker`, and `arbitrum` is not a `possibleIntermediary` → blank countervalues for ETH-denominated portfolios. This PR removes that latent failure *ahead of* the injection rather than discovering it after.

**Fix (two parts):**

1. Make the tiebreak comparison case-insensitive — `keywords?.some(k => k.toLowerCase() === currency.ticker.toLowerCase())`. This revives the tiebreak for currencies that already carry the ticker as a keyword: `ethereum` (`["eth","ethereum"]`), `bsc`, `polkadot` win ETH/BNB/DOT over rivals that have no keywords.
2. Backfill the missing keywords: `tezos` and `crypto_org` had **no** `keywords`, so the tiebreak had nothing to match and XTZ/CRO would still be first-in-array-wins. Added `keywords: ["xtz", "tezos"]` and `keywords: ["cro", "cronos pos chain"]` in both the legacy `currencies.ts` and the domain registry (kept in sync by the existing parity test).

Resolution is now **order-independent** for all 5 tickers. The lookup-parity guard test injects the domain array sorted by id (which places the non-canonical currency first for every ambiguous ticker — the meaningful regression scenario) and again reversed, so neither ordering can silently pass for the wrong reason.

> The ordering alternative — cloning the legacy array order into the domain registry — was prototyped in #18867 and **rejected** as cargo-cult; making the tiebreak itself order-independent is the root-cause fix.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33115](https://ledgerhq.atlassian.net/browse/LIVE-33115) — prerequisite for [LIVE-32900](https://ledgerhq.atlassian.net/browse/LIVE-32900); completes the seed work from #18867 ([LIVE-31915](https://ledgerhq.atlassian.net/browse/LIVE-31915))
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32900]: https://ledgerhq.atlassian.net/browse/LIVE-32900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-33115]: https://ledgerhq.atlassian.net/browse/LIVE-33115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ