### PR TITLE
ci: adjust permissions to auto-close smartling prs and branches

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -18,6 +18,7 @@ jobs:
   pre_job:
     permissions:
       contents: write
+      pull-requests: write
     name: "Skip Check"
     if: ${{!github.event.pull_request.head.repo.fork}}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adding explicit pr permissions for smartling to close PR requests and branches