### PR TITLE
fix(e2e-swap): normalize swap amount precision before device verification

### DIFF
--- a/e2e/mobile/specs/swap/swap.ts
+++ b/e2e/mobile/specs/swap/swap.ts
@@ -47,7 +47,10 @@ export function runSwapTest(
     it(`Swap ${accountToDebit.currency.name} to ${accountToCredit.currency.name}`, async () => {
       const minAmount = await app.swapLiveApp.getMinimumAmount(accountToDebit, accountToCredit);
       const swapAmount = minAmount
-        ? (Math.trunc(Number(minAmount) * 1e8) / 1e8).toFixed(8).replace(/0+$/, "").replace(/\.$/, "")
+        ? (Math.trunc(Number(minAmount) * 1e8) / 1e8)
+            .toFixed(8)
+            .replace(/0+$/, "")
+            .replace(/\.$/, "")
         : minAmount;
       swap.amount = swapAmount;
 

--- a/e2e/mobile/specs/swap/swap.ts
+++ b/e2e/mobile/specs/swap/swap.ts
@@ -47,7 +47,7 @@ export function runSwapTest(
     it(`Swap ${accountToDebit.currency.name} to ${accountToCredit.currency.name}`, async () => {
       const minAmount = await app.swapLiveApp.getMinimumAmount(accountToDebit, accountToCredit);
       const swapAmount = minAmount
-        ? Number(minAmount).toFixed(8).replace(/0+$/, "").replace(/\.$/, "")
+        ? (Math.trunc(Number(minAmount) * 1e8) / 1e8).toFixed(8).replace(/0+$/, "").replace(/\.$/, "")
         : minAmount;
       swap.amount = swapAmount;
 

--- a/e2e/mobile/specs/swap/swap.ts
+++ b/e2e/mobile/specs/swap/swap.ts
@@ -47,7 +47,7 @@ export function runSwapTest(
     it(`Swap ${accountToDebit.currency.name} to ${accountToCredit.currency.name}`, async () => {
       const minAmount = await app.swapLiveApp.getMinimumAmount(accountToDebit, accountToCredit);
       const swapAmount = minAmount
-        ? Number(minAmount).toFixed(8).replace(/\.?0+$/, "")
+        ? Number(minAmount).toFixed(8).replace(/0+$/, "").replace(/\.$/, "")
         : minAmount;
       swap.amount = swapAmount;
 

--- a/e2e/mobile/specs/swap/swap.ts
+++ b/e2e/mobile/specs/swap/swap.ts
@@ -46,7 +46,9 @@ export function runSwapTest(
     tags.forEach(tag => $Tag(tag));
     it(`Swap ${accountToDebit.currency.name} to ${accountToCredit.currency.name}`, async () => {
       const minAmount = await app.swapLiveApp.getMinimumAmount(accountToDebit, accountToCredit);
-      const swapAmount = parseFloat(Number(minAmount).toFixed(8)).toString();
+      const swapAmount = minAmount
+        ? Number(minAmount).toFixed(8).replace(/\.?0+$/, "")
+        : minAmount;
       swap.amount = swapAmount;
 
       await performSwapUntilQuoteSelectionStep(accountToDebit, accountToCredit, swapAmount);

--- a/e2e/mobile/specs/swap/swap.ts
+++ b/e2e/mobile/specs/swap/swap.ts
@@ -1,8 +1,8 @@
 import { SwapType } from "@ledgerhq/live-e2e-shared/models/Swap";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
+import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { setEnv } from "@ledgerhq/live-env";
 import { performSwapUntilQuoteSelectionStep } from "../../utils/swapUtils";
-import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { Fee } from "@ledgerhq/live-e2e-shared/enum/Fee";
 import { setTeamOwner } from "../../helpers/allure/allure-helper";
 import { beforeAllFunctionSwap } from "./swap.setup";
@@ -46,10 +46,7 @@ export function runSwapTest(
     tags.forEach(tag => $Tag(tag));
     it(`Swap ${accountToDebit.currency.name} to ${accountToCredit.currency.name}`, async () => {
       const minAmount = await app.swapLiveApp.getMinimumAmount(accountToDebit, accountToCredit);
-      const swapAmount =
-        accountToDebit.currency.name === Account.XRP_1.currency.name
-          ? parseFloat(Number(minAmount).toFixed(6)).toString()
-          : minAmount;
+      const swapAmount = parseFloat(Number(minAmount).toFixed(8)).toString();
       swap.amount = swapAmount;
 
       await performSwapUntilQuoteSelectionStep(accountToDebit, accountToCredit, swapAmount);


### PR DESCRIPTION
## Summary

- Replaces the XRP-only `.toFixed(6)` workaround in `runSwapTest` with a universal `parseFloat(Number(minAmount).toFixed(8)).toString()` for all currencies
- Fixes the **Swap BTC→LTC** E2E test that was failing because the device never received the hold-to-sign confirmation

## Root cause

`getMinimumSwapAmount()` probes the quote API with a small amount. When the probe is **below** the provider minimum (BTC→LTC case), the API returns an `AMOUNT_OFF_LIMITS` error with a raw float `minAmount` (e.g. `0.0008087735757497331`). This full-precision string was passed directly to `verifyAmountsAndAcceptSwap`, but the Speculos device firmware truncates BTC to 8 decimal places (`0.00080877`). The substring check threw before `longPressAndRelease(HOLD_TO_SIGN)` was ever called — so the swap was never confirmed on device.

## Why other tests weren't affected

- **BTC→SOL**: probe is above the provider minimum → falls back to `getAmountFromUSD` → returns a clean round number → no precision mismatch
- **Desktop BTC→LTC**: used `toFixed(6)` → produced `0.000809` → the fuzzy regex accidentally matched by spanning the Send amount (`0.00080877`) and the `9` in the Receive amount (`1.131986**9** LTC`) in the concatenated events string

## Test plan
- [ ] Run `swapBTC_NATIVE_SEGWIT_LTC.spec.ts` — should pass, device events contain `0.00080877`, hold-to-sign executes
- [ ] Confirm XRP swap specs still pass (`toFixed(8)` + `parseFloat` is equivalent to the old `toFixed(6)` for XRP since XRP max precision is 6 decimal places)

🤖 Generated with [Claude Code](https://claude.com/claude-code)