### PR TITLE
test(e2e): add cross-account swap warning verification for DEX providers

### DIFF
--- a/.changeset/qaa-706-cross-account-swap-warning.md
+++ b/.changeset/qaa-706-cross-account-swap-warning.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop-e2e-tests": minor
+"ledger-live-mobile-e2e-tests": minor
+"@ledgerhq/live-e2e-shared": patch
+---
+
+Add E2E coverage for the swap cross-account warning across DEX providers (1inch, Velora, Uniswap, OKX) on Desktop (Playwright) and Mobile (Detox): swapping a token to a different account of the destination currency must surface the "Cross-account swaps are not currently supported" message. Mobile now selects a specific destination account via `modularDrawer.selectAssetAndAccount` / the opt-in `selectSpecificToAccount` flag in `performSwapUntilQuoteSelectionStep` (previously the drawer always kept the first account), and relaunches a fresh app per provider for test isolation. `@ledgerhq/live-e2e-shared` exports `keepRunningProviders` for provider-health skipping.

--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -35,6 +35,7 @@ export class SwapPage extends WebViewAppPage {
   private maxSpendableToggle = this.page.getByTestId("swap-max-spendable-toggle");
   private fromAccountCoinSelector = "from-account-coin-selector";
   private fromAccountAmountInput = "from-account-amount-input";
+  private readonly fromAccountError = "from-account-error";
   private fromAccountBalance = "from-account-balance";
   private toAccountCoinSelector = "to-account-coin-selector";
   private readonly toAccountAccountNameTag = "to-account-account-name-tag";
@@ -489,8 +490,15 @@ export class SwapPage extends WebViewAppPage {
   @step("Verify swap amount error message match: $0")
   async verifySwapAmountErrorMessageIsCorrect(message: string | RegExp) {
     const webview = await this.getWebView();
-    const errorSpan = await webview.getByTestId("from-account-error").textContent();
+    const errorSpan = await webview.getByTestId(this.fromAccountError).textContent();
     expect(errorSpan).toMatch(message);
+  }
+
+  @step("Verify swap cross account error message match: $0")
+  async verifySwapCrossAccountErrorMessageIsCorrect(message: string | RegExp) {
+    const webview = await this.getWebView();
+    // Auto-retrying locator assertion: waits for the cross-account warning to render before matching.
+    await expect(webview.getByTestId(this.fromAccountError)).toContainText(message);
   }
 
   @step("Check insufficient funds warning banner is visible")

--- a/e2e/desktop/tests/specs/crossAccount.warning.swap.spec.ts
+++ b/e2e/desktop/tests/specs/crossAccount.warning.swap.spec.ts
@@ -1,0 +1,82 @@
+import { SwapProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
+import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
+import test from "tests/fixtures/common";
+import { addTmsLink } from "tests/utils/allureUtils";
+import { getDescription } from "tests/utils/customJsonReporter";
+import { performSwapUntilQuoteSelectionStep, setupEnv } from "tests/utils/swapUtils";
+import { keepRunningProviders } from "@ledgerhq/live-e2e-shared/swap";
+import { Account, TokenAccount } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { Swap } from "@ledgerhq/live-e2e-shared/models/Swap";
+import { liveDataWithAddressCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
+
+const dexProviders = [
+  SwapProvider.ONE_INCH,
+  SwapProvider.VELORA,
+  SwapProvider.UNISWAP,
+  SwapProvider.OKX,
+];
+const fromAccount = TokenAccount.ETH_USDT_1;
+const toAccount = Account.ETH_3;
+
+test.describe("Swap cross account warning", () => {
+  setupEnv();
+
+  test.use({
+    teamOwner: Team.SWAP,
+    userdata: "skip-onboarding-with-last-seen-device",
+
+    cliCommandsOnApp: [
+      [
+        {
+          app: fromAccount.currency.speculosApp,
+          cmd: liveDataWithAddressCommand(fromAccount),
+        },
+        {
+          app: toAccount.currency.speculosApp,
+          cmd: liveDataWithAddressCommand(toAccount),
+        },
+      ],
+      { scope: "test" },
+    ],
+  });
+
+  for (const provider of dexProviders) {
+    test(
+      `A warning should be visible for a cross account swap with ${provider.uiName}`,
+      {
+        tag: [
+          "@NanoSP",
+          "@LNS",
+          "@NanoX",
+          "@Stax",
+          "@Flex",
+          "@NanoGen5",
+          "@ethereum",
+          "@family-evm",
+        ],
+        annotation: [
+          {
+            type: "TMS",
+            description: "LIVE-19543",
+          },
+        ],
+      },
+      async ({ app }) => {
+        const healthyProviders = await keepRunningProviders([provider], fromAccount, toAccount);
+        test.skip(
+          healthyProviders.length === 0,
+          `${provider.uiName} provider is currently down — skipping cross-account warning check`,
+        );
+
+        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+        const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);
+        const swap = new Swap(fromAccount, toAccount, minAmount, provider);
+        const errorMessage =
+          "Cross-account swaps are not currently supported. Please ensure your sending and receiving accounts are the same.";
+        await performSwapUntilQuoteSelectionStep(app, swap, minAmount);
+        await app.swap.selectSpecificProvider(provider);
+        await app.swap.verifySwapCrossAccountErrorMessageIsCorrect(errorMessage);
+      },
+    );
+  }
+});

--- a/e2e/mobile/page/drawer/modular.drawer.ts
+++ b/e2e/mobile/page/drawer/modular.drawer.ts
@@ -122,13 +122,23 @@ export default class ModularDrawer {
     }
   }
 
-  @Step("Select currency in modular drawer")
-  async selectAsset(account: Account): Promise<void> {
+  private async selectAssetCurrencyAndNetwork(account: Account): Promise<void> {
     await this.performSearchByTicker(account.currency.ticker);
     await this.selectCurrencyByTicker(account.currency.ticker);
     const networkName = this.getNetworkNameForAccount(account);
     await this.selectNetworkIfAsked(networkName);
+  }
+
+  @Step("Select currency in modular drawer")
+  async selectAsset(account: Account): Promise<void> {
+    await this.selectAssetCurrencyAndNetwork(account);
     await this.selectFirstAccount();
+  }
+
+  @Step("Select currency then a specific account in modular drawer")
+  async selectAssetAndAccount(account: Account): Promise<void> {
+    await this.selectAssetCurrencyAndNetwork(account);
+    await this.selectAccount(account.accountName);
   }
 
   @Step("Validate account(s) present on account list")

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -350,6 +350,13 @@ export default class SwapLiveAppPage {
     }
   }
 
+  @Step("Verify swap cross account error message match: $0")
+  async verifySwapCrossAccountErrorMessageIsCorrect(expectedMessage: string | RegExp) {
+    // Cross-account warnings render in the same from-account error slot as amount errors, so reuse
+    // the sibling check: a string stays a literal substring (toContain), only a RegExp is a pattern.
+    await this.verifySwapAmountErrorMessageIsCorrect(expectedMessage);
+  }
+
   @Step("Verify swap CTA banner displayed")
   async checkCtaBanner(quotesVisible: boolean) {
     const showDetailsLink = quotesVisible

--- a/e2e/mobile/specs/swap/otherTestCases/swap.crossAccount.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.crossAccount.spec.ts
@@ -1,0 +1,27 @@
+import { SwapProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
+import { runSwapCrossAccountTest } from "./swap.crossAccount";
+
+const dexProviders = [
+  SwapProvider.ONE_INCH,
+  SwapProvider.VELORA,
+  SwapProvider.UNISWAP,
+  SwapProvider.OKX,
+];
+const fromAccount = TokenAccount.ETH_USDT_1;
+const toAccount = Account.ETH_3;
+
+const swapCrossAccountTestConfig = {
+  fromAccount,
+  toAccount,
+  dexProviders,
+  tmsLinks: ["LIVE-19543"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
+};
+
+runSwapCrossAccountTest(
+  swapCrossAccountTestConfig.fromAccount,
+  swapCrossAccountTestConfig.toAccount,
+  swapCrossAccountTestConfig.dexProviders,
+  swapCrossAccountTestConfig.tmsLinks,
+  swapCrossAccountTestConfig.tags,
+);

--- a/e2e/mobile/specs/swap/otherTestCases/swap.crossAccount.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.crossAccount.ts
@@ -1,0 +1,56 @@
+import { Account, TokenAccount } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { performSwapUntilQuoteSelectionStep } from "../../../utils/swapUtils";
+import { SwapProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
+import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
+import { setEnv } from "@ledgerhq/live-env";
+import { beforeAllFunctionSwap } from "../swap.setup";
+import { setTeamOwner } from "../../../helpers/allure/allure-helper";
+import { launchApp } from "helpers/commonHelpers";
+import { pickRotatingProvider } from "@ledgerhq/live-e2e-shared/swap";
+
+setEnv("DISABLE_TRANSACTION_BROADCAST", true);
+
+export function runSwapCrossAccountTest(
+  fromAccount: TokenAccount,
+  toAccount: Account,
+  providers: SwapProvider[],
+  tmsLinks: string[],
+  tags: string[],
+) {
+  describe("Swap cross account warning", () => {
+    beforeAll(async () => {
+      await launchApp({ newInstance: true });
+      await app.speculos.setExchangeDependencies(fromAccount, toAccount);
+      await beforeAllFunctionSwap({
+        userdata: "skip-onboarding",
+        cliCommandsOnApp: [
+          {
+            app: fromAccount.currency.speculosApp,
+            cmd: liveDataWithAddressCommand(fromAccount),
+          },
+          {
+            app: toAccount.currency.speculosApp,
+            cmd: liveDataWithAddressCommand(toAccount),
+          },
+        ],
+      });
+    });
+
+    setTeamOwner(Team.SWAP);
+    tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+    tags.forEach(tag => $Tag(tag));
+
+    it("Should show a visible warning for a cross account swap", async () => {
+      const provider = await pickRotatingProvider(providers, fromAccount, toAccount);
+      await app.swap.logSelectedProvider(provider.uiName);
+      const minAmount = await app.swapLiveApp.getMinimumAmount(fromAccount, toAccount, [
+        provider.name,
+      ]);
+      const errorMessage =
+        "Cross-account swaps are not currently supported. Please ensure your sending and receiving accounts are the same.";
+      await performSwapUntilQuoteSelectionStep(fromAccount, toAccount, minAmount, true, true);
+      await app.swapLiveApp.selectSpecificProvider(provider.uiName);
+      await app.swapLiveApp.verifySwapCrossAccountErrorMessageIsCorrect(errorMessage);
+    });
+  });
+}

--- a/e2e/mobile/utils/swapUtils.ts
+++ b/e2e/mobile/utils/swapUtils.ts
@@ -7,13 +7,19 @@ import BigNumber from "bignumber.js";
 import { deleteSpeculos, launchSpeculos, registerSpeculos } from "./speculosUtils";
 import { log } from "detox";
 
-async function selectCurrency(account: Account, isFromCurrency: boolean = true) {
+async function selectCurrency(
+  account: Account,
+  isFromCurrency: boolean = true,
+  selectSpecificAccount: boolean = false,
+) {
   // Check the appropriate field based on whether we're selecting FROM or TO
   const currentCurrencyText = isFromCurrency
     ? await app.swapLiveApp.getFromCurrencyTexts()
     : await app.swapLiveApp.getToCurrencyTexts();
 
-  if (currentCurrencyText.includes(account.currency.ticker)) {
+  // When a specific (non-default) account is required, always open the drawer to pick it —
+  // even if the currency already matches — otherwise the default first account is kept.
+  if (!selectSpecificAccount && currentCurrencyText.includes(account.currency.ticker)) {
     return;
   }
   if (isFromCurrency) {
@@ -22,7 +28,11 @@ async function selectCurrency(account: Account, isFromCurrency: boolean = true) 
     await app.swapLiveApp.tapToCurrency();
   }
 
-  await app.modularDrawer.selectAsset(account);
+  if (selectSpecificAccount) {
+    await app.modularDrawer.selectAssetAndAccount(account);
+  } else {
+    await app.modularDrawer.selectAsset(account);
+  }
   await app.swapLiveApp.verifyCurrencyIsSelected(account.currency.ticker, isFromCurrency);
 }
 
@@ -31,9 +41,10 @@ export async function performSwapUntilQuoteSelectionStep(
   accountToCredit: Account,
   amount: string,
   continueToQuotes: boolean = true,
+  selectSpecificToAccount: boolean = false,
 ) {
   await selectCurrency(accountToDebit, true);
-  await selectCurrency(accountToCredit, false);
+  await selectCurrency(accountToCredit, false, selectSpecificToAccount);
   await app.swapLiveApp.inputAmount(amount);
   if (continueToQuotes) {
     await waitForWebElementToMatchRegex(app.swapLiveApp.toAmountInput, floatNumberRegex, 20000);

--- a/libs/live-e2e-shared/src/swap.ts
+++ b/libs/live-e2e-shared/src/swap.ts
@@ -109,7 +109,7 @@ function isUsableQuote(q: SwapQuoteItem): boolean {
   return q.code === undefined && Number(q.amountTo) > 0;
 }
 
-async function keepRunningProviders(
+export async function keepRunningProviders(
   eligibleProviders: SwapProvider[],
   accountFrom: Account,
   accountTo: Account,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _This PR **is** the automated coverage (new Desktop Playwright + Mobile Detox specs). It requires Speculos + a simulator + live DEX-provider health, so it runs on the E2E CI rather than the unit-test suite; the per-provider matrix should be confirmed green on a full CI run before merge._
- [x] **Impact of the changes:**
  - Swap cross-account warning on **Desktop** and **Mobile** for the 4 DEX providers (1inch, Velora, Uniswap, OKX).
  - Mobile destination-account selection: `modularDrawer.selectAssetAndAccount` now targets a *specific* account (was always the first). Verify the shared `selectAsset` / `selectFirstAccount` behavior is unchanged for all other swap & buy/sell specs (opt-in flag defaults to `false`).
  - Mobile test isolation: each provider relaunches a fresh app (`launchApp({ newInstance: true })`) — watch total runtime and per-provider stability.
  - `@ledgerhq/live-e2e-shared` now exports `keepRunningProviders` (provider-health skip); ensure no other importer breaks.

### 📝 Description

Adds end-to-end verification for the swap **cross-account warning** on both apps, per QAA-706 / LIVE-19543. Case: swap **USDT (Ethereum 1) → native ETH on a different account (Ethereum 3)** must display _"Cross-account swaps are not currently supported. Please ensure your sending and receiving accounts are the same."_ across the DEX providers 1inch, Velora, Uniswap and OKX.

**Problem** — There was no automated coverage for the cross-account warning. On Mobile, the modular drawer's `selectAsset` always selected the **first** account of the chosen currency, so a "cross-account" swap silently collapsed to the same account and never exercised the warning. Additionally, looping providers via one `describe`/`beforeAll` per provider left the app inside the Swap live-app webview, so `app.init` for providers 2+ timed out waiting for `topbar-discover`.

**Solution**
- **Mobile** — added `modularDrawer.selectAssetAndAccount(account)` (currency + network, then `selectAccount(account.accountName)`), extracted from the existing `selectAsset` so its first-account behavior is untouched. `performSwapUntilQuoteSelectionStep` gained an opt-in `selectSpecificToAccount` (default `false`) that opens the TO drawer even when the ticker already matches and picks the specific destination account.
- **Desktop** — new `crossAccount.warning.swap.spec.ts` drives the same flow through the quote step and asserts the warning per provider, guarded by `keepRunningProviders` so a down provider is skipped rather than failing the suite.
- **Shared** — `@ledgerhq/live-e2e-shared` exports `keepRunningProviders`.

Migrated the specs to `@ledgerhq/live-e2e-shared` imports (away from the deprecated `@ledgerhq/live-common/e2e/*`).

### ❓ Context

- **JIRA or GitHub link**: [QAA-706](https://ledgerhq.atlassian.net/browse/QAA-706) (initial: [LIVE-19543](https://ledgerhq.atlassian.net/browse/LIVE-19543))
- **Desktop CI**: https://github.com/LedgerHQ/ledger-live/actions/runs/28849619629
- **Mobile CI**: https://github.com/LedgerHQ/ledger-live/actions/runs/28849629290

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-706]: https://ledgerhq.atlassian.net/browse/QAA-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ