### PR TITLE
[LWM] fix(lwm): prevent duplicate contentcard_impression on InViewContext re-subscription

### DIFF
--- a/.changeset/quiet-banners-rest.md
+++ b/.changeset/quiet-banners-rest.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix duplicate `contentcard_impression` events: keep `InViewContext` visibility memory keyed by the stable target ref so impressions no longer re-fire when a content card re-subscribes (e.g. carousel rebuilding its items) while still in view

--- a/.changeset/quiet-banners-rest.md
+++ b/.changeset/quiet-banners-rest.md
@@ -1,5 +1,5 @@
 ---
-"live-mobile": minor
+"live-mobile": patch
 ---
 
 Fix duplicate `contentcard_impression` events: keep `InViewContext` visibility memory keyed by the stable target ref so impressions no longer re-fire when a content card re-subscribes (e.g. carousel rebuilding its items) while still in view

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -400,7 +400,7 @@ apps/ledger-live-mobile/src/mvvm/features/WelcomePage/                          
 apps/ledger-live-mobile/src/mvvm/features/Onboarding/                                          @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/PostOnboardingHubDrawer/                             @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/DynamicContent/                                      @ledgerhq/engagement
-apps/ledger-live-mobile/src/mvvm/contexts/InViewContext/                                       @ledgerhq/wallet-xp @ledgerhq/engagement
+apps/ledger-live-mobile/src/mvvm/contexts/InViewContext/                                       @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/                              @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/LandingPages/                                        @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/                                 @ledgerhq/engagement

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -400,6 +400,7 @@ apps/ledger-live-mobile/src/mvvm/features/WelcomePage/                          
 apps/ledger-live-mobile/src/mvvm/features/Onboarding/                                          @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/PostOnboardingHubDrawer/                             @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/DynamicContent/                                      @ledgerhq/engagement
+apps/ledger-live-mobile/src/mvvm/contexts/InViewContext/                                       @ledgerhq/wallet-xp @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/                              @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/LandingPages/                                        @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/                                 @ledgerhq/engagement

--- a/apps/ledger-live-mobile/src/mvvm/contexts/InViewContext/index.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/contexts/InViewContext/index.test.tsx
@@ -27,9 +27,17 @@ function Consumer({
   depValue: number;
 }) {
   const ref = useRef<View | null>(null);
-  // Inline callback like the real carousel; changing `depValue` forces a re-subscription.
-  // oxlint-disable-next-line react-hooks/exhaustive-deps -- depValue intentionally drives re-subscription
-  useInViewContext(entry => onUpdate(entry), [onUpdate, depValue], ref);
+  // The callback closes over `depValue`, so bumping it changes the memoized callback
+  // identity and forces a re-subscription with a new WatchedItem but the same target
+  // ref — exactly how the carousel re-subscribes when it rebuilds its `items`.
+  useInViewContext(
+    entry => {
+      if (depValue < 0) return;
+      onUpdate(entry);
+    },
+    [onUpdate, depValue],
+    ref,
+  );
   return <View ref={ref} />;
 }
 

--- a/apps/ledger-live-mobile/src/mvvm/contexts/InViewContext/index.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/contexts/InViewContext/index.test.tsx
@@ -28,6 +28,7 @@ function Consumer({
 }) {
   const ref = useRef<View | null>(null);
   // Inline callback like the real carousel; changing `depValue` forces a re-subscription.
+  // oxlint-disable-next-line react-hooks/exhaustive-deps -- depValue intentionally drives re-subscription
   useInViewContext(entry => onUpdate(entry), [onUpdate, depValue], ref);
   return <View ref={ref} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/contexts/InViewContext/index.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/contexts/InViewContext/index.test.tsx
@@ -19,25 +19,9 @@ const entry = (isInView: boolean): InViewEntry => ({
   progressRatio: isInView ? 1 : 0,
 });
 
-function Consumer({
-  onUpdate,
-  depValue,
-}: {
-  onUpdate: (entry: InViewEntry) => void;
-  depValue: number;
-}) {
+function Consumer({ onUpdate }: { onUpdate: (entry: InViewEntry) => void }) {
   const ref = useRef<View | null>(null);
-  // The callback closes over `depValue`, so bumping it changes the memoized callback
-  // identity and forces a re-subscription with a new WatchedItem but the same target
-  // ref — exactly how the carousel re-subscribes when it rebuilds its `items`.
-  useInViewContext(
-    entry => {
-      if (depValue < 0) return;
-      onUpdate(entry);
-    },
-    [onUpdate, depValue],
-    ref,
-  );
+  useInViewContext(onUpdate, [onUpdate], ref);
   return <View ref={ref} />;
 }
 
@@ -55,7 +39,7 @@ describe("InViewContext", () => {
   });
 
   afterEach(() => {
-    jest.runOnlyPendingTimers();
+    jest.clearAllTimers();
     jest.useRealTimers();
   });
 
@@ -65,7 +49,7 @@ describe("InViewContext", () => {
 
     render(
       <InViewProvider intervalDuration={INTERVAL}>
-        <Consumer onUpdate={onUpdate} depValue={0} />
+        <Consumer onUpdate={onUpdate} />
       </InViewProvider>,
     );
 
@@ -81,17 +65,17 @@ describe("InViewContext", () => {
 
     const { rerender } = render(
       <InViewProvider intervalDuration={INTERVAL}>
-        <Consumer onUpdate={onUpdate} depValue={0} />
+        <Consumer onUpdate={entry => onUpdate(entry)} />
       </InViewProvider>,
     );
 
     await tick();
     expect(onUpdate).toHaveBeenCalledTimes(1);
 
-    // New WatchedItem, same target ref — like the carousel rebuilding `items`.
+    // New callback identity creates a new WatchedItem, same target ref.
     rerender(
       <InViewProvider intervalDuration={INTERVAL}>
-        <Consumer onUpdate={onUpdate} depValue={1} />
+        <Consumer onUpdate={entry => onUpdate(entry)} />
       </InViewProvider>,
     );
 
@@ -106,7 +90,7 @@ describe("InViewContext", () => {
 
     render(
       <InViewProvider intervalDuration={INTERVAL}>
-        <Consumer onUpdate={onUpdate} depValue={0} />
+        <Consumer onUpdate={onUpdate} />
       </InViewProvider>,
     );
 

--- a/apps/ledger-live-mobile/src/mvvm/contexts/InViewContext/index.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/contexts/InViewContext/index.test.tsx
@@ -1,0 +1,117 @@
+import React, { useRef } from "react";
+import { View } from "react-native";
+import { act, render } from "@tests/test-renderer";
+import { InViewProvider, useInViewContext } from "./index";
+import { inViewStatus } from "./utils";
+import type { InViewEntry } from "./types";
+
+jest.mock("./utils", () => ({
+  inViewStatus: jest.fn(),
+}));
+
+const mockedInViewStatus = jest.mocked(inViewStatus);
+
+const INTERVAL = 200;
+
+const entry = (isInView: boolean): InViewEntry => ({
+  boundingClientRect: { x: 0, y: 0, width: 100, height: 100 },
+  isInView,
+  progressRatio: isInView ? 1 : 0,
+});
+
+function Consumer({
+  onUpdate,
+  depValue,
+}: {
+  onUpdate: (entry: InViewEntry) => void;
+  depValue: number;
+}) {
+  const ref = useRef<View | null>(null);
+  // Inline callback like the real carousel; changing `depValue` forces a re-subscription.
+  useInViewContext(entry => onUpdate(entry), [onUpdate, depValue], ref);
+  return <View ref={ref} />;
+}
+
+// Advances the rxjs interval one tick and flushes the async measurement chain.
+const tick = async () => {
+  await act(async () => {
+    await jest.advanceTimersByTimeAsync(INTERVAL);
+  });
+};
+
+describe("InViewContext", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockedInViewStatus.mockReset();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("fires onInViewUpdate once when a target becomes visible", async () => {
+    mockedInViewStatus.mockResolvedValue(entry(true));
+    const onUpdate = jest.fn();
+
+    render(
+      <InViewProvider intervalDuration={INTERVAL}>
+        <Consumer onUpdate={onUpdate} depValue={0} />
+      </InViewProvider>,
+    );
+
+    await tick();
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenLastCalledWith(expect.objectContaining({ isInView: true }));
+  });
+
+  it("does not re-fire when the same target is re-subscribed while still in view", async () => {
+    mockedInViewStatus.mockResolvedValue(entry(true));
+    const onUpdate = jest.fn();
+
+    const { rerender } = render(
+      <InViewProvider intervalDuration={INTERVAL}>
+        <Consumer onUpdate={onUpdate} depValue={0} />
+      </InViewProvider>,
+    );
+
+    await tick();
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+
+    // New WatchedItem, same target ref — like the carousel rebuilding `items`.
+    rerender(
+      <InViewProvider intervalDuration={INTERVAL}>
+        <Consumer onUpdate={onUpdate} depValue={1} />
+      </InViewProvider>,
+    );
+
+    await tick();
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires again on a genuine visibility transition (out then back in)", async () => {
+    mockedInViewStatus.mockResolvedValue(entry(true));
+    const onUpdate = jest.fn();
+
+    render(
+      <InViewProvider intervalDuration={INTERVAL}>
+        <Consumer onUpdate={onUpdate} depValue={0} />
+      </InViewProvider>,
+    );
+
+    await tick();
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+
+    mockedInViewStatus.mockResolvedValue(entry(false));
+    await tick();
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+    expect(onUpdate).toHaveBeenLastCalledWith(expect.objectContaining({ isInView: false }));
+
+    mockedInViewStatus.mockResolvedValue(entry(true));
+    await tick();
+    expect(onUpdate).toHaveBeenCalledTimes(3);
+    expect(onUpdate).toHaveBeenLastCalledWith(expect.objectContaining({ isInView: true }));
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/contexts/InViewContext/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/contexts/InViewContext/index.tsx
@@ -44,7 +44,9 @@ function Effect({
   itemsRef: React.RefObject<WatchedItem[]>;
   outOfViewThreshold: number;
 }) {
-  const watchedItem = useRef(new WeakMap<WatchedItem, boolean>());
+  // Keyed by the stable `target` ref, not the WatchedItem, so visibility memory
+  // survives re-subscriptions and avoids re-firing on re-render.
+  const visibilityByTarget = useRef(new WeakMap<RefObject<View | null>, boolean>());
 
   const hasItems = useSelector(inViewHasItemsSelector);
 
@@ -61,7 +63,7 @@ function Effect({
           from(
             Promise.all(
               items.map(async item => {
-                const threshold = watchedItem.current.get(item)
+                const threshold = visibilityByTarget.current.get(item.target)
                   ? outOfViewThreshold
                   : inViewThreshold;
 
@@ -74,8 +76,8 @@ function Effect({
       )
       .subscribe(xs => {
         xs.forEach(({ item, entry }) => {
-          if (entry.isInView === watchedItem.current.get(item)) return;
-          watchedItem.current.set(item, entry.isInView);
+          if (entry.isInView === visibilityByTarget.current.get(item.target)) return;
+          visibilityByTarget.current.set(item.target, entry.isInView);
           item.onInViewUpdate(entry);
         });
       });

--- a/apps/ledger-live-mobile/src/mvvm/contexts/InViewContext/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/contexts/InViewContext/index.tsx
@@ -44,8 +44,6 @@ function Effect({
   itemsRef: React.RefObject<WatchedItem[]>;
   outOfViewThreshold: number;
 }) {
-  // Keyed by the stable `target` ref, not the WatchedItem, so visibility memory
-  // survives re-subscriptions and avoids re-firing on re-render.
   const visibilityByTarget = useRef(new WeakMap<RefObject<View | null>, boolean>());
 
   const hasItems = useSelector(inViewHasItemsSelector);

--- a/apps/ledger-live-mobile/src/mvvm/contexts/InViewContext/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/contexts/InViewContext/index.tsx
@@ -76,7 +76,8 @@ function Effect({
       )
       .subscribe(xs => {
         xs.forEach(({ item, entry }) => {
-          if (entry.isInView === visibilityByTarget.current.get(item.target)) return;
+          const wasInView = visibilityByTarget.current.get(item.target);
+          if (entry.isInView === wasInView) return;
           visibilityByTarget.current.set(item.target, entry.isInView);
           item.onInViewUpdate(entry);
         });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Content card / banner impression analytics on the Portfolio (carousel layout)
  - `InViewContext` visibility tracking and de-duplication of `contentcard_impression` events
  - Any consumer of `useInViewContext` that re-subscribes on re-render

### 📝 Description

**Problem**: `contentcard_impression` events were being logged twice for the same card. The `InViewContext` stored a card's "is in view" memory in a `WeakMap` keyed by the per-subscription `WatchedItem` object. Consumers such as the carousel (`contentCards/layouts/carousel`) pass a non-memoized `items` array, so `useInViewContext` re-subscribes on every re-render, creating a brand-new `WatchedItem`. Because the new key had no prior visibility entry, an already-visible card was treated as newly in-view and `logImpressionCard` fired again — producing duplicate impression analytics.

**Solution**: Key the visibility `WeakMap` by the stable `target` ref (`RefObject<View>`) instead of the ephemeral `WatchedItem`. The visibility memory now survives re-subscriptions, so a card that is still in view does not re-fire its impression after a re-render.

Before:

```ts
const watchedItem = useRef(new WeakMap<WatchedItem, boolean>());
// ...
const threshold = watchedItem.current.get(item) ? outOfViewThreshold : inViewThreshold;
if (entry.isInView === watchedItem.current.get(item)) return;
watchedItem.current.set(item, entry.isInView);
```

After:

```ts
const visibilityByTarget = useRef(new WeakMap<RefObject<View | null>, boolean>());
// ...
const threshold = visibilityByTarget.current.get(item.target) ? outOfViewThreshold : inViewThreshold;
if (entry.isInView === visibilityByTarget.current.get(item.target)) return;
visibilityByTarget.current.set(item.target, entry.isInView);
```

A new unit test (`InViewContext/index.test.tsx`) reproduces the bug deterministically: it forces a re-subscription of an item that is still in view and asserts the in-view callback fires only once (it fired twice before the fix).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32791](https://ledgerhq.atlassian.net/browse/LIVE-32791)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-32791]: https://ledgerhq.atlassian.net/browse/LIVE-32791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ