### PR TITLE
test(e2e/desktop): temporarily disable Swap Celo to Solana test

### DIFF
--- a/e2e/desktop/tests/specs/send.swap.spec.ts
+++ b/e2e/desktop/tests/specs/send.swap.spec.ts
@@ -349,22 +349,23 @@ const swaps = [
       "@family-sui",
     ],
   },
-  {
-    fromAccount: TokenAccount.CELO_1,
-    toAccount: Account.SOL_1,
-    xrayTicket: "B2CQA-4011",
-    tag: [
-      "@NanoSP",
-      "@NanoX",
-      "@Stax",
-      "@Flex",
-      "@NanoGen5",
-      "@celo",
-      "@solana",
-      "@family-solana",
-      "@family-celo",
-    ],
-  },
+  // Temporary removed with Changelly deactivation.
+  // {
+  //   fromAccount: TokenAccount.CELO_1,
+  //   toAccount: Account.SOL_1,
+  //   xrayTicket: "B2CQA-4011",
+  //   tag: [
+  //     "@NanoSP",
+  //     "@NanoX",
+  //     "@Stax",
+  //     "@Flex",
+  //     "@NanoGen5",
+  //     "@celo",
+  //     "@solana",
+  //     "@family-solana",
+  //     "@family-celo",
+  //   ],
+  // },
 ];
 
 for (const { fromAccount, toAccount, xrayTicket, tag } of swaps) {


### PR DESCRIPTION
## Summary
- Comments out the "Swap Celo to Solana" E2E test in `e2e/desktop/tests/specs/send.swap.spec.ts` (was the only swap-FROM-CELO test in the desktop suite, xrayTicket B2CQA-4011).
- Reason: Changelly (the provider backing this pair) has been deactivated, so this scenario has no live provider to run against.
- Mobile (LWM) swap E2E suite was audited and contains no swap-FROM-CELO tests, so no mobile changes are needed.

## Test plan
- [ ] Typecheck passes for the edited file (`send.swap.spec.ts` has no new errors)
- [ ] `swaps` array still parses correctly with the commented-out entry (remaining 15 swap scenarios unaffected)
- [ ] CI desktop E2E swap suite runs green without the "Swap Celo to Solana" case

🤖 Generated with [Claude Code](https://claude.com/claude-code)