### PR TITLE
[LWDM] refactor(bridge): deprecate preload/hydrate on CurrencyBridge

### DIFF
--- a/.changeset/deprecate-preload-hydrate-currency-bridge.md
+++ b/.changeset/deprecate-preload-hydrate-currency-bridge.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/types-live": minor
+---
+
+Deprecate `preload` and `hydrate` on `CurrencyBridge` interface — both methods are now optional. Prefer loading data lazily in UI flows instead of eagerly via these methods.

--- a/libs/coin-modules/coin-aleo/src/bridge/index.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/index.test.ts
@@ -42,30 +42,11 @@ describe("Bridge", () => {
     jest.fn().mockReturnValue(mockConfig);
 
   describe("buildCurrencyBridge", () => {
-    it("should return a currency bridge with preload, hydrate, and scanAccounts methods", () => {
+    it("should return a currency bridge with scanAccounts method", () => {
       const signerContext = createMockSignerContext();
       const currencyBridge = buildCurrencyBridge(signerContext);
 
-      expect(currencyBridge.preload).toBeInstanceOf(Function);
-      expect(currencyBridge.hydrate).toBeInstanceOf(Function);
       expect(currencyBridge.scanAccounts).toBeInstanceOf(Function);
-    });
-
-    it("should preload successfully", async () => {
-      const signerContext = createMockSignerContext();
-      const currencyBridge = buildCurrencyBridge(signerContext);
-
-      const result = await currencyBridge.preload(getMockedCurrency());
-
-      expect(result).toEqual({});
-    });
-
-    it("hydrate should be a no-op function", () => {
-      const signerContext = createMockSignerContext();
-      const currencyBridge = buildCurrencyBridge(signerContext);
-
-      const result = currencyBridge.hydrate({}, getMockedCurrency());
-      expect(result).toBeUndefined();
     });
   });
 
@@ -136,13 +117,11 @@ describe("Bridge", () => {
       expect(bridges.accountBridge).toBeInstanceOf(Object);
     });
 
-    it("currency bridge should have preload, hydrate, and scanAccounts", () => {
+    it("currency bridge should have scanAccounts", () => {
       const signerContext = createMockSignerContext();
       const mockCoinConfig = createMockCoinConfig();
       const bridges = createBridges(signerContext, mockCoinConfig);
 
-      expect(bridges.currencyBridge.preload).toBeInstanceOf(Function);
-      expect(bridges.currencyBridge.hydrate).toBeInstanceOf(Function);
       expect(bridges.currencyBridge.scanAccounts).toBeInstanceOf(Function);
     });
 

--- a/libs/coin-modules/coin-aleo/src/bridge/index.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/index.ts
@@ -43,8 +43,6 @@ export function buildCurrencyBridge(signerContext: SignerContext<AleoSigner>): C
   });
 
   return {
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-algorand/src/bridge/js.test.ts
+++ b/libs/coin-modules/coin-algorand/src/bridge/js.test.ts
@@ -72,26 +72,8 @@ describe("bridge/js", () => {
     it("should build a currency bridge with required methods", () => {
       const bridge = buildCurrencyBridge(mockSignerContext);
 
-      expect(bridge).toHaveProperty("preload");
-      expect(bridge).toHaveProperty("hydrate");
       expect(bridge).toHaveProperty("scanAccounts");
-      expect(typeof bridge.preload).toBe("function");
-      expect(typeof bridge.hydrate).toBe("function");
       expect(typeof bridge.scanAccounts).toBe("function");
-    });
-
-    it("preload should resolve to empty object", async () => {
-      const bridge = buildCurrencyBridge(mockSignerContext);
-
-      const result = await bridge.preload();
-
-      expect(result).toEqual({});
-    });
-
-    it("hydrate should be callable", () => {
-      const bridge = buildCurrencyBridge(mockSignerContext);
-
-      expect(() => bridge.hydrate()).not.toThrow();
     });
   });
 
@@ -150,8 +132,6 @@ describe("bridge/js", () => {
     it("should return valid currency bridge", () => {
       const { currencyBridge } = createBridges(mockSignerContext);
 
-      expect(currencyBridge).toHaveProperty("preload");
-      expect(currencyBridge).toHaveProperty("hydrate");
       expect(currencyBridge).toHaveProperty("scanAccounts");
     });
 

--- a/libs/coin-modules/coin-algorand/src/bridge/js.ts
+++ b/libs/coin-modules/coin-algorand/src/bridge/js.ts
@@ -37,8 +37,6 @@ export function buildCurrencyBridge(signerContext: SignerContext<AlgorandSigner>
   });
 
   return {
-    preload: async () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-aptos/src/__tests__/bridge/index.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/bridge/index.test.ts
@@ -14,7 +14,7 @@ describe("Aptos bridge interface", () => {
   describe("currencyBridge", () => {
     it("should have a preload method that returns a promise", async () => {
       const cryptoCurrency = getCryptoCurrencyById("aptos");
-      const result = bridge.currencyBridge.preload(cryptoCurrency);
+      const result = bridge.currencyBridge.preload?.(cryptoCurrency);
       expect(result).toBeInstanceOf(Promise);
       await expect(result).resolves.toMatchObject({ validatorsWithMeta: [] });
     });
@@ -22,7 +22,7 @@ describe("Aptos bridge interface", () => {
     it("should have a hydrate method that is a function", () => {
       expect(bridge.currencyBridge.hydrate).toBeInstanceOf(Function);
       const cryptoCurrency = getCryptoCurrencyById("aptos");
-      const result = bridge.currencyBridge.hydrate({}, cryptoCurrency);
+      const result = bridge.currencyBridge.hydrate?.({}, cryptoCurrency);
       expect(result).toBeUndefined();
     });
 

--- a/libs/coin-modules/coin-bitcoin/src/bridge/js.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/bridge/js.test.ts
@@ -23,8 +23,6 @@ describe("createBridges", () => {
         validateAddress: expect.any(Function),
       },
       currencyBridge: {
-        preload: expect.any(Function),
-        hydrate: expect.any(Function),
         scanAccounts: expect.any(Function),
       },
     });

--- a/libs/coin-modules/coin-bitcoin/src/bridge/js.ts
+++ b/libs/coin-modules/coin-bitcoin/src/bridge/js.ts
@@ -46,8 +46,6 @@ function buildCurrencyBridge(signerContext: SignerContext) {
 
   return {
     scanAccounts,
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
   };
 }
 

--- a/libs/coin-modules/coin-canton/src/bridge/index.test.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/index.test.ts
@@ -24,8 +24,6 @@ describe("createBridges", () => {
         authorizePreapproval: expect.any(Function),
         onboardAccount: expect.any(Function),
         transferInstruction: expect.any(Function),
-        preload: expect.any(Function),
-        hydrate: expect.any(Function),
         scanAccounts: expect.any(Function),
       },
     });

--- a/libs/coin-modules/coin-canton/src/bridge/index.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/index.ts
@@ -45,8 +45,6 @@ export function createBridges(
   const transferInstruction = buildTransferInstruction(signerContext);
 
   const currencyBridge: CantonCurrencyBridge = {
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
     onboardAccount,
     authorizePreapproval,

--- a/libs/coin-modules/coin-cardano/src/bridge/index.ts
+++ b/libs/coin-modules/coin-cardano/src/bridge/index.ts
@@ -35,8 +35,6 @@ export function buildCurrencyBridge(signerContext: SignerContext<CardanoSigner>)
 
   return {
     scanAccounts,
-    preload: async () => ({}),
-    hydrate: () => {},
   };
 }
 

--- a/libs/coin-modules/coin-casper/src/bridge/index.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/index.ts
@@ -31,8 +31,6 @@ function buildCurrencyBridge(signerContext: SignerContext<CasperSigner>): Curren
   });
 
   return {
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-concordium/src/bridge/index.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/index.test.ts
@@ -21,10 +21,8 @@ describe("createBridges", () => {
         validateAddress: expect.any(Function),
       },
       currencyBridge: {
-        hydrate: expect.any(Function),
         onboardAccount: expect.any(Function),
         pairWalletConnect: expect.any(Function),
-        preload: expect.any(Function),
         scanAccounts: expect.any(Function),
       },
     });

--- a/libs/coin-modules/coin-concordium/src/bridge/index.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/index.ts
@@ -42,8 +42,6 @@ export function createBridges(
   const pairWalletConnect = buildPairWalletConnect();
 
   const currencyBridge: ConcordiumCurrencyBridge = {
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
     pairWalletConnect,
     onboardAccount,

--- a/libs/coin-modules/coin-filecoin/src/bridge/index.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/index.ts
@@ -29,8 +29,6 @@ function buildCurrencyBridge(signerContext: SignerContext<FilecoinSigner>): Curr
   });
 
   return {
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-icon/src/bridge/index.ts
+++ b/libs/coin-modules/coin-icon/src/bridge/index.ts
@@ -35,8 +35,6 @@ export function buildCurrencyBridge(signerContext: SignerContext<IconSigner>): C
   });
 
   return {
-    preload: async () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-internet_computer/src/bridge/index.ts
+++ b/libs/coin-modules/coin-internet_computer/src/bridge/index.ts
@@ -29,8 +29,6 @@ function buildCurrencyBridge(signerContext: SignerContext<ICPSigner>): CurrencyB
   });
 
   return {
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-kaspa/src/bridge/index.ts
+++ b/libs/coin-modules/coin-kaspa/src/bridge/index.ts
@@ -41,8 +41,6 @@ function buildCurrencyBridge(signerContext: SignerContext<KaspaSigner>): Currenc
   });
 
   return {
-    preload: async () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-mina/src/bridge/index.test.ts
+++ b/libs/coin-modules/coin-mina/src/bridge/index.test.ts
@@ -1,21 +1,8 @@
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
-import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { SignRawOperationArg0 } from "@ledgerhq/types-live";
 import { MinaCoinConfig } from "../config";
 import { MinaAccount, MinaSigner } from "../types";
-import { createBridges, buildCurrencyBridge, buildAccountBridge } from ".";
-
-describe("buildCurrencyBridge", () => {
-  const currencyBridge = buildCurrencyBridge(jest.fn() as SignerContext<MinaSigner>);
-
-  it("preload resolves to empty object", async () => {
-    expect(await currencyBridge.preload({} as CryptoCurrency)).toEqual({});
-  });
-
-  it("hydrate does not throw", () => {
-    expect(() => currencyBridge.hydrate({} as CryptoCurrency, {} as CryptoCurrency)).not.toThrow();
-  });
-});
+import { createBridges, buildAccountBridge } from ".";
 
 describe("buildAccountBridge", () => {
   const accountBridge = buildAccountBridge(jest.fn() as SignerContext<MinaSigner>);
@@ -52,8 +39,6 @@ describe("createBridges", () => {
         assignToAccountRaw: expect.any(Function),
       },
       currencyBridge: {
-        preload: expect.any(Function),
-        hydrate: expect.any(Function),
         scanAccounts: expect.any(Function),
       },
     });

--- a/libs/coin-modules/coin-mina/src/bridge/index.ts
+++ b/libs/coin-modules/coin-mina/src/bridge/index.ts
@@ -36,8 +36,6 @@ export function buildCurrencyBridge(signerContext: SignerContext<MinaSigner>): C
   });
 
   return {
-    preload: async () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-module-boilerplate/src/bridge/index.test.ts
+++ b/libs/coin-modules/coin-module-boilerplate/src/bridge/index.test.ts
@@ -19,8 +19,6 @@ describe("createBridges", () => {
         validateAddress: expect.any(Function),
       },
       currencyBridge: {
-        preload: expect.any(Function),
-        hydrate: expect.any(Function),
         scanAccounts: expect.any(Function),
       },
     });

--- a/libs/coin-modules/coin-module-boilerplate/src/bridge/index.ts
+++ b/libs/coin-modules/coin-module-boilerplate/src/bridge/index.ts
@@ -34,8 +34,6 @@ export function createBridges(
 
   const scanAccounts = makeScanAccounts({ getAccountShape, getAddressFn: getAddress });
   const currencyBridge: CurrencyBridge = {
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 

--- a/libs/coin-modules/coin-solana/src/bridge/bridge.ts
+++ b/libs/coin-modules/coin-solana/src/bridge/bridge.ts
@@ -156,8 +156,10 @@ function makeSign(
   };
 }
 
-function makePreload(getChainAPI: (config: Config) => ChainAPI): CurrencyBridge["preload"] {
-  const preload: CurrencyBridge["preload"] = (currency): Promise<SolanaPreloadDataV1> => {
+function makePreload(
+  getChainAPI: (config: Config) => ChainAPI,
+): (currency: CryptoCurrency) => Promise<SolanaPreloadDataV1> {
+  const preload = (currency: CryptoCurrency): Promise<SolanaPreloadDataV1> => {
     const config: Config = {
       endpoint: endpointByCurrencyId(currency.id),
     };
@@ -212,7 +214,6 @@ export function makeBridges({
 
   const currencyBridge: CurrencyBridge = {
     preload: makePreload(getAPI),
-    hydrate: (_data: unknown, _currency: CryptoCurrency) => {},
     scanAccounts: scan,
     getPreloadStrategy,
     nftResolvers,

--- a/libs/coin-modules/coin-stacks/src/bridge/index.ts
+++ b/libs/coin-modules/coin-stacks/src/bridge/index.ts
@@ -29,8 +29,6 @@ function buildCurrencyBridge(signerContext: SignerContext<StacksSigner>): Curren
   });
 
   return {
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-sui/src/bridge/index.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/index.test.ts
@@ -158,14 +158,14 @@ describe("bridge/index", () => {
     });
 
     it("should return preload from preload module", async () => {
-      const result = await currencyBridge.preload(mockCurrency);
+      const result = await currencyBridge.preload?.(mockCurrency);
       expect(mockPreload).toHaveBeenCalled();
       expect(result).toEqual({});
     });
 
     it("should return hydrate from preload module", () => {
       const data = { some: "data" };
-      currencyBridge.hydrate(data, mockCurrency);
+      currencyBridge.hydrate?.(data, mockCurrency);
       expect(mockHydrate).toHaveBeenCalledWith(data, mockCurrency);
     });
 

--- a/libs/coin-modules/coin-ton/src/bridge/js.ts
+++ b/libs/coin-modules/coin-ton/src/bridge/js.ts
@@ -31,8 +31,6 @@ export function buildCurrencyBridge(signerContext: SignerContext<TonSigner>): Cu
   });
 
   return {
-    preload: async () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-tron/src/bridge/index.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/index.ts
@@ -37,8 +37,6 @@ function buildCurrencyBridge(signerContext: SignerContext<TronSigner>): Currency
   });
 
   return {
-    preload: () => Promise.resolve({}),
-    hydrate: () => undefined,
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-vechain/src/bridge/index.ts
+++ b/libs/coin-modules/coin-vechain/src/bridge/index.ts
@@ -29,8 +29,6 @@ export function buildCurrencyBridge(signerContext: SignerContext<VechainSigner>)
   });
 
   return {
-    preload: async () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-tester-modules/coin-tester-bitcoin/src/scenarii/bitcoin.ts
+++ b/libs/coin-tester-modules/coin-tester-bitcoin/src/scenarii/bitcoin.ts
@@ -289,7 +289,6 @@ export const scenarioBitcoin: Scenario<BtcTransaction, BitcoinAccount> = {
     });
 
     const { accountBridge, currencyBridge } = createBridges(signerContext, () => coinConfig);
-    await currencyBridge.preload();
     const BITCOIN = getCryptoCurrencyById("bitcoin_regtest");
     const getAddress = resolver(signerContext);
     // Can also test LEGACY here

--- a/libs/coin-tester/src/main.ts
+++ b/libs/coin-tester/src/main.ts
@@ -122,9 +122,11 @@ export async function executeScenario<T extends TransactionCommon, A extends Acc
       "\n\n",
     );
 
-    const data = await currencyBridge.preload(account.currency);
-    currencyBridge.hydrate(data, account.currency);
-    console.log("Preload + hydrate completed ✓");
+    if (currencyBridge.preload) {
+      const data = await currencyBridge.preload(account.currency);
+      currencyBridge.hydrate?.(data, account.currency);
+      console.log(`Preload${currencyBridge.hydrate ? " + hydrate" : ""} completed ✓`);
+    }
 
     await scenario.beforeSync?.();
     console.log("Running a synchronization on the account...");

--- a/libs/ledger-live-common/src/__tests__/migration/account-migration.ts
+++ b/libs/ledger-live-common/src/__tests__/migration/account-migration.ts
@@ -92,8 +92,8 @@ const testSync = async (currencyId: string, xpubOrAddress: string) => {
   const mockAccount = getMockAccount(currencyId, xpubOrAddress);
   const currency = getCryptoCurrencyById(currencyId);
   const currencyBridge = await getCurrencyBridge(currency);
-  const data = await currencyBridge.preload(currency);
-  currencyBridge.hydrate(data, currency);
+  const data = await currencyBridge.preload?.(currency);
+  currencyBridge.hydrate?.(data, currency);
   const accountBridge = await getAccountBridgeByFamily(
     mockAccount.currency!.family,
     mockAccount.id,
@@ -115,8 +115,8 @@ const testSyncAccount = async (account: Account) => {
   console.log("starting sync on", account.currency.id, account.xpub ?? account.freshAddress);
   const currency = getCryptoCurrencyById(account.currency.id);
   const currencyBridge = await getCurrencyBridge(currency);
-  const data = await currencyBridge.preload(currency);
-  currencyBridge.hydrate(data, currency);
+  const data = await currencyBridge.preload?.(currency);
+  currencyBridge.hydrate?.(data, currency);
   const accountBridge = await getAccountBridgeByFamily(account.currency!.family, account.id);
 
   const syncedAccount = await firstValueFrom(

--- a/libs/ledger-live-common/src/__tests__/test-helpers/bridge.ts
+++ b/libs/ledger-live-common/src/__tests__/test-helpers/bridge.ts
@@ -158,33 +158,30 @@ export function testBridge<T extends TransactionCommon>(data: DatasetTest<T>): v
       } = currencyData;
       test("functions are defined", () => {
         expect(typeof bridge.scanAccounts).toBe("function");
-        expect(typeof bridge.preload).toBe("function");
-        expect(typeof bridge.hydrate).toBe("function");
       });
-      if (FIXME_ignorePreloadFields !== true) {
-        test("preload and rehydrate", async () => {
-          const data1 = (await bridge.preload(currency)) || {};
-          const data1filtered = omit(data1, FIXME_ignorePreloadFields || []);
+      test("preload and rehydrate", async () => {
+        if (FIXME_ignorePreloadFields === true || !bridge.preload) return;
+        const data1 = (await bridge.preload(currency)) || {};
+        const data1filtered = omit(data1, FIXME_ignorePreloadFields || []);
 
-          bridge.hydrate(data1filtered, currency);
+        bridge.hydrate?.(data1filtered, currency);
 
-          if (data1filtered) {
-            const serialized1 = JSON.parse(JSON.stringify(data1filtered));
-            bridge.hydrate(serialized1, currency);
-            expect(serialized1).toBeDefined();
-            const data2 = (await bridge.preload(currency)) || {};
-            const data2filtered = omit(data2, FIXME_ignorePreloadFields || []);
+        if (data1filtered) {
+          const serialized1 = JSON.parse(JSON.stringify(data1filtered));
+          bridge.hydrate?.(serialized1, currency);
+          expect(serialized1).toBeDefined();
+          const data2 = (await bridge.preload(currency)) || {};
+          const data2filtered = omit(data2, FIXME_ignorePreloadFields || []);
 
-            if (data2filtered) {
-              bridge.hydrate(data2filtered, currency);
-              expect(data1filtered).toMatchObject(data2filtered);
-              const serialized2 = JSON.parse(JSON.stringify(data2filtered));
-              expect(serialized1).toMatchObject(serialized2);
-              bridge.hydrate(serialized2, currency);
-            }
+          if (data2filtered) {
+            bridge.hydrate?.(data2filtered, currency);
+            expect(data1filtered).toMatchObject(data2filtered);
+            const serialized2 = JSON.parse(JSON.stringify(data2filtered));
+            expect(serialized1).toMatchObject(serialized2);
+            bridge.hydrate?.(serialized2, currency);
           }
-        });
-      }
+        }
+      });
 
       if (scanAccounts) {
         if (FIXME_ignoreOperationFields && FIXME_ignoreOperationFields.length) {

--- a/libs/ledger-live-common/src/bridge/cache.ts
+++ b/libs/ledger-live-common/src/bridge/cache.ts
@@ -16,7 +16,7 @@ export function makeBridgeCacheSystem({
   const hydrateCurrency = async (currency: CryptoCurrency) => {
     const value = await getData(currency);
     const bridge = await getCurrencyBridge(currency);
-    bridge.hydrate(value, currency);
+    bridge.hydrate?.(value, currency);
     return value;
   };
 
@@ -36,10 +36,11 @@ export function makeBridgeCacheSystem({
     if (!cache || forceUpdate) {
       cache = makeLRUCache(
         async () => {
+          if (!bridge.preload) return undefined;
           const preloaded = await bridge.preload(currency);
 
           if (preloaded) {
-            bridge.hydrate(preloaded, currency);
+            bridge.hydrate?.(preloaded, currency);
             await saveData(currency, preloaded);
           }
 

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/currencyBridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/currencyBridge.ts
@@ -12,8 +12,6 @@ export async function getCoinFrameworkCurrencyBridge(
 ): Promise<CurrencyBridge> {
   const signer = customSigner ?? (await getSigner(network));
   return {
-    preload: () => Promise.resolve({}),
-    hydrate: () => undefined,
     scanAccounts: makeScanAccounts({
       getAccountShape: genericGetAccountShape(network, kind),
       getAddressFn: signer.getAddress.bind(signer),

--- a/libs/ledger-wallet-framework/src/test-helpers/bridge-integration-suite.ts
+++ b/libs/ledger-wallet-framework/src/test-helpers/bridge-integration-suite.ts
@@ -165,26 +165,27 @@ export async function testBridge<T extends TransactionCommon, U extends Transact
       const { FIXME_ignoreAccountFields, FIXME_ignoreOperationFields, FIXME_ignorePreloadFields } =
         currencyData;
 
-      if (FIXME_ignorePreloadFields !== true) {
+      if (FIXME_ignorePreloadFields !== true && bridge.preload) {
+        const { preload } = bridge;
         test("preload and rehydrate", async () => {
-          const data1 = (await bridge.preload(currency)) || {};
+          const data1 = (await preload(currency)) || {};
           const data1filtered = omit(data1, FIXME_ignorePreloadFields || []);
 
-          bridge.hydrate(data1filtered, currency);
+          bridge.hydrate?.(data1filtered, currency);
 
           if (data1filtered) {
             const serialized1 = JSON.parse(JSON.stringify(data1filtered));
-            bridge.hydrate(serialized1, currency);
+            bridge.hydrate?.(serialized1, currency);
             expect(serialized1).toBeDefined();
-            const data2 = (await bridge.preload(currency)) || {};
+            const data2 = (await preload(currency)) || {};
             const data2filtered = omit(data2, FIXME_ignorePreloadFields || []);
 
             if (data2filtered) {
-              bridge.hydrate(data2filtered, currency);
+              bridge.hydrate?.(data2filtered, currency);
               expect(data1filtered).toMatchObject(data2filtered);
               const serialized2 = JSON.parse(JSON.stringify(data2filtered));
               expect(serialized1).toMatchObject(serialized2);
-              bridge.hydrate(serialized2, currency);
+              bridge.hydrate?.(serialized2, currency);
             }
           }
         });

--- a/libs/ledgerjs/packages/types-live/src/bridge.ts
+++ b/libs/ledgerjs/packages/types-live/src/bridge.ts
@@ -118,14 +118,19 @@ export type ScanInfo = {
  * Abstraction related to a currency
  */
 export interface CurrencyBridge {
-  // Preload data required for the bridges to work. (e.g. tokens, delegators,...)
-  // Assume to call it at every load time but as lazy as possible (if user have such account already AND/OR if user is about to scanAccounts)
-  // returned value is a serializable object
-  // fail if data was not able to load.
-  preload(currency: CryptoCurrency): Promise<Record<string, any> | Array<unknown> | void>;
-  // reinject the preloaded data (typically if it was cached)
-  // method need to treat the data object as unsafe and validate all fields / be backward compatible.
-  hydrate(data: unknown, currency: CryptoCurrency): void;
+  /**
+   * @deprecated Prefer loading data lazily in the UI/flows that need it.
+   * Eagerly fetches data required by the bridge (e.g. validators, delegators).
+   * Should be called as late as possible — only when the user has such an account or is about to scan.
+   * Returns a serializable object, or undefined if no data needs to be preloaded. Throws if data could not be loaded.
+   */
+  preload?(currency: CryptoCurrency): Promise<Record<string, any> | Array<unknown> | void>;
+  /**
+   * @deprecated Prefer loading data lazily in the UI/flows that need it.
+   * Re-injects previously preloaded data (e.g. from a cache).
+   * Must treat the data as untrusted: validate all fields and handle missing/unknown keys gracefully.
+   */
+  hydrate?(data: unknown, currency: CryptoCurrency): void;
   // Scan all available accounts with a device
   scanAccounts(info: ScanInfo): Observable<ScanAccountEvent>;
   getPreloadStrategy?: (currency: CryptoCurrency) => PreloadStrategy;


### PR DESCRIPTION
> [!NOTE]
> The preload/hydrate mechanism on CurrencyBridge is a legacy pattern for eagerly loading delegator/validator data. The preferred approach is lazy loading in the UI flows that need the data.

### 📝 Description

Consolidates three related changes into a single PR:

1. Mark preload and hydrate as optional and @deprecated on the CurrencyBridge interface in @ledgerhq/types-live (minor bump).
2. Remove no-op preload/hydrate stubs from 18 coin bridges (algorand, aleo, bitcoin, canton, cardano, casper, concordium, filecoin, icon, internet_computer, kaspa, mina, module-boilerplate, solana, stacks, ton, tron, vechain).
3. Guard all remaining call sites with optional chaining or presence checks (bridge/cache.ts, coin-tester, bridge-integration-suite, account-migration tests).

Consumer-side impact — new coin bridges no longer need to declare these:

```diff
  const currencyBridge: CurrencyBridge = {
-   preload: () => Promise.resolve({}),
-   hydrate: () => {},
    scanAccounts,
  };
```

Coin bridges that still implement preload/hydrate (cosmos, EVM, tezos, xrp, multiversx, solana mock, bitcoin mock) continue to work without changes — the interface change is purely additive (making required fields optional).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-33992](https://ledgerhq.atlassian.net/browse/LIVE-33992)
- **ADR** (if any): N/A

[LIVE-33992]: https://ledgerhq.atlassian.net/browse/LIVE-33992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ