### PR TITLE
[LWDM] chore(env): drop unused USE_LEARN_STAGING_URL

### DIFF
--- a/.changeset/clean-learn-remove.md
+++ b/.changeset/clean-learn-remove.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-env": patch
+"live-mobile": patch
+---
+
+Remove unused USE_LEARN_STAGING_URL env var

--- a/apps/ledger-live-mobile/src/experimental.ts
+++ b/apps/ledger-live-mobile/src/experimental.ts
@@ -120,12 +120,6 @@ export const developerFeatures: Feature[] = [
   },
   {
     type: "toggle",
-    name: "USE_LEARN_STAGING_URL",
-    title: i18nKeyDeveloper("staggingUrl", "title"),
-    description: i18nKeyDeveloper("staggingUrl", "description"),
-  },
-  {
-    type: "toggle",
     name: "MOCK_APP_UPDATE",
     title: i18nKeyDeveloper("mockAppUpdate", "title"),
     description: i18nKeyDeveloper("mockAppUpdate", "description"),

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -948,11 +948,6 @@ const envDefinitions = {
     parser: stringParser,
     desc: "Coingecko API",
   },
-  USE_LEARN_STAGING_URL: {
-    def: false,
-    parser: boolParser,
-    desc: "use the staging URL for the learn page",
-  },
   DYNAMIC_CAL_BASE_URL: {
     def: "https://cdn.live.ledger.com/cryptoassets",
     parser: stringParser,


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.** No test needed — dead code removal with no runtime surface.
- [x] **Impact of the changes:**
  - Removes USE_LEARN_STAGING_URL from the env registry and the mobile experimental toggles screen. No functional change.

### 📝 Description

USE_LEARN_STAGING_URL was declared in libs/env and exposed as a toggle in the mobile Developer section, but getEnv("USE_LEARN_STAGING_URL") was never called anywhere in the codebase. This PR removes the declaration and the UI toggle.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-33114
- **ADR link (if any)**: N/A