### PR TITLE
test: check webview display during mobile e2e buy/Sell tests

### DIFF
--- a/e2e/mobile/helpers/elementHelpers.ts
+++ b/e2e/mobile/helpers/elementHelpers.ts
@@ -560,6 +560,48 @@ export const WebElementHelpers = {
     return currentUrl;
   },
 
+  /**
+   * Asserts the current webview actually rendered something and is not a blank
+   * Polls the webview <body> until it has a non-zero height and either enough
+   * visible text or at least one meaningful content element (iframe, input,
+   * button, form, image, link). Throws if it stays blank until `timeout`.
+   */
+  async waitForWebviewContentToRender(
+    timeout = DEFAULT_TIMEOUT,
+  ): Promise<{ height: number; textLength: number; contentElements: number }> {
+    let snapshot = { height: 0, textLength: 0, contentElements: 0 };
+    await retryUntilTimeout(
+      async () => {
+        const raw = await WebElementHelpers.getWebElementByTag("body").runScript(() => {
+          const body = document.body;
+          if (!body) return JSON.stringify({ height: 0, textLength: 0, contentElements: 0 });
+          const height = Math.round(body.getBoundingClientRect().height);
+          const textLength = (body.innerText || body.textContent || "").trim().length;
+          const contentElements = document.querySelectorAll(
+            "iframe, input, button, form, img, a[href], [role='button']",
+          ).length;
+          return JSON.stringify({ height, textLength, contentElements });
+        });
+        const json =
+          raw != null && typeof raw === "object" && "result" in raw ? raw["result"] : raw;
+        try {
+          snapshot = JSON.parse(String(json));
+        } catch {
+          throw new Error(`Unexpected webview content payload (not JSON): ${String(json)}`);
+        }
+        const rendered =
+          snapshot.height > 0 && (snapshot.textLength >= 20 || snapshot.contentElements >= 1);
+        if (!rendered) {
+          throw new Error(`Webview appears blank (no content rendered): ${String(json)}`);
+        }
+        return snapshot;
+      },
+      timeout,
+      DEFAULT_WEB_ELEMENT_INTERVAL,
+    );
+    return snapshot;
+  },
+
   async waitForWebElementToMatchRegex(
     webElementId: string,
     regexPattern: RegExp,

--- a/e2e/mobile/jest.environment.ts
+++ b/e2e/mobile/jest.environment.ts
@@ -215,6 +215,7 @@ export default class TestEnvironment extends DetoxEnvironment {
       tapWebElementByTestId: WebElementHelpers.tapWebElementByTestId,
       typeTextByWebTestId: WebElementHelpers.typeTextByWebTestId,
       waitForCurrentWebviewUrlToContain: WebElementHelpers.waitForCurrentWebviewUrlToContain,
+      waitForWebviewContentToRender: WebElementHelpers.waitForWebviewContentToRender,
       waitForWebElementToBeEnabled: WebElementHelpers.waitForWebElementToBeEnabled,
       waitForWebElementToMatchRegex: WebElementHelpers.waitForWebElementToMatchRegex,
       waitWebElement: WebElementHelpers.waitWebElement,

--- a/e2e/mobile/page/trade/buySell.page.ts
+++ b/e2e/mobile/page/trade/buySell.page.ts
@@ -3,6 +3,7 @@ import { AccountType, getParentAccountName } from "@ledgerhq/live-e2e-shared/enu
 import { BuySell, Fiat } from "@ledgerhq/live-e2e-shared/models/BuySell";
 import { BuySellProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
 import { openDeeplink, normalizeText } from "../../helpers/commonHelpers";
+import { checkForErrorElement, ERROR_MODAL_SELECTORS } from "../../helpers/errorHelpers";
 import { sanitizeError } from "@ledgerhq/live-e2e-shared/index";
 
 export default class BuySellPage {
@@ -198,7 +199,26 @@ export default class BuySellPage {
       const currentUrl = await waitForCurrentWebviewUrlToContain(normalizedProvider);
       jestExpect(currentUrl.toLowerCase()).toContain(normalizedProvider);
     } catch (error) {
-      throw new Error(`Provider page verification failed: ${sanitizeError(error)}`);
+      throw Object.assign(new Error(`Provider page verification failed: ${sanitizeError(error)}`), {
+        cause: error,
+      });
+    }
+  }
+
+  @Step("Verify provider page is displayed and not a blank/error screen")
+  async verifyProviderPageIsNotBlank(provider: string) {
+    try {
+      await waitForWebviewContentToRender();
+    } catch (error) {
+      throw Object.assign(
+        new Error(
+          `Provider "${provider}" redirected to the correct URL but rendered a blank screen: ${sanitizeError(error)}`,
+        ),
+        { cause: error },
+      );
+    }
+    for (const errorSelector of ERROR_MODAL_SELECTORS) {
+      await checkForErrorElement(errorSelector, 1000);
     }
   }
 
@@ -216,6 +236,7 @@ export default class BuySellPage {
     const selectedProvider = await this.selectRandomProvider();
     await this.tapBuySellWithCta(selectedProvider, buySell.operation);
     await this.verifyProviderPageLoadedWithCorrectUrl(selectedProvider);
+    await this.verifyProviderPageIsNotBlank(selectedProvider);
   }
 
   @Step("Handle sell flow")
@@ -229,5 +250,6 @@ export default class BuySellPage {
     await this.selectProvider(provider.name);
     await this.tapBuySellWithCta(provider.uiName, buySell.operation);
     await this.verifyProviderPageLoadedWithCorrectUrl(provider.uiName);
+    await this.verifyProviderPageIsNotBlank(provider.uiName);
   }
 }

--- a/e2e/mobile/types/global.d.ts
+++ b/e2e/mobile/types/global.d.ts
@@ -104,6 +104,7 @@ declare global {
   var tapWebElementByTestId: typeof WebElementHelpers.tapWebElementByTestId;
   var typeTextByWebTestId: typeof WebElementHelpers.typeTextByWebTestId;
   var waitForCurrentWebviewUrlToContain: typeof WebElementHelpers.waitForCurrentWebviewUrlToContain;
+  var waitForWebviewContentToRender: typeof WebElementHelpers.waitForWebviewContentToRender;
   var waitForWebElementToBeEnabled: typeof WebElementHelpers.waitForWebElementToBeEnabled;
   var waitForWebElementToMatchRegex: typeof WebElementHelpers.waitForWebElementToMatchRegex;
   var waitWebElement: typeof WebElementHelpers.waitWebElement;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - E2E Mobile Buy tests

### 📝 Description

This PR strengthens mobile E2E trade (buy/sell) flows by adding a webview-render check to detect cases where the provider URL is correct but the embedded webview remains blank or fails to render content.

Added a new Detox webview helper (waitForWebviewContentToRender) to assert that webview content is actually rendered.


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- E2E [Run](https://github.com/LedgerHQ/ledger-live/actions/runs/28775690999)
- Buy/sell [run](https://github.com/LedgerHQ/ledger-live/actions/runs/28776314849)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
