### PR TITLE
[LWDM] feat(bitcoin): block manual fee below node min relay fee

### DIFF
--- a/.changeset/btc-min-relay-fee-floor.md
+++ b/.changeset/btc-min-relay-fee-floor.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/coin-bitcoin": minor
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Use the node's min relay fee as the minimum for manual Bitcoin-family fees in the send flow (BTC falls back to 1 sat/vB). A fee below it is now rejected in the form instead of at broadcast.

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7330,6 +7330,9 @@
     "FeeRequired": {
       "title": "Fees are required"
     },
+    "FeeTooLow": {
+      "title": "Fees are too low to be accepted by the network. Please increase them"
+    },
     "GasLessThanEstimate": {
       "title": "This may be too low. Please increase"
     },

--- a/apps/ledger-live-mobile/src/families/bitcoin/ScreenEditCustomFees.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/ScreenEditCustomFees.tsx
@@ -60,12 +60,16 @@ function BitcoinEditCustomFees({ navigation, route }: Props) {
   const bridge = useAccountBridge<BitcoinTransaction>(account, parentAccount);
   const [ownSatPerByte, setOwnSatPerByte] = useState(satPerByte ? satPerByte.toString() : "");
 
+  const relayFeePerByte = transaction.networkInfo?.relayFeePerByte;
+  const feeValue = BigNumber(ownSatPerByte || 0);
+  const isBelowRelayFee = !!relayFeePerByte && feeValue.gt(0) && feeValue.lt(relayFeePerByte);
+
   const onChange = useCallback((text: string) => {
     setOwnSatPerByte(text.replace(/\D/g, ""));
   }, []);
 
   const onValidateText = useCallback(() => {
-    if (BigNumber(ownSatPerByte || 0).isZero()) return;
+    if (BigNumber(ownSatPerByte || 0).isZero() || isBelowRelayFee) return;
     Keyboard.dismiss();
     if (setSatPerByte) {
       setSatPerByte(BigNumber(ownSatPerByte || 0));
@@ -90,7 +94,16 @@ function BitcoinEditCustomFees({ navigation, route }: Props) {
     }
 
     popToScreen(navigation, currentNavigation, nextParams);
-  }, [setSatPerByte, ownSatPerByte, account, bridge, route.params, navigation, transaction]);
+  }, [
+    setSatPerByte,
+    ownSatPerByte,
+    isBelowRelayFee,
+    account,
+    bridge,
+    route.params,
+    navigation,
+    transaction,
+  ]);
   return (
     <SafeAreaView
       edges={["left", "right", "bottom"]}
@@ -134,6 +147,11 @@ function BitcoinEditCustomFees({ navigation, route }: Props) {
               {t("common.satPerByte")}
             </LText>
           </View>
+          {isBelowRelayFee ? (
+            <LText style={[styles.error, { color: colors.alert }]}>
+              {t("errors.FeeTooLow.title")}
+            </LText>
+          ) : null}
           <View style={styles.flex}>
             <Button
               event="BitcoinSetSatPerByte"
@@ -141,7 +159,7 @@ function BitcoinEditCustomFees({ navigation, route }: Props) {
               title={t("common.continue")}
               onPress={onValidateText}
               containerStyle={styles.buttonContainer}
-              disabled={BigNumber(ownSatPerByte || 0).isZero()}
+              disabled={feeValue.isZero() || isBelowRelayFee}
             />
           </View>
         </NavigationScrollView>
@@ -172,6 +190,10 @@ const styles = StyleSheet.create({
   currency: {
     fontSize: 20,
     padding: 6,
+  },
+  error: {
+    textAlign: "center",
+    paddingHorizontal: 20,
   },
   buttonContainer: {
     marginHorizontal: 16,

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -478,6 +478,9 @@
     "FeeRequired": {
       "title": "Fees are required"
     },
+    "FeeTooLow": {
+      "title": "Fees are too low to be accepted by the network. Please increase them"
+    },
     "FirmwareOrAppUpdateRequired": {
       "title": "Firmware or app update needed",
       "description": "Please use My Ledger to uninstall all apps then check if a firmware update is available before reinstalling them."

--- a/libs/coin-modules/coin-bitcoin/src/__tests__/unit/prepareTransaction.unit.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/__tests__/unit/prepareTransaction.unit.test.ts
@@ -111,6 +111,7 @@ describe("prepareTransaction", () => {
       })),
       defaultFeePerByte: new BigNumber("2"),
     },
+    relayFeePerByte: new BigNumber("1"),
   };
 
   const makeTransaction = (overrides: Partial<Transaction> = {}): Transaction =>

--- a/libs/coin-modules/coin-bitcoin/src/datasets/bitcoin.ts
+++ b/libs/coin-modules/coin-bitcoin/src/datasets/bitcoin.ts
@@ -210,6 +210,7 @@ const dataset: CurrenciesData<Transaction> = {
                   ],
                   defaultFeePerByte: new BigNumber(1),
                 },
+                relayFeePerByte: new BigNumber(1),
               },
               rbf: false,
               utxoStrategy: {
@@ -258,6 +259,7 @@ const dataset: CurrenciesData<Transaction> = {
                   ],
                   defaultFeePerByte: new BigNumber(1),
                 },
+                relayFeePerByte: new BigNumber(1),
               },
               rbf: false,
               utxoStrategy: {
@@ -309,6 +311,7 @@ const dataset: CurrenciesData<Transaction> = {
                   ],
                   defaultFeePerByte: new BigNumber(1),
                 },
+                relayFeePerByte: new BigNumber(1),
               },
               rbf: false,
               utxoStrategy: {

--- a/libs/coin-modules/coin-bitcoin/src/errors.ts
+++ b/libs/coin-modules/coin-bitcoin/src/errors.ts
@@ -7,3 +7,5 @@ export const TaprootNotActivated = createCustomErrorClass("TaprootNotActivated")
 export const BitcoinInfrastructureError = createCustomErrorClass("InfrastructureError");
 
 export const RbfBuildError = createCustomErrorClass("RbfBuildError");
+
+export const FeeTooLow = createCustomErrorClass("FeeTooLow");

--- a/libs/coin-modules/coin-bitcoin/src/getAccountNetworkInfo.relayFee.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/getAccountNetworkInfo.relayFee.test.ts
@@ -1,0 +1,45 @@
+import { Account } from "@ledgerhq/types-live";
+
+const explorerWith = (relay_fee?: string) => ({
+  getFees: jest.fn().mockResolvedValue({ "2": 3000, "3": 2000, "6": 1000 }),
+  // getRelayFeeFloorSatVb only calls getNetwork when it exists; omit it to simulate a node
+  // that does not expose the relay fee.
+  ...(relay_fee !== undefined ? { getNetwork: jest.fn().mockResolvedValue({ relay_fee }) } : {}),
+});
+
+let currentExplorer = explorerWith("0.00001000");
+
+jest.mock("./wallet-btc", () => ({
+  __esModule: true,
+  getWalletAccount: jest.fn(() => ({ xpub: { explorer: currentExplorer } })),
+}));
+
+import { getAccountNetworkInfo } from "./getAccountNetworkInfo";
+
+const account = (id = "bitcoin") => ({ currency: { id } }) as unknown as Account;
+
+describe("getAccountNetworkInfo relayFeePerByte", () => {
+  it("uses the relay fee returned by the node (not the fallback)", async () => {
+    currentExplorer = explorerWith("0.00003000"); // 3 sat/vB
+    const info = await getAccountNetworkInfo(account());
+    expect(info.relayFeePerByte.toNumber()).toBe(3);
+  });
+
+  it("falls back to 1 sat/vB when the node does not return a relay fee", async () => {
+    currentExplorer = explorerWith(undefined);
+    const info = await getAccountNetworkInfo(account());
+    expect(info.relayFeePerByte.toNumber()).toBe(1);
+  });
+
+  it("uses the node relay fee as-is for non-bitcoin coins (no 1 sat/vB clamp)", async () => {
+    currentExplorer = explorerWith("0.00003000"); // 3 sat/vB
+    const info = await getAccountNetworkInfo(account("litecoin"));
+    expect(info.relayFeePerByte.toNumber()).toBe(3);
+  });
+
+  it("sets 0 (no floor) for non-bitcoin coins when the node has no relay fee", async () => {
+    currentExplorer = explorerWith(undefined);
+    const info = await getAccountNetworkInfo(account("litecoin"));
+    expect(info.relayFeePerByte.toNumber()).toBe(0);
+  });
+});

--- a/libs/coin-modules/coin-bitcoin/src/getAccountNetworkInfo.ts
+++ b/libs/coin-modules/coin-bitcoin/src/getAccountNetworkInfo.ts
@@ -66,8 +66,13 @@ export async function getAccountNetworkInfo(account: Account): Promise<NetworkIn
     })),
     defaultFeePerByte: clamped[Math.floor(clamped.length / 2)] || new BigNumber(0),
   };
+  // BTC enforces a 1 sat/vB floor (Bitcoin Core's minrelaytxfee default); other coins use the node value as-is
+  const relayFeePerByte =
+    account.currency.id === "bitcoin" ? BigNumber.max(floorSatPerVB, 1) : floorSatPerVB;
+
   return {
     family: "bitcoin",
     feeItems,
+    relayFeePerByte,
   };
 }

--- a/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.test.ts
@@ -3,7 +3,7 @@
 import { Account } from "@ledgerhq/types-live";
 import { BitcoinInput, Transaction } from "./types";
 import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
-import { RbfBuildError } from "./errors";
+import { RbfBuildError, FeeTooLow } from "./errors";
 import BigNumber from "bignumber.js";
 
 // Mock modules before importing the module under test
@@ -182,6 +182,61 @@ describe("getTransactionStatus on Bitcoin", () => {
       await expect(getTransactionStatus(buildAccount(), buildTransaction())).rejects.toBe(
         unknownError,
       );
+    });
+  });
+
+  describe("min relay fee floor", () => {
+    const recipient = "bc1pxlmrudqyq8qd8pfsc4mpmlaw56x6vtcr9m8nvp8kj3gckefc4kmqhkg4l7";
+
+    beforeEach(() => {
+      validateRecipientSpy.mockResolvedValue({
+        recipientError: undefined,
+        recipientWarning: undefined,
+        changeAddressError: undefined,
+        changeAddressWarning: undefined,
+      });
+      isAddressSanctionedSpy.mockResolvedValue(false);
+      calculateFeesSpy.mockResolvedValue({ txInputs: [], txOutputs: [], fees: BigNumber(0) });
+    });
+
+    const buildAccount = () =>
+      ({
+        currency: { id: "bitcoin" },
+        blockHeight: MAX_BLOCK_HEIGHT_FOR_TAPROOT + 1,
+      }) as unknown as Account;
+
+    const buildTransaction = (feePerByte: number, relayFeePerByte?: number) =>
+      ({
+        amount: BigNumber(1),
+        recipient,
+        feePerByte: BigNumber(feePerByte),
+        networkInfo:
+          relayFeePerByte !== undefined
+            ? { family: "bitcoin", feeItems: {}, relayFeePerByte: BigNumber(relayFeePerByte) }
+            : undefined,
+      }) as unknown as Transaction;
+
+    it("sets FeeTooLow when manual fee is below the relay floor", async () => {
+      const status = await getTransactionStatus(buildAccount(), buildTransaction(1, 3));
+      expect(status.errors.feePerByte).toBeInstanceOf(FeeTooLow);
+    });
+
+    it("accepts a manual fee equal to the relay floor", async () => {
+      const status = await getTransactionStatus(buildAccount(), buildTransaction(3, 3));
+      expect(status.errors.feePerByte).toBeUndefined();
+    });
+
+    it("applies the 1 sat/vB fallback for bitcoin when networkInfo is missing", async () => {
+      const tooLow = await getTransactionStatus(buildAccount(), buildTransaction(0.5));
+      expect(tooLow.errors.feePerByte).toBeInstanceOf(FeeTooLow);
+
+      const atFloor = await getTransactionStatus(buildAccount(), buildTransaction(1));
+      expect(atFloor.errors.feePerByte).toBeUndefined();
+    });
+
+    it("applies the 1 sat/vB fallback for bitcoin when relayFeePerByte is 0 (back-compat)", async () => {
+      const status = await getTransactionStatus(buildAccount(), buildTransaction(0.5, 0));
+      expect(status.errors.feePerByte).toBeInstanceOf(FeeTooLow);
     });
   });
 });

--- a/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.ts
@@ -15,7 +15,7 @@ import { calculateFees, validateRecipient, isTaprootRecipient } from "./cache";
 import { OP_RETURN_DATA_SIZE_LIMIT } from "./wallet-btc/crypto/base";
 import cryptoFactory from "./wallet-btc/crypto/factory";
 import { computeDustAmount } from "./wallet-btc/utils";
-import { TaprootNotActivated } from "./errors";
+import { TaprootNotActivated, FeeTooLow } from "./errors";
 import { Currency } from "./wallet-btc";
 import { isAddressSanctioned } from "@ledgerhq/ledger-wallet-framework/sanction/index";
 import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
@@ -79,10 +79,20 @@ export const getTransactionStatus: AccountBridge<
   let estimatedFees = new BigNumber(0);
   const { opReturnData, changeAddress } = transaction;
 
+  const networkRelayFee = transaction.networkInfo?.relayFeePerByte;
+  const relayFeePerByte =
+    networkRelayFee && networkRelayFee.gt(0)
+      ? networkRelayFee
+      : account.currency.id === "bitcoin"
+        ? new BigNumber(1)
+        : undefined;
+
   if (!transaction.feePerByte) {
     errors.feePerByte = new FeeNotLoaded();
   } else if (transaction.feePerByte.eq(0)) {
     errors.feePerByte = new FeeRequired();
+  } else if (relayFeePerByte && transaction.feePerByte.lt(relayFeePerByte)) {
+    errors.feePerByte = new FeeTooLow();
   } else if (transaction.recipient && !errors.recipient) {
     await calculateFees({
       account: account,

--- a/libs/coin-modules/coin-bitcoin/src/transaction.ts
+++ b/libs/coin-modules/coin-bitcoin/src/transaction.ts
@@ -57,6 +57,7 @@ export const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
     networkInfo: tr.networkInfo && {
       family: tr.networkInfo.family,
       feeItems: fromFeeItemsRaw(tr.networkInfo.feeItems),
+      relayFeePerByte: new BigNumber(tr.networkInfo.relayFeePerByte ?? 0),
     },
     feesStrategy: tr.feesStrategy,
     opReturnData: tr.opReturnData,
@@ -75,6 +76,7 @@ export const toTransactionRaw = (t: Transaction): TransactionRaw => {
     networkInfo: t.networkInfo && {
       family: t.networkInfo.family,
       feeItems: toFeeItemsRaw(t.networkInfo.feeItems),
+      relayFeePerByte: t.networkInfo.relayFeePerByte.toString(),
     },
     feesStrategy: t.feesStrategy,
     opReturnData: t.opReturnData,

--- a/libs/coin-modules/coin-bitcoin/src/types.ts
+++ b/libs/coin-modules/coin-bitcoin/src/types.ts
@@ -117,10 +117,13 @@ export type FeeItemsRaw = {
 export type NetworkInfo = {
   family: "bitcoin";
   feeItems: FeeItems;
+  relayFeePerByte: BigNumber;
 };
 export type NetworkInfoRaw = {
   family: "bitcoin";
   feeItems: FeeItemsRaw;
+  // optional for back-compat with transactions serialized before this field existed
+  relayFeePerByte?: string;
 };
 export const bitcoinPickingStrategy = {
   DEEP_OUTPUTS_FIRST: 0,

--- a/libs/ledger-live-common/src/families/bitcoin/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/bridge/mock.ts
@@ -124,6 +124,7 @@ const prepareTransaction = async (
       networkInfo: {
         family: "bitcoin",
         feeItems,
+        relayFeePerByte: new BigNumber(1),
       },
     };
   }

--- a/libs/ledger-live-common/src/families/bitcoin/descriptor/fees.test.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/descriptor/fees.test.ts
@@ -1,0 +1,31 @@
+import { BigNumber } from "bignumber.js";
+import { fees } from "./fees";
+
+const feePerByteInput = fees.custom?.inputs.find(input => input.key === "feePerByte");
+
+describe("bitcoin fee descriptor - feePerByte minValue", () => {
+  it("returns the relay fee floor from networkInfo when present", () => {
+    const transaction = {
+      networkInfo: { relayFeePerByte: new BigNumber(3) },
+    };
+    expect(feePerByteInput?.minValue?.getValue(transaction)).toBe("3");
+  });
+
+  it("returns null when networkInfo has no relay fee (no floor enforced)", () => {
+    const transaction = { networkInfo: { feeItems: { items: [] } } };
+    expect(feePerByteInput?.minValue?.getValue(transaction)).toBeNull();
+  });
+
+  it("returns null when relayFeePerByte is 0 (no misleading minimum)", () => {
+    const transaction = { networkInfo: { relayFeePerByte: new BigNumber(0) } };
+    expect(feePerByteInput?.minValue?.getValue(transaction)).toBeNull();
+  });
+
+  it("returns null when networkInfo is missing", () => {
+    expect(feePerByteInput?.minValue?.getValue({})).toBeNull();
+  });
+
+  it("returns null for a non-record transaction", () => {
+    expect(feePerByteInput?.minValue?.getValue(undefined)).toBeNull();
+  });
+});

--- a/libs/ledger-live-common/src/families/bitcoin/descriptor/fees.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/descriptor/fees.ts
@@ -99,6 +99,16 @@ export const fees: FeeDescriptor = {
             return getSuggestedFeePerByteRange(transaction);
           },
         },
+        minValue: {
+          getValue: transaction => {
+            if (!isRecord(transaction)) return null;
+            const networkInfo = transaction.networkInfo;
+            const relayFeePerByte = isRecord(networkInfo) ? networkInfo.relayFeePerByte : undefined;
+            return isBigNumber(relayFeePerByte) && relayFeePerByte.gt(0)
+              ? relayFeePerByte.toFixed()
+              : null;
+          },
+        },
       },
     ],
     getInitialValues: (transaction): Record<string, string> => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Bitcoin-family send flow: BTC enforces a 1 sat/vB floor; other coins (LTC, DOGE, DASH, DGB, ZEC…) use their node's relay fee as the floor when the explorer exposes it (no floor otherwise).
      - Manual / custom fee entry in all four send flows (old + new, desktop + mobile).
      - Verify a manual fee below the node minimum is blocked in the form (not at broadcast), and a normal fee still goes through.

### 📝 Description

**Problem**: a user could enter a custom sat/vB below what the node will relay, which only failed later at broadcast with a "min relay fee not met" error.

**Solution**: fetch the node's min relay fee from Atlas (`/network` → `relay_fee`) and use it as the minimum for manual BTC fees in the send flow. When the node doesn't return it, we fall back to **1 sat/vB** (Bitcoin Core's default `minrelaytxfee`). The floor is stored on `networkInfo.relayFeePerByte` (BTC only) by `getAccountNetworkInfo`, then enforced in the form.

#### What happens per flow

| Flow | Input | Behaviour when fee < floor |
| --- | --- | --- |
| **Desktop – old** (`FeesField`) | integer-only | `FeeTooLow` shown directly under the fee input, Continue disabled |
| **Mobile – old** (`ScreenEditCustomFees`) | integer-only | inline `FeeTooLow` message added on the input + button disabled (also caught on the Summary) |
| **Desktop – new** (MVVM `CustomFees`) | decimals allowed | descriptor `minValue` → "Minimum is N" on the input + confirm disabled |
| **Mobile – new** (MVVM `CustomFees`) | decimals allowed | same shared descriptor → "Minimum is N" on the input + confirm disabled |

#### Why two guards

1. **`minValue` on the custom-fee descriptor** (`live-common`, used by both *new* flows): the front-line, input-level guard. It's the only layer that can show "Minimum is N" *where the user types*, and it's needed because the new flows accept decimals (e.g. `0.1`, which otherwise got floored to `0` and showed a confusing "fees required").

2. **`FeeTooLow` in `getTransactionStatus`** (`coin-bitcoin`): the backstop at transaction-validation level. `getTransactionStatus` runs for **every** flow and path (old flows, RBF / edit-transaction), so it invalidates a too-low fee even where no input-level guard exists. This matters as soon as the node returns a relay fee **> 1**: in the old flows the integer input happily accepts `1`, and only this backstop would reject it when the floor is e.g. `3`.

The two are complementary: `minValue` is UX (clear message at the input, new flows), `FeeTooLow` is correctness (uniform coverage across all flows/paths). Today the node returns `1 sat/vB`, so the practical effect is a robust 1 sat/vB floor + a fallback if Atlas is unavailable; the mechanism scales automatically if the node ever reports a higher relay fee.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-23486](https://ledgerhq.atlassian.net/browse/LIVE-23486)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23486]: https://ledgerhq.atlassian.net/browse/LIVE-23486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
