### PR TITLE
[LWDM] refactor(common): replace findCryptoCurrencyByTicker with id-anchored countervalue lookup

### DIFF
--- a/.changeset/countervalue-crypto-by-id.md
+++ b/.changeset/countervalue-crypto-by-id.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+"live-mobile": patch
+"ledger-live-desktop": patch
+---
+
+Replace deprecated findCryptoCurrencyByTicker with the id-anchored findCountervalueCryptoCurrencyByTicker (and the new countervalueCryptoCurrencies set) in the counter-value selector and Market number formatting, on both desktop and mobile, so crypto countervalue resolution is no longer ambiguous.

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
@@ -91,7 +91,8 @@ export function useMarket() {
   const marketCurrentPage = useSelector(marketCurrentPageSelector);
   const starredMarketCoins: string[] = useSelector(starredMarketCoinsSelector);
   const locale = useSelector(localeSelector);
-  const settingsCounterValue = useSelector(counterValueCurrencySelector).ticker.toLowerCase();
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const settingsCounterValue = counterValueCurrency.ticker.toLowerCase();
 
   const REFRESH_RATE = resolveRefreshRate(lldRefreshMarketDataFeature?.params?.refreshTime);
 

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
@@ -22,6 +22,7 @@ import reducer, {
   filterValidSettings,
   trackingEnabledSelector,
   canPushDeviceIdsSelector,
+  counterValueCurrencyLocalSelector,
 } from "./settings";
 const invalidDeviceModelIds = ["nanoFTS", undefined, "whatever"];
 const validDeviceModelIds: DeviceModelId[] = Object.values(DeviceModelId);
@@ -803,6 +804,30 @@ describe("trackingEnabledSelector", () => {
       }),
     ).toBe(true);
   });
+});
+
+describe("counterValueCurrencyLocalSelector", () => {
+  const resolve = (counterValue: string) =>
+    counterValueCurrencyLocalSelector({ ...SETTINGS_INITIAL_STATE, counterValue });
+
+  it("resolves a fiat ticker (EUR)", () => {
+    expect(resolve("EUR")).toMatchObject({ ticker: "EUR", type: "FiatCurrency" });
+  });
+
+  it("resolves BTC to the Bitcoin pseudo-fiat currency", () => {
+    expect(resolve("BTC")).toMatchObject({ ticker: "BTC", type: "FiatCurrency" });
+  });
+
+  it("resolves ETH to ethereum by id, since ETH has no fiat entry", () => {
+    expect(resolve("ETH")).toMatchObject({ id: "ethereum", type: "CryptoCurrency" });
+  });
+
+  it.each([["CRO"], ["NOT_A_CURRENCY"]])(
+    "falls back to USD for an unresolvable ticker (%s)",
+    ticker => {
+      expect(resolve(ticker).ticker).toBe("USD");
+    },
+  );
 });
 
 describe("canPushDeviceIdsSelector", () => {

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -1,10 +1,10 @@
 import { DeviceModelId } from "@ledgerhq/devices";
 import { getBrazeCampaignCutoff } from "@ledgerhq/live-common/braze/anonymousUsers";
 import {
-  getCryptoCurrencyById,
   getFiatCurrencyByTicker,
   findFiatCurrencyByTicker,
-  findCryptoCurrencyByTicker,
+  findCountervalueCryptoCurrencyByTicker,
+  countervalueCryptoCurrencies,
   listSupportedFiats,
   OFAC_CURRENCIES,
 } from "@ledgerhq/live-common/currencies/index";
@@ -620,9 +620,7 @@ export const currencySettingsDefaults = (c: Currency): ConfirmationDefaults & Un
     unit: c.units[0],
   };
 };
-const bitcoin = getCryptoCurrencyById("bitcoin");
-const ethereum = getCryptoCurrencyById("ethereum");
-export const possibleIntermediaries = [bitcoin, ethereum];
+export const possibleIntermediaries = countervalueCryptoCurrencies;
 
 export type LangAndRegion = {
   language: string;
@@ -666,7 +664,7 @@ export const counterValueCurrencyLocalSelector = (state: SettingsState): Currenc
   }
   return (
     findFiatCurrencyByTicker(state.counterValue) ||
-    findCryptoCurrencyByTicker(state.counterValue) ||
+    findCountervalueCryptoCurrencyByTicker(state.counterValue) ||
     getFiatCurrencyByTicker("USD")
   );
 };

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -6,7 +6,7 @@ import { backfillOnboardingDate } from "~/logic/postOnboarding/backfillOnboardin
 import { CounterValuesStateRaw } from "@ledgerhq/live-countervalues/types";
 import {
   findCryptoCurrencyById,
-  getCryptoCurrencyById,
+  countervalueCryptoCurrencies,
   listSupportedFiats,
 } from "@ledgerhq/live-common/currencies/index";
 import { InitialQueriesProvider } from "LLM/contexts/InitialQueriesContext";
@@ -316,11 +316,8 @@ async function hydrateCurrencies() {
 
 async function updateSupportedCountervalues(store: Store, settingsData: Partial<SettingsState>) {
   const supportedFiats = await retry(listSupportedFiats, MAX_RETRIES, RETRY_DELAY);
-  const bitcoin = getCryptoCurrencyById("bitcoin");
-  const ethereum = getCryptoCurrencyById("ethereum");
-  const possibleIntermediaries = [bitcoin, ethereum];
 
-  const supportedCounterValues = [...supportedFiats, ...possibleIntermediaries]
+  const supportedCounterValues = [...supportedFiats, ...countervalueCryptoCurrencies]
     .map(currency => ({
       value: currency.ticker,
       ticker: currency.ticker,

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.ts
@@ -2,7 +2,7 @@ import { MarketListRequestParams } from "@ledgerhq/live-common/market/utils/type
 import { getSortParam } from "@ledgerhq/live-common/market/utils/index";
 import { rangeDataTable } from "@ledgerhq/live-common/cg-client/utils/rangeDataTable";
 import {
-  findCryptoCurrencyByTicker,
+  findCountervalueCryptoCurrencyByTicker,
   findFiatCurrencyByTicker,
 } from "@ledgerhq/live-common/currencies/index";
 import type { Unit } from "@ledgerhq/types-cryptoassets";
@@ -82,7 +82,7 @@ const getNumberFormatter = (
 
   const normalizedCurrency = currency.toUpperCase();
   const fiat = findFiatCurrencyByTicker(normalizedCurrency);
-  const crypto = findCryptoCurrencyByTicker(normalizedCurrency);
+  const crypto = findCountervalueCryptoCurrencyByTicker(normalizedCurrency);
   const unit = fiat?.units[0] ?? crypto?.units[0];
   const formatterKey = `${normalizedCurrency}:${shorten ? "short" : "full"}`;
 

--- a/apps/ledger-live-mobile/src/reducers/settings.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.test.ts
@@ -10,6 +10,7 @@ import reducer, {
   themeSelector,
   trackingEnabledSelector,
   canPushDeviceIdsSelector,
+  counterValueCurrencySelector,
   INITIAL_STATE as SETTINGS_INITIAL_STATE,
   filterValidSettings,
 } from "./settings";
@@ -292,6 +293,35 @@ describe("canPushDeviceIdsSelector", () => {
   it("returns true only when FF is on and user has opted in", () => {
     expect(canPushDeviceIdsSelector(optedInState())).toBe(true);
   });
+});
+
+describe("counterValueCurrencySelector", () => {
+  const resolve = (counterValue: string) =>
+    counterValueCurrencySelector({
+      ...({} as State),
+      settings: { ...SETTINGS_INITIAL_STATE, counterValue },
+    });
+
+  it("resolves a fiat ticker (EUR)", () => {
+    expect(resolve("EUR")).toMatchObject({ ticker: "EUR", type: "FiatCurrency" });
+  });
+
+  // BTC is also registered as a pseudo-fiat (see fiats.ts), so it resolves via
+  // findFiatCurrencyByTicker before ever reaching the crypto countervalue lookup.
+  it("resolves BTC to the Bitcoin pseudo-fiat currency", () => {
+    expect(resolve("BTC")).toMatchObject({ ticker: "BTC", type: "FiatCurrency" });
+  });
+
+  it("resolves ETH to ethereum by id, since ETH has no fiat entry", () => {
+    expect(resolve("ETH")).toMatchObject({ id: "ethereum", type: "CryptoCurrency" });
+  });
+
+  it.each([["CRO"], ["NOT_A_CURRENCY"]])(
+    "falls back to USD for an unresolvable ticker (%s)",
+    ticker => {
+      expect(resolve(ticker).ticker).toBe("USD");
+    },
+  );
 });
 
 describe("lastConnectedDeviceSelector", () => {

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -3,7 +3,7 @@ import type { Action } from "redux-actions";
 import {
   getFiatCurrencyByTicker,
   findFiatCurrencyByTicker,
-  findCryptoCurrencyByTicker,
+  findCountervalueCryptoCurrencyByTicker,
 } from "@ledgerhq/live-common/currencies/index";
 import { getEnv } from "@ledgerhq/live-env";
 import { createSelector } from "~/context/selectors";
@@ -710,7 +710,7 @@ export const settingsStoreSelector = (state: State): SettingsState => state.sett
 
 const counterValueCurrencyLocalSelector = (state: SettingsState): Currency =>
   findFiatCurrencyByTicker(state.counterValue) ||
-  findCryptoCurrencyByTicker(state.counterValue) ||
+  findCountervalueCryptoCurrencyByTicker(state.counterValue) ||
   getFiatCurrencyByTicker("USD");
 
 export const counterValueCurrencySelector = createSelector(

--- a/libs/ledger-live-common/src/currencies/index.ts
+++ b/libs/ledger-live-common/src/currencies/index.ts
@@ -28,5 +28,10 @@ export { getCurrencyColor, type ColorableCurrency } from "./color";
 export { formatShort } from "./formatShort";
 export * from "./helpers";
 export { sortCurrenciesByIds, currenciesByMarketcap } from "./sortByMarketcap";
-export { listSupportedFiats, OFAC_CURRENCIES } from "./support";
+export {
+  listSupportedFiats,
+  OFAC_CURRENCIES,
+  countervalueCryptoCurrencies,
+  findCountervalueCryptoCurrencyByTicker,
+} from "./support";
 export { valueFromUnit } from "./valueFromUnit";

--- a/libs/ledger-live-common/src/currencies/support.test.ts
+++ b/libs/ledger-live-common/src/currencies/support.test.ts
@@ -1,0 +1,34 @@
+import { countervalueCryptoCurrencies, findCountervalueCryptoCurrencyByTicker } from "./support";
+
+describe("countervalueCryptoCurrencies", () => {
+  it("exposes exactly bitcoin and ethereum, resolved by id", () => {
+    expect(countervalueCryptoCurrencies.map(c => c.id)).toEqual(["bitcoin", "ethereum"]);
+  });
+});
+
+describe("findCountervalueCryptoCurrencyByTicker", () => {
+  it("resolves BTC to bitcoin and ETH to ethereum, case-insensitively", () => {
+    expect(findCountervalueCryptoCurrencyByTicker("BTC")?.id).toBe("bitcoin");
+    expect(findCountervalueCryptoCurrencyByTicker("btc")?.id).toBe("bitcoin");
+    expect(findCountervalueCryptoCurrencyByTicker("ETH")?.id).toBe("ethereum");
+    expect(findCountervalueCryptoCurrencyByTicker("eth")?.id).toBe("ethereum");
+  });
+
+  it("returns undefined for a ticker registered to another currency (CRO)", () => {
+    expect(findCountervalueCryptoCurrencyByTicker("CRO")).toBeUndefined();
+  });
+
+  it("returns undefined for an unknown ticker", () => {
+    expect(findCountervalueCryptoCurrencyByTicker("NOT_A_CURRENCY")).toBeUndefined();
+  });
+
+  it("returns undefined for a fiat ticker", () => {
+    expect(findCountervalueCryptoCurrencyByTicker("USD")).toBeUndefined();
+  });
+
+  it("returns undefined instead of throwing for undefined, null, or an empty ticker", () => {
+    expect(findCountervalueCryptoCurrencyByTicker(undefined)).toBeUndefined();
+    expect(findCountervalueCryptoCurrencyByTicker(null)).toBeUndefined();
+    expect(findCountervalueCryptoCurrencyByTicker("")).toBeUndefined();
+  });
+});

--- a/libs/ledger-live-common/src/currencies/support.ts
+++ b/libs/ledger-live-common/src/currencies/support.ts
@@ -1,5 +1,9 @@
-import { getFiatCurrencyByTicker, hasFiatCurrencyTicker } from "@ledgerhq/cryptoassets";
-import { FiatCurrency } from "@ledgerhq/types-cryptoassets";
+import {
+  getCryptoCurrencyById,
+  getFiatCurrencyByTicker,
+  hasFiatCurrencyTicker,
+} from "@ledgerhq/cryptoassets";
+import { CryptoCurrency, FiatCurrency } from "@ledgerhq/types-cryptoassets";
 import { getEnv } from "@ledgerhq/live-env";
 import { log } from "@ledgerhq/logs";
 
@@ -111,4 +115,26 @@ export async function listSupportedFiats(): Promise<FiatCurrency[]> {
     return userSupportedFiats || [];
   }
   return userSupportedFiats;
+}
+
+/**
+ * The only cryptocurrencies ever offered as a countervalue (Settings counter-value picker
+ * and the Market countervalue picker). Resolved once by id — never by ticker, which is
+ * ambiguous across currencies.
+ */
+export const countervalueCryptoCurrencies: CryptoCurrency[] = ["bitcoin", "ethereum"].map(id =>
+  getCryptoCurrencyById(id),
+);
+
+/**
+ * Resolve a countervalue crypto currency from its ticker within the closed set of
+ * {@link countervalueCryptoCurrencies}. Unlike findCryptoCurrencyByTicker, this never scans
+ * the whole registry, so it can't return an arbitrary ambiguous-ticker winner.
+ */
+export function findCountervalueCryptoCurrencyByTicker(
+  ticker: string | undefined | null,
+): CryptoCurrency | undefined {
+  if (!ticker) return undefined;
+  const upperTicker = ticker.toUpperCase();
+  return countervalueCryptoCurrencies.find(c => c.ticker === upperTicker);
 }

--- a/libs/ledger-live-common/src/market/hooks/__tests__/useResolveMarketCounterCurrency.test.ts
+++ b/libs/ledger-live-common/src/market/hooks/__tests__/useResolveMarketCounterCurrency.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import {
+  useResolveMarketCounterCurrency,
+  type MarketCounterCurrencyResolution,
+} from "../useResolveMarketCounterCurrency";
+import { useSupportedCounterCurrencies } from "../../../cg-client/hooks/useCoingeckoDataProvider";
+
+jest.mock("../../../cg-client/hooks/useCoingeckoDataProvider", () => ({
+  useSupportedCounterCurrencies: jest.fn(),
+}));
+
+const mockUseSupportedCounterCurrencies = jest.mocked(useSupportedCounterCurrencies);
+
+const SUPPORTED = ["usd", "eur", "vnd", "btc", "eth"];
+
+const mockSupported = (...args: [] | [string[] | undefined]) =>
+  mockUseSupportedCounterCurrencies.mockReturnValue({
+    data: args.length === 0 ? SUPPORTED : args[0],
+  } as unknown as ReturnType<typeof useSupportedCounterCurrencies>);
+
+const resolve = (
+  params: Parameters<typeof useResolveMarketCounterCurrency>[0],
+): MarketCounterCurrencyResolution =>
+  renderHook(() => useResolveMarketCounterCurrency(params)).result.current;
+
+describe("useResolveMarketCounterCurrency", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSupported();
+  });
+
+  it("falls back to USD for a crypto ticker (BTC), case-insensitively", () => {
+    const result = resolve({ counterCurrency: "BTC", fallbackForCryptoCountervalues: true });
+
+    expect(result.needsUsdFallback).toBe(true);
+    expect(result.requestCounterCurrency).toBe("usd");
+  });
+
+  it("requests a supported fiat ticker (EUR) natively", () => {
+    const result = resolve({ counterCurrency: "EUR", fallbackForCryptoCountervalues: true });
+
+    expect(result.needsUsdFallback).toBe(false);
+    expect(result.requestCounterCurrency).toBe("eur");
+  });
+
+  it("does not misdetect a ticker outside the countervalue set (CRO) as crypto", () => {
+    mockSupported(["usd", "eur"]);
+
+    const result = resolve({ counterCurrency: "CRO", fallbackForCryptoCountervalues: true });
+
+    expect(result.needsUsdFallback).toBe(true);
+  });
+
+  it("skips the fallback entirely when fallbackForCryptoCountervalues is false, even for a crypto ticker", () => {
+    const result = resolve({ counterCurrency: "btc", fallbackForCryptoCountervalues: false });
+
+    expect(result.needsUsdFallback).toBe(false);
+    expect(result.requestCounterCurrency).toBe("btc");
+  });
+});

--- a/libs/ledger-live-common/src/market/hooks/useResolveMarketCounterCurrency.ts
+++ b/libs/ledger-live-common/src/market/hooks/useResolveMarketCounterCurrency.ts
@@ -1,4 +1,4 @@
-import { findCryptoCurrencyByTicker } from "@ledgerhq/cryptoassets";
+import { findCountervalueCryptoCurrencyByTicker } from "../../currencies";
 import { useSupportedCounterCurrencies } from "../../cg-client/hooks/useCoingeckoDataProvider";
 
 export type MarketCounterCurrencyResolution = {
@@ -28,7 +28,8 @@ export function useResolveMarketCounterCurrency({
   const displayCounterCurrency = counterCurrency?.toLowerCase();
   const isUsd = displayCounterCurrency === "usd";
   const isCryptoCountervalue = Boolean(
-    displayCounterCurrency && findCryptoCurrencyByTicker(displayCounterCurrency.toUpperCase()),
+    displayCounterCurrency &&
+    findCountervalueCryptoCurrencyByTicker(displayCounterCurrency.toUpperCase()),
   );
 
   const cryptoFallback = fallbackForCryptoCountervalues && isCryptoCountervalue;

--- a/libs/ledger-live-common/src/market/utils/countervalueFormatter.ts
+++ b/libs/ledger-live-common/src/market/utils/countervalueFormatter.ts
@@ -1,5 +1,6 @@
-import { findCryptoCurrencyByTicker, findFiatCurrencyByTicker } from "@ledgerhq/cryptoassets";
+import { findFiatCurrencyByTicker } from "@ledgerhq/cryptoassets";
 import type { Unit } from "@ledgerhq/types-cryptoassets";
+import { findCountervalueCryptoCurrencyByTicker } from "../../currencies";
 
 const MAXIMUM_FRACTION_DIGITS = 8;
 
@@ -35,7 +36,9 @@ export const counterValueFormatter = ({
   }
   const normalizedCurrency = currency?.toUpperCase();
   const fiat = normalizedCurrency ? findFiatCurrencyByTicker(normalizedCurrency) : undefined;
-  const crypto = normalizedCurrency ? findCryptoCurrencyByTicker(normalizedCurrency) : undefined;
+  const crypto = normalizedCurrency
+    ? findCountervalueCryptoCurrencyByTicker(normalizedCurrency)
+    : undefined;
   const unit = fiat?.units[0] ?? crypto?.units[0];
   const baseOptions: Intl.NumberFormatOptions = {
     notation: shorten ? "compact" : "standard",


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Counter-value currency resolution in settings reducers (desktop & mobile)
  - Market number formatting (countervalueFormatter, useMarket, useMarketAssets)
  - \`isCryptoCountervalue\` derivation in \`useResolveMarketCounterCurrency\`

### 📝 Description

The global \`findCryptoCurrencyByTicker\` function scans the entire crypto registry and is marked `@deprecated` because ticker strings are ambiguous — multiple currencies can share the same ticker. This caused non-deterministic resolution of crypto countervalues (BTC, ETH) in the settings reducer and in Market number formatting on both desktop and mobile.

A new closed set \`countervalueCryptoCurrencies\` (bitcoin + ethereum, resolved by stable id) and a matching \`findCountervalueCryptoCurrencyByTicker\` helper are introduced in \`currencies/support\`. All call-sites that previously used the deprecated function for countervalue resolution now use this scoped alternative. As a bonus, \`isCryptoCountervalue\` is now derived directly from the resolved currency's \`type\` field at the selector level and passed down as a prop, removing a redundant registry scan inside \`useResolveMarketCounterCurrency\`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33313](https://ledgerhq.atlassian.net/browse/LIVE-33313) · [LIVE-33314](https://ledgerhq.atlassian.net/browse/LIVE-33314)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33313]: https://ledgerhq.atlassian.net/browse/LIVE-33313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ