### PR TITLE
[LWM] feat(mobile): gate dust filtering behind feature flag

### DIFF
--- a/.changeset/fresh-history-mobile.md
+++ b/.changeset/fresh-history-mobile.md
@@ -2,4 +2,4 @@
 "live-mobile": minor
 ---
 
-Add Mobile transaction history dust filtering controls.
+Add Mobile transaction history dust filtering controls behind a feature flag.

--- a/.changeset/fresh-history-mobile.md
+++ b/.changeset/fresh-history-mobile.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add Mobile transaction history dust filtering controls.

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -38,6 +38,7 @@ import {
   SettingsSetDismissedDynamicCardsPayload,
   SettingsSetDebugAppLevelDrawerOpenedPayload,
   SettingsFilterTokenOperationsZeroAmountPayload,
+  SettingsHideSmallValueTokenOperationsPayload,
   SettingsLastSeenDeviceLanguagePayload,
   SettingsCompleteOnboardingPayload,
   SettingsSetDateFormatPayload,
@@ -143,6 +144,10 @@ export const setHideEmptyTokenAccounts = createAction<SettingsHideEmptyTokenAcco
 export const setFilterTokenOperationsZeroAmount =
   createAction<SettingsFilterTokenOperationsZeroAmountPayload>(
     SettingsActionTypes.SETTINGS_FILTER_TOKEN_OPERATIONS_ZERO_AMOUNT,
+  );
+export const setHideSmallValueTokenOperations =
+  createAction<SettingsHideSmallValueTokenOperationsPayload>(
+    SettingsActionTypes.SETTINGS_HIDE_SMALL_VALUE_TOKEN_OPERATIONS,
   );
 export const blacklistToken = createAction<SettingsBlacklistTokenPayload>(
   SettingsActionTypes.BLACKLIST_TOKEN,

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -274,6 +274,7 @@ export enum SettingsActionTypes {
   SETTINGS_SWITCH_COUNTERVALUE_FIRST = "SETTINGS_SWITCH_COUNTERVALUE_FIRST",
   SETTINGS_HIDE_EMPTY_TOKEN_ACCOUNTS = "SETTINGS_HIDE_EMPTY_TOKEN_ACCOUNTS",
   SETTINGS_FILTER_TOKEN_OPERATIONS_ZERO_AMOUNT = "SETTINGS_FILTER_TOKEN_OPERATIONS_ZERO_AMOUNT",
+  SETTINGS_HIDE_SMALL_VALUE_TOKEN_OPERATIONS = "SETTINGS_HIDE_SMALL_VALUE_TOKEN_OPERATIONS",
   SHOW_TOKEN = "SHOW_TOKEN",
   BLACKLIST_TOKEN = "BLACKLIST_TOKEN",
   SETTINGS_DISMISS_BANNER = "SETTINGS_DISMISS_BANNER",
@@ -344,6 +345,8 @@ export type SettingsSetReadOnlyModePayload = SettingsState["readOnlyModeEnabled"
 export type SettingsHideEmptyTokenAccountsPayload = SettingsState["hideEmptyTokenAccounts"];
 export type SettingsFilterTokenOperationsZeroAmountPayload =
   SettingsState["filterTokenOperationsZeroAmount"];
+export type SettingsHideSmallValueTokenOperationsPayload =
+  SettingsState["hideSmallValueTokenOperations"];
 export type SettingsShowTokenPayload = string;
 export type SettingsBlacklistTokenPayload = string;
 export type SettingsDismissBannerPayload = string;
@@ -432,6 +435,8 @@ export type SettingsPayload =
   | SettingsSetHasInstalledAnyAppPayload
   | SettingsSetReadOnlyModePayload
   | SettingsHideEmptyTokenAccountsPayload
+  | SettingsFilterTokenOperationsZeroAmountPayload
+  | SettingsHideSmallValueTokenOperationsPayload
   | SettingsShowTokenPayload
   | SettingsBlacklistTokenPayload
   | SettingsDismissBannerPayload

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3041,7 +3041,13 @@
   "operationsList": {
     "to": "To",
     "from": "From",
-    "pending": "Pending"
+    "pending": "Pending",
+    "options": {
+      "more": "Transaction history options",
+      "hideDustTransactions": "Hide dust transactions",
+      "showDustTransactions": "Show dust transactions",
+      "dustTransactionsDescription": "Transactions below {{threshold}} in your main currency will be hidden."
+    }
   },
   "operationDetails": {
     "title": "Transaction details",

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/constants.ts
@@ -1,0 +1,1 @@
+export const HISTORY_DUST_FILTER_THRESHOLD_USD = 0.01;

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
@@ -45,7 +45,7 @@ const mockNavigate = jest.fn();
 const mockSetOptions = jest.fn();
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
-  useNavigation: () => ({ navigate: mockNavigate, setOptions: mockSetOptions }),
+  useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
 const Stack = createNativeStackNavigator<OperationsHistoryNavigatorParamsList>();
@@ -55,6 +55,24 @@ const MockNavigator = () => (
     <Stack.Screen name={ScreenName.OperationsList} component={OperationsList} />
   </Stack.Navigator>
 );
+
+type OperationsListProps = React.ComponentProps<typeof OperationsList>;
+
+const operationsListRoute = {
+  key: ScreenName.OperationsList,
+  name: ScreenName.OperationsList,
+  params: undefined,
+} as OperationsListProps["route"];
+
+const renderOperationsListWithNavigation = (
+  navigation: Partial<OperationsListProps["navigation"]>,
+) =>
+  render(
+    <OperationsList
+      route={operationsListRoute}
+      navigation={navigation as OperationsListProps["navigation"]}
+    />,
+  );
 
 describe("OperationsList", () => {
   beforeEach(() => {
@@ -75,7 +93,7 @@ describe("OperationsList", () => {
   });
 
   it("registers the transaction history options menu in the navigation bar", () => {
-    render(<MockNavigator />);
+    renderOperationsListWithNavigation({ setOptions: mockSetOptions });
 
     expect(mockSetOptions).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
@@ -42,9 +42,10 @@ function stateWithAccountsAndOperations(base: State): State {
 const operation = accountWithOperations.operations[1];
 
 const mockNavigate = jest.fn();
+const mockSetOptions = jest.fn();
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
-  useNavigation: () => ({ navigate: mockNavigate }),
+  useNavigation: () => ({ navigate: mockNavigate, setOptions: mockSetOptions }),
 }));
 
 const Stack = createNativeStackNavigator<OperationsHistoryNavigatorParamsList>();
@@ -56,6 +57,10 @@ const MockNavigator = () => (
 );
 
 describe("OperationsList", () => {
+  beforeEach(() => {
+    mockSetOptions.mockClear();
+  });
+
   it("tracks the OperationsList screen on focus", () => {
     render(<MockNavigator />);
     expect(screen).toHaveBeenCalledWith(
@@ -66,6 +71,18 @@ describe("OperationsList", () => {
       true,
       false,
       false,
+    );
+  });
+
+  it("registers the transaction history options menu in the navigation bar", () => {
+    render(<MockNavigator />);
+
+    expect(mockSetOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lumenNavBar: expect.objectContaining({
+          renderTrailing: expect.any(Function),
+        }),
+      }),
     );
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { Account } from "@ledgerhq/types-live";
-import { render } from "@tests/test-renderer";
+import { render, withFlagOverrides } from "@tests/test-renderer";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { screen, track } from "~/analytics";
 import type { OperationsHistoryNavigatorParamsList } from "LLM/features/OperationsHistory/types";
@@ -66,12 +66,14 @@ const operationsListRoute = {
 
 const renderOperationsListWithNavigation = (
   navigation: Partial<OperationsListProps["navigation"]>,
+  options?: Parameters<typeof render>[1],
 ) =>
   render(
     <OperationsList
       route={operationsListRoute}
       navigation={navigation as OperationsListProps["navigation"]}
     />,
+    options,
   );
 
 describe("OperationsList", () => {
@@ -92,8 +94,27 @@ describe("OperationsList", () => {
     );
   });
 
-  it("registers the transaction history options menu in the navigation bar", () => {
+  it("does not register the transaction history options menu when the dust filter feature flag is disabled", () => {
     renderOperationsListWithNavigation({ setOptions: mockSetOptions });
+
+    expect(mockSetOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lumenNavBar: expect.objectContaining({
+          renderTrailing: undefined,
+        }),
+      }),
+    );
+  });
+
+  it("registers the transaction history options menu in the navigation bar when the dust filter feature flag is enabled", () => {
+    renderOperationsListWithNavigation(
+      { setOptions: mockSetOptions },
+      {
+        overrideInitialState: withFlagOverrides({
+          llmHideSmallValueTokenOperations: { enabled: true },
+        }),
+      },
+    );
 
     expect(mockSetOptions).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
@@ -111,7 +111,10 @@ describe("OperationsList", () => {
       { setOptions: mockSetOptions },
       {
         overrideInitialState: withFlagOverrides({
-          llmHideSmallValueTokenOperations: { enabled: true },
+          llHideSmallValueTokenOperations: {
+            enabled: true,
+            params: { mobile: true, desktop: false },
+          },
         }),
       },
     );

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
@@ -111,9 +111,8 @@ describe("OperationsList", () => {
       { setOptions: mockSetOptions },
       {
         overrideInitialState: withFlagOverrides({
-          lwHideSmallValueTokenOperations: {
+          lwmDustFiltering: {
             enabled: true,
-            params: { enabledMobile: true, enabledDesktop: false },
           },
         }),
       },

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
@@ -111,7 +111,7 @@ describe("OperationsList", () => {
       { setOptions: mockSetOptions },
       {
         overrideInitialState: withFlagOverrides({
-          llHideSmallValueTokenOperations: {
+          lwHideSmallValueTokenOperations: {
             enabled: true,
             params: { enabledMobile: true, enabledDesktop: false },
           },

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
@@ -113,7 +113,7 @@ describe("OperationsList", () => {
         overrideInitialState: withFlagOverrides({
           llHideSmallValueTokenOperations: {
             enabled: true,
-            params: { mobile: true, desktop: false },
+            params: { enabledMobile: true, enabledDesktop: false },
           },
         }),
       },

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
@@ -104,7 +104,10 @@ describe("useOperationsListViewModel", () => {
     it("starts disabled and toggles the setting from the options sheet when the feature flag is enabled", () => {
       const { result, store } = renderHook(() => useOperationsListViewModel(), {
         overrideInitialState: withFlagOverrides({
-          llmHideSmallValueTokenOperations: { enabled: true },
+          llHideSmallValueTokenOperations: {
+            enabled: true,
+            params: { mobile: true, desktop: false },
+          },
         }),
       });
 
@@ -126,6 +129,21 @@ describe("useOperationsListViewModel", () => {
       expect(store.getState().settings.hideSmallValueTokenOperations).toBe(true);
       expect(result.current.isOptionsSheetOpen).toBe(false);
       expect(result.current.dustFilterOption?.title).toBe("Show dust transactions");
+    });
+
+    it("hides and disables the dust filter option when only the desktop flag param is enabled", () => {
+      const { result } = renderHook(() => useOperationsListViewModel(), {
+        overrideInitialState: withFlagOverrides({
+          llHideSmallValueTokenOperations: {
+            enabled: true,
+            params: { mobile: false, desktop: true },
+          },
+        }),
+      });
+
+      expect(result.current.hideSmallValueTokenOperations).toBe(false);
+      expect(result.current.isDustFilterFeatureEnabled).toBe(false);
+      expect(result.current.dustFilterOption).toBeUndefined();
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
@@ -104,9 +104,8 @@ describe("useOperationsListViewModel", () => {
     it("starts disabled and toggles the setting from the options sheet when the feature flag is enabled", () => {
       const { result, store } = renderHook(() => useOperationsListViewModel(), {
         overrideInitialState: withFlagOverrides({
-          lwHideSmallValueTokenOperations: {
+          lwmDustFiltering: {
             enabled: true,
-            params: { enabledMobile: true, enabledDesktop: false },
           },
         }),
       });
@@ -134,9 +133,8 @@ describe("useOperationsListViewModel", () => {
     it("hides and disables the dust filter option when only the desktop flag param is enabled", () => {
       const { result } = renderHook(() => useOperationsListViewModel(), {
         overrideInitialState: withFlagOverrides({
-          lwHideSmallValueTokenOperations: {
+          lwdDustFiltering: {
             enabled: true,
-            params: { enabledMobile: false, enabledDesktop: true },
           },
         }),
       });

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
@@ -104,7 +104,7 @@ describe("useOperationsListViewModel", () => {
     it("starts disabled and toggles the setting from the options sheet when the feature flag is enabled", () => {
       const { result, store } = renderHook(() => useOperationsListViewModel(), {
         overrideInitialState: withFlagOverrides({
-          llHideSmallValueTokenOperations: {
+          lwHideSmallValueTokenOperations: {
             enabled: true,
             params: { enabledMobile: true, enabledDesktop: false },
           },
@@ -134,7 +134,7 @@ describe("useOperationsListViewModel", () => {
     it("hides and disables the dust filter option when only the desktop flag param is enabled", () => {
       const { result } = renderHook(() => useOperationsListViewModel(), {
         overrideInitialState: withFlagOverrides({
-          llHideSmallValueTokenOperations: {
+          lwHideSmallValueTokenOperations: {
             enabled: true,
             params: { enabledMobile: false, enabledDesktop: true },
           },

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
@@ -1,5 +1,5 @@
 import { act } from "@testing-library/react-native";
-import { renderHook } from "@tests/test-renderer";
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
 import { usdcToken, maticEth } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
@@ -73,12 +73,45 @@ describe("useOperationsListViewModel", () => {
   });
 
   describe("dust filtering options", () => {
-    it("starts disabled and toggles the setting from the options sheet", () => {
-      const { result, store } = renderHook(() => useOperationsListViewModel());
+    it("hides and disables the dust filter option when the feature flag is disabled", () => {
+      const { result, store } = renderHook(() => useOperationsListViewModel(), {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          settings: {
+            ...state.settings,
+            hideSmallValueTokenOperations: true,
+          },
+        }),
+      });
 
       expect(result.current.hideSmallValueTokenOperations).toBe(false);
+      expect(result.current.isDustFilterFeatureEnabled).toBe(false);
+      expect(result.current.dustFilterOption).toBeUndefined();
+
+      act(() => {
+        result.current.openOptionsSheet();
+      });
+
       expect(result.current.isOptionsSheetOpen).toBe(false);
-      expect(result.current.dustFilterOption.title).toBe("Hide dust transactions");
+
+      act(() => {
+        result.current.onToggleHideSmallValueTokenOperations();
+      });
+
+      expect(store.getState().settings.hideSmallValueTokenOperations).toBe(true);
+    });
+
+    it("starts disabled and toggles the setting from the options sheet when the feature flag is enabled", () => {
+      const { result, store } = renderHook(() => useOperationsListViewModel(), {
+        overrideInitialState: withFlagOverrides({
+          llmHideSmallValueTokenOperations: { enabled: true },
+        }),
+      });
+
+      expect(result.current.isDustFilterFeatureEnabled).toBe(true);
+      expect(result.current.hideSmallValueTokenOperations).toBe(false);
+      expect(result.current.isOptionsSheetOpen).toBe(false);
+      expect(result.current.dustFilterOption?.title).toBe("Hide dust transactions");
 
       act(() => {
         result.current.openOptionsSheet();
@@ -92,7 +125,7 @@ describe("useOperationsListViewModel", () => {
 
       expect(store.getState().settings.hideSmallValueTokenOperations).toBe(true);
       expect(result.current.isOptionsSheetOpen).toBe(false);
-      expect(result.current.dustFilterOption.title).toBe("Show dust transactions");
+      expect(result.current.dustFilterOption?.title).toBe("Show dust transactions");
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
@@ -78,6 +78,7 @@ describe("useOperationsListViewModel", () => {
 
       expect(result.current.hideSmallValueTokenOperations).toBe(false);
       expect(result.current.isOptionsSheetOpen).toBe(false);
+      expect(result.current.dustFilterOption.title).toBe("Hide dust transactions");
 
       act(() => {
         result.current.openOptionsSheet();
@@ -91,6 +92,7 @@ describe("useOperationsListViewModel", () => {
 
       expect(store.getState().settings.hideSmallValueTokenOperations).toBe(true);
       expect(result.current.isOptionsSheetOpen).toBe(false);
+      expect(result.current.dustFilterOption.title).toBe("Show dust transactions");
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
@@ -72,6 +72,28 @@ describe("useOperationsListViewModel", () => {
     });
   });
 
+  describe("dust filtering options", () => {
+    it("starts disabled and toggles the setting from the options sheet", () => {
+      const { result, store } = renderHook(() => useOperationsListViewModel());
+
+      expect(result.current.hideSmallValueTokenOperations).toBe(false);
+      expect(result.current.isOptionsSheetOpen).toBe(false);
+
+      act(() => {
+        result.current.openOptionsSheet();
+      });
+
+      expect(result.current.isOptionsSheetOpen).toBe(true);
+
+      act(() => {
+        result.current.onToggleHideSmallValueTokenOperations();
+      });
+
+      expect(store.getState().settings.hideSmallValueTokenOperations).toBe(true);
+      expect(result.current.isOptionsSheetOpen).toBe(false);
+    });
+  });
+
   describe("accountIds scoping", () => {
     it("filters root accounts to those whose tree intersects the given accountIds", () => {
       const ethereum = getCryptoCurrencyById("ethereum");

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
@@ -106,7 +106,7 @@ describe("useOperationsListViewModel", () => {
         overrideInitialState: withFlagOverrides({
           llHideSmallValueTokenOperations: {
             enabled: true,
-            params: { mobile: true, desktop: false },
+            params: { enabledMobile: true, enabledDesktop: false },
           },
         }),
       });
@@ -136,7 +136,7 @@ describe("useOperationsListViewModel", () => {
         overrideInitialState: withFlagOverrides({
           llHideSmallValueTokenOperations: {
             enabled: true,
-            params: { mobile: false, desktop: true },
+            params: { enabledMobile: false, enabledDesktop: true },
           },
         }),
       });

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsHistoryOptionsSheet.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsHistoryOptionsSheet.tsx
@@ -10,31 +10,24 @@ import {
   ListItemTitle,
   Spot,
 } from "@ledgerhq/lumen-ui-rnative";
-import { Eye, EyeCross } from "@ledgerhq/lumen-ui-rnative/symbols";
 import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
-import { useTranslation } from "~/context/Locale";
+import type { OperationsHistoryDustFilterOption } from "../useOperationsListViewModel";
 
 type Props = Readonly<{
   isOpen: boolean;
-  isFilterEnabled: boolean;
-  threshold: string;
+  dustFilterOption: OperationsHistoryDustFilterOption;
   onClose: () => void;
   onToggle: () => void;
 }>;
 
 export function OperationsHistoryOptionsSheet({
   isOpen,
-  isFilterEnabled,
-  threshold,
+  dustFilterOption,
   onClose,
   onToggle,
 }: Props) {
-  const { t } = useTranslation();
   const { bottom } = useSafeAreaInsets();
-  const Icon = isFilterEnabled ? Eye : EyeCross;
-  const title = isFilterEnabled
-    ? t("operationsList.options.showDustTransactions")
-    : t("operationsList.options.hideDustTransactions");
+  const { Icon, title, description } = dustFilterOption;
 
   return (
     <QueuedDrawerBottomSheet
@@ -50,9 +43,7 @@ export function OperationsHistoryOptionsSheet({
             <Spot appearance="icon" icon={Icon} />
             <ListItemContent>
               <ListItemTitle>{title}</ListItemTitle>
-              <ListItemDescription>
-                {t("operationsList.options.dustTransactionsDescription", { threshold })}
-              </ListItemDescription>
+              <ListItemDescription>{description}</ListItemDescription>
             </ListItemContent>
           </ListItemLeading>
         </ListItem>

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsHistoryOptionsSheet.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsHistoryOptionsSheet.tsx
@@ -15,7 +15,7 @@ import type { OperationsHistoryDustFilterOption } from "../useOperationsListView
 
 type Props = Readonly<{
   isOpen: boolean;
-  dustFilterOption: OperationsHistoryDustFilterOption;
+  dustFilterOption: OperationsHistoryDustFilterOption | undefined;
   onClose: () => void;
   onToggle: () => void;
 }>;
@@ -27,6 +27,8 @@ export function OperationsHistoryOptionsSheet({
   onToggle,
 }: Props) {
   const { bottom } = useSafeAreaInsets();
+  if (!dustFilterOption) return null;
+
   const { Icon, title, description } = dustFilterOption;
 
   return (

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsHistoryOptionsSheet.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsHistoryOptionsSheet.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import {
+  BottomSheetHeader,
+  BottomSheetView,
+  ListItem,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
+  Spot,
+} from "@ledgerhq/lumen-ui-rnative";
+import { Eye, EyeCross } from "@ledgerhq/lumen-ui-rnative/symbols";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import { useTranslation } from "~/context/Locale";
+
+type Props = Readonly<{
+  isOpen: boolean;
+  isFilterEnabled: boolean;
+  threshold: string;
+  onClose: () => void;
+  onToggle: () => void;
+}>;
+
+export function OperationsHistoryOptionsSheet({
+  isOpen,
+  isFilterEnabled,
+  threshold,
+  onClose,
+  onToggle,
+}: Props) {
+  const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
+  const Icon = isFilterEnabled ? Eye : EyeCross;
+  const title = isFilterEnabled
+    ? t("operationsList.options.showDustTransactions")
+    : t("operationsList.options.hideDustTransactions");
+
+  return (
+    <QueuedDrawerBottomSheet
+      testID="operations-history-options-sheet"
+      isRequestingToBeOpened={isOpen}
+      enableDynamicSizing
+      onClose={onClose}
+    >
+      <BottomSheetView style={{ paddingBottom: bottom + 24 }}>
+        <BottomSheetHeader />
+        <ListItem onPress={onToggle} testID="operations-history-toggle-dust-filter">
+          <ListItemLeading>
+            <Spot appearance="icon" icon={Icon} />
+            <ListItemContent>
+              <ListItemTitle>{title}</ListItemTitle>
+              <ListItemDescription>
+                {t("operationsList.options.dustTransactionsDescription", { threshold })}
+              </ListItemDescription>
+            </ListItemContent>
+          </ListItemLeading>
+        </ListItem>
+      </BottomSheetView>
+    </QueuedDrawerBottomSheet>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsHistoryOptionsTrailing.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsHistoryOptionsTrailing.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { IconButton } from "@ledgerhq/lumen-ui-rnative";
+import { MoreVertical } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTranslation } from "~/context/Locale";
+
+type Props = Readonly<{
+  onPress: () => void;
+}>;
+
+export function OperationsHistoryOptionsTrailing({ onPress }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <IconButton
+      appearance="no-background"
+      size="md"
+      icon={MoreVertical}
+      accessibilityLabel={t("operationsList.options.more")}
+      onPress={onPress}
+      testID="operations-history-options-trigger"
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
@@ -1,11 +1,7 @@
 import React, { useCallback, useLayoutEffect, useMemo } from "react";
 import { SectionList, SectionListRenderItem } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useNavigation } from "@react-navigation/native";
-import type {
-  NativeStackHeaderRightProps,
-  NativeStackNavigationProp,
-} from "@react-navigation/native-stack";
+import type { NativeStackHeaderRightProps } from "@react-navigation/native-stack";
 import { Account, Operation } from "@ledgerhq/types-live";
 import type { OperationsListSection } from "./useOperationsListViewModel";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
@@ -26,19 +22,14 @@ import { OperationsHistoryOptionsTrailing } from "./components/OperationsHistory
 import { OperationsHistoryOptionsSheet } from "./components/OperationsHistoryOptionsSheet";
 
 type Props = StackNavigatorProps<OperationsHistoryNavigatorParamsList, ScreenName.OperationsList>;
-type NavigationProps = NativeStackNavigationProp<
-  OperationsHistoryNavigatorParamsList,
-  ScreenName.OperationsList
->;
 
 function keyExtractor(item: Operation) {
   return `${item.accountId}_${item.id}_${item.type}`;
 }
 
-export default function OperationsList({ route }: Props) {
+export default function OperationsList({ route, navigation }: Props) {
   const { bottom } = useSafeAreaInsets();
   const accountIds = route.params?.accountIds;
-  const navigation = useNavigation<NavigationProps>();
   const {
     accounts,
     flattenedAccounts,

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
@@ -52,8 +52,7 @@ export default function OperationsList({ route }: Props) {
     isOptionsSheetOpen,
     openOptionsSheet,
     closeOptionsSheet,
-    hideSmallValueTokenOperations,
-    dustFilterThreshold,
+    dustFilterOption,
     onToggleHideSmallValueTokenOperations,
   } = useOperationsListViewModel(accountIds);
 
@@ -150,8 +149,7 @@ export default function OperationsList({ route }: Props) {
       {!isEmpty && <BottomFadeGradient />}
       <OperationsHistoryOptionsSheet
         isOpen={isOptionsSheetOpen}
-        isFilterEnabled={hideSmallValueTokenOperations}
-        threshold={dustFilterThreshold}
+        dustFilterOption={dustFilterOption}
         onClose={closeOptionsSheet}
         onToggle={onToggleHideSmallValueTokenOperations}
       />

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
@@ -43,6 +43,7 @@ export default function OperationsList({ route, navigation }: Props) {
     isOptionsSheetOpen,
     openOptionsSheet,
     closeOptionsSheet,
+    isDustFilterFeatureEnabled,
     dustFilterOption,
     onToggleHideSmallValueTokenOperations,
   } = useOperationsListViewModel(accountIds);
@@ -57,15 +58,17 @@ export default function OperationsList({ route, navigation }: Props) {
   useLayoutEffect(() => {
     const opts: Partial<LumenNativeStackNavigationOptions> = {
       lumenNavBar: {
-        renderTrailing,
-        navBarTrailingProps: {
-          style: { marginRight: 16 },
-        },
+        renderTrailing: isDustFilterFeatureEnabled ? renderTrailing : undefined,
+        navBarTrailingProps: isDustFilterFeatureEnabled
+          ? {
+              style: { marginRight: 16 },
+            }
+          : undefined,
       },
     };
 
     navigation.setOptions(opts);
-  }, [navigation, renderTrailing]);
+  }, [isDustFilterFeatureEnabled, navigation, renderTrailing]);
 
   const listContentStyle = useMemo(
     () => ({
@@ -138,12 +141,14 @@ export default function OperationsList({ route, navigation }: Props) {
         ListEmptyComponent={ListEmptyComponent}
       />
       {!isEmpty && <BottomFadeGradient />}
-      <OperationsHistoryOptionsSheet
-        isOpen={isOptionsSheetOpen}
-        dustFilterOption={dustFilterOption}
-        onClose={closeOptionsSheet}
-        onToggle={onToggleHideSmallValueTokenOperations}
-      />
+      {isDustFilterFeatureEnabled ? (
+        <OperationsHistoryOptionsSheet
+          isOpen={isOptionsSheetOpen}
+          dustFilterOption={dustFilterOption}
+          onClose={closeOptionsSheet}
+          onToggle={onToggleHideSmallValueTokenOperations}
+        />
+      ) : null}
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
@@ -1,6 +1,11 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useLayoutEffect, useMemo } from "react";
 import { SectionList, SectionListRenderItem } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useNavigation } from "@react-navigation/native";
+import type {
+  NativeStackHeaderRightProps,
+  NativeStackNavigationProp,
+} from "@react-navigation/native-stack";
 import { Account, Operation } from "@ledgerhq/types-live";
 import type { OperationsListSection } from "./useOperationsListViewModel";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
@@ -8,6 +13,7 @@ import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { TrackScreen } from "~/analytics";
 import { ScreenName } from "~/const";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import type { LumenNativeStackNavigationOptions } from "LLM/components/Navigation";
 import type { OperationsHistoryNavigatorParamsList } from "LLM/features/OperationsHistory/types";
 import OperationsListItem from "./components/OperationsListItem";
 import OperationsSectionHeader from "./components/OperationsSectionHeader";
@@ -16,8 +22,14 @@ import { OperationsListFooter } from "./components/OperationsListFooter";
 import { SectionSeparator } from "./components/SectionSeparator";
 import { useOperationsListViewModel } from "./useOperationsListViewModel";
 import { BottomFadeGradient, GRADIENT_HEIGHT } from "LLM/components/BottomFadeGradient";
+import { OperationsHistoryOptionsTrailing } from "./components/OperationsHistoryOptionsTrailing";
+import { OperationsHistoryOptionsSheet } from "./components/OperationsHistoryOptionsSheet";
 
 type Props = StackNavigatorProps<OperationsHistoryNavigatorParamsList, ScreenName.OperationsList>;
+type NavigationProps = NativeStackNavigationProp<
+  OperationsHistoryNavigatorParamsList,
+  ScreenName.OperationsList
+>;
 
 function keyExtractor(item: Operation) {
   return `${item.accountId}_${item.id}_${item.type}`;
@@ -26,6 +38,7 @@ function keyExtractor(item: Operation) {
 export default function OperationsList({ route }: Props) {
   const { bottom } = useSafeAreaInsets();
   const accountIds = route.params?.accountIds;
+  const navigation = useNavigation<NavigationProps>();
   const {
     accounts,
     flattenedAccounts,
@@ -36,7 +49,33 @@ export default function OperationsList({ route }: Props) {
     isEmpty,
     hasPendingOperations,
     onEndReached,
+    isOptionsSheetOpen,
+    openOptionsSheet,
+    closeOptionsSheet,
+    hideSmallValueTokenOperations,
+    dustFilterThreshold,
+    onToggleHideSmallValueTokenOperations,
   } = useOperationsListViewModel(accountIds);
+
+  const renderTrailing = useCallback(
+    (_props: NativeStackHeaderRightProps) => (
+      <OperationsHistoryOptionsTrailing onPress={openOptionsSheet} />
+    ),
+    [openOptionsSheet],
+  );
+
+  useLayoutEffect(() => {
+    const opts: Partial<LumenNativeStackNavigationOptions> = {
+      lumenNavBar: {
+        renderTrailing,
+        navBarTrailingProps: {
+          style: { marginRight: 16 },
+        },
+      },
+    };
+
+    navigation.setOptions(opts);
+  }, [navigation, renderTrailing]);
 
   const listContentStyle = useMemo(
     () => ({
@@ -109,6 +148,13 @@ export default function OperationsList({ route }: Props) {
         ListEmptyComponent={ListEmptyComponent}
       />
       {!isEmpty && <BottomFadeGradient />}
+      <OperationsHistoryOptionsSheet
+        isOpen={isOptionsSheetOpen}
+        isFilterEnabled={hideSmallValueTokenOperations}
+        threshold={dustFilterThreshold}
+        onClose={closeOptionsSheet}
+        onToggle={onToggleHideSmallValueTokenOperations}
+      />
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
@@ -1,8 +1,9 @@
-import { useState, useCallback, useEffect, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo, type ComponentType } from "react";
 import BigNumber from "bignumber.js";
 import { flattenAccounts, getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { floorThresholdToCurrencyMinorUnit } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
+import type { IconProps } from "@ledgerhq/lumen-ui-rnative";
 import { Eye, EyeCross } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { setHideSmallValueTokenOperations } from "~/actions/settings";
 import { useSelector, useDispatch } from "~/context/hooks";
@@ -22,7 +23,7 @@ import { HISTORY_DUST_FILTER_THRESHOLD_USD } from "LLM/features/OperationsHistor
 export type { OperationsListSection } from "./hooks/useOperationsSections";
 
 export type OperationsHistoryDustFilterOption = Readonly<{
-  Icon: typeof Eye;
+  Icon: ComponentType<IconProps>;
   title: string;
   description: string;
 }>;

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
@@ -12,6 +12,7 @@ import { flattenAccountsSelector, shallowAccountsSelector } from "~/reducers/acc
 import { lastSeenOperationDateSelector, markOperationsAsSeen } from "~/reducers/history";
 import {
   counterValueCurrencySelector,
+  hideSmallValueTokenOperationsFeatureEnabledSelector,
   hideSmallValueTokenOperationsEnabledSelector,
 } from "~/reducers/settings";
 import { parseLastSeenMs } from "LLM/features/OperationsHistory/utils/unreadOperations";
@@ -37,8 +38,15 @@ export function useOperationsListViewModel(accountIds?: string[]) {
   const allFlattenedAccounts = useSelector(flattenAccountsSelector);
   const [opCount, setOpCount] = useState(INITIAL_OP_COUNT);
   const [isOptionsSheetOpen, setOptionsSheetOpen] = useState(false);
-  const hideSmallValueTokenOperations = useSelector(hideSmallValueTokenOperationsEnabledSelector);
-  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const isDustFilterFeatureEnabled = useSelector(
+    hideSmallValueTokenOperationsFeatureEnabledSelector,
+  );
+  const userHideSmallValueTokenOperations = useSelector(
+    hideSmallValueTokenOperationsEnabledSelector,
+  );
+  const counterValueCurrency = useSelector(state =>
+    isDustFilterFeatureEnabled ? counterValueCurrencySelector(state) : undefined,
+  );
   const { locale } = useLocale();
   const { t } = useTranslation();
 
@@ -100,6 +108,8 @@ export function useOperationsListViewModel(accountIds?: string[]) {
 
   const hasPendingOperations = useMemo(() => sections.some(s => s.isPending), [sections]);
   const dustFilterThreshold = useMemo(() => {
+    if (!counterValueCurrency) return undefined;
+
     const thresholdMinorUnit =
       floorThresholdToCurrencyMinorUnit(HISTORY_DUST_FILTER_THRESHOLD_USD, counterValueCurrency) ??
       new BigNumber(0);
@@ -109,9 +119,11 @@ export function useOperationsListViewModel(accountIds?: string[]) {
       locale,
     });
   }, [counterValueCurrency, locale]);
-  const dustFilterOption: OperationsHistoryDustFilterOption = useMemo(() => {
-    const Icon = hideSmallValueTokenOperations ? Eye : EyeCross;
-    const title = hideSmallValueTokenOperations
+  const dustFilterOption: OperationsHistoryDustFilterOption | undefined = useMemo(() => {
+    if (!isDustFilterFeatureEnabled || !dustFilterThreshold) return undefined;
+
+    const Icon = userHideSmallValueTokenOperations ? Eye : EyeCross;
+    const title = userHideSmallValueTokenOperations
       ? t("operationsList.options.showDustTransactions")
       : t("operationsList.options.hideDustTransactions");
 
@@ -122,14 +134,20 @@ export function useOperationsListViewModel(accountIds?: string[]) {
         threshold: dustFilterThreshold,
       }),
     };
-  }, [dustFilterThreshold, hideSmallValueTokenOperations, t]);
+  }, [dustFilterThreshold, isDustFilterFeatureEnabled, userHideSmallValueTokenOperations, t]);
 
-  const openOptionsSheet = useCallback(() => setOptionsSheetOpen(true), []);
+  const openOptionsSheet = useCallback(() => {
+    if (isDustFilterFeatureEnabled) {
+      setOptionsSheetOpen(true);
+    }
+  }, [isDustFilterFeatureEnabled]);
   const closeOptionsSheet = useCallback(() => setOptionsSheetOpen(false), []);
   const onToggleHideSmallValueTokenOperations = useCallback(() => {
-    dispatch(setHideSmallValueTokenOperations(!hideSmallValueTokenOperations));
+    if (!isDustFilterFeatureEnabled) return;
+
+    dispatch(setHideSmallValueTokenOperations(!userHideSmallValueTokenOperations));
     closeOptionsSheet();
-  }, [dispatch, hideSmallValueTokenOperations, closeOptionsSheet]);
+  }, [dispatch, isDustFilterFeatureEnabled, userHideSmallValueTokenOperations, closeOptionsSheet]);
 
   return {
     accounts,
@@ -144,7 +162,8 @@ export function useOperationsListViewModel(accountIds?: string[]) {
     isOptionsSheetOpen,
     openOptionsSheet,
     closeOptionsSheet,
-    hideSmallValueTokenOperations,
+    hideSmallValueTokenOperations: isDustFilterFeatureEnabled && userHideSmallValueTokenOperations,
+    isDustFilterFeatureEnabled,
     dustFilterOption,
     onToggleHideSmallValueTokenOperations,
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
@@ -3,9 +3,10 @@ import BigNumber from "bignumber.js";
 import { flattenAccounts, getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { floorThresholdToCurrencyMinorUnit } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
+import { Eye, EyeCross } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { setHideSmallValueTokenOperations } from "~/actions/settings";
 import { useSelector, useDispatch } from "~/context/hooks";
-import { useLocale } from "~/context/Locale";
+import { useLocale, useTranslation } from "~/context/Locale";
 import { flattenAccountsSelector, shallowAccountsSelector } from "~/reducers/accounts";
 import { lastSeenOperationDateSelector, markOperationsAsSeen } from "~/reducers/history";
 import {
@@ -20,6 +21,12 @@ import { HISTORY_DUST_FILTER_THRESHOLD_USD } from "LLM/features/OperationsHistor
 
 export type { OperationsListSection } from "./hooks/useOperationsSections";
 
+export type OperationsHistoryDustFilterOption = Readonly<{
+  Icon: typeof Eye;
+  title: string;
+  description: string;
+}>;
+
 const INITIAL_OP_COUNT = 50;
 const OP_COUNT_INCREMENT = 50;
 
@@ -32,6 +39,7 @@ export function useOperationsListViewModel(accountIds?: string[]) {
   const hideSmallValueTokenOperations = useSelector(hideSmallValueTokenOperationsEnabledSelector);
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const { locale } = useLocale();
+  const { t } = useTranslation();
 
   const allowedIds = useMemo(
     () => (accountIds && accountIds.length > 0 ? new Set(accountIds) : null),
@@ -100,6 +108,20 @@ export function useOperationsListViewModel(accountIds?: string[]) {
       locale,
     });
   }, [counterValueCurrency, locale]);
+  const dustFilterOption: OperationsHistoryDustFilterOption = useMemo(() => {
+    const Icon = hideSmallValueTokenOperations ? Eye : EyeCross;
+    const title = hideSmallValueTokenOperations
+      ? t("operationsList.options.showDustTransactions")
+      : t("operationsList.options.hideDustTransactions");
+
+    return {
+      Icon,
+      title,
+      description: t("operationsList.options.dustTransactionsDescription", {
+        threshold: dustFilterThreshold,
+      }),
+    };
+  }, [dustFilterThreshold, hideSmallValueTokenOperations, t]);
 
   const openOptionsSheet = useCallback(() => setOptionsSheetOpen(true), []);
   const closeOptionsSheet = useCallback(() => setOptionsSheetOpen(false), []);
@@ -122,7 +144,7 @@ export function useOperationsListViewModel(accountIds?: string[]) {
     openOptionsSheet,
     closeOptionsSheet,
     hideSmallValueTokenOperations,
-    dustFilterThreshold,
+    dustFilterOption,
     onToggleHideSmallValueTokenOperations,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useMemo, type ComponentType } from "react";
 import BigNumber from "bignumber.js";
+import { useHideSmallValueTokenOperationsFeature } from "@features/platform-feature-flags";
 import { flattenAccounts, getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { floorThresholdToCurrencyMinorUnit } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
@@ -12,7 +13,6 @@ import { flattenAccountsSelector, shallowAccountsSelector } from "~/reducers/acc
 import { lastSeenOperationDateSelector, markOperationsAsSeen } from "~/reducers/history";
 import {
   counterValueCurrencySelector,
-  hideSmallValueTokenOperationsFeatureEnabledSelector,
   hideSmallValueTokenOperationsEnabledSelector,
 } from "~/reducers/settings";
 import { parseLastSeenMs } from "LLM/features/OperationsHistory/utils/unreadOperations";
@@ -38,9 +38,8 @@ export function useOperationsListViewModel(accountIds?: string[]) {
   const allFlattenedAccounts = useSelector(flattenAccountsSelector);
   const [opCount, setOpCount] = useState(INITIAL_OP_COUNT);
   const [isOptionsSheetOpen, setOptionsSheetOpen] = useState(false);
-  const isDustFilterFeatureEnabled = useSelector(
-    hideSmallValueTokenOperationsFeatureEnabledSelector,
-  );
+  const { isEnabled: isDustFilterFeatureEnabled } =
+    useHideSmallValueTokenOperationsFeature("mobile");
   const userHideSmallValueTokenOperations = useSelector(
     hideSmallValueTokenOperationsEnabledSelector,
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
@@ -1,12 +1,22 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
+import BigNumber from "bignumber.js";
 import { flattenAccounts, getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { floorThresholdToCurrencyMinorUnit } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
+import { setHideSmallValueTokenOperations } from "~/actions/settings";
 import { useSelector, useDispatch } from "~/context/hooks";
+import { useLocale } from "~/context/Locale";
 import { flattenAccountsSelector, shallowAccountsSelector } from "~/reducers/accounts";
 import { lastSeenOperationDateSelector, markOperationsAsSeen } from "~/reducers/history";
+import {
+  counterValueCurrencySelector,
+  hideSmallValueTokenOperationsEnabledSelector,
+} from "~/reducers/settings";
 import { parseLastSeenMs } from "LLM/features/OperationsHistory/utils/unreadOperations";
 import { useOperationsV1 } from "~/screens/Analytics/Operations/useOperationsV1";
 import { AccountLike, Operation } from "@ledgerhq/types-live";
 import { useOperationsSections } from "./hooks/useOperationsSections";
+import { HISTORY_DUST_FILTER_THRESHOLD_USD } from "LLM/features/OperationsHistory/constants";
 
 export type { OperationsListSection } from "./hooks/useOperationsSections";
 
@@ -18,6 +28,10 @@ export function useOperationsListViewModel(accountIds?: string[]) {
   const allAccounts = useSelector(shallowAccountsSelector);
   const allFlattenedAccounts = useSelector(flattenAccountsSelector);
   const [opCount, setOpCount] = useState(INITIAL_OP_COUNT);
+  const [isOptionsSheetOpen, setOptionsSheetOpen] = useState(false);
+  const hideSmallValueTokenOperations = useSelector(hideSmallValueTokenOperationsEnabledSelector);
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const { locale } = useLocale();
 
   const allowedIds = useMemo(
     () => (accountIds && accountIds.length > 0 ? new Set(accountIds) : null),
@@ -76,6 +90,23 @@ export function useOperationsListViewModel(accountIds?: string[]) {
   const isEmpty = completed && sections.length === 0;
 
   const hasPendingOperations = useMemo(() => sections.some(s => s.isPending), [sections]);
+  const dustFilterThreshold = useMemo(() => {
+    const thresholdMinorUnit =
+      floorThresholdToCurrencyMinorUnit(HISTORY_DUST_FILTER_THRESHOLD_USD, counterValueCurrency) ??
+      new BigNumber(0);
+
+    return formatCurrencyUnit(counterValueCurrency.units[0], thresholdMinorUnit, {
+      showCode: true,
+      locale,
+    });
+  }, [counterValueCurrency, locale]);
+
+  const openOptionsSheet = useCallback(() => setOptionsSheetOpen(true), []);
+  const closeOptionsSheet = useCallback(() => setOptionsSheetOpen(false), []);
+  const onToggleHideSmallValueTokenOperations = useCallback(() => {
+    dispatch(setHideSmallValueTokenOperations(!hideSmallValueTokenOperations));
+    closeOptionsSheet();
+  }, [dispatch, hideSmallValueTokenOperations, closeOptionsSheet]);
 
   return {
     accounts,
@@ -87,5 +118,11 @@ export function useOperationsListViewModel(accountIds?: string[]) {
     isEmpty,
     hasPendingOperations,
     onEndReached,
+    isOptionsSheetOpen,
+    openOptionsSheet,
+    closeOptionsSheet,
+    hideSmallValueTokenOperations,
+    dustFilterThreshold,
+    onToggleHideSmallValueTokenOperations,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useMemo, type ComponentType } from "react";
 import BigNumber from "bignumber.js";
-import { useHideSmallValueTokenOperationsFeature } from "@features/platform-feature-flags";
+import { useDustFilteringFeature } from "@features/platform-feature-flags";
 import { flattenAccounts, getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { floorThresholdToCurrencyMinorUnit } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
@@ -38,8 +38,7 @@ export function useOperationsListViewModel(accountIds?: string[]) {
   const allFlattenedAccounts = useSelector(flattenAccountsSelector);
   const [opCount, setOpCount] = useState(INITIAL_OP_COUNT);
   const [isOptionsSheetOpen, setOptionsSheetOpen] = useState(false);
-  const { isEnabled: isDustFilterFeatureEnabled } =
-    useHideSmallValueTokenOperationsFeature("mobile");
+  const { isEnabled: isDustFilterFeatureEnabled } = useDustFilteringFeature("mobile");
   const userHideSmallValueTokenOperations = useSelector(
     hideSmallValueTokenOperationsEnabledSelector,
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/utils/unreadOperations.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/utils/unreadOperations.ts
@@ -1,11 +1,15 @@
 import type { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import type { Features } from "@shared/feature-flags";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
 import { flattenAccounts } from "@ledgerhq/live-common/account/index";
+import { isSmallValueTokenOperation } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
 import {
   flattenOperationWithInternalsAndNfts,
   isAddressPoisoningOperation,
 } from "@ledgerhq/ledger-wallet-framework/operation";
 import { getEnv } from "@ledgerhq/live-env";
+import { HISTORY_DUST_FILTER_THRESHOLD_USD } from "../constants";
 
 /**
  * Mirrors {@link useAddressPoisoningOperationsFamilies} using Redux-resolved flags.
@@ -43,6 +47,9 @@ export function hasUnreadOperations(
   lastSeenDate: string | null,
   shouldFilterTokenOps: boolean,
   addressPoisoningFamilies: string[] | null,
+  shouldHideSmallValueTokenOperations = false,
+  countervaluesState?: CounterValuesState,
+  userCounterValueCurrency?: Currency,
 ): boolean {
   if (!lastSeenDate) return false;
 
@@ -50,12 +57,33 @@ export function hasUnreadOperations(
   if (lastSeenTs === null) return false;
 
   const filterOperation = (operation: Operation, account: AccountLike): boolean => {
-    if (!shouldFilterTokenOps) return true;
-    return !isAddressPoisoningOperation(
-      operation,
-      account,
-      addressPoisoningFamilies ? { families: addressPoisoningFamilies } : undefined,
-    );
+    if (
+      shouldFilterTokenOps &&
+      isAddressPoisoningOperation(
+        operation,
+        account,
+        addressPoisoningFamilies ? { families: addressPoisoningFamilies } : undefined,
+      )
+    ) {
+      return false;
+    }
+
+    if (
+      shouldHideSmallValueTokenOperations &&
+      countervaluesState &&
+      userCounterValueCurrency &&
+      isSmallValueTokenOperation({
+        operation,
+        account,
+        countervaluesState,
+        userCounterValueCurrency,
+        thresholdUsd: HISTORY_DUST_FILTER_THRESHOLD_USD,
+      })
+    ) {
+      return false;
+    }
+
+    return true;
   };
 
   const allAccounts = flattenAccounts(accounts);

--- a/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
@@ -9,6 +9,8 @@ import historyReducer, {
   lastSeenOperationDateSelector,
   hasUnreadOperationsSelector,
 } from "../history";
+import { INITIAL_STATE as COUNTERVALUES_INITIAL_STATE } from "../countervalues";
+import { INITIAL_STATE as SETTINGS_INITIAL_STATE } from "../settings";
 import type { State } from "../types";
 
 const SEEN = "2024-06-01T00:00:00.000Z";
@@ -33,8 +35,12 @@ function mapAllOperationsDate<T extends AccountLike>(accountLike: T, date: Date)
 function makeState(lastSeenDate: string | null, accounts: Account[]): State {
   return {
     accounts: { active: accounts },
+    countervalues: COUNTERVALUES_INITIAL_STATE,
     history: { lastSeenOperationDate: lastSeenDate },
-    settings: { filterTokenOperationsZeroAmount: false },
+    settings: {
+      ...SETTINGS_INITIAL_STATE,
+      filterTokenOperationsZeroAmount: false,
+    },
     featureFlags: FEATURE_FLAGS_INITIAL_STATE,
   } as unknown as State;
 }

--- a/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
@@ -99,7 +99,7 @@ function withDustFeatureEnabled(state: State): State {
         ...state.featureFlags.resolved,
         llHideSmallValueTokenOperations: {
           enabled: true,
-          params: { mobile: true, desktop: false },
+          params: { enabledMobile: true, enabledDesktop: false },
         },
       },
     },

--- a/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
@@ -1,7 +1,9 @@
 import { FEATURE_FLAGS_INITIAL_STATE } from "@shared/feature-flags";
-import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import BigNumber from "bignumber.js";
+import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
-import type { Account, AccountLike } from "@ledgerhq/types-live";
+import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import type { Account, AccountLike, Operation, TokenAccount } from "@ledgerhq/types-live";
 import historyReducer, {
   type HistoryState,
   markOperationsAsSeen,
@@ -43,6 +45,62 @@ function makeState(lastSeenDate: string | null, accounts: Account[]): State {
     },
     featureFlags: FEATURE_FLAGS_INITIAL_STATE,
   } as unknown as State;
+}
+
+function createAccountWithUnreadZeroValueTokenOperation(): Account {
+  const parentAccount = genAccount("history-test-dust", {
+    currency: ethereum,
+    operationsSize: 0,
+    subAccountsCount: 0,
+  });
+  const tokenAccount = genTokenAccount(0, parentAccount, usdcToken);
+  const operation: Operation = {
+    id: "history-test-dust-zero-value-token-op",
+    hash: "0xdust",
+    type: "IN",
+    value: new BigNumber(0),
+    fee: new BigNumber(0),
+    senders: ["0xsender"],
+    recipients: ["0xrecipient"],
+    blockHash: "0xblock",
+    blockHeight: 1,
+    accountId: tokenAccount.id,
+    date: new Date("2024-12-01T00:00:00.000Z"),
+    extra: {},
+  };
+  const tokenAccountWithOperation: TokenAccount = {
+    ...tokenAccount,
+    operations: [operation],
+    operationsCount: 1,
+  };
+
+  return {
+    ...parentAccount,
+    subAccounts: [tokenAccountWithOperation],
+  };
+}
+
+function withDustPreferenceEnabled(state: State): State {
+  return {
+    ...state,
+    settings: {
+      ...state.settings,
+      hideSmallValueTokenOperations: true,
+    },
+  };
+}
+
+function withDustFeatureEnabled(state: State): State {
+  return {
+    ...state,
+    featureFlags: {
+      ...state.featureFlags,
+      resolved: {
+        ...state.featureFlags.resolved,
+        llmHideSmallValueTokenOperations: { enabled: true },
+      },
+    },
+  };
 }
 
 describe("historyReducer", () => {
@@ -119,5 +177,27 @@ describe("hasUnreadOperationsSelector", () => {
       operations: [{ ...rootOp, nftOperations: [nftOp] }, ...rest],
     };
     expect(hasUnreadOperationsSelector(makeState(SEEN, [accountWithNft]))).toBe(true);
+  });
+
+  it("ignores the dust preference when the dust filter feature flag is disabled", () => {
+    const accountWithDustOperation = createAccountWithUnreadZeroValueTokenOperation();
+
+    expect(
+      hasUnreadOperationsSelector(
+        withDustPreferenceEnabled(makeState(SEEN, [accountWithDustOperation])),
+      ),
+    ).toBe(true);
+  });
+
+  it("filters dust operations when the dust preference and feature flag are enabled", () => {
+    const accountWithDustOperation = createAccountWithUnreadZeroValueTokenOperation();
+
+    expect(
+      hasUnreadOperationsSelector(
+        withDustFeatureEnabled(
+          withDustPreferenceEnabled(makeState(SEEN, [accountWithDustOperation])),
+        ),
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
@@ -97,7 +97,7 @@ function withDustFeatureEnabled(state: State): State {
       ...state.featureFlags,
       resolved: {
         ...state.featureFlags.resolved,
-        llHideSmallValueTokenOperations: {
+        lwHideSmallValueTokenOperations: {
           enabled: true,
           params: { enabledMobile: true, enabledDesktop: false },
         },

--- a/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
@@ -97,9 +97,8 @@ function withDustFeatureEnabled(state: State): State {
       ...state.featureFlags,
       resolved: {
         ...state.featureFlags.resolved,
-        lwHideSmallValueTokenOperations: {
+        lwmDustFiltering: {
           enabled: true,
-          params: { enabledMobile: true, enabledDesktop: false },
         },
       },
     },

--- a/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
@@ -97,7 +97,10 @@ function withDustFeatureEnabled(state: State): State {
       ...state.featureFlags,
       resolved: {
         ...state.featureFlags.resolved,
-        llmHideSmallValueTokenOperations: { enabled: true },
+        llHideSmallValueTokenOperations: {
+          enabled: true,
+          params: { mobile: true, desktop: false },
+        },
       },
     },
   };

--- a/apps/ledger-live-mobile/src/reducers/history.ts
+++ b/apps/ledger-live-mobile/src/reducers/history.ts
@@ -6,7 +6,12 @@ import {
 } from "LLM/features/OperationsHistory/utils/unreadOperations";
 import type { State } from "./types";
 import { accountsSelector } from "./accounts";
-import { filterTokenOperationsZeroAmountEnabledSelector } from "./settings";
+import {
+  counterValueCurrencySelector,
+  filterTokenOperationsZeroAmountEnabledSelector,
+  hideSmallValueTokenOperationsEnabledSelector,
+} from "./settings";
+import { countervaluesStateSelector } from "./countervalues";
 
 export type HistoryState = {
   lastSeenOperationDate: string | null;
@@ -46,10 +51,29 @@ export const hasUnreadOperationsSelector = createSelector(
   accountsSelector,
   lastSeenOperationDateSelector,
   filterTokenOperationsZeroAmountEnabledSelector,
+  hideSmallValueTokenOperationsEnabledSelector,
+  countervaluesStateSelector,
+  counterValueCurrencySelector,
   (state: State) => selectFeature(state, "addressPoisoningOperationsFilter"),
-  (accounts, lastSeenDate, shouldFilterTokenOps, poisoningFeature) => {
+  (
+    accounts,
+    lastSeenDate,
+    shouldFilterTokenOps,
+    shouldHideSmallValueTokenOperations,
+    countervaluesState,
+    userCounterValueCurrency,
+    poisoningFeature,
+  ) => {
     if (!lastSeenDate) return false;
     const families = getAddressPoisoningFamiliesForFilter(shouldFilterTokenOps, poisoningFeature);
-    return hasUnreadOperations(accounts, lastSeenDate, shouldFilterTokenOps, families);
+    return hasUnreadOperations(
+      accounts,
+      lastSeenDate,
+      shouldFilterTokenOps,
+      families,
+      shouldHideSmallValueTokenOperations,
+      countervaluesState,
+      userCounterValueCurrency,
+    );
   },
 );

--- a/apps/ledger-live-mobile/src/reducers/history.ts
+++ b/apps/ledger-live-mobile/src/reducers/history.ts
@@ -9,7 +9,7 @@ import { accountsSelector } from "./accounts";
 import {
   counterValueCurrencySelector,
   filterTokenOperationsZeroAmountEnabledSelector,
-  hideSmallValueTokenOperationsEnabledSelector,
+  hideSmallValueTokenOperationsEffectiveSelector,
 } from "./settings";
 import { countervaluesStateSelector } from "./countervalues";
 
@@ -43,12 +43,12 @@ export const lastSeenOperationDateSelector = (state: Pick<State, "history">): st
   state.history.lastSeenOperationDate;
 
 const dustFilterCountervaluesStateSelector = (state: State) =>
-  hideSmallValueTokenOperationsEnabledSelector(state)
+  hideSmallValueTokenOperationsEffectiveSelector(state)
     ? countervaluesStateSelector(state)
     : undefined;
 
 const dustFilterCounterValueCurrencySelector = (state: State) =>
-  hideSmallValueTokenOperationsEnabledSelector(state)
+  hideSmallValueTokenOperationsEffectiveSelector(state)
     ? counterValueCurrencySelector(state)
     : undefined;
 
@@ -61,7 +61,7 @@ export const hasUnreadOperationsSelector = createSelector(
   accountsSelector,
   lastSeenOperationDateSelector,
   filterTokenOperationsZeroAmountEnabledSelector,
-  hideSmallValueTokenOperationsEnabledSelector,
+  hideSmallValueTokenOperationsEffectiveSelector,
   dustFilterCountervaluesStateSelector,
   dustFilterCounterValueCurrencySelector,
   (state: State) => selectFeature(state, "addressPoisoningOperationsFilter"),

--- a/apps/ledger-live-mobile/src/reducers/history.ts
+++ b/apps/ledger-live-mobile/src/reducers/history.ts
@@ -42,6 +42,16 @@ export default historySlice.reducer;
 export const lastSeenOperationDateSelector = (state: Pick<State, "history">): string | null =>
   state.history.lastSeenOperationDate;
 
+const dustFilterCountervaluesStateSelector = (state: State) =>
+  hideSmallValueTokenOperationsEnabledSelector(state)
+    ? countervaluesStateSelector(state)
+    : undefined;
+
+const dustFilterCounterValueCurrencySelector = (state: State) =>
+  hideSmallValueTokenOperationsEnabledSelector(state)
+    ? counterValueCurrencySelector(state)
+    : undefined;
+
 /**
  * Returns true when any operation shown in global History is newer than lastSeenOperationDate
  * (same pipeline as the History list: flattened accounts, pending ops, address-poisoning filter).
@@ -52,8 +62,8 @@ export const hasUnreadOperationsSelector = createSelector(
   lastSeenOperationDateSelector,
   filterTokenOperationsZeroAmountEnabledSelector,
   hideSmallValueTokenOperationsEnabledSelector,
-  countervaluesStateSelector,
-  counterValueCurrencySelector,
+  dustFilterCountervaluesStateSelector,
+  dustFilterCounterValueCurrencySelector,
   (state: State) => selectFeature(state, "addressPoisoningOperationsFilter"),
   (
     accounts,

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -861,8 +861,10 @@ export const filterTokenOperationsZeroAmountEnabledSelector = (state: State) =>
   state.settings.filterTokenOperationsZeroAmount;
 export const hideSmallValueTokenOperationsEnabledSelector = (state: State) =>
   state.settings.hideSmallValueTokenOperations;
-export const hideSmallValueTokenOperationsFeatureEnabledSelector = (state: State) =>
-  selectFeature(state, "llmHideSmallValueTokenOperations")?.enabled === true;
+export const hideSmallValueTokenOperationsFeatureEnabledSelector = (state: State) => {
+  const feature = selectFeature(state, "llHideSmallValueTokenOperations");
+  return feature?.enabled === true && feature.params?.mobile === true;
+};
 export const hideSmallValueTokenOperationsEffectiveSelector = (state: State) =>
   hideSmallValueTokenOperationsFeatureEnabledSelector(state) &&
   hideSmallValueTokenOperationsEnabledSelector(state);

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -861,6 +861,11 @@ export const filterTokenOperationsZeroAmountEnabledSelector = (state: State) =>
   state.settings.filterTokenOperationsZeroAmount;
 export const hideSmallValueTokenOperationsEnabledSelector = (state: State) =>
   state.settings.hideSmallValueTokenOperations;
+export const hideSmallValueTokenOperationsFeatureEnabledSelector = (state: State) =>
+  selectFeature(state, "llmHideSmallValueTokenOperations")?.enabled === true;
+export const hideSmallValueTokenOperationsEffectiveSelector = (state: State) =>
+  hideSmallValueTokenOperationsFeatureEnabledSelector(state) &&
+  hideSmallValueTokenOperationsEnabledSelector(state);
 export const dismissedBannersSelector = (state: State) => state.settings.dismissedBanners;
 export const hasAvailableUpdateSelector = (state: State) => state.settings.hasAvailableUpdate;
 export const dismissedDynamicCardsSelector = (state: State) => state.settings.dismissedDynamicCards;

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -82,6 +82,7 @@ import type {
   SettingsSetHasSeenQ2WalletV4TourPayload,
   SettingsSetAnalyticsConsentInfoPayload,
   SettingsSetHasClickedRecoverPayload,
+  SettingsHideSmallValueTokenOperationsPayload,
 } from "../actions/types";
 import { SettingsActionTypes } from "../actions/types";
 import { getFeature } from "@ledgerhq/live-common/firebase/featureFlags";
@@ -112,6 +113,7 @@ export const INITIAL_STATE: SettingsState = {
   graphCountervalueFirst: true,
   hideEmptyTokenAccounts: false,
   filterTokenOperationsZeroAmount: true,
+  hideSmallValueTokenOperations: false,
   blacklistedTokenIds: [],
   dismissedBanners: [],
   hasAvailableUpdate: false,
@@ -405,6 +407,12 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
     filterTokenOperationsZeroAmount: (
       action as Action<SettingsFilterTokenOperationsZeroAmountPayload>
     ).payload,
+  }),
+
+  [SettingsActionTypes.SETTINGS_HIDE_SMALL_VALUE_TOKEN_OPERATIONS]: (state, action) => ({
+    ...state,
+    hideSmallValueTokenOperations: (action as Action<SettingsHideSmallValueTokenOperationsPayload>)
+      .payload,
   }),
 
   [SettingsActionTypes.SHOW_TOKEN]: (state, action) => {
@@ -851,6 +859,8 @@ export const hideEmptyTokenAccountsEnabledSelector = (state: State) =>
   state.settings.hideEmptyTokenAccounts;
 export const filterTokenOperationsZeroAmountEnabledSelector = (state: State) =>
   state.settings.filterTokenOperationsZeroAmount;
+export const hideSmallValueTokenOperationsEnabledSelector = (state: State) =>
+  state.settings.hideSmallValueTokenOperations;
 export const dismissedBannersSelector = (state: State) => state.settings.dismissedBanners;
 export const hasAvailableUpdateSelector = (state: State) => state.settings.hasAvailableUpdate;
 export const dismissedDynamicCardsSelector = (state: State) => state.settings.dismissedDynamicCards;

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -863,7 +863,7 @@ export const hideSmallValueTokenOperationsEnabledSelector = (state: State) =>
   state.settings.hideSmallValueTokenOperations;
 export const hideSmallValueTokenOperationsFeatureEnabledSelector = (state: State) => {
   const feature = selectFeature(state, "llHideSmallValueTokenOperations");
-  return feature?.enabled === true && feature.params?.mobile === true;
+  return feature?.enabled === true && feature.params?.enabledMobile === true;
 };
 export const hideSmallValueTokenOperationsEffectiveSelector = (state: State) =>
   hideSmallValueTokenOperationsFeatureEnabledSelector(state) &&

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -862,7 +862,7 @@ export const filterTokenOperationsZeroAmountEnabledSelector = (state: State) =>
 export const hideSmallValueTokenOperationsEnabledSelector = (state: State) =>
   state.settings.hideSmallValueTokenOperations;
 export const hideSmallValueTokenOperationsFeatureEnabledSelector = (state: State) => {
-  const feature = selectFeature(state, "llHideSmallValueTokenOperations");
+  const feature = selectFeature(state, "lwHideSmallValueTokenOperations");
   return feature?.enabled === true && feature.params?.enabledMobile === true;
 };
 export const hideSmallValueTokenOperationsEffectiveSelector = (state: State) =>

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -862,8 +862,8 @@ export const filterTokenOperationsZeroAmountEnabledSelector = (state: State) =>
 export const hideSmallValueTokenOperationsEnabledSelector = (state: State) =>
   state.settings.hideSmallValueTokenOperations;
 export const hideSmallValueTokenOperationsFeatureEnabledSelector = (state: State) => {
-  const feature = selectFeature(state, "lwHideSmallValueTokenOperations");
-  return feature?.enabled === true && feature.params?.enabledMobile === true;
+  const feature = selectFeature(state, "lwmDustFiltering");
+  return feature?.enabled === true;
 };
 export const hideSmallValueTokenOperationsEffectiveSelector = (state: State) =>
   hideSmallValueTokenOperationsFeatureEnabledSelector(state) &&

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -253,6 +253,7 @@ export type SettingsState = {
   graphCountervalueFirst: boolean;
   hideEmptyTokenAccounts: boolean;
   filterTokenOperationsZeroAmount: boolean;
+  hideSmallValueTokenOperations: boolean;
   blacklistedTokenIds: string[];
   dismissedBanners: string[];
   hasAvailableUpdate: boolean;

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
@@ -3,7 +3,7 @@ import type { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { renderHook } from "@tests/test-renderer";
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { useOperationsV1 } from "../useOperationsV1";
 import { State } from "~/reducers/types";
 
@@ -107,7 +107,7 @@ const initialStateWithFilterEnabledButNoEvmFamily = (state: State): State => ({
   },
 });
 
-const initialStateWithDustFilterEnabled = (state: State): State => ({
+const initialStateWithDustPreferenceEnabled = (state: State): State => ({
   ...state,
   settings: {
     ...state.settings,
@@ -115,6 +115,13 @@ const initialStateWithDustFilterEnabled = (state: State): State => ({
     hideSmallValueTokenOperations: true,
   },
 });
+
+const initialStateWithDustFilterEnabled = withFlagOverrides(
+  {
+    llmHideSmallValueTokenOperations: { enabled: true },
+  },
+  initialStateWithDustPreferenceEnabled,
+);
 
 describe("useOperationsV1 integration", () => {
   beforeEach(() => {
@@ -142,7 +149,17 @@ describe("useOperationsV1 integration", () => {
     expect(result.current.sections[0].data.length).toBe(2);
   });
 
-  it("should filter out zero-value token operations when dust filtering is enabled", () => {
+  it("should not filter zero-value token operations when dust preference is enabled but the feature flag is disabled", () => {
+    const accountWithZeroValueTokenOp = createAccountWithZeroValueTokenOperation();
+
+    const { result } = renderHook(() => useOperationsV1([accountWithZeroValueTokenOp], 50), {
+      overrideInitialState: initialStateWithDustPreferenceEnabled,
+    });
+
+    expect(result.current.sections[0].data).toHaveLength(2);
+  });
+
+  it("should filter out zero-value token operations when dust preference and feature flag are enabled", () => {
     const accountWithZeroValueTokenOp = createAccountWithZeroValueTokenOperation();
 
     const { result } = renderHook(() => useOperationsV1([accountWithZeroValueTokenOp], 50), {

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
@@ -118,7 +118,20 @@ const initialStateWithDustPreferenceEnabled = (state: State): State => ({
 
 const initialStateWithDustFilterEnabled = withFlagOverrides(
   {
-    llmHideSmallValueTokenOperations: { enabled: true },
+    llHideSmallValueTokenOperations: {
+      enabled: true,
+      params: { mobile: true, desktop: false },
+    },
+  },
+  initialStateWithDustPreferenceEnabled,
+);
+
+const initialStateWithDesktopDustFilterEnabled = withFlagOverrides(
+  {
+    llHideSmallValueTokenOperations: {
+      enabled: true,
+      params: { mobile: false, desktop: true },
+    },
   },
   initialStateWithDustPreferenceEnabled,
 );
@@ -154,6 +167,16 @@ describe("useOperationsV1 integration", () => {
 
     const { result } = renderHook(() => useOperationsV1([accountWithZeroValueTokenOp], 50), {
       overrideInitialState: initialStateWithDustPreferenceEnabled,
+    });
+
+    expect(result.current.sections[0].data).toHaveLength(2);
+  });
+
+  it("should not filter zero-value token operations when only the desktop dust filter param is enabled", () => {
+    const accountWithZeroValueTokenOp = createAccountWithZeroValueTokenOperation();
+
+    const { result } = renderHook(() => useOperationsV1([accountWithZeroValueTokenOp], 50), {
+      overrideInitialState: initialStateWithDesktopDustFilterEnabled,
     });
 
     expect(result.current.sections[0].data).toHaveLength(2);

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
@@ -118,7 +118,7 @@ const initialStateWithDustPreferenceEnabled = (state: State): State => ({
 
 const initialStateWithDustFilterEnabled = withFlagOverrides(
   {
-    llHideSmallValueTokenOperations: {
+    lwHideSmallValueTokenOperations: {
       enabled: true,
       params: { enabledMobile: true, enabledDesktop: false },
     },
@@ -128,7 +128,7 @@ const initialStateWithDustFilterEnabled = withFlagOverrides(
 
 const initialStateWithDesktopDustFilterEnabled = withFlagOverrides(
   {
-    llHideSmallValueTokenOperations: {
+    lwHideSmallValueTokenOperations: {
       enabled: true,
       params: { enabledMobile: false, enabledDesktop: true },
     },

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
@@ -120,7 +120,7 @@ const initialStateWithDustFilterEnabled = withFlagOverrides(
   {
     llHideSmallValueTokenOperations: {
       enabled: true,
-      params: { mobile: true, desktop: false },
+      params: { enabledMobile: true, enabledDesktop: false },
     },
   },
   initialStateWithDustPreferenceEnabled,
@@ -130,7 +130,7 @@ const initialStateWithDesktopDustFilterEnabled = withFlagOverrides(
   {
     llHideSmallValueTokenOperations: {
       enabled: true,
-      params: { mobile: false, desktop: true },
+      params: { enabledMobile: false, enabledDesktop: true },
     },
   },
   initialStateWithDustPreferenceEnabled,

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
@@ -118,9 +118,8 @@ const initialStateWithDustPreferenceEnabled = (state: State): State => ({
 
 const initialStateWithDustFilterEnabled = withFlagOverrides(
   {
-    lwHideSmallValueTokenOperations: {
+    lwmDustFiltering: {
       enabled: true,
-      params: { enabledMobile: true, enabledDesktop: false },
     },
   },
   initialStateWithDustPreferenceEnabled,
@@ -128,9 +127,8 @@ const initialStateWithDustFilterEnabled = withFlagOverrides(
 
 const initialStateWithDesktopDustFilterEnabled = withFlagOverrides(
   {
-    lwHideSmallValueTokenOperations: {
+    lwdDustFiltering: {
       enabled: true,
-      params: { enabledMobile: false, enabledDesktop: true },
     },
   },
   initialStateWithDustPreferenceEnabled,

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
@@ -107,6 +107,15 @@ const initialStateWithFilterEnabledButNoEvmFamily = (state: State): State => ({
   },
 });
 
+const initialStateWithDustFilterEnabled = (state: State): State => ({
+  ...state,
+  settings: {
+    ...state.settings,
+    filterTokenOperationsZeroAmount: false,
+    hideSmallValueTokenOperations: true,
+  },
+});
+
 describe("useOperationsV1 integration", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -131,5 +140,16 @@ describe("useOperationsV1 integration", () => {
     });
 
     expect(result.current.sections[0].data.length).toBe(2);
+  });
+
+  it("should filter out zero-value token operations when dust filtering is enabled", () => {
+    const accountWithZeroValueTokenOp = createAccountWithZeroValueTokenOperation();
+
+    const { result } = renderHook(() => useOperationsV1([accountWithZeroValueTokenOp], 50), {
+      overrideInitialState: initialStateWithDustFilterEnabled,
+    });
+
+    expect(result.current.sections[0].data.length).toBe(1);
+    expect(result.current.sections[0].data[0].id).toBe("non-zero-value-token-op-id");
   });
 });

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/useOperationsV1.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/useOperationsV1.ts
@@ -7,7 +7,7 @@ import { useSelector } from "~/context/hooks";
 import {
   counterValueCurrencySelector,
   filterTokenOperationsZeroAmountEnabledSelector,
-  hideSmallValueTokenOperationsEnabledSelector,
+  hideSmallValueTokenOperationsEffectiveSelector,
 } from "~/reducers/settings";
 import { countervaluesStateSelector } from "~/reducers/countervalues";
 import { useAddressPoisoningOperationsFamilies } from "@ledgerhq/live-common/hooks/useAddressPoisoningOperationsFamilies";
@@ -26,7 +26,7 @@ export function useOperationsV1(
     filterTokenOperationsZeroAmountEnabledSelector,
   );
   const shouldHideSmallValueTokenOperations = useSelector(
-    hideSmallValueTokenOperationsEnabledSelector,
+    hideSmallValueTokenOperationsEffectiveSelector,
   );
   const countervaluesState = useSelector(state =>
     shouldHideSmallValueTokenOperations ? countervaluesStateSelector(state) : undefined,

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/useOperationsV1.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/useOperationsV1.ts
@@ -9,7 +9,7 @@ import {
   filterTokenOperationsZeroAmountEnabledSelector,
   hideSmallValueTokenOperationsEnabledSelector,
 } from "~/reducers/settings";
-import { useCountervaluesState } from "~/reducers/countervalues";
+import { countervaluesStateSelector } from "~/reducers/countervalues";
 import { useAddressPoisoningOperationsFamilies } from "@ledgerhq/live-common/hooks/useAddressPoisoningOperationsFamilies";
 import { HISTORY_DUST_FILTER_THRESHOLD_USD } from "LLM/features/OperationsHistory/constants";
 
@@ -28,8 +28,12 @@ export function useOperationsV1(
   const shouldHideSmallValueTokenOperations = useSelector(
     hideSmallValueTokenOperationsEnabledSelector,
   );
-  const countervaluesState = useCountervaluesState();
-  const userCounterValueCurrency = useSelector(counterValueCurrencySelector);
+  const countervaluesState = useSelector(state =>
+    shouldHideSmallValueTokenOperations ? countervaluesStateSelector(state) : undefined,
+  );
+  const userCounterValueCurrency = useSelector(state =>
+    shouldHideSmallValueTokenOperations ? counterValueCurrencySelector(state) : undefined,
+  );
 
   const addressPoisoningFamilies = useAddressPoisoningOperationsFamilies({
     shouldFilter: shouldFilterTokenOpsZeroAmount,
@@ -55,6 +59,8 @@ export function useOperationsV1(
 
       if (
         shouldHideSmallValueTokenOperations &&
+        countervaluesState &&
+        userCounterValueCurrency &&
         isSmallValueTokenOperation({
           operation,
           account,

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/useOperationsV1.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/useOperationsV1.ts
@@ -1,10 +1,17 @@
 import { groupAccountsOperationsByDay } from "@ledgerhq/ledger-wallet-framework/account/groupOperations";
 import { isAddressPoisoningOperation } from "@ledgerhq/ledger-wallet-framework/operation";
+import { isSmallValueTokenOperation } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
 import { AccountLike, Operation } from "@ledgerhq/types-live";
 import { useCallback } from "react";
 import { useSelector } from "~/context/hooks";
-import { filterTokenOperationsZeroAmountEnabledSelector } from "~/reducers/settings";
+import {
+  counterValueCurrencySelector,
+  filterTokenOperationsZeroAmountEnabledSelector,
+  hideSmallValueTokenOperationsEnabledSelector,
+} from "~/reducers/settings";
+import { useCountervaluesState } from "~/reducers/countervalues";
 import { useAddressPoisoningOperationsFamilies } from "@ledgerhq/live-common/hooks/useAddressPoisoningOperationsFamilies";
+import { HISTORY_DUST_FILTER_THRESHOLD_USD } from "LLM/features/OperationsHistory/constants";
 
 export type UseOperationsV1Options = {
   filterOperation?: (operation: Operation, account: AccountLike) => boolean;
@@ -18,6 +25,11 @@ export function useOperationsV1(
   const shouldFilterTokenOpsZeroAmount = useSelector(
     filterTokenOperationsZeroAmountEnabledSelector,
   );
+  const shouldHideSmallValueTokenOperations = useSelector(
+    hideSmallValueTokenOperationsEnabledSelector,
+  );
+  const countervaluesState = useCountervaluesState();
+  const userCounterValueCurrency = useSelector(counterValueCurrencySelector);
 
   const addressPoisoningFamilies = useAddressPoisoningOperationsFamilies({
     shouldFilter: shouldFilterTokenOpsZeroAmount,
@@ -39,9 +51,31 @@ export function useOperationsV1(
 
       const shouldFilterOperation = !(shouldFilterTokenOpsZeroAmount && isOperationPoisoned);
 
-      return shouldFilterOperation;
+      if (!shouldFilterOperation) return false;
+
+      if (
+        shouldHideSmallValueTokenOperations &&
+        isSmallValueTokenOperation({
+          operation,
+          account,
+          countervaluesState,
+          userCounterValueCurrency,
+          thresholdUsd: HISTORY_DUST_FILTER_THRESHOLD_USD,
+        })
+      ) {
+        return false;
+      }
+
+      return true;
     },
-    [shouldFilterTokenOpsZeroAmount, addressPoisoningFamilies, externalFilter],
+    [
+      shouldFilterTokenOpsZeroAmount,
+      addressPoisoningFamilies,
+      externalFilter,
+      shouldHideSmallValueTokenOperations,
+      countervaluesState,
+      userCounterValueCurrency,
+    ],
   );
 
   const { sections, completed } = groupAccountsOperationsByDay(accounts, {

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/__tests__/GenerateMockAccounts.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/__tests__/GenerateMockAccounts.test.tsx
@@ -32,6 +32,7 @@ jest.mock("react-native-safe-area-context", () => ({
 }));
 
 jest.mock("@ledgerhq/live-common/currencies/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/currencies/index"),
   listSupportedCurrencies: () => [{ id: "ethereum", ticker: "ETH", name: "Ethereum" }],
 }));
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Ran targeted Jest coverage for history reducer/selectors, `useOperationsV1`, the Operations History view model, and `OperationsList`.
- [x] **Impact of the changes:**
      Mobile operations history dust filtering UI, selector behavior, countervalue subscription gating, and unread-operation computation.

### 📝 Description

Gates the mobile dust filtering behavior behind the dedicated Wallet XP feature flag `lwmDustFiltering`.

When the flag is disabled, the transaction history option is not registered, the setting does not activate filtering, unread operation checks ignore dust filtering, and countervalue recomputations for dust filtering are avoided. When `lwmDustFiltering` is enabled, the existing user setting controls whether small token operations are filtered.

No screenshots.

### ❓ Context

- **JIRA or GitHub link**: LIVE-29299 / https://github.com/LedgerHQ/ledger-live/pull/18952

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
