### PR TITLE
[LWM] feat: notification permission status refresh fix

### DIFF
--- a/.changeset/afraid-beds-fail.md
+++ b/.changeset/afraid-beds-fail.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix hasEnabledOsNotifications being intermittently tracked as false after the user enabled OS notifications

--- a/apps/ledger-live-mobile/src/analytics/__tests__/segment.osNotifications.test.ts
+++ b/apps/ledger-live-mobile/src/analytics/__tests__/segment.osNotifications.test.ts
@@ -1,0 +1,181 @@
+import { AppState, type AppStateStatus } from "react-native";
+import { waitFor } from "@testing-library/react-native";
+import { configureStore } from "@reduxjs/toolkit";
+import { AuthorizationStatus } from "@react-native-firebase/messaging";
+import reducers from "~/reducers";
+import type { AppStore } from "~/reducers";
+import { setAnalytics, setAnalyticsConsentInfo } from "~/actions/settings";
+import { getNotificationPermissionStatus } from "~/logic/getNotificationPermissionStatus";
+import * as segment from "../segment";
+
+jest.unmock("../segment");
+
+jest.mock("~/logic/getNotificationPermissionStatus", () => ({
+  getNotificationPermissionStatus: jest.fn(),
+}));
+
+const mockGetNotificationPermissionStatus = getNotificationPermissionStatus as jest.Mock;
+
+const { _trackMock: mockTrack } = require("@segment/analytics-react-native") as {
+  _trackMock: jest.Mock;
+};
+
+const analyticsConsentInfo = {
+  consentDate: "2026-04-29T00:00:00.000Z",
+  privacyPolicyVersion: 1,
+};
+
+const flushPromises = () => new Promise(resolve => setImmediate(resolve));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const makeStore = (): AppStore =>
+  configureStore({
+    reducer: reducers,
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware({
+        serializableCheck: false,
+        immutableCheck: false,
+      }),
+  }) as AppStore;
+
+describe("segment hasEnabledOsNotifications", () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useFakeTimers();
+  });
+
+  let store: AppStore;
+  let appStateHandler: ((status: AppStateStatus) => void) | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appStateHandler = undefined;
+    jest.spyOn(AppState, "addEventListener").mockImplementation((type, handler) => {
+      if (type === "change") appStateHandler = handler as (status: AppStateStatus) => void;
+      return { remove: jest.fn() };
+    });
+
+    store = makeStore();
+    store.dispatch(setAnalyticsConsentInfo(analyticsConsentInfo));
+    store.dispatch(setAnalytics(true));
+  });
+
+  it("track() sends hasEnabledOsNotifications as true when the OS permission is AUTHORIZED", async () => {
+    mockGetNotificationPermissionStatus.mockResolvedValue(AuthorizationStatus.AUTHORIZED);
+    await segment.start(store);
+    mockTrack.mockClear();
+
+    segment.track("TestEvent", {});
+
+    await waitFor(() =>
+      expect(mockTrack).toHaveBeenCalledWith(
+        "TestEvent",
+        expect.objectContaining({ hasEnabledOsNotifications: true }),
+      ),
+    );
+  });
+
+  it("track() sends hasEnabledOsNotifications as false when the OS permission is DENIED", async () => {
+    mockGetNotificationPermissionStatus.mockResolvedValue(AuthorizationStatus.DENIED);
+    await segment.start(store);
+    mockTrack.mockClear();
+
+    segment.track("TestEvent", {});
+
+    await waitFor(() =>
+      expect(mockTrack).toHaveBeenCalledWith(
+        "TestEvent",
+        expect.objectContaining({ hasEnabledOsNotifications: false }),
+      ),
+    );
+  });
+
+  it("refreshes on AppState 'active' so a later track() flips from false to true", async () => {
+    // App starts with notifications denied.
+    mockGetNotificationPermissionStatus.mockResolvedValue(AuthorizationStatus.DENIED);
+    await segment.start(store);
+    mockTrack.mockClear();
+
+    segment.track("BeforeEnabling", {});
+    await waitFor(() =>
+      expect(mockTrack).toHaveBeenCalledWith(
+        "BeforeEnabling",
+        expect.objectContaining({ hasEnabledOsNotifications: false }),
+      ),
+    );
+
+    // User enables notifications in the phone settings and returns to the app.
+    mockGetNotificationPermissionStatus.mockResolvedValue(AuthorizationStatus.AUTHORIZED);
+    appStateHandler?.("active");
+    mockTrack.mockClear();
+
+    segment.track("AfterEnabling", {});
+    await waitFor(() =>
+      expect(mockTrack).toHaveBeenCalledWith(
+        "AfterEnabling",
+        expect.objectContaining({ hasEnabledOsNotifications: true }),
+      ),
+    );
+  });
+
+  it("deduplicates overlapping refreshes: an in-flight refresh is reused, not restarted", async () => {
+    mockGetNotificationPermissionStatus.mockResolvedValue(AuthorizationStatus.DENIED);
+    await segment.start(store);
+    // Ensure the start-time refresh has settled (and cleared the in-flight promise) before we
+    // start the deferred ones below, otherwise the first trigger would reuse it.
+    await flushPromises();
+
+    // A foreground refresh is now in-flight (its native read is deferred).
+    const refresh = deferred<number>();
+    mockGetNotificationPermissionStatus.mockClear();
+    mockGetNotificationPermissionStatus.mockReturnValueOnce(refresh.promise);
+
+    appStateHandler?.("active"); // starts the refresh
+    appStateHandler?.("active"); // in-flight -> reused, no new native read
+    appStateHandler?.("active"); // in-flight -> reused, no new native read
+
+    // Only a single native read happened despite three triggers: no overlap
+    expect(mockGetNotificationPermissionStatus).toHaveBeenCalledTimes(1);
+
+    refresh.resolve(AuthorizationStatus.AUTHORIZED);
+    mockTrack.mockClear();
+    segment.track("AfterOverlap", {});
+    await waitFor(() =>
+      expect(mockTrack).toHaveBeenCalledWith(
+        "AfterOverlap",
+        expect.objectContaining({ hasEnabledOsNotifications: true }),
+      ),
+    );
+  });
+
+  it("keeps the last-known value when a refresh rejects", async () => {
+    mockGetNotificationPermissionStatus.mockResolvedValue(AuthorizationStatus.AUTHORIZED);
+    await segment.start(store);
+
+    // A refresh on foreground fails (e.g. native error): the cached value must be preserved.
+    mockGetNotificationPermissionStatus.mockRejectedValue(new Error("native failure"));
+    appStateHandler?.("active");
+    mockTrack.mockClear();
+
+    segment.track("TestEvent", {});
+    await waitFor(() =>
+      expect(mockTrack).toHaveBeenCalledWith(
+        "TestEvent",
+        expect.objectContaining({ hasEnabledOsNotifications: true }),
+      ),
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -2,7 +2,7 @@
 import "crypto";
 import { v4 as uuid } from "uuid";
 import Config from "react-native-config";
-import { Linking, Platform } from "react-native";
+import { AppState, Linking, Platform, type NativeEventSubscription } from "react-native";
 import { createClient, SegmentClient, UserTraits } from "@segment/analytics-react-native";
 import VersionNumber from "react-native-version-number";
 import RNLocalize from "react-native-localize";
@@ -69,8 +69,8 @@ import { getTotalStakeableAssets } from "@ledgerhq/live-common/domain/getTotalSt
 import { getOnboardingCounterfeitWarningAttributes } from "@ledgerhq/live-common/analytics/featureFlagHelpers/onboardingCounterfeitWarning";
 import { getWallet40Attributes } from "@ledgerhq/live-common/analytics/featureFlagHelpers/wallet40";
 import { getRemoteABTestingAttributes } from "@ledgerhq/live-common/analytics/remoteABTesting/remoteABTestingAnalytics";
-import { notificationsPermissionStatusSelector } from "~/reducers/notifications";
-import { AuthorizationStatus } from "@react-native-firebase/messaging";
+import { AuthorizationStatus, type FirebaseMessagingTypes } from "@react-native-firebase/messaging";
+import { getNotificationPermissionStatus } from "~/logic/getNotificationPermissionStatus";
 
 const sessionId = uuid();
 const appVersion = `${VersionNumber.appVersion || ""} (${VersionNumber.buildVersion || ""})`;
@@ -81,6 +81,35 @@ type MaybeAppStore = Maybe<AppStore>;
 let storeInstance: MaybeAppStore; // is the redux store. it's also used as a flag to know if analytics is on or off.
 let segmentClient: SegmentClient | undefined;
 let analyticsFeatureFlagMethod: null | (<T extends FeatureId>(key: T) => Features[T] | null);
+
+let cachedOsPermissionStatus: FirebaseMessagingTypes.AuthorizationStatus | undefined;
+let osPermissionRefreshPromise: Promise<
+  FirebaseMessagingTypes.AuthorizationStatus | undefined
+> | null = null;
+let appStateSubscription: NativeEventSubscription | undefined;
+
+const refreshOsPermissionStatus = (): Promise<
+  FirebaseMessagingTypes.AuthorizationStatus | undefined
+> => {
+  if (osPermissionRefreshPromise) return osPermissionRefreshPromise;
+  osPermissionRefreshPromise = (async () => {
+    try {
+      cachedOsPermissionStatus = await getNotificationPermissionStatus();
+    } catch {
+      // keep last-known value on native failure
+    } finally {
+      osPermissionRefreshPromise = null;
+    }
+    return cachedOsPermissionStatus;
+  })();
+  return osPermissionRefreshPromise;
+};
+
+// Resolves with the cached value without a native call in steady state; while a refresh is
+// in-flight (right after the app comes back to the foreground) it awaits that single refresh so
+// events tracked in that window still get the up-to-date value instead of a stale one.
+const getOsPermissionStatus = (): Promise<FirebaseMessagingTypes.AuthorizationStatus | undefined> =>
+  osPermissionRefreshPromise ?? Promise.resolve(cachedOsPermissionStatus);
 
 export function setAnalyticsFeatureFlagMethod(method: typeof analyticsFeatureFlagMethod): void {
   analyticsFeatureFlagMethod = method;
@@ -338,8 +367,8 @@ const extraProperties = async (store: AppStore) => {
   const isReborn = isRebornSelector(state);
 
   const notifications = notificationsSelector(state);
-  const hasEnabledOsNotifications =
-    notificationsPermissionStatusSelector(state) === AuthorizationStatus.AUTHORIZED;
+  const osPermissionStatus = await getOsPermissionStatus();
+  const hasEnabledOsNotifications = osPermissionStatus === AuthorizationStatus.AUTHORIZED;
 
   const notificationsOptedIn = {
     notificationsAllowed: notifications.areNotificationsAllowed,
@@ -466,6 +495,14 @@ const extraProperties = async (store: AppStore) => {
 const token = ANALYTICS_TOKEN;
 export const start = async (store: AppStore): Promise<SegmentClient | undefined> => {
   storeInstance = store;
+
+  // Prime the OS notification permission cache and keep it fresh on every foreground, so that
+  // `hasEnabledOsNotifications` reflects changes the user made in the phone settings.
+  refreshOsPermissionStatus();
+  appStateSubscription?.remove();
+  appStateSubscription = AppState.addEventListener("change", nextAppState => {
+    if (nextAppState === "active") refreshOsPermissionStatus();
+  });
 
   const initialUrl = await Linking.getInitialURL();
   const isDeeplinkSession = !!initialUrl;

--- a/apps/ledger-live-mobile/src/logic/getNotificationPermissionStatus.ts
+++ b/apps/ledger-live-mobile/src/logic/getNotificationPermissionStatus.ts
@@ -1,7 +1,6 @@
-import { getMessaging, AuthorizationStatus } from "@react-native-firebase/messaging";
+import { getMessaging, type FirebaseMessagingTypes } from "@react-native-firebase/messaging";
 
-export const getNotificationPermissionStatus = async (): Promise<
-  (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus]
-> => {
-  return getMessaging().hasPermission();
-};
+export const getNotificationPermissionStatus =
+  async (): Promise<FirebaseMessagingTypes.AuthorizationStatus> => {
+    return getMessaging().hasPermission();
+  };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

A user that changes their notification permission settings on their phone sometimes has the setting set to false in analytics as the event does not propagate immediately resulting in some track events having the wrong data. This PR updates the analytics state to avoid the race condition causing this bug.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-26329


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
