### PR TITLE
[LWD] feat(lld): add desktop known devices store

### DIFF
--- a/.changeset/connect-device-known-devices-store.md
+++ b/.changeset/connect-device-known-devices-store.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add a desktop known devices store: a persisted `knownDevices` reducer (seeded on settings load from `lastSeenDevice` / `lastOnboardedDevice`, upserted from device sources, deduped per model id) using the shared `KnownDevice` shape, with WebHID serialization helpers for robust persistence.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -279,6 +279,8 @@ apps/ledger-live-mobile/src/components/BleDevicePairingFlow/       @ledgerhq/liv
 **/BleDevicePairing*                                               @ledgerhq/live-devices
 apps/ledger-live-mobile/src/reducers/knownDevices.ts               @ledgerhq/live-devices
 apps/ledger-live-mobile/src/reducers/__tests__/knownDevices.test.ts @ledgerhq/live-devices
+apps/ledger-live-desktop/src/renderer/reducers/knownDevices.ts     @ledgerhq/live-devices
+apps/ledger-live-desktop/src/renderer/reducers/knownDevices.test.ts @ledgerhq/live-devices
 apps/ledger-live-mobile/src/transport/                             @ledgerhq/live-devices
 apps/ledger-live-mobile/src/react-native-hw-transport-ble/         @ledgerhq/live-devices
 apps/ledger-live-mobile/src/screens/FirmwareUpdate/                @ledgerhq/live-devices

--- a/apps/ledger-live-desktop/src/main/db/index.test.ts
+++ b/apps/ledger-live-desktop/src/main/db/index.test.ts
@@ -98,16 +98,23 @@ describe("db (app namespace allow list + keepLegacy)", () => {
     await expect(db.setKey("app", "settings.deep", { x: 1 })).resolves.toBeUndefined();
   });
 
+  it("allows knownDevices persistence", async () => {
+    readFileMock.mockResolvedValueOnce(appJson({}));
+    await expect(db.setKey("app", "knownDevices", { knownDevices: [] })).resolves.toBeUndefined();
+  });
+
   it("preserves allowed and keepLegacy keys on load", async () => {
     readFileMock.mockResolvedValueOnce(
       appJson({
         settings: { a: 1 },
         identities: { userId: "u" },
+        knownDevices: { knownDevices: [] },
         user: { id: "legacy" },
       }),
     );
     expect(await db.getKey("app", "settings", undefined)).toEqual({ a: 1 });
     expect(await db.getKey("app", "identities", undefined)).toEqual({ userId: "u" });
+    expect(await db.getKey("app", "knownDevices", undefined)).toEqual({ knownDevices: [] });
     expect(await db.getKey("app", "user", undefined)).toEqual({ id: "legacy" });
   });
 

--- a/apps/ledger-live-desktop/src/main/db/index.ts
+++ b/apps/ledger-live-desktop/src/main/db/index.ts
@@ -58,6 +58,7 @@ const APP_NAMESPACE_ALLOWED_KEY_PATHS: ReadonlySet<string> = new Set([
   "wallet",
   "market",
   "marketBanner",
+  "knownDevices",
   "cryptoAssets",
   "identities",
   "featureFlags",

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -52,6 +52,7 @@ import { listCachedCurrencyIds } from "./bridge/cache";
 import { LogEntry } from "winston";
 import { importMarketState } from "./actions/market";
 import { importMarketBannerState } from "./reducers/marketBanner";
+import { importKnownDevices, mapPersistedKnownDeviceToKnownDevice } from "./reducers/knownDevices";
 import { fetchWallet } from "./actions/wallet";
 import { fetchTrustchain } from "./actions/trustchain";
 import { setupRecentAddressesStore } from "./recentAddresses";
@@ -210,6 +211,20 @@ async function init() {
 
   if (deepLinkUrl) {
     settingsToLoad.deepLinkUrl = deepLinkUrl;
+  }
+
+  // Hydrate persisted known devices before settings so the settings-based
+  // migration only seeds the store for first-time users (empty known devices).
+  const persistedKnownDevices = await getKey("app", "knownDevices");
+  if (persistedKnownDevices?.knownDevices?.length) {
+    store.dispatch(
+      importKnownDevices({
+        knownDevices: persistedKnownDevices.knownDevices.flatMap(device => {
+          const knownDevice = mapPersistedKnownDeviceToKnownDevice(device);
+          return knownDevice ? [knownDevice] : [];
+        }),
+      }),
+    );
   }
 
   fetchSettings(settingsToLoad)(store.dispatch);

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -26,6 +26,7 @@ import {
 
 import { marketStoreSelector } from "../reducers/market";
 import { marketBannerStoreSelector } from "../reducers/marketBanner";
+import { knownDevicesStoreSelector } from "../reducers/knownDevices";
 import { exportIdentitiesForPersistence } from "@ledgerhq/client-ids/store";
 import { accountsPersistedStateChanged } from "@ledgerhq/live-common/account/index";
 
@@ -151,6 +152,10 @@ const DBMiddleware: Middleware<object, State> = store => next => action => {
 
   if (oldState.history !== newState.history) {
     setKey("app", "history", newState.history);
+  }
+
+  if (oldState.knownDevices !== newState.knownDevices) {
+    setKey("app", "knownDevices", knownDevicesStoreSelector(newState));
   }
 
   if (

--- a/apps/ledger-live-desktop/src/renderer/reducers/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/index.ts
@@ -42,6 +42,7 @@ import genericAwarenessModal, {
   GenericAwarenessModalSliceState,
 } from "./genericAwarenessModalSlice";
 import coinConfigOverrides, { CoinConfigOverridesState } from "./coinConfigOverrides";
+import knownDevices, { KnownDevicesState } from "./knownDevices";
 
 export type State = LLDRTKApiState & {
   accounts: AccountsState;
@@ -75,6 +76,7 @@ export type State = LLDRTKApiState & {
   recoverState: RecoverStateSliceState;
   genericAwarenessModal: GenericAwarenessModalSliceState;
   coinConfigOverrides: CoinConfigOverridesState;
+  knownDevices: KnownDevicesState;
 };
 
 const appReducer = combineReducers({
@@ -109,6 +111,7 @@ const appReducer = combineReducers({
   recoverState: recoverStateReducer,
   genericAwarenessModal,
   coinConfigOverrides,
+  knownDevices,
   ...lldRTKApiReducers,
   ...(getEnv("PLAYWRIGHT_RUN") && { lastAction: (_: unknown, action: PayloadAction) => action }),
 });

--- a/apps/ledger-live-desktop/src/renderer/reducers/knownDevices.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/knownDevices.test.ts
@@ -1,0 +1,322 @@
+import { DeviceModelId } from "@ledgerhq/devices";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import type { DeviceInfo, DeviceModelInfo } from "@ledgerhq/types-live";
+import reducer, {
+  INITIAL_STATE,
+  WEB_HID_TRANSPORT_IDENTIFIER,
+  importKnownDevices,
+  knownDevicesSelector,
+  knownDevicesStoreSelector,
+  mapKnownDeviceToPersistedKnownDevice,
+  mapPersistedKnownDeviceToKnownDevice,
+  type KnownDevicesState,
+  type PersistedKnownDevice,
+} from "./knownDevices";
+import type { KnownDevice } from "@ledgerhq/live-dmk-shared";
+import type { State } from "./index";
+
+const makeLastSeenDevice = (modelId: DeviceModelId): DeviceModelInfo => ({
+  modelId,
+  deviceInfo: {} as DeviceInfo,
+  apps: [],
+});
+
+const makeDevice = (overrides: Partial<Device> = {}): Device => ({
+  deviceId: "device-id",
+  deviceName: "My Ledger",
+  modelId: DeviceModelId.stax,
+  wired: true,
+  ...overrides,
+});
+
+const fetchSettings = (payload: Record<string, unknown>) => ({ type: "FETCH_SETTINGS", payload });
+const lastSeenDeviceInfo = (modelId: DeviceModelId) => ({
+  type: "LAST_SEEN_DEVICE_INFO",
+  payload: { lastSeenDevice: makeLastSeenDevice(modelId) },
+});
+const setLastOnboardedDevice = (payload: Device | null) => ({
+  type: "SET_LAST_ONBOARDED_DEVICE",
+  payload,
+});
+const addDevice = (payload: Device) => ({ type: "ADD_DEVICE", payload });
+
+describe("knownDevices reducer", () => {
+  it("normalizes known devices as web-hid", () => {
+    expect(WEB_HID_TRANSPORT_IDENTIFIER).toBe("web-hid");
+  });
+
+  it("starts empty", () => {
+    expect(reducer(undefined, { type: "@@INIT" })).toEqual(INITIAL_STATE);
+  });
+
+  describe("migration on settings fetch", () => {
+    it("seeds from lastSeenDevice when empty", () => {
+      const state = reducer(
+        INITIAL_STATE,
+        fetchSettings({ lastSeenDevice: makeLastSeenDevice(DeviceModelId.stax) }),
+      );
+      expect(state.knownDevices).toEqual([
+        {
+          transport: WEB_HID_TRANSPORT_IDENTIFIER,
+          deviceModelId: DeviceModelId.stax,
+          id: "",
+          name: null,
+        },
+      ]);
+    });
+
+    it("falls back to lastOnboardedDevice when lastSeenDevice is missing", () => {
+      const state = reducer(
+        INITIAL_STATE,
+        fetchSettings({
+          lastSeenDevice: null,
+          lastOnboardedDevice: makeDevice({
+            modelId: DeviceModelId.europa,
+            deviceName: "My Flex",
+          }),
+        }),
+      );
+      expect(state.knownDevices).toEqual([
+        {
+          transport: WEB_HID_TRANSPORT_IDENTIFIER,
+          deviceModelId: DeviceModelId.europa,
+          id: "",
+          name: "My Flex",
+        },
+      ]);
+    });
+
+    it("prefers lastSeenDevice over lastOnboardedDevice", () => {
+      const state = reducer(
+        INITIAL_STATE,
+        fetchSettings({
+          lastSeenDevice: makeLastSeenDevice(DeviceModelId.stax),
+          lastOnboardedDevice: makeDevice({ modelId: DeviceModelId.europa }),
+        }),
+      );
+      expect(state.knownDevices).toHaveLength(1);
+      expect(state.knownDevices[0].deviceModelId).toBe(DeviceModelId.stax);
+    });
+
+    it("does nothing when both sources are null", () => {
+      const state = reducer(
+        INITIAL_STATE,
+        fetchSettings({ lastSeenDevice: null, lastOnboardedDevice: null }),
+      );
+      expect(state.knownDevices).toEqual([]);
+    });
+
+    it("does not seed when known devices already exist", () => {
+      const seeded: KnownDevicesState = {
+        knownDevices: [
+          {
+            transport: WEB_HID_TRANSPORT_IDENTIFIER,
+            deviceModelId: DeviceModelId.europa,
+            id: "",
+            name: null,
+          },
+        ],
+      };
+      const state = reducer(
+        seeded,
+        fetchSettings({ lastSeenDevice: makeLastSeenDevice(DeviceModelId.stax) }),
+      );
+      expect(state.knownDevices).toEqual(seeded.knownDevices);
+    });
+  });
+
+  describe("upsert", () => {
+    it("upserts on lastSeenDevice change", () => {
+      const state = reducer(INITIAL_STATE, lastSeenDeviceInfo(DeviceModelId.stax));
+      expect(state.knownDevices).toEqual([
+        {
+          transport: WEB_HID_TRANSPORT_IDENTIFIER,
+          deviceModelId: DeviceModelId.stax,
+          id: "",
+          name: null,
+        },
+      ]);
+    });
+
+    it("upserts on lastOnboardedDevice change", () => {
+      const state = reducer(
+        INITIAL_STATE,
+        setLastOnboardedDevice(makeDevice({ modelId: DeviceModelId.europa, deviceName: "Flex" })),
+      );
+      expect(state.knownDevices).toEqual([
+        {
+          transport: WEB_HID_TRANSPORT_IDENTIFIER,
+          deviceModelId: DeviceModelId.europa,
+          id: "",
+          name: "Flex",
+        },
+      ]);
+    });
+
+    it("upserts on current device change", () => {
+      const state = reducer(
+        INITIAL_STATE,
+        addDevice(makeDevice({ modelId: DeviceModelId.stax, deviceName: "Stax" })),
+      );
+      expect(state.knownDevices).toEqual([
+        {
+          transport: WEB_HID_TRANSPORT_IDENTIFIER,
+          deviceModelId: DeviceModelId.stax,
+          id: "",
+          name: "Stax",
+        },
+      ]);
+    });
+
+    it("dedupes by device model id", () => {
+      let state = reducer(INITIAL_STATE, addDevice(makeDevice({ modelId: DeviceModelId.stax })));
+      state = reducer(state, lastSeenDeviceInfo(DeviceModelId.stax));
+      state = reducer(state, addDevice(makeDevice({ modelId: DeviceModelId.europa })));
+      expect(state.knownDevices.map(d => d.deviceModelId)).toEqual([
+        DeviceModelId.stax,
+        DeviceModelId.europa,
+      ]);
+    });
+
+    it("keeps a previously known name when the new source has none", () => {
+      let state = reducer(
+        INITIAL_STATE,
+        addDevice(makeDevice({ modelId: DeviceModelId.stax, deviceName: "My Stax" })),
+      );
+      // lastSeenDevice carries no name; the existing name must be preserved.
+      state = reducer(state, lastSeenDeviceInfo(DeviceModelId.stax));
+      expect(state.knownDevices[0].name).toBe("My Stax");
+    });
+  });
+
+  describe("null sources", () => {
+    it("never removes known devices when lastOnboardedDevice becomes null", () => {
+      const seeded: KnownDevicesState = {
+        knownDevices: [
+          {
+            transport: WEB_HID_TRANSPORT_IDENTIFIER,
+            deviceModelId: DeviceModelId.stax,
+            id: "",
+            name: null,
+          },
+        ],
+      };
+      const state = reducer(seeded, setLastOnboardedDevice(null));
+      expect(state.knownDevices).toEqual(seeded.knownDevices);
+    });
+  });
+
+  describe("import", () => {
+    it("replaces the state with the persisted known devices", () => {
+      const persisted: KnownDevicesState = {
+        knownDevices: [
+          {
+            transport: WEB_HID_TRANSPORT_IDENTIFIER,
+            deviceModelId: DeviceModelId.europa,
+            id: "",
+            name: "Flex",
+          },
+        ],
+      };
+      const state = reducer(INITIAL_STATE, importKnownDevices(persisted));
+      expect(state).toEqual(persisted);
+    });
+  });
+
+  describe("selector", () => {
+    it("returns the known devices from the root state", () => {
+      const knownDevices = [
+        {
+          transport: WEB_HID_TRANSPORT_IDENTIFIER,
+          deviceModelId: DeviceModelId.stax,
+          id: "",
+          name: null,
+        },
+      ];
+      expect(knownDevicesSelector({ knownDevices: { knownDevices } } as State)).toEqual(
+        knownDevices,
+      );
+    });
+  });
+
+  describe("serialization", () => {
+    const webHidKnownDevice: KnownDevice = {
+      transport: WEB_HID_TRANSPORT_IDENTIFIER,
+      deviceModelId: DeviceModelId.stax,
+      id: "",
+      name: "My Stax",
+    };
+
+    describe("mapKnownDeviceToPersistedKnownDevice", () => {
+      it("persists a web-hid device using the stable transport code", () => {
+        expect(mapKnownDeviceToPersistedKnownDevice(webHidKnownDevice)).toEqual({
+          ...webHidKnownDevice,
+          transport: "webhid",
+        });
+      });
+
+      it("returns null for an unsupported transport", () => {
+        const device = { ...webHidKnownDevice, transport: "httpdebug" } as KnownDevice;
+        expect(mapKnownDeviceToPersistedKnownDevice(device)).toBeNull();
+      });
+    });
+
+    describe("mapPersistedKnownDeviceToKnownDevice", () => {
+      it("hydrates a persisted web-hid device to the runtime transport identifier", () => {
+        const persisted: PersistedKnownDevice = {
+          transport: "webhid",
+          deviceModelId: DeviceModelId.europa,
+          id: "",
+          name: "Flex",
+        };
+        expect(mapPersistedKnownDeviceToKnownDevice(persisted)).toEqual({
+          transport: WEB_HID_TRANSPORT_IDENTIFIER,
+          deviceModelId: DeviceModelId.europa,
+          id: "",
+          name: "Flex",
+        });
+      });
+
+      it("returns null for an unknown persisted transport code", () => {
+        const device = {
+          transport: "unsupported",
+          deviceModelId: DeviceModelId.stax,
+          id: "",
+          name: null,
+        };
+        expect(mapPersistedKnownDeviceToKnownDevice(device)).toBeNull();
+      });
+    });
+
+    describe("knownDevicesStoreSelector (export)", () => {
+      it("exports supported devices with their stable transport code", () => {
+        const state = { knownDevices: { knownDevices: [webHidKnownDevice] } } as State;
+        expect(knownDevicesStoreSelector(state)).toEqual({
+          knownDevices: [{ ...webHidKnownDevice, transport: "webhid" }],
+        });
+      });
+
+      it("drops devices with unsupported transports", () => {
+        const state = {
+          knownDevices: {
+            knownDevices: [
+              webHidKnownDevice,
+              { ...webHidKnownDevice, transport: "httpdebug" } as KnownDevice,
+            ],
+          },
+        } as State;
+        expect(knownDevicesStoreSelector(state)).toEqual({
+          knownDevices: [{ ...webHidKnownDevice, transport: "webhid" }],
+        });
+      });
+    });
+
+    it("round-trips a web-hid device through export and import", () => {
+      const persisted = mapKnownDeviceToPersistedKnownDevice(webHidKnownDevice);
+      expect(persisted).not.toBeNull();
+      expect(mapPersistedKnownDeviceToKnownDevice(persisted as PersistedKnownDevice)).toEqual(
+        webHidKnownDevice,
+      );
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/reducers/knownDevices.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/knownDevices.ts
@@ -1,0 +1,176 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import type { DeviceModelId } from "@ledgerhq/types-devices";
+import type { DeviceModelInfo } from "@ledgerhq/types-live";
+import type { KnownDevice } from "@ledgerhq/live-dmk-shared";
+import type { State } from "./index";
+import type { SettingsState } from "./settings";
+
+/**
+ * Transport identifier used by the DMK WebHID transport (`webHidIdentifier`).
+ * Desktop only connects over WebHID, so all known devices use this transport.
+ */
+export const WEB_HID_TRANSPORT_IDENTIFIER: KnownDevice["transport"] = "web-hid";
+
+export type KnownDevicesState = {
+  knownDevices: KnownDevice[];
+};
+
+/**
+ * Stable, persisted transport codes. They decouple the on-disk format from the
+ * DMK transport identifier strings (e.g. `webHidIdentifier`) so persisted data
+ * survives a change of those identifiers. Add a new code here for each new
+ * supported transport (e.g. `"webble"`).
+ */
+export type PersistedKnownDeviceTransport = "webhid";
+
+export type PersistedKnownDevice = Omit<KnownDevice, "transport"> & {
+  transport: PersistedKnownDeviceTransport;
+};
+
+export type PersistedKnownDevicesState = {
+  knownDevices: PersistedKnownDevice[];
+};
+
+export const INITIAL_STATE: KnownDevicesState = {
+  knownDevices: [],
+};
+
+/**
+ * On desktop, devices connect over WebHID, which does not expose a stable per-device
+ * identifier we want to persist. A known device is therefore normalized as a WebHID
+ * device with an empty `id` and is uniquely identified by its `deviceModelId`.
+ */
+function mapToWebHidKnownDevice(
+  deviceModelId: DeviceModelId,
+  name: string | null = null,
+): KnownDevice {
+  return {
+    transport: WEB_HID_TRANSPORT_IDENTIFIER,
+    deviceModelId,
+    id: "",
+    name,
+  };
+}
+
+export function mapLastSeenDeviceToKnownDevice(
+  device: DeviceModelInfo | null | undefined,
+): KnownDevice | null {
+  if (!device) return null;
+  return mapToWebHidKnownDevice(device.modelId);
+}
+
+export function mapDeviceToKnownDevice(device: Device | null | undefined): KnownDevice | null {
+  if (!device) return null;
+  return mapToWebHidKnownDevice(device.modelId, device.deviceName ?? null);
+}
+
+/**
+ * Serialize a runtime known device for persistence. Returns `null` for any
+ * transport that cannot be persisted, so unknown transports are dropped on save.
+ */
+export function mapKnownDeviceToPersistedKnownDevice(
+  device: KnownDevice,
+): PersistedKnownDevice | null {
+  if (device.transport === WEB_HID_TRANSPORT_IDENTIFIER) {
+    return { ...device, transport: "webhid" };
+  }
+
+  return null;
+}
+
+/**
+ * Deserialize a persisted known device. Returns `null` for any unknown/legacy
+ * transport code, so malformed or unsupported records are dropped on load.
+ */
+export function mapPersistedKnownDeviceToKnownDevice(
+  device: Omit<KnownDevice, "transport"> & { transport: string },
+): KnownDevice | null {
+  if (device.transport === "webhid") {
+    return { ...device, transport: WEB_HID_TRANSPORT_IDENTIFIER };
+  }
+
+  return null;
+}
+
+function upsertKnownDevice(state: KnownDevicesState, device: KnownDevice | null) {
+  if (!device) return;
+
+  const existingIndex = state.knownDevices.findIndex(d => d.deviceModelId === device.deviceModelId);
+
+  if (existingIndex === -1) {
+    state.knownDevices.push(device);
+    return;
+  }
+
+  const existing = state.knownDevices[existingIndex];
+  state.knownDevices[existingIndex] = {
+    ...device,
+    // Keep a previously known name when the new source does not provide one.
+    name: device.name ?? existing.name,
+  };
+}
+
+const knownDevicesSlice = createSlice({
+  name: "knownDevices",
+  initialState: INITIAL_STATE,
+  reducers: {
+    importKnownDevices: (_state, action: PayloadAction<KnownDevicesState>) => action.payload,
+  },
+  extraReducers: builder => {
+    builder
+      // On settings load, seed the store only when empty: prefer `lastSeenDevice`,
+      // fallback to `lastOnboardedDevice`.
+      .addMatcher(
+        (action): action is PayloadAction<Partial<SettingsState>> =>
+          action.type === "FETCH_SETTINGS",
+        (state, action) => {
+          if (state.knownDevices.length > 0) return;
+
+          const seed =
+            mapLastSeenDeviceToKnownDevice(action.payload?.lastSeenDevice) ??
+            mapDeviceToKnownDevice(action.payload?.lastOnboardedDevice);
+
+          if (seed) state.knownDevices.push(seed);
+        },
+      )
+      // Upsert when `lastSeenDevice` changes.
+      .addMatcher(
+        (action): action is PayloadAction<{ lastSeenDevice: DeviceModelInfo }> =>
+          action.type === "LAST_SEEN_DEVICE_INFO",
+        (state, action) => {
+          upsertKnownDevice(state, mapLastSeenDeviceToKnownDevice(action.payload?.lastSeenDevice));
+        },
+      )
+      // Upsert when `lastOnboardedDevice` changes. Never remove on null.
+      .addMatcher(
+        (action): action is PayloadAction<Device | null> =>
+          action.type === "SET_LAST_ONBOARDED_DEVICE",
+        (state, action) => {
+          upsertKnownDevice(state, mapDeviceToKnownDevice(action.payload));
+        },
+      )
+      // Upsert when `devices.currentDevice` changes (a device is added/connected).
+      .addMatcher(
+        (action): action is PayloadAction<Device> => action.type === "ADD_DEVICE",
+        (state, action) => {
+          upsertKnownDevice(state, mapDeviceToKnownDevice(action.payload));
+        },
+      );
+  },
+});
+
+export const { importKnownDevices } = knownDevicesSlice.actions;
+
+export const knownDevicesSelector = (state: State): KnownDevice[] =>
+  state.knownDevices.knownDevices;
+
+/** Persisted (export) projection of the known devices store. */
+export const knownDevicesStoreSelector = (state: State): PersistedKnownDevicesState => ({
+  knownDevices: state.knownDevices.knownDevices.flatMap(device => {
+    const persistedDevice = mapKnownDeviceToPersistedKnownDevice(device);
+    return persistedDevice ? [persistedDevice] : [];
+  }),
+});
+
+export default knownDevicesSlice.reducer;

--- a/apps/ledger-live-desktop/src/renderer/storage.ts
+++ b/apps/ledger-live-desktop/src/renderer/storage.ts
@@ -16,6 +16,7 @@ import logger from "./logger";
 import { trustchainStoreSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { marketStoreSelector } from "./reducers/market";
 import { marketBannerStoreSelector } from "./reducers/marketBanner";
+import { knownDevicesStoreSelector } from "./reducers/knownDevices";
 import { ExportedWalletState } from "@ledgerhq/live-wallet/store";
 import type { PersistedCAL } from "@ledgerhq/cryptoassets/cal-client/persistence";
 import type { PersistedIdentities } from "@ledgerhq/client-ids/store";
@@ -39,6 +40,7 @@ export type PostOnboarding = ReturnType<typeof hubStateSelector>;
 export type Settings = ReturnType<typeof settingsStoreSelector>;
 export type Market = ReturnType<typeof marketStoreSelector>;
 export type MarketBanner = ReturnType<typeof marketBannerStoreSelector>;
+export type KnownDevices = ReturnType<typeof knownDevicesStoreSelector>;
 
 export type TrustchainStore = ReturnType<typeof trustchainStoreSelector>;
 
@@ -53,6 +55,7 @@ type DatabaseValues = {
   wallet: ExportedWalletState;
   market: Market;
   marketBanner: MarketBanner;
+  knownDevices: KnownDevices;
   cryptoAssets: PersistedCAL;
   featureFlags: Pick<FeatureFlagsState, "overrides" | "bannerVisible">;
   coinConfigOverrides: { overrides: Record<string, unknown> };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - `ledger-live-desktop`: adds a persisted `knownDevices` store (reducer, selectors, persistence wiring) using the shared `KnownDevice` shape from `@ledgerhq/live-dmk-shared`. It reacts to existing settings/device actions and ships WebHID serialization helpers for the on-disk format.
  - **No user-facing behavior change yet**: the store is not consumed by any screen until the desktop ConnectDevice enablement branch (LIVE-33000).

### 📝 Description

We are bringing the **Device Intent Executor** to desktop. This is the second enabler branch, following the shared-core extraction (#18978).

The shared "connect device" flow matches the devices it discovers against the user's **known devices**. On mobile this list comes from a dedicated `knownDevices` store; **desktop has no equivalent**, so there is nothing to drive device selection for the upcoming desktop flow.

This PR **adds a desktop `knownDevices` store**, mirroring the mobile reducer but adapting the identity rules to desktop, where the only transport is **WebHID**:

1. **Source of truth** — desktop has no dedicated device-tracking actions, so the reducer **reacts to existing actions** instead of scattering new dispatches:
   - seeds on settings load (`FETCH_SETTINGS`) **only when empty**, preferring `lastSeenDevice` and falling back to `lastOnboardedDevice`;
   - upserts on `LAST_SEEN_DEVICE_INFO`, `SET_LAST_ONBOARDED_DEVICE` and `ADD_DEVICE` (current device);
   - dedupes per `deviceModelId` and **never removes** a known device when a source becomes null.
2. **Identity** — WebHID exposes no stable per-device id, so known devices are normalized as `transport: "web-hid"`, `id: ""`, unique by `deviceModelId`, with an optional `name` preserved across upserts.
3. **Persistence** — wired through the DB middleware + `storage.ts` + `init.tsx` hydration, using mobile-style serialization helpers (`mapKnownDeviceToPersistedKnownDevice` / `mapPersistedKnownDeviceToKnownDevice`).

#### Persistence & forward-compatibility

The on-disk format uses a stable transport code (`"webhid"`) decoupled from the DMK `webHidIdentifier` string, and the import path drops malformed / unknown records. Adding a future transport (e.g. web-ble) is purely additive — a new code in the mappers — and requires **no persisted-data migration**.

### ❓ Context

- **JIRA or GitHub link**: LIVE-33224
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)