### PR TITLE
fix: override feature flag to not use the new send flowfor now

### DIFF
--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -13,6 +13,7 @@ import {
 } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 import { Addresses } from "@ledgerhq/live-common/e2e/enum/Addresses";
 import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
+import { FF_NEW_SEND_FLOW_DISABLED } from "tests/utils/featureFlagUtils";
 
 const transactionsAmountInvalid = [
   {
@@ -267,6 +268,9 @@ test.describe("Send flows", () => {
         userdata: "skip-onboarding-with-last-seen-device",
         speculosApp: transaction.transaction.accountToDebit.currency.speculosApp,
         cliCommands: [liveDataWithRecipientAddressCommand(transaction.transaction)],
+        featureFlags: {
+          ...FF_NEW_SEND_FLOW_DISABLED,
+        },
       });
 
       const family = getFamilyByCurrencyId(transaction.transaction.accountToDebit.currency.id);
@@ -326,6 +330,9 @@ test.describe("Send flows", () => {
         userdata: "skip-onboarding-with-last-seen-device",
         speculosApp: transaction.transaction.accountToDebit.currency.speculosApp,
         cliCommands: [liveDataWithRecipientAddressCommand(transaction.transaction)],
+        featureFlags: {
+          ...FF_NEW_SEND_FLOW_DISABLED,
+        },
       });
 
       const family = getFamilyByCurrencyId(transaction.transaction.accountToDebit.currency.id);
@@ -382,6 +389,9 @@ test.describe("Send flows", () => {
       userdata: "skip-onboarding-with-last-seen-device",
       speculosApp: transactionInputValid.accountToDebit.currency.speculosApp,
       cliCommands: [liveDataWithRecipientAddressCommand(transactionInputValid)],
+      featureFlags: {
+        ...FF_NEW_SEND_FLOW_DISABLED,
+      },
     });
 
     const family = getFamilyByCurrencyId(transactionInputValid.accountToDebit.currency.id);
@@ -431,6 +441,9 @@ test.describe("Send flows", () => {
         cliCommands: [
           liveDataWithRecipientAddressCommand(transaction.transaction, { useScheme: true }),
         ],
+        featureFlags: {
+          ...FF_NEW_SEND_FLOW_DISABLED,
+        },
       });
 
       const family = getFamilyByCurrencyId(transaction.transaction.accountToDebit.currency.id);
@@ -506,6 +519,9 @@ test.describe("Send flows", () => {
             return transaction.address;
           },
         ],
+        featureFlags: {
+          ...FF_NEW_SEND_FLOW_DISABLED,
+        },
       });
 
       const family = getFamilyByCurrencyId(transaction.transaction.accountToDebit.currency.id);
@@ -566,6 +582,9 @@ test.describe("Send flows", () => {
       speculosApp: transactionEnsAddress.accountToDebit.currency.speculosApp,
       cliCommands: [liveDataWithRecipientAddressCommand(transactionEnsAddress)],
       env: { DISABLE_TRANSACTION_BROADCAST: "1" },
+      featureFlags: {
+        ...FF_NEW_SEND_FLOW_DISABLED,
+      },
     });
 
     const family = getFamilyByCurrencyId(transactionEnsAddress.accountToDebit.currency.id);
@@ -637,6 +656,7 @@ test.describe("Send flows", () => {
         },
       ],
       featureFlags: {
+        ...FF_NEW_SEND_FLOW_DISABLED,
         currencyConcordiumTestnet: { enabled: true },
         analyticsOptIn: { enabled: true, params: { policyVersion: 1, consentValidityDays: 365 } },
       },

--- a/e2e/desktop/tests/specs/subAccount.spec.ts
+++ b/e2e/desktop/tests/specs/subAccount.spec.ts
@@ -19,6 +19,7 @@ import {
 } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 import { Addresses } from "@ledgerhq/live-common/e2e/enum/Addresses";
 import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
+import { FF_NEW_SEND_FLOW_DISABLED } from "tests/utils/featureFlagUtils";
 
 const subAccounts = [
   {
@@ -88,6 +89,9 @@ for (const token of subAccounts) {
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "skip-onboarding-with-last-seen-device",
       speculosApp: token.account.parentAccount?.currency.speculosApp,
+      featureFlags: {
+        ...FF_NEW_SEND_FLOW_DISABLED,
+      },
     });
 
     const family = getFamilyByCurrencyId(token.account.currency.id);
@@ -148,6 +152,9 @@ for (const token of subAccountReceive) {
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "speculos-subAccount",
       speculosApp: token.account.currency.speculosApp,
+      featureFlags: {
+        ...FF_NEW_SEND_FLOW_DISABLED,
+      },
     });
 
     const family = getFamilyByCurrencyId(token.account.currency.id);
@@ -204,6 +211,9 @@ for (const token of subAccounts) {
     test.use({
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "speculos-subAccount",
+      featureFlags: {
+        ...FF_NEW_SEND_FLOW_DISABLED,
+      },
     });
 
     const family = getFamilyByCurrencyId(token.account.currency.id);
@@ -264,6 +274,9 @@ for (const transaction of transactionE2E) {
           transaction.tx.accountToCredit,
         ),
       ],
+      featureFlags: {
+        ...FF_NEW_SEND_FLOW_DISABLED,
+      },
     });
 
     test(
@@ -367,6 +380,9 @@ for (const transaction of transactionsAddressInvalid) {
           return transaction.recipient;
         },
       ],
+      featureFlags: {
+        ...FF_NEW_SEND_FLOW_DISABLED,
+      },
     });
 
     const family = getFamilyByCurrencyId(transaction.transaction.accountToDebit.currency.id);
@@ -425,6 +441,9 @@ for (const transaction of transactionsAddressValid) {
       userdata: "skip-onboarding-with-last-seen-device",
       speculosApp: transaction.transaction.accountToDebit.currency.speculosApp,
       cliCommands: [liveDataCommand(transaction.transaction.accountToDebit)],
+      featureFlags: {
+        ...FF_NEW_SEND_FLOW_DISABLED,
+      },
     });
 
     test(
@@ -509,6 +528,9 @@ for (const transaction of tokenTransactionInvalid) {
           transaction.tx.accountToCredit,
         ),
       ],
+      featureFlags: {
+        ...FF_NEW_SEND_FLOW_DISABLED,
+      },
     });
 
     const family = getFamilyByCurrencyId(transaction.tx.accountToDebit.currency.id);
@@ -569,6 +591,9 @@ test.describe("Send token (subAccount) - valid address & amount input", () => {
         tokenTransactionValid.accountToCredit,
       ),
     ],
+    featureFlags: {
+      ...FF_NEW_SEND_FLOW_DISABLED,
+    },
   });
 
   test(

--- a/e2e/desktop/tests/utils/featureFlagUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagUtils.ts
@@ -95,6 +95,16 @@ export const FF_STAKE_PROGRAMS_MODAL = {
   },
 } satisfies OptionalFeatureMap;
 
+export const FF_NEW_SEND_FLOW_DISABLED = {
+  newSendFlow: {
+    enabled: false,
+    params: {
+      families: [],
+      excludedCurrencyIds: [],
+    },
+  },
+} satisfies OptionalFeatureMap;
+
 export const getFeatureFlags = async (page: Page): Promise<OptionalFeatureMap> => {
   const featureFlags = await page.evaluate(() => {
     return window.getAllFeatureFlags("en");


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Disable new send flow on test that are made to test the old send flow only to avoid failure.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-33504](https://ledgerhq.atlassian.net/browse/LIVE-33504)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-33504]: https://ledgerhq.atlassian.net/browse/LIVE-33504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ