### PR TITLE
[LWM] feat(lwm): add notifications prompt QA debug screen

### DIFF
--- a/.changeset/quiet-prompts-debug.md
+++ b/.changeset/quiet-prompts-debug.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add LWM notifications prompt QA debug screen with reprompt tooling

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
@@ -37,6 +37,7 @@ import DebugPlayground from "~/screens/Settings/Debug/Playground";
 import DebugBluetoothAndLocationServices from "~/screens/Settings/Debug/Debugging/BluetoothAndLocationServices";
 import DebugSettings from "~/screens/Settings/Debug";
 import DebugAnalyticsConsentQA from "~/screens/Settings/Debug/AnalyticsConsentQA";
+import DebugNotificationsPromptQA from "~/screens/Settings/Debug/NotificationsPromptQA";
 import DebugSnackbars from "~/screens/Settings/Debug/Features/Snackbars";
 import DebugTransactionsAlerts from "~/screens/Settings/Debug/Features/TransactionsAlerts";
 import DebugStore from "~/screens/Settings/Debug/Debugging/Store";
@@ -253,6 +254,13 @@ export default function SettingsNavigator() {
         component={DebugAnalyticsConsentQA}
         options={{
           title: "Analytics opt-in consent — QA",
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.DebugNotificationsPromptQA}
+        component={DebugNotificationsPromptQA}
+        options={{
+          title: "Notifications prompt — QA",
         }}
       />
       <Stack.Screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
@@ -30,6 +30,7 @@ export type SettingsNavigatorStackParamList = {
   [ScreenName.CustomCALRefInput]: undefined;
   [ScreenName.DebugSettings]: undefined;
   [ScreenName.DebugAnalyticsConsentQA]: undefined;
+  [ScreenName.DebugNotificationsPromptQA]: undefined;
   [ScreenName.DebugFeatureFlags]: undefined;
   [ScreenName.DebugLargeScreenUpsell]: undefined;
   [ScreenName.DebugInformation]: undefined;

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -39,6 +39,7 @@ export enum ScreenName {
   EditCurrencyUnits = "EditCurrencyUnits",
   CustomCALRefInput = "CustomCALRefInput",
   DebugAnalyticsConsentQA = "DebugAnalyticsConsentQA",
+  DebugNotificationsPromptQA = "DebugNotificationsPromptQA",
   DebugBLEDevicePairing = "DebugBLEDevicePairing",
   DebugConfiguration = "DebugConfiguration",
   DebugCommandSender = "DebugCommandSender",

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/utils.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/utils.test.ts
@@ -1,0 +1,327 @@
+import { add, sub } from "date-fns";
+import {
+  buildInactiveUserData,
+  buildRepromptableUserData,
+  buildTruncatedDismissalsUserData,
+  formatDismissalTimestamp,
+  getAfterActionRepromptLabel,
+  getGlobalPushNotificationsDismissals,
+  getInactivityRepromptLabel,
+} from "../utils";
+
+describe("NotificationsPromptQA utils", () => {
+  const now = new Date("2026-01-10T12:00:00.000Z").getTime();
+  const repromptSchedule = [{ days: 7, hours: 0, minutes: 0, months: 0, seconds: 0 }];
+
+  it("should format reprompt timing as in X days", () => {
+    expect(
+      getInactivityRepromptLabel({
+        lastActionAt: now,
+        inactivityReprompt: { months: 0, days: 3, hours: 0, minutes: 0, seconds: 0 },
+        inactivityEnabled: true,
+        now,
+      }),
+    ).toBe("in 3 days");
+    expect(
+      getInactivityRepromptLabel({
+        lastActionAt: now,
+        inactivityReprompt: { months: 0, days: 1, hours: 0, minutes: 0, seconds: 0 },
+        inactivityEnabled: true,
+        now,
+      }),
+    ).toBe("in 1 day");
+    expect(
+      getInactivityRepromptLabel({
+        lastActionAt: now - 1,
+        inactivityReprompt: { months: 0, days: 0, hours: 0, minutes: 0, seconds: 0 },
+        inactivityEnabled: true,
+        now,
+      }),
+    ).toBe("now (eligible)");
+  });
+
+  it("should use elapsed time instead of calendar-day boundaries for reprompt labels", () => {
+    const evening = new Date("2026-01-10T23:30:00.000Z").getTime();
+    const shortlyAfterMidnight = new Date("2026-01-11T00:15:00.000Z").getTime();
+
+    expect(
+      getAfterActionRepromptLabel({
+        dismissedOptInDrawerAtList: [evening],
+        repromptSchedule: [{ months: 0, days: 0, hours: 0, minutes: 30, seconds: 0 }],
+        now: evening,
+      }),
+    ).toBe("in less than 1 day");
+    expect(
+      getInactivityRepromptLabel({
+        lastActionAt: evening,
+        inactivityReprompt: { months: 0, days: 0, hours: 0, minutes: 30, seconds: 0 },
+        inactivityEnabled: true,
+        now: evening,
+      }),
+    ).toBe("in less than 1 day");
+    expect(
+      getAfterActionRepromptLabel({
+        dismissedOptInDrawerAtList: [evening],
+        repromptSchedule: [{ months: 0, days: 0, hours: 0, minutes: 30, seconds: 0 }],
+        now: shortlyAfterMidnight,
+      }),
+    ).toBe("now (eligible)");
+  });
+
+  it("should format invalid dismissal timestamps without throwing", () => {
+    expect(formatDismissalTimestamp(Number.NaN)).toEqual({
+      epochMs: "NaN",
+      iso: "invalid",
+      local: "invalid",
+    });
+  });
+
+  it("should compute after-action reprompt from the latest dismissal", () => {
+    const dismissedOptInDrawerAtList = [add(now, { days: -10 }).getTime()];
+
+    expect(
+      getAfterActionRepromptLabel({
+        dismissedOptInDrawerAtList,
+        repromptSchedule,
+        now,
+      }),
+    ).toBe("now (eligible)");
+  });
+
+  it("should use the latest dismissal when multiple dismissals exist", () => {
+    const dismissedOptInDrawerAtList = [
+      add(now, { days: -30 }).getTime(),
+      add(now, { days: -3 }).getTime(),
+    ];
+
+    expect(
+      getAfterActionRepromptLabel({
+        dismissedOptInDrawerAtList,
+        repromptSchedule,
+        now,
+      }),
+    ).toBe("in 4 days");
+  });
+
+  it("should compute inactivity reprompt from lastActionAt", () => {
+    expect(
+      getInactivityRepromptLabel({
+        lastActionAt: add(now, { days: -1 }).getTime(),
+        inactivityReprompt: { months: 0, days: 2, hours: 0, minutes: 0, seconds: 0 },
+        inactivityEnabled: true,
+        now,
+      }),
+    ).toBe("in 1 day");
+  });
+
+  it("should prefer globalPushNotifications dismissals over the legacy field", () => {
+    const migratedDismissals = [add(now, { days: -3 }).getTime()];
+    const legacyDismissals = [add(now, { days: -30 }).getTime()];
+    const userData = {
+      dismissedOptInDrawerAtList: legacyDismissals,
+      dismissedPromptAtListByTarget: { globalPushNotifications: migratedDismissals },
+    };
+
+    expect(getGlobalPushNotificationsDismissals(userData)).toEqual(migratedDismissals);
+    expect(
+      getAfterActionRepromptLabel({
+        dismissedOptInDrawerAtList: getGlobalPushNotificationsDismissals(userData),
+        repromptSchedule,
+        now,
+      }),
+    ).toBe("in 4 days");
+  });
+
+  it("should build reprompt-eligible user data when dismissal history exists", () => {
+    const result = buildRepromptableUserData(
+      {
+        dismissedOptInDrawerAtList: [add(now, { days: -1 }).getTime()],
+      },
+      repromptSchedule,
+      now,
+    );
+
+    const dismissedList = result.dismissedOptInDrawerAtList;
+    expect(dismissedList).toBeDefined();
+    const lastDismissedAt = dismissedList!.at(-1);
+    expect(lastDismissedAt).toBeDefined();
+    expect(lastDismissedAt).toBeLessThan(now);
+    expect(add(lastDismissedAt as number, repromptSchedule[0]).getTime()).toBeLessThanOrEqual(now);
+    expect(
+      getAfterActionRepromptLabel({
+        dismissedOptInDrawerAtList: result.dismissedOptInDrawerAtList,
+        repromptSchedule,
+        now,
+      }),
+    ).toBe("now (eligible)");
+  });
+
+  it("should build reprompt-eligible user data when dismissal history is empty", () => {
+    const result = buildRepromptableUserData(undefined, repromptSchedule, now);
+
+    const dismissedList = result.dismissedOptInDrawerAtList;
+    expect(dismissedList).toHaveLength(1);
+    const lastDismissedAt = dismissedList!.at(-1);
+    expect(lastDismissedAt).toBe(sub(now, repromptSchedule[0]).getTime());
+    expect(add(lastDismissedAt as number, repromptSchedule[0]).getTime()).toBeLessThanOrEqual(now);
+    expect(
+      getAfterActionRepromptLabel({
+        dismissedOptInDrawerAtList: result.dismissedOptInDrawerAtList,
+        repromptSchedule,
+        now,
+      }),
+    ).toBe("now (eligible)");
+  });
+
+  it("should use the matching schedule delay when multiple dismissals exist", () => {
+    const repromptDelays = [
+      { months: 0, days: 7, hours: 0, minutes: 0, seconds: 0 },
+      { months: 0, days: 14, hours: 0, minutes: 0, seconds: 0 },
+    ];
+    const result = buildRepromptableUserData(
+      {
+        dismissedOptInDrawerAtList: [
+          add(now, { days: -30 }).getTime(),
+          add(now, { days: -1 }).getTime(),
+        ],
+      },
+      repromptDelays,
+      now,
+    );
+
+    const lastDismissedAt = result.dismissedOptInDrawerAtList!.at(-1);
+    expect(lastDismissedAt).toBe(sub(now, repromptDelays[1]).getTime());
+    expect(add(lastDismissedAt as number, repromptDelays[1]).getTime()).toBeLessThanOrEqual(now);
+  });
+
+  it("should build reprompt-eligible user data from globalPushNotifications dismissals", () => {
+    const result = buildRepromptableUserData(
+      {
+        dismissedPromptAtListByTarget: {
+          globalPushNotifications: [add(now, { days: -1 }).getTime()],
+        },
+      },
+      repromptSchedule,
+      now,
+    );
+
+    expect(result.dismissedPromptAtListByTarget?.globalPushNotifications).toHaveLength(1);
+    expect(
+      getAfterActionRepromptLabel({
+        dismissedOptInDrawerAtList: getGlobalPushNotificationsDismissals(result),
+        repromptSchedule,
+        now,
+      }),
+    ).toBe("now (eligible)");
+  });
+
+  describe("buildTruncatedDismissalsUserData", () => {
+    it("should truncate globalPushNotifications dismissals when legacy field is empty", () => {
+      const dismissals = [
+        add(now, { days: -30 }).getTime(),
+        add(now, { days: -20 }).getTime(),
+        add(now, { days: -10 }).getTime(),
+      ];
+      const result = buildTruncatedDismissalsUserData(
+        {
+          dismissedPromptAtListByTarget: {
+            globalPushNotifications: dismissals,
+          },
+        },
+        2,
+      );
+
+      expect(getGlobalPushNotificationsDismissals(result)).toEqual(dismissals.slice(0, 2));
+      expect(result.dismissedOptInDrawerAtList).toEqual(dismissals.slice(0, 2));
+      expect(result.dismissedPromptAtListByTarget?.globalPushNotifications).toEqual(
+        dismissals.slice(0, 2),
+      );
+    });
+
+    it("should truncate legacy dismissedOptInDrawerAtList dismissals", () => {
+      const dismissals = [
+        add(now, { days: -30 }).getTime(),
+        add(now, { days: -20 }).getTime(),
+        add(now, { days: -10 }).getTime(),
+      ];
+      const result = buildTruncatedDismissalsUserData(
+        { dismissedOptInDrawerAtList: dismissals },
+        2,
+      );
+
+      expect(result.dismissedOptInDrawerAtList).toEqual(dismissals.slice(0, 2));
+      expect(result.dismissedPromptAtListByTarget?.globalPushNotifications).toEqual(
+        result.dismissedOptInDrawerAtList,
+      );
+    });
+
+    it("should prefer globalPushNotifications when legacy field is stale", () => {
+      const migratedDismissals = [
+        add(now, { days: -30 }).getTime(),
+        add(now, { days: -20 }).getTime(),
+        add(now, { days: -10 }).getTime(),
+      ];
+      const legacyDismissals = [add(now, { days: -1 }).getTime()];
+
+      const result = buildTruncatedDismissalsUserData(
+        {
+          dismissedOptInDrawerAtList: legacyDismissals,
+          dismissedPromptAtListByTarget: { globalPushNotifications: migratedDismissals },
+        },
+        2,
+      );
+
+      expect(result.dismissedOptInDrawerAtList).toEqual(migratedDismissals.slice(0, 2));
+      expect(result.dismissedPromptAtListByTarget?.globalPushNotifications).toEqual(
+        migratedDismissals.slice(0, 2),
+      );
+    });
+
+    it("should return empty dismissals when input has no dismissal history", () => {
+      const result = buildTruncatedDismissalsUserData(undefined, 2);
+
+      expect(result.dismissedOptInDrawerAtList).toEqual([]);
+      expect(result.dismissedPromptAtListByTarget?.globalPushNotifications).toEqual([]);
+    });
+
+    it("should keep the full list when keepCount exceeds dismissal count", () => {
+      const dismissals = [add(now, { days: -10 }).getTime()];
+      const result = buildTruncatedDismissalsUserData(
+        { dismissedOptInDrawerAtList: dismissals },
+        5,
+      );
+
+      expect(result.dismissedOptInDrawerAtList).toEqual(dismissals);
+      expect(result.dismissedPromptAtListByTarget?.globalPushNotifications).toEqual(dismissals);
+    });
+
+    it("should treat negative keepCount as zero", () => {
+      const dismissals = [add(now, { days: -10 }).getTime(), add(now, { days: -5 }).getTime()];
+      const result = buildTruncatedDismissalsUserData(
+        { dismissedOptInDrawerAtList: dismissals },
+        -1,
+      );
+
+      expect(result.dismissedOptInDrawerAtList).toEqual([]);
+      expect(result.dismissedPromptAtListByTarget?.globalPushNotifications).toEqual([]);
+    });
+  });
+
+  it("should build inactive user data that satisfies checkIsInactive", () => {
+    const inactivityReprompt = { months: 0, days: 2, hours: 0, minutes: 0, seconds: 0 };
+    const result = buildInactiveUserData(undefined, inactivityReprompt, now);
+
+    expect(result.lastActionAt).toBe(sub(now, inactivityReprompt).getTime());
+    expect(add(result.lastActionAt as number, inactivityReprompt).getTime()).toBeLessThanOrEqual(
+      now,
+    );
+    expect(
+      getInactivityRepromptLabel({
+        lastActionAt: result.lastActionAt,
+        inactivityReprompt,
+        inactivityEnabled: true,
+        now,
+      }),
+    ).toBe("now (eligible)");
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/index.tsx
@@ -1,0 +1,287 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { AuthorizationStatus } from "@react-native-firebase/messaging";
+import { Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
+import { useFeature } from "@features/platform-feature-flags";
+import {
+  type NotificationsPromptAfterActionSource,
+  useNotificationsContext,
+  useNotificationsData,
+} from "LLM/features/NotificationsPrompt";
+import { useNotificationsPromptDrawerScheduler } from "LLM/features/NotificationsPrompt/new/hooks/useNotificationsPromptDrawerScheduler";
+import { useNotificationsPermission } from "LLM/hooks/useNotificationsPermission";
+import { TrackScreen } from "~/analytics";
+import { useSelector } from "~/context/hooks";
+import { hasCompletedOnboardingSelector, notificationsSelector } from "~/reducers/settings";
+import SettingsNavigationScrollView from "../../SettingsNavigationScrollView";
+import {
+  buildInactiveUserData,
+  buildRepromptableUserData,
+  buildTruncatedDismissalsUserData,
+  formatDismissalTimestamp,
+  getAfterActionRepromptLabel,
+  getGlobalPushNotificationsDismissals,
+  getInactivityRepromptLabel,
+} from "./utils";
+
+const TRIGGER_SOURCES: NotificationsPromptAfterActionSource[] = [
+  "onboarding",
+  "add_favorite_coin",
+  "send",
+  "receive",
+  "swap",
+  "stake",
+];
+
+function valueLxColor(ok: boolean): "success" | "error" {
+  return ok ? "success" : "error";
+}
+
+export default function DebugNotificationsPromptQA() {
+  const [selectedSource, setSelectedSource] =
+    useState<NotificationsPromptAfterActionSource>("onboarding");
+  const [featureFlagsExpanded, setFeatureFlagsExpanded] = useState(false);
+
+  const brazePushNotifications = useFeature("brazePushNotifications");
+  const notifications = useSelector(notificationsSelector);
+  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const { permissionStatus } = useNotificationsPermission();
+  const { pushNotificationsDataOfUser, updatePushNotificationsDataOfUserInStateAndStore } =
+    useNotificationsData();
+  const { notifyFlowCompleted } = useNotificationsContext();
+  const { openDrawer } = useNotificationsPromptDrawerScheduler();
+
+  const globalPushNotificationsDismissals = useMemo(
+    () => getGlobalPushNotificationsDismissals(pushNotificationsDataOfUser),
+    [pushNotificationsDataOfUser],
+  );
+  const dismissedCount = globalPushNotificationsDismissals?.length ?? 0;
+  const isOsNotificationsEnabled = permissionStatus === AuthorizationStatus.AUTHORIZED;
+  const isAppNotificationsEnabled = notifications.areNotificationsAllowed === true;
+  const isOptIn = isOsNotificationsEnabled && isAppNotificationsEnabled;
+  const optState = isOptIn ? "isOptIn" : "isOptOut";
+
+  const now = Date.now();
+  const afterActionRepromptLabel = getAfterActionRepromptLabel({
+    dismissedOptInDrawerAtList: globalPushNotificationsDismissals,
+    repromptSchedule: brazePushNotifications?.params?.reprompt_schedule,
+    now,
+  });
+  const inactivityRepromptLabel = getInactivityRepromptLabel({
+    lastActionAt: pushNotificationsDataOfUser?.lastActionAt,
+    inactivityReprompt: brazePushNotifications?.params?.inactivity_reprompt,
+    inactivityEnabled: brazePushNotifications?.params?.inactivity_enabled,
+    now,
+  });
+
+  const onMarkInactive = useCallback(() => {
+    updatePushNotificationsDataOfUserInStateAndStore(
+      buildInactiveUserData(
+        pushNotificationsDataOfUser,
+        brazePushNotifications?.params?.inactivity_reprompt,
+        Date.now(),
+      ),
+    );
+  }, [
+    brazePushNotifications?.params?.inactivity_reprompt,
+    pushNotificationsDataOfUser,
+    updatePushNotificationsDataOfUserInStateAndStore,
+  ]);
+
+  const onMarkRepromptable = useCallback(() => {
+    updatePushNotificationsDataOfUserInStateAndStore(
+      buildRepromptableUserData(
+        pushNotificationsDataOfUser,
+        brazePushNotifications?.params?.reprompt_schedule,
+        Date.now(),
+      ),
+    );
+  }, [
+    brazePushNotifications?.params?.reprompt_schedule,
+    pushNotificationsDataOfUser,
+    updatePushNotificationsDataOfUserInStateAndStore,
+  ]);
+
+  const onGoBackToSecondDismissal = useCallback(() => {
+    updatePushNotificationsDataOfUserInStateAndStore(
+      buildTruncatedDismissalsUserData(pushNotificationsDataOfUser, 2),
+    );
+  }, [pushNotificationsDataOfUser, updatePushNotificationsDataOfUserInStateAndStore]);
+
+  const onTriggerDrawer = useCallback(() => {
+    notifyFlowCompleted(selectedSource);
+  }, [notifyFlowCompleted, selectedSource]);
+
+  const onForceOpenDrawer = useCallback(() => {
+    openDrawer(selectedSource, 0, "globalPushNotifications");
+  }, [openDrawer, selectedSource]);
+
+  return (
+    <SettingsNavigationScrollView>
+      <TrackScreen category="Settings" name="DebugNotificationsPromptQA" />
+      <Box lx={{ paddingHorizontal: "s24", paddingBottom: "s24" }}>
+        <Text typography="body2SemiBold" lx={{ color: "muted", marginBottom: "s12" }}>
+          NOTIFICATIONS PROMPT — QA
+        </Text>
+
+        <SectionTitle>1. Opt state</SectionTitle>
+        <InfoRow label="State" value={optState} valueColor={isOptIn ? "success" : "error"} />
+
+        <SectionTitle>2. Notification enablement status</SectionTitle>
+        <InfoRow
+          label="App notifications enabled"
+          value={String(isAppNotificationsEnabled)}
+          valueColor={valueLxColor(isAppNotificationsEnabled)}
+        />
+        <InfoRow
+          label="OS notifications enabled"
+          value={String(isOsNotificationsEnabled)}
+          valueColor={valueLxColor(isOsNotificationsEnabled)}
+        />
+        <InfoRow label="OS permission status" value={String(permissionStatus ?? "undefined")} />
+        <InfoRow
+          label="Onboarding complete"
+          value={String(hasCompletedOnboarding)}
+          valueColor={valueLxColor(hasCompletedOnboarding)}
+        />
+
+        <SectionTitle>3. Reprompt timing</SectionTitle>
+        <InfoRow label="After action" value={afterActionRepromptLabel} />
+        <InfoRow label="After inactivity" value={inactivityRepromptLabel} />
+
+        <SectionTitle>4. Dismissal data</SectionTitle>
+        <InfoRow label="dismissedCount" value={String(dismissedCount)} />
+        {!globalPushNotificationsDismissals?.length ? (
+          <Text typography="body3" lx={{ color: "muted", marginBottom: "s12" }}>
+            globalPushNotifications dismissals are empty
+          </Text>
+        ) : (
+          globalPushNotificationsDismissals.map((timestamp, index) => {
+            const formatted = formatDismissalTimestamp(timestamp);
+            return (
+              <Box key={`${timestamp}-${index}`} lx={{ marginBottom: "s12" }}>
+                <Text typography="body3SemiBold" lx={{ color: "base", marginBottom: "s4" }}>
+                  #{index + 1}
+                </Text>
+                <Text typography="body3" lx={{ color: "muted" }} selectable>
+                  epoch ms: {formatted.epochMs}
+                </Text>
+                <Text typography="body3" lx={{ color: "muted" }} selectable>
+                  ISO: {formatted.iso}
+                </Text>
+                <Text typography="body3" lx={{ color: "muted" }} selectable>
+                  local: {formatted.local}
+                </Text>
+              </Box>
+            );
+          })
+        )}
+
+        <SectionTitle>5. Feature flags</SectionTitle>
+        <Button
+          size="sm"
+          appearance="base"
+          onPress={() => setFeatureFlagsExpanded(expanded => !expanded)}
+          lx={{ marginBottom: "s12", alignSelf: "flex-start" }}
+        >
+          {featureFlagsExpanded ? "Hide feature flag details" : "Show feature flag details"}
+        </Button>
+        {featureFlagsExpanded ? (
+          <Box lx={{ marginBottom: "s16" }}>
+            <Text typography="body3" lx={{ color: "muted", marginBottom: "s8" }} selectable>
+              brazePushNotifications.enabled: {String(brazePushNotifications?.enabled ?? false)}
+            </Text>
+            <Text typography="body3" lx={{ color: "muted", marginBottom: "s8" }} selectable>
+              reprompt_schedule:{" "}
+              {JSON.stringify(brazePushNotifications?.params?.reprompt_schedule ?? null)}
+            </Text>
+            <Text typography="body3" lx={{ color: "muted", marginBottom: "s8" }} selectable>
+              action_events: {JSON.stringify(brazePushNotifications?.params?.action_events ?? null)}
+            </Text>
+            <Text typography="body3" lx={{ color: "muted", marginBottom: "s8" }} selectable>
+              inactivity_enabled:{" "}
+              {String(brazePushNotifications?.params?.inactivity_enabled ?? false)}
+            </Text>
+            <Text typography="body3" lx={{ color: "muted" }} selectable>
+              inactivity_reprompt:{" "}
+              {JSON.stringify(brazePushNotifications?.params?.inactivity_reprompt ?? null)}
+            </Text>
+          </Box>
+        ) : null}
+
+        <SectionTitle>Actions</SectionTitle>
+        <Box lx={{ gap: "s8", marginBottom: "s16" }}>
+          <Button appearance="accent" size="sm" onPress={onMarkInactive}>
+            Mark as inactive
+          </Button>
+          <Button appearance="accent" size="sm" onPress={onMarkRepromptable}>
+            Mark user as can be reprompted
+          </Button>
+          <Button appearance="accent" size="sm" onPress={onGoBackToSecondDismissal}>
+            Go back in time (keep 2 dismissals)
+          </Button>
+        </Box>
+
+        <Text typography="body3SemiBold" lx={{ color: "base", marginBottom: "s8" }}>
+          Trigger drawer source
+        </Text>
+        <Box lx={{ flexDirection: "row", flexWrap: "wrap", gap: "s8", marginBottom: "s12" }}>
+          {TRIGGER_SOURCES.map(source => (
+            <Button
+              key={source}
+              size="sm"
+              appearance={selectedSource === source ? "accent" : "base"}
+              onPress={() => setSelectedSource(source)}
+            >
+              {source}
+            </Button>
+          ))}
+        </Box>
+        <Box lx={{ gap: "s8", marginBottom: "s16" }}>
+          <Button appearance="accent" onPress={onTriggerDrawer}>
+            Trigger drawer (production rules)
+          </Button>
+          <Button appearance="base" onPress={onForceOpenDrawer}>
+            Force open drawer
+          </Button>
+        </Box>
+
+        <Text typography="body3" lx={{ color: "muted" }}>
+          Leave this screen to see the drawer. Production rules may skip the drawer if eligibility
+          checks fail — use force open to bypass them.
+        </Text>
+      </Box>
+    </SettingsNavigationScrollView>
+  );
+}
+
+function SectionTitle({ children }: Readonly<{ children: string }>) {
+  return (
+    <Text
+      typography="heading5SemiBold"
+      lx={{ color: "base", marginTop: "s16", marginBottom: "s8" }}
+    >
+      {children}
+    </Text>
+  );
+}
+
+function InfoRow({
+  label,
+  value,
+  valueColor = "base",
+}: Readonly<{
+  label: string;
+  value: string;
+  valueColor?: "base" | "success" | "error" | "muted";
+}>) {
+  return (
+    <Box lx={{ marginBottom: "s8" }}>
+      <Text typography="body3" lx={{ color: "muted" }}>
+        {label}
+      </Text>
+      <Text typography="body2SemiBold" lx={{ color: valueColor }} selectable>
+        {value}
+      </Text>
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/utils.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/utils.ts
@@ -1,0 +1,212 @@
+import { add, sub } from "date-fns";
+import type {
+  DataOfUser,
+  NotificationsPromptRepromptDelay,
+} from "LLM/features/NotificationsPrompt";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+type RepromptDuration = NotificationsPromptRepromptDelay;
+
+export const getGlobalPushNotificationsDismissals = (
+  pushNotificationsDataOfUser: DataOfUser | null | undefined,
+): number[] | undefined => {
+  const dismissedPromptAtListByTarget =
+    pushNotificationsDataOfUser?.dismissedPromptAtListByTarget ?? {};
+
+  return (
+    dismissedPromptAtListByTarget.globalPushNotifications ??
+    pushNotificationsDataOfUser?.dismissedOptInDrawerAtList
+  );
+};
+
+const formatRepromptInDays = (targetMs: number, now: number): string => {
+  if (targetMs <= now) {
+    return "now (eligible)";
+  }
+
+  const remainingMs = targetMs - now;
+  if (remainingMs < MS_PER_DAY) {
+    return "in less than 1 day";
+  }
+
+  const days = Math.ceil(remainingMs / MS_PER_DAY);
+  const dayLabel = days === 1 ? "day" : "days";
+  return `in ${days} ${dayLabel}`;
+};
+
+export const formatDismissalTimestamp = (timestamp: number) => {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return {
+      epochMs: String(timestamp),
+      iso: "invalid",
+      local: "invalid",
+    };
+  }
+
+  return {
+    epochMs: String(timestamp),
+    iso: date.toISOString(),
+    local: date.toLocaleString(),
+  };
+};
+
+export const getAfterActionRepromptLabel = ({
+  dismissedOptInDrawerAtList,
+  repromptSchedule,
+  now,
+}: {
+  dismissedOptInDrawerAtList: number[] | undefined;
+  repromptSchedule: RepromptDuration[] | null | undefined;
+  now: number;
+}): string => {
+  if (!dismissedOptInDrawerAtList?.length) {
+    return "now (eligible)";
+  }
+
+  if (!repromptSchedule?.length) {
+    return "not configured";
+  }
+
+  const scheduleIndex = Math.min(
+    dismissedOptInDrawerAtList.length - 1,
+    repromptSchedule.length - 1,
+  );
+  const nextRepromptDelay = repromptSchedule[scheduleIndex];
+  const lastDismissedAt = dismissedOptInDrawerAtList.at(-1);
+  if (lastDismissedAt === undefined) {
+    return "now (eligible)";
+  }
+
+  return formatRepromptInDays(add(lastDismissedAt, nextRepromptDelay).getTime(), now);
+};
+
+export const getInactivityRepromptLabel = ({
+  lastActionAt,
+  inactivityReprompt,
+  inactivityEnabled,
+  now,
+}: {
+  lastActionAt: number | undefined;
+  inactivityReprompt: RepromptDuration | null | undefined;
+  inactivityEnabled: boolean | undefined;
+  now: number;
+}): string => {
+  if (!inactivityEnabled) {
+    return "disabled";
+  }
+
+  if (!inactivityReprompt) {
+    return "not configured";
+  }
+
+  if (lastActionAt === undefined) {
+    return "unknown (no lastActionAt)";
+  }
+
+  return formatRepromptInDays(add(lastActionAt, inactivityReprompt).getTime(), now);
+};
+
+/** Mirrors notificationsPromptEngine: add(timestamp, delay).getTime() <= now */
+const getTimestampEligibleForDelay = (delay: RepromptDuration, now: number): number =>
+  sub(now, delay).getTime();
+
+const getRepromptDelayForDismissalCount = (
+  repromptSchedule: RepromptDuration[] | null | undefined,
+  dismissalCount: number,
+): RepromptDuration => {
+  const fallbackDelay: RepromptDuration = {
+    days: 7,
+    hours: 0,
+    minutes: 0,
+    months: 0,
+    seconds: 0,
+  };
+  const schedule = repromptSchedule?.length ? repromptSchedule : [fallbackDelay];
+  const scheduleIndex = Math.min(Math.max(dismissalCount, 1) - 1, schedule.length - 1);
+  return schedule[scheduleIndex];
+};
+
+const getRepromptEligibleDismissalAt = (
+  repromptSchedule: RepromptDuration[] | null | undefined,
+  dismissalCount: number,
+  now: number,
+): number =>
+  getTimestampEligibleForDelay(
+    getRepromptDelayForDismissalCount(repromptSchedule, dismissalCount),
+    now,
+  );
+
+export const buildRepromptableUserData = (
+  pushNotificationsDataOfUser: DataOfUser | null | undefined,
+  repromptSchedule: RepromptDuration[] | null | undefined,
+  now: number,
+): DataOfUser => {
+  const dismissedOptInDrawerAtList = [
+    ...(getGlobalPushNotificationsDismissals(pushNotificationsDataOfUser) ?? []),
+  ];
+
+  const dismissalCount = Math.max(dismissedOptInDrawerAtList.length, 1);
+  const repromptableDismissalAt = getRepromptEligibleDismissalAt(
+    repromptSchedule,
+    dismissalCount,
+    now,
+  );
+
+  if (!dismissedOptInDrawerAtList.length) {
+    dismissedOptInDrawerAtList.push(repromptableDismissalAt);
+  } else {
+    dismissedOptInDrawerAtList[dismissedOptInDrawerAtList.length - 1] = repromptableDismissalAt;
+  }
+
+  return {
+    ...pushNotificationsDataOfUser,
+    dismissedOptInDrawerAtList,
+    dismissedPromptAtListByTarget: {
+      ...pushNotificationsDataOfUser?.dismissedPromptAtListByTarget,
+      globalPushNotifications: dismissedOptInDrawerAtList,
+    },
+    lastActionAt: pushNotificationsDataOfUser?.lastActionAt ?? now,
+  };
+};
+
+export const buildInactiveUserData = (
+  pushNotificationsDataOfUser: DataOfUser | null | undefined,
+  inactivityReprompt: RepromptDuration | null | undefined,
+  now: number,
+): DataOfUser => {
+  const delay = inactivityReprompt ?? {
+    months: 6,
+    days: 0,
+    hours: 0,
+    minutes: 0,
+    seconds: 0,
+  };
+
+  const inactiveLastActionAt = getTimestampEligibleForDelay(delay, now);
+
+  return {
+    ...pushNotificationsDataOfUser,
+    lastActionAt: inactiveLastActionAt,
+  };
+};
+
+export const buildTruncatedDismissalsUserData = (
+  pushNotificationsDataOfUser: DataOfUser | null | undefined,
+  keepCount: number,
+): DataOfUser => {
+  const safeKeepCount = Math.max(0, Math.floor(keepCount));
+  const dismissedOptInDrawerAtList = (
+    getGlobalPushNotificationsDismissals(pushNotificationsDataOfUser) ?? []
+  ).slice(0, safeKeepCount);
+
+  return {
+    ...pushNotificationsDataOfUser,
+    dismissedOptInDrawerAtList,
+    dismissedPromptAtListByTarget: {
+      ...pushNotificationsDataOfUser?.dismissedPromptAtListByTarget,
+      globalPushNotifications: dismissedOptInDrawerAtList,
+    },
+  };
+};

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/index.tsx
@@ -97,6 +97,12 @@ export default function DebugSettings({
         iconLeft={<IconsLegacy.ChartNetworkMedium size={24} color="black" />}
         onPress={() => navigate(ScreenName.DebugAnalyticsConsentQA)}
       />
+      <SettingsRow
+        title="Notifications prompt — QA"
+        desc="Inspect notifications opt-in state, reprompt timing, and trigger the drawer"
+        iconLeft={<IconsLegacy.NotificationsMedium size={24} color="black" />}
+        onPress={() => navigate(ScreenName.DebugNotificationsPromptQA)}
+      />
     </SettingsNavigationScrollView>
   );
 }


### PR DESCRIPTION
### 📝 Description

This pull request introduces a new QA/debug screen for notifications prompt reprompting in the Ledger Live Mobile app. The main addition is a comprehensive debug interface for testing and manipulating the push notification prompt's eligibility, reprompt schedule, and dismissal data, along with supporting utilities and navigation integration.

https://github.com/user-attachments/assets/256324e4-0315-448d-b7bc-25d3f70bf1a6

The most important changes are:

**New Debug QA Screen for Notifications Prompt:**
* Added the `DebugNotificationsPromptQA` screen, which displays the current notification opt-in state, enablement status, reprompt timing, dismissal history, and feature flag parameters. It also provides tooling to manipulate user data and trigger or force the prompt drawer for QA purposes. (`apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/index.tsx`)

**Navigation & Type Integration:**
* Registered the new debug screen in the settings navigator, including the route, stack param list, and screen name enum. (`apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx`, `apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts`, `apps/ledger-live-mobile/src/const/navigation.ts`) [[1]](diffhunk://#diff-1d758aa4ec54245da55b23fd3462d84f85569a11dda74ffe26d799476312ebdeR40) [[2]](diffhunk://#diff-1d758aa4ec54245da55b23fd3462d84f85569a11dda74ffe26d799476312ebdeR259-R265) [[3]](diffhunk://#diff-11b4b5693f2a673735f1f1bcb932a85d9fb2f426f5afc6d92245db1f2d335194R33) [[4]](diffhunk://#diff-e8c66117c7353e1986881b4c86cafe568116e540ef74f5220beaed4cc1857e87R42)

**Utilities and Tests for Reprompt Logic:**
* Added utility functions and a comprehensive test suite to build, format, and manipulate notification prompt reprompt and dismissal data, supporting the QA screen's tooling. (`apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/utils.test.ts`)

**Release Note:**
* Added a changeset describing the addition of the LWM notifications prompt QA debug screen and reprompt tooling. (`.changeset/quiet-prompts-debug.md`)

These changes provide a robust interface for QA engineers to test and verify notifications prompt reprompting logic and user state transitions.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-27106](https://ledgerhq.atlassian.net/browse/LIVE-27106)

[LIVE-27106]: https://ledgerhq.atlassian.net/browse/LIVE-27106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ