### PR TITLE
[LWD] fix(lld): make full-screen Live App webview load resilient on cold start (LIVE-33113)

### DIFF
--- a/.changeset/recover-webview-infinite-loader.md
+++ b/.changeset/recover-webview-infinite-loader.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix full-screen live apps (e.g. Recover) getting stuck on an infinite loader on cold start. The webview's `did-finish-load` listener was attached via an effect keyed on a stable ref, so on a cold start it could attach after the webview had already finished loading and miss the event, leaving `widgetLoaded` false forever. The listener now keys off the mounted webview node and recovers if the load already completed.

--- a/.changeset/recover-webview-infinite-loader.md
+++ b/.changeset/recover-webview-infinite-loader.md
@@ -2,4 +2,8 @@
 "ledger-live-desktop": minor
 ---
 
-Fix full-screen live apps (e.g. Recover) getting stuck on an infinite loader on cold start. The webview's `did-finish-load` listener was attached via an effect keyed on a stable ref, so on a cold start it could attach after the webview had already finished loading and miss the event, leaving `widgetLoaded` false forever. The listener now keys off the mounted webview node and recovers if the load already completed.
+Harden the Live App webview load so full-screen apps (e.g. Recover) can no longer get stuck on an infinite loader on cold start:
+
+- The `did-finish-load` listener now keys off the mounted webview node (not a stable ref) and recovers if the load already completed, so a mount-timing race can't leave `widgetLoaded` false forever.
+- Bound the load with a timeout: if the webview never finishes loading (e.g. its document response stalls mid-stream on a cold start), fall back to the existing network-error/retry screen instead of spinning indefinitely.
+- Stop leaking React Router's splat (`*`) into the webview URL as a junk query param.

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -440,17 +440,20 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
         webview.addEventListener("did-finish-load", handleLoad);
         webview.addEventListener("dom-ready", handleDomReady);
 
-        // Recover from a missed "did-finish-load": on a cold start the main thread is busy and
-        // this passive effect can attach after the webview already finished loading, so the
-        // event never reaches us and the loader stays up forever. If the load is already done,
-        // mark the widget loaded now. isLoading() throws before dom-ready (the webview has no
-        // WebContents yet) — that just means it is still loading, so the listener will catch it.
+        // Recover from missed events: on a cold start the main thread is busy and this passive
+        // effect can attach after the webview already finished loading, so neither "did-finish-load"
+        // nor "dom-ready" ever reaches us — the loader stays up forever and the manifest-domain
+        // guard (installed via handleDomReady) is never wired. If the load is already done, replay
+        // both: dom-ready always precedes did-finish-load, so a settled load implies both fired.
+        // isLoading() throws before dom-ready (the webview has no WebContents yet) — that just means
+        // it is still loading, so the listeners will catch the events.
         try {
           if (!webview.isLoading()) {
+            handleDomReady();
             handleLoad();
           }
         } catch {
-          // webview not attached/dom-ready yet — nothing to recover, the listener will fire.
+          // webview not attached/dom-ready yet — nothing to recover, the listeners will fire.
         }
       }
 
@@ -460,7 +463,6 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
           webview.removeEventListener("dom-ready", handleDomReady);
         }
       };
-      // oxlint-disable-next-line react-hooks/exhaustive-deps
     }, [handleLoad, handleDomReady, webviewNode]);
 
     const webviewStyle = useMemo(() => {

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -51,7 +51,7 @@ import { setOriginFlow } from "~/renderer/analytics/originFlow";
 export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
   ({ manifest, inputs = {}, onStateChange }, ref) => {
     const manifestDomainCheckEnabled = useFeature("lldWebviewManifestDomainCheck")?.enabled;
-    const { webviewState, webviewRef, setWebviewRef, webviewProps, webviewPartition } =
+    const { webviewState, webviewRef, webviewNode, setWebviewRef, webviewProps, webviewPartition } =
       useWebviewState(
         {
           manifest,
@@ -432,11 +432,26 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
     }, [manifest.domains, manifestDomainCheckEnabled, webviewRef]);
 
     useEffect(() => {
-      const webview = webviewRef.current;
+      // Key off the node state (not the stable ref) so this effect re-runs exactly when the
+      // <webview> mounts, guaranteeing the listeners attach to the live node.
+      const webview = webviewNode;
 
       if (webview) {
         webview.addEventListener("did-finish-load", handleLoad);
         webview.addEventListener("dom-ready", handleDomReady);
+
+        // Recover from a missed "did-finish-load": on a cold start the main thread is busy and
+        // this passive effect can attach after the webview already finished loading, so the
+        // event never reaches us and the loader stays up forever. If the load is already done,
+        // mark the widget loaded now. isLoading() throws before dom-ready (the webview has no
+        // WebContents yet) — that just means it is still loading, so the listener will catch it.
+        try {
+          if (!webview.isLoading()) {
+            handleLoad();
+          }
+        } catch {
+          // webview not attached/dom-ready yet — nothing to recover, the listener will fire.
+        }
       }
 
       return () => {
@@ -446,7 +461,7 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
         }
       };
       // oxlint-disable-next-line react-hooks/exhaustive-deps
-    }, [handleLoad, handleDomReady]);
+    }, [handleLoad, handleDomReady, webviewNode]);
 
     const webviewStyle = useMemo(() => {
       return {

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -427,17 +427,20 @@ function useWebView(
       webview.addEventListener("ipc-message", handleMessage);
       webview.addEventListener("dom-ready", handleDomReady);
 
-      // Recover from a missed "did-finish-load": on a cold start the main thread is busy and
-      // this passive effect can attach after the webview already finished loading, so the
-      // event never reaches us and the loader stays up forever. If the load is already done,
-      // mark the widget loaded now. isLoading() throws before dom-ready (the webview has no
-      // WebContents yet) — that just means it is still loading, so the listener will catch it.
+      // Recover from missed events: on a cold start the main thread is busy and this passive
+      // effect can attach after the webview already finished loading, so neither "did-finish-load"
+      // nor "dom-ready" ever reaches us — the loader stays up forever and the manifest-domain
+      // guard (installed via handleDomReady) is never wired. If the load is already done, replay
+      // both: dom-ready always precedes did-finish-load, so a settled load implies both fired.
+      // isLoading() throws before dom-ready (the webview has no WebContents yet) — that just means
+      // it is still loading, so the listeners will catch the events.
       try {
         if (!webview.isLoading()) {
+          handleDomReady();
           onLoad();
         }
       } catch {
-        // webview not attached/dom-ready yet — nothing to recover, the listener will fire.
+        // webview not attached/dom-ready yet — nothing to recover, the listeners will fire.
       }
     }
 

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -322,6 +322,7 @@ function useWebView(
     "manifest" | "customHandlers" | "currentAccountHistDb" | "setCurrentAccountHistDb" | "inputs"
   >,
   webviewRef: RefObject<WebviewTag | null>,
+  webviewNode: WebviewTag | null,
   tracking: TrackingAPI,
   serverRef: RefObject<WalletAPIServer | undefined>,
   customWebviewStyle?: React.CSSProperties,
@@ -417,12 +418,27 @@ function useWebView(
   }, [manifest.domains, manifestDomainCheckEnabled, webviewRef]);
 
   useEffect(() => {
-    const webview = webviewRef.current;
+    // Key off the node state (not the stable ref) so this effect re-runs exactly when the
+    // <webview> mounts, guaranteeing the listeners attach to the live node.
+    const webview = webviewNode;
 
     if (webview) {
       webview.addEventListener("did-finish-load", onLoad);
       webview.addEventListener("ipc-message", handleMessage);
       webview.addEventListener("dom-ready", handleDomReady);
+
+      // Recover from a missed "did-finish-load": on a cold start the main thread is busy and
+      // this passive effect can attach after the webview already finished loading, so the
+      // event never reaches us and the loader stays up forever. If the load is already done,
+      // mark the widget loaded now. isLoading() throws before dom-ready (the webview has no
+      // WebContents yet) — that just means it is still loading, so the listener will catch it.
+      try {
+        if (!webview.isLoading()) {
+          onLoad();
+        }
+      } catch {
+        // webview not attached/dom-ready yet — nothing to recover, the listener will fire.
+      }
     }
 
     return () => {
@@ -432,7 +448,7 @@ function useWebView(
         webview.removeEventListener("dom-ready", handleDomReady);
       }
     };
-  }, [handleDomReady, handleMessage, onLoad, webviewRef]);
+  }, [handleDomReady, handleMessage, onLoad, webviewNode]);
 
   const webviewStyle = useMemo(() => {
     return {
@@ -495,6 +511,7 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
     const {
       webviewState,
       webviewRef,
+      webviewNode,
       setWebviewRef,
       webviewProps,
       handleRefresh,
@@ -523,6 +540,7 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
         inputs,
       },
       webviewRef,
+      webviewNode,
       tracking,
       serverRef,
       customWebviewStyle,

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -11,7 +11,15 @@ import { AppManifest, WalletAPIServer } from "@ledgerhq/live-common/wallet-api/t
 import { useDappLogic } from "@ledgerhq/live-common/wallet-api/useDappLogic";
 import { Operation } from "@ledgerhq/types-live";
 import { ipcRenderer } from "electron";
-import React, { type RefObject, forwardRef, useCallback, useEffect, useMemo, useRef } from "react";
+import React, {
+  type RefObject,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { userIdSelector } from "@ledgerhq/client-ids/store";
@@ -43,6 +51,11 @@ import { useFeature } from "@features/platform-feature-flags";
 import { setOriginFlow } from "~/renderer/analytics/originFlow";
 
 const wallet = { name: "ledger-live-desktop", version: __APP_VERSION__ };
+
+// If a Live App webview never fires `did-finish-load` within this window (e.g. its document
+// response stalls mid-stream on a cold start), fall back to the network-error/retry screen
+// instead of spinning forever.
+const WEBVIEW_LOAD_TIMEOUT_MS = 20_000;
 
 function useUiHook(manifest: AppManifest, tracking: TrackingAPI): UiHook {
   const { pushToast } = useToasts();
@@ -549,7 +562,23 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
       customWebviewStyle,
       manifestDomainCheckEnabled,
     );
-    const isNetworkErrorVisible = !webviewState.loading && webviewState.isAppUnavailable;
+    // Bound the load: if `did-finish-load` never fires (stalled document on cold start), surface
+    // the retry screen instead of an infinite spinner. Cleared once the widget loads; restarted
+    // on retry.
+    const [loadTimedOut, setLoadTimedOut] = useState(false);
+    useEffect(() => {
+      if (widgetLoaded || loadTimedOut) return;
+      const id = setTimeout(() => setLoadTimedOut(true), WEBVIEW_LOAD_TIMEOUT_MS);
+      return () => clearTimeout(id);
+    }, [widgetLoaded, loadTimedOut]);
+
+    const handleRetry = useCallback(() => {
+      setLoadTimedOut(false);
+      handleRefresh();
+    }, [handleRefresh]);
+
+    const isNetworkErrorVisible =
+      (!webviewState.loading && webviewState.isAppUnavailable) || (loadTimedOut && !widgetLoaded);
     const displayedWebviewStyle = useMemo(
       () => (isNetworkErrorVisible ? { ...webviewStyle, display: "none" } : webviewStyle),
       [isNetworkErrorVisible, webviewStyle],
@@ -572,7 +601,7 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
 
     return (
       <>
-        {isNetworkErrorVisible && <NetworkErrorScreen refresh={handleRefresh} />}
+        {isNetworkErrorVisible && <NetworkErrorScreen refresh={handleRetry} />}
         <webview
           ref={setWebviewRef}
           /**
@@ -595,7 +624,9 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
           {...webviewProps}
           {...webviewPartition}
         />
-        {!hideLoader ? <Loader manifest={manifest} isLoading={!widgetLoaded} /> : null}
+        {!hideLoader ? (
+          <Loader manifest={manifest} isLoading={!widgetLoaded && !isNetworkErrorVisible} />
+        ) : null}
       </>
     );
   },

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
@@ -56,6 +56,8 @@ type UseWebviewStateReturn = {
     src: string;
   };
   webviewRef: RefObject<WebviewTag | null>;
+  /** The mounted <webview> DOM node, tracked as state so effects re-run when it mounts. */
+  webviewNode: WebviewTag | null;
   setWebviewRef: (node: WebviewTag) => () => void;
   webviewPartition: WebviewPartition;
   handleRefresh: () => void;
@@ -318,6 +320,7 @@ export function useWebviewState(
     webviewState: state,
     webviewProps: props,
     webviewRef,
+    webviewNode,
     setWebviewRef,
     webviewPartition,
     handleRefresh,

--- a/apps/ledger-live-desktop/src/renderer/screens/recover/Player.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/recover/Player.tsx
@@ -102,19 +102,24 @@ export default function RecoverPlayer() {
   }, [onClose, onboardingState]);
 
   const inputs = useMemo(
-    () => ({
-      theme,
-      lang: locale,
-      availableOnDesktop,
-      deviceId: state?.deviceId,
-      deviceModelId: device?.modelId,
-      devModeEnabled,
-      currency,
-      hasConnectedNanoS,
-      countryCode,
-      ...params,
-      ...queryParams,
-    }),
+    () => {
+      // React Router's splat ("*") leaks into params/queryParams and ends up as a junk
+      // "*=recover/protect-prod" query param on the webview URL, which the Recover frontend
+      // can choke on. It is never a valid Live App input, so drop it.
+      const { "*": _splat, ...passthroughParams } = { ...params, ...queryParams };
+      return {
+        theme,
+        lang: locale,
+        availableOnDesktop,
+        deviceId: state?.deviceId,
+        deviceModelId: device?.modelId,
+        devModeEnabled,
+        currency,
+        hasConnectedNanoS,
+        countryCode,
+        ...passthroughParams,
+      };
+    },
     /**
      * deviceModelId is purposely ignored from dependencies.
      *


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** 
- [x] **Impact of the changes:**
  - **Shared `Web3AppWebview` code** → affects **every full-screen Live App**

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33113](https://ledgerhq.atlassian.net/browse/LIVE-33113)
- **ADR link (if any)**: N/A


[LIVE-33113]: https://ledgerhq.atlassian.net/browse/LIVE-33113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ