### PR TITLE
[LWM] feat(lwm): switch to deviceaction instead of die with FF on new send …

### DIFF
--- a/.changeset/bright-flies-explode.md
+++ b/.changeset/bright-flies-explode.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@shared/feature-flags": minor
+---
+
+feat(lwm): switch to deviceaction instead of die with FF on new send flow

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -479,6 +479,9 @@
     "FeeRequired": {
       "title": "Fees are required"
     },
+    "FeeTooHigh": {
+      "title": "Network fees are above 10% of the amount"
+    },
     "FeeTooLow": {
       "title": "Fees are too low to be accepted by the network. Please increase them"
     },
@@ -911,6 +914,9 @@
     },
     "NotSupportedLegacyAddress": {
       "title": "The legacy address format is no longer supported"
+    },
+    "RecipientRequired": {
+      "title": "Recipient address is required"
     },
     "SourceHasMultiSign": {
       "title": "Please disable multisign to send {{currencyName}}"
@@ -4572,6 +4578,10 @@
           "description": "You rejected the transaction. Your funds won't be affected.",
           "close": "Close",
           "retry": "Try again"
+        },
+        "error": {
+          "retry": "Try again",
+          "close": "Close"
         }
       },
       "confirmation": {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/SignatureDeviceActionScreen.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/SignatureDeviceActionScreen.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { SignatureDeviceActionView } from "./components/SignatureDeviceActionView";
+import { useSignatureDeviceActionViewModel } from "./hooks/useSignatureDeviceActionViewModel";
+
+export function SignatureDeviceActionScreen() {
+  const {
+    account,
+    parentAccount,
+    transaction,
+    request,
+    action,
+    selectedDevice,
+    setSelectedDevice,
+    onDeviceActionResultCompleted,
+    onUserCancel,
+  } = useSignatureDeviceActionViewModel();
+
+  if (!account || !transaction || !request) {
+    return null;
+  }
+
+  return (
+    <SignatureDeviceActionView
+      account={account}
+      parentAccount={parentAccount}
+      request={request}
+      action={action}
+      selectedDevice={selectedDevice}
+      setSelectedDevice={setSelectedDevice}
+      onDeviceActionResultCompleted={onDeviceActionResultCompleted}
+      onUserCancel={onUserCancel}
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/SignatureExecutorScreen.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/SignatureExecutorScreen.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { SignatureScreenView } from "./components/SignatureScreenView";
+import { useSignatureViewModel } from "./hooks/useSignatureViewModel";
+
+export function SignatureExecutorScreen() {
+  const {
+    account,
+    parentAccount,
+    transaction,
+    request,
+    deviceInitializationInput,
+    signatureIntent,
+    onIntentJobStateChanged,
+    onIntentJobError,
+    onUserCancel,
+  } = useSignatureViewModel();
+
+  if (!account || !transaction || !request || !deviceInitializationInput || !signatureIntent) {
+    return null;
+  }
+
+  return (
+    <SignatureScreenView
+      deviceInitializationInput={deviceInitializationInput}
+      signatureIntent={signatureIntent}
+      onIntentJobStateChanged={onIntentJobStateChanged}
+      onIntentJobError={onIntentJobError}
+      onUserCancel={onUserCancel}
+      account={account}
+      parentAccount={parentAccount ?? undefined}
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/__tests__/SignatureScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/__tests__/SignatureScreen.test.tsx
@@ -3,13 +3,18 @@ import { Observable } from "rxjs";
 import type { SignatureRequest } from "@ledgerhq/live-common/flows/send/hooks/useSendFlowSignatureCore";
 import type { SignTransactionIntent } from "@ledgerhq/live-common/intents/signTransactionIntent";
 import type { InitializationInput } from "LLM/components/DeviceIntentExecutor";
+import { useFeature } from "@features/platform-feature-flags";
 import { render, screen } from "@tests/test-renderer";
 import { SignatureScreen } from "../index";
 import * as UseSignatureViewModelModule from "../hooks/useSignatureViewModel";
+import * as UseSignatureDeviceActionViewModelModule from "../hooks/useSignatureDeviceActionViewModel";
 import { createBitcoinTransaction } from "../../CoinControl/hooks/__tests__/helpers";
 import { createMockAccount } from "../../Recipient/hooks/__tests__/accounts";
 
 type SignatureViewModel = ReturnType<typeof UseSignatureViewModelModule.useSignatureViewModel>;
+type SignatureDeviceActionViewModel = ReturnType<
+  typeof UseSignatureDeviceActionViewModelModule.useSignatureDeviceActionViewModel
+>;
 
 const mockAccount = createMockAccount({ id: "account-1" });
 const mockParentAccount = createMockAccount({ id: "account-0" });
@@ -36,6 +41,7 @@ const mockSignatureIntent = {
 } satisfies SignTransactionIntent;
 
 const mockDeviceIntentExecutorLWM = jest.fn();
+const mockSignatureDeviceActionView = jest.fn();
 
 jest.mock(
   "@ledgerhq/live-common/firebase/featureFlags",
@@ -67,6 +73,22 @@ jest.mock("../hooks/useSignatureViewModel", () => ({
   useSignatureViewModel: jest.fn(),
 }));
 
+jest.mock("../hooks/useSignatureDeviceActionViewModel", () => ({
+  useSignatureDeviceActionViewModel: jest.fn(),
+}));
+
+jest.mock("../components/SignatureDeviceActionView", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+
+  return {
+    SignatureDeviceActionView: (props: unknown) => {
+      mockSignatureDeviceActionView(props);
+      return React.createElement(View, { testID: "send-signature-device-action-step" });
+    },
+  };
+});
+
 function buildViewModel(overrides: Partial<SignatureViewModel> = {}): SignatureViewModel {
   return {
     account: mockAccount,
@@ -83,12 +105,36 @@ function buildViewModel(overrides: Partial<SignatureViewModel> = {}): SignatureV
   };
 }
 
+function buildDeviceActionViewModel(
+  overrides: Partial<SignatureDeviceActionViewModel> = {},
+): SignatureDeviceActionViewModel {
+  return {
+    account: mockAccount,
+    parentAccount: mockParentAccount,
+    transaction: mockTransaction,
+    request: mockRequest,
+    action: {
+      useHook: jest.fn(),
+      mapResult: jest.fn(),
+    } as unknown as SignatureDeviceActionViewModel["action"],
+    selectedDevice: null,
+    setSelectedDevice: jest.fn(),
+    onDeviceActionResultCompleted: jest.fn(),
+    onUserCancel: jest.fn(),
+    ...overrides,
+  };
+}
+
 describe("SignatureScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(useFeature).mockReturnValue({ enabled: false });
     jest
       .mocked(UseSignatureViewModelModule.useSignatureViewModel)
       .mockReturnValue(buildViewModel());
+    jest
+      .mocked(UseSignatureDeviceActionViewModelModule.useSignatureDeviceActionViewModel)
+      .mockReturnValue(buildDeviceActionViewModel());
   });
 
   describe("when required flow data is missing", () => {
@@ -125,13 +171,15 @@ describe("SignatureScreen", () => {
     });
   });
 
-  it("should render DeviceIntentExecutorLWM with signature props", () => {
+  it("should render DeviceIntentExecutorLWM when useDeviceActionSignatureSend is disabled", () => {
     const viewModel = buildViewModel();
     jest.mocked(UseSignatureViewModelModule.useSignatureViewModel).mockReturnValue(viewModel);
 
     render(<SignatureScreen />);
 
+    expect(useFeature).toHaveBeenCalledWith("useDeviceActionSignatureSend");
     expect(screen.getByTestId("send-signature-step")).toBeOnTheScreen();
+    expect(mockSignatureDeviceActionView).not.toHaveBeenCalled();
     expect(mockDeviceIntentExecutorLWM).toHaveBeenCalledWith(
       expect.objectContaining({
         enabled: true,
@@ -142,6 +190,32 @@ describe("SignatureScreen", () => {
         intentComponentExtraProps: undefined,
         onIntentJobStateChanged: viewModel.onIntentJobStateChanged,
         onIntentJobError: viewModel.onIntentJobError,
+        onUserCancel: viewModel.onUserCancel,
+      }),
+    );
+  });
+
+  it("should render DeviceAction screen when useDeviceActionSignatureSend is enabled", () => {
+    const viewModel = buildDeviceActionViewModel();
+    jest.mocked(useFeature).mockReturnValue({ enabled: true });
+    jest
+      .mocked(UseSignatureDeviceActionViewModelModule.useSignatureDeviceActionViewModel)
+      .mockReturnValue(viewModel);
+
+    render(<SignatureScreen />);
+
+    expect(useFeature).toHaveBeenCalledWith("useDeviceActionSignatureSend");
+    expect(screen.getByTestId("send-signature-device-action-step")).toBeOnTheScreen();
+    expect(mockDeviceIntentExecutorLWM).not.toHaveBeenCalled();
+    expect(mockSignatureDeviceActionView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: viewModel.account,
+        parentAccount: viewModel.parentAccount,
+        request: viewModel.request,
+        action: viewModel.action,
+        selectedDevice: viewModel.selectedDevice,
+        setSelectedDevice: viewModel.setSelectedDevice,
+        onDeviceActionResultCompleted: viewModel.onDeviceActionResultCompleted,
         onUserCancel: viewModel.onUserCancel,
       }),
     );

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureDeviceActionView/components/SignatureCancelledState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureDeviceActionView/components/SignatureCancelledState.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { InfoState } from "LLM/components/InfoState";
+import { useTranslation } from "~/context/Locale";
+
+type SignatureCancelledStateProps = Readonly<{
+  onClose: () => void;
+  onRetry: () => void;
+}>;
+
+export function SignatureCancelledState({ onClose, onRetry }: SignatureCancelledStateProps) {
+  const { t } = useTranslation();
+
+  return (
+    <InfoState
+      preset="info"
+      size="hug"
+      title={t("send.newSendFlow.sign.cancelled.title")}
+      description={t("send.newSendFlow.sign.cancelled.description")}
+      primaryCta={{
+        label: t("send.newSendFlow.sign.cancelled.close"),
+        onPress: onClose,
+        testID: "send-signature-cancelled-close",
+      }}
+      secondaryCta={{
+        label: t("send.newSendFlow.sign.cancelled.retry"),
+        onPress: onRetry,
+        testID: "send-signature-cancelled-retry",
+      }}
+      testID="send-signature-cancelled"
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureDeviceActionView/components/SignatureErrorState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureDeviceActionView/components/SignatureErrorState.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { InfoState } from "LLM/components/InfoState";
+import TranslatedError from "~/components/TranslatedError";
+import { useTranslation } from "~/context/Locale";
+
+type SignatureErrorStateProps = Readonly<{
+  error: Error;
+  onClose: () => void;
+  onRetry: () => void;
+}>;
+
+export function SignatureErrorState({ error, onClose, onRetry }: SignatureErrorStateProps) {
+  const { t } = useTranslation();
+
+  return (
+    <InfoState
+      preset="error"
+      size="hug"
+      title={<TranslatedError error={error} field="title" />}
+      description={<TranslatedError error={error} field="description" />}
+      primaryCta={{
+        label: t("send.newSendFlow.sign.error.retry"),
+        onPress: onRetry,
+        testID: "send-signature-error-retry",
+      }}
+      secondaryCta={{
+        label: t("send.newSendFlow.sign.error.close"),
+        onPress: onClose,
+        testID: "send-signature-error-close",
+      }}
+      testID="send-signature-error"
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureDeviceActionView/components/SigningBody.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureDeviceActionView/components/SigningBody.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect } from "react";
+import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { SimplifiedTransactionConfirm } from "../../SimplifiedTransactionConfirm";
+import { SignatureCancelledState } from "./SignatureCancelledState";
+import { SignatureErrorState } from "./SignatureErrorState";
+import { SigningLoader } from "./SigningLoader";
+
+type SignatureDeviceActionViewModel = ReturnType<
+  typeof import("../../../hooks/useSignatureDeviceActionViewModel").useSignatureDeviceActionViewModel
+>;
+
+type SigningBodyProps = Readonly<{
+  device: Device;
+  action: SignatureDeviceActionViewModel["action"];
+  request: NonNullable<SignatureDeviceActionViewModel["request"]>;
+  onResult: SignatureDeviceActionViewModel["onDeviceActionResultCompleted"];
+  onClose: () => void;
+}>;
+
+export function SigningBody({ device, action, request, onResult, onClose }: SigningBodyProps) {
+  const status = action.useHook(device, request);
+  const payload = action.mapResult(status);
+
+  const signedOperation =
+    payload && "signedOperation" in payload ? payload.signedOperation : undefined;
+
+  useEffect(() => {
+    if (signedOperation) {
+      onResult({ signedOperation, device });
+    }
+  }, [signedOperation, device, onResult]);
+
+  const signError = status.transactionSignError ?? status.error ?? undefined;
+
+  if (signError) {
+    const isUserRefused =
+      signError instanceof UserRefusedOnDevice || signError instanceof TransactionRefusedOnDevice;
+
+    return isUserRefused ? (
+      <SignatureCancelledState onClose={onClose} onRetry={status.onRetry} />
+    ) : (
+      <SignatureErrorState error={signError} onClose={onClose} onRetry={status.onRetry} />
+    );
+  }
+
+  // Broadcasting after signature, or the device confirmation is displayed on-device.
+  if (signedOperation) {
+    return <SigningLoader />;
+  }
+
+  if (status.deviceSignatureRequested) {
+    return <SimplifiedTransactionConfirm deviceModelId={device.modelId} />;
+  }
+
+  // Connecting, opening the app or streaming the transaction to the device.
+  return <SigningLoader />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureDeviceActionView/components/SigningLoader.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureDeviceActionView/components/SigningLoader.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { View } from "react-native";
+import InfiniteLoader from "~/components/InfiniteLoader";
+
+const loaderContainerStyle = {
+  flex: 1,
+  minHeight: 320,
+  alignItems: "center",
+  justifyContent: "center",
+} as const;
+
+export function SigningLoader() {
+  return (
+    <View style={loaderContainerStyle}>
+      <InfiniteLoader testID="send-signature-loading" />
+    </View>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureDeviceActionView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureDeviceActionView/index.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useMemo } from "react";
+import { View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { BottomSheetView } from "@ledgerhq/lumen-ui-rnative";
+import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import SelectDevice2, { type SetHeaderOptionsRequest } from "~/components/SelectDevice2";
+import { useAnalytics } from "~/analytics";
+import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework/tracking/send";
+import { SigningBody } from "./components/SigningBody";
+
+type SignatureDeviceActionViewModel = ReturnType<
+  typeof import("../../hooks/useSignatureDeviceActionViewModel").useSignatureDeviceActionViewModel
+>;
+
+type SignatureDeviceActionViewProps = Pick<
+  SignatureDeviceActionViewModel,
+  | "account"
+  | "parentAccount"
+  | "request"
+  | "action"
+  | "selectedDevice"
+  | "setSelectedDevice"
+  | "onDeviceActionResultCompleted"
+  | "onUserCancel"
+>;
+
+// SelectDevice2 can request to override the navigation header during the BLE pairing flow. Inside
+// the signature overlay we do not own a dedicated header, and auto-selection means the pairing flow
+// is rarely reached, so header override requests are intentionally ignored here.
+const ignoreHeaderOptions = (_request: SetHeaderOptionsRequest) => undefined;
+
+export function SignatureDeviceActionView({
+  account,
+  parentAccount,
+  request,
+  action,
+  selectedDevice,
+  setSelectedDevice,
+  onDeviceActionResultCompleted,
+  onUserCancel,
+}: SignatureDeviceActionViewProps) {
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const { track } = useAnalytics();
+
+  const trackingProperties = useMemo(
+    () => getSendFlowTrackingProperties(account, parentAccount ?? undefined),
+    [account, parentAccount],
+  );
+
+  useEffect(() => {
+    track("send_modal", {
+      ...trackingProperties,
+      name: "step review device",
+      flow: "send",
+    });
+  }, [track, trackingProperties]);
+
+  return (
+    <View style={{ flex: 1 }} testID="send-signature-step">
+      <QueuedDrawerBottomSheet
+        isRequestingToBeOpened
+        onClose={onUserCancel}
+        preventBackdropClick={!!selectedDevice}
+        hideHandle
+        enableDynamicSizing
+      >
+        <BottomSheetView style={{ paddingBottom: bottomInset + 16 }}>
+          {selectedDevice && request ? (
+            <SigningBody
+              device={selectedDevice}
+              action={action}
+              request={request}
+              onResult={onDeviceActionResultCompleted}
+              onClose={onUserCancel}
+            />
+          ) : (
+            <SelectDevice2
+              onSelect={setSelectedDevice}
+              stopBleScanning={!!selectedDevice}
+              requestToSetHeaderOptions={ignoreHeaderOptions}
+              autoSelectLastConnectedDevice
+            />
+          )}
+          {selectedDevice ? <SyncSkipUnderPriority priority={100} /> : null}
+        </BottomSheetView>
+      </QueuedDrawerBottomSheet>
+    </View>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/hooks/useSignatureDeviceActionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/hooks/useSignatureDeviceActionViewModel.ts
@@ -1,0 +1,133 @@
+import { useCallback, useRef, useState } from "react";
+import type { Account, Operation } from "@ledgerhq/types-live";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { useBroadcast } from "@ledgerhq/live-common/hooks/useBroadcast";
+import { addPendingOperation } from "@ledgerhq/live-common/account/index";
+import {
+  useSendFlowSignatureCore,
+  type SignatureDeviceActionResult,
+} from "@ledgerhq/live-common/flows/send/hooks/useSendFlowSignatureCore";
+import { useDispatch, useSelector } from "~/context/hooks";
+import { updateAccountWithUpdater } from "~/actions/accounts";
+import { mevProtectionSelector } from "~/reducers/settings";
+import { broadcastLogger } from "~/datadog";
+import { useTransactionDeviceAction } from "~/hooks/deviceActions";
+import { useSendFlowActions, useSendFlowData } from "../../../context/SendFlowContext";
+import { useSendSignature } from "../../../context/SendSignatureContext";
+
+/**
+ * DeviceAction-based signature step view model (used when `useDeviceActionSignatureSend` is enabled).
+ * Shares business logic with `useSignatureViewModel` via `useSendFlowSignatureCore`; only device orchestration differs.
+ */
+export function useSignatureDeviceActionViewModel() {
+  const { operation, status } = useSendFlowActions();
+  const { state } = useSendFlowData();
+  const { finishSigning, stopSigning } = useSendSignature();
+  const reduxDispatch = useDispatch();
+
+  const { account, parentAccount, currency } = state.account;
+  const transaction = state.transaction.transaction;
+  const txStatus = state.transaction.status;
+
+  const mevProtected = useSelector(mevProtectionSelector);
+  const [selectedDevice, setSelectedDevice] = useState<Device | null>(null);
+  const isSigningCompletedRef = useRef(false);
+
+  const action = useTransactionDeviceAction();
+
+  const signatureInputsRef = useRef({ account, parentAccount, transaction, txStatus });
+  if (
+    signatureInputsRef.current.account !== account ||
+    signatureInputsRef.current.parentAccount !== parentAccount ||
+    signatureInputsRef.current.transaction !== transaction ||
+    signatureInputsRef.current.txStatus !== txStatus
+  ) {
+    isSigningCompletedRef.current = false;
+    signatureInputsRef.current = { account, parentAccount, transaction, txStatus };
+  }
+
+  const broadcast = useBroadcast({
+    account,
+    parentAccount,
+    transaction,
+    broadcastConfig: {
+      mevProtected,
+      source: {
+        type: "coin-module",
+        name: "ledger-live-mobile",
+        flags: { newSendFlow: true },
+      },
+    },
+    logger: broadcastLogger,
+  });
+
+  const registerPendingOperation = useCallback(
+    (mainAccount: Account, op: Operation) => {
+      reduxDispatch(
+        updateAccountWithUpdater({
+          accountId: mainAccount.id,
+          updater: acc => addPendingOperation(acc, op),
+        }),
+      );
+    },
+    [reduxDispatch],
+  );
+
+  const goToConfirmation = useCallback(() => {
+    // Dismisses the overlay and runs the onComplete callback registered by the triggering screen
+    // (Amount or CoinControl), matching the executor path.
+    finishSigning();
+  }, [finishSigning]);
+
+  const { request, onDeviceActionResult } = useSendFlowSignatureCore({
+    account,
+    parentAccount,
+    transaction,
+    status: txStatus,
+    currency,
+    broadcast,
+    operation,
+    statusActions: status,
+    onFinish: goToConfirmation,
+    registerPendingOperation,
+    recipientEnsName: state.recipient?.ensName,
+  });
+
+  // Only the success path advances the flow (broadcast + navigate to confirmation). Signature
+  // refusals and device errors keep the sheet open with their own retry/close affordances, exactly
+  // like the executor path (which stays on the sheet and never navigates away on failure).
+  const onDeviceActionResultCompleted = useCallback(
+    (result: SignatureDeviceActionResult) => {
+      if (isSigningCompletedRef.current) {
+        return;
+      }
+
+      if ("signedOperation" in result && result.signedOperation) {
+        isSigningCompletedRef.current = true;
+        onDeviceActionResult(result);
+      }
+    },
+    [onDeviceActionResult],
+  );
+
+  // Explicit dismiss of the sheet (close button / backdrop) closes the overlay and leaves the user
+  // on the underlying review screen, unless the signature already completed.
+  const onUserCancel = useCallback(() => {
+    if (isSigningCompletedRef.current) {
+      return;
+    }
+    stopSigning();
+  }, [stopSigning]);
+
+  return {
+    account,
+    parentAccount,
+    transaction,
+    request,
+    action,
+    selectedDevice,
+    setSelectedDevice,
+    onDeviceActionResultCompleted,
+    onUserCancel,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/index.tsx
@@ -1,33 +1,10 @@
 import React from "react";
-import { SignatureScreenView } from "./components/SignatureScreenView";
-import { useSignatureViewModel } from "./hooks/useSignatureViewModel";
+import { useFeature } from "@features/platform-feature-flags";
+import { SignatureExecutorScreen } from "./SignatureExecutorScreen";
+import { SignatureDeviceActionScreen } from "./SignatureDeviceActionScreen";
 
 export function SignatureScreen() {
-  const {
-    account,
-    parentAccount,
-    transaction,
-    request,
-    deviceInitializationInput,
-    signatureIntent,
-    onIntentJobStateChanged,
-    onIntentJobError,
-    onUserCancel,
-  } = useSignatureViewModel();
+  const useDeviceActionSignature = useFeature("useDeviceActionSignatureSend")?.enabled ?? false;
 
-  if (!account || !transaction || !request || !deviceInitializationInput || !signatureIntent) {
-    return null;
-  }
-
-  return (
-    <SignatureScreenView
-      deviceInitializationInput={deviceInitializationInput}
-      signatureIntent={signatureIntent}
-      onIntentJobStateChanged={onIntentJobStateChanged}
-      onIntentJobError={onIntentJobError}
-      onUserCancel={onUserCancel}
-      account={account}
-      parentAccount={parentAccount ?? undefined}
-    />
-  );
+  return useDeviceActionSignature ? <SignatureDeviceActionScreen /> : <SignatureExecutorScreen />;
 }

--- a/shared/feature-flags/src/flags/team-coin-integration/index.ts
+++ b/shared/feature-flags/src/flags/team-coin-integration/index.ts
@@ -110,5 +110,6 @@ export * from "./llmMemoTag";
 export * from "./llmTezosStaking";
 export * from "./llmWebviewManifestDomainCheck";
 export * from "./newSendFlow";
+export * from "./useDeviceActionSignatureSend";
 export * from "./web3hub";
 export * from "./zcashShielded";

--- a/shared/feature-flags/src/flags/team-coin-integration/useDeviceActionSignatureSend.ts
+++ b/shared/feature-flags/src/flags/team-coin-integration/useDeviceActionSignatureSend.ts
@@ -1,0 +1,3 @@
+import { flag } from "../../define";
+
+export const useDeviceActionSignatureSend = flag();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Can toggle between DIE and DeviceAction on the new send flow for LWM with the `useDeviceActionSignatureSend` feature flag

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-33735)** <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
