### PR TITLE
[LWDM] refactor(coin-framework): stop recomputing send-max via validateIntent

### DIFF
--- a/.changeset/loud-pillows-attack.md
+++ b/.changeset/loud-pillows-attack.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+generic coin-framework bridge: compute the `useAllAmount` (send-max) amount once. `prepareTransaction` now derives the final amount from the single fee estimation (`parameters.amount` when the coin module provides it, e.g. Tezos, otherwise `spendableBalance - fees`), `signOperation` reuses that amount instead of recomputing it, and `estimateMaxSpendable` no longer calls `validateIntent`. `getTransactionStatus` still uses `validateIntent` for errors/warnings, so the displayed amount is unchanged (LIVE-22227, LIVE-22228, LIVE-22229).

--- a/.changeset/loud-pillows-attack.md
+++ b/.changeset/loud-pillows-attack.md
@@ -1,5 +1,7 @@
 ---
 "@ledgerhq/live-common": patch
+"@ledgerhq/coin-evm": patch
+"@ledgerhq/coin-tezos": patch
 ---
 
-generic coin-framework bridge: compute the `useAllAmount` (send-max) amount once. `prepareTransaction` now derives the final amount from the single fee estimation (`parameters.amount` when the coin module provides it, e.g. Tezos, otherwise `spendableBalance - fees`), `signOperation` reuses that amount instead of recomputing it, and `estimateMaxSpendable` no longer calls `validateIntent`. `getTransactionStatus` still uses `validateIntent` for errors/warnings, so the displayed amount is unchanged (LIVE-22227, LIVE-22228, LIVE-22229).
+generic coin-framework bridge: compute the send-max (`useAllAmount`) amount once in `prepareTransaction` and reuse it in `signOperation`, instead of recomputing it via `validateIntent` in `prepareTransaction`, `signOperation` and `estimateMaxSpendable`. The amount is `parameters.amount` when the coin exposes it (Tezos), the token sub-account balance for token sends, otherwise `spendableBalance - max(reserve, fees)` (coin-evm now exposes `reserve`/`amountScale` for delegate). Pending operations are subtracted so the amount stays consistent with `getTransactionStatus` (LIVE-22227, LIVE-22228, LIVE-22229).

--- a/libs/coin-modules/coin-evm/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/estimateFees.test.ts
@@ -479,6 +479,36 @@ describe("estimateFees", () => {
     });
   });
 
+  it("exposes reserve and amountScale for a delegate send-max (useAllAmount)", async () => {
+    nodeApiMock.getGasEstimation.mockResolvedValue(new BigNumber("21000"));
+    nodeApiMock.getTransactionCount.mockResolvedValue(42);
+    nodeApiMock.getFeeData.mockResolvedValue({
+      gasPrice: new BigNumber("20000000000"),
+      maxFeePerGas: null,
+      maxPriorityFeePerGas: null,
+      nextBaseFee: null,
+    });
+    mockGetGasTracker.mockReturnValue(null);
+
+    const delegateMaxIntent = {
+      ...mockIntent,
+      intentType: "staking" as const,
+      mode: "delegate",
+      recipient: "0x0000000000000000000000000000000000001005",
+      valAddress: "seivaloper1y82m5y3wevjneamzg0pmx87dzanyxzht0kepvn",
+      amount: 1000000n,
+      useAllAmount: true,
+    };
+    const result = await estimateFees(
+      { ...mockCurrency, id: "sei_evm", ethereumLikeInfo: { chainId: 1329 } },
+      delegateMaxIntent,
+    );
+    expect(result.parameters).toMatchObject({
+      reserve: 10n ** 17n, // 0.1 SEI reserve
+      amountScale: 10n ** 12n, // usei -> wei scale
+    });
+  });
+
   it("returns 0 for redelegate without dstValAddress and makes no node/gas-tracker calls", async () => {
     const redelegateNoDst = {
       ...mockIntent,

--- a/libs/coin-modules/coin-evm/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-evm/src/logic/estimateFees.ts
@@ -12,6 +12,7 @@ import { getGasTracker } from "../network/gasTracker";
 import { getNodeApi } from "../network/node";
 import { ApiFeeData, ApiGasOptions, FeeData, GasOptions, TransactionTypes } from "../types";
 import { isEthAddress, isStakingIntent } from "../utils";
+import { STAKING_CONTRACTS } from "../staking";
 import { getTransactionType, prepareUnsignedTxParams } from "./common";
 import { getNextSequence } from "./getNextSequence";
 
@@ -200,6 +201,18 @@ export async function estimateFees(
   };
   const additionalFees = await computeAdditionalFees(currency, unsignedTransaction);
 
+  // delegate send-max: expose reserve/scale so the bridge can compute the amount (it has the balance)
+  const stakingConfig = STAKING_CONTRACTS[currency.id];
+  const delegateMaxParams =
+    transactionIntent.useAllAmount &&
+    isStakingIntent(transactionIntent) &&
+    transactionIntent.mode === "delegate"
+      ? {
+          reserve: stakingConfig?.delegationMaxAmountReserve,
+          amountScale: stakingConfig?.calldataAmountScale,
+        }
+      : undefined;
+
   return {
     value: BigInt(fee.toString()),
     parameters: {
@@ -208,6 +221,7 @@ export async function estimateFees(
       additionalFees: additionalFees && BigInt(additionalFees.toFixed()),
       gasLimit: BigInt(gasLimit.toFixed()),
       gasOptions: finalGasOptions && toApiGasOptions(finalGasOptions),
+      ...delegateMaxParams,
     },
   };
 }

--- a/libs/coin-modules/coin-tezos/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.test.ts
@@ -447,6 +447,44 @@ describe("estimateFees", () => {
     });
   });
 
+  it("forwards stakedBalance and unstakedBalance to the logic estimate for send-max", async () => {
+    (networkApi.getAccountByAddress as jest.Mock).mockResolvedValueOnce({
+      type: "user",
+      balance: 1000,
+      revealed: true,
+      address: "tz1test",
+      publicKey: "edpktest",
+      counter: 0,
+      delegationLevel: 0,
+      delegationTime: "2021-01-01T00:00:00Z",
+      numTransactions: 0,
+      firstActivityTime: "2021-01-01T00:00:00Z",
+      stakedBalance: 200,
+      unstakedBalance: 300,
+    });
+    logicEstimateFees.mockResolvedValue({
+      estimatedFees: DEFAULT_ESTIMATED_FEES,
+      gasLimit: DEFAULT_GAS_LIMIT,
+      storageLimit: DEFAULT_STORAGE_LIMIT,
+      amount: 500n,
+    });
+
+    await api.estimateFees({
+      intentType: "transaction",
+      type: "send",
+      sender: "tz1test",
+      recipient: "tz1recipient",
+      amount: 0n,
+      useAllAmount: true,
+    } as TransactionIntent);
+
+    expect(logicEstimateFees).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: expect.objectContaining({ stakedBalance: 200n, unstakedBalance: 300n }),
+      }),
+    );
+  });
+
   it("should throw taquito errors", async () => {
     logicEstimateFees.mockResolvedValue({
       estimatedFees: DEFAULT_ESTIMATED_FEES,

--- a/libs/coin-modules/coin-tezos/src/api/index.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.ts
@@ -240,6 +240,7 @@ async function estimate(transactionIntent: TransactionIntent): Promise<TezosFeeE
     revealed: senderAccountInfo.revealed,
     balance: BigInt(senderAccountInfo.balance),
     stakedBalance: BigInt(senderAccountInfo.stakedBalance ?? 0),
+    unstakedBalance: BigInt(senderAccountInfo.unstakedBalance ?? 0),
   };
 
   const tokenEstimationInfo =

--- a/libs/coin-modules/coin-tezos/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/estimateFees.test.ts
@@ -254,6 +254,28 @@ describe("estimateFees", () => {
     expect(result.amount).toBe(4321n);
   });
 
+  it("useAllAmount unstake resolves max to the staked balance", async () => {
+    mockTezosToolkit.estimate.unstake.mockResolvedValue({
+      suggestedFeeMutez: 710,
+      gasLimit: 1200,
+      storageLimit: 6,
+      burnFeeMutez: 0,
+      opSize: 100,
+    });
+
+    const result = await estimateFees({
+      account: { ...revealedAccount, stakedBalance: 5000n },
+      transaction: {
+        mode: "unstake",
+        recipient: "",
+        amount: 0n,
+        useAllAmount: true,
+      },
+    });
+
+    expect(result.amount).toBe(5000n);
+  });
+
   it("useAllAmount stake coerces amount to 1 for estimation and resolves max to balance minus fees and reserve", async () => {
     const suggestedFee = 700;
     const balance = 1_000_000n;

--- a/libs/coin-modules/coin-tezos/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/estimateFees.ts
@@ -203,6 +203,9 @@ export async function estimateFees({
         account.unstakedBalance ?? 0n,
         BigInt(mainOpFee) + revealFee,
       );
+    } else if (transaction.useAllAmount && transaction.mode === "unstake") {
+      // unstake-max draws from the staked balance, not the spendable balance
+      estimation.amount = account.stakedBalance ?? 0n;
     } else {
       estimation.amount = transaction.amount;
     }

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/estimateMaxSpendable.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/estimateMaxSpendable.ts
@@ -3,7 +3,12 @@ import type { FeeEstimation } from "@ledgerhq/coin-module-framework/api/types";
 import { getMainAccount } from "../../account";
 import { getCoinModuleApi } from "./api";
 import { createTransaction } from "./createTransaction";
-import { computeUseAllAmount, getPendingTokenSpent, transactionToIntent } from "./utils";
+import {
+  computeUseAllAmount,
+  getNativeSpendableAfterPending,
+  getPendingTokenSpent,
+  transactionToIntent,
+} from "./utils";
 import BigNumber from "bignumber.js";
 import { GenericTransaction } from "./types";
 import { getBridgeApi } from "./bridge";
@@ -27,22 +32,23 @@ export function genericEstimateMaxSpendable(
       useAllAmount: true,
     };
 
-    const estimation: FeeEstimation = BigNumber.isBigNumber(transaction?.fees)
-      ? {
-          value: BigInt(transaction.fees.toFixed()),
-          parameters: BigNumber.isBigNumber(transaction?.additionalFees)
-            ? { additionalFees: BigInt(transaction.additionalFees.toFixed()) }
-            : undefined,
-        }
-      : await coinModuleApi.estimateFees(
-          transactionToIntent(
-            mainAccount,
-            draftTransaction,
-            bridgeApi.computeIntentType,
-            coinModuleApi.craftTransactionData,
-          ),
-        );
+    const estimated = await coinModuleApi.estimateFees(
+      transactionToIntent(
+        mainAccount,
+        draftTransaction,
+        bridgeApi.computeIntentType,
+        coinModuleApi.craftTransactionData,
+      ),
+    );
+    const estimation: FeeEstimation = {
+      value: BigNumber.isBigNumber(transaction?.fees)
+        ? BigInt(transaction.fees.toFixed())
+        : estimated.value,
+      parameters: BigNumber.isBigNumber(transaction?.additionalFees)
+        ? { ...estimated.parameters, additionalFees: BigInt(transaction.additionalFees.toFixed()) }
+        : estimated.parameters,
+    };
 
-    return computeUseAllAmount(estimation, account.spendableBalance);
+    return computeUseAllAmount(estimation, getNativeSpendableAfterPending(account));
   };
 }

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/estimateMaxSpendable.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/estimateMaxSpendable.ts
@@ -1,13 +1,9 @@
 import { AccountBridge } from "@ledgerhq/types-live";
+import type { FeeEstimation } from "@ledgerhq/coin-module-framework/api/types";
 import { getMainAccount } from "../../account";
 import { getCoinModuleApi } from "./api";
 import { createTransaction } from "./createTransaction";
-import {
-  bigNumberToBigIntDeep,
-  extractBalances,
-  getPendingTokenSpent,
-  transactionToIntent,
-} from "./utils";
+import { computeUseAllAmount, getPendingTokenSpent, transactionToIntent } from "./utils";
 import BigNumber from "bignumber.js";
 import { GenericTransaction } from "./types";
 import { getBridgeApi } from "./bridge";
@@ -31,35 +27,22 @@ export function genericEstimateMaxSpendable(
       useAllAmount: true,
     };
 
-    let fees = transaction?.fees;
-    if (!BigNumber.isBigNumber(fees)) {
-      const { value } = await coinModuleApi.estimateFees(
-        transactionToIntent(
-          mainAccount,
-          draftTransaction,
-          bridgeApi.computeIntentType,
-          coinModuleApi.craftTransactionData,
-        ),
-      );
+    const estimation: FeeEstimation = BigNumber.isBigNumber(transaction?.fees)
+      ? {
+          value: BigInt(transaction.fees.toFixed()),
+          parameters: BigNumber.isBigNumber(transaction?.additionalFees)
+            ? { additionalFees: BigInt(transaction.additionalFees.toFixed()) }
+            : undefined,
+        }
+      : await coinModuleApi.estimateFees(
+          transactionToIntent(
+            mainAccount,
+            draftTransaction,
+            bridgeApi.computeIntentType,
+            coinModuleApi.craftTransactionData,
+          ),
+        );
 
-      fees = new BigNumber(value.toString());
-    }
-
-    // TODO Remove the call to `validateIntent` https://ledgerhq.atlassian.net/browse/LIVE-22229
-    const { amount } = await coinModuleApi.validateIntent(
-      transactionToIntent(
-        account,
-        { ...draftTransaction },
-        bridgeApi.computeIntentType,
-        coinModuleApi.craftTransactionData,
-      ),
-      extractBalances(account, bridgeApi.getAssetFromToken),
-      bigNumberToBigIntDeep({ value: transaction?.fees ?? new BigNumber(0) }),
-    );
-    if (["stellar", "tezos", "evm", "solana"].includes(network)) {
-      return amount > 0 ? new BigNumber(amount.toString()) : new BigNumber(0);
-    }
-    const bnFee = BigNumber(fees.toString());
-    return BigNumber.max(0, account.spendableBalance.minus(bnFee));
+    return computeUseAllAmount(estimation, account.spendableBalance);
   };
 }

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
@@ -3,6 +3,7 @@ import { getCoinModuleApi } from "./api";
 import { getBridgeApi } from "./bridge";
 import {
   bigNumberToBigIntDeep,
+  computeUseAllAmount,
   extractBalances,
   toGasOptionsFromUnknown,
   transactionToIntent,
@@ -106,69 +107,76 @@ export function genericPrepareTransaction(
       gasOptions: transaction.gasOptions,
     });
     const estimation: FeeEstimation = customParametersFees
-      ? { value: BigInt(customParametersFees.toFixed()) }
+      ? {
+          value: BigInt(customParametersFees.toFixed()),
+          parameters: BigNumber.isBigNumber(transaction.additionalFees)
+            ? { additionalFees: BigInt(transaction.additionalFees.toFixed()) }
+            : undefined,
+        }
       : await coinModuleApi.estimateFees(intent, customFeesParameters);
     const fees = new BigNumber(estimation.value.toString());
 
-    if (!bnEq(transaction.fees, fees)) {
-      const next: GenericTransaction = {
-        ...transaction,
-        fees,
-        assetReference,
-        assetOwner,
-        customFees: {
-          parameters: {
-            fees: customParametersFees ? new BigNumber(customParametersFees.toString()) : undefined,
-          },
-        },
-      };
-
-      // Propagate needed fields
-      const fieldsToPropagate = [
-        "type",
-        "storageLimit",
-        "gasPrice",
-        // gas limit must not change in case it is custom
-        ...(transaction.customGasLimit ? [] : ["gasLimit"]),
-        "maxFeePerGas",
-        "maxPriorityFeePerGas",
-        "additionalFees",
-        // Slow/medium/fast presets produced by the coin-module: surfaced as-is
-        // so the UI can render fee presets without ever fetching them itself.
-        // Families that don't produce them leave this untouched.
-        "gasOptions",
-      ];
-
-      for (const field of fieldsToPropagate) {
-        propagateField(estimation, field, next);
-      }
-
-      if (
-        transaction.useAllAmount ||
-        ["stake", "unstake", "finalize_unstake", "delegate", "undelegate", "redelegate"].includes(
-          transaction.mode ?? "",
-        )
-      ) {
-        // TODO Remove the call to `validateIntent` https://ledgerhq.atlassian.net/browse/LIVE-22228
-        const { amount } = await coinModuleApi.validateIntent(
+    let nextAmount = transaction.amount;
+    if (transaction.useAllAmount) {
+      if (transaction.subAccountId) {
+        // token send-max uses the full token balance (fees are paid in the native unit)
+        nextAmount = amount;
+      } else if (intent.intentType === "staking" || (!!assetReference && !!assetOwner)) {
+        // staking and tokens without a subAccountId have a coin-specific max we can't
+        // compute generically, so let the coin module work it out via validateIntent
+        const { amount: validated } = await coinModuleApi.validateIntent(
           transactionToIntent(
             account,
-            {
-              ...transaction,
-              assetOwner,
-              assetReference,
-            },
+            { ...transaction, assetOwner, assetReference },
             bridgeApi.computeIntentType,
             coinModuleApi.craftTransactionData,
           ),
           extractBalances(account, getAssetFromTokenForCurrency),
         );
-        next.amount = new BigNumber(amount.toString());
+        nextAmount = new BigNumber(validated.toString());
+      } else {
+        nextAmount = computeUseAllAmount(estimation, account.spendableBalance);
       }
-      return next;
     }
 
-    return transaction;
+    if (bnEq(transaction.fees, fees) && bnEq(transaction.amount, nextAmount)) {
+      return transaction;
+    }
+
+    const next: GenericTransaction = {
+      ...transaction,
+      fees,
+      amount: nextAmount,
+      assetReference,
+      assetOwner,
+      customFees: {
+        parameters: {
+          fees: customParametersFees ? new BigNumber(customParametersFees.toString()) : undefined,
+        },
+      },
+    };
+
+    // Propagate needed fields
+    const fieldsToPropagate = [
+      "type",
+      "storageLimit",
+      "gasPrice",
+      // gas limit must not change in case it is custom
+      ...(transaction.customGasLimit ? [] : ["gasLimit"]),
+      "maxFeePerGas",
+      "maxPriorityFeePerGas",
+      "additionalFees",
+      // Slow/medium/fast presets produced by the coin-module: surfaced as-is
+      // so the UI can render fee presets without ever fetching them itself.
+      // Families that don't produce them leave this untouched.
+      "gasOptions",
+    ];
+
+    for (const field of fieldsToPropagate) {
+      propagateField(estimation, field, next);
+    }
+
+    return next;
   };
 }
 

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
@@ -4,7 +4,8 @@ import { getBridgeApi } from "./bridge";
 import {
   bigNumberToBigIntDeep,
   computeUseAllAmount,
-  extractBalances,
+  getNativeSpendableAfterPending,
+  getPendingTokenSpent,
   toGasOptionsFromUnknown,
   transactionToIntent,
 } from "./utils";
@@ -81,7 +82,10 @@ export function genericPrepareTransaction(
     let amount = transaction.amount;
     if (transaction.useAllAmount && transaction.subAccountId) {
       const subAccount = account.subAccounts?.find(acc => acc.id === transaction.subAccountId);
-      amount = subAccount?.spendableBalance ?? amount;
+      if (subAccount) {
+        const pendingTokenSpent = getPendingTokenSpent(subAccount.pendingOperations ?? []);
+        amount = BigNumber.max(0, subAccount.spendableBalance.minus(pendingTokenSpent));
+      }
     }
 
     // Pass any parameters that help estimating fees
@@ -106,40 +110,30 @@ export function genericPrepareTransaction(
       gasLimit: transaction.customGasLimit,
       gasOptions: transaction.gasOptions,
     });
+
+    const estimated =
+      customParametersFees && !transaction.useAllAmount
+        ? undefined
+        : await coinModuleApi.estimateFees(intent, customFeesParameters);
     const estimation: FeeEstimation = customParametersFees
-      ? {
-          value: BigInt(customParametersFees.toFixed()),
-          parameters: BigNumber.isBigNumber(transaction.additionalFees)
-            ? { additionalFees: BigInt(transaction.additionalFees.toFixed()) }
-            : undefined,
-        }
-      : await coinModuleApi.estimateFees(intent, customFeesParameters);
+      ? { value: BigInt(customParametersFees.toFixed()), parameters: estimated?.parameters }
+      : (estimated as FeeEstimation);
     const fees = new BigNumber(estimation.value.toString());
 
     let nextAmount = transaction.amount;
     if (transaction.useAllAmount) {
-      if (transaction.subAccountId) {
-        // token send-max uses the full token balance (fees are paid in the native unit)
-        nextAmount = amount;
-      } else if (intent.intentType === "staking" || (!!assetReference && !!assetOwner)) {
-        // staking and tokens without a subAccountId have a coin-specific max we can't
-        // compute generically, so let the coin module work it out via validateIntent
-        const { amount: validated } = await coinModuleApi.validateIntent(
-          transactionToIntent(
-            account,
-            { ...transaction, assetOwner, assetReference },
-            bridgeApi.computeIntentType,
-            coinModuleApi.craftTransactionData,
-          ),
-          extractBalances(account, getAssetFromTokenForCurrency),
-        );
-        nextAmount = new BigNumber(validated.toString());
-      } else {
-        nextAmount = computeUseAllAmount(estimation, account.spendableBalance);
-      }
+      // token: full token balance (fees are paid in the native unit), else compute from the estimation
+      nextAmount = transaction.subAccountId
+        ? amount
+        : computeUseAllAmount(estimation, getNativeSpendableAfterPending(account));
     }
 
-    if (bnEq(transaction.fees, fees) && bnEq(transaction.amount, nextAmount)) {
+    if (
+      bnEq(transaction.fees, fees) &&
+      bnEq(transaction.amount, nextAmount) &&
+      (transaction.assetReference ?? "") === assetReference &&
+      (transaction.assetOwner ?? "") === assetOwner
+    ) {
       return transaction;
     }
 

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
@@ -3,12 +3,7 @@ import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type { Account, DeviceId, SignOperationEvent, AccountBridge } from "@ledgerhq/types-live";
 import { getCoinModuleApi } from "./api";
 import { getBridgeApi } from "./bridge";
-import {
-  bigNumberToBigIntDeep,
-  buildOptimisticOperation,
-  extractBalances,
-  transactionToIntent,
-} from "./utils";
+import { bigNumberToBigIntDeep, buildOptimisticOperation, transactionToIntent } from "./utils";
 import { FeeNotLoaded } from "@ledgerhq/errors";
 import { type GetAddressResult } from "@ledgerhq/ledger-wallet-framework/derivation";
 import { log } from "@ledgerhq/logs";
@@ -45,40 +40,7 @@ export const genericSignOperation =
             additionalFees: transaction.additionalFees,
           },
         });
-        if (transaction.useAllAmount) {
-          const draftTransaction = {
-            mode: transaction.mode,
-            recipient: transaction.recipient,
-            amount: transaction.amount ?? 0,
-            useAllAmount: !!transaction.useAllAmount,
-            assetReference: transaction?.assetReference || "",
-            assetOwner: transaction?.assetOwner || "",
-            subAccountId: transaction.subAccountId || "",
-            memoType: transaction.memoType || "",
-            memoValue: transaction.memoValue || "",
-            tag: transaction.tag,
-            family: transaction.family,
-            feesStrategy: transaction.feesStrategy,
-            data: transaction.data,
-            type: transaction.type,
-            sponsored: transaction.sponsored,
-            valAddress: transaction?.valAddress || "",
-            valId: transaction?.valId,
-            dstValAddress: transaction?.dstValAddress || "",
-          };
-          // TODO Remove the call to `validateIntent` https://ledgerhq.atlassian.net/browse/LIVE-22227
-          const { amount } = await coinModuleApi.validateIntent(
-            transactionToIntent(
-              account,
-              draftTransaction,
-              bridgeApi.computeIntentType,
-              coinModuleApi.craftTransactionData,
-            ),
-            extractBalances(account, bridgeApi.getAssetFromToken),
-            customFees,
-          );
-          transaction.amount = new BigNumber(amount.toString());
-        }
+        // amount is already finalized by prepareTransaction; sign it as-is
         const signedInfo = await signerContext(deviceId, async signer => {
           const derivationPath = account.freshAddressPath;
           const { publicKey } = (await signer.getAddress(derivationPath, {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/estimateMaxSpendable.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/estimateMaxSpendable.test.ts
@@ -15,7 +15,6 @@ jest.mock("../createTransaction", () => ({
 const mockedGetCoinModuleApi = coinframework.getCoinModuleApi as jest.Mock;
 
 describe("genericEstimateMaxSpendable", () => {
-  const validateIntentMock = jest.fn();
   const estimateFeesMock = jest.fn();
   const dummyAccount = {
     id: "account_id",
@@ -36,10 +35,23 @@ describe("genericEstimateMaxSpendable", () => {
     jest.clearAllMocks();
   });
 
+  it("returns the token account spendable balance directly for a TokenAccount", async () => {
+    mockedGetCoinModuleApi.mockReturnValue({ estimateFees: estimateFeesMock });
+
+    const estimate = genericEstimateMaxSpendable("testnet", "local");
+    const result = await estimate({
+      account: { type: "TokenAccount", spendableBalance: new BigNumber(123) } as any,
+      parentAccount: null,
+      transaction: {} as any,
+    });
+
+    expect(result.toString()).toBe("123");
+    expect(estimateFeesMock).not.toHaveBeenCalled();
+  });
+
   it("subtracts estimated fee from spendable balance", async () => {
     mockedGetCoinModuleApi.mockReturnValue({
       estimateFees: estimateFeesMock.mockResolvedValue({ value: 10000n }),
-      validateIntent: validateIntentMock.mockResolvedValue({ amount: 49990000n }),
     });
 
     const estimate = genericEstimateMaxSpendable("testnet", "local");
@@ -50,11 +62,42 @@ describe("genericEstimateMaxSpendable", () => {
     });
 
     expect(result.toString()).toBe("49990000");
-    expect(validateIntentMock).toHaveBeenCalledWith(
-      expect.anything(),
-      [{ value: 60000000n, locked: 10000000n, asset: { type: "native" } }],
-      expect.anything(),
-    );
+  });
+
+  it("subtracts additionalFees surfaced in parameters", async () => {
+    mockedGetCoinModuleApi.mockReturnValue({
+      estimateFees: estimateFeesMock.mockResolvedValue({
+        value: 10000n,
+        parameters: { additionalFees: 5000n },
+      }),
+    });
+
+    const estimate = genericEstimateMaxSpendable("testnet", "local");
+    const result = await estimate({
+      account: dummyAccount,
+      parentAccount: null,
+      transaction: {} as any,
+    });
+
+    expect(result.toString()).toBe("49985000");
+  });
+
+  it("uses parameters.amount when the coin module provides it", async () => {
+    mockedGetCoinModuleApi.mockReturnValue({
+      estimateFees: estimateFeesMock.mockResolvedValue({
+        value: 10000n,
+        parameters: { amount: 42n },
+      }),
+    });
+
+    const estimate = genericEstimateMaxSpendable("testnet", "local");
+    const result = await estimate({
+      account: dummyAccount,
+      parentAccount: null,
+      transaction: {} as any,
+    });
+
+    expect(result.toString()).toBe("42");
   });
 
   it("returns 0 if fee is higher than spendable", async () => {
@@ -65,7 +108,6 @@ describe("genericEstimateMaxSpendable", () => {
 
     mockedGetCoinModuleApi.mockReturnValue({
       estimateFees: estimateFeesMock.mockResolvedValue({ value: 10000n }),
-      validateIntent: validateIntentMock.mockResolvedValue({ amount: 0n }),
     });
 
     const estimate = genericEstimateMaxSpendable("testnet", "local");
@@ -131,7 +173,6 @@ describe("genericEstimateMaxSpendable", () => {
   it("returns full spendable balance if fee is 0", async () => {
     mockedGetCoinModuleApi.mockReturnValue({
       estimateFees: estimateFeesMock.mockResolvedValue({ value: 0n }),
-      validateIntent: validateIntentMock.mockResolvedValue({ amount: 50000000n }),
     });
 
     const estimate = genericEstimateMaxSpendable("testnet", "local");
@@ -142,5 +183,37 @@ describe("genericEstimateMaxSpendable", () => {
     });
 
     expect(result.toString()).toBe("50000000");
+  });
+
+  it("uses the provided transaction fees without estimating again", async () => {
+    mockedGetCoinModuleApi.mockReturnValue({
+      estimateFees: estimateFeesMock,
+    });
+
+    const estimate = genericEstimateMaxSpendable("testnet", "local");
+    const result = await estimate({
+      account: dummyAccount,
+      parentAccount: null,
+      transaction: { fees: new BigNumber(20000) } as any,
+    });
+
+    expect(result.toString()).toBe("49980000");
+    expect(estimateFeesMock).not.toHaveBeenCalled();
+  });
+
+  it("subtracts provided additionalFees on top of the provided fees", async () => {
+    mockedGetCoinModuleApi.mockReturnValue({
+      estimateFees: estimateFeesMock,
+    });
+
+    const estimate = genericEstimateMaxSpendable("testnet", "local");
+    const result = await estimate({
+      account: dummyAccount,
+      parentAccount: null,
+      transaction: { fees: new BigNumber(20000), additionalFees: new BigNumber(5000) } as any,
+    });
+
+    expect(result.toString()).toBe("49975000");
+    expect(estimateFeesMock).not.toHaveBeenCalled();
   });
 });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/estimateMaxSpendable.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/estimateMaxSpendable.test.ts
@@ -82,6 +82,28 @@ describe("genericEstimateMaxSpendable", () => {
     expect(result.toString()).toBe("49985000");
   });
 
+  it("subtracts funds committed by pending native operations from the send-max", async () => {
+    mockedGetCoinModuleApi.mockReturnValue({
+      estimateFees: estimateFeesMock.mockResolvedValue({ value: 10000n }),
+    });
+
+    const estimate = genericEstimateMaxSpendable("testnet", "local");
+    const result = await estimate({
+      account: {
+        ...dummyAccount,
+        // pending OUT send commits its value + fee against the native balance until next sync
+        pendingOperations: [
+          { type: "OUT", value: new BigNumber(1_000_000), fee: new BigNumber(2000) },
+        ],
+      } as unknown as Account,
+      parentAccount: null,
+      transaction: {} as any,
+    });
+
+    // 50000000 - (1000000 + 2000) pending - 10000 fee
+    expect(result.toString()).toBe("48988000");
+  });
+
   it("uses parameters.amount when the coin module provides it", async () => {
     mockedGetCoinModuleApi.mockReturnValue({
       estimateFees: estimateFeesMock.mockResolvedValue({
@@ -98,6 +120,24 @@ describe("genericEstimateMaxSpendable", () => {
     });
 
     expect(result.toString()).toBe("42");
+  });
+
+  it("falls back to 0 when parameters.amount is not numeric", async () => {
+    mockedGetCoinModuleApi.mockReturnValue({
+      estimateFees: estimateFeesMock.mockResolvedValue({
+        value: 10000n,
+        parameters: { amount: null },
+      }),
+    });
+
+    const estimate = genericEstimateMaxSpendable("testnet", "local");
+    const result = await estimate({
+      account: dummyAccount,
+      parentAccount: null,
+      transaction: {} as any,
+    });
+
+    expect(result.toString()).toBe("0");
   });
 
   it("returns 0 if fee is higher than spendable", async () => {
@@ -185,9 +225,12 @@ describe("genericEstimateMaxSpendable", () => {
     expect(result.toString()).toBe("50000000");
   });
 
-  it("uses the provided transaction fees without estimating again", async () => {
+  it("overrides the estimated fee value with the provided one but keeps coin parameters", async () => {
     mockedGetCoinModuleApi.mockReturnValue({
-      estimateFees: estimateFeesMock,
+      estimateFees: estimateFeesMock.mockResolvedValue({
+        value: 999n,
+        parameters: { amount: 42n },
+      }),
     });
 
     const estimate = genericEstimateMaxSpendable("testnet", "local");
@@ -197,13 +240,14 @@ describe("genericEstimateMaxSpendable", () => {
       transaction: { fees: new BigNumber(20000) } as any,
     });
 
-    expect(result.toString()).toBe("49980000");
-    expect(estimateFeesMock).not.toHaveBeenCalled();
+    // parameters.amount wins over the spendable-minus-fee computation
+    expect(result.toString()).toBe("42");
+    expect(estimateFeesMock).toHaveBeenCalled();
   });
 
-  it("subtracts provided additionalFees on top of the provided fees", async () => {
+  it("overrides the estimated fee value with the provided fees + additionalFees", async () => {
     mockedGetCoinModuleApi.mockReturnValue({
-      estimateFees: estimateFeesMock,
+      estimateFees: estimateFeesMock.mockResolvedValue({ value: 999n }),
     });
 
     const estimate = genericEstimateMaxSpendable("testnet", "local");
@@ -214,6 +258,5 @@ describe("genericEstimateMaxSpendable", () => {
     });
 
     expect(result.toString()).toBe("49975000");
-    expect(estimateFeesMock).not.toHaveBeenCalled();
   });
 });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/prepareTransaction.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/prepareTransaction.test.ts
@@ -238,58 +238,131 @@ describe("genericPrepareTransaction", () => {
     );
   });
 
+  it("uses customFees.parameters.fees without calling estimateFees", async () => {
+    const estimateFees = jest.fn();
+    (getCoinModuleApi as jest.Mock).mockReturnValue({ estimateFees });
+
+    const prepareTransaction = genericPrepareTransaction("testnet", "local");
+    const result = await prepareTransaction(account, {
+      ...baseTransaction,
+      customFees: { parameters: { fees: new BigNumber(900) } },
+    } as GenericTransaction);
+
+    expect(estimateFees).not.toHaveBeenCalled();
+    expect((result as any).fees.toString()).toBe("900");
+  });
+
+  it("subtracts additionalFees from the synthetic custom-fees estimation on send-max", async () => {
+    const estimateFees = jest.fn();
+    (getCoinModuleApi as jest.Mock).mockReturnValue({ estimateFees });
+
+    const prepareTransaction = genericPrepareTransaction("testnet", "local");
+    const result = await prepareTransaction(
+      { ...account, spendableBalance: new BigNumber(1_000_000) },
+      {
+        ...baseTransaction,
+        customFees: { parameters: { fees: new BigNumber(900) } },
+        additionalFees: new BigNumber(100),
+        mode: "send",
+        useAllAmount: true,
+      } as GenericTransaction,
+    );
+
+    expect(estimateFees).not.toHaveBeenCalled();
+    // 1_000_000 - 900 - 100
+    expect((result as any).amount.toString()).toBe("999000");
+  });
+
   describe("delegation gas estimation (useAllAmount)", () => {
     const delegationAccount = {
       ...account,
       spendableBalance: new BigNumber(1_000_000_000),
     };
 
-    it("passes transaction amount to fee estimation for delegation with useAllAmount", async () => {
+    it("defers to validateIntent for staking send-max (e.g. EVM delegate)", async () => {
+      (transactionToIntent as jest.Mock).mockReturnValue({ intentType: "staking" });
       const estimateFees = jest.fn().mockResolvedValue({ value: new BigNumber(100) });
-      (getCoinModuleApi as jest.Mock).mockReturnValue({
-        estimateFees,
-        validateIntent: jest.fn().mockResolvedValue({ amount: 0n }),
-      });
+      const validateIntent = jest.fn().mockResolvedValue({ amount: 777n });
+      (getCoinModuleApi as jest.Mock).mockReturnValue({ estimateFees, validateIntent });
 
       const prepareTransaction = genericPrepareTransaction("testnet", "local");
-      await prepareTransaction(delegationAccount, {
+      const result = await prepareTransaction(delegationAccount, {
         ...baseTransaction,
         mode: "delegate",
         useAllAmount: true,
       } as GenericTransaction);
 
-      expect(transactionToIntent).toHaveBeenCalledWith(
-        delegationAccount,
-        expect.objectContaining({ amount: baseTransaction.amount }),
-        undefined,
-        undefined,
-      );
+      expect(validateIntent).toHaveBeenCalled();
+      expect((result as any).amount.toString()).toBe("777");
     });
 
-    it("passes transaction amount to fee estimation for non-delegation modes with useAllAmount", async () => {
-      const estimateFees = jest.fn().mockResolvedValue({ value: new BigNumber(1_200_000) });
-      (getCoinModuleApi as jest.Mock).mockReturnValue({
-        estimateFees,
-        validateIntent: jest.fn().mockResolvedValue({ amount: 0n }),
-      });
+    it("defers to validateIntent for token send-max without subAccountId", async () => {
+      const estimateFees = jest.fn().mockResolvedValue({ value: new BigNumber(100) });
+      const validateIntent = jest.fn().mockResolvedValue({ amount: 4242n });
+      (getCoinModuleApi as jest.Mock).mockReturnValue({ estimateFees, validateIntent });
 
       const prepareTransaction = genericPrepareTransaction("testnet", "local");
-      await prepareTransaction(delegationAccount, {
+      const result = await prepareTransaction(delegationAccount, {
+        ...baseTransaction,
+        assetReference: "usdc",
+        assetOwner: "0xowner",
+        useAllAmount: true,
+      } as GenericTransaction);
+
+      expect(validateIntent).toHaveBeenCalled();
+      expect((result as any).amount.toString()).toBe("4242");
+    });
+
+    it("computes the send-max amount for non-delegation modes with useAllAmount", async () => {
+      const estimateFees = jest.fn().mockResolvedValue({ value: new BigNumber(1_200_000) });
+      (getCoinModuleApi as jest.Mock).mockReturnValue({ estimateFees });
+
+      const prepareTransaction = genericPrepareTransaction("testnet", "local");
+      const result = await prepareTransaction(delegationAccount, {
         ...baseTransaction,
         mode: "send",
         useAllAmount: true,
       } as GenericTransaction);
 
-      expect(transactionToIntent).toHaveBeenCalledWith(
-        delegationAccount,
-        expect.objectContaining({ amount: baseTransaction.amount }),
-        undefined,
-        undefined,
-      );
+      expect((result as any).amount.toString()).toBe("998800000");
+    });
+
+    it("uses parameters.amount when the coin module provides it", async () => {
+      const estimateFees = jest.fn().mockResolvedValue({
+        value: new BigNumber(100),
+        parameters: { amount: 12345n },
+      });
+      (getCoinModuleApi as jest.Mock).mockReturnValue({ estimateFees });
+
+      const prepareTransaction = genericPrepareTransaction("testnet", "local");
+      const result = await prepareTransaction(delegationAccount, {
+        ...baseTransaction,
+        mode: "send",
+        useAllAmount: true,
+      } as GenericTransaction);
+
+      expect((result as any).amount.toString()).toBe("12345");
+    });
+
+    it("refreshes the send-max amount even when fees are unchanged", async () => {
+      // fees already equal the estimation, so the early return path must still set the amount
+      const estimateFees = jest.fn().mockResolvedValue({ value: new BigNumber(500) });
+      (getCoinModuleApi as jest.Mock).mockReturnValue({ estimateFees });
+
+      const prepareTransaction = genericPrepareTransaction("testnet", "local");
+      const result = await prepareTransaction(delegationAccount, {
+        ...baseTransaction,
+        fees: new BigNumber(500),
+        amount: new BigNumber(0),
+        mode: "send",
+        useAllAmount: true,
+      } as GenericTransaction);
+
+      expect((result as any).amount.toString()).toBe("999999500");
     });
   });
 
-  it("estimates using the token account spendable balance when sending all amount", async () => {
+  it("uses the token account spendable balance when sending all amount", async () => {
     (decodeTokenAccountId as jest.Mock).mockResolvedValueOnce({
       accountId: "test-sub-account",
       token: undefined,
@@ -298,13 +371,10 @@ describe("genericPrepareTransaction", () => {
     (transactionToIntent as jest.Mock).mockImplementation((_, transaction) => ({
       amount: BigInt(transaction.amount.toFixed()),
     }));
-    (getCoinModuleApi as jest.Mock).mockReturnValue({
-      estimateFees,
-      validateIntent: intent => Promise.resolve({ amount: intent.amount }),
-    });
+    (getCoinModuleApi as jest.Mock).mockReturnValue({ estimateFees });
     const prepareTransaction = genericPrepareTransaction("testnet", "local");
 
-    await prepareTransaction(
+    const result = await prepareTransaction(
       {
         ...account,
         subAccounts: [{ id: "test-sub-account", spendableBalance: new BigNumber(100) }],
@@ -317,6 +387,7 @@ describe("genericPrepareTransaction", () => {
     );
 
     expect(estimateFees).toHaveBeenCalledWith(expect.objectContaining({ amount: 100n }), {});
+    expect((result as any).amount.toString()).toBe("100");
   });
 
   it("fills 'assetOwner' and 'assetReference' from 'subAccountId' for retro compatibility", async () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/prepareTransaction.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/prepareTransaction.test.ts
@@ -252,8 +252,11 @@ describe("genericPrepareTransaction", () => {
     expect((result as any).fees.toString()).toBe("900");
   });
 
-  it("subtracts additionalFees from the synthetic custom-fees estimation on send-max", async () => {
-    const estimateFees = jest.fn();
+  it("keeps the custom fee value but still fetches coin parameters on send-max", async () => {
+    // a custom total fee overrides only the value; additionalFees still come from estimateFees
+    const estimateFees = jest
+      .fn()
+      .mockResolvedValue({ value: 50n, parameters: { additionalFees: 100n } });
     (getCoinModuleApi as jest.Mock).mockReturnValue({ estimateFees });
 
     const prepareTransaction = genericPrepareTransaction("testnet", "local");
@@ -262,55 +265,38 @@ describe("genericPrepareTransaction", () => {
       {
         ...baseTransaction,
         customFees: { parameters: { fees: new BigNumber(900) } },
-        additionalFees: new BigNumber(100),
         mode: "send",
         useAllAmount: true,
       } as GenericTransaction,
     );
 
-    expect(estimateFees).not.toHaveBeenCalled();
-    // 1_000_000 - 900 - 100
+    expect(estimateFees).toHaveBeenCalled();
     expect((result as any).amount.toString()).toBe("999000");
   });
 
-  describe("delegation gas estimation (useAllAmount)", () => {
-    const delegationAccount = {
+  describe("useAllAmount (send-max) amount", () => {
+    const fundedAccount = {
       ...account,
       spendableBalance: new BigNumber(1_000_000_000),
     };
 
-    it("defers to validateIntent for staking send-max (e.g. EVM delegate)", async () => {
-      (transactionToIntent as jest.Mock).mockReturnValue({ intentType: "staking" });
-      const estimateFees = jest.fn().mockResolvedValue({ value: new BigNumber(100) });
-      const validateIntent = jest.fn().mockResolvedValue({ amount: 777n });
+    it("computes delegate send-max from reserve/amountScale params, without validateIntent", async () => {
+      const estimateFees = jest.fn().mockResolvedValue({
+        value: new BigNumber(100),
+        parameters: { reserve: 5500n, amountScale: 1000n },
+      });
+      const validateIntent = jest.fn();
       (getCoinModuleApi as jest.Mock).mockReturnValue({ estimateFees, validateIntent });
 
       const prepareTransaction = genericPrepareTransaction("testnet", "local");
-      const result = await prepareTransaction(delegationAccount, {
+      const result = await prepareTransaction(fundedAccount, {
         ...baseTransaction,
         mode: "delegate",
         useAllAmount: true,
       } as GenericTransaction);
 
-      expect(validateIntent).toHaveBeenCalled();
-      expect((result as any).amount.toString()).toBe("777");
-    });
-
-    it("defers to validateIntent for token send-max without subAccountId", async () => {
-      const estimateFees = jest.fn().mockResolvedValue({ value: new BigNumber(100) });
-      const validateIntent = jest.fn().mockResolvedValue({ amount: 4242n });
-      (getCoinModuleApi as jest.Mock).mockReturnValue({ estimateFees, validateIntent });
-
-      const prepareTransaction = genericPrepareTransaction("testnet", "local");
-      const result = await prepareTransaction(delegationAccount, {
-        ...baseTransaction,
-        assetReference: "usdc",
-        assetOwner: "0xowner",
-        useAllAmount: true,
-      } as GenericTransaction);
-
-      expect(validateIntent).toHaveBeenCalled();
-      expect((result as any).amount.toString()).toBe("4242");
+      expect((result as any).amount.toString()).toBe("999994000");
+      expect(validateIntent).not.toHaveBeenCalled();
     });
 
     it("computes the send-max amount for non-delegation modes with useAllAmount", async () => {
@@ -318,7 +304,7 @@ describe("genericPrepareTransaction", () => {
       (getCoinModuleApi as jest.Mock).mockReturnValue({ estimateFees });
 
       const prepareTransaction = genericPrepareTransaction("testnet", "local");
-      const result = await prepareTransaction(delegationAccount, {
+      const result = await prepareTransaction(fundedAccount, {
         ...baseTransaction,
         mode: "send",
         useAllAmount: true,
@@ -335,7 +321,7 @@ describe("genericPrepareTransaction", () => {
       (getCoinModuleApi as jest.Mock).mockReturnValue({ estimateFees });
 
       const prepareTransaction = genericPrepareTransaction("testnet", "local");
-      const result = await prepareTransaction(delegationAccount, {
+      const result = await prepareTransaction(fundedAccount, {
         ...baseTransaction,
         mode: "send",
         useAllAmount: true,
@@ -344,13 +330,37 @@ describe("genericPrepareTransaction", () => {
       expect((result as any).amount.toString()).toBe("12345");
     });
 
+    it("subtracts funds committed by pending native operations from the send-max", async () => {
+      const estimateFees = jest.fn().mockResolvedValue({ value: new BigNumber(1_200_000) });
+      (getCoinModuleApi as jest.Mock).mockReturnValue({ estimateFees });
+
+      const prepareTransaction = genericPrepareTransaction("testnet", "local");
+      const result = await prepareTransaction(
+        {
+          ...fundedAccount,
+          // pending OUT send commits its value + fee against the native balance until next sync
+          pendingOperations: [
+            { type: "OUT", value: new BigNumber(10_000_000), fee: new BigNumber(1_200_000) },
+          ],
+        },
+        {
+          ...baseTransaction,
+          mode: "send",
+          useAllAmount: true,
+        } as GenericTransaction,
+      );
+
+      // 1000000000 - (10000000 + 1200000) pending - 1200000 fee
+      expect((result as any).amount.toString()).toBe("987600000");
+    });
+
     it("refreshes the send-max amount even when fees are unchanged", async () => {
       // fees already equal the estimation, so the early return path must still set the amount
       const estimateFees = jest.fn().mockResolvedValue({ value: new BigNumber(500) });
       (getCoinModuleApi as jest.Mock).mockReturnValue({ estimateFees });
 
       const prepareTransaction = genericPrepareTransaction("testnet", "local");
-      const result = await prepareTransaction(delegationAccount, {
+      const result = await prepareTransaction(fundedAccount, {
         ...baseTransaction,
         fees: new BigNumber(500),
         amount: new BigNumber(0),
@@ -388,6 +398,40 @@ describe("genericPrepareTransaction", () => {
 
     expect(estimateFees).toHaveBeenCalledWith(expect.objectContaining({ amount: 100n }), {});
     expect((result as any).amount.toString()).toBe("100");
+  });
+
+  it("subtracts pending token operations from the token send-max", async () => {
+    (decodeTokenAccountId as jest.Mock).mockResolvedValueOnce({
+      accountId: "test-sub-account",
+      token: undefined,
+    });
+    const estimateFees = jest.fn().mockResolvedValue({ value: new BigNumber(50) });
+    (transactionToIntent as jest.Mock).mockImplementation((_, transaction) => ({
+      amount: BigInt(transaction.amount.toFixed()),
+    }));
+    (getCoinModuleApi as jest.Mock).mockReturnValue({ estimateFees });
+    const prepareTransaction = genericPrepareTransaction("testnet", "local");
+
+    const result = await prepareTransaction(
+      {
+        ...account,
+        subAccounts: [
+          {
+            id: "test-sub-account",
+            spendableBalance: new BigNumber(100),
+            pendingOperations: [{ type: "OUT", value: new BigNumber(30) }],
+          },
+        ],
+      },
+      {
+        subAccountId: "test-sub-account",
+        useAllAmount: true,
+        amount: new BigNumber(0),
+      } as GenericTransaction,
+    );
+
+    // 100 token spendable - 30 committed by the pending token send
+    expect((result as any).amount.toString()).toBe("70");
   });
 
   it("fills 'assetOwner' and 'assetReference' from 'subAccountId' for retro compatibility", async () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/signOperation.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/signOperation.test.ts
@@ -90,6 +90,32 @@ describe("genericSignOperation", () => {
     );
   });
 
+  it("signs the prepared amount on useAllAmount without recomputing it via validateIntent", async () => {
+    const validateIntent = jest.fn();
+    (getCoinModuleApi as jest.Mock).mockReturnValue({
+      craftTransaction,
+      getAccountInfo: jest.fn().mockResolvedValue("pubKey"),
+      combine: jest.fn().mockResolvedValue("signedTx"),
+      getNextSequence: jest.fn().mockResolvedValue(1n),
+      validateIntent,
+    });
+
+    const signOperation = genericSignOperation("mainnet", "xrp")(mockSignerContext);
+    const observable = signOperation({
+      account,
+      transaction: { ...transaction, useAllAmount: true, amount: new BigNumber(100_000) },
+      deviceId: "",
+    });
+
+    await lastValueFrom(observable.pipe(toArray()));
+
+    expect(validateIntent).not.toHaveBeenCalled();
+    expect(craftTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 100000n }),
+      expect.anything(),
+    );
+  });
+
   it("throws FeeNotLoaded if fees are missing", async () => {
     const txWithoutFees = { ...transaction };
     delete txWithoutFees.fees;

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -119,7 +119,7 @@ function isSponsoredOperation(op: Operation): boolean {
  * `pendingOperations` are optimistic and don’t affect `spendableBalance` until the next sync.
  * Lock the native amount already committed by pending ops: fees for any non-sponsored op, plus outgoing value for OUT-family ops. See LIVE-33180.
  */
-function getPendingNativeSpent(pendingOperations: Operation[]): BigNumber {
+export function getPendingNativeSpent(pendingOperations: Operation[]): BigNumber {
   return pendingOperations.reduce((spent, op) => {
     const withFee = isSponsoredOperation(op) ? spent : spent.plus(op.fee);
     if (op.type === "FEES") return withFee;
@@ -127,6 +127,18 @@ function getPendingNativeSpent(pendingOperations: Operation[]): BigNumber {
 
     return withFee;
   }, new BigNumber(0));
+}
+
+/**
+ * Native spendable balance once funds committed by pending (optimistic, not-yet-synced)
+ * operations are removed. `spendableBalance` alone ignores pending ops until the next
+ * sync, so send-max computed from it would overestimate while a previous send is pending.
+ * This keeps the generic `computeUseAllAmount` path in sync with `validateIntent`
+ * (used by `getTransactionStatus`), which already accounts for pending via `extractBalances`.
+ */
+export function getNativeSpendableAfterPending(account: Account): BigNumber {
+  const pendingSpent = getPendingNativeSpent(account.pendingOperations ?? []);
+  return BigNumber.max(0, account.spendableBalance.minus(pendingSpent));
 }
 
 // Used for token sub-accounts: lock `op.value` for pending ops that should reduce token spendable.
@@ -181,34 +193,44 @@ export function extractBalances(
     balances.push({
       value: BigInt(subAccount.balance.toFixed()),
       asset,
-      locked: BigInt(
-        BigNumber.min(tokenReserve.plus(tokenPending), subAccount.balance).toFixed(),
-      ),
+      locked: BigInt(BigNumber.min(tokenReserve.plus(tokenPending), subAccount.balance).toFixed()),
     });
   }
 
   return balances;
 }
 
-/** Base fee plus any `additionalFees` from parameters (e.g. EVM L2 data fees). */
-function totalFeesFromEstimation(estimation: FeeEstimation): BigNumber {
-  const raw = estimation.parameters?.additionalFees;
-  const additional =
-    typeof raw === "bigint" || typeof raw === "number" || typeof raw === "string"
-      ? new BigNumber(raw.toString())
-      : new BigNumber(0);
-  return new BigNumber(estimation.value.toString()).plus(additional);
+/** Reads a numeric `parameters` field (bigint/number/string) as BigNumber, else `fallback`. */
+function numericParam(value: unknown, fallback: bigint): BigNumber {
+  return typeof value === "bigint" || typeof value === "number" || typeof value === "string"
+    ? new BigNumber(value.toString())
+    : new BigNumber(fallback.toString());
 }
 
-/** Send-max amount: the coin's `parameters.amount` if present (e.g. Tezos), else spendableBalance - fees. */
+/** Base fee plus any `additionalFees` from parameters (e.g. EVM L2 data fees). */
+function totalFeesFromEstimation(estimation: FeeEstimation): BigNumber {
+  return new BigNumber(estimation.value.toString()).plus(
+    numericParam(estimation.parameters?.additionalFees, 0n),
+  );
+}
+
+/**
+ * Send-max amount: `parameters.amount` if the coin exposes it (e.g. Tezos), else
+ * `spendableBalance - max(reserve, fees)` floored to `amountScale` (both optional, default 0/1).
+ */
 export function computeUseAllAmount(
   estimation: FeeEstimation,
   spendableBalance: BigNumber,
 ): BigNumber {
   if (estimation.parameters?.amount !== undefined) {
-    return BigNumber.max(0, new BigNumber(String(estimation.parameters.amount)));
+    return BigNumber.max(0, numericParam(estimation.parameters.amount, 0n));
   }
-  return BigNumber.max(0, spendableBalance.minus(totalFeesFromEstimation(estimation)));
+  const reserve = numericParam(estimation.parameters?.reserve, 0n);
+  const scaleParam = numericParam(estimation.parameters?.amountScale, 1n);
+  const scale = scaleParam.gt(0) ? scaleParam : new BigNumber(1);
+  const effectiveReserve = BigNumber.max(reserve, totalFeesFromEstimation(estimation));
+  const raw = BigNumber.max(0, spendableBalance.minus(effectiveReserve));
+  return raw.idiv(scale).times(scale);
 }
 
 function isStringArray(value: unknown): value is string[] {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -10,6 +10,7 @@ import type {
   AssetInfo,
   Balance,
   Operation as CoreOperation,
+  FeeEstimation,
   StakingOperation,
   TransactionIntent,
   TxData,
@@ -187,6 +188,27 @@ export function extractBalances(
   }
 
   return balances;
+}
+
+/** Base fee plus any `additionalFees` from parameters (e.g. EVM L2 data fees). */
+function totalFeesFromEstimation(estimation: FeeEstimation): BigNumber {
+  const raw = estimation.parameters?.additionalFees;
+  const additional =
+    typeof raw === "bigint" || typeof raw === "number" || typeof raw === "string"
+      ? new BigNumber(raw.toString())
+      : new BigNumber(0);
+  return new BigNumber(estimation.value.toString()).plus(additional);
+}
+
+/** Send-max amount: the coin's `parameters.amount` if present (e.g. Tezos), else spendableBalance - fees. */
+export function computeUseAllAmount(
+  estimation: FeeEstimation,
+  spendableBalance: BigNumber,
+): BigNumber {
+  if (estimation.parameters?.amount !== undefined) {
+    return BigNumber.max(0, new BigNumber(String(estimation.parameters.amount)));
+  }
+  return BigNumber.max(0, spendableBalance.minus(totalFeesFromEstimation(estimation)));
 }
 
 function isStringArray(value: unknown): value is string[] {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Send max (`useAllAmount`) on evm, xrp, stellar, tezos

### 📝 Description

For a single send-max, the amount used to be recomputed several times (in `estimateMaxSpendable`, `prepareTransaction`, `getTransactionStatus`, and again in `signOperation`), each `validateIntent` call re-estimating fees.

This computes it **once** in `prepareTransaction` and reuses it:

- `prepareTransaction` sets the final amount:
  - native send-max: `spendableBalance - max(reserve, fees)` floored to `amountScale` (a coin can expose `reserve`/`amountScale`, e.g. EVM delegate), or the coin module's `parameters.amount` when it provides one (Tezos).
  - token send-max: the token sub-account spendable balance.
  - in both cases, funds committed by pending operations are subtracted.
- `signOperation` signs that amount directly, without recomputing it.
- `estimateMaxSpendable` no longer calls `validateIntent`.

`validateIntent` is fully removed from those three methods. It remains only in `getTransactionStatus` (errors/warnings + displayed amount), which already accounts for pending via `extractBalances`, so the displayed and signed amounts stay consistent.

To keep the generic path correct without `validateIntent`, the coin modules surface their send-max specifics through `estimateFees`: coin-evm exposes `reserve`/`amountScale` for delegate, and coin-tezos exposes `parameters.amount` (send/stake/unstake max) and accounts for `unstakedBalance`.

### 🧪 Manual QA

Operations with **max amount**. Empty = not tested yet.

| useMax for (LWD) | Sei | Base | Mainnet | Stellar | Tezos | XRP | 
| -------- | --- | --- | ----- | ------- | ----- | --- |
| Native send |✅|✅|✅|✅|✅| N/A |
| Token send |✅|✅|✅|✅|N/A| N/A |
| delegate |✅| N/A | N/A |  N/A |✅| N/A |
| undelegate |✅| N/A | N/A |  N/A |✅| N/A |

### ❓ Context

- [LIVE-22227](https://ledgerhq.atlassian.net/browse/LIVE-22227) — remove `validateIntent` from generic `signOperation`
- [LIVE-22228](https://ledgerhq.atlassian.net/browse/LIVE-22228) — remove `validateIntent` from generic `prepareTransaction`
- [LIVE-22229](https://ledgerhq.atlassian.net/browse/LIVE-22229) — remove `validateIntent` from generic `estimateMaxSpendable`

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-22227]: https://ledgerhq.atlassian.net/browse/LIVE-22227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
