### PR TITLE
chore(desktop): ignore animation json files from oxfmt

### DIFF
--- a/apps/ledger-live-desktop/.oxfmtrc.json
+++ b/apps/ledger-live-desktop/.oxfmtrc.json
@@ -4,5 +4,5 @@
   "trailingComma": "all",
   "arrowParens": "avoid",
   "sortPackageJson": false,
-  "ignorePatterns": ["static/i18n/**"]
+  "ignorePatterns": ["static/i18n/**", "**/animations/**/*.json"]
 }


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** N/A — config change only
- [x] **Impact of the changes:**
  - Lottie animation JSON files under src/renderer/animations/ are now excluded from oxfmt format checks

### 📝 Description

The desktop oxfmt config did not ignore JSON files (unlike the root config which has \`**/*.json\` in ignorePatterns). oxfmt has no config extends mechanism, so the local .oxfmtrc.json is standalone. This caused 58 Lottie animation JSON files to be flagged as unformatted by format:check, despite being machine-generated assets that should not be reformatted.

Adds `**/animations/**/*.json` to ignorePatterns in apps/ledger-live-desktop/.oxfmtrc.json.

### ❓ Context

- **JIRA or GitHub link**: N/A