### PR TITLE
[LWD] feat(desktop): bootstrap device intent executor

### DIFF
--- a/.changeset/live-32999-lwd-die-bootstrap.md
+++ b/.changeset/live-32999-lwd-die-bootstrap.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Bootstrap the Device Intent Executor integration on desktop with an initialization playground.

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -78,6 +78,7 @@
     "@ledgerhq/crypto-icons": "catalog:",
     "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/devices": "workspace:*",
+    "@ledgerhq/device-intent": "workspace:^",
     "@ledgerhq/domain-service": "workspace:^",
     "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/ethereum-provider": "workspace:^",

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/index.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import type { DeviceConnectionComponent, DeviceConnectionResult } from "@ledgerhq/device-intent";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import { EMPTY } from "rxjs";
+
+function formatParams(params: unknown): string {
+  return JSON.stringify(params, null, 2) ?? "";
+}
+
+const DeviceConnectionComponentLWD: DeviceConnectionComponent = ({
+  deviceConnectionParams,
+  onConnected,
+  onClose,
+}) => {
+  const simulateConnected = () => {
+    onConnected(buildMockConnectionResult());
+  };
+
+  return (
+    <div
+      className="flex w-full flex-col gap-24 px-16 py-24"
+      data-testid="device-intent-executor-device-connection-placeholder"
+    >
+      <div className="flex flex-col gap-8 text-center">
+        <h3 className="heading-4-semi-bold text-base">Device connection placeholder</h3>
+        <p className="body-2 text-muted">
+          The desktop device connection implementation is pending.
+        </p>
+      </div>
+      <pre className="max-h-[240px] overflow-auto rounded-md bg-muted p-12 text-left font-mono text-xs text-base">
+        {formatParams(deviceConnectionParams)}
+      </pre>
+      <div className="flex w-full flex-col gap-12">
+        <Button appearance="base" size="lg" isFull onClick={simulateConnected}>
+          Simulate connected device
+        </Button>
+        <Button appearance="gray" size="lg" isFull onClick={onClose}>
+          Close
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+function buildMockConnectionResult(): DeviceConnectionResult {
+  const sessionId = "debug-session-id";
+
+  return {
+    dmk: {
+      getDeviceSessionState: () => EMPTY,
+    } as unknown as DeviceConnectionResult["dmk"],
+    sessionId,
+    connectedDevice: {
+      id: "debug-device-id",
+      name: "Ledger Flex Debug",
+      modelId: "FLEX",
+      sessionId,
+      type: "USB",
+      transport: "web-hid",
+    } as unknown as DeviceConnectionResult["connectedDevice"],
+    compatDeviceId: "debug-device-id",
+    compatDeviceModelId: DeviceModelId.europa,
+    compatDeviceName: "Ledger Flex Debug",
+    compatDeviceWired: true,
+  };
+}
+
+export default DeviceConnectionComponentLWD;

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/index.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import type {
+  DeviceConnectionResult,
+  DeviceContextInitializerComponent,
+  DeviceExtractedContext,
+} from "@ledgerhq/device-intent";
+import type { EnsureAppReadyUseCaseDependencies } from "@ledgerhq/live-common/device/use-cases/ensureAppReady/ensureAppReadyUseCase";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import type { InitializationInput } from "../types";
+
+export type InitializerConfig =
+  | {
+      dependencies?: Partial<EnsureAppReadyUseCaseDependencies>;
+    }
+  | undefined;
+
+function formatParams(params: unknown): string {
+  return JSON.stringify(params, null, 2) ?? "";
+}
+
+const DeviceContextInitializerComponentLWD: DeviceContextInitializerComponent<
+  InitializationInput,
+  InitializerConfig
+> = ({ connectionResult, deviceInitializationInput, onContextInitialized, onClose }) => {
+  const simulateInitialized = () => {
+    onContextInitialized(buildMockDeviceContext(deviceInitializationInput));
+  };
+
+  return (
+    <div
+      className="flex w-full flex-col gap-24 px-16 py-24"
+      data-testid="device-intent-executor-device-context-initializer-placeholder"
+    >
+      <div className="flex flex-col gap-8 text-center">
+        <h3 className="heading-4-semi-bold text-base">Device context initializer placeholder</h3>
+        <p className="body-2 text-muted">
+          The desktop device initializer implementation is pending.
+        </p>
+      </div>
+      <DebugSection title="Connected device" value={buildConnectionSummary(connectionResult)} />
+      <DebugSection title="Initialization input" value={deviceInitializationInput} />
+      <div className="flex w-full flex-col gap-12">
+        <Button appearance="base" size="lg" isFull onClick={simulateInitialized}>
+          Simulate initialized context
+        </Button>
+        <Button appearance="gray" size="lg" isFull onClick={onClose}>
+          Close
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+function DebugSection({ title, value }: Readonly<{ title: string; value: unknown }>) {
+  return (
+    <div className="flex flex-col gap-8">
+      <span className="body-2-semi-bold text-base">{title}</span>
+      <pre className="max-h-[240px] overflow-auto rounded-md bg-muted p-12 text-left font-mono text-xs text-base">
+        {formatParams(value)}
+      </pre>
+    </div>
+  );
+}
+
+function buildConnectionSummary(connectionResult: DeviceConnectionResult) {
+  return {
+    sessionId: connectionResult.sessionId,
+    compatDeviceId: connectionResult.compatDeviceId,
+    compatDeviceModelId: connectionResult.compatDeviceModelId,
+    compatDeviceName: connectionResult.compatDeviceName,
+    compatDeviceWired: connectionResult.compatDeviceWired,
+    connectedDevice: {
+      id: connectionResult.connectedDevice.id,
+      name: connectionResult.connectedDevice.name,
+      modelId: connectionResult.connectedDevice.modelId,
+      sessionId: connectionResult.connectedDevice.sessionId,
+      type: connectionResult.connectedDevice.type,
+      transport: connectionResult.connectedDevice.transport,
+    },
+  };
+}
+
+function buildMockDeviceContext(
+  deviceInitializationInput: InitializationInput,
+): DeviceExtractedContext {
+  return {
+    currentOsVersion: "2.2.0",
+    osUpdateAvailable: false,
+    currentAppName: deviceInitializationInput.appName,
+    currentAppVersion: "1.0.0-debug",
+    derivedAddress: deviceInitializationInput.requiresDerivation
+      ? "0x0000000000000000000000000000000000000000"
+      : undefined,
+  };
+}
+
+export default DeviceContextInitializerComponentLWD;

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/utils/buildDeviceInitializationInput.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/utils/buildDeviceInitializationInput.ts
@@ -1,0 +1,24 @@
+import {
+  buildEnsureAppReadyInput,
+  type BuildEnsureAppReadyInputParams,
+} from "@ledgerhq/live-common/device/use-cases/ensureAppReady/buildEnsureAppReadyInput";
+import type { InitializationInput } from "../../types";
+
+export type BuildDeviceInitializationInputParams = BuildEnsureAppReadyInputParams;
+
+/**
+ * Build the `deviceInitializationInput` consumed by the LWD
+ * `DeviceIntentExecutor` from an `AppRequest`.
+ *
+ * Canonical translation from the rich `AppRequest` shape (account, currency,
+ * dependencies, ...) that flows already build for the legacy `connectApp`
+ * device-action into the structured input the executor needs to drive
+ * Phase 2 (device context initialisation).
+ *
+ * @see buildEnsureAppReadyInput - underlying implementation.
+ */
+export function buildDeviceInitializationInput(
+  params: BuildDeviceInitializationInputParams,
+): Promise<InitializationInput> {
+  return buildEnsureAppReadyInput(params);
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceDisconnected.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceDisconnected.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import type { DeviceDisconnectedComponent } from "@ledgerhq/device-intent";
+import { InfoState } from "LLD/components/InfoState";
+
+export const DeviceDisconnected: DeviceDisconnectedComponent = ({ onRetry, onClose }) => {
+  const { t } = useTranslation();
+
+  return (
+    <InfoState
+      preset="error"
+      size="hug"
+      title={t("deviceIntentExecutor.errors.connectionError.title")}
+      description={t("deviceIntentExecutor.errors.connectionError.description")}
+      primaryCta={{
+        label: t("common.retry"),
+        onPress: onRetry,
+      }}
+      secondaryCta={{
+        label: t("common.close"),
+        onPress: onClose,
+      }}
+      testID="device-intent-executor-device-disconnected"
+    />
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { getDeviceModel } from "@ledgerhq/devices";
+import type { DeviceModelId } from "@ledgerhq/types-devices";
+import { DeviceActionContent } from "LLD/components/DeviceActionContent";
+
+type ContinueOnDeviceProps = Readonly<{
+  deviceModelId: DeviceModelId;
+  deviceName: string;
+  testID?: string;
+}>;
+
+export function ContinueOnDevice({ deviceModelId, deviceName, testID }: ContinueOnDeviceProps) {
+  const { t } = useTranslation();
+  const { productName } = getDeviceModel(deviceModelId);
+
+  return (
+    <DeviceActionContent
+      action="continue"
+      deviceModelId={deviceModelId}
+      deviceName={deviceName}
+      title={t("deviceIntentExecutor.genericStates.continueOnDevice.title", { productName })}
+      description={t("deviceIntentExecutor.genericStates.continueOnDevice.description")}
+      testID={testID}
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceGenericStates/RetryableDeviceLocked.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceGenericStates/RetryableDeviceLocked.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { getDeviceModel } from "@ledgerhq/devices";
+import type { DeviceModelId } from "@ledgerhq/types-devices";
+import { InfoState } from "LLD/components/InfoState";
+
+type RetryableDeviceLockedProps = Readonly<{
+  deviceModelId: DeviceModelId;
+  onRetry: () => void;
+  testID?: string;
+}>;
+
+export function RetryableDeviceLocked({
+  deviceModelId,
+  onRetry,
+  testID,
+}: RetryableDeviceLockedProps) {
+  const { t } = useTranslation();
+  const { productName } = getDeviceModel(deviceModelId);
+
+  return (
+    <InfoState
+      preset="info"
+      size="hug"
+      title={t("deviceIntentExecutor.genericStates.retryableDeviceLocked.title", { productName })}
+      description={t("deviceIntentExecutor.genericStates.retryableDeviceLocked.description", {
+        productName,
+      })}
+      primaryCta={{
+        label: t("common.retry"),
+        onPress: onRetry,
+      }}
+      testID={testID}
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceGenericStates/UnlockDevice.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceGenericStates/UnlockDevice.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { getDeviceModel } from "@ledgerhq/devices";
+import type { DeviceModelId } from "@ledgerhq/types-devices";
+import { DeviceActionContent } from "LLD/components/DeviceActionContent";
+
+type UnlockDeviceProps = Readonly<{
+  deviceModelId: DeviceModelId;
+  deviceName: string;
+  testID?: string;
+}>;
+
+export function UnlockDevice({ deviceModelId, deviceName, testID }: UnlockDeviceProps) {
+  const { t } = useTranslation();
+  const { productName } = getDeviceModel(deviceModelId);
+
+  return (
+    <DeviceActionContent
+      action="power-and-unlock"
+      deviceModelId={deviceModelId}
+      deviceName={deviceName}
+      title={t("deviceIntentExecutor.genericStates.unlockDevice.title", { productName })}
+      testID={testID}
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/IntentError.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/IntentError.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import type { ErrorComponent } from "@ledgerhq/device-intent";
+import { isDmkError } from "@ledgerhq/live-dmk-desktop";
+import TranslatedError from "~/renderer/components/TranslatedError";
+import { InfoState } from "LLD/components/InfoState";
+
+const devBanner = __DEV__
+  ? ({
+      title: "Developer note",
+      description:
+        "The current intent let an error escape its job observable. " +
+        "Handle errors inside the intent's job so this generic fallback is not shown.",
+      appearance: "warning",
+    } as const)
+  : undefined;
+
+export const IntentError: ErrorComponent = ({ onRetry, onClose, error }) => {
+  const { t } = useTranslation();
+  const errorIsTranslatable = error && (isDmkError(error) || error instanceof Error);
+  const translatedError = error as Error;
+
+  return (
+    <InfoState
+      preset="error"
+      size="hug"
+      title={
+        errorIsTranslatable ? (
+          <TranslatedError error={translatedError} field="title" />
+        ) : (
+          t("deviceIntentExecutor.errors.intentError.title")
+        )
+      }
+      description={
+        errorIsTranslatable ? (
+          <TranslatedError error={translatedError} field="description" />
+        ) : (
+          t("deviceIntentExecutor.errors.intentError.description")
+        )
+      }
+      banner={devBanner}
+      primaryCta={{
+        label: t("common.retry"),
+        onPress: onRetry,
+      }}
+      secondaryCta={{
+        label: t("common.close"),
+        onPress: onClose,
+      }}
+      testID="device-intent-executor-intent-error"
+    />
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/InvalidOperation.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/InvalidOperation.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import type { InvalidOperationComponent } from "@ledgerhq/device-intent";
+import { InfoState } from "LLD/components/InfoState";
+
+const devBanner = __DEV__
+  ? ({
+      title: "Developer note",
+      description:
+        "The DeviceIntentExecutor entered an invalid state. This signals a mistake " +
+        "in how the executor is integrated by the caller (e.g. swapping intents while " +
+        "one is still running).",
+      appearance: "warning",
+    } as const)
+  : undefined;
+
+export const InvalidOperation: InvalidOperationComponent = ({ onClose }) => {
+  const { t } = useTranslation();
+
+  return (
+    <InfoState
+      preset="error"
+      size="hug"
+      title={t("deviceIntentExecutor.errors.invalidOperation.title")}
+      description={t("deviceIntentExecutor.errors.invalidOperation.description")}
+      banner={devBanner}
+      primaryCta={{
+        label: t("common.close"),
+        onPress: onClose,
+      }}
+      testID="device-intent-executor-invalid-operation"
+    />
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/index.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import {
+  DeviceIntentExecutor,
+  type DeviceIntentExecutorProps,
+  type ExecutorPlatformConfiguration,
+} from "@ledgerhq/device-intent";
+import { Dialog, DialogBody, DialogContent, DialogHeader } from "@ledgerhq/lumen-ui-react";
+import { DialogBackgroundToneProvider } from "LLD/components/DialogBackgroundGradient";
+import { DeviceDisconnected } from "./components/DeviceDisconnected";
+import { IntentError } from "./components/IntentError";
+import { InvalidOperation } from "./components/InvalidOperation";
+import DeviceConnectionComponentLWD from "./DeviceConnectionComponentLWD";
+import DeviceContextInitializerComponentLWD, {
+  InitializerConfig,
+} from "./DeviceContextInitializerComponentLWD";
+import type { InitializationInput } from "./types";
+import { useDeviceIntentExecutorLWDViewModel } from "./useDeviceIntentExecutorLWDViewModel";
+
+export {
+  buildDeviceInitializationInput,
+  type BuildDeviceInitializationInputParams,
+} from "./DeviceContextInitializerComponentLWD/utils/buildDeviceInitializationInput";
+export type { InitializationInput } from "./types";
+export { ContinueOnDevice } from "./components/DeviceGenericStates/ContinueOnDevice";
+export { RetryableDeviceLocked } from "./components/DeviceGenericStates/RetryableDeviceLocked";
+export { UnlockDevice } from "./components/DeviceGenericStates/UnlockDevice";
+
+type Props<JobState, Input, ExtraProps> = DeviceIntentExecutorProps<
+  JobState,
+  Input,
+  ExtraProps,
+  InitializationInput
+> & {
+  initializerConfig?: InitializerConfig;
+};
+
+const platformConfig: ExecutorPlatformConfiguration<InitializationInput, InitializerConfig> = {
+  DeviceConnectionComponent: DeviceConnectionComponentLWD,
+  DeviceContextInitializerComponent: DeviceContextInitializerComponentLWD,
+  DeviceDisconnectedComponent: DeviceDisconnected,
+  IntentErrorComponent: IntentError,
+  InvalidOperationComponent: InvalidOperation,
+};
+
+export function DeviceIntentExecutorLWD<JobState, Input, ExtraProps>(
+  props: Props<JobState, Input, ExtraProps>,
+): React.ReactElement | null {
+  const { wrappedProps, onOpenChange, onClose } = useDeviceIntentExecutorLWDViewModel(props);
+
+  if (!wrappedProps.enabled) return null;
+
+  return (
+    <Dialog open={wrappedProps.enabled} onOpenChange={onOpenChange} height="fit">
+      <DialogContent
+        aria-describedby={undefined}
+        className="max-h-[calc(100vh-16px)] w-[400px] overflow-hidden bg-base p-0"
+        data-testid="device-intent-executor-dialog"
+      >
+        <DialogBackgroundToneProvider>
+          <DialogHeader density="compact" onClose={onClose} />
+          <DialogBody className="relative flex min-h-0 flex-col px-24 pb-24">
+            <DeviceIntentExecutor
+              {...wrappedProps}
+              platformConfig={platformConfig}
+              initializerConfig={wrappedProps.initializerConfig}
+            />
+          </DialogBody>
+        </DialogBackgroundToneProvider>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/types.ts
@@ -1,0 +1,3 @@
+import type { EnsureAppReadyInput } from "@ledgerhq/live-common/device/use-cases/ensureAppReady/types";
+
+export type InitializationInput = EnsureAppReadyInput;

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWDViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWDViewModel.ts
@@ -1,0 +1,40 @@
+import { useCallback } from "react";
+import type { DeviceIntentExecutorProps } from "@ledgerhq/device-intent";
+import type { InitializerConfig } from "./DeviceContextInitializerComponentLWD";
+import type { InitializationInput } from "./types";
+
+type Props<JobState, Input, ExtraProps> = DeviceIntentExecutorProps<
+  JobState,
+  Input,
+  ExtraProps,
+  InitializationInput
+> & {
+  initializerConfig?: InitializerConfig;
+};
+
+export type DeviceIntentExecutorLWDViewModel<JobState, Input, ExtraProps> = {
+  wrappedProps: Props<JobState, Input, ExtraProps>;
+  onOpenChange: (open: boolean) => void;
+  onClose: () => void;
+};
+
+export function useDeviceIntentExecutorLWDViewModel<JobState, Input, ExtraProps>(
+  props: Props<JobState, Input, ExtraProps>,
+): DeviceIntentExecutorLWDViewModel<JobState, Input, ExtraProps> {
+  const { onUserCancel } = props;
+
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onUserCancel();
+      }
+    },
+    [onUserCancel],
+  );
+
+  return {
+    wrappedProps: props,
+    onOpenChange,
+    onClose: onUserCancel,
+  };
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceIntentExecutorDevTool/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceIntentExecutorDevTool/index.tsx
@@ -1,0 +1,26 @@
+import React, { useCallback } from "react";
+import { useNavigate } from "react-router";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import { SettingsSectionRow } from "~/renderer/screens/settings/SettingsSection";
+
+const COPY = {
+  rowTitle: "Device Intent Executor playground",
+  rowDesc:
+    "Open a screen to test the desktop Device Intent Executor dialog orchestration and initialization scenarios.",
+  open: "Open",
+} as const;
+
+export default function DeviceIntentExecutorDevTool() {
+  const navigate = useNavigate();
+  const onOpen = useCallback(() => {
+    navigate("/settings/developer/device-intent-executor-qa");
+  }, [navigate]);
+
+  return (
+    <SettingsSectionRow title={COPY.rowTitle} desc={COPY.rowDesc}>
+      <Button size="sm" appearance="accent" onClick={onOpen}>
+        {COPY.open}
+      </Button>
+    </SettingsSectionRow>
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceIntentExecutorDevTool/initializationScenarios.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceIntentExecutorDevTool/initializationScenarios.ts
@@ -1,0 +1,252 @@
+import { FlowName } from "@ledgerhq/live-common/device-action/utils";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import type { InitializerConfig } from "LLD/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD";
+import type { InitializationInput } from "LLD/components/DeviceIntentExecutor";
+
+export type InitializationScenario = {
+  id: string;
+  title: string;
+  description: string;
+  input: InitializationInput;
+  inputSummary: string;
+  initializerConfig?: InitializerConfig;
+  initializerConfigSummary: string;
+};
+
+const ETHEREUM_INPUT_SUMMARY = "Opens Ethereum, derives 44'/60'/0'/0/0.";
+const ETHEREUM_DEPRECATION_INPUT_SUMMARY =
+  "Opens Ethereum, derives 44'/60'/0'/0/0, signals deprecation flow=send / currency=Ethereum.";
+const BITCOIN_INPUT_SUMMARY = "Opens Bitcoin, derives native segwit 84'/0'/0'/0/0.";
+const NO_INITIALIZER_OVERRIDES_SUMMARY =
+  "No overrides - uses real production dependencies (remote config etc. not overridden).";
+
+const BOLOS_INPUT: InitializationInput = {
+  appName: "BOLOS",
+  dependencies: [],
+  requireLatestFirmware: false,
+  allowPartialDependencies: false,
+};
+
+const ETHEREUM_INPUT: InitializationInput = {
+  appName: "Ethereum",
+  dependencies: [],
+  requireLatestFirmware: false,
+  allowPartialDependencies: false,
+  requiresDerivation: {
+    currencyId: "ethereum",
+    path: "44'/60'/0'/0/0",
+    derivationMode: "ethM",
+    forceFormat: "eip55",
+  },
+};
+
+const BITCOIN_INPUT: InitializationInput = {
+  appName: "Bitcoin",
+  dependencies: [],
+  requireLatestFirmware: false,
+  allowPartialDependencies: false,
+  requiresDerivation: {
+    currencyId: "bitcoin",
+    path: "84'/0'/0'/0/0",
+    derivationMode: "native_segwit",
+  },
+};
+
+const PAST_DATE = "2000-01-01T00:00:00.000Z";
+const FUTURE_DATE = "2999-01-01T00:00:00.000Z";
+
+const deprecatedDeviceModels = [
+  DeviceModelId.nanoS,
+  DeviceModelId.nanoSP,
+  DeviceModelId.nanoX,
+  DeviceModelId.stax,
+  DeviceModelId.europa,
+  DeviceModelId.apex,
+];
+
+type ScreenTrigger = {
+  date: typeof PAST_DATE | typeof FUTURE_DATE;
+  deprecatedFlow: FlowName[];
+};
+
+function buildEthereumSendDeprecationConfig(params: {
+  warningScreen: ScreenTrigger;
+  warningClearSigningScreen: ScreenTrigger;
+  errorScreen: ScreenTrigger;
+}) {
+  return () =>
+    deprecatedDeviceModels.map(deviceModelId => ({
+      deviceModelId,
+      warningScreen: { ...params.warningScreen, exception: [] },
+      warningClearSigningScreen: { ...params.warningClearSigningScreen, exception: [] },
+      errorScreen: { ...params.errorScreen, exception: [] },
+    }));
+}
+
+const ETHEREUM_SEND_DEPRECATION: NonNullable<InitializationInput["deprecation"]> = {
+  flow: FlowName.send,
+  currencyName: "Ethereum",
+};
+
+export const INITIALIZATION_SCENARIOS: InitializationScenario[] = [
+  {
+    id: "bolos-dashboard",
+    title: "BOLOS dashboard",
+    description:
+      "Opens the dashboard without derivation.\nExpect a successful context with no derivedAddress.",
+    input: BOLOS_INPUT,
+    inputSummary: "Opens the BOLOS dashboard, no derivation.",
+    initializerConfigSummary: NO_INITIALIZER_OVERRIDES_SUMMARY,
+  },
+  {
+    id: "ethereum-derivation",
+    title: "Ethereum derivation",
+    description:
+      "Opens Ethereum and derives 44'/60'/0'/0/0.\nExpect derivedAddress to be populated.",
+    input: ETHEREUM_INPUT,
+    inputSummary: ETHEREUM_INPUT_SUMMARY,
+    initializerConfigSummary: NO_INITIALIZER_OVERRIDES_SUMMARY,
+  },
+  {
+    id: "bitcoin-derivation",
+    title: "Bitcoin derivation",
+    description:
+      "Opens Bitcoin and derives native segwit 84'/0'/0'/0/0.\nExpect derivedAddress to be populated.",
+    input: BITCOIN_INPUT,
+    inputSummary: BITCOIN_INPUT_SUMMARY,
+    initializerConfigSummary: NO_INITIALIZER_OVERRIDES_SUMMARY,
+  },
+  {
+    id: "bitcoin-should-upgrade",
+    title: "Bitcoin forced should-upgrade",
+    description:
+      "Injects shouldUpgrade() returning true for Bitcoin to exercise the app upgrade flow.\nIn production, shouldUpgrade only returns true for Bitcoin-family apps with a version below 1.4.0.",
+    input: BITCOIN_INPUT,
+    inputSummary: BITCOIN_INPUT_SUMMARY,
+    initializerConfig: {
+      dependencies: {
+        shouldUpgrade: () => true,
+      },
+    },
+    initializerConfigSummary:
+      "shouldUpgrade() returns true - in prod this only triggers for Bitcoin-family apps below 1.4.0 (LSB-010).",
+  },
+  {
+    id: "ethereum-forced-min-app",
+    title: "Ethereum forced min app",
+    description:
+      "Injects a high Ethereum min version to exercise app version handling and install/update states.",
+    input: ETHEREUM_INPUT,
+    inputSummary: ETHEREUM_INPUT_SUMMARY,
+    initializerConfig: {
+      dependencies: {
+        getMinVersion: () => "99.99.99",
+      },
+    },
+    initializerConfigSummary: "getMinVersion() returns 99.99.99 (forces install/update).",
+  },
+  {
+    id: "ethereum-deprecation-warning",
+    title: "Ethereum deprecation warning",
+    description:
+      "Injects a past warning deprecation config for Ethereum send.\nExpect a deprecation warning UI before the echo intent runs.",
+    input: {
+      ...ETHEREUM_INPUT,
+      deprecation: ETHEREUM_SEND_DEPRECATION,
+    },
+    inputSummary: ETHEREUM_DEPRECATION_INPUT_SUMMARY,
+    initializerConfig: {
+      dependencies: {
+        getDeprecationConfig: buildEthereumSendDeprecationConfig({
+          warningScreen: { date: PAST_DATE, deprecatedFlow: [FlowName.send] },
+          warningClearSigningScreen: { date: FUTURE_DATE, deprecatedFlow: [] },
+          errorScreen: { date: FUTURE_DATE, deprecatedFlow: [] },
+        }),
+      },
+    },
+    initializerConfigSummary:
+      "getDeprecationConfig returns a past warning screen for Ethereum send on all supported models.",
+  },
+  {
+    id: "ethereum-deprecation-clear-signing",
+    title: "Ethereum deprecation clear-signing warning",
+    description:
+      "Injects a past clear-signing deprecation config for Ethereum send.\nExpect a clear-signing warning UI before the echo intent runs.",
+    input: {
+      ...ETHEREUM_INPUT,
+      deprecation: ETHEREUM_SEND_DEPRECATION,
+    },
+    inputSummary: ETHEREUM_DEPRECATION_INPUT_SUMMARY,
+    initializerConfig: {
+      dependencies: {
+        getDeprecationConfig: buildEthereumSendDeprecationConfig({
+          warningScreen: { date: FUTURE_DATE, deprecatedFlow: [] },
+          warningClearSigningScreen: { date: PAST_DATE, deprecatedFlow: [FlowName.send] },
+          errorScreen: { date: FUTURE_DATE, deprecatedFlow: [] },
+        }),
+      },
+    },
+    initializerConfigSummary:
+      "getDeprecationConfig returns a past clear-signing screen for Ethereum send on all supported models.",
+  },
+  {
+    id: "ethereum-deprecation-warning-and-clear-signing",
+    title: "Ethereum deprecation warning + clear-signing",
+    description:
+      "Injects past warning and clear-signing deprecation configs for Ethereum send.\nExpect the warning UI followed by the clear-signing UI before the echo intent runs.",
+    input: {
+      ...ETHEREUM_INPUT,
+      deprecation: ETHEREUM_SEND_DEPRECATION,
+    },
+    inputSummary: ETHEREUM_DEPRECATION_INPUT_SUMMARY,
+    initializerConfig: {
+      dependencies: {
+        getDeprecationConfig: buildEthereumSendDeprecationConfig({
+          warningScreen: { date: PAST_DATE, deprecatedFlow: [FlowName.send] },
+          warningClearSigningScreen: { date: PAST_DATE, deprecatedFlow: [FlowName.send] },
+          errorScreen: { date: FUTURE_DATE, deprecatedFlow: [] },
+        }),
+      },
+    },
+    initializerConfigSummary:
+      "getDeprecationConfig returns past warning and clear-signing screens for Ethereum send on all supported models.",
+  },
+  {
+    id: "ethereum-deprecation-blocking",
+    title: "Ethereum deprecation blocking",
+    description:
+      "Injects a past blocking deprecation config for Ethereum send.\nExpect the device deprecation error screen and no echo intent.",
+    input: {
+      ...ETHEREUM_INPUT,
+      deprecation: ETHEREUM_SEND_DEPRECATION,
+    },
+    inputSummary: ETHEREUM_DEPRECATION_INPUT_SUMMARY,
+    initializerConfig: {
+      dependencies: {
+        getDeprecationConfig: buildEthereumSendDeprecationConfig({
+          warningScreen: { date: FUTURE_DATE, deprecatedFlow: [] },
+          warningClearSigningScreen: { date: FUTURE_DATE, deprecatedFlow: [] },
+          errorScreen: { date: PAST_DATE, deprecatedFlow: [FlowName.send] },
+        }),
+      },
+    },
+    initializerConfigSummary:
+      "getDeprecationConfig returns a past blocking error screen for Ethereum send on all supported models.",
+  },
+  {
+    id: "ethereum-wrong-account",
+    title: "Ethereum wrong account",
+    description:
+      "Requests an Ethereum derivation but expects an impossible address. This address is impossible so it cannot match the derived address.\nExpect a wrong-device / wrong-account mismatch.",
+    input: {
+      ...ETHEREUM_INPUT,
+      expectedAccount: {
+        accountName: "Impossible Ethereum Account",
+        acceptableDerivedAddresses: ["0ximpossibleaddress"],
+      },
+    },
+    inputSummary:
+      "Opens Ethereum, derives 44'/60'/0'/0/0, expects account \"Impossible Ethereum Account\" with acceptable address 0ximpossibleaddress.",
+    initializerConfigSummary: NO_INITIALIZER_OVERRIDES_SUMMARY,
+  },
+];

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceIntentExecutorDevTool/intents/initializationEchoIntent/componentLWD.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceIntentExecutorDevTool/intents/initializationEchoIntent/componentLWD.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import type { InitializationEchoIntentJobState } from "./types";
+
+export function InitializationEchoIntentComponentLWD({
+  jobState,
+}: Readonly<{
+  jobState: InitializationEchoIntentJobState | undefined;
+  extraProps: Record<string, never>;
+  onClose: () => void;
+}>) {
+  return (
+    <div className="flex w-full flex-col gap-16 px-16 py-24">
+      <h3 className="heading-4-semi-bold text-center text-base">Initialization Echo</h3>
+      {jobState?.type === "contextReceived" ? (
+        <div className="flex flex-col gap-8">
+          <span className="body-2 text-muted">Device context received by the intent job:</span>
+          <pre className="max-h-[260px] overflow-auto rounded-md bg-muted p-12 text-xs text-base">
+            {JSON.stringify(jobState.deviceExtractedContext, null, 2)}
+          </pre>
+        </div>
+      ) : (
+        <p className="body-2 text-muted text-center">Waiting for initialization to complete...</p>
+      )}
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceIntentExecutorDevTool/intents/initializationEchoIntent/intentDefinition.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceIntentExecutorDevTool/intents/initializationEchoIntent/intentDefinition.ts
@@ -1,0 +1,9 @@
+import { type InitializationEchoIntentDefinition } from "./types";
+import { initializationEchoIntentJob } from "./job";
+
+export const initializationEchoIntentDefinition: InitializationEchoIntentDefinition = {
+  label: "Initialization Echo",
+  requiresConnectedDevice: true,
+  delegateDeviceLockStateHandlingToExecutor: false,
+  job: initializationEchoIntentJob,
+};

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceIntentExecutorDevTool/intents/initializationEchoIntent/intentLWDDefinition.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceIntentExecutorDevTool/intents/initializationEchoIntent/intentLWDDefinition.ts
@@ -1,0 +1,8 @@
+import { InitializationEchoIntentComponentLWD } from "./componentLWD";
+import { initializationEchoIntentDefinition } from "./intentDefinition";
+import { type InitializationEchoIntentPlatformDefinition } from "./types";
+
+export const initializationEchoIntentLWDDefinition: InitializationEchoIntentPlatformDefinition = {
+  ...initializationEchoIntentDefinition,
+  component: InitializationEchoIntentComponentLWD,
+};

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceIntentExecutorDevTool/intents/initializationEchoIntent/job.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceIntentExecutorDevTool/intents/initializationEchoIntent/job.ts
@@ -1,0 +1,12 @@
+import { of, type Observable } from "rxjs";
+import type { Job } from "@ledgerhq/device-intent";
+import type { InitializationEchoIntentInput, InitializationEchoIntentJobState } from "./types";
+
+export const initializationEchoIntentJob: Job<
+  InitializationEchoIntentJobState,
+  InitializationEchoIntentInput
+> = ({ deviceExtractedContext }): Observable<InitializationEchoIntentJobState> =>
+  of({
+    type: "contextReceived",
+    deviceExtractedContext,
+  });

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceIntentExecutorDevTool/intents/initializationEchoIntent/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceIntentExecutorDevTool/intents/initializationEchoIntent/types.ts
@@ -1,0 +1,25 @@
+import type {
+  DeviceExtractedContext,
+  IntentDefinition,
+  IntentPlatformDefinition,
+} from "@ledgerhq/device-intent";
+
+export type InitializationEchoIntentJobState = {
+  type: "contextReceived";
+  deviceExtractedContext: DeviceExtractedContext;
+};
+
+export type InitializationEchoIntentInput = undefined;
+
+type InitializationEchoIntentExtraProps = Record<string, never>;
+
+export type InitializationEchoIntentDefinition = IntentDefinition<
+  InitializationEchoIntentJobState,
+  InitializationEchoIntentInput
+>;
+
+export type InitializationEchoIntentPlatformDefinition = IntentPlatformDefinition<
+  InitializationEchoIntentJobState,
+  InitializationEchoIntentInput,
+  InitializationEchoIntentExtraProps
+>;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceIntentExecutorDevTool/screens/DeviceIntentExecutorDevScreen/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceIntentExecutorDevTool/screens/DeviceIntentExecutorDevScreen/index.tsx
@@ -1,0 +1,271 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import {
+  createIntent,
+  type DeviceConnectionParams,
+  type DeviceIntentExecutorProps,
+  type ExecutorState,
+} from "@ledgerhq/device-intent";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import { ArrowLeft } from "@ledgerhq/lumen-ui-react/symbols";
+import {
+  DeviceIntentExecutorLWD,
+  type InitializationInput,
+} from "LLD/components/DeviceIntentExecutor";
+import type { InitializerConfig } from "LLD/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD";
+import { INITIALIZATION_SCENARIOS } from "../../initializationScenarios";
+import { initializationEchoIntentLWDDefinition } from "../../intents/initializationEchoIntent/intentLWDDefinition";
+import type {
+  InitializationEchoIntentInput,
+  InitializationEchoIntentJobState,
+} from "../../intents/initializationEchoIntent/types";
+
+type InitializationExecutorProps = DeviceIntentExecutorProps<
+  InitializationEchoIntentJobState,
+  InitializationEchoIntentInput,
+  Record<string, never>,
+  InitializationInput
+> & {
+  initializerConfig?: InitializerConfig;
+};
+
+const DEFAULT_CONNECTION_PARAMS: DeviceConnectionParams = {
+  acceptedDeviceModelIds: [],
+};
+
+const initializationIntent = createIntent(initializationEchoIntentLWDDefinition, undefined);
+
+export default function DeviceIntentExecutorDevScreen() {
+  const navigate = useNavigate();
+
+  return (
+    <div
+      className="flex min-h-0 flex-1 flex-col p-8 pb-16"
+      data-testid="device-intent-executor-dev-screen"
+    >
+      <header className="mb-14 grid grid-cols-[1fr_auto_1fr] items-center gap-x-3 py-6">
+        <div className="flex min-w-0 justify-start">
+          <Button
+            size="sm"
+            appearance="no-background"
+            onClick={() => navigate("/settings/developer")}
+            icon={ArrowLeft}
+          >
+            Back
+          </Button>
+        </div>
+        <span className="heading-2-semi-bold max-w-[min(100vw-8rem,34rem)] text-center text-base">
+          Device Intent Executor playground
+        </span>
+        <div aria-hidden className="min-w-0" />
+      </header>
+
+      <main className="mx-auto flex w-full max-w-4xl flex-col gap-16 px-4">
+        <p className="body-2 text-muted">
+          Exercises the desktop Device Intent Executor dialog. Use the dialog&apos;s placeholder
+          buttons to simulate connection and initialization while the real LWD platform components
+          are still being implemented.
+        </p>
+
+        <InitializationMode />
+      </main>
+    </div>
+  );
+}
+
+function InitializationMode() {
+  const [selectedScenarioId, setSelectedScenarioId] = useState(INITIALIZATION_SCENARIOS[0].id);
+  const [enabled, setEnabled] = useState(false);
+  const [executorState, setExecutorState] = useState<ExecutorState | null>(null);
+  const [latestJobState, setLatestJobState] = useState<InitializationEchoIntentJobState | null>(
+    null,
+  );
+  const [jobCompleted, setJobCompleted] = useState(false);
+  const [jobError, setJobError] = useState<unknown>(null);
+
+  const selectedScenario =
+    INITIALIZATION_SCENARIOS.find(scenario => scenario.id === selectedScenarioId) ??
+    INITIALIZATION_SCENARIOS[0];
+
+  const resetRunState = useCallback(() => {
+    setExecutorState(null);
+    setLatestJobState(null);
+    setJobCompleted(false);
+    setJobError(null);
+  }, []);
+
+  const handleUserCancel = useCallback(() => {
+    setEnabled(false);
+    setExecutorState(null);
+  }, []);
+
+  const executorProps = useMemo<InitializationExecutorProps>(
+    () => ({
+      enabled: true,
+      deviceConnectionParams: DEFAULT_CONNECTION_PARAMS,
+      deviceInitializationInput: selectedScenario.input,
+      initializerConfig: selectedScenario.initializerConfig,
+      intent: initializationIntent,
+      intentComponentExtraProps: {},
+      onExecutorStateChanged: setExecutorState,
+      onIntentJobStateChanged: setLatestJobState,
+      onIntentJobComplete: () => {
+        setJobCompleted(true);
+      },
+      onIntentJobError: (error: unknown) => {
+        setJobError(error);
+      },
+      cancelIntentRequestId: undefined,
+      onUserCancel: handleUserCancel,
+    }),
+    [handleUserCancel, selectedScenario],
+  );
+
+  const selectScenario = useCallback(
+    (scenarioId: string) => {
+      if (enabled) return;
+      setSelectedScenarioId(scenarioId);
+      resetRunState();
+    },
+    [enabled, resetRunState],
+  );
+
+  const start = useCallback(() => {
+    resetRunState();
+    setEnabled(true);
+  }, [resetRunState]);
+
+  const stop = useCallback(() => {
+    setEnabled(false);
+    setExecutorState(null);
+  }, []);
+
+  return (
+    <>
+      <section className="flex w-full flex-col gap-16 rounded-lg bg-surface p-16">
+        <h2 className="body-2-semi-bold text-base">Initialization mode</h2>
+        <p className="body-2 text-muted">
+          Mirrors the mobile initialization playground with the same scenario inputs. The current
+          LWD initializer placeholder displays these params and lets you simulate the extracted
+          context.
+        </p>
+
+        <StateCard>
+          <StateRow label="Selected scenario" value={selectedScenario.title} />
+          <StateRow label="Executor" value={executorState?.type ?? "-"} />
+          <StateRow label="Job completed" value={jobCompleted ? "YES" : "no"} />
+          <StateRow label="Job error" value={formatError(jobError)} />
+        </StateCard>
+
+        <SummaryBox label="Input" value={selectedScenario.inputSummary} />
+        <SummaryBox label="Initializer config" value={selectedScenario.initializerConfigSummary} />
+
+        <SettingSection title="Scenarios">
+          {INITIALIZATION_SCENARIOS.map(scenario => (
+            <ChoiceButton
+              key={scenario.id}
+              label={scenario.title}
+              selected={scenario.id === selectedScenario.id}
+              disabled={enabled}
+              onPress={() => selectScenario(scenario.id)}
+            />
+          ))}
+        </SettingSection>
+
+        <RawDetails title="Raw initialization input" value={selectedScenario.input} />
+
+        {latestJobState ? (
+          <RawDetails title="Latest echo job state" value={latestJobState} />
+        ) : null}
+
+        <Button appearance={enabled ? "red" : "base"} size="lg" onClick={enabled ? stop : start}>
+          {enabled ? "Stop initialization" : "Start initialization"}
+        </Button>
+      </section>
+
+      {enabled ? <DeviceIntentExecutorLWD {...executorProps} /> : null}
+    </>
+  );
+}
+
+function StateCard({ children }: Readonly<{ children: React.ReactNode }>) {
+  return <div className="flex flex-col gap-8 rounded-md bg-muted p-12">{children}</div>;
+}
+
+function StateRow({ label, value }: Readonly<{ label: string; value: string }>) {
+  return (
+    <div className="flex flex-row justify-between gap-16">
+      <span className="body-2 text-muted">{label}</span>
+      <span className="body-2-semi-bold min-w-0 break-words text-right text-base">{value}</span>
+    </div>
+  );
+}
+
+function SettingSection({
+  title,
+  children,
+}: Readonly<{
+  title: string;
+  children: React.ReactNode;
+}>) {
+  return (
+    <div className="flex flex-col gap-8">
+      <span className="body-2 text-muted">{title}</span>
+      <div className="flex flex-row flex-wrap items-center gap-8">{children}</div>
+    </div>
+  );
+}
+
+function ChoiceButton({
+  label,
+  selected,
+  disabled,
+  onPress,
+}: Readonly<{
+  label: string;
+  selected: boolean;
+  disabled?: boolean;
+  onPress: () => void;
+}>) {
+  return (
+    <Button appearance={selected ? "base" : "gray"} size="sm" disabled={disabled} onClick={onPress}>
+      {label}
+    </Button>
+  );
+}
+
+function SummaryBox({ label, value }: Readonly<{ label: string; value: string }>) {
+  return (
+    <div className="flex flex-col gap-4 rounded-md bg-muted p-12">
+      <span className="body-2-semi-bold text-base">{label}</span>
+      <span className="body-2 text-muted whitespace-pre-line">{value}</span>
+    </div>
+  );
+}
+
+function RawDetails({ title, value }: Readonly<{ title: string; value: unknown }>) {
+  return (
+    <div className="flex flex-col gap-8">
+      <span className="body-2 text-muted">{title}</span>
+      <pre className="max-h-[260px] overflow-auto rounded-md bg-muted p-12 text-xs text-base">
+        {formatJson(value)}
+      </pre>
+    </div>
+  );
+}
+
+function formatJson(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value, null, 2) ?? "";
+}
+
+function formatError(error: unknown): string {
+  if (!error) return "-";
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error) ?? "Unknown error";
+  } catch {
+    return "Unknown error";
+  }
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/index.tsx
@@ -46,6 +46,8 @@ import InfoStateDevTool from "./InfoStateDevTool";
 import InfoStateDevScreen from "./InfoStateDevTool/screens/InfoStateDevScreen";
 import DeviceActionContentDevTool from "./DeviceActionContentDevTool";
 import DeviceActionContentDevScreen from "./DeviceActionContentDevTool/screens/DeviceActionContentDevScreen";
+import DeviceIntentExecutorDevTool from "./DeviceIntentExecutorDevTool";
+import DeviceIntentExecutorDevScreen from "./DeviceIntentExecutorDevTool/screens/DeviceIntentExecutorDevScreen";
 
 const Default = () => {
   const { t } = useTranslation();
@@ -153,6 +155,7 @@ const Default = () => {
       <GenericAwarenessModalDevTool />
       <InfoStateDevTool />
       <DeviceActionContentDevTool />
+      <DeviceIntentExecutorDevTool />
       <ModularDrawerDevTool />
       <CryptoAssetsListDevTool />
       <MockAccountGeneratorSection />
@@ -169,6 +172,7 @@ const SectionDeveloper = () => (
       <Route path="generic-awareness-modal-qa" element={<GenericAwarenessModalDevScreen />} />
       <Route path="info-state-qa" element={<InfoStateDevScreen />} />
       <Route path="device-action-content-qa" element={<DeviceActionContentDevScreen />} />
+      <Route path="device-intent-executor-qa" element={<DeviceIntentExecutorDevScreen />} />
       <Route path="*" element={<Default />} />
     </Routes>
   </>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9376,7 +9376,7 @@
       },
       "continueOnDevice": {
         "title": "Continue on your {{productName}}",
-        "description": "Follow the instructions displayed on your Secure Screen"
+        "description": "Follow the instructions displayed on your Secure Screen."
       }
     },
     "errors": {

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9365,6 +9365,35 @@
       "earnBannerAction": "Go to Earn"
     }
   },
+  "deviceIntentExecutor": {
+    "genericStates": {
+      "retryableDeviceLocked": {
+        "title": "Device is locked",
+        "description": "Unlock your device to continue."
+      },
+      "unlockDevice": {
+        "title": "Unlock your {{productName}}"
+      },
+      "continueOnDevice": {
+        "title": "Continue on your {{productName}}",
+        "description": "Follow the instructions displayed on your Secure Screen"
+      }
+    },
+    "errors": {
+      "connectionError": {
+        "title": "Device disconnected",
+        "description": "Your Ledger is no longer connected. Make sure it's powered on and plugged in."
+      },
+      "intentError": {
+        "title": "Unknown error",
+        "description": "An error occurred. Please try again or contact Ledger support if the issue persists."
+      },
+      "invalidOperation": {
+        "title": "Invalid state",
+        "description": "An error occurred. Please try again or contact Ledger support if the issue persists."
+      }
+    }
+  },
   "pnl": {
     "asset": {
       "entry": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -955,6 +955,9 @@ importers:
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
+      '@ledgerhq/device-intent':
+        specifier: workspace:^
+        version: link:../../libs/device-intent
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../libs/ledgerjs/packages/devices


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Partially: focused component tests, focused lint/format checks, and `pnpm desktop typecheck` passed; the new developer playground does not yet have dedicated UI tests._
- [x] **Impact of the changes:**
  - Developer settings Device Intent Executor playground entry and initialization flow.
  - Desktop Device Intent Executor dialog rendering and placeholder connection/initialization steps.
  - Device disconnected, intent error, invalid operation, and generic device state screens.
  - English desktop strings for the new DIE states and developer tooling.

### 📝 Description

This PR bootstraps the Device Intent Executor integration for Ledger Live Desktop so desktop flows can start adopting the shared DIE component already used on mobile.

The implementation adds a desktop `DeviceIntentExecutorLWD` wrapper using a Lumen dialog, placeholder device connection and context initialization components, desktop renderers for the shared device states, and an initialization-only developer playground. The playground mirrors the mobile initialization scenarios while keeping orchestration/demo intents out of this bootstrap branch.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32999](https://ledgerhq.atlassian.net/browse/LIVE-32999)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-32999]: https://ledgerhq.atlassian.net/browse/LIVE-32999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ