### PR TITLE
[LWDM] fix(celo): exclude saturated validator groups from vote list

### DIFF
--- a/.changeset/celo-vote-cap-filter.md
+++ b/.changeset/celo-vote-cap-filter.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/coin-celo": patch
+---
+
+celo: stop offering saturated validator groups in the vote flow, and refresh the validator list properly.
+
+- The capacity check now compares the group's vote cap (`getNumVotesReceivable`) against its current total votes instead of just checking the cap is positive, so groups that are already at or above their cap are filtered out and no longer revert with "vote cap exceeded" when voting.
+- `preload` now always refetches the validator groups (gated by `preloadMaxAge`) instead of skipping when a hydrated list already exists. Previously a once-cached list was pinned forever, so users never saw newly available or removed groups. Per-group capacity reads are batched into a single Multicall3 round-trip.

--- a/e2e/mobile/specs/delegate/voteCELO.spec.ts
+++ b/e2e/mobile/specs/delegate/voteCELO.spec.ts
@@ -1,7 +1,7 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runVoteCelo } from "./delegate";
 
-const delegation = new Delegate(Account.CELO_1, "0.001", "cLabs");
+const delegation = new Delegate(Account.CELO_1, "0.001", "GrassrootsEconomics");
 runVoteCelo(
   delegation,
   ["B2CQA-201"],

--- a/libs/coin-modules/coin-celo/src/__tests__/network/hubble.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/network/hubble.test.ts
@@ -1,0 +1,136 @@
+const networkMock = jest.fn();
+const getCeloClientMock = jest.fn();
+const getRegistryAddressForMock = jest.fn();
+const readContractMock = jest.fn();
+const multicallMock = jest.fn();
+
+jest.mock("@ledgerhq/live-network/network", () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => networkMock(...args),
+}));
+jest.mock("../../network/client", () => ({
+  getCeloClient: (...args: unknown[]) => getCeloClientMock(...args),
+}));
+jest.mock("../../network/registry", () => ({
+  getRegistryAddressFor: (...args: unknown[]) => getRegistryAddressForMock(...args),
+}));
+
+import { getValidatorGroups } from "../../network/hubble";
+
+const FIGMENT = "0x0861a61Bf679A30680510EcC238ee43B82C5e843";
+
+type Group = {
+  address: string;
+  name: string;
+  cap: bigint; // getNumVotesReceivable (vote cap)
+  total: bigint; // getTotalVotesForGroup
+  eligible: boolean;
+};
+
+const setup = (groups: Group[]) => {
+  networkMock.mockResolvedValue({
+    data: {
+      items: groups.map(g => ({
+        address: g.address,
+        name: g.name,
+        active_votes: g.total.toString(),
+        pending_votes: "0",
+      })),
+    },
+  });
+
+  readContractMock.mockImplementation(async ({ functionName }: { functionName: string }) => {
+    if (functionName === "getEligibleValidatorGroups") {
+      return groups.filter(g => g.eligible).map(g => g.address);
+    }
+    return 0n;
+  });
+
+  // getValidatorGroups batches the per-group capacity reads via client.multicall, in the order
+  // [getNumVotesReceivable, getTotalVotesForGroup] for each raw group.
+  multicallMock.mockImplementation(async () =>
+    groups.flatMap(g => [
+      { status: "success", result: g.cap },
+      { status: "success", result: g.total },
+    ]),
+  );
+};
+
+describe("network/hubble - getValidatorGroups", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    getCeloClientMock.mockReturnValue({ readContract: readContractMock, multicall: multicallMock });
+    getRegistryAddressForMock.mockResolvedValue("0x000000000000000000000000000000000000ce10");
+  });
+
+  it("keeps eligible groups that still have capacity, ranked by TVL", async () => {
+    setup([
+      { address: "0xaaa", name: "Alpha", cap: 1000n, total: 100n, eligible: true },
+      { address: "0xbbb", name: "Beta", cap: 1000n, total: 300n, eligible: true },
+    ]);
+
+    const result = await getValidatorGroups();
+
+    expect(result.map(g => g.name)).toEqual(["Beta", "Alpha"]);
+  });
+
+  it("filters out saturated groups (cap <= total) so they are not offered", async () => {
+    setup([
+      { address: "0xaaa", name: "Alpha", cap: 1000n, total: 100n, eligible: true },
+      { address: "0xsat", name: "Saturated", cap: 100n, total: 500n, eligible: true },
+    ]);
+
+    const result = await getValidatorGroups();
+
+    expect(result.map(g => g.name)).toEqual(["Alpha"]);
+  });
+
+  it("filters out groups that are not in the eligible set", async () => {
+    setup([
+      { address: "0xaaa", name: "Alpha", cap: 1000n, total: 100n, eligible: true },
+      { address: "0xine", name: "Ineligible", cap: 1000n, total: 100n, eligible: false },
+    ]);
+
+    const result = await getValidatorGroups();
+
+    expect(result.map(g => g.name)).toEqual(["Alpha"]);
+  });
+
+  it("keeps eligible groups when the capacity multicall fails (fail open)", async () => {
+    setup([
+      { address: "0xaaa", name: "Alpha", cap: 1000n, total: 100n, eligible: true },
+      { address: "0xbbb", name: "Beta", cap: 1000n, total: 300n, eligible: true },
+      { address: "0xine", name: "Ineligible", cap: 1000n, total: 100n, eligible: false },
+    ]);
+    multicallMock.mockRejectedValueOnce(new Error("rpc down"));
+
+    const result = await getValidatorGroups();
+
+    expect(result.map(g => g.name)).toEqual(["Beta", "Alpha"]);
+  });
+
+  it("keeps a group when one of its two capacity reads fails (fail open)", async () => {
+    setup([{ address: "0xaaa", name: "Alpha", cap: 1000n, total: 100n, eligible: true }]);
+    // getNumVotesReceivable succeeds, getTotalVotesForGroup fails for the only group.
+    multicallMock.mockResolvedValueOnce([
+      { status: "success", result: 1000n },
+      { status: "failure", error: new Error("revert") },
+    ]);
+
+    const result = await getValidatorGroups();
+
+    expect(result.map(g => g.name)).toEqual(["Alpha"]);
+  });
+
+  it("excludes the deprecated 'Ledger by Figment' group even when it has capacity", async () => {
+    setup([
+      { address: "0xaaa", name: "Alpha", cap: 1000n, total: 100n, eligible: true },
+      { address: FIGMENT, name: "Ledger by Figment", cap: 999999n, total: 0n, eligible: true },
+    ]);
+
+    const result = await getValidatorGroups();
+
+    expect(result.map(g => g.name)).toEqual(["Alpha"]);
+  });
+});

--- a/libs/coin-modules/coin-celo/src/bridge/preload.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/preload.ts
@@ -53,16 +53,12 @@ export const preload = async (): Promise<CeloPreloadData> => {
   const { validatorGroups: previousValidatorGroups } = currentCeloPreloadedData;
   let validatorGroups = previousValidatorGroups;
 
-  if (!validatorGroups || !validatorGroups.length) {
-    log("celo/preload", "refreshing celo validatorGroups...");
-
-    try {
-      validatorGroups = await getValidatorGroups();
-    } catch (error) {
-      log("celo/preload", "failed to fetch validatorGroups", {
-        error,
-      });
-    }
+  // Always refetch (gated by preloadMaxAge); guarding on the hydrated list would pin it forever.
+  log("celo/preload", "refreshing celo validatorGroups...");
+  try {
+    validatorGroups = await getValidatorGroups();
+  } catch (error) {
+    log("celo/preload", "failed to fetch validatorGroups", { error });
   }
 
   return { validatorGroups };

--- a/libs/coin-modules/coin-celo/src/network/hubble.ts
+++ b/libs/coin-modules/coin-celo/src/network/hubble.ts
@@ -32,25 +32,36 @@ export const getValidatorGroups = async (): Promise<CeloValidatorGroup[]> => {
 
   const eligibleSet = new Set(eligibleGroups.map(a => a.toLowerCase()));
 
-  // Check on-chain capacity for every group in parallel.
-  // A group must be in the eligible set and have remaining vote capacity (getNumVotesReceivable > 0),
-  // which matches the semantics of ContractKit's getValidatorGroupVotes { eligible, capacity }.
-  const canReceiveVotes = await Promise.all(
-    rawGroups.map(async (vg: { address: `0x${string}` }) => {
-      try {
-        if (!eligibleSet.has(vg.address.toLowerCase())) return false;
-        const capacity = await client.readContract({
+  // Batch all capacity reads in one Multicall3 round-trip. A group can receive votes when its
+  // cap (getNumVotesReceivable) is above its current total votes; saturated groups are excluded.
+  type CapacityResult = { status: "success"; result: unknown } | { status: "failure" };
+  const capacityResults: readonly CapacityResult[] = await client
+    .multicall({
+      allowFailure: true,
+      contracts: rawGroups.flatMap((vg: { address: `0x${string}` }) => [
+        {
           address: electionAddress,
           abi: electionABI,
           functionName: "getNumVotesReceivable",
           args: [vg.address],
-        });
-        return capacity > BigInt(0);
-      } catch {
-        return true;
-      }
-    }),
-  );
+        },
+        {
+          address: electionAddress,
+          abi: electionABI,
+          functionName: "getTotalVotesForGroup",
+          args: [vg.address],
+        },
+      ]),
+    })
+    .catch(() => []);
+
+  const canReceiveVotes = rawGroups.map((vg: { address: `0x${string}` }, index: number) => {
+    if (!eligibleSet.has(vg.address.toLowerCase())) return false;
+    const voteCap = capacityResults[index * 2];
+    const totalVotes = capacityResults[index * 2 + 1];
+    if (voteCap?.status !== "success" || totalVotes?.status !== "success") return true;
+    return (voteCap.result as bigint) > (totalVotes.result as bigint);
+  });
 
   const result = rawGroups
     .filter((_: unknown, idx: number) => canReceiveVotes[idx])


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Unit tests on `getValidatorGroups` cover capacity / eligibility / Figment exclusion and TVL ranking.
- [x] **Impact of the changes:**
      - **Celo Vote flow**: validator groups at or above their on-chain vote cap are no longer listed/selectable (no more "vote cap exceeded" reverts).
      - The validator list now actually refreshes instead of being pinned to the first cached version.
      - Remaining (votable) groups are still ranked by TVL.

### 📝 Description

Voting for some Celo validator groups failed at broadcast with `Validator group ... cannot receive more votes: vote cap exceeded`.

**1. Wrong capacity check.** `getNumVotesReceivable` returns a group's **vote cap** (max total votes it may hold), not the remaining capacity. The code only checked `cap > 0` (always true), so saturated groups (current total ≥ cap) stayed eligible and selectable, then reverted on vote. Fix: compare the cap against the group's current total votes (`getNumVotesReceivable(group) > getTotalVotesForGroup(group)`), matching ContractKit's `getValidatorGroupVotes { capacity }` semantics. The per-group reads are batched into a single Multicall3 round-trip to avoid ~2N `eth_call` requests.

**2. The validator list was pinned forever.** `preload` only fetched when the in-memory list was empty. But `hydrate` repopulates that list from the persisted cache on every startup, so `preload` always short-circuited and never refetched — a once-cached list never picked up new/removed groups (the `preloadMaxAge` TTL was effectively dead). `preload` now always refetches (gated by `preloadMaxAge`), falling back to the previous list on error, consistent with the other coin modules.

This was surfaced by the Figment deprecation (LIVE-33087): with no default validator and the list ranked by TVL, users are nudged toward the largest groups, which are the most likely to be at their cap (e.g. cLabs: cap 2.25M < total 2.42M).

Also updated the celo vote e2e to target a validator with real headroom (cLabs was at cap).

### ❓ Context

- Follow-up / fix surfaced by [LIVE-33087](https://ledgerhq.atlassian.net/browse/LIVE-33087)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-33087]: https://ledgerhq.atlassian.net/browse/LIVE-33087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ