### PR TITLE
[LWDM] feat(bitcoin): compute dust threshold from min relay fee

### DIFF
--- a/.changeset/btc-dust-min-relay-fee.md
+++ b/.changeset/btc-dust-min-relay-fee.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-bitcoin": minor
+---
+
+Compute the BTC dust threshold from the node's min relay fee (Bitcoin Core model: 3 × input vBytes × relay fee rate), floored at the legacy threshold. Altcoins and missing-relay-fee cases keep the previous size-only behavior.

--- a/libs/coin-modules/coin-bitcoin/src/buildTransaction.ts
+++ b/libs/coin-modules/coin-bitcoin/src/buildTransaction.ts
@@ -157,6 +157,9 @@ export const buildTransaction = async (
     changeAddress,
     ...(transaction.replaceTxId === undefined ? {} : { originalTxId: transaction.replaceTxId }),
     ...(pendingOperations === undefined ? {} : { pendingOperations }),
+    ...(transaction.networkInfo?.relayFeePerByte === undefined
+      ? {}
+      : { relayFeePerByteSatVb: transaction.networkInfo.relayFeePerByte }),
   });
   log("btcwallet", "txInfo", txInfo);
 

--- a/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.test.ts
@@ -286,5 +286,10 @@ describe("getTransactionStatus on Bitcoin", () => {
       const status = await getTransactionStatus(buildAccount(), buildTransaction(1000, 1, 1));
       expect(status.errors.dustLimit).toBeUndefined();
     });
+
+    it("does not compute dust (no DustLimit) when feePerByte is zero", async () => {
+      const status = await getTransactionStatus(buildAccount(), buildTransaction(1000, 0, 10));
+      expect(status.errors.dustLimit).toBeUndefined();
+    });
   });
 });

--- a/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.test.ts
@@ -3,6 +3,7 @@
 import { Account } from "@ledgerhq/types-live";
 import { BitcoinInput, Transaction } from "./types";
 import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
+import { DustLimit } from "@ledgerhq/errors";
 import { RbfBuildError, FeeTooLow } from "./errors";
 import BigNumber from "bignumber.js";
 
@@ -237,6 +238,53 @@ describe("getTransactionStatus on Bitcoin", () => {
     it("applies the 1 sat/vB fallback for bitcoin when relayFeePerByte is 0 (back-compat)", async () => {
       const status = await getTransactionStatus(buildAccount(), buildTransaction(0.5, 0));
       expect(status.errors.feePerByte).toBeInstanceOf(FeeTooLow);
+    });
+  });
+
+  describe("relay-aware dust limit", () => {
+    const recipient = "bc1pxlmrudqyq8qd8pfsc4mpmlaw56x6vtcr9m8nvp8kj3gckefc4kmqhkg4l7";
+
+    beforeEach(() => {
+      validateRecipientSpy.mockResolvedValue({
+        recipientError: undefined,
+        recipientWarning: undefined,
+        changeAddressError: undefined,
+        changeAddressWarning: undefined,
+      });
+      isAddressSanctionedSpy.mockResolvedValue(false);
+      calculateFeesSpy.mockResolvedValue({ txInputs: [], txOutputs: [], fees: BigNumber(0) });
+    });
+
+    // Native SegWit input = 68 vB, so relay-aware dust = 3 * 68 * relayFeePerByte
+    const buildAccount = () =>
+      ({
+        currency: { id: "bitcoin" },
+        blockHeight: MAX_BLOCK_HEIGHT_FOR_TAPROOT + 1,
+        bitcoinResources: { walletAccount: { params: { derivationMode: "Native SegWit" } } },
+      }) as unknown as Account;
+
+    const buildTransaction = (amount: number, feePerByte: number, relayFeePerByte: number) =>
+      ({
+        amount: BigNumber(amount),
+        recipient,
+        feePerByte: BigNumber(feePerByte),
+        networkInfo: {
+          family: "bitcoin",
+          feeItems: {},
+          relayFeePerByte: BigNumber(relayFeePerByte),
+        },
+      }) as unknown as Transaction;
+
+    it("raises DustLimit when amount is below the relay-aware dust", async () => {
+      // dust = 3 * 68 * 10 = 2040 > amount 1000
+      const status = await getTransactionStatus(buildAccount(), buildTransaction(1000, 10, 10));
+      expect(status.errors.dustLimit).toBeInstanceOf(DustLimit);
+    });
+
+    it("does not raise DustLimit at a low relay fee for the same amount", async () => {
+      // dust = 3 * 68 * 1 = 204 < amount 1000
+      const status = await getTransactionStatus(buildAccount(), buildTransaction(1000, 1, 1));
+      expect(status.errors.dustLimit).toBeUndefined();
     });
   });
 });

--- a/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.ts
@@ -10,7 +10,13 @@ import {
 import { BigNumber } from "bignumber.js";
 import { log } from "@ledgerhq/logs";
 import type { Account, AccountBridge } from "@ledgerhq/types-live";
-import type { BitcoinInput, BitcoinOutput, Transaction, TransactionStatus } from "./types";
+import type {
+  BitcoinAccount,
+  BitcoinInput,
+  BitcoinOutput,
+  Transaction,
+  TransactionStatus,
+} from "./types";
 import { calculateFees, validateRecipient, isTaprootRecipient } from "./cache";
 import { OP_RETURN_DATA_SIZE_LIMIT } from "./wallet-btc/crypto/base";
 import cryptoFactory from "./wallet-btc/crypto/factory";
@@ -167,7 +173,12 @@ export const getTransactionStatus: AccountBridge<
   if (transaction.feePerByte) {
     const txSize = Math.ceil(estimatedFees.toNumber() / transaction.feePerByte.toNumber());
     const crypto = cryptoFactory(account.currency.id as Currency);
-    const dustAmount = computeDustAmount(crypto, txSize);
+    const derivationMode = (account as BitcoinAccount).bitcoinResources?.walletAccount?.params
+      .derivationMode;
+    const dustAmount = computeDustAmount(crypto, txSize, {
+      derivationMode,
+      relayFeePerByteSatVb: transaction.networkInfo?.relayFeePerByte,
+    });
 
     if (amount.gt(0) && amount.lt(dustAmount)) {
       errors.dustLimit = new DustLimit();

--- a/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.ts
@@ -170,7 +170,7 @@ export const getTransactionStatus: AccountBridge<
     warnings.feeTooHigh = new FeeTooHigh();
   }
 
-  if (transaction.feePerByte) {
+  if (transaction.feePerByte && transaction.feePerByte.gt(0)) {
     const txSize = Math.ceil(estimatedFees.toNumber() / transaction.feePerByte.toNumber());
     const crypto = cryptoFactory(account.currency.id as Currency);
     const derivationMode = (account as BitcoinAccount).bitcoinResources?.walletAccount?.params

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/computeDustAmount.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/computeDustAmount.test.ts
@@ -1,0 +1,83 @@
+import BigNumber from "bignumber.js";
+import cryptoFactory from "../crypto/factory";
+import { DerivationModes } from "../types";
+import { computeDustAmount } from "../utils";
+
+const bitcoin = cryptoFactory("bitcoin"); // dustThreshold 3000, PER_KBYTE
+const litecoin = cryptoFactory("litecoin"); // dustThreshold 10000, FIXED
+
+// inputVBytes = vbytesCeilFromWeight(inputWeight(mode)): legacy 148, native segwit 68, taproot 58
+describe("computeDustAmount", () => {
+  describe("relay-aware (bitcoin, PER_KBYTE)", () => {
+    it("uses 3 x inputVBytes x relayFee when above the legacy floor", () => {
+      // 3 * 68 * 5 = 1020 > legacy 3 * 100 = 300
+      expect(
+        computeDustAmount(bitcoin, 100, {
+          derivationMode: DerivationModes.NATIVE_SEGWIT,
+          relayFeePerByteSatVb: new BigNumber(5),
+        }),
+      ).toBe(1020);
+    });
+
+    it("sizes the input per derivation mode", () => {
+      const relayFeePerByteSatVb = new BigNumber(10);
+      expect(
+        computeDustAmount(bitcoin, 0, {
+          derivationMode: DerivationModes.LEGACY,
+          relayFeePerByteSatVb,
+        }),
+      ).toBe(3 * 148 * 10);
+      expect(
+        computeDustAmount(bitcoin, 0, {
+          derivationMode: DerivationModes.TAPROOT,
+          relayFeePerByteSatVb,
+        }),
+      ).toBe(3 * 58 * 10);
+    });
+
+    it("never drops below the legacy threshold (low relay fee floor)", () => {
+      // 3 * 68 * 1 = 204 < legacy 3 * 400 = 1200
+      expect(
+        computeDustAmount(bitcoin, 400, {
+          derivationMode: DerivationModes.NATIVE_SEGWIT,
+          relayFeePerByteSatVb: new BigNumber(1),
+        }),
+      ).toBe(1200);
+    });
+  });
+
+  describe("legacy fallback", () => {
+    it("falls back when relay fee is missing", () => {
+      expect(
+        computeDustAmount(bitcoin, 200, { derivationMode: DerivationModes.NATIVE_SEGWIT }),
+      ).toBe(600);
+    });
+
+    it("falls back when derivation mode is missing", () => {
+      expect(computeDustAmount(bitcoin, 200, { relayFeePerByteSatVb: new BigNumber(5) })).toBe(600);
+    });
+
+    it("falls back when relay fee is zero", () => {
+      expect(
+        computeDustAmount(bitcoin, 200, {
+          derivationMode: DerivationModes.NATIVE_SEGWIT,
+          relayFeePerByteSatVb: new BigNumber(0),
+        }),
+      ).toBe(600);
+    });
+
+    it("keeps FIXED-policy altcoins unchanged even with a relay fee", () => {
+      expect(
+        computeDustAmount(litecoin, 200, {
+          derivationMode: DerivationModes.NATIVE_SEGWIT,
+          relayFeePerByteSatVb: new BigNumber(5),
+        }),
+      ).toBe(10000);
+    });
+
+    it("matches the previous behavior with no opts", () => {
+      expect(computeDustAmount(bitcoin, 200)).toBe(600);
+      expect(computeDustAmount(litecoin, 200)).toBe(10000);
+    });
+  });
+});

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/computeDustAmount.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/computeDustAmount.test.ts
@@ -35,6 +35,16 @@ describe("computeDustAmount", () => {
       ).toBe(3 * 58 * 10);
     });
 
+    it("rounds the dust up to an integer for a fractional relay fee", () => {
+      // 3 * 68 * 0.1 = 20.4 -> 21
+      expect(
+        computeDustAmount(bitcoin, 0, {
+          derivationMode: DerivationModes.NATIVE_SEGWIT,
+          relayFeePerByteSatVb: new BigNumber(0.1),
+        }),
+      ).toBe(21);
+    });
+
     it("never drops below the legacy threshold (low relay fee floor)", () => {
       // 3 * 68 * 1 = 204 < legacy 3 * 400 = 1200
       expect(

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/computeDustAmount.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/computeDustAmount.test.ts
@@ -57,6 +57,15 @@ describe("computeDustAmount", () => {
       expect(computeDustAmount(bitcoin, 200, { relayFeePerByteSatVb: new BigNumber(5) })).toBe(600);
     });
 
+    it("falls back (no throw) when derivation mode is unknown", () => {
+      expect(
+        computeDustAmount(bitcoin, 200, {
+          derivationMode: "Unknown",
+          relayFeePerByteSatVb: new BigNumber(5),
+        }),
+      ).toBe(600);
+    });
+
     it("falls back when relay fee is zero", () => {
       expect(
         computeDustAmount(bitcoin, 200, {

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/utils.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/utils.ts
@@ -174,6 +174,7 @@ export function computeDustAmount(
   if (
     currency.network.dustPolicy === "PER_KBYTE" &&
     derivationMode !== undefined &&
+    Object.prototype.hasOwnProperty.call(INPUT_WEIGHT_SPECS, derivationMode) &&
     relayFeePerByteSatVb !== undefined &&
     relayFeePerByteSatVb.isFinite() &&
     relayFeePerByteSatVb.gt(0)

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/utils.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/utils.ts
@@ -144,7 +144,7 @@ export function maxTxSizeCeil(
 }
 
 // refer to https://github.com/LedgerHQ/lib-ledger-core/blob/fc9d762b83fc2b269d072b662065747a64ab2816/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.cpp#L253
-export function computeDustAmount(currency: ICrypto, txSize: number): number {
+function legacyDustAmount(currency: ICrypto, txSize: number): number {
   let dustAmount = currency.network.dustThreshold;
   switch (currency.network.dustPolicy) {
     case "PER_KBYTE":
@@ -158,6 +158,32 @@ export function computeDustAmount(currency: ICrypto, txSize: number): number {
   }
 
   return dustAmount;
+}
+
+// Bitcoin Core dust model: dust = 3 × inputVBytes × minRelayFeeRate (sat/vB), floored at the legacy
+// threshold so a low relay fee never relaxes the historical protection. Falls back to the legacy
+// size-only computation for altcoins or when the relay fee / derivation mode is unknown.
+export function computeDustAmount(
+  currency: ICrypto,
+  txSize: number,
+  opts?: { derivationMode?: string | undefined; relayFeePerByteSatVb?: BigNumber | undefined },
+): number {
+  const legacyDust = legacyDustAmount(currency, txSize);
+
+  const { derivationMode, relayFeePerByteSatVb } = opts ?? {};
+  if (
+    currency.network.dustPolicy === "PER_KBYTE" &&
+    derivationMode !== undefined &&
+    relayFeePerByteSatVb !== undefined &&
+    relayFeePerByteSatVb.isFinite() &&
+    relayFeePerByteSatVb.gt(0)
+  ) {
+    const inputVBytes = vbytesCeilFromWeight(inputWeight(derivationMode));
+    const coreDust = relayFeePerByteSatVb.times(3).times(inputVBytes).toNumber();
+    return Math.max(coreDust, legacyDust);
+  }
+
+  return legacyDust;
 }
 
 export function isValidAddress(address: string, currency?: Currency): boolean {

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/utils.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/utils.ts
@@ -180,7 +180,11 @@ export function computeDustAmount(
     relayFeePerByteSatVb.gt(0)
   ) {
     const inputVBytes = vbytesCeilFromWeight(inputWeight(derivationMode));
-    const coreDust = relayFeePerByteSatVb.times(3).times(inputVBytes).toNumber();
+    const coreDust = relayFeePerByteSatVb
+      .times(3)
+      .times(inputVBytes)
+      .integerValue(BigNumber.ROUND_CEIL)
+      .toNumber();
     return Math.max(coreDust, legacyDust);
   }
 

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/wallet.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/wallet.ts
@@ -31,6 +31,7 @@ type BuildAccountTxParams = {
   originalTxId?: string;
   /** Pending operations (hash + extra.inputs) to detect conflicting txs; when set with originalTxId, min fee is max over all conflicting */
   pendingOperations?: Array<{ hash: string; extra?: { inputs?: string[] } }>;
+  relayFeePerByteSatVb?: BigNumber;
 };
 
 const hasExportedTxs = (value: unknown): value is { txs: TX[] } => {
@@ -314,6 +315,9 @@ class BitcoinLikeWallet {
       opReturnData: params.opReturnData,
       ...(params.originalTxId === undefined ? {} : { originalTxId: params.originalTxId }),
       ...(minReplacementFeeSat === undefined ? {} : { minReplacementFeeSat }),
+      ...(params.relayFeePerByteSatVb === undefined
+        ? {}
+        : { relayFeePerByteSatVb: params.relayFeePerByteSatVb }),
     });
 
     return txInfo;

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/xpub.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/xpub.ts
@@ -29,6 +29,7 @@ type BuildTxParams = {
   originalTxId?: string;
   /** For RBF: minimum total fee (sats) so replacement pays more than original (avoids "less fees than conflicting" reject) */
   minReplacementFeeSat?: number;
+  relayFeePerByteSatVb?: BigNumber;
 };
 
 type BuildTxSelection = {
@@ -219,6 +220,7 @@ class Xpub {
       sequence,
       originalTxId,
       minReplacementFeeSat,
+      relayFeePerByteSatVb,
     } = params;
 
     const outputs = this.buildOutputs({ amount, opReturnData, destAddress });
@@ -260,7 +262,10 @@ class Xpub {
       this.derivationMode,
     );
 
-    const dustLimit = computeDustAmount(this.crypto, txSize);
+    const dustLimit = computeDustAmount(this.crypto, txSize, {
+      derivationMode: this.derivationMode,
+      relayFeePerByteSatVb,
+    });
 
     // Abandon the change output if change output amount is less than dust amount
     if (needChangeoutput && total.minus(amount).minus(fee).gt(dustLimit)) {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - BTC send flow dust validation (`DustLimit`) when sending small amounts
  - Change-output handling (a tiny change output is dropped if below the relay-aware dust)
  - RBF flows reuse the same dust limit
  - Altcoins (LTC, DOGE, etc.) and missing-relay-fee cases must keep the previous behavior

### 📝 Description

The BTC dust threshold was derived from a hardcoded rate (`dustThreshold = 3000`, `PER_KBYTE` → `3 sat/vB × txSize`), ignoring the node's actual min relay fee. When the mempool min relay fee rises, an output that passes this stale threshold can be economically unspendable / rejected by the network.

This PR computes the dust threshold using Bitcoin Core's model: `dust = 3 × inputVBytes × minRelayFeeRate (sat/vB)`, where `inputVBytes` is the cost to redeem a single output (per derivation mode) and the relay fee comes from `transaction.networkInfo.relayFeePerByte` (added by the base branch). The result is floored at the legacy threshold so a low relay fee never relaxes the historical protection. `computeDustAmount` falls back to the legacy size-only computation for altcoins (`FIXED` policy) or when the relay fee / derivation mode is unknown.

The relay fee is threaded from `buildTransaction` → `wallet.buildAccountTx` → `xpub.buildTx` for the change-output decision, and read directly in `getTransactionStatus` for the user-facing validation.

> Based on [feat/btc-min-relay-fee-floor](https://github.com/LedgerHQ/ledger-live/pull/19087), not `develop` — it depends on the `relayFeePerByte` plumbing introduced there.

| OSF | NSF |
| ----- | ----- |
|<img width="554" height="742" alt="Screenshot 2026-06-30 at 11 48 29" src="https://github.com/user-attachments/assets/616f5a89-b5b0-458a-9ff6-25578cf55468" />|<img width="444" height="591" alt="Screenshot 2026-06-30 at 11 47 05" src="https://github.com/user-attachments/assets/4b021154-c715-4162-b78e-04887c95fadf" />|
|<img width="453" height="456" alt="image" src="https://github.com/user-attachments/assets/decc20e2-99b0-4a77-bcc5-7dc52531f96f" />|<img width="391" height="420" alt="Screenshot 2026-07-01 at 12 35 24" src="https://github.com/user-attachments/assets/f7f6305a-bde7-4fb0-b3c0-be73b9989feb" />|





### ❓ Context

- **JIRA or GitHub link**: [LIVE-23490](https://ledgerhq.atlassian.net/browse/LIVE-23490)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-23490]: https://ledgerhq.atlassian.net/browse/LIVE-23490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ