### PR TITLE
test(e2e): serialize swap approve/revoke broadcasts to fix nonce race (QAA-1323)

### DIFF
--- a/e2e/desktop/playwright.config.ts
+++ b/e2e/desktop/playwright.config.ts
@@ -35,8 +35,7 @@ const config: PlaywrightTestConfig = {
     {
       // Everything else runs fully parallel (inherits the global workers + fullyParallel).
       name: "parallel",
-      // grepInvert: /@swapBroadcast/,
-      testMatch: /.*send.swap.spec.ts/,
+      grepInvert: /@swapBroadcast/,
     },
   ],
   reporter: process.env.CI

--- a/e2e/desktop/playwright.config.ts
+++ b/e2e/desktop/playwright.config.ts
@@ -23,28 +23,44 @@ const config: PlaywrightTestConfig = {
   reportSlowTests: process.env.CI ? { max: 0, threshold: 60000 } : null,
   fullyParallel: true,
   workers: "100%",
+  projects: [
+    {
+      // Specs that broadcast real approve/revoke txs all sign from the same
+      // shared EOA. Pin them to a single worker so their broadcasts never overlap and
+      // race on the account nonce. Tag the broadcasting tests with @swapBroadcast.
+      name: "swap-broadcast-serial",
+      grep: /@swapBroadcast/,
+      workers: 1,
+    },
+    {
+      // Everything else runs fully parallel (inherits the global workers + fullyParallel).
+      name: "parallel",
+      // grepInvert: /@swapBroadcast/,
+      testMatch: /.*send.swap.spec.ts/,
+    },
+  ],
   reporter: process.env.CI
     ? [
-        ["github"],
-        ["list"],
-        [
-          "allure-playwright",
-          {
-            detail: false,
-            links: {
-              issue: {
-                nameTemplate: "%s",
-                urlTemplate: "https://ledgerhq.atlassian.net/browse/%s",
-              },
-              tms: {
-                nameTemplate: "%s",
-                urlTemplate: "https://ledgerhq.atlassian.net/browse/%s",
-              },
+      ["github"],
+      ["list"],
+      [
+        "allure-playwright",
+        {
+          detail: false,
+          links: {
+            issue: {
+              nameTemplate: "%s",
+              urlTemplate: "https://ledgerhq.atlassian.net/browse/%s",
+            },
+            tms: {
+              nameTemplate: "%s",
+              urlTemplate: "https://ledgerhq.atlassian.net/browse/%s",
             },
           },
-        ],
-        ["./tests/utils/customJsonReporter.ts"],
-      ]
+        },
+      ],
+      ["./tests/utils/customJsonReporter.ts"],
+    ]
     : [["allure-playwright", { detail: false }]],
 };
 

--- a/e2e/desktop/playwright.config.ts
+++ b/e2e/desktop/playwright.config.ts
@@ -25,16 +25,10 @@ const config: PlaywrightTestConfig = {
   workers: "100%",
   projects: [
     {
-      // Specs that broadcast real approve/revoke txs all sign from the same
-      // shared EOA. Pin them to a single worker so their broadcasts never overlap and
-      // race on the account nonce. Tag the broadcasting tests with @swapBroadcast.
-      name: "swap-broadcast-serial",
       grep: /@swapBroadcast/,
       workers: 1,
     },
     {
-      // Everything else runs fully parallel (inherits the global workers + fullyParallel).
-      name: "parallel",
       grepInvert: /@swapBroadcast/,
     },
   ],

--- a/e2e/desktop/tests/specs/provider.swap.spec.ts
+++ b/e2e/desktop/tests/specs/provider.swap.spec.ts
@@ -70,6 +70,7 @@ for (const { fromAccount, toAccount, provider, xrayTicket, bugTickets } of provi
           "@NanoGen5",
           "@ethereum",
           "@family-evm",
+          ...(fromAccount instanceof TokenAccount ? ["@swapBroadcast"] : []),
         ],
         annotation: [
           {

--- a/e2e/desktop/tests/specs/send.swap.spec.ts
+++ b/e2e/desktop/tests/specs/send.swap.spec.ts
@@ -406,7 +406,7 @@ for (const { fromAccount, toAccount, xrayTicket, tag } of swaps) {
     test(
       `Swap ${fromAccount.currency.name} to ${toAccount.currency.name}`,
       {
-        tag: tag,
+        tag: [...tag, ...(fromAccount instanceof TokenAccount ? ["@swapBroadcast"] : [])],
         annotation: {
           type: "TMS",
           description: xrayTicket,

--- a/e2e/desktop/tests/specs/token.approval.swap.spec.ts
+++ b/e2e/desktop/tests/specs/token.approval.swap.spec.ts
@@ -56,7 +56,17 @@ test.describe("Token approval - flow", () => {
   test(
     "Swap - token approval flow",
     {
-      tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
+      tag: [
+        "@NanoSP",
+        "@LNS",
+        "@NanoX",
+        "@Stax",
+        "@Flex",
+        "@NanoGen5",
+        "@ethereum",
+        "@family-evm",
+        "@swapBroadcast",
+      ],
       annotation: [
         {
           type: "TMS",

--- a/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
+++ b/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
@@ -57,7 +57,17 @@ test.describe("Token reapproval - flow", () => {
   test(
     "Swap - token reapproval flow",
     {
-      tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
+      tag: [
+        "@NanoSP",
+        "@LNS",
+        "@NanoX",
+        "@Stax",
+        "@Flex",
+        "@NanoGen5",
+        "@ethereum",
+        "@family-evm",
+        "@swapBroadcast",
+      ],
       annotation: [
         {
           type: "TMS",


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not required — changes are confined to `e2e/desktop/` (no published package affected)._
- [ ] **Covered by automatic tests.** _Test-infra change: it re-routes the swap broadcast specs into a serial Playwright project (`workers: 1`). `tsc` typecheck passes; the serialization itself is exercised on the Monday broadcast nightly. The `@swapBroadcast` `grep`/`grepInvert` partition guarantees each broadcast test runs in exactly one project._
- [x] **Impact of the changes:**
      - Swap E2E on the Monday broadcast nightly: `token.approval`, `token.reapproval`, `provider.swap`, `send.swap`
      - Playwright worker scheduling — new `swap-broadcast-serial` project pinned to `workers: 1`
      - Non-broadcast specs are unaffected (still fully parallel)

### 📝 Description

Token (re)approval swap E2E flakes intermittently on the Monday broadcast nightly with `replacement transaction underpriced (-32000)` or `Transaction … was not confirmed within 120000ms`.

**Root cause:** several swap specs broadcast real ERC-20 approve/revoke transactions from the **same shared EOA** (`Account.ETH_1`) concurrently (`fullyParallel: true`, `workers: "100%"`). Each broadcast fetches the nonce fresh with no cross-worker coordination, so two concurrent broadcasts grab the same nonce — one is rejected as underpriced, or is replaced and never mines.

**Approach:** rather than a cross-process lock or splitting work across multiple EOAs, serialize the broadcasting specs with a dedicated Playwright **project** pinned to a single worker:

- **`swap-broadcast-serial`** — `grep: /@swapBroadcast/`, `workers: 1`: runs every approve/revoke broadcast test one-at-a-time, so their broadcasts can never overlap on the shared EOA.
- **`parallel`** — `grepInvert: /@swapBroadcast/`: everything else keeps full parallelism.
- Broadcasting tests are tagged `@swapBroadcast` — statically in `token.approval` / `token.reapproval`, and conditionally (token `fromAccount` only) in `provider.swap` / `send.swap`.

No production code is touched. The serial project runs concurrently with the parallel batch, so there is effectively no added wall-clock time.

### ❓ Context

- **JIRA or GitHub link**: [QAA-1323](https://ledgerhq.atlassian.net/browse/QAA-1323)
- **Desktop CI**: [broadcast ON](https://github.com/LedgerHQ/ledger-live/actions/runs/28108826468) / [broadcast OFF](https://github.com/LedgerHQ/ledger-live/actions/runs/28108884335)
- **Mobile CI**: https://github.com/LedgerHQ/ledger-live/actions/runs/28108082331

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1323]: https://ledgerhq.atlassian.net/browse/QAA-1323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ