### PR TITLE
[LWD] chore(desktop): drop deprecated `findCryptoCurrencyByTicker`

### DIFF
--- a/.changeset/brave-icons-resolve.md
+++ b/.changeset/brave-icons-resolve.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Replace deprecated findCryptoCurrencyByTicker with findCryptoCurrencyById in EVM staking provider icon

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/component/ProviderItem.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/component/ProviderItem.tsx
@@ -1,6 +1,6 @@
 import { useRemoteLiveAppManifest } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
-import { findCryptoCurrencyByTicker } from "@ledgerhq/live-common/currencies/index";
+import { findCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { Flex, Icon, Text } from "@ledgerhq/react-ui";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import { EthStakingProvider } from "@ledgerhq/types-live";
@@ -39,14 +39,13 @@ function StakingIcon({ icon }: { icon?: string }) {
     );
   }
   if (iconType === "crypto") {
-    const currency = findCryptoCurrencyByTicker(iconName);
+    const currency = findCryptoCurrencyById(iconName);
     if (currency) {
       const ledgerId = currency.id;
       const ticker = currency.ticker;
       return <CryptoIcon ledgerId={ledgerId} ticker={ticker} size={56} />;
     }
-    // Fallback: if currency not found, just use the ticker (library will handle fallback)
-    return <CryptoIcon ledgerId={iconName.toLowerCase()} ticker={iconName} size={56} />;
+    return <CryptoIcon ledgerId={iconName.trim().toLowerCase()} ticker={iconName} size={56} />;
   }
   if (iconType === "provider") {
     return (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Replace deprecated `findCryptoCurrencyByTicker` with `findCryptoCurrencyById` in `StakingIcon`
- The `ethStakingProviders` feature flag icon format for `:crypto` type now expects a `ledgerId` (e.g. `"ethereum:crypto"`) instead of a ticker (note: no regression since format is always `:provider` in production)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
