### PR TITLE
chore(codeowners): assign currency-crypto currencies to coin-integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -144,6 +144,7 @@ apps/ledger-live-mobile/src/screens/SignTransaction/                @ledgerhq/co
 ### ... cryptoassets ongoing rework => the lib now belongs to @ledgerhq/wallet-xp (with currencies owned by @ledgerhq/coin-integration) ... ###
 libs/ledgerjs/packages/cryptoassets                      @ledgerhq/wallet-xp
 libs/ledgerjs/packages/cryptoassets/src/currencies.ts    @ledgerhq/coin-integration
+domain/entity/currency-crypto/src/currencies/            @ledgerhq/coin-integration
 libs/ledgerjs/packages/types-live/src/lnsUpsell.ts       @ledgerhq/engagement
 libs/ledgerjs/packages/types-live/src/postOnboarding.ts  @ledgerhq/engagement
 


### PR DESCRIPTION
### 📝 Description

Assigns domain/entity/currency-crypto/src/currencies/ to @ledgerhq/coin-integration, mirroring the existing ownership of libs/ledgerjs/packages/cryptoassets/src/currencies.ts.

### 🔗 Context

- **JIRA / GitHub issue**: N/A
- **ADR** (if any): N/A