### PR TITLE
test(desktop): prefix legacy send flow e2e describe blocks

### DIFF
--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -262,7 +262,7 @@ function shouldSkipLNSTag(currencyId: string): boolean {
 
 test.describe("Send flows", () => {
   for (const transaction of transactionE2E) {
-    test.describe("Send from 1 account to another", () => {
+    test.describe("legacy send flow - Send from 1 account to another", () => {
       test.use({
         teamOwner: Team.COIN_INTEGRATION,
         userdata: "skip-onboarding-with-last-seen-device",
@@ -324,7 +324,7 @@ test.describe("Send flows", () => {
   }
 
   for (const transaction of transactionsAmountInvalid) {
-    test.describe("Check invalid amount input error", () => {
+    test.describe("legacy send flow - Check invalid amount input error", () => {
       test.use({
         teamOwner: Team.COIN_INTEGRATION,
         userdata: "skip-onboarding-with-last-seen-device",
@@ -376,7 +376,7 @@ test.describe("Send flows", () => {
     });
   }
 
-  test.describe("Verify send max user flow", () => {
+  test.describe("legacy send flow - Verify send max user flow", () => {
     const transactionInputValid = new Transaction(
       Account.ETH_1,
       Account.ETH_2,
@@ -433,7 +433,7 @@ test.describe("Send flows", () => {
   });
 
   for (const transaction of transactionAddressValid) {
-    test.describe("Send funds step 1 (Recipient) - positive cases (Button enabled)", () => {
+    test.describe("legacy send flow - Send funds step 1 (Recipient) - positive cases (Button enabled)", () => {
       test.use({
         teamOwner: Team.COIN_INTEGRATION,
         userdata: "skip-onboarding-with-last-seen-device",
@@ -495,7 +495,7 @@ test.describe("Send flows", () => {
   }
 
   for (const transaction of transactionsAddressInvalid) {
-    test.describe("Send funds step 1 (Recipient) - negative cases (Button disabled)", () => {
+    test.describe("legacy send flow - Send funds step 1 (Recipient) - negative cases (Button disabled)", () => {
       test.use({
         teamOwner: Team.COIN_INTEGRATION,
         userdata: "skip-onboarding-with-last-seen-device",
@@ -568,7 +568,7 @@ test.describe("Send flows", () => {
     });
   }
 
-  test.describe("User sends funds to ENS address", () => {
+  test.describe("legacy send flow - User sends funds to ENS address", () => {
     const transactionEnsAddress = new Transaction(
       Account.ETH_1,
       Account.ETH_2_WITH_ENS,
@@ -630,7 +630,7 @@ test.describe("Send flows", () => {
     );
   });
 
-  test.describe("Send Concordium (Testnet)", () => {
+  test.describe("legacy send flow - Send Concordium (Testnet)", () => {
     const ccdTx = new Transaction(
       Account.CCD_TESTNET_1,
       Account.CCD_TESTNET_2,

--- a/e2e/desktop/tests/specs/subAccount.spec.ts
+++ b/e2e/desktop/tests/specs/subAccount.spec.ts
@@ -84,7 +84,7 @@ const subAccountReceive: Array<{
 ];
 
 for (const token of subAccounts) {
-  test.describe("Add subAccount without parent", () => {
+  test.describe("legacy send flow - Add subAccount without parent", () => {
     test.use({
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "skip-onboarding-with-last-seen-device",
@@ -147,7 +147,7 @@ for (const token of subAccounts) {
 }
 
 for (const token of subAccountReceive) {
-  test.describe("Add subAccount when parent exists", () => {
+  test.describe("legacy send flow - Add subAccount when parent exists", () => {
     test.use({
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "speculos-subAccount",
@@ -207,7 +207,7 @@ for (const token of subAccountReceive) {
 }
 
 for (const token of subAccounts) {
-  test.describe("Token visible in parent account", () => {
+  test.describe("legacy send flow - Token visible in parent account", () => {
     test.use({
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "speculos-subAccount",
@@ -263,7 +263,7 @@ const transactionE2E = [
 ];
 
 for (const transaction of transactionE2E) {
-  test.describe("Send token - E2E", () => {
+  test.describe("legacy send flow - Send token - E2E", () => {
     test.use({
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "skip-onboarding-with-last-seen-device",
@@ -363,7 +363,7 @@ const transactionsAddressInvalid = [
 ];
 
 for (const transaction of transactionsAddressInvalid) {
-  test.describe("Send token - invalid address input", () => {
+  test.describe("legacy send flow - Send token - invalid address input", () => {
     test.use({
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "skip-onboarding-with-last-seen-device",
@@ -435,7 +435,7 @@ const transactionsAddressValid = [
 ];
 
 for (const transaction of transactionsAddressValid) {
-  test.describe("Send token - valid address input", () => {
+  test.describe("legacy send flow - Send token - valid address input", () => {
     test.use({
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "skip-onboarding-with-last-seen-device",
@@ -517,7 +517,7 @@ const tokenTransactionInvalid = [
 ];
 
 for (const transaction of tokenTransactionInvalid) {
-  test.describe("Send token (subAccount) - invalid amount input", () => {
+  test.describe("legacy send flow - Send token (subAccount) - invalid amount input", () => {
     test.use({
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "skip-onboarding-with-last-seen-device",
@@ -574,7 +574,7 @@ for (const transaction of tokenTransactionInvalid) {
   });
 }
 
-test.describe("Send token (subAccount) - valid address & amount input", () => {
+test.describe("legacy send flow - Send token (subAccount) - valid address & amount input", () => {
   const tokenTransactionValid = new Transaction(
     TokenAccount.ETH_USDT_1,
     TokenAccount.ETH_USDT_3,


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not applicable — only the private `ledger-live-desktop-e2e-tests` package is touched, which is not published._
- [x] **Covered by automatic tests.** _This change is test-only: it renames e2e `describe` blocks._
- [x] **Impact of the changes:**
  - Desktop e2e test reporting/naming only — no product code touched.
  - Verify the renamed `describe` blocks still run and report under their new "legacy send flow - ..." titles in Allure/CI.

### 📝 Description

The e2e `describe` blocks that force the old send flow via the `FF_NEW_SEND_FLOW_DISABLED` feature flag were named identically to generic send tests, making it impossible to tell at a glance which suites exercise the legacy flow versus the new one.

Every `test.describe` in `send.tx.spec.ts` (7 blocks) and `subAccount.spec.ts` (8 blocks) that uses `FF_NEW_SEND_FLOW_DISABLED` is now prefixed with `"legacy send flow - "`, mirroring the naming convention used for the new send flow. No test logic, tags, or product code changed.

### ❓ Context

- **JIRA or GitHub link**: _No linked ticket._

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)