### PR TITLE
[LWDM] fix(die): match deprecation config model ids

### DIFF
--- a/.changeset/die-deprecation-model-ids.md
+++ b/.changeset/die-deprecation-model-ids.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-dmk-shared": patch
+---
+
+Match device deprecation configs against Ledger Live device model ids.

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/initializationScenarios.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/DeviceIntentExecutor/initializationScenarios.ts
@@ -1,5 +1,5 @@
-import { DeviceModelId } from "@ledgerhq/device-management-kit";
 import { FlowName } from "@ledgerhq/live-common/device-action/utils";
+import { DeviceModelId } from "@ledgerhq/types-devices";
 import type { InitializerConfig } from "LLM/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM";
 import type { InitializationInput } from "LLM/components/DeviceIntentExecutor/types";
 
@@ -56,12 +56,12 @@ const PAST_DATE = "2000-01-01T00:00:00.000Z";
 const FUTURE_DATE = "2999-01-01T00:00:00.000Z";
 
 const deprecatedDeviceModels = [
-  DeviceModelId.NANO_S,
-  DeviceModelId.NANO_SP,
-  DeviceModelId.NANO_X,
-  DeviceModelId.STAX,
-  DeviceModelId.FLEX,
-  DeviceModelId.APEX,
+  DeviceModelId.nanoS,
+  DeviceModelId.nanoSP,
+  DeviceModelId.nanoX,
+  DeviceModelId.stax,
+  DeviceModelId.europa,
+  DeviceModelId.apex,
 ];
 
 type ScreenTrigger = {

--- a/libs/live-dmk-shared/src/device-action/ConnectApp/ConnectAppDeviceAction.test.ts
+++ b/libs/live-dmk-shared/src/device-action/ConnectApp/ConnectAppDeviceAction.test.ts
@@ -966,7 +966,7 @@ describe("OpenAppWithDependenciesDeviceAction", () => {
     const FUTURE = "2999-01-01";
 
     const baseEntry = (over: Partial<DeviceDeprecationConfig> = {}): DeviceDeprecationConfig => ({
-      deviceModelId: LLDeviceModelId.nanoS,
+      deviceModelId: "nanoS" as LLDeviceModelId,
       warningScreen: { date: FUTURE, deprecatedFlow: [] },
       errorScreen: { date: FUTURE, deprecatedFlow: [] },
       warningClearSigningScreen: { date: FUTURE, deprecatedFlow: [], exception: [] },
@@ -975,7 +975,7 @@ describe("OpenAppWithDependenciesDeviceAction", () => {
 
     const INFO_PAST_CONFIG: DeviceDeprecationConfigs = [
       {
-        deviceModelId: LLDeviceModelId.nanoS,
+        deviceModelId: "nanoS" as LLDeviceModelId,
         warningScreen: { date: PAST, deprecatedFlow: ["receive"] },
         errorScreen: { date: FUTURE, deprecatedFlow: [] },
         warningClearSigningScreen: { date: FUTURE, deprecatedFlow: [], exception: [] },
@@ -984,7 +984,7 @@ describe("OpenAppWithDependenciesDeviceAction", () => {
 
     const ERROR_PAST_CONFIG: DeviceDeprecationConfigs = [
       {
-        deviceModelId: LLDeviceModelId.nanoS,
+        deviceModelId: "nanoS" as LLDeviceModelId,
         warningScreen: { date: FUTURE, deprecatedFlow: [] },
         errorScreen: { date: PAST, deprecatedFlow: ["receive"] },
         warningClearSigningScreen: { date: FUTURE, deprecatedFlow: [], exception: [] },

--- a/libs/live-dmk-shared/src/device-action/ConnectApp/ConnectAppDeviceAction.test.ts
+++ b/libs/live-dmk-shared/src/device-action/ConnectApp/ConnectAppDeviceAction.test.ts
@@ -11,6 +11,7 @@ import {
   UnknownDAError,
   UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
+import { DeviceModelId as LLDeviceModelId } from "@ledgerhq/types-devices";
 
 import { makeDeviceActionInternalApiMock } from "../__test-utils__/makeInternalApi";
 import {
@@ -33,7 +34,7 @@ import {
   type DeviceDeprecationConfigs,
   type DeviceDeprecationConfig,
 } from "./types";
-import { isDeviceDeprecated } from "./deprecation";
+import { extractDeviceDeprecationRules } from "./extractDeviceDeprecationRules";
 
 jest.mock("@ledgerhq/device-management-kit", () => {
   const original = jest.requireActual<typeof import("@ledgerhq/device-management-kit")>(
@@ -965,7 +966,7 @@ describe("OpenAppWithDependenciesDeviceAction", () => {
     const FUTURE = "2999-01-01";
 
     const baseEntry = (over: Partial<DeviceDeprecationConfig> = {}): DeviceDeprecationConfig => ({
-      deviceModelId: "nanoS",
+      deviceModelId: LLDeviceModelId.nanoS,
       warningScreen: { date: FUTURE, deprecatedFlow: [] },
       errorScreen: { date: FUTURE, deprecatedFlow: [] },
       warningClearSigningScreen: { date: FUTURE, deprecatedFlow: [], exception: [] },
@@ -974,7 +975,7 @@ describe("OpenAppWithDependenciesDeviceAction", () => {
 
     const INFO_PAST_CONFIG: DeviceDeprecationConfigs = [
       {
-        deviceModelId: MODEL,
+        deviceModelId: LLDeviceModelId.nanoS,
         warningScreen: { date: PAST, deprecatedFlow: ["receive"] },
         errorScreen: { date: FUTURE, deprecatedFlow: [] },
         warningClearSigningScreen: { date: FUTURE, deprecatedFlow: [], exception: [] },
@@ -983,7 +984,7 @@ describe("OpenAppWithDependenciesDeviceAction", () => {
 
     const ERROR_PAST_CONFIG: DeviceDeprecationConfigs = [
       {
-        deviceModelId: MODEL,
+        deviceModelId: LLDeviceModelId.nanoS,
         warningScreen: { date: FUTURE, deprecatedFlow: [] },
         errorScreen: { date: PAST, deprecatedFlow: ["receive"] },
         warningClearSigningScreen: { date: FUTURE, deprecatedFlow: [], exception: [] },
@@ -1006,18 +1007,32 @@ describe("OpenAppWithDependenciesDeviceAction", () => {
       const cfg: DeviceDeprecationConfigs = [
         baseEntry({ warningScreen: { date: PAST, deprecatedFlow: ["receive"] } }),
       ];
-      const res = isDeviceDeprecated(cfg, MODEL);
+      const res = extractDeviceDeprecationRules(cfg, MODEL);
       expect(res.warningScreenVisible).toBe(true);
       expect(res.warningScreenRules).toEqual({ exception: [], deprecatedFlow: ["receive"] });
       expect(res.errorScreenVisible).toBe(false);
       expect(res.clearSigningScreenVisible).toBe(false);
     });
 
+    it("matches Ledger Live device ids from remote config against the connected DMK model", () => {
+      const cfg: DeviceDeprecationConfigs = [
+        baseEntry({
+          deviceModelId: LLDeviceModelId.europa,
+          warningScreen: { date: PAST, deprecatedFlow: ["receive"] },
+        }),
+      ];
+
+      const res = extractDeviceDeprecationRules(cfg, DeviceModelId.FLEX);
+
+      expect(res.warningScreenVisible).toBe(true);
+      expect(res.modelId).toBe(LLDeviceModelId.europa);
+    });
+
     it("sets error visible and date = errorDate when errorScreen is past", () => {
       const cfg: DeviceDeprecationConfigs = [
         baseEntry({ errorScreen: { date: PAST, deprecatedFlow: ["receive"], exception: ["X"] } }),
       ];
-      const res = isDeviceDeprecated(cfg, MODEL);
+      const res = extractDeviceDeprecationRules(cfg, MODEL);
       expect(res.errorScreenVisible).toBe(true);
       expect(res.errorScreenRules).toEqual({ exception: ["X"], deprecatedFlow: ["receive"] });
       expect(res.date.toISOString().startsWith("2000-01-01")).toBe(true);
@@ -1033,7 +1048,7 @@ describe("OpenAppWithDependenciesDeviceAction", () => {
           },
         }),
       ];
-      const res = isDeviceDeprecated(cfg, MODEL);
+      const res = extractDeviceDeprecationRules(cfg, MODEL);
       expect(res.clearSigningScreenVisible).toBe(true);
       expect(res.clearSigningScreenRules).toEqual({
         exception: ["A", "B"],
@@ -1043,7 +1058,7 @@ describe("OpenAppWithDependenciesDeviceAction", () => {
 
     it("does not set visible flags when all dates are future", () => {
       const cfg: DeviceDeprecationConfigs = [baseEntry()];
-      const res = isDeviceDeprecated(cfg, MODEL);
+      const res = extractDeviceDeprecationRules(cfg, MODEL);
       expect(res.warningScreenVisible).toBe(false);
       expect(res.errorScreenVisible).toBe(false);
       expect(res.clearSigningScreenVisible).toBe(false);
@@ -1057,7 +1072,7 @@ describe("OpenAppWithDependenciesDeviceAction", () => {
           warningClearSigningScreen: { date: FUTURE, deprecatedFlow: [], exception: [] },
         }),
       ];
-      const res = isDeviceDeprecated(cfg, MODEL);
+      const res = extractDeviceDeprecationRules(cfg, MODEL);
       expect(res.warningScreenVisible).toBe(true);
       expect(res.errorScreenVisible).toBe(false);
       expect(res.clearSigningScreenVisible).toBe(false);

--- a/libs/live-dmk-shared/src/device-action/ConnectApp/ConnectAppDeviceAction.ts
+++ b/libs/live-dmk-shared/src/device-action/ConnectApp/ConnectAppDeviceAction.ts
@@ -32,7 +32,7 @@ import {
   DeviceDeprecationConfigs,
   DeviceDeprecationError,
 } from "./types";
-import { isDeviceDeprecated } from "./deprecation";
+import { extractDeviceDeprecationRules } from "./extractDeviceDeprecationRules";
 
 type ConnectAppMachineInternalState = {
   readonly error: ConnectAppDAError | null;
@@ -123,13 +123,13 @@ export class ConnectAppDeviceAction extends XStateDeviceAction<
           }
           return await this.input.requiredDerivation();
         }),
-        isDeviceDeprecated: fromPromise(async ({ input }) => {
+        extractDeviceDeprecationRules: fromPromise(async ({ input }) => {
           const { deprecationConfig, modelId } = input as {
             deprecationConfig: DeviceDeprecationConfigs;
             modelId: DeviceModelId;
           };
 
-          const payload = isDeviceDeprecated(deprecationConfig, modelId);
+          const payload = extractDeviceDeprecationRules(deprecationConfig, modelId);
 
           return payload;
         }),
@@ -146,22 +146,19 @@ export class ConnectAppDeviceAction extends XStateDeviceAction<
         }) => ConnectAppDeviceAction.isAppOpened(application, deviceStatus!, deviceModel!),
         requiresDerivation: ({ context }) => context.input.requiredDerivation !== undefined,
         hasError: ({ context }) => context._internalState.error !== null,
-        isDeprecation: ({ context }) => {
+        shouldShowDeviceDeprecation: ({ context }) => {
           const configs = context.input.deprecationConfig;
-          const today = new Date();
           const modelId = context._internalState.deviceModel;
 
           if (!modelId || !configs || configs.length === 0) return false;
           if (context._internalState.deprecationShown) return false;
 
-          const isPast = (dateStr?: string) => !!dateStr && new Date(dateStr) < today;
+          const deprecation = extractDeviceDeprecationRules(configs, modelId);
 
-          return configs.some(
-            config =>
-              config.deviceModelId === modelId &&
-              (isPast(config.errorScreen?.date) ||
-                isPast(config.warningScreen?.date) ||
-                isPast(config.warningClearSigningScreen?.date)),
+          return (
+            deprecation.errorScreenVisible ||
+            deprecation.warningScreenVisible ||
+            deprecation.clearSigningScreenVisible
           );
         },
       },
@@ -247,7 +244,7 @@ export class ConnectAppDeviceAction extends XStateDeviceAction<
               }),
             },
             onDone: {
-              target: "IsDeviceDeprecatedCheck",
+              target: "DeviceDeprecationCheck",
               actions: "assignDeviceStatusFromOutput",
             },
             onError: {
@@ -256,11 +253,11 @@ export class ConnectAppDeviceAction extends XStateDeviceAction<
             },
           },
         },
-        IsDeviceDeprecatedCheck: {
+        DeviceDeprecationCheck: {
           always: [
             {
-              guard: "isDeprecation",
-              target: "DeviceDeprecated",
+              guard: "shouldShowDeviceDeprecation",
+              target: "ExtractDeviceDeprecationRules",
             },
             {
               guard: "hasError",
@@ -294,9 +291,9 @@ export class ConnectAppDeviceAction extends XStateDeviceAction<
             },
           ],
         },
-        DeviceDeprecated: {
+        ExtractDeviceDeprecationRules: {
           invoke: {
-            src: "isDeviceDeprecated",
+            src: "extractDeviceDeprecationRules",
             input: ({ context }) => ({
               deprecationConfig: context.input.deprecationConfig,
               modelId: context._internalState.deviceModel,

--- a/libs/live-dmk-shared/src/device-action/ConnectApp/extractDeviceDeprecationRules.ts
+++ b/libs/live-dmk-shared/src/device-action/ConnectApp/extractDeviceDeprecationRules.ts
@@ -6,20 +6,23 @@ import type {
   DeviceDeprecationScreenRules,
   DeviceDeprecationScreenConfig,
 } from "./types";
-import type { DeviceModelId } from "@ledgerhq/device-management-kit";
 
-export function isDeviceDeprecated(
+import type { DeviceModelId as DMKDeviceModelId } from "@ledgerhq/device-management-kit";
+import type { DeviceModelId as LLDeviceModelId } from "@ledgerhq/types-devices";
+
+export function extractDeviceDeprecationRules(
   configs: DeviceDeprecationConfigs,
-  modelId: DeviceModelId,
+  dmkDeviceModelId: DMKDeviceModelId,
 ): DeviceDeprecationRules {
   const now = new Date();
   const fallbackDate = now;
+  const llDeviceModelId: LLDeviceModelId = dmkToLedgerDeviceIdMap[dmkDeviceModelId];
 
   const base: DeviceDeprecationRules = {
     warningScreenVisible: false,
     clearSigningScreenVisible: false,
     errorScreenVisible: false,
-    modelId: dmkToLedgerDeviceIdMap[modelId],
+    modelId: llDeviceModelId,
     date: fallbackDate,
     warningScreenRules: { exception: [], deprecatedFlow: [] },
     clearSigningScreenRules: { exception: [], deprecatedFlow: [] },
@@ -28,7 +31,7 @@ export function isDeviceDeprecated(
   };
 
   const config: DeviceDeprecationConfig | undefined = configs.find(
-    (cfg: DeviceDeprecationConfig) => cfg.deviceModelId === modelId,
+    (cfg: DeviceDeprecationConfig) => cfg.deviceModelId === llDeviceModelId,
   );
   if (!config) return base;
   const createScreenRules = (

--- a/libs/live-dmk-shared/src/device-action/ConnectApp/extractDeviceDeprecationRules.ts
+++ b/libs/live-dmk-shared/src/device-action/ConnectApp/extractDeviceDeprecationRules.ts
@@ -10,6 +10,12 @@ import type {
 import type { DeviceModelId as DMKDeviceModelId } from "@ledgerhq/device-management-kit";
 import type { DeviceModelId as LLDeviceModelId } from "@ledgerhq/types-devices";
 
+/**
+ * Extracts UI deprecation rules for the connected device.
+ *
+ * Deprecation configs come from Ledger Live remote config and use Ledger Live
+ * device model ids, while the connected device model comes from DMK.
+ */
 export function extractDeviceDeprecationRules(
   configs: DeviceDeprecationConfigs,
   dmkDeviceModelId: DMKDeviceModelId,

--- a/libs/live-dmk-shared/src/device-action/ConnectApp/types.ts
+++ b/libs/live-dmk-shared/src/device-action/ConnectApp/types.ts
@@ -71,7 +71,7 @@ export type DeviceDeprecationScreenConfig = {
  * @property warningClearSigningScreen: config for the warning screen shown when clearing signing
  */
 export type DeviceDeprecationConfig = {
-  deviceModelId: string;
+  deviceModelId: LLDeviceModelId;
   warningScreen: DeviceDeprecationScreenConfig;
   errorScreen: DeviceDeprecationScreenConfig;
   warningClearSigningScreen: DeviceDeprecationScreenConfig;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added coverage for LL `europa` config matching a DMK `FLEX` device model.
- [x] **Impact of the changes:**
  - Deprecation config now explicitly uses Ledger Live device ids.
  - No expected production change today: prod only targets Nano S, where DMK and LL ids both resolve to `"nanoS"`.

### 📝 Description

While implementing DIE on LWD, we noticed the dev scenarios only triggered deprecation screens when mocked with DMK model ids. That is not the shape we expect from LiveConfig: device deprecation config belongs to Ledger Live and should use Ledger Live device ids.

This PR makes that boundary explicit. `DeviceDeprecationConfig` expects LL device ids, and Connect App maps the connected DMK model id to its LL id before extracting deprecation rules.

It also renames the deprecation helper/actor/guard to better describe what they do: extract UI deprecation rules rather than answer a boolean question.

### ❓ Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A