### PR TITLE
test(e2e): show merged feature flags in Allure report overview (QAA-1360)

### DIFF
--- a/.changeset/qaa-1360-allure-merged-ff.md
+++ b/.changeset/qaa-1360-allure-merged-ff.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop-e2e-tests": patch
+"ledger-live-mobile-e2e-tests": patch
+---
+
+E2E Allure report overview now reflects the feature flags actually applied at runtime (e2e defaults + workflow `E2E_FEATURE_FLAGS_JSON` overrides, with JSON taking precedence), instead of Firebase-only values. FF resolution is centralised per platform via a shared `getMergedFeatureFlags()` used by both the test setup and the report teardown, so the overview and per-test data share one source of truth.

--- a/e2e/desktop/tests/utils/global.teardown.ts
+++ b/e2e/desktop/tests/utils/global.teardown.ts
@@ -2,14 +2,18 @@ import { formatFlagsData, formatEnvData } from "@ledgerhq/live-common/e2e/index"
 import { writeFileSync } from "fs";
 import { ElectronApplication, expect } from "@playwright/test";
 import { launchApp } from "./electronUtils";
-import { getFeatureFlags } from "./featureFlagUtils";
+import { getFeatureFlags, getMergedFeatureFlags } from "./featureFlagUtils";
 
 const environmentFilePath = "allure-results/environment.properties";
 
 export default async function globalTeardown() {
   if (process.env.CI) {
     const electronApp: ElectronApplication = await launchApp({
-      env: { ...process.env, PLAYWRIGHT_RUN: "true" },
+      env: {
+        ...process.env,
+        PLAYWRIGHT_RUN: "true",
+        FEATURE_FLAGS: JSON.stringify(getMergedFeatureFlags()),
+      },
       lang: "en-US",
       theme: "dark",
       userdataDestinationPath: "",

--- a/e2e/mobile/jest.globalTeardown.ts
+++ b/e2e/mobile/jest.globalTeardown.ts
@@ -10,9 +10,16 @@ register({
 
 import { globalTeardown } from "detox/runners/jest";
 import { promises as fs } from "fs";
-import { close as closeBridge, getEnvs, getFlags, loadConfig } from "./bridge/server";
+import {
+  close as closeBridge,
+  getEnvs,
+  getFlags,
+  loadConfig,
+  setFeatureFlags,
+} from "./bridge/server";
 import { formatEnvData, formatFlagsData } from "@ledgerhq/live-common/e2e";
 import { launchApp } from "./helpers/commonHelpers";
+import { getMergedFeatureFlags } from "./utils/featureFlagUtils";
 import detox from "detox/internals";
 import path from "path";
 import { glob } from "glob";
@@ -43,6 +50,8 @@ export default async () => {
       await launchApp({ newInstance: true });
       await loadConfig("1AccountBTC1AccountETHReadOnlyFalse", true);
       await NativeElementHelpers.waitForElementById("topbar-settings", 120_000);
+
+      await setFeatureFlags(getMergedFeatureFlags());
 
       const flagsData = formatFlagsData(JSON.parse(await getFlags()));
       const envsData = formatEnvData(JSON.parse(await getEnvs()));

--- a/e2e/mobile/utils/featureFlagUtils.ts
+++ b/e2e/mobile/utils/featureFlagUtils.ts
@@ -1,0 +1,49 @@
+import { parseExtraFeatureFlags } from "@ledgerhq/live-common/e2e/featureFlagsJsonUtils";
+import type { PartialFeatures } from "@shared/feature-flags";
+import { isWallet40 } from "../helpers/commonHelpers";
+
+const defaultFlags = {
+  lwmWallet40: {
+    enabled: isWallet40,
+    params: {
+      mainNavigation: isWallet40,
+      marketBanner: isWallet40,
+      graphRework: isWallet40,
+      quickActionCtas: isWallet40,
+      tour: false,
+      lazyOnboarding: isWallet40,
+      balanceRefreshRework: isWallet40,
+      assetSection: false,
+      operationsList: false,
+      aggregatedAssets: false,
+      myWallet: isWallet40,
+      pnl: false,
+      assetDiscoverability: false,
+    },
+  },
+  onboardingWidget: {
+    enabled: true,
+  },
+  llmModularDrawer: {
+    enabled: true,
+    params: {
+      add_account: true,
+      live_app: true,
+      live_apps_allowlist: [],
+      live_apps_blocklist: ["revoke-cash"],
+      receive_flow: false,
+      send_flow: false,
+      enableModularization: true,
+      searchDebounceTime: 300,
+      backendEnvironment: "PROD",
+    },
+  },
+};
+
+export const getMergedFeatureFlags = ({
+  testFlags,
+}: { testFlags?: PartialFeatures } = {}): PartialFeatures => ({
+  ...defaultFlags,
+  ...parseExtraFeatureFlags<PartialFeatures>(process.env.E2E_FEATURE_FLAGS_JSON),
+  ...testFlags,
+});

--- a/e2e/mobile/utils/initUtil.ts
+++ b/e2e/mobile/utils/initUtil.ts
@@ -3,7 +3,7 @@ import { isObservable, lastValueFrom, Observable } from "rxjs";
 import { log } from "detox";
 import { allure } from "jest-allure2-reporter/api";
 import { SpeculosAppType } from "@ledgerhq/live-common/e2e/enum/AppInfos";
-import { isSpeculosRemote, isWallet40 } from "../helpers/commonHelpers";
+import { isSpeculosRemote } from "../helpers/commonHelpers";
 import {
   deleteSpeculos,
   launchSpeculos,
@@ -14,7 +14,7 @@ import {
 import { waitForSpeculosReady } from "@ledgerhq/live-common/e2e/speculosCI";
 import type { PartialFeatures } from "@shared/feature-flags";
 import { sanitizeError } from "@ledgerhq/live-common/e2e/index";
-import { parseExtraFeatureFlags } from "@ledgerhq/live-common/e2e/featureFlagsJsonUtils";
+import { getMergedFeatureFlags } from "./featureFlagUtils";
 
 function checkTestFailed(): void {
   if (globalThis.IS_FAILED) {
@@ -403,51 +403,7 @@ export class InitializationManager {
   }
 
   static async setFeatureFlags(featureFlags: PartialFeatures) {
-    const defaultFlags = {
-      lwmWallet40: {
-        enabled: isWallet40,
-        params: {
-          mainNavigation: isWallet40,
-          marketBanner: isWallet40,
-          graphRework: isWallet40,
-          quickActionCtas: isWallet40,
-          tour: false,
-          lazyOnboarding: isWallet40,
-          balanceRefreshRework: isWallet40,
-          assetSection: false,
-          operationsList: false,
-          aggregatedAssets: false,
-          myWallet: isWallet40,
-          pnl: false,
-          assetDiscoverability: false,
-        },
-      },
-      onboardingWidget: {
-        enabled: true,
-      },
-      llmModularDrawer: {
-        enabled: true,
-        params: {
-          add_account: true,
-          live_app: true,
-          live_apps_allowlist: [],
-          live_apps_blocklist: ["revoke-cash"],
-          receive_flow: false,
-          send_flow: false,
-          enableModularization: true,
-          searchDebounceTime: 300,
-          backendEnvironment: "PROD",
-        },
-      },
-    };
-    const extraFeatureFlags = parseExtraFeatureFlags<PartialFeatures>(
-      process.env.E2E_FEATURE_FLAGS_JSON,
-    );
-    const mergedFeatureFlags = {
-      ...defaultFlags,
-      ...extraFeatureFlags,
-      ...featureFlags,
-    };
+    const mergedFeatureFlags = getMergedFeatureFlags({ testFlags: featureFlags });
     const wallet40 = mergedFeatureFlags.lwmWallet40;
     isMyWalletEnabled = Boolean(wallet40?.enabled && wallet40?.params?.myWallet);
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _E2E test-reporting tooling; no new unit test added. Validated end-to-end by a green Desktop E2E **smoke** run with a JSON FF override — [run 28376307754](https://github.com/LedgerHQ/ledger-live/actions/runs/28376307754) (9/9 passed). The Allure overview `environment.properties` showed both the JSON override (`FF.currencyConcordiumTestnet = true`) and the e2e defaults (`FF.lwdWallet40 = true` + params), confirming it is no longer Firebase-only._
- [x] **Impact of the changes:**
  - E2E **Allure report overview** (Environment widget) now lists the **merged** feature flags (e2e defaults + workflow `E2E_FEATURE_FLAGS_JSON`, JSON winning) on **both Desktop (LWD) and Mobile (LWM)** — not Firebase-only.
  - Per-test **"Merged Feature Flags"** attachment is intentionally **unchanged**.
  - Passing a `feature_flags_json` workflow input is now reflected in the overview.

### 📝 Description

**Problem.** The E2E Allure report *overview* (its Environment widget, sourced from `environment.properties`) showed **Firebase-only** feature flags. That disagreed with the per-test *"Merged Feature Flags"* attachment and with the workflow `E2E_FEATURE_FLAGS_JSON` override — three conflicting sources of truth. Root cause (identical on both platforms): the teardown that writes `environment.properties` launches a *fresh* app and reads its flags **without re-applying the e2e default + JSON overrides** the suite actually ran with.

**Solution.** Centralise FF resolution per platform and reuse it in the report teardown, so the overview reflects the real runtime baseline = `Firebase ⊕ e2e defaults ⊕ workflow JSON` (JSON takes precedence over defaults):

- **Desktop** — `e2e/desktop/tests/utils/global.teardown.ts` now passes `FEATURE_FLAGS: JSON.stringify(getMergedFeatureFlags())` into the teardown app launch (resolver already added by #19065 in `featureFlagUtils.ts`).
- **Mobile** — new shared `e2e/mobile/utils/featureFlagUtils.ts#getMergedFeatureFlags()` (extracted from `initUtil.ts`, behavior preserved), reused by `InitializationManager.setFeatureFlags` and applied via the bridge in `e2e/mobile/jest.globalTeardown.ts` before reading flags.

Per-test FF display is left as-is, per the ticket.

> 🔗 **Stacked on #19065** (\`support/QAA-1358\`), which introduces the desktop \`getMergedFeatureFlags()\`. This PR currently targets that branch for a clean single-commit diff — **retarget to \`develop\` once #19065 merges**.

<img width="1624" height="1000" alt="Screenshot 2026-06-29 at 16 25 51" src="https://github.com/user-attachments/assets/c6f5eaf4-13d7-4531-8098-30fe2b25f379" />


### ❓ Context

- **JIRA or GitHub link**: [QAA-1360](https://ledgerhq.atlassian.net/browse/QAA-1360)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1360]: https://ledgerhq.atlassian.net/browse/QAA-1360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ