### PR TITLE
[LWDM] fix(coin-celo): celo-app enable contract data message

### DIFF
--- a/.changeset/celo-blind-signing-wording.md
+++ b/.changeset/celo-blind-signing-wording.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Fix the misleading "Please enable Contract data" wording for the Celo blind-signing error (`CeloAppPleaseEnableContractData`). The message now asks to enable Blind signing, matching the current Celo app setting, and the previously missing translation key was added on mobile.

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7415,7 +7415,7 @@
       "title": "Enable Blind signing or Contract data in Ethereum app"
     },
     "CeloAppPleaseEnableContractData": {
-      "title": "Please enable Contract data in the Celo app Settings"
+      "title": "Enable Blind signing in the Celo app"
     },
     "InvalidXRPTag": {
       "title": "Invalid XRP Destination tag"

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -496,6 +496,9 @@
     "EthAppPleaseEnableContractData": {
       "title": "Enable Blind signing or Contract data in Ethereum app"
     },
+    "CeloAppPleaseEnableContractData": {
+      "title": "Enable Blind signing in the Celo app"
+    },
     "HardResetFail": {
       "title": "Sorry, could not reset",
       "description": "Please try again. If the problem persists, please save your logs using the button below and provide them to Ledger Support."


### PR DESCRIPTION
  <!--
  Thank you for your contribution! 👍
  Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
  -->

  ### ✅ Checklist

  <!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

  - [x] `npx changeset` was attached.
  - [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) --> Copy-only change to `en` locale files (no logic changed), so no automated test is added.
  - [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
    - Only the user-facing error message for `CeloAppPleaseEnableContractData` changes (Desktop + Mobile). No behavioural or signing-flow change.
    - QA focus: the Celo staking flows (Earn → Register / Lock / Vote) on a device with **Blind signing disabled**. The error is only reachable on older Celo app versions (see Context) — verify against one of those that the message now reads "Enable Blind signing in the Celo app".

  ### 📝 Description

  The Celo blind-signing rejection error (`CeloAppPleaseEnableContractData`) displayed misleading text. When a Celo contract transaction (e.g. the **Register account** / `createAccount` step of the staking flow) is signed with **Blind signing disabled**, the device rejects with
  status `0x6a80`, which is remapped to `CeloAppPleaseEnableContractData`. The message asked the user to *"enable Contract data"*, but the modern Celo app no longer has a "Contract data" setting — it is now called **Blind signing** — so the instruction did not match anything on the
  device.

  This PR corrects the wording so the message explicitly tells the user to enable **Blind signing**, as requested in the ticket. Additionally, the Mobile app had **no translation key** for `CeloAppPleaseEnableContractData` at all (only the Ethereum one existed), so it fell back to a
  generic message; the missing key is now added.

  **Changes**
  - **Desktop** — `apps/ledger-live-desktop/static/i18n/en/app.json`: `CeloAppPleaseEnableContractData.title` → `"Enable Blind signing in the Celo app"`.
  - **Mobile** — `apps/ledger-live-mobile/src/locales/en/common.json`: added the missing `CeloAppPleaseEnableContractData` key with the same wording.

  Only the `en` files are edited; other locales are handled by the translation pipeline.

  > **Note on reproducibility:** this is not reproducible on the current Celo app versions. Recent Celo apps handle the `createAccount`/staking transactions and reach the normal "Accept and send" review screen (they no longer reject with `0x6a80`), even with Blind signing disabled.
  The misleading error only surfaces on older Celo app versions that could not process these transactions. The string was nonetheless incorrect and is fixed for the versions/paths where it still triggers.

  | Before | After |
  | ------------- | ------------- |
  | Please enable Contract data in the Celo app Settings | Enable Blind signing in the Celo app |

  ### ❓ Context

  - **JIRA or GitHub link**: [LIVE-30139](https://ledgerhq.atlassian.net/browse/LIVE-30139)
  - **ADR link (if any)**: N/A


  ---

  ### 🧐 Checklist for the PR Reviewers

  <!-- Please do not edit this if you are the PR author -->

  - **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
  - **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
  - **There are no undocumented trade-offs**, technical debt, or maintainability issues.
  - **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
  - **Any new dependencies** have been justified and documented.
  - **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30139]: https://ledgerhq.atlassian.net/browse/LIVE-30139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ