### PR TITLE
[LWDM] feat: add onboardingDate as common data field

### DIFF
--- a/.changeset/grumpy-fishes-float.md
+++ b/.changeset/grumpy-fishes-float.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/types-live": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Add onboardingDate backfill and common state

--- a/apps/ledger-live-desktop/src/renderer/App.tsx
+++ b/apps/ledger-live-desktop/src/renderer/App.tsx
@@ -27,11 +27,12 @@ import { ConnectEnvsToDatadog } from "~/renderer/components/ConnectEnvsToDatadog
 import PostOnboardingProviderWrapped from "~/renderer/components/PostOnboardingHub/logic/PostOnboardingProviderWrapped";
 import { useBraze } from "./hooks/useBraze";
 import { useResetTimeRangeOnGraphRework } from "LLD/hooks/useResetTimeRangeOnGraphRework";
+import { useBackfillOnboardingDate } from "@ledgerhq/live-common/postOnboarding/hooks/index";
 import { CounterValuesStateRaw } from "@ledgerhq/live-countervalues/types";
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { AppDataStorageProvider } from "~/renderer/hooks/storage-provider/useAppDataStorage";
-import { allowDebugReactQuerySelector } from "./reducers/settings";
+import { allowDebugReactQuerySelector, hasCompletedOnboardingSelector } from "./reducers/settings";
 import { ThemeProvider } from "@ledgerhq/lumen-ui-react";
 
 const reloadApp = (event: KeyboardEvent) => {
@@ -52,6 +53,7 @@ const InnerApp = ({ initialCountervalues }: { initialCountervalues: CounterValue
 
   useBraze();
   useResetTimeRangeOnGraphRework();
+  useBackfillOnboardingDate(useSelector(hasCompletedOnboardingSelector));
 
   useEffect(() => {
     const reload = (e: KeyboardEvent) => {

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -339,8 +339,9 @@ async function init() {
     check();
   });
 
-  r(<ReactRoot store={store} language={language} initialCountervalues={initialCountervalues} />);
-
+  // Rehydrate the post-onboarding slice before the first render so the
+  // onboardingDate backfill effect (useBackfillOnboardingDate) never runs
+  // against the un-rehydrated initial state and overwrites a stored date.
   const postOnboardingState = await getKey("app", "postOnboarding");
   if (postOnboardingState) {
     store.dispatch(
@@ -349,6 +350,8 @@ async function init() {
       }),
     );
   }
+
+  r(<ReactRoot store={store} language={language} initialCountervalues={initialCountervalues} />);
 
   await dispatch(fetchTrustchain());
   await dispatch(fetchWallet());

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/PostOnboardingHubTester.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/PostOnboardingHubTester.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
+import { useDispatch } from "react-redux";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { useStartPostOnboardingCallback } from "@ledgerhq/live-common/postOnboarding/hooks/index";
+import { setPostOnboardingDate } from "@ledgerhq/live-common/postOnboarding/actions";
 import { SettingsSectionRow } from "~/renderer/screens/settings/SettingsSection";
 import { Button } from "@ledgerhq/lumen-ui-react";
 import { Flex } from "@ledgerhq/react-ui";
@@ -10,6 +12,7 @@ import { Flex } from "@ledgerhq/react-ui";
 const PostOnboardingHubTester = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const dispatch = useDispatch();
 
   const handleInitPostOnboarding = useStartPostOnboardingCallback();
 
@@ -72,6 +75,29 @@ const PostOnboardingHubTester = () => {
           </Flex>
         </SettingsSectionRow>
       ))}
+      <SettingsSectionRow
+        title="Post-onboarding onboardingDate"
+        desc="Set the persisted onboarding date used for the large-screen upsell cooldown, or reset it (re-backfilled to today on next launch)."
+      >
+        <Flex flexDirection={"row"} columnGap={3}>
+          <Button
+            onClick={() =>
+              dispatch(setPostOnboardingDate(new Date(Date.now() - 31 * 24 * 60 * 60 * 1000)))
+            }
+            appearance="accent"
+            size="sm"
+          >
+            Set 31 days ago
+          </Button>
+          <Button
+            onClick={() => dispatch(setPostOnboardingDate(null))}
+            appearance="accent"
+            size="sm"
+          >
+            Reset (null)
+          </Button>
+        </Flex>
+      </SettingsSectionRow>
     </>
   );
 };

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -25,6 +25,7 @@ import {
   reportErrorsEnabledSelector,
   isOnboardingFlowSelector,
   isPostOnboardingFlowSelector,
+  hasCompletedOnboardingSelector,
 } from "~/reducers/settings";
 import { accountsSelector } from "~/reducers/accounts";
 import { rebootIdSelector } from "~/reducers/appstate";
@@ -68,7 +69,10 @@ import { setAnalyticsFeatureFlagMethod } from "~/analytics/segment";
 import { selectFeature, type FeatureId } from "@shared/feature-flags";
 import { useSettings } from "~/hooks";
 import AppProviders from "./AppProviders";
-import { useAutoDismissPostOnboardingEntryPoint } from "@ledgerhq/live-common/postOnboarding/hooks/index";
+import {
+  useAutoDismissPostOnboardingEntryPoint,
+  useBackfillOnboardingDate,
+} from "@ledgerhq/live-common/postOnboarding/hooks/index";
 import QueuedDrawersContextProvider from "LLM/components/QueuedDrawer/QueuedDrawersContextProvider";
 import { registerTransports } from "~/services/registerTransports";
 import { useDeviceManagementKit } from "@ledgerhq/live-dmk-mobile";
@@ -230,6 +234,7 @@ function App() {
   useFetchCurrencyAll();
   useFetchCurrencyFrom();
   useAutoDismissPostOnboardingEntryPoint();
+  useBackfillOnboardingDate(useSelector(hasCompletedOnboardingSelector));
 
   return (
     <>

--- a/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingDebugScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingDebugScreen.tsx
@@ -10,7 +10,10 @@ import SafeAreaViewFixed from "~/components/SafeAreaView";
 import { usePostOnboardingHubCompletionContext } from "~/logic/postOnboarding/usePostOnboardingHubCompletionContext";
 import { setStoreValue } from "~/store";
 import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
-import { removePostOnboardingActionCompleted } from "@ledgerhq/live-common/postOnboarding/actions";
+import {
+  removePostOnboardingActionCompleted,
+  setPostOnboardingDate,
+} from "@ledgerhq/live-common/postOnboarding/actions";
 import { PostOnboardingActionId } from "@ledgerhq/types-live";
 import { useDispatch } from "~/context/hooks";
 import {
@@ -29,7 +32,11 @@ export default () => {
     await setStoreValue("DISPLAY_BANNER", "true", protectId);
     dispatch(setDisplayBanner({ protectId, displayBanner: true }));
     dispatch(setRecoverStateAction({ protectId, subscriptionState: input }));
-    dispatch(removePostOnboardingActionCompleted({ actionId: PostOnboardingActionId.recover }));
+    dispatch(
+      removePostOnboardingActionCompleted({
+        actionId: PostOnboardingActionId.recover,
+      }),
+    );
   };
 
   const handleInitPostOnboardingHub = useCallback(
@@ -91,6 +98,19 @@ export default () => {
           title="Recover - Complete"
           desc="Set recover local state to being complete"
           onPress={() => setRecoverState(LedgerRecoverSubscriptionStateEnum.BACKUP_DONE)}
+        />
+
+        <SettingsRow
+          title="Set onboardingDate = 31 days ago"
+          desc="Simulate an elapsed large-screen upsell cooldown."
+          onPress={() =>
+            dispatch(setPostOnboardingDate(new Date(Date.now() - 31 * 24 * 60 * 60 * 1000)))
+          }
+        />
+        <SettingsRow
+          title="Reset onboardingDate (null)"
+          desc="Clear the persisted onboarding date (re-backfilled to today on next launch)."
+          onPress={() => dispatch(setPostOnboardingDate(null))}
         />
       </ScrollView>
     </SafeAreaViewFixed>

--- a/libs/ledger-live-common/src/postOnboarding/actions.ts
+++ b/libs/ledger-live-common/src/postOnboarding/actions.ts
@@ -61,3 +61,14 @@ export const postOnboardingSetFinished: ActionCreatorPlain = () => ({
   type: `${actionTypePrefix}SET_FINISHED`,
   payload: undefined,
 });
+
+/**
+ * Sets (or, with `null`, resets) the persisted onboarding date used as the
+ * starting point for the large-screen upsell cooldown. Takes a `Date` object;
+ * the reducer serializes it to an ISO 8601 string for storage. Drives the
+ * legacy backfill and QA tooling.
+ */
+export const setPostOnboardingDate: ActionCreator<Date | null> = date => ({
+  type: `${actionTypePrefix}SET_ONBOARDING_DATE`,
+  payload: date,
+});

--- a/libs/ledger-live-common/src/postOnboarding/hooks/index.ts
+++ b/libs/ledger-live-common/src/postOnboarding/hooks/index.ts
@@ -5,5 +5,6 @@ export * from "./usePostOnboardingPortfolioWidgetVisibility";
 export * from "./usePostOnboardingHubState";
 export * from "./useStartPostOnboardingCallback";
 export * from "./useAutoDismissPostOnboardingEntryPoint";
+export * from "./useBackfillOnboardingDate";
 export * from "./usePostOnboardingDeeplinkHandler";
 export * from "./useCheckAccountWithFundsAction";

--- a/libs/ledger-live-common/src/postOnboarding/hooks/useBackfillOnboardingDate.test.ts
+++ b/libs/ledger-live-common/src/postOnboarding/hooks/useBackfillOnboardingDate.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import { createElement, type ComponentType, type ReactNode } from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { configureStore, type EnhancedStore } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
+import type { PostOnboardingState } from "@ledgerhq/types-live";
+import postOnboardingReducer, { initialState as postOnboardingInitialState } from "../reducer";
+import { useBackfillOnboardingDate } from "./useBackfillOnboardingDate";
+
+type BackfillTestState = { postOnboarding: PostOnboardingState };
+type BackfillTestStore = EnhancedStore<BackfillTestState>;
+
+const TestReduxProvider = Provider as ComponentType<{
+  store: BackfillTestStore;
+  children?: ReactNode;
+}>;
+
+function createTestStore(overrides: Partial<PostOnboardingState> = {}): BackfillTestStore {
+  const postOnboarding: PostOnboardingState = {
+    ...postOnboardingInitialState,
+    ...overrides,
+  };
+  return configureStore({
+    reducer: { postOnboarding: postOnboardingReducer as never },
+    middleware: getDefaultMiddleware => getDefaultMiddleware({ serializableCheck: false }),
+    preloadedState: { postOnboarding },
+  }) as BackfillTestStore;
+}
+
+function renderBackfillHook(store: BackfillTestStore, isOnboardingDone: boolean) {
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(TestReduxProvider, { store }, children);
+  return renderHook(({ done }: { done: boolean }) => useBackfillOnboardingDate(done), {
+    wrapper,
+    initialProps: { done: isOnboardingDone },
+  });
+}
+
+describe("useBackfillOnboardingDate", () => {
+  it("writes today (as an ISO string) when onboarding is done and no date is stored", async () => {
+    const store = createTestStore({ onboardingDate: null });
+    renderBackfillHook(store, true);
+    await waitFor(() => {
+      expect(store.getState().postOnboarding.onboardingDate).not.toBe(null);
+    });
+    expect(typeof store.getState().postOnboarding.onboardingDate).toBe("string");
+  });
+
+  it("does not write when onboarding is not done", () => {
+    const store = createTestStore({ onboardingDate: null });
+    renderBackfillHook(store, false);
+    expect(store.getState().postOnboarding.onboardingDate).toBe(null);
+  });
+
+  it("never overwrites an existing date", () => {
+    const existing = new Date("2020-01-20").toISOString();
+    const store = createTestStore({ onboardingDate: existing });
+    renderBackfillHook(store, true);
+    expect(store.getState().postOnboarding.onboardingDate).toBe(existing);
+  });
+});

--- a/libs/ledger-live-common/src/postOnboarding/hooks/useBackfillOnboardingDate.ts
+++ b/libs/ledger-live-common/src/postOnboarding/hooks/useBackfillOnboardingDate.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { setPostOnboardingDate } from "../actions";
+import { postOnboardingOnboardingDateSelector } from "../reducer";
+
+/**
+ * Backfills the persisted `onboardingDate` for legacy users (LWD + LWM).
+ *
+ * On app start, if onboarding is already done and no date has been stored yet,
+ * writes "today" so the large-screen upsell cooldown clock starts on the first
+ * launch of the version that introduces this — nobody is upsold within the
+ * cooldown window of opening the new version.
+ *
+ * Writes only once and never overwrites an existing date (the guard on
+ * `onboardingDate == null`). Brand-new onboardings already get the date from
+ * the POST_ONBOARDING_INIT handler.
+ *
+ * @param isOnboardingDone — app selector value for "onboarding completed"
+ *   (e.g. hasCompletedOnboardingSelector).
+ */
+export function useBackfillOnboardingDate(isOnboardingDone: boolean): void {
+  const dispatch = useDispatch();
+  const onboardingDate = useSelector(postOnboardingOnboardingDateSelector);
+
+  useEffect(() => {
+    if (isOnboardingDone && onboardingDate == null) {
+      dispatch(setPostOnboardingDate(new Date()));
+    }
+  }, [isOnboardingDone, onboardingDate, dispatch]);
+}

--- a/libs/ledger-live-common/src/postOnboarding/reducer.test.ts
+++ b/libs/ledger-live-common/src/postOnboarding/reducer.test.ts
@@ -4,6 +4,7 @@ import reducer, {
   hubStateSelector,
   initialState,
   postOnboardingDeviceModelIdSelector,
+  postOnboardingOnboardingDateSelector,
   postOnboardingSelector,
   walletEntryPointEligibleForPortfolioSelector,
 } from "./reducer";
@@ -15,6 +16,7 @@ import {
   clearPostOnboardingLastActionCompleted,
   hidePostOnboardingWalletEntryPoint,
   setPostOnboardingWalletEntryPointEligibility,
+  setPostOnboardingDate,
   addPostOnboardingAction,
   removePostOnboardingActionCompleted,
 } from "./actions";
@@ -32,6 +34,7 @@ const initializationParamsA: Parameters<typeof initPostOnboarding> = [
 
 // initialState -> importPostOnboardingState(...initializationParamsA)
 const stateA0: PostOnboardingState = {
+  onboardingDate: new Date("2020-01-20").toISOString(),
   deviceModelId: DeviceModelId.nanoX,
   walletEntryPointDismissed: false,
   entryPointFirstDisplayedDate: new Date("2020-01-20"),
@@ -52,6 +55,7 @@ const stateA0: PostOnboardingState = {
 
 // stateA0 -> setPostOnboardingActionCompleted(claimMock)
 const stateA1: PostOnboardingState = {
+  onboardingDate: new Date("2020-01-20").toISOString(),
   deviceModelId: DeviceModelId.nanoX,
   walletEntryPointDismissed: false,
   entryPointFirstDisplayedDate: new Date("2020-01-20"),
@@ -72,6 +76,7 @@ const stateA1: PostOnboardingState = {
 
 // stateA1 -> clearPostOnboardingLastActionCompleted()
 const stateA2: PostOnboardingState = {
+  onboardingDate: new Date("2020-01-20").toISOString(),
   deviceModelId: DeviceModelId.nanoX,
   walletEntryPointDismissed: false,
   entryPointFirstDisplayedDate: new Date("2020-01-20"),
@@ -92,6 +97,7 @@ const stateA2: PostOnboardingState = {
 
 // stateA2 -> setPostOnboardingActionCompleted(personalizeMock)
 const stateA3: PostOnboardingState = {
+  onboardingDate: new Date("2020-01-20").toISOString(),
   deviceModelId: DeviceModelId.nanoX,
   walletEntryPointDismissed: false,
   entryPointFirstDisplayedDate: new Date("2020-01-20"),
@@ -112,6 +118,7 @@ const stateA3: PostOnboardingState = {
 
 // stateA3 -> hidePostOnboardingWalletEntryPoint()
 const stateA4: PostOnboardingState = {
+  onboardingDate: new Date("2020-01-20").toISOString(), // preserved by hidePostOnboardingWalletEntryPoint()
   deviceModelId: DeviceModelId.nanoX,
   walletEntryPointDismissed: true, // stateA3 -> hidePostOnboardingWalletEntryPoint()
   entryPointFirstDisplayedDate: null,
@@ -132,6 +139,7 @@ const stateA4: PostOnboardingState = {
 
 // stateA0 -> addPostOnboardingAction(recoverMock)
 const stateA5: PostOnboardingState = {
+  onboardingDate: new Date("2020-01-20").toISOString(),
   deviceModelId: DeviceModelId.nanoX,
   walletEntryPointDismissed: false,
   entryPointFirstDisplayedDate: new Date("2020-01-20"),
@@ -154,6 +162,7 @@ const stateA5: PostOnboardingState = {
 
 // stateA1 -> removePostOnboardingActionCompleted(claimMock)
 const stateA6: PostOnboardingState = {
+  onboardingDate: new Date("2020-01-20").toISOString(),
   deviceModelId: DeviceModelId.nanoX,
   walletEntryPointDismissed: false,
   entryPointFirstDisplayedDate: new Date("2020-01-20"),
@@ -181,6 +190,7 @@ const initializationParamsB: Parameters<typeof initPostOnboarding> = [
 
 // initialState -> importPostOnboardingState(...initializationParamsB)
 const stateB0 = {
+  onboardingDate: new Date("2020-01-20").toISOString(),
   deviceModelId: DeviceModelId.nanoS,
   walletEntryPointDismissed: false,
   entryPointFirstDisplayedDate: new Date("2020-01-20"),
@@ -193,6 +203,7 @@ const stateB0 = {
 
 // stateB0 -> setPostOnboardingActionCompleted(claimMock)
 const stateB1 = {
+  onboardingDate: new Date("2020-01-20").toISOString(),
   deviceModelId: DeviceModelId.nanoS,
   walletEntryPointDismissed: false,
   entryPointFirstDisplayedDate: new Date("2020-01-20"),
@@ -212,6 +223,7 @@ const initializationParamsC: Parameters<typeof initPostOnboarding> = [
 
 // initialState -> importPostOnboardingState(...initializationParamsC)
 const stateC0 = {
+  onboardingDate: new Date("2020-01-20").toISOString(),
   deviceModelId: DeviceModelId.nanoSP,
   walletEntryPointDismissed: false,
   entryPointFirstDisplayedDate: new Date("2020-01-20"),
@@ -329,6 +341,61 @@ describe("postOnboarding reducer (& action creators)", () => {
     expect(state).toBe(stateBefore);
   });
 
+  it("should set onboardingDate (as an ISO string) on initPostOnboarding", () => {
+    state = reducer(state, initPostOnboarding(...initializationParamsA));
+    expect(typeof state.onboardingDate).toBe("string");
+    expect(state.onboardingDate).toBe(new Date("2020-01-20").toISOString());
+  });
+
+  it("should preserve an existing onboardingDate when re-initialized for another device", () => {
+    state = reducer(state, initPostOnboarding(...initializationParamsA));
+    const firstDate = state.onboardingDate;
+    expect(firstDate).toBe(new Date("2020-01-20").toISOString());
+
+    // A later onboarding of a different device must NOT reset the cooldown anchor.
+    jest.setSystemTime(new Date("2021-09-09"));
+    state = reducer(state, initPostOnboarding(...initializationParamsB));
+    expect(state.deviceModelId).toBe(DeviceModelId.nanoS); // the rest of the state did re-init
+    expect(state.onboardingDate).toBe(firstDate); // but onboardingDate is preserved
+
+    // Restore the fake clock so later tests that assume 2020-01-20 are unaffected.
+    jest.setSystemTime(new Date("2020-01-20"));
+  });
+
+  it("should not wipe onboardingDate when hiding the wallet entry point", () => {
+    state = stateA3;
+    state = reducer(state, hidePostOnboardingWalletEntryPoint());
+    expect(state.onboardingDate).toBe(new Date("2020-01-20").toISOString());
+  });
+
+  it("should default onboardingDate to null when missing from imported state", () => {
+    const { onboardingDate, ...withoutDate } = stateA0;
+    state = reducer(state, importPostOnboardingState({ newState: withoutDate }));
+    expect(state.onboardingDate).toBe(null);
+  });
+
+  it("should round-trip onboardingDate through importPostOnboardingState", () => {
+    state = reducer(state, importPostOnboardingState({ newState: stateA0 }));
+    expect(state.onboardingDate).toBe(new Date("2020-01-20").toISOString());
+  });
+
+  it("should set and reset onboardingDate via setPostOnboardingDate", () => {
+    const date = new Date("2021-05-05");
+    state = reducer(state, setPostOnboardingDate(date));
+    expect(state.onboardingDate).toBe(date.toISOString());
+
+    state = reducer(state, setPostOnboardingDate(null));
+    expect(state.onboardingDate).toBe(null);
+  });
+
+  it("should ignore a non-Date, non-null payload for setPostOnboardingDate", () => {
+    state = reducer(state, setPostOnboardingDate(new Date("2021-05-05")));
+    const before = state;
+    // @ts-expect-error - testing with an invalid (string) payload
+    state = reducer(state, setPostOnboardingDate("2022-06-06"));
+    expect(state).toBe(before);
+  });
+
   it("should handle successive actions properly", () => {
     // initializing state with new device & set of actions
     state = reducer(state, initPostOnboarding(...initializationParamsA));
@@ -382,6 +449,7 @@ describe("postOnboarding reducer (& action creators)", () => {
 describe("postOnboarding selectors", () => {
   it("should keep valid device ids", () => {
     const stateValidDeviceId: PostOnboardingState = {
+      onboardingDate: null,
       deviceModelId: DeviceModelId.nanoX,
       walletEntryPointDismissed: false,
       entryPointFirstDisplayedDate: new Date("2020-01-20"),
@@ -411,6 +479,7 @@ describe("postOnboarding selectors", () => {
 
   it('should sanitize "nanoFTS" device ids to "stax"', () => {
     const stateValidDeviceId: PostOnboardingState = {
+      onboardingDate: null,
       // @ts-expect-error - testing with "nanoFTS" device id
       deviceModelId: "nanoFTS",
       walletEntryPointDismissed: false,
@@ -461,5 +530,16 @@ describe("postOnboarding selectors", () => {
 
     const storeStateNull = { postOnboarding: initialState };
     expect(walletEntryPointEligibleForPortfolioSelector(storeStateNull)).toBe(null);
+  });
+
+  it("should return onboardingDate from state", () => {
+    const date = new Date("2021-05-05").toISOString();
+    const storeStateWithDate = {
+      postOnboarding: { ...initialState, onboardingDate: date },
+    };
+    expect(postOnboardingOnboardingDateSelector(storeStateWithDate)).toBe(date);
+
+    const storeStateNull = { postOnboarding: initialState };
+    expect(postOnboardingOnboardingDateSelector(storeStateNull)).toBe(null);
   });
 });

--- a/libs/ledger-live-common/src/postOnboarding/reducer.ts
+++ b/libs/ledger-live-common/src/postOnboarding/reducer.ts
@@ -13,6 +13,7 @@ export const initialState: PostOnboardingState = {
   actionsCompleted: {},
   lastActionCompleted: null,
   postOnboardingInProgress: false,
+  onboardingDate: null,
 };
 
 type PartialNewStatePayload = { newState: Partial<PostOnboardingState> };
@@ -33,14 +34,16 @@ export type Payload =
   | InitPayload
   | SetActionCompletedPayload
   | AddPayload
-  | boolean;
+  | boolean
+  | Date
+  | null;
 
 const handlers: ReducerMap<PostOnboardingState, Payload> = {
   POST_ONBOARDING_IMPORT_STATE: (_, { payload }): PostOnboardingState => ({
     ...initialState,
     ...(payload as PartialNewStatePayload).newState,
   }),
-  POST_ONBOARDING_INIT: (_, { payload }) => {
+  POST_ONBOARDING_INIT: (state, { payload }) => {
     const { deviceModelId, actionsIds } = payload as InitPayload;
     return {
       deviceModelId,
@@ -51,6 +54,9 @@ const handlers: ReducerMap<PostOnboardingState, Payload> = {
       actionsCompleted: Object.fromEntries(actionsIds.map(id => [id, false])),
       lastActionCompleted: null,
       postOnboardingInProgress: true,
+      // Set once: onboardingDate is the completion / cooldown anchor, so re-initializing
+      // post-onboarding (another device, debug screens) must not overwrite an existing date.
+      onboardingDate: state.onboardingDate ?? new Date().toISOString(),
     };
   },
   POST_ONBOARDING_ADD_ACTION: (state, { payload }) => {
@@ -113,6 +119,14 @@ const handlers: ReducerMap<PostOnboardingState, Payload> = {
     ...state,
     postOnboardingInProgress: false,
   }),
+
+  POST_ONBOARDING_SET_ONBOARDING_DATE: (state, { payload }) => {
+    if (payload !== null && !(payload instanceof Date)) return state;
+    return {
+      ...state,
+      onboardingDate: payload === null ? null : payload.toISOString(),
+    };
+  },
 };
 
 export default handleActions<PostOnboardingState, Payload>(handlers, initialState);
@@ -178,4 +192,9 @@ export const entryPointFirstDisplayedDateSelector = createSelector(
 export const walletEntryPointEligibleForPortfolioSelector = createSelector(
   postOnboardingSelector,
   postOnboarding => postOnboarding.walletEntryPointEligibleForPortfolio,
+);
+
+export const postOnboardingOnboardingDateSelector = createSelector(
+  postOnboardingSelector,
+  postOnboarding => postOnboarding.onboardingDate,
 );

--- a/libs/ledgerjs/packages/types-live/src/postOnboarding.ts
+++ b/libs/ledgerjs/packages/types-live/src/postOnboarding.ts
@@ -207,6 +207,15 @@ export type PostOnboardingState = {
    * Did the user started the PostOnboarding without closing or finishing it ?
    */
   postOnboardingInProgress: boolean;
+
+  /**
+   * Date the user completed onboarding, as an ISO 8601 string. Starting point
+   * for the large-screen upsell cooldown. Stored as a string so it
+   * survives JSON persistence/rehydration unchanged. Null means not set yet
+   * (backfilled to "today" on first launch for legacy users who onboarded
+   * before this field existed).
+   */
+  onboardingDate: string | null;
 };
 
 /**


### PR DESCRIPTION
chore: changeset

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Adds onboardingDate and backfill for users across both lwd and lwm for large upsell screen. 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-33149 and https://ledgerhq.atlassian.net/browse/LIVE-33157


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
