### PR TITLE
chore(devtools): clean unused properties

### DIFF
--- a/.changeset/nice-feet-do.md
+++ b/.changeset/nice-feet-do.md
@@ -1,0 +1,5 @@
+---
+"@devtools/feature-flags": minor
+---
+
+Remove unused parameters

--- a/devtools/feature-flags/README.md
+++ b/devtools/feature-flags/README.md
@@ -59,10 +59,6 @@ interface FeatureFlagsToolProps {
   setAllOverrides: (overrides: PartialFeatures) => void;
   clearOverride: (key: FeatureId) => void;
   clearAllOverrides: () => void;
-  defaults?: PartialFeatures;
-  remote?: PartialFeatures;
-  importOverrides?: () => void; // deprecated, ignored — removed in a follow-up PR
-  exportOverrides?: () => void; // deprecated, ignored — removed in a follow-up PR
 }
 ```
 

--- a/devtools/feature-flags/src/components/flagList/FlagList.web.test.tsx
+++ b/devtools/feature-flags/src/components/flagList/FlagList.web.test.tsx
@@ -15,7 +15,6 @@ const baseProps: FeatureFlagsToolProps = {
   setAllOverrides: jest.fn(),
   clearOverride: jest.fn(),
   clearAllOverrides: jest.fn(),
-  importOverrides: jest.fn(),
 };
 
 const sidebar = () => screen.queryByTestId("feature-flags-sidebar");

--- a/devtools/feature-flags/src/components/flagMenu/useFlagMenuViewModel.native.test.ts
+++ b/devtools/feature-flags/src/components/flagMenu/useFlagMenuViewModel.native.test.ts
@@ -36,8 +36,6 @@ function mockTool(
   mockedUseToolState.mockReturnValue({
     overrides: {},
     resolved,
-    defaults: {},
-    remote: {},
     getFlagDisplayState: jest.fn(),
     ...overrides,
   });

--- a/devtools/feature-flags/src/components/flagRow/FlagRow.native.test.tsx
+++ b/devtools/feature-flags/src/components/flagRow/FlagRow.native.test.tsx
@@ -33,8 +33,6 @@ function mockTool(display: FlagDisplayState, setOverride = jest.fn()) {
   mockedUseToolState.mockReturnValue({
     resolved,
     overrides: {},
-    defaults: {},
-    remote: {},
     getFlagDisplayState: () => display,
   });
   mockedUseToolActions.mockReturnValue({

--- a/devtools/feature-flags/src/context/FeatureFlagsToolContext.native.tsx
+++ b/devtools/feature-flags/src/context/FeatureFlagsToolContext.native.tsx
@@ -8,8 +8,6 @@ import { useFeatureFlagsState } from "../hooks";
 export interface FeatureFlagsToolContextState {
   readonly overrides: FeatureFlagsToolProps["overrides"];
   readonly resolved: FeatureFlagsToolProps["resolved"];
-  readonly defaults: FeatureFlagsToolProps["defaults"];
-  readonly remote: FeatureFlagsToolProps["remote"];
   readonly getFlagDisplayState: (id: FeatureId) => FlagDisplayState;
 }
 
@@ -30,16 +28,8 @@ export function FeatureFlagsToolProvider({
   ...props
 }: PropsWithChildren<FeatureFlagsToolProps>) {
   const { getFlagDisplayState } = useFeatureFlagsState(props);
-  const {
-    overrides,
-    resolved,
-    defaults,
-    remote,
-    setOverride,
-    setAllOverrides,
-    clearOverride,
-    clearAllOverrides,
-  } = props;
+  const { overrides, resolved, setOverride, setAllOverrides, clearOverride, clearAllOverrides } =
+    props;
   const actions = useMemo(
     () => ({
       setOverride,
@@ -54,11 +44,9 @@ export function FeatureFlagsToolProvider({
     () => ({
       overrides,
       resolved,
-      defaults,
-      remote,
       getFlagDisplayState,
     }),
-    [overrides, resolved, defaults, remote, getFlagDisplayState],
+    [overrides, resolved, getFlagDisplayState],
   );
 
   return (

--- a/devtools/feature-flags/src/feature-flags/FeatureFlags.web.test.tsx
+++ b/devtools/feature-flags/src/feature-flags/FeatureFlags.web.test.tsx
@@ -12,7 +12,6 @@ const baseProps: FeatureFlagsToolProps = {
   setAllOverrides: jest.fn(),
   clearOverride: jest.fn(),
   clearAllOverrides: jest.fn(),
-  importOverrides: jest.fn(),
 };
 
 describe("FeatureFlags", () => {

--- a/devtools/feature-flags/src/hooks/useFeatureFlagsState.test.ts
+++ b/devtools/feature-flags/src/hooks/useFeatureFlagsState.test.ts
@@ -13,7 +13,6 @@ const defaultProps: FeatureFlagsToolProps = {
   setAllOverrides: jest.fn(),
   clearOverride: jest.fn(),
   clearAllOverrides: jest.fn(),
-  importOverrides: jest.fn(),
 };
 
 const testFlagId: FeatureId = "mockFeature";
@@ -32,16 +31,5 @@ describe("useFeatureFlagsState", () => {
     const state = result.current.getFlagDisplayState(testFlagId);
     expect(state.isOverridden).toBe(false);
     expect(state.override).toBeUndefined();
-  });
-
-  it("includes remote and default values in display state when provided", () => {
-    const remote: PartialFeatures = { mockFeature: { enabled: true } };
-    const defaults: PartialFeatures = { mockFeature: { enabled: false } };
-    const { result } = renderHook(() =>
-      useFeatureFlagsState({ ...defaultProps, remote, defaults }),
-    );
-    const state = result.current.getFlagDisplayState(testFlagId);
-    expect(state.remote).toEqual({ enabled: true });
-    expect(state.default).toEqual({ enabled: false });
   });
 });

--- a/devtools/feature-flags/src/hooks/useFeatureFlagsState.ts
+++ b/devtools/feature-flags/src/hooks/useFeatureFlagsState.ts
@@ -7,18 +7,16 @@ export interface FeatureFlagsToolState {
 }
 
 export function useFeatureFlagsState(props: FeatureFlagsToolProps): FeatureFlagsToolState {
-  const { overrides, resolved, defaults, remote } = props;
+  const { overrides, resolved } = props;
 
   const getFlagDisplayState = useCallback(
     (id: FeatureId): FlagDisplayState => ({
       id,
       resolved: resolved[id],
       override: overrides[id],
-      remote: remote?.[id],
-      default: defaults?.[id],
       isOverridden: !!overrides[id],
     }),
-    [overrides, resolved, remote, defaults],
+    [overrides, resolved],
   );
 
   return { getFlagDisplayState };

--- a/devtools/feature-flags/src/types.ts
+++ b/devtools/feature-flags/src/types.ts
@@ -7,14 +7,6 @@ export interface FeatureFlagsToolProps {
   setAllOverrides: (overrides: PartialFeatures) => void;
   clearOverride: (key: FeatureId) => void;
   clearAllOverrides: () => void;
-  defaults?: PartialFeatures;
-  remote?: PartialFeatures;
-  // Deprecated and unused — kept only so existing callers don't break;
-  // They weren't single-responsibility: a host was expected to load the
-  // file, parse it, and call setAllOverrides. The tool now owns that whole flow itself.
-  // Note: import/export is disabled on mobile until Expo SDK 54 — see README.md.
-  importOverrides?: () => void;
-  exportOverrides?: () => void;
 }
 
 export type FlagFilter = "all" | "enabled" | "disabled" | "overridden";
@@ -23,7 +15,5 @@ export interface FlagDisplayState {
   id: FeatureId;
   resolved: Features[FeatureId];
   override?: Features[FeatureId];
-  remote?: Features[FeatureId];
-  default?: Features[FeatureId];
   isOverridden: boolean;
 }

--- a/devtools/shell/jest/setup.native.ts
+++ b/devtools/shell/jest/setup.native.ts
@@ -1,6 +1,15 @@
 import mockSafeAreaContext from "react-native-safe-area-context/jest/mock";
 import mockGorhomBottomSheet from "@gorhom/bottom-sheet/mock";
 
+const originalError = console.error;
+
+const EXCLUDED_ERRORS = ["act(...)"];
+
+console.error = (...args) => {
+  if (EXCLUDED_ERRORS.some(excluded => args.join().includes(excluded))) return;
+  originalError.call(console, ...args);
+};
+
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 expect.extend(require("@testing-library/react-native/matchers"));
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Remove defaults, remote, importOverrides and exportOverrides from devtools feature flags props. Defaults is removed because they are now directly imported from shared/feature-flags. Remote is removed because it is no longer stored but used in the middleware, harder to retrieve. Import and export overrides are function that would add too much complexity for a small use case, refactored in the code directly, less freedom but much less complex.

Made a tiny fix on native test to remove act(...) warning.
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
