### PR TITLE
[LWM] test(mobile): support add account with Wallet 4.0 Q2 flags

### DIFF
--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/TotalBalanceView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/TotalBalanceView.tsx
@@ -35,6 +35,7 @@ export function TotalBalanceView({
             formatter={counterValueFormatter}
             hidden={discreet}
             size="sm"
+            testID={ASSET_DETAIL_TEST_IDS.totalBalanceAmount}
           />
         )}
         <Text typography="body3" lx={{ color: "muted" }}>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
@@ -6,6 +6,7 @@ export const ASSET_DETAIL_TEST_IDS = {
   receiveButton: "asset-detail-receive-button",
   balanceDetails: "asset-detail-balance-details",
   totalBalance: "asset-detail-total-balance",
+  totalBalanceAmount: "asset-detail-total-balance-amount",
   transferButton: "asset-detail-transfer-button",
   earnBanner: "asset-detail-earn-banner",
   availableBalance: "asset-detail-available-balance",

--- a/e2e/mobile/page/accounts/assetAccounts.page.ts
+++ b/e2e/mobile/page/accounts/assetAccounts.page.ts
@@ -22,8 +22,9 @@ export default class AssetAccountsPage {
 
   @Step("Wait for individual asset rows to load")
   async waitForAccountAssetsToLoad(assetName: string) {
-    await waitForElementById(this.titleId(assetName));
-    await waitForElementById(this.accountAssetId(assetName));
+    const assetNameId = assetName.toLowerCase();
+    await waitForElementById(this.titleId(assetNameId));
+    await waitForElementById(this.accountAssetId(assetNameId));
   }
 
   @Step("Open asset list via deeplink")

--- a/e2e/mobile/page/index.ts
+++ b/e2e/mobile/page/index.ts
@@ -15,6 +15,7 @@ import OperationDetailsPage from "./trade/operationDetails.page";
 import PasswordEntryPage from "./passwordEntry.page";
 import PortfolioEmptyStatePage from "./wallet/portfolioEmptyState.page";
 import PortfolioPage from "./wallet/portfolio.page";
+import AssetDetailPage from "./wallet/assetDetail.page";
 import ReceivePage from "./trade/receive.page";
 import SendPage from "./trade/send.page";
 import SettingsGeneralPage from "./settings/settingsGeneral.page";
@@ -70,6 +71,7 @@ export class Application {
   private passwordEntryPageInstance = lazyInit(PasswordEntryPage);
   private portfolioEmptyStatePageInstance = lazyInit(PortfolioEmptyStatePage);
   private portfolioPageInstance = lazyInit(PortfolioPage);
+  private assetDetailPageInstance = lazyInit(AssetDetailPage);
   private receivePageInstance = lazyInit(ReceivePage);
   private sendPageInstance = lazyInit(SendPage);
   private settingsPageInstance = lazyInit(SettingsPage);
@@ -160,6 +162,10 @@ export class Application {
 
   public get portfolio() {
     return this.portfolioPageInstance();
+  }
+
+  public get assetDetail() {
+    return this.assetDetailPageInstance();
   }
 
   public get portfolioEmptyState() {

--- a/e2e/mobile/page/wallet/assetDetail.page.ts
+++ b/e2e/mobile/page/wallet/assetDetail.page.ts
@@ -1,0 +1,24 @@
+import { element, by } from "detox";
+import { Step } from "jest-allure2-reporter/api";
+import { OPERATION_ITEM_ID } from "./operation.page";
+
+const ASSET_DETAIL_TOTAL_BALANCE_AMOUNT_ID = "asset-detail-total-balance-amount";
+const ASSET_DETAIL_MARKET_PRICE_ID = "asset-detail-market-price";
+
+export default class AssetDetailPage {
+  @Step("Expect asset detail balance to be visible")
+  async expectTotalBalanceVisible() {
+    await waitForElementById(ASSET_DETAIL_TOTAL_BALANCE_AMOUNT_ID);
+  }
+
+  @Step("Expect asset detail market price to be visible")
+  async expectMarketPriceVisible() {
+    await waitForElementById(ASSET_DETAIL_MARKET_PRICE_ID);
+  }
+
+  @Step("Expect asset detail operation item to be visible")
+  async expectOperationItemVisible() {
+    await scrollToId(OPERATION_ITEM_ID, undefined, undefined);
+    await detoxExpect(element(by.id(OPERATION_ITEM_ID)).atIndex(0)).toBeVisible();
+  }
+}

--- a/e2e/mobile/page/wallet/operation.page.ts
+++ b/e2e/mobile/page/wallet/operation.page.ts
@@ -1,11 +1,13 @@
 import { element, by } from "detox";
 import { Step } from "jest-allure2-reporter/api";
 
+export const OPERATION_ITEM_ID = "operations-list-item";
+
 export default class OperationPage {
   // MVVM OperationsList screen
   operationsListId = "operations-list-section-list";
   sectionHeaderId = "operations-section-header";
-  operationItemId = "operations-list-item";
+  operationItemId = OPERATION_ITEM_ID;
   emptyStateId = "operations-empty-state";
 
   @Step("Expect Operations List to be visible")

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -2,6 +2,10 @@ import { Step } from "jest-allure2-reporter/api";
 import { isWallet40, openDeeplink } from "../../helpers/commonHelpers";
 import { getFlags } from "../../bridge/server";
 import type { Features } from "@shared/feature-flags";
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const DEFAULT_TIMEOUT = 60000;
+
 export default class PortfolioPage {
   addNewOrExistingAccount = "add-new-account-button";
   assetsListId = "AssetsList";
@@ -58,6 +62,14 @@ export default class PortfolioPage {
   stablecoinListId = "StablecoinList";
   cryptosSectionHeaderId = "portfolio-cryptos-section-header";
   stablecoinsSectionHeaderId = "portfolio-stablecoins-section-header";
+  portfolioStocksListId = "PortfolioStocksList";
+  stocksListId = "StocksList";
+  stocksSectionHeaderId = "portfolio-stocks-section-header";
+  stocksDiscoveryId = "portfolio-stocks-discovery";
+  stocksDiscoveryHeaderId = "portfolio-stocks-discovery-header";
+  sectionAssetItemRegExp = (sectionId: string) => new RegExp(String.raw`^${sectionId}-item-\d+$`);
+  assetItemIdRegExp = (currencyName: string) =>
+    new RegExp(`^${this.baseAssetItem}${escapeRegExp(currencyName)}$`, "i");
 
   portfolioSettingsButton = async () => getElementById(this.portfolioSettingsId);
   assetItemId = (currencyName: string) => `${this.baseAssetItem}${currencyName}`;
@@ -440,6 +452,16 @@ export default class PortfolioPage {
     jestExpect(count).toBe(expected);
   }
 
+  private async checkSectionAssetItemCount(sectionId: string, expected: number) {
+    const count = await countElementsById(this.sectionAssetItemRegExp(sectionId));
+    jestExpect(count).toBe(expected);
+  }
+
+  @Step("Check cryptos section asset item count")
+  async checkCryptosSectionAssetItemCount(expected: number) {
+    await this.checkSectionAssetItemCount(this.portfolioCryptosListId, expected);
+  }
+
   @Step("Tap first asset item (wallet 4.0) and return its currency name")
   async tapFirstAssetItemW40(): Promise<string> {
     const testId = await getIdByRegexp(this.assetItemRegExp, 0);
@@ -450,7 +472,14 @@ export default class PortfolioPage {
 
   @Step("Check asset is visible on page")
   async checkAssetVisible(currencyName: string) {
-    await detoxExpect(getElementById(`assetItem-${currencyName}`)).toExist();
+    await detoxExpect(getElementById(this.assetItemIdRegExp(currencyName))).toExist();
+  }
+
+  @Step("Open asset detail from portfolio")
+  async openAssetDetail(currencyName: string, direction: "up" | "down" = "down") {
+    const assetItemId = this.assetItemIdRegExp(currencyName);
+    await scrollToId(assetItemId, this.accountsListView, undefined, direction);
+    await tapById(assetItemId);
   }
 
   @Step("Tap cryptos section title")
@@ -483,5 +512,43 @@ export default class PortfolioPage {
   @Step("Scroll to the top of the portfolio page")
   async scrollToTopOfPortfolioPage() {
     await scrollToId(this.portfolioBalanceNormal, this.accountsListView, 1000, "up");
+  }
+
+  private async scrollToStocksHeader(headerId: string) {
+    await waitForElementById(headerId, DEFAULT_TIMEOUT, {
+      checkVisibility: false,
+    });
+    await scrollToId(headerId, this.accountsListView);
+  }
+
+  @Step("Check stocks discovery (empty) section is visible")
+  async checkStocksDiscoverySectionVisible() {
+    await this.scrollToStocksHeader(this.stocksDiscoveryHeaderId);
+    await detoxExpect(getElementById(this.stocksDiscoveryId)).toExist();
+    await detoxExpect(getElementById(this.stocksDiscoveryHeaderId)).toBeVisible();
+  }
+
+  @Step("Tap 'Explore all' in the stocks discovery section")
+  async tapStocksExploreAll() {
+    await this.scrollToStocksHeader(this.stocksDiscoveryHeaderId);
+    await tapById(this.stocksDiscoveryHeaderId);
+  }
+
+  @Step("Check stocks holdings section is visible")
+  async checkStocksHoldingsSectionVisible() {
+    await this.scrollToStocksHeader(this.stocksSectionHeaderId);
+    await detoxExpect(getElementById(this.stocksSectionHeaderId)).toBeVisible();
+    await detoxExpect(getElementById(this.portfolioStocksListId)).toExist();
+  }
+
+  @Step("Tap stocks section title")
+  async tapStocksSectionTitle() {
+    await this.scrollToStocksHeader(this.stocksSectionHeaderId);
+    await tapById(this.stocksSectionHeaderId);
+  }
+
+  @Step("Check full stocks list page is visible")
+  async checkStocksListPageVisible() {
+    await this.checkListPageVisible(this.stocksListId);
   }
 }

--- a/e2e/mobile/specs/addAccount/addAccount.ts
+++ b/e2e/mobile/specs/addAccount/addAccount.ts
@@ -59,7 +59,7 @@ export function runAddAccountTest(currency: CurrencyType, tmsLinks: string[], ta
       await app.portfolio.goToAccounts(currency.name);
 
       await app.assetAccountsPage.waitForAccountPageToLoad(currency.name);
-      await app.assetAccountsPage.expectAccountsBalanceVisible();
+      await app.assetAccountsPage.waitForAccountAssetsToLoad(currency.name);
       await app.common.goToAccount(accountId);
       await app.account.expectAccountBalanceVisible(accountId);
       await app.account.expectOperationHistoryVisible(accountId);

--- a/e2e/mobile/specs/addAccount/addAccount.ts
+++ b/e2e/mobile/specs/addAccount/addAccount.ts
@@ -5,13 +5,22 @@ import { getMergedFeatureFlags } from "../../utils/constants";
 
 const BST_ADD_ACCOUNT_CURRENCIES = new Set(["ton", "aptos", "cardano", "tezos"]);
 
+// When aggregatedAssets is on, some networks are shown under an aggregated parent asset
+// (e.g. Base shares the ETH ticker and is aggregated under Ethereum), so the portfolio
+// renders `assetItem-Ethereum` instead of `assetItem-Base`. Map those to the parent name.
+const AGGREGATED_ASSET_NAME_BY_ID: Record<string, string> = {
+  base: "Ethereum",
+};
+
 export function runAddAccountTest(currency: CurrencyType, tmsLinks: string[], tags: string[]) {
   describe("Add accounts - Network Based", () => {
     let isAssetSectionEnabled = false;
+    let isAggregatedAssetsEnabled = false;
 
     beforeAll(async () => {
       const featureFlags = getMergedFeatureFlags();
       isAssetSectionEnabled = featureFlags.lwmWallet40?.params?.assetSection === true;
+      isAggregatedAssetsEnabled = featureFlags.lwmWallet40?.params?.aggregatedAssets === true;
 
       await app.init({
         userdata: "skip-onboarding",
@@ -48,8 +57,12 @@ export function runAddAccountTest(currency: CurrencyType, tmsLinks: string[], ta
       await app.addAccount.tapCloseAddAccountCta();
 
       if (isAssetSectionEnabled) {
-        await app.portfolio.checkAssetVisible(currency.name);
-        await app.portfolio.openAssetDetail(currency.name, "up");
+        const assetName =
+          isAggregatedAssetsEnabled && AGGREGATED_ASSET_NAME_BY_ID[currency.id]
+            ? AGGREGATED_ASSET_NAME_BY_ID[currency.id]
+            : currency.name;
+        await app.portfolio.checkAssetVisible(assetName);
+        await app.portfolio.openAssetDetail(assetName, "up");
         await app.assetDetail.expectTotalBalanceVisible();
         await app.assetDetail.expectMarketPriceVisible();
         await app.assetDetail.expectOperationItemVisible();

--- a/e2e/mobile/specs/addAccount/addAccount.ts
+++ b/e2e/mobile/specs/addAccount/addAccount.ts
@@ -1,15 +1,22 @@
 import { CurrencyType } from "@ledgerhq/live-common/e2e/enum/Currency";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { setTeamOwner } from "../../helpers/allure/allure-helper";
+import { getMergedFeatureFlags } from "../../utils/constants";
 
 const BST_ADD_ACCOUNT_CURRENCIES = new Set(["ton", "aptos", "cardano", "tezos"]);
 
 export function runAddAccountTest(currency: CurrencyType, tmsLinks: string[], tags: string[]) {
   describe("Add accounts - Network Based", () => {
+    let isAssetSectionEnabled = false;
+
     beforeAll(async () => {
+      const featureFlags = getMergedFeatureFlags();
+      isAssetSectionEnabled = featureFlags.lwmWallet40?.params?.assetSection === true;
+
       await app.init({
         userdata: "skip-onboarding",
         speculosApp: currency.speculosApp,
+        featureFlags,
       });
       await app.mainNavigation.waitForWallet40Ready();
     });
@@ -39,6 +46,15 @@ export function runAddAccountTest(currency: CurrencyType, tmsLinks: string[], ta
       );
 
       await app.addAccount.tapCloseAddAccountCta();
+
+      if (isAssetSectionEnabled) {
+        await app.portfolio.checkAssetVisible(currency.name);
+        await app.portfolio.openAssetDetail(currency.name, "up");
+        await app.assetDetail.expectTotalBalanceVisible();
+        await app.assetDetail.expectMarketPriceVisible();
+        await app.assetDetail.expectOperationItemVisible();
+        return;
+      }
 
       await app.portfolio.goToAccounts(currency.name);
 

--- a/e2e/mobile/utils/constants.ts
+++ b/e2e/mobile/utils/constants.ts
@@ -1,23 +1,90 @@
+import type { PartialFeatures } from "@shared/feature-flags";
+import { parseExtraFeatureFlags } from "@ledgerhq/live-common/e2e/featureFlagsJsonUtils";
+
 export const NANO_APP_CATALOG_PATH = "artifacts/appVersion/nano-app-catalog.json";
 
-// Shared Wallet 4.0 feature flags for e2e specs — remove when Wallet 4.0 is default
-export const WALLET_40_FEATURE_FLAGS = {
+export const isAssetSectionEnabled = process.env.E2E_ENABLE_ASSET_SECTION !== "0";
+export const isOperationsListEnabled = process.env.E2E_ENABLE_OPERATIONS_LIST !== "0";
+export const isMyWalletEnabled = process.env.E2E_ENABLE_MY_WALLET !== "0";
+
+const lwmWallet40BaseParams = {
+  marketBanner: true,
+  graphRework: true,
+  mainNavigation: true,
+  quickActionCtas: true,
+  tour: false,
+  balanceRefreshRework: true,
+  lazyOnboarding: true,
+  brazePlacement: true,
+} as const;
+
+export const FF_LWM_WALLET_40_Q1 = {
   lwmWallet40: {
     enabled: true,
     params: {
-      marketBanner: true,
-      graphRework: true,
-      quickActionCtas: true,
-      mainNavigation: true,
-      tour: true,
-      lazyOnboarding: true,
-      balanceRefreshRework: true,
-      assetSection: true,
-      operationsList: true,
+      ...lwmWallet40BaseParams,
+      assetSection: false,
+      operationsList: false,
       aggregatedAssets: false,
-      myWallet: true,
+      myWallet: false,
       pnl: false,
+      earnUpselling: false,
+      earnSimulator: false,
       assetDiscoverability: false,
+      q2Tour: false,
     },
   },
-} as const;
+} satisfies PartialFeatures;
+
+export const WALLET_40_FEATURE_FLAGS = FF_LWM_WALLET_40_Q1;
+
+export const FF_LWM_WALLET_40_Q2 = {
+  lwmWallet40: {
+    enabled: true,
+    params: {
+      ...lwmWallet40BaseParams,
+      assetSection: isAssetSectionEnabled,
+      operationsList: isOperationsListEnabled,
+      aggregatedAssets: true,
+      myWallet: isMyWalletEnabled,
+      pnl: true,
+      earnUpselling: true,
+      earnSimulator: true,
+      assetDiscoverability: true,
+      q2Tour: false,
+    },
+  },
+} satisfies PartialFeatures;
+
+export const getMergedFeatureFlags = ({
+  testFlags,
+}: { testFlags?: PartialFeatures } = {}): PartialFeatures => {
+  const defaultFlags: PartialFeatures = {
+    llmModularDrawer: {
+      enabled: true,
+      params: {
+        add_account: true,
+        live_app: true,
+        receive_flow: false,
+        send_flow: false,
+        enableModularization: true,
+        searchDebounceTime: 300,
+        backendEnvironment: "PROD",
+        live_apps_allowlist: [],
+        live_apps_blocklist: [],
+      },
+    },
+  };
+
+  const jsonOverrideFlags = parseExtraFeatureFlags<PartialFeatures>(
+    process.env.E2E_FEATURE_FLAGS_JSON,
+  );
+
+  return {
+    // return with spread so that duplicate keys are overridden (last one wins)
+    ...defaultFlags,
+    ...FF_LWM_WALLET_40_Q2,
+    ...jsonOverrideFlags,
+    ...testFlags,
+  };
+};


### PR DESCRIPTION
## Summary
- Adapt mobile add-account E2E to validate the Wallet 4.0 Q2 asset detail path when `assetSection` is enabled.
- Keep the Q1 account-detail assertions for the legacy path.
- Add AssetDetail test IDs/page object support and env-driven Wallet 4.0 Q2 feature flags for mobile E2E.

## Test plan
- `pnpm --filter ledger-live-mobile-e2e-tests typecheck`
- `pnpm --filter ledger-live-mobile-e2e-tests lint`


run https://github.com/LedgerHQ/ledger-live/actions/runs/28513992301