### PR TITLE
ci: add slack notif check on e2e mobile workflow

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -52,6 +52,11 @@ on:
         required: false
         type: boolean
         default: false
+      slack_notif:
+        description: "Send notification to Slack"
+        required: false
+        type: boolean
+        default: false
       export_to_xray:
         description: "Send results to Xray"
         required: false
@@ -112,6 +117,11 @@ on:
         default: false
       enable_broadcast:
         description: "Enable transaction broadcast"
+        required: false
+        type: boolean
+        default: false
+      slack_notif:
+        description: "Send notification to Slack"
         required: false
         type: boolean
         default: false
@@ -291,6 +301,7 @@ jobs:
           echo "- **Test Execution ticket ID (iOS):** $TEST_EXECUTION_IOS"
           echo "- **Firebase env to target:** $BUILD_TYPE"
           echo "- **Broadcast enabled:** $BROADCAST_ENABLED"
+          echo "- **Slack notification:** ${{ (inputs.slack_notif || github.event_name == 'schedule') && 'enabled' || 'disabled' }}"
           echo "- **Wallet 4.0:** ${{ env.E2E_ENABLE_WALLET40 == '1' && 'enabled' || 'disabled' }}"
           echo "- **Extra feature flags:** $EXTRA_FEATURE_FLAGS"
           } >> $GITHUB_STEP_SUMMARY
@@ -1273,7 +1284,7 @@ jobs:
           token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           payload-file-path: "./payload-slack-content.json"
       - name: post to a Slack channel
-        if: ${{ contains(fromJson('["release"]'), github.ref_name) || contains(fromJson('["release, develop"]'), inputs.ref) || github.event_name == 'schedule' }}
+        if: ${{ inputs.slack_notif || github.event_name == 'schedule' }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.postMessage


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - E2E Mobile slack notif

### 📝 Description

This PR updates the reusable Mobile E2E GitHub Actions workflow to introduce an explicit slack_notif input intended to control whether Slack notifications are sent for non-scheduled runs.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- Notification [Link](https://ledger.slack.com/archives/C05FKJ7DFAP/p1782311935497469)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
