### PR TITLE
[LWDM] fix(settings): resolve crypto counter-values by ledger id instead of ticker

### DIFF
--- a/.changeset/counter-value-crypto-by-id.md
+++ b/.changeset/counter-value-crypto-by-id.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Resolve crypto counter-values by Ledger id instead of ticker, and migrate existing users' persisted crypto counterValue (BTC/ETH) to ids. Fiats keep ticker-based resolution.

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -39,6 +39,7 @@ import {
   trackingEnabledSelector,
   hideEmptyTokenAccountsSelector,
   filterTokenOperationsZeroAmountSelector,
+  migrateLegacyCryptoCounterValue,
 } from "~/renderer/reducers/settings";
 import { liveBlindSigningReporter } from "@ledgerhq/live-dmk-shared";
 import ReactRoot from "~/renderer/ReactRoot";
@@ -207,6 +208,11 @@ async function init() {
   const settingsToLoad = { ...initialSettings };
   if (wasHardReset) {
     settingsToLoad.hasCompletedOnboarding = false;
+  }
+
+  // Legacy crypto counter-values were persisted as ticker (BTC/ETH); migrate them to Ledger ids.
+  if (typeof settingsToLoad.counterValue === "string") {
+    settingsToLoad.counterValue = migrateLegacyCryptoCounterValue(settingsToLoad.counterValue);
   }
 
   if (deepLinkUrl) {

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
@@ -13,6 +13,10 @@ import {
   removeDismissedContentCards,
   setDismissedContentCards,
 } from "../actions/settings";
+import {
+  getCryptoCurrencyById,
+  getFiatCurrencyByTicker,
+} from "@ledgerhq/live-common/currencies/index";
 import reducer, {
   lastSeenDeviceSelector,
   languageSelector,
@@ -22,6 +26,9 @@ import reducer, {
   filterValidSettings,
   trackingEnabledSelector,
   canPushDeviceIdsSelector,
+  counterValueCurrencySelector,
+  counterValueIdOf,
+  migrateLegacyCryptoCounterValue,
 } from "./settings";
 const invalidDeviceModelIds = ["nanoFTS", undefined, "whatever"];
 const validDeviceModelIds: DeviceModelId[] = Object.values(DeviceModelId);
@@ -802,6 +809,60 @@ describe("trackingEnabledSelector", () => {
         },
       }),
     ).toBe(true);
+  });
+});
+
+describe("counterValueCurrencySelector", () => {
+  const buildState = (counterValue: string): State => ({
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    ...({} as State),
+    settings: {
+      ...SETTINGS_INITIAL_STATE,
+      counterValue,
+    },
+  });
+
+  it("resolves a fiat counter-value by ticker", () => {
+    expect(counterValueCurrencySelector(buildState("EUR"))).toBe(getFiatCurrencyByTicker("EUR"));
+  });
+
+  it("resolves a crypto counter-value by Ledger id to the CryptoCurrency", () => {
+    const btc = counterValueCurrencySelector(buildState("bitcoin"));
+    expect(btc).toBe(getCryptoCurrencyById("bitcoin"));
+    expect(btc.type).toBe("CryptoCurrency");
+
+    const eth = counterValueCurrencySelector(buildState("ethereum"));
+    expect(eth).toBe(getCryptoCurrencyById("ethereum"));
+    expect(eth.type).toBe("CryptoCurrency");
+  });
+
+  it("falls back to USD for unknown values", () => {
+    expect(counterValueCurrencySelector(buildState("not-a-currency"))).toBe(
+      getFiatCurrencyByTicker("USD"),
+    );
+  });
+});
+
+describe("counterValueIdOf", () => {
+  it("returns the Ledger id for crypto currencies", () => {
+    expect(counterValueIdOf(getCryptoCurrencyById("bitcoin"))).toBe("bitcoin");
+    expect(counterValueIdOf(getCryptoCurrencyById("ethereum"))).toBe("ethereum");
+  });
+
+  it("returns the ticker for fiat currencies", () => {
+    expect(counterValueIdOf(getFiatCurrencyByTicker("EUR"))).toBe("EUR");
+  });
+});
+
+describe("migrateLegacyCryptoCounterValue", () => {
+  it("migrates legacy crypto tickers to Ledger ids", () => {
+    expect(migrateLegacyCryptoCounterValue("BTC")).toBe("bitcoin");
+    expect(migrateLegacyCryptoCounterValue("ETH")).toBe("ethereum");
+  });
+
+  it("leaves fiat tickers and already-migrated ids untouched", () => {
+    expect(migrateLegacyCryptoCounterValue("USD")).toBe("USD");
+    expect(migrateLegacyCryptoCounterValue("bitcoin")).toBe("bitcoin");
   });
 });
 

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -4,7 +4,7 @@ import {
   getCryptoCurrencyById,
   getFiatCurrencyByTicker,
   findFiatCurrencyByTicker,
-  findCryptoCurrencyByTicker,
+  findCryptoCurrencyById,
   listSupportedFiats,
   OFAC_CURRENCIES,
 } from "@ledgerhq/live-common/currencies/index";
@@ -439,7 +439,7 @@ const handlers: SettingsHandlers = {
     let activeCounterValue = state.counterValue;
     if (
       activeCounterValue &&
-      !payload.find(({ currency }) => currency.ticker === activeCounterValue)
+      !payload.find(({ currency }) => counterValueIdOf(currency) === activeCounterValue)
     ) {
       activeCounterValue = INITIAL_STATE.counterValue;
     }
@@ -624,6 +624,18 @@ const bitcoin = getCryptoCurrencyById("bitcoin");
 const ethereum = getCryptoCurrencyById("ethereum");
 export const possibleIntermediaries = [bitcoin, ethereum];
 
+// The persisted counterValue identifies fiats by ticker and cryptos by Ledger id.
+export const counterValueIdOf = (currency: Currency): string =>
+  currency.type === "CryptoCurrency" ? currency.id : currency.ticker;
+
+// One-time migration: legacy persisted crypto counterValues were stored as ticker.
+const LEGACY_CRYPTO_COUNTERVALUE_TICKER_TO_ID: Record<string, string> = {
+  BTC: "bitcoin",
+  ETH: "ethereum",
+};
+export const migrateLegacyCryptoCounterValue = (counterValue: string): string =>
+  LEGACY_CRYPTO_COUNTERVALUE_TICKER_TO_ID[counterValue] ?? counterValue;
+
 export type LangAndRegion = {
   language: string;
   region: string | undefined | null;
@@ -666,7 +678,7 @@ export const counterValueCurrencyLocalSelector = (state: SettingsState): Currenc
   }
   return (
     findFiatCurrencyByTicker(state.counterValue) ||
-    findCryptoCurrencyByTicker(state.counterValue) ||
+    findCryptoCurrencyById(state.counterValue) ||
     getFiatCurrencyByTicker("USD")
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/CounterValueSelect.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/CounterValueSelect.tsx
@@ -4,6 +4,7 @@ import { setCounterValue } from "~/renderer/actions/settings";
 import {
   SupportedCountervaluesData,
   counterValueCurrencySelector,
+  counterValueIdOf,
   supportedCounterValuesSelector,
 } from "~/renderer/reducers/settings";
 import Select from "~/renderer/components/Select";
@@ -17,7 +18,7 @@ const CounterValueSelectComponent: React.FC = () => {
   const handleChangeCounterValue = useCallback(
     (item?: SupportedCountervaluesData | null) => {
       if (!item) return;
-      dispatch(setCounterValue(item.currency.ticker));
+      dispatch(setCounterValue(counterValueIdOf(item.currency)));
     },
     [dispatch],
   );

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -40,7 +40,11 @@ import { importStore as importAccountsRaw } from "~/actions/accounts";
 import { importBle } from "~/actions/ble";
 import { importKnownDevices } from "~/reducers/knownDevices";
 import { updateProtectData, updateProtectStatus } from "~/actions/protect";
-import { INITIAL_STATE as settingsState } from "~/reducers/settings";
+import {
+  INITIAL_STATE as settingsState,
+  counterValueIdOf,
+  migrateLegacyCryptoCounterValue,
+} from "~/reducers/settings";
 import { listCachedCurrencyIds, hydrateCurrency } from "~/bridge/cache";
 import { importMarket } from "~/actions/market";
 import { importMarketListConfig } from "~/reducers/market";
@@ -139,6 +143,11 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
       store.dispatch(importBle(bleData));
       if (persistedKnownDevices) {
         store.dispatch(importKnownDevices(persistedKnownDevices));
+      }
+
+      // Legacy crypto counter-values were persisted as ticker (BTC/ETH); migrate them to Ledger ids.
+      if (settingsData && typeof settingsData.counterValue === "string") {
+        settingsData.counterValue = migrateLegacyCryptoCounterValue(settingsData.counterValue);
       }
 
       store.dispatch(importSettings(settingsData));
@@ -333,7 +342,9 @@ async function updateSupportedCountervalues(store: Store, settingsData: Partial<
 
   if (
     settingsData?.counterValue &&
-    !supportedCounterValues.find(({ ticker }) => ticker === settingsData.counterValue) &&
+    !supportedCounterValues.find(
+      ({ currency }) => counterValueIdOf(currency) === settingsData.counterValue,
+    ) &&
     settingsData.counterValue !== settingsState.counterValue
   ) {
     settingsData.counterValue = settingsState.counterValue;

--- a/apps/ledger-live-mobile/src/reducers/settings.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.test.ts
@@ -10,11 +10,18 @@ import reducer, {
   themeSelector,
   trackingEnabledSelector,
   canPushDeviceIdsSelector,
+  counterValueCurrencySelector,
+  counterValueIdOf,
+  migrateLegacyCryptoCounterValue,
   INITIAL_STATE as SETTINGS_INITIAL_STATE,
   filterValidSettings,
 } from "./settings";
 import { State, Theme, SettingsState } from "./types";
 import { aDeviceInfoBuilder } from "@ledgerhq/live-common/mock/fixtures/aDeviceInfo";
+import {
+  getCryptoCurrencyById,
+  getFiatCurrencyByTicker,
+} from "@ledgerhq/live-common/currencies/index";
 import {
   importSettings,
   setAnalyticsConsentInfo,
@@ -666,5 +673,52 @@ describe("productTourCompleted setting", () => {
     const afterTrue = reducer(SETTINGS_INITIAL_STATE, setProductTourCompleted(true));
     const afterFalse = reducer(afterTrue, setProductTourCompleted(false));
     expect(afterFalse.productTourCompleted).toBe(false);
+  });
+});
+
+describe("counterValueCurrencySelector", () => {
+  const buildState = (counterValue: string): State => stateWithSettings({ counterValue });
+
+  it("resolves a fiat counter-value by ticker", () => {
+    expect(counterValueCurrencySelector(buildState("EUR"))).toBe(getFiatCurrencyByTicker("EUR"));
+  });
+
+  it("resolves a crypto counter-value by Ledger id to the CryptoCurrency", () => {
+    const btc = counterValueCurrencySelector(buildState("bitcoin"));
+    expect(btc).toBe(getCryptoCurrencyById("bitcoin"));
+    expect(btc.type).toBe("CryptoCurrency");
+
+    const eth = counterValueCurrencySelector(buildState("ethereum"));
+    expect(eth).toBe(getCryptoCurrencyById("ethereum"));
+    expect(eth.type).toBe("CryptoCurrency");
+  });
+
+  it("falls back to USD for unknown values", () => {
+    expect(counterValueCurrencySelector(buildState("not-a-currency"))).toBe(
+      getFiatCurrencyByTicker("USD"),
+    );
+  });
+});
+
+describe("counterValueIdOf", () => {
+  it("returns the Ledger id for crypto currencies", () => {
+    expect(counterValueIdOf(getCryptoCurrencyById("bitcoin"))).toBe("bitcoin");
+    expect(counterValueIdOf(getCryptoCurrencyById("ethereum"))).toBe("ethereum");
+  });
+
+  it("returns the ticker for fiat currencies", () => {
+    expect(counterValueIdOf(getFiatCurrencyByTicker("EUR"))).toBe("EUR");
+  });
+});
+
+describe("migrateLegacyCryptoCounterValue", () => {
+  it("migrates legacy crypto tickers to Ledger ids", () => {
+    expect(migrateLegacyCryptoCounterValue("BTC")).toBe("bitcoin");
+    expect(migrateLegacyCryptoCounterValue("ETH")).toBe("ethereum");
+  });
+
+  it("leaves fiat tickers and already-migrated ids untouched", () => {
+    expect(migrateLegacyCryptoCounterValue("USD")).toBe("USD");
+    expect(migrateLegacyCryptoCounterValue("bitcoin")).toBe("bitcoin");
   });
 });

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -3,7 +3,7 @@ import type { Action } from "redux-actions";
 import {
   getFiatCurrencyByTicker,
   findFiatCurrencyByTicker,
-  findCryptoCurrencyByTicker,
+  findCryptoCurrencyById,
 } from "@ledgerhq/live-common/currencies/index";
 import { getEnv } from "@ledgerhq/live-env";
 import { createSelector } from "~/context/selectors";
@@ -708,9 +708,21 @@ export default handleActions<SettingsState, SettingsPayload>(handlers, INITIAL_S
 
 export const settingsStoreSelector = (state: State): SettingsState => state.settings;
 
+// The persisted counterValue identifies fiats by ticker and cryptos by Ledger id.
+export const counterValueIdOf = (currency: Currency): string =>
+  currency.type === "CryptoCurrency" ? currency.id : currency.ticker;
+
+// One-time migration: legacy persisted crypto counterValues were stored as ticker.
+const LEGACY_CRYPTO_COUNTERVALUE_TICKER_TO_ID: Record<string, string> = {
+  BTC: "bitcoin",
+  ETH: "ethereum",
+};
+export const migrateLegacyCryptoCounterValue = (counterValue: string): string =>
+  LEGACY_CRYPTO_COUNTERVALUE_TICKER_TO_ID[counterValue] ?? counterValue;
+
 const counterValueCurrencyLocalSelector = (state: SettingsState): Currency =>
   findFiatCurrencyByTicker(state.counterValue) ||
-  findCryptoCurrencyByTicker(state.counterValue) ||
+  findCryptoCurrencyById(state.counterValue) ||
   getFiatCurrencyByTicker("USD");
 
 export const counterValueCurrencySelector = createSelector(

--- a/apps/ledger-live-mobile/src/screens/Settings/General/CountervalueSettings.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/General/CountervalueSettings.tsx
@@ -1,7 +1,11 @@
 import { connect } from "react-redux";
 import { setCountervalue } from "~/actions/settings";
-import { counterValueCurrencySelector, supportedCounterValuesSelector } from "~/reducers/settings";
-import { State } from "~/reducers/types";
+import {
+  counterValueCurrencySelector,
+  counterValueIdOf,
+  supportedCounterValuesSelector,
+} from "~/reducers/settings";
+import { State, supportedCountervaluesData } from "~/reducers/types";
 import makeGenericSelectScreen from "../../makeGenericSelectScreen";
 
 const mapStateToProps = (state: State) => ({
@@ -10,10 +14,11 @@ const mapStateToProps = (state: State) => ({
 });
 
 const mapDispatchToProps = {
-  onValueChange: ({ value }: { value: string }) => setCountervalue(value),
+  onValueChange: (item: supportedCountervaluesData) =>
+    setCountervalue(counterValueIdOf(item.currency)),
 };
 
-const Screen = makeGenericSelectScreen({
+const Screen = makeGenericSelectScreen<supportedCountervaluesData>({
   id: "CounterValueSettingsSelect",
   itemEventProperties: item => ({ countervalue: item.value }),
   keyExtractor: item => item.value,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Selecting a crypto currency (BTC, ETH) as counter-value in Settings > General on both desktop and mobile
  - Users who previously had BTC or ETH set as counter-value before this change should have it preserved correctly after app restart/upgrade
  - EUR, USD and other fiat selections should continue to work exactly as before
  - Prices shown with a crypto counter-value in the portfolio and asset screens should still display correctly

### 📝 Description

Counter-value currencies in Ledger Live can be set to either a fiat (EUR, USD…) or a crypto (BTC, ETH). Previously, both types were resolved by ticker, meaning a persisted `"BTC"` would be looked up via `findCryptoCurrencyByTicker`. This is fragile: ticker strings are not guaranteed to be unique or stable across Ledger's coin registry.

This PR switches crypto counter-value resolution to use the Ledger coin `id` instead (e.g. `"bitcoin"`, `"ethereum"`). Fiat currencies keep their ticker-based resolution unchanged. A one-time migration is applied at app startup to rewrite legacy persisted values (`BTC` → `bitcoin`, `ETH` → `ethereum`) so existing users are not affected.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33313](https://ledgerhq.atlassian.net/browse/LIVE-33313)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33313]: https://ledgerhq.atlassian.net/browse/LIVE-33313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ