### PR TITLE
test(swap): add discreet mode e2e for desktop and mobile

### DIFF
--- a/e2e/desktop/tests/page/dialog/modular.asset.dialog.ts
+++ b/e2e/desktop/tests/page/dialog/modular.asset.dialog.ts
@@ -5,13 +5,14 @@ import { expect } from "@playwright/test";
 
 export class ModularAssetDialog extends Dialog {
   private searchInputTestId = "modular-asset-dialog-search-input";
+  private assetItemTestId = "asset-item-ticker-";
   private modularAssetSelectorContainer = this.page.getByTestId(
     "modular-dialog-screen-ASSET_SELECTION",
   );
   private searchInput = this.page.getByTestId(this.searchInputTestId);
   private assetListContainer = this.page.getByTestId("asset-selector-list-container");
   private assetItemRow = (ticker: string) =>
-    this.page.getByTestId(`asset-item-ticker-${ticker.toLowerCase()}`);
+    this.page.getByTestId(`${this.assetItemTestId}${ticker.toLowerCase()}`);
 
   @step("Wait for dialog to be visible")
   async waitForDialogToBeVisible() {
@@ -38,5 +39,23 @@ export class ModularAssetDialog extends Dialog {
     await expect(this.searchInput).toBeVisible();
     await this.searchInput.fill(currency.ticker);
     await this.assetItemRow(currency.ticker).first().click();
+  }
+
+  @step("Check asset $0 amount is masked in discreet mode")
+  async checkAssetAmountIsDiscreet(ticker: string) {
+    await expect(this.searchInput).toBeVisible();
+    await this.searchInput.fill(ticker);
+
+    const row = this.assetItemRow(ticker).first();
+    await expect(row).toBeVisible();
+    await expect(row).toContainText("$***");
+    await expect(row).toContainText(new RegExp(`\\*\\*\\*\\s+${ticker}`, "i"));
+  }
+
+  @step("Check listed asset amounts are masked in discreet mode")
+  async checkAssetAmountsAreDiscreet(tickers: string[]) {
+    for (const ticker of tickers) {
+      await this.checkAssetAmountIsDiscreet(ticker);
+    }
   }
 }

--- a/e2e/desktop/tests/page/dialog/modular.dialog.ts
+++ b/e2e/desktop/tests/page/dialog/modular.dialog.ts
@@ -55,6 +55,14 @@ export class ModularDialog extends Dialog {
     return await this.assetDialog.selectAssetByTicker(currency);
   }
 
+  async checkAssetAmountIsDiscreet(ticker: string) {
+    return await this.assetDialog.checkAssetAmountIsDiscreet(ticker);
+  }
+
+  async checkAssetAmountsAreDiscreet(tickers: string[]) {
+    return await this.assetDialog.checkAssetAmountsAreDiscreet(tickers);
+  }
+
   async selectNetwork(currency: Currency, networkIndex: number = 0) {
     if (await this.isNetworkDialogVisible()) {
       await this.networkDialog.selectNetwork(currency, networkIndex);

--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -35,6 +35,7 @@ export class SwapPage extends WebViewAppPage {
   private maxSpendableToggle = this.page.getByTestId("swap-max-spendable-toggle");
   private fromAccountCoinSelector = "from-account-coin-selector";
   private fromAccountAmountInput = "from-account-amount-input";
+  private fromAccountBalance = "from-account-balance";
   private toAccountCoinSelector = "to-account-coin-selector";
   private readonly toAccountAccountNameTag = "to-account-account-name-tag";
   private quoteCardProviderName = "compact-quote-card-provider-";
@@ -624,5 +625,12 @@ export class SwapPage extends WebViewAppPage {
   @step("Selected provider: $0")
   async logSelectedProvider(providerName: string) {
     expect(providerName).toBeDefined();
+  }
+
+  @step("Check swap widget balance is masked in discreet mode for $0")
+  async checkWidgetBalanceIsDiscreet(ticker: string) {
+    const webview = await this.getWebView();
+    const text = webview.getByTestId(this.fromAccountBalance);
+    await expect(text).toContainText(new RegExp(`\\*\\*\\*\\s+${ticker}`, "i"));
   }
 }

--- a/e2e/desktop/tests/specs/discreet.swap.spec.ts
+++ b/e2e/desktop/tests/specs/discreet.swap.spec.ts
@@ -1,0 +1,104 @@
+import { Account, type AccountType, TokenAccount } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
+import { liveDataWithAddressCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
+import test from "tests/fixtures/common";
+import { addTmsLink } from "tests/utils/allureUtils";
+import { getDescription } from "tests/utils/customJsonReporter";
+import { setupEnv } from "tests/utils/swapUtils";
+
+const xrayTicket = "B2CQA-2457";
+const fundedAssetsAccounts: AccountType[] = [
+  Account.BTC_NATIVE_SEGWIT_1,
+  Account.ETH_1,
+  TokenAccount.ETH_USDC_1,
+  TokenAccount.ETH_USDT_1,
+];
+
+test.describe("Swap Discreet mode", () => {
+  setupEnv();
+
+  test.use({
+    teamOwner: Team.SWAP,
+    userdata: "discreet-mode-on",
+
+    cliCommandsOnApp: [
+      [
+        {
+          app: Account.BTC_NATIVE_SEGWIT_1.currency.speculosApp,
+          cmd: liveDataWithAddressCommand(Account.BTC_NATIVE_SEGWIT_1),
+        },
+        {
+          app: Account.ETH_1.currency.speculosApp,
+          cmd: liveDataWithAddressCommand(Account.ETH_1),
+        },
+      ],
+      { scope: "test" },
+    ],
+  });
+
+  test(
+    "No amount should be visible in the asset drawer",
+    {
+      tag: [
+        "@NanoSP",
+        "@LNS",
+        "@NanoX",
+        "@Stax",
+        "@Flex",
+        "@NanoGen5",
+        "@ethereum",
+        "@family-evm",
+        "@bitcoin",
+        "@family-bitcoin",
+      ],
+      annotation: [
+        {
+          type: "TMS",
+          description: xrayTicket,
+        },
+      ],
+    },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      const fundedAssetTickers = fundedAssetsAccounts.map(account => account.currency.ticker);
+      await app.swap.selectFromAccountCoinSelector();
+      await app.modularDialog.validateItems();
+      await app.modularDialog.checkAssetAmountsAreDiscreet(fundedAssetTickers);
+    },
+  );
+
+  test(
+    "Balance should not be visible in the swap widget",
+    {
+      tag: [
+        "@NanoSP",
+        "@LNS",
+        "@NanoX",
+        "@Stax",
+        "@Flex",
+        "@NanoGen5",
+        "@ethereum",
+        "@family-evm",
+        "@bitcoin",
+        "@family-bitcoin",
+      ],
+      annotation: [
+        {
+          type: "TMS",
+          description: xrayTicket,
+        },
+      ],
+    },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      for (const account of fundedAssetsAccounts) {
+        await app.swap.selectFromAccountCoinSelector();
+        await app.modularDialog.selectAsset(account.currency);
+        await app.modularDialog.selectNetwork(account.currency);
+        await app.modularDialog.selectAccountByName(account);
+        await app.swap.checkAssetFromContains(account.currency.ticker);
+        await app.swap.checkWidgetBalanceIsDiscreet(account.currency.ticker);
+      }
+    },
+  );
+});

--- a/e2e/desktop/tests/userdata/discreet-mode-on.json
+++ b/e2e/desktop/tests/userdata/discreet-mode-on.json
@@ -1,0 +1,82 @@
+{
+  "data": {
+    "PLAYWRIGHT_RUN": {
+      "localStorage": {
+        "acceptedTermsVersion": "2042-01-01"
+      }
+    },
+    "settings": {
+      "hasCompletedOnboarding": true,
+      "hasSeenWalletV4Tour": true,
+      "counterValue": "USD",
+      "language": "en",
+      "theme": null,
+      "region": null,
+      "locale": "en-US",
+      "orderAccounts": "balance|desc",
+      "countervalueFirst": false,
+      "autoLockTimeout": 10,
+      "selectedTimeRange": "month",
+      "marketIndicator": "western",
+      "currenciesSettings": {},
+      "pairExchanges": {},
+      "developerMode": false,
+      "loaded": true,
+      "shareAnalytics": false,
+      "sharePersonalizedRecommandations": false,
+      "analyticsConsentInfo": {
+        "consentDate": "2099-01-01T00:00:00.000Z",
+        "privacyPolicyVersion": 1
+      },
+      "hasSeenAnalyticsOptInPrompt": true,
+      "sentryLogs": true,
+      "lastUsedVersion": "99.99.99",
+      "dismissedBanners": [],
+      "accountsViewMode": "list",
+      "showAccountsHelperBanner": true,
+      "hideEmptyTokenAccounts": false,
+      "sidebarCollapsed": false,
+      "discreetMode": true,
+      "preferredDeviceModel": "nanoSP",
+      "hasInstalledApps": true,
+      "hasAcceptedSwapKYC": false,
+      "lastSeenDevice": {
+        "modelId": "nanoSP",
+        "deviceInfo": {
+          "version": "1.0.2",
+          "mcuVersion": "4.02",
+          "seVersion": "1.0.2",
+          "majMin": "1.0.2",
+          "providerName": null,
+          "targetId": 856686596,
+          "hasDevFirmware": false,
+          "seTargetId": 856686596,
+          "isOSU": false,
+          "isBootloader": false,
+          "isRecoveryMode": false,
+          "managerAllowed": false,
+          "pinValidated": true,
+          "onboarded": true,
+          "bootloaderVersion": "3.12",
+          "hardwareVersion": 0,
+          "languageId": 0,
+          "seFlags": []
+        },
+        "apps": []
+      },
+      "blacklistedTokenIds": [],
+      "swapAcceptedProviderIds": [],
+      "deepLinkUrl": null,
+      "firstTimeLend": false,
+      "swapProviders": [],
+      "showClearCacheBanner": false,
+      "starredAccountIds": [],
+      "hasPassword": false
+    },
+    "user": {
+      "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971"
+    },
+    "accounts": [],
+    "countervalues": {}
+  }
+}

--- a/e2e/mobile/page/drawer/modular.drawer.ts
+++ b/e2e/mobile/page/drawer/modular.drawer.ts
@@ -74,6 +74,29 @@ export default class ModularDrawer {
     await tapById(assetItemId, 0);
   }
 
+  @Step("Check asset $0 amount is masked in discreet mode")
+  async checkAssetAmountIsDiscreet(ticker: string): Promise<void> {
+    await this.performSearchByTicker(ticker);
+    const assetItemId = this.assetItemByTicker(ticker);
+    await waitForElement(getElementById(assetItemId));
+    await detoxExpect(getElementById(assetItemId)).toBeVisible();
+
+    const assetItemIdentifier = await getIdByRegexp(assetItemId);
+    const fiatMask = /\$\*\*\*/;
+    const cryptoMask = new RegExp(`\\*\\*\\*\\s+${ticker}`, "i");
+
+    await detoxExpect(
+      getElementByIdWithDescendantTexts(assetItemIdentifier, fiatMask, cryptoMask).atIndex(0),
+    ).toBeVisible();
+  }
+
+  @Step("Check listed asset amounts are masked in discreet mode")
+  async checkAssetAmountsAreDiscreet(tickers: string[]): Promise<void> {
+    for (const ticker of tickers) {
+      await this.checkAssetAmountIsDiscreet(ticker);
+    }
+  }
+
   @Step("Select network in list if needed")
   async selectNetworkIfAsked(networkName: string): Promise<void> {
     if (await IsIdVisible(this.networkScreenId)) {

--- a/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
@@ -1,6 +1,6 @@
-import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { Device } from "@ledgerhq/live-e2e-shared/enum/Device";
 import { SwapType } from "@ledgerhq/live-e2e-shared/models/Swap";
+import { Account, type AccountType } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { performSwapUntilQuoteSelectionStep } from "../../../utils/swapUtils";
 import { AppInfos } from "@ledgerhq/live-e2e-shared/enum/AppInfos";
 import { SwapProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
@@ -580,6 +580,41 @@ export function runSwapNetworkFeesAboveAccountBalanceTest(
       await app.swapLiveApp.checkQuotes();
       await app.swapLiveApp.selectExchange();
       await app.swapLiveApp.verifySwapAmountErrorMessageIsCorrect(errorMessage);
+    });
+  });
+}
+
+export function runSwapDiscreetModeTest(
+  accounts: AccountType[],
+  tmsLinks: string[],
+  tags: string[],
+) {
+  describe("Swap Discreet Mode", () => {
+    beforeAll(async () => {
+      await beforeAllFunctionSwap({
+        userdata: "discreet-mode",
+        cliCommandsOnApp: [
+          {
+            app: Account.BTC_NATIVE_SEGWIT_1.currency.speculosApp,
+            cmd: liveDataWithAddressCommand(Account.BTC_NATIVE_SEGWIT_1),
+          },
+          {
+            app: Account.ETH_1.currency.speculosApp,
+            cmd: liveDataWithAddressCommand(Account.ETH_1),
+          },
+        ],
+      });
+    });
+
+    setTeamOwner(Team.SWAP);
+    tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+    tags.forEach(tag => $Tag(tag));
+
+    it("Checks if the amount is hidden in the asset drawer", async () => {
+      const tickers = accounts.map(account => account.currency.ticker);
+      await app.swapLiveApp.tapFromCurrency();
+      await app.modularDrawer.checkSelectAssetPage();
+      await app.modularDrawer.checkAssetAmountsAreDiscreet(tickers);
     });
   });
 }

--- a/e2e/mobile/specs/swap/otherTestCases/swapDiscreetMode.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDiscreetMode.spec.ts
@@ -1,0 +1,32 @@
+import { Account, type AccountType, TokenAccount } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { runSwapDiscreetModeTest } from "./swap.other";
+
+const fundedAssetsAccounts: AccountType[] = [
+  Account.BTC_NATIVE_SEGWIT_1,
+  Account.ETH_1,
+  TokenAccount.ETH_USDC_1,
+  TokenAccount.ETH_USDT_1,
+];
+
+const swapDiscreetModeTestConfig = {
+  fundedAssetsAccounts,
+  tmsLinks: ["B2CQA-2457"],
+  tags: [
+    "@NanoSP",
+    "@LNS",
+    "@NanoX",
+    "@Stax",
+    "@Flex",
+    "@NanoGen5",
+    "@ethereum",
+    "@family-evm",
+    "@bitcoin",
+    "@family-bitcoin",
+  ],
+};
+
+runSwapDiscreetModeTest(
+  swapDiscreetModeTestConfig.fundedAssetsAccounts,
+  swapDiscreetModeTestConfig.tmsLinks,
+  swapDiscreetModeTestConfig.tags,
+);

--- a/e2e/mobile/userdata/discreet-mode.json
+++ b/e2e/mobile/userdata/discreet-mode.json
@@ -1,0 +1,58 @@
+{
+  "data": {
+    "SPECTRON_RUN": {
+      "localStorage": {
+        "acceptedTermsVersion": "2019-12-04"
+      }
+    },
+    "settings": {
+      "hasCompletedOnboarding": true,
+      "counterValue": "USD",
+      "language": "en",
+      "theme": "light",
+      "region": null,
+      "locale": "en-US",
+      "orderAccounts": "balance|desc",
+      "countervalueFirst": false,
+      "autoLockTimeout": 10,
+      "marketIndicator": "western",
+      "currenciesSettings": {},
+      "pairExchanges": {},
+      "developerMode": false,
+      "loaded": true,
+      "shareAnalytics": false,
+      "sharePersonalizedRecommandations": false,
+      "hasSeenAnalyticsOptInPrompt": true,
+      "analyticsEnabled": false,
+      "personalizedRecommendationsEnabled": false,
+      "trackingEnabled": false,
+      "sentryLogs": true,
+      "readOnlyModeEnabled": false,
+      "hasOrderedNano": true,
+      "lastUsedVersion": "99.99.99",
+      "dismissedBanners": [],
+      "accountsViewMode": "list",
+      "showAccountsHelperBanner": true,
+      "hideEmptyTokenAccounts": false,
+      "sidebarCollapsed": false,
+      "discreetMode": true,
+      "preferredDeviceModel": "nanoS",
+      "hasInstalledApps": true,
+      "dismissedDynamicCards": [],
+      "seenDevices": [],
+      "blacklistedTokenIds": [],
+      "swapAcceptedProviderIds": [],
+      "deepLinkUrl": null,
+      "firstTimeLend": false,
+      "swapProviders": [],
+      "showClearCacheBanner": false,
+      "starredAccountIds": [],
+      "hasPassword": false
+    },
+    "user": {
+      "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971"
+    },
+    "accounts": [],
+    "countervalues": {}
+  }
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` — **N/A**: changes are E2E tests in private, unversioned packages (`ledger-live-mobile-e2e-tests`, `ledger-live-desktop-e2e-tests`), so no changeset is required.
- [x] **Covered by automatic tests.** _These changes **are** the automated E2E tests for discreet mode (QAA-703 / B2CQA-2457)._
- [x] **Impact of the changes:**
      - Swap **"from" asset drawer** with discreet mode ON — every funded asset row must render masked amounts: fiat `$***` and crypto `*** <TICKER>`.
      - **Desktop only:** the swap **widget balance** is also masked after selecting an account.
      - Assets covered: desktop `BTC / ETH / USDC / USDT`; mobile `BTC / ETH / USDC / USDT` (the userdata-funded subset).
      - Confirm the **modular drawer** (`live_app` flow) is the path exercised, not the legacy selector.

### 📝 Description

Discreet mode (which hides fiat/crypto amounts across the app) had **no automated E2E coverage in the swap flow**. This PR adds that coverage, automating manual test **B2CQA-2457** ("verify that having discreet mode enabled hides any amount in fiat/crypto when using the swap feature").

**Desktop (Playwright)** — `e2e/desktop/tests/specs/discreet.swap.spec.ts`, two tests under *"Swap Discreet mode"*:
- amounts are masked in the from-asset drawer (`$***` / `*** <TICKER>`);
- the swap widget balance is masked after selecting an account.

**Mobile (Detox)** — new `e2e/mobile/specs/swap/otherTestCases/swapDiscreetMode.spec.ts` mirroring the **drawer** test only (there is no swap widget on mobile). Adds `checkAssetAmountIsDiscreet` / `checkAssetAmountsAreDiscreet` to the modular drawer page object (`e2e/mobile/page/drawer/modular.drawer.ts`) and a `discreet-mode` userdata.

Discreet mode is a global display toggle (not per-asset), so the mobile test is scoped to the userdata-funded subset (BTC, ETH, USDC, USDT) and still proves the masking behavior; desktop exercises the full funded set.

### ❓ Context

- **JIRA or GitHub link**: [QAA-703](https://ledgerhq.atlassian.net/browse/QAA-703) — automates manual test [B2CQA-2457](https://ledgerhq.atlassian.net/browse/B2CQA-2457)
- **Desktop**: https://github.com/LedgerHQ/ledger-live/actions/runs/28782766924
- **Mobile**: https://github.com/LedgerHQ/ledger-live/actions/runs/28782781917

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-703]: https://ledgerhq.atlassian.net/browse/QAA-703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ