### PR TITLE
[LWM] feat(LIVE-30500): aleo mobile no accounts added screen

### DIFF
--- a/.changeset/silly-dancers-fix.md
+++ b/.changeset/silly-dancers-fix.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add a "No Accounts Added" screen to the Aleo mobile add-account flow, shown when view-key approval resolves zero accounts to add

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -425,6 +425,7 @@ export enum ScreenName {
   AleoAddAccount = "AleoAddAccount",
   AleoViewKeyWarning = "AleoViewKeyWarning",
   AleoViewKeyApprove = "AleoViewKeyApprove",
+  AleoNoAccountsAdded = "AleoNoAccountsAdded",
   AleoSendBalanceSelection = "AleoSendBalanceSelection",
   AleoMandatoryPrivateSync = "AleoMandatoryPrivateSync",
 

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/AddAccountNavigator.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/AddAccountNavigator.tsx
@@ -3,6 +3,7 @@ import { Platform } from "react-native";
 import { useTheme } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import TransparentHeaderNavigationOptions from "~/navigation/TransparentHeaderNavigationOptions";
 import { NavigationHeaderCloseButtonAdvanced } from "~/components/NavigationHeaderCloseButton";
 import { Trans } from "~/context/Locale";
 import type {
@@ -14,6 +15,7 @@ import { ScreenName } from "~/const";
 import { AleoAddAccountParamList, AleoViewKeyFlowParamList } from "./types";
 import ViewKeyWarningScreen from "./ViewKeyWarningScreen";
 import ViewKeyApproveScreen from "./ViewKeyApproveScreen";
+import NoAccountsAddedScreen from "./NoAccountsAddedScreen";
 
 type Props = StackNavigatorProps<AleoAddAccountParamList, ScreenName.AleoAddAccount>;
 
@@ -23,12 +25,13 @@ const DEFAULT_ADD_ACCOUNT_FLOW_DEPTH = 2; // SelectDevice + AddAccounts
 
 interface HeaderRightProps {
   onClose: () => void;
+  withConfirmation?: boolean;
 }
 
-function HeaderRight({ onClose }: Readonly<HeaderRightProps>) {
+function HeaderRight({ onClose, withConfirmation = true }: Readonly<HeaderRightProps>) {
   return (
     <NavigationHeaderCloseButtonAdvanced
-      withConfirmation
+      withConfirmation={withConfirmation}
       skipNavigation
       onClose={onClose}
       confirmationTitle={<Trans i18nKey="addAccounts.quitConfirmation.v2.title" />}
@@ -69,6 +72,12 @@ function AddAccountNavigator({ route, navigation }: Readonly<Props>) {
   }, [navigation, navigationDepth]);
 
   const renderHeaderRight = useCallback(() => <HeaderRight onClose={handleClose} />, [handleClose]);
+  const renderHeaderRightNoConfirmation = useCallback(
+    () => <HeaderRight onClose={handleClose} withConfirmation={false} />,
+    [handleClose],
+  );
+
+  const { accountsToAdd: _, ...viewKeyWarningParams } = route.params;
 
   return (
     <Stack.Navigator
@@ -83,7 +92,7 @@ function AddAccountNavigator({ route, navigation }: Readonly<Props>) {
       <Stack.Screen
         name={ScreenName.AleoViewKeyWarning}
         component={ViewKeyWarningScreen}
-        initialParams={{ ...route.params, onCloseNavigation: handleClose }}
+        initialParams={{ ...viewKeyWarningParams, onCloseNavigation: handleClose }}
         options={{ headerTitle: "" }}
       />
       <Stack.Screen
@@ -91,6 +100,17 @@ function AddAccountNavigator({ route, navigation }: Readonly<Props>) {
         component={ViewKeyApproveScreen}
         initialParams={{ ...route.params, onCloseNavigation: handleClose }}
         options={{ headerTitle: "" }}
+      />
+      <Stack.Screen
+        name={ScreenName.AleoNoAccountsAdded}
+        component={NoAccountsAddedScreen}
+        initialParams={{ ...viewKeyWarningParams, onCloseNavigation: handleClose }}
+        options={{
+          ...TransparentHeaderNavigationOptions,
+          headerLeft: () => null,
+          headerRight: renderHeaderRightNoConfirmation,
+          gestureEnabled: false,
+        }}
       />
     </Stack.Navigator>
   );

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/NoAccountsAddedScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/NoAccountsAddedScreen.tsx
@@ -1,0 +1,83 @@
+import React, { useCallback } from "react";
+import { StyleSheet } from "react-native";
+import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import { WarningFill } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTheme } from "styled-components/native";
+import { ScreenName } from "~/const";
+import SafeAreaView from "~/components/SafeAreaView";
+import CloseWithConfirmation from "LLM/components/CloseWithConfirmation";
+import VerticalGradientBackground from "LLM/features/Accounts/components/VerticalGradientBackground";
+import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import { Trans, useTranslation } from "~/context/Locale";
+import { TrackScreen } from "~/analytics";
+import type { AleoViewKeyFlowParamList } from "./types";
+
+type Props = StackNavigatorProps<AleoViewKeyFlowParamList, ScreenName.AleoNoAccountsAdded>;
+
+export default function NoAccountsAddedScreen({ route }: Props) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const { currency, onCloseNavigation } = route.params;
+  const statusColor = colors.warning.c70;
+
+  const handleClose = useCallback(() => {
+    onCloseNavigation?.();
+  }, [onCloseNavigation]);
+
+  return (
+    <SafeAreaView edges={["left", "right", "bottom", "top"]} isFlex>
+      <TrackScreen category="AleoAddAccountFlow" name="No accounts added" />
+      <VerticalGradientBackground stopColor={statusColor} />
+      <Box lx={{ backgroundColor: "warning", marginTop: "s96" }} style={styles.iconWrapper}>
+        <WarningFill size={40} color="warning" />
+      </Box>
+      <Box
+        lx={{ alignItems: "center", justifyContent: "flex-start", paddingHorizontal: "s20" }}
+        style={styles.textContainer}
+      >
+        <Text typography="heading3SemiBold" style={styles.title} lx={{ color: "base" }}>
+          <Trans
+            i18nKey="aleo.addAccount.stepNoAccountsAdded.title"
+            values={{ currency: currency.name }}
+          />
+        </Text>
+        <Text typography="body2" style={styles.desc} lx={{ color: "muted" }}>
+          <Trans i18nKey="aleo.addAccount.stepNoAccountsAdded.description" />
+        </Text>
+      </Box>
+      <Box lx={{ paddingHorizontal: "s16", rowGap: "s16" }}>
+        <CloseWithConfirmation
+          showButton
+          buttonText={t("addAccounts.addAccountsSuccess.ctaClose")}
+          onClose={handleClose}
+        />
+      </Box>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  title: {
+    marginTop: 32,
+    textAlign: "center",
+    width: "100%",
+  },
+  desc: {
+    marginTop: 16,
+    marginBottom: 32,
+    width: "100%",
+    textAlign: "center",
+    alignSelf: "stretch",
+  },
+  iconWrapper: {
+    height: 72,
+    width: 72,
+    borderRadius: 50,
+    alignItems: "center",
+    justifyContent: "center",
+    alignSelf: "center",
+  },
+  textContainer: {
+    flex: 1,
+  },
+});

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyApproveScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyApproveScreen.tsx
@@ -23,6 +23,7 @@ import { getDeviceAnimation, getDeviceAnimationStyles } from "~/helpers/getDevic
 import { useAccountName } from "~/reducers/wallet";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { accountsSelector } from "~/reducers/accounts";
+import { TrackScreen } from "~/analytics";
 import type { AleoViewKeyFlowParamList } from "./types";
 
 type Props = StackNavigatorProps<AleoViewKeyFlowParamList, ScreenName.AleoViewKeyApprove>;
@@ -96,7 +97,9 @@ export default function ViewKeyApproveScreen({ route, navigation }: Props) {
     const accountsWithViewKeys = buildAccountsWithViewKeys(accountsToAdd, payload);
 
     if (accountsWithViewKeys.length === 0) {
-      onCloseNavigation?.();
+      abortedRef.current = true;
+      const { accountsToAdd: _accountsToAdd, ...noAccountsAddedParams } = route.params;
+      navigation.replace(ScreenName.AleoNoAccountsAdded, noAccountsAddedParams);
       return;
     }
 
@@ -129,8 +132,8 @@ export default function ViewKeyApproveScreen({ route, navigation }: Props) {
     existingAccounts,
     dispatch,
     navigation,
+    route.params,
     currency,
-    onCloseNavigation,
     onSuccess,
     context,
   ]);
@@ -222,6 +225,7 @@ export default function ViewKeyApproveScreen({ route, navigation }: Props) {
       edges={["bottom"]}
       style={[styles.root, { backgroundColor: colors.background.main }]}
     >
+      <TrackScreen category="AleoAddAccountFlow" name="View key approve" />
       <DeviceActionDefaultRendering
         status={hookState}
         request={request}

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyWarningScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyWarningScreen.tsx
@@ -11,6 +11,7 @@ import { urls } from "~/utils/urls";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 import type { AleoViewKeyFlowParamList } from "./types";
 import ConfirmationModal from "~/components/ConfirmationModal";
+import { TrackScreen } from "~/analytics";
 
 type Props = StackNavigatorProps<AleoViewKeyFlowParamList, ScreenName.AleoViewKeyWarning>;
 
@@ -67,6 +68,7 @@ export default function ViewKeyWarningScreen({ route, navigation }: Props) {
       edges={["bottom"]}
       style={[styles.root, { backgroundColor: colors.background.main }]}
     >
+      <TrackScreen category="AleoAddAccountFlow" name="View key warning" />
       <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         <LText semiBold style={styles.title} color="neutral.c100">
           <Trans i18nKey="aleo.addAccount.stepViewKeyWarning.title" />

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/AddAccountNavigator.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/AddAccountNavigator.test.tsx
@@ -19,6 +19,7 @@ type ScreenProps = {
 // Capture the props that AddAccountNavigator injects into the inner screens.
 let capturedRouteParams: ScreenProps["route"]["params"] | null = null;
 let capturedApproveRouteParams: ScreenProps["route"]["params"] | null = null;
+let capturedNoAccountsAddedRouteParams: ScreenProps["route"]["params"] | null = null;
 
 jest.mock("../ViewKeyWarningScreen", () => {
   return function MockViewKeyWarningScreen({ route }: ScreenProps) {
@@ -30,6 +31,13 @@ jest.mock("../ViewKeyWarningScreen", () => {
 jest.mock("../ViewKeyApproveScreen", () => {
   return function MockViewKeyApproveScreen({ route }: ScreenProps) {
     capturedApproveRouteParams = route.params;
+    return <></>;
+  };
+});
+
+jest.mock("../NoAccountsAddedScreen", () => {
+  return function MockNoAccountsAddedScreen({ route }: ScreenProps) {
+    capturedNoAccountsAddedRouteParams = route.params;
     return <></>;
   };
 });
@@ -80,6 +88,7 @@ describe("AleoAddAccountNavigator", () => {
   beforeEach(() => {
     capturedRouteParams = null;
     capturedApproveRouteParams = null;
+    capturedNoAccountsAddedRouteParams = null;
     mockPop.mockClear();
   });
 
@@ -161,6 +170,27 @@ describe("AleoAddAccountNavigator", () => {
     expect(capturedRouteParams).not.toBeNull();
     expect(capturedApproveRouteParams).toBeNull();
   });
+
+  it("routes to NoAccountsAdded and injects onCloseNavigation when initialRouteName is AleoNoAccountsAdded", () => {
+    const Stack = createNativeStackNavigator<AleoAddAccountParamList>();
+    render(
+      <Stack.Navigator>
+        <Stack.Screen
+          name={ScreenName.AleoAddAccount}
+          component={AddAccountNavigator}
+          initialParams={{
+            currency: aleoCurrency,
+            device: mockDevice,
+            initialRouteName: ScreenName.AleoNoAccountsAdded,
+          }}
+        />
+      </Stack.Navigator>,
+    );
+    expect(capturedNoAccountsAddedRouteParams).not.toBeNull();
+    expect(capturedRouteParams).toBeNull();
+    expect(capturedApproveRouteParams).toBeNull();
+    expect(capturedNoAccountsAddedRouteParams?.onCloseNavigation).toBeInstanceOf(Function);
+  });
 });
 
 describe("AleoAddAccountNavigator — handleClose", () => {
@@ -177,6 +207,7 @@ describe("AleoAddAccountNavigator — handleClose", () => {
       />,
     );
     capturedRouteParams?.onCloseNavigation?.();
+    expect(mockPop).toHaveBeenCalledTimes(1);
     expect(mockPop).toHaveBeenCalledWith(2);
   });
 
@@ -190,6 +221,7 @@ describe("AleoAddAccountNavigator — handleClose", () => {
       />,
     );
     capturedRouteParams?.onCloseNavigation?.();
+    expect(mockPop).toHaveBeenCalledTimes(1);
     expect(mockPop).toHaveBeenCalledWith(4);
   });
 

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/NoAccountsAddedScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/NoAccountsAddedScreen.test.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { Text, TouchableOpacity } from "react-native";
+import { screen, render } from "@tests/test-renderer";
+import NoAccountsAddedScreen from "../NoAccountsAddedScreen";
+import { aleoCurrency } from "../../__mocks__/currency.mock";
+
+let capturedCategory: string | undefined;
+let capturedName: string | undefined;
+jest.mock("~/analytics", () => ({
+  TrackScreen: ({ category, name }: { category: string; name?: string }) => {
+    capturedCategory = category;
+    capturedName = name;
+    return null;
+  },
+}));
+
+jest.mock("LLM/components/CloseWithConfirmation", () => {
+  return function MockCloseWithConfirmation({
+    onClose,
+    buttonText,
+  }: {
+    onClose?: () => void;
+    buttonText?: string;
+  }) {
+    return (
+      <TouchableOpacity testID="close-button" onPress={onClose}>
+        <Text>{buttonText}</Text>
+      </TouchableOpacity>
+    );
+  };
+});
+
+const makeMockRoute = (overrides: { onCloseNavigation?: () => void } = {}) => ({
+  params: {
+    currency: aleoCurrency,
+    device: { deviceId: "device-1", modelId: "nanoX", wired: false },
+    context: undefined,
+    onCloseNavigation: overrides.onCloseNavigation,
+  },
+});
+
+const renderScreen = (routeOverrides: { onCloseNavigation?: () => void } = {}) =>
+  render(
+    <NoAccountsAddedScreen
+      route={makeMockRoute(routeOverrides) as never}
+      navigation={{} as never}
+    />,
+  );
+
+describe("NoAccountsAddedScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedCategory = undefined;
+    capturedName = undefined;
+  });
+
+  it("tracks the screen with the AleoAddAccountFlow category and 'No accounts added' name", () => {
+    renderScreen();
+    expect(capturedCategory).toBe("AleoAddAccountFlow");
+    expect(capturedName).toBe("No accounts added");
+  });
+
+  it("renders the title with the currency name interpolated", () => {
+    renderScreen();
+    expect(screen.getByText("No Aleo accounts were added")).toBeOnTheScreen();
+  });
+
+  it("renders the description", () => {
+    renderScreen();
+    expect(
+      screen.getByText(
+        "You haven't shared view keys for any of the selected accounts. View keys are required to display your private balance in Ledger Wallet.",
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it("renders the close button with the ctaClose translation", () => {
+    renderScreen();
+    expect(screen.getByText("Close")).toBeOnTheScreen();
+  });
+
+  it("calls onCloseNavigation when provided", async () => {
+    const onCloseNavigation = jest.fn();
+    const { user } = renderScreen({ onCloseNavigation });
+
+    await user.press(screen.getByTestId("close-button"));
+
+    expect(onCloseNavigation).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when onCloseNavigation is not provided", async () => {
+    const { user } = renderScreen();
+
+    await expect(user.press(screen.getByTestId("close-button"))).resolves.not.toThrow();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyApproveScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyApproveScreen.test.tsx
@@ -77,6 +77,13 @@ jest.mock("~/components/Loading", () => ({
   Loading: () => <View testID="loading" />,
 }));
 
+// TrackScreen uses the real useIsFocused(), which subscribes to navigation focus
+// events outside of a Screen context here — stub it out so the test doesn't depend
+// on that subscription's behavior.
+jest.mock("~/analytics", () => ({
+  TrackScreen: () => null,
+}));
+
 jest.mock("~/components/wrappedUi/Button", () => {
   return ({
     children,
@@ -114,7 +121,7 @@ const ACCOUNT_2 = { id: "account2", freshAddress: "addr2" } as Account;
 
 const mockParentNavigate = jest.fn();
 const mockNavigation = {
-  navigate: jest.fn(),
+  replace: jest.fn(),
   getParent: jest.fn(() => ({ navigate: mockParentNavigate })),
 };
 
@@ -264,7 +271,7 @@ describe("ViewKeyApproveScreen", () => {
       });
       fireEvent.press(screen.getByTestId("button-AleoAddAccountViewKeyApproveCancelAll"));
       capturedOnResult!();
-      expect(mockNavigation.navigate).not.toHaveBeenCalled();
+      expect(mockNavigation.replace).not.toHaveBeenCalled();
       expect(mockParentNavigate).not.toHaveBeenCalled();
       expect(mockDispatch).not.toHaveBeenCalled();
     });
@@ -278,12 +285,16 @@ describe("ViewKeyApproveScreen", () => {
       expect(mockParentNavigate).not.toHaveBeenCalled();
     });
 
-    it("calls onCloseNavigation when buildAccountsWithViewKeys returns empty", () => {
-      const mockOnClose = jest.fn();
+    it("navigates to AleoNoAccountsAdded when buildAccountsWithViewKeys returns empty", () => {
       mockBuildAccountsWithViewKeys.mockReturnValue([]);
-      renderScreen({ payload: {} }, { onCloseNavigation: mockOnClose });
+      renderScreen({ payload: {} });
       capturedOnResult!();
-      expect(mockOnClose).toHaveBeenCalledTimes(1);
+      const { accountsToAdd: _accountsToAdd, ...expectedParams } = mockRoute.params;
+      expect(mockNavigation.replace).toHaveBeenCalledTimes(1);
+      expect(mockNavigation.replace).toHaveBeenCalledWith(
+        ScreenName.AleoNoAccountsAdded,
+        expectedParams,
+      );
       expect(mockDispatch).not.toHaveBeenCalled();
     });
 
@@ -291,7 +302,9 @@ describe("ViewKeyApproveScreen", () => {
       mockBuildAccountsWithViewKeys.mockReturnValue([ACCOUNT_1]);
       renderScreen({ payload: { account1: "vk1" } });
       capturedOnResult!();
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
       expect(mockDispatch).toHaveBeenCalledWith({ type: "ADD_ACCOUNTS" });
+      expect(mockParentNavigate).toHaveBeenCalledTimes(1);
       expect(mockParentNavigate).toHaveBeenCalledWith(
         ScreenName.AddAccountsSuccess,
         expect.objectContaining({

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/types.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/types.ts
@@ -15,7 +15,10 @@ export type AleoAddAccountParams = {
   inline?: boolean;
   returnToSwap?: boolean;
   onSuccess?: (res: { scannedAccounts: Account[]; selected: Account[] }) => void;
-  initialRouteName?: ScreenName.AleoViewKeyWarning | ScreenName.AleoViewKeyApprove;
+  initialRouteName?:
+    | ScreenName.AleoViewKeyWarning
+    | ScreenName.AleoViewKeyApprove
+    | ScreenName.AleoNoAccountsAdded;
 };
 
 export type AleoAddAccountParamList = {
@@ -27,4 +30,5 @@ export type AleoViewKeyFlowParamList = {
   [ScreenName.AleoViewKeyApprove]: AleoAddAccountParams & {
     accountsToAdd: Account[];
   };
+  [ScreenName.AleoNoAccountsAdded]: Omit<AleoAddAccountParams, "accountsToAdd">;
 };

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10069,6 +10069,10 @@
         "cancelAllBtn_one": "Cancel",
         "cancelAllBtn_other": "Cancel all"
       },
+      "stepNoAccountsAdded": {
+        "title": "No {{currency}} accounts were added",
+        "description": "You haven't shared view keys for any of the selected accounts. View keys are required to display your private balance in Ledger Wallet."
+      },
       "stepScanAccounts": {
         "cta": {
           "shareViewKeys": "Share view keys"


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - This PR adds a "No Accounts Added" screen to the Aleo mobile add-account flow, shown when view-key approval resolves zero accounts to add.
  
### 📝 Description

Add a "No Accounts Added" screen to the Aleo mobile add-account flow, shown when view-key approval resolves zero accounts to add.

<img src="https://github.com/user-attachments/assets/f55757bf-5505-45cf-b12a-49e800eaf0e7" alt="no-accounts-added" width="220" />

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-30500

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
