### PR TITLE
ci(e2e): clearer Scope & Currency filters for the manual E2E workflows

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -14,7 +14,6 @@ on:
     - cron: "0 3 * * 1-5" # Mon–Fri → Wallet 4.0 (default)
   workflow_dispatch:
     inputs:
-      # ────────────── What to test (start here) ──────────────
       ref:
         description: "Branch to test — leave blank to use this workflow's own branch"
         required: false
@@ -39,16 +38,30 @@ on:
         default: "All currencies"
         options:
           - "All currencies"
-          - "Bitcoin"
           - "Ethereum & EVM chains"
+          - "Bitcoin"
           - "Solana"
           - "XRP"
           - "Cosmos"
           - "Polkadot"
           - "Tron"
-          - "Cardano"
+          - "Hedera"
+          - "Algorand"
           - "Tezos"
           - "Stellar"
+          - "Cardano"
+          - "Sui"
+          - "Celo"
+          - "Aptos"
+          - "Zcash"
+          - "NEAR"
+          - "Litecoin"
+          - "VeChain"
+          - "TON"
+          - "MultiversX"
+          - "Kaspa"
+          - "Internet Computer"
+          - "Concordium"
       tests_type:
         description: "Which platforms to run on?"
         required: true
@@ -70,9 +83,8 @@ on:
           - flex
           - nanoGen5
         default: nanoX
-      # ────────────── Advanced filtering (power users) ──────────────
       test_filter:
-        description: 'Advanced override: custom pattern by tag (@bitcoin, @family-evm) or test name (addAccount). Comma-separate to match any. When set, REPLACES the Scope & Currency choices above.'
+        description: "Advanced override: custom pattern by tag (@bitcoin, @family-evm) or test name (addAccount). Comma-separate to match any. When set, REPLACES the Scope & Currency choices above."
         required: false
         type: string
       production_firebase:
@@ -136,7 +148,7 @@ on:
         type: string
         default: "All currencies"
       test_filter:
-        description: 'Advanced override: custom pattern by tag or test name. When set, replaces test_scope/currency.'
+        description: "Advanced override: custom pattern by tag or test name. When set, replaces test_scope/currency."
         required: false
         type: string
       tests_type:

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -14,15 +14,43 @@ on:
     - cron: "0 3 * * 1-5" # Mon–Fri → Wallet 4.0 (default)
   workflow_dispatch:
     inputs:
+      # ────────────── What to test (start here) ──────────────
       ref:
-        description: "Specify branch to checkout and test or leave blank to use the workflow branch"
+        description: "Branch to test — leave blank to use this workflow's own branch"
         required: false
-      test_filter:
-        description: Filter pattern(s) to execute only selected test suites by test name, file path or tag, separated by ',' or '|' (e.g. "Accounts @smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "addAccount deeplinks")
+      test_scope:
+        description: "Which feature area? Leave on 'All tests' to run everything."
         required: false
-        type: string
+        type: choice
+        default: "All tests"
+        options:
+          - "All tests"
+          - "Send & Receive"
+          - "Swap"
+          - "Stake / Earn"
+          - "Buy / Sell"
+          - "Accounts"
+          - "Settings"
+          - "Portfolio"
+      currency:
+        description: "Limit to one currency? Leave on 'All currencies' for no limit."
+        required: false
+        type: choice
+        default: "All currencies"
+        options:
+          - "All currencies"
+          - "Bitcoin"
+          - "Ethereum & EVM chains"
+          - "Solana"
+          - "XRP"
+          - "Cosmos"
+          - "Polkadot"
+          - "Tron"
+          - "Cardano"
+          - "Tezos"
+          - "Stellar"
       tests_type:
-        description: "Which tests to run"
+        description: "Which platforms to run on?"
         required: true
         type: choice
         default: "iOS & Android"
@@ -31,7 +59,7 @@ on:
           - "iOS Only"
           - "iOS & Android"
       speculos_device:
-        description: Speculos device to use
+        description: "Hardware device to simulate — Nano X / Stax / Flex / Nano S Plus / Nano Gen5 / Nano S"
         required: true
         type: choice
         options:
@@ -42,6 +70,11 @@ on:
           - flex
           - nanoGen5
         default: nanoX
+      # ────────────── Advanced filtering (power users) ──────────────
+      test_filter:
+        description: 'Advanced override: custom pattern by tag (@bitcoin, @family-evm) or test name (addAccount). Comma-separate to match any. When set, REPLACES the Scope & Currency choices above.'
+        required: false
+        type: string
       production_firebase:
         description: "Target Firebase Production env"
         required: false
@@ -66,7 +99,7 @@ on:
         required: false
         type: string
       smoke_tests:
-        description: "Run smoke tests"
+        description: "Run only the fast smoke subset (quick sanity check)"
         required: false
         type: boolean
         default: false
@@ -92,8 +125,18 @@ on:
         description: "Specify branch to checkout and test or leave blank to use the workflow branch"
         required: false
         type: string
+      test_scope:
+        description: "Friendly feature-area preset (see e2e-test-presets.json). Use 'All tests' for no scope."
+        required: false
+        type: string
+        default: "All tests"
+      currency:
+        description: "Friendly currency preset (see e2e-test-presets.json). Use 'All currencies' for no limit."
+        required: false
+        type: string
+        default: "All currencies"
       test_filter:
-        description: Filter pattern(s) to execute only selected test suites by test name, file path or tag, separated by ',' or '|' (e.g. "Accounts @smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "addAccount deeplinks")
+        description: 'Advanced override: custom pattern by tag or test name. When set, replaces test_scope/currency.'
         required: false
         type: string
       tests_type:
@@ -116,7 +159,7 @@ on:
         type: boolean
         default: false
       smoke_tests:
-        description: "Run smoke tests"
+        description: "Run only the fast smoke subset (quick sanity check)"
         required: false
         type: boolean
         default: false
@@ -218,6 +261,7 @@ jobs:
             e2e/mobile
             libs/ledger-live-common/src/bridge/generic-coin-framework/genericCoinFrameworkFamilies.json
             scripts/resolve-e2e-test-filter.mjs
+            scripts/e2e-test-presets.json
             .pnpmfile.cjs
             tools
             .mise/tasks
@@ -285,7 +329,9 @@ jobs:
           echo "- **Commit SHA:** ${{ github.sha }}"
           echo "- **iOS device:** $IOS_DEVICE"
           echo "- **Android device:** $ANDROID_DEVICE"
-          echo "- **Filtered pattern:** $FILTER_PATTERN"
+          echo "- **Scope selected:** ${{ inputs.test_scope || 'All tests' }}"
+          echo "- **Currency selected:** ${{ inputs.currency || 'All currencies' }}"
+          echo "- **Advanced filter (raw input):** $FILTER_PATTERN"
           echo "- **Smoke tests:** $SMOKE_TESTS"
           echo "- **Test Execution ticket ID (Android):** $TEST_EXECUTION_ANDROID"
           echo "- **Test Execution ticket ID (iOS):** $TEST_EXECUTION_IOS"
@@ -332,12 +378,16 @@ jobs:
         run: |
           RESOLVED_FILTER="$(node scripts/resolve-e2e-test-filter.mjs \
             --input "$TEST_FILTER_INPUT" \
+            --scope "$TEST_SCOPE_INPUT" \
+            --currency "$CURRENCY_INPUT" \
             --smoke-tests "$SMOKE_TESTS_INPUT" \
             --check-dir "e2e/mobile/specs")"
           echo "filter=$RESOLVED_FILTER" >> $GITHUB_OUTPUT
         shell: bash
         env:
           TEST_FILTER_INPUT: ${{ inputs.test_filter }}
+          TEST_SCOPE_INPUT: ${{ inputs.test_scope }}
+          CURRENCY_INPUT: ${{ inputs.currency }}
           SMOKE_TESTS_INPUT: ${{ inputs.smoke_tests }}
 
       - name: Write resolved filter to GitHub Summary
@@ -364,6 +414,16 @@ jobs:
           aws_session_token: ${{ env.AWS_SESSION_TOKEN }}
           cache_bucket: ${{ env.cache-bucket }}
           aws_region: ${{ secrets.AWS_CACHE_REGION }}
+
+      # Fail loudly instead of "passing" with zero tests: if a manual run asked to narrow
+      # the suite (Scope / Currency / advanced filter / smoke) but nothing matched, the
+      # downstream build & test jobs would be skipped and the workflow would look green.
+      - name: Guard against an empty manual selection
+        if: ${{ github.event_name == 'workflow_dispatch' && steps.generate-shards.outputs.test_files_for_sharding == '' && (inputs.test_filter != '' || (inputs.test_scope != '' && inputs.test_scope != 'All tests') || (inputs.currency != '' && inputs.currency != 'All currencies') || inputs.smoke_tests) }}
+        run: |
+          echo "::error title=No tests matched your selection::Scope='${{ inputs.test_scope }}', Currency='${{ inputs.currency }}', Filter='${{ inputs.test_filter }}', Smoke='${{ inputs.smoke_tests }}' resolved to '${{ steps.test-filter.outputs.filter }}' and matched 0 specs. Check your selection (or clear the advanced filter)."
+          exit 1
+        shell: bash
 
       - name: Check if iOS Native Build exists already
         id: check-ios-native

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -7,7 +7,6 @@ on:
     - cron: "0 4 * * 1-5"
   workflow_dispatch:
     inputs:
-      # ────────────── What to test (start here) ──────────────
       ref:
         description: "Branch to test — leave blank to use this workflow's own branch"
         required: false
@@ -32,16 +31,30 @@ on:
         default: "All currencies"
         options:
           - "All currencies"
-          - "Bitcoin"
           - "Ethereum & EVM chains"
+          - "Bitcoin"
           - "Solana"
           - "XRP"
           - "Cosmos"
           - "Polkadot"
           - "Tron"
-          - "Cardano"
+          - "Hedera"
+          - "Algorand"
           - "Tezos"
           - "Stellar"
+          - "Cardano"
+          - "Sui"
+          - "Celo"
+          - "Aptos"
+          - "Zcash"
+          - "NEAR"
+          - "Litecoin"
+          - "VeChain"
+          - "TON"
+          - "MultiversX"
+          - "Kaspa"
+          - "Internet Computer"
+          - "Concordium"
       speculos_device:
         description: "Hardware device to simulate — Nano S Plus / Stax / Flex / Nano X / Nano Gen5 / Nano S"
         required: false
@@ -60,15 +73,13 @@ on:
         required: false
         type: boolean
         default: false
-      # ────────────── Advanced filtering (power users) ──────────────
       test_filter:
-        description: 'Advanced override: custom pattern by tag (@bitcoin, @family-evm) or test name (Accounts). Comma-separate to match any. When set, REPLACES the Scope & Currency choices above.'
+        description: "Advanced override: custom pattern by tag (@bitcoin, @family-evm) or test name (Accounts). Comma-separate to match any. When set, REPLACES the Scope & Currency choices above."
         required: false
       invert_filter:
         description: "Advanced: run everything EXCEPT what matches the selection/filter above"
         type: boolean
         default: false
-      # ────────────── Run options ──────────────
       enable_broadcast:
         description: "Enable transaction broadcast"
         required: false
@@ -96,7 +107,6 @@ on:
         description: "Repeat each test N times (optional)"
         required: false
         type: number
-      # ────────────── Reporting ──────────────
       slack_notif:
         description: "Send notification to Slack?"
         required: false
@@ -129,7 +139,7 @@ on:
         type: string
         default: "All currencies"
       test_filter:
-        description: 'Advanced override: custom pattern by tag or test name. When set, replaces test_scope/currency.'
+        description: "Advanced override: custom pattern by tag or test name. When set, replaces test_scope/currency."
         required: false
         type: string
       invert_filter:

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -7,30 +7,68 @@ on:
     - cron: "0 4 * * 1-5"
   workflow_dispatch:
     inputs:
+      # ────────────── What to test (start here) ──────────────
       ref:
-        description: "Specify branch to checkout and test or leave blank to use the workflow branch"
+        description: "Branch to test — leave blank to use this workflow's own branch"
         required: false
+      test_scope:
+        description: "Which feature area? Leave on 'All tests' to run everything."
+        required: false
+        type: choice
+        default: "All tests"
+        options:
+          - "All tests"
+          - "Send & Receive"
+          - "Swap"
+          - "Stake / Earn"
+          - "Buy / Sell"
+          - "Accounts"
+          - "Settings"
+          - "Portfolio"
+      currency:
+        description: "Limit to one currency? Leave on 'All currencies' for no limit."
+        required: false
+        type: choice
+        default: "All currencies"
+        options:
+          - "All currencies"
+          - "Bitcoin"
+          - "Ethereum & EVM chains"
+          - "Solana"
+          - "XRP"
+          - "Cosmos"
+          - "Polkadot"
+          - "Tron"
+          - "Cardano"
+          - "Tezos"
+          - "Stellar"
+      speculos_device:
+        description: "Hardware device to simulate — Nano S Plus / Stax / Flex / Nano X / Nano Gen5 / Nano S"
+        required: false
+        type: choice
+        options:
+          - nanoS
+          - nanoSP
+          - nanoX
+          - stax
+          - flex
+          - nanoGen5
+          - nanoSP and stax
+        default: nanoSP
+      smoke_tests:
+        description: "Run only the fast smoke subset (quick sanity check)"
+        required: false
+        type: boolean
+        default: false
+      # ────────────── Advanced filtering (power users) ──────────────
       test_filter:
-        description: Filter pattern(s) to execute only selected test suites by test name, file path or tag, separated by ',' or '|' (e.g. "Accounts @smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "Accounts @smoke|Settings")
+        description: 'Advanced override: custom pattern by tag (@bitcoin, @family-evm) or test name (Accounts). Comma-separate to match any. When set, REPLACES the Scope & Currency choices above.'
         required: false
       invert_filter:
-        description: Ignore test having name pattern (entered in the previous field)
+        description: "Advanced: run everything EXCEPT what matches the selection/filter above"
         type: boolean
         default: false
-      slack_notif:
-        description: "Send notification to Slack?"
-        required: false
-        type: boolean
-        default: false
-      export_to_xray:
-        description: Send tests results to Xray
-        required: false
-        type: boolean
-        default: false
-      test_execution:
-        description: "Test Execution ticket ID"
-        required: false
-        type: string
+      # ────────────── Run options ──────────────
       enable_broadcast:
         description: "Enable transaction broadcast"
         required: false
@@ -45,24 +83,6 @@ on:
           - staging
           - testing
         default: testing
-      speculos_device:
-        description: "Device to be used"
-        required: false
-        type: choice
-        options:
-          - nanoS
-          - nanoSP
-          - nanoX
-          - stax
-          - flex
-          - nanoGen5
-          - nanoSP and stax
-        default: nanoSP
-      smoke_tests:
-        description: "Run smoke tests"
-        required: false
-        type: boolean
-        default: false
       enable_asset_section:
         description: "Enable the Wallet 4.0 Asset Section"
         type: boolean
@@ -76,6 +96,21 @@ on:
         description: "Repeat each test N times (optional)"
         required: false
         type: number
+      # ────────────── Reporting ──────────────
+      slack_notif:
+        description: "Send notification to Slack?"
+        required: false
+        type: boolean
+        default: false
+      export_to_xray:
+        description: Send tests results to Xray
+        required: false
+        type: boolean
+        default: false
+      test_execution:
+        description: "Test Execution ticket ID"
+        required: false
+        type: string
 
   workflow_call:
     inputs:
@@ -83,12 +118,22 @@ on:
         description: "Specify branch to checkout and test or leave blank to use the workflow branch"
         required: false
         type: string
+      test_scope:
+        description: "Friendly feature-area preset (see e2e-test-presets.json). Use 'All tests' for no scope."
+        required: false
+        type: string
+        default: "All tests"
+      currency:
+        description: "Friendly currency preset (see e2e-test-presets.json). Use 'All currencies' for no limit."
+        required: false
+        type: string
+        default: "All currencies"
       test_filter:
-        description: Filter pattern(s) to execute only selected test suites by test name, file path or tag, separated by ',' or '|' (e.g. "Accounts @smoke", "@generic-coin-framework,@solana", "@bitcoin,@family-evm" or "Accounts @smoke|Settings")
+        description: 'Advanced override: custom pattern by tag or test name. When set, replaces test_scope/currency.'
         required: false
         type: string
       invert_filter:
-        description: Ignore test having name pattern (entered in the previous field)
+        description: Run everything EXCEPT what matches the selection/filter above
         type: boolean
         default: false
       slack_notif:
@@ -272,12 +317,16 @@ jobs:
         run: |
           RESOLVED_FILTER="$(node scripts/resolve-e2e-test-filter.mjs \
             --input "$TEST_FILTER_INPUT" \
+            --scope "$TEST_SCOPE_INPUT" \
+            --currency "$CURRENCY_INPUT" \
             --smoke-tests "$SMOKE_TESTS_INPUT" \
             --check-dir "e2e/desktop/tests")"
           echo "filter=$RESOLVED_FILTER" >> $GITHUB_OUTPUT
         shell: bash
         env:
           TEST_FILTER_INPUT: ${{ inputs.test_filter }}
+          TEST_SCOPE_INPUT: ${{ inputs.test_scope }}
+          CURRENCY_INPUT: ${{ inputs.currency }}
           SMOKE_TESTS_INPUT: ${{ inputs.smoke_tests }}
 
       - name: Write workflow context to GitHub Summary
@@ -306,8 +355,10 @@ jobs:
             echo "- **Triggered branch:** ${{ inputs.ref || github.ref_name }}"
             echo "- **Commit SHA:** ${{ github.sha }}"
             echo "- **Device selected:** $DEVICE"
+            echo "- **Scope selected:** ${{ inputs.test_scope || 'All tests' }}"
+            echo "- **Currency selected:** ${{ inputs.currency || 'All currencies' }}"
             echo "- **Asset Section:** ${{ (github.event_name == 'schedule' || inputs.enable_asset_section != false) && 'enabled' || 'disabled' }}"
-            echo "- **Filtered pattern:** $FILTER_PATTERN"
+            echo "- **Resolved filter pattern:** $FILTER_PATTERN"
             echo "- **Test Execution ticket ID:** $TEST_EXECUTION"
             echo "- **Firebase env to target:** $BUILD_TYPE"
             echo "- **Broadcast enabled:** $BROADCAST_ENABLED"

--- a/scripts/e2e-test-presets.json
+++ b/scripts/e2e-test-presets.json
@@ -1,0 +1,24 @@
+{
+  "$comment": "Single source of truth for the friendly 'Scope' and 'Currency' selectors used by the Desktop and Mobile E2E workflows. Each label maps to a regex fragment understood by resolve-e2e-test-filter.mjs. Scope patterns are case-tolerant so they match both Desktop test titles (Capitalized, e.g. 'Swap') and Mobile spec paths/dirs (lowercase, e.g. 'swap/'). Currency patterns are @family-* tags that exist in both Desktop (built at runtime) and Mobile (spec tags). Keep the 'options:' lists in the two workflow YAMLs in sync with the keys below.",
+  "scopes": {
+    "Send & Receive": "[Ss]end|[Rr]eceive",
+    "Swap": "[Ss]wap",
+    "Stake / Earn": "[Ee]arn|[Dd]elegate|[Ss]take",
+    "Buy / Sell": "[Bb]uy|[Ss]ell",
+    "Accounts": "[Aa]ccount",
+    "Settings": "[Ss]ettings",
+    "Portfolio": "[Pp]ortfolio"
+  },
+  "currencies": {
+    "Bitcoin": "@family-bitcoin",
+    "Ethereum & EVM chains": "@family-evm",
+    "Solana": "@family-solana",
+    "XRP": "@family-xrp",
+    "Cosmos": "@family-cosmos",
+    "Polkadot": "@family-polkadot",
+    "Tron": "@family-tron",
+    "Cardano": "@family-cardano",
+    "Tezos": "@family-tezos",
+    "Stellar": "@family-stellar"
+  }
+}

--- a/scripts/e2e-test-presets.json
+++ b/scripts/e2e-test-presets.json
@@ -10,15 +10,29 @@
     "Portfolio": "[Pp]ortfolio"
   },
   "currencies": {
-    "Bitcoin": "@family-bitcoin",
     "Ethereum & EVM chains": "@family-evm",
+    "Bitcoin": "@family-bitcoin",
     "Solana": "@family-solana",
     "XRP": "@family-xrp",
     "Cosmos": "@family-cosmos",
     "Polkadot": "@family-polkadot",
     "Tron": "@family-tron",
-    "Cardano": "@family-cardano",
+    "Hedera": "@family-hedera",
+    "Algorand": "@family-algorand",
     "Tezos": "@family-tezos",
-    "Stellar": "@family-stellar"
+    "Stellar": "@family-stellar",
+    "Cardano": "@family-cardano",
+    "Sui": "@family-sui",
+    "Celo": "@family-celo",
+    "Aptos": "@family-aptos",
+    "Zcash": "@family-zcash",
+    "NEAR": "@family-near",
+    "Litecoin": "@family-litecoin",
+    "VeChain": "@family-vechain",
+    "TON": "@family-ton",
+    "MultiversX": "@family-multiversx",
+    "Kaspa": "@family-kaspa",
+    "Internet Computer": "@family-internet_computer",
+    "Concordium": "@family-concordium"
   }
 }

--- a/scripts/resolve-e2e-test-filter.mjs
+++ b/scripts/resolve-e2e-test-filter.mjs
@@ -12,6 +12,7 @@ const genericCoinFrameworkFamiliesPath = path.join(
   repoRoot,
   "libs/ledger-live-common/src/bridge/generic-coin-framework/genericCoinFrameworkFamilies.json",
 );
+const presetsPath = path.join(currentDir, "e2e-test-presets.json");
 
 const GENERIC_COIN_FRAMEWORK_ALIASES = new Set([
   "generic-family",
@@ -36,6 +37,32 @@ function splitFilter(input) {
 
 function joinFilterParts(parts) {
   return [...new Set(parts)].join("|");
+}
+
+export function loadPresets(presetsFilePath = presetsPath) {
+  try {
+    const presets = JSON.parse(fs.readFileSync(presetsFilePath, "utf8"));
+    return { scopes: presets.scopes ?? {}, currencies: presets.currencies ?? {} };
+  } catch {
+    console.warn(
+      `::warning title=E2E presets unavailable::Could not read ${presetsFilePath}; Scope/Currency selectors are ignored`,
+    );
+    return { scopes: {}, currencies: {} };
+  }
+}
+
+// Resolves the friendly "Scope" + "Currency" selectors into a single grep expression.
+// Each selector maps to a regex fragment via the presets file. When both are set we AND
+// them with zero-width lookaheads so the run is narrowed to their intersection
+// (e.g. "Swap" + "Bitcoin" -> only Bitcoin swap tests). A single selector is used as-is.
+export function resolveScopeAndCurrency(scope = "", currency = "", presets = loadPresets()) {
+  const scopeExpr = presets.scopes?.[scope?.trim()] ?? "";
+  const currencyExpr = presets.currencies?.[currency?.trim()] ?? "";
+
+  if (scopeExpr && currencyExpr) {
+    return `(?=.*(${scopeExpr}))(?=.*(${currencyExpr}))`;
+  }
+  return scopeExpr || currencyExpr;
 }
 
 export function resolveBaseFilter(
@@ -127,6 +154,8 @@ function warnZeroMatches(checkDir, baseFilter, expandedTags) {
 function parseArgs(args) {
   const parsed = {
     input: "",
+    scope: "",
+    currency: "",
     smokeTests: false,
     checkDir: "",
   };
@@ -136,6 +165,12 @@ function parseArgs(args) {
     switch (arg) {
       case "--input":
         parsed.input = args[++i] ?? "";
+        break;
+      case "--scope":
+        parsed.scope = args[++i] ?? "";
+        break;
+      case "--currency":
+        parsed.currency = args[++i] ?? "";
         break;
       case "--smoke-tests":
         parsed.smokeTests = args[++i] === "true";
@@ -152,9 +187,23 @@ function parseArgs(args) {
   return parsed;
 }
 
-export function resolveTestFilter({ input = "", smokeTests = false, checkDir = "" } = {}) {
-  const { filter: baseFilter, expandedTags } = resolveBaseFilter(input);
-  warnZeroMatches(checkDir, baseFilter, expandedTags);
+export function resolveTestFilter({
+  input = "",
+  scope = "",
+  currency = "",
+  smokeTests = false,
+  checkDir = "",
+} = {}) {
+  // The advanced "Filter" field always wins: when it is set we ignore the Scope/Currency
+  // selectors and keep the legacy behaviour (alias expansion + zero-match warnings).
+  if (input) {
+    const { filter: baseFilter, expandedTags } = resolveBaseFilter(input);
+    warnZeroMatches(checkDir, baseFilter, expandedTags);
+    return applySmokeFilter(baseFilter, smokeTests);
+  }
+
+  const baseFilter = resolveScopeAndCurrency(scope, currency);
+  warnZeroMatches(checkDir, baseFilter, []);
   return applySmokeFilter(baseFilter, smokeTests);
 }
 

--- a/scripts/resolve-e2e-test-filter.test.mjs
+++ b/scripts/resolve-e2e-test-filter.test.mjs
@@ -7,10 +7,16 @@ import { test } from "node:test";
 import {
   applySmokeFilter,
   resolveBaseFilter,
+  resolveScopeAndCurrency,
   resolveTestFilter,
 } from "./resolve-e2e-test-filter.mjs";
 
 const ENABLED_FAMILIES = ["evm", "xrp", "stellar", "tezos"];
+
+const PRESETS = {
+  scopes: { Swap: "[Ss]wap", "Send & Receive": "[Ss]end|[Rr]eceive" },
+  currencies: { Bitcoin: "@family-bitcoin", "Ethereum & EVM chains": "@family-evm" },
+};
 
 test("expands generic coin framework aliases from enabled families", () => {
   assert.equal(
@@ -46,6 +52,33 @@ test("deduplicates expanded and explicit filters", () => {
 
 test("applies smoke filter after alias expansion", () => {
   assert.equal(applySmokeFilter("@family-evm|@family-xrp", true), "@smoke @family-evm|@family-xrp");
+});
+
+test("resolves a single scope selector to its preset expression", () => {
+  assert.equal(resolveScopeAndCurrency("Swap", "All currencies", PRESETS), "[Ss]wap");
+});
+
+test("resolves a single currency selector to its preset tag", () => {
+  assert.equal(resolveScopeAndCurrency("All tests", "Bitcoin", PRESETS), "@family-bitcoin");
+});
+
+test("ANDs scope and currency with lookaheads when both are selected", () => {
+  assert.equal(
+    resolveScopeAndCurrency("Send & Receive", "Ethereum & EVM chains", PRESETS),
+    "(?=.*([Ss]end|[Rr]eceive))(?=.*(@family-evm))",
+  );
+});
+
+test("returns an empty filter when neither selector narrows the run", () => {
+  assert.equal(resolveScopeAndCurrency("All tests", "All currencies", PRESETS), "");
+  assert.equal(resolveScopeAndCurrency("", "", PRESETS), "");
+});
+
+test("advanced filter input takes precedence over scope/currency selectors", () => {
+  assert.equal(
+    resolveTestFilter({ input: "@solana", scope: "Swap", currency: "Bitcoin" }),
+    "@solana",
+  );
 });
 
 test("emits warnings but preserves resolved filter when a tag has no matches", () => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` — _not required: CI workflows + a root tooling script only, no published package affected._
- [ ] **Covered by automatic tests.** _The filter-resolution logic (`resolve-e2e-test-filter.mjs`) is covered by unit tests (11/11). The GitHub Actions workflow wiring is validated with `actionlint` and by manual dispatch — it isn't unit-testable._
- [x] **Impact of the changes:**
  - Manually trigger **both** workflows and confirm the new **Scope** and **Currency** dropdowns render and the form is usable
  - Pick a **Currency** (e.g. Bitcoin) → only that family's tests run
  - Pick **Scope + Currency** together (e.g. Swap + Bitcoin) → only the intersection runs (verified: hits the ETH→BTC swap test, excludes non-Bitcoin swaps and non-swap Bitcoin tests)
  - Fill the **advanced filter** box → it overrides the dropdowns (legacy behavior preserved)
  - **Smoke** toggle still works
  - **Mobile only:** a manual run whose selection matches **0 specs** now **fails loudly** (zero-match guard) instead of going green with nothing run

### 📝 Description

The manual-run forms for the Desktop and Mobile E2E workflows exposed a single free-text `test_filter` box whose description mixed test names, file paths and tags with a misleading `,` vs `|` syntax. Non-technical users and newcomers had no way to know which tags existed or how to target a currency (you had to know to type `@family-evm`), and a typo silently matched 0 tests and reported green.

This PR adds **friendly point-and-click selectors** backed by a single shared source of truth:

- **`scripts/e2e-test-presets.json`** — maps friendly labels → filter expressions (Scope + Currency). One file feeds both workflows so their dropdowns can't drift.
- **`scripts/resolve-e2e-test-filter.mjs`** — new `--scope` / `--currency` flags. A single selector is used as-is; **Scope + Currency are AND-combined** via regex lookaheads (`(?=.*([Ss]wap))(?=.*(@family-bitcoin))`). The advanced `test_filter` box, when filled, fully overrides the selectors (legacy behavior preserved).
- **Both workflows** — `test_scope` + `currency` `choice` inputs, grouped/reworded inputs (advanced filter demoted to "power users", marketing device names, dropped the fake `,`/`|` wording), and the resolved selection echoed into the run summary.
- **Currency** covers **every** `@family-*` tag that actually exists in the specs (24 families), so nothing is missing.
- **Mobile zero-match guard** — a filtered manual run that matches nothing fails with a clear message instead of skipping silently (Desktop already failed at `TOTAL=0`).

Note on design: currency works on both engines because `@family-*` tags reach the Playwright title (desktop) and the spec `tags` (mobile). Feature scopes use case-tolerant patterns (`[Ss]wap`) to match desktop's Capitalized titles and mobile's lowercase paths. Team filtering was intentionally **not** added — `teamOwner`/`setTeamOwner` only emit an Allure owner label, which isn't part of the grep-able test title.

### ❓ Context

- **JIRA or GitHub link**: [QAA-1346](https://ledgerhq.atlassian.net/browse/QAA-1346)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1346]: https://ledgerhq.atlassian.net/browse/QAA-1346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ