### PR TITLE
[LWD] fix: prevent scrubber focus from sticking below graph

### DIFF
--- a/.changeset/calm-charts-unfocus.md
+++ b/.changeset/calm-charts-unfocus.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Analytics and Asset Detail charts keeping scrubber focus when moving the pointer below the graph. Use the default chart height with Y-axis domain padding instead of an extra 50px SVG hit area.

--- a/apps/ledger-live-desktop/src/mvvm/components/LineChart/utils/lineChartAxisConfig.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/LineChart/utils/lineChartAxisConfig.ts
@@ -7,9 +7,6 @@ const MIN_X_AXIS_TICKS_1D = 8;
 
 export const LINE_CHART_Y_AXIS_BOTTOM_OFFSET_PX = 50;
 
-export const LINE_CHART_VIEW_HEIGHT =
-  DEFAULT_LINE_CHART_HEIGHT + LINE_CHART_Y_AXIS_BOTTOM_OFFSET_PX;
-
 export function buildLineChartXAxisConfig({
   timestamps,
   selectedRange,

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/useChartSectionViewModel.ts
@@ -13,10 +13,10 @@ import {
 } from "LLD/components/LineChart";
 import { createSmallestUnitFiatLineChartValueFormatter } from "LLD/components/LineChart/utils/createFiatLineChartValueFormatter";
 import { createLineChartTooltipTitle } from "LLD/components/LineChart/utils/createLineChartTooltipTitle";
+import { DEFAULT_LINE_CHART_HEIGHT } from "LLD/components/LineChart/constants";
 import {
   buildLineChartBottomPaddedYAxisConfig,
   buildLineChartXAxisConfig,
-  LINE_CHART_VIEW_HEIGHT,
 } from "LLD/components/LineChart/utils/lineChartAxisConfig";
 import {
   counterValueCurrencySelector,
@@ -143,7 +143,7 @@ export function useChartSectionViewModel({
       onRangeChange,
       color,
       isLoading: isChartLoading,
-      height: LINE_CHART_VIEW_HEIGHT,
+      height: DEFAULT_LINE_CHART_HEIGHT,
       formatValue,
       tooltipTitle,
       onScrubberPositionChange,

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
@@ -27,10 +27,10 @@ import {
 } from "LLD/components/LineChart";
 import { createFiatLineChartValueFormatter } from "LLD/components/LineChart/utils/createFiatLineChartValueFormatter";
 import { createLineChartTooltipTitle } from "LLD/components/LineChart/utils/createLineChartTooltipTitle";
+import { DEFAULT_LINE_CHART_HEIGHT } from "LLD/components/LineChart/constants";
 import {
   buildLineChartBottomPaddedYAxisConfig,
   buildLineChartXAxisConfig,
-  LINE_CHART_VIEW_HEIGHT,
 } from "LLD/components/LineChart/utils/lineChartAxisConfig";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import {
@@ -288,7 +288,7 @@ export function useChartSectionViewModel({
 
   return {
     series,
-    height: LINE_CHART_VIEW_HEIGHT,
+    height: DEFAULT_LINE_CHART_HEIGHT,
     selectedRange,
     onRangeChange: handleRangeChange,
     color,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

This pull request addresses a UX issue with the Analytics and Asset Detail charts where the scrubber focus would remain active when the pointer moved below the graph. It also simplifies chart sizing by using the default chart height with Y-axis domain padding, instead of an extra 50px SVG hit area. The most important changes are:

**Bug Fixes:**

* Fixed the issue where Analytics and Asset Detail charts kept the scrubber focus when the pointer was moved below the graph.

**Chart Sizing Refactor:**

* Updated both Analytics and Asset Detail chart components to use `DEFAULT_LINE_CHART_HEIGHT` for the chart height instead of the previously used `LINE_CHART_VIEW_HEIGHT`, removing the extra 50px SVG hit area in favor of Y-axis domain padding. 


https://github.com/user-attachments/assets/e53d2ac1-2861-4be5-9b8b-6785a60945f7



### 🔗 Context

[LIVE-33632](https://ledgerhq.atlassian.net/browse/LIVE-33632)


[LIVE-33632]: https://ledgerhq.atlassian.net/browse/LIVE-33632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ