### PR TITLE
[LWDM] feat(live-wallet): log non-imported wallet sync accounts

### DIFF
--- a/.changeset/wallet-sync-log-non-imported-accounts.md
+++ b/.changeset/wallet-sync-log-non-imported-accounts.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-wallet": patch
+---
+
+Wallet Sync: log the non-imported accounts (id + attempts) so account discrepancies can be diagnosed from exported logs

--- a/libs/live-wallet/src/walletsync/incrementalUpdates.ts
+++ b/libs/live-wallet/src/walletsync/incrementalUpdates.ts
@@ -4,6 +4,14 @@ import { UpdateEvent } from "../cloudsync/sdk";
 import { WalletSyncDataManagerResolutionContext } from "./types";
 import { WSState } from "../store";
 
+function logNonImportedAccountInfos(localState: LocalState) {
+  const { nonImportedAccountInfos } = localState.accounts;
+  if (nonImportedAccountInfos.length === 0) return;
+  log("walletsync", `${nonImportedAccountInfos.length} non-imported accounts`, {
+    nonImportedAccountInfos: nonImportedAccountInfos.map(({ id, attempts }) => ({ id, attempts })),
+  });
+}
+
 export function makeSaveNewUpdate<S>({
   ctx,
   getState,
@@ -40,6 +48,7 @@ export function makeSaveNewUpdate<S>({
           const localState = localStateSelector(getState()); // fetch again latest state because it might have changed
           const newLocalState = walletsync.applyUpdate(localState, resolved.update); // we resolve in sync the new local state to save
           await saveUpdate(data, version, newLocalState);
+          logNonImportedAccountInfos(newLocalState);
           log("walletsync", "resolved. changes applied.");
         } else {
           log("walletsync", "resolved. no changes to apply.");
@@ -89,6 +98,7 @@ export function makeLocalIncrementalUpdate<S>({
       const localState = localStateSelector(getState()); // fetch again latest state because it might have changed
       const newLocalState = walletsync.applyUpdate(localState, resolved.update); // we resolve in sync the new local state to save
       await saveUpdate(data, version, newLocalState);
+      logNonImportedAccountInfos(newLocalState);
       log("walletsync", "localIncrementalUpdate done.");
     }
   };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Existing `libs/live-wallet/src/walletsync` suite (870 tests) still passes; this only adds a `log()` call on paths already exercised.
- [ ] **Impact of the changes:**
  - Adds a `walletsync` log entry listing non-imported Wallet Sync accounts. No behavioral change beyond logging.

### 📝 Description

`nonImportedAccountInfos` (Wallet Sync accounts that failed to import and are retried) was only kept in redux and shown in the hidden **Settings → Developer → WalletSync → Checker** screen. It was never written to logs — the watch loop only logged `loop`, `local->dist diff to push`, `notification`, `saveNewUpdate` — which made Wallet Sync account discrepancies impossible to diagnose from exported logs.

This adds a `logNonImportedAccountInfos` helper in `libs/live-wallet/src/walletsync/incrementalUpdates.ts`, called right after the new local state is computed in both update paths (`makeSaveNewUpdate` for new distant data, and `makeLocalIncrementalUpdate` for local resolution). It logs the count plus `{ id, attempts }` for each non-imported account (only when there is at least one, to avoid log noise):

```
walletsync 2 non-imported accounts { nonImportedAccountInfos: [{ id, attempts }, ...] }
```

The logging lives in `incrementalUpdates.ts` rather than the generic `createWalletSyncWatchLoop.ts` (named in the ticket) because the watch loop is generic over `LocalState` and cannot see the `.accounts.nonImportedAccountInfos` shape — `incrementalUpdates.ts` is the concrete module where that typed state is computed.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33311](https://ledgerhq.atlassian.net/browse/LIVE-33311)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIVE-33311]: https://ledgerhq.atlassian.net/browse/LIVE-33311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ