### PR TITLE
test(desktop): add receive-crypto option step to sub-account e2e flow

### DIFF
--- a/.changeset/nasty-birds-hug.md
+++ b/.changeset/nasty-birds-hug.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": minor
+---
+
+Add a `shouldSelectReceiveCryptoOption` step to the sub-account receive e2e flow (used for ETH_USDT and ETH_LIDO) so the test selects the receive-crypto option from the receive menu before continuing.

--- a/e2e/desktop/tests/specs/subAccount.spec.ts
+++ b/e2e/desktop/tests/specs/subAccount.spec.ts
@@ -26,21 +26,54 @@ const subAccounts = [
     xrayTicket1: "B2CQA-2577, B2CQA-1079",
     xrayTicket2: "B2CQA-2583",
   },
-  { account: TokenAccount.XLM_USDC, xrayTicket1: "B2CQA-2579", xrayTicket2: "B2CQA-2585" },
-  { account: TokenAccount.ALGO_USDT_1, xrayTicket1: "B2CQA-2575", xrayTicket2: "B2CQA-2581" },
-  { account: TokenAccount.TRX_USDT, xrayTicket1: "B2CQA-2580", xrayTicket2: "B2CQA-2586" },
-  { account: TokenAccount.BSC_BUSD_1, xrayTicket1: "B2CQA-2576", xrayTicket2: "B2CQA-2582" },
-  { account: TokenAccount.POL_DAI_1, xrayTicket1: "B2CQA-2578", xrayTicket2: "B2CQA-2584" },
-  { account: TokenAccount.SUI_USDC_1, xrayTicket1: "B2CQA-3904", xrayTicket2: "B2CQA-3905" },
+  {
+    account: TokenAccount.XLM_USDC,
+    xrayTicket1: "B2CQA-2579",
+    xrayTicket2: "B2CQA-2585",
+  },
+  {
+    account: TokenAccount.ALGO_USDT_1,
+    xrayTicket1: "B2CQA-2575",
+    xrayTicket2: "B2CQA-2581",
+  },
+  {
+    account: TokenAccount.TRX_USDT,
+    xrayTicket1: "B2CQA-2580",
+    xrayTicket2: "B2CQA-2586",
+  },
+  {
+    account: TokenAccount.BSC_BUSD_1,
+    xrayTicket1: "B2CQA-2576",
+    xrayTicket2: "B2CQA-2582",
+  },
+  {
+    account: TokenAccount.POL_DAI_1,
+    xrayTicket1: "B2CQA-2578",
+    xrayTicket2: "B2CQA-2584",
+  },
+  {
+    account: TokenAccount.SUI_USDC_1,
+    xrayTicket1: "B2CQA-3904",
+    xrayTicket2: "B2CQA-3905",
+  },
 ];
 
 const subAccountReceive: Array<{
   account: TokenAccount;
   xrayTicket: string;
   shouldSelectTokenOnReceiveFlow?: boolean;
+  shouldSelectReceiveCryptoOption?: boolean;
 }> = [
-  { account: TokenAccount.ETH_USDT_1, xrayTicket: "B2CQA-2492" },
-  { account: TokenAccount.ETH_LIDO, xrayTicket: "B2CQA-2491" },
+  {
+    account: TokenAccount.ETH_USDT_1,
+    xrayTicket: "B2CQA-2492",
+    shouldSelectReceiveCryptoOption: true,
+  },
+  {
+    account: TokenAccount.ETH_LIDO,
+    xrayTicket: "B2CQA-2491",
+    shouldSelectReceiveCryptoOption: true,
+  },
   { account: TokenAccount.TRX_USDT, xrayTicket: "B2CQA-2496" },
   //TODO: re-enable tests when https://ledgerhq.atlassian.net/browse/LIVE-25852 is fixed
   // { account: TokenAccount.BSC_BUSD_1, xrayTicket: "B2CQA-2489" },
@@ -145,6 +178,10 @@ for (const token of subAccountReceive) {
         await app.account.expectAccountVisibility(getParentAccountName(token.account));
 
         await app.account.clickAddToken();
+        if (token.shouldSelectReceiveCryptoOption) {
+          await app.receive.expectRecieveMenu();
+          await app.receive.clickReceive();
+        }
         if (token.shouldSelectTokenOnReceiveFlow) {
           // e.g. for Hedera. This works together with the fact a family activate or not the receiveTokensConfig
           await app.receive.selectToken(token.account);
@@ -320,9 +357,9 @@ for (const transaction of transactionsAddressInvalid) {
       speculosApp: transaction.transaction.accountToDebit.currency.speculosApp,
       cliCommands: [
         async (userdataPath?: string) => {
-          await liveDataCommand(transaction.transaction.accountToDebit, { useScheme: false })(
-            userdataPath,
-          );
+          await liveDataCommand(transaction.transaction.accountToDebit, {
+            useScheme: false,
+          })(userdataPath);
           if (transaction.recipient === undefined) {
             const receiveAddress = await getAccountAddress(transaction.transaction.accountToCredit);
             transaction.recipient = receiveAddress;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _This PR is itself a change to the desktop e2e test suite._
- [x] **Impact of the changes:**
      - Token receive flow (desktop e2e): receiving ETH_USDT / ETH_LIDO sub-accounts via the new receive-crypto menu step

### 📝 Description

The sub-account receive e2e flow did not account for the receive menu that prompts the user to select the "receive crypto" option before continuing. For the ETH_USDT and ETH_LIDO sub-accounts, this step is required, so the test needed a way to opt into it.

This PR adds an optional `shouldSelectReceiveCryptoOption` flag to the `subAccountReceive` test cases. When set, the test asserts the receive menu is shown (`expectRecieveMenu`) and clicks the receive option (`clickReceive`) before proceeding with the rest of the receive flow. The flag is enabled for ETH_USDT and ETH_LIDO. Surrounding object literals were also reflowed to multiline for readability.

### ❓ Context


- **JIRA or GitHub link**: [LIVE-33219](https://ledgerhq.atlassian.net/browse/LIVE-33219)
- e2e => https://github.com/LedgerHQ/ledger-live/actions/runs/28112394038

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33219]: https://ledgerhq.atlassian.net/browse/LIVE-33219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ