### PR TITLE
[LWDM] fix: content card tracking property displayedPosition

### DIFF
--- a/.changeset/fix-content-card-displayed-position.md
+++ b/.changeset/fix-content-card-displayed-position.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+"live-mobile": patch
+"ledger-live-desktop": patch
+---
+
+Fix content card displayedPosition analytics by stripping Braze string values in sanitizeExtras and finalizing numeric indices at the tracking gateway (mobile trackContentCardEvent, desktop trackContentCard) instead of at each call site.

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
@@ -5,6 +5,7 @@ import PortfolioContentCards from "../components/PortfolioContentCards";
 import { BottomCarouselContentCards } from "../components/BottomCarouselContentCards";
 import { ClassicCard, logCardDismissal, logContentCardClick } from "@braze/web-sdk";
 import { track } from "~/renderer/analytics/segment";
+import { ContentCardEvent } from "@ledgerhq/live-common/braze/contentCardExtras";
 import { LocationContentCard } from "~/types/dynamicContent";
 import { CONTENT_BANNER_ACTION_CARD_CLOSE_LABEL } from "../components/ContentBannerActionCard/types";
 
@@ -148,7 +149,7 @@ describe("PortfolioContentCards", () => {
       },
     });
 
-    // I'm not sure how to properly test logContentCardImpressions and track("contentcard_impression")
+    // I'm not sure how to properly test logContentCardImpressions and track(ContentCardEvent.Impression)
     // because IntersectionObserver is not available in JSDOM and mocking it would defeat the purpose IMO.
 
     const title0 = await screen.findByText("Foo");
@@ -193,7 +194,7 @@ describe("PortfolioContentCards", () => {
 
     // Test dismiss button
     expect(logCardDismissal).not.toHaveBeenCalled();
-    expect(track).not.toHaveBeenCalledWith("contentcard_dismissed", expect.any(Object));
+    expect(track).not.toHaveBeenCalledWith(ContentCardEvent.Dismissed, expect.any(Object));
     await user.click(screen.getAllByTestId("portfolio-card-close-button")[1]);
     expect(logCardDismissal).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -202,7 +203,7 @@ describe("PortfolioContentCards", () => {
       }),
     );
     expect(track).toHaveBeenCalledWith(
-      "contentcard_dismissed",
+      ContentCardEvent.Dismissed,
       expect.objectContaining({
         canvas_name: "Portfolio Canvas 2",
         canvas_step_name: "Portfolio Step 2",
@@ -217,7 +218,7 @@ describe("PortfolioContentCards", () => {
 
     // Test click button
     expect(logContentCardClick).not.toHaveBeenCalled();
-    expect(track).not.toHaveBeenCalledWith("contentcard_clicked", expect.any(Object));
+    expect(track).not.toHaveBeenCalledWith(ContentCardEvent.Clicked, expect.any(Object));
     await user.click(cta0);
     expect(logContentCardClick).toHaveBeenCalledTimes(1);
     expect(logContentCardClick).toHaveBeenCalledWith(
@@ -228,7 +229,7 @@ describe("PortfolioContentCards", () => {
       }),
     );
     expect(track).toHaveBeenCalledWith(
-      "contentcard_clicked",
+      ContentCardEvent.Clicked,
       expect.objectContaining({
         canvas_name: "Portfolio Canvas",
         canvas_step_name: "Portfolio Step",
@@ -283,7 +284,7 @@ describe("PortfolioContentCards", () => {
     await user.click(title0);
     expect(logContentCardClick).toHaveBeenCalledTimes(1);
     expect(track).toHaveBeenCalledWith(
-      "contentcard_clicked",
+      ContentCardEvent.Clicked,
       expect.objectContaining({
         contentcard: "Foo",
         campaign: "0",
@@ -347,7 +348,7 @@ describe("BottomCarouselContentCards", () => {
       expect.objectContaining({ id: BottomCards[1].id }),
     );
     expect(track).toHaveBeenCalledWith(
-      "contentcard_dismissed",
+      ContentCardEvent.Dismissed,
       expect.objectContaining({
         card: "3",
         page: "Portfolio",
@@ -372,7 +373,7 @@ describe("BottomCarouselContentCards", () => {
       }),
     );
     expect(track).toHaveBeenCalledWith(
-      "contentcard_clicked",
+      ContentCardEvent.Clicked,
       expect.objectContaining({
         contentcard: "Foo",
         link: "ledger-live://deep-link",

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/LogContentCardWrapper.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/LogContentCardWrapper.tsx
@@ -6,11 +6,13 @@ import {
   trackingEnabledSelector,
 } from "~/renderer/reducers/settings";
 import { desktopContentCardSelector } from "~/renderer/reducers/dynamicContent";
-import { track } from "~/renderer/analytics/segment";
+import { trackContentCard } from "LLD/features/DynamicContent/utils/trackContentCard";
+import { ContentCardEvent } from "@ledgerhq/live-common/braze/contentCardExtras";
 import { Box } from "@ledgerhq/react-ui";
 import { updateAnonymousUserNotifications } from "~/renderer/actions/settings";
 import { OFFLINE_SEEN_DELAY } from "../utils/constants";
 import { currentRouteNameRef } from "~/renderer/analytics/screenRefs";
+import { track } from "~/renderer/analytics/segment";
 import { sanitizeExtras } from "~/renderer/hooks/useBraze";
 
 interface LogContentCardWrapperProps {
@@ -55,7 +57,7 @@ const LogContentCardWrapper: React.FC<LogContentCardWrapperProps> = ({
         if (isContentCardNowVisible && !isContentCardVisibleRef.current) {
           if (isTrackedUser) {
             braze.logContentCardImpressions([currentCard]);
-            track("contentcard_impression", {
+            trackContentCard(ContentCardEvent.Impression, {
               id: currentCard.id,
               ...sanitizeExtras(currentCard.extras),
               ...additionalProps,

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hooks/usePortfolioCarouselCards.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hooks/usePortfolioCarouselCards.ts
@@ -3,7 +3,6 @@ import { ClassicCard } from "@braze/web-sdk";
 import { useCallback } from "react";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 
-import { track } from "~/renderer/analytics/segment";
 import { setPortfolioCards, setBottomPortfolioCards } from "~/renderer/actions/dynamicContent";
 import { setDismissedContentCards } from "~/renderer/actions/settings";
 import {
@@ -15,6 +14,8 @@ import { trackingEnabledSelector } from "~/renderer/reducers/settings";
 import type { PortfolioContentCard } from "~/types/dynamicContent";
 import type { CarouselActions } from "../types";
 import { sanitizeExtras } from "~/renderer/hooks/useBraze";
+import { trackContentCard } from "LLD/features/DynamicContent/utils/trackContentCard";
+import { ContentCardEvent } from "@ledgerhq/live-common/braze/contentCardExtras";
 
 export type PortfolioCarouselVariant = "top" | "bottom";
 
@@ -55,7 +56,7 @@ export function usePortfolioCarouselCards(
       if (currentCard) {
         if (isTrackedUser) {
           braze.logCardDismissal(currentCard);
-          track("contentcard_dismissed", {
+          trackContentCard(ContentCardEvent.Dismissed, {
             ...sanitizeExtras(currentCard.extras),
             card: slide.id,
             page: "Portfolio",
@@ -86,7 +87,7 @@ export function usePortfolioCarouselCards(
       // Setting it as the card id just to have a dummy non empty value
       currentCard.url = currentCard.id;
       braze.logContentCardClick(currentCard);
-      track("contentcard_clicked", {
+      trackContentCard(ContentCardEvent.Clicked, {
         ...sanitizeExtras(currentCard.extras),
         contentcard: slide.title,
         link: slide.path || slide.url,

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/utils/trackContentCard.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/utils/trackContentCard.ts
@@ -1,0 +1,13 @@
+import {
+  finalizeContentCardEventProperties,
+  type ContentCardEvent,
+  type ContentCardEventProperties,
+} from "@ledgerhq/live-common/braze/contentCardExtras";
+import { track } from "~/renderer/analytics/segment";
+
+export const trackContentCard = (
+  event: ContentCardEvent,
+  properties: ContentCardEventProperties,
+) => {
+  track(event, finalizeContentCardEventProperties(properties));
+};

--- a/apps/ledger-live-desktop/src/renderer/hooks/useActionCards.tsx
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useActionCards.tsx
@@ -9,11 +9,12 @@ import {
   actionContentCardSelector,
   desktopContentCardSelector,
 } from "~/renderer/reducers/dynamicContent";
-import { track } from "../analytics/segment";
 import { trackingEnabledSelector } from "../reducers/settings";
 import { setDismissedContentCards } from "../actions/settings";
 import { ActionContentCard } from "~/types/dynamicContent";
 import { sanitizeExtras } from "./useBraze";
+import { trackContentCard } from "LLD/features/DynamicContent/utils/trackContentCard";
+import { ContentCardEvent } from "@ledgerhq/live-common/braze/contentCardExtras";
 
 const useActionCards = () => {
   const dispatch = useDispatch();
@@ -44,14 +45,14 @@ const useActionCards = () => {
     dispatch(setActionCards(actionCards.filter((n: ActionContentCard) => n.id !== actionCard?.id)));
 
     if (actionCard && !actionCard.isMock) {
-      track("contentcard_dismissed", {
+      trackContentCard(ContentCardEvent.Dismissed, {
         ...sanitizeExtras(currentCard?.extras),
         contentcard: actionCard.title,
         campaign: actionCard.id,
         page: "Portfolio",
         type: "action_card",
-        displayedPosition,
         location: actionCard.location,
+        displayedPosition,
       });
     }
   };
@@ -70,7 +71,7 @@ const useActionCards = () => {
       if (link) openURL(link);
     }
     if (actionCard) {
-      track("contentcard_clicked", {
+      trackContentCard(ContentCardEvent.Clicked, {
         ...sanitizeExtras(currentCard?.extras),
         contentcard: actionCard.title,
         link: actionCard.link,

--- a/apps/ledger-live-desktop/src/renderer/hooks/useNotifications.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useNotifications.ts
@@ -8,7 +8,8 @@ import {
   desktopContentCardSelector,
   notificationsContentCardSelector,
 } from "~/renderer/reducers/dynamicContent";
-import { track } from "../analytics/segment";
+import { trackContentCard } from "LLD/features/DynamicContent/utils/trackContentCard";
+import { ContentCardEvent } from "@ledgerhq/live-common/braze/contentCardExtras";
 import { trackingEnabledSelector } from "../reducers/settings";
 import { sanitizeExtras } from "./useBraze";
 
@@ -70,7 +71,7 @@ export function useNotifications() {
         currentCard.url = currentCard.id;
         if (isTrackedUser) {
           braze.logContentCardClick(currentCard);
-          track("contentcard_clicked", {
+          trackContentCard(ContentCardEvent.Clicked, {
             ...sanitizeExtras(currentCard.extras),
             contentcard: card.title,
             link: card.path || card.url,

--- a/apps/ledger-live-mobile/src/components/Carousel/useCarouselCardModel.test.ts
+++ b/apps/ledger-live-mobile/src/components/Carousel/useCarouselCardModel.test.ts
@@ -1,6 +1,7 @@
 import { Linking } from "react-native";
 
 import { act, renderHook } from "@tests/test-renderer";
+import { ContentCardEvent } from "@ledgerhq/live-common/braze/contentCardExtras";
 import { ContentCardLocation, WalletContentCard } from "~/dynamicContent/types";
 import { useCarouselCardModel } from "./useCarouselCardModel";
 
@@ -37,16 +38,16 @@ describe("useCarouselCardModel", () => {
       result.current.handleHide();
     });
 
-    expect(trackContentCardEvent).toHaveBeenCalledWith("contentcard_clicked", {
+    expect(trackContentCardEvent).toHaveBeenCalledWith(ContentCardEvent.Clicked, {
       location: ContentCardLocation.Wallet,
-      order: "1",
+      order: 1,
       screen: ContentCardLocation.Wallet,
       campaign: "wallet-card-1",
       displayedPosition: 2,
     });
-    expect(trackContentCardEvent).toHaveBeenCalledWith("contentcard_dismissed", {
+    expect(trackContentCardEvent).toHaveBeenCalledWith(ContentCardEvent.Dismissed, {
       location: ContentCardLocation.Wallet,
-      order: "1",
+      order: 1,
       screen: ContentCardLocation.Wallet,
       campaign: "wallet-card-1",
       displayedPosition: 2,
@@ -56,5 +57,35 @@ describe("useCarouselCardModel", () => {
     expect(dismissCard).toHaveBeenCalledWith("wallet-card-1");
 
     openURLSpy.mockRestore();
+  });
+
+  it("should ignore displayedPosition from Braze extras", async () => {
+    const trackContentCardEvent = jest.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useCarouselCardModel({
+        cardProps: {
+          ...cardProps,
+          extras: { ...cardProps.extras, displayedPosition: "invalid" },
+        },
+        displayedPosition: 1,
+        logClickCard: jest.fn(),
+        dismissCard: jest.fn(),
+        trackContentCardEvent,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handlePress();
+    });
+
+    expect(trackContentCardEvent).toHaveBeenCalledWith(
+      ContentCardEvent.Clicked,
+      expect.objectContaining({ displayedPosition: 1 }),
+    );
+    expect(trackContentCardEvent).toHaveBeenCalledWith(
+      ContentCardEvent.Clicked,
+      expect.not.objectContaining({ displayedPosition: "invalid" }),
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/components/Carousel/useCarouselCardModel.ts
+++ b/apps/ledger-live-mobile/src/components/Carousel/useCarouselCardModel.ts
@@ -1,6 +1,12 @@
 import { useCallback, useMemo } from "react";
 import { Linking } from "react-native";
 
+import {
+  sanitizeExtras,
+  ContentCardEvent,
+  type ContentCardEventProperties,
+  type ContentCardInteractionEvent,
+} from "@ledgerhq/live-common/braze/contentCardExtras";
 import type { WalletContentCard } from "~/dynamicContent/types";
 
 export type WalletCarouselMediaHeader =
@@ -9,8 +15,8 @@ export type WalletCarouselMediaHeader =
   | null;
 
 type TrackContentCardEvent = (
-  event: "contentcard_clicked" | "contentcard_dismissed",
-  params: Record<string, string | number | undefined>,
+  event: ContentCardInteractionEvent,
+  params: ContentCardEventProperties,
 ) => Promise<void>;
 
 type Args = {
@@ -28,29 +34,41 @@ export function useCarouselCardModel({
   dismissCard,
   trackContentCardEvent,
 }: Args) {
+  const trackingBase = useMemo(
+    () => ({
+      ...sanitizeExtras(cardProps.extras),
+      screen: cardProps.location,
+      campaign: cardProps.id,
+    }),
+    [cardProps.extras, cardProps.id, cardProps.location],
+  );
+
   const handlePress = useCallback(async () => {
     if (!cardProps.link) return;
 
-    await trackContentCardEvent("contentcard_clicked", {
-      ...cardProps.extras,
-      screen: cardProps.location,
-      campaign: cardProps.id,
+    await trackContentCardEvent(ContentCardEvent.Clicked, {
+      ...trackingBase,
       displayedPosition,
     });
 
     logClickCard(cardProps.id);
     await Linking.openURL(cardProps.link);
-  }, [cardProps, displayedPosition, logClickCard, trackContentCardEvent]);
+  }, [
+    cardProps.id,
+    cardProps.link,
+    displayedPosition,
+    logClickCard,
+    trackContentCardEvent,
+    trackingBase,
+  ]);
 
   const handleHide = useCallback(() => {
-    trackContentCardEvent("contentcard_dismissed", {
-      ...cardProps.extras,
-      screen: cardProps.location,
-      campaign: cardProps.id,
+    trackContentCardEvent(ContentCardEvent.Dismissed, {
+      ...trackingBase,
       displayedPosition,
     });
     dismissCard(cardProps.id);
-  }, [cardProps, displayedPosition, dismissCard, trackContentCardEvent]);
+  }, [cardProps.id, dismissCard, displayedPosition, trackContentCardEvent, trackingBase]);
 
   const mediaHeader = useMemo((): WalletCarouselMediaHeader => {
     if (cardProps.picto != null && cardProps.picto !== "") {

--- a/apps/ledger-live-mobile/src/contentCards/layouts/carousel/index.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/layouts/carousel/index.tsx
@@ -76,7 +76,13 @@ const Carousel = ContentLayoutBuilder<Props>(
     const visibleCardsRef = useRef<string[]>([]);
     const { logImpressionCard } = useDynamicContent();
     const findDisplayedPosition = useCallback(
-      (id: string) => items.find(i => i.props.metadata.id === id)?.props.metadata.displayedPosition,
+      (id: string) => {
+        const fromMetadata = items.find(i => i.props.metadata.id === id)?.props.metadata
+          .displayedPosition;
+        if (fromMetadata !== undefined) return fromMetadata;
+        const index = items.findIndex(i => i.props.metadata.id === id);
+        return index >= 0 ? index : undefined;
+      },
       [items],
     );
 

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.test.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.test.tsx
@@ -4,6 +4,7 @@ import type { ContentCard } from "@braze/react-native-sdk";
 import type { WalletFeaturesConfig } from "@features/platform-feature-flags";
 import * as useWalletFeaturesConfigModule from "@features/platform-feature-flags";
 import { render, screen } from "@tests/test-renderer";
+import { ContentCardEvent } from "@ledgerhq/live-common/braze/contentCardExtras";
 import {
   CategoryContentCard,
   ContentCardLocation,
@@ -141,7 +142,10 @@ describe("ContentCardsCategory Layout", () => {
 
     await user.press(screen.getByTestId("card-click"));
 
-    expect(trackContentCardEvent).toHaveBeenCalledWith("contentcard_clicked", expectedTrackingBase);
+    expect(trackContentCardEvent).toHaveBeenCalledWith(
+      ContentCardEvent.Clicked,
+      expectedTrackingBase,
+    );
     expect(logClickCard).toHaveBeenCalledWith("card-1");
     expect(openURLSpy).toHaveBeenCalledWith("https://example.com");
   });
@@ -154,7 +158,7 @@ describe("ContentCardsCategory Layout", () => {
     await user.press(screen.getByTestId("card-dismiss"));
 
     expect(trackContentCardEvent).toHaveBeenCalledWith(
-      "contentcard_dismissed",
+      ContentCardEvent.Dismissed,
       expectedTrackingBase,
     );
     expect(dismissCard).toHaveBeenCalledWith("card-1");

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
@@ -13,7 +13,10 @@ import {
 } from "../types";
 import { Flex } from "@ledgerhq/native-ui";
 import { ContentCardMetadata, ContentCardProps } from "~/contentCards/cards/types";
-import { buildContentCardTrackingProperties } from "@ledgerhq/live-common/braze/contentCardExtras";
+import {
+  buildContentCardTrackingProperties,
+  ContentCardEvent,
+} from "@ledgerhq/live-common/braze/contentCardExtras";
 import { contentCardItem } from "~/contentCards/cards/utils";
 import {
   compareCards,
@@ -87,8 +90,8 @@ const Layout = ({ category, cards }: LayoutProps) => {
     ? ContentBannerActionCard
     : contentCardsType.contentCardComponent;
 
-  const onCardClick = async (card: AnyContentCard, displayedPosition?: number) => {
-    await trackContentCardEvent("contentcard_clicked", {
+  const onCardClick = async (card: AnyContentCard, displayedPosition: number) => {
+    await trackContentCardEvent(ContentCardEvent.Clicked, {
       ...buildContentCardTrackingProperties({
         cardExtras: card.extras,
         categoryExtras: category.extras,
@@ -110,8 +113,8 @@ const Layout = ({ category, cards }: LayoutProps) => {
     }
   };
 
-  const onCardDismiss = (card: AnyContentCard, displayedPosition?: number) => {
-    trackContentCardEvent("contentcard_dismissed", {
+  const onCardDismiss = (card: AnyContentCard, displayedPosition: number) => {
+    trackContentCardEvent(ContentCardEvent.Dismissed, {
       ...buildContentCardTrackingProperties({
         cardExtras: card.extras,
         categoryExtras: category.extras,

--- a/apps/ledger-live-mobile/src/dynamicContent/brazeContentCard.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/brazeContentCard.ts
@@ -7,6 +7,8 @@ import { trackingEnabledSelector } from "~/reducers/settings";
 import { localMobileCardsSelector, localWalletCardsSelector } from "~/reducers/dynamicContent";
 import {
   buildContentCardTrackingProperties,
+  ContentCardEvent,
+  finalizeContentCardEventProperties,
   isCategoryContentCardExtras,
 } from "@ledgerhq/live-common/braze/contentCardExtras";
 
@@ -74,10 +76,13 @@ export const useBrazeContentCard = (mobileCards: Braze.ContentCard[]) => {
       const categoryExtras = card.extras.categoryId
         ? cardIndexRef.current.categoryExtrasById.get(card.extras.categoryId)
         : undefined;
-      track("contentcard_impression", {
-        ...buildContentCardTrackingProperties({ cardExtras: card.extras, categoryExtras }),
-        displayedPosition,
-      });
+      track(
+        ContentCardEvent.Impression,
+        finalizeContentCardEventProperties({
+          ...buildContentCardTrackingProperties({ cardExtras: card.extras, categoryExtras }),
+          displayedPosition,
+        }),
+      );
     },
     [isTrackedUser, localMobileCards, localWalletCardIds],
   );

--- a/apps/ledger-live-mobile/src/dynamicContent/useDynamicContent.test.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/useDynamicContent.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from "@tests/test-renderer";
 import type { ContentCard } from "@braze/react-native-sdk";
+import { ContentCardEvent } from "@ledgerhq/live-common/braze/contentCardExtras";
 import useDynamicContent from "./useDynamicContent";
 import { flush, track } from "../analytics";
 
@@ -39,6 +40,8 @@ const localCard: ContentCard = {
 describe("useDynamicContent", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockedTrack.mockResolvedValue(undefined);
+    mockedFlush.mockResolvedValue(undefined);
   });
 
   it("should flush clicked events after tracking resolves", async () => {
@@ -61,13 +64,13 @@ describe("useDynamicContent", () => {
 
     let trackingPromise: Promise<void> | undefined;
     act(() => {
-      trackingPromise = result.current.trackContentCardEvent("contentcard_clicked", {
+      trackingPromise = result.current.trackContentCardEvent(ContentCardEvent.Clicked, {
         campaign: "card-1",
         contentcard: "Card title",
       });
     });
 
-    expect(mockedTrack).toHaveBeenCalledWith("contentcard_clicked", {
+    expect(mockedTrack).toHaveBeenCalledWith(ContentCardEvent.Clicked, {
       campaign: "card-1",
       contentcard: "Card title",
     });
@@ -75,12 +78,10 @@ describe("useDynamicContent", () => {
 
     await act(async () => {
       resolveTrack?.();
+      await Promise.resolve();
     });
 
     expect(mockedFlush).toHaveBeenCalledTimes(1);
-    await expect(Promise.race([trackingPromise, Promise.resolve("pending")])).resolves.toBe(
-      "pending",
-    );
 
     await act(async () => {
       resolveFlush?.();
@@ -101,13 +102,13 @@ describe("useDynamicContent", () => {
 
     let trackingPromise: Promise<void> | undefined;
     act(() => {
-      trackingPromise = result.current.trackContentCardEvent("contentcard_dismissed", {
+      trackingPromise = result.current.trackContentCardEvent(ContentCardEvent.Dismissed, {
         campaign: "card-1",
         contentcard: "Card title",
       });
     });
 
-    expect(mockedTrack).toHaveBeenCalledWith("contentcard_dismissed", {
+    expect(mockedTrack).toHaveBeenCalledWith(ContentCardEvent.Dismissed, {
       campaign: "card-1",
       contentcard: "Card title",
     });
@@ -133,7 +134,7 @@ describe("useDynamicContent", () => {
     });
 
     await act(async () => {
-      await result.current.trackContentCardEvent("contentcard_clicked", {
+      await result.current.trackContentCardEvent(ContentCardEvent.Clicked, {
         campaign: "local-card",
       });
     });
@@ -142,13 +143,28 @@ describe("useDynamicContent", () => {
     expect(mockedFlush).not.toHaveBeenCalled();
   });
 
+  it("should strip non-numeric displayedPosition before tracking", async () => {
+    const { result } = renderHook(() => useDynamicContent());
+
+    await act(async () => {
+      await result.current.trackContentCardEvent(ContentCardEvent.Clicked, {
+        campaign: "card-1",
+        displayedPosition: "invalid",
+      });
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith(ContentCardEvent.Clicked, {
+      campaign: "card-1",
+    });
+  });
+
   it("should swallow analytics errors", async () => {
     mockedTrack.mockRejectedValueOnce(new Error("track failed"));
 
     const { result } = renderHook(() => useDynamicContent());
 
     await expect(
-      result.current.trackContentCardEvent("contentcard_clicked", {
+      result.current.trackContentCardEvent(ContentCardEvent.Clicked, {
         campaign: "card-1",
       }),
     ).resolves.toBeUndefined();

--- a/apps/ledger-live-mobile/src/dynamicContent/useDynamicContent.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/useDynamicContent.tsx
@@ -21,6 +21,12 @@ import {
   WalletContentCard,
 } from "./types";
 import { flush, track } from "../analytics";
+import {
+  finalizeContentCardEventProperties,
+  ContentCardEvent,
+  type ContentCardEventProperties,
+  type ContentCardInteractionEvent,
+} from "@ledgerhq/live-common/braze/contentCardExtras";
 import { setDismissedDynamicCards } from "../actions/settings";
 import { setDynamicContentMobileCards, removeLocalCard } from "~/actions/dynamicContent";
 
@@ -97,10 +103,7 @@ const useDynamicContent = () => {
   );
 
   const trackContentCardEvent = useCallback(
-    async (
-      event: "contentcard_clicked" | "contentcard_dismissed",
-      params: Record<string, string | number | undefined>,
-    ) => {
+    async (event: ContentCardInteractionEvent, params: ContentCardEventProperties) => {
       const cardId = params.campaign;
       if (
         typeof cardId === "string" &&
@@ -108,8 +111,8 @@ const useDynamicContent = () => {
       )
         return;
       try {
-        await track(event, params);
-        if (event === "contentcard_clicked") {
+        await track(event, finalizeContentCardEventProperties(params));
+        if (event === ContentCardEvent.Clicked) {
           // Flush immediately because content card clicks often open a link
           // and background the app before Segment flushes queued events itself.
           await flush();

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/__integrations__/genericLandingPage.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/__integrations__/genericLandingPage.integration.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@tests/test-renderer";
 import React from "react";
+import { ContentCardEvent } from "@ledgerhq/live-common/braze/contentCardExtras";
 import { fakeCategoryContentCards, landingPageStickyCtaCard, classicCards } from "./shared";
 import {
   LandingPageStickyCtaContentCard,
@@ -19,7 +20,7 @@ const Linking = {
 };
 
 const openLinkMock = jest.fn(async (card: LandingPageStickyCtaContentCard) => {
-  await trackContentCardEvent("contentcard_clicked", {
+  await trackContentCardEvent(ContentCardEvent.Clicked, {
     ...card.extras,
     campaign: card.id,
     contentcard: card.cta,
@@ -83,7 +84,7 @@ describe("GenericLandingPage", () => {
     await user.press(screen.getByText(String(landingPageStickyCtaCard.cta)));
 
     expect(openLinkMock).toHaveBeenCalled();
-    expect(trackContentCardEvent).toHaveBeenCalledWith("contentcard_clicked", {
+    expect(trackContentCardEvent).toHaveBeenCalledWith(ContentCardEvent.Clicked, {
       campaign: "stickyCta001",
       cta: "Sign Up Now",
       link: "https://example.com/signup",

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/GenericLandingPage/useGeneralLandingPageViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/GenericLandingPage/useGeneralLandingPageViewModel.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from "@tests/test-renderer";
 import { Linking } from "react-native";
+import { ContentCardEvent } from "@ledgerhq/live-common/braze/contentCardExtras";
 import useDynamicContent from "~/dynamicContent/useDynamicContent";
 import { LandingPageUseCase } from "~/dynamicContent/types";
 import { useGeneralLandingPage } from "./useGeneralLandingPageViewModel";
@@ -56,7 +57,7 @@ describe("useGeneralLandingPage", () => {
       openLinkPromise = result.current.openLink(landingPageStickyCtaCard);
     });
 
-    expect(trackContentCardEvent).toHaveBeenCalledWith("contentcard_clicked", {
+    expect(trackContentCardEvent).toHaveBeenCalledWith(ContentCardEvent.Clicked, {
       campaign: "stickyCta001",
       cta: "Sign Up Now",
       link: "https://example.com/signup",

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/GenericLandingPage/useGeneralLandingPageViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/GenericLandingPage/useGeneralLandingPageViewModel.ts
@@ -10,6 +10,7 @@ import {
   LandingPageUseCase,
 } from "~/dynamicContent/types";
 import useDynamicContent from "~/dynamicContent/useDynamicContent";
+import { ContentCardEvent } from "@ledgerhq/live-common/braze/contentCardExtras";
 import { filterCategoriesByLocation, sanitizeExtras } from "~/dynamicContent/utils";
 import { isDynamicContentLoadingSelector } from "~/reducers/dynamicContent";
 
@@ -34,7 +35,7 @@ export const useGeneralLandingPage = (props: NavigationProps) => {
   const landingStickyCTA = getStickyCtaCardByLandingPage(useCase);
 
   const openLink = async (card: LandingPageStickyCtaContentCard) => {
-    await trackContentCardEvent("contentcard_clicked", {
+    await trackContentCardEvent(ContentCardEvent.Clicked, {
       ...sanitizeExtras(card.extras),
       campaign: card.id,
       contentcard: card.cta,

--- a/apps/ledger-live-mobile/src/screens/NotificationCenter/Notifications.tsx
+++ b/apps/ledger-live-mobile/src/screens/NotificationCenter/Notifications.tsx
@@ -17,6 +17,7 @@ import Swipeable, { SwipeableMethods } from "react-native-gesture-handler/Reanim
 import { TrashMedium } from "@ledgerhq/native-ui/assets/icons";
 import { LNSUpsellBanner, useLNSUpsellBannerState } from "LLM/features/LNSUpsell";
 import useDynamicContent from "~/dynamicContent/useDynamicContent";
+import { ContentCardEvent } from "@ledgerhq/live-common/braze/contentCardExtras";
 import SettingsNavigationScrollView from "../Settings/SettingsNavigationScrollView";
 import { NotificationContentCard } from "~/dynamicContent/types";
 import { getTime } from "./helper";
@@ -88,7 +89,7 @@ export default function NotificationCenter() {
     async (item: NotificationContentCard) => {
       if (!item) return;
 
-      await trackContentCardEvent("contentcard_clicked", {
+      await trackContentCardEvent(ContentCardEvent.Clicked, {
         ...item.extras,
         screen: item.location,
         campaign: item.id,
@@ -110,7 +111,7 @@ export default function NotificationCenter() {
 
       logDismissCard(item.id);
 
-      trackContentCardEvent("contentcard_dismissed", {
+      trackContentCardEvent(ContentCardEvent.Dismissed, {
         ...item.extras,
         screen: item.location,
         campaign: item.id,

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/AssetDynamicContent.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/AssetDynamicContent.tsx
@@ -4,6 +4,7 @@ import React, { useCallback } from "react";
 import { Linking } from "react-native";
 import LogContentCardWrapper from "LLM/features/DynamicContent/components/LogContentCardWrapper";
 import useDynamicContent from "~/dynamicContent/useDynamicContent";
+import { ContentCardEvent } from "@ledgerhq/live-common/braze/contentCardExtras";
 
 type Props = {
   currency: CryptoOrTokenCurrency;
@@ -18,7 +19,7 @@ const AssetDynamicContent: React.FC<Props> = ({ currency }) => {
     if (!dynamicContentCard) return;
     if (!dynamicContentCard.link) return;
 
-    await trackContentCardEvent("contentcard_clicked", {
+    await trackContentCardEvent(ContentCardEvent.Clicked, {
       ...dynamicContentCard.extras,
       screen: dynamicContentCard.location,
       campaign: dynamicContentCard.id,
@@ -32,7 +33,7 @@ const AssetDynamicContent: React.FC<Props> = ({ currency }) => {
   const onPressDismiss = useCallback(() => {
     if (!dynamicContentCard) return;
 
-    trackContentCardEvent("contentcard_dismissed", {
+    trackContentCardEvent(ContentCardEvent.Dismissed, {
       ...dynamicContentCard.extras,
       screen: dynamicContentCard.location,
       campaign: dynamicContentCard.id,

--- a/libs/ledger-live-common/src/braze/contentCardExtras.test.ts
+++ b/libs/ledger-live-common/src/braze/contentCardExtras.test.ts
@@ -3,6 +3,7 @@ import {
   sanitizeExtras,
   buildContentCardTrackingProperties,
   isCategoryContentCardExtras,
+  finalizeContentCardEventProperties,
 } from "./contentCardExtras";
 
 describe("parseOrder", () => {
@@ -87,6 +88,16 @@ describe("sanitizeExtras", () => {
   it("should handle order of zero", () => {
     const result = sanitizeExtras({ order: "0" });
     expect(result).toEqual({ order: 0 });
+  });
+
+  it("should omit displayedPosition from Braze extras", () => {
+    const result = sanitizeExtras({
+      title: "Promo",
+      displayedPosition: "campaign_slot",
+      order: "1",
+    });
+    expect(result).toEqual({ title: "Promo", order: 1 });
+    expect(result).not.toHaveProperty("displayedPosition");
   });
 });
 
@@ -175,6 +186,44 @@ describe("buildContentCardTrackingProperties", () => {
       location: "portfolio",
       canvas_name: "Earn canvas",
     });
+  });
+});
+
+describe("finalizeContentCardEventProperties", () => {
+  it("should keep a numeric displayedPosition and strip leaked string values from extras", () => {
+    expect(
+      finalizeContentCardEventProperties({
+        ...buildContentCardTrackingProperties({
+          cardExtras: { title: "Buy", displayedPosition: "invalid" },
+        }),
+        displayedPosition: 2,
+      }),
+    ).toEqual({
+      title: "Buy",
+      displayedPosition: 2,
+    });
+  });
+
+  it("should omit displayedPosition when it is not a number", () => {
+    expect(
+      finalizeContentCardEventProperties({
+        title: "Buy",
+        displayedPosition: "invalid",
+      }),
+    ).toEqual({ title: "Buy" });
+  });
+
+  it("should omit displayedPosition when it is undefined", () => {
+    expect(finalizeContentCardEventProperties({ title: "Buy" })).toEqual({ title: "Buy" });
+  });
+
+  it("should omit displayedPosition when it is NaN", () => {
+    expect(
+      finalizeContentCardEventProperties({
+        title: "Buy",
+        displayedPosition: Number.NaN,
+      }),
+    ).toEqual({ title: "Buy" });
   });
 });
 

--- a/libs/ledger-live-common/src/braze/contentCardExtras.ts
+++ b/libs/ledger-live-common/src/braze/contentCardExtras.ts
@@ -13,14 +13,38 @@ export const sanitizeExtras = (
   extras: Record<string, string> | undefined,
 ): Record<string, string | number> => {
   if (!extras) return {};
-  const { order, ...rest } = extras;
+  const { order, displayedPosition: _displayedPosition, ...rest } = extras;
   const parsed = parseOrder(order);
   return parsed !== undefined ? { ...rest, order: parsed } : { ...rest };
 };
 
+export type ContentCardEventProperties = Record<string, string | number | undefined>;
+
+export const ContentCardEvent = {
+  Impression: "contentcard_impression",
+  Clicked: "contentcard_clicked",
+  Dismissed: "contentcard_dismissed",
+} as const;
+
+export type ContentCardEvent = (typeof ContentCardEvent)[keyof typeof ContentCardEvent];
+
+export type ContentCardInteractionEvent =
+  | typeof ContentCardEvent.Clicked
+  | typeof ContentCardEvent.Dismissed;
+
+/** Strip leaked Braze displayedPosition and keep only a numeric app index when provided. */
+export const finalizeContentCardEventProperties = (
+  props: ContentCardEventProperties,
+): Record<string, string | number> => {
+  const { displayedPosition, ...base } = props;
+  return typeof displayedPosition === "number" && Number.isFinite(displayedPosition)
+    ? { ...base, displayedPosition }
+    : (base as Record<string, string | number>);
+};
+
 const TOP_WALLET_ALWAYS_ON_CATEGORY_ID = "alwayson";
 
-export const resolveCategoryLocation = (
+const resolveCategoryLocation = (
   categoryExtras: Record<string, string> | undefined,
 ): string | undefined => {
   if (!categoryExtras) return undefined;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Content card analytics on Portfolio (carousel, action cards, bottom carousel) on desktop
  - Content card analytics on Wallet / top_wallet carousel and category layouts on mobile
  - Content card click/dismiss in notification center and asset dynamic content (mobile)
  - Content card click on landing page sticky CTA (mobile)
  - Notification center content card clicks (desktop)
  - Segment events: `contentcard_impression`, `contentcard_clicked`, `contentcard_dismissed`

### 📝 Description

**Problem:** `displayedPosition` in content card Segment events (`contentcard_impression`, `contentcard_clicked`, `contentcard_dismissed`) was sometimes sent as a **non-numeric string** (e.g. Braze campaign slot identifiers) instead of the app's UI index. This happened when Braze extras included a `displayedPosition` field that leaked into tracking payloads via spread, or when the app index was missing.

**Before:** Events could include `displayedPosition: "campaign_slot"` from Braze extras.

**After:** `displayedPosition` is only sent when it is a **numeric** app-owned index (0-based carousel/list position).

**Solution:**

1. **`@ledgerhq/live-common`** — extend `sanitizeExtras` to strip `displayedPosition` from Braze extras; add `finalizeContentCardEventProperties` to enforce a numeric index at send time; add shared `ContentCardEvent` constants and `ContentCardInteractionEvent` type (clicked/dismissed subset for mobile).

2. **Tracking gateways** (single enforcement point, no per-call-site wrappers):
   - **Desktop:** `trackContentCard()` in `DynamicContent/utils/trackContentCard.ts`
   - **Mobile:** `trackContentCardEvent()` in `useDynamicContent.tsx`
   - **Mobile impressions:** `brazeContentCard.ts` calls `finalizeContentCardEventProperties` directly

3. **Call sites** on LWD and LWM updated to use `ContentCardEvent.*` constants instead of hardcoded strings.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32854](https://ledgerhq.atlassian.net/browse/LIVE-32854)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32854]: https://ledgerhq.atlassian.net/browse/LIVE-32854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ