### PR TITLE
test:  e2e mobile change wait for w40 with discovery topbar

### DIFF
--- a/e2e/mobile/page/wallet/mainNavigation.page.ts
+++ b/e2e/mobile/page/wallet/mainNavigation.page.ts
@@ -35,7 +35,7 @@ export default class MainNavigationPage {
 
   @Step("Wait for Wallet 4.0 navigation to be ready")
   async waitForWallet40Ready(timeout = 60000) {
-    await waitForElementById(this.topBarMyWalletId, timeout);
+    await waitForElementById(this.topBarDiscoverId, timeout);
   }
 
   @Step("Wait for Legacy navigation to be ready")


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - E2E Mobile tests

### 📝 Description

Updates the mobile Detox E2E navigation page-object so “Wallet 4.0 ready” detection waits for the Discover top-bar element, aligning the readiness check with the Wallet 4.0 discovery topbar UI to be valid for Q1 and Q2.


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- E2E [Run](https://github.com/LedgerHQ/ledger-live/actions/runs/28386677699)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
