### PR TITLE
[LWD] fix(desktop): fix flex onboarding completion confetti positioning

### DIFF
--- a/.changeset/fix-flex-onboarding-confetti.md
+++ b/.changeset/fix-flex-onboarding-confetti.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Flex onboarding completion confetti animation stuck in the top-left corner

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/components/EuropaCompletionView/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompletion/components/EuropaCompletionView/index.tsx
@@ -1,22 +1,42 @@
-import Animation from "~/renderer/animations";
-import { getDeviceAnimation } from "~/renderer/components/DeviceAction/animations";
 import React from "react";
-import { useTheme } from "styled-components";
+import Lottie from "react-lottie";
+import { getEnv } from "@ledgerhq/live-env";
 import { Flex } from "@ledgerhq/react-ui";
 import { DeviceModelId } from "@ledgerhq/types-devices";
+import { useTheme } from "styled-components";
+import { getDeviceAnimation } from "~/renderer/components/DeviceAction/animations";
 import Europa from "../../assets/europa-success.png";
+
+const confettiLayerStyle: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  zIndex: 0,
+  pointerEvents: "none",
+};
 
 export default function EuropaCompletionView() {
   const { theme } = useTheme();
+  const animation = getDeviceAnimation(DeviceModelId.europa, theme, "onboardingSuccess");
+  const isPlaywright = !!getEnv("PLAYWRIGHT_RUN");
 
   return (
     <Flex height="100vh" width="100vw" data-testid="europa-completion-view">
-      <Flex position="fixed">
-        <Animation
-          animation={getDeviceAnimation(DeviceModelId.europa, theme, "onboardingSuccess")}
-          height="100vh"
-          width="100vw"
-        />
+      <Flex style={confettiLayerStyle}>
+        {animation ? (
+          <Lottie
+            style={{ width: "100%", height: "100%" }}
+            isClickToPauseDisabled
+            ariaRole="presentation"
+            options={{
+              loop: true,
+              autoplay: !isPlaywright,
+              animationData: animation,
+              rendererSettings: {
+                preserveAspectRatio: "xMidYMid slice",
+              },
+            }}
+          />
+        ) : null}
       </Flex>
       <Flex alignItems="center" justifyContent="center" style={{ zIndex: 1 }} flex={1}>
         <img src={Europa} alt="Europa" />


### PR DESCRIPTION
### ✅ Checklist
- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No unit test covers EuropaCompletionView confetti layout; manual QA on Flex/Europa sync onboarding completion is required._
- [x] **Impact of the changes:**
  - Flex/Europa sync onboarding completion screen
  - Confetti Lottie animation positioning and full-viewport coverage
  - Playwright/E2E stability (autoplay disabled when `PLAYWRIGHT_RUN` is set)
### 📝 Description
On the Flex (Europa) sync onboarding completion screen, the confetti animation was stuck in the top-left corner instead of covering the full viewport.
**Problem:** The shared `Animation` wrapper did not size/position the Flex `onboardingSuccess` Lottie correctly on this screen.
**Solution:** Render the confetti with `react-lottie` directly in `EuropaCompletionView`, using a fixed full-viewport layer (`100vw`/`100vh`) and `preserveAspectRatio: "xMidYMid slice"` so the animation fills the screen behind the success image.


https://github.com/user-attachments/assets/63a179b8-1bd3-46a5-8662-320ce188ee06


### ❓ Context
- **JIRA or GitHub link**: [LIVE-30731](https://ledgerhq.atlassian.net/browse/LIVE-30731)
---
### 🧐 Checklist for the PR Reviewers
- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30731]: https://ledgerhq.atlassian.net/browse/LIVE-30731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ