### PR TITLE
[LWDM] Implement signRawOperation (for cosmos_signAmino)

### DIFF
--- a/.changeset/cosmos-sign-raw-operation.md
+++ b/.changeset/cosmos-sign-raw-operation.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-cosmos": minor
+---
+
+Implement `signRawOperation` for Cosmos: sign an externally-built amino `StdSignDoc` (e.g. from WalletConnect `cosmos_signAmino`) verbatim and return the detached 64-byte secp256k1 signature, without broadcasting. Previously a throwing stub.

--- a/libs/coin-modules/coin-cosmos/src/bridge/index.ts
+++ b/libs/coin-modules/coin-cosmos/src/bridge/index.ts
@@ -25,6 +25,7 @@ import {
   toOperationExtraRaw,
 } from "../serialization";
 import { buildSignOperation } from "../signOperation";
+import { buildSignRawOperation } from "../signRawOperation";
 import { getAccountShape } from "../synchronisation";
 import type { CosmosAccount, CosmosOperation, Transaction, TransactionStatus } from "../types";
 import { CosmosSigner } from "../types/signer";
@@ -67,9 +68,7 @@ function buildAccountBridge(
     sync,
     receive,
     signOperation,
-    signRawOperation: () => {
-      throw new Error("signRawOperation is not supported");
-    },
+    signRawOperation: buildSignRawOperation(signerContext),
     assignFromAccountRaw,
     assignToAccountRaw,
     broadcast: async ({ account, signedOperation }) => {

--- a/libs/coin-modules/coin-cosmos/src/signRawOperation.ts
+++ b/libs/coin-modules/coin-cosmos/src/signRawOperation.ts
@@ -1,0 +1,129 @@
+import { serializeSignDoc, StdSignDoc } from "@cosmjs/amino";
+import { Secp256k1Signature } from "@cosmjs/crypto";
+import { ExpertModeRequired, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
+import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
+import type { AccountBridge, Operation } from "@ledgerhq/types-live";
+import BigNumber from "bignumber.js";
+import { Observable } from "rxjs";
+import cryptoFactory from "./chain/chain";
+import { CosmosAccount, RETURN_CODES, Transaction } from "./types";
+import { CosmosSignatureSdk, CosmosSigner } from "./types/signer";
+
+// Minimal structural guard so a malformed payload fails with a clear message
+// instead of a cryptic serializeSignDoc error. Full param validation (Zod) lives
+// in the live-app (WalletConnect) layer.
+function assertValidStdSignDoc(doc: unknown): asserts doc is StdSignDoc {
+  const d = doc as Partial<StdSignDoc> | null;
+  if (!d || typeof d !== "object") {
+    throw new Error("signRawOperation: signDoc must be a JSON object");
+  }
+  if (typeof d.chain_id !== "string") {
+    throw new Error("signRawOperation: signDoc.chain_id must be a string");
+  }
+  if (typeof d.account_number !== "string" || typeof d.sequence !== "string") {
+    throw new Error("signRawOperation: signDoc.account_number and sequence must be strings");
+  }
+  if (typeof d.memo !== "string") {
+    throw new Error("signRawOperation: signDoc.memo must be a string");
+  }
+  if (!d.fee || !Array.isArray(d.fee.amount) || typeof d.fee.gas !== "string") {
+    throw new Error("signRawOperation: signDoc.fee must have { amount: [], gas }");
+  }
+  if (!Array.isArray(d.msgs) || d.msgs.length === 0) {
+    throw new Error("signRawOperation: signDoc.msgs must be a non-empty array");
+  }
+}
+
+// `transaction` is a JSON-serialized amino `StdSignDoc`, built entirely by the
+// dApp (via WalletConnect `cosmos_signAmino`). We sign the canonical serialized
+// bytes verbatim — no re-fetching of account number / sequence / chain id / fee
+// — and return the detached 64-byte secp256k1 signature (hex). The caller pairs
+// it with the account public key and broadcasts; this method never broadcasts.
+export const buildSignRawOperation =
+  (
+    signerContext: SignerContext<CosmosSigner>,
+  ): AccountBridge<Transaction, CosmosAccount>["signRawOperation"] =>
+  ({ account, deviceId, transaction }) =>
+    new Observable(o => {
+      let cancelled = false;
+      async function main() {
+        const chainInstance = cryptoFactory(account.currency.id);
+
+        let signDoc: StdSignDoc;
+        try {
+          signDoc = JSON.parse(transaction);
+        } catch (e) {
+          throw new Error(
+            `signRawOperation: transaction is not valid JSON (${(e as Error).message})`,
+          );
+        }
+        assertValidStdSignDoc(signDoc);
+        const tx = Buffer.from(serializeSignDoc(signDoc));
+        const path = account.freshAddressPath.split("/").map(p => parseInt(p.replace("'", "")));
+
+        o.next({ type: "device-signature-requested" });
+
+        const { signature: resSignature, return_code } = (await signerContext(
+          deviceId,
+          async signer =>
+            // HRP is only needed when signing for ethermint chains.
+            path[1] === 60 ? signer.sign(path, tx, chainInstance.prefix) : signer.sign(path, tx),
+        )) as CosmosSignatureSdk;
+
+        switch (return_code) {
+          case RETURN_CODES.EXPERT_MODE_REQUIRED:
+            throw new ExpertModeRequired();
+          case RETURN_CODES.REFUSED_OPERATION:
+            throw new UserRefusedOnDevice();
+        }
+
+        o.next({ type: "device-signature-granted" });
+
+        // DER → fixed 64-byte r‖s, hex-encoded.
+        const signature = Buffer.from(
+          Secp256k1Signature.fromDer(resSignature).toFixedLength(),
+        ).toString("hex");
+
+        if (cancelled) {
+          return;
+        }
+
+        // Optimistic operation: the real tx is assembled and broadcast by the
+        // dApp, so we only have a placeholder here.
+        const accountId = account.id;
+        const hash = "";
+        const operation: Operation = {
+          id: encodeOperationId(accountId, hash, "OUT"),
+          hash,
+          type: "OUT",
+          value: new BigNumber(0),
+          fee: new BigNumber(0),
+          extra: {},
+          blockHash: null,
+          blockHeight: null,
+          senders: [account.freshAddress],
+          recipients: [],
+          accountId,
+          date: new Date(),
+        };
+
+        o.next({
+          type: "signed",
+          signedOperation: {
+            operation,
+            signature,
+          },
+        });
+      }
+      main().then(
+        () => o.complete(),
+        e => o.error(e),
+      );
+
+      return () => {
+        cancelled = true;
+      };
+    });
+
+export default buildSignRawOperation;

--- a/libs/coin-modules/coin-cosmos/src/signRawOperation.ts
+++ b/libs/coin-modules/coin-cosmos/src/signRawOperation.ts
@@ -36,7 +36,13 @@ function assertValidStdSignDoc(doc: unknown): asserts doc is StdSignDoc {
 }
 
 function parseDerivationPath(freshAddressPath: string): number[] {
-  return freshAddressPath.split("/").map(segment => Number.parseInt(segment.replace(/'/g, ""), 10));
+  const path = freshAddressPath
+    .split("/")
+    .map(segment => Number.parseInt(segment.replace(/'/g, ""), 10));
+  if (path.length < 2 || path.some(Number.isNaN)) {
+    throw new Error(`signRawOperation: malformed derivation path "${freshAddressPath}"`);
+  }
+  return path;
 }
 
 function signTransaction(
@@ -94,16 +100,17 @@ async function performSignRawOperation(
     throw new Error(`signRawOperation: device returned no signature (return_code ${return_code})`);
   }
 
-  observer.next({ type: "device-signature-granted" });
-
   // DER → fixed 64-byte r‖s, hex-encoded.
   const signature = Buffer.from(Secp256k1Signature.fromDer(resSignature).toFixedLength()).toString(
     "hex",
   );
 
+  // Mirror signOperation: don't emit any post-device event once unsubscribed.
   if (isCancelled()) {
     return;
   }
+
+  observer.next({ type: "device-signature-granted" });
 
   // Optimistic operation: the real tx is assembled and broadcast by the
   // dApp, so we only have a placeholder here.

--- a/libs/coin-modules/coin-cosmos/src/signRawOperation.ts
+++ b/libs/coin-modules/coin-cosmos/src/signRawOperation.ts
@@ -3,12 +3,12 @@ import { Secp256k1Signature } from "@cosmjs/crypto";
 import { ExpertModeRequired, UserRefusedOnDevice } from "@ledgerhq/errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
-import type { AccountBridge, Operation } from "@ledgerhq/types-live";
+import type { AccountBridge, Operation, SignOperationEvent } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
-import { Observable } from "rxjs";
+import { Observable, Observer } from "rxjs";
 import cryptoFactory from "./chain/chain";
 import { CosmosAccount, RETURN_CODES, Transaction } from "./types";
-import { CosmosSignatureSdk, CosmosSigner } from "./types/signer";
+import { CosmosSignature, CosmosSigner } from "./types/signer";
 
 // Minimal structural guard so a malformed payload fails with a clear message
 // instead of a cryptic serializeSignDoc error. Full param validation (Zod) lives
@@ -16,23 +16,121 @@ import { CosmosSignatureSdk, CosmosSigner } from "./types/signer";
 function assertValidStdSignDoc(doc: unknown): asserts doc is StdSignDoc {
   const d = doc as Partial<StdSignDoc> | null;
   if (!d || typeof d !== "object") {
-    throw new Error("signRawOperation: signDoc must be a JSON object");
+    throw new TypeError("signRawOperation: signDoc must be a JSON object");
   }
   if (typeof d.chain_id !== "string") {
-    throw new Error("signRawOperation: signDoc.chain_id must be a string");
+    throw new TypeError("signRawOperation: signDoc.chain_id must be a string");
   }
   if (typeof d.account_number !== "string" || typeof d.sequence !== "string") {
-    throw new Error("signRawOperation: signDoc.account_number and sequence must be strings");
+    throw new TypeError("signRawOperation: signDoc.account_number and sequence must be strings");
   }
   if (typeof d.memo !== "string") {
-    throw new Error("signRawOperation: signDoc.memo must be a string");
+    throw new TypeError("signRawOperation: signDoc.memo must be a string");
   }
   if (!d.fee || !Array.isArray(d.fee.amount) || typeof d.fee.gas !== "string") {
-    throw new Error("signRawOperation: signDoc.fee must have { amount: [], gas }");
+    throw new TypeError("signRawOperation: signDoc.fee must have { amount: [], gas }");
   }
   if (!Array.isArray(d.msgs) || d.msgs.length === 0) {
-    throw new Error("signRawOperation: signDoc.msgs must be a non-empty array");
+    throw new TypeError("signRawOperation: signDoc.msgs must be a non-empty array");
   }
+}
+
+function parseDerivationPath(freshAddressPath: string): number[] {
+  return freshAddressPath.split("/").map(segment => Number.parseInt(segment.replace(/'/g, ""), 10));
+}
+
+function signTransaction(
+  signerContext: SignerContext<CosmosSigner>,
+  deviceId: string,
+  path: number[],
+  tx: Buffer,
+  prefix: string,
+): Promise<CosmosSignature> {
+  return signerContext(deviceId, signer =>
+    // HRP is only needed when signing for ethermint chains.
+    path[1] === 60 ? signer.sign(path, tx, prefix) : signer.sign(path, tx),
+  );
+}
+
+async function performSignRawOperation(
+  signerContext: SignerContext<CosmosSigner>,
+  account: CosmosAccount,
+  deviceId: string,
+  transaction: string,
+  observer: Observer<SignOperationEvent>,
+  isCancelled: () => boolean,
+): Promise<void> {
+  const chainInstance = cryptoFactory(account.currency.id);
+
+  let signDoc: StdSignDoc;
+  try {
+    signDoc = JSON.parse(transaction);
+  } catch (e) {
+    throw new Error(`signRawOperation: transaction is not valid JSON (${(e as Error).message})`);
+  }
+  assertValidStdSignDoc(signDoc);
+  const tx = Buffer.from(serializeSignDoc(signDoc));
+  const path = parseDerivationPath(account.freshAddressPath);
+
+  observer.next({ type: "device-signature-requested" });
+
+  const { signature: resSignature, return_code } = await signTransaction(
+    signerContext,
+    deviceId,
+    path,
+    tx,
+    chainInstance.prefix,
+  );
+
+  switch (return_code) {
+    case RETURN_CODES.EXPERT_MODE_REQUIRED:
+      throw new ExpertModeRequired();
+    case RETURN_CODES.REFUSED_OPERATION:
+      throw new UserRefusedOnDevice();
+  }
+  if (!resSignature) {
+    // Defensive: an unhandled non-success return_code can still carry a null signature;
+    // fail clearly instead of letting Secp256k1Signature.fromDer throw on null.
+    throw new Error(`signRawOperation: device returned no signature (return_code ${return_code})`);
+  }
+
+  observer.next({ type: "device-signature-granted" });
+
+  // DER → fixed 64-byte r‖s, hex-encoded.
+  const signature = Buffer.from(Secp256k1Signature.fromDer(resSignature).toFixedLength()).toString(
+    "hex",
+  );
+
+  if (isCancelled()) {
+    return;
+  }
+
+  // Optimistic operation: the real tx is assembled and broadcast by the
+  // dApp, so we only have a placeholder here.
+  const accountId = account.id;
+  const hash = "";
+  const operation: Operation = {
+    id: encodeOperationId(accountId, hash, "OUT"),
+    hash,
+    type: "OUT",
+    value: new BigNumber(0),
+    fee: new BigNumber(0),
+    extra: {},
+    blockHash: null,
+    blockHeight: null,
+    senders: [account.freshAddress],
+    recipients: [],
+    accountId,
+    date: new Date(),
+  };
+
+  observer.next({
+    type: "signed",
+    signedOperation: {
+      operation,
+      signature,
+    },
+  });
 }
 
 // `transaction` is a JSON-serialized amino `StdSignDoc`, built entirely by the
@@ -47,76 +145,14 @@ export const buildSignRawOperation =
   ({ account, deviceId, transaction }) =>
     new Observable(o => {
       let cancelled = false;
-      async function main() {
-        const chainInstance = cryptoFactory(account.currency.id);
-
-        let signDoc: StdSignDoc;
-        try {
-          signDoc = JSON.parse(transaction);
-        } catch (e) {
-          throw new Error(
-            `signRawOperation: transaction is not valid JSON (${(e as Error).message})`,
-          );
-        }
-        assertValidStdSignDoc(signDoc);
-        const tx = Buffer.from(serializeSignDoc(signDoc));
-        const path = account.freshAddressPath.split("/").map(p => parseInt(p.replace("'", "")));
-
-        o.next({ type: "device-signature-requested" });
-
-        const { signature: resSignature, return_code } = (await signerContext(
-          deviceId,
-          async signer =>
-            // HRP is only needed when signing for ethermint chains.
-            path[1] === 60 ? signer.sign(path, tx, chainInstance.prefix) : signer.sign(path, tx),
-        )) as CosmosSignatureSdk;
-
-        switch (return_code) {
-          case RETURN_CODES.EXPERT_MODE_REQUIRED:
-            throw new ExpertModeRequired();
-          case RETURN_CODES.REFUSED_OPERATION:
-            throw new UserRefusedOnDevice();
-        }
-
-        o.next({ type: "device-signature-granted" });
-
-        // DER → fixed 64-byte r‖s, hex-encoded.
-        const signature = Buffer.from(
-          Secp256k1Signature.fromDer(resSignature).toFixedLength(),
-        ).toString("hex");
-
-        if (cancelled) {
-          return;
-        }
-
-        // Optimistic operation: the real tx is assembled and broadcast by the
-        // dApp, so we only have a placeholder here.
-        const accountId = account.id;
-        const hash = "";
-        const operation: Operation = {
-          id: encodeOperationId(accountId, hash, "OUT"),
-          hash,
-          type: "OUT",
-          value: new BigNumber(0),
-          fee: new BigNumber(0),
-          extra: {},
-          blockHash: null,
-          blockHeight: null,
-          senders: [account.freshAddress],
-          recipients: [],
-          accountId,
-          date: new Date(),
-        };
-
-        o.next({
-          type: "signed",
-          signedOperation: {
-            operation,
-            signature,
-          },
-        });
-      }
-      main().then(
+      performSignRawOperation(
+        signerContext,
+        account,
+        deviceId,
+        transaction,
+        o,
+        () => cancelled,
+      ).then(
         () => o.complete(),
         e => o.error(e),
       );

--- a/libs/coin-modules/coin-cosmos/src/signRawOperation.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/signRawOperation.unit.test.ts
@@ -10,11 +10,11 @@ const SUCCESS = 0x9000; // 36864
 
 const privkey = sha256(Buffer.from("coin-cosmos signRawOperation test seed"));
 
-function makeAccount(): CosmosAccount {
+function makeAccount(freshAddressPath = "44'/118'/0'/0/0"): CosmosAccount {
   return {
     id: "js:2:cosmos:cosmos1xxx:",
     freshAddress: "cosmos1xxx",
-    freshAddressPath: "44'/118'/0'/0/0",
+    freshAddressPath,
     currency: { id: "cosmos", units: [{ code: "ATOM" }, { code: "uatom" }] },
   } as unknown as CosmosAccount;
 }
@@ -191,6 +191,38 @@ describe("buildSignRawOperation", () => {
       ),
     ).rejects.toThrow("device returned no signature");
     expect(signer.sign).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the HRP as the 3rd sign arg for ethermint chains (coin type 60)", async () => {
+    const signer = makeRealSigner();
+    const signRawOperation = buildSignRawOperation(signerContextOf(signer));
+
+    await firstValueFrom(
+      signRawOperation({
+        account: makeAccount("44'/60'/0'/0/0"),
+        deviceId: "mock",
+        transaction: makeSignDocJson(MSG_SEND),
+      }).pipe(toArray()),
+    );
+
+    // ethermint/60 → HRP (the cosmos chain prefix) is passed as the 3rd arg.
+    expect(signer.sign.mock.calls[0][2]).toBe("cosmos");
+  });
+
+  it("rejects a malformed derivation path before any device interaction", async () => {
+    const signer = makeRealSigner();
+    const signRawOperation = buildSignRawOperation(signerContextOf(signer));
+
+    await expect(
+      firstValueFrom(
+        signRawOperation({
+          account: makeAccount("not-a-path"),
+          deviceId: "mock",
+          transaction: makeSignDocJson(MSG_SEND),
+        }).pipe(toArray()),
+      ),
+    ).rejects.toThrow("malformed derivation path");
+    expect(signer.sign).not.toHaveBeenCalled();
   });
 
   it("rejects malformed JSON before any device interaction", async () => {

--- a/libs/coin-modules/coin-cosmos/src/signRawOperation.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/signRawOperation.unit.test.ts
@@ -175,6 +175,24 @@ describe("buildSignRawOperation", () => {
     ).rejects.toBeInstanceOf(ExpertModeRequired);
   });
 
+  it("throws a clear error when the device returns no signature on an unhandled return_code", async () => {
+    const signer = {
+      sign: jest.fn(async () => ({ signature: null, return_code: 0x6e00 })),
+    } as unknown as CosmosSigner;
+    const signRawOperation = buildSignRawOperation(signerContextOf(signer));
+
+    await expect(
+      firstValueFrom(
+        signRawOperation({
+          account: makeAccount(),
+          deviceId: "mock",
+          transaction: makeSignDocJson(MSG_SEND),
+        }).pipe(toArray()),
+      ),
+    ).rejects.toThrow("device returned no signature");
+    expect(signer.sign).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects malformed JSON before any device interaction", async () => {
     const signer = makeRealSigner();
     const signRawOperation = buildSignRawOperation(signerContextOf(signer));

--- a/libs/coin-modules/coin-cosmos/src/signRawOperation.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/signRawOperation.unit.test.ts
@@ -1,0 +1,206 @@
+import { AminoMsg, makeSignDoc, serializeSignDoc } from "@cosmjs/amino";
+import { Secp256k1, Secp256k1Signature, sha256 } from "@cosmjs/crypto";
+import { ExpertModeRequired, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { firstValueFrom, toArray } from "rxjs";
+import { buildSignRawOperation } from "./signRawOperation";
+import { CosmosAccount, RETURN_CODES } from "./types";
+import { CosmosSigner } from "./types/signer";
+
+const SUCCESS = 0x9000; // 36864
+
+const privkey = sha256(Buffer.from("coin-cosmos signRawOperation test seed"));
+
+function makeAccount(): CosmosAccount {
+  return {
+    id: "js:2:cosmos:cosmos1xxx:",
+    freshAddress: "cosmos1xxx",
+    freshAddressPath: "44'/118'/0'/0/0",
+    currency: { id: "cosmos", units: [{ code: "ATOM" }, { code: "uatom" }] },
+  } as unknown as CosmosAccount;
+}
+
+function makeSignDocJson(msgs: AminoMsg[]): string {
+  const fee = { amount: [{ denom: "uatom", amount: "500" }], gas: "200000" };
+  return JSON.stringify(makeSignDoc(msgs, fee, "cosmoshub-4", "", "1", "2"));
+}
+
+// Signer that produces a real DER secp256k1 signature over the bytes it receives.
+function makeRealSigner(): CosmosSigner & { sign: jest.Mock } {
+  const sign = jest.fn(async (_path: number[], buffer: Buffer) => {
+    const sig = await Secp256k1.createSignature(sha256(buffer), privkey);
+    return { signature: Buffer.from(sig.toDer()), return_code: SUCCESS };
+  });
+  return { sign } as unknown as CosmosSigner & { sign: jest.Mock };
+}
+
+const signerContextOf =
+  (signer: CosmosSigner) => (_deviceId: string, fn: (s: CosmosSigner) => any) =>
+    fn(signer);
+
+const MSG_SEND: AminoMsg[] = [
+  {
+    type: "cosmos-sdk/MsgSend",
+    value: {
+      from_address: "cosmos1xxx",
+      to_address: "cosmos1yyy",
+      amount: [{ denom: "uatom", amount: "1000" }],
+    },
+  },
+];
+
+const MSG_DELEGATE_WRAPPED: AminoMsg[] = [
+  {
+    type: "/babylon.epoching.v1.MsgWrappedDelegate",
+    value: {
+      msg: {
+        delegator_address: "cosmos1xxx",
+        validator_address: "cosmosvaloper1zzz",
+        amount: { denom: "uatom", amount: "1000" },
+      },
+    },
+  },
+];
+
+describe("buildSignRawOperation", () => {
+  it("signs an amino StdSignDoc and returns a verifiable detached 64-byte signature", async () => {
+    const signer = makeRealSigner();
+    const transaction = makeSignDocJson(MSG_SEND);
+    const signRawOperation = buildSignRawOperation(signerContextOf(signer));
+
+    const events = await firstValueFrom(
+      signRawOperation({
+        account: makeAccount(),
+        deviceId: "mock",
+        transaction,
+      }).pipe(toArray()),
+    );
+
+    expect(events.map(e => e.type)).toEqual([
+      "device-signature-requested",
+      "device-signature-granted",
+      "signed",
+    ]);
+
+    // The device signs the canonical serialized signDoc, verbatim.
+    const expectedBytes = Buffer.from(serializeSignDoc(JSON.parse(transaction)));
+    expect(Buffer.from(signer.sign.mock.calls[0][1])).toEqual(expectedBytes);
+    // coin type 118 → HRP is not passed (only ethermint/60 needs it).
+    expect(signer.sign.mock.calls[0][2]).toBeUndefined();
+
+    const signedEvt = events.find(e => e.type === "signed");
+    if (signedEvt?.type !== "signed") throw new Error("no signed event");
+    const sigHex = signedEvt.signedOperation.signature;
+    const sigBytes = Buffer.from(sigHex, "hex");
+    expect(sigBytes).toHaveLength(64);
+
+    const pubkey = Secp256k1.compressPubkey((await Secp256k1.makeKeypair(privkey)).pubkey);
+    const recovered = Secp256k1Signature.fromFixedLength(sigBytes);
+    const valid = await Secp256k1.verifySignature(recovered, sha256(expectedBytes), pubkey);
+    expect(valid).toBe(true);
+  });
+
+  it("signs a wrapped (babylon epoching) delegate message", async () => {
+    const signer = makeRealSigner();
+    const transaction = makeSignDocJson(MSG_DELEGATE_WRAPPED);
+    const signRawOperation = buildSignRawOperation(signerContextOf(signer));
+
+    const events = await firstValueFrom(
+      signRawOperation({
+        account: makeAccount(),
+        deviceId: "mock",
+        transaction,
+      }).pipe(toArray()),
+    );
+
+    const signedEvt = events.find(e => e.type === "signed");
+    if (signedEvt?.type !== "signed") throw new Error("no signed event");
+    expect(Buffer.from(signedEvt.signedOperation.signature, "hex")).toHaveLength(64);
+  });
+
+  it("signs a multi-message batch", async () => {
+    const signer = makeRealSigner();
+    const transaction = makeSignDocJson([...MSG_SEND, ...MSG_DELEGATE_WRAPPED]);
+    const signRawOperation = buildSignRawOperation(signerContextOf(signer));
+
+    const events = await firstValueFrom(
+      signRawOperation({
+        account: makeAccount(),
+        deviceId: "mock",
+        transaction,
+      }).pipe(toArray()),
+    );
+
+    const signedEvt = events.find(e => e.type === "signed");
+    if (signedEvt?.type !== "signed") throw new Error("no signed event");
+    expect(Buffer.from(signedEvt.signedOperation.signature, "hex")).toHaveLength(64);
+  });
+
+  it("errors with UserRefusedOnDevice when the user rejects on device", async () => {
+    const signer = {
+      sign: jest.fn(async () => ({
+        signature: null,
+        return_code: RETURN_CODES.REFUSED_OPERATION,
+      })),
+    } as unknown as CosmosSigner;
+    const signRawOperation = buildSignRawOperation(signerContextOf(signer));
+
+    await expect(
+      firstValueFrom(
+        signRawOperation({
+          account: makeAccount(),
+          deviceId: "mock",
+          transaction: makeSignDocJson(MSG_SEND),
+        }).pipe(toArray()),
+      ),
+    ).rejects.toBeInstanceOf(UserRefusedOnDevice);
+  });
+
+  it("errors with ExpertModeRequired when the device demands expert mode", async () => {
+    const signer = {
+      sign: jest.fn(async () => ({
+        signature: null,
+        return_code: RETURN_CODES.EXPERT_MODE_REQUIRED,
+      })),
+    } as unknown as CosmosSigner;
+    const signRawOperation = buildSignRawOperation(signerContextOf(signer));
+
+    await expect(
+      firstValueFrom(
+        signRawOperation({
+          account: makeAccount(),
+          deviceId: "mock",
+          transaction: makeSignDocJson(MSG_SEND),
+        }).pipe(toArray()),
+      ),
+    ).rejects.toBeInstanceOf(ExpertModeRequired);
+  });
+
+  it("rejects malformed JSON before any device interaction", async () => {
+    const signer = makeRealSigner();
+    const signRawOperation = buildSignRawOperation(signerContextOf(signer));
+
+    await expect(
+      firstValueFrom(
+        signRawOperation({
+          account: makeAccount(),
+          deviceId: "mock",
+          transaction: "not-json",
+        }).pipe(toArray()),
+      ),
+    ).rejects.toThrow("not valid JSON");
+    expect(signer.sign).not.toHaveBeenCalled();
+  });
+
+  it("rejects a signDoc with no messages", async () => {
+    const signer = makeRealSigner();
+    const signRawOperation = buildSignRawOperation(signerContextOf(signer));
+    const transaction = makeSignDocJson([]);
+
+    await expect(
+      firstValueFrom(
+        signRawOperation({ account: makeAccount(), deviceId: "mock", transaction }).pipe(toArray()),
+      ),
+    ).rejects.toThrow("non-empty array");
+    expect(signer.sign).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Sign an externally-built amino StdSignDoc verbatim and return the detached 64-byte secp256k1 signature; no broadcast. Replaces the throwing stub. Unblocks WalletConnect cosmos_signAmino.

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Library-only addition to `@ledgerhq/coin-cosmos`; no user-facing surface consumes it yet.
  - `signRawOperation` was a throwing stub and is now implemented — net-new capability, no behaviour change to existing flows (`signOperation`, sync, broadcast untouched).
  - QA focus: none device-facing yet; relevant once the live-app `cosmos_signAmino` handler is wired (follow-up PR).

### 📝 Description

Implements `signRawOperation` in `coin-cosmos` (previously a throwing stub), the building block behind the Wallet API `transaction.signRaw` path used by WalletConnect `cosmos_signAmino`.

The dApp builds the amino `StdSignDoc` (`chain_id`, `account_number`, `sequence`, `fee`, `memo`, `msgs`) and passes it as a JSON string. We `serializeSignDoc` it and sign the canonical bytes **verbatim** on the device — no re-fetching of account number / sequence / chain id / fee — then return the **detached 64-byte secp256k1 signature** (hex). The caller pairs it with the account public key and broadcasts; this method never broadcasts.

A minimal structural guard rejects a malformed `StdSignDoc` with a clear error before any device interaction; full param validation lives in the live-app layer. `EXPERT_MODE_REQUIRED` / `REFUSED_OPERATION` device codes map to the existing `ExpertModeRequired` / `UserRefusedOnDevice` errors.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31881](https://ledgerhq.atlassian.net/browse/LIVE-31881?atlOrigin=eyJpIjoiODY0ZmY3ODAxOWQ3NGZjMjg4Y2NmNDkxMDc1ODI3MWMiLCJwIjoiaiJ9)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31881]: https://ledgerhq.atlassian.net/browse/LIVE-31881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ