### PR TITLE
[LWDM] feat(cryptoassets): inject domain fiat registry as runtime source of truth

### DIFF
--- a/.changeset/fiat-domain-source-of-truth.md
+++ b/.changeset/fiat-domain-source-of-truth.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/cryptoassets": minor
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/wallet-cli": patch
+"@ledgerhq/web-tools": patch
+---
+
+Make the `@ledgerhq/cryptoassets` fiat registry injectable (`setFiatCurrenciesStore`) and inject the `@domain/entity-currency-fiat` registry at each app's bootstrap, so the domain registry is the single runtime source of truth for fiat currency data. The bundled fiat list stays as the fallback and is kept in sync by the existing parity test.

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -76,6 +76,7 @@
     "@ledgerhq/coin-evm": "workspace:^",
     "@ledgerhq/coin-filecoin": "workspace:^",
     "@ledgerhq/coin-module-framework": "catalog:",
+    "@domain/entity-currency-fiat": "workspace:^",
     "@ledgerhq/crypto-icons": "catalog:",
     "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/devices": "workspace:*",

--- a/apps/ledger-live-desktop/src/live-common-setup-base.ts
+++ b/apps/ledger-live-desktop/src/live-common-setup-base.ts
@@ -1,15 +1,17 @@
 import os from "os";
 import { setEnv, getEnv } from "@ledgerhq/live-env";
 import { liveBlindSigningReporter } from "@ledgerhq/live-dmk-shared";
-import BigNumber from "bignumber.js";
-import { setCryptoCurrenciesStore } from "@ledgerhq/cryptoassets";
+import { setCryptoCurrenciesStore, setFiatCurrenciesStore } from "@ledgerhq/cryptoassets";
 import {
   CRYPTO_CURRENCIES_REGISTRY,
   CRYPTO_CURRENCY_ALIASES,
 } from "@domain/entity-currency-crypto";
+import { FIAT_CURRENCIES_REGISTRY } from "@domain/entity-currency-fiat";
+import BigNumber from "bignumber.js";
 
-// The domain registry is the runtime source of truth for currency data.
+// The domain registries are the runtime source of truth for currency data.
 setCryptoCurrenciesStore(Object.values(CRYPTO_CURRENCIES_REGISTRY), CRYPTO_CURRENCY_ALIASES);
+setFiatCurrenciesStore(Object.values(FIAT_CURRENCIES_REGISTRY));
 
 let ledgerClientVersion = `lld/${__APP_VERSION__}`;
 

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -105,6 +105,7 @@
     "@ledgerhq/coin-module-framework": "catalog:",
     "@ledgerhq/coin-multiversx": "workspace:^",
     "@ledgerhq/coin-stacks": "workspace:^",
+    "@domain/entity-currency-fiat": "workspace:^",
     "@ledgerhq/crypto-icons": "catalog:",
     "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/device-intent": "workspace:^",

--- a/apps/ledger-live-mobile/src/live-common-setup.ts
+++ b/apps/ledger-live-mobile/src/live-common-setup.ts
@@ -10,17 +10,19 @@ import { Platform } from "react-native";
 import { setSecp256k1Instance } from "@ledgerhq/live-common/families/bitcoin/logic";
 import { setGlobalOnBridgeError } from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { liveBlindSigningReporter } from "@ledgerhq/live-dmk-shared";
-import "./experimental";
-import logger, { ConsoleLogger } from "./logger";
-import BigNumber from "bignumber.js";
-import { setCryptoCurrenciesStore } from "@ledgerhq/cryptoassets";
+import { setCryptoCurrenciesStore, setFiatCurrenciesStore } from "@ledgerhq/cryptoassets";
 import {
   CRYPTO_CURRENCIES_REGISTRY,
   CRYPTO_CURRENCY_ALIASES,
 } from "@domain/entity-currency-crypto";
+import { FIAT_CURRENCIES_REGISTRY } from "@domain/entity-currency-fiat";
+import "./experimental";
+import logger, { ConsoleLogger } from "./logger";
+import BigNumber from "bignumber.js";
 
-// The domain registry is the runtime source of truth for currency data.
+// The domain registries are the runtime source of truth for currency data.
 setCryptoCurrenciesStore(Object.values(CRYPTO_CURRENCIES_REGISTRY), CRYPTO_CURRENCY_ALIASES);
+setFiatCurrenciesStore(Object.values(FIAT_CURRENCIES_REGISTRY));
 
 registerAllCoins();
 

--- a/apps/wallet-cli/package.json
+++ b/apps/wallet-cli/package.json
@@ -48,6 +48,7 @@
     "@ledgerhq/coin-bitcoin": "workspace:^",
     "@ledgerhq/coin-evm": "workspace:^",
     "@ledgerhq/coin-module-framework": "catalog:",
+    "@domain/entity-currency-fiat": "workspace:^",
     "@ledgerhq/coin-solana": "workspace:^",
     "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/device-management-kit": "catalog:",

--- a/apps/wallet-cli/src/live-common-setup.ts
+++ b/apps/wallet-cli/src/live-common-setup.ts
@@ -7,13 +7,14 @@ import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { setEnv } from "@ledgerhq/live-env";
 import { registerWalletCliDmkTransport } from "./device/register-dmk-transport";
-import pkg from "../package.json" with { type: "json" };
-import type { CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
-import { setCryptoCurrenciesStore } from "@ledgerhq/cryptoassets";
+import { setCryptoCurrenciesStore, setFiatCurrenciesStore } from "@ledgerhq/cryptoassets";
 import {
   CRYPTO_CURRENCIES_REGISTRY,
   CRYPTO_CURRENCY_ALIASES,
 } from "@domain/entity-currency-crypto";
+import { FIAT_CURRENCIES_REGISTRY } from "@domain/entity-currency-fiat";
+import pkg from "../package.json" with { type: "json" };
+import type { CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 
 /**
  * Ensure USER_ID is set so DMK firmware distribution salt is stable for this CLI.
@@ -102,9 +103,10 @@ export const WALLET_CLI_SUPPORTED_CRYPTO_CURRENCY_IDS: readonly CryptoCurrencyId
   "solana",
 ];
 
-setWalletAPIVersion(WALLET_API_VERSION);
-// The domain registry is the runtime source of truth for currency data.
+// The domain registries are the runtime source of truth for currency data.
 setCryptoCurrenciesStore(Object.values(CRYPTO_CURRENCIES_REGISTRY), CRYPTO_CURRENCY_ALIASES);
+setFiatCurrenciesStore(Object.values(FIAT_CURRENCIES_REGISTRY));
+setWalletAPIVersion(WALLET_API_VERSION);
 registerCoinModules(walletCliLoaders);
 LiveConfig.setConfig(walletCliConfig);
 // TODO: wallet-cli should own its Redux store setup (createRtkCryptoAssetsStore + RTK middleware)

--- a/apps/web-tools/package.json
+++ b/apps/web-tools/package.json
@@ -27,6 +27,7 @@
     "react-redux": "catalog:",
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/view": "^6.39.5",
+    "@domain/entity-currency-fiat": "workspace:^",
     "@ledgerhq/coin-module-framework": "catalog:",
     "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/crypto-icons": "catalog:",

--- a/apps/web-tools/src/App.tsx
+++ b/apps/web-tools/src/App.tsx
@@ -1,9 +1,9 @@
+import "./live-common-setup";
 import { BrowserRouter } from "react-router-dom";
 import { Provider } from "react-redux";
 import { AppRoutes } from "./routes";
 import { store } from "./store";
 import "./globals.css";
-import "./live-common-setup";
 
 export const App = () => (
   <Provider store={store}>

--- a/apps/web-tools/src/live-common-setup.ts
+++ b/apps/web-tools/src/live-common-setup.ts
@@ -5,14 +5,16 @@ import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { liveConfig } from "@ledgerhq/live-common/config/sharedConfig";
 import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
-import { setCryptoCurrenciesStore } from "@ledgerhq/cryptoassets";
+import { setCryptoCurrenciesStore, setFiatCurrenciesStore } from "@ledgerhq/cryptoassets";
 import {
   CRYPTO_CURRENCIES_REGISTRY,
   CRYPTO_CURRENCY_ALIASES,
 } from "@domain/entity-currency-crypto";
+import { FIAT_CURRENCIES_REGISTRY } from "@domain/entity-currency-fiat";
 
-// The domain registry is the runtime source of truth for currency data.
+// The domain registries are the runtime source of truth for currency data.
 setCryptoCurrenciesStore(Object.values(CRYPTO_CURRENCIES_REGISTRY), CRYPTO_CURRENCY_ALIASES);
+setFiatCurrenciesStore(Object.values(FIAT_CURRENCIES_REGISTRY));
 
 LiveConfig.setConfig(liveConfig);
 LiveConfig.setAppinfo({

--- a/libs/ledgerjs/packages/cryptoassets/src/fiats-store.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/fiats-store.ts
@@ -1,0 +1,62 @@
+import type { FiatCurrency } from "@ledgerhq/types-cryptoassets";
+
+/**
+ * Internal, derived shape consumed by the accessors in `fiats.ts`.
+ *
+ * It is **not** the injection contract: callers pass a `FiatCurrency[]` to
+ * {@link setFiatCurrenciesStore} and the by-ticker index/array below are derived here, so they
+ * cannot drift out of sync. Tickers are unique across the fiat registry, so — unlike the crypto
+ * store — there is no scheme/keyword tiebreak and no dev/prod split.
+ */
+export type FiatCurrenciesStore = {
+  fiatCurrenciesByTicker: Record<string, FiatCurrency>;
+  fiatCurrenciesArray: FiatCurrency[];
+};
+
+declare global {
+  interface GlobalThis {
+    __ledgerFiatCurrenciesStore?: FiatCurrenciesStore;
+  }
+}
+
+function emptyFiatCurrenciesStore(): FiatCurrenciesStore {
+  return {
+    // Null-prototype map: keys come from external (injected) currency data, so a ticker like
+    // "__proto__" or "constructor" stays a plain own key and can't mutate the prototype chain.
+    fiatCurrenciesByTicker: Object.create(null),
+    fiatCurrenciesArray: [],
+  };
+}
+
+export function buildFiatCurrenciesStore(currencies: FiatCurrency[]): FiatCurrenciesStore {
+  const store = emptyFiatCurrenciesStore();
+  for (const currency of currencies) {
+    store.fiatCurrenciesByTicker[currency.ticker] = currency;
+    store.fiatCurrenciesArray.push(currency);
+  }
+  return store;
+}
+
+/**
+ * Injects the fiat-currency registry from the canonical currency list.
+ * This should be called once during application initialization.
+ *
+ * The caller only provides the currencies; the by-ticker index and the array are derived here so
+ * they stay consistent by construction.
+ *
+ * Uses globalThis to ensure a single shared reference across all module instances, which is
+ * critical when modules are lazy-loaded and may resolve to separate module copies.
+ */
+export function setFiatCurrenciesStore(currencies: FiatCurrency[]): void {
+  globalThis.__ledgerFiatCurrenciesStore = buildFiatCurrenciesStore(currencies);
+}
+
+/**
+ * Returns the injected fiat-currency registry store, or `undefined` when none has been set.
+ *
+ * This never throws: callers fall back to the bundled data, so accessors invoked at
+ * module-evaluation time (before any injection) stay safe.
+ */
+export function getInjectedFiatCurrenciesStore(): FiatCurrenciesStore | undefined {
+  return globalThis.__ledgerFiatCurrenciesStore;
+}

--- a/libs/ledgerjs/packages/cryptoassets/src/fiats.domain-parity.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/fiats.domain-parity.test.ts
@@ -1,6 +1,7 @@
 import type { FiatCurrency } from "@ledgerhq/types-cryptoassets";
 import { FIAT_CURRENCIES_REGISTRY } from "@domain/entity-currency-fiat";
-import { listFiatCurrencies } from "./fiats";
+import { findFiatCurrencyByTicker, getFiatCurrencyByTicker, listFiatCurrencies } from "./fiats";
+import { setFiatCurrenciesStore } from "./fiats-store";
 
 /**
  * Parity guard between the legacy bundled fiat registry (`@ledgerhq/cryptoassets`) and the
@@ -34,5 +35,34 @@ describe("@domain/entity-currency-fiat parity with @ledgerhq/cryptoassets", () =
   it.each(sortedTickers)("matches the legacy definition for %s", ticker => {
     const id = ticker.toLowerCase();
     expect(FIAT_CURRENCIES_REGISTRY[id]).toEqual({ ...legacyByTicker.get(ticker), id });
+  });
+});
+
+/**
+ * Once the domain registry is injected (as every app does at bootstrap), the cryptoassets
+ * accessors must hand back the *same object reference* as `@domain/entity-currency-fiat` — this is
+ * the single-source-of-truth guarantee that keeps `usd === usd` across the codebase. Object
+ * equality (`toEqual`) is already covered above; here we assert reference equality (`toBe`).
+ */
+describe("lookup parity: injected domain store hands back domain references", () => {
+  const domainFiats = Object.values(FIAT_CURRENCIES_REGISTRY);
+
+  beforeAll(() => {
+    setFiatCurrenciesStore(domainFiats);
+  });
+
+  afterAll(() => {
+    // Reset the global store so other suites fall back to the bundled registry.
+    globalThis.__ledgerFiatCurrenciesStore = undefined;
+  });
+
+  it("listFiatCurrencies returns the domain objects", () => {
+    expect(new Set(listFiatCurrencies())).toEqual(new Set(domainFiats));
+  });
+
+  it.each(sortedTickers)("getFiatCurrencyByTicker(%s) is the domain object reference", ticker => {
+    const domain = FIAT_CURRENCIES_REGISTRY[ticker.toLowerCase()];
+    expect(getFiatCurrencyByTicker(ticker)).toBe(domain);
+    expect(findFiatCurrencyByTicker(ticker)).toBe(domain);
   });
 });

--- a/libs/ledgerjs/packages/cryptoassets/src/fiats.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/fiats.ts
@@ -1,4 +1,9 @@
 import type { FiatCurrency } from "@ledgerhq/types-cryptoassets";
+import {
+  buildFiatCurrenciesStore,
+  type FiatCurrenciesStore,
+  getInjectedFiatCurrenciesStore,
+} from "./fiats-store";
 // inspired by https://github.com/smirzaei/currency-formatter/blob/master/currencies.json
 
 function fiat(name, ticker, defaultSymbol, defaultMagnitude): FiatCurrency {
@@ -186,14 +191,26 @@ const byTicker: Record<string, FiatCurrency> = {
   ZAR: fiat("South African Rand", "ZAR", "R", 2),
   ZMW: fiat("Zambian Kwacha", "ZMW", "ZK", 2),
 };
-const list = Object.keys(byTicker).map(k => byTicker[k]);
+// The bundled registry, used as fallback whenever no store has been injected. Built through the
+// same path as the injected store so both share the null-prototype map (no prototype pollution).
+const bundledFiatCurrenciesStore: FiatCurrenciesStore = buildFiatCurrenciesStore(
+  Object.values(byTicker),
+);
+
+// Returns the injected store (the app's source of truth) or the bundled fallback.
+function activeFiatCurrenciesStore(): FiatCurrenciesStore {
+  return getInjectedFiatCurrenciesStore() ?? bundledFiatCurrenciesStore;
+}
 
 /**
  *
  * @param {*} ticker
  */
 export function hasFiatCurrencyTicker(ticker: string): boolean {
-  return ticker in byTicker;
+  return Object.prototype.hasOwnProperty.call(
+    activeFiatCurrenciesStore().fiatCurrenciesByTicker,
+    ticker,
+  );
 }
 
 /**
@@ -201,7 +218,7 @@ export function hasFiatCurrencyTicker(ticker: string): boolean {
  * @param {*} ticker
  */
 export function findFiatCurrencyByTicker(ticker: string): FiatCurrency | null | undefined {
-  return byTicker[ticker];
+  return activeFiatCurrenciesStore().fiatCurrenciesByTicker[ticker];
 }
 
 /**
@@ -222,5 +239,5 @@ export function getFiatCurrencyByTicker(ticker: string): FiatCurrency {
  *
  */
 export function listFiatCurrencies(): FiatCurrency[] {
-  return list;
+  return activeFiatCurrenciesStore().fiatCurrenciesArray;
 }

--- a/libs/ledgerjs/packages/cryptoassets/src/index.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./fiats";
 export * from "./currencies";
 export { setCryptoCurrenciesStore } from "./currencies-store";
+export { setFiatCurrenciesStore } from "./fiats-store";
 export * from "./api-token-converter";
 export * from "./api-asset-converter";
 export * from "./state";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -913,6 +913,9 @@ importers:
       '@domain/entity-currency-crypto':
         specifier: workspace:*
         version: link:../../domain/entity/currency-crypto
+      '@domain/entity-currency-fiat':
+        specifier: workspace:^
+        version: link:../../domain/entity/currency-fiat
       '@electron/fuses':
         specifier: 2.0.0
         version: 2.0.0
@@ -1575,6 +1578,9 @@ importers:
       '@domain/entity-currency-crypto':
         specifier: workspace:*
         version: link:../../domain/entity/currency-crypto
+      '@domain/entity-currency-fiat':
+        specifier: workspace:^
+        version: link:../../domain/entity/currency-fiat
       '@features/platform-feature-flags':
         specifier: workspace:^
         version: link:../../features/platform/feature-flags
@@ -2344,6 +2350,9 @@ importers:
       '@domain/entity-currency-crypto':
         specifier: workspace:^
         version: link:../../domain/entity/currency-crypto
+      '@domain/entity-currency-fiat':
+        specifier: workspace:^
+        version: link:../../domain/entity/currency-fiat
       '@ledgerhq/coin-bitcoin':
         specifier: workspace:^
         version: link:../../libs/coin-modules/coin-bitcoin
@@ -2503,6 +2512,9 @@ importers:
       '@domain/entity-currency-crypto':
         specifier: workspace:*
         version: link:../../domain/entity/currency-crypto
+      '@domain/entity-currency-fiat':
+        specifier: workspace:^
+        version: link:../../domain/entity/currency-fiat
       '@features/platform-feature-flags':
         specifier: workspace:*
         version: link:../../features/platform/feature-flags
@@ -22323,7 +22335,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: '*'
+      webpack: ^5.89.0
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -24268,7 +24280,7 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
+    deprecated: this version is no longer supported, please update to at least 0.8.*
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -24617,7 +24629,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -33877,6 +33889,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode-terminal@0.11.0:


### PR DESCRIPTION
> [!NOTE]
> Fiat counterpart of #19007. Makes @domain/entity-currency-fiat the single runtime source of truth for fiat data, so a usd is always === a usd across the codebase.

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** A guard in fiats.domain-parity.test.ts injects the real domain array and asserts every accessor (getFiatCurrencyByTicker / findFiatCurrencyByTicker / listFiatCurrencies) returns the exact domain object reference (usd === usd); the existing field-parity guard keeps bundled and domain iso.
- [ ] **Impact of the changes:**
  - The runtime source of truth for fiat **data** in 4 apps (desktop, mobile, wallet-cli, web-tools) switches from the bundled @ledgerhq/cryptoassets fiat list to @domain/entity-currency-fiat (values are parity-tested equal; the bundled list stays as fallback). **QA focus:** app bootstrap (no throw at setFiatCurrenciesStore), fiat selection in settings, countervalue display, and the web-tools PnL calculator.

### 📝 Description

LIVE-32899/#19007 did this for crypto currencies. This is the fiat half: there were two runtime copies of every fiat (bundled cryptoassets vs domain), field-equal but not reference-equal, which breaks as fiats go dynamic via the Countervalues Service.

This PR makes the bundled cryptoassets fiat registry injectable (new setFiatCurrenciesStore, accessors read injected ?? bundled) and injects Object.values(FIAT_CURRENCIES_REGISTRY) at each app bootstrap, so domain becomes the single runtime source of truth and reference identity holds everywhere.

apps/cli is intentionally left untouched (deprecated). In web-tools the setup import is hoisted first so currency captures at module-eval (wallet-pnl scenarios) see the injected store.

### ❓ Context

- **JIRA or GitHub link**: follows #19007 (crypto), parent epic LIVE-31901 — fiat ticket TBD
- **ADR link (if any)**: n/a
