### PR TITLE
[LWDM] fix(e2e): resolve Concordium testnet currency in app.json generation

### DIFF
--- a/.changeset/concordium-testnet-appjson-currency.md
+++ b/.changeset/concordium-testnet-appjson-currency.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-cli": patch
+"@ledgerhq/live-common": patch
+---
+
+Fix Concordium e2e app.json generation resolving to the mainnet currency instead of testnet, by giving the testnet its own Speculos app identity (mirroring Ethereum Sepolia).

--- a/apps/cli/src/commands/live/generateAppJson.ts
+++ b/apps/cli/src/commands/live/generateAppJson.ts
@@ -17,13 +17,19 @@ export type GenerateAppJsonJobOpts = Partial<{
   base: string;
 }>;
 
-type CoinGroup = { currency: Currency; accounts: { index: number; scheme?: string }[] };
+type CoinGroup = {
+  currency: Currency;
+  accounts: { index: number; scheme?: string }[];
+};
 
 const DEFAULT_OUTPUT_DIR = "e2e/userdata/generated";
-const DEFAULT_BASE = "e2e/desktop/tests/userdata/skip-onboarding-with-last-seen-device.json";
+const DEFAULT_BASE =
+  "e2e/desktop/tests/userdata/skip-onboarding-with-last-seen-device.json";
 
 function resolveOutputDir(outputDir?: string): string {
-  return path.resolve(outputDir ?? process.env.E2E_GENERATED_USERDATA_DIR ?? DEFAULT_OUTPUT_DIR);
+  return path.resolve(
+    outputDir ?? process.env.E2E_GENERATED_USERDATA_DIR ?? DEFAULT_OUTPUT_DIR,
+  );
 }
 
 function groupAccountsByCoin(coins?: string[]): Map<string, CoinGroup> {
@@ -35,7 +41,11 @@ function groupAccountsByCoin(coins?: string[]): Map<string, CoinGroup> {
     if (coins?.length && !coins.includes(id)) continue;
     const group = groups.get(id) ?? { currency: value.currency, accounts: [] };
     const scheme = value.derivationMode || undefined;
-    if (!group.accounts.some(a => a.index === value.index && a.scheme === scheme)) {
+    if (
+      !group.accounts.some(
+        (a) => a.index === value.index && a.scheme === scheme,
+      )
+    ) {
       group.accounts.push({ index: value.index, scheme });
     }
     groups.set(id, group);
@@ -75,14 +85,17 @@ async function generateCoin(
     const count = written?.data?.accounts?.length ?? 0;
     return `${coinId}: ${count} account(s) -> ${outPath}`;
   } catch (error) {
-    return `${coinId}: FAILED (${error instanceof Error ? error.message : String(error)})`;
+    return `${coinId}: FAILED (${
+      error instanceof Error ? error.message : String(error)
+    })`;
   } finally {
     if (device) await stopSpeculos(device.id);
   }
 }
 
 export default {
-  description: "Generate one app.json per coin for E2E userdata, launching Speculos automatically",
+  description:
+    "Generate one app.json per coin for E2E userdata, launching Speculos automatically",
   args: [
     {
       name: "coin",
@@ -112,7 +125,8 @@ export default {
     fs.mkdirSync(outDir, { recursive: true });
 
     const baseTemplate = path.resolve(base ?? DEFAULT_BASE);
-    if (!fs.existsSync(baseTemplate)) throw new Error(`base userdata not found: ${baseTemplate}`);
+    if (!fs.existsSync(baseTemplate))
+      throw new Error(`base userdata not found: ${baseTemplate}`);
 
     process.env.LEDGER_LIVE_CLI_BIN = process.argv[1];
     setEnv("MOCK", "");
@@ -120,7 +134,10 @@ export default {
     setEnv("PLAYWRIGHT_RUN", true);
 
     if (!getEnv("E2E_NANO_APP_VERSION_PATH")) {
-      setEnv("E2E_NANO_APP_VERSION_PATH", path.join(outDir, "nano-app-catalog.json"));
+      setEnv(
+        "E2E_NANO_APP_VERSION_PATH",
+        path.join(outDir, "nano-app-catalog.json"),
+      );
     }
 
     const groups = groupAccountsByCoin(coin);

--- a/libs/ledger-live-common/src/e2e/data/deviceLabelsData.ts
+++ b/libs/ledger-live-common/src/e2e/data/deviceLabelsData.ts
@@ -72,6 +72,7 @@ export const DEVICE_LABELS_CONFIG: DeviceLabelsConfig = {
       [AppInfos.SOLANA.name]: DeviceLabels.PUBKEY,
       [AppInfos.ZCASH.name]: DeviceLabels.VERIFY_ADDRESS,
       [AppInfos.CONCORDIUM.name]: DeviceLabels.ADDRESS,
+      [AppInfos.CONCORDIUM_TESTNET.name]: DeviceLabels.ADDRESS,
       default: DeviceLabels.ADDRESS,
     },
     receiveConfirm: {
@@ -104,6 +105,7 @@ export const DEVICE_LABELS_CONFIG: DeviceLabelsConfig = {
       [AppInfos.COSMOS.name]: DeviceLabels.TYPE_SEND,
       [AppInfos.POLKADOT.name]: DeviceLabels.CHAIN_STATEMINT,
       [AppInfos.CONCORDIUM.name]: DeviceLabels.TRANSACTION_TYPE,
+      [AppInfos.CONCORDIUM_TESTNET.name]: DeviceLabels.TRANSACTION_TYPE,
       default: DeviceLabels.REVIEW_OPERATION,
     },
     sendConfirm: {
@@ -119,6 +121,7 @@ export const DEVICE_LABELS_CONFIG: DeviceLabelsConfig = {
       [AppInfos.DOGECOIN.name]: DeviceLabels.ACCEPT,
       [AppInfos.BITCOIN.name]: DeviceLabels.CONTINUE,
       [AppInfos.CONCORDIUM.name]: DeviceLabels.SIGN_TRANSACTION,
+      [AppInfos.CONCORDIUM_TESTNET.name]: DeviceLabels.SIGN_TRANSACTION,
       default: DeviceLabels.CAPS_APPROVE,
     },
   },
@@ -187,6 +190,7 @@ export const DEVICE_LABELS_CONFIG: DeviceLabelsConfig = {
       [AppInfos.DOGECOIN.name]: DeviceLabels.ACCEPT,
       [AppInfos.BITCOIN_CASH.name]: DeviceLabels.ACCEPT,
       [AppInfos.CONCORDIUM.name]: DeviceLabels.SIGN_TRANSACTION,
+      [AppInfos.CONCORDIUM_TESTNET.name]: DeviceLabels.SIGN_TRANSACTION,
       default: DeviceLabels.CAPS_APPROVE,
     },
   },

--- a/libs/ledger-live-common/src/e2e/enum/AppInfos.ts
+++ b/libs/ledger-live-common/src/e2e/enum/AppInfos.ts
@@ -83,5 +83,7 @@ export class AppInfos {
 
   static readonly CONCORDIUM = new AppInfos("Concordium");
 
+  static readonly CONCORDIUM_TESTNET = new AppInfos("Concordium (Testnet)");
+
   static readonly SEI = new AppInfos("Sei");
 }

--- a/libs/ledger-live-common/src/e2e/enum/Currency.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Currency.ts
@@ -225,7 +225,7 @@ export class Currency {
     "Concordium (Testnet)",
     "CCD",
     "concordium_testnet",
-    AppInfos.CONCORDIUM,
+    AppInfos.CONCORDIUM_TESTNET,
     [Network.CONCORDIUM],
   );
 

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -444,6 +444,14 @@ export const specs: Specs = {
     },
     dependencies: [],
   },
+  "Concordium_(Testnet)": {
+    currency: getCryptoCurrencyById("concordium_testnet"),
+    appQuery: {
+      model: getSpeculosModel(),
+      appName: "Concordium",
+    },
+    dependencies: [],
+  },
 };
 
 // Resolves DeviceParams from the Provider 1 catalog (app version + firmware) and


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This is e2e test-infrastructure code itself (no unit tests apply). Correctness is validated by the CI "Generate app.json userdata (Speculos)" step and the existing "Send Concordium (Testnet)" e2e spec._
- [x] **Impact of the changes:**
      - CI's "Generate app.json userdata (Speculos)" step (desktop & mobile) should generate `concordium_testnet.json` against the **testnet** currency instead of mainnet.
      - The existing "Send Concordium (Testnet)" e2e spec (`send.tx.spec.ts`) should still pass — on-device labels (address / transaction type / sign transaction) must still display correctly on Nano S.
      - No regression on any other currency's app.json generation (mainnet Concordium's `AppInfos` is untouched; the generic `speculosApp.name` resolution path used by every other coin is unaffected).

### 📝 Description

**Problem**: CI's `generateAppJson` CLI command resolves each coin's `--currency` argument for the `liveData` command via `currency.speculosApp.name`. For Concordium, both the mainnet and testnet `Currency` entries shared the same `AppInfos.CONCORDIUM` ("Concordium") Speculos-app identity, so passing "Concordium" to `liveData --currency` always resolved to the **mainnet** currency — even when generating the CCD **testnet** account used by e2e tests. See the failing step: https://github.com/LedgerHQ/ledger-live/actions/runs/28487968240/job/84438399354#step:8:72

**Solution**: Give the testnet its own `AppInfos.CONCORDIUM_TESTNET` ("Concordium (Testnet)") — mirroring the existing pattern for `AppInfos.ETHEREUM_SEPOLIA` — and point `Currency.CCD_TESTNET.speculosApp` at it. Added the matching Speculos spec entry (reusing the same physical "Concordium" app binary) and duplicated the on-device label overrides so device-label matching keeps working for the testnet identity. As a result, `generateAppJson.ts` needs no special-casing anymore — it resolves correctly like every other coin — and every other CLI helper (`getCcdAccountAddress`, `cliCommandsUtils.ts`, etc.) that resolves currency the same way is fixed too.

### ❓ Context

- **JIRA or GitHub link**: N/A — fix originated from a failing CI run, not a tracked ticket.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)