### PR TITLE
[LWDM] fix(celo): correct new-send-flow fee display for sub-18-decimal currencies

### DIFF
--- a/.changeset/stale-onions-buy.md
+++ b/.changeset/stale-onions-buy.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+Fix Celo network-fee display for sub-18-decimal fee currencies (USDC/USDT): the CIP-64 fee-currency adapter reports gas price in 18 decimals, so the fee is now rescaled to the selected fee token's decimals before display in the new send flow.

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useFeeInfo.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useFeeInfo.ts
@@ -12,6 +12,7 @@ import {
   getAccountCurrency,
   getMainAccount,
 } from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import { scaleFeesToDisplayUnit } from "@ledgerhq/live-common/flows/send/utils/networkFeesDisplay";
 
 type UseFeeInfoParams = Readonly<{
   account: AccountLike;
@@ -54,10 +55,14 @@ export function useFeeInfo({
     () => status.estimatedFees ?? new BigNumber(0),
     [status.estimatedFees],
   );
+  const displayFees = useMemo(
+    () => scaleFeesToDisplayUnit(estimatedFees, accountUnit, displayUnit),
+    [estimatedFees, accountUnit, displayUnit],
+  );
   const estimatedFeesCountervalue = useCalculate({
     from: displayCurrency,
     to: counterValueCurrency,
-    value: estimatedFees.toNumber(),
+    value: displayFees.toNumber(),
     disableRounding: true,
   });
   const estimatedFeesFiat = useMemo(
@@ -67,7 +72,7 @@ export function useFeeInfo({
 
   const feeSummary = useMemo(
     () =>
-      estimatedFees.gt(0) || estimatedFeesFiat.gt(0)
+      displayFees.gt(0) || estimatedFeesFiat.gt(0)
         ? {
             fiatLabel: t("newSendFlow.networkFeesInFiat", {
               currency: counterValueCurrency.ticker,
@@ -80,7 +85,7 @@ export function useFeeInfo({
             cryptoLabel: t("newSendFlow.feesAmount", {
               unit: displayUnit.code,
             }),
-            cryptoValue: formatCurrencyUnit(displayUnit, estimatedFees, {
+            cryptoValue: formatCurrencyUnit(displayUnit, displayFees, {
               showCode: true,
               disableRounding: true,
               locale,
@@ -88,15 +93,7 @@ export function useFeeInfo({
             description: t("newSendFlow.feesPaid"),
           }
         : null,
-    [
-      displayUnit,
-      counterValueCurrency.ticker,
-      estimatedFees,
-      estimatedFeesFiat,
-      fiatUnit,
-      locale,
-      t,
-    ],
+    [displayUnit, counterValueCurrency.ticker, displayFees, estimatedFeesFiat, fiatUnit, locale, t],
   );
 
   return { feeSummary };

--- a/libs/ledger-live-common/src/flows/send/hooks/__tests__/useNetworkFeesCore.test.ts
+++ b/libs/ledger-live-common/src/flows/send/hooks/__tests__/useNetworkFeesCore.test.ts
@@ -26,6 +26,7 @@ jest.mock("../useFeePresetFiatValuesCore", () => ({
 jest.mock("@ledgerhq/ledger-wallet-framework/account/helpers", () => ({
   getMainAccount: jest.fn((acc: AccountLike) => acc),
   getAccountCurrency: jest.fn((acc: Account) => acc.currency),
+  isTokenAccount: jest.fn((acc: unknown) => (acc as { type?: string })?.type === "TokenAccount"),
 }));
 
 const mockedSendFeatures = jest.mocked(sendFeatures);
@@ -188,5 +189,69 @@ describe("useNetworkFeesCore", () => {
         enabled: false,
       }),
     );
+  });
+
+  describe("fee-currency decimals rescaling (e.g. Celo CIP-64 with a sub-decimal fee token)", () => {
+    const usdcUnit: Unit = { name: "USD Coin", code: "USDC", magnitude: 6 };
+    const usdcToken = {
+      type: "TokenCurrency",
+      id: "celo/erc20/usdc",
+      ticker: "USDC",
+      units: [usdcUnit],
+    } as unknown as import("@ledgerhq/types-cryptoassets").TokenCurrency;
+    const usdcSubAccount = {
+      type: "TokenAccount",
+      id: "usdc-sub-account-id",
+      token: usdcToken,
+      balance: new BigNumber(0),
+    } as unknown as import("@ledgerhq/types-live").TokenAccount;
+
+    const celoAccount = {
+      ...mockAccount,
+      subAccounts: [usdcSubAccount],
+    } as unknown as Account;
+
+    const renderCoreWithFeeCurrency = (overrides?: { status?: Partial<TransactionStatus> }) =>
+      renderHook(() =>
+        useNetworkFeesCore({
+          account: celoAccount,
+          parentAccount: null,
+          transaction: buildTransaction(),
+          status: { ...mockStatus, ...overrides?.status },
+          uiConfig: mockUiConfig,
+          transactionActions: { updateTransaction: mockUpdateTransaction } as never,
+          fiatUnit: usdUnit,
+          accountUnit: btcUnit,
+          calculateCountervalue: mockCalculateCountervalue,
+        }),
+      );
+
+    it("rescales an 18-decimal-style estimated fee into the 6-decimal fee-currency unit before display", () => {
+      mockedSendFeatures.getFeeCurrencyAccountId.mockReturnValue("usdc-sub-account-id");
+      // accountUnit magnitude is 8 (btcUnit) in this suite's fixtures; use a fee value that
+      // would be off by the magnitude delta (1e2) if left unscaled, to prove scaling occurred.
+      const rawFees = new BigNumber("100000000000"); // 8 -> 6 decimals: shift down by 1e2
+
+      const { result } = renderCoreWithFeeCurrency({ status: { estimatedFees: rawFees } });
+
+      // The value handed to calculateCountervalue/formatCurrencyUnit must already be scaled
+      // from accountUnit (magnitude 8) to the fee-currency unit (magnitude 6) — not the raw,
+      // unscaled estimatedFees (which would be 1e2 too large).
+      const expectedScaled = rawFees.shiftedBy(usdcUnit.magnitude - btcUnit.magnitude);
+      expect(mockCalculateCountervalue).toHaveBeenCalledWith(
+        usdcToken,
+        expect.objectContaining({ toString: expect.any(Function) }),
+      );
+      const [, calledValue] = mockCalculateCountervalue.mock.calls[0];
+      expect(calledValue.toString()).toBe(expectedScaled.toString());
+
+      // calculateCountervalue is mocked as value/100, and formatDisplayFeesValue prefers the
+      // fiat-formatted value once a countervalue is available.
+      const expectedFiat = expectedScaled.dividedBy(100);
+      expect(result.current.displayFeesValue).toBe(`FORMATTED_${expectedFiat.toString()}`);
+      expect(result.current.formattedEstimatedFeesFiat).toBe(
+        `FORMATTED_${expectedFiat.toString()}`,
+      );
+    });
   });
 });

--- a/libs/ledger-live-common/src/flows/send/hooks/useNetworkFeesCore.ts
+++ b/libs/ledger-live-common/src/flows/send/hooks/useNetworkFeesCore.ts
@@ -18,6 +18,7 @@ import {
   getFeePresetEstimationConfig,
   getSelectedPresetFiatValue,
   resolveFeeDisplayContext,
+  scaleFeesToDisplayUnit,
 } from "../utils/networkFeesDisplay";
 import { useFeePresetFiatValuesCore, type FeeFiatMap } from "./useFeePresetFiatValuesCore";
 
@@ -110,20 +111,24 @@ export function useNetworkFeesCore({
     () => status.estimatedFees ?? new BigNumber(0),
     [status.estimatedFees],
   );
+  const displayFees = useMemo(
+    () => scaleFeesToDisplayUnit(estimatedFees, accountUnit, displayUnit),
+    [estimatedFees, accountUnit, displayUnit],
+  );
   const estimatedFeesCountervalue = useMemo(
-    () => calculateCountervalue(displayCurrency, estimatedFees),
-    [calculateCountervalue, displayCurrency, estimatedFees],
+    () => calculateCountervalue(displayCurrency, displayFees),
+    [calculateCountervalue, displayCurrency, displayFees],
   );
   const { displayFeesValue, formattedEstimatedFeesFiat } = useMemo(
     () =>
       formatDisplayFeesValue({
-        estimatedFees,
+        estimatedFees: displayFees,
         estimatedFeesCountervalue,
         fiatUnit,
         displayUnit,
         locale,
       }),
-    [displayUnit, estimatedFees, estimatedFeesCountervalue, fiatUnit, locale],
+    [displayUnit, displayFees, estimatedFeesCountervalue, fiatUnit, locale],
   );
 
   const updateTransactionWithPatch = useCallback(

--- a/libs/ledger-live-common/src/flows/send/utils/__tests__/networkFeesDisplay.test.ts
+++ b/libs/ledger-live-common/src/flows/send/utils/__tests__/networkFeesDisplay.test.ts
@@ -6,6 +6,7 @@ import {
   formatDisplayFeesValue,
   getSelectedPresetFiatValue,
   resolveFeeDisplayContext,
+  scaleFeesToDisplayUnit,
 } from "../networkFeesDisplay";
 import type { Account } from "@ledgerhq/types-live";
 
@@ -78,5 +79,31 @@ describe("networkFeesDisplay", () => {
   it("getSelectedPresetFiatValue ignores custom strategy", () => {
     expect(getSelectedPresetFiatValue("custom", { slow: "$1" })).toBeNull();
     expect(getSelectedPresetFiatValue("slow", { slow: "$1" })).toBe("$1");
+  });
+
+  describe("scaleFeesToDisplayUnit", () => {
+    const celoUnit = { name: "Celo", code: "CELO", magnitude: 18 };
+    const usdcUnit6 = { name: "USD Coin", code: "USDC", magnitude: 6 };
+
+    it("returns the fee unchanged when units share the same magnitude", () => {
+      const fees = new BigNumber("2100000000000000");
+      const result = scaleFeesToDisplayUnit(fees, celoUnit, celoUnit);
+
+      expect(result.toString()).toBe(fees.toString());
+    });
+
+    it("rescales an 18-decimal fee down to a 6-decimal fee currency", () => {
+      const fees = new BigNumber("2100000000000000");
+      const result = scaleFeesToDisplayUnit(fees, celoUnit, usdcUnit6);
+
+      expect(result.toString()).toBe("2100");
+    });
+
+    it("is a no-op when the account unit and display unit magnitudes match", () => {
+      const fees = new BigNumber("12345");
+      const result = scaleFeesToDisplayUnit(fees, btcUnit, btcUnit);
+
+      expect(result.toString()).toBe(fees.toString());
+    });
   });
 });

--- a/libs/ledger-live-common/src/flows/send/utils/networkFeesDisplay.ts
+++ b/libs/ledger-live-common/src/flows/send/utils/networkFeesDisplay.ts
@@ -20,8 +20,7 @@ export function resolveFeeDisplayContext(params: {
 }): FeeDisplayContext {
   const feeCurrencySubAccount = params.feeCurrencyAccountId
     ? ((params.mainAccount.subAccounts ?? []).find(
-        (sub): sub is TokenAccount =>
-          sub.id === params.feeCurrencyAccountId && isTokenAccount(sub),
+        (sub): sub is TokenAccount => sub.id === params.feeCurrencyAccountId && isTokenAccount(sub),
       ) ?? null)
     : null;
 
@@ -67,6 +66,26 @@ export function formatDisplayFeesValue(params: {
     formatOptions,
   );
   return { displayFeesValue, formattedEstimatedFeesFiat: null };
+}
+
+/**
+ * Rescale an estimated fee expressed in the account currency's atomic scale into the
+ * fee-currency's atomic scale, preserving the human value. No-op when the units share a
+ * magnitude (i.e. the fee currency is the account currency), so non-Celo coins are unaffected.
+ * This corrects display when a coin module denominates the fee in the native-coin scale
+ * (e.g. Celo's 18-decimal CIP-64 adapter amount) but the fee is shown against a sub-decimal
+ * fee token (e.g. 6-decimal USDC). ROUND_FLOOR can floor a sub-1-atomic-unit fee to 0
+ * (rendered as "-"), which does not occur for realistic fees.
+ */
+export function scaleFeesToDisplayUnit(
+  fees: BigNumber,
+  accountUnit: Unit,
+  displayUnit: Unit,
+): BigNumber {
+  if (displayUnit.magnitude === accountUnit.magnitude) return fees;
+  return fees
+    .shiftedBy(displayUnit.magnitude - accountUnit.magnitude)
+    .integerValue(BigNumber.ROUND_FLOOR);
 }
 
 export function getSelectedPresetFiatValue(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
  - Unit tests for `scaleFeesToDisplayUnit` (no-op on equal magnitude; 18→6 ÷1e12), a numeric scaled-fee assertion in `useNetworkFeesCore` (with a negative guard against the un-scaled value), and desktop `useFeeInfo`. Non-regression comes from the helper being a strict no-op whenever the fee currency equals the account currency.
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Only the **network-fee display** in the new send flow changes. QA should focus on: **Celo** send → Custom fees → "Pay fees in" → **USDC/USDT** shows a small, realistic fee (not ~1e12 too large) with correct fiat; **CELO** and **18-decimal** fee tokens (cUSD, `*m`) unchanged; **non-Celo coins** (ETH/BTC/…) fee display unchanged (no-op). Desktop + mobile.

### 📝 Description

**Problem.** In the new send flow, selecting a **sub-18-decimal** Celo fee currency (USDC/USDT, 6 decimals) as the gas token displayed the network fee **~10¹² too large** (a ~0.002 USDC fee rendered as billions), including the fiat countervalue.

**Root cause.** Celo CIP-64 fee-currency adapters report gas price in **18 decimals**, so `transaction.fees` is 18-decimal by design — coin-celo's `getTransactionStatus`/`buildTransaction` already convert it (`convertNumberDecimals`, param typed `EighteenDecimalBigNumber`). The shared fee **display** was the only consumer that didn't convert: it formatted the 18-decimal value with the fee token's native unit (`token.units[0]`).

**Fix.** Added `scaleFeesToDisplayUnit(fees, accountUnit, displayUnit)` in `flows/send/utils/networkFeesDisplay.ts` and applied it in `useNetworkFeesCore` (both the crypto value **and** the fiat countervalue) and the desktop `useFeeInfo` hook. It is a **strict no-op when `displayUnit.magnitude === accountUnit.magnitude`**, so native CELO and every non-Celo coin are unaffected. `coin-celo` is untouched (no double-correction). Verified against mainnet `eth_gasPrice(adapter)`, which returns an 18-decimal value.

**Before / After** — USDC fee display:

| Before        | After         |
| ------------- | ------------- |
| ~2,100,000,000 USDC (10¹² too large) | ~0.0021 USDC |

<!-- screenshots to be attached -->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-33544
- **ADR link (if any)**: N/A — the plugin→`customAssets` refactor that moved the "Pay fees in" selector is #18633 (ADR "Getting rid of Plugins"), referenced for context only.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)