### PR TITLE
[LWDM] fix(e2e): use concordium testnet currency in Speculos spec

### DIFF
--- a/.changeset/tame-pillows-grow.md
+++ b/.changeset/tame-pillows-grow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Point the Concordium Speculos e2e spec at the concordium_testnet currency it actually tests

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -437,7 +437,7 @@ export const specs: Specs = {
     dependencies: [],
   },
   Concordium: {
-    currency: getCryptoCurrencyById("concordium"),
+    currency: getCryptoCurrencyById("concordium_testnet"),
     appQuery: {
       model: getSpeculosModel(),
       appName: "Concordium",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Behavior-preserving change to existing e2e test config; the Concordium (Testnet) send specs (desktop `send.tx.spec.ts`, mobile `sendCCD.spec.ts`) already exercise this path. The full Speculos e2e wasn't runnable in my local sandbox, but I verified at runtime that `concordium_testnet` resolves to the same `managerAppName: "Concordium"` as `concordium`, so the Speculos app/version resolution is unchanged._
- [x] **Impact of the changes:**
      - Concordium (Testnet) send e2e on Speculos (desktop + mobile)
      - Speculos app/version resolution for the Concordium app

### 📝 Description

The Concordium Speculos spec (`libs/ledger-live-common/src/e2e/speculos.ts`) declared `currency: getCryptoCurrencyById("concordium")` (mainnet), even though the e2e flow runs against the testnet currency (`Account.CCD_TESTNET_*`, `sendCCD.spec.ts`, and the "Send Concordium (Testnet)" block in `send.tx.spec.ts`). The spec named the wrong currency for the test it backs.

Both `concordium` and `concordium_testnet` share `managerAppName: "Concordium"` (a single on-device app), and `startSpeculos` resolves the catalog app/version via `spec.currency.managerAppName`. Switching the spec to `getCryptoCurrencyById("concordium_testnet")` is therefore behavior-preserving for app/version resolution, while making the spec correctly reference the currency actually under test. No change to the nano-app catalog cache is needed — the on-device app is still "Concordium".

### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)