### PR TITLE
fix(feature-flag): env flags should still be applied when remote fetc…

### DIFF
--- a/shared/feature-flags/src/data/middleware.ts
+++ b/shared/feature-flags/src/data/middleware.ts
@@ -112,9 +112,10 @@ function getMeta(action: Action<string>) {
 
 /**
  * Self-rescheduling poll loop: fetches remote flags, writes them to the ref on
- * success, dispatches the update, signals readiness, then schedules the next
- * iteration. A failed fetch resolves to `null` (via `.catch`), leaves the ref
- * untouched, and still re-schedules so transient errors don't kill the loop.
+ * success, updates the ref, re-resolves flags (so env overrides still apply when
+ * remote is empty), signals readiness, then schedules the next iteration. A
+ * failed fetch resolves to `null` (via `.catch`), leaves the ref untouched, still
+ * re-resolves, and re-schedules so transient errors don't kill the loop.
  *
  * @param fetch
  * Async callback that returns the latest remote flags map.
@@ -146,8 +147,8 @@ async function pollRemoteFlags(
   const remote = await fetch().catch(() => null);
   if (remote !== null) {
     ref.current = remote;
-    dispatchSync();
   }
+  dispatchSync();
   dispatchReady();
   setTimeout(pollRemoteFlags, ms, fetch, ref, dispatchSync, dispatchReady, ms);
 }

--- a/shared/feature-flags/src/data/slice.test.ts
+++ b/shared/feature-flags/src/data/slice.test.ts
@@ -325,8 +325,7 @@ describe("middleware behavior", () => {
 
     jest.advanceTimersByTime(1_000);
     await flushPromises();
-    // Reducer state is unchanged because syncRemoteConfig is not dispatched on failure;
-    // the previous resolved value remains visible.
+    // Remote cache is unchanged on failure; resolved value stays as after the last sync.
     expect(store.getState().featureFlags.resolved.mockFeature.enabled).toBe(true);
   });
 
@@ -345,9 +344,28 @@ describe("middleware behavior", () => {
     const store = createStore(undefined, { fetchRemoteFlags: fetcher, refreshInterval: 1_000 });
 
     await flushPromises();
-    // syncRemoteConfig never fires on failure, so resolved stays at defaults.
     expect(store.getState().featureFlags.remoteFlagsReady).toBe(true);
     expect(store.getState().featureFlags.resolved.mockFeature).toEqual(defaults.mockFeature);
+  });
+
+  it("uses envFlags when the first fetch rejects", async () => {
+    const fetcher = jest.fn().mockRejectedValue(new Error("network down"));
+    const store = createStore(undefined, {
+      resolutionConfig: {
+        envFlags: { mockFeature: { enabled: true, params: { fromEnv: true } } },
+      },
+      fetchRemoteFlags: fetcher,
+      refreshInterval: 1_000,
+    });
+
+    await flushPromises();
+    expect(store.getState().featureFlags.remoteFlagsReady).toBe(true);
+    expect(store.getState().featureFlags.resolved.mockFeature).toEqual({
+      enabled: true,
+      params: { fromEnv: true },
+      overriddenByEnv: true,
+      overridesRemote: true,
+    });
   });
 
   it("does not schedule any timer when fetchRemoteFlags is omitted", () => {


### PR DESCRIPTION
…h fails

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Sometimes Firebase fetch fails and fallback ff values are applied.
We need to make sure env flags are still applied and take precedence over defaults.
Adding a test to cover this scope.

What it exercises:
- fetchRemoteFlags rejects (simulated Firebase 429 / network error).
- envFlags is set on resolutionConfig (like desktop’s FEATURE_FLAGS env).
- After the fetch settles, resolved.mockFeature comes from env, not remote or schema defaults.

Middleware change required:
- Previously syncRemoteConfig() only ran on success, so envFlags were never applied when remote failed.
- pollRemoteFlags now always calls dispatchSync() after each attempt.


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
