### PR TITLE
[LWDM] fix(coin-cardano): avoid mutating frozen account state during sync (LIVE-33264)

### DIFF
--- a/.changeset/cardano-frozen-account-sync-fix.md
+++ b/.changeset/cardano-frozen-account-sync-fix.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-cardano": patch
+---
+
+cardano: fix account sync TypeError by cloning frozen credentials instead of mutating in place

--- a/libs/coin-modules/coin-cardano/src/api/getTransactions.ts
+++ b/libs/coin-modules/coin-cardano/src/api/getTransactions.ts
@@ -95,8 +95,9 @@ async function getSyncedTransactionsByChain(
   };
   transactions.forEach(trx => {
     [...trx.inputs, ...trx.outputs].forEach(io => {
-      if (availablePaymentCredentialsMap[io.paymentKey]) {
-        availablePaymentCredentialsMap[io.paymentKey].isUsed = true;
+      const credential = availablePaymentCredentialsMap[io.paymentKey];
+      if (credential) {
+        availablePaymentCredentialsMap[io.paymentKey] = { ...credential, isUsed: true };
       }
     });
   });

--- a/libs/coin-modules/coin-cardano/src/api/getTransactions.unit.test.ts
+++ b/libs/coin-modules/coin-cardano/src/api/getTransactions.unit.test.ts
@@ -1,0 +1,58 @@
+import { getTransactions } from "./getTransactions";
+import { getAllTransactionsByKeys } from "./fetchTransactions";
+import { CardanoAccount } from "../types";
+
+jest.mock("./fetchTransactions");
+
+const deepFreeze = <T>(value: T): T => {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    Object.values(value).forEach(deepFreeze);
+  }
+  return value;
+};
+
+const xpub =
+  "2b7203eaac6970424a3c03c6523d73d5c5c8608bbdb2da6cac0fa818a550070226ff4d533833edaf32c8153559089195376128ae9f533a5e89fc4c256a50f6df";
+
+describe("getTransactions — sync must not mutate frozen initialAccount credentials", () => {
+  it("does not mutate frozen credentials sourced from initialAccount", async () => {
+    const usedKey = "bd2717d482fa89b20f7ba1299344d203d14cfa231d8da9847aa51e07"; // gitleaks:allow
+    const initialAccount = deepFreeze({
+      cardanoResources: {
+        externalCredentials: [
+          {
+            isUsed: false,
+            key: usedKey,
+            path: { account: 0, chain: 0, coin: 1815, index: 0, purpose: 1852 },
+          },
+        ],
+        internalCredentials: [],
+      },
+    } as unknown as CardanoAccount);
+
+    jest.mocked(getAllTransactionsByKeys).mockResolvedValue({
+      transactions: [
+        {
+          fees: "0",
+          hash: "tx1",
+          timestamp: "2024-01-01T00:00:00.000Z",
+          blockHeight: 1,
+          inputs: [],
+          outputs: [{ address: "addr", value: "5", paymentKey: usedKey, tokens: [] }],
+          certificate: {
+            stakeRegistrations: [],
+            stakeDeRegistrations: [],
+            stakeDelegations: [],
+          },
+        },
+      ],
+      blockHeight: 1,
+    } as any);
+
+    const result = await getTransactions(xpub, 0, initialAccount, 0, { id: "cardano" } as any);
+
+    expect(result.externalCredentials.find(c => c.key === usedKey)?.isUsed).toBe(true);
+    expect(initialAccount.cardanoResources.externalCredentials[0].isUsed).toBe(false);
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/buildTransaction.test.ts
+++ b/libs/coin-modules/coin-cardano/src/buildTransaction.test.ts
@@ -195,4 +195,122 @@ describe("buildTransaction", () => {
       expect(registerCertificate).toBeUndefined();
     });
   });
+
+  describe("frozen account state — UTXO selection must not sort in place", () => {
+    const deepFreeze = <T>(value: T): T => {
+      if (value && typeof value === "object" && !Object.isFrozen(value)) {
+        Object.freeze(value);
+        Object.values(value).forEach(deepFreeze);
+      }
+      return value;
+    };
+
+    const makeTwoUtxos = () => [
+      {
+        hash: "e807160f59455ffc011e6d0a48c0922645797707b8520788f176ca21f2b49561",
+        index: 0,
+        address:
+          "00bd2717d482fa89b20f7ba1299344d203d14cfa231d8da9847aa51e07db5e8ece0982acc4883de67c2e3411cc26bd56686a162074998c02bc",
+        amount: new BigNumber(20e6),
+        tokens: [],
+        paymentCredential: {
+          key: "bd2717d482fa89b20f7ba1299344d203d14cfa231d8da9847aa51e07", // gitleaks:allow
+          path: { account: 0, chain: 0, coin: 1815, index: 0, purpose: 1852 },
+        },
+      },
+      {
+        hash: "f918271a6a566aad122f7e1b59d1a33756808818c9631899a287db32e3c5a672",
+        index: 1,
+        address:
+          "00bd2717d482fa89b20f7ba1299344d203d14cfa231d8da9847aa51e07db5e8ece0982acc4883de67c2e3411cc26bd56686a162074998c02bc",
+        amount: new BigNumber(100e6),
+        tokens: [],
+        paymentCredential: {
+          key: "bd2717d482fa89b20f7ba1299344d203d14cfa231d8da9847aa51e07", // gitleaks:allow
+          path: { account: 0, chain: 0, coin: 1815, index: 0, purpose: 1852 },
+        },
+      },
+    ];
+
+    it("builds a send transaction without mutating the frozen utxo array", async () => {
+      const account = deepFreeze(
+        getCardanoAccountFixture({ delegation: undefined, utxos: makeTwoUtxos() }),
+      );
+      await expect(buildTransaction(account, txPayload)).resolves.toBeDefined();
+    });
+
+    it("builds a send-all transaction without mutating the frozen utxo array", async () => {
+      const account = deepFreeze(
+        getCardanoAccountFixture({ delegation: undefined, utxos: makeTwoUtxos() }),
+      );
+      await expect(
+        buildTransaction(account, { ...txPayload, useAllAmount: true }),
+      ).resolves.toBeDefined();
+    });
+
+    it("builds a delegate transaction without mutating the frozen utxo array", async () => {
+      const account = deepFreeze(
+        getCardanoAccountFixture({
+          delegation: { status: true, deposit: (2e6).toString(), rewards: new BigNumber(0) },
+          utxos: makeTwoUtxos(),
+        }),
+      );
+      await expect(
+        buildTransaction(account, {
+          ...txPayload,
+          recipient: "",
+          amount: new BigNumber(0),
+          mode: "delegate",
+          poolId: "7df262feae9201d1b2e32d4c825ca91b29fbafb2b8e556f6efb7f549",
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    it("builds an undelegate transaction without mutating the frozen utxo array", async () => {
+      const account = deepFreeze(
+        getCardanoAccountFixture({
+          delegation: { status: true, deposit: (2e6).toString(), rewards: new BigNumber(0) },
+          utxos: makeTwoUtxos(),
+        }),
+      );
+      await expect(
+        buildTransaction(account, {
+          ...txPayload,
+          recipient: "",
+          amount: new BigNumber(0),
+          mode: "undelegate",
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    it("builds a token-send transaction without mutating the frozen utxo/token arrays", async () => {
+      const policyId = "a".repeat(56);
+      const assetName = "74657374";
+      const tokenId = `cardano/native/${policyId}${assetName}`;
+      const tokenUtxos = makeTwoUtxos().map(u => ({
+        ...u,
+        tokens: [{ policyId, assetName, amount: new BigNumber(1000) }],
+      }));
+
+      const account = getCardanoAccountFixture({ delegation: undefined, utxos: tokenUtxos });
+      account.cardanoResources.protocolParams = getProtocolParamsFixture();
+      account.subAccounts = [
+        {
+          type: "TokenAccount",
+          id: "token-account-1",
+          token: { id: tokenId },
+          balance: new BigNumber(1000),
+        } as any,
+      ];
+      deepFreeze(account);
+
+      await expect(
+        buildTransaction(account, {
+          ...txPayload,
+          subAccountId: "token-account-1",
+          amount: new BigNumber(500),
+        }),
+      ).resolves.toBeDefined();
+    });
+  });
 });

--- a/libs/coin-modules/coin-cardano/src/fixtures/accounts.ts
+++ b/libs/coin-modules/coin-cardano/src/fixtures/accounts.ts
@@ -1,10 +1,32 @@
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { BalanceHistoryCache } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
-import { CardanoAccount, CardanoDelegation } from "../types";
+import { CardanoAccount, CardanoDelegation, CardanoOutput } from "../types";
+
+const getDefaultUtxos = (): Array<CardanoOutput> => [
+  {
+    hash: "e807160f59455ffc011e6d0a48c0922645797707b8520788f176ca21f2b49561",
+    index: 0,
+    address:
+      "00bd2717d482fa89b20f7ba1299344d203d14cfa231d8da9847aa51e07db5e8ece0982acc4883de67c2e3411cc26bd56686a162074998c02bc",
+    amount: new BigNumber(100e6),
+    tokens: [],
+    paymentCredential: {
+      key: "bd2717d482fa89b20f7ba1299344d203d14cfa231d8da9847aa51e07", // gitleaks:allow
+      path: {
+        account: 0,
+        chain: 0,
+        coin: 1815,
+        index: 0,
+        purpose: 1852,
+      },
+    },
+  },
+];
 
 export const getCardanoAccountFixture = (params: {
   delegation?: Partial<CardanoDelegation>;
+  utxos?: Array<CardanoOutput>;
 }): CardanoAccount => ({
   type: "Account",
   id: "cardano-testnet-1",
@@ -57,26 +79,7 @@ export const getCardanoAccountFixture = (params: {
         },
       },
     ],
-    utxos: [
-      {
-        hash: "e807160f59455ffc011e6d0a48c0922645797707b8520788f176ca21f2b49561",
-        index: 0,
-        address:
-          "00bd2717d482fa89b20f7ba1299344d203d14cfa231d8da9847aa51e07db5e8ece0982acc4883de67c2e3411cc26bd56686a162074998c02bc",
-        amount: new BigNumber(100e6),
-        tokens: [],
-        paymentCredential: {
-          key: "bd2717d482fa89b20f7ba1299344d203d14cfa231d8da9847aa51e07",
-          path: {
-            account: 0,
-            chain: 0,
-            coin: 1815,
-            index: 0,
-            purpose: 1852,
-          },
-        },
-      },
-    ],
+    utxos: params.utxos ?? getDefaultUtxos(),
     delegation: params.delegation as any,
     protocolParams: {} as any,
   },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Regression tests added for both the sync path and all `buildTransaction` modes against deep-frozen account state.
- [x] **Impact of the changes:** Cardano account sync and transaction preparation when account state is frozen by the store. QA should focus on syncing and sending from a Cardano account that holds ≥2 UTXOs (including native tokens) and on delegate/undelegate flows.

### 📝 Description

A Cardano account could fail to sync, and transactions from it failed to load, with:

> `TypeError: Cannot assign to read-only property '0' of object '[object Array]'`

**Root cause.** Account state is deep-frozen in the store. Two code paths mutated frozen data in place:

1. **Sync** (`api/getTransactions.ts`) — marked a credential used via `credential.isUsed = true` on a credential object referenced from `initialAccount`, throwing `Cannot assign to read-only property 'isUsed'`. This is the "fails to sync" symptom and was **still present on `main`** — it is the fix in this PR.
2. **Transaction build** (`buildTransaction.ts`) — sorted `cardanoResources.utxos` in place; `Array.prototype.sort` writing to a frozen array throws the reported `'0' of [object Array]` error. This was **already fixed on `main`** (`61fe10b15a` for send, shipped in 4.9.0; `2c2d04136a` for delegate/undelegate). The only thing missing was regression coverage — added here.

> Note: a frozen in-place sort only throws with ≥2 elements (a single-element sort short-circuits), which is why only some accounts were affected.

**This PR:**
- Fixes the remaining sync-path mutation by cloning the credential (`{ ...credential, isUsed: true }`) instead of mutating in place.
- Adds regression tests that drive both paths against a deep-frozen account so neither mutation can be reintroduced:
  - `getTransactions`: frozen `initialAccount` credentials (sync path).
  - `buildTransaction`: send / send-all / delegate / undelegate / token-send.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33264](https://ledgerhq.atlassian.net/browse/LIVE-33264)
- **ADR link (if any)**: N/A


[LIVE-33264]: https://ledgerhq.atlassian.net/browse/LIVE-33264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ