### PR TITLE
[LWM] feat(LIVE-30453): mobile operation details parser for aleo

### DIFF
--- a/.changeset/cyan-mails-invent.md
+++ b/.changeset/cyan-mails-invent.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat: mobile operation details parser for aleo

--- a/apps/ledger-live-mobile/src/families/aleo/__mocks__/account.mock.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/__mocks__/account.mock.ts
@@ -1,0 +1,4 @@
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { aleoCurrency } from "./currency.mock";
+
+export const ALEO_ACCOUNT_1 = { ...genAccount("aleo-1", { currency: aleoCurrency }), index: 0 };

--- a/apps/ledger-live-mobile/src/families/aleo/__mocks__/currency.mock.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/__mocks__/currency.mock.ts
@@ -1,0 +1,3 @@
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+
+export const aleoCurrency = getCryptoCurrencyById("aleo");

--- a/apps/ledger-live-mobile/src/families/aleo/__tests__/operationDetails.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/__tests__/operationDetails.test.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import type { AleoOperation } from "@ledgerhq/live-common/families/aleo/types";
+import { ALEO_ACCOUNT_1 } from "../__mocks__/account.mock";
+import operationDetails from "../operationDetails";
+
+const { OperationDetailsExtra } = operationDetails;
+
+describe("OperationDetailsExtra", () => {
+  it("should only render functionId and not expose transactionType or patched", () => {
+    const mockOperation: AleoOperation = {
+      ...ALEO_ACCOUNT_1.operations[0],
+      extra: {
+        functionId: "transfer_public",
+        transactionType: "public",
+        patched: true,
+      },
+    };
+
+    render(<OperationDetailsExtra operation={mockOperation} />);
+
+    expect(screen.getByText("Function ID")).toBeOnTheScreen();
+    expect(screen.getByText("transfer_public")).toBeOnTheScreen();
+    expect(screen.queryByText("transactionType")).not.toBeOnTheScreen();
+    expect(screen.queryByText("public")).not.toBeOnTheScreen();
+    expect(screen.queryByText("patched")).not.toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/operationDetails.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/operationDetails.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { getOperationDetailsExtraFields } from "@ledgerhq/live-common/families/aleo/utils";
+import type { AleoOperation } from "@ledgerhq/live-common/families/aleo/types";
+import { useTranslation } from "~/context/Locale";
+import Section from "~/screens/OperationDetails/Section";
+
+interface OperationDetailsExtraProps {
+  operation: AleoOperation;
+}
+
+const OperationDetailsExtra = ({ operation }: OperationDetailsExtraProps) => {
+  const { t } = useTranslation();
+
+  const extraFields = getOperationDetailsExtraFields(operation.extra);
+
+  return (
+    <>
+      {extraFields.map(item => (
+        <Section
+          title={t(`operationDetails.extra.${item.key}`)}
+          value={String(item.value)}
+          key={item.key}
+        />
+      ))}
+    </>
+  );
+};
+
+export default {
+  OperationDetailsExtra,
+};

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3132,7 +3132,8 @@
       "targetStakingNodeId": "Target node ID",
       "previousStakingNodeId": "Previous node ID",
       "gasConsumed": "Gas consumed",
-      "gasUsed": "Gas used"
+      "gasUsed": "Gas used",
+      "functionId": "Function ID"
     },
     "multipleAddresses": "Why multiple addresses?"
   },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - custom Aleo operation details should be visible in mobile app
  - no impact on non-Aleo coin families

### 📝 Description

This PR adds the mobile operation details view for Aleo.

Screenshot was made on `feat/aleo-add-account-approve` branch with cherry-picked commit from this PR:

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/6dfc6f64-ba5d-4ef4-bce7-a7de6e6398c1" />


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-30453

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
