### PR TITLE
[LWDM] feat(LIVE-30502): aleo mobile send flow skeleton

### DIFF
--- a/.changeset/unlucky-kids-clap.md
+++ b/.changeset/unlucky-kids-clap.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-aleo": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+feat: aleo mobile send flow customization

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.ts
@@ -8,7 +8,6 @@ import {
 import {
   MAX_PRIVATE_RECORDS_PER_TRANSACTION,
   MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION,
-  TRANSACTION_TYPE,
   PRIVATE_BALANCE_PLACEHOLDER,
 } from "@ledgerhq/live-common/families/aleo/constants";
 import {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.ts
@@ -14,6 +14,7 @@ import {
 import {
   derivePrivateTransactionMode,
   derivePublicTransactionMode,
+  isPrivateDestination,
   isPrivateTransaction,
   isSelfTransferTransaction,
 } from "@ledgerhq/live-common/families/aleo/utils";
@@ -49,15 +50,6 @@ export function isAleoAccount(acc: AccountLike): acc is AleoAccount | AleoTokenA
 
 export function isAleoTransaction(tx: Transaction): tx is AleoTransaction {
   return tx.family === "aleo";
-}
-
-function isPrivateDestination(transaction: AleoTransaction): boolean {
-  return (
-    transaction.mode === TRANSACTION_TYPE.TRANSFER_PRIVATE ||
-    transaction.mode === TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE ||
-    transaction.mode === TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE ||
-    transaction.mode === TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE
-  );
 }
 
 export function getAleoAddressBadgeI18nKey(

--- a/apps/ledger-live-mobile/scripts/sync-families-dispatch.mjs
+++ b/apps/ledger-live-mobile/scripts/sync-families-dispatch.mjs
@@ -46,6 +46,7 @@ const targets = [
   "ShouldUseReceiveOptions",
   "PendingTransferProposals",
   "customAddAccountFlow",
+  "customSendFlow",
 ];
 
 async function genTarget(target) {

--- a/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.test.ts
+++ b/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.test.ts
@@ -1,0 +1,146 @@
+import { renderHook } from "@tests/test-renderer";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { State } from "~/reducers/types";
+import { ScreenName } from "~/const";
+import useAssetActions from "./useAssetActions";
+import { getCustomSendFlow } from "~/screens/SendFunds/utils/customSendFlow";
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useRoute: () => ({ name: "Asset", key: "asset-key", params: {} }),
+}));
+
+jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog", () => ({
+  useRampCatalog: () => ({ isCurrencyAvailable: jest.fn(() => false) }),
+}));
+
+jest.mock("@features/platform-feature-flags", () => ({
+  useFeature: jest.fn(() => ({ enabled: true })),
+}));
+
+jest.mock("@ledgerhq/live-common/exchange/swap/hooks/index", () => ({
+  useFetchCurrencyAll: () => ({ data: [] }),
+}));
+
+jest.mock("LLM/hooks/useStake/useStake", () => ({
+  useStake: () => ({ getCanStakeCurrency: jest.fn(() => false) }),
+}));
+
+jest.mock("LLM/features/Stake", () => ({
+  useOpenStakeDrawer: () => ({ handleOpenStakeDrawer: jest.fn() }),
+}));
+
+jest.mock("LLM/features/Receive", () => ({
+  useOpenReceiveDrawer: () => ({ handleOpenReceiveDrawer: jest.fn() }),
+}));
+
+jest.mock("LLM/features/Swap", () => ({
+  useOpenSwap: () => ({ handleOpenSwap: jest.fn() }),
+}));
+
+jest.mock("LLM/features/ModularDrawer", () => ({
+  useModularDrawerController: () => ({ openDrawer: jest.fn() }),
+}));
+
+jest.mock("~/generated/accountActions", () => ({
+  __esModule: true,
+  default: {
+    aleo: {
+      getAdditionalAssetActions: jest.fn(() => [{ id: "custom-action", label: "Custom" }]),
+    },
+  },
+}));
+
+jest.mock("~/screens/SendFunds/utils/customSendFlow", () => ({
+  getCustomSendFlow: jest.fn(() => null),
+}));
+
+const mockGetCustomSendFlow = jest.mocked(getCustomSendFlow);
+const currencyAleo = getCryptoCurrencyById("aleo");
+const ALEO_ACCOUNT_1 = genAccount("asset-actions-aleo-1", {
+  currency: currencyAleo,
+  operationsSize: 3,
+});
+const ALEO_ACCOUNT_2 = genAccount("asset-actions-aleo-2", {
+  currency: currencyAleo,
+  operationsSize: 3,
+});
+
+const withSingleAccount = (state: State): State => ({
+  ...state,
+  settings: { ...state.settings, readOnlyModeEnabled: false },
+  accounts: { active: [ALEO_ACCOUNT_1] },
+});
+
+const withTwoAccounts = (state: State): State => ({
+  ...state,
+  settings: { ...state.settings, readOnlyModeEnabled: false },
+  accounts: { active: [ALEO_ACCOUNT_1, ALEO_ACCOUNT_2] },
+});
+
+describe("useAssetActions - custom send flow", () => {
+  beforeEach(() => {
+    mockGetCustomSendFlow.mockReturnValue(null);
+  });
+
+  it("uses buildSendEntrypoint when the family has a custom send flow", () => {
+    mockGetCustomSendFlow.mockReturnValue({
+      screens: [],
+      buildSendEntrypoint: jest.fn(() => ({
+        screen: ScreenName.AleoSendBalanceSelection,
+        params: {},
+      })),
+    });
+
+    const { result } = renderHook(
+      () => useAssetActions({ currency: currencyAleo, accounts: [ALEO_ACCOUNT_1] }),
+      { overrideInitialState: withSingleAccount },
+    );
+
+    const sendAction = result.current.mainActions.find(a => a.id === "send");
+
+    expect(sendAction?.navigationParams?.[1]).toMatchObject({
+      screen: ScreenName.AleoSendBalanceSelection,
+    });
+  });
+
+  it("uses SendSelectRecipient with accountId when 1 account and no custom flow", () => {
+    const { result } = renderHook(
+      () => useAssetActions({ currency: currencyAleo, accounts: [ALEO_ACCOUNT_1] }),
+      { overrideInitialState: withSingleAccount },
+    );
+
+    const sendAction = result.current.mainActions.find(a => a.id === "send");
+
+    expect(sendAction?.navigationParams?.[1]).toMatchObject({
+      screen: ScreenName.SendSelectRecipient,
+      params: expect.objectContaining({ accountId: ALEO_ACCOUNT_1.id }),
+    });
+  });
+
+  it("uses SendCoin with selectedCurrency when there is no single default account", () => {
+    const { result } = renderHook(
+      () => useAssetActions({ currency: currencyAleo, accounts: [ALEO_ACCOUNT_1, ALEO_ACCOUNT_2] }),
+      { overrideInitialState: withTwoAccounts },
+    );
+
+    const sendAction = result.current.mainActions.find(a => a.id === "send");
+
+    expect(sendAction?.navigationParams?.[1]).toMatchObject({
+      screen: ScreenName.SendCoin,
+      params: expect.objectContaining({ selectedCurrency: currencyAleo }),
+    });
+  });
+
+  it("includes additional family actions from getAdditionalAssetActions", () => {
+    const { result } = renderHook(
+      () => useAssetActions({ currency: currencyAleo, accounts: [ALEO_ACCOUNT_1] }),
+      { overrideInitialState: withSingleAccount },
+    );
+
+    expect(result.current.mainActions).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "custom-action" })]),
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.test.ts
+++ b/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.test.ts
@@ -11,36 +11,8 @@ jest.mock("@react-navigation/native", () => ({
   useRoute: () => ({ name: "Asset", key: "asset-key", params: {} }),
 }));
 
-jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog", () => ({
-  useRampCatalog: () => ({ isCurrencyAvailable: jest.fn(() => false) }),
-}));
-
-jest.mock("@features/platform-feature-flags", () => ({
-  useFeature: jest.fn(() => ({ enabled: true })),
-}));
-
 jest.mock("@ledgerhq/live-common/exchange/swap/hooks/index", () => ({
   useFetchCurrencyAll: () => ({ data: [] }),
-}));
-
-jest.mock("LLM/hooks/useStake/useStake", () => ({
-  useStake: () => ({ getCanStakeCurrency: jest.fn(() => false) }),
-}));
-
-jest.mock("LLM/features/Stake", () => ({
-  useOpenStakeDrawer: () => ({ handleOpenStakeDrawer: jest.fn() }),
-}));
-
-jest.mock("LLM/features/Receive", () => ({
-  useOpenReceiveDrawer: () => ({ handleOpenReceiveDrawer: jest.fn() }),
-}));
-
-jest.mock("LLM/features/Swap", () => ({
-  useOpenSwap: () => ({ handleOpenSwap: jest.fn() }),
-}));
-
-jest.mock("LLM/features/ModularDrawer", () => ({
-  useModularDrawerController: () => ({ openDrawer: jest.fn() }),
 }));
 
 jest.mock("~/generated/accountActions", () => ({

--- a/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.tsx
+++ b/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { useRoute } from "@react-navigation/native";
-import { AccountLikeArray } from "@ledgerhq/types-live";
+import type { AccountLikeArray } from "@ledgerhq/types-live";
 import { useSelector } from "~/context/hooks";
 import { useTranslation } from "~/context/Locale";
 import { IconsLegacy } from "@ledgerhq/native-ui";
@@ -9,12 +9,15 @@ import {
   getParentAccount,
   isTokenAccount,
 } from "@ledgerhq/live-common/account/index";
+import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/index";
 import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { useFeature } from "@features/platform-feature-flags";
 import { NavigatorName, ScreenName } from "~/const";
 import { readOnlyModeEnabledSelector } from "~/reducers/settings";
 import { ActionButtonEvent } from "..";
+import { getCustomSendFlow } from "~/screens/SendFunds/utils/customSendFlow";
+import perFamilyAccountActions from "~/generated/accountActions";
 import ZeroBalanceDisabledModalContent from "../modals/ZeroBalanceDisabledModalContent";
 import { sharedSwapTracking } from "~/screens/Swap/utils";
 import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
@@ -82,6 +85,7 @@ export default function useAssetActions({ currency, accounts }: useAssetActionsP
 
   const { getCanStakeCurrency } = useStake();
   const accountCurrency = !defaultAccount ? null : getAccountCurrency(defaultAccount);
+  const family = currency ? getFamilyByCurrencyId(currency.id) : undefined;
   const assetId = !currency ? accountCurrency?.id : currency.id;
   const canStakeCurrency = !assetId ? false : getCanStakeCurrency(assetId);
 
@@ -96,6 +100,12 @@ export default function useAssetActions({ currency, accounts }: useAssetActionsP
 
   const { openDrawer } = useModularDrawerController();
 
+  const familySendFlow = family ? getCustomSendFlow(family) : null;
+
+  const familyAccountActions = family
+    ? perFamilyAccountActions[family as keyof typeof perFamilyAccountActions]
+    : null;
+
   const handleOpenAddAccountDrawer = useCallback(() => {
     openDrawer({
       currencies: currency ? [currency.id] : [],
@@ -107,6 +117,36 @@ export default function useAssetActions({ currency, accounts }: useAssetActionsP
 
   const actions = useMemo<ActionButtonEvent[]>(() => {
     const isPtxServiceCtaScreensDisabled = !(ptxServiceCtaScreens?.enabled ?? true);
+
+    const additionalAssetActions =
+      familyAccountActions && "getAdditionalAssetActions" in familyAccountActions
+        ? familyAccountActions.getAdditionalAssetActions({
+            currency,
+            defaultAccount,
+            parentAccount,
+          })
+        : [];
+
+    const getScreenDescriptor = () => {
+      if (defaultAccount && familySendFlow?.buildSendEntrypoint) {
+        return familySendFlow.buildSendEntrypoint({ account: defaultAccount, parentAccount });
+      }
+
+      if (defaultAccount) {
+        return {
+          screen: ScreenName.SendSelectRecipient,
+          params: {
+            accountId: defaultAccount.id,
+            parentId: defaultAccount.type === "TokenAccount" ? defaultAccount.parentId : undefined,
+          },
+        };
+      }
+
+      return {
+        screen: ScreenName.SendCoin,
+        params: { selectedCurrency: currency },
+      };
+    };
 
     return [
       ...(canBeBought
@@ -207,29 +247,16 @@ export default function useAssetActions({ currency, accounts }: useAssetActionsP
               id: "send",
               label: t("transfer.send.title"),
               Icon: iconSend,
-              navigationParams: [
-                NavigatorName.SendFunds,
-                defaultAccount
-                  ? {
-                      screen: ScreenName.SendSelectRecipient,
-                      params: {
-                        accountId: defaultAccount.id,
-                        parentId:
-                          defaultAccount.type === "TokenAccount"
-                            ? defaultAccount.parentId
-                            : undefined,
-                      },
-                    }
-                  : {
-                      screen: ScreenName.SendCoin,
-                      params: { selectedCurrency: currency },
-                    },
-              ] as const,
+              navigationParams: [NavigatorName.SendFunds, getScreenDescriptor()] as const,
               disabled: areAccountsBalanceEmpty,
               modalOnDisabledClick: {
                 component: ZeroBalanceDisabledModalContent,
               },
             },
+            ...additionalAssetActions.map(additionalAction => ({
+              disabled: areAccountsBalanceEmpty,
+              ...additionalAction,
+            })),
           ]
         : [
             ...(!readOnlyModeEnabled
@@ -255,10 +282,13 @@ export default function useAssetActions({ currency, accounts }: useAssetActionsP
     readOnlyModeEnabled,
     availableOnSwap,
     defaultAccount,
+    parentAccount,
     canStakeCurrency,
     assetId,
     stakeLabel,
     accountCurrency?.ticker,
+    familySendFlow,
+    familyAccountActions,
     handleOpenStakeDrawer,
     handleOpenReceiveDrawer,
     handleOpenSwap,

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SendFundsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SendFundsNavigator.tsx
@@ -17,6 +17,7 @@ import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigatio
 import StepHeader from "../StepHeader";
 import type { SendFundsNavigatorStackParamList } from "./types/SendFundsNavigator";
 import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import perFamilySendFlow from "~/generated/customSendFlow";
 
 const totalSteps = "5";
 
@@ -165,6 +166,17 @@ export default function SendFundsNavigator() {
             headerShown: false,
           }}
         />
+        {Object.values(perFamilySendFlow).flatMap(family =>
+          (family?.screens ?? []).map(({ name, component, options, initialParams }) => (
+            <Stack.Screen
+              key={name}
+              name={name}
+              component={component}
+              options={options}
+              initialParams={initialParams}
+            />
+          )),
+        )}
       </Stack.Navigator>
     </DomainServiceProvider>
   );

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SendFundsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SendFundsNavigator.ts
@@ -61,6 +61,7 @@ export type SendFundsNavigatorStackParamList = {
         category?: string;
         notEmptyAccounts?: boolean;
         minBalance?: number;
+        extra?: Record<string, unknown>;
       }
     | undefined;
   [ScreenName.SendSelectRecipient]: {
@@ -390,5 +391,15 @@ export type SendFundsNavigatorStackParamList = {
       | ScreenName.SignTransactionSelectDevice
       | ScreenName.SendSelectDevice
       | ScreenName.SwapForm;
+  };
+  [ScreenName.AleoSendBalanceSelection]: {
+    account: AccountLike;
+    parentAccount?: Account;
+    isSelfTransfer: boolean;
+  };
+  [ScreenName.AleoMandatoryPrivateSync]: {
+    account: AccountLike;
+    parentAccount?: Account;
+    transaction: Transaction;
   };
 };

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -425,6 +425,8 @@ export enum ScreenName {
   AleoAddAccount = "AleoAddAccount",
   AleoViewKeyWarning = "AleoViewKeyWarning",
   AleoViewKeyApprove = "AleoViewKeyApprove",
+  AleoSendBalanceSelection = "AleoSendBalanceSelection",
+  AleoMandatoryPrivateSync = "AleoMandatoryPrivateSync",
 
   OnboardingWelcome = "OnboardingWelcome",
   OnboardingPostWelcomeSelection = "OnboardingPostWelcomeSelection",

--- a/apps/ledger-live-mobile/src/families/aleo/Send/BalanceSelectionScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/BalanceSelectionScreen.tsx
@@ -1,0 +1,99 @@
+import React, { useCallback } from "react";
+import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as AleoTransaction } from "@ledgerhq/live-common/families/aleo/types";
+import { useTranslation } from "~/context/Locale";
+import Button from "~/components/Button";
+import StepHeader from "~/components/StepHeader";
+import { ScreenName } from "~/const";
+import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import type { SendFundsNavigatorStackParamList } from "~/components/RootNavigator/types/SendFundsNavigator";
+
+type Props = StackNavigatorProps<
+  SendFundsNavigatorStackParamList,
+  ScreenName.AleoSendBalanceSelection
+>;
+
+export function BalanceSelectionHeaderTitle() {
+  const { t } = useTranslation();
+
+  return <StepHeader title={t("aleo.send.balanceSelection.title")} />;
+}
+
+export function BalanceSelectionScreen({ navigation, route }: Props) {
+  const { account, parentAccount, isSelfTransfer } = route.params;
+  const { t } = useTranslation();
+  const bridge = useAccountBridge<AleoTransaction>(account, parentAccount);
+
+  const onConfirm = useCallback(
+    (variant: "public" | "private") => {
+      const transaction = bridge.createTransaction(account);
+
+      if (variant === "private") {
+        navigation.navigate(ScreenName.AleoMandatoryPrivateSync, {
+          account,
+          parentAccount,
+          transaction,
+        });
+        return;
+      }
+
+      const targetScreen = isSelfTransfer
+        ? ScreenName.SendAmountCoin
+        : ScreenName.SendSelectRecipient;
+
+      navigation.navigate(targetScreen, {
+        accountId: account.id,
+        parentId: parentAccount?.id,
+        transaction,
+      });
+    },
+    [account, bridge, navigation, parentAccount, isSelfTransfer],
+  );
+
+  return (
+    <Box lx={wrapperStyle}>
+      <Box lx={contentStyle}>
+        <Text lx={{ color: "base" }}>{t("aleo.send.balanceSelection.mockTitle")}</Text>
+        <Text lx={{ color: "base" }}>
+          {t("aleo.send.balanceSelection.selfTransfer", {
+            value: isSelfTransfer ? t("common.yes") : t("common.no"),
+          })}
+        </Text>
+      </Box>
+      <Box lx={footerStyle}>
+        <Button
+          event="AleoBalanceSelectionConfirm"
+          type="primary"
+          title="Public"
+          containerStyle={{ flexGrow: 1 }}
+          onPress={() => onConfirm("public")}
+        />
+        <Button
+          event="AleoBalanceSelectionConfirm"
+          type="primary"
+          title="Private"
+          containerStyle={{ flexGrow: 1 }}
+          onPress={() => onConfirm("private")}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+const wrapperStyle: LumenViewStyle = {
+  flex: 1,
+  paddingHorizontal: "s16",
+};
+
+const contentStyle: LumenViewStyle = {
+  flex: 1,
+};
+
+const footerStyle: LumenViewStyle = {
+  justifyContent: "center",
+  flexDirection: "row",
+  gap: "s8",
+  paddingBottom: "s24",
+};

--- a/apps/ledger-live-mobile/src/families/aleo/Send/BalanceSelectionScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/BalanceSelectionScreen.tsx
@@ -1,10 +1,9 @@
 import React, { useCallback } from "react";
-import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import { Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction as AleoTransaction } from "@ledgerhq/live-common/families/aleo/types";
 import { useTranslation } from "~/context/Locale";
-import Button from "~/components/Button";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
@@ -63,20 +62,12 @@ export function BalanceSelectionScreen({ navigation, route }: Props) {
         </Text>
       </Box>
       <Box lx={footerStyle}>
-        <Button
-          event="AleoBalanceSelectionConfirm"
-          type="primary"
-          title="Public"
-          containerStyle={{ flexGrow: 1 }}
-          onPress={() => onConfirm("public")}
-        />
-        <Button
-          event="AleoBalanceSelectionConfirm"
-          type="primary"
-          title="Private"
-          containerStyle={{ flexGrow: 1 }}
-          onPress={() => onConfirm("private")}
-        />
+        <Button appearance="base" style={{ flexGrow: 1 }} onPress={() => onConfirm("public")}>
+          {t("aleo.send.balanceSelection.mockButtonPublic")}
+        </Button>
+        <Button appearance="base" style={{ flexGrow: 1 }} onPress={() => onConfirm("private")}>
+          {t("aleo.send.balanceSelection.mockButtonPrivate")}
+        </Button>
       </Box>
     </Box>
   );

--- a/apps/ledger-live-mobile/src/families/aleo/Send/MandatoryPrivateSyncScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/MandatoryPrivateSyncScreen.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect } from "react";
+import { Box, Text, Spinner } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "~/context/Locale";
+import { ScreenName } from "~/const";
+import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import type { SendFundsNavigatorStackParamList } from "~/components/RootNavigator/types/SendFundsNavigator";
+
+type Props = StackNavigatorProps<
+  SendFundsNavigatorStackParamList,
+  ScreenName.AleoMandatoryPrivateSync
+>;
+
+export function MandatoryPrivateSyncScreen({ navigation, route }: Props) {
+  const { t } = useTranslation();
+  const { account, parentAccount, transaction } = route.params;
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      navigation.replace(ScreenName.SendAmountCoin, {
+        accountId: account.id,
+        parentId: parentAccount?.id,
+        transaction,
+      });
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, [account, navigation, parentAccount, transaction]);
+
+  return (
+    <Box
+      lx={{ flex: 1, alignItems: "center", justifyContent: "center", gap: "s24", padding: "s24" }}
+    >
+      <Spinner size={48} />
+      <Text typography="heading4SemiBold" lx={{ color: "base", textAlign: "center" }}>
+        {t("aleo.send.privateSync.mockTitle")}
+      </Text>
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/BalanceSelectionScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/BalanceSelectionScreen.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { View, Text } from "react-native";
+import { screen, render } from "@tests/test-renderer";
+import { BalanceSelectionScreen } from "../BalanceSelectionScreen";
+import { ScreenName } from "~/const";
+import { ALEO_ACCOUNT_1 } from "../../__mocks__/account.mock";
+
+const mockTransaction = { family: "aleo" };
+const mockCreateTransaction = jest.fn(() => mockTransaction);
+
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: jest.fn(() => ({
+    createTransaction: mockCreateTransaction,
+  })),
+}));
+
+jest.mock("@ledgerhq/lumen-ui-rnative", () => {
+  const actual = jest.requireActual("@ledgerhq/lumen-ui-rnative");
+
+  return {
+    ...actual,
+    Box: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
+    Text: ({ children }: { children: React.ReactNode }) => <Text>{children}</Text>,
+  };
+});
+
+jest.mock("~/components/StepHeader", () => {
+  return function MockStepHeader({ title }: { title: string }) {
+    return <Text testID="step-header">{title}</Text>;
+  };
+});
+
+function makeNavigation() {
+  return { navigate: jest.fn() };
+}
+
+function makeRoute() {
+  return {
+    key: "aleo-balance-selection",
+    name: "AleoSendBalanceSelection" as const,
+    params: { account: ALEO_ACCOUNT_1, parentAccount: undefined, isSelfTransfer: false },
+  };
+}
+
+describe("BalanceSelectionScreen", () => {
+  const mockNavigation = makeNavigation();
+  const mockRoute = makeRoute();
+
+  it("navigates to SendSelectRecipient with the created transaction", async () => {
+    const { user } = render(
+      <BalanceSelectionScreen navigation={mockNavigation as never} route={mockRoute as never} />,
+    );
+
+    await user.press(screen.getByText("Public"));
+
+    expect(mockNavigation.navigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigation.navigate).toHaveBeenCalledWith(
+      ScreenName.SendSelectRecipient,
+      expect.objectContaining({
+        accountId: ALEO_ACCOUNT_1.id,
+        transaction: mockTransaction,
+      }),
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/MandatoryPrivateSyncScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/MandatoryPrivateSyncScreen.test.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { View, Text } from "react-native";
+import { act, render } from "@tests/test-renderer";
+import { MandatoryPrivateSyncScreen } from "../MandatoryPrivateSyncScreen";
+import { ScreenName } from "~/const";
+import { ALEO_ACCOUNT_1 } from "../../__mocks__/account.mock";
+
+jest.mock("@ledgerhq/lumen-ui-rnative", () => {
+  const actual = jest.requireActual("@ledgerhq/lumen-ui-rnative");
+
+  return {
+    ...actual,
+    Box: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
+    Text: ({ children }: { children: React.ReactNode }) => <Text>{children}</Text>,
+    Spinner: () => <View testID="spinner" />,
+  };
+});
+
+const mockTransaction = { family: "aleo", recipient: "aleo1abc" } as never;
+
+function makeNavigation() {
+  return { replace: jest.fn() };
+}
+
+function makeRoute() {
+  return {
+    key: "aleo-private-sync",
+    name: "AleoMandatoryPrivateSync" as const,
+    params: { account: ALEO_ACCOUNT_1, parentAccount: undefined, transaction: mockTransaction },
+  };
+}
+
+describe("MandatoryPrivateSyncScreen", () => {
+  const mockNavigation = makeNavigation();
+  const mockRoute = makeRoute();
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockNavigation.replace.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("navigates to SendAmountCoin after 2 seconds", () => {
+    render(
+      <MandatoryPrivateSyncScreen
+        navigation={mockNavigation as never}
+        route={mockRoute as never}
+      />,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(mockNavigation.replace).toHaveBeenCalledTimes(1);
+    expect(mockNavigation.replace).toHaveBeenCalledWith(
+      ScreenName.SendAmountCoin,
+      expect.objectContaining({
+        accountId: ALEO_ACCOUNT_1.id,
+        transaction: mockTransaction,
+      }),
+    );
+  });
+
+  it("does not navigate before 2 seconds have elapsed", () => {
+    render(
+      <MandatoryPrivateSyncScreen
+        navigation={mockNavigation as never}
+        route={mockRoute as never}
+      />,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(1999);
+    });
+
+    expect(mockNavigation.replace).not.toHaveBeenCalled();
+  });
+
+  it("cancels the timer on unmount", () => {
+    const { unmount } = render(
+      <MandatoryPrivateSyncScreen
+        navigation={mockNavigation as never}
+        route={mockRoute as never}
+      />,
+    );
+
+    unmount();
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(mockNavigation.replace).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/MandatoryPrivateSyncScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/MandatoryPrivateSyncScreen.test.tsx
@@ -1,20 +1,8 @@
 import React from "react";
-import { View, Text } from "react-native";
 import { act, render } from "@tests/test-renderer";
 import { MandatoryPrivateSyncScreen } from "../MandatoryPrivateSyncScreen";
 import { ScreenName } from "~/const";
 import { ALEO_ACCOUNT_1 } from "../../__mocks__/account.mock";
-
-jest.mock("@ledgerhq/lumen-ui-rnative", () => {
-  const actual = jest.requireActual("@ledgerhq/lumen-ui-rnative");
-
-  return {
-    ...actual,
-    Box: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
-    Text: ({ children }: { children: React.ReactNode }) => <Text>{children}</Text>,
-    Spinner: () => <View testID="spinner" />,
-  };
-});
 
 const mockTransaction = { family: "aleo", recipient: "aleo1abc" } as never;
 

--- a/apps/ledger-live-mobile/src/families/aleo/__tests__/accountActions.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/__tests__/accountActions.test.tsx
@@ -1,6 +1,8 @@
 import { IconsLegacy } from "@ledgerhq/native-ui";
 import accountActions from "../accountActions";
 import { ALEO_ACCOUNT_1 } from "../__mocks__/account.mock";
+import { aleoCurrency } from "../__mocks__/currency.mock";
+import { NavigatorName, ScreenName } from "~/const";
 
 jest.mock("@ledgerhq/native-ui", () => ({
   IconsLegacy: { TransferMedium: "TransferMedium" },
@@ -25,6 +27,62 @@ describe("accountActions.getMainActions", () => {
       currency: "ALEO",
       page: "Account Page",
     });
-    expect(typeof action.customHandler).toBe("function");
+    expect(action.navigationParams).toEqual([
+      NavigatorName.SendFunds,
+      expect.objectContaining({
+        screen: ScreenName.AleoSendBalanceSelection,
+        params: expect.objectContaining({ isSelfTransfer: true }),
+      }),
+    ]);
+  });
+});
+
+describe("accountActions.getExtraSendActionParams", () => {
+  it("returns navigationParams pointing to AleoSendBalanceSelection with isSelfTransfer: false", () => {
+    const result = accountActions.getExtraSendActionParams({ account: ALEO_ACCOUNT_1 });
+
+    expect(result.navigationParams).toEqual([
+      NavigatorName.SendFunds,
+      expect.objectContaining({
+        screen: ScreenName.AleoSendBalanceSelection,
+        params: expect.objectContaining({ isSelfTransfer: false }),
+      }),
+    ]);
+  });
+});
+
+describe("accountActions.getAdditionalAssetActions", () => {
+  it("with defaultAccount — navigates to AleoSendBalanceSelection with isSelfTransfer: true", () => {
+    const [action] = accountActions.getAdditionalAssetActions({
+      currency: aleoCurrency,
+      defaultAccount: ALEO_ACCOUNT_1,
+      parentAccount: undefined,
+    });
+
+    expect(action.navigationParams).toEqual([
+      NavigatorName.SendFunds,
+      expect.objectContaining({
+        screen: ScreenName.AleoSendBalanceSelection,
+        params: expect.objectContaining({ isSelfTransfer: true }),
+      }),
+    ]);
+  });
+
+  it("without defaultAccount — navigates to SendCoin with extra.isSelfTransfer: true", () => {
+    const [action] = accountActions.getAdditionalAssetActions({
+      currency: aleoCurrency,
+      defaultAccount: undefined,
+      parentAccount: undefined,
+    });
+
+    expect(action.navigationParams).toEqual([
+      NavigatorName.SendFunds,
+      expect.objectContaining({
+        screen: ScreenName.SendCoin,
+        params: expect.objectContaining({
+          extra: expect.objectContaining({ isSelfTransfer: true }),
+        }),
+      }),
+    ]);
   });
 });

--- a/apps/ledger-live-mobile/src/families/aleo/__tests__/customSendFlow.test.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/__tests__/customSendFlow.test.ts
@@ -1,0 +1,98 @@
+import aleoSendFlow from "../customSendFlow";
+import { ScreenName } from "~/const";
+import { ALEO_ACCOUNT_1 } from "../__mocks__/account.mock";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import { isPrivateTransaction } from "@ledgerhq/live-common/families/aleo/utils";
+
+jest.mock("@ledgerhq/live-common/families/aleo/utils", () => ({
+  isPrivateTransaction: jest.fn(),
+}));
+
+const mockIsPrivateTransaction = jest.mocked(isPrivateTransaction);
+const navigate = jest.fn();
+
+describe("Aleo customSendFlow", () => {
+  const mockTransaction = { family: "aleo" } as Transaction;
+
+  beforeEach(() => {
+    navigate.mockClear();
+  });
+
+  describe("buildSendEntrypoint", () => {
+    it("returns AleoSendBalanceSelection with isSelfTransfer: false", () => {
+      const result = aleoSendFlow.buildSendEntrypoint!({
+        account: ALEO_ACCOUNT_1,
+        parentAccount: undefined,
+      });
+
+      expect(result.screen).toBe(ScreenName.AleoSendBalanceSelection);
+      expect(result.params).toMatchObject({ isSelfTransfer: false, account: ALEO_ACCOUNT_1 });
+    });
+  });
+
+  describe("navigateToInitialScreen", () => {
+    it("navigates to AleoSendBalanceSelection with isSelfTransfer: false by default", () => {
+      aleoSendFlow.navigateToInitialScreen!({
+        navigation: { navigate } as never,
+        account: ALEO_ACCOUNT_1,
+        parentAccount: undefined,
+      });
+
+      expect(navigate).toHaveBeenCalledTimes(1);
+      expect(navigate).toHaveBeenCalledWith(
+        ScreenName.AleoSendBalanceSelection,
+        expect.objectContaining({ isSelfTransfer: false }),
+      );
+    });
+
+    it("passes isSelfTransfer: true when extra.isSelfTransfer is true", () => {
+      aleoSendFlow.navigateToInitialScreen!({
+        navigation: { navigate } as never,
+        account: ALEO_ACCOUNT_1,
+        parentAccount: undefined,
+        extra: { isSelfTransfer: true },
+      });
+
+      expect(navigate).toHaveBeenCalledTimes(1);
+      expect(navigate).toHaveBeenCalledWith(
+        ScreenName.AleoSendBalanceSelection,
+        expect.objectContaining({ isSelfTransfer: true }),
+      );
+    });
+  });
+
+  describe("navigateAfterRecipient", () => {
+    it("navigates to AleoMandatoryPrivateSync for private transactions and returns true", () => {
+      mockIsPrivateTransaction.mockReturnValue(true);
+
+      const result = aleoSendFlow.navigateAfterRecipient!({
+        navigation: { navigate } as never,
+        account: ALEO_ACCOUNT_1,
+        parentAccount: undefined,
+        transaction: mockTransaction,
+      });
+
+      expect(result).toBe(true);
+      expect(navigate).toHaveBeenCalledTimes(1);
+      expect(navigate).toHaveBeenCalledWith(ScreenName.AleoMandatoryPrivateSync, {
+        account: ALEO_ACCOUNT_1,
+        parentAccount: undefined,
+        transaction: mockTransaction,
+      });
+    });
+
+    it("returns false for non-private aleo transactions", () => {
+      mockIsPrivateTransaction.mockReturnValue(false);
+
+      const result = aleoSendFlow.navigateAfterRecipient!({
+        navigation: { navigate } as never,
+        account: ALEO_ACCOUNT_1,
+        parentAccount: undefined,
+        transaction: mockTransaction,
+      });
+
+      expect(result).toBe(false);
+      expect(navigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/accountActions.tsx
@@ -1,27 +1,94 @@
 import React from "react";
 import { Trans } from "~/context/Locale";
 import { IconsLegacy } from "@ledgerhq/native-ui";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
+import { NavigatorName, ScreenName } from "~/const";
 import type { ActionButtonEvent } from "~/components/FabActions";
 
-const getMainActions = ({ account: _account }: { account: AleoAccount }): ActionButtonEvent[] => {
-  return [
-    {
-      id: "public_to_private",
-      label: <Trans i18nKey="aleo.accountActions.publicToPrivate" />,
-      Icon: IconsLegacy.TransferMedium,
-      event: "button_clicked",
-      eventProperties: {
-        button: "public_to_private",
-        currency: "ALEO",
-        page: "Account Page",
-      },
-      // TODO: handler, for now empty skeleton only ( https://ledgerhq.atlassian.net/browse/LIVE-30501 )
-      customHandler: () => {},
+const getMainActions = ({
+  account,
+  parentAccount,
+}: {
+  account: AleoAccount;
+  parentAccount?: Account;
+}): ActionButtonEvent[] => [
+  {
+    id: "public_to_private",
+    label: <Trans i18nKey="aleo.accountActions.publicToPrivate" />,
+    Icon: IconsLegacy.TransferMedium,
+    event: "button_clicked",
+    eventProperties: {
+      button: "public_to_private",
+      currency: "ALEO",
+      page: "Account Page",
     },
-  ];
-};
+    navigationParams: [
+      NavigatorName.SendFunds,
+      {
+        screen: ScreenName.AleoSendBalanceSelection,
+        params: { account, parentAccount, isSelfTransfer: true },
+      },
+    ],
+  },
+];
+
+const getExtraSendActionParams = ({
+  account,
+  parentAccount,
+}: {
+  account: AccountLike;
+  parentAccount?: Account;
+}) => ({
+  navigationParams: [
+    NavigatorName.SendFunds,
+    {
+      screen: ScreenName.AleoSendBalanceSelection,
+      params: { account, parentAccount: parentAccount ?? undefined, isSelfTransfer: false },
+    },
+  ],
+});
+
+const getAdditionalAssetActions = ({
+  currency,
+  defaultAccount,
+  parentAccount,
+}: {
+  currency: CryptoCurrency | TokenCurrency | undefined;
+  defaultAccount: AccountLike | undefined;
+  parentAccount: Account | undefined;
+}): ActionButtonEvent[] => [
+  {
+    id: "self_transfer",
+    label: <Trans i18nKey="aleo.accountActions.publicToPrivate" />,
+    Icon: IconsLegacy.TransferMedium,
+    event: "button_clicked",
+    eventProperties: { button: "self_transfer", currency: currency?.ticker },
+    navigationParams: [
+      NavigatorName.SendFunds,
+      defaultAccount
+        ? {
+            screen: ScreenName.AleoSendBalanceSelection,
+            params: {
+              account: defaultAccount,
+              parentAccount,
+              isSelfTransfer: true,
+            },
+          }
+        : {
+            screen: ScreenName.SendCoin,
+            params: {
+              selectedCurrency: currency,
+              extra: { isSelfTransfer: true },
+            },
+          },
+    ],
+  },
+];
 
 export default {
   getMainActions,
+  getExtraSendActionParams,
+  getAdditionalAssetActions,
 };

--- a/apps/ledger-live-mobile/src/families/aleo/customSendFlow.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/customSendFlow.ts
@@ -1,0 +1,50 @@
+import { isPrivateTransaction } from "@ledgerhq/live-common/families/aleo/utils";
+import { ScreenName } from "~/const";
+import type {
+  CustomSendFlow,
+  CustomSendFlowScreen,
+} from "~/screens/SendFunds/utils/customSendFlow";
+import { BalanceSelectionScreen, BalanceSelectionHeaderTitle } from "./Send/BalanceSelectionScreen";
+import { MandatoryPrivateSyncScreen } from "./Send/MandatoryPrivateSyncScreen";
+
+const screens: CustomSendFlowScreen[] = [
+  {
+    name: ScreenName.AleoSendBalanceSelection,
+    component: BalanceSelectionScreen,
+    options: { headerTitle: BalanceSelectionHeaderTitle },
+  },
+  {
+    name: ScreenName.AleoMandatoryPrivateSync,
+    component: MandatoryPrivateSyncScreen,
+    options: { headerShown: false },
+  },
+];
+
+const aleoSendFlow = {
+  screens,
+  buildSendEntrypoint: ({ account, parentAccount }) => ({
+    screen: ScreenName.AleoSendBalanceSelection,
+    params: { account, parentAccount, isSelfTransfer: false },
+  }),
+  navigateToInitialScreen: ({ navigation, account, parentAccount, extra }) => {
+    navigation.navigate(ScreenName.AleoSendBalanceSelection, {
+      account,
+      parentAccount,
+      isSelfTransfer: extra?.isSelfTransfer === true,
+    });
+  },
+  navigateAfterRecipient: ({ navigation, account, parentAccount, transaction }) => {
+    if (transaction.family === "aleo" && isPrivateTransaction(transaction)) {
+      navigation.navigate(ScreenName.AleoMandatoryPrivateSync, {
+        account,
+        parentAccount,
+        transaction,
+      });
+      return true;
+    }
+
+    return false;
+  },
+} satisfies CustomSendFlow;
+
+export default aleoSendFlow;

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10078,7 +10078,9 @@
       "balanceSelection": {
         "title": "Select balance",
         "mockTitle": "Balance selection screen mock",
-        "selfTransfer": "Self transfer: {{value}}"
+        "selfTransfer": "Self transfer: {{value}}",
+        "mockButtonPublic": "Public",
+        "mockButtonPrivate": "Private"
       },
       "privateSync": {
         "mockTitle": "Private sync mock"

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2971,6 +2971,8 @@
     "month": "1M",
     "year": "1Y",
     "all": "All",
+    "second_short": "s",
+    "minute_short": "min",
     "since": {
       "day": "past day",
       "week": "past week",
@@ -10072,6 +10074,16 @@
     "accountActions": {
       "publicToPrivate": "Self transfer"
     },
+    "send": {
+      "balanceSelection": {
+        "title": "Select balance",
+        "mockTitle": "Balance selection screen mock",
+        "selfTransfer": "Self transfer: {{value}}"
+      },
+      "privateSync": {
+        "mockTitle": "Private sync mock"
+      }
+    },
     "balancesSection": "Balances",
     "info": {
       "transparent": {
@@ -10089,6 +10101,12 @@
         "stopSync": "Stop sync",
         "syncAgain": "Sync again",
         "lastSync": "Last synced: {{date}}"
+      }
+    },
+    "operations": {
+      "type": {
+        "public": "Public",
+        "private": "Private"
       }
     }
   }

--- a/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
@@ -107,7 +107,7 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
 
   const extraReceiveActionParams = useMemo(
     () =>
-      decorators && decorators.getExtraSendActionParams
+      decorators && decorators.getExtraReceiveActionParams
         ? decorators.getExtraReceiveActionParams({ account, parentAccount })
         : {},
     [account, parentAccount, decorators],

--- a/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
@@ -20,6 +20,7 @@ import SafeAreaView from "~/components/SafeAreaView";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { withDiscreetMode } from "~/context/DiscreetModeContext";
 import { useNewSendFlowFeature } from "LLM/features/Send/hooks/useNewSendFlowFeature";
+import { getCustomSendFlow } from "~/screens/SendFunds/utils/customSendFlow";
 
 type Props = BaseComposite<
   StackNavigatorProps<SendFundsNavigatorStackParamList, ScreenName.SendCoin>
@@ -95,43 +96,57 @@ function ReceiveFunds({ navigation, route }: Props) {
 
       if (typeof minBalance !== "undefined" && !isNaN(minBalance) && balance.lte(minBalance)) {
         setError(new NotEnoughBalance());
-      } else {
-        // If navigating to Send flow, check if new flow is enabled for this account's family
-        if (next === ScreenName.SendSelectRecipient) {
-          const parentAccount = getParentAccount(account, accounts);
-          const accountFamily = getFamilyFromAccount(account, parentAccount);
-          const accountCurrencyId = getCurrencyIdFromAccount(account, parentAccount);
-          const shouldUseNewFlow = isEnabledForFamily(accountFamily, accountCurrencyId);
+        return;
+      }
 
-          if (shouldUseNewFlow) {
-            const mainAccount = getMainAccount(account, parentAccount);
-            navigation.navigate(NavigatorName.SendFlow, {
-              params: {
-                account,
-                parentAccount: mainAccount === account ? undefined : mainAccount,
-              },
-            });
-            return;
-          }
+      // If navigating to Send flow, check if new flow is enabled for this account's family
+      if (next === ScreenName.SendSelectRecipient) {
+        const parentAccount = getParentAccount(account, accounts);
+        const accountFamily = getFamilyFromAccount(account, parentAccount);
+        const accountCurrencyId = getCurrencyIdFromAccount(account, parentAccount);
+        const shouldUseNewFlow = isEnabledForFamily(accountFamily, accountCurrencyId);
+        const mainAccount = getMainAccount(account, parentAccount);
+
+        if (shouldUseNewFlow) {
+          navigation.navigate(NavigatorName.SendFlow, {
+            params: {
+              account,
+              parentAccount: mainAccount === account ? undefined : mainAccount,
+            },
+          });
+          return;
         }
 
-        // Determine navigation target for old flows or non-Send flows
-        const targetScreen = next || ScreenName.ReceiveConnectDevice;
+        const family = mainAccount.currency.family;
+        const familySendFlow = getCustomSendFlow(family);
 
-        // FIXME: Double check if this works because it seems very weird.
-        // 1) "next" does not seem to be passed as a param anywhere
-        // 2) This component belongs to "SendFundsNavigator", but ReceiveConnectDevice does not.
-        //    It belongs to "ReceiveFundsNavigator".
-        // Update: next is never passed as a dynamic param, it is only defined as an initial param
-        // Thus, next is always defined and the || condition seems to be kinda stupid.
-        // @ts-expect-error this seems impossible to type correctly…
-        navigation.navigate(targetScreen, {
-          ...route.params,
-          account,
-          accountId: account.id,
-          parentId: account.type !== "Account" ? account.parentId : undefined,
-        });
+        if (familySendFlow?.navigateToInitialScreen) {
+          familySendFlow.navigateToInitialScreen({
+            navigation,
+            account,
+            parentAccount,
+            extra: route.params?.extra,
+          });
+          return;
+        }
       }
+
+      // Determine navigation target for old flows or non-Send flows
+      const targetScreen = next || ScreenName.ReceiveConnectDevice;
+
+      // FIXME: Double check if this works because it seems very weird.
+      // 1) "next" does not seem to be passed as a param anywhere
+      // 2) This component belongs to "SendFundsNavigator", but ReceiveConnectDevice does not.
+      //    It belongs to "ReceiveFundsNavigator".
+      // Update: next is never passed as a dynamic param, it is only defined as an initial param
+      // Thus, next is always defined and the || condition seems to be kinda stupid.
+      // @ts-expect-error this seems impossible to type correctly…
+      navigation.navigate(targetScreen, {
+        ...route.params,
+        account,
+        accountId: account.id,
+        parentId: account.type !== "Account" ? account.parentId : undefined,
+      });
     },
     [
       accounts,

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.test.tsx
@@ -1,12 +1,14 @@
 import React from "react";
-import { screen } from "@testing-library/react-native";
-import { render } from "@tests/test-renderer";
+import { screen, render } from "@tests/test-renderer";
 import SendSelectRecipient from "./02-SelectRecipient";
 import { Account } from "@ledgerhq/types-live";
 import * as useBridgeTransactionModule from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { RouteProp } from "@react-navigation/core";
 import { ScreenName } from "~/const";
 import { SendFundsNavigatorStackParamList } from "~/components/RootNavigator/types/SendFundsNavigator";
+import { getCustomSendFlow } from "~/screens/SendFunds/utils/customSendFlow";
+
+const mockNavigate = jest.fn();
 
 jest.mock("@ledgerhq/live-common/bridge/useBridgeTransaction", () => ({
   __esModule: true,
@@ -19,6 +21,10 @@ jest.mock("@react-native-clipboard/clipboard", () => ({}));
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
   useScrollToTop: jest.fn(),
+  useNavigation: () => ({ navigate: mockNavigate, getParent: jest.fn(() => null) }),
+}));
+jest.mock("~/screens/SendFunds/utils/customSendFlow", () => ({
+  getCustomSendFlow: jest.fn(() => null),
 }));
 jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
   useAccountBridge: jest.fn().mockReturnValue({
@@ -122,5 +128,99 @@ describe("SendSelectRecipient", () => {
     );
 
     expect(screen.queryByTestId("spl-2022-problematic-extension")).toBeNull();
+  });
+});
+
+const mockGetCustomSendFlow = jest.mocked(getCustomSendFlow);
+
+describe("SendSelectRecipient — custom send flow", () => {
+  const mockNavigateAfterRecipient = jest.fn();
+
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockNavigateAfterRecipient.mockClear();
+    mockGetCustomSendFlow.mockReturnValue(null);
+  });
+
+  const accountState = (state: Parameters<typeof Object>[0]) => ({
+    ...state,
+    accounts: {
+      active: [
+        {
+          id: "parentId",
+          type: "Account",
+          currency: { units: [], family: "aleo", id: "aleo" },
+          subAccounts: [],
+          operations: [],
+          operationsCount: 0,
+          balance: { gt: () => true },
+          spendableBalance: { gt: () => true },
+        } as unknown as Account,
+      ],
+    },
+  });
+
+  it("calls navigateAfterRecipient and returns early when it returns true", async () => {
+    mockNavigateAfterRecipient.mockReturnValue(true);
+    mockGetCustomSendFlow.mockReturnValue({
+      screens: [],
+      navigateAfterRecipient: mockNavigateAfterRecipient,
+    });
+
+    jest.spyOn(useBridgeTransactionModule, "default").mockReturnValue({
+      transaction: { recipient: "aleo1abc", family: "aleo" },
+      status: { errors: {}, warnings: {} },
+    } as unknown as useBridgeTransactionModule.Result);
+
+    const { user } = render(
+      <SendSelectRecipient
+        route={
+          {
+            params: { accountId: "parentId" },
+          } as unknown as RouteProp<
+            SendFundsNavigatorStackParamList,
+            ScreenName.SendSelectRecipient
+          >
+        }
+      />,
+      { overrideInitialState: accountState },
+    );
+
+    await user.press(screen.getByTestId("enabled-recipient-continue-button"));
+
+    expect(mockNavigateAfterRecipient).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalledWith(ScreenName.SendAmountCoin, expect.anything());
+  });
+
+  it("falls through to SendAmountCoin when navigateAfterRecipient returns false", async () => {
+    mockNavigateAfterRecipient.mockReturnValue(false);
+    mockGetCustomSendFlow.mockReturnValue({
+      screens: [],
+      navigateAfterRecipient: mockNavigateAfterRecipient,
+    });
+
+    jest.spyOn(useBridgeTransactionModule, "default").mockReturnValue({
+      transaction: { recipient: "aleo1abc", family: "aleo" },
+      status: { errors: {}, warnings: {} },
+    } as unknown as useBridgeTransactionModule.Result);
+
+    const { user } = render(
+      <SendSelectRecipient
+        route={
+          {
+            params: { accountId: "parentId" },
+          } as unknown as RouteProp<
+            SendFundsNavigatorStackParamList,
+            ScreenName.SendSelectRecipient
+          >
+        }
+      />,
+      { overrideInitialState: accountState },
+    );
+
+    await user.press(screen.getByTestId("enabled-recipient-continue-button"));
+
+    expect(mockNavigateAfterRecipient).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.SendAmountCoin, expect.anything());
   });
 });

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -41,6 +41,7 @@ import { useExpiryDurationInput } from "LLM/features/ExpiryDuration/hooks/useExp
 import DomainServiceRecipientRow from "./DomainServiceRecipientRow";
 import RecipientRow from "./RecipientRow";
 import perFamilySendSelectRecipient from "../../generated/SendSelectRecipient";
+import { getCustomSendFlow } from "~/screens/SendFunds/utils/customSendFlow";
 import {
   getTokenExtensions,
   hasProblematicExtension,
@@ -206,6 +207,19 @@ export default function SendSelectRecipient({ route }: Props) {
       });
     }
 
+    const family = mainAccount.currency.family;
+    const familySendFlow = getCustomSendFlow(family);
+
+    if (familySendFlow?.navigateAfterRecipient) {
+      const handled = familySendFlow.navigateAfterRecipient({
+        navigation,
+        account,
+        parentAccount: parentAccount ?? undefined,
+        transaction,
+      });
+      if (handled) return;
+    }
+
     return navigation.navigate(ScreenName.SendAmountCoin, {
       accountId: account.id,
       parentId: parentAccount?.id,
@@ -213,10 +227,11 @@ export default function SendSelectRecipient({ route }: Props) {
     });
   }, [
     account,
+    mainAccount,
     transaction,
     shouldSkipAmount,
     navigation,
-    parentAccount?.id,
+    parentAccount,
     route.params,
     memoTag?.isEmpty,
     memoTagDrawerState,

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.test.tsx
@@ -25,24 +25,8 @@ jest.mock("@ledgerhq/live-common/bridge/useBridgeTransaction", () => ({
   default: jest.fn(),
 }));
 
-jest.mock("LLM/hooks/useAccountUnit", () => ({
-  useMaybeAccountUnit: jest.fn(() => ({ code: "ALEO", magnitude: 6, name: "Aleo" })),
-}));
-
 jest.mock("~/screens/SendFunds/utils/customSendFlow", () => ({
   getCustomSendFlow: jest.fn(() => null),
-}));
-
-jest.mock("~/screens/SendFunds/AmountInput", () => () => <View testID="amount-input" />);
-
-jest.mock("~/components/KeyboardView", () => ({
-  __esModule: true,
-  default: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
-}));
-
-jest.mock("~/components/SafeAreaView", () => ({
-  __esModule: true,
-  default: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
 }));
 
 const mockGetCustomSendFlow = jest.mocked(getCustomSendFlow);

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { View } from "react-native";
+import { BigNumber } from "bignumber.js";
+import { render, screen } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountScreen } from "LLM/hooks/useAccountScreen";
+import { getCustomSendFlow } from "~/screens/SendFunds/utils/customSendFlow";
+import { ALEO_ACCOUNT_1 } from "~/families/aleo/__mocks__/account.mock";
+import SendAmountCoin from "./03a-AmountCoin";
+
+jest.mock("LLM/hooks/useAccountScreen", () => ({
+  useAccountScreen: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: jest.fn(() => ({
+    estimateMaxSpendable: jest.fn(() => Promise.resolve(new BigNumber(0))),
+    updateTransaction: jest.fn((t: object, patch: object) => ({ ...t, ...patch })),
+  })),
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/useBridgeTransaction", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("LLM/hooks/useAccountUnit", () => ({
+  useMaybeAccountUnit: jest.fn(() => ({ code: "ALEO", magnitude: 6, name: "Aleo" })),
+}));
+
+jest.mock("~/screens/SendFunds/utils/customSendFlow", () => ({
+  getCustomSendFlow: jest.fn(() => null),
+}));
+
+jest.mock("~/screens/SendFunds/AmountInput", () => () => <View testID="amount-input" />);
+
+jest.mock("~/components/KeyboardView", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
+}));
+
+jest.mock("~/components/SafeAreaView", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
+}));
+
+const mockGetCustomSendFlow = jest.mocked(getCustomSendFlow);
+const mockUseAccountScreen = jest.mocked(useAccountScreen);
+const mockUseBridgeTransaction = jest.mocked(useBridgeTransaction);
+const mockTransaction = {
+  family: "aleo",
+  recipient: "",
+  useAllAmount: false,
+  amount: new BigNumber(0),
+};
+
+function makeNavigation() {
+  return {
+    navigate: jest.fn(),
+    getParent: jest.fn(),
+  };
+}
+
+function makeRoute() {
+  return {
+    key: "amount-key",
+    name: ScreenName.SendAmountCoin as const,
+    params: { accountId: ALEO_ACCOUNT_1.id, transaction: mockTransaction },
+  };
+}
+
+describe("SendAmountCoin — custom send flow", () => {
+  const mockNavigation = makeNavigation();
+  const mockRoute = makeRoute();
+
+  beforeEach(() => {
+    mockGetCustomSendFlow.mockReturnValue(null);
+    mockUseAccountScreen.mockReturnValue({ account: ALEO_ACCOUNT_1, parentAccount: null });
+    mockUseBridgeTransaction.mockReturnValue({
+      transaction: mockTransaction,
+      setTransaction: jest.fn(),
+      status: { errors: {}, warnings: {}, amount: new BigNumber(0) },
+      bridgePending: false,
+      bridgeError: null,
+    } as never);
+
+    mockNavigation.navigate.mockClear();
+  });
+
+  it("renders without AfterAmountInput when no custom flow", () => {
+    render(<SendAmountCoin navigation={mockNavigation as never} route={mockRoute as never} />);
+
+    expect(screen.getByTestId("amount-input")).toBeOnTheScreen();
+  });
+
+  it("renders AfterAmountInput when the family has a custom send flow", () => {
+    mockGetCustomSendFlow.mockReturnValue({
+      screens: [],
+      AfterAmountInput: () => <View testID="after-amount-input" />,
+    });
+
+    render(<SendAmountCoin navigation={mockNavigation as never} route={mockRoute as never} />);
+
+    expect(screen.getByTestId("after-amount-input")).toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
@@ -11,6 +11,8 @@ import type { AccountLike, Account } from "@ledgerhq/types-live";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
+import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/index";
+import { getCustomSendFlow } from "~/screens/SendFunds/utils/customSendFlow";
 import { ScreenName } from "~/const";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 import { TrackScreen } from "~/analytics";
@@ -135,12 +137,20 @@ function SendAmountCoinContent({ navigation, route, account, parentAccount }: Co
   }, [setTransaction, bridge, transaction]);
   const blur = useCallback(() => Keyboard.dismiss(), []);
   const onMaxSpendableLearnMore = useCallback(() => Linking.openURL(urls.maxSpendable), []);
+  const handleUpdateTransaction = useCallback(
+    (updater: (arg0: Transaction) => Transaction) => {
+      if (transaction) setTransaction(updater(transaction));
+    },
+    [setTransaction, transaction],
+  );
 
   const unit = useMaybeAccountUnit(account);
   if (!transaction || !unit) return null;
   const { useAllAmount } = transaction;
   const { amount } = status;
   const currency = getAccountCurrency(account);
+  const family = getFamilyByCurrencyId(currency.id);
+  const familySendFlow = family ? getCustomSendFlow(family) : null;
 
   const transferFee =
     "model" in transaction && transaction.model.commandDescriptor?.command.kind === "token.transfer"
@@ -179,6 +189,16 @@ function SendAmountCoinContent({ navigation, route, account, parentAccount }: Co
                 }
                 warning={status.warnings.amount}
               />
+
+              {familySendFlow?.AfterAmountInput && (
+                <View style={styles.afterAmountInputWrapper}>
+                  <familySendFlow.AfterAmountInput
+                    account={account}
+                    transaction={transaction}
+                    updateTransaction={handleUpdateTransaction}
+                  />
+                </View>
+              )}
 
               <View style={styles.bottomWrapper}>
                 <View style={[styles.available]}>
@@ -300,6 +320,9 @@ const styles = StyleSheet.create({
   },
   maxLabel: {
     marginRight: 4,
+  },
+  afterAmountInputWrapper: {
+    flex: 1,
   },
   bottomWrapper: {
     alignSelf: "stretch",

--- a/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.test.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { View, ScrollView } from "react-native";
+import { BigNumber } from "bignumber.js";
+import { render, screen } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountScreen } from "LLM/hooks/useAccountScreen";
+import { getCustomSendFlow } from "~/screens/SendFunds/utils/customSendFlow";
+import { ALEO_ACCOUNT_1 } from "~/families/aleo/__mocks__/account.mock";
+import SendSummary from "./04-Summary";
+
+jest.mock("LLM/hooks/useAccountScreen", () => ({
+  useAccountScreen: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: jest.fn(() => ({})),
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/useBridgeTransaction", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("~/logic/screenTransactionHooks", () => ({
+  useTransactionChangeFromNavigation: jest.fn(),
+}));
+
+jest.mock("~/screens/SendFunds/utils/customSendFlow", () => ({
+  getCustomSendFlow: jest.fn(() => null),
+}));
+
+jest.mock("~/components/SafeAreaView", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
+}));
+
+jest.mock("~/components/NavigationScrollView", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <ScrollView>{children}</ScrollView>,
+}));
+
+const mockGetCustomSendFlow = jest.mocked(getCustomSendFlow);
+const mockUseAccountScreen = jest.mocked(useAccountScreen);
+const mockUseBridgeTransaction = jest.mocked(useBridgeTransaction);
+const mockStatus = {
+  errors: {},
+  warnings: {},
+  amount: new BigNumber(100),
+  totalSpent: new BigNumber(100),
+};
+
+function makeNavigation() {
+  return {
+    navigate: jest.fn(),
+    getParent: jest.fn(() => null),
+    setOptions: jest.fn(),
+  };
+}
+
+function makeRoute(transactionOverride = {}) {
+  return {
+    key: "summary-key",
+    name: ScreenName.SendSummary as const,
+    params: {
+      accountId: ALEO_ACCOUNT_1.id,
+      transaction: {
+        family: "aleo",
+        recipient: "aleo1abc",
+        useAllAmount: false,
+        ...transactionOverride,
+      },
+      nextNavigation: null,
+      overrideAmountLabel: undefined,
+      hideTotal: false,
+    },
+  };
+}
+
+describe("SendSummary — custom send flow", () => {
+  const mockNavigation = makeNavigation();
+  const mockRoute = makeRoute();
+
+  beforeEach(() => {
+    mockGetCustomSendFlow.mockReturnValue(null);
+    mockUseAccountScreen.mockReturnValue({ account: ALEO_ACCOUNT_1, parentAccount: null });
+    mockUseBridgeTransaction.mockReturnValue({
+      transaction: { family: "aleo", recipient: "aleo1abc", useAllAmount: false },
+      setTransaction: jest.fn(),
+      status: mockStatus,
+      bridgePending: false,
+      bridgeError: null,
+    } as never);
+  });
+
+  it("renders correctly with no custom flow", () => {
+    render(<SendSummary navigation={mockNavigation as never} route={mockRoute as never} />);
+
+    expect(screen.getByTestId("enabled-summary-continue-button")).toBeOnTheScreen();
+  });
+
+  it("renders custom SummaryToSection when family has a custom flow", () => {
+    mockGetCustomSendFlow.mockReturnValue({
+      screens: [],
+      SummaryToSection: () => <View testID="custom-summary-to" />,
+    });
+
+    render(<SendSummary navigation={mockNavigation as never} route={mockRoute as never} />);
+
+    expect(screen.getByTestId("custom-summary-to")).toBeOnTheScreen();
+  });
+
+  it("skips the recipient section when transaction has no recipient", () => {
+    const mockRouteWithNoRecipient = makeRoute({ recipient: "" });
+
+    mockUseBridgeTransaction.mockReturnValue({
+      transaction: { family: "aleo", recipient: "", useAllAmount: false },
+      setTransaction: jest.fn(),
+      status: mockStatus,
+      bridgePending: false,
+      bridgeError: null,
+    } as never);
+
+    render(
+      <SendSummary
+        navigation={mockNavigation as never}
+        route={mockRouteWithNoRecipient as never}
+      />,
+    );
+
+    expect(screen.getByTestId("enabled-summary-continue-button")).toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
@@ -37,6 +37,7 @@ import { SwapNavigatorParamList } from "~/components/RootNavigator/types/SwapNav
 import { Alert as NativeUiAlert, Flex, Text } from "@ledgerhq/native-ui";
 import SupportLinkError from "~/components/SupportLinkError";
 import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
+import { getCustomSendFlow } from "~/screens/SendFunds/utils/customSendFlow";
 
 type Navigation = BaseComposite<
   | StackNavigatorProps<SendFundsNavigatorStackParamList, ScreenName.SendSummary>
@@ -139,6 +140,8 @@ function SendSummary({ navigation, route }: Props) {
   const { tooManyUtxos } = warnings || {};
   const mainAccount = getMainAccount(account, parentAccount);
   const currencyOrToken = getAccountCurrency(account);
+  const family = mainAccount.currency.family;
+  const familySendFlow = getCustomSendFlow(family);
   const hasNonEmptySubAccounts =
     account &&
     account.type === "Account" &&
@@ -174,6 +177,37 @@ function SendSummary({ navigation, route }: Props) {
   const displayedError = mergeErrors();
 
   const isSolanaRawTransaction = "raw" in transaction && transaction.raw;
+  const shouldShowTotal = !amount.eq(totalSpent) && !hideTotal && !isSolanaRawTransaction;
+
+  const renderToSection = useCallback(() => {
+    if (!transaction.recipient) {
+      return null;
+    }
+
+    const badge = familySendFlow?.SummaryToBadge ? (
+      <familySendFlow.SummaryToBadge transaction={transaction} />
+    ) : undefined;
+
+    if (familySendFlow?.SummaryToSection) {
+      return (
+        <familySendFlow.SummaryToSection
+          transaction={transaction}
+          currency={mainAccount.currency}
+          account={account}
+          parentAccount={parentAccount}
+          {...(badge && { badge })}
+        />
+      );
+    }
+
+    return (
+      <SummaryToSection
+        transaction={transaction}
+        currency={mainAccount.currency}
+        {...(badge && { badge })}
+      />
+    );
+  }, [transaction, familySendFlow, account, parentAccount, mainAccount.currency]);
 
   if (!account || !transaction || !currencyOrToken) {
     return null;
@@ -204,7 +238,13 @@ function SendSummary({ navigation, route }: Props) {
             </Alert>
           </View>
         ) : null}
-        <SummaryFromSection account={account} parentAccount={parentAccount} />
+        <SummaryFromSection
+          account={account}
+          parentAccount={parentAccount}
+          {...(familySendFlow?.SummaryFromBadge && {
+            badge: <familySendFlow.SummaryFromBadge transaction={transaction} />,
+          })}
+        />
         <View
           style={[
             styles.verticalConnector,
@@ -213,9 +253,7 @@ function SendSummary({ navigation, route }: Props) {
             },
           ]}
         />
-        {transaction.recipient ? (
-          <SummaryToSection transaction={transaction} currency={mainAccount.currency} />
-        ) : null}
+        {renderToSection()}
         {status.warnings.recipient ? (
           <LText style={styles.warning} color="orange" testID="send-summary-warning">
             <TranslatedError error={status.warnings.recipient} />
@@ -268,7 +306,7 @@ function SendSummary({ navigation, route }: Props) {
           route={route}
         />
 
-        {!amount.eq(totalSpent) && !hideTotal && !isSolanaRawTransaction ? (
+        {shouldShowTotal ? (
           <>
             <SectionSeparator lineColor={colors.lightFog} />
             <SummaryTotalSection

--- a/apps/ledger-live-mobile/src/screens/SendFunds/SummaryFromSection.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/SummaryFromSection.tsx
@@ -11,12 +11,13 @@ import CurrencyIcon from "~/components/CurrencyIcon";
 import Wallet from "@ledgerhq/icons-ui/native/Wallet";
 import { useAccountName } from "~/reducers/wallet";
 
-type Props = {
+type Props = Readonly<{
   account: AccountLike;
   parentAccount: Account | null | undefined;
-};
+  badge?: React.ReactNode;
+}>;
 
-function SummaryFromSection({ account }: Props) {
+function SummaryFromSection({ account, badge }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
   const currency = getAccountCurrency(account);
@@ -29,12 +30,9 @@ function SummaryFromSection({ account }: Props) {
           <Wallet size="S" color={colors.primary.c80} />
         </Circle>
       }
+      labelBadge={badge}
       data={
-        <View
-          style={{
-            flexDirection: "row",
-          }}
-        >
+        <View style={{ flexDirection: "row" }}>
           <View style={styles.currencyIcon}>
             <CurrencyIcon size={14} currency={currency} />
           </View>

--- a/apps/ledger-live-mobile/src/screens/SendFunds/SummaryRowCustom.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/SummaryRowCustom.tsx
@@ -10,6 +10,11 @@ const styles = StyleSheet.create({
   labelStyle: {
     fontSize: 16,
   },
+  labelRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
   iconLeft: {
     paddingRight: 16,
   },
@@ -22,16 +27,20 @@ type Props = {
   label: string;
   data: React.ReactNode;
   iconLeft: React.ReactElement;
+  labelBadge?: React.ReactNode;
 };
 
-const SummaryRowCustom = ({ label, data, iconLeft }: Props) => {
+const SummaryRowCustom = ({ label, data, iconLeft, labelBadge }: Props) => {
   return (
     <View style={styles.root}>
       <View style={styles.iconLeft}>{iconLeft}</View>
       <View style={styles.right}>
-        <LText style={styles.labelStyle} color="grey">
-          {label}
-        </LText>
+        <View style={styles.labelRow}>
+          <LText style={styles.labelStyle} color="grey">
+            {label}
+          </LText>
+          {labelBadge}
+        </View>
         {data}
       </View>
     </View>

--- a/apps/ledger-live-mobile/src/screens/SendFunds/SummaryToSection.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/SummaryToSection.tsx
@@ -13,10 +13,11 @@ import Circle from "~/components/Circle";
 import LText from "~/components/LText";
 import QrCode from "@ledgerhq/icons-ui/native/QrCode";
 
-type Props = {
+export type Props = Readonly<{
   transaction: Transaction;
   currency: CryptoCurrency;
-};
+  badge?: React.ReactNode;
+}>;
 
 const DefaultRecipientTemplate = memo(({ transaction }: Pick<Props, "transaction">) => {
   const { recipient, recipientDomain } = transaction;
@@ -66,7 +67,7 @@ const RecipientWithResolutionTemplate = memo(({ transaction }: Pick<Props, "tran
 });
 RecipientWithResolutionTemplate.displayName = "RecipientWithResolutionTemplate";
 
-function SummaryToSection({ transaction, currency }: Props) {
+function SummaryToSection({ transaction, currency, badge }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
 
@@ -88,6 +89,7 @@ function SummaryToSection({ transaction, currency }: Props) {
           <QrCode size="S" color={colors.primary.c80} />
         </Circle>
       }
+      labelBadge={badge}
       data={
         shouldTryResolvingDomain ? (
           <RecipientWithResolutionTemplate transaction={transaction} />

--- a/apps/ledger-live-mobile/src/screens/SendFunds/utils/customSendFlow.test.ts
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/utils/customSendFlow.test.ts
@@ -1,0 +1,26 @@
+import { getCustomSendFlow } from "./customSendFlow";
+
+jest.mock("~/generated/customSendFlow", () => ({
+  __esModule: true,
+  default: {
+    aleo: {
+      screens: [],
+      buildSendEntrypoint: jest.fn(),
+    },
+  },
+}));
+
+describe("getCustomSendFlow", () => {
+  it("returns null for unknown family", () => {
+    expect(getCustomSendFlow("bitcoin")).toBeNull();
+    expect(getCustomSendFlow("ethereum")).toBeNull();
+    expect(getCustomSendFlow("")).toBeNull();
+  });
+
+  it("returns the flow object for a registered family", () => {
+    const flow = getCustomSendFlow("aleo");
+
+    expect(flow).not.toBeNull();
+    expect(flow?.screens).toEqual([]);
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/SendFunds/utils/customSendFlow.ts
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/utils/customSendFlow.ts
@@ -1,0 +1,79 @@
+import type { ComponentType } from "react";
+import type { AccountLike, Account } from "@ledgerhq/types-live";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { NativeStackNavigationOptions } from "@react-navigation/native-stack";
+import type { SendFundsNavigatorStackParamList } from "~/components/RootNavigator/types/SendFundsNavigator";
+import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import { ScreenName } from "~/const";
+import perFamilySendFlow from "~/generated/customSendFlow";
+import type { Props as BaseSummaryToSectionProps } from "~/screens/SendFunds/SummaryToSection";
+
+export type CustomSendFlowScreen = {
+  name: keyof SendFundsNavigatorStackParamList;
+  // Screen components have typed route/navigation props that vary per screen name.
+  // A generic bound isn't expressible without `any` due to contravariance.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  component: ComponentType<any>;
+  options?: NativeStackNavigationOptions;
+  initialParams?: Partial<SendFundsNavigatorStackParamList[keyof SendFundsNavigatorStackParamList]>;
+};
+
+type SendFundsNavigation = StackNavigatorProps<
+  SendFundsNavigatorStackParamList,
+  ScreenName.SendCoin
+>["navigation"];
+
+type SelectRecipientNavigation = StackNavigatorProps<
+  SendFundsNavigatorStackParamList,
+  ScreenName.SendSelectRecipient
+>["navigation"];
+
+export type SummaryToSectionProps = BaseSummaryToSectionProps & {
+  account: AccountLike;
+  parentAccount: Account | null | undefined;
+};
+
+export type AfterAmountInputProps = {
+  account: AccountLike;
+  transaction: Transaction;
+  updateTransaction: (updater: (t: Transaction) => Transaction) => void;
+};
+
+type InitialScreenNavParams = {
+  navigation: SendFundsNavigation;
+  account: AccountLike;
+  parentAccount: Account | undefined;
+  extra?: Record<string, unknown>;
+};
+
+type AfterRecipientNavParams = {
+  navigation: SelectRecipientNavigation;
+  account: AccountLike;
+  parentAccount: Account | undefined;
+  transaction: Transaction;
+};
+
+export type CustomSendFlow = {
+  screens: CustomSendFlowScreen[];
+  /** Declarative entrypoint for navigation from outside the SendFunds navigator (e.g. asset action buttons). */
+  buildSendEntrypoint?: (opts: { account: AccountLike; parentAccount: Account | undefined }) => {
+    screen: keyof SendFundsNavigatorStackParamList;
+    params: Record<string, unknown>;
+  };
+  SummaryFromBadge?: ComponentType<{ transaction: Transaction }>;
+  SummaryToBadge?: ComponentType<{ transaction: Transaction }>;
+  SummaryToSection?: ComponentType<SummaryToSectionProps>;
+  AfterAmountInput?: ComponentType<AfterAmountInputProps>;
+  /** Imperative navigation from within the SendFunds navigator after account selection. */
+  navigateToInitialScreen?: (params: InitialScreenNavParams) => void;
+  /** Imperative navigation from within the SendFunds navigator after recipient selection. */
+  navigateAfterRecipient?: (params: AfterRecipientNavParams) => boolean;
+};
+
+const isCustomSendFlowFamily = (family: string): family is keyof typeof perFamilySendFlow =>
+  Object.hasOwn(perFamilySendFlow, family);
+
+export const getCustomSendFlow = (family: string): CustomSendFlow | null => {
+  if (!isCustomSendFlowFamily(family)) return null;
+  return perFamilySendFlow[family];
+};

--- a/apps/ledger-live-mobile/src/screens/__tests__/SelectAccount.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/__tests__/SelectAccount.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import BigNumber from "bignumber.js";
+import { View, Pressable, Text } from "react-native";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
@@ -7,6 +8,8 @@ import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { render, screen } from "@tests/test-renderer";
 import SelectAccount from "../SelectAccount";
 import type { State } from "~/reducers/types";
+import { ScreenName } from "~/const";
+import { getCustomSendFlow } from "~/screens/SendFunds/utils/customSendFlow";
 
 jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => {
   const { defaultIsAccountEmpty } = jest.requireActual(
@@ -22,19 +25,28 @@ jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => {
 });
 
 jest.mock("~/components/AccountSelector", () => {
-  const { View, Text } = jest.requireActual("react-native");
-  return function MockAccountSelector({ list }: { list: AccountLike[] }) {
+  return function MockAccountSelector({
+    list,
+    onSelectAccount,
+  }: {
+    list: AccountLike[];
+    onSelectAccount: (a: AccountLike) => void;
+  }) {
     return (
       <View testID="account-selector">
         {list.map(a => (
-          <Text key={a.id} testID={`account-${a.id}`}>
-            {a.id}
-          </Text>
+          <Pressable key={a.id} testID={`account-${a.id}`} onPress={() => onSelectAccount(a)}>
+            <Text>{a.id}</Text>
+          </Pressable>
         ))}
       </View>
     );
   };
 });
+
+jest.mock("~/screens/SendFunds/utils/customSendFlow", () => ({
+  getCustomSendFlow: jest.fn(() => null),
+}));
 
 jest.mock("LLM/features/Send/hooks/useNewSendFlowFeature", () => ({
   useNewSendFlowFeature: () => ({
@@ -204,5 +216,63 @@ describe("SelectAccount — currencyIds multi-network filter", () => {
 
     expect(screen.getByTestId(`account-${USDT_ETH.id}`)).toBeVisible();
     expect(screen.queryByTestId(`account-${EMPTY_USDT_POLY.id}`)).toBeNull();
+  });
+});
+
+const mockGetCustomSendFlow = jest.mocked(getCustomSendFlow);
+
+describe("SelectAccount — custom send flow navigation", () => {
+  afterEach(() => {
+    mockGetCustomSendFlow.mockReturnValue(null);
+  });
+
+  it("calls navigateToInitialScreen when the family has a custom flow", async () => {
+    const mockNavigateToInitialScreen = jest.fn();
+    mockGetCustomSendFlow.mockReturnValue({
+      screens: [],
+      navigateToInitialScreen: mockNavigateToInitialScreen,
+    });
+
+    const navigation = makeNavigation();
+    const { user } = render(
+      <SelectAccount
+        // oxlint-disable-next-line typescript/no-explicit-any
+        navigation={navigation as any}
+        route={
+          // oxlint-disable-next-line typescript/no-explicit-any
+          makeRoute({ next: ScreenName.SendSelectRecipient, minBalance: 0 }) as any
+        }
+      />,
+      { overrideInitialState: withAccounts([FUNDED_ETH]) },
+    );
+
+    await user.press(screen.getByTestId(`account-${FUNDED_ETH.id}`));
+
+    expect(mockNavigateToInitialScreen).toHaveBeenCalledWith(
+      expect.objectContaining({ account: FUNDED_ETH }),
+    );
+    expect(navigation.navigate).not.toHaveBeenCalled();
+  });
+
+  it("falls through to default navigation when no custom flow exists", async () => {
+    const navigation = makeNavigation();
+    const { user } = render(
+      <SelectAccount
+        // oxlint-disable-next-line typescript/no-explicit-any
+        navigation={navigation as any}
+        route={
+          // oxlint-disable-next-line typescript/no-explicit-any
+          makeRoute({ next: ScreenName.SendSelectRecipient, minBalance: 0 }) as any
+        }
+      />,
+      { overrideInitialState: withAccounts([FUNDED_ETH]) },
+    );
+
+    await user.press(screen.getByTestId(`account-${FUNDED_ETH.id}`));
+
+    expect(navigation.navigate).toHaveBeenCalledWith(
+      ScreenName.SendSelectRecipient,
+      expect.objectContaining({ accountId: FUNDED_ETH.id }),
+    );
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -79,6 +79,7 @@ import {
   isPublicTransaction,
   isPrivateTransaction,
   isTokenTransaction,
+  isPrivateDestination,
   derivePublicTransactionMode,
   derivePrivateTransactionMode,
   createTransactionIntent,
@@ -1552,6 +1553,23 @@ describe("isPrivateTransaction", () => {
     const transaction = getMockedTransaction({ mode });
 
     expect(isPrivateTransaction(transaction)).toBe(expected);
+  });
+});
+
+describe("isPrivateDestination", () => {
+  it.each([
+    [true, TRANSACTION_TYPE.TRANSFER_PRIVATE],
+    [true, TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE],
+    [true, TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE],
+    [true, TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE],
+    [false, TRANSACTION_TYPE.TRANSFER_PUBLIC],
+    [false, TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC],
+    [false, TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC],
+    [false, TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC],
+  ] as const)("should return %s for mode '%s'", (expected, mode) => {
+    const transaction = getMockedTransaction({ mode });
+
+    expect(isPrivateDestination(transaction)).toBe(expected);
   });
 });
 

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -430,6 +430,15 @@ export function isPrivateTransaction(transaction: Transaction): transaction is T
   );
 }
 
+export function isPrivateDestination(transaction: Transaction): boolean {
+  return (
+    transaction.mode === TRANSACTION_TYPE.TRANSFER_PRIVATE ||
+    transaction.mode === TRANSACTION_TYPE.CONVERT_PUBLIC_TO_PRIVATE ||
+    transaction.mode === TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE ||
+    transaction.mode === TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE
+  );
+}
+
 /**
  * Workaround for useBridgeTransaction.setAccount preserving the previous mode and only patching subAccountId.
  * Switching between main/sub-account can leave a native mode on a token tx (or vice versa).


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR introduces a `customSendFlow` extension point that lets coin families inject custom screens, navigation logic, and UI components into the shared mobile send flow without modifying generic screens. 

It also implements the Aleo-specific send flow skeleton on top of it: 
- send flow entrypoint is balance-selection screen (user must to be able to choose public vs private send/self transfer)
- for private transactions, there must be a mandatory-private-sync screen that fires between recipient entry and the amount screen
- added extension point for "self transfer" button in Assets details view, using `getAdditionalAssetActions`
- added extension point for "quick amount selector" in Amount step with AfterAmountInput
- added extension point for "private" and "public" badges in Summary step

Also:
- fixes a pre-existing bug where getExtraSendActionParams was incorrectly checked in place of getExtraReceiveActionParams in useAccountActions
- deduplicates isPrivateDestination into @ledgerhq/live-common.

Following screen recording shows: 
- Aleo asset view with custom "Self transfer" button linking to balance-selection screen
- Aleo asset view with "Send" button linking to balance-selection screen
- Aleo account view with "Self transfer" and "Send buttons"
- Linking between balance-selection and different screens based on `private` or `public` selection, respecting `isSelfTransfer` param that should skip "select recipient" step
- Unaffected Ethereum account view

https://drive.google.com/file/d/1oUtAw8nRqS3JqS-0QIUAXNRG0K4a8Ihh/view?usp=sharing

Summary step, just to ensure that lack of badge doesn't break anything:


|  <img width="400" height="900" alt="summary-view-without-badges" src="https://github.com/user-attachments/assets/bf9cdaaa-638b-4a89-b311-2ff473d90077" />  |
|---|

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->


### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-30502
