### PR TITLE
[LWDM] style: apply oxfmt formatting to drifted files

### DIFF
--- a/apps/cli/src/commands/live/generateAppJson.ts
+++ b/apps/cli/src/commands/live/generateAppJson.ts
@@ -23,13 +23,10 @@ type CoinGroup = {
 };
 
 const DEFAULT_OUTPUT_DIR = "e2e/userdata/generated";
-const DEFAULT_BASE =
-  "e2e/desktop/tests/userdata/skip-onboarding-with-last-seen-device.json";
+const DEFAULT_BASE = "e2e/desktop/tests/userdata/skip-onboarding-with-last-seen-device.json";
 
 function resolveOutputDir(outputDir?: string): string {
-  return path.resolve(
-    outputDir ?? process.env.E2E_GENERATED_USERDATA_DIR ?? DEFAULT_OUTPUT_DIR,
-  );
+  return path.resolve(outputDir ?? process.env.E2E_GENERATED_USERDATA_DIR ?? DEFAULT_OUTPUT_DIR);
 }
 
 function groupAccountsByCoin(coins?: string[]): Map<string, CoinGroup> {
@@ -41,11 +38,7 @@ function groupAccountsByCoin(coins?: string[]): Map<string, CoinGroup> {
     if (coins?.length && !coins.includes(id)) continue;
     const group = groups.get(id) ?? { currency: value.currency, accounts: [] };
     const scheme = value.derivationMode || undefined;
-    if (
-      !group.accounts.some(
-        (a) => a.index === value.index && a.scheme === scheme,
-      )
-    ) {
+    if (!group.accounts.some(a => a.index === value.index && a.scheme === scheme)) {
       group.accounts.push({ index: value.index, scheme });
     }
     groups.set(id, group);
@@ -85,17 +78,14 @@ async function generateCoin(
     const count = written?.data?.accounts?.length ?? 0;
     return `${coinId}: ${count} account(s) -> ${outPath}`;
   } catch (error) {
-    return `${coinId}: FAILED (${
-      error instanceof Error ? error.message : String(error)
-    })`;
+    return `${coinId}: FAILED (${error instanceof Error ? error.message : String(error)})`;
   } finally {
     if (device) await stopSpeculos(device.id);
   }
 }
 
 export default {
-  description:
-    "Generate one app.json per coin for E2E userdata, launching Speculos automatically",
+  description: "Generate one app.json per coin for E2E userdata, launching Speculos automatically",
   args: [
     {
       name: "coin",
@@ -125,8 +115,7 @@ export default {
     fs.mkdirSync(outDir, { recursive: true });
 
     const baseTemplate = path.resolve(base ?? DEFAULT_BASE);
-    if (!fs.existsSync(baseTemplate))
-      throw new Error(`base userdata not found: ${baseTemplate}`);
+    if (!fs.existsSync(baseTemplate)) throw new Error(`base userdata not found: ${baseTemplate}`);
 
     process.env.LEDGER_LIVE_CLI_BIN = process.argv[1];
     setEnv("MOCK", "");
@@ -134,10 +123,7 @@ export default {
     setEnv("PLAYWRIGHT_RUN", true);
 
     if (!getEnv("E2E_NANO_APP_VERSION_PATH")) {
-      setEnv(
-        "E2E_NANO_APP_VERSION_PATH",
-        path.join(outDir, "nano-app-catalog.json"),
-      );
+      setEnv("E2E_NANO_APP_VERSION_PATH", path.join(outDir, "nano-app-catalog.json"));
     }
 
     const groups = groupAccountsByCoin(coin);

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useFeePresetFiatValues.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useFeePresetFiatValues.ts
@@ -23,10 +23,7 @@ type Params = Readonly<
   }
 >;
 
-export function useFeePresetFiatValues({
-  counterValueCurrency,
-  ...params
-}: Params): FeeFiatMap {
+export function useFeePresetFiatValues({ counterValueCurrency, ...params }: Params): FeeFiatMap {
   const calculateCountervalue = useCalculateCountervalueCallback({ to: counterValueCurrency });
   return useFeePresetFiatValuesCore({ ...params, calculateCountervalue });
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useNetworkFees.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useNetworkFees.ts
@@ -64,17 +64,21 @@ export function useNetworkFees({
     calculateCountervalue,
   });
 
-  const getFeeStrategyLabel = useCallback((strategy: string | null): string => {
-    if (!strategy) return t("fees.medium");
-    if (strategy === "custom") return t("fees.custom");
-    return t(`fees.${strategy}`);
-  }, [t]);
+  const getFeeStrategyLabel = useCallback(
+    (strategy: string | null): string => {
+      if (!strategy) return t("fees.medium");
+      if (strategy === "custom") return t("fees.custom");
+      return t(`fees.${strategy}`);
+    },
+    [t],
+  );
 
   return useMemo(
     () => ({
       feesRowLabel: t("fees.networkFees"),
       feesRowValue:
-        core.selectedPresetFiatValue ?? (core.displayFeesValue === "-" ? "--" : core.displayFeesValue),
+        core.selectedPresetFiatValue ??
+        (core.displayFeesValue === "-" ? "--" : core.displayFeesValue),
       feesRowStrategyLabel: getFeeStrategyLabel(core.selectedFeeStrategy),
       showNetworkFees: true,
       showFeePresets: core.showFeePresets,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendFlowTransaction.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendFlowTransaction.ts
@@ -52,7 +52,10 @@ export function useSendFlowTransaction({
     (recipient: RecipientData) => {
       if (!account || !transaction || !bridge) return;
 
-      const updates = buildRecipientTransactionPatch(transaction, recipient) as Partial<Transaction>;
+      const updates = buildRecipientTransactionPatch(
+        transaction,
+        recipient,
+      ) as Partial<Transaction>;
 
       bridgeSetTransaction(bridge.updateTransaction(transaction, updates));
     },

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/NetworkFeesMenu.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/NetworkFeesMenu.tsx
@@ -85,7 +85,8 @@ export function NetworkFeesMenu({ display, selection, presets, actions }: Networ
     [currency],
   );
   const fallbackPresetIds = useMemo(
-    () => (currency && transaction ? sendFeatures.getFeePresetFallbackIds(currency, transaction) : []),
+    () =>
+      currency && transaction ? sendFeatures.getFeePresetFallbackIds(currency, transaction) : [],
     [currency, transaction],
   );
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/types.ts
@@ -72,10 +72,7 @@ type ReviewProps = Readonly<{
   onGetFunds?: () => void;
 }>;
 
-export type AmountScreenViewProps = AmountInputProps &
-  FeesProps &
-  QuickActionsProps &
-  ReviewProps;
+export type AmountScreenViewProps = AmountInputProps & FeesProps & QuickActionsProps & ReviewProps;
 
 export type AmountScreenViewModel = Omit<
   AmountScreenViewProps,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/hooks/__tests__/useCustomFeesViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/hooks/__tests__/useCustomFeesViewModel.test.ts
@@ -104,7 +104,9 @@ const mockCustomAssetsConfigs: Record<string, ReturnType<() => unknown>> = {
       { id: "cusd", ticker: "cUSD", label: "cUSD" },
     ],
     getSelectedOptionId: () => "celo",
-    buildPatch: (optionId: string) => ({ feeCurrencyAccountId: optionId === "celo" ? null : optionId }),
+    buildPatch: (optionId: string) => ({
+      feeCurrencyAccountId: optionId === "celo" ? null : optionId,
+    }),
   },
 };
 

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepAmount.tsx
@@ -63,7 +63,9 @@ const StepAmount = (props: StepProps) => {
       {error ? <ErrorBanner error={error} /> : null}
       <Fragment key={account.id}>
         {isAutoPickingStrategy ? (
-          isAleoAccount(account) ? <InfoBanner account={account} /> : null
+          isAleoAccount(account) ? (
+            <InfoBanner account={account} />
+          ) : null
         ) : (
           <SpendableBanner
             account={account}

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/QuickAmountSelector.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/QuickAmountSelector.test.tsx
@@ -283,8 +283,9 @@ describe("QuickAmountSelector", () => {
 
     it("sets useAllAmount when full tile is clicked with more token records than the token cap", async () => {
       // MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION + 1 records — full tile fills exactly the cap → isSendMax
-      const records = Array.from({ length: MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION + 1 }, (_, i) =>
-        makeRecord(String((i + 1) * 100)),
+      const records = Array.from(
+        { length: MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION + 1 },
+        (_, i) => makeRecord(String((i + 1) * 100)),
       );
       const account = makeTokenAccount(records);
       const transaction = makeAleoTransaction();

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.ts
@@ -118,9 +118,7 @@ export function formatAleoBalances({
   };
 }
 
-export function getMaxPrivateRecordsForAccount(
-  account: AleoAccount | AleoTokenAccount,
-): number {
+export function getMaxPrivateRecordsForAccount(account: AleoAccount | AleoTokenAccount): number {
   return account.type === "TokenAccount"
     ? MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION
     : MAX_PRIVATE_RECORDS_PER_TRANSACTION;

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
@@ -7,7 +7,11 @@ import { TFunction } from "i18next";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { addPendingOperation, getMainAccount, getRecentAddressesStore } from "@ledgerhq/live-common/account/index";
+import {
+  addPendingOperation,
+  getMainAccount,
+  getRecentAddressesStore,
+} from "@ledgerhq/live-common/account/index";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/components/RequiresBLE/index.tsx
+++ b/apps/ledger-live-mobile/src/components/RequiresBLE/index.tsx
@@ -24,7 +24,9 @@ type Props = {
 const RequiresBLE: React.FC<Props> = ({ children, forceOpenSettingsOnErrorButton = false }) => {
   if (Platform.OS === "android") {
     return (
-      <AndroidRequiresBluetoothPermissions forceOpenSettingsOnErrorButton={forceOpenSettingsOnErrorButton}>
+      <AndroidRequiresBluetoothPermissions
+        forceOpenSettingsOnErrorButton={forceOpenSettingsOnErrorButton}
+      >
         <RequiresBluetoothEnabled forceOpenSettingsOnErrorButton={forceOpenSettingsOnErrorButton}>
           <AndroidRequiresLocationPermission
             required={Platform.Version <= 30}

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyWarningScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyWarningScreen.tsx
@@ -63,7 +63,10 @@ export default function ViewKeyWarningScreen({ route, navigation }: Props) {
   }, []);
 
   return (
-    <SafeAreaView edges={["bottom"]} style={[styles.root, { backgroundColor: colors.background.main }]}>
+    <SafeAreaView
+      edges={["bottom"]}
+      style={[styles.root, { backgroundColor: colors.background.main }]}
+    >
       <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         <LText semiBold style={styles.title} color="neutral.c100">
           <Trans i18nKey="aleo.addAccount.stepViewKeyWarning.title" />

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/AddAccountNavigator.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/AddAccountNavigator.test.tsx
@@ -100,7 +100,9 @@ describe("AleoAddAccountNavigator — handleClose", () => {
   it("pops navigationDepth screens when navigationDepth is provided", () => {
     render(
       <AddAccountNavigator
-        route={{ params: { currency: aleoCurrency, device: mockDevice, navigationDepth: 4 } } as any}
+        route={
+          { params: { currency: aleoCurrency, device: mockDevice, navigationDepth: 4 } } as any
+        }
         navigation={{ getParent: () => ({ pop: mockPop }) } as any}
       />,
     );

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/hooks/useOnboardingNavigation.ts
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/hooks/useOnboardingNavigation.ts
@@ -60,8 +60,7 @@ export function useOnboardingNavigation({
               // Already-onboarded Canton accounts are importable even when unfunded (used=false). LIVE-32985
               const importableAccounts = accountsToAdd.filter(
                 account =>
-                  account.used ||
-                  (isCantonAccount(account) && account.cantonResources.isOnboarded),
+                  account.used || (isCantonAccount(account) && account.cantonResources.isOnboarded),
               );
               const completedAccount = onboardResult.account;
 

--- a/apps/ledger-live-mobile/src/families/cardano/DelegationFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/DelegationFlow/02-Summary.tsx
@@ -167,7 +167,10 @@ export default function DelegationSummary({ navigation, route }: Props) {
   }, [status]);
 
   return (
-    <SafeAreaView edges={["left", "right", "bottom"]} style={[styles.root, { backgroundColor: colors.background }]}>
+    <SafeAreaView
+      edges={["left", "right", "bottom"]}
+      style={[styles.root, { backgroundColor: colors.background }]}
+    >
       <TrackScreen
         category="DelegationFlow"
         name={route.params.skipStartedStep ? "Step Starter" : "Summary"}

--- a/apps/ledger-live-mobile/src/families/cardano/DelegationFlow/SelectPool.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/DelegationFlow/SelectPool.tsx
@@ -46,7 +46,10 @@ export default function SelectPool({ navigation, route }: Props) {
   );
 
   return (
-    <SafeAreaView edges={["left", "right", "bottom"]} style={[styles.root, { backgroundColor: colors.background }]}>
+    <SafeAreaView
+      edges={["left", "right", "bottom"]}
+      style={[styles.root, { backgroundColor: colors.background }]}
+    >
       <TrackScreen category="DelegationFlow" name="SelectValidator" />
       <SelectPoolSearchBox searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
       <View style={styles.header}>

--- a/apps/ledger-live-mobile/src/families/celo/ActivateFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/ActivateFlow/02-Summary.tsx
@@ -110,7 +110,10 @@ export default function ActivateSummary({ navigation, route }: Props) {
     status.warnings && Object.keys(status.warnings).length > 0 && Object.values(status.warnings)[0];
 
   return (
-    <SafeAreaView edges={["left", "right", "bottom"]} style={[styles.root, { backgroundColor: colors.background }]}>
+    <SafeAreaView
+      edges={["left", "right", "bottom"]}
+      style={[styles.root, { backgroundColor: colors.background }]}
+    >
       <TrackScreen
         category="ActivateFlow"
         name="Summary"

--- a/apps/ledger-live-mobile/src/families/celo/ActivateFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/ActivateFlow/SelectValidator.tsx
@@ -70,7 +70,10 @@ export default function SelectValidator({ navigation, route }: Props) {
     );
 
   return (
-    <SafeAreaView edges={["left", "right", "bottom"]} style={[styles.root, { backgroundColor: colors.background }]}>
+    <SafeAreaView
+      edges={["left", "right", "bottom"]}
+      style={[styles.root, { backgroundColor: colors.background }]}
+    >
       <TrackScreen
         category="ActivateFlow"
         name="SelectValidator"

--- a/apps/ledger-live-mobile/src/families/celo/RevokeFlow/01-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RevokeFlow/01-Summary.tsx
@@ -137,7 +137,10 @@ export default function RevokeSummary({ navigation, route }: Props) {
   const hasErrors = Object.keys(status.errors).length > 0;
 
   return (
-    <SafeAreaView edges={["left", "right", "bottom"]} style={[styles.root, { backgroundColor: colors.background }]}>
+    <SafeAreaView
+      edges={["left", "right", "bottom"]}
+      style={[styles.root, { backgroundColor: colors.background }]}
+    >
       <TrackScreen
         category="CeloRevoke"
         name="Summary"

--- a/apps/ledger-live-mobile/src/families/celo/RevokeFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RevokeFlow/SelectValidator.tsx
@@ -68,7 +68,10 @@ export default function SelectValidator({ navigation, route }: Props) {
     );
 
   return (
-    <SafeAreaView edges={["left", "right", "bottom"]} style={[styles.root, { backgroundColor: colors.background }]}>
+    <SafeAreaView
+      edges={["left", "right", "bottom"]}
+      style={[styles.root, { backgroundColor: colors.background }]}
+    >
       <TrackScreen
         category="CeloRevoke"
         name="SelectValidator"

--- a/apps/ledger-live-mobile/src/families/celo/VoteFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/VoteFlow/02-Summary.tsx
@@ -117,7 +117,10 @@ export default function VoteSummary({ navigation, route }: Props) {
   const hasErrors = Object.keys(status.errors).length > 0;
 
   return (
-    <SafeAreaView edges={["left", "right", "bottom"]} style={[styles.root, { backgroundColor: colors.background }]}>
+    <SafeAreaView
+      edges={["left", "right", "bottom"]}
+      style={[styles.root, { backgroundColor: colors.background }]}
+    >
       <TrackScreen category="VoteFlow" name="Summary" flow="stake" action="vote" currency="celo" />
 
       <View style={styles.body}>

--- a/apps/ledger-live-mobile/src/families/celo/VoteFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/VoteFlow/SelectValidator.tsx
@@ -45,7 +45,10 @@ export default function SelectValidator({ navigation, route }: Props) {
   );
 
   return (
-    <SafeAreaView edges={["left", "right", "bottom"]} style={[styles.root, { backgroundColor: colors.background }]}>
+    <SafeAreaView
+      edges={["left", "right", "bottom"]}
+      style={[styles.root, { backgroundColor: colors.background }]}
+    >
       <TrackScreen
         category="VoteFlow"
         name="SelectValidator"

--- a/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/WithdrawAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/WithdrawAmount.tsx
@@ -115,7 +115,10 @@ export default function WithdrawAmount({ navigation, route }: Props) {
     status.warnings && Object.keys(status.warnings).length > 0 && Object.values(status.warnings)[0];
 
   return (
-    <SafeAreaView edges={["left", "right", "bottom"]} style={[styles.root, { backgroundColor: colors.background }]}>
+    <SafeAreaView
+      edges={["left", "right", "bottom"]}
+      style={[styles.root, { backgroundColor: colors.background }]}
+    >
       <TrackScreen
         category="CeloWithdraw"
         name="Amount"

--- a/apps/ledger-live-mobile/src/families/evm/DelegationFlow/01-SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/DelegationFlow/01-SelectValidator.tsx
@@ -114,7 +114,10 @@ export default function SelectValidator({ navigation, route }: Props) {
   }
 
   return (
-    <SafeAreaView edges={["left", "right", "bottom"]} style={[styles.root, { backgroundColor: colors.background }]}>
+    <SafeAreaView
+      edges={["left", "right", "bottom"]}
+      style={[styles.root, { backgroundColor: colors.background }]}
+    >
       <TrackScreen
         category="EvmDelegationFlow"
         name="SelectValidator"

--- a/apps/ledger-live-mobile/src/families/near/StakingFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/near/StakingFlow/02-Summary.tsx
@@ -135,7 +135,10 @@ export default function StakingSummary({ navigation, route }: Props) {
   const hasErrors = hasStatusError(status);
 
   return (
-    <SafeAreaView edges={["left", "right", "bottom"]} style={[styles.root, { backgroundColor: colors.background }]}>
+    <SafeAreaView
+      edges={["left", "right", "bottom"]}
+      style={[styles.root, { backgroundColor: colors.background }]}
+    >
       <TrackScreen
         category="DelegationFlow"
         name={route.params.skipStartedStep ? "Step Starter" : "Summary"}

--- a/apps/ledger-live-mobile/src/families/near/StakingFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/near/StakingFlow/SelectValidator.tsx
@@ -45,7 +45,10 @@ export default function SelectValidator({ navigation, route }: Props) {
   );
 
   return (
-    <SafeAreaView edges={["left", "right", "bottom"]} style={[styles.root, { backgroundColor: colors.background }]}>
+    <SafeAreaView
+      edges={["left", "right", "bottom"]}
+      style={[styles.root, { backgroundColor: colors.background }]}
+    >
       <TrackScreen
         category="DelegationFlow"
         name="SelectValidator"

--- a/apps/ledger-live-mobile/src/families/sui/StakingFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/sui/StakingFlow/02-Summary.tsx
@@ -147,7 +147,10 @@ export default function StakingSummary({ navigation, route }: Props) {
   const hasErrors = hasStatusError(status);
 
   return (
-    <SafeAreaView edges={["left", "right", "bottom"]} style={[styles.root, { backgroundColor: colors.background }]}>
+    <SafeAreaView
+      edges={["left", "right", "bottom"]}
+      style={[styles.root, { backgroundColor: colors.background }]}
+    >
       <TrackScreen
         category="DelegationFlow"
         name={route.params.skipStartedStep ? "Step Starter" : "Summary"}

--- a/apps/ledger-live-mobile/src/families/sui/StakingFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/sui/StakingFlow/SelectValidator.tsx
@@ -45,7 +45,10 @@ export default function SelectValidator({ navigation, route }: Props) {
   );
 
   return (
-    <SafeAreaView edges={["left", "right", "bottom"]} style={[styles.root, { backgroundColor: colors.background }]}>
+    <SafeAreaView
+      edges={["left", "right", "bottom"]}
+      style={[styles.root, { backgroundColor: colors.background }]}
+    >
       <TrackScreen
         category="DelegationFlow"
         name="SelectValidator"

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/usePrecomputedAssetListData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/usePrecomputedAssetListData.ts
@@ -109,13 +109,12 @@ function computeAssetItemData(asset: Asset, state: SharedState): AssetListItemVi
 
   const unit = asset.currency.units?.[0];
   const formattedBalance = unit ? formatCurrencyUnit(unit, balance, fmtOpts) : "";
-  const counterValue = getCounterValue(
-    asset,
-    balance,
-    state.cvState,
+  const counterValue = getCounterValue(asset, balance, state.cvState, state.counterValueCurrency);
+  const formattedCounterValue = formatCounterValue(
+    counterValue,
     state.counterValueCurrency,
+    fmtOpts,
   );
-  const formattedCounterValue = formatCounterValue(counterValue, state.counterValueCurrency, fmtOpts);
   const countervalueChange = getCountervalueChange(asset, state, counterValue);
 
   return { formattedBalance, formattedCounterValue, countervalueChange };

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/components/LedgerRecoverRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/components/LedgerRecoverRow.tsx
@@ -41,10 +41,7 @@ export function LedgerRecoverRow({
         />
         <ListItemContent>
           <ListItemTitle>{title}</ListItemTitle>
-          <ListItemDescription
-            numberOfLines={2}
-            lx={isWarning ? { color: "warning" } : undefined}
-          >
+          <ListItemDescription numberOfLines={2} lx={isWarning ? { color: "warning" } : undefined}>
             {description}
           </ListItemDescription>
         </ListItemContent>

--- a/apps/ledger-live-mobile/src/mvvm/features/DeviceSelection/__integrations__/deviceSelection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/DeviceSelection/__integrations__/deviceSelection.integration.test.tsx
@@ -113,4 +113,3 @@ describe("Device Selection feature integration test", () => {
     });
   });
 });
-

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/hooks/__tests__/useMarketCoinData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/hooks/__tests__/useMarketCoinData.test.ts
@@ -132,10 +132,13 @@ describe("useMarketCoinData hooks", () => {
       withMarketState({ marketParams: { counterCurrency: "btc" } }),
     );
 
-    expect(mockedUseCurrencyData).toHaveBeenCalledWith({
-      counterCurrency: "usd",
-      id: "bitcoin",
-    }, { skip: false });
+    expect(mockedUseCurrencyData).toHaveBeenCalledWith(
+      {
+        counterCurrency: "usd",
+        id: "bitcoin",
+      },
+      { skip: false },
+    );
     expect(mockedUseUsdToFiatRate).toHaveBeenCalledWith("btc", { skip: false });
     expect(result.current.counterCurrency).toBe("btc");
     expect(result.current.currency?.price).toBeCloseTo(0.001);

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/__tests__/useQuickActionsRowViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/__tests__/useQuickActionsRowViewModel.test.ts
@@ -8,10 +8,7 @@ import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
 import { urls } from "~/utils/urls";
 import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
-import {
-  PROTECT_ID,
-  withRecoverState,
-} from "LLM/features/Portfolio/utils/recoverTestHelpers";
+import { PROTECT_ID, withRecoverState } from "LLM/features/Portfolio/utils/recoverTestHelpers";
 import { ShieldCheckNotificationIcon } from "LLM/features/BackupHub/components/ShieldCheckNotificationIcon";
 import { MY_WALLET_TRACKING_PAGE_NAME } from "../../../constants";
 import { useQuickActionsRowViewModel } from "../useQuickActionsRowViewModel";
@@ -205,9 +202,7 @@ describe("useQuickActionsRowViewModel", () => {
 
       it("should open the Backup Hub navigator and track the event on press", () => {
         const { result } = renderHook(() => useQuickActionsRowViewModel(), {
-          overrideInitialState: withBackupHubOn(
-            LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION,
-          ),
+          overrideInitialState: withBackupHubOn(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION),
         });
         const recoverAction = result.current.actions.find(a => a.id === "recover")!;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPrompt.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPrompt.test.tsx
@@ -994,5 +994,4 @@ describe("NotificationsPrompt Integration", () => {
       expect(screen.getByText(/allow notifications/i)).toBeOnTheScreen();
     });
   });
-
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
@@ -113,12 +113,7 @@ export const useNotificationsDrawer = ({
         openDrawer("inactivity", 1000);
       }
     },
-    [
-      featureBrazePushNotifications?.enabled,
-      isRatingsModalOpen,
-      openDrawer,
-      checkIsInactive,
-    ],
+    [featureBrazePushNotifications?.enabled, isRatingsModalOpen, openDrawer, checkIsInactive],
   );
 
   const tryTriggerPushNotificationDrawerAfterAction = useCallback(

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBorrowSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBorrowSection/index.tsx
@@ -31,7 +31,8 @@ export const PortfolioBorrowSection = ({ onPress }: PortfolioBorrowSectionProps)
   const containerStyle = shouldDisplayOperationsList ? { paddingBottom: bottom + 24 } : undefined;
 
   return (
-    <Box style={containerStyle}
+    <Box
+      style={containerStyle}
       lx={{
         paddingTop: "s32",
         paddingHorizontal: "s16",

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendFlowTransaction.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendFlowTransaction.ts
@@ -43,7 +43,10 @@ export function useSendFlowTransaction({
     (recipient: RecipientData) => {
       if (!account || !transaction || !bridge) return;
 
-      const updates = buildRecipientTransactionPatch(transaction, recipient) as Partial<Transaction>;
+      const updates = buildRecipientTransactionPatch(
+        transaction,
+        recipient,
+      ) as Partial<Transaction>;
 
       setTransaction(bridge.updateTransaction(transaction, updates));
     },

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
@@ -129,10 +129,7 @@ export const RecipientScreenView = ({
         {isLoading && <LoadingState />}
 
         {showInitialState && clipboardAddress && (
-          <PasteFromClipboard
-            address={clipboardAddress}
-            onPaste={handlePasteFromClipboard}
-          />
+          <PasteFromClipboard address={clipboardAddress} onPaste={handlePasteFromClipboard} />
         )}
 
         {showMemo && <MemoControls vm={memoVm} />}
@@ -155,11 +152,7 @@ export const RecipientScreenView = ({
         {shouldShowErrorBanner && (
           <Box lx={{ marginHorizontal: "s8", gap: "s16" }}>
             {showBridgeSenderError && (
-              <ValidationBanner
-                type="error"
-                error={bridgeSenderError}
-                variant="sender"
-              />
+              <ValidationBanner type="error" error={bridgeSenderError} variant="sender" />
             )}
             {showSanctionedBanner && <ValidationBanner type="sanctioned" />}
             {showBridgeRecipientError && (

--- a/apps/ledger-live-mobile/src/screens/Account/__tests__/ListHeaderComponent.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/__tests__/ListHeaderComponent.test.tsx
@@ -120,7 +120,9 @@ describe("Testing ListHeaderComponent Component", () => {
     };
 
     it("should not render AccountBalanceHeader for a family without one", () => {
-      const { listHeaderComponents } = getUseListHeaderComponentsResult({} as unknown as CurrencyConfig);
+      const { listHeaderComponents } = getUseListHeaderComponentsResult(
+        {} as unknown as CurrencyConfig,
+      );
 
       expect(listHeaderComponents[7]).toBeFalsy();
     });

--- a/apps/wallet-cli/src/commands/swap/cli-swap-flow-ports.ts
+++ b/apps/wallet-cli/src/commands/swap/cli-swap-flow-ports.ts
@@ -18,7 +18,10 @@ import type {
   SignSwapEvmIntentInput,
 } from "@ledgerhq/live-common/wallet-api/Exchange/intents/index";
 import { walletCliDebug } from "../../shared/log";
-import type { SignRfqOrderIntentInput, SubmitRfqOrderIntentInput } from "@ledgerhq/live-common/wallet-api/Exchange/swapFlow/types";
+import type {
+  SignRfqOrderIntentInput,
+  SubmitRfqOrderIntentInput,
+} from "@ledgerhq/live-common/wallet-api/Exchange/swapFlow/types";
 
 export type CliInitInput = { readonly appName: string };
 
@@ -52,25 +55,30 @@ export const CLI_SWAP_FLOW_PORTS: SwapFlowPorts<CliSwapIntent, CliInitInput> = {
   buildSwapTransactionData: async ({ provider, context }) => {
     const startedAt = Date.now();
     walletCliDebug(
-      `Requesting calldata from swap-api (provider=${provider}, amountFrom=${context.amountFrom.toFixed()}, slippage=${context.slippage})…`
+      `Requesting calldata from swap-api (provider=${provider}, amountFrom=${context.amountFrom.toFixed()}, slippage=${context.slippage})…`,
     );
     try {
       const { transactionData, appName } = await buildProviderTransactionData(provider, context);
       walletCliDebug(
-        `Swap-api returned in ${Date.now() - startedAt}ms (appName=${appName}, to=${transactionData.to}, gasLimit=${transactionData.gasLimit})`
+        `Swap-api returned in ${Date.now() - startedAt}ms (appName=${appName}, to=${transactionData.to}, gasLimit=${transactionData.gasLimit})`,
       );
       return { transactionData, appName };
     } catch (err) {
       walletCliDebug(
-        `Swap-api failed after ${Date.now() - startedAt}ms — ${err instanceof Error ? `${err.name}: ${err.message}` : String(err)}`
+        `Swap-api failed after ${Date.now() - startedAt}ms — ${err instanceof Error ? `${err.name}: ${err.message}` : String(err)}`,
       );
       throw err;
     }
   },
-  createSignRfqOrderIntent: function (input: SignRfqOrderIntentInput): { intent: CliSwapIntent; initInput: CliInitInput; } {
+  createSignRfqOrderIntent: function (input: SignRfqOrderIntentInput): {
+    intent: CliSwapIntent;
+    initInput: CliInitInput;
+  } {
     throw new Error("Function not implemented.");
   },
-  createSubmitRfqOrderIntent: function (input: SubmitRfqOrderIntentInput & { initInput: CliInitInput; }): { intent: CliSwapIntent; initInput: CliInitInput; } {
+  createSubmitRfqOrderIntent: function (
+    input: SubmitRfqOrderIntentInput & { initInput: CliInitInput },
+  ): { intent: CliSwapIntent; initInput: CliInitInput } {
     throw new Error("Function not implemented.");
-  }
+  },
 };

--- a/apps/wallet-cli/src/commands/swap/cli-swap-pipeline.ts
+++ b/apps/wallet-cli/src/commands/swap/cli-swap-pipeline.ts
@@ -35,7 +35,11 @@ import {
   getSwapStepFromError,
 } from "@ledgerhq/live-common/exchange/error";
 import { WalletCliDeviceError } from "../../device/wallet-cli-device-error";
-import { trackSwapCompleted, trackSwapRejected, trackSwapStarted } from "../../analytics/swap-analytics";
+import {
+  trackSwapCompleted,
+  trackSwapRejected,
+  trackSwapStarted,
+} from "../../analytics/swap-analytics";
 
 const EXCHANGE_SWAP: ExchangeTypes.Swap = 0x00;
 const RATE_FIXED: RateTypes = 0x00;

--- a/apps/wallet-cli/src/commands/swap/quote.ts
+++ b/apps/wallet-cli/src/commands/swap/quote.ts
@@ -13,7 +13,11 @@ import {
   resolveOutputFormat,
 } from "../inputs";
 import { mapSwapQuoteLine, WALLET_CLI_DEFAULT_SWAP_PROVIDERS } from "./quote-shared";
-import { swapFlowId, trackSwapQuoteRequested, trackSwapQuoteReturned } from "../../analytics/swap-analytics";
+import {
+  swapFlowId,
+  trackSwapQuoteRequested,
+  trackSwapQuoteReturned,
+} from "../../analytics/swap-analytics";
 
 const walletCliSupportedSwapCurrencyIds = new Set<string>(WALLET_CLI_SUPPORTED_CRYPTO_CURRENCY_IDS);
 

--- a/e2e/mobile/specs/subAccount/addSubAccountWithoutParent/addSubAccountPOL_DAI.spec.ts
+++ b/e2e/mobile/specs/subAccount/addSubAccountWithoutParent/addSubAccountPOL_DAI.spec.ts
@@ -3,16 +3,7 @@ import { runAddSubAccountTest } from "../subAccount";
 const testConfig = {
   asset: TokenAccount.POL_DAI_1,
   tmslinks: ["B2CQA-2578"],
-  tags: [
-    "@NanoSP",
-    "@LNS",
-    "@NanoX",
-    "@Stax",
-    "@Flex",
-    "@NanoGen5",
-    "@polygon",
-    "@family-evm",
-  ],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@polygon", "@family-evm"],
 };
 
 runAddSubAccountTest(testConfig);

--- a/e2e/mobile/specs/subAccount/subAccountGIGA.spec.ts
+++ b/e2e/mobile/specs/subAccount/subAccountGIGA.spec.ts
@@ -10,15 +10,7 @@ const transactionE2E = [
       "noTag",
     ),
     xrayTicket: ["B2CQA-3055", "B2CQA-3057"],
-    tag: [
-      "@NanoSP",
-      "@NanoX",
-      "@Stax",
-      "@Flex",
-      "@NanoGen5",
-      "@solana",
-      "@family-solana",
-    ],
+    tag: ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@solana", "@family-solana"],
   },
 ];
 

--- a/e2e/mobile/specs/swap/swap.ts
+++ b/e2e/mobile/specs/swap/swap.ts
@@ -62,7 +62,7 @@ export function runSwapTest(
       if (app.swapLiveApp.isApprovalRequired(exchangeButtonText, provider.uiName)) {
         console.warn(
           `[swap] ${provider.uiName} requires token approval for ${accountToDebit.currency.name}; ` +
-          `skipping swap completion (covered by the token-approval spec).`,
+            `skipping swap completion (covered by the token-approval spec).`,
         );
       } else {
         await app.common.disableSynchronizationForiOS();

--- a/e2e/mobile/specs/verifyAddress/verifyAddressETH.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressETH.spec.ts
@@ -4,5 +4,15 @@ import { runVerifyAddressTest } from "./verifyAddress";
 runVerifyAddressTest(
   Account.ETH_1,
   ["B2CQA-2561", "B2CQA-2688"],
-  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@smoke", "@ethereum", "@family-evm"],
+  [
+    "@NanoSP",
+    "@LNS",
+    "@NanoX",
+    "@Stax",
+    "@Flex",
+    "@NanoGen5",
+    "@smoke",
+    "@ethereum",
+    "@family-evm",
+  ],
 );

--- a/e2e/mobile/specs/verifyAddress/verifyAddressSOL.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressSOL.spec.ts
@@ -4,14 +4,5 @@ import { runVerifyAddressTest } from "./verifyAddress";
 runVerifyAddressTest(
   Account.SOL_1,
   ["B2CQA-2563", "B2CQA-2689"],
-  [
-    "@NanoSP",
-    "@LNS",
-    "@NanoX",
-    "@Stax",
-    "@Flex",
-    "@NanoGen5",
-    "@solana",
-    "@family-solana",
-  ],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@solana", "@family-solana"],
 );

--- a/e2e/mobile/utils/initUtil.ts
+++ b/e2e/mobile/utils/initUtil.ts
@@ -18,9 +18,7 @@ import { getMergedFeatureFlags } from "./featureFlagUtils";
 
 function checkTestFailed(): void {
   if (globalThis.IS_FAILED) {
-    throw new Error(
-      "Test failed - aborting initialization to prevent orphaned Speculos instances",
-    );
+    throw new Error("Test failed - aborting initialization to prevent orphaned Speculos instances");
   }
 }
 
@@ -77,11 +75,9 @@ async function executeCliCommand(
 
 // Setup all Speculos devices in parallel for better performance.
 // If any launch fails, release the ones that already came up to avoid leaking pods.
-async function launchSpeculosDevices(
-  toStart: SpeculosAppType[],
-): Promise<Record<string, Entry>> {
+async function launchSpeculosDevices(toStart: SpeculosAppType[]): Promise<Record<string, Entry>> {
   const results = await Promise.allSettled(
-    toStart.map(async (app) => {
+    toStart.map(async app => {
       checkTestFailed();
       const device = await launchSpeculos(app.name);
       return {
@@ -101,8 +97,8 @@ async function launchSpeculosDevices(
 
   if (failures.length) {
     await Promise.all(
-      launched.map((entry) =>
-        deleteSpeculos(entry.deviceId).catch((err) =>
+      launched.map(entry =>
+        deleteSpeculos(entry.deviceId).catch(err =>
           log.warn(
             "E2E",
             `Cleanup after partial launch failure: failed to delete ${entry.deviceId}: ${sanitizeError(err)}`,
@@ -155,9 +151,7 @@ async function executeCliCommandsOnApp(
         await registerSpeculos(speculosPort);
 
         for (let i = 0; i < cmds.length; i++) {
-          log.info(
-            `  📝 [${app.name}] Executing command ${i + 1}/${cmds.length}`,
-          );
+          log.info(`  📝 [${app.name}] Executing command ${i + 1}/${cmds.length}`);
           await executeCliCommand(cmds[i], userdataPath, deviceId);
         }
 
@@ -204,9 +198,7 @@ async function setupMainSpeculosApp(
 ): Promise<void> {
   const main = entryMap[speculosApp.name];
   if (!main) {
-    throw new Error(
-      `No entry found for main speculos app: ${speculosApp.name}`,
-    );
+    throw new Error(`No entry found for main speculos app: ${speculosApp.name}`);
   }
 
   const maxRetries = 3;
@@ -218,9 +210,7 @@ async function setupMainSpeculosApp(
     attempt++;
 
     try {
-      log.info(
-        `\n🔄 [${speculosApp.name}] Main setup attempt ${attempt}/${maxRetries}`,
-      );
+      log.info(`\n🔄 [${speculosApp.name}] Main setup attempt ${attempt}/${maxRetries}`);
 
       if (isSpeculosRemote()) await waitForSpeculosReady(main.deviceId);
       await registerSpeculos(main.speculosPort);
@@ -237,9 +227,7 @@ async function setupMainSpeculosApp(
       if (attempt < maxRetries) {
         checkTestFailed();
 
-        log.info(
-          `[${speculosApp.name}] Creating new main Speculos instance for retry`,
-        );
+        log.info(`[${speculosApp.name}] Creating new main Speculos instance for retry`);
         await removeSpeculosAndDeregisterKnownSpeculos(main.deviceId);
         const device = await launchSpeculos(main.name);
 
@@ -302,9 +290,7 @@ async function executeCliCommands(
       }
 
       if (attempt < maxRetries) {
-        log.info(
-          `[Global CLI] Retrying full command run (attempt ${attempt + 1}/${maxRetries})`,
-        );
+        log.info(`[Global CLI] Retrying full command run (attempt ${attempt + 1}/${maxRetries})`);
       }
     }
   }
@@ -336,7 +322,7 @@ export class InitializationManager {
       !!speculosForSetupOnly &&
       cliCommandsOnApp.length === 0 &&
       cliCommands.length > 0 &&
-      cliCommands.every((cmd) => cmd.canUseGeneratedUserdata?.() ?? false);
+      cliCommands.every(cmd => cmd.canUseGeneratedUserdata?.() ?? false);
 
     if (skipSpeculos) {
       await executeCliCommands(cliCommands, userdataPath);
@@ -345,10 +331,7 @@ export class InitializationManager {
     }
 
     // Group commands by app name
-    const commandsByAppMap = new Map<
-      string,
-      { app: SpeculosAppType; cmds: CliCommand[] }
-    >();
+    const commandsByAppMap = new Map<string, { app: SpeculosAppType; cmds: CliCommand[] }>();
     for (const { app, cmd } of cliCommandsOnApp) {
       const existing = commandsByAppMap.get(app.name);
       if (existing) {
@@ -363,20 +346,15 @@ export class InitializationManager {
     const appsToLaunch = [
       ...new Map(
         commandsByApp
-          .map((x) => x.app)
+          .map(x => x.app)
           .concat(speculosApp ? [speculosApp] : [])
-          .map((app) => [app.name, app]),
+          .map(app => [app.name, app]),
       ).values(),
     ];
     const speculosDevices = await launchSpeculosDevices(appsToLaunch);
 
     // Execute app-specific commands with retry logic
-    await executeCliCommandsOnApp(
-      commandsByApp,
-      speculosDevices,
-      userdataPath,
-      speculosApp,
-    );
+    await executeCliCommandsOnApp(commandsByApp, speculosDevices, userdataPath, speculosApp);
 
     // Setup main Speculos app if specified
     if (speculosApp) {
@@ -388,12 +366,7 @@ export class InitializationManager {
     }
 
     // Execute global commands with internal full-run retry and Speculos re-initialization
-    await executeCliCommands(
-      cliCommands,
-      userdataPath,
-      speculosApp,
-      speculosDevices,
-    );
+    await executeCliCommands(cliCommands, userdataPath, speculosApp, speculosDevices);
 
     await InitializationManager.finalizeSetup(userdataSpeculos);
   }

--- a/libs/coin-modules/coin-canton/src/bridge/onboard.test.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/onboard.test.ts
@@ -193,7 +193,9 @@ describe("onboard", () => {
         new Error('Party with public key "pk" does not exist'),
       );
       mockedGateway.prepareOnboarding.mockRejectedValue(
-        new Error(`Party with id "${existingPartyId}" already exists and its topology is up to date`),
+        new Error(
+          `Party with id "${existingPartyId}" already exists and its topology is up to date`,
+        ),
       );
       mockedGateway.isPartyAlreadyExists.mockReturnValue(true);
 

--- a/libs/coin-modules/coin-canton/src/bridge/onboard.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/onboard.ts
@@ -50,7 +50,9 @@ export const isAccountOnboarded = async (currency: CryptoCurrency, publicKey: st
 const PARTY_ALREADY_EXISTS_ID_RE = /party with id\s+"?([^"\s]+)"?\s+already exists/i;
 
 const extractExistingPartyId = (error: unknown): string | undefined =>
-  error instanceof Error ? (error.message.match(PARTY_ALREADY_EXISTS_ID_RE)?.[1] ?? undefined) : undefined;
+  error instanceof Error
+    ? (error.message.match(PARTY_ALREADY_EXISTS_ID_RE)?.[1] ?? undefined)
+    : undefined;
 
 export const isCantonCoinPreapproved = async (currency: CryptoCurrency, partyId: string) => {
   const { expires_at, receiver } = await getTransferPreApproval(currency, partyId);

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/buildTransaction.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/buildTransaction.test.ts
@@ -444,7 +444,10 @@ describe("buildTransaction", () => {
     // The voted-groups list must be read for the vote *signer*, not the raw account,
     // otherwise the computed index wouldn't match the vote list shown in the UI.
     expect(readContractMock).toHaveBeenCalledWith(
-      expect.objectContaining({ functionName: "getGroupsVotedForByAccount", args: ["signer_account"] }),
+      expect.objectContaining({
+        functionName: "getGroupsVotedForByAccount",
+        args: ["signer_account"],
+      }),
     );
   });
 

--- a/libs/coin-modules/coin-solana/src/logic/broadcast.ts
+++ b/libs/coin-modules/coin-solana/src/logic/broadcast.ts
@@ -37,8 +37,10 @@ function classifySimulationError(err: TransactionError): Error {
       if (detail === "InsufficientFunds") return new InvalidTransactionError("Insufficient funds");
       if (detail && typeof detail === "object" && "Custom" in detail) {
         const custom = (detail as { Custom: number }).Custom;
-        if (custom === SPL_TOKEN_ACCOUNT_FROZEN) return new InvalidTransactionError("Token account frozen");
-        if (custom === SPL_TOKEN_INSUFFICIENT_FUNDS) return new InvalidTransactionError("Insufficient funds");
+        if (custom === SPL_TOKEN_ACCOUNT_FROZEN)
+          return new InvalidTransactionError("Token account frozen");
+        if (custom === SPL_TOKEN_INSUFFICIENT_FUNDS)
+          return new InvalidTransactionError("Insufficient funds");
       }
       return new InvalidTransactionError("Transaction simulation failed");
     }

--- a/libs/coin-modules/coin-solana/src/logic/tests/broadcast.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/broadcast.unit.test.ts
@@ -8,9 +8,9 @@ import {
 import type { ChainAPI } from "../../network";
 import { broadcast } from "../broadcast";
 
-jest.spyOn(VersionedTransaction, "deserialize").mockImplementation(
-  () => ({ __mocked: true }) as unknown as VersionedTransaction,
-);
+jest
+  .spyOn(VersionedTransaction, "deserialize")
+  .mockImplementation(() => ({ __mocked: true }) as unknown as VersionedTransaction);
 
 function buildApi({
   simulateValues,
@@ -61,10 +61,7 @@ describe("broadcast", () => {
       replaceRecentBlockhash: false,
       commitment: "confirmed",
     });
-    expect(sendRawTransaction).toHaveBeenCalledWith(
-      Buffer.from(txBase64, "base64"),
-      undefined,
-    );
+    expect(sendRawTransaction).toHaveBeenCalledWith(Buffer.from(txBase64, "base64"), undefined);
   });
 
   it("forwards recentBlockhash to sendRawTransaction", async () => {
@@ -76,7 +73,10 @@ describe("broadcast", () => {
 
     const result = await broadcast(api, txBase64, { recentBlockhash });
     expect(result).toBe("sig");
-    expect(sendRawTransaction).toHaveBeenCalledWith(Buffer.from(txBase64, "base64"), recentBlockhash);
+    expect(sendRawTransaction).toHaveBeenCalledWith(
+      Buffer.from(txBase64, "base64"),
+      recentBlockhash,
+    );
   });
 
   it("should throw an error if the simulation fails", async () => {

--- a/libs/coin-modules/coin-solana/src/network/chain/index.ts
+++ b/libs/coin-modules/coin-solana/src/network/chain/index.ts
@@ -270,10 +270,8 @@ export function getChainAPI(
         .then(r => r.value)
         .catch(remapErrors),
 
-    simulateTransaction: (
-      transaction: VersionedTransaction,
-      config?: SimulateTransactionConfig,
-    ) => connection.simulateTransaction(transaction, config).catch(remapErrors),
+    simulateTransaction: (transaction: VersionedTransaction, config?: SimulateTransactionConfig) =>
+      connection.simulateTransaction(transaction, config).catch(remapErrors),
 
     sendRawTransaction: (buffer: Buffer, recentBlockhash?: BlockhashWithExpiryBlockHeight) => {
       return (async () => {

--- a/libs/coin-tester-modules/coin-tester-cosmos/src/scenarii.test.ts
+++ b/libs/coin-tester-modules/coin-tester-cosmos/src/scenarii.test.ts
@@ -35,11 +35,13 @@ describe("Cosmos Tester", () => {
 // `exit` (and some signal paths) won't await pending promises, so the handler
 // must trigger teardown synchronously rather than awaiting it. Tear down both
 // devnets — whichever scenario was mid-run, its containers must not leak.
-["exit", "SIGINT", "SIGQUIT", "SIGTERM", "SIGUSR1", "SIGUSR2", "uncaughtException"].forEach(event => {
-  process.on(event, () => {
-    // Swallow rejections: a failed teardown here must not become an
-    // unhandledRejection that masks the original error.
-    void killBabylond().catch(() => {});
-    void killGaiad().catch(() => {});
-  });
-});
+["exit", "SIGINT", "SIGQUIT", "SIGTERM", "SIGUSR1", "SIGUSR2", "uncaughtException"].forEach(
+  event => {
+    process.on(event, () => {
+      // Swallow rejections: a failed teardown here must not become an
+      // unhandledRejection that masks the original error.
+      void killBabylond().catch(() => {});
+      void killGaiad().catch(() => {});
+    });
+  },
+);

--- a/libs/coin-tester-modules/coin-tester-cosmos/src/scenarii/shared.ts
+++ b/libs/coin-tester-modules/coin-tester-cosmos/src/scenarii/shared.ts
@@ -131,7 +131,9 @@ export function makeCosmosScenario(
         // Cosmos Hub, at the next epoch boundary on Babylon); once applied, the
         // LCD reflects it.
         expect(
-          currentAccount.cosmosResources.delegations.some(d => d.validatorAddress === validatorAddress),
+          currentAccount.cosmosResources.delegations.some(
+            d => d.validatorAddress === validatorAddress,
+          ),
         ).toBe(true);
         expect(currentAccount.cosmosResources.delegatedBalance.toFixed()).toBe(
           parseCurrencyUnit(unit, "100").toFixed(),

--- a/libs/coin-tester-modules/coin-tester-cosmos/src/signer.ts
+++ b/libs/coin-tester-modules/coin-tester-cosmos/src/signer.ts
@@ -27,9 +27,7 @@ type DerivedKey = { privKey: Uint8Array; compressedPubKey: Uint8Array };
 // markers before calling the signer (see signOperation.ts), so we re-apply
 // the hardening here.
 function applyCosmosHardening(path: number[]) {
-  return path.map((n, i) =>
-    i < 3 ? Slip10RawIndex.hardened(n) : Slip10RawIndex.normal(n),
-  );
+  return path.map((n, i) => (i < 3 ? Slip10RawIndex.hardened(n) : Slip10RawIndex.normal(n)));
 }
 
 // Like the device, the tester signs from a single seed for the whole run. The
@@ -45,11 +43,7 @@ export async function buildSigner(): Promise<CosmosSigner> {
   const seed = await Bip39.mnemonicToSeed(phrase);
 
   async function deriveFromNumberPath(path: number[]): Promise<DerivedKey> {
-    const { privkey } = Slip10.derivePath(
-      Slip10Curve.Secp256k1,
-      seed,
-      applyCosmosHardening(path),
-    );
+    const { privkey } = Slip10.derivePath(Slip10Curve.Secp256k1, seed, applyCosmosHardening(path));
     const { pubkey } = await Secp256k1.makeKeypair(privkey);
     return { privKey: privkey, compressedPubKey: Secp256k1.compressPubkey(pubkey) };
   }
@@ -65,10 +59,7 @@ export async function buildSigner(): Promise<CosmosSigner> {
   }
 
   return {
-    async getAddressAndPubKey(
-      path: number[],
-      hrp: string,
-    ): Promise<CosmosGetAddressAndPubKeyRes> {
+    async getAddressAndPubKey(path: number[], hrp: string): Promise<CosmosGetAddressAndPubKeyRes> {
       const { compressedPubKey } = await deriveFromNumberPath(path);
       const rawAddr = rawSecp256k1PubkeyToRawAddress(compressedPubKey);
       return {

--- a/libs/ledger-live-common/src/bridge/descriptor/send/features.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/send/features.ts
@@ -29,7 +29,7 @@ function fromDescriptor<T>(
 ): (currency: CryptoOrTokenCurrency | undefined) => T {
   return currency => {
     const d = getSendDescriptor(currency);
-    return d ? getter(d) ?? fallback : fallback;
+    return d ? (getter(d) ?? fallback) : fallback;
   };
 }
 

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/sendMaxPending.integration.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/sendMaxPending.integration.test.ts
@@ -61,7 +61,12 @@ describe("[integration] EVM send-max accounts for pending operations", () => {
       useAllAmount: true,
     } as unknown as GenericTransaction;
 
-    const intent = transactionToIntent(account, transaction, computeIntentType, craftTransactionData);
+    const intent = transactionToIntent(
+      account,
+      transaction,
+      computeIntentType,
+      craftTransactionData,
+    );
     const { amount } = await validateIntent(
       ethereum,
       intent as Parameters<typeof validateIntent>[1],

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -848,9 +848,7 @@ describe("coin-framework utils", () => {
         extractBalances({
           spendableBalance: BigNumber(8),
           balance: BigNumber(10),
-          pendingOperations: [
-            { type: "OUT", value: BigNumber(3), fee: BigNumber(1) },
-          ],
+          pendingOperations: [{ type: "OUT", value: BigNumber(3), fee: BigNumber(1) }],
         } as unknown as Account),
       ).toEqual([{ value: 10n, locked: 6n, asset: { type: "native" } }]);
 

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -180,9 +180,7 @@ export function extractBalances(
     balances.push({
       value: BigInt(subAccount.balance.toFixed()),
       asset,
-      locked: BigInt(
-        BigNumber.min(tokenReserve.plus(tokenPending), subAccount.balance).toFixed(),
-      ),
+      locked: BigInt(BigNumber.min(tokenReserve.plus(tokenPending), subAccount.balance).toFixed()),
     });
   }
 

--- a/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.test.ts
@@ -191,7 +191,10 @@ describe("getCompleteSwapHistory", () => {
 
   it("leaves finalAmount undefined for a DEX swap when the receive operation has not synced yet", async () => {
     const txHash = "0xdexpendinghash";
-    const senderParent = genAccount("dex-missing-sender", { operationsSize: 0, currency: ethereum });
+    const senderParent = genAccount("dex-missing-sender", {
+      operationsSize: 0,
+      currency: ethereum,
+    });
     const receiverParent = genAccount("dex-missing-receiver", {
       operationsSize: 0,
       currency: ethereum,

--- a/libs/ledger-live-common/src/families/celo/descriptor/feeAssets.ts
+++ b/libs/ledger-live-common/src/families/celo/descriptor/feeAssets.ts
@@ -25,10 +25,7 @@ const RESET_PATCH: TransactionPatch = {
 
 type EligibleTokenAccount = TokenAccount & { feeCurrencyName: string };
 
-function getTransactionStringField(
-  transaction: unknown,
-  key: string
-): string | null {
+function getTransactionStringField(transaction: unknown, key: string): string | null {
   if (typeof transaction !== "object" || transaction === null) return null;
   const value = Reflect.get(transaction, key);
   return typeof value === "string" ? value : null;
@@ -42,10 +39,7 @@ function getFeeCurrencyUnwrapped(transaction: unknown): string | null {
   return getTransactionStringField(transaction, "feeCurrencyUnwrapped");
 }
 
-function transformFiniteValue(
-  value: string,
-  transform: (value: BigNumber) => BigNumber
-): string {
+function transformFiniteValue(value: string, transform: (value: BigNumber) => BigNumber): string {
   if (value.trim() === "") return value;
 
   const parsed = new BigNumber(value);
@@ -60,44 +54,34 @@ function transformFiniteValue(
 const feeAssetInputValueTransform = {
   inputKeys: FEE_INPUT_KEYS,
   fromCanonicalValue: (value: string) =>
-    transformFiniteValue(value, (parsed) =>
-      parsed.dividedBy(GWEI_DIVISOR)
-    ),
+    transformFiniteValue(value, parsed => parsed.dividedBy(GWEI_DIVISOR)),
   toCanonicalValue: (value: string) =>
-    transformFiniteValue(value, (parsed) =>
-      parsed.times(GWEI_DIVISOR)
-    ),
+    transformFiniteValue(value, parsed => parsed.times(GWEI_DIVISOR)),
 };
 
 /** Token sub-accounts with a positive balance that are allowlisted as fee currencies. */
-function getEligibleTokenAccounts(
-  mainAccount: Account
-): EligibleTokenAccount[] {
+function getEligibleTokenAccounts(mainAccount: Account): EligibleTokenAccount[] {
   return (mainAccount.subAccounts ?? [])
     .filter(
       (sub): sub is TokenAccount =>
         sub.type === "TokenAccount" &&
         sub.balance.gt(0) &&
-        FEE_CURRENCY_BY_CONTRACT.has(sub.token.contractAddress.toLowerCase())
+        FEE_CURRENCY_BY_CONTRACT.has(sub.token.contractAddress.toLowerCase()),
     )
-    .map((sub) => ({
+    .map(sub => ({
       ...sub,
       feeCurrencyName:
-        FEE_CURRENCY_BY_CONTRACT.get(sub.token.contractAddress.toLowerCase())
-          ?.name ?? sub.token.name,
+        FEE_CURRENCY_BY_CONTRACT.get(sub.token.contractAddress.toLowerCase())?.name ??
+        sub.token.name,
     }));
 }
 
-function getHydratingSelectedTokenOption(
-  transaction: unknown
-): FeeAssetOption | null {
+function getHydratingSelectedTokenOption(transaction: unknown): FeeAssetOption | null {
   const selectedAccountId = getFeeCurrencyAccountId(transaction);
   const feeCurrencyUnwrapped = getFeeCurrencyUnwrapped(transaction);
   if (!selectedAccountId || !feeCurrencyUnwrapped) return null;
 
-  const feeCurrencyOption = FEE_CURRENCY_BY_CONTRACT.get(
-    feeCurrencyUnwrapped.toLowerCase()
-  );
+  const feeCurrencyOption = FEE_CURRENCY_BY_CONTRACT.get(feeCurrencyUnwrapped.toLowerCase());
   if (!feeCurrencyOption) return null;
 
   return {
@@ -131,7 +115,7 @@ export const celoFeeAssets: FeeAssetsConfig = {
 
     // Token options intentionally omit `unitLabel`: the fee input unit falls
     // back to the ticker while the value is transformed to token decimals.
-    const tokens = getEligibleTokenAccounts(mainAccount).map((token) => ({
+    const tokens = getEligibleTokenAccounts(mainAccount).map(token => ({
       id: token.id,
       ticker: token.feeCurrencyName,
       label: token.feeCurrencyName,
@@ -149,23 +133,20 @@ export const celoFeeAssets: FeeAssetsConfig = {
       return RESET_PATCH;
     }
 
-    const tokenAccount = getEligibleTokenAccounts(mainAccount).find(
-      (token) => token.id === optionId
-    );
+    const tokenAccount = getEligibleTokenAccounts(mainAccount).find(token => token.id === optionId);
     if (!tokenAccount) {
       return RESET_PATCH;
     }
 
     const matchedOption = FEE_CURRENCY_BY_CONTRACT.get(
-      tokenAccount.token.contractAddress.toLowerCase()
+      tokenAccount.token.contractAddress.toLowerCase(),
     );
     if (!matchedOption) {
       return RESET_PATCH;
     }
 
     return {
-      feeCurrency:
-        matchedOption.adapterAddress ?? matchedOption.contractAddress ?? null,
+      feeCurrency: matchedOption.adapterAddress ?? matchedOption.contractAddress ?? null,
       feeCurrencyUnwrapped: matchedOption.contractAddress ?? null,
       feeCurrencyAccountId: tokenAccount.id,
     };
@@ -177,7 +158,7 @@ export const celoFeeAssets: FeeAssetsConfig = {
     // Sub-accounts may still be hydrating: don't reset while we can't tell.
     if (mainAccount.subAccounts === undefined) return null;
     const stillSelectable = getEligibleTokenAccounts(mainAccount).some(
-      (token) => token.id === feeCurrencyAccountId
+      token => token.id === feeCurrencyAccountId,
     );
     return stillSelectable ? null : RESET_PATCH;
   },

--- a/libs/ledger-live-common/src/families/sui/react.test.ts
+++ b/libs/ledger-live-common/src/families/sui/react.test.ts
@@ -48,7 +48,12 @@ const makeAccount = (operations: unknown[] = []): SuiAccount =>
   ({ type: "Account", operations }) as unknown as SuiAccount;
 
 const stakingOp = (extra: Record<string, unknown>, hash = DIGEST) =>
-  ({ id: "op", hash, type: "DELEGATE" as OperationType, extra }) as unknown as SuiAccount["operations"][number];
+  ({
+    id: "op",
+    hash,
+    type: "DELEGATE" as OperationType,
+    extra,
+  }) as unknown as SuiAccount["operations"][number];
 
 describe("useGetExtraDetails", () => {
   beforeEach(() => {
@@ -58,9 +63,7 @@ describe("useGetExtraDetails", () => {
   });
 
   it("synced fast-path: resolves amount/address/name from op.extra without fetching", () => {
-    const account = makeAccount([
-      stakingOp({ validatorAddress: VALIDATOR, stakedAmount: STAKED }),
-    ]);
+    const account = makeAccount([stakingOp({ validatorAddress: VALIDATOR, stakedAmount: STAKED })]);
 
     const { result } = renderHook(() => useGetExtraDetails(account, "DELEGATE", DIGEST));
 
@@ -70,9 +73,7 @@ describe("useGetExtraDetails", () => {
 
   it("leaves name undefined when the validator is absent from preload", () => {
     const unknown = "0xunknown";
-    const account = makeAccount([
-      stakingOp({ validatorAddress: unknown, stakedAmount: STAKED }),
-    ]);
+    const account = makeAccount([stakingOp({ validatorAddress: unknown, stakedAmount: STAKED })]);
 
     const { result } = renderHook(() => useGetExtraDetails(account, "DELEGATE", DIGEST));
 

--- a/libs/ledger-live-common/src/flows/send/__tests__/utils.test.ts
+++ b/libs/ledger-live-common/src/flows/send/__tests__/utils.test.ts
@@ -1,4 +1,8 @@
-import { getRecipientDisplayValue, getRecipientSearchPrefillValue, saveRecentSendRecipient } from "../utils";
+import {
+  getRecipientDisplayValue,
+  getRecipientSearchPrefillValue,
+  saveRecentSendRecipient,
+} from "../utils";
 import { getMainAccount, getRecentAddressesStore } from "../../../account/index";
 import type { Transaction } from "../../../coin-modules/transaction-types";
 
@@ -22,11 +26,9 @@ describe("saveRecentSendRecipient", () => {
   });
 
   it("should persist the recipient after broadcast", () => {
-    saveRecentSendRecipient(
-      { type: "Account", id: "eth-account" } as never,
-      null,
-      { recipient: "0xrecipient" } as Transaction,
-    );
+    saveRecentSendRecipient({ type: "Account", id: "eth-account" } as never, null, {
+      recipient: "0xrecipient",
+    } as Transaction);
 
     expect(addAddress).toHaveBeenCalledWith("ethereum", "0xrecipient", undefined);
   });
@@ -46,11 +48,9 @@ describe("saveRecentSendRecipient", () => {
   });
 
   it("should skip empty recipients", () => {
-    saveRecentSendRecipient(
-      { type: "Account", id: "eth-account" } as never,
-      null,
-      { recipient: "   " } as Transaction,
-    );
+    saveRecentSendRecipient({ type: "Account", id: "eth-account" } as never, null, {
+      recipient: "   ",
+    } as Transaction);
 
     expect(addAddress).not.toHaveBeenCalled();
   });

--- a/libs/ledger-live-common/src/flows/send/customFees/hooks/__tests__/useCustomFeesViewModelCore.test.ts
+++ b/libs/ledger-live-common/src/flows/send/customFees/hooks/__tests__/useCustomFeesViewModelCore.test.ts
@@ -6,10 +6,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { BigNumber } from "bignumber.js";
 import type { Account } from "@ledgerhq/types-live";
 import type { CryptoCurrency, Currency } from "@ledgerhq/types-cryptoassets";
-import type {
-  Transaction,
-  TransactionStatus,
-} from "../../../../../coin-modules/transaction-types";
+import type { Transaction, TransactionStatus } from "../../../../../coin-modules/transaction-types";
 import type { SendFlowTransactionActions } from "../../../types";
 import { useCustomFeesViewModelCore } from "../useCustomFeesViewModelCore";
 import { useBridgeFeeEstimation } from "../useBridgeFeeEstimation";
@@ -17,10 +14,8 @@ import { getAccountBridge } from "../../../../../bridge/impl";
 
 const feeAssetInputValueTransform = {
   inputKeys: ["fees"],
-  fromCanonicalValue: (value: string) =>
-    new BigNumber(value).dividedBy("1e9").toFixed(),
-  toCanonicalValue: (value: string) =>
-    new BigNumber(value).times("1e9").toFixed(),
+  fromCanonicalValue: (value: string) => new BigNumber(value).dividedBy("1e9").toFixed(),
+  toCanonicalValue: (value: string) => new BigNumber(value).times("1e9").toFixed(),
 };
 
 const customFeeConfig = {
@@ -76,8 +71,7 @@ jest.mock("../../../../../bridge/descriptor/send/features", () => ({
 jest.mock("../../../../../bridge/impl");
 
 const mockedGetAccountBridge = jest.mocked(getAccountBridge);
-const flushBridgeEstimation = () =>
-  new Promise<void>((resolve) => setTimeout(resolve, 0));
+const flushBridgeEstimation = () => new Promise<void>(resolve => setTimeout(resolve, 0));
 
 const celoCurrency = {
   id: "celo",
@@ -148,15 +142,12 @@ function createTransactionActions(): SendFlowTransactionActions {
 }
 
 const labels = {
-  getInputLabel: (_inputKey: string, unit: string | undefined) =>
-    `Fees amount (${unit})`,
+  getInputLabel: (_inputKey: string, unit: string | undefined) => `Fees amount (${unit})`,
   getHelperLabel: () => null,
-  getNetworkFeesInFiatLabel: (currencyTicker: string) =>
-    `Network fees in ${currencyTicker}`,
+  getNetworkFeesInFiatLabel: (currencyTicker: string) => `Network fees in ${currencyTicker}`,
   invalidValue: "Enter a valid number",
   belowMinimum: (min: string) => `Minimum is ${min}`,
-  maxFeeBelowPriorityFee:
-    "Max fee must be greater than or equal to max priority fee",
+  maxFeeBelowPriorityFee: "Max fee must be greater than or equal to max priority fee",
   insufficientBalanceFees: "Insufficient balance for fees",
   confirm: "Confirm",
   suggested: "Suggested",
@@ -167,15 +158,11 @@ describe("useCustomFeesViewModelCore", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedGetAccountBridge.mockResolvedValue({
-      updateTransaction: jest.fn(
-        (tx: Transaction, patch: Partial<Transaction>) => ({
-          ...tx,
-          ...patch,
-        })
-      ),
-      prepareTransaction: jest.fn(
-        async (_account: Account, tx: Transaction) => tx
-      ),
+      updateTransaction: jest.fn((tx: Transaction, patch: Partial<Transaction>) => ({
+        ...tx,
+        ...patch,
+      })),
+      prepareTransaction: jest.fn(async (_account: Account, tx: Transaction) => tx),
       getTransactionStatus: jest.fn(async () => ({
         errors: {},
         estimatedFees: new BigNumber("2006769"),
@@ -187,7 +174,7 @@ describe("useCustomFeesViewModelCore", () => {
     const transaction = createTransaction();
     const transactionActions = createTransactionActions();
     const calculateCountervalue = jest.fn((_from: Currency, value: BigNumber) =>
-      value.eq("2006769") ? new BigNumber("175") : new BigNumber(0)
+      value.eq("2006769") ? new BigNumber("175") : new BigNumber(0),
     );
 
     const { result } = renderHook(() =>
@@ -203,7 +190,7 @@ describe("useCustomFeesViewModelCore", () => {
         counterValueCurrency: usdCurrency,
         calculateCountervalue,
         labels,
-      })
+      }),
     );
 
     expect(result.current.inputs[0]).toMatchObject({
@@ -222,7 +209,7 @@ describe("useCustomFeesViewModelCore", () => {
     await waitFor(() => {
       expect(calculateCountervalue).toHaveBeenCalledWith(
         expect.objectContaining({ ticker: "USDT" }),
-        new BigNumber("2006769")
+        new BigNumber("2006769"),
       );
     });
 
@@ -238,8 +225,7 @@ describe("useCustomFeesViewModelCore", () => {
       result.current.onConfirm();
     });
 
-    const updater = (transactionActions.updateTransaction as jest.Mock).mock
-      .calls[0][0];
+    const updater = (transactionActions.updateTransaction as jest.Mock).mock.calls[0][0];
     const nextTransaction = updater(transaction);
 
     expect(nextTransaction.feesStrategy).toBe("custom");
@@ -258,15 +244,11 @@ describe("useCustomFeesViewModelCore", () => {
         estimatedFees: new BigNumber("3006769"),
       });
     mockedGetAccountBridge.mockResolvedValue({
-      updateTransaction: jest.fn(
-        (tx: Transaction, patch: Partial<Transaction>) => ({
-          ...tx,
-          ...patch,
-        })
-      ),
-      prepareTransaction: jest.fn(
-        async (_account: Account, tx: Transaction) => tx
-      ),
+      updateTransaction: jest.fn((tx: Transaction, patch: Partial<Transaction>) => ({
+        ...tx,
+        ...patch,
+      })),
+      prepareTransaction: jest.fn(async (_account: Account, tx: Transaction) => tx),
       getTransactionStatus,
     } as never);
 
@@ -290,7 +272,7 @@ describe("useCustomFeesViewModelCore", () => {
           estimatedFeesFromInputs: null,
           customFeeConfig,
         }),
-      { initialProps: { tx: transaction } }
+      { initialProps: { tx: transaction } },
     );
 
     await act(async () => {
@@ -321,15 +303,11 @@ describe("useCustomFeesViewModelCore", () => {
 
   it("should ignore previous bridge insufficient balance when local fee estimation is available", async () => {
     mockedGetAccountBridge.mockResolvedValue({
-      updateTransaction: jest.fn(
-        (tx: Transaction, patch: Partial<Transaction>) => ({
-          ...tx,
-          ...patch,
-        })
-      ),
-      prepareTransaction: jest.fn(
-        async (_account: Account, tx: Transaction) => tx
-      ),
+      updateTransaction: jest.fn((tx: Transaction, patch: Partial<Transaction>) => ({
+        ...tx,
+        ...patch,
+      })),
+      prepareTransaction: jest.fn(async (_account: Account, tx: Transaction) => tx),
       getTransactionStatus: jest.fn(async () => ({
         errors: { insufficientBalanceFees: new Error("Insufficient balance") },
         estimatedFees: new BigNumber("2020160084"),
@@ -367,7 +345,7 @@ describe("useCustomFeesViewModelCore", () => {
           tx: transaction,
           estimatedFeesFromInputs: null as BigNumber | null,
         },
-      }
+      },
     );
 
     await act(async () => {

--- a/libs/ledger-live-common/src/flows/send/customFees/utils/__tests__/customFeeUtils.test.ts
+++ b/libs/ledger-live-common/src/flows/send/customFees/utils/__tests__/customFeeUtils.test.ts
@@ -1,12 +1,9 @@
 import { isValidNumberForInput } from "../customFeeUtils";
 
 describe("isValidNumberForInput", () => {
-  it.each(["Infinity", "-Infinity", "NaN"])(
-    "rejects non-finite values for fee inputs",
-    (value) => {
-      expect(isValidNumberForInput("fees", value)).toBe(false);
-    },
-  );
+  it.each(["Infinity", "-Infinity", "NaN"])("rejects non-finite values for fee inputs", value => {
+    expect(isValidNumberForInput("fees", value)).toBe(false);
+  });
 
   it("accepts positive finite values", () => {
     expect(isValidNumberForInput("fees", "1.5")).toBe(true);

--- a/libs/ledger-live-common/src/flows/send/utils/networkFeesDisplay.ts
+++ b/libs/ledger-live-common/src/flows/send/utils/networkFeesDisplay.ts
@@ -20,8 +20,7 @@ export function resolveFeeDisplayContext(params: {
 }): FeeDisplayContext {
   const feeCurrencySubAccount = params.feeCurrencyAccountId
     ? ((params.mainAccount.subAccounts ?? []).find(
-        (sub): sub is TokenAccount =>
-          sub.id === params.feeCurrencyAccountId && isTokenAccount(sub),
+        (sub): sub is TokenAccount => sub.id === params.feeCurrencyAccountId && isTokenAccount(sub),
       ) ?? null)
     : null;
 

--- a/libs/ledger-live-common/src/wallet-api/Exchange/dex/index.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/dex/index.ts
@@ -5,14 +5,8 @@
  * and sign it through the device intent stack without going back to the
  * live-app.
  */
-export {
-  buildProviderTransactionData,
-  isDexExecutionProvider,
-} from "./dexDataBuilders";
-export {
-  DEFAULT_DEX_GAS_LIMIT,
-  DEFAULT_DEX_GAS_LIMIT_MULTIPLIER,
-} from "./constants";
+export { buildProviderTransactionData, isDexExecutionProvider } from "./dexDataBuilders";
+export { DEFAULT_DEX_GAS_LIMIT, DEFAULT_DEX_GAS_LIMIT_MULTIPLIER } from "./constants";
 export { getAdjustedGasLimit } from "./gasLimitAdjusted";
 export type {
   DexBuildContext,

--- a/libs/ledger-live-common/src/wallet-api/Exchange/dex/swap-api/okx.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/dex/swap-api/okx.ts
@@ -17,9 +17,7 @@ export interface OkxSwapInput {
  * Fetches OKX DEX calldata. OKX forwards the opaque `customFields` blob
  * straight through, mirroring the live-app behaviour.
  */
-export const getOkxTransaction = async (
-  input: OkxSwapInput,
-): Promise<OkxSwapResponse> => {
+export const getOkxTransaction = async (input: OkxSwapInput): Promise<OkxSwapResponse> => {
   const baseURL = getSwapAPIBaseURL();
   const response = await network<{ swapResponse: OkxSwapResponse }>({
     method: "POST",

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/index.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/index.ts
@@ -6,10 +6,7 @@
  * platform-specific React components live alongside their callers (LWM
  * under `apps/ledger-live-mobile`, LWD under `apps/ledger-live-desktop`).
  */
-export {
-  signApprovalEvmIntentDefinition,
-  signApprovalEvmJob,
-} from "./signApprovalEvm";
+export { signApprovalEvmIntentDefinition, signApprovalEvmJob } from "./signApprovalEvm";
 export type {
   SignApprovalEvmIntentDefinition,
   SignApprovalEvmIntentInput,
@@ -53,10 +50,7 @@ export type {
   SignRfqOrderEvmJobState,
 } from "./signRfqOrderEvm";
 
-export {
-  submitRfqOrderEvmIntentDefinition,
-  submitRfqOrderEvmJob,
-} from "./submitRfqOrderEvm";
+export { submitRfqOrderEvmIntentDefinition, submitRfqOrderEvmJob } from "./submitRfqOrderEvm";
 export type {
   SubmitRfqOrderEvmIntentDefinition,
   SubmitRfqOrderEvmIntentInput,

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/shared/mapDmkSignerError.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/shared/mapDmkSignerError.test.ts
@@ -23,9 +23,7 @@ describe("mapDmkSignerError", () => {
         "Sign approval failed",
       );
       expect(result).toBeInstanceOf(UserRefusedOnDevice);
-      expect(result.message).toBe(
-        "EthAppCommandError (code: 6985) - Condition not satisfied",
-      );
+      expect(result.message).toBe("EthAppCommandError (code: 6985) - Condition not satisfied");
     });
 
     it("returns EthAppPleaseEnableContractData for SW 6a80, carrying the DMK-sourced message", () => {
@@ -34,9 +32,7 @@ describe("mapDmkSignerError", () => {
         "Sign approval failed",
       );
       expect(result).toBeInstanceOf(EthAppPleaseEnableContractData);
-      expect(result.message).toBe(
-        "EthAppCommandError (code: 6a80) - Invalid data",
-      );
+      expect(result.message).toBe("EthAppCommandError (code: 6a80) - Invalid data");
     });
   });
 
@@ -74,9 +70,7 @@ describe("mapDmkSignerError", () => {
         { errorCode: "6800", message: "Internal error" },
         "Sign approval failed",
       );
-      expect(result.message).toBe(
-        "Sign approval failed (code: 6800) - Internal error",
-      );
+      expect(result.message).toBe("Sign approval failed (code: 6800) - Internal error");
     });
 
     it("uses just _tag when no errorCode or message is present (UnknownDeviceExchangeError shape)", () => {

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/shared/signTypedDataEvm.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/shared/signTypedDataEvm.ts
@@ -1,10 +1,7 @@
 import { defer, of, type Observable } from "rxjs";
 import { catchError, filter, finalize, map } from "rxjs/operators";
 import { Signature as EthersSignature } from "ethers";
-import {
-  DeviceActionStatus,
-  UserInteractionRequired,
-} from "@ledgerhq/device-management-kit";
+import { DeviceActionStatus, UserInteractionRequired } from "@ledgerhq/device-management-kit";
 import { SignTypedDataDAStateStep } from "@ledgerhq/device-signer-kit-ethereum";
 import type { DeviceConnectionResult } from "@ledgerhq/device-intent";
 import type { EIP712Message } from "@ledgerhq/types-live";
@@ -48,11 +45,9 @@ export function runSignTypedDataEvm(
     // filters load on-device (Permit2 spender, token symbols, …)
     // instead of falling back to blind signing.
     const signer = new DmkSignerEth(dmk, sessionId).signer;
-    const { observable, cancel } = signer.signTypedData(
-      derivationPath,
-      typedData,
-      { skipOpenApp: true },
-    );
+    const { observable, cancel } = signer.signTypedData(derivationPath, typedData, {
+      skipOpenApp: true,
+    });
 
     return observable.pipe(
       finalize(cancel),

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/signPermit2Evm/job.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/signPermit2Evm/job.test.ts
@@ -36,9 +36,7 @@ beforeEach(() => {
 describe("signPermit2EvmJob", () => {
   it("prepends `preparing` and forwards Permit2 input to the shared typed-data signer", async () => {
     const failure = { type: "failed", error: new Error("boom") } as const;
-    runSignTypedDataEvm.mockReturnValueOnce(
-      of<SignTypedDataEvmRunState>(failure),
-    );
+    runSignTypedDataEvm.mockReturnValueOnce(of<SignTypedDataEvmRunState>(failure));
 
     const states = await lastValueFrom(run().pipe(toArray()));
     const [connection, typedData, path, errorLabel] = runSignTypedDataEvm.mock.calls[0];

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/signPermit2Evm/job.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/signPermit2Evm/job.ts
@@ -1,10 +1,7 @@
 import { concat, of } from "rxjs";
 import type { Job } from "@ledgerhq/device-intent";
 import { runSignTypedDataEvm } from "../shared/signTypedDataEvm";
-import type {
-  SignPermit2EvmIntentInput,
-  SignPermit2EvmJobState,
-} from "./types";
+import type { SignPermit2EvmIntentInput, SignPermit2EvmJobState } from "./types";
 
 /**
  * Job for the Permit2 EIP-712 signing intent.
@@ -20,10 +17,10 @@ import type {
  * states into `SignPermit2EvmJobState` and prepends the synchronous
  * `preparing` value the executor expects.
  */
-export const signPermit2EvmJob: Job<
-  SignPermit2EvmJobState,
-  SignPermit2EvmIntentInput
-> = ({ deviceConnectionResult, input }) =>
+export const signPermit2EvmJob: Job<SignPermit2EvmJobState, SignPermit2EvmIntentInput> = ({
+  deviceConnectionResult,
+  input,
+}) =>
   concat(
     of<SignPermit2EvmJobState>({ type: "preparing" }),
     runSignTypedDataEvm(

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/signRfqOrderEvm/intentDefinition.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/signRfqOrderEvm/intentDefinition.ts
@@ -9,10 +9,9 @@ import type { SignRfqOrderEvmIntentDefinition } from "./types";
  * the device-action's own UI states can be surfaced through
  * {@link SignRfqOrderEvmJobState}.
  */
-export const signRfqOrderEvmIntentDefinition: SignRfqOrderEvmIntentDefinition =
-  {
-    label: "Sign EVM RFQ order typed data",
-    requiresConnectedDevice: true,
-    delegateDeviceLockStateHandlingToExecutor: false,
-    job: signRfqOrderEvmJob,
-  };
+export const signRfqOrderEvmIntentDefinition: SignRfqOrderEvmIntentDefinition = {
+  label: "Sign EVM RFQ order typed data",
+  requiresConnectedDevice: true,
+  delegateDeviceLockStateHandlingToExecutor: false,
+  job: signRfqOrderEvmJob,
+};

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/signRfqOrderEvm/job.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/signRfqOrderEvm/job.test.ts
@@ -36,9 +36,7 @@ beforeEach(() => {
 describe("signRfqOrderEvmJob", () => {
   it("prepends `preparing` and forwards RFQ input to the shared typed-data signer", async () => {
     const failure = { type: "failed", error: new Error("boom") } as const;
-    runSignTypedDataEvm.mockReturnValueOnce(
-      of<SignTypedDataEvmRunState>(failure),
-    );
+    runSignTypedDataEvm.mockReturnValueOnce(of<SignTypedDataEvmRunState>(failure));
 
     const states = await lastValueFrom(run().pipe(toArray()));
     const [connection, typedData, path, errorLabel] = runSignTypedDataEvm.mock.calls[0];

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/signRfqOrderEvm/job.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/signRfqOrderEvm/job.ts
@@ -1,10 +1,7 @@
 import { concat, of } from "rxjs";
 import type { Job } from "@ledgerhq/device-intent";
 import { runSignTypedDataEvm } from "../shared/signTypedDataEvm";
-import type {
-  SignRfqOrderEvmIntentInput,
-  SignRfqOrderEvmJobState,
-} from "./types";
+import type { SignRfqOrderEvmIntentInput, SignRfqOrderEvmJobState } from "./types";
 
 /**
  * Job for the RFQ order EIP-712 signing intent (UniswapX, 1inch Fusion).
@@ -19,10 +16,10 @@ import type {
  * device errors into a terminal `failed` state instead of an observable
  * error so the orchestrator can react in `onIntentJobComplete`.
  */
-export const signRfqOrderEvmJob: Job<
-  SignRfqOrderEvmJobState,
-  SignRfqOrderEvmIntentInput
-> = ({ deviceConnectionResult, input }) =>
+export const signRfqOrderEvmJob: Job<SignRfqOrderEvmJobState, SignRfqOrderEvmIntentInput> = ({
+  deviceConnectionResult,
+  input,
+}) =>
   concat(
     of<SignRfqOrderEvmJobState>({ type: "preparing" }),
     runSignTypedDataEvm(

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/signRfqOrderEvm/rfqTypedData.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/signRfqOrderEvm/rfqTypedData.test.ts
@@ -44,10 +44,7 @@ describe("toRfqEIP712Message", () => {
   });
 
   it("preserves the provider-supplied primaryType for 1inch Fusion", () => {
-    const result = toRfqEIP712Message(
-      ONEINCH_FUSION_TYPED_DATA,
-      "oneinchfusion",
-    );
+    const result = toRfqEIP712Message(ONEINCH_FUSION_TYPED_DATA, "oneinchfusion");
     expect(result.primaryType).toBe("Order");
   });
 
@@ -57,10 +54,7 @@ describe("toRfqEIP712Message", () => {
   });
 
   it("reads message from `message` (1inch Fusion) when `values` is absent", () => {
-    const result = toRfqEIP712Message(
-      ONEINCH_FUSION_TYPED_DATA,
-      "oneinchfusion",
-    );
+    const result = toRfqEIP712Message(ONEINCH_FUSION_TYPED_DATA, "oneinchfusion");
     expect(result.message).toEqual(BASE_VALUES);
   });
 
@@ -104,28 +98,19 @@ describe("toRfqEIP712Message", () => {
 
   it("throws when the payload is missing both `values` and `message`", () => {
     expect(() =>
-      toRfqEIP712Message(
-        { domain: BASE_DOMAIN, types: BASE_TYPES },
-        "uniswapx",
-      ),
+      toRfqEIP712Message({ domain: BASE_DOMAIN, types: BASE_TYPES }, "uniswapx"),
     ).toThrow(/values/);
   });
 
   it("throws when the payload is missing the domain", () => {
     expect(() =>
-      toRfqEIP712Message(
-        { values: BASE_VALUES, types: BASE_TYPES },
-        "uniswapx",
-      ),
+      toRfqEIP712Message({ values: BASE_VALUES, types: BASE_TYPES }, "uniswapx"),
     ).toThrow(/domain/);
   });
 
   it("throws when the payload is missing the types", () => {
     expect(() =>
-      toRfqEIP712Message(
-        { values: BASE_VALUES, domain: BASE_DOMAIN },
-        "uniswapx",
-      ),
+      toRfqEIP712Message({ values: BASE_VALUES, domain: BASE_DOMAIN }, "uniswapx"),
     ).toThrow(/types/);
   });
 

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/signRfqOrderEvm/rfqTypedData.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/signRfqOrderEvm/rfqTypedData.ts
@@ -48,14 +48,9 @@ export function toRfqEIP712Message(
     throw new Error("RFQ typedData is missing `types`");
   }
 
-  const primaryType =
-    provider === "uniswapx"
-      ? "PermitWitnessTransferFrom"
-      : typedData.primaryType;
+  const primaryType = provider === "uniswapx" ? "PermitWitnessTransferFrom" : typedData.primaryType;
   if (!primaryType) {
-    throw new Error(
-      "RFQ typedData is missing `primaryType` (1inch-fusion must ship one)",
-    );
+    throw new Error("RFQ typedData is missing `primaryType` (1inch-fusion must ship one)");
   }
 
   // Layer the partner-provided `types` over the canonical Permit2

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/submitRfqOrderEvm/intentDefinition.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/submitRfqOrderEvm/intentDefinition.ts
@@ -10,10 +10,9 @@ import type { SubmitRfqOrderEvmIntentDefinition } from "./types";
  * UI can render a "submitting / waiting" loader while the partner fills
  * the order.
  */
-export const submitRfqOrderEvmIntentDefinition: SubmitRfqOrderEvmIntentDefinition =
-  {
-    label: "Submit RFQ order to partner",
-    requiresConnectedDevice: false,
-    delegateDeviceLockStateHandlingToExecutor: false,
-    job: submitRfqOrderEvmJob,
-  };
+export const submitRfqOrderEvmIntentDefinition: SubmitRfqOrderEvmIntentDefinition = {
+  label: "Submit RFQ order to partner",
+  requiresConnectedDevice: false,
+  delegateDeviceLockStateHandlingToExecutor: false,
+  job: submitRfqOrderEvmJob,
+};

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/submitRfqOrderEvm/job.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/submitRfqOrderEvm/job.test.ts
@@ -1,13 +1,7 @@
 import { firstValueFrom, lastValueFrom, toArray } from "rxjs";
-import type {
-  DeviceConnectionResult,
-  DeviceExtractedContext,
-} from "@ledgerhq/device-intent";
+import type { DeviceConnectionResult, DeviceExtractedContext } from "@ledgerhq/device-intent";
 import { submitRfqOrderEvmJob } from "./job";
-import type {
-  SubmitRfqOrderEvmIntentInput,
-  SubmitRfqOrderEvmJobState,
-} from "./types";
+import type { SubmitRfqOrderEvmIntentInput, SubmitRfqOrderEvmJobState } from "./types";
 
 const FAKE_DEVICE_CONNECTION = {} as DeviceConnectionResult;
 const FAKE_DEVICE_CONTEXT = {} as DeviceExtractedContext;
@@ -96,10 +90,7 @@ describe("submitRfqOrderEvmJob", () => {
   });
 
   it("prefers the precomputed order id over the submit response", async () => {
-    const { fetchImpl, calls } = makeFetch([
-      { body: {} },
-      { body: [{ status: "finished" }] },
-    ]);
+    const { fetchImpl, calls } = makeFetch([{ body: {} }, { body: [{ status: "finished" }] }]);
     const states = await collectStates({
       ...BASE_INPUT,
       provider: "oneinchfusion",

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/submitRfqOrderEvm/job.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/submitRfqOrderEvm/job.ts
@@ -26,11 +26,7 @@ const DEFAULT_MAX_POLL_ATTEMPTS = 60;
  * cannot be redirected to an arbitrary route via the wallet-api input
  * (CodeQL SSRF guard).
  */
-const ALLOWED_RFQ_PROVIDERS = new Set<string>([
-  "uniswap",
-  "oneinch",
-  "oneinchfusion",
-]);
+const ALLOWED_RFQ_PROVIDERS = new Set<string>(["uniswap", "oneinch", "oneinchfusion"]);
 
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -86,14 +82,11 @@ function buildSubmitObservable(
           `Unsupported RFQ provider "${input.provider}" — refusing to issue swap-api submit request`,
         );
       }
-      const submitResponse = await fetchImpl(
-        `${baseURL}/${input.provider}/submit`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(input.submitBody),
-        },
-      );
+      const submitResponse = await fetchImpl(`${baseURL}/${input.provider}/submit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input.submitBody),
+      });
       if (cancelled) return;
       if (!submitResponse.ok) {
         throw new Error(
@@ -103,12 +96,9 @@ function buildSubmitObservable(
       const submitJson = (await submitResponse.json()) as SubmitResponse;
       if (cancelled) return;
 
-      const orderId =
-        input.precomputedOrderId ?? extractOrderId(submitJson);
+      const orderId = input.precomputedOrderId ?? extractOrderId(submitJson);
       if (!orderId) {
-        throw new Error(
-          "RFQ submit did not return an order id and no precomputed id was provided",
-        );
+        throw new Error("RFQ submit did not return an order id and no precomputed id was provided");
       }
       subscriber.next({ type: "submitted", orderId });
 
@@ -159,9 +149,7 @@ function buildSubmitObservable(
 
       subscriber.next({
         type: "failed",
-        error: new Error(
-          `RFQ order ${orderId} did not resolve after ${maxAttempts} attempts`,
-        ),
+        error: new Error(`RFQ order ${orderId} did not resolve after ${maxAttempts} attempts`),
       });
       subscriber.complete();
     })().catch(err => {
@@ -193,10 +181,9 @@ function buildSubmitObservable(
  * the observable always completes cleanly so the orchestrator can react
  * in `onIntentJobComplete`.
  */
-export const submitRfqOrderEvmJob: Job<
-  SubmitRfqOrderEvmJobState,
-  SubmitRfqOrderEvmIntentInput
-> = ({ input }) =>
+export const submitRfqOrderEvmJob: Job<SubmitRfqOrderEvmJobState, SubmitRfqOrderEvmIntentInput> = ({
+  input,
+}) =>
   concat(
     of<SubmitRfqOrderEvmJobState>({ type: "submitting" }),
     buildSubmitObservable(input).pipe(

--- a/libs/ledger-live-common/src/wallet-api/Exchange/swapFlow/machine.rfq.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/swapFlow/machine.rfq.test.ts
@@ -1,11 +1,7 @@
 import { createActor } from "xstate";
 import type { Account, EIP712Message } from "@ledgerhq/types-live";
 import { createSwapFlowMachine } from "./machine";
-import type {
-  SwapFlowPlan,
-  SwapFlowPorts,
-  SwapFlowResolvers,
-} from "./types";
+import type { SwapFlowPlan, SwapFlowPorts, SwapFlowResolvers } from "./types";
 
 type TestIntent = { kind: string };
 type TestInitInput = { appName: string };
@@ -50,10 +46,7 @@ const RFQ_PLAN: Extract<SwapFlowPlan, { kind: "rfq-order" }> = {
   network: "ethereum",
 };
 
-const APPROVAL_THEN_RFQ_PLAN: Extract<
-  SwapFlowPlan,
-  { kind: "approval-then-rfq-order" }
-> = {
+const APPROVAL_THEN_RFQ_PLAN: Extract<SwapFlowPlan, { kind: "approval-then-rfq-order" }> = {
   kind: "approval-then-rfq-order",
   approvalTransaction: APPROVAL_TX,
   rfqProvider: "uniswapx",

--- a/libs/ledger-live-common/src/wallet-api/Exchange/swapFlow/planSwapFlow.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/swapFlow/planSwapFlow.test.ts
@@ -35,19 +35,21 @@ const PERMIT_TYPED_DATA: QuotePermit2Message = {
   primaryType: "PermitSingle",
 };
 
-function makeQuote(overrides: {
-  provider?: string;
-  providerType?: "DEX" | "CEX";
-  isUniswapX?: boolean;
-  isTokenApprovalRequired?: boolean;
-  isApproved?: boolean;
-  hasApprovalBlob?: boolean;
-  permitTypedData?: QuotePermit2Message | null;
-  permitOrderHash?: string;
-  customFields?: Record<string, unknown>;
-  approvedAmount?: string;
-  sendAmount?: number;
-} = {}): Quote {
+function makeQuote(
+  overrides: {
+    provider?: string;
+    providerType?: "DEX" | "CEX";
+    isUniswapX?: boolean;
+    isTokenApprovalRequired?: boolean;
+    isApproved?: boolean;
+    hasApprovalBlob?: boolean;
+    permitTypedData?: QuotePermit2Message | null;
+    permitOrderHash?: string;
+    customFields?: Record<string, unknown>;
+    approvedAmount?: string;
+    sendAmount?: number;
+  } = {},
+): Quote {
   const {
     provider = "uniswap",
     providerType = "DEX",
@@ -233,9 +235,7 @@ describe("planSwapFlow", () => {
       if (result.kind === "rfq-order") {
         expect(result.rfqProvider).toBe("uniswapx");
         expect(result.provider).toBe("uniswap");
-        expect(result.orderTypedData.primaryType).toBe(
-          "PermitWitnessTransferFrom",
-        );
+        expect(result.orderTypedData.primaryType).toBe("PermitWitnessTransferFrom");
       }
     });
 

--- a/libs/ledger-live-common/src/wallet-api/Exchange/swapFlow/planSwapFlow.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/swapFlow/planSwapFlow.ts
@@ -2,14 +2,8 @@ import BigNumber from "bignumber.js";
 import type { EIP712Message } from "@ledgerhq/types-live";
 import { isDexExecutionProvider, type DexBuildContext } from "../dex";
 import { toEIP712Message } from "../intents/signPermit2Evm/permit2";
-import {
-  toRfqEIP712Message,
-  type RfqProvider,
-} from "../intents/signRfqOrderEvm/rfqTypedData";
-import type {
-  Quote,
-  QuoteApprovalTransaction,
-} from "../quotes/types";
+import { toRfqEIP712Message, type RfqProvider } from "../intents/signRfqOrderEvm/rfqTypedData";
+import type { Quote, QuoteApprovalTransaction } from "../quotes/types";
 import type { PlanSwapFlowInput, SwapFlowPlan } from "./types";
 
 /**
@@ -43,8 +37,8 @@ export function quoteNeedsApproval(quote: Quote): boolean {
   const tokenAllowance = quote.quoteDetails.tokenAllowance;
   return Boolean(
     quote.quoteDetails.tags?.isTokenApprovalRequired &&
-      tokenAllowance &&
-      !tokenAllowance.isApproved,
+    tokenAllowance &&
+    !tokenAllowance.isApproved,
   );
 }
 
@@ -58,9 +52,7 @@ export function quoteNeedsApproval(quote: Quote): boolean {
  * transaction blob. The planner uses {@link quoteNeedsApproval} to
  * detect that mismatch and refuse to silently downgrade to a direct swap.
  */
-function getApprovalTransaction(
-  quote: Quote,
-): QuoteApprovalTransaction | null {
+function getApprovalTransaction(quote: Quote): QuoteApprovalTransaction | null {
   const tokenAllowance = quote.quoteDetails.tokenAllowance;
   if (
     quote.quoteDetails.tags?.isTokenApprovalRequired &&
@@ -122,10 +114,7 @@ function getPermitTypedData(quote: Quote): EIP712Message | null {
  * The wallet-side machine splices in the `signature` field once the
  * device signs the order, so the planner returns the body without it.
  */
-function buildRfqSubmitBody(
-  quote: Quote,
-  provider: RfqProvider,
-): Record<string, unknown> {
+function buildRfqSubmitBody(quote: Quote, provider: RfqProvider): Record<string, unknown> {
   const customFields = quote.customFields ?? {};
   if (provider === "uniswapx") {
     return { ...customFields, routing: "DUTCH_V2" };
@@ -146,9 +135,7 @@ function buildRfqPlan(
   const submitBody = buildRfqSubmitBody(quote, rfqProvider);
   const network = quote.quoteDetails.networkFees.currencyId;
   const precomputedOrderId =
-    rfqProvider === "oneinchfusion"
-      ? quote.quoteDetails.permitData?.orderHash
-      : undefined;
+    rfqProvider === "oneinchfusion" ? quote.quoteDetails.permitData?.orderHash : undefined;
 
   if (approvalTransaction) {
     return {
@@ -203,9 +190,7 @@ function needsUsdtRevoke(
 
   // `sendAmount` is in display units (e.g. `350` USDT); atomise it
   // before comparing against the on-chain allowance (atomic units).
-  const sendAmountAtomic = new BigNumber(
-    quote.quoteDetails.sendAmount,
-  ).shiftedBy(USDT_DECIMALS);
+  const sendAmountAtomic = new BigNumber(quote.quoteDetails.sendAmount).shiftedBy(USDT_DECIMALS);
 
   return sendAmountAtomic.gt(approvedAmount);
 }
@@ -228,9 +213,7 @@ function needsUsdtRevoke(
 export function planSwapFlow(input: PlanSwapFlowInput): SwapFlowPlan {
   const { quote } = input;
 
-  if (
-    needsUsdtRevoke(quote, input.fromCurrencyTicker, input.fromCurrencyParentId)
-  ) {
+  if (needsUsdtRevoke(quote, input.fromCurrencyTicker, input.fromCurrencyParentId)) {
     return { kind: "skip", reason: "usdt-revoke-needed" };
   }
 
@@ -307,9 +290,7 @@ export function planSwapFlow(input: PlanSwapFlowInput): SwapFlowPlan {
     const tokenAllowance = quote.quoteDetails.tokenAllowance;
     return {
       kind: "skip",
-      reason: tokenAllowance?.isApproved
-        ? "already-approved-non-dex"
-        : "no-approval-non-dex",
+      reason: tokenAllowance?.isApproved ? "already-approved-non-dex" : "no-approval-non-dex",
     };
   }
 

--- a/libs/ledger-live-common/src/wallet-api/tracking.ts
+++ b/libs/ledger-live-common/src/wallet-api/tracking.ts
@@ -1,8 +1,4 @@
-import type {
-  AppManifest,
-  BroadcastTrackingData,
-  DAppTrackingData,
-} from "./types";
+import type { AppManifest, BroadcastTrackingData, DAppTrackingData } from "./types";
 
 /**
  * This signature is to be compatible with track method of `segment.js` file in LLM and LLD
@@ -12,7 +8,7 @@ import type {
 type TrackWalletAPI = (
   event: string,
   properties: Record<string, any> | null,
-  mandatory: boolean | null
+  mandatory: boolean | null,
 ) => void;
 
 /**
@@ -29,7 +25,7 @@ function getSignTrackingPayload(
   manifest: AppManifest,
   isEmbeddedSwap?: boolean,
   partner?: string,
-  swapEntryPoint?: string
+  swapEntryPoint?: string,
 ) {
   return {
     ...getEventData(manifest),
@@ -80,16 +76,11 @@ export default function trackingWrapper(trackCall: TrackWalletAPI) {
       manifest: AppManifest,
       isEmbeddedSwap?: boolean,
       partner?: string,
-      swapEntryPoint?: string
+      swapEntryPoint?: string,
     ) => {
       track(
         "WalletAPI SignTransaction",
-        getSignTrackingPayload(
-          manifest,
-          isEmbeddedSwap,
-          partner,
-          swapEntryPoint
-        )
+        getSignTrackingPayload(manifest, isEmbeddedSwap, partner, swapEntryPoint),
       );
     },
 
@@ -98,16 +89,11 @@ export default function trackingWrapper(trackCall: TrackWalletAPI) {
       manifest: AppManifest,
       isEmbeddedSwap?: boolean,
       partner?: string,
-      swapEntryPoint?: string
+      swapEntryPoint?: string,
     ) => {
       track(
         "WalletAPI SignTransaction Fail",
-        getSignTrackingPayload(
-          manifest,
-          isEmbeddedSwap,
-          partner,
-          swapEntryPoint
-        )
+        getSignTrackingPayload(manifest, isEmbeddedSwap, partner, swapEntryPoint),
       );
     },
 
@@ -116,16 +102,11 @@ export default function trackingWrapper(trackCall: TrackWalletAPI) {
       manifest: AppManifest,
       isEmbeddedSwap?: boolean,
       partner?: string,
-      swapEntryPoint?: string
+      swapEntryPoint?: string,
     ) => {
       track(
         "WalletAPI SignTransaction Success",
-        getSignTrackingPayload(
-          manifest,
-          isEmbeddedSwap,
-          partner,
-          swapEntryPoint
-        )
+        getSignTrackingPayload(manifest, isEmbeddedSwap, partner, swapEntryPoint),
       );
     },
 
@@ -179,13 +160,10 @@ export default function trackingWrapper(trackCall: TrackWalletAPI) {
       const properties: Record<string, unknown> = getEventData(manifest);
       if (data?.isEmbeddedSwap !== undefined)
         properties.isEmbeddedSwap = String(data.isEmbeddedSwap);
-      if (data?.swapEntryPoint !== undefined)
-        properties.swapEntryPoint = data.swapEntryPoint;
+      if (data?.swapEntryPoint !== undefined) properties.swapEntryPoint = data.swapEntryPoint;
       if (data?.partner !== undefined) properties.partner = data.partner;
-      if (data?.sourceCurrency !== undefined)
-        properties.sourceCurrency = data.sourceCurrency;
-      if (data?.targetCurrency !== undefined)
-        properties.targetCurrency = data.targetCurrency;
+      if (data?.sourceCurrency !== undefined) properties.sourceCurrency = data.sourceCurrency;
+      if (data?.targetCurrency !== undefined) properties.targetCurrency = data.targetCurrency;
       if (data?.network !== undefined) properties.network = data.network;
       track("WalletAPI Broadcast Fail", properties);
     },
@@ -195,13 +173,10 @@ export default function trackingWrapper(trackCall: TrackWalletAPI) {
       const properties: Record<string, unknown> = getEventData(manifest);
       if (data?.isEmbeddedSwap !== undefined)
         properties.isEmbeddedSwap = String(data.isEmbeddedSwap);
-      if (data?.swapEntryPoint !== undefined)
-        properties.swapEntryPoint = data.swapEntryPoint;
+      if (data?.swapEntryPoint !== undefined) properties.swapEntryPoint = data.swapEntryPoint;
       if (data?.partner !== undefined) properties.partner = data.partner;
-      if (data?.sourceCurrency !== undefined)
-        properties.sourceCurrency = data.sourceCurrency;
-      if (data?.targetCurrency !== undefined)
-        properties.targetCurrency = data.targetCurrency;
+      if (data?.sourceCurrency !== undefined) properties.sourceCurrency = data.sourceCurrency;
+      if (data?.targetCurrency !== undefined) properties.targetCurrency = data.targetCurrency;
       if (data?.network !== undefined) properties.network = data.network;
       track("WalletAPI Broadcast Success", properties);
     },
@@ -295,40 +270,22 @@ export default function trackingWrapper(trackCall: TrackWalletAPI) {
       track("WalletAPI device close fail", getEventData(manifest));
     },
     bitcoinFamilyAccountAddressRequested: (manifest: AppManifest) => {
-      track(
-        "WalletAPI bitcoin family account address requested",
-        getEventData(manifest)
-      );
+      track("WalletAPI bitcoin family account address requested", getEventData(manifest));
     },
     bitcoinFamilyAccountAddressFail: (manifest: AppManifest) => {
-      track(
-        "WalletAPI bitcoin family account address fail",
-        getEventData(manifest)
-      );
+      track("WalletAPI bitcoin family account address fail", getEventData(manifest));
     },
     bitcoinFamilyAccountAddressSuccess: (manifest: AppManifest) => {
-      track(
-        "WalletAPI bitcoin family account address success",
-        getEventData(manifest)
-      );
+      track("WalletAPI bitcoin family account address success", getEventData(manifest));
     },
     bitcoinFamilyAccountPublicKeyRequested: (manifest: AppManifest) => {
-      track(
-        "WalletAPI bitcoin family account publicKey requested",
-        getEventData(manifest)
-      );
+      track("WalletAPI bitcoin family account publicKey requested", getEventData(manifest));
     },
     bitcoinFamilyAccountPublicKeyFail: (manifest: AppManifest) => {
-      track(
-        "WalletAPI bitcoin family account publicKey fail",
-        getEventData(manifest)
-      );
+      track("WalletAPI bitcoin family account publicKey fail", getEventData(manifest));
     },
     bitcoinFamilyAccountPublicKeySuccess: (manifest: AppManifest) => {
-      track(
-        "WalletAPI bitcoin family account publicKey success",
-        getEventData(manifest)
-      );
+      track("WalletAPI bitcoin family account publicKey success", getEventData(manifest));
     },
     accountGetPublicKeyRequested: (manifest: AppManifest) => {
       track("WalletAPI account getPublicKey requested", getEventData(manifest));
@@ -340,64 +297,37 @@ export default function trackingWrapper(trackCall: TrackWalletAPI) {
       track("WalletAPI account getPublicKey success", getEventData(manifest));
     },
     bitcoinFamilyAccountXpubRequested: (manifest: AppManifest) => {
-      track(
-        "WalletAPI bitcoin family account xpub requested",
-        getEventData(manifest)
-      );
+      track("WalletAPI bitcoin family account xpub requested", getEventData(manifest));
     },
     bitcoinFamilyAccountXpubFail: (manifest: AppManifest) => {
-      track(
-        "WalletAPI bitcoin family account xpub fail",
-        getEventData(manifest)
-      );
+      track("WalletAPI bitcoin family account xpub fail", getEventData(manifest));
     },
     bitcoinFamilyAccountXpubSuccess: (manifest: AppManifest) => {
-      track(
-        "WalletAPI bitcoin family account xpub success",
-        getEventData(manifest)
-      );
+      track("WalletAPI bitcoin family account xpub success", getEventData(manifest));
     },
     bitcoinFamilyAccountAddressesRequested: (manifest: AppManifest) => {
-      track(
-        "WalletAPI bitcoin family account addresses requested",
-        getEventData(manifest)
-      );
+      track("WalletAPI bitcoin family account addresses requested", getEventData(manifest));
     },
     bitcoinFamilyAccountAddressesFail: (manifest: AppManifest) => {
-      track(
-        "WalletAPI bitcoin family account addresses fail",
-        getEventData(manifest)
-      );
+      track("WalletAPI bitcoin family account addresses fail", getEventData(manifest));
     },
     bitcoinFamilyAccountAddressesSuccess: (manifest: AppManifest) => {
-      track(
-        "WalletAPI bitcoin family account addresses success",
-        getEventData(manifest)
-      );
+      track("WalletAPI bitcoin family account addresses success", getEventData(manifest));
     },
 
-    dappSendTransactionRequested: (
-      manifest: AppManifest,
-      trackingData: DAppTrackingData
-    ) => {
+    dappSendTransactionRequested: (manifest: AppManifest, trackingData: DAppTrackingData) => {
       track("dApp SendTransaction requested", {
         ...getEventData(manifest),
         ...trackingData,
       });
     },
-    dappSendTransactionSuccess: (
-      manifest: AppManifest,
-      trackingData: DAppTrackingData
-    ) => {
+    dappSendTransactionSuccess: (manifest: AppManifest, trackingData: DAppTrackingData) => {
       track("dApp SendTransaction success", {
         ...getEventData(manifest),
         ...trackingData,
       });
     },
-    dappSendTransactionFail: (
-      manifest: AppManifest,
-      trackingData?: DAppTrackingData
-    ) => {
+    dappSendTransactionFail: (manifest: AppManifest, trackingData?: DAppTrackingData) => {
       track("dApp SendTransaction fail", {
         ...getEventData(manifest),
         ...(trackingData || {}),


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** N/A — formatting only, no logic change
- [x] **Impact of the changes:**
  - 87 source files reformatted to match oxfmt rules
  - Pure whitespace/style changes, zero logic diff

### 📝 Description

Since the transition from prettier/eslint to oxfmt/oxlint, the format:check gate was not enforced in CI. 87 files drifted out of format across apps/ledger-live-desktop, apps/ledger-live-mobile, apps/cli, apps/wallet-cli, e2e/mobile, libs/coin-modules, libs/coin-tester-modules and libs/ledger-live-common.

This is a bulk reformat pass to clear the drift. No logic was changed — only whitespace and style.

> [!NOTE]
> Companion PR: #19206 adds **/animations/**/*.json to the desktop oxfmt ignore list so Lottie animation assets are not touched by future format runs.

### ❓ Context

- **JIRA or GitHub link**: N/A