### PR TITLE
[LWD] fix(desktop): correct x100 countervalue shift in portfolio analytics chart

### DIFF
--- a/.changeset/chart-countervalue-x100-shift.md
+++ b/.changeset/chart-countervalue-x100-shift.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix the portfolio Analytics chart displaying countervalues inflated by x100. The chart data and variation text are already expressed in the fiat unit's smallest atom, but the formatter applied an extra magnitude shift. A dedicated `createSmallestUnitFiatLineChartValueFormatter` is now used for smallest-atom data, and the variation text is shifted down by the unit magnitude.

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/__tests__/createFiatLineChartValueFormatter.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/__tests__/createFiatLineChartValueFormatter.test.ts
@@ -1,0 +1,43 @@
+import type { Unit } from "@ledgerhq/types-cryptoassets";
+import {
+  createFiatLineChartValueFormatter,
+  createSmallestUnitFiatLineChartValueFormatter,
+} from "../utils/createFiatLineChartValueFormatter";
+
+const usdUnit: Unit = {
+  code: "$",
+  name: "US Dollar",
+  magnitude: 2,
+  showAllDigits: true,
+  prefixCode: true,
+};
+
+describe("createFiatLineChartValueFormatter", () => {
+  it("formats a value expressed in the main/display unit (e.g. a market price)", () => {
+    const formatValue = createFiatLineChartValueFormatter(usdUnit, "en-US");
+    expect(formatValue(50_000)).toBe("$50,000.00");
+  });
+
+  it("masks the value in discreet mode", () => {
+    const formatValue = createFiatLineChartValueFormatter(usdUnit, "en-US", true);
+    expect(formatValue(50_000)).toBe("$***");
+  });
+});
+
+describe("createSmallestUnitFiatLineChartValueFormatter", () => {
+  it("formats a value already expressed in the unit's smallest atom (e.g. portfolio countervalue data)", () => {
+    const formatValue = createSmallestUnitFiatLineChartValueFormatter(usdUnit, "en-US");
+    expect(formatValue(5_000_000)).toBe("$50,000.00");
+  });
+
+  it("masks the value in discreet mode", () => {
+    const formatValue = createSmallestUnitFiatLineChartValueFormatter(usdUnit, "en-US", true);
+    expect(formatValue(5_000_000)).toBe("$***");
+  });
+
+  it("does not apply the x100 magnitude shift performed by the main-unit formatter", () => {
+    const smallestUnitFormatter = createSmallestUnitFiatLineChartValueFormatter(usdUnit, "en-US");
+    const mainUnitFormatter = createFiatLineChartValueFormatter(usdUnit, "en-US");
+    expect(smallestUnitFormatter(5_000_000)).toBe(mainUnitFormatter(50_000));
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/utils/createFiatLineChartValueFormatter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/utils/createFiatLineChartValueFormatter.ts
@@ -3,15 +3,41 @@ import { formatPrice } from "@ledgerhq/live-currency-format";
 import type { Unit } from "@ledgerhq/types-cryptoassets";
 import type { LineChartValueFormatter } from "../types";
 
+function formatFiatAtomValue(
+  fiatUnit: Unit,
+  locale: string,
+  discreet: boolean,
+  atomValue: BigNumber,
+): string {
+  return formatPrice(fiatUnit, atomValue, { showCode: true, locale, discreet });
+}
+
+/**
+ * For chart values expressed in the unit's main/display denomination
+ * (e.g. market prices such as `50000` for $50,000).
+ */
 export function createFiatLineChartValueFormatter(
   fiatUnit: Unit,
   locale: string,
   discreet = false,
 ): LineChartValueFormatter {
   return value =>
-    formatPrice(fiatUnit, new BigNumber(value).times(10 ** fiatUnit.magnitude), {
-      showCode: true,
+    formatFiatAtomValue(
+      fiatUnit,
       locale,
       discreet,
-    });
+      new BigNumber(value).times(10 ** fiatUnit.magnitude),
+    );
+}
+
+/**
+ * For chart values already expressed in the unit's smallest atom (e.g. portfolio
+ * countervalue data such as cents for USD), matching the contract of `formatPrice`.
+ */
+export function createSmallestUnitFiatLineChartValueFormatter(
+  fiatUnit: Unit,
+  locale: string,
+  discreet = false,
+): LineChartValueFormatter {
+  return value => formatFiatAtomValue(fiatUnit, locale, discreet, new BigNumber(value));
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/__tests__/useChartSectionHeaderViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/__tests__/useChartSectionHeaderViewModel.test.ts
@@ -23,6 +23,23 @@ describe("useChartSectionHeaderViewModel", () => {
     expect(result.current.percentageValue).toBe(12.34);
   });
 
+  it("formats the variation from a smallest-atom countervalue without a x100 shift", () => {
+    const { result } = renderHook(
+      () =>
+        useChartSectionHeaderViewModel({
+          balanceInfo: {
+            ...mockPortfolioBalanceInfo,
+            valueChange: { percentage: 0.1, value: 1300 },
+          },
+          hoveredBalance: null,
+          isLoading: false,
+        }),
+      { initialState: chartSectionHeaderInitialState },
+    );
+
+    expect(result.current.variationText).toBe("+$13.00");
+  });
+
   it("uses the hovered balance when scrubbing the chart", () => {
     const { result } = renderHook(
       () =>

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/useChartSectionHeaderViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/useChartSectionHeaderViewModel.ts
@@ -47,7 +47,10 @@ export function useChartSectionHeaderViewModel({
 
   const variationText = useMemo(() => {
     if (discreet) return "***";
-    return formatSignedFiatVariation(balanceInfo.valueChange.value, fiatUnit, locale);
+    const mainUnitValue = new BigNumber(balanceInfo.valueChange.value)
+      .shiftedBy(-fiatUnit.magnitude)
+      .toNumber();
+    return formatSignedFiatVariation(mainUnitValue, fiatUnit, locale);
   }, [balanceInfo.valueChange.value, discreet, fiatUnit, locale]);
 
   const rangeLabel = t(PORTFOLIO_RANGE_LABEL_KEY[selectedTimeRange]);

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/useChartSectionViewModel.ts
@@ -11,7 +11,7 @@ import {
   type LineChartScrubberPositionChange,
   type LineChartSeries,
 } from "LLD/components/LineChart";
-import { createFiatLineChartValueFormatter } from "LLD/components/LineChart/utils/createFiatLineChartValueFormatter";
+import { createSmallestUnitFiatLineChartValueFormatter } from "LLD/components/LineChart/utils/createFiatLineChartValueFormatter";
 import { createLineChartTooltipTitle } from "LLD/components/LineChart/utils/createLineChartTooltipTitle";
 import {
   buildLineChartBottomPaddedYAxisConfig,
@@ -90,7 +90,7 @@ export function useChartSectionViewModel({
   const points = useMemo(() => getExtremaPointMarkers(series), [series]);
 
   const formatValue = useMemo(
-    () => createFiatLineChartValueFormatter(fiatUnit, locale, discreet),
+    () => createSmallestUnitFiatLineChartValueFormatter(fiatUnit, locale, discreet),
     [fiatUnit, locale, discreet],
   );
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio Analytics chart Y-axis / hovered tooltip countervalues
      - Chart header variation text (`+$13.00` style deltas)
      - Verify displayed values are no longer inflated by x100 across fiat units (USD, EUR, JPY with magnitude 0, etc.)

### 📝 Description

**Problem**: The portfolio Analytics chart displayed countervalues inflated by x100. Portfolio countervalue data and the header variation value are already expressed in the fiat unit's smallest atom (e.g. cents for USD), but `createFiatLineChartValueFormatter` applied an extra `10^magnitude` shift, double-scaling the values.

**Solution**:
- Introduced `createSmallestUnitFiatLineChartValueFormatter`, which formats values already expressed in the unit's smallest atom (matching `formatPrice`'s contract) without the extra magnitude shift. The chart now uses this formatter.
- Kept `createFiatLineChartValueFormatter` for values expressed in the main/display denomination (e.g. market prices), with both formatters sharing a common `formatFiatAtomValue` helper.
- Fixed the header variation text by shifting the smallest-atom `valueChange.value` down by the unit magnitude before formatting.

Added unit tests covering both formatters (including a regression test asserting the smallest-unit formatter does not apply the x100 shift) and the variation-text formatting in the chart header view model.

### 📸 Screenshots

https://github.com/user-attachments/assets/f76fba1a-1279-4558-bf33-48261a833a36


### ❓ Context

- **JIRA or GitHub link**: [LIVE-33565](https://ledgerhq.atlassian.net/browse/LIVE-33565)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33565]: https://ledgerhq.atlassian.net/browse/LIVE-33565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ