### PR TITLE
[LWDM] fix(coin-cardano): fix inflated Send Max fee and add self-send warning

### DIFF
--- a/.changeset/cardano-send-max-fee-and-self-send.md
+++ b/.changeset/cardano-send-max-fee-and-self-send.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-cardano": patch
+---
+
+cardano: fix Send Max showing a ~10× inflated network fee (the whole low balance) and instead report the real protocol fee; surface a clear min-UTXO error when the balance is below the sendable dust threshold; warn (non-blocking) when the recipient is one of the account's own addresses (self-send). Applies to both the account bridge and the CoinModule API paths (LIVE-33176).

--- a/.changeset/cardano-send-max-fee-and-self-send.md
+++ b/.changeset/cardano-send-max-fee-and-self-send.md
@@ -1,5 +1,6 @@
 ---
 "@ledgerhq/coin-cardano": patch
+"@ledgerhq/live-common": patch
 ---
 
-cardano: fix Send Max showing a ~10× inflated network fee (the whole low balance) and instead report the real protocol fee; surface a clear min-UTXO error when the balance is below the sendable dust threshold; warn (non-blocking) when the recipient is one of the account's own addresses (self-send). Applies to both the account bridge and the CoinModule API paths (LIVE-33176).
+cardano: fix Send Max showing a ~10× inflated network fee (the whole low balance) and instead report the real protocol fee; surface a clear min-UTXO error when the balance is below the sendable dust threshold (both the account bridge and the CoinModule API paths). Also warn (non-blocking) on a self-send: the bridge `getTransactionStatus` and the CoinModule `validateIntent` now flag a recipient that is one of the account's own addresses, and the cardano family descriptor `selfTransfer` policy is set to "warning" so the new send flow surfaces it without blocking (matches vechain/near) (LIVE-33176).

--- a/libs/coin-modules/coin-cardano/src/buildTransaction.test.ts
+++ b/libs/coin-modules/coin-cardano/src/buildTransaction.test.ts
@@ -1,6 +1,7 @@
 import { types as TyphonTypes } from "@stricahq/typhonjs";
 import BigNumber from "bignumber.js";
 import { buildTransaction } from "./buildTransaction";
+import { CardanoMinAmountError } from "./errors";
 import { getCardanoAccountFixture } from "./fixtures/accounts";
 import { getProtocolParamsFixture } from "./fixtures/protocolParams";
 import { Transaction } from "./types";
@@ -109,6 +110,47 @@ describe("buildTransaction", () => {
       const transaction = await buildTransaction(account, txPayload);
       const withdrawals = transaction.getWithdrawals();
       expect(withdrawals.length).toBe(1);
+    });
+  });
+
+  describe("send all (useAllAmount)", () => {
+    const sendAllPayload: Transaction = {
+      ...txPayload,
+      amount: new BigNumber(0),
+      useAllAmount: true,
+    };
+
+    it("sends the full balance minus a realistic fee, not the whole balance as fee (LIVE-33176)", async () => {
+      // Fixture holds a single 100 ADA UTXO.
+      const account = getCardanoAccountFixture({ delegation: undefined });
+      account.cardanoResources.protocolParams = getProtocolParamsFixture();
+
+      const transaction = await buildTransaction(account, sendAllPayload);
+
+      const fee = transaction.getFee();
+      // The real linear fee is well under 1 ADA; the dust-guard bug set it to the whole ~balance.
+      expect(fee.lt(1e6)).toBe(true);
+
+      const outputs = transaction.getOutputs();
+      expect(outputs).toHaveLength(1);
+      // Recipient receives balance − fee, and inputs balance outputs + fee exactly.
+      expect(outputs[0].amount.plus(fee).toString()).toBe((100e6).toString());
+    });
+
+    it("throws CardanoMinAmountError when the balance is below the dust threshold and cannot be sent", async () => {
+      const account = getCardanoAccountFixture({ delegation: undefined });
+      account.cardanoResources.protocolParams = getProtocolParamsFixture();
+      account.balance = new BigNumber(1e6);
+      account.spendableBalance = new BigNumber(1e6);
+      // A ~1 ADA balance: after fees the leftover is below the Babbage min-UTXO floor, so no valid
+      // output can be created. The fix surfaces this clearly instead of folding it into the fee.
+      account.cardanoResources.utxos = [
+        { ...account.cardanoResources.utxos[0], amount: new BigNumber(1e6) },
+      ];
+
+      await expect(buildTransaction(account, sendAllPayload)).rejects.toBeInstanceOf(
+        CardanoMinAmountError,
+      );
     });
   });
 

--- a/libs/coin-modules/coin-cardano/src/buildTransaction.ts
+++ b/libs/coin-modules/coin-cardano/src/buildTransaction.ts
@@ -8,7 +8,7 @@ import {
 import BigNumber from "bignumber.js";
 import { decodeTokenAssetId, decodeTokenCurrencyId, getTokenAssetId } from "./buildSubAccounts";
 import { CARDANO_MAX_SUPPLY } from "./constants";
-import { CardanoInvalidProtoParams } from "./errors";
+import { CardanoInvalidProtoParams, CardanoMinAmountError } from "./errors";
 import {
   getAccountStakeCredential,
   getBaseAddress,
@@ -211,10 +211,45 @@ const buildSendAdaTransaction = async ({
     const rewardsWithdrawalCertificate = getRewardWithdrawalCertificate(account);
     if (rewardsWithdrawalCertificate) typhonTx.addWithdrawal(rewardsWithdrawalCertificate);
 
-    return typhonTx.prepareTransaction({
-      inputs: [],
-      changeAddress: receiverAddress,
+    // Send Max: the recipient receives the whole balance minus the fee (and minus any min-ADA
+    // reserved for a token-change output). We compute the fee and the recipient amount explicitly
+    // rather than routing the recipient through Typhon's change mechanism (`changeAddress:
+    // receiverAddress`). Typhon's change path folds the entire remaining balance into the fee
+    // when the leftover is below ~2 ADA — its dust guard — which on a low-balance account
+    // surfaced a ~10× inflated fee and made the balance look stranded (LIVE-33176). This mirrors
+    // Typhon's own change math (fee for the full output, then `balance − fee`), but raises a clear
+    // min-UTXO error when the balance can't fund a valid output instead of silently over-paying.
+    const availableAda = typhonTx.getInputAmount().ada.plus(typhonTx.getAdditionalInputAda());
+    const committedAda = typhonTx.getOutputAmount().ada.plus(typhonTx.getAdditionalOutputAda());
+    const spendableAda = availableAda.minus(committedAda);
+
+    const fee = typhonTx.calculateFee([
+      { address: receiverAddress, amount: spendableAda, tokens: [] },
+    ]);
+    const recipientAmount = spendableAda.minus(fee);
+
+    const minRecipientUtxo = typhonTx.calculateMinUtxoAmountBabbage({
+      address: receiverAddress,
+      amount: new BigNumber(CARDANO_MAX_SUPPLY),
+      tokens: [],
     });
+    if (recipientAmount.lt(minRecipientUtxo)) {
+      // After fees the balance can't fund an output above the Babbage min-UTXO floor: the funds
+      // are below the network's economic dust threshold and cannot be sent (they are NOT lost to
+      // an inflated fee). Recoverable — the status layer maps this to a clear amount error.
+      throw new CardanoMinAmountError("", {
+        amount: minRecipientUtxo.div(1e6).toString(),
+      });
+    }
+
+    typhonTx.setFee(fee);
+    typhonTx.addOutput({
+      address: receiverAddress,
+      amount: recipientAmount,
+      tokens: [],
+    });
+
+    return typhonTx;
   }
 
   // Prefer pure ADA UTXOs first to avoid unnecessarily pulling in native

--- a/libs/coin-modules/coin-cardano/src/buildTransaction.ts
+++ b/libs/coin-modules/coin-cardano/src/buildTransaction.ts
@@ -211,14 +211,10 @@ const buildSendAdaTransaction = async ({
     const rewardsWithdrawalCertificate = getRewardWithdrawalCertificate(account);
     if (rewardsWithdrawalCertificate) typhonTx.addWithdrawal(rewardsWithdrawalCertificate);
 
-    // Send Max: the recipient receives the whole balance minus the fee (and minus any min-ADA
-    // reserved for a token-change output). We compute the fee and the recipient amount explicitly
-    // rather than routing the recipient through Typhon's change mechanism (`changeAddress:
-    // receiverAddress`). Typhon's change path folds the entire remaining balance into the fee
-    // when the leftover is below ~2 ADA — its dust guard — which on a low-balance account
-    // surfaced a ~10× inflated fee and made the balance look stranded (LIVE-33176). This mirrors
-    // Typhon's own change math (fee for the full output, then `balance − fee`), but raises a clear
-    // min-UTXO error when the balance can't fund a valid output instead of silently over-paying.
+    // Send Max: compute the fee + recipient amount explicitly instead of routing the recipient
+    // through Typhon's change mechanism, whose <2 ADA dust guard would fold the whole low balance
+    // into the fee (the ~10× inflated fee in LIVE-33176). Raise a clear min-UTXO error when the
+    // balance can't fund a valid output rather than silently over-paying.
     const availableAda = typhonTx.getInputAmount().ada.plus(typhonTx.getAdditionalInputAda());
     const committedAda = typhonTx.getOutputAmount().ada.plus(typhonTx.getAdditionalOutputAda());
     const spendableAda = availableAda.minus(committedAda);

--- a/libs/coin-modules/coin-cardano/src/getTransactionStatus/buildErrors.ts
+++ b/libs/coin-modules/coin-cardano/src/getTransactionStatus/buildErrors.ts
@@ -5,8 +5,14 @@
  *  - "Not enough tokens"
  *  - "Tx size limit reached, try spending lesser ADA/Tokens"
  *
+ * The Send Max builder also throws `CardanoMinAmountError` when the balance, after fees, can't
+ * fund an output above the Babbage min-UTXO floor (LIVE-33176) — likewise an amount problem to
+ * surface, not a programming error to re-throw. Matched by `name` (not `instanceof`) so it stays
+ * robust if the error is re-created across the coin-module-framework boundary.
  */
 export const isRecoverableBuildError = (error: unknown): boolean => {
+  if (error instanceof Error && error.name === "CardanoMinAmountError") return true;
+
   const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
 
   return (

--- a/libs/coin-modules/coin-cardano/src/getTransactionStatus/buildErrors.ts
+++ b/libs/coin-modules/coin-cardano/src/getTransactionStatus/buildErrors.ts
@@ -11,7 +11,7 @@
  * robust if the error is re-created across the coin-module-framework boundary.
  */
 export const isRecoverableBuildError = (error: unknown): boolean => {
-  if (error instanceof Error && error.name === "CardanoMinAmountError") return true;
+  if ((error as { name?: unknown } | null)?.name === "CardanoMinAmountError") return true;
 
   const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
 

--- a/libs/coin-modules/coin-cardano/src/getTransactionStatus/send.test.ts
+++ b/libs/coin-modules/coin-cardano/src/getTransactionStatus/send.test.ts
@@ -1,7 +1,9 @@
+import { utils as TyphonUtils } from "@stricahq/typhonjs";
 import { BigNumber } from "bignumber.js";
 import { getProtocolParamsFixture } from "../fixtures/protocolParams";
 import { getCardanoAccountFixture } from "../fixtures/accounts";
 import { buildTransaction } from "../buildTransaction";
+import { CardanoMinAmountError } from "../errors";
 import type { Transaction } from "../types";
 import { getSendTransactionStatus } from "./send";
 
@@ -45,11 +47,36 @@ describe("getSendTransactionStatus", () => {
     expect(status.errors.amount?.name).toBe("CardanoNotEnoughFunds");
   });
 
+  it("maps a thrown CardanoMinAmountError to an amount error instead of re-throwing", async () => {
+    mockedBuildTransaction.mockRejectedValueOnce(new CardanoMinAmountError("", { amount: "1" }));
+
+    const status = await getSendTransactionStatus(account, buildTransactionInput());
+
+    expect(status.errors.amount?.name).toBe("CardanoNotEnoughFunds");
+  });
+
   it("re-throws unexpected build errors", async () => {
     mockedBuildTransaction.mockRejectedValueOnce(new Error("Unexpected programming error"));
 
     await expect(getSendTransactionStatus(account, buildTransactionInput())).rejects.toThrow(
       "Unexpected programming error",
     );
+  });
+
+  it("warns (without blocking) when the recipient is one of the account's own addresses", async () => {
+    mockedBuildTransaction.mockResolvedValueOnce({} as never);
+    // The fixture's only UTXO is paid to the account's own external credential; its bech32 form is
+    // therefore one of the account's own addresses (a self-send).
+    const ownAddress = TyphonUtils.getAddressFromHex(
+      Buffer.from(account.cardanoResources.utxos[0].address, "hex"),
+    ).getBech32();
+
+    const status = await getSendTransactionStatus(account, {
+      ...buildTransactionInput(),
+      recipient: ownAddress,
+    });
+
+    expect(status.errors.recipient).toBeUndefined();
+    expect(status.warnings.recipient?.name).toBe("InvalidAddressBecauseDestinationIsAlsoSource");
   });
 });

--- a/libs/coin-modules/coin-cardano/src/getTransactionStatus/send.test.ts
+++ b/libs/coin-modules/coin-cardano/src/getTransactionStatus/send.test.ts
@@ -66,7 +66,8 @@ describe("getSendTransactionStatus", () => {
   it("warns (without blocking) when the recipient is one of the account's own addresses", async () => {
     mockedBuildTransaction.mockResolvedValueOnce({} as never);
     // The fixture's only UTXO is paid to the account's own external credential; its bech32 form is
-    // therefore one of the account's own addresses (a self-send).
+    // therefore one of the account's own addresses (a self-send). This is the warning the new send
+    // flow surfaces as the recipient warning banner.
     const ownAddress = TyphonUtils.getAddressFromHex(
       Buffer.from(account.cardanoResources.utxos[0].address, "hex"),
     ).getBech32();

--- a/libs/coin-modules/coin-cardano/src/getTransactionStatus/send.ts
+++ b/libs/coin-modules/coin-cardano/src/getTransactionStatus/send.ts
@@ -79,12 +79,9 @@ export async function getSendTransactionStatus(
       currencyName: account.currency.name,
     });
   } else {
-    // Self-send: comparing the recipient's payment-credential hash to the account's own
-    // credentials (external + internal/change) flags sending to any of the account's addresses,
-    // not just the displayed one. Valid on-chain but almost always a mistake, so warn without
-    // blocking. This warning is what the new send flow surfaces as the recipient warning banner
-    // (useBridgeRecipientValidation reads getTransactionStatus().warnings); the family descriptor's
-    // selfTransfer: "warning" policy permits the self-send without blocking it (LIVE-33176).
+    // Self-send: warn (non-blocking) when the recipient's payment-credential hash matches any of
+    // the account's own credentials. Surfaced as the new send flow's recipient banner; the
+    // descriptor selfTransfer policy permits it. LIVE-33176.
     const recipientKeyHash = getPaymentCredentialKeyHash(transaction.recipient);
     if (recipientKeyHash) {
       const ownKeyHashes = new Set([

--- a/libs/coin-modules/coin-cardano/src/getTransactionStatus/send.ts
+++ b/libs/coin-modules/coin-cardano/src/getTransactionStatus/send.ts
@@ -82,7 +82,9 @@ export async function getSendTransactionStatus(
     // Self-send: comparing the recipient's payment-credential hash to the account's own
     // credentials (external + internal/change) flags sending to any of the account's addresses,
     // not just the displayed one. Valid on-chain but almost always a mistake, so warn without
-    // blocking (LIVE-33176).
+    // blocking. This warning is what the new send flow surfaces as the recipient warning banner
+    // (useBridgeRecipientValidation reads getTransactionStatus().warnings); the family descriptor's
+    // selfTransfer: "warning" policy permits the self-send without blocking it (LIVE-33176).
     const recipientKeyHash = getPaymentCredentialKeyHash(transaction.recipient);
     if (recipientKeyHash) {
       const ownKeyHashes = new Set([

--- a/libs/coin-modules/coin-cardano/src/getTransactionStatus/send.ts
+++ b/libs/coin-modules/coin-cardano/src/getTransactionStatus/send.ts
@@ -2,6 +2,7 @@ import {
   AmountRequired,
   FeeNotLoaded,
   InvalidAddress,
+  InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
 } from "@ledgerhq/errors";
@@ -12,7 +13,7 @@ import { buildTransaction } from "../buildTransaction";
 import { CARDANO_MAX_SUPPLY } from "../constants";
 import { CardanoMinAmountError, CardanoNotEnoughFunds } from "../errors";
 import { estimateMaxSpendable } from "../estimateMaxSpendable";
-import { isValidAddress } from "../logic";
+import { getPaymentCredentialKeyHash, isValidAddress } from "../logic";
 import { getNetworkParameters } from "../networks";
 import type { CardanoAccount, Token, Transaction, TransactionStatus } from "../types";
 import { isRecoverableBuildError } from "./buildErrors";
@@ -78,6 +79,21 @@ export async function getSendTransactionStatus(
       currencyName: account.currency.name,
     });
   } else {
+    // Self-send: comparing the recipient's payment-credential hash to the account's own
+    // credentials (external + internal/change) flags sending to any of the account's addresses,
+    // not just the displayed one. Valid on-chain but almost always a mistake, so warn without
+    // blocking (LIVE-33176).
+    const recipientKeyHash = getPaymentCredentialKeyHash(transaction.recipient);
+    if (recipientKeyHash) {
+      const ownKeyHashes = new Set([
+        ...cardanoResources.externalCredentials.map(c => c.key),
+        ...cardanoResources.internalCredentials.map(c => c.key),
+      ]);
+      if (ownKeyHashes.has(recipientKeyHash)) {
+        warnings.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
+      }
+    }
+
     // minTransactionAmount can only be calculated with valid recipient
     const recipient = TyphonUtils.getAddressFromString(transaction.recipient);
     minTransactionAmount = TyphonUtils.calculateMinUtxoAmountBabbage(

--- a/libs/coin-modules/coin-cardano/src/logic.ts
+++ b/libs/coin-modules/coin-cardano/src/logic.ts
@@ -180,6 +180,28 @@ export const isValidAddress = (address: string, networkId: number): boolean => {
   return true;
 };
 
+/**
+ * The payment-credential key hash (hex) embedded in a Shelley address, or `undefined` for a
+ * Byron / script / unparseable address. Lets callers tell whether a recipient belongs to the
+ * account by comparing it to the account's own credential key hashes (external + internal),
+ * which catches sending to *any* of the account's addresses — not just the displayed one — and
+ * is robust to base vs enterprise encodings of the same key (unlike a raw string compare).
+ */
+export const getPaymentCredentialKeyHash = (address: string): string | undefined => {
+  try {
+    const cardanoAddress = TyphonUtils.getAddressFromString(address);
+    if (
+      cardanoAddress instanceof ShelleyTypeAddress &&
+      cardanoAddress.paymentCredential.type === TyphonTypes.HashType.ADDRESS
+    ) {
+      return cardanoAddress.paymentCredential.hash.toString("hex");
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+};
+
 export const getAbsoluteSlot = function (networkName: string, time: Date): number {
   const networkParams = getNetworkParameters(networkName);
   const byronChainEndSlots = networkParams.shelleyStartEpoch * networkParams.byronSlotsPerEpoch;

--- a/libs/coin-modules/coin-cardano/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/craftTransaction.test.ts
@@ -167,6 +167,28 @@ describe("buildUnsignedTransaction — native ADA", () => {
     expect(recipientOutput?.tokens).toEqual([]);
   });
 
+  it("send-all charges a realistic fee, not the whole balance (LIVE-33176)", async () => {
+    // A ~1.5 ADA balance is above the dust floor but inside the range where Typhon's change path
+    // would fold the leftover into the fee. The recipient must still receive balance − a real fee.
+    mockFetchTxs.mockResolvedValue(paged([makeTx({ hash: "a", outputs: [output("1500000")] })]));
+
+    const tx = await buildUnsignedTransaction(currency, sendIntent({ useAllAmount: true }));
+
+    expect(tx.getFee().lt(1e6)).toBe(true);
+    expect(tx.getOutputs()).toHaveLength(1);
+    expect(tx.getOutputs()[0].amount.plus(tx.getFee()).toFixed()).toBe((1_500_000).toString());
+  });
+
+  it("rejects a send-all below the dust threshold instead of folding the balance into the fee", async () => {
+    // ~1 ADA: after fees the leftover is below the Babbage min-UTXO floor, so no valid output can
+    // be made. Surface a clear error rather than the dust-guard's ~10× inflated fee (LIVE-33176).
+    mockFetchTxs.mockResolvedValue(paged([makeTx({ hash: "a", outputs: [output("1000000")] })]));
+
+    await expect(
+      buildUnsignedTransaction(currency, sendIntent({ useAllAmount: true })),
+    ).rejects.toThrow("below the minimum required for an output");
+  });
+
   it("rejects a non-positive amount", async () => {
     await expect(buildUnsignedTransaction(currency, sendIntent({ amount: 0n }))).rejects.toThrow(
       "Transaction amount must be positive",

--- a/libs/coin-modules/coin-cardano/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/craftTransaction.test.ts
@@ -12,6 +12,7 @@ import { getDelegationInfo } from "../api/getDelegationInfo";
 import { fetchNetworkInfo } from "../api/getNetworkInfo";
 import { getProtocolParamsFixture } from "../fixtures/protocolParams";
 import { extractPaymentKeyFromAddress } from "../utils";
+import { CardanoMinAmountError } from "../errors";
 import { buildUnsignedTransaction, craftTransaction } from "./craftTransaction";
 
 jest.mock("../api/fetchTransactions");
@@ -186,7 +187,7 @@ describe("buildUnsignedTransaction — native ADA", () => {
 
     await expect(
       buildUnsignedTransaction(currency, sendIntent({ useAllAmount: true })),
-    ).rejects.toThrow("below the minimum required for an output");
+    ).rejects.toBeInstanceOf(CardanoMinAmountError);
   });
 
   it("rejects a non-positive amount", async () => {
@@ -196,9 +197,9 @@ describe("buildUnsignedTransaction — native ADA", () => {
   });
 
   it("rejects an amount below the per-output min-ADA floor", async () => {
-    await expect(buildUnsignedTransaction(currency, sendIntent({ amount: 1n }))).rejects.toThrow(
-      "Transaction amount is below the minimum required for an output",
-    );
+    await expect(
+      buildUnsignedTransaction(currency, sendIntent({ amount: 1n })),
+    ).rejects.toBeInstanceOf(CardanoMinAmountError);
   });
 
   it("rejects a sender address with no payment credential without hitting the network", async () => {

--- a/libs/coin-modules/coin-cardano/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/craftTransaction.ts
@@ -357,21 +357,45 @@ export async function buildUnsignedTransaction(
   // inputs (smaller tx, lower fee) — mirrors the legacy builder's largest-first ordering.
   inputs.sort((a, b) => b.amount.comparedTo(a.amount));
 
-  // A max-ADA native send must spend the ENTIRE UTXO set. Typhon's prepareTransaction does
-  // minimal coin selection over the inputs it is given (it stops as soon as the outputs + fee are
-  // covered), so for a sweep we force every UTXO as a mandatory input and hand it nothing to
-  // select — all remaining ADA then lands in the change output (whose address is the recipient).
-  // Every other intent lets Typhon select the minimal set from the available inputs.
   const sweepAll = intent.intentType === "transaction" && !isTokenTransfer && !!intent.useAllAmount;
-  if (sweepAll) {
-    inputs.forEach(input => typhonTx.addInput(input));
-  }
-
   const baseOutputCount = typhonTx.getOutputs().length;
-  const prepared = typhonTx.prepareTransaction({
-    inputs: sweepAll ? [] : inputs,
-    changeAddress,
-  });
+
+  let prepared: TyphonTransaction;
+  if (sweepAll) {
+    // A max-ADA send must spend the ENTIRE UTXO set and route everything (minus fee) to the
+    // recipient. We add all inputs and compute the fee + recipient amount explicitly rather than
+    // letting Typhon's change mechanism handle it (`changeAddress` is the recipient here): its
+    // <2 ADA dust guard would otherwise fold the whole remaining balance into the fee on a
+    // low-balance account, showing a ~10× inflated fee and stranding the funds (LIVE-33176).
+    // Mirrors the legacy bridge fix in buildSendAdaTransaction.
+    inputs.forEach(input => typhonTx.addInput(input));
+
+    const availableAda = typhonTx.getInputAmount().ada.plus(typhonTx.getAdditionalInputAda());
+    const committedAda = typhonTx.getOutputAmount().ada.plus(typhonTx.getAdditionalOutputAda());
+    const spendableAda = availableAda.minus(committedAda);
+
+    const fee = typhonTx.calculateFee([{ address: changeAddress, amount: spendableAda, tokens: [] }]);
+    const recipientAmount = spendableAda.minus(fee);
+
+    const minRecipientUtxo = typhonTx.calculateMinUtxoAmountBabbage({
+      address: changeAddress,
+      amount: new BigNumber(CARDANO_MAX_SUPPLY),
+      tokens: [],
+    });
+    if (recipientAmount.lt(minRecipientUtxo)) {
+      // After fees the balance can't fund an output above the Babbage min-UTXO floor — the funds
+      // are below the network's economic dust threshold and cannot be sent (not lost to fee).
+      throw new Error("Transaction amount is below the minimum required for an output");
+    }
+
+    typhonTx.setFee(fee);
+    typhonTx.addOutput({ address: changeAddress, amount: recipientAmount, tokens: [] });
+    prepared = typhonTx;
+  } else {
+    // Typhon selects the minimal input set from the available inputs and returns change to the
+    // sender (or, for a token send-all, sweeps token-bearing UTXOs — see addTokenOutput).
+    prepared = typhonTx.prepareTransaction({ inputs, changeAddress });
+  }
 
   if (customFees) {
     applyCustomFee(prepared, baseOutputCount, new BigNumber(customFees.value.toString()));

--- a/libs/coin-modules/coin-cardano/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/craftTransaction.ts
@@ -373,7 +373,9 @@ export async function buildUnsignedTransaction(
     const committedAda = typhonTx.getOutputAmount().ada.plus(typhonTx.getAdditionalOutputAda());
     const spendableAda = availableAda.minus(committedAda);
 
-    const fee = typhonTx.calculateFee([{ address: changeAddress, amount: spendableAda, tokens: [] }]);
+    const fee = typhonTx.calculateFee([
+      { address: changeAddress, amount: spendableAda, tokens: [] },
+    ]);
     const recipientAmount = spendableAda.minus(fee);
 
     const minRecipientUtxo = typhonTx.calculateMinUtxoAmountBabbage({

--- a/libs/coin-modules/coin-cardano/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/craftTransaction.ts
@@ -18,6 +18,7 @@ import { getAllTransactionsByKeys } from "../api/fetchTransactions";
 import { getDelegationInfo } from "../api/getDelegationInfo";
 import { fetchNetworkInfo } from "../api/getNetworkInfo";
 import { CARDANO_MAX_SUPPLY, MEMO_LABEL } from "../constants";
+import { CardanoMinAmountError } from "../errors";
 import {
   type DerivedUtxo,
   deriveUtxos,
@@ -201,7 +202,7 @@ function addNativeOutputs(
     new BigNumber(protocolParams.utxoCostPerByte),
   );
   if (amount.lt(minAda)) {
-    throw new Error("Transaction amount is below the minimum required for an output");
+    throw new CardanoMinAmountError("", { amount: minAda.div(1e6).toString() });
   }
   typhonTx.addOutput({ address: recipientAddress, amount, tokens: [] });
   return senderAddress;
@@ -383,7 +384,7 @@ export async function buildUnsignedTransaction(
     if (recipientAmount.lt(minRecipientUtxo)) {
       // After fees the balance can't fund an output above the Babbage min-UTXO floor — the funds
       // are below the network's economic dust threshold and cannot be sent (not lost to fee).
-      throw new Error("Transaction amount is below the minimum required for an output");
+      throw new CardanoMinAmountError("", { amount: minRecipientUtxo.div(1e6).toString() });
     }
 
     typhonTx.setFee(fee);

--- a/libs/coin-modules/coin-cardano/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/craftTransaction.ts
@@ -163,10 +163,11 @@ function addStakingCertificates(
 }
 
 /**
- * Add the output(s) for a native ADA send and return the change address. A send-all routes the
- * remaining ADA to the recipient (via change) while keeping any tokens the sender holds on the
- * sender — a max-ADA send must not transfer them. A fixed-amount send adds an explicit recipient
- * output and change returns to the sender. Mirrors the legacy buildSendAdaTransaction behaviour.
+ * Add the output(s) for a native ADA send and return the change address. A send-all keeps any
+ * tokens the sender holds on the sender (a max-ADA send must not transfer them) and returns the
+ * recipient as the change address — the explicit recipient ADA output is added by the caller's
+ * send-all branch. A fixed-amount send adds an explicit recipient output and change returns to the
+ * sender. Mirrors the legacy buildSendAdaTransaction behaviour.
  */
 function addNativeOutputs(
   typhonTx: TyphonTransaction,
@@ -332,8 +333,8 @@ export async function buildUnsignedTransaction(
     addAccountObligations(typhonTx, currency, stakeKey, delegation);
   }
 
-  // changeAddress is the sender for sends/staking; for a send-all it is the recipient, so the
-  // entire balance (minus fee) lands there with no explicit recipient output.
+  // changeAddress is the sender for fixed-amount sends/staking; for a send-all it is the recipient
+  // (the send-all branch below sends the balance minus fee there as an explicit output).
   let changeAddress: TyphonTypes.CardanoAddress = senderAddress;
 
   const isTokenTransfer = isTokenAsset(intent.asset);
@@ -362,12 +363,9 @@ export async function buildUnsignedTransaction(
 
   let prepared: TyphonTransaction;
   if (sweepAll) {
-    // A max-ADA send must spend the ENTIRE UTXO set and route everything (minus fee) to the
-    // recipient. We add all inputs and compute the fee + recipient amount explicitly rather than
-    // letting Typhon's change mechanism handle it (`changeAddress` is the recipient here): its
-    // <2 ADA dust guard would otherwise fold the whole remaining balance into the fee on a
-    // low-balance account, showing a ~10× inflated fee and stranding the funds (LIVE-33176).
-    // Mirrors the legacy bridge fix in buildSendAdaTransaction.
+    // Send-all: spend every UTXO and compute the fee + recipient amount explicitly instead of
+    // using Typhon's change mechanism, whose <2 ADA dust guard would fold the whole low balance
+    // into the fee (LIVE-33176). Mirrors the bridge fix in buildSendAdaTransaction.
     inputs.forEach(input => typhonTx.addInput(input));
 
     const availableAda = typhonTx.getInputAmount().ada.plus(typhonTx.getAdditionalInputAda());

--- a/libs/coin-modules/coin-cardano/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/validateIntent.ts
@@ -12,6 +12,7 @@ import {
   AmountRequired,
   FeeTooHigh,
   InvalidAddress,
+  InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
   ValAddressRequired,
@@ -22,7 +23,7 @@ import BigNumber from "bignumber.js";
 import { fetchNetworkInfo } from "../api/getNetworkInfo";
 import { CARDANO_MAX_SUPPLY } from "../constants";
 import { CardanoMemoExceededSizeError, CardanoMinAmountError } from "../errors";
-import { isTestnet, isTokenAsset, isValidAddress } from "../logic";
+import { getPaymentCredentialKeyHash, isTestnet, isTokenAsset, isValidAddress } from "../logic";
 import { validateMemo } from "./validateMemo";
 
 type Intent = TransactionIntent<StringMemo | MemoNotSupported>;
@@ -63,6 +64,17 @@ export async function validateIntent(
   const isTokenTransfer = isTokenAsset(intent.asset);
 
   validateRecipient(currency, intent, errors);
+  // Self-send: compare the payment-credential hashes of sender and recipient (not the raw address
+  // strings) so a base/enterprise re-encoding of the same key is still caught — consistent with the
+  // legacy bridge's check (getTransactionStatus/send.ts). Valid on-chain but almost always a
+  // mistake, so warn without blocking (LIVE-33176). Only when the recipient is otherwise valid.
+  if (!errors.recipient && intent.recipient) {
+    const senderKeyHash = getPaymentCredentialKeyHash(intent.sender);
+    const recipientKeyHash = getPaymentCredentialKeyHash(intent.recipient);
+    if (senderKeyHash && recipientKeyHash && senderKeyHash === recipientKeyHash) {
+      warnings.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
+    }
+  }
   validateMemoSize(intent, errors);
 
   const amount = computeAmount(intent, balances, estimatedFees, isTokenTransfer);

--- a/libs/coin-modules/coin-cardano/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/validateIntent.ts
@@ -64,10 +64,8 @@ export async function validateIntent(
   const isTokenTransfer = isTokenAsset(intent.asset);
 
   validateRecipient(currency, intent, errors);
-  // Self-send: compare the payment-credential hashes of sender and recipient (not the raw address
-  // strings) so a base/enterprise re-encoding of the same key is still caught — consistent with the
-  // legacy bridge's check (getTransactionStatus/send.ts). Valid on-chain but almost always a
-  // mistake, so warn without blocking (LIVE-33176). Only when the recipient is otherwise valid.
+  // Self-send: compare sender/recipient payment-credential hashes (robust to base/enterprise
+  // re-encodings). Non-blocking warning, only when the recipient is otherwise valid. LIVE-33176.
   if (!errors.recipient && intent.recipient) {
     const senderKeyHash = getPaymentCredentialKeyHash(intent.sender);
     const recipientKeyHash = getPaymentCredentialKeyHash(intent.recipient);

--- a/libs/coin-modules/coin-cardano/src/logic/validateIntent.unit.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/validateIntent.unit.test.ts
@@ -62,7 +62,7 @@ describe("validateIntent", () => {
     expect(res.errors.recipient?.name).toBe(name);
   });
 
-  it("allows a self-send (sender === recipient)", async () => {
+  it("warns (without blocking) on a self-send (sender === recipient)", async () => {
     const res = await validateIntent(
       currency,
       intent({ recipient: SENDER }),
@@ -71,7 +71,10 @@ describe("validateIntent", () => {
         value: 200_000n,
       },
     );
+    // Self-send is valid on-chain, so it is a non-blocking warning, not an error (LIVE-33176).
+    // Reuses the shared, already-localized error class (as VeChain does for its self-send warning).
     expect(res.errors.recipient).toBeUndefined();
+    expect(res.warnings.recipient?.name).toBe("InvalidAddressBecauseDestinationIsAlsoSource");
   });
 
   it("flags a zero amount", async () => {

--- a/libs/coin-modules/coin-cardano/src/logic/validateIntent.unit.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/validateIntent.unit.test.ts
@@ -71,8 +71,7 @@ describe("validateIntent", () => {
         value: 200_000n,
       },
     );
-    // Self-send is valid on-chain, so it is a non-blocking warning, not an error (LIVE-33176).
-    // Reuses the shared, already-localized error class (as VeChain does for its self-send warning).
+    // Self-send is a non-blocking warning, reusing the shared already-localized error. LIVE-33176.
     expect(res.errors.recipient).toBeUndefined();
     expect(res.warnings.recipient?.name).toBe("InvalidAddressBecauseDestinationIsAlsoSource");
   });

--- a/libs/coin-modules/coin-cardano/src/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-cardano/src/prepareTransaction.test.ts
@@ -1,0 +1,36 @@
+import { BigNumber } from "bignumber.js";
+import { getCardanoAccountFixture } from "./fixtures/accounts";
+import { getProtocolParamsFixture } from "./fixtures/protocolParams";
+import { prepareTransaction } from "./prepareTransaction";
+import type { Transaction } from "./types";
+
+// Passing protocolParams on the transaction makes prepareTransaction skip its network fetch.
+const baseTransaction = (): Transaction => ({
+  family: "cardano",
+  recipient:
+    "addr_test1qz7jw975stagnvs00wsjny6y6gpazn86yvwcm2vy02j3up7mt68vuzvz4nzgs00x0shrgywvy674v6r2zcs8fxvvq27qfjq8np",
+  amount: new BigNumber(0),
+  mode: "send",
+  poolId: undefined,
+  protocolParams: getProtocolParamsFixture(),
+});
+
+describe("prepareTransaction", () => {
+  it("reports the real network fee, not the whole balance, on a low-balance account with no amount entered (LIVE-33176)", async () => {
+    const account = getCardanoAccountFixture({ delegation: undefined });
+    account.balance = new BigNumber(1e6);
+    account.spendableBalance = new BigNumber(1e6);
+    account.cardanoResources.protocolParams = getProtocolParamsFixture();
+    account.cardanoResources.utxos = [
+      { ...account.cardanoResources.utxos[0], amount: new BigNumber(1e6) },
+    ];
+
+    const prepared = await prepareTransaction(account, baseTransaction());
+
+    // Before the fix Typhon's dust guard set the fee to the whole ~1 ADA balance; it must now show
+    // the protocol-minimum fee (a few hundred thousand lovelace), well under the balance.
+    expect(prepared.amount.toString()).toBe("0");
+    expect(prepared.fees?.gt(0)).toBe(true);
+    expect(prepared.fees?.lt(1e6)).toBe(true);
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/prepareTransaction.ts
+++ b/libs/coin-modules/coin-cardano/src/prepareTransaction.ts
@@ -40,12 +40,10 @@ export const prepareTransaction: AccountBridge<
           )
           .reduce((total, o) => total.plus(o.amount), new BigNumber(0));
 
-    // Typhon's <2 ADA dust guard folds the entire balance into the fee when no spendable output
-    // can be formed — a low-balance account, or simply before an amount is entered (amount 0). That
-    // donation is not a real network fee and the send is blocked anyway (AmountRequired / below
-    // min-UTXO), so report the protocol-minimum fee rather than the inflated ~whole-balance value
-    // (LIVE-33176). A real send (amount > 0) keeps getFee(), which legitimately includes any dust
-    // folded into the fee of an otherwise-valid transaction — so we never under-disclose.
+    // When no spendable output forms (low balance / no amount entered yet), Typhon's dust guard
+    // folds the whole balance into the fee; report the real protocol-minimum fee instead. A real
+    // send (amount > 0) keeps getFee() so a legitimately dust-folded fee is still disclosed.
+    // See LIVE-33176.
     const transactionFees =
       !transaction.subAccountId && transactionAmount.isZero()
         ? cardanoTransaction.calculateFee()

--- a/libs/coin-modules/coin-cardano/src/prepareTransaction.ts
+++ b/libs/coin-modules/coin-cardano/src/prepareTransaction.ts
@@ -28,7 +28,6 @@ export const prepareTransaction: AccountBridge<
 
   try {
     const cardanoTransaction = await buildTransaction(account, transaction);
-    const transactionFees = cardanoTransaction.getFee();
     const transactionAmount = transaction.subAccountId
       ? transaction.amount
       : cardanoTransaction
@@ -40,6 +39,17 @@ export const prepareTransaction: AccountBridge<
               o.address.paymentCredential.bipPath === undefined,
           )
           .reduce((total, o) => total.plus(o.amount), new BigNumber(0));
+
+    // Typhon's <2 ADA dust guard folds the entire balance into the fee when no spendable output
+    // can be formed — a low-balance account, or simply before an amount is entered (amount 0). That
+    // donation is not a real network fee and the send is blocked anyway (AmountRequired / below
+    // min-UTXO), so report the protocol-minimum fee rather than the inflated ~whole-balance value
+    // (LIVE-33176). A real send (amount > 0) keeps getFee(), which legitimately includes any dust
+    // folded into the fee of an otherwise-valid transaction — so we never under-disclose.
+    const transactionFees =
+      !transaction.subAccountId && transactionAmount.isZero()
+        ? cardanoTransaction.calculateFee()
+        : cardanoTransaction.getFee();
 
     patch = { fees: transactionFees, amount: transactionAmount };
   } catch {

--- a/libs/ledger-live-common/src/bridge/descriptor.test.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor.test.ts
@@ -642,9 +642,9 @@ describe("sendFeatures", () => {
     ["bitcoin", "free"],
     ["ethereum", "free"],
     ["filecoin", "free"],
-    ["cardano", "free"],
     ["solana", "impossible"],
     ["cosmos", "impossible"],
+    ["cardano", "warning"],
     ["near", "warning"],
     ["vechain", "warning"],
   ])("should get self transfer policy for %s", (currencyId, expected) => {

--- a/libs/ledger-live-common/src/families/cardano/descriptor/index.ts
+++ b/libs/ledger-live-common/src/families/cardano/descriptor/index.ts
@@ -8,8 +8,7 @@ export const descriptor: CoinDescriptor = {
       hasPresets: false,
       hasCustom: false,
     },
-    // A Cardano self-send is valid on-chain (funds return to one of the account's own UTXOs) but
-    // is almost always a mistake, so warn without blocking — mirrors vechain/near (LIVE-33176).
+    // Self-send is valid on-chain but almost always a mistake — warn without blocking. LIVE-33176.
     selfTransfer: "warning",
   },
 };

--- a/libs/ledger-live-common/src/families/cardano/descriptor/index.ts
+++ b/libs/ledger-live-common/src/families/cardano/descriptor/index.ts
@@ -8,6 +8,8 @@ export const descriptor: CoinDescriptor = {
       hasPresets: false,
       hasCustom: false,
     },
-    selfTransfer: "free",
+    // A Cardano self-send is valid on-chain (funds return to one of the account's own UTXOs) but
+    // is almost always a mistake, so warn without blocking — mirrors vechain/near (LIVE-33176).
+    selfTransfer: "warning",
   },
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This fixes two independent issues on the Cardano send flow, both reported in LIVE-33176.

1. Send Max showed a ~10× inflated network fee and made low balances look stuck.

- Previous behaviour: on a low-balance account (≲ ~1.14 ADA), the Amount step displayed the entire remaining balance as the network fee (e.g. 1 ADA fee on a ~1 ADA account) with Max spendable ~0, so the funds appeared permanently stuck.
- Cause: the recipient was routed through typhon's change mechanism, whose < 2 ADA dust guard folds the whole remaining balance into the fee when it can't form a valid change output.
- Fix: the Send Max path now computes the fee and recipient amount explicitly (fee = calculateFee([recipient]); amount = balance − fee) instead of relying on the change/dust path, and raises a clear min-UTXO error when the balance is genuinely below Cardano's sendable threshold. prepareTransaction now reports the real protocol-minimum fee (not the dust-guard value) when no spendable output can be formed. Applied to both the account bridge (Wallet apps) and the CoinModule/Alpaca API path.

▎ Note: a ~1 ADA balance is genuinely below Cardano's min-UTXO + fee floor and cannot be sent — this change makes the wallet report that honestly (realistic fee, "not enough funds") instead of a misleading inflated fee.

2. No validation when the recipient is the sender's own address (self-send).

- Previous behaviour: sending to one of the account's own addresses produced no feedback.
- Fix: a non-blocking warning is now shown in both validation paths, reusing the shared InvalidAddressBecauseDestinationIsAlsoSource error (already localized — no new translation strings).

<img width="512" height="449" alt="image" src="https://github.com/user-attachments/assets/d18e1adf-bdb9-490f-8afd-94bc9a55f274" />


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) --> [LIVE-33176](https://ledgerhq.atlassian.net/browse/LIVE-33176)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
