### PR TITLE
[LWM] test(swap): adopt e2e swap history test for SwapTransactionStatus drawer

### DIFF
--- a/.changeset/tame-donkeys-shout.md
+++ b/.changeset/tame-donkeys-shout.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add testIDs to SwapTransactionStatus drawer components for e2e coverage

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Details/DetailRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Details/DetailRow.tsx
@@ -4,9 +4,10 @@ import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
 type DetailRowProps = Readonly<{
   label: string;
   value: React.ReactNode;
+  testId?: string;
 }>;
 
-export function DetailRow({ label, value }: DetailRowProps) {
+export function DetailRow({ label, value, testId }: DetailRowProps) {
   return (
     <Box
       lx={{
@@ -20,7 +21,11 @@ export function DetailRow({ label, value }: DetailRowProps) {
         {label}
       </Text>
       {typeof value === "string" ? (
-        <Text typography="body3" lx={{ color: "base", textAlign: "right", flexShrink: 1 }}>
+        <Text
+          testID={testId}
+          typography="body3"
+          lx={{ color: "base", textAlign: "right", flexShrink: 1 }}
+        >
           {value}
         </Text>
       ) : (

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Details/DetailsSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Details/DetailsSection.tsx
@@ -39,6 +39,7 @@ export function DetailsSection({
   const receiveAccountValue = renderReceiveAccountValue({
     receiveAccountName,
     receiveAccountCurrency,
+    testId: "swap-transaction-details-receive-account",
   });
   const providerRow = renderProviderRow({
     label: providerLabel,
@@ -52,6 +53,7 @@ export function DetailsSection({
       <DetailRow
         label={networkFeesLabel}
         value={feesAmount ?? <Skeleton lx={{ height: "s16", width: "s96" }} />}
+        testId="swap-transaction-details-network-fees"
       />
       <DetailRow label={receiveAccountLabel} value={receiveAccountValue} />
       {providerRow}
@@ -59,7 +61,11 @@ export function DetailsSection({
         label={swapIdLabel}
         value={
           <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s6" }}>
-            <Text typography="body3SemiBold" lx={{ color: "base" }}>
+            <Text
+              testID="swap-transaction-details-swap-id"
+              typography="body3SemiBold"
+              lx={{ color: "base" }}
+            >
               {truncatedSwapId}
             </Text>
             <CopyIconButton text={swapId} />
@@ -73,11 +79,13 @@ export function DetailsSection({
 type ReceiveAccountValueProps = Readonly<{
   receiveAccountName?: string;
   receiveAccountCurrency?: CryptoCurrency;
+  testId: string;
 }>;
 
 function renderReceiveAccountValue({
   receiveAccountName,
   receiveAccountCurrency,
+  testId,
 }: ReceiveAccountValueProps) {
   if (!receiveAccountName) {
     return <Skeleton lx={{ height: "s16", width: "s112" }} />;
@@ -92,7 +100,11 @@ function renderReceiveAccountValue({
         flexShrink: 1,
       }}
     >
-      <Text typography="body3" lx={{ color: "base", textAlign: "right", flexShrink: 1 }}>
+      <Text
+        testID={testId}
+        typography="body3"
+        lx={{ color: "base", textAlign: "right", flexShrink: 1 }}
+      >
         {receiveAccountName}
       </Text>
       {receiveAccountCurrency ? (
@@ -121,6 +133,7 @@ function renderProviderRow({ label, provider, providerName, providerMainUrl }: P
         provider,
         providerName,
         providerMainUrl,
+        testId: "swap-transaction-details-provider",
       })}
     />
   );
@@ -130,14 +143,18 @@ type ProviderValueRendererProps = Readonly<{
   provider: string;
   providerName: string;
   providerMainUrl?: string;
+  testId: string;
 }>;
 
 function renderProviderValue({
   provider,
   providerName,
   providerMainUrl,
+  testId,
 }: ProviderValueRendererProps) {
-  const providerValue = <ProviderValue provider={provider} providerName={providerName} />;
+  const providerValue = (
+    <ProviderValue provider={provider} providerName={providerName} testId={testId} />
+  );
 
   if (!providerMainUrl) {
     return providerValue;
@@ -163,12 +180,13 @@ function renderProviderValue({
 type ProviderValueProps = Readonly<{
   provider: string;
   providerName: string;
+  testId: string;
 }>;
 
-function ProviderValue({ provider, providerName }: ProviderValueProps) {
+function ProviderValue({ provider, providerName, testId }: ProviderValueProps) {
   return (
     <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s6" }}>
-      <Text typography="body3SemiBold" lx={{ color: "base", textAlign: "right" }}>
+      <Text testID={testId} typography="body3SemiBold" lx={{ color: "base", textAlign: "right" }}>
         {providerName}
       </Text>
       <ProviderIcon name={provider} />

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Footer/FooterSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Footer/FooterSection.tsx
@@ -23,6 +23,7 @@ export function FooterSection({ explorerUrl, isLoading }: FooterSectionProps) {
 
   return (
     <Button
+      testID="swap-transaction-view-explorer-btn"
       appearance="transparent"
       size="md"
       icon={ExternalLink}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Status/StatusRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Status/StatusRow.tsx
@@ -17,6 +17,7 @@ type StatusRowProps = Readonly<{
   isLoading: boolean;
   lineStatus?: SwapTransactionStatusDisplayStatus;
   isLast?: boolean;
+  testId?: string;
 }>;
 
 export function StatusRow({
@@ -27,11 +28,12 @@ export function StatusRow({
   isLoading,
   lineStatus,
   isLast,
+  testId,
 }: StatusRowProps) {
   const visualTokens = getSwapTransactionStatusVisualTokens(status);
 
   return (
-    <Box lx={{ flexDirection: "row", gap: "s12" }}>
+    <Box testID={testId ? `${testId}-row` : undefined} lx={{ flexDirection: "row", gap: "s12" }}>
       <Box lx={{ alignItems: "center", width: "s20", paddingTop: "s1" }}>
         {renderStatusIcon(visualTokens.icon)}
         {isLast ? null : <StatusLine status={lineStatus ?? status} />}
@@ -46,7 +48,11 @@ export function StatusRow({
             </Text>
           )}
           {typeof value === "string" ? (
-            <Text typography="body2SemiBold" lx={{ color: "base", textAlign: "right" }}>
+            <Text
+              testID={testId ? `${testId}-amount` : undefined}
+              typography="body2SemiBold"
+              lx={{ color: "base", textAlign: "right" }}
+            >
               {value}
             </Text>
           ) : (

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Status/StatusSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Status/StatusSection.tsx
@@ -44,6 +44,7 @@ export function StatusSection({
           value={sentAmount ?? <Skeleton lx={{ height: "s16", width: "s96" }} />}
           isLoading={isLoading}
           lineStatus={sendRow.lineStatus}
+          testId="swap-transaction-status-send"
         />
         <StatusRow
           status={receiveRow.status}
@@ -52,6 +53,7 @@ export function StatusSection({
           value={receivedAmount ?? <Skeleton lx={{ height: "s16", width: "s96" }} />}
           isLoading={isLoading}
           isLast
+          testId="swap-transaction-status-receive"
         />
       </Box>
     </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/SwapTransactionStatusView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/SwapTransactionStatusView.tsx
@@ -26,7 +26,10 @@ export function SwapTransactionStatusView({
   isFooterLoading,
 }: Readonly<SwapTransactionStatusViewModel>) {
   return (
-    <BottomSheetScrollView showsVerticalScrollIndicator={false}>
+    <BottomSheetScrollView
+      testID="swap-transaction-status-scroll-view"
+      showsVerticalScrollIndicator={false}
+    >
       <Box lx={{ gap: "s24", paddingBottom: "s24" }}>
         <TransactionHeader
           sendCurrency={sendCurrency}

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/TransactionHeader.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/TransactionHeader.tsx
@@ -42,14 +42,22 @@ export function TransactionHeader({
         )}
       </Box>
       {title ? (
-        <Text typography="heading5SemiBold" lx={{ color: "base", textAlign: "center" }}>
+        <Text
+          testID="swap-transaction-title"
+          typography="heading5SemiBold"
+          lx={{ color: "base", textAlign: "center" }}
+        >
           {title}
         </Text>
       ) : (
         <Skeleton lx={{ height: "s24", width: "s176" }} />
       )}
       {formattedDate ? (
-        <Text typography="body3" lx={{ color: "muted", textAlign: "center" }}>
+        <Text
+          testID="swap-transaction-date"
+          typography="body3"
+          lx={{ color: "muted", textAlign: "center" }}
+        >
           {formattedDate}
         </Text>
       ) : (

--- a/e2e/mobile/page/drawer/swapTransactionStatus.drawer.ts
+++ b/e2e/mobile/page/drawer/swapTransactionStatus.drawer.ts
@@ -1,0 +1,80 @@
+import { Step } from "jest-allure2-reporter/api";
+import { normalizeText } from "../../helpers/commonHelpers";
+import { SwapProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
+import { retryUntilTimeout } from "../../utils/retry";
+
+export type SwapTransactionStatusDetails = {
+  date: string;
+  sentAmount: string;
+  // Received amount depends on a live-computed final amount, not just the fixture's raw value: leave unset to only assert visibility.
+  receivedAmount?: string;
+  networkFees: string;
+  receiveAccount: string;
+};
+
+export default class SwapTransactionStatusDrawer {
+  scrollViewId = "swap-transaction-status-scroll-view";
+  titleId = "swap-transaction-title";
+  dateId = "swap-transaction-date";
+  sendRowId = "swap-transaction-status-send-row";
+  receiveRowId = "swap-transaction-status-receive-row";
+  sentAmountId = "swap-transaction-status-send-amount";
+  receivedAmountId = "swap-transaction-status-receive-amount";
+  networkFeesId = "swap-transaction-details-network-fees";
+  receiveAccountId = "swap-transaction-details-receive-account";
+  providerId = "swap-transaction-details-provider";
+  swapIdId = "swap-transaction-details-swap-id";
+  viewInExplorerButtonId = "swap-transaction-view-explorer-btn";
+
+  // Amounts/details render behind a loading Skeleton until the swap status view-model resolves,
+  // so the underlying text can briefly be empty right after the drawer opens: poll instead of reading once.
+  private async expectTextEventually(id: string, matcher: (text: string) => void) {
+    await retryUntilTimeout(async () => {
+      matcher(normalizeText(await getTextOfElement(id)));
+    });
+  }
+
+  @Step("Verify swap transaction status drawer information")
+  async expectSwapTransactionStatusDrawerInfos(
+    swapIdPrefix: string,
+    provider: SwapProvider,
+    details: SwapTransactionStatusDetails,
+  ) {
+    await waitForElementById(this.titleId);
+    await this.expectTextEventually(this.dateId, text =>
+      jestExpect(text).toContain(normalizeText(details.date)),
+    );
+
+    await detoxExpect(getElementById(this.sendRowId)).toBeVisible();
+    await this.expectTextEventually(this.sentAmountId, text =>
+      jestExpect(text).toEqual(normalizeText(details.sentAmount)),
+    );
+
+    await detoxExpect(getElementById(this.receiveRowId)).toBeVisible();
+    if (details.receivedAmount) {
+      const receivedAmount = normalizeText(details.receivedAmount);
+      await this.expectTextEventually(this.receivedAmountId, text =>
+        jestExpect(text).toEqual(receivedAmount),
+      );
+    } else {
+      await detoxExpect(getElementById(this.receivedAmountId)).toBeVisible();
+    }
+
+    await scrollToId(this.networkFeesId, this.scrollViewId);
+    await this.expectTextEventually(this.networkFeesId, text =>
+      jestExpect(text).toEqual(normalizeText(details.networkFees)),
+    );
+    await this.expectTextEventually(this.receiveAccountId, text =>
+      jestExpect(text).toContain(normalizeText(details.receiveAccount)),
+    );
+    await this.expectTextEventually(this.providerId, text =>
+      jestExpect(text).toEqual(normalizeText(provider.uiName)),
+    );
+    await this.expectTextEventually(this.swapIdId, text =>
+      jestExpect(text).toContain(swapIdPrefix),
+    );
+
+    await scrollToId(this.viewInExplorerButtonId, this.scrollViewId);
+    await detoxExpect(getElementById(this.viewInExplorerButtonId)).toBeVisible();
+  }
+}

--- a/e2e/mobile/page/drawer/swapTransactionStatus.drawer.ts
+++ b/e2e/mobile/page/drawer/swapTransactionStatus.drawer.ts
@@ -1,7 +1,7 @@
 import { Step } from "jest-allure2-reporter/api";
 import { normalizeText } from "../../helpers/commonHelpers";
 import { SwapProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
-import { retryUntilTimeout } from "../../utils/retry";
+import { DEFAULT_TIMEOUT } from "../../helpers/elementHelpers";
 
 export type SwapTransactionStatusDetails = {
   date: string;
@@ -53,7 +53,8 @@ export default class SwapTransactionStatusDrawer {
       await detoxExpect(getElementById(this.receivedAmountId)).toBeVisible();
     }
 
-    await retryUntilTimeout(() => scrollToId(this.networkFeesId, this.scrollViewId));
+    await waitForElementById(this.networkFeesId, DEFAULT_TIMEOUT, { checkVisibility: false });
+    await scrollToId(this.networkFeesId, this.scrollViewId);
     jestExpect(normalizeText(await getTextOfElement(this.networkFeesId))).toEqual(
       normalizeText(details.networkFees),
     );
@@ -65,7 +66,10 @@ export default class SwapTransactionStatusDrawer {
     );
     jestExpect(normalizeText(await getTextOfElement(this.swapIdId))).toContain(swapIdPrefix);
 
-    await retryUntilTimeout(() => scrollToId(this.viewInExplorerButtonId, this.scrollViewId));
+    await waitForElementById(this.viewInExplorerButtonId, DEFAULT_TIMEOUT, {
+      checkVisibility: false,
+    });
+    await scrollToId(this.viewInExplorerButtonId, this.scrollViewId);
     await detoxExpect(getElementById(this.viewInExplorerButtonId)).toBeVisible();
   }
 }

--- a/e2e/mobile/page/drawer/swapTransactionStatus.drawer.ts
+++ b/e2e/mobile/page/drawer/swapTransactionStatus.drawer.ts
@@ -26,53 +26,44 @@ export default class SwapTransactionStatusDrawer {
   swapIdId = "swap-transaction-details-swap-id";
   viewInExplorerButtonId = "swap-transaction-view-explorer-btn";
 
-  // Amounts/details render behind a loading Skeleton until the swap status view-model resolves,
-  // so the underlying text can briefly be empty right after the drawer opens: poll instead of reading once.
-  private async expectTextEventually(id: string, matcher: (text: string) => void) {
-    await retryUntilTimeout(async () => {
-      matcher(normalizeText(await getTextOfElement(id)));
-    });
-  }
-
   @Step("Verify swap transaction status drawer information")
   async expectSwapTransactionStatusDrawerInfos(
     swapIdPrefix: string,
     provider: SwapProvider,
     details: SwapTransactionStatusDetails,
   ) {
+    // Every value here only mounts its testID once resolved (a Skeleton renders otherwise), so
+    // getTextOfElement's built-in retry-until-exists already guarantees the text is final once found.
     await waitForElementById(this.titleId);
-    await this.expectTextEventually(this.dateId, text =>
-      jestExpect(text).toContain(normalizeText(details.date)),
+    jestExpect(normalizeText(await getTextOfElement(this.dateId))).toContain(
+      normalizeText(details.date),
     );
 
     await detoxExpect(getElementById(this.sendRowId)).toBeVisible();
-    await this.expectTextEventually(this.sentAmountId, text =>
-      jestExpect(text).toEqual(normalizeText(details.sentAmount)),
+    jestExpect(normalizeText(await getTextOfElement(this.sentAmountId))).toEqual(
+      normalizeText(details.sentAmount),
     );
 
     await detoxExpect(getElementById(this.receiveRowId)).toBeVisible();
     if (details.receivedAmount) {
-      const receivedAmount = normalizeText(details.receivedAmount);
-      await this.expectTextEventually(this.receivedAmountId, text =>
-        jestExpect(text).toEqual(receivedAmount),
+      jestExpect(normalizeText(await getTextOfElement(this.receivedAmountId))).toEqual(
+        normalizeText(details.receivedAmount),
       );
     } else {
       await detoxExpect(getElementById(this.receivedAmountId)).toBeVisible();
     }
 
     await retryUntilTimeout(() => scrollToId(this.networkFeesId, this.scrollViewId));
-    await this.expectTextEventually(this.networkFeesId, text =>
-      jestExpect(text).toEqual(normalizeText(details.networkFees)),
+    jestExpect(normalizeText(await getTextOfElement(this.networkFeesId))).toEqual(
+      normalizeText(details.networkFees),
     );
-    await this.expectTextEventually(this.receiveAccountId, text =>
-      jestExpect(text).toContain(normalizeText(details.receiveAccount)),
+    jestExpect(normalizeText(await getTextOfElement(this.receiveAccountId))).toContain(
+      normalizeText(details.receiveAccount),
     );
-    await this.expectTextEventually(this.providerId, text =>
-      jestExpect(text).toEqual(normalizeText(provider.uiName)),
+    jestExpect(normalizeText(await getTextOfElement(this.providerId))).toEqual(
+      normalizeText(provider.uiName),
     );
-    await this.expectTextEventually(this.swapIdId, text =>
-      jestExpect(text).toContain(swapIdPrefix),
-    );
+    jestExpect(normalizeText(await getTextOfElement(this.swapIdId))).toContain(swapIdPrefix);
 
     await retryUntilTimeout(() => scrollToId(this.viewInExplorerButtonId, this.scrollViewId));
     await detoxExpect(getElementById(this.viewInExplorerButtonId)).toBeVisible();

--- a/e2e/mobile/page/drawer/swapTransactionStatus.drawer.ts
+++ b/e2e/mobile/page/drawer/swapTransactionStatus.drawer.ts
@@ -60,7 +60,7 @@ export default class SwapTransactionStatusDrawer {
       await detoxExpect(getElementById(this.receivedAmountId)).toBeVisible();
     }
 
-    await scrollToId(this.networkFeesId, this.scrollViewId);
+    await retryUntilTimeout(() => scrollToId(this.networkFeesId, this.scrollViewId));
     await this.expectTextEventually(this.networkFeesId, text =>
       jestExpect(text).toEqual(normalizeText(details.networkFees)),
     );
@@ -74,7 +74,7 @@ export default class SwapTransactionStatusDrawer {
       jestExpect(text).toContain(swapIdPrefix),
     );
 
-    await scrollToId(this.viewInExplorerButtonId, this.scrollViewId);
+    await retryUntilTimeout(() => scrollToId(this.viewInExplorerButtonId, this.scrollViewId));
     await detoxExpect(getElementById(this.viewInExplorerButtonId)).toBeVisible();
   }
 }

--- a/e2e/mobile/page/index.ts
+++ b/e2e/mobile/page/index.ts
@@ -35,6 +35,7 @@ import TransferMenuDrawer from "./wallet/transferMenu.drawer";
 import BuySellPage from "./trade/buySell.page";
 import EarnV2DashboardPage from "./trade/earnV2Dashboard.page";
 import ModularDrawer from "./drawer/modular.drawer";
+import SwapTransactionStatusDrawer from "./drawer/swapTransactionStatus.drawer";
 
 import path from "path";
 import fs from "fs";
@@ -91,6 +92,7 @@ export class Application {
   private settingsHelpPageInstance = lazyInit(SettingsHelpPage);
   private readonly earnV2DashboardPageInstance = lazyInit(EarnV2DashboardPage);
   private modularDrawerPageInstance = lazyInit(ModularDrawer);
+  private swapTransactionStatusDrawerInstance = lazyInit(SwapTransactionStatusDrawer);
   private readonly topBarSearchPageInstance = lazyInit(TopBarSearchPage);
 
   @Step("Account initialization")
@@ -243,6 +245,10 @@ export class Application {
 
   public get modularDrawer() {
     return this.modularDrawerPageInstance();
+  }
+
+  public get swapTransactionStatusDrawer() {
+    return this.swapTransactionStatusDrawerInstance();
   }
 
   public get topBarSearch() {

--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -12,7 +12,6 @@ export default class SwapPage extends CommonPage {
   baseLink = "swap";
   confirmSwapOnDeviceDrawerId = "confirm-swap-on-device";
   swapSuccessTitleId = "swap-success-title";
-  swapOperationDetailsScrollViewId = "swap-operation-details-scroll-view";
   deviceActionLoading = "device-action-loading";
   operationRow = {
     rowBaseId: "swap-operation-row-",
@@ -24,22 +23,9 @@ export default class SwapPage extends CommonPage {
   };
   historyButton = "navigation-header-swap-history";
   topBarSwapHistoryButton = "topbar-swap-history";
-  swapStatus = "swap-status";
   exportOperationsButton = "enabled-export-swap-operations-link";
   swapHistoryFeedbackLink = "swap-history-feedback-link";
   swapFormTabId = "swap-form-tab";
-
-  operationDetails = {
-    fromAccount: "swap-operation-details-fromAccount",
-    toAccount: "swap-operation-details-toAccount",
-    fromAmount: "swap-operation-details-fromAmount",
-    toAmount: "swap-operation-details-toAmount",
-    provider: "swap-operation-details-provider",
-    providerLink: "swap-operation-details-provider-link",
-    swapId: "swap-operation-details-swapId",
-    date: "swap-operation-details-date",
-    viewInExplorerButton: "operation-detail-view-in-explorer-button",
-  };
 
   swapFormTab = () => getElementById(this.swapFormTabId);
   operationRows = () => getElementById(this.operationRow.rowRegexp);
@@ -98,39 +84,6 @@ export default class SwapPage extends CommonPage {
   @Step("Open selected operation by swapId: $0")
   async openSelectedOperation(swapId: string) {
     await tapByElement(this.getSpecificOperation(swapId));
-  }
-
-  @Step("Verify swap operation details")
-  async expectSwapDrawerInfos(swapId: string, swap: SwapType, provider: SwapProvider) {
-    jestExpect(normalizeText(await getTextOfElement(this.swapStatus))).toMatch(/Pending|Finished/);
-    await detoxExpect(getElementByText("Swap ID")).toBeVisible();
-    jestExpect(normalizeText(await getTextOfElement(this.operationDetails.swapId))).toEqual(swapId);
-    if (await IsIdVisible(this.operationDetails.providerLink)) {
-      jestExpect(normalizeText(await getTextOfElement(this.operationDetails.providerLink))).toEqual(
-        normalizeText(provider.uiName),
-      );
-    } else {
-      jestExpect(normalizeText(await getTextOfElement(this.operationDetails.provider))).toEqual(
-        normalizeText(provider.uiName),
-      );
-    }
-    jestExpect(normalizeText(await getTextOfElement(this.operationDetails.date))).toMatch(
-      /^(0?[1-9]|1[0-2])\/(0?[1-9]|[12][0-9]|3[01])\/\d{4}$/,
-    );
-    jestExpect(normalizeText(await getTextOfElement(this.operationDetails.fromAccount))).toEqual(
-      normalizeText(swap.accountToDebit.accountName),
-    );
-    jestExpect(normalizeText(await getTextOfElement(this.operationDetails.fromAmount))).toEqual(
-      normalizeText(`${swap.amount} ${swap.accountToDebit.currency.ticker}`),
-    );
-
-    await scrollToId(this.operationDetails.toAmount, this.swapOperationDetailsScrollViewId);
-    jestExpect(normalizeText(await getTextOfElement(this.operationDetails.toAccount))).toEqual(
-      normalizeText(swap.accountToCredit.accountName),
-    );
-    await detoxExpect(getElementById(this.operationDetails.toAmount)).toBeVisible();
-
-    await detoxExpect(getElementById(this.operationDetails.viewInExplorerButton)).toBeVisible();
   }
 
   @Step("Click on export operations")

--- a/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
@@ -8,6 +8,7 @@ import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { setEnv } from "@ledgerhq/live-env";
 import { beforeAllFunctionSwap } from "../swap.setup";
 import { setTeamOwner } from "../../../helpers/allure/allure-helper";
+import { SwapTransactionStatusDetails } from "../../../page/drawer/swapTransactionStatus.drawer";
 
 setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
@@ -326,6 +327,7 @@ export function runSwapHistoryOperationsTest(
   swapId: string,
   tmsLinks: string[],
   tags: string[],
+  details: SwapTransactionStatusDetails,
 ) {
   describe("Swap history", () => {
     beforeAll(async () => {
@@ -343,7 +345,11 @@ export function runSwapHistoryOperationsTest(
       await app.swap.goToSwapHistory();
       await app.swap.checkSwapOperation(swapId, swap);
       await app.swap.openSelectedOperation(swapId);
-      await app.swap.expectSwapDrawerInfos(swapId, swap, provider);
+      await app.swapTransactionStatusDrawer.expectSwapTransactionStatusDrawerInfos(
+        swapId.slice(0, 6),
+        provider,
+        details,
+      );
     });
   });
 }

--- a/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
@@ -8,7 +8,7 @@ import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { setEnv } from "@ledgerhq/live-env";
 import { beforeAllFunctionSwap } from "../swap.setup";
 import { setTeamOwner } from "../../../helpers/allure/allure-helper";
-import { SwapTransactionStatusDetails } from "../../../page/drawer/swapTransactionStatus.drawer";
+import type { SwapTransactionStatusDetails } from "../../../page/drawer/swapTransactionStatus.drawer";
 
 setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
@@ -346,7 +346,7 @@ export function runSwapHistoryOperationsTest(
       await app.swap.checkSwapOperation(swapId, swap);
       await app.swap.openSelectedOperation(swapId);
       await app.swapTransactionStatusDrawer.expectSwapTransactionStatusDrawerInfos(
-        swapId.slice(0, 6),
+        swapId.slice(0, 8),
         provider,
         details,
       );

--- a/e2e/mobile/specs/swap/otherTestCases/swapSeeHistoryOperations.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapSeeHistoryOperations.spec.ts
@@ -19,6 +19,12 @@ const swapHistoryTestConfig = {
     "@ethereum",
     "@family-evm",
   ],
+  details: {
+    date: "July 15, 2025",
+    sentAmount: "0.07 SOL",
+    networkFees: "0.000005 SOL",
+    receiveAccount: "Ethereum 1",
+  },
 };
 
 runSwapHistoryOperationsTest(
@@ -27,4 +33,5 @@ runSwapHistoryOperationsTest(
   swapHistoryTestConfig.swapId,
   swapHistoryTestConfig.tmsLinks,
   swapHistoryTestConfig.tags,
+  swapHistoryTestConfig.details,
 );


### PR DESCRIPTION
## Summary

- Adds `testID`s to all relevant `SwapTransactionStatus` drawer components (`TransactionHeader`, `StatusRow`/`StatusSection`, `DetailRow`/`DetailsSection`, `FooterSection`, `SwapTransactionStatusView`) — mirroring the desktop adoption in #18594, with `testID` placed directly on the leaf `Text` nodes (not wrapping `Box`es) so Detox can read their content on Android
- Introduces a new `SwapTransactionStatusDrawer` page object (`e2e/mobile/page/drawer/swapTransactionStatus.drawer.ts`), registered in the mobile `Application` page index
- Rewires `swapSeeHistoryOperations.spec.ts` / `swap.other.ts` to assert against the new drawer (title, date, sent/received status rows, network fees, receive account, provider, swap id, "view in explorer" button) instead of the old, now-unreachable `OperationDetails` screen
- Removes the dead `expectSwapDrawerInfos`/`swap-status`/`swap-operation-details-*` assertions from `swap.page.ts`

## Context

A new `SwapTransactionStatus` bottom-sheet drawer (LIVE-29443) replaced the old `OperationDetails` screen for swap-history row taps, but the e2e test was never updated — it kept waiting on the old screen's `swap-status` testID, which became unreachable dead code, causing a 60s timeout.

## Test plan

- [ ] Rebuild the Android e2e app (`pnpm build:android` from `e2e/mobile`) and run `pnpm test:android -- swapSeeHistoryOperations.spec.ts`
- [ ] Confirm `Swap history operations - Solana to Ethereum` passes end-to-end
- [ ] Confirm mobile app and e2e typechecks pass

e2e execution of swapSeeHistoryOperations.spec.ts: https://github.com/LedgerHQ/ledger-live/actions/runs/28664830400

e2e execution of the whole SWAP set on Mobile: https://github.com/LedgerHQ/ledger-live/actions/runs/28665394004