### PR TITLE
test(concordium): lower e2e send amount to preserve testnet funds

### DIFF
--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -612,7 +612,12 @@ test.describe("Send flows", () => {
   });
 
   test.describe("Send Concordium (Testnet)", () => {
-    const ccdTx = new Transaction(Account.CCD_TESTNET_1, Account.CCD_TESTNET_2, "50", undefined);
+    const ccdTx = new Transaction(
+      Account.CCD_TESTNET_1,
+      Account.CCD_TESTNET_2,
+      "0.000005",
+      undefined,
+    );
 
     test.use({
       teamOwner: Team.COIN_INTEGRATION,

--- a/e2e/mobile/specs/send/sendCCD.spec.ts
+++ b/e2e/mobile/specs/send/sendCCD.spec.ts
@@ -1,7 +1,12 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSendTest } from "./send";
 
-const transaction = new Transaction(Account.CCD_TESTNET_1, Account.CCD_TESTNET_2, "50", undefined);
+const transaction = new Transaction(
+  Account.CCD_TESTNET_1,
+  Account.CCD_TESTNET_2,
+  "0.000005",
+  undefined,
+);
 runSendTest(
   transaction,
   ["B2CQA-2949"],


### PR DESCRIPTION
## Description

Lowers the transaction amount in the Concordium (testnet) send-flow E2E tests from `50` CCD to `0.000005` CCD (5 microCCD).

These tests broadcast a real testnet transaction one-directionally (`CCD_TESTNET_1` → `CCD_TESTNET_2`) on every run, so the source account was draining by 50 CCD per execution. Reducing the amount preserves the QA testnet funds while keeping full coverage of the send flow.

`0.000005` CCD is safely valid: the coin module rejects only a zero amount (`AmountRequired`) and enforces no dust/minimum floor; `minReserve` constrains the source's remaining balance, not the send amount.

## Changes

- `e2e/desktop/tests/specs/send.tx.spec.ts` — Concordium send amount `50` → `0.000005`
- `e2e/mobile/specs/send/sendCCD.spec.ts` — Concordium send amount `50` → `0.000005`

## Test coverage

No behavioural change to the test logic — same send flow, smaller amount. Requested by QA (B2CQA-2949).
