### PR TITLE
test(swap): give token reapproval its own EOA to fix nonce-race flakiness

### DIFF
--- a/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
+++ b/e2e/desktop/tests/specs/token.reapproval.swap.spec.ts
@@ -16,8 +16,8 @@ import { getDescription } from "tests/utils/customJsonReporter";
 import BigNumber from "bignumber.js";
 import { pickRotatingProvider } from "@ledgerhq/live-e2e-shared/swap";
 
-const fromAccount = TokenAccount.ETH_USDT_1;
-const toAccount = Account.ETH_1;
+const fromAccount = TokenAccount.ETH_USDT_3;
+const toAccount = Account.ETH_3;
 const eligibleProviders = [
   SwapProvider.THORCHAIN,
   SwapProvider.LIFI,

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalRotatingProvider.spec.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalRotatingProvider.spec.ts
@@ -10,8 +10,8 @@ const eligibleProviders = [
 ];
 
 const swapTokenReapprovalFlowTestConfig = {
-  fromAccount: TokenAccount.ETH_USDT_1,
-  toAccount: Account.ETH_1,
+  fromAccount: TokenAccount.ETH_USDT_3,
+  toAccount: Account.ETH_3,
   providers: eligibleProviders,
   tmsLinks: ["B2CQA-4012"],
   tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _The modified specs are broadcast-gated — they run only on the Monday `DISABLE_TRANSACTION_BROADCAST=0` nightly against Speculos + real mainnet funds, so they are not exercised by PR CI. Verified here via desktop + mobile e2e `typecheck`._
- [x] **Impact of the changes:**
  - **Funding prerequisite (blocking):** `ETH_3`'s mainnet address (`44'/60'/2'/0/0`) must hold **USDT** (plus its existing ETH for gas) before the next broadcast nightly — the change is inert without it.
  - Next broadcast nightly: `token.reapproval.swap` (desktop) and `swapTokenReapprovalRotatingProvider` (mobile) should no longer fail on the first attempt with `give-approval-button` / `execute-swap-button-step-approval` visibility timeouts.
  - Confirm `token.approval.swap` (USDC, still on `ETH_1`) stays green.

### 📝 Description

The `token.approval` (USDC) and `token.reapproval` (USDT) swap specs both broadcast their in-app approve/revoke/swap transactions from the **same** parent EOA `Account.ETH_1` (index 0). On the Monday broadcast nightly — run in parallel across device shards — two broadcasts grab the same confirmed-nonce, one tx is left pending/replaced, the app waits for a confirmation that never comes, and the next swap step never renders → `toBeVisible` timeout. This is the residual, **app-side** part of QAA-1323, whose CLI-side lock+retry does not (and cannot) cover the app's own broadcasts.

Give the USDT reapproval flow its own EOA so its nonce sequence is independent of the USDC approval flow. The desktop spec and the mobile rotating-provider caller now debit `TokenAccount.ETH_USDT_3` (parent `Account.ETH_3`) and credit `Account.ETH_3`; the approval flow stays on `ETH_1`. `ETH_3` was chosen deliberately: `ETH_2` must stay near-empty for `validation.swap` network-fee error tests, and no earn spec enables app broadcast — so `ETH_3` has no concurrent broadcaster.

**Scope / known residual:** this removes the approval-vs-reapproval (USDC-vs-USDT) EOA collision. The cross-shard / cross-runner self-collision (the same spec broadcasting from its EOA across multiple device shards) is intentionally out of scope here (AC #2) and left as follow-up.

### ❓ Context

- **JIRA or GitHub link**: [QAA-1366](https://ledgerhq.atlassian.net/browse/QAA-1366)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1366]: https://ledgerhq.atlassian.net/browse/QAA-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ