### PR TITLE
[LWDM] fix: stellar getBlock returns the same value as listop

### DIFF
--- a/.changeset/bright-bikes-remember.md
+++ b/.changeset/bright-bikes-remember.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-stellar": patch
+---
+
+coin-stellar: Align getBlock OPT_IN/OPT_OUT assetAmount with listOperations by using fee_charged instead of the trustline limit

--- a/libs/coin-modules/coin-stellar/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/getBlock.test.ts
@@ -289,7 +289,7 @@ describe("getBlock", () => {
     expect(block.transactions[0].operations[0]).toMatchObject({
       type: "other",
       ledgerOpType: "OPT_IN",
-      assetAmount: "1000.0000000",
+      assetAmount: "100",
       memo: { type: "NO_MEMO" },
       sequence: "12345",
     });

--- a/libs/coin-modules/coin-stellar/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/getBlock.ts
@@ -243,7 +243,7 @@ async function blockTransactionForHash(
   const txCtx: TxContext = {
     memo: decodeMemo(tx),
     sequence: parseSequence(tx.source_account_sequence),
-    feeCharged: new BigNumber(tx.fee_charged).toString(),
+    feeCharged: new BigNumber(tx.fee_charged || "0").toString(),
   };
 
   let blockOperations: BlockOperation[] = [];

--- a/libs/coin-modules/coin-stellar/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/getBlock.ts
@@ -243,7 +243,7 @@ async function blockTransactionForHash(
   const txCtx: TxContext = {
     memo: decodeMemo(tx),
     sequence: parseSequence(tx.source_account_sequence),
-    feeCharged: tx.fee_charged ?? "0",
+    feeCharged: tx.fee_charged || "0",
   };
 
   let blockOperations: BlockOperation[] = [];

--- a/libs/coin-modules/coin-stellar/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/getBlock.ts
@@ -195,6 +195,7 @@ function blockOperationsPathStrictReceive(op: RawPathStrictReceiveOp): BlockOper
 type TxContext = {
   memo: StellarMemo | undefined;
   sequence: string | undefined;
+  feeCharged: string;
 };
 
 function mapSupportedOperationToBlockOperations(
@@ -211,12 +212,12 @@ function mapSupportedOperationToBlockOperations(
   }
   if (op.type === "change_trust") {
     const isOptOut = new BigNumber(op.limit || "0").eq(0);
-    // Align with listOperations details (convertToLegacyOperation output)
+    // Align with listOperations: assetAmount = fee_charged (not the trustline limit)
     return [
       {
         type: "other",
         ledgerOpType: isOptOut ? "OPT_OUT" : "OPT_IN",
-        assetAmount: op.asset_code ? op.limit : undefined,
+        assetAmount: op.asset_code ? txCtx.feeCharged : undefined,
         ...(txCtx.memo && { memo: txCtx.memo }),
         ...(txCtx.sequence && { sequence: txCtx.sequence }),
       },
@@ -242,6 +243,7 @@ async function blockTransactionForHash(
   const txCtx: TxContext = {
     memo: decodeMemo(tx),
     sequence: parseSequence(tx.source_account_sequence),
+    feeCharged: tx.fee_charged,
   };
 
   let blockOperations: BlockOperation[] = [];

--- a/libs/coin-modules/coin-stellar/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/getBlock.ts
@@ -243,7 +243,7 @@ async function blockTransactionForHash(
   const txCtx: TxContext = {
     memo: decodeMemo(tx),
     sequence: parseSequence(tx.source_account_sequence),
-    feeCharged: tx.fee_charged,
+    feeCharged: tx.fee_charged ?? "0",
   };
 
   let blockOperations: BlockOperation[] = [];

--- a/libs/coin-modules/coin-stellar/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/getBlock.ts
@@ -243,7 +243,7 @@ async function blockTransactionForHash(
   const txCtx: TxContext = {
     memo: decodeMemo(tx),
     sequence: parseSequence(tx.source_account_sequence),
-    feeCharged: tx.fee_charged || "0",
+    feeCharged: new BigNumber(tx.fee_charged).toString(),
   };
 
   let blockOperations: BlockOperation[] = [];


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->


### 📝 Description

`getBlock` and `listOperations` returned different `assetAmount` values for `change_trust` (OPT_IN/OPT_OUT) operations, causing reindex mismatches when downstream systems compared initial   sync data (from `listOperations`) with reindexed data (from `getBlock`).

#### Before

For a `change_trust` operation with `limit: "900000000000.0000000"` and `fee_charged: "100"`:

| Code path | `assetAmount` |
|-----------|---------------|
| `listOperations` | `"100"` (fee_charged, via `getSimpleOperationValue` default case) |
| `getBlock` | `"900000000000.0000000"` (trustline limit, via `op.limit`) |

Reindex detects a mismatch and the operation diff fails.

#### After

| Code path | `assetAmount` |
|-----------|---------------|
| `listOperations` | `"100"` (fee_charged — unchanged) |
| `getBlock` | `"100"` (fee_charged — now aligned) |

Both paths return the same value.

#### Changes

- **`getBlock.ts`**: Use `txCtx.feeCharged` instead of `op.limit` for `change_trust` `assetAmount`
- **`getBlock.ts`**: Add `feeCharged` to `TxContext` type, populated from `tx.fee_charged`
- **`getBlock.test.ts`**: Update expected `assetAmount` from `"1000.0000000"` to `"100"` (the mock's default `fee_charged`)


### ❓ Context

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
