### PR TITLE
chore(cryptoassets): deprecate findCryptoCurrencyByTicker

### DIFF
--- a/.changeset/deprecate-find-crypto-currency-by-ticker.md
+++ b/.changeset/deprecate-find-crypto-currency-by-ticker.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/cryptoassets": patch
+---
+
+Mark findCryptoCurrencyByTicker as @deprecated: tickers are not unique so the lookup is ambiguous. Use findCryptoCurrencyById instead.

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -5177,8 +5177,9 @@ export function findCryptoCurrencyByScheme(scheme: string): CryptoCurrency | nul
 }
 
 /**
- *
- * @param {*} ticker
+ * @deprecated Tickers are not unique across currencies, so the result is ambiguous and arbitrary.
+ * Look up by id with {@link findCryptoCurrencyById} instead.
+ * @param ticker
  */
 export function findCryptoCurrencyByTicker(ticker: string): CryptoCurrency | null | undefined {
   return activeCurrenciesStore().cryptocurrenciesByTicker[ticker];


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- JSDoc-only annotation, no runtime behavior change; existing cryptoassets tests still pass. -->
- [x] **Impact of the changes:** None at runtime. The `@deprecated` tag is advisory only (IDE strikethrough / warning). No eslint `no-deprecated` rule is active in the repo, so existing call sites do not fail CI.
  - QA: no functional area affected.

### 📝 Description

`findCryptoCurrencyByTicker` looks currencies up by ticker, but tickers are **not unique** across currencies — the underlying `byTicker` store resolves collisions arbitrarily (testnets excluded, keyword-priority tiebreak). This makes the lookup ambiguous and unsafe (cf. the TON/GRAM rename post-mortem).

This PR adds an `@deprecated` JSDoc tag pointing callers to `findCryptoCurrencyById` (the unique, stable lookup), so any **new** usage surfaces a deprecation warning in editors. It is JSDoc-only — no behavior change.

Migration of the existing call sites is tracked separately in LIVE-33269.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33282](https://ledgerhq.atlassian.net/browse/LIVE-33282) (sibling of [LIVE-33269](https://ledgerhq.atlassian.net/browse/LIVE-33269))
- **ADR link (if any)**:


[LIVE-33282]: https://ledgerhq.atlassian.net/browse/LIVE-33282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ