### PR TITLE
[LWDM] docs(libs): add missing README.md to 26 library packages

### DIFF
--- a/libs/README.md
+++ b/libs/README.md
@@ -8,6 +8,7 @@ Shared library packages — the home for new shared code today.
 
 1. **A new dedicated `libs/*` package** — for new shared code (e.g. a self-contained library, a coin module under `libs/coin-modules/`).
    - New packages **must be private** (`"private": true` in `package.json`) to prepare for the upcoming domain transition.
+   - Every new package **must include a `README.md`** explaining its scope, what problems it solves, and its main exports. Keep it concise; a few paragraphs are enough.
 2. **Never grow `libs/ledger-live-common`** — it is in maintenance mode. Bugfixes and edits to existing code are fine; new features, folders or top-level modules are not.
 
 The repo is moving toward a DDD layout (`domain/`, `features/`, `shared/`); it is not yet the default for new code.

--- a/libs/asset-aggregation/README.md
+++ b/libs/asset-aggregation/README.md
@@ -1,0 +1,21 @@
+# asset-aggregation
+
+`@ledgerhq/asset-aggregation` aggregates and categorizes assets across all user accounts for portfolio display in Ledger Live. It computes per-asset totals, groups assets by category, and calculates the distribution of holdings — feeding the portfolio and asset screens on both desktop and mobile.
+
+## What it does
+
+- Aggregates balances for the same currency across multiple accounts into a single asset view
+- Categorizes assets (crypto, token, NFT, etc.)
+- Computes asset distribution (percentage breakdown of holdings by asset)
+- Provides mock data for development and testing
+
+## Key exports / concepts
+
+- `assetAggregation` — core logic to merge accounts into a deduplicated asset list
+- `assetCategorization` — classifies assets by type/category
+- `assetDistribution` — computes portfolio share (%) per asset
+- `mocks/` — mock asset data for tests and Storybook
+
+## Usage context
+
+Used in both `apps/ledger-live-desktop` and `apps/ledger-live-mobile` on the portfolio and asset list screens. Typically consumed alongside `@ledgerhq/live-countervalues` to enrich aggregated assets with fiat values.

--- a/libs/asset-detail/README.md
+++ b/libs/asset-detail/README.md
@@ -1,0 +1,20 @@
+# asset-detail
+
+`@ledgerhq/asset-detail` is a shared module providing React hooks, types, and utilities for the asset detail screen in Ledger Live. It abstracts the data-fetching and formatting logic needed to display an asset's market data (price, chart, stats) in one place, shared between desktop and mobile.
+
+## What it does
+
+- Exposes React hooks that fetch and combine market data for a given asset
+- Provides shared TypeScript types for asset detail state and props
+- Contains utility helpers for formatting and transforming asset detail data
+- Decouples the asset detail data layer from platform-specific rendering
+
+## Key exports / concepts
+
+- `hooks/` — React hooks (e.g. market data fetcher, price change computation)
+- `types.ts` — shared types for asset detail data structures
+- `utils/` — formatting and transformation helpers
+
+## Usage context
+
+Imported by both `apps/ledger-live-desktop` and `apps/ledger-live-mobile` on their respective asset detail screens. Works alongside `@ledgerhq/live-countervalues` for fiat conversion and market data APIs.

--- a/libs/coin-tester-modules/README.md
+++ b/libs/coin-tester-modules/README.md
@@ -1,0 +1,29 @@
+# coin-tester-modules
+
+A workspace directory of coin-specific end-to-end test packages for Ledger Live. Each sub-package implements the test scenarios, fixtures, and hardware-wallet signer integration needed to run the coin tester against a real (or simulated) Ledger device for a specific blockchain.
+
+## What it does
+
+- Provides per-coin test scenario implementations for the `@ledgerhq/coin-tester` runner
+- Encapsulates coin-specific fixtures (accounts, transactions, expected outcomes)
+- Wires up the hardware-wallet signer for each coin family
+- Can run against Speculos (emulator) or a physical device
+
+## Packages
+
+| Package | Blockchain |
+|---|---|
+| `@ledgerhq/coin-tester-bitcoin` | Bitcoin |
+| `@ledgerhq/coin-tester-cardano` | Cardano |
+| `@ledgerhq/coin-tester-cosmos` | Cosmos |
+| `@ledgerhq/coin-tester-evm` | EVM chains (Ethereum, etc.) |
+| `@ledgerhq/coin-tester-polkadot` | Polkadot |
+| `@ledgerhq/coin-tester-solana` | Solana |
+| `@ledgerhq/coin-tester-stellar` | Stellar |
+| `@ledgerhq/coin-tester-tezos` | Tezos |
+| `@ledgerhq/coin-tester-tron` | Tron |
+| `@ledgerhq/coin-tester-xrp` | XRP |
+
+## Usage context
+
+Run via `libs/coin-tester` (the test runner/framework). Typically executed in CI against Speculos containers to validate coin implementations end-to-end.

--- a/libs/deeplink-module/README.md
+++ b/libs/deeplink-module/README.md
@@ -1,0 +1,18 @@
+# deeplink-module
+
+`@ledgerhq/wallet-api-deeplink-module` is a Wallet-API module that adds deep-link handling to Live apps embedded in Ledger Live. It allows web apps and DApps running inside the Ledger Live browser to trigger in-app navigation or actions by emitting deep-link URLs, which the host app then resolves.
+
+## What it does
+
+- Exposes a Wallet-API module interface for deep-link dispatch
+- Lets DApps request navigation to specific screens inside Ledger Live (e.g. send, receive, swap) via a standardised URL scheme
+- Decouples deep-link intent from platform routing so the same module works on desktop and mobile
+
+## Key exports / concepts
+
+- Module class / factory (exported from `index.ts`) — registers the deep-link handler on a Wallet-API server
+- `types.ts` — TypeScript types for deep-link payloads and handler signatures
+
+## Usage context
+
+Registered as an optional module when instantiating a Wallet-API server in `apps/ledger-live-desktop` or `apps/ledger-live-mobile`. Works alongside other Wallet-API modules (`@ledgerhq/wallet-api-exchange-module`, etc.).

--- a/libs/device-core/README.md
+++ b/libs/device-core/README.md
@@ -1,0 +1,25 @@
+# device-core
+
+`@ledgerhq/device-core` is the core library for interacting with Ledger hardware devices in Ledger Live. It provides low-level device commands (APDU wrappers), high-level flows (firmware update, manager API), capability detection, and custom lock screen support — shared across desktop and mobile.
+
+## What it does
+
+- Exposes typed APDU command wrappers for communicating with Ledger devices
+- Implements firmware update flows (preparation, flashing, validation)
+- Provides a client for the Ledger Manager API (app install/uninstall, device info)
+- Detects device capabilities (e.g. supported features per firmware version)
+- Handles custom lock screen (image encoding, transfer)
+- Defines device-specific error types
+
+## Key exports / concepts
+
+- `commands/` — individual APDU command implementations
+- `firmwareUpdate/` — multi-step firmware update orchestration
+- `managerApi/` — HTTP + transport layer for the Ledger Manager service
+- `capabilities/` — feature flags derived from device model and firmware
+- `customLockScreen/` — image preparation and transfer logic
+- `errors.ts` — device-specific error classes
+
+## Usage context
+
+Used by `apps/ledger-live-desktop` and `apps/ledger-live-mobile`, and by `@ledgerhq/device-intent` for higher-level device interaction flows. Also consumed by `@ledgerhq/live-common` for device-dependent operations.

--- a/libs/device-react/README.md
+++ b/libs/device-react/README.md
@@ -1,0 +1,18 @@
+# device-react
+
+`@ledgerhq/device-react` is a thin React layer on top of `@ledgerhq/device-core`, exposing React hooks for device-related operations in Ledger Live. It handles the async lifecycle of device queries (mounting/unmounting, state updates) so UI components don't have to.
+
+## What it does
+
+- Wraps `device-core` async calls in React hooks with proper effect cleanup
+- Manages loading/result state for device queries within React components
+- Provides shared types for hook options used across desktop and mobile
+
+## Key exports / concepts
+
+- `useGetLatestFirmware(options)` — fetches the latest available firmware for a connected device once on mount and returns a `FirmwareUpdateContextEntity | null`
+- `UseGetLatestFirmwareForDeviceOptions` — typed options (deviceInfo, providerId, userId, managerApiRepository)
+
+## Usage context
+
+Used by both `ledger-live-desktop` and `ledger-live-mobile` in firmware-update flows. Depends on `@ledgerhq/device-core` for the underlying logic and the `HttpManagerApiRepository` for Manager API calls.

--- a/libs/env/README.md
+++ b/libs/env/README.md
@@ -1,0 +1,22 @@
+# live-env
+
+`@ledgerhq/live-env` centralizes all runtime environment variables and configuration flags for Ledger Live. It defines every env key with a typed default value and a description, and exposes a reactive API to read and override them at runtime — useful for debugging, testing, and feature toggling without a full rebuild.
+
+## What it does
+
+- Declares a typed registry (`envDefinitions`) of all supported env keys with defaults and parsers
+- Provides `getEnv(key)` / `setEnv(key, value)` for safe, typed access
+- Emits an RxJS `Subject` stream when a value changes, enabling reactive subscriptions
+- Supports parsing from raw strings (e.g. process.env) with int/float/bool/JSON parsers
+
+## Key exports / concepts
+
+- `getEnv(name)` — read the current value of an env key (returns the typed default if not set)
+- `setEnv(name, value)` — override a value at runtime
+- `EnvName` — union type of all valid env key names
+- `EnvValue<Name>` — inferred value type for a given key
+- `changes$` — RxJS observable of `{ name, value }` for reactive env updates
+
+## Usage context
+
+Used across the entire monorepo (desktop, mobile, live-common, coin libs) wherever runtime configuration or debug flags are needed. Consumed at the top of app startup to apply env overrides from `process.env` and developer tooling.

--- a/libs/ethereum-provider/README.md
+++ b/libs/ethereum-provider/README.md
@@ -1,0 +1,20 @@
+# ethereum-provider
+
+`@ledgerhq/ethereum-provider` implements an [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193)-compatible Ethereum provider backed by the Ledger Live Wallet API. It bridges dApps embedded in the Ledger Live webview (both Electron and React Native) to Ethereum accounts managed by the connected hardware wallet.
+
+## What it does
+
+- Implements the standard `window.ethereum` EIP-1193 provider interface via `postMessage` / `addEventListener`
+- Routes JSON-RPC requests (`eth_requestAccounts`, `eth_sendTransaction`, `personal_sign`, etc.) through the Ledger Live host over the webview message bridge
+- Handles both Electron (`ElectronWebview.postMessage`) and React Native (`ReactNativeWebView.postMessage`) transports
+- Injects itself into the page via `onPageLoad` for use in Live Apps
+
+## Key exports / concepts
+
+- `LedgerLiveEthereumProvider` — the main EIP-1193 provider class; extends `EventEmitter`, handles request routing and response correlation
+- `LedgerLiveEthereumProviderOptions` — construction options (targetOrigin, timeout, event source/target)
+- `onPageLoad` — entry point to inject the provider into `window.ethereum` when the page loads
+
+## Usage context
+
+Used in the Ledger Live browser / Live Apps webview context. Consumed by dApps that need to call Ethereum RPC methods against the user's hardware wallet accounts without running a full node.

--- a/libs/exchange-module/README.md
+++ b/libs/exchange-module/README.md
@@ -1,0 +1,24 @@
+# wallet-api-exchange-module
+
+`@ledgerhq/wallet-api-exchange-module` is a [Wallet API](https://github.com/LedgerHQ/wallet-api) `CustomModule` that exposes swap, sell, and fund exchange flows to Live Apps running inside Ledger Live. It lets dApps initiate exchange transactions through Ledger Live's built-in exchange service without implementing device signing themselves.
+
+## What it does
+
+- Extends `CustomModule` from `@ledgerhq/wallet-api-client` with exchange-specific RPC methods
+- Handles the two-phase exchange flow: `start*` (get a nonce from the device) → `complete*` (sign and broadcast)
+- Supports **swap**, **sell**, and **fund** exchange types
+- Provides quote fetching (`getQuotes`) and transaction status polling (`getTransactionStatus`)
+- Exposes a `customSwap` method for the device-intent-based swap flow
+
+## Key exports / concepts
+
+- `ExchangeModule` — the main class; instantiated with a `WalletAPIClient` and used by Live Apps
+- `startSwap / startSell / startFund` — begin an exchange, returns a `transactionId`
+- `completeSwap / completeSell / completeFund` — finalize with signed payload; returns `transactionHash`
+- `swap` — single-call swap using the newer `custom.exchange.swap` RPC
+- `getQuotes` / `getTransactionStatus` — communicate with the Ledger swap backend via the host
+- `throwExchangeErrorToLedgerLive` — surface exchange errors in the Ledger Live UI
+
+## Usage context
+
+Used by Live Apps (dApps embedded in Ledger Live) that need to perform asset exchanges. The Ledger Live host implements the matching RPC handlers; this module is the client-side counterpart bundled with the Live App.

--- a/libs/feature-flag-module/README.md
+++ b/libs/feature-flag-module/README.md
@@ -1,0 +1,21 @@
+# wallet-api-feature-flag-module
+
+`@ledgerhq/wallet-api-feature-flag-module` is a [Wallet API](https://github.com/LedgerHQ/wallet-api) `CustomModule` that lets Live Apps query Ledger Live's feature flags at runtime. A Live App can gate UI or behaviour on whether a specific flag is enabled in the host app, without needing its own flag infrastructure.
+
+## What it does
+
+- Extends `CustomModule` from `@ledgerhq/wallet-api-client` with a feature-flag RPC method
+- Sends a `custom.featureFlags.get` request to the Ledger Live host
+- Returns a typed map of flag IDs to their current `Feature` value (or `null` if not declared / unauthorized)
+- Access is scoped: a Live App must declare the flags it needs in its manifest's `featureFlags` array
+
+## Key exports / concepts
+
+- `FeatureFlagModule` — the main class; instantiated with a `WalletAPIClient`
+- `get(featureFlagIds: string[])` — fetch one or more flags; returns `Record<string, Feature<unknown> | null>`
+- `Feature<T>` — flag shape (typically `{ enabled: boolean; params?: T }`)
+- `FeatureFlagGetParams` / `FeatureFlagGetResult` — wire types for the RPC call
+
+## Usage context
+
+Used by Live Apps (dApps embedded in Ledger Live) that need to adapt their behaviour to feature flags controlled by the Ledger Live host. The host evaluates the flags via Firebase Remote Config; this module is the client-side API bundled with the Live App.

--- a/libs/ledger-auth/README.md
+++ b/libs/ledger-auth/README.md
@@ -1,0 +1,21 @@
+# ledger-auth
+
+`@ledgerhq/ledger-auth` provides authentication helpers for Ledger Live apps to authenticate users against Ledger's Keycloak-based OAuth2/OIDC service. It handles the full PKCE authorization code flow, token storage, and silent token refresh, exposing a simple `AuthSDK` facade.
+
+## What it does
+
+- Implements the OAuth2 PKCE flow (code verifier / challenge generation)
+- Communicates with Ledger's Keycloak identity service via typed HTTP helpers
+- Manages access and refresh tokens (storage, expiry detection, refresh)
+- Exposes error types for auth failures (token expired, network error, etc.)
+
+## Key exports / concepts
+
+- `AuthSDK` — main class; call `.login()`, `.logout()`, `.getAccessToken()`, `.refreshToken()`
+- `pkce` — PKCE code verifier/challenge utilities
+- `keycloakService` — low-level Keycloak endpoint wrappers
+- Error classes: `AuthError` and subtypes from `errors.ts`
+
+## Usage context
+
+Used by Ledger Live Desktop and Mobile wherever a Ledger account login is required (e.g. accessing Ledger services that require authentication). Consumed via the `AuthSDK` singleton initialized at app boot.

--- a/libs/ledger-services/README.md
+++ b/libs/ledger-services/README.md
@@ -1,0 +1,33 @@
+# ledger-services
+
+This workspace groups typed HTTP client libraries for Ledger's backend services. Each sub-package wraps a specific Ledger API, providing strongly-typed request/response models and integration-tested clients.
+
+## Packages
+
+### `@ledgerhq/ledger-cal-service` (`cal/`)
+
+Client for Ledger's **CAL (Crypto Assets List)** service. CAL is the authoritative source for Ledger's supported assets metadata.
+
+**What it does:**
+- Fetches asset certificates (authenticity proofs for Ledger-supported tokens)
+- Queries supported currencies and networks
+- Retrieves token lists and partner token metadata
+
+**Key exports:** `getCurrencies`, `getNetworks`, `getTokens`, `getCertificate`, `getPartners`
+
+---
+
+### `@ledgerhq/ledger-trust-service` (`trust/`)
+
+Client for Ledger's **Trust service**, which provides validator and stake account data for proof-of-stake chains.
+
+**What it does:**
+- Fetches Solana validator information and trust scores
+- Fetches Hedera network node/trust data
+- Provides typed response models for validator metadata
+
+**Key exports:** `getSolanaValidators`, `getHederaNodes`
+
+## Usage context
+
+Both packages are used by `ledger-live-common` and coin-specific libs to resolve asset metadata and validator data at runtime. Desktop and Mobile both depend on them transitively.

--- a/libs/ledger-wallet-framework/README.md
+++ b/libs/ledger-wallet-framework/README.md
@@ -1,0 +1,30 @@
+# ledger-wallet-framework
+
+`@ledgerhq/ledger-wallet-framework` is the core wallet logic framework that consolidates shared infrastructure for coin implementations in Ledger Live. It was introduced to centralize concerns that previously lived in `ledger-live-common` or were duplicated across coin modules, extending and wrapping `@ledgerhq/coin-module-framework`.
+
+## What it does
+
+- Defines the **bridge interface** (account sync, transaction signing, broadcast) that all coin bridges implement
+- Provides **account** utilities: account creation, balance aggregation, sub-account handling
+- Implements **operation** parsing and merging logic shared across coin families
+- Handles **transaction** building, fee estimation types, and status computation contracts
+- Provides **derivation** path utilities and helpers
+- Includes **NFT** data structures and helpers
+- Provides **serialization** helpers for accounts and transactions (for persistence and inter-process communication)
+- Exports **bot** testing infrastructure for automated wallet scenario tests
+- Offers **mocks** for testing without a real device
+- Includes a **sanction** checking integration and **tracking** event helpers
+
+## Key exports / concepts
+
+- `Bridge` types and base implementations (account bridge, currency bridge)
+- `Account`, `SubAccount`, `TokenAccount` types and utilities
+- `Operation` creation, merging, and pagination helpers
+- `Transaction` base types and `TransactionStatus`
+- `derivation` — BIP32/BIP44 path calculation per coin family
+- `BotScenario` and test runner helpers
+- `serialize` / `deserialize` for accounts
+
+## Usage context
+
+Used by all coin family implementations (`libs/coin-modules/*`, `libs/ledger-live-common`) and by the desktop/mobile apps indirectly through the coin bridge layer. It is the foundational dependency for anything that needs to interact with wallet state or hardware signing.

--- a/libs/live-countervalues-react/README.md
+++ b/libs/live-countervalues-react/README.md
@@ -1,0 +1,20 @@
+# live-countervalues-react
+
+`@ledgerhq/live-countervalues-react` is the React layer over `@ledgerhq/live-countervalues`. It provides a context provider and hooks so that components can subscribe to fiat countervalue data without managing rate-fetching or caching themselves.
+
+## What it does
+
+- Wraps `live-countervalues` state into a React context
+- Triggers periodic rate refresh and exposes loading state
+- Provides portfolio valuation hooks for per-account and total-balance fiat display
+
+## Key exports / concepts
+
+- `CountervaluesProvider` — context provider; wrap the app root to enable countervalue hooks
+- `useCountervaluesState` — returns the current `CountervaluesState`
+- `usePortfolioState` — computes fiat portfolio value for a set of accounts
+- `portfolio.tsx` — portfolio-level valuation hook with memoized selectors
+
+## Usage context
+
+Used in both Ledger Live Desktop and Mobile at the app root level. Any component that needs to show fiat-denominated amounts (balance, history charts, asset list rows) consumes a hook from this package.

--- a/libs/live-countervalues/README.md
+++ b/libs/live-countervalues/README.md
@@ -1,0 +1,23 @@
+# live-countervalues
+
+`@ledgerhq/live-countervalues` manages fiat (and cross-crypto) exchange rate fetching, caching, and portfolio valuation for Ledger Live. It fetches rates from Ledger's countervalues API and exposes pure functions to convert crypto amounts to fiat at any point in time.
+
+## What it does
+
+- Fetches exchange rates for crypto/fiat pairs from Ledger's API (`api/`)
+- Caches rates with time-bucketing to avoid redundant requests
+- Computes portfolio valuations: per-account balance in fiat, total portfolio value
+- Provides mock data generators for tests
+- Exposes rate interpolation and rounding helpers
+
+## Key exports / concepts
+
+- `CountervaluesAPI` — the data-fetching layer (rate queries, batch requests)
+- `logic` — pure functions: `calculateCounterValue`, `inferCounterValue`
+- `portfolio` — functions to compute fiat valuation across a list of accounts
+- `CountervaluesState` — the shape of the cached rate store
+- `CountervaluesPair` — `{ from: Currency, to: Currency }` rate pair type
+
+## Usage context
+
+Used by both Desktop and Mobile. The state is managed in Redux (or equivalent) and seeded from `portfolio.ts`. `live-countervalues-react` wraps this for React component consumption.

--- a/libs/live-currency-format/README.md
+++ b/libs/live-currency-format/README.md
@@ -1,0 +1,24 @@
+# live-currency-format
+
+Locale-aware currency formatting utilities for Ledger Live. Handles display of crypto and fiat amounts, parsing user input back into BigNumber values, RTL language support, and price formatting. Used across both desktop and mobile UIs wherever a balance, fee, or price must be rendered as a human-readable string.
+
+## What it does
+
+- Formats `BigNumber` crypto/fiat amounts respecting locale decimal separators and grouping
+- Parses user-typed currency strings back into `BigNumber` (input sanitization)
+- Formats price values (fiat countervalues, market prices)
+- Provides RTL utility helpers for correct text direction in Arabic, Hebrew, etc.
+- Exposes locale detection utilities used by the formatters
+
+## Key exports / concepts
+
+- `formatCurrencyUnit(unit, value, options)` — main formatting function for any currency unit
+- `parseCurrencyUnit(unit, str)` — inverse of format; returns a BigNumber
+- `BigNumberToLocaleString` — low-level locale-aware number stringifier
+- `sanitizeValueString` — cleans raw user input before parsing
+- `formatPrice` / `priceFormat` — countervalue / market price display
+- `isRTL` / RTL helpers — direction utilities
+
+## Usage context
+
+Used by both `apps/ledger-live-desktop` and `apps/ledger-live-mobile`, and by `libs/ledger-live-common`, wherever amounts need to be displayed or entered. This is a leaf dependency with no Ledger Live runtime dependencies of its own.

--- a/libs/live-dmk-desktop/README.md
+++ b/libs/live-dmk-desktop/README.md
@@ -1,0 +1,20 @@
+# live-dmk-desktop
+
+Desktop-specific integration of the Ledger Device Management Kit (DMK) for Ledger Live Desktop. Provides the Electron/USB transport adapter and React hooks that wire the DMK into the LLD renderer process, enabling USB-based hardware wallet communication on macOS, Windows, and Linux.
+
+## What it does
+
+- Implements the DMK `Transport` interface over the Electron USB/HID bridge
+- Exposes React hooks for device connection lifecycle (connect, disconnect, errors)
+- Maps DMK-level transport errors to Ledger Live Desktop error types
+- Integrates with the LLD main-process IPC channel for USB access
+
+## Key exports / concepts
+
+- `transport/` — USB/HID transport adapter implementing the DMK interface
+- `hooks/` — React hooks for consuming device connection state in renderer components
+- `errors.ts` — Desktop-specific error types extending DMK base errors
+
+## Usage context
+
+Used exclusively by `apps/ledger-live-desktop`. Depends on `libs/live-dmk-shared` for shared device-action logic and interfaces. The mobile equivalent is `libs/live-dmk-mobile`.

--- a/libs/live-dmk-mobile/README.md
+++ b/libs/live-dmk-mobile/README.md
@@ -1,0 +1,23 @@
+# live-dmk-mobile
+
+Mobile-specific integration of the Ledger Device Management Kit (DMK) for Ledger Live Mobile. Provides React Native BLE and USB-C transport adapters, device discovery flows, and React hooks for hardware wallet communication on iOS and Android.
+
+## What it does
+
+- Implements the DMK `Transport` interface over React Native BLE (Bluetooth Low Energy) and USB-C
+- Provides device discovery and pairing flows specific to mobile OS constraints
+- Exposes React hooks for managing connection state in mobile screens
+- Maps DMK transport errors to mobile-specific Ledger Live error types
+- Includes utilities for platform-specific quirks (background BLE, permissions, etc.)
+
+## Key exports / concepts
+
+- `transport/` — BLE and USB transport adapters implementing the DMK interface
+- `connectDevice/` — mobile device discovery and connection orchestration
+- `hooks/` — React hooks for device connection state
+- `errors.ts` — mobile-specific error types extending DMK base errors
+- `utils/` — platform helpers (permissions, reconnection logic)
+
+## Usage context
+
+Used exclusively by `apps/ledger-live-mobile`. Depends on `libs/live-dmk-shared` for shared interfaces and device-action logic. The desktop equivalent is `libs/live-dmk-desktop`.

--- a/libs/live-dmk-shared/README.md
+++ b/libs/live-dmk-shared/README.md
@@ -1,0 +1,26 @@
+# live-dmk-shared
+
+Platform-agnostic shared logic for the Ledger Device Management Kit (DMK) integration in Ledger Live. Contains device discovery interfaces, device-action orchestration, transport abstractions, and cross-platform services used by both the desktop and mobile DMK adapters.
+
+## What it does
+
+- Defines the `DeviceDiscoveryService` interface and a `DefaultDeviceDiscoveryService` implementation
+- Provides device-action orchestration types and helpers for executing operations on a connected device
+- Abstracts transport-level concepts shared across platforms
+- Implements cross-platform services:
+  - `LedgerLiveLogger` — logging adapter bridging DMK events to Ledger Live's log system
+  - `LiveBlindSigningReporter` — reports blind-signing events for analytics/safety
+  - `UserHashService` — hashed user identifier for DMK telemetry
+- Centralises DMK configuration
+
+## Key exports / concepts
+
+- `DefaultDeviceDiscoveryService` — base discovery service both platforms extend
+- `ConnectDeviceUIState` / `DeviceDiscoveryService` — core interfaces for device connection
+- `DeviceDiscoveryStartArgs`, `MatchedDevice`, `KnownDevice` — discovery data types
+- `LedgerLiveLogger`, `LiveBlindSigningReporter`, `UserHashService` — shared services
+- `transport/` — shared transport interface definitions
+
+## Usage context
+
+Consumed by `libs/live-dmk-desktop` and `libs/live-dmk-mobile`. Not used directly by the apps.

--- a/libs/live-dmk-speculos/README.md
+++ b/libs/live-dmk-speculos/README.md
@@ -1,0 +1,16 @@
+# live-dmk-speculos
+
+DMK transport adapter for Speculos, Ledger's hardware wallet emulator. Enables automated tests and CI pipelines to run full device-interaction flows without physical Ledger hardware by connecting the Device Management Kit to a running Speculos instance over HTTP/WebSocket.
+
+## What it does
+
+- Implements the DMK `Transport` interface targeting a Speculos emulator endpoint
+- Allows CI and integration tests to exercise device-action flows end-to-end
+
+## Key exports / concepts
+
+- `transport/` — Speculos HTTP/WebSocket transport implementing the DMK transport interface
+
+## Usage context
+
+Used in test and CI environments by `libs/coin-tester-modules`, `libs/coin-tester`, and related integration test setups. Not imported by `apps/ledger-live-desktop` or `apps/ledger-live-mobile` in production.

--- a/libs/live-hooks/README.md
+++ b/libs/live-hooks/README.md
@@ -1,0 +1,17 @@
+# live-hooks
+
+`@ledgerhq/live-hooks` is a small collection of shared React hooks used across Ledger Live desktop and mobile. It centralises common UI performance patterns — debouncing and throttling — so they don't need to be re-implemented in each app.
+
+## What it does
+
+- Provides `useDebounce` to delay state updates until a value has stopped changing for a given interval, useful for search inputs and filter fields.
+- Provides `useThrottledFunction` to limit how often a callback is invoked, useful for scroll handlers and frequent event sources.
+
+## Key exports / concepts
+
+- `useDebounce<T>(value: T, delay: number): T` — returns a debounced copy of `value`.
+- `useThrottledFunction(fn, delay)` — returns a throttled version of `fn`.
+
+## Usage context
+
+Used by both `apps/ledger-live-desktop` and `apps/ledger-live-mobile` wherever input debouncing or handler throttling is needed. No dependencies on platform-specific APIs; works in any React environment.

--- a/libs/live-network/README.md
+++ b/libs/live-network/README.md
@@ -1,0 +1,19 @@
+# live-network
+
+`@ledgerhq/live-network` is the shared network layer for Ledger Live. It wraps the underlying HTTP client with Ledger-specific logging, error normalisation, and request optimisation utilities so all services in the monorepo make network calls consistently.
+
+## What it does
+
+- Exposes a `network()` helper that wraps `axios` with automatic logging (via `@ledgerhq/logs`) and maps HTTP errors into typed Ledger errors.
+- Provides a **request batcher** (`batcher/`) that coalesces concurrent requests for the same resource into a single in-flight call, reducing redundant network traffic.
+- Provides a **cache layer** (`cache.ts`) for memoising responses with configurable TTL.
+
+## Key exports / concepts
+
+- Default export `network(options)` — drop-in replacement for `axios` with logging and error handling.
+- `seconds(n) / minutes(n) / hours(n)` — helpers that produce `CacheOptions` for use with `lru-cache`.
+- `makeBatcher(request, params)` — batches concurrent calls within the same event-loop tick into a single upstream request (via `@ledgerhq/live-network/batcher`).
+
+## Usage context
+
+Used throughout `libs/ledger-live-common`, coin modules, and service clients. Both desktop and mobile depend on it transitively. It is the single place to configure global request behaviour (timeouts, base URLs via `@ledgerhq/live-env`).

--- a/libs/live-signer-celo/README.md
+++ b/libs/live-signer-celo/README.md
@@ -1,0 +1,17 @@
+# live-signer-celo
+
+`@ledgerhq/live-signer-celo` is the hardware-wallet signer for the Celo blockchain. It wraps the Celo Ledger app's APDU protocol and exposes a typed signer interface consumed by the Celo coin module.
+
+## What it does
+
+- Communicates with the Celo app on the Ledger device over the transport layer to sign transactions and retrieve public keys.
+- Exports a `LegacySignerCelo` class for backwards-compatible signing flows from earlier Celo app versions.
+
+## Key exports / concepts
+
+- Default signer implementing the `CeloSigner` interface expected by `@ledgerhq/coin-celo`.
+- `LegacySignerCelo` — handles older Celo app firmware where the signing command differs.
+
+## Usage context
+
+Consumed exclusively by the Celo coin module. Follows the same pattern as every other `libs/live-signer-*` package: one signer per coin family, injected at runtime by the coin module loader.

--- a/libs/promise/README.md
+++ b/libs/promise/README.md
@@ -1,0 +1,17 @@
+# live-promise
+
+`@ledgerhq/live-promise` provides small, focused Promise utilities for Ledger Live. Rather than pulling in a heavy async library, it ships only the primitives the codebase actually needs: retrying, delaying, and composing async operations.
+
+## What it does
+
+- `retry(fn, options)` — retries an async function with configurable exponential back-off, max attempts, and a custom retry-condition predicate.
+- `delay(ms)` — returns a Promise that resolves after `ms` milliseconds.
+
+## Key exports / concepts
+
+- `retry<A>(f: () => Promise<A>, options?)` — `maxRetry`, `interval`, `intervalMultiplicator`, `retryCondition`.
+- `delay(ms: number): Promise<void>`.
+
+## Usage context
+
+Used throughout `libs/ledger-live-common` and coin modules wherever network calls or device commands need automatic retry logic. Zero runtime dependencies beyond the standard Promise API.

--- a/libs/test-utils/README.md
+++ b/libs/test-utils/README.md
@@ -1,0 +1,16 @@
+# test-utils
+
+`@ledgerhq/test-utils` is a shared test-support package for the Ledger Live monorepo. It provides dummy application scaffolding and reusable helpers that multiple test suites depend on, keeping test boilerplate out of production packages.
+
+## What it does
+
+- Exports lightweight dummy app wrappers and stubs for use in Jest unit and integration tests.
+- Centralises test-only utilities so they can be updated in one place without touching every consumer.
+
+## Key exports / concepts
+
+- See `src/index.ts` for the current public surface — it is intentionally kept small and grows with genuine cross-package test needs.
+
+## Usage context
+
+Consumed as a `devDependency` by packages that need shared test scaffolding. Not imported by any production code.

--- a/libs/wallet-pnl/README.md
+++ b/libs/wallet-pnl/README.md
@@ -1,0 +1,25 @@
+# wallet-pnl
+
+`@ledgerhq/wallet-pnl` computes Profit & Loss (PnL) for crypto assets and the overall portfolio inside Ledger Live. It implements the **Average Cost Basis (ACB)** accounting method to translate on-chain operation history into realised and unrealised gains, percentage returns, and trend indicators.
+
+## What it does
+
+- Classifies every account operation (buy, sell, receive, send, swap, …) into cost-basis events.
+- Maintains a **cost basis cache** and reconciles it against live on-chain data to keep PnL consistent across syncs.
+- Computes **per-asset PnL** (`computeAssetPnL`), **asset-group PnL** (`computeAssetGroupPnL`), and **portfolio-level PnL** (`computePortfolioPnL`).
+- Calculates percentage return and trend direction for display in the UI.
+- Exposes React hooks for consuming PnL data in components.
+
+## Key exports / concepts
+
+- `computeAssetPnL(asset, operations, countervalues)` — per-asset realised/unrealised PnL.
+- `computeAssetGroupPnL(...)` — grouped asset PnL (e.g. all ETH accounts).
+- `computePortfolioPnL(accounts, countervalues)` — aggregated portfolio view.
+- `classifyOperation(op)` — maps an operation type to its ACB impact.
+- `costBasis / costBasisCache / costBasisReconciliation` — core accounting logic.
+- `trendFromSign(sign)` — up/down/flat indicator.
+- Hooks in `hooks/` for React integration.
+
+## Usage context
+
+Used by `apps/ledger-live-desktop` and `apps/ledger-live-mobile` to power the portfolio PnL view and per-asset detail screens. Depends on `@ledgerhq/live-countervalues` for fiat conversion and `@ledgerhq/types-live` for account/operation types.


### PR DESCRIPTION
### ✅ Checklist

- [ ] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.** — docs only, no logic changed
- [x] **Impact of the changes:**
  - No runtime impact — documentation only

### 📝 Description

26 libs under libs/ were missing a README.md. This adds concise README files to all of them, each describing the package scope, what it does, key exports, and usage context within the monorepo.

Also adds a rule to libs/README.md requiring every new package to ship with a README.

**Why is it important?** Because the lack of README.md on our libs creates blind spots, notably for LLMs that we suspect have caused blind spot in our recent decisions, plannings and sunsets.

### ❓ Context

- **JIRA or GitHub link**: N/A