### PR TITLE
[LWDM] fix(format): fix oxfmt violations in coin-tezos and aleo

### DIFF
--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
@@ -1196,7 +1196,9 @@ describe("staking operations", () => {
 describe("origination operations", () => {
   it("produces a BlockTransaction with ledgerOpType ORIGINATION and zero amount for zero-balance origination", async () => {
     mockGetBlockByLevel.mockResolvedValue(makeBlock());
-    mockFetchBlockOriginations.mockResolvedValue([makeOrigination({ contractBalance: 0, counter: 42, gasLimit: 3494, storageLimit: 5852 })]);
+    mockFetchBlockOriginations.mockResolvedValue([
+      makeOrigination({ contractBalance: 0, counter: 42, gasLimit: 3494, storageLimit: 5852 }),
+    ]);
 
     const result = await getBlock(5_000_000);
 
@@ -1211,7 +1213,13 @@ describe("origination operations", () => {
       type: "other",
       address: "tz1Deployer",
       amount: 0n,
-      details: { ledgerOpType: "ORIGINATION", counter: 42, gasLimit: 3494, storageLimit: 5852, originatedContract: "KT1NewContract" },
+      details: {
+        ledgerOpType: "ORIGINATION",
+        counter: 42,
+        gasLimit: 3494,
+        storageLimit: 5852,
+        originatedContract: "KT1NewContract",
+      },
     });
   });
 
@@ -1233,9 +1241,7 @@ describe("origination operations", () => {
 
   it("treats negative contractBalance as zero (defensive guard)", async () => {
     mockGetBlockByLevel.mockResolvedValue(makeBlock());
-    mockFetchBlockOriginations.mockResolvedValue([
-      makeOrigination({ contractBalance: -500 }),
-    ]);
+    mockFetchBlockOriginations.mockResolvedValue([makeOrigination({ contractBalance: -500 })]);
 
     const result = await getBlock(5_000_000);
 

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
@@ -534,17 +534,25 @@ export async function getBlock(height: number): Promise<Block> {
     throw new Error(`getBlock: height must be a positive integer, got ${height}`);
   }
 
-  const [block, parentBlock, transactions, tokenTransfers, delegations, stakings, originations, reveals] =
-    await Promise.all([
-      tzkt.getBlockByLevel(height),
-      tzkt.getBlockByLevel(height - 1),
-      fetchBlockTransactions(height),
-      fetchBlockTokenTransfers(height),
-      fetchBlockDelegations(height),
-      fetchBlockStaking(height),
-      fetchBlockOriginations(height),
-      fetchBlockReveals(height),
-    ]);
+  const [
+    block,
+    parentBlock,
+    transactions,
+    tokenTransfers,
+    delegations,
+    stakings,
+    originations,
+    reveals,
+  ] = await Promise.all([
+    tzkt.getBlockByLevel(height),
+    tzkt.getBlockByLevel(height - 1),
+    fetchBlockTransactions(height),
+    fetchBlockTokenTransfers(height),
+    fetchBlockDelegations(height),
+    fetchBlockStaking(height),
+    fetchBlockOriginations(height),
+    fetchBlockReveals(height),
+  ]);
 
   // Token transfers triggered by originations from other blocks carry an
   // `originationId` that points outside this block's origination set. Resolve

--- a/libs/ledger-live-common/src/families/aleo/react.test.ts
+++ b/libs/ledger-live-common/src/families/aleo/react.test.ts
@@ -256,7 +256,10 @@ const updateAccountWithUpdater = jest.fn((accountId: string, updater: (a: Accoun
 }));
 
 const useTestAleoPrivateSync = (
-  options: Omit<Parameters<typeof useAleoPrivateSync>[0], "accountSelector" | "updateAccountWithUpdater">,
+  options: Omit<
+    Parameters<typeof useAleoPrivateSync>[0],
+    "accountSelector" | "updateAccountWithUpdater"
+  >,
 ) => useAleoPrivateSync({ ...options, accountSelector, updateAccountWithUpdater });
 
 function renderAleoPrivateSync<Props = void>(
@@ -275,11 +278,7 @@ function renderAleoPrivateSync<Props = void>(
     store,
     ...renderHook(hook, {
       wrapper: ({ children }: { children: React.ReactNode }) =>
-        React.createElement(
-          Provider,
-          { store } as React.ComponentProps<typeof Provider>,
-          children,
-        ),
+        React.createElement(Provider, { store } as React.ComponentProps<typeof Provider>, children),
       initialProps,
     }),
   };
@@ -308,7 +307,9 @@ describe("useAleoPrivateSync", () => {
     });
 
     it("should have isSyncing as false and progress as 0 initially", () => {
-      const { result } = renderAleoPrivateSync(() => useTestAleoPrivateSync({ account: makeAleoAccount() }));
+      const { result } = renderAleoPrivateSync(() =>
+        useTestAleoPrivateSync({ account: makeAleoAccount() }),
+      );
 
       expect(result.current.isSyncing).toBe(false);
       expect(result.current.progress).toBe(0);
@@ -316,7 +317,9 @@ describe("useAleoPrivateSync", () => {
     });
 
     it("should call sync and set isSyncing to true when start() is called", async () => {
-      const { result } = renderAleoPrivateSync(() => useTestAleoPrivateSync({ account: makeAleoAccount() }));
+      const { result } = renderAleoPrivateSync(() =>
+        useTestAleoPrivateSync({ account: makeAleoAccount() }),
+      );
 
       await act(async () => {
         result.current.start();
@@ -327,7 +330,9 @@ describe("useAleoPrivateSync", () => {
     });
 
     it("should set progress to 100 when next is emitted from the bridge observable", async () => {
-      const { result } = renderAleoPrivateSync(() => useTestAleoPrivateSync({ account: makeAleoAccount() }));
+      const { result } = renderAleoPrivateSync(() =>
+        useTestAleoPrivateSync({ account: makeAleoAccount() }),
+      );
 
       await act(async () => {
         result.current.start();
@@ -358,7 +363,9 @@ describe("useAleoPrivateSync", () => {
     });
 
     it("should set error and stop syncing when the observable errors", async () => {
-      const { result } = renderAleoPrivateSync(() => useTestAleoPrivateSync({ account: makeAleoAccount() }));
+      const { result } = renderAleoPrivateSync(() =>
+        useTestAleoPrivateSync({ account: makeAleoAccount() }),
+      );
 
       await act(async () => {
         result.current.start();
@@ -373,7 +380,9 @@ describe("useAleoPrivateSync", () => {
     });
 
     it("should clear error when start() is called again after an error", async () => {
-      const { result } = renderAleoPrivateSync(() => useTestAleoPrivateSync({ account: makeAleoAccount() }));
+      const { result } = renderAleoPrivateSync(() =>
+        useTestAleoPrivateSync({ account: makeAleoAccount() }),
+      );
 
       await act(async () => {
         result.current.start();
@@ -396,7 +405,9 @@ describe("useAleoPrivateSync", () => {
     });
 
     it("should set isSyncing to false when stop() is called", async () => {
-      const { result } = renderAleoPrivateSync(() => useTestAleoPrivateSync({ account: makeAleoAccount() }));
+      const { result } = renderAleoPrivateSync(() =>
+        useTestAleoPrivateSync({ account: makeAleoAccount() }),
+      );
 
       await act(async () => {
         result.current.start();
@@ -410,7 +421,9 @@ describe("useAleoPrivateSync", () => {
     });
 
     it("should set isSyncing to false when complete fires with synced=true", async () => {
-      const { result } = renderAleoPrivateSync(() => useTestAleoPrivateSync({ account: makeAleoAccount() }));
+      const { result } = renderAleoPrivateSync(() =>
+        useTestAleoPrivateSync({ account: makeAleoAccount() }),
+      );
 
       await act(async () => {
         result.current.start();
@@ -433,7 +446,9 @@ describe("useAleoPrivateSync", () => {
         .mockReturnValueOnce(firstSubject.asObservable())
         .mockReturnValueOnce(secondSubject.asObservable());
 
-      const { result } = renderAleoPrivateSync(() => useTestAleoPrivateSync({ account: makeAleoAccount() }));
+      const { result } = renderAleoPrivateSync(() =>
+        useTestAleoPrivateSync({ account: makeAleoAccount() }),
+      );
 
       act(() => {
         result.current.start();
@@ -471,7 +486,9 @@ describe("useAleoPrivateSync", () => {
         .mockReturnValueOnce(firstSubject.asObservable())
         .mockReturnValueOnce(secondSubject.asObservable());
 
-      const { result } = renderAleoPrivateSync(() => useTestAleoPrivateSync({ account: makeAleoAccount() }));
+      const { result } = renderAleoPrivateSync(() =>
+        useTestAleoPrivateSync({ account: makeAleoAccount() }),
+      );
 
       act(() => {
         result.current.start();
@@ -500,7 +517,9 @@ describe("useAleoPrivateSync", () => {
 
     it("should not retry when stop() is called before complete fires", async () => {
       jest.useFakeTimers();
-      const { result } = renderAleoPrivateSync(() => useTestAleoPrivateSync({ account: makeAleoAccount() }));
+      const { result } = renderAleoPrivateSync(() =>
+        useTestAleoPrivateSync({ account: makeAleoAccount() }),
+      );
 
       act(() => {
         result.current.start();
@@ -522,7 +541,9 @@ describe("useAleoPrivateSync", () => {
 
     it("should not call sync for a non-Aleo account", async () => {
       const nonAleoAccount = genAccount("btc-1", { currency: getCryptoCurrencyById("bitcoin") });
-      const { result } = renderAleoPrivateSync(() => useTestAleoPrivateSync({ account: nonAleoAccount }));
+      const { result } = renderAleoPrivateSync(() =>
+        useTestAleoPrivateSync({ account: nonAleoAccount }),
+      );
 
       await act(async () => {
         result.current.start();
@@ -557,7 +578,9 @@ describe("useAleoPrivateSync", () => {
 
   describe("autoStart: true", () => {
     it("should call sync immediately on mount", async () => {
-      renderAleoPrivateSync(() => useTestAleoPrivateSync({ account: makeAleoAccount(), autoStart: true }));
+      renderAleoPrivateSync(() =>
+        useTestAleoPrivateSync({ account: makeAleoAccount(), autoStart: true }),
+      );
       await Promise.resolve(); // flush from(Promise.resolve(bridge)) microtask
 
       expect(mockSync).toHaveBeenCalledTimes(1);
@@ -629,7 +652,9 @@ describe("useAleoPrivateSync", () => {
 
     it("should not call onAccountUpdated when not provided", async () => {
       // No onAccountUpdated — just confirm it doesn't throw and progress reaches 100
-      const { result } = renderAleoPrivateSync(() => useTestAleoPrivateSync({ account: makeAleoAccount() }));
+      const { result } = renderAleoPrivateSync(() =>
+        useTestAleoPrivateSync({ account: makeAleoAccount() }),
+      );
 
       await act(async () => {
         result.current.start();
@@ -748,7 +773,9 @@ describe("useAleoPrivateSync", () => {
         .mockReturnValueOnce(firstSubject.asObservable())
         .mockReturnValueOnce(secondSubject.asObservable());
 
-      const { result } = renderAleoPrivateSync(() => useTestAleoPrivateSync({ account: makeAleoAccount() }));
+      const { result } = renderAleoPrivateSync(() =>
+        useTestAleoPrivateSync({ account: makeAleoAccount() }),
+      );
 
       await act(async () => {
         result.current.start();
@@ -772,7 +799,9 @@ describe("useAleoPrivateSync", () => {
     });
 
     it("should clear a previous error when start() is called while an error is set", async () => {
-      const { result } = renderAleoPrivateSync(() => useTestAleoPrivateSync({ account: makeAleoAccount() }));
+      const { result } = renderAleoPrivateSync(() =>
+        useTestAleoPrivateSync({ account: makeAleoAccount() }),
+      );
 
       await act(async () => {
         result.current.start();
@@ -797,7 +826,9 @@ describe("useAleoPrivateSync", () => {
 
   describe("dispatch behaviour", () => {
     it("should dispatch updateAccountWithUpdater on each sync emission", async () => {
-      const { result } = renderAleoPrivateSync(() => useTestAleoPrivateSync({ account: makeAleoAccount() }));
+      const { result } = renderAleoPrivateSync(() =>
+        useTestAleoPrivateSync({ account: makeAleoAccount() }),
+      );
 
       await act(async () => {
         result.current.start();
@@ -815,7 +846,9 @@ describe("useAleoPrivateSync", () => {
     });
 
     it("should dispatch once per emission when multiple next values arrive", async () => {
-      const { result } = renderAleoPrivateSync(() => useTestAleoPrivateSync({ account: makeAleoAccount() }));
+      const { result } = renderAleoPrivateSync(() =>
+        useTestAleoPrivateSync({ account: makeAleoAccount() }),
+      );
 
       await act(async () => {
         result.current.start();


### PR DESCRIPTION
> [!NOTE]
> Format-only change. No logic touched.

### 📝 Description

Fixes oxfmt violations that slipped through CI in two libs:

- libs/coin-modules/coin-tezos/src/logic/getBlock.ts — long destructuring array in Promise.all
- libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts — long inline mock args
- libs/ledger-live-common/src/families/aleo/react.test.ts — long Omit type and renderAleoPrivateSync calls

Root cause: the format:check step in test-libs-reusable.yml has continue-on-error: true,
so it never blocks a merge even when it fails. PRs #19225 (coin-tezos) and #19256 (aleo)
both merged with failing format checks because of this.

### 🔗 Context

- **JIRA / GitHub issue**: N/A
- **ADR** (if any): N/A