### PR TITLE
fix(mobile): move e2e tags to spec files so coin/family filters work on CI

### DIFF
--- a/e2e/mobile/specs/delegate/delegate.ts
+++ b/e2e/mobile/specs/delegate/delegate.ts
@@ -1,7 +1,10 @@
 import { setEnv } from "@ledgerhq/live-env";
 import { DelegateType } from "@ledgerhq/live-common/e2e/models/Delegate";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
-import { verifyAppValidationStakeInfo, verifyStakeOperationDetailsInfo } from "../../models/stake";
+import {
+  verifyAppValidationStakeInfo,
+  verifyStakeOperationDetailsInfo,
+} from "../../models/stake";
 import { getCurrencyManagerApp } from "../../models/currencies";
 import { setTeamOwner } from "../../helpers/allure/allure-helper";
 
@@ -16,12 +19,18 @@ const beforeAllFunction = async (delegation: DelegateType) => {
   await app.mainNavigation.waitForWallet40Ready();
 };
 
-export function runDelegateTest(delegation: DelegateType, tmsLinks: string[], tags: string[]) {
+export function runDelegateTest(
+  delegation: DelegateType,
+  tmsLinks: string[],
+  tags: string[],
+) {
   setTeamOwner(
-    BST_DELEGATE_CURRENCIES.has(delegation.account.currency.id) ? Team.BST : Team.COIN_INTEGRATION,
+    BST_DELEGATE_CURRENCIES.has(delegation.account.currency.id)
+      ? Team.BST
+      : Team.COIN_INTEGRATION,
   );
-  tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
-  tags.forEach(tag => $Tag(tag));
+  tmsLinks.forEach((tmsLink) => $TmsLink(tmsLink));
+  tags.forEach((tag) => $Tag(tag));
   describe("Delegate", () => {
     beforeAll(async () => {
       await beforeAllFunction(delegation);
@@ -29,9 +38,11 @@ export function runDelegateTest(delegation: DelegateType, tmsLinks: string[], ta
 
     it(`Delegate on ${delegation.account.currency.name}`, async () => {
       let fees;
-      const amountWithCode = delegation.amount + " " + delegation.account.currency.ticker;
+      const amountWithCode =
+        delegation.amount + " " + delegation.account.currency.ticker;
       const currencyId =
-        getCurrencyManagerApp(delegation.account.currency.id) ?? delegation.account.currency.id;
+        getCurrencyManagerApp(delegation.account.currency.id) ??
+        delegation.account.currency.id;
 
       if (delegation.account.currency.name == Currency.INJ.name) {
         await app.speculos.activateExpertMode();
@@ -73,8 +84,8 @@ export function runDelegateDefaultValidatorTest(
   tags: string[],
 ) {
   setTeamOwner(Team.COIN_INTEGRATION);
-  tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
-  tags.forEach(tag => $Tag(tag));
+  tmsLinks.forEach((tmsLink) => $TmsLink(tmsLink));
+  tags.forEach((tag) => $Tag(tag));
   describe("Delegate - default validator", () => {
     beforeAll(async () => {
       await beforeAllFunction(delegation);
@@ -82,7 +93,8 @@ export function runDelegateDefaultValidatorTest(
 
     it(`Defaults to ${delegation.provider} on ${delegation.account.currency.name}`, async () => {
       const currencyId =
-        getCurrencyManagerApp(delegation.account.currency.id) ?? delegation.account.currency.id;
+        getCurrencyManagerApp(delegation.account.currency.id) ??
+        delegation.account.currency.id;
 
       await app.portfolio.goToAccounts(delegation.account.currency.name);
       await app.common.goToAccountByName(delegation.account.accountName);
@@ -94,21 +106,22 @@ export function runDelegateDefaultValidatorTest(
   });
 }
 
-export async function runLockCelo(
+export function runLockCelo(
   delegation: DelegateType,
   tmsLinks: string[],
-  tags: string[] = ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", `@celo`, `@family-celo`],
+  tags: string[],
 ) {
   setTeamOwner(Team.COIN_INTEGRATION);
-  tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
-  tags.forEach(tag => $Tag(tag));
+  tmsLinks.forEach((tmsLink) => $TmsLink(tmsLink));
+  tags.forEach((tag) => $Tag(tag));
   describe(`Lock flow on CELO`, () => {
     beforeAll(async () => {
       await beforeAllFunction(delegation);
     });
 
     it(`Lock on CELO`, async () => {
-      const amountWithCode = delegation.amount + " " + delegation.account.currency.ticker;
+      const amountWithCode =
+        delegation.amount + " " + delegation.account.currency.ticker;
       const currencyId = delegation.account.currency.id;
 
       await app.portfolio.goToAccounts(delegation.account.currency.name);
@@ -130,21 +143,22 @@ export async function runLockCelo(
   });
 }
 
-export async function runVoteCelo(
+export function runVoteCelo(
   delegation: DelegateType,
   tmsLinks: string[],
-  tags: string[] = ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", `@celo`, `@family-celo`],
+  tags: string[],
 ) {
   setTeamOwner(Team.COIN_INTEGRATION);
-  tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
-  tags.forEach(tag => $Tag(tag));
+  tmsLinks.forEach((tmsLink) => $TmsLink(tmsLink));
+  tags.forEach((tag) => $Tag(tag));
   describe(`Vote flow on CELO`, () => {
     beforeAll(async () => {
       await beforeAllFunction(delegation);
     });
 
     it(`Vote on CELO with ${delegation.provider}`, async () => {
-      const amountWithCode = delegation.amount + " " + delegation.account.currency.ticker;
+      const amountWithCode =
+        delegation.amount + " " + delegation.account.currency.ticker;
 
       await app.portfolio.goToAccounts(delegation.account.currency.name);
       await app.common.goToAccountByName(delegation.account.accountName);
@@ -152,7 +166,10 @@ export async function runVoteCelo(
 
       await app.celoManageAssets.checkManagePage();
       await app.celoManageAssets.clickVote();
-      await app.stake.selectValidator(delegation.account.currency.id, delegation.provider);
+      await app.stake.selectValidator(
+        delegation.account.currency.id,
+        delegation.provider,
+      );
 
       await app.stake.openCeloVoteAmount();
       await app.stake.setCeloVoteAmount(delegation.amount);
@@ -165,36 +182,33 @@ export async function runVoteCelo(
 
       await app.common.successViewDetails();
 
-      await verifyStakeOperationDetailsInfo(delegation, amountWithCode, undefined, "VOTE");
+      await verifyStakeOperationDetailsInfo(
+        delegation,
+        amountWithCode,
+        undefined,
+        "VOTE",
+      );
     });
   });
 }
 
-export async function runDelegateTezos(
+export function runDelegateTezos(
   delegation: DelegateType,
   tmsLinks: string[],
-  tags: string[] = [
-    "@NanoSP",
-    "@LNS",
-    "@NanoX",
-    "@Stax",
-    "@Flex",
-    "@NanoGen5",
-    `@tezos`,
-    `@family-tezos`,
-  ],
+  tags: string[],
 ) {
   setEnv("DISABLE_TRANSACTION_BROADCAST", true);
   setTeamOwner(Team.BST);
-  tags.forEach(tag => $Tag(tag));
-  tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+  tags.forEach((tag) => $Tag(tag));
+  tmsLinks.forEach((tmsLink) => $TmsLink(tmsLink));
   describe(`Delegate flow on TEZOS`, () => {
     beforeAll(async () => {
       await beforeAllFunction(delegation);
     });
 
     it(`Delegate on TEZOS`, async () => {
-      const amountWithCode = delegation.amount + " " + delegation.account.currency.ticker;
+      const amountWithCode =
+        delegation.amount + " " + delegation.account.currency.ticker;
       const currencyId = delegation.account.currency.id;
 
       await app.speculos.goToSettings();

--- a/e2e/mobile/specs/delegate/delegateTEZOS.spec.ts
+++ b/e2e/mobile/specs/delegate/delegateTEZOS.spec.ts
@@ -2,4 +2,17 @@ import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runDelegateTezos } from "./delegate";
 
 const delegation = new Delegate(Account.XTZ_1, "N/A", "Ledger by Kiln");
-runDelegateTezos(delegation, ["B2CQA-3041"]);
+runDelegateTezos(
+  delegation,
+  ["B2CQA-3041"],
+  [
+    "@NanoSP",
+    "@LNS",
+    "@NanoX",
+    "@Stax",
+    "@Flex",
+    "@NanoGen5",
+    `@tezos`,
+    `@family-tezos`,
+  ],
+);

--- a/e2e/mobile/specs/delegate/lockCELO.spec.ts
+++ b/e2e/mobile/specs/delegate/lockCELO.spec.ts
@@ -2,4 +2,8 @@ import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runLockCelo } from "./delegate";
 
 const delegation = new Delegate(Account.CELO_1, "0.001", "N/A");
-runLockCelo(delegation, ["B2CQA-3042"]);
+runLockCelo(
+  delegation,
+  ["B2CQA-3042"],
+  ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", `@celo`, `@family-celo`],
+);

--- a/e2e/mobile/specs/delegate/voteCELO.spec.ts
+++ b/e2e/mobile/specs/delegate/voteCELO.spec.ts
@@ -2,4 +2,8 @@ import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runVoteCelo } from "./delegate";
 
 const delegation = new Delegate(Account.CELO_1, "0.001", "cLabs");
-runVoteCelo(delegation, ["B2CQA-201"]);
+runVoteCelo(
+  delegation,
+  ["B2CQA-201"],
+  ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", `@celo`, `@family-celo`],
+);

--- a/e2e/mobile/specs/subAccount/addSubAccountWithoutParent/addSubAccountPOL_DAI.spec.ts
+++ b/e2e/mobile/specs/subAccount/addSubAccountWithoutParent/addSubAccountPOL_DAI.spec.ts
@@ -10,8 +10,8 @@ const testConfig = {
     "@Stax",
     "@Flex",
     "@NanoGen5",
-    "@polkadot",
-    "@family-polkadot",
+    "@polygon",
+    "@family-evm",
   ],
 };
 


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- N/A — e2e test specs only, no published package changes -->
- [x] **Covered by automatic tests.** <!-- These are the mobile E2E specs themselves; the fix is verified by the dispatch below. -->
- [ ] **Impact of the changes:**
  - Mobile E2E only. Restores `@family-*` / coin tag filtering on CI (e.g. `@family-celo`, `@family-tezos`). No app/runtime code touched.

### 📝 Description

**Problem.** Mobile E2E spec selection (`apps/ledger-live-mobile/scripts/shard-tests.mjs` → `filterTestFiles`) decides which `*.spec.ts` files run by matching the filter **against the spec file's path or content**. It only ever reads `*.spec.ts` files — never the shared helper `*.ts` files.

So when a tag like `@family-celo` lived only as a **default parameter value inside a shared helper** (`delegate.ts`), the literal string was absent from `lockCELO.spec.ts` / `voteCELO.spec.ts`. A `@family-celo` filter matched **0 files**, the shard was empty, and the tests silently never ran.

Example of the symptom (filter matched nothing):
https://github.com/LedgerHQ/ledger-live/actions/runs/28102617087/job/83208302733

**Fix.** Make the filter-relevant tags inline literals in the spec files:

- **delegate**: move device/coin/family tags out of helper defaults in `delegate.ts` and pass them explicitly from each spec (`lockCELO`, `voteCELO`, `delegateTEZOS`).
- **subAccount**: fix the Polygon sub-account family tag — `POL` is an EVM coin but was mistagged `@polkadot` / `@family-polkadot`, so it was invisible to `@family-evm` (now `@polygon` / `@family-evm`).

I also audited all mobile specs: every other coin-specific spec already carries its coin + `@family-*` tag inline, and every `@family-*` tag now maps to a real currency `family`.

### ▶️ Verification — dispatched E2E run with the `@family-celo` filter

Triggered `test-mobile-e2e-reusable.yml` on this branch with `test_filter=@family-celo` (iOS & Android, nanoX) to confirm the filter now selects the CELO specs instead of matching zero files:

```
gh workflow run test-mobile-e2e-reusable.yml \
  --ref support/mobile-e2e-family-tags \
  -f test_filter=@family-celo \
  -f tests_type="iOS & Android" \
  -f speculos_device=nanoX
```

Run: https://github.com/LedgerHQ/ledger-live/actions/runs/28105483720

### ❓ Context

- **JIRA or GitHub link**: _n/a — CI test-tooling fix_

