### PR TITLE
[LWDM] chore(feature-flags): enable lwWallet40 flag by default

### DIFF
--- a/.changeset/strong-lobsters-appear.md
+++ b/.changeset/strong-lobsters-appear.md
@@ -1,6 +1,7 @@
 ---
 "@shared/feature-flags": minor
 "ledger-live-desktop": minor
+"live-mobile": minor
 ---
 
-Enable the `lwdWallet40` feature flag by default (Wallet 4.0)
+Enable the `lwdWallet40` & `lwmWallet40` feature flag by default (Wallet 4.0)

--- a/.changeset/strong-lobsters-appear.md
+++ b/.changeset/strong-lobsters-appear.md
@@ -1,5 +1,6 @@
 ---
 "@shared/feature-flags": minor
+"ledger-live-desktop": minor
 ---
 
 Enable the `lwdWallet40` feature flag by default (Wallet 4.0)

--- a/.changeset/strong-lobsters-appear.md
+++ b/.changeset/strong-lobsters-appear.md
@@ -1,0 +1,5 @@
+---
+"@shared/feature-flags": minor
+---
+
+Enable the `lwdWallet40` feature flag by default (Wallet 4.0)

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/__tests__/useSideBarViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/__tests__/useSideBarViewModel.test.ts
@@ -57,12 +57,18 @@ const ACTIVE_CHANGE_NAV_CASES = Object.keys(SIDEBAR_VALUE_TO_PATH)
   }));
 
 describe("useSideBarViewModel", () => {
+  const originalInnerWidth = window.innerWidth;
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockedUseNavigate.mockReturnValue(mockNavigate);
-    // Wallet 4.0 (enabled by default) auto-collapses the sidebar on narrow
-    // viewports. Use a wide viewport so the collapse logic under test is deterministic.
+    // Wallet 4.0 auto-collapses the sidebar on narrow viewports; use a wide one
+    // so the collapse logic under test is deterministic.
     window.innerWidth = 1440;
+  });
+
+  afterEach(() => {
+    window.innerWidth = originalInnerWidth;
   });
 
   it("should return correct default state", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/__tests__/useSideBarViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/__tests__/useSideBarViewModel.test.ts
@@ -60,6 +60,9 @@ describe("useSideBarViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedUseNavigate.mockReturnValue(mockNavigate);
+    // Wallet 4.0 (enabled by default) auto-collapses the sidebar on narrow
+    // viewports. Use a wide viewport so the collapse logic under test is deterministic.
+    window.innerWidth = 1440;
   });
 
   it("should return correct default state", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
@@ -128,9 +128,7 @@ describe("LNSUpsellBanner", () => {
           ...withFlagOverrides({
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             lldNanoSUpsellBanners: { enabled: ffEnabled, params: ffParams as any },
-            ...(brazePlacement
-              ? { lwdWallet40: { enabled: true, params: { brazePlacement: true } } }
-              : {}),
+            lwdWallet40: { enabled: brazePlacement, params: { brazePlacement } },
           }),
           settings: {
             shareAnalytics: true,

--- a/apps/ledger-live-desktop/src/mvvm/features/LiveAppModal/__integrations__/LiveAppModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LiveAppModal/__integrations__/LiveAppModal.integration.test.tsx
@@ -171,7 +171,7 @@ describe("LiveAppModal Integration", () => {
       expect(lastCall.inputs).toEqual(
         expect.objectContaining({
           uiVersion: "v1",
-          lw40enabled: "false",
+          lw40enabled: "true",
           ethDepositCohort: expect.any(String),
         }),
       );

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/Welcome/hooks/__tests__/useWelcomeNewViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/Welcome/hooks/__tests__/useWelcomeNewViewModel.test.ts
@@ -95,6 +95,12 @@ describe("useWelcomeViewModel", () => {
             ...INITIAL_STATE,
             hasCompletedOnboarding: true,
           },
+          ...withFlagOverrides({
+            lwdWallet40: {
+              enabled: false,
+              params: { lazyOnboarding: false },
+            },
+          }),
         },
       });
 
@@ -134,6 +140,12 @@ describe("useWelcomeViewModel", () => {
             ...INITIAL_STATE,
             hasCompletedOnboarding: false,
           },
+          ...withFlagOverrides({
+            lwdWallet40: {
+              enabled: false,
+              params: { lazyOnboarding: false },
+            },
+          }),
         },
       });
 

--- a/apps/ledger-live-desktop/src/renderer/__tests__/Default.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/__tests__/Default.test.tsx
@@ -82,6 +82,7 @@ describe("Default", () => {
             devicesModelList: [],
             anonymousUserNotifications: {},
             orderAccounts: "balance|desc",
+            starredMarketCoins: [],
           },
         },
         initialRoute: "/",

--- a/apps/ledger-live-mobile/__tests__/mocks/gorhomBottomSheetLifecycle.ts
+++ b/apps/ledger-live-mobile/__tests__/mocks/gorhomBottomSheetLifecycle.ts
@@ -1,0 +1,45 @@
+import React from "react";
+
+type BottomSheetModalProps = {
+  onAnimate?: (
+    fromIndex: number,
+    toIndex: number,
+    fromPosition?: number,
+    toPosition?: number,
+  ) => void;
+  onChange?: (index: number, position?: number, type?: number) => void;
+  onDismiss?: () => void;
+  children?: React.ReactNode | ((props: object) => React.ReactNode);
+};
+
+export function createGorhomBottomSheetLifecycleMock() {
+  const actualMock = jest.requireActual("@gorhom/bottom-sheet/mock");
+
+  class BottomSheetModal extends React.Component<BottomSheetModalProps> {
+    present() {
+      this.props.onAnimate?.(-1, 0, 0, 0);
+      this.props.onChange?.(0, 0, 0);
+    }
+    dismiss() {
+      this.props.onAnimate?.(0, -1, 0, 0);
+      this.props.onChange?.(-1, 0, 0);
+      this.props.onDismiss?.();
+    }
+    close() {
+      this.dismiss();
+    }
+    forceClose() {
+      this.dismiss();
+    }
+    snapToIndex() {}
+    snapToPosition() {}
+    expand() {}
+    collapse() {}
+    render() {
+      const { children } = this.props;
+      return typeof children === "function" ? children({}) : children;
+    }
+  }
+
+  return { ...actualMock, BottomSheetModal };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/useUpdateBannerViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/useUpdateBannerViewModel.test.tsx
@@ -77,12 +77,12 @@ function withState(overrides: {
           }),
         },
       };
-      if (overrides.withWallet40MainNav) {
-        return withFlagOverrides({
-          lwmWallet40: { enabled: true, params: { mainNavigation: true } },
-        })(base);
-      }
-      return base;
+      return withFlagOverrides({
+        lwmWallet40: {
+          enabled: Boolean(overrides.withWallet40MainNav),
+          params: { mainNavigation: Boolean(overrides.withWallet40MainNav) },
+        },
+      })(base);
     },
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/addAccountFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/addAccountFlow.test.tsx
@@ -7,6 +7,12 @@ import { of, Observable } from "rxjs";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { IsDeviceLockedResultType } from "~/hooks/useIsDeviceLockedPolling/types";
 
+// With lwmWallet40 enabled (now the default), the Modular Drawer renders the Lumen
+// `QueuedDrawerBottomSheet`
+jest.mock("@gorhom/bottom-sheet", () =>
+  require("@tests/mocks/gorhomBottomSheetLifecycle").createGorhomBottomSheetLifecycleMock(),
+);
+
 // Needed for receive navigator
 jest.mock("@ledgerhq/live-config/LiveConfig", () => {
   const mockConfig = { mock: { type: "string", default: "test" } };

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
@@ -92,7 +92,8 @@ const DRAWER_VARIANTS: DrawerVariant[] = [
     label: "Gorhom (legacy)",
     backButtonTestId: "drawer-back-button",
     renderOptions: {
-      overrideInitialState: withReadOnlyDisabled,
+      overrideInitialState: (state: State) =>
+        withFlagOverrides({ lwmWallet40: { enabled: false } })(withReadOnlyDisabled(state)),
     },
   },
   {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
@@ -61,6 +61,12 @@ const withFreezeFlag = {
   }),
 };
 
+const withoutFreezeFlag = {
+  overrideInitialState: withFlagOverrides({
+    lwmWallet40: { enabled: true, params: { balanceRefreshRework: false } },
+  }),
+};
+
 describe("usePortfolioBalanceSectionViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -85,8 +91,9 @@ describe("usePortfolioBalanceSectionViewModel", () => {
 
   describe("isLoading", () => {
     it("is true while syncPhase is syncing, false otherwise", () => {
-      const { result, rerender } = renderHook(() =>
-        usePortfolioBalanceSectionViewModel(defaultProps),
+      const { result, rerender } = renderHook(
+        () => usePortfolioBalanceSectionViewModel(defaultProps),
+        withoutFreezeFlag,
       );
       expect(result.current.isLoading).toBe(false);
 
@@ -138,8 +145,9 @@ describe("usePortfolioBalanceSectionViewModel", () => {
         makeReturn({ balanceAvailable: false, syncPhase: "syncing", portfolio: emptyPortfolio }),
       );
 
-      const { result, rerender } = renderHook(() =>
-        usePortfolioBalanceSectionViewModel(defaultProps),
+      const { result, rerender } = renderHook(
+        () => usePortfolioBalanceSectionViewModel(defaultProps),
+        withoutFreezeFlag,
       );
       expect(result.current.isBalanceAvailable).toBe(false);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSync/__tests__/PortfolioBalanceSync.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSync/__tests__/PortfolioBalanceSync.test.tsx
@@ -75,7 +75,11 @@ describe("PortfolioBalanceSync", () => {
   });
 
   it("sets isLoading true when syncPhase is syncing", () => {
-    mockUsePortfolioBalance.mockReturnValue(makeReturn({ syncPhase: "syncing" }));
+    // With the balance-refresh rework (lwmWallet40, on by default) loading is scoped to the
+    // CVS phase (cvPending), so a user-triggered sync reports isCvPending true.
+    mockUsePortfolioBalance.mockReturnValue(
+      makeReturn({ syncPhase: "syncing", isCvPending: true }),
+    );
 
     const { store } = render(<PortfolioBalanceSync />);
     const state = store.getState() as State;

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/__integrations__/PortfolioRefreshStatus.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/__integrations__/PortfolioRefreshStatus.integration.test.tsx
@@ -32,10 +32,21 @@ jest.mock("react-native-reanimated", () => {
 import React from "react";
 import { render, screen, act, withFlagOverrides } from "@tests/test-renderer";
 import { genAccount } from "@ledgerhq/live-common/mock/account";
+import type { SyncPhase } from "@ledgerhq/live-common/bridge/react/index";
 import { REFRESH_STATUS_VISIBLE_DURATION_MS } from "../usePortfolioRefreshStatusViewModel";
 import { PortfolioRefreshStatus } from "../index";
-import { setRefreshCompleted } from "~/reducers/portfolioRefresh";
+import * as usePortfolioBalanceModule from "LLM/hooks/usePortfolioBalance";
 import { State } from "~/reducers/types";
+
+// In the rework (lwmWallet40, on by default) refreshing / up-to-date are driven by the sync
+// lifecycle from usePortfolioBalance, not by redux — so we mock its syncPhase.
+jest.mock("LLM/hooks/usePortfolioBalance");
+
+const mockBalance = (syncPhase: SyncPhase, isManualRefreshLoading = false) =>
+  jest.mocked(usePortfolioBalanceModule.usePortfolioBalance).mockReturnValue({
+    syncPhase,
+    isManualRefreshLoading,
+  } as ReturnType<typeof usePortfolioBalanceModule.usePortfolioBalance>);
 
 const FIXED_NOW = new Date("2025-08-15T12:00:00Z").getTime();
 
@@ -48,17 +59,6 @@ const makeAccount = (lastSyncDate: Date) => ({
 
 const withBalanceRefreshRework = withFlagOverrides({
   lwmWallet40: { enabled: true, params: { balanceRefreshRework: true } },
-});
-
-const withRefreshing = (): ((state: State) => State) => state => ({
-  ...state,
-  portfolioRefresh: {
-    isRefreshing: true,
-    lastSyncTimestampSnapshot: null,
-    hasCompletedInitialSync: false,
-    lastUserSyncClickTimestamp: 0,
-    lastOfflineRefreshAttemptTimestamp: 0,
-  },
 });
 
 const withIdle =
@@ -90,21 +90,26 @@ const withOfflineAttempt = (): ((state: State) => State) => state =>
     },
   });
 
-const renderRefreshing = () =>
-  render(<PortfolioRefreshStatus />, {
-    overrideInitialState: withRefreshing(),
+const renderRefreshing = () => {
+  mockBalance("syncing", true);
+  return render(<PortfolioRefreshStatus />, {
+    overrideInitialState: withBalanceRefreshRework,
   });
+};
 
-const completeRefresh = (store: ReturnType<typeof renderRefreshing>["store"]) =>
+const completeRefresh = (rerender: ReturnType<typeof renderRefreshing>["rerender"]) => {
+  mockBalance("synced");
   act(() => {
-    store.dispatch(setRefreshCompleted());
+    rerender(<PortfolioRefreshStatus />);
   });
+};
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe("PortfolioRefreshStatus", () => {
   beforeEach(() => {
     jest.setSystemTime(FIXED_NOW);
+    mockBalance("synced");
   });
 
   describe("idle state", () => {
@@ -158,8 +163,8 @@ describe("PortfolioRefreshStatus", () => {
 
   describe("up-to-date state", () => {
     it("should show checkmark and 'You're up to date' without spinner right after refresh completes", () => {
-      const { store } = renderRefreshing();
-      completeRefresh(store);
+      const { rerender } = renderRefreshing();
+      completeRefresh(rerender);
 
       expect(screen.getByTestId("portfolio-refresh-status-up-to-date")).toBeVisible();
       expect(screen.getByText("Portfolio up to date")).toBeVisible();
@@ -168,8 +173,8 @@ describe("PortfolioRefreshStatus", () => {
     });
 
     it("should hide after the visibility duration elapses", () => {
-      const { store } = renderRefreshing();
-      completeRefresh(store);
+      const { rerender } = renderRefreshing();
+      completeRefresh(rerender);
 
       expect(screen.getByTestId("portfolio-refresh-status-up-to-date")).toBeVisible();
 

--- a/apps/ledger-live-mobile/src/screens/Portfolio/__integrations__/portfolioAssets.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/__integrations__/portfolioAssets.integration.test.tsx
@@ -34,8 +34,10 @@ const mockContentSizeChangeEvent = (width: number, height: number) => ({
 });
 
 describe("portfolioAssets", () => {
-  it("should render quick actions", async () => {
-    const { getByText } = render(
+  it("should not render the legacy quick actions bar with wallet 4.0 enabled", async () => {
+    // With wallet 4.0 (lwmWallet40, on by default) the quick action CTAs are handled by the
+    // wallet 4.0 navigation, so PortfolioAssets no longer renders its legacy PortfolioQuickActionsBar.
+    const { queryByText } = render(
       <TestNavigator>
         <PortfolioAssets hideEmptyTokenAccount={false} openAddModal={() => null} />
       </TestNavigator>,
@@ -47,7 +49,7 @@ describe("portfolioAssets", () => {
       },
     );
     const quickActions = [/buy/i, /swap/i, /send/i, /receive/i];
-    quickActions.forEach(action => expect(getByText(action)).toBeVisible());
+    quickActions.forEach(action => expect(queryByText(action)).toBeNull());
   });
 
   it("should track click on tab account", async () => {

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwdWallet40.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwdWallet40.ts
@@ -20,7 +20,7 @@ export const lwdWallet40 = flagWith(
     earnSimulator: z.boolean().optional(),
   },
   {
-    enabled: false,
+    enabled: true,
     params: {
       graphRework: true,
       mainNavigation: true,

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwmWallet40.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwmWallet40.ts
@@ -21,7 +21,7 @@ export const lwmWallet40 = flagWith(
     q2Tour: z.boolean().optional(),
   },
   {
-    enabled: false,
+    enabled: true,
     params: {
       graphRework: true,
       quickActionCtas: true,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Feature-flag default value change; no test coverage applicable._
- [x] **Impact of the changes:**
      - Wallet 4.0 is now active by default for all users (the `lwdWallet40` flag defaults to `enabled: true`).
      - Verify the enabled Wallet 4.0 sub-features render correctly: market banner, graph rework, quick-action CTAs, main navigation, tour, lazy onboarding, balance refresh rework, and Braze placement.
      - Sub-features still gated off (`q2Tour`, `assetSection`, `operationsList`, `aggregatedAssets`, `myWallet`, `pnl`, `assetDiscoverability`, `earn*`) should remain inactive.

### 📝 Description

This change flips the `lwWallet40` (Wallet 4.0) feature flag default from `enabled: false` to `enabled: true`, rolling out the Wallet 4.0 experience by default.

**Problem**: Wallet 4.0 was gated behind a disabled-by-default feature flag.

**Solution**: Set the flag's default `enabled` value to `true`. Individual sub-feature params are unchanged, so only the features already toggled on in the flag params become active.

### ❓ Context

- **JIRA or GitHub link**: _N/A_
- desktop => https://github.com/LedgerHQ/ledger-live/actions/runs/28576336111
- mobile => https://github.com/LedgerHQ/ledger-live/actions/runs/28576350476

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)