### PR TITLE
[LWD] feat(LIVE-31587): max number of records refactor for Aleo

### DIFF
--- a/.changeset/rotten-scissors-greet.md
+++ b/.changeset/rotten-scissors-greet.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+refactored max number of records per account type

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepAmount.tsx
@@ -63,7 +63,7 @@ const StepAmount = (props: StepProps) => {
       {error ? <ErrorBanner error={error} /> : null}
       <Fragment key={account.id}>
         {isAutoPickingStrategy ? (
-          <InfoBanner />
+          isAleoAccount(account) ? <InfoBanner account={account} /> : null
         ) : (
           <SpendableBanner
             account={account}

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/InfoBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/InfoBanner.test.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { render, screen } from "tests/testSetup";
-import { MAX_PRIVATE_RECORDS_PER_TRANSACTION } from "@ledgerhq/live-common/families/aleo/constants";
+import {
+  MAX_PRIVATE_RECORDS_PER_TRANSACTION,
+  MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION,
+} from "@ledgerhq/live-common/families/aleo/constants";
+import { ALEO_MAIN_ACCOUNT, makeTokenAccount } from "../__mocks__/account.mock";
 import InfoBanner from "./InfoBanner";
 
 jest.mock("~/renderer/components/Alert", () => ({
@@ -24,28 +28,35 @@ jest.mock("~/renderer/components/Alert", () => ({
 
 describe("InfoBanner", () => {
   it("renders without crashing", () => {
-    render(<InfoBanner />);
+    render(<InfoBanner account={ALEO_MAIN_ACCOUNT} />);
 
     expect(screen.getByTestId("alert")).toBeInTheDocument();
   });
 
   it("renders part one description text", () => {
-    render(<InfoBanner />);
+    render(<InfoBanner account={ALEO_MAIN_ACCOUNT} />);
 
     expect(screen.getByText("Sender, amount and recipient hidden on-chain.")).toBeInTheDocument();
   });
 
-  it("renders max records count from constants", () => {
-    render(<InfoBanner />);
+  it("renders coin account max records count", () => {
+    render(<InfoBanner account={ALEO_MAIN_ACCOUNT} />);
 
-    // The translated string for descPartTwo includes the MAX_PRIVATE_RECORDS_PER_TRANSACTION value
     expect(
       screen.getByText(new RegExp(String(MAX_PRIVATE_RECORDS_PER_TRANSACTION))),
     ).toBeInTheDocument();
   });
 
+  it("renders token account max records count", () => {
+    render(<InfoBanner account={makeTokenAccount([])} />);
+
+    expect(
+      screen.getByText(new RegExp(String(MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION))),
+    ).toBeInTheDocument();
+  });
+
   it("renders a learn-more link pointing to the maxSpendable url", () => {
-    render(<InfoBanner />);
+    render(<InfoBanner account={ALEO_MAIN_ACCOUNT} />);
 
     const link = screen.getByTestId("learn-more-link");
     expect(link).toBeInTheDocument();

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/InfoBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/InfoBanner.tsx
@@ -2,21 +2,25 @@ import React from "react";
 import { Trans } from "react-i18next";
 import { urls } from "~/config/urls";
 import Alert from "~/renderer/components/Alert";
-import { MAX_PRIVATE_RECORDS_PER_TRANSACTION } from "@ledgerhq/live-common/families/aleo/constants";
+import type { AleoAccount, AleoTokenAccount } from "@ledgerhq/live-common/families/aleo/types";
+import { getMaxPrivateRecordsForAccount } from "./utils";
 
-const InfoBanner = () => (
-  <Alert type="secondary" small learnMoreUrl={urls.maxSpendable} learnMoreOnRight>
-    <div className="flex flex-col gap-1">
-      <div className="inline-flex">
-        <Trans i18nKey="aleo.shared.infoBanner.descPartOne" />
+type Props = { account: AleoAccount | AleoTokenAccount };
+
+const InfoBanner = ({ account }: Props) => {
+  const max = getMaxPrivateRecordsForAccount(account);
+
+  return (
+    <Alert type="secondary" small learnMoreUrl={urls.maxSpendable} learnMoreOnRight>
+      <div className="flex flex-col gap-1">
+        <div className="inline-flex">
+          <Trans i18nKey="aleo.shared.infoBanner.descPartOne" />
+        </div>
+        <div className="inline-flex">
+          <Trans i18nKey="aleo.shared.infoBanner.descPartTwo" values={{ max }} />
+        </div>
       </div>
-      <div className="inline-flex">
-        <Trans
-          i18nKey="aleo.shared.infoBanner.descPartTwo"
-          values={{ max: MAX_PRIVATE_RECORDS_PER_TRANSACTION }}
-        />
-      </div>
-    </div>
-  </Alert>
-);
+    </Alert>
+  );
+};
 export default InfoBanner;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/QuickAmountSelector.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/QuickAmountSelector.test.tsx
@@ -2,7 +2,10 @@ import BigNumber from "bignumber.js";
 import React from "react";
 import { render, screen } from "tests/testSetup";
 import type { AleoAccount, AleoUnspentRecord } from "@ledgerhq/live-common/families/aleo/types";
-import { MAX_PRIVATE_RECORDS_PER_TRANSACTION } from "@ledgerhq/live-common/families/aleo/constants";
+import {
+  MAX_PRIVATE_RECORDS_PER_TRANSACTION,
+  MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION,
+} from "@ledgerhq/live-common/families/aleo/constants";
 import { getEstimatedSigningTime } from "@ledgerhq/live-common/families/aleo/utils";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import { ALEO_ACCOUNT_1, makeTokenAccount } from "../__mocks__/account.mock";
@@ -276,6 +279,32 @@ describe("QuickAmountSelector", () => {
       expect(updateTransaction).toHaveBeenCalledTimes(1);
       const updater = updateTransaction.mock.calls[0][0];
       expect(updater(transaction).useAllAmount).toBe(true);
+    });
+
+    it("sets useAllAmount when full tile is clicked with more token records than the token cap", async () => {
+      // MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION + 1 records — full tile fills exactly the cap → isSendMax
+      const records = Array.from({ length: MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION + 1 }, (_, i) =>
+        makeRecord(String((i + 1) * 100)),
+      );
+      const account = makeTokenAccount(records);
+      const transaction = makeAleoTransaction();
+      const updateTransaction = jest.fn();
+
+      const { user } = render(
+        <QuickAmountSelector
+          account={account}
+          transaction={transaction}
+          updateTransaction={updateTransaction}
+        />,
+      );
+
+      await user.click(screen.getByText("Full"));
+
+      expect(updateTransaction).toHaveBeenCalledTimes(1);
+      const updater = updateTransaction.mock.calls[0][0];
+      const result = updater(transaction);
+      expect(result.useAllAmount).toBe(true);
+      expect(result.amount.isEqualTo(new BigNumber(0))).toBe(true);
     });
 
     it("all tiles are disabled when token account has null unspentPrivateRecords", async () => {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/QuickAmountSelector.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/QuickAmountSelector.tsx
@@ -11,7 +11,6 @@ import TachometerLow from "~/renderer/icons/TachometerLow";
 import TachometerMedium from "~/renderer/icons/TachometerMedium";
 import Label from "~/renderer/components/Label";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
-import { MAX_PRIVATE_RECORDS_PER_TRANSACTION } from "@ledgerhq/live-common/families/aleo/constants";
 import type {
   AleoAccount,
   AleoTokenAccount,
@@ -23,7 +22,7 @@ import {
   isPrivateTransaction,
   sumPrivateRecords,
 } from "@ledgerhq/live-common/families/aleo/utils";
-import { isAleoTransaction } from "./utils";
+import { getMaxPrivateRecordsForAccount, isAleoTransaction } from "./utils";
 
 type SigningStrategy = "fast" | "balanced" | "full";
 
@@ -36,17 +35,23 @@ interface StrategyConfig {
 const FAST_PRIVATE_RECORDS_PER_TRANSACTION = 4;
 const BALANCED_PRIVATE_RECORDS_PER_TRANSACTION = 8;
 
-const STRATEGY_CONFIG: Record<SigningStrategy, StrategyConfig> = {
-  fast: { min: 1, max: FAST_PRIVATE_RECORDS_PER_TRANSACTION },
-  balanced: {
-    min: FAST_PRIVATE_RECORDS_PER_TRANSACTION + 1,
-    max: BALANCED_PRIVATE_RECORDS_PER_TRANSACTION,
-  },
-  full: {
-    min: BALANCED_PRIVATE_RECORDS_PER_TRANSACTION + 1,
-    max: MAX_PRIVATE_RECORDS_PER_TRANSACTION,
-  },
-};
+function getStrategyConfig(
+  account: AleoAccount | AleoTokenAccount,
+): Record<SigningStrategy, StrategyConfig> {
+  const maxRecords = getMaxPrivateRecordsForAccount(account);
+
+  return {
+    fast: { min: 1, max: FAST_PRIVATE_RECORDS_PER_TRANSACTION },
+    balanced: {
+      min: FAST_PRIVATE_RECORDS_PER_TRANSACTION + 1,
+      max: BALANCED_PRIVATE_RECORDS_PER_TRANSACTION,
+    },
+    full: {
+      min: BALANCED_PRIVATE_RECORDS_PER_TRANSACTION + 1,
+      max: maxRecords,
+    },
+  };
+}
 
 const STRATEGIES: SigningStrategy[] = ["fast", "balanced", "full"];
 
@@ -127,9 +132,11 @@ const QuickAmountSelector = ({ account, transaction, updateTransaction, onSelect
       .sort((a, b) => new BigNumber(b.microcredits).comparedTo(a.microcredits));
   }, [account]);
 
+  const strategyConfig = useMemo(() => getStrategyConfig(account), [account]);
+
   const spendableRecords = useMemo(
-    () => sortedRecords.slice(0, MAX_PRIVATE_RECORDS_PER_TRANSACTION),
-    [sortedRecords],
+    () => sortedRecords.slice(0, strategyConfig.full.max),
+    [sortedRecords, strategyConfig],
   );
 
   const totalSpendableBalance = sumPrivateRecords(spendableRecords);
@@ -148,7 +155,7 @@ const QuickAmountSelector = ({ account, transaction, updateTransaction, onSelect
   const strategyData = useMemo(
     () =>
       STRATEGIES.map(strategy => {
-        const { min, max } = STRATEGY_CONFIG[strategy];
+        const { min, max } = strategyConfig[strategy];
 
         const rangeRecords = sortedRecords.slice(0, max);
         const availableCount = rangeRecords.length;
@@ -158,7 +165,7 @@ const QuickAmountSelector = ({ account, transaction, updateTransaction, onSelect
         const isSendMax =
           !disabled &&
           (availableCount === totalRecords ||
-            (max === MAX_PRIVATE_RECORDS_PER_TRANSACTION && availableCount === max));
+            (max === strategyConfig.full.max && availableCount === max));
         const selected =
           !disabled &&
           (isSendMax
@@ -169,7 +176,7 @@ const QuickAmountSelector = ({ account, transaction, updateTransaction, onSelect
 
         return { strategy, min, max, availableCount, rangeSum, disabled, selected, isSendMax };
       }),
-    [sortedRecords, totalRecords, transaction.amount, transaction.useAllAmount],
+    [sortedRecords, totalRecords, transaction.amount, transaction.useAllAmount, strategyConfig],
   );
 
   return (

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.test.ts
@@ -1,6 +1,10 @@
 import BigNumber from "bignumber.js";
 import { getCurrencyConfiguration } from "@ledgerhq/live-common/config/index";
-import { TRANSACTION_TYPE } from "@ledgerhq/live-common/families/aleo/constants";
+import {
+  MAX_PRIVATE_RECORDS_PER_TRANSACTION,
+  MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION,
+  TRANSACTION_TYPE,
+} from "@ledgerhq/live-common/families/aleo/constants";
 import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { ALEO_ACCOUNT_1, ALEO_TOKEN_ACCOUNT } from "../__mocks__/account.mock";
@@ -10,6 +14,7 @@ import { makeAleoTransaction } from "../__mocks__/transaction.mock";
 import {
   getAleoAddressBadgeI18nKey,
   getAleoCurrencyConfig,
+  getMaxPrivateRecordsForAccount,
   isAleoAccount,
   isAleoTransaction,
   applyAleoBalanceSourceChange,
@@ -220,6 +225,29 @@ describe("applyAleoBalanceSourceChange", () => {
       }
     },
   );
+});
+
+describe("getMaxPrivateRecordsForAccount", () => {
+  it("returns MAX_PRIVATE_RECORDS_PER_TRANSACTION for a coin account", () => {
+    const aleoAccount: AleoAccount = {
+      ...ALEO_ACCOUNT_1,
+      aleoResources: {
+        transparentBalance: new BigNumber(0),
+        privateBalance: new BigNumber(0),
+        unspentPrivateRecords: [],
+        provableApi: null,
+        lastPrivateSyncDate: null,
+      },
+    };
+
+    expect(getMaxPrivateRecordsForAccount(aleoAccount)).toBe(MAX_PRIVATE_RECORDS_PER_TRANSACTION);
+  });
+
+  it("returns MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION for a token account", () => {
+    expect(getMaxPrivateRecordsForAccount(ALEO_TOKEN_ACCOUNT)).toBe(
+      MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION,
+    );
+  });
 });
 
 describe("formatAleoBalances", () => {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.ts
@@ -5,7 +5,11 @@ import {
   formatCurrencyUnit,
   type formatCurrencyUnitOptions,
 } from "@ledgerhq/live-common/currencies/index";
-import { TRANSACTION_TYPE } from "@ledgerhq/live-common/families/aleo/constants";
+import {
+  MAX_PRIVATE_RECORDS_PER_TRANSACTION,
+  MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION,
+  TRANSACTION_TYPE,
+} from "@ledgerhq/live-common/families/aleo/constants";
 import {
   derivePrivateTransactionMode,
   derivePublicTransactionMode,
@@ -112,4 +116,12 @@ export function formatAleoBalances({
       ? formatCurrencyUnit(unit, balances.privateBalance, formatConfig)
       : PRIVATE_BALANCE_PLACEHOLDER,
   };
+}
+
+export function getMaxPrivateRecordsForAccount(
+  account: AleoAccount | AleoTokenAccount,
+): number {
+  return account.type === "TokenAccount"
+    ? MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION
+    : MAX_PRIVATE_RECORDS_PER_TRANSACTION;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - added support for different max number of records per account type for Aleo

### 📝 Description

Extended with support for different number of records per account type for Aleo. 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [https://ledgerhq.atlassian.net/browse/LIVE-31587](https://ledgerhq.atlassian.net/browse/LIVE-31587)

Native coin: 

<img width="647" height="738" alt="image" src="https://github.com/user-attachments/assets/30ee2c1c-9508-446f-96b5-3cae39988b80" />

Example token: 
<img width="647" height="738" alt="image" src="https://github.com/user-attachments/assets/50e74f0f-0047-4b6f-8ebe-6c15ac32fd2f" />


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
