### PR TITLE
ci(libs): make format:check mandatory on develop, skip on release branches

### DIFF
--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -165,10 +165,7 @@ jobs:
         run: pnpm i
       - name: Check formatting of affected libraries
         id: format-check-libs
-        # TODO(LIVE-31553): remove continue-on-error once the release cycle has
-        # the format:check scripts on HEAD (~2 weeks). format:check does not yet
-        # exist on release branches, so keep this non-blocking to not break release.
-        continue-on-error: true
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop'
         run: pnpm exec nx run-many -t format:check --exclude=ledger-live-desktop,live-mobile,@ledgerhq/live-cli,@ledgerhq/web-tools,ledger-live-desktop-e2e-tests,ledger-live-mobile-e2e-tests --parallel=3 --nxBail=false
       - name: Lint affected libraries
         id: lint-libs


### PR DESCRIPTION
> [!NOTE]
> Completes #19210 which missed test-libs-reusable.yml.

### 📝 Description

#19210 replaced continue-on-error: true on format:check steps across 7 workflows but missed test-libs-reusable.yml — the one that covers coin-modules and ledger-live-common. This left a gap where PRs could merge into develop with oxfmt violations (e.g. #19225, #19256).

Applies the same pattern: skip the step on release branches (which don't have the format:check script) and let it fail-hard when targeting develop.

### 🔗 Context

- **JIRA / GitHub issue**: LIVE-31553
- **ADR** (if any): N/A