### PR TITLE
[LWDM] chore(recover): replace protect-simu defaults with protect-prod

### DIFF
--- a/.changeset/recover-ff-defaults-protect-prod.md
+++ b/.changeset/recover-ff-defaults-protect-prod.md
@@ -1,0 +1,9 @@
+---
+"@shared/feature-flags": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Replace `protect-simu` schema defaults with `protect-prod` in `protectServicesDesktop` / `protectServicesMobile` and drop deleted manifests from `WebRecoverPlayer` dev top-bar allow-lists.
+
+`protect-simu` was removed from `manifest-api`; clients falling back to schema defaults (local dev, failed remote config fetch, tests) were still deeplinking to it. Also remove `protect-simu` and `protect-staging-v2` from the `WebRecoverPlayer` top-bar allow-lists — both manifests are gone. PROD behavior is unchanged because Firebase Remote Config already pins `protectId` to `protect-prod`.

--- a/apps/ledger-live-desktop/src/renderer/components/WebRecoverPlayer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebRecoverPlayer/index.tsx
@@ -28,13 +28,7 @@ export const Wrapper = styled(Box).attrs(() => ({
   position: relative;
 `;
 
-const recoverIdsShowTopBar = [
-  "protect-local",
-  "protect-local-dev",
-  "protect-simu",
-  "protect-staging",
-  "protect-staging-v2",
-];
+const recoverIdsShowTopBar = ["protect-local", "protect-local-dev", "protect-staging"];
 
 export default function WebRecoverPlayer({ manifest, inputs, onClose }: RecoverWebviewProps) {
   useRecoverStateSync(manifest.id);

--- a/apps/ledger-live-mobile/src/components/WebRecoverPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebRecoverPlayer/index.tsx
@@ -22,13 +22,7 @@ type Props = {
   inputs?: Record<string, string | undefined>;
 };
 
-const headerShownIds = [
-  "protect-local",
-  "protect-local-dev",
-  "protect-simu",
-  "protect-staging",
-  "protect-staging-v2",
-];
+const headerShownIds = ["protect-local", "protect-local-dev", "protect-staging"];
 
 const WebRecoverPlayer = ({ manifest, inputs }: Props) => {
   const webviewAPIRef = useRef<WebviewAPI>(null);

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/__tests__/useQuickActionsRowViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/__tests__/useQuickActionsRowViewModel.test.ts
@@ -8,10 +8,7 @@ import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
 import { urls } from "~/utils/urls";
 import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
-import {
-  PROTECT_ID,
-  withRecoverState,
-} from "LLM/features/Portfolio/utils/recoverTestHelpers";
+import { PROTECT_ID, withRecoverState } from "LLM/features/Portfolio/utils/recoverTestHelpers";
 import { ShieldCheckNotificationIcon } from "LLM/features/BackupHub/components/ShieldCheckNotificationIcon";
 import { MY_WALLET_TRACKING_PAGE_NAME } from "../../../constants";
 import { useQuickActionsRowViewModel } from "../useQuickActionsRowViewModel";
@@ -100,7 +97,7 @@ describe("useQuickActionsRowViewModel", () => {
       act(() => recoverAction.onPress());
 
       expect(mockNavigate).toHaveBeenCalledWith(ScreenName.Recover, {
-        platform: "protect-simu",
+        platform: "protect-prod",
         device: undefined,
       });
       expect(track).toHaveBeenCalledWith("button_clicked", {
@@ -205,9 +202,7 @@ describe("useQuickActionsRowViewModel", () => {
 
       it("should open the Backup Hub navigator and track the event on press", () => {
         const { result } = renderHook(() => useQuickActionsRowViewModel(), {
-          overrideInitialState: withBackupHubOn(
-            LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION,
-          ),
+          overrideInitialState: withBackupHubOn(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION),
         });
         const recoverAction = result.current.actions.find(a => a.id === "recover")!;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/FirstStepSyncOnboarding/useFirstStepSyncOnboardingViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/FirstStepSyncOnboarding/useFirstStepSyncOnboardingViewModel.test.ts
@@ -184,7 +184,7 @@ describe("useFirstStepSyncOnboardingViewModel", () => {
     const props = defaultProps();
 
     const { result } = renderHook(() => useFirstStepSyncOnboardingViewModel(props), {
-      overrideInitialState: withProtectServicesMobile(true, { protectId: "protect" }),
+      overrideInitialState: withProtectServicesMobile(true, { protectId: "protect-prod" }),
     });
 
     act(() => {
@@ -198,7 +198,7 @@ describe("useFirstStepSyncOnboardingViewModel", () => {
         params: expect.objectContaining({
           fromOnboarding: true,
           device,
-          platform: "protect",
+          platform: "protect-prod",
           redirectTo: "restore",
           date: expect.any(String),
         }),

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/utils/recoverTestHelpers.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/utils/recoverTestHelpers.ts
@@ -2,7 +2,7 @@ import { withFlagOverrides } from "@tests/test-renderer";
 import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
 import type { State } from "~/reducers/types";
 
-export const PROTECT_ID = "protect-simu";
+export const PROTECT_ID = "protect-prod";
 
 export const withBannerEnabled = withFlagOverrides({
   protectServicesMobile: {

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useRecoverEntry.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useRecoverEntry.test.ts
@@ -38,7 +38,7 @@ describe("useRecoverEntry", () => {
     const { result } = renderHook(() => useRecoverEntry());
 
     // The test environment provides the protectServicesMobile feature flag default.
-    expect(result.current.protectId).toBe("protect-simu");
+    expect(result.current.protectId).toBe("protect-prod");
   });
 
   it("falls back to DEFAULT_PROTECT_ID when the feature flag has no protectId param", () => {
@@ -57,7 +57,7 @@ describe("useRecoverEntry", () => {
     act(() => result.current.openRecover());
 
     expect(mockNavigate).toHaveBeenCalledWith(ScreenName.Recover, {
-      platform: "protect-simu",
+      platform: "protect-prod",
       device: undefined,
     });
   });
@@ -70,7 +70,7 @@ describe("useRecoverEntry", () => {
     act(() => result.current.openRecover());
 
     expect(mockNavigate).toHaveBeenCalledWith(ScreenName.Recover, {
-      platform: "protect-simu",
+      platform: "protect-prod",
       device: mockDevice,
     });
   });

--- a/shared/feature-flags/src/flags/team-recover-software/protectServicesDesktop.ts
+++ b/shared/feature-flags/src/flags/team-recover-software/protectServicesDesktop.ts
@@ -30,19 +30,19 @@ export const protectServicesDesktop = flagWith(
       bannerSubscriptionNotification: false,
       account: {
         homeURI:
-          "ledgerlive://recover/protect-simu?source=lld-sidebar-navigation&ajs_recover_source=lld-sidebar-navigation&ajs_recover_campaign=recover-launch",
+          "ledgerlive://recover/protect-prod?source=lld-sidebar-navigation&ajs_recover_source=lld-sidebar-navigation&ajs_recover_campaign=recover-launch",
       },
       discoverTheBenefitsLink: "https://www.ledger.com/recover",
       onboardingCompleted: {
         alreadyDeviceSeededURI:
-          "ledgerlive://recover/protect-simu?redirectTo=upsell&source=lld-pairing&ajs_recover_source=lld-pairing&ajs_recover_campaign=recover-launch",
+          "ledgerlive://recover/protect-prod?redirectTo=upsell&source=lld-pairing&ajs_recover_source=lld-pairing&ajs_recover_campaign=recover-launch",
         upsellURI:
-          "ledgerlive://recover/protect-simu?redirectTo=upsell&source=lld-onboarding-24&ajs_recover_source=lld-onboarding-24&ajs_recover_campaign=recover-launch",
+          "ledgerlive://recover/protect-prod?redirectTo=upsell&source=lld-onboarding-24&ajs_recover_source=lld-onboarding-24&ajs_recover_campaign=recover-launch",
         restore24URI:
-          "ledgerlive://recover/protect-simu?redirectTo=upsell&source=lld-restore-24&ajs_recover_source=lld-restore-24&ajs_recover_campaign=recover-launch",
+          "ledgerlive://recover/protect-prod?redirectTo=upsell&source=lld-restore-24&ajs_recover_source=lld-restore-24&ajs_recover_campaign=recover-launch",
       },
       openRecoverFromSidebar: true,
-      protectId: "protect-simu",
+      protectId: "protect-prod",
     },
   },
 );

--- a/shared/feature-flags/src/flags/team-recover-software/protectServicesMobile.ts
+++ b/shared/feature-flags/src/flags/team-recover-software/protectServicesMobile.ts
@@ -40,25 +40,25 @@ export const protectServicesMobile = flagWith(
       deeplink: "",
       account: {
         homeURI:
-          "ledgerlive://recover/protect-simu?source=llm-myledger-access-card&ajs_prop_source=llm-myledger-access-card&ajs_prop_campaign=recover-launch",
+          "ledgerlive://recover/protect-prod?source=llm-myledger-access-card&ajs_prop_source=llm-myledger-access-card&ajs_prop_campaign=recover-launch",
       },
       managerStatesData: {
         NEW: {
           quickAccessURI:
-            "ledgerlive://recover/protect-simu?redirectTo=upsell&source=llm-navbar-quick-access&ajs_prop_source=llm-navbar-quick-access&ajs_prop_campaign=recover-launch",
+            "ledgerlive://recover/protect-prod?redirectTo=upsell&source=llm-navbar-quick-access&ajs_prop_source=llm-navbar-quick-access&ajs_prop_campaign=recover-launch",
           alreadyOnboardedURI:
-            "ledgerlive://recover/protect-simu?redirectTo=upsell&source=llm-pairing&ajs_prop_source=llm-pairing&ajs_prop_campaign=recover-launch",
+            "ledgerlive://recover/protect-prod?redirectTo=upsell&source=llm-pairing&ajs_prop_source=llm-pairing&ajs_prop_campaign=recover-launch",
         },
       },
       onboardingRestore: {
         postOnboardingURI:
-          "ledgerlive://recover/protect-simu?redirectTo=restore&source=llm-restore-24&ajs_prop_source=llm-restore-24&ajs_prop_campaign=recover-launch",
+          "ledgerlive://recover/protect-prod?redirectTo=restore&source=llm-restore-24&ajs_prop_source=llm-restore-24&ajs_prop_campaign=recover-launch",
         restoreInfoDrawer: {
           enabled: true,
           supportLinkURI: "https://support.ledger.com",
         },
       },
-      protectId: "protect-simu",
+      protectId: "protect-prod",
     },
   },
 );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Existing mobile test fixtures updated to expect `protect-prod`. No new test logic — the change is default-value alignment after deleted manifests were removed from `manifest-api`.
- [x] **Impact of the changes:**
  - **Scope:** `protectServicesDesktop` / `protectServicesMobile` schema defaults, `WebRecoverPlayer` dev top-bar allow-lists (desktop + mobile), mobile Recover test fixtures.
  - **PROD behavior unchanged:** clients fetch Firebase Remote Config with `protectId: "protect-prod"`; schema defaults are only used when remote config has not loaded (local dev, first-fetch fallback, tests).
  - **Dev / fallback path:** Recover deeplinks now default to `protect-prod` instead of the deleted `protect-simu` manifest.
  - **QA focus:** _None required for PROD — no user-facing behavior change when Remote Config is healthy._

### 📝 Description

`protect-simu` and `protect-staging-v2` were deleted from `manifest-api` (#915, #917), but `protectServicesDesktop` and `protectServicesMobile` still defaulted `protectId` and every templated URI to `protect-simu`. Any client falling back to schema defaults — local dev without Firebase Remote Config, failed first remote fetch, integration tests — pointed at a nonexistent manifest.

This PR:

1. **Schema defaults** — switch `protectId` and all default deeplink URIs in `protectServicesDesktop.ts` and `protectServicesMobile.ts` from `protect-simu` to `protect-prod`.
2. **WebRecoverPlayer allow-lists** — drop `"protect-simu"` and `"protect-staging-v2"` from `recoverIdsShowTopBar` (desktop) and `headerShownIds` (mobile); the dev top-bar hint cannot match deleted manifests.
3. **Test fixtures** — update mobile tests that hardcoded `protect-simu` or the deleted `protect` manifest id to `protect-prod`.

The `useReplacedURI` regression test in `recoverFeatureFlag.test.ts` that parametrizes `protect-simu` as a legacy placeholder is intentionally kept — it documents the regex contract, not a live manifest reference.

#### Why `protect-prod` and not `protect-staging`?

Schema defaults are a safety net when remote config is unavailable. `protect-prod` matches what a healthy prod client already receives from Firebase; using `protect-staging` would split fallback vs happy-path behavior without benefit.

### ❓ Context

- **JIRA or GitHub link**: _none — follow-up to manifest-api cleanup (`protect-simu`, `protect-staging-v2` removal)._
- **ADR link (if any)**: _n/a_


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)