### PR TITLE
[LWD] test(lld): fix flaky History export dialog integration test [LIVE-33397]

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
@@ -3,7 +3,9 @@ import { cleanup, render, screen, waitFor, within } from "tests/testSetup";
 import { useNavigate } from "react-router";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { useExportOperationsCsv } from "~/renderer/hooks/useExportOperationsCsv";
-import { BTC_ACCOUNT, ETH_ACCOUNT, EMPTY_BTC_ACCOUNT } from "../../__mocks__/accounts.mock";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { BTC_ACCOUNT, EMPTY_BTC_ACCOUNT } from "../../__mocks__/accounts.mock";
+import { bitcoinCurrency, ethereumCurrency } from "../../__mocks__/useSelectAssetFlow.mock";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 import type { Account } from "@ledgerhq/types-live";
 import History from "../index";
@@ -204,10 +206,19 @@ describe("History export dialog integration", () => {
     cleanup();
   });
 
+  const LIGHT_BTC_ACCOUNT = genAccount("bitcoin-1", {
+    currency: bitcoinCurrency,
+    operationsSize: 1,
+  });
+  const LIGHT_ETH_ACCOUNT = genAccount("ethereum-1", {
+    currency: ethereumCurrency,
+    operationsSize: 1,
+  });
+
   function renderHistoryWithAccounts() {
     return render(<History />, {
       initialState: {
-        accounts: [BTC_ACCOUNT, ETH_ACCOUNT],
+        accounts: [LIGHT_BTC_ACCOUNT, LIGHT_ETH_ACCOUNT],
         settings: AFTER_ONBOARDING_STATE,
       },
     });
@@ -224,7 +235,9 @@ describe("History export dialog integration", () => {
     dialog: ReturnType<typeof within>,
   ) {
     await user.click(dialog.getByText(/select all/i));
-    const exportButton = dialog.getByRole("button", { name: /export history/i });
+    const exportButton = dialog.getByRole("button", {
+      name: /export history/i,
+    });
     await waitFor(() => expect(exportButton).toBeEnabled());
     await user.click(exportButton);
   }
@@ -236,7 +249,9 @@ describe("History export dialog integration", () => {
     expect(dialog.getByText(/Bitcoin/)).toBeVisible();
     expect(dialog.getByText(/Ethereum/)).toBeVisible();
 
-    const exportButton = dialog.getByRole("button", { name: /export history/i });
+    const exportButton = dialog.getByRole("button", {
+      name: /export history/i,
+    });
     expect(exportButton).toBeDisabled();
 
     await user.click(dialog.getByText(/select all/i));


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. <!-- N/A: test-only change, no published package behaviour is affected. -->
- [x] **Covered by automatic tests.** <!-- This PR fixes the flaky test itself; the full file passes (10 tests). -->
- [x] **Impact of the changes:** none on app behaviour — test-only.
  - QA: no focus area required. CI stability only.

### 📝 Description

Fixes the flaky `History.integration.test.tsx` failure on `develop` ([failing run](https://github.com/LedgerHQ/ledger-live/actions/runs/28373881922/job/84058379384)): `History export dialog integration › should export selected accounts and show success scene` exceeded the 5000 ms default timeout (5157 ms).

**Previous behaviour / root cause**

The export-dialog tests rendered the full History page with `BTC_ACCOUNT` + `ETH_ACCOUNT`. Both come from `genAccount`, which defaults `operationsSize` to `rng.nextInt(1, 200)` — up to ~200 operations each. The test's virtualizer mock renders **every** row (no windowing), so each `user.click` in the dialog flow re-rendered hundreds of operation rows underneath the modal. The "export & success" test does the most interactions, so it sat right at the limit and tipped over on loaded CI runners.

Locally the same tests run at ~1.5 s, well under the timeout — so the slowness is real render cost amplified by a loaded CI runner, not a one-off fluke. Bumping the timeout would only have masked it.

**Fix**

The export dialog only reads account name / currency / balance — never operations. So the export-dialog `describe` now renders History with lightweight accounts (`operationsSize: 1`), keeping the underlying table cheap to re-render. The other `History integration` describe block is untouched and still uses the full mock accounts.

Local timings, 3 runs each on the same machine:

| Test | Before | After |
| ------------- | ------------- | ------------- |
| open dialog, toggle | 811 / 843 / 890 ms | 341 / 344 / 357 ms |
| **export & success** | 1504 / 1531 / 1551 ms | **141 / 146 / 146 ms** |
| stay on cancel | 532 / 543 / 551 ms | 92 / 100 / 101 ms |
| error scene + retry | 1474 / 1477 / 1488 ms | 139 / 143 / 157 ms |

~10× faster per test, no `timeout` band-aids.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33397](https://ledgerhq.atlassian.net/browse/LIVE-33397)
- **ADR link (if any)**: N/A


[LIVE-33397]: https://ledgerhq.atlassian.net/browse/LIVE-33397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ