### PR TITLE
[LWM] fix(mobile): [LIVE-23757] Restore android permission retries

### DIFF
--- a/.changeset/tall-badgers-retry.md
+++ b/.changeset/tall-badgers-retry.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"@ledgerhq/live-dmk-mobile": patch
+---
+
+Restore Android permission retry behavior after the React Native permission fix

--- a/apps/ledger-live-mobile/src/components/RequiresBLE/hooks/useAndroidBluetoothPermissions.ts
+++ b/apps/ledger-live-mobile/src/components/RequiresBLE/hooks/useAndroidBluetoothPermissions.ts
@@ -175,21 +175,12 @@ export const useAndroidBluetoothPermissions = (
     let cancelled = false;
 
     async function asyncRequestBluetoothPermissions() {
-      /*
-       * First do a simple check to avoid this issue: https://github.com/facebook/react-native/issues/53887
-       * or the permission state might be stuck in "unknown" state.
-       */
-      const checkResult = await checkBluetoothPermissions();
-      if (cancelled) return;
-      setHasPermissions(checkResult ? "granted" : "denied");
-      if (checkResult) return;
-
-      const requestResult = await requestBluetoothPermissions();
+      const res = await requestBluetoothPermissions();
 
       if (!cancelled) {
         /** https://developer.android.com/about/versions/11/privacy/permissions#dialog-visibility */
-        setNeverAskAgain(requestResult.generalStatus === RESULTS.NEVER_ASK_AGAIN);
-        setHasPermissions(requestResult.allGranted ? "granted" : "denied");
+        setNeverAskAgain(res.generalStatus === RESULTS.NEVER_ASK_AGAIN);
+        setHasPermissions(res.allGranted ? "granted" : "denied");
       }
     }
 

--- a/apps/ledger-live-mobile/src/components/RequiresBLE/hooks/useRequireBluetooth.ts
+++ b/apps/ledger-live-mobile/src/components/RequiresBLE/hooks/useRequireBluetooth.ts
@@ -55,7 +55,7 @@ export const useRequireBluetooth = ({
 
   const {
     hasPermissions: androidHasBluetoothPermissions,
-    neverAskAgain: _androidBluetoothPermissionsNeverAskAgain,
+    neverAskAgain: androidBluetoothPermissionsNeverAskAgain,
     requestForPermissionsAgain: androidBluetoothPermissionsRequestForPermissionsAgain,
   } = useAndroidBluetoothPermissions({
     isHookEnabled: isAndroidBluetoothPermissionsHookEnabled,
@@ -81,7 +81,7 @@ export const useRequireBluetooth = ({
 
   const {
     hasPermission: androidHasLocationPermission,
-    neverAskAgain: _androidLocationPermissionNeverAskAgain,
+    neverAskAgain: androidLocationPermissionNeverAskAgain,
     requestForPermissionAgain: androidLocationPermissionRequestForPermissionsAgain,
   } = useAndroidLocationPermission({
     isHookEnabled: isAndroidLocationPermissionHookEnabled,
@@ -115,12 +115,7 @@ export const useRequireBluetooth = ({
     if (androidHasBluetoothPermissions === "denied") {
       bluetoothRequirementsState = "bluetooth_permissions_ungranted";
       retryRequestOnIssue = androidBluetoothPermissionsRequestForPermissionsAgain;
-      /*
-       * FIXME: temporary fix to avoid this issue: https://github.com/facebook/react-native/issues/53887
-       * Revert `cannotRetryRequest` to `_androidBluetoothPermissionsNeverAskAgain` when React Native gets upgraded to 0.81.5
-       * to include the fix https://github.com/facebook/react-native/commit/447a7a3527e3e38e4c3ceb330d12d77afe7bc0b4
-       */
-      cannotRetryRequest = true;
+      cannotRetryRequest = androidBluetoothPermissionsNeverAskAgain;
     } else if (androidHasBluetoothPermissions !== "granted") {
       someUnknown = true;
     }
@@ -130,12 +125,7 @@ export const useRequireBluetooth = ({
     if (androidHasLocationPermission === "denied") {
       bluetoothRequirementsState = "location_permission_ungranted";
       retryRequestOnIssue = androidLocationPermissionRequestForPermissionsAgain;
-      /*
-       * FIXME: temporary fix to avoid this issue: https://github.com/facebook/react-native/issues/53887
-       * Revert `cannotRetryRequest` to `_androidLocationPermissionNeverAskAgain` when React Native gets upgraded to 0.81.5
-       * to include the fix https://github.com/facebook/react-native/commit/447a7a3527e3e38e4c3ceb330d12d77afe7bc0b4
-       */
-      cannotRetryRequest = true;
+      cannotRetryRequest = androidLocationPermissionNeverAskAgain;
     } else if (androidHasLocationPermission !== "granted") {
       someUnknown = true;
     }

--- a/apps/ledger-live-mobile/src/components/RequiresBLE/index.tsx
+++ b/apps/ledger-live-mobile/src/components/RequiresBLE/index.tsx
@@ -23,20 +23,12 @@ type Props = {
  */
 const RequiresBLE: React.FC<Props> = ({ children, forceOpenSettingsOnErrorButton = false }) => {
   if (Platform.OS === "android") {
-    /*
-     * FIXME: temporary fix to avoid this issue: https://github.com/facebook/react-native/issues/53887
-     * To revert to `forceOpenSettingsOnErrorButton` when React Native gets upgraded to 0.81.5
-     * to include the fix https://github.com/facebook/react-native/commit/447a7a3527e3e38e4c3ceb330d12d77afe7bc0b4
-     */
-    const forceOpenSettingsForPermissions = true;
     return (
-      <AndroidRequiresBluetoothPermissions
-        forceOpenSettingsOnErrorButton={forceOpenSettingsForPermissions}
-      >
+      <AndroidRequiresBluetoothPermissions forceOpenSettingsOnErrorButton={forceOpenSettingsOnErrorButton}>
         <RequiresBluetoothEnabled forceOpenSettingsOnErrorButton={forceOpenSettingsOnErrorButton}>
           <AndroidRequiresLocationPermission
             required={Platform.Version <= 30}
-            forceOpenSettingsOnErrorButton={forceOpenSettingsForPermissions}
+            forceOpenSettingsOnErrorButton={forceOpenSettingsOnErrorButton}
           >
             <AndroidRequiresLocationEnabled
               required={Platform.Version <= 30}

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.test.ts
@@ -1,5 +1,5 @@
 import { PermissionsAndroid, type Permission } from "react-native";
-import type { DiscoveryError } from "../../../types";
+import type { MobileDiscoveryError } from "../../../types";
 import { requestPermission, requestPermissions, runPermissionPreflight } from "./permissionHelpers";
 
 jest.mock("react-native", () => ({
@@ -82,9 +82,9 @@ describe("permissionHelpers", () => {
 
   it("GIVEN missing permission remains promptable, WHEN running preflight, THEN it should return a promptable error", async () => {
     // GIVEN
-    const retry = jest.fn<Promise<true | DiscoveryError>, []>();
-    const promptableError = { type: "promptable" } as unknown as DiscoveryError;
-    const manualSettingsError = { type: "manual-settings" } as unknown as DiscoveryError;
+    const retry = jest.fn<Promise<true | MobileDiscoveryError>, []>();
+    const promptableError = { type: "promptable" } as unknown as MobileDiscoveryError;
+    const manualSettingsError = { type: "manual-settings" } as unknown as MobileDiscoveryError;
     const buildPromptableError = jest.fn(() => promptableError);
     const buildManualSettingsError = jest.fn(() => manualSettingsError);
     jest.mocked(PermissionsAndroid.check).mockResolvedValue(false);
@@ -106,9 +106,9 @@ describe("permissionHelpers", () => {
 
   it("GIVEN missing permission can no longer be prompted, WHEN running preflight, THEN it should return a manual settings error", async () => {
     // GIVEN
-    const retry = jest.fn<Promise<true | DiscoveryError>, []>();
-    const promptableError = { type: "promptable" } as unknown as DiscoveryError;
-    const manualSettingsError = { type: "manual-settings" } as unknown as DiscoveryError;
+    const retry = jest.fn<Promise<true | MobileDiscoveryError>, []>();
+    const promptableError = { type: "promptable" } as unknown as MobileDiscoveryError;
+    const manualSettingsError = { type: "manual-settings" } as unknown as MobileDiscoveryError;
     const buildPromptableError = jest.fn(() => promptableError);
     const buildManualSettingsError = jest.fn(() => manualSettingsError);
     jest.mocked(PermissionsAndroid.check).mockResolvedValue(false);
@@ -131,9 +131,9 @@ describe("permissionHelpers", () => {
   it("GIVEN multiple missing permissions with a mixed native status, WHEN running preflight, THEN it should return a manual settings error", async () => {
     // GIVEN
     const permissions = [bluetoothScanPermission, bluetoothConnectPermission];
-    const retry = jest.fn<Promise<true | DiscoveryError>, []>();
-    const promptableError = { type: "promptable" } as unknown as DiscoveryError;
-    const manualSettingsError = { type: "manual-settings" } as unknown as DiscoveryError;
+    const retry = jest.fn<Promise<true | MobileDiscoveryError>, []>();
+    const promptableError = { type: "promptable" } as unknown as MobileDiscoveryError;
+    const manualSettingsError = { type: "manual-settings" } as unknown as MobileDiscoveryError;
     const buildPromptableError = jest.fn(() => promptableError);
     const buildManualSettingsError = jest.fn(() => manualSettingsError);
     const requestMultipleResult = {

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.test.ts
@@ -1,9 +1,6 @@
 import { PermissionsAndroid, type Permission } from "react-native";
-import {
-  DEFAULT_PERMISSION_REQUEST_TIMEOUT_MS,
-  requestPermission,
-  requestPermissions,
-} from "./permissionHelpers";
+import type { DiscoveryError } from "../../../types";
+import { requestPermission, requestPermissions, runPermissionPreflight } from "./permissionHelpers";
 
 jest.mock("react-native", () => ({
   PermissionsAndroid: {
@@ -28,51 +25,12 @@ const bluetoothConnectPermission: Permission = PermissionsAndroid.PERMISSIONS.BL
 
 describe("permissionHelpers", () => {
   beforeEach(() => {
-    jest.useFakeTimers();
+    jest.mocked(PermissionsAndroid.check).mockReset();
     jest.mocked(PermissionsAndroid.request).mockReset();
     jest.mocked(PermissionsAndroid.requestMultiple).mockReset();
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
-  });
-
-  it("GIVEN a single permission request does not resolve, WHEN the timeout is reached, THEN it should require manual settings", async () => {
-    // GIVEN
-    jest.mocked(PermissionsAndroid.request).mockImplementation(() => new Promise(() => undefined));
-
-    // WHEN
-    const resultPromise = requestPermission(bluetoothScanPermission);
-    await jest.advanceTimersByTimeAsync(DEFAULT_PERMISSION_REQUEST_TIMEOUT_MS);
-
-    // THEN
-    await expect(resultPromise).resolves.toEqual({
-      granted: false,
-      neverAskAgain: true,
-      deniedPermissions: [bluetoothScanPermission],
-    });
-  });
-
-  it("GIVEN a multiple permissions request does not resolve, WHEN the timeout is reached, THEN it should require manual settings", async () => {
-    // GIVEN
-    const permissions = [bluetoothScanPermission, bluetoothConnectPermission];
-    jest
-      .mocked(PermissionsAndroid.requestMultiple)
-      .mockImplementation(() => new Promise(() => undefined));
-
-    // WHEN
-    const resultPromise = requestPermissions(permissions);
-    await jest.advanceTimersByTimeAsync(DEFAULT_PERMISSION_REQUEST_TIMEOUT_MS);
-
-    // THEN
-    await expect(resultPromise).resolves.toEqual({
-      granted: false,
-      neverAskAgain: true,
-      deniedPermissions: permissions,
-    });
-  });
-
-  it("GIVEN a permission request resolves before the timeout, WHEN requesting, THEN it should keep the native status", async () => {
+  it("GIVEN a permission request is denied, WHEN requesting, THEN it should keep the native promptable status", async () => {
     // GIVEN
     jest.mocked(PermissionsAndroid.request).mockResolvedValue(RESULTS.DENIED);
 
@@ -85,5 +43,88 @@ describe("permissionHelpers", () => {
       neverAskAgain: false,
       deniedPermissions: [bluetoothScanPermission],
     });
+  });
+
+  it("GIVEN a permission request resolves to never ask again, WHEN requesting, THEN it should require manual settings", async () => {
+    // GIVEN
+    jest.mocked(PermissionsAndroid.request).mockResolvedValue(RESULTS.NEVER_ASK_AGAIN);
+
+    // WHEN
+    const result = await requestPermission(bluetoothScanPermission);
+
+    // THEN
+    expect(result).toEqual({
+      granted: false,
+      neverAskAgain: true,
+      deniedPermissions: [bluetoothScanPermission],
+    });
+  });
+
+  it("GIVEN multiple permission requests are denied, WHEN requesting, THEN it should keep them promptable", async () => {
+    // GIVEN
+    const permissions = [bluetoothScanPermission, bluetoothConnectPermission];
+    const requestMultipleResult = {
+      [bluetoothScanPermission]: RESULTS.DENIED,
+      [bluetoothConnectPermission]: RESULTS.DENIED,
+    } as Awaited<ReturnType<typeof PermissionsAndroid.requestMultiple>>;
+    jest.mocked(PermissionsAndroid.requestMultiple).mockResolvedValue(requestMultipleResult);
+
+    // WHEN
+    const result = await requestPermissions(permissions);
+
+    // THEN
+    expect(result).toEqual({
+      granted: false,
+      neverAskAgain: false,
+      deniedPermissions: permissions,
+    });
+  });
+
+  it("GIVEN missing permission remains promptable, WHEN running preflight, THEN it should return a promptable error", async () => {
+    // GIVEN
+    const retry = jest.fn<Promise<true | DiscoveryError>, []>();
+    const promptableError = { type: "promptable" } as unknown as DiscoveryError;
+    const manualSettingsError = { type: "manual-settings" } as unknown as DiscoveryError;
+    const buildPromptableError = jest.fn(() => promptableError);
+    const buildManualSettingsError = jest.fn(() => manualSettingsError);
+    jest.mocked(PermissionsAndroid.check).mockResolvedValue(false);
+    jest.mocked(PermissionsAndroid.request).mockResolvedValue(RESULTS.DENIED);
+
+    // WHEN
+    const result = await runPermissionPreflight({
+      permissions: [bluetoothScanPermission],
+      retry,
+      buildPromptableError,
+      buildManualSettingsError,
+    });
+
+    // THEN
+    expect(result).toEqual({ success: false, discoveryError: promptableError });
+    expect(buildPromptableError).toHaveBeenCalledWith([bluetoothScanPermission], retry);
+    expect(buildManualSettingsError).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN missing permission can no longer be prompted, WHEN running preflight, THEN it should return a manual settings error", async () => {
+    // GIVEN
+    const retry = jest.fn<Promise<true | DiscoveryError>, []>();
+    const promptableError = { type: "promptable" } as unknown as DiscoveryError;
+    const manualSettingsError = { type: "manual-settings" } as unknown as DiscoveryError;
+    const buildPromptableError = jest.fn(() => promptableError);
+    const buildManualSettingsError = jest.fn(() => manualSettingsError);
+    jest.mocked(PermissionsAndroid.check).mockResolvedValue(false);
+    jest.mocked(PermissionsAndroid.request).mockResolvedValue(RESULTS.NEVER_ASK_AGAIN);
+
+    // WHEN
+    const result = await runPermissionPreflight({
+      permissions: [bluetoothScanPermission],
+      retry,
+      buildPromptableError,
+      buildManualSettingsError,
+    });
+
+    // THEN
+    expect(result).toEqual({ success: false, discoveryError: manualSettingsError });
+    expect(buildPromptableError).not.toHaveBeenCalled();
+    expect(buildManualSettingsError).toHaveBeenCalledWith([bluetoothScanPermission], retry);
   });
 });

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.test.ts
@@ -127,4 +127,35 @@ describe("permissionHelpers", () => {
     expect(buildPromptableError).not.toHaveBeenCalled();
     expect(buildManualSettingsError).toHaveBeenCalledWith([bluetoothScanPermission], retry);
   });
+
+  it("GIVEN multiple missing permissions with a mixed native status, WHEN running preflight, THEN it should return a manual settings error", async () => {
+    // GIVEN
+    const permissions = [bluetoothScanPermission, bluetoothConnectPermission];
+    const retry = jest.fn<Promise<true | DiscoveryError>, []>();
+    const promptableError = { type: "promptable" } as unknown as DiscoveryError;
+    const manualSettingsError = { type: "manual-settings" } as unknown as DiscoveryError;
+    const buildPromptableError = jest.fn(() => promptableError);
+    const buildManualSettingsError = jest.fn(() => manualSettingsError);
+    const requestMultipleResult = {
+      [bluetoothScanPermission]: RESULTS.DENIED,
+      [bluetoothConnectPermission]: RESULTS.NEVER_ASK_AGAIN,
+    } as Awaited<ReturnType<typeof PermissionsAndroid.requestMultiple>>;
+    jest.mocked(PermissionsAndroid.check).mockResolvedValue(false);
+    jest.mocked(PermissionsAndroid.requestMultiple).mockResolvedValue(requestMultipleResult);
+
+    // WHEN
+    const result = await runPermissionPreflight({
+      permissions,
+      retry,
+      buildPromptableError,
+      buildManualSettingsError,
+    });
+
+    // THEN
+    expect(result).toEqual({ success: false, discoveryError: manualSettingsError });
+    expect(PermissionsAndroid.request).not.toHaveBeenCalled();
+    expect(PermissionsAndroid.requestMultiple).toHaveBeenCalledWith(permissions);
+    expect(buildPromptableError).not.toHaveBeenCalled();
+    expect(buildManualSettingsError).toHaveBeenCalledWith(permissions, retry);
+  });
 });

--- a/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/discoveryService/preflight/android/permissionHelpers.ts
@@ -1,4 +1,4 @@
-import { PermissionsAndroid, type Permission, type PermissionStatus } from "react-native";
+import { PermissionsAndroid, type Permission } from "react-native";
 import type { MobileDiscoveryError } from "../../../types";
 import {
   mapDiscoveryErrorToPreflightResult,
@@ -7,11 +7,6 @@ import {
 } from "../preflightResult";
 
 const { RESULTS } = PermissionsAndroid;
-
-export const DEFAULT_PERMISSION_REQUEST_TIMEOUT_MS = 10_000;
-export const shouldUseManualActionForPermissionDenial = true;
-
-type PermissionRequestStatuses = Partial<Record<Permission, PermissionStatus>>;
 
 export type PermissionRequestResult = {
   granted: boolean;
@@ -35,10 +30,7 @@ type PermissionPreflightConfig = {
 export const requestPermissions = async (
   permissions: Permission[],
 ): Promise<PermissionRequestResult> => {
-  const requestResult = await withPermissionRequestTimeout<PermissionRequestStatuses>(
-    PermissionsAndroid.requestMultiple(permissions),
-    getPermissionRequestTimeoutStatuses(permissions),
-  );
+  const requestResult = await PermissionsAndroid.requestMultiple(permissions);
   const deniedPermissions = permissions.filter(
     permission => requestResult[permission] !== RESULTS.GRANTED,
   );
@@ -55,10 +47,7 @@ export const requestPermissions = async (
 export const requestPermission = async (
   permission: Permission,
 ): Promise<PermissionRequestResult> => {
-  const status = await withPermissionRequestTimeout(
-    PermissionsAndroid.request(permission),
-    RESULTS.NEVER_ASK_AGAIN,
-  );
+  const status = await PermissionsAndroid.request(permission);
 
   return {
     granted: status === RESULTS.GRANTED,
@@ -92,7 +81,7 @@ export const runPermissionPreflight = async (
   }
 
   return mapDiscoveryErrorToPreflightResult(
-    shouldUseManualActionForPermissionDenial || requestResult.neverAskAgain
+    requestResult.neverAskAgain
       ? config.buildManualSettingsError(requestResult.deniedPermissions, config.retry)
       : config.buildPromptableError(requestResult.deniedPermissions, config.retry),
   );
@@ -107,39 +96,4 @@ const getMissingPermissions = async (permissions: Permission[]): Promise<Permiss
   );
 
   return results.filter(({ granted }) => !granted).map(({ permission }) => permission);
-};
-
-/**
- * TODO(LIVE-23757): This workaround for never resolving permission request
- * can be removed once React Native is upgraded to 0.81.6
- */
-const withPermissionRequestTimeout = async <T>(
-  request: Promise<T>,
-  timeoutValue: T,
-  timeoutMs = DEFAULT_PERMISSION_REQUEST_TIMEOUT_MS,
-): Promise<T> => {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<T>(resolve => {
-    timeoutId = setTimeout(() => resolve(timeoutValue), timeoutMs);
-  });
-
-  try {
-    return await Promise.race([request, timeout]);
-  } finally {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
-  }
-};
-
-const getPermissionRequestTimeoutStatuses = (
-  permissions: Permission[],
-): PermissionRequestStatuses => {
-  const statuses: PermissionRequestStatuses = {};
-
-  permissions.forEach(permission => {
-    statuses[permission] = RESULTS.NEVER_ASK_AGAIN;
-  });
-
-  return statuses;
 };


### PR DESCRIPTION
(replay of https://github.com/LedgerHQ/ledger-live/pull/17806 which had to be reverted following the RN upgrade reversal...)

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Android BLE/location permission retry flows in Ledger Live Mobile
  - Device discovery preflight permission handling in `@ledgerhq/live-dmk-mobile`
  - QA should verify denied permissions can be retried when still promptable, and app settings are used only for never-ask-again cases

### 📝 Description

React Native 0.81.6 includes the Android `PermissionsAndroid` fix for permission requests that previously could hang instead of resolving to `NEVER_ASK_AGAIN`. The temporary Ledger Live workarounds forced users toward app settings and added a timeout fallback in the device discovery permission helper.

This PR reverts those workarounds: mobile BLE/location permission screens now use the real `neverAskAgain` state to decide whether retry is available, and `@ledgerhq/live-dmk-mobile` maps native permission results directly so `DENIED` remains promptable while `NEVER_ASK_AGAIN` uses manual settings. The permission helper tests were updated to cover both cases.

This specifically reverts the behavior introduced by:

- #13010 for the initial Android permission workaround in SelectDevice.
- #17329 for the `permissionHelpers` timeout/manual-settings workaround in device discovery preflight checks.

### 🧪 How to test

Use an Android flow that requests BLE permissions, for example device discovery / SelectDevice. On Android 12+, this covers `BLUETOOTH_SCAN` / `BLUETOOTH_CONNECT`; on Android 11 and below, scanning also depends on location permission.

- Promptable case: reset permission state, trigger the flow, deny the system permission dialog once. The Ledger permission screen should offer the retry/authorize CTA, and tapping it should show the system permission dialog again.
- Not promptable case: deny the same permission more than once during the app install lifetime, or choose "Don't ask again" where the OS shows it. Android marks this as a permanent denial (`USER_FIXED`), which React Native reports as `NEVER_ASK_AGAIN`; the Ledger permission screen should offer app settings instead of retrying the prompt.
- For debugging, Android exposes the state with `adb shell dumpsys package <package>` and permissions can be reset with `adb shell pm clear-permission-flags <package> <permission> user-set user-fixed`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-23757](https://ledgerhq.atlassian.net/browse/LIVE-23757)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-23757]: https://ledgerhq.atlassian.net/browse/LIVE-23757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ