### PR TITLE
fix(e2e): update MultiversX delegate validator name to "Ledger by Figment"

### DIFF
--- a/e2e/mobile/specs/delegate/delegateEGLD.spec.ts
+++ b/e2e/mobile/specs/delegate/delegateEGLD.spec.ts
@@ -4,7 +4,7 @@ import { setEnv } from "@ledgerhq/live-env";
 
 setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
-const delegation = new Delegate(Account.MULTIVERS_X_1, "1", "Figment");
+const delegation = new Delegate(Account.MULTIVERS_X_1, "1", "Ledger by Figment");
 runDelegateTest(
   delegation,
   ["B2CQA-3020"],


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached. _N/A — change is confined to the private `ledger-live-mobile-e2e-tests` package; per repo convention, e2e-spec-only changes don't ship a changeset._
- [x] **Covered by automatic tests.** _This change is to the E2E test itself; the `delegateEGLD` spec passes locally on iOS after the fix (`Delegate on MultiversX [OK]`)._
- [x] **Impact of the changes:**
  - MultiversX (EGLD) delegate flow — validator selection (search + row tap) and the delegation summary validator assertion.

### 📝 Description

The `delegateEGLD` E2E spec was failing at the "select validator" step with:

```
Test Failed: No elements found for "MATCHER(id == "provider-row-Figment") AT INDEX(0)"
```

**Problem**: The MultiversX Ledger validator's on-chain `identity.name` changed from `"Figment"` to `"Ledger by Figment"`. The spec hard-codes the provider name, and `StakePage.selectValidator` reuses that single string both as the search query **and** as the exact `provider-row-${name}` testID suffix (`by.id` is an exact match). The search still surfaced the row (substring match), but the tap targeted the now-stale `provider-row-Figment` testID instead of the real `provider-row-Ledger by Figment`.

**Solution**: Update the spec's provider to the validator's current name, `"Ledger by Figment"`. This value flows consistently through all three usages:

```ts
// e2e/mobile/specs/delegate/delegateEGLD.spec.ts
- const delegation = new Delegate(Account.MULTIVERS_X_1, "1", "Figment");
+ const delegation = new Delegate(Account.MULTIVERS_X_1, "1", "Ledger by Figment");
```

- search query `"Ledger by Figment"` → row stays visible (`identity.name.toLowerCase().includes(needle)`)
- tap `provider-row-Ledger by Figment` → matches `Item.tsx` testID
- summary `toContain("Ledger by Figment")` → matches `SetDelegation.tsx` (`identity.name`)

No production code changed — this is a test-data correction.

### ❓ Context

- **JIRA or GitHub link**: _N/A — standalone E2E test maintenance fix._

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)