### PR TITLE
[LWM] test(mobile-e2e): disable currencyPolkadot in polkadot receive spec

### DIFF
--- a/.changeset/polkadot-receive-e2e-disable-polkadot-flag.md
+++ b/.changeset/polkadot-receive-e2e-disable-polkadot-flag.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+e2e: disable the legacy currencyPolkadot flag in the polkadot/cosmos receive spec so the DOT search resolves to assethub_polkadot (matching prod/staging) instead of the duplicate polkadot row.

--- a/apps/ledger-live-mobile/e2e/specs/receive/currencies.polkadotCosmos.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/receive/currencies.polkadotCosmos.spec.ts
@@ -20,6 +20,9 @@ describe("Receive different currency (polkadot, cosmos)", () => {
         currencyPolkadot: {
           enabled: false,
         },
+        currencyAssetHubPolkadot: {
+          enabled: true,
+        },
       },
     });
     deviceAction = new DeviceAction(knownDevice);

--- a/apps/ledger-live-mobile/e2e/specs/receive/currencies.polkadotCosmos.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/receive/currencies.polkadotCosmos.spec.ts
@@ -17,6 +17,9 @@ describe("Receive different currency (polkadot, cosmos)", () => {
         noah: {
           enabled: false,
         },
+        currencyPolkadot: {
+          enabled: false,
+        },
       },
     });
     deviceAction = new DeviceAction(knownDevice);


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.** Fixes the failing \`receive on \"polkadot\" (through scanning)\` test in the iOS/Android Detox suite.
- [ ] **Impact of the changes:**
  - e2e only — one feature-flag override added to \`currencies.polkadotCosmos.spec.ts\`. No app/runtime code touched.

### 📝 Description

\`DOT\` is shared by two currencies: \`polkadot\` and \`assethub_polkadot\`. \`currencyPolkadot\` is **ON by default**, so the modular drawer shows **both** rows when searching the \`DOT\` ticker. The receive-via-scanning test lands on the first row (\`polkadot\`) but asserts an \`assethub_polkadot\` account, so it fails:

\`\`\`
Test Failed: No elements found for "MATCHER(id == "/account-item-mock:1:assethub_polkadot:...")"
\`\`\`

In prod/staging only \`assethub_polkadot\` is shown. This disables the legacy \`currencyPolkadot\` flag for this spec so the \`DOT\` search resolves to \`assethub_polkadot\`, matching prod/staging — as suggested by @François in the thread.

The spec hasn't changed in ~6 months; the failure surfaces on any branch running this iOS Detox shard (it is **not** caused by a code change). Spotted on PR #18933 (LIVE-33115).

### ❓ Context

- **JIRA or GitHub link**: surfaced on [#18933](https://github.com/LedgerHQ/ledger-live/pull/18933); flags \`currencyPolkadot\` / \`currencyAssetHubPolkadot\` (team-coin-integration)
- **ADR link (if any)**: N/A