### PR TITLE
[LWDM] feat(wallet-api): add broadcast log helper, pass broadcastLogger to entry pts

### DIFF
--- a/.changeset/broadcast-logger-wallet-api-entrypoints.md
+++ b/.changeset/broadcast-logger-wallet-api-entrypoints.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add a shared broadcast log-event helper (flow/error-type categorisation, cross-family transaction type) and pass an optional `broadcastLogger` through the wallet-api entry points. Refactor `useBroadcast` to consume the helper, wire the `transaction.signAndBroadcast` flow, and inject the logger from the desktop and mobile webviews.

--- a/apps/ledger-live-desktop/src/datadog/logs.test.ts
+++ b/apps/ledger-live-desktop/src/datadog/logs.test.ts
@@ -1,4 +1,8 @@
 import {
+  BroadcastErrorType,
+  BroadcastFlow,
+} from "@ledgerhq/live-common/wallet-api/broadcastLogEvent";
+import {
   __resetDatadogLogsForTesting,
   broadcastLogger,
   initDatadogLogs,
@@ -179,6 +183,7 @@ describe("datadog logs", () => {
     it("calls datadogLogs.logger.info with correct parameters on success event", () => {
       broadcastLogger({
         status: "success",
+        flow: BroadcastFlow.Send,
         appVersion: "1.0.0",
         currencyId: "bitcoin",
         family: "bitcoin",
@@ -190,6 +195,7 @@ describe("datadog logs", () => {
       expect(datadogLogs.logger.info).toHaveBeenCalledWith("broadcast_success", {
         event: {
           status: "success",
+          flow: BroadcastFlow.Send,
           appVersion: "1.0.0",
           currencyId: "bitcoin",
           family: "bitcoin",
@@ -210,7 +216,9 @@ describe("datadog logs", () => {
 
       broadcastLogger({
         status: "failure",
+        flow: BroadcastFlow.Send,
         error,
+        errorType: BroadcastErrorType.Unknown,
         txPayload: { signature: "signature" },
         appVersion: "1.0.0",
         currencyId: "ethereum",
@@ -225,6 +233,8 @@ describe("datadog logs", () => {
         {
           event: {
             status: "failure",
+            flow: BroadcastFlow.Send,
+            errorType: BroadcastErrorType.Unknown,
             txPayload: { signature: "signature" },
             appVersion: "1.0.0",
             currencyId: "ethereum",

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -7,6 +7,7 @@ import {
   useWalletAPIServer,
 } from "@ledgerhq/live-common/wallet-api/react";
 import trackingWrapper, { TrackingAPI } from "@ledgerhq/live-common/wallet-api/tracking";
+import { broadcastLogger } from "~/datadog/logs";
 import { AppManifest, WalletAPIServer } from "@ledgerhq/live-common/wallet-api/types";
 import { useDappLogic } from "@ledgerhq/live-common/wallet-api/useDappLogic";
 import { Operation } from "@ledgerhq/types-live";
@@ -333,6 +334,7 @@ function useWebView(
     webviewHook,
     uiHook,
     customHandlers,
+    broadcastLogger,
   });
 
   useEffect(() => {

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
@@ -17,6 +17,7 @@ import type { AccountLike, Operation, Account } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import trackingWrapper from "@ledgerhq/live-common/wallet-api/tracking";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { broadcastLogger } from "~/datadog";
 import { useSelector } from "~/context/hooks";
 import { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { WebViewProps, WebView, WebViewMessageEvent } from "react-native-webview";
@@ -162,6 +163,7 @@ export function useWebView(
     webviewHook,
     uiHook,
     customHandlers,
+    broadcastLogger,
   });
   const [cacheBustedLiveAppsDb, setCacheBustedLiveAppsDbState, cacheBustedLoaded] =
     useCacheBustedLiveAppsDB();

--- a/apps/ledger-live-mobile/src/datadog.test.ts
+++ b/apps/ledger-live-mobile/src/datadog.test.ts
@@ -1,4 +1,8 @@
 import { DdLogs } from "@datadog/mobile-react-native";
+import {
+  BroadcastErrorType,
+  BroadcastFlow,
+} from "@ledgerhq/live-common/wallet-api/broadcastLogEvent";
 import { broadcastLogger, customErrorEventMapper } from "./datadog";
 
 jest.mock("@datadog/mobile-react-native", () => ({
@@ -44,6 +48,7 @@ describe("broadcastLogger", () => {
 
     broadcastLogger({
       status: "success",
+      flow: BroadcastFlow.Send,
       appVersion: "1.0.0",
       currencyId: "bitcoin",
       family: "family",
@@ -55,6 +60,7 @@ describe("broadcastLogger", () => {
     expect(infoSpy).toHaveBeenCalledWith("broadcast_success", {
       event: {
         status: "success",
+        flow: BroadcastFlow.Send,
         appVersion: "1.0.0",
         currencyId: "bitcoin",
         family: "family",
@@ -72,7 +78,9 @@ describe("broadcastLogger", () => {
 
     broadcastLogger({
       status: "failure",
+      flow: BroadcastFlow.Send,
       error,
+      errorType: BroadcastErrorType.Unknown,
       txPayload: { signature: "signature" },
       appVersion: "1.0.0",
       currencyId: "ethereum",
@@ -90,6 +98,8 @@ describe("broadcastLogger", () => {
       {
         event: {
           status: "failure",
+          flow: BroadcastFlow.Send,
+          errorType: BroadcastErrorType.Unknown,
           txPayload: { signature: "signature" },
           appVersion: "1.0.0",
           currencyId: "ethereum",

--- a/libs/ledger-live-common/src/hooks/useBroadcast.test.ts
+++ b/libs/ledger-live-common/src/hooks/useBroadcast.test.ts
@@ -79,6 +79,7 @@ describe("useBroadcast", () => {
 
       expect(logger).toHaveBeenCalledWith({
         status: "success",
+        flow: "send",
         currencyId: "currency-id",
         tokenId: expectedTokenId,
         family: "family",
@@ -118,7 +119,9 @@ describe("useBroadcast", () => {
 
       expect(logger).toHaveBeenCalledWith({
         status: "failure",
+        flow: "send",
         error: new Error("Broadcast failed"),
+        errorType: "Unknown",
         currencyId: "currency-id",
         tokenId: expectedTokenId,
         family: "family",

--- a/libs/ledger-live-common/src/hooks/useBroadcast.ts
+++ b/libs/ledger-live-common/src/hooks/useBroadcast.ts
@@ -6,54 +6,31 @@ import type {
   AccountLike,
   Account,
   BroadcastConfig,
-  TransactionSource,
   TransactionCommon,
 } from "@ledgerhq/types-live";
 import { getEnv } from "@ledgerhq/live-env";
 import { formatOperation, getMainAccount } from "../account/index";
 import { getAccountBridge } from "../bridge/index";
 import { execAndWaitAtLeast } from "../promise";
+import {
+  BroadcastFlow,
+  buildBroadcastCommonEvent,
+  buildBroadcastFailureEvent,
+  buildBroadcastSuccessEvent,
+  type BroadcastLogger,
+  type LogEvent,
+} from "../wallet-api/broadcastLogEvent";
 
-type CommonLogEvent = {
-  appVersion: string;
-  source?: TransactionSource;
-  currencyId: string;
-  family: string;
-  tokenId?: string;
-  isTestnet: boolean;
-  isSendMax: boolean;
-};
-
-type ErrorLogEvent = {
-  status: "failure";
-  error: Error;
-  txPayload: {
-    signature: string;
-    rawData?: Record<string, unknown>;
-  };
-} & CommonLogEvent;
-
-type SuccessLogEvent = { status: "success" } & CommonLogEvent;
-
-export type LogEvent = SuccessLogEvent | ErrorLogEvent;
+// Re-exported for backward compatibility — consumers import `LogEvent` from this module.
+export type { LogEvent, BroadcastLogger };
 
 export type SignTransactionArgs = {
   account?: AccountLike | null;
   parentAccount?: Account | null;
   broadcastConfig?: BroadcastConfig;
-  logger?: (event: LogEvent) => void;
+  logger?: BroadcastLogger;
   transaction?: TransactionCommon | null;
 };
-
-function toError(err: unknown): Error {
-  if (err instanceof Error) return err;
-  if (typeof err === "string") return new Error(err);
-  try {
-    return new Error(JSON.stringify(err));
-  } catch {
-    return new Error(String(err));
-  }
-}
 
 export const useBroadcast = ({
   account,
@@ -72,15 +49,13 @@ export const useBroadcast = ({
         return Promise.resolve(signedOperation.operation);
       }
 
-      const commonLogEvent: CommonLogEvent = {
-        appVersion: getEnv("LEDGER_CLIENT_VERSION"),
+      const commonLogEvent = buildBroadcastCommonEvent({
+        account,
+        mainAccount,
+        flow: BroadcastFlow.Send,
         source: broadcastConfig?.source,
-        currencyId: mainAccount.currency.id,
-        family: mainAccount.currency.family,
-        isTestnet: Boolean(mainAccount.currency.isTestnetFor),
         isSendMax: Boolean(transaction?.useAllAmount),
-        ...(account.type === "TokenAccount" ? { tokenId: account.token.id } : {}),
-      };
+      });
 
       return execAndWaitAtLeast(3000, async () => {
         try {
@@ -94,24 +69,12 @@ export const useBroadcast = ({
             `✔️ broadcasted! optimistic operation: ${(await formatOperation(mainAccount))(operation)}`,
           );
           if (logger) {
-            logger({
-              status: "success",
-              ...commonLogEvent,
-            });
+            logger(buildBroadcastSuccessEvent(commonLogEvent));
           }
           return operation;
         } catch (err) {
-          const error = toError(err);
           if (logger) {
-            logger({
-              status: "failure",
-              error,
-              txPayload: {
-                signature: signedOperation.signature,
-                ...(signedOperation.rawData ? { rawData: signedOperation.rawData } : {}),
-              },
-              ...commonLogEvent,
-            });
+            logger(buildBroadcastFailureEvent(commonLogEvent, err, signedOperation));
           }
           throw err;
         }

--- a/libs/ledger-live-common/src/wallet-api/broadcastLogEvent.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/broadcastLogEvent.test.ts
@@ -1,0 +1,168 @@
+import { setEnv } from "@ledgerhq/live-env";
+import type { Account, AccountLike, SignedOperation } from "@ledgerhq/types-live";
+import type { Transaction as WalletAPITransaction } from "@ledgerhq/wallet-api-core";
+import {
+  BroadcastErrorType,
+  BroadcastFlow,
+  buildBroadcastCommonEvent,
+  buildBroadcastFailureEvent,
+  buildBroadcastSuccessEvent,
+  categorizeBroadcastError,
+  getBroadcastTransactionType,
+} from "./broadcastLogEvent";
+
+const mainAccount = {
+  id: "main-account-id",
+  type: "Account",
+  currency: { id: "ethereum", family: "evm" },
+} as unknown as Account;
+
+const tokenAccount = {
+  id: "sub-account-id",
+  type: "TokenAccount",
+  token: { id: "ethereum/erc20/usdc" },
+} as unknown as AccountLike;
+
+describe("buildBroadcastCommonEvent", () => {
+  beforeEach(() => setEnv("LEDGER_CLIENT_VERSION", "llc/test"));
+
+  it("builds the common fields for a native-account broadcast", () => {
+    expect(
+      buildBroadcastCommonEvent({
+        account: mainAccount,
+        mainAccount,
+        flow: BroadcastFlow.WalletApiSignAndBroadcast,
+        manifestId: "some-dapp",
+        source: { type: "live-app", name: "some-dapp" },
+        transactionType: "approve",
+        isSendMax: true,
+      }),
+    ).toEqual({
+      appVersion: "llc/test",
+      flow: "wallet-api/transaction.signAndBroadcast",
+      manifestId: "some-dapp",
+      source: { type: "live-app", name: "some-dapp" },
+      currencyId: "ethereum",
+      family: "evm",
+      transactionType: "approve",
+      isTestnet: false,
+      isSendMax: true,
+    });
+  });
+
+  it("adds tokenId for token accounts and omits empty optionals", () => {
+    const event = buildBroadcastCommonEvent({
+      account: tokenAccount,
+      mainAccount,
+      flow: BroadcastFlow.Send,
+    });
+    expect(event.tokenId).toBe("ethereum/erc20/usdc");
+    expect(event.manifestId).toBeUndefined();
+    expect(event.transactionType).toBeUndefined();
+    expect(event.isSendMax).toBe(false);
+  });
+});
+
+describe("buildBroadcastSuccessEvent / buildBroadcastFailureEvent", () => {
+  const common = buildBroadcastCommonEvent({
+    account: mainAccount,
+    mainAccount,
+    flow: BroadcastFlow.Acre,
+  });
+
+  it("tags success", () => {
+    expect(buildBroadcastSuccessEvent(common).status).toBe("success");
+  });
+
+  it("tags failure with normalized errorType and txPayload", () => {
+    const signedOperation = {
+      signature: "deadbeef",
+      rawData: { psbt: "x" },
+    } as unknown as SignedOperation;
+    const event = buildBroadcastFailureEvent(
+      common,
+      new Error("insufficient_funds for transfer"),
+      signedOperation,
+    );
+    expect(event.status).toBe("failure");
+    expect(event.errorType).toBe(BroadcastErrorType.InsufficientFunds);
+    expect(event.txPayload).toEqual({ signature: "deadbeef", rawData: { psbt: "x" } });
+  });
+
+  it("coerces non-Error throwables", () => {
+    const event = buildBroadcastFailureEvent(common, "boom", {
+      signature: "sig",
+    } as unknown as SignedOperation);
+    expect(event.error).toBeInstanceOf(Error);
+    expect(event.error.message).toBe("boom");
+  });
+});
+
+describe("categorizeBroadcastError", () => {
+  it.each([
+    [
+      "InsufficientFunds (name)",
+      { name: "InsufficientFunds" },
+      BroadcastErrorType.InsufficientFunds,
+    ],
+    [
+      "InvalidTransactionError (name)",
+      { name: "InvalidTransactionError" },
+      BroadcastErrorType.InvalidTransaction,
+    ],
+    [
+      "SequenceNumberError (name)",
+      { name: "SequenceNumberError" },
+      BroadcastErrorType.NonceOrSequenceError,
+    ],
+    [
+      "TronTransactionExpired (name)",
+      { name: "TronTransactionExpired" },
+      BroadcastErrorType.TransactionExpired,
+    ],
+    ["NetworkError (name)", { name: "NetworkError" }, BroadcastErrorType.NetworkError],
+    [
+      "NONCE_EXPIRED (message)",
+      { message: "nonce_expired: foo" },
+      BroadcastErrorType.NonceOrSequenceError,
+    ],
+    [
+      "REPLACEMENT_UNDERPRICED (message)",
+      { message: "replacement_underpriced" },
+      BroadcastErrorType.ReplacementUnderpriced,
+    ],
+    [
+      "UNPREDICTABLE_GAS_LIMIT (message)",
+      { message: "cannot estimate gas; UNPREDICTABLE_GAS_LIMIT" },
+      BroadcastErrorType.GasError,
+    ],
+    ["unknown", { name: "Error", message: "something weird" }, BroadcastErrorType.Unknown],
+  ])("maps %s", (_label, partial, expected) => {
+    const error = Object.assign(new Error(), partial) as Error;
+    expect(categorizeBroadcastError(error)).toBe(expected);
+  });
+});
+
+describe("getBroadcastTransactionType", () => {
+  it("returns undefined when no transaction", () => {
+    expect(getBroadcastTransactionType(undefined)).toBeUndefined();
+  });
+
+  it("reads mode for families that expose one (cosmos)", () => {
+    const tx = { family: "cosmos", mode: "delegate" } as unknown as WalletAPITransaction;
+    expect(getBroadcastTransactionType(tx)).toBe("delegate");
+  });
+
+  it("returns 'send' for families without a discriminator (bitcoin)", () => {
+    const tx = { family: "bitcoin" } as unknown as WalletAPITransaction;
+    expect(getBroadcastTransactionType(tx)).toBe("send");
+  });
+
+  it("reads solana model.kind", () => {
+    const tx = {
+      family: "solana",
+      model: { kind: "token.transfer" },
+    } as unknown as WalletAPITransaction;
+    expect(getBroadcastTransactionType(tx)).toBe("token.transfer");
+  });
+});

--- a/libs/ledger-live-common/src/wallet-api/broadcastLogEvent.ts
+++ b/libs/ledger-live-common/src/wallet-api/broadcastLogEvent.ts
@@ -1,0 +1,230 @@
+import type { Transaction as WalletAPITransaction } from "@ledgerhq/wallet-api-core";
+import type {
+  Account,
+  AccountLike,
+  SignedOperation,
+  TransactionSource,
+} from "@ledgerhq/types-live";
+import { getEnv } from "@ledgerhq/live-env";
+import { getTxType } from "./utils/txTrackingHelper";
+
+/**
+ * Identifies which broadcast pathway emitted the log event.
+ * This is the granular "where", complementing the live-app `manifestId`.
+ */
+export enum BroadcastFlow {
+  /** Native in-app send flow (`useBroadcast`). */
+  Send = "send",
+  WalletApiSignAndBroadcast = "wallet-api/transaction.signAndBroadcast",
+  WalletApiSignRaw = "wallet-api/transaction.signRaw",
+  WalletApiSignPsbt = "wallet-api/bitcoin.signPsbt",
+  Dapp = "dApp/eth_sendTransaction",
+  Acre = "acre/transactionSignAndBroadcast",
+  PlatformLegacy = "platform/broadcast",
+}
+
+/**
+ * Normalized, countable broadcast error categories.
+ *
+ * Broadcast errors are a mix of Ledger custom errors (stable `error.name`) and
+ * raw network/RPC errors (signal only in `error.message`). This enum lets
+ * dashboards group failures reliably without parsing free-text messages.
+ *
+ * Keep this list small and grow it from real Datadog data — the size of the
+ * `Unknown` bucket is itself a quality metric.
+ */
+export enum BroadcastErrorType {
+  InsufficientFunds = "InsufficientFunds",
+  InvalidTransaction = "InvalidTransaction",
+  /** EVM NONCE_EXPIRED + Cosmos sequence mismatch. */
+  NonceOrSequenceError = "NonceOrSequenceError",
+  ReplacementUnderpriced = "ReplacementUnderpriced",
+  TransactionUnderpriced = "TransactionUnderpriced",
+  /** GasEstimationError + UNPREDICTABLE_GAS_LIMIT. */
+  GasError = "GasError",
+  /** Tron expiry + generic expiry. */
+  TransactionExpired = "TransactionExpired",
+  UnsupportedRpcMethod = "UnsupportedRpcMethod",
+  /** Connectivity / timeout / fetch failures. */
+  NetworkError = "NetworkError",
+  /** Node responded with an uncategorized error. */
+  RpcError = "RpcError",
+  Unknown = "Unknown",
+}
+
+type CommonLogEvent = {
+  appVersion: string;
+  /** Which broadcast pathway emitted the event. */
+  flow: BroadcastFlow;
+  /** Live-app manifest id — the primary "where". Absent for the native send flow. */
+  manifestId?: string;
+  source?: TransactionSource;
+  /** Parent/network currency id (e.g. "ethereum"); token id is reported separately. */
+  currencyId: string;
+  family: string;
+  tokenId?: string;
+  /** Family-specific transaction type/mode. Only populated when a rich transaction is available. */
+  transactionType?: string;
+  isTestnet: boolean;
+  isSendMax: boolean;
+};
+
+type ErrorLogEvent = {
+  status: "failure";
+  error: Error;
+  errorType: BroadcastErrorType;
+  txPayload: {
+    signature: string;
+    rawData?: Record<string, unknown>;
+  };
+} & CommonLogEvent;
+
+type SuccessLogEvent = { status: "success" } & CommonLogEvent;
+
+export type LogEvent = SuccessLogEvent | ErrorLogEvent;
+
+/** A function that consumes a broadcast {@link LogEvent}, injected by each app (e.g. to forward to Datadog). */
+export type BroadcastLogger = (event: LogEvent) => void;
+
+export function toError(err: unknown): Error {
+  if (err instanceof Error) return err;
+  if (typeof err === "string") return new Error(err);
+  try {
+    return new Error(JSON.stringify(err));
+  } catch {
+    return new Error(String(err));
+  }
+}
+
+/**
+ * Derives a family-specific transaction type from a wallet-api transaction.
+ *
+ * - EVM: the call-data function selector (e.g. "approve", "swap", "withdraw"), "transfer" as fallback.
+ * - Families with an operation `mode`: the mode string (e.g. "delegate", "freeze", "bond").
+ * - Solana: the model kind.
+ * - Ton: the payload type.
+ * - Families with no discriminator (e.g. bitcoin, stellar): "send".
+ *
+ * Returns `undefined` when no rich transaction is available (signRaw / signPsbt / ACRE / legacy platform).
+ */
+export function getBroadcastTransactionType(
+  tx: WalletAPITransaction | undefined | null,
+): string | undefined {
+  if (!tx) return undefined;
+
+  switch (tx.family) {
+    case "ethereum":
+      // getTxType only reads `tx.data` (a Buffer), which the wallet-api ethereum tx also carries.
+      return getTxType(tx as unknown as Parameters<typeof getTxType>[0]);
+    case "solana":
+      return tx.model?.kind;
+    case "ton":
+      return tx.payload?.type ?? "send";
+    case "bitcoin":
+    case "stellar":
+      return "send";
+    default:
+      // Most remaining families (cosmos, tron, polkadot, cardano, algorand, near, …) expose a `mode`.
+      return (tx as { mode?: string }).mode;
+  }
+}
+
+/**
+ * Maps an arbitrary broadcast error to a normalized {@link BroadcastErrorType}.
+ *
+ * Pure string-matching (no coin-module imports): matches stable `error.name`
+ * first, then falls back to stable RPC code substrings in `error.message`.
+ */
+export function categorizeBroadcastError(error: Error): BroadcastErrorType {
+  const name = error.name ?? "";
+  const message = (error.message ?? "").toUpperCase();
+
+  // 1. Stable Ledger custom error names.
+  switch (name) {
+    case "InsufficientFunds":
+      return BroadcastErrorType.InsufficientFunds;
+    case "InvalidTransactionError":
+      return BroadcastErrorType.InvalidTransaction;
+    case "SequenceNumberError":
+      return BroadcastErrorType.NonceOrSequenceError;
+    case "GasEstimationError":
+      return BroadcastErrorType.GasError;
+    case "TronTransactionExpired":
+      return BroadcastErrorType.TransactionExpired;
+    case "UnsupportedRpcMethodError":
+      return BroadcastErrorType.UnsupportedRpcMethod;
+    case "NetworkError":
+    case "NetworkDown":
+      return BroadcastErrorType.NetworkError;
+    case "SendTransactionError":
+      return BroadcastErrorType.RpcError;
+  }
+
+  // 2. Stable RPC code substrings (ethers.js error codes are not localized).
+  if (message.includes("INSUFFICIENT_FUNDS")) return BroadcastErrorType.InsufficientFunds;
+  if (message.includes("NONCE_EXPIRED") || message.includes("NONCE TOO LOW"))
+    return BroadcastErrorType.NonceOrSequenceError;
+  if (message.includes("REPLACEMENT_UNDERPRICED")) return BroadcastErrorType.ReplacementUnderpriced;
+  if (message.includes("TRANSACTION_UNDERPRICED")) return BroadcastErrorType.TransactionUnderpriced;
+  if (message.includes("UNPREDICTABLE_GAS_LIMIT")) return BroadcastErrorType.GasError;
+
+  return BroadcastErrorType.Unknown;
+}
+
+export type BuildBroadcastCommonEventParams = {
+  /** The signing account (used to read the token id). */
+  account: AccountLike;
+  /** The resolved main account (used to read currency/family/testnet). */
+  mainAccount: Account;
+  flow: BroadcastFlow;
+  manifestId?: string;
+  source?: TransactionSource;
+  transactionType?: string;
+  isSendMax?: boolean;
+};
+
+/** Builds the shared part of a broadcast log event. */
+export function buildBroadcastCommonEvent({
+  account,
+  mainAccount,
+  flow,
+  manifestId,
+  source,
+  transactionType,
+  isSendMax = false,
+}: BuildBroadcastCommonEventParams): CommonLogEvent {
+  return {
+    appVersion: getEnv("LEDGER_CLIENT_VERSION"),
+    flow,
+    currencyId: mainAccount.currency.id,
+    family: mainAccount.currency.family,
+    isTestnet: Boolean(mainAccount.currency.isTestnetFor),
+    isSendMax,
+    ...(manifestId ? { manifestId } : {}),
+    ...(source ? { source } : {}),
+    ...(transactionType ? { transactionType } : {}),
+    ...(account.type === "TokenAccount" ? { tokenId: account.token.id } : {}),
+  };
+}
+
+export function buildBroadcastSuccessEvent(common: CommonLogEvent): SuccessLogEvent {
+  return { status: "success", ...common };
+}
+
+export function buildBroadcastFailureEvent(
+  common: CommonLogEvent,
+  err: unknown,
+  signedOperation: SignedOperation,
+): ErrorLogEvent {
+  const error = toError(err);
+  return {
+    status: "failure",
+    error,
+    errorType: categorizeBroadcastError(error),
+    txPayload: {
+      signature: signedOperation.signature,
+      ...(signedOperation.rawData ? { rawData: signedOperation.rawData } : {}),
+    },
+    ...common,
+  };
+}

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -56,6 +56,14 @@ import {
 } from "./logic";
 import { handlers as featureFlagsHandlers } from "./FeatureFlags";
 import { getAccountBridge } from "../bridge";
+import {
+  BroadcastFlow,
+  buildBroadcastCommonEvent,
+  buildBroadcastFailureEvent,
+  buildBroadcastSuccessEvent,
+  getBroadcastTransactionType,
+  type BroadcastLogger,
+} from "./broadcastLogEvent";
 import openTransportAsSubject, { BidirectionalEvent } from "../hw/openTransportAsSubject";
 import { AppResult } from "../hw/actions/app";
 import { Transaction } from "../coin-modules/transaction-types";
@@ -279,6 +287,8 @@ export type useWalletAPIServerOptions = {
   };
   uiHook: Partial<UiHook>;
   customHandlers?: WalletAPICustomHandlers;
+  /** Optional sink for Datadog broadcast log events, injected by each app. */
+  broadcastLogger?: BroadcastLogger;
 };
 
 export function useWalletAPIServer({
@@ -303,6 +313,7 @@ export function useWalletAPIServer({
     "exchange.complete": uiExchangeComplete,
   },
   customHandlers,
+  broadcastLogger,
 }: useWalletAPIServerOptions): {
   onMessage: (event: string) => void;
   server: WalletAPIServer;
@@ -993,6 +1004,17 @@ export function useWalletAPIServer({
               network: networkId,
             };
 
+            const broadcastLogEvent = buildBroadcastCommonEvent({
+              account,
+              mainAccount,
+              flow: BroadcastFlow.WalletApiSignAndBroadcast,
+              manifestId: manifest.id,
+              source: { type: "live-app", name: manifest.id },
+              transactionType: getBroadcastTransactionType(transaction),
+              // `useAllAmount` is family-specific and absent from the wallet-api common shape.
+              isSendMax: Boolean((transaction as { useAllAmount?: boolean }).useAllAmount),
+            });
+
             let optimisticOperation: Operation = signedOperation.operation;
 
             if (!getEnv("DISABLE_TRANSACTION_BROADCAST")) {
@@ -1007,8 +1029,12 @@ export function useWalletAPIServer({
                   },
                 });
                 tracking.broadcastSuccess(manifest, broadcastTrackingData);
+                broadcastLogger?.(buildBroadcastSuccessEvent(broadcastLogEvent));
               } catch (error) {
                 tracking.broadcastFail(manifest, broadcastTrackingData);
+                broadcastLogger?.(
+                  buildBroadcastFailureEvent(broadcastLogEvent, error, signedOperation),
+                );
                 throw error;
               }
             }
@@ -1022,7 +1048,16 @@ export function useWalletAPIServer({
         );
       },
     );
-  }, [accounts, config.mevProtected, manifest, server, tracking, uiTxBroadcast, uiTxSign]);
+  }, [
+    accounts,
+    config.mevProtected,
+    manifest,
+    server,
+    tracking,
+    uiTxBroadcast,
+    uiTxSign,
+    broadcastLogger,
+  ]);
 
   const onLoad = useCallback(() => {
     tracking.loadSuccess(manifest);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Add broadcastLogEvent helper: BroadcastFlow/BroadcastErrorType enums, event builders, getBroadcastTransactionType (cross-family), categorizeBroadcastError
- Refactor useBroadcast to consume the shared helper; re-export LogEvent
- Add optional broadcastLogger to useWalletAPIServer and wire the transaction.signAndBroadcast reference flow
- Inject broadcastLogger from desktop and mobile webview call sites

### ❓ Context

- **JIRA or GitHub link**: LIVE-33120 https://ledgerhq.atlassian.net/browse/LIVE-33120


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
