### PR TITLE
fix: automatically delete smartling branches when closing prs

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -10,7 +10,7 @@ concurrency:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
   pull-requests: write
   actions: write
 
@@ -34,7 +34,7 @@ jobs:
         if: ${{ env.IS_SMARTLING == 'true' }}
         run: |
           echo "should_skip=true" >> $GITHUB_OUTPUT
-          gh pr close ${{ github.event.pull_request.number }} -R LedgerHQ/ledger-live
+          gh pr close ${{ github.event.pull_request.number }} -R LedgerHQ/ledger-live --delete-branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -10,12 +10,14 @@ concurrency:
 
 permissions:
   id-token: write
-  contents: write
+  contents: read
   pull-requests: write
   actions: write
 
 jobs:
   pre_job:
+    permissions:
+      contents: write
     name: "Skip Check"
     if: ${{!github.event.pull_request.head.repo.fork}}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Smartling PRs are auto-closed by the `smartling_check` step in `build-and-test-pr.yml`, but `gh pr close` only closes the PR — it never deletes the head branch. GitHub's "auto-delete head branch" setting only triggers on *merge*, not *close*, so every Smartling branch is orphaned. This has left **1,225** stale `smartling-content-updated-*` / `smartling-translation-completed-*` branches on the remote (accumulating ~190–300/month since Oct 2025).

## Notes

- This stops the leak going forward. The ~1,225 existing stale branches still need a one-time bulk cleanup (tracked separately in [LIVE-18158](https://ledgerhq.atlassian.net/browse/LIVE-18158)).

[LIVE-18158]: https://ledgerhq.atlassian.net/browse/LIVE-18158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ