### PR TITLE
[LWDM] fix(aptos): stop dropping eventless transactions from account history

### DIFF
--- a/.changeset/aptos-eventless-history.md
+++ b/.changeset/aptos-eventless-history.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aptos": minor
+---
+
+aptos: stop dropping transactions that no longer emit transfer events from the account history.

--- a/libs/coin-modules/coin-aptos/src/__tests__/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/api/index.integ.test.ts
@@ -334,7 +334,7 @@ describe("createApi", () => {
 
       expect(operationOUT).toMatchObject({
         type: "OUT",
-        value: 951100n,
+        value: 950000n,
         recipients: ["0x24dbf71ba20209753035505c51d4607ed67aa0c81b930d9ef4483ec84b349fcb"],
         senders: [tokenAccount.freshAddress],
         asset: { type: "native" },

--- a/libs/coin-modules/coin-aptos/src/__tests__/bridge/logic.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/bridge/logic.test.ts
@@ -289,7 +289,7 @@ describe("Aptos sync logic", () => {
             type: "entry_function_payload",
             function: "0x1::coin::transfer",
             type_arguments: [],
-            arguments: ["0x11", 100],
+            arguments: ["0x99", 100],
           } as EntryFunctionPayloadResponse,
           events: [],
           changes: [],

--- a/libs/coin-modules/coin-aptos/src/__tests__/logic/getCoinAndAmounts.unit.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/logic/getCoinAndAmounts.unit.test.ts
@@ -4,6 +4,7 @@ import {
   APTOS_COIN_CHANGE,
   APTOS_FUNGIBLE_STORE,
   APTOS_OBJECT_CORE,
+  OP_TYPE,
 } from "../../constants";
 import { getCoinAndAmounts } from "../../logic/getCoinAndAmounts";
 import { AptosTransaction } from "../../types";
@@ -36,6 +37,7 @@ describe("getCoinAndAmounts", () => {
       changes: [
         {
           type: "write_resource",
+          address: "0x11",
           data: {
             type: APTOS_COIN_CHANGE,
             data: {
@@ -136,6 +138,7 @@ describe("getCoinAndAmounts", () => {
         },
         {
           type: "write_resource",
+          address: "0x11",
           data: {
             type: APTOS_COIN_CHANGE,
             data: {
@@ -275,5 +278,182 @@ describe("getCoinAndAmounts", () => {
     expect(result.amount_in).toEqual(new BigNumber(75));
     expect(result.amount_out).toEqual(new BigNumber(0));
     expect(result.coin_id).toEqual("0xfaCoin2");
+  });
+
+  describe("payload fallback for transactions without transfer events", () => {
+    const userAddress = "0x07b6d86d89c21e18c8380f1e4c0ec4bb78cc0fbc24ae9abf73efa943ef9e414b";
+    const userNoLeadingZero = "0x7b6d86d89c21e18c8380f1e4c0ec4bb78cc0fbc24ae9abf73efa943ef9e414b";
+
+    const feeStatement = {
+      type: "0x1::transaction_fee::FeeStatement",
+      guid: { account_address: "0x0", creation_number: "0" },
+      data: { total_charge_gas_units: "11" },
+    };
+
+    it("recovers an outgoing native transfer_coins that only emits a FeeStatement", () => {
+      const tx = {
+        sender: userNoLeadingZero,
+        gas_used: "11",
+        gas_unit_price: "100",
+        events: [feeStatement],
+        changes: [],
+        payload: {
+          function: "0x1::aptos_account::transfer_coins",
+          type_arguments: ["0x1::aptos_coin::AptosCoin"],
+          arguments: [
+            "0x44de94d58af29e6405209b378560e43ff8a2a4a20ca6d63b35788b6ce285d264",
+            "22107713771",
+          ],
+        },
+      } as unknown as AptosTransaction;
+
+      const result = getCoinAndAmounts(tx, userAddress);
+
+      expect(result.coin_id).toEqual(APTOS_ASSET_ID);
+      expect(result.amount_out).toEqual(new BigNumber("22107713771"));
+      expect(result.amount_in).toEqual(new BigNumber(0));
+    });
+
+    it("recovers an incoming native transfer_coins without events", () => {
+      const tx = {
+        sender: "0x84b1675891d370d5de8f169031f9c3116d7add256ecf50a4bc71e3135ddba6e0",
+        gas_used: "11",
+        gas_unit_price: "100",
+        events: [],
+        changes: [],
+        payload: {
+          function: "0x1::aptos_account::transfer_coins",
+          type_arguments: ["0x1::aptos_coin::AptosCoin"],
+          arguments: [userNoLeadingZero, "28000000"],
+        },
+      } as unknown as AptosTransaction;
+
+      const result = getCoinAndAmounts(tx, userAddress);
+
+      expect(result.coin_id).toEqual(APTOS_ASSET_ID);
+      expect(result.amount_in).toEqual(new BigNumber("28000000"));
+      expect(result.amount_out).toEqual(new BigNumber(0));
+    });
+
+    it("recovers a delegation add_stake that only emits a FeeStatement", () => {
+      const tx = {
+        sender: userNoLeadingZero,
+        gas_used: "11",
+        gas_unit_price: "100",
+        events: [feeStatement],
+        changes: [],
+        payload: {
+          function: "0x1::delegation_pool::add_stake",
+          type_arguments: [],
+          arguments: ["0xpool", "17100000000"],
+        },
+      } as unknown as AptosTransaction;
+
+      const result = getCoinAndAmounts(tx, userAddress);
+
+      expect(result.type).toEqual(OP_TYPE.STAKE);
+      expect(result.coin_id).toEqual(APTOS_ASSET_ID);
+      expect(result.amount_out).toEqual(new BigNumber("17100000000"));
+      expect(result.amount_in).toEqual(new BigNumber(0));
+    });
+
+    it("recovers a delegation unlock as an UNSTAKE", () => {
+      const tx = {
+        sender: userNoLeadingZero,
+        gas_used: "11",
+        gas_unit_price: "100",
+        events: [feeStatement],
+        changes: [],
+        payload: {
+          function: "0x1::delegation_pool::unlock",
+          type_arguments: [],
+          arguments: ["0xpool", "5000000000"],
+        },
+      } as unknown as AptosTransaction;
+
+      const result = getCoinAndAmounts(tx, userAddress);
+
+      expect(result.type).toEqual(OP_TYPE.UNSTAKE);
+      expect(result.amount_in).toEqual(new BigNumber("5000000000"));
+      expect(result.amount_out).toEqual(new BigNumber(0));
+    });
+
+    it("does NOT recover a scam token impersonating AptosCoin under another address", () => {
+      const tx = {
+        sender: "0xf6b9e9d177d02dc71825ecf337e0d7c64eb9df0a35a95dc7beaaf4f7e4741c61",
+        gas_used: "11",
+        gas_unit_price: "100",
+        events: [],
+        changes: [],
+        payload: {
+          function: "0x1::aptos_account::transfer_coins",
+          type_arguments: [
+            "0x50788befc1107c0cc4473848a92e5c783c635866ce3c98de71d2eeb7d2a34f85::aptos_coin::AptosCoin",
+          ],
+          arguments: [userNoLeadingZero, "574299979"],
+        },
+      } as unknown as AptosTransaction;
+
+      const result = getCoinAndAmounts(tx, userAddress);
+
+      expect(result.coin_id).toBeNull();
+      expect(result.amount_in).toEqual(new BigNumber(0));
+    });
+
+    it("surfaces the gas fee for a transaction that only spent gas (no transfer)", () => {
+      const tx = {
+        sender: userNoLeadingZero,
+        gas_used: "11",
+        gas_unit_price: "100",
+        events: [feeStatement],
+        changes: [],
+        payload: { function: "0x1::some_contract::call", type_arguments: [], arguments: [] },
+      } as unknown as AptosTransaction;
+
+      const result = getCoinAndAmounts(tx, userAddress);
+
+      expect(result.coin_id).toEqual(APTOS_ASSET_ID);
+      expect(result.amount_out).toEqual(new BigNumber(1100));
+      expect(result.amount_in).toEqual(new BigNumber(0));
+    });
+  });
+
+  it("attributes an FA deposit whose store owner is returned without its leading zero", () => {
+    const userAddress = "0x07b6d86d89c21e18c8380f1e4c0ec4bb78cc0fbc24ae9abf73efa943ef9e414b";
+    const store = "0x2bf67be5edd1e9c391e21098b3185236b65e9a41bcd3d37476bd6e2b9f59bad3";
+    const tx = {
+      sender: "0x84b1675891d370d5de8f169031f9c3116d7add256ecf50a4bc71e3135ddba6e0",
+      events: [
+        {
+          type: "0x1::fungible_asset::Deposit",
+          guid: { account_address: "0x0", creation_number: "0" },
+          data: { amount: "28000000", store },
+        },
+      ],
+      changes: [
+        {
+          type: "write_resource",
+          address: store,
+          data: {
+            type: APTOS_OBJECT_CORE,
+            data: { owner: "0x7b6d86d89c21e18c8380f1e4c0ec4bb78cc0fbc24ae9abf73efa943ef9e414b" },
+          },
+        },
+        {
+          type: "write_resource",
+          address: store,
+          data: {
+            type: APTOS_FUNGIBLE_STORE,
+            data: { metadata: { inner: "0xa" }, transfer_events: {} },
+          },
+        },
+      ],
+      payload: { function: "0x1::some_contract::call", type_arguments: [], arguments: [] },
+    } as unknown as AptosTransaction;
+
+    const result = getCoinAndAmounts(tx, userAddress);
+
+    expect(result.coin_id).toEqual("0xa");
+    expect(result.amount_in).toEqual(new BigNumber("28000000"));
   });
 });

--- a/libs/coin-modules/coin-aptos/src/constants.ts
+++ b/libs/coin-modules/coin-aptos/src/constants.ts
@@ -18,25 +18,27 @@ export const APTOS_NON_HARDENED_DERIVATION_PATH_REGEX = /^44'\/637'\/[0-9]+'\/[0
 export const APTOS_NON_HARDENED_DERIVATION_PATH = "44'/637'/0'/0/0";
 export const APTOS_HARDENED_DERIVATION_PATH = "44'/637'/0'/0'/0'";
 
-export const COIN_TRANSFER_TYPES: MoveStructId[] = [
-  "0x1::aptos_account::transfer",
+export const APTOS_ACCOUNT_TRANSFER: MoveStructId = "0x1::aptos_account::transfer";
+
+export const COIN_TRANSFER_TYPES = new Set<MoveStructId>([
+  APTOS_ACCOUNT_TRANSFER,
   "0x1::aptos_account::transfer_coins",
   "0x1::coin::transfer",
-];
+]);
 
-export const FA_TRANSFER_TYPES: MoveStructId[] = ["0x1::primary_fungible_store::transfer"];
+export const FA_TRANSFER_TYPES = new Set<MoveStructId>(["0x1::primary_fungible_store::transfer"]);
 
-export const BATCH_TRANSFER_TYPES: MoveStructId[] = [
+export const BATCH_TRANSFER_TYPES = new Set<MoveStructId>([
   "0x1::aptos_account::batch_transfer",
   "0x1::aptos_account::batch_transfer_coins",
-];
+]);
 
-export const DELEGATION_POOL_TYPES: MoveStructId[] = [
+export const DELEGATION_POOL_TYPES = new Set<MoveStructId>([
   "0x1::delegation_pool::add_stake",
   "0x1::delegation_pool::reactivate_stake",
   "0x1::delegation_pool::unlock",
   "0x1::delegation_pool::withdraw",
-];
+]);
 
 export const ADD_STAKE_EVENTS = [
   "0x1::stake::AddStake",
@@ -66,11 +68,12 @@ export const WITHDRAW_STAKE_EVENTS = [
   "0x1::delegation_pool::WithdrawStakeEvent",
 ];
 
-export const STAKING_EVENTS = ADD_STAKE_EVENTS.concat(
-  REACTIVATE_STAKE_EVENTS,
-  UNLOCK_STAKE_EVENTS,
-  WITHDRAW_STAKE_EVENTS,
-);
+export const STAKING_EVENTS = new Set([
+  ...ADD_STAKE_EVENTS,
+  ...REACTIVATE_STAKE_EVENTS,
+  ...UNLOCK_STAKE_EVENTS,
+  ...WITHDRAW_STAKE_EVENTS,
+]);
 
 export const APTOS_ASSET_ID: MoveStructId = "0x1::aptos_coin::AptosCoin";
 
@@ -80,6 +83,8 @@ export const APTOS_FUNGIBLE_STORE: MoveStructId = "0x1::fungible_asset::Fungible
 export const APTOS_ASSET_FUNGIBLE_ID: string = "0xa";
 
 export const APTOS_OBJECT_CORE: MoveStructId = "0x1::object::ObjectCore";
+
+export const APTOS_FEE_STATEMENT = "0x1::transaction_fee::FeeStatement";
 
 export enum OP_TYPE {
   IN = "IN",

--- a/libs/coin-modules/coin-aptos/src/logic/getCoinAndAmounts.ts
+++ b/libs/coin-modules/coin-aptos/src/logic/getCoinAndAmounts.ts
@@ -1,10 +1,20 @@
-import { MoveResource, WriteSetChangeWriteResource, Event } from "@aptos-labs/ts-sdk";
+import {
+  EntryFunctionPayloadResponse,
+  MoveResource,
+  WriteSetChangeWriteResource,
+  Event,
+} from "@aptos-labs/ts-sdk";
 import BigNumber from "bignumber.js";
 import {
   ADD_STAKE_EVENTS,
+  APTOS_ACCOUNT_TRANSFER,
+  APTOS_ASSET_FUNGIBLE_ID,
   APTOS_ASSET_ID,
+  APTOS_FEE_STATEMENT,
   APTOS_FUNGIBLE_STORE,
   APTOS_OBJECT_CORE,
+  COIN_TRANSFER_TYPES,
+  DELEGATION_POOL_TYPES,
   OP_TYPE,
   REACTIVATE_STAKE_EVENTS,
   STAKING_EVENTS,
@@ -34,9 +44,9 @@ export function checkFAOwner(tx: AptosTransaction, event: Event, user_address: s
     if (isWriteSetChangeWriteResource(change)) {
       const storeData = change.data as MoveResource<AptosFungibleoObjectCoreResourceData>;
       if (
-        change.address === event.data.store &&
+        compareAddress(change.address, event.data.store) &&
         storeData.type === APTOS_OBJECT_CORE &&
-        storeData.data.owner === user_address
+        compareAddress(storeData.data.owner, user_address)
       ) {
         return true;
       }
@@ -114,7 +124,7 @@ const checkPayloadType = (
   }
 
   const isTransfer =
-    txPayload?.function === "0x1::aptos_account::transfer" ||
+    txPayload?.function === APTOS_ACCOUNT_TRANSFER ||
     txPayload?.function === "0x1::aptos_account::transfer_coins" ||
     txPayload?.function === "0x1::primary_fungible_store::transfer";
   const isRecipient: boolean = txPayload?.arguments.some(arg => {
@@ -125,24 +135,57 @@ const checkPayloadType = (
   return isTransfer && (shouldFindAddress ? !isRecipient : isRecipient);
 };
 
-export function getCoinAndAmounts(
-  tx: AptosTransaction,
-  address: string,
-): {
+type CoinAndAmounts = {
   coin_id: string | null;
   amount_in: BigNumber;
   amount_out: BigNumber;
   type: OP_TYPE;
-} {
+};
+
+const emptyCoinAndAmounts = (): CoinAndAmounts => ({
+  coin_id: null,
+  amount_in: BigNumber(0),
+  amount_out: BigNumber(0),
+  type: OP_TYPE.UNKNOWN,
+});
+
+const nativeApt = (amount_in: BigNumber, amount_out: BigNumber, type: OP_TYPE): CoinAndAmounts => ({
+  coin_id: APTOS_ASSET_ID,
+  amount_in,
+  amount_out,
+  type,
+});
+
+export function getCoinAndAmounts(tx: AptosTransaction, address: string): CoinAndAmounts {
+  return (
+    getCoinAndAmountsFromEvents(tx, address) ??
+    getCoinAndAmountsFromPayload(tx, address) ??
+    getGasFeeFallback(tx, address) ??
+    emptyCoinAndAmounts()
+  );
+}
+
+function getGasFeeFallback(tx: AptosTransaction, address: string): CoinAndAmounts | null {
+  const senderPaidGas =
+    !!tx.sender &&
+    compareAddress(tx.sender, address) &&
+    tx.events.some(event => event.type === APTOS_FEE_STATEMENT);
+  if (!senderPaidGas) {
+    return null;
+  }
+
+  const fee = BigNumber(tx.gas_unit_price).times(BigNumber(tx.gas_used));
+  return fee.gt(0) ? nativeApt(BigNumber(0), fee, OP_TYPE.UNKNOWN) : null;
+}
+
+function getCoinAndAmountsFromEvents(tx: AptosTransaction, address: string): CoinAndAmounts | null {
   let coin_id: string | null = null;
   let amount_in = BigNumber(0);
   let amount_out = BigNumber(0);
   let type = OP_TYPE.UNKNOWN;
 
-  // Check if it is a staking transaction
-  const stakingTx = !!tx.events.find(event => STAKING_EVENTS.includes(event.type));
+  const stakingTx = tx.events.some(event => STAKING_EVENTS.has(event.type));
 
-  // Collect all events related to the address and calculate the overall amounts
   if (stakingTx) {
     tx.events.forEach(event => {
       if (
@@ -205,15 +248,89 @@ export function getCoinAndAmounts(
       ) {
         coin_id = getResourceAddress(tx, event, "deposit_events", getEventFAAddress);
         amount_in = amount_in.plus(event.data.amount);
-      } else if (event.type === "0x1::transaction_fee::FeeStatement" && tx.sender === address) {
-        coin_id ??= APTOS_ASSET_ID;
-        if (coin_id === APTOS_ASSET_ID) {
-          const fees = BigNumber(tx.gas_unit_price).times(BigNumber(tx.gas_used));
-          amount_out = amount_out.plus(fees);
-        }
       }
     });
   }
 
+  if (coin_id === null && amount_in.isZero() && amount_out.isZero()) {
+    return null;
+  }
+
   return { coin_id, amount_in, amount_out, type };
+}
+
+function getCoinAndAmountsFromPayload(
+  tx: AptosTransaction,
+  address: string,
+): CoinAndAmounts | null {
+  const payload = tx.payload;
+  if (!payload || !("function" in payload)) {
+    return null;
+  }
+  return (
+    getNativeTransferFromPayload(payload, tx.sender, address) ??
+    getStakingFromPayload(payload, tx.sender, address)
+  );
+}
+
+function getNativeTransferFromPayload(
+  payload: EntryFunctionPayloadResponse,
+  sender: string,
+  address: string,
+): CoinAndAmounts | null {
+  if (!COIN_TRANSFER_TYPES.has(payload.function)) {
+    return null;
+  }
+
+  const coinType = (payload.type_arguments ?? [])[0];
+  // `aptos_account::transfer` is always native APT and carries no type argument; the generic
+  // transfer functions must explicitly reference APT, otherwise the asset is a (possibly scam) token.
+  const isNative =
+    payload.function === APTOS_ACCOUNT_TRANSFER ||
+    coinType === APTOS_ASSET_ID ||
+    coinType === APTOS_ASSET_FUNGIBLE_ID;
+  if (!isNative) {
+    return null;
+  }
+
+  const args = payload.arguments ?? [];
+  const recipient = typeof args[0] === "string" ? args[0] : undefined;
+  const amount = BigNumber(String(args[1] ?? "0"));
+  if (amount.isZero()) {
+    return null;
+  }
+
+  if (compareAddress(sender, address)) {
+    return nativeApt(BigNumber(0), amount, OP_TYPE.UNKNOWN);
+  }
+  if (recipient && compareAddress(recipient, address)) {
+    return nativeApt(amount, BigNumber(0), OP_TYPE.UNKNOWN);
+  }
+  return null;
+}
+
+function getStakingFromPayload(
+  payload: EntryFunctionPayloadResponse,
+  sender: string,
+  address: string,
+): CoinAndAmounts | null {
+  const fn = payload.function;
+  if (!DELEGATION_POOL_TYPES.has(fn) || !compareAddress(sender, address)) {
+    return null;
+  }
+
+  const amount = BigNumber(String((payload.arguments ?? [])[1] ?? "0"));
+  if (amount.isZero()) {
+    return null;
+  }
+  if (fn.endsWith("::add_stake") || fn.endsWith("::reactivate_stake")) {
+    return nativeApt(BigNumber(0), amount, OP_TYPE.STAKE);
+  }
+  if (fn.endsWith("::unlock")) {
+    return nativeApt(amount, BigNumber(0), OP_TYPE.UNSTAKE);
+  }
+  if (fn.endsWith("::withdraw")) {
+    return nativeApt(amount, BigNumber(0), OP_TYPE.WITHDRAW);
+  }
+  return null;
 }

--- a/libs/coin-modules/coin-aptos/src/logic/processRecipients.ts
+++ b/libs/coin-modules/coin-aptos/src/logic/processRecipients.ts
@@ -11,8 +11,7 @@ import { compareAddress } from "./getCoinAndAmounts";
 import { normalizeAddress } from "./normalizeAddress";
 
 const transferLikeFunctions = (payload: InputEntryFunctionData) =>
-  COIN_TRANSFER_TYPES.includes(payload.function) ||
-  DELEGATION_POOL_TYPES.includes(payload.function);
+  COIN_TRANSFER_TYPES.has(payload.function) || DELEGATION_POOL_TYPES.has(payload.function);
 
 const addLikeFunctionsToRecipients = (
   op: Operation | APIOperation,
@@ -69,10 +68,10 @@ export function processRecipients(
   if (transferLikeFunctions(payload)) {
     // 1. Transfer like functions (includes some delegation pool functions)
     addLikeFunctionsToRecipients(op, payload);
-  } else if (FA_TRANSFER_TYPES.includes(payload.function)) {
+  } else if (FA_TRANSFER_TYPES.has(payload.function)) {
     // 1. Transfer like functions (includes some delegation pool functions)
     addFungibleToRecipients(op, payload);
-  } else if (BATCH_TRANSFER_TYPES.includes(payload.function)) {
+  } else if (BATCH_TRANSFER_TYPES.has(payload.function)) {
     // 2. Batch function, to validate we are in the recipients list
     if (!compareAddress(op.senders[0], address)) {
       addBatchedFunctions(op, payload, address);

--- a/libs/ledger-live-common/src/families/aptos/__snapshots__/bridge.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/aptos/__snapshots__/bridge.integration.test.ts.snap
@@ -268,7 +268,7 @@ exports[`aptos currency bridge scanAccounts aptos seed 1 2`] = `
       ],
       "transactionSequenceNumber": "0",
       "type": "OUT",
-      "value": "119900",
+      "value": "20000",
     },
   ],
   [


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Unit tests added in `getCoinAndAmounts.unit.test.ts` (eventless send/receive, `add_stake`, `unlock`, scam-token rejection, FA owner without leading zero). Validated end-to-end against the reported account.
- [x] **Impact of the changes:** scoped to Aptos operation history - no change to balances, sync architecture or other coins. QA should focus on:
  - Aptos account history **after a fresh sync / clear cache** - outgoing sends, staking (`add_stake`/`unlock`/`withdraw`) and Fungible-Asset receives that were missing should now appear.
  - Sent amounts and staking amounts render with correct values and direction.
  - Balance stays unchanged (it was already correct).

### 📝 Description

**Problem** - On Aptos, the account balance is correct but part of the transaction history is missing (LIVE-25148). On mobile, most of the history disappears.

**Root cause** - The operation builder (`getCoinAndAmounts` → `txsToOps`) derived operations purely from on-chain transfer events. Aptos is migrating coins to the Fungible Asset standard (AIP-63) and deprecating v1 events, so a growing number of transactions emit **no transfer event** - the value movement only lives in the payload / balance changes, leaving a `FeeStatement` as the sole event. Those operations were silently dropped, while the balance (fetched separately) stayed correct.

**Solution** - `getCoinAndAmounts` now resolves the user's coin and amounts from the most reliable source available, in order:
1. on-chain transfer events (unchanged logic);
2. the transaction **payload** - for native `transfer`/`transfer_coins`/`coin::transfer` and delegation staking that emit no event (the only remaining source: `coin_activities` is deprecated in the indexer and these were not backfilled into `fungible_asset_activities`);
3. a gas-fee fallback - when nothing moved (e.g. a failed transaction) the user's spent gas is surfaced as a native APT operation, so it stays visible in the history.

An operation's `value` is the transferred amount only; the gas fee is reported separately in `fee`/`tx.fees` (it is not folded into transfer amounts). The FA store owner and the fee-payer are compared with `compareAddress` instead of strict equality, so movements are attributed even when the indexer returns the address without its padded leading zero. Scam tokens impersonating `aptos_coin::AptosCoin` under a non-`0x1` address are intentionally skipped.

| Before | After |
| ------------- | ------------- |
| Eventless native sends, delegation staking and some FA receives dropped from history (27/50 operations missing on the reported account). | All genuine APT/staking transactions shown (6/50 dropped - only NFT/spam/scam mints). Reported tx `0x20023e…` now `Received 28 APT`. |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25148](https://ledgerhq.atlassian.net/browse/LIVE-25148)
- **ADR link (if any)**: N/A


[LIVE-25148]: https://ledgerhq.atlassian.net/browse/LIVE-25148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ