### PR TITLE
feat(wallet-cli): add one-time, agent-aware first-run nudge

### DIFF
--- a/.changeset/wallet-cli-first-run-nudge.md
+++ b/.changeset/wallet-cli-first-run-nudge.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": minor
+---
+
+Add a one-time, agent-aware first-run nudge that prints a tailored hint to stderr (e.g. `wallet-cli skill install --agent claude`) on the first real command, so agents discover the embedded skill. It is shown at most once per user (persisted via an XDG state marker), silent under `--output json` and for `skill *` commands, opt-out via `WALLET_CLI_NO_NUDGE=1`, and fully best-effort (never throws or changes exit codes). Agent detection is centralized in a new `agent-detection` helper that `isAgentEnvironment()` now delegates to.

--- a/apps/wallet-cli/README.md
+++ b/apps/wallet-cli/README.md
@@ -108,6 +108,17 @@ This package is DMK-focused and is separate from `@ledgerhq/live-cli` ([`apps/cl
 
 AI agents should read the [ledger-wallet-cli agent skill](../../.claude/skills/ledger-wallet-cli/SKILL.md) before running wallet-cli commands. It maps informal user requests to commands and documents hardware-wallet safety rules, session labels, USB sandbox requirements, and device-contention constraints.
 
+### First-run nudge
+
+On the first real command, wallet-cli prints a one-time hint to **stderr** pointing at `skill install`. When a known agent is detected (Claude Code, Cursor, Codex, …) the hint is tailored to it (e.g. `wallet-cli skill install --agent claude`); otherwise it shows the generic `wallet-cli skill install`. The nudge:
+
+- shows at most **once per user** — a marker is written under the XDG state dir (`stateDir("ledger-wallet-cli")`, honoring `XDG_STATE_HOME`);
+- writes to **stderr only**, so it never pollutes piped stdout, and is **silent under `--output json`**;
+- is **not shown for `skill *` commands** (you are already engaging with skills);
+- can be disabled entirely with `WALLET_CLI_NO_NUDGE=1`.
+
+It is fully best-effort: it never throws and never changes a command's exit code.
+
 The skill also **ships inside the compiled binary**, so it is available even from an installed npm package with no repo checkout, via the `skill` command group:
 
 ```bash

--- a/apps/wallet-cli/src/cli.ts
+++ b/apps/wallet-cli/src/cli.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 import { createCLI } from "@bunli/core";
 import "./live-common-setup";
 import { emitTestingBuildBannerIfNeeded } from "./shared/testing-build-banner";
+import { maybeShowFirstRunNudge } from "./shared/first-run-nudge";
 // createCLI() normally tries to import .bunli/commands.gen.ts from process.cwd() via a file:// URL.
 // Our @bunli/core patch removes that dynamic import entirely because it can hang in Bun standalone
 // mode, this static import registers commands instead.
@@ -49,6 +50,7 @@ export async function runMain(argv: string[] = process.argv.slice(2)): Promise<n
   cli.command(GenuineCheckCommand);
   cli.command(RingGroup);
   cli.command(SkillGroup);
+  maybeShowFirstRunNudge(argv);
   const code = await cli.run(normalizeNegatedFlags(argv), { noExit: true });
   return code ?? 0;
 }

--- a/apps/wallet-cli/src/shared/agent-detection.ts
+++ b/apps/wallet-cli/src/shared/agent-detection.ts
@@ -1,0 +1,52 @@
+// Single source of truth for "which AI agent is invoking this CLI", derived from
+// the same env signals used by @bunli/plugin-ai-detect. Keeps detection logic in
+// one place so isAgentEnvironment() and the first-run nudge stay in sync.
+
+import type { SupportedAgent } from "../skills/registry";
+
+export type AgentDetection = {
+  /** True when any known agent env signal is present. */
+  detected: boolean;
+  /**
+   * A valid `skill install --agent` value whenever an agent is detected — a
+   * specific agent (e.g. "claude"), or the generic "agents" bucket
+   * (-> .agents/skills) for agents without a dedicated directory (Gemini CLI /
+   * opencode / amp). Null only when no agent signal is present.
+   */
+  agent: SupportedAgent | null;
+  /** Human-readable name for messaging (falls back to a generic phrase). */
+  label: string;
+};
+
+/**
+ * Detect the calling AI agent from the environment.
+ *
+ * When an agent is detected, `agent` is always a value accepted by
+ * `skill install --agent` — either a specific agent or the generic "agents"
+ * bucket. It is null only when no known agent env signal is present (in which
+ * case `detected` is false too), and callers fall back to generic messaging.
+ */
+export function detectAgent(): AgentDetection {
+  const env = process.env;
+
+  if (env.CLAUDECODE || env.CLAUDE_CODE) {
+    return { detected: true, agent: "claude", label: "Claude Code" };
+  }
+  if (env.CURSOR_AGENT) {
+    return { detected: true, agent: "cursor", label: "Cursor" };
+  }
+  if (env.CODEX_ENABLED) {
+    return { detected: true, agent: "codex", label: "Codex" };
+  }
+  if (env.GEMINI_CLI) {
+    return { detected: true, agent: "agents", label: "Gemini CLI" };
+  }
+  if (env.OPENCODE) {
+    return { detected: true, agent: "agents", label: "opencode" };
+  }
+  if (env.AMP_CURRENT_THREAD_ID || env.AGENT === "amp") {
+    return { detected: true, agent: "agents", label: "amp" };
+  }
+
+  return { detected: false, agent: null, label: "your AI agent" };
+}

--- a/apps/wallet-cli/src/shared/first-run-nudge.ts
+++ b/apps/wallet-cli/src/shared/first-run-nudge.ts
@@ -1,0 +1,71 @@
+// One-time, agent-aware hint printed to stderr on the first real command,
+// pointing the caller at `wallet-cli skill install`. Everything here is
+// best-effort: the whole body is guarded so it can never disrupt the command
+// being run or alter its exit code.
+
+import { colors, isAgentEnvironment, writeStderr } from "./ui";
+import { detectAgent } from "./agent-detection";
+import { hasNudgeBeenShown, markNudgeShown } from "./first-run";
+
+function isJsonOutput(argv: string[]): boolean {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    // Only `--output` has no short alias; `-o` is `--out` (an output file path)
+    // in `ring encrypt/decrypt`, so treating it as `--output` here would misread
+    // e.g. `ring encrypt -o json` (a file named "json") as JSON output.
+    if (arg === "--output=json") return true;
+    if (arg === "--output" && argv[i + 1] === "json") return true;
+  }
+  return false;
+}
+
+/**
+ * True when argv carries no subcommand: an empty invocation, or one that leads
+ * with a flag (`--help`, `-h`, `--version`, or any other flag-led root call).
+ * bunli prints help/root output for all of these, so they aren't a "first real
+ * command" and must not consume the one-time nudge.
+ */
+function isNonCommandInvocation(argv: string[]): boolean {
+  return argv.length === 0 || argv[0].startsWith("-");
+}
+
+function buildMessage(): string {
+  const { agent, label } = detectAgent();
+  // Any detected agent maps to a valid `--agent` value, including the generic
+  // "agents" bucket (-> .agents/skills), which is where Gemini CLI / opencode /
+  // amp read their skills. A bare `skill install` defaults to --agent claude, so
+  // omitting the flag here would point those users at the wrong directory.
+  if (agent) {
+    return (
+      `Tip: install the Ledger wallet-cli skill so ${label} can drive this CLI:\n` +
+      `  wallet-cli skill install --agent ${agent}\n`
+    );
+  }
+  return `Tip: install the Ledger wallet-cli agent skill:\n  wallet-cli skill install\n`;
+}
+
+/**
+ * Show the first-run nudge if appropriate, then persist a marker so it never
+ * shows again for this user. Returns void and never throws.
+ */
+export function maybeShowFirstRunNudge(argv: string[]): void {
+  try {
+    // Opt-out. Empty string stays falsy so tests can re-enable the nudge.
+    if (process.env.WALLET_CLI_NO_NUDGE) return;
+    // Never pollute machine-readable output (also goes to stderr regardless).
+    if (isJsonOutput(argv)) return;
+    // Empty / flag-led invocations (help, version, bare root listing) aren't a
+    // real command — don't consume the one-time nudge before the user runs one.
+    if (isNonCommandInvocation(argv)) return;
+    // The user is already engaging with skills.
+    if (argv[0] === "skill") return;
+    // Show for interactive humans and detected agents; stay quiet in plain pipes.
+    if (!(process.stderr.isTTY === true || isAgentEnvironment())) return;
+    if (hasNudgeBeenShown()) return;
+
+    writeStderr(colors.dim(buildMessage()));
+    markNudgeShown();
+  } catch {
+    // Never let the nudge disrupt the command or its exit code.
+  }
+}

--- a/apps/wallet-cli/src/shared/first-run.ts
+++ b/apps/wallet-cli/src/shared/first-run.ts
@@ -1,0 +1,42 @@
+// Persists a single per-user marker so the first-run nudge is shown at most once.
+// Mirrors session-store.ts: stateDir(APP_NAME) honors XDG_STATE_HOME. All fs
+// access is best-effort — read-only or otherwise hostile environments must never
+// cause the CLI to throw or change its exit code.
+
+import { stateDir } from "@bunli/utils";
+import { join } from "node:path";
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { APP_NAME } from "../session/session-store";
+import { CLI_VERSION } from "../skills/registry";
+
+const MARKER_FILE = "first-run.json";
+
+function markerPath(): string {
+  return join(stateDir(APP_NAME), MARKER_FILE);
+}
+
+/** True when the nudge marker already exists. Returns false on any error. */
+export function hasNudgeBeenShown(): boolean {
+  try {
+    return existsSync(markerPath());
+  } catch {
+    return false;
+  }
+}
+
+/** Record that the nudge has been shown. Swallows all fs errors (never throws). */
+export function markNudgeShown(): void {
+  try {
+    const dir = stateDir(APP_NAME);
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    chmodSync(dir, 0o700); // enforce on existing dirs created by prior versions (mirrors session-store)
+    writeFileSync(
+      join(dir, MARKER_FILE),
+      `${JSON.stringify({ nudgeShownAt: new Date().toISOString(), version: CLI_VERSION }, null, 2)}\n`,
+      { mode: 0o600 },
+    );
+  } catch {
+    // Read-only or unwritable state dir — the nudge may re-appear next run, which
+    // is acceptable and strictly better than failing the command.
+  }
+}

--- a/apps/wallet-cli/src/shared/ui.ts
+++ b/apps/wallet-cli/src/shared/ui.ts
@@ -4,6 +4,7 @@
 import yoctoSpinner from "yocto-spinner";
 import type { Spinner } from "yocto-spinner";
 import { colors, writeStdout as bunliWriteStdout } from "@bunli/utils";
+import { detectAgent } from "./agent-detection";
 export { colors };
 
 type Writer = (chunk: string) => void;
@@ -41,16 +42,7 @@ export function writeStderr(message: string): void {
 let activeSpinner: Spinner | null = null;
 
 export function isAgentEnvironment(): boolean {
-  return Boolean(
-    process.env.CLAUDECODE ||
-    process.env.CLAUDE_CODE ||
-    process.env.CURSOR_AGENT ||
-    process.env.CODEX_ENABLED ||
-    process.env.GEMINI_CLI ||
-    process.env.OPENCODE ||
-    process.env.AMP_CURRENT_THREAD_ID ||
-    process.env.AGENT === "amp",
-  );
+  return detectAgent().detected;
 }
 
 /**

--- a/apps/wallet-cli/src/test/commands/first-run-nudge.test.ts
+++ b/apps/wallet-cli/src/test/commands/first-run-nudge.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { runCli } from "../helpers/cli-runner";
+import { APP_NAME } from "../../session/session-store";
+
+let tmpDir: string | undefined;
+afterEach(async () => {
+  if (tmpDir) {
+    await rm(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  }
+});
+
+async function makeStateHome(): Promise<string> {
+  tmpDir = await mkdtemp(path.join(os.tmpdir(), "wallet-cli-nudgetest-"));
+  return tmpDir;
+}
+
+function markerPath(stateHome: string): string {
+  return path.join(stateHome, APP_NAME, "first-run.json");
+}
+
+// Neutralizes every ambient agent signal (e.g. CURSOR_AGENT is present in the
+// real process.env when this suite runs inside Cursor) so per-agent tests can
+// assert on exactly the one they set.
+const CLEAR_AGENTS = {
+  CLAUDECODE: "",
+  CLAUDE_CODE: "",
+  CURSOR_AGENT: "",
+  CODEX_ENABLED: "",
+  GEMINI_CLI: "",
+  OPENCODE: "",
+  AMP_CURRENT_THREAD_ID: "",
+  AGENT: "",
+};
+
+/** Env that lets the nudge fire: re-enable it and isolate the state marker. */
+function nudgeEnv(
+  stateHome: string,
+  overrides: Record<string, string> = {},
+): Record<string, string> {
+  return {
+    WALLET_CLI_NO_NUDGE: "",
+    XDG_STATE_HOME: stateHome,
+    ...overrides,
+  };
+}
+
+// runCli runs in-process, so we can toggle the real process's stderr.isTTY to
+// exercise the interactive-human vs. plain-pipe branch with no agent detected.
+//
+// Other suites (output.test / ui-spinner.test) redefine process.stderr.isTTY as
+// a *non-writable* data property and only restore it when it started as an own
+// property — so in the full-suite run it can reach us read-only, and a plain
+// `stream.isTTY = …` then throws "Attempted to assign to readonly property".
+// Redefine it (configurable + writable) so we're order-independent, and restore
+// the exact prior descriptor afterwards (or delete it if there was none).
+async function withStderrTTY<T>(isTTY: boolean, fn: () => Promise<T>): Promise<T> {
+  const stream = process.stderr as unknown as { isTTY?: boolean };
+  const original = Object.getOwnPropertyDescriptor(stream, "isTTY");
+  Object.defineProperty(stream, "isTTY", {
+    value: isTTY,
+    configurable: true,
+    writable: true,
+    enumerable: true,
+  });
+  try {
+    return await fn();
+  } finally {
+    if (original) {
+      Object.defineProperty(stream, "isTTY", original);
+    } else {
+      delete stream.isTTY;
+    }
+  }
+}
+
+const TIP = "Tip:";
+const INSTALL = "wallet-cli skill install";
+
+describe("first-run nudge", () => {
+  it("shows once, then not again for the same user", async () => {
+    const stateHome = await makeStateHome();
+
+    const first = await runCli(["session", "view"], nudgeEnv(stateHome));
+    expect(first.exitCode, `stderr: ${first.stderr}`).toBe(0);
+    expect(first.stderr).toContain(TIP);
+    expect(first.stderr).toContain(INSTALL);
+    expect(existsSync(markerPath(stateHome))).toBe(true);
+
+    const second = await runCli(["session", "view"], nudgeEnv(stateHome));
+    expect(second.exitCode).toBe(0);
+    expect(second.stderr).not.toContain(TIP);
+  });
+
+  it("respects WALLET_CLI_NO_NUDGE=1", async () => {
+    const stateHome = await makeStateHome();
+
+    const res = await runCli(
+      ["session", "view"],
+      nudgeEnv(stateHome, { WALLET_CLI_NO_NUDGE: "1" }),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stderr).not.toContain(TIP);
+    expect(existsSync(markerPath(stateHome))).toBe(false);
+  });
+
+  it("is suppressed under --output json", async () => {
+    const stateHome = await makeStateHome();
+
+    const res = await runCli(["session", "view", "--output", "json"], nudgeEnv(stateHome));
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).not.toContain(TIP);
+    expect(res.stderr).not.toContain(TIP);
+    // Marker must not be written when the nudge is skipped.
+    expect(existsSync(markerPath(stateHome))).toBe(false);
+  });
+
+  it("tailors the --agent flag for Claude Code", async () => {
+    const stateHome = await makeStateHome();
+    const res = await runCli(
+      ["session", "view"],
+      nudgeEnv(stateHome, { ...CLEAR_AGENTS, CLAUDECODE: "1" }),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stderr).toContain("wallet-cli skill install --agent claude");
+  });
+
+  it("tailors the --agent flag for Cursor", async () => {
+    const stateHome = await makeStateHome();
+    const res = await runCli(
+      ["session", "view"],
+      nudgeEnv(stateHome, { ...CLEAR_AGENTS, CURSOR_AGENT: "1" }),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stderr).toContain("wallet-cli skill install --agent cursor");
+  });
+
+  it("tailors the --agent flag for Codex", async () => {
+    const stateHome = await makeStateHome();
+    const res = await runCli(
+      ["session", "view"],
+      nudgeEnv(stateHome, { ...CLEAR_AGENTS, CODEX_ENABLED: "1" }),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stderr).toContain("wallet-cli skill install --agent codex");
+  });
+
+  it("tailors the --agent flag to the generic `agents` bucket for opencode/Gemini/amp", async () => {
+    const stateHome = await makeStateHome();
+    const res = await runCli(
+      ["session", "view"],
+      nudgeEnv(stateHome, { ...CLEAR_AGENTS, OPENCODE: "1" }),
+    );
+    expect(res.exitCode).toBe(0);
+    // The generic bucket still maps to a valid --agent value (-> .agents/skills);
+    // a bare `skill install` would default to --agent claude (wrong directory).
+    expect(res.stderr).toContain("wallet-cli skill install --agent agents");
+  });
+
+  it("does not consume the nudge on flag-led (help/version/bare-root) invocations", async () => {
+    // Force an agent env so the no-subcommand guard is the only thing suppressing
+    // the nudge; cover `--help`, `-h` and `--version` (all lead with a flag).
+    for (const argv of [["--help"], ["-h"], ["--version"]]) {
+      const stateHome = await makeStateHome();
+      const res = await runCli(argv, nudgeEnv(stateHome, { ...CLEAR_AGENTS, CLAUDECODE: "1" }));
+      expect(res.stderr, `argv: ${argv.join(" ")}`).not.toContain(TIP);
+      expect(existsSync(markerPath(stateHome)), `argv: ${argv.join(" ")}`).toBe(false);
+      await rm(stateHome, { recursive: true, force: true });
+    }
+  });
+
+  it("shows for an interactive human (TTY) even when no agent is detected", async () => {
+    const stateHome = await makeStateHome();
+    const res = await withStderrTTY(true, () =>
+      runCli(["session", "view"], nudgeEnv(stateHome, { ...CLEAR_AGENTS })),
+    );
+    expect(res.exitCode, `stderr: ${res.stderr}`).toBe(0);
+    expect(res.stderr).toContain(TIP);
+    expect(existsSync(markerPath(stateHome))).toBe(true);
+  });
+
+  it("stays quiet in a plain non-interactive pipe with no agent detected", async () => {
+    const stateHome = await makeStateHome();
+    const res = await withStderrTTY(false, () =>
+      runCli(["session", "view"], nudgeEnv(stateHome, { ...CLEAR_AGENTS })),
+    );
+    expect(res.exitCode, `stderr: ${res.stderr}`).toBe(0);
+    expect(res.stderr).not.toContain(TIP);
+    expect(existsSync(markerPath(stateHome))).toBe(false);
+  });
+
+  it("is not shown for `skill` commands and leaves no marker", async () => {
+    const stateHome = await makeStateHome();
+    const res = await runCli(["skill", "list"], nudgeEnv(stateHome));
+    expect(res.exitCode, `stderr: ${res.stderr}`).toBe(0);
+    expect(res.stderr).not.toContain(TIP);
+    expect(existsSync(markerPath(stateHome))).toBe(false);
+  });
+});

--- a/apps/wallet-cli/src/test/helpers/cli-runner.ts
+++ b/apps/wallet-cli/src/test/helpers/cli-runner.ts
@@ -278,11 +278,14 @@ export type RunResult = {
  */
 export async function runCli(args: string[], env: Record<string, string> = {}): Promise<RunResult> {
   // Mirror the env defaults set by the old Bun.spawn approach:
-  //   NO_COLOR=1     — disable ANSI escape codes in output
-  //   CLAUDECODE=1   — triggers isInteractive() === false → disables spinner
+  //   NO_COLOR=1            — disable ANSI escape codes in output
+  //   CLAUDECODE=1          — triggers isInteractive() === false → disables spinner
+  //   WALLET_CLI_NO_NUDGE=1 — CLAUDECODE=1 would otherwise fire the first-run nudge
+  //                           into unrelated tests' stderr; opt out by default.
   const mergedEnv: Record<string, string> = {
     NO_COLOR: "1",
     CLAUDECODE: "1",
+    WALLET_CLI_NO_NUDGE: "1",
     ...env,
   };
 


### PR DESCRIPTION
> Stacked PR 3/5 — base: `feat/wallet-cli-skill-doctor` (#19160). Review/merge after PR 2.

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Prints a one-time hint to stderr on first run; never alters a command's exit code. Opt-out via `WALLET_CLI_NO_NUDGE=1`.

### 📝 Description

On the first real command, print a one-time hint to stderr pointing at `skill install`, tailored to the detected agent (e.g. Claude Code → `wallet-cli skill install --agent claude`) with a generic fallback when the agent is unknown.

- Centralize agent detection in `detectAgent()` and have `isAgentEnvironment()` delegate to it, keeping env signals in one place.
- Persist a per-user marker under `stateDir("ledger-wallet-cli")` (honors `XDG_STATE_HOME`) so the nudge shows at most once; all fs access is best-effort and never throws or alters a command's exit code.
- Suppress the nudge under `--output json`, for `skill *` commands, in plain non-interactive pipes, and via `WALLET_CLI_NO_NUDGE=1`.
- Wire `maybeShowFirstRunNudge(argv)` into `runMain` before `cli.run`.
- Default `WALLET_CLI_NO_NUDGE=1` in the test cli-runner to keep existing tests deterministic; add first-run-nudge tests.

### ❓ Context

- **JIRA or GitHub link**: N/A
