### PR TITLE
chore: assign live-wallet walletsync to team-platform in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -67,6 +67,7 @@ libs/asset-aggregation/                                  @ledgerhq/wallet-xp
 libs/asset-detail/                                       @ledgerhq/wallet-xp
 libs/wallet-pnl/                                         @ledgerhq/wallet-xp
 libs/live-wallet/                                        @ledgerhq/wallet-xp
+libs/live-wallet/src/walletsync/                          @ledgerhq/platform
 libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/ @ledgerhq/wallet-xp
 libs/ledger-live-common/src/modularDrawer/               @ledgerhq/wallet-xp
 libs/ledger-live-common/src/cg-client/                   @ledgerhq/wallet-xp


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached. _N/A — CODEOWNERS-only change, no package affected._
- [x] **Covered by automatic tests.** _N/A — repository metadata change._
- [x] **Impact of the changes:**
  - Review routing only: PRs touching `libs/live-wallet/src/walletsync/` now request `@ledgerhq/platform` instead of `@ledgerhq/wallet-xp`.

### 📝 Description

`libs/live-wallet/src/walletsync/` is owned by **#team-platform**, but CODEOWNERS only had the broader `libs/live-wallet/ → @ledgerhq/wallet-xp` rule.

This adds a more specific entry right after it. CODEOWNERS uses last-match-wins, so the `walletsync` sub-tree is now owned by `@ledgerhq/platform`:

```diff
 libs/live-wallet/                                        @ledgerhq/wallet-xp
+libs/live-wallet/src/walletsync/                          @ledgerhq/platform
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33311](https://ledgerhq.atlassian.net/browse/LIVE-33311)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIVE-33311]: https://ledgerhq.atlassian.net/browse/LIVE-33311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ