### PR TITLE
[LWDM] feat(desktop): add history dust filtering

### DIFF
--- a/.changeset/fresh-history-desktop.md
+++ b/.changeset/fresh-history-desktop.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": minor
+---
+
+Add Desktop transaction history dust filtering controls.

--- a/apps/ledger-live-desktop/src/mvvm/features/History/HistoryView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/HistoryView.tsx
@@ -15,6 +15,10 @@ export function HistoryView({
   onExportClick,
   operationsCount,
   hasPendingOperations,
+  showDustFilterOption,
+  hideSmallValueTokenOperations,
+  dustFilterThreshold,
+  onToggleHideSmallValueTokenOperations,
 }: Readonly<HistoryViewModel>) {
   const operationsCountRef = useRef(operationsCount);
   const hasPendingOperationsRef = useRef(hasPendingOperations);
@@ -24,11 +28,15 @@ export function HistoryView({
       <TrackPage
         category="OperationList"
         operationsCount={operationsCountRef.current}
-        has_pending_operations={hasPendingOperationsRef.current ? true : false}
+        has_pending_operations={hasPendingOperationsRef.current}
       />
       <HistoryPageHeader
         onBack={showBackButton ? navigateBack : undefined}
         onExportClick={onExportClick}
+        showDustFilterOption={showDustFilterOption}
+        hideSmallValueTokenOperations={hideSmallValueTokenOperations}
+        dustFilterThreshold={dustFilterThreshold}
+        onToggleHideSmallValueTokenOperations={onToggleHideSmallValueTokenOperations}
       />
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <HistoryList

--- a/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { cleanup, render, screen, waitFor, within } from "tests/testSetup";
+import { cleanup, render, screen, waitFor, within, withFlagOverrides } from "tests/testSetup";
 import { useNavigate } from "react-router";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { useExportOperationsCsv } from "~/renderer/hooks/useExportOperationsCsv";
@@ -90,11 +90,12 @@ describe("History integration", () => {
     cleanup();
   });
 
-  function renderHistory(accounts: Account[] = [BTC_ACCOUNT]) {
+  function renderHistory(accounts: Account[] = [BTC_ACCOUNT], initialState = {}) {
     return render(<History />, {
       initialState: {
         accounts,
         settings: AFTER_ONBOARDING_STATE,
+        ...initialState,
       },
     });
   }
@@ -191,6 +192,27 @@ describe("History integration", () => {
 
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });
+
+  it("toggles dust filtering from the actions menu", async () => {
+    const { user, store } = renderHistory(
+      [BTC_ACCOUNT],
+      withFlagOverrides({ lwdDustFiltering: { enabled: true } }),
+    );
+
+    await user.click(await screen.findByTestId("history-actions-menu-button"));
+    expect(await screen.findByText("Transactions below US$0.01 will be hidden.")).toBeVisible();
+    await user.click(await screen.findByTestId("history-toggle-dust-filter-button"));
+
+    expect(store.getState().settings.hideSmallValueTokenOperations).toBe(true);
+  });
+
+  it("does not render the dust filtering action when the feature flag is disabled", async () => {
+    const { user } = renderHistory();
+
+    await user.click(await screen.findByTestId("history-actions-menu-button"));
+
+    expect(screen.queryByTestId("history-toggle-dust-filter-button")).not.toBeInTheDocument();
+  });
 });
 
 describe("History export dialog integration", () => {
@@ -225,6 +247,8 @@ describe("History export dialog integration", () => {
   }
 
   async function openExportDialog(user: ReturnType<typeof renderHistoryWithAccounts>["user"]) {
+    const menuButton = await screen.findByTestId("history-actions-menu-button");
+    await user.click(menuButton);
     const exportButton = await screen.findByTestId("history-export-csv-button");
     await user.click(exportButton);
     return within(await screen.findByRole("dialog"));

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryExportDialog/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryExportDialog/index.tsx
@@ -10,18 +10,31 @@ function HistoryExportDialogContent({
   return <HistoryExportDialogView {...vm} />;
 }
 
-export function HistoryExportDialog({ children }: Readonly<{ children: React.ReactNode }>) {
-  const [open, setOpen] = useState(false);
-  const [dialogHeight, setDialogHeight] = useState<"fixed" | "fit">("fixed");
+type Props = Readonly<{
+  children?: React.ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}>;
 
-  const handleOpenChange = useCallback((next: boolean) => {
-    setOpen(next);
-    if (!next) setDialogHeight("fixed");
-  }, []);
+export function HistoryExportDialog({ children, open: controlledOpen, onOpenChange }: Props) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const [dialogHeight, setDialogHeight] = useState<"fixed" | "fit">("fixed");
+  const open = controlledOpen ?? uncontrolledOpen;
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (controlledOpen === undefined) {
+        setUncontrolledOpen(next);
+      }
+      onOpenChange?.(next);
+      if (!next) setDialogHeight("fixed");
+    },
+    [controlledOpen, onOpenChange],
+  );
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange} height={dialogHeight}>
-      <DialogTrigger asChild>{children}</DialogTrigger>
+      {children ? <DialogTrigger asChild>{children}</DialogTrigger> : null}
       {open ? <HistoryExportDialogContent setDialogHeight={setDialogHeight} /> : null}
     </Dialog>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryPageHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryPageHeader.tsx
@@ -1,35 +1,46 @@
-import React from "react";
+import React, { useState } from "react";
 import PageHeader from "LLD/components/PageHeader";
-import { Button } from "@ledgerhq/lumen-ui-react";
-import { Csv } from "@ledgerhq/lumen-ui-react/symbols";
 import { useTranslation } from "react-i18next";
 import { HistoryExportDialog } from "./HistoryExportDialog";
+import { ActionsMenu } from "./HistoryPageHeader/ActionsMenu";
 
 type Props = Readonly<{
   onBack?: () => void;
   onExportClick: () => void;
+  showDustFilterOption: boolean;
+  hideSmallValueTokenOperations: boolean;
+  dustFilterThreshold: string;
+  onToggleHideSmallValueTokenOperations: () => void;
 }>;
 
-export default function HistoryPageHeader({ onBack, onExportClick }: Props) {
+export default function HistoryPageHeader({
+  onBack,
+  onExportClick,
+  showDustFilterOption,
+  hideSmallValueTokenOperations,
+  dustFilterThreshold,
+  onToggleHideSmallValueTokenOperations,
+}: Props) {
   const { t } = useTranslation();
+  const [isExportDialogOpen, setExportDialogOpen] = useState(false);
 
   return (
-    <PageHeader
-      title={t("history.title")}
-      onBack={onBack}
-      trailing={
-        <HistoryExportDialog>
-          <Button
-            appearance="transparent"
-            size="sm"
-            icon={Csv}
-            onClick={onExportClick}
-            data-testid="history-export-csv-button"
-          >
-            {t("history.actionsBar.csv")}
-          </Button>
-        </HistoryExportDialog>
-      }
-    />
+    <>
+      <HistoryExportDialog open={isExportDialogOpen} onOpenChange={setExportDialogOpen} />
+      <PageHeader
+        title={t("history.title")}
+        onBack={onBack}
+        trailing={
+          <ActionsMenu
+            onExportClick={onExportClick}
+            onOpenExportDialog={() => setExportDialogOpen(true)}
+            showDustFilterOption={showDustFilterOption}
+            hideSmallValueTokenOperations={hideSmallValueTokenOperations}
+            dustFilterThreshold={dustFilterThreshold}
+            onToggleHideSmallValueTokenOperations={onToggleHideSmallValueTokenOperations}
+          />
+        }
+      />
+    </>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryPageHeader/ActionsMenu.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryPageHeader/ActionsMenu.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { IconButton, Menu, MenuContent, MenuItem, MenuTrigger } from "@ledgerhq/lumen-ui-react";
+import { Csv, MoreVertical } from "@ledgerhq/lumen-ui-react/symbols";
+import { useTranslation } from "react-i18next";
+import { Dust } from "./Dust";
+
+type Props = Readonly<{
+  onExportClick: () => void;
+  onOpenExportDialog: () => void;
+  showDustFilterOption: boolean;
+  hideSmallValueTokenOperations: boolean;
+  dustFilterThreshold: string;
+  onToggleHideSmallValueTokenOperations: () => void;
+}>;
+
+export function ActionsMenu({
+  onExportClick,
+  onOpenExportDialog,
+  showDustFilterOption,
+  hideSmallValueTokenOperations,
+  dustFilterThreshold,
+  onToggleHideSmallValueTokenOperations,
+}: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <Menu>
+      <MenuTrigger
+        render={
+          <IconButton
+            appearance="transparent"
+            size="sm"
+            icon={MoreVertical}
+            aria-label={t("history.actionsBar.more")}
+            data-testid="history-actions-menu-button"
+          />
+        }
+      />
+      <MenuContent className="min-w-280" side="bottom" align="end">
+        <MenuItem
+          className="cursor-pointer"
+          onClick={() => {
+            onExportClick();
+            onOpenExportDialog();
+          }}
+          data-testid="history-export-csv-button"
+        >
+          <Csv size={20} />
+          {t("history.actionsBar.csv")}
+        </MenuItem>
+        {showDustFilterOption ? (
+          <Dust
+            hideSmallValueTokenOperations={hideSmallValueTokenOperations}
+            dustFilterThreshold={dustFilterThreshold}
+            onToggleHideSmallValueTokenOperations={onToggleHideSmallValueTokenOperations}
+          />
+        ) : null}
+      </MenuContent>
+    </Menu>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryPageHeader/Dust.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryPageHeader/Dust.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { MenuItem } from "@ledgerhq/lumen-ui-react";
+import { Eye, EyeCross } from "@ledgerhq/lumen-ui-react/symbols";
+import { useTranslation } from "react-i18next";
+
+type Props = Readonly<{
+  hideSmallValueTokenOperations: boolean;
+  dustFilterThreshold: string;
+  onToggleHideSmallValueTokenOperations: () => void;
+}>;
+
+export function Dust({
+  hideSmallValueTokenOperations,
+  dustFilterThreshold,
+  onToggleHideSmallValueTokenOperations,
+}: Props) {
+  const { t } = useTranslation();
+  const dustFilterLabel = hideSmallValueTokenOperations
+    ? t("history.actionsBar.showDustTransactions")
+    : t("history.actionsBar.hideDustTransactions");
+  const DustFilterIcon = hideSmallValueTokenOperations ? Eye : EyeCross;
+
+  return (
+    <MenuItem
+      className="cursor-pointer"
+      onClick={onToggleHideSmallValueTokenOperations}
+      data-testid="history-toggle-dust-filter-button"
+    >
+      <DustFilterIcon size={20} className="shrink-0" />
+      <span className="flex flex-col">
+        <span>{dustFilterLabel}</span>
+        <span className="body-3 text-muted">
+          {t("history.actionsBar.dustTransactionsDescription", {
+            threshold: dustFilterThreshold,
+          })}
+        </span>
+      </span>
+    </MenuItem>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/__tests__/OperationRow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/__tests__/OperationRow.test.tsx
@@ -67,7 +67,7 @@ const renderRow = (row: OperationRowType, onRowClick = jest.fn()) => {
 describe("History/OperationRow", () => {
   it("uses the family-scoped label for a coin currency with an override", () => {
     renderRow(makeRow());
-    expect(screen.getByText("Unstaking")).toBeInTheDocument();
+    expect(screen.getByText("Unstaking")).toBeVisible();
   });
 
   it("resolves the family from the parent currency for token operations", () => {
@@ -79,7 +79,7 @@ describe("History/OperationRow", () => {
         operation: makeOperation({ type: "IN" }),
       }),
     );
-    expect(screen.getByText("Received")).toBeInTheDocument();
+    expect(screen.getByText("Received")).toBeVisible();
   });
 
   it("shows the failed label for failed operations", () => {
@@ -89,7 +89,7 @@ describe("History/OperationRow", () => {
         operation: makeOperation({ type: "OUT", hasFailed: true }),
       }),
     );
-    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(screen.getByText("Failed")).toBeVisible();
   });
 
   it("forwards row clicks", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/History/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/constants.ts
@@ -1,0 +1,1 @@
+export const HISTORY_DUST_FILTER_THRESHOLD_USD = 0.01;

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryOperations.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryOperations.test.ts
@@ -1,12 +1,85 @@
-import { renderHook } from "tests/testSetup";
+import BigNumber from "bignumber.js";
+import { renderHook, withFlagOverrides } from "tests/testSetup";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { calculate } from "@ledgerhq/live-countervalues/logic";
 import { maticEth, usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import type { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
 import { useHistoryOperations } from "../useHistoryOperations";
 import { BTC_ACCOUNT, ETH_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
 
+jest.mock("@ledgerhq/live-countervalues/logic", () => ({
+  ...jest.requireActual("@ledgerhq/live-countervalues/logic"),
+  calculate: jest.fn(),
+}));
+
+const ZERO_VALUE_TOKEN_OP_ID = "zero-value-token-op-id";
+const NON_ZERO_VALUE_TOKEN_OP_ID = "non-zero-value-token-op-id";
+const SMALL_NON_ZERO_TOKEN_OP_ID = "small-non-zero-token-op-id";
+const LARGE_NON_ZERO_TOKEN_OP_ID = "large-non-zero-token-op-id";
+
+const mockCalculate = calculate as jest.MockedFunction<typeof calculate>;
+
+function createTokenOperation(tokenAccountId: string, id: string, value: BigNumber): Operation {
+  return {
+    id,
+    hash: id,
+    type: "IN",
+    value,
+    fee: new BigNumber(0),
+    senders: ["0xsender"],
+    recipients: ["0xrecipient"],
+    blockHash: "0xblock",
+    blockHeight: 1,
+    accountId: tokenAccountId,
+    date: new Date(),
+    extra: {},
+  };
+}
+
+function createAccountWithTokenOperations(
+  seed: string,
+  operations: Array<{ id: string; value: BigNumber }>,
+): Account {
+  const ethRoot = genAccount(seed, {
+    currency: ETH_ACCOUNT.currency,
+    subAccountsCount: 0,
+    operationsSize: 0,
+  });
+  const usdc = genTokenAccount(0, ethRoot, usdcToken);
+
+  const tokenAccountWithOperations: TokenAccount = {
+    ...usdc,
+    operations: operations.map(({ id, value }) => createTokenOperation(usdc.id, id, value)),
+    operationsCount: operations.length,
+  };
+
+  return {
+    ...ethRoot,
+    subAccounts: [tokenAccountWithOperations],
+  };
+}
+
+function createAccountWithZeroValueTokenOperation(): Account {
+  return createAccountWithTokenOperations("eth-zero-value-token", [
+    { id: ZERO_VALUE_TOKEN_OP_ID, value: new BigNumber(0) },
+    { id: NON_ZERO_VALUE_TOKEN_OP_ID, value: new BigNumber(1) },
+  ]);
+}
+
+function createAccountWithNonZeroValueTokenOperations(): Account {
+  return createAccountWithTokenOperations("eth-non-zero-value-token", [
+    { id: SMALL_NON_ZERO_TOKEN_OP_ID, value: new BigNumber(1) },
+    { id: LARGE_NON_ZERO_TOKEN_OP_ID, value: new BigNumber(2) },
+  ]);
+}
+
 describe("useHistoryOperations", () => {
+  beforeEach(() => {
+    mockCalculate.mockReset();
+  });
+
   it("returns an empty array when there are no accounts", () => {
     const { result } = renderHook(() => useHistoryOperations(), {
       initialState: { accounts: [], settings: INITIAL_STATE },
@@ -73,6 +146,86 @@ describe("useHistoryOperations", () => {
     const items = result.current;
     expect(items.length).toBeGreaterThan(0);
     expect(items.every(item => item.account.id === usdc.id)).toBe(true);
+  });
+
+  it("keeps zero-value token operations when dust filtering is disabled", () => {
+    const account = createAccountWithZeroValueTokenOperation();
+
+    const { result } = renderHook(() => useHistoryOperations(), {
+      initialState: {
+        accounts: [account],
+        settings: {
+          ...INITIAL_STATE,
+          filterTokenOperationsZeroAmount: false,
+          hideSmallValueTokenOperations: false,
+        },
+      },
+    });
+
+    expect(result.current.map(item => item.operation.id)).toEqual(
+      expect.arrayContaining([ZERO_VALUE_TOKEN_OP_ID, NON_ZERO_VALUE_TOKEN_OP_ID]),
+    );
+  });
+
+  it("filters zero-value token operations when dust filtering is enabled", () => {
+    const account = createAccountWithZeroValueTokenOperation();
+
+    const { result } = renderHook(() => useHistoryOperations(), {
+      initialState: {
+        accounts: [account],
+        settings: {
+          ...INITIAL_STATE,
+          filterTokenOperationsZeroAmount: false,
+          hideSmallValueTokenOperations: true,
+        },
+        ...withFlagOverrides({ lwdDustFiltering: { enabled: true } }),
+      },
+    });
+
+    expect(result.current.map(item => item.operation.id)).toEqual([NON_ZERO_VALUE_TOKEN_OP_ID]);
+  });
+
+  it("filters non-zero token operations below the dust countervalue threshold", () => {
+    const account = createAccountWithNonZeroValueTokenOperations();
+    mockCalculate.mockImplementation((_state, query) => {
+      if (query.from === usdcToken && query.value === 1) return 0.5;
+      if (query.from === usdcToken && query.value === 2) return 2;
+      if (query.from.ticker === "USD") return 1;
+      return null;
+    });
+
+    const { result } = renderHook(() => useHistoryOperations(), {
+      initialState: {
+        accounts: [account],
+        settings: {
+          ...INITIAL_STATE,
+          filterTokenOperationsZeroAmount: false,
+          hideSmallValueTokenOperations: true,
+        },
+        ...withFlagOverrides({ lwdDustFiltering: { enabled: true } }),
+      },
+    });
+
+    expect(result.current.map(item => item.operation.id)).toEqual([LARGE_NON_ZERO_TOKEN_OP_ID]);
+  });
+
+  it("keeps zero-value token operations when the dust feature flag is disabled", () => {
+    const account = createAccountWithZeroValueTokenOperation();
+
+    const { result } = renderHook(() => useHistoryOperations(), {
+      initialState: {
+        accounts: [account],
+        settings: {
+          ...INITIAL_STATE,
+          filterTokenOperationsZeroAmount: false,
+          hideSmallValueTokenOperations: true,
+        },
+      },
+    });
+
+    expect(result.current.map(item => item.operation.id)).toEqual(
+      expect.arrayContaining([ZERO_VALUE_TOKEN_OP_ID, NON_ZERO_VALUE_TOKEN_OP_ID]),
+    );
   });
 
   describe("isUnread flag", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryViewModel.test.ts
@@ -1,6 +1,13 @@
-import { renderHook, act } from "tests/testSetup";
+import { renderHook, act, waitFor, withFlagOverrides } from "tests/testSetup";
 import { useNavigate, useLocation } from "react-router";
-import { useHistoryViewModel } from "../useHistoryViewModel";
+import { formatDustFilterThreshold, useHistoryViewModel } from "../useHistoryViewModel";
+import { importCountervalues } from "@ledgerhq/live-countervalues/logic";
+import type {
+  CountervaluesSettings,
+  CounterValuesStateRaw,
+} from "@ledgerhq/live-countervalues/types";
+import { getFiatCurrencyByTicker } from "@ledgerhq/live-common/currencies/index";
+import type { CountervaluesState } from "~/renderer/reducers/countervalues";
 
 jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
@@ -30,11 +37,45 @@ jest.mock("../useHistoryVirtualization", () => ({
 const mockNavigate = jest.fn();
 const mockUseNavigate = jest.mocked(useNavigate);
 const mockUseLocation = jest.mocked(useLocation);
+const USD = getFiatCurrencyByTicker("USD");
+const EUR = getFiatCurrencyByTicker("EUR");
+const countervaluesSettings: CountervaluesSettings = {
+  trackingPairs: [{ from: USD, to: EUR, startDate: new Date("2026-01-01T00:00:00.000Z") }],
+  autofillGaps: false,
+  refreshRate: 60000,
+  marketCapBatchingAfterRank: 100,
+};
+
+const buildUsdEurCountervaluesState = (): CountervaluesState => ({
+  countervalues: {
+    state: importCountervalues(
+      {
+        status: {},
+        "EUR USD": { latest: 0.92 },
+      } as CounterValuesStateRaw,
+      countervaluesSettings,
+    ),
+    pending: false,
+    error: null,
+  },
+  polling: {
+    isPolling: true,
+    triggerLoad: false,
+  },
+  userSettings: countervaluesSettings,
+});
 
 describe("useHistoryViewModel navigateBack", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseNavigate.mockReturnValue(mockNavigate);
+    mockUseLocation.mockReturnValue({
+      pathname: "/history",
+      state: null,
+      key: "default",
+      search: "",
+      hash: "",
+    });
   });
 
   it("shows back button and pops the stack when historyBackPath is set", () => {
@@ -58,16 +99,70 @@ describe("useHistoryViewModel navigateBack", () => {
   });
 
   it("hides back button when historyBackPath is missing", () => {
-    mockUseLocation.mockReturnValue({
-      pathname: "/history",
-      state: null,
-      key: "default",
-      search: "",
-      hash: "",
-    });
-
     const { result } = renderHook(() => useHistoryViewModel());
 
     expect(result.current.showBackButton).toBe(false);
+  });
+
+  it("should format the dust filter threshold in USD without a reference conversion", () => {
+    const { result } = renderHook(() => useHistoryViewModel(), {
+      initialState: {
+        settings: { counterValue: "USD", locale: "en-US" },
+        ...withFlagOverrides({ lwdDustFiltering: { enabled: true } }),
+      },
+    });
+
+    expect(result.current.dustFilterThreshold).toBe("US$0.01");
+  });
+
+  it("should format the dust filter threshold with the USD reference when the countervalue is not USD", () => {
+    expect(
+      formatDustFilterThreshold({
+        countervaluesState: buildUsdEurCountervaluesState().countervalues.state,
+        counterValueCurrency: EUR,
+        locale: "en-US",
+        thresholdUsd: 0.01,
+      }),
+    ).toBe("US$0.01 (€0.0092)");
+  });
+
+  it("should format the converted dust filter threshold with the current locale", () => {
+    expect(
+      formatDustFilterThreshold({
+        countervaluesState: buildUsdEurCountervaluesState().countervalues.state,
+        counterValueCurrency: EUR,
+        locale: "fr-FR",
+        thresholdUsd: 0.01,
+      }),
+    ).toBe("US$0,01 (€0,0092)");
+  });
+
+  it("should request USD countervalue tracking when the dust filter option is shown for a non-USD countervalue", async () => {
+    const { store } = renderHook(() => useHistoryViewModel(), {
+      initialState: {
+        settings: { counterValue: "EUR", locale: "en-US" },
+        ...withFlagOverrides({ lwdDustFiltering: { enabled: true } }),
+      },
+    });
+
+    await waitFor(() =>
+      expect(store.getState().countervaluesExtraTracking.extraTrackingPairs).toEqual([
+        expect.objectContaining({
+          from: expect.objectContaining({ ticker: "USD" }),
+          to: expect.objectContaining({ ticker: "EUR" }),
+        }),
+      ]),
+    );
+  });
+
+  it("should not request USD countervalue tracking when the dust filter option is hidden", () => {
+    const { store } = renderHook(() => useHistoryViewModel(), {
+      initialState: {
+        settings: { counterValue: "EUR", locale: "en-US" },
+        ...withFlagOverrides({ lwdDustFiltering: { enabled: false } }),
+      },
+    });
+
+    expect(store.getState().countervaluesExtraTracking.extraTrackingPairs).toEqual([]);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryOperationItemsForRootAccounts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryOperationItemsForRootAccounts.ts
@@ -1,14 +1,17 @@
-import { useMemo, useCallback } from "react";
+import { useMemo } from "react";
 import { useSelector } from "LLD/hooks/redux";
 import { selectFeature } from "@shared/feature-flags";
-import type { Account, AccountLike, Operation } from "@ledgerhq/types-live";
-import { isAddressPoisoningOperation } from "@ledgerhq/ledger-wallet-framework/operation";
+import type { Account } from "@ledgerhq/types-live";
 import { filterTokenOperationsZeroAmountSelector } from "~/renderer/reducers/settings";
 import {
   buildHistoryOperationItems,
+  buildHistoryOperationFilter,
   getAddressPoisoningFamiliesForFilter,
 } from "../utils/historyOperationItems";
-import { lastSeenOperationDateSelector } from "~/renderer/reducers/history";
+import {
+  historyDustFilterOptionsSelector,
+  lastSeenOperationDateSelector,
+} from "~/renderer/reducers/history";
 import type { State } from "~/renderer/reducers";
 import type { OperationTableItem } from "../types";
 
@@ -19,6 +22,7 @@ export function useHistoryOperationItemsForRootAccounts(
   const currenciesSettings = useSelector((state: State) => state.settings.currenciesSettings);
   const lastSeenOperationDate = useSelector(lastSeenOperationDateSelector);
   const shouldFilterTokenOps = useSelector(filterTokenOperationsZeroAmountSelector);
+  const dustFilterOptions = useSelector(historyDustFilterOptionsSelector);
   const poisoningFeature = useSelector((state: State) =>
     selectFeature(state, "addressPoisoningOperationsFilter"),
   );
@@ -28,16 +32,14 @@ export function useHistoryOperationItemsForRootAccounts(
     [shouldFilterTokenOps, poisoningFeature],
   );
 
-  const filterOperation = useCallback(
-    (operation: Operation, account: AccountLike) => {
-      if (!shouldFilterTokenOps) return true;
-      return !isAddressPoisoningOperation(
-        operation,
-        account,
-        addressPoisoningFamilies ? { families: addressPoisoningFamilies } : undefined,
-      );
-    },
-    [shouldFilterTokenOps, addressPoisoningFamilies],
+  const filterOperation = useMemo(
+    () =>
+      buildHistoryOperationFilter({
+        shouldFilterTokenOps,
+        addressPoisoningFamilies,
+        ...dustFilterOptions,
+      }),
+    [shouldFilterTokenOps, addressPoisoningFamilies, dustFilterOptions],
   );
 
   return useMemo(

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryViewModel.ts
@@ -1,6 +1,23 @@
 import { useCallback, useEffect, useMemo } from "react";
-import { useDispatch } from "LLD/hooks/redux";
-import { markOperationsAsSeen } from "~/renderer/reducers/history";
+import BigNumber from "bignumber.js";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import {
+  convertThresholdFromUsdToCountervalueMinorUnit,
+  floorThresholdToCurrencyMinorUnit,
+  SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
+} from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import type { Currency, Unit } from "@ledgerhq/types-cryptoassets";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { useHideSmallValueTokenOperations } from "~/renderer/actions/settings";
+import { addExtraTrackingPairs } from "~/renderer/reducers/countervaluesExtraTracking";
+import {
+  historyDustFilterCounterValueCurrencyForDisplaySelector,
+  historyDustFilterCountervaluesStateForDisplaySelector,
+  historyDustFilteringFeatureEnabledSelector,
+  historyDustFilterLocaleSelector,
+  markOperationsAsSeen,
+} from "~/renderer/reducers/history";
 import type { Virtualizer } from "@tanstack/react-virtual";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
@@ -11,6 +28,67 @@ import type { HistoryTable, OperationRow, VirtualItem } from "../types";
 import { track } from "~/renderer/analytics/segment";
 import { parseHistoryBackPath } from "../utils/historyLocationState";
 import { usePopNavigationBack } from "LLD/utils/usePopNavigationBack";
+import { HISTORY_DUST_FILTER_THRESHOLD_USD } from "../constants";
+
+export function formatDustFilterThreshold({
+  countervaluesState,
+  counterValueCurrency,
+  locale,
+  thresholdUsd,
+}: {
+  countervaluesState?: CounterValuesState;
+  counterValueCurrency: Currency;
+  locale: string | undefined | null;
+  thresholdUsd: number;
+}) {
+  const formatThreshold = (currency: Currency, unit: Unit = currency.units[0]) => {
+    const thresholdMinorUnit =
+      floorThresholdToCurrencyMinorUnit(thresholdUsd, currency) ?? new BigNumber(0);
+
+    return formatCurrencyUnit(unit, thresholdMinorUnit, {
+      showCode: true,
+      locale: locale ?? undefined,
+    });
+  };
+  const formatCounterValueThreshold = (currency: Currency, thresholdMinorUnit: BigNumber) => {
+    const unit = currency.units[0];
+    const amount = thresholdMinorUnit.div(new BigNumber(10).pow(unit.magnitude));
+    const fractionDigits = Math.min(Math.max(unit.magnitude + 2, 4), 8);
+    const formattedAmount = new Intl.NumberFormat(locale ?? undefined, {
+      maximumFractionDigits: fractionDigits,
+      minimumFractionDigits: 0,
+      useGrouping: false,
+    }).format(amount.toNumber());
+
+    return unit.prefixCode
+      ? `${unit.code}${formattedAmount}`
+      : `${formattedAmount}\u00A0${unit.code}`;
+  };
+
+  const referenceThreshold = formatThreshold(SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY, {
+    ...SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY.units[0],
+    code: "US$",
+  });
+
+  if (counterValueCurrency.ticker === SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY.ticker) {
+    return referenceThreshold;
+  }
+
+  if (!countervaluesState) return referenceThreshold;
+
+  const counterValueThresholdMinorUnit = convertThresholdFromUsdToCountervalueMinorUnit({
+    counterValueCurrency,
+    countervaluesState,
+    thresholdUsd,
+  });
+
+  if (!counterValueThresholdMinorUnit) return referenceThreshold;
+
+  return `${referenceThreshold} (${formatCounterValueThreshold(
+    counterValueCurrency,
+    counterValueThresholdMinorUnit,
+  )})`;
+}
 
 export type HistoryViewModel = {
   showBackButton: boolean;
@@ -23,6 +101,10 @@ export type HistoryViewModel = {
   onExportClick: () => void;
   operationsCount: number;
   hasPendingOperations: boolean;
+  showDustFilterOption: boolean;
+  hideSmallValueTokenOperations: boolean;
+  dustFilterThreshold: string;
+  onToggleHideSmallValueTokenOperations: () => void;
 };
 
 export function useHistoryViewModel(): HistoryViewModel {
@@ -55,6 +137,45 @@ export function useHistoryViewModel(): HistoryViewModel {
   const onExportClick = () => track("ExportAccountOperations");
   const operationsCount = flatItems.length;
   const hasPendingOperations = useMemo(() => operations.some(op => op.isPending), [operations]);
+  const [hideSmallValueTokenOperations, setHideSmallValueTokenOperations] =
+    useHideSmallValueTokenOperations();
+  const showDustFilterOption = useSelector(historyDustFilteringFeatureEnabledSelector);
+  const counterValueCurrency = useSelector(historyDustFilterCounterValueCurrencyForDisplaySelector);
+  const countervaluesState = useSelector(historyDustFilterCountervaluesStateForDisplaySelector);
+  useEffect(() => {
+    if (
+      !showDustFilterOption ||
+      !counterValueCurrency ||
+      counterValueCurrency.ticker === SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY.ticker
+    ) {
+      return;
+    }
+
+    dispatch(
+      addExtraTrackingPairs([
+        {
+          from: SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
+          to: counterValueCurrency,
+          startDate: new Date(),
+        },
+      ]),
+    );
+  }, [counterValueCurrency, dispatch, showDustFilterOption]);
+  const locale = useSelector(historyDustFilterLocaleSelector);
+  const dustFilterThreshold = useMemo(() => {
+    if (!counterValueCurrency) return "";
+
+    return formatDustFilterThreshold({
+      countervaluesState,
+      counterValueCurrency,
+      locale,
+      thresholdUsd: HISTORY_DUST_FILTER_THRESHOLD_USD,
+    });
+  }, [countervaluesState, counterValueCurrency, locale]);
+  const onToggleHideSmallValueTokenOperations = useCallback(() => {
+    if (!showDustFilterOption) return;
+    setHideSmallValueTokenOperations(!hideSmallValueTokenOperations);
+  }, [hideSmallValueTokenOperations, setHideSmallValueTokenOperations, showDustFilterOption]);
 
   return {
     showBackButton,
@@ -67,5 +188,9 @@ export function useHistoryViewModel(): HistoryViewModel {
     onExportClick,
     operationsCount,
     hasPendingOperations,
+    showDustFilterOption,
+    hideSmallValueTokenOperations,
+    dustFilterThreshold,
+    onToggleHideSmallValueTokenOperations,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/History/utils/historyOperationItems.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/utils/historyOperationItems.ts
@@ -1,12 +1,14 @@
 import type { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import type { Features } from "@shared/feature-flags";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoCurrency, Currency } from "@ledgerhq/types-cryptoassets";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
 import { getEnv } from "@ledgerhq/live-env";
 import {
   flattenAccounts,
   getAccountCurrency,
   getMainAccount,
 } from "@ledgerhq/live-common/account/index";
+import { isSmallValueTokenOperation } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
 import {
   getOperationAmountNumber,
   flattenOperationWithInternalsAndNfts,
@@ -16,10 +18,21 @@ import { isAddressPoisoningOperation } from "@ledgerhq/ledger-wallet-framework/o
 import { currencySettingsDefaults, type CurrencySettings } from "~/renderer/reducers/settings";
 import { getOperationCounterpartyAddress } from "./getOperationCounterpartyAddress";
 import type { OperationTableItem } from "../types";
+import { HISTORY_DUST_FILTER_THRESHOLD_USD } from "../constants";
 
 type AccountInfo = { account: AccountLike; parentAccount?: Account };
 type FilterFn = (operation: Operation, account: AccountLike) => boolean;
 type TaggedOperation = { operation: Operation; isPending: boolean };
+export type HistoryOperationFilterOptions = {
+  readonly shouldFilterTokenOps: boolean;
+  readonly addressPoisoningFamilies: string[] | null;
+  readonly shouldHideSmallValueTokenOperations?: boolean;
+  readonly countervaluesState?: CounterValuesState;
+  readonly userCounterValueCurrency?: Currency;
+};
+export type HistoryUnreadOperationsOptions = HistoryOperationFilterOptions & {
+  readonly currenciesSettings: Record<string, CurrencySettings>;
+};
 
 export function parseLastSeenMs(iso: string | null): number | null {
   if (!iso) return null;
@@ -164,6 +177,44 @@ export function buildHistoryOperationItems(
   return items.sort((a, b) => b.date.getTime() - a.date.getTime());
 }
 
+export function buildHistoryOperationFilter({
+  shouldFilterTokenOps,
+  addressPoisoningFamilies,
+  shouldHideSmallValueTokenOperations = false,
+  countervaluesState,
+  userCounterValueCurrency,
+}: HistoryOperationFilterOptions): FilterFn {
+  return (operation, account) => {
+    if (
+      shouldFilterTokenOps &&
+      isAddressPoisoningOperation(
+        operation,
+        account,
+        addressPoisoningFamilies ? { families: addressPoisoningFamilies } : undefined,
+      )
+    ) {
+      return false;
+    }
+
+    if (
+      shouldHideSmallValueTokenOperations &&
+      countervaluesState &&
+      userCounterValueCurrency &&
+      isSmallValueTokenOperation({
+        operation,
+        account,
+        countervaluesState,
+        userCounterValueCurrency,
+        thresholdUsd: HISTORY_DUST_FILTER_THRESHOLD_USD,
+      })
+    ) {
+      return false;
+    }
+
+    return true;
+  };
+}
+
 /**
  * True when any operation that would appear in the global History list is newer than `lastSeenDate`.
  * Uses the same flattening, pending merge, and filters as {@link buildHistoryOperationItems}.
@@ -171,22 +222,13 @@ export function buildHistoryOperationItems(
 export function historyHasUnreadOperations(
   accounts: Account[],
   lastSeenDate: string | null,
-  currenciesSettings: Record<string, CurrencySettings>,
-  shouldFilterTokenOps: boolean,
-  addressPoisoningFamilies: string[] | null,
+  options: HistoryUnreadOperationsOptions,
 ): boolean {
   if (!lastSeenDate) return false;
   const lastSeenTs = parseLastSeenMs(lastSeenDate);
-  const filterOperation: FilterFn = (operation, account) => {
-    if (!shouldFilterTokenOps) return true;
-    return !isAddressPoisoningOperation(
-      operation,
-      account,
-      addressPoisoningFamilies ? { families: addressPoisoningFamilies } : undefined,
-    );
-  };
+  const filterOperation = buildHistoryOperationFilter(options);
   const getConfirmationsNb = (mainAccount: Account) =>
-    getConfirmationsNbForCurrency(currenciesSettings, mainAccount.currency);
+    getConfirmationsNbForCurrency(options.currenciesSettings, mainAccount.currency);
   const accountsMap = buildAccountsMap(accounts);
   const items = buildOperationItems(accountsMap, filterOperation, getConfirmationsNb, lastSeenTs);
   return items.some(item => item.isUnread);

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -10,6 +10,7 @@ import {
   AnalyticsConsentInfo,
   SettingsState as Settings,
   hideEmptyTokenAccountsSelector,
+  hideSmallValueTokenOperationsSelector,
   filterTokenOperationsZeroAmountSelector,
   selectedTimeRangeSelector,
   SettingsState,
@@ -190,6 +191,24 @@ export function useFilterTokenOperationsZeroAmount(): [
           }),
         );
       }
+    },
+    [dispatch],
+  );
+  return [value, setter];
+}
+export function useHideSmallValueTokenOperations(): [
+  boolean,
+  (hideSmallValueTokenOperations: boolean) => void,
+] {
+  const dispatch = useDispatch();
+  const value = useSelector(hideSmallValueTokenOperationsSelector);
+  const setter = useCallback(
+    (hideSmallValueTokenOperations: boolean) => {
+      dispatch(
+        saveSettings({
+          hideSmallValueTokenOperations,
+        }),
+      );
     },
     [dispatch],
   );

--- a/apps/ledger-live-desktop/src/renderer/reducers/__tests__/history.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/__tests__/history.test.ts
@@ -1,4 +1,8 @@
-import type { Account, AccountLike } from "@ledgerhq/types-live";
+import BigNumber from "bignumber.js";
+import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { initialState as countervaluesInitialState } from "@ledgerhq/live-countervalues/logic";
+import type { CountervaluesSettings } from "@ledgerhq/live-countervalues/types";
+import type { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import { FEATURE_FLAGS_INITIAL_STATE } from "@shared/feature-flags";
 import {
   BTC_ACCOUNT,
@@ -6,6 +10,7 @@ import {
   ETH_ACCOUNT,
   ETH_ACCOUNT_WITH_USDC,
 } from "LLD/features/__mocks__/accounts.mock";
+import { usdcToken } from "LLD/features/__mocks__/useSelectAssetFlow.mock";
 import historyReducer, {
   type HistoryState,
   markOperationsAsSeen,
@@ -14,6 +19,7 @@ import historyReducer, {
   hasUnreadOperationsSelector,
 } from "../history";
 import type { State } from "../index";
+import type { CountervaluesState } from "../countervalues";
 
 const settingsUnreadBase = {
   currenciesSettings: {},
@@ -37,6 +43,86 @@ function makeUnreadTestState(lastSeenDate: string | null, accounts: Account[]): 
     settings: settingsUnreadBase,
     featureFlags: FEATURE_FLAGS_INITIAL_STATE,
   } as unknown as State;
+}
+
+function createCountervaluesState(): CountervaluesState {
+  return {
+    countervalues: {
+      state: countervaluesInitialState,
+      pending: false,
+      error: null,
+    },
+    polling: {
+      isPolling: true,
+      triggerLoad: false,
+    },
+    userSettings: {
+      trackingPairs: [],
+      autofillGaps: true,
+      refreshRate: 0,
+      marketCapBatchingAfterRank: 0,
+    } satisfies CountervaluesSettings,
+  };
+}
+
+function createAccountWithUnreadZeroValueTokenOperation(): Account {
+  const parentAccount = genAccount("history-test-dust-desktop", {
+    currency: ETH_ACCOUNT.currency,
+    operationsSize: 0,
+    subAccountsCount: 0,
+  });
+  const tokenAccount = genTokenAccount(0, parentAccount, usdcToken);
+  const tokenOperation = {
+    id: "history-test-dust-zero-value-token-op",
+    hash: "0xdust",
+    type: "IN",
+    value: new BigNumber(0),
+    fee: new BigNumber(0),
+    senders: ["0xsender"],
+    recipients: ["0xrecipient"],
+    blockHash: "0xblock",
+    blockHeight: 1,
+    accountId: tokenAccount.id,
+    date: new Date("2024-12-01T00:00:00.000Z"),
+    extra: {},
+  } satisfies Operation;
+
+  return {
+    ...parentAccount,
+    subAccounts: [
+      {
+        ...tokenAccount,
+        operations: [tokenOperation],
+        operationsCount: 1,
+      },
+    ],
+  };
+}
+
+function withDustPreferenceEnabled(state: State): State {
+  return {
+    ...state,
+    settings: {
+      ...state.settings,
+      hideSmallValueTokenOperations: true,
+    },
+  };
+}
+
+function withDustFeatureEnabled(state: State): State {
+  return {
+    ...state,
+    countervalues: createCountervaluesState(),
+    featureFlags: {
+      ...state.featureFlags,
+      resolved: {
+        ...state.featureFlags.resolved,
+        lwdDustFiltering: {
+          enabled: true,
+        },
+      },
+    },
+  };
 }
 
 describe("historyReducer", () => {
@@ -118,5 +204,31 @@ describe("hasUnreadOperationsSelector", () => {
   it("returns false when lastSeenOperationDate is in the future", () => {
     const future = new Date("2099-01-01").toISOString();
     expect(hasUnreadOperationsSelector(makeUnreadTestState(future, [BTC_ACCOUNT]))).toBe(false);
+  });
+
+  it("ignores the dust preference when the dust filter feature flag is disabled", () => {
+    const accountWithDustOperation = createAccountWithUnreadZeroValueTokenOperation();
+
+    expect(
+      hasUnreadOperationsSelector(
+        withDustPreferenceEnabled(
+          makeUnreadTestState("2024-06-01T00:00:00.000Z", [accountWithDustOperation]),
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("filters dust operations when the dust preference and feature flag are enabled", () => {
+    const accountWithDustOperation = createAccountWithUnreadZeroValueTokenOperation();
+
+    expect(
+      hasUnreadOperationsSelector(
+        withDustFeatureEnabled(
+          withDustPreferenceEnabled(
+            makeUnreadTestState("2024-06-01T00:00:00.000Z", [accountWithDustOperation]),
+          ),
+        ),
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/reducers/history.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/history.ts
@@ -1,12 +1,22 @@
-import { createSelector, createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { createSelector } from "reselect";
 import { selectFeature } from "@shared/feature-flags";
 import {
   getAddressPoisoningFamiliesForFilter,
   historyHasUnreadOperations,
+  type HistoryOperationFilterOptions,
+  type HistoryUnreadOperationsOptions,
 } from "LLD/features/History/utils/historyOperationItems";
 import type { State } from ".";
 import { accountsSelector } from "./accounts";
-import { filterTokenOperationsZeroAmountSelector } from "./settings";
+import {
+  counterValueCurrencySelector,
+  filterTokenOperationsZeroAmountSelector,
+  hideSmallValueTokenOperationsSelector,
+  localeSelector,
+} from "./settings";
+import { countervaluesStateSelector } from "./countervalues";
+import { SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
 
 export type HistoryState = {
   lastSeenOperationDate: string | null;
@@ -35,6 +45,87 @@ export default historySlice.reducer;
 export const lastSeenOperationDateSelector = (state: Pick<State, "history">): string | null =>
   state.history.lastSeenOperationDate;
 
+export const historyDustFilteringFeatureEnabledSelector = (state: State) =>
+  selectFeature(state, "lwdDustFiltering")?.enabled === true;
+
+export const hideSmallValueTokenOperationsEffectiveSelector = createSelector(
+  historyDustFilteringFeatureEnabledSelector,
+  hideSmallValueTokenOperationsSelector,
+  (isHistoryDustFilteringFeatureEnabled, hideSmallValueTokenOperations) =>
+    isHistoryDustFilteringFeatureEnabled && hideSmallValueTokenOperations,
+);
+
+const selectWhenDustFilterEnabled = <T>(
+  state: State,
+  selector: (state: State) => T,
+): T | undefined =>
+  hideSmallValueTokenOperationsEffectiveSelector(state) ? selector(state) : undefined;
+
+const dustFilterCountervaluesStateSelector = (state: State) =>
+  selectWhenDustFilterEnabled(state, countervaluesStateSelector);
+
+const dustFilterCounterValueCurrencySelector = (state: State) =>
+  selectWhenDustFilterEnabled(state, counterValueCurrencySelector);
+
+export const historyDustFilterOptionsSelector = createSelector(
+  hideSmallValueTokenOperationsEffectiveSelector,
+  dustFilterCountervaluesStateSelector,
+  dustFilterCounterValueCurrencySelector,
+  (
+    shouldHideSmallValueTokenOperations,
+    countervaluesState,
+    userCounterValueCurrency,
+  ): Pick<
+    HistoryOperationFilterOptions,
+    "shouldHideSmallValueTokenOperations" | "countervaluesState" | "userCounterValueCurrency"
+  > => ({
+    shouldHideSmallValueTokenOperations,
+    countervaluesState,
+    userCounterValueCurrency,
+  }),
+);
+
+export const historyDustFilterCounterValueCurrencyForDisplaySelector = (state: State) =>
+  historyDustFilteringFeatureEnabledSelector(state)
+    ? counterValueCurrencySelector(state)
+    : undefined;
+
+export const historyDustFilterCountervaluesStateForDisplaySelector = (state: State) => {
+  const counterValueCurrency = historyDustFilterCounterValueCurrencyForDisplaySelector(state);
+  if (
+    !counterValueCurrency ||
+    counterValueCurrency.ticker === SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY.ticker
+  ) {
+    return undefined;
+  }
+
+  return countervaluesStateSelector(state);
+};
+
+export const historyDustFilterLocaleSelector = (state: State) =>
+  historyDustFilteringFeatureEnabledSelector(state) ? localeSelector(state) : undefined;
+
+const historyUnreadOperationsOptionsSelector = createSelector(
+  (state: State) => state.settings.currenciesSettings,
+  filterTokenOperationsZeroAmountSelector,
+  historyDustFilterOptionsSelector,
+  (state: State) => selectFeature(state, "addressPoisoningOperationsFilter"),
+  (
+    currenciesSettings,
+    shouldFilterTokenOps,
+    dustFilterOptions,
+    poisoningFeature,
+  ): HistoryUnreadOperationsOptions => ({
+    currenciesSettings,
+    shouldFilterTokenOps,
+    addressPoisoningFamilies: getAddressPoisoningFamiliesForFilter(
+      shouldFilterTokenOps,
+      poisoningFeature,
+    ),
+    ...dustFilterOptions,
+  }),
+);
+
 /**
  * Returns true when any operation shown in global History is newer than lastSeenOperationDate
  * (same pipeline as the History list: flattened accounts, pending ops, address-poisoning filter).
@@ -43,18 +134,9 @@ export const lastSeenOperationDateSelector = (state: Pick<State, "history">): st
 export const hasUnreadOperationsSelector = createSelector(
   accountsSelector,
   lastSeenOperationDateSelector,
-  (state: State) => state.settings.currenciesSettings,
-  filterTokenOperationsZeroAmountSelector,
-  (state: State) => selectFeature(state, "addressPoisoningOperationsFilter"),
-  (accounts, lastSeenDate, currenciesSettings, shouldFilterTokenOps, poisoningFeature) => {
+  historyUnreadOperationsOptionsSelector,
+  (accounts, lastSeenDate, options) => {
     if (!lastSeenDate) return false;
-    const families = getAddressPoisoningFamiliesForFilter(shouldFilterTokenOps, poisoningFeature);
-    return historyHasUnreadOperations(
-      accounts,
-      lastSeenDate,
-      currenciesSettings,
-      shouldFilterTokenOps,
-      families,
-    );
+    return historyHasUnreadOperations(accounts, lastSeenDate, options);
   },
 );

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -97,6 +97,7 @@ export type SettingsState = {
   mevProtection: boolean;
   hideEmptyTokenAccounts: boolean;
   filterTokenOperationsZeroAmount: boolean;
+  hideSmallValueTokenOperations: boolean;
   sidebarCollapsed: boolean;
   discreetMode: boolean;
   starredAccountIds?: string[];
@@ -194,6 +195,7 @@ export const INITIAL_STATE: SettingsState = {
   showAccountsHelperBanner: true,
   hideEmptyTokenAccounts: getEnv("HIDE_EMPTY_TOKEN_ACCOUNTS"),
   filterTokenOperationsZeroAmount: getEnv("FILTER_ZERO_AMOUNT_ERC20_EVENTS"),
+  hideSmallValueTokenOperations: false,
   sidebarCollapsed: false,
   discreetMode: false,
   preferredDeviceModel: DeviceModelId.nanoS,
@@ -339,7 +341,7 @@ const handlers: SettingsHandlers = {
   SAVE_SETTINGS: (state, { payload }) => {
     if (!payload) return state;
     const filteredPayload = filterValidSettings(payload);
-    const { analyticsConsentInfo, ...rest } = filteredPayload;
+    const { analyticsConsentInfo: _analyticsConsentInfo, ...rest } = filteredPayload;
 
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const changed = (Object.keys(rest) as (keyof typeof rest)[]).some(
@@ -842,6 +844,8 @@ export const hideEmptyTokenAccountsSelector = (state: State) =>
   state.settings.hideEmptyTokenAccounts;
 export const filterTokenOperationsZeroAmountSelector = (state: State) =>
   state.settings.filterTokenOperationsZeroAmount;
+export const hideSmallValueTokenOperationsSelector = (state: State) =>
+  state.settings.hideSmallValueTokenOperations;
 
 export const doNotAskAgainSkipMemoSelector = (state: State) => state.settings.doNotAskAgainSkipMemo;
 export const lastSeenDeviceSelector = (state: State): DeviceModelInfo | null | undefined => {

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9188,7 +9188,11 @@
       "description": "Come back later to see your transactions."
     },
     "actionsBar": {
-      "csv": "Export"
+      "csv": "Export",
+      "more": "Transaction history options",
+      "hideDustTransactions": "Hide dust transactions",
+      "showDustTransactions": "Show dust transactions",
+      "dustTransactionsDescription": "Transactions below {{threshold}} will be hidden."
     },
     "exportDialog": {
       "title": "Export transaction history",

--- a/libs/ledger-live-common/src/hideSmallValueTokenOperations/__tests__/smallValueOperationsThreshold.test.ts
+++ b/libs/ledger-live-common/src/hideSmallValueTokenOperations/__tests__/smallValueOperationsThreshold.test.ts
@@ -20,8 +20,8 @@ jest.mock("@ledgerhq/live-countervalues/logic", () => ({
 
 import { calculate } from "@ledgerhq/live-countervalues/logic";
 
-const mockCalculate = calculate as jest.MockedFunction<typeof calculate>;
-const mockCountervaluesState = {} as CounterValuesState;
+const mockCalculate = jest.mocked(calculate);
+const mockCountervaluesState: CounterValuesState = { data: {}, status: {}, cache: {} };
 const USD = getFiatCurrencyByTicker("USD");
 const EUR = getFiatCurrencyByTicker("EUR");
 const JPY = getFiatCurrencyByTicker("JPY");
@@ -96,7 +96,7 @@ describe("smallValueOperationsThreshold", () => {
         thresholdUsd: 0.5,
       });
 
-      expect(result?.toString()).toBe("72");
+      expect(result?.toString()).toBe("72.8");
       expect(mockCalculate).toHaveBeenCalledWith(mockCountervaluesState, {
         from: SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
         to: JPY,
@@ -180,9 +180,18 @@ describe("smallValueOperationsThreshold", () => {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       ({ type, value }) as Operation;
 
-    // calculate is called as { from: token, to: user_fiat, value: op.value } and returns
-    // the operation's fiat value in user_fiat minor units (eg EUR cents)
-    // The threshold is floor(thresholdUsd × 10^fiat.magnitude), e.g. $0.5 -> 50 EUR cents
+    const mockSmallValueCalculations = (
+      opFiatValue: number | undefined,
+      thresholdFiatValue = 50,
+    ) => {
+      mockCalculate.mockImplementation((_state, query) => {
+        if (query.from === mockToken) return opFiatValue;
+        if (query.from === SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY) {
+          return thresholdFiatValue;
+        }
+        return undefined;
+      });
+    };
 
     it.each([
       { desc: "non-token Account", account: "regular", opType: "IN" },
@@ -211,7 +220,8 @@ describe("smallValueOperationsThreshold", () => {
       expect(mockCalculate).not.toHaveBeenCalled();
     });
 
-    // threshold = floor($0.5 × 100) = 50 EUR cents; calculate returns the op's fiat value
+    // The USD threshold is converted to 50 EUR cents; calculate also returns
+    // the operation's fiat value in EUR minor units.
     it.each([
       { fiatValue: 49, opValue: 499_999, expected: true, desc: "strictly below threshold -> dust" },
       {
@@ -222,7 +232,7 @@ describe("smallValueOperationsThreshold", () => {
       },
       { fiatValue: 51, opValue: 510_000, expected: false, desc: "above threshold -> not dust" },
     ])("$desc", ({ fiatValue, opValue, expected }) => {
-      mockCalculate.mockReturnValue(fiatValue);
+      mockSmallValueCalculations(fiatValue);
 
       const result = isSmallValueTokenOperation({
         operation: buildOp("IN", new BigNumber(opValue)),
@@ -238,7 +248,7 @@ describe("smallValueOperationsThreshold", () => {
       { fiatValue: undefined, desc: "calculate returns undefined" },
       { fiatValue: Number.POSITIVE_INFINITY, desc: "calculate returns Infinity" },
     ])("should not filter when price feed is unavailable ($desc)", ({ fiatValue }) => {
-      mockCalculate.mockReturnValue(fiatValue);
+      mockSmallValueCalculations(fiatValue);
 
       const result = isSmallValueTokenOperation({
         operation: buildOp("IN", new BigNumber(1_000_000)),
@@ -253,7 +263,7 @@ describe("smallValueOperationsThreshold", () => {
     it("should correctly filter a dust amount from an 18-decimal token", () => {
       // Scenario: 18-decimal token, op worth ~1 EUR cent (dust)
       // calculate(token -> EUR, 10^20) -> 1 EUR cent ; threshold = 50 EUR cents
-      mockCalculate.mockReturnValue(1);
+      mockSmallValueCalculations(1);
 
       const dustAmount = new BigNumber("100").times(new BigNumber(10).pow(18)); // 10^20
 
@@ -268,9 +278,7 @@ describe("smallValueOperationsThreshold", () => {
     });
 
     it("should use a custom Firebase thresholdUsd when provided", () => {
-      // Firebase overrides the threshold to $0.25 _> floor(0.25 × 100) = 25 EUR cents
-      // calculate returns 24 EUR cents -> below 25 ->dust.
-      mockCalculate.mockReturnValue(24);
+      mockSmallValueCalculations(24, 25);
 
       const result = isSmallValueTokenOperation({
         operation: buildOp("IN", new BigNumber(249_999)),
@@ -293,8 +301,7 @@ describe("smallValueOperationsThreshold", () => {
     });
 
     it("should fall back to the default threshold ($0.5 -> 50 EUR cents) when thresholdUsd is omitted", () => {
-      // calculate returns 1 EUR cent -> below 50 EUR cents default threshold
-      mockCalculate.mockReturnValue(1);
+      mockSmallValueCalculations(1);
 
       const result = isSmallValueTokenOperation({
         operation: buildOp("IN", new BigNumber(1)),
@@ -306,11 +313,9 @@ describe("smallValueOperationsThreshold", () => {
       expect(result).toBe(true);
     });
 
-    it("should return false for JPY (0 decimal places -> threshold rounds to 0 -> no filtering)", () => {
-      // JPY has magnitude=0, so floor(0.5 × 10^0) = floor(0.5) = 0 JPY.
-      // A zero threshold is treated as "no threshold" to avoid filtering all operations
-      // calculate is not expected to be called in this path (function returns early)
-      mockCalculate.mockReturnValue(0);
+    it("should return false when the converted threshold is zero", () => {
+      // A zero threshold is treated as "no threshold" to avoid filtering all operations.
+      mockSmallValueCalculations(0, 0);
 
       const result = isSmallValueTokenOperation({
         operation: buildOp("IN", new BigNumber(1)),

--- a/libs/ledger-live-common/src/hideSmallValueTokenOperations/smallValueOperationsThreshold.ts
+++ b/libs/ledger-live-common/src/hideSmallValueTokenOperations/smallValueOperationsThreshold.ts
@@ -66,7 +66,7 @@ export function convertThresholdFromUsdToCountervalueMinorUnit({
     return null;
   }
 
-  return new BigNumber(rawCountervalueMinorUnit).decimalPlaces(0, BigNumber.ROUND_FLOOR);
+  return new BigNumber(rawCountervalueMinorUnit);
 }
 
 export function convertThresholdFromCountervalueMinorUnitToUsd({
@@ -103,22 +103,16 @@ export function convertThresholdFromCountervalueMinorUnitToUsd({
  * - it belongs to a TokenAccount, AND
  * - its type is "IN" (incoming transfer), AND
  * - either its crypto value is exactly zero, OR its fiat countervalue is
- *   strictly below the configured threshold (defaults to $0.5, overridable
- *   via ff).
+ *   strictly below the configured USD threshold (defaults to $0.5,
+ *   overridable via ff).
  *
  * When the fiat countervalue cannot be computed (e.g. price feed unavailable),
  * the operation is NOT filtered so that legitimate transactions are never
  * accidentally hidden.
  *
  * The comparison is performed in the user's countervalue currency space:
- * we convert the operation amount (token minor units) to user-fiat minor
- * units via the stored `{from: token, to: user_fiat}` countervalue pair,
- * then compare against the threshold expressed in the same units.
- *
- * The countervalues state only stores `{from: token, to: user_fiat}` pairs
- * (never `{from: USD, to: token}`), so the threshold is expressed directly
- * in user_fiat minor units as `floor(thresholdUsd × 10^user_fiat.magnitude)`.
- * This is a ~1:1 USD/fiat approximation that is acceptable for a dust filter.
+ * we convert both the operation amount and the USD threshold to user-fiat
+ * minor units, then compare those raw values.
  */
 export function isSmallValueTokenOperation({
   operation,
@@ -151,10 +145,11 @@ export function isSmallValueTokenOperation({
 
   if (typeof rawOpFiatValue !== "number" || !Number.isFinite(rawOpFiatValue)) return false;
 
-  const thresholdFiatMinorUnit = floorThresholdToCurrencyMinorUnit(
-    clampSmallValueThresholdUsd(thresholdUsd, 0),
-    userCounterValueCurrency,
-  );
+  const thresholdFiatMinorUnit = convertThresholdFromUsdToCountervalueMinorUnit({
+    counterValueCurrency: userCounterValueCurrency,
+    countervaluesState,
+    thresholdUsd,
+  });
 
   if (!thresholdFiatMinorUnit || thresholdFiatMinorUnit.isZero()) return false;
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Desktop transaction history overflow menu and export dialog access
      - Desktop dust transaction filtering state, unread indicators, and history list filtering

### 📝 Description

This PR adds the Desktop dust filtering setting requested for LIVE-29298 on the W4.0 transaction history screen. The setting is disabled by default and keeps the existing Settings toggle for zero-amount token operations unchanged.

Ledger Live Desktop now exposes a transaction history options menu that can hide or show incoming token dust transactions below the $0.01 main-currency threshold. The same filtering path is applied to the rendered history list and unread-history selector, and the UI strings are added in English only.

<img width="1397" height="700" alt="image" src="https://github.com/user-attachments/assets/b117907a-98dc-4638-b9ee-461c348de7eb" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-29298](https://ledgerhq.atlassian.net/browse/LIVE-29298)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29298]: https://ledgerhq.atlassian.net/browse/LIVE-29298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ