### PR TITLE
test(e2e): disable Changelly KYC warning check and swap provider

### DIFF
--- a/e2e/desktop/tests/specs/ui.swap.spec.ts
+++ b/e2e/desktop/tests/specs/ui.swap.spec.ts
@@ -25,12 +25,12 @@ const swapUiTags = [
 
 const kycFromAccount = Account.BTC_NATIVE_SEGWIT_1;
 const kycToAccount = Account.ETH_1;
-const kycProvider = SwapProvider.CHANGELLY;
+const kycProvider = SwapProvider.NEAR_INTENTS;
 const accPair: string[] = [kycFromAccount, kycToAccount].map(acc =>
   acc.currency.speculosApp.name.replaceAll(" ", "_"),
 );
 
-test.describe("Swap - Changelly KYC warning and feedback link", () => {
+test.describe("Swap - feedback link", () => {
   setupEnv(true);
   test.beforeEach(async () => {
     setExchangeDependencies(
@@ -65,7 +65,7 @@ test.describe("Swap - Changelly KYC warning and feedback link", () => {
     ],
   });
   test(
-    "shows Changelly AML/KYC warning and displays feedback link from success drawer",
+    "displays feedback link from success drawer",
     {
       tag: swapUiTags,
       annotation: {
@@ -85,7 +85,8 @@ test.describe("Swap - Changelly KYC warning and feedback link", () => {
       const swap = new Swap(kycFromAccount, kycToAccount, amountToSend);
 
       await app.swap.clickExchangeButton(kycProvider.name);
-      await app.swapDrawer.checkKycWarningBannerVisible();
+      // TODO: re-enable once Changelly provider is re-enabled
+      // await app.swapDrawer.checkKycWarningBannerVisible();
       await app.speculos.verifyAmountsAndAcceptSwap(swap, amountToSend);
       await app.swapDrawer.verifyExchangeCompletedTextContent(swap.accountToCredit.currency.name);
       await app.swapDrawer.checkShareYourFeedbackLinkVisible();

--- a/e2e/shared/src/enum/Provider.ts
+++ b/e2e/shared/src/enum/Provider.ts
@@ -35,7 +35,8 @@ export class SwapProvider extends BaseProvider {
     super(name, uiName);
   }
 
-  static readonly CHANGELLY = new SwapProvider("changelly_v2", "Changelly", false, true);
+  // TODO: re-enable once Changelly provider is re-enabled
+  //static readonly CHANGELLY = new SwapProvider("changelly_v2", "Changelly", false, true);
   static readonly EXODUS = new SwapProvider("exodus", "Exodus", false, true);
   static readonly MOONPAY = new SwapProvider("moonpay", "MoonPay", true, true);
   static readonly CIC = new SwapProvider("cic_v2", "CIC", false, true);


### PR DESCRIPTION
## Summary
- Comment out `SwapProvider.CHANGELLY` in the shared e2e provider enum ([Provider.ts](e2e/shared/src/enum/Provider.ts)) since Changelly is temporarily unavailable as a swap provider; no other spec referenced it.
- Update `ui.swap.spec.ts` accordingly: drop the `checkKycWarningBannerVisible()` assertion (with a TODO to re-enable once Changelly is back), switch `kycProvider` to `SwapProvider.NEAR_INTENTS` (a whitelisted, non-KYC provider that supports the BTC→ETH pair), and rename the test/describe block to reflect that only the feedback-link check remains active.

## Test plan
- [x] `oxfmt --check` and `oxlint` pass on both changed files
- [ ] Run `ui.swap.spec.ts` in CI to confirm `displays feedback link from success drawer` passes end-to-end with the new provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)