### PR TITLE
[LWDM] fix(coin-filecoin): serialize broadcast value with toFixed for amount…

### DIFF
--- a/.changeset/quiet-otters-broadcast.md
+++ b/.changeset/quiet-otters-broadcast.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-filecoin": minor
+---
+
+Fix Filecoin transaction broadcast failing for amounts >= 1000 FIL. The amount was serialized with `BigNumber.toString()`, which emits exponential notation ("1e+21") at 1e21 attoFIL (1000 FIL) and up, causing the broadcast backend to reject it with a 500. Serialize with `toFixed()` so the value is always a plain integer string.

--- a/.changeset/quiet-otters-broadcast.md
+++ b/.changeset/quiet-otters-broadcast.md
@@ -1,5 +1,5 @@
 ---
-"@ledgerhq/coin-filecoin": minor
+"@ledgerhq/coin-filecoin": patch
 ---
 
 Fix Filecoin transaction broadcast failing for amounts >= 1000 FIL. The amount was serialized with `BigNumber.toString()`, which emits exponential notation ("1e+21") at 1e21 attoFIL (1000 FIL) and up, causing the broadcast backend to reject it with a 500. Serialize with `toFixed()` so the value is always a plain integer string.

--- a/libs/coin-modules/coin-filecoin/src/bridge/serializer.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/serializer.ts
@@ -38,7 +38,7 @@ export const toCBOR = async (account: Account, tx: Transaction): Promise<toCBORR
     finalRecipient = recipientValidation.parsedAddress.toString();
   }
 
-  const finalAmount = tokenTransfer ? "0" : amount.toString();
+  const finalAmount = tokenTransfer ? "0" : amount.toFixed();
 
   const message = new Message({
     to: finalRecipient,

--- a/libs/coin-modules/coin-filecoin/src/bridge/serializer.unit.test.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/serializer.unit.test.ts
@@ -59,9 +59,7 @@ function makeTx(fil: number): Transaction {
 describe("toCBOR (legacy bridge serializer)", () => {
   beforeEach(() => mockMessageCtor.mockClear());
 
-  // Regression for LIVE-31661: 1000 FIL == 1e21 attoFIL, the exact magnitude at which
-  // BigNumber.toString() flips to exponential notation ("1e+21"). The broadcast backend
-  // can't parse that and responds 500. The amount must serialize as a plain integer.
+  //Regression test for LIVE-31661: value must be serialized as a plain integer string (no exponential notation).
   it.each([
     [999, "999000000000000000000"],
     [1000, "1000000000000000000000"],

--- a/libs/coin-modules/coin-filecoin/src/bridge/serializer.unit.test.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/serializer.unit.test.ts
@@ -1,0 +1,100 @@
+import { BigNumber } from "bignumber.js";
+import { Account } from "@ledgerhq/types-live";
+import { toCBOR } from "./serializer";
+import { Transaction } from "../types";
+
+jest.mock("@ledgerhq/logs");
+
+// iso-filecoin's Message runs address-checksum validation inside serialize(); stub it
+// and capture the constructor args so we can assert exactly what `value` we serialize.
+const mockMessageCtor = jest.fn();
+jest.mock("iso-filecoin/message", () => ({
+  Message: class {
+    constructor(msg: Record<string, unknown>) {
+      mockMessageCtor(msg);
+    }
+    serialize(): Uint8Array {
+      return new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    }
+  },
+}));
+
+// Stub the iso-filecoin-backed validator so synthetic test addresses pass.
+jest.mock("../network", () => ({
+  validateAddress: (input: string) => ({
+    isValid: input !== "INVALID",
+    parsedAddress: { toString: () => input },
+  }),
+}));
+
+jest.mock("../erc20/tokenAccounts", () => ({
+  encodeTxnParams: (_data: string) => "encoded-params",
+}));
+
+const ATTO_PER_FIL = new BigNumber(10).pow(18);
+
+function makeAccount(): Account {
+  return {
+    id: "js:2:filecoin:f1sender:glif",
+    freshAddress: "f1sender",
+    freshAddressPath: "44'/461'/0'/0/0",
+    subAccounts: [],
+  } as unknown as Account;
+}
+
+function makeTx(fil: number): Transaction {
+  return {
+    family: "filecoin",
+    recipient: "f1recipient",
+    amount: new BigNumber(fil).times(ATTO_PER_FIL),
+    method: 0,
+    version: 0,
+    nonce: 6,
+    gasLimit: new BigNumber(1516578),
+    gasFeeCap: new BigNumber(854792),
+    gasPremium: new BigNumber(199489),
+  } as unknown as Transaction;
+}
+
+describe("toCBOR (legacy bridge serializer)", () => {
+  beforeEach(() => mockMessageCtor.mockClear());
+
+  // Regression for LIVE-31661: 1000 FIL == 1e21 attoFIL, the exact magnitude at which
+  // BigNumber.toString() flips to exponential notation ("1e+21"). The broadcast backend
+  // can't parse that and responds 500. The amount must serialize as a plain integer.
+  it.each([
+    [999, "999000000000000000000"],
+    [1000, "1000000000000000000000"],
+    [1001, "1001000000000000000000"],
+    [12345, "12345000000000000000000"],
+  ])("serializes %i FIL as a plain integer string, never exponential", async (fil, expected) => {
+    const res = await toCBOR(makeAccount(), makeTx(fil));
+
+    // value handed to the CBOR Message (what the device signs)
+    const messageArg = mockMessageCtor.mock.calls[0][0] as { value: string };
+    expect(messageArg.value).toBe(expected);
+    expect(messageArg.value).not.toMatch(/e/i);
+
+    // value carried forward for broadcast
+    expect(res.amountToBroadcast.toFixed()).toBe(expected);
+    expect(res.amountToBroadcast.toFixed()).not.toMatch(/e/i);
+  });
+
+  it("serializes a token transfer amount as 0", async () => {
+    const account = makeAccount();
+    const subAccountId = "js:2:filecoin:f1sender:glif+erc20";
+    (account as unknown as { subAccounts: unknown[] }).subAccounts = [
+      {
+        id: subAccountId,
+        type: "TokenAccount",
+        token: { contractAddress: "f1contract" },
+      },
+    ];
+    const tx = { ...makeTx(1000), subAccountId, params: "0xdata" } as unknown as Transaction;
+
+    const res = await toCBOR(account, tx);
+
+    expect((mockMessageCtor.mock.calls[0][0] as { value: string }).value).toBe("0");
+    expect(res.amountToBroadcast.toFixed()).toBe("0");
+  });
+});

--- a/libs/coin-modules/coin-filecoin/src/bridge/serializer.unit.test.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/serializer.unit.test.ts
@@ -59,7 +59,7 @@ function makeTx(fil: number): Transaction {
 describe("toCBOR (legacy bridge serializer)", () => {
   beforeEach(() => mockMessageCtor.mockClear());
 
-  //Regression test for LIVE-31661: value must be serialized as a plain integer string (no exponential notation).
+  // Regression test for LIVE-31661: value must be serialized as a plain integer string (no exponential notation).
   it.each([
     [999, "999000000000000000000"],
     [1000, "1000000000000000000000"],

--- a/libs/coin-modules/coin-filecoin/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/signOperation.ts
@@ -77,7 +77,7 @@ export const buildSignOperation =
           nonce,
           signatureType: 1,
           tokenTransfer: tokenAccountTxn,
-          value: finalAmount.toString(),
+          value: finalAmount.toFixed(),
         };
 
         o.next({

--- a/libs/coin-modules/coin-filecoin/src/bridge/signOperation.unit.test.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/signOperation.unit.test.ts
@@ -72,9 +72,7 @@ describe("buildSignOperation (legacy bridge)", () => {
     mockSign.mockResolvedValue({ signature_compact: new Uint8Array([1, 2, 3]) });
   });
 
-  // Regression for LIVE-31661: the `signed` event's rawData.value is what broadcast sends
-  // to the backend. For 1000 FIL (1e21 attoFIL) it must be a plain integer string, not the
-  // exponential "1e+21" that BigNumber.toString() produces and the backend rejects (500).
+  //Regression test for LIVE-31661 (broadcast rejects exponential BigNumber strings at ≥ 1e21 attoFIL)
   it.each([
     [999, "999000000000000000000"],
     [1000, "1000000000000000000000"],

--- a/libs/coin-modules/coin-filecoin/src/bridge/signOperation.unit.test.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/signOperation.unit.test.ts
@@ -1,0 +1,116 @@
+import { BigNumber } from "bignumber.js";
+import { Account } from "@ledgerhq/types-live";
+import { Observable } from "rxjs";
+import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
+import { buildSignOperation } from "./signOperation";
+import { Transaction, FilecoinSigner } from "../types";
+
+jest.mock("@ledgerhq/logs");
+
+jest.mock("iso-filecoin/message", () => ({
+  Message: class {
+    serialize(): Uint8Array {
+      return new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    }
+  },
+}));
+
+jest.mock("../network", () => ({
+  validateAddress: (input: string) => ({
+    isValid: input !== "INVALID",
+    parsedAddress: { toString: () => input },
+  }),
+}));
+
+jest.mock("../erc20/tokenAccounts", () => ({
+  encodeTxnParams: (_data: string) => "encoded-params",
+}));
+
+const ATTO_PER_FIL = new BigNumber(10).pow(18);
+
+function makeAccount(): Account {
+  return {
+    id: "js:2:filecoin:f1sender:glif",
+    freshAddress: "f1sender",
+    freshAddressPath: "44'/461'/0'/0/0",
+    subAccounts: [],
+  } as unknown as Account;
+}
+
+function makeTx(fil: number): Transaction {
+  return {
+    family: "filecoin",
+    recipient: "f1recipient",
+    amount: new BigNumber(fil).times(ATTO_PER_FIL),
+    method: 0,
+    version: 0,
+    nonce: 6,
+    gasLimit: new BigNumber(1516578),
+    gasFeeCap: new BigNumber(854792),
+    gasPremium: new BigNumber(199489),
+  } as unknown as Transaction;
+}
+
+function collect<T>(obs: Observable<T>): Promise<T[]> {
+  return new Promise((resolve, reject) => {
+    const events: T[] = [];
+    obs.subscribe({
+      next: e => events.push(e),
+      error: reject,
+      complete: () => resolve(events),
+    });
+  });
+}
+
+const mockSign = jest.fn();
+const signerContext = ((_deviceId: string, fn: (signer: FilecoinSigner) => unknown) =>
+  fn({ sign: mockSign } as unknown as FilecoinSigner)) as unknown as SignerContext<FilecoinSigner>;
+
+describe("buildSignOperation (legacy bridge)", () => {
+  beforeEach(() => {
+    mockSign.mockReset();
+    mockSign.mockResolvedValue({ signature_compact: new Uint8Array([1, 2, 3]) });
+  });
+
+  // Regression for LIVE-31661: the `signed` event's rawData.value is what broadcast sends
+  // to the backend. For 1000 FIL (1e21 attoFIL) it must be a plain integer string, not the
+  // exponential "1e+21" that BigNumber.toString() produces and the backend rejects (500).
+  it.each([
+    [999, "999000000000000000000"],
+    [1000, "1000000000000000000000"],
+    [1001, "1001000000000000000000"],
+  ])(
+    "emits broadcast value for %i FIL as a plain integer, not exponential",
+    async (fil, expected) => {
+      const events = await collect(
+        buildSignOperation(signerContext)({
+          account: makeAccount(),
+          deviceId: "device-1",
+          transaction: makeTx(fil),
+        }),
+      );
+
+      const signed = events.find(e => e.type === "signed") as
+        | { signedOperation: { rawData: { value: string } } }
+        | undefined;
+      expect(signed?.signedOperation.rawData.value).toBe(expected);
+      expect(signed?.signedOperation.rawData.value).not.toMatch(/e/i);
+    },
+  );
+
+  it("streams the device-signature event sequence in order", async () => {
+    const events = await collect(
+      buildSignOperation(signerContext)({
+        account: makeAccount(),
+        deviceId: "device-1",
+        transaction: makeTx(1000),
+      }),
+    );
+
+    expect(events.map(e => e.type)).toEqual([
+      "device-signature-requested",
+      "device-signature-granted",
+      "signed",
+    ]);
+  });
+});

--- a/libs/coin-modules/coin-filecoin/src/bridge/signOperation.unit.test.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/signOperation.unit.test.ts
@@ -72,7 +72,7 @@ describe("buildSignOperation (legacy bridge)", () => {
     mockSign.mockResolvedValue({ signature_compact: new Uint8Array([1, 2, 3]) });
   });
 
-  //Regression test for LIVE-31661 (broadcast rejects exponential BigNumber strings at ≥ 1e21 attoFIL)
+  // Regression test for LIVE-31661 (broadcast rejects exponential BigNumber strings at ≥ 1e21 attoFIL)
   it.each([
     [999, "999000000000000000000"],
     [1000, "1000000000000000000000"],


### PR DESCRIPTION
  <!--
  Thank you for your contribution! 👍
  Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
  -->

  ### ✅ Checklist

  <!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

  - [x] `npx changeset` was attached.
  - [x] **Covered by automatic tests.**
  - [x] **Impact of the changes:**
    - Filecoin (FIL) send flow only — native FIL transfers of **≥ 1000 FIL**.
    - QA should verify sending exactly **1000 FIL**, a large amount (e.g. **1234 FIL**), and a small amount (e.g. **1 FIL**) all broadcast successfully. Values below 1000 FIL were unaffected and should keep working.

  ### 📝 Description

  **Problem:** Filecoin transactions failed to broadcast for amounts ≥ 1000 FIL, returning `500 "Something went wrong"` from `POST /v2/transaction/broadcast`. Smaller amounts (e.g. 999 FIL) worked.

  **Root cause:** The amount was serialized with `BigNumber.toString()`. `1000 FIL = 1e21 attoFIL`, and BigNumber's `toString()` switches to **exponential notation** (`"1e+21"`) at ≥ 1e21. The broadcast backend can't parse `"1e+21"` as an integer and rejects it with a 500.

  **Fix:** Serialize the amount with `.toFixed()` instead of `.toString()` in the legacy bridge path (`serializer.ts` and `signOperation.ts`). `toFixed()` always emits a plain integer string (`"1000000000000000000000"`) at any magnitude, with no exponential notation.

  | Before (`.toString()`) | After (`.toFixed()`) |
  | ---------------------- | -------------------- |
  | `1000 FIL → "1e+21"` → 500 | `1000 FIL → "1000000000000000000000"` → ✅ |

  **Tests:** Added regression coverage for the previously-untested legacy bridge sign/serialize path:
  - `serializer.unit.test.ts` — asserts `toCBOR` serializes 999 / 1000 / 1001 / 12345 FIL (and token transfers) as plain integers, never exponential.
  - `signOperation.unit.test.ts` — asserts the emitted `signed` event's `rawData.value` (what broadcast sends) is a plain integer, plus the device-signature event order.

  Both were verified to fail against the old `.toString()` code before the fix.

  > **Note:** The Jira workaround ("send 1001 FIL instead") is inaccurate — 1001 FIL also produced exponential notation (`"1.001e+21"`) and failed. Only amounts **< 1000 FIL** avoided the bug. This is now fixed for all amounts.
  >
  > **Possible follow-up (out of scope):** other coin modules that serialize broadcast amounts via `BigNumber.toString()` may share this latent bug (18-decimal coins hit it at 1000 units) — worth a separate ticket.

  ### ❓ Context

  - **JIRA or GitHub link**: [LIVE-31661](https://ledgerhq.atlassian.net/browse/LIVE-31661)
  - **ADR link (if any)**: N/A


  ---

  ### 🧐 Checklist for the PR Reviewers

  <!-- Please do not edit this if you are the PR author -->

  - **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
  - **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
  - **There are no undocumented trade-offs**, technical debt, or maintainability issues.
  - **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
  - **Any new dependencies** have been justified and documented.
  - **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31661]: https://ledgerhq.atlassian.net/browse/LIVE-31661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ