### PR TITLE
ci(e2e): run detox-ui-e2e smoke tests on PRs

### DIFF
--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -682,10 +682,7 @@ jobs:
 
   detox-ui-e2e-android:
     name: "Android UI E2E Smoke Tests"
-    continue-on-error: true
     needs: [build-android, determine-builds]
-    # Only run on merge to develop (push), not on PRs
-    if: ${{ github.event_name == 'push' && github.ref_name == 'develop' }}
     runs-on: [ledger-live-linux-8CPU-32RAM]
     timeout-minutes: 80
     env:
@@ -966,12 +963,8 @@ jobs:
 
   detox-ui-e2e-ios:
     name: "iOS UI E2E Smoke Tests"
-    continue-on-error: true
     needs: [build-ios, determine-builds]
-    # Only run on merge to develop (push), not on PRs
-    if: ${{ github.event_name == 'push' && github.ref_name == 'develop' }}
-    # Pin to performance-pool so smoke-test timing stats are accurate and consistent
-    runs-on: ["performance-pool", macOS, ARM64]
+    runs-on: ["${{ inputs.macos-specificity-runner-label }}", macOS, ARM64]
     timeout-minutes: 80
     env:
       NODE_OPTIONS: "--max-old-space-size=8192"


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _N/A — CI-only change, no package code modified._
- [ ] **Covered by automatic tests.** _This PR is itself a CI change; the smoke tests it enables are the coverage._
- [x] **Impact of the changes:**
  - `detox-ui-e2e-android` and `detox-ui-e2e-ios` smoke jobs now run on every PR that touches `ledger-live-mobile` (same trigger as the full mock suite), instead of only on push to `develop`.
  - Both jobs keep `continue-on-error: true` — they are **non-blocking**.

### 📝 Description

**Problem:** The `detox-ui-e2e-android` and `detox-ui-e2e-ios` smoke test jobs in `test-mobile-mock-reusable.yml` were gated behind `if: github.event_name == 'push' && github.ref_name == 'develop'`, meaning they only ran after a PR was merged into `develop`. Failures were discovered too late in the cycle.

**Solution:** Remove those `if` conditions so the smoke jobs run whenever the reusable workflow is called — which on PRs means when `ledger-live-mobile` is in the affected paths.

> ⚠️ **This is PR 1 of 2.** The full sharded mock tests (`detox-tests-android` / `detox-tests-ios`) are kept intentionally — they will be removed in the follow-up PR once both are ready to merge.
>
> **Do not merge this PR alone.** Both PRs should be merged together (or back-to-back) to avoid overloading the macOS runners with duplicate test runs.

### ❓ Context

- No JIRA ticket — pure CI infrastructure improvement.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)