### PR TITLE
[LWD] chore(feature-flags): enable lwdWallet40 flag by default

### DIFF
--- a/.changeset/dull-paws-double.md
+++ b/.changeset/dull-paws-double.md
@@ -1,0 +1,5 @@
+---
+"@shared/feature-flags": minor
+---
+
+enable lwdWallet40 feature flag by default

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
@@ -128,9 +128,7 @@ describe("LNSUpsellBanner", () => {
           ...withFlagOverrides({
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             lldNanoSUpsellBanners: { enabled: ffEnabled, params: ffParams as any },
-            ...(brazePlacement
-              ? { lwdWallet40: { enabled: true, params: { brazePlacement: true } } }
-              : {}),
+            lwdWallet40: { enabled: true, params: { brazePlacement } },
           }),
           settings: {
             shareAnalytics: true,

--- a/apps/ledger-live-desktop/src/mvvm/features/LiveAppModal/__integrations__/LiveAppModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LiveAppModal/__integrations__/LiveAppModal.integration.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor, act } from "tests/testSetup";
+import { render, screen, waitFor, act, withFlagOverrides } from "tests/testSetup";
 import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
 import {
@@ -158,7 +158,11 @@ describe("LiveAppModal Integration", () => {
     });
 
     it("should merge earn extra inputs when useCase is 'earn'", async () => {
-      const { store } = render(<LiveAppModal />);
+      const { store } = render(<LiveAppModal />, {
+        initialState: withFlagOverrides({
+          lwdWallet40: { enabled: true },
+        }),
+      });
 
       act(() => {
         store.dispatch(setLiveAppModal({ ...baseParams, useCase: "earn" }));
@@ -171,7 +175,7 @@ describe("LiveAppModal Integration", () => {
       expect(lastCall.inputs).toEqual(
         expect.objectContaining({
           uiVersion: "v1",
-          lw40enabled: "false",
+          lw40enabled: "true",
           ethDepositCohort: expect.any(String),
         }),
       );

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/Welcome/hooks/__tests__/useWelcomeNewViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/Welcome/hooks/__tests__/useWelcomeNewViewModel.test.ts
@@ -95,6 +95,9 @@ describe("useWelcomeViewModel", () => {
             ...INITIAL_STATE,
             hasCompletedOnboarding: true,
           },
+          ...withFlagOverrides({
+            lwdWallet40: { enabled: true, params: { lazyOnboarding: false } },
+          }),
         },
       });
 
@@ -134,6 +137,9 @@ describe("useWelcomeViewModel", () => {
             ...INITIAL_STATE,
             hasCompletedOnboarding: false,
           },
+          ...withFlagOverrides({
+            lwdWallet40: { enabled: true, params: { lazyOnboarding: false } },
+          }),
         },
       });
 

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwdWallet40.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwdWallet40.ts
@@ -18,7 +18,7 @@ export const lwdWallet40 = flagWith(
     earnSimulator: z.boolean().optional(),
   },
   {
-    enabled: false,
+    enabled: true,
     params: {
       graphRework: true,
       tour: true,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - The `lwdWallet40` feature flag is now enabled by default, activating the Wallet 4.0 experience for users.

### 📝 Description

The `lwdWallet40` feature flag was previously disabled by default, preventing the Wallet 4.0 experience from rolling out. This PR enables the flag so the new wallet experience is active by default.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33742](https://ledgerhq.atlassian.net/browse/LIVE-33742)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-33742]: https://ledgerhq.atlassian.net/browse/LIVE-33742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ