### PR TITLE
feat(currencies): add @domain/api-currency-fiat CVS client

### DIFF
--- a/.changeset/api-currency-fiat-cvs-client.md
+++ b/.changeset/api-currency-fiat-cvs-client.md
@@ -1,0 +1,14 @@
+---
+"@domain/api-currency-fiat": minor
+"@domain/entity-currency-fiat": minor
+---
+
+Add `@domain/api-currency-fiat`, the RTK Query client for fiat currencies backed by the Ledger
+Countervalues Service (CVS): `currencyFiatApi` (`getSupportedFiats`), the Zod response schema and the
+tickers→`FiatCurrency[]` resolver (`resolveSupportedFiats`: OFAC filtering, registry-based resolution
+and de-duplication). The CVS URL is injected via the store's thunk `extraArgument` (`cvsApiExtra`),
+so the package owns no env/config dependency. Typed on `@domain/entity-currency-fiat`; no
+`@ledgerhq/*` dependency. Not yet wired into the apps.
+
+`@domain/entity-currency-fiat` gains a by-ticker lookup (`FIAT_CURRENCIES_BY_TICKER` +
+`getFiatCurrencyByTicker`), since the CVS returns ISO 4217 tickers while the registry is keyed by id.

--- a/domain/api/currency-fiat/README.md
+++ b/domain/api/currency-fiat/README.md
@@ -1,0 +1,87 @@
+# @domain/api-currency-fiat
+
+Domain API client for **fiat currencies**, backed by the Ledger Countervalues Service (CVS). RTK
+Query endpoint and helpers, typed on the Zod-first `@domain/entity-currency-fiat` entity. Owns no
+env/config/logging dependency.
+
+Start of the DDD evolution of `libs/ledger-live-common/src/currencies/support.ts` (the supported-fiat
+part) into an RTK Query model, following the `@domain/api-currency-token` package strategy.
+
+- `schema.ts` — Zod schemas for the CVS `/v3/supported/fiat` response (`SupportedFiatsResponseSchema`,
+  an array of tickers) and the `extraArgument` contract (`CvsApiExtraSchema`).
+- `types.ts` — inferred `SupportedFiatsResponse` and `CvsApiExtra` types.
+- `converter.ts` — `resolveSupportedFiats(tickers) → FiatCurrency[]`: normalizes tickers, drops
+  OFAC-sanctioned currencies, resolves entities from `@domain/entity-currency-fiat` (dropping unknown
+  tickers) and de-duplicates by id.
+- `api.ts` — `currencyFiatApi` (`createApi`) with the `getSupportedFiats` query, whose
+  `transformResponse` validates and resolves the response to `FiatCurrency[]`. The CVS URL is read
+  from the store's thunk `extraArgument`; the app supplies it via `cvsApiExtra(...)` so this package
+  owns no env/config dependency.
+- `internals/` — **package-private** (not re-exported from `index.ts`): `constants.ts` (cache tags,
+  reducer path, retry count, the OFAC ticker `Set`).
+
+Store wiring (app side):
+
+```ts
+configureStore({
+  reducer: { [currencyFiatApi.reducerPath]: currencyFiatApi.reducer },
+  middleware: gdm =>
+    gdm({
+      thunk: {
+        extraArgument: cvsApiExtra({
+          // Pass the staging URL here when running in staging mode — the package has no staging switch.
+          countervaluesServiceUrl: getEnv("LEDGER_COUNTERVALUES_API"),
+        }),
+      },
+    }).concat(currencyFiatApi.middleware),
+});
+```
+
+When a store hosts several currency APIs (token, crypto, fiat), merge their extras with object
+spread — `{ ...calApiExtra({ … }), ...cvsApiExtra({ … }) }` yields the combined `extraArgument` type.
+
+#### Intentional, scoped divergences vs legacy `support.ts`
+
+This is the _start_ of the migration and is **not connected into the apps yet** — so the following
+are deliberately deferred:
+
+- **No local fallback list** when the CVS call fails or returns `[]` (legacy fell back to a 36-ticker
+  hardcoded list). On failure the query has no `data` (RTK Query error state, `data === undefined`);
+  consumers should default with `?? []`. There is no empty-array seeding for now.
+- **Registry-bounded resolution**: tickers the `@domain/entity-currency-fiat` registry doesn't know
+  yet are dropped. The registry is being onboarded incrementally.
+- **OFAC list is duplicated** (not shared with `support.ts`) on purpose — the domain package must not
+  depend on `@ledgerhq/live-common`. A single source of truth can be revisited once `support.ts` is
+  retired.
+
+## App integration & reconciling legacy usecases (planned, not built yet)
+
+This package is intentionally a **pure CVS client**: it fetches, validates and resolves to
+`FiatCurrency[]`. It owns no redux slice, no fallback, no retry/orchestration policy — those are
+**app/UX concerns** and the domain layer cannot depend on a feature package (module boundaries). So
+the missing pieces from legacy `support.ts` are not lost; they move up a layer.
+
+The home for that layer is a future **`@features/platform-currencies`** package (already referenced by
+`@domain/api-currency-token`'s README; the `features/platform/currencies` dir is a stale stub for
+now). It is expected to own:
+
+- **The `supportedFiats` slice** — populated via `extraReducers` on
+  `currencyFiatApi.endpoints.getSupportedFiats.matchFulfilled`, storing the resolved `FiatCurrency[]`.
+- **The fallback list** — the legacy 36-ticker hardcoded list. Because this API surfaces an RTK Query
+  **error/empty** state rather than degrading (see divergences above), the feature selector is where
+  the legacy "never-empty" contract of `listSupportedFiats()` is re-established: on error or `[]`, the
+  selector returns the local fallback (resolved through `@domain/entity-currency-fiat`, OFAC-filtered
+  the same way). Keep the fallback here, not in the api — it is a product decision, not a CVS fact.
+- **Orchestration** — the retry currently in mobile `LedgerStore.tsx` (`retry(listSupportedFiats, …)`)
+  and the eager fetch in desktop `settings.ts` become a `getSupportedFiats` `initiate(...)` (or hook)
+  plus the slice binding.
+
+**Call sites to migrate** (the usecases to reconcile), all currently consuming
+`listSupportedFiats()` from `@ledgerhq/live-common`:
+
+- `apps/ledger-live-mobile/src/context/LedgerStore.tsx` — `updateSupportedCountervalues()`
+- `apps/ledger-live-desktop/src/renderer/reducers/settings.ts` — `getsupportedCountervalues()`
+
+The migration is a swap of the data source (CVS client + feature selector) behind the same selector
+shape these call sites already expect — done incrementally, app by app, with the fallback guaranteeing
+parity while `@domain/entity-currency-fiat`'s registry is still being onboarded.

--- a/domain/api/currency-fiat/jest.config.js
+++ b/domain/api/currency-fiat/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/domain/api/currency-fiat/package.json
+++ b/domain/api/currency-fiat/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@domain/api-currency-fiat",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Domain API client for fiat currencies (Countervalues Service): RTK Query endpoints typed on @domain/entity-currency-fiat",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage"
+  },
+  "dependencies": {
+    "@domain/entity-currency-fiat": "workspace:*",
+    "@reduxjs/toolkit": "catalog:",
+    "zod": "catalog:"
+  },
+  "peerDependencies": {
+    "react": ">=19.0.0",
+    "react-redux": ">=9.0.0"
+  },
+  "devDependencies": {
+    "@jest/globals": "catalog:",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "react": "catalog:",
+    "react-redux": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/domain/api/currency-fiat/project.json
+++ b/domain/api/currency-fiat/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@domain/api-currency-fiat",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/api/currency-fiat/src/api.test.ts
+++ b/domain/api/currency-fiat/src/api.test.ts
@@ -1,0 +1,114 @@
+import { configureStore } from "@reduxjs/toolkit";
+
+jest.mock("./converter", () => ({
+  resolveSupportedFiats: jest.fn(),
+}));
+
+import { resolveSupportedFiats } from "./converter";
+import { currencyFiatApi, cvsApiExtra, useGetSupportedFiatsQuery } from "./api";
+import { SupportedFiatsResponseSchema } from "./schema";
+import { mockSupportedFiatsResponse } from "./fixtures";
+
+const mockResolve = resolveSupportedFiats as jest.MockedFunction<typeof resolveSupportedFiats>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockResolve.mockReturnValue([]);
+});
+
+describe("SupportedFiatsResponseSchema", () => {
+  it("validates an array of tickers", () => {
+    expect(SupportedFiatsResponseSchema.parse(mockSupportedFiatsResponse)).toEqual([
+      "USD",
+      "EUR",
+      "GBP",
+    ]);
+  });
+
+  it("validates an empty array", () => {
+    expect(SupportedFiatsResponseSchema.parse([])).toHaveLength(0);
+  });
+
+  it("throws on a non-array payload", () => {
+    expect(() => SupportedFiatsResponseSchema.parse("not an array")).toThrow();
+  });
+
+  it("drops non-string entries instead of rejecting the whole list", () => {
+    expect(SupportedFiatsResponseSchema.parse(["USD", 1, null, "EUR"])).toEqual(["USD", "EUR"]);
+  });
+});
+
+describe("currencyFiatApi configuration", () => {
+  it("has the correct reducer path", () => {
+    expect(currencyFiatApi.reducerPath).toBe("currencyFiatApi");
+  });
+
+  it("exposes the getSupportedFiats endpoint and its hook", () => {
+    expect(currencyFiatApi.endpoints.getSupportedFiats).toBeDefined();
+    expect(useGetSupportedFiatsQuery).toBeDefined();
+  });
+});
+
+describe("cvsApiExtra", () => {
+  it("returns the validated config", () => {
+    expect(cvsApiExtra({ countervaluesServiceUrl: "https://cvs.test" })).toEqual({
+      countervaluesServiceUrl: "https://cvs.test",
+    });
+  });
+
+  it("throws when the url is missing or empty", () => {
+    // @ts-expect-error — countervaluesServiceUrl is required
+    expect(() => cvsApiExtra({})).toThrow();
+    expect(() => cvsApiExtra({ countervaluesServiceUrl: "" })).toThrow();
+  });
+});
+
+describe("currencyFiatApi requests", () => {
+  let fetchSpy: jest.SpyInstance;
+
+  const makeStore = () =>
+    configureStore({
+      reducer: { [currencyFiatApi.reducerPath]: currencyFiatApi.reducer },
+      middleware: gdm =>
+        gdm({
+          thunk: {
+            extraArgument: cvsApiExtra({
+              countervaluesServiceUrl: "https://cvs.test",
+            }),
+          },
+        }).concat(currencyFiatApi.middleware),
+    });
+
+  function mockFetch(body: unknown) {
+    fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  }
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+  });
+
+  it("getSupportedFiats hits the injected base URL with the Accept header", async () => {
+    mockFetch(["USD", "EUR"]);
+    const store = makeStore();
+
+    await store.dispatch(currencyFiatApi.endpoints.getSupportedFiats.initiate());
+
+    const request = fetchSpy.mock.calls[0][0] as Request;
+    expect(request.url).toContain("https://cvs.test/v3/supported/fiat");
+    expect(request.headers.get("Accept")).toBe("application/json");
+  });
+
+  it("passes the validated tickers to resolveSupportedFiats", async () => {
+    mockFetch(["USD", "EUR"]);
+    const store = makeStore();
+
+    await store.dispatch(currencyFiatApi.endpoints.getSupportedFiats.initiate());
+
+    expect(mockResolve).toHaveBeenCalledWith(["USD", "EUR"]);
+  });
+});

--- a/domain/api/currency-fiat/src/api.ts
+++ b/domain/api/currency-fiat/src/api.ts
@@ -1,0 +1,61 @@
+import {
+  createApi,
+  fetchBaseQuery,
+  retry,
+  type BaseQueryFn,
+  type FetchArgs,
+  type FetchBaseQueryError,
+} from "@reduxjs/toolkit/query/react";
+import type { FiatCurrency } from "@domain/entity-currency-fiat";
+import { resolveSupportedFiats } from "./converter";
+import { CvsApiExtraSchema, SupportedFiatsResponseSchema } from "./schema";
+import type { CvsApiExtra } from "./types";
+import { CURRENCY_FIAT_REDUCER_PATH, FIAT_TAGS, MAX_RETRIES } from "./internals";
+
+/**
+ * Builds this package's slice of the thunk `extraArgument`. RTK leaves `extraArgument` untyped, so
+ * this is the one compile- and runtime-checked entry point: `parse` fails fast at app init if the
+ * Countervalues Service config is incomplete (e.g. an env var resolved to an empty string).
+ */
+export function cvsApiExtra(extra: CvsApiExtra): CvsApiExtra {
+  return CvsApiExtraSchema.parse(extra);
+}
+
+/** Extracts the {@link CvsApiExtra} from the `extraArgument` of the API. */
+function getCvsExtra(api: { extra: unknown }): CvsApiExtra {
+  return api.extra as CvsApiExtra;
+}
+
+/** Reads the injected {@link CvsApiExtra} and delegates to {@link fetchBaseQuery}. Wrapped in `retry`. */
+const cvsBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError> = retry(
+  (args, api, extraOptions) => {
+    const extra = getCvsExtra(api);
+    return fetchBaseQuery({
+      baseUrl: extra.countervaluesServiceUrl,
+      prepareHeaders: headers => {
+        headers.set("Accept", "application/json");
+        return headers;
+      },
+    })(args, api, extraOptions);
+  },
+  { maxRetries: MAX_RETRIES },
+);
+
+/** RTK Query API for the Countervalues Service fiat data. */
+export const currencyFiatApi = createApi({
+  reducerPath: CURRENCY_FIAT_REDUCER_PATH,
+  baseQuery: cvsBaseQuery,
+  tagTypes: [...FIAT_TAGS],
+  endpoints: build => ({
+    getSupportedFiats: build.query<FiatCurrency[], void>({
+      query: () => "/v3/supported/fiat",
+      transformResponse: (response: unknown) =>
+        resolveSupportedFiats(SupportedFiatsResponseSchema.parse(response)),
+      providesTags: [...FIAT_TAGS],
+    }),
+  }),
+});
+
+export const { useGetSupportedFiatsQuery } = currencyFiatApi;
+
+export type CurrencyFiatApi = typeof currencyFiatApi;

--- a/domain/api/currency-fiat/src/converter.test.ts
+++ b/domain/api/currency-fiat/src/converter.test.ts
@@ -1,0 +1,40 @@
+import { resolveSupportedFiats } from "./converter";
+import { fiatByTicker } from "./fixtures";
+
+describe("resolveSupportedFiats", () => {
+  it("resolves known tickers to FiatCurrency entities, preserving order", () => {
+    const result = resolveSupportedFiats(["USD", "EUR", "GBP"]);
+
+    expect(result.map(c => c.ticker)).toEqual(["USD", "EUR", "GBP"]);
+    expect(result[0]).toEqual(fiatByTicker("USD"));
+  });
+
+  it("filters out OFAC-sanctioned tickers", () => {
+    const result = resolveSupportedFiats(["USD", "RUB", "IRR", "EUR"]);
+
+    expect(result.map(c => c.ticker)).toEqual(["USD", "EUR"]);
+  });
+
+  it("drops tickers the registry does not know", () => {
+    const result = resolveSupportedFiats(["USD", "ZZZ", "EUR"]);
+
+    expect(result.map(c => c.ticker)).toEqual(["USD", "EUR"]);
+  });
+
+  it("normalizes lower-case tickers before resolving", () => {
+    const result = resolveSupportedFiats(["usd", "eur"]);
+
+    expect(result.map(c => c.ticker)).toEqual(["USD", "EUR"]);
+  });
+
+  it("de-duplicates by currency id", () => {
+    const result = resolveSupportedFiats(["USD", "usd", "USD"]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].ticker).toBe("USD");
+  });
+
+  it("returns an empty array for an empty input", () => {
+    expect(resolveSupportedFiats([])).toEqual([]);
+  });
+});

--- a/domain/api/currency-fiat/src/converter.ts
+++ b/domain/api/currency-fiat/src/converter.ts
@@ -1,0 +1,27 @@
+import { getFiatCurrencyByTicker, type FiatCurrency } from "@domain/entity-currency-fiat";
+import { OFAC_FIAT_TICKERS } from "./internals";
+
+/**
+ * Resolves the Countervalues Service supported-fiat tickers to {@link FiatCurrency} entities.
+ *
+ * For each ticker (normalized to upper-case): drops OFAC-sanctioned currencies, resolves the
+ * entity from the static `@domain/entity-currency-fiat` registry (dropping tickers the registry
+ * does not know yet), and de-duplicates by currency id while preserving order.
+ */
+export function resolveSupportedFiats(tickers: string[]): FiatCurrency[] {
+  const seen = new Set<string>();
+  const resolved: FiatCurrency[] = [];
+
+  for (const ticker of tickers) {
+    const upper = ticker.toUpperCase();
+    if (OFAC_FIAT_TICKERS.has(upper)) continue;
+
+    const currency = getFiatCurrencyByTicker(upper);
+    if (!currency || seen.has(currency.id)) continue;
+
+    seen.add(currency.id);
+    resolved.push(currency);
+  }
+
+  return resolved;
+}

--- a/domain/api/currency-fiat/src/fixtures/index.ts
+++ b/domain/api/currency-fiat/src/fixtures/index.ts
@@ -1,0 +1,13 @@
+import { getFiatCurrencyByTicker, type FiatCurrency } from "@domain/entity-currency-fiat";
+
+// Shared test fixtures. Not re-exported from the package barrel; imported only by `*.test.ts`.
+
+/** Helper that resolves a registry fiat by ticker for assertions; throws if the seed is missing. */
+export function fiatByTicker(ticker: string): FiatCurrency {
+  const currency = getFiatCurrencyByTicker(ticker);
+  if (!currency) throw new Error(`fixture ticker not in registry: ${ticker}`);
+  return currency;
+}
+
+/** Canonical Countervalues Service `/v3/supported/fiat` response. */
+export const mockSupportedFiatsResponse: string[] = ["USD", "EUR", "GBP"];

--- a/domain/api/currency-fiat/src/index.ts
+++ b/domain/api/currency-fiat/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./schema";
+export * from "./types";
+export * from "./converter";
+export * from "./api";

--- a/domain/api/currency-fiat/src/internals/constants.ts
+++ b/domain/api/currency-fiat/src/internals/constants.ts
@@ -1,0 +1,31 @@
+// Package-private: nothing under `internals/` is re-exported from the public barrel (`../index.ts`).
+
+/** RTK Query cache tags exposed by the fiat currency api. */
+export const FIAT_TAGS = ["SupportedFiats"] as const;
+
+/** RTK Query reducer path for the fiat currency API — stable; it keys the store slice. */
+export const CURRENCY_FIAT_REDUCER_PATH = "currencyFiatApi";
+
+/** Max retries for transient Countervalues Service request failures. */
+export const MAX_RETRIES = 3;
+
+/**
+ * OFAC-sanctioned fiat tickers, filtered out of the supported list regardless of what the
+ * Countervalues Service returns.
+ *
+ * Duplicated here on purpose: the domain package must not depend on `@ledgerhq/live-common`.
+ * A single source of truth can be revisited once the legacy `support.ts` is retired.
+ */
+export const OFAC_FIAT_TICKERS: ReadonlySet<string> = new Set([
+  "AFN",
+  "BYN",
+  "CUP",
+  "CUC",
+  "IRR",
+  "IQD",
+  "KPW",
+  "RUB",
+  "SDG",
+  "SYP",
+  "MMK",
+]);

--- a/domain/api/currency-fiat/src/internals/index.ts
+++ b/domain/api/currency-fiat/src/internals/index.ts
@@ -1,0 +1,1 @@
+export * from "./constants";

--- a/domain/api/currency-fiat/src/schema.ts
+++ b/domain/api/currency-fiat/src/schema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+/**
+ * Schema for the Countervalues Service `/v3/supported/fiat` response: an array of ISO 4217 tickers
+ * (e.g. `["USD", "EUR"]`). Non-string entries are dropped rather than rejecting the whole list, so a
+ * single malformed item never wipes out every supported fiat.
+ */
+export const SupportedFiatsResponseSchema = z
+  .array(z.unknown())
+  .transform(items => items.filter((ticker): ticker is string => typeof ticker === "string"));
+
+/**
+ * Thunk `extraArgument` contract for the fiat currency api. The app supplies the resolved
+ * Countervalues Service URL at store configuration time, so this package owns no env/config
+ * dependency. The app picks the prod or staging URL — there is no staging switch in here.
+ */
+export const CvsApiExtraSchema = z.object({
+  countervaluesServiceUrl: z.string().min(1),
+});

--- a/domain/api/currency-fiat/src/types.ts
+++ b/domain/api/currency-fiat/src/types.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+import { CvsApiExtraSchema, SupportedFiatsResponseSchema } from "./schema";
+
+/** The Countervalues Service `/v3/supported/fiat` response (array of tickers). */
+export type SupportedFiatsResponse = z.infer<typeof SupportedFiatsResponseSchema>;
+
+/** Thunk `extraArgument` contract for the fiat currency api. */
+export type CvsApiExtra = z.infer<typeof CvsApiExtraSchema>;

--- a/domain/api/currency-fiat/tsconfig.json
+++ b/domain/api/currency-fiat/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2024", "DOM"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/domain/entity/currency-fiat/src/registry.test.ts
+++ b/domain/entity/currency-fiat/src/registry.test.ts
@@ -1,5 +1,10 @@
 import * as currencies from "./currencies";
-import { FIAT_CURRENCIES_REGISTRY, FIAT_CURRENCIES_IDS } from "./registry";
+import {
+  FIAT_CURRENCIES_REGISTRY,
+  FIAT_CURRENCIES_IDS,
+  FIAT_CURRENCIES_BY_TICKER,
+  getFiatCurrencyByTicker,
+} from "./registry";
 
 describe("FIAT_CURRENCIES_REGISTRY", () => {
   it("is non-empty", () => {
@@ -32,5 +37,28 @@ describe("FIAT_CURRENCIES_REGISTRY", () => {
 describe("FIAT_CURRENCIES_IDS", () => {
   it("length matches registry", () => {
     expect(FIAT_CURRENCIES_IDS.length).toBe(Object.keys(FIAT_CURRENCIES_REGISTRY).length);
+  });
+});
+
+describe("FIAT_CURRENCIES_BY_TICKER", () => {
+  it("has no duplicate tickers across currency files", () => {
+    const tickers = Object.values(currencies).map(c => c.ticker);
+    expect(new Set(tickers).size).toBe(tickers.length);
+  });
+
+  it("every entry is keyed by its own ticker", () => {
+    for (const [key, currency] of Object.entries(FIAT_CURRENCIES_BY_TICKER)) {
+      expect(currency.ticker).toBe(key);
+    }
+  });
+});
+
+describe("getFiatCurrencyByTicker", () => {
+  it("resolves a known ticker", () => {
+    expect(getFiatCurrencyByTicker("USD")?.id).toBe("usd");
+  });
+
+  it("returns undefined for an unknown ticker", () => {
+    expect(getFiatCurrencyByTicker("ZZZ")).toBeUndefined();
   });
 });

--- a/domain/entity/currency-fiat/src/registry.ts
+++ b/domain/entity/currency-fiat/src/registry.ts
@@ -12,3 +12,16 @@ export const FIAT_CURRENCIES_REGISTRY: Record<string, FiatCurrency> = Object.fro
 
 /** All known fiat currency ids as a constant array. */
 export const FIAT_CURRENCIES_IDS = Object.values(FIAT_CURRENCIES_REGISTRY).map(c => c.id);
+
+/**
+ * Registry of all known fiat currencies, keyed by ISO 4217 ticker (e.g. `"USD"`).
+ * Tickers are unique across the registry, so no entry is shadowed.
+ */
+export const FIAT_CURRENCIES_BY_TICKER: Record<string, FiatCurrency> = Object.fromEntries(
+  Object.values(FIAT_CURRENCIES_REGISTRY).map(c => [c.ticker, c]),
+);
+
+/** Looks up a fiat currency by its ISO 4217 ticker (e.g. `"USD"`); `undefined` when unknown. */
+export function getFiatCurrencyByTicker(ticker: string): FiatCurrency | undefined {
+  return FIAT_CURRENCIES_BY_TICKER[ticker];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3057,6 +3057,46 @@ importers:
         specifier: 'catalog:'
         version: 6.0.2
 
+  domain/api/currency-fiat:
+    dependencies:
+      '@domain/entity-currency-fiat':
+        specifier: workspace:*
+        version: link:../../entity/currency-fiat
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2(react-redux@9.2.0(react@19.1.4))(react@19.1.4)
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@jest/globals':
+        specifier: 'catalog:'
+        version: 30.2.0
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
+      react:
+        specifier: 19.1.4
+        version: 19.1.4
+      react-redux:
+        specifier: 'catalog:'
+        version: 9.2.0(react@19.1.4)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.2
+
   domain/api/currency-token:
     dependencies:
       '@domain/entity-currency-crypto':


### PR DESCRIPTION
> [!NOTE]
> New isolated domain package. Not wired into LLD/LLM yet — no app behavior changes.

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- api.test.ts, converter.test.ts, entity registry.test.ts -->
- [ ] **Impact of the changes:** New isolated package + an additive by-ticker lookup on the fiat entity. Nothing consumes them yet.
  - QA: none for now (no app wiring).

### 📝 Description

Reboots #18628 (which had review feedback) cleanly, following the now-merged `@domain/api-currency-token` strategy (#19053).

Adds **`@domain/api-currency-fiat`**, a pure RTK Query client for the supported fiat list from the Countervalues Service:

- `schema.ts` — Zod schema for `/v3/supported/fiat` (array of tickers; non-string entries are dropped, not list-rejecting) + the `cvsApiExtra` contract.
- `converter.ts` — `resolveSupportedFiats(tickers) → FiatCurrency[]`: upper-cases, drops OFAC tickers, resolves via the `@domain/entity-currency-fiat` registry (drops unknowns), de-dupes by id.
- `api.ts` — `currencyFiatApi` with `getSupportedFiats`; the CVS URL is injected via the store thunk `extraArgument` (`cvsApiExtra`), so the package owns no env/config dependency. No `@ledgerhq/*` dependency.
- `@domain/entity-currency-fiat` gains `FIAT_CURRENCIES_BY_TICKER` + `getFiatCurrencyByTicker` (CVS returns tickers; the registry is keyed by id).

Intentional, scoped divergences vs legacy `support.ts` (documented in the README): no local fallback list, registry-bounded resolution, OFAC list duplicated on purpose (no live-common dep).

The README also documents the **integration plan**: the fallback list, the `supportedFiats` slice and the retry/orchestration belong in a future `@features/platform-currencies` layer (the domain api stays pure), re-establishing the never-empty contract of `listSupportedFiats()` at the feature selector. Call sites to migrate later: mobile `LedgerStore.tsx`, desktop `settings.ts`.

Consumer side, once a store wires it:

```ts
const { data } = useGetSupportedFiatsQuery();
const supportedFiats = data ?? []; // undefined on error/cold cache — feature layer will add the fallback
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32269](https://ledgerhq.atlassian.net/browse/LIVE-32269)
- **ADR link (if any)**: supported-set ADR — LIVE-31919 (pending)


[LIVE-32269]: https://ledgerhq.atlassian.net/browse/LIVE-32269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ