### PR TITLE
chore(codeowners): opt out docs/services.md from platform ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -534,3 +534,4 @@ libs/ledger-live-common/src/config/sharedConfig.ts
 libs/ledger-live-common/package.json
 **/generated/
 **/live-common-set*.ts
+docs/services.md


### PR DESCRIPTION
### 📝 Description

Adds docs/services.md to the CODEOWNERS opt-out section so that the platform team is not auto-requested as reviewer when this file changes. This file covers services owned by multiple teams and is a cross-team concern — platform should not be the default gatekeeper for it.

### 🔗 Context

- **JIRA / GitHub issue**: N/A