### PR TITLE
[LWM] feat: implement PnL chart section on Analytics screen

### DIFF
--- a/.changeset/calm-charts-glow.md
+++ b/.changeset/calm-charts-glow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add Lumen portfolio chart to mobile Analytics when PnL is enabled, with balance header and range-aware variation (first receive baseline for all-time).

--- a/apps/ledger-live-mobile/src/mvvm/components/TrendSection/__tests__/TrendSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TrendSection/__tests__/TrendSection.test.tsx
@@ -59,4 +59,20 @@ describe("TrendSection", () => {
     expect(screen.getByText("+$10.00")).toBeVisible();
     expect(screen.queryByText("·")).toBeNull();
   });
+
+  it("hides the trend icon when showTrend is false", () => {
+    render(
+      <TrendSection
+        percentage={5.5}
+        formattedChange="+$10.00"
+        timeLabel="1 week"
+        showTrend={false}
+        testID="trend"
+      />,
+    );
+
+    expect(screen.queryByText("5.50%")).toBeNull();
+    expect(screen.getByText("+$10.00")).toBeVisible();
+    expect(screen.getByText("1 week")).toBeVisible();
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/TrendSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TrendSection/index.tsx
@@ -7,9 +7,18 @@ type Props = Readonly<{
   formattedChange?: string;
   timeLabel?: string;
   testID?: string;
+  trendSize?: "sm" | "md";
+  showTrend?: boolean;
 }>;
 
-export function TrendSection({ percentage, formattedChange, timeLabel, testID }: Props) {
+export function TrendSection({
+  percentage,
+  formattedChange,
+  timeLabel,
+  testID,
+  trendSize = "md",
+  showTrend = true,
+}: Props) {
   // NaN signals missing data → neutral dash. A real 0 is rendered as a neutral
   // (grey) trend so the row (and its time label) stays visible, e.g. while
   // scrubbing back to the start of the range.
@@ -23,7 +32,7 @@ export function TrendSection({ percentage, formattedChange, timeLabel, testID }:
 
   return (
     <Box lx={rowStyle} testID={testID}>
-      <Trend value={percentage} size="md" />
+      {showTrend && <Trend value={percentage} size={trendSize} />}
       {formattedChange != null && (
         <Text typography="body2" lx={{ color: "muted" }}>
           {formattedChange}

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/hooks/__tests__/useShouldDisplayAnalyticsPnl.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/hooks/__tests__/useShouldDisplayAnalyticsPnl.test.ts
@@ -1,0 +1,54 @@
+import { renderHook } from "@testing-library/react-native";
+import * as useWalletFeaturesConfigModule from "@features/platform-feature-flags";
+import type { WalletFeaturesConfig } from "@features/platform-feature-flags";
+import { useSelector } from "~/context/hooks";
+import { useShouldDisplayAnalyticsPnl } from "../useShouldDisplayAnalyticsPnl";
+
+jest.mock("@features/platform-feature-flags");
+jest.mock("~/context/hooks", () => ({
+  useSelector: jest.fn(),
+}));
+
+const mockUseWalletFeaturesConfig = jest.mocked(
+  useWalletFeaturesConfigModule.useWalletFeaturesConfig,
+);
+const mockUseSelector = jest.mocked(useSelector);
+
+const mockAccount = { id: "acc-1" };
+
+function mockWalletConfig(shouldDisplayPnl: boolean) {
+  mockUseWalletFeaturesConfig.mockReturnValue({
+    shouldDisplayPnl,
+  } as WalletFeaturesConfig);
+}
+
+describe("useShouldDisplayAnalyticsPnl", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWalletConfig(true);
+    mockUseSelector.mockReturnValue([mockAccount]);
+  });
+
+  it("returns true when the pnl flag is on and accounts exist", () => {
+    const { result } = renderHook(() => useShouldDisplayAnalyticsPnl());
+
+    expect(result.current).toBe(true);
+    expect(mockUseWalletFeaturesConfig).toHaveBeenCalledWith("mobile");
+  });
+
+  it("returns false when the pnl flag is off", () => {
+    mockWalletConfig(false);
+
+    const { result } = renderHook(() => useShouldDisplayAnalyticsPnl());
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns false when there are no accounts", () => {
+    mockUseSelector.mockReturnValue([]);
+
+    const { result } = renderHook(() => useShouldDisplayAnalyticsPnl());
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/hooks/useShouldDisplayAnalyticsPnl.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/hooks/useShouldDisplayAnalyticsPnl.ts
@@ -1,0 +1,9 @@
+import { useSelector } from "~/context/hooks";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import { shallowAccountsSelector } from "~/reducers/accounts";
+
+export function useShouldDisplayAnalyticsPnl(): boolean {
+  const { shouldDisplayPnl: isPnlFlagOn } = useWalletFeaturesConfig("mobile");
+  const accounts = useSelector(shallowAccountsSelector);
+  return isPnlFlagOn && accounts.length > 0;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/ChartSectionHeaderView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/ChartSectionHeaderView.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { TrendSection } from "LLM/components/TrendSection";
+import { AnalyticsBalanceDisplay } from "LLM/features/Analytics/components/AnalyticsBalanceDisplay";
+import { CHART_SECTION_TEST_IDS, type ChartSectionHeaderViewModel } from "./types";
+
+type Props = Readonly<{
+  viewModel: ChartSectionHeaderViewModel;
+}>;
+
+export function ChartSectionHeaderView({ viewModel }: Props) {
+  const {
+    hoveredBalance,
+    isBalanceAvailable,
+    percentageValue,
+    variationText,
+    rangeLabel,
+    discreet,
+  } = viewModel;
+
+  return (
+    <Box lx={headerStyle} testID={CHART_SECTION_TEST_IDS.header}>
+      <AnalyticsBalanceDisplay hoveredValue={hoveredBalance} />
+      {isBalanceAvailable && (
+        <TrendSection
+          percentage={percentageValue}
+          formattedChange={variationText}
+          timeLabel={rangeLabel}
+          testID={CHART_SECTION_TEST_IDS.trend}
+          trendSize="sm"
+          showTrend={!discreet}
+        />
+      )}
+    </Box>
+  );
+}
+
+const headerStyle: LumenViewStyle = {
+  gap: "s8",
+  paddingHorizontal: "s16",
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/ChartSectionView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/ChartSectionView.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { LineChart } from "LLM/components/LineChart";
+import { ChartSectionHeaderView } from "./ChartSectionHeaderView";
+import { CHART_SECTION_TEST_IDS, type ChartSectionViewModel } from "./types";
+
+type Props = Readonly<{
+  viewModel: ChartSectionViewModel;
+}>;
+
+export function ChartSectionView({ viewModel }: Props) {
+  const { header, chart } = viewModel;
+
+  return (
+    <Box lx={containerStyle} testID={CHART_SECTION_TEST_IDS.root}>
+      <ChartSectionHeaderView viewModel={header} />
+      <Box lx={chartContainerStyle}>
+        <LineChart {...chart} />
+      </Box>
+    </Box>
+  );
+}
+
+const containerStyle: LumenViewStyle = {
+  gap: "s24",
+};
+
+const chartContainerStyle: LumenViewStyle = {
+  paddingHorizontal: "s16",
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/ChartSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/ChartSection.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { genAccount } from "@ledgerhq/live-common/mock/account";
+import { render, screen, withFlagOverrides } from "@tests/test-renderer";
+import { State } from "~/reducers/types";
+import { INITIAL_STATE as portfolioBalanceDisplayInitialState } from "~/reducers/portfolioBalanceDisplay";
+import ChartSection from "..";
+import { CHART_SECTION_TEST_IDS } from "../types";
+
+const btcAccount = genAccount("btc-1", {
+  currency: getCryptoCurrencyById("bitcoin"),
+  operationsSize: 0,
+});
+
+const withChartState =
+  (balanceAvailable = true) =>
+  (state: State): State =>
+    withFlagOverrides({
+      lwmWallet40: { enabled: true, params: { pnl: true } },
+    })({
+      ...state,
+      accounts: { ...state.accounts, active: [btcAccount] },
+      portfolioBalanceDisplay: {
+        ...portfolioBalanceDisplayInitialState,
+        displayedBalance: 5000,
+        isBalanceAvailable: balanceAvailable,
+        isLoading: false,
+      },
+      settings: {
+        ...state.settings,
+        selectedTimeRange: "week",
+      },
+    });
+
+describe("ChartSection", () => {
+  it("renders the balance header and chart when balance is available", () => {
+    render(<ChartSection />, {
+      overrideInitialState: withChartState(true),
+    });
+
+    expect(screen.getByTestId(CHART_SECTION_TEST_IDS.root)).toBeVisible();
+    expect(screen.getByTestId(CHART_SECTION_TEST_IDS.header)).toBeVisible();
+    expect(screen.getByTestId("analytics-balance-amount")).toBeVisible();
+    expect(screen.getByTestId(CHART_SECTION_TEST_IDS.trend)).toBeVisible();
+    expect(screen.getByTestId("analytics-chart")).toBeVisible();
+  });
+
+  it("shows a skeleton when the balance is unavailable", () => {
+    render(<ChartSection />, {
+      overrideInitialState: withChartState(false),
+    });
+
+    expect(screen.getByTestId("analytics-balance-skeleton")).toBeVisible();
+    expect(screen.queryByTestId(CHART_SECTION_TEST_IDS.trend)).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/fixtures.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/fixtures.ts
@@ -1,0 +1,31 @@
+import { INITIAL_STATE as portfolioBalanceDisplayInitialState } from "~/reducers/portfolioBalanceDisplay";
+
+export const portfolioWithHistory = {
+  balanceHistory: [
+    { date: new Date("2026-01-01T00:00:00.000Z"), value: 1000 },
+    { date: new Date("2026-01-02T00:00:00.000Z"), value: 1200 },
+  ],
+  countervalueChange: { percentage: 0.2, value: 200 },
+  balanceAvailable: true,
+  availableAccounts: [],
+  unavailableCurrencies: [],
+  accounts: [],
+  range: "week" as const,
+  histories: [],
+  countervalueReceiveSum: 0,
+  countervalueSendSum: 0,
+};
+
+export const chartSectionInitialState = (state: import("~/reducers/types").State) => ({
+  ...state,
+  portfolioBalanceDisplay: {
+    ...portfolioBalanceDisplayInitialState,
+    displayedBalance: 1200,
+    isBalanceAvailable: true,
+    isLoading: false,
+  },
+  settings: {
+    ...state.settings,
+    selectedTimeRange: "week" as const,
+  },
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/useChartSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/useChartSectionViewModel.test.ts
@@ -1,0 +1,123 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { track } from "~/analytics";
+import { usePortfolioAllAccounts } from "~/hooks/portfolio";
+import { useChartSectionViewModel } from "../useChartSectionViewModel";
+import { chartSectionInitialState, portfolioWithHistory } from "./fixtures";
+
+jest.mock("~/hooks/portfolio", () => ({
+  usePortfolioAllAccounts: jest.fn(),
+}));
+
+jest.mock("~/analytics", () => ({
+  track: jest.fn(),
+}));
+
+const mockUsePortfolioAllAccounts = jest.mocked(usePortfolioAllAccounts);
+const mockTrack = jest.mocked(track);
+
+describe("useChartSectionViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePortfolioAllAccounts.mockReturnValue(portfolioWithHistory);
+  });
+
+  it("builds chart series from portfolio balance history and maps the selected range", () => {
+    const { result } = renderHook(() => useChartSectionViewModel(), {
+      overrideInitialState: chartSectionInitialState,
+    });
+
+    expect(result.current.chart.series[0].data).toEqual([1000, 1200]);
+    expect(result.current.chart.selectedRange).toBe("1w");
+    expect(result.current.header.hoveredBalance).toBeNull();
+    expect(result.current.header.isBalanceAvailable).toBe(true);
+  });
+
+  it("uses balance availability for the chart loading state", () => {
+    const { result } = renderHook(() => useChartSectionViewModel(), {
+      overrideInitialState: state => ({
+        ...chartSectionInitialState(state),
+        portfolioBalanceDisplay: {
+          ...state.portfolioBalanceDisplay,
+          isBalanceAvailable: false,
+          isLoading: true,
+        },
+      }),
+    });
+
+    expect(result.current.chart.isLoading).toBe(true);
+  });
+
+  it("dispatches the portfolio range and tracks when the chart range changes", () => {
+    const { result, store } = renderHook(() => useChartSectionViewModel(), {
+      overrideInitialState: chartSectionInitialState,
+    });
+
+    act(() => {
+      result.current.chart.onRangeChange("1m");
+    });
+
+    expect(store.getState().settings.selectedTimeRange).toBe("month");
+    expect(mockTrack).toHaveBeenCalledWith("timeframe_clicked", { timeframe: "month" });
+  });
+
+  it("formats chart tooltip and variation values from smallest-unit countervalues", () => {
+    const { result } = renderHook(() => useChartSectionViewModel(), {
+      overrideInitialState: chartSectionInitialState,
+    });
+
+    expect(result.current.chart.formatValue?.(1000)).toBe("$10.00");
+    expect(result.current.header.variationText).toBe("+$2.00");
+    expect(result.current.header.percentageValue).toBe(20);
+  });
+
+  it("uses NaN percentage when the value change percentage is unavailable", () => {
+    mockUsePortfolioAllAccounts.mockReturnValue({
+      ...portfolioWithHistory,
+      countervalueChange: { percentage: null, value: 0 },
+    });
+
+    const { result } = renderHook(() => useChartSectionViewModel(), {
+      overrideInitialState: state => ({
+        ...chartSectionInitialState(state),
+        settings: {
+          ...chartSectionInitialState(state).settings,
+          selectedTimeRange: "all",
+        },
+      }),
+    });
+
+    expect(result.current.header.percentageValue).toBeNaN();
+  });
+
+  it("masks the chart tooltip value when discreet mode is enabled", () => {
+    const { result } = renderHook(() => useChartSectionViewModel(), {
+      overrideInitialState: state => ({
+        ...chartSectionInitialState(state),
+        settings: {
+          ...chartSectionInitialState(state).settings,
+          discreetMode: true,
+        },
+      }),
+    });
+
+    expect(result.current.chart.formatValue?.(1000)).toBe("$***");
+    expect(result.current.header.discreet).toBe(true);
+    expect(result.current.header.variationText).toBe("***");
+  });
+
+  it("updates hoveredBalance when scrubbing the chart", () => {
+    const { result } = renderHook(() => useChartSectionViewModel(), {
+      overrideInitialState: chartSectionInitialState,
+    });
+
+    act(() => {
+      result.current.chart.onScrubberPositionChange?.(0);
+    });
+    expect(result.current.header.hoveredBalance).toBe(1000);
+
+    act(() => {
+      result.current.chart.onScrubberPositionChange?.(undefined);
+    });
+    expect(result.current.header.hoveredBalance).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/index.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { ChartSectionView } from "./ChartSectionView";
+import { useChartSectionViewModel } from "./useChartSectionViewModel";
+
+export function ChartSection() {
+  const viewModel = useChartSectionViewModel();
+  return <ChartSectionView viewModel={viewModel} />;
+}
+
+export default React.memo(ChartSection);

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/types.ts
@@ -1,0 +1,22 @@
+import type { LineChartProps } from "LLM/components/LineChart";
+import type { AnalyticsChartRange } from "LLM/features/Analytics/utils/portfolioRangeMapping";
+
+export type ChartSectionHeaderViewModel = Readonly<{
+  hoveredBalance: number | null;
+  isBalanceAvailable: boolean;
+  percentageValue: number;
+  variationText: string;
+  rangeLabel: string;
+  discreet: boolean;
+}>;
+
+export type ChartSectionViewModel = Readonly<{
+  header: ChartSectionHeaderViewModel;
+  chart: LineChartProps<AnalyticsChartRange>;
+}>;
+
+export const CHART_SECTION_TEST_IDS = {
+  root: "analytics-chart-section",
+  header: "analytics-chart-header",
+  trend: "analytics-balance-trend",
+} as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/useChartSectionViewModel.ts
@@ -1,0 +1,195 @@
+import { useCallback, useMemo, useState } from "react";
+import BigNumber from "bignumber.js";
+import { useDispatch, useSelector } from "~/context/hooks";
+import { useTranslation, useLocale } from "~/context/Locale";
+import { formatPrice, formatSignedFiatVariation } from "@ledgerhq/live-currency-format";
+import { useCountervaluesState } from "~/reducers/countervalues";
+import { accountsSelector } from "~/reducers/accounts";
+import {
+  counterValueCurrencySelector,
+  discreetModeSelector,
+  selectedTimeRangeSelector,
+} from "~/reducers/settings";
+import { setSelectedTimeRange } from "~/actions/settings";
+import { track } from "~/analytics";
+import { usePortfolioAllAccounts } from "~/hooks/portfolio";
+import { usePortfolioBalanceForDisplay } from "LLM/hooks/usePortfolioBalanceForDisplay";
+import {
+  DEFAULT_LINE_CHART_HEIGHT,
+  getExtremaPointMarkers,
+  resolveLineChartColorFromPercentChange,
+  type LineChartScrubberPositionChange,
+  type LineChartSeries,
+  type LineChartTooltipTitle,
+  type LineChartValueFormatter,
+} from "LLM/components/LineChart";
+import {
+  ANALYTICS_CHART_RANGES,
+  isAnalyticsChartRange,
+  lineChartRangeToPortfolioRange,
+  portfolioRangeToLineChartRange,
+  type AnalyticsChartRange,
+} from "LLM/features/Analytics/utils/portfolioRangeMapping";
+import { resolveAnalyticsValueChange } from "LLM/features/Analytics/utils/resolveAnalyticsValueChange";
+import {
+  buildAnalyticsChartXAxisConfig,
+  buildAnalyticsChartYAxisConfig,
+} from "LLM/features/Analytics/utils/chartAxisConfig";
+import type { ChartSectionViewModel } from "./types";
+
+export function useChartSectionViewModel(): ChartSectionViewModel {
+  const { t } = useTranslation();
+  const { locale } = useLocale();
+  const dispatch = useDispatch();
+  const selectedTimeRange = useSelector(selectedTimeRangeSelector);
+  const counterValue = useSelector(counterValueCurrencySelector);
+  const accounts = useSelector(accountsSelector);
+  const countervalues = useCountervaluesState();
+  const discreet = useSelector(discreetModeSelector);
+  const portfolio = usePortfolioAllAccounts();
+  const { displayedBalance, isBalanceAvailable } = usePortfolioBalanceForDisplay();
+
+  const selectedRange = portfolioRangeToLineChartRange(selectedTimeRange);
+  const fiatUnit = counterValue.units[0];
+  const [hoveredBalance, setHoveredBalance] = useState<number | null>(null);
+
+  const valueChange = useMemo(
+    () =>
+      resolveAnalyticsValueChange({
+        selectedTimeRange,
+        accounts,
+        currentBalance: displayedBalance,
+        portfolio,
+        cvState: countervalues,
+        counterValue,
+      }),
+    [selectedTimeRange, accounts, displayedBalance, portfolio, countervalues, counterValue],
+  );
+
+  const { prices, timestamps } = useMemo(() => {
+    const history = portfolio.balanceHistory;
+    return {
+      prices: history.map(point => point.value),
+      timestamps: history.map(point => point.date.getTime()),
+    };
+  }, [portfolio.balanceHistory]);
+
+  const series = useMemo<LineChartSeries[]>(
+    () => [
+      {
+        id: "analytics-portfolio-balance",
+        data: prices,
+        label: t("analytics.title"),
+        stroke: "",
+      },
+    ],
+    [prices, t],
+  );
+
+  const formatValue = useMemo<LineChartValueFormatter>(
+    () => value =>
+      formatPrice(fiatUnit, new BigNumber(value), {
+        showCode: true,
+        locale,
+        discreet,
+      }),
+    [fiatUnit, locale, discreet],
+  );
+
+  const dateFormatters = useMemo(
+    () => ({
+      hour: new Intl.DateTimeFormat(locale, { hour: "numeric", minute: "numeric" }),
+      day: new Intl.DateTimeFormat(locale, {
+        day: "numeric",
+        month: "numeric",
+        year: "numeric",
+      }),
+    }),
+    [locale],
+  );
+
+  const formatDate = useCallback(
+    (timestamp: number) =>
+      (selectedRange === "1d" ? dateFormatters.hour : dateFormatters.day).format(
+        new Date(timestamp),
+      ),
+    [selectedRange, dateFormatters],
+  );
+
+  const tooltipTitle = useMemo<LineChartTooltipTitle>(
+    () => dataIndex => {
+      const timestamp = timestamps[dataIndex];
+      if (timestamp == null) return undefined;
+      return formatDate(timestamp);
+    },
+    [timestamps, formatDate],
+  );
+
+  const onScrubberPositionChange = useCallback<LineChartScrubberPositionChange>(
+    index => {
+      if (index == null) {
+        setHoveredBalance(null);
+        return;
+      }
+      const value = prices[index];
+      setHoveredBalance(Number.isFinite(value) ? value : null);
+    },
+    [prices],
+  );
+
+  const onRangeChange = useCallback(
+    (range: AnalyticsChartRange) => {
+      const portfolioRange = lineChartRangeToPortfolioRange(range);
+      if (!portfolioRange || portfolioRange === selectedTimeRange) return;
+      setHoveredBalance(null);
+      dispatch(setSelectedTimeRange(portfolioRange));
+      track("timeframe_clicked", { timeframe: portfolioRange });
+    },
+    [dispatch, selectedTimeRange],
+  );
+
+  const percentageValue = valueChange.percentage == null ? NaN : valueChange.percentage * 100;
+  const mainUnitValue = new BigNumber(valueChange.value).shiftedBy(-fiatUnit.magnitude).toNumber();
+  const variationText = discreet
+    ? "***"
+    : formatSignedFiatVariation(mainUnitValue, fiatUnit, locale);
+  const rangeLabel = t(`assetDetail.balanceGraph.timeLabel.${selectedRange}`);
+
+  return {
+    header: {
+      hoveredBalance,
+      isBalanceAvailable,
+      percentageValue,
+      variationText,
+      rangeLabel,
+      discreet,
+    },
+    chart: {
+      series,
+      selectedRange,
+      onRangeChange,
+      ranges: ANALYTICS_CHART_RANGES.map(value => ({
+        value,
+        label: t(`common:time.${lineChartRangeToPortfolioRange(value) ?? "day"}`),
+      })),
+      isRangeValue: isAnalyticsChartRange,
+      color: resolveLineChartColorFromPercentChange(
+        valueChange.percentage == null ? undefined : percentageValue,
+      ),
+      isLoading: !isBalanceAvailable,
+      height: DEFAULT_LINE_CHART_HEIGHT,
+      formatValue,
+      tooltipTitle,
+      onScrubberPositionChange,
+      showScrubberTooltip: true,
+      showScrubberBeacons: false,
+      showXAxis: false,
+      showYAxis: false,
+      xAxis: buildAnalyticsChartXAxisConfig({ timestamps, selectedRange, formatDate }),
+      yAxis: buildAnalyticsChartYAxisConfig(),
+      points: getExtremaPointMarkers(series),
+      accessibilityLabel: t("assetDetail.balanceGraph.timeframeSelector"),
+      testID: "analytics-chart",
+    },
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/MainGraph.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/MainGraph.tsx
@@ -1,8 +1,16 @@
 import React from "react";
 import PortfolioGraphCard from "~/screens/Portfolio/PortfolioGraphCard";
+import { useShouldDisplayAnalyticsPnl } from "LLM/features/Analytics/hooks/useShouldDisplayAnalyticsPnl";
 import { ANALYTICS_PAGE } from "../../../const";
+import ChartSection from "./ChartSection";
 
 const MainGraph: React.FC = () => {
+  const shouldDisplayPnl = useShouldDisplayAnalyticsPnl();
+
+  if (shouldDisplayPnl) {
+    return <ChartSection />;
+  }
+
   return <PortfolioGraphCard showAssets={true} screenName={ANALYTICS_PAGE} />;
 };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/usePnlSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/usePnlSectionViewModel.ts
@@ -1,6 +1,5 @@
 import { useCallback, useMemo, useState, useRef } from "react";
 import { BigNumber } from "bignumber.js";
-import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { usePortfolioPnL } from "@ledgerhq/wallet-pnl/hooks";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useSelector } from "~/context/hooks";
@@ -11,6 +10,7 @@ import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/s
 import { buildReturnCard } from "LLM/features/Pnl/builders/buildReturnCard";
 import { buildPnlDetail } from "LLM/features/Pnl/builders/buildPnlDetail";
 import { PNL_BUTTON, PNL_DETAIL_PAGE } from "LLM/features/Pnl/const";
+import { useShouldDisplayAnalyticsPnl } from "LLM/features/Analytics/hooks/useShouldDisplayAnalyticsPnl";
 import type { PnlSectionViewModel } from "./types";
 import { track } from "~/analytics";
 import { ANALYTICS_PAGE } from "../../../../const";
@@ -21,14 +21,14 @@ const EMPTY_ACCOUNTS: Parameters<typeof usePortfolioPnL>[0] = [];
 export function usePnlSectionViewModel(): PnlSectionViewModel {
   const { t } = useTranslation();
   const { locale } = useLocale();
-  const { shouldDisplayPnl: isPnlFlagOn } = useWalletFeaturesConfig("mobile");
+  const shouldDisplayPnl = useShouldDisplayAnalyticsPnl();
   const accounts = useSelector(shallowAccountsSelector);
   const countervalues = useCountervaluesState();
   const fiat = useSelector(counterValueCurrencySelector);
   const discreet = useSelector(discreetModeSelector);
 
   // Skip the (potentially expensive) portfolio walk when the section is hidden.
-  const pnl = usePortfolioPnL(isPnlFlagOn ? accounts : EMPTY_ACCOUNTS, countervalues, fiat);
+  const pnl = usePortfolioPnL(shouldDisplayPnl ? accounts : EMPTY_ACCOUNTS, countervalues, fiat);
   const { unrealisedPnL = ZERO, realisedPnL = ZERO, totalPnL = ZERO } = pnl ?? {};
 
   const [isDrawerOpen, setDrawerOpen] = useState(false);
@@ -98,7 +98,7 @@ export function usePnlSectionViewModel(): PnlSectionViewModel {
   );
 
   return {
-    shouldDisplayPnl: isPnlFlagOn && accounts.length > 0,
+    shouldDisplayPnl,
     title: t("pnl.portfolio.title"),
     unrealised,
     realised,

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/__tests__/MainGraph.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/__tests__/MainGraph.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { useShouldDisplayAnalyticsPnl } from "LLM/features/Analytics/hooks/useShouldDisplayAnalyticsPnl";
+import MainGraph from "../MainGraph";
+
+jest.mock("LLM/features/Analytics/hooks/useShouldDisplayAnalyticsPnl");
+jest.mock("../ChartSection", () => {
+  const { View } = require("react-native");
+  return {
+    __esModule: true,
+    default: () => <View testID="analytics-chart-section" />,
+  };
+});
+jest.mock("~/screens/Portfolio/PortfolioGraphCard", () => {
+  const { View } = require("react-native");
+  return {
+    __esModule: true,
+    default: () => <View testID="legacy-portfolio-graph-card" />,
+  };
+});
+
+const mockUseShouldDisplayAnalyticsPnl = jest.mocked(useShouldDisplayAnalyticsPnl);
+
+describe("MainGraph", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders ChartSection when the PnL flag is on and accounts exist", () => {
+    mockUseShouldDisplayAnalyticsPnl.mockReturnValue(true);
+
+    render(<MainGraph />);
+
+    expect(screen.getByTestId("analytics-chart-section")).toBeVisible();
+    expect(screen.queryByTestId("legacy-portfolio-graph-card")).toBeNull();
+  });
+
+  it("renders the legacy portfolio graph when PnL is hidden", () => {
+    mockUseShouldDisplayAnalyticsPnl.mockReturnValue(false);
+
+    render(<MainGraph />);
+
+    expect(screen.getByTestId("legacy-portfolio-graph-card")).toBeVisible();
+    expect(screen.queryByTestId("analytics-chart-section")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/utils/__tests__/computeAllTimeValueChangeFromFirstReceive.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/utils/__tests__/computeAllTimeValueChangeFromFirstReceive.test.ts
@@ -1,0 +1,89 @@
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import {
+  getCryptoCurrencyById,
+  getFiatCurrencyByTicker,
+} from "@ledgerhq/live-common/currencies/index";
+import { genAccount } from "@ledgerhq/live-common/mock/account";
+import { calculate } from "@ledgerhq/live-countervalues/logic";
+import BigNumber from "bignumber.js";
+import type { Account } from "@ledgerhq/types-live";
+import { computeAllTimeValueChangeFromFirstReceive } from "../computeAllTimeValueChangeFromFirstReceive";
+
+jest.mock("@ledgerhq/live-countervalues/logic", () => ({
+  calculate: jest.fn(),
+}));
+
+const mockCalculate = jest.mocked(calculate);
+
+const btc = getCryptoCurrencyById("bitcoin");
+const usd = getFiatCurrencyByTicker("USD");
+const mockCvState = { data: {}, status: {}, cache: {} } as CounterValuesState;
+
+function accountWithReceive(id: string, receiveDate: Date, receiveValue: number): Account {
+  const account = genAccount(id, { currency: btc, operationsSize: 1 });
+  account.operations = [
+    {
+      ...account.operations[0],
+      id: `${id}-receive`,
+      type: "IN",
+      date: receiveDate,
+      value: new BigNumber(receiveValue),
+    },
+  ];
+  return account;
+}
+
+describe("computeAllTimeValueChangeFromFirstReceive", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns null percentage when there are no receive operations", () => {
+    const account = genAccount("empty", { currency: btc, operationsSize: 0 });
+    account.operations = [];
+
+    const result = computeAllTimeValueChangeFromFirstReceive([account], 1000, mockCvState, usd);
+
+    expect(result).toEqual({ value: 0, percentage: null });
+  });
+
+  it("uses the earliest receive operation as the all-time baseline", () => {
+    const earlier = accountWithReceive("btc-1", new Date("2020-01-01"), 1_000_000);
+    const later = accountWithReceive("btc-2", new Date("2021-01-01"), 2_000_000);
+    mockCalculate.mockReturnValue(100);
+
+    const result = computeAllTimeValueChangeFromFirstReceive(
+      [later, earlier],
+      250,
+      mockCvState,
+      usd,
+    );
+
+    expect(mockCalculate).toHaveBeenCalledWith(
+      mockCvState,
+      expect.objectContaining({
+        date: earlier.operations[0].date,
+      }),
+    );
+    expect(result.value).toBe(150);
+    expect(result.percentage).toBe(1.5);
+  });
+
+  it("returns a neutral value change when the first receive countervalue is unavailable", () => {
+    const account = accountWithReceive("btc-1", new Date("2020-01-01"), 1_000_000);
+    mockCalculate.mockReturnValue(undefined);
+
+    const result = computeAllTimeValueChangeFromFirstReceive([account], 1000, mockCvState, usd);
+
+    expect(result).toEqual({ value: 0, percentage: null });
+  });
+
+  it("returns zero percentage when the all-time delta is exactly zero", () => {
+    const account = accountWithReceive("btc-1", new Date("2020-01-01"), 1_000_000);
+    mockCalculate.mockReturnValue(1000);
+
+    const result = computeAllTimeValueChangeFromFirstReceive([account], 1000, mockCvState, usd);
+
+    expect(result).toEqual({ value: 0, percentage: 0 });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/utils/__tests__/portfolioRangeMapping.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/utils/__tests__/portfolioRangeMapping.test.ts
@@ -1,0 +1,34 @@
+import {
+  ANALYTICS_CHART_RANGES,
+  isAnalyticsChartRange,
+  lineChartRangeToPortfolioRange,
+  portfolioRangeToLineChartRange,
+} from "../portfolioRangeMapping";
+
+describe("portfolioRangeMapping", () => {
+  it("maps portfolio ranges to line chart ranges", () => {
+    expect(portfolioRangeToLineChartRange("day")).toBe("1d");
+    expect(portfolioRangeToLineChartRange("week")).toBe("1w");
+    expect(portfolioRangeToLineChartRange("month")).toBe("1m");
+    expect(portfolioRangeToLineChartRange("year")).toBe("1y");
+    expect(portfolioRangeToLineChartRange("all")).toBe("all");
+  });
+
+  it("maps supported line chart ranges back to portfolio ranges", () => {
+    expect(lineChartRangeToPortfolioRange("1d")).toBe("day");
+    expect(lineChartRangeToPortfolioRange("1w")).toBe("week");
+    expect(lineChartRangeToPortfolioRange("1m")).toBe("month");
+    expect(lineChartRangeToPortfolioRange("1y")).toBe("year");
+    expect(lineChartRangeToPortfolioRange("all")).toBe("all");
+    expect(lineChartRangeToPortfolioRange("6m")).toBeUndefined();
+  });
+
+  it("exposes only portfolio-compatible analytics chart ranges", () => {
+    expect(ANALYTICS_CHART_RANGES).toEqual(["1d", "1w", "1m", "1y", "all"]);
+  });
+
+  it("validates analytics chart range values", () => {
+    expect(isAnalyticsChartRange("1w")).toBe(true);
+    expect(isAnalyticsChartRange("6m")).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/utils/__tests__/resolveAnalyticsValueChange.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/utils/__tests__/resolveAnalyticsValueChange.test.ts
@@ -1,0 +1,47 @@
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import { getFiatCurrencyByTicker } from "@ledgerhq/live-common/currencies/index";
+import { resolveAnalyticsValueChange } from "../resolveAnalyticsValueChange";
+
+const mockCounterValue = getFiatCurrencyByTicker("USD");
+const mockCvState = { data: {}, status: {}, cache: {} } as CounterValuesState;
+
+const defaultPortfolio = {
+  balanceHistory: [],
+  countervalueChange: { percentage: 0.12, value: 120 },
+  balanceAvailable: true,
+  availableAccounts: [],
+  unavailableCurrencies: [],
+  accounts: [],
+  range: "week" as const,
+  histories: [],
+  countervalueReceiveSum: 0,
+  countervalueSendSum: 0,
+};
+
+describe("resolveAnalyticsValueChange", () => {
+  it("uses the selected portfolio range change for non-all ranges", () => {
+    const result = resolveAnalyticsValueChange({
+      selectedTimeRange: "week",
+      accounts: [],
+      currentBalance: 1000,
+      portfolio: defaultPortfolio,
+      cvState: mockCvState,
+      counterValue: mockCounterValue,
+    });
+
+    expect(result).toEqual(defaultPortfolio.countervalueChange);
+  });
+
+  it("uses the first receive baseline for the all-time range", () => {
+    const result = resolveAnalyticsValueChange({
+      selectedTimeRange: "all",
+      accounts: [],
+      currentBalance: 1000,
+      portfolio: defaultPortfolio,
+      cvState: mockCvState,
+      counterValue: mockCounterValue,
+    });
+
+    expect(result).toEqual({ value: 0, percentage: null });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/utils/chartAxisConfig.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/utils/chartAxisConfig.ts
@@ -1,0 +1,52 @@
+import { DEFAULT_LINE_CHART_HEIGHT } from "LLM/components/LineChart";
+import type { LineChartXAxisConfig, LineChartYAxisConfig } from "LLM/components/LineChart";
+import type { AnalyticsChartRange } from "./portfolioRangeMapping";
+
+const MIN_X_AXIS_TICKS = 5;
+const MIN_X_AXIS_TICKS_1D = 8;
+const Y_AXIS_BOTTOM_OFFSET_PX = 50;
+
+function getEvenlySpacedTicks(length: number, minTicks: number): number[] {
+  if (length <= 0) return [];
+  if (length <= minTicks) return Array.from({ length }, (_, index) => index);
+
+  const ticks = Array.from({ length: minTicks }, (_, index) =>
+    Math.round((index * (length - 1)) / (minTicks - 1)),
+  );
+  return Array.from(new Set(ticks));
+}
+
+export function buildAnalyticsChartXAxisConfig({
+  timestamps,
+  selectedRange,
+  formatDate,
+}: {
+  readonly timestamps: number[];
+  readonly selectedRange: AnalyticsChartRange;
+  readonly formatDate: (timestamp: number) => string;
+}): LineChartXAxisConfig {
+  return {
+    showLine: false,
+    ticks: getEvenlySpacedTicks(
+      timestamps.length,
+      selectedRange === "1d" ? MIN_X_AXIS_TICKS_1D : MIN_X_AXIS_TICKS,
+    ),
+    tickLabelFormatter: value => {
+      const timestamp = timestamps[Number(value)];
+      return timestamp == null ? "" : formatDate(timestamp);
+    },
+  };
+}
+
+export function buildAnalyticsChartYAxisConfig(): LineChartYAxisConfig {
+  return {
+    domain: ({ min, max }) => {
+      const range = max - min || Math.abs(max) || 1;
+      const valuePerPx = range / DEFAULT_LINE_CHART_HEIGHT;
+      return {
+        min: min - Y_AXIS_BOTTOM_OFFSET_PX * valuePerPx,
+        max,
+      };
+    },
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/utils/computeAllTimeValueChangeFromFirstReceive.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/utils/computeAllTimeValueChangeFromFirstReceive.ts
@@ -1,0 +1,53 @@
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { getOperationAmountNumber } from "@ledgerhq/live-common/operation";
+import { calculate } from "@ledgerhq/live-countervalues/logic";
+import { meaningfulPercentage } from "@ledgerhq/live-countervalues/portfolio";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import { flattenAccounts } from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import type { AccountLike, ValueChange } from "@ledgerhq/types-live";
+
+export function computeAllTimeValueChangeFromFirstReceive(
+  accounts: AccountLike[],
+  currentBalance: number,
+  cvState: CounterValuesState,
+  cvCurrency: Currency,
+): ValueChange {
+  let firstReceiveDate: Date | undefined;
+  let firstReceiveAmount = 0;
+  let firstReceiveCurrency: Currency | undefined;
+
+  for (const account of flattenAccounts(accounts)) {
+    for (const operation of account.operations) {
+      if (operation.type !== "IN") continue;
+      if (!firstReceiveDate || operation.date < firstReceiveDate) {
+        firstReceiveDate = operation.date;
+        firstReceiveAmount = getOperationAmountNumber(operation).toNumber();
+        firstReceiveCurrency = getAccountCurrency(account);
+      }
+    }
+  }
+
+  if (!firstReceiveDate || !firstReceiveCurrency) {
+    return { value: 0, percentage: null };
+  }
+
+  const firstReceiveCountervalue = calculate(cvState, {
+    from: firstReceiveCurrency,
+    to: cvCurrency,
+    value: firstReceiveAmount,
+    date: firstReceiveDate,
+    disableRounding: true,
+  });
+
+  if (typeof firstReceiveCountervalue !== "number") {
+    return { value: 0, percentage: null };
+  }
+
+  const value = currentBalance - firstReceiveCountervalue;
+
+  return {
+    value,
+    percentage: value === 0 ? 0 : (meaningfulPercentage(value, firstReceiveCountervalue) ?? null),
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/utils/portfolioRangeMapping.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/utils/portfolioRangeMapping.ts
@@ -1,0 +1,36 @@
+import type { PortfolioRange } from "@ledgerhq/types-live";
+
+export const ANALYTICS_CHART_RANGES = ["1d", "1w", "1m", "1y", "all"] as const;
+
+export type AnalyticsChartRange = (typeof ANALYTICS_CHART_RANGES)[number];
+
+const ANALYTICS_CHART_RANGE_SET: ReadonlySet<string> = new Set(ANALYTICS_CHART_RANGES);
+
+const PORTFOLIO_TO_CHART_RANGE: Record<PortfolioRange, AnalyticsChartRange> = {
+  day: "1d",
+  week: "1w",
+  month: "1m",
+  year: "1y",
+  all: "all",
+};
+
+const CHART_TO_PORTFOLIO_RANGE: Partial<Record<AnalyticsChartRange, PortfolioRange>> = {
+  "1d": "day",
+  "1w": "week",
+  "1m": "month",
+  "1y": "year",
+  all: "all",
+};
+
+export function portfolioRangeToLineChartRange(range: PortfolioRange): AnalyticsChartRange {
+  return PORTFOLIO_TO_CHART_RANGE[range];
+}
+
+export function lineChartRangeToPortfolioRange(range: string): PortfolioRange | undefined {
+  if (!isAnalyticsChartRange(range)) return undefined;
+  return CHART_TO_PORTFOLIO_RANGE[range];
+}
+
+export function isAnalyticsChartRange(value: string): value is AnalyticsChartRange {
+  return ANALYTICS_CHART_RANGE_SET.has(value);
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/utils/resolveAnalyticsValueChange.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/utils/resolveAnalyticsValueChange.ts
@@ -1,0 +1,31 @@
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import type { AccountLike, Portfolio, PortfolioRange, ValueChange } from "@ledgerhq/types-live";
+import { computeAllTimeValueChangeFromFirstReceive } from "./computeAllTimeValueChangeFromFirstReceive";
+
+export function resolveAnalyticsValueChange({
+  selectedTimeRange,
+  accounts,
+  currentBalance,
+  portfolio,
+  cvState,
+  counterValue,
+}: {
+  readonly selectedTimeRange: PortfolioRange;
+  readonly accounts: AccountLike[];
+  readonly currentBalance: number;
+  readonly portfolio: Portfolio;
+  readonly cvState: CounterValuesState;
+  readonly counterValue: Currency;
+}): ValueChange {
+  if (selectedTimeRange === "all") {
+    return computeAllTimeValueChangeFromFirstReceive(
+      accounts,
+      currentBalance,
+      cvState,
+      counterValue,
+    );
+  }
+
+  return portfolio.countervalueChange;
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a new "ChartSection" component to the Analytics feature, providing a modernized portfolio balance chart with improved UI and test coverage. It also centralizes the logic for displaying PnL (Profit & Loss) analytics, ensuring consistent feature flag handling across the codebase. The most important changes are summarized below.


https://github.com/user-attachments/assets/296d42a9-7266-4cda-94bf-505663d3f4fd




### ❓ Context

[LIVE-31885](https://ledgerhq.atlassian.net/browse/LIVE-31885)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-31885]: https://ledgerhq.atlassian.net/browse/LIVE-31885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ