### PR TITLE
[LWM] fix(send): use sat/vByte instead of sat/bytes for btc fee rate label

### DIFF
--- a/.changeset/silver-clocks-sleep.md
+++ b/.changeset/silver-clocks-sleep.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix BTC fee rate unit label from "sat/bytes" to "sat/vByte"

--- a/apps/ledger-live-mobile/src/families/bitcoin/ScreenEditCustomFees.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/ScreenEditCustomFees.tsx
@@ -144,7 +144,7 @@ function BitcoinEditCustomFees({ navigation, route }: Props) {
                 },
               ]}
             >
-              {t("common.satPerByte")}
+              {t("common.satPerVByte")}
             </LText>
           </View>
           {isBelowRelayFee ? (

--- a/apps/ledger-live-mobile/src/families/bitcoin/SendRowsFee.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/SendRowsFee.tsx
@@ -94,7 +94,7 @@ export default function BitcoinSendRowsFee({
       account={account}
       parentAccount={parentAccount}
       transaction={transaction}
-      forceUnitLabel={<Trans i18nKey="common.satPerByte" />}
+      forceUnitLabel={<Trans i18nKey="common.satPerVByte" />}
       status={status}
     />
   );

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -49,6 +49,7 @@
     "transactionDate": "Transaction date",
     "outdated": "Outdated",
     "satPerByte": "sat/bytes",
+    "satPerVByte": "sat/vByte",
     "sompiPerByte": "sompi/bytes",
     "notAvailable": "Not available",
     "import": "Import",


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _String-only change — no unit test needed._
- [x] **Impact of the changes:**
  - BTC send flow on mobile: verify the fee rate unit label shows \"sat/vByte\" on the fee selection screen (send flow + custom fees screen)

### 📝 Description

The fee rate unit label in the mobile BTC send flow displayed the legacy string \"sat/bytes\" instead of the correct \"sat/vByte\". The fee computation itself was already correct (uses virtual size with the SegWit discount), only the display label was stale.

**Fix:** Added a new `satPerVByte` i18n key in the EN locale with the correct value \"sat/vByte\", and updated the two components that render the fee rate unit label to use this new key. Smartling will handle translations for other languages. The old `satPerByte` key is left untouched for now.

<img width="300" height="655" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-06 at 15 12 34" src="https://github.com/user-attachments/assets/9b341540-37a9-42b2-a3d8-9d125adce368" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-33673](https://ledgerhq.atlassian.net/browse/LIVE-33673)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33673]: https://ledgerhq.atlassian.net/browse/LIVE-33673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ