### PR TITLE
[LWD] fix(lwd): include testnets in global search results (LIVE-33220)

### DIFF
--- a/.changeset/lwd-globalsearch-testnets.md
+++ b/.changeset/lwd-globalsearch-testnets.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Global Search now surfaces testnets when developer mode is enabled, mirroring the Receive flow's DADA query logic (`includeTestNetworks` + staging environment). Fixes LIVE-33220.

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/__tests__/useAssetSearchResultsViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/__tests__/useAssetSearchResultsViewModel.test.ts
@@ -1,14 +1,34 @@
 import { renderHook, withFlagOverrides } from "tests/testSetup";
 import { setEnv } from "@ledgerhq/live-env";
 import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
+import { selectCurrencyForMetaId } from "@ledgerhq/live-common/dada-client/utils/currencySelection";
 import { useAssetSearchResultsViewModel } from "../useAssetSearchResultsViewModel";
 
 jest.mock("@ledgerhq/live-common/dada-client/hooks/useAssetsData");
+jest.mock("@ledgerhq/live-common/dada-client/utils/currencySelection");
 jest.mock("@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate", () => ({
   useUsdToFiatRate: () => ({ rate: 1, status: "ready" }),
 }));
 
 const mockedAssets = jest.mocked(useAssetsData);
+const mockedSelectCurrency = jest.mocked(selectCurrencyForMetaId);
+
+// Single-network search payload (the mapper falls back to the asset id when no currency resolves).
+const buildSearchData = (network: string) =>
+  buildAssetsData({
+    data: {
+      currenciesOrder: { metaCurrencyIds: ["amdx"], key: "marketCap", order: "desc" },
+      cryptoAssets: {
+        amdx: {
+          id: "amdx",
+          name: "AMD xStock",
+          ticker: "AMDX",
+          assetsIds: { [network]: `${network}/erc20/amd` },
+        },
+      },
+      markets: {},
+    },
+  } as never);
 
 const buildAssetsData = (
   overrides: Partial<ReturnType<typeof useAssetsData>> = {},
@@ -31,6 +51,7 @@ describe("useAssetSearchResultsViewModel", () => {
     jest.clearAllMocks();
     setEnv("MANAGER_DEV_MODE", false);
     mockedAssets.mockReturnValue(buildAssetsData());
+    mockedSelectCurrency.mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -63,5 +84,23 @@ describe("useAssetSearchResultsViewModel", () => {
     });
 
     expect(mockedAssets).toHaveBeenLastCalledWith(expect.objectContaining({ isStaging: true }));
+  });
+
+  it("hides a result whose only network currency flag is off", () => {
+    mockedAssets.mockReturnValue(buildSearchData("robinhood_testnet"));
+
+    const { result } = renderHook(() => useAssetSearchResultsViewModel({ search: "amd" }));
+
+    expect(result.current.data).toHaveLength(0);
+  });
+
+  it("shows the result when its network currency flag is on", () => {
+    mockedAssets.mockReturnValue(buildSearchData("robinhood_testnet"));
+
+    const { result } = renderHook(() => useAssetSearchResultsViewModel({ search: "amd" }), {
+      initialState: withFlagOverrides({ currencyRobinhoodTestnet: { enabled: true } }),
+    });
+
+    expect(result.current.data).toHaveLength(1);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/__tests__/useAssetSearchResultsViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/__tests__/useAssetSearchResultsViewModel.test.ts
@@ -1,0 +1,40 @@
+import { renderHook } from "tests/testSetup";
+import { setEnv } from "@ledgerhq/live-env";
+import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
+import { useAssetSearchResultsViewModel } from "../useAssetSearchResultsViewModel";
+
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useAssetsData");
+jest.mock("@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate", () => ({
+  useUsdToFiatRate: () => ({ rate: 1, status: "ready" }),
+}));
+
+const mockedAssets = jest.mocked(useAssetsData);
+
+describe("useAssetSearchResultsViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedAssets.mockReturnValue({ data: undefined, isLoading: false } as never);
+  });
+
+  afterEach(() => {
+    setEnv("MANAGER_DEV_MODE", false);
+  });
+
+  it("excludes testnets from the query by default", () => {
+    renderHook(() => useAssetSearchResultsViewModel({ search: "btc" }));
+
+    expect(mockedAssets).toHaveBeenLastCalledWith(
+      expect.objectContaining({ search: "btc", includeTestNetworks: false }),
+    );
+  });
+
+  it("includes testnets in the query only in developer mode", () => {
+    setEnv("MANAGER_DEV_MODE", true);
+
+    renderHook(() => useAssetSearchResultsViewModel({ search: "btc" }));
+
+    expect(mockedAssets).toHaveBeenLastCalledWith(
+      expect.objectContaining({ includeTestNetworks: true }),
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/__tests__/useAssetSearchResultsViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/__tests__/useAssetSearchResultsViewModel.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "tests/testSetup";
+import { renderHook, withFlagOverrides } from "tests/testSetup";
 import { setEnv } from "@ledgerhq/live-env";
 import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
 import { useAssetSearchResultsViewModel } from "../useAssetSearchResultsViewModel";
@@ -10,21 +10,38 @@ jest.mock("@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate", () => ({
 
 const mockedAssets = jest.mocked(useAssetsData);
 
+const buildAssetsData = (
+  overrides: Partial<ReturnType<typeof useAssetsData>> = {},
+): ReturnType<typeof useAssetsData> =>
+  ({
+    data: undefined,
+    isLoading: false,
+    isFetchingNextPage: false,
+    error: undefined,
+    errorInfo: undefined,
+    loadNext: undefined,
+    isSuccess: true,
+    isError: false,
+    refetch: jest.fn(),
+    ...overrides,
+  }) as ReturnType<typeof useAssetsData>;
+
 describe("useAssetSearchResultsViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedAssets.mockReturnValue({ data: undefined, isLoading: false } as never);
+    setEnv("MANAGER_DEV_MODE", false);
+    mockedAssets.mockReturnValue(buildAssetsData());
   });
 
   afterEach(() => {
     setEnv("MANAGER_DEV_MODE", false);
   });
 
-  it("excludes testnets from the query by default", () => {
+  it("excludes testnets and uses the prod environment by default", () => {
     renderHook(() => useAssetSearchResultsViewModel({ search: "btc" }));
 
     expect(mockedAssets).toHaveBeenLastCalledWith(
-      expect.objectContaining({ search: "btc", includeTestNetworks: false }),
+      expect.objectContaining({ search: "btc", includeTestNetworks: false, isStaging: false }),
     );
   });
 
@@ -36,5 +53,15 @@ describe("useAssetSearchResultsViewModel", () => {
     expect(mockedAssets).toHaveBeenLastCalledWith(
       expect.objectContaining({ includeTestNetworks: true }),
     );
+  });
+
+  it("derives isStaging from the lldModularDrawer backend environment", () => {
+    renderHook(() => useAssetSearchResultsViewModel({ search: "btc" }), {
+      initialState: withFlagOverrides({
+        lldModularDrawer: { enabled: true, params: { backendEnvironment: "STAGING" } },
+      }),
+    });
+
+    expect(mockedAssets).toHaveBeenLastCalledWith(expect.objectContaining({ isStaging: true }));
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSearchResultsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSearchResultsViewModel.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
 import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
+import { useCurrenciesUnderFeatureFlag } from "@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag";
 import type { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
 import { useFeature } from "@features/platform-feature-flags";
 import { useSelector } from "LLD/hooks/redux";
@@ -40,9 +41,12 @@ export function useAssetSearchResultsViewModel({ search, skip }: Params): Result
 
   const { status: rateStatus, rate } = useUsdToFiatRate(counterCurrency);
 
+  // Hide currencies disabled by a feature flag, mirroring the receive flow.
+  const { deactivatedCurrencyIds } = useCurrenciesUnderFeatureFlag();
+
   const results = useMemo<MarketCurrencyData[]>(
-    () => mapAssetsDataToMarketCurrencies(data, rate ?? 1),
-    [data, rate],
+    () => mapAssetsDataToMarketCurrencies(data, rate ?? 1, deactivatedCurrencyIds),
+    [data, rate, deactivatedCurrencyIds],
   );
 
   const hasData = !!data;

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSearchResultsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSearchResultsViewModel.ts
@@ -1,7 +1,9 @@
 import { useMemo } from "react";
 import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
 import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
+import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import type { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
+import { useFeature } from "@features/platform-feature-flags";
 import { useSelector } from "LLD/hooks/redux";
 import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
 import { mapAssetsDataToMarketCurrencies } from "../utils/mapAssetsDataToMarketCurrencies";
@@ -23,11 +25,17 @@ type Result = {
 export function useAssetSearchResultsViewModel({ search, skip }: Params): Result {
   const counterCurrency = useSelector(counterValueCurrencySelector).ticker;
 
+  const modularDrawer = useFeature("lldModularDrawer");
+  const isStaging = modularDrawer?.params?.backendEnvironment === "STAGING";
+  const includeTestNetworks = useEnv("MANAGER_DEV_MODE");
+
   const { data, isLoading, isError, loadNext, isFetchingNextPage } = useAssetsData({
     product: "lld",
     version: __APP_VERSION__,
     search,
     skip,
+    isStaging,
+    includeTestNetworks,
   });
 
   const { status: rateStatus, rate } = useUsdToFiatRate(counterCurrency);

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/utils/mapAssetsDataToMarketCurrencies.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/utils/mapAssetsDataToMarketCurrencies.ts
@@ -5,10 +5,13 @@ import { applyUsdRateToMarket } from "@ledgerhq/live-common/market/utils/applyUs
 import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
 import { buildSearchMarketCurrencyData } from "./buildSearchMarketCurrencyData";
 
+const NO_DEACTIVATED_CURRENCIES = new Set<string>();
+
 /** DADA prices are USD-denominated; `usdToFiatRate` converts them into the counter currency (1 = no-op). */
 export function mapAssetsDataToMarketCurrencies(
   data: AssetsDataWithPagination | undefined,
   usdToFiatRate = 1,
+  deactivatedCurrencyIds: ReadonlySet<string> = NO_DEACTIVATED_CURRENCIES,
 ): MarketCurrencyData[] {
   if (!data) return [];
   const { cryptoAssets, markets, currenciesOrder } = data;
@@ -16,6 +19,13 @@ export function mapAssetsDataToMarketCurrencies(
   return currenciesOrder.metaCurrencyIds.flatMap(id => {
     const meta = cryptoAssets[id];
     if (!meta) return [];
+
+    // Hide an asset whose every network currency is disabled by a feature flag,
+    // mirroring how the receive flow filters out deactivated currencies.
+    const networks = Object.keys(meta.assetsIds);
+    if (networks.length > 0 && networks.every(network => deactivatedCurrencyIds.has(network))) {
+      return [];
+    }
 
     const currency = selectCurrencyForMetaId(id, data);
     const ledgerId = currency?.id ?? Object.values(meta.assetsIds)[0];


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Unit test asserting `useAssetsData` is queried with `includeTestNetworks` driven by `MANAGER_DEV_MODE`.
- [ ] **Impact of the changes:**
  - Global Search (Wallet 4.0, desktop). QA should verify that with developer mode enabled, testnet assets now appear in Global Search results, and that with developer mode disabled the results are unchanged (mainnets only).

### 📝 Description

Desktop port of the LWM fix (#18931 / LIVE-33199). Global Search did not surface testnets because `useAssetSearchResultsViewModel` called the DADA `useAssetsData` hook **without** the `includeTestNetworks` / `isStaging` parameters, so the backend returned mainnets only.

This PR adds the same logic the Receive flow already uses (`useReceiveNetworkLedgerIds`):

- `includeTestNetworks` from `useEnv("MANAGER_DEV_MODE")` → testnets surface only in developer mode.
- `isStaging` derived from the `lldModularDrawer` feature flag's `backendEnvironment` param, keeping the DADA environment consistent with the rest of the app.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33220](https://ledgerhq.atlassian.net/browse/LIVE-33220)


[LIVE-33220]: https://ledgerhq.atlassian.net/browse/LIVE-33220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ