### PR TITLE
[LWDM] feat: Add pure  and  helpers for the large-screen upsell timing

### DIFF
--- a/.changeset/honest-geese-give.md
+++ b/.changeset/honest-geese-give.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Add pure `isCooldownElapsed` and `shouldThrottle` helpers for the large-screen upsell timing.

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -304,7 +304,7 @@
     "src/postOnboarding/hooks/usePostOnboardingEntryPointVisibleOnWallet.ts",
     "src/postOnboarding/hooks/usePostOnboardingPortfolioWidgetVisibility.ts",
     "src/postOnboarding/hooks/useStartPostOnboardingCallback.ts",
-    "src/postOnboarding/logic/shouldRedirectToPostOnboardingOrRecoverUpsell.ts",
+    "src/postOnboarding/logic/index.ts",
     "src/postOnboarding/PostOnboardingProvider.ts",
     "src/postOnboarding/reducer.ts",
     "src/promise.ts",

--- a/libs/ledger-live-common/src/postOnboarding/logic/index.ts
+++ b/libs/ledger-live-common/src/postOnboarding/logic/index.ts
@@ -1,0 +1,2 @@
+export { shouldRedirectToPostOnboardingOrRecoverUpsell } from "./shouldRedirectToPostOnboardingOrRecoverUpsell";
+export { isCooldownElapsed, shouldThrottle } from "./upsellFrequency";

--- a/libs/ledger-live-common/src/postOnboarding/logic/upsellFrequency.test.ts
+++ b/libs/ledger-live-common/src/postOnboarding/logic/upsellFrequency.test.ts
@@ -1,0 +1,53 @@
+import { isCooldownElapsed, shouldThrottle } from "./upsellFrequency";
+
+describe("isCooldownElapsed", () => {
+  const now = new Date("2026-07-03T10:00:00.000Z");
+
+  it("should return true when onboarding date is null", () => {
+    expect(isCooldownElapsed(null, 30, now)).toBe(true);
+  });
+
+  it("should return true when cooldown is 0 days", () => {
+    expect(isCooldownElapsed(new Date("2026-07-03T10:00:00.000Z"), 0, now)).toBe(true);
+  });
+
+  it("should return false before the cooldown boundary", () => {
+    expect(isCooldownElapsed(new Date("2026-06-04T10:00:00.000Z"), 30, now)).toBe(false);
+  });
+
+  it("should return true on the cooldown boundary", () => {
+    expect(isCooldownElapsed(new Date("2026-06-03T10:00:00.000Z"), 30, now)).toBe(true);
+  });
+
+  it("should return true after the cooldown boundary", () => {
+    expect(isCooldownElapsed(new Date("2026-06-02T10:00:00.000Z"), 30, now)).toBe(true);
+  });
+});
+
+describe("shouldThrottle", () => {
+  const now = new Date("2026-07-03T10:00:00.000Z");
+
+  it("should return false below the kill threshold", () => {
+    expect(shouldThrottle(2, new Date("2026-07-03T10:00:00.000Z"), 3, 7, now)).toBe(false);
+  });
+
+  it("should return false at the kill threshold when last seen date is null", () => {
+    expect(shouldThrottle(3, null, 3, 7, now)).toBe(false);
+  });
+
+  it("should return true within the cadence window once the kill threshold is reached", () => {
+    expect(shouldThrottle(3, new Date("2026-06-27T10:00:00.000Z"), 3, 7, now)).toBe(true);
+  });
+
+  it("should return false on the cadence boundary once the kill threshold is reached", () => {
+    expect(shouldThrottle(3, new Date("2026-06-26T10:00:00.000Z"), 3, 7, now)).toBe(false);
+  });
+
+  it("should return false after the cadence boundary once the kill threshold is reached", () => {
+    expect(shouldThrottle(3, new Date("2026-06-25T10:00:00.000Z"), 3, 7, now)).toBe(false);
+  });
+
+  it("should return true within the cadence window when kills exceed the threshold", () => {
+    expect(shouldThrottle(4, new Date("2026-07-01T10:00:00.000Z"), 3, 7, now)).toBe(true);
+  });
+});

--- a/libs/ledger-live-common/src/postOnboarding/logic/upsellFrequency.ts
+++ b/libs/ledger-live-common/src/postOnboarding/logic/upsellFrequency.ts
@@ -13,13 +13,13 @@ export function isCooldownElapsed(
 }
 
 export function shouldThrottle(
-  retriesUpsellModal: number,
+  killsUpsellModal: number,
   lastSeenUpsellModal: Date | null,
   killThreshold: number,
   cadenceDays: number,
   now: Date,
 ): boolean {
-  if (retriesUpsellModal < killThreshold || lastSeenUpsellModal === null) {
+  if (killsUpsellModal < killThreshold || lastSeenUpsellModal === null) {
     return false;
   }
 

--- a/libs/ledger-live-common/src/postOnboarding/logic/upsellFrequency.ts
+++ b/libs/ledger-live-common/src/postOnboarding/logic/upsellFrequency.ts
@@ -1,0 +1,27 @@
+import { differenceInCalendarDays } from "date-fns";
+
+export function isCooldownElapsed(
+  onboardingDate: Date | null,
+  cooldownDays: number,
+  now: Date,
+): boolean {
+  if (onboardingDate === null) {
+    return true;
+  }
+
+  return differenceInCalendarDays(now, onboardingDate) >= cooldownDays;
+}
+
+export function shouldThrottle(
+  retriesUpsellModal: number,
+  lastSeenUpsellModal: Date | null,
+  killThreshold: number,
+  cadenceDays: number,
+  now: Date,
+): boolean {
+  if (retriesUpsellModal < killThreshold || lastSeenUpsellModal === null) {
+    return false;
+  }
+
+  return differenceInCalendarDays(now, lastSeenUpsellModal) < cadenceDays;
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Add pure `isCooldownElapsed` and `shouldThrottle` helpers for the large-screen upsell timing.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33151]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-33151]: https://ledgerhq.atlassian.net/browse/LIVE-33151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ