### PR TITLE
[LWD] chore(lld): upgrade Electron to 42.5.0

### DIFF
--- a/.changeset/upgrade-electron-42.md
+++ b/.changeset/upgrade-electron-42.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+chore(lld): upgrade Electron from 40.6.0 to 42.5.0

--- a/apps/ledger-live-desktop/tests/utils/global.setup.ts
+++ b/apps/ledger-live-desktop/tests/utils/global.setup.ts
@@ -1,8 +1,10 @@
 import fs from "fs";
+import { execFileSync } from "child_process";
 import { FullConfig } from "@playwright/test";
 import { responseLogfilePath } from "./networkResponseLogger";
 
 export default async function globalSetup(_config: FullConfig) {
+  ensureElectronBinary();
   if (responseLogfilePath) {
     fs.unlink(responseLogfilePath, error => {
       if (error) {
@@ -12,4 +14,9 @@ export default async function globalSetup(_config: FullConfig) {
       console.log("Previous response.log file removed");
     });
   }
+}
+
+// Electron 42+ downloads its binary on first run rather than at install time; do it once here so parallel workers don't race extracting into dist/.
+function ensureElectronBinary() {
+  execFileSync(process.execPath, [require.resolve("electron/install.js")], { stdio: "inherit" });
 }

--- a/e2e/desktop/tests/utils/global.setup.ts
+++ b/e2e/desktop/tests/utils/global.setup.ts
@@ -1,4 +1,5 @@
 import { FullConfig } from "@playwright/test";
+import { execFileSync } from "child_process";
 import { responseLogfilePath } from "./networkResponseLogger";
 import { mkdirSync, promises as fs, unlink, writeFileSync } from "fs";
 import {
@@ -12,6 +13,7 @@ import { NANO_APP_CATALOG_PATH } from "./fileUtils";
 const environmentFilePath = "allure-results/environment.properties";
 
 export default async function globalSetup(_config: FullConfig) {
+  ensureElectronBinary();
   await cleanupPreviousNanoAppJsonFile();
   if (responseLogfilePath) {
     unlink(responseLogfilePath, error => {
@@ -40,6 +42,11 @@ export default async function globalSetup(_config: FullConfig) {
     ].join("\n"),
     { encoding: "utf8", flag: "w" },
   );
+}
+
+// Electron 42+ downloads its binary on first run rather than at install time; do it once here so parallel workers don't race extracting into dist/.
+function ensureElectronBinary() {
+  execFileSync(process.execPath, [require.resolve("electron/install.js")], { stdio: "inherit" });
 }
 
 async function cleanupPreviousNanoAppJsonFile() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,8 +319,8 @@ catalogs:
       specifier: 20.51.3
       version: 20.51.3
     electron:
-      specifier: 40.6.0
-      version: 40.6.0
+      specifier: 42.5.0
+      version: 42.5.0
     eslint-plugin-better-tailwindcss:
       specifier: 4.0.0-beta.3
       version: 4.0.0-beta.3
@@ -1450,7 +1450,7 @@ importers:
         version: 26.0.1(lodash@4.17.21)
       electron:
         specifier: 'catalog:'
-        version: 40.6.0
+        version: 42.5.0
       electron-builder:
         specifier: 26.0.1
         version: 26.0.1(lodash@4.17.21)
@@ -3226,7 +3226,7 @@ importers:
         version: 4.17.16
       electron:
         specifier: 'catalog:'
-        version: 40.6.0
+        version: 42.5.0
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -15632,6 +15632,10 @@ packages:
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
     engines: {node: '>=0.8.0'}
 
+  '@electron-internal/extract-zip@1.0.4':
+    resolution: {integrity: sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==}
+    engines: {node: '>=22.12.0'}
+
   '@electron/asar@3.2.18':
     resolution: {integrity: sha512-2XyvMe3N3Nrs8cV39IKELRHTYUWFKrmqqSY1U+GMlc0jvqjIVnoxhNd2H4JolWQncbJi1DCvb5TNxZuI2fEjWg==}
     engines: {node: '>=10.12.0'}
@@ -15654,6 +15658,10 @@ packages:
   '@electron/get@2.0.3':
     resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
     engines: {node: '>=12'}
+
+  '@electron/get@5.0.0':
+    resolution: {integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==}
+    engines: {node: '>=22.12.0'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
     resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
@@ -24043,7 +24051,7 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
+    deprecated: this version is no longer supported, please update to at least 0.8.*
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -24392,7 +24400,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -27204,9 +27212,9 @@ packages:
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
-  electron@40.6.0:
-    resolution: {integrity: sha512-ett8W+yOFGDuM0vhJMamYSkrbV3LoaffzJd9GfjI96zRAxyrNqUSKqBpf/WGbQCweDxX2pkUCUfrv4wwKpsFZA==}
-    engines: {node: '>= 12.20.55'}
+  electron@42.5.0:
+    resolution: {integrity: sha512-cYEKS9XFz+c9fAB4jI0x49yz1FFzB55r3q96wu9YkwwJMv7t9202IE/ltlgy6yitl/J4M7C8JQcmUqdzDvPl/w==}
+    engines: {node: '>= 22.12.0'}
     hasBin: true
 
   elegant-spinner@1.0.1:
@@ -33634,6 +33642,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode-terminal@0.11.0:
@@ -36521,6 +36530,10 @@ packages:
 
   undici@7.18.2:
     resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unfetch@3.1.2:
@@ -42301,6 +42314,8 @@ snapshots:
     dependencies:
       '@types/hammerjs': 2.0.45
 
+  '@electron-internal/extract-zip@1.0.4': {}
+
   '@electron/asar@3.2.18':
     dependencies:
       commander: 5.1.0
@@ -42332,6 +42347,19 @@ snapshots:
       sumchecker: 3.0.1
     optionalDependencies:
       global-agent: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@electron/get@5.0.0':
+    dependencies:
+      debug: 4.4.3
+      env-paths: 3.0.0
+      graceful-fs: 4.2.11
+      progress: 2.0.3
+      semver: 7.8.1
+      sumchecker: 3.0.1
+    optionalDependencies:
+      undici: 7.28.0
     transitivePeerDependencies:
       - supports-color
 
@@ -59416,11 +59444,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@40.6.0:
+  electron@42.5.0:
     dependencies:
-      '@electron/get': 2.0.3
+      '@electron-internal/extract-zip': 1.0.4
+      '@electron/get': 5.0.0
       '@types/node': 24.12.0
-      extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -72176,6 +72204,9 @@ snapshots:
   undici@6.19.2: {}
 
   undici@7.18.2: {}
+
+  undici@7.28.0:
+    optional: true
 
   unfetch@3.1.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -133,7 +133,7 @@ catalog:
   bs58check: ^2.1.2
   class-variance-authority: 0.7.1
   clsx: 2.1.1
-  electron: 40.6.0
+  electron: 42.5.0
   eslint-plugin-better-tailwindcss: 4.0.0-beta.3
   eslint-plugin-jest: 27.9.0
   ethers: 6.15.0


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- Desktop build + E2E + Ubuntu Mock validate the runtime upgrade. -->
- [x] **Impact of the changes:** Electron runtime bump for ledger-live-desktop. QA should focus on:
  - App launch, auto-update flow, and native module behaviour (USB/HID device connection).
  - Window management, deep links, tray/notifications.

### 📝 Description

Upgrade Electron from 40.6.0 to 42.5.0 (latest stable) via the pnpm catalog.

No application code changes were required. Reviewed breaking changes for Electron 41 and 42; none affect runtime code:
- `Session.clearStorageData(options)` dropped the `quotas` option — we call `clearStorageData()` with no args.
- macOS migrated `NSUserNotification` -> `UNNotification` — no `Notification` usage in main process source.
- PDF guest-WebContents removal, offscreen-rendering scale change, Linux `showHiddenFiles` deprecation — all unused.

**E2E fix included.** Electron 42 stopped downloading its binary at install time — it now fetches it on first run. In CI the parallel Playwright workers each triggered the download and raced extracting into `dist/` (`File exists (os error 17)`), which broke the Desktop E2E and Ubuntu Mock suites. Fixed by materializing the binary once in each Playwright `globalSetup`, before workers spawn:

```ts
// Electron 42+ downloads its binary on first run rather than at install time.
function ensureElectronBinary() {
  execFileSync(process.execPath, [require.resolve("electron/install.js")], { stdio: "inherit" });
}
```

Verified locally: native deps rebuilt against electronVersion 42.5.0, typecheck passes, full production JS build compiles, production build is green on macOS/Linux/Windows, and the binary pre-download is idempotent + restores a missing `dist/`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27552](https://ledgerhq.atlassian.net/browse/LIVE-27552)
- **ADR link (if any)**: N/A


[LIVE-27552]: https://ledgerhq.atlassian.net/browse/LIVE-27552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ