### PR TITLE
[LWDM] feat(apps): inject domain crypto-currency registry at bootstrap (LIVE-32900)

### DIFF
--- a/.changeset/live-32900-inject-domain-currencies.md
+++ b/.changeset/live-32900-inject-domain-currencies.md
@@ -1,0 +1,9 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-cli": minor
+"@ledgerhq/wallet-cli": minor
+"@ledgerhq/web-tools": minor
+---
+
+Inject the domain-backed crypto-currency registry (`@domain/entity-currency-crypto`) at app bootstrap via `setCryptoCurrenciesStore`, making the domain registry the runtime source of truth for currency data. The bundled data in `@ledgerhq/cryptoassets` stays as the fallback.

--- a/.changeset/live-32900-keep-currency-aliases.md
+++ b/.changeset/live-32900-keep-currency-aliases.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/cryptoassets": minor
+"@domain/entity-currency-crypto": minor
+---
+
+`setCryptoCurrenciesStore` now accepts an optional `aliases` map (alias key → canonical id) and registers those keys in the injected by-id index, so legacy alias lookups (e.g. `getCryptoCurrencyById("osmosis")`) keep resolving after injection, matching the bundled map. `@domain/entity-currency-crypto` exposes `CRYPTO_CURRENCY_ALIASES` (`osmosis`→`osmo`, `groestlcoin`→`groestcoin`, `lbry`→`LBRY`) for apps to pass at bootstrap.

--- a/.changeset/live-32900-loosen-explorerid.md
+++ b/.changeset/live-32900-loosen-explorerid.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/types-cryptoassets": minor
+"@domain/entity-currency-crypto": minor
+---
+
+Loosen `LedgerExplorerId` to `string` and mark `CryptoCurrency.explorerId` as `@deprecated` (kept only for backward compatibility; the explorer-id concept is being phased out). The domain crypto registry stays assignable to the legacy `CryptoCurrency` type, so it injects via `setCryptoCurrenciesStore` with no cast.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -29,6 +29,7 @@
     "test": "zx ./scripts/test.mjs"
   },
   "dependencies": {
+    "@domain/entity-currency-crypto": "workspace:^",
     "@ledgerhq/coin-bitcoin": "workspace:^",
     "@ledgerhq/coin-module-framework": "catalog:",
     "@ledgerhq/cryptoassets": "workspace:^",

--- a/apps/cli/src/live-common-setup-base.ts
+++ b/apps/cli/src/live-common-setup-base.ts
@@ -6,6 +6,14 @@ import { registerAllCoins } from "@ledgerhq/live-common/coin-modules/load-all-co
 import { setWalletAPIVersion } from "@ledgerhq/live-common/wallet-api/version";
 import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
 import BigNumber from "bignumber.js";
+import { setCryptoCurrenciesStore } from "@ledgerhq/cryptoassets";
+import {
+  CRYPTO_CURRENCIES_REGISTRY,
+  CRYPTO_CURRENCY_ALIASES,
+} from "@domain/entity-currency-crypto";
+
+// The domain registry is the runtime source of truth for currency data.
+setCryptoCurrenciesStore(Object.values(CRYPTO_CURRENCIES_REGISTRY), CRYPTO_CURRENCY_ALIASES);
 
 setWalletAPIVersion(WALLET_API_VERSION);
 

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -60,6 +60,7 @@
     "@braze/web-sdk": "6.4.0",
     "@datadog/browser-logs": "6.30.1",
     "@datadog/browser-rum": "6.30.1",
+    "@domain/entity-currency-crypto": "workspace:*",
     "@electron/fuses": "2.0.0",
     "@features/flow-market-banner": "workspace:^",
     "@features/platform-feature-flags": "workspace:^",

--- a/apps/ledger-live-desktop/src/live-common-setup-base.ts
+++ b/apps/ledger-live-desktop/src/live-common-setup-base.ts
@@ -2,6 +2,14 @@ import os from "os";
 import { setEnv, getEnv } from "@ledgerhq/live-env";
 import { liveBlindSigningReporter } from "@ledgerhq/live-dmk-shared";
 import BigNumber from "bignumber.js";
+import { setCryptoCurrenciesStore } from "@ledgerhq/cryptoassets";
+import {
+  CRYPTO_CURRENCIES_REGISTRY,
+  CRYPTO_CURRENCY_ALIASES,
+} from "@domain/entity-currency-crypto";
+
+// The domain registry is the runtime source of truth for currency data.
+setCryptoCurrenciesStore(Object.values(CRYPTO_CURRENCIES_REGISTRY), CRYPTO_CURRENCY_ALIASES);
 
 let ledgerClientVersion = `lld/${__APP_VERSION__}`;
 

--- a/apps/ledger-live-desktop/tools/rspack/rspack.renderer.ts
+++ b/apps/ledger-live-desktop/tools/rspack/rspack.renderer.ts
@@ -181,6 +181,7 @@ export function createRendererConfig(
             path.resolve(lldRoot, "tools"),
             path.resolve(lldRoot, "..", "..", "features"),
             path.resolve(lldRoot, "..", "..", "shared"),
+            path.resolve(lldRoot, "..", "..", "domain"),
           ],
           exclude: /node_modules/,
           loader: "builtin:swc-loader",

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -88,6 +88,7 @@
     "@braze/react-native-sdk": "18.0.0",
     "@datadog/mobile-react-native": "2.8.2",
     "@datadog/mobile-react-navigation": "2.8.2",
+    "@domain/entity-currency-crypto": "workspace:*",
     "@features/platform-feature-flags": "workspace:^",
     "@formatjs/intl-locale": "3.4.5",
     "@formatjs/intl-pluralrules": "5.2.12",

--- a/apps/ledger-live-mobile/src/live-common-setup.ts
+++ b/apps/ledger-live-mobile/src/live-common-setup.ts
@@ -13,6 +13,14 @@ import { liveBlindSigningReporter } from "@ledgerhq/live-dmk-shared";
 import "./experimental";
 import logger, { ConsoleLogger } from "./logger";
 import BigNumber from "bignumber.js";
+import { setCryptoCurrenciesStore } from "@ledgerhq/cryptoassets";
+import {
+  CRYPTO_CURRENCIES_REGISTRY,
+  CRYPTO_CURRENCY_ALIASES,
+} from "@domain/entity-currency-crypto";
+
+// The domain registry is the runtime source of truth for currency data.
+setCryptoCurrenciesStore(Object.values(CRYPTO_CURRENCIES_REGISTRY), CRYPTO_CURRENCY_ALIASES);
 
 registerAllCoins();
 

--- a/apps/wallet-cli/package.json
+++ b/apps/wallet-cli/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@bunli/core": "0.9.1",
     "@bunli/utils": "0.6.0",
+    "@domain/entity-currency-crypto": "workspace:^",
     "@ledgerhq/coin-bitcoin": "workspace:^",
     "@ledgerhq/coin-evm": "workspace:^",
     "@ledgerhq/coin-module-framework": "catalog:",

--- a/apps/wallet-cli/scripts/check-third-party-notices.mjs
+++ b/apps/wallet-cli/scripts/check-third-party-notices.mjs
@@ -26,7 +26,7 @@ const NON_REDISTRIBUTED = new Set([
 
 // First-party scopes: Ledger-owned workspace packages bundled as source under
 // the same Apache-2.0 license as wallet-cli itself — not third-party.
-const FIRST_PARTY_SCOPES = ["@ledgerhq/", "@shared/"];
+const FIRST_PARTY_SCOPES = ["@ledgerhq/", "@shared/", "@domain/"];
 
 const pkg = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
 const notices = await readFile(path.join(root, "THIRD_PARTY_NOTICES.md"), "utf8");
@@ -39,8 +39,7 @@ const redistributed = [
   ...Object.keys(pkg.devDependencies ?? {}),
 ].filter(name => !NON_REDISTRIBUTED.has(name) && !isFirstParty(name));
 
-const mentionsPackage = name =>
-  notices.includes(`| ${name} |`) || notices.includes(`\`${name}\``);
+const mentionsPackage = name => notices.includes(`| ${name} |`) || notices.includes(`\`${name}\``);
 
 const missing = redistributed.filter(name => !mentionsPackage(name));
 
@@ -49,9 +48,7 @@ if (missing.length > 0) {
   for (const name of missing) {
     console.error(`  - ${name}`);
   }
-  console.error(
-    "\nEach direct dependency declared in apps/wallet-cli/package.json that ships",
-  );
+  console.error("\nEach direct dependency declared in apps/wallet-cli/package.json that ships");
   console.error("inside the published binary must appear in THIRD_PARTY_NOTICES.md,");
   console.error("either as a markdown table row (`| package-name |`) or quoted in");
   console.error("backticks. If the new dep is build-only and not redistributed, add it");
@@ -59,4 +56,6 @@ if (missing.length > 0) {
   process.exit(1);
 }
 
-console.log(`THIRD_PARTY_NOTICES.md covers all ${redistributed.length} redistributed dependencies.`);
+console.log(
+  `THIRD_PARTY_NOTICES.md covers all ${redistributed.length} redistributed dependencies.`,
+);

--- a/apps/wallet-cli/src/live-common-setup.ts
+++ b/apps/wallet-cli/src/live-common-setup.ts
@@ -9,6 +9,11 @@ import { setEnv } from "@ledgerhq/live-env";
 import { registerWalletCliDmkTransport } from "./device/register-dmk-transport";
 import pkg from "../package.json" with { type: "json" };
 import type { CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
+import { setCryptoCurrenciesStore } from "@ledgerhq/cryptoassets";
+import {
+  CRYPTO_CURRENCIES_REGISTRY,
+  CRYPTO_CURRENCY_ALIASES,
+} from "@domain/entity-currency-crypto";
 
 /**
  * Ensure USER_ID is set so DMK firmware distribution salt is stable for this CLI.
@@ -97,6 +102,8 @@ export const WALLET_CLI_SUPPORTED_CRYPTO_CURRENCY_IDS: readonly CryptoCurrencyId
 ];
 
 setWalletAPIVersion(WALLET_API_VERSION);
+// The domain registry is the runtime source of truth for currency data.
+setCryptoCurrenciesStore(Object.values(CRYPTO_CURRENCIES_REGISTRY), CRYPTO_CURRENCY_ALIASES);
 registerCoinModules(walletCliLoaders);
 LiveConfig.setConfig(walletCliConfig);
 // TODO: wallet-cli should own its Redux store setup (createRtkCryptoAssetsStore + RTK middleware)

--- a/apps/web-tools/package.json
+++ b/apps/web-tools/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@devtools/shell": "workspace:*",
+    "@domain/entity-currency-crypto": "workspace:*",
     "@reduxjs/toolkit": "catalog:",
     "@shared/feature-flags": "workspace:*",
     "@features/platform-feature-flags": "workspace:*",

--- a/apps/web-tools/src/live-common-setup.ts
+++ b/apps/web-tools/src/live-common-setup.ts
@@ -5,6 +5,14 @@ import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { liveConfig } from "@ledgerhq/live-common/config/sharedConfig";
 import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
+import { setCryptoCurrenciesStore } from "@ledgerhq/cryptoassets";
+import {
+  CRYPTO_CURRENCIES_REGISTRY,
+  CRYPTO_CURRENCY_ALIASES,
+} from "@domain/entity-currency-crypto";
+
+// The domain registry is the runtime source of truth for currency data.
+setCryptoCurrenciesStore(Object.values(CRYPTO_CURRENCIES_REGISTRY), CRYPTO_CURRENCY_ALIASES);
 
 LiveConfig.setConfig(liveConfig);
 LiveConfig.setAppinfo({

--- a/domain/entity/currency-crypto/src/registry.ts
+++ b/domain/entity/currency-crypto/src/registry.ts
@@ -20,3 +20,15 @@ export const CRYPTO_CURRENCIES_REGISTRY: Record<string, CryptoCurrency> = Object
  * Use this when you need to enumerate or validate against all known currencies.
  */
 export const CRYPTO_CURRENCIES_IDS = Object.values(CRYPTO_CURRENCIES_REGISTRY).map(c => c.id);
+
+/**
+ * Legacy alias keys from `@ledgerhq/cryptoassets` whose source-literal key differs from the
+ * currency `.id` (the bundled map exposes both keys). Passed to `setCryptoCurrenciesStore` next to
+ * the registry so `getCryptoCurrencyById` keeps resolving these aliases after injection. Maps the
+ * alias key to its canonical id.
+ */
+export const CRYPTO_CURRENCY_ALIASES: Record<string, string> = {
+  osmosis: "osmo",
+  groestlcoin: "groestcoin",
+  lbry: "LBRY",
+};

--- a/domain/entity/currency-crypto/src/schema.ts
+++ b/domain/entity/currency-crypto/src/schema.ts
@@ -98,7 +98,10 @@ export const CryptoCurrencySchema = z.object({
   explorerViews: z.array(ExplorerViewSchema),
   /** Ticker displayed on the device (when different from `ticker`). */
   deviceTicker: z.string().optional(),
-  /** Id used to connect to the Ledger explorer endpoint (when different from the currency id and ticker). */
+  /**
+   * Id used to connect to the Ledger explorer endpoint (when different from the currency id and ticker).
+   * @deprecated Kept only for backward compatibility; the explorer-id concept is being phased out.
+   */
   explorerId: z.string().optional(),
   /** Token standards supported by this chain (e.g. `["erc20"]`). */
   tokenTypes: z.array(z.string()).optional(),

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies-store.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies-store.test.ts
@@ -94,3 +94,24 @@ describe("currencies-store: store injected", () => {
     expect(getCryptoCurrencyById("bitcoin")).toMatchObject({ id: "bitcoin" });
   });
 });
+
+describe("currencies-store: alias keys", () => {
+  afterEach(clearInjectedStore);
+
+  it("registers a valid alias so getCryptoCurrencyById resolves it to the canonical currency", () => {
+    setCryptoCurrenciesStore(injectedCurrencies, { [`${prodActive.id}_alias`]: prodActive.id });
+    expect(getCryptoCurrencyById(`${prodActive.id}_alias`)).toBe(prodActive);
+  });
+
+  it("throws when an alias points to an unknown currency id (fail fast)", () => {
+    expect(() => setCryptoCurrenciesStore(injectedCurrencies, { foo: "does_not_exist" })).toThrow(
+      'alias "foo" points to unknown currency id "does_not_exist"',
+    );
+  });
+
+  it("throws when an alias collides with an existing currency id", () => {
+    expect(() =>
+      setCryptoCurrenciesStore(injectedCurrencies, { [prodActive.id]: prodActive2.id }),
+    ).toThrow(`alias "${prodActive.id}" collides with an existing currency id`);
+  });
+});

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies-store.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies-store.ts
@@ -82,15 +82,40 @@ function buildCryptoCurrenciesStore(currencies: CryptoCurrency[]): CryptoCurrenc
  * Injects the crypto-currency registry from the canonical currency list.
  * This should be called once during application initialization.
  *
- * The caller only provides the currencies; the by-id/ticker/scheme indices and the
- * dev/prod arrays are derived here so they stay consistent by construction.
+ * The caller provides the currencies; the by-id/ticker/scheme indices and the dev/prod arrays are
+ * derived here so they stay consistent by construction. `aliases` maps a legacy alias key to a
+ * canonical id (e.g. `{ osmosis: "osmo" }`) so id lookups by that alias keep resolving, as they do
+ * against the bundled map which exposes the same legacy aliases.
  *
  * Uses globalThis to ensure a single shared reference across all module instances,
  * which is critical when coin-modules are lazy-loaded and may resolve to separate
  * module copies.
  */
-export function setCryptoCurrenciesStore(currencies: CryptoCurrency[]): void {
-  globalThis.__ledgerCryptoCurrenciesStore = buildCryptoCurrenciesStore(currencies);
+export function setCryptoCurrenciesStore(
+  currencies: CryptoCurrency[],
+  aliases: Record<string, string> = {},
+): void {
+  const store = buildCryptoCurrenciesStore(currencies);
+  for (const [alias, id] of Object.entries(aliases)) {
+    // Fail fast on a misconfigured alias map at injection time, rather than silently dropping it and
+    // letting a later getCryptoCurrencyById(alias) throw an opaque "not found" at runtime.
+    const currency = store.cryptocurrenciesById[id];
+    if (!currency) {
+      throw new Error(
+        `setCryptoCurrenciesStore: alias "${alias}" points to unknown currency id "${id}"`,
+      );
+    }
+    // The by-id map is null-prototype and only ever holds defined currencies, so a direct read is a
+    // safe own-key existence check (no prototype traversal) — and avoids Object.hasOwn, which needs a
+    // newer lib target than this package compiles against.
+    if (store.cryptocurrenciesById[alias]) {
+      throw new Error(
+        `setCryptoCurrenciesStore: alias "${alias}" collides with an existing currency id`,
+      );
+    }
+    store.cryptocurrenciesById[alias] = currency;
+  }
+  globalThis.__ledgerCryptoCurrenciesStore = store;
 }
 
 /**

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.domain-parity.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.domain-parity.test.ts
@@ -1,8 +1,13 @@
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import { CRYPTO_CURRENCIES_REGISTRY } from "@domain/entity-currency-crypto";
 import {
+  CRYPTO_CURRENCIES_REGISTRY,
+  CRYPTO_CURRENCY_ALIASES,
+} from "@domain/entity-currency-crypto";
+import {
+  cryptocurrenciesById,
   findCryptoCurrencyByScheme,
   findCryptoCurrencyByTicker,
+  getCryptoCurrencyById,
   listCryptoCurrencies,
 } from "./currencies";
 import { setCryptoCurrenciesStore } from "./currencies-store";
@@ -39,6 +44,17 @@ describe("@domain/entity-currency-crypto parity with @ledgerhq/cryptoassets", ()
 
   it.each(sortedLegacyIds)("matches the legacy definition for %s", id => {
     expect(CRYPTO_CURRENCIES_REGISTRY[id]).toEqual(legacyById.get(id));
+  });
+
+  // The bundled map exposes a few legacy alias keys (source-literal key ≠ .id, e.g. "osmosis" → osmo).
+  // CRYPTO_CURRENCY_ALIASES must mirror them so the injected store keeps resolving those keys.
+  it("CRYPTO_CURRENCY_ALIASES mirrors the legacy bundled alias keys", () => {
+    const legacyAliases = Object.fromEntries(
+      Object.entries(cryptocurrenciesById)
+        .filter(([key, currency]) => key !== currency.id)
+        .map(([key, currency]) => [key, currency.id]),
+    );
+    expect(CRYPTO_CURRENCY_ALIASES).toEqual(legacyAliases);
   });
 });
 
@@ -99,4 +115,26 @@ describe("lookup parity: bundled store vs injected domain array", () => {
       }
     });
   });
+});
+
+// Guards the injection contract used by every app's bootstrap (`setCryptoCurrenciesStore(
+// Object.values(CRYPTO_CURRENCIES_REGISTRY), CRYPTO_CURRENCY_ALIASES)`): once injected, the store
+// has no per-key fallback, so `getCryptoCurrencyById` must resolve every id — and every alias — or
+// it throws. This is the guard against the alias-key regression class (e.g. legacy "osmosis" → osmo).
+describe("getCryptoCurrencyById over the injected domain registry", () => {
+  beforeEach(() =>
+    setCryptoCurrenciesStore(Object.values(CRYPTO_CURRENCIES_REGISTRY), CRYPTO_CURRENCY_ALIASES),
+  );
+  afterEach(clearInjectedStore);
+
+  it.each(sortedLegacyIds)("resolves %s to the domain object", id => {
+    expect(getCryptoCurrencyById(id)).toBe(CRYPTO_CURRENCIES_REGISTRY[id]);
+  });
+
+  it.each(Object.entries(CRYPTO_CURRENCY_ALIASES))(
+    "resolves legacy alias %s to its canonical currency",
+    (alias, id) => {
+      expect(getCryptoCurrencyById(alias)).toBe(CRYPTO_CURRENCIES_REGISTRY[id]);
+    },
+  );
 });

--- a/libs/ledgerjs/packages/types-cryptoassets/src/index.ts
+++ b/libs/ledgerjs/packages/types-cryptoassets/src/index.ts
@@ -2,32 +2,11 @@ import { CoinType } from "./slip44";
 
 export type CryptoCurrencyId = string;
 
-export type LedgerExplorerId =
-  | "btc"
-  | "btc_testnet"
-  | "bch"
-  | "btg"
-  | "club"
-  | "dash"
-  | "dcr"
-  | "dgb"
-  | "doge"
-  | "hsr"
-  | "kmd"
-  | "ltc"
-  | "posw"
-  | "qtum"
-  | "strat"
-  | "zec"
-  | "zen"
-  | "avax"
-  | "eth"
-  | "eth_sepolia"
-  | "eth_hoodi"
-  | "etc"
-  | "matic"
-  | "matic_amoy"
-  | "bnb";
+/**
+ * @deprecated Opaque Ledger-explorer endpoint id, kept only for backward compatibility.
+ * Loosened from a fixed union to `string`; the explorer-id concept is being phased out.
+ */
+export type LedgerExplorerId = string;
 
 /**
  *
@@ -139,7 +118,10 @@ export type CryptoCurrency = CurrencyCommon & {
   ethereumLikeInfo?: EthereumLikeInfo;
   explorerViews: ExplorerView[];
   deviceTicker?: string;
-  // Used to connect to the right endpoint url since it is different from currencyId and ticker
+  /**
+   * Used to connect to the right endpoint url since it is different from currencyId and ticker.
+   * @deprecated Kept only for backward compatibility; the explorer-id concept is being phased out.
+   */
   explorerId?: LedgerExplorerId;
   tokenTypes?: string[];
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -673,6 +673,9 @@ importers:
 
   apps/cli:
     dependencies:
+      '@domain/entity-currency-crypto':
+        specifier: workspace:^
+        version: link:../../domain/entity/currency-crypto
       '@ledgerhq/coin-bitcoin':
         specifier: workspace:^
         version: link:../../libs/coin-modules/coin-bitcoin
@@ -904,6 +907,9 @@ importers:
       '@datadog/browser-rum':
         specifier: 6.30.1
         version: 6.30.1(@datadog/browser-logs@6.30.1)
+      '@domain/entity-currency-crypto':
+        specifier: workspace:*
+        version: link:../../domain/entity/currency-crypto
       '@electron/fuses':
         specifier: 2.0.0
         version: 2.0.0
@@ -1560,6 +1566,9 @@ importers:
       '@datadog/mobile-react-navigation':
         specifier: 2.8.2
         version: 2.8.2(@datadog/mobile-react-native@2.8.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@domain/entity-currency-crypto':
+        specifier: workspace:*
+        version: link:../../domain/entity/currency-crypto
       '@features/platform-feature-flags':
         specifier: workspace:^
         version: link:../../features/platform/feature-flags
@@ -2326,6 +2335,9 @@ importers:
       '@bunli/utils':
         specifier: 0.6.0
         version: 0.6.0
+      '@domain/entity-currency-crypto':
+        specifier: workspace:^
+        version: link:../../domain/entity/currency-crypto
       '@ledgerhq/coin-bitcoin':
         specifier: workspace:^
         version: link:../../libs/coin-modules/coin-bitcoin
@@ -2479,6 +2491,9 @@ importers:
       '@devtools/shell':
         specifier: workspace:*
         version: link:../../devtools/shell
+      '@domain/entity-currency-crypto':
+        specifier: workspace:*
+        version: link:../../domain/entity/currency-crypto
       '@features/platform-feature-flags':
         specifier: workspace:*
         version: link:../../features/platform/feature-flags


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** A guard test in `currencies.domain-parity.test.ts` injects the real domain array and asserts `getCryptoCurrencyById` resolves **every** id to the domain object; combined with #18933's ambiguous-ticker / scheme parity tests this covers the injected-store lookup path. The `"osmosis"` → `"osmo"` production fix (`coin-modules/registry.ts:21` over the cosmos loader `supportedCoins`) is covered transitively (`getCryptoCurrencyById("osmo")` resolves under injection). _Not_ in this PR: full functional e2e / app-boot — see QA focus below.
- [ ] **Impact of the changes:**
  - The runtime source of truth for crypto-currency **data** in all 5 apps switches from the bundled `@ledgerhq/cryptoassets` registry to `@domain/entity-currency-crypto` (values are parity-tested equal; bundled stays as fallback). **QA focus:** app bootstrap (no throw at `registerAllCoins()`), currency lists, add-account search, token accounts, send/receive (BTC + an EVM token), and countervalues for ambiguous tickers (ETH/BNB/DOT/XTZ/CRO).
  
### E2E run after merge
- https://github.com/LedgerHQ/ledger-live/actions/runs/28428767451
- https://github.com/LedgerHQ/ledger-live/actions/runs/28428777114

### 📝 Description

PR2 of the currency service-locator thread. [LIVE-32899](https://ledgerhq.atlassian.net/browse/LIVE-32899) made the `@ledgerhq/cryptoassets` currency registry injectable (accessors read `getInjectedCurrenciesStore() ?? bundledCurrenciesStore`). Until now nothing injected, so every app ran on the bundled data. This PR makes each app inject the **domain** registry at bootstrap, so the runtime source of truth for currency data becomes domain — the bundled data remains as the fallback and is kept iso by the LIVE-31915 parity test.

**What changed**

- **Injection (5 apps).** `setCryptoCurrenciesStore(Object.values(CRYPTO_CURRENCIES_REGISTRY) as unknown as CryptoCurrency[])` added at each app's `live-common-setup*.ts` bootstrap, before `registerAllCoins()` / `registerCoinModules()`:
  - desktop → `src/live-common-setup-base.ts` (shared by main + renderer)
  - mobile → `src/live-common-setup.ts`
  - cli → `src/live-common-setup-base.ts`
  - wallet-cli → `src/live-common-setup.ts`
  - web-tools → `src/live-common-setup.ts`
  - plus `@domain/entity-currency-crypto` added to each app's `package.json`.
  - _Note:_ not `config/bridge-setup.ts` (only desktop+mobile have it; it's the redux-coupled CAL **token** store, called late). `live-common-setup*.ts` exists for all 5 and runs early.
- **Type bridge.** The cast is required: legacy `coinType` is a real `enum CoinType` and `explorerId` a `LedgerExplorerId` union, so the domain type is structurally wider, not assignable. Values are parity-guaranteed, so the cast is sound.
- **Alias-key fix.** Once injected, `getCryptoCurrencyById` resolves only by canonical `.id` (no per-key fallback). The legacy alias `"osmosis"` (canonical id `"osmo"`) was migrated at 3 sites — most importantly the **production** path `libs/ledger-live-common/src/coin-modules/registry.ts:21`, which resolves every loader's `supportedCoins` through `getCryptoCurrencyById` at `registerAllCoins()` and would otherwise throw. `groestlcoin`/`lbry` aliases are never used as lookup keys, so they needed no change.

**Verification:** 5-app typecheck green; `pnpm lint:boundaries` green (apps may depend on `@domain/*`); cryptoassets parity/guard suite 423 pass.

> ⚠️ **Stacked on #18933 — do not merge yet.** This branch is based on [#18933](https://github.com/LedgerHQ/ledger-live/pull/18933) ([LIVE-33115](https://ledgerhq.atlassian.net/browse/LIVE-33115), order-independent `findCryptoCurrencyByTicker`). Without that fix, injecting the alphabetical domain array flips 5 ambiguous tickers. **Do not merge until #18933 lands in `develop`; then rebase onto `develop`** (the #18933 commits will drop out of this diff once it merges).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32900](https://ledgerhq.atlassian.net/browse/LIVE-32900) · depends on [LIVE-33115](https://ledgerhq.atlassian.net/browse/LIVE-33115) ([#18933](https://github.com/LedgerHQ/ledger-live/pull/18933)) · parent epic [LIVE-31901](https://ledgerhq.atlassian.net/browse/LIVE-31901)
- **ADR link (if any)**: n/a


[LIVE-32899]: https://ledgerhq.atlassian.net/browse/LIVE-32899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ