### PR TITLE
[LWM] feat(LIVE-30492): private mobile sync for aleo

### DIFF
--- a/.changeset/angry-cobras-sniff.md
+++ b/.changeset/angry-cobras-sniff.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Private sync flow for Aleo (mobile)

--- a/apps/ledger-live-mobile/src/families/aleo/AccountBalanceHeader.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AccountBalanceHeader.tsx
@@ -9,11 +9,12 @@ import CurrencyUnitValue from "~/components/CurrencyUnitValue";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import type { ModalInfo } from "~/modals/Info";
 import type { AccountLike } from "@ledgerhq/types-live";
+import { PRIVATE_BALANCE_PLACEHOLDER } from "@ledgerhq/live-common/families/aleo/constants";
 import InfoModal from "~/modals/Info";
 import InfoItem from "~/components/BalanceSummaryInfoItem";
 import SectionContainer from "~/screens/WalletCentricSections/SectionContainer";
 import SectionTitle from "~/screens/WalletCentricSections/SectionTitle";
-import { PRIVATE_BALANCE_PLACEHOLDER } from "@ledgerhq/live-common/families/aleo/constants";
+import PrivateSyncButton from "./PrivateSyncButton";
 
 type InfoName = "transparent" | "private";
 
@@ -65,6 +66,7 @@ function AleoBalanceSummary({ account }: { readonly account: AleoAccount }) {
           />
         </Box>
       </ScrollView>
+      <PrivateSyncButton account={account} />
     </SectionContainer>
   );
 }

--- a/apps/ledger-live-mobile/src/families/aleo/PrivateSyncButton.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/PrivateSyncButton.tsx
@@ -1,0 +1,73 @@
+import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
+import { Box, Button, Spinner, Text } from "@ledgerhq/lumen-ui-rnative";
+import React, { useMemo } from "react";
+import { useTranslation } from "~/context/Locale";
+import { useSelector } from "~/context/hooks";
+import { localeSelector } from "~/reducers/settings";
+import { useAleoPrivateSync } from "./hooks/useAleoPrivateSync";
+
+type AleoSyncState = "ready" | "running" | "complete";
+
+const lastSyncDateFormat: Intl.DateTimeFormatOptions = {
+  day: "numeric",
+  month: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+};
+
+export default function PrivateSyncButton({
+  account,
+}: {
+  readonly account: AleoAccount;
+}) {
+  const { t } = useTranslation();
+  const locale = useSelector(localeSelector);
+
+  const { isSyncing, progress, start, stop } = useAleoPrivateSync({
+    account,
+    autoStart: !account.aleoResources?.lastPrivateSyncDate,
+    keepAliveOnUnmount: true,
+  });
+
+  const lastSync = account.aleoResources?.lastPrivateSyncDate ?? null;
+  const syncState: AleoSyncState = isSyncing ? "running" : lastSync ? "complete" : "ready";
+
+  const formattedLastSync = useMemo(
+    () => (lastSync ? new Intl.DateTimeFormat(locale, lastSyncDateFormat).format(lastSync) : ""),
+    [lastSync, locale],
+  );
+
+  return (
+    <Box style={{ flexDirection: "row", alignItems: "center", paddingHorizontal: 16, marginTop: 12 }}>
+      {syncState === "ready" && (
+        <Button size="sm" onPress={start} testID="start-private-sync-button">
+          {t("aleo.account.syncButton.startSync")}
+        </Button>
+      )}
+      {syncState === "running" && (
+        <Button size="sm" appearance="gray" onPress={stop} testID="stop-private-sync-button">
+          {t("aleo.account.syncButton.stopSync")}
+        </Button>
+      )}
+      {syncState === "complete" && (
+        <Button size="sm" onPress={start} testID="sync-again-button">
+          {t("aleo.account.syncButton.syncAgain")}
+        </Button>
+      )}
+      {syncState === "running" && (
+        <Box style={{ flexDirection: "row", alignItems: "center", marginLeft: 12 }}>
+          <Spinner size={12} />
+          <Text typography="body4" lx={{ color: "muted" }} style={{ marginLeft: 8 }}>
+            {progress}%
+          </Text>
+        </Box>
+      )}
+      {syncState === "complete" && (
+        <Text typography="body4" lx={{ color: "muted" }} style={{ marginLeft: 12 }}>
+          {t("aleo.account.syncButton.lastSync", { date: formattedLastSync })}
+        </Text>
+      )}
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/families/aleo/__tests__/AccountBalanceHeader.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/__tests__/AccountBalanceHeader.test.tsx
@@ -11,9 +11,6 @@ jest.mock("~/context/Locale", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-// PrivateSyncButton (rendered by AccountBalanceHeader) pulls in the real hw/bridge
-// stack through the live-common hook — mock it so this stays a unit test of the
-// balance header, not an integration test of the private sync flow.
 jest.mock("../hooks/useAleoPrivateSync");
 
 jest.mocked(useAleoPrivateSync).mockReturnValue({

--- a/apps/ledger-live-mobile/src/families/aleo/__tests__/AccountBalanceHeader.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/__tests__/AccountBalanceHeader.test.tsx
@@ -5,10 +5,24 @@ import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
 import { ALEO_ACCOUNT_1 } from "../__mocks__/account.mock";
 import AccountBalanceHeader from "../AccountBalanceHeader";
 import { PRIVATE_BALANCE_PLACEHOLDER } from "@ledgerhq/live-common/families/aleo/constants";
+import { useAleoPrivateSync } from "../hooks/useAleoPrivateSync";
 
 jest.mock("~/context/Locale", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
+
+// PrivateSyncButton (rendered by AccountBalanceHeader) pulls in the real hw/bridge
+// stack through the live-common hook — mock it so this stays a unit test of the
+// balance header, not an integration test of the private sync flow.
+jest.mock("../hooks/useAleoPrivateSync");
+
+jest.mocked(useAleoPrivateSync).mockReturnValue({
+  isSyncing: false,
+  progress: 0,
+  error: null,
+  start: jest.fn(),
+  stop: jest.fn(),
+});
 
 jest.mock("LLM/hooks/useAccountUnit", () => ({
   useAccountUnit: () => ({ code: "ALEO", name: "Aleo", magnitude: 6 }),

--- a/apps/ledger-live-mobile/src/families/aleo/__tests__/PrivateSyncButton.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/__tests__/PrivateSyncButton.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import BigNumber from "bignumber.js";
 import { render, screen } from "@tests/test-renderer";
 import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
 import { ALEO_ACCOUNT_1 } from "../__mocks__/account.mock";
@@ -16,7 +17,7 @@ const mockUseAleoPrivateSync = jest.mocked(useAleoPrivateSync);
 const baseAccount: AleoAccount = {
   ...(ALEO_ACCOUNT_1 as AleoAccount),
   aleoResources: {
-    transparentBalance: null,
+    transparentBalance: new BigNumber(0),
     provableApi: null,
     privateBalance: null,
     unspentPrivateRecords: null,

--- a/apps/ledger-live-mobile/src/families/aleo/__tests__/PrivateSyncButton.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/__tests__/PrivateSyncButton.test.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
+import { ALEO_ACCOUNT_1 } from "../__mocks__/account.mock";
+import PrivateSyncButton from "../PrivateSyncButton";
+import { useAleoPrivateSync } from "../hooks/useAleoPrivateSync";
+
+jest.mock("~/context/Locale", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock("../hooks/useAleoPrivateSync");
+
+const mockUseAleoPrivateSync = jest.mocked(useAleoPrivateSync);
+
+const baseAccount: AleoAccount = {
+  ...(ALEO_ACCOUNT_1 as AleoAccount),
+  aleoResources: {
+    transparentBalance: null,
+    provableApi: null,
+    privateBalance: null,
+    unspentPrivateRecords: null,
+    lastPrivateSyncDate: null,
+  },
+};
+
+describe("PrivateSyncButton", () => {
+  let mockStart: jest.Mock;
+  let mockStop: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStart = jest.fn();
+    mockStop = jest.fn();
+    mockUseAleoPrivateSync.mockReturnValue({
+      isSyncing: false,
+      progress: 0,
+      error: null,
+      start: mockStart,
+      stop: mockStop,
+    });
+  });
+
+  it("passes autoStart: true and keepAliveOnUnmount: true for an unsynced account", () => {
+    render(<PrivateSyncButton account={baseAccount} />);
+
+    expect(mockUseAleoPrivateSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: baseAccount,
+        autoStart: true,
+        keepAliveOnUnmount: true,
+      }),
+    );
+  });
+
+  it("passes autoStart: false for an already-synced account", () => {
+    const syncedAccount: AleoAccount = {
+      ...baseAccount,
+      aleoResources: { ...baseAccount.aleoResources!, lastPrivateSyncDate: new Date() },
+    };
+
+    render(<PrivateSyncButton account={syncedAccount} />);
+
+    expect(mockUseAleoPrivateSync).toHaveBeenCalledWith(
+      expect.objectContaining({ autoStart: false }),
+    );
+  });
+
+  it("shows the start-sync button in the ready state", () => {
+    render(<PrivateSyncButton account={baseAccount} />);
+
+    expect(screen.getByTestId("start-private-sync-button")).toBeOnTheScreen();
+    expect(screen.queryByTestId("stop-private-sync-button")).not.toBeOnTheScreen();
+    expect(screen.queryByTestId("sync-again-button")).not.toBeOnTheScreen();
+  });
+
+  it("calls start() when the start-sync button is pressed", async () => {
+    const { user } = render(<PrivateSyncButton account={baseAccount} />);
+
+    await user.press(screen.getByTestId("start-private-sync-button"));
+
+    expect(mockStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the stop-sync button and progress while syncing", () => {
+    mockUseAleoPrivateSync.mockReturnValue({
+      isSyncing: true,
+      progress: 42,
+      error: null,
+      start: mockStart,
+      stop: mockStop,
+    });
+
+    render(<PrivateSyncButton account={baseAccount} />);
+
+    expect(screen.getByTestId("stop-private-sync-button")).toBeOnTheScreen();
+    expect(screen.getByText("42%")).toBeOnTheScreen();
+  });
+
+  it("calls stop() when the stop-sync button is pressed", async () => {
+    mockUseAleoPrivateSync.mockReturnValue({
+      isSyncing: true,
+      progress: 42,
+      error: null,
+      start: mockStart,
+      stop: mockStop,
+    });
+
+    const { user } = render(<PrivateSyncButton account={baseAccount} />);
+
+    await user.press(screen.getByTestId("stop-private-sync-button"));
+
+    expect(mockStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the sync-again button and last sync text once synced", () => {
+    const syncedAccount: AleoAccount = {
+      ...baseAccount,
+      aleoResources: { ...baseAccount.aleoResources!, lastPrivateSyncDate: new Date() },
+    };
+
+    render(<PrivateSyncButton account={syncedAccount} />);
+
+    expect(screen.getByTestId("sync-again-button")).toBeOnTheScreen();
+    expect(screen.getByText("aleo.account.syncButton.lastSync")).toBeOnTheScreen();
+  });
+
+  it("calls start() when the sync-again button is pressed", async () => {
+    const syncedAccount: AleoAccount = {
+      ...baseAccount,
+      aleoResources: { ...baseAccount.aleoResources!, lastPrivateSyncDate: new Date() },
+    };
+
+    const { user } = render(<PrivateSyncButton account={syncedAccount} />);
+
+    await user.press(screen.getByTestId("sync-again-button"));
+
+    expect(mockStart).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/hooks/useAleoPrivateSync.test.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/hooks/useAleoPrivateSync.test.ts
@@ -1,0 +1,74 @@
+import { useAleoPrivateSync as useAleoPrivateSyncCore } from "@ledgerhq/live-common/families/aleo/react";
+import { accountSelector } from "~/reducers/accounts";
+import { updateAccountWithUpdater } from "~/actions/accounts";
+import { ALEO_ACCOUNT_1 } from "../__mocks__/account.mock";
+import { useAleoPrivateSync } from "./useAleoPrivateSync";
+
+jest.mock("@ledgerhq/live-common/families/aleo/react", () => ({
+  useAleoPrivateSync: jest.fn(),
+}));
+jest.mock("~/reducers/accounts", () => ({
+  ...jest.requireActual("~/reducers/accounts"),
+  accountSelector: jest.fn(),
+}));
+jest.mock("~/actions/accounts", () => ({
+  ...jest.requireActual("~/actions/accounts"),
+  updateAccountWithUpdater: jest.fn(),
+}));
+
+const mockCore = jest.mocked(useAleoPrivateSyncCore);
+const mockAccountSelector = jest.mocked(accountSelector);
+const mockUpdateAccountWithUpdater = jest.mocked(updateAccountWithUpdater);
+
+describe("useAleoPrivateSync (mobile wrapper)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCore.mockReturnValue({
+      isSyncing: false,
+      progress: 0,
+      error: null,
+      start: jest.fn(),
+      stop: jest.fn(),
+    });
+  });
+
+  it("delegates to the live-common core hook with the given options", () => {
+    const onAccountUpdated = jest.fn();
+    useAleoPrivateSync({
+      account: ALEO_ACCOUNT_1,
+      autoStart: true,
+      keepAliveOnUnmount: true,
+      onAccountUpdated,
+    });
+
+    expect(mockCore).toHaveBeenCalledTimes(1);
+    const call = mockCore.mock.calls[0][0];
+    expect(call.account).toBe(ALEO_ACCOUNT_1);
+    expect(call.autoStart).toBe(true);
+    expect(call.keepAliveOnUnmount).toBe(true);
+    expect(call.onAccountUpdated).toBe(onAccountUpdated);
+  });
+
+  it("wires accountSelector through to the app's real selector", () => {
+    useAleoPrivateSync({ account: ALEO_ACCOUNT_1 });
+
+    const call = mockCore.mock.calls[0][0];
+    const state = { accounts: [ALEO_ACCOUNT_1] };
+    call.accountSelector(state, { accountId: ALEO_ACCOUNT_1.id });
+
+    expect(mockAccountSelector).toHaveBeenCalledWith(state, { accountId: ALEO_ACCOUNT_1.id });
+  });
+
+  it("wires updateAccountWithUpdater through to the app's real action creator", () => {
+    useAleoPrivateSync({ account: ALEO_ACCOUNT_1 });
+
+    const call = mockCore.mock.calls[0][0];
+    const updater = (a: typeof ALEO_ACCOUNT_1) => a;
+    call.updateAccountWithUpdater(ALEO_ACCOUNT_1.id, updater);
+
+    expect(mockUpdateAccountWithUpdater).toHaveBeenCalledWith({
+      accountId: ALEO_ACCOUNT_1.id,
+      updater,
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/hooks/useAleoPrivateSync.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/hooks/useAleoPrivateSync.ts
@@ -1,0 +1,17 @@
+import { useAleoPrivateSync as useAleoPrivateSyncCore } from "@ledgerhq/live-common/families/aleo/react";
+import { accountSelector } from "~/reducers/accounts";
+import type { State } from "~/reducers/types";
+import { updateAccountWithUpdater } from "~/actions/accounts";
+
+type UseAleoPrivateSyncOptions = Omit<
+  Parameters<typeof useAleoPrivateSyncCore>[0],
+  "accountSelector" | "updateAccountWithUpdater"
+>;
+
+export const useAleoPrivateSync = (options: UseAleoPrivateSyncOptions) =>
+  useAleoPrivateSyncCore({
+    ...options,
+    accountSelector: (state, params) => accountSelector(state as State, params),
+    updateAccountWithUpdater: (accountId, updater) =>
+      updateAccountWithUpdater({ accountId, updater }),
+  });

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10070,6 +10070,14 @@
         "title": "Private balance",
         "description": "The shielded balance on the Aleo network. This balance is only visible to you and requires proof generation for private transactions."
       }
+    },
+    "account": {
+      "syncButton": {
+        "startSync": "Start sync",
+        "stopSync": "Stop sync",
+        "syncAgain": "Sync again",
+        "lastSync": "Last synced: {{date}}"
+      }
     }
   }
 }

--- a/apps/ledger-live-mobile/src/screens/Account/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/index.tsx
@@ -190,6 +190,7 @@ const AccountScreenInner = ({
         gradientColor={getCurrencyColor(currency) || colors.primary.c80}
       />
       <AnimatedFlatListWithRefreshControl
+        accountId={mainAccount.id}
         style={{ flex: 1 }}
         contentContainerStyle={{
           paddingTop: 48, //CurrencyHeader height


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
 - mobile wrapper hook around the core useAleoPrivateSync from live-common, wiring in mobile's accountSelector and updateAccountWithUpdater.
-  UI button component (start/stop/sync-again + last-synced label) driven by that hook.
-  renders PrivateSyncButton under the balance summary.
-  passes accountId down to AnimatedFlatListWithRefreshControl (resolve issue with sync after swiping).
-  added account.syncButton.* strings (startSync, stopSync, syncAgain, lastSync) to en/common.json.
  
### 📝 Description

Add a support for private sync to Aleo. List of changes above. 

Example screen: 

<img width="1080" height="2400" alt="Screenshot_2026-07-06-14-51-53-586_com ledger live debug" src="https://github.com/user-attachments/assets/b9f0aa73-3936-44bd-9819-202933ddefc6" />


### ❓ Context

[https://ledgerhq.atlassian.net/browse/LIVE-30492](https://ledgerhq.atlassian.net/browse/LIVE-30492)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)