### PR TITLE
fix(e2e): update XRP send & receive device labels after app review-flow change

### DIFF
--- a/libs/ledger-live-common/src/e2e/data/deviceLabelsData.ts
+++ b/libs/ledger-live-common/src/e2e/data/deviceLabelsData.ts
@@ -143,6 +143,7 @@ export const DEVICE_LABELS_CONFIG: DeviceLabelsConfig = {
       [AppInfos.ETHEREUM.name]: DeviceLabels.CONFIRM,
       [AppInfos.POLKADOT.name]: DeviceLabels.CAPS_APPROVE,
       [AppInfos.POLYGON.name]: DeviceLabels.CONFIRM,
+      [AppInfos.RIPPLE.name]: DeviceLabels.CONFIRM,
       [AppInfos.SOLANA.name]: DeviceLabels.CONFIRM,
       [AppInfos.ZCASH.name]: DeviceLabels.CONFIRM,
       [AppInfos.SUI.name]: DeviceLabels.CONFIRM,

--- a/libs/ledger-live-common/src/e2e/data/deviceLabelsData.ts
+++ b/libs/ledger-live-common/src/e2e/data/deviceLabelsData.ts
@@ -170,7 +170,6 @@ export const DEVICE_LABELS_CONFIG: DeviceLabelsConfig = {
     },
     sendVerify: {
       [AppInfos.SOLANA.name]: DeviceLabels.REVIEW_TRANSACTION_TO,
-      [AppInfos.RIPPLE.name]: DeviceLabels.TRANSACTION_TYPE,
       default: DeviceLabels.REVIEW_OPERATION,
     },
     sendConfirm: {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached. _N/A — e2e device-label fix in `@ledgerhq/live-common/src/e2e`; per repo convention these don't ship a changeset (see precedent `fix(e2e): drop stale Concordium nano verify label`)._
- [x] **Covered by automatic tests.** _These are e2e fixes. Verified locally on iOS: `sendXRP` passes; `verifyAddressXRP` now clears the device-confirmation step. CI E2E runs dispatched on this branch — see **CI validation** below._
- [x] **Impact of the changes:**
  - XRP (Ripple) **send** signing and **receive** address verification on Speculos — the device-screen labels used by the shared e2e flow (`getSendEvents` / `expectValidAddressDevice` → `getDeviceLabels`), consumed by **both** Mobile (`e2e/mobile`) and Desktop (`e2e/desktop`) Speculos specs.

### 📝 Description

The XRP (Ripple) Speculos app's review/confirmation flow changed, breaking two e2e device-label expectations in the `default` (nanoX / nanoSP) device config:

**1. Send** — the first signing screen is now **"Review transaction"** instead of **"Transaction Type"**:
```
Text "Transaction Type" not found on device screen … Last screen text: "Review transaction"
```
Fix: drop the stale `RIPPLE → TRANSACTION_TYPE` `sendVerify` override so it falls back to `default: REVIEW_OPERATION` (`"Review"`), which substring-matches `"Review transaction"`.

**2. Receive** — the address-confirmation button is now **"Confirm"** instead of **"Approve"**:
```
Element with text "Approve" not found on speculos screen.
Screens: [1] "Verify XRP Address" → [2] "Address rG8…" → [3] "Confirm" → [4] "Cancel"
```
Fix: add a `RIPPLE → CONFIRM` `receiveConfirm` override.

```diff
// libs/ledger-live-common/src/e2e/data/deviceLabelsData.ts (default config)
     receiveConfirm: {
       ...
       [AppInfos.POLYGON.name]: DeviceLabels.CONFIRM,
+      [AppInfos.RIPPLE.name]: DeviceLabels.CONFIRM,
       [AppInfos.SOLANA.name]: DeviceLabels.CONFIRM,
       ...
     },
     sendVerify: {
       [AppInfos.SOLANA.name]: DeviceLabels.REVIEW_TRANSACTION_TO,
-      [AppInfos.RIPPLE.name]: DeviceLabels.TRANSACTION_TYPE,
       default: DeviceLabels.REVIEW_OPERATION,
     },
```

> **Scope note:** only the `default` config (nanoX / nanoSP) is changed — same scoping as the Concordium precedent. The `nanoS` config keeps its own entries; if a `@LNS` run later shows the same symptom, the nanoS entries need the equivalent update.

### 🧪 CI validation

Manually dispatched on `support/fix-xrp-send-device-label` (commit `e2697b1387`), filtered to `@family-xrp`:

| Workflow | Scope | Run |
|---|---|---|
| Desktop E2E | `@family-xrp`, Speculos nanoSP | [run 28447138822](https://github.com/LedgerHQ/ledger-live/actions/runs/28447138822) |
| Mobile E2E | `@family-xrp`, iOS & Android, nanoSP | [run 28447141301](https://github.com/LedgerHQ/ledger-live/actions/runs/28447141301) |

### ❓ Context

- **JIRA or GitHub link**: _N/A — standalone E2E test maintenance fix (XRP app review-flow change)._

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)