### PR TITLE
[LWDM] fix(ledger-wallet-framework, live-common): store account public key in Account.xpub

### DIFF
--- a/.changeset/live-33547-xpub-account-public-key.md
+++ b/.changeset/live-33547-xpub-account-public-key.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/ledger-wallet-framework": patch
+"@ledgerhq/live-common": patch
+---
+
+generic-coin-framework: store the account public key in `Account.xpub` (previously the address) for the evm/xrp/stellar/tezos families. Derive `makeSync`'s account-id identity from the immutable account id instead of the mutable `xpub` field, so healing `xpub` to the public key never re-keys or clears accounts. Account ids remain address-based; existing accounts populate `xpub` on the next device-connected scan.

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
@@ -326,7 +326,7 @@ function buildParentOperations(
 
 export function genericGetAccountShape(network: string, kind: string): GetAccountShape {
   return async (info, syncConfig) => {
-    const { address, initialAccount, currency, derivationMode } = info;
+    const { address, initialAccount, currency, derivationMode, rest } = info;
     const coinModuleApi = await getCoinModuleApi(currency.id, kind);
     const bridgeApi = await getBridgeApi(currency, network);
 
@@ -545,7 +545,9 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
       stakingPositions?: StakingPositionOnAccount[];
     } = {
       id: accountId,
-      xpub: address,
+      // `||` (not `??`): a device getAddress may return an empty-string publicKey (e.g. when the
+      // chain code is not requested); treat "" as absent and fall back rather than storing a blank xpub.
+      xpub: rest?.publicKey || initialAccount?.xpub || address,
       blockHeight: operations.length === 0 ? 0 : blockInfo.height || initialAccount?.blockHeight,
       balance: new BigNumber(nativeBalance.toString()),
       spendableBalance: new BigNumber(spendableBalance.toString()),

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
@@ -781,6 +781,92 @@ describe("genericGetAccountShape", () => {
     });
   });
 
+  describe("xpub (account public key)", () => {
+    const network = "mainnet";
+    const currency = { id: "tezos", name: "Tezos" };
+
+    beforeEach(() => {
+      getSyncHashMock.mockReturnValue("sync-hash");
+      getBalanceMock.mockResolvedValue([{ asset: { type: "native" }, value: 0n, locked: 0n }]);
+      extractBalanceMock.mockReturnValue({ value: 0n, locked: 0n });
+      listOperationsMock.mockResolvedValue({ items: [], next: undefined });
+      buildSubAccountsMock.mockReturnValue([]);
+      lastBlockMock.mockResolvedValue({ height: 0 });
+      mergeOpsMock.mockImplementation((_old: any[], newOps: any[]) => newOps ?? []);
+      cleanedOperationMock.mockImplementation((op: any) => op);
+      inferSubOperationsMock.mockReturnValue([]);
+    });
+
+    test("stores the device public key from info.rest.publicKey", async () => {
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        {
+          address: "tz1address",
+          initialAccount: undefined,
+          currency,
+          derivationMode: "",
+          rest: { publicKey: "edpkPUBLICKEY" },
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(result.xpub).toBe("edpkPUBLICKEY");
+    });
+
+    test("preserves the stored xpub on a device-less resync (no rest)", async () => {
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        {
+          address: "tz1address",
+          initialAccount: {
+            xpub: "edpkPUBLICKEY",
+            operations: [],
+            pendingOperations: [],
+            blockHeight: 0,
+          },
+          currency,
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      // Never clobbered back to the address.
+      expect(result.xpub).toBe("edpkPUBLICKEY");
+    });
+
+    test("treats an empty-string device publicKey as absent (does not store a blank xpub)", async () => {
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        {
+          address: "tz1address",
+          initialAccount: undefined,
+          currency,
+          derivationMode: "",
+          rest: { publicKey: "" },
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      // "" must fall through to the address, never be stored as the xpub.
+      expect(result.xpub).toBe("tz1address");
+    });
+
+    test("falls back to the address pre-heal (no rest, no stored xpub)", async () => {
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        {
+          address: "tz1address",
+          initialAccount: undefined,
+          currency,
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(result.xpub).toBe("tz1address");
+    });
+  });
+
   describe("evm", () => {
     const network = "mainnet";
     const currency = { id: "evm", name: "EVM" };

--- a/libs/ledger-wallet-framework/src/bridge/jsHelpers.test.ts
+++ b/libs/ledger-wallet-framework/src/bridge/jsHelpers.test.ts
@@ -150,6 +150,53 @@ describe("makeSync", () => {
     expect(newAccount.id).toEqual(account.id);
   });
 
+  it("does not re-key or clear the account when xpub holds the public key instead of the address", async () => {
+    // Account id is address-based; xpub now carries the account public key (post device-heal).
+    // Identity must come from the immutable id, not the mutable xpub field, so the id is unchanged
+    // and the account is NOT cleared/rebuilt on resync.
+    const account = createAccount({
+      id: "js:2:bitcoin:tz1address:",
+      freshAddress: "tz1address",
+      xpub: "edpkPublicKeyDifferentFromTheAddress",
+    });
+
+    // When
+    let capturedInitialAccount: unknown;
+    const accountUpdater = makeSync({
+      getAccountShape: (info: AccountShapeInfo) => {
+        capturedInitialAccount = info.initialAccount;
+        return Promise.resolve({} as Account);
+      },
+    })(account, {} as SyncConfig);
+    const updater = await firstValueFrom(accountUpdater);
+    const newAccount = updater(account);
+
+    // Then — id stays address-based (would be re-keyed to the pubkey if derived from initial.xpub) ...
+    expect(newAccount.id).toEqual("js:2:bitcoin:tz1address:");
+    // ... and needClear was false: getAccountShape received the original account, not a cleared copy.
+    expect(capturedInitialAccount).toBe(account);
+  });
+
+  it("still recomputes the id on a legitimate change (derivationMode)", async () => {
+    // Stored id has derivationMode="", but the account's derivationMode is "segwit":
+    // a legitimate mismatch must still recompute the id (needClear preserved).
+    const account = createAccount({
+      id: "js:2:bitcoin:tz1address:",
+      freshAddress: "tz1address",
+      derivationMode: "segwit",
+    });
+
+    // When
+    const accountUpdater = makeSync({
+      getAccountShape: (_accountShape: AccountShapeInfo) => Promise.resolve({} as Account),
+    })(account, {} as SyncConfig);
+    const updater = await firstValueFrom(accountUpdater);
+    const newAccount = updater(account);
+
+    // Then
+    expect(newAccount.id).toEqual("js:2:bitcoin:tz1address:segwit");
+  });
+
   it("supports getAccountShape returning an Observable", async () => {
     const account = createAccount({
       id: "12",
@@ -912,5 +959,6 @@ function createAccount(init: Partial<Account>): Account {
     // subAccounts: [],
     balanceHistoryCache: createEmptyHistoryCache(),
     swapHistory: [],
+    ...init,
   };
 }

--- a/libs/ledger-wallet-framework/src/bridge/jsHelpers.ts
+++ b/libs/ledger-wallet-framework/src/bridge/jsHelpers.ts
@@ -220,6 +220,14 @@ const getCustomDataFromAccountId = (accountId: string): string | undefined => {
   }
 };
 
+const getXpubOrAddressFromAccountId = (accountId: string): string | undefined => {
+  try {
+    return decodeAccountId(accountId).xpubOrAddress;
+  } catch {
+    return undefined;
+  }
+};
+
 export const makeSync =
   <
     T extends TransactionCommon = TransactionCommon,
@@ -247,7 +255,11 @@ export const makeSync =
           type: "js",
           version: "2",
           currencyId: initial.currency.id,
-          xpubOrAddress: initial.xpub || initial.freshAddress,
+          // Identity comes from the immutable account id, decoupled from the mutable `xpub` field
+          // (so healing xpub to the public key never re-keys the account). Only if the id is
+          // undecodable (malformed) do we fall back to the pre-existing recovery behaviour.
+          xpubOrAddress:
+            getXpubOrAddressFromAccountId(initial.id) ?? (initial.xpub || initial.freshAddress),
           derivationMode: initial.derivationMode,
           ...(customData && { customData }),
         });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - `Account.xpub` now holds the account **public key** (was the address) for the generic-coin-framework families (evm, xrp, stellar, tezos). Account ids are unchanged (still address-based).
  - QA focus: account scan/sync and Ledger Sync for these families — confirm no account reset/duplication on upgrade, balances and operations are intact, and existing accounts populate `xpub` after a device-connected sync. No data migration.

### 📝 Description

**Problem.** The generic-coin-framework stored the account **address** in `Account.xpub`, a field meant to hold the account **public key**; the per-account public key returned by the device at scan was discarded, leaving no account field to expose it. Separately, shared `makeSync` derived its account-id `needClear` check from the mutable `xpub` field, so changing `xpub` would re-key and clear accounts on every js-bridge chain.

**Solution.**

- `makeSync` (`ledger-wallet-framework`) now derives the account-id identity from the **immutable account id** (`decodeAccountId(initial.id)`), falling back to `xpub || freshAddress` only when the id is undecodable. Verified no-op for existing accounts across all js-bridge chains.
- `getAccountShape` (`generic-coin-framework`) stores the device public key (`info.rest.publicKey`) in `xpub`, preserves the stored value on device-less resync, treats an empty-string `publicKey` as absent, and falls back to the address pre-heal. Account ids remain address-based.

**Migration.** None. `xpub` is not part of the Ledger Sync descriptor and account ids are unchanged; existing accounts repopulate `xpub` on the next device-connected scan.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33547](https://ledgerhq.atlassian.net/browse/LIVE-33547)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-33547]: https://ledgerhq.atlassian.net/browse/LIVE-33547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ