### PR TITLE
[LWM] Feat(LIVE-30501): aleo self transfer btn for mobile

### DIFF
--- a/.changeset/big-trains-own.md
+++ b/.changeset/big-trains-own.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+selfTransfer button for Aleo (without any logic)

--- a/apps/ledger-live-mobile/src/families/aleo/__tests__/accountActions.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/__tests__/accountActions.test.tsx
@@ -1,0 +1,30 @@
+import { IconsLegacy } from "@ledgerhq/native-ui";
+import accountActions from "../accountActions";
+import { ALEO_ACCOUNT_1 } from "../__mocks__/account.mock";
+
+jest.mock("@ledgerhq/native-ui", () => ({
+  IconsLegacy: { TransferMedium: "TransferMedium" },
+}));
+
+jest.mock("~/context/Locale", () => ({
+  Trans: ({ i18nKey }: { i18nKey: string }) => i18nKey,
+}));
+
+describe("accountActions.getMainActions", () => {
+  it("returns a single publicToPrivate action with correct shape", () => {
+    const [action] = accountActions.getMainActions({ account: ALEO_ACCOUNT_1 });
+
+    expect(action.id).toBe("public_to_private");
+    expect((action.label as { props: { i18nKey: string } }).props.i18nKey).toBe(
+      "aleo.accountActions.publicToPrivate",
+    );
+    expect(action.Icon).toBe(IconsLegacy.TransferMedium);
+    expect(action.event).toBe("button_clicked");
+    expect(action.eventProperties).toEqual({
+      button: "public_to_private",
+      currency: "ALEO",
+      page: "Account Page",
+    });
+    expect(typeof action.customHandler).toBe("function");
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/accountActions.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Trans } from "~/context/Locale";
+import { IconsLegacy } from "@ledgerhq/native-ui";
+import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
+import type { ActionButtonEvent } from "~/components/FabActions";
+
+const getMainActions = ({ account: _account }: { account: AleoAccount }): ActionButtonEvent[] => {
+  return [
+    {
+      id: "public_to_private",
+      label: <Trans i18nKey="aleo.accountActions.publicToPrivate" />,
+      Icon: IconsLegacy.TransferMedium,
+      event: "button_clicked",
+      eventProperties: {
+        button: "public_to_private",
+        currency: "ALEO",
+        page: "Account Page",
+      },
+      // TODO: handler, for now empty skeleton only ( https://ledgerhq.atlassian.net/browse/LIVE-30501 )
+      customHandler: () => {},
+    },
+  ];
+};
+
+export default {
+  getMainActions,
+};

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10008,5 +10008,10 @@
       "unavailable": "Not connected",
       "menuAccessibilityLabel": "Device options"
     }
+  },
+  "aleo": {
+    "accountActions": {
+      "publicToPrivate": "Self transfer"
+    }
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - self transfer button skeleton for Aleo mobile

### 📝 Description

Added skeleton with self transfer button for Aleo (mobile). 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [https://ledgerhq.atlassian.net/browse/LIVE-30501](https://ledgerhq.atlassian.net/browse/LIVE-30501)


### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
