### PR TITLE
[LWM] fix(lwm): hide feature-flag-disabled currencies from global search results (LIVE-33199)

### DIFF
--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/__tests__/useGlobalSearchResults.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/__tests__/useGlobalSearchResults.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@tests/test-renderer";
+import { renderHook, act, withFlagOverrides } from "@tests/test-renderer";
 import { setEnv } from "@ledgerhq/live-env";
 import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
 import { selectCurrencyForMetaId } from "@ledgerhq/live-common/dada-client/utils/currencySelection";
@@ -25,6 +25,20 @@ const buildData = (ids: string[]) =>
       ids.map(id => [id, { id, name: id, ticker: id.toUpperCase(), assetsIds: { ethereum: id } }]),
     ),
     markets: Object.fromEntries(ids.map((id, i) => [id, { id, marketCapRank: i + 1, price: 1 }])),
+  }) as never;
+
+const buildDataOnNetwork = (network: string) =>
+  ({
+    currenciesOrder: { metaCurrencyIds: ["amdx"], key: "marketCap", order: "desc" },
+    cryptoAssets: {
+      amdx: {
+        id: "amdx",
+        name: "AMD",
+        ticker: "AMDX",
+        assetsIds: { [network]: `${network}/erc20/amd` },
+      },
+    },
+    markets: { amdx: { id: "amdx", marketCapRank: 1, price: 1 } },
   }) as never;
 
 describe("useGlobalSearchResults", () => {
@@ -69,6 +83,33 @@ describe("useGlobalSearchResults", () => {
     expect(mockedAssets).toHaveBeenLastCalledWith(
       expect.objectContaining({ includeTestNetworks: true }),
     );
+  });
+
+  it("hides a result whose only network currency flag is off", () => {
+    mockedAssets.mockReturnValue({
+      data: buildDataOnNetwork("robinhood_testnet"),
+      isLoading: false,
+    } as never);
+
+    const { result } = renderHook(() => useGlobalSearchResults());
+    act(() => result.current.setSearch("amd"));
+
+    expect(result.current.searchResults).toEqual([]);
+    expect(result.current.hasNoResults).toBe(true);
+  });
+
+  it("shows the result when its network currency flag is on", () => {
+    mockedAssets.mockReturnValue({
+      data: buildDataOnNetwork("robinhood_testnet"),
+      isLoading: false,
+    } as never);
+
+    const { result } = renderHook(() => useGlobalSearchResults(), {
+      overrideInitialState: withFlagOverrides({ currencyRobinhoodTestnet: { enabled: true } }),
+    });
+    act(() => result.current.setSearch("amd"));
+
+    expect(result.current.searchResults).toHaveLength(1);
   });
 
   it("tracks search_query when the debounced query changes", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/useGlobalSearchResults.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/useGlobalSearchResults.ts
@@ -3,6 +3,7 @@ import VersionNumber from "react-native-version-number";
 import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
 import { selectCurrencyForMetaId } from "@ledgerhq/live-common/dada-client/utils/currencySelection";
 import { useSearchCommon } from "@ledgerhq/live-common/modularDrawer/hooks/useSearch";
+import { useCurrenciesUnderFeatureFlag } from "@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
@@ -41,6 +42,8 @@ export function useGlobalSearchResults(): GlobalSearchResults {
   const modularDrawer = useFeature("llmModularDrawer");
   const isStaging = modularDrawer?.params?.backendEnvironment === "STAGING";
   const includeTestNetworks = useEnv("MANAGER_DEV_MODE");
+  // Hide currencies disabled by a feature flag, mirroring the receive flow.
+  const { deactivatedCurrencyIds } = useCurrenciesUnderFeatureFlag();
 
   const handleTrackSearch = useCallback(
     (query: string) => track("search_query", { query, page: ScreenName.GlobalSearch }),
@@ -79,6 +82,11 @@ export function useGlobalSearchResults(): GlobalSearchResults {
     return data.currenciesOrder.metaCurrencyIds.flatMap(id => {
       const meta = data.cryptoAssets[id];
       if (!meta) return [];
+      // Drop an asset whose every network currency is disabled by a feature flag.
+      const networks = Object.keys(meta.assetsIds);
+      if (networks.length > 0 && networks.every(network => deactivatedCurrencyIds.has(network))) {
+        return [];
+      }
       const currency = selectCurrencyForMetaId(id, data);
       if (!currency) return [];
 
@@ -90,7 +98,16 @@ export function useGlobalSearchResults(): GlobalSearchResults {
         ),
       ];
     });
-  }, [data, query, counterCurrency, counterValueUnit, usdToFiatRate, locale, t]);
+  }, [
+    data,
+    query,
+    deactivatedCurrencyIds,
+    counterCurrency,
+    counterValueUnit,
+    usdToFiatRate,
+    locale,
+    t,
+  ]);
 
   const isLoadingSearch = isSearchActive && (isDebouncing || isLoading || rateStatus === "loading");
   const clearSearch = useCallback(() => handleSearch(""), [handleSearch]);


### PR DESCRIPTION
### ✅ Checklist

- [x] **Covered by automatic tests.** Unit tests asserting a result is hidden when its only network currency flag is off, and shown when on.
- [ ] **Impact of the changes:**
  - Global Search (Wallet 4.0, mobile). QA: with developer mode on, a testnet asset whose currency flag is OFF (e.g. robinhood_testnet with `currencyRobinhoodTestnet` off) should NOT appear in Global Search; enabling the flag makes it appear. Mainnet results are unaffected.

### 📝 Description

Follow-up to #18931 (merged). After enabling testnets in Global Search, results still included currencies whose currency feature flag is off — unlike the receive flow, which hides them.

This filters Global Search results through `useCurrenciesUnderFeatureFlag`'s `deactivatedCurrencyIds` (the same mechanism the receive flow uses): a search result is dropped when **every** network of its asset is disabled by a feature flag. Mock mode (E2E) is unaffected since `deactivatedCurrencyIds` is empty there.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33199](https://ledgerhq.atlassian.net/browse/LIVE-33199)


[LIVE-33199]: https://ledgerhq.atlassian.net/browse/LIVE-33199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ