### PR TITLE
test: fix e2e test access to settings with myWallet false

### DIFF
--- a/e2e/mobile/page/wallet/mainNavigation.page.ts
+++ b/e2e/mobile/page/wallet/mainNavigation.page.ts
@@ -1,6 +1,7 @@
 import { element, by } from "detox";
 import { Step } from "jest-allure2-reporter/api";
 import { openDeeplink } from "../../helpers/commonHelpers";
+import { isMyWalletEnabled } from "../../utils/initUtil";
 
 type Wallet40TabName = "home" | "swap" | "earn" | "card";
 
@@ -11,8 +12,12 @@ export default class MainNavigationPage {
   // --- Wallet 4.0 top bar buttons ---
   topBarDiscoverId = "topbar-discover";
   topBarMyWalletId = "topbar-mywallet";
+  topBarMyLedgerId = "topbar-myledger";
+  topBarSettingsId = "topbar-settings";
+  topBarNotificationsId = "topbar-notifications";
   topBarTransactionHistoryId = "topbar-transaction-history";
   headerBackButtonId = "header-back-button";
+  myWalletHeaderSettingsButtonId = "my-wallet-header-settings-button";
 
   // --- Legacy bottom tabs ---
   legacyPortfolioTabId = "tab-bar-portfolio";
@@ -71,6 +76,16 @@ export default class MainNavigationPage {
     await tapById(this.topBarTransactionHistoryId);
   }
 
+  @Step("Navigate to Settings")
+  async navigateToSettings() {
+    if (isMyWalletEnabled) {
+      await tapById(this.topBarMyWalletId);
+      await tapById(this.myWalletHeaderSettingsButtonId);
+    } else {
+      await tapById(this.topBarSettingsId);
+    }
+  }
+
   // =====================
   // Legacy Tab Actions
   // =====================
@@ -109,7 +124,13 @@ export default class MainNavigationPage {
 
   @Step("Expect Wallet 4.0 top bar to be visible")
   async expectWallet40TopBarVisible() {
-    await detoxExpect(getElementById(this.topBarMyWalletId)).toBeVisible();
+    if (isMyWalletEnabled) {
+      await detoxExpect(getElementById(this.topBarMyWalletId)).toBeVisible();
+    } else {
+      await detoxExpect(getElementById(this.topBarMyLedgerId)).toBeVisible();
+      await detoxExpect(getElementById(this.topBarNotificationsId)).toBeVisible();
+      await detoxExpect(getElementById(this.topBarSettingsId)).toBeVisible();
+    }
     await detoxExpect(getElementById(this.topBarDiscoverId)).toBeVisible();
     await detoxExpect(getElementById(this.topBarTransactionHistoryId)).toBeVisible();
   }
@@ -135,7 +156,11 @@ export default class MainNavigationPage {
 
   @Step("Expect Wallet 4.0 top bar NOT visible")
   async expectWallet40TopBarNotVisible() {
-    await detoxExpect(getElementById(this.topBarMyWalletId)).not.toBeVisible();
+    if (isMyWalletEnabled) {
+      await detoxExpect(getElementById(this.topBarMyWalletId)).not.toBeVisible();
+    } else {
+      await detoxExpect(getElementById(this.topBarMyLedgerId)).not.toBeVisible();
+    }
   }
 
   // =====================

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -15,8 +15,6 @@ export default class PortfolioPage {
   accountsListView = "PortfolioAccountsList";
   emptyPortfolioListId = "PortfolioEmptyList";
   portfolioSettingsId = "topbar-settings";
-  myWalletHeaderSettingsButtonId = "my-wallet-header-settings-button";
-  topBarMyWalletId = "topbar-mywallet";
   portfolioListIdRegex = new RegExp(`portfolio-screen|${this.readOnlyItemsId}`);
   addAccountCta = "add-account-cta";
   allocationSectionTitleId = "portfolio-allocation-section";
@@ -76,16 +74,6 @@ export default class PortfolioPage {
     accountName
       ? getElementByIdWithDescendantTexts(this.operationRowBody, accountName, operationType)
       : getElementByIdWithDescendantTexts(this.operationRowBody, operationType);
-
-  @Step("Navigate to Settings")
-  async navigateToSettings() {
-    if (isWallet40) {
-      await tapById(this.topBarMyWalletId);
-      await tapById(this.myWalletHeaderSettingsButtonId);
-    } else {
-      await tapByElement(await this.portfolioSettingsButton());
-    }
-  }
 
   @Step("Wait for portfolio page to load")
   async waitForPortfolioPageToLoad(timeout = 120000) {

--- a/e2e/mobile/specs/languageChange.spec.ts
+++ b/e2e/mobile/specs/languageChange.spec.ts
@@ -63,7 +63,7 @@ describe("Change Language", () => {
   });
 
   it("should go to General Settings", async () => {
-    await app.portfolio.navigateToSettings();
+    await app.mainNavigation.navigateToSettings();
     await app.settings.navigateToGeneralSettings();
   });
 

--- a/e2e/mobile/specs/ledgerSync/ledgerSync.spec.ts
+++ b/e2e/mobile/specs/ledgerSync/ledgerSync.spec.ts
@@ -31,7 +31,7 @@ describeIfNotNanoS(`Ledger Sync Accounts`, () => {
     await app.accounts.openViaDeeplink();
     await app.accounts.expectNoAccount();
     await app.mainNavigation.openPortfolioViaDeeplink();
-    await app.portfolio.navigateToSettings();
+    await app.mainNavigation.navigateToSettings();
     await app.settings.navigateToGeneralSettings();
     await app.settingsGeneral.navigateToLedgerSync();
     await app.ledgerSync.expectLedgerSyncPageIsDisplayed();
@@ -45,7 +45,7 @@ describeIfNotNanoS(`Ledger Sync Accounts`, () => {
     await app.accounts.openViaDeeplink();
     await app.accounts.expectAccountsNumber(2, app.ledgerSync.ledgerSyncPushDataArgs.data);
     await app.mainNavigation.openPortfolioViaDeeplink();
-    await app.portfolio.navigateToSettings();
+    await app.mainNavigation.navigateToSettings();
     await app.settings.navigateToGeneralSettings();
     await device.disableSynchronization(); // TODO: Remove line when LIVE-15405 is fixed
     await app.settingsGeneral.navigateToLedgerSync();

--- a/e2e/mobile/specs/settings/settings.ts
+++ b/e2e/mobile/specs/settings/settings.ts
@@ -33,7 +33,7 @@ export function runUserClearApplicationCacheTest(
     test("The user can clear application cache", async () => {
       await app.portfolio.tapTabSelector("Accounts");
       const countBeforeClearingCache = await app.portfolio.countAccounts();
-      await app.portfolio.navigateToSettings();
+      await app.mainNavigation.navigateToSettings();
       await app.settings.navigateToHelpSettings();
       await app.settingsHelp.clickOnClearCacheRow();
       await app.settingsHelp.checkClearCacheModalIsDisplayed();
@@ -56,7 +56,7 @@ export function runUserCanExportLogsTest(tmsLinks: string[], tags: string[]) {
     tags.forEach(tag => $Tag(tag));
 
     test("Verify that user can export logs", async () => {
-      await app.portfolio.navigateToSettings();
+      await app.mainNavigation.navigateToSettings();
       await app.settings.navigateToHelpSettings();
       await app.settingsHelp.clickOnExportLogsRow();
       await app.settingsHelp.verifyLogsAreExported();
@@ -74,7 +74,7 @@ export function runUserCanAccessLedgerSupportTest(tmsLinks: string[], tags: stri
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     test("Verify that user can access Ledger Support (Web Link)", async () => {
-      await app.portfolio.navigateToSettings();
+      await app.mainNavigation.navigateToSettings();
       await app.settings.navigateToHelpSettings();
       await app.settingsHelp.expectLedgerSupportUrlToBeCorrect();
     });
@@ -99,7 +99,7 @@ export function runUserCanSelectCounterValueToDisplayAmountInLedgerLive(
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     test("Verify that user can select counter value to display amount in Ledger Live", async () => {
-      await app.portfolio.navigateToSettings();
+      await app.mainNavigation.navigateToSettings();
       await app.settings.navigateToGeneralSettings();
       await app.settingsGeneral.changeCounterValue("Euro - EUR");
       await app.settingsGeneral.expectCounterValue("EUR");
@@ -136,7 +136,7 @@ export function runPasswordUnlockTest(tmsLinks: string[], tags: string[]) {
   describe("Password Lock Screen - Unlock with correct password", () => {
     beforeAll(async () => {
       await initPasswordTest();
-      await app.portfolio.navigateToSettings();
+      await app.mainNavigation.navigateToSettings();
       await app.settings.navigateToGeneralSettings();
       await app.settingsGeneral.setupPasswordAndLock(CORRECT_PASSWORD);
       await app.passwordEntry.expectLock();
@@ -160,7 +160,7 @@ export function runPasswordIncorrectTest(tmsLinks: string[], tags: string[]) {
   describe("Password Lock Screen - Stay locked with incorrect password", () => {
     beforeAll(async () => {
       await initPasswordTest();
-      await app.portfolio.navigateToSettings();
+      await app.mainNavigation.navigateToSettings();
       await app.settings.navigateToGeneralSettings();
       await app.settingsGeneral.setupPasswordAndLock(CORRECT_PASSWORD);
       await app.passwordEntry.expectLock();

--- a/e2e/mobile/utils/initUtil.ts
+++ b/e2e/mobile/utils/initUtil.ts
@@ -27,6 +27,8 @@ type CliCommand = (
   speculosAddress?: string,
 ) => Observable<unknown> | Promise<unknown> | string;
 
+export let isMyWalletEnabled = false;
+
 export type InitOptions = {
   speculosApp?: SpeculosAppType;
   cliCommands?: CliCommand[];
@@ -395,6 +397,9 @@ export class InitializationManager {
       ...extraFeatureFlags,
       ...featureFlags,
     };
+    const wallet40 = mergedFeatureFlags.lwmWallet40;
+    isMyWalletEnabled = Boolean(wallet40?.enabled && wallet40?.params?.myWallet);
+
     await allure.attachment(
       "Merged Feature Flags",
       JSON.stringify(mergedFeatureFlags, null, 2),


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - E2E Mobile tests

### 📝 Description

This PR updates the mobile Detox E2E suite to reliably access the Settings screen when Wallet 4.0 is enabled but the myWallet feature flag is false.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- E2E Q1 [Run](https://github.com/LedgerHQ/ledger-live/actions/runs/28405623529)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
