### PR TITLE
[LWDM] chore(recover): replace protect-simu defaults with protect-prod

### DIFF
--- a/.changeset/recover-ff-defaults-protect-prod.md
+++ b/.changeset/recover-ff-defaults-protect-prod.md
@@ -1,0 +1,15 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+chore(recover): replace protect-simu defaults with protect-prod in protectServices feature flags
+
+`protectServicesDesktop` and `protectServicesMobile` defaulted `protectId` and every templated URI to `protect-simu` — a manifest that was deleted from `manifest-api` along with five other unused entries. With the manifest gone, any client that fell back to the schema defaults (local dev builds without Firebase Remote Config, fresh installs that fail the first remote fetch, integration tests) ended up with deeplinks pointing at a nonexistent manifest, producing broken Recover entry-points for developers.
+
+Switch the schema defaults (and the matching test fixtures) to `protect-prod`. Production behavior is unchanged: prod clients fetch a healthy Firebase payload that already pins `protectId: "protect-prod"`, so the schema default is only used as a safety net in dev / fallback scenarios.
+
+Also drop `"protect-simu"` from the `recoverIdsShowTopBar` / `headerShownIds` allow-lists in `WebRecoverPlayer` (desktop + mobile) — the dev top-bar hint was never going to match a deleted manifest.
+
+The `useReplacedURI` regression test that explicitly asserts the regex still substitutes the legacy `protect-simu` placeholder is intentionally preserved.

--- a/apps/ledger-live-desktop/src/renderer/components/WebRecoverPlayer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebRecoverPlayer/index.tsx
@@ -31,7 +31,6 @@ export const Wrapper = styled(Box).attrs(() => ({
 const recoverIdsShowTopBar = [
   "protect-local",
   "protect-local-dev",
-  "protect-simu",
   "protect-staging",
   "protect-staging-v2",
 ];

--- a/apps/ledger-live-mobile/src/components/WebRecoverPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebRecoverPlayer/index.tsx
@@ -25,7 +25,6 @@ type Props = {
 const headerShownIds = [
   "protect-local",
   "protect-local-dev",
-  "protect-simu",
   "protect-staging",
   "protect-staging-v2",
 ];

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/__tests__/useQuickActionsRowViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/__tests__/useQuickActionsRowViewModel.test.ts
@@ -8,10 +8,7 @@ import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
 import { urls } from "~/utils/urls";
 import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
-import {
-  PROTECT_ID,
-  withRecoverState,
-} from "LLM/features/Portfolio/utils/recoverTestHelpers";
+import { PROTECT_ID, withRecoverState } from "LLM/features/Portfolio/utils/recoverTestHelpers";
 import { ShieldCheckNotificationIcon } from "LLM/features/BackupHub/components/ShieldCheckNotificationIcon";
 import { MY_WALLET_TRACKING_PAGE_NAME } from "../../../constants";
 import { useQuickActionsRowViewModel } from "../useQuickActionsRowViewModel";
@@ -100,7 +97,7 @@ describe("useQuickActionsRowViewModel", () => {
       act(() => recoverAction.onPress());
 
       expect(mockNavigate).toHaveBeenCalledWith(ScreenName.Recover, {
-        platform: "protect-simu",
+        platform: "protect-prod",
         device: undefined,
       });
       expect(track).toHaveBeenCalledWith("button_clicked", {
@@ -205,9 +202,7 @@ describe("useQuickActionsRowViewModel", () => {
 
       it("should open the Backup Hub navigator and track the event on press", () => {
         const { result } = renderHook(() => useQuickActionsRowViewModel(), {
-          overrideInitialState: withBackupHubOn(
-            LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION,
-          ),
+          overrideInitialState: withBackupHubOn(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION),
         });
         const recoverAction = result.current.actions.find(a => a.id === "recover")!;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/FirstStepSyncOnboarding/useFirstStepSyncOnboardingViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/FirstStepSyncOnboarding/useFirstStepSyncOnboardingViewModel.test.ts
@@ -184,7 +184,7 @@ describe("useFirstStepSyncOnboardingViewModel", () => {
     const props = defaultProps();
 
     const { result } = renderHook(() => useFirstStepSyncOnboardingViewModel(props), {
-      overrideInitialState: withProtectServicesMobile(true, { protectId: "protect" }),
+      overrideInitialState: withProtectServicesMobile(true, { protectId: "protect-prod" }),
     });
 
     act(() => {
@@ -198,7 +198,7 @@ describe("useFirstStepSyncOnboardingViewModel", () => {
         params: expect.objectContaining({
           fromOnboarding: true,
           device,
-          platform: "protect",
+          platform: "protect-prod",
           redirectTo: "restore",
           date: expect.any(String),
         }),

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/utils/recoverTestHelpers.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/utils/recoverTestHelpers.ts
@@ -2,7 +2,7 @@ import { withFlagOverrides } from "@tests/test-renderer";
 import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
 import type { State } from "~/reducers/types";
 
-export const PROTECT_ID = "protect-simu";
+export const PROTECT_ID = "protect-prod";
 
 export const withBannerEnabled = withFlagOverrides({
   protectServicesMobile: {

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useRecoverEntry.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useRecoverEntry.test.ts
@@ -38,7 +38,7 @@ describe("useRecoverEntry", () => {
     const { result } = renderHook(() => useRecoverEntry());
 
     // The test environment provides the protectServicesMobile feature flag default.
-    expect(result.current.protectId).toBe("protect-simu");
+    expect(result.current.protectId).toBe("protect-prod");
   });
 
   it("falls back to DEFAULT_PROTECT_ID when the feature flag has no protectId param", () => {
@@ -57,7 +57,7 @@ describe("useRecoverEntry", () => {
     act(() => result.current.openRecover());
 
     expect(mockNavigate).toHaveBeenCalledWith(ScreenName.Recover, {
-      platform: "protect-simu",
+      platform: "protect-prod",
       device: undefined,
     });
   });
@@ -70,7 +70,7 @@ describe("useRecoverEntry", () => {
     act(() => result.current.openRecover());
 
     expect(mockNavigate).toHaveBeenCalledWith(ScreenName.Recover, {
-      platform: "protect-simu",
+      platform: "protect-prod",
       device: mockDevice,
     });
   });

--- a/shared/feature-flags/src/flags/team-recover-software/protectServicesDesktop.ts
+++ b/shared/feature-flags/src/flags/team-recover-software/protectServicesDesktop.ts
@@ -30,19 +30,19 @@ export const protectServicesDesktop = flagWith(
       bannerSubscriptionNotification: false,
       account: {
         homeURI:
-          "ledgerlive://recover/protect-simu?source=lld-sidebar-navigation&ajs_recover_source=lld-sidebar-navigation&ajs_recover_campaign=recover-launch",
+          "ledgerlive://recover/protect-prod?source=lld-sidebar-navigation&ajs_recover_source=lld-sidebar-navigation&ajs_recover_campaign=recover-launch",
       },
       discoverTheBenefitsLink: "https://www.ledger.com/recover",
       onboardingCompleted: {
         alreadyDeviceSeededURI:
-          "ledgerlive://recover/protect-simu?redirectTo=upsell&source=lld-pairing&ajs_recover_source=lld-pairing&ajs_recover_campaign=recover-launch",
+          "ledgerlive://recover/protect-prod?redirectTo=upsell&source=lld-pairing&ajs_recover_source=lld-pairing&ajs_recover_campaign=recover-launch",
         upsellURI:
-          "ledgerlive://recover/protect-simu?redirectTo=upsell&source=lld-onboarding-24&ajs_recover_source=lld-onboarding-24&ajs_recover_campaign=recover-launch",
+          "ledgerlive://recover/protect-prod?redirectTo=upsell&source=lld-onboarding-24&ajs_recover_source=lld-onboarding-24&ajs_recover_campaign=recover-launch",
         restore24URI:
-          "ledgerlive://recover/protect-simu?redirectTo=upsell&source=lld-restore-24&ajs_recover_source=lld-restore-24&ajs_recover_campaign=recover-launch",
+          "ledgerlive://recover/protect-prod?redirectTo=upsell&source=lld-restore-24&ajs_recover_source=lld-restore-24&ajs_recover_campaign=recover-launch",
       },
       openRecoverFromSidebar: true,
-      protectId: "protect-simu",
+      protectId: "protect-prod",
     },
   },
 );

--- a/shared/feature-flags/src/flags/team-recover-software/protectServicesMobile.ts
+++ b/shared/feature-flags/src/flags/team-recover-software/protectServicesMobile.ts
@@ -40,25 +40,25 @@ export const protectServicesMobile = flagWith(
       deeplink: "",
       account: {
         homeURI:
-          "ledgerlive://recover/protect-simu?source=llm-myledger-access-card&ajs_prop_source=llm-myledger-access-card&ajs_prop_campaign=recover-launch",
+          "ledgerlive://recover/protect-prod?source=llm-myledger-access-card&ajs_prop_source=llm-myledger-access-card&ajs_prop_campaign=recover-launch",
       },
       managerStatesData: {
         NEW: {
           quickAccessURI:
-            "ledgerlive://recover/protect-simu?redirectTo=upsell&source=llm-navbar-quick-access&ajs_prop_source=llm-navbar-quick-access&ajs_prop_campaign=recover-launch",
+            "ledgerlive://recover/protect-prod?redirectTo=upsell&source=llm-navbar-quick-access&ajs_prop_source=llm-navbar-quick-access&ajs_prop_campaign=recover-launch",
           alreadyOnboardedURI:
-            "ledgerlive://recover/protect-simu?redirectTo=upsell&source=llm-pairing&ajs_prop_source=llm-pairing&ajs_prop_campaign=recover-launch",
+            "ledgerlive://recover/protect-prod?redirectTo=upsell&source=llm-pairing&ajs_prop_source=llm-pairing&ajs_prop_campaign=recover-launch",
         },
       },
       onboardingRestore: {
         postOnboardingURI:
-          "ledgerlive://recover/protect-simu?redirectTo=restore&source=llm-restore-24&ajs_prop_source=llm-restore-24&ajs_prop_campaign=recover-launch",
+          "ledgerlive://recover/protect-prod?redirectTo=restore&source=llm-restore-24&ajs_prop_source=llm-restore-24&ajs_prop_campaign=recover-launch",
         restoreInfoDrawer: {
           enabled: true,
           supportLinkURI: "https://support.ledger.com",
         },
       },
-      protectId: "protect-simu",
+      protectId: "protect-prod",
     },
   },
 );


### PR DESCRIPTION
## Summary

The `protect-simu` manifest was deleted from `manifest-api` in the recent batch cleanup ([#915](https://github.com/LedgerHQ/manifest-api/pull/915), [#917](https://github.com/LedgerHQ/manifest-api/pull/917)), but `protectServicesDesktop` and `protectServicesMobile` still defaulted `protectId` and every templated URI to it. Any client that falls back to the schema defaults — local dev builds without Firebase Remote Config, fresh installs that fail the first remote fetch, integration tests — ended up pointing at a nonexistent manifest.

This PR:
- Switches the schema defaults in `protectServicesDesktop.ts` and `protectServicesMobile.ts` (every templated URI + the explicit `protectId` field) from `protect-simu` to `protect-prod`.
- Updates the matching mobile test fixtures (`recoverTestHelpers.ts`, `useRecoverEntry.test.ts`, `useQuickActionsRowViewModel.test.ts`, `useFirstStepSyncOnboardingViewModel.test.ts`).
- Drops `"protect-simu"` from the `recoverIdsShowTopBar` / `headerShownIds` allow-lists in `WebRecoverPlayer` (desktop + mobile) — the dev top-bar hint was never going to match a deleted manifest.

## Why `protect-prod` and not `protect-staging`?

The schema defaults are a fallback for when remote config has not loaded. `protect-prod` is the manifest a real production client will end up with anyway, so the safety net should match it; pointing developers at `protect-staging` would be a behavioral split between "fallback" and "happy path" without any benefit.

## Production impact

None. Prod clients fetch a healthy Firebase Remote Config payload that already pins `protectId: "protect-prod"` and ships fully-rendered URIs — the schema defaults are never observed. This change only affects the dev / fallback path.

## Why is the legacy `protect-simu` test in `recoverFeatureFlag.test.ts` still there?

That test asserts that `useReplacedURI`'s regex (`/protect-[a-z0-9-]+/g`) correctly substitutes legacy placeholders, including `protect-simu`. The test value documents a regex contract, not a manifest reference, so it stays.

## Test plan

- [x] `pnpm --filter @shared/feature-flags typecheck` — passes
- [x] `pnpm --filter @shared/feature-flags test` — 85/85 pass
- [x] `pnpm --filter @ledgerhq/live-common run jest recoverFeatureFlag` — 16/16 pass (regression coverage for `protect-simu` placeholder kept)
- [x] `pnpm mobile test:jest "useRecoverEntry|useQuickActionsRowViewModel|useFirstStepSyncOnboardingViewModel"` — 26/26 pass
- [ ] CI green

Made with [Cursor](https://cursor.com)