### PR TITLE
[LWM] feat(mobile): gate dust filtering behind feature flag

### DIFF
--- a/.changeset/fresh-history-mobile.md
+++ b/.changeset/fresh-history-mobile.md
@@ -2,4 +2,4 @@
 "live-mobile": minor
 ---
 
-Add Mobile transaction history dust filtering controls.
+Add Mobile transaction history dust filtering controls behind a feature flag.

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { Account } from "@ledgerhq/types-live";
-import { render } from "@tests/test-renderer";
+import { render, withFlagOverrides } from "@tests/test-renderer";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { screen, track } from "~/analytics";
 import type { OperationsHistoryNavigatorParamsList } from "LLM/features/OperationsHistory/types";
@@ -66,12 +66,14 @@ const operationsListRoute = {
 
 const renderOperationsListWithNavigation = (
   navigation: Partial<OperationsListProps["navigation"]>,
+  options?: Parameters<typeof render>[1],
 ) =>
   render(
     <OperationsList
       route={operationsListRoute}
       navigation={navigation as OperationsListProps["navigation"]}
     />,
+    options,
   );
 
 describe("OperationsList", () => {
@@ -92,8 +94,27 @@ describe("OperationsList", () => {
     );
   });
 
-  it("registers the transaction history options menu in the navigation bar", () => {
+  it("does not register the transaction history options menu when the dust filter feature flag is disabled", () => {
     renderOperationsListWithNavigation({ setOptions: mockSetOptions });
+
+    expect(mockSetOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lumenNavBar: expect.objectContaining({
+          renderTrailing: undefined,
+        }),
+      }),
+    );
+  });
+
+  it("registers the transaction history options menu in the navigation bar when the dust filter feature flag is enabled", () => {
+    renderOperationsListWithNavigation(
+      { setOptions: mockSetOptions },
+      {
+        overrideInitialState: withFlagOverrides({
+          llmHideSmallValueTokenOperations: { enabled: true },
+        }),
+      },
+    );
 
     expect(mockSetOptions).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
@@ -1,5 +1,5 @@
 import { act } from "@testing-library/react-native";
-import { renderHook } from "@tests/test-renderer";
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
 import { usdcToken, maticEth } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
@@ -73,12 +73,45 @@ describe("useOperationsListViewModel", () => {
   });
 
   describe("dust filtering options", () => {
-    it("starts disabled and toggles the setting from the options sheet", () => {
-      const { result, store } = renderHook(() => useOperationsListViewModel());
+    it("hides and disables the dust filter option when the feature flag is disabled", () => {
+      const { result, store } = renderHook(() => useOperationsListViewModel(), {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          settings: {
+            ...state.settings,
+            hideSmallValueTokenOperations: true,
+          },
+        }),
+      });
 
       expect(result.current.hideSmallValueTokenOperations).toBe(false);
+      expect(result.current.isDustFilterFeatureEnabled).toBe(false);
+      expect(result.current.dustFilterOption).toBeUndefined();
+
+      act(() => {
+        result.current.openOptionsSheet();
+      });
+
       expect(result.current.isOptionsSheetOpen).toBe(false);
-      expect(result.current.dustFilterOption.title).toBe("Hide dust transactions");
+
+      act(() => {
+        result.current.onToggleHideSmallValueTokenOperations();
+      });
+
+      expect(store.getState().settings.hideSmallValueTokenOperations).toBe(true);
+    });
+
+    it("starts disabled and toggles the setting from the options sheet when the feature flag is enabled", () => {
+      const { result, store } = renderHook(() => useOperationsListViewModel(), {
+        overrideInitialState: withFlagOverrides({
+          llmHideSmallValueTokenOperations: { enabled: true },
+        }),
+      });
+
+      expect(result.current.isDustFilterFeatureEnabled).toBe(true);
+      expect(result.current.hideSmallValueTokenOperations).toBe(false);
+      expect(result.current.isOptionsSheetOpen).toBe(false);
+      expect(result.current.dustFilterOption?.title).toBe("Hide dust transactions");
 
       act(() => {
         result.current.openOptionsSheet();
@@ -92,7 +125,7 @@ describe("useOperationsListViewModel", () => {
 
       expect(store.getState().settings.hideSmallValueTokenOperations).toBe(true);
       expect(result.current.isOptionsSheetOpen).toBe(false);
-      expect(result.current.dustFilterOption.title).toBe("Show dust transactions");
+      expect(result.current.dustFilterOption?.title).toBe("Show dust transactions");
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsHistoryOptionsSheet.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsHistoryOptionsSheet.tsx
@@ -15,7 +15,7 @@ import type { OperationsHistoryDustFilterOption } from "../useOperationsListView
 
 type Props = Readonly<{
   isOpen: boolean;
-  dustFilterOption: OperationsHistoryDustFilterOption;
+  dustFilterOption: OperationsHistoryDustFilterOption | undefined;
   onClose: () => void;
   onToggle: () => void;
 }>;
@@ -27,6 +27,8 @@ export function OperationsHistoryOptionsSheet({
   onToggle,
 }: Props) {
   const { bottom } = useSafeAreaInsets();
+  if (!dustFilterOption) return null;
+
   const { Icon, title, description } = dustFilterOption;
 
   return (

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
@@ -43,6 +43,7 @@ export default function OperationsList({ route, navigation }: Props) {
     isOptionsSheetOpen,
     openOptionsSheet,
     closeOptionsSheet,
+    isDustFilterFeatureEnabled,
     dustFilterOption,
     onToggleHideSmallValueTokenOperations,
   } = useOperationsListViewModel(accountIds);
@@ -57,15 +58,17 @@ export default function OperationsList({ route, navigation }: Props) {
   useLayoutEffect(() => {
     const opts: Partial<LumenNativeStackNavigationOptions> = {
       lumenNavBar: {
-        renderTrailing,
-        navBarTrailingProps: {
-          style: { marginRight: 16 },
-        },
+        renderTrailing: isDustFilterFeatureEnabled ? renderTrailing : undefined,
+        navBarTrailingProps: isDustFilterFeatureEnabled
+          ? {
+              style: { marginRight: 16 },
+            }
+          : undefined,
       },
     };
 
     navigation.setOptions(opts);
-  }, [navigation, renderTrailing]);
+  }, [isDustFilterFeatureEnabled, navigation, renderTrailing]);
 
   const listContentStyle = useMemo(
     () => ({
@@ -138,12 +141,14 @@ export default function OperationsList({ route, navigation }: Props) {
         ListEmptyComponent={ListEmptyComponent}
       />
       {!isEmpty && <BottomFadeGradient />}
-      <OperationsHistoryOptionsSheet
-        isOpen={isOptionsSheetOpen}
-        dustFilterOption={dustFilterOption}
-        onClose={closeOptionsSheet}
-        onToggle={onToggleHideSmallValueTokenOperations}
-      />
+      {isDustFilterFeatureEnabled ? (
+        <OperationsHistoryOptionsSheet
+          isOpen={isOptionsSheetOpen}
+          dustFilterOption={dustFilterOption}
+          onClose={closeOptionsSheet}
+          onToggle={onToggleHideSmallValueTokenOperations}
+        />
+      ) : null}
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
@@ -12,6 +12,7 @@ import { flattenAccountsSelector, shallowAccountsSelector } from "~/reducers/acc
 import { lastSeenOperationDateSelector, markOperationsAsSeen } from "~/reducers/history";
 import {
   counterValueCurrencySelector,
+  hideSmallValueTokenOperationsFeatureEnabledSelector,
   hideSmallValueTokenOperationsEnabledSelector,
 } from "~/reducers/settings";
 import { parseLastSeenMs } from "LLM/features/OperationsHistory/utils/unreadOperations";
@@ -37,8 +38,15 @@ export function useOperationsListViewModel(accountIds?: string[]) {
   const allFlattenedAccounts = useSelector(flattenAccountsSelector);
   const [opCount, setOpCount] = useState(INITIAL_OP_COUNT);
   const [isOptionsSheetOpen, setOptionsSheetOpen] = useState(false);
-  const hideSmallValueTokenOperations = useSelector(hideSmallValueTokenOperationsEnabledSelector);
-  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const isDustFilterFeatureEnabled = useSelector(
+    hideSmallValueTokenOperationsFeatureEnabledSelector,
+  );
+  const userHideSmallValueTokenOperations = useSelector(
+    hideSmallValueTokenOperationsEnabledSelector,
+  );
+  const counterValueCurrency = useSelector(state =>
+    isDustFilterFeatureEnabled ? counterValueCurrencySelector(state) : undefined,
+  );
   const { locale } = useLocale();
   const { t } = useTranslation();
 
@@ -100,6 +108,8 @@ export function useOperationsListViewModel(accountIds?: string[]) {
 
   const hasPendingOperations = useMemo(() => sections.some(s => s.isPending), [sections]);
   const dustFilterThreshold = useMemo(() => {
+    if (!counterValueCurrency) return undefined;
+
     const thresholdMinorUnit =
       floorThresholdToCurrencyMinorUnit(HISTORY_DUST_FILTER_THRESHOLD_USD, counterValueCurrency) ??
       new BigNumber(0);
@@ -109,9 +119,11 @@ export function useOperationsListViewModel(accountIds?: string[]) {
       locale,
     });
   }, [counterValueCurrency, locale]);
-  const dustFilterOption: OperationsHistoryDustFilterOption = useMemo(() => {
-    const Icon = hideSmallValueTokenOperations ? Eye : EyeCross;
-    const title = hideSmallValueTokenOperations
+  const dustFilterOption: OperationsHistoryDustFilterOption | undefined = useMemo(() => {
+    if (!isDustFilterFeatureEnabled || !dustFilterThreshold) return undefined;
+
+    const Icon = userHideSmallValueTokenOperations ? Eye : EyeCross;
+    const title = userHideSmallValueTokenOperations
       ? t("operationsList.options.showDustTransactions")
       : t("operationsList.options.hideDustTransactions");
 
@@ -122,14 +134,20 @@ export function useOperationsListViewModel(accountIds?: string[]) {
         threshold: dustFilterThreshold,
       }),
     };
-  }, [dustFilterThreshold, hideSmallValueTokenOperations, t]);
+  }, [dustFilterThreshold, isDustFilterFeatureEnabled, userHideSmallValueTokenOperations, t]);
 
-  const openOptionsSheet = useCallback(() => setOptionsSheetOpen(true), []);
+  const openOptionsSheet = useCallback(() => {
+    if (isDustFilterFeatureEnabled) {
+      setOptionsSheetOpen(true);
+    }
+  }, [isDustFilterFeatureEnabled]);
   const closeOptionsSheet = useCallback(() => setOptionsSheetOpen(false), []);
   const onToggleHideSmallValueTokenOperations = useCallback(() => {
-    dispatch(setHideSmallValueTokenOperations(!hideSmallValueTokenOperations));
+    if (!isDustFilterFeatureEnabled) return;
+
+    dispatch(setHideSmallValueTokenOperations(!userHideSmallValueTokenOperations));
     closeOptionsSheet();
-  }, [dispatch, hideSmallValueTokenOperations, closeOptionsSheet]);
+  }, [dispatch, isDustFilterFeatureEnabled, userHideSmallValueTokenOperations, closeOptionsSheet]);
 
   return {
     accounts,
@@ -144,7 +162,8 @@ export function useOperationsListViewModel(accountIds?: string[]) {
     isOptionsSheetOpen,
     openOptionsSheet,
     closeOptionsSheet,
-    hideSmallValueTokenOperations,
+    hideSmallValueTokenOperations: isDustFilterFeatureEnabled && userHideSmallValueTokenOperations,
+    isDustFilterFeatureEnabled,
     dustFilterOption,
     onToggleHideSmallValueTokenOperations,
   };

--- a/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
@@ -1,7 +1,9 @@
 import { FEATURE_FLAGS_INITIAL_STATE } from "@shared/feature-flags";
-import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import BigNumber from "bignumber.js";
+import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
-import type { Account, AccountLike } from "@ledgerhq/types-live";
+import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import type { Account, AccountLike, Operation, TokenAccount } from "@ledgerhq/types-live";
 import historyReducer, {
   type HistoryState,
   markOperationsAsSeen,
@@ -43,6 +45,62 @@ function makeState(lastSeenDate: string | null, accounts: Account[]): State {
     },
     featureFlags: FEATURE_FLAGS_INITIAL_STATE,
   } as unknown as State;
+}
+
+function createAccountWithUnreadZeroValueTokenOperation(): Account {
+  const parentAccount = genAccount("history-test-dust", {
+    currency: ethereum,
+    operationsSize: 0,
+    subAccountsCount: 0,
+  });
+  const tokenAccount = genTokenAccount(0, parentAccount, usdcToken);
+  const operation: Operation = {
+    id: "history-test-dust-zero-value-token-op",
+    hash: "0xdust",
+    type: "IN",
+    value: new BigNumber(0),
+    fee: new BigNumber(0),
+    senders: ["0xsender"],
+    recipients: ["0xrecipient"],
+    blockHash: "0xblock",
+    blockHeight: 1,
+    accountId: tokenAccount.id,
+    date: new Date("2024-12-01T00:00:00.000Z"),
+    extra: {},
+  };
+  const tokenAccountWithOperation: TokenAccount = {
+    ...tokenAccount,
+    operations: [operation],
+    operationsCount: 1,
+  };
+
+  return {
+    ...parentAccount,
+    subAccounts: [tokenAccountWithOperation],
+  };
+}
+
+function withDustPreferenceEnabled(state: State): State {
+  return {
+    ...state,
+    settings: {
+      ...state.settings,
+      hideSmallValueTokenOperations: true,
+    },
+  };
+}
+
+function withDustFeatureEnabled(state: State): State {
+  return {
+    ...state,
+    featureFlags: {
+      ...state.featureFlags,
+      resolved: {
+        ...state.featureFlags.resolved,
+        llmHideSmallValueTokenOperations: { enabled: true },
+      },
+    },
+  };
 }
 
 describe("historyReducer", () => {
@@ -119,5 +177,27 @@ describe("hasUnreadOperationsSelector", () => {
       operations: [{ ...rootOp, nftOperations: [nftOp] }, ...rest],
     };
     expect(hasUnreadOperationsSelector(makeState(SEEN, [accountWithNft]))).toBe(true);
+  });
+
+  it("ignores the dust preference when the dust filter feature flag is disabled", () => {
+    const accountWithDustOperation = createAccountWithUnreadZeroValueTokenOperation();
+
+    expect(
+      hasUnreadOperationsSelector(
+        withDustPreferenceEnabled(makeState(SEEN, [accountWithDustOperation])),
+      ),
+    ).toBe(true);
+  });
+
+  it("filters dust operations when the dust preference and feature flag are enabled", () => {
+    const accountWithDustOperation = createAccountWithUnreadZeroValueTokenOperation();
+
+    expect(
+      hasUnreadOperationsSelector(
+        withDustFeatureEnabled(
+          withDustPreferenceEnabled(makeState(SEEN, [accountWithDustOperation])),
+        ),
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/ledger-live-mobile/src/reducers/history.ts
+++ b/apps/ledger-live-mobile/src/reducers/history.ts
@@ -9,7 +9,7 @@ import { accountsSelector } from "./accounts";
 import {
   counterValueCurrencySelector,
   filterTokenOperationsZeroAmountEnabledSelector,
-  hideSmallValueTokenOperationsEnabledSelector,
+  hideSmallValueTokenOperationsEffectiveSelector,
 } from "./settings";
 import { countervaluesStateSelector } from "./countervalues";
 
@@ -43,12 +43,12 @@ export const lastSeenOperationDateSelector = (state: Pick<State, "history">): st
   state.history.lastSeenOperationDate;
 
 const dustFilterCountervaluesStateSelector = (state: State) =>
-  hideSmallValueTokenOperationsEnabledSelector(state)
+  hideSmallValueTokenOperationsEffectiveSelector(state)
     ? countervaluesStateSelector(state)
     : undefined;
 
 const dustFilterCounterValueCurrencySelector = (state: State) =>
-  hideSmallValueTokenOperationsEnabledSelector(state)
+  hideSmallValueTokenOperationsEffectiveSelector(state)
     ? counterValueCurrencySelector(state)
     : undefined;
 
@@ -61,7 +61,7 @@ export const hasUnreadOperationsSelector = createSelector(
   accountsSelector,
   lastSeenOperationDateSelector,
   filterTokenOperationsZeroAmountEnabledSelector,
-  hideSmallValueTokenOperationsEnabledSelector,
+  hideSmallValueTokenOperationsEffectiveSelector,
   dustFilterCountervaluesStateSelector,
   dustFilterCounterValueCurrencySelector,
   (state: State) => selectFeature(state, "addressPoisoningOperationsFilter"),

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -867,6 +867,11 @@ export const filterTokenOperationsZeroAmountEnabledSelector = (state: State) =>
   state.settings.filterTokenOperationsZeroAmount;
 export const hideSmallValueTokenOperationsEnabledSelector = (state: State) =>
   state.settings.hideSmallValueTokenOperations;
+export const hideSmallValueTokenOperationsFeatureEnabledSelector = (state: State) =>
+  selectFeature(state, "llmHideSmallValueTokenOperations")?.enabled === true;
+export const hideSmallValueTokenOperationsEffectiveSelector = (state: State) =>
+  hideSmallValueTokenOperationsFeatureEnabledSelector(state) &&
+  hideSmallValueTokenOperationsEnabledSelector(state);
 export const dismissedBannersSelector = (state: State) => state.settings.dismissedBanners;
 export const hasAvailableUpdateSelector = (state: State) => state.settings.hasAvailableUpdate;
 export const dismissedDynamicCardsSelector = (state: State) => state.settings.dismissedDynamicCards;

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
@@ -3,7 +3,7 @@ import type { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { renderHook } from "@tests/test-renderer";
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { useOperationsV1 } from "../useOperationsV1";
 import { State } from "~/reducers/types";
 
@@ -107,7 +107,7 @@ const initialStateWithFilterEnabledButNoEvmFamily = (state: State): State => ({
   },
 });
 
-const initialStateWithDustFilterEnabled = (state: State): State => ({
+const initialStateWithDustPreferenceEnabled = (state: State): State => ({
   ...state,
   settings: {
     ...state.settings,
@@ -115,6 +115,13 @@ const initialStateWithDustFilterEnabled = (state: State): State => ({
     hideSmallValueTokenOperations: true,
   },
 });
+
+const initialStateWithDustFilterEnabled = withFlagOverrides(
+  {
+    llmHideSmallValueTokenOperations: { enabled: true },
+  },
+  initialStateWithDustPreferenceEnabled,
+);
 
 describe("useOperationsV1 integration", () => {
   beforeEach(() => {
@@ -142,7 +149,17 @@ describe("useOperationsV1 integration", () => {
     expect(result.current.sections[0].data.length).toBe(2);
   });
 
-  it("should filter out zero-value token operations when dust filtering is enabled", () => {
+  it("should not filter zero-value token operations when dust preference is enabled but the feature flag is disabled", () => {
+    const accountWithZeroValueTokenOp = createAccountWithZeroValueTokenOperation();
+
+    const { result } = renderHook(() => useOperationsV1([accountWithZeroValueTokenOp], 50), {
+      overrideInitialState: initialStateWithDustPreferenceEnabled,
+    });
+
+    expect(result.current.sections[0].data).toHaveLength(2);
+  });
+
+  it("should filter out zero-value token operations when dust preference and feature flag are enabled", () => {
     const accountWithZeroValueTokenOp = createAccountWithZeroValueTokenOperation();
 
     const { result } = renderHook(() => useOperationsV1([accountWithZeroValueTokenOp], 50), {

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/useOperationsV1.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/useOperationsV1.ts
@@ -7,7 +7,7 @@ import { useSelector } from "~/context/hooks";
 import {
   counterValueCurrencySelector,
   filterTokenOperationsZeroAmountEnabledSelector,
-  hideSmallValueTokenOperationsEnabledSelector,
+  hideSmallValueTokenOperationsEffectiveSelector,
 } from "~/reducers/settings";
 import { countervaluesStateSelector } from "~/reducers/countervalues";
 import { useAddressPoisoningOperationsFamilies } from "@ledgerhq/live-common/hooks/useAddressPoisoningOperationsFamilies";
@@ -26,7 +26,7 @@ export function useOperationsV1(
     filterTokenOperationsZeroAmountEnabledSelector,
   );
   const shouldHideSmallValueTokenOperations = useSelector(
-    hideSmallValueTokenOperationsEnabledSelector,
+    hideSmallValueTokenOperationsEffectiveSelector,
   );
   const countervaluesState = useSelector(state =>
     shouldHideSmallValueTokenOperations ? countervaluesStateSelector(state) : undefined,

--- a/shared/feature-flags/src/flags/team-coin-integration/index.ts
+++ b/shared/feature-flags/src/flags/team-coin-integration/index.ts
@@ -105,6 +105,7 @@ export * from "./lldHideSmallValueTokenOperations";
 export * from "./lldMemoTag";
 export * from "./lldTezosStaking";
 export * from "./lldWebviewManifestDomainCheck";
+export * from "./llmHideSmallValueTokenOperations";
 export * from "./lwdDeeplinkOpenHardening";
 export * from "./lwmDeeplinkOpenHardening";
 export * from "./llmMemoTag";

--- a/shared/feature-flags/src/flags/team-coin-integration/llmHideSmallValueTokenOperations.ts
+++ b/shared/feature-flags/src/flags/team-coin-integration/llmHideSmallValueTokenOperations.ts
@@ -1,0 +1,4 @@
+import { flag } from "../../define";
+
+/** Enables dust filtering for incoming token operations on LLM. */
+export const llmHideSmallValueTokenOperations = flag();


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Mobile transaction history options menu with the dust filter feature flag disabled and enabled
      - `useOperationsV1` dust filtering with the feature flag and user setting combinations
      - Unread operations indicator behavior for dust operations

### 📝 Description

This stacked PR adds a dedicated `llmHideSmallValueTokenOperations` feature flag for the mobile dust filtering work introduced by LIVE-29299.

The flag defaults disabled. When it is off, the mobile history options menu does not expose the dust filter, toggle actions no-op, operation filtering ignores the saved dust preference, and unread history avoids selecting countervalues. When it is on, the existing user setting controls filtering as intended.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29299](https://ledgerhq.atlassian.net/browse/LIVE-29299), [mobile base PR #18952](https://github.com/LedgerHQ/ledger-live/pull/18952)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29299]: https://ledgerhq.atlassian.net/browse/LIVE-29299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ