### PR TITLE
[LWDM] fix(mobile): improve dust filter option

### DIFF
--- a/.changeset/calm-dust-wrap.md
+++ b/.changeset/calm-dust-wrap.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix the dust filter option copy and wrapping on mobile transaction history.

--- a/.changeset/calm-dust-wrap.md
+++ b/.changeset/calm-dust-wrap.md
@@ -1,5 +1,6 @@
 ---
+"@ledgerhq/live-common": patch
 "live-mobile": minor
 ---
 
-Fix the dust filter option copy and wrapping on mobile transaction history.
+Fix the dust filter option copy and wrapping on mobile transaction history, and share the dust threshold formatter across apps.

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryViewModel.test.ts
@@ -1,13 +1,6 @@
 import { renderHook, act, waitFor, withFlagOverrides } from "tests/testSetup";
 import { useNavigate, useLocation } from "react-router";
-import { formatDustFilterThreshold, useHistoryViewModel } from "../useHistoryViewModel";
-import { importCountervalues } from "@ledgerhq/live-countervalues/logic";
-import type {
-  CountervaluesSettings,
-  CounterValuesStateRaw,
-} from "@ledgerhq/live-countervalues/types";
-import { getFiatCurrencyByTicker } from "@ledgerhq/live-common/currencies/index";
-import type { CountervaluesState } from "~/renderer/reducers/countervalues";
+import { useHistoryViewModel } from "../useHistoryViewModel";
 import { track } from "~/renderer/analytics/segment";
 
 jest.mock("react-router", () => ({
@@ -38,33 +31,6 @@ jest.mock("../useHistoryVirtualization", () => ({
 const mockNavigate = jest.fn();
 const mockUseNavigate = jest.mocked(useNavigate);
 const mockUseLocation = jest.mocked(useLocation);
-const USD = getFiatCurrencyByTicker("USD");
-const EUR = getFiatCurrencyByTicker("EUR");
-const countervaluesSettings: CountervaluesSettings = {
-  trackingPairs: [{ from: USD, to: EUR, startDate: new Date("2026-01-01T00:00:00.000Z") }],
-  autofillGaps: false,
-  refreshRate: 60000,
-  marketCapBatchingAfterRank: 100,
-};
-
-const buildUsdEurCountervaluesState = (): CountervaluesState => ({
-  countervalues: {
-    state: importCountervalues(
-      {
-        status: {},
-        "EUR USD": { latest: 0.92 },
-      } as CounterValuesStateRaw,
-      countervaluesSettings,
-    ),
-    pending: false,
-    error: null,
-  },
-  polling: {
-    isPolling: true,
-    triggerLoad: false,
-  },
-  userSettings: countervaluesSettings,
-});
 
 describe("useHistoryViewModel navigateBack", () => {
   beforeEach(() => {
@@ -114,28 +80,6 @@ describe("useHistoryViewModel navigateBack", () => {
     });
 
     expect(result.current.dustFilterThreshold).toBe("US$0.01");
-  });
-
-  it("should format the dust filter threshold with the USD reference when the countervalue is not USD", () => {
-    expect(
-      formatDustFilterThreshold({
-        countervaluesState: buildUsdEurCountervaluesState().countervalues.state,
-        counterValueCurrency: EUR,
-        locale: "en-US",
-        thresholdUsd: 0.01,
-      }),
-    ).toBe("US$0.01 (€0.0092)");
-  });
-
-  it("should format the converted dust filter threshold with the current locale", () => {
-    expect(
-      formatDustFilterThreshold({
-        countervaluesState: buildUsdEurCountervaluesState().countervalues.state,
-        counterValueCurrency: EUR,
-        locale: "fr-FR",
-        thresholdUsd: 0.01,
-      }),
-    ).toBe("US$0,01 (€0,0092)");
   });
 
   it("should request USD countervalue tracking when the dust filter option is shown for a non-USD countervalue", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryViewModel.ts
@@ -1,13 +1,8 @@
 import { useCallback, useEffect, useMemo } from "react";
-import BigNumber from "bignumber.js";
-import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import {
-  convertThresholdFromUsdToCountervalueMinorUnit,
-  floorThresholdToCurrencyMinorUnit,
+  formatSmallValueOperationsThreshold,
   SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
 } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
-import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
-import type { Currency, Unit } from "@ledgerhq/types-cryptoassets";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { useHideSmallValueTokenOperations } from "~/renderer/actions/settings";
 import { addExtraTrackingPairs } from "~/renderer/reducers/countervaluesExtraTracking";
@@ -29,66 +24,6 @@ import { track } from "~/renderer/analytics/segment";
 import { parseHistoryBackPath } from "../utils/historyLocationState";
 import { usePopNavigationBack } from "LLD/utils/usePopNavigationBack";
 import { HISTORY_DUST_FILTER_THRESHOLD_USD } from "../constants";
-
-export function formatDustFilterThreshold({
-  countervaluesState,
-  counterValueCurrency,
-  locale,
-  thresholdUsd,
-}: {
-  countervaluesState?: CounterValuesState;
-  counterValueCurrency: Currency;
-  locale: string | undefined | null;
-  thresholdUsd: number;
-}) {
-  const formatThreshold = (currency: Currency, unit: Unit = currency.units[0]) => {
-    const thresholdMinorUnit =
-      floorThresholdToCurrencyMinorUnit(thresholdUsd, currency) ?? new BigNumber(0);
-
-    return formatCurrencyUnit(unit, thresholdMinorUnit, {
-      showCode: true,
-      locale: locale ?? undefined,
-    });
-  };
-  const formatCounterValueThreshold = (currency: Currency, thresholdMinorUnit: BigNumber) => {
-    const unit = currency.units[0];
-    const amount = thresholdMinorUnit.div(new BigNumber(10).pow(unit.magnitude));
-    const fractionDigits = Math.min(Math.max(unit.magnitude + 2, 4), 8);
-    const formattedAmount = new Intl.NumberFormat(locale ?? undefined, {
-      maximumFractionDigits: fractionDigits,
-      minimumFractionDigits: 0,
-      useGrouping: false,
-    }).format(amount.toNumber());
-
-    return unit.prefixCode
-      ? `${unit.code}${formattedAmount}`
-      : `${formattedAmount}\u00A0${unit.code}`;
-  };
-
-  const referenceThreshold = formatThreshold(SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY, {
-    ...SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY.units[0],
-    code: "US$",
-  });
-
-  if (counterValueCurrency.ticker === SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY.ticker) {
-    return referenceThreshold;
-  }
-
-  if (!countervaluesState) return referenceThreshold;
-
-  const counterValueThresholdMinorUnit = convertThresholdFromUsdToCountervalueMinorUnit({
-    counterValueCurrency,
-    countervaluesState,
-    thresholdUsd,
-  });
-
-  if (!counterValueThresholdMinorUnit) return referenceThreshold;
-
-  return `${referenceThreshold} (${formatCounterValueThreshold(
-    counterValueCurrency,
-    counterValueThresholdMinorUnit,
-  )})`;
-}
 
 export type HistoryViewModel = {
   showBackButton: boolean;
@@ -165,7 +100,7 @@ export function useHistoryViewModel(): HistoryViewModel {
   const dustFilterThreshold = useMemo(() => {
     if (!counterValueCurrency) return "";
 
-    return formatDustFilterThreshold({
+    return formatSmallValueOperationsThreshold({
       countervaluesState,
       counterValueCurrency,
       locale,

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3042,7 +3042,7 @@
       "more": "Transaction history options",
       "hideDustTransactions": "Hide dust transactions",
       "showDustTransactions": "Show dust transactions",
-      "dustTransactionsDescription": "Transactions below {{threshold}} in your main currency will be hidden."
+      "dustTransactionsDescription": "Transactions below {{threshold}} will be hidden."
     }
   },
   "operationDetails": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3042,7 +3042,8 @@
       "more": "Transaction history options",
       "hideDustTransactions": "Hide dust transactions",
       "showDustTransactions": "Show dust transactions",
-      "dustTransactionsDescription": "Transactions below {{threshold}} will be hidden."
+      "dustTransactionsHiddenDescription": "Transactions below {{threshold}} will be hidden.",
+      "dustTransactionsDisplayedDescription": "Transactions below {{threshold}} will be displayed."
     }
   },
   "operationDetails": {

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
@@ -3,7 +3,9 @@ import { renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
 import { usdcToken, maticEth } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import { calculate } from "@ledgerhq/live-countervalues/logic";
 import type { Account } from "@ledgerhq/types-live";
+import { track } from "~/analytics";
 import type { State } from "~/reducers/types";
 import { useOperationsListViewModel } from "../useOperationsListViewModel";
 
@@ -15,10 +17,19 @@ jest.mock("~/screens/Analytics/Operations/useOperationsV1", () => ({
   useOperationsV1: (...args: unknown[]) => mockUseOperationsV1(...args),
 }));
 
+jest.mock("@ledgerhq/live-countervalues/logic", () => ({
+  ...jest.requireActual("@ledgerhq/live-countervalues/logic"),
+  calculate: jest.fn(),
+}));
+
+const mockedCalculate = jest.mocked(calculate);
+const mockedTrack = jest.mocked(track);
+
 describe("useOperationsListViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseOperationsV1.mockReturnValue({ sections: [], completed: true });
+    mockedCalculate.mockReturnValue(undefined);
   });
 
   it("isEmpty is true when completed with no sections", () => {
@@ -115,7 +126,7 @@ describe("useOperationsListViewModel", () => {
       expect(result.current.isOptionsSheetOpen).toBe(false);
       expect(result.current.dustFilterOption?.title).toBe("Hide dust transactions");
       expect(result.current.dustFilterOption?.description).toBe(
-        "Transactions below $0.01 will be hidden.",
+        "Transactions below US$0.01 will be hidden.",
       );
 
       act(() => {
@@ -131,9 +142,53 @@ describe("useOperationsListViewModel", () => {
       expect(store.getState().settings.hideSmallValueTokenOperations).toBe(true);
       expect(result.current.isOptionsSheetOpen).toBe(false);
       expect(result.current.dustFilterOption?.title).toBe("Show dust transactions");
+      expect(result.current.dustFilterOption?.description).toBe(
+        "Transactions below US$0.01 will be displayed.",
+      );
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+        button: "dust_filter",
+        enabled: true,
+      });
     });
 
-    it("adds the selected countervalue threshold in parentheses when it is not USD", () => {
+    it("tracks the dust filter toggle as disabled when showing dust transactions again", () => {
+      const { result, store } = renderHook(() => useOperationsListViewModel(), {
+        overrideInitialState: withFlagOverrides(
+          {
+            lwmDustFiltering: {
+              enabled: true,
+            },
+          },
+          (state: State) => ({
+            ...state,
+            settings: {
+              ...state.settings,
+              hideSmallValueTokenOperations: true,
+            },
+          }),
+        ),
+      });
+
+      expect(result.current.dustFilterOption?.title).toBe("Show dust transactions");
+      expect(result.current.dustFilterOption?.description).toBe(
+        "Transactions below US$0.01 will be displayed.",
+      );
+
+      act(() => {
+        result.current.onToggleHideSmallValueTokenOperations();
+      });
+
+      expect(store.getState().settings.hideSmallValueTokenOperations).toBe(false);
+      expect(result.current.dustFilterOption?.title).toBe("Hide dust transactions");
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+        button: "dust_filter",
+        enabled: false,
+      });
+    });
+
+    it("adds the converted USD threshold in parentheses when the countervalue is not USD", () => {
+      mockedCalculate.mockReturnValue(0.92);
+
       const { result } = renderHook(() => useOperationsListViewModel(), {
         overrideInitialState: withFlagOverrides(
           {
@@ -152,8 +207,14 @@ describe("useOperationsListViewModel", () => {
       });
 
       expect(result.current.dustFilterOption?.description).toBe(
-        "Transactions below $0.01 (€0.01) will be hidden.",
+        "Transactions below US$0.01 (€0.0092) will be hidden.",
       );
+      expect(mockedCalculate).toHaveBeenCalledWith(expect.any(Object), {
+        from: expect.objectContaining({ ticker: "USD" }),
+        to: expect.objectContaining({ ticker: "EUR" }),
+        value: 1,
+        disableRounding: true,
+      });
     });
 
     it("hides and disables the dust filter option when only the desktop flag param is enabled", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
@@ -114,6 +114,9 @@ describe("useOperationsListViewModel", () => {
       expect(result.current.hideSmallValueTokenOperations).toBe(false);
       expect(result.current.isOptionsSheetOpen).toBe(false);
       expect(result.current.dustFilterOption?.title).toBe("Hide dust transactions");
+      expect(result.current.dustFilterOption?.description).toBe(
+        "Transactions below $0.01 will be hidden.",
+      );
 
       act(() => {
         result.current.openOptionsSheet();
@@ -128,6 +131,29 @@ describe("useOperationsListViewModel", () => {
       expect(store.getState().settings.hideSmallValueTokenOperations).toBe(true);
       expect(result.current.isOptionsSheetOpen).toBe(false);
       expect(result.current.dustFilterOption?.title).toBe("Show dust transactions");
+    });
+
+    it("adds the selected countervalue threshold in parentheses when it is not USD", () => {
+      const { result } = renderHook(() => useOperationsListViewModel(), {
+        overrideInitialState: withFlagOverrides(
+          {
+            lwmDustFiltering: {
+              enabled: true,
+            },
+          },
+          (state: State) => ({
+            ...state,
+            settings: {
+              ...state.settings,
+              counterValue: "EUR",
+            },
+          }),
+        ),
+      });
+
+      expect(result.current.dustFilterOption?.description).toBe(
+        "Transactions below $0.01 (€0.01) will be hidden.",
+      );
     });
 
     it("hides and disables the dust filter option when only the desktop flag param is enabled", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsHistoryOptionsSheet.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsHistoryOptionsSheet.tsx
@@ -45,7 +45,7 @@ export function OperationsHistoryOptionsSheet({
             <Spot appearance="icon" icon={Icon} />
             <ListItemContent>
               <ListItemTitle>{title}</ListItemTitle>
-              <ListItemDescription>{description}</ListItemDescription>
+              <ListItemDescription numberOfLines={2}>{description}</ListItemDescription>
             </ListItemContent>
           </ListItemLeading>
         </ListItem>

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
@@ -1,18 +1,19 @@
 import { useState, useCallback, useEffect, useMemo, type ComponentType } from "react";
-import BigNumber from "bignumber.js";
 import { useDustFilteringFeature } from "@features/platform-feature-flags";
 import { flattenAccounts, getAccountCurrency } from "@ledgerhq/live-common/account/index";
-import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import {
-  floorThresholdToCurrencyMinorUnit,
+  formatSmallValueOperationsThreshold,
   SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
 } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
 import type { IconProps } from "@ledgerhq/lumen-ui-rnative";
 import { Eye, EyeCross } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { addExtraSessionTrackingPair } from "~/actions/general";
 import { setHideSmallValueTokenOperations } from "~/actions/settings";
+import { track } from "~/analytics";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { useLocale, useTranslation } from "~/context/Locale";
 import { flattenAccountsSelector, shallowAccountsSelector } from "~/reducers/accounts";
+import { countervaluesStateSelector } from "~/reducers/countervalues";
 import { lastSeenOperationDateSelector, markOperationsAsSeen } from "~/reducers/history";
 import {
   counterValueCurrencySelector,
@@ -48,8 +49,27 @@ export function useOperationsListViewModel(accountIds?: string[]) {
   const counterValueCurrency = useSelector(state =>
     isDustFilterFeatureEnabled ? counterValueCurrencySelector(state) : undefined,
   );
+  const isReferenceCounterValue =
+    counterValueCurrency?.ticker === SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY.ticker;
+  const countervaluesState = useSelector(state =>
+    isDustFilterFeatureEnabled && counterValueCurrency && !isReferenceCounterValue
+      ? countervaluesStateSelector(state)
+      : undefined,
+  );
   const { locale } = useLocale();
   const { t } = useTranslation();
+
+  useEffect(() => {
+    if (!isDustFilterFeatureEnabled || !counterValueCurrency || isReferenceCounterValue) {
+      return;
+    }
+
+    addExtraSessionTrackingPair({
+      from: SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
+      to: counterValueCurrency,
+      startDate: new Date(),
+    });
+  }, [counterValueCurrency, isDustFilterFeatureEnabled, isReferenceCounterValue]);
 
   const allowedIds = useMemo(
     () => (accountIds && accountIds.length > 0 ? new Set(accountIds) : null),
@@ -111,41 +131,13 @@ export function useOperationsListViewModel(accountIds?: string[]) {
   const dustFilterThreshold = useMemo(() => {
     if (!counterValueCurrency) return undefined;
 
-    const referenceThresholdMinorUnit =
-      floorThresholdToCurrencyMinorUnit(
-        HISTORY_DUST_FILTER_THRESHOLD_USD,
-        SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
-      ) ?? new BigNumber(0);
-
-    const referenceThreshold = formatCurrencyUnit(
-      SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY.units[0],
-      referenceThresholdMinorUnit,
-      {
-        showCode: true,
-        locale,
-      },
-    );
-
-    if (
-      counterValueCurrency.ticker === SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY.ticker
-    ) {
-      return referenceThreshold;
-    }
-
-    const countervalueThresholdMinorUnit =
-      floorThresholdToCurrencyMinorUnit(HISTORY_DUST_FILTER_THRESHOLD_USD, counterValueCurrency) ??
-      new BigNumber(0);
-    const countervalueThreshold = formatCurrencyUnit(
-      counterValueCurrency.units[0],
-      countervalueThresholdMinorUnit,
-      {
-        showCode: true,
-        locale,
-      },
-    );
-
-    return `${referenceThreshold} (${countervalueThreshold})`;
-  }, [counterValueCurrency, locale]);
+    return formatSmallValueOperationsThreshold({
+      countervaluesState,
+      counterValueCurrency,
+      locale,
+      thresholdUsd: HISTORY_DUST_FILTER_THRESHOLD_USD,
+    });
+  }, [countervaluesState, counterValueCurrency, locale]);
 
   const dustFilterOption: OperationsHistoryDustFilterOption | undefined = useMemo(() => {
     if (!isDustFilterFeatureEnabled || !dustFilterThreshold) return undefined;
@@ -154,11 +146,14 @@ export function useOperationsListViewModel(accountIds?: string[]) {
     const title = userHideSmallValueTokenOperations
       ? t("operationsList.options.showDustTransactions")
       : t("operationsList.options.hideDustTransactions");
+    const descriptionKey = userHideSmallValueTokenOperations
+      ? "operationsList.options.dustTransactionsDisplayedDescription"
+      : "operationsList.options.dustTransactionsHiddenDescription";
 
     return {
       Icon,
       title,
-      description: t("operationsList.options.dustTransactionsDescription", {
+      description: t(descriptionKey, {
         threshold: dustFilterThreshold,
       }),
     };
@@ -173,7 +168,13 @@ export function useOperationsListViewModel(accountIds?: string[]) {
   const onToggleHideSmallValueTokenOperations = useCallback(() => {
     if (!isDustFilterFeatureEnabled) return;
 
-    dispatch(setHideSmallValueTokenOperations(!userHideSmallValueTokenOperations));
+    const isEnabled = !userHideSmallValueTokenOperations;
+
+    track("button_clicked", {
+      button: "dust_filter",
+      enabled: isEnabled,
+    });
+    dispatch(setHideSmallValueTokenOperations(isEnabled));
     closeOptionsSheet();
   }, [dispatch, isDustFilterFeatureEnabled, userHideSmallValueTokenOperations, closeOptionsSheet]);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
@@ -3,7 +3,10 @@ import BigNumber from "bignumber.js";
 import { useDustFilteringFeature } from "@features/platform-feature-flags";
 import { flattenAccounts, getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
-import { floorThresholdToCurrencyMinorUnit } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
+import {
+  floorThresholdToCurrencyMinorUnit,
+  SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
+} from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
 import type { IconProps } from "@ledgerhq/lumen-ui-rnative";
 import { Eye, EyeCross } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { setHideSmallValueTokenOperations } from "~/actions/settings";
@@ -108,15 +111,42 @@ export function useOperationsListViewModel(accountIds?: string[]) {
   const dustFilterThreshold = useMemo(() => {
     if (!counterValueCurrency) return undefined;
 
-    const thresholdMinorUnit =
+    const referenceThresholdMinorUnit =
+      floorThresholdToCurrencyMinorUnit(
+        HISTORY_DUST_FILTER_THRESHOLD_USD,
+        SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
+      ) ?? new BigNumber(0);
+
+    const referenceThreshold = formatCurrencyUnit(
+      SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY.units[0],
+      referenceThresholdMinorUnit,
+      {
+        showCode: true,
+        locale,
+      },
+    );
+
+    if (
+      counterValueCurrency.ticker === SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY.ticker
+    ) {
+      return referenceThreshold;
+    }
+
+    const countervalueThresholdMinorUnit =
       floorThresholdToCurrencyMinorUnit(HISTORY_DUST_FILTER_THRESHOLD_USD, counterValueCurrency) ??
       new BigNumber(0);
+    const countervalueThreshold = formatCurrencyUnit(
+      counterValueCurrency.units[0],
+      countervalueThresholdMinorUnit,
+      {
+        showCode: true,
+        locale,
+      },
+    );
 
-    return formatCurrencyUnit(counterValueCurrency.units[0], thresholdMinorUnit, {
-      showCode: true,
-      locale,
-    });
+    return `${referenceThreshold} (${countervalueThreshold})`;
   }, [counterValueCurrency, locale]);
+
   const dustFilterOption: OperationsHistoryDustFilterOption | undefined = useMemo(() => {
     if (!isDustFilterFeatureEnabled || !dustFilterThreshold) return undefined;
 

--- a/libs/ledger-live-common/src/hideSmallValueTokenOperations/__tests__/smallValueOperationsThreshold.test.ts
+++ b/libs/ledger-live-common/src/hideSmallValueTokenOperations/__tests__/smallValueOperationsThreshold.test.ts
@@ -10,6 +10,7 @@ import {
   convertThresholdMinorUnitToMajor,
   floorThresholdToCurrencyMinorUnit,
   formatThresholdMinorUnitForInput,
+  formatSmallValueOperationsThreshold,
   isSmallValueTokenOperation,
   SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
 } from "../smallValueOperationsThreshold";
@@ -83,6 +84,45 @@ describe("smallValueOperationsThreshold", () => {
 
     it("should format the input value without forcing trailing zeros", () => {
       expect(formatThresholdMinorUnitForInput(new BigNumber(50), USD)).toBe("0.5");
+    });
+  });
+
+  describe("formatSmallValueOperationsThreshold", () => {
+    it("should format the dust filter threshold in USD without a reference conversion", () => {
+      expect(
+        formatSmallValueOperationsThreshold({
+          counterValueCurrency: USD,
+          locale: "en-US",
+          thresholdUsd: 0.01,
+        }),
+      ).toBe("US$0.01");
+      expect(mockCalculate).not.toHaveBeenCalled();
+    });
+
+    it("should include the converted threshold when the countervalue is not USD", () => {
+      mockCalculate.mockReturnValue(0.92);
+
+      expect(
+        formatSmallValueOperationsThreshold({
+          countervaluesState: mockCountervaluesState,
+          counterValueCurrency: EUR,
+          locale: "en-US",
+          thresholdUsd: 0.01,
+        }),
+      ).toBe("US$0.01 (€0.0092)");
+    });
+
+    it("should format the converted threshold with the current locale", () => {
+      mockCalculate.mockReturnValue(0.92);
+
+      expect(
+        formatSmallValueOperationsThreshold({
+          countervaluesState: mockCountervaluesState,
+          counterValueCurrency: EUR,
+          locale: "fr-FR",
+          thresholdUsd: 0.01,
+        }),
+      ).toBe("US$0,01 (€0,0092)");
     });
   });
 

--- a/libs/ledger-live-common/src/hideSmallValueTokenOperations/smallValueOperationsThreshold.ts
+++ b/libs/ledger-live-common/src/hideSmallValueTokenOperations/smallValueOperationsThreshold.ts
@@ -1,8 +1,8 @@
 import BigNumber from "bignumber.js";
 import { calculate } from "@ledgerhq/live-countervalues/logic";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
-import { getFiatCurrencyByTicker } from "../currencies";
-import type { Currency } from "@ledgerhq/types-cryptoassets";
+import { formatCurrencyUnit, getFiatCurrencyByTicker } from "../currencies";
+import type { Currency, Unit } from "@ledgerhq/types-cryptoassets";
 import type { AccountLike, Operation } from "@ledgerhq/types-live";
 
 export const MAX_SMALL_VALUE_OPERATIONS_THRESHOLD_USD = 0.5;
@@ -38,6 +38,86 @@ export const formatThresholdMinorUnitForInput = (
   thresholdMinorUnit: BigNumber,
   currency: Currency,
 ) => convertThresholdMinorUnitToMajor(thresholdMinorUnit, currency).toFixed();
+
+const formatCounterValueThreshold = ({
+  currency,
+  locale,
+  thresholdMinorUnit,
+}: {
+  currency: Currency;
+  locale: string | null | undefined;
+  thresholdMinorUnit: BigNumber;
+}) => {
+  const unit = currency.units[0];
+  const amount = convertThresholdMinorUnitToMajor(thresholdMinorUnit, currency);
+  const fractionDigits = Math.min(Math.max(unit.magnitude + 2, 4), 8);
+  const formattedAmount = new Intl.NumberFormat(locale ?? undefined, {
+    maximumFractionDigits: fractionDigits,
+    minimumFractionDigits: 0,
+    useGrouping: false,
+  }).format(amount.toNumber());
+
+  return unit.prefixCode
+    ? `${unit.code}${formattedAmount}`
+    : `${formattedAmount}\u00A0${unit.code}`;
+};
+
+const formatReferenceThreshold = ({
+  locale,
+  thresholdUsd,
+}: {
+  locale: string | null | undefined;
+  thresholdUsd: number;
+}) => {
+  const unit: Unit = {
+    ...SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY.units[0],
+    code: "US$",
+  };
+  const thresholdMinorUnit =
+    floorThresholdToCurrencyMinorUnit(
+      thresholdUsd,
+      SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
+    ) ?? new BigNumber(0);
+
+  return formatCurrencyUnit(unit, thresholdMinorUnit, {
+    showCode: true,
+    locale: locale ?? undefined,
+  });
+};
+
+export function formatSmallValueOperationsThreshold({
+  countervaluesState,
+  counterValueCurrency,
+  locale,
+  thresholdUsd,
+}: {
+  countervaluesState?: CounterValuesState;
+  counterValueCurrency: Currency;
+  locale: string | null | undefined;
+  thresholdUsd: number;
+}) {
+  const referenceThreshold = formatReferenceThreshold({ locale, thresholdUsd });
+
+  if (counterValueCurrency.ticker === SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY.ticker) {
+    return referenceThreshold;
+  }
+
+  if (!countervaluesState) return referenceThreshold;
+
+  const counterValueThresholdMinorUnit = convertThresholdFromUsdToCountervalueMinorUnit({
+    counterValueCurrency,
+    countervaluesState,
+    thresholdUsd,
+  });
+
+  if (!counterValueThresholdMinorUnit) return referenceThreshold;
+
+  return `${referenceThreshold} (${formatCounterValueThreshold({
+    currency: counterValueCurrency,
+    locale,
+    thresholdMinorUnit: counterValueThresholdMinorUnit,
+  })})`;
+}
 
 export function convertThresholdFromUsdToCountervalueMinorUnit({
   counterValueCurrency,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added and ran focused Jest coverage for USD and non-USD dust filter descriptions.
- [x] **Impact of the changes:**
      - Mobile transaction history options sheet
      - Dust filter threshold copy in USD and non-USD countervalues
      - English locale for the dust filter description

### 📝 Description

The mobile transaction history dust filter option could truncate its subtitle in the bottom sheet, making the copy hard to read.

This PR lets the subtitle wrap across two lines and formats the dust threshold as the USD reference amount, adding the selected countervalue amount in parentheses when it is not USD. Only the English locale copy is updated.

<img width="371" height="203" alt="image" src="https://github.com/user-attachments/assets/a3e67137-4396-4bdd-81b0-14b35ed5ac41" />
<img width="366" height="222" alt="image" src="https://github.com/user-attachments/assets/43b5409c-51e9-45f0-a30b-49011ecdbdf0" />

### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)