### PR TITLE
test(e2e/desktop): always block broadcast for ZEC send

### DIFF
--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -243,6 +243,7 @@ const transactionE2E = [
   {
     transaction: new Transaction(Account.ZEC_1, Account.ZEC_2, "0.001"),
     xrayTicket: "B2CQA-4299",
+    disableBroadcast: true,
   },
   {
     transaction: new Transaction(Account.HEDERA_1, Account.HEDERA_2, "0.00001", undefined, "noTag"),
@@ -268,6 +269,7 @@ test.describe("Send flows", () => {
         userdata: "skip-onboarding-with-last-seen-device",
         speculosApp: transaction.transaction.accountToDebit.currency.speculosApp,
         cliCommands: [liveDataWithRecipientAddressCommand(transaction.transaction)],
+        env: transaction.disableBroadcast ? { DISABLE_TRANSACTION_BROADCAST: "1" } : {},
         featureFlags: {
           ...FF_NEW_SEND_FLOW_DISABLED,
         },


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. — _Not required: test-only change to the private `ledger-live-desktop-e2e-tests` package (consistent with repo convention for e2e spec-only changes)._
- [x] **Covered by automatic tests.** _The change is itself an e2e test adjustment (ZEC send spec)._
- [x] **Impact of the changes:**
      - ZEC send e2e test (`B2CQA-4299`) now runs with `DISABLE_TRANSACTION_BROADCAST=1`, so it no longer submits a real transaction to the network.
      - No other currencies in the `transactionE2E` suite are affected — the new `disableBroadcast` flag is opt-in per transaction.

### 📝 Description

The ZEC send e2e test always broadcasts its transaction to the network, which is undesirable for this flow.

This PR blocks the broadcast for the ZEC send case by reusing the existing pattern from `delegate.spec.ts` (the Solana "delegate without broadcasting" flow): a per-transaction `disableBroadcast` flag drives `env: { DISABLE_TRANSACTION_BROADCAST: "1" }` on the test's `test.use`. The post-send verification steps still pass because the transaction shows as an optimistic/pending operation — the same behaviour already relied on by the ENS send test in this file.

\`\`\`ts
{
  transaction: new Transaction(Account.ZEC_1, Account.ZEC_2, "0.001"),
  xrayTicket: "B2CQA-4299",
  disableBroadcast: true,
},
\`\`\`

\`\`\`ts
env: transaction.disableBroadcast ? { DISABLE_TRANSACTION_BROADCAST: "1" } : {},
\`\`\`

### ❓ Context

- **JIRA or GitHub link**: _N/A_

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)