### PR TITLE
[LWDM] refactor(live-signer-evm): source DMK context module CAL URL from env

### DIFF
--- a/.changeset/dmk-eth-cal-config-env.md
+++ b/.changeset/dmk-eth-cal-config-env.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-signer-evm": patch
+---
+
+evm: wire the DMK context module CAL URL from `getEnv("CAL_SERVICE_URL")` via `setCalConfig`, so the EVM signer no longer relies on the context-module hardcoded default and the CAL base URL has a single env-driven source of truth (prep for the Gravitee URL switch)

--- a/libs/live-signer-evm/package.json
+++ b/libs/live-signer-evm/package.json
@@ -33,6 +33,7 @@
     "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-app-eth": "workspace:^",
     "@ledgerhq/live-dmk-shared": "workspace:^",
+    "@ledgerhq/live-env": "workspace:^",
     "rxjs": "catalog:"
   },
   "scripts": {

--- a/libs/live-signer-evm/src/DmkSignerEth.ts
+++ b/libs/live-signer-evm/src/DmkSignerEth.ts
@@ -17,6 +17,7 @@ import {
   hexaStringToBuffer,
 } from "@ledgerhq/device-management-kit";
 import { ContextModuleBuilder, ContextModuleChainID } from "@ledgerhq/context-module";
+import { getEnv } from "@ledgerhq/live-env";
 import { EIP712Message } from "@ledgerhq/types-live";
 import {
   EthAppPleaseEnableContractData,
@@ -60,6 +61,7 @@ export class DmkSignerEth implements EvmSigner {
       .setAppSource("ledger-wallet")
       .setBlindSigningReporter(liveBlindSigningReporter)
       .setChain(ContextModuleChainID.Ethereum)
+      .setCalConfig({ url: `${getEnv("CAL_SERVICE_URL")}/v1`, mode: "prod", branch: "main" })
       .build();
     this.signer = new SignerEthBuilder({
       dmk,

--- a/libs/live-signer-evm/tests/DmkSignerEth.test.ts
+++ b/libs/live-signer-evm/tests/DmkSignerEth.test.ts
@@ -3,6 +3,8 @@ import { EIP712Message } from "@ledgerhq/types-live";
 import { lastValueFrom, of } from "rxjs";
 import { DmkSignerEth } from "../src/DmkSignerEth";
 import { SignTransactionDAStep } from "@ledgerhq/device-signer-kit-ethereum";
+import { ContextModuleBuilder } from "@ledgerhq/context-module";
+import { getEnv, setEnv } from "@ledgerhq/live-env";
 
 describe("DmkSignerEth", () => {
   const dmkMock = {
@@ -338,16 +340,18 @@ describe("DmkSignerEth", () => {
       });
 
       // WHEN
-      const result = await lastValueFrom(signer.signTransaction(path, rawTxHex, {
-        domains: [
-          {
-            registry: "ens",
-            domain,
-            address: "0x",
-            type: "forward",
-          },
-        ]
-      }));
+      const result = await lastValueFrom(
+        signer.signTransaction(path, rawTxHex, {
+          domains: [
+            {
+              registry: "ens",
+              domain,
+              address: "0x",
+              type: "forward",
+            },
+          ],
+        }),
+      );
 
       // THEN
       expect(dmkMock.executeDeviceAction).toHaveBeenCalledWith(
@@ -615,6 +619,27 @@ describe("DmkSignerEth", () => {
       } catch (error) {
         // THEN
         expect(error).toEqual(new Error("Method not implemented."));
+      }
+    });
+  });
+
+  describe("CAL config", () => {
+    it("wires setCalConfig from the CAL_SERVICE_URL env", () => {
+      const previous = getEnv("CAL_SERVICE_URL");
+      const setCalConfig = jest.spyOn(ContextModuleBuilder.prototype, "setCalConfig");
+      setEnv("CAL_SERVICE_URL", "https://cal.example.test");
+
+      try {
+        new DmkSignerEth(dmkMock as unknown as DeviceManagementKit, "sessionId");
+
+        expect(setCalConfig).toHaveBeenCalledWith({
+          url: "https://cal.example.test/v1",
+          mode: "prod",
+          branch: "main",
+        });
+      } finally {
+        setEnv("CAL_SERVICE_URL", previous);
+        setCalConfig.mockRestore();
       }
     });
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11528,6 +11528,9 @@ importers:
       '@ledgerhq/live-dmk-shared':
         specifier: workspace:^
         version: link:../live-dmk-shared
+      '@ledgerhq/live-env':
+        specifier: workspace:^
+        version: link:../env
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2


### PR DESCRIPTION
Wire the EVM DMK context module CAL URL from `getEnv("CAL_SERVICE_URL")` via `setCalConfig` instead of the context-module hardcoded default, giving the CAL base URL a single env-driven source of truth on the EVM signer (prep for the Gravitee URL switch). Appends `/v1` to match the version-less env convention; keeps the context-module `mode`/`branch` defaults (`prod`/`main`), so no behavior change today.

Solana & Concordium signers have the same divergence (they build a default context module internally) — tracked separately in LIVE-33607 / LIVE-33608.

[LIVE-33579](https://ledgerhq.atlassian.net/browse/LIVE-33579)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIVE-33579]: https://ledgerhq.atlassian.net/browse/LIVE-33579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ