### PR TITLE
[LWDM] fix: tezos getblock, small details

### DIFF
--- a/.changeset/cold-impalas-serve.md
+++ b/.changeset/cold-impalas-serve.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": patch
+---
+
+Remove extra delegate/originatedContract fields from getBlock details so reindexing produces identical event data as initial indexation

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.integ.test.ts
@@ -146,7 +146,6 @@ describe("getBlock — Shadownet Paris staking ops", () => {
       expect(stakingOp.type).toBe("other");
       expect(details.operationType).toBe(expectedOpType);
       expect(details.stakedAmount).toBe(expectedAmount);
-      expect(details.delegate).toBe(SHADOWNET_BAKER);
       expect(details.ledgerOpType).toBe(expectedOpType);
     },
   );

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.integ.test.ts
@@ -147,6 +147,7 @@ describe("getBlock — Shadownet Paris staking ops", () => {
       expect(details.operationType).toBe(expectedOpType);
       expect(details.stakedAmount).toBe(expectedAmount);
       expect(details.ledgerOpType).toBe(expectedOpType);
+      expect(details).not.toHaveProperty("delegate");
     },
   );
 

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
@@ -1212,6 +1212,7 @@ describe("origination operations", () => {
       amount: 0n,
       details: { ledgerOpType: "ORIGINATION", counter: 42, gasLimit: 3494, storageLimit: 5852 },
     });
+    expect((tx.operations[0] as any).details).not.toHaveProperty("originatedContract");
   });
 
   it("produces negative amount for an origination with contractBalance > 0", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
@@ -860,7 +860,6 @@ describe("delegation operations", () => {
       details: {
         operationType: "DELEGATE",
         stakedAmount: 0n,
-        delegate: "tz1Baker",
         counter: 42,
         gasLimit: 1000,
         storageLimit: 257,
@@ -898,7 +897,6 @@ describe("delegation operations", () => {
       details: {
         operationType: "UNDELEGATE",
         stakedAmount: 0n,
-        delegate: "tz1PrevBaker",
         counter: 7,
         gasLimit: 500,
         storageLimit: 100,
@@ -1113,7 +1111,6 @@ describe("staking operations", () => {
         details: {
           operationType: expectedOpType,
           stakedAmount: expectedStakedAmount,
-          delegate: "tz1Baker",
           counter: 1,
           gasLimit: 3630,
           storageLimit: 0,
@@ -1213,13 +1210,7 @@ describe("origination operations", () => {
       type: "other",
       address: "tz1Deployer",
       amount: 0n,
-      details: {
-        ledgerOpType: "ORIGINATION",
-        counter: 42,
-        gasLimit: 3494,
-        storageLimit: 5852,
-        originatedContract: "KT1NewContract",
-      },
+      details: { ledgerOpType: "ORIGINATION", counter: 42, gasLimit: 3494, storageLimit: 5852 },
     });
   });
 

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
@@ -136,7 +136,6 @@ function buildDelegationOperations(op: APIDelegationType): BlockOperation[] {
   const senderAddr = op.sender?.address;
   if (!senderAddr) return [];
 
-  const targetAddr = op.newDelegate?.address || op.prevDelegate?.address;
   const isDelegate = !!op.newDelegate?.address;
 
   return [
@@ -148,7 +147,6 @@ function buildDelegationOperations(op: APIDelegationType): BlockOperation[] {
       details: {
         operationType: isDelegate ? "DELEGATE" : "UNDELEGATE",
         stakedAmount: 0n,
-        ...(targetAddr && { delegate: targetAddr }),
         counter: op.counter,
         gasLimit: op.gasLimit,
         storageLimit: op.storageLimit,
@@ -183,7 +181,6 @@ function buildStakingOperations(op: APIStakingType): BlockOperation[] {
   if (!senderAddr) return [];
 
   const operationType = STAKING_ACTION_TO_OP_TYPE[op.action];
-  const bakerAddr = op.baker?.address;
 
   return [
     {
@@ -194,7 +191,6 @@ function buildStakingOperations(op: APIStakingType): BlockOperation[] {
       details: {
         operationType,
         stakedAmount: BigInt(op.amount ?? 0),
-        ...(bakerAddr && { delegate: bakerAddr }),
         counter: op.counter,
         gasLimit: op.gasLimit,
         storageLimit: op.storageLimit,
@@ -228,8 +224,6 @@ function buildOriginationOperations(op: APIOriginationType): BlockOperation[] {
   const senderAddr = op.sender?.address;
   if (!senderAddr) return [];
 
-  const contractAddr = op.originatedContract?.address;
-
   return [
     {
       type: "other",
@@ -241,7 +235,6 @@ function buildOriginationOperations(op: APIOriginationType): BlockOperation[] {
         gasLimit: op.gasLimit,
         storageLimit: op.storageLimit,
         ledgerOpType: "ORIGINATION",
-        ...(contractAddr && { originatedContract: contractAddr }),
       },
     },
   ];


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Align getBlock operation details with listOperations so reindexing produces identical event data as initial indexation.                                                                     
   
Removes extra fields from getBlock details that listOperations does not produce:                                                                                                            
- delegate from delegation and staking operations
- originatedContract from origination operations                                                                                                                                            
                                                  


### ❓ Context

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
