### PR TITLE
[LWDM] feat(desktop): add device context initializer

### DIFF
--- a/.changeset/desktop-die-initializer.md
+++ b/.changeset/desktop-die-initializer.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add desktop Device Intent Executor context initializer.

--- a/.changeset/live-33001-last-seen-device-apps.md
+++ b/.changeset/live-33001-last-seen-device-apps.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Preserve installed apps in Device Intent Executor last seen device info.

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectingState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectingState.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { Spinner } from "@ledgerhq/lumen-ui-react";
 import { ConnectDeviceUIStateTypes, type ConnectDeviceUIState } from "@ledgerhq/live-dmk-desktop";
 import { useTranslation } from "react-i18next";
+import { LoadingContent } from "../../components/DeviceGenericStates/LoadingContent";
 
 type ConnectingStateProps = {
   state: Extract<ConnectDeviceUIState, { type: ConnectDeviceUIStateTypes.Connecting }>;
@@ -10,12 +10,5 @@ type ConnectingStateProps = {
 export function ConnectingState(_props: Readonly<ConnectingStateProps>): React.ReactNode {
   const { t } = useTranslation();
 
-  return (
-    <div className="flex w-full flex-col items-center gap-16 px-16 py-32">
-      <Spinner size={32} />
-      <h3 className="heading-4-semi-bold text-center text-base">
-        {t("deviceIntentExecutor.connectDevice.states.connecting.title")}
-      </h3>
-    </div>
-  );
+  return <LoadingContent title={t("deviceIntentExecutor.connectDevice.states.connecting.title")} />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/DeviceContextInitializerComponentLWDView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/DeviceContextInitializerComponentLWDView.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import {
+  AppInteractionRequiredStateType,
+  BlockingStateType,
+  DeviceInteractionRequiredType,
+  FinalStateType,
+  LoadingStateType,
+  RetryableStateType,
+} from "@ledgerhq/live-dmk-shared";
+import type { DeviceContextInitializerComponentLWDViewProps } from "./types";
+import { LoadingState } from "./components/LoadingState";
+import { InstallingAppState } from "./components/InstallingAppState";
+import { UnlockDeviceState } from "./components/UnlockDeviceState";
+import { AllowSecureConnectionState } from "./components/AllowSecureConnectionState";
+import { ConfirmOpenAppState } from "./components/ConfirmOpenAppState";
+import { DeviceDeprecatedNonBlockingState } from "./components/DeviceDeprecatedNonBlockingState";
+import { OutdatedAppWarning } from "./components/OutdatedAppWarning";
+import { UserRefusedOnDeviceState } from "./components/UserRefusedOnDeviceState";
+import { RetryableDeviceLockedState } from "./components/RetryableDeviceLockedState";
+import { DeviceBusyState } from "./components/DeviceBusyState";
+import { UnsupportedFirmwareVersion } from "./components/UnsupportedFirmwareVersion";
+import { UnsupportedApplication } from "./components/UnsupportedApplication";
+import { UnsupportedFeature } from "./components/UnsupportedFeature";
+import { DeviceDeprecatedBlockingState } from "./components/DeviceDeprecatedBlockingState";
+import { WrongDeviceForAccount } from "./components/WrongDeviceForAccount";
+import { DeviceOutOfStorageSpace } from "./components/DeviceOutOfStorageSpace";
+import { DeviceNotOnboarded } from "./components/DeviceNotOnboarded";
+import { FinalError } from "./components/FinalError";
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled ensure app ready state: ${JSON.stringify(value)}`);
+}
+
+export function DeviceContextInitializerComponentLWDView({
+  state,
+  device,
+  onCancel,
+}: DeviceContextInitializerComponentLWDViewProps) {
+  const commonProps = { device, onCancel } as const;
+
+  switch (state.type) {
+    case LoadingStateType.Loading:
+      return <LoadingState />;
+    case LoadingStateType.InstallingApp:
+      return <InstallingAppState />;
+    case DeviceInteractionRequiredType.UnlockDevice:
+      return <UnlockDeviceState state={state} {...commonProps} />;
+    case DeviceInteractionRequiredType.AllowSecureConnection:
+      return <AllowSecureConnectionState state={state} {...commonProps} />;
+    case DeviceInteractionRequiredType.ConfirmOpenApp:
+      return <ConfirmOpenAppState state={state} {...commonProps} />;
+    case AppInteractionRequiredStateType.DeviceDeprecatedNonBlocking:
+      return <DeviceDeprecatedNonBlockingState state={state} {...commonProps} />;
+    case AppInteractionRequiredStateType.OutdatedAppWarning:
+      return <OutdatedAppWarning state={state} {...commonProps} />;
+    case RetryableStateType.UserRefusedOnDevice:
+      return <UserRefusedOnDeviceState state={state} {...commonProps} />;
+    case RetryableStateType.DeviceLocked:
+      return <RetryableDeviceLockedState state={state} {...commonProps} />;
+    case RetryableStateType.DeviceBusy:
+      return <DeviceBusyState state={state} {...commonProps} />;
+    case BlockingStateType.UnsupportedFirmwareVersion:
+      return <UnsupportedFirmwareVersion state={state} {...commonProps} />;
+    case BlockingStateType.UnsupportedApplication:
+      return <UnsupportedApplication state={state} {...commonProps} />;
+    case BlockingStateType.UnsupportedFeature:
+      return <UnsupportedFeature state={state} {...commonProps} />;
+    case BlockingStateType.DeviceDeprecatedBlocking:
+      return <DeviceDeprecatedBlockingState state={state} {...commonProps} />;
+    case BlockingStateType.WrongDeviceForAccount:
+      return <WrongDeviceForAccount state={state} {...commonProps} />;
+    case BlockingStateType.DeviceOutOfStorageSpace:
+      return <DeviceOutOfStorageSpace state={state} {...commonProps} />;
+    case BlockingStateType.DeviceNotOnboarded:
+      return <DeviceNotOnboarded state={state} {...commonProps} />;
+    case FinalStateType.Error:
+      return <FinalError state={state} {...commonProps} />;
+    case FinalStateType.Success:
+      return null;
+    default:
+      return assertNever(state);
+  }
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/__tests__/DeviceContextInitializerComponentLWDView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/__tests__/DeviceContextInitializerComponentLWDView.test.tsx
@@ -1,0 +1,245 @@
+import React from "react";
+import {
+  AppInteractionRequiredStateType,
+  BlockingStateType,
+  DeviceInteractionRequiredType,
+  FinalStateType,
+  LoadingStateType,
+  RetryableStateType,
+  type EnsureAppReadyState,
+} from "@ledgerhq/live-dmk-shared";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { DeviceContextInitializerComponentLWDView } from "../DeviceContextInitializerComponentLWDView";
+import { initializerDevice } from "../testUtils";
+
+jest.mock("~/renderer/components/DeviceAction/animations", () => ({
+  getDeviceAnimation: jest.fn(() => undefined),
+}));
+
+jest.mock("~/renderer/components/DeviceAction/Screen/DeviceDeprecationScreen", () => ({
+  DeviceDeprecationScreens: {
+    clearSigningScreen: 0,
+    warningScreen: 1,
+    errorScreen: 2,
+  },
+  DeviceDeprecationScreen: ({ screenName }: { screenName: number }) => (
+    <div data-testid={`device-deprecation-screen-${screenName}`} />
+  ),
+}));
+
+jest.mock("~/renderer/components/TranslatedError", () => ({
+  __esModule: true,
+  default: ({ field }: { field: string }) => <span>{`translated-${field}`}</span>,
+}));
+
+function renderView(state: EnsureAppReadyState) {
+  return render(
+    <DeviceContextInitializerComponentLWDView
+      state={state}
+      device={initializerDevice}
+      onCancel={jest.fn()}
+    />,
+  );
+}
+
+describe("DeviceContextInitializerComponentLWDView", () => {
+  it("GIVEN the loading state WHEN rendering THEN it renders the loading content", () => {
+    // WHEN
+    renderView({ type: LoadingStateType.Loading });
+
+    // THEN
+    expect(screen.getByText("Loading")).toBeVisible();
+  });
+
+  it.each([
+    {
+      label: "installing app",
+      state: { type: LoadingStateType.InstallingApp },
+      getElement: () => screen.getByText("Installing app"),
+    },
+    {
+      label: "unlock device",
+      state: { type: DeviceInteractionRequiredType.UnlockDevice },
+      getElement: () => screen.getByTestId("device-initializer-unlock-device"),
+    },
+    {
+      label: "allow secure connection",
+      state: { type: DeviceInteractionRequiredType.AllowSecureConnection },
+      getElement: () => screen.getByTestId("device-initializer-allow-secure-connection"),
+    },
+    {
+      label: "confirm open app",
+      state: { type: DeviceInteractionRequiredType.ConfirmOpenApp },
+      getElement: () => screen.getByTestId("device-initializer-confirm-open-app"),
+    },
+    {
+      label: "non-blocking device deprecation",
+      state: {
+        type: AppInteractionRequiredStateType.DeviceDeprecatedNonBlocking,
+        decision: {
+          status: "show",
+          screenSequence: ["warning"],
+          currencyName: "Ethereum",
+          deviceModelId: DeviceModelId.nanoX,
+          supportEndDate: new Date("2026-01-01"),
+        },
+        onContinue: jest.fn(),
+      },
+      getElement: () => screen.getByTestId("device-deprecation-screen-1"),
+    },
+    {
+      label: "outdated app warning",
+      state: {
+        type: AppInteractionRequiredStateType.OutdatedAppWarning,
+        appName: "Ethereum",
+        onContinue: jest.fn(),
+      },
+      getElement: () => screen.getByText("App version outdated"),
+    },
+    {
+      label: "retryable device locked",
+      state: { type: RetryableStateType.DeviceLocked, retry: jest.fn() },
+      getElement: () => screen.getByTestId("device-initializer-retryable-device-locked"),
+    },
+    {
+      label: "retryable device busy",
+      state: { type: RetryableStateType.DeviceBusy, retry: jest.fn() },
+      getElement: () => screen.getByText("Action pending on your Ledger device"),
+    },
+    {
+      label: "unsupported firmware version",
+      state: { type: BlockingStateType.UnsupportedFirmwareVersion },
+      getElement: () => screen.getByText("Ledger OS update required"),
+    },
+    {
+      label: "unsupported application",
+      state: {
+        type: BlockingStateType.UnsupportedApplication,
+        appName: "Ethereum",
+        deviceModelId: DeviceModelId.nanoX,
+      },
+      getElement: () => screen.getByTestId("device-initializer-unsupported-application"),
+    },
+    {
+      label: "unsupported feature",
+      state: {
+        type: BlockingStateType.UnsupportedFeature,
+        deviceModelId: DeviceModelId.nanoX,
+      },
+      getElement: () => screen.getByTestId("device-initializer-unsupported-feature"),
+    },
+    {
+      label: "blocking device deprecation",
+      state: {
+        type: BlockingStateType.DeviceDeprecatedBlocking,
+        decision: {
+          status: "block",
+          currencyName: "Ethereum",
+          deviceModelId: DeviceModelId.nanoX,
+          supportEndDate: new Date("2026-01-01"),
+        },
+      },
+      getElement: () => screen.getByTestId("device-deprecation-screen-2"),
+    },
+    {
+      label: "wrong device for account",
+      state: {
+        type: BlockingStateType.WrongDeviceForAccount,
+        accountName: "Ethereum 1",
+      },
+      getElement: () => screen.getByText("Wrong Secret Recovery Phrase"),
+    },
+    {
+      label: "device not onboarded",
+      state: { type: BlockingStateType.DeviceNotOnboarded },
+      getElement: () => screen.getByText("Your Ledger is not ready to use yet"),
+    },
+    {
+      label: "final error",
+      state: { type: FinalStateType.Error, error: new Error("unexpected") },
+      getElement: () => screen.getByText("translated-title"),
+    },
+  ] satisfies Array<{
+    label: string;
+    state: EnsureAppReadyState;
+    getElement: () => HTMLElement;
+  }>)(
+    "GIVEN the $label state WHEN rendering THEN it renders the matching desktop state",
+    ({ state, getElement }) => {
+      // WHEN
+      renderView(state);
+
+      // THEN
+      expect(getElement()).toBeVisible();
+    },
+  );
+
+  it("GIVEN the device storage blocking state WHEN rendering THEN it renders the storage content", () => {
+    // WHEN
+    renderView({
+      type: BlockingStateType.DeviceOutOfStorageSpace,
+      appNames: ["Ethereum", "Bitcoin"],
+    });
+
+    // THEN
+    expect(screen.getByText("Not enough device memory")).toBeVisible();
+    expect(screen.getByText("Apps to manage: Ethereum, Bitcoin")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Go to My Ledger" })).toBeVisible();
+  });
+
+  const renderUserRefusalState = () => {
+    const retry = jest.fn();
+    const onCancel = jest.fn();
+    const { user } = render(
+      <DeviceContextInitializerComponentLWDView
+        state={{ type: RetryableStateType.UserRefusedOnDevice, retry }}
+        device={initializerDevice}
+        onCancel={onCancel}
+      />,
+    );
+    return { user, retry, onCancel };
+  };
+
+  it("GIVEN a retryable user refusal state WHEN clicking Close THEN it forwards the cancel callback", async () => {
+    // GIVEN
+    const { user, retry, onCancel } = renderUserRefusalState();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    // THEN
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN a retryable user refusal state WHEN clicking Retry THEN it forwards the retry callback", async () => {
+    // GIVEN
+    const { user, retry, onCancel } = renderUserRefusalState();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    // THEN
+    expect(retry).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN the success state WHEN rendering THEN it renders no content", () => {
+    // WHEN
+    const { container } = renderView({
+      type: FinalStateType.Success,
+      extractedContext: {
+        currentOsVersion: "2.2.0",
+        osUpdateAvailable: false,
+        currentAppName: "Ethereum",
+        currentAppVersion: "1.0.0",
+        derivedAddress: undefined,
+      },
+    });
+
+    // THEN
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/__tests__/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/__tests__/index.test.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { LoadingStateType } from "@ledgerhq/live-dmk-shared";
+import type { EnsureAppReadyUseCaseDependencies } from "@ledgerhq/live-common/device/use-cases/ensureAppReady/ensureAppReadyUseCase";
+import { render } from "@testing-library/react";
+import DeviceContextInitializerComponentLWD from "..";
+import { DeviceContextInitializerComponentLWDView } from "../DeviceContextInitializerComponentLWDView";
+import { useDeviceContextInitializerComponentLWDViewModel } from "../useDeviceContextInitializerComponentLWDViewModel";
+import { connectionResult, deviceInitializationInput, initializerDevice } from "../testUtils";
+
+jest.mock("../useDeviceContextInitializerComponentLWDViewModel", () => ({
+  useDeviceContextInitializerComponentLWDViewModel: jest.fn(),
+}));
+
+jest.mock("../DeviceContextInitializerComponentLWDView", () => ({
+  DeviceContextInitializerComponentLWDView: jest.fn(() => null),
+}));
+
+const mockedUseViewModel = jest.mocked(useDeviceContextInitializerComponentLWDViewModel);
+const mockedView = jest.mocked(DeviceContextInitializerComponentLWDView);
+
+describe("DeviceContextInitializerComponentLWD", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseViewModel.mockReturnValue({
+      state: { type: LoadingStateType.Loading },
+      device: initializerDevice,
+    });
+  });
+
+  it("GIVEN no initializer config WHEN rendering THEN it passes initialization params to the view model", () => {
+    // GIVEN
+    const onContextInitialized = jest.fn();
+
+    // WHEN
+    render(
+      <DeviceContextInitializerComponentLWD
+        connectionResult={connectionResult}
+        deviceInitializationInput={deviceInitializationInput}
+        onContextInitialized={onContextInitialized}
+        onClose={jest.fn()}
+      />,
+    );
+
+    // THEN
+    expect(mockedUseViewModel).toHaveBeenCalledTimes(1);
+    expect(mockedUseViewModel).toHaveBeenCalledWith({
+      connectionResult,
+      deviceInitializationInput,
+      onContextInitialized,
+      dependencies: undefined,
+    });
+  });
+
+  it("GIVEN initializer config dependencies WHEN rendering THEN it forwards dependencies to the view model", () => {
+    // GIVEN
+    const onContextInitialized = jest.fn();
+    const dependencies: Partial<EnsureAppReadyUseCaseDependencies> = {};
+
+    // WHEN
+    render(
+      <DeviceContextInitializerComponentLWD
+        connectionResult={connectionResult}
+        deviceInitializationInput={deviceInitializationInput}
+        onContextInitialized={onContextInitialized}
+        config={{ dependencies }}
+        onClose={jest.fn()}
+      />,
+    );
+
+    // THEN
+    expect(mockedUseViewModel).toHaveBeenCalledTimes(1);
+    expect(mockedUseViewModel).toHaveBeenCalledWith({
+      connectionResult,
+      deviceInitializationInput,
+      onContextInitialized,
+      dependencies,
+    });
+  });
+
+  it("GIVEN the executor close callback WHEN rendering THEN it forwards it as the view cancel callback", () => {
+    // GIVEN
+    const onClose = jest.fn();
+
+    // WHEN
+    render(
+      <DeviceContextInitializerComponentLWD
+        connectionResult={connectionResult}
+        deviceInitializationInput={deviceInitializationInput}
+        onContextInitialized={jest.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    // THEN
+    expect(mockedView).toHaveBeenCalledTimes(1);
+    expect(mockedView.mock.calls[0][0].onCancel).toBe(onClose);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/__tests__/useDeviceContextInitializerComponentLWDViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/__tests__/useDeviceContextInitializerComponentLWDViewModel.test.tsx
@@ -1,0 +1,219 @@
+import React from "react";
+import { Observable, Subject } from "rxjs";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router";
+import { act, renderHook } from "@testing-library/react";
+import { DeviceId } from "@ledgerhq/client-ids/ids";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import type { DeviceInfo } from "@ledgerhq/types-live";
+import {
+  DeviceInteractionRequiredType,
+  FinalStateType,
+  LoadingStateType,
+  type EnsureAppReadyState,
+} from "@ledgerhq/live-dmk-shared";
+import { ensureAppReadyUseCase } from "@ledgerhq/live-common/device/use-cases/ensureAppReady/ensureAppReadyUseCase";
+import type { State } from "~/renderer/reducers";
+import { INITIAL_STATE as INITIAL_SETTINGS_STATE } from "~/renderer/reducers/settings";
+import createStore, { type ReduxStore } from "~/state-manager/configureStore";
+import { useDeviceContextInitializerComponentLWDViewModel } from "../useDeviceContextInitializerComponentLWDViewModel";
+import { connectionResult, deviceInitializationInput } from "../testUtils";
+
+jest.mock("@ledgerhq/live-common/device/use-cases/ensureAppReady/ensureAppReadyUseCase", () => ({
+  ensureAppReadyUseCase: jest.fn(),
+}));
+
+const mockedEnsureAppReadyUseCase = jest.mocked(ensureAppReadyUseCase);
+
+const extractedContext = {
+  currentOsVersion: "2.0.0",
+  osUpdateAvailable: false,
+  currentAppName: "Ethereum",
+  currentAppVersion: "1.0.0",
+  derivedAddress: "0x123",
+};
+
+function setupObservable() {
+  const subject = new Subject<EnsureAppReadyState>();
+  mockedEnsureAppReadyUseCase.mockReturnValue(subject.asObservable());
+  return subject;
+}
+
+function renderViewModel({
+  onContextInitialized = jest.fn(),
+  deprecationDoNotRemind = ["Ethereum"],
+}: {
+  onContextInitialized?: jest.Mock;
+  deprecationDoNotRemind?: string[];
+} = {}) {
+  const store = createStore({
+    state: {
+      settings: {
+        ...INITIAL_SETTINGS_STATE,
+        deprecationDoNotRemind,
+      },
+    } as State,
+    fetchRemoteFlags: null,
+  });
+
+  const rendered = renderHook(
+    () =>
+      useDeviceContextInitializerComponentLWDViewModel({
+        connectionResult,
+        deviceInitializationInput,
+        onContextInitialized,
+      }),
+    {
+      wrapper: ({ children }) => <TestWrapper store={store}>{children}</TestWrapper>,
+    },
+  );
+
+  return { ...rendered, store, onContextInitialized };
+}
+
+function TestWrapper({ children, store }: { children: React.ReactNode; store: ReduxStore }) {
+  return (
+    <Provider store={store}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </Provider>
+  );
+}
+
+describe("useDeviceContextInitializerComponentLWDViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupObservable();
+  });
+
+  it("GIVEN the initializer starts WHEN rendering the view model THEN it exposes loading state and a normalized device", () => {
+    // WHEN
+    const { result } = renderViewModel();
+
+    // THEN
+    expect(result.current.state).toEqual({ type: LoadingStateType.Loading });
+    expect(result.current.device).toEqual(
+      expect.objectContaining({
+        id: "device-id",
+        modelId: DeviceModelId.nanoX,
+        name: "Ledger Nano X",
+        wired: true,
+      }),
+    );
+  });
+
+  it("GIVEN dismissed deprecations WHEN rendering the view model THEN it starts ensure app ready with them", () => {
+    // GIVEN
+    const deprecationDoNotRemind = ["Ethereum", "Bitcoin"];
+
+    // WHEN
+    renderViewModel({ deprecationDoNotRemind });
+
+    // THEN
+    expect(mockedEnsureAppReadyUseCase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dmk: connectionResult.dmk,
+        sessionId: connectionResult.sessionId,
+        input: deviceInitializationInput,
+        deprecationDismissedCurrencyNames: deprecationDoNotRemind,
+      }),
+    );
+  });
+
+  it("GIVEN the use case emits a non-final state WHEN observing the flow THEN it updates the state", () => {
+    // GIVEN
+    const subject = setupObservable();
+    const { result } = renderViewModel();
+    const nextState: EnsureAppReadyState = { type: DeviceInteractionRequiredType.UnlockDevice };
+
+    // WHEN
+    act(() => {
+      subject.next(nextState);
+    });
+
+    // THEN
+    expect(result.current.state).toEqual(nextState);
+  });
+
+  it("GIVEN the use case succeeds twice WHEN observing the flow THEN it notifies context initialization once", () => {
+    // GIVEN
+    const subject = setupObservable();
+    const onContextInitialized = jest.fn();
+    const { result } = renderViewModel({ onContextInitialized });
+    const successState: EnsureAppReadyState = {
+      type: FinalStateType.Success,
+      extractedContext,
+    };
+
+    // WHEN
+    act(() => {
+      subject.next(successState);
+      subject.next(successState);
+    });
+
+    // THEN
+    expect(result.current.state).toEqual(successState);
+    expect(onContextInitialized).toHaveBeenCalledTimes(1);
+    expect(onContextInitialized).toHaveBeenCalledWith(extractedContext);
+  });
+
+  it("GIVEN the use case errors WHEN observing the flow THEN it exposes a final error state", () => {
+    // GIVEN
+    const subject = setupObservable();
+    const { result } = renderViewModel();
+    const error = new Error("unexpected");
+
+    // WHEN
+    act(() => {
+      subject.error(error);
+    });
+
+    // THEN
+    expect(result.current.state).toEqual({
+      type: FinalStateType.Error,
+      error,
+    });
+  });
+
+  it("GIVEN the view model is subscribed WHEN unmounting THEN it unsubscribes from the use case", () => {
+    // GIVEN
+    const unsubscribe = jest.fn();
+    mockedEnsureAppReadyUseCase.mockReturnValue(
+      new Observable<EnsureAppReadyState>(() => unsubscribe),
+    );
+    const { unmount } = renderViewModel();
+
+    // WHEN
+    unmount();
+
+    // THEN
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN use case side effects WHEN they observe device metadata THEN they update desktop stores", () => {
+    // GIVEN
+    const { store } = renderViewModel();
+    const { sideEffects } = mockedEnsureAppReadyUseCase.mock.calls[0][0];
+    const deviceId = DeviceId.fromString("010203");
+    const deviceInfo = { version: "2.0.0" } as DeviceInfo;
+
+    // WHEN
+    sideEffects.onDeviceIdObserved(deviceId);
+    sideEffects.onLastSeenDeviceInfoObserved({
+      modelId: DeviceModelId.nanoX,
+      deviceInfo,
+      latestFirmware: null,
+    });
+
+    // THEN
+    const state = store.getState();
+    expect(state.identities.deviceIds).toHaveLength(1);
+    expect(state.identities.deviceIds[0].equals(deviceId)).toBe(true);
+    expect(state.settings.lastSeenDevice).toEqual({
+      modelId: DeviceModelId.nanoX,
+      deviceInfo,
+      apps: [],
+    });
+    expect(state.settings.latestFirmware).toBeNull();
+    expect(state.settings.devicesModelList).toContain(DeviceModelId.nanoX);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/__tests__/useDeviceContextInitializerComponentLWDViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/__tests__/useDeviceContextInitializerComponentLWDViewModel.test.tsx
@@ -195,12 +195,14 @@ describe("useDeviceContextInitializerComponentLWDViewModel", () => {
     const { sideEffects } = mockedEnsureAppReadyUseCase.mock.calls[0][0];
     const deviceId = DeviceId.fromString("010203");
     const deviceInfo = { version: "2.0.0" } as DeviceInfo;
+    const apps = [{ name: "Bitcoin", version: "2.2.0" }];
 
     // WHEN
     sideEffects.onDeviceIdObserved(deviceId);
     sideEffects.onLastSeenDeviceInfoObserved({
       modelId: DeviceModelId.nanoX,
       deviceInfo,
+      apps,
       latestFirmware: null,
     });
 
@@ -211,7 +213,7 @@ describe("useDeviceContextInitializerComponentLWDViewModel", () => {
     expect(state.settings.lastSeenDevice).toEqual({
       modelId: DeviceModelId.nanoX,
       deviceInfo,
-      apps: [],
+      apps,
     });
     expect(state.settings.latestFirmware).toBeNull();
     expect(state.settings.devicesModelList).toContain(DeviceModelId.nanoX);

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/__tests__/useDeviceContextInitializerComponentLWDViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/__tests__/useDeviceContextInitializerComponentLWDViewModel.test.tsx
@@ -3,7 +3,7 @@ import { Observable, Subject } from "rxjs";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
 import { act, renderHook } from "@testing-library/react";
-import { DeviceId } from "@ledgerhq/client-ids/ids";
+import { DeviceId } from "@domain/entity-client-identity";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import type { DeviceInfo } from "@ledgerhq/types-live";
 import {

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/__tests__/useInitializerActions.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/__tests__/useInitializerActions.test.tsx
@@ -1,0 +1,87 @@
+import { renderHook } from "@testing-library/react";
+import { useNavigate } from "react-router";
+import { urls } from "~/config/urls";
+import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
+import { openURL } from "~/renderer/linking";
+import { useInitializerActions } from "../hooks/useInitializerActions";
+
+jest.mock("react-router", () => ({
+  useNavigate: jest.fn(),
+}));
+
+jest.mock("~/renderer/hooks/useLocalizedUrls", () => ({
+  useLocalizedUrl: jest.fn(),
+}));
+
+jest.mock("~/renderer/linking", () => ({
+  openURL: jest.fn(),
+}));
+
+const mockedUseNavigate = jest.mocked(useNavigate);
+const mockedUseLocalizedUrl = jest.mocked(useLocalizedUrl);
+const mockedOpenURL = jest.mocked(openURL);
+const navigate = jest.fn();
+
+describe("useInitializerActions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseNavigate.mockReturnValue(navigate);
+    mockedUseLocalizedUrl.mockReturnValue("https://support.ledger.com/en");
+  });
+
+  it("GIVEN no search query WHEN opening My Ledger THEN it navigates to Manager", () => {
+    // GIVEN
+    const { result } = renderHook(() => useInitializerActions());
+
+    // WHEN
+    result.current.openMyLedger();
+
+    // THEN
+    expect(navigate).toHaveBeenCalledWith("/manager");
+  });
+
+  it("GIVEN an app search query WHEN opening My Ledger THEN it navigates to Manager with encoded search", () => {
+    // GIVEN
+    const { result } = renderHook(() => useInitializerActions());
+
+    // WHEN
+    result.current.openMyLedger("Ethereum Classic");
+
+    // THEN
+    expect(navigate).toHaveBeenCalledWith("/manager?q=Ethereum%20Classic");
+  });
+
+  it("GIVEN firmware update is required WHEN opening firmware update THEN it navigates to Manager firmware route", () => {
+    // GIVEN
+    const { result } = renderHook(() => useInitializerActions());
+
+    // WHEN
+    result.current.openMyLedgerFirmwareUpdate();
+
+    // THEN
+    expect(navigate).toHaveBeenCalledWith("/manager?firmwareUpdate=true");
+  });
+
+  it("GIVEN a device is not onboarded WHEN opening onboarding THEN it navigates to desktop onboarding entry", () => {
+    // GIVEN
+    const { result } = renderHook(() => useInitializerActions());
+
+    // WHEN
+    result.current.openOnboarding();
+
+    // THEN
+    expect(navigate).toHaveBeenCalledWith("/onboarding/select-device");
+  });
+
+  it("GIVEN contact support is requested WHEN opening support THEN it opens the localized support URL", () => {
+    // GIVEN
+    const { result } = renderHook(() => useInitializerActions());
+
+    // WHEN
+    result.current.openSupport();
+
+    // THEN
+    expect(mockedUseLocalizedUrl).toHaveBeenCalledWith(urls.contactSupport);
+    expect(mockedOpenURL).toHaveBeenCalledWith("https://support.ledger.com/en");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/AllowSecureConnectionState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/AllowSecureConnectionState.test.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { DeviceInteractionRequiredType } from "@ledgerhq/live-dmk-shared";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { initializerDevice } from "../testUtils";
+import { AllowSecureConnectionState } from "./AllowSecureConnectionState";
+
+describe("AllowSecureConnectionState", () => {
+  it("GIVEN the allow secure connection state WHEN rendering THEN it renders the pending action copy", () => {
+    // WHEN
+    render(
+      <AllowSecureConnectionState
+        state={{ type: DeviceInteractionRequiredType.AllowSecureConnection }}
+        device={initializerDevice}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    // THEN
+    expect(screen.getByText("Continue on your Ledger Nano X")).toBeVisible();
+    expect(
+      screen.getByText("Follow the instructions displayed on your Secure Screen."),
+    ).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/AllowSecureConnectionState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/AllowSecureConnectionState.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { DeviceInteractionRequiredType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { ContinueOnDevice } from "../../components/DeviceGenericStates/ContinueOnDevice";
+import type { BaseInitializerStateProps } from "../types";
+
+type AllowSecureConnectionStateProps = BaseInitializerStateProps<
+  Extract<EnsureAppReadyState, { type: DeviceInteractionRequiredType.AllowSecureConnection }>
+>;
+
+export function AllowSecureConnectionState({ device }: AllowSecureConnectionStateProps) {
+  return (
+    <ContinueOnDevice
+      deviceModelId={device.modelId}
+      deviceName={device.name}
+      testID="device-initializer-allow-secure-connection"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/ConfirmOpenAppState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/ConfirmOpenAppState.test.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { DeviceInteractionRequiredType } from "@ledgerhq/live-dmk-shared";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { initializerDevice } from "../testUtils";
+import { ConfirmOpenAppState } from "./ConfirmOpenAppState";
+
+describe("ConfirmOpenAppState", () => {
+  it("GIVEN the confirm open app state WHEN rendering THEN it renders the pending action copy", () => {
+    // WHEN
+    render(
+      <ConfirmOpenAppState
+        state={{ type: DeviceInteractionRequiredType.ConfirmOpenApp }}
+        device={initializerDevice}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    // THEN
+    expect(screen.getByText("Continue on your Ledger Nano X")).toBeVisible();
+    expect(
+      screen.getByText("Follow the instructions displayed on your Secure Screen."),
+    ).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/ConfirmOpenAppState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/ConfirmOpenAppState.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { DeviceInteractionRequiredType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { ContinueOnDevice } from "../../components/DeviceGenericStates/ContinueOnDevice";
+import type { BaseInitializerStateProps } from "../types";
+
+type ConfirmOpenAppStateProps = BaseInitializerStateProps<
+  Extract<EnsureAppReadyState, { type: DeviceInteractionRequiredType.ConfirmOpenApp }>
+>;
+
+export function ConfirmOpenAppState({ device }: ConfirmOpenAppStateProps) {
+  return (
+    <ContinueOnDevice
+      deviceModelId={device.modelId}
+      deviceName={device.name}
+      testID="device-initializer-confirm-open-app"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceBusyState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceBusyState.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { RetryableStateType } from "@ledgerhq/live-dmk-shared";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { initializerDevice } from "../testUtils";
+import { DeviceBusyState } from "./DeviceBusyState";
+
+describe("DeviceBusyState", () => {
+  const renderState = () => {
+    const retry = jest.fn();
+    const onCancel = jest.fn();
+    const { user } = render(
+      <DeviceBusyState
+        state={{ type: RetryableStateType.DeviceBusy, retry }}
+        device={initializerDevice}
+        onCancel={onCancel}
+      />,
+    );
+    return { user, retry, onCancel };
+  };
+
+  it("GIVEN the device busy state WHEN rendering THEN it shows the pending action copy", () => {
+    // GIVEN
+    renderState();
+
+    // THEN
+    expect(screen.getByText("Action pending on your Ledger device")).toBeVisible();
+  });
+
+  it("GIVEN the device busy state WHEN clicking Retry THEN it calls retry", async () => {
+    // GIVEN
+    const { user, retry, onCancel } = renderState();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    // THEN
+    expect(retry).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN the device busy state WHEN clicking Cancel THEN it calls cancel", async () => {
+    // GIVEN
+    const { user, retry, onCancel } = renderState();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Cancel operation" }));
+
+    // THEN
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceBusyState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceBusyState.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { RetryableStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { InfoState } from "LLD/components/InfoState";
+import type { BaseInitializerStateProps } from "../types";
+
+type DeviceBusyStateProps = BaseInitializerStateProps<
+  Extract<EnsureAppReadyState, { type: RetryableStateType.DeviceBusy }>
+>;
+
+export function DeviceBusyState({ state, onCancel }: DeviceBusyStateProps) {
+  const { t } = useTranslation();
+
+  return (
+    <InfoState
+      preset="info"
+      size="hug"
+      title={t("deviceIntentExecutor.initialization.retryable.deviceBusy.title")}
+      description={t("deviceIntentExecutor.initialization.retryable.deviceBusy.description")}
+      primaryCta={{
+        label: t("common.retry"),
+        onPress: state.retry,
+      }}
+      secondaryCta={{
+        label: t("deviceIntentExecutor.initialization.cta.cancelOperation"),
+        onPress: onCancel,
+      }}
+      testID="device-initializer-device-busy"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceDeprecatedBlockingState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceDeprecatedBlockingState.test.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { BlockingStateType } from "@ledgerhq/live-dmk-shared";
+import {
+  DeviceDeprecationScreen,
+  DeviceDeprecationScreens,
+} from "~/renderer/components/DeviceAction/Screen/DeviceDeprecationScreen";
+import { initializerDevice } from "../testUtils";
+import { DeviceDeprecatedBlockingState } from "./DeviceDeprecatedBlockingState";
+
+jest.mock("~/renderer/components/DeviceAction/Screen/DeviceDeprecationScreen", () => ({
+  DeviceDeprecationScreens: {
+    clearSigningScreen: 0,
+    warningScreen: 1,
+    errorScreen: 2,
+  },
+  DeviceDeprecationScreen: jest.fn(() => null),
+}));
+
+const mockedDeviceDeprecationScreen = jest.mocked(DeviceDeprecationScreen);
+
+describe("DeviceDeprecatedBlockingState", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("GIVEN a blocking deprecation decision WHEN rendering THEN it wires the desktop error screen", () => {
+    // GIVEN
+    const supportEndDate = new Date("2026-01-01");
+
+    // WHEN
+    render(
+      <DeviceDeprecatedBlockingState
+        state={{
+          type: BlockingStateType.DeviceDeprecatedBlocking,
+          decision: {
+            status: "block",
+            currencyName: "Ethereum",
+            deviceModelId: DeviceModelId.nanoX,
+            supportEndDate,
+          },
+        }}
+        device={initializerDevice}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    // THEN
+    expect(mockedDeviceDeprecationScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        coinName: "Ethereum",
+        date: supportEndDate,
+        productName: expect.stringContaining("Nano"),
+        screenName: DeviceDeprecationScreens.errorScreen,
+      }),
+      undefined,
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceDeprecatedBlockingState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceDeprecatedBlockingState.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { getDeviceModel } from "@ledgerhq/devices";
+import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import {
+  DeviceDeprecationScreen,
+  DeviceDeprecationScreens,
+} from "~/renderer/components/DeviceAction/Screen/DeviceDeprecationScreen";
+import type { BaseInitializerStateProps } from "../types";
+
+type DeviceDeprecatedBlockingStateProps = BaseInitializerStateProps<
+  Extract<EnsureAppReadyState, { type: BlockingStateType.DeviceDeprecatedBlocking }>
+>;
+
+export function DeviceDeprecatedBlockingState({ state }: DeviceDeprecatedBlockingStateProps) {
+  const { decision } = state;
+
+  return (
+    <DeviceDeprecationScreen
+      coinName={decision.currencyName}
+      date={decision.supportEndDate}
+      productName={getDeviceModel(decision.deviceModelId).productName}
+      screenName={DeviceDeprecationScreens.errorScreen}
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceDeprecatedNonBlockingState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceDeprecatedNonBlockingState.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { AppInteractionRequiredStateType } from "@ledgerhq/live-dmk-shared";
+import {
+  DeviceDeprecationScreen,
+  DeviceDeprecationScreens,
+} from "~/renderer/components/DeviceAction/Screen/DeviceDeprecationScreen";
+import { initializerDevice } from "../testUtils";
+import { DeviceDeprecatedNonBlockingState } from "./DeviceDeprecatedNonBlockingState";
+
+jest.mock("~/renderer/components/DeviceAction/Screen/DeviceDeprecationScreen", () => ({
+  DeviceDeprecationScreens: {
+    clearSigningScreen: 0,
+    warningScreen: 1,
+    errorScreen: 2,
+  },
+  DeviceDeprecationScreen: jest.fn(() => null),
+}));
+
+const mockedDeviceDeprecationScreen = jest.mocked(DeviceDeprecationScreen);
+
+describe("DeviceDeprecatedNonBlockingState", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("GIVEN warning and clear-signing screens WHEN rendering THEN it wires the desktop deprecation screen", () => {
+    // GIVEN
+    const onContinue = jest.fn();
+    const supportEndDate = new Date("2026-01-01");
+
+    // WHEN
+    render(
+      <DeviceDeprecatedNonBlockingState
+        state={{
+          type: AppInteractionRequiredStateType.DeviceDeprecatedNonBlocking,
+          decision: {
+            status: "show",
+            screenSequence: ["warning", "clearSigning"],
+            currencyName: "Ethereum",
+            deviceModelId: DeviceModelId.nanoX,
+            supportEndDate,
+          },
+          onContinue,
+        }}
+        device={initializerDevice}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    // THEN
+    expect(mockedDeviceDeprecationScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        coinName: "Ethereum",
+        date: supportEndDate,
+        onContinue,
+        productName: expect.stringContaining("Nano"),
+        screenName: DeviceDeprecationScreens.warningScreen,
+        displayClearSigningWarning: true,
+      }),
+      undefined,
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceDeprecatedNonBlockingState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceDeprecatedNonBlockingState.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { getDeviceModel } from "@ledgerhq/devices";
+import {
+  AppInteractionRequiredStateType,
+  type EnsureAppReadyState,
+} from "@ledgerhq/live-dmk-shared";
+import {
+  DeviceDeprecationScreen,
+  DeviceDeprecationScreens,
+} from "~/renderer/components/DeviceAction/Screen/DeviceDeprecationScreen";
+import type { BaseInitializerStateProps } from "../types";
+
+type DeviceDeprecatedNonBlockingStateProps = BaseInitializerStateProps<
+  Extract<
+    EnsureAppReadyState,
+    { type: AppInteractionRequiredStateType.DeviceDeprecatedNonBlocking }
+  >
+>;
+
+export function DeviceDeprecatedNonBlockingState({ state }: DeviceDeprecatedNonBlockingStateProps) {
+  const { decision, onContinue } = state;
+  const displayClearSigningWarning = decision.screenSequence.includes("clearSigning");
+
+  return (
+    <DeviceDeprecationScreen
+      coinName={decision.currencyName}
+      date={decision.supportEndDate}
+      onContinue={onContinue}
+      productName={getDeviceModel(decision.deviceModelId).productName}
+      screenName={
+        decision.screenSequence.includes("warning")
+          ? DeviceDeprecationScreens.warningScreen
+          : DeviceDeprecationScreens.clearSigningScreen
+      }
+      displayClearSigningWarning={displayClearSigningWarning}
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceNotOnboarded/DeviceNotOnboardedView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceNotOnboarded/DeviceNotOnboardedView.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { DeviceNotOnboardedView } from "./DeviceNotOnboardedView";
+
+describe("DeviceNotOnboardedView", () => {
+  const renderView = () => {
+    const onSetupDevice = jest.fn();
+    const { user } = render(
+      <DeviceNotOnboardedView productName="Ledger Nano X" onSetupDevice={onSetupDevice} />,
+    );
+    return { user, onSetupDevice };
+  };
+
+  it("GIVEN the device not onboarded view WHEN rendering THEN it shows the not ready copy", () => {
+    // GIVEN
+    renderView();
+
+    // THEN
+    expect(screen.getByText("Your Ledger is not ready to use yet")).toBeVisible();
+  });
+
+  it("GIVEN the device not onboarded view WHEN clicking Set up device THEN it calls the setup action", async () => {
+    // GIVEN
+    const { user, onSetupDevice } = renderView();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Set up device" }));
+
+    // THEN
+    expect(onSetupDevice).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceNotOnboarded/DeviceNotOnboardedView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceNotOnboarded/DeviceNotOnboardedView.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { InfoState } from "LLD/components/InfoState";
+
+type DeviceNotOnboardedViewProps = Readonly<{
+  productName: string;
+  onSetupDevice: () => void;
+}>;
+
+export function DeviceNotOnboardedView({
+  productName,
+  onSetupDevice,
+}: DeviceNotOnboardedViewProps) {
+  const { t } = useTranslation();
+
+  return (
+    <InfoState
+      preset="info"
+      size="hug"
+      title={t("deviceIntentExecutor.initialization.blocking.deviceNotOnboarded.title")}
+      description={t(
+        "deviceIntentExecutor.initialization.blocking.deviceNotOnboarded.description",
+        {
+          productName,
+        },
+      )}
+      primaryCta={{
+        label: t("deviceIntentExecutor.initialization.cta.setupDevice"),
+        onPress: onSetupDevice,
+      }}
+      testID="device-initializer-device-not-onboarded"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceNotOnboarded/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceNotOnboarded/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import type { BaseInitializerStateProps } from "../../types";
+import { DeviceNotOnboardedView } from "./DeviceNotOnboardedView";
+import { useDeviceNotOnboardedViewModel } from "./useDeviceNotOnboardedViewModel";
+
+type DeviceNotOnboardedProps = BaseInitializerStateProps<
+  Extract<EnsureAppReadyState, { type: BlockingStateType.DeviceNotOnboarded }>
+>;
+
+export function DeviceNotOnboarded({ device }: DeviceNotOnboardedProps) {
+  const viewModel = useDeviceNotOnboardedViewModel({ device });
+
+  return <DeviceNotOnboardedView {...viewModel} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.test.tsx
@@ -1,0 +1,46 @@
+import { renderHook } from "@testing-library/react";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { initializerDevice } from "../../testUtils";
+import { useDeviceNotOnboardedViewModel } from "./useDeviceNotOnboardedViewModel";
+
+jest.mock("../../hooks/useInitializerActions", () => ({
+  useInitializerActions: jest.fn(),
+}));
+
+const mockedUseInitializerActions = jest.mocked(useInitializerActions);
+const openOnboarding = jest.fn();
+
+describe("useDeviceNotOnboardedViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseInitializerActions.mockReturnValue({
+      openMyLedger: jest.fn(),
+      openMyLedgerFirmwareUpdate: jest.fn(),
+      openOnboarding,
+      openSupport: jest.fn(),
+    });
+  });
+
+  it("GIVEN a not onboarded device WHEN rendering THEN it exposes the product name", () => {
+    // GIVEN
+    const { result } = renderHook(() =>
+      useDeviceNotOnboardedViewModel({ device: initializerDevice }),
+    );
+
+    // THEN
+    expect(result.current.productName).toBe("Ledger Nano X");
+  });
+
+  it("GIVEN a not onboarded device WHEN setting up device THEN it opens onboarding", () => {
+    // GIVEN
+    const { result } = renderHook(() =>
+      useDeviceNotOnboardedViewModel({ device: initializerDevice }),
+    );
+
+    // WHEN
+    result.current.onSetupDevice();
+
+    // THEN
+    expect(openOnboarding).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.ts
@@ -1,0 +1,15 @@
+import type { InitializerDevice } from "../../types";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+
+type Params = Readonly<{
+  device: InitializerDevice;
+}>;
+
+export function useDeviceNotOnboardedViewModel({ device }: Params) {
+  const { openOnboarding } = useInitializerActions();
+
+  return {
+    productName: device.productName,
+    onSetupDevice: openOnboarding,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceOutOfStorageSpace/DeviceOutOfStorageSpaceView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceOutOfStorageSpace/DeviceOutOfStorageSpaceView.test.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { DeviceOutOfStorageSpaceView } from "./DeviceOutOfStorageSpaceView";
+
+describe("DeviceOutOfStorageSpaceView", () => {
+  const renderView = () => {
+    const onOpenMyLedger = jest.fn();
+    const { user } = render(
+      <DeviceOutOfStorageSpaceView
+        appNamesText="Ethereum, Bitcoin"
+        onOpenMyLedger={onOpenMyLedger}
+      />,
+    );
+    return { user, onOpenMyLedger };
+  };
+
+  it("GIVEN the out of storage view WHEN rendering THEN it shows the memory warning and the apps to manage", () => {
+    // GIVEN
+    renderView();
+
+    // THEN
+    expect(screen.getByText("Not enough device memory")).toBeVisible();
+    expect(screen.getByText("Apps to manage: Ethereum, Bitcoin")).toBeVisible();
+  });
+
+  it("GIVEN the out of storage view WHEN clicking Go to My Ledger THEN it opens the manager", async () => {
+    // GIVEN
+    const { user, onOpenMyLedger } = renderView();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Go to My Ledger" }));
+
+    // THEN
+    expect(onOpenMyLedger).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceOutOfStorageSpace/DeviceOutOfStorageSpaceView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceOutOfStorageSpace/DeviceOutOfStorageSpaceView.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { InfoState } from "LLD/components/InfoState";
+
+type DeviceOutOfStorageSpaceViewProps = Readonly<{
+  appNamesText: string;
+  onOpenMyLedger: () => void;
+}>;
+
+export function DeviceOutOfStorageSpaceView({
+  appNamesText,
+  onOpenMyLedger,
+}: DeviceOutOfStorageSpaceViewProps) {
+  const { t } = useTranslation();
+
+  return (
+    <InfoState
+      preset="info"
+      size="hug"
+      title={t("deviceIntentExecutor.initialization.blocking.deviceOutOfStorageSpace.title")}
+      description={
+        <span className="flex flex-col gap-8">
+          <span>
+            {t("deviceIntentExecutor.initialization.blocking.deviceOutOfStorageSpace.description")}
+          </span>
+          <span>
+            {t("deviceIntentExecutor.initialization.blocking.deviceOutOfStorageSpace.apps", {
+              appNames: appNamesText,
+            })}
+          </span>
+        </span>
+      }
+      primaryCta={{
+        label: t("deviceIntentExecutor.initialization.cta.goToMyLedger"),
+        onPress: onOpenMyLedger,
+      }}
+      testID="device-initializer-device-out-of-storage-space"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceOutOfStorageSpace/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceOutOfStorageSpace/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import type { BaseInitializerStateProps } from "../../types";
+import { DeviceOutOfStorageSpaceView } from "./DeviceOutOfStorageSpaceView";
+import { useDeviceOutOfStorageSpaceViewModel } from "./useDeviceOutOfStorageSpaceViewModel";
+
+type DeviceOutOfStorageSpaceProps = BaseInitializerStateProps<
+  Extract<EnsureAppReadyState, { type: BlockingStateType.DeviceOutOfStorageSpace }>
+>;
+
+export function DeviceOutOfStorageSpace({ state }: DeviceOutOfStorageSpaceProps) {
+  const viewModel = useDeviceOutOfStorageSpaceViewModel({ state });
+
+  return <DeviceOutOfStorageSpaceView {...viewModel} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.test.tsx
@@ -1,0 +1,52 @@
+import { renderHook } from "@testing-library/react";
+import { BlockingStateType } from "@ledgerhq/live-dmk-shared";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { useDeviceOutOfStorageSpaceViewModel } from "./useDeviceOutOfStorageSpaceViewModel";
+
+jest.mock("../../hooks/useInitializerActions", () => ({
+  useInitializerActions: jest.fn(),
+}));
+
+const mockedUseInitializerActions = jest.mocked(useInitializerActions);
+const openMyLedger = jest.fn();
+
+describe("useDeviceOutOfStorageSpaceViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseInitializerActions.mockReturnValue({
+      openMyLedger,
+      openMyLedgerFirmwareUpdate: jest.fn(),
+      openOnboarding: jest.fn(),
+      openSupport: jest.fn(),
+    });
+  });
+
+  const renderViewModel = () =>
+    renderHook(() =>
+      useDeviceOutOfStorageSpaceViewModel({
+        state: {
+          type: BlockingStateType.DeviceOutOfStorageSpace,
+          appNames: ["Ethereum", "Bitcoin"],
+        },
+      }),
+    );
+
+  it("GIVEN multiple apps WHEN rendering THEN it displays all apps", () => {
+    // GIVEN
+    const { result } = renderViewModel();
+
+    // THEN
+    expect(result.current.appNamesText).toBe("Ethereum, Bitcoin");
+  });
+
+  it("GIVEN multiple apps WHEN opening My Ledger THEN it searches with all app names", () => {
+    // GIVEN
+    const { result } = renderViewModel();
+
+    // WHEN
+    result.current.onOpenMyLedger();
+
+    // THEN
+    expect(openMyLedger).toHaveBeenCalledWith("Ethereum, Bitcoin");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.ts
@@ -1,0 +1,26 @@
+import { useCallback, useMemo } from "react";
+import type { BlockingStateType, EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+
+type DeviceOutOfStorageSpaceState = Extract<
+  EnsureAppReadyState,
+  { type: BlockingStateType.DeviceOutOfStorageSpace }
+>;
+
+type Params = Readonly<{
+  state: DeviceOutOfStorageSpaceState;
+}>;
+
+export function useDeviceOutOfStorageSpaceViewModel({ state }: Params) {
+  const { openMyLedger } = useInitializerActions();
+  const appNamesText = useMemo(() => state.appNames.join(", "), [state.appNames]);
+
+  const onOpenMyLedger = useCallback(() => {
+    openMyLedger(appNamesText);
+  }, [appNamesText, openMyLedger]);
+
+  return {
+    appNamesText,
+    onOpenMyLedger,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/FinalErrorView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/FinalErrorView.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { FinalErrorView } from "./FinalErrorView";
+
+jest.mock("~/renderer/components/TranslatedError", () => ({
+  __esModule: true,
+  default: ({ field }: { field: string }) => <span>{`translated-${field}`}</span>,
+}));
+
+describe("FinalErrorView", () => {
+  const renderView = () => {
+    const onContactSupport = jest.fn();
+    const onCancel = jest.fn();
+    const { user } = render(
+      <FinalErrorView
+        error={new Error("unexpected")}
+        onContactSupport={onContactSupport}
+        onCancel={onCancel}
+      />,
+    );
+    return { user, onContactSupport, onCancel };
+  };
+
+  it("GIVEN the final error view WHEN rendering THEN it shows the translated title and description", () => {
+    // GIVEN
+    renderView();
+
+    // THEN
+    expect(screen.getByText("translated-title")).toBeVisible();
+    expect(screen.getByText("translated-description")).toBeVisible();
+  });
+
+  it("GIVEN the final error view WHEN clicking Contact Ledger support THEN it calls support", async () => {
+    // GIVEN
+    const { user, onContactSupport, onCancel } = renderView();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Contact Ledger support" }));
+
+    // THEN
+    expect(onContactSupport).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN the final error view WHEN clicking Close THEN it calls cancel", async () => {
+    // GIVEN
+    const { user, onContactSupport, onCancel } = renderView();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    // THEN
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onContactSupport).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/FinalErrorView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/FinalErrorView.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import type { DmkError } from "@ledgerhq/live-dmk-desktop";
+import { InfoState } from "LLD/components/InfoState";
+import TranslatedError from "~/renderer/components/TranslatedError";
+
+type FinalErrorViewProps = Readonly<{
+  error: Error | DmkError;
+  onCancel: () => void;
+  onContactSupport: () => void;
+}>;
+
+export function FinalErrorView({ error, onCancel, onContactSupport }: FinalErrorViewProps) {
+  const { t } = useTranslation();
+
+  return (
+    <InfoState
+      preset="error"
+      size="hug"
+      title={<TranslatedError error={error} field="title" />}
+      description={<TranslatedError error={error} field="description" />}
+      primaryCta={{
+        label: t("deviceIntentExecutor.initialization.cta.contactLedgerSupport"),
+        onPress: onContactSupport,
+      }}
+      secondaryCta={{
+        label: t("common.close"),
+        onPress: onCancel,
+      }}
+      testID="device-initializer-final-error"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { FinalStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import type { BaseInitializerStateProps } from "../../types";
+import { FinalErrorView } from "./FinalErrorView";
+import { useFinalErrorViewModel } from "./useFinalErrorViewModel";
+
+type FinalErrorProps = BaseInitializerStateProps<
+  Extract<EnsureAppReadyState, { type: FinalStateType.Error }>
+>;
+
+export function FinalError({ state, onCancel }: FinalErrorProps) {
+  const viewModel = useFinalErrorViewModel({ state, onCancel });
+
+  return <FinalErrorView {...viewModel} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/useFinalErrorViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/useFinalErrorViewModel.test.tsx
@@ -1,0 +1,87 @@
+import { renderHook } from "@testing-library/react";
+import { BlockingStateType, FinalStateType } from "@ledgerhq/live-dmk-shared";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { useFinalErrorViewModel } from "./useFinalErrorViewModel";
+
+jest.mock("../../hooks/useInitializerActions", () => ({
+  useInitializerActions: jest.fn(),
+}));
+
+const mockedUseInitializerActions = jest.mocked(useInitializerActions);
+const openSupport = jest.fn();
+
+describe("useFinalErrorViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseInitializerActions.mockReturnValue({
+      openMyLedger: jest.fn(),
+      openMyLedgerFirmwareUpdate: jest.fn(),
+      openOnboarding: jest.fn(),
+      openSupport,
+    });
+  });
+
+  it("GIVEN a final error state WHEN rendering THEN it exposes the error", () => {
+    // GIVEN
+    const error = new Error("unexpected");
+    const { result } = renderHook(() =>
+      useFinalErrorViewModel({
+        state: { type: FinalStateType.Error, error },
+        onCancel: jest.fn(),
+      }),
+    );
+
+    // THEN
+    expect(result.current.error).toBe(error);
+  });
+
+  it("GIVEN a final error state WHEN calling onContactSupport THEN it opens support", () => {
+    // GIVEN
+    const { result } = renderHook(() =>
+      useFinalErrorViewModel({
+        state: { type: FinalStateType.Error, error: new Error("unexpected") },
+        onCancel: jest.fn(),
+      }),
+    );
+
+    // WHEN
+    result.current.onContactSupport();
+
+    // THEN
+    expect(openSupport).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN a final error state WHEN calling onCancel THEN it wires cancel", () => {
+    // GIVEN
+    const onCancel = jest.fn();
+    const { result } = renderHook(() =>
+      useFinalErrorViewModel({
+        state: { type: FinalStateType.Error, error: new Error("unexpected") },
+        onCancel,
+      }),
+    );
+
+    // WHEN
+    result.current.onCancel();
+
+    // THEN
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN an unknown final error WHEN rendering THEN it exposes a generic error", () => {
+    // WHEN
+    const { result } = renderHook(() =>
+      useFinalErrorViewModel({
+        state: {
+          type: FinalStateType.Error,
+          error: { type: BlockingStateType.UnsupportedFeature },
+        },
+        onCancel: jest.fn(),
+      }),
+    );
+
+    // THEN
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error.message).toBe("Unknown error");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/useFinalErrorViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/useFinalErrorViewModel.ts
@@ -1,0 +1,28 @@
+import { isDmkError, type DmkError } from "@ledgerhq/live-dmk-desktop";
+import type { EnsureAppReadyState, FinalStateType } from "@ledgerhq/live-dmk-shared";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+
+type FinalErrorState = Extract<EnsureAppReadyState, { type: FinalStateType.Error }>;
+
+type Params = Readonly<{
+  state: FinalErrorState;
+  onCancel: () => void;
+}>;
+
+export function useFinalErrorViewModel({ state, onCancel }: Params) {
+  const { openSupport } = useInitializerActions();
+
+  return {
+    error: getTranslatedErrorInput(state.error),
+    onCancel,
+    onContactSupport: openSupport,
+  };
+}
+
+function getTranslatedErrorInput(error: unknown): Error | DmkError {
+  if (error instanceof Error || isDmkError(error)) {
+    return error;
+  }
+
+  return new Error("Unknown error");
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/InstallingAppState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/InstallingAppState.test.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { InstallingAppState } from "./InstallingAppState";
+
+describe("InstallingAppState", () => {
+  it("GIVEN the installing app state WHEN rendering THEN it renders the installing app title", () => {
+    // WHEN
+    render(<InstallingAppState />);
+
+    // THEN
+    expect(screen.getByText("Installing app")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/InstallingAppState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/InstallingAppState.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { LoadingContent } from "../../components/DeviceGenericStates/LoadingContent";
+
+export function InstallingAppState() {
+  const { t } = useTranslation();
+
+  return (
+    <LoadingContent
+      title={t("deviceIntentExecutor.initialization.installingApp.title")}
+      testID="device-initializer-installing-app"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/LoadingState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/LoadingState.test.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { LoadingState } from "./LoadingState";
+
+describe("LoadingState", () => {
+  it("GIVEN the loading state WHEN rendering THEN it renders the loading title", () => {
+    // WHEN
+    render(<LoadingState />);
+
+    // THEN
+    expect(screen.getByText("Loading")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/LoadingState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/LoadingState.tsx
@@ -2,8 +2,13 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { LoadingContent } from "../../components/DeviceGenericStates/LoadingContent";
 
-export function LoadingState(): React.ReactNode {
+export function LoadingState() {
   const { t } = useTranslation();
 
-  return <LoadingContent title={t("deviceIntentExecutor.connectDevice.states.loading.title")} />;
+  return (
+    <LoadingContent
+      title={t("deviceIntentExecutor.initialization.loading.title")}
+      testID="device-initializer-loading"
+    />
+  );
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/OutdatedAppWarning/OutdatedAppWarningView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/OutdatedAppWarning/OutdatedAppWarningView.test.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { OutdatedAppWarningView } from "./OutdatedAppWarningView";
+
+describe("OutdatedAppWarningView", () => {
+  const renderView = () => {
+    const onOpenMyLedger = jest.fn();
+    const onContinue = jest.fn();
+    const { user } = render(
+      <OutdatedAppWarningView
+        appName="Ethereum"
+        onOpenMyLedger={onOpenMyLedger}
+        onContinue={onContinue}
+      />,
+    );
+    return { user, onOpenMyLedger, onContinue };
+  };
+
+  it("GIVEN the outdated app view WHEN rendering THEN it shows the outdated app copy", () => {
+    // GIVEN
+    renderView();
+
+    // THEN
+    expect(screen.getByText("App version outdated")).toBeVisible();
+  });
+
+  it("GIVEN the outdated app view WHEN clicking Open My Ledger THEN it opens the manager", async () => {
+    // GIVEN
+    const { user, onOpenMyLedger, onContinue } = renderView();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Open My Ledger" }));
+
+    // THEN
+    expect(onOpenMyLedger).toHaveBeenCalledTimes(1);
+    expect(onContinue).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN the outdated app view WHEN clicking Continue THEN it continues", async () => {
+    // GIVEN
+    const { user, onOpenMyLedger, onContinue } = renderView();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    // THEN
+    expect(onContinue).toHaveBeenCalledTimes(1);
+    expect(onOpenMyLedger).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/OutdatedAppWarning/OutdatedAppWarningView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/OutdatedAppWarning/OutdatedAppWarningView.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { InfoState } from "LLD/components/InfoState";
+
+type OutdatedAppWarningViewProps = Readonly<{
+  appName: string;
+  onOpenMyLedger: () => void;
+  onContinue: () => void;
+}>;
+
+export function OutdatedAppWarningView({
+  appName,
+  onOpenMyLedger,
+  onContinue,
+}: OutdatedAppWarningViewProps) {
+  const { t } = useTranslation();
+
+  return (
+    <InfoState
+      preset="info"
+      size="hug"
+      title={t("deviceIntentExecutor.initialization.outdatedAppWarning.title")}
+      description={t("deviceIntentExecutor.initialization.outdatedAppWarning.description", {
+        appName,
+      })}
+      primaryCta={{
+        label: t("deviceIntentExecutor.initialization.cta.openMyLedger"),
+        onPress: onOpenMyLedger,
+      }}
+      secondaryCta={{
+        label: t("common.continue"),
+        onPress: onContinue,
+      }}
+      testID="device-initializer-outdated-app-warning"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/OutdatedAppWarning/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/OutdatedAppWarning/index.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import type {
+  AppInteractionRequiredStateType,
+  EnsureAppReadyState,
+} from "@ledgerhq/live-dmk-shared";
+import type { BaseInitializerStateProps } from "../../types";
+import { OutdatedAppWarningView } from "./OutdatedAppWarningView";
+import { useOutdatedAppWarningViewModel } from "./useOutdatedAppWarningViewModel";
+
+type OutdatedAppWarningProps = BaseInitializerStateProps<
+  Extract<EnsureAppReadyState, { type: AppInteractionRequiredStateType.OutdatedAppWarning }>
+>;
+
+export function OutdatedAppWarning({ state }: OutdatedAppWarningProps) {
+  const viewModel = useOutdatedAppWarningViewModel({ state });
+
+  return <OutdatedAppWarningView {...viewModel} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.test.tsx
@@ -1,0 +1,65 @@
+import { renderHook } from "@testing-library/react";
+import { AppInteractionRequiredStateType } from "@ledgerhq/live-dmk-shared";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { useOutdatedAppWarningViewModel } from "./useOutdatedAppWarningViewModel";
+
+jest.mock("../../hooks/useInitializerActions", () => ({
+  useInitializerActions: jest.fn(),
+}));
+
+const mockedUseInitializerActions = jest.mocked(useInitializerActions);
+const openMyLedger = jest.fn();
+
+describe("useOutdatedAppWarningViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseInitializerActions.mockReturnValue({
+      openMyLedger,
+      openMyLedgerFirmwareUpdate: jest.fn(),
+      openOnboarding: jest.fn(),
+      openSupport: jest.fn(),
+    });
+  });
+
+  const renderViewModel = (onContinue = jest.fn()) =>
+    renderHook(() =>
+      useOutdatedAppWarningViewModel({
+        state: {
+          type: AppInteractionRequiredStateType.OutdatedAppWarning,
+          appName: "Ethereum",
+          onContinue,
+        },
+      }),
+    );
+
+  it("GIVEN an outdated app warning WHEN rendering THEN it exposes the app name", () => {
+    // GIVEN
+    const { result } = renderViewModel();
+
+    // THEN
+    expect(result.current.appName).toBe("Ethereum");
+  });
+
+  it("GIVEN an outdated app warning WHEN calling onOpenMyLedger THEN it opens Manager for the app", () => {
+    // GIVEN
+    const { result } = renderViewModel();
+
+    // WHEN
+    result.current.onOpenMyLedger();
+
+    // THEN
+    expect(openMyLedger).toHaveBeenCalledWith("Ethereum");
+  });
+
+  it("GIVEN an outdated app warning WHEN calling onContinue THEN it preserves continue", () => {
+    // GIVEN
+    const onContinue = jest.fn();
+    const { result } = renderViewModel(onContinue);
+
+    // WHEN
+    result.current.onContinue();
+
+    // THEN
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.ts
@@ -1,0 +1,29 @@
+import { useCallback } from "react";
+import type {
+  AppInteractionRequiredStateType,
+  EnsureAppReadyState,
+} from "@ledgerhq/live-dmk-shared";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+
+type OutdatedAppWarningState = Extract<
+  EnsureAppReadyState,
+  { type: AppInteractionRequiredStateType.OutdatedAppWarning }
+>;
+
+type Params = Readonly<{
+  state: OutdatedAppWarningState;
+}>;
+
+export function useOutdatedAppWarningViewModel({ state }: Params) {
+  const { openMyLedger } = useInitializerActions();
+
+  const onOpenMyLedger = useCallback(() => {
+    openMyLedger(state.appName);
+  }, [openMyLedger, state.appName]);
+
+  return {
+    appName: state.appName,
+    onOpenMyLedger,
+    onContinue: state.onContinue,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/RetryableDeviceLockedState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/RetryableDeviceLockedState.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { RetryableStateType } from "@ledgerhq/live-dmk-shared";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { initializerDevice } from "../testUtils";
+import { RetryableDeviceLockedState } from "./RetryableDeviceLockedState";
+
+describe("RetryableDeviceLockedState", () => {
+  const renderState = () => {
+    const retry = jest.fn();
+    const { user } = render(
+      <RetryableDeviceLockedState
+        state={{ type: RetryableStateType.DeviceLocked, retry }}
+        device={initializerDevice}
+        onCancel={jest.fn()}
+      />,
+    );
+    return { user, retry };
+  };
+
+  it("GIVEN the retryable device locked state WHEN rendering THEN it shows the device locked copy", () => {
+    // GIVEN
+    renderState();
+
+    // THEN
+    expect(screen.getByText("Device is locked")).toBeVisible();
+  });
+
+  it("GIVEN the retryable device locked state WHEN clicking Retry THEN it calls retry", async () => {
+    // GIVEN
+    const { user, retry } = renderState();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    // THEN
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/RetryableDeviceLockedState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/RetryableDeviceLockedState.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { RetryableStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { RetryableDeviceLocked } from "../../components/DeviceGenericStates/RetryableDeviceLocked";
+import type { BaseInitializerStateProps } from "../types";
+
+type RetryableDeviceLockedStateProps = BaseInitializerStateProps<
+  Extract<EnsureAppReadyState, { type: RetryableStateType.DeviceLocked }>
+>;
+
+export function RetryableDeviceLockedState({ state, device }: RetryableDeviceLockedStateProps) {
+  return (
+    <RetryableDeviceLocked
+      deviceModelId={device.modelId}
+      onRetry={state.retry}
+      testID="device-initializer-retryable-device-locked"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnlockDeviceState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnlockDeviceState.test.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { DeviceInteractionRequiredType } from "@ledgerhq/live-dmk-shared";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { initializerDevice } from "../testUtils";
+import { UnlockDeviceState } from "./UnlockDeviceState";
+
+describe("UnlockDeviceState", () => {
+  it("GIVEN the unlock device state WHEN rendering THEN it renders the unlock title", () => {
+    // WHEN
+    render(
+      <UnlockDeviceState
+        state={{ type: DeviceInteractionRequiredType.UnlockDevice }}
+        device={initializerDevice}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    // THEN
+    expect(screen.getByText("Unlock your Ledger Nano X")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnlockDeviceState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnlockDeviceState.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { DeviceInteractionRequiredType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { UnlockDevice } from "../../components/DeviceGenericStates/UnlockDevice";
+import type { BaseInitializerStateProps } from "../types";
+
+type UnlockDeviceStateProps = BaseInitializerStateProps<
+  Extract<EnsureAppReadyState, { type: DeviceInteractionRequiredType.UnlockDevice }>
+>;
+
+export function UnlockDeviceState({ device }: UnlockDeviceStateProps) {
+  return (
+    <UnlockDevice
+      deviceModelId={device.modelId}
+      deviceName={device.name}
+      testID="device-initializer-unlock-device"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedApplication/UnsupportedApplicationView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedApplication/UnsupportedApplicationView.test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { UnsupportedApplicationView } from "./UnsupportedApplicationView";
+
+describe("UnsupportedApplicationView", () => {
+  const renderView = () => {
+    const onContactSupport = jest.fn();
+    const { user } = render(<UnsupportedApplicationView onContactSupport={onContactSupport} />);
+    return { user, onContactSupport };
+  };
+
+  it("GIVEN the unsupported application view WHEN rendering THEN it shows the unsupported feature copy", () => {
+    // GIVEN
+    renderView();
+
+    // THEN
+    expect(screen.getByText("Unsupported feature")).toBeVisible();
+  });
+
+  it("GIVEN the unsupported application view WHEN clicking Contact Ledger support THEN it calls support", async () => {
+    // GIVEN
+    const { user, onContactSupport } = renderView();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Contact Ledger support" }));
+
+    // THEN
+    expect(onContactSupport).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedApplication/UnsupportedApplicationView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedApplication/UnsupportedApplicationView.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { InfoState } from "LLD/components/InfoState";
+
+type UnsupportedApplicationViewProps = Readonly<{
+  onContactSupport: () => void;
+}>;
+
+export function UnsupportedApplicationView({ onContactSupport }: UnsupportedApplicationViewProps) {
+  const { t } = useTranslation();
+
+  return (
+    <InfoState
+      preset="info"
+      size="hug"
+      title={t("deviceIntentExecutor.initialization.blocking.unsupportedApplication.title")}
+      description={t(
+        "deviceIntentExecutor.initialization.blocking.unsupportedApplication.description",
+      )}
+      primaryCta={{
+        label: t("deviceIntentExecutor.initialization.cta.contactLedgerSupport"),
+        onPress: onContactSupport,
+      }}
+      testID="device-initializer-unsupported-application"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedApplication/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedApplication/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import type { BaseInitializerStateProps } from "../../types";
+import { UnsupportedApplicationView } from "./UnsupportedApplicationView";
+import { useUnsupportedApplicationViewModel } from "./useUnsupportedApplicationViewModel";
+
+type UnsupportedApplicationProps = BaseInitializerStateProps<
+  Extract<EnsureAppReadyState, { type: BlockingStateType.UnsupportedApplication }>
+>;
+
+export function UnsupportedApplication(_: UnsupportedApplicationProps) {
+  const viewModel = useUnsupportedApplicationViewModel();
+
+  return <UnsupportedApplicationView {...viewModel} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedApplication/useUnsupportedApplicationViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedApplication/useUnsupportedApplicationViewModel.test.tsx
@@ -1,0 +1,33 @@
+import { renderHook } from "@testing-library/react";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { useUnsupportedApplicationViewModel } from "./useUnsupportedApplicationViewModel";
+
+jest.mock("../../hooks/useInitializerActions", () => ({
+  useInitializerActions: jest.fn(),
+}));
+
+const mockedUseInitializerActions = jest.mocked(useInitializerActions);
+const openSupport = jest.fn();
+
+describe("useUnsupportedApplicationViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseInitializerActions.mockReturnValue({
+      openMyLedger: jest.fn(),
+      openMyLedgerFirmwareUpdate: jest.fn(),
+      openOnboarding: jest.fn(),
+      openSupport,
+    });
+  });
+
+  it("GIVEN an unsupported application state WHEN contacting support THEN it opens support", () => {
+    // GIVEN
+    const { result } = renderHook(() => useUnsupportedApplicationViewModel());
+
+    // WHEN
+    result.current.onContactSupport();
+
+    // THEN
+    expect(openSupport).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedApplication/useUnsupportedApplicationViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedApplication/useUnsupportedApplicationViewModel.ts
@@ -1,0 +1,9 @@
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+
+export function useUnsupportedApplicationViewModel() {
+  const { openSupport } = useInitializerActions();
+
+  return {
+    onContactSupport: openSupport,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFeature/UnsupportedFeatureView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFeature/UnsupportedFeatureView.test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { UnsupportedFeatureView } from "./UnsupportedFeatureView";
+
+describe("UnsupportedFeatureView", () => {
+  const renderView = () => {
+    const onContactSupport = jest.fn();
+    const { user } = render(<UnsupportedFeatureView onContactSupport={onContactSupport} />);
+    return { user, onContactSupport };
+  };
+
+  it("GIVEN the unsupported feature view WHEN rendering THEN it shows the unsupported feature copy", () => {
+    // GIVEN
+    renderView();
+
+    // THEN
+    expect(screen.getByText("Unsupported feature")).toBeVisible();
+  });
+
+  it("GIVEN the unsupported feature view WHEN clicking Contact Ledger support THEN it calls support", async () => {
+    // GIVEN
+    const { user, onContactSupport } = renderView();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Contact Ledger support" }));
+
+    // THEN
+    expect(onContactSupport).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFeature/UnsupportedFeatureView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFeature/UnsupportedFeatureView.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { InfoState } from "LLD/components/InfoState";
+
+type UnsupportedFeatureViewProps = Readonly<{
+  onContactSupport: () => void;
+}>;
+
+export function UnsupportedFeatureView({ onContactSupport }: UnsupportedFeatureViewProps) {
+  const { t } = useTranslation();
+
+  return (
+    <InfoState
+      preset="info"
+      size="hug"
+      title={t("deviceIntentExecutor.initialization.blocking.unsupportedFeature.title")}
+      description={t("deviceIntentExecutor.initialization.blocking.unsupportedFeature.description")}
+      primaryCta={{
+        label: t("deviceIntentExecutor.initialization.cta.contactLedgerSupport"),
+        onPress: onContactSupport,
+      }}
+      testID="device-initializer-unsupported-feature"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFeature/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFeature/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import type { BaseInitializerStateProps } from "../../types";
+import { UnsupportedFeatureView } from "./UnsupportedFeatureView";
+import { useUnsupportedFeatureViewModel } from "./useUnsupportedFeatureViewModel";
+
+type UnsupportedFeatureProps = BaseInitializerStateProps<
+  Extract<EnsureAppReadyState, { type: BlockingStateType.UnsupportedFeature }>
+>;
+
+export function UnsupportedFeature(_: UnsupportedFeatureProps) {
+  const viewModel = useUnsupportedFeatureViewModel();
+
+  return <UnsupportedFeatureView {...viewModel} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFeature/useUnsupportedFeatureViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFeature/useUnsupportedFeatureViewModel.test.tsx
@@ -1,0 +1,33 @@
+import { renderHook } from "@testing-library/react";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { useUnsupportedFeatureViewModel } from "./useUnsupportedFeatureViewModel";
+
+jest.mock("../../hooks/useInitializerActions", () => ({
+  useInitializerActions: jest.fn(),
+}));
+
+const mockedUseInitializerActions = jest.mocked(useInitializerActions);
+const openSupport = jest.fn();
+
+describe("useUnsupportedFeatureViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseInitializerActions.mockReturnValue({
+      openMyLedger: jest.fn(),
+      openMyLedgerFirmwareUpdate: jest.fn(),
+      openOnboarding: jest.fn(),
+      openSupport,
+    });
+  });
+
+  it("GIVEN an unsupported feature state WHEN contacting support THEN it opens support", () => {
+    // GIVEN
+    const { result } = renderHook(() => useUnsupportedFeatureViewModel());
+
+    // WHEN
+    result.current.onContactSupport();
+
+    // THEN
+    expect(openSupport).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFeature/useUnsupportedFeatureViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFeature/useUnsupportedFeatureViewModel.ts
@@ -1,0 +1,9 @@
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+
+export function useUnsupportedFeatureViewModel() {
+  const { openSupport } = useInitializerActions();
+
+  return {
+    onContactSupport: openSupport,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFirmwareVersion/UnsupportedFirmwareVersionView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFirmwareVersion/UnsupportedFirmwareVersionView.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { UnsupportedFirmwareVersionView } from "./UnsupportedFirmwareVersionView";
+
+describe("UnsupportedFirmwareVersionView", () => {
+  const renderView = () => {
+    const onUpdateLedgerOs = jest.fn();
+    const onCancel = jest.fn();
+    const { user } = render(
+      <UnsupportedFirmwareVersionView onUpdateLedgerOs={onUpdateLedgerOs} onCancel={onCancel} />,
+    );
+    return { user, onUpdateLedgerOs, onCancel };
+  };
+
+  it("GIVEN the unsupported firmware view WHEN rendering THEN it shows the update required copy", () => {
+    // GIVEN
+    renderView();
+
+    // THEN
+    expect(screen.getByText("Ledger OS update required")).toBeVisible();
+  });
+
+  it("GIVEN the unsupported firmware view WHEN clicking Update Ledger OS THEN it calls update", async () => {
+    // GIVEN
+    const { user, onUpdateLedgerOs, onCancel } = renderView();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Update Ledger OS" }));
+
+    // THEN
+    expect(onUpdateLedgerOs).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN the unsupported firmware view WHEN clicking Cancel THEN it calls cancel", async () => {
+    // GIVEN
+    const { user, onUpdateLedgerOs, onCancel } = renderView();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Cancel operation" }));
+
+    // THEN
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onUpdateLedgerOs).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFirmwareVersion/UnsupportedFirmwareVersionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFirmwareVersion/UnsupportedFirmwareVersionView.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { InfoState } from "LLD/components/InfoState";
+
+type UnsupportedFirmwareVersionViewProps = Readonly<{
+  onUpdateLedgerOs: () => void;
+  onCancel: () => void;
+}>;
+
+export function UnsupportedFirmwareVersionView({
+  onUpdateLedgerOs,
+  onCancel,
+}: UnsupportedFirmwareVersionViewProps) {
+  const { t } = useTranslation();
+
+  return (
+    <InfoState
+      preset="info"
+      size="hug"
+      title={t("deviceIntentExecutor.initialization.blocking.unsupportedFirmwareVersion.title")}
+      primaryCta={{
+        label: t("deviceIntentExecutor.initialization.cta.updateLedgerOs"),
+        onPress: onUpdateLedgerOs,
+      }}
+      secondaryCta={{
+        label: t("deviceIntentExecutor.initialization.cta.cancelOperation"),
+        onPress: onCancel,
+      }}
+      testID="device-initializer-unsupported-firmware-version"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFirmwareVersion/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFirmwareVersion/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import type { BaseInitializerStateProps } from "../../types";
+import { UnsupportedFirmwareVersionView } from "./UnsupportedFirmwareVersionView";
+import { useUnsupportedFirmwareVersionViewModel } from "./useUnsupportedFirmwareVersionViewModel";
+
+type UnsupportedFirmwareVersionProps = BaseInitializerStateProps<
+  Extract<EnsureAppReadyState, { type: BlockingStateType.UnsupportedFirmwareVersion }>
+>;
+
+export function UnsupportedFirmwareVersion({ onCancel }: UnsupportedFirmwareVersionProps) {
+  const viewModel = useUnsupportedFirmwareVersionViewModel({ onCancel });
+
+  return <UnsupportedFirmwareVersionView {...viewModel} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.test.tsx
@@ -1,0 +1,47 @@
+import { renderHook } from "@testing-library/react";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { useUnsupportedFirmwareVersionViewModel } from "./useUnsupportedFirmwareVersionViewModel";
+
+jest.mock("../../hooks/useInitializerActions", () => ({
+  useInitializerActions: jest.fn(),
+}));
+
+const mockedUseInitializerActions = jest.mocked(useInitializerActions);
+const openMyLedgerFirmwareUpdate = jest.fn();
+
+describe("useUnsupportedFirmwareVersionViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseInitializerActions.mockReturnValue({
+      openMyLedger: jest.fn(),
+      openMyLedgerFirmwareUpdate,
+      openOnboarding: jest.fn(),
+      openSupport: jest.fn(),
+    });
+  });
+
+  it("GIVEN an unsupported firmware state WHEN calling onUpdateLedgerOs THEN it opens the firmware update", () => {
+    // GIVEN
+    const { result } = renderHook(() =>
+      useUnsupportedFirmwareVersionViewModel({ onCancel: jest.fn() }),
+    );
+
+    // WHEN
+    result.current.onUpdateLedgerOs();
+
+    // THEN
+    expect(openMyLedgerFirmwareUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN an unsupported firmware state WHEN calling onCancel THEN it preserves cancel", () => {
+    // GIVEN
+    const onCancel = jest.fn();
+    const { result } = renderHook(() => useUnsupportedFirmwareVersionViewModel({ onCancel }));
+
+    // WHEN
+    result.current.onCancel();
+
+    // THEN
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.ts
@@ -1,0 +1,14 @@
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+
+type Params = Readonly<{
+  onCancel: () => void;
+}>;
+
+export function useUnsupportedFirmwareVersionViewModel({ onCancel }: Params) {
+  const { openMyLedgerFirmwareUpdate } = useInitializerActions();
+
+  return {
+    onCancel,
+    onUpdateLedgerOs: openMyLedgerFirmwareUpdate,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UserRefusedOnDeviceState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UserRefusedOnDeviceState.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { RetryableStateType } from "@ledgerhq/live-dmk-shared";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { initializerDevice } from "../testUtils";
+import { UserRefusedOnDeviceState } from "./UserRefusedOnDeviceState";
+
+describe("UserRefusedOnDeviceState", () => {
+  const renderState = () => {
+    const retry = jest.fn();
+    const onCancel = jest.fn();
+    const { user } = render(
+      <UserRefusedOnDeviceState
+        state={{ type: RetryableStateType.UserRefusedOnDevice, retry }}
+        device={initializerDevice}
+        onCancel={onCancel}
+      />,
+    );
+    return { user, retry, onCancel };
+  };
+
+  it("GIVEN the user refused state WHEN rendering THEN it shows the operation rejected copy", () => {
+    // GIVEN
+    renderState();
+
+    // THEN
+    expect(screen.getByText("Operation rejected on device")).toBeVisible();
+  });
+
+  it("GIVEN the user refused state WHEN clicking Close THEN it calls cancel", async () => {
+    // GIVEN
+    const { user, retry, onCancel } = renderState();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    // THEN
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN the user refused state WHEN clicking Retry THEN it calls retry", async () => {
+    // GIVEN
+    const { user, retry, onCancel } = renderState();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    // THEN
+    expect(retry).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UserRefusedOnDeviceState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UserRefusedOnDeviceState.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { RetryableStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { InfoState } from "LLD/components/InfoState";
+import type { BaseInitializerStateProps } from "../types";
+
+type UserRefusedOnDeviceStateProps = BaseInitializerStateProps<
+  Extract<EnsureAppReadyState, { type: RetryableStateType.UserRefusedOnDevice }>
+>;
+
+export function UserRefusedOnDeviceState({ state, onCancel }: UserRefusedOnDeviceStateProps) {
+  const { t } = useTranslation();
+
+  return (
+    <InfoState
+      preset="info"
+      size="hug"
+      title={t("deviceIntentExecutor.initialization.retryable.userRefused.title")}
+      primaryCta={{
+        label: t("common.close"),
+        onPress: onCancel,
+      }}
+      secondaryCta={{
+        label: t("common.retry"),
+        onPress: state.retry,
+      }}
+      testID="device-initializer-user-refused-on-device"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/WrongDeviceForAccount/WrongDeviceForAccountView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/WrongDeviceForAccount/WrongDeviceForAccountView.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { WrongDeviceForAccountView } from "./WrongDeviceForAccountView";
+
+describe("WrongDeviceForAccountView", () => {
+  const renderView = () => {
+    const onCancel = jest.fn();
+    const onContactSupport = jest.fn();
+    const { user } = render(
+      <WrongDeviceForAccountView onCancel={onCancel} onContactSupport={onContactSupport} />,
+    );
+    return { user, onCancel, onContactSupport };
+  };
+
+  it("GIVEN the wrong device view WHEN rendering THEN it shows the wrong recovery phrase copy", () => {
+    // GIVEN
+    renderView();
+
+    // THEN
+    expect(screen.getByText("Wrong Secret Recovery Phrase")).toBeVisible();
+  });
+
+  it("GIVEN the wrong device view WHEN clicking Close THEN it calls cancel", async () => {
+    // GIVEN
+    const { user, onCancel, onContactSupport } = renderView();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    // THEN
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onContactSupport).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN the wrong device view WHEN clicking Contact Ledger support THEN it calls support", async () => {
+    // GIVEN
+    const { user, onCancel, onContactSupport } = renderView();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Contact Ledger support" }));
+
+    // THEN
+    expect(onContactSupport).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/WrongDeviceForAccount/WrongDeviceForAccountView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/WrongDeviceForAccount/WrongDeviceForAccountView.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { InfoState } from "LLD/components/InfoState";
+
+type WrongDeviceForAccountViewProps = Readonly<{
+  onCancel: () => void;
+  onContactSupport: () => void;
+}>;
+
+export function WrongDeviceForAccountView({
+  onCancel,
+  onContactSupport,
+}: WrongDeviceForAccountViewProps) {
+  const { t } = useTranslation();
+
+  return (
+    <InfoState
+      preset="info"
+      size="hug"
+      title={t("deviceIntentExecutor.initialization.blocking.wrongDeviceForAccount.title")}
+      description={t(
+        "deviceIntentExecutor.initialization.blocking.wrongDeviceForAccount.description",
+      )}
+      primaryCta={{
+        label: t("common.close"),
+        onPress: onCancel,
+      }}
+      secondaryCta={{
+        label: t("deviceIntentExecutor.initialization.cta.contactLedgerSupport"),
+        onPress: onContactSupport,
+      }}
+      testID="device-initializer-wrong-device-for-account"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/WrongDeviceForAccount/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/WrongDeviceForAccount/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import type { BaseInitializerStateProps } from "../../types";
+import { WrongDeviceForAccountView } from "./WrongDeviceForAccountView";
+import { useWrongDeviceForAccountViewModel } from "./useWrongDeviceForAccountViewModel";
+
+type WrongDeviceForAccountProps = BaseInitializerStateProps<
+  Extract<EnsureAppReadyState, { type: BlockingStateType.WrongDeviceForAccount }>
+>;
+
+export function WrongDeviceForAccount({ onCancel }: WrongDeviceForAccountProps) {
+  const viewModel = useWrongDeviceForAccountViewModel({ onCancel });
+
+  return <WrongDeviceForAccountView {...viewModel} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.test.tsx
@@ -1,0 +1,45 @@
+import { renderHook } from "@testing-library/react";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { useWrongDeviceForAccountViewModel } from "./useWrongDeviceForAccountViewModel";
+
+jest.mock("../../hooks/useInitializerActions", () => ({
+  useInitializerActions: jest.fn(),
+}));
+
+const mockedUseInitializerActions = jest.mocked(useInitializerActions);
+const openSupport = jest.fn();
+
+describe("useWrongDeviceForAccountViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseInitializerActions.mockReturnValue({
+      openMyLedger: jest.fn(),
+      openMyLedgerFirmwareUpdate: jest.fn(),
+      openOnboarding: jest.fn(),
+      openSupport,
+    });
+  });
+
+  it("GIVEN a wrong device state WHEN calling onCancel THEN it cancels", () => {
+    // GIVEN
+    const onCancel = jest.fn();
+    const { result } = renderHook(() => useWrongDeviceForAccountViewModel({ onCancel }));
+
+    // WHEN
+    result.current.onCancel();
+
+    // THEN
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN a wrong device state WHEN calling onContactSupport THEN it opens support", () => {
+    // GIVEN
+    const { result } = renderHook(() => useWrongDeviceForAccountViewModel({ onCancel: jest.fn() }));
+
+    // WHEN
+    result.current.onContactSupport();
+
+    // THEN
+    expect(openSupport).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.ts
@@ -1,0 +1,14 @@
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+
+type Params = Readonly<{
+  onCancel: () => void;
+}>;
+
+export function useWrongDeviceForAccountViewModel({ onCancel }: Params) {
+  const { openSupport } = useInitializerActions();
+
+  return {
+    onCancel,
+    onContactSupport: openSupport,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/hooks/useInitializerActions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/hooks/useInitializerActions.ts
@@ -1,0 +1,44 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router";
+import { urls } from "~/config/urls";
+import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
+import { openURL } from "~/renderer/linking";
+
+const MANAGER_ROUTE = "/manager";
+const ONBOARDING_ROUTE = "/onboarding/select-device";
+
+export function useInitializerActions() {
+  const navigate = useNavigate();
+  const contactSupportUrl = useLocalizedUrl(urls.contactSupport);
+
+  const openMyLedger = useCallback(
+    (searchQuery?: string) => {
+      if (!searchQuery) {
+        navigate(MANAGER_ROUTE);
+        return;
+      }
+
+      navigate(`${MANAGER_ROUTE}?q=${encodeURIComponent(searchQuery)}`);
+    },
+    [navigate],
+  );
+
+  const openMyLedgerFirmwareUpdate = useCallback(() => {
+    navigate(`${MANAGER_ROUTE}?firmwareUpdate=true`);
+  }, [navigate]);
+
+  const openOnboarding = useCallback(() => {
+    navigate(ONBOARDING_ROUTE);
+  }, [navigate]);
+
+  const openSupport = useCallback(() => {
+    openURL(contactSupportUrl);
+  }, [contactSupportUrl]);
+
+  return {
+    openMyLedger,
+    openMyLedgerFirmwareUpdate,
+    openOnboarding,
+    openSupport,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/index.tsx
@@ -1,12 +1,9 @@
 import React from "react";
-import type {
-  DeviceConnectionResult,
-  DeviceContextInitializerComponent,
-  DeviceExtractedContext,
-} from "@ledgerhq/device-intent";
+import type { DeviceContextInitializerComponent } from "@ledgerhq/device-intent";
 import type { EnsureAppReadyUseCaseDependencies } from "@ledgerhq/live-common/device/use-cases/ensureAppReady/ensureAppReadyUseCase";
-import { Button } from "@ledgerhq/lumen-ui-react";
 import type { InitializationInput } from "../types";
+import { DeviceContextInitializerComponentLWDView } from "./DeviceContextInitializerComponentLWDView";
+import { useDeviceContextInitializerComponentLWDViewModel } from "./useDeviceContextInitializerComponentLWDViewModel";
 
 export type InitializerConfig =
   | {
@@ -14,84 +11,20 @@ export type InitializerConfig =
     }
   | undefined;
 
-function formatParams(params: unknown): string {
-  return JSON.stringify(params, null, 2) ?? "";
-}
-
 const DeviceContextInitializerComponentLWD: DeviceContextInitializerComponent<
   InitializationInput,
   InitializerConfig
-> = ({ connectionResult, deviceInitializationInput, onContextInitialized, onClose }) => {
-  const simulateInitialized = () => {
-    onContextInitialized(buildMockDeviceContext(deviceInitializationInput));
-  };
+> = ({ connectionResult, deviceInitializationInput, onContextInitialized, config, onClose }) => {
+  const { state, device } = useDeviceContextInitializerComponentLWDViewModel({
+    connectionResult,
+    deviceInitializationInput,
+    onContextInitialized,
+    dependencies: config?.dependencies,
+  });
 
   return (
-    <div
-      className="flex w-full flex-col gap-24 px-16 py-24"
-      data-testid="device-intent-executor-device-context-initializer-placeholder"
-    >
-      <div className="flex flex-col gap-8 text-center">
-        <h3 className="heading-4-semi-bold text-base">Device context initializer placeholder</h3>
-        <p className="body-2 text-muted">
-          The desktop device initializer implementation is pending.
-        </p>
-      </div>
-      <DebugSection title="Connected device" value={buildConnectionSummary(connectionResult)} />
-      <DebugSection title="Initialization input" value={deviceInitializationInput} />
-      <div className="flex w-full flex-col gap-12">
-        <Button appearance="base" size="lg" isFull onClick={simulateInitialized}>
-          Simulate initialized context
-        </Button>
-        <Button appearance="gray" size="lg" isFull onClick={onClose}>
-          Close
-        </Button>
-      </div>
-    </div>
+    <DeviceContextInitializerComponentLWDView state={state} device={device} onCancel={onClose} />
   );
 };
-
-function DebugSection({ title, value }: Readonly<{ title: string; value: unknown }>) {
-  return (
-    <div className="flex flex-col gap-8">
-      <span className="body-2-semi-bold text-base">{title}</span>
-      <pre className="max-h-[240px] overflow-auto rounded-md bg-muted p-12 text-left font-mono text-xs text-base">
-        {formatParams(value)}
-      </pre>
-    </div>
-  );
-}
-
-function buildConnectionSummary(connectionResult: DeviceConnectionResult) {
-  return {
-    sessionId: connectionResult.sessionId,
-    compatDeviceId: connectionResult.compatDeviceId,
-    compatDeviceModelId: connectionResult.compatDeviceModelId,
-    compatDeviceName: connectionResult.compatDeviceName,
-    compatDeviceWired: connectionResult.compatDeviceWired,
-    connectedDevice: {
-      id: connectionResult.connectedDevice.id,
-      name: connectionResult.connectedDevice.name,
-      modelId: connectionResult.connectedDevice.modelId,
-      sessionId: connectionResult.connectedDevice.sessionId,
-      type: connectionResult.connectedDevice.type,
-      transport: connectionResult.connectedDevice.transport,
-    },
-  };
-}
-
-function buildMockDeviceContext(
-  deviceInitializationInput: InitializationInput,
-): DeviceExtractedContext {
-  return {
-    currentOsVersion: "2.2.0",
-    osUpdateAvailable: false,
-    currentAppName: deviceInitializationInput.appName,
-    currentAppVersion: "1.0.0-debug",
-    derivedAddress: deviceInitializationInput.requiresDerivation
-      ? "0x0000000000000000000000000000000000000000"
-      : undefined,
-  };
-}
 
 export default DeviceContextInitializerComponentLWD;

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/testUtils.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/testUtils.tsx
@@ -1,0 +1,38 @@
+import type { DeviceConnectionResult } from "@ledgerhq/device-intent";
+import { ledgerToDmkDeviceIdMap } from "@ledgerhq/live-dmk-shared";
+import { webHidTransportIdentifier } from "@ledgerhq/live-dmk-desktop";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import type { InitializationInput } from "../types";
+import type { InitializerDevice } from "./types";
+
+export const connectionResult = {
+  compatDeviceId: "device-id",
+  compatDeviceModelId: DeviceModelId.nanoX,
+  compatDeviceName: "Ledger Nano X",
+  compatDeviceWired: true,
+  connectedDevice: {
+    id: "device-id",
+    name: "Ledger Nano X",
+    modelId: ledgerToDmkDeviceIdMap[DeviceModelId.nanoX],
+    sessionId: "session-1",
+    type: "USB",
+    transport: webHidTransportIdentifier,
+  },
+  dmk: { id: "dmk" },
+  sessionId: "session-1",
+} as unknown as DeviceConnectionResult;
+
+export const deviceInitializationInput: InitializationInput = {
+  appName: "Ethereum",
+  dependencies: ["1inch"],
+  requireLatestFirmware: false,
+  allowPartialDependencies: false,
+};
+
+export const initializerDevice: InitializerDevice = {
+  id: "device-id",
+  modelId: DeviceModelId.nanoX,
+  name: "Ledger Nano X",
+  productName: "Ledger Nano X",
+  wired: true,
+};

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/testUtils.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/testUtils.tsx
@@ -26,7 +26,6 @@ export const deviceInitializationInput: InitializationInput = {
   appName: "Ethereum",
   dependencies: ["1inch"],
   requireLatestFirmware: false,
-  allowPartialDependencies: false,
 };
 
 export const initializerDevice: InitializerDevice = {

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/types.ts
@@ -1,0 +1,22 @@
+import type { EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import type { DeviceModelId } from "@ledgerhq/types-devices";
+
+export type InitializerDevice = Readonly<{
+  id: string;
+  modelId: DeviceModelId;
+  name: string;
+  productName: string;
+  wired: boolean;
+}>;
+
+export type DeviceContextInitializerComponentLWDViewProps = Readonly<{
+  state: EnsureAppReadyState;
+  device: InitializerDevice;
+  onCancel: () => void;
+}>;
+
+export type BaseInitializerStateProps<State extends EnsureAppReadyState> = Readonly<{
+  state: State;
+  device: InitializerDevice;
+  onCancel: () => void;
+}>;

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/useDeviceContextInitializerComponentLWDViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/useDeviceContextInitializerComponentLWDViewModel.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { DeviceConnectionResult, DeviceExtractedContext } from "@ledgerhq/device-intent";
-import { identitiesSlice } from "@ledgerhq/client-ids/store";
+import { identitiesSlice } from "@domain/entity-client-identity";
 import {
   ensureAppReadyUseCase,
   type EnsureAppReadyUseCaseDependencies,

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/useDeviceContextInitializerComponentLWDViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/useDeviceContextInitializerComponentLWDViewModel.ts
@@ -1,0 +1,112 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { DeviceConnectionResult, DeviceExtractedContext } from "@ledgerhq/device-intent";
+import { identitiesSlice } from "@ledgerhq/client-ids/store";
+import {
+  ensureAppReadyUseCase,
+  type EnsureAppReadyUseCaseDependencies,
+} from "@ledgerhq/live-common/device/use-cases/ensureAppReady/ensureAppReadyUseCase";
+import type { ConnectAppInitSideEffects } from "@ledgerhq/live-common/device/use-cases/ensureAppReady/types";
+import {
+  FinalStateType,
+  LoadingStateType,
+  type EnsureAppReadyState,
+} from "@ledgerhq/live-dmk-shared";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { addNewDeviceModel, setLastSeenDeviceInfo } from "~/renderer/actions/settings";
+import { settingsStoreSelector } from "~/renderer/reducers/settings";
+import type { InitializationInput } from "../types";
+import type { InitializerDevice } from "./types";
+import { buildInitializerDevice } from "./utils/buildInitializerDevice";
+
+type UseDeviceContextInitializerComponentLWDViewModelParams = {
+  connectionResult: DeviceConnectionResult;
+  deviceInitializationInput: InitializationInput;
+  onContextInitialized: (context: DeviceExtractedContext) => void;
+  dependencies?: Partial<EnsureAppReadyUseCaseDependencies>;
+};
+
+type UseDeviceContextInitializerComponentLWDViewModelResult = {
+  state: EnsureAppReadyState;
+  device: InitializerDevice;
+};
+
+const LOADING_STATE: EnsureAppReadyState = { type: LoadingStateType.Loading };
+
+export function useDeviceContextInitializerComponentLWDViewModel({
+  connectionResult,
+  deviceInitializationInput,
+  onContextInitialized,
+  dependencies,
+}: UseDeviceContextInitializerComponentLWDViewModelParams): UseDeviceContextInitializerComponentLWDViewModelResult {
+  const dispatch = useDispatch();
+  const deprecationDismissedCurrencyNames = useSelector(
+    state => settingsStoreSelector(state).deprecationDoNotRemind,
+  );
+  const [state, setState] = useState<EnsureAppReadyState>(LOADING_STATE);
+  const completedRef = useRef(false);
+
+  const device = useMemo(() => buildInitializerDevice(connectionResult), [connectionResult]);
+
+  const sideEffects = useMemo<ConnectAppInitSideEffects>(
+    () => ({
+      onDeviceIdObserved: deviceId => {
+        dispatch(identitiesSlice.actions.addDeviceId(deviceId));
+      },
+      onLastSeenDeviceInfoObserved: ({ modelId, deviceInfo, latestFirmware }) => {
+        dispatch(
+          setLastSeenDeviceInfo({
+            lastSeenDevice: {
+              modelId,
+              deviceInfo,
+              apps: [],
+            },
+            latestFirmware,
+          }),
+        );
+        dispatch(addNewDeviceModel({ deviceModelId: modelId }));
+      },
+    }),
+    [dispatch],
+  );
+
+  useEffect(() => {
+    const { dmk, sessionId } = connectionResult;
+    completedRef.current = false;
+    setState(LOADING_STATE);
+
+    const subscription = ensureAppReadyUseCase({
+      dmk,
+      sessionId,
+      input: deviceInitializationInput,
+      deprecationDismissedCurrencyNames,
+      sideEffects,
+      dependencies,
+    }).subscribe({
+      next: nextState => {
+        setState(nextState);
+
+        if (nextState.type === FinalStateType.Success && !completedRef.current) {
+          completedRef.current = true;
+          onContextInitialized(nextState.extractedContext);
+        }
+      },
+      error: error => {
+        setState({
+          type: FinalStateType.Error,
+          error,
+        });
+      },
+    });
+
+    return () => subscription.unsubscribe();
+  }, [
+    connectionResult,
+    deprecationDismissedCurrencyNames,
+    dependencies,
+    deviceInitializationInput,
+    onContextInitialized,
+    sideEffects,
+  ]);
+
+  return { state, device };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/useDeviceContextInitializerComponentLWDViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/useDeviceContextInitializerComponentLWDViewModel.ts
@@ -52,13 +52,13 @@ export function useDeviceContextInitializerComponentLWDViewModel({
       onDeviceIdObserved: deviceId => {
         dispatch(identitiesSlice.actions.addDeviceId(deviceId));
       },
-      onLastSeenDeviceInfoObserved: ({ modelId, deviceInfo, latestFirmware }) => {
+      onLastSeenDeviceInfoObserved: ({ modelId, deviceInfo, apps, latestFirmware }) => {
         dispatch(
           setLastSeenDeviceInfo({
             lastSeenDevice: {
               modelId,
               deviceInfo,
-              apps: [],
+              apps,
             },
             latestFirmware,
           }),

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/utils/buildInitializerDevice.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/utils/buildInitializerDevice.test.ts
@@ -1,0 +1,51 @@
+import type { DeviceConnectionResult } from "@ledgerhq/device-intent";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { buildInitializerDevice } from "./buildInitializerDevice";
+
+describe("buildInitializerDevice", () => {
+  it("GIVEN a connection result with a custom name WHEN building the initializer device THEN it preserves the name and wired flag", () => {
+    // GIVEN
+    const connectionResult = {
+      compatDeviceId: "device-id",
+      compatDeviceModelId: DeviceModelId.nanoX,
+      compatDeviceName: "Olivier's Ledger",
+      compatDeviceWired: true,
+    } satisfies Pick<
+      DeviceConnectionResult,
+      "compatDeviceId" | "compatDeviceModelId" | "compatDeviceName" | "compatDeviceWired"
+    >;
+
+    // WHEN
+    const device = buildInitializerDevice(connectionResult);
+
+    // THEN
+    expect(device).toEqual({
+      id: "device-id",
+      modelId: DeviceModelId.nanoX,
+      name: "Olivier's Ledger",
+      productName: expect.stringContaining("Nano"),
+      wired: true,
+    });
+  });
+
+  it("GIVEN a connection result without a custom name WHEN building the initializer device THEN it falls back to the product name", () => {
+    // GIVEN
+    const connectionResult = {
+      compatDeviceId: "device-id",
+      compatDeviceModelId: DeviceModelId.nanoX,
+      compatDeviceName: "",
+      compatDeviceWired: false,
+    } satisfies Pick<
+      DeviceConnectionResult,
+      "compatDeviceId" | "compatDeviceModelId" | "compatDeviceName" | "compatDeviceWired"
+    >;
+
+    // WHEN
+    const device = buildInitializerDevice(connectionResult);
+
+    // THEN
+    expect(device.name).toBe(device.productName);
+    expect(device.productName).toEqual(expect.stringContaining("Nano"));
+    expect(device.wired).toBe(false);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/utils/buildInitializerDevice.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/utils/buildInitializerDevice.ts
@@ -1,0 +1,31 @@
+import { getDeviceModel } from "@ledgerhq/devices";
+import type { DeviceConnectionResult } from "@ledgerhq/device-intent";
+import type { InitializerDevice } from "../types";
+
+/**
+ * Maps the raw device connection result to the minimal, display-only
+ * {@link InitializerDevice} consumed by the presentational initializer states
+ * (titles, product name, wired badge, etc.).
+ *
+ * It carries no behavior and is not used for device communication: it only
+ * normalizes the `compat*` fields and derives the product name so the views
+ * have stable, ready-to-render data.
+ */
+export function buildInitializerDevice(
+  connectionResult: Pick<
+    DeviceConnectionResult,
+    "compatDeviceId" | "compatDeviceModelId" | "compatDeviceName" | "compatDeviceWired"
+  >,
+): InitializerDevice {
+  const { compatDeviceId, compatDeviceModelId, compatDeviceName, compatDeviceWired } =
+    connectionResult;
+  const productName = getDeviceModel(compatDeviceModelId).productName;
+
+  return {
+    id: compatDeviceId,
+    modelId: compatDeviceModelId,
+    name: compatDeviceName || productName,
+    productName,
+    wired: compatDeviceWired,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceGenericStates/LoadingContent.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceGenericStates/LoadingContent.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Spinner } from "@ledgerhq/lumen-ui-react";
+import { cn } from "LLD/utils/cn";
+
+type LoadingContentProps = Readonly<{
+  title: React.ReactNode;
+  testID?: string;
+  className?: string;
+}>;
+
+export function LoadingContent({ title, testID, className }: LoadingContentProps) {
+  return (
+    <div
+      className={cn("flex w-full flex-col items-center gap-16 px-16 py-24", className)}
+      data-testid={testID}
+    >
+      <Spinner size={32} />
+      <h3 className="heading-4-semi-bold text-center text-base">{title}</h3>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/index.tsx
@@ -53,7 +53,7 @@ export function DeviceIntentExecutorLWD<JobState, Input, ExtraProps>(
     <Dialog open={wrappedProps.enabled} onOpenChange={onOpenChange} height="fit">
       <DialogContent
         aria-describedby={undefined}
-        className="w-[400px] bg-base p-0"
+        className="max-h-[90vh] w-[400px] bg-base p-0"
         data-testid="device-intent-executor-dialog"
       >
         <DialogBackgroundToneProvider>

--- a/apps/ledger-live-desktop/src/renderer/components/TranslatedError/TranslatedError.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TranslatedError/TranslatedError.tsx
@@ -11,10 +11,10 @@ import ExternalLink from "../ExternalLink";
 import { openURL } from "~/renderer/linking";
 import { urls } from "~/config/urls";
 import { useErrorLinks } from "./hooks/useErrorLinks";
-import { isDmkError } from "@ledgerhq/live-dmk-desktop";
+import { isDmkError, type DmkError } from "@ledgerhq/live-dmk-desktop";
 import { ErrorWithAnchorContent } from "./ErrorWithAnchor";
 type Props = {
-  error: Error | undefined | null;
+  error: Error | DmkError | undefined | null;
   field?: "title" | "description" | "list";
   noLink?: boolean;
   fallback?: React.ReactNode;
@@ -44,23 +44,23 @@ export function TranslatedError({
 }: Props): React.JSX.Element {
   const { t } = useTranslation();
 
-  const errorName = error?.name;
+  const regularError = error instanceof Error ? error : undefined;
+  const errorName = regularError?.name;
 
   const translationKey = useMemo(() => `errors.${errorName}.${field}`, [errorName, field]);
 
-  const isValidError = useMemo(() => error instanceof Error, [error]);
   const links = useErrorLinks(error);
 
   const args = useMemo(() => {
-    if (isValidError) {
+    if (regularError) {
       return {
-        ...error,
-        message: error?.message,
+        ...regularError,
+        message: regularError.message,
         returnObjects: true,
       };
     }
     return {};
-  }, [error, isValidError]);
+  }, [regularError]);
 
   const translation = useMemo(() => {
     const translation = t(translationKey, { ...args });
@@ -68,12 +68,12 @@ export function TranslatedError({
   }, [args, t, translationKey]);
 
   useEffect(() => {
-    if (!isValidError) {
+    if (!regularError) {
       logger.critical(`TranslatedError invalid usage: ${String(error)}`);
     }
-  }, [isValidError, error]);
+  }, [regularError, error]);
 
-  if (!error || !isValidError) {
+  if (!error || !regularError) {
     // NOTE: Temporary handling of DMK errors
     if (isDmkError(error)) {
       const translatedKey = `errors.${error._tag}.${field}`;
@@ -117,13 +117,13 @@ export function TranslatedError({
         </span>
       )}
 
-      {urls.errors[error.name] && !noLink && (
+      {regularError && urls.errors[regularError.name] && !noLink && (
         <>
           {" "}
           <Text ff="Inter|SemiBold">
             <ExternalLink
               label={t("common.learnMore")}
-              onClick={() => openURL(urls.errors[error.name])}
+              onClick={() => openURL(urls.errors[regularError.name])}
             />
           </Text>
         </>

--- a/apps/ledger-live-desktop/src/renderer/components/TranslatedError/hooks/useErrorLinks.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TranslatedError/hooks/useErrorLinks.tsx
@@ -4,7 +4,7 @@ import * as S from "../styles";
 import { openURL } from "~/renderer/linking";
 import { getSafeStringLinks, isAbsoluteUrl } from "../utils";
 
-export function useErrorLinks(error?: Error | null): Record<string, ReactElement> {
+export function useErrorLinks(error?: unknown): Record<string, ReactElement> {
   const safeStringLinks = getSafeStringLinks(error);
 
   const navigate = useNavigate();

--- a/apps/ledger-live-desktop/src/renderer/components/TranslatedError/utils/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/TranslatedError/utils/index.ts
@@ -1,4 +1,4 @@
-function getSafeStringLinks(error?: Error | null): string[] {
+function getSafeStringLinks(error?: unknown): string[] {
   return error && typeof error === "object" && "links" in error && Array.isArray(error.links)
     ? error.links.filter((link): link is string => typeof link === "string")
     : [];

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9488,6 +9488,61 @@
         "description": "An error occurred. Please try again or contact Ledger support if the issue persists."
       }
     },
+    "initialization": {
+      "loading": {
+        "title": "Loading"
+      },
+      "installingApp": {
+        "title": "Installing app"
+      },
+      "outdatedAppWarning": {
+        "title": "App version outdated",
+        "description": "An important update is available for the {{appName}} application on your device. Please go to My Ledger to update it."
+      },
+      "retryable": {
+        "userRefused": {
+          "title": "Operation rejected on device"
+        },
+        "deviceBusy": {
+          "title": "Action pending on your Ledger device",
+          "description": "Complete it and then select Retry."
+        }
+      },
+      "blocking": {
+        "deviceNotOnboarded": {
+          "title": "Your Ledger is not ready to use yet",
+          "description": "You need to set up your {{productName}} first. We will guide you through the device setup process."
+        },
+        "unsupportedFirmwareVersion": {
+          "title": "Ledger OS update required"
+        },
+        "unsupportedApplication": {
+          "title": "Unsupported feature",
+          "description": "The app required for this operation is not currently available on your Ledger device. Please contact Ledger support for details."
+        },
+        "unsupportedFeature": {
+          "title": "Unsupported feature",
+          "description": "The app required for this operation is not currently available on your Ledger device. Please contact Ledger support for details."
+        },
+        "wrongDeviceForAccount": {
+          "title": "Wrong Secret Recovery Phrase",
+          "description": "This Ledger isn't set up with the recovery phrase linked to the selected account. Check that you're using the correct device."
+        },
+        "deviceOutOfStorageSpace": {
+          "title": "Not enough device memory",
+          "description": "Your device doesn't have enough memory. Please uninstall apps and try again.",
+          "apps": "Apps to manage: {{appNames}}"
+        }
+      },
+      "cta": {
+        "openMyLedger": "Open My Ledger",
+        "goToMyLedger": "Go to My Ledger",
+        "setupDevice": "Set up device",
+        "updateLedgerOs": "Update Ledger OS",
+        "cancelOperation": "Cancel operation",
+        "contactLedgerSupport": "Contact Ledger support"
+      }
+    },
     "connectDevice": {
       "common": {
         "ledgerDevice": "Ledger device",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/__tests__/useDeviceContextInitializerComponentLWMViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/__tests__/useDeviceContextInitializerComponentLWMViewModel.test.tsx
@@ -183,19 +183,24 @@ describe("useDeviceContextInitializerComponentLWMViewModel", () => {
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 
-  it("should dispatch store updates from use case side effects", () => {
+  it("GIVEN use case side effects WHEN they observe device metadata THEN they update mobile stores", () => {
+    // GIVEN
     const { store } = renderViewModel();
     const { sideEffects } = mockedEnsureAppReadyUseCase.mock.calls[0][0];
     const deviceId = DeviceId.fromString("010203");
     const deviceInfo = { version: "2.0.0" } as DeviceInfo;
+    const apps = [{ name: "Bitcoin", version: "2.2.0" }];
 
+    // WHEN
     sideEffects.onDeviceIdObserved(deviceId);
     sideEffects.onLastSeenDeviceInfoObserved({
       modelId: DeviceModelId.nanoX,
       deviceInfo,
+      apps,
       latestFirmware: null,
     });
 
+    // THEN
     const state = store.getState();
     expect(state.identities.deviceIds).toHaveLength(1);
     expect(state.identities.deviceIds[0].equals(deviceId)).toBe(true);
@@ -203,7 +208,7 @@ describe("useDeviceContextInitializerComponentLWMViewModel", () => {
       {
         modelId: DeviceModelId.nanoX,
         deviceInfo,
-        apps: [],
+        apps,
       },
     ]);
   });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/useDeviceContextInitializerComponentLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/useDeviceContextInitializerComponentLWMViewModel.ts
@@ -51,12 +51,12 @@ export function useDeviceContextInitializerComponentLWMViewModel({
       onDeviceIdObserved: deviceId => {
         dispatch(identitiesSlice.actions.addDeviceId(deviceId));
       },
-      onLastSeenDeviceInfoObserved: ({ modelId, deviceInfo }) => {
+      onLastSeenDeviceInfoObserved: ({ modelId, deviceInfo, apps }) => {
         dispatch(
           setLastSeenDeviceInfo({
             modelId,
             deviceInfo,
-            apps: [],
+            apps,
           }),
         );
       },

--- a/libs/device-intent/README.md
+++ b/libs/device-intent/README.md
@@ -76,11 +76,12 @@ platform-specific components.
 
 ### LWD (Ledger Wallet Desktop)
 
-Not yet integrated — coming soon. The wrapper will mirror the LWM one
-(planned as `DeviceIntentExecutorLWD`) and inject desktop-specific platform
-components for the connection, initialisation, and error screens. The
-shared core (`DeviceIntentExecutor`, state machine, intent definitions, initialization logic via `ensureAppReadyUseCase`) is
-already platform-agnostic, so the wiring is the only missing piece.
+Supported via the `DeviceIntentExecutorLWD` wrapper at
+`apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/`. It mirrors
+the LWM integration and injects desktop-specific platform components for the
+connection, context-initialisation, and error screens. The shared core
+(`DeviceIntentExecutor`, state machine, intent definitions, initialization logic
+via `ensureAppReadyUseCase`) remains platform-agnostic.
 
 ### CLI
 

--- a/libs/ledger-live-common/src/device/use-cases/ensureAppReady/helpers/ConnectAppSideEffectsHandler.test.ts
+++ b/libs/ledger-live-common/src/device/use-cases/ensureAppReady/helpers/ConnectAppSideEffectsHandler.test.ts
@@ -36,6 +36,28 @@ const firmwareMetadata = {
   langId: 1,
 };
 
+const applications = [
+  {
+    versionName: "Bitcoin",
+    version: "2.2.0",
+  },
+  {
+    versionName: "Ethereum",
+    version: "1.12.0",
+  },
+];
+
+const mappedApplications = [
+  {
+    name: "Bitcoin",
+    version: "2.2.0",
+  },
+  {
+    name: "Ethereum",
+    version: "1.12.0",
+  },
+];
+
 type PendingIntermediateValue = Extract<
   ConnectAppDAState,
   { status: DeviceActionStatus.Pending }
@@ -53,6 +75,7 @@ function makeDeviceMetadata(
       metadata,
     },
     firmwareUpdateContext,
+    applications,
   } as unknown as GetDeviceMetadataDAOutput;
 }
 
@@ -174,6 +197,7 @@ describe("ConnectAppSideEffectsHandler", () => {
             version: "2.1.0",
             seVersion: "2.1.0",
           }),
+          apps: mappedApplications,
         }),
       );
     });

--- a/libs/ledger-live-common/src/device/use-cases/ensureAppReady/helpers/ConnectAppSideEffectsHandler.ts
+++ b/libs/ledger-live-common/src/device/use-cases/ensureAppReady/helpers/ConnectAppSideEffectsHandler.ts
@@ -12,7 +12,7 @@ import {
   type ConnectAppDAState,
 } from "@ledgerhq/live-dmk-shared";
 import type { DeviceModelId } from "@ledgerhq/types-devices";
-import { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
+import type { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
 import { parseDeviceInfo } from "../../../../deviceSDK/tasks/getDeviceInfo";
 import type { ConnectAppInitSideEffects } from "../types";
 
@@ -152,6 +152,10 @@ function mapLatestFirmware(
 export type LastSeenDeviceInfoPayload = {
   modelId: DeviceModelId;
   deviceInfo: DeviceInfo;
+  apps: Array<{
+    name: string;
+    version: string;
+  }>;
   latestFirmware: FirmwareUpdateContext | null;
 };
 
@@ -175,6 +179,10 @@ export function buildLastSeenDeviceInfoPayload(params: {
   return {
     modelId: dmkToLedgerDeviceIdMap[deviceModelId],
     deviceInfo,
+    apps: deviceMetadata.applications.map(({ versionName, version }) => ({
+      name: versionName,
+      version,
+    })),
     latestFirmware: mapLatestFirmware(deviceMetadata?.firmwareUpdateContext),
   };
 }

--- a/libs/ledger-live-common/src/device/use-cases/ensureAppReady/types.ts
+++ b/libs/ledger-live-common/src/device/use-cases/ensureAppReady/types.ts
@@ -51,6 +51,10 @@ export type ConnectAppInitSideEffects = {
   onLastSeenDeviceInfoObserved: (params: {
     modelId: DeviceModelId;
     deviceInfo: DeviceInfo;
+    apps: Array<{
+      name: string;
+      version: string;
+    }>;
     latestFirmware: FirmwareUpdateContext | null;
   }) => void;
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Desktop Device Intent Executor initialization phase
  - App opening, installation, deprecation, retryable, blocking, and final error states
  - Manager/onboarding/support navigation from initializer states
  - Desktop DIE dev scenarios that exercise app readiness

### 📝 Description

This PR implements the context initialization phase of the Device Intent Executor for Ledger Wallet Desktop as part of [LIVE-33001](https://ledgerhq.atlassian.net/browse/LIVE-33001). Desktop previously had a placeholder initializer that simulated a ready device context instead of running the same app-readiness flow as mobile.

The new LWD initializer mirrors the mobile `DeviceContextInitializerComponentLWM` structure and behavior around `ensureAppReadyUseCase`, excluding tracking and modal locking which are planned separately.

https://github.com/user-attachments/assets/3a50f629-f419-4db8-8848-f6fb4fbc482f



### ❓ Context

- **JIRA or GitHub link**: [LIVE-33001](https://ledgerhq.atlassian.net/browse/LIVE-33001)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33001]: https://ledgerhq.atlassian.net/browse/LIVE-33001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-33001]: https://ledgerhq.atlassian.net/browse/LIVE-33001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ