### PR TITLE
[LWD] feat(desktop): wire analytics consent screen as variant B

### DIFF
--- a/.changeset/wire-analytics-opt-in-screen-v2-variant-b.md
+++ b/.changeset/wire-analytics-opt-in-screen-v2-variant-b.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Wire Welcome analytics opt-in screen v2 as variant B behind lwdAnalyticsOptInScreenV2

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/const/__tests__/policyUrls.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/const/__tests__/policyUrls.test.ts
@@ -1,0 +1,21 @@
+import { EntryPoint } from "LLD/features/AnalyticsOptInPrompt/types/AnalyticsOptInPromptNavigator";
+import { urls } from "~/config/urls";
+import { analyticsOptInPolicyUrlByVariant, resolveAnalyticsOptInPolicyUrl } from "../policyUrls";
+
+describe("resolveAnalyticsOptInPolicyUrl", () => {
+  it("should use privacy policy for variant A onboarding", () => {
+    expect(resolveAnalyticsOptInPolicyUrl(EntryPoint.onboarding, "A")).toBe(
+      analyticsOptInPolicyUrlByVariant.A,
+    );
+  });
+
+  it("should use tracking policy for variant B onboarding", () => {
+    expect(resolveAnalyticsOptInPolicyUrl(EntryPoint.onboarding, "B")).toBe(
+      analyticsOptInPolicyUrlByVariant.B,
+    );
+  });
+
+  it("should use privacy policy for portfolio regardless of variant", () => {
+    expect(resolveAnalyticsOptInPolicyUrl(EntryPoint.portfolio, "B")).toBe(urls.privacyPolicy);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/const/policyUrls.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/const/policyUrls.ts
@@ -1,0 +1,21 @@
+import { urls } from "~/config/urls";
+import { EntryPoint } from "../types/AnalyticsOptInPromptNavigator";
+
+export type AnalyticsOptInVariant = "A" | "B";
+
+/** Onboarding variant B links to the tracking policy; all other paths use privacy policy. */
+export const analyticsOptInPolicyUrlByVariant = {
+  A: urls.privacyPolicy,
+  B: urls.trackingPolicy,
+} as const;
+
+export function resolveAnalyticsOptInPolicyUrl(
+  entryPoint: EntryPoint,
+  variant: AnalyticsOptInVariant,
+): string {
+  if (entryPoint === EntryPoint.onboarding && variant === "B") {
+    return analyticsOptInPolicyUrlByVariant.B;
+  }
+
+  return analyticsOptInPolicyUrlByVariant.A;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/__tests__/useShouldUseAnalyticsOptInScreenV2.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/__tests__/useShouldUseAnalyticsOptInScreenV2.test.ts
@@ -1,0 +1,98 @@
+import { renderHook } from "tests/testSetup";
+import { FEATURE_FLAGS_DEFAULTS, FEATURE_FLAGS_INITIAL_STATE } from "@shared/feature-flags";
+import { EntryPoint } from "LLD/features/AnalyticsOptInPrompt/types/AnalyticsOptInPromptNavigator";
+import { useShouldUseAnalyticsOptInScreenV2 } from "../useShouldUseAnalyticsOptInScreenV2";
+
+const buildFeatureFlagsState = (overrides: Record<string, unknown>) => ({
+  ...FEATURE_FLAGS_INITIAL_STATE,
+  overrides: {
+    ...FEATURE_FLAGS_INITIAL_STATE.overrides,
+    ...overrides,
+  },
+  resolved: {
+    ...FEATURE_FLAGS_DEFAULTS,
+    ...overrides,
+  },
+});
+
+describe("useShouldUseAnalyticsOptInScreenV2", () => {
+  it("should return true for onboarding variant B when the v2 flag is enabled", () => {
+    const { result } = renderHook(() => useShouldUseAnalyticsOptInScreenV2(EntryPoint.onboarding), {
+      initialState: {
+        featureFlags: buildFeatureFlagsState({
+          lldAnalyticsOptInPrompt: {
+            enabled: true,
+            params: { variant: "B", entryPoints: ["Onboarding"] },
+          },
+          lwdAnalyticsOptInScreenV2: { enabled: true },
+        }),
+      },
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("should return false for portfolio even when variant B and v2 flag are enabled", () => {
+    const { result } = renderHook(() => useShouldUseAnalyticsOptInScreenV2(EntryPoint.portfolio), {
+      initialState: {
+        featureFlags: buildFeatureFlagsState({
+          lldAnalyticsOptInPrompt: {
+            enabled: true,
+            params: { variant: "B", entryPoints: ["Portfolio"] },
+          },
+          lwdAnalyticsOptInScreenV2: { enabled: true },
+        }),
+      },
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("should return false for onboarding variant B when the v2 flag is disabled", () => {
+    const { result } = renderHook(() => useShouldUseAnalyticsOptInScreenV2(EntryPoint.onboarding), {
+      initialState: {
+        featureFlags: buildFeatureFlagsState({
+          lldAnalyticsOptInPrompt: {
+            enabled: true,
+            params: { variant: "B", entryPoints: ["Onboarding"] },
+          },
+          lwdAnalyticsOptInScreenV2: { enabled: false },
+        }),
+      },
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("should return false for onboarding variant A even when the v2 flag is enabled", () => {
+    const { result } = renderHook(() => useShouldUseAnalyticsOptInScreenV2(EntryPoint.onboarding), {
+      initialState: {
+        featureFlags: buildFeatureFlagsState({
+          lldAnalyticsOptInPrompt: {
+            enabled: true,
+            params: { variant: "A", entryPoints: ["Onboarding"] },
+          },
+          lwdAnalyticsOptInScreenV2: { enabled: true },
+        }),
+      },
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("should return false for onboarding variant B when lldAnalyticsOptInPrompt is disabled", () => {
+    const { result } = renderHook(() => useShouldUseAnalyticsOptInScreenV2(EntryPoint.onboarding), {
+      initialState: {
+        featureFlags: buildFeatureFlagsState({
+          lldAnalyticsOptInPrompt: {
+            enabled: false,
+            params: { variant: "B", entryPoints: ["Onboarding"] },
+          },
+          lwdAnalyticsOptInScreenV2: { enabled: true },
+        }),
+      },
+    });
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
@@ -11,10 +11,10 @@ import {
   setHasSeenAnalyticsOptInPrompt,
 } from "~/renderer/actions/settings";
 import { EntryPoint } from "../types/AnalyticsOptInPromptNavigator";
-import { urls } from "~/config/urls";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
 import { openURL } from "~/renderer/linking";
 import { track, updateIdentify } from "~/renderer/analytics/segment";
+import { resolveAnalyticsOptInPolicyUrl, type AnalyticsOptInVariant } from "../const/policyUrls";
 
 const trackingKeysByFlow: Record<EntryPoint, string> = {
   onboarding: "consent onboarding",
@@ -39,8 +39,9 @@ export const useAnalyticsOptInPrompt = ({ entryPoint }: Props) => {
 
   const [nextStep, setNextStep] = useState<(() => void) | null>(null);
   const flow = trackingKeysByFlow?.[entryPoint];
-
-  const trackingPolicyUrl = useLocalizedUrl(urls.trackingPolicy);
+  const variant = (lldAnalyticsOptInPromptFlag?.params?.variant ?? "A") as AnalyticsOptInVariant;
+  const policyUrlKey = resolveAnalyticsOptInPolicyUrl(entryPoint, variant);
+  const policyUrl = useLocalizedUrl(policyUrlKey);
 
   const openAnalyticsOptInPrompt = useCallback(
     (routePath: string, callBack: () => void) => {
@@ -89,13 +90,15 @@ export const useAnalyticsOptInPrompt = ({ entryPoint }: Props) => {
   };
 
   const handleOpenPrivacyPolicy = (page?: string) => {
-    openURL(trackingPolicyUrl);
+    openURL(policyUrl);
     track(
       "button_clicked",
       {
         button: "Learn more link",
         flow,
         page,
+        variant,
+        entryPoint,
       },
       shouldWeTrack,
     );
@@ -109,6 +112,7 @@ export const useAnalyticsOptInPrompt = ({ entryPoint }: Props) => {
     isFeatureFlagsAnalyticsPrefDisplayed: isFlagEnabled,
     lldAnalyticsOptInPromptFlag,
     flow,
+    variant,
     shouldWeTrack,
     handleOpenPrivacyPolicy,
   };

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useDrawerLogic.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useDrawerLogic.tsx
@@ -14,16 +14,16 @@ export const useDrawerLogic = ({ entryPoint, onClose }: UseDrawerLogicProps) => 
 
   const isNotOnBoarding = entryPoint !== EntryPoint.onboarding;
 
-  const { shouldWeTrack } = useAnalyticsOptInPrompt({ entryPoint });
+  const { shouldWeTrack, flow, variant } = useAnalyticsOptInPrompt({ entryPoint });
 
   const handleRequestBack = () => {
     setStep(prevState => prevState - 1);
-    track("button_clicked", { button: "back", entryPoint }, shouldWeTrack);
+    track("button_clicked", { button: "back", entryPoint, flow, variant }, shouldWeTrack);
   };
 
   const handleRequestClose = () => {
     onClose();
-    track("button_clicked", { button: "close", entryPoint }, shouldWeTrack);
+    track("button_clicked", { button: "close", entryPoint, flow, variant }, shouldWeTrack);
   };
 
   useEffect(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useShouldUseAnalyticsOptInScreenV2.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useShouldUseAnalyticsOptInScreenV2.ts
@@ -1,0 +1,14 @@
+import { useFeature } from "@features/platform-feature-flags";
+import { EntryPoint } from "../types/AnalyticsOptInPromptNavigator";
+
+export function useShouldUseAnalyticsOptInScreenV2(entryPoint: EntryPoint): boolean {
+  const lldAnalyticsOptInPrompt = useFeature("lldAnalyticsOptInPrompt");
+  const lwdAnalyticsOptInScreenV2 = useFeature("lwdAnalyticsOptInScreenV2");
+
+  return (
+    entryPoint === EntryPoint.onboarding &&
+    Boolean(lldAnalyticsOptInPrompt?.enabled) &&
+    lldAnalyticsOptInPrompt?.params?.variant === "B" &&
+    Boolean(lwdAnalyticsOptInScreenV2?.enabled)
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/screens/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/screens/index.tsx
@@ -3,11 +3,13 @@ import { SideDrawer } from "~/renderer/components/SideDrawer";
 import { useTheme } from "styled-components";
 import type { AnalyticsOptInPromptHostProps } from "LLD/features/AnalyticsOptInPrompt/types/AnalyticsOptInPromptNavigator";
 import AnalyticsOptInScreen from "LLD/features/AnalyticsOptInPrompt/screens/AnalyticsOptInScreen";
+import { AnalyticsOptInScreenV2 } from "LLD/features/AnalyticsOptInScreenV2";
 import Box from "~/renderer/components/Box";
 import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import { useDrawerLogic } from "../hooks/useDrawerLogic";
+import { useShouldUseAnalyticsOptInScreenV2 } from "../hooks/useShouldUseAnalyticsOptInScreenV2";
 
-const AnalyticsOptInPrompt = memo(
+const AnalyticsOptInPromptLegacyDrawer = memo(
   ({ onClose, onSubmit, isOpened, entryPoint }: AnalyticsOptInPromptHostProps) => {
     const { colors } = useTheme();
     const { step, setStep, handleRequestBack, handleRequestClose, preventClosable } =
@@ -40,6 +42,18 @@ const AnalyticsOptInPrompt = memo(
     );
   },
 );
+
+AnalyticsOptInPromptLegacyDrawer.displayName = "AnalyticsOptInPromptLegacyDrawer";
+
+const AnalyticsOptInPrompt = memo((props: AnalyticsOptInPromptHostProps) => {
+  const shouldUseScreenV2 = useShouldUseAnalyticsOptInScreenV2(props.entryPoint);
+
+  if (shouldUseScreenV2) {
+    return <AnalyticsOptInScreenV2 {...props} />;
+  }
+
+  return <AnalyticsOptInPromptLegacyDrawer {...props} />;
+});
 
 AnalyticsOptInPrompt.displayName = "AnalyticsOptInPrompt";
 export default withV3StyleProvider(AnalyticsOptInPrompt);

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/AnalyticsOptInScreenView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/AnalyticsOptInScreenView.tsx
@@ -2,11 +2,9 @@ import React from "react";
 import { cn } from "LLD/utils/cn";
 import { AnalyticsConsentScreen } from "./components/AnalyticsConsentScreen";
 import { PreferencesDialog } from "./components/PreferencesDialog";
-import type { useAnalyticsOptInScreenViewModel } from "./hooks/useAnalyticsOptInScreenViewModel";
+import type { AnalyticsOptInScreenViewModel } from "./hooks/useAnalyticsOptInScreenViewModel";
 
-export type AnalyticsOptInScreenViewProps = Readonly<
-  ReturnType<typeof useAnalyticsOptInScreenViewModel>
->;
+export type AnalyticsOptInScreenViewProps = Readonly<AnalyticsOptInScreenViewModel>;
 
 export function AnalyticsOptInScreenView({
   isOpened,

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/AnalyticsOptInScreenView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/AnalyticsOptInScreenView.tsx
@@ -12,6 +12,7 @@ export function AnalyticsOptInScreenView({
   isOpened,
   step,
   isPreferencesDialogOpen,
+  shouldWeTrack,
   handleAcceptAll,
   handleRefuseAll,
   handlePrevious,
@@ -39,6 +40,7 @@ export function AnalyticsOptInScreenView({
       >
         <div className="relative flex h-full min-h-0 flex-col">
           <AnalyticsConsentScreen
+            shouldWeTrack={shouldWeTrack}
             onAcceptAll={handleAcceptAll}
             onRefuseAll={handleRefuseAll}
             onPrevious={handlePrevious}
@@ -49,6 +51,7 @@ export function AnalyticsOptInScreenView({
       </div>
       <PreferencesDialog
         isOpen={isPreferencesDialogOpen}
+        shouldWeTrack={shouldWeTrack}
         onBackFromPreferences={handleBackFromPreferences}
         onClosed={handlePreferencesDialogClosed}
         draftShareAnalytics={draftShareAnalytics}

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/__integrations__/AnalyticsOptInScreen.welcome.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/__integrations__/AnalyticsOptInScreen.welcome.integration.test.tsx
@@ -23,7 +23,7 @@ const analyticsPromptEnabledOverrides = {
   lldAnalyticsOptInPrompt: {
     enabled: true,
     params: {
-      variant: "A",
+      variant: "B",
       entryPoints: ["Onboarding"],
     },
   },
@@ -44,6 +44,15 @@ const featureFlagsState = {
 describe("AnalyticsOptInScreen on Welcome", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    if (!document.getElementById("modals")) {
+      const modals = document.createElement("div");
+      modals.id = "modals";
+      document.body.appendChild(modals);
+    }
+  });
+
+  afterEach(() => {
+    document.getElementById("modals")?.remove();
   });
 
   it("should open the screen when user starts onboarding and accept continues flow", async () => {
@@ -129,6 +138,47 @@ describe("AnalyticsOptInScreen on Welcome", () => {
       }),
       true,
     );
+  });
+
+  it("should keep the legacy drawer for onboarding variant A when the v2 flag is enabled", async () => {
+    const variantAFeatureFlagsState = {
+      ...featureFlagsState,
+      overrides: {
+        ...featureFlagsState.overrides,
+        lldAnalyticsOptInPrompt: {
+          enabled: true,
+          params: {
+            variant: "A",
+            entryPoints: ["Onboarding"],
+          },
+        },
+      },
+      resolved: {
+        ...featureFlagsState.resolved,
+        lldAnalyticsOptInPrompt: {
+          enabled: true,
+          params: {
+            variant: "A",
+            entryPoints: ["Onboarding"],
+          },
+        },
+      },
+    };
+
+    const { user } = render(<Welcome />, {
+      initialState: {
+        featureFlags: variantAFeatureFlagsState,
+        settings: {
+          ...INITIAL_STATE,
+          hasSeenAnalyticsOptInPrompt: false,
+        },
+      },
+    });
+
+    await user.click(screen.getByTestId("v3-onboarding-get-started-button"));
+
+    expect(await screen.findByTestId("accept-analytics-button")).toBeVisible();
+    expect(screen.queryByTestId("analytics-opt-in-screen")).not.toBeInTheDocument();
   });
 
   it("should refuse all and close the screen", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/analytics/trackAnalyticsOptInScreen.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/analytics/trackAnalyticsOptInScreen.ts
@@ -19,6 +19,7 @@ const basePayload = (page: string): TrackPayload => ({
 export const trackAnalyticsOptInScreenClick = (
   button: string,
   page: keyof typeof ANALYTICS_OPT_IN_SCREEN_PAGES,
+  shouldWeTrack: boolean,
 ) => {
   track(
     "button_clicked",
@@ -29,11 +30,15 @@ export const trackAnalyticsOptInScreenClick = (
       variant: ANALYTICS_OPT_IN_SCREEN_VARIANT,
       entryPoint: "Onboarding",
     },
-    true,
+    shouldWeTrack,
   );
 };
 
-export const trackAnalyticsOptInScreenToggle = (toggle: string, value: boolean) => {
+export const trackAnalyticsOptInScreenToggle = (
+  toggle: string,
+  value: boolean,
+  shouldWeTrack: boolean,
+) => {
   track(
     "toggle_clicked",
     {
@@ -44,6 +49,6 @@ export const trackAnalyticsOptInScreenToggle = (toggle: string, value: boolean) 
       variant: ANALYTICS_OPT_IN_SCREEN_VARIANT,
       entryPoint: "Onboarding",
     },
-    true,
+    shouldWeTrack,
   );
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/components/AnalyticsConsentScreen.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/components/AnalyticsConsentScreen.tsx
@@ -9,6 +9,7 @@ import analyticsConsentIllustration from "LLD/features/AnalyticsOptInScreenV2/as
 import { ANALYTICS_OPT_IN_SCREEN_PAGES } from "LLD/features/AnalyticsOptInScreenV2/types";
 
 export type AnalyticsConsentScreenProps = Readonly<{
+  shouldWeTrack: boolean;
   onAcceptAll: () => void;
   onRefuseAll: () => void;
   onPrevious: () => void;
@@ -17,6 +18,7 @@ export type AnalyticsConsentScreenProps = Readonly<{
 }>;
 
 export function AnalyticsConsentScreen({
+  shouldWeTrack,
   onAcceptAll,
   onRefuseAll,
   onPrevious,
@@ -29,7 +31,7 @@ export function AnalyticsConsentScreen({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <Track onMount mandatory event={page} page={page} />
+      <Track onMount mandatory={shouldWeTrack} event={page} page={page} />
       <header className="relative flex shrink-0 items-center justify-between px-24 py-40">
         <Button size="sm" appearance="no-background" onClick={onPrevious} icon={ArrowLeft}>
           {t("analyticsOptInScreen.main.ctaPrevious")}

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/components/PreferencesDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/components/PreferencesDialog.tsx
@@ -6,6 +6,7 @@ import Track from "~/renderer/analytics/Track";
 
 export type PreferencesDialogProps = Readonly<{
   isOpen: boolean;
+  shouldWeTrack: boolean;
   onBackFromPreferences: () => void;
   onClosed: () => void;
   draftShareAnalytics: boolean;
@@ -19,6 +20,7 @@ export type PreferencesDialogProps = Readonly<{
 
 export function PreferencesDialog({
   isOpen,
+  shouldWeTrack,
   onBackFromPreferences,
   onClosed,
   draftShareAnalytics,
@@ -54,7 +56,7 @@ export function PreferencesDialog({
         onOpenAutoFocus={event => event.preventDefault()}
         onCloseAutoFocus={handleCloseAutoFocus}
       >
-        {isOpen ? <Track onMount mandatory event={page} page={page} /> : null}
+        {isOpen ? <Track onMount mandatory={shouldWeTrack} event={page} page={page} /> : null}
         <AnalyticsConsentPreferencesView
           onBackFromPreferences={onBackFromPreferences}
           draftShareAnalytics={draftShareAnalytics}

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/components/__tests__/AnalyticsConsentScreen.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/components/__tests__/AnalyticsConsentScreen.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "tests/testSetup";
 import { AnalyticsConsentScreen } from "../AnalyticsConsentScreen";
 
 const baseProps = {
+  shouldWeTrack: false,
   onAcceptAll: jest.fn(),
   onRefuseAll: jest.fn(),
   onPrevious: jest.fn(),

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/components/__tests__/PreferencesDialog.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/components/__tests__/PreferencesDialog.test.tsx
@@ -4,6 +4,7 @@ import { PreferencesDialog } from "../PreferencesDialog";
 
 const baseProps = {
   isOpen: true,
+  shouldWeTrack: false,
   onBackFromPreferences: jest.fn(),
   onClosed: jest.fn(),
   draftShareAnalytics: false,

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/hooks/__tests__/useAnalyticsOptInScreenViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/hooks/__tests__/useAnalyticsOptInScreenViewModel.test.ts
@@ -10,6 +10,12 @@ jest.mock("~/renderer/linking", () => ({
   openURL: jest.fn(),
 }));
 
+jest.mock("LLD/features/AnalyticsOptInPrompt/hooks/useCommonLogic", () => ({
+  useAnalyticsOptInPrompt: jest.fn(() => ({
+    shouldWeTrack: true,
+  })),
+}));
+
 type SettingsState = typeof INITIAL_STATE;
 
 const renderViewModel = (

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/hooks/useAnalyticsOptInScreenViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/hooks/useAnalyticsOptInScreenViewModel.ts
@@ -16,6 +16,7 @@ import {
 import { urls } from "~/config/urls";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
 import { openURL } from "~/renderer/linking";
+import { analyticsOptInPolicyUrlByVariant } from "LLD/features/AnalyticsOptInPrompt/const/policyUrls";
 
 export function useAnalyticsOptInScreenViewModel({
   isOpened = false,
@@ -24,7 +25,7 @@ export function useAnalyticsOptInScreenViewModel({
   entryPoint,
 }: AnalyticsOptInScreenHostProps) {
   const dispatch = useDispatch();
-  const trackingPolicyUrl = useLocalizedUrl(urls.trackingPolicy);
+  const trackingPolicyUrl = useLocalizedUrl(analyticsOptInPolicyUrlByVariant.B);
   const privacyPolicyUrl = useLocalizedUrl(urls.privacyPolicy);
   const { shouldWeTrack } = useAnalyticsOptInPrompt({ entryPoint });
 
@@ -143,3 +144,5 @@ export function useAnalyticsOptInScreenViewModel({
     handleOpenPrivacyPolicy,
   };
 }
+
+export type AnalyticsOptInScreenViewModel = ReturnType<typeof useAnalyticsOptInScreenViewModel>;

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/hooks/useAnalyticsOptInScreenViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/hooks/useAnalyticsOptInScreenViewModel.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import { useDispatch } from "LLD/hooks/redux";
+import { useAnalyticsOptInPrompt } from "LLD/features/AnalyticsOptInPrompt/hooks/useCommonLogic";
 import {
   trackAnalyticsOptInScreenClick,
   trackAnalyticsOptInScreenToggle,
@@ -20,10 +21,12 @@ export function useAnalyticsOptInScreenViewModel({
   isOpened = false,
   onClose,
   onSubmit,
+  entryPoint,
 }: AnalyticsOptInScreenHostProps) {
   const dispatch = useDispatch();
   const trackingPolicyUrl = useLocalizedUrl(urls.trackingPolicy);
   const privacyPolicyUrl = useLocalizedUrl(urls.privacyPolicy);
+  const { shouldWeTrack } = useAnalyticsOptInPrompt({ entryPoint });
 
   const [step, setStep] = useState<AnalyticsOptInScreenStep>("main");
   const [isPreferencesDialogOpen, setIsPreferencesDialogOpen] = useState(false);
@@ -32,13 +35,13 @@ export function useAnalyticsOptInScreenViewModel({
 
   const handleOpenTrackingPolicy = useCallback(() => {
     openURL(trackingPolicyUrl);
-    trackAnalyticsOptInScreenClick("Learn more link", "main");
-  }, [trackingPolicyUrl]);
+    trackAnalyticsOptInScreenClick("Learn more link", "main", shouldWeTrack);
+  }, [shouldWeTrack, trackingPolicyUrl]);
 
   const handleOpenPrivacyPolicy = useCallback(() => {
     openURL(privacyPolicyUrl);
-    trackAnalyticsOptInScreenClick("Learn more link", "preferences");
-  }, [privacyPolicyUrl]);
+    trackAnalyticsOptInScreenClick("Learn more link", "preferences", shouldWeTrack);
+  }, [privacyPolicyUrl, shouldWeTrack]);
 
   const closeScreen = useCallback(() => {
     setStep("main");
@@ -58,65 +61,72 @@ export function useAnalyticsOptInScreenViewModel({
 
   const handleAcceptAll = useCallback(() => {
     // Mandatory: user is opting in — always record the click (same as legacy Accept All).
-    trackAnalyticsOptInScreenClick("Accept all", "main");
+    trackAnalyticsOptInScreenClick("Accept all", "main", true);
     applyConsent(true, true);
   }, [applyConsent]);
 
   const handleRefuseAll = useCallback(() => {
-    trackAnalyticsOptInScreenClick("Refuse all", "main");
+    trackAnalyticsOptInScreenClick("Refuse all", "main", shouldWeTrack);
     applyConsent(false, false);
-  }, [applyConsent]);
+  }, [applyConsent, shouldWeTrack]);
 
   // Previous intentionally records no consent; the user returns to Welcome and the prompt can show again.
   const handlePrevious = useCallback(() => {
-    trackAnalyticsOptInScreenClick("Previous", "main");
+    trackAnalyticsOptInScreenClick("Previous", "main", shouldWeTrack);
     closeScreen();
-  }, [closeScreen]);
+  }, [closeScreen, shouldWeTrack]);
 
   const handleOpenPreferences = useCallback(() => {
-    trackAnalyticsOptInScreenClick("Set preferences", "main");
+    trackAnalyticsOptInScreenClick("Set preferences", "main", shouldWeTrack);
     setShareAnalyticsDraft(false);
     setSharePersonalizedDraft(false);
     setStep("preferences");
     setIsPreferencesDialogOpen(true);
-  }, []);
+  }, [shouldWeTrack]);
 
   const handleBackFromPreferences = useCallback(() => {
-    trackAnalyticsOptInScreenClick("Close", "preferences");
+    trackAnalyticsOptInScreenClick("Close", "preferences", shouldWeTrack);
     setIsPreferencesDialogOpen(false);
-  }, []);
+  }, [shouldWeTrack]);
 
   const handlePreferencesDialogClosed = useCallback(() => {
     setStep("main");
   }, []);
 
-  const setDraftShareAnalytics = useCallback((value: boolean) => {
-    setShareAnalyticsDraft(prev => {
-      if (prev !== value) {
-        trackAnalyticsOptInScreenToggle("Analytics", value);
-      }
-      return value;
-    });
-  }, []);
+  const setDraftShareAnalytics = useCallback(
+    (value: boolean) => {
+      setShareAnalyticsDraft(prev => {
+        if (prev !== value) {
+          trackAnalyticsOptInScreenToggle("Analytics", value, shouldWeTrack);
+        }
+        return value;
+      });
+    },
+    [shouldWeTrack],
+  );
 
-  const setDraftSharePersonalized = useCallback((value: boolean) => {
-    setSharePersonalizedDraft(prev => {
-      if (prev !== value) {
-        trackAnalyticsOptInScreenToggle("Personalised Recommendations", value);
-      }
-      return value;
-    });
-  }, []);
+  const setDraftSharePersonalized = useCallback(
+    (value: boolean) => {
+      setSharePersonalizedDraft(prev => {
+        if (prev !== value) {
+          trackAnalyticsOptInScreenToggle("Personalised Recommendations", value, shouldWeTrack);
+        }
+        return value;
+      });
+    },
+    [shouldWeTrack],
+  );
 
   const applyPreferences = useCallback(() => {
-    trackAnalyticsOptInScreenClick("Confirm", "preferences");
+    trackAnalyticsOptInScreenClick("Confirm", "preferences", shouldWeTrack);
     applyConsent(shareAnalyticsDraft, sharePersonalizedDraft);
-  }, [applyConsent, shareAnalyticsDraft, sharePersonalizedDraft]);
+  }, [applyConsent, shareAnalyticsDraft, sharePersonalizedDraft, shouldWeTrack]);
 
   return {
     isOpened,
     step,
     isPreferencesDialogOpen,
+    shouldWeTrack,
     handleAcceptAll,
     handleRefuseAll,
     handlePrevious,

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/Welcome/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/Welcome/index.tsx
@@ -3,7 +3,8 @@ import React from "react";
 import { Trans } from "react-i18next";
 import { useTheme } from "styled-components";
 import AnalyticsOptInPrompt from "LLD/features/AnalyticsOptInPrompt/screens";
-import { AnalyticsOptInScreenV2 } from "LLD/features/AnalyticsOptInScreenV2";
+import { useShouldUseAnalyticsOptInScreenV2 } from "LLD/features/AnalyticsOptInPrompt/hooks/useShouldUseAnalyticsOptInScreenV2";
+import { EntryPoint } from "LLD/features/AnalyticsOptInPrompt/types/AnalyticsOptInPromptNavigator";
 import LedgerSyncEntryPoint from "LLD/features/LedgerSyncEntryPoints";
 import { EntryPoint as LSEntryPoint } from "LLD/features/LedgerSyncEntryPoints/types";
 
@@ -21,7 +22,7 @@ import {
   TermsAndConditionsText,
   StyledLink,
 } from "./components/WelcomeStyles";
-import { useFeature, useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 
 export function Welcome() {
   const {
@@ -53,10 +54,9 @@ export function Welcome() {
   const { colors } = useTheme();
 
   const { shouldUseLazyOnboarding } = useWalletFeaturesConfig("desktop");
-  const lwdAnalyticsOptInScreenV2 = useFeature("lwdAnalyticsOptInScreenV2");
+  const shouldUseAnalyticsOptInScreenV2 = useShouldUseAnalyticsOptInScreenV2(EntryPoint.onboarding);
   const isAnalyticsOptInOpen = extendedAnalyticsOptInPromptProps.isOpened;
-  const shouldHideWelcomeCarousel =
-    isAnalyticsOptInOpen && Boolean(lwdAnalyticsOptInScreenV2?.enabled);
+  const shouldHideWelcomeCarousel = isAnalyticsOptInOpen && shouldUseAnalyticsOptInScreenV2;
 
   return (
     <WelcomeContainer ref={containerRef}>
@@ -168,12 +168,9 @@ export function Welcome() {
           </ContentOverlay>
         </>
       ) : null}
-      {isFeatureFlagsAnalyticsPrefDisplayed &&
-        (lwdAnalyticsOptInScreenV2?.enabled ? (
-          <AnalyticsOptInScreenV2 {...extendedAnalyticsOptInPromptProps} />
-        ) : (
-          <AnalyticsOptInPrompt {...extendedAnalyticsOptInPromptProps} />
-        ))}
+      {isFeatureFlagsAnalyticsPrefDisplayed && (
+        <AnalyticsOptInPrompt {...extendedAnalyticsOptInPromptProps} />
+      )}
     </WelcomeContainer>
   );
 }

--- a/shared/feature-flags/src/flags/team-engagement/lwdAnalyticsOptInScreenV2.ts
+++ b/shared/feature-flags/src/flags/team-engagement/lwdAnalyticsOptInScreenV2.ts
@@ -1,3 +1,4 @@
 import { flag } from "../../define";
 
+/** Rollout: internal QA → staged B traffic on Welcome onboarding only (with lldAnalyticsOptInPrompt variant B). */
 export const lwdAnalyticsOptInScreenV2 = flag();


### PR DESCRIPTION
### ✅ Checklist
- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Welcome onboarding analytics opt-in routing (variant B + `lwdAnalyticsOptInScreenV2`)
  - Legacy side drawer for variant A and Portfolio entry point
  - Welcome carousel visibility behind legacy drawer vs full-screen v2
  - Segment tracking payloads (`variant`, `entryPoint`)
  - Policy link URLs for variant B onboarding (tracking policy)
### 📝 Description
**Problem**: The new Welcome analytics opt-in screen v2 (LIVE-32618) was wired directly from Welcome via a feature-flag bypass, ignoring the existing `lldAnalyticsOptInPrompt` A/B variant assignment.
**Solution**: Route onboarding through `AnalyticsOptInPrompt` when `variant === "B"` and `lwdAnalyticsOptInScreenV2` is enabled. Portfolio keeps the legacy drawer. Welcome only hides the carousel for the full-screen v2 flow; the legacy drawer still shows the video behind it. Policy URLs and drawer tracking are aligned with variant B.
**Rollout**: Enable `lldAnalyticsOptInPrompt.params.variant = "B"` + `lwdAnalyticsOptInScreenV2` for internal QA, then staged B traffic on Welcome onboarding only.
### ❓ Context
- **JIRA or GitHub link**: [LIVE-32619](https://ledgerhq.atlassian.net/browse/LIVE-32619)
- **Depends on**: [LIVE-32618](https://ledgerhq.atlassian.net/browse/LIVE-32618)
---
### 🧐 Checklist for the PR Reviewers
- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32619]: https://ledgerhq.atlassian.net/browse/LIVE-32619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ