### PR TITLE
feat(devtools): add generic websocket transport and protocols packages

### DIFF
--- a/.changeset/wet-walls-play.md
+++ b/.changeset/wet-walls-play.md
@@ -1,0 +1,12 @@
+---
+"@devtools/protocols": minor
+"@devtools/transport": minor
+---
+
+Add WebSocket devtools libraries for web-tools ⇄ Ledger app interaction.
+
+  `transport` provides an isomorphic WebSocket factory with reactive connection
+  state, a handshake protocol, and a `TransportProtocol` interface for custom
+  behaviour. `protocols` builds on it with a `copyStore` protocol that replicates
+  Redux store state across the wire.
+

--- a/devtools/protocols/README.md
+++ b/devtools/protocols/README.md
@@ -1,0 +1,65 @@
+# @devtools/protocols
+
+Message contracts and `TransportProtocol` implementations for DevTools host ⇄ tool communication.
+
+Each protocol defines a `MessageMap`, a `createXxxProtocol` factory, and any helpers the app needs to wire its end. Import from the named export of the protocol you want — no barrel index.
+
+## copy-store
+
+```ts
+import { createCopyStoreProtocol, withCopyStoreHydration } from "@devtools/protocols/copyStore";
+```
+
+Mirrors a Redux store across the wire. Both ends run the same loop: every locally dispatched action is relayed to the peer, and every action received from the peer is dispatched into the local store. A full snapshot is exchanged at connect for initial hydration.
+
+### Wiring — app side (host or tool)
+
+**1. Wrap the root reducer** so it can accept a full snapshot:
+
+```ts
+import { withCopyStoreHydration } from "@devtools/protocols/copyStore";
+
+configureStore({
+  reducer: withCopyStoreHydration(combineReducers({ featureFlags })),
+});
+```
+
+**2. Register the listener middleware** in the store (do not call `startListening` yourself — the protocol owns it):
+
+```ts
+const listenerMiddleware = createListenerMiddleware();
+
+configureStore({
+  reducer: withCopyStoreHydration(combineReducers({ featureFlags })),
+  middleware: gDM => gDM().prepend(listenerMiddleware.middleware),
+});
+```
+
+**3. Create the protocol** and pass it to `createTransport`:
+
+```ts
+ import { createCopyStoreProtocol, replaceStoreAction, type CopyStoreMessages } from "@devtools/protocols/copyStore";
+ import { createTransport } from "@devtools/transport";
+
+const protocol = createCopyStoreProtocol({
+  role: "host",
+  dispatch: store.dispatch,
+  setStoreState: snapshot => store.dispatch(replaceStoreAction(snapshot)),
+  getSnapshot: store.getState,
+  listener: listenerMiddleware,
+});
+
+const transport = createTransport<CopyStoreMessages>(
+  { url: "ws://localhost:3000", origin: "app" },
+  protocol,
+);
+```
+
+### Role behaviour
+
+| Role | `onOpen` |
+|---|---|
+| `host` | Pushes current snapshot immediately |
+| `tool` | Requests a snapshot; hydrates whenever it arrives |
+
+Running both roles covers either join order — the protocol is symmetric once connected.

--- a/devtools/protocols/jest.config.js
+++ b/devtools/protocols/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  transform: {
+    "^.+\\.tsx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  moduleFileExtensions: ["ts", "js", "json"],
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/devtools/protocols/jest/mockStore.ts
+++ b/devtools/protocols/jest/mockStore.ts
@@ -1,0 +1,44 @@
+import type { StoreActionListener } from "../src/copyStore";
+import { COPY_STORE_REPLACE } from "../src/copyStore";
+
+export type MockState = Record<string, unknown>;
+
+/**
+ * Minimal store standing in for an RTK store + listener middleware.
+ *
+ * `dispatch` applies the action to state and then fires each registered listener
+ * effect whose predicate passes — the same seam the copy-store protocol drives.
+ * This lets protocol tests verify echo suppression through real behaviour rather
+ * than spying on the predicate.
+ */
+export function createMockStore(initialState: MockState = {}) {
+  let state: MockState = initialState;
+  const listeners = new Set<{ predicate: () => boolean; effect: (action: unknown) => void }>();
+
+  const listener: StoreActionListener = {
+    startListening: options => {
+      listeners.add(options);
+      return () => listeners.delete(options);
+    },
+  };
+
+  const dispatch = (action: unknown) => {
+    const { type, payload } = action as { type: string; payload?: unknown };
+    if (type === COPY_STORE_REPLACE) {
+      if (payload !== undefined) state = payload as MockState;
+    } else {
+      state = { ...state, lastAction: type };
+    }
+    for (const l of listeners) if (l.predicate()) l.effect(action);
+  };
+
+  return {
+    listener,
+    dispatch,
+    getSnapshot: () => state,
+    setStoreState: (snapshot: unknown) => {
+      state = snapshot as MockState;
+    },
+    getState: () => state,
+  };
+}

--- a/devtools/protocols/package.json
+++ b/devtools/protocols/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@devtools/protocols",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shared WebSocket message contracts for DevTools host ⇄ tool communication",
+  "sideEffects": false,
+  "exports": {
+    "./copyStore": "./src/copyStore.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "format": "oxfmt src jest.config.js",
+    "format:check": "oxfmt src jest.config.js --check",
+    "typecheck": "tsc --noEmit",
+    "coverage": "jest --config jest.config.js --coverage",
+    "test": "jest --config jest.config.js"
+  },
+  "dependencies": {
+    "@devtools/transport": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "jest": "catalog:"
+  }
+}

--- a/devtools/protocols/src/copyStore.test.ts
+++ b/devtools/protocols/src/copyStore.test.ts
@@ -1,0 +1,138 @@
+import type { Transport } from "@devtools/transport";
+import { createMockStore } from "../jest/mockStore";
+import {
+  COPY_STORE_REPLACE,
+  createCopyStoreProtocol,
+  replaceStoreAction,
+  withCopyStoreHydration,
+} from "./copyStore";
+import type { CopyStoreMessages } from "./copyStore";
+
+describe("replaceStoreAction", () => {
+  it("should wrap a snapshot as a replace action", () => {
+    expect(replaceStoreAction({ a: 1 })).toEqual({
+      type: COPY_STORE_REPLACE,
+      payload: { a: 1 },
+    });
+  });
+});
+
+describe("withCopyStoreHydration", () => {
+  const counter = (state: number | undefined = 0, action: { type: string }) =>
+    action.type === "increment" ? state + 1 : state;
+
+  it("should replace the state with the snapshot on a replace action", () => {
+    const reducer = withCopyStoreHydration(counter);
+    expect(reducer(0, replaceStoreAction(42) as { type: string })).toBe(42);
+  });
+
+  it("should pass non-replace actions through the wrapped reducer", () => {
+    const reducer = withCopyStoreHydration(counter);
+    expect(reducer(7, { type: "increment" })).toBe(8);
+  });
+
+  it("should keep the current state on a malformed replace with no payload", () => {
+    const reducer = withCopyStoreHydration(counter);
+    expect(reducer(9, { type: COPY_STORE_REPLACE })).toBe(9);
+  });
+});
+
+describe("createCopyStoreProtocol", () => {
+  function setup(role: "host" | "tool") {
+    const store = createMockStore({ count: 1 });
+    const send = jest.fn();
+    const transport = { send } as unknown as Transport<CopyStoreMessages>;
+
+    const protocol = createCopyStoreProtocol({
+      role,
+      dispatch: store.dispatch,
+      setStoreState: store.setStoreState,
+      getSnapshot: store.getSnapshot,
+      listener: store.listener,
+    });
+
+    return { protocol, transport, send, store };
+  }
+
+  const env = {} as never;
+
+  it("should push a snapshot on open when host", () => {
+    const { protocol, transport, send } = setup("host");
+    protocol.onOpen?.(transport);
+    expect(send).toHaveBeenCalledWith("snapshot", { count: 1 });
+  });
+
+  it("should request a snapshot on open when tool", () => {
+    const { protocol, transport, send } = setup("tool");
+    protocol.onOpen?.(transport);
+    expect(send).toHaveBeenCalledWith("requestSnapshot", null);
+  });
+
+  it("should relay a locally-dispatched action", () => {
+    const { protocol, transport, send, store } = setup("host");
+    protocol.onOpen?.(transport);
+
+    store.dispatch({ type: "local/action" });
+
+    expect(send).toHaveBeenCalledWith("action", { type: "local/action" });
+  });
+
+  it("should dispatch a received action into the local store", () => {
+    const { protocol, transport, store } = setup("host");
+    protocol.onOpen?.(transport);
+
+    protocol.onReceive("action", { type: "remote/action" }, env);
+
+    expect(store.getState().lastAction).toBe("remote/action");
+  });
+
+  it("should not relay a received action back to the peer", () => {
+    const { protocol, transport, send } = setup("host");
+    protocol.onOpen?.(transport);
+    send.mockClear();
+
+    protocol.onReceive("action", { type: "remote/action" }, env);
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("should relay again after a received action has been applied", () => {
+    const { protocol, transport, send, store } = setup("host");
+    protocol.onOpen?.(transport);
+
+    protocol.onReceive("action", { type: "remote/action" }, env);
+    store.dispatch({ type: "local/action" });
+
+    expect(send).toHaveBeenCalledWith("action", { type: "local/action" });
+  });
+
+  it("should hydrate the local store from a received snapshot", () => {
+    const { protocol, transport, store } = setup("tool");
+    protocol.onOpen?.(transport);
+
+    protocol.onReceive("snapshot", { count: 5 }, env);
+
+    expect(store.getState()).toEqual({ count: 5 });
+  });
+
+  it("should answer a snapshot request with the current snapshot", () => {
+    const { protocol, transport, send } = setup("host");
+    protocol.onOpen?.(transport);
+    send.mockClear();
+
+    protocol.onReceive("requestSnapshot", null, env);
+
+    expect(send).toHaveBeenCalledWith("snapshot", { count: 1 });
+  });
+
+  it("should stop relaying after close", () => {
+    const { protocol, transport, send, store } = setup("host");
+    protocol.onOpen?.(transport);
+    protocol.onClose?.();
+    send.mockClear();
+
+    store.dispatch({ type: "local/action" });
+
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/devtools/protocols/src/copyStore.ts
+++ b/devtools/protocols/src/copyStore.ts
@@ -1,0 +1,159 @@
+import type { Role, Transport, TransportProtocol } from "@devtools/transport";
+
+/**
+ * copy-store protocol — mirror a Redux store across the wire.
+ *
+ * The two ends run the same loop: every action dispatched locally is relayed to
+ * the peer (the protocol drives the app's RTK listener middleware), and every action
+ * received from the peer is `dispatch`ed into the local store. Both stores stay in
+ * lock-step; the protocol suppresses relay while applying peer actions, so no echo.
+ * A full snapshot, exchanged once at connect, is applied through `setStoreState`.
+ *
+ * Role only matters at connect time, in `onOpen`:
+ *   - **host** pushes its current snapshot, so a tool already connected hydrates;
+ *   - **tool** requests a snapshot, so it hydrates even if it connects after the host.
+ *
+ * Running both covers either join order. `onReceive` is identical on both sides.
+ *
+ * Build it with {@link createCopyStoreProtocol} and pass the result to
+ * `createTransport<CopyStoreMessages>(config, protocol)`.
+ */
+export type CopyStoreMessages = {
+  /** A Redux action relayed to the peer, dispatched on the other side. */
+  action: unknown;
+  /** Full store snapshot, used for initial hydration. */
+  snapshot: unknown;
+  /** A peer asking for the current snapshot. No payload. */
+  requestSnapshot: null;
+};
+
+export const COPY_STORE_PROTOCOL_ID = "copy-store";
+
+/** Convenience action type for a `setStoreState` impl that replaces state via a root reducer handling it. */
+export const COPY_STORE_REPLACE = "@devtools/copy-store/replace" as const;
+
+/** Convenience: wrap a snapshot as the replace-state action a `setStoreState` impl can dispatch. */
+export const replaceStoreAction = (snapshot: unknown) => ({
+  type: COPY_STORE_REPLACE,
+  payload: snapshot,
+});
+
+/**
+ * Wrap a root reducer so it hydrates on {@link replaceStoreAction}.
+ *
+ * On a {@link COPY_STORE_REPLACE} action carrying a `payload`, it feeds that snapshot
+ * back through the wrapped reducer as the next state
+ *
+ * @example
+ * configureStore({ reducer: withCopyStoreHydration(combineReducers({ featureFlags })) })
+ */
+export function withCopyStoreHydration<S, A extends { type: string }>(
+  reducer: (state: S | undefined, action: A) => S,
+): (state: S | undefined, action: A) => S {
+  return (state, action) => {
+    if (action.type !== COPY_STORE_REPLACE) return reducer(state, action);
+
+    if (!("payload" in action)) return reducer(state, action);
+
+    const { payload } = action as { payload?: unknown };
+    if (payload === undefined) return reducer(state, action);
+    return reducer(payload as S, action);
+  };
+}
+
+/**
+ * The slice of an RTK listener-middleware instance the protocol drives.
+ *
+ * The app creates the instance with `createListenerMiddleware()`, registers its
+ * `.middleware` in the store, and hands the bare instance over — no `startListening`
+ * call of its own. The protocol owns the listener's behaviour: it starts listening
+ * in `onOpen` (relaying every locally-dispatched action) and tears it down in
+ * `onClose` via the returned unsubscribe.
+ *
+ * Structural on purpose: this is exactly the surface RTK's `ListenerMiddlewareInstance`
+ * already satisfies, so the protocol stays free of a hard `@reduxjs/toolkit` dependency.
+ */
+export type StoreActionListener = {
+  startListening(options: {
+    predicate: () => boolean;
+    effect: (action: unknown) => void;
+  }): () => void;
+};
+
+export type CopyStoreOptions = {
+  /** This end's role; only changes `onOpen` behaviour. */
+  role: Role;
+  /** Dispatch into the local store, raw. The protocol guards against the echo loop itself. */
+  dispatch: (action: unknown) => void;
+  /**
+   * Replace the local store with a received full snapshot (hydration). The app
+   * owns how the replace happens — e.g. dispatch {@link replaceStoreAction} into a
+   * root reducer that handles {@link COPY_STORE_REPLACE}, or scope it to mirrored slices.
+   */
+  setStoreState: (snapshot: unknown) => void;
+  /** Read the current full store state, sent on a snapshot push or request. */
+  getSnapshot: () => unknown;
+  /**
+   * The app's empty RTK listener-middleware instance. The protocol drives it:
+   * relays each locally-dispatched action on connect, suppresses relay while
+   * applying peer-originated actions (no echo loop), and stops on disconnect.
+   */
+  listener: StoreActionListener;
+};
+
+/**
+ * Build the copy-store {@link TransportProtocol}.
+ *
+ * @param options - see {@link CopyStoreOptions}; the only role-specific behaviour is the open-time handshake.
+ */
+export function createCopyStoreProtocol(
+  options: CopyStoreOptions,
+): TransportProtocol<CopyStoreMessages> {
+  const { role, dispatch, setStoreState, getSnapshot, listener } = options;
+  let transport: Transport<CopyStoreMessages> | undefined;
+  let unsubscribe: (() => void) | undefined;
+
+  // Set while applying a peer-originated update so the listener skips relaying it
+  // back — this is what breaks the echo loop between the two mirrored stores.
+  let applyingRemote = false;
+  const applyRemote = (apply: () => void) => {
+    applyingRemote = true;
+    try {
+      apply();
+    } finally {
+      applyingRemote = false;
+    }
+  };
+
+  return {
+    onOpen(t) {
+      transport = t;
+      if (role === "host") t.send("snapshot", getSnapshot());
+      else t.send("requestSnapshot", null);
+      unsubscribe = listener.startListening({
+        predicate: () => !applyingRemote,
+        effect: action => t.send("action", action),
+      });
+    },
+
+    onReceive(kind, payload) {
+      switch (kind) {
+        case "action":
+          applyRemote(() => dispatch(payload));
+          break;
+        case "snapshot":
+          applyRemote(() => setStoreState(payload));
+          break;
+        case "requestSnapshot":
+          transport?.send("snapshot", getSnapshot());
+          break;
+      }
+    },
+
+    onClose() {
+      unsubscribe?.();
+      unsubscribe = undefined;
+      transport = undefined;
+    },
+  };
+}

--- a/devtools/protocols/tsconfig.json
+++ b/devtools/protocols/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "moduleSuffixes": [".web", ""],
+    "types": ["jest"]
+
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/devtools/transport/README.md
+++ b/devtools/transport/README.md
@@ -1,0 +1,49 @@
+# @devtools/transport
+
+Generic WebSocket transport for DevTools — connection, status, history, and message framing.
+
+Protocol-agnostic: the transport handles the socket lifecycle and message framing; all domain logic lives in a `TransportProtocol` implementation supplied by the consumer.
+
+## Core concepts
+
+**`Transport<M>`** — the public instance. Imperative writes (`connect`, `disconnect`, `send`, `setUrl`) and reactive reads (`getState`, `subscribe`) are kept separate. `getState` returns a stable-reference snapshot suitable for `useSyncExternalStore`.
+
+**`TransportProtocol<M>`** — the consumer-supplied strategy. Implement `onOpen`, `onReceive`, `onClose`, and `onError` to wire domain logic. In `onOpen` you receive the transport handle and can start sending or attach listeners. See `@devtools/protocols` for ready-made implementations.
+
+**`MessageMap`** — a `Record<string, unknown>` declared by the consumer that binds message kinds to their payload types. The transport is fully typed against it.
+
+**`Envelope<M, K>`** — every message, in and out, is wrapped in an envelope stamped with `id`, `seq`, `ts`, and `origin`. Useful for dedup, ordering, and replay.
+
+## Usage
+
+```ts
+import { createTransport, identityUrl } from "@devtools/transport";
+import type { TransportProtocol } from "@devtools/transport";
+
+type MyMessages = { ping: null; pong: null };
+
+const protocol: TransportProtocol<MyMessages> = {
+  onOpen(t) { t.send("ping", null); },
+  onReceive(kind) { console.log("received", kind); },
+};
+
+const transport = createTransport<MyMessages>(
+  { url: identityUrl("ws://localhost:3000", { role: "tool", id: "web-tools", target: "app" }), origin: "web-tools" },
+  protocol,
+);
+
+transport.connect();
+```
+
+## Handshake / identity
+
+Identity travels in the connection URL's query string so the relay can read it from the HTTP upgrade request without an in-band hello frame.
+
+| Helper | Side | Purpose |
+|---|---|---|
+| `identityUrl(baseUrl, identity)` | client | Build the full connect URL |
+| `identityToQuery(identity)` | client | Encode identity as a query string only |
+| `parseIdentity(reqUrl)` | relay | Parse identity from an upgrade request URL |
+
+A `host` omits `target`; a `tool` sets `target` to the host id it wants to reach.
+

--- a/devtools/transport/jest.config.js
+++ b/devtools/transport/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  transform: {
+    "^.+\\.tsx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  moduleFileExtensions: ["ts", "js", "json"],
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/devtools/transport/package.json
+++ b/devtools/transport/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@devtools/transport",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Generic WebSocket transport for DevTools — connection, status, history, framing",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "sideEffects": false,
+  "scripts": {
+    "format": "oxfmt src jest.config.js",
+    "format:check": "oxfmt src jest.config.js --check",
+    "typecheck": "tsc --noEmit",
+    "test": "jest --config jest.config.js",
+    "coverage": "jest --config jest.config.js --coverage"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/devtools/transport/src/createTransport.test.ts
+++ b/devtools/transport/src/createTransport.test.ts
@@ -1,0 +1,293 @@
+import { createTransport } from "./createTransport";
+import type { TransportConfig, TransportProtocol, WebSocketLike } from "./types";
+
+type TestMap = { ping: string; pong: number };
+
+function makeMockSocket() {
+  const socket: WebSocketLike = {
+    send: jest.fn(),
+    close: jest.fn(),
+    onopen: null,
+    onclose: null,
+    onerror: null,
+    onmessage: null,
+  };
+  return {
+    socket,
+    open: () => socket.onopen?.({}),
+    message: (data: unknown) => socket.onmessage?.({ data: JSON.stringify(data) }),
+    error: () => socket.onerror?.({}),
+    close: () => socket.onclose?.({}),
+  };
+}
+
+function makeTransport(
+  overrides?: Partial<TransportConfig>,
+  protocol?: Partial<TransportProtocol<TestMap>>,
+) {
+  const mock = makeMockSocket();
+  const factory = jest.fn(() => mock.socket);
+  const config: TransportConfig = {
+    url: "ws://localhost",
+    origin: "test-origin",
+    socketFactory: factory,
+    ...overrides,
+  };
+  const proto: TransportProtocol<TestMap> = {
+    onReceive: jest.fn(),
+    onOpen: jest.fn(),
+    onClose: jest.fn(),
+    onError: jest.fn(),
+    ...protocol,
+  };
+  const transport = createTransport<TestMap>(config, proto);
+  return { transport, mock, factory, proto };
+}
+
+describe("createTransport — status transitions", () => {
+  it("should start in idle", () => {
+    const { transport } = makeTransport();
+    expect(transport.getState().status).toBe("idle");
+  });
+
+  it("should move to connecting when connect() is called", () => {
+    const { transport } = makeTransport();
+    transport.connect();
+    expect(transport.getState().status).toBe("connecting");
+  });
+
+  it("should move to open when the socket fires onopen", () => {
+    const { transport, mock } = makeTransport();
+    transport.connect();
+    mock.open();
+    expect(transport.getState().status).toBe("open");
+  });
+
+  it("should move to closed when the socket fires onclose", () => {
+    const { transport, mock } = makeTransport();
+    transport.connect();
+    mock.open();
+    mock.close();
+    expect(transport.getState().status).toBe("closed");
+  });
+
+  it("should move to error when the socket fires onerror", () => {
+    const { transport, mock } = makeTransport();
+    transport.connect();
+    mock.error();
+    expect(transport.getState().status).toBe("error");
+  });
+
+  it("should set lastError on socket error", () => {
+    const { transport, mock } = makeTransport();
+    transport.connect();
+    mock.error();
+    expect(transport.getState().lastError).toBeInstanceOf(Error);
+  });
+
+  it("should move to closed when disconnect() is called", () => {
+    const { transport, mock } = makeTransport();
+    transport.connect();
+    mock.open();
+    transport.disconnect();
+    expect(transport.getState().status).toBe("closed");
+  });
+
+  it("should call socket.close() on disconnect()", () => {
+    const { transport, mock } = makeTransport();
+    transport.connect();
+    transport.disconnect();
+    expect(mock.socket.close).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createTransport — connect() guard", () => {
+  it("should be a no-op when called while already connected", () => {
+    const { transport, factory } = makeTransport();
+    transport.connect();
+    transport.connect();
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createTransport — send()", () => {
+  it("should return an envelope with the correct kind and payload", () => {
+    const { transport, mock } = makeTransport();
+    transport.connect();
+    mock.open();
+    const env = transport.send("ping", "hello");
+    expect(env.kind).toBe("ping");
+    expect(env.payload).toBe("hello");
+  });
+
+  it("should stamp origin from config", () => {
+    const { transport, mock } = makeTransport();
+    transport.connect();
+    mock.open();
+    const env = transport.send("ping", "hello");
+    expect(env.origin).toBe("test-origin");
+  });
+
+  it("should increment seq monotonically", () => {
+    const { transport, mock } = makeTransport();
+    transport.connect();
+    mock.open();
+    const first = transport.send("ping", "a");
+    const second = transport.send("ping", "b");
+    expect(second.seq).toBe(first.seq + 1);
+  });
+
+  it("should call socket.send with JSON-encoded envelope", () => {
+    const { transport, mock } = makeTransport();
+    transport.connect();
+    mock.open();
+    const env = transport.send("ping", "hello");
+    expect(mock.socket.send).toHaveBeenCalledWith(JSON.stringify(env));
+  });
+
+  it("should throw an error when sending while disconnected", () => {
+    const { transport } = makeTransport();
+    transport.connect();
+    transport.disconnect();
+    expect(() => transport.send("ping", "hello")).toThrow("transport is not open");
+  });
+});
+
+describe("createTransport — history", () => {
+  it("should record sent envelopes in order", () => {
+    const { transport, mock } = makeTransport();
+    transport.connect();
+    mock.open();
+    transport.send("ping", "first");
+    transport.send("ping", "second");
+    const { history } = transport.getState();
+    expect(history[0].payload).toBe("first");
+    expect(history[1].payload).toBe("second");
+  });
+
+  it("should record received messages in history", () => {
+    const { transport, mock } = makeTransport();
+    transport.connect();
+    mock.open();
+    mock.message({ id: "x", seq: 0, ts: 0, origin: "remote", kind: "pong", payload: 42 });
+    const { history } = transport.getState();
+    expect(history[0]).toMatchObject({ kind: "pong", payload: 42 });
+  });
+
+  it("should evict the oldest entry when historyLimit is exceeded", () => {
+    const { transport, mock } = makeTransport({ historyLimit: 2 });
+    transport.connect();
+    mock.open();
+    transport.send("ping", "a");
+    transport.send("ping", "b");
+    transport.send("ping", "c");
+    const { history } = transport.getState();
+    expect(history).toHaveLength(2);
+    expect(history[0].payload).toBe("b");
+    expect(history[1].payload).toBe("c");
+  });
+});
+
+describe("createTransport — subscribe()", () => {
+  it("should call listener on status change", () => {
+    const { transport } = makeTransport();
+    const listener = jest.fn();
+    transport.subscribe(listener);
+    transport.connect();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("should stop calling listener after unsubscribe", () => {
+    const { transport } = makeTransport();
+    const listener = jest.fn();
+    const unsub = transport.subscribe(listener);
+    unsub();
+    transport.connect();
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe("createTransport — getState()", () => {
+  it("should return the same reference between state changes", () => {
+    const { transport } = makeTransport();
+    const a = transport.getState();
+    const b = transport.getState();
+    expect(a).toBe(b);
+  });
+
+  it("should return a new reference after a state change", () => {
+    const { transport } = makeTransport();
+    const before = transport.getState();
+    transport.connect();
+    const after = transport.getState();
+    expect(before).not.toBe(after);
+  });
+});
+
+describe("createTransport — setUrl()", () => {
+  it("should reconnect with the new URL", () => {
+    const { transport, factory } = makeTransport();
+    transport.connect();
+    transport.setUrl("ws://newhost");
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(factory).toHaveBeenNthCalledWith(2, "ws://newhost", undefined);
+  });
+
+  it("should close the old socket before reconnecting", () => {
+    const { transport, mock } = makeTransport();
+    transport.connect();
+    transport.setUrl("ws://newhost");
+    expect(mock.socket.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("should reflect the new URL in state", () => {
+    const { transport } = makeTransport();
+    transport.setUrl("ws://newhost");
+    expect(transport.getState().url).toBe("ws://newhost");
+  });
+});
+
+describe("createTransport — protocol callbacks", () => {
+  it("should call onOpen with the transport handle when socket opens", () => {
+    const { transport, mock, proto } = makeTransport();
+    transport.connect();
+    mock.open();
+    expect(proto.onOpen).toHaveBeenCalledWith(transport);
+  });
+
+  it("should call onReceive with kind and payload on incoming message", () => {
+    const { transport, mock, proto } = makeTransport();
+    transport.connect();
+    mock.open();
+    mock.message({ id: "x", seq: 0, ts: 0, origin: "remote", kind: "pong", payload: 7 });
+    expect(proto.onReceive).toHaveBeenCalledWith(
+      "pong",
+      7,
+      expect.objectContaining({ kind: "pong", payload: 7 }),
+    );
+  });
+
+  it("should call onError on socket error", () => {
+    const { transport, mock, proto } = makeTransport();
+    transport.connect();
+    mock.error();
+    expect(proto.onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("should call onClose when socket closes", () => {
+    const { transport, mock, proto } = makeTransport();
+    transport.connect();
+    mock.open();
+    mock.close();
+    expect(proto.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("should ignore stale socket events after disconnect", () => {
+    const { transport, mock, proto } = makeTransport();
+    transport.connect();
+    mock.open();
+    transport.disconnect();
+    mock.close();
+    expect(proto.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/devtools/transport/src/createTransport.ts
+++ b/devtools/transport/src/createTransport.ts
@@ -1,0 +1,162 @@
+import type {
+  ConnectionStatus,
+  Envelope,
+  MessageMap,
+  Transport,
+  TransportConfig,
+  TransportProtocol,
+  TransportState,
+  WebSocketLike,
+} from "./types";
+
+import { createSocketFactory } from "./socketFactory";
+
+const isEnvelope = <M extends MessageMap>(value: unknown): value is Envelope<M> =>
+  typeof value === "object" && value !== null && "kind" in value && "payload" in value;
+
+export function createTransport<M extends MessageMap>(
+  config: TransportConfig,
+  protocol: TransportProtocol<M>,
+): Transport<M> {
+  const factory = config.socketFactory ?? createSocketFactory();
+  const historyLimit = config.historyLimit ?? 500;
+
+  // --- private state: the transport owns all of this ---
+  let socket: WebSocketLike | null = null;
+  let status: ConnectionStatus = "idle";
+  let url = config.url;
+  let seq = 0;
+  let lastError: Error | undefined;
+  let history: ReadonlyArray<Envelope<M>> = [];
+  const listeners = new Set<() => void>();
+
+  function buildSnapshot(): TransportState<M> {
+    return {
+      status,
+      url,
+      history,
+      lastError,
+    };
+  }
+
+  let snapshot: TransportState<M> = buildSnapshot();
+
+  function emit() {
+    snapshot = buildSnapshot();
+    listeners.forEach(fn => fn());
+  }
+
+  function setStatus(next: ConnectionStatus) {
+    status = next;
+    emit();
+  }
+
+  function record(env: Envelope<M>) {
+    if (historyLimit <= 0) return;
+    history = [...history, env].slice(-historyLimit);
+  }
+
+  const transport: Transport<M> = {
+    connect() {
+      if (socket) return;
+      lastError = undefined;
+      setStatus("connecting");
+      try {
+        const s = factory(url, config.wsSubProtocols);
+        socket = s;
+        s.onopen = () => {
+          if (socket !== s) return;
+          setStatus("open");
+          protocol.onOpen?.(transport);
+        };
+        s.onmessage = e => {
+          if (socket !== s) return;
+          try {
+            const parsed = JSON.parse(String(e.data));
+            if (!isEnvelope<M>(parsed)) throw new Error("websocket message has invalid shape");
+            const env = parsed;
+            record(env);
+            emit();
+            protocol.onReceive(env.kind, env.payload, env);
+          } catch (err) {
+            const error = new Error("websocket message parse error", { cause: err });
+            lastError = error;
+            socket = null;
+            s.close();
+            setStatus("error");
+            protocol.onError?.(error);
+            protocol.onClose?.();
+          }
+        };
+        s.onerror = () => {
+          if (socket !== s) return;
+          socket = null;
+          s.close();
+
+          lastError = new Error("websocket error");
+          setStatus("error");
+          protocol.onError?.(lastError);
+          protocol.onClose?.();
+        };
+        s.onclose = () => {
+          if (socket !== s) return;
+          socket = null;
+          setStatus("closed");
+          protocol.onClose?.();
+        };
+      } catch (err) {
+        lastError = new Error("websocket connection error", { cause: err });
+        setStatus("error");
+        protocol.onError?.(lastError);
+        protocol.onClose?.();
+      }
+    },
+
+    disconnect() {
+      const local = socket;
+      socket = null;
+      local?.close();
+      setStatus("closed");
+      protocol.onClose?.();
+    },
+
+    send<K extends keyof M>(kind: K, payload: M[K]): Envelope<M, K> {
+      if (status !== "open") {
+        throw new Error("transport is not open");
+      }
+      const date = Date.now();
+      seq++;
+      const env = {
+        id: `${config.origin}-${date}-${seq}`,
+        seq: seq,
+        ts: date,
+        origin: config.origin,
+        kind,
+        payload,
+      };
+      socket?.send(JSON.stringify(env));
+      record(env);
+      emit();
+      return env;
+    },
+
+    setUrl(next: string) {
+      url = next;
+      transport.disconnect();
+      transport.connect();
+    },
+
+    getState() {
+      return snapshot;
+    },
+
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+
+  return transport;
+}

--- a/devtools/transport/src/handshake.test.ts
+++ b/devtools/transport/src/handshake.test.ts
@@ -1,0 +1,92 @@
+import { identityToQuery, identityUrl, parseIdentity } from "./handshake";
+import type { Identity } from "./handshake";
+
+describe("identityToQuery", () => {
+  it("should encode role and id for a host", () => {
+    const result = identityToQuery({ role: "host", id: "app" });
+    expect(new URLSearchParams(result).get("role")).toBe("host");
+    expect(new URLSearchParams(result).get("id")).toBe("app");
+    expect(new URLSearchParams(result).get("target")).toBeNull();
+  });
+
+  it("should include target when provided", () => {
+    const result = identityToQuery({ role: "tool", id: "web-tools", target: "app" });
+    expect(new URLSearchParams(result).get("target")).toBe("app");
+  });
+
+  it("should omit target when undefined", () => {
+    const result = identityToQuery({ role: "tool", id: "web-tools" });
+    expect(new URLSearchParams(result).has("target")).toBe(false);
+  });
+
+  it("should percent-encode special characters in id", () => {
+    const result = identityToQuery({ role: "host", id: "my app" });
+    expect(new URLSearchParams(result).get("id")).toBe("my app");
+  });
+});
+
+describe("identityUrl", () => {
+  it("should append query string with ? when base URL has none", () => {
+    const url = identityUrl("ws://localhost:8080", { role: "host", id: "app" });
+    expect(url).toMatch(/^ws:\/\/localhost:8080\?/);
+    const qs = url.split("?")[1];
+    expect(new URLSearchParams(qs).get("role")).toBe("host");
+  });
+
+  it("should append with & when base URL already has a query string", () => {
+    const url = identityUrl("ws://localhost:8080?foo=bar", {
+      role: "tool",
+      id: "dev",
+      target: "app",
+    });
+    expect(url).toMatch(/^ws:\/\/localhost:8080\?foo=bar&/);
+  });
+
+  it("should include target in the final URL", () => {
+    const url = identityUrl("ws://localhost", { role: "tool", id: "dev", target: "app" });
+    const qs = url.split("?")[1];
+    expect(new URLSearchParams(qs).get("target")).toBe("app");
+  });
+});
+
+describe("parseIdentity", () => {
+  it("should parse a valid host URL", () => {
+    const result = parseIdentity("/?role=host&id=app");
+    expect(result).toEqual({ role: "host", id: "app", target: undefined });
+  });
+
+  it("should parse a valid tool URL with target", () => {
+    const result = parseIdentity("/?role=tool&id=web-tools&target=app");
+    expect(result).toEqual({ role: "tool", id: "web-tools", target: "app" });
+  });
+
+  it("should return undefined when role is missing", () => {
+    expect(parseIdentity("/?id=app")).toBeUndefined();
+  });
+
+  it("should return undefined when id is missing", () => {
+    expect(parseIdentity("/?role=host")).toBeUndefined();
+  });
+
+  it("should return undefined when role is invalid", () => {
+    expect(parseIdentity("/?role=admin&id=app")).toBeUndefined();
+  });
+
+  it("should return undefined for undefined input", () => {
+    expect(parseIdentity(undefined)).toBeUndefined();
+  });
+
+  it("should return undefined for an empty string", () => {
+    expect(parseIdentity("")).toBeUndefined();
+  });
+
+  it("should handle a URL with no query string", () => {
+    expect(parseIdentity("/")).toBeUndefined();
+  });
+
+  it("should round-trip through identityToQuery", () => {
+    const identity: Identity = { role: "tool", id: "web-tools", target: "app" };
+    const qs = `/?${identityToQuery(identity)}`;
+    expect(parseIdentity(qs)).toEqual(identity);
+  });
+});

--- a/devtools/transport/src/handshake.ts
+++ b/devtools/transport/src/handshake.ts
@@ -1,0 +1,48 @@
+/**
+ * Base handshake protocol — the single source of truth shared by every client
+ * (transport side) and the relay (server side).
+ *
+ * Identity is fixed and known at connect, so it travels in the connection URL's
+ * query string (read from the HTTP upgrade request) rather than an in-band hello
+ * frame. Clients build the URL with {@link identityUrl}; the relay reads it with
+ * {@link parseIdentity}. Both use this one file so the param names never drift.
+ */
+
+export type Role = "host" | "tool";
+
+/** Who a connection is, declared in its connect URL. */
+export type Identity = {
+  role: Role;
+  id: string;
+  /** A `tool` names the host it wants to talk to. A `host` omits it. */
+  target?: string;
+};
+
+/** Encode an identity as a query string. */
+export function identityToQuery(identity: Identity): string {
+  const params = new URLSearchParams({ role: identity.role, id: identity.id });
+  if (identity.target) params.set("target", identity.target);
+  return params.toString();
+}
+
+/** Build a full connect URL with the identity baked into the query. */
+export function identityUrl(baseUrl: string, identity: Identity): string {
+  const sep = baseUrl.includes("?") ? "&" : "?";
+  return `${baseUrl}${sep}${identityToQuery(identity)}`;
+}
+
+/**
+ * Relay side: read the identity from the upgrade request URL (`req.url`, e.g.
+ * `"/?role=tool&id=web-tools&target=app"`). Returns `undefined` if invalid.
+ */
+export function parseIdentity(reqUrl: string | undefined): Identity | undefined {
+  if (!reqUrl) return undefined;
+  const qs = reqUrl.includes("?") ? reqUrl.slice(reqUrl.indexOf("?") + 1) : "";
+  const params = new URLSearchParams(qs);
+  const role = params.get("role");
+  const id = params.get("id");
+  if ((role === "host" || role === "tool") && id) {
+    return { role, id, target: params.get("target") ?? undefined };
+  }
+  return undefined;
+}

--- a/devtools/transport/src/index.ts
+++ b/devtools/transport/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export { identityToQuery, identityUrl, parseIdentity, type Identity, type Role } from "./handshake";
+export { createTransport } from "./createTransport";

--- a/devtools/transport/src/socketFactory.ts
+++ b/devtools/transport/src/socketFactory.ts
@@ -1,0 +1,28 @@
+import type { WebSocketLike } from "./types";
+
+export function createSocketFactory() {
+  return function socketFactory(url: string, protocols?: string | string[]): WebSocketLike {
+    if (typeof WebSocket === "undefined") {
+      throw new TypeError(
+        "Global WebSocket is not available; provide TransportConfig.socketFactory",
+      );
+    }
+    const ws = new WebSocket(url, protocols);
+
+    const socket: WebSocketLike = {
+      send: data => ws.send(data),
+      close: (code, reason) => ws.close(code, reason),
+      onopen: null,
+      onclose: null,
+      onerror: null,
+      onmessage: null,
+    };
+
+    ws.onopen = event => socket.onopen?.(event);
+    ws.onclose = event => socket.onclose?.(event);
+    ws.onerror = event => socket.onerror?.(event);
+    ws.onmessage = event => socket.onmessage?.({ data: event.data });
+
+    return socket;
+  };
+}

--- a/devtools/transport/src/types.ts
+++ b/devtools/transport/src/types.ts
@@ -1,0 +1,136 @@
+/**
+ * Map of message kinds to their payload type, declared by the consumer.
+ *
+ * Transport is generic over this map: it gets typed `kind`s and payloads while
+ * staying ignorant of what any kind means. `@devtools/protocols` (or any other
+ * consumer) defines its own `MessageMap` — e.g. `{ action: AnyAction; snapshot: RootState }`.
+ */
+export type MessageMap = Record<string, unknown>;
+
+/**
+ * A framed message as it travels over the socket — the transport's only I/O type.
+ *
+ * The consumer sends `(kind, payload)`; transport stamps `id`/`seq`/`ts`/`origin`
+ * and emits a full `Envelope`. Received messages are full `Envelope`s too.
+ *
+ * @typeParam M - The consumer's {@link MessageMap}.
+ * @typeParam K - The specific kind this envelope carries.
+ */
+export type Envelope<M extends MessageMap, K extends keyof M = keyof M> = {
+  /** Unique per message — used for dedup. */
+  id: string;
+  /** Monotonic per sender — used for ordering and late-join replay. */
+  seq: number;
+  /** Creation time, epoch ms. */
+  ts: number;
+  /** Sender identity, taken from {@link TransportConfig.origin}. */
+  origin: string;
+  /** Typed key of the consumer's {@link MessageMap}. */
+  kind: K;
+  /** Payload type bound to `kind` by the {@link MessageMap}. */
+  payload: M[K];
+};
+
+/**
+ * Connection lifecycle state, surfaced through {@link TransportState.status}.
+ */
+export type ConnectionStatus = "idle" | "connecting" | "open" | "closed" | "error";
+
+/**
+ * Strategy declared by transport and implemented by the consumer.
+ *
+ * Transport knows nothing about Redux or any domain — it only calls these
+ * methods. The implementation's bodies hold all the real logic (e.g. dispatching
+ * to an RTK store). This is the dependency-inversion seam: transport depends on
+ * the interface, the consumer provides the concrete impl via the constructor.
+ *
+ * Methods are inbound/lifecycle only. There is deliberately **no `onSend`** —
+ * outbound flows the other way (the impl calls {@link Transport.send}), and any
+ * "send when X changes" logic is wired by the impl inside {@link onOpen}, where
+ * it receives the transport handle.
+ *
+ * @typeParam M - The consumer's {@link MessageMap}.
+ */
+export interface TransportProtocol<M extends MessageMap> {
+  /** Called for every received message, narrowed by `kind`. */
+  onReceive<K extends keyof M>(kind: K, payload: M[K], env: Envelope<M, K>): void;
+  /** Called once the socket is open; the impl gets the handle to send or wire listeners. */
+  onOpen?(transport: Transport<M>): void;
+  /** Called when the socket closes. */
+  onClose?(): void;
+  /** Called on a connection or protocol error. */
+  onError?(err: Error): void;
+}
+
+/**
+ * Minimal WebSocket surface the transport relies on.
+ *
+ * Lets the transport stay isomorphic: the browser passes the global `WebSocket`,
+ * Node passes the `ws` package — both satisfy this shape. Also the test seam.
+ */
+export interface WebSocketLike {
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  onopen: ((ev: unknown) => void) | null;
+  onclose: ((ev: unknown) => void) | null;
+  onerror: ((ev: unknown) => void) | null;
+  onmessage: ((ev: { data: unknown }) => void) | null;
+}
+
+/**
+ * Construction config for a {@link Transport}. Only `url` and `origin` are required.
+ */
+export type TransportConfig = {
+  /** WebSocket URL to connect to. */
+  url: string;
+  /** Identity stamped on every outbound {@link Envelope}. */
+  origin: string;
+  /** Optional WebSocket subprotocols. */
+  wsSubProtocols?: string | string[];
+  /** History ring-buffer size; defaults to ~500. */
+  historyLimit?: number;
+  /**
+   * Factory for the underlying socket — the isomorphism seam. Defaults to the
+   * global `WebSocket` when present; Node consumers pass a `ws`-backed factory.
+   */
+  socketFactory?: (url: string, protocols?: string | string[]) => WebSocketLike;
+};
+
+/**
+ * Reactive snapshot of a {@link Transport}, read via {@link Transport.getState}.
+ *
+ * Must be a cached value with a stable reference between changes so it can back
+ * `useSyncExternalStore` without looping.
+ *
+ * @typeParam M - The consumer's {@link MessageMap}.
+ */
+export type TransportState<M extends MessageMap> = {
+  status: ConnectionStatus;
+  url: string;
+  history: ReadonlyArray<Envelope<M>>;
+  lastError?: Error;
+};
+
+/**
+ * Public instance type of the transport.
+ *
+ * Split by direction: imperative **writes** are methods; reactive **reads** go
+ * through `getState`/`subscribe`. No `dispatch`, `store`, `role` or `snapshot`
+ * here — all domain logic lives in the {@link TransportProtocol} implementation.
+ *
+ * @typeParam M - The consumer's {@link MessageMap}.
+ */
+export interface Transport<M extends MessageMap> {
+  /** Open the connection. */
+  connect(): void;
+  /** Close the connection and stop reconnecting. */
+  disconnect(): void;
+  /** Frame and ship a message; returns the stamped envelope. */
+  send<K extends keyof M>(kind: K, payload: M[K]): Envelope<M, K>;
+  /** Change the target URL and reconnect */
+  setUrl(url: string): void;
+  /** Cached, stable-reference snapshot for reactive reads. */
+  getState(): TransportState<M>;
+  /** Subscribe to state changes; returns an unsubscribe function. */
+  subscribe(listener: () => void): () => void;
+}

--- a/devtools/transport/tsconfig.json
+++ b/devtools/transport/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleSuffixes": [".web", ""],
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/devtools/tsconfig.json
+++ b/devtools/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "files": [],
-  "references": [{ "path": "./shell"}],
+  "references": [{ "path": "./shell" }, { "path": "./feature-flags" }, { "path": "./registry" }, { "path": "./transport" }, { "path": "./protocols" }],
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2909,6 +2909,16 @@ importers:
         specifier: 'catalog:'
         version: 6.0.2
 
+  devtools/protocols:
+    dependencies:
+      '@devtools/transport':
+        specifier: workspace:*
+        version: link:../transport
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.2
+
   devtools/registry:
     dependencies:
       '@devtools/feature-flags':
@@ -3066,6 +3076,24 @@ importers:
       tailwind-merge:
         specifier: 'catalog:'
         version: 3.4.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.2
+
+  devtools/transport:
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2915,6 +2915,15 @@ importers:
         specifier: workspace:*
         version: link:../transport
     devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -65227,7 +65236,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -65351,6 +65360,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2924,6 +2924,9 @@ importers:
       '@types/jest':
         specifier: 'catalog:'
         version: 30.0.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -65236,7 +65239,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -65360,54 +65363,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->
  Adds 2 new libraries in devtools for WebSocket-based interaction between web-tools and Ledger apps.

  Adds a transport library that defines the shared types and a factory to spin up an isomorphic WebSocket (browser or
  Node). It exposes a reactive connection state (status, history) alongside the imperative send/connect API, plus a
  handshake protocol so any WebSocket server built for it can identify and route connections. The library also defines a
  TransportProtocol interface, the seam for plugging custom behaviour per use case.

  A second library, protocols, builds on top to define concrete protocols. It depends directly on transport. For now it
  ships a single copyStore protocol that replicates Redux store state across the wire.


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-29142](https://ledgerhq.atlassian.net/browse/LIVE-29142)<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-29142]: https://ledgerhq.atlassian.net/browse/LIVE-29142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ