### PR TITLE
feat: robinhood disclaimer banner on asset detail — LWD + LWM (LIVE-32756 / LIVE-32758)

### DIFF
--- a/.changeset/lwd-robinhood-disclaimer-banner.md
+++ b/.changeset/lwd-robinhood-disclaimer-banner.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/asset-detail": patch
+---
+
+Add an informational disclaimer banner on the Wallet 4.0 asset detail screen for assets supported exclusively on a Robinhood chain (e.g. tokenized stocks on robinhood_testnet) when the user holds a positive balance. The banner is gated by the `llRobinhoodDisclaimer` feature flag. Adds the shared `isRobinhoodExclusiveAsset` helper to `@ledgerhq/asset-detail`. Implements LIVE-32756.

--- a/.changeset/lwm-robinhood-banner-balance.md
+++ b/.changeset/lwm-robinhood-banner-balance.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Only show the Robinhood disclaimer banner on the Wallet 4.0 asset detail screen when the user holds a positive balance for the asset, matching the desktop behaviour and the LIVE-32756 spec (LIVE-32758).

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/AssetDetailView.tsx
@@ -5,6 +5,7 @@ import { AssetHeader } from "./components/AssetHeader";
 import { ActionBar } from "./components/ActionBar";
 import { ChartSection } from "./components/ChartSection";
 import { FallbackBanner } from "./components/FallbackBanner";
+import { RobinhoodDisclaimerBanner } from "./components/RobinhoodDisclaimerBanner";
 import { HiddenBanner } from "./components/HiddenBanner";
 import { resolveRampLedgerIds } from "./utils/resolveRampLedgerIds";
 import { MarketPriceSection } from "./components/MarketPriceSection";
@@ -103,6 +104,8 @@ export function AssetDetailView({ viewModel }: AssetDetailViewProps) {
         {showPortfolioSections && (
           <TotalBalance distributionItem={distributionItem} isLoading={portfolioSectionLoading} />
         )}
+
+        <RobinhoodDisclaimerBanner distributionItem={distributionItem} />
 
         <MetricsRowSection
           distributionItem={distributionItem}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/RobinhoodDisclaimerBanner/RobinhoodDisclaimerBannerView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/RobinhoodDisclaimerBanner/RobinhoodDisclaimerBannerView.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Banner } from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "react-i18next";
+
+export function RobinhoodDisclaimerBannerView() {
+  const { t } = useTranslation();
+
+  return (
+    <Banner
+      appearance="info"
+      title={t("assetDetails.robinhoodDisclaimerBanner.title")}
+      data-testid="asset-detail-robinhood-disclaimer-banner"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/RobinhoodDisclaimerBanner/__tests__/RobinhoodDisclaimerBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/RobinhoodDisclaimerBanner/__tests__/RobinhoodDisclaimerBanner.test.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { render, screen, withFlagOverrides } from "tests/testSetup";
+import type { DistributionItem } from "@ledgerhq/types-live";
+import { useReceiveNetworkLedgerIds } from "../../../hooks/useReceiveNetworkLedgerIds";
+import { RobinhoodDisclaimerBanner } from "..";
+
+jest.mock("../../../hooks/useReceiveNetworkLedgerIds");
+
+const mockedReceive = jest.mocked(useReceiveNetworkLedgerIds);
+const TEST_ID = "asset-detail-robinhood-disclaimer-banner";
+const ROBINHOOD_ONLY = ["robinhood_testnet/erc20/amd_0x71178bac73cbeb415514eb542a8995b82669778d"];
+
+const buildDistributionItem = (amount: number): DistributionItem =>
+  ({
+    currency: { id: "robinhood_testnet/erc20/amd", ticker: "AMD" },
+    amount,
+    accounts: [],
+    distribution: 1,
+  }) as unknown as DistributionItem;
+
+const enableDisclaimer = () => ({
+  initialState: withFlagOverrides({ llRobinhoodDisclaimer: { enabled: true } }),
+});
+
+describe("RobinhoodDisclaimerBanner", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedReceive.mockReturnValue(ROBINHOOD_ONLY);
+  });
+
+  it("shows the banner when the flag is on, balance is positive and the asset is Robinhood-exclusive", () => {
+    render(
+      <RobinhoodDisclaimerBanner distributionItem={buildDistributionItem(5)} />,
+      enableDisclaimer(),
+    );
+
+    expect(screen.getByTestId(TEST_ID)).toBeVisible();
+    expect(
+      screen.getByText("Total balance does not include dividends or stock splits."),
+    ).toBeVisible();
+  });
+
+  it("hides the banner when the balance is zero", () => {
+    render(
+      <RobinhoodDisclaimerBanner distributionItem={buildDistributionItem(0)} />,
+      enableDisclaimer(),
+    );
+
+    expect(screen.queryByTestId(TEST_ID)).toBeNull();
+  });
+
+  it("hides the banner for a multi-network asset that also lives on Robinhood", () => {
+    mockedReceive.mockReturnValue([
+      "ethereum/erc20/weth_0x0bd7d308f8e1639fab988df18a8011f41eacad73",
+      "robinhood/erc20/weth_0x0bd7d308f8e1639fab988df18a8011f41eacad73",
+    ]);
+
+    render(
+      <RobinhoodDisclaimerBanner distributionItem={buildDistributionItem(5)} />,
+      enableDisclaimer(),
+    );
+
+    expect(screen.queryByTestId(TEST_ID)).toBeNull();
+  });
+
+  it("hides the banner when the flag is off", () => {
+    render(<RobinhoodDisclaimerBanner distributionItem={buildDistributionItem(5)} />);
+
+    expect(screen.queryByTestId(TEST_ID)).toBeNull();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/RobinhoodDisclaimerBanner/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/RobinhoodDisclaimerBanner/index.tsx
@@ -1,40 +1,16 @@
 import React from "react";
-import { Banner } from "@ledgerhq/lumen-ui-react";
-import { useTranslation } from "react-i18next";
 import type { DistributionItem } from "@ledgerhq/types-live";
-import { isRobinhoodExclusiveAsset } from "@ledgerhq/asset-detail";
-import { useFeature } from "@features/platform-feature-flags";
-import { useReceiveNetworkLedgerIds } from "../../hooks/useReceiveNetworkLedgerIds";
+import { useRobinhoodDisclaimerBannerViewModel } from "./useRobinhoodDisclaimerBannerViewModel";
+import { RobinhoodDisclaimerBannerView } from "./RobinhoodDisclaimerBannerView";
 
 type RobinhoodDisclaimerBannerProps = Readonly<{
   distributionItem?: DistributionItem;
 }>;
 
 export function RobinhoodDisclaimerBanner({ distributionItem }: RobinhoodDisclaimerBannerProps) {
-  const { t } = useTranslation();
-  const robinhoodDisclaimer = useFeature("llRobinhoodDisclaimer");
-
-  const networkLedgerIds = useReceiveNetworkLedgerIds({
-    metaCurrencyId: distributionItem?.metaCurrencyId,
-    marketApiId: distributionItem?.marketId,
-    ticker: distributionItem?.currency.ticker,
-    currencyId: distributionItem?.currency.id,
-    fallbackLedgerIds: [],
-  });
-
-  const hasPositiveBalance = (distributionItem?.amount ?? 0) > 0;
-  const show =
-    !!robinhoodDisclaimer?.enabled &&
-    hasPositiveBalance &&
-    isRobinhoodExclusiveAsset(networkLedgerIds);
+  const { show } = useRobinhoodDisclaimerBannerViewModel({ distributionItem });
 
   if (!show) return null;
 
-  return (
-    <Banner
-      appearance="info"
-      title={t("assetDetails.robinhoodDisclaimerBanner.title")}
-      data-testid="asset-detail-robinhood-disclaimer-banner"
-    />
-  );
+  return <RobinhoodDisclaimerBannerView />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/RobinhoodDisclaimerBanner/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/RobinhoodDisclaimerBanner/index.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Banner } from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "react-i18next";
+import type { DistributionItem } from "@ledgerhq/types-live";
+import { isRobinhoodExclusiveAsset } from "@ledgerhq/asset-detail";
+import { useFeature } from "@features/platform-feature-flags";
+import { useReceiveNetworkLedgerIds } from "../../hooks/useReceiveNetworkLedgerIds";
+
+type RobinhoodDisclaimerBannerProps = Readonly<{
+  distributionItem?: DistributionItem;
+}>;
+
+export function RobinhoodDisclaimerBanner({ distributionItem }: RobinhoodDisclaimerBannerProps) {
+  const { t } = useTranslation();
+  const robinhoodDisclaimer = useFeature("llRobinhoodDisclaimer");
+
+  const networkLedgerIds = useReceiveNetworkLedgerIds({
+    metaCurrencyId: distributionItem?.metaCurrencyId,
+    marketApiId: distributionItem?.marketId,
+    ticker: distributionItem?.currency.ticker,
+    currencyId: distributionItem?.currency.id,
+    fallbackLedgerIds: [],
+  });
+
+  const hasPositiveBalance = (distributionItem?.amount ?? 0) > 0;
+  const show =
+    !!robinhoodDisclaimer?.enabled &&
+    hasPositiveBalance &&
+    isRobinhoodExclusiveAsset(networkLedgerIds);
+
+  if (!show) return null;
+
+  return (
+    <Banner
+      appearance="info"
+      title={t("assetDetails.robinhoodDisclaimerBanner.title")}
+      data-testid="asset-detail-robinhood-disclaimer-banner"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/RobinhoodDisclaimerBanner/useRobinhoodDisclaimerBannerViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/RobinhoodDisclaimerBanner/useRobinhoodDisclaimerBannerViewModel.ts
@@ -1,0 +1,28 @@
+import type { DistributionItem } from "@ledgerhq/types-live";
+import { isRobinhoodExclusiveAsset } from "@ledgerhq/asset-detail";
+import { useFeature } from "@features/platform-feature-flags";
+import { useReceiveNetworkLedgerIds } from "../../hooks/useReceiveNetworkLedgerIds";
+
+type Params = Readonly<{
+  distributionItem?: DistributionItem;
+}>;
+
+export function useRobinhoodDisclaimerBannerViewModel({ distributionItem }: Params) {
+  const robinhoodDisclaimer = useFeature("llRobinhoodDisclaimer");
+
+  const networkLedgerIds = useReceiveNetworkLedgerIds({
+    metaCurrencyId: distributionItem?.metaCurrencyId,
+    marketApiId: distributionItem?.marketId,
+    ticker: distributionItem?.currency.ticker,
+    currencyId: distributionItem?.currency.id,
+    fallbackLedgerIds: [],
+  });
+
+  const hasPositiveBalance = (distributionItem?.amount ?? 0) > 0;
+  const show =
+    !!robinhoodDisclaimer?.enabled &&
+    hasPositiveBalance &&
+    isRobinhoodExclusiveAsset(networkLedgerIds);
+
+  return { show };
+}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9340,6 +9340,9 @@
     "fallbackBanner": {
       "title": "Swap and Buy are not supported for this asset."
     },
+    "robinhoodDisclaimerBanner": {
+      "title": "Total balance does not include dividends or stock splits."
+    },
     "day": "1 day",
     "week": "1 week",
     "month": "1 month",

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -393,11 +393,15 @@ describe("AssetDetail screen layout", () => {
     const ROBINHOOD_ONLY_LEDGER_IDS = [
       "robinhood_testnet/erc20/amd_0x71178bac73cbeb415514eb542a8995b82669778d",
     ];
+    // Enables the flag and funds the asset, so only the Robinhood-exclusivity gate is exercised.
     const enableDisclaimer = () => ({
-      overrideInitialState: withFlagOverrides({ llRobinhoodDisclaimer: { enabled: true } }),
+      overrideInitialState: withFlagOverrides(
+        { llRobinhoodDisclaimer: { enabled: true } },
+        withBtcAccounts(1).overrideInitialState,
+      ),
     });
 
-    it("shows the disclaimer banner when the flag is on and the asset is exclusive to a Robinhood chain", async () => {
+    it("shows the disclaimer banner when the flag is on, the balance is positive and the asset is exclusive to a Robinhood chain", async () => {
       mockedUseReceiveNetworkLedgerIds.mockReturnValue(ROBINHOOD_ONLY_LEDGER_IDS);
 
       render(<AssetDetailTestNavigator />, enableDisclaimer());
@@ -433,6 +437,16 @@ describe("AssetDetail screen layout", () => {
       mockedUseReceiveNetworkLedgerIds.mockReturnValue(ROBINHOOD_ONLY_LEDGER_IDS);
 
       render(<AssetDetailTestNavigator />);
+
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.stockDisclaimerBanner)).toBeNull();
+    });
+
+    it("hides the disclaimer banner when the asset has no balance", () => {
+      mockedUseReceiveNetworkLedgerIds.mockReturnValue(ROBINHOOD_ONLY_LEDGER_IDS);
+
+      render(<AssetDetailTestNavigator />, {
+        overrideInitialState: withFlagOverrides({ llRobinhoodDisclaimer: { enabled: true } }),
+      });
 
       expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.stockDisclaimerBanner)).toBeNull();
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -78,8 +78,11 @@ export function useAssetDetailViewModel() {
   const hideReceiveInBalanceGraph = !isCurrencySupported || secondaryButton === "receive";
   const showFallbackBanner = isCurrencySupported && !isBuyAvailable && !availableOnSwap;
   const robinhoodDisclaimer = useFeature("llRobinhoodDisclaimer");
+  const hasPositiveBalance = (distributionItem?.amount ?? 0) > 0;
   const showStockDisclaimerBanner =
-    !!robinhoodDisclaimer?.enabled && isRobinhoodExclusiveAsset(receiveLedgerIds);
+    !!robinhoodDisclaimer?.enabled &&
+    hasPositiveBalance &&
+    isRobinhoodExclusiveAsset(receiveLedgerIds);
 
   const coinOptions = useAssetCoinOptionsViewModel({ currency, currencyId, marketId });
 

--- a/libs/asset-detail/src/index.ts
+++ b/libs/asset-detail/src/index.ts
@@ -3,6 +3,7 @@ export * from "./hooks/useReceiveNetworkLedgerIds";
 export * from "./hooks/useTradeAvailability";
 export * from "./utils/assetDetailMarketInfo";
 export * from "./utils/getTransactionPointMarkers";
+export * from "./utils/isRobinhoodExclusiveAsset";
 export * from "./utils/resolveMaxSupplyDisplay";
 export * from "./utils/tradeAvailability";
 export type {

--- a/libs/asset-detail/src/utils/__tests__/isRobinhoodExclusiveAsset.test.ts
+++ b/libs/asset-detail/src/utils/__tests__/isRobinhoodExclusiveAsset.test.ts
@@ -1,0 +1,38 @@
+import { isRobinhoodExclusiveAsset } from "../isRobinhoodExclusiveAsset";
+
+describe("isRobinhoodExclusiveAsset", () => {
+  it("returns true for a token only on robinhood_testnet", () => {
+    expect(
+      isRobinhoodExclusiveAsset([
+        "robinhood_testnet/erc20/amd_0x71178bac73cbeb415514eb542a8995b82669778d",
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns true for a token only on robinhood mainnet", () => {
+    expect(isRobinhoodExclusiveAsset(["robinhood/erc20/amd_0xabc"])).toBe(true);
+  });
+
+  it("returns true when every network is a Robinhood chain", () => {
+    expect(
+      isRobinhoodExclusiveAsset(["robinhood/erc20/amd_0xabc", "robinhood_testnet/erc20/amd_0xdef"]),
+    ).toBe(true);
+  });
+
+  it("returns false for a multi-network asset that also lives on Robinhood (e.g. WETH)", () => {
+    expect(
+      isRobinhoodExclusiveAsset([
+        "ethereum/erc20/weth_0x0bd7d308f8e1639fab988df18a8011f41eacad73",
+        "robinhood/erc20/weth_0x0bd7d308f8e1639fab988df18a8011f41eacad73",
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns false for an asset on another chain only", () => {
+    expect(isRobinhoodExclusiveAsset(["ethereum"])).toBe(false);
+  });
+
+  it("returns false for an empty list", () => {
+    expect(isRobinhoodExclusiveAsset([])).toBe(false);
+  });
+});

--- a/libs/asset-detail/src/utils/isRobinhoodExclusiveAsset.ts
+++ b/libs/asset-detail/src/utils/isRobinhoodExclusiveAsset.ts
@@ -1,0 +1,17 @@
+/**
+ * Networks that make up the Robinhood chain. Tokenized stocks currently live on
+ * `robinhood_testnet` only; `robinhood` (mainnet) is included so the check keeps
+ * working once stocks ship there.
+ */
+const ROBINHOOD_NETWORK_IDS = new Set(["robinhood", "robinhood_testnet"]);
+
+const getNetworkId = (ledgerId: string): string => ledgerId.split("/")[0];
+
+/**
+ * An asset is "Robinhood-exclusive" when every network it is available on is a
+ * Robinhood chain. Multi-network assets that merely include a Robinhood network
+ * (e.g. WETH, also on Ethereum) are not exclusive and return `false`.
+ */
+export function isRobinhoodExclusiveAsset(ledgerIds: readonly string[]): boolean {
+  return ledgerIds.length > 0 && ledgerIds.every(id => ROBINHOOD_NETWORK_IDS.has(getNetworkId(id)));
+}

--- a/libs/asset-detail/src/utils/isRobinhoodExclusiveAsset.ts
+++ b/libs/asset-detail/src/utils/isRobinhoodExclusiveAsset.ts
@@ -1,17 +1,7 @@
-/**
- * Networks that make up the Robinhood chain. Tokenized stocks currently live on
- * `robinhood_testnet` only; `robinhood` (mainnet) is included so the check keeps
- * working once stocks ship there.
- */
 const ROBINHOOD_NETWORK_IDS = new Set(["robinhood", "robinhood_testnet"]);
 
 const getNetworkId = (ledgerId: string): string => ledgerId.split("/")[0];
 
-/**
- * An asset is "Robinhood-exclusive" when every network it is available on is a
- * Robinhood chain. Multi-network assets that merely include a Robinhood network
- * (e.g. WETH, also on Ethereum) are not exclusive and return `false`.
- */
 export function isRobinhoodExclusiveAsset(ledgerIds: readonly string[]): boolean {
   return ledgerIds.length > 0 && ledgerIds.every(id => ROBINHOOD_NETWORK_IDS.has(getNetworkId(id)));
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Shared trigger-helper unit tests + desktop component tests + mobile integration tests (flag on/off, positive vs zero balance, Robinhood-exclusive vs multi-network).
- [ ] **Impact of the changes:**
  - Wallet 4.0 asset detail screen (desktop **and** mobile). QA: the disclaimer banner appears only when the `llRobinhoodDisclaimer` flag is on, the asset is supported **exclusively** on a Robinhood chain, **and** the user holds a positive balance. Assets on non-Robinhood chains (or Robinhood + other chains), or held with zero balance, do not show it.

### 📝 Description

Adds an informational disclaimer banner to the Wallet 4.0 asset detail screen on **both apps**.

- **Trigger**: `llRobinhoodDisclaimer` flag on **+** positive balance for the asset **+** the asset is supported exclusively on a Robinhood chain (every network in its resolved list is `robinhood` / `robinhood_testnet`; multi-network assets like WETH don't qualify).
- **Behaviour**: informational only — Lumen info `Banner`, copy _"Total balance does not include dividends or stock splits."_, placed under Total balance.
- **Shared logic**: the exclusivity check lives in `@ledgerhq/asset-detail` as `isRobinhoodExclusiveAsset`, reused by both apps.

Temporary measure until EIP-8056 support lands (which will surface the correct balance).

Includes the LWM positive-balance parity fix (LIVE-32758), folded in here so both platforms ship the same behaviour in one PR.

Example with forced show to true for UI testing

<img width="1583" height="951" alt="Screenshot 2026-06-25 at 1 59 37 PM" src="https://github.com/user-attachments/assets/9659ebfe-7e54-4010-aa29-c9bfc7f05805" />

### ❓ Context

- **JIRA**: [LIVE-32756](https://ledgerhq.atlassian.net/browse/LIVE-32756) (LWD) · [LIVE-32758](https://ledgerhq.atlassian.net/browse/LIVE-32758) (LWM balance parity) · epic [LIVE-31149](https://ledgerhq.atlassian.net/browse/LIVE-31149)
- **Design**: [Figma — Asset / Address screens • Wallet 4.0](https://www.figma.com/design/mv0arYJWSwklM6RdyKq9Xk/Asset---Address-screens--%E2%80%A2-Wallet-4.0?node-id=20919-32663&m=dev)


[LIVE-32756]: https://ledgerhq.atlassian.net/browse/LIVE-32756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ