### PR TITLE
[LWDM] test(coin-stellar): replace nock with Stellar SDK mocks

### DIFF
--- a/.changeset/wise-otters-mock.md
+++ b/.changeset/wise-otters-mock.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-stellar": patch
+---
+
+Replace nock with Stellar SDK mocks in coin-stellar unit tests and drop the nock dependency

--- a/libs/coin-modules/coin-stellar/package.json
+++ b/libs/coin-modules/coin-stellar/package.json
@@ -116,7 +116,6 @@
     "@types/node": "catalog:",
     "jest": "catalog:",
     "msw": "catalog:",
-    "nock": "14.0.2",
     "oxfmt": "catalog:",
     "oxlint": "catalog:"
   }

--- a/libs/coin-modules/coin-stellar/src/api/index_error.test.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index_error.test.ts
@@ -1,20 +1,30 @@
 import type { CoinModuleApi } from "@ledgerhq/coin-module-framework/api/index";
-import nock from "nock";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
+import { Horizon } from "@stellar/stellar-sdk";
 import { StellarMemo } from "../types";
 import { createApi } from ".";
+
+/**
+ * Minimal chainable stub of a Horizon call builder: every builder method returns
+ * the builder itself, and `call()` rejects with the configured error.
+ */
+function rejectingBuilder(error: unknown): unknown {
+  const builder: unknown = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === "call") return () => Promise.reject(error);
+        return () => builder;
+      },
+    },
+  );
+  return builder;
+}
 
 describe("Stellar Api", () => {
   let module: CoinModuleApi<StellarMemo>;
   const ADDRESS = "GBAUZBDXMVV7HII4JWBGFMLVKVJ6OLQAKOCGXM5E2FM4TAZB6C7JO2L7";
 
   beforeAll(() => {
-    nock("https://horizon-testnet.stellar.org")
-      .get(/.*/)
-      .reply(() => {
-        return [429, { error: "whatever, only status code is important" }];
-      });
-
     module = createApi({
       explorer: {
         url: "https://horizon-testnet.stellar.org/",
@@ -22,11 +32,21 @@ describe("Stellar Api", () => {
     });
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe("listOperations propagates 429 errors to caller", () => {
     it("throws LedgerAPI4xx on rate limit", async () => {
-      await expect(module.listOperations(ADDRESS, { minHeight: 0, order: "asc" })).rejects.toThrow(
-        LedgerAPI4xx,
-      );
+      // Horizon surfaces a 429 as a NetworkError whose message is the "Too Many Requests"
+      // status text, which fetchOperations maps to the rate-limit-specific LedgerAPI4xx.
+      jest
+        .spyOn(Horizon.Server.prototype, "operations")
+        .mockReturnValue(rejectingBuilder(new Error("Too Many Requests")) as never);
+
+      await expect(
+        module.listOperations(ADDRESS, { minHeight: 0, order: "asc" }),
+      ).rejects.toMatchObject({ name: "LedgerAPI4xx", status: 429 });
     });
   });
 });

--- a/libs/coin-modules/coin-stellar/src/network/fetchLedgerOperations.unit.test.ts
+++ b/libs/coin-modules/coin-stellar/src/network/fetchLedgerOperations.unit.test.ts
@@ -1,13 +1,13 @@
-import nock from "nock";
-import coinConfig, { type StellarCoinConfig } from "../config";
+import { Horizon, NotFoundError } from "@stellar/stellar-sdk";
 import type { CoinConfig } from "@ledgerhq/coin-module-framework/config";
+import coinConfig, { type StellarCoinConfig } from "../config";
 import { fetchAllLedgerOperations, fetchLedgerRecord } from "./horizon";
 
 const HORIZON = "https://horizon-testnet.stellar.org";
 
 let originalGetCoinConfig: CoinConfig<StellarCoinConfig>;
 
-/** Minimal Horizon payment op shape for nock fixtures (embedded.records). */
+/** Minimal Horizon payment op shape (embedded.records). */
 const MINIMAL_HORIZON_PAYMENT_OP = {
   _links: {
     self: { href: "" },
@@ -30,7 +30,25 @@ const MINIMAL_HORIZON_PAYMENT_OP = {
   amount: "1.0000000",
 };
 
-function setExplorer(fetchLimit = 100) {
+/**
+ * Minimal chainable stub of a Horizon call builder: every builder method returns
+ * the builder itself, and `call()` resolves (or rejects) with the configured value.
+ * Lets us drive `getServer().ledgers()...call()` / `.operations()...call()` without HTTP.
+ */
+function callBuilder(call: () => Promise<unknown>): unknown {
+  const builder: unknown = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === "call") return call;
+        return () => builder;
+      },
+    },
+  );
+  return builder;
+}
+
+function setExplorer(fetchLimit = 100): void {
   coinConfig.setCoinConfig(
     (): StellarCoinConfig =>
       ({
@@ -40,7 +58,15 @@ function setExplorer(fetchLimit = 100) {
   );
 }
 
-describe("fetchLedgerRecord / fetchAllLedgerOperations (nock)", () => {
+function mockLedgers(call: () => Promise<unknown>): void {
+  jest.spyOn(Horizon.Server.prototype, "ledgers").mockReturnValue(callBuilder(call) as never);
+}
+
+function mockOperations(call: () => Promise<unknown>): void {
+  jest.spyOn(Horizon.Server.prototype, "operations").mockReturnValue(callBuilder(call) as never);
+}
+
+describe("fetchLedgerRecord / fetchAllLedgerOperations", () => {
   beforeAll(() => {
     originalGetCoinConfig = coinConfig.getCoinConfig;
   });
@@ -52,29 +78,21 @@ describe("fetchLedgerRecord / fetchAllLedgerOperations (nock)", () => {
   });
 
   beforeEach(() => {
-    nock.cleanAll();
-    nock.disableNetConnect();
     setExplorer(100);
   });
 
   afterEach(() => {
-    nock.cleanAll();
-    nock.enableNetConnect();
+    jest.restoreAllMocks();
   });
 
   it("fetchLedgerRecord maps 404 to not found error", async () => {
-    nock(HORIZON).get("/ledgers/424242").reply(404, {
-      status: 404,
-      type: "https://stellar.org/horizon-errors/not_found",
-    });
+    mockLedgers(() => Promise.reject(new NotFoundError("Not Found", {} as never)));
 
     await expect(fetchLedgerRecord(424242)).rejects.toThrow("Stellar ledger 424242 not found");
   });
 
   it("fetchAllLedgerOperations maps 404 to not found error", async () => {
-    nock(HORIZON)
-      .get(uri => uri.startsWith("/ledgers/424243/operations"))
-      .reply(404, { status: 404, type: "https://stellar.org/horizon-errors/not_found" });
+    mockOperations(() => Promise.reject(new NotFoundError("Not Found", {} as never)));
 
     await expect(fetchAllLedgerOperations(424243)).rejects.toThrow(
       "Stellar ledger 424243 not found",
@@ -102,7 +120,7 @@ describe("fetchLedgerRecord / fetchAllLedgerOperations (nock)", () => {
       protocol_version: 1,
       header_xdr: "",
     };
-    nock(HORIZON).get("/ledgers/3").reply(200, ledgerBody);
+    mockLedgers(() => Promise.resolve(ledgerBody));
 
     const rec = await fetchLedgerRecord(3);
     expect(rec.sequence).toBe(3);
@@ -111,17 +129,10 @@ describe("fetchLedgerRecord / fetchAllLedgerOperations (nock)", () => {
 
   it("fetchAllLedgerOperations returns embedded records on 200", async () => {
     const page = {
-      _links: {
-        self: { href: `${HORIZON}/ledgers/10/operations` },
-        next: { href: "" },
-        prev: { href: "" },
-      },
-      _embedded: { records: [MINIMAL_HORIZON_PAYMENT_OP] },
+      records: [MINIMAL_HORIZON_PAYMENT_OP],
+      next: () => Promise.resolve({ records: [] }),
     };
-
-    nock(HORIZON)
-      .get(uri => uri.includes("/ledgers/10/operations"))
-      .reply(200, page);
+    mockOperations(() => Promise.resolve(page));
 
     const records = await fetchAllLedgerOperations(10);
     expect(records).toHaveLength(1);
@@ -131,24 +142,9 @@ describe("fetchLedgerRecord / fetchAllLedgerOperations (nock)", () => {
   it("fetchAllLedgerOperations paginates when page is full then stops on empty page", async () => {
     setExplorer(1);
 
-    const nextHref = `${HORIZON}/ledgers/11/operations?cursor=after&limit=1&order=asc&include_failed=true&join=transactions`;
-
-    const page1 = {
-      _links: {
-        self: { href: `${HORIZON}/ledgers/11/operations` },
-        next: { href: nextHref },
-        prev: { href: "" },
-      },
-      _embedded: { records: [MINIMAL_HORIZON_PAYMENT_OP] },
-    };
-
-    const page2 = {
-      _links: { self: { href: "" }, next: { href: "" }, prev: { href: "" } },
-      _embedded: { records: [] },
-    };
-
-    nock(HORIZON).get("/ledgers/11/operations").query(true).reply(200, page1);
-    nock(HORIZON).get("/ledgers/11/operations").query(true).reply(200, page2);
+    const page2 = { records: [], next: () => Promise.resolve({ records: [] }) };
+    const page1 = { records: [MINIMAL_HORIZON_PAYMENT_OP], next: () => Promise.resolve(page2) };
+    mockOperations(() => Promise.resolve(page1));
 
     const records = await fetchAllLedgerOperations(11);
     expect(records.length).toBe(1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6213,9 +6213,6 @@ importers:
       msw:
         specifier: 'catalog:'
         version: 2.7.3(@types/node@24.12.0)(typescript@6.0.2)
-      nock:
-        specifier: 14.0.2
-        version: 14.0.2
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -17557,10 +17554,6 @@ packages:
     resolution: {integrity: sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==}
     engines: {node: '>=18'}
 
-  '@mswjs/interceptors@0.38.0':
-    resolution: {integrity: sha512-nPHVM+LUl4V1kXPXuTcNN5OMD//ltCQ0lccuEagvidJdpbig3hP3W6/ctWHx6mee7vZIWE0L+Mqj3vx0ASlm/w==}
-    engines: {node: '>=18'}
-
   '@mswjs/interceptors@0.38.3':
     resolution: {integrity: sha512-3AMc2fTnX4q3qyO6K/LKwWXjUAFc3COC3bo5YCROIyQYJ8g/++5Col5fSIglIyUdBN787CTbL+c04KRwaaZ/UA==}
     engines: {node: '>=18'}
@@ -23691,7 +23684,7 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -28172,7 +28165,7 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
-    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -31667,10 +31660,6 @@ packages:
   nock@13.5.6:
     resolution: {integrity: sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==}
     engines: {node: '>= 10.13'}
-
-  nock@14.0.2:
-    resolution: {integrity: sha512-jDUBpCNY7KLyOF2FTiT4mLRxV2kpjo4YrcGtv3IMCIwqFKxOQFrmeXefvuEiWvS3ApPWQHAkakkkVpoOrDNCVg==}
-    engines: {node: '>=18.20.0 <20 || >=20.12.1'}
 
   nock@14.0.3:
     resolution: {integrity: sha512-sJ9RNmCuYBqXDmGZZHgZ1D1441MqFOU4T5aeLGVGEB4OWI/2LM0mZlkfBQzQKdOfJypL+2nPPBugXKjixBn4kQ==}
@@ -46078,21 +46067,6 @@ snapshots:
       is-node-process: 1.2.0
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
-
-  '@mswjs/interceptors@0.38.0':
-    dependencies:
-      '@open-draft/deferred-promise': 2.2.0
-      '@open-draft/logger': 0.3.0
-      '@open-draft/until': 2.1.0
-      is-node-process: 1.2.0
-      jsdom: 26.1.0
-      outvariant: 1.4.3
-      strict-event-emitter: 0.5.1
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - utf-8-validate
 
   '@mswjs/interceptors@0.38.3':
     dependencies:
@@ -65974,17 +65948,6 @@ snapshots:
       propagate: 2.0.1
     transitivePeerDependencies:
       - supports-color
-
-  nock@14.0.2:
-    dependencies:
-      '@mswjs/interceptors': 0.38.0
-      json-stringify-safe: 5.0.1
-      propagate: 2.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - utf-8-validate
 
   nock@14.0.3:
     dependencies:


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - coin-stellar unit tests only — no production code change.

### 📝 Description

Removes the `nock` dependency from `coin-stellar` and rewrites its two HTTP-mocking unit tests to stub the Stellar SDK directly.

**Problem**: The `coin-stellar` unit tests intercept Horizon traffic with `nock`. Under `nock@14`, HTTP interception is delegated to `@mswjs/interceptors`, whose resolution is version-sensitive: a fresh install (e.g. in the `coin-modules` repo) picks up `0.38.7`, which regresses the interception and breaks these tests (`Invalid URL`). This makes the module fragile to migrate.

**Solution**: Drop `nock` entirely and mock at the SDK boundary instead, mirroring the `coin-xrp` approach (`jest.mock` / `jest.spyOn`):
- `jest.spyOn(Horizon.Server.prototype, "ledgers" | "operations")` returns a minimal chainable call-builder stub whose `call()` resolves/rejects with the fixture.
- Error mapping is still exercised through the real code path (`throwHorizonLedgerOrOperationsError`), using real `NotFoundError` and status-code messages.

No production code is touched; behaviour is unchanged. Integration tests (real Horizon) remain and still pass.

### ❓ Context

- **JIRA or GitHub link**: N/A (test-only cleanup, ahead of the coin-stellar migration to `coin-modules`)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.
