### PR TITLE
[LWDM] refactor(llc): source EVM signer calServiceURL from env

### DIFF
--- a/.changeset/cal-service-url-single-source.md
+++ b/.changeset/cal-service-url-single-source.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+evm: source the EVM signer `calServiceURL` from `getEnv("CAL_SERVICE_URL")` instead of relying on the hw-app-eth hardcoded default, so the CAL base URL has a single env-driven source of truth

--- a/libs/ledger-live-common/src/families/evm/signer.ts
+++ b/libs/ledger-live-common/src/families/evm/signer.ts
@@ -70,6 +70,7 @@ export const createSigner: CreateSigner<Signer> = (transport: Transport) => {
         domains: domain && [domain],
       };
       const loadConfig: LoadConfig = {
+        calServiceURL: getEnv("CAL_SERVICE_URL"),
         cryptoassetsBaseURL: getEnv("DYNAMIC_CAL_BASE_URL"),
         nftExplorerBaseURL: getEnv("NFT_METADATA_SERVICE") + "/v1/ethereum",
       };


### PR DESCRIPTION
Route the EVM signer `calServiceURL` through `getEnv("CAL_SERVICE_URL")` instead of relying on the hw-app-eth hardcoded default, giving the CAL base URL a single env-driven source of truth (prep for the Gravitee URL switch). No value change today.

[LIVE-33577](https://ledgerhq.atlassian.net/browse/LIVE-33577)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIVE-33577]: https://ledgerhq.atlassian.net/browse/LIVE-33577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ