### PR TITLE
ci: fix format check steps never running on PRs targeting develop

### DIFF
--- a/.github/workflows/test-desktop-codechecks-reusable.yml
+++ b/.github/workflows/test-desktop-codechecks-reusable.yml
@@ -68,7 +68,7 @@ jobs:
           skip_builds: true
 
       - name: format check
-        if: inputs.base_ref == 'develop' || github.ref == 'refs/heads/develop'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop'
         run: pnpm desktop format:check
 
       - name: lint

--- a/.github/workflows/test-mobile-reusable.yml
+++ b/.github/workflows/test-mobile-reusable.yml
@@ -63,7 +63,7 @@ jobs:
         run: pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
 
       - name: Run format check
-        if: inputs.base_ref == 'develop' || github.ref == 'refs/heads/develop'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop'
         run: pnpm exec nx run live-mobile:format:check
 
       - name: Run linter


### PR DESCRIPTION
## Summary

- The "format check" steps in `test-desktop-codechecks-reusable.yml` and `test-mobile-reusable.yml` were conditioned on `inputs.base_ref == 'develop'`
- `inputs.base_ref` is only populated on manual `workflow_dispatch` runs; when these workflows are called via`workflow_call` from the PR workflow, it is always an empty string — so the format check was silently skipped
  on every PR
- Fixed by switching to `github.base_ref`, which is inherited from the`pull_request` event context and resolves correctly without any explicit input passing
- This aligns both workflows with the other five format check steps in the repo (`test-desktop-e2e-lint-reusable.yml`, `test-mobile-e2e-lint-reusable.yml`, `test-cli-reusable.yml`, `build-wallet-cli-reusable.yml`, `build-web-tools-reusable.yml`), which already use `github.base_ref`