### PR TITLE
[LWM] fix(lwm): gate robinhood disclaimer banner on positive balance (LIVE-32758)

### DIFF
--- a/.changeset/lwm-robinhood-banner-balance.md
+++ b/.changeset/lwm-robinhood-banner-balance.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Only show the Robinhood disclaimer banner on the Wallet 4.0 asset detail screen when the user holds a positive balance for the asset, matching the desktop behaviour and the LIVE-32756 spec (LIVE-32758).

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -393,11 +393,15 @@ describe("AssetDetail screen layout", () => {
     const ROBINHOOD_ONLY_LEDGER_IDS = [
       "robinhood_testnet/erc20/amd_0x71178bac73cbeb415514eb542a8995b82669778d",
     ];
+    // Enables the flag and funds the asset, so only the Robinhood-exclusivity gate is exercised.
     const enableDisclaimer = () => ({
-      overrideInitialState: withFlagOverrides({ llRobinhoodDisclaimer: { enabled: true } }),
+      overrideInitialState: withFlagOverrides(
+        { llRobinhoodDisclaimer: { enabled: true } },
+        withBtcAccounts(1).overrideInitialState,
+      ),
     });
 
-    it("shows the disclaimer banner when the flag is on and the asset is exclusive to a Robinhood chain", async () => {
+    it("shows the disclaimer banner when the flag is on, the balance is positive and the asset is exclusive to a Robinhood chain", async () => {
       mockedUseReceiveNetworkLedgerIds.mockReturnValue(ROBINHOOD_ONLY_LEDGER_IDS);
 
       render(<AssetDetailTestNavigator />, enableDisclaimer());
@@ -433,6 +437,16 @@ describe("AssetDetail screen layout", () => {
       mockedUseReceiveNetworkLedgerIds.mockReturnValue(ROBINHOOD_ONLY_LEDGER_IDS);
 
       render(<AssetDetailTestNavigator />);
+
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.stockDisclaimerBanner)).toBeNull();
+    });
+
+    it("hides the disclaimer banner when the asset has no balance", () => {
+      mockedUseReceiveNetworkLedgerIds.mockReturnValue(ROBINHOOD_ONLY_LEDGER_IDS);
+
+      render(<AssetDetailTestNavigator />, {
+        overrideInitialState: withFlagOverrides({ llRobinhoodDisclaimer: { enabled: true } }),
+      });
 
       expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.stockDisclaimerBanner)).toBeNull();
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -78,8 +78,11 @@ export function useAssetDetailViewModel() {
   const hideReceiveInBalanceGraph = !isCurrencySupported || secondaryButton === "receive";
   const showFallbackBanner = isCurrencySupported && !isBuyAvailable && !availableOnSwap;
   const robinhoodDisclaimer = useFeature("llRobinhoodDisclaimer");
+  const hasPositiveBalance = (distributionItem?.amount ?? 0) > 0;
   const showStockDisclaimerBanner =
-    !!robinhoodDisclaimer?.enabled && isRobinhoodExclusiveAsset(receiveLedgerIds);
+    !!robinhoodDisclaimer?.enabled &&
+    hasPositiveBalance &&
+    isRobinhoodExclusiveAsset(receiveLedgerIds);
 
   const coinOptions = useAssetCoinOptionsViewModel({ currency, currencyId, marketId });
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Integration tests: banner shown only with a positive balance; hidden at zero balance, when not Robinhood-exclusive, or when the flag is off.
- [ ] **Impact of the changes:**
  - Wallet 4.0 asset detail screen (mobile). QA: the Robinhood disclaimer banner now appears only when you **hold a positive balance** of a Robinhood-exclusive asset (with the flag on). Viewing such an asset without holding it no longer shows the banner.

### 📝 Description

Brings LWM in line with LWD (#18960) and the LIVE-32756 spec, which requires the banner only when *"I have a positive balance for this asset"*. The merged mobile banner (#18932) was missing that gate, so it showed regardless of balance.

Adds `hasPositiveBalance = (distributionItem?.amount ?? 0) > 0` to the banner condition.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32758](https://ledgerhq.atlassian.net/browse/LIVE-32758) (parity with [LIVE-32756](https://ledgerhq.atlassian.net/browse/LIVE-32756))


[LIVE-32758]: https://ledgerhq.atlassian.net/browse/LIVE-32758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-32756]: https://ledgerhq.atlassian.net/browse/LIVE-32756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ