### PR TITLE
[LWD] fix: keep caret in place when editing advanced-mode fee inputs

### DIFF
--- a/.changeset/shiny-pigs-double.md
+++ b/.changeset/shiny-pigs-double.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix: keep the caret in place when editing the EVM advanced-mode fee inputs (Max Priority Fee / Max Fee). InputCurrency now maps the caret through sanitizeValueString so editing a value already at the unit's max decimals (e.g. 9 Gwei decimals) no longer teleports the cursor to the end.

--- a/apps/ledger-live-desktop/src/renderer/components/InputCurrency.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/InputCurrency.test.tsx
@@ -72,4 +72,19 @@ describe("InputCurrency — caret preservation", () => {
     expect(input.value).toBe("3.014305248"); // value unchanged
     expect(input.selectionStart).toBe(11); // caret stays at the end, no jump
   });
+
+  it("forwards a ref to the underlying input element", () => {
+    const ref = React.createRef<HTMLInputElement>();
+    render(
+      <InputCurrency
+        ref={ref}
+        defaultUnit={gweiUnit}
+        value={new BigNumber("1000000000")} // 1 Gwei
+        onChange={() => {}}
+      />,
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    expect(ref.current).toBe(screen.getByRole("textbox"));
+  });
 });

--- a/apps/ledger-live-desktop/src/renderer/components/InputCurrency.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/InputCurrency.test.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { BigNumber } from "bignumber.js";
+import { render, screen } from "tests/testSetup";
+import InputCurrency from "./InputCurrency";
+
+// Ethereum's "Gwei" fee unit — magnitude 9, i.e. at most 9 decimals.
+const gweiUnit = { name: "Gwei", code: "Gwei", magnitude: 9 };
+
+describe("InputCurrency — caret preservation", () => {
+  // Regression: the EVM advanced-fee inputs (Max Priority Fee / Max Fee) are
+  // pre-filled by the gas tracker with values that already use all 9 Gwei
+  // decimals. Inserting a digit in the middle pushed the string to 10 decimals,
+  // sanitizeValueString truncated it, and React reset the caret to the end.
+  it("keeps the caret in place when editing a value already at the unit's max decimals", async () => {
+    const { user } = render(
+      <InputCurrency
+        autoFocus
+        defaultUnit={gweiUnit}
+        value={new BigNumber("3014305248")} // 3.014305248 Gwei
+        onChange={() => {}}
+      />,
+    );
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    expect(input.value).toBe("3.014305248");
+
+    // Place the caret right after "3." and type a digit.
+    await user.type(input, "9", { initialSelectionStart: 2, initialSelectionEnd: 2 });
+
+    // The 10th decimal overflows and is dropped, but the caret must stay right
+    // after the just-typed "9" (index 3), not teleport to the end.
+    expect(input.value).toBe("3.901430524");
+    expect(input.selectionStart).toBe(3);
+  });
+
+  it("keeps the caret in place on a normal mid-string edit (no truncation)", async () => {
+    const { user } = render(
+      <InputCurrency
+        autoFocus
+        defaultUnit={gweiUnit}
+        value={new BigNumber("1200000")} // 0.0012 Gwei — well under 9 decimals
+        onChange={() => {}}
+      />,
+    );
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    expect(input.value).toBe("0.0012");
+
+    // Insert "5" right after "0.00" (index 4).
+    await user.type(input, "5", { initialSelectionStart: 4, initialSelectionEnd: 4 });
+
+    expect(input.value).toBe("0.00512");
+    expect(input.selectionStart).toBe(5);
+  });
+
+  it("rejects an overflow digit appended at the end and leaves the caret there", async () => {
+    const { user } = render(
+      <InputCurrency
+        autoFocus
+        defaultUnit={gweiUnit}
+        value={new BigNumber("3014305248")} // 3.014305248 Gwei — already 9 decimals
+        onChange={() => {}}
+      />,
+    );
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    expect(input.value).toBe("3.014305248");
+
+    // Append a 10th decimal at the very end: it overflows and is dropped.
+    await user.type(input, "9", { initialSelectionStart: 11, initialSelectionEnd: 11 });
+
+    expect(input.value).toBe("3.014305248"); // value unchanged
+    expect(input.selectionStart).toBe(11); // caret stays at the end, no jump
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/components/InputCurrency.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/InputCurrency.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useLayoutEffect, useCallback } from "react";
+import React, { useState, useLayoutEffect, useCallback, useRef } from "react";
 import { BigNumber } from "bignumber.js";
 import { uncontrollable } from "uncontrollable";
 import styled from "styled-components";
@@ -115,6 +115,18 @@ function InputCurrency(props: Props) {
     return { isFocused, displayValue, rawValue: "" };
   });
 
+  // Merge our caret-tracking ref with any parent-forwarded ref.
+  const innerRef = useRef<HTMLInputElement | null>(null);
+  const caretRef = useRef<number | null>(null);
+  const setRefs = useCallback(
+    (node: HTMLInputElement | null) => {
+      innerRef.current = node;
+      if (typeof forwardedRef === "function") forwardedRef(node);
+      else if (forwardedRef) forwardedRef.current = node;
+    },
+    [forwardedRef],
+  );
+
   const syncInput = useCallback(
     (isFocused: boolean) => {
       setState(prev => {
@@ -155,8 +167,22 @@ function InputCurrency(props: Props) {
 
   const handleChange = useCallback(
     (val: string) => {
-      const v = decimals === 0 ? val.replace(/[.,]/g, "") : val;
+      const stripSeparators = (s: string) => (decimals === 0 ? s.replace(/[.,]/g, "") : s);
+      const v = stripSeparators(val);
       const r = sanitizeValueString(unit, v, locale);
+
+      // Capture the caret before onChange can schedule a parent re-render.
+      // sanitizeValueString can drop overflow chars (e.g. the 10th Gwei decimal),
+      // so React reassigns the value and would push the caret to the end; re-map it
+      // through the same sanitizer on the pre-caret text so it lands correctly.
+      const selectionStart = innerRef.current?.selectionStart;
+      if (selectionStart == null) {
+        caretRef.current = null;
+      } else {
+        const beforeCaret = stripSeparators(val.slice(0, selectionStart));
+        caretRef.current = sanitizeValueString(unit, beforeCaret, locale).display.length;
+      }
+
       const satoshiValue = BigNumber(r.value);
       if (!value || !value.isEqualTo(satoshiValue)) {
         onChange(satoshiValue, unit);
@@ -165,6 +191,16 @@ function InputCurrency(props: Props) {
     },
     [unit, value, locale, decimals, onChange],
   );
+
+  // Restore the caret after commit (React moved it to the end). No deps: must also
+  // fire when the sanitized value is unchanged. Only acts right after a user edit.
+  useLayoutEffect(() => {
+    const caret = caretRef.current;
+    if (caret == null || !innerRef.current) return;
+    caretRef.current = null;
+    const pos = Math.min(caret, state.displayValue.length);
+    innerRef.current.setSelectionRange(pos, pos);
+  });
 
   const handleBlur = useCallback(() => {
     syncInput(false);
@@ -203,7 +239,7 @@ function InputCurrency(props: Props) {
       {...rest}
       disabled={disabled}
       ff="Inter"
-      ref={forwardedRef}
+      ref={setRefs}
       value={state.displayValue}
       onChange={handleChange}
       onFocus={handleFocus}

--- a/apps/ledger-live-desktop/src/renderer/components/InputCurrency.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/InputCurrency.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useLayoutEffect, useCallback, useRef } from "react";
+import React, { useState, useLayoutEffect, useCallback, useRef, useImperativeHandle } from "react";
 import { BigNumber } from "bignumber.js";
 import { uncontrollable } from "uncontrollable";
 import styled from "styled-components";
@@ -115,17 +115,11 @@ function InputCurrency(props: Props) {
     return { isFocused, displayValue, rawValue: "" };
   });
 
-  // Merge our caret-tracking ref with any parent-forwarded ref.
+  // Hold the DOM input via an object ref so Input's click-to-focus (which needs a
+  // ref exposing `.current`) keeps working, and expose it to any forwarded ref.
   const innerRef = useRef<HTMLInputElement | null>(null);
   const caretRef = useRef<number | null>(null);
-  const setRefs = useCallback(
-    (node: HTMLInputElement | null) => {
-      innerRef.current = node;
-      if (typeof forwardedRef === "function") forwardedRef(node);
-      else if (forwardedRef) forwardedRef.current = node;
-    },
-    [forwardedRef],
-  );
+  useImperativeHandle(forwardedRef, () => innerRef.current as HTMLInputElement, []);
 
   const syncInput = useCallback(
     (isFocused: boolean) => {
@@ -239,7 +233,7 @@ function InputCurrency(props: Props) {
       {...rest}
       disabled={disabled}
       ff="Inter"
-      ref={setRefs}
+      ref={innerRef}
       value={state.displayValue}
       onChange={handleChange}
       onFocus={handleFocus}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** New `InputCurrency.test.tsx` covers mid-string edit, normal edit, and trailing-overflow append (RED→GREEN, non-regression).
- [x] **Impact of the changes:**
  - `InputCurrency` is shared by the Amount field (`RequestAmount`) and the EVM advanced-mode fee fields, plus most currency-amount inputs across families.
  - QA focus: typing/caret behavior in the **Amount** field and the **advanced-mode Max Priority Fee / Max Fee (Gwei)** inputs — mid-string edits, paste, and Send Max — across EVM chains; confirm no regression in normal amount entry.

### 📝 Description

Editing the EVM advanced-mode fee inputs (Max Priority Fee / Max Fee, in Gwei) moved the cursor to the end and silently dropped the value's last decimal, making the fields hard to edit; the Amount field was unaffected.

**Root cause:** the fee fields and the Amount field share `InputCurrency`, which reformats each keystroke via `sanitizeValueString`. That helper truncates once the decimal count exceeds the unit's magnitude (Gwei = 9). The gas tracker pre-fills the fee fields with values already at 9 decimals, so inserting a digit into the decimals overflows to 10 → it gets truncated → the controlled value no longer matches the DOM → React reassigns `input.value` and the caret snaps to the end. Only edits that push past 9 decimals trigger it (integer-part edits, deletions, and end-appends don't). The Amount field escapes it because its unit has 18 decimals and typed values are short.

**Fix:** capture `selectionStart` before `onChange`, map it through the same sanitizer on the pre-caret substring, and restore it in a layout effect after the controlled re-render. Safe for `<input type="number">` (null `selectionStart` skips restoration) and for pasted values.

| Before | After |
| ------------- | ------------- |
| Editing the decimals of a fee value already at Gwei's 9-decimal limit jumps the cursor to the end | Cursor stays where you typed, same as the Amount field |

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-33667
- **ADR link (if any)**: —


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)