### PR TITLE
[LWDM] feat(desktop): add connect device flow

### DIFF
--- a/.changeset/connect-device-desktop-mvvm.md
+++ b/.changeset/connect-device-desktop-mvvm.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-dmk-desktop": minor
+---
+
+Add MVVM connect device flow on desktop with a WebHID discovery source

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/DeviceConnectionComponentLWDView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/DeviceConnectionComponentLWDView.test.tsx
@@ -1,0 +1,164 @@
+import React from "react";
+import {
+  BaseConnectionErrorTypes,
+  BaseDiscoveryErrorTypes,
+  ConnectDeviceUIStateTypes,
+  type ConnectDeviceUIState,
+} from "@ledgerhq/live-dmk-desktop";
+import { screen } from "@testing-library/react";
+
+import { DeviceConnectionComponentLWDView } from "./DeviceConnectionComponentLWDView";
+import { makeKnownDevice, renderWithUser } from "./testUtils";
+import type { DeviceConnectionComponentLWDViewModel } from "./useDeviceConnectionComponentLWDViewModel";
+
+jest.mock("~/renderer/components/DeviceAction/animations", () => ({
+  getDeviceAnimation: jest.fn(() => undefined),
+}));
+
+jest.mock("~/renderer/hooks/useTheme", () => () => ({ theme: "dark" }));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      const { mockT } = jest.requireActual("./testUtils");
+      return mockT(key, params);
+    },
+  }),
+}));
+
+function renderView(
+  state: ConnectDeviceUIState,
+  callbacks: Partial<Omit<DeviceConnectionComponentLWDViewModel, "state">> = {},
+) {
+  return renderWithUser(
+    <DeviceConnectionComponentLWDView
+      state={state}
+      onConnectLedgerDevice={callbacks.onConnectLedgerDevice ?? jest.fn()}
+      onBuyLedgerDevice={callbacks.onBuyLedgerDevice ?? jest.fn()}
+    />,
+  );
+}
+
+describe("DeviceConnectionComponentLWDView", () => {
+  it("GIVEN connect device is loading WHEN rendering THEN it shows the loading state", () => {
+    // WHEN
+    renderView({ type: ConnectDeviceUIStateTypes.Loading });
+
+    // THEN
+    expect(screen.getByText("Loading")).toBeVisible();
+  });
+
+  it("GIVEN there is no known device WHEN clicking both CTAs THEN it renders the state and forwards callbacks", async () => {
+    // GIVEN
+    const onConnectLedgerDevice = jest.fn();
+    const onBuyLedgerDevice = jest.fn();
+    const { user } = renderView(
+      { type: ConnectDeviceUIStateTypes.NoKnownDevice },
+      { onConnectLedgerDevice, onBuyLedgerDevice },
+    );
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Connect Ledger device" }));
+    await user.click(screen.getByRole("button", { name: "I don't have a Ledger device" }));
+
+    // THEN
+    expect(screen.getByText("Ledger device required")).toBeVisible();
+    expect(onConnectLedgerDevice).toHaveBeenCalledTimes(1);
+    expect(onBuyLedgerDevice).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN known devices are listed WHEN rendering THEN it shows the discovering state", () => {
+    // WHEN
+    renderView({
+      type: ConnectDeviceUIStateTypes.Discovering,
+      devices: [
+        {
+          type: "available",
+          knownDevice: makeKnownDevice({ name: "My Ledger" }),
+          onSelect: jest.fn(),
+        },
+      ],
+    });
+
+    // THEN
+    expect(screen.getByText("Select a device")).toBeVisible();
+    expect(screen.getByText("My Ledger")).toBeVisible();
+    expect(screen.getByText("Available")).toBeVisible();
+  });
+
+  it("GIVEN a selected device is not connected yet WHEN rendering THEN it shows the waiting state", () => {
+    // WHEN
+    renderView({
+      type: ConnectDeviceUIStateTypes.WaitingForSelectedDevice,
+      device: makeKnownDevice(),
+    });
+
+    // THEN
+    expect(screen.getByText("Power on and unlock your Ledger Nano X")).toBeVisible();
+  });
+
+  it("GIVEN WebHID discovery fails with an unknown error WHEN rendering THEN it shows the discovery error", () => {
+    // WHEN
+    renderView({
+      type: ConnectDeviceUIStateTypes.DiscoveryError,
+      error: { type: BaseDiscoveryErrorTypes.Unknown },
+      retry: jest.fn(),
+      ignore: jest.fn(),
+    });
+
+    // THEN
+    expect(screen.getByText("Something went wrong")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeVisible();
+  });
+
+  it("GIVEN a non-desktop discovery error WHEN rendering THEN it renders nothing", () => {
+    // WHEN
+    const { container } = renderView({
+      type: ConnectDeviceUIStateTypes.DiscoveryError,
+      error: { type: "bluetooth-disabled-promptable" },
+      ignore: jest.fn(),
+    } as unknown as ConnectDeviceUIState);
+
+    // THEN
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("GIVEN a device connection is in progress WHEN rendering THEN it shows the connecting state", () => {
+    // WHEN
+    renderView({ type: ConnectDeviceUIStateTypes.Connecting, device: makeKnownDevice() });
+
+    // THEN
+    expect(screen.getByText("Loading")).toBeVisible();
+  });
+
+  it("GIVEN WebHID connection fails with an unknown error WHEN rendering THEN it shows the connection error", () => {
+    // WHEN
+    renderView({
+      type: ConnectDeviceUIStateTypes.ConnectionError,
+      error: { type: BaseConnectionErrorTypes.Unknown },
+      device: makeKnownDevice(),
+      retry: jest.fn(),
+      ignore: jest.fn(),
+    });
+
+    // THEN
+    expect(screen.getByText("Pairing unsuccessful")).toBeVisible();
+    expect(screen.getByText("Make sure your device is unlocked.")).toBeVisible();
+  });
+
+  it("GIVEN the device is connected WHEN rendering THEN it renders nothing", () => {
+    // WHEN
+    const { container } = renderView({ type: ConnectDeviceUIStateTypes.Connected });
+
+    // THEN
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("GIVEN an unexpected error escapes WHEN rendering THEN it shows the generic unknown error state", () => {
+    // WHEN
+    renderView({ type: ConnectDeviceUIStateTypes.UnknownError, error: new Error("boom") });
+
+    // THEN
+    expect(screen.getByText("Unknown error")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/DeviceConnectionComponentLWDView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/DeviceConnectionComponentLWDView.test.tsx
@@ -6,9 +6,10 @@ import {
   type ConnectDeviceUIState,
 } from "@ledgerhq/live-dmk-desktop";
 import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
 
 import { DeviceConnectionComponentLWDView } from "./DeviceConnectionComponentLWDView";
-import { makeKnownDevice, renderWithUser } from "./testUtils";
+import { makeKnownDevice } from "./testUtils";
 import type { DeviceConnectionComponentLWDViewModel } from "./useDeviceConnectionComponentLWDViewModel";
 
 jest.mock("~/renderer/components/DeviceAction/animations", () => ({
@@ -17,20 +18,11 @@ jest.mock("~/renderer/components/DeviceAction/animations", () => ({
 
 jest.mock("~/renderer/hooks/useTheme", () => () => ({ theme: "dark" }));
 
-jest.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, params?: Record<string, string>) => {
-      const { mockT } = jest.requireActual("./testUtils");
-      return mockT(key, params);
-    },
-  }),
-}));
-
 function renderView(
   state: ConnectDeviceUIState,
   callbacks: Partial<Omit<DeviceConnectionComponentLWDViewModel, "state">> = {},
 ) {
-  return renderWithUser(
+  return render(
     <DeviceConnectionComponentLWDView
       state={state}
       onConnectLedgerDevice={callbacks.onConnectLedgerDevice ?? jest.fn()}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/DeviceConnectionComponentLWDView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/DeviceConnectionComponentLWDView.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { ConnectDeviceUIStateTypes } from "@ledgerhq/live-dmk-desktop";
+
+import { ConnectedState } from "./components/ConnectedState";
+import { ConnectingState } from "./components/ConnectingState";
+import { ConnectionErrorState } from "./components/ConnectionErrorState";
+import { DiscoveringState } from "./components/DiscoveringState";
+import { DiscoveryErrorState } from "./components/DiscoveryErrorState";
+import { LoadingState } from "./components/LoadingState";
+import { NoKnownDeviceState } from "./components/NoKnownDeviceState";
+import { UnknownErrorState } from "./components/UnknownErrorState";
+import { WaitingForSelectedDeviceState } from "./components/WaitingForSelectedDeviceState";
+import type { DeviceConnectionComponentLWDViewModel } from "./useDeviceConnectionComponentLWDViewModel";
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled connect device state: ${JSON.stringify(value)}`);
+}
+
+export function DeviceConnectionComponentLWDView({
+  state,
+  onConnectLedgerDevice,
+  onBuyLedgerDevice,
+}: Readonly<DeviceConnectionComponentLWDViewModel>) {
+  switch (state.type) {
+    case ConnectDeviceUIStateTypes.Loading:
+      return <LoadingState />;
+
+    case ConnectDeviceUIStateTypes.NoKnownDevice:
+      return (
+        <NoKnownDeviceState
+          onConnectLedgerDevice={onConnectLedgerDevice}
+          onBuyLedgerDevice={onBuyLedgerDevice}
+        />
+      );
+
+    case ConnectDeviceUIStateTypes.Discovering:
+      return <DiscoveringState state={state} />;
+
+    case ConnectDeviceUIStateTypes.WaitingForSelectedDevice:
+      return <WaitingForSelectedDeviceState state={state} />;
+
+    case ConnectDeviceUIStateTypes.DiscoveryError:
+      return <DiscoveryErrorState state={state} />;
+
+    case ConnectDeviceUIStateTypes.Connecting:
+      return <ConnectingState state={state} />;
+
+    case ConnectDeviceUIStateTypes.ConnectionError:
+      return <ConnectionErrorState state={state} />;
+
+    case ConnectDeviceUIStateTypes.Connected:
+      return <ConnectedState />;
+
+    case ConnectDeviceUIStateTypes.UnknownError:
+      return <UnknownErrorState />;
+
+    default:
+      return assertNever(state);
+  }
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectedState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectedState.test.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+import { renderWithUser } from "../testUtils";
+import { ConnectedState } from "./ConnectedState";
+
+describe("ConnectedState", () => {
+  it("GIVEN a connected device WHEN rendering THEN it renders nothing", () => {
+    // WHEN
+    const { container } = renderWithUser(<ConnectedState />);
+
+    // THEN
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectedState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectedState.test.tsx
@@ -1,12 +1,12 @@
 import React from "react";
+import { render } from "tests/testSetup";
 
-import { renderWithUser } from "../testUtils";
 import { ConnectedState } from "./ConnectedState";
 
 describe("ConnectedState", () => {
   it("GIVEN a connected device WHEN rendering THEN it renders nothing", () => {
     // WHEN
-    const { container } = renderWithUser(<ConnectedState />);
+    const { container } = render(<ConnectedState />);
 
     // THEN
     expect(container).toBeEmptyDOMElement();

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectedState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectedState.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export function ConnectedState(): React.ReactNode {
+  return null;
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectingState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectingState.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { ConnectDeviceUIStateTypes, type ConnectDeviceUIState } from "@ledgerhq/live-dmk-desktop";
+import { screen } from "@testing-library/react";
+
+import { makeKnownDevice, renderWithUser } from "../testUtils";
+import { ConnectingState } from "./ConnectingState";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      const { mockT } = jest.requireActual("../testUtils");
+      return mockT(key, params);
+    },
+  }),
+}));
+
+type ConnectingUIState = Extract<
+  ConnectDeviceUIState,
+  { type: ConnectDeviceUIStateTypes.Connecting }
+>;
+
+describe("ConnectingState", () => {
+  it("GIVEN a connecting state WHEN rendering THEN it shows the loading title", () => {
+    // GIVEN
+    const state: ConnectingUIState = {
+      type: ConnectDeviceUIStateTypes.Connecting,
+      device: makeKnownDevice(),
+    };
+
+    // WHEN
+    renderWithUser(<ConnectingState state={state} />);
+
+    // THEN
+    expect(screen.getByText("Loading")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectingState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectingState.test.tsx
@@ -1,18 +1,10 @@
 import React from "react";
 import { ConnectDeviceUIStateTypes, type ConnectDeviceUIState } from "@ledgerhq/live-dmk-desktop";
 import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
 
-import { makeKnownDevice, renderWithUser } from "../testUtils";
+import { makeKnownDevice } from "../testUtils";
 import { ConnectingState } from "./ConnectingState";
-
-jest.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, params?: Record<string, string>) => {
-      const { mockT } = jest.requireActual("../testUtils");
-      return mockT(key, params);
-    },
-  }),
-}));
 
 type ConnectingUIState = Extract<
   ConnectDeviceUIState,
@@ -28,7 +20,7 @@ describe("ConnectingState", () => {
     };
 
     // WHEN
-    renderWithUser(<ConnectingState state={state} />);
+    render(<ConnectingState state={state} />);
 
     // THEN
     expect(screen.getByText("Loading")).toBeVisible();

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectingState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectingState.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Spinner } from "@ledgerhq/lumen-ui-react";
+import { ConnectDeviceUIStateTypes, type ConnectDeviceUIState } from "@ledgerhq/live-dmk-desktop";
+import { useTranslation } from "react-i18next";
+
+type ConnectingStateProps = {
+  state: Extract<ConnectDeviceUIState, { type: ConnectDeviceUIStateTypes.Connecting }>;
+};
+
+export function ConnectingState(_props: Readonly<ConnectingStateProps>): React.ReactNode {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex w-full flex-col items-center gap-16 px-16 py-32">
+      <Spinner size={32} />
+      <h3 className="heading-4-semi-bold text-center text-base">
+        {t("deviceIntentExecutor.connectDevice.states.connecting.title")}
+      </h3>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectionErrorState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectionErrorState.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import {
+  BaseConnectionErrorTypes,
+  ConnectDeviceUIStateTypes,
+  type ConnectDeviceUIState,
+} from "@ledgerhq/live-dmk-desktop";
+import { screen } from "@testing-library/react";
+
+import { makeKnownDevice, renderWithUser } from "../testUtils";
+import { ConnectionErrorState } from "./ConnectionErrorState";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      const { mockT } = jest.requireActual("../testUtils");
+      return mockT(key, params);
+    },
+  }),
+}));
+
+type ConnectionErrorUIState = Extract<
+  ConnectDeviceUIState,
+  { type: ConnectDeviceUIStateTypes.ConnectionError }
+>;
+
+function renderState(state: Partial<ConnectionErrorUIState> = {}) {
+  return renderWithUser(
+    <ConnectionErrorState
+      state={
+        {
+          type: ConnectDeviceUIStateTypes.ConnectionError,
+          error: { type: BaseConnectionErrorTypes.Unknown },
+          device: makeKnownDevice(),
+          retry: jest.fn(),
+          ignore: jest.fn(),
+          ...state,
+        } as ConnectionErrorUIState
+      }
+    />,
+  );
+}
+
+describe("ConnectionErrorState", () => {
+  it("GIVEN an unknown connection error WHEN rendering THEN it shows the title and retry CTA", () => {
+    // WHEN
+    renderState();
+
+    // THEN
+    expect(screen.getByText("Pairing unsuccessful")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeVisible();
+  });
+
+  it("GIVEN an unknown connection error WHEN rendering THEN it shows the description and tip", () => {
+    // WHEN
+    renderState();
+
+    // THEN
+    expect(screen.getByText("Please try again.")).toBeVisible();
+    expect(screen.getByText("Make sure your device is unlocked.")).toBeVisible();
+  });
+
+  it("GIVEN an unknown connection error WHEN clicking the retry CTA THEN it calls retry", async () => {
+    // GIVEN
+    const retry = jest.fn();
+    const { user } = renderState({ retry });
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    // THEN
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN a non-desktop connection error WHEN rendering THEN it renders nothing", () => {
+    // WHEN
+    const { container } = renderState({
+      error: { type: "ble-pairing-refused" },
+    } as unknown as Partial<ConnectionErrorUIState>);
+
+    // THEN
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectionErrorState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectionErrorState.test.tsx
@@ -5,18 +5,10 @@ import {
   type ConnectDeviceUIState,
 } from "@ledgerhq/live-dmk-desktop";
 import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
 
-import { makeKnownDevice, renderWithUser } from "../testUtils";
+import { makeKnownDevice } from "../testUtils";
 import { ConnectionErrorState } from "./ConnectionErrorState";
-
-jest.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, params?: Record<string, string>) => {
-      const { mockT } = jest.requireActual("../testUtils");
-      return mockT(key, params);
-    },
-  }),
-}));
 
 type ConnectionErrorUIState = Extract<
   ConnectDeviceUIState,
@@ -24,7 +16,7 @@ type ConnectionErrorUIState = Extract<
 >;
 
 function renderState(state: Partial<ConnectionErrorUIState> = {}) {
-  return renderWithUser(
+  return render(
     <ConnectionErrorState
       state={
         {

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectionErrorState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectionErrorState.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import {
+  BaseConnectionErrorTypes,
+  ConnectDeviceUIStateTypes,
+  type ConnectDeviceUIState,
+} from "@ledgerhq/live-dmk-desktop";
+import { useTranslation } from "react-i18next";
+
+import { InfoState } from "LLD/components/InfoState";
+
+type ConnectionErrorStateProps = {
+  state: Extract<ConnectDeviceUIState, { type: ConnectDeviceUIStateTypes.ConnectionError }>;
+};
+
+export function ConnectionErrorState({
+  state,
+}: Readonly<ConnectionErrorStateProps>): React.ReactNode {
+  const { t } = useTranslation();
+
+  if (state.error.type !== BaseConnectionErrorTypes.Unknown) {
+    return null;
+  }
+
+  return (
+    <InfoState
+      preset="error"
+      size="hug"
+      title={t("deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.title")}
+      description={t(
+        "deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.description",
+      )}
+      banner={{
+        title: t("deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.tip"),
+      }}
+      primaryCta={{
+        label: t(
+          "deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.cta.retry",
+        ),
+        onPress: state.retry,
+      }}
+      testID="device-intent-executor-connect-device-connection-error"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DeviceListItem.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DeviceListItem.test.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { getProductName } from "@ledgerhq/devices";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { screen } from "@testing-library/react";
+
+import { makeDisplayedDevice, makeKnownDevice, renderWithUser } from "../testUtils";
+import { DeviceListItem } from "./DeviceListItem";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      const { mockT } = jest.requireActual("../testUtils");
+      return mockT(key, params);
+    },
+  }),
+}));
+
+describe("DeviceListItem", () => {
+  it("GIVEN an available device WHEN rendering THEN it shows the device name and available status", () => {
+    // GIVEN
+    const device = makeDisplayedDevice({
+      type: "available",
+      knownDevice: makeKnownDevice({ name: "Available Ledger" }),
+    });
+
+    // WHEN
+    renderWithUser(<DeviceListItem device={device} />);
+
+    // THEN
+    expect(screen.getByText("Available Ledger")).toBeVisible();
+    expect(screen.getByText("Available")).toBeVisible();
+  });
+
+  it("GIVEN an unavailable device WHEN rendering THEN it shows the device name and not connected status", () => {
+    // GIVEN
+    const device = makeDisplayedDevice({
+      type: "not-available",
+      knownDevice: makeKnownDevice({ name: "Unavailable Ledger" }),
+    });
+
+    // WHEN
+    renderWithUser(<DeviceListItem device={device} />);
+
+    // THEN
+    expect(screen.getByText("Unavailable Ledger")).toBeVisible();
+    expect(screen.getByText("Not connected")).toBeVisible();
+  });
+
+  it("GIVEN a known device without a name WHEN rendering THEN it falls back to the product name", () => {
+    // GIVEN
+    const device = makeDisplayedDevice({
+      knownDevice: makeKnownDevice({ name: null }),
+    });
+
+    // WHEN
+    renderWithUser(<DeviceListItem device={device} />);
+
+    // THEN
+    expect(
+      screen.getByText(new RegExp(getProductName(DeviceModelId.nanoX).replace(/\u00a0/g, "\\s+"))),
+    ).toBeVisible();
+  });
+
+  it("GIVEN a selectable device WHEN clicking the device row THEN it calls the selection callback", async () => {
+    // GIVEN
+    const onSelect = jest.fn();
+    const device = makeDisplayedDevice({
+      knownDevice: makeKnownDevice({
+        name: "Ledger Stax",
+        deviceModelId: DeviceModelId.stax,
+      }),
+      onSelect,
+    });
+    const { user } = renderWithUser(<DeviceListItem device={device} />);
+
+    // WHEN
+    await user.click(screen.getByText("Ledger Stax"));
+
+    // THEN
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DeviceListItem.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DeviceListItem.test.tsx
@@ -2,18 +2,10 @@ import React from "react";
 import { getProductName } from "@ledgerhq/devices";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
 
-import { makeDisplayedDevice, makeKnownDevice, renderWithUser } from "../testUtils";
+import { makeDisplayedDevice, makeKnownDevice } from "../testUtils";
 import { DeviceListItem } from "./DeviceListItem";
-
-jest.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, params?: Record<string, string>) => {
-      const { mockT } = jest.requireActual("../testUtils");
-      return mockT(key, params);
-    },
-  }),
-}));
 
 describe("DeviceListItem", () => {
   it("GIVEN an available device WHEN rendering THEN it shows the device name and available status", () => {
@@ -24,7 +16,7 @@ describe("DeviceListItem", () => {
     });
 
     // WHEN
-    renderWithUser(<DeviceListItem device={device} />);
+    render(<DeviceListItem device={device} />);
 
     // THEN
     expect(screen.getByText("Available Ledger")).toBeVisible();
@@ -39,7 +31,7 @@ describe("DeviceListItem", () => {
     });
 
     // WHEN
-    renderWithUser(<DeviceListItem device={device} />);
+    render(<DeviceListItem device={device} />);
 
     // THEN
     expect(screen.getByText("Unavailable Ledger")).toBeVisible();
@@ -53,7 +45,7 @@ describe("DeviceListItem", () => {
     });
 
     // WHEN
-    renderWithUser(<DeviceListItem device={device} />);
+    render(<DeviceListItem device={device} />);
 
     // THEN
     expect(
@@ -71,7 +63,7 @@ describe("DeviceListItem", () => {
       }),
       onSelect,
     });
-    const { user } = renderWithUser(<DeviceListItem device={device} />);
+    const { user } = render(<DeviceListItem device={device} />);
 
     // WHEN
     await user.click(screen.getByText("Ledger Stax"));

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DeviceListItem.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DeviceListItem.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import {
+  ListItem,
+  ListItemContent,
+  ListItemLeading,
+  ListItemTitle,
+  ListItemTrailing,
+  Spot,
+  Tag,
+} from "@ledgerhq/lumen-ui-react";
+import type { DisplayedDevice } from "@ledgerhq/live-dmk-desktop";
+import { getProductName } from "@ledgerhq/devices";
+import { getDeviceIcon } from "LLD/utils/getDeviceIcon";
+import { useTranslation } from "react-i18next";
+
+type DeviceListItemProps = {
+  device: DisplayedDevice;
+};
+
+function getDeviceName(device: DisplayedDevice["knownDevice"], fallbackName: string): string {
+  return device.name ?? fallbackName;
+}
+
+export function DeviceListItem({ device }: Readonly<DeviceListItemProps>): React.ReactNode {
+  const { t } = useTranslation();
+  const DeviceIcon = getDeviceIcon(device.knownDevice.deviceModelId);
+  const isAvailable = device.type === "available";
+
+  return (
+    <ListItem onClick={device.onSelect}>
+      <ListItemLeading>
+        <Spot size={48} appearance="icon" icon={DeviceIcon} />
+        <ListItemContent>
+          <ListItemTitle>
+            {getDeviceName(device.knownDevice, getProductName(device.knownDevice.deviceModelId))}
+          </ListItemTitle>
+        </ListItemContent>
+      </ListItemLeading>
+      <ListItemTrailing>
+        <Tag
+          appearance={isAvailable ? "accent-subtle" : "gray"}
+          label={t(
+            isAvailable
+              ? "deviceIntentExecutor.connectDevice.common.available"
+              : "deviceIntentExecutor.connectDevice.common.notConnected",
+          )}
+          size="md"
+        />
+      </ListItemTrailing>
+    </ListItem>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveringState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveringState.test.tsx
@@ -1,18 +1,10 @@
 import React from "react";
 import { ConnectDeviceUIStateTypes, type ConnectDeviceUIState } from "@ledgerhq/live-dmk-desktop";
 import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
 
-import { makeDisplayedDevice, makeKnownDevice, renderWithUser } from "../testUtils";
+import { makeDisplayedDevice, makeKnownDevice } from "../testUtils";
 import { DiscoveringState } from "./DiscoveringState";
-
-jest.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, params?: Record<string, string>) => {
-      const { mockT } = jest.requireActual("../testUtils");
-      return mockT(key, params);
-    },
-  }),
-}));
 
 type DiscoveringUIState = Extract<
   ConnectDeviceUIState,
@@ -20,7 +12,7 @@ type DiscoveringUIState = Extract<
 >;
 
 function renderState(state: Partial<DiscoveringUIState> = {}) {
-  return renderWithUser(
+  return render(
     <DiscoveringState
       state={{
         type: ConnectDeviceUIStateTypes.Discovering,

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveringState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveringState.test.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { ConnectDeviceUIStateTypes, type ConnectDeviceUIState } from "@ledgerhq/live-dmk-desktop";
+import { screen } from "@testing-library/react";
+
+import { makeDisplayedDevice, makeKnownDevice, renderWithUser } from "../testUtils";
+import { DiscoveringState } from "./DiscoveringState";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      const { mockT } = jest.requireActual("../testUtils");
+      return mockT(key, params);
+    },
+  }),
+}));
+
+type DiscoveringUIState = Extract<
+  ConnectDeviceUIState,
+  { type: ConnectDeviceUIStateTypes.Discovering }
+>;
+
+function renderState(state: Partial<DiscoveringUIState> = {}) {
+  return renderWithUser(
+    <DiscoveringState
+      state={{
+        type: ConnectDeviceUIStateTypes.Discovering,
+        devices: [
+          makeDisplayedDevice({
+            type: "available",
+            knownDevice: makeKnownDevice({ name: "Available Ledger" }),
+          }),
+          makeDisplayedDevice({
+            type: "not-available",
+            knownDevice: makeKnownDevice({ name: "Unavailable Ledger" }),
+          }),
+        ],
+        ...state,
+      }}
+    />,
+  );
+}
+
+describe("DiscoveringState", () => {
+  it("GIVEN an available device WHEN rendering THEN it asks the user to select a device", () => {
+    // WHEN
+    renderState();
+
+    // THEN
+    expect(screen.getByText("Select a device")).toBeVisible();
+    expect(screen.getByText("Available Ledger")).toBeVisible();
+    expect(screen.getByText("Unavailable Ledger")).toBeVisible();
+  });
+
+  it("GIVEN no available device WHEN rendering THEN it asks the user to power on and unlock a device", () => {
+    // WHEN
+    renderState({
+      devices: [
+        makeDisplayedDevice({
+          type: "not-available",
+          knownDevice: makeKnownDevice({ name: "Unavailable Ledger" }),
+        }),
+      ],
+    });
+
+    // THEN
+    expect(screen.getByText("Power on and unlock a device")).toBeVisible();
+    expect(screen.getByText("Unavailable Ledger")).toBeVisible();
+  });
+
+  it("GIVEN a selectable device WHEN clicking the row THEN it forwards the selection callback", async () => {
+    // GIVEN
+    const onSelect = jest.fn();
+    const { user } = renderState({
+      devices: [
+        makeDisplayedDevice({
+          knownDevice: makeKnownDevice({ name: "My Ledger" }),
+          onSelect,
+        }),
+      ],
+    });
+
+    // WHEN
+    await user.click(screen.getByText("My Ledger"));
+
+    // THEN
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveringState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveringState.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import {
+  ConnectDeviceUIStateTypes,
+  type ConnectDeviceUIState,
+  type DisplayedDevice,
+} from "@ledgerhq/live-dmk-desktop";
+import { useTranslation } from "react-i18next";
+
+import { DeviceListItem } from "./DeviceListItem";
+
+type DiscoveringStateProps = {
+  state: Extract<ConnectDeviceUIState, { type: ConnectDeviceUIStateTypes.Discovering }>;
+};
+
+function getDeviceKey(device: DisplayedDevice, index: number): string {
+  const { deviceModelId, id, name, transport } = device.knownDevice;
+
+  return `${transport}-${deviceModelId}-${id || name || index}`;
+}
+
+export function DiscoveringState({ state }: Readonly<DiscoveringStateProps>): React.ReactNode {
+  const { t } = useTranslation();
+  const hasAvailableDevice = state.devices.some(device => device.type === "available");
+
+  return (
+    <div className="flex w-full flex-col gap-16">
+      <h3 className="heading-4-semi-bold text-left text-base">
+        {t(
+          hasAvailableDevice
+            ? "deviceIntentExecutor.connectDevice.states.discovering.title"
+            : "deviceIntentExecutor.connectDevice.states.discovering.noAvailableDeviceTitle",
+        )}
+      </h3>
+      <div className="flex flex-col">
+        {state.devices.map((device, index) => (
+          <DeviceListItem key={getDeviceKey(device, index)} device={device} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveryErrorState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveryErrorState.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import {
+  BaseDiscoveryErrorTypes,
+  ConnectDeviceUIStateTypes,
+  type ConnectDeviceUIState,
+} from "@ledgerhq/live-dmk-desktop";
+import { screen } from "@testing-library/react";
+
+import { renderWithUser } from "../testUtils";
+import { DiscoveryErrorState } from "./DiscoveryErrorState";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      const { mockT } = jest.requireActual("../testUtils");
+      return mockT(key, params);
+    },
+  }),
+}));
+
+type DiscoveryErrorUIState = Extract<
+  ConnectDeviceUIState,
+  { type: ConnectDeviceUIStateTypes.DiscoveryError }
+>;
+
+function renderState(state: Partial<DiscoveryErrorUIState> = {}) {
+  return renderWithUser(
+    <DiscoveryErrorState
+      state={
+        {
+          type: ConnectDeviceUIStateTypes.DiscoveryError,
+          error: { type: BaseDiscoveryErrorTypes.Unknown },
+          retry: jest.fn(),
+          ignore: jest.fn(),
+          ...state,
+        } as DiscoveryErrorUIState
+      }
+    />,
+  );
+}
+
+describe("DiscoveryErrorState", () => {
+  it("GIVEN an unknown discovery error WHEN rendering THEN it shows the title and description", () => {
+    // WHEN
+    renderState();
+
+    // THEN
+    expect(screen.getByText("Something went wrong")).toBeVisible();
+    expect(screen.getByText("Please try again or contact Ledger support.")).toBeVisible();
+  });
+
+  it("GIVEN an unknown discovery error with retry WHEN clicking the retry CTA THEN it calls retry", async () => {
+    // GIVEN
+    const retry = jest.fn();
+    const { user } = renderState({ retry });
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    // THEN
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN an unknown discovery error without retry WHEN rendering THEN it hides the retry CTA", () => {
+    // WHEN
+    renderState({ retry: undefined });
+
+    // THEN
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+  });
+
+  it("GIVEN a non-desktop discovery error WHEN rendering THEN it renders nothing", () => {
+    // WHEN
+    const { container } = renderState({
+      error: { type: "bluetooth-disabled-promptable" },
+    } as unknown as Partial<DiscoveryErrorUIState>);
+
+    // THEN
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveryErrorState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveryErrorState.test.tsx
@@ -5,18 +5,9 @@ import {
   type ConnectDeviceUIState,
 } from "@ledgerhq/live-dmk-desktop";
 import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
 
-import { renderWithUser } from "../testUtils";
 import { DiscoveryErrorState } from "./DiscoveryErrorState";
-
-jest.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, params?: Record<string, string>) => {
-      const { mockT } = jest.requireActual("../testUtils");
-      return mockT(key, params);
-    },
-  }),
-}));
 
 type DiscoveryErrorUIState = Extract<
   ConnectDeviceUIState,
@@ -24,7 +15,7 @@ type DiscoveryErrorUIState = Extract<
 >;
 
 function renderState(state: Partial<DiscoveryErrorUIState> = {}) {
-  return renderWithUser(
+  return render(
     <DiscoveryErrorState
       state={
         {

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveryErrorState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveryErrorState.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import {
+  BaseDiscoveryErrorTypes,
+  ConnectDeviceUIStateTypes,
+  type ConnectDeviceUIState,
+} from "@ledgerhq/live-dmk-desktop";
+import { useTranslation } from "react-i18next";
+
+import { InfoState } from "LLD/components/InfoState";
+
+type DiscoveryErrorStateProps = {
+  state: Extract<ConnectDeviceUIState, { type: ConnectDeviceUIStateTypes.DiscoveryError }>;
+};
+
+export function DiscoveryErrorState({
+  state,
+}: Readonly<DiscoveryErrorStateProps>): React.ReactNode {
+  const { t } = useTranslation();
+
+  if (state.error.type !== BaseDiscoveryErrorTypes.Unknown) {
+    return null;
+  }
+
+  return (
+    <InfoState
+      preset="error"
+      size="hug"
+      title={t("deviceIntentExecutor.connectDevice.states.discoveryError.errors.unknown.title")}
+      description={t(
+        "deviceIntentExecutor.connectDevice.states.discoveryError.errors.unknown.description",
+      )}
+      primaryCta={
+        state.retry
+          ? {
+              label: t(
+                "deviceIntentExecutor.connectDevice.states.discoveryError.errors.unknown.cta.retry",
+              ),
+              onPress: state.retry,
+            }
+          : undefined
+      }
+      testID="device-intent-executor-connect-device-discovery-error"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/LoadingState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/LoadingState.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+
+import { renderWithUser } from "../testUtils";
+import { LoadingState } from "./LoadingState";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      const { mockT } = jest.requireActual("../testUtils");
+      return mockT(key, params);
+    },
+  }),
+}));
+
+describe("LoadingState", () => {
+  it("GIVEN connect device is loading WHEN rendering THEN it shows the loading title", () => {
+    // WHEN
+    renderWithUser(<LoadingState />);
+
+    // THEN
+    expect(screen.getByText("Loading")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/LoadingState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/LoadingState.test.tsx
@@ -1,22 +1,13 @@
 import React from "react";
 import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
 
-import { renderWithUser } from "../testUtils";
 import { LoadingState } from "./LoadingState";
-
-jest.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, params?: Record<string, string>) => {
-      const { mockT } = jest.requireActual("../testUtils");
-      return mockT(key, params);
-    },
-  }),
-}));
 
 describe("LoadingState", () => {
   it("GIVEN connect device is loading WHEN rendering THEN it shows the loading title", () => {
     // WHEN
-    renderWithUser(<LoadingState />);
+    render(<LoadingState />);
 
     // THEN
     expect(screen.getByText("Loading")).toBeVisible();

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/LoadingState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/LoadingState.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Spinner } from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "react-i18next";
+
+export function LoadingState(): React.ReactNode {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex w-full flex-col items-center gap-16 px-16 py-24">
+      <Spinner size={32} />
+      <h3 className="heading-4-semi-bold text-center text-base">
+        {t("deviceIntentExecutor.connectDevice.states.loading.title")}
+      </h3>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/NoKnownDeviceState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/NoKnownDeviceState.test.tsx
@@ -1,24 +1,13 @@
 import React from "react";
 import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
 
-import { renderWithUser } from "../testUtils";
 import { NoKnownDeviceState } from "./NoKnownDeviceState";
-
-jest.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, params?: Record<string, string>) => {
-      const { mockT } = jest.requireActual("../testUtils");
-      return mockT(key, params);
-    },
-  }),
-}));
 
 describe("NoKnownDeviceState", () => {
   it("GIVEN there is no known device WHEN rendering THEN it shows the no known device copy", () => {
     // WHEN
-    renderWithUser(
-      <NoKnownDeviceState onConnectLedgerDevice={jest.fn()} onBuyLedgerDevice={jest.fn()} />,
-    );
+    render(<NoKnownDeviceState onConnectLedgerDevice={jest.fn()} onBuyLedgerDevice={jest.fn()} />);
 
     // THEN
     expect(screen.getByText("Ledger device required")).toBeVisible();
@@ -28,7 +17,7 @@ describe("NoKnownDeviceState", () => {
   it("GIVEN there is no known device WHEN clicking the connect CTA THEN it calls the connect callback", async () => {
     // GIVEN
     const onConnectLedgerDevice = jest.fn();
-    const { user } = renderWithUser(
+    const { user } = render(
       <NoKnownDeviceState
         onConnectLedgerDevice={onConnectLedgerDevice}
         onBuyLedgerDevice={jest.fn()}
@@ -45,7 +34,7 @@ describe("NoKnownDeviceState", () => {
   it("GIVEN there is no known device WHEN clicking the buy device CTA THEN it calls the buy device callback", async () => {
     // GIVEN
     const onBuyLedgerDevice = jest.fn();
-    const { user } = renderWithUser(
+    const { user } = render(
       <NoKnownDeviceState
         onConnectLedgerDevice={jest.fn()}
         onBuyLedgerDevice={onBuyLedgerDevice}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/NoKnownDeviceState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/NoKnownDeviceState.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+
+import { renderWithUser } from "../testUtils";
+import { NoKnownDeviceState } from "./NoKnownDeviceState";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      const { mockT } = jest.requireActual("../testUtils");
+      return mockT(key, params);
+    },
+  }),
+}));
+
+describe("NoKnownDeviceState", () => {
+  it("GIVEN there is no known device WHEN rendering THEN it shows the no known device copy", () => {
+    // WHEN
+    renderWithUser(
+      <NoKnownDeviceState onConnectLedgerDevice={jest.fn()} onBuyLedgerDevice={jest.fn()} />,
+    );
+
+    // THEN
+    expect(screen.getByText("Ledger device required")).toBeVisible();
+    expect(screen.getByText("To continue, set up or connect your signer.")).toBeVisible();
+  });
+
+  it("GIVEN there is no known device WHEN clicking the connect CTA THEN it calls the connect callback", async () => {
+    // GIVEN
+    const onConnectLedgerDevice = jest.fn();
+    const { user } = renderWithUser(
+      <NoKnownDeviceState
+        onConnectLedgerDevice={onConnectLedgerDevice}
+        onBuyLedgerDevice={jest.fn()}
+      />,
+    );
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Connect Ledger device" }));
+
+    // THEN
+    expect(onConnectLedgerDevice).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN there is no known device WHEN clicking the buy device CTA THEN it calls the buy device callback", async () => {
+    // GIVEN
+    const onBuyLedgerDevice = jest.fn();
+    const { user } = renderWithUser(
+      <NoKnownDeviceState
+        onConnectLedgerDevice={jest.fn()}
+        onBuyLedgerDevice={onBuyLedgerDevice}
+      />,
+    );
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "I don't have a Ledger device" }));
+
+    // THEN
+    expect(onBuyLedgerDevice).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/NoKnownDeviceState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/NoKnownDeviceState.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { LedgerDevices } from "@ledgerhq/lumen-ui-react/symbols";
+import { useTranslation } from "react-i18next";
+
+import { InfoState } from "LLD/components/InfoState";
+
+type NoKnownDeviceStateProps = {
+  onConnectLedgerDevice: () => void;
+  onBuyLedgerDevice: () => void;
+};
+
+export function NoKnownDeviceState({
+  onConnectLedgerDevice,
+  onBuyLedgerDevice,
+}: Readonly<NoKnownDeviceStateProps>): React.ReactNode {
+  const { t } = useTranslation();
+
+  return (
+    <InfoState
+      preset="spot"
+      spotProps={{ icon: LedgerDevices }}
+      size="hug"
+      title={t("deviceIntentExecutor.connectDevice.states.noKnownDevice.title")}
+      description={t("deviceIntentExecutor.connectDevice.states.noKnownDevice.description")}
+      primaryCta={{
+        label: t("deviceIntentExecutor.connectDevice.states.noKnownDevice.connectLedgerDevice"),
+        onPress: onConnectLedgerDevice,
+      }}
+      secondaryCta={{
+        label: t("deviceIntentExecutor.connectDevice.states.noKnownDevice.noLedgerDevice"),
+        onPress: onBuyLedgerDevice,
+      }}
+      testID="device-intent-executor-connect-device-no-known-device"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/UnknownErrorState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/UnknownErrorState.test.tsx
@@ -1,22 +1,13 @@
 import React from "react";
 import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
 
-import { renderWithUser } from "../testUtils";
 import { UnknownErrorState } from "./UnknownErrorState";
-
-jest.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, params?: Record<string, string>) => {
-      const { mockT } = jest.requireActual("../testUtils");
-      return mockT(key, params);
-    },
-  }),
-}));
 
 describe("UnknownErrorState", () => {
   it("GIVEN an unexpected error escapes WHEN rendering THEN it shows the generic intent error copy", () => {
     // WHEN
-    renderWithUser(<UnknownErrorState />);
+    render(<UnknownErrorState />);
 
     // THEN
     expect(screen.getByText("Unknown error")).toBeVisible();

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/UnknownErrorState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/UnknownErrorState.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+
+import { renderWithUser } from "../testUtils";
+import { UnknownErrorState } from "./UnknownErrorState";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      const { mockT } = jest.requireActual("../testUtils");
+      return mockT(key, params);
+    },
+  }),
+}));
+
+describe("UnknownErrorState", () => {
+  it("GIVEN an unexpected error escapes WHEN rendering THEN it shows the generic intent error copy", () => {
+    // WHEN
+    renderWithUser(<UnknownErrorState />);
+
+    // THEN
+    expect(screen.getByText("Unknown error")).toBeVisible();
+    expect(
+      screen.getByText(
+        "An error occurred. Please try again or contact Ledger support if the issue persists.",
+      ),
+    ).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/UnknownErrorState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/UnknownErrorState.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import { InfoState } from "LLD/components/InfoState";
+
+export function UnknownErrorState(): React.ReactNode {
+  const { t } = useTranslation();
+
+  return (
+    <InfoState
+      preset="error"
+      size="hug"
+      title={t("deviceIntentExecutor.errors.intentError.title")}
+      description={t("deviceIntentExecutor.errors.intentError.description")}
+      testID="device-intent-executor-connect-device-unknown-error"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/WaitingForSelectedDeviceState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/WaitingForSelectedDeviceState.test.tsx
@@ -3,8 +3,9 @@ import { getProductName } from "@ledgerhq/devices";
 import { ConnectDeviceUIStateTypes, type ConnectDeviceUIState } from "@ledgerhq/live-dmk-desktop";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
 
-import { makeKnownDevice, renderWithUser } from "../testUtils";
+import { makeKnownDevice } from "../testUtils";
 import { WaitingForSelectedDeviceState } from "./WaitingForSelectedDeviceState";
 
 jest.mock("~/renderer/components/DeviceAction/animations", () => ({
@@ -13,22 +14,13 @@ jest.mock("~/renderer/components/DeviceAction/animations", () => ({
 
 jest.mock("~/renderer/hooks/useTheme", () => () => ({ theme: "dark" }));
 
-jest.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, params?: Record<string, string>) => {
-      const { mockT } = jest.requireActual("../testUtils");
-      return mockT(key, params);
-    },
-  }),
-}));
-
 type WaitingForSelectedDeviceUIState = Extract<
   ConnectDeviceUIState,
   { type: ConnectDeviceUIStateTypes.WaitingForSelectedDevice }
 >;
 
 function renderState(device: WaitingForSelectedDeviceUIState["device"]) {
-  return renderWithUser(
+  return render(
     <WaitingForSelectedDeviceState
       state={{
         type: ConnectDeviceUIStateTypes.WaitingForSelectedDevice,

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/WaitingForSelectedDeviceState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/WaitingForSelectedDeviceState.test.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { getProductName } from "@ledgerhq/devices";
+import { ConnectDeviceUIStateTypes, type ConnectDeviceUIState } from "@ledgerhq/live-dmk-desktop";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { screen } from "@testing-library/react";
+
+import { makeKnownDevice, renderWithUser } from "../testUtils";
+import { WaitingForSelectedDeviceState } from "./WaitingForSelectedDeviceState";
+
+jest.mock("~/renderer/components/DeviceAction/animations", () => ({
+  getDeviceAnimation: jest.fn(() => undefined),
+}));
+
+jest.mock("~/renderer/hooks/useTheme", () => () => ({ theme: "dark" }));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      const { mockT } = jest.requireActual("../testUtils");
+      return mockT(key, params);
+    },
+  }),
+}));
+
+type WaitingForSelectedDeviceUIState = Extract<
+  ConnectDeviceUIState,
+  { type: ConnectDeviceUIStateTypes.WaitingForSelectedDevice }
+>;
+
+function renderState(device: WaitingForSelectedDeviceUIState["device"]) {
+  return renderWithUser(
+    <WaitingForSelectedDeviceState
+      state={{
+        type: ConnectDeviceUIStateTypes.WaitingForSelectedDevice,
+        device,
+      }}
+    />,
+  );
+}
+
+describe("WaitingForSelectedDeviceState", () => {
+  it("GIVEN a selected device with a name WHEN rendering THEN it shows the device name and product-specific title", () => {
+    // WHEN
+    renderState(makeKnownDevice({ name: "My Ledger" }));
+
+    // THEN
+    expect(screen.getByText("My Ledger")).toBeVisible();
+    expect(
+      screen.getByRole("heading", {
+        name: new RegExp(
+          `Power on and unlock your ${getProductName(DeviceModelId.nanoX).replace(
+            /\u00a0/g,
+            "\\s+",
+          )}`,
+        ),
+      }),
+    ).toBeVisible();
+  });
+
+  it("GIVEN a selected device without a name WHEN rendering THEN it falls back to the product name", () => {
+    // WHEN
+    renderState(makeKnownDevice({ name: null }));
+
+    // THEN
+    const [deviceNameLabel] = screen.getAllByText(
+      new RegExp(getProductName(DeviceModelId.nanoX).replace(/\u00a0/g, "\\s+")),
+    );
+    expect(deviceNameLabel).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/WaitingForSelectedDeviceState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/WaitingForSelectedDeviceState.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { getProductName } from "@ledgerhq/devices";
+import { ConnectDeviceUIStateTypes, type ConnectDeviceUIState } from "@ledgerhq/live-dmk-desktop";
+import { useTranslation } from "react-i18next";
+
+import { DeviceActionContent } from "LLD/components/DeviceActionContent";
+
+type WaitingForSelectedDeviceStateProps = {
+  state: Extract<
+    ConnectDeviceUIState,
+    { type: ConnectDeviceUIStateTypes.WaitingForSelectedDevice }
+  >;
+};
+
+function getDeviceName(
+  device: WaitingForSelectedDeviceStateProps["state"]["device"],
+  fallbackName: string,
+): string {
+  return device.name ?? fallbackName;
+}
+
+export function WaitingForSelectedDeviceState({
+  state,
+}: Readonly<WaitingForSelectedDeviceStateProps>): React.ReactNode {
+  const { t } = useTranslation();
+  const productName = getProductName(state.device.deviceModelId);
+
+  return (
+    <DeviceActionContent
+      action="power-and-unlock"
+      deviceModelId={state.device.deviceModelId}
+      deviceName={getDeviceName(state.device, productName)}
+      title={t("deviceIntentExecutor.connectDevice.states.waitingForSelectedDevice.title", {
+        productName,
+      })}
+      testID="device-intent-executor-connect-device-waiting-for-selected-device"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/index.tsx
@@ -1,69 +1,19 @@
 import React from "react";
-import type { DeviceConnectionComponent, DeviceConnectionResult } from "@ledgerhq/device-intent";
-import { DeviceModelId } from "@ledgerhq/types-devices";
-import { Button } from "@ledgerhq/lumen-ui-react";
-import { EMPTY } from "rxjs";
+import type { DeviceConnectionComponent } from "@ledgerhq/device-intent";
 
-function formatParams(params: unknown): string {
-  return JSON.stringify(params, null, 2) ?? "";
-}
+import { DeviceConnectionComponentLWDView } from "./DeviceConnectionComponentLWDView";
+import { useDeviceConnectionComponentLWDViewModel } from "./useDeviceConnectionComponentLWDViewModel";
 
 const DeviceConnectionComponentLWD: DeviceConnectionComponent = ({
   deviceConnectionParams,
   onConnected,
-  onClose,
 }) => {
-  const simulateConnected = () => {
-    onConnected(buildMockConnectionResult());
-  };
+  const viewModel = useDeviceConnectionComponentLWDViewModel({
+    deviceConnectionParams,
+    onConnected,
+  });
 
-  return (
-    <div
-      className="flex w-full flex-col gap-24 px-16 py-24"
-      data-testid="device-intent-executor-device-connection-placeholder"
-    >
-      <div className="flex flex-col gap-8 text-center">
-        <h3 className="heading-4-semi-bold text-base">Device connection placeholder</h3>
-        <p className="body-2 text-muted">
-          The desktop device connection implementation is pending.
-        </p>
-      </div>
-      <pre className="max-h-[240px] overflow-auto rounded-md bg-muted p-12 text-left font-mono text-xs text-base">
-        {formatParams(deviceConnectionParams)}
-      </pre>
-      <div className="flex w-full flex-col gap-12">
-        <Button appearance="base" size="lg" isFull onClick={simulateConnected}>
-          Simulate connected device
-        </Button>
-        <Button appearance="gray" size="lg" isFull onClick={onClose}>
-          Close
-        </Button>
-      </div>
-    </div>
-  );
+  return <DeviceConnectionComponentLWDView {...viewModel} />;
 };
-
-function buildMockConnectionResult(): DeviceConnectionResult {
-  const sessionId = "debug-session-id";
-
-  return {
-    dmk: {
-      getDeviceSessionState: () => EMPTY,
-    } as unknown as DeviceConnectionResult["dmk"],
-    sessionId,
-    connectedDevice: {
-      id: "debug-device-id",
-      name: "Ledger Flex Debug",
-      modelId: "FLEX",
-      sessionId,
-      type: "USB",
-      transport: "web-hid",
-    } as unknown as DeviceConnectionResult["connectedDevice"],
-    compatDeviceId: "debug-device-id",
-    compatDeviceModelId: DeviceModelId.europa,
-    compatDeviceName: "Ledger Flex Debug",
-    compatDeviceWired: true,
-  };
-}
 
 export default DeviceConnectionComponentLWD;

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/testUtils.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/testUtils.tsx
@@ -1,53 +1,6 @@
-import React from "react";
 import { webHidTransportIdentifier, type DisplayedDevice } from "@ledgerhq/live-dmk-desktop";
 import type { KnownDevice } from "@ledgerhq/live-dmk-shared";
 import { DeviceModelId } from "@ledgerhq/types-devices";
-import { render } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-
-export const mockTranslations: Record<string, string> = {
-  "deviceIntentExecutor.connectDevice.common.ledgerDevice": "Ledger device",
-  "deviceIntentExecutor.connectDevice.common.available": "Available",
-  "deviceIntentExecutor.connectDevice.common.notConnected": "Not connected",
-  "deviceIntentExecutor.connectDevice.states.loading.title": "Loading",
-  "deviceIntentExecutor.connectDevice.states.connecting.title": "Loading",
-  "deviceIntentExecutor.connectDevice.states.noKnownDevice.title": "Ledger device required",
-  "deviceIntentExecutor.connectDevice.states.noKnownDevice.description":
-    "To continue, set up or connect your signer.",
-  "deviceIntentExecutor.connectDevice.states.noKnownDevice.connectLedgerDevice":
-    "Connect Ledger device",
-  "deviceIntentExecutor.connectDevice.states.noKnownDevice.noLedgerDevice":
-    "I don't have a Ledger device",
-  "deviceIntentExecutor.connectDevice.states.discovering.title": "Select a device",
-  "deviceIntentExecutor.connectDevice.states.discovering.noAvailableDeviceTitle":
-    "Power on and unlock a device",
-  "deviceIntentExecutor.connectDevice.states.waitingForSelectedDevice.title":
-    "Power on and unlock your {{productName}}",
-  "deviceIntentExecutor.connectDevice.states.discoveryError.errors.unknown.title":
-    "Something went wrong",
-  "deviceIntentExecutor.connectDevice.states.discoveryError.errors.unknown.description":
-    "Please try again or contact Ledger support.",
-  "deviceIntentExecutor.connectDevice.states.discoveryError.errors.unknown.cta.retry": "Try again",
-  "deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.title":
-    "Pairing unsuccessful",
-  "deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.description":
-    "Please try again.",
-  "deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.tip":
-    "Make sure your device is unlocked.",
-  "deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.cta.retry": "Try again",
-  "deviceIntentExecutor.errors.intentError.title": "Unknown error",
-  "deviceIntentExecutor.errors.intentError.description":
-    "An error occurred. Please try again or contact Ledger support if the issue persists.",
-};
-
-export function mockT(key: string, params?: Record<string, string>): string {
-  const translation = mockTranslations[key] ?? key;
-
-  return Object.entries(params ?? {}).reduce(
-    (value, [paramKey, paramValue]) => value.replace(`{{${paramKey}}}`, paramValue),
-    translation,
-  );
-}
 
 export function makeKnownDevice(overrides: Partial<KnownDevice> = {}): KnownDevice {
   return {
@@ -66,11 +19,4 @@ export function makeDisplayedDevice(overrides: Partial<DisplayedDevice> = {}): D
     onSelect: () => undefined,
     ...overrides,
   } as DisplayedDevice;
-}
-
-export function renderWithUser(ui: React.ReactElement) {
-  return {
-    user: userEvent.setup({ pointerEventsCheck: 0 }),
-    ...render(ui),
-  };
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/testUtils.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/testUtils.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { webHidTransportIdentifier, type DisplayedDevice } from "@ledgerhq/live-dmk-desktop";
+import type { KnownDevice } from "@ledgerhq/live-dmk-shared";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+export const mockTranslations: Record<string, string> = {
+  "deviceIntentExecutor.connectDevice.common.ledgerDevice": "Ledger device",
+  "deviceIntentExecutor.connectDevice.common.available": "Available",
+  "deviceIntentExecutor.connectDevice.common.notConnected": "Not connected",
+  "deviceIntentExecutor.connectDevice.states.loading.title": "Loading",
+  "deviceIntentExecutor.connectDevice.states.connecting.title": "Loading",
+  "deviceIntentExecutor.connectDevice.states.noKnownDevice.title": "Ledger device required",
+  "deviceIntentExecutor.connectDevice.states.noKnownDevice.description":
+    "To continue, set up or connect your signer.",
+  "deviceIntentExecutor.connectDevice.states.noKnownDevice.connectLedgerDevice":
+    "Connect Ledger device",
+  "deviceIntentExecutor.connectDevice.states.noKnownDevice.noLedgerDevice":
+    "I don't have a Ledger device",
+  "deviceIntentExecutor.connectDevice.states.discovering.title": "Select a device",
+  "deviceIntentExecutor.connectDevice.states.discovering.noAvailableDeviceTitle":
+    "Power on and unlock a device",
+  "deviceIntentExecutor.connectDevice.states.waitingForSelectedDevice.title":
+    "Power on and unlock your {{productName}}",
+  "deviceIntentExecutor.connectDevice.states.discoveryError.errors.unknown.title":
+    "Something went wrong",
+  "deviceIntentExecutor.connectDevice.states.discoveryError.errors.unknown.description":
+    "Please try again or contact Ledger support.",
+  "deviceIntentExecutor.connectDevice.states.discoveryError.errors.unknown.cta.retry": "Try again",
+  "deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.title":
+    "Pairing unsuccessful",
+  "deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.description":
+    "Please try again.",
+  "deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.tip":
+    "Make sure your device is unlocked.",
+  "deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.cta.retry": "Try again",
+  "deviceIntentExecutor.errors.intentError.title": "Unknown error",
+  "deviceIntentExecutor.errors.intentError.description":
+    "An error occurred. Please try again or contact Ledger support if the issue persists.",
+};
+
+export function mockT(key: string, params?: Record<string, string>): string {
+  const translation = mockTranslations[key] ?? key;
+
+  return Object.entries(params ?? {}).reduce(
+    (value, [paramKey, paramValue]) => value.replace(`{{${paramKey}}}`, paramValue),
+    translation,
+  );
+}
+
+export function makeKnownDevice(overrides: Partial<KnownDevice> = {}): KnownDevice {
+  return {
+    id: "",
+    name: "Ledger Nano X",
+    deviceModelId: DeviceModelId.nanoX,
+    transport: webHidTransportIdentifier,
+    ...overrides,
+  };
+}
+
+export function makeDisplayedDevice(overrides: Partial<DisplayedDevice> = {}): DisplayedDevice {
+  return {
+    type: "available",
+    knownDevice: makeKnownDevice(),
+    onSelect: () => undefined,
+    ...overrides,
+  } as DisplayedDevice;
+}
+
+export function renderWithUser(ui: React.ReactElement) {
+  return {
+    user: userEvent.setup({ pointerEventsCheck: 0 }),
+    ...render(ui),
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.test.tsx
@@ -1,0 +1,254 @@
+import type { DeviceConnectionParams, DeviceConnectionResult } from "@ledgerhq/device-intent";
+import {
+  connectDevice,
+  ConnectDeviceUIStateTypes,
+  webHidTransportIdentifier,
+  type ConnectDeviceUIState,
+  useDeviceManagementKit,
+} from "@ledgerhq/live-dmk-desktop";
+import { ledgerToDmkDeviceIdMap, type KnownDevice } from "@ledgerhq/live-dmk-shared";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router";
+import type { State } from "~/renderer/reducers";
+import createStore, { type ReduxStore } from "~/state-manager/configureStore";
+
+import { useDeviceConnectionComponentLWDViewModel } from "./useDeviceConnectionComponentLWDViewModel";
+
+const mockHandleConnect = jest.fn();
+const mockHandleBuyDevice = jest.fn();
+
+jest.mock("LLD/hooks/useLazyOnboardingActions", () => ({
+  useLazyOnboardingActions: () => ({
+    handleConnect: mockHandleConnect,
+    handleBuyDevice: mockHandleBuyDevice,
+  }),
+}));
+
+jest.mock("@ledgerhq/live-dmk-desktop", () => {
+  const actual = jest.requireActual("@ledgerhq/live-dmk-desktop");
+
+  return {
+    ...actual,
+    connectDevice: jest.fn(),
+    useDeviceManagementKit: jest.fn(),
+  };
+});
+
+type ConnectDeviceObserver = {
+  next: (state: ConnectDeviceUIState) => void;
+};
+
+const mockedUseDeviceManagementKit = jest.mocked(useDeviceManagementKit);
+const mockedConnectDevice = jest.mocked(connectDevice);
+const mockDmk = { id: "dmk" } as unknown as NonNullable<ReturnType<typeof useDeviceManagementKit>>;
+
+let connectDeviceObserver: ConnectDeviceObserver | undefined;
+let mockUnsubscribe: jest.Mock;
+
+const defaultDeviceConnectionParams: DeviceConnectionParams = {
+  acceptedDeviceModelIds: [],
+};
+
+function mockConnectDeviceSubscription() {
+  mockUnsubscribe = jest.fn();
+  mockedConnectDevice.mockReturnValue({
+    subscribe: jest.fn((observer: ConnectDeviceObserver) => {
+      connectDeviceObserver = observer;
+
+      return { unsubscribe: mockUnsubscribe };
+    }),
+  } as unknown as ReturnType<typeof connectDevice>);
+}
+
+function renderViewModel({
+  knownDevices = [],
+  deviceConnectionParams = defaultDeviceConnectionParams,
+  onConnected = jest.fn(),
+}: {
+  knownDevices?: KnownDevice[];
+  deviceConnectionParams?: DeviceConnectionParams;
+  onConnected?: (connectionResult: DeviceConnectionResult) => void;
+} = {}) {
+  const store = createStore({
+    state: {
+      knownDevices: { knownDevices },
+    } as State,
+    fetchRemoteFlags: null,
+  });
+
+  const rendered = renderHook(
+    () =>
+      useDeviceConnectionComponentLWDViewModel({
+        deviceConnectionParams,
+        onConnected,
+      }),
+    {
+      wrapper: ({ children }) => <TestWrapper store={store}>{children}</TestWrapper>,
+    },
+  );
+
+  return { ...rendered, store };
+}
+
+function TestWrapper({ children, store }: { children: React.ReactNode; store: ReduxStore }) {
+  return (
+    <Provider store={store}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </Provider>
+  );
+}
+
+function makeKnownDevice(overrides: Partial<KnownDevice> = {}): KnownDevice {
+  return {
+    id: "",
+    name: "Known Ledger",
+    deviceModelId: DeviceModelId.nanoX,
+    transport: webHidTransportIdentifier,
+    ...overrides,
+  };
+}
+
+function makeConnectionResult(
+  overrides: Partial<DeviceConnectionResult> = {},
+): DeviceConnectionResult {
+  const { connectedDevice: connectedDeviceOverride, ...resultOverrides } = overrides;
+
+  return {
+    compatDeviceId: "device-id",
+    compatDeviceName: "Ledger Nano X",
+    compatDeviceModelId: DeviceModelId.nanoX,
+    compatDeviceWired: true,
+    dmk: mockDmk,
+    sessionId: "session-id",
+    connectedDevice: {
+      id: "device-id",
+      name: "Ledger Nano X",
+      modelId: ledgerToDmkDeviceIdMap[DeviceModelId.nanoX],
+      sessionId: "session-id",
+      type: "USB",
+      transport: webHidTransportIdentifier,
+      ...connectedDeviceOverride,
+    },
+    ...resultOverrides,
+  } as DeviceConnectionResult;
+}
+
+describe("useDeviceConnectionComponentLWDViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    connectDeviceObserver = undefined;
+    mockUnsubscribe = jest.fn();
+    mockedUseDeviceManagementKit.mockReturnValue(mockDmk);
+    mockConnectDeviceSubscription();
+  });
+
+  it("GIVEN known devices WHEN rendering the view model THEN it exposes loading state and subscribes to connect device", () => {
+    // GIVEN
+    const knownDevices = [makeKnownDevice()];
+
+    // WHEN
+    const { result } = renderViewModel({ knownDevices });
+
+    // THEN
+    expect(result.current.state).toEqual({ type: ConnectDeviceUIStateTypes.Loading });
+    expect(mockedConnectDevice).toHaveBeenCalledWith({
+      knownDevices,
+      acceptedDeviceModelIds: [],
+      dmk: mockDmk,
+      onConnected: expect.any(Function),
+    });
+  });
+
+  it("GIVEN accepted device model ids WHEN rendering the view model THEN it passes them to connect device", () => {
+    // GIVEN
+    const acceptedDeviceModelIds = [DeviceModelId.stax];
+
+    // WHEN
+    renderViewModel({
+      deviceConnectionParams: { acceptedDeviceModelIds },
+    });
+
+    // THEN
+    expect(mockedConnectDevice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        acceptedDeviceModelIds,
+      }),
+    );
+  });
+
+  it("GIVEN the connect device flow emits a state WHEN observing the flow THEN it updates the view model state", () => {
+    // GIVEN
+    const { result } = renderViewModel();
+    const discoveringState: ConnectDeviceUIState = {
+      type: ConnectDeviceUIStateTypes.Discovering,
+      devices: [],
+    };
+
+    // WHEN
+    act(() => connectDeviceObserver?.next(discoveringState));
+
+    // THEN
+    expect(result.current.state).toBe(discoveringState);
+  });
+
+  it("GIVEN the view model is subscribed WHEN unmounting THEN it unsubscribes from connect device", () => {
+    // GIVEN
+    const { unmount } = renderViewModel();
+
+    // WHEN
+    unmount();
+
+    // THEN
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN connect device reports a connection WHEN handling the result THEN it updates desktop device state and notifies the executor", () => {
+    // GIVEN
+    const onConnected = jest.fn();
+    const { store } = renderViewModel({ onConnected });
+    const connectionResult = makeConnectionResult();
+    const wrappedOnConnected = mockedConnectDevice.mock.calls[0][0].onConnected;
+
+    // WHEN
+    act(() => wrappedOnConnected(connectionResult));
+
+    // THEN
+    expect(onConnected).toHaveBeenCalledWith(connectionResult);
+    expect(store.getState().settings.devicesModelList).toContain(DeviceModelId.nanoX);
+  });
+
+  it("GIVEN desktop onboarding actions are available WHEN calling no-known-device handlers THEN it forwards to onboarding actions", () => {
+    // GIVEN
+    const { result } = renderViewModel();
+
+    // WHEN
+    result.current.onConnectLedgerDevice();
+    result.current.onBuyLedgerDevice();
+
+    // THEN
+    expect(mockHandleConnect).toHaveBeenCalledTimes(1);
+    expect(mockHandleBuyDevice).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN Device Management Kit is unavailable WHEN rendering the view model THEN it exposes an unknown error state", async () => {
+    // GIVEN
+    mockedUseDeviceManagementKit.mockReturnValue(null);
+
+    // WHEN
+    const { result } = renderViewModel();
+
+    // THEN
+    await waitFor(() =>
+      expect(result.current.state).toEqual({
+        type: ConnectDeviceUIStateTypes.UnknownError,
+        error: expect.objectContaining({
+          message: "Device Management Kit is not available",
+        }),
+      }),
+    );
+    expect(mockedConnectDevice).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useState } from "react";
+import type { DeviceConnectionParams, DeviceConnectionResult } from "@ledgerhq/device-intent";
+import { dmkToLedgerDeviceIdMap } from "@ledgerhq/live-dmk-shared";
+import {
+  connectDevice,
+  ConnectDeviceUIStateTypes,
+  type ConnectDeviceUIState,
+  useDeviceManagementKit,
+} from "@ledgerhq/live-dmk-desktop";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { useLazyOnboardingActions } from "LLD/hooks/useLazyOnboardingActions";
+import { addNewDeviceModel } from "~/renderer/actions/settings";
+import { knownDevicesSelector } from "~/renderer/reducers/knownDevices";
+
+const missingDeviceManagementKitError = new Error("Device Management Kit is not available");
+
+type UseDeviceConnectionComponentLWDViewModelParams = {
+  deviceConnectionParams: DeviceConnectionParams;
+  onConnected: (connectionResult: DeviceConnectionResult) => void;
+};
+
+export type DeviceConnectionComponentLWDViewModel = {
+  state: ConnectDeviceUIState;
+  onConnectLedgerDevice: () => void;
+  onBuyLedgerDevice: () => void;
+};
+
+export function useDeviceConnectionComponentLWDViewModel({
+  deviceConnectionParams,
+  onConnected,
+}: UseDeviceConnectionComponentLWDViewModelParams): DeviceConnectionComponentLWDViewModel {
+  const dispatch = useDispatch();
+  const dmk = useDeviceManagementKit();
+  const knownDevices = useSelector(knownDevicesSelector);
+  const { handleConnect, handleBuyDevice } = useLazyOnboardingActions();
+  const [state, setState] = useState<ConnectDeviceUIState>({
+    type: ConnectDeviceUIStateTypes.Loading,
+  });
+
+  const wrappedOnConnected = useCallback(
+    (result: DeviceConnectionResult) => {
+      const modelId = dmkToLedgerDeviceIdMap[result.connectedDevice.modelId];
+      dispatch(addNewDeviceModel({ deviceModelId: modelId }));
+
+      onConnected(result);
+    },
+    [dispatch, onConnected],
+  );
+
+  useEffect(() => {
+    if (!dmk) {
+      setState({
+        type: ConnectDeviceUIStateTypes.UnknownError,
+        error: missingDeviceManagementKitError,
+      });
+      return;
+    }
+
+    const subscription = connectDevice({
+      knownDevices,
+      acceptedDeviceModelIds: deviceConnectionParams.acceptedDeviceModelIds,
+      dmk,
+      onConnected: wrappedOnConnected,
+    }).subscribe({
+      next: nextState => {
+        setState(nextState);
+      },
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [deviceConnectionParams.acceptedDeviceModelIds, dmk, knownDevices, wrappedOnConnected]);
+
+  return {
+    state,
+    onConnectLedgerDevice: handleConnect,
+    onBuyLedgerDevice: handleBuyDevice,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { getDeviceModel } from "@ledgerhq/devices";
+import { getProductName } from "@ledgerhq/devices";
 import type { DeviceModelId } from "@ledgerhq/types-devices";
 import { DeviceActionContent } from "LLD/components/DeviceActionContent";
 
@@ -12,7 +12,7 @@ type ContinueOnDeviceProps = Readonly<{
 
 export function ContinueOnDevice({ deviceModelId, deviceName, testID }: ContinueOnDeviceProps) {
   const { t } = useTranslation();
-  const { productName } = getDeviceModel(deviceModelId);
+  const productName = getProductName(deviceModelId);
 
   return (
     <DeviceActionContent

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceGenericStates/RetryableDeviceLocked.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceGenericStates/RetryableDeviceLocked.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { getDeviceModel } from "@ledgerhq/devices";
+import { getProductName } from "@ledgerhq/devices";
 import type { DeviceModelId } from "@ledgerhq/types-devices";
 import { InfoState } from "LLD/components/InfoState";
 
@@ -16,7 +16,7 @@ export function RetryableDeviceLocked({
   testID,
 }: RetryableDeviceLockedProps) {
   const { t } = useTranslation();
-  const { productName } = getDeviceModel(deviceModelId);
+  const productName = getProductName(deviceModelId);
 
   return (
     <InfoState

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceGenericStates/UnlockDevice.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceGenericStates/UnlockDevice.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { getDeviceModel } from "@ledgerhq/devices";
+import { getProductName } from "@ledgerhq/devices";
 import type { DeviceModelId } from "@ledgerhq/types-devices";
 import { DeviceActionContent } from "LLD/components/DeviceActionContent";
 
@@ -12,7 +12,7 @@ type UnlockDeviceProps = Readonly<{
 
 export function UnlockDevice({ deviceModelId, deviceName, testID }: UnlockDeviceProps) {
   const { t } = useTranslation();
-  const { productName } = getDeviceModel(deviceModelId);
+  const productName = getProductName(deviceModelId);
 
   return (
     <DeviceActionContent

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/index.tsx
@@ -53,12 +53,12 @@ export function DeviceIntentExecutorLWD<JobState, Input, ExtraProps>(
     <Dialog open={wrappedProps.enabled} onOpenChange={onOpenChange} height="fit">
       <DialogContent
         aria-describedby={undefined}
-        className="max-h-[calc(100vh-16px)] w-[400px] overflow-hidden bg-base p-0"
+        className="w-[400px] bg-base p-0"
         data-testid="device-intent-executor-dialog"
       >
         <DialogBackgroundToneProvider>
-          <DialogHeader density="compact" onClose={onClose} />
-          <DialogBody className="relative flex min-h-0 flex-col px-24 pb-24">
+          <DialogHeader density="compact" onClose={onClose} className="!mb-0" />
+          <DialogBody className="!mb-0 flex min-h-0 flex-col px-24 pb-24">
             <DeviceIntentExecutor
               {...wrappedProps}
               platformConfig={platformConfig}

--- a/apps/ledger-live-desktop/src/mvvm/components/InfoState/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/InfoState/index.tsx
@@ -28,7 +28,7 @@ export function InfoState(props: InfoStateProps) {
     <div className={cn("w-full", isFullHeight && "flex flex-1")} data-testid={testID}>
       <div
         className={cn(
-          "flex w-full flex-col items-center gap-32 overflow-hidden px-16 py-24",
+          "flex w-full flex-col items-center gap-32 overflow-hidden",
           isFullHeight && "min-h-[480px] flex-1",
         )}
       >

--- a/apps/ledger-live-desktop/src/mvvm/utils/tests/getDeviceIcon.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/utils/tests/getDeviceIcon.test.ts
@@ -1,0 +1,29 @@
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { Apex, Flex, LedgerDevices, Nano, Stax } from "@ledgerhq/lumen-ui-react/symbols";
+
+import { getDeviceIcon } from "../getDeviceIcon";
+
+describe("getDeviceIcon", () => {
+  it.each([DeviceModelId.nanoS, DeviceModelId.nanoSP, DeviceModelId.nanoX, DeviceModelId.blue])(
+    "should return the Nano icon for %s",
+    modelId => {
+      expect(getDeviceIcon(modelId)).toBe(Nano);
+    },
+  );
+
+  it("should return the Stax icon for Ledger Stax", () => {
+    expect(getDeviceIcon(DeviceModelId.stax)).toBe(Stax);
+  });
+
+  it("should return the Flex icon for Ledger Flex", () => {
+    expect(getDeviceIcon(DeviceModelId.europa)).toBe(Flex);
+  });
+
+  it("should return the Apex icon for Ledger Apex", () => {
+    expect(getDeviceIcon(DeviceModelId.apex)).toBe(Apex);
+  });
+
+  it("should return the generic Ledger devices icon for an unknown model", () => {
+    expect(getDeviceIcon(undefined)).toBe(LedgerDevices);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/reducers/knownDevices.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/knownDevices.test.ts
@@ -1,9 +1,9 @@
 import { DeviceModelId } from "@ledgerhq/devices";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { webHidTransportIdentifier } from "@ledgerhq/live-dmk-desktop";
 import type { DeviceInfo, DeviceModelInfo } from "@ledgerhq/types-live";
 import reducer, {
   INITIAL_STATE,
-  WEB_HID_TRANSPORT_IDENTIFIER,
   importKnownDevices,
   knownDevicesSelector,
   knownDevicesStoreSelector,
@@ -41,10 +41,6 @@ const setLastOnboardedDevice = (payload: Device | null) => ({
 const addDevice = (payload: Device) => ({ type: "ADD_DEVICE", payload });
 
 describe("knownDevices reducer", () => {
-  it("normalizes known devices as web-hid", () => {
-    expect(WEB_HID_TRANSPORT_IDENTIFIER).toBe("web-hid");
-  });
-
   it("starts empty", () => {
     expect(reducer(undefined, { type: "@@INIT" })).toEqual(INITIAL_STATE);
   });
@@ -57,7 +53,7 @@ describe("knownDevices reducer", () => {
       );
       expect(state.knownDevices).toEqual([
         {
-          transport: WEB_HID_TRANSPORT_IDENTIFIER,
+          transport: webHidTransportIdentifier,
           deviceModelId: DeviceModelId.stax,
           id: "",
           name: null,
@@ -78,7 +74,7 @@ describe("knownDevices reducer", () => {
       );
       expect(state.knownDevices).toEqual([
         {
-          transport: WEB_HID_TRANSPORT_IDENTIFIER,
+          transport: webHidTransportIdentifier,
           deviceModelId: DeviceModelId.europa,
           id: "",
           name: "My Flex",
@@ -110,7 +106,7 @@ describe("knownDevices reducer", () => {
       const seeded: KnownDevicesState = {
         knownDevices: [
           {
-            transport: WEB_HID_TRANSPORT_IDENTIFIER,
+            transport: webHidTransportIdentifier,
             deviceModelId: DeviceModelId.europa,
             id: "",
             name: null,
@@ -130,7 +126,7 @@ describe("knownDevices reducer", () => {
       const state = reducer(INITIAL_STATE, lastSeenDeviceInfo(DeviceModelId.stax));
       expect(state.knownDevices).toEqual([
         {
-          transport: WEB_HID_TRANSPORT_IDENTIFIER,
+          transport: webHidTransportIdentifier,
           deviceModelId: DeviceModelId.stax,
           id: "",
           name: null,
@@ -145,7 +141,7 @@ describe("knownDevices reducer", () => {
       );
       expect(state.knownDevices).toEqual([
         {
-          transport: WEB_HID_TRANSPORT_IDENTIFIER,
+          transport: webHidTransportIdentifier,
           deviceModelId: DeviceModelId.europa,
           id: "",
           name: "Flex",
@@ -160,7 +156,7 @@ describe("knownDevices reducer", () => {
       );
       expect(state.knownDevices).toEqual([
         {
-          transport: WEB_HID_TRANSPORT_IDENTIFIER,
+          transport: webHidTransportIdentifier,
           deviceModelId: DeviceModelId.stax,
           id: "",
           name: "Stax",
@@ -194,7 +190,7 @@ describe("knownDevices reducer", () => {
       const seeded: KnownDevicesState = {
         knownDevices: [
           {
-            transport: WEB_HID_TRANSPORT_IDENTIFIER,
+            transport: webHidTransportIdentifier,
             deviceModelId: DeviceModelId.stax,
             id: "",
             name: null,
@@ -211,7 +207,7 @@ describe("knownDevices reducer", () => {
       const persisted: KnownDevicesState = {
         knownDevices: [
           {
-            transport: WEB_HID_TRANSPORT_IDENTIFIER,
+            transport: webHidTransportIdentifier,
             deviceModelId: DeviceModelId.europa,
             id: "",
             name: "Flex",
@@ -227,7 +223,7 @@ describe("knownDevices reducer", () => {
     it("returns the known devices from the root state", () => {
       const knownDevices = [
         {
-          transport: WEB_HID_TRANSPORT_IDENTIFIER,
+          transport: webHidTransportIdentifier,
           deviceModelId: DeviceModelId.stax,
           id: "",
           name: null,
@@ -241,7 +237,7 @@ describe("knownDevices reducer", () => {
 
   describe("serialization", () => {
     const webHidKnownDevice: KnownDevice = {
-      transport: WEB_HID_TRANSPORT_IDENTIFIER,
+      transport: webHidTransportIdentifier,
       deviceModelId: DeviceModelId.stax,
       id: "",
       name: "My Stax",
@@ -270,7 +266,7 @@ describe("knownDevices reducer", () => {
           name: "Flex",
         };
         expect(mapPersistedKnownDeviceToKnownDevice(persisted)).toEqual({
-          transport: WEB_HID_TRANSPORT_IDENTIFIER,
+          transport: webHidTransportIdentifier,
           deviceModelId: DeviceModelId.europa,
           id: "",
           name: "Flex",

--- a/apps/ledger-live-desktop/src/renderer/reducers/knownDevices.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/knownDevices.ts
@@ -1,16 +1,11 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { webHidTransportIdentifier } from "@ledgerhq/live-dmk-desktop";
 import type { DeviceModelId } from "@ledgerhq/types-devices";
 import type { DeviceModelInfo } from "@ledgerhq/types-live";
 import type { KnownDevice } from "@ledgerhq/live-dmk-shared";
 import type { State } from "./index";
 import type { SettingsState } from "./settings";
-
-/**
- * Transport identifier used by the DMK WebHID transport (`webHidIdentifier`).
- * Desktop only connects over WebHID, so all known devices use this transport.
- */
-export const WEB_HID_TRANSPORT_IDENTIFIER: KnownDevice["transport"] = "web-hid";
 
 export type KnownDevicesState = {
   knownDevices: KnownDevice[];
@@ -46,7 +41,7 @@ function mapToWebHidKnownDevice(
   name: string | null = null,
 ): KnownDevice {
   return {
-    transport: WEB_HID_TRANSPORT_IDENTIFIER,
+    transport: webHidTransportIdentifier,
     deviceModelId,
     id: "",
     name,
@@ -72,7 +67,7 @@ export function mapDeviceToKnownDevice(device: Device | null | undefined): Known
 export function mapKnownDeviceToPersistedKnownDevice(
   device: KnownDevice,
 ): PersistedKnownDevice | null {
-  if (device.transport === WEB_HID_TRANSPORT_IDENTIFIER) {
+  if (device.transport === webHidTransportIdentifier) {
     return { ...device, transport: "webhid" };
   }
 
@@ -87,7 +82,7 @@ export function mapPersistedKnownDeviceToKnownDevice(
   device: Omit<KnownDevice, "transport"> & { transport: string },
 ): KnownDevice | null {
   if (device.transport === "webhid") {
-    return { ...device, transport: WEB_HID_TRANSPORT_IDENTIFIER };
+    return { ...device, transport: webHidTransportIdentifier };
   }
 
   return null;

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9336,6 +9336,58 @@
         "title": "Invalid state",
         "description": "An error occurred. Please try again or contact Ledger support if the issue persists."
       }
+    },
+    "connectDevice": {
+      "common": {
+        "ledgerDevice": "Ledger device",
+        "available": "Available",
+        "notConnected": "Not connected"
+      },
+      "states": {
+        "loading": {
+          "title": "Loading"
+        },
+        "connecting": {
+          "title": "Loading"
+        },
+        "connectionError": {
+          "errors": {
+            "unknown": {
+              "title": "Pairing unsuccessful",
+              "description": "Please try again.",
+              "tip": "Make sure your device is unlocked.",
+              "cta": {
+                "retry": "Try again",
+                "help": "Get help"
+              }
+            }
+          }
+        },
+        "discovering": {
+          "title": "Select a device",
+          "noAvailableDeviceTitle": "Power on and unlock a device"
+        },
+        "discoveryError": {
+          "errors": {
+            "unknown": {
+              "title": "Something went wrong",
+              "description": "Please try again or contact Ledger support.",
+              "cta": {
+                "retry": "Try again"
+              }
+            }
+          }
+        },
+        "noKnownDevice": {
+          "title": "Ledger device required",
+          "description": "To continue, set up or connect your signer.",
+          "connectLedgerDevice": "Connect Ledger device",
+          "noLedgerDevice": "I don't have a Ledger device"
+        },
+        "waitingForSelectedDevice": {
+          "title": "Power on and unlock your {{productName}}"
+        }
+      }
     }
   },
   "pnl": {

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveringState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/components/DiscoveringState.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
-import { ConnectDeviceUIStateTypes, type ConnectDeviceUIState } from "@ledgerhq/live-dmk-mobile";
+import {
+  ConnectDeviceUIStateTypes,
+  type ConnectDeviceUIState,
+  type DisplayedDevice,
+} from "@ledgerhq/live-dmk-mobile";
 import { TrackScreen } from "~/analytics";
 import { useTranslation } from "~/context/Locale";
 import { useSourceFlow } from "../../utils/SourceFlowContext";
@@ -10,6 +14,12 @@ import { DeviceListItem } from "./DeviceListItem";
 type DiscoveringStateProps = {
   state: Extract<ConnectDeviceUIState, { type: ConnectDeviceUIStateTypes.Discovering }>;
 };
+
+function getDeviceKey(device: DisplayedDevice, index: number): string {
+  const { deviceModelId, id, name, transport } = device.knownDevice;
+
+  return `${transport}:${deviceModelId}:${id || name || index}`;
+}
 
 export function DiscoveringState({ state }: Readonly<DiscoveringStateProps>): React.ReactNode {
   const { t } = useTranslation();
@@ -27,8 +37,8 @@ export function DiscoveringState({ state }: Readonly<DiscoveringStateProps>): Re
         {t("deviceIntentExecutor.connectDevice.states.discovering.title")}
       </Text>
       <Box>
-        {state.devices.map(device => (
-          <DeviceListItem key={device.knownDevice.id} device={device} />
+        {state.devices.map((device, index) => (
+          <DeviceListItem key={getDeviceKey(device, index)} device={device} />
         ))}
       </Box>
     </Box>

--- a/libs/live-dmk-desktop/src/connectDevice/ConnectDevice.test.ts
+++ b/libs/live-dmk-desktop/src/connectDevice/ConnectDevice.test.ts
@@ -1,0 +1,72 @@
+import type { DeviceManagementKit } from "@ledgerhq/device-management-kit";
+import { webHidIdentifier as webHidTransportIdentifier } from "@ledgerhq/device-transport-kit-web-hid";
+import {
+  connectDeviceUseCase as sharedConnectDeviceUseCase,
+  DefaultDeviceDiscoveryService,
+  type KnownDevice,
+} from "@ledgerhq/live-dmk-shared";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { EMPTY } from "rxjs";
+
+import { connectDevice } from "./connectDevice";
+import { WebHidDeviceDiscoverySource } from "./discoveryService/sources/WebHidDeviceDiscoverySource";
+import { createConnectionError, filterMatchedDevices } from "./utils";
+
+jest.mock("@ledgerhq/live-dmk-shared", () => {
+  const actual = jest.requireActual("@ledgerhq/live-dmk-shared");
+
+  return {
+    ...actual,
+    connectDeviceUseCase: jest.fn(() => EMPTY),
+  };
+});
+
+jest.mock("./discoveryService/sources/WebHidDeviceDiscoverySource", () => ({
+  WebHidDeviceDiscoverySource: jest.fn().mockImplementation(() => ({
+    listen: jest.fn(),
+    transportId: "WEB-HID",
+  })),
+}));
+
+const mockedSharedConnectDeviceUseCase = jest.mocked(sharedConnectDeviceUseCase);
+
+const knownDevice: KnownDevice = {
+  transport: webHidTransportIdentifier,
+  deviceModelId: DeviceModelId.nanoX,
+  id: "",
+  name: "Ledger Nano X",
+};
+
+describe("desktop connectDevice", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("GIVEN connect input, WHEN connecting on desktop, THEN it should delegate to the shared use case with WebHID dependencies", () => {
+    // GIVEN
+    const dmk = {} as DeviceManagementKit;
+    const onConnected = jest.fn();
+    const acceptedDeviceModelIds = [DeviceModelId.nanoX];
+
+    // WHEN
+    const result = connectDevice({
+      acceptedDeviceModelIds,
+      dmk,
+      knownDevices: [knownDevice],
+      onConnected,
+    });
+
+    // THEN
+    expect(result).toBe(EMPTY);
+    expect(WebHidDeviceDiscoverySource).toHaveBeenCalledWith(dmk);
+    expect(mockedSharedConnectDeviceUseCase).toHaveBeenCalledWith({
+      acceptedDeviceModelIds,
+      dmk,
+      knownDevices: [knownDevice],
+      onConnected,
+      deviceDiscoveryService: expect.any(DefaultDeviceDiscoveryService),
+      matchDiscoveredDevices: filterMatchedDevices,
+      mapConnectionError: createConnectionError,
+    });
+  });
+});

--- a/libs/live-dmk-desktop/src/connectDevice/connectDevice.ts
+++ b/libs/live-dmk-desktop/src/connectDevice/connectDevice.ts
@@ -1,0 +1,39 @@
+import type { DeviceManagementKit, TransportIdentifier } from "@ledgerhq/device-management-kit";
+import {
+  connectDeviceUseCase,
+  DefaultDeviceDiscoveryService,
+  type DeviceConnectionResult,
+  type DeviceDiscoverySource,
+  type KnownDevice,
+} from "@ledgerhq/live-dmk-shared";
+import type { DeviceModelId } from "@ledgerhq/types-devices";
+import type { Observable } from "rxjs";
+
+import { WebHidDeviceDiscoverySource } from "./discoveryService/sources/WebHidDeviceDiscoverySource";
+import { type DesktopConnectDeviceUIState, type DesktopDiscoveryError } from "./types";
+import { createConnectionError, filterMatchedDevices } from "./utils";
+
+export type ConnectDeviceInput = {
+  knownDevices: Array<KnownDevice>;
+  acceptedDeviceModelIds?: Array<DeviceModelId>;
+  dmk: DeviceManagementKit;
+  onConnected: (result: DeviceConnectionResult) => void;
+};
+
+export function connectDevice(input: ConnectDeviceInput): Observable<DesktopConnectDeviceUIState> {
+  const webHidSource = new WebHidDeviceDiscoverySource(input.dmk);
+  const discoverySources: Map<
+    TransportIdentifier,
+    DeviceDiscoverySource<DesktopDiscoveryError>
+  > = new Map();
+  discoverySources.set(webHidSource.transportId, webHidSource);
+
+  return connectDeviceUseCase({
+    ...input,
+    deviceDiscoveryService: new DefaultDeviceDiscoveryService<DesktopDiscoveryError>(
+      discoverySources,
+    ),
+    matchDiscoveredDevices: filterMatchedDevices,
+    mapConnectionError: createConnectionError,
+  });
+}

--- a/libs/live-dmk-desktop/src/connectDevice/discoveryService/sources/WebHidDeviceDiscoverySource.test.ts
+++ b/libs/live-dmk-desktop/src/connectDevice/discoveryService/sources/WebHidDeviceDiscoverySource.test.ts
@@ -1,0 +1,56 @@
+import type { DeviceManagementKit, DiscoveredDevice } from "@ledgerhq/device-management-kit";
+import { firstValueFrom, of, throwError } from "rxjs";
+
+import { BaseDiscoveryErrorTypes } from "../../types";
+import { webHidIdentifier as webHidTransportIdentifier } from "@ledgerhq/device-transport-kit-web-hid";
+import { WebHidDeviceDiscoverySource } from "./WebHidDeviceDiscoverySource";
+
+const createMockDMK = (listenToAvailableDevices: jest.Mock): DeviceManagementKit =>
+  ({ listenToAvailableDevices }) as unknown as DeviceManagementKit;
+
+const createDiscoveredDevice = (id: string): DiscoveredDevice =>
+  ({
+    id,
+    name: id,
+    deviceModel: { id: "model", model: "model", name: "model" },
+    transport: webHidTransportIdentifier,
+  }) as unknown as DiscoveredDevice;
+
+describe("WebHidDeviceDiscoverySource", () => {
+  it("GIVEN WebHID discovery emits devices, WHEN listening, THEN it should emit discovered devices", async () => {
+    // GIVEN
+    const devices = [createDiscoveredDevice("webhid-1")];
+    const listenToAvailableDevices = jest.fn().mockReturnValue(of(devices));
+    const source = new WebHidDeviceDiscoverySource(createMockDMK(listenToAvailableDevices));
+
+    // WHEN
+    const event = firstValueFrom(source.listen());
+
+    // THEN
+    await expect(event).resolves.toEqual({
+      type: "devices",
+      devices,
+    });
+    expect(listenToAvailableDevices).toHaveBeenCalledWith({ transport: webHidTransportIdentifier });
+  });
+
+  it("GIVEN WebHID discovery fails, WHEN listening, THEN it should emit an unknown discovery error", async () => {
+    // GIVEN
+    const error = new Error("webhid failure");
+    const listenToAvailableDevices = jest.fn().mockReturnValue(throwError(() => error));
+    const source = new WebHidDeviceDiscoverySource(createMockDMK(listenToAvailableDevices));
+
+    // WHEN
+    const event = firstValueFrom(source.listen());
+
+    // THEN
+    await expect(event).resolves.toEqual({
+      type: "error",
+      error: {
+        type: BaseDiscoveryErrorTypes.Unknown,
+        transportId: webHidTransportIdentifier,
+        error,
+      },
+    });
+  });
+});

--- a/libs/live-dmk-desktop/src/connectDevice/discoveryService/sources/WebHidDeviceDiscoverySource.ts
+++ b/libs/live-dmk-desktop/src/connectDevice/discoveryService/sources/WebHidDeviceDiscoverySource.ts
@@ -1,0 +1,43 @@
+import type { DeviceManagementKit } from "@ledgerhq/device-management-kit";
+import type { DeviceDiscoverySource, DeviceDiscoverySourceEvent } from "@ledgerhq/live-dmk-shared";
+import { catchError, map, of, type Observable } from "rxjs";
+
+import { BaseDiscoveryErrorTypes, type DesktopDiscoveryError } from "../../types";
+import { webHidIdentifier as webHidTransportIdentifier } from "@ledgerhq/device-transport-kit-web-hid";
+
+type DesktopDeviceDiscoverySource = DeviceDiscoverySource<DesktopDiscoveryError>;
+type DesktopDeviceDiscoverySourceEvent = DeviceDiscoverySourceEvent<DesktopDiscoveryError>;
+
+export class WebHidDeviceDiscoverySource implements DesktopDeviceDiscoverySource {
+  readonly transportId = webHidTransportIdentifier;
+
+  constructor(private readonly dmk: DeviceManagementKit) {}
+
+  listen(): Observable<DesktopDeviceDiscoverySourceEvent> {
+    return this.dmk
+      .listenToAvailableDevices({
+        transport: this.transportId,
+      })
+      .pipe(
+        map(
+          devices =>
+            ({
+              type: "devices",
+              devices,
+            }) as const,
+        ),
+        catchError(error => {
+          const event: DesktopDeviceDiscoverySourceEvent = {
+            type: "error",
+            error: {
+              type: BaseDiscoveryErrorTypes.Unknown,
+              transportId: this.transportId,
+              error,
+            },
+          };
+
+          return of(event);
+        }),
+      );
+  }
+}

--- a/libs/live-dmk-desktop/src/connectDevice/types.ts
+++ b/libs/live-dmk-desktop/src/connectDevice/types.ts
@@ -1,0 +1,20 @@
+import type {
+  ConnectDeviceUIState,
+  UnknownConnectionError,
+  UnknownDiscoveryError,
+} from "@ledgerhq/live-dmk-shared";
+
+export {
+  BaseConnectionErrorTypes,
+  BaseDiscoveryErrorTypes,
+  ConnectDeviceUIStateTypes,
+} from "@ledgerhq/live-dmk-shared";
+
+export type DesktopConnectionError = UnknownConnectionError;
+
+export type DesktopDiscoveryError = UnknownDiscoveryError;
+
+export type DesktopConnectDeviceUIState = ConnectDeviceUIState<
+  DesktopDiscoveryError,
+  DesktopConnectionError
+>;

--- a/libs/live-dmk-desktop/src/connectDevice/utils.test.ts
+++ b/libs/live-dmk-desktop/src/connectDevice/utils.test.ts
@@ -1,0 +1,118 @@
+import {
+  DeviceModelId as DMKDeviceModelId,
+  type DiscoveredDevice,
+} from "@ledgerhq/device-management-kit";
+import { webHidIdentifier as webHidTransportIdentifier } from "@ledgerhq/device-transport-kit-web-hid";
+import type { KnownDevice } from "@ledgerhq/live-dmk-shared";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+
+import { BaseConnectionErrorTypes } from "./types";
+import { createConnectionError, filterMatchedDevices } from "./utils";
+
+const knownDeviceA: KnownDevice = {
+  transport: webHidTransportIdentifier,
+  deviceModelId: DeviceModelId.nanoX,
+  id: "",
+  name: "Ledger Nano X",
+};
+
+const knownDeviceB: KnownDevice = {
+  transport: webHidTransportIdentifier,
+  deviceModelId: DeviceModelId.nanoSP,
+  id: "",
+  name: "Ledger Nano S Plus",
+};
+
+const makeDiscoveredDevice = ({
+  id = "discovered-device-a",
+  name = "Ledger Nano X",
+  model = DMKDeviceModelId.NANO_X,
+  deviceModelId = DeviceModelId.nanoX,
+  transport = webHidTransportIdentifier,
+}: {
+  id?: string;
+  name?: string;
+  model?: DMKDeviceModelId;
+  deviceModelId?: DiscoveredDevice["deviceModel"]["id"];
+  transport?: DiscoveredDevice["transport"];
+} = {}): DiscoveredDevice =>
+  ({
+    id,
+    name,
+    deviceModel: {
+      id: deviceModelId,
+      model,
+      name,
+    },
+    transport,
+  }) as DiscoveredDevice;
+
+describe("desktop connectDevice utils", () => {
+  describe("filterMatchedDevices", () => {
+    it("GIVEN a WebHID known device with the same model, WHEN filtering, THEN it should match", () => {
+      // GIVEN
+      const discoveredDevice = makeDiscoveredDevice();
+
+      // WHEN / THEN
+      expect(filterMatchedDevices([discoveredDevice], [knownDeviceA])).toEqual([
+        { knownDevice: knownDeviceA, discoveredDevice },
+      ]);
+    });
+
+    it("GIVEN a legacy lowercase WebHID transport, WHEN filtering, THEN it should not match", () => {
+      // GIVEN
+      const discoveredDevice = makeDiscoveredDevice({ transport: "web-hid" });
+
+      // WHEN / THEN
+      expect(filterMatchedDevices([discoveredDevice], [knownDeviceA])).toEqual([]);
+    });
+
+    it("GIVEN a WebHID known device with another model, WHEN filtering, THEN it should not match", () => {
+      // GIVEN
+      const discoveredDevice = makeDiscoveredDevice();
+
+      // WHEN / THEN
+      expect(filterMatchedDevices([discoveredDevice], [knownDeviceB])).toEqual([]);
+    });
+
+    it("GIVEN a discovered device from another transport, WHEN filtering, THEN it should not match", () => {
+      // GIVEN
+      const discoveredDevice = makeDiscoveredDevice({ transport: "ble" });
+
+      // WHEN / THEN
+      expect(filterMatchedDevices([discoveredDevice], [knownDeviceA])).toEqual([]);
+    });
+
+    it("GIVEN multiple discovered devices, WHEN filtering, THEN it should return the matching models only", () => {
+      // GIVEN
+      const unmatchedDiscoveredDevice = makeDiscoveredDevice({
+        model: DMKDeviceModelId.STAX,
+        deviceModelId: DeviceModelId.stax,
+      });
+      const matchedDiscoveredDevice = makeDiscoveredDevice({
+        id: "nano-sp",
+        name: "Ledger Nano S Plus",
+        model: DMKDeviceModelId.NANO_SP,
+        deviceModelId: DeviceModelId.nanoSP,
+      });
+
+      // WHEN / THEN
+      expect(
+        filterMatchedDevices([unmatchedDiscoveredDevice, matchedDiscoveredDevice], [knownDeviceB]),
+      ).toEqual([{ knownDevice: knownDeviceB, discoveredDevice: matchedDiscoveredDevice }]);
+    });
+  });
+
+  describe("createConnectionError", () => {
+    it("GIVEN any connection error, WHEN mapping it, THEN it should return an unknown error", () => {
+      // GIVEN
+      const error = new Error("unknown error");
+
+      // WHEN / THEN
+      expect(createConnectionError(error)).toEqual({
+        type: BaseConnectionErrorTypes.Unknown,
+        error,
+      });
+    });
+  });
+});

--- a/libs/live-dmk-desktop/src/connectDevice/utils.ts
+++ b/libs/live-dmk-desktop/src/connectDevice/utils.ts
@@ -1,0 +1,45 @@
+import type { DiscoveredDevice } from "@ledgerhq/device-management-kit";
+import { webHidIdentifier as webHidTransportIdentifier } from "@ledgerhq/device-transport-kit-web-hid";
+import {
+  dmkToLedgerDeviceIdMap,
+  type KnownDevice,
+  type MatchedDevice,
+} from "@ledgerhq/live-dmk-shared";
+
+import { BaseConnectionErrorTypes, type DesktopConnectionError } from "./types";
+
+export const filterMatchedDevices = (
+  discoveredDevices: DiscoveredDevice[],
+  knownDevices: KnownDevice[],
+): MatchedDevice[] => {
+  return discoveredDevices
+    .map(device => {
+      if (device.transport !== webHidTransportIdentifier) {
+        return null;
+      }
+
+      const matchedDevice = knownDevices.find(knownDevice => {
+        if (device.transport !== knownDevice.transport) {
+          return false;
+        }
+
+        if (knownDevice.transport === webHidTransportIdentifier) {
+          return dmkToLedgerDeviceIdMap[device.deviceModel.model] === knownDevice.deviceModelId;
+        }
+
+        return false;
+      });
+
+      if (!matchedDevice) {
+        return null;
+      }
+
+      return matchedDevice ? { knownDevice: matchedDevice, discoveredDevice: device } : null;
+    })
+    .filter((matchedDevice): matchedDevice is MatchedDevice => matchedDevice !== null);
+};
+
+export const createConnectionError = (error: unknown): DesktopConnectionError => ({
+  type: BaseConnectionErrorTypes.Unknown,
+  error,
+});

--- a/libs/live-dmk-desktop/src/index.ts
+++ b/libs/live-dmk-desktop/src/index.ts
@@ -6,4 +6,15 @@ export {
   isInvalidGetFirmwareMetadataResponseError,
   isDmkError,
 } from "./errors";
+export {
+  BaseConnectionErrorTypes,
+  BaseDiscoveryErrorTypes,
+  ConnectDeviceUIStateTypes,
+  type DesktopConnectionError as ConnectionError,
+  type DesktopDiscoveryError as DiscoveryError,
+  type DesktopConnectDeviceUIState as ConnectDeviceUIState,
+} from "./connectDevice/types";
+export type { DisplayedDevice } from "@ledgerhq/live-dmk-shared";
+export { connectDevice, type ConnectDeviceInput } from "./connectDevice/connectDevice";
+export { webHidIdentifier as webHidTransportIdentifier } from "@ledgerhq/device-transport-kit-web-hid";
 export type { DmkError } from "@ledgerhq/device-management-kit";

--- a/libs/live-dmk-shared/src/connectDevice/ConnectDeviceStateMachine.ts
+++ b/libs/live-dmk-shared/src/connectDevice/ConnectDeviceStateMachine.ts
@@ -504,6 +504,7 @@ export class DefaultConnectDeviceStateMachine<
 
   stop(): void {
     const snapshot = this.actor.getSnapshot();
+
     if (snapshot.context.isDiscovering) {
       this.deviceDiscoveryService.stop();
     }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Desktop Device Intent Executor connect-device flow and state handling
  - Known-device persistence and migration from existing last-seen/onboarded device storage
  - WebHID desktop device discovery and serialization helpers
  - Developer settings playground for DIE initialization scenarios

### 📝 Description

This PR implements the Ledger Wallet Desktop connect-device flow for Device Intent Executor.

https://github.com/user-attachments/assets/86351400-9c51-4ec7-81f2-0e70e8b6599b

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33000](https://ledgerhq.atlassian.net/browse/LIVE-33000)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33000]: https://ledgerhq.atlassian.net/browse/LIVE-33000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ