### PR TITLE
[LWDM] refactor(bridge): guard optional preload/hydrate call sites; fix JSDoc

### DIFF
--- a/.changeset/deprecate-preload-hydrate-currency-bridge.md
+++ b/.changeset/deprecate-preload-hydrate-currency-bridge.md
@@ -1,5 +1,5 @@
 ---
-"@ledgerhq/types-live": patch
+"@ledgerhq/types-live": minor
 ---
 
 Deprecate `preload` and `hydrate` on `CurrencyBridge` interface — both methods are now optional. Prefer loading data lazily in UI flows instead of eagerly via these methods.

--- a/.changeset/deprecate-preload-hydrate-currency-bridge.md
+++ b/.changeset/deprecate-preload-hydrate-currency-bridge.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/types-live": patch
+---
+
+Deprecate `preload` and `hydrate` on `CurrencyBridge` interface — both methods are now optional. Prefer loading data lazily in UI flows instead of eagerly via these methods.

--- a/libs/coin-modules/coin-aleo/src/bridge/index.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/index.test.ts
@@ -42,30 +42,11 @@ describe("Bridge", () => {
     jest.fn().mockReturnValue(mockConfig);
 
   describe("buildCurrencyBridge", () => {
-    it("should return a currency bridge with preload, hydrate, and scanAccounts methods", () => {
+    it("should return a currency bridge with scanAccounts method", () => {
       const signerContext = createMockSignerContext();
       const currencyBridge = buildCurrencyBridge(signerContext);
 
-      expect(currencyBridge.preload).toBeInstanceOf(Function);
-      expect(currencyBridge.hydrate).toBeInstanceOf(Function);
       expect(currencyBridge.scanAccounts).toBeInstanceOf(Function);
-    });
-
-    it("should preload successfully", async () => {
-      const signerContext = createMockSignerContext();
-      const currencyBridge = buildCurrencyBridge(signerContext);
-
-      const result = await currencyBridge.preload(getMockedCurrency());
-
-      expect(result).toEqual({});
-    });
-
-    it("hydrate should be a no-op function", () => {
-      const signerContext = createMockSignerContext();
-      const currencyBridge = buildCurrencyBridge(signerContext);
-
-      const result = currencyBridge.hydrate({}, getMockedCurrency());
-      expect(result).toBeUndefined();
     });
   });
 
@@ -136,13 +117,11 @@ describe("Bridge", () => {
       expect(bridges.accountBridge).toBeInstanceOf(Object);
     });
 
-    it("currency bridge should have preload, hydrate, and scanAccounts", () => {
+    it("currency bridge should have scanAccounts", () => {
       const signerContext = createMockSignerContext();
       const mockCoinConfig = createMockCoinConfig();
       const bridges = createBridges(signerContext, mockCoinConfig);
 
-      expect(bridges.currencyBridge.preload).toBeInstanceOf(Function);
-      expect(bridges.currencyBridge.hydrate).toBeInstanceOf(Function);
       expect(bridges.currencyBridge.scanAccounts).toBeInstanceOf(Function);
     });
 

--- a/libs/coin-modules/coin-algorand/src/bridge/js.test.ts
+++ b/libs/coin-modules/coin-algorand/src/bridge/js.test.ts
@@ -72,26 +72,8 @@ describe("bridge/js", () => {
     it("should build a currency bridge with required methods", () => {
       const bridge = buildCurrencyBridge(mockSignerContext);
 
-      expect(bridge).toHaveProperty("preload");
-      expect(bridge).toHaveProperty("hydrate");
       expect(bridge).toHaveProperty("scanAccounts");
-      expect(typeof bridge.preload).toBe("function");
-      expect(typeof bridge.hydrate).toBe("function");
       expect(typeof bridge.scanAccounts).toBe("function");
-    });
-
-    it("preload should resolve to empty object", async () => {
-      const bridge = buildCurrencyBridge(mockSignerContext);
-
-      const result = await bridge.preload();
-
-      expect(result).toEqual({});
-    });
-
-    it("hydrate should be callable", () => {
-      const bridge = buildCurrencyBridge(mockSignerContext);
-
-      expect(() => bridge.hydrate()).not.toThrow();
     });
   });
 
@@ -150,8 +132,6 @@ describe("bridge/js", () => {
     it("should return valid currency bridge", () => {
       const { currencyBridge } = createBridges(mockSignerContext);
 
-      expect(currencyBridge).toHaveProperty("preload");
-      expect(currencyBridge).toHaveProperty("hydrate");
       expect(currencyBridge).toHaveProperty("scanAccounts");
     });
 

--- a/libs/coin-modules/coin-bitcoin/src/bridge/js.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/bridge/js.test.ts
@@ -23,8 +23,6 @@ describe("createBridges", () => {
         validateAddress: expect.any(Function),
       },
       currencyBridge: {
-        preload: expect.any(Function),
-        hydrate: expect.any(Function),
         scanAccounts: expect.any(Function),
       },
     });

--- a/libs/coin-modules/coin-canton/src/bridge/index.test.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/index.test.ts
@@ -24,8 +24,6 @@ describe("createBridges", () => {
         authorizePreapproval: expect.any(Function),
         onboardAccount: expect.any(Function),
         transferInstruction: expect.any(Function),
-        preload: expect.any(Function),
-        hydrate: expect.any(Function),
         scanAccounts: expect.any(Function),
       },
     });

--- a/libs/coin-modules/coin-concordium/src/bridge/index.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/index.test.ts
@@ -21,10 +21,8 @@ describe("createBridges", () => {
         validateAddress: expect.any(Function),
       },
       currencyBridge: {
-        hydrate: expect.any(Function),
         onboardAccount: expect.any(Function),
         pairWalletConnect: expect.any(Function),
-        preload: expect.any(Function),
         scanAccounts: expect.any(Function),
       },
     });

--- a/libs/coin-modules/coin-mina/src/bridge/index.test.ts
+++ b/libs/coin-modules/coin-mina/src/bridge/index.test.ts
@@ -1,21 +1,8 @@
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
-import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { SignRawOperationArg0 } from "@ledgerhq/types-live";
 import { MinaCoinConfig } from "../config";
 import { MinaAccount, MinaSigner } from "../types";
-import { createBridges, buildCurrencyBridge, buildAccountBridge } from ".";
-
-describe("buildCurrencyBridge", () => {
-  const currencyBridge = buildCurrencyBridge(jest.fn() as SignerContext<MinaSigner>);
-
-  it("preload resolves to empty object", async () => {
-    expect(await currencyBridge.preload({} as CryptoCurrency)).toEqual({});
-  });
-
-  it("hydrate does not throw", () => {
-    expect(() => currencyBridge.hydrate({} as CryptoCurrency, {} as CryptoCurrency)).not.toThrow();
-  });
-});
+import { createBridges, buildAccountBridge } from ".";
 
 describe("buildAccountBridge", () => {
   const accountBridge = buildAccountBridge(jest.fn() as SignerContext<MinaSigner>);
@@ -52,8 +39,6 @@ describe("createBridges", () => {
         assignToAccountRaw: expect.any(Function),
       },
       currencyBridge: {
-        preload: expect.any(Function),
-        hydrate: expect.any(Function),
         scanAccounts: expect.any(Function),
       },
     });

--- a/libs/coin-tester-modules/coin-tester-bitcoin/src/scenarii/bitcoin.ts
+++ b/libs/coin-tester-modules/coin-tester-bitcoin/src/scenarii/bitcoin.ts
@@ -289,7 +289,7 @@ export const scenarioBitcoin: Scenario<BtcTransaction, BitcoinAccount> = {
     });
 
     const { accountBridge, currencyBridge } = createBridges(signerContext, () => coinConfig);
-    await currencyBridge.preload();
+    await currencyBridge.preload?.();
     const BITCOIN = getCryptoCurrencyById("bitcoin_regtest");
     const getAddress = resolver(signerContext);
     // Can also test LEGACY here

--- a/libs/coin-tester/src/main.ts
+++ b/libs/coin-tester/src/main.ts
@@ -125,7 +125,7 @@ export async function executeScenario<T extends TransactionCommon, A extends Acc
     if (currencyBridge.preload) {
       const data = await currencyBridge.preload(account.currency);
       currencyBridge.hydrate?.(data, account.currency);
-      console.log("Preload + hydrate completed ✓");
+      console.log(`Preload${currencyBridge.hydrate ? " + hydrate" : ""} completed ✓`);
     }
 
     await scenario.beforeSync?.();

--- a/libs/ledger-live-common/src/__tests__/migration/account-migration.ts
+++ b/libs/ledger-live-common/src/__tests__/migration/account-migration.ts
@@ -92,8 +92,8 @@ const testSync = async (currencyId: string, xpubOrAddress: string) => {
   const mockAccount = getMockAccount(currencyId, xpubOrAddress);
   const currency = getCryptoCurrencyById(currencyId);
   const currencyBridge = await getCurrencyBridge(currency);
-  const data = await currencyBridge.preload(currency);
-  currencyBridge.hydrate(data, currency);
+  const data = await currencyBridge.preload?.(currency);
+  currencyBridge.hydrate?.(data, currency);
   const accountBridge = await getAccountBridgeByFamily(
     mockAccount.currency!.family,
     mockAccount.id,
@@ -115,8 +115,8 @@ const testSyncAccount = async (account: Account) => {
   console.log("starting sync on", account.currency.id, account.xpub ?? account.freshAddress);
   const currency = getCryptoCurrencyById(account.currency.id);
   const currencyBridge = await getCurrencyBridge(currency);
-  const data = await currencyBridge.preload(currency);
-  currencyBridge.hydrate(data, currency);
+  const data = await currencyBridge.preload?.(currency);
+  currencyBridge.hydrate?.(data, currency);
   const accountBridge = await getAccountBridgeByFamily(account.currency!.family, account.id);
 
   const syncedAccount = await firstValueFrom(

--- a/libs/ledger-wallet-framework/src/test-helpers/bridge-integration-suite.ts
+++ b/libs/ledger-wallet-framework/src/test-helpers/bridge-integration-suite.ts
@@ -167,24 +167,25 @@ export async function testBridge<T extends TransactionCommon, U extends Transact
 
       if (FIXME_ignorePreloadFields !== true) {
         test("preload and rehydrate", async () => {
+          if (!bridge.preload) return;
           const data1 = (await bridge.preload(currency)) || {};
           const data1filtered = omit(data1, FIXME_ignorePreloadFields || []);
 
-          bridge.hydrate(data1filtered, currency);
+          bridge.hydrate?.(data1filtered, currency);
 
           if (data1filtered) {
             const serialized1 = JSON.parse(JSON.stringify(data1filtered));
-            bridge.hydrate(serialized1, currency);
+            bridge.hydrate?.(serialized1, currency);
             expect(serialized1).toBeDefined();
             const data2 = (await bridge.preload(currency)) || {};
             const data2filtered = omit(data2, FIXME_ignorePreloadFields || []);
 
             if (data2filtered) {
-              bridge.hydrate(data2filtered, currency);
+              bridge.hydrate?.(data2filtered, currency);
               expect(data1filtered).toMatchObject(data2filtered);
               const serialized2 = JSON.parse(JSON.stringify(data2filtered));
               expect(serialized1).toMatchObject(serialized2);
-              bridge.hydrate(serialized2, currency);
+              bridge.hydrate?.(serialized2, currency);
             }
           }
         });

--- a/libs/ledgerjs/packages/types-live/src/bridge.ts
+++ b/libs/ledgerjs/packages/types-live/src/bridge.ts
@@ -120,16 +120,15 @@ export type ScanInfo = {
 export interface CurrencyBridge {
   /**
    * @deprecated Prefer loading data lazily in the UI/flows that need it.
-   * Preload data required for the bridges to work. (e.g. tokens, delegators,...)
-   * Assume to call it at every load time but as lazy as possible (if user have such account already AND/OR if user is about to scanAccounts)
-   * returned value is a serializable object
-   * fail if data was not able to load.
+   * Eagerly fetches data required by the bridge (e.g. validators, delegators).
+   * Should be called as late as possible — only when the user has such an account or is about to scan.
+   * Returns a serializable object, or undefined if no data needs to be preloaded. Throws if data could not be loaded.
    */
   preload?(currency: CryptoCurrency): Promise<Record<string, any> | Array<unknown> | void>;
   /**
    * @deprecated Prefer loading data lazily in the UI/flows that need it.
-   * Reinject the preloaded data (typically if it was cached).
-   * Method need to treat the data object as unsafe and validate all fields / be backward compatible.
+   * Re-injects previously preloaded data (e.g. from a cache).
+   * Must treat the data as untrusted: validate all fields and handle missing/unknown keys gracefully.
    */
   hydrate?(data: unknown, currency: CryptoCurrency): void;
   // Scan all available accounts with a device


### PR DESCRIPTION
> [!NOTE]
> Stacked on #19334, which is stacked on #19333. Merge those first.

### 📝 Description

Addresses Copilot review feedback on #19333:

1. JSDoc: tighten wording on both deprecated methods (grammar + clarity).
2. Guard unguarded preload/hydrate call sites that would become TypeScript errors or runtime crashes now that both methods are optional:
   - libs/ledger-live-common/src/__tests__/test-helpers/bridge.ts — skip preload/hydrate assertions and test block when the bridge does not implement them; use optional chaining on all calls
   - libs/coin-tester/src/main.ts — wrap preload + hydrate in an existence check

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-33992](https://ledgerhq.atlassian.net/browse/LIVE-33992)
- **ADR** (if any): N/A

[LIVE-33992]: https://ledgerhq.atlassian.net/browse/LIVE-33992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ