### PR TITLE
fix(e2e-swap): tolerate cents rounding in checkBestOffer ranking

### DIFF
--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -13,6 +13,9 @@ const APPROVAL_PROCESSING_TIMEOUT = 300_000;
 // before embedding in a RegExp so they match literally instead of altering the pattern.
 const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
+// Net value of a quote as shown on screen: amount received minus network fees (both in fiat).
+const quoteNetValue = (quote: { rate: number; fees: number }) => quote.rate - quote.fees;
+
 export default class SwapLiveAppPage {
   fromSelector = "from-account-coin-selector";
   fromAmount = "from-account";
@@ -283,18 +286,24 @@ export default class SwapLiveAppPage {
 
   @Step('Check "Best Offer" corresponds to the best quote')
   async checkBestOffer(providerList: string[]) {
+    if (providerList.length === 0) {
+      throw new Error("checkBestOffer: expected a non-empty provider list");
+    }
+    // net = cent-rounded amount - cent-rounded fees, so each net carries ±0.01; two providers'
+    // nets can therefore differ by up to 0.02 from rounding alone.
+    const NET_ROUNDING_TOLERANCE = 0.02;
+
     await retryUntilTimeout(async () => {
       const quotes = [];
       for (const provider of providerList) {
         quotes.push(await this.getProviderQuote(provider));
       }
-      const bestOffer = quotes.reduce<{ provider: string; rate: number; fees: number } | null>(
-        (max, current) =>
-          current && (!max || current.rate - current.fees > max.rate - max.fees) ? current : max,
-        null,
-      );
 
-      jestExpect(bestOffer?.provider).toBe(providerList[0]);
+      const firstQuote = quotes[0];
+      const bestNetValue = Math.max(...quotes.map(quoteNetValue));
+      jestExpect(bestNetValue - quoteNetValue(firstQuote)).toBeLessThanOrEqual(
+        NET_ROUNDING_TOLERANCE,
+      );
     });
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

checkBestOffer re-derived the best quote with a strict arg-max over rate - fees, but cards render fiat rounded to cents while the app sorts by full-precision net value (amountToFiat - networkFeesFiat). Near-tied top quotes flipped the arg-max, so the retry never settled and timed out at 60s.

Assert instead that the app's first quote is within the cent-rounding tolerance (0.02) of the best displayed net value, which still catches a genuine mis-ranking while tolerating rounding ties.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  [QAA-1377](https://ledgerhq.atlassian.net/browse/QAA-1377)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->
[@Mobile E2E • Manual • iOS & Android • fix/e2e-swap-best-offer-rounding • cunhabruno](https://github.com/LedgerHQ/ledger-live/actions/runs/28782225256)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1377]: https://ledgerhq.atlassian.net/browse/QAA-1377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ