### PR TITLE
[LWM] feat(LIVE-30450): add view key warning screen to Aleo mobile add account flow

### DIFF
--- a/.changeset/honest-snakes-play.md
+++ b/.changeset/honest-snakes-play.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add view key warning screen to Aleo add-account flow on mobile

--- a/apps/ledger-live-mobile/scripts/sync-families-dispatch.mjs
+++ b/apps/ledger-live-mobile/scripts/sync-families-dispatch.mjs
@@ -44,6 +44,7 @@ const targets = [
   "ExpiryDurationInput",
   "ShouldUseReceiveOptions",
   "PendingTransferProposals",
+  "customAddAccountFlow",
 ];
 
 async function genTarget(target) {

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -421,6 +421,9 @@ export enum ScreenName {
   CantonOnboardAccount = "CantonOnboardAccount",
   // Concordium
   ConcordiumOnboardAccount = "ConcordiumOnboardAccount",
+  // Aleo
+  AleoAddAccount = "AleoAddAccount",
+  AleoViewKeyWarning = "AleoViewKeyWarning",
 
   OnboardingWelcome = "OnboardingWelcome",
   OnboardingPostWelcomeSelection = "OnboardingPostWelcomeSelection",

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/AddAccountNavigator.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/AddAccountNavigator.tsx
@@ -1,0 +1,77 @@
+import React, { useCallback, useMemo } from "react";
+import { Platform } from "react-native";
+import { useTheme } from "@react-navigation/native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { NavigationHeaderCloseButtonAdvanced } from "~/components/NavigationHeaderCloseButton";
+import { Trans } from "~/context/Locale";
+import type {
+  StackNavigatorNavigation,
+  StackNavigatorProps,
+} from "~/components/RootNavigator/types/helpers";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { ScreenName } from "~/const";
+import { AleoAddAccountParamList, AleoViewKeyFlowParamList } from "./types";
+import ViewKeyWarningScreen from "./ViewKeyWarningScreen";
+
+type Props = StackNavigatorProps<AleoAddAccountParamList, ScreenName.AleoAddAccount>;
+
+const Stack = createNativeStackNavigator<AleoViewKeyFlowParamList>();
+
+const DEFAULT_ADD_ACCOUNT_FLOW_DEPTH = 2; // SelectDevice + AddAccounts
+
+function AddAccountNavigator({ route, navigation }: Props) {
+  const { colors } = useTheme();
+  const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, false), [colors]);
+  const initialRouteName = ScreenName.AleoViewKeyWarning;
+  const navigationDepth = route.params.navigationDepth;
+  const handleClose = useCallback(() => {
+    const parent = navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>();
+    parent?.pop(navigationDepth ?? DEFAULT_ADD_ACCOUNT_FLOW_DEPTH);
+  }, [navigation, navigationDepth]);
+
+  return (
+    <Stack.Navigator
+      initialRouteName={initialRouteName}
+      screenOptions={{
+        ...stackNavigationConfig,
+        gestureEnabled: Platform.OS === "ios",
+        // Default close pops only one parent screen; pop(navigationDepth) exits the full add-account stack.
+        headerRight: () => (
+          <NavigationHeaderCloseButtonAdvanced
+            withConfirmation
+            skipNavigation
+            onClose={handleClose}
+            confirmationTitle={<Trans i18nKey="addAccounts.quitConfirmation.v2.title" />}
+            confirmButtonText={<Trans i18nKey="addAccounts.quitConfirmation.v2.cancel" />}
+            rejectButtonText={<Trans i18nKey="addAccounts.quitConfirmation.v2.continue" />}
+            cancelCTAConfig={{ type: "primary", outline: true }}
+            customDrawerStyle={{
+              title: {
+                textAlign: "left",
+                fontSize: 18,
+                fontWeight: "600",
+                lineHeight: 32.4,
+                letterSpacing: -0.72,
+                marginBottom: 16,
+                marginTop: -45,
+              },
+            }}
+          />
+        ),
+      }}
+    >
+      <Stack.Screen
+        name={ScreenName.AleoViewKeyWarning}
+        component={ViewKeyWarningScreen}
+        initialParams={{ ...route.params, onCloseNavigation: handleClose }}
+        options={{ headerTitle: "" }}
+      />
+    </Stack.Navigator>
+  );
+}
+
+const options = {
+  headerShown: false,
+};
+export { AddAccountNavigator as component, options };

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/AddAccountNavigator.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/AddAccountNavigator.tsx
@@ -20,7 +20,36 @@ const Stack = createNativeStackNavigator<AleoViewKeyFlowParamList>();
 
 const DEFAULT_ADD_ACCOUNT_FLOW_DEPTH = 2; // SelectDevice + AddAccounts
 
-function AddAccountNavigator({ route, navigation }: Props) {
+interface HeaderRightProps {
+  onClose: () => void;
+}
+
+function HeaderRight({ onClose }: Readonly<HeaderRightProps>) {
+  return (
+    <NavigationHeaderCloseButtonAdvanced
+      withConfirmation
+      skipNavigation
+      onClose={onClose}
+      confirmationTitle={<Trans i18nKey="addAccounts.quitConfirmation.v2.title" />}
+      confirmButtonText={<Trans i18nKey="addAccounts.quitConfirmation.v2.cancel" />}
+      rejectButtonText={<Trans i18nKey="addAccounts.quitConfirmation.v2.continue" />}
+      cancelCTAConfig={{ type: "primary", outline: true }}
+      customDrawerStyle={{
+        title: {
+          textAlign: "left",
+          fontSize: 18,
+          fontWeight: "600",
+          lineHeight: 32.4,
+          letterSpacing: -0.72,
+          marginBottom: 16,
+          marginTop: -45,
+        },
+      }}
+    />
+  );
+}
+
+function AddAccountNavigator({ route, navigation }: Readonly<Props>) {
   const { colors } = useTheme();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, false), [colors]);
   const initialRouteName = ScreenName.AleoViewKeyWarning;
@@ -30,6 +59,8 @@ function AddAccountNavigator({ route, navigation }: Props) {
     parent?.pop(navigationDepth ?? DEFAULT_ADD_ACCOUNT_FLOW_DEPTH);
   }, [navigation, navigationDepth]);
 
+  const renderHeaderRight = useCallback(() => <HeaderRight onClose={handleClose} />, [handleClose]);
+
   return (
     <Stack.Navigator
       initialRouteName={initialRouteName}
@@ -37,28 +68,7 @@ function AddAccountNavigator({ route, navigation }: Props) {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
         // Default close pops only one parent screen; pop(navigationDepth) exits the full add-account stack.
-        headerRight: () => (
-          <NavigationHeaderCloseButtonAdvanced
-            withConfirmation
-            skipNavigation
-            onClose={handleClose}
-            confirmationTitle={<Trans i18nKey="addAccounts.quitConfirmation.v2.title" />}
-            confirmButtonText={<Trans i18nKey="addAccounts.quitConfirmation.v2.cancel" />}
-            rejectButtonText={<Trans i18nKey="addAccounts.quitConfirmation.v2.continue" />}
-            cancelCTAConfig={{ type: "primary", outline: true }}
-            customDrawerStyle={{
-              title: {
-                textAlign: "left",
-                fontSize: 18,
-                fontWeight: "600",
-                lineHeight: 32.4,
-                letterSpacing: -0.72,
-                marginBottom: 16,
-                marginTop: -45,
-              },
-            }}
-          />
-        ),
+        headerRight: renderHeaderRight,
       }}
     >
       <Stack.Screen

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyWarningScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyWarningScreen.tsx
@@ -1,0 +1,162 @@
+import React, { useCallback, useState } from "react";
+import { Linking, ScrollView, StyleSheet, View } from "react-native";
+import SafeAreaView from "~/components/SafeAreaView";
+import { useTheme } from "styled-components/native";
+import { ScreenName } from "~/const";
+import LText from "~/components/LText";
+import Button from "~/components/wrappedUi/Button";
+import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import { Trans, useTranslation } from "~/context/Locale";
+import { urls } from "~/utils/urls";
+import type { AleoViewKeyFlowParamList } from "./types";
+import ConfirmationModal from "~/components/ConfirmationModal";
+
+type Props = StackNavigatorProps<AleoViewKeyFlowParamList, ScreenName.AleoViewKeyWarning>;
+
+const bulletPointTranslationKeys = [
+  "aleo.addAccount.stepViewKeyWarning.bullets.0",
+  "aleo.addAccount.stepViewKeyWarning.bullets.1",
+  "aleo.addAccount.stepViewKeyWarning.bullets.2",
+  "aleo.addAccount.stepViewKeyWarning.bullets.3",
+  "aleo.addAccount.stepViewKeyWarning.bullets.4",
+];
+
+const confirmationTitleStyle: Record<string, unknown> = {
+  textAlign: "left",
+  fontSize: 18,
+  fontWeight: "600",
+  lineHeight: 32.4,
+  letterSpacing: -0.72,
+  marginBottom: 16,
+  marginTop: -45,
+};
+
+export default function ViewKeyWarningScreen({ route, navigation }: Props) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+
+  const { onCloseNavigation } = route.params;
+  const [isConfirmationModalOpened, setIsConfirmationModalOpened] = useState(false);
+  const [shouldNavigateOnHide, setShouldNavigateOnHide] = useState(false);
+
+  const onContinue = useCallback(() => {
+    navigation.getParent()?.navigate(ScreenName.ScanDeviceAccounts, {
+      ...route.params,
+      onCloseNavigation,
+    });
+  }, [navigation, onCloseNavigation, route.params]);
+
+  const onCancel = useCallback(() => {
+    setIsConfirmationModalOpened(true);
+  }, []);
+
+  const closeConfirmationModal = useCallback(() => {
+    setShouldNavigateOnHide(false);
+    setIsConfirmationModalOpened(false);
+  }, []);
+
+  const onConfirmCancel = useCallback(() => {
+    setShouldNavigateOnHide(true);
+    setIsConfirmationModalOpened(false);
+  }, []);
+
+  return (
+    <SafeAreaView edges={["bottom"]} style={[styles.root, { backgroundColor: colors.background.main }]}>
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+        <LText semiBold style={styles.title} color="neutral.c100">
+          <Trans i18nKey="aleo.addAccount.stepViewKeyWarning.title" />
+        </LText>
+        <LText secondary style={styles.description} color="neutral.c70">
+          <Trans i18nKey="aleo.addAccount.stepViewKeyWarning.description">
+            <LText
+              onPress={() => Linking.openURL(urls.aleo.learnMore)}
+              accessibilityRole="link"
+              color="primary.c80"
+            />
+          </Trans>
+        </LText>
+        <View style={styles.bullets}>
+          {bulletPointTranslationKeys.map(i18nKey => (
+            <View key={i18nKey} style={styles.bulletRow}>
+              <View style={[styles.bulletDot, { backgroundColor: colors.neutral.c70 }]} />
+              <LText secondary style={styles.bullet} color="neutral.c70">
+                <Trans i18nKey={i18nKey} />
+              </LText>
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+      <View style={styles.footer}>
+        <Button type="main" onPress={onContinue} event="AleoAddAccountViewKeyWarningContinue">
+          {t("aleo.addAccount.stepViewKeyWarning.cta.allow")}
+        </Button>
+        <Button
+          type="main"
+          outline
+          mt={4}
+          onPress={onCancel}
+          event="AleoAddAccountViewKeyWarningCancel"
+        >
+          {t("aleo.addAccount.stepViewKeyWarning.cta.cancel")}
+        </Button>
+      </View>
+      <ConfirmationModal
+        isOpened={isConfirmationModalOpened}
+        onClose={closeConfirmationModal}
+        onConfirm={onConfirmCancel}
+        onModalHide={shouldNavigateOnHide ? onCloseNavigation : undefined}
+        confirmationTitle={<Trans i18nKey="addAccounts.quitConfirmation.v2.title" />}
+        confirmButtonText={<Trans i18nKey="addAccounts.quitConfirmation.v2.cancel" />}
+        rejectButtonText={<Trans i18nKey="addAccounts.quitConfirmation.v2.continue" />}
+        cancelCTAConfig={{ type: "primary", outline: true }}
+        customTitleStyle={confirmationTitleStyle}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  scroll: {
+    flex: 1,
+  },
+  content: {
+    paddingHorizontal: 16,
+    paddingVertical: 24,
+    rowGap: 16,
+  },
+  title: {
+    fontSize: 24,
+    lineHeight: 32,
+    textAlign: "center",
+  },
+  description: {
+    fontSize: 14,
+    lineHeight: 22,
+    textAlign: "left",
+  },
+  bullets: {
+    rowGap: 12,
+  },
+  bulletRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    columnGap: 10,
+  },
+  bulletDot: {
+    marginTop: 8,
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+  },
+  bullet: {
+    fontSize: 14,
+    lineHeight: 22,
+    flex: 1,
+  },
+  footer: {
+    padding: 16,
+  },
+});

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyWarningScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyWarningScreen.tsx
@@ -8,6 +8,7 @@ import Button from "~/components/wrappedUi/Button";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { Trans, useTranslation } from "~/context/Locale";
 import { urls } from "~/utils/urls";
+import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 import type { AleoViewKeyFlowParamList } from "./types";
 import ConfirmationModal from "~/components/ConfirmationModal";
 
@@ -36,6 +37,7 @@ export default function ViewKeyWarningScreen({ route, navigation }: Props) {
   const { t } = useTranslation();
 
   const { onCloseNavigation } = route.params;
+  const learnMoreUrl = useLocalizedUrl(urls.aleo.learnMore);
   const [isConfirmationModalOpened, setIsConfirmationModalOpened] = useState(false);
   const [shouldNavigateOnHide, setShouldNavigateOnHide] = useState(false);
 
@@ -69,7 +71,7 @@ export default function ViewKeyWarningScreen({ route, navigation }: Props) {
         <LText secondary style={styles.description} color="neutral.c70">
           <Trans i18nKey="aleo.addAccount.stepViewKeyWarning.description">
             <LText
-              onPress={() => Linking.openURL(urls.aleo.learnMore)}
+              onPress={() => Linking.openURL(learnMoreUrl)}
               accessibilityRole="link"
               color="primary.c80"
             />

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/AddAccountNavigator.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/AddAccountNavigator.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { render } from "@tests/test-renderer";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { ScreenName } from "~/const";
+import { component as AddAccountNavigator, options } from "../AddAccountNavigator";
+import type { AleoAddAccountParamList } from "../types";
+import { aleoCurrency } from "../../__mocks__/currency.mock";
+
+type ScreenProps = { route: { params: { onCloseNavigation?: () => void } } };
+
+// Capture the props that AddAccountNavigator injects into the inner screen.
+let capturedRouteParams: ScreenProps["route"]["params"] | null = null;
+
+jest.mock("../ViewKeyWarningScreen", () => {
+  return function MockViewKeyWarningScreen({ route }: ScreenProps) {
+    capturedRouteParams = route.params;
+    return <></>;
+  };
+});
+
+jest.mock("~/navigation/navigatorConfig", () => ({
+  getStackNavigatorConfig: jest.fn(() => ({
+    headerStyle: { backgroundColor: "#000" },
+    headerTintColor: "#fff",
+  })),
+}));
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useTheme: jest.fn(() => ({
+    colors: {
+      background: "#000",
+      card: "#111",
+      text: "#fff",
+      border: "#333",
+      notification: "#ff0000",
+      primary: "#0066cc",
+    },
+    fonts: {
+      bold: "System",
+      regular: "System",
+      medium: "System",
+    },
+  })),
+}));
+
+const mockDevice = { deviceId: "device-1", modelId: "nanoX", wired: false };
+const mockPop = jest.fn();
+
+const makeTestNavigator = (navigationDepth?: number) => {
+  const Stack = createNativeStackNavigator<AleoAddAccountParamList>();
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name={ScreenName.AleoAddAccount}
+        component={AddAccountNavigator}
+        initialParams={{ currency: aleoCurrency, device: mockDevice, navigationDepth }}
+      />
+    </Stack.Navigator>
+  );
+};
+
+describe("AleoAddAccountNavigator", () => {
+  beforeEach(() => {
+    capturedRouteParams = null;
+    mockPop.mockClear();
+  });
+
+  it("exports headerShown: false options", () => {
+    expect(options).toEqual({ headerShown: false });
+  });
+
+  it("renders without crashing", () => {
+    expect(() => render(makeTestNavigator())).not.toThrow();
+  });
+
+  it("injects an onCloseNavigation function into the inner screen's route params", () => {
+    render(makeTestNavigator());
+    expect(capturedRouteParams?.onCloseNavigation).toBeInstanceOf(Function);
+  });
+});
+
+describe("AleoAddAccountNavigator — handleClose", () => {
+  beforeEach(() => {
+    capturedRouteParams = null;
+    mockPop.mockClear();
+  });
+
+  it("pops 2 screens (default depth) when no navigationDepth is provided", () => {
+    render(
+      <AddAccountNavigator
+        route={{ params: { currency: aleoCurrency, device: mockDevice } } as any}
+        navigation={{ getParent: () => ({ pop: mockPop }) } as any}
+      />,
+    );
+    capturedRouteParams?.onCloseNavigation?.();
+    expect(mockPop).toHaveBeenCalledWith(2);
+  });
+
+  it("pops navigationDepth screens when navigationDepth is provided", () => {
+    render(
+      <AddAccountNavigator
+        route={{ params: { currency: aleoCurrency, device: mockDevice, navigationDepth: 4 } } as any}
+        navigation={{ getParent: () => ({ pop: mockPop }) } as any}
+      />,
+    );
+    capturedRouteParams?.onCloseNavigation?.();
+    expect(mockPop).toHaveBeenCalledWith(4);
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyWarningScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyWarningScreen.test.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { screen, render } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import ViewKeyWarningScreen from "../ViewKeyWarningScreen";
+import { aleoCurrency } from "../../__mocks__/currency.mock";
+
+// Capture onModalHide so each test can trigger it directly instead of
+// simulating the drawer's close animation via hooks.
+let capturedOnModalHide: (() => void) | undefined;
+
+jest.mock("~/components/ConfirmationModal", () => {
+  const { Pressable } = jest.requireActual<typeof import("react-native")>("react-native");
+  return function MockConfirmationModal({
+    isOpened,
+    onConfirm,
+    onModalHide,
+  }: {
+    isOpened: boolean;
+    onConfirm?: () => void;
+    onModalHide?: () => void;
+  }) {
+    capturedOnModalHide = onModalHide;
+    if (!isOpened) return null;
+    return <Pressable testID="enabled-confirmation-modal-confirm-button" onPress={onConfirm} />;
+  };
+});
+
+const mockParentNavigate = jest.fn();
+const mockOnCloseNavigation = jest.fn();
+
+const mockNavigation = {
+  getParent: jest.fn(() => ({
+    navigate: mockParentNavigate,
+  })),
+};
+
+const mockRoute = {
+  params: {
+    currency: aleoCurrency,
+    device: { deviceId: "device-1", modelId: "nanoX", wired: false },
+    context: undefined,
+    onCloseNavigation: mockOnCloseNavigation,
+    navigationDepth: undefined,
+    inline: undefined,
+    returnToSwap: undefined,
+    onSuccess: undefined,
+    sourceScreenName: "SelectDevice",
+  },
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const renderScreen = () =>
+  render(<ViewKeyWarningScreen route={mockRoute as any} navigation={mockNavigation as any} />);
+
+describe("ViewKeyWarningScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedOnModalHide = undefined;
+  });
+
+  it("renders the title", () => {
+    renderScreen();
+    expect(screen.getByText("Set up Aleo private balance")).toBeOnTheScreen();
+  });
+
+  it("renders the Allow and Cancel buttons", () => {
+    renderScreen();
+    expect(screen.getByText("Allow")).toBeOnTheScreen();
+    expect(screen.getByText("Cancel")).toBeOnTheScreen();
+  });
+
+  it("navigates to ScanDeviceAccounts with route params when Allow is pressed", async () => {
+    const { user } = renderScreen();
+
+    await user.press(screen.getByText("Allow"));
+
+    expect(mockParentNavigate).toHaveBeenCalledWith(ScreenName.ScanDeviceAccounts, {
+      currency: expect.objectContaining({ id: "aleo" }),
+      device: expect.objectContaining({ deviceId: "device-1" }),
+      context: undefined,
+      onCloseNavigation: mockOnCloseNavigation,
+      navigationDepth: undefined,
+      inline: undefined,
+      returnToSwap: undefined,
+      onSuccess: undefined,
+      sourceScreenName: "SelectDevice",
+    });
+  });
+
+  it("calls onCloseNavigation when Cancel is confirmed", async () => {
+    const { user } = renderScreen();
+
+    await user.press(screen.getByText("Cancel"));
+    await user.press(screen.getByTestId("enabled-confirmation-modal-confirm-button"));
+    // After confirm, the component re-renders with onModalHide = onCloseNavigation.
+    // Call it directly to simulate the drawer's close animation completing.
+    capturedOnModalHide?.();
+
+    expect(mockOnCloseNavigation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/types.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/types.ts
@@ -1,0 +1,22 @@
+import type { Account } from "@ledgerhq/types-live";
+import type { Device } from "@ledgerhq/types-devices";
+import { ScreenName } from "~/const";
+import type { CommonParams } from "LLM/features/Accounts/screens/AddAccount/types";
+
+export type AleoAddAccountParams = CommonParams & {
+  device: Device;
+  inline?: boolean;
+  returnToSwap?: boolean;
+  onSuccess?: (res: { scannedAccounts: Account[]; selected: Account[] }) => void;
+};
+
+// Outer navigator screen (AddAccountNavigator itself, mounted in the root stack).
+export type AleoAddAccountParamList = {
+  [ScreenName.AleoAddAccount]: AleoAddAccountParams;
+};
+
+// Inner stack created inside AddAccountNavigator — keyed on a different screen name,
+// so it cannot reuse AleoAddAccountParamList directly.
+export type AleoViewKeyFlowParamList = {
+  [ScreenName.AleoViewKeyWarning]: AleoAddAccountParams;
+};

--- a/apps/ledger-live-mobile/src/families/aleo/customAddAccountFlow.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/customAddAccountFlow.ts
@@ -1,0 +1,18 @@
+import { NavigatorName, ScreenName } from "~/const";
+import type { CustomAddAccountFlow } from "LLM/features/Accounts/customAddAccountFlow";
+
+export default {
+  onDeviceConnected: ({ navigation, routeParams }) => {
+    // Exclude onCloseNavigation when undefined so it doesn't override the default
+    // injected by Aleo AddAccountNavigator (handleClose) via initialParams.
+    const { onCloseNavigation, ...restParams } = routeParams;
+
+    navigation.navigate(NavigatorName.AddAccounts, {
+      screen: ScreenName.AleoAddAccount,
+      params: {
+        ...restParams,
+        ...(typeof onCloseNavigation === "function" ? { onCloseNavigation } : {}),
+      },
+    });
+  },
+} satisfies CustomAddAccountFlow;

--- a/apps/ledger-live-mobile/src/families/aleo/customAddAccountFlow.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/customAddAccountFlow.ts
@@ -1,5 +1,5 @@
 import { NavigatorName, ScreenName } from "~/const";
-import type { CustomAddAccountFlow } from "LLM/features/Accounts/customAddAccountFlow";
+import type { CustomAddAccountFlow } from "LLM/features/Accounts/utils/customAddAccountFlow";
 
 export default {
   onDeviceConnected: ({ navigation, routeParams }) => {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10011,6 +10011,23 @@
     }
   },
   "aleo": {
+    "addAccount": {
+      "stepViewKeyWarning": {
+        "title": "Set up Aleo private balance",
+        "description": "Ledger Wallet stores your view key to display your private balance and uses third-party services to process private transactions. <0>Learn more</0>",
+        "bullets": [
+          "Read-only access to decrypt your private balance",
+          "Ledger cannot send or spend your funds",
+          "Only you can sign and spend your funds",
+          "Proof generation is handled by third-party prover services to ensure fast processing",
+          "Provers cannot access or spend your funds"
+        ],
+        "cta": {
+          "allow": "Allow",
+          "cancel": "Cancel"
+        }
+      }
+    },
     "accountActions": {
       "publicToPrivate": "Self transfer"
     }

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/Navigator.tsx
@@ -16,6 +16,7 @@ import AddAccountsSuccess from "./screens/AddAccountSuccess";
 import AddAccountsWarning from "./screens/AddAccountWarning";
 import NoAssociatedAccountsView from "./screens/NoAssociatedAccountsView";
 import CantonOnboardNavigator from "~/families/canton/Onboard/Onboard";
+import { component as AleoAddAccountNavigator } from "~/families/aleo/AddAccountFlow/AddAccountNavigator";
 import CloseWithConfirmation from "LLM/components/CloseWithConfirmation";
 import {
   BaseComposite,
@@ -118,6 +119,11 @@ export default function Navigator() {
       <Stack.Screen
         name={ScreenName.CantonOnboardAccount}
         component={CantonOnboardNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={ScreenName.AleoAddAccount}
+        component={AleoAddAccountNavigator}
         options={{ headerShown: false }}
       />
       <Stack.Screen

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/customAddAccountFlow.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/customAddAccountFlow.ts
@@ -1,0 +1,29 @@
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import customAddAccountFlowByFamily from "~/generated/customAddAccountFlow";
+import type {
+  DeviceSelectionNavigationProps,
+  SelectDeviceRouteParams,
+} from "../DeviceSelection/types";
+import type { AppResult } from "@ledgerhq/live-common/hw/actions/app";
+
+type DeviceConnectedParams = {
+  navigation: DeviceSelectionNavigationProps["navigation"];
+  routeParams: SelectDeviceRouteParams & AppResult;
+};
+
+export type CustomAddAccountFlow = {
+  onDeviceConnected?: (params: DeviceConnectedParams) => void;
+};
+
+const isCustomAddAccountFlowFamily = (
+  family: string,
+): family is keyof typeof customAddAccountFlowByFamily =>
+  Object.prototype.hasOwnProperty.call(customAddAccountFlowByFamily, family);
+
+export const getCustomAddAccountFlow = (
+  currency: CryptoOrTokenCurrency,
+): CustomAddAccountFlow | null => {
+  if (currency.type !== "CryptoCurrency") return null;
+  if (!isCustomAddAccountFlowFamily(currency.family)) return null;
+  return customAddAccountFlowByFamily[currency.family];
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/AddAccount/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/AddAccount/types.ts
@@ -1,14 +1,15 @@
-import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { ScreenName } from "~/const";
-import { Device } from "@ledgerhq/types-devices";
-import { Account } from "@ledgerhq/types-live";
-import { Props as TouchableProps } from "~/components/Touchable";
+import type { Device } from "@ledgerhq/types-devices";
+import type { Account } from "@ledgerhq/types-live";
+import type { Props as TouchableProps } from "~/components/Touchable";
 import { AddAccountContexts } from "./enums";
-import { CantonOnboardAccountParamList } from "~/families/canton/Onboard/types";
+import type { CantonOnboardAccountParamList } from "~/families/canton/Onboard/types";
+import type { AleoAddAccountParamList } from "~/families/aleo/AddAccountFlow/types";
 
 export type AddAccountContextType = `${AddAccountContexts}`;
 
-type CommonParams = {
+export type CommonParams = {
   context?: AddAccountContextType;
   onCloseNavigation?: () => void;
   // Number of navigators to pop when closing the flow (calculated at entry point)
@@ -40,4 +41,5 @@ export type NetworkBasedAddAccountNavigator = {
     }) => React.JSX.Element;
   };
   [ScreenName.CantonOnboardAccount]: CantonOnboardAccountParamList[ScreenName.CantonOnboardAccount];
+  [ScreenName.AleoAddAccount]: AleoAddAccountParamList[ScreenName.AleoAddAccount];
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/utils/customAddAccountFlow.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/utils/customAddAccountFlow.ts
@@ -18,7 +18,7 @@ export type CustomAddAccountFlow = {
 const isCustomAddAccountFlowFamily = (
   family: string,
 ): family is keyof typeof customAddAccountFlowByFamily =>
-  Object.prototype.hasOwnProperty.call(customAddAccountFlowByFamily, family);
+  Object.hasOwn(customAddAccountFlowByFamily, family);
 
 export const getCustomAddAccountFlow = (
   currency: CryptoOrTokenCurrency,

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/utils/customAddAccountFlow.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/utils/customAddAccountFlow.ts
@@ -3,7 +3,7 @@ import customAddAccountFlowByFamily from "~/generated/customAddAccountFlow";
 import type {
   DeviceSelectionNavigationProps,
   SelectDeviceRouteParams,
-} from "../DeviceSelection/types";
+} from "../../DeviceSelection/types";
 import type { AppResult } from "@ledgerhq/live-common/hw/actions/app";
 
 type DeviceConnectedParams = {

--- a/apps/ledger-live-mobile/src/mvvm/features/DeviceSelection/__integrations__/deviceSelection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/DeviceSelection/__integrations__/deviceSelection.integration.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen, withReadOnlyDisabled, renderHook } from "@tests/test-renderer";
+import { render, screen, withReadOnlyDisabled } from "@tests/test-renderer";
 import DeviceSelectionNavigator from "../Navigator";
 import { useRoute, useNavigation } from "@react-navigation/native";
 import { useNavigation as useNavigationCore } from "@react-navigation/core";
@@ -7,11 +7,6 @@ import { discoverDevices } from "@ledgerhq/live-common/hw/index";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { of } from "rxjs";
 import { AddAccountContexts } from "../../Accounts/screens/AddAccount/enums";
-import useSelectDeviceViewModel from "../screens/SelectDevice/useSelectDeviceViewModel";
-import { getCustomAddAccountFlow } from "LLM/features/Accounts/customAddAccountFlow";
-import { NavigatorName, ScreenName } from "~/const";
-import type { AppResult } from "@ledgerhq/live-common/hw/actions/app";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 
 const MockUseRoute = useRoute as jest.Mock;
 const mockNavigate = jest.fn();
@@ -43,7 +38,7 @@ jest.mock("@ledgerhq/live-common/hw/index", () => ({
   discoverDevices: jest.fn(),
 }));
 
-jest.mock("LLM/features/Accounts/customAddAccountFlow", () => ({
+jest.mock("LLM/features/Accounts/utils/customAddAccountFlow", () => ({
   getCustomAddAccountFlow: jest.fn(),
 }));
 
@@ -119,108 +114,3 @@ describe("Device Selection feature integration test", () => {
   });
 });
 
-describe("useSelectDeviceViewModel — onResult navigation", () => {
-  const mockGetCustomAddAccountFlow = getCustomAddAccountFlow as jest.Mock;
-  const mockOnDeviceConnected = jest.fn();
-
-  const aleoCurrency: CryptoCurrency = {
-    type: "CryptoCurrency",
-    coinType: 683,
-    scheme: "aleo",
-    id: "aleo",
-    ticker: "ALEO",
-    name: "Aleo",
-    family: "aleo",
-    color: "#000000",
-    managerAppName: "Aleo",
-    units: [],
-    explorerViews: [],
-  };
-
-  const bitcoinCurrency: CryptoCurrency = {
-    type: "CryptoCurrency",
-    coinType: 0,
-    scheme: "bitcoin",
-    id: "bitcoin",
-    ticker: "BTC",
-    name: "Bitcoin",
-    family: "bitcoin",
-    color: "#ffae35",
-    managerAppName: "Bitcoin",
-    units: [],
-    explorerViews: [],
-  };
-
-  const mockMeta = {} as AppResult;
-
-  const getRouteMock = (currency: CryptoCurrency) => {
-    return {
-      params: { context: AddAccountContexts.AddAccounts, currency },
-    } as unknown as Parameters<typeof useSelectDeviceViewModel>[0];
-  };
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    (useNavigation as jest.Mock).mockReturnValue({
-      navigate: mockNavigate,
-      addListener: jest.fn(),
-    });
-    (useNavigationCore as jest.Mock).mockReturnValue({
-      navigate: mockNavigate,
-      addListener: jest.fn(),
-    });
-  });
-
-  it("invokes onDeviceConnected and does not navigate to ScanDeviceAccounts when a custom flow is registered", () => {
-    mockGetCustomAddAccountFlow.mockReturnValue({ onDeviceConnected: mockOnDeviceConnected });
-
-    const route = getRouteMock(aleoCurrency);
-
-    const { result } = renderHook(() => useSelectDeviceViewModel(route), {
-      overrideInitialState: withReadOnlyDisabled,
-    });
-
-    result.current.onResult(mockMeta);
-
-    expect(mockOnDeviceConnected).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).not.toHaveBeenCalledWith(
-      NavigatorName.AddAccounts,
-      expect.objectContaining({ screen: ScreenName.ScanDeviceAccounts }),
-    );
-  });
-
-  it("navigates to ScanDeviceAccounts when no custom flow is registered for the currency", () => {
-    mockGetCustomAddAccountFlow.mockReturnValue(null);
-
-    const route = getRouteMock(bitcoinCurrency);
-
-    const { result } = renderHook(() => useSelectDeviceViewModel(route), {
-      overrideInitialState: withReadOnlyDisabled,
-    });
-
-    result.current.onResult(mockMeta);
-
-    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.AddAccounts, {
-      screen: ScreenName.ScanDeviceAccounts,
-      params: expect.objectContaining({ sourceScreenName: ScreenName.SelectDevice }),
-    });
-    expect(mockOnDeviceConnected).not.toHaveBeenCalled();
-  });
-
-  it("navigates to ScanDeviceAccounts when a custom flow exists but has no onDeviceConnected handler", () => {
-    mockGetCustomAddAccountFlow.mockReturnValue({});
-
-    const route = getRouteMock(bitcoinCurrency);
-
-    const { result } = renderHook(() => useSelectDeviceViewModel(route), {
-      overrideInitialState: withReadOnlyDisabled,
-    });
-
-    result.current.onResult(mockMeta);
-
-    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.AddAccounts, {
-      screen: ScreenName.ScanDeviceAccounts,
-      params: expect.objectContaining({ sourceScreenName: ScreenName.SelectDevice }),
-    });
-  });
-});

--- a/apps/ledger-live-mobile/src/mvvm/features/DeviceSelection/__integrations__/deviceSelection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/DeviceSelection/__integrations__/deviceSelection.integration.test.tsx
@@ -1,11 +1,17 @@
 import * as React from "react";
-import { render, screen, withReadOnlyDisabled } from "@tests/test-renderer";
+import { render, screen, withReadOnlyDisabled, renderHook } from "@tests/test-renderer";
 import DeviceSelectionNavigator from "../Navigator";
 import { useRoute, useNavigation } from "@react-navigation/native";
+import { useNavigation as useNavigationCore } from "@react-navigation/core";
 import { discoverDevices } from "@ledgerhq/live-common/hw/index";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { of } from "rxjs";
 import { AddAccountContexts } from "../../Accounts/screens/AddAccount/enums";
+import useSelectDeviceViewModel from "../screens/SelectDevice/useSelectDeviceViewModel";
+import { getCustomAddAccountFlow } from "LLM/features/Accounts/customAddAccountFlow";
+import { NavigatorName, ScreenName } from "~/const";
+import type { AppResult } from "@ledgerhq/live-common/hw/actions/app";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 
 const MockUseRoute = useRoute as jest.Mock;
 const mockNavigate = jest.fn();
@@ -16,15 +22,37 @@ const mockDiscoverDevices = discoverDevices as jest.Mock;
   addListener: jest.fn(),
 });
 
+(useNavigationCore as jest.Mock).mockReturnValue({
+  navigate: mockNavigate,
+  addListener: jest.fn(),
+});
+
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
   useRoute: jest.fn(),
   useNavigation: jest.fn(),
 }));
 
+jest.mock("@react-navigation/core", () => ({
+  ...jest.requireActual("@react-navigation/core"),
+  useNavigation: jest.fn(),
+}));
+
 jest.mock("@ledgerhq/live-common/hw/index", () => ({
   ...jest.requireActual("@ledgerhq/live-common/hw/index"),
   discoverDevices: jest.fn(),
+}));
+
+jest.mock("LLM/features/Accounts/customAddAccountFlow", () => ({
+  getCustomAddAccountFlow: jest.fn(),
+}));
+
+jest.mock("~/hooks/deviceActions", () => ({
+  useAppDeviceAction: jest.fn().mockReturnValue(jest.fn()),
+}));
+
+jest.mock("~/bridge/cache", () => ({
+  prepareCurrency: jest.fn(),
 }));
 
 describe("Device Selection feature integration test", () => {
@@ -87,6 +115,112 @@ describe("Device Selection feature integration test", () => {
 
     [deviceCTA, notConnectedText, bottomText, buyNowCTA, addNewCTA].forEach(element => {
       expect(element).toBeOnTheScreen();
+    });
+  });
+});
+
+describe("useSelectDeviceViewModel — onResult navigation", () => {
+  const mockGetCustomAddAccountFlow = getCustomAddAccountFlow as jest.Mock;
+  const mockOnDeviceConnected = jest.fn();
+
+  const aleoCurrency: CryptoCurrency = {
+    type: "CryptoCurrency",
+    coinType: 683,
+    scheme: "aleo",
+    id: "aleo",
+    ticker: "ALEO",
+    name: "Aleo",
+    family: "aleo",
+    color: "#000000",
+    managerAppName: "Aleo",
+    units: [],
+    explorerViews: [],
+  };
+
+  const bitcoinCurrency: CryptoCurrency = {
+    type: "CryptoCurrency",
+    coinType: 0,
+    scheme: "bitcoin",
+    id: "bitcoin",
+    ticker: "BTC",
+    name: "Bitcoin",
+    family: "bitcoin",
+    color: "#ffae35",
+    managerAppName: "Bitcoin",
+    units: [],
+    explorerViews: [],
+  };
+
+  const mockMeta = {} as AppResult;
+
+  const getRouteMock = (currency: CryptoCurrency) => {
+    return {
+      params: { context: AddAccountContexts.AddAccounts, currency },
+    } as unknown as Parameters<typeof useSelectDeviceViewModel>[0];
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useNavigation as jest.Mock).mockReturnValue({
+      navigate: mockNavigate,
+      addListener: jest.fn(),
+    });
+    (useNavigationCore as jest.Mock).mockReturnValue({
+      navigate: mockNavigate,
+      addListener: jest.fn(),
+    });
+  });
+
+  it("invokes onDeviceConnected and does not navigate to ScanDeviceAccounts when a custom flow is registered", () => {
+    mockGetCustomAddAccountFlow.mockReturnValue({ onDeviceConnected: mockOnDeviceConnected });
+
+    const route = getRouteMock(aleoCurrency);
+
+    const { result } = renderHook(() => useSelectDeviceViewModel(route), {
+      overrideInitialState: withReadOnlyDisabled,
+    });
+
+    result.current.onResult(mockMeta);
+
+    expect(mockOnDeviceConnected).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      NavigatorName.AddAccounts,
+      expect.objectContaining({ screen: ScreenName.ScanDeviceAccounts }),
+    );
+  });
+
+  it("navigates to ScanDeviceAccounts when no custom flow is registered for the currency", () => {
+    mockGetCustomAddAccountFlow.mockReturnValue(null);
+
+    const route = getRouteMock(bitcoinCurrency);
+
+    const { result } = renderHook(() => useSelectDeviceViewModel(route), {
+      overrideInitialState: withReadOnlyDisabled,
+    });
+
+    result.current.onResult(mockMeta);
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.AddAccounts, {
+      screen: ScreenName.ScanDeviceAccounts,
+      params: expect.objectContaining({ sourceScreenName: ScreenName.SelectDevice }),
+    });
+    expect(mockOnDeviceConnected).not.toHaveBeenCalled();
+  });
+
+  it("navigates to ScanDeviceAccounts when a custom flow exists but has no onDeviceConnected handler", () => {
+    mockGetCustomAddAccountFlow.mockReturnValue({});
+
+    const route = getRouteMock(bitcoinCurrency);
+
+    const { result } = renderHook(() => useSelectDeviceViewModel(route), {
+      overrideInitialState: withReadOnlyDisabled,
+    });
+
+    result.current.onResult(mockMeta);
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.AddAccounts, {
+      screen: ScreenName.ScanDeviceAccounts,
+      params: expect.objectContaining({ sourceScreenName: ScreenName.SelectDevice }),
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/DeviceSelection/__integrations__/selectDeviceViewModel.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/DeviceSelection/__integrations__/selectDeviceViewModel.integration.test.tsx
@@ -1,0 +1,149 @@
+import { renderHook, withReadOnlyDisabled } from "@tests/test-renderer";
+import { useNavigation } from "@react-navigation/native";
+import { useNavigation as useNavigationCore } from "@react-navigation/core";
+import { AddAccountContexts } from "../../Accounts/screens/AddAccount/enums";
+import useSelectDeviceViewModel from "../screens/SelectDevice/useSelectDeviceViewModel";
+import { getCustomAddAccountFlow } from "LLM/features/Accounts/utils/customAddAccountFlow";
+import { NavigatorName, ScreenName } from "~/const";
+import type { AppResult } from "@ledgerhq/live-common/hw/actions/app";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+
+const mockNavigate = jest.fn();
+
+(useNavigation as jest.Mock).mockReturnValue({
+  navigate: mockNavigate,
+  addListener: jest.fn(),
+});
+
+(useNavigationCore as jest.Mock).mockReturnValue({
+  navigate: mockNavigate,
+  addListener: jest.fn(),
+});
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: jest.fn(),
+}));
+
+jest.mock("@react-navigation/core", () => ({
+  ...jest.requireActual("@react-navigation/core"),
+  useNavigation: jest.fn(),
+}));
+
+jest.mock("LLM/features/Accounts/utils/customAddAccountFlow", () => ({
+  getCustomAddAccountFlow: jest.fn(),
+}));
+
+jest.mock("~/hooks/deviceActions", () => ({
+  useAppDeviceAction: jest.fn().mockReturnValue(jest.fn()),
+}));
+
+jest.mock("~/bridge/cache", () => ({
+  prepareCurrency: jest.fn(),
+}));
+
+describe("useSelectDeviceViewModel — onResult navigation", () => {
+  const mockGetCustomAddAccountFlow = getCustomAddAccountFlow as jest.Mock;
+  const mockOnDeviceConnected = jest.fn();
+
+  const aleoCurrency: CryptoCurrency = {
+    type: "CryptoCurrency",
+    coinType: 683,
+    scheme: "aleo",
+    id: "aleo",
+    ticker: "ALEO",
+    name: "Aleo",
+    family: "aleo",
+    color: "#000000",
+    managerAppName: "Aleo",
+    units: [],
+    explorerViews: [],
+  };
+
+  const bitcoinCurrency: CryptoCurrency = {
+    type: "CryptoCurrency",
+    coinType: 0,
+    scheme: "bitcoin",
+    id: "bitcoin",
+    ticker: "BTC",
+    name: "Bitcoin",
+    family: "bitcoin",
+    color: "#ffae35",
+    managerAppName: "Bitcoin",
+    units: [],
+    explorerViews: [],
+  };
+
+  const mockMeta = {} as AppResult;
+
+  const getRouteMock = (currency: CryptoCurrency) => {
+    return {
+      params: { context: AddAccountContexts.AddAccounts, currency },
+    } as unknown as Parameters<typeof useSelectDeviceViewModel>[0];
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useNavigation as jest.Mock).mockReturnValue({
+      navigate: mockNavigate,
+      addListener: jest.fn(),
+    });
+    (useNavigationCore as jest.Mock).mockReturnValue({
+      navigate: mockNavigate,
+      addListener: jest.fn(),
+    });
+  });
+
+  it("invokes onDeviceConnected and does not navigate to ScanDeviceAccounts when a custom flow is registered", () => {
+    mockGetCustomAddAccountFlow.mockReturnValue({ onDeviceConnected: mockOnDeviceConnected });
+
+    const route = getRouteMock(aleoCurrency);
+
+    const { result } = renderHook(() => useSelectDeviceViewModel(route), {
+      overrideInitialState: withReadOnlyDisabled,
+    });
+
+    result.current.onResult(mockMeta);
+
+    expect(mockOnDeviceConnected).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      NavigatorName.AddAccounts,
+      expect.objectContaining({ screen: ScreenName.ScanDeviceAccounts }),
+    );
+  });
+
+  it("navigates to ScanDeviceAccounts when no custom flow is registered for the currency", () => {
+    mockGetCustomAddAccountFlow.mockReturnValue(null);
+
+    const route = getRouteMock(bitcoinCurrency);
+
+    const { result } = renderHook(() => useSelectDeviceViewModel(route), {
+      overrideInitialState: withReadOnlyDisabled,
+    });
+
+    result.current.onResult(mockMeta);
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.AddAccounts, {
+      screen: ScreenName.ScanDeviceAccounts,
+      params: expect.objectContaining({ sourceScreenName: ScreenName.SelectDevice }),
+    });
+    expect(mockOnDeviceConnected).not.toHaveBeenCalled();
+  });
+
+  it("navigates to ScanDeviceAccounts when a custom flow exists but has no onDeviceConnected handler", () => {
+    mockGetCustomAddAccountFlow.mockReturnValue({});
+
+    const route = getRouteMock(bitcoinCurrency);
+
+    const { result } = renderHook(() => useSelectDeviceViewModel(route), {
+      overrideInitialState: withReadOnlyDisabled,
+    });
+
+    result.current.onResult(mockMeta);
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.AddAccounts, {
+      screen: ScreenName.ScanDeviceAccounts,
+      params: expect.objectContaining({ sourceScreenName: ScreenName.SelectDevice }),
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/DeviceSelection/screens/SelectDevice/useSelectDeviceViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/DeviceSelection/screens/SelectDevice/useSelectDeviceViewModel.ts
@@ -7,6 +7,7 @@ import { NavigatorName, ScreenName } from "~/const";
 import { useAppDeviceAction } from "~/hooks/deviceActions";
 import { AppResult } from "@ledgerhq/live-common/hw/actions/app";
 import { DeviceSelectionNavigationProps, DeviceSelectionNavigatorParamsList } from "../../types";
+import { getCustomAddAccountFlow } from "LLM/features/Accounts/customAddAccountFlow";
 import { NetworkBasedAddAccountNavigator } from "LLM/features/Accounts/screens/AddAccount/types";
 import { useDispatch, useSelector } from "~/context/hooks";
 import { readOnlyModeEnabledSelector } from "~/reducers/settings";
@@ -48,22 +49,28 @@ export default function useSelectDeviceViewModel(
     (meta: AppResult) => {
       setDevice(null);
 
-      const params = {
+      const navigationParams = {
         ...route.params,
         ...meta,
         context,
         sourceScreenName: ScreenName.SelectDevice,
       };
 
+      const customFlow = currency ? getCustomAddAccountFlow(currency) : null;
+      if (customFlow?.onDeviceConnected) {
+        customFlow.onDeviceConnected({ navigation, routeParams: navigationParams });
+        return;
+      }
+
       // Always use navigate instead of replace to keep SelectDevice in the stack.
       // This allows retry navigation when device errors occur (e.g., device locked).
       // Previously, inline flows used replace which prevented retry navigation.
       navigation.navigate(NavigatorName.AddAccounts, {
         screen: ScreenName.ScanDeviceAccounts,
-        params,
+        params: navigationParams,
       });
     },
-    [navigation, route, context],
+    [navigation, route, context, currency],
   );
 
   useEffect(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/DeviceSelection/screens/SelectDevice/useSelectDeviceViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/DeviceSelection/screens/SelectDevice/useSelectDeviceViewModel.ts
@@ -7,7 +7,7 @@ import { NavigatorName, ScreenName } from "~/const";
 import { useAppDeviceAction } from "~/hooks/deviceActions";
 import { AppResult } from "@ledgerhq/live-common/hw/actions/app";
 import { DeviceSelectionNavigationProps, DeviceSelectionNavigatorParamsList } from "../../types";
-import { getCustomAddAccountFlow } from "LLM/features/Accounts/customAddAccountFlow";
+import { getCustomAddAccountFlow } from "LLM/features/Accounts/utils/customAddAccountFlow";
 import { NetworkBasedAddAccountNavigator } from "LLM/features/Accounts/screens/AddAccount/types";
 import { useDispatch, useSelector } from "~/context/hooks";
 import { readOnlyModeEnabledSelector } from "~/reducers/settings";

--- a/apps/ledger-live-mobile/src/utils/urls.tsx
+++ b/apps/ledger-live-mobile/src/utils/urls.tsx
@@ -270,6 +270,9 @@ export const urls = {
     evmAddressVerification: "https://ledger.com/e14",
     staking: "https://support.ledger.com/article/Staking-Hedera-HBAR-through-Ledger-Live",
   },
+  aleo: {
+    learnMore: "https://support.ledger.com/article/Aleo-ALEO",
+  },
   canton: {
     learnMore: "https://support.ledger.com/article/Canton-Network",
   },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - This PR adds view key warning screen to Aleo add-account flow on mobile.

### 📝 Description

Add view key warning screen to Aleo add-account flow on mobile.

<img
  src="https://github.com/user-attachments/assets/eed49a37-7b7b-4482-a708-d89b775ab0c4"
  alt="Simulator Screenshot"
  width="440"
/>

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-30450

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
