### PR TITLE
chore(mobile): exclude src/generated from oxfmt check

### DIFF
--- a/apps/ledger-live-mobile/.oxfmtrc.json
+++ b/apps/ledger-live-mobile/.oxfmtrc.json
@@ -5,6 +5,7 @@
   "arrowParens": "avoid",
   "sortPackageJson": false,
   "ignorePatterns": [
-    "**/*.json"
+    "**/*.json",
+    "src/generated/**"
   ]
 }


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** N/A — config-only change
- [ ] **Impact of the changes:**
  - Generated files under apps/ledger-live-mobile/src/generated/ are no longer flagged or reformatted by oxfmt

### 📝 Description

Adds src/generated/** to the ignorePatterns of the mobile oxfmt config so that auto-generated files are never touched or reported by the formatter.

### ❓ Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A