### PR TITLE
[LWDM] feat(earn): pass swapToEarn feature flag to Earn app

### DIFF
--- a/.changeset/swaptoearn-flag-to-earn-app.md
+++ b/.changeset/swaptoearn-flag-to-earn-app.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Pass the `swapToEarn` feature flag to the Earn app as a `{ enabled, params? }` object, consistent with how other flags are forwarded

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/index.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/index.test.tsx
@@ -102,6 +102,7 @@ describe("Earn screen", () => {
       initialState: withFlagOverrides({
         ptxEarnLiveApp: { enabled: true, params: { manifest_id: "earn-manifest-id" } },
         stakePrograms: { enabled: true, params: { list: [], redirects: {} } } as never,
+        swapToEarn: { enabled: true, params: { foo: "bar" } } as never,
       }),
     });
 
@@ -116,6 +117,9 @@ describe("Earn screen", () => {
     expect(goToURL).toContain("lang=");
     expect(goToURL).toContain("uiVersion=");
     expect(goToURL).toContain("lw40enabled=");
+    expect(goToURL).toContain(
+      `swapToEarn=${encodeURIComponent(JSON.stringify({ enabled: true, params: { foo: "bar" } }))}`,
+    );
     useLocationSpy.mockRestore();
   });
 

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/index.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/index.test.tsx
@@ -183,6 +183,40 @@ describe("Earn screen", () => {
     expect(lastCall.inputs.lw40enabled).toBe("true");
   });
 
+  it("passes swapToEarn with enabled and params when the feature is enabled", () => {
+    render(<Earn />, {
+      initialState: withFlagOverrides({
+        ptxEarnLiveApp: { enabled: true, params: { manifest_id: "earn-manifest-id" } },
+        stakePrograms: { enabled: true, params: { list: [], redirects: {} } } as never,
+        swapToEarn: { enabled: true, params: { foo: "bar" } } as never,
+      }),
+    });
+
+    const lastCall = mockWebPlatformPlayer.mock.calls.at(-1)?.[0] as unknown as {
+      inputs: Record<string, string | undefined>;
+    };
+
+    expect(lastCall.inputs.swapToEarn).toBe(
+      JSON.stringify({ enabled: true, params: { foo: "bar" } }),
+    );
+  });
+
+  it("passes swapToEarn with enabled=false and no params key when the feature is disabled", () => {
+    render(<Earn />, {
+      initialState: withFlagOverrides({
+        ptxEarnLiveApp: { enabled: true, params: { manifest_id: "earn-manifest-id" } },
+        stakePrograms: { enabled: true, params: { list: [], redirects: {} } } as never,
+        swapToEarn: { enabled: false } as never,
+      }),
+    });
+
+    const lastCall = mockWebPlatformPlayer.mock.calls.at(-1)?.[0] as unknown as {
+      inputs: Record<string, string | undefined>;
+    };
+
+    expect(lastCall.inputs.swapToEarn).toBe(JSON.stringify({ enabled: false }));
+  });
+
   it("passes uiVersion v4 when earn simulator is enabled", () => {
     render(<Earn />, {
       initialState: withFlagOverrides({

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
@@ -72,6 +72,15 @@ const Earn = () => {
     [stakePrograms],
   );
 
+  const swapToEarnFlag = useFeature("swapToEarn");
+  const swapToEarnParam = useMemo(
+    () =>
+      swapToEarnFlag
+        ? JSON.stringify({ enabled: swapToEarnFlag.enabled, params: swapToEarnFlag.params })
+        : undefined,
+    [swapToEarnFlag],
+  );
+
   const { updateManifests } = useRemoteLiveAppContext();
 
   const inputs = useMemo(() => {
@@ -91,6 +100,7 @@ const Earn = () => {
       stakeProgramsParam: stakeProgramsParam ? JSON.stringify(stakeProgramsParam) : undefined,
       stakeCurrenciesParam: stakeCurrenciesParam ? JSON.stringify(stakeCurrenciesParam) : undefined,
       ethDepositCohort,
+      swapToEarn: swapToEarnParam,
     };
 
     return {
@@ -114,6 +124,7 @@ const Earn = () => {
     stakeProgramsParam,
     stakeCurrenciesParam,
     ethDepositCohort,
+    swapToEarnParam,
   ]);
 
   if (!manifest) {

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
@@ -85,6 +85,15 @@ function Earn({ route }: Props) {
     [stakePrograms],
   );
 
+  const swapToEarnFlag = useFeature("swapToEarn");
+  const swapToEarnParam = useMemo(
+    () =>
+      swapToEarnFlag
+        ? JSON.stringify({ enabled: swapToEarnFlag.enabled, params: swapToEarnFlag.params })
+        : undefined,
+    [swapToEarnFlag],
+  );
+
   if (!remoteLiveAppState.isLoading && !manifest) {
     console.error(appManifestNotFoundError);
   }
@@ -106,6 +115,7 @@ function Earn({ route }: Props) {
       stakeCurrenciesParam: stakeCurrenciesParam?.length
         ? JSON.stringify(stakeCurrenciesParam)
         : undefined,
+      swapToEarn: swapToEarnParam,
       OS: Platform.OS,
       ethDepositCohort,
       uiVersion: "v1",
@@ -127,6 +137,7 @@ function Earn({ route }: Props) {
     stakeProgramsParam,
     stakeCurrenciesParam,
     ethDepositCohort,
+    swapToEarnParam,
     params,
     searchParams,
   ]);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Earn dashboard on **mobile** and **desktop** loads correctly (webview receives a new `swapToEarn` input key)
  - Verify the Earn app receives `swapToEarn` as a JSON `{ enabled, params? }` object when the `swapToEarn` flag is enabled/disabled
  - No regression in existing Earn params (`stakeProgramsParam`, `stakeCurrenciesParam`, `ethDepositCohort`, etc.)

### 📝 Description

The `swapToEarn` feature flag was not being forwarded to the Earn live app, so the Earn app had no way to know whether Swap-to-Earn should be enabled or what params to use.

This PR forwards the `swapToEarn` flag to the Earn app on both **mobile** and **desktop**, following the same pattern used for other flags (e.g. `stakePrograms`). The flag is passed as a JSON-stringified `{ enabled: boolean, params?: Record<string, unknown> }` object. `params` is omitted when absent.

```ts
const swapToEarnFlag = useFeature("swapToEarn");
const swapToEarnParam = useMemo(
  () =>
    swapToEarnFlag
      ? JSON.stringify({ enabled: swapToEarnFlag.enabled, params: swapToEarnFlag.params })
      : undefined,
  [swapToEarnFlag],
);
// ...forwarded as `swapToEarn` in the Earn webview inputs, when present.
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33662](https://ledgerhq.atlassian.net/browse/LIVE-33662)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33662]: https://ledgerhq.atlassian.net/browse/LIVE-33662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ