### PR TITLE
[LWM] feat(mobile): respect safe-area in Borrow webview & Portfolio section

### DIFF
--- a/.changeset/borrow-safe-area-insets.md
+++ b/.changeset/borrow-safe-area-insets.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Forward device safe-area insets (top/bottom/left/right) as query params to the Borrow live app webview so the embedded app can offset notches and the home indicator, and add a safe-area-aware bottom padding to the Borrow card on the Portfolio screen when the operations list owns the screen footer.

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/components/BorrowWebView/__tests__/BorrowWebView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/components/BorrowWebView/__tests__/BorrowWebView.test.tsx
@@ -32,6 +32,10 @@ const defaultInputs: BorrowWebviewInputs = {
   currencyTicker: "USD",
   OS: "ios",
   platform: "LLM",
+  safeAreaTop: "0",
+  safeAreaBottom: "0",
+  safeAreaLeft: "0",
+  safeAreaRight: "0",
 };
 
 describe("BorrowWebView", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/__tests__/BorrowLiveAppView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/__tests__/BorrowLiveAppView.test.tsx
@@ -29,6 +29,10 @@ const defaultInputs: BorrowWebviewInputs = {
   currencyTicker: "USD",
   OS: "ios",
   platform: "LLM",
+  safeAreaTop: "0",
+  safeAreaBottom: "0",
+  safeAreaLeft: "0",
+  safeAreaRight: "0",
 };
 
 const defaultProps = {

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/__tests__/useBorrowLiveAppViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/__tests__/useBorrowLiveAppViewModel.test.ts
@@ -149,6 +149,19 @@ describe("useBorrowLiveAppViewModel", () => {
     );
   });
 
+  it("should expose safe-area insets as strings", () => {
+    const { result } = renderHook(() => useBorrowLiveAppViewModel());
+
+    expect(result.current.webviewInputs).toEqual(
+      expect.objectContaining({
+        safeAreaTop: "0",
+        safeAreaBottom: "0",
+        safeAreaLeft: "0",
+        safeAreaRight: "0",
+      }),
+    );
+  });
+
   it("should expose a webviewRef", () => {
     const { result } = renderHook(() => useBorrowLiveAppViewModel());
     expect(result.current.webviewRef).toBeDefined();

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/useBorrowLiveAppViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/useBorrowLiveAppViewModel.ts
@@ -29,10 +29,7 @@ export type BorrowWebviewInputs = {
   currencyTicker: string;
   OS: string;
   platform: "LLM";
-  // Device safe area insets (in px), so the borrow web app can avoid notches
-  // / home indicators when it owns its own screen padding. Inside the webview
-  // `env(safe-area-inset-*)` returns 0 because the host already offsets the
-  // viewport, so we forward the real values from `useSafeAreaInsets`.
+  // Safe-area insets (RN layout units) forwarded to the web app; stringified for query params.
   safeAreaTop: string;
   safeAreaBottom: string;
   safeAreaLeft: string;

--- a/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/useBorrowLiveAppViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Borrow/screens/BorrowLiveApp/useBorrowLiveAppViewModel.ts
@@ -8,6 +8,7 @@ import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
 import { useNetInfo } from "@react-native-community/netinfo";
 import { Platform } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "styled-components/native";
 import { useSelector } from "~/context/hooks";
 import { useTranslation } from "~/context/Locale";
@@ -28,6 +29,14 @@ export type BorrowWebviewInputs = {
   currencyTicker: string;
   OS: string;
   platform: "LLM";
+  // Device safe area insets (in px), so the borrow web app can avoid notches
+  // / home indicators when it owns its own screen padding. Inside the webview
+  // `env(safe-area-inset-*)` returns 0 because the host already offsets the
+  // viewport, so we forward the real values from `useSafeAreaInsets`.
+  safeAreaTop: string;
+  safeAreaBottom: string;
+  safeAreaLeft: string;
+  safeAreaRight: string;
 };
 
 type BorrowLiveAppViewModel = {
@@ -52,6 +61,7 @@ export function useBorrowLiveAppViewModel(): BorrowLiveAppViewModel {
   const { language } = useSettings();
   const { ticker: currencyTicker } = useSelector(counterValueCurrencySelector);
   const exportSettings = useSelector(exportSettingsSelector);
+  const insets = useSafeAreaInsets();
 
   const webviewRef = useRef<WebviewAPI>(null);
   const countryLocale = getCountryLocale();
@@ -85,8 +95,22 @@ export function useBorrowLiveAppViewModel(): BorrowLiveAppViewModel {
       currencyTicker,
       OS: Platform.OS,
       platform: "LLM",
+      safeAreaTop: insets.top.toString(),
+      safeAreaBottom: insets.bottom.toString(),
+      safeAreaLeft: insets.left.toString(),
+      safeAreaRight: insets.right.toString(),
     }),
-    [currencyTicker, countryLocale, exportSettings.developerModeEnabled, language, theme],
+    [
+      currencyTicker,
+      countryLocale,
+      exportSettings.developerModeEnabled,
+      language,
+      theme,
+      insets.top,
+      insets.bottom,
+      insets.left,
+      insets.right,
+    ],
   );
 
   const error: Error | null = useMemo(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBorrowSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBorrowSection/index.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import {
   Box,
   Button,
@@ -23,9 +25,15 @@ interface PortfolioBorrowSectionProps {
 
 export const PortfolioBorrowSection = ({ onPress }: PortfolioBorrowSectionProps) => {
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
+  const { shouldDisplayOperationsList } = useWalletFeaturesConfig("mobile");
+
+  /** Tx History in header: this section is last — safe area + s24 below the card. */
+  const bottomPadding = shouldDisplayOperationsList ? bottom + 24 : undefined;
 
   return (
     <Box
+      style={bottomPadding === undefined ? undefined : { paddingBottom: bottomPadding }}
       lx={{
         paddingTop: "s32",
         paddingHorizontal: "s16",

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBorrowSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBorrowSection/index.tsx
@@ -28,12 +28,10 @@ export const PortfolioBorrowSection = ({ onPress }: PortfolioBorrowSectionProps)
   const { bottom } = useSafeAreaInsets();
   const { shouldDisplayOperationsList } = useWalletFeaturesConfig("mobile");
 
-  /** Tx History in header: this section is last — safe area + s24 below the card. */
-  const bottomPadding = shouldDisplayOperationsList ? bottom + 24 : undefined;
+  const containerStyle = shouldDisplayOperationsList ? { paddingBottom: bottom + 24 } : undefined;
 
   return (
-    <Box
-      style={bottomPadding === undefined ? undefined : { paddingBottom: bottomPadding }}
+    <Box style={containerStyle}
       lx={{
         paddingTop: "s32",
         paddingHorizontal: "s16",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Borrow live app rendering on devices with notches / home indicators (iPhone X+ and modern Android)
  - Portfolio screen layout when the operations list is enabled (bottom spacing under the Borrow card)
  - Existing Borrow webview query params (new `safeArea{Top,Bottom,Left,Right}` keys are appended; no other inputs change)

### 📝 Description

The Borrow live app renders inside a host webview that already offsets its own viewport for the device safe-area. As a result, `env(safe-area-inset-*)` inside the embedded app always resolves to `0`, leaving the live app unable to react to notches or the home indicator on its own (e.g. when it owns a full-bleed layout). On the host side, the Portfolio Borrow card was also missing bottom padding when it ended up being the last section on screen (Tx History in header → operations list owns the footer).

This PR addresses both:

- **`useBorrowLiveAppViewModel`** now reads `useSafeAreaInsets()` and forwards the four values as `safeAreaTop / safeAreaBottom / safeAreaLeft / safeAreaRight` query-param strings (in px) alongside the existing webview inputs. The dependency array of the memoized inputs is extended with each inset so the URL stays in sync with orientation / device changes.
- **`PortfolioBorrowSection`** now applies a `paddingBottom` of `insets.bottom + s24` whenever `shouldDisplayOperationsList` is `true`, so the Borrow card breathes properly above the home indicator when it's the last item on the Portfolio screen.

Tests:

- New unit test in `useBorrowLiveAppViewModel.test.ts` asserts the four `safeArea*` strings are exposed by the view model.
- `BorrowWebView.test.tsx` and `BorrowLiveAppView.test.tsx` default inputs are updated to include the new fields so render tests stay valid.

### Before / After

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: _N/A — internal polish, no ticket._

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)