### PR TITLE
[LWDM] fix(send): translate "To:" prefix in new send flow recipient input

### DIFF
--- a/.changeset/quiet-pugs-relax.md
+++ b/.changeset/quiet-pugs-relax.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Translate the "To:" prefix label in the new Send flow recipient input

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
@@ -100,7 +100,12 @@ export function SendHeader() {
       return (
         <div className="-mt-12 mb-24 px-24">
           <div className="relative">
-            <AddressInput className="w-full" value={addressInputValue} hideClearButton />
+            <AddressInput
+              className="w-full"
+              value={addressInputValue}
+              hideClearButton
+              prefix={t("newSendFlow.to")}
+            />
             <button
               type="button"
               className="absolute inset-0"
@@ -120,6 +125,7 @@ export function SendHeader() {
           id="send-recipient-input"
           data-testid="send-recipient-input"
           autoFocus
+          prefix={t("newSendFlow.to")}
           value={addressInputValue}
           onChange={e => recipientSearch.setValue(e.target.value)}
           onClear={recipientSearch.clear}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -2537,6 +2537,7 @@
   "newSendFlow": {
     "title": "Send {{currency}}",
     "available": "Available {{amount}}",
+    "to": "To:",
     "placeholder": "Enter address or ENS",
     "placeholderNoENS": "Enter address",
     "recent": "Recent",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4456,6 +4456,7 @@
     "newSendFlow": {
       "title": "Send {{currency}}",
       "available": "Available {{amount}}",
+      "to": "To:",
       "placeholder": "Enter address or ENS",
       "placeholderNoENS": "Enter address",
       "pasteFromClipboard": {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/SendHeader.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/SendHeader.tsx
@@ -80,6 +80,7 @@ export function SendHeader({ headerRight }: SendHeaderProps) {
         <View style={styles.addressInputContainer}>
           {viewModel.isRecipientStep ? (
             <AddressInput
+              prefix={t("send.newSendFlow.to")}
               value={viewModel.recipientSearch.value}
               onChangeText={viewModel.recipientSearch.setValue}
               onClear={viewModel.clearRecipientSearch}
@@ -89,6 +90,7 @@ export function SendHeader({ headerRight }: SendHeaderProps) {
           ) : (
             <>
               <AddressInput
+                prefix={t("send.newSendFlow.to")}
                 value={viewModel.formattedAddress}
                 editable={false}
                 hideClearButton


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No automated test added; this is a one-line i18n wiring change (passing an existing `prefix` prop). Verified by typecheck and manual review._
- [x] **Impact of the changes:**
      - New Send flow recipient input on **desktop** (LWD 4.0) and **mobile** (LWM)
      - The "To:" label before the address now uses the `prefix` prop wired to an i18n key
      - Confirm the label renders as "To:" in EN and falls back to EN for locales not yet translated by the translation pipeline

### 📝 Description

The "To:" label rendered before the recipient address in the new Send UI was hardcoded in English. The Lumen `AddressInput` component (both `@ledgerhq/lumen-ui-react` and `@ledgerhq/lumen-ui-rnative`) renders a `prefix` prop that defaults to `"To:"`, but the apps were relying on that default, so the label never got translated.

This PR wires the existing `prefix` prop to a new i18n key (`newSendFlow.to` on desktop, `send.newSendFlow.to` on mobile) in every `AddressInput` usage of the Send header on both platforms. Only the English source files are edited; other locales are populated by the managed translation pipeline (per the i18n README, translations must not be added manually on GitHub).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32907](https://ledgerhq.atlassian.net/browse/LIVE-32907)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32907]: https://ledgerhq.atlassian.net/browse/LIVE-32907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ