### PR TITLE
[LWDM] feat(llc): create extraFields property for the new send flow architec…

### DIFF
--- a/.changeset/cool-numbers-hammer.md
+++ b/.changeset/cool-numbers-hammer.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+feat(llc): create extraFields property for the new send flow architecture

--- a/libs/ledger-live-common/src/bridge/descriptor.test.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor.test.ts
@@ -412,16 +412,6 @@ describe("sendFeatures", () => {
     expect(sendFeatures.canEstimateFeePresetsWithZeroAmount(ethereum, {})).toBe(true);
   });
 
-  it("should return empty plugins when not specified", () => {
-    const bitcoin = getCryptoCurrencyById("bitcoin");
-    expect(sendFeatures.getAmountPlugins(bitcoin)).toEqual([]);
-  });
-
-  it("should not expose legacy amount plugins for evm", () => {
-    const ethereum = getCryptoCurrencyById("ethereum");
-    expect(sendFeatures.getAmountPlugins(ethereum)).toEqual([]);
-  });
-
   it("should expose the gas options sync effect for evm", () => {
     const ethereum = getCryptoCurrencyById("ethereum");
     expect(sendFeatures.getAmountEffects(ethereum).map(e => e.id)).toEqual(["syncGasOptions"]);

--- a/libs/ledger-live-common/src/bridge/descriptor/send/features.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/send/features.ts
@@ -1,6 +1,7 @@
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getSendDescriptor } from "../registry";
 import type {
+  AmountExtraField,
   CoinControlConfig,
   CustomFeeConfig,
   FeeAssetsConfig,
@@ -36,8 +37,8 @@ function fromDescriptor<T>(
 const noCustomFeeConfig: CustomFeeConfig | null = null;
 const noFeeAssetsConfig: FeeAssetsConfig | null = null;
 const noCoinControlConfig: CoinControlConfig | null = null;
-const noAmountPlugins: readonly string[] = [];
 const noAmountEffects: readonly FlowEffect[] = [];
+const noAmountExtraFields: readonly AmountExtraField[] = [];
 const defaultSelfTransferPolicy: SelfTransferPolicy = "impossible";
 
 export const sendFeatures = {
@@ -84,8 +85,8 @@ export const sendFeatures = {
 
     return allowZeroAmount ?? false;
   },
-  getAmountPlugins: fromDescriptor(d => d.amount?.getPlugins?.(), noAmountPlugins),
   getAmountEffects: fromDescriptor(d => d.amount?.effects, noAmountEffects),
+  getAmountExtraFields: fromDescriptor(d => d.amount?.extraFields, noAmountExtraFields),
   getFeeCurrencyAccountId: (
     currency: CryptoOrTokenCurrency | undefined,
     transaction: unknown,

--- a/libs/ledger-live-common/src/bridge/descriptor/types.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/types.ts
@@ -68,7 +68,8 @@ export type CustomFeeConfig = Readonly<{
 }>;
 
 /**
- * Option for a fee-paying asset (for Celo WIP)
+ * A single selectable fee-paying asset displayed in the "Pay fees in" control
+ * of the Custom Fees step
  */
 export type FeeAssetOption = Readonly<{
   id: string;
@@ -79,11 +80,35 @@ export type FeeAssetOption = Readonly<{
 }>;
 
 /**
- * Configuration for coins that support paying fees with alternative assets/tokens.
+ * Context handed to a fee asset config. Exposes the resolved main account (so a
+ * config can read sub-accounts, balances, ...) and the current transaction.
+ * `transaction` is intentionally `unknown`: the owning coin-module narrows it,
+ * the generic UI never reads it
+ */
+export type FeeAssetContext = Readonly<{
+  mainAccount: Account;
+  transaction: unknown;
+}>;
+
+/**
+ * Declarative, family agnostic configuration for coins that let users pay fees
+ * with an alternative asset/token (e.g. Celo's fee abstraction). The coin-module
+ * owns the options, the selected value and the resulting opaque transaction
+ * patch; the generic Custom Fees UI only renders the "Pay fees in" select and
+ * forwards the user's choice — no coin code lives in the apps.
  */
 export type FeeAssetsConfig = Readonly<{
-  options: readonly FeeAssetOption[];
-  defaultId: string;
+  /** Computes the selectable fee assets from the current account/transaction. */
+  getOptions: (context: FeeAssetContext) => readonly FeeAssetOption[];
+  /** Resolves the currently-selected option id from the transaction. */
+  getSelectedOptionId: (context: FeeAssetContext) => string;
+  /** Builds an opaque transaction patch for the chosen option, or `null`. */
+  buildPatch: (optionId: string, context: FeeAssetContext) => TransactionPatch | null;
+  /**
+   * Optional reconciliation run by the generic UI when the account/transaction
+   * change. Returns a patch to apply when the current selection became invalid
+   */
+  reconcile?: (context: FeeAssetContext) => TransactionPatch | null;
 }>;
 
 export type FeePresetOption = Readonly<{
@@ -214,8 +239,8 @@ export type FeeDescriptor = {
   /**
    * Configuration for fee asset selection.
    * When `hasCustomAssets` is true, this describes which assets can be used
-   * to pay transaction fees (e.g. Celo's cUSD, cEUR).
-   * (Not yet implemented)
+   * to pay transaction fees (e.g. Celo's fee abstraction tokens) and how the
+   * selection maps to an opaque transaction patch.
    */
   customAssets?: FeeAssetsConfig;
   /** When `hasCoinControl` is true, describes rows and patches for the coin control step. */
@@ -265,12 +290,77 @@ export type FlowEffect = Readonly<{
   run: (context: FlowEffectContext) => Promise<TransactionPatch | null>;
 }>;
 
-export type SendAmountDescriptor = Readonly<{
+/**
+ * Context handed to an amount extra field. It exposes the resolved main account
+ * (so a field can read sub-accounts, balances, ...) and the current transaction.
+ * `transaction` is intentionally `unknown`: the owning coin-module narrows it,
+ * the generic UI never reads it.
+ */
+export type AmountExtraFieldContext = Readonly<{
+  mainAccount: Account;
+  transaction: unknown;
+}>;
+
+/**
+ * A single selectable option of an amount extra field.
+ * `label` is a literal display string provided by the coin-module (e.g. a token
+ * ticker), not an i18n key.
+ */
+export type AmountExtraFieldOption = Readonly<{
+  id: string;
+  label: string;
+}>;
+
+export type AmountInfoFieldRow = Readonly<{
+  id: string;
+  label: string;
+  value: string;
+}>;
+
+/**
+ * A declarative, family agnostic visual field rendered on the Amount step by a
+ * generic UI slot. The coin-module owns the options and the resulting opaque
+ * patch; the UI only renders a control and forwards the user's choice.
+ *
+ * Replaces family-specific Amount plugins: no coin component, no plugin registry.
+ */
+export type AmountSelectField = Readonly<{
+  type: "select";
+  /** Stable identifier. */
+  id: string;
+  /** i18n key for the field label, resolved by the platform UI. */
+  labelKey: string;
+  /** Optional base test id for the rendered control. */
+  testId?: string;
+  /** Computes the selectable options from the current account/transaction. */
+  getOptions: (context: AmountExtraFieldContext) => readonly AmountExtraFieldOption[];
+  /** Resolves the currently-selected option id from the transaction. */
+  getSelectedOptionId: (context: AmountExtraFieldContext) => string;
+  /** Builds an opaque transaction patch for the chosen option, or `null`. */
+  buildPatch: (optionId: string, context: AmountExtraFieldContext) => TransactionPatch | null;
   /**
-   * Optional list of plugins that should run on the Amount step.
-   * These are executed by the UI layer through a plugin registry.
+   * Optional reconciliation run by the generic UI when the account/transaction
+   * change. Returns a patch to apply when the current selection became invalid
+   * (e.g. the selected sub-account disappeared), or `null` to leave it as-is.
    */
-  getPlugins?: () => readonly string[];
+  reconcile?: (context: AmountExtraFieldContext) => TransactionPatch | null;
+}>;
+
+export type AmountInfoField = Readonly<{
+  type: "info";
+  /** Stable identifier. */
+  id: string;
+  /** i18n key for the section label, resolved by the platform UI. */
+  labelKey: string;
+  /** Optional base test id for the rendered section. */
+  testId?: string;
+  /** Computes read-only rows from the current account/transaction. */
+  getRows: (context: AmountExtraFieldContext) => readonly AmountInfoFieldRow[];
+}>;
+
+export type AmountExtraField = AmountSelectField | AmountInfoField;
+
+export type SendAmountDescriptor = Readonly<{
   canSendMax?: boolean;
   /**
    * Generic and family agnostic effects executed by the `useFlowEffects` runner
@@ -278,6 +368,11 @@ export type SendAmountDescriptor = Readonly<{
    * patch applied through the `bridge.updateTransaction`
    */
   effects?: readonly FlowEffect[];
+  /**
+   * Generic and family agnostic visual fields rendered on the Amount step by a
+   * generic UI slot. Replaces family-specific Amount plugins.
+   */
+  extraFields?: readonly AmountExtraField[];
 }>;
 
 /**

--- a/libs/ledger-live-common/src/families/celo/descriptor/index.ts
+++ b/libs/ledger-live-common/src/families/celo/descriptor/index.ts
@@ -5,8 +5,5 @@ export const descriptor: CoinDescriptor = {
   send: {
     inputs: {},
     fees,
-    amount: {
-      getPlugins: () => ["celoFeeCurrency"],
-    },
   },
 };

--- a/libs/ledger-live-common/src/flows/__tests__/uiConfig.test.ts
+++ b/libs/ledger-live-common/src/flows/__tests__/uiConfig.test.ts
@@ -16,7 +16,7 @@ jest.mock("../../bridge/descriptor/send/features", () => ({
     hasFeePresets: jest.fn(),
     hasCustomFees: jest.fn(),
     hasCoinControl: jest.fn(),
-    getAmountPlugins: jest.fn(() => []),
+    getAmountExtraFields: jest.fn(() => []),
   },
 }));
 
@@ -104,7 +104,7 @@ describe("getSendUiConfig", () => {
         hasFeePresets: true,
         hasCustomFees: true,
         hasCoinControl: true,
-        hasAmountPlugins: false,
+        hasAmountExtraFields: false,
       });
     });
   });
@@ -136,7 +136,7 @@ describe("getSendUiConfig", () => {
         hasFeePresets: true,
         hasCustomFees: true,
         hasCoinControl: false,
-        hasAmountPlugins: false,
+        hasAmountExtraFields: false,
       });
     });
   });
@@ -170,13 +170,13 @@ describe("getSendUiConfig", () => {
         hasFeePresets: false,
         hasCustomFees: true,
         hasCoinControl: false,
-        hasAmountPlugins: false,
+        hasAmountExtraFields: false,
       });
     });
   });
 
-  describe("for a coin with Amount plugins (e.g. Celo)", () => {
-    it("returns hasAmountPlugins: true when the descriptor advertises plugins", () => {
+  describe("for a coin that advertises generic Amount extra fields", () => {
+    it("returns hasAmountExtraFields: true when the descriptor advertises extra fields", () => {
       mockedGetSendDescriptor.mockReturnValue({
         inputs: {},
         fees: { hasPresets: false, hasCustom: true },
@@ -189,15 +189,17 @@ describe("getSendUiConfig", () => {
       mockedSendFeatures.hasFeePresets.mockReturnValue(false);
       mockedSendFeatures.hasCustomFees.mockReturnValue(true);
       mockedSendFeatures.hasCoinControl.mockReturnValue(false);
-      mockedSendFeatures.getAmountPlugins.mockReturnValue(["celoFeeCurrency"]);
+      mockedSendFeatures.getAmountExtraFields.mockReturnValue([
+        { id: "someAmountField" } as never,
+      ]);
 
       const result = getSendUiConfig(mockCeloCurrency);
 
-      expect(result.hasAmountPlugins).toBe(true);
-      expect(mockedSendFeatures.getAmountPlugins).toHaveBeenCalledWith(mockCeloCurrency);
+      expect(result.hasAmountExtraFields).toBe(true);
+      expect(mockedSendFeatures.getAmountExtraFields).toHaveBeenCalledWith(mockCeloCurrency);
     });
 
-    it("returns hasAmountPlugins: false when the descriptor advertises no plugins", () => {
+    it("returns hasAmountExtraFields: false when the descriptor advertises no extra fields", () => {
       mockedGetSendDescriptor.mockReturnValue({
         inputs: {},
         fees: { hasPresets: false, hasCustom: true },
@@ -210,11 +212,11 @@ describe("getSendUiConfig", () => {
       mockedSendFeatures.hasFeePresets.mockReturnValue(false);
       mockedSendFeatures.hasCustomFees.mockReturnValue(true);
       mockedSendFeatures.hasCoinControl.mockReturnValue(false);
-      mockedSendFeatures.getAmountPlugins.mockReturnValue([]);
+      mockedSendFeatures.getAmountExtraFields.mockReturnValue([]);
 
       const result = getSendUiConfig(mockCeloCurrency);
 
-      expect(result.hasAmountPlugins).toBe(false);
+      expect(result.hasAmountExtraFields).toBe(false);
     });
   });
 
@@ -230,7 +232,7 @@ describe("getSendUiConfig", () => {
         hasFeePresets: false,
         hasCustomFees: false,
         hasCoinControl: false,
-        hasAmountPlugins: false,
+        hasAmountExtraFields: false,
       });
     });
   });

--- a/libs/ledger-live-common/src/flows/send/customFees/hooks/useCustomFeesViewModelCore.ts
+++ b/libs/ledger-live-common/src/flows/send/customFees/hooks/useCustomFeesViewModelCore.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { BigNumber } from "bignumber.js";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type { Currency, CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
@@ -8,7 +8,7 @@ import {
   getMainAccount,
 } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import type { Transaction, TransactionStatus } from "../../../../coin-modules/transaction-types";
-import type { FeeAssetOption } from "../../../../bridge/descriptor/types";
+import type { FeeAssetContext, FeeAssetOption } from "../../../../bridge/descriptor/types";
 import { resolveFeeUnitLabel, sendFeatures } from "../../../../bridge/descriptor/send/features";
 import type { SendFlowTransactionActions } from "../../types";
 import { useBridgeFeeEstimation } from "./useBridgeFeeEstimation";
@@ -106,19 +106,48 @@ export function useCustomFeesViewModelCore({
     () => sendFeatures.getCustomAssetsConfig(currency),
     [currency],
   );
-  const hasCustomAssetsFlag = Boolean(customAssetsConfig?.options.length);
 
-  const [selectedAssetId, setSelectedAssetId] = useState<string>(
-    () => customAssetsConfig?.defaultId ?? "",
+  const feeAssetContext = useMemo<FeeAssetContext>(
+    () => ({ mainAccount, transaction }),
+    [mainAccount, transaction],
   );
-  const onAssetChange = useCallback((id: string) => setSelectedAssetId(id), []);
+
+  // The coin-module owns the options, the selected value and the resulting patch.
+  // This view model only renders the "Pay fees in" select and forwards the choice.
+  const assetOptions = useMemo(
+    () => customAssetsConfig?.getOptions(feeAssetContext) ?? [],
+    [customAssetsConfig, feeAssetContext],
+  );
+  const hasCustomAssetsFlag = assetOptions.length > 0;
+
+  const selectedAssetId = useMemo(
+    () => customAssetsConfig?.getSelectedOptionId(feeAssetContext) ?? "",
+    [customAssetsConfig, feeAssetContext],
+  );
+
+  const onAssetChange = useCallback(
+    (id: string) => {
+      const patch = customAssetsConfig?.buildPatch(id, feeAssetContext);
+      if (!patch) return;
+      transactionActions.updateTransaction(tx => ({ ...tx, ...patch }) as Transaction);
+    },
+    [customAssetsConfig, feeAssetContext, transactionActions],
+  );
+
+  // Let the coin-module reset an invalid fee asset selection (e.g. the selected
+  // token sub-account vanished). Reconciliation logic stays in the descriptor.
+  useEffect(() => {
+    const patch = customAssetsConfig?.reconcile?.(feeAssetContext);
+    if (!patch) return;
+    transactionActions.updateTransaction(tx => ({ ...tx, ...patch }) as Transaction);
+  }, [customAssetsConfig, feeAssetContext, transactionActions]);
 
   // When hasCustomAssets, the unit label comes from the selected asset (eg. "Gwei" for CELO)
   const effectiveUnitLabel = useMemo(() => {
-    if (!hasCustomAssetsFlag || !customAssetsConfig) return null;
-    const selectedAsset = customAssetsConfig.options.find(o => o.id === selectedAssetId);
+    if (!hasCustomAssetsFlag) return null;
+    const selectedAsset = assetOptions.find(o => o.id === selectedAssetId);
     return selectedAsset?.unitLabel ?? selectedAsset?.ticker ?? null;
-  }, [hasCustomAssetsFlag, customAssetsConfig, selectedAssetId]);
+  }, [hasCustomAssetsFlag, assetOptions, selectedAssetId]);
 
   const [values, setValues] = useState<Record<string, string>>(() => {
     if (!customFeeConfig) return {};
@@ -317,7 +346,7 @@ export function useCustomFeesViewModelCore({
     onInputClear,
     onConfirm: handleConfirm,
     hasCustomAssets: hasCustomAssetsFlag,
-    assetOptions: customAssetsConfig?.options ?? [],
+    assetOptions,
     selectedAssetId,
     onAssetChange,
     confirmLabel: labels.confirm,

--- a/libs/ledger-live-common/src/flows/send/types.ts
+++ b/libs/ledger-live-common/src/flows/send/types.ts
@@ -34,7 +34,7 @@ export type SendFlowUiConfig = Readonly<{
   hasFeePresets: boolean;
   hasCustomFees: boolean;
   hasCoinControl: boolean;
-  hasAmountPlugins: boolean;
+  hasAmountExtraFields: boolean;
 }>;
 
 export type Memo = { value: string; type?: string };

--- a/libs/ledger-live-common/src/flows/send/uiConfig.ts
+++ b/libs/ledger-live-common/src/flows/send/uiConfig.ts
@@ -13,7 +13,7 @@ export const DEFAULT_SEND_UI_CONFIG: SendFlowUiConfig = {
   hasFeePresets: false,
   hasCustomFees: false,
   hasCoinControl: false,
-  hasAmountPlugins: false,
+  hasAmountExtraFields: false,
 };
 
 export function getSendUiConfig(currency: CryptoOrTokenCurrency | null): SendFlowUiConfig {
@@ -36,6 +36,6 @@ export function getSendUiConfig(currency: CryptoOrTokenCurrency | null): SendFlo
     hasFeePresets: sendFeatures.hasFeePresets(currency),
     hasCustomFees: sendFeatures.hasCustomFees(currency),
     hasCoinControl: sendFeatures.hasCoinControl(currency),
-    hasAmountPlugins: sendFeatures.getAmountPlugins(currency).length > 0,
+    hasAmountExtraFields: sendFeatures.getAmountExtraFields(currency).length > 0,
   };
 }


### PR DESCRIPTION
…ture

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

extends the descriptor-driven send flow in `@ledgerhq/live-common` by replacing legacy family-specific Amount plugins with declarative `extraFields` (`AmountSelectField` / `AmountInfoField`), where coin-modules own options, selection state, and opaque transaction patches while the generic UI only renders controls. 

It also refactors `FeeAssetsConfig` from static `options`/`defaultId` to a callback-based API (`getOptions`, `getSelectedOptionId`, `buildPatch`, optional `reconcile`), wires `useCustomFeesViewModelCore` to that model, and renames `hasAmountPlugins` to `hasAmountExtraFields` in the send UI config, to prepare to moving Celo’s fee asset selection from the Amount step to Custom Fees as the first concrete use case

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-32721)**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->
https://ledgerhq.atlassian.net/wiki/spaces/CF/pages/7193100452/Descriptor+driven+architecture 
https://ledgerhq.atlassian.net/wiki/spaces/CF/pages/7246119017/Getting+rid+of+Plugins

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
