### PR TITLE
fix(feature-flags): resolve env overrides at boot when the first remote fetch fails (cherry-pick #19073)

### DIFF
--- a/.changeset/ff-env-resolve-at-boot.md
+++ b/.changeset/ff-env-resolve-at-boot.md
@@ -1,0 +1,5 @@
+---
+"@shared/feature-flags": minor
+---
+
+feature-flags: apply env (`FEATURE_FLAGS`) overrides at store boot even when the first remote-flags fetch fails. The middleware now re-resolves once on the first settled fetch — on success as before, and once on the first failure — so env (and version/language) resolution runs at boot without depending on a successful remote fetch. Subsequent failed polls do not re-resolve (a one-shot guard), so there is no per-poll churn. No app changes are required: any consumer of `createFeatureFlagsMiddleware` gets correct env-at-boot resolution.

--- a/shared/feature-flags/src/data/middleware.ts
+++ b/shared/feature-flags/src/data/middleware.ts
@@ -49,7 +49,13 @@ export function createFeatureFlagsMiddleware<S = unknown>(
     let lastLang = readLang();
     if (fetchRemoteFlags) {
       let readyDispatched = false;
-      const dispatchSync = () => dispatch(syncRemoteConfig());
+      let initialSyncDone = false;
+      const dispatchSync = (didFetch: boolean) => {
+        if (didFetch || !initialSyncDone) {
+          initialSyncDone = true;
+          dispatch(syncRemoteConfig());
+        }
+      };
       const dispatchReady = () => {
         if (readyDispatched) return;
         readyDispatched = true;
@@ -124,8 +130,9 @@ function getMeta(action: Action<string>) {
  * middleware when injecting `action.meta.remoteFlags`.
  *
  * @param dispatchSync
- * Callback fired after each *successful* fetch — used to dispatch
- * `syncRemoteConfig()` so reducers re-resolve.
+ * Callback fired after each *settled* fetch, told whether the fetch succeeded. It
+ * re-resolves (`syncRemoteConfig()`) on every success and once on the first settle
+ * even if it failed, so env/default resolution runs at boot.
  *
  * @param dispatchReady
  * Callback fired after each *settled* fetch (resolved or rejected) — used to
@@ -139,15 +146,15 @@ function getMeta(action: Action<string>) {
 async function pollRemoteFlags(
   fetch: () => Promise<PartialFeatures>,
   ref: RemoteFlagsRef,
-  dispatchSync: () => void,
+  dispatchSync: (didFetch: boolean) => void,
   dispatchReady: () => void,
   ms: number = FEATURE_FLAGS_REMOTE_POLLING_INTERVAL_MS,
 ) {
   const remote = await fetch().catch(() => null);
   if (remote !== null) {
     ref.current = remote;
-    dispatchSync();
   }
+  dispatchSync(remote !== null);
   dispatchReady();
   setTimeout(pollRemoteFlags, ms, fetch, ref, dispatchSync, dispatchReady, ms);
 }

--- a/shared/feature-flags/src/data/slice.test.ts
+++ b/shared/feature-flags/src/data/slice.test.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
-import { configureStore } from "@reduxjs/toolkit";
+import { configureStore, type Middleware } from "@reduxjs/toolkit";
 import {
   featureFlagsReducer,
   setOverride,
   setAllOverrides,
   setBannerVisible,
   setRemoteFlagsReady,
+  syncRemoteConfig,
   importState,
 } from "./slice";
 import { createFeatureFlagsMiddleware, type FeatureFlagsMiddlewareConfig } from "./middleware";
@@ -325,8 +326,8 @@ describe("middleware behavior", () => {
 
     jest.advanceTimersByTime(1_000);
     await flushPromises();
-    // Reducer state is unchanged because syncRemoteConfig is not dispatched on failure;
-    // the previous resolved value remains visible.
+    // syncRemoteConfig already fired on the earlier success, so the failed poll does
+    // not re-resolve (the one-shot guard is spent); the previous value remains visible.
     expect(store.getState().featureFlags.resolved.mockFeature.enabled).toBe(true);
   });
 
@@ -345,9 +346,60 @@ describe("middleware behavior", () => {
     const store = createStore(undefined, { fetchRemoteFlags: fetcher, refreshInterval: 1_000 });
 
     await flushPromises();
-    // syncRemoteConfig never fires on failure, so resolved stays at defaults.
+    // With no overrides/env and an empty remote, the first-settle re-resolve yields defaults.
     expect(store.getState().featureFlags.remoteFlagsReady).toBe(true);
     expect(store.getState().featureFlags.resolved.mockFeature).toEqual(defaults.mockFeature);
+  });
+
+  it("applies envFlags at boot even when the first fetch fails", async () => {
+    const fetcher = jest.fn().mockRejectedValue(new Error("network down"));
+    const store = createStore(undefined, {
+      resolutionConfig: {
+        envFlags: { mockFeature: { enabled: true, params: { fromEnv: true } } },
+      },
+      fetchRemoteFlags: fetcher,
+      refreshInterval: 1_000,
+    });
+
+    await flushPromises();
+    expect(store.getState().featureFlags.resolved.mockFeature).toEqual({
+      enabled: true,
+      params: { fromEnv: true },
+      overridesRemote: true,
+      overriddenByEnv: true,
+    });
+  });
+
+  it("dispatches syncRemoteConfig only once across repeated failed polls", async () => {
+    const fetcher = jest.fn().mockRejectedValue(new Error("network down"));
+    const dispatchedTypes: string[] = [];
+    const recorder: Middleware = () => next => action => {
+      dispatchedTypes.push((action as { type: string }).type);
+      return next(action);
+    };
+    const store = configureStore({
+      reducer: { featureFlags: featureFlagsReducer },
+      middleware: getDefaultMiddleware =>
+        getDefaultMiddleware()
+          .concat(recorder)
+          .concat(
+            createFeatureFlagsMiddleware({
+              resolutionConfig: {},
+              fetchRemoteFlags: fetcher,
+              refreshInterval: 1_000,
+            }),
+          ),
+    });
+
+    await flushPromises(); // first settle (failure) → one syncRemoteConfig
+    jest.advanceTimersByTime(1_000);
+    await flushPromises(); // second failed poll → no re-resolve
+    jest.advanceTimersByTime(1_000);
+    await flushPromises(); // third failed poll → no re-resolve
+
+    const syncs = dispatchedTypes.filter(type => type === syncRemoteConfig.type).length;
+    expect(syncs).toBe(1);
+    expect(fetcher).toHaveBeenCalledTimes(3);
   });
 
   it("does not schedule any timer when fetchRemoteFlags is omitted", () => {


### PR DESCRIPTION
Backport of #19073 onto `release` (clean cherry-pick of merge commit `0a53d05`, no conflicts).

- Original merged to `develop`: 0a53d05
- Changeset: `minor` `@shared/feature-flags`
- Files: `shared/feature-flags/src/data/middleware.ts` + `slice.test.ts` + changeset

Applies the env (`FEATURE_FLAGS`) override resolution at store boot even when the first remote-flags fetch fails.