### PR TITLE
[LWD] fix(desktop): remove overflow-hidden from analytics chart container

### DIFF
--- a/.changeset/calm-charts-fix.md
+++ b/.changeset/calm-charts-fix.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix analytics chart overflow clipping by removing overflow-hidden class

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
@@ -36,7 +36,7 @@ function AnalyticsView({ viewModel }: { readonly viewModel: AnalyticsViewModel }
       <PageHeader title={t("analytics.title")} onBack={navigateToDashboard} />
 
       <div
-        className={cn("overflow-hidden", !shouldDisplayPnl && "rounded-md bg-surface")}
+        className={cn(!shouldDisplayPnl && "rounded-md bg-surface")}
         data-testid="analytics-chart"
       >
         {shouldDisplayPnl ? (


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _CSS-only class removal, no logic change._
- [x] **Impact of the changes:**
  - Analytics screen chart rendering when PnL is not displayed
  - Visual appearance of the `rounded-md bg-surface` background on the chart container

### 📝 Description

The analytics chart container had `overflow-hidden` applied unconditionally via `cn()`, which was clipping the rounded background surface styling when PnL is not displayed.

Removed `overflow-hidden` from the class list so the `rounded-md bg-surface` background renders correctly for the non-PnL chart view.

|
<img width="363" height="415" alt="Screenshot 2026-07-06 at 18 02 03" src="https://github.com/user-attachments/assets/567bc1e2-04cd-463e-8338-f2c453c43ae9" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33989](https://ledgerhq.atlassian.net/browse/LIVE-33989)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33989]: https://ledgerhq.atlassian.net/browse/LIVE-33989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ