### PR TITLE
[LWDM] feat(common): show real on-chain received amount for DEX swap history

### DIFF
--- a/.changeset/swap-dex-history-real-received-amount.md
+++ b/.changeset/swap-dex-history-real-received-amount.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Show the real on-chain received amount for finished DEX swaps in swap history. `getCompleteSwapHistory` now derives `finalAmount` from the receiving account's incoming operation (including native receives via internal operations) instead of always falling back to the quoted `toAmount`, so both the history rows and the transaction status detail/drawer reflect what was actually received.

--- a/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.test.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import type { Operation, SwapOperation, TokenAccount } from "@ledgerhq/types-live";
+import type { Account, Operation, SwapOperation, TokenAccount } from "@ledgerhq/types-live";
 import { getCryptoCurrencyById } from "../../currencies";
 import { setupMockCryptoAssetsStore } from "../../test-helpers/cryptoAssetsStore";
 import { genAccount } from "../../mock/account";
@@ -37,6 +37,19 @@ const makeSwapOperation = (
   tokenId,
 });
 
+const makeOperation = (
+  overrides: Pick<Operation, "id" | "hash" | "type" | "value" | "accountId"> & Partial<Operation>,
+): Operation => ({
+  fee: new BigNumber(0),
+  senders: [],
+  recipients: [],
+  blockHeight: 1,
+  blockHash: "0xblock",
+  date: new Date("2026-01-02T03:04:05.000Z"),
+  extra: {},
+  ...overrides,
+});
+
 describe("getCompleteSwapHistory", () => {
   it("returns valid swaps and keeps resolved sender parent account", async () => {
     const senderParent = genAccount("sender-parent", { operationsSize: 1, currency: ethereum });
@@ -61,5 +74,208 @@ describe("getCompleteSwapHistory", () => {
     expect(result[0].data).toHaveLength(1);
     expect(result[0].data[0].fromParentAccount?.id).toBe(senderParent.id);
     expect(result[0].data[0].toAccount.id).toBe(receiverAccount.id);
+  });
+
+  it("derives finalAmount for a finished DEX swap from the receiving token account IN operation", async () => {
+    const txHash = "0xdextokenhash";
+    const senderParent = genAccount("dex-token-sender", { operationsSize: 0, currency: ethereum });
+    const receiverParent = genAccount("dex-token-receiver", {
+      operationsSize: 0,
+      currency: ethereum,
+    });
+    const receiverToken = genTokenAccount(
+      0,
+      receiverParent,
+      makeTokenCurrency("mock:token:dex-receiver"),
+    );
+
+    const sender: Account = {
+      ...senderParent,
+      operations: [
+        makeOperation({
+          id: `${senderParent.id}-${txHash}-OUT`,
+          hash: txHash,
+          type: "OUT",
+          value: new BigNumber(1),
+          accountId: senderParent.id,
+        }),
+      ],
+      pendingOperations: [],
+      swapHistory: [
+        {
+          provider: "uniswap",
+          swapId: "dex-swap-1",
+          receiverAccountId: receiverToken.id,
+          operationId: `dex-swap-1-${txHash}-OUT`,
+          fromAmount: new BigNumber(1),
+          toAmount: new BigNumber("200000"),
+          status: "finished",
+        },
+      ],
+    };
+    const receiver: TokenAccount = {
+      ...receiverToken,
+      operations: [
+        makeOperation({
+          id: `${receiverToken.id}-${txHash}-IN`,
+          hash: txHash,
+          type: "IN",
+          value: new BigNumber("250000"),
+          accountId: receiverToken.id,
+        }),
+      ],
+      pendingOperations: [],
+    };
+
+    const result = await getCompleteSwapHistory([sender, receiverParent, receiver]);
+
+    expect(result[0].data[0].finalAmount?.toString()).toBe("250000");
+  });
+
+  it("derives finalAmount for a finished DEX swap from a native receive internal operation", async () => {
+    const txHash = "0xdexnativehash";
+    const senderParent = genAccount("dex-native-sender", { operationsSize: 0, currency: ethereum });
+    const receiver = genAccount("dex-native-receiver", { operationsSize: 0, currency: ethereum });
+
+    const receiverWithReceive: Account = {
+      ...receiver,
+      operations: [
+        makeOperation({
+          id: `${receiver.id}-${txHash}-OUT`,
+          hash: txHash,
+          type: "OUT",
+          value: new BigNumber("21000"),
+          accountId: receiver.id,
+          internalOperations: [
+            makeOperation({
+              id: `${receiver.id}-${txHash}-i0-IN`,
+              hash: txHash,
+              type: "IN",
+              value: new BigNumber("500000"),
+              accountId: receiver.id,
+            }),
+          ],
+        }),
+      ],
+      pendingOperations: [],
+    };
+    const sender: Account = {
+      ...senderParent,
+      operations: [
+        makeOperation({
+          id: `${senderParent.id}-${txHash}-OUT`,
+          hash: txHash,
+          type: "OUT",
+          value: new BigNumber(1),
+          accountId: senderParent.id,
+        }),
+      ],
+      pendingOperations: [],
+      swapHistory: [
+        {
+          provider: "uniswap",
+          swapId: "dex-native-1",
+          receiverAccountId: receiver.id,
+          operationId: `dex-native-1-${txHash}-OUT`,
+          fromAmount: new BigNumber(1),
+          toAmount: new BigNumber("400000"),
+          status: "finished",
+        },
+      ],
+    };
+
+    const result = await getCompleteSwapHistory([sender, receiverWithReceive]);
+
+    expect(result[0].data[0].finalAmount?.toString()).toBe("500000");
+  });
+
+  it("leaves finalAmount undefined for a DEX swap when the receive operation has not synced yet", async () => {
+    const txHash = "0xdexpendinghash";
+    const senderParent = genAccount("dex-missing-sender", { operationsSize: 0, currency: ethereum });
+    const receiverParent = genAccount("dex-missing-receiver", {
+      operationsSize: 0,
+      currency: ethereum,
+    });
+    const receiverToken = genTokenAccount(
+      0,
+      receiverParent,
+      makeTokenCurrency("mock:token:dex-missing"),
+    );
+
+    const sender: Account = {
+      ...senderParent,
+      operations: [
+        makeOperation({
+          id: `${senderParent.id}-${txHash}-OUT`,
+          hash: txHash,
+          type: "OUT",
+          value: new BigNumber(1),
+          accountId: senderParent.id,
+        }),
+      ],
+      pendingOperations: [],
+      swapHistory: [
+        {
+          provider: "uniswap",
+          swapId: "dex-missing-1",
+          receiverAccountId: receiverToken.id,
+          operationId: `dex-missing-1-${txHash}-OUT`,
+          fromAmount: new BigNumber(1),
+          toAmount: new BigNumber("200000"),
+          status: "finished",
+        },
+      ],
+    };
+    const receiver: TokenAccount = {
+      ...receiverToken,
+      operations: [],
+      pendingOperations: [],
+    };
+
+    const result = await getCompleteSwapHistory([sender, receiverParent, receiver]);
+
+    expect(result[0].data[0].finalAmount).toBeUndefined();
+  });
+
+  it("keeps the persisted (CEX) finalAmount and converts it to atomic units", async () => {
+    const txHash = "0xcexhash";
+    const senderParent = genAccount("cex-sender", { operationsSize: 0, currency: ethereum });
+    const receiverParent = genAccount("cex-receiver", { operationsSize: 0, currency: ethereum });
+    const receiverToken = genTokenAccount(0, receiverParent, makeTokenCurrency("mock:token:cex"));
+
+    const sender: Account = {
+      ...senderParent,
+      operations: [
+        makeOperation({
+          id: "cex-operation-id",
+          hash: txHash,
+          type: "OUT",
+          value: new BigNumber(1),
+          accountId: senderParent.id,
+        }),
+      ],
+      pendingOperations: [],
+      swapHistory: [
+        {
+          provider: "changelly",
+          swapId: "cex-swap",
+          receiverAccountId: receiverToken.id,
+          operationId: "cex-operation-id",
+          fromAmount: new BigNumber(1),
+          toAmount: new BigNumber("200000"),
+          finalAmount: new BigNumber("0.003"),
+          status: "finished",
+        },
+      ],
+    };
+    const receiver: TokenAccount = {
+      ...receiverToken,
+      operations: [],
+      pendingOperations: [],
+    };
+
+    const result = await getCompleteSwapHistory([sender, receiverParent, receiver]);
+
+    expect(result[0].data[0].finalAmount?.toString()).toBe("3000000000000000");
   });
 });

--- a/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.ts
@@ -1,8 +1,40 @@
 import { BigNumber } from "bignumber.js";
 import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
-import type { AccountLike, SwapOperation } from "@ledgerhq/types-live";
+import type { AccountLike, Operation, SwapOperation } from "@ledgerhq/types-live";
+import { TransactionStatus } from "@ledgerhq/wallet-api-exchange-module";
 import { accountWithMandatoryTokens, getAccountCurrency } from "../../account";
 import type { MappedSwapOperation, SwapHistorySection } from "./types";
+
+// Sum the atomic value credited to an account by the given transaction: direct
+// incoming operations (token receives) plus incoming internal operations
+// (native receives that happen inside a contract call).
+const sumIncomingOperationValue = (operations: Operation[], txHash: string): BigNumber => {
+  let total = new BigNumber(0);
+  for (const operation of operations) {
+    if (operation.hash !== txHash) continue;
+    if (operation.type === "IN") {
+      total = total.plus(operation.value);
+    } else if (operation.internalOperations?.length) {
+      for (const internalOperation of operation.internalOperations) {
+        if (internalOperation.type === "IN") total = total.plus(internalOperation.value);
+      }
+    }
+  }
+  return total;
+};
+
+// For DEX swaps the received amount is settled on-chain in the receiving
+// account, so we read the real credited amount from that account's incoming
+// operation(s) sharing the swap transaction hash. Returned in atomic units to
+// match the `toAmount` convention.
+const getDexReceivedAmount = (
+  toAccount: AccountLike,
+  txHash: string | undefined,
+): BigNumber | undefined => {
+  if (!txHash) return undefined;
+  const received = sumIncomingOperationValue(toAccount.operations ?? [], txHash);
+  return received.isGreaterThan(0) ? received : undefined;
+};
 
 const getSwapOperationMap =
   (account: AccountLike, accounts: AccountLike[]) =>
@@ -67,10 +99,20 @@ const getSwapOperationMap =
 
         const toCurrency = getAccountCurrency(toAccount);
         const toMagnitude = toCurrency.units[0].magnitude;
-        const magnitudeAwareFinalAmount =
+        // CEX providers report the final amount remotely (stored in human units).
+        const persistedFinalAmount =
           finalAmount && finalAmount.isGreaterThan(0)
             ? finalAmount.times(new BigNumber(10).pow(toMagnitude))
             : undefined;
+        // DEX swaps (swapId embedded in operationId) never persist a finalAmount,
+        // so once the swap is finished we derive the real received amount from the
+        // receiving account's on-chain operation.
+        const isDexSwap = Boolean(operationId && swapId && operationId.includes(swapId));
+        const magnitudeAwareFinalAmount =
+          persistedFinalAmount ??
+          (isDexSwap && status === TransactionStatus.Finished
+            ? getDexReceivedAmount(toAccount, op.hash)
+            : undefined);
 
         return {
           provider,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Swap history for **DEX** swaps (e.g. Uniswap/1inch) on both Desktop and Mobile
      - History list rows: received amount shown for **finished** DEX swaps
      - Swap transaction status **detail screen** (Mobile) and status **dialog/drawer** (Desktop)
      - **CEX** swaps: verify `finalAmount` behavior is unchanged (regression check)

### 📝 Description

**Problem**: For DEX swaps, the swap history displayed the **quoted** output amount (`toAmount`) instead of the amount **actually received on-chain**. `finalAmount` was only ever populated for CEX providers (reported remotely by the swap status API), so DEX entries always fell back to the quote.

**Solution**: `getCompleteSwapHistory` now derives `finalAmount` for **finished** DEX swaps from the receiving account's on-chain operation:

- Direct incoming (`IN`) operations — token receives.
- Incoming **internal** operations — native receives that happen inside a contract call.

The value is matched by the swap transaction hash and returned in atomic units to match the existing `toAmount` convention. Precedence is:

1. Persisted `finalAmount` (CEX, remote) — unchanged.
2. DEX-derived on-chain received amount — new.
3. `undefined` → UI falls back to `toAmount` exactly as before.

```ts
const isDexSwap = Boolean(operationId && swapId && operationId.includes(swapId));
const magnitudeAwareFinalAmount =
  persistedFinalAmount ??
  (isDexSwap && status === TransactionStatus.Finished
    ? getDexReceivedAmount(toAccount, op.hash)
    : undefined);
```

Because every surface (Desktop history row, Desktop status dialog via `getTransactionStatus`, Mobile history row, Mobile detail screen) reads from `getCompleteSwapHistory`, this single change covers them all with **no UI component changes** — the display already prefers `finalAmount` over `toAmount`.

**Known edge**: the Desktop status dialog stops polling once a swap is terminal, so if the receiving `IN` operation has not synced at that exact instant it shows the quoted amount until reopened. History rows self-correct on every account update. For typical DEX EVM swaps the receive leg syncs with the send, so this is rare.

### 🖼️ Screenshots

<img width="407" height="592" alt="Capture d’écran 2026-07-01 à 11 32 16" src="https://github.com/user-attachments/assets/e7ec63ce-3779-4a47-82ce-d861b9d56c45" />
<img width="800" height="46" alt="Capture d’écran 2026-07-01 à 11 32 21" src="https://github.com/user-attachments/assets/aa3c22c7-20bc-4249-ad79-fbbfc0e6cc92" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-33344](https://ledgerhq.atlassian.net/browse/LIVE-33344)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-33344]: https://ledgerhq.atlassian.net/browse/LIVE-33344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ