### PR TITLE
[LWDM] chore: mark internal-only packages as private

### DIFF
--- a/libs/asset-aggregation/package.json
+++ b/libs/asset-aggregation/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/asset-aggregation",
   "version": "0.9.0",
+  "private": true,
   "description": "Ledger Live asset-aggregation module – asset aggregation & categorization",
   "keywords": [
     "Ledger"
@@ -13,9 +14,6 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/asset-aggregation",
-  "publishConfig": {
-    "access": "public"
-  },
   "main": "lib/index.js",
   "module": "lib-es/index.js",
   "types": "lib/index.d.ts",

--- a/libs/coin-modules/coin-module-boilerplate/package.json
+++ b/libs/coin-modules/coin-module-boilerplate/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/coin-module-boilerplate",
   "version": "4.22.0",
+  "private": true,
   "description": "Boilerplate coin integration",
   "keywords": [
     "Ledger",
@@ -16,9 +17,6 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/coin-modules/coin-module-boilerplate",
-  "publishConfig": {
-    "access": "public"
-  },
   "typesVersions": {
     "*": {
       "lib/*": [

--- a/libs/coin-tester-modules/coin-tester-bitcoin/package.json
+++ b/libs/coin-tester-modules/coin-tester-bitcoin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/coin-tester-bitcoin",
   "version": "1.10.7",
+  "private": true,
   "description": "Ledger BTC Coin Tester",
   "main": "src/scenarii.test.ts",
   "keywords": [
@@ -18,9 +19,6 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/coin-tester-modules/coin-tester-bitcoin",
-  "publishConfig": {
-    "access": "public"
-  },
   "typesVersions": {
     "*": {
       "lib/*": [

--- a/libs/coin-tester-modules/coin-tester-polkadot/package.json
+++ b/libs/coin-tester-modules/coin-tester-polkadot/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/coin-tester-polkadot",
   "version": "1.17.5",
+  "private": true,
   "description": "Ledger Polkadot Coin Tester",
   "main": "src/scenarii.test.ts",
   "keywords": [
@@ -18,9 +19,6 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/coin-tester-modules/coin-tester-polkadot",
-  "publishConfig": {
-    "access": "public"
-  },
   "typesVersions": {
     "*": {
       "lib/*": [

--- a/libs/coin-tester-modules/coin-tester-tron/package.json
+++ b/libs/coin-tester-modules/coin-tester-tron/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/coin-tester-tron",
   "version": "0.2.2",
+  "private": true,
   "description": "Ledger Tron Coin Tester",
   "main": "src/scenarii.test.ts",
   "keywords": [
@@ -17,9 +18,6 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/coin-tester-modules/coin-tester-tron",
-  "publishConfig": {
-    "access": "public"
-  },
   "typesVersions": {
     "*": {
       "lib/*": [

--- a/libs/coin-tester-modules/coin-tester-xrp/package.json
+++ b/libs/coin-tester-modules/coin-tester-xrp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/coin-tester-xrp",
   "version": "0.1.1",
+  "private": true,
   "description": "Ledger XRP Coin Tester",
   "main": "src/scenarii.test.ts",
   "keywords": [
@@ -18,9 +19,6 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/coin-tester-modules/coin-tester-xrp",
-  "publishConfig": {
-    "access": "public"
-  },
   "typesVersions": {
     "*": {
       "lib/*": [

--- a/libs/coin-tester/package.json
+++ b/libs/coin-tester/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/coin-tester",
   "version": "0.20.0",
+  "private": true,
   "description": "Deterministic testing of Ledger coin-modules",
   "license": "Apache-2.0",
   "scripts": {

--- a/libs/device-core/package.json
+++ b/libs/device-core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/device-core",
   "version": "0.11.5",
+  "private": true,
   "description": "Ledger Live device core module",
   "license": "Apache-2.0",
   "keywords": [

--- a/libs/device-react/package.json
+++ b/libs/device-react/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/device-react",
   "version": "0.6.8",
+  "private": true,
   "description": "Ledger Live device react module",
   "keywords": [
     "Ledger"

--- a/libs/hw-ledger-key-ring-protocol/package.json
+++ b/libs/hw-ledger-key-ring-protocol/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/hw-ledger-key-ring-protocol",
   "version": "0.10.7",
+  "private": true,
   "description": "Ledger Key Ring Protocol hardware layer",
   "keywords": [
     "Ledger"

--- a/libs/ledger-key-ring-protocol/package.json
+++ b/libs/ledger-key-ring-protocol/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/ledger-key-ring-protocol",
   "version": "0.15.2",
+  "private": true,
   "description": "Ledger Key Ring Protocol layer",
   "keywords": [
     "Ledger"

--- a/libs/ledger-services/cal/package.json
+++ b/libs/ledger-services/cal/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/ledger-cal-service",
   "version": "1.18.2",
+  "private": true,
   "description": "Ledger CAL service client",
   "keywords": [
     "Ledger",

--- a/libs/ledger-services/trust/package.json
+++ b/libs/ledger-services/trust/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/ledger-trust-service",
   "version": "0.8.7",
+  "private": true,
   "description": "Ledger Trust service client",
   "keywords": [
     "Ledger",

--- a/libs/ledgerjs/packages/hw-transport-http/package.json
+++ b/libs/ledgerjs/packages/hw-transport-http/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/hw-transport-http",
   "version": "6.36.5",
+  "private": true,
   "description": "Ledger Hardware Wallet communication layer over http",
   "keywords": [
     "Ledger",
@@ -19,9 +20,6 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-transport-http",
-  "publishConfig": {
-    "access": "public"
-  },
   "exports": {
     ".": {
       "@ledgerhq/source": "./src/withStaticURLs.ts",

--- a/libs/ledgerjs/packages/hw-transport-vault/package.json
+++ b/libs/ledgerjs/packages/hw-transport-vault/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/hw-transport-vault",
   "version": "1.7.5",
+  "private": true,
   "description": "Ledger Vault transport",
   "keywords": [
     "Ledger",
@@ -19,9 +20,6 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-transport-vault",
-  "publishConfig": {
-    "access": "public"
-  },
   "main": "lib/index.js",
   "module": "lib-es/index.js",
   "types": "lib/index.d.ts",

--- a/libs/live-wallet/package.json
+++ b/libs/live-wallet/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/live-wallet",
   "version": "0.27.4",
+  "private": true,
   "description": "Ledger Live wallet",
   "keywords": [
     "Ledger"
@@ -13,9 +14,6 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/env",
-  "publishConfig": {
-    "access": "public"
-  },
   "main": "lib/index.js",
   "module": "lib-es/index.js",
   "types": "lib/index.d.ts",

--- a/libs/speculos-transport/package.json
+++ b/libs/speculos-transport/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ledgerhq/speculos-transport",
   "version": "0.10.6",
+  "private": true,
   "description": "Ledger Live speculos transport test helper",
   "keywords": [
     "Ledger"


### PR DESCRIPTION
### 📝 Description

Set \`"private": true\` on 17 packages identified as internal-only in the [monorepo package visibility inventory](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6975684839).

All packages in scope have no external consumers — their only dependents are either already private, apps, or packages also targeted for privatization in this batch.

Packages changed:

- asset-aggregation
- coin-module-boilerplate
- coin-tester, coin-tester-bitcoin, coin-tester-polkadot, coin-tester-tron, coin-tester-xrp
- device-core, device-react
- hw-ledger-key-ring-protocol
- hw-transport-http, hw-transport-vault
- ledger-cal-service, ledger-trust-service
- ledger-key-ring-protocol
- live-wallet
- speculos-transport

Packages from the PRIVATIZE list not included (blocked by public dependents):

- hw-transport-node-speculos-http: blocked by hw-app-canton (Next: EXTRACT)
- live-currency-format: blocked by ledger-wallet-framework (Next: GATE)
- client-ids: blocked by types-live (Next: GATE)

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6975684839
- **ADR** (if any): N/A