### PR TITLE
[LWM] fix(LIVE-33810): preserve market category on back navigation

### DIFF
--- a/.changeset/beige-jars-smash.md
+++ b/.changeset/beige-jars-smash.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix market category resetting to entry value when navigating back from asset detail

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketCategories.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketCategories.test.ts
@@ -1,0 +1,93 @@
+import { act, renderHook } from "@tests/test-renderer";
+import type { MarketListCategory } from "~/reducers/types";
+import { useMarketCategories } from "../useMarketCategories";
+
+let mockFocusCallback: (() => void) | null = null;
+
+jest.mock("@react-navigation/native", () => {
+  const React = jest.requireActual("react");
+
+  return {
+    ...jest.requireActual("@react-navigation/native"),
+    useFocusEffect: jest.fn((cb: () => void) => {
+      mockFocusCallback = cb;
+      React.useEffect(() => cb(), [cb]);
+    }),
+  };
+});
+
+jest.mock("@ledgerhq/live-common/market/state-manager/api", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/market/state-manager/api"),
+  useGetTrendingCategoriesQuery: () => ({ data: undefined }),
+}));
+
+function simulateFocus() {
+  if (mockFocusCallback) mockFocusCallback();
+}
+
+describe("useMarketCategories", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFocusCallback = null;
+  });
+
+  it("should default to the all category when no routeCategory is given", () => {
+    const { result } = renderHook(() => useMarketCategories());
+    expect(result.current.selectedCategory).toBe("all");
+  });
+
+  it("should use the routeCategory as the initial selected category", () => {
+    const { result } = renderHook(() => useMarketCategories({ routeCategory: "stocks" }));
+    expect(result.current.selectedCategory).toBe("stocks");
+  });
+
+  it("should allow switching the category", () => {
+    const { result } = renderHook(() => useMarketCategories());
+
+    act(() => result.current.onSelectCategory("stocks"));
+
+    expect(result.current.selectedCategory).toBe("stocks");
+  });
+
+  it("should preserve the user-selected category when the screen regains focus (LIVE-33810)", () => {
+    const { result } = renderHook(() => useMarketCategories({ routeCategory: "stocks" }));
+
+    expect(result.current.selectedCategory).toBe("stocks");
+
+    act(() => result.current.onSelectCategory("all"));
+
+    expect(result.current.selectedCategory).toBe("all");
+
+    act(() => simulateFocus());
+
+    expect(result.current.selectedCategory).toBe("all");
+  });
+
+  it("should apply the routeCategory on first focus but not override subsequent user selections", () => {
+    const { result } = renderHook(() => useMarketCategories({ routeCategory: "stocks" }));
+
+    expect(result.current.selectedCategory).toBe("stocks");
+
+    act(() => result.current.onSelectCategory("starred"));
+    expect(result.current.selectedCategory).toBe("starred");
+
+    act(() => simulateFocus());
+
+    expect(result.current.selectedCategory).toBe("starred");
+  });
+
+  it("should apply a new routeCategory when it changes (rerender)", () => {
+    let routeCategory: MarketListCategory | undefined = "stocks";
+    const { result, rerender } = renderHook(() => useMarketCategories({ routeCategory }));
+
+    expect(result.current.selectedCategory).toBe("stocks");
+
+    act(() => result.current.onSelectCategory("all"));
+    expect(result.current.selectedCategory).toBe("all");
+
+    routeCategory = "starred";
+    rerender(undefined);
+
+    expect(result.current.selectedCategory).toBe("starred");
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketCategories.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketCategories.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useFocusEffect } from "@react-navigation/native";
 import { useGetTrendingCategoriesQuery } from "@ledgerhq/live-common/market/state-manager/api";
 import { track } from "~/analytics";
@@ -40,6 +40,7 @@ export function useMarketCategories({
   const { data: trendingCategories } = useGetTrendingCategoriesQuery();
   const entryCategory = routeCategory ?? DEFAULT_CATEGORY;
   const [selectedCategory, setSelectedCategory] = useState<MarketListCategory>(entryCategory);
+  const lastAppliedEntryCategory = useRef<MarketListCategory | undefined>(undefined);
 
   const tabs = useMemo<MarketCategoryTab[]>(
     () => [
@@ -56,7 +57,10 @@ export function useMarketCategories({
 
   useFocusEffect(
     useCallback(() => {
-      setSelectedCategory(entryCategory);
+      if (lastAppliedEntryCategory.current !== entryCategory) {
+        lastAppliedEntryCategory.current = entryCategory;
+        setSelectedCategory(entryCategory);
+      }
     }, [entryCategory]),
   );
 


### PR DESCRIPTION
<!--
Thank you for your contribution! :+1:
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** New regression test `useMarketCategories.test.ts` reproduces the exact LIVE-33810 scenario.
- [x] **Impact of the changes:** Only affects `useMarketCategories.ts` — the category filter state on the Market screen. QA should verify that:
  - Navigating back from a market asset detail preserves the selected category.
  - The initial category from route params (e.g. `"stocks"` from "Explore All Stocks") is still correctly applied on first load.

### 📝 Description

Fixes a bug where the market category filter was silently reset on every screen focus.

`useFocusEffect` in `useMarketCategories.ts` was unconditionally calling `setSelectedCategory(entryCategory)` each time the screen regained focus — including when returning from a market asset detail. This discarded any category change the user had made during the session.

Fix: added a `hasAppliedEntryCategory` ref so the route-param category is applied only once (first mount/focus). Subsequent re-focuses no longer override the user's selection.

https://github.com/user-attachments/assets/b9ee6a82-e2af-4728-a6da-5bd1c1addabc


### ❓ Context

- **JIRA or GitHub link**: [LIVE-33810](https://ledgerhq.atlassian.net/browse/LIVE-33810)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- The code aligns with the requirements described in the linked JIRA or GitHub issue.
- The PR description clearly documents the changes made and explains any technical trade-offs or design decisions.
- There are no undocumented trade-offs, technical debt, or maintainability issues.
- The PR has been tested thoroughly, and any potential edge cases have been considered and handled.
- Any new dependencies have been justified and documented.
- Performance considerations have been taken into account.

[LIVE-33810]: https://ledgerhq.atlassian.net/browse/LIVE-33810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ