### PR TITLE
[LWDM] style: apply oxfmt formatting to drifted files

### DIFF
--- a/libs/ledger-live-common/src/families/evm/editTransaction/getTransactionStatus.test.ts
+++ b/libs/ledger-live-common/src/families/evm/editTransaction/getTransactionStatus.test.ts
@@ -5,7 +5,11 @@ import {
 } from "@ledgerhq/errors";
 import BigNumber from "bignumber.js";
 import { NotEnoughNftOwned, NotOwnedNft } from "@ledgerhq/coin-evm/errors";
-import { EvmTransactionEIP1559, EvmTransactionLegacy, TransactionStatus } from "@ledgerhq/coin-evm/types/index";
+import {
+  EvmTransactionEIP1559,
+  EvmTransactionLegacy,
+  TransactionStatus,
+} from "@ledgerhq/coin-evm/types/index";
 import { getMinEip1559Fees, getMinLegacyFees } from "./getMinEditTransactionFees";
 import { validateEditTransaction, getEditTransactionStatus } from "./getTransactionStatus";
 

--- a/libs/ledger-live-common/src/families/evm/editTransaction/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/families/evm/editTransaction/getTransactionStatus.ts
@@ -2,7 +2,11 @@ import { AmountRequired, ReplacementTransactionUnderpriced } from "@ledgerhq/err
 import { TransactionStatusCommon } from "@ledgerhq/types-live";
 import { getMinEip1559Fees, getMinLegacyFees } from "./getMinEditTransactionFees";
 import { NotEnoughNftOwned, NotOwnedNft } from "@ledgerhq/coin-evm/errors";
-import { EditType, Transaction as EvmTransaction, TransactionStatus } from "@ledgerhq/coin-evm/types/index";
+import {
+  EditType,
+  Transaction as EvmTransaction,
+  TransactionStatus,
+} from "@ledgerhq/coin-evm/types/index";
 
 type ValidatedTransactionFields =
   | "recipient"


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** N/A — formatting only, no logic changes.
- [x] **Impact of the changes:**
  - No functional impact. Import statements reformatted to comply with oxfmt line-length rules.

### 📝 Description

Applies oxfmt formatting to two files that drifted from the enforced style:

- `libs/ledger-live-common/src/families/evm/editTransaction/getTransactionStatus.ts`
- `libs/ledger-live-common/src/families/evm/editTransaction/getTransactionStatus.test.ts`

Both files had a single long import line that oxfmt expects to be split across multiple lines.

### ❓ Context

- **JIRA or GitHub link**: N/A — routine format drift fix.
- **ADR link (if any)**: N/A