### PR TITLE
[LWD] fix(lld): reliably close Live App webview DevTools on Electron 42

### DIFF
--- a/.changeset/tidy-webview-devtools-cleanup.md
+++ b/.changeset/tidy-webview-devtools-cleanup.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix orphaned Live App `<webview>` DevTools window on Electron 42: leaving a Live App now reliably closes its DevTools window again. The previous cleanup relied on the webview's `devtools-opened` / `devToolsWebContents` capture, which became unreliable on Electron 42 and left the DevTools window open; it is now discovered app-wide via its `devtools://` URL.

--- a/apps/ledger-live-desktop/src/main/webviewHandlers.test.ts
+++ b/apps/ledger-live-desktop/src/main/webviewHandlers.test.ts
@@ -1,5 +1,5 @@
 import { app, ipcMain, session, webContents } from "electron";
-import { setupWebviewHandlers } from "./webviewHandlers";
+import { closeTrackedWebviewDevTools, setupWebviewHandlers } from "./webviewHandlers";
 
 jest.mock("electron", () => ({
   app: {
@@ -17,12 +17,31 @@ jest.mock("electron", () => ({
   },
   webContents: {
     fromId: jest.fn(),
+    getAllWebContents: jest.fn(() => []),
   },
 }));
 
 type DomReadyHandler = (event: Electron.IpcMainEvent, id: number, domains?: string[]) => void;
 type WebContentsCreatedHandler = (event: Electron.Event, contents: Electron.WebContents) => void;
 type SchemeGuard = (event: Electron.Event<{ url: string }>) => void;
+type ContentsListener = (...args: unknown[]) => void;
+
+const makeDevToolsContents = () => ({
+  getType: jest.fn(() => "remote"),
+  getURL: jest.fn(() => "devtools://devtools/bundled/inspector.html"),
+  getTitle: jest.fn(() => "DevTools"),
+  isDestroyed: jest.fn(() => false),
+  close: jest.fn(),
+  on: jest.fn(),
+  once: jest.fn(),
+});
+
+const makeOwner = (id: number, type: string, devToolsWebContents: unknown) => ({
+  id,
+  getType: jest.fn(() => type),
+  isDestroyed: jest.fn(() => false),
+  devToolsWebContents,
+});
 
 describe("setupWebviewHandlers", () => {
   beforeEach(() => {
@@ -177,4 +196,253 @@ describe("setupWebviewHandlers", () => {
       expect(preventDefault).not.toHaveBeenCalled();
     },
   );
+});
+
+describe("guest DevTools tracking", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(webContents.getAllWebContents).mockReturnValue([]);
+    delete (globalThis as typeof globalThis & { __ledgerLiveWebviewHandlersSetup__?: boolean })
+      .__ledgerLiveWebviewHandlersSetup__;
+  });
+
+  const getWebContentsCreatedHandler = () =>
+    (jest.mocked(app.on) as jest.Mock).mock.calls.find(
+      ([eventName]) => eventName === "web-contents-created",
+    )?.[1] as WebContentsCreatedHandler | undefined;
+
+  const getListener = (contents: { on: jest.Mock; once: jest.Mock }, eventName: string) => {
+    const call =
+      contents.on.mock.calls.find(([name]) => name === eventName) ??
+      contents.once.mock.calls.find(([name]) => name === eventName);
+    return call?.[1] as ContentsListener | undefined;
+  };
+
+  // Drops the module-level tracking entry between tests.
+  const cleanup = (dt: { on: jest.Mock; once: jest.Mock }) => getListener(dt, "destroyed")?.();
+
+  // Runs the DevTools discovery path.
+  const discover = (
+    handler: WebContentsCreatedHandler | undefined,
+    devtools: ReturnType<typeof makeDevToolsContents>,
+  ) => {
+    handler?.({} as Electron.Event, devtools as unknown as Electron.WebContents);
+    getListener(devtools, "page-title-updated")?.();
+  };
+
+  it("tracks a guest's DevTools and closes it on that guest's teardown", () => {
+    setupWebviewHandlers(["ledgerlive"]);
+    const handler = getWebContentsCreatedHandler();
+
+    const devtools = makeDevToolsContents();
+    const guest = makeOwner(7, "webview", devtools);
+    jest
+      .mocked(webContents.getAllWebContents)
+      .mockReturnValue([guest, devtools] as unknown as Electron.WebContents[]);
+
+    discover(handler, devtools);
+
+    closeTrackedWebviewDevTools(7);
+    expect(devtools.close).toHaveBeenCalledTimes(1);
+
+    cleanup(devtools);
+  });
+
+  it("does NOT close the main window's own DevTools", () => {
+    setupWebviewHandlers(["ledgerlive"]);
+    const handler = getWebContentsCreatedHandler();
+
+    const mainDevtools = makeDevToolsContents();
+    const mainWindow = makeOwner(1, "window", mainDevtools);
+    jest
+      .mocked(webContents.getAllWebContents)
+      .mockReturnValue([mainWindow, mainDevtools] as unknown as Electron.WebContents[]);
+
+    discover(handler, mainDevtools);
+
+    // A guest teardown (or an app-wide close) must never reach the main window.
+    closeTrackedWebviewDevTools(7);
+    closeTrackedWebviewDevTools();
+    expect(mainDevtools.close).not.toHaveBeenCalled();
+
+    cleanup(mainDevtools);
+  });
+
+  it("closes a guest's DevTools without touching another guest's DevTools", () => {
+    setupWebviewHandlers(["ledgerlive"]);
+    const handler = getWebContentsCreatedHandler();
+
+    const devtoolsA = makeDevToolsContents();
+    const guestA = makeOwner(7, "webview", devtoolsA);
+    const devtoolsB = makeDevToolsContents();
+    const guestB = makeOwner(9, "webview", devtoolsB);
+
+    jest
+      .mocked(webContents.getAllWebContents)
+      .mockReturnValue([guestA, devtoolsA, guestB, devtoolsB] as unknown as Electron.WebContents[]);
+
+    discover(handler, devtoolsA);
+    discover(handler, devtoolsB);
+
+    closeTrackedWebviewDevTools(7);
+    expect(devtoolsA.close).toHaveBeenCalledTimes(1);
+    expect(devtoolsB.close).not.toHaveBeenCalled();
+
+    cleanup(devtoolsA);
+    cleanup(devtoolsB);
+  });
+
+  it("removes a tracked DevTools entry when its WebContents is destroyed", () => {
+    setupWebviewHandlers(["ledgerlive"]);
+    const handler = getWebContentsCreatedHandler();
+
+    const devtools = makeDevToolsContents();
+    const guest = makeOwner(7, "webview", devtools);
+    jest
+      .mocked(webContents.getAllWebContents)
+      .mockReturnValue([guest, devtools] as unknown as Electron.WebContents[]);
+
+    discover(handler, devtools);
+
+    // Simulate the DevTools WebContents being destroyed - the entry must be
+    // dropped so a later close is a no-op (no leak, no use-after-free close()).
+    cleanup(devtools);
+
+    closeTrackedWebviewDevTools(7);
+    expect(devtools.close).not.toHaveBeenCalled();
+  });
+
+  it("drops a tracked DevTools entry when closing throws during teardown", () => {
+    setupWebviewHandlers(["ledgerlive"]);
+    const handler = getWebContentsCreatedHandler();
+
+    const devtools = makeDevToolsContents();
+    devtools.close.mockImplementation(() => {
+      throw new Error("Object has been destroyed");
+    });
+    const guest = makeOwner(7, "webview", devtools);
+    jest
+      .mocked(webContents.getAllWebContents)
+      .mockReturnValue([guest, devtools] as unknown as Electron.WebContents[]);
+
+    discover(handler, devtools);
+
+    expect(() => closeTrackedWebviewDevTools(7)).not.toThrow();
+    expect(devtools.close).toHaveBeenCalledTimes(1);
+
+    closeTrackedWebviewDevTools(7);
+    expect(devtools.close).toHaveBeenCalledTimes(1);
+
+    cleanup(devtools);
+  });
+
+  it("ignores DevTools contents when Electron probes throw during discovery", () => {
+    setupWebviewHandlers(["ledgerlive"]);
+    const handler = getWebContentsCreatedHandler();
+
+    const devtools = makeDevToolsContents();
+    devtools.getURL.mockImplementation(() => {
+      throw new Error("Object has been destroyed");
+    });
+
+    expect(() => discover(handler, devtools)).not.toThrow();
+
+    closeTrackedWebviewDevTools(7);
+    expect(devtools.close).not.toHaveBeenCalled();
+
+    cleanup(devtools);
+  });
+
+  it("retries attribution to a non-webview owner at close time and never closes it", () => {
+    setupWebviewHandlers(["ledgerlive"]);
+    const handler = getWebContentsCreatedHandler();
+
+    const devtools = makeDevToolsContents();
+
+    // Discovery happens with no owner visible yet -> tracked without attribution.
+    jest.mocked(webContents.getAllWebContents).mockReturnValue([]);
+    discover(handler, devtools);
+
+    // By close time the owner is now visible and turns out to be the main
+    // window (non-"webview"): the re-derivation must drop the entry and skip it.
+    const mainWindow = makeOwner(1, "window", devtools);
+    jest
+      .mocked(webContents.getAllWebContents)
+      .mockReturnValue([mainWindow, devtools] as unknown as Electron.WebContents[]);
+
+    closeTrackedWebviewDevTools(7);
+    expect(devtools.close).not.toHaveBeenCalled();
+
+    // Entry was removed, so a subsequent app-wide close is also a no-op.
+    closeTrackedWebviewDevTools();
+    expect(devtools.close).not.toHaveBeenCalled();
+
+    cleanup(devtools);
+  });
+
+  it("retries attribution to another guest at close time and closes only on that guest's teardown", () => {
+    setupWebviewHandlers(["ledgerlive"]);
+    const handler = getWebContentsCreatedHandler();
+
+    const devtools = makeDevToolsContents();
+
+    // Discovery with no owner visible -> tracked without attribution.
+    jest.mocked(webContents.getAllWebContents).mockReturnValue([]);
+    discover(handler, devtools);
+
+    // At close time attribution resolves to a different, still-alive guest.
+    const otherGuest = makeOwner(9, "webview", devtools);
+    jest
+      .mocked(webContents.getAllWebContents)
+      .mockReturnValue([otherGuest, devtools] as unknown as Electron.WebContents[]);
+
+    // Closing for the destroyed guest (7) must not touch guest 9's DevTools.
+    closeTrackedWebviewDevTools(7);
+    expect(devtools.close).not.toHaveBeenCalled();
+
+    // Closing for guest 9 re-derives owner 9 and closes it.
+    closeTrackedWebviewDevTools(9);
+    expect(devtools.close).toHaveBeenCalledTimes(1);
+
+    cleanup(devtools);
+  });
+
+  it("retries attribution to this guest at close time and closes it", () => {
+    setupWebviewHandlers(["ledgerlive"]);
+    const handler = getWebContentsCreatedHandler();
+
+    const devtools = makeDevToolsContents();
+
+    // Discovery with no owner visible -> tracked without attribution.
+    jest.mocked(webContents.getAllWebContents).mockReturnValue([]);
+    discover(handler, devtools);
+
+    // At close time attribution resolves to the guest being torn down.
+    const guest = makeOwner(7, "webview", devtools);
+    jest
+      .mocked(webContents.getAllWebContents)
+      .mockReturnValue([guest, devtools] as unknown as Electron.WebContents[]);
+
+    closeTrackedWebviewDevTools(7);
+    expect(devtools.close).toHaveBeenCalledTimes(1);
+
+    cleanup(devtools);
+  });
+
+  it("closes a still-unattributed DevTools entry as a safety net", () => {
+    setupWebviewHandlers(["ledgerlive"]);
+    const handler = getWebContentsCreatedHandler();
+
+    const devtools = makeDevToolsContents();
+
+    // Discovery with no owner visible, and the re-derivation at close time
+    // still finds no owner.
+    jest.mocked(webContents.getAllWebContents).mockReturnValue([]);
+    discover(handler, devtools);
+
+    closeTrackedWebviewDevTools(7);
+    expect(devtools.close).toHaveBeenCalledTimes(1);
+
+    cleanup(devtools);
+  });
 });

--- a/apps/ledger-live-desktop/src/main/webviewHandlers.ts
+++ b/apps/ledger-live-desktop/src/main/webviewHandlers.ts
@@ -13,6 +13,78 @@ type WebviewHandlersGlobal = typeof globalThis & {
 
 const webviewHandlersGlobal = globalThis as WebviewHandlersGlobal;
 
+// Electron 42 made guest-side DevTools capture unreliable, so discovery happens
+// app-wide and ownership is re-derived when a Live App <webview> is destroyed.
+const trackedDevToolsContents = new Set<Electron.WebContents>();
+
+const isDevToolsContents = (contents: Electron.WebContents) => {
+  try {
+    return (
+      !contents.isDestroyed() &&
+      contents.getType() === "remote" &&
+      // `devtools://` is a stable, localization-independent signal; the exact
+      // "DevTools" title is kept as a fallback in case the URL isn't populated yet.
+      (contents.getURL().startsWith("devtools://") || contents.getTitle() === "DevTools")
+    );
+  } catch {
+    return false;
+  }
+};
+
+const findDevToolsOwner = (
+  devToolsContents: Electron.WebContents,
+): Electron.WebContents | undefined => {
+  try {
+    return webContents
+      .getAllWebContents()
+      .find(wc => !wc.isDestroyed() && wc.devToolsWebContents === devToolsContents);
+  } catch {
+    return undefined;
+  }
+};
+
+const trackDevToolsForGuest = (contents: Electron.WebContents) => {
+  if (!isDevToolsContents(contents)) return;
+  const owner = findDevToolsOwner(contents);
+  if (owner && owner.getType() !== "webview") {
+    trackedDevToolsContents.delete(contents);
+    return;
+  }
+  trackedDevToolsContents.add(contents);
+};
+
+/**
+ * Force-closes tracked, still-alive guest DevTools WebContents.
+ *
+ * When `guestId` is provided, only DevTools whose owner resolves to that guest
+ * are closed. Ownership is re-derived here (more reliable once the DevTools
+ * document has loaded than at discovery): a non-<webview> owner is dropped and
+ * left alone (protecting the developer's own DevTools, even on an app-wide
+ * close), a different still-alive guest is left for its own teardown, and an
+ * unattributable owner is closed as the deliberate Electron 42 safety net.
+ *
+ * Called from the main process when a Live App <webview> guest is destroyed.
+ */
+export function closeTrackedWebviewDevTools(guestId?: number) {
+  for (const contents of trackedDevToolsContents) {
+    if (contents.isDestroyed()) {
+      trackedDevToolsContents.delete(contents);
+      continue;
+    }
+    const owner = findDevToolsOwner(contents);
+    if (owner && owner.getType() !== "webview") {
+      trackedDevToolsContents.delete(contents);
+      continue;
+    }
+    if (guestId !== undefined && owner && owner.id !== guestId) continue;
+    try {
+      contents.close();
+    } catch {
+      trackedDevToolsContents.delete(contents);
+    }
+  }
+}
+
 /**
  * Wires up all security-sensitive handlers for Live App <webview> guests
  * (CSP injection, external-protocol handoff guards, manifest-domain
@@ -125,7 +197,19 @@ export function setupWebviewHandlers(supportedSchemes: string[]) {
   // `event.preventDefault()` inside the scheme guard stops Chromium from
   // delegating the URL to the OS's external-protocol handler.
   app.on("web-contents-created", (_appEvent, contents) => {
-    if (contents.getType() !== "webview") return;
+    const contentsType = contents.getType();
+
+    if (contentsType === "remote") {
+      // DevTools ownership is usually available once the DevTools document loads.
+      contents.on("page-title-updated", () => {
+        trackDevToolsForGuest(contents);
+      });
+      contents.once("destroyed", () => {
+        trackedDevToolsContents.delete(contents);
+      });
+    }
+
+    if (contentsType !== "webview") return;
 
     // Route same-tab `window.open` attempts: http(s) goes to the user's
     // default browser via `openURL`; everything else (including

--- a/apps/ledger-live-desktop/src/main/window-lifecycle.ts
+++ b/apps/ledger-live-desktop/src/main/window-lifecycle.ts
@@ -1,9 +1,10 @@
-import { BrowserWindow, screen, app, WebPreferences, WebContents } from "electron";
+import { BrowserWindow, screen, app, WebPreferences } from "electron";
 import path from "path";
 import { delay } from "@ledgerhq/live-common/promise";
 import { URL, pathToFileURL } from "url";
 import { ledgerUSBVendorId } from "@ledgerhq/devices";
 import { intFromEnv, MIN_HEIGHT, MIN_WIDTH } from "~/config/windowConstants";
+import { closeTrackedWebviewDevTools } from "./webviewHandlers";
 
 export const DEFAULT_WINDOW_WIDTH = intFromEnv("LEDGER_DEFAULT_WINDOW_WIDTH", 1024);
 export const DEFAULT_WINDOW_HEIGHT = intFromEnv("LEDGER_DEFAULT_WINDOW_HEIGHT", 768);
@@ -196,18 +197,12 @@ function setupMainWindowHandlers() {
     return false;
   });
 
-  // Track and clean up a webview's DevTools WebContents to avoid orphaned DevTools windows.
+  // On <webview> teardown, close any tracked DevTools window for that guest id.
+  // (Capture the id before `destroyed` because the WebContents is gone by then.)
   mainWindow.webContents.on("did-attach-webview", function (_event, webContents) {
-    let devtoolContents: WebContents | null = null;
-    webContents.on("devtools-opened", () => {
-      devtoolContents = webContents.devToolsWebContents;
-      devtoolContents?.on("destroyed", () => {
-        devtoolContents = null;
-      });
-    });
-
+    const guestId = webContents.id;
     webContents.on("destroyed", () => {
-      devtoolContents?.close();
+      closeTrackedWebviewDevTools(guestId);
     });
   });
 


### PR DESCRIPTION
### 📝 Description

Leaving a Live App left an orphaned DevTools window on Electron 42. The previous cleanup captured the webview's DevTools via the guest `devtools-opened` / `devToolsWebContents` path, which is unreliable at open/destroy time on Electron 42, so the reference was often empty and nothing was closed.

DevTools windows are now discovered app-wide in `webviewHandlers` by their `devtools://` URL (with the "DevTools" title as a fallback), and force-closed when the owning `<webview>` guest is destroyed. Ownership is re-derived from the live WebContents at close time and scoped to the destroyed guest, so a guest teardown never closes another webview's or the main window's DevTools; an unattributable owner is still closed as a safety net.

Adds unit tests for discovery, per-guest scoping, main-window exclusion and close-time attribution retry.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
