### PR TITLE
feat(currencies): add @domain/api-currency-token CAL token client

### DIFF
--- a/.changeset/api-currency-token-cal-client.md
+++ b/.changeset/api-currency-token-cal-client.md
@@ -1,0 +1,12 @@
+---
+"@domain/api-currency-token": minor
+---
+
+Add `@domain/api-currency-token`, the RTK Query client for token currencies backed by the Crypto
+Asset List (CAL): `cryptoAssetsApi` (`findTokenById`, `findTokenByAddressInCurrency`,
+`getTokensSyncHash`, `getTokensData`), the Zod token schema, the API→`TokenCurrency` converter
+(registry-based parent lookup) and the Zod-validated RTK Query persistence helpers. Service URLs,
+client version and an optional logger are injected via the store's thunk `extraArgument`
+(`calApiExtra`), so the package owns no env/config/logging dependency. Typed on
+`@domain/entity-currency-token` / `-crypto` / `-unit`; no `@ledgerhq/*` dependency.
+Not yet wired into the apps.

--- a/domain/api/currency-token/README.md
+++ b/domain/api/currency-token/README.md
@@ -1,0 +1,47 @@
+# @domain/api-currency-token
+
+Domain API client for **token currencies**, backed by the Crypto Asset List (CAL). RTK Query
+endpoints and helpers, typed on the Zod-first `@domain/entity-currency-token` entity. Owns no
+env/config/logging dependency.
+
+Relocation of `libs/ledgerjs/packages/cryptoassets/src/cal-client/*` and `api-token-converter.ts`.
+
+- `schema.ts` — Zod schema for the CAL `/v1/tokens` response (`ApiTokenResponseSchema`), reusing
+  `UnitSchema` from `@domain/entity-currency-unit`.
+- `types.ts` — query-arg and pagination types (`TokenByIdParams`, `TokenByAddressInCurrencyParams`,
+  `GetTokensDataParams`, `TokensDataWithPagination`).
+- `converter.ts` — `convertApiToken(apiToken)` → `TokenCurrency`; resolves the parent crypto
+  currency from `@domain/entity-currency-crypto`'s registry and drops tokens with an unknown parent.
+- `api.ts` — `cryptoAssetsApi` (`createApi`) with `findTokenById`, `findTokenByAddressInCurrency`,
+  `getTokensSyncHash`, `getTokensData`. Service URLs, client version and an optional logger are read
+  from the store's thunk `extraArgument`; the app supplies them via `calApiExtra(...)` so this
+  package owns no env/config dependency.
+- `persistence.ts` — Zod-validated RTK Query cache extraction/restoration and CAL hash validation.
+- `internals/` — **package-private** (not re-exported from `index.ts`): `constants.ts` (header
+  names, retry/page-size/persistence-version constants, the `TOKEN_TAGS` cache tags) and `utils.ts`
+  (the derived `output` projection + response transform helpers used by `api.ts`).
+
+Store wiring (app side):
+
+```ts
+configureStore({
+  reducer: { [cryptoAssetsApi.reducerPath]: cryptoAssetsApi.reducer },
+  middleware: gdm =>
+    gdm({
+      thunk: {
+        extraArgument: calApiExtra({
+          // Pass the staging URL here when running in staging mode — the package has no staging switch.
+          calServiceUrl: getEnv("CAL_SERVICE_URL"),
+          ledgerClientVersion: getEnv("LEDGER_CLIENT_VERSION"),
+        }),
+      },
+    }).concat(cryptoAssetsApi.middleware),
+});
+```
+
+When a store hosts several currency APIs (token, crypto, fiat), merge their extras with object
+spread — `{ ...calApiExtra({ … }), ...cryptoApiExtra({ … }) }` yields the combined `extraArgument` type.
+
+The imperative store builder and the slice binding (`onQueryStarted`) live in
+`@features/platform-currencies`, which keeps the domain api pure (the domain layer cannot depend on a
+feature package per the module boundaries).

--- a/domain/api/currency-token/jest.config.js
+++ b/domain/api/currency-token/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/domain/api/currency-token/package.json
+++ b/domain/api/currency-token/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@domain/api-currency-token",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Domain API client for token currencies (Crypto Asset List): RTK Query endpoints typed on @domain/entity-currency-token",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage"
+  },
+  "dependencies": {
+    "@domain/entity-currency-crypto": "workspace:*",
+    "@domain/entity-currency-token": "workspace:*",
+    "@domain/entity-currency-unit": "workspace:*",
+    "@reduxjs/toolkit": "catalog:",
+    "lodash": "^4.17.21",
+    "zod": "catalog:"
+  },
+  "peerDependencies": {
+    "react": ">=19.0.0",
+    "react-redux": ">=9.0.0"
+  },
+  "devDependencies": {
+    "@jest/globals": "catalog:",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/lodash": "^4.14.191",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "react": "catalog:",
+    "react-redux": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/domain/api/currency-token/project.json
+++ b/domain/api/currency-token/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@domain/api-currency-token",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/api/currency-token/src/api.test.ts
+++ b/domain/api/currency-token/src/api.test.ts
@@ -1,0 +1,251 @@
+import { configureStore } from "@reduxjs/toolkit";
+import type { TokenCurrency } from "@domain/entity-currency-token";
+
+jest.mock("./converter", () => ({
+  convertApiToken: jest.fn(),
+}));
+
+import { convertApiToken } from "./converter";
+import {
+  cryptoAssetsApi,
+  calApiExtra,
+  useGetTokensDataInfiniteQuery,
+  useFindTokenByIdQuery,
+  useFindTokenByAddressInCurrencyQuery,
+  useGetTokensSyncHashQuery,
+} from "./api";
+import { ApiResponseSchema, type ApiTokenResponse } from "./schema";
+import type { TokenByIdParams, TokenByAddressInCurrencyParams } from "./types";
+
+const mockConvert = convertApiToken as jest.MockedFunction<typeof convertApiToken>;
+
+const mockApiTokenResponse: ApiTokenResponse = {
+  id: "ethereum/erc20/usd_coin",
+  contract_address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  name: "USD Coin",
+  ticker: "USDC",
+  units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
+  standard: "erc20",
+  decimals: 6,
+  delisted: false,
+  live_signature: "3045022100...",
+};
+
+const mockTokenCurrency = {
+  type: "TokenCurrency",
+  id: "ethereum/erc20/usd_coin",
+  contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  parentCurrencyId: "ethereum",
+  tokenType: "erc20",
+  name: "USD Coin",
+  ticker: "USDC",
+  delisted: false,
+  disableCountervalue: false,
+  units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
+} as TokenCurrency;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockConvert.mockReturnValue(mockTokenCurrency);
+});
+
+describe("ApiResponseSchema", () => {
+  it("should validate an array of tokens", () => {
+    const result = ApiResponseSchema.parse([mockApiTokenResponse]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(mockApiTokenResponse);
+  });
+
+  it("should validate an empty array", () => {
+    expect(ApiResponseSchema.parse([])).toHaveLength(0);
+  });
+
+  it("should throw on a non-array payload", () => {
+    expect(() => ApiResponseSchema.parse("not an array")).toThrow();
+  });
+
+  it("should throw on an invalid token structure", () => {
+    expect(() => ApiResponseSchema.parse([{ invalid: "data" }])).toThrow();
+  });
+
+  it("should throw on missing required fields", () => {
+    const invalidToken = { ...mockApiTokenResponse };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (invalidToken as any).id;
+    expect(() => ApiResponseSchema.parse([invalidToken])).toThrow();
+  });
+
+  it("should validate a token with optional fields", () => {
+    const result = ApiResponseSchema.parse([
+      { ...mockApiTokenResponse, token_identifier: "some-identifier" },
+    ]);
+    expect(result[0].token_identifier).toBe("some-identifier");
+  });
+
+  it("should validate a token without optional fields", () => {
+    const tokenWithoutOptionals = { ...mockApiTokenResponse };
+    delete tokenWithoutOptionals.token_identifier;
+    delete tokenWithoutOptionals.live_signature;
+    const result = ApiResponseSchema.parse([tokenWithoutOptionals]);
+    expect(result[0].token_identifier).toBeUndefined();
+    expect(result[0].live_signature).toBeUndefined();
+  });
+
+  it("should throw when units is empty", () => {
+    expect(() => ApiResponseSchema.parse([{ ...mockApiTokenResponse, units: [] }])).toThrow();
+  });
+});
+
+describe("cryptoAssetsApi configuration", () => {
+  it("should have the correct reducer path", () => {
+    expect(cryptoAssetsApi.reducerPath).toBe("cryptoAssetsApi");
+  });
+
+  it("should expose all four endpoints", () => {
+    expect(cryptoAssetsApi.endpoints.findTokenById).toBeDefined();
+    expect(cryptoAssetsApi.endpoints.findTokenByAddressInCurrency).toBeDefined();
+    expect(cryptoAssetsApi.endpoints.getTokensSyncHash).toBeDefined();
+    expect(cryptoAssetsApi.endpoints.getTokensData).toBeDefined();
+  });
+
+  it("should export the generated hooks", () => {
+    expect(useGetTokensDataInfiniteQuery).toBeDefined();
+    expect(useFindTokenByIdQuery).toBeDefined();
+    expect(useFindTokenByAddressInCurrencyQuery).toBeDefined();
+    expect(useGetTokensSyncHashQuery).toBeDefined();
+  });
+});
+
+describe("param interfaces", () => {
+  it("accepts TokenByIdParams", () => {
+    const params: TokenByIdParams = { id: "ethereum/erc20/usdc" };
+    expect(params.id).toBe("ethereum/erc20/usdc");
+  });
+
+  it("accepts TokenByAddressInCurrencyParams with and without token_identifier", () => {
+    const a: TokenByAddressInCurrencyParams = {
+      contract_address: "EGLD-123",
+      network: "elrond",
+      token_identifier: "MYTOKEN-abc123",
+    };
+    const b: TokenByAddressInCurrencyParams = {
+      contract_address: "0xabc",
+      network: "ethereum",
+    };
+    expect(a.token_identifier).toBe("MYTOKEN-abc123");
+    expect(b.token_identifier).toBeUndefined();
+  });
+});
+
+describe("cryptoAssetsApi requests", () => {
+  let fetchSpy: jest.SpyInstance;
+
+  const makeStore = () =>
+    configureStore({
+      reducer: { [cryptoAssetsApi.reducerPath]: cryptoAssetsApi.reducer },
+      middleware: gdm =>
+        gdm({
+          thunk: {
+            extraArgument: calApiExtra({
+              calServiceUrl: "https://cal.test",
+              ledgerClientVersion: "1.2.3",
+            }),
+          },
+        }).concat(cryptoAssetsApi.middleware),
+    });
+
+  function mockFetch(body: unknown, headers: Record<string, string> = {}) {
+    fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json", ...headers },
+      }),
+    );
+  }
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+  });
+
+  it("findTokenById hits the prod base URL with the client-version header", async () => {
+    mockConvert.mockReturnValue(undefined);
+    mockFetch([]);
+    const store = makeStore();
+
+    await store.dispatch(
+      cryptoAssetsApi.endpoints.findTokenById.initiate({
+        id: "ethereum/erc20/usdc",
+      }),
+    );
+
+    const request = fetchSpy.mock.calls[0][0] as Request;
+    expect(request.url).toContain("https://cal.test/v1/tokens");
+    expect(request.url).toContain("id=ethereum%2Ferc20%2Fusdc");
+    expect(request.headers.get("X-Ledger-Client-Version")).toBe("1.2.3");
+  });
+
+  it("findTokenByAddressInCurrency forwards the contract address and network", async () => {
+    mockConvert.mockReturnValue(undefined);
+    mockFetch([]);
+    const store = makeStore();
+
+    await store.dispatch(
+      cryptoAssetsApi.endpoints.findTokenByAddressInCurrency.initiate({
+        contract_address: "0xabc",
+        network: "ethereum",
+      }),
+    );
+
+    const request = fetchSpy.mock.calls[0][0] as Request;
+    expect(request.url).toContain("https://cal.test/v1/tokens");
+    expect(request.url).toContain("contract_address=0xabc");
+    expect(request.url).toContain("network=ethereum");
+  });
+
+  it("getTokensData uses the injected CAL service base URL", async () => {
+    mockFetch([]);
+    const store = makeStore();
+
+    await store.dispatch(cryptoAssetsApi.endpoints.getTokensData.initiate({}));
+
+    const request = fetchSpy.mock.calls[0][0] as Request;
+    expect(request.url).toContain("https://cal.test/v1/tokens");
+  });
+
+  it("getTokensSyncHash returns the X-Ledger-Commit header from /v1/currencies", async () => {
+    mockFetch([{ id: "ethereum" }], { "X-Ledger-Commit": "commit-hash" });
+    const store = makeStore();
+
+    const result = await store.dispatch(
+      cryptoAssetsApi.endpoints.getTokensSyncHash.initiate("ethereum"),
+    );
+
+    expect(result.data).toBe("commit-hash");
+    // getTokensSyncHash calls fetch with a URL object; stringify before asserting.
+    const url = String(fetchSpy.mock.calls[0][0]);
+    expect(url).toContain("https://cal.test/v1/currencies");
+    expect(url).toContain("id=ethereum");
+  });
+
+  it("getTokensSyncHash errors with 404 on an empty currency array", async () => {
+    mockFetch([], { "X-Ledger-Commit": "commit-hash" });
+    const store = makeStore();
+
+    const result = await store.dispatch(
+      cryptoAssetsApi.endpoints.getTokensSyncHash.initiate("unknown"),
+    );
+
+    expect(result.isError).toBe(true);
+  });
+
+  it("getTokensSyncHash errors when the X-Ledger-Commit header is missing", async () => {
+    mockFetch([{ id: "ethereum" }]);
+    const store = makeStore();
+
+    const result = await store.dispatch(
+      cryptoAssetsApi.endpoints.getTokensSyncHash.initiate("ethereum"),
+    );
+
+    expect(result.isError).toBe(true);
+  });
+});

--- a/domain/api/currency-token/src/api.test.ts
+++ b/domain/api/currency-token/src/api.test.ts
@@ -1,5 +1,4 @@
 import { configureStore } from "@reduxjs/toolkit";
-import type { TokenCurrency } from "@domain/entity-currency-token";
 
 jest.mock("./converter", () => ({
   convertApiToken: jest.fn(),
@@ -14,35 +13,11 @@ import {
   useFindTokenByAddressInCurrencyQuery,
   useGetTokensSyncHashQuery,
 } from "./api";
-import { ApiResponseSchema, type ApiTokenResponse } from "./schema";
+import { ApiResponseSchema } from "./schema";
 import type { TokenByIdParams, TokenByAddressInCurrencyParams } from "./types";
+import { mockApiTokenResponse, mockTokenCurrency } from "./fixtures";
 
 const mockConvert = convertApiToken as jest.MockedFunction<typeof convertApiToken>;
-
-const mockApiTokenResponse: ApiTokenResponse = {
-  id: "ethereum/erc20/usd_coin",
-  contract_address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-  name: "USD Coin",
-  ticker: "USDC",
-  units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
-  standard: "erc20",
-  decimals: 6,
-  delisted: false,
-  live_signature: "3045022100...",
-};
-
-const mockTokenCurrency = {
-  type: "TokenCurrency",
-  id: "ethereum/erc20/usd_coin",
-  contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-  parentCurrencyId: "ethereum",
-  tokenType: "erc20",
-  name: "USD Coin",
-  ticker: "USDC",
-  delisted: false,
-  disableCountervalue: false,
-  units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
-} as TokenCurrency;
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/domain/api/currency-token/src/api.test.ts
+++ b/domain/api/currency-token/src/api.test.ts
@@ -137,6 +137,20 @@ describe("param interfaces", () => {
   });
 });
 
+describe("calApiExtra", () => {
+  it("returns the validated config", () => {
+    expect(
+      calApiExtra({ calServiceUrl: "https://cal.test", ledgerClientVersion: "1.2.3" }),
+    ).toEqual({ calServiceUrl: "https://cal.test", ledgerClientVersion: "1.2.3" });
+  });
+
+  it("throws when a required field is missing or empty", () => {
+    // @ts-expect-error — ledgerClientVersion is required
+    expect(() => calApiExtra({ calServiceUrl: "https://cal.test" })).toThrow();
+    expect(() => calApiExtra({ calServiceUrl: "", ledgerClientVersion: "1.2.3" })).toThrow();
+  });
+});
+
 describe("cryptoAssetsApi requests", () => {
   let fetchSpy: jest.SpyInstance;
 

--- a/domain/api/currency-token/src/api.ts
+++ b/domain/api/currency-token/src/api.ts
@@ -6,6 +6,7 @@ import {
   type FetchArgs,
   type FetchBaseQueryError,
 } from "@reduxjs/toolkit/query/react";
+import { z } from "zod";
 import type { TokenCurrency } from "@domain/entity-currency-token";
 import {
   type GetTokensDataParams,
@@ -22,6 +23,10 @@ import {
   MAX_RETRIES,
   TOKEN_OUTPUT_FIELDS,
   TOKEN_TAGS,
+  commitHeaderMissingError,
+  currencyNotFoundError,
+  fetchCurrencyError,
+  fetchError,
   transformTokensResponse,
   validateAndTransformSingleTokenResponse,
 } from "./internals";
@@ -32,24 +37,32 @@ import {
  * owns no env/config/logging dependency. The app picks the prod or staging URL — there is no
  * staging switch in here.
  */
-export interface CalApiExtra {
-  calServiceUrl: string;
-  ledgerClientVersion: string;
-  logger?: (...args: unknown[]) => void;
-}
+const CalApiExtraSchema = z.object({
+  calServiceUrl: z.string().min(1),
+  ledgerClientVersion: z.string().min(1),
+  logger: z.custom<(...args: unknown[]) => void>().optional(),
+});
+
+export type CalApiExtra = z.infer<typeof CalApiExtraSchema>;
 
 /**
  * Builds this package's slice of the thunk `extraArgument`. RTK leaves `extraArgument` untyped, so
- * this is the one compile-checked entry point ensuring the CAL config is complete and correctly named.
+ * this is the one compile- and runtime-checked entry point: `parse` fails fast at app init if the CAL
+ * config is incomplete (e.g. an env var resolved to an empty string).
  */
 export function calApiExtra(extra: CalApiExtra): CalApiExtra {
-  return extra;
+  return CalApiExtraSchema.parse(extra);
+}
+
+/** Extracts the {@link CalApiExtra} from the `extraArgument` of the API. */
+function getCalExtra(api: { extra: unknown }): CalApiExtra {
+  return api.extra as CalApiExtra;
 }
 
 /** Reads the injected {@link CalApiExtra} and delegates to {@link fetchBaseQuery}. Wrapped in `retry`. */
 const calBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError> = retry(
   (args, api, extraOptions) => {
-    const extra = api.extra as CalApiExtra;
+    const extra = getCalExtra(api);
     return fetchBaseQuery({
       baseUrl: extra.calServiceUrl,
       prepareHeaders: headers => {
@@ -103,7 +116,7 @@ export const cryptoAssetsApi = createApi({
 
     getTokensSyncHash: build.query<string, string>({
       async queryFn(currencyId, queryApi) {
-        const extra = queryApi.extra as CalApiExtra;
+        const extra = getCalExtra(queryApi);
         try {
           const url = new URL("/v1/currencies", extra.calServiceUrl);
           url.searchParams.set("output", "id");
@@ -118,61 +131,38 @@ export const cryptoAssetsApi = createApi({
           });
 
           if (!response.ok) {
-            return {
-              error: {
-                status: response.status,
-                data: `Failed to fetch currency: ${response.statusText}`,
-                originalStatus: response.status,
-              },
-            };
+            return fetchCurrencyError(response.status, response.statusText);
           }
 
           // Check if the response contains data (not an empty array)
           const responseData = await response.json();
           if (Array.isArray(responseData) && responseData.length === 0) {
-            return {
-              error: {
-                status: 404,
-                data: `Currency not found: ${currencyId}`,
-                originalStatus: 404,
-              },
-            };
+            return currencyNotFoundError(currencyId);
           }
 
           const hash = response.headers.get(HEADER_X_LEDGER_COMMIT);
 
           if (!hash) {
-            return {
-              error: {
-                status: "PARSING_ERROR",
-                data: "X-Ledger-Commit header not found in response",
-                error: "X-Ledger-Commit header not found in response",
-                originalStatus: 200,
-              },
-            };
+            return commitHeaderMissingError();
           }
 
           return { data: hash };
         } catch (error) {
-          return {
-            error: {
-              status: "FETCH_ERROR",
-              error: error instanceof Error ? error.message : "Unknown error",
-            },
-          };
+          return fetchError(error);
         }
       },
-      async onQueryStarted(currencyId, { dispatch, queryFulfilled, getCacheEntry, extra }) {
+      async onQueryStarted(currencyId, api) {
+        const extra = getCalExtra(api);
         try {
-          const previousHash = getCacheEntry()?.data as string | undefined;
-          const { data: newHash } = await queryFulfilled;
+          const previousHash = api.getCacheEntry()?.data as string | undefined;
+          const { data: newHash } = await api.queryFulfilled;
 
           if (previousHash && newHash && previousHash !== newHash) {
-            (extra as CalApiExtra).logger?.(
+            extra.logger?.(
               "cryptoassets",
               `Hash changed for currencyId ${currencyId}: ${previousHash} -> ${newHash}, evicting token cache`,
             );
-            dispatch(cryptoAssetsApi.util.invalidateTags([...TOKEN_TAGS]));
+            api.dispatch(cryptoAssetsApi.util.invalidateTags([...TOKEN_TAGS]));
           }
         } catch {
           // Query failed, skip eviction
@@ -181,18 +171,17 @@ export const cryptoAssetsApi = createApi({
     }),
 
     getTokensData: build.infiniteQuery<TokensDataWithPagination, GetTokensDataParams, PageParam>({
-      query: ({ pageParam, queryArg = {} }) => {
+      query({ pageParam, queryArg = {} }) {
         const { output, networkFamily, pageSize = DEFAULT_PAGE_SIZE, limit, ref } = queryArg;
 
         const params = {
-          output: output?.join(",") || TOKEN_OUTPUT_FIELDS.join(","),
+          output: output?.join(",") ?? TOKEN_OUTPUT_FIELDS.join(","),
+          pageSize,
           ...(pageParam?.cursor && { cursor: pageParam.cursor }),
           ...(networkFamily && { network_family: networkFamily }),
-          pageSize,
           ...(limit && { limit }),
           ...(ref && { ref }),
         };
-
         return {
           url: "/v1/tokens",
           params,

--- a/domain/api/currency-token/src/api.ts
+++ b/domain/api/currency-token/src/api.ts
@@ -6,9 +6,10 @@ import {
   type FetchArgs,
   type FetchBaseQueryError,
 } from "@reduxjs/toolkit/query/react";
-import { z } from "zod";
 import type { TokenCurrency } from "@domain/entity-currency-token";
+import { CalApiExtraSchema } from "./schema";
 import {
+  type CalApiExtra,
   type GetTokensDataParams,
   type PageParam,
   type TokenByAddressInCurrencyParams,
@@ -30,20 +31,6 @@ import {
   transformTokensResponse,
   validateAndTransformSingleTokenResponse,
 } from "./internals";
-
-/**
- * Thunk `extraArgument` contract for {@link cryptoAssetsApi}. The app supplies the resolved CAL
- * service URL, client version and an optional logger at store configuration time, so this package
- * owns no env/config/logging dependency. The app picks the prod or staging URL — there is no
- * staging switch in here.
- */
-const CalApiExtraSchema = z.object({
-  calServiceUrl: z.string().min(1),
-  ledgerClientVersion: z.string().min(1),
-  logger: z.custom<(...args: unknown[]) => void>().optional(),
-});
-
-export type CalApiExtra = z.infer<typeof CalApiExtraSchema>;
 
 /**
  * Builds this package's slice of the thunk `extraArgument`. RTK leaves `extraArgument` untyped, so

--- a/domain/api/currency-token/src/api.ts
+++ b/domain/api/currency-token/src/api.ts
@@ -1,0 +1,221 @@
+import {
+  createApi,
+  fetchBaseQuery,
+  retry,
+  type BaseQueryFn,
+  type FetchArgs,
+  type FetchBaseQueryError,
+} from "@reduxjs/toolkit/query/react";
+import type { TokenCurrency } from "@domain/entity-currency-token";
+import {
+  type GetTokensDataParams,
+  type PageParam,
+  type TokenByAddressInCurrencyParams,
+  type TokenByIdParams,
+  type TokensDataWithPagination,
+} from "./types";
+import {
+  CAL_REDUCER_PATH,
+  DEFAULT_PAGE_SIZE,
+  HEADER_X_LEDGER_CLIENT_VERSION,
+  HEADER_X_LEDGER_COMMIT,
+  MAX_RETRIES,
+  TOKEN_OUTPUT_FIELDS,
+  TOKEN_TAGS,
+  transformTokensResponse,
+  validateAndTransformSingleTokenResponse,
+} from "./internals";
+
+/**
+ * Thunk `extraArgument` contract for {@link cryptoAssetsApi}. The app supplies the resolved CAL
+ * service URL, client version and an optional logger at store configuration time, so this package
+ * owns no env/config/logging dependency. The app picks the prod or staging URL — there is no
+ * staging switch in here.
+ */
+export interface CalApiExtra {
+  calServiceUrl: string;
+  ledgerClientVersion: string;
+  logger?: (...args: unknown[]) => void;
+}
+
+/**
+ * Builds this package's slice of the thunk `extraArgument`. RTK leaves `extraArgument` untyped, so
+ * this is the one compile-checked entry point ensuring the CAL config is complete and correctly named.
+ */
+export function calApiExtra(extra: CalApiExtra): CalApiExtra {
+  return extra;
+}
+
+/** Reads the injected {@link CalApiExtra} and delegates to {@link fetchBaseQuery}. Wrapped in `retry`. */
+const calBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError> = retry(
+  (args, api, extraOptions) => {
+    const extra = api.extra as CalApiExtra;
+    return fetchBaseQuery({
+      baseUrl: extra.calServiceUrl,
+      prepareHeaders: headers => {
+        headers.set("Content-Type", "application/json");
+        headers.set(HEADER_X_LEDGER_CLIENT_VERSION, extra.ledgerClientVersion);
+        return headers;
+      },
+    })(args, api, extraOptions);
+  },
+  { maxRetries: MAX_RETRIES },
+);
+
+/** RTK Query API for the Crypto Asset List (CAL) token data. */
+export const cryptoAssetsApi = createApi({
+  reducerPath: CAL_REDUCER_PATH,
+  baseQuery: calBaseQuery,
+  tagTypes: [...TOKEN_TAGS],
+  endpoints: build => ({
+    findTokenById: build.query<TokenCurrency | undefined, TokenByIdParams>({
+      query: params => ({
+        url: "/v1/tokens",
+        params: {
+          id: params.id,
+          limit: "1",
+          output: TOKEN_OUTPUT_FIELDS.join(","),
+        },
+      }),
+      transformResponse: validateAndTransformSingleTokenResponse,
+      providesTags: [...TOKEN_TAGS],
+    }),
+
+    findTokenByAddressInCurrency: build.query<
+      TokenCurrency | undefined,
+      TokenByAddressInCurrencyParams
+    >({
+      query: params => ({
+        url: "/v1/tokens",
+        params: {
+          contract_address: params.contract_address,
+          network: params.network,
+          limit: "1",
+          output: TOKEN_OUTPUT_FIELDS.join(","),
+          ...(params.token_identifier === undefined
+            ? {}
+            : { token_identifier: params.token_identifier }),
+        },
+      }),
+      transformResponse: validateAndTransformSingleTokenResponse,
+      providesTags: [...TOKEN_TAGS],
+    }),
+
+    getTokensSyncHash: build.query<string, string>({
+      async queryFn(currencyId, queryApi) {
+        const extra = queryApi.extra as CalApiExtra;
+        try {
+          const url = new URL("/v1/currencies", extra.calServiceUrl);
+          url.searchParams.set("output", "id");
+          url.searchParams.set("limit", "1");
+          url.searchParams.set("id", currencyId);
+
+          const response = await fetch(url, {
+            headers: {
+              "Content-Type": "application/json",
+              [HEADER_X_LEDGER_CLIENT_VERSION]: extra.ledgerClientVersion,
+            },
+          });
+
+          if (!response.ok) {
+            return {
+              error: {
+                status: response.status,
+                data: `Failed to fetch currency: ${response.statusText}`,
+                originalStatus: response.status,
+              },
+            };
+          }
+
+          // Check if the response contains data (not an empty array)
+          const responseData = await response.json();
+          if (Array.isArray(responseData) && responseData.length === 0) {
+            return {
+              error: {
+                status: 404,
+                data: `Currency not found: ${currencyId}`,
+                originalStatus: 404,
+              },
+            };
+          }
+
+          const hash = response.headers.get(HEADER_X_LEDGER_COMMIT);
+
+          if (!hash) {
+            return {
+              error: {
+                status: "PARSING_ERROR",
+                data: "X-Ledger-Commit header not found in response",
+                error: "X-Ledger-Commit header not found in response",
+                originalStatus: 200,
+              },
+            };
+          }
+
+          return { data: hash };
+        } catch (error) {
+          return {
+            error: {
+              status: "FETCH_ERROR",
+              error: error instanceof Error ? error.message : "Unknown error",
+            },
+          };
+        }
+      },
+      async onQueryStarted(currencyId, { dispatch, queryFulfilled, getCacheEntry, extra }) {
+        try {
+          const previousHash = getCacheEntry()?.data as string | undefined;
+          const { data: newHash } = await queryFulfilled;
+
+          if (previousHash && newHash && previousHash !== newHash) {
+            (extra as CalApiExtra).logger?.(
+              "cryptoassets",
+              `Hash changed for currencyId ${currencyId}: ${previousHash} -> ${newHash}, evicting token cache`,
+            );
+            dispatch(cryptoAssetsApi.util.invalidateTags([...TOKEN_TAGS]));
+          }
+        } catch {
+          // Query failed, skip eviction
+        }
+      },
+    }),
+
+    getTokensData: build.infiniteQuery<TokensDataWithPagination, GetTokensDataParams, PageParam>({
+      query: ({ pageParam, queryArg = {} }) => {
+        const { output, networkFamily, pageSize = DEFAULT_PAGE_SIZE, limit, ref } = queryArg;
+
+        const params = {
+          output: output?.join(",") || TOKEN_OUTPUT_FIELDS.join(","),
+          ...(pageParam?.cursor && { cursor: pageParam.cursor }),
+          ...(networkFamily && { network_family: networkFamily }),
+          pageSize,
+          ...(limit && { limit }),
+          ...(ref && { ref }),
+        };
+
+        return {
+          url: "/v1/tokens",
+          params,
+        };
+      },
+      providesTags: [...TOKEN_TAGS],
+      transformResponse: transformTokensResponse,
+      infiniteQueryOptions: {
+        initialPageParam: {
+          cursor: "",
+        },
+        getNextPageParam: lastPage =>
+          lastPage.pagination.nextCursor ? { cursor: lastPage.pagination.nextCursor } : undefined,
+      },
+    }),
+  }),
+});
+
+export const {
+  useGetTokensDataInfiniteQuery,
+  useFindTokenByIdQuery,
+  useFindTokenByAddressInCurrencyQuery,
+  useGetTokensSyncHashQuery,
+} = cryptoAssetsApi;
+
+export type CryptoAssetsApi = typeof cryptoAssetsApi;

--- a/domain/api/currency-token/src/converter.test.ts
+++ b/domain/api/currency-token/src/converter.test.ts
@@ -1,18 +1,16 @@
-import { convertApiToken, type ApiTokenData } from "./converter";
+import { convertApiToken } from "./converter";
+import { buildApiTokenData } from "./fixtures";
 
 describe("convertApiToken", () => {
   describe("Cardano transformation", () => {
     it("should not reconstruct if tokenIdentifier is missing", () => {
-      const apiToken: ApiTokenData = {
-        id: "cardano/native/policyId",
-        contractAddress: "policyId",
-        name: "Test Token",
-        ticker: "TEST",
-        units: [{ code: "TEST", name: "Test Token", magnitude: 6 }],
-        standard: "native",
-      };
-
-      const result = convertApiToken(apiToken);
+      const result = convertApiToken(
+        buildApiTokenData({
+          id: "cardano/native/policyId",
+          contractAddress: "policyId",
+          standard: "native",
+        }),
+      );
 
       expect(result?.contractAddress).toBe("policyId");
     });
@@ -20,17 +18,14 @@ describe("convertApiToken", () => {
 
   describe("Sui passthrough", () => {
     it("should keep 'coin' standard as tokenType for sui tokens", () => {
-      const apiToken: ApiTokenData = {
-        id: "sui/coin/usdc_0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::usdc",
-        contractAddress:
-          "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC",
-        name: "USDC",
-        ticker: "USDC",
-        units: [{ code: "USDC", name: "USDC", magnitude: 6 }],
-        standard: "coin",
-      };
-
-      const result = convertApiToken(apiToken);
+      const result = convertApiToken(
+        buildApiTokenData({
+          id: "sui/coin/usdc_0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::usdc",
+          contractAddress:
+            "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC",
+          standard: "coin",
+        }),
+      );
 
       expect(result?.tokenType).toBe("coin");
       expect(result?.parentCurrencyId).toBe("sui");
@@ -39,32 +34,13 @@ describe("convertApiToken", () => {
 
   describe("ledgerSignature handling", () => {
     it("should include ledgerSignature when provided", () => {
-      const apiToken: ApiTokenData = {
-        id: "ethereum/erc20/usdc",
-        contractAddress: "0xA0b86",
-        name: "USD Coin",
-        ticker: "USDC",
-        units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
-        standard: "erc20",
-        ledgerSignature: "3045022100...",
-      };
-
-      const result = convertApiToken(apiToken);
+      const result = convertApiToken(buildApiTokenData({ ledgerSignature: "3045022100..." }));
 
       expect(result?.ledgerSignature).toBe("3045022100...");
     });
 
     it("should not include ledgerSignature when not provided", () => {
-      const apiToken: ApiTokenData = {
-        id: "ethereum/erc20/usdc",
-        contractAddress: "0xA0b86",
-        name: "USD Coin",
-        ticker: "USDC",
-        units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
-        standard: "erc20",
-      };
-
-      const result = convertApiToken(apiToken);
+      const result = convertApiToken(buildApiTokenData());
 
       expect(result?.ledgerSignature).toBeUndefined();
     });
@@ -72,47 +48,27 @@ describe("convertApiToken", () => {
 
   describe("disableCountervalue handling", () => {
     it("should set disableCountervalue for testnet currencies", () => {
-      const apiToken: ApiTokenData = {
-        id: "ethereum_sepolia/erc20/usdc",
-        contractAddress: "0x123",
-        name: "USD Coin",
-        ticker: "USDC",
-        units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
-        standard: "erc20",
-      };
-
-      const result = convertApiToken(apiToken);
+      const result = convertApiToken(
+        buildApiTokenData({ id: "ethereum_sepolia/erc20/usdc", contractAddress: "0x123" }),
+      );
 
       expect(result?.disableCountervalue).toBe(true);
     });
 
     it("should respect explicit disableCountervalue flag", () => {
-      const apiToken: ApiTokenData = {
-        id: "ethereum/erc20/test",
-        contractAddress: "0x123",
-        name: "Test Token",
-        ticker: "TEST",
-        units: [{ code: "TEST", name: "Test Token", magnitude: 18 }],
-        standard: "erc20",
-        disableCountervalue: true,
-      };
-
-      const result = convertApiToken(apiToken);
+      const result = convertApiToken(
+        buildApiTokenData({
+          id: "ethereum/erc20/test",
+          contractAddress: "0x123",
+          disableCountervalue: true,
+        }),
+      );
 
       expect(result?.disableCountervalue).toBe(true);
     });
 
     it("should not disable countervalue for a mainnet currency without the flag", () => {
-      const apiToken: ApiTokenData = {
-        id: "ethereum/erc20/usdc",
-        contractAddress: "0xA0b86",
-        name: "USD Coin",
-        ticker: "USDC",
-        units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
-        standard: "erc20",
-      };
-
-      const result = convertApiToken(apiToken);
+      const result = convertApiToken(buildApiTokenData());
 
       expect(result?.disableCountervalue).toBe(false);
     });
@@ -120,47 +76,25 @@ describe("convertApiToken", () => {
 
   describe("Edge cases", () => {
     it("should return undefined for unknown parent currency", () => {
-      const apiToken: ApiTokenData = {
-        id: "unknowncurrency/erc20/test",
-        contractAddress: "0x123",
-        name: "Test",
-        ticker: "TEST",
-        units: [{ code: "TEST", name: "Test", magnitude: 18 }],
-        standard: "erc20",
-      };
-
-      const result = convertApiToken(apiToken);
+      const result = convertApiToken(
+        buildApiTokenData({ id: "unknowncurrency/erc20/test", contractAddress: "0x123" }),
+      );
 
       expect(result).toBeUndefined();
     });
 
     it("should handle delisted tokens", () => {
-      const apiToken: ApiTokenData = {
-        id: "ethereum/erc20/old",
-        contractAddress: "0x123",
-        name: "Old Token",
-        ticker: "OLD",
-        units: [{ code: "OLD", name: "Old Token", magnitude: 18 }],
-        standard: "erc20",
-        delisted: true,
-      };
-
-      const result = convertApiToken(apiToken);
+      const result = convertApiToken(
+        buildApiTokenData({ id: "ethereum/erc20/old", contractAddress: "0x123", delisted: true }),
+      );
 
       expect(result?.delisted).toBe(true);
     });
 
     it("should handle empty units array", () => {
-      const apiToken: ApiTokenData = {
-        id: "ethereum/erc20/test",
-        contractAddress: "0x123",
-        name: "Test",
-        ticker: "TEST",
-        units: [],
-        standard: "erc20",
-      };
-
-      const result = convertApiToken(apiToken);
+      const result = convertApiToken(
+        buildApiTokenData({ id: "ethereum/erc20/test", contractAddress: "0x123", units: [] }),
+      );
 
       expect(result?.units).toEqual([]);
     });
@@ -168,16 +102,7 @@ describe("convertApiToken", () => {
 
   describe("Standard token types", () => {
     it("should convert ERC20 token", () => {
-      const apiToken: ApiTokenData = {
-        id: "ethereum/erc20/usdc",
-        contractAddress: "0xA0b86",
-        name: "USD Coin",
-        ticker: "USDC",
-        units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
-        standard: "erc20",
-      };
-
-      const result = convertApiToken(apiToken);
+      const result = convertApiToken(buildApiTokenData());
 
       expect(result?.type).toBe("TokenCurrency");
       expect(result?.tokenType).toBe("erc20");
@@ -185,48 +110,39 @@ describe("convertApiToken", () => {
     });
 
     it("should convert SPL token", () => {
-      const apiToken: ApiTokenData = {
-        id: "solana/spl/usdc",
-        contractAddress: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-        name: "USD Coin",
-        ticker: "USDC",
-        units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
-        standard: "spl",
-      };
-
-      const result = convertApiToken(apiToken);
+      const result = convertApiToken(
+        buildApiTokenData({
+          id: "solana/spl/usdc",
+          contractAddress: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          standard: "spl",
+        }),
+      );
 
       expect(result?.tokenType).toBe("spl");
       expect(result?.parentCurrencyId).toBe("solana");
     });
 
     it("should convert TRC20 token", () => {
-      const apiToken: ApiTokenData = {
-        id: "tron/trc20/usdt",
-        contractAddress: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
-        name: "Tether USD",
-        ticker: "USDT",
-        units: [{ code: "USDT", name: "Tether USD", magnitude: 6 }],
-        standard: "trc20",
-      };
-
-      const result = convertApiToken(apiToken);
+      const result = convertApiToken(
+        buildApiTokenData({
+          id: "tron/trc20/usdt",
+          contractAddress: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+          standard: "trc20",
+        }),
+      );
 
       expect(result?.tokenType).toBe("trc20");
       expect(result?.parentCurrencyId).toBe("tron");
     });
 
     it("should convert ASA token", () => {
-      const apiToken: ApiTokenData = {
-        id: "algorand/asa/31566704",
-        contractAddress: "31566704",
-        name: "USDC",
-        ticker: "USDC",
-        units: [{ code: "USDC", name: "USDC", magnitude: 6 }],
-        standard: "asa",
-      };
-
-      const result = convertApiToken(apiToken);
+      const result = convertApiToken(
+        buildApiTokenData({
+          id: "algorand/asa/31566704",
+          contractAddress: "31566704",
+          standard: "asa",
+        }),
+      );
 
       expect(result?.tokenType).toBe("asa");
       expect(result?.parentCurrencyId).toBe("algorand");

--- a/domain/api/currency-token/src/converter.test.ts
+++ b/domain/api/currency-token/src/converter.test.ts
@@ -1,0 +1,235 @@
+import { convertApiToken, type ApiTokenData } from "./converter";
+
+describe("convertApiToken", () => {
+  describe("Cardano transformation", () => {
+    it("should not reconstruct if tokenIdentifier is missing", () => {
+      const apiToken: ApiTokenData = {
+        id: "cardano/native/policyId",
+        contractAddress: "policyId",
+        name: "Test Token",
+        ticker: "TEST",
+        units: [{ code: "TEST", name: "Test Token", magnitude: 6 }],
+        standard: "native",
+      };
+
+      const result = convertApiToken(apiToken);
+
+      expect(result?.contractAddress).toBe("policyId");
+    });
+  });
+
+  describe("Sui passthrough", () => {
+    it("should keep 'coin' standard as tokenType for sui tokens", () => {
+      const apiToken: ApiTokenData = {
+        id: "sui/coin/usdc_0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::usdc",
+        contractAddress:
+          "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC",
+        name: "USDC",
+        ticker: "USDC",
+        units: [{ code: "USDC", name: "USDC", magnitude: 6 }],
+        standard: "coin",
+      };
+
+      const result = convertApiToken(apiToken);
+
+      expect(result?.tokenType).toBe("coin");
+      expect(result?.parentCurrencyId).toBe("sui");
+    });
+  });
+
+  describe("ledgerSignature handling", () => {
+    it("should include ledgerSignature when provided", () => {
+      const apiToken: ApiTokenData = {
+        id: "ethereum/erc20/usdc",
+        contractAddress: "0xA0b86",
+        name: "USD Coin",
+        ticker: "USDC",
+        units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
+        standard: "erc20",
+        ledgerSignature: "3045022100...",
+      };
+
+      const result = convertApiToken(apiToken);
+
+      expect(result?.ledgerSignature).toBe("3045022100...");
+    });
+
+    it("should not include ledgerSignature when not provided", () => {
+      const apiToken: ApiTokenData = {
+        id: "ethereum/erc20/usdc",
+        contractAddress: "0xA0b86",
+        name: "USD Coin",
+        ticker: "USDC",
+        units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
+        standard: "erc20",
+      };
+
+      const result = convertApiToken(apiToken);
+
+      expect(result?.ledgerSignature).toBeUndefined();
+    });
+  });
+
+  describe("disableCountervalue handling", () => {
+    it("should set disableCountervalue for testnet currencies", () => {
+      const apiToken: ApiTokenData = {
+        id: "ethereum_sepolia/erc20/usdc",
+        contractAddress: "0x123",
+        name: "USD Coin",
+        ticker: "USDC",
+        units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
+        standard: "erc20",
+      };
+
+      const result = convertApiToken(apiToken);
+
+      expect(result?.disableCountervalue).toBe(true);
+    });
+
+    it("should respect explicit disableCountervalue flag", () => {
+      const apiToken: ApiTokenData = {
+        id: "ethereum/erc20/test",
+        contractAddress: "0x123",
+        name: "Test Token",
+        ticker: "TEST",
+        units: [{ code: "TEST", name: "Test Token", magnitude: 18 }],
+        standard: "erc20",
+        disableCountervalue: true,
+      };
+
+      const result = convertApiToken(apiToken);
+
+      expect(result?.disableCountervalue).toBe(true);
+    });
+
+    it("should not disable countervalue for a mainnet currency without the flag", () => {
+      const apiToken: ApiTokenData = {
+        id: "ethereum/erc20/usdc",
+        contractAddress: "0xA0b86",
+        name: "USD Coin",
+        ticker: "USDC",
+        units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
+        standard: "erc20",
+      };
+
+      const result = convertApiToken(apiToken);
+
+      expect(result?.disableCountervalue).toBe(false);
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should return undefined for unknown parent currency", () => {
+      const apiToken: ApiTokenData = {
+        id: "unknowncurrency/erc20/test",
+        contractAddress: "0x123",
+        name: "Test",
+        ticker: "TEST",
+        units: [{ code: "TEST", name: "Test", magnitude: 18 }],
+        standard: "erc20",
+      };
+
+      const result = convertApiToken(apiToken);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should handle delisted tokens", () => {
+      const apiToken: ApiTokenData = {
+        id: "ethereum/erc20/old",
+        contractAddress: "0x123",
+        name: "Old Token",
+        ticker: "OLD",
+        units: [{ code: "OLD", name: "Old Token", magnitude: 18 }],
+        standard: "erc20",
+        delisted: true,
+      };
+
+      const result = convertApiToken(apiToken);
+
+      expect(result?.delisted).toBe(true);
+    });
+
+    it("should handle empty units array", () => {
+      const apiToken: ApiTokenData = {
+        id: "ethereum/erc20/test",
+        contractAddress: "0x123",
+        name: "Test",
+        ticker: "TEST",
+        units: [],
+        standard: "erc20",
+      };
+
+      const result = convertApiToken(apiToken);
+
+      expect(result?.units).toEqual([]);
+    });
+  });
+
+  describe("Standard token types", () => {
+    it("should convert ERC20 token", () => {
+      const apiToken: ApiTokenData = {
+        id: "ethereum/erc20/usdc",
+        contractAddress: "0xA0b86",
+        name: "USD Coin",
+        ticker: "USDC",
+        units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
+        standard: "erc20",
+      };
+
+      const result = convertApiToken(apiToken);
+
+      expect(result?.type).toBe("TokenCurrency");
+      expect(result?.tokenType).toBe("erc20");
+      expect(result?.parentCurrencyId).toBe("ethereum");
+    });
+
+    it("should convert SPL token", () => {
+      const apiToken: ApiTokenData = {
+        id: "solana/spl/usdc",
+        contractAddress: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        name: "USD Coin",
+        ticker: "USDC",
+        units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
+        standard: "spl",
+      };
+
+      const result = convertApiToken(apiToken);
+
+      expect(result?.tokenType).toBe("spl");
+      expect(result?.parentCurrencyId).toBe("solana");
+    });
+
+    it("should convert TRC20 token", () => {
+      const apiToken: ApiTokenData = {
+        id: "tron/trc20/usdt",
+        contractAddress: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+        name: "Tether USD",
+        ticker: "USDT",
+        units: [{ code: "USDT", name: "Tether USD", magnitude: 6 }],
+        standard: "trc20",
+      };
+
+      const result = convertApiToken(apiToken);
+
+      expect(result?.tokenType).toBe("trc20");
+      expect(result?.parentCurrencyId).toBe("tron");
+    });
+
+    it("should convert ASA token", () => {
+      const apiToken: ApiTokenData = {
+        id: "algorand/asa/31566704",
+        contractAddress: "31566704",
+        name: "USDC",
+        ticker: "USDC",
+        units: [{ code: "USDC", name: "USDC", magnitude: 6 }],
+        standard: "asa",
+      };
+
+      const result = convertApiToken(apiToken);
+
+      expect(result?.tokenType).toBe("asa");
+      expect(result?.parentCurrencyId).toBe("algorand");
+    });
+  });
+});

--- a/domain/api/currency-token/src/converter.ts
+++ b/domain/api/currency-token/src/converter.ts
@@ -1,0 +1,66 @@
+import { CRYPTO_CURRENCIES_REGISTRY } from "@domain/entity-currency-crypto";
+import type { TokenCurrency } from "@domain/entity-currency-token";
+import type { Unit } from "@domain/entity-currency-unit";
+
+export interface ApiTokenData {
+  id: string;
+  contractAddress: string;
+  name: string;
+  ticker: string;
+  units: Unit[];
+  standard: string;
+  delisted?: boolean;
+  disableCountervalue?: boolean;
+  tokenIdentifier?: string;
+  ledgerSignature?: string;
+}
+
+/**
+ * Converts CAL token data to a {@link TokenCurrency}.
+ *
+ * Resolves the parent crypto currency from the static `@domain/entity-currency-crypto`
+ * registry to derive `disableCountervalue` (testnet parents disable countervalues) and
+ * to drop tokens whose parent currency is unknown.
+ *
+ * @returns
+ * The token currency, or `undefined` when the parent currency is not found.
+ */
+export function convertApiToken(apiToken: ApiTokenData): TokenCurrency | undefined {
+  const {
+    standard,
+    id,
+    contractAddress,
+    name,
+    ticker,
+    units,
+    delisted = false,
+    ledgerSignature,
+  } = apiToken;
+
+  const parentCurrencyId = id.split("/")[0];
+  const parentCurrency = CRYPTO_CURRENCIES_REGISTRY[parentCurrencyId];
+
+  if (!parentCurrency) {
+    return undefined;
+  }
+
+  const tokenCurrency: TokenCurrency = {
+    type: "TokenCurrency",
+    id: id as TokenCurrency["id"],
+    contractAddress,
+    parentCurrencyId: parentCurrencyId as TokenCurrency["parentCurrencyId"],
+    tokenType: standard,
+    name,
+    ticker,
+    delisted,
+    disableCountervalue: !!parentCurrency.isTestnetFor || !!apiToken.disableCountervalue,
+    units: units.map(unit => ({
+      name: unit.name,
+      code: unit.code,
+      magnitude: unit.magnitude,
+    })),
+    ...(ledgerSignature ? { ledgerSignature } : {}),
+  };
+
+  return tokenCurrency;
+}

--- a/domain/api/currency-token/src/fixtures/index.ts
+++ b/domain/api/currency-token/src/fixtures/index.ts
@@ -1,0 +1,45 @@
+import type { TokenCurrency } from "@domain/entity-currency-token";
+import type { ApiTokenData } from "../converter";
+import type { ApiTokenResponse } from "../types";
+
+// Shared test fixtures. Not re-exported from the package barrel; imported only by `*.test.ts`.
+
+/** Canonical CAL `/v1/tokens` response entry (USDC on Ethereum). */
+export const mockApiTokenResponse: ApiTokenResponse = {
+  id: "ethereum/erc20/usd_coin",
+  contract_address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  name: "USD Coin",
+  ticker: "USDC",
+  units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
+  standard: "erc20",
+  decimals: 6,
+  delisted: false,
+  live_signature: "3045022100...",
+};
+
+/** The {@link TokenCurrency} that {@link mockApiTokenResponse} converts to. */
+export const mockTokenCurrency = {
+  type: "TokenCurrency",
+  id: "ethereum/erc20/usd_coin",
+  contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  parentCurrencyId: "ethereum",
+  tokenType: "erc20",
+  name: "USD Coin",
+  ticker: "USDC",
+  delisted: false,
+  disableCountervalue: false,
+  units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
+} as TokenCurrency;
+
+/** Builds an {@link ApiTokenData} converter input with ERC-20/USDC defaults; override per case. */
+export function buildApiTokenData(overrides: Partial<ApiTokenData> = {}): ApiTokenData {
+  return {
+    id: "ethereum/erc20/usdc",
+    contractAddress: "0xA0b86",
+    name: "USD Coin",
+    ticker: "USDC",
+    units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
+    standard: "erc20",
+    ...overrides,
+  };
+}

--- a/domain/api/currency-token/src/index.ts
+++ b/domain/api/currency-token/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./schema";
+export * from "./types";
+export * from "./converter";
+export * from "./api";
+export * from "./persistence";

--- a/domain/api/currency-token/src/internals/constants.ts
+++ b/domain/api/currency-token/src/internals/constants.ts
@@ -23,3 +23,6 @@ export const HEADER_X_LEDGER_NEXT = "x-ledger-next";
 
 /** Persisted-cache format version. Bump to invalidate older blobs (pinned via `z.literal`). */
 export const PERSISTENCE_VERSION = 2;
+
+/** Matches an RTK Query `getTokensSyncHash` cache key, capturing the currency id. */
+export const SYNC_HASH_QUERY_KEY = /getTokensSyncHash\("([^"]+)"\)/;

--- a/domain/api/currency-token/src/internals/constants.ts
+++ b/domain/api/currency-token/src/internals/constants.ts
@@ -1,0 +1,25 @@
+// Package-private: nothing under `internals/` is re-exported from the public barrel (`../index.ts`).
+
+/** RTK Query cache tags exposed by the CAL token api. */
+export const TOKEN_TAGS = ["Tokens"] as const;
+
+/** RTK Query reducer path for the CAL token API — stable; it keys the persisted cache. */
+export const CAL_REDUCER_PATH = "cryptoAssetsApi";
+
+/** Max retries for transient CAL request failures. */
+export const MAX_RETRIES = 3;
+
+/** Default page size for the paginated `getTokensData` query. */
+export const DEFAULT_PAGE_SIZE = 1000;
+
+/** Request header carrying the Ledger client version on every CAL request. */
+export const HEADER_X_LEDGER_CLIENT_VERSION = "X-Ledger-Client-Version";
+
+/** Response header holding the CAL commit hash, used for token-cache invalidation. */
+export const HEADER_X_LEDGER_COMMIT = "X-Ledger-Commit";
+
+/** Response header carrying the pagination cursor for the next page. */
+export const HEADER_X_LEDGER_NEXT = "x-ledger-next";
+
+/** Persisted-cache format version. Bump to invalidate older blobs (pinned via `z.literal`). */
+export const PERSISTENCE_VERSION = 2;

--- a/domain/api/currency-token/src/internals/errors.ts
+++ b/domain/api/currency-token/src/internals/errors.ts
@@ -1,0 +1,36 @@
+import type { FetchBaseQueryError } from "@reduxjs/toolkit/query/react";
+
+/** Shape of an error result returned from a `queryFn`. */
+type QueryFnError = { error: FetchBaseQueryError };
+
+/** The CAL request returned a non-OK HTTP status. */
+export function fetchCurrencyError(status: number, statusText: string): QueryFnError {
+  return {
+    error: { status, data: `Failed to fetch currency: ${statusText}` },
+  };
+}
+
+/** No currency matched the requested id (CAL returned an empty list). */
+export function currencyNotFoundError(currencyId: string): QueryFnError {
+  return {
+    error: { status: 404, data: `Currency not found: ${currencyId}` },
+  };
+}
+
+/** The CAL response was missing the `X-Ledger-Commit` header. */
+export function commitHeaderMissingError(): QueryFnError {
+  const message = "X-Ledger-Commit header not found in response";
+  return {
+    error: { status: "PARSING_ERROR", data: message, error: message, originalStatus: 200 },
+  };
+}
+
+/** A network or unknown failure while fetching the sync hash. */
+export function fetchError(error: unknown): QueryFnError {
+  return {
+    error: {
+      status: "FETCH_ERROR",
+      error: error instanceof Error ? error.message : "Unknown error",
+    },
+  };
+}

--- a/domain/api/currency-token/src/internals/index.ts
+++ b/domain/api/currency-token/src/internals/index.ts
@@ -1,0 +1,2 @@
+export * from "./constants";
+export * from "./utils";

--- a/domain/api/currency-token/src/internals/index.ts
+++ b/domain/api/currency-token/src/internals/index.ts
@@ -1,2 +1,3 @@
 export * from "./constants";
+export * from "./errors";
 export * from "./utils";

--- a/domain/api/currency-token/src/internals/restore.test.ts
+++ b/domain/api/currency-token/src/internals/restore.test.ts
@@ -1,5 +1,5 @@
 import { token } from "@domain/entity-currency-token";
-import type { PersistedTokenEntry } from "../persistence";
+import type { PersistedTokenEntry } from "../types";
 import {
   buildRestoreCacheEntries,
   groupTokensByCurrency,

--- a/domain/api/currency-token/src/internals/restore.test.ts
+++ b/domain/api/currency-token/src/internals/restore.test.ts
@@ -1,0 +1,135 @@
+import { token } from "@domain/entity-currency-token";
+import type { PersistedTokenEntry } from "../persistence";
+import {
+  buildRestoreCacheEntries,
+  groupTokensByCurrency,
+  resolveCurrenciesToEvict,
+} from "./restore";
+
+function entry(
+  id: string,
+  parentCurrencyId: string,
+  tokenIdentifier?: string,
+): PersistedTokenEntry {
+  return {
+    data: token({
+      type: "TokenCurrency",
+      id,
+      parentCurrencyId,
+      contractAddress: "0xabc",
+      tokenType: "erc20",
+      name: "Test",
+      ticker: "TEST",
+      units: [{ name: "Test", code: "TEST", magnitude: 0 }],
+    }),
+    timestamp: Date.now(),
+    ...(tokenIdentifier === undefined ? {} : { token_identifier: tokenIdentifier }),
+  };
+}
+
+describe("groupTokensByCurrency", () => {
+  it("groups entries by parentCurrencyId", () => {
+    const grouped = groupTokensByCurrency([
+      entry("ethereum/erc20/a", "ethereum"),
+      entry("ethereum/erc20/b", "ethereum"),
+      entry("polygon/erc20/c", "polygon"),
+    ]);
+
+    expect(grouped.get("ethereum")).toHaveLength(2);
+    expect(grouped.get("polygon")).toHaveLength(1);
+  });
+
+  it("returns an empty map for no tokens", () => {
+    expect(groupTokensByCurrency([]).size).toBe(0);
+  });
+});
+
+describe("buildRestoreCacheEntries", () => {
+  it("builds an id + address entry per token", () => {
+    const entries = buildRestoreCacheEntries([entry("ethereum/erc20/a", "ethereum")]);
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      endpointName: "findTokenById",
+      arg: { id: "ethereum/erc20/a" },
+    });
+    expect(entries[1]).toMatchObject({
+      endpointName: "findTokenByAddressInCurrency",
+      arg: { contract_address: "0xabc", network: "ethereum" },
+    });
+  });
+
+  it("adds an address-only entry when token_identifier is present", () => {
+    const entries = buildRestoreCacheEntries([entry("elrond/esdt/a", "elrond", "MYTOKEN-1")]);
+    const addressEntries = entries.filter(e => e.endpointName === "findTokenByAddressInCurrency");
+
+    expect(entries).toHaveLength(3);
+    expect(
+      addressEntries.some(
+        e => "token_identifier" in e.arg && e.arg.token_identifier === "MYTOKEN-1",
+      ),
+    ).toBe(true);
+    expect(addressEntries.some(e => !("token_identifier" in e.arg))).toBe(true);
+  });
+});
+
+describe("resolveCurrenciesToEvict", () => {
+  type Dispatch = Parameters<typeof resolveCurrenciesToEvict>[0];
+
+  function currencies(...ids: string[]): Map<string, PersistedTokenEntry[]> {
+    const map = new Map<string, PersistedTokenEntry[]>();
+    for (const id of ids) map.set(id, []);
+    return map;
+  }
+
+  it("does not evict currencies without a stored hash", async () => {
+    const dispatch = jest.fn();
+    const evict = await resolveCurrenciesToEvict(
+      dispatch as unknown as Dispatch,
+      currencies("ethereum"),
+      {},
+    );
+
+    expect(evict.size).toBe(0);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("does not evict when the current hash matches the stored one", async () => {
+    const dispatch = jest.fn().mockResolvedValue({ data: "hash1" });
+    const evict = await resolveCurrenciesToEvict(
+      dispatch as unknown as Dispatch,
+      currencies("ethereum"),
+      {
+        ethereum: "hash1",
+      },
+    );
+
+    expect(evict.has("ethereum")).toBe(false);
+  });
+
+  it("evicts when the current hash differs", async () => {
+    const dispatch = jest.fn().mockResolvedValue({ data: "hash2" });
+    const evict = await resolveCurrenciesToEvict(
+      dispatch as unknown as Dispatch,
+      currencies("ethereum"),
+      {
+        ethereum: "hash1",
+      },
+    );
+
+    expect(evict.has("ethereum")).toBe(true);
+  });
+
+  it("evicts when the hash fetch fails", async () => {
+    const dispatch = jest.fn().mockRejectedValue(new Error("network"));
+    const evict = await resolveCurrenciesToEvict(
+      dispatch as unknown as Dispatch,
+      currencies("ethereum"),
+      {
+        ethereum: "hash1",
+      },
+    );
+
+    expect(evict.has("ethereum")).toBe(true);
+  });
+});

--- a/domain/api/currency-token/src/internals/restore.ts
+++ b/domain/api/currency-token/src/internals/restore.ts
@@ -1,0 +1,94 @@
+import type { ThunkDispatch } from "@reduxjs/toolkit";
+import type { TokenCurrency } from "@domain/entity-currency-token";
+import { cryptoAssetsApi } from "../api";
+import type { PersistedTokenEntry } from "../persistence";
+
+// Package-private cache-restoration helpers for `restoreTokensToCache`. Imported directly by
+// `persistence.ts` (not via the internals barrel) so `api.ts` → internals never forms a cycle.
+
+/** Groups persisted token entries by their parent crypto-currency id. */
+export function groupTokensByCurrency(
+  tokens: PersistedTokenEntry[],
+): Map<string, PersistedTokenEntry[]> {
+  const byCurrency = new Map<string, PersistedTokenEntry[]>();
+  for (const entry of tokens) {
+    const currencyId = entry.data.parentCurrencyId;
+    const group = byCurrency.get(currencyId);
+    if (group) {
+      group.push(entry);
+    } else {
+      byCurrency.set(currencyId, [entry]);
+    }
+  }
+  return byCurrency;
+}
+
+/**
+ * For each currency that has a stored hash, fetches the current server hash and returns the set of
+ * currencies whose hash changed (or whose fetch failed) — those must not be restored from cache.
+ * Currencies without a stored hash are never evicted.
+ */
+export async function resolveCurrenciesToEvict(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  dispatch: ThunkDispatch<any, any, any>,
+  tokensByCurrency: Map<string, PersistedTokenEntry[]>,
+  hashes: Record<string, string>,
+): Promise<Set<string>> {
+  const toEvict = new Set<string>();
+  for (const currencyId of tokensByCurrency.keys()) {
+    const storedHash = hashes[currencyId];
+    if (!storedHash) continue;
+
+    try {
+      const { data: currentHash } = await dispatch(
+        cryptoAssetsApi.endpoints.getTokensSyncHash.initiate(currencyId, { forceRefetch: false }),
+      );
+      if (currentHash && currentHash !== storedHash) {
+        toEvict.add(currencyId);
+      }
+    } catch {
+      toEvict.add(currencyId);
+    }
+  }
+  return toEvict;
+}
+
+type RestoreCacheEntry =
+  | { endpointName: "findTokenById"; arg: { id: string }; value: TokenCurrency | undefined }
+  | {
+      endpointName: "findTokenByAddressInCurrency";
+      arg: { contract_address: string; network: string; token_identifier?: string };
+      value: TokenCurrency | undefined;
+    };
+
+/**
+ * Builds the RTK Query cache entries to upsert for the given persisted tokens: a `findTokenById`
+ * and a `findTokenByAddressInCurrency` entry per token, plus an address-only key when a
+ * `token_identifier` is present (so lookups without it still hit the cache).
+ */
+export function buildRestoreCacheEntries(tokens: PersistedTokenEntry[]): RestoreCacheEntry[] {
+  return tokens.flatMap(({ data: token, token_identifier }) => {
+    const entries: RestoreCacheEntry[] = [
+      { endpointName: "findTokenById", arg: { id: token.id }, value: token },
+      {
+        endpointName: "findTokenByAddressInCurrency",
+        arg: {
+          contract_address: token.contractAddress,
+          network: token.parentCurrencyId,
+          ...(token_identifier === undefined ? {} : { token_identifier }),
+        },
+        value: token,
+      },
+    ];
+
+    if (token_identifier !== undefined) {
+      entries.push({
+        endpointName: "findTokenByAddressInCurrency",
+        arg: { contract_address: token.contractAddress, network: token.parentCurrencyId },
+        value: token,
+      });
+    }
+
+    return entries;
+  });
+}

--- a/domain/api/currency-token/src/internals/restore.ts
+++ b/domain/api/currency-token/src/internals/restore.ts
@@ -1,7 +1,7 @@
 import type { ThunkDispatch } from "@reduxjs/toolkit";
 import type { TokenCurrency } from "@domain/entity-currency-token";
 import { cryptoAssetsApi } from "../api";
-import type { PersistedTokenEntry } from "../persistence";
+import type { PersistedTokenEntry } from "../types";
 
 // Package-private cache-restoration helpers for `restoreTokensToCache`. Imported directly by
 // `persistence.ts` (not via the internals barrel) so `api.ts` → internals never forms a cycle.

--- a/domain/api/currency-token/src/internals/utils.test.ts
+++ b/domain/api/currency-token/src/internals/utils.test.ts
@@ -1,5 +1,4 @@
 import type { FetchBaseQueryMeta } from "@reduxjs/toolkit/query/react";
-import type { TokenCurrency } from "@domain/entity-currency-token";
 
 jest.mock("../converter", () => ({
   convertApiToken: jest.fn(),
@@ -12,34 +11,10 @@ import {
   transformApiTokenToTokenCurrency,
   validateAndTransformSingleTokenResponse,
 } from "./utils";
-import { ApiTokenResponseSchema, type ApiTokenResponse } from "../schema";
+import { ApiTokenResponseSchema } from "../schema";
+import { mockApiTokenResponse, mockTokenCurrency } from "../fixtures";
 
 const mockConvert = convertApiToken as jest.MockedFunction<typeof convertApiToken>;
-
-const mockApiTokenResponse: ApiTokenResponse = {
-  id: "ethereum/erc20/usd_coin",
-  contract_address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-  name: "USD Coin",
-  ticker: "USDC",
-  units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
-  standard: "erc20",
-  decimals: 6,
-  delisted: false,
-  live_signature: "3045022100...",
-};
-
-const mockTokenCurrency = {
-  type: "TokenCurrency",
-  id: "ethereum/erc20/usd_coin",
-  contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-  parentCurrencyId: "ethereum",
-  tokenType: "erc20",
-  name: "USD Coin",
-  ticker: "USDC",
-  delisted: false,
-  disableCountervalue: false,
-  units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
-} as TokenCurrency;
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/domain/api/currency-token/src/internals/utils.test.ts
+++ b/domain/api/currency-token/src/internals/utils.test.ts
@@ -1,0 +1,144 @@
+import type { FetchBaseQueryMeta } from "@reduxjs/toolkit/query/react";
+import type { TokenCurrency } from "@domain/entity-currency-token";
+
+jest.mock("../converter", () => ({
+  convertApiToken: jest.fn(),
+}));
+
+import { convertApiToken } from "../converter";
+import {
+  TOKEN_OUTPUT_FIELDS,
+  transformTokensResponse,
+  transformApiTokenToTokenCurrency,
+  validateAndTransformSingleTokenResponse,
+} from "./utils";
+import { ApiTokenResponseSchema, type ApiTokenResponse } from "../schema";
+
+const mockConvert = convertApiToken as jest.MockedFunction<typeof convertApiToken>;
+
+const mockApiTokenResponse: ApiTokenResponse = {
+  id: "ethereum/erc20/usd_coin",
+  contract_address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  name: "USD Coin",
+  ticker: "USDC",
+  units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
+  standard: "erc20",
+  decimals: 6,
+  delisted: false,
+  live_signature: "3045022100...",
+};
+
+const mockTokenCurrency = {
+  type: "TokenCurrency",
+  id: "ethereum/erc20/usd_coin",
+  contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  parentCurrencyId: "ethereum",
+  tokenType: "erc20",
+  name: "USD Coin",
+  ticker: "USDC",
+  delisted: false,
+  disableCountervalue: false,
+  units: [{ code: "USDC", name: "USD Coin", magnitude: 6 }],
+} as TokenCurrency;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockConvert.mockReturnValue(mockTokenCurrency);
+});
+
+describe("TOKEN_OUTPUT_FIELDS", () => {
+  it("is derived from the response schema (no drift)", () => {
+    expect(TOKEN_OUTPUT_FIELDS).toEqual(Object.keys(ApiTokenResponseSchema.shape));
+  });
+
+  it("covers the fields the converter needs", () => {
+    expect(TOKEN_OUTPUT_FIELDS).toEqual(
+      expect.arrayContaining(["id", "contract_address", "units", "live_signature"]),
+    );
+  });
+});
+
+describe("transformTokensResponse", () => {
+  it("should transform an array of API tokens to a TokenCurrency array", () => {
+    const result = transformTokensResponse([mockApiTokenResponse]);
+    expect(result.tokens).toHaveLength(1);
+    expect(result.tokens[0]).toEqual(mockTokenCurrency);
+  });
+
+  it("should extract nextCursor from response headers", () => {
+    const meta = {
+      response: {
+        headers: {
+          get: (h: string) => (h === "x-ledger-next" ? "next-cursor" : null),
+        },
+      },
+    } as unknown as FetchBaseQueryMeta;
+    const result = transformTokensResponse([mockApiTokenResponse], meta);
+    expect(result.pagination.nextCursor).toBe("next-cursor");
+  });
+
+  it("should set nextCursor undefined when no meta is provided", () => {
+    expect(transformTokensResponse([mockApiTokenResponse]).pagination.nextCursor).toBeUndefined();
+  });
+
+  it("should filter out tokens that fail conversion", () => {
+    mockConvert
+      .mockReturnValueOnce(mockTokenCurrency)
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce(mockTokenCurrency);
+    const result = transformTokensResponse([
+      mockApiTokenResponse,
+      mockApiTokenResponse,
+      mockApiTokenResponse,
+    ]);
+    expect(result.tokens).toHaveLength(2);
+  });
+
+  it("should handle an empty token array", () => {
+    const result = transformTokensResponse([]);
+    expect(result.tokens).toHaveLength(0);
+    expect(result.pagination.nextCursor).toBeUndefined();
+  });
+});
+
+describe("transformApiTokenToTokenCurrency", () => {
+  it("should call convertApiToken with mapped parameters", () => {
+    transformApiTokenToTokenCurrency(mockApiTokenResponse);
+    expect(convertApiToken).toHaveBeenCalledWith({
+      id: mockApiTokenResponse.id,
+      contractAddress: mockApiTokenResponse.contract_address,
+      name: mockApiTokenResponse.name,
+      ticker: mockApiTokenResponse.ticker,
+      units: mockApiTokenResponse.units,
+      standard: mockApiTokenResponse.standard,
+      tokenIdentifier: mockApiTokenResponse.token_identifier,
+      delisted: mockApiTokenResponse.delisted,
+      ledgerSignature: mockApiTokenResponse.live_signature,
+    });
+  });
+
+  it("should return undefined when convertApiToken returns undefined", () => {
+    mockConvert.mockReturnValue(undefined);
+    expect(transformApiTokenToTokenCurrency(mockApiTokenResponse)).toBeUndefined();
+  });
+});
+
+describe("validateAndTransformSingleTokenResponse", () => {
+  it("should validate and transform a single token response", () => {
+    expect(validateAndTransformSingleTokenResponse([mockApiTokenResponse])).toEqual(
+      mockTokenCurrency,
+    );
+  });
+
+  it("should return undefined when the array is empty", () => {
+    expect(validateAndTransformSingleTokenResponse([])).toBeUndefined();
+  });
+
+  it("should throw when the response is not an array", () => {
+    expect(() => validateAndTransformSingleTokenResponse("not an array")).toThrow();
+  });
+
+  it("should throw when the token structure is invalid", () => {
+    expect(() => validateAndTransformSingleTokenResponse([{ invalid: "data" }])).toThrow();
+  });
+});

--- a/domain/api/currency-token/src/internals/utils.ts
+++ b/domain/api/currency-token/src/internals/utils.ts
@@ -1,8 +1,8 @@
 import type { FetchBaseQueryMeta } from "@reduxjs/toolkit/query/react";
 import type { TokenCurrency } from "@domain/entity-currency-token";
-import { ApiResponseSchema, ApiTokenResponseSchema, type ApiTokenResponse } from "../schema";
+import { ApiResponseSchema, ApiTokenResponseSchema } from "../schema";
 import { convertApiToken } from "../converter";
-import type { TokensDataWithPagination } from "../types";
+import type { ApiTokenResponse, TokensDataWithPagination } from "../types";
 import { HEADER_X_LEDGER_NEXT } from "./constants";
 
 /**

--- a/domain/api/currency-token/src/internals/utils.ts
+++ b/domain/api/currency-token/src/internals/utils.ts
@@ -1,0 +1,67 @@
+import type { FetchBaseQueryMeta } from "@reduxjs/toolkit/query/react";
+import type { TokenCurrency } from "@domain/entity-currency-token";
+import { ApiResponseSchema, ApiTokenResponseSchema, type ApiTokenResponse } from "../schema";
+import { convertApiToken } from "../converter";
+import type { TokensDataWithPagination } from "../types";
+import { HEADER_X_LEDGER_NEXT } from "./constants";
+
+/**
+ * Request field projection sent as the CAL `output` param. Derived from the response schema so the
+ * requested fields and the validated fields can never drift apart.
+ */
+export const TOKEN_OUTPUT_FIELDS = Object.keys(ApiTokenResponseSchema.shape);
+
+/** Maps a paginated CAL token response to {@link TokenCurrency} entities + the next-page cursor. */
+export function transformTokensResponse(
+  response: ApiTokenResponse[],
+  meta?: FetchBaseQueryMeta,
+): TokensDataWithPagination {
+  const nextCursor = meta?.response?.headers.get(HEADER_X_LEDGER_NEXT) || undefined;
+
+  return {
+    tokens: response.flatMap(token => {
+      const result = transformApiTokenToTokenCurrency(token);
+      return result ? [result] : [];
+    }),
+    pagination: { nextCursor },
+  };
+}
+
+/** Maps a single raw CAL token to a {@link TokenCurrency} (or `undefined` if unconvertible). */
+export function transformApiTokenToTokenCurrency(
+  token: ApiTokenResponse,
+): TokenCurrency | undefined {
+  return convertApiToken({
+    id: token.id,
+    contractAddress: token.contract_address,
+    name: token.name,
+    ticker: token.ticker,
+    units: token.units,
+    standard: token.standard,
+    tokenIdentifier: token.token_identifier,
+    delisted: token.delisted,
+    ledgerSignature: token.live_signature,
+  });
+}
+
+/** Validates a single-token CAL response (`[token]`) and converts the first entry. */
+export function validateAndTransformSingleTokenResponse(
+  response: unknown,
+): TokenCurrency | undefined {
+  const validatedResponse = ApiResponseSchema.parse(response);
+  const apiToken = validatedResponse[0];
+  if (!apiToken) {
+    return undefined;
+  }
+  return convertApiToken({
+    id: apiToken.id,
+    contractAddress: apiToken.contract_address,
+    name: apiToken.name,
+    ticker: apiToken.ticker,
+    units: apiToken.units,
+    standard: apiToken.standard,
+    tokenIdentifier: apiToken.token_identifier,
+    delisted: apiToken.delisted,
+    ledgerSignature: apiToken.live_signature,
+  });
+}

--- a/domain/api/currency-token/src/persistence.test.ts
+++ b/domain/api/currency-token/src/persistence.test.ts
@@ -1,0 +1,645 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { token, type TokenCurrency } from "@domain/entity-currency-token";
+import { cryptoAssetsApi, calApiExtra } from "./api";
+import { PERSISTENCE_VERSION } from "./internals";
+import {
+  extractTokensFromState,
+  extractHashesFromState,
+  extractPersistedCALFromState,
+  persistedCALContentEqual,
+  filterExpiredTokens,
+  restoreTokensToCache,
+  parsePersistedCAL,
+  type PersistedTokenEntry,
+  type PersistedCAL,
+  type WithCryptoAssetsApi,
+} from "./persistence";
+
+const mockToken: TokenCurrency = token({
+  type: "TokenCurrency",
+  id: "ethereum/erc20/usdt",
+  contractAddress: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+  parentCurrencyId: "ethereum",
+  tokenType: "erc20",
+  name: "Tether USD",
+  ticker: "USDT",
+  delisted: false,
+  disableCountervalue: false,
+  units: [{ name: "USDT", code: "USDT", magnitude: 6 }],
+});
+
+describe("Token Persistence", () => {
+  describe("parsePersistedCAL", () => {
+    it("parses a valid persisted blob and re-validates tokens", () => {
+      const blob = {
+        version: PERSISTENCE_VERSION,
+        tokens: [{ data: mockToken, timestamp: 1000 }],
+        hashes: { ethereum: "hash1" },
+      };
+
+      const parsed = parsePersistedCAL(blob);
+
+      expect(parsed).not.toBeNull();
+      expect(parsed?.tokens[0].data.id).toBe("ethereum/erc20/usdt");
+      expect(parsed?.hashes).toEqual({ ethereum: "hash1" });
+    });
+
+    it("survives a JSON serialization round-trip", () => {
+      const extracted = extractPersistedCALFromState({
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "fulfilled",
+              data: mockToken,
+              endpointName: "findTokenById",
+              fulfilledTimeStamp: Date.now(),
+            },
+          },
+        },
+      } as unknown as WithCryptoAssetsApi);
+
+      const parsed = parsePersistedCAL(JSON.parse(JSON.stringify(extracted)));
+
+      expect(parsed?.tokens[0].data).toEqual(mockToken);
+    });
+
+    it("returns null for an older format version", () => {
+      expect(parsePersistedCAL({ version: PERSISTENCE_VERSION - 1, tokens: [] })).toBeNull();
+    });
+
+    it("returns null for a malformed token", () => {
+      expect(
+        parsePersistedCAL({
+          version: PERSISTENCE_VERSION,
+          tokens: [{ data: { id: "x" }, timestamp: 1 }],
+        }),
+      ).toBeNull();
+    });
+
+    it("returns null for non-object input", () => {
+      expect(parsePersistedCAL("nope")).toBeNull();
+      expect(parsePersistedCAL(null)).toBeNull();
+    });
+  });
+
+  describe("extractTokensFromState", () => {
+    it("should extract fulfilled token queries from RTK state", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "fulfilled",
+              data: mockToken,
+              endpointName: "findTokenById",
+              fulfilledTimeStamp: Date.now(),
+            },
+          },
+        },
+      } as unknown as WithCryptoAssetsApi;
+
+      const tokens = extractTokensFromState(mockState);
+
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0].data.id).toBe("ethereum/erc20/usdt");
+      expect(tokens[0].data.contractAddress).toBe("0xdac17f958d2ee523a2206206994597c13d831ec7");
+      expect(tokens[0].data.parentCurrencyId).toBe("ethereum");
+      expect(tokens[0].timestamp).toBeDefined();
+    });
+
+    it("should ignore pending queries", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "pending",
+              data: undefined,
+              endpointName: "findTokenById",
+            },
+          },
+        },
+      } as unknown as WithCryptoAssetsApi;
+
+      expect(extractTokensFromState(mockState)).toHaveLength(0);
+    });
+
+    it("should deduplicate tokens by ID", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "fulfilled",
+              data: mockToken,
+              endpointName: "findTokenById",
+              fulfilledTimeStamp: Date.now(),
+            },
+            'findTokenByAddressInCurrency({"contract_address":"0xdac17f958d2ee523a2206206994597c13d831ec7","network":"ethereum"})':
+              {
+                status: "fulfilled",
+                data: mockToken,
+                endpointName: "findTokenByAddressInCurrency",
+                fulfilledTimeStamp: Date.now(),
+              },
+          },
+        },
+      } as unknown as WithCryptoAssetsApi;
+
+      expect(extractTokensFromState(mockState)).toHaveLength(1);
+    });
+
+    it("should return empty array if no queries", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: { queries: {} },
+      } as unknown as WithCryptoAssetsApi;
+
+      expect(extractTokensFromState(mockState)).toEqual([]);
+    });
+
+    it("should return empty array if no RTK Query state", () => {
+      expect(extractTokensFromState({} as unknown as WithCryptoAssetsApi)).toEqual([]);
+    });
+
+    it("should return empty array if queries is undefined", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {},
+      } as unknown as WithCryptoAssetsApi;
+
+      expect(extractTokensFromState(mockState)).toEqual([]);
+    });
+
+    it("should extract token_identifier from findTokenByAddressInCurrency originalArgs", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenByAddressInCurrency({"contract_address":"0xdac17f958d2ee523a2206206994597c13d831ec7","network":"ethereum","token_identifier":"MYTOKEN-abc123"})':
+              {
+                status: "fulfilled",
+                data: mockToken,
+                endpointName: "findTokenByAddressInCurrency",
+                originalArgs: {
+                  contract_address: mockToken.contractAddress,
+                  network: mockToken.parentCurrencyId,
+                  token_identifier: "MYTOKEN-abc123",
+                },
+                fulfilledTimeStamp: Date.now(),
+              },
+          },
+        },
+      } as unknown as WithCryptoAssetsApi;
+
+      const tokens = extractTokensFromState(mockState);
+
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0].token_identifier).toBe("MYTOKEN-abc123");
+    });
+
+    it("should not set token_identifier for findTokenById queries", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "fulfilled",
+              data: mockToken,
+              endpointName: "findTokenById",
+              originalArgs: { id: mockToken.id },
+              fulfilledTimeStamp: Date.now(),
+            },
+          },
+        },
+      } as unknown as WithCryptoAssetsApi;
+
+      const tokens = extractTokensFromState(mockState);
+
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0].token_identifier).toBeUndefined();
+    });
+  });
+
+  describe("filterExpiredTokens", () => {
+    const baseData = mockToken;
+
+    it("should keep tokens within TTL", () => {
+      const now = Date.now();
+      const ttl = 24 * 60 * 60 * 1000;
+      const tokens: PersistedTokenEntry[] = [
+        { data: baseData, timestamp: now - 1000 },
+        { data: baseData, timestamp: now - 12 * 60 * 60 * 1000 },
+      ];
+
+      expect(filterExpiredTokens(tokens, ttl)).toHaveLength(2);
+    });
+
+    it("should filter out expired tokens", () => {
+      const now = Date.now();
+      const ttl = 24 * 60 * 60 * 1000;
+      const tokens: PersistedTokenEntry[] = [
+        { data: baseData, timestamp: now - 1000 },
+        { data: baseData, timestamp: now - 25 * 60 * 60 * 1000 },
+      ];
+
+      expect(filterExpiredTokens(tokens, ttl)).toHaveLength(1);
+    });
+  });
+
+  describe("restoreTokensToCache", () => {
+    const ttl = 24 * 60 * 60 * 1000;
+
+    it("should restore valid tokens to RTK Query cache", async () => {
+      const mockDispatch = jest.fn();
+      const persistedData: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [{ data: mockToken, timestamp: Date.now() }],
+      };
+
+      await restoreTokensToCache(mockDispatch, persistedData, ttl);
+
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should skip expired tokens", async () => {
+      const mockDispatch = jest.fn();
+      const persistedData: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [{ data: mockToken, timestamp: Date.now() - 25 * 60 * 60 * 1000 }],
+      };
+
+      await restoreTokensToCache(mockDispatch, persistedData, ttl);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it("should restore tokens even when the parent currency is unknown (guard moved to the converter)", async () => {
+      const mockDispatch = jest.fn();
+      const orphanToken = token({
+        type: "TokenCurrency",
+        id: "ethereum/erc20/orphan",
+        contractAddress: "0xabc",
+        parentCurrencyId: "unknown_currency",
+        tokenType: "erc20",
+        name: "Orphan",
+        ticker: "ORPH",
+        units: [{ name: "Orphan", code: "ORPH", magnitude: 18 }],
+      });
+      const persistedData: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [{ data: orphanToken, timestamp: Date.now() }],
+      };
+
+      await restoreTokensToCache(mockDispatch, persistedData, ttl);
+
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should restore tokens when hash matches", async () => {
+      const storedHash = "hash123";
+      const mockDispatch = jest.fn(async action => {
+        if (typeof action === "function") {
+          return { data: storedHash, error: undefined };
+        }
+        return action;
+      });
+
+      const persistedData: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [{ data: mockToken, timestamp: Date.now() }],
+        hashes: { ethereum: storedHash },
+      };
+
+      await restoreTokensToCache(mockDispatch, persistedData, ttl);
+
+      const invalidateCalls = mockDispatch.mock.calls.filter(call =>
+        String(call[0]).includes("invalidateTags"),
+      );
+      expect(invalidateCalls).toHaveLength(0);
+      expect(mockDispatch).toHaveBeenCalled();
+    });
+
+    it("should skip restore when hash changed", async () => {
+      const upsertActions: unknown[] = [];
+      const mockDispatch = jest.fn(async action => {
+        if (typeof action === "function") {
+          return { data: "hash456", error: undefined };
+        }
+        const actionType = (action as { type?: string })?.type || "";
+        if (actionType.includes("upsert")) upsertActions.push(action);
+        return action;
+      });
+
+      const persistedData: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [{ data: mockToken, timestamp: Date.now() }],
+        hashes: { ethereum: "hash123" },
+      };
+
+      await restoreTokensToCache(mockDispatch, persistedData, ttl);
+
+      expect(upsertActions).toHaveLength(0);
+    });
+
+    it("should skip restore when hash fetch fails", async () => {
+      const upsertActions: unknown[] = [];
+      const mockDispatch = jest.fn(async action => {
+        if (typeof action === "function") {
+          throw new Error("Network error");
+        }
+        const actionType = (action as { type?: string })?.type || "";
+        if (actionType.includes("upsert")) upsertActions.push(action);
+        return action;
+      });
+
+      const persistedData: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [{ data: mockToken, timestamp: Date.now() }],
+        hashes: { ethereum: "hash123" },
+      };
+
+      await restoreTokensToCache(mockDispatch, persistedData, ttl);
+
+      expect(upsertActions).toHaveLength(0);
+    });
+
+    it("should restore tokens without hash (backward compatibility)", async () => {
+      const mockDispatch = jest.fn();
+      const persistedData: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [{ data: mockToken, timestamp: Date.now() }],
+      };
+
+      await restoreTokensToCache(mockDispatch, persistedData, ttl);
+
+      const invalidateCalls = mockDispatch.mock.calls.filter(call =>
+        String(call[0]).includes("invalidateTags"),
+      );
+      expect(invalidateCalls).toHaveLength(0);
+      expect(mockDispatch).toHaveBeenCalled();
+    });
+  });
+
+  describe("extractHashesFromState", () => {
+    it("should extract hashes from getTokensSyncHash queries", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'getTokensSyncHash("ethereum")': {
+              status: "fulfilled",
+              data: "hash123",
+              endpointName: "getTokensSyncHash",
+            },
+            'getTokensSyncHash("polygon")': {
+              status: "fulfilled",
+              data: "hash456",
+              endpointName: "getTokensSyncHash",
+            },
+          },
+        },
+      } as unknown as WithCryptoAssetsApi;
+
+      expect(extractHashesFromState(mockState)).toEqual({
+        ethereum: "hash123",
+        polygon: "hash456",
+      });
+    });
+
+    it("should return empty object when no hash queries exist", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "fulfilled",
+              data: mockToken,
+              endpointName: "findTokenById",
+            },
+          },
+        },
+      } as unknown as WithCryptoAssetsApi;
+
+      expect(extractHashesFromState(mockState)).toEqual({});
+    });
+
+    it("should return empty object if no RTK Query state", () => {
+      expect(extractHashesFromState({} as unknown as WithCryptoAssetsApi)).toEqual({});
+    });
+  });
+
+  describe("extractPersistedCALFromState", () => {
+    it("should extract complete PersistedCAL with tokens and hashes", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "fulfilled",
+              data: mockToken,
+              endpointName: "findTokenById",
+              fulfilledTimeStamp: Date.now(),
+            },
+            'getTokensSyncHash("ethereum")': {
+              status: "fulfilled",
+              data: "hash123",
+              endpointName: "getTokensSyncHash",
+            },
+          },
+        },
+      } as unknown as WithCryptoAssetsApi;
+
+      const persistedData = extractPersistedCALFromState(mockState);
+
+      expect(persistedData.version).toBe(PERSISTENCE_VERSION);
+      expect(persistedData.tokens).toHaveLength(1);
+      expect(persistedData.tokens[0].data.id).toBe("ethereum/erc20/usdt");
+      expect(persistedData.hashes).toEqual({ ethereum: "hash123" });
+    });
+
+    it("should extract PersistedCAL without hashes if none exist", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "fulfilled",
+              data: mockToken,
+              endpointName: "findTokenById",
+              fulfilledTimeStamp: Date.now(),
+            },
+          },
+        },
+      } as unknown as WithCryptoAssetsApi;
+
+      const persistedData = extractPersistedCALFromState(mockState);
+
+      expect(persistedData.version).toBe(PERSISTENCE_VERSION);
+      expect(persistedData.tokens).toHaveLength(1);
+      expect(persistedData.hashes).toBeUndefined();
+    });
+  });
+
+  describe("integration: token_identifier round-trip", () => {
+    const ttl = 24 * 60 * 60 * 1000;
+
+    function makeStore() {
+      return configureStore({
+        reducer: { [cryptoAssetsApi.reducerPath]: cryptoAssetsApi.reducer },
+        middleware: getDefaultMiddleware =>
+          getDefaultMiddleware({
+            serializableCheck: false,
+            thunk: {
+              extraArgument: calApiExtra({
+                calServiceUrl: "https://cal.test",
+                ledgerClientVersion: "1.0.0",
+              }),
+            },
+          }).concat(cryptoAssetsApi.middleware),
+      });
+    }
+
+    it("should restore cache entry with token_identifier after extract → restore cycle", async () => {
+      const sourceState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenByAddressInCurrency({"contract_address":"0xdac17f958d2ee523a2206206994597c13d831ec7","network":"ethereum","token_identifier":"MYTOKEN-abc123"})':
+              {
+                status: "fulfilled",
+                data: mockToken,
+                endpointName: "findTokenByAddressInCurrency",
+                originalArgs: {
+                  contract_address: mockToken.contractAddress,
+                  network: mockToken.parentCurrencyId,
+                  token_identifier: "MYTOKEN-abc123",
+                },
+                fulfilledTimeStamp: Date.now(),
+              },
+          },
+        },
+      } as unknown as WithCryptoAssetsApi;
+
+      const persisted = extractPersistedCALFromState(sourceState);
+      expect(persisted.tokens[0].token_identifier).toBe("MYTOKEN-abc123");
+
+      const newStore = makeStore();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await restoreTokensToCache(newStore.dispatch as any, persisted, ttl);
+
+      const newQueries = newStore.getState()[cryptoAssetsApi.reducerPath].queries;
+      const restoredEntry = Object.values(newQueries).find(
+        entry =>
+          entry?.endpointName === "findTokenByAddressInCurrency" &&
+          (entry.originalArgs as { token_identifier?: string } | undefined)?.token_identifier ===
+            "MYTOKEN-abc123",
+      );
+      expect(restoredEntry).toBeDefined();
+      expect(restoredEntry?.data).toMatchObject({ id: mockToken.id });
+    });
+
+    it("should restore cache entry without token_identifier unchanged after round-trip", async () => {
+      const sourceState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "fulfilled",
+              data: mockToken,
+              endpointName: "findTokenById",
+              originalArgs: { id: mockToken.id },
+              fulfilledTimeStamp: Date.now(),
+            },
+          },
+        },
+      } as unknown as WithCryptoAssetsApi;
+
+      const persisted = extractPersistedCALFromState(sourceState);
+      expect(persisted.tokens[0].token_identifier).toBeUndefined();
+
+      const newStore = makeStore();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await restoreTokensToCache(newStore.dispatch as any, persisted, ttl);
+
+      const newQueries = newStore.getState()[cryptoAssetsApi.reducerPath].queries;
+      const addressEntry = Object.values(newQueries).find(
+        entry => entry?.endpointName === "findTokenByAddressInCurrency",
+      );
+      expect(addressEntry).toBeDefined();
+      expect(
+        (addressEntry?.originalArgs as { token_identifier?: string } | undefined)?.token_identifier,
+      ).toBeUndefined();
+    });
+  });
+
+  describe("persistedCALContentEqual", () => {
+    const baseTokenData = mockToken;
+
+    it("should return true when both are null", () => {
+      expect(persistedCALContentEqual(null, null)).toBe(true);
+    });
+
+    it("should return false when one is null and the other is not", () => {
+      const cal: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [{ data: baseTokenData, timestamp: 1000 }],
+      };
+      expect(persistedCALContentEqual(null, cal)).toBe(false);
+      expect(persistedCALContentEqual(cal, null)).toBe(false);
+    });
+
+    it("should return true for same content with different timestamps", () => {
+      const a: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [{ data: baseTokenData, timestamp: 1000 }],
+        hashes: { ethereum: "hash1" },
+      };
+      const b: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [{ data: baseTokenData, timestamp: 2000 }],
+        hashes: { ethereum: "hash1" },
+      };
+      expect(persistedCALContentEqual(a, b)).toBe(true);
+    });
+
+    it("should return false when hashes differ", () => {
+      const a: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [{ data: baseTokenData, timestamp: 1000 }],
+        hashes: { ethereum: "hash1" },
+      };
+      const b: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [{ data: baseTokenData, timestamp: 1000 }],
+        hashes: { ethereum: "hash2" },
+      };
+      expect(persistedCALContentEqual(a, b)).toBe(false);
+    });
+
+    it("should return false when token set differs", () => {
+      const otherToken = token({
+        type: "TokenCurrency",
+        id: "ethereum/erc20/usdc",
+        contractAddress: "0xa0b8",
+        parentCurrencyId: "ethereum",
+        tokenType: "erc20",
+        name: "USD Coin",
+        ticker: "USDC",
+        units: [{ name: "USD Coin", code: "USDC", magnitude: 6 }],
+      });
+      const a: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [{ data: baseTokenData, timestamp: 1000 }],
+      };
+      const b: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [
+          { data: baseTokenData, timestamp: 1000 },
+          { data: otherToken, timestamp: 1000 },
+        ],
+      };
+      expect(persistedCALContentEqual(a, b)).toBe(false);
+    });
+
+    it("should return false when token data differs", () => {
+      const changedToken = token({ ...mockToken, ticker: "USDC" });
+      const a: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [{ data: baseTokenData, timestamp: 1000 }],
+      };
+      const b: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [{ data: changedToken, timestamp: 1000 }],
+      };
+      expect(persistedCALContentEqual(a, b)).toBe(false);
+    });
+  });
+});

--- a/domain/api/currency-token/src/persistence.test.ts
+++ b/domain/api/currency-token/src/persistence.test.ts
@@ -10,10 +10,9 @@ import {
   filterExpiredTokens,
   restoreTokensToCache,
   parsePersistedCAL,
-  type PersistedTokenEntry,
-  type PersistedCAL,
   type WithCryptoAssetsApi,
 } from "./persistence";
+import { type PersistedCAL, type PersistedTokenEntry } from "./types";
 
 const mockToken: TokenCurrency = token({
   type: "TokenCurrency",

--- a/domain/api/currency-token/src/persistence.ts
+++ b/domain/api/currency-token/src/persistence.ts
@@ -1,0 +1,278 @@
+import { z } from "zod";
+import isEqual from "lodash/isEqual";
+import { TokenCurrencySchema, type TokenCurrency } from "@domain/entity-currency-token";
+import type { ThunkDispatch } from "@reduxjs/toolkit";
+import { cryptoAssetsApi } from "./api";
+import { PERSISTENCE_VERSION } from "./internals";
+import type { TokenByAddressInCurrencyParams } from "./types";
+
+/** Schema for a persisted token entry: a {@link TokenCurrency} plus cache-restoration metadata. */
+export const PersistedTokenEntrySchema = z.object({
+  /** Serializable token data (post-LIVE-32268 `TokenCurrency` is already serializable). */
+  data: TokenCurrencySchema,
+  /** When this token was fetched (Unix timestamp in ms). */
+  timestamp: z.number(),
+  /**
+   * The `token_identifier` used in the `findTokenByAddressInCurrency` query, if any.
+   * Needed to reconstruct the correct RTK Query cache key on hydration for chains where
+   * `contract_address` alone is not unique (e.g. MultiversX, Algorand, Cardano).
+   */
+  token_identifier: z.string().optional(),
+});
+
+export type PersistedTokenEntry = z.infer<typeof PersistedTokenEntrySchema>;
+
+/** Schema for the root persisted CAL blob, with a version pin and an optional hash map. */
+export const PersistedCALSchema = z.object({
+  /** The persistence version of the CAL blob. Used to determine compatibility with the current schema. */
+  version: z.literal(PERSISTENCE_VERSION),
+  /** The persisted token entries. */
+  tokens: z.array(PersistedTokenEntrySchema),
+  /** Mapping of currencyId to its `X-Ledger-Commit` hash. */
+  hashes: z.record(z.string(), z.string()).optional(),
+});
+
+export type PersistedCAL = z.infer<typeof PersistedCALSchema>;
+
+/**
+ * Validates an untrusted persisted blob (e.g. read from localStorage) against
+ * {@link PersistedCALSchema}. Returns `null` when the blob is missing, corrupt, or from an
+ * older format version.
+ */
+export function parsePersistedCAL(raw: unknown): PersistedCAL | null {
+  const result = PersistedCALSchema.safeParse(raw);
+  return result.success ? result.data : null;
+}
+
+/** Redux state that includes the {@link cryptoAssetsApi} reducer. */
+export interface WithCryptoAssetsApi {
+  [cryptoAssetsApi.reducerPath]: ReturnType<typeof cryptoAssetsApi.reducer>;
+}
+
+/**
+ * Extracts all cached tokens from RTK Query state. Only fulfilled `findTokenById` and
+ * `findTokenByAddressInCurrency` queries are considered, deduplicated by token id.
+ */
+export function extractTokensFromState(state: WithCryptoAssetsApi): PersistedTokenEntry[] {
+  const rtkState = state[cryptoAssetsApi.reducerPath];
+
+  if (!rtkState || !rtkState.queries) {
+    return [];
+  }
+
+  const tokens: PersistedTokenEntry[] = [];
+  const seenIds = new Set<string>();
+
+  for (const query of Object.values(rtkState.queries)) {
+    if (
+      query &&
+      query.status === "fulfilled" &&
+      query.data &&
+      (query.endpointName === "findTokenById" ||
+        query.endpointName === "findTokenByAddressInCurrency")
+    ) {
+      const token = query.data as TokenCurrency;
+      if (!token?.id) continue;
+
+      const tokenIdentifier =
+        query.endpointName === "findTokenByAddressInCurrency"
+          ? (query.originalArgs as TokenByAddressInCurrencyParams | undefined)?.token_identifier
+          : undefined;
+
+      if (seenIds.has(token.id)) continue;
+      seenIds.add(token.id);
+
+      tokens.push({
+        data: token,
+        timestamp: query.fulfilledTimeStamp || Date.now(),
+        token_identifier: tokenIdentifier,
+      });
+    }
+  }
+
+  return tokens;
+}
+
+/** Extracts the `currencyId → hash` map from fulfilled `getTokensSyncHash` queries. */
+export function extractHashesFromState(state: WithCryptoAssetsApi): Record<string, string> {
+  const rtkState = state[cryptoAssetsApi.reducerPath];
+
+  if (!rtkState || !rtkState.queries) {
+    return {};
+  }
+
+  const hashes: Record<string, string> = {};
+
+  for (const [queryKey, query] of Object.entries(rtkState.queries)) {
+    if (
+      query &&
+      query.status === "fulfilled" &&
+      query.endpointName === "getTokensSyncHash" &&
+      query.data &&
+      typeof query.data === "string"
+    ) {
+      // Query key format: 'getTokensSyncHash("ethereum")'
+      const match = queryKey.match(/getTokensSyncHash\("([^"]+)"\)/);
+      if (match && match[1]) {
+        hashes[match[1]] = query.data;
+      }
+    }
+  }
+
+  return hashes;
+}
+
+/** Extracts a complete {@link PersistedCAL} (tokens + hashes) from RTK Query state. */
+export function extractPersistedCALFromState(state: WithCryptoAssetsApi): PersistedCAL {
+  const tokens = extractTokensFromState(state);
+  const hashes = extractHashesFromState(state);
+
+  return {
+    version: PERSISTENCE_VERSION,
+    tokens,
+    ...(Object.keys(hashes).length > 0 && { hashes }),
+  };
+}
+
+/**
+ * Compares two {@link PersistedCAL} values by content (version, hashes, token data), ignoring
+ * token timestamps so refetches with identical cache content are considered equal. Returns true
+ * only when both are null or both are content-equal.
+ */
+export function persistedCALContentEqual(a: PersistedCAL | null, b: PersistedCAL | null): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (a.version !== b.version) return false;
+  if (!isEqual(a.hashes, b.hashes)) return false;
+  if (a.tokens.length !== b.tokens.length) return false;
+  const tokensByIdA = new Map(a.tokens.map(t => [t.data.id, t.data]));
+  const tokensByIdB = new Map(b.tokens.map(t => [t.data.id, t.data]));
+  for (const [id, dataA] of tokensByIdA) {
+    const dataB = tokensByIdB.get(id);
+    if (!dataB || !isEqual(dataA, dataB)) return false;
+  }
+  return true;
+}
+
+/** Filters out persisted tokens older than `ttl` (ms). */
+export function filterExpiredTokens(
+  tokens: PersistedTokenEntry[],
+  ttl: number,
+): PersistedTokenEntry[] {
+  const now = Date.now();
+  return tokens.filter(token => now - token.timestamp < ttl);
+}
+
+/**
+ * Restores persisted tokens into the RTK Query cache. For a currency with a stored hash, validates
+ * it against the current server hash and skips restoring that currency when the hash changed or the
+ * hash fetch failed. Currencies with no stored hash are restored unconditionally (backward-compatible
+ * with pre-hash persisted blobs).
+ */
+export async function restoreTokensToCache(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  dispatch: ThunkDispatch<any, any, any>,
+  persistedData: PersistedCAL,
+  ttl: number,
+): Promise<void> {
+  const validTokens = filterExpiredTokens(persistedData.tokens, ttl);
+  if (validTokens.length === 0) {
+    return;
+  }
+
+  const tokensByCurrency = new Map<string, PersistedTokenEntry[]>();
+  for (const entry of validTokens) {
+    const currencyId = entry.data.parentCurrencyId;
+    if (!tokensByCurrency.has(currencyId)) {
+      tokensByCurrency.set(currencyId, []);
+    }
+    tokensByCurrency.get(currencyId)!.push(entry);
+  }
+
+  const currencyIdsToEvict = new Set<string>();
+  const hashes = persistedData.hashes || {};
+
+  for (const currencyId of tokensByCurrency.keys()) {
+    const storedHash = hashes[currencyId];
+    if (!storedHash) continue;
+
+    try {
+      const currentHashResult = await dispatch(
+        cryptoAssetsApi.endpoints.getTokensSyncHash.initiate(currencyId, {
+          forceRefetch: false,
+        }),
+      );
+      const currentHash = currentHashResult.data;
+
+      if (currentHash && currentHash !== storedHash) {
+        currencyIdsToEvict.add(currencyId);
+      }
+    } catch {
+      currencyIdsToEvict.add(currencyId);
+    }
+  }
+
+  const tokensToRestore = validTokens.filter(
+    entry => !currencyIdsToEvict.has(entry.data.parentCurrencyId),
+  );
+
+  if (tokensToRestore.length === 0) {
+    return;
+  }
+
+  const entries: Array<
+    | {
+        endpointName: "findTokenById";
+        arg: { id: string };
+        value: TokenCurrency | undefined;
+      }
+    | {
+        endpointName: "findTokenByAddressInCurrency";
+        arg: {
+          contract_address: string;
+          network: string;
+          token_identifier?: string;
+        };
+        value: TokenCurrency | undefined;
+      }
+  > = [];
+
+  for (const entry of tokensToRestore) {
+    const token = entry.data;
+
+    entries.push({
+      endpointName: "findTokenById",
+      arg: { id: token.id },
+      value: token,
+    });
+
+    entries.push({
+      endpointName: "findTokenByAddressInCurrency",
+      arg: {
+        contract_address: token.contractAddress,
+        network: token.parentCurrencyId,
+        ...(entry.token_identifier === undefined
+          ? {}
+          : { token_identifier: entry.token_identifier }),
+      },
+      value: token,
+    });
+
+    // Also restore the address-only key so lookups without token_identifier hit the cache.
+    // Collision on chains where address is not unique is a coin-level concern.
+    if (entry.token_identifier !== undefined) {
+      entries.push({
+        endpointName: "findTokenByAddressInCurrency",
+        arg: {
+          contract_address: token.contractAddress,
+          network: token.parentCurrencyId,
+        },
+        value: token,
+      });
+    }
+  }
+
+  if (entries.length > 0) {
+    dispatch(cryptoAssetsApi.util.upsertQueryEntries(entries));
+  }
+}

--- a/domain/api/currency-token/src/persistence.ts
+++ b/domain/api/currency-token/src/persistence.ts
@@ -4,7 +4,15 @@ import { TokenCurrencySchema, type TokenCurrency } from "@domain/entity-currency
 import type { ThunkDispatch } from "@reduxjs/toolkit";
 import { cryptoAssetsApi } from "./api";
 import { PERSISTENCE_VERSION } from "./internals";
+import {
+  buildRestoreCacheEntries,
+  groupTokensByCurrency,
+  resolveCurrenciesToEvict,
+} from "./internals/restore";
 import type { TokenByAddressInCurrencyParams } from "./types";
+
+/** Matches an RTK Query `getTokensSyncHash` cache key, capturing the currency id. */
+const SYNC_HASH_QUERY_KEY = /getTokensSyncHash\("([^"]+)"\)/;
 
 /** Schema for a persisted token entry: a {@link TokenCurrency} plus cache-restoration metadata. */
 export const PersistedTokenEntrySchema = z.object({
@@ -56,7 +64,7 @@ export interface WithCryptoAssetsApi {
 export function extractTokensFromState(state: WithCryptoAssetsApi): PersistedTokenEntry[] {
   const rtkState = state[cryptoAssetsApi.reducerPath];
 
-  if (!rtkState || !rtkState.queries) {
+  if (!rtkState?.queries) {
     return [];
   }
 
@@ -65,8 +73,7 @@ export function extractTokensFromState(state: WithCryptoAssetsApi): PersistedTok
 
   for (const query of Object.values(rtkState.queries)) {
     if (
-      query &&
-      query.status === "fulfilled" &&
+      query?.status === "fulfilled" &&
       query.data &&
       (query.endpointName === "findTokenById" ||
         query.endpointName === "findTokenByAddressInCurrency")
@@ -97,7 +104,7 @@ export function extractTokensFromState(state: WithCryptoAssetsApi): PersistedTok
 export function extractHashesFromState(state: WithCryptoAssetsApi): Record<string, string> {
   const rtkState = state[cryptoAssetsApi.reducerPath];
 
-  if (!rtkState || !rtkState.queries) {
+  if (!rtkState?.queries) {
     return {};
   }
 
@@ -105,15 +112,14 @@ export function extractHashesFromState(state: WithCryptoAssetsApi): Record<strin
 
   for (const [queryKey, query] of Object.entries(rtkState.queries)) {
     if (
-      query &&
-      query.status === "fulfilled" &&
+      query?.status === "fulfilled" &&
       query.endpointName === "getTokensSyncHash" &&
       query.data &&
       typeof query.data === "string"
     ) {
       // Query key format: 'getTokensSyncHash("ethereum")'
-      const match = queryKey.match(/getTokensSyncHash\("([^"]+)"\)/);
-      if (match && match[1]) {
+      const match = SYNC_HASH_QUERY_KEY.exec(queryKey);
+      if (match?.[1]) {
         hashes[match[1]] = query.data;
       }
     }
@@ -180,98 +186,21 @@ export async function restoreTokensToCache(
     return;
   }
 
-  const tokensByCurrency = new Map<string, PersistedTokenEntry[]>();
-  for (const entry of validTokens) {
-    const currencyId = entry.data.parentCurrencyId;
-    if (!tokensByCurrency.has(currencyId)) {
-      tokensByCurrency.set(currencyId, []);
-    }
-    tokensByCurrency.get(currencyId)!.push(entry);
-  }
-
-  const currencyIdsToEvict = new Set<string>();
-  const hashes = persistedData.hashes || {};
-
-  for (const currencyId of tokensByCurrency.keys()) {
-    const storedHash = hashes[currencyId];
-    if (!storedHash) continue;
-
-    try {
-      const currentHashResult = await dispatch(
-        cryptoAssetsApi.endpoints.getTokensSyncHash.initiate(currencyId, {
-          forceRefetch: false,
-        }),
-      );
-      const currentHash = currentHashResult.data;
-
-      if (currentHash && currentHash !== storedHash) {
-        currencyIdsToEvict.add(currencyId);
-      }
-    } catch {
-      currencyIdsToEvict.add(currencyId);
-    }
-  }
+  const tokensByCurrency = groupTokensByCurrency(validTokens);
+  const currencyIdsToEvict = await resolveCurrenciesToEvict(
+    dispatch,
+    tokensByCurrency,
+    persistedData.hashes ?? {},
+  );
 
   const tokensToRestore = validTokens.filter(
     entry => !currencyIdsToEvict.has(entry.data.parentCurrencyId),
   );
-
   if (tokensToRestore.length === 0) {
     return;
   }
 
-  const entries: Array<
-    | {
-        endpointName: "findTokenById";
-        arg: { id: string };
-        value: TokenCurrency | undefined;
-      }
-    | {
-        endpointName: "findTokenByAddressInCurrency";
-        arg: {
-          contract_address: string;
-          network: string;
-          token_identifier?: string;
-        };
-        value: TokenCurrency | undefined;
-      }
-  > = [];
-
-  for (const entry of tokensToRestore) {
-    const token = entry.data;
-
-    entries.push({
-      endpointName: "findTokenById",
-      arg: { id: token.id },
-      value: token,
-    });
-
-    entries.push({
-      endpointName: "findTokenByAddressInCurrency",
-      arg: {
-        contract_address: token.contractAddress,
-        network: token.parentCurrencyId,
-        ...(entry.token_identifier === undefined
-          ? {}
-          : { token_identifier: entry.token_identifier }),
-      },
-      value: token,
-    });
-
-    // Also restore the address-only key so lookups without token_identifier hit the cache.
-    // Collision on chains where address is not unique is a coin-level concern.
-    if (entry.token_identifier !== undefined) {
-      entries.push({
-        endpointName: "findTokenByAddressInCurrency",
-        arg: {
-          contract_address: token.contractAddress,
-          network: token.parentCurrencyId,
-        },
-        value: token,
-      });
-    }
-  }
-
+  const entries = buildRestoreCacheEntries(tokensToRestore);
   if (entries.length > 0) {
     dispatch(cryptoAssetsApi.util.upsertQueryEntries(entries));
   }

--- a/domain/api/currency-token/src/persistence.ts
+++ b/domain/api/currency-token/src/persistence.ts
@@ -1,46 +1,15 @@
-import { z } from "zod";
 import isEqual from "lodash/isEqual";
-import { TokenCurrencySchema, type TokenCurrency } from "@domain/entity-currency-token";
+import type { TokenCurrency } from "@domain/entity-currency-token";
 import type { ThunkDispatch } from "@reduxjs/toolkit";
 import { cryptoAssetsApi } from "./api";
-import { PERSISTENCE_VERSION } from "./internals";
+import { PERSISTENCE_VERSION, SYNC_HASH_QUERY_KEY } from "./internals";
 import {
   buildRestoreCacheEntries,
   groupTokensByCurrency,
   resolveCurrenciesToEvict,
 } from "./internals/restore";
-import type { TokenByAddressInCurrencyParams } from "./types";
-
-/** Matches an RTK Query `getTokensSyncHash` cache key, capturing the currency id. */
-const SYNC_HASH_QUERY_KEY = /getTokensSyncHash\("([^"]+)"\)/;
-
-/** Schema for a persisted token entry: a {@link TokenCurrency} plus cache-restoration metadata. */
-export const PersistedTokenEntrySchema = z.object({
-  /** Serializable token data (post-LIVE-32268 `TokenCurrency` is already serializable). */
-  data: TokenCurrencySchema,
-  /** When this token was fetched (Unix timestamp in ms). */
-  timestamp: z.number(),
-  /**
-   * The `token_identifier` used in the `findTokenByAddressInCurrency` query, if any.
-   * Needed to reconstruct the correct RTK Query cache key on hydration for chains where
-   * `contract_address` alone is not unique (e.g. MultiversX, Algorand, Cardano).
-   */
-  token_identifier: z.string().optional(),
-});
-
-export type PersistedTokenEntry = z.infer<typeof PersistedTokenEntrySchema>;
-
-/** Schema for the root persisted CAL blob, with a version pin and an optional hash map. */
-export const PersistedCALSchema = z.object({
-  /** The persistence version of the CAL blob. Used to determine compatibility with the current schema. */
-  version: z.literal(PERSISTENCE_VERSION),
-  /** The persisted token entries. */
-  tokens: z.array(PersistedTokenEntrySchema),
-  /** Mapping of currencyId to its `X-Ledger-Commit` hash. */
-  hashes: z.record(z.string(), z.string()).optional(),
-});
-
-export type PersistedCAL = z.infer<typeof PersistedCALSchema>;
+import { PersistedCALSchema } from "./schema";
+import type { PersistedCAL, PersistedTokenEntry, TokenByAddressInCurrencyParams } from "./types";
 
 /**
  * Validates an untrusted persisted blob (e.g. read from localStorage) against

--- a/domain/api/currency-token/src/schema.ts
+++ b/domain/api/currency-token/src/schema.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
+import { TokenCurrencySchema } from "@domain/entity-currency-token";
 import { UnitSchema } from "@domain/entity-currency-unit";
+import { PERSISTENCE_VERSION } from "./internals/constants";
 
 /** Schema for a single token in the CAL `/v1/tokens` response. */
 export const ApiTokenResponseSchema = z.object({
@@ -16,7 +18,41 @@ export const ApiTokenResponseSchema = z.object({
   live_signature: z.string().optional(),
 });
 
-export type ApiTokenResponse = z.infer<typeof ApiTokenResponseSchema>;
-
 /** Schema for the CAL `/v1/tokens` response: an array of tokens. */
 export const ApiResponseSchema = z.array(ApiTokenResponseSchema);
+
+/** Schema for a persisted token entry: a {@link TokenCurrency} plus cache-restoration metadata. */
+export const PersistedTokenEntrySchema = z.object({
+  /** Serializable token data (post-LIVE-32268 `TokenCurrency` is already serializable). */
+  data: TokenCurrencySchema,
+  /** When this token was fetched (Unix timestamp in ms). */
+  timestamp: z.number(),
+  /**
+   * The `token_identifier` used in the `findTokenByAddressInCurrency` query, if any.
+   * Needed to reconstruct the correct RTK Query cache key on hydration for chains where
+   * `contract_address` alone is not unique (e.g. MultiversX, Algorand, Cardano).
+   */
+  token_identifier: z.string().optional(),
+});
+
+/** Schema for the root persisted CAL blob, with a version pin and an optional hash map. */
+export const PersistedCALSchema = z.object({
+  /** The persistence version of the CAL blob. Used to determine compatibility with the current schema. */
+  version: z.literal(PERSISTENCE_VERSION),
+  /** The persisted token entries. */
+  tokens: z.array(PersistedTokenEntrySchema),
+  /** Mapping of currencyId to its `X-Ledger-Commit` hash. */
+  hashes: z.record(z.string(), z.string()).optional(),
+});
+
+/**
+ * Thunk `extraArgument` contract for the CAL token api. The app supplies the resolved CAL service
+ * URL, client version and an optional logger at store configuration time, so this package owns no
+ * env/config/logging dependency. The app picks the prod or staging URL — there is no staging switch
+ * in here.
+ */
+export const CalApiExtraSchema = z.object({
+  calServiceUrl: z.string().min(1),
+  ledgerClientVersion: z.string().min(1),
+  logger: z.custom<(...args: unknown[]) => void>().optional(),
+});

--- a/domain/api/currency-token/src/schema.ts
+++ b/domain/api/currency-token/src/schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { UnitSchema } from "@domain/entity-currency-unit";
+
+/** Schema for a single token in the CAL `/v1/tokens` response. */
+export const ApiTokenResponseSchema = z.object({
+  id: z.string(),
+  contract_address: z.string(),
+  standard: z.string(),
+  decimals: z.number(),
+  delisted: z.boolean(),
+  name: z.string(),
+  ticker: z.string(),
+  units: z.array(UnitSchema).min(1),
+  /** Only present for Cardano native assets, used to reconstruct the full assetId. */
+  token_identifier: z.string().optional(),
+  live_signature: z.string().optional(),
+});
+
+export type ApiTokenResponse = z.infer<typeof ApiTokenResponseSchema>;
+
+/** Schema for the CAL `/v1/tokens` response: an array of tokens. */
+export const ApiResponseSchema = z.array(ApiTokenResponseSchema);

--- a/domain/api/currency-token/src/types.ts
+++ b/domain/api/currency-token/src/types.ts
@@ -1,0 +1,48 @@
+import type { TokenCurrency } from "@domain/entity-currency-token";
+
+export interface TokenByIdParams {
+  id: string;
+}
+
+/** Parameters for the `findTokenByAddressInCurrency` query. */
+export interface TokenByAddressInCurrencyParams {
+  /** The contract address of the token. */
+  contract_address: string;
+  /** The network of the token. */
+  network: string;
+  /** The token identifier. */
+  token_identifier?: string;
+}
+
+/** Parameters for the `getTokensData` query. */
+export interface GetTokensDataParams {
+  /** Filter by network family (e.g. "ethereum", "polygon"). */
+  networkFamily?: string;
+  /** Output fields to request (defaults to the full token-schema projection). */
+  output?: string[];
+  /** Maximum number of assets to return. */
+  limit?: number;
+  /** Items per page (default 1000). */
+  pageSize?: number;
+  /** CAL reference to read from (e.g. "branch:main", "tag:tokens-1.11.12"). */
+  ref?: string;
+}
+
+/** Parameters for pagination. */
+export interface PageParam {
+  /** Cursor for the next page of results. */
+  cursor?: string;
+}
+
+/** Response data for the `getTokensData` query, including pagination. */
+export interface TokensDataWithPagination {
+  /** The list of token currencies. */
+  tokens: TokenCurrency[];
+  pagination: TokenPagination;
+}
+
+/** Pagination metadata returned with `getTokensData` responses. */
+export interface TokenPagination {
+  /** Cursor for the next page of results. */
+  nextCursor?: string;
+}

--- a/domain/api/currency-token/src/types.ts
+++ b/domain/api/currency-token/src/types.ts
@@ -1,4 +1,11 @@
+import { z } from "zod";
 import type { TokenCurrency } from "@domain/entity-currency-token";
+import {
+  ApiTokenResponseSchema,
+  CalApiExtraSchema,
+  PersistedCALSchema,
+  PersistedTokenEntrySchema,
+} from "./schema";
 
 export interface TokenByIdParams {
   id: string;
@@ -46,3 +53,15 @@ export interface TokenPagination {
   /** Cursor for the next page of results. */
   nextCursor?: string;
 }
+
+/** A single token in the CAL `/v1/tokens` response (inferred from {@link ApiTokenResponseSchema}). */
+export type ApiTokenResponse = z.infer<typeof ApiTokenResponseSchema>;
+
+/** A persisted token entry: a {@link TokenCurrency} plus cache-restoration metadata. */
+export type PersistedTokenEntry = z.infer<typeof PersistedTokenEntrySchema>;
+
+/** The root persisted CAL blob (version pin + token entries + optional hash map). */
+export type PersistedCAL = z.infer<typeof PersistedCALSchema>;
+
+/** Thunk `extraArgument` contract for the CAL token api. */
+export type CalApiExtra = z.infer<typeof CalApiExtraSchema>;

--- a/domain/api/currency-token/tsconfig.json
+++ b/domain/api/currency-token/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2024", "DOM"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3006,6 +3006,58 @@ importers:
         specifier: 'catalog:'
         version: 6.0.2
 
+  domain/api/currency-token:
+    dependencies:
+      '@domain/entity-currency-crypto':
+        specifier: workspace:*
+        version: link:../../entity/currency-crypto
+      '@domain/entity-currency-token':
+        specifier: workspace:*
+        version: link:../../entity/currency-token
+      '@domain/entity-currency-unit':
+        specifier: workspace:*
+        version: link:../../entity/currency-unit
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2(react-redux@9.2.0(react@19.1.4))(react@19.1.4)
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@jest/globals':
+        specifier: 'catalog:'
+        version: 30.2.0
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/lodash':
+        specifier: ^4.14.191
+        version: 4.17.21
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
+      react:
+        specifier: 19.1.4
+        version: 19.1.4
+      react-redux:
+        specifier: 'catalog:'
+        version: 9.2.0(react@19.1.4)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.2
+
   domain/entity/currency:
     dependencies:
       '@domain/entity-currency-crypto':
@@ -22098,7 +22150,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -49875,6 +49927,18 @@ snapshots:
       react: 19.1.4
       react-redux: 9.2.0(@types/react@19.0.14)(react@19.1.4)
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(react@19.1.4))(react@19.1.4)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.3
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.1.4
+      react-redux: 9.2.0(react@19.1.4)
+
   '@remix-run/router@1.23.2': {}
 
   '@rjsf/core@5.24.13(@rjsf/utils@5.24.13(react@19.1.4))(react@19.1.4)':
@@ -69190,6 +69254,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.14
       redux: 5.0.1
+
+  react-redux@9.2.0(react@19.1.4):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.1.4
+      use-sync-external-store: 1.6.0(react@19.1.4)
 
   react-refresh@0.14.2: {}
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** 82 unit tests: Zod schema parsing, converter parity against the crypto registry, persistence (extract/restore/hash-validation + Zod blob validation), and RTK request/header/staging-selection assertions via a `fetch` spy.
- [ ] **Impact of the changes:** New **private** package only — **not wired into any app**, so there is no runtime impact yet.
  - Adds `@domain/api-currency-token`; no existing code path changes. The legacy `cal-client` / `api-token-converter` remain untouched and in use. QA focus: none for this PR — it will be consumed later by [LIVE-31914](https://ledgerhq.atlassian.net/browse/LIVE-31914).

### 📝 Description

Relocates the **CAL (Crypto Asset List) token-data client** out of `libs/ledgerjs/packages/cryptoassets/src/cal-client/*` + `api-token-converter.ts` into a new **private** package **`@domain/api-currency-token`** (`domain/api/currency-token/`). Part of the per-entity split of the currencies API layer — token = CAL, crypto = DADA, fiat = CVS ([LIVE-32269](https://ledgerhq.atlassian.net/browse/LIVE-32269)).

**Ships**

- `cryptoAssetsApi` RTK Query API: `findTokenById`, `findTokenByAddressInCurrency`, `getTokensSyncHash`, `getTokensData`.
- Zod response schema (reusing `UnitSchema` from `@domain/entity-currency-unit`) and the `convertApiToken` converter — parent crypto currency resolved from `@domain/entity-currency-crypto`'s registry, output typed on `@domain/entity-currency-token`.
- Zod-validated RTK Query persistence helpers (`parsePersistedCAL`, cache extract/restore, CAL hash validation).

**Design**

- **Injected config** — service URLs, client version and an optional logger come from the store's thunk `extraArgument` via `calApiExtra(...)`; the package owns no `@ledgerhq/live-env` / `@ledgerhq/logs` / `@ledgerhq/types-cryptoassets` dependency.
- **Additive / dual-maintained** — legacy `cal-client` + `api-token-converter` stay in place (still imported by coin-modules + DADA); this is a parallel, retyped copy. Not yet wired into the apps (store binding is [LIVE-31914](https://ledgerhq.atlassian.net/browse/LIVE-31914); single-source gate [LIVE-32346](https://ledgerhq.atlassian.net/browse/LIVE-32346)).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31904](https://ledgerhq.atlassian.net/browse/LIVE-31904)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31914]: https://ledgerhq.atlassian.net/browse/LIVE-31914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-32269]: https://ledgerhq.atlassian.net/browse/LIVE-32269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ