### PR TITLE
[LWDM] refactor(coin): remove no-op preload/hydrate stubs from 16 coin bridges

### DIFF
--- a/libs/coin-modules/coin-aleo/src/bridge/index.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/index.ts
@@ -43,8 +43,6 @@ export function buildCurrencyBridge(signerContext: SignerContext<AleoSigner>): C
   });
 
   return {
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-algorand/src/bridge/js.ts
+++ b/libs/coin-modules/coin-algorand/src/bridge/js.ts
@@ -37,8 +37,6 @@ export function buildCurrencyBridge(signerContext: SignerContext<AlgorandSigner>
   });
 
   return {
-    preload: async () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-bitcoin/src/bridge/js.ts
+++ b/libs/coin-modules/coin-bitcoin/src/bridge/js.ts
@@ -46,8 +46,6 @@ function buildCurrencyBridge(signerContext: SignerContext) {
 
   return {
     scanAccounts,
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
   };
 }
 

--- a/libs/coin-modules/coin-canton/src/bridge/index.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/index.ts
@@ -45,8 +45,6 @@ export function createBridges(
   const transferInstruction = buildTransferInstruction(signerContext);
 
   const currencyBridge: CantonCurrencyBridge = {
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
     onboardAccount,
     authorizePreapproval,

--- a/libs/coin-modules/coin-cardano/src/bridge/index.ts
+++ b/libs/coin-modules/coin-cardano/src/bridge/index.ts
@@ -35,8 +35,6 @@ export function buildCurrencyBridge(signerContext: SignerContext<CardanoSigner>)
 
   return {
     scanAccounts,
-    preload: async () => ({}),
-    hydrate: () => {},
   };
 }
 

--- a/libs/coin-modules/coin-casper/src/bridge/index.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/index.ts
@@ -31,8 +31,6 @@ function buildCurrencyBridge(signerContext: SignerContext<CasperSigner>): Curren
   });
 
   return {
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-concordium/src/bridge/index.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/index.ts
@@ -42,8 +42,6 @@ export function createBridges(
   const pairWalletConnect = buildPairWalletConnect();
 
   const currencyBridge: ConcordiumCurrencyBridge = {
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
     pairWalletConnect,
     onboardAccount,

--- a/libs/coin-modules/coin-filecoin/src/bridge/index.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/index.ts
@@ -29,8 +29,6 @@ function buildCurrencyBridge(signerContext: SignerContext<FilecoinSigner>): Curr
   });
 
   return {
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-icon/src/bridge/index.ts
+++ b/libs/coin-modules/coin-icon/src/bridge/index.ts
@@ -35,8 +35,6 @@ export function buildCurrencyBridge(signerContext: SignerContext<IconSigner>): C
   });
 
   return {
-    preload: async () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-internet_computer/src/bridge/index.ts
+++ b/libs/coin-modules/coin-internet_computer/src/bridge/index.ts
@@ -29,8 +29,6 @@ function buildCurrencyBridge(signerContext: SignerContext<ICPSigner>): CurrencyB
   });
 
   return {
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-kaspa/src/bridge/index.ts
+++ b/libs/coin-modules/coin-kaspa/src/bridge/index.ts
@@ -41,8 +41,6 @@ function buildCurrencyBridge(signerContext: SignerContext<KaspaSigner>): Currenc
   });
 
   return {
-    preload: async () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-mina/src/bridge/index.ts
+++ b/libs/coin-modules/coin-mina/src/bridge/index.ts
@@ -36,8 +36,6 @@ export function buildCurrencyBridge(signerContext: SignerContext<MinaSigner>): C
   });
 
   return {
-    preload: async () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-module-boilerplate/src/bridge/index.test.ts
+++ b/libs/coin-modules/coin-module-boilerplate/src/bridge/index.test.ts
@@ -19,8 +19,6 @@ describe("createBridges", () => {
         validateAddress: expect.any(Function),
       },
       currencyBridge: {
-        preload: expect.any(Function),
-        hydrate: expect.any(Function),
         scanAccounts: expect.any(Function),
       },
     });

--- a/libs/coin-modules/coin-module-boilerplate/src/bridge/index.ts
+++ b/libs/coin-modules/coin-module-boilerplate/src/bridge/index.ts
@@ -34,8 +34,6 @@ export function createBridges(
 
   const scanAccounts = makeScanAccounts({ getAccountShape, getAddressFn: getAddress });
   const currencyBridge: CurrencyBridge = {
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 

--- a/libs/coin-modules/coin-solana/src/bridge/bridge.ts
+++ b/libs/coin-modules/coin-solana/src/bridge/bridge.ts
@@ -214,7 +214,6 @@ export function makeBridges({
 
   const currencyBridge: CurrencyBridge = {
     preload: makePreload(getAPI),
-    hydrate: (_data: unknown, _currency: CryptoCurrency) => {},
     scanAccounts: scan,
     getPreloadStrategy,
     nftResolvers,

--- a/libs/coin-modules/coin-solana/src/bridge/bridge.ts
+++ b/libs/coin-modules/coin-solana/src/bridge/bridge.ts
@@ -156,8 +156,10 @@ function makeSign(
   };
 }
 
-function makePreload(getChainAPI: (config: Config) => ChainAPI): CurrencyBridge["preload"] {
-  const preload: CurrencyBridge["preload"] = (currency): Promise<SolanaPreloadDataV1> => {
+function makePreload(
+  getChainAPI: (config: Config) => ChainAPI,
+): (currency: CryptoCurrency) => Promise<SolanaPreloadDataV1> {
+  const preload = (currency: CryptoCurrency): Promise<SolanaPreloadDataV1> => {
     const config: Config = {
       endpoint: endpointByCurrencyId(currency.id),
     };

--- a/libs/coin-modules/coin-stacks/src/bridge/index.ts
+++ b/libs/coin-modules/coin-stacks/src/bridge/index.ts
@@ -29,8 +29,6 @@ function buildCurrencyBridge(signerContext: SignerContext<StacksSigner>): Curren
   });
 
   return {
-    preload: () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-ton/src/bridge/js.ts
+++ b/libs/coin-modules/coin-ton/src/bridge/js.ts
@@ -31,8 +31,6 @@ export function buildCurrencyBridge(signerContext: SignerContext<TonSigner>): Cu
   });
 
   return {
-    preload: async () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-tron/src/bridge/index.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/index.ts
@@ -37,8 +37,6 @@ function buildCurrencyBridge(signerContext: SignerContext<TronSigner>): Currency
   });
 
   return {
-    preload: () => Promise.resolve({}),
-    hydrate: () => undefined,
     scanAccounts,
   };
 }

--- a/libs/coin-modules/coin-vechain/src/bridge/index.ts
+++ b/libs/coin-modules/coin-vechain/src/bridge/index.ts
@@ -29,8 +29,6 @@ export function buildCurrencyBridge(signerContext: SignerContext<VechainSigner>)
   });
 
   return {
-    preload: async () => Promise.resolve({}),
-    hydrate: () => {},
     scanAccounts,
   };
 }

--- a/libs/coin-tester/src/main.ts
+++ b/libs/coin-tester/src/main.ts
@@ -122,9 +122,11 @@ export async function executeScenario<T extends TransactionCommon, A extends Acc
       "\n\n",
     );
 
-    const data = await currencyBridge.preload(account.currency);
-    currencyBridge.hydrate(data, account.currency);
-    console.log("Preload + hydrate completed ✓");
+    if (currencyBridge.preload) {
+      const data = await currencyBridge.preload(account.currency);
+      currencyBridge.hydrate?.(data, account.currency);
+      console.log("Preload + hydrate completed ✓");
+    }
 
     await scenario.beforeSync?.();
     console.log("Running a synchronization on the account...");

--- a/libs/ledger-live-common/src/__tests__/test-helpers/bridge.ts
+++ b/libs/ledger-live-common/src/__tests__/test-helpers/bridge.ts
@@ -158,33 +158,30 @@ export function testBridge<T extends TransactionCommon>(data: DatasetTest<T>): v
       } = currencyData;
       test("functions are defined", () => {
         expect(typeof bridge.scanAccounts).toBe("function");
-        expect(typeof bridge.preload).toBe("function");
-        expect(typeof bridge.hydrate).toBe("function");
       });
-      if (FIXME_ignorePreloadFields !== true) {
-        test("preload and rehydrate", async () => {
-          const data1 = (await bridge.preload(currency)) || {};
-          const data1filtered = omit(data1, FIXME_ignorePreloadFields || []);
+      test("preload and rehydrate", async () => {
+        if (FIXME_ignorePreloadFields === true || !bridge.preload) return;
+        const data1 = (await bridge.preload(currency)) || {};
+        const data1filtered = omit(data1, FIXME_ignorePreloadFields || []);
 
-          bridge.hydrate(data1filtered, currency);
+        bridge.hydrate?.(data1filtered, currency);
 
-          if (data1filtered) {
-            const serialized1 = JSON.parse(JSON.stringify(data1filtered));
-            bridge.hydrate(serialized1, currency);
-            expect(serialized1).toBeDefined();
-            const data2 = (await bridge.preload(currency)) || {};
-            const data2filtered = omit(data2, FIXME_ignorePreloadFields || []);
+        if (data1filtered) {
+          const serialized1 = JSON.parse(JSON.stringify(data1filtered));
+          bridge.hydrate?.(serialized1, currency);
+          expect(serialized1).toBeDefined();
+          const data2 = (await bridge.preload(currency)) || {};
+          const data2filtered = omit(data2, FIXME_ignorePreloadFields || []);
 
-            if (data2filtered) {
-              bridge.hydrate(data2filtered, currency);
-              expect(data1filtered).toMatchObject(data2filtered);
-              const serialized2 = JSON.parse(JSON.stringify(data2filtered));
-              expect(serialized1).toMatchObject(serialized2);
-              bridge.hydrate(serialized2, currency);
-            }
+          if (data2filtered) {
+            bridge.hydrate?.(data2filtered, currency);
+            expect(data1filtered).toMatchObject(data2filtered);
+            const serialized2 = JSON.parse(JSON.stringify(data2filtered));
+            expect(serialized1).toMatchObject(serialized2);
+            bridge.hydrate?.(serialized2, currency);
           }
-        });
-      }
+        }
+      });
 
       if (scanAccounts) {
         if (FIXME_ignoreOperationFields && FIXME_ignoreOperationFields.length) {

--- a/libs/ledger-live-common/src/bridge/cache.ts
+++ b/libs/ledger-live-common/src/bridge/cache.ts
@@ -16,7 +16,7 @@ export function makeBridgeCacheSystem({
   const hydrateCurrency = async (currency: CryptoCurrency) => {
     const value = await getData(currency);
     const bridge = await getCurrencyBridge(currency);
-    bridge.hydrate(value, currency);
+    bridge.hydrate?.(value, currency);
     return value;
   };
 
@@ -36,10 +36,11 @@ export function makeBridgeCacheSystem({
     if (!cache || forceUpdate) {
       cache = makeLRUCache(
         async () => {
+          if (!bridge.preload) return undefined;
           const preloaded = await bridge.preload(currency);
 
           if (preloaded) {
-            bridge.hydrate(preloaded, currency);
+            bridge.hydrate?.(preloaded, currency);
             await saveData(currency, preloaded);
           }
 

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/currencyBridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/currencyBridge.ts
@@ -12,8 +12,6 @@ export async function getCoinFrameworkCurrencyBridge(
 ): Promise<CurrencyBridge> {
   const signer = customSigner ?? (await getSigner(network));
   return {
-    preload: () => Promise.resolve({}),
-    hydrate: () => undefined,
     scanAccounts: makeScanAccounts({
       getAccountShape: genericGetAccountShape(network, kind),
       getAddressFn: signer.getAddress.bind(signer),

--- a/libs/ledgerjs/packages/types-live/src/bridge.ts
+++ b/libs/ledgerjs/packages/types-live/src/bridge.ts
@@ -118,14 +118,20 @@ export type ScanInfo = {
  * Abstraction related to a currency
  */
 export interface CurrencyBridge {
-  // Preload data required for the bridges to work. (e.g. tokens, delegators,...)
-  // Assume to call it at every load time but as lazy as possible (if user have such account already AND/OR if user is about to scanAccounts)
-  // returned value is a serializable object
-  // fail if data was not able to load.
-  preload(currency: CryptoCurrency): Promise<Record<string, any> | Array<unknown> | void>;
-  // reinject the preloaded data (typically if it was cached)
-  // method need to treat the data object as unsafe and validate all fields / be backward compatible.
-  hydrate(data: unknown, currency: CryptoCurrency): void;
+  /**
+   * @deprecated Prefer loading data lazily in the UI/flows that need it.
+   * Preload data required for the bridges to work. (e.g. tokens, delegators,...)
+   * Assume to call it at every load time but as lazy as possible (if user have such account already AND/OR if user is about to scanAccounts)
+   * returned value is a serializable object
+   * fail if data was not able to load.
+   */
+  preload?(currency: CryptoCurrency): Promise<Record<string, any> | Array<unknown> | void>;
+  /**
+   * @deprecated Prefer loading data lazily in the UI/flows that need it.
+   * Reinject the preloaded data (typically if it was cached).
+   * Method need to treat the data object as unsafe and validate all fields / be backward compatible.
+   */
+  hydrate?(data: unknown, currency: CryptoCurrency): void;
   // Scan all available accounts with a device
   scanAccounts(info: ScanInfo): Observable<ScanAccountEvent>;
   getPreloadStrategy?: (currency: CryptoCurrency) => PreloadStrategy;


### PR DESCRIPTION
> [!NOTE]
> Stacked on #19333. Merge that first.

### 📝 Description

Follow-up to #19333 which made preload/hydrate optional on CurrencyBridge.

Now that these methods are not required, the 16 coin bridges that implemented empty stubs (preload: () => Promise.resolve({}) / hydrate: () => {}) can simply drop them. Keeping them around would mislead future contributors into thinking they are needed.

Coins cleaned: aleo, algorand, bitcoin, canton, cardano, casper, concordium, filecoin, icon, internet_computer, kaspa, mina, stacks, ton, tron, vechain.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-33992](https://ledgerhq.atlassian.net/browse/LIVE-33992)
- **ADR** (if any): N/A

[LIVE-33992]: https://ledgerhq.atlassian.net/browse/LIVE-33992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ