### PR TITLE
[LWDM] feat(analytics): add borrowFeature analytics property

### DIFF
--- a/.changeset/borrow-feature-analytics.md
+++ b/.changeset/borrow-feature-analytics.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Add `borrowFeature` analytics property derived from the `ptxBorrowLiveApp` feature flag, included in identify traits and track events on both desktop and mobile.

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -153,6 +153,7 @@ const getPtxAttributes = () => {
   const ptxCard = analyticsFeatureFlagMethod("ptxCard");
   const ptxSwapLiveAppOnPortfolio = analyticsFeatureFlagMethod("ptxSwapLiveAppOnPortfolio");
   const ptxSwapLiveAppOnAsset = analyticsFeatureFlagMethod("ptxSwapLiveAppOnAsset");
+  const ptxBorrowLiveApp = analyticsFeatureFlagMethod("ptxBorrowLiveApp");
   const isBatch1Enabled: boolean =
     !!fetchAdditionalCoins?.enabled && fetchAdditionalCoins?.params?.batch === 1;
   const isBatch2Enabled: boolean =
@@ -192,6 +193,7 @@ const getPtxAttributes = () => {
     ptxCard: ptxCard?.enabled,
     ptxSwapLiveAppOnPortfolio: ptxSwapLiveAppOnPortfolio?.enabled,
     ptxSwapLiveAppOnAsset: ptxSwapLiveAppOnAsset?.enabled,
+    borrowFeature: !!ptxBorrowLiveApp?.enabled,
     stablecoinYield,
     bitcoinYield,
     ethDepositScreen,

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -96,6 +96,7 @@ const getFeatureFlagProperties = () => {
 
     const ptxSwapLiveAppMobileFlag = analyticsFeatureFlagMethod("ptxSwapLiveAppMobile");
     const ptxSwapLiveAppKycWarning = analyticsFeatureFlagMethod("ptxSwapLiveAppKycWarning");
+    const ptxBorrowLiveAppFlag = analyticsFeatureFlagMethod("ptxBorrowLiveApp");
     const llmSyncOnboardingIncr1Flag = analyticsFeatureFlagMethod("llmSyncOnboardingIncr1");
     const lwmAnalyticsConsentOnboardingFlag = analyticsFeatureFlagMethod(
       "lwmAnalyticsConsentOnboarding",
@@ -113,6 +114,7 @@ const getFeatureFlagProperties = () => {
 
     const ptxSwapLiveAppMobileEnabled = Boolean(ptxSwapLiveAppMobileFlag?.enabled);
     const ptxSwapLiveAppKycWarningEnabled = Boolean(ptxSwapLiveAppKycWarning?.enabled);
+    const borrowFeature = Boolean(ptxBorrowLiveAppFlag?.enabled);
     const llmSyncOnboardingIncr1 = Boolean(llmSyncOnboardingIncr1Flag?.enabled);
     const lwmAnalyticsConsentOnboarding = Boolean(lwmAnalyticsConsentOnboardingFlag?.enabled);
     const lwmNotificationsOptIn = Boolean(lwmNotificationsOptInFlag?.enabled);
@@ -149,6 +151,7 @@ const getFeatureFlagProperties = () => {
       partnerStakingCurrenciesEnabled,
       ptxSwapLiveAppMobileEnabled,
       ptxSwapLiveAppKycWarningEnabled,
+      borrowFeature,
       llmSyncOnboardingIncr1,
       lwmAnalyticsConsentOnboarding,
       lwmNotificationsOptIn,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new tests added — matches the existing pattern for other PTX flags (`ptxCard`, `ptxSwapLiveApp*`), which are similarly untested in `segment.ts`._
- [x] **Impact of the changes:**
  - Analytics payloads (identify traits + every track/screen event) include a `borrowFeature: true | false` property derived from the `ptxBorrowLiveApp` feature flag, on both desktop and mobile.

### 📝 Description

Adds a new `borrowFeature` boolean analytics property derived from the `ptxBorrowLiveApp` feature flag, allowing the data team to slice analytics by whether the Borrow Live App is enabled for the user.

**Problem**: The `ptxBorrowLiveApp` feature flag controls visibility/availability of the Borrow Live App, but its state is not currently visible in analytics, making it impossible to correlate user behaviour with the flag's rollout.

**Solution**:
- **Desktop** (`apps/ledger-live-desktop/src/renderer/analytics/segment.ts`): read `ptxBorrowLiveApp` in `getPtxAttributes()` and expose `borrowFeature: !!ptxBorrowLiveApp?.enabled` so the value is included in `extraProperties()` on every identify and track call.
- **Mobile** (`apps/ledger-live-mobile/src/analytics/segment.ts`): read `ptxBorrowLiveApp` in `getFeatureFlagProperties()` and expose `borrowFeature: Boolean(ptxBorrowLiveAppFlag?.enabled)` in the deferred `updateIdentify({ ... })` call.

The emitted property is intentionally named `borrowFeature` (not `ptxBorrowLiveApp`) for analytics readability.

<img width="1050" height="522" alt="image" src="https://github.com/user-attachments/assets/1bbe45a0-b8c4-492e-a22a-8ab28acbf135" />


### ❓ Context

- **JIRA or GitHub link**: _no ticket_