### PR TITLE
[LWDM] fix(coin-hedera): drop zero-value NONE operations from listOperations

### DIFF
--- a/.changeset/hedera-drop-none-operations.md
+++ b/.changeset/hedera-drop-none-operations.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-hedera": patch
+---
+
+listOperations: drop zero-value `NONE` operations
+
+`listOperations` emitted a `NONE` (value 0) operation for transactions where the account is neither a sender nor a recipient of any transfer (e.g. an HTS transfer between third parties for a token the account is merely associated with). These have no balance impact and are never surfaced by `getBlock`, which caused historical sync and block sync to produce different operation lists. They are now dropped to keep both paths consistent.

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
@@ -745,8 +745,7 @@ describe("listOperationsV2", () => {
       result: "INSUFFICIENT_PAYER_BALANCE",
       token_transfers: [],
       staking_reward_transfers: [],
-      // the account is a transfer participant (recipient) while a different account (0.0.23) pays the fee,
-      // so the operation is kept and its inferred feesPayer can be asserted
+      // account must be a transfer participant so the op survives the NONE filter; fee payer stays a different account
       transfers: [
         { account: "0.0.23", amount: -40743 },
         { account: mockMirrorAccount.account, amount: 40743 },

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
@@ -745,9 +745,11 @@ describe("listOperationsV2", () => {
       result: "INSUFFICIENT_PAYER_BALANCE",
       token_transfers: [],
       staking_reward_transfers: [],
+      // the account is a transfer participant (recipient) while a different account (0.0.23) pays the fee,
+      // so the operation is kept and its inferred feesPayer can be asserted
       transfers: [
         { account: "0.0.23", amount: -40743 },
-        { account: "0.0.801", amount: 40743 },
+        { account: mockMirrorAccount.account, amount: 40743 },
       ],
       name: "CRYPTOTRANSFER",
     });
@@ -1075,6 +1077,49 @@ describe("listOperationsV2", () => {
 
     expect(result.coinOperations).toEqual([]);
     expect(result.tokenOperations).toEqual([expect.objectContaining({ type: "IN" })]);
+  });
+
+  it("should drop NONE operations for HTS transfers between third parties (account not a participant)", async () => {
+    const mockTokenHTS = getMockedHTSTokenCurrency();
+    const mockTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1625097600.000000000",
+      transaction_hash: "hash1",
+      charged_tx_fee: 500000,
+      result: "SUCCESS",
+      token_transfers: [
+        { token_id: mockTokenHTS.contractAddress, account: "0.0.67890", amount: -1000 },
+        { token_id: mockTokenHTS.contractAddress, account: "0.0.99999", amount: 1000 },
+      ],
+      staking_reward_transfers: [],
+      transfers: [],
+      name: "CRYPTOTRANSFER",
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [mockTransaction],
+      nextCursor: null,
+    });
+
+    setupMockCryptoAssetsStore({
+      findTokenByAddressInCurrency: jest.fn().mockResolvedValue(mockTokenHTS),
+    });
+
+    const result = await listOperations({
+      limit: mockLimit,
+      order: mockOrder,
+      currencyId: mockCurrency.id,
+      address: mockMirrorAccount.account,
+      evmAddress: mockMirrorAccount.evm_address,
+      mirrorTokens: [],
+      tokenEvmAddresses: [],
+      fetchAllPages: true,
+      skipFeesForTokenOperations: false,
+      useEncodedHash: false,
+      useSyntheticBlocks: false,
+    });
+
+    expect(result.coinOperations).toEqual([]);
+    expect(result.tokenOperations).toEqual([]);
   });
 
   it("should skip FEES operations for ERC20 IN transfers", async () => {

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
@@ -539,15 +539,16 @@ export async function listOperationsV2({
   // `NONE` operations are produced when the account is neither a sender nor a recipient of any transfer in a
   // transaction (value 0, no balance impact) — e.g. an HTS transfer between third parties for a token the account
   // is merely associated with. getBlock builds operations only from real transfer participants and never emits
-  // these, so we drop them here to keep listOperations and getBlock consistent.
-  const coinOperationsWithoutNone = coinOperations.filter(op => op.type !== "NONE");
-  const tokenOperationsWithoutNone = tokenOperations.filter(op => op.type !== "NONE");
+  // these, so we drop them here to keep listOperations and getBlock consistent. Fees are unaffected: they are
+  // represented separately (transaction-level feesPayer/fees and dedicated FEES operations), never as a NONE op.
+  const removeNone = (ops: Operation<HederaOperationExtra>[]) =>
+    ops.filter(op => op.type !== "NONE");
 
   return {
-    tokenOperations: tokenOperationsWithoutNone,
+    tokenOperations: removeNone(tokenOperations),
     coinOperations: skipFeesForTokenOperations
-      ? coinOperationsWithoutNone.filter(op => op.type !== "FEES")
-      : coinOperationsWithoutNone,
+      ? removeNone(coinOperations).filter(op => op.type !== "FEES")
+      : removeNone(coinOperations),
     nextCursor: mergeResult.nextCursor,
   };
 }

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
@@ -536,11 +536,9 @@ export async function listOperationsV2({
     tokenOperations.push(...result.newTokenOperations);
   }
 
-  // `NONE` operations are produced when the account is neither a sender nor a recipient of any transfer in a
-  // transaction (value 0, no balance impact) — e.g. an HTS transfer between third parties for a token the account
-  // is merely associated with. getBlock builds operations only from real transfer participants and never emits
-  // these, so we drop them here to keep listOperations and getBlock consistent. Fees are unaffected: they are
-  // represented separately (transaction-level feesPayer/fees and dedicated FEES operations), never as a NONE op.
+  // Drop `NONE` operations (account is neither sender nor recipient; value 0) to stay consistent with getBlock,
+  // which only emits real transfer participants. Fees are represented separately, so this never discards a fee.
+  // See BACK-11641.
   const removeNone = (ops: Operation<HederaOperationExtra>[]) =>
     ops.filter(op => op.type !== "NONE");
 

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
@@ -536,11 +536,18 @@ export async function listOperationsV2({
     tokenOperations.push(...result.newTokenOperations);
   }
 
+  // `NONE` operations are produced when the account is neither a sender nor a recipient of any transfer in a
+  // transaction (value 0, no balance impact) — e.g. an HTS transfer between third parties for a token the account
+  // is merely associated with. getBlock builds operations only from real transfer participants and never emits
+  // these, so we drop them here to keep listOperations and getBlock consistent.
+  const coinOperationsWithoutNone = coinOperations.filter(op => op.type !== "NONE");
+  const tokenOperationsWithoutNone = tokenOperations.filter(op => op.type !== "NONE");
+
   return {
-    tokenOperations,
+    tokenOperations: tokenOperationsWithoutNone,
     coinOperations: skipFeesForTokenOperations
-      ? coinOperations.filter(op => op.type !== "FEES")
-      : coinOperations,
+      ? coinOperationsWithoutNone.filter(op => op.type !== "FEES")
+      : coinOperationsWithoutNone,
     nextCursor: mergeResult.nextCursor,
   };
 }


### PR DESCRIPTION
## Description

`listOperations` (v2) emits a `NONE` (value 0) operation for transactions where the account is **neither a sender nor a recipient** of any transfer — e.g. an HTS transfer between third parties for a token the account is merely associated with. In Hedera the fee debit is itself an entry in the transfer list, so a `NONE` op also means the account is **not the fee payer**: there is no balance impact.

`getBlock` (v2) builds operations only from real transfer participants (`createBlockOperationFrom*`), so it never surfaces these. The result was that **historical sync** (`listOperations`) and **block sync** (`getBlock`) produced different operation lists for the same account, which broke `/block` vs `/operations` reindexation parity checks downstream (a4 / coin-service, BACK-11641).

This drops `NONE` operations from `listOperations` so both paths are consistent. Fees are unaffected — they are represented separately (transaction-level `feesPayer`/`fees`, and `FEES` coin operations), never via the value-0 `NONE` op.

## Changes

- `listOperations.v2.ts`: filter out `type === "NONE"` operations (both coin and token) before returning.
- Added a test for an HTS transfer between third parties (account not a participant → no ops).
- Updated the existing "inferred fees payer" test to use a transaction where the account is an actual participant (it previously relied on a `NONE` op being returned).

## Test plan

- [x] `pnpm test` in `libs/coin-modules/coin-hedera`: **464 passed** (34 suites)

<!-- changeset: @ledgerhq/coin-hedera patch -->

Made with [Cursor](https://cursor.com)