### PR TITLE
feat/zcash lw signer pczt support [LIVE-31199]

### DIFF
--- a/.changeset/quick-swans-whisper.md
+++ b/.changeset/quick-swans-whisper.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-signer-zcash": minor
+---
+
+Zcash: add PCZT support on LW signer

--- a/libs/live-signer-zcash/package.json
+++ b/libs/live-signer-zcash/package.json
@@ -28,7 +28,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/device-management-kit": "catalog:",
-    "@ledgerhq/device-signer-kit-zcash": "0.0.0-develop-20260706002934",
+    "@ledgerhq/device-signer-kit-zcash": "0.4.0",
     "@ledgerhq/errors": "workspace:^",
     "rxjs": "catalog:"
   },

--- a/libs/live-signer-zcash/package.json
+++ b/libs/live-signer-zcash/package.json
@@ -28,7 +28,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/device-management-kit": "catalog:",
-    "@ledgerhq/device-signer-kit-zcash": "0.3.0",
+    "@ledgerhq/device-signer-kit-zcash": "0.0.0-develop-20260706002934",
     "@ledgerhq/errors": "workspace:^",
     "rxjs": "catalog:"
   },

--- a/libs/live-signer-zcash/src/DmkSignerZcash.ts
+++ b/libs/live-signer-zcash/src/DmkSignerZcash.ts
@@ -7,6 +7,8 @@ import type {
   ZcashSignature,
   SignerTransactionLike,
   BitcoinCreateTransactionLike,
+  PcztTransaction,
+  SignPcztTransactionResult,
 } from "./types";
 import { lastValueFrom, type Observable } from "rxjs";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
@@ -22,6 +24,7 @@ import {
   type SignerZcash,
   type LegacyCreateTransactionArg,
   type LegacyTransaction,
+  type SignPcztTransactionDAError,
   type SignTransactionDAError,
   type SignTransactionDAOutput,
 } from "@ledgerhq/device-signer-kit-zcash";
@@ -214,6 +217,25 @@ export class DmkSignerZcash implements ZcashSigner {
     onDeviceSignatureGranted?.();
 
     return signedTx.startsWith("0x") ? signedTx.slice(2) : signedTx;
+  }
+
+  /**
+   * Sign an Orchard PCZT via the DMK signer.
+   *
+   * Delegates to the DMK `signPcztTransaction` device action, which streams the
+   * PCZT bundle to the device and collects all spend-authorization signatures
+   * atomically. Returns `SignPcztTransactionResult` containing per-action Orchard
+   * signatures and per-input transparent signatures — callers must not reorder
+   * them before passing to `finalizeTransaction`.
+   *
+   * `skipOpenApp: true` is consistent with the other signer methods; the caller
+   * (signOperation orchestration) is responsible for ensuring the Zcash app is open.
+   */
+  async signPcztTransaction(pczt: PcztTransaction): Promise<SignPcztTransactionResult> {
+    const { observable } = this.signer.signPcztTransaction(pczt, { skipOpenApp: true });
+    return this.resolveDeviceAction<SignPcztTransactionResult, SignPcztTransactionDAError>(
+      observable,
+    );
   }
 
   async signMessage(_path: string, _messageHex: string): Promise<ZcashSignature> {

--- a/libs/live-signer-zcash/src/types.ts
+++ b/libs/live-signer-zcash/src/types.ts
@@ -1,3 +1,16 @@
+/**
+ * PCZT signing types are re-exported straight from the DMK Zcash signer so the
+ * app-facing `ZcashSigner` contract and `DmkSignerZcash` share the exact shapes
+ * the device action consumes/produces — no local mirror to keep in sync.
+ */
+import type {
+  OrchardActionSignature,
+  PcztTransaction,
+  SignPcztTransactionResult,
+} from "@ledgerhq/device-signer-kit-zcash";
+
+export type { OrchardActionSignature, PcztTransaction, SignPcztTransactionResult };
+
 export type ZcashAppConfig = {
   version: string;
 };
@@ -83,5 +96,6 @@ export type ZcashSigner = {
   getAddress: (path: string, display?: boolean) => Promise<ZcashAddress>;
   getFullViewingKey: (path: string) => Promise<ZcashViewKey>;
   createPaymentTransaction: (arg: BitcoinCreateTransactionLike) => Promise<string>;
+  signPcztTransaction: (pczt: PcztTransaction) => Promise<SignPcztTransactionResult>;
   signMessage: (path: string, messageHex: string) => Promise<ZcashSignature>;
 };

--- a/libs/live-signer-zcash/tests/DmkSignerZcash.test.ts
+++ b/libs/live-signer-zcash/tests/DmkSignerZcash.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { SignerZcashBuilder } from "@ledgerhq/device-signer-kit-zcash";
 import { DmkSignerZcash } from "../src/DmkSignerZcash";
+import type { PcztTransaction } from "../src/types";
 
 jest.mock("@ledgerhq/device-signer-kit-zcash", () => ({
   SignerZcashBuilder: jest.fn(),
@@ -18,6 +19,7 @@ describe("DmkSignerZcash", () => {
     getAddress: jest.fn(),
     getFullViewingKey: jest.fn(),
     signTransaction: jest.fn(),
+    signPcztTransaction: jest.fn(),
   };
 
   let signer: DmkSignerZcash;
@@ -402,6 +404,114 @@ describe("DmkSignerZcash", () => {
       });
 
       await expect(signer.createPaymentTransaction(baseArg)).resolves.toBe("00signed");
+    });
+  });
+
+  describe("signPcztTransaction", () => {
+    const orchardSig = new Uint8Array(64).fill(0xab);
+    const transparentSig = new Uint8Array(72).fill(0xcd);
+
+    // Minimal valid-shaped PCZT — the mock doesn't inspect fields
+    const minimalPczt: PcztTransaction = {
+      global: {
+        txVersion: 5,
+        versionGroupId: 0x26a7270a,
+        consensusBranchId: 0xc2d6d0b4,
+        fallbackLockTime: null,
+        expiryHeight: 0,
+        coinType: 133,
+        txModifiable: 0,
+      },
+      transparentInputs: [],
+      transparentOutputs: [],
+      orchardBundle: null,
+    };
+
+    it("returns orchard spendAuthSigs and empty transparentInputSigs for a pure-Orchard transaction", async () => {
+      const result = { orchard: [{ spendAuthSig: orchardSig }], transparentInputSigs: [] };
+      mockSignerZcash.signPcztTransaction.mockReturnValue({
+        observable: createCompletedObservable(result),
+      });
+
+      expect(await signer.signPcztTransaction(minimalPczt)).toEqual(result);
+      expect(mockSignerZcash.signPcztTransaction).toHaveBeenCalledWith(minimalPczt, {
+        skipOpenApp: true,
+      });
+    });
+
+    it("preserves spendAuthSig order: N actions return N signatures in action order", async () => {
+      const sigs = [0x01, 0x02, 0x03].map(b => new Uint8Array(64).fill(b));
+      const result = {
+        orchard: sigs.map(spendAuthSig => ({ spendAuthSig })),
+        transparentInputSigs: [],
+      };
+      mockSignerZcash.signPcztTransaction.mockReturnValue({
+        observable: createCompletedObservable(result),
+      });
+
+      const out = await signer.signPcztTransaction(minimalPczt);
+
+      expect(out.orchard).toHaveLength(3);
+      out.orchard.forEach((sig, i) => {
+        expect(sig.spendAuthSig[0]).toBe(i + 1);
+      });
+    });
+
+    it("returns both orchard sigs and transparentInputSigs for a mixed transaction", async () => {
+      const result = {
+        orchard: [{ spendAuthSig: orchardSig }],
+        transparentInputSigs: [transparentSig],
+      };
+      mockSignerZcash.signPcztTransaction.mockReturnValue({
+        observable: createCompletedObservable(result),
+      });
+
+      const out = await signer.signPcztTransaction(minimalPczt);
+
+      expect(out.orchard).toHaveLength(1);
+      expect(out.transparentInputSigs).toHaveLength(1);
+      expect(out.transparentInputSigs[0]).toBe(transparentSig);
+    });
+
+    it("rejects with UserRefusedOnDevice when the user declines on device (6985)", async () => {
+      mockSignerZcash.signPcztTransaction.mockReturnValue({
+        observable: createErrorStatusObservable({
+          _tag: "ZcashAppCommandError",
+          errorCode: "6985",
+        }),
+      });
+
+      await expect(signer.signPcztTransaction(minimalPczt)).rejects.toMatchObject({
+        name: "UserRefusedOnDevice",
+      });
+    });
+
+    it("rejects with a mapped error when the device action returns error status", async () => {
+      mockSignerZcash.signPcztTransaction.mockReturnValue({
+        observable: createErrorStatusObservable({ _tag: "SignPcztTransactionDAError" }),
+      });
+
+      await expect(signer.signPcztTransaction(minimalPczt)).rejects.toThrow(
+        "SignPcztTransactionDAError",
+      );
+    });
+
+    it("rejects when the observable emits a transport error", async () => {
+      mockSignerZcash.signPcztTransaction.mockReturnValue({
+        observable: createTransportErrorObservable(new Error("transport down")),
+      });
+
+      await expect(signer.signPcztTransaction(minimalPczt)).rejects.toThrow("transport down");
+    });
+
+    it("rejects instead of hanging when the device action is stopped", async () => {
+      mockSignerZcash.signPcztTransaction.mockReturnValue({
+        observable: createStoppedObservable(),
+      });
+
+      await expect(signer.signPcztTransaction(minimalPczt)).rejects.toThrow(
+        "Unexpected device action status: stopped",
+      );
     });
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11673,8 +11673,8 @@ importers:
         specifier: 'catalog:'
         version: 1.7.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-zcash':
-        specifier: 0.0.0-develop-20260706002934
-        version: 0.0.0-develop-20260706002934(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        specifier: 0.4.0
+        version: 0.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -17368,10 +17368,10 @@ packages:
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.5.1
 
-  '@ledgerhq/device-signer-kit-zcash@0.0.0-develop-20260706002934':
-    resolution: {integrity: sha512-XFpy5CE6sT4T8wUw2fjjfZAzqfhmD4FnxucqXCqjMKWSn5w2pgSUHy447l+WYexkan7sc7vwfX7GjZKiBdfgaw==}
+  '@ledgerhq/device-signer-kit-zcash@0.4.0':
+    resolution: {integrity: sha512-ipCVVjyWiRchK1iKu83v7VIc6IYQEIkgIseMSF1VLy/UpzEr3Ou29y8YsNFNTHoURznRUDqG5k6mF3xM64wPDg==}
     peerDependencies:
-      '@ledgerhq/device-management-kit': 0.0.0-develop-20260706002934
+      '@ledgerhq/device-management-kit': ^1.7.1
 
   '@ledgerhq/device-transport-kit-react-native-ble@1.3.2':
     resolution: {integrity: sha512-NX/Ml23AR/8iQ5pUPQqum3qjQpValxNhZSbp+Zm/lSl8W0HETLMFK03w/4lj2nfPjiwBy3U+uPhzYNDzdROYQg==}
@@ -17515,11 +17515,6 @@ packages:
     resolution: {integrity: sha512-G/eZXvir5wgmrTx8gkHU+oe+lGS9iIYXBZtb9IYJlJJ5JYN4h3GbrM/w0dCe9zCePqUCyAIztCOBVeltZDeXRA==}
     peerDependencies:
       react: 19.1.4
-
-  '@ledgerhq/signer-utils@0.0.0-develop-20260706002934':
-    resolution: {integrity: sha512-lhSYXLf8GpoiFWD0Kcj50bRgIFLtnoYM3jkB8JAJJS9DkGb/hurm7rZQCxVRGA1jMKfhkTUp6nhN52ZLnCNH4Q==}
-    peerDependencies:
-      '@ledgerhq/device-management-kit': 0.0.0-develop-20260706002934
 
   '@ledgerhq/signer-utils@1.1.3':
     resolution: {integrity: sha512-3Y1ove1TyMVuCTKxM1eB9QMXpmrnYVjRc0fEPr5F+I6YJ0DX/yRc+t38ZFJw6m/IkVl8NN1TtmDyaFWJb+xXnQ==}
@@ -45654,10 +45649,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-zcash@0.0.0-develop-20260706002934(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-zcash@0.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 0.0.0-develop-20260706002934(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@noble/hashes': 1.8.0
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
@@ -45971,11 +45966,6 @@ snapshots:
       clsx: 2.1.1
       react: 19.1.4
       tailwind-merge: 2.6.0
-
-  '@ledgerhq/signer-utils@0.0.0-develop-20260706002934(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
-    dependencies:
-      '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
-      semver: 7.7.2
 
   '@ledgerhq/signer-utils@1.1.3(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
@@ -65098,7 +65088,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -65222,6 +65212,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3596,7 +3596,7 @@ importers:
         version: 0.1.19
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.45(@ledgerhq/lumen-design-core@0.1.19)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
+        version: 0.1.45(@ledgerhq/lumen-design-core@0.1.19)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
         version: 0.1.48(bdae926a59af589d19d78b5b880d45b3)
@@ -11673,8 +11673,8 @@ importers:
         specifier: 'catalog:'
         version: 1.7.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-zcash':
-        specifier: 0.3.0
-        version: 0.3.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        specifier: 0.0.0-develop-20260706002934
+        version: 0.0.0-develop-20260706002934(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -17368,10 +17368,10 @@ packages:
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.5.1
 
-  '@ledgerhq/device-signer-kit-zcash@0.3.0':
-    resolution: {integrity: sha512-+wgFuOGe/BC1cZzJS/0MC9P37C3QYQ33BX+6gmqSwsSZveDyHAvPXxSeZ+6pmzgYHDIC2aO+4LU4vQI1+R5luQ==}
+  '@ledgerhq/device-signer-kit-zcash@0.0.0-develop-20260706002934':
+    resolution: {integrity: sha512-XFpy5CE6sT4T8wUw2fjjfZAzqfhmD4FnxucqXCqjMKWSn5w2pgSUHy447l+WYexkan7sc7vwfX7GjZKiBdfgaw==}
     peerDependencies:
-      '@ledgerhq/device-management-kit': ^1.7.1
+      '@ledgerhq/device-management-kit': 0.0.0-develop-20260706002934
 
   '@ledgerhq/device-transport-kit-react-native-ble@1.3.2':
     resolution: {integrity: sha512-NX/Ml23AR/8iQ5pUPQqum3qjQpValxNhZSbp+Zm/lSl8W0HETLMFK03w/4lj2nfPjiwBy3U+uPhzYNDzdROYQg==}
@@ -17515,6 +17515,11 @@ packages:
     resolution: {integrity: sha512-G/eZXvir5wgmrTx8gkHU+oe+lGS9iIYXBZtb9IYJlJJ5JYN4h3GbrM/w0dCe9zCePqUCyAIztCOBVeltZDeXRA==}
     peerDependencies:
       react: 19.1.4
+
+  '@ledgerhq/signer-utils@0.0.0-develop-20260706002934':
+    resolution: {integrity: sha512-lhSYXLf8GpoiFWD0Kcj50bRgIFLtnoYM3jkB8JAJJS9DkGb/hurm7rZQCxVRGA1jMKfhkTUp6nhN52ZLnCNH4Q==}
+    peerDependencies:
+      '@ledgerhq/device-management-kit': 0.0.0-develop-20260706002934
 
   '@ledgerhq/signer-utils@1.1.3':
     resolution: {integrity: sha512-3Y1ove1TyMVuCTKxM1eB9QMXpmrnYVjRc0fEPr5F+I6YJ0DX/yRc+t38ZFJw6m/IkVl8NN1TtmDyaFWJb+xXnQ==}
@@ -45649,10 +45654,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-zcash@0.3.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-zcash@0.0.0-develop-20260706002934(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+      '@ledgerhq/signer-utils': 0.0.0-develop-20260706002934(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@noble/hashes': 1.8.0
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
@@ -45849,16 +45854,14 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.45(@ledgerhq/lumen-design-core@0.1.19)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react@0.1.45(@ledgerhq/lumen-design-core@0.1.19)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
     dependencies:
       '@ledgerhq/lumen-design-core': 0.1.19
       '@ledgerhq/lumen-utils-shared': 0.1.7(react@19.1.4)
-      clsx: 2.1.1
       i18next: 23.10.1
       react: 19.1.4
       react-dom: 19.1.4(react@19.1.4)
       react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      tailwind-merge: 3.4.0
     transitivePeerDependencies:
       - react-native
 
@@ -45968,6 +45971,11 @@ snapshots:
       clsx: 2.1.1
       react: 19.1.4
       tailwind-merge: 2.6.0
+
+  '@ledgerhq/signer-utils@0.0.0-develop-20260706002934(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
+    dependencies:
+      '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
+      semver: 7.7.2
 
   '@ledgerhq/signer-utils@1.1.3(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
@@ -65090,7 +65098,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -65214,54 +65222,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - @ledgerhq/live-signer-zcash

### 📝 Description

Implement `signPcztTransaction` on `DmkSignerZcash` — the LW bridge for Orchard PCZT signing.
Delegates to the DMK `signPcztTransaction` device action and returns per-action Orchard
`spendAuthSig` values and per-input transparent signatures, in action/input order, ready
for the coin module to pass to `finalizeTransaction`. Bumps `device-signer-kit-zcash` to 0.4.0
which ships the `signPcztTransaction` device action.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-31199


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
