### PR TITLE
test(mobile): add wallet 4.0 asset aggregation e2e

### DIFF
--- a/.changeset/bright-dai-rows.md
+++ b/.changeset/bright-dai-rows.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Add Wallet 4.0 asset aggregation E2E coverage for stablecoin holdings.

--- a/e2e/mobile/page/index.ts
+++ b/e2e/mobile/page/index.ts
@@ -15,6 +15,7 @@ import OperationDetailsPage from "./trade/operationDetails.page";
 import PasswordEntryPage from "./passwordEntry.page";
 import PortfolioEmptyStatePage from "./wallet/portfolioEmptyState.page";
 import PortfolioPage from "./wallet/portfolio.page";
+import AssetDetailPage from "./wallet/assetDetail.page";
 import ReceivePage from "./trade/receive.page";
 import SendPage from "./trade/send.page";
 import SettingsGeneralPage from "./settings/settingsGeneral.page";
@@ -72,6 +73,7 @@ export class Application {
   private passwordEntryPageInstance = lazyInit(PasswordEntryPage);
   private portfolioEmptyStatePageInstance = lazyInit(PortfolioEmptyStatePage);
   private portfolioPageInstance = lazyInit(PortfolioPage);
+  private assetDetailPageInstance = lazyInit(AssetDetailPage);
   private receivePageInstance = lazyInit(ReceivePage);
   private sendPageInstance = lazyInit(SendPage);
   private settingsPageInstance = lazyInit(SettingsPage);
@@ -163,6 +165,10 @@ export class Application {
 
   public get portfolio() {
     return this.portfolioPageInstance();
+  }
+
+  public get assetDetail() {
+    return this.assetDetailPageInstance();
   }
 
   public get portfolioEmptyState() {

--- a/e2e/mobile/page/wallet/assetDetail.page.ts
+++ b/e2e/mobile/page/wallet/assetDetail.page.ts
@@ -1,0 +1,96 @@
+import { Step } from "jest-allure2-reporter/api";
+import { normalizeText } from "../../helpers/commonHelpers";
+
+type HoldingAddressExpectation = {
+  accountId: string;
+  name: string;
+  addressFragment?: string;
+};
+
+const TOKEN_BALANCE_DECIMAL_PRECISION = 5;
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+
+const parseTickerAmount = (text: string, ticker: string) => {
+  const normalized = normalizeText(text).replace(/,/g, "");
+  const tickerAmountRegex = new RegExp(String.raw`(-?\d+(?:\.\d+)?)\s*${escapeRegExp(ticker)}`);
+  const match = tickerAmountRegex.exec(normalized);
+  if (!match) throw new Error(`Unable to parse ${ticker} amount from "${text}"`);
+  return Number(match[1]);
+};
+
+export default class AssetDetailPage {
+  screenId = "asset-detail-screen";
+  totalBalanceId = "asset-detail-total-balance";
+
+  addressItemId = (accountId: string) => `asset-detail-address-item-${accountId}`;
+
+  private async scrollToAddressItem(accountId: string) {
+    await scrollToId(this.addressItemId(accountId), undefined, 450, "down");
+    await waitForElementById(this.addressItemId(accountId), 10_000, {
+      checkVisibility: false,
+    });
+  }
+
+  private async getVisibleTickerAmount(ticker: string) {
+    const tickerAmountRegex = new RegExp(String.raw`\d+(?:\.\d+)?\s*${escapeRegExp(ticker)}`);
+    const attributes = await getElementByText(tickerAmountRegex, 0).getAttributes();
+    const text = "elements" in attributes ? attributes.elements[0]?.text : attributes.text;
+    const label = "elements" in attributes ? attributes.elements[0]?.label : attributes.label;
+    return parseTickerAmount(String(text || label || ""), ticker);
+  }
+
+  private async getHoldingAddressLabel(accountId: string) {
+    await this.scrollToAddressItem(accountId);
+    return normalizeText(await getLabelOfElement(this.addressItemId(accountId)));
+  }
+
+  private async getHoldingAddressBalance(accountId: string, ticker: string) {
+    return parseTickerAmount(await this.getHoldingAddressLabel(accountId), ticker);
+  }
+
+  @Step("Expect Asset Detail page for ticker")
+  async expectAssetDetailPageForTicker(ticker: string) {
+    await waitForElementById(this.screenId, undefined, { checkVisibility: false });
+    await scrollToId(this.totalBalanceId);
+    jestExpect(await this.getVisibleTickerAmount(ticker)).toBeGreaterThan(0);
+  }
+
+  @Step("Expect Asset Detail total crypto balance for ticker")
+  async expectTotalBalanceCryptoForTicker(ticker: string) {
+    await scrollToId(this.totalBalanceId);
+    jestExpect(await this.getVisibleTickerAmount(ticker)).toBeGreaterThan(0);
+  }
+
+  @Step("Expect holding address details")
+  async expectHoldingAddressDetails(expectedAddresses: HoldingAddressExpectation[], ticker: string) {
+    for (const expectedAddress of expectedAddresses) {
+      const addressLabel = await this.getHoldingAddressLabel(expectedAddress.accountId);
+      jestExpect(addressLabel).toContain(expectedAddress.name);
+
+      if (expectedAddress.addressFragment) {
+        jestExpect(addressLabel.toLowerCase()).toContain(
+          expectedAddress.addressFragment.toLowerCase(),
+        );
+      }
+
+      jestExpect(addressLabel).toMatch(/\$\d/);
+      jestExpect(parseTickerAmount(addressLabel, ticker)).toBeGreaterThan(0);
+    }
+  }
+
+  @Step("Expect holding address balances to add up to total")
+  async expectHoldingAddressBalancesSumToTotal(accountIds: string[], ticker: string) {
+    await scrollToId(this.totalBalanceId);
+    const totalBalance = await this.getVisibleTickerAmount(ticker);
+
+    let holdingBalance = 0;
+    for (const accountId of accountIds) {
+      const accountBalance = await this.getHoldingAddressBalance(accountId, ticker);
+      jestExpect(accountBalance).toBeGreaterThan(0);
+      holdingBalance += accountBalance;
+    }
+
+    jestExpect(holdingBalance).toBeCloseTo(totalBalance, TOKEN_BALANCE_DECIMAL_PRECISION);
+    return { holdingBalance, totalBalance };
+  }
+}

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -3,6 +3,9 @@ import { openDeeplink } from "../../helpers/commonHelpers";
 import { DEFAULT_TIMEOUT } from "../../helpers/elementHelpers";
 import { getFlags } from "../../bridge/server";
 import type { Features } from "@shared/feature-flags";
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+
 export default class PortfolioPage {
   addNewOrExistingAccount = "add-new-account-button";
   assetsListId = "AssetsList";
@@ -64,6 +67,10 @@ export default class PortfolioPage {
   portfolioSettingsButton = async () => getElementById(this.portfolioSettingsId);
   assetItemId = (currencyName: string) => `${this.baseAssetItem}${currencyName}`;
   assetItemBalanceId = (currencyName: string) => `${this.baseAssetItem}${currencyName}-balance`;
+  assetItemCountervalueId = (currencyName: string) =>
+    `${this.baseAssetItem}${currencyName}-countervalue`;
+  assetItemExactRegExp = (currencyName: string) =>
+    new RegExp(`^${this.baseAssetItem}${escapeRegExp(currencyName)}$`);
   tabSelector = (id: "Accounts" | "Assets") => getElementById(`${this.tabSelectorBase}${id}`);
   walletTabSelector = (id: "Wallet" | "Market") =>
     getElementById(`${this.walletTabSelectorBase}${id}`);
@@ -456,6 +463,45 @@ export default class PortfolioPage {
   async tapStablecoinsSectionTitle() {
     await scrollToId(this.stablecoinsSectionHeaderId, this.accountsListView);
     await tapById(this.stablecoinsSectionHeaderId);
+  }
+
+  @Step("Open Wallet 4.0 stablecoins list")
+  async openStablecoinsListW40() {
+    await this.tapStablecoinsSectionTitle();
+    await this.checkStablecoinListPageVisible();
+  }
+
+  @Step("Check aggregated asset row is visible")
+  async checkAggregatedAssetRowVisible(currencyName: string, scrollViewId?: string) {
+    if (scrollViewId) {
+      await scrollToId(this.assetItemId(currencyName), scrollViewId);
+    }
+
+    await detoxExpect(getElementById(this.assetItemId(currencyName))).toBeVisible();
+  }
+
+  @Step("Get aggregated asset row count")
+  async getAggregatedAssetRowCount(currencyName: string) {
+    return await countElementsById(this.assetItemExactRegExp(currencyName));
+  }
+
+  @Step("Check asset countervalue is visible")
+  async checkAssetCountervalueVisible(currencyName: string, scrollViewId?: string) {
+    if (scrollViewId) {
+      await scrollToId(this.assetItemId(currencyName), scrollViewId);
+    }
+
+    await detoxExpect(getElementById(this.assetItemCountervalueId(currencyName))).toBeVisible();
+  }
+
+  @Step("Open Wallet 4.0 asset detail")
+  async openAssetDetailW40(currencyName: string, scrollViewId?: string) {
+    if (scrollViewId) {
+      await scrollToId(this.assetItemId(currencyName), scrollViewId);
+    }
+
+    await detoxExpect(getElementById(this.assetItemId(currencyName))).toBeVisible();
+    await tapById(this.assetItemId(currencyName));
   }
 
   private async checkListPageVisible(listId: string) {

--- a/e2e/mobile/specs/wallet40/assetAggregationMarketDetail.spec.ts
+++ b/e2e/mobile/specs/wallet40/assetAggregationMarketDetail.spec.ts
@@ -1,0 +1,92 @@
+import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
+import { parseExtraFeatureFlags } from "@ledgerhq/live-e2e-shared/featureFlagsJsonUtils";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
+import { WALLET_40_FEATURE_FLAGS } from "../../utils/constants";
+
+import type { OptionalFeatureMap, PartialFeatures } from "@shared/feature-flags";
+
+const TAGS = ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"];
+
+const DAI_ASSET_NAME = "Dai Stablecoin v2.0";
+const DAI_TICKER = "DAI";
+const ETHEREUM_ACCOUNT_ID = "js:2:ethereum:0xE32ad14b89F334dF1CD1036c2a0E39A19248b75a:";
+const POLYGON_ACCOUNT_ID = "js:2:polygon:0xE32ad14b89F334dF1CD1036c2a0E39A19248b75a:";
+
+const ASSET_AGGREGATION_FEATURE_FLAGS = {
+  lwmWallet40: {
+    ...WALLET_40_FEATURE_FLAGS.lwmWallet40,
+    params: {
+      ...WALLET_40_FEATURE_FLAGS.lwmWallet40.params,
+      aggregatedAssets: true,
+      assetSection: true,
+      lazyOnboarding: false,
+      tour: false,
+    },
+  },
+} satisfies OptionalFeatureMap;
+
+const getAddressFromAccountId = (accountId: string) => {
+  const address = accountId.split(":")[3];
+  if (!address) throw new Error(`Unable to resolve address from account id: ${accountId}`);
+  return address;
+};
+
+const getAddressPrefix = (accountId: string) => getAddressFromAccountId(accountId).slice(0, 4);
+
+const isAggregatedAssetsDisabledByJson = () =>
+  parseExtraFeatureFlags<PartialFeatures>(process.env.E2E_FEATURE_FLAGS_JSON).lwmWallet40
+    ?.params?.aggregatedAssets === false;
+
+const describeWithAggregatedAssets = isAggregatedAssetsDisabledByJson() ? describe.skip : describe;
+
+setTeamOwner(Team.WALLET_XP);
+describeWithAggregatedAssets("Wallet 4.0 - Asset Aggregation / Asset Market / Asset Detail", () => {
+  beforeAll(async () => {
+    await app.init({
+      userdata: "wallet40-many-stablecoins",
+      featureFlags: ASSET_AGGREGATION_FEATURE_FLAGS,
+    });
+    await app.mainNavigation.waitForWallet40Ready();
+  });
+
+  TAGS.forEach(tag => $Tag(tag));
+
+  $TmsLink("B2CQA-5519");
+  $TmsLink("B2CQA-5520");
+  it("aggregates the same asset across networks and lists holding addresses", async () => {
+    await app.portfolio.openStablecoinsListW40();
+    await app.portfolio.checkAggregatedAssetRowVisible(
+      DAI_ASSET_NAME,
+      app.portfolio.stablecoinListId,
+    );
+    const aggregatedAssetRowCount = await app.portfolio.getAggregatedAssetRowCount(DAI_ASSET_NAME);
+    expect(aggregatedAssetRowCount).toBe(1);
+    await app.portfolio.checkAssetCountervalueVisible(
+      DAI_ASSET_NAME,
+      app.portfolio.stablecoinListId,
+    );
+
+    await app.portfolio.openAssetDetailW40(DAI_ASSET_NAME, app.portfolio.stablecoinListId);
+    await app.assetDetail.expectAssetDetailPageForTicker(DAI_TICKER);
+    await app.assetDetail.expectTotalBalanceCryptoForTicker(DAI_TICKER);
+    await app.assetDetail.expectHoldingAddressDetails(
+      [
+        {
+          accountId: POLYGON_ACCOUNT_ID,
+          name: "Polygon 1",
+          addressFragment: getAddressPrefix(POLYGON_ACCOUNT_ID),
+        },
+        {
+          accountId: ETHEREUM_ACCOUNT_ID,
+          name: "Ethereum 1",
+          addressFragment: getAddressPrefix(ETHEREUM_ACCOUNT_ID),
+        },
+      ],
+      DAI_TICKER,
+    );
+    await app.assetDetail.expectHoldingAddressBalancesSumToTotal(
+      [POLYGON_ACCOUNT_ID, ETHEREUM_ACCOUNT_ID],
+      DAI_TICKER,
+    );
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** `ledger-live-mobile-e2e-tests` typecheck/lint passed, and the new iOS Detox spec passed locally. Android Detox was attempted locally but the app failed to connect to Detox before the scenario ran.
- [x] **Impact of the changes:**
      - Wallet 4.0 mobile E2E coverage for aggregated stablecoin holdings
      - Stablecoins list navigation and DAI Asset Detail assertions
      - Asset Detail holding balance parsing in mobile E2E page objects

### 📝 Description

This PR is the first minimal batch for LIVE-29336. It covers only Scenario 1: opening the Wallet 4.0 Stablecoins list, verifying that DAI appears as a single aggregated row, opening the DAI Asset Detail page, and validating the Polygon/Ethereum holding rows.

The test enables `aggregatedAssets` only locally for this spec and skips when external E2E feature flags explicitly force `aggregatedAssets:false`. The Asset Detail page object reads the visible DAI balances and asserts that the sum of the holding balances matches the total crypto balance.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29336](https://ledgerhq.atlassian.net/browse/LIVE-29336)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29336]: https://ledgerhq.atlassian.net/browse/LIVE-29336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ