### PR TITLE
[LWM] feat(LIVE-30500): aleo mobile no accounts added screen

### DIFF
--- a/.changeset/silly-dancers-fix.md
+++ b/.changeset/silly-dancers-fix.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add a "No Accounts Added" screen to the Aleo mobile add-account flow, shown when view-key approval resolves zero accounts to add

--- a/.changeset/tame-keys-fold.md
+++ b/.changeset/tame-keys-fold.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add Aleo view key approve screen and extend custom add-account flow API with onImportAccounts, onScanDeviceAccountsBack, and per-family CTA label support

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -425,6 +425,7 @@ export enum ScreenName {
   AleoAddAccount = "AleoAddAccount",
   AleoViewKeyWarning = "AleoViewKeyWarning",
   AleoViewKeyApprove = "AleoViewKeyApprove",
+  AleoNoAccountsAdded = "AleoNoAccountsAdded",
 
   OnboardingWelcome = "OnboardingWelcome",
   OnboardingPostWelcomeSelection = "OnboardingPostWelcomeSelection",

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -424,6 +424,7 @@ export enum ScreenName {
   // Aleo
   AleoAddAccount = "AleoAddAccount",
   AleoViewKeyWarning = "AleoViewKeyWarning",
+  AleoViewKeyApprove = "AleoViewKeyApprove",
 
   OnboardingWelcome = "OnboardingWelcome",
   OnboardingPostWelcomeSelection = "OnboardingPostWelcomeSelection",

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/AddAccountNavigator.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/AddAccountNavigator.tsx
@@ -14,6 +14,7 @@ import { ScreenName } from "~/const";
 import { AleoAddAccountParamList, AleoViewKeyFlowParamList } from "./types";
 import ViewKeyWarningScreen from "./ViewKeyWarningScreen";
 import ViewKeyApproveScreen from "./ViewKeyApproveScreen";
+import NoAccountsAddedScreen from "./NoAccountsAddedScreen";
 
 type Props = StackNavigatorProps<AleoAddAccountParamList, ScreenName.AleoAddAccount>;
 
@@ -70,6 +71,8 @@ function AddAccountNavigator({ route, navigation }: Readonly<Props>) {
 
   const renderHeaderRight = useCallback(() => <HeaderRight onClose={handleClose} />, [handleClose]);
 
+  const { accountsToAdd: _, ...viewKeyWarningParams } = route.params;
+
   return (
     <Stack.Navigator
       initialRouteName={initialRouteName}
@@ -83,7 +86,7 @@ function AddAccountNavigator({ route, navigation }: Readonly<Props>) {
       <Stack.Screen
         name={ScreenName.AleoViewKeyWarning}
         component={ViewKeyWarningScreen}
-        initialParams={{ ...route.params, onCloseNavigation: handleClose }}
+        initialParams={{ ...viewKeyWarningParams, onCloseNavigation: handleClose }}
         options={{ headerTitle: "" }}
       />
       <Stack.Screen
@@ -91,6 +94,12 @@ function AddAccountNavigator({ route, navigation }: Readonly<Props>) {
         component={ViewKeyApproveScreen}
         initialParams={{ ...route.params, onCloseNavigation: handleClose }}
         options={{ headerTitle: "" }}
+      />
+      <Stack.Screen
+        name={ScreenName.AleoNoAccountsAdded}
+        component={NoAccountsAddedScreen}
+        initialParams={{ ...route.params, onCloseNavigation: handleClose }}
+        options={{ headerTitle: "", headerLeft: () => null }}
       />
     </Stack.Navigator>
   );

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/AddAccountNavigator.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/AddAccountNavigator.tsx
@@ -13,6 +13,7 @@ import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/typ
 import { ScreenName } from "~/const";
 import { AleoAddAccountParamList, AleoViewKeyFlowParamList } from "./types";
 import ViewKeyWarningScreen from "./ViewKeyWarningScreen";
+import ViewKeyApproveScreen from "./ViewKeyApproveScreen";
 
 type Props = StackNavigatorProps<AleoAddAccountParamList, ScreenName.AleoAddAccount>;
 
@@ -52,7 +53,15 @@ function HeaderRight({ onClose }: Readonly<HeaderRightProps>) {
 function AddAccountNavigator({ route, navigation }: Readonly<Props>) {
   const { colors } = useTheme();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, false), [colors]);
-  const initialRouteName = ScreenName.AleoViewKeyWarning;
+  // AleoViewKeyApprove requires a non-empty accountsToAdd; fall back to the warning screen
+  // rather than letting ViewKeyApproveScreen mount with an invalid navigation state.
+  const hasAccountsToAdd = Array.isArray(route.params.accountsToAdd)
+    ? route.params.accountsToAdd.length > 0
+    : false;
+  const initialRouteName =
+    route.params.initialRouteName === ScreenName.AleoViewKeyApprove && !hasAccountsToAdd
+      ? ScreenName.AleoViewKeyWarning
+      : (route.params.initialRouteName ?? ScreenName.AleoViewKeyWarning);
   const navigationDepth = route.params.navigationDepth;
   const handleClose = useCallback(() => {
     const parent = navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>();
@@ -74,6 +83,12 @@ function AddAccountNavigator({ route, navigation }: Readonly<Props>) {
       <Stack.Screen
         name={ScreenName.AleoViewKeyWarning}
         component={ViewKeyWarningScreen}
+        initialParams={{ ...route.params, onCloseNavigation: handleClose }}
+        options={{ headerTitle: "" }}
+      />
+      <Stack.Screen
+        name={ScreenName.AleoViewKeyApprove}
+        component={ViewKeyApproveScreen}
         initialParams={{ ...route.params, onCloseNavigation: handleClose }}
         options={{ headerTitle: "" }}
       />

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/NoAccountsAddedScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/NoAccountsAddedScreen.tsx
@@ -1,0 +1,91 @@
+import React, { useCallback } from "react";
+import { StyleSheet } from "react-native";
+import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import { WarningFill } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTheme } from "styled-components/native";
+import { ScreenName } from "~/const";
+import SafeAreaView from "~/components/SafeAreaView";
+import CloseWithConfirmation from "LLM/components/CloseWithConfirmation";
+import VerticalGradientBackground from "LLM/features/Accounts/components/VerticalGradientBackground";
+import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import { Trans, useTranslation } from "~/context/Locale";
+import { TrackScreen } from "~/analytics";
+import type { AleoViewKeyFlowParamList } from "./types";
+
+type Props = StackNavigatorProps<AleoViewKeyFlowParamList, ScreenName.AleoNoAccountsAdded>;
+
+export default function NoAccountsAddedScreen({ route }: Props) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const { currency, onCloseNavigation } = route.params;
+  const statusColor = colors.warning.c70;
+
+  const handleClose = useCallback(() => {
+    onCloseNavigation?.();
+  }, [onCloseNavigation]);
+
+  return (
+    <SafeAreaView edges={["left", "right", "bottom", "top"]} isFlex>
+      <TrackScreen category="AleoAddAccountFlow" name="No accounts added" />
+      <VerticalGradientBackground stopColor={statusColor} />
+      <Box lx={{ backgroundColor: "warning", marginTop: "s96" }} style={styles.iconWrapper}>
+        <WarningFill size={40} color="warning" />
+      </Box>
+      <Box
+        lx={{ alignItems: "center", justifyContent: "flex-start", paddingHorizontal: "s20" }}
+        style={styles.textContainer}
+      >
+        <Text style={styles.title} lx={{ color: "base" }}>
+          <Trans
+            i18nKey="aleo.addAccount.stepNoAccountsAdded.title"
+            values={{ currency: currency.name }}
+          />
+        </Text>
+        <Text style={styles.desc} lx={{ color: "muted" }}>
+          <Trans i18nKey="aleo.addAccount.stepNoAccountsAdded.description" />
+        </Text>
+      </Box>
+      <Box lx={{ paddingHorizontal: "s16", rowGap: "s16" }}>
+        <CloseWithConfirmation
+          showButton
+          buttonText={t("addAccounts.addAccountsSuccess.ctaClose")}
+          onClose={handleClose}
+        />
+      </Box>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  title: {
+    marginTop: 32,
+    fontSize: 24,
+    textAlign: "center",
+    width: "100%",
+    fontWeight: "600",
+    fontStyle: "normal",
+    lineHeight: 32.4,
+    letterSpacing: 0.75,
+  },
+  desc: {
+    marginTop: 16,
+    marginBottom: 32,
+    fontSize: 14,
+    width: "100%",
+    lineHeight: 23.8,
+    fontWeight: "500",
+    textAlign: "center",
+    alignSelf: "stretch",
+  },
+  iconWrapper: {
+    height: 72,
+    width: 72,
+    borderRadius: 50,
+    alignItems: "center",
+    justifyContent: "center",
+    alignSelf: "center",
+  },
+  textContainer: {
+    flex: 1,
+  },
+});

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyApproveScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyApproveScreen.tsx
@@ -1,0 +1,296 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { ScrollView, StyleSheet } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
+import { Banner, Box, Spinner, Text } from "@ledgerhq/lumen-ui-rnative";
+import { Check, Close, Refresh } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { Account } from "@ledgerhq/types-live";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { useTheme } from "styled-components/native";
+import {
+  useAleoViewKeyApproval,
+  buildAccountsWithViewKeys,
+} from "@ledgerhq/live-common/families/aleo/react";
+import { addAccountsAction } from "@ledgerhq/live-wallet/addAccounts";
+import { ScreenName } from "~/const";
+import { Loading } from "~/components/Loading";
+import Animation from "~/components/Animation";
+import Button from "~/components/wrappedUi/Button";
+import { DeviceActionDefaultRendering } from "~/components/DeviceAction";
+import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import { Trans, useTranslation } from "~/context/Locale";
+import { getDeviceAnimation, getDeviceAnimationStyles } from "~/helpers/getDeviceAnimation";
+import { useAccountName } from "~/reducers/wallet";
+import { useSelector, useDispatch } from "~/context/hooks";
+import { accountsSelector } from "~/reducers/accounts";
+import type { AleoViewKeyFlowParamList } from "./types";
+
+type Props = StackNavigatorProps<AleoViewKeyFlowParamList, ScreenName.AleoViewKeyApprove>;
+
+function AccountStatusLabel({
+  account,
+  fallbackLabel,
+}: Readonly<{
+  account: Account;
+  fallbackLabel: string;
+}>) {
+  const accountName = useAccountName(account);
+  return (
+    <Text
+      typography="body2"
+      numberOfLines={1}
+      style={styles.accountLabel}
+      lx={{ color: "muted" }}
+    >
+      {accountName || fallbackLabel}
+    </Text>
+  );
+}
+
+export default function ViewKeyApproveScreen({ route, navigation }: Props) {
+  const { colors, theme } = useTheme();
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const existingAccounts = useSelector(accountsSelector);
+  const abortedRef = useRef(false);
+  const insets = useSafeAreaInsets();
+
+  const {
+    accountsToAdd: allAccountsToAdd,
+    currency,
+    device,
+    onCloseNavigation,
+    onSuccess,
+    context,
+  } = route.params;
+
+  const cryptoCurrency =
+    currency.type === "CryptoCurrency"
+      ? currency
+      : getCryptoCurrencyById(currency.parentCurrencyId);
+
+  // Freeze the device-request list on mount: existingAccounts (a live Redux selector) can
+  // get a new reference from background sync, and useAleoViewKeyApproval keys its device
+  // transport subscription off selectedAccounts by reference, not content — recomputing it
+  // mid-approval would tear down the subscription without restarting it.
+  const [accountsToAdd] = useState(() => {
+    const existingAddresses = new Set(existingAccounts.map(a => a.freshAddress));
+    return allAccountsToAdd.filter(a => !existingAddresses.has(a.freshAddress));
+  });
+
+  const hasAccountsToAdd = accountsToAdd.length > 0;
+
+  // getViewKeyExec requires at least one selected account, so if every incoming account
+  // was already imported, keep the device action from starting by passing device: null.
+  const { hookState, payload, request, confirmedAccountIds, rejectedAccountIds } =
+    useAleoViewKeyApproval({
+      device: hasAccountsToAdd ? device : null,
+      selectedAccounts: accountsToAdd,
+      currency: cryptoCurrency,
+    });
+
+  useEffect(() => {
+    if (!hasAccountsToAdd) {
+      onCloseNavigation?.();
+    }
+  }, [hasAccountsToAdd, onCloseNavigation]);
+
+  const onResult = useCallback(() => {
+    if (abortedRef.current) return;
+    if (!payload) return;
+    const accountsWithViewKeys = buildAccountsWithViewKeys(accountsToAdd, payload);
+
+    if (accountsWithViewKeys.length === 0) {
+      onCloseNavigation?.();
+      return;
+    }
+
+    dispatch(
+      addAccountsAction({
+        existingAccounts,
+        scannedAccounts: accountsWithViewKeys,
+        selectedIds: accountsWithViewKeys.map(a => a.id),
+        renamings: {},
+      }),
+    );
+
+    onSuccess?.({
+      scannedAccounts: accountsWithViewKeys,
+      selected: accountsWithViewKeys,
+    });
+
+    // Deliberately omit onCloseNavigation here: it's this screen's own `handleClose`
+    // (which pops the Aleo sub-navigator), and forwarding it would override
+    // AddAccountsSuccess's own initialParams.onCloseNavigation, causing a duplicate
+    // pop against an already-popped stack (see AddAccountNavigator.tsx handleClose).
+    navigation.getParent()?.navigate(ScreenName.AddAccountsSuccess, {
+      currency,
+      accountsToAdd: accountsWithViewKeys,
+      context,
+    });
+  }, [
+    payload,
+    accountsToAdd,
+    existingAccounts,
+    dispatch,
+    navigation,
+    currency,
+    onCloseNavigation,
+    onSuccess,
+    context,
+  ]);
+
+  const getAccountStatusIcon = useCallback(
+    (index: number, accountId: string) => {
+      if (index === hookState.shareProgress.completed && hookState.sharePending) {
+        return <Spinner size={16} />;
+      }
+      if (confirmedAccountIds.has(accountId)) {
+        return <Check size={16} color="muted" />;
+      }
+      if (rejectedAccountIds.has(accountId)) {
+        return <Close size={16} color="muted" />;
+      }
+      return <Refresh size={16} color="muted" />;
+    },
+    [
+      confirmedAccountIds,
+      hookState.sharePending,
+      hookState.shareProgress.completed,
+      rejectedAccountIds,
+    ],
+  );
+
+  const onCancel = useCallback(() => {
+    abortedRef.current = true;
+    onCloseNavigation?.();
+  }, [onCloseNavigation]);
+
+  const renderApprovalContent = () => {
+    if (hookState.sharePending) {
+      return (
+        <Box style={[styles.overlay, { backgroundColor: colors.background.main }]}>
+          <ScrollView style={styles.list} contentContainerStyle={styles.contentContainer}>
+            <Box style={styles.animationContainer}>
+              <Animation
+                source={getDeviceAnimation({ modelId: device.modelId, key: "verify", theme })}
+                style={getDeviceAnimationStyles(device.modelId)}
+              />
+            </Box>
+            <Text typography="heading3SemiBold" style={styles.title} lx={{ color: "base" }}>
+              <Trans i18nKey="aleo.addAccount.stepViewKeyApprove.title" />
+            </Text>
+            <Text typography="body2" style={styles.description} lx={{ color: "base" }}>
+              <Trans i18nKey="aleo.addAccount.stepViewKeyApprove.description" />
+            </Text>
+            <Box style={styles.listContent}>
+              {accountsToAdd.map((account, index) => (
+                <Box
+                  style={[styles.row, { backgroundColor: colors.opacityDefault.c05 }]}
+                  key={account.id}
+                >
+                  <AccountStatusLabel account={account} fallbackLabel={account.freshAddress} />
+                  <Box style={styles.statusIcon}>{getAccountStatusIcon(index, account.id)}</Box>
+                </Box>
+              ))}
+            </Box>
+            <Banner
+              appearance="info"
+              description={t("aleo.addAccount.stepViewKeyApprove.cancelAlert")}
+            />
+          </ScrollView>
+          <Box style={[styles.footer, { bottom: insets.bottom + 24 }]}>
+            <Button
+              type="main"
+              outline
+              onPress={onCancel}
+              event="AleoAddAccountViewKeyApproveCancelAll"
+            >
+              {t("aleo.addAccount.stepViewKeyApprove.cancelAllBtn", {
+                count: accountsToAdd.length,
+              })}
+            </Button>
+          </Box>
+        </Box>
+      );
+    }
+
+    if (payload === null) {
+      return null;
+    }
+
+    return <Loading />;
+  };
+
+  return (
+    <SafeAreaView
+      edges={["bottom"]}
+      style={[styles.root, { backgroundColor: colors.background.main }]}
+    >
+      <DeviceActionDefaultRendering
+        status={hookState}
+        request={request}
+        payload={payload}
+        device={device}
+        onResult={onResult}
+      />
+      {renderApprovalContent()}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    paddingTop: 16,
+  },
+  contentContainer: {
+    paddingHorizontal: 16,
+    paddingBottom: 128,
+  },
+  animationContainer: {
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 120,
+    marginBottom: 8,
+  },
+  title: {
+    textAlign: "center",
+  },
+  description: {
+    marginTop: 8,
+    marginBottom: 16,
+    textAlign: "center",
+  },
+  list: {
+    flex: 1,
+  },
+  listContent: {
+    rowGap: 8,
+    marginBottom: 12,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+  },
+  accountLabel: {
+    flex: 1,
+    marginRight: 12,
+  },
+  statusIcon: {
+    width: 20,
+    alignItems: "center",
+  },
+  footer: {
+    position: "absolute",
+    left: 16,
+    right: 16,
+  },
+});

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyApproveScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyApproveScreen.tsx
@@ -23,6 +23,7 @@ import { getDeviceAnimation, getDeviceAnimationStyles } from "~/helpers/getDevic
 import { useAccountName } from "~/reducers/wallet";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { accountsSelector } from "~/reducers/accounts";
+import { TrackScreen } from "~/analytics";
 import type { AleoViewKeyFlowParamList } from "./types";
 
 type Props = StackNavigatorProps<AleoViewKeyFlowParamList, ScreenName.AleoViewKeyApprove>;
@@ -36,12 +37,7 @@ function AccountStatusLabel({
 }>) {
   const accountName = useAccountName(account);
   return (
-    <Text
-      typography="body2"
-      numberOfLines={1}
-      style={styles.accountLabel}
-      lx={{ color: "muted" }}
-    >
+    <Text typography="body2" numberOfLines={1} style={styles.accountLabel} lx={{ color: "muted" }}>
       {accountName || fallbackLabel}
     </Text>
   );
@@ -101,7 +97,7 @@ export default function ViewKeyApproveScreen({ route, navigation }: Props) {
     const accountsWithViewKeys = buildAccountsWithViewKeys(accountsToAdd, payload);
 
     if (accountsWithViewKeys.length === 0) {
-      onCloseNavigation?.();
+      navigation.navigate(ScreenName.AleoNoAccountsAdded, route.params);
       return;
     }
 
@@ -134,8 +130,8 @@ export default function ViewKeyApproveScreen({ route, navigation }: Props) {
     existingAccounts,
     dispatch,
     navigation,
+    route.params,
     currency,
-    onCloseNavigation,
     onSuccess,
     context,
   ]);
@@ -227,6 +223,7 @@ export default function ViewKeyApproveScreen({ route, navigation }: Props) {
       edges={["bottom"]}
       style={[styles.root, { backgroundColor: colors.background.main }]}
     >
+      <TrackScreen category="AleoAddAccountFlow" name="View key approve" />
       <DeviceActionDefaultRendering
         status={hookState}
         request={request}

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyWarningScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyWarningScreen.tsx
@@ -11,6 +11,7 @@ import { urls } from "~/utils/urls";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 import type { AleoViewKeyFlowParamList } from "./types";
 import ConfirmationModal from "~/components/ConfirmationModal";
+import { TrackScreen } from "~/analytics";
 
 type Props = StackNavigatorProps<AleoViewKeyFlowParamList, ScreenName.AleoViewKeyWarning>;
 
@@ -67,6 +68,7 @@ export default function ViewKeyWarningScreen({ route, navigation }: Props) {
       edges={["bottom"]}
       style={[styles.root, { backgroundColor: colors.background.main }]}
     >
+      <TrackScreen category="AleoAddAccountFlow" name="View key warning" />
       <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         <LText semiBold style={styles.title} color="neutral.c100">
           <Trans i18nKey="aleo.addAccount.stepViewKeyWarning.title" />

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/AddAccountNavigator.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/AddAccountNavigator.test.tsx
@@ -19,6 +19,7 @@ type ScreenProps = {
 // Capture the props that AddAccountNavigator injects into the inner screens.
 let capturedRouteParams: ScreenProps["route"]["params"] | null = null;
 let capturedApproveRouteParams: ScreenProps["route"]["params"] | null = null;
+let capturedNoAccountsAddedRouteParams: ScreenProps["route"]["params"] | null = null;
 
 jest.mock("../ViewKeyWarningScreen", () => {
   return function MockViewKeyWarningScreen({ route }: ScreenProps) {
@@ -30,6 +31,13 @@ jest.mock("../ViewKeyWarningScreen", () => {
 jest.mock("../ViewKeyApproveScreen", () => {
   return function MockViewKeyApproveScreen({ route }: ScreenProps) {
     capturedApproveRouteParams = route.params;
+    return <></>;
+  };
+});
+
+jest.mock("../NoAccountsAddedScreen", () => {
+  return function MockNoAccountsAddedScreen({ route }: ScreenProps) {
+    capturedNoAccountsAddedRouteParams = route.params;
     return <></>;
   };
 });
@@ -80,6 +88,7 @@ describe("AleoAddAccountNavigator", () => {
   beforeEach(() => {
     capturedRouteParams = null;
     capturedApproveRouteParams = null;
+    capturedNoAccountsAddedRouteParams = null;
     mockPop.mockClear();
   });
 
@@ -161,6 +170,27 @@ describe("AleoAddAccountNavigator", () => {
     expect(capturedRouteParams).not.toBeNull();
     expect(capturedApproveRouteParams).toBeNull();
   });
+
+  it("routes to NoAccountsAdded and injects onCloseNavigation when initialRouteName is AleoNoAccountsAdded", () => {
+    const Stack = createNativeStackNavigator<AleoAddAccountParamList>();
+    render(
+      <Stack.Navigator>
+        <Stack.Screen
+          name={ScreenName.AleoAddAccount}
+          component={AddAccountNavigator}
+          initialParams={{
+            currency: aleoCurrency,
+            device: mockDevice,
+            initialRouteName: ScreenName.AleoNoAccountsAdded,
+          }}
+        />
+      </Stack.Navigator>,
+    );
+    expect(capturedNoAccountsAddedRouteParams).not.toBeNull();
+    expect(capturedRouteParams).toBeNull();
+    expect(capturedApproveRouteParams).toBeNull();
+    expect(capturedNoAccountsAddedRouteParams?.onCloseNavigation).toBeInstanceOf(Function);
+  });
 });
 
 describe("AleoAddAccountNavigator — handleClose", () => {
@@ -177,6 +207,7 @@ describe("AleoAddAccountNavigator — handleClose", () => {
       />,
     );
     capturedRouteParams?.onCloseNavigation?.();
+    expect(mockPop).toHaveBeenCalledTimes(1);
     expect(mockPop).toHaveBeenCalledWith(2);
   });
 
@@ -190,6 +221,7 @@ describe("AleoAddAccountNavigator — handleClose", () => {
       />,
     );
     capturedRouteParams?.onCloseNavigation?.();
+    expect(mockPop).toHaveBeenCalledTimes(1);
     expect(mockPop).toHaveBeenCalledWith(4);
   });
 

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/AddAccountNavigator.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/AddAccountNavigator.test.tsx
@@ -5,15 +5,31 @@ import { ScreenName } from "~/const";
 import { component as AddAccountNavigator, options } from "../AddAccountNavigator";
 import type { AleoAddAccountParamList } from "../types";
 import { aleoCurrency } from "../../__mocks__/currency.mock";
+import { ALEO_ACCOUNT_1 } from "../../__mocks__/account.mock";
 
-type ScreenProps = { route: { params: { onCloseNavigation?: () => void } } };
+type ScreenProps = {
+  route: {
+    params: {
+      onCloseNavigation?: () => void;
+      initialRouteName?: ScreenName;
+    };
+  };
+};
 
-// Capture the props that AddAccountNavigator injects into the inner screen.
+// Capture the props that AddAccountNavigator injects into the inner screens.
 let capturedRouteParams: ScreenProps["route"]["params"] | null = null;
+let capturedApproveRouteParams: ScreenProps["route"]["params"] | null = null;
 
 jest.mock("../ViewKeyWarningScreen", () => {
   return function MockViewKeyWarningScreen({ route }: ScreenProps) {
     capturedRouteParams = route.params;
+    return <></>;
+  };
+});
+
+jest.mock("../ViewKeyApproveScreen", () => {
+  return function MockViewKeyApproveScreen({ route }: ScreenProps) {
+    capturedApproveRouteParams = route.params;
     return <></>;
   };
 });
@@ -63,6 +79,7 @@ const makeTestNavigator = (navigationDepth?: number) => {
 describe("AleoAddAccountNavigator", () => {
   beforeEach(() => {
     capturedRouteParams = null;
+    capturedApproveRouteParams = null;
     mockPop.mockClear();
   });
 
@@ -77,6 +94,72 @@ describe("AleoAddAccountNavigator", () => {
   it("injects an onCloseNavigation function into the inner screen's route params", () => {
     render(makeTestNavigator());
     expect(capturedRouteParams?.onCloseNavigation).toBeInstanceOf(Function);
+  });
+
+  it("defaults to the ViewKeyWarning screen when no initialRouteName is provided", () => {
+    render(makeTestNavigator());
+    expect(capturedRouteParams).not.toBeNull();
+    expect(capturedApproveRouteParams).toBeNull();
+  });
+
+  it("routes to ViewKeyApprove and injects onCloseNavigation when initialRouteName is AleoViewKeyApprove with accountsToAdd", () => {
+    const Stack = createNativeStackNavigator<AleoAddAccountParamList>();
+    render(
+      <Stack.Navigator>
+        <Stack.Screen
+          name={ScreenName.AleoAddAccount}
+          component={AddAccountNavigator}
+          initialParams={{
+            currency: aleoCurrency,
+            device: mockDevice,
+            initialRouteName: ScreenName.AleoViewKeyApprove,
+            accountsToAdd: [ALEO_ACCOUNT_1],
+          }}
+        />
+      </Stack.Navigator>,
+    );
+    expect(capturedApproveRouteParams).not.toBeNull();
+    expect(capturedRouteParams).toBeNull();
+    expect(capturedApproveRouteParams?.onCloseNavigation).toBeInstanceOf(Function);
+  });
+
+  it("falls back to ViewKeyWarning when initialRouteName is AleoViewKeyApprove but accountsToAdd is missing", () => {
+    const Stack = createNativeStackNavigator<AleoAddAccountParamList>();
+    render(
+      <Stack.Navigator>
+        <Stack.Screen
+          name={ScreenName.AleoAddAccount}
+          component={AddAccountNavigator}
+          initialParams={{
+            currency: aleoCurrency,
+            device: mockDevice,
+            initialRouteName: ScreenName.AleoViewKeyApprove,
+          }}
+        />
+      </Stack.Navigator>,
+    );
+    expect(capturedRouteParams).not.toBeNull();
+    expect(capturedApproveRouteParams).toBeNull();
+  });
+
+  it("falls back to ViewKeyWarning when initialRouteName is AleoViewKeyApprove but accountsToAdd is empty", () => {
+    const Stack = createNativeStackNavigator<AleoAddAccountParamList>();
+    render(
+      <Stack.Navigator>
+        <Stack.Screen
+          name={ScreenName.AleoAddAccount}
+          component={AddAccountNavigator}
+          initialParams={{
+            currency: aleoCurrency,
+            device: mockDevice,
+            initialRouteName: ScreenName.AleoViewKeyApprove,
+            accountsToAdd: [],
+          }}
+        />
+      </Stack.Navigator>,
+    );
+    expect(capturedRouteParams).not.toBeNull();
+    expect(capturedApproveRouteParams).toBeNull();
   });
 });
 
@@ -108,5 +191,16 @@ describe("AleoAddAccountNavigator — handleClose", () => {
     );
     capturedRouteParams?.onCloseNavigation?.();
     expect(mockPop).toHaveBeenCalledWith(4);
+  });
+
+  it("does not throw when there is no parent navigator to pop", () => {
+    render(
+      <AddAccountNavigator
+        route={{ params: { currency: aleoCurrency, device: mockDevice } } as any}
+        navigation={{ getParent: () => undefined } as any}
+      />,
+    );
+    expect(() => capturedRouteParams?.onCloseNavigation?.()).not.toThrow();
+    expect(mockPop).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/NoAccountsAddedScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/NoAccountsAddedScreen.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { screen, render, fireEvent } from "@tests/test-renderer";
+import NoAccountsAddedScreen from "../NoAccountsAddedScreen";
+import { aleoCurrency } from "../../__mocks__/currency.mock";
+
+let capturedCategory: string | undefined;
+let capturedName: string | undefined;
+jest.mock("~/analytics", () => ({
+  TrackScreen: ({ category, name }: { category: string; name?: string }) => {
+    capturedCategory = category;
+    capturedName = name;
+    return null;
+  },
+}));
+
+jest.mock("LLM/components/CloseWithConfirmation", () => {
+  const { TouchableOpacity, Text } =
+    jest.requireActual<typeof import("react-native")>("react-native");
+  return function MockCloseWithConfirmation({
+    onClose,
+    buttonText,
+  }: {
+    onClose?: () => void;
+    buttonText?: string;
+  }) {
+    return (
+      <TouchableOpacity testID="close-button" onPress={onClose}>
+        <Text>{buttonText}</Text>
+      </TouchableOpacity>
+    );
+  };
+});
+
+const makeMockRoute = (overrides: { onCloseNavigation?: () => void } = {}) => ({
+  params: {
+    currency: aleoCurrency,
+    device: { deviceId: "device-1", modelId: "nanoX", wired: false },
+    context: undefined,
+    onCloseNavigation: overrides.onCloseNavigation,
+  },
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const renderScreen = (routeOverrides: { onCloseNavigation?: () => void } = {}) =>
+  render(
+    <NoAccountsAddedScreen route={makeMockRoute(routeOverrides) as any} navigation={{} as any} />,
+  );
+
+describe("NoAccountsAddedScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedCategory = undefined;
+    capturedName = undefined;
+  });
+
+  it("tracks the screen with the AleoAddAccountFlow category and 'No accounts added' name", () => {
+    renderScreen();
+    expect(capturedCategory).toBe("AleoAddAccountFlow");
+    expect(capturedName).toBe("No accounts added");
+  });
+
+  it("renders the title with the currency name interpolated", () => {
+    renderScreen();
+    expect(screen.getByText("No Aleo accounts were added")).toBeOnTheScreen();
+  });
+
+  it("renders the description", () => {
+    renderScreen();
+    expect(
+      screen.getByText(
+        "You haven't shared view keys for any of the selected accounts. View keys are required to display your private balance in Ledger Wallet.",
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it("renders the close button with the ctaClose translation", () => {
+    renderScreen();
+    expect(screen.getByText("Close")).toBeOnTheScreen();
+  });
+
+  it("calls onCloseNavigation when provided", () => {
+    const onCloseNavigation = jest.fn();
+    renderScreen({ onCloseNavigation });
+
+    fireEvent.press(screen.getByTestId("close-button"));
+
+    expect(onCloseNavigation).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when onCloseNavigation is not provided", () => {
+    renderScreen();
+
+    expect(() => fireEvent.press(screen.getByTestId("close-button"))).not.toThrow();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyApproveScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyApproveScreen.test.tsx
@@ -278,12 +278,15 @@ describe("ViewKeyApproveScreen", () => {
       expect(mockParentNavigate).not.toHaveBeenCalled();
     });
 
-    it("calls onCloseNavigation when buildAccountsWithViewKeys returns empty", () => {
-      const mockOnClose = jest.fn();
+    it("navigates to AleoNoAccountsAdded when buildAccountsWithViewKeys returns empty", () => {
       mockBuildAccountsWithViewKeys.mockReturnValue([]);
-      renderScreen({ payload: {} }, { onCloseNavigation: mockOnClose });
+      renderScreen({ payload: {} });
       capturedOnResult!();
-      expect(mockOnClose).toHaveBeenCalledTimes(1);
+      expect(mockNavigation.navigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        ScreenName.AleoNoAccountsAdded,
+        mockRoute.params,
+      );
       expect(mockDispatch).not.toHaveBeenCalled();
     });
 
@@ -291,7 +294,9 @@ describe("ViewKeyApproveScreen", () => {
       mockBuildAccountsWithViewKeys.mockReturnValue([ACCOUNT_1]);
       renderScreen({ payload: { account1: "vk1" } });
       capturedOnResult!();
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
       expect(mockDispatch).toHaveBeenCalledWith({ type: "ADD_ACCOUNTS" });
+      expect(mockParentNavigate).toHaveBeenCalledTimes(1);
       expect(mockParentNavigate).toHaveBeenCalledWith(
         ScreenName.AddAccountsSuccess,
         expect.objectContaining({

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyApproveScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyApproveScreen.test.tsx
@@ -1,0 +1,304 @@
+import React from "react";
+import { View, Text, TouchableOpacity } from "react-native";
+import { render, screen, fireEvent } from "@tests/test-renderer";
+import type { Account } from "@ledgerhq/types-live";
+import {
+  useAleoViewKeyApproval,
+  buildAccountsWithViewKeys,
+} from "@ledgerhq/live-common/families/aleo/react";
+import ViewKeyApproveScreen from "../ViewKeyApproveScreen";
+import { ScreenName } from "~/const";
+
+type MockViewKeyApprovalReturn = {
+  hookState: {
+    sharePending: boolean;
+    shareProgress: { completed: number; total: number };
+  };
+  payload: Record<string, string | null> | null;
+  request: Record<string, unknown>;
+  confirmedAccountIds: Set<string>;
+  rejectedAccountIds: Set<string>;
+};
+
+const defaultReturn: MockViewKeyApprovalReturn = {
+  hookState: { sharePending: false, shareProgress: { completed: 0, total: 2 } },
+  payload: null,
+  request: {},
+  confirmedAccountIds: new Set(),
+  rejectedAccountIds: new Set(),
+};
+
+let mockViewKeyApprovalReturn: MockViewKeyApprovalReturn = { ...defaultReturn };
+
+jest.mock("@ledgerhq/live-common/families/aleo/react", () => ({
+  useAleoViewKeyApproval: jest.fn(),
+  buildAccountsWithViewKeys: jest.fn(),
+}));
+
+const mockUseAleoViewKeyApproval = jest.mocked(useAleoViewKeyApproval);
+const mockBuildAccountsWithViewKeys = jest.mocked(buildAccountsWithViewKeys);
+
+let capturedOnResult: (() => void) | undefined;
+
+jest.mock("~/components/DeviceAction", () => ({
+  DeviceActionDefaultRendering: jest.fn(({ onResult }: { onResult: () => void }) => {
+    capturedOnResult = onResult;
+    return <View testID="device-action-rendering" />;
+  }),
+}));
+
+jest.mock("~/components/Animation", () => {
+  return () => <View testID="device-animation" />;
+});
+
+jest.mock("~/helpers/getDeviceAnimation", () => ({
+  getDeviceAnimation: jest.fn(() => null),
+  getDeviceAnimationStyles: jest.fn(() => ({})),
+}));
+
+jest.mock("@ledgerhq/lumen-ui-rnative", () => {
+  const actual = jest.requireActual("@ledgerhq/lumen-ui-rnative");
+  return {
+    ...actual,
+    Spinner: () => <View testID="icon-spinner" />,
+    Banner: ({ description }: { description: React.ReactNode }) => (
+      <View testID="banner">{description}</View>
+    ),
+  };
+});
+
+jest.mock("@ledgerhq/lumen-ui-rnative/symbols", () => ({
+  Check: () => <View testID="icon-check" />,
+  Close: () => <View testID="icon-close" />,
+  Refresh: () => <View testID="icon-refresh" />,
+}));
+
+jest.mock("~/components/Loading", () => ({
+  Loading: () => <View testID="loading" />,
+}));
+
+jest.mock("~/components/wrappedUi/Button", () => {
+  return ({
+    children,
+    onPress,
+    event,
+  }: {
+    children: React.ReactNode;
+    onPress: () => void;
+    event: string;
+  }) => (
+    <TouchableOpacity testID={`button-${event}`} onPress={onPress}>
+      <Text>{children}</Text>
+    </TouchableOpacity>
+  );
+});
+
+const mockDispatch = jest.fn();
+
+jest.mock("~/context/hooks", () => ({
+  useSelector: jest.fn(() => []),
+  useDispatch: jest.fn(() => mockDispatch),
+}));
+
+jest.mock("~/reducers/wallet", () => ({
+  ...jest.requireActual("~/reducers/wallet"),
+  useAccountName: jest.fn((account: Account) => account.id),
+}));
+
+jest.mock("@ledgerhq/live-wallet/addAccounts", () => ({
+  addAccountsAction: jest.fn(() => ({ type: "ADD_ACCOUNTS" })),
+}));
+
+const ACCOUNT_1 = { id: "account1", freshAddress: "addr1" } as Account;
+const ACCOUNT_2 = { id: "account2", freshAddress: "addr2" } as Account;
+
+const mockParentNavigate = jest.fn();
+const mockNavigation = {
+  navigate: jest.fn(),
+  getParent: jest.fn(() => ({ navigate: mockParentNavigate })),
+};
+
+const mockRoute = {
+  params: {
+    currency: { type: "CryptoCurrency" as const, id: "aleo" },
+    device: { modelId: "stax", deviceId: "test-device-id" },
+    accountsToAdd: [ACCOUNT_1, ACCOUNT_2],
+    context: undefined,
+    onCloseNavigation: undefined as (() => void) | undefined,
+  },
+  name: ScreenName.AleoViewKeyApprove,
+  key: "test-key",
+};
+
+const renderScreen = (
+  viewKeyOverrides: Partial<MockViewKeyApprovalReturn> = {},
+  routeParamOverrides: Partial<typeof mockRoute.params> = {},
+) => {
+  mockViewKeyApprovalReturn = { ...defaultReturn, ...viewKeyOverrides };
+  mockUseAleoViewKeyApproval.mockReturnValue(mockViewKeyApprovalReturn as never);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return render(
+    <ViewKeyApproveScreen
+      route={{ ...mockRoute, params: { ...mockRoute.params, ...routeParamOverrides } } as any}
+      navigation={mockNavigation as any}
+    />,
+  );
+};
+
+describe("ViewKeyApproveScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedOnResult = undefined;
+    mockBuildAccountsWithViewKeys.mockReturnValue([]);
+    mockViewKeyApprovalReturn = { ...defaultReturn };
+  });
+
+  describe("when sharePending is false", () => {
+    it("renders DeviceActionDefaultRendering without the overlay", () => {
+      renderScreen();
+      expect(screen.getByTestId("device-action-rendering")).toBeTruthy();
+      expect(screen.queryByTestId("device-animation")).toBeNull();
+    });
+  });
+
+  describe("when sharePending is true", () => {
+    it("shows device animation, account names, and cancel button", () => {
+      renderScreen({
+        hookState: { sharePending: true, shareProgress: { completed: 0, total: 2 } },
+      });
+      expect(screen.getByTestId("device-animation")).toBeTruthy();
+      expect(screen.getByText("account1")).toBeTruthy();
+      expect(screen.getByText("account2")).toBeTruthy();
+      expect(screen.getByTestId("button-AleoAddAccountViewKeyApproveCancelAll")).toBeTruthy();
+    });
+
+    describe("account status icons", () => {
+      it("shows checkmark for confirmed account and spinner for current account", () => {
+        renderScreen({
+          hookState: { sharePending: true, shareProgress: { completed: 1, total: 2 } },
+          confirmedAccountIds: new Set(["account1"]),
+        });
+        expect(screen.getByTestId("icon-check")).toBeTruthy();
+        expect(screen.getByTestId("icon-spinner")).toBeTruthy();
+      });
+
+      it("shows X icon for rejected account", () => {
+        renderScreen({
+          hookState: { sharePending: true, shareProgress: { completed: 1, total: 2 } },
+          rejectedAccountIds: new Set(["account1"]),
+        });
+        expect(screen.getByTestId("icon-close")).toBeTruthy();
+        expect(screen.getByTestId("icon-spinner")).toBeTruthy();
+      });
+
+      it("shows refresh icon for accounts not yet processed", () => {
+        renderScreen({
+          hookState: { sharePending: true, shareProgress: { completed: 0, total: 2 } },
+        });
+        expect(screen.getByTestId("icon-spinner")).toBeTruthy();
+        expect(screen.getByTestId("icon-refresh")).toBeTruthy();
+      });
+    });
+  });
+
+  describe("when confirmation is complete (payload is set)", () => {
+    it("shows the full-screen loader instead of the account list", () => {
+      renderScreen({
+        hookState: { sharePending: false, shareProgress: { completed: 2, total: 2 } },
+        payload: { account1: "vk1", account2: "vk2" },
+      });
+
+      expect(screen.getByTestId("loading")).toBeTruthy();
+      expect(screen.queryByTestId("device-animation")).toBeNull();
+      expect(screen.queryByTestId("button-AleoAddAccountViewKeyApproveCancelAll")).toBeNull();
+    });
+  });
+
+  describe("already-imported account filtering", () => {
+    afterEach(() => {
+      const { useSelector } = jest.requireMock("~/context/hooks");
+      useSelector.mockReturnValue([]);
+    });
+
+    it("shows only accounts whose freshAddress is not already in the wallet", () => {
+      const { useSelector } = jest.requireMock("~/context/hooks");
+      useSelector.mockReturnValue([{ id: "existing", freshAddress: "addr1" }]);
+
+      renderScreen({
+        hookState: { sharePending: true, shareProgress: { completed: 0, total: 1 } },
+      });
+
+      expect(screen.getByText("account2")).toBeTruthy();
+      expect(screen.queryByText("account1")).toBeNull();
+    });
+  });
+
+  describe("no accounts remaining after filtering", () => {
+    afterEach(() => {
+      const { useSelector } = jest.requireMock("~/context/hooks");
+      useSelector.mockReturnValue([]);
+    });
+
+    it("does not start the device action and closes the flow", () => {
+      const { useSelector } = jest.requireMock("~/context/hooks");
+      useSelector.mockReturnValue([
+        { id: "existing1", freshAddress: "addr1" },
+        { id: "existing2", freshAddress: "addr2" },
+      ]);
+      const mockOnClose = jest.fn();
+
+      renderScreen({}, { onCloseNavigation: mockOnClose });
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+      expect(mockUseAleoViewKeyApproval).toHaveBeenCalledWith(
+        expect.objectContaining({ device: null, selectedAccounts: [] }),
+      );
+    });
+  });
+
+  describe("cancel button", () => {
+    it("sets abortedRef on cancel so onResult becomes a no-op", () => {
+      renderScreen({
+        hookState: { sharePending: true, shareProgress: { completed: 0, total: 2 } },
+      });
+      fireEvent.press(screen.getByTestId("button-AleoAddAccountViewKeyApproveCancelAll"));
+      capturedOnResult!();
+      expect(mockNavigation.navigate).not.toHaveBeenCalled();
+      expect(mockParentNavigate).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("onResult", () => {
+    it("does nothing when payload is null", () => {
+      renderScreen({ payload: null });
+      capturedOnResult!();
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockParentNavigate).not.toHaveBeenCalled();
+    });
+
+    it("calls onCloseNavigation when buildAccountsWithViewKeys returns empty", () => {
+      const mockOnClose = jest.fn();
+      mockBuildAccountsWithViewKeys.mockReturnValue([]);
+      renderScreen({ payload: {} }, { onCloseNavigation: mockOnClose });
+      capturedOnResult!();
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it("dispatches addAccountsAction and navigates to AddAccountsSuccess", () => {
+      mockBuildAccountsWithViewKeys.mockReturnValue([ACCOUNT_1]);
+      renderScreen({ payload: { account1: "vk1" } });
+      capturedOnResult!();
+      expect(mockDispatch).toHaveBeenCalledWith({ type: "ADD_ACCOUNTS" });
+      expect(mockParentNavigate).toHaveBeenCalledWith(
+        ScreenName.AddAccountsSuccess,
+        expect.objectContaining({
+          currency: expect.anything(),
+          accountsToAdd: [ACCOUNT_1],
+        }),
+      );
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/types.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/types.ts
@@ -15,7 +15,10 @@ export type AleoAddAccountParams = {
   inline?: boolean;
   returnToSwap?: boolean;
   onSuccess?: (res: { scannedAccounts: Account[]; selected: Account[] }) => void;
-  initialRouteName?: ScreenName.AleoViewKeyWarning | ScreenName.AleoViewKeyApprove;
+  initialRouteName?:
+    | ScreenName.AleoViewKeyWarning
+    | ScreenName.AleoViewKeyApprove
+    | ScreenName.AleoNoAccountsAdded;
 };
 
 export type AleoAddAccountParamList = {
@@ -27,4 +30,5 @@ export type AleoViewKeyFlowParamList = {
   [ScreenName.AleoViewKeyApprove]: AleoAddAccountParams & {
     accountsToAdd: Account[];
   };
+  [ScreenName.AleoNoAccountsAdded]: AleoAddAccountParams;
 };

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/types.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/types.ts
@@ -1,22 +1,30 @@
 import type { Account } from "@ledgerhq/types-live";
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Device } from "@ledgerhq/types-devices";
 import { ScreenName } from "~/const";
-import type { CommonParams } from "LLM/features/Accounts/screens/AddAccount/types";
+import type { AddAccountContextType } from "LLM/features/Accounts/screens/AddAccount/types";
 
-export type AleoAddAccountParams = CommonParams & {
+export type AleoAddAccountParams = {
+  currency: CryptoOrTokenCurrency;
   device: Device;
+  context?: AddAccountContextType;
+  sourceScreenName?: string;
+  onCloseNavigation?: () => void;
+  navigationDepth?: number;
+  accountsToAdd?: Account[];
   inline?: boolean;
   returnToSwap?: boolean;
   onSuccess?: (res: { scannedAccounts: Account[]; selected: Account[] }) => void;
+  initialRouteName?: ScreenName.AleoViewKeyWarning | ScreenName.AleoViewKeyApprove;
 };
 
-// Outer navigator screen (AddAccountNavigator itself, mounted in the root stack).
 export type AleoAddAccountParamList = {
   [ScreenName.AleoAddAccount]: AleoAddAccountParams;
 };
 
-// Inner stack created inside AddAccountNavigator — keyed on a different screen name,
-// so it cannot reuse AleoAddAccountParamList directly.
 export type AleoViewKeyFlowParamList = {
-  [ScreenName.AleoViewKeyWarning]: AleoAddAccountParams;
+  [ScreenName.AleoViewKeyWarning]: Omit<AleoAddAccountParams, "accountsToAdd">;
+  [ScreenName.AleoViewKeyApprove]: AleoAddAccountParams & {
+    accountsToAdd: Account[];
+  };
 };

--- a/apps/ledger-live-mobile/src/families/aleo/customAddAccountFlow.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/customAddAccountFlow.ts
@@ -15,4 +15,18 @@ export default {
       },
     });
   },
+  onImportAccounts: ({ navigation, routeParams, accountsToAdd }) => {
+    // Same as onDeviceConnected: omit undefined onCloseNavigation to preserve initialParams.
+    const { onCloseNavigation, ...restParams } = routeParams;
+    navigation.replace(ScreenName.AleoAddAccount, {
+      ...restParams,
+      ...(typeof onCloseNavigation === "function" ? { onCloseNavigation } : {}),
+      accountsToAdd,
+      initialRouteName: ScreenName.AleoViewKeyApprove,
+    });
+  },
+  onScanDeviceAccountsBack: ({ navigation }) => {
+    navigation.goBack();
+  },
+  scanDeviceAccountsCtaI18nKey: "aleo.addAccount.stepScanAccounts.cta.shareViewKeys",
 } satisfies CustomAddAccountFlow;

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10019,6 +10019,18 @@
           "allow": "Allow",
           "cancel": "Cancel"
         }
+      },
+      "stepViewKeyApprove": {
+        "title": "Approve on your Ledger",
+        "description": "Confirm sharing the view key on your device",
+        "cancelAlert": "You can reject individual accounts on your device. Cancelling all will stop adding any accounts to your portfolio.",
+        "cancelAllBtn_one": "Cancel",
+        "cancelAllBtn_other": "Cancel all"
+      },
+      "stepScanAccounts": {
+        "cta": {
+          "shareViewKeys": "Share view keys"
+        }
       }
     },
     "accountActions": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10027,6 +10027,10 @@
         "cancelAllBtn_one": "Cancel",
         "cancelAllBtn_other": "Cancel all"
       },
+      "stepNoAccountsAdded": {
+        "title": "No {{currency}} accounts were added",
+        "description": "You haven't shared view keys for any of the selected accounts. View keys are required to display your private balance in Ledger Wallet."
+      },
       "stepScanAccounts": {
         "cta": {
           "shareViewKeys": "Share view keys"

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/Navigator.tsx
@@ -125,6 +125,7 @@ export default function Navigator() {
         name={ScreenName.AleoAddAccount}
         component={AleoAddAccountNavigator}
         options={{ headerShown: false }}
+        initialParams={{ onCloseNavigation: onClose }}
       />
       <Stack.Screen
         name={ScreenName.AddAccountsSuccess}

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/__tests__/ScanDeviceAccountsCustomFlow.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/__tests__/ScanDeviceAccountsCustomFlow.test.ts
@@ -1,0 +1,139 @@
+import BigNumber from "bignumber.js";
+import { of, EMPTY } from "rxjs";
+import type { Account } from "@ledgerhq/types-live";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { renderHook, waitFor } from "@tests/test-renderer";
+import { setupScanDeviceTests } from "./shared";
+import useScanDeviceAccountsViewModel from "../useScanDeviceAccountsViewModel";
+import { track } from "~/analytics";
+
+const mockOnImportAccounts = jest.fn();
+const mockOnScanDeviceAccountsBack = jest.fn();
+
+jest.mock("LLM/features/Accounts/utils/customAddAccountFlow", () => ({
+  getCustomAddAccountFlow: jest.fn(() => ({
+    onImportAccounts: mockOnImportAccounts,
+    onScanDeviceAccountsBack: mockOnScanDeviceAccountsBack,
+    scanDeviceAccountsCtaI18nKey: "aleo.addAccount.stepScanAccounts.cta.shareViewKeys",
+  })),
+}));
+
+jest.mock("~/analytics", () => ({
+  track: jest.fn(),
+}));
+
+const mockTrack = jest.mocked(track);
+
+const analyticsMetadata = {
+  AccountsFound: {
+    onContinue: { eventName: "button_clicked", payload: { button: "Continue" } },
+  },
+  ScanDeviceAccounts: {
+    onBack: { eventName: "button_clicked", payload: { button: "Back" } },
+  },
+};
+
+const { replace, setRouteParams, setScanObservable, makeDiscoveredEvent, resetSpies } =
+  setupScanDeviceTests();
+
+const createAleoAccount = (overrides?: Partial<Account>): Account => {
+  const balance = overrides?.balance ?? new BigNumber(0);
+  return {
+    type: "Account",
+    id: overrides?.id ?? "js:2:aleo:addr1:aleo",
+    seedIdentifier: "seed",
+    derivationMode: "",
+    index: 0,
+    freshAddress: overrides?.freshAddress ?? "aleo1abc",
+    freshAddressPath: "44/7027",
+    used: overrides?.used ?? false,
+    balance,
+    spendableBalance: balance,
+    creationDate: new Date(),
+    blockHeight: 0,
+    currency: getCryptoCurrencyById("aleo"),
+    operationsCount: 0,
+    operations: [],
+    pendingOperations: [],
+    lastSyncDate: new Date(),
+    balanceHistoryCache: {
+      HOUR: { latestDate: null, balances: [] },
+      DAY: { latestDate: null, balances: [] },
+      WEEK: { latestDate: null, balances: [] },
+    },
+    swapHistory: [],
+    subAccounts: [],
+    ...overrides,
+  };
+};
+
+describe("ScanDeviceAccounts - customAddAccountFlow delegation", () => {
+  beforeEach(() => {
+    resetSpies();
+    mockOnImportAccounts.mockClear();
+    mockOnScanDeviceAccountsBack.mockClear();
+    mockTrack.mockClear();
+    setRouteParams("aleo");
+    setScanObservable(EMPTY);
+  });
+
+  it("delegates to customFlow.onImportAccounts instead of dispatching addAccountsAction", async () => {
+    const aleoAccount = createAleoAccount({ used: true, balance: new BigNumber(1000) });
+    setScanObservable(of(makeDiscoveredEvent(aleoAccount)));
+
+    const { result } = renderHook(() =>
+      useScanDeviceAccountsViewModel({
+        existingAccounts: [],
+        blacklistedTokenIds: [],
+        analyticsMetadata,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.scannedAccounts).toHaveLength(1));
+
+    result.current.onPressAccount(aleoAccount);
+    await waitFor(() => expect(result.current.selectedIds).toContain(aleoAccount.id));
+
+    result.current.importAccounts();
+
+    expect(mockOnImportAccounts).toHaveBeenCalledTimes(1);
+    expect(mockOnImportAccounts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountsToAdd: [aleoAccount],
+      }),
+    );
+    expect(replace).not.toHaveBeenCalled();
+
+    // Delegating to the custom flow must not skip the AccountsFound.onContinue tracking
+    // that the default import path emits.
+    expect(mockTrack).toHaveBeenCalledWith(
+      analyticsMetadata.AccountsFound.onContinue.eventName,
+      analyticsMetadata.AccountsFound.onContinue.payload,
+    );
+    expect(mockTrack.mock.invocationCallOrder[0]).toBeLessThan(
+      mockOnImportAccounts.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("exposes a scanDeviceAccountsBack callback that tracks ScanDeviceAccounts.onBack before delegating to the custom flow handler", async () => {
+    const { result } = renderHook(() =>
+      useScanDeviceAccountsViewModel({
+        existingAccounts: [],
+        blacklistedTokenIds: [],
+        analyticsMetadata,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.scanDeviceAccountsBack).toBeInstanceOf(Function));
+    result.current.scanDeviceAccountsBack?.();
+
+    expect(mockOnScanDeviceAccountsBack).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledWith(
+      analyticsMetadata.ScanDeviceAccounts.onBack.eventName,
+      analyticsMetadata.ScanDeviceAccounts.onBack.payload,
+    );
+    expect(mockTrack.mock.invocationCallOrder[0]).toBeLessThan(
+      mockOnScanDeviceAccountsBack.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/components/ScanDeviceAccountsFooter/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/components/ScanDeviceAccountsFooter/index.tsx
@@ -17,6 +17,7 @@ const ScanDeviceAccountsFooter = ({
   canDone,
   onRetry,
   onDone,
+  confirmI18nKey = "addAccounts.scanDeviceAccounts.confirm",
 }: ScanDeviceAccountsFooterProps) => {
   const { animatedSelectableAccount } = useSelectableAccountAnimation();
 
@@ -49,7 +50,7 @@ const ScanDeviceAccountsFooter = ({
           testID="add-accounts-continue-button"
           event="AddAccountsSelected"
           type="primary"
-          title={<Trans i18nKey="addAccounts.scanDeviceAccounts.confirm" />}
+          title={<Trans i18nKey={confirmI18nKey} />}
           onPress={isDisabled ? undefined : onContinue}
         />
       )}

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/index.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useCallback, useLayoutEffect } from "react";
 import { StyleSheet, View, Pressable } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
+import { NavigationHeaderBackButton } from "~/components/NavigationHeaderBackButton";
 import { useSelector } from "~/context/hooks";
 import { Trans, useTranslation } from "~/context/Locale";
 import Config from "react-native-config";
@@ -20,7 +21,7 @@ import AnimatedGradient from "./components/AnimatedGradient";
 import ScanDeviceAccountsFooter from "./components/ScanDeviceAccountsFooter";
 import AddressTypeTooltip from "./components/AddressTypeTooltip";
 import ScannedAccountsSection from "./components/ScannedAccountsSection";
-import { useRoute } from "@react-navigation/core";
+import { useNavigation, useRoute } from "@react-navigation/core";
 import { ScanDeviceAccountsNavigationProps } from "./types";
 import useAnalytics from "LLM/hooks/useAnalytics";
 
@@ -38,8 +39,17 @@ const StyledPressable = styled(Pressable)`
   column-gap: 12px;
 `;
 
+interface HeaderLeftProps {
+  onPress?: () => void;
+}
+
+function HeaderLeft({ onPress }: Readonly<HeaderLeftProps>) {
+  return <NavigationHeaderBackButton onPress={onPress} />;
+}
+
 function ScanDeviceAccounts() {
   const { colors } = useTheme();
+  const navigation = useNavigation();
 
   const existingAccounts = useSelector(accountsSelector);
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
@@ -72,11 +82,25 @@ function ScanDeviceAccounts() {
     viewAllCreatedAccounts,
     currency,
     returnToSwap,
+    confirmI18nKey,
+    scanDeviceAccountsBack,
   } = useScanDeviceAccountsViewModel({
     existingAccounts,
     blacklistedTokenIds,
     analyticsMetadata,
   });
+
+  const renderHeaderLeft = useCallback(
+    () => <HeaderLeft onPress={scanDeviceAccountsBack} />,
+    [scanDeviceAccountsBack],
+  );
+
+  useLayoutEffect(() => {
+    if (!scanDeviceAccountsBack) return;
+    navigation.setOptions({
+      headerLeft: renderHeaderLeft,
+    });
+  }, [navigation, scanDeviceAccountsBack, renderHeaderLeft]);
 
   const pageTrackingEvent =
     sections?.length === 0
@@ -193,6 +217,7 @@ function ScanDeviceAccounts() {
           onContinue={importAccounts}
           isDisabled={selectedIds.length === 0}
           returnToSwap={returnToSwap}
+          confirmI18nKey={confirmI18nKey}
         />
       )}
       <GenericErrorBottomModal

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/types.ts
@@ -32,4 +32,5 @@ export type ScanDeviceAccountsFooterProps = {
   isDisabled: boolean;
   supportLink?: AddAccountSupportLink;
   returnToSwap?: boolean;
+  confirmI18nKey?: string;
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
@@ -14,6 +14,7 @@ import logger from "~/logger";
 import { NavigatorName, ScreenName } from "~/const";
 import { prepareCurrency } from "~/bridge/cache";
 import noAssociatedAccountsByFamily from "~/generated/NoAssociatedAccounts";
+import { getCustomAddAccountFlow } from "LLM/features/Accounts/utils/customAddAccountFlow";
 import { StackNavigatorNavigation } from "~/components/RootNavigator/types/helpers";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { groupAddAccounts, addAccountsAction } from "@ledgerhq/live-wallet/addAccounts";
@@ -63,6 +64,8 @@ export default function useScanDeviceAccountsViewModel({
     navigationDepth,
     context,
   } = route.params || {};
+
+  const customFlow = getCustomAddAccountFlow(currency);
 
   const newAccountSchemes = useMemo(() => {
     // Find accounts that are (scanned && !existing && !used)
@@ -234,6 +237,18 @@ export default function useScanDeviceAccountsViewModel({
       }
     }
 
+    if (customFlow?.onImportAccounts) {
+      const continueMetadata = analyticsMetadata?.AccountsFound?.onContinue;
+      if (continueMetadata)
+        track(continueMetadata.eventName, {
+          ...continueMetadata.payload,
+        });
+
+      setIsAddinAccounts(true);
+      customFlow.onImportAccounts({ navigation, routeParams: route.params, accountsToAdd });
+      return;
+    }
+
     setIsAddinAccounts(true);
 
     dispatch(
@@ -276,6 +291,7 @@ export default function useScanDeviceAccountsViewModel({
         amount: accountsToAdd.length,
       });
   }, [
+    customFlow,
     currency,
     inline,
     navigation,
@@ -409,6 +425,18 @@ export default function useScanDeviceAccountsViewModel({
     scannedAccounts.length,
     latestScannedAccount,
   ]);
+
+  const scanDeviceAccountsBack = customFlow?.onScanDeviceAccountsBack
+    ? () => {
+        const backMetadata = analyticsMetadata?.ScanDeviceAccounts?.onBack;
+        if (backMetadata)
+          track(backMetadata.eventName, {
+            ...backMetadata.payload,
+          });
+        customFlow.onScanDeviceAccountsBack?.({ navigation });
+      }
+    : undefined;
+
   return {
     alreadyEmptyAccount,
     alreadyEmptyAccountName,
@@ -436,5 +464,7 @@ export default function useScanDeviceAccountsViewModel({
     returnToSwap,
     currency,
     onCloseNavigation,
+    confirmI18nKey: customFlow?.scanDeviceAccountsCtaI18nKey,
+    scanDeviceAccountsBack,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/utils/customAddAccountFlow.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/utils/customAddAccountFlow.ts
@@ -1,18 +1,33 @@
+import type { Account } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import customAddAccountFlowByFamily from "~/generated/customAddAccountFlow";
+import type { ScanDeviceAccountsNavigationProps } from "../screens/ScanDeviceAccounts/types";
 import type {
   DeviceSelectionNavigationProps,
   SelectDeviceRouteParams,
 } from "../../DeviceSelection/types";
 import type { AppResult } from "@ledgerhq/live-common/hw/actions/app";
 
+type ImportAccountsParams = {
+  navigation: ScanDeviceAccountsNavigationProps["navigation"];
+  routeParams: ScanDeviceAccountsNavigationProps["route"]["params"];
+  accountsToAdd: Account[];
+};
+
 type DeviceConnectedParams = {
   navigation: DeviceSelectionNavigationProps["navigation"];
   routeParams: SelectDeviceRouteParams & AppResult;
 };
 
+type ScanBackParams = {
+  navigation: ScanDeviceAccountsNavigationProps["navigation"];
+};
+
 export type CustomAddAccountFlow = {
+  onImportAccounts?: (params: ImportAccountsParams) => void;
   onDeviceConnected?: (params: DeviceConnectedParams) => void;
+  onScanDeviceAccountsBack?: (params: ScanBackParams) => void;
+  scanDeviceAccountsCtaI18nKey?: string;
 };
 
 const isCustomAddAccountFlowFamily = (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - This PR adds a "No Accounts Added" screen to the Aleo mobile add-account flow, shown when view-key approval resolves zero accounts to add.
  
### 📝 Description

Add a "No Accounts Added" screen to the Aleo mobile add-account flow, shown when view-key approval resolves zero accounts to add.

<img src="https://github.com/user-attachments/assets/eb19434c-928a-486a-b3e2-5147b50512fe" alt="no-accounts-added" width="220" />

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-30500

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
