### PR TITLE
[LWDM] fix(coin-celo): preserve custom fees in prepareTransaction

### DIFF
--- a/.changeset/quiet-tomatoes-rule.md
+++ b/.changeset/quiet-tomatoes-rule.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-celo": minor
+---
+
+fix(coin-celo): apply fix for the custom fees on celo

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/prepareTransaction.test.ts
@@ -119,6 +119,30 @@ describe("prepareTransaction", () => {
     });
   });
 
+  it("should preserve custom fees", async () => {
+    const transaction = await prepareTransaction(
+      { ...accountFixture, balance: BigNumber(222222), spendableBalance: BigNumber(222222) },
+      {
+        ...transactionFixture,
+        recipient: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+        amount: BigNumber(22),
+        feesStrategy: "custom",
+        fees: BigNumber(123000000000),
+      },
+    );
+
+    expect(transaction).toMatchObject({
+      amount: BigNumber(22),
+      recipient: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+      useAllAmount: false,
+      family: "celo",
+      mode: "send",
+      index: 0,
+      feesStrategy: "custom",
+      fees: BigNumber(123000000000),
+    });
+  });
+
   it("should return the prepared stable token transaction", async () => {
     const transaction = await prepareTransaction(
       {

--- a/libs/coin-modules/coin-celo/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/prepareTransaction.ts
@@ -22,7 +22,12 @@ export const prepareTransaction: AccountBridge<
   )
     return transaction;
 
-  const fees = await getFeesForTransaction({ account, transaction });
+  const fees =
+    transaction.feesStrategy === "custom" &&
+    BigNumber.isBigNumber(transaction.fees) &&
+    transaction.fees.gt(0)
+      ? transaction.fees
+      : await getFeesForTransaction({ account, transaction });
 
   const tokenAccount = findSubAccountById(account, transaction.subAccountId || "");
   const isTokenTransaction = tokenAccount?.type === "TokenAccount";


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR fixes Celo send transactions where custom fees were ignored during `prepareTransaction`. When `feesStrategy` is set to custom with a positive fee value, `prepareTransaction` now keeps the user provided fees instead of recalculating them via `getFeesForTransaction`

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-32721)**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
