### PR TITLE
[LWD] refactor(desktop): remove wallet 4.0 graph and balance rework flags

### DIFF
--- a/.changeset/orange-ads-build.md
+++ b/.changeset/orange-ads-build.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Remove the temporary Wallet 4.0 `graphRework` and `balanceRefreshRework` feature-flag gating on the portfolio. The reworked balance graph, balance refresh animation and two-decimal value-change percentage are now always on, and the related `shouldDisplayGraphRework` / `shouldDisplayBalanceRefreshRework` props and config reads have been dropped.

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/__integrations__/Analytics.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/__integrations__/Analytics.test.tsx
@@ -50,7 +50,6 @@ const defaultViewModel = {
   balanceInfo: mockPortfolioBalanceInfo,
   portfolio: defaultPortfolio,
   isLoading: false,
-  shouldDisplayBalanceRefreshRework: false,
   shouldDisplayPnl: false,
 };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/__tests__/useAnalyticsViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/__tests__/useAnalyticsViewModel.test.ts
@@ -28,7 +28,6 @@ describe("useAnalyticsViewModel", () => {
         countervalueChange: { percentage: 0.2, value: 200 },
       },
       isLoading: false,
-      shouldDisplayBalanceRefreshRework: false,
     } as ReturnType<typeof usePortfolioBalanceDisplayStateModule.usePortfolioBalanceDisplayState>);
   });
 
@@ -39,7 +38,7 @@ describe("useAnalyticsViewModel", () => {
     const { result } = renderHook(() => useAnalyticsViewModel(), {
       initialState: {
         ...withFlagOverrides({
-          lwdWallet40: { enabled: true, params: { graphRework: true, pnl: true } },
+          lwdWallet40: { enabled: true, params: { pnl: true } },
         }),
         settings: {
           ...INITIAL_STATE,
@@ -51,7 +50,6 @@ describe("useAnalyticsViewModel", () => {
 
     expect(result.current.counterValue).toBe(getFiatCurrencyByTicker("USD"));
     expect(result.current.selectedTimeRange).toBe("day");
-    expect(result.current.shouldDisplayGraphRework).toBe(true);
     expect(result.current.shouldDisplayPnl).toBe(false);
     expect(result.current.balanceInfo.valueChange).toEqual({ percentage: 0.2, value: 200 });
     expect(result.current.portfolio.countervalueChange).toEqual({ percentage: 0.2, value: 200 });
@@ -74,12 +72,11 @@ describe("useAnalyticsViewModel", () => {
         countervalueChange: { percentage: 0.08, value: 80 },
       },
       isLoading: false,
-      shouldDisplayBalanceRefreshRework: false,
     } as ReturnType<typeof usePortfolioBalanceDisplayStateModule.usePortfolioBalanceDisplayState>);
 
     const { result } = renderHook(() => useAnalyticsViewModel(), {
       initialState: {
-        ...withFlagOverrides({ lwdWallet40: { enabled: true, params: { graphRework: true } } }),
+        ...withFlagOverrides({ lwdWallet40: { enabled: true } }),
         settings: {
           ...INITIAL_STATE,
           counterValue: "USD",

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/ChartSectionHeaderView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/ChartSectionHeaderView.tsx
@@ -12,7 +12,6 @@ export function ChartSectionHeaderView({ viewModel }: ChartSectionHeaderViewProp
     balance,
     balanceAvailable,
     isLoading,
-    shouldDisplayBalanceRefreshRework,
     balanceFormatter,
     discreet,
     percentageValue,
@@ -27,7 +26,7 @@ export function ChartSectionHeaderView({ viewModel }: ChartSectionHeaderViewProp
           value={balance}
           formatter={balanceFormatter}
           hidden={discreet}
-          loading={shouldDisplayBalanceRefreshRework && isLoading}
+          loading={isLoading}
           data-testid="analytics-balance-amount"
         />
       ) : (

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/__tests__/ChartSectionHeaderView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/__tests__/ChartSectionHeaderView.test.tsx
@@ -8,7 +8,6 @@ const baseViewModel: ChartSectionHeaderViewModel = {
   balance: mockPortfolioBalanceInfo.totalBalance,
   balanceAvailable: true,
   isLoading: false,
-  shouldDisplayBalanceRefreshRework: true,
   balanceFormatter: value => ({
     currencyText: "$",
     decimalSeparator: ".",

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/__tests__/useChartSectionHeaderViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/__tests__/useChartSectionHeaderViewModel.test.ts
@@ -14,7 +14,6 @@ describe("useChartSectionHeaderViewModel", () => {
           },
           hoveredBalance: null,
           isLoading: false,
-          shouldDisplayBalanceRefreshRework: true,
         }),
       { initialState: chartSectionHeaderInitialState },
     );
@@ -31,7 +30,6 @@ describe("useChartSectionHeaderViewModel", () => {
           balanceInfo: mockPortfolioBalanceInfo,
           hoveredBalance: 1000,
           isLoading: false,
-          shouldDisplayBalanceRefreshRework: true,
         }),
       { initialState: chartSectionHeaderInitialState },
     );
@@ -46,7 +44,6 @@ describe("useChartSectionHeaderViewModel", () => {
           balanceInfo: mockPortfolioBalanceInfo,
           hoveredBalance: null,
           isLoading: true,
-          shouldDisplayBalanceRefreshRework: true,
         }),
       { initialState: chartSectionHeaderInitialState },
     );

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/index.tsx
@@ -9,20 +9,17 @@ type ChartSectionHeaderProps = Readonly<{
   balanceInfo: PortfolioBalanceInfo;
   hoveredBalance: number | null;
   isLoading: boolean;
-  shouldDisplayBalanceRefreshRework: boolean;
 }>;
 
 export function ChartSectionHeader({
   balanceInfo,
   hoveredBalance,
   isLoading,
-  shouldDisplayBalanceRefreshRework,
 }: ChartSectionHeaderProps) {
   const viewModel = useChartSectionHeaderViewModel({
     balanceInfo,
     hoveredBalance,
     isLoading,
-    shouldDisplayBalanceRefreshRework,
   });
   return <ChartSectionHeaderView viewModel={viewModel} />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/types.ts
@@ -4,7 +4,6 @@ export type ChartSectionHeaderViewModel = Readonly<{
   balance: number;
   balanceAvailable: boolean;
   isLoading: boolean;
-  shouldDisplayBalanceRefreshRework: boolean;
   balanceFormatter: (value: number) => FormattedValue;
   discreet: boolean;
   percentageValue: number;

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/useChartSectionHeaderViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/useChartSectionHeaderViewModel.ts
@@ -18,14 +18,12 @@ type UseChartSectionHeaderViewModelProps = Readonly<{
   balanceInfo: PortfolioBalanceInfo;
   hoveredBalance: number | null;
   isLoading: boolean;
-  shouldDisplayBalanceRefreshRework: boolean;
 }>;
 
 export function useChartSectionHeaderViewModel({
   balanceInfo,
   hoveredBalance,
   isLoading,
-  shouldDisplayBalanceRefreshRework,
 }: UseChartSectionHeaderViewModelProps): ChartSectionHeaderViewModel {
   const { t } = useTranslation();
   const selectedTimeRange = useSelector(selectedTimeRangeSelector);
@@ -58,7 +56,6 @@ export function useChartSectionHeaderViewModel({
     balance,
     balanceAvailable: balanceInfo.isAvailable,
     isLoading,
-    shouldDisplayBalanceRefreshRework,
     balanceFormatter,
     discreet,
     percentageValue,

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionView.tsx
@@ -8,8 +8,7 @@ type ChartSectionViewProps = Readonly<{
 }>;
 
 export function ChartSectionView({ viewModel }: ChartSectionViewProps) {
-  const { balanceInfo, hoveredBalance, chart, isLoading, shouldDisplayBalanceRefreshRework } =
-    viewModel;
+  const { balanceInfo, hoveredBalance, chart, isLoading } = viewModel;
 
   return (
     <div className="flex flex-col gap-24" data-testid="analytics-chart-section">
@@ -17,7 +16,6 @@ export function ChartSectionView({ viewModel }: ChartSectionViewProps) {
         balanceInfo={balanceInfo}
         hoveredBalance={hoveredBalance}
         isLoading={isLoading}
-        shouldDisplayBalanceRefreshRework={shouldDisplayBalanceRefreshRework}
       />
       <LineChart {...chart} />
     </div>

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/__tests__/ChartSection.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/__tests__/ChartSection.test.tsx
@@ -23,7 +23,6 @@ describe("ChartSection", () => {
         balanceInfo={mockPortfolioBalanceInfo}
         portfolio={portfolioWithHistory}
         isLoading={false}
-        shouldDisplayBalanceRefreshRework={false}
       />,
       { initialState: chartSectionInitialState },
     );
@@ -41,7 +40,6 @@ describe("ChartSection", () => {
         balanceInfo={{ ...mockPortfolioBalanceInfo, isAvailable: false }}
         portfolio={portfolioWithHistory}
         isLoading={false}
-        shouldDisplayBalanceRefreshRework={false}
       />,
       { initialState: chartSectionInitialState },
     );

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/__tests__/useChartSectionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/__tests__/useChartSectionViewModel.test.ts
@@ -22,7 +22,6 @@ describe("useChartSectionViewModel", () => {
           balanceInfo: mockPortfolioBalanceInfo,
           portfolio: portfolioWithHistory,
           isLoading: false,
-          shouldDisplayBalanceRefreshRework: false,
         }),
       { initialState: chartSectionInitialState },
     );
@@ -40,7 +39,6 @@ describe("useChartSectionViewModel", () => {
           balanceInfo: { ...mockPortfolioBalanceInfo, isAvailable: false },
           portfolio: portfolioWithHistory,
           isLoading: true,
-          shouldDisplayBalanceRefreshRework: true,
         }),
       { initialState: chartSectionInitialState },
     );
@@ -55,7 +53,6 @@ describe("useChartSectionViewModel", () => {
           balanceInfo: mockPortfolioBalanceInfo,
           portfolio: portfolioWithHistory,
           isLoading: false,
-          shouldDisplayBalanceRefreshRework: false,
         }),
       { initialState: chartSectionInitialState },
     );
@@ -75,7 +72,6 @@ describe("useChartSectionViewModel", () => {
           balanceInfo: mockPortfolioBalanceInfo,
           portfolio: portfolioWithHistory,
           isLoading: false,
-          shouldDisplayBalanceRefreshRework: false,
         }),
       {
         initialState: {
@@ -94,7 +90,6 @@ describe("useChartSectionViewModel", () => {
           balanceInfo: mockPortfolioBalanceInfo,
           portfolio: portfolioWithHistory,
           isLoading: false,
-          shouldDisplayBalanceRefreshRework: false,
         }),
       { initialState: chartSectionInitialState },
     );

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/index.tsx
@@ -8,7 +8,6 @@ type ChartSectionProps = Readonly<{
   balanceInfo: PortfolioBalanceInfo;
   portfolio: Portfolio;
   isLoading: boolean;
-  shouldDisplayBalanceRefreshRework: boolean;
 }>;
 
 export function ChartSection(props: ChartSectionProps) {

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/useChartSectionViewModel.ts
@@ -37,14 +37,12 @@ type UseChartSectionViewModelProps = Readonly<{
   balanceInfo: PortfolioBalanceInfo;
   portfolio: Portfolio;
   isLoading: boolean;
-  shouldDisplayBalanceRefreshRework: boolean;
 }>;
 
 export type ChartSectionViewModelResult = Readonly<{
   balanceInfo: PortfolioBalanceInfo;
   hoveredBalance: number | null;
   isLoading: boolean;
-  shouldDisplayBalanceRefreshRework: boolean;
   chart: LineChartProps;
 }>;
 
@@ -52,7 +50,6 @@ export function useChartSectionViewModel({
   balanceInfo,
   portfolio,
   isLoading,
-  shouldDisplayBalanceRefreshRework,
 }: UseChartSectionViewModelProps): ChartSectionViewModelResult {
   const { t } = useTranslation();
   const dispatch = useDispatch();
@@ -140,7 +137,6 @@ export function useChartSectionViewModel({
     balanceInfo,
     hoveredBalance,
     isLoading,
-    shouldDisplayBalanceRefreshRework,
     chart: {
       series,
       selectedRange,

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
@@ -21,13 +21,11 @@ function AnalyticsView({ viewModel }: { readonly viewModel: AnalyticsViewModel }
     counterValue,
     selectedTimeRange,
     navigateToDashboard,
-    shouldDisplayGraphRework,
     shouldDisplayAssetSection,
     shouldDisplayPnl,
     balanceInfo,
     portfolio,
     isLoading,
-    shouldDisplayBalanceRefreshRework,
   } = viewModel;
 
   const { t } = useTranslation();
@@ -42,19 +40,13 @@ function AnalyticsView({ viewModel }: { readonly viewModel: AnalyticsViewModel }
         data-testid="analytics-chart"
       >
         {shouldDisplayPnl ? (
-          <ChartSection
-            balanceInfo={balanceInfo}
-            portfolio={portfolio}
-            isLoading={isLoading}
-            shouldDisplayBalanceRefreshRework={shouldDisplayBalanceRefreshRework}
-          />
+          <ChartSection balanceInfo={balanceInfo} portfolio={portfolio} isLoading={isLoading} />
         ) : (
           <PortfolioBalanceSummary
             counterValue={counterValue}
             chartColor={colors.wallet}
             range={selectedTimeRange}
             isWallet40
-            shouldDisplayGraphRework={shouldDisplayGraphRework}
             balanceInfo={balanceInfo}
           />
         )}

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/types.ts
@@ -22,8 +22,6 @@ export type AnalyticsViewModel = {
   balanceInfo: PortfolioBalanceInfo;
   portfolio: Portfolio;
   isLoading: boolean;
-  shouldDisplayBalanceRefreshRework: boolean;
-  shouldDisplayGraphRework?: boolean;
   shouldDisplayAssetSection?: boolean;
   shouldDisplayPnl: boolean;
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/useAnalyticsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/useAnalyticsViewModel.ts
@@ -18,16 +18,12 @@ export default function useAnalyticsViewModel(): AnalyticsViewModel {
   const selectedTimeRange = useSelector(selectedTimeRangeSelector);
   const accounts = useSelector(accountsSelector);
   const cvState = useCountervaluesState();
-  const {
-    shouldDisplayGraphRework,
-    shouldDisplayAssetSection,
-    shouldDisplayPnl: isPnlFlagOn,
-  } = useWalletFeaturesConfig("desktop");
+  const { shouldDisplayAssetSection, shouldDisplayPnl: isPnlFlagOn } =
+    useWalletFeaturesConfig("desktop");
   const {
     balanceInfo: syncBalanceInfo,
     portfolio,
     isLoading,
-    shouldDisplayBalanceRefreshRework,
   } = usePortfolioBalanceDisplayState({ legacyRange: true });
 
   const shouldDisplayPnl = isPnlFlagOn && accounts.length > 0;
@@ -64,8 +60,6 @@ export default function useAnalyticsViewModel(): AnalyticsViewModel {
     balanceInfo,
     portfolio,
     isLoading,
-    shouldDisplayBalanceRefreshRework,
-    shouldDisplayGraphRework,
     shouldDisplayAssetSection,
     shouldDisplayPnl,
   };

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
@@ -25,7 +25,6 @@ export const PortfolioView = memo(function PortfolioView({
   totalOperations,
   totalCurrencies,
   hasExchangeBannerCTA,
-  shouldDisplayGraphRework,
   shouldDisplayAssetSection,
   shouldDisplayAssetDiscoverability,
   shouldDisplayBorrowSection,
@@ -58,7 +57,7 @@ export const PortfolioView = memo(function PortfolioView({
         <div className="flex flex-1 flex-col gap-32 pb-32">
           <div className="flex flex-col gap-24">
             <PageHeader title={t("portfolio.title")} />
-            {shouldDisplayGraphRework && <Balance />}
+            <Balance />
 
             <QuickActions trackingPageName={PORTFOLIO_TRACKING_PAGE_NAME} />
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -165,7 +165,6 @@ describe("PortfolioView", () => {
     totalOperations: 10,
     totalCurrencies: 3,
     hasExchangeBannerCTA: true,
-    shouldDisplayGraphRework: true,
     shouldDisplayAssetSection: true,
     shouldDisplayAssetDiscoverability: false,
     shouldDisplayOperationsList: true,
@@ -198,8 +197,8 @@ describe("PortfolioView", () => {
   });
 
   describe("Balance", () => {
-    it("should render Balance with total balance when shouldDisplayGraphRework is true", () => {
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+    it("should render Balance with total balance", () => {
+      render(<PortfolioView {...defaultProps} />, {
         initialState: {
           accounts: [BTC_ACCOUNT],
           settings: AFTER_ONBOARDING_STATE,
@@ -210,13 +209,8 @@ describe("PortfolioView", () => {
       expect(screen.getByTestId("portfolio-total-balance")).toBeVisible();
     });
 
-    it("should not render Balance when shouldDisplayGraphRework is false", () => {
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={false} />);
-      expect(screen.queryByTestId("portfolio-balance")).toBeNull();
-    });
-
     it("should navigate to analytics when clicking on balance", async () => {
-      const { user } = render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />, {
+      const { user } = render(<PortfolioView {...defaultProps} />, {
         initialState: {
           accounts: [BTC_ACCOUNT],
           settings: AFTER_ONBOARDING_STATE,
@@ -229,7 +223,7 @@ describe("PortfolioView", () => {
     });
 
     it("should render NoBalanceView when user has no accounts", () => {
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+      render(<PortfolioView {...defaultProps} />, {
         initialState: {
           accounts: [],
           settings: AFTER_ONBOARDING_STATE,
@@ -241,7 +235,7 @@ describe("PortfolioView", () => {
     });
 
     it("should render BalanceView when user has accounts but no funds", () => {
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+      render(<PortfolioView {...defaultProps} />, {
         initialState: {
           accounts: [EMPTY_BTC_ACCOUNT],
           settings: AFTER_ONBOARDING_STATE,
@@ -252,7 +246,7 @@ describe("PortfolioView", () => {
     });
 
     it("should render NoDeviceView when no device has been onboarded", () => {
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+      render(<PortfolioView {...defaultProps} />, {
         initialState: {
           accounts: [],
           settings: {
@@ -268,7 +262,7 @@ describe("PortfolioView", () => {
     });
 
     it("should render NoDeviceView when user completed lazy onboarding without a device", () => {
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+      render(<PortfolioView {...defaultProps} />, {
         initialState: {
           accounts: [],
           settings: {
@@ -282,7 +276,7 @@ describe("PortfolioView", () => {
       expect(screen.queryByTestId("portfolio-balance")).toBeNull();
     });
     it("should display discreet placeholders when discreet mode is enabled", () => {
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+      render(<PortfolioView {...defaultProps} />, {
         initialState: {
           accounts: [BTC_ACCOUNT],
           settings: {
@@ -298,7 +292,7 @@ describe("PortfolioView", () => {
     });
 
     it("should render Balance with total balance and show actual amount when discreet mode is disabled", () => {
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+      render(<PortfolioView {...defaultProps} />, {
         initialState: {
           accounts: [BTC_ACCOUNT],
           settings: {
@@ -322,7 +316,7 @@ describe("PortfolioView", () => {
         pending: true,
       });
 
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+      render(<PortfolioView {...defaultProps} />, {
         initialState: {
           accounts: [BTC_ACCOUNT],
           settings: {
@@ -347,7 +341,7 @@ describe("PortfolioView", () => {
         balanceHistory: [],
       });
 
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+      render(<PortfolioView {...defaultProps} />, {
         initialState: {
           accounts: [BTC_ACCOUNT],
           settings: {
@@ -374,7 +368,7 @@ describe("PortfolioView", () => {
         createPortfolioMock({ percentage: 0.0542, value: 5000 }),
       );
 
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />, {
+      render(<PortfolioView {...defaultProps} />, {
         initialState: {
           accounts: [BTC_ACCOUNT],
           settings: AFTER_ONBOARDING_STATE,
@@ -391,7 +385,7 @@ describe("PortfolioView", () => {
         createPortfolioMock({ percentage: -0.0315, value: -3000 }),
       );
 
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />, {
+      render(<PortfolioView {...defaultProps} />, {
         initialState: {
           accounts: [BTC_ACCOUNT],
           settings: AFTER_ONBOARDING_STATE,
@@ -405,7 +399,7 @@ describe("PortfolioView", () => {
     it("should show 0% when percentage is zero", () => {
       mockUsePortfolioThrottled.mockReturnValue(createPortfolioMock({ percentage: 0, value: 0 }));
 
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />, {
+      render(<PortfolioView {...defaultProps} />, {
         initialState: {
           accounts: [BTC_ACCOUNT],
           settings: AFTER_ONBOARDING_STATE,
@@ -416,12 +410,6 @@ describe("PortfolioView", () => {
       expect(screen.getByTestId("portfolio-trend-percentage")).toBeVisible();
       expect(screen.getByText("0.00%")).toBeVisible();
       expect(screen.getByText(/today/i)).toBeVisible();
-    });
-
-    it("should not render Trend when shouldDisplayGraphRework is false", () => {
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={false} />);
-
-      expect(screen.queryByTestId("portfolio-trend")).toBeNull();
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/BalanceView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/BalanceView.tsx
@@ -15,16 +15,12 @@ export const BalanceView = ({
   navigateToAnalytics,
   handleKeyDown,
   isLoading,
-  shouldDisplayBalanceRefreshRework,
   theme,
 }: BalanceViewProps) => {
   return (
     <button
       type="button"
-      className={cn(
-        "flex cursor-pointer border-0 bg-transparent p-0 text-inherit",
-        shouldDisplayBalanceRefreshRework && "group",
-      )}
+      className={cn("flex cursor-pointer border-0 bg-transparent p-0 text-inherit", "group")}
       data-testid="portfolio-balance"
       onClick={navigateToAnalytics}
       onKeyDown={handleKeyDown}
@@ -44,8 +40,8 @@ export const BalanceView = ({
             value={balance}
             formatter={formatter}
             hidden={discreet}
-            animate={shouldDisplayBalanceRefreshRework}
-            loading={shouldDisplayBalanceRefreshRework && isLoading}
+            animate
+            loading={isLoading}
             data-testid="portfolio-total-balance"
           />
         )}

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
@@ -11,7 +11,6 @@ export interface BalanceViewProps {
   readonly handleKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
   readonly isColdStart: boolean;
   readonly isLoading: boolean;
-  readonly shouldDisplayBalanceRefreshRework: boolean;
   readonly theme: "light" | "dark";
 }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBalanceViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBalanceViewModel.test.ts
@@ -52,7 +52,6 @@ describe("useBalanceViewModel", () => {
     expect(result.current.formatter(result.current.balance).integerPart).toContain("15");
     expect(result.current.valueChange).toEqual(portfolioWithBalance.countervalueChange);
     expect(result.current.isColdStart).toBe(false);
-    expect(result.current.shouldDisplayBalanceRefreshRework).toBe(true);
     expect(result.current.hasAccount).toBeDefined();
     expect(result.current.hasOnboardedDevice).toBeDefined();
   });
@@ -198,20 +197,5 @@ describe("useBalanceViewModel", () => {
     );
     rerender();
     expect(result.current.balanceAvailable).toBe(true);
-  });
-
-  it("should return shouldDisplayBalanceRefreshRework false when flag is disabled", () => {
-    const { result } = renderHook(() => useBalanceViewModel(), {
-      initialState: {
-        settings: {
-          ...initialState.settings,
-        },
-        ...withFlagOverrides({
-          lwdWallet40: { enabled: true, params: { balanceRefreshRework: false } },
-        }),
-      },
-    });
-
-    expect(result.current.shouldDisplayBalanceRefreshRework).toBe(false);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/usePortfolioViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/usePortfolioViewModel.test.ts
@@ -92,7 +92,6 @@ describe("usePortfolioViewModel", () => {
     });
 
     expect(result.current.hasExchangeBannerCTA).toBe(true);
-    expect(result.current.shouldDisplayGraphRework).toBe(true);
     expect(result.current.isWallet40Enabled).toBe(true);
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
@@ -31,15 +31,8 @@ export const useBalanceViewModel = (
   const theme = useSelector(themeSelector);
   const { hasAccount } = useAccountStatus();
 
-  const {
-    counterValue,
-    displayedBalance,
-    balanceAvailable,
-    isLoading,
-    isColdStart,
-    valueChange,
-    shouldDisplayBalanceRefreshRework,
-  } = usePortfolioBalanceDisplayState(options);
+  const { counterValue, displayedBalance, balanceAvailable, isLoading, isColdStart, valueChange } =
+    usePortfolioBalanceDisplayState(options);
 
   const unit = counterValue.units[0];
 
@@ -82,7 +75,6 @@ export const useBalanceViewModel = (
     hasAccount,
     hasOnboardedDevice,
     isColdStart,
-    shouldDisplayBalanceRefreshRework,
     isLoading,
     theme,
   };

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/usePortfolioViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/usePortfolioViewModel.ts
@@ -18,7 +18,6 @@ export interface PortfolioViewModelResult {
   readonly totalOperations: number;
   readonly totalCurrencies: number;
   readonly hasExchangeBannerCTA: boolean;
-  readonly shouldDisplayGraphRework: boolean;
   readonly shouldDisplayAssetSection: boolean;
   readonly shouldDisplayAssetDiscoverability: boolean;
   readonly shouldDisplayBorrowSection: boolean;
@@ -39,7 +38,6 @@ export const usePortfolioViewModel = (): PortfolioViewModelResult => {
   useResumeAddAccountAfterOnboarding();
 
   const {
-    shouldDisplayGraphRework,
     shouldDisplayAssetSection,
     shouldDisplayAssetDiscoverability,
     shouldDisplayOperationsList,
@@ -86,7 +84,6 @@ export const usePortfolioViewModel = (): PortfolioViewModelResult => {
     totalOperations,
     totalCurrencies,
     hasExchangeBannerCTA,
-    shouldDisplayGraphRework,
     shouldDisplayAssetSection,
     shouldDisplayAssetDiscoverability,
     shouldDisplayBorrowSection,

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useResetTimeRangeOnGraphRework.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useResetTimeRangeOnGraphRework.test.ts
@@ -2,41 +2,15 @@ import { renderHook } from "tests/testSetup";
 import createStore from "~/state-manager/configureStore";
 import { setSelectedTimeRange } from "~/renderer/actions/settings";
 import { selectedTimeRangeSelector } from "~/renderer/reducers/settings";
-import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { useResetTimeRangeOnGraphRework } from "../useResetTimeRangeOnGraphRework";
-
-// Mock only useWalletFeaturesConfig — testSetup renders the hook under the real Providers/store,
-// so the rest of @features/platform-feature-flags must stay real.
-jest.mock("@features/platform-feature-flags", () => ({
-  ...jest.requireActual("@features/platform-feature-flags"),
-  useWalletFeaturesConfig: jest.fn(),
-}));
-
-const mockUseWalletFeaturesConfig = jest.mocked(useWalletFeaturesConfig);
-
-function configWith(shouldDisplayGraphRework: boolean) {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  return { shouldDisplayGraphRework } as ReturnType<typeof useWalletFeaturesConfig>;
-}
 
 describe("useResetTimeRangeOnGraphRework", () => {
   it("resets the selected time range to 'day' when the graph rework is enabled", () => {
-    mockUseWalletFeaturesConfig.mockReturnValue(configWith(true));
     const store = createStore({ fetchRemoteFlags: null });
     store.dispatch(setSelectedTimeRange("week"));
 
     renderHook(() => useResetTimeRangeOnGraphRework(), { store });
 
     expect(selectedTimeRangeSelector(store.getState())).toBe("day");
-  });
-
-  it("leaves the selected time range unchanged when the graph rework is disabled", () => {
-    mockUseWalletFeaturesConfig.mockReturnValue(configWith(false));
-    const store = createStore({ fetchRemoteFlags: null });
-    store.dispatch(setSelectedTimeRange("week"));
-
-    renderHook(() => useResetTimeRangeOnGraphRework(), { store });
-
-    expect(selectedTimeRangeSelector(store.getState())).toBe("week");
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/hooks/usePortfolioBalanceDisplayState.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/usePortfolioBalanceDisplayState.ts
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 import { useBalanceSyncState } from "@ledgerhq/live-common/bridge/react/index";
 import type { SyncPhase } from "@ledgerhq/live-common/bridge/react/useSyncLifecycle";
-import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import type { Currency } from "@ledgerhq/types-cryptoassets";
 import type { Portfolio, ValueChange } from "@ledgerhq/types-live";
 import { usePortfolioBalance } from "LLD/hooks/usePortfolioBalance";
@@ -27,13 +26,11 @@ export interface PortfolioBalanceDisplayState {
   readonly syncPhase: SyncPhase;
   readonly valueChange: ValueChange;
   readonly balanceInfo: PortfolioBalanceInfo;
-  readonly shouldDisplayBalanceRefreshRework: boolean;
 }
 
 export function usePortfolioBalanceDisplayState(
   options: UsePortfolioBalanceDisplayStateOptions = {},
 ): PortfolioBalanceDisplayState {
-  const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("desktop");
   const {
     portfolio,
     counterValue,
@@ -50,8 +47,8 @@ export function usePortfolioBalanceDisplayState(
     rawBalanceAvailable,
     syncPhase,
     latestBalance: latestBalanceValue,
-    shouldFreezeOnSync: shouldDisplayBalanceRefreshRework,
-    cvPending: shouldDisplayBalanceRefreshRework ? isCvPending : undefined,
+    shouldFreezeOnSync: true,
+    cvPending: isCvPending,
   });
 
   const valueChange = portfolio.countervalueChange;
@@ -76,7 +73,6 @@ export function usePortfolioBalanceDisplayState(
       syncPhase,
       valueChange,
       balanceInfo,
-      shouldDisplayBalanceRefreshRework,
     }),
     [
       portfolio,
@@ -89,7 +85,6 @@ export function usePortfolioBalanceDisplayState(
       syncPhase,
       valueChange,
       balanceInfo,
-      shouldDisplayBalanceRefreshRework,
     ],
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useResetTimeRangeOnGraphRework.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useResetTimeRangeOnGraphRework.ts
@@ -1,21 +1,19 @@
 import { useEffect, useRef } from "react";
 import { useDispatch } from "LLD/hooks/redux";
-import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { setSelectedTimeRange } from "~/renderer/actions/settings";
 
 /**
- * Wallet 4.0 graph rework: reset the selected time range to "day" once per launch when the
- * rework is enabled. Temporary until wallet 4.0 is 100% enabled.
+ * Reset the selected time range to "day" once per launch when the
+ * rework is enabled.
  */
 export function useResetTimeRangeOnGraphRework(): void {
   const dispatch = useDispatch();
-  const { shouldDisplayGraphRework } = useWalletFeaturesConfig("desktop");
   const hasReset = useRef(false);
 
   useEffect(() => {
-    if (shouldDisplayGraphRework && !hasReset.current) {
+    if (!hasReset.current) {
       hasReset.current = true;
       dispatch(setSelectedTimeRange("day"));
     }
-  }, [shouldDisplayGraphRework, dispatch]);
+  }, [dispatch]);
 }

--- a/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.tsx
@@ -40,15 +40,8 @@ type BalanceTotalProps = {
 type Props = {
   unit: Unit;
   counterValueId?: string;
-  shouldDisplayGraphRework?: boolean;
 } & BalanceSinceProps;
-export function BalanceDiff({
-  valueChange,
-  unit,
-  isAvailable,
-  shouldDisplayGraphRework,
-  ...boxProps
-}: Props) {
+export function BalanceDiff({ valueChange, unit, isAvailable, ...boxProps }: Props) {
   if (!isAvailable) return null;
   return (
     <Box horizontal {...boxProps}>
@@ -65,14 +58,10 @@ export function BalanceDiff({
           <FormattedVal
             isPercent
             animateTicker
-            val={
-              shouldDisplayGraphRework
-                ? valueChange.percentage * 100
-                : Math.round(valueChange.percentage * 100)
-            }
+            val={valueChange.percentage * 100}
             inline
             withIcon
-            percentageTwoDecimals={shouldDisplayGraphRework}
+            percentageTwoDecimals
           />
         )}
         {valueChange.value === 0 ? (
@@ -139,7 +128,6 @@ export default function BalanceInfos({
   isAvailable,
   unit,
   counterValueId,
-  shouldDisplayGraphRework,
 }: Props) {
   const swapDefaultTrack = useGetSwapTrackingProperties();
   const { t } = useTranslation();
@@ -235,7 +223,6 @@ export default function BalanceInfos({
         valueChange={valueChange}
         unit={unit}
         isAvailable={isAvailable}
-        shouldDisplayGraphRework={shouldDisplayGraphRework}
       />
     </Box>
   );

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/GlobalSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/GlobalSummary.tsx
@@ -19,7 +19,6 @@ type Props = {
   chartColor: string;
   range: PortfolioRange;
   isWallet40?: boolean;
-  shouldDisplayGraphRework?: boolean;
   balanceInfo?: PortfolioBalanceInfo;
 };
 export default function PortfolioBalanceSummary({
@@ -27,7 +26,6 @@ export default function PortfolioBalanceSummary({
   chartColor,
   counterValue,
   isWallet40,
-  shouldDisplayGraphRework,
   balanceInfo,
 }: Props) {
   const portfolio = usePortfolio();
@@ -78,7 +76,6 @@ export default function PortfolioBalanceSummary({
           isAvailable={displayBalanceInfo.isAvailable}
           valueChange={displayBalanceInfo.valueChange}
           totalBalance={displayBalanceInfo.totalBalance}
-          shouldDisplayGraphRework={shouldDisplayGraphRework}
         />
       </Box>
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio balance graph rendering (now always uses the reworked graph)
      - Balance refresh behavior on sync (freeze-on-sync + animation always on)
      - Value-change percentage formatting (now always two decimals)
      - Analytics screen balance summary
      - Time range reset on launch

### 📝 Description

The Wallet 4.0 portfolio rework was rolled out behind the temporary `graphRework` and `balanceRefreshRework` parameters of the `lwdWallet40` feature flag. Now that the rework is fully enabled, the conditional gating is dead weight that complicates the portfolio code and tests.

This PR removes the `shouldDisplayGraphRework` and `shouldDisplayBalanceRefreshRework` flag reads, props and branches across the Portfolio and Analytics features. The reworked balance graph, the balance refresh animation (freeze-on-sync + countervalue pending) and the two-decimal value-change percentage are now always on. The `useResetTimeRangeOnGraphRework` hook no longer depends on the flag and always resets the range once per launch. Tests are updated to drop the flag-driven cases.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33502](https://ledgerhq.atlassian.net/browse/LIVE-33502)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33502]: https://ledgerhq.atlassian.net/browse/LIVE-33502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ