### PR TITLE
[LWDM] feat(celo): show currency icon + balance in the 'Pay fees in' screen

### DIFF
--- a/.changeset/modern-feet-camp.md
+++ b/.changeset/modern-feet-camp.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Celo Custom-fees "Pay fees in" options now show a currency icon and held balance for native CELO and each allowlisted fee token, on desktop and mobile. The generic `FeeAssetOption` contract gains two optional fields (`currency`, `balance`); the UI formats the raw balance with the user's locale. Coins that don't set them render exactly as before.

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/components/CustomFeesScreenView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/components/CustomFeesScreenView.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { TextInput, Button, DialogBody, DialogFooter } from "@ledgerhq/lumen-ui-react";
-import type { FeeAssetOption } from "@ledgerhq/live-common/bridge/descriptor/types";
+import type { FeeAssetUiOption } from "@ledgerhq/live-common/flows/send/customFees/hooks/useCustomFeesViewModelCore";
 import type { CustomFeeInputState } from "../hooks/useCustomFeesViewModel";
 import { FeeAssetSelector } from "./FeeAssetSelector";
 
@@ -13,7 +13,7 @@ type CustomFeesScreenViewProps = Readonly<{
   onInputClear: (key: string) => void;
   onConfirm: () => void;
   hasCustomAssets: boolean;
-  assetOptions: readonly FeeAssetOption[];
+  assetOptions: readonly FeeAssetUiOption[];
   selectedAssetId: string;
   onAssetChange: (id: string) => void;
   confirmLabel: string;

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/components/FeeAssetSelector.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/components/FeeAssetSelector.tsx
@@ -12,10 +12,11 @@ import {
   ListItemTrailing,
 } from "@ledgerhq/lumen-ui-react";
 import { ChevronRight } from "@ledgerhq/lumen-ui-react/symbols";
-import type { FeeAssetOption } from "@ledgerhq/live-common/bridge/descriptor/types";
+import type { FeeAssetUiOption } from "@ledgerhq/live-common/flows/send/customFees/hooks/useCustomFeesViewModelCore";
+import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
 
 type FeeAssetSelectorProps = Readonly<{
-  options: readonly FeeAssetOption[];
+  options: readonly FeeAssetUiOption[];
   selectedId: string;
   onChange: (id: string) => void;
   payFeesInLabel: string;
@@ -40,23 +41,47 @@ function FeeAssetSelectorComponent({
               </ListItemContent>
             </ListItemLeading>
             <ListItemTrailing>
-              <span className="body-2-semi-bold text-base">{selectedOption?.ticker ?? ""}</span>
+              <span className="flex items-center gap-8">
+                {selectedOption?.currency && (
+                  <CryptoCurrencyIcon currency={selectedOption.currency} size={16} />
+                )}
+                <span className="body-2-semi-bold text-base">{selectedOption?.ticker ?? ""}</span>
+              </span>
               <ChevronRight size={16} />
             </ListItemTrailing>
           </ListItem>
         }
       />
-      <MenuContent className="pointer-events-auto" side="bottom" align="end">
+      <MenuContent
+        className="w-[var(--anchor-width)] pointer-events-auto"
+        side="bottom"
+        align="end"
+      >
         <MenuRadioGroup value={selectedId} onValueChange={onChange}>
           {options.map(option => (
             <MenuRadioItem
               key={option.id}
               value={option.id}
               closeOnClick
-              className="cursor-pointer"
+              className="flex cursor-pointer items-center justify-between gap-8"
               data-testid={`send-fee-asset-option-${option.id}`}
             >
-              {option.ticker}
+              <span className="flex items-center gap-8">
+                {option.currency && (
+                  <span data-testid={`send-fee-asset-icon-${option.id}`}>
+                    <CryptoCurrencyIcon currency={option.currency} size={24} />
+                  </span>
+                )}
+                <span className="body-2-semi-bold text-base">{option.ticker}</span>
+              </span>
+              {option.formattedBalance !== undefined && (
+                <span
+                  className="body-2-regular text-muted"
+                  data-testid={`send-fee-asset-balance-${option.id}`}
+                >
+                  {option.formattedBalance}
+                </span>
+              )}
             </MenuRadioItem>
           ))}
         </MenuRadioGroup>

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/components/__tests__/FeeAssetSelector.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/components/__tests__/FeeAssetSelector.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { FeeAssetUiOption } from "@ledgerhq/live-common/flows/send/customFees/hooks/useCustomFeesViewModelCore";
+import { FeeAssetSelector } from "../FeeAssetSelector";
+
+jest.mock("~/renderer/components/CryptoCurrencyIcon", () => ({
+  __esModule: true,
+  default: ({ currency }: { currency: { ticker: string } }) => (
+    <span data-testid={`crypto-icon-${currency.ticker}`} />
+  ),
+}));
+
+const celoCurrency = {
+  id: "celo",
+  type: "CryptoCurrency",
+  family: "celo",
+  name: "Celo",
+  ticker: "CELO",
+  units: [{ name: "Celo", code: "CELO", magnitude: 18 }],
+} as CryptoCurrency;
+
+const usdtCurrency: TokenCurrency = {
+  id: "celo/erc20/usdt",
+  type: "TokenCurrency",
+  parentCurrencyId: celoCurrency.id,
+  tokenType: "erc20",
+  contractAddress: "0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e",
+  name: "Tether USD",
+  ticker: "USDT",
+  units: [{ name: "Tether USD", code: "USDT", magnitude: 6 }],
+};
+
+const optionsWithIconsAndBalances: readonly FeeAssetUiOption[] = [
+  {
+    id: "celo",
+    ticker: "CELO",
+    label: "CELO",
+    unitLabel: "Gwei",
+    currency: celoCurrency,
+    formattedBalance: "2.5",
+  },
+  {
+    id: "usdt-account-id",
+    ticker: "USDT",
+    label: "USDT",
+    currency: usdtCurrency,
+    formattedBalance: "10",
+  },
+];
+
+// Legacy-shaped options (no currency/formattedBalance) — must render exactly as before.
+const legacyOptions: readonly FeeAssetUiOption[] = [
+  { id: "celo", ticker: "CELO", label: "CELO", unitLabel: "Gwei" },
+  { id: "cusd", ticker: "cUSD", label: "cUSD" },
+];
+
+describe("FeeAssetSelector", () => {
+  it("renders the trigger with the selected option's ticker", () => {
+    render(
+      <FeeAssetSelector
+        options={optionsWithIconsAndBalances}
+        selectedId="celo"
+        onChange={jest.fn()}
+        payFeesInLabel="Pay fees in"
+      />,
+    );
+
+    expect(screen.getByTestId("send-fee-asset-select")).toBeInTheDocument();
+    expect(screen.getByText("Pay fees in")).toBeInTheDocument();
+    expect(screen.getByText("CELO")).toBeInTheDocument();
+  });
+
+  it("renders an icon and the formatted balance for each option once opened", async () => {
+    const { user } = render(
+      <FeeAssetSelector
+        options={optionsWithIconsAndBalances}
+        selectedId="celo"
+        onChange={jest.fn()}
+        payFeesInLabel="Pay fees in"
+      />,
+    );
+
+    await user.click(screen.getByTestId("send-fee-asset-select"));
+
+    const celoOption = await screen.findByTestId("send-fee-asset-option-celo");
+    expect(celoOption).toBeInTheDocument();
+    expect(screen.getByTestId("send-fee-asset-icon-celo")).toBeInTheDocument();
+    expect(screen.getByTestId("send-fee-asset-balance-celo")).toHaveTextContent("2.5");
+
+    const usdtOption = screen.getByTestId("send-fee-asset-option-usdt-account-id");
+    expect(usdtOption).toBeInTheDocument();
+    expect(screen.getByTestId("send-fee-asset-icon-usdt-account-id")).toBeInTheDocument();
+    expect(screen.getByTestId("send-fee-asset-balance-usdt-account-id")).toHaveTextContent("10");
+  });
+
+  it("renders no icon or balance for options that don't set them (backward compatible)", async () => {
+    const { user } = render(
+      <FeeAssetSelector
+        options={legacyOptions}
+        selectedId="celo"
+        onChange={jest.fn()}
+        payFeesInLabel="Pay fees in"
+      />,
+    );
+
+    await user.click(screen.getByTestId("send-fee-asset-select"));
+
+    await screen.findByTestId("send-fee-asset-option-celo");
+    expect(screen.queryByTestId("send-fee-asset-icon-celo")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("send-fee-asset-balance-celo")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("send-fee-asset-icon-cusd")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("send-fee-asset-balance-cusd")).not.toBeInTheDocument();
+
+    expect(screen.getByText("cUSD")).toBeInTheDocument();
+  });
+
+  it("calls onChange with the option id when an option is selected", async () => {
+    const onChange = jest.fn();
+    const { user } = render(
+      <FeeAssetSelector
+        options={optionsWithIconsAndBalances}
+        selectedId="celo"
+        onChange={onChange}
+        payFeesInLabel="Pay fees in"
+      />,
+    );
+
+    await user.click(screen.getByTestId("send-fee-asset-select"));
+    const usdtOption = await screen.findByTestId("send-fee-asset-option-usdt-account-id");
+    await user.click(usdtOption);
+
+    expect(onChange).toHaveBeenCalledWith("usdt-account-id");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/hooks/useCustomFeesViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/hooks/useCustomFeesViewModel.ts
@@ -14,7 +14,11 @@ import {
   getCustomFeeLabelKey,
   getCustomFeeHelperLabelKey,
 } from "@ledgerhq/live-common/flows/send/customFees/utils/customFeeUtils";
-import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
+import {
+  counterValueCurrencySelector,
+  discreetModeSelector,
+  localeSelector,
+} from "~/renderer/reducers/settings";
 
 export type {
   CustomFeeInputState,
@@ -37,6 +41,7 @@ export function useCustomFeesViewModel(
   const { t } = useTranslation();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const locale = useSelector(localeSelector);
+  const discreet = useSelector(discreetModeSelector);
   const calculateCountervalue = useCalculateCountervalueCallback({ to: counterValueCurrency });
 
   const labels: CustomFeesViewModelLabels = useMemo(
@@ -62,6 +67,7 @@ export function useCustomFeesViewModel(
   return useCustomFeesViewModelCore({
     ...props,
     locale,
+    discreet,
     counterValueCurrency,
     calculateCountervalue,
     labels,

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4581,6 +4581,7 @@
         "maxPriorityFee": "Max priority fee ({{unit}})",
         "gasLimit": "Gas limit ({{unit}})",
         "feePerByte": "Fees amount ({{unit}})",
+        "feesAmount": "Fees amount ({{unit}})",
         "suggested": "Suggested",
         "nextBlock": "Next block",
         "networkFeesInFiat": "Network fees in {{currency}}",

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/NetworkFeesRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/NetworkFeesRow.tsx
@@ -98,11 +98,16 @@ export function NetworkFeesRow({ viewModel }: NetworkFeesRowProps) {
     infoBottomSheetRef.current?.present();
   }, [infoBottomSheetRef]);
 
+  const canOpenFeeSelector =
+    viewModel.showFeePresets ||
+    !!viewModel.uiConfig?.hasCustomFees ||
+    !!viewModel.uiConfig?.hasCoinControl;
+
   const handleOpenSelector = useCallback(() => {
-    if (viewModel.showFeePresets) {
+    if (canOpenFeeSelector) {
       selectorBottomSheetRef.current?.present();
     }
-  }, [viewModel.showFeePresets, selectorBottomSheetRef]);
+  }, [canOpenFeeSelector, selectorBottomSheetRef]);
 
   const handleSelectStrategy = useCallback(
     (strategy: string) => {
@@ -147,7 +152,7 @@ export function NetworkFeesRow({ viewModel }: NetworkFeesRowProps) {
         <Pressable
           style={styles.rightSection}
           onPress={handleOpenSelector}
-          disabled={!viewModel.showFeePresets}
+          disabled={!canOpenFeeSelector}
         >
           <View style={styles.feeValue}>
             <Text typography="body3" lx={{ color: "base" }}>
@@ -160,7 +165,7 @@ export function NetworkFeesRow({ viewModel }: NetworkFeesRowProps) {
               {viewModel.strategyLabel}
             </Text>
           </View>
-          {viewModel.showFeePresets ? <ChevronDown size={16} /> : null}
+          {canOpenFeeSelector ? <ChevronDown size={16} /> : null}
         </Pressable>
       </View>
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CustomFees/components/CustomFeesScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CustomFees/components/CustomFeesScreenView.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { Box, Button, Text, TextInput } from "@ledgerhq/lumen-ui-rnative";
-import type { FeeAssetOption } from "@ledgerhq/live-common/bridge/descriptor/types";
-import type { CustomFeeInputState } from "@ledgerhq/live-common/flows/send/customFees/hooks/useCustomFeesViewModelCore";
+import type {
+  CustomFeeInputState,
+  FeeAssetUiOption,
+} from "@ledgerhq/live-common/flows/send/customFees/hooks/useCustomFeesViewModelCore";
 import { SendFlowLayout } from "../../../components/SendFlowLayout";
 import { FeeAssetSelector } from "./FeeAssetSelector";
 
@@ -38,7 +40,7 @@ type CustomFeesScreenViewProps = Readonly<{
   onInputClear: (key: string) => void;
   onConfirm: () => void;
   hasCustomAssets: boolean;
-  assetOptions: readonly FeeAssetOption[];
+  assetOptions: readonly FeeAssetUiOption[];
   selectedAssetId: string;
   onAssetChange: (id: string) => void;
   confirmLabel: string;

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CustomFees/components/FeeAssetSelector.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CustomFees/components/FeeAssetSelector.tsx
@@ -8,6 +8,8 @@ import {
   OptionListContent,
   OptionListItem,
   OptionListItemContent,
+  OptionListItemDescription,
+  OptionListItemLeading,
   OptionListItemText,
   OptionListTrigger,
   Subheader,
@@ -16,14 +18,24 @@ import {
   Text,
   useBottomSheetRef,
 } from "@ledgerhq/lumen-ui-rnative";
-import type { FeeAssetOption } from "@ledgerhq/live-common/bridge/descriptor/types";
+import type { OptionListItemData } from "@ledgerhq/lumen-ui-rnative";
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { FeeAssetUiOption } from "@ledgerhq/live-common/flows/send/customFees/hooks/useCustomFeesViewModelCore";
+import CurrencyIcon from "~/components/CurrencyIcon";
 
 type FeeAssetSelectorProps = Readonly<{
-  options: readonly FeeAssetOption[];
+  options: readonly FeeAssetUiOption[];
   selectedId: string;
   onChange: (id: string) => void;
   payFeesInLabel: string;
 }>;
+
+type FeeAssetMeta = Readonly<{
+  currency: CryptoOrTokenCurrency | undefined;
+  formattedBalance: string | undefined;
+}>;
+
+type FeeAssetListItem = OptionListItemData<string, FeeAssetMeta>;
 
 export function FeeAssetSelector({
   options,
@@ -33,8 +45,16 @@ export function FeeAssetSelector({
 }: FeeAssetSelectorProps) {
   const bottomSheetRef = useBottomSheetRef();
 
-  const items = useMemo(
-    () => options.map(option => ({ value: option.id, label: option.ticker })),
+  const items = useMemo<FeeAssetListItem[]>(
+    () =>
+      options.map(option => ({
+        value: option.id,
+        label: option.ticker,
+        meta: {
+          currency: option.currency,
+          formattedBalance: option.formattedBalance,
+        },
+      })),
     [options],
   );
 
@@ -69,7 +89,14 @@ export function FeeAssetSelector({
         </SubheaderRow>
       </Subheader>
       <OptionListTrigger onPress={handleOpenSheet}>
-        {selectedOption != null && <Text lx={{ color: "base" }}>{selectedOption.ticker}</Text>}
+        {selectedOption != null && (
+          <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s8" }}>
+            {selectedOption.currency && (
+              <CurrencyIcon currency={selectedOption.currency} size={16} />
+            )}
+            <Text lx={{ color: "base" }}>{selectedOption.ticker}</Text>
+          </Box>
+        )}
       </OptionListTrigger>
       <BottomSheet
         ref={bottomSheetRef}
@@ -80,15 +107,29 @@ export function FeeAssetSelector({
         <BottomSheetView>
           <BottomSheetHeader title={payFeesInLabel} />
           <OptionList items={items} value={selectedId || null} onValueChange={handleValueChange}>
-            <OptionListContent
+            <OptionListContent<string, FeeAssetMeta>
               lx={{ marginBottom: "s24" }}
-              renderItem={item => (
-                <OptionListItem value={item.value}>
-                  <OptionListItemContent>
-                    <OptionListItemText>{item.label}</OptionListItemText>
-                  </OptionListItemContent>
-                </OptionListItem>
-              )}
+              renderItem={item => {
+                const currency = item.meta?.currency;
+                const formattedBalance = item.meta?.formattedBalance;
+                return (
+                  <OptionListItem value={item.value}>
+                    {currency && (
+                      <OptionListItemLeading testID={`send-fee-asset-icon-${item.value}`}>
+                        <CurrencyIcon currency={currency} size={32} />
+                      </OptionListItemLeading>
+                    )}
+                    <OptionListItemContent>
+                      <OptionListItemText>{item.label}</OptionListItemText>
+                      {formattedBalance !== undefined && (
+                        <OptionListItemDescription testID={`send-fee-asset-balance-${item.value}`}>
+                          {formattedBalance}
+                        </OptionListItemDescription>
+                      )}
+                    </OptionListItemContent>
+                  </OptionListItem>
+                );
+              }}
             />
           </OptionList>
         </BottomSheetView>

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CustomFees/components/__tests__/FeeAssetSelector.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CustomFees/components/__tests__/FeeAssetSelector.test.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { render as rntlRender, screen } from "@testing-library/react-native";
+import { ThemeProvider } from "@ledgerhq/lumen-ui-rnative";
+import { ledgerLiveThemes } from "@ledgerhq/lumen-design-core";
+import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { FeeAssetUiOption } from "@ledgerhq/live-common/flows/send/customFees/hooks/useCustomFeesViewModelCore";
+import { FeeAssetSelector } from "../FeeAssetSelector";
+
+function render(ui: React.ReactElement) {
+  return rntlRender(
+    <ThemeProvider themes={ledgerLiveThemes} colorScheme="dark">
+      {ui}
+    </ThemeProvider>,
+  );
+}
+
+jest.mock("~/components/CurrencyIcon", () => {
+  const RN = jest.requireActual<typeof import("react-native")>("react-native");
+  return {
+    __esModule: true,
+    default: ({ currency }: { currency: { ticker: string } }) => (
+      <RN.View testID={`crypto-icon-${currency.ticker}`} />
+    ),
+  };
+});
+
+const celoCurrency = {
+  id: "celo",
+  type: "CryptoCurrency",
+  family: "celo",
+  name: "Celo",
+  ticker: "CELO",
+  units: [{ name: "Celo", code: "CELO", magnitude: 18 }],
+} as CryptoCurrency;
+
+const usdtCurrency: TokenCurrency = {
+  id: "celo/erc20/usdt",
+  type: "TokenCurrency",
+  parentCurrencyId: celoCurrency.id,
+  tokenType: "erc20",
+  contractAddress: "0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e",
+  name: "Tether USD",
+  ticker: "USDT",
+  units: [{ name: "Tether USD", code: "USDT", magnitude: 6 }],
+};
+
+const optionsWithIconsAndBalances: readonly FeeAssetUiOption[] = [
+  {
+    id: "celo",
+    ticker: "CELO",
+    label: "CELO",
+    unitLabel: "Gwei",
+    currency: celoCurrency,
+    formattedBalance: "2.5",
+  },
+  {
+    id: "usdt-account-id",
+    ticker: "USDT",
+    label: "USDT",
+    currency: usdtCurrency,
+    formattedBalance: "10",
+  },
+];
+
+// Legacy-shaped options (no currency/formattedBalance) — must render exactly as before.
+const legacyOptions: readonly FeeAssetUiOption[] = [
+  { id: "celo", ticker: "CELO", label: "CELO", unitLabel: "Gwei" },
+  { id: "cusd", ticker: "cUSD", label: "cUSD" },
+];
+
+describe("FeeAssetSelector", () => {
+  it("renders the trigger with the selected option's ticker and icon", () => {
+    render(
+      <FeeAssetSelector
+        options={optionsWithIconsAndBalances}
+        selectedId="celo"
+        onChange={jest.fn()}
+        payFeesInLabel="Pay fees in"
+      />,
+    );
+
+    // "Pay fees in" and the selected ticker "CELO" each appear twice: once in the
+    // trigger row, once inside the (eagerly-mounted) bottom sheet content.
+    expect(screen.getAllByText("Pay fees in").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("CELO").length).toBeGreaterThan(0);
+    expect(screen.getAllByTestId("crypto-icon-CELO").length).toBeGreaterThan(0);
+  });
+
+  it("renders an icon and the formatted balance for each option", () => {
+    render(
+      <FeeAssetSelector
+        options={optionsWithIconsAndBalances}
+        selectedId="celo"
+        onChange={jest.fn()}
+        payFeesInLabel="Pay fees in"
+      />,
+    );
+
+    expect(screen.getByTestId("send-fee-asset-icon-celo")).toBeOnTheScreen();
+    expect(screen.getByTestId("send-fee-asset-balance-celo")).toHaveTextContent("2.5");
+
+    expect(screen.getByTestId("send-fee-asset-icon-usdt-account-id")).toBeOnTheScreen();
+    expect(screen.getByTestId("send-fee-asset-balance-usdt-account-id")).toHaveTextContent("10");
+  });
+
+  it("renders no icon or balance for options that don't set them (backward compatible)", () => {
+    render(
+      <FeeAssetSelector
+        options={legacyOptions}
+        selectedId="celo"
+        onChange={jest.fn()}
+        payFeesInLabel="Pay fees in"
+      />,
+    );
+
+    expect(screen.queryByTestId("send-fee-asset-icon-celo")).not.toBeOnTheScreen();
+    expect(screen.queryByTestId("send-fee-asset-balance-celo")).not.toBeOnTheScreen();
+    expect(screen.queryByTestId("send-fee-asset-icon-cusd")).not.toBeOnTheScreen();
+    expect(screen.queryByTestId("send-fee-asset-balance-cusd")).not.toBeOnTheScreen();
+
+    expect(screen.getByText("cUSD")).toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CustomFees/hooks/useCustomFeesViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CustomFees/hooks/useCustomFeesViewModel.ts
@@ -15,7 +15,7 @@ import {
   getCustomFeeLabelKey,
   getCustomFeeHelperLabelKey,
 } from "@ledgerhq/live-common/flows/send/customFees/utils/customFeeUtils";
-import { counterValueCurrencySelector } from "~/reducers/settings";
+import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/settings";
 
 type UseCustomFeesViewModelParams = Readonly<{
   account: AccountLike;
@@ -31,6 +31,7 @@ export function useCustomFeesViewModel(params: UseCustomFeesViewModelParams): Cu
   const { t } = useTranslation();
   const { locale } = useLocale();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const discreet = useSelector(discreetModeSelector);
   const calculateCountervalue = useCalculateCountervalueCallback({ to: counterValueCurrency });
 
   const labels: CustomFeesViewModelLabels = useMemo(
@@ -56,6 +57,7 @@ export function useCustomFeesViewModel(params: UseCustomFeesViewModelParams): Cu
   return useCustomFeesViewModelCore({
     ...params,
     locale,
+    discreet,
     counterValueCurrency,
     calculateCountervalue,
     labels,

--- a/libs/ledger-live-common/src/bridge/descriptor/types.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/types.ts
@@ -88,6 +88,10 @@ export type FeeAssetOption = Readonly<{
   unitLabel?: string;
   /** Optional conversion between descriptor-native fee values and selected-asset display values. */
   customFeeInputValueTransform?: CustomFeeInputValueTransform;
+  /** Currency for the leading icon; the coin-module already has it resolved (no async lookup needed). */
+  currency?: CryptoOrTokenCurrency;
+  /** Raw held balance in the currency's smallest (atomic) unit; the UI formats it with `currency.units[0]` and the user's locale. */
+  balance?: BigNumber;
 }>;
 
 /**

--- a/libs/ledger-live-common/src/families/celo/descriptor/feeAssets.test.ts
+++ b/libs/ledger-live-common/src/families/celo/descriptor/feeAssets.test.ts
@@ -1,0 +1,126 @@
+import { BigNumber } from "bignumber.js";
+import type { Account, TokenAccount } from "@ledgerhq/types-live";
+import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { celoFeeAssets } from "./feeAssets";
+
+const celoCurrency = {
+  id: "celo",
+  type: "CryptoCurrency",
+  family: "celo",
+  name: "Celo",
+  ticker: "CELO",
+  units: [{ name: "Celo", code: "CELO", magnitude: 18 }],
+} as CryptoCurrency;
+
+const usdtCurrency: TokenCurrency = {
+  id: "celo/erc20/usdt",
+  type: "TokenCurrency",
+  parentCurrencyId: celoCurrency.id,
+  tokenType: "erc20",
+  contractAddress: "0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e",
+  name: "Tether USD",
+  ticker: "USDT",
+  units: [{ name: "Tether USD", code: "USDT", magnitude: 6 }],
+};
+
+function createMainAccount(overrides?: Partial<Account>): Account {
+  return {
+    type: "Account",
+    id: "js:2:celo:abc:",
+    currency: celoCurrency,
+    spendableBalance: new BigNumber("2500000000000000000"), // 2.5 CELO
+    subAccounts: [],
+    ...overrides,
+  } as unknown as Account;
+}
+
+function createUsdtSubAccount(overrides?: Partial<TokenAccount>): TokenAccount {
+  return {
+    type: "TokenAccount",
+    id: "js:2:celo:abc:+celo%2Ferc20%2Fusdt",
+    parentId: "js:2:celo:abc:",
+    token: {
+      ...usdtCurrency,
+      contractAddress: "0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e",
+    },
+    balance: new BigNumber("10000000"), // 10 USDT (6 decimals)
+    spendableBalance: new BigNumber("9000000"), // deliberately lower than balance, to prove options use spendableBalance
+    ...overrides,
+  } as unknown as TokenAccount;
+}
+
+describe("celoFeeAssets.getOptions", () => {
+  it("returns the native CELO option first, carrying currency + balance (no formattedBalance)", () => {
+    const mainAccount = createMainAccount();
+
+    const options = celoFeeAssets.getOptions({ mainAccount, transaction: {} });
+
+    expect(options).toHaveLength(1);
+    expect(options[0]).toMatchObject({
+      id: "celo",
+      ticker: "CELO",
+      currency: celoCurrency,
+    });
+    expect(options[0].balance).toBeInstanceOf(BigNumber);
+    expect(options[0].balance).toEqual(mainAccount.spendableBalance);
+    expect(options[0]).not.toHaveProperty("formattedBalance");
+  });
+
+  it("lists held, allowlisted tokens after the native option, each carrying currency + balance (no formattedBalance)", () => {
+    const usdtSubAccount = createUsdtSubAccount();
+    const mainAccount = createMainAccount({ subAccounts: [usdtSubAccount] });
+
+    const options = celoFeeAssets.getOptions({ mainAccount, transaction: {} });
+
+    expect(options.map(o => o.id)).toEqual(["celo", usdtSubAccount.id]);
+
+    const tokenOption = options[1];
+    expect(tokenOption.currency).toBe(usdtSubAccount.token);
+    expect(tokenOption.balance).toBeInstanceOf(BigNumber);
+    expect(tokenOption.balance).toEqual(usdtSubAccount.spendableBalance);
+    expect(tokenOption).not.toHaveProperty("formattedBalance");
+  });
+
+  it("omits tokens with a zero balance (held-tokens-only)", () => {
+    const zeroBalanceUsdt = createUsdtSubAccount({
+      balance: new BigNumber(0),
+      spendableBalance: new BigNumber(0),
+    });
+    const mainAccount = createMainAccount({ subAccounts: [zeroBalanceUsdt] });
+
+    const options = celoFeeAssets.getOptions({ mainAccount, transaction: {} });
+
+    expect(options.map(o => o.id)).toEqual(["celo"]);
+  });
+
+  it("omits tokens that are not allowlisted fee currencies", () => {
+    const notAllowlisted = createUsdtSubAccount({
+      token: {
+        ...usdtCurrency,
+        id: "celo/erc20/not-allowlisted",
+        contractAddress: "0x0000000000000000000000000000000000dead",
+      } as TokenCurrency,
+    });
+    const mainAccount = createMainAccount({ subAccounts: [notAllowlisted] });
+
+    const options = celoFeeAssets.getOptions({ mainAccount, transaction: {} });
+
+    expect(options.map(o => o.id)).toEqual(["celo"]);
+  });
+
+  it("leaves currency/balance unset on the hydrating transient token option", () => {
+    // subAccounts undefined => sub-accounts are still hydrating.
+    const mainAccount = createMainAccount({ subAccounts: undefined });
+    const transaction = {
+      feeCurrencyAccountId: "js:2:celo:abc:+celo%2Ferc20%2Fusdt",
+      feeCurrencyUnwrapped: "0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e",
+    };
+
+    const options = celoFeeAssets.getOptions({ mainAccount, transaction });
+
+    expect(options).toHaveLength(2);
+    const hydratingOption = options[1];
+    expect(hydratingOption.currency).toBeUndefined();
+    expect(hydratingOption.balance).toBeUndefined();
+  });
+});

--- a/libs/ledger-live-common/src/families/celo/descriptor/feeAssets.ts
+++ b/libs/ledger-live-common/src/families/celo/descriptor/feeAssets.ts
@@ -107,6 +107,8 @@ export const celoFeeAssets: FeeAssetsConfig = {
       ticker: FEE_CURRENCY_OPTIONS[0].name,
       label: FEE_CURRENCY_OPTIONS[0].name,
       unitLabel: CELO_FEE_UNIT_LABEL,
+      currency: mainAccount.currency,
+      balance: mainAccount.spendableBalance,
     };
     if (mainAccount.subAccounts === undefined) {
       const selectedToken = getHydratingSelectedTokenOption(transaction);
@@ -120,6 +122,8 @@ export const celoFeeAssets: FeeAssetsConfig = {
       ticker: token.feeCurrencyName,
       label: token.feeCurrencyName,
       customFeeInputValueTransform: feeAssetInputValueTransform,
+      currency: token.token,
+      balance: token.spendableBalance,
     }));
     return [native, ...tokens];
   },

--- a/libs/ledger-live-common/src/flows/send/customFees/hooks/__tests__/useCustomFeesViewModelCore.test.ts
+++ b/libs/ledger-live-common/src/flows/send/customFees/hooks/__tests__/useCustomFeesViewModelCore.test.ts
@@ -48,6 +48,14 @@ const customFeeConfig = {
   }),
 };
 
+const usdtCurrencyForAssetOption = {
+  id: "celo/erc20/usdt",
+  type: "TokenCurrency",
+  name: "Tether USD",
+  ticker: "USDT",
+  units: [{ name: "Tether USD", code: "USDT", magnitude: 6 }],
+};
+
 jest.mock("../../../../../bridge/descriptor/send/features", () => ({
   resolveFeeUnitLabel: (unitLabel: string | undefined) => unitLabel,
   sendFeatures: {
@@ -61,6 +69,8 @@ jest.mock("../../../../../bridge/descriptor/send/features", () => ({
           ticker: "USDT",
           label: "USDT",
           customFeeInputValueTransform: feeAssetInputValueTransform,
+          currency: usdtCurrencyForAssetOption,
+          balance: new BigNumber("1234500000"), // 1,234.5 USDT (6 decimals)
         },
       ],
       getSelectedOptionId: () => "usdt-account-id",
@@ -187,6 +197,7 @@ describe("useCustomFeesViewModelCore", () => {
         transactionActions,
         onConfirm: jest.fn(),
         locale: "en",
+        discreet: false,
         counterValueCurrency: usdCurrency,
         calculateCountervalue,
         labels,
@@ -230,6 +241,89 @@ describe("useCustomFeesViewModelCore", () => {
 
     expect(nextTransaction.feesStrategy).toBe("custom");
     expect(nextTransaction.fees.toFixed()).toBe("30000000000000000");
+  });
+
+  it("derives each asset option's formattedBalance from balance + currency + locale", async () => {
+    const transaction = createTransaction();
+    const transactionActions = createTransactionActions();
+    const calculateCountervalue = jest.fn(() => new BigNumber(0));
+
+    const { result } = renderHook(() =>
+      useCustomFeesViewModelCore({
+        account: createAccount(),
+        parentAccount: null,
+        transaction,
+        status: createStatus(),
+        currency: celoCurrency,
+        transactionActions,
+        onConfirm: jest.fn(),
+        locale: "en",
+        discreet: false,
+        counterValueCurrency: usdCurrency,
+        calculateCountervalue,
+        labels,
+      }),
+    );
+
+    // Native CELO option in the mock has no `balance`/`currency` -> no formattedBalance.
+    const celoOption = result.current.assetOptions.find(option => option.id === "celo");
+    expect(celoOption?.formattedBalance).toBeUndefined();
+
+    // USDT option carries `balance` (raw BigNumber) + `currency` -> formatted with locale.
+    const usdtOption = result.current.assetOptions.find(option => option.id === "usdt-account-id");
+    expect(usdtOption?.formattedBalance).toBe("1,234.5");
+
+    const { result: resultFr } = renderHook(() =>
+      useCustomFeesViewModelCore({
+        account: createAccount(),
+        parentAccount: null,
+        transaction,
+        status: createStatus(),
+        currency: celoCurrency,
+        transactionActions,
+        onConfirm: jest.fn(),
+        locale: "fr-FR",
+        discreet: false,
+        counterValueCurrency: usdCurrency,
+        calculateCountervalue,
+        labels,
+      }),
+    );
+
+    const usdtOptionFr = resultFr.current.assetOptions.find(
+      option => option.id === "usdt-account-id",
+    );
+    // Different locale -> different grouping/decimal separators, same underlying value.
+    // fr-FR groups with a narrow no-break space (U+202F), not a plain ASCII space.
+    expect(usdtOptionFr?.formattedBalance).not.toBe(usdtOption?.formattedBalance);
+    expect(usdtOptionFr?.formattedBalance).toBe("1 234,5");
+  });
+
+  it("masks asset option balances when discreet mode is on", async () => {
+    const transaction = createTransaction();
+    const transactionActions = createTransactionActions();
+    const calculateCountervalue = jest.fn(() => new BigNumber(0));
+
+    const { result } = renderHook(() =>
+      useCustomFeesViewModelCore({
+        account: createAccount(),
+        parentAccount: null,
+        transaction,
+        status: createStatus(),
+        currency: celoCurrency,
+        transactionActions,
+        onConfirm: jest.fn(),
+        locale: "en",
+        discreet: true,
+        counterValueCurrency: usdCurrency,
+        calculateCountervalue,
+        labels,
+      }),
+    );
+
+    const usdtOption = result.current.assetOptions.find(option => option.id === "usdt-account-id");
+    // discreet mode masks the value regardless of the underlying balance/locale.
+    expect(usdtOption?.formattedBalance).toBe("***");
   });
 
   it("should re-estimate bridge fees when the selected fee asset changes", async () => {

--- a/libs/ledger-live-common/src/flows/send/customFees/hooks/useCustomFeesViewModelCore.ts
+++ b/libs/ledger-live-common/src/flows/send/customFees/hooks/useCustomFeesViewModelCore.ts
@@ -34,6 +34,9 @@ export type CustomFeeInputState = Readonly<{
   helperValue: string | null;
 }>;
 
+/** A `FeeAssetOption` enriched with a locale-formatted balance for display. */
+export type FeeAssetUiOption = Readonly<FeeAssetOption & { formattedBalance?: string }>;
+
 export type CustomFeesViewModel = Readonly<{
   inputs: readonly CustomFeeInputState[];
   fiatLabel: string | null;
@@ -43,7 +46,7 @@ export type CustomFeesViewModel = Readonly<{
   onInputClear: (key: string) => void;
   onConfirm: () => void;
   hasCustomAssets: boolean;
-  assetOptions: readonly FeeAssetOption[];
+  assetOptions: readonly FeeAssetUiOption[];
   selectedAssetId: string;
   onAssetChange: (id: string) => void;
   confirmLabel: string;
@@ -80,6 +83,7 @@ export type UseCustomFeesViewModelCoreParams = Readonly<{
   transactionActions: SendFlowTransactionActions;
   onConfirm: () => void;
   locale: string;
+  discreet: boolean;
   counterValueCurrency: Currency;
   /** Reactive countervalue calculator (e.g. from useCalculateCountervalueCallback). */
   calculateCountervalue: (from: Currency, value: BigNumber) => BigNumber | null | undefined;
@@ -131,6 +135,7 @@ export function useCustomFeesViewModelCore({
   transactionActions,
   onConfirm,
   locale,
+  discreet,
   counterValueCurrency,
   calculateCountervalue,
   labels,
@@ -155,10 +160,22 @@ export function useCustomFeesViewModelCore({
 
   // The coin-module owns the options, the selected value and the resulting patch.
   // This view model only renders the "Pay fees in" select and forwards the choice.
-  const assetOptions = useMemo(
-    () => customAssetsConfig?.getOptions(feeAssetContext) ?? [],
-    [customAssetsConfig, feeAssetContext],
-  );
+  // The raw `balance` is formatted here (locale-aware); the descriptor stays locale-blind.
+  const assetOptions = useMemo<readonly FeeAssetUiOption[]>(() => {
+    const options = customAssetsConfig?.getOptions(feeAssetContext) ?? [];
+    return options.map(option => ({
+      ...option,
+      formattedBalance:
+        option.balance !== undefined && option.currency
+          ? formatCurrencyUnit(option.currency.units[0], option.balance, {
+              showCode: false,
+              disableRounding: true,
+              discreet,
+              locale,
+            })
+          : undefined,
+    }));
+  }, [customAssetsConfig, feeAssetContext, locale, discreet]);
   const hasCustomAssetsFlag = assetOptions.length > 0;
 
   const selectedAssetId = useMemo(


### PR DESCRIPTION
### ✅ Checklist
- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** live-common `feeAssets` (raw `balance`/`currency`; a fixture where `spendableBalance ≠ balance` makes the "uses spendable" assertion load-bearing) + `useCustomFeesViewModelCore` (locale-formatted balance, asserted across two locales) + desktop/mobile `FeeAssetSelector` (icon + balance render; "legacy options" backward-compat).
- [x] **Impact of the changes:** Custom fees → "Pay fees in": each option shows a currency **icon + held balance** (desktop + mobile). QA: verify icons/balances for native CELO + held tokens (USDC/USDT/`*m`), correct in the user's **locale**; no-op for all non-Celo coins; default CELO + held-tokens-only unchanged.

### 📝 Description
Enriches the Celo Custom-fees "Pay fees in" selector: each option now shows a currency icon and the user's held (spendable) balance, on desktop and mobile.

The generic `customAssets` `FeeAssetOption` gains two **optional** fields — `currency` (`CryptoOrTokenCurrency`, for the icon) and `balance` (raw `BigNumber`). The coin-module (`celoFeeAssets`) sets them at zero cost (native `mainAccount.currency`/`spendableBalance`, token `sub.token`/`spendableBalance`). The Custom Fees view model (`useCustomFeesViewModelCore`), which has the user's `locale`, formats the raw balance into a `FeeAssetUiOption.formattedBalance`; the selectors render the icon straight from `option.currency` (no id→currency resolution — none exists synchronously for tokens) and the locale-formatted balance. Fields are optional, so coins that don't set them render exactly as today (Celo is the only `customAssets` user).

Addresses review feedback: balance is now denominated in **spendable** for both native and tokens (consistency), and formatted with the **user's locale** in the UI layer rather than pre-formatted in the descriptor.

Desktop:
<img width="399" height="333" alt="image" src="https://github.com/user-attachments/assets/0f3083a7-d65d-48c6-a866-c139cd1e98d1" />

Mobile:
<img width="419" height="814" alt="Screenshot 2026-07-07 at 21 22 32" src="https://github.com/user-attachments/assets/4d67e48c-bb37-45ac-8846-0a657d678a78" />

### ❓ Context
- **JIRA**: https://ledgerhq.atlassian.net/browse/LIVE-30160
- **ADR**: extends the `customAssets`/`extraFields` contract from #18633 ("Getting rid of Plugins") — cc the #18633 owners for the `FeeAssetOption` (`currency` + raw `balance`) extension.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)