### PR TITLE
[LWDM] feat(history): add dust filtering controls

### DIFF
--- a/.changeset/fresh-history-filter.md
+++ b/.changeset/fresh-history-filter.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add transaction history dust filtering controls.

--- a/apps/ledger-live-desktop/src/mvvm/features/History/HistoryView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/HistoryView.tsx
@@ -15,6 +15,9 @@ export function HistoryView({
   onExportClick,
   operationsCount,
   hasPendingOperations,
+  hideSmallValueTokenOperations,
+  dustFilterThreshold,
+  onToggleHideSmallValueTokenOperations,
 }: Readonly<HistoryViewModel>) {
   const operationsCountRef = useRef(operationsCount);
   const hasPendingOperationsRef = useRef(hasPendingOperations);
@@ -24,11 +27,14 @@ export function HistoryView({
       <TrackPage
         category="OperationList"
         operationsCount={operationsCountRef.current}
-        has_pending_operations={hasPendingOperationsRef.current ? true : false}
+        has_pending_operations={hasPendingOperationsRef.current}
       />
       <HistoryPageHeader
         onBack={showBackButton ? navigateBack : undefined}
         onExportClick={onExportClick}
+        hideSmallValueTokenOperations={hideSmallValueTokenOperations}
+        dustFilterThreshold={dustFilterThreshold}
+        onToggleHideSmallValueTokenOperations={onToggleHideSmallValueTokenOperations}
       />
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <HistoryList

--- a/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
@@ -189,6 +189,15 @@ describe("History integration", () => {
 
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });
+
+  it("toggles dust filtering from the actions menu", async () => {
+    const { user, store } = renderHistory();
+
+    await user.click(await screen.findByTestId("history-actions-menu-button"));
+    await user.click(await screen.findByTestId("history-toggle-dust-filter-button"));
+
+    expect(store.getState().settings.hideSmallValueTokenOperations).toBe(true);
+  });
 });
 
 describe("History export dialog integration", () => {
@@ -214,6 +223,8 @@ describe("History export dialog integration", () => {
   }
 
   async function openExportDialog(user: ReturnType<typeof renderHistoryWithAccounts>["user"]) {
+    const menuButton = await screen.findByTestId("history-actions-menu-button");
+    await user.click(menuButton);
     const exportButton = await screen.findByTestId("history-export-csv-button");
     await user.click(exportButton);
     return within(await screen.findByRole("dialog"));

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryExportDialog/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryExportDialog/index.tsx
@@ -10,18 +10,31 @@ function HistoryExportDialogContent({
   return <HistoryExportDialogView {...vm} />;
 }
 
-export function HistoryExportDialog({ children }: Readonly<{ children: React.ReactNode }>) {
-  const [open, setOpen] = useState(false);
-  const [dialogHeight, setDialogHeight] = useState<"fixed" | "fit">("fixed");
+type Props = Readonly<{
+  children?: React.ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}>;
 
-  const handleOpenChange = useCallback((next: boolean) => {
-    setOpen(next);
-    if (!next) setDialogHeight("fixed");
-  }, []);
+export function HistoryExportDialog({ children, open: controlledOpen, onOpenChange }: Props) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const [dialogHeight, setDialogHeight] = useState<"fixed" | "fit">("fixed");
+  const open = controlledOpen ?? uncontrolledOpen;
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (controlledOpen === undefined) {
+        setUncontrolledOpen(next);
+      }
+      onOpenChange?.(next);
+      if (!next) setDialogHeight("fixed");
+    },
+    [controlledOpen, onOpenChange],
+  );
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange} height={dialogHeight}>
-      <DialogTrigger asChild>{children}</DialogTrigger>
+      {children ? <DialogTrigger asChild>{children}</DialogTrigger> : null}
       {open ? <HistoryExportDialogContent setDialogHeight={setDialogHeight} /> : null}
     </Dialog>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryPageHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryPageHeader.tsx
@@ -1,35 +1,82 @@
-import React from "react";
+import React, { useState } from "react";
 import PageHeader from "LLD/components/PageHeader";
-import { Button } from "@ledgerhq/lumen-ui-react";
-import { Csv } from "@ledgerhq/lumen-ui-react/symbols";
+import { IconButton, Menu, MenuContent, MenuItem, MenuTrigger } from "@ledgerhq/lumen-ui-react";
+import { Csv, Eye, EyeCross, MoreVertical } from "@ledgerhq/lumen-ui-react/symbols";
 import { useTranslation } from "react-i18next";
 import { HistoryExportDialog } from "./HistoryExportDialog";
 
 type Props = Readonly<{
   onBack?: () => void;
   onExportClick: () => void;
+  hideSmallValueTokenOperations: boolean;
+  dustFilterThreshold: string;
+  onToggleHideSmallValueTokenOperations: () => void;
 }>;
 
-export default function HistoryPageHeader({ onBack, onExportClick }: Props) {
+export default function HistoryPageHeader({
+  onBack,
+  onExportClick,
+  hideSmallValueTokenOperations,
+  dustFilterThreshold,
+  onToggleHideSmallValueTokenOperations,
+}: Props) {
   const { t } = useTranslation();
+  const [isExportDialogOpen, setExportDialogOpen] = useState(false);
+  const dustFilterLabel = hideSmallValueTokenOperations
+    ? t("history.actionsBar.showDustTransactions")
+    : t("history.actionsBar.hideDustTransactions");
+  const DustFilterIcon = hideSmallValueTokenOperations ? Eye : EyeCross;
 
   return (
-    <PageHeader
-      title={t("history.title")}
-      onBack={onBack}
-      trailing={
-        <HistoryExportDialog>
-          <Button
-            appearance="transparent"
-            size="sm"
-            icon={Csv}
-            onClick={onExportClick}
-            data-testid="history-export-csv-button"
-          >
-            {t("history.actionsBar.csv")}
-          </Button>
-        </HistoryExportDialog>
-      }
-    />
+    <>
+      <HistoryExportDialog open={isExportDialogOpen} onOpenChange={setExportDialogOpen} />
+      <PageHeader
+        title={t("history.title")}
+        onBack={onBack}
+        trailing={
+          <Menu>
+            <MenuTrigger
+              render={
+                <IconButton
+                  appearance="transparent"
+                  size="sm"
+                  icon={MoreVertical}
+                  aria-label={t("history.actionsBar.more")}
+                  data-testid="history-actions-menu-button"
+                />
+              }
+            />
+            <MenuContent className="min-w-280" side="bottom" align="end">
+              <MenuItem
+                className="cursor-pointer"
+                onClick={() => {
+                  onExportClick();
+                  setExportDialogOpen(true);
+                }}
+                data-testid="history-export-csv-button"
+              >
+                <Csv size={20} />
+                {t("history.actionsBar.csv")}
+              </MenuItem>
+              <MenuItem
+                className="cursor-pointer"
+                onClick={onToggleHideSmallValueTokenOperations}
+                data-testid="history-toggle-dust-filter-button"
+              >
+                <DustFilterIcon size={20} className="shrink-0" />
+                <span className="flex flex-col">
+                  <span>{dustFilterLabel}</span>
+                  <span className="body-3 text-muted">
+                    {t("history.actionsBar.dustTransactionsDescription", {
+                      threshold: dustFilterThreshold,
+                    })}
+                  </span>
+                </span>
+              </MenuItem>
+            </MenuContent>
+          </Menu>
+        }
+      />
+    </>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/History/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/constants.ts
@@ -1,0 +1,1 @@
+export const HISTORY_DUST_FILTER_THRESHOLD_USD = 0.01;

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryOperations.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryOperations.test.ts
@@ -1,10 +1,55 @@
+import BigNumber from "bignumber.js";
 import { renderHook } from "tests/testSetup";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { maticEth, usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import type { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
 import { useHistoryOperations } from "../useHistoryOperations";
 import { BTC_ACCOUNT, ETH_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
+
+const ZERO_VALUE_TOKEN_OP_ID = "zero-value-token-op-id";
+const NON_ZERO_VALUE_TOKEN_OP_ID = "non-zero-value-token-op-id";
+
+function createTokenOperation(tokenAccountId: string, id: string, value: BigNumber): Operation {
+  return {
+    id,
+    hash: id,
+    type: "IN",
+    value,
+    fee: new BigNumber(0),
+    senders: ["0xsender"],
+    recipients: ["0xrecipient"],
+    blockHash: "0xblock",
+    blockHeight: 1,
+    accountId: tokenAccountId,
+    date: new Date(),
+    extra: {},
+  };
+}
+
+function createAccountWithZeroValueTokenOperation(): Account {
+  const ethRoot = genAccount("eth-zero-value-token", {
+    currency: ETH_ACCOUNT.currency,
+    subAccountsCount: 0,
+    operationsSize: 0,
+  });
+  const usdc = genTokenAccount(0, ethRoot, usdcToken);
+
+  const tokenAccountWithOperations: TokenAccount = {
+    ...usdc,
+    operations: [
+      createTokenOperation(usdc.id, ZERO_VALUE_TOKEN_OP_ID, new BigNumber(0)),
+      createTokenOperation(usdc.id, NON_ZERO_VALUE_TOKEN_OP_ID, new BigNumber(1)),
+    ],
+    operationsCount: 2,
+  };
+
+  return {
+    ...ethRoot,
+    subAccounts: [tokenAccountWithOperations],
+  };
+}
 
 describe("useHistoryOperations", () => {
   it("returns an empty array when there are no accounts", () => {
@@ -73,6 +118,42 @@ describe("useHistoryOperations", () => {
     const items = result.current;
     expect(items.length).toBeGreaterThan(0);
     expect(items.every(item => item.account.id === usdc.id)).toBe(true);
+  });
+
+  it("keeps zero-value token operations when dust filtering is disabled", () => {
+    const account = createAccountWithZeroValueTokenOperation();
+
+    const { result } = renderHook(() => useHistoryOperations(), {
+      initialState: {
+        accounts: [account],
+        settings: {
+          ...INITIAL_STATE,
+          filterTokenOperationsZeroAmount: false,
+          hideSmallValueTokenOperations: false,
+        },
+      },
+    });
+
+    expect(result.current.map(item => item.operation.id)).toEqual(
+      expect.arrayContaining([ZERO_VALUE_TOKEN_OP_ID, NON_ZERO_VALUE_TOKEN_OP_ID]),
+    );
+  });
+
+  it("filters zero-value token operations when dust filtering is enabled", () => {
+    const account = createAccountWithZeroValueTokenOperation();
+
+    const { result } = renderHook(() => useHistoryOperations(), {
+      initialState: {
+        accounts: [account],
+        settings: {
+          ...INITIAL_STATE,
+          filterTokenOperationsZeroAmount: false,
+          hideSmallValueTokenOperations: true,
+        },
+      },
+    });
+
+    expect(result.current.map(item => item.operation.id)).toEqual([NON_ZERO_VALUE_TOKEN_OP_ID]);
   });
 
   describe("isUnread flag", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryOperationItemsForRootAccounts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryOperationItemsForRootAccounts.ts
@@ -1,9 +1,15 @@
 import { useMemo, useCallback } from "react";
 import { useSelector } from "LLD/hooks/redux";
 import { selectFeature } from "@shared/feature-flags";
+import { useCountervaluesState } from "@ledgerhq/live-countervalues-react";
 import type { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import { isAddressPoisoningOperation } from "@ledgerhq/ledger-wallet-framework/operation";
-import { filterTokenOperationsZeroAmountSelector } from "~/renderer/reducers/settings";
+import { isSmallValueTokenOperation } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
+import {
+  counterValueCurrencySelector,
+  filterTokenOperationsZeroAmountSelector,
+  hideSmallValueTokenOperationsSelector,
+} from "~/renderer/reducers/settings";
 import {
   buildHistoryOperationItems,
   getAddressPoisoningFamiliesForFilter,
@@ -11,6 +17,7 @@ import {
 import { lastSeenOperationDateSelector } from "~/renderer/reducers/history";
 import type { State } from "~/renderer/reducers";
 import type { OperationTableItem } from "../types";
+import { HISTORY_DUST_FILTER_THRESHOLD_USD } from "../constants";
 
 /** Same pipeline as the full History list, limited to the given root portfolio accounts. */
 export function useHistoryOperationItemsForRootAccounts(
@@ -19,6 +26,9 @@ export function useHistoryOperationItemsForRootAccounts(
   const currenciesSettings = useSelector((state: State) => state.settings.currenciesSettings);
   const lastSeenOperationDate = useSelector(lastSeenOperationDateSelector);
   const shouldFilterTokenOps = useSelector(filterTokenOperationsZeroAmountSelector);
+  const shouldHideSmallValueTokenOperations = useSelector(hideSmallValueTokenOperationsSelector);
+  const countervaluesState = useCountervaluesState();
+  const userCounterValueCurrency = useSelector(counterValueCurrencySelector);
   const poisoningFeature = useSelector((state: State) =>
     selectFeature(state, "addressPoisoningOperationsFilter"),
   );
@@ -30,14 +40,39 @@ export function useHistoryOperationItemsForRootAccounts(
 
   const filterOperation = useCallback(
     (operation: Operation, account: AccountLike) => {
-      if (!shouldFilterTokenOps) return true;
-      return !isAddressPoisoningOperation(
-        operation,
-        account,
-        addressPoisoningFamilies ? { families: addressPoisoningFamilies } : undefined,
-      );
+      if (
+        shouldFilterTokenOps &&
+        isAddressPoisoningOperation(
+          operation,
+          account,
+          addressPoisoningFamilies ? { families: addressPoisoningFamilies } : undefined,
+        )
+      ) {
+        return false;
+      }
+
+      if (
+        shouldHideSmallValueTokenOperations &&
+        isSmallValueTokenOperation({
+          operation,
+          account,
+          countervaluesState,
+          userCounterValueCurrency,
+          thresholdUsd: HISTORY_DUST_FILTER_THRESHOLD_USD,
+        })
+      ) {
+        return false;
+      }
+
+      return true;
     },
-    [shouldFilterTokenOps, addressPoisoningFamilies],
+    [
+      shouldFilterTokenOps,
+      addressPoisoningFamilies,
+      shouldHideSmallValueTokenOperations,
+      countervaluesState,
+      userCounterValueCurrency,
+    ],
   );
 
   return useMemo(

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryViewModel.ts
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useMemo } from "react";
-import { useDispatch } from "LLD/hooks/redux";
+import BigNumber from "bignumber.js";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { floorThresholdToCurrencyMinorUnit } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { useHideSmallValueTokenOperations } from "~/renderer/actions/settings";
 import { markOperationsAsSeen } from "~/renderer/reducers/history";
+import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
 import type { Virtualizer } from "@tanstack/react-virtual";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
@@ -11,6 +16,7 @@ import type { HistoryTable, OperationRow, VirtualItem } from "../types";
 import { track } from "~/renderer/analytics/segment";
 import { parseHistoryBackPath } from "../utils/historyLocationState";
 import { usePopNavigationBack } from "LLD/utils/usePopNavigationBack";
+import { HISTORY_DUST_FILTER_THRESHOLD_USD } from "../constants";
 
 export type HistoryViewModel = {
   showBackButton: boolean;
@@ -23,6 +29,9 @@ export type HistoryViewModel = {
   onExportClick: () => void;
   operationsCount: number;
   hasPendingOperations: boolean;
+  hideSmallValueTokenOperations: boolean;
+  dustFilterThreshold: string;
+  onToggleHideSmallValueTokenOperations: () => void;
 };
 
 export function useHistoryViewModel(): HistoryViewModel {
@@ -55,6 +64,23 @@ export function useHistoryViewModel(): HistoryViewModel {
   const onExportClick = () => track("ExportAccountOperations");
   const operationsCount = flatItems.length;
   const hasPendingOperations = useMemo(() => operations.some(op => op.isPending), [operations]);
+  const [hideSmallValueTokenOperations, setHideSmallValueTokenOperations] =
+    useHideSmallValueTokenOperations();
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const locale = useSelector(localeSelector);
+  const dustFilterThreshold = useMemo(() => {
+    const thresholdMinorUnit =
+      floorThresholdToCurrencyMinorUnit(HISTORY_DUST_FILTER_THRESHOLD_USD, counterValueCurrency) ??
+      new BigNumber(0);
+
+    return formatCurrencyUnit(counterValueCurrency.units[0], thresholdMinorUnit, {
+      showCode: true,
+      locale,
+    });
+  }, [counterValueCurrency, locale]);
+  const onToggleHideSmallValueTokenOperations = useCallback(() => {
+    setHideSmallValueTokenOperations(!hideSmallValueTokenOperations);
+  }, [hideSmallValueTokenOperations, setHideSmallValueTokenOperations]);
 
   return {
     showBackButton,
@@ -67,5 +93,8 @@ export function useHistoryViewModel(): HistoryViewModel {
     onExportClick,
     operationsCount,
     hasPendingOperations,
+    hideSmallValueTokenOperations,
+    dustFilterThreshold,
+    onToggleHideSmallValueTokenOperations,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/History/utils/historyOperationItems.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/utils/historyOperationItems.ts
@@ -1,12 +1,14 @@
 import type { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import type { Features } from "@shared/feature-flags";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoCurrency, Currency } from "@ledgerhq/types-cryptoassets";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
 import { getEnv } from "@ledgerhq/live-env";
 import {
   flattenAccounts,
   getAccountCurrency,
   getMainAccount,
 } from "@ledgerhq/live-common/account/index";
+import { isSmallValueTokenOperation } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
 import {
   getOperationAmountNumber,
   flattenOperationWithInternalsAndNfts,
@@ -16,6 +18,7 @@ import { isAddressPoisoningOperation } from "@ledgerhq/ledger-wallet-framework/o
 import { currencySettingsDefaults, type CurrencySettings } from "~/renderer/reducers/settings";
 import { getOperationCounterpartyAddress } from "./getOperationCounterpartyAddress";
 import type { OperationTableItem } from "../types";
+import { HISTORY_DUST_FILTER_THRESHOLD_USD } from "../constants";
 
 type AccountInfo = { account: AccountLike; parentAccount?: Account };
 type FilterFn = (operation: Operation, account: AccountLike) => boolean;
@@ -174,16 +177,40 @@ export function historyHasUnreadOperations(
   currenciesSettings: Record<string, CurrencySettings>,
   shouldFilterTokenOps: boolean,
   addressPoisoningFamilies: string[] | null,
+  shouldHideSmallValueTokenOperations = false,
+  countervaluesState?: CounterValuesState,
+  userCounterValueCurrency?: Currency,
 ): boolean {
   if (!lastSeenDate) return false;
   const lastSeenTs = parseLastSeenMs(lastSeenDate);
   const filterOperation: FilterFn = (operation, account) => {
-    if (!shouldFilterTokenOps) return true;
-    return !isAddressPoisoningOperation(
-      operation,
-      account,
-      addressPoisoningFamilies ? { families: addressPoisoningFamilies } : undefined,
-    );
+    if (
+      shouldFilterTokenOps &&
+      isAddressPoisoningOperation(
+        operation,
+        account,
+        addressPoisoningFamilies ? { families: addressPoisoningFamilies } : undefined,
+      )
+    ) {
+      return false;
+    }
+
+    if (
+      shouldHideSmallValueTokenOperations &&
+      countervaluesState &&
+      userCounterValueCurrency &&
+      isSmallValueTokenOperation({
+        operation,
+        account,
+        countervaluesState,
+        userCounterValueCurrency,
+        thresholdUsd: HISTORY_DUST_FILTER_THRESHOLD_USD,
+      })
+    ) {
+      return false;
+    }
+
+    return true;
   };
   const getConfirmationsNb = (mainAccount: Account) =>
     getConfirmationsNbForCurrency(currenciesSettings, mainAccount.currency);

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -10,6 +10,7 @@ import {
   AnalyticsConsentInfo,
   SettingsState as Settings,
   hideEmptyTokenAccountsSelector,
+  hideSmallValueTokenOperationsSelector,
   filterTokenOperationsZeroAmountSelector,
   selectedTimeRangeSelector,
   SettingsState,
@@ -190,6 +191,24 @@ export function useFilterTokenOperationsZeroAmount(): [
           }),
         );
       }
+    },
+    [dispatch],
+  );
+  return [value, setter];
+}
+export function useHideSmallValueTokenOperations(): [
+  boolean,
+  (hideSmallValueTokenOperations: boolean) => void,
+] {
+  const dispatch = useDispatch();
+  const value = useSelector(hideSmallValueTokenOperationsSelector);
+  const setter = useCallback(
+    (hideSmallValueTokenOperations: boolean) => {
+      dispatch(
+        saveSettings({
+          hideSmallValueTokenOperations,
+        }),
+      );
     },
     [dispatch],
   );

--- a/apps/ledger-live-desktop/src/renderer/reducers/history.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/history.ts
@@ -6,7 +6,12 @@ import {
 } from "LLD/features/History/utils/historyOperationItems";
 import type { State } from ".";
 import { accountsSelector } from "./accounts";
-import { filterTokenOperationsZeroAmountSelector } from "./settings";
+import {
+  counterValueCurrencySelector,
+  filterTokenOperationsZeroAmountSelector,
+  hideSmallValueTokenOperationsSelector,
+} from "./settings";
+import { countervaluesStateSelector } from "./countervalues";
 
 export type HistoryState = {
   lastSeenOperationDate: string | null;
@@ -45,8 +50,20 @@ export const hasUnreadOperationsSelector = createSelector(
   lastSeenOperationDateSelector,
   (state: State) => state.settings.currenciesSettings,
   filterTokenOperationsZeroAmountSelector,
+  hideSmallValueTokenOperationsSelector,
+  countervaluesStateSelector,
+  counterValueCurrencySelector,
   (state: State) => selectFeature(state, "addressPoisoningOperationsFilter"),
-  (accounts, lastSeenDate, currenciesSettings, shouldFilterTokenOps, poisoningFeature) => {
+  (
+    accounts,
+    lastSeenDate,
+    currenciesSettings,
+    shouldFilterTokenOps,
+    shouldHideSmallValueTokenOperations,
+    countervaluesState,
+    userCounterValueCurrency,
+    poisoningFeature,
+  ) => {
     if (!lastSeenDate) return false;
     const families = getAddressPoisoningFamiliesForFilter(shouldFilterTokenOps, poisoningFeature);
     return historyHasUnreadOperations(
@@ -55,6 +72,9 @@ export const hasUnreadOperationsSelector = createSelector(
       currenciesSettings,
       shouldFilterTokenOps,
       families,
+      shouldHideSmallValueTokenOperations,
+      countervaluesState,
+      userCounterValueCurrency,
     );
   },
 );

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -97,6 +97,7 @@ export type SettingsState = {
   mevProtection: boolean;
   hideEmptyTokenAccounts: boolean;
   filterTokenOperationsZeroAmount: boolean;
+  hideSmallValueTokenOperations: boolean;
   sidebarCollapsed: boolean;
   discreetMode: boolean;
   starredAccountIds?: string[];
@@ -194,6 +195,7 @@ export const INITIAL_STATE: SettingsState = {
   showAccountsHelperBanner: true,
   hideEmptyTokenAccounts: getEnv("HIDE_EMPTY_TOKEN_ACCOUNTS"),
   filterTokenOperationsZeroAmount: getEnv("FILTER_ZERO_AMOUNT_ERC20_EVENTS"),
+  hideSmallValueTokenOperations: false,
   sidebarCollapsed: false,
   discreetMode: false,
   preferredDeviceModel: DeviceModelId.nanoS,
@@ -339,7 +341,7 @@ const handlers: SettingsHandlers = {
   SAVE_SETTINGS: (state, { payload }) => {
     if (!payload) return state;
     const filteredPayload = filterValidSettings(payload);
-    const { analyticsConsentInfo, ...rest } = filteredPayload;
+    const { analyticsConsentInfo: _analyticsConsentInfo, ...rest } = filteredPayload;
 
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const changed = (Object.keys(rest) as (keyof typeof rest)[]).some(
@@ -842,6 +844,8 @@ export const hideEmptyTokenAccountsSelector = (state: State) =>
   state.settings.hideEmptyTokenAccounts;
 export const filterTokenOperationsZeroAmountSelector = (state: State) =>
   state.settings.filterTokenOperationsZeroAmount;
+export const hideSmallValueTokenOperationsSelector = (state: State) =>
+  state.settings.hideSmallValueTokenOperations;
 
 export const doNotAskAgainSkipMemoSelector = (state: State) => state.settings.doNotAskAgainSkipMemo;
 export const lastSeenDeviceSelector = (state: State): DeviceModelInfo | null | undefined => {

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9241,7 +9241,11 @@
       "description": "Come back later to see your transactions."
     },
     "actionsBar": {
-      "csv": "Export"
+      "csv": "Export",
+      "more": "Transaction history options",
+      "hideDustTransactions": "Hide dust transactions",
+      "showDustTransactions": "Show dust transactions",
+      "dustTransactionsDescription": "Transactions below {{threshold}} in your main currency will be hidden."
     },
     "exportDialog": {
       "title": "Export transaction history",

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -39,6 +39,7 @@ import {
   SettingsSetDismissedDynamicCardsPayload,
   SettingsSetDebugAppLevelDrawerOpenedPayload,
   SettingsFilterTokenOperationsZeroAmountPayload,
+  SettingsHideSmallValueTokenOperationsPayload,
   SettingsLastSeenDeviceLanguagePayload,
   SettingsCompleteOnboardingPayload,
   SettingsSetDateFormatPayload,
@@ -143,6 +144,10 @@ export const setHideEmptyTokenAccounts = createAction<SettingsHideEmptyTokenAcco
 export const setFilterTokenOperationsZeroAmount =
   createAction<SettingsFilterTokenOperationsZeroAmountPayload>(
     SettingsActionTypes.SETTINGS_FILTER_TOKEN_OPERATIONS_ZERO_AMOUNT,
+  );
+export const setHideSmallValueTokenOperations =
+  createAction<SettingsHideSmallValueTokenOperationsPayload>(
+    SettingsActionTypes.SETTINGS_HIDE_SMALL_VALUE_TOKEN_OPERATIONS,
   );
 export const blacklistToken = createAction<SettingsBlacklistTokenPayload>(
   SettingsActionTypes.BLACKLIST_TOKEN,

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -274,6 +274,7 @@ export enum SettingsActionTypes {
   SETTINGS_SWITCH_COUNTERVALUE_FIRST = "SETTINGS_SWITCH_COUNTERVALUE_FIRST",
   SETTINGS_HIDE_EMPTY_TOKEN_ACCOUNTS = "SETTINGS_HIDE_EMPTY_TOKEN_ACCOUNTS",
   SETTINGS_FILTER_TOKEN_OPERATIONS_ZERO_AMOUNT = "SETTINGS_FILTER_TOKEN_OPERATIONS_ZERO_AMOUNT",
+  SETTINGS_HIDE_SMALL_VALUE_TOKEN_OPERATIONS = "SETTINGS_HIDE_SMALL_VALUE_TOKEN_OPERATIONS",
   SHOW_TOKEN = "SHOW_TOKEN",
   BLACKLIST_TOKEN = "BLACKLIST_TOKEN",
   SETTINGS_DISMISS_BANNER = "SETTINGS_DISMISS_BANNER",
@@ -344,6 +345,8 @@ export type SettingsSetReadOnlyModePayload = SettingsState["readOnlyModeEnabled"
 export type SettingsHideEmptyTokenAccountsPayload = SettingsState["hideEmptyTokenAccounts"];
 export type SettingsFilterTokenOperationsZeroAmountPayload =
   SettingsState["filterTokenOperationsZeroAmount"];
+export type SettingsHideSmallValueTokenOperationsPayload =
+  SettingsState["hideSmallValueTokenOperations"];
 export type SettingsShowTokenPayload = string;
 export type SettingsBlacklistTokenPayload = string;
 export type SettingsDismissBannerPayload = string;
@@ -433,6 +436,8 @@ export type SettingsPayload =
   | SettingsSetHasInstalledAnyAppPayload
   | SettingsSetReadOnlyModePayload
   | SettingsHideEmptyTokenAccountsPayload
+  | SettingsFilterTokenOperationsZeroAmountPayload
+  | SettingsHideSmallValueTokenOperationsPayload
   | SettingsShowTokenPayload
   | SettingsBlacklistTokenPayload
   | SettingsDismissBannerPayload

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3059,7 +3059,13 @@
   "operationsList": {
     "to": "To",
     "from": "From",
-    "pending": "Pending"
+    "pending": "Pending",
+    "options": {
+      "more": "Transaction history options",
+      "hideDustTransactions": "Hide dust transactions",
+      "showDustTransactions": "Show dust transactions",
+      "dustTransactionsDescription": "Transactions below {{threshold}} in your main currency will be hidden."
+    }
   },
   "operationDetails": {
     "title": "Transaction details",

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/constants.ts
@@ -1,0 +1,1 @@
+export const HISTORY_DUST_FILTER_THRESHOLD_USD = 0.01;

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
@@ -42,9 +42,10 @@ function stateWithAccountsAndOperations(base: State): State {
 const operation = accountWithOperations.operations[1];
 
 const mockNavigate = jest.fn();
+const mockSetOptions = jest.fn();
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
-  useNavigation: () => ({ navigate: mockNavigate }),
+  useNavigation: () => ({ navigate: mockNavigate, setOptions: mockSetOptions }),
 }));
 
 const Stack = createNativeStackNavigator<OperationsHistoryNavigatorParamsList>();
@@ -56,6 +57,10 @@ const MockNavigator = () => (
 );
 
 describe("OperationsList", () => {
+  beforeEach(() => {
+    mockSetOptions.mockClear();
+  });
+
   it("tracks the OperationsList screen on focus", () => {
     render(<MockNavigator />);
     expect(screen).toHaveBeenCalledWith(
@@ -66,6 +71,18 @@ describe("OperationsList", () => {
       true,
       false,
       false,
+    );
+  });
+
+  it("registers the transaction history options menu in the navigation bar", () => {
+    render(<MockNavigator />);
+
+    expect(mockSetOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lumenNavBar: expect.objectContaining({
+          renderTrailing: expect.any(Function),
+        }),
+      }),
     );
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
@@ -72,6 +72,28 @@ describe("useOperationsListViewModel", () => {
     });
   });
 
+  describe("dust filtering options", () => {
+    it("starts disabled and toggles the setting from the options sheet", () => {
+      const { result, store } = renderHook(() => useOperationsListViewModel());
+
+      expect(result.current.hideSmallValueTokenOperations).toBe(false);
+      expect(result.current.isOptionsSheetOpen).toBe(false);
+
+      act(() => {
+        result.current.openOptionsSheet();
+      });
+
+      expect(result.current.isOptionsSheetOpen).toBe(true);
+
+      act(() => {
+        result.current.onToggleHideSmallValueTokenOperations();
+      });
+
+      expect(store.getState().settings.hideSmallValueTokenOperations).toBe(true);
+      expect(result.current.isOptionsSheetOpen).toBe(false);
+    });
+  });
+
   describe("accountIds scoping", () => {
     it("filters root accounts to those whose tree intersects the given accountIds", () => {
       const ethereum = getCryptoCurrencyById("ethereum");

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsHistoryOptionsSheet.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsHistoryOptionsSheet.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import {
+  BottomSheetHeader,
+  BottomSheetView,
+  ListItem,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
+  Spot,
+} from "@ledgerhq/lumen-ui-rnative";
+import { Eye, EyeCross } from "@ledgerhq/lumen-ui-rnative/symbols";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import { useTranslation } from "~/context/Locale";
+
+type Props = Readonly<{
+  isOpen: boolean;
+  isFilterEnabled: boolean;
+  threshold: string;
+  onClose: () => void;
+  onToggle: () => void;
+}>;
+
+export function OperationsHistoryOptionsSheet({
+  isOpen,
+  isFilterEnabled,
+  threshold,
+  onClose,
+  onToggle,
+}: Props) {
+  const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
+  const Icon = isFilterEnabled ? Eye : EyeCross;
+  const title = isFilterEnabled
+    ? t("operationsList.options.showDustTransactions")
+    : t("operationsList.options.hideDustTransactions");
+
+  return (
+    <QueuedDrawerBottomSheet
+      testID="operations-history-options-sheet"
+      isRequestingToBeOpened={isOpen}
+      enableDynamicSizing
+      onClose={onClose}
+    >
+      <BottomSheetView style={{ paddingBottom: bottom + 24 }}>
+        <BottomSheetHeader />
+        <ListItem onPress={onToggle} testID="operations-history-toggle-dust-filter">
+          <ListItemLeading>
+            <Spot appearance="icon" icon={Icon} />
+            <ListItemContent>
+              <ListItemTitle>{title}</ListItemTitle>
+              <ListItemDescription>
+                {t("operationsList.options.dustTransactionsDescription", { threshold })}
+              </ListItemDescription>
+            </ListItemContent>
+          </ListItemLeading>
+        </ListItem>
+      </BottomSheetView>
+    </QueuedDrawerBottomSheet>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsHistoryOptionsTrailing.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsHistoryOptionsTrailing.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { IconButton } from "@ledgerhq/lumen-ui-rnative";
+import { MoreVertical } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTranslation } from "~/context/Locale";
+
+type Props = Readonly<{
+  onPress: () => void;
+}>;
+
+export function OperationsHistoryOptionsTrailing({ onPress }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <IconButton
+      appearance="no-background"
+      size="md"
+      icon={MoreVertical}
+      accessibilityLabel={t("operationsList.options.more")}
+      onPress={onPress}
+      testID="operations-history-options-trigger"
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
@@ -1,6 +1,11 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useLayoutEffect, useMemo } from "react";
 import { SectionList, SectionListRenderItem } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useNavigation } from "@react-navigation/native";
+import type {
+  NativeStackHeaderRightProps,
+  NativeStackNavigationProp,
+} from "@react-navigation/native-stack";
 import { Account, Operation } from "@ledgerhq/types-live";
 import type { OperationsListSection } from "./useOperationsListViewModel";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
@@ -8,6 +13,7 @@ import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { TrackScreen } from "~/analytics";
 import { ScreenName } from "~/const";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import type { LumenNativeStackNavigationOptions } from "LLM/components/Navigation";
 import type { OperationsHistoryNavigatorParamsList } from "LLM/features/OperationsHistory/types";
 import OperationsListItem from "./components/OperationsListItem";
 import OperationsSectionHeader from "./components/OperationsSectionHeader";
@@ -16,8 +22,14 @@ import { OperationsListFooter } from "./components/OperationsListFooter";
 import { SectionSeparator } from "./components/SectionSeparator";
 import { useOperationsListViewModel } from "./useOperationsListViewModel";
 import { BottomFadeGradient, GRADIENT_HEIGHT } from "LLM/components/BottomFadeGradient";
+import { OperationsHistoryOptionsTrailing } from "./components/OperationsHistoryOptionsTrailing";
+import { OperationsHistoryOptionsSheet } from "./components/OperationsHistoryOptionsSheet";
 
 type Props = StackNavigatorProps<OperationsHistoryNavigatorParamsList, ScreenName.OperationsList>;
+type NavigationProps = NativeStackNavigationProp<
+  OperationsHistoryNavigatorParamsList,
+  ScreenName.OperationsList
+>;
 
 function keyExtractor(item: Operation) {
   return `${item.accountId}_${item.id}_${item.type}`;
@@ -26,6 +38,7 @@ function keyExtractor(item: Operation) {
 export default function OperationsList({ route }: Props) {
   const { bottom } = useSafeAreaInsets();
   const accountIds = route.params?.accountIds;
+  const navigation = useNavigation<NavigationProps>();
   const {
     accounts,
     flattenedAccounts,
@@ -36,7 +49,33 @@ export default function OperationsList({ route }: Props) {
     isEmpty,
     hasPendingOperations,
     onEndReached,
+    isOptionsSheetOpen,
+    openOptionsSheet,
+    closeOptionsSheet,
+    hideSmallValueTokenOperations,
+    dustFilterThreshold,
+    onToggleHideSmallValueTokenOperations,
   } = useOperationsListViewModel(accountIds);
+
+  const renderTrailing = useCallback(
+    (_props: NativeStackHeaderRightProps) => (
+      <OperationsHistoryOptionsTrailing onPress={openOptionsSheet} />
+    ),
+    [openOptionsSheet],
+  );
+
+  useLayoutEffect(() => {
+    const opts: Partial<LumenNativeStackNavigationOptions> = {
+      lumenNavBar: {
+        renderTrailing,
+        navBarTrailingProps: {
+          style: { marginRight: 16 },
+        },
+      },
+    };
+
+    navigation.setOptions(opts);
+  }, [navigation, renderTrailing]);
 
   const listContentStyle = useMemo(
     () => ({
@@ -109,6 +148,13 @@ export default function OperationsList({ route }: Props) {
         ListEmptyComponent={ListEmptyComponent}
       />
       {!isEmpty && <BottomFadeGradient />}
+      <OperationsHistoryOptionsSheet
+        isOpen={isOptionsSheetOpen}
+        isFilterEnabled={hideSmallValueTokenOperations}
+        threshold={dustFilterThreshold}
+        onClose={closeOptionsSheet}
+        onToggle={onToggleHideSmallValueTokenOperations}
+      />
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
@@ -1,12 +1,22 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
+import BigNumber from "bignumber.js";
 import { flattenAccounts, getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { floorThresholdToCurrencyMinorUnit } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
+import { setHideSmallValueTokenOperations } from "~/actions/settings";
 import { useSelector, useDispatch } from "~/context/hooks";
+import { useLocale } from "~/context/Locale";
 import { flattenAccountsSelector, shallowAccountsSelector } from "~/reducers/accounts";
 import { lastSeenOperationDateSelector, markOperationsAsSeen } from "~/reducers/history";
+import {
+  counterValueCurrencySelector,
+  hideSmallValueTokenOperationsEnabledSelector,
+} from "~/reducers/settings";
 import { parseLastSeenMs } from "LLM/features/OperationsHistory/utils/unreadOperations";
 import { useOperationsV1 } from "~/screens/Analytics/Operations/useOperationsV1";
 import { AccountLike, Operation } from "@ledgerhq/types-live";
 import { useOperationsSections } from "./hooks/useOperationsSections";
+import { HISTORY_DUST_FILTER_THRESHOLD_USD } from "LLM/features/OperationsHistory/constants";
 
 export type { OperationsListSection } from "./hooks/useOperationsSections";
 
@@ -18,6 +28,10 @@ export function useOperationsListViewModel(accountIds?: string[]) {
   const allAccounts = useSelector(shallowAccountsSelector);
   const allFlattenedAccounts = useSelector(flattenAccountsSelector);
   const [opCount, setOpCount] = useState(INITIAL_OP_COUNT);
+  const [isOptionsSheetOpen, setOptionsSheetOpen] = useState(false);
+  const hideSmallValueTokenOperations = useSelector(hideSmallValueTokenOperationsEnabledSelector);
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const { locale } = useLocale();
 
   const allowedIds = useMemo(
     () => (accountIds && accountIds.length > 0 ? new Set(accountIds) : null),
@@ -76,6 +90,23 @@ export function useOperationsListViewModel(accountIds?: string[]) {
   const isEmpty = completed && sections.length === 0;
 
   const hasPendingOperations = useMemo(() => sections.some(s => s.isPending), [sections]);
+  const dustFilterThreshold = useMemo(() => {
+    const thresholdMinorUnit =
+      floorThresholdToCurrencyMinorUnit(HISTORY_DUST_FILTER_THRESHOLD_USD, counterValueCurrency) ??
+      new BigNumber(0);
+
+    return formatCurrencyUnit(counterValueCurrency.units[0], thresholdMinorUnit, {
+      showCode: true,
+      locale,
+    });
+  }, [counterValueCurrency, locale]);
+
+  const openOptionsSheet = useCallback(() => setOptionsSheetOpen(true), []);
+  const closeOptionsSheet = useCallback(() => setOptionsSheetOpen(false), []);
+  const onToggleHideSmallValueTokenOperations = useCallback(() => {
+    dispatch(setHideSmallValueTokenOperations(!hideSmallValueTokenOperations));
+    closeOptionsSheet();
+  }, [dispatch, hideSmallValueTokenOperations, closeOptionsSheet]);
 
   return {
     accounts,
@@ -87,5 +118,11 @@ export function useOperationsListViewModel(accountIds?: string[]) {
     isEmpty,
     hasPendingOperations,
     onEndReached,
+    isOptionsSheetOpen,
+    openOptionsSheet,
+    closeOptionsSheet,
+    hideSmallValueTokenOperations,
+    dustFilterThreshold,
+    onToggleHideSmallValueTokenOperations,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/utils/unreadOperations.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/utils/unreadOperations.ts
@@ -1,11 +1,15 @@
 import type { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import type { Features } from "@shared/feature-flags";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
 import { flattenAccounts } from "@ledgerhq/live-common/account/index";
+import { isSmallValueTokenOperation } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
 import {
   flattenOperationWithInternalsAndNfts,
   isAddressPoisoningOperation,
 } from "@ledgerhq/ledger-wallet-framework/operation";
 import { getEnv } from "@ledgerhq/live-env";
+import { HISTORY_DUST_FILTER_THRESHOLD_USD } from "../constants";
 
 /**
  * Mirrors {@link useAddressPoisoningOperationsFamilies} using Redux-resolved flags.
@@ -43,6 +47,9 @@ export function hasUnreadOperations(
   lastSeenDate: string | null,
   shouldFilterTokenOps: boolean,
   addressPoisoningFamilies: string[] | null,
+  shouldHideSmallValueTokenOperations = false,
+  countervaluesState?: CounterValuesState,
+  userCounterValueCurrency?: Currency,
 ): boolean {
   if (!lastSeenDate) return false;
 
@@ -50,12 +57,33 @@ export function hasUnreadOperations(
   if (lastSeenTs === null) return false;
 
   const filterOperation = (operation: Operation, account: AccountLike): boolean => {
-    if (!shouldFilterTokenOps) return true;
-    return !isAddressPoisoningOperation(
-      operation,
-      account,
-      addressPoisoningFamilies ? { families: addressPoisoningFamilies } : undefined,
-    );
+    if (
+      shouldFilterTokenOps &&
+      isAddressPoisoningOperation(
+        operation,
+        account,
+        addressPoisoningFamilies ? { families: addressPoisoningFamilies } : undefined,
+      )
+    ) {
+      return false;
+    }
+
+    if (
+      shouldHideSmallValueTokenOperations &&
+      countervaluesState &&
+      userCounterValueCurrency &&
+      isSmallValueTokenOperation({
+        operation,
+        account,
+        countervaluesState,
+        userCounterValueCurrency,
+        thresholdUsd: HISTORY_DUST_FILTER_THRESHOLD_USD,
+      })
+    ) {
+      return false;
+    }
+
+    return true;
   };
 
   const allAccounts = flattenAccounts(accounts);

--- a/apps/ledger-live-mobile/src/reducers/history.ts
+++ b/apps/ledger-live-mobile/src/reducers/history.ts
@@ -6,7 +6,12 @@ import {
 } from "LLM/features/OperationsHistory/utils/unreadOperations";
 import type { State } from "./types";
 import { accountsSelector } from "./accounts";
-import { filterTokenOperationsZeroAmountEnabledSelector } from "./settings";
+import {
+  counterValueCurrencySelector,
+  filterTokenOperationsZeroAmountEnabledSelector,
+  hideSmallValueTokenOperationsEnabledSelector,
+} from "./settings";
+import { countervaluesStateSelector } from "./countervalues";
 
 export type HistoryState = {
   lastSeenOperationDate: string | null;
@@ -46,10 +51,29 @@ export const hasUnreadOperationsSelector = createSelector(
   accountsSelector,
   lastSeenOperationDateSelector,
   filterTokenOperationsZeroAmountEnabledSelector,
+  hideSmallValueTokenOperationsEnabledSelector,
+  countervaluesStateSelector,
+  counterValueCurrencySelector,
   (state: State) => selectFeature(state, "addressPoisoningOperationsFilter"),
-  (accounts, lastSeenDate, shouldFilterTokenOps, poisoningFeature) => {
+  (
+    accounts,
+    lastSeenDate,
+    shouldFilterTokenOps,
+    shouldHideSmallValueTokenOperations,
+    countervaluesState,
+    userCounterValueCurrency,
+    poisoningFeature,
+  ) => {
     if (!lastSeenDate) return false;
     const families = getAddressPoisoningFamiliesForFilter(shouldFilterTokenOps, poisoningFeature);
-    return hasUnreadOperations(accounts, lastSeenDate, shouldFilterTokenOps, families);
+    return hasUnreadOperations(
+      accounts,
+      lastSeenDate,
+      shouldFilterTokenOps,
+      families,
+      shouldHideSmallValueTokenOperations,
+      countervaluesState,
+      userCounterValueCurrency,
+    );
   },
 );

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -81,6 +81,7 @@ import type {
   SettingsSetHasSeenQ2WalletV4TourPayload,
   SettingsSetAnalyticsConsentInfoPayload,
   SettingsSetHasClickedRecoverPayload,
+  SettingsHideSmallValueTokenOperationsPayload,
 } from "../actions/types";
 import {
   SettingsActionTypes,
@@ -115,6 +116,7 @@ export const INITIAL_STATE: SettingsState = {
   graphCountervalueFirst: true,
   hideEmptyTokenAccounts: false,
   filterTokenOperationsZeroAmount: true,
+  hideSmallValueTokenOperations: false,
   blacklistedTokenIds: [],
   dismissedBanners: [],
   hasAvailableUpdate: false,
@@ -408,6 +410,12 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
     filterTokenOperationsZeroAmount: (
       action as Action<SettingsFilterTokenOperationsZeroAmountPayload>
     ).payload,
+  }),
+
+  [SettingsActionTypes.SETTINGS_HIDE_SMALL_VALUE_TOKEN_OPERATIONS]: (state, action) => ({
+    ...state,
+    hideSmallValueTokenOperations: (action as Action<SettingsHideSmallValueTokenOperationsPayload>)
+      .payload,
   }),
 
   [SettingsActionTypes.SHOW_TOKEN]: (state, action) => {
@@ -857,6 +865,8 @@ export const hideEmptyTokenAccountsEnabledSelector = (state: State) =>
   state.settings.hideEmptyTokenAccounts;
 export const filterTokenOperationsZeroAmountEnabledSelector = (state: State) =>
   state.settings.filterTokenOperationsZeroAmount;
+export const hideSmallValueTokenOperationsEnabledSelector = (state: State) =>
+  state.settings.hideSmallValueTokenOperations;
 export const dismissedBannersSelector = (state: State) => state.settings.dismissedBanners;
 export const hasAvailableUpdateSelector = (state: State) => state.settings.hasAvailableUpdate;
 export const dismissedDynamicCardsSelector = (state: State) => state.settings.dismissedDynamicCards;

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -250,6 +250,7 @@ export type SettingsState = {
   graphCountervalueFirst: boolean;
   hideEmptyTokenAccounts: boolean;
   filterTokenOperationsZeroAmount: boolean;
+  hideSmallValueTokenOperations: boolean;
   blacklistedTokenIds: string[];
   dismissedBanners: string[];
   hasAvailableUpdate: boolean;

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
@@ -107,6 +107,15 @@ const initialStateWithFilterEnabledButNoEvmFamily = (state: State): State => ({
   },
 });
 
+const initialStateWithDustFilterEnabled = (state: State): State => ({
+  ...state,
+  settings: {
+    ...state.settings,
+    filterTokenOperationsZeroAmount: false,
+    hideSmallValueTokenOperations: true,
+  },
+});
+
 describe("useOperationsV1 integration", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -131,5 +140,16 @@ describe("useOperationsV1 integration", () => {
     });
 
     expect(result.current.sections[0].data.length).toBe(2);
+  });
+
+  it("should filter out zero-value token operations when dust filtering is enabled", () => {
+    const accountWithZeroValueTokenOp = createAccountWithZeroValueTokenOperation();
+
+    const { result } = renderHook(() => useOperationsV1([accountWithZeroValueTokenOp], 50), {
+      overrideInitialState: initialStateWithDustFilterEnabled,
+    });
+
+    expect(result.current.sections[0].data.length).toBe(1);
+    expect(result.current.sections[0].data[0].id).toBe("non-zero-value-token-op-id");
   });
 });

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/useOperationsV1.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/useOperationsV1.ts
@@ -1,10 +1,17 @@
 import { groupAccountsOperationsByDay } from "@ledgerhq/ledger-wallet-framework/account/groupOperations";
 import { isAddressPoisoningOperation } from "@ledgerhq/ledger-wallet-framework/operation";
+import { isSmallValueTokenOperation } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
 import { AccountLike, Operation } from "@ledgerhq/types-live";
 import { useCallback } from "react";
 import { useSelector } from "~/context/hooks";
-import { filterTokenOperationsZeroAmountEnabledSelector } from "~/reducers/settings";
+import {
+  counterValueCurrencySelector,
+  filterTokenOperationsZeroAmountEnabledSelector,
+  hideSmallValueTokenOperationsEnabledSelector,
+} from "~/reducers/settings";
+import { useCountervaluesState } from "~/reducers/countervalues";
 import { useAddressPoisoningOperationsFamilies } from "@ledgerhq/live-common/hooks/useAddressPoisoningOperationsFamilies";
+import { HISTORY_DUST_FILTER_THRESHOLD_USD } from "LLM/features/OperationsHistory/constants";
 
 export type UseOperationsV1Options = {
   filterOperation?: (operation: Operation, account: AccountLike) => boolean;
@@ -18,6 +25,11 @@ export function useOperationsV1(
   const shouldFilterTokenOpsZeroAmount = useSelector(
     filterTokenOperationsZeroAmountEnabledSelector,
   );
+  const shouldHideSmallValueTokenOperations = useSelector(
+    hideSmallValueTokenOperationsEnabledSelector,
+  );
+  const countervaluesState = useCountervaluesState();
+  const userCounterValueCurrency = useSelector(counterValueCurrencySelector);
 
   const addressPoisoningFamilies = useAddressPoisoningOperationsFamilies({
     shouldFilter: shouldFilterTokenOpsZeroAmount,
@@ -39,9 +51,31 @@ export function useOperationsV1(
 
       const shouldFilterOperation = !(shouldFilterTokenOpsZeroAmount && isOperationPoisoned);
 
-      return shouldFilterOperation;
+      if (!shouldFilterOperation) return false;
+
+      if (
+        shouldHideSmallValueTokenOperations &&
+        isSmallValueTokenOperation({
+          operation,
+          account,
+          countervaluesState,
+          userCounterValueCurrency,
+          thresholdUsd: HISTORY_DUST_FILTER_THRESHOLD_USD,
+        })
+      ) {
+        return false;
+      }
+
+      return true;
     },
-    [shouldFilterTokenOpsZeroAmount, addressPoisoningFamilies, externalFilter],
+    [
+      shouldFilterTokenOpsZeroAmount,
+      addressPoisoningFamilies,
+      externalFilter,
+      shouldHideSmallValueTokenOperations,
+      countervaluesState,
+      userCounterValueCurrency,
+    ],
   );
 
   const { sections, completed } = groupAccountsOperationsByDay(accounts, {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Desktop transaction history overflow menu and export dialog access
      - Mobile transaction history overflow menu and bottom sheet
      - Dust transaction filtering state, unread indicators, and history list filtering

### 📝 Description

This PR adds the dust filtering setting requested for LIVE-29298 and LIVE-29299 on the W4.0 transaction history screens. The setting is disabled by default and keeps the existing Settings toggle for zero-amount token operations unchanged.

Desktop and mobile now expose a transaction history options menu that can hide or show incoming token dust transactions below the $0.01 main-currency threshold. The same filtering path is applied to the rendered history lists and unread-history selectors, and the UI strings are added in English only.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29298](https://ledgerhq.atlassian.net/browse/LIVE-29298), [LIVE-29299](https://ledgerhq.atlassian.net/browse/LIVE-29299)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29298]: https://ledgerhq.atlassian.net/browse/LIVE-29298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ