### PR TITLE
[LWM] fix: double error showed when edit transaction is failing on evm

### DIFF
--- a/.changeset/new-cycles-eat.md
+++ b/.changeset/new-cycles-eat.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix: double error when edit transaction is failing

--- a/.changeset/new-cycles-eat.md
+++ b/.changeset/new-cycles-eat.md
@@ -2,4 +2,4 @@
 "live-mobile": patch
 ---
 
-Fix: double error when edit transaction is failing
+Fix: double error when edit transaction is failing, and show the correct "Invalid transaction" error (instead of "Transaction already validated") when editing an EVM or Bitcoin transaction fails at broadcast, to match the desktop behavior

--- a/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.test.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.test.tsx
@@ -84,7 +84,7 @@ describe("Bitcoin MethodSelection", () => {
 
     render(
       <MethodSelection
-        navigation={{ navigate } as never}
+        navigation={{ navigate, isFocused: () => true } as never}
         route={{ params: { operation, account, parentAccount } } as never}
       />,
     );

--- a/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.tsx
@@ -136,11 +136,17 @@ function MethodSelectionComponent({ navigation, route }: Props) {
     };
   }, [mainAccount, operation.hash]);
 
-  if (transactionHasBeenValidated) {
+  useEffect(() => {
+    if (!transactionHasBeenValidated) return;
+    // Only surface the "already validated" screen while the user is still on the
+    // method selection screen (mirrors desktop where the banner only gates the
+    // form). Once the user has moved forward to sign/broadcast, the broadcast
+    // handler owns the error, so we must not navigate over it.
+    if (!navigation.isFocused()) return;
     navigation.navigate(ScreenName.TransactionAlreadyValidatedError, {
       error: new TransactionHasBeenValidatedError(),
     });
-  }
+  }, [transactionHasBeenValidated, navigation]);
 
   useEffect(() => {
     if (!selectedMethod || !transaction) {

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.test.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.test.tsx
@@ -88,7 +88,7 @@ describe("EVM MethodSelection", () => {
 
     render(
       <MethodSelection
-        navigation={{ navigate } as never}
+        navigation={{ navigate, isFocused: () => true } as never}
         route={{ params: { operation, account, parentAccount } } as never}
       />,
     );

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
@@ -136,11 +136,12 @@ function MethodSelectionComponent({ navigation, route }: Props) {
     };
   }, [bridge, mainAccount.currency, operation.hash]);
 
-  if (transactionHasBeenValidated) {
+  useEffect(() => {
+    if (!transactionHasBeenValidated) return;
     navigation.navigate(ScreenName.TransactionAlreadyValidatedError, {
       error: new TransactionHasBeenValidatedError(),
     });
-  }
+  }, [transactionHasBeenValidated, navigation]);
 
   useEffect(() => {
     log("[edit transaction]", "Transaction to edit", transaction);

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
@@ -138,6 +138,11 @@ function MethodSelectionComponent({ navigation, route }: Props) {
 
   useEffect(() => {
     if (!transactionHasBeenValidated) return;
+    // Only surface the "already validated" screen while the user is still on the
+    // method selection screen (mirrors desktop where the banner only gates the
+    // form). Once the user has moved forward to sign/broadcast, the broadcast
+    // handler owns the error, so we must not navigate over it.
+    if (!navigation.isFocused()) return;
     navigation.navigate(ScreenName.TransactionAlreadyValidatedError, {
       error: new TransactionHasBeenValidatedError(),
     });

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -532,6 +532,10 @@
     "InvalidExplorerResponse": {
       "title": "Invalid response from {{currencyName}} explorer"
     },
+    "InvalidTransactionError": {
+      "title": "Invalid transaction",
+      "description": "The transaction doesn't match the blockchain state anymore. Please start the flow again."
+    },
     "LanguageInstallRefusedOnDevice": {
       "title": "Language installation refused on device",
       "description": "Please try again. If the problem persists, please save your logs using the button below and provide them to Ledger Support."

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -13,7 +13,7 @@ import type {
   BroadcastConfig,
 } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError, UserRefusedOnDevice } from "@ledgerhq/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import {
   addPendingOperation,
@@ -372,6 +372,16 @@ export function useSignedTxHandler({
           !(error instanceof UserRefusedOnDevice || error instanceof TransactionRefusedOnDevice)
         ) {
           logger.critical(error as Error);
+        }
+
+        const isEditTransaction = Boolean(
+          (route.params as { editType?: string } | undefined)?.editType,
+        );
+        if (isEditTransaction && shouldRestartFlow(error as Error)) {
+          return (navigation as NativeStackNavigationProp<{ [key: string]: object }>).navigate(
+            ScreenName.TransactionAlreadyValidatedError,
+            { error: new TransactionHasBeenValidatedError() },
+          );
         }
 
         if (

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -13,7 +13,7 @@ import type {
   BroadcastConfig,
 } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
-import { TransactionHasBeenValidatedError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import {
   addPendingOperation,
@@ -372,16 +372,6 @@ export function useSignedTxHandler({
           !(error instanceof UserRefusedOnDevice || error instanceof TransactionRefusedOnDevice)
         ) {
           logger.critical(error as Error);
-        }
-
-        const isEditTransaction = Boolean(
-          (route.params as { editType?: string } | undefined)?.editType,
-        );
-        if (isEditTransaction && shouldRestartFlow(error as Error)) {
-          return (navigation as NativeStackNavigationProp<{ [key: string]: object }>).navigate(
-            ScreenName.TransactionAlreadyValidatedError,
-            { error: new TransactionHasBeenValidatedError() },
-          );
         }
 
         if (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Only show one "Invalid transaction" message one em broadcast is failing.

https://github.com/user-attachments/assets/f8ef0ce7-1c58-45ab-8ea1-6d3a3ca5c72d


### ❓ Context

- **JIRA or GitHub link**: [LIVE-33610](https://ledgerhq.atlassian.net/browse/LIVE-33610)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-33610]: https://ledgerhq.atlassian.net/browse/LIVE-33610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ