### PR TITLE
[LWD] test(e2e-desktop): fix flaky swap "Asset Allocation" entry point

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -590,7 +590,7 @@ const SwapWebView = ({
         />
       )}
 
-      <SwapWebAppWrapper>
+      <SwapWebAppWrapper data-testid={`swap-web-app-container-${isEmbedded ? "embedded" : "full"}`}>
         <Web3AppWebview
           manifest={manifestWithHash}
           inputs={{

--- a/e2e/desktop/tests/page/asset.page.ts
+++ b/e2e/desktop/tests/page/asset.page.ts
@@ -1,5 +1,6 @@
 import { step } from "../misc/reporters/step";
 import { AppPage } from "./abstractClasses";
+import { isAggregatedAssetsEnabled } from "tests/utils/featureFlagUtils";
 
 export class AssetPage extends AppPage {
   // Buy CTA differs between the legacy Asset page (`asset-page-buy-button`) and the Wallet 4.0
@@ -19,15 +20,11 @@ export class AssetPage extends AppPage {
 
   @step("Start swap flow")
   async startSwapFlow() {
-    // Wait for whichever swap entry the rendered page exposes, then click only the legacy CTA.
-    // On AssetDetail the embedded rail is already mounted, so there is nothing to click and the
-    // caller's swap-readiness wait takes over from here.
-    await this.legacySwapButton
-      .or(this.embeddedSwapContainer)
-      .first()
-      .waitFor({ state: "visible" });
-    if (await this.legacySwapButton.isVisible()) {
-      await this.legacySwapButton.click();
+    if (await isAggregatedAssetsEnabled(this.page)) {
+      await this.embeddedSwapContainer.waitFor();
+      return;
     }
+    await this.legacySwapButton.waitFor();
+    await this.legacySwapButton.click();
   }
 }

--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -15,6 +15,7 @@ import { getMinimumSwapAmount } from "@ledgerhq/live-e2e-shared/swap";
 // Uniswap's Permit2 "Approve token access" step can take 1-5 min to confirm on-chain
 // before the sign-permit button appears (the app shows a "1-5 mins" estimate).
 const APPROVAL_PROCESSING_TIMEOUT = 300_000;
+type SwapSurface = "full" | "embedded";
 
 export class SwapPage extends WebViewAppPage {
   protected readonly webviewIdentifier = "swap";
@@ -24,12 +25,8 @@ export class SwapPage extends WebViewAppPage {
     "../artifacts/ledgerwallet-swap-history.csv",
   );
 
-  private swapPageHeading = this.page
-    .getByTestId("page-header")
-    .getByRole("heading", { name: "Swap" });
-  // Wallet 4.0 AssetDetail (aggregatedAssets ON) reaches swap through the always-mounted embedded
-  // rail rather than the full swap page, so there is no "Swap" page header to wait for.
-  private readonly embeddedSwapContainer = this.page.getByTestId("embedded-swap-container");
+  private readonly fullSwapContainer = this.page.getByTestId("swap-web-app-container-full");
+  private readonly embeddedSwapContainer = this.page.getByTestId("swap-web-app-container-embedded");
 
   // Swap Amount and Currency components
   private maxSpendableToggle = this.page.getByTestId("swap-max-spendable-toggle");
@@ -508,17 +505,17 @@ export class SwapPage extends WebViewAppPage {
   }
 
   @step("Go and wait for Swap app to be ready")
-  async goAndWaitForSwapToBeReady(swapFunction: () => Promise<void>) {
+  async goAndWaitForSwapToBeReady(
+    swapFunction: () => Promise<void>,
+    surface: SwapSurface = "full",
+  ) {
     // reset cached webview page to ensure we fetch the correct one after navigation
     this._webviewPage = undefined;
 
-    // perform passed in action and wait for the swap page and webview. Swap renders either as the
-    // full swap page (legacy / left-menu entry) or the embedded rail on AssetDetail; accept both.
     await swapFunction();
-    await this.swapPageHeading
-      .or(this.embeddedSwapContainer)
-      .first()
-      .waitFor({ state: "visible", timeout: 60_000 });
+    const swapContainer =
+      surface === "embedded" ? this.embeddedSwapContainer : this.fullSwapContainer;
+    await swapContainer.waitFor();
     await this.getWebView();
   }
 

--- a/e2e/desktop/tests/specs/entrypoint.swap.spec.ts
+++ b/e2e/desktop/tests/specs/entrypoint.swap.spec.ts
@@ -17,6 +17,7 @@ import { overrideNetworkPayload } from "tests/utils/networkUtils";
 import { getModularSelector } from "tests/utils/modularSelectorUtils";
 import { liveDataWithAddressCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
 import { Addresses } from "@ledgerhq/live-e2e-shared/enum/Addresses";
+import { isAggregatedAssetsEnabled } from "tests/utils/featureFlagUtils";
 
 const app: AppInfos = AppInfos.EXCHANGE;
 
@@ -73,7 +74,10 @@ test.describe("Swap flow from different entry point", () => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.mainNavigation.openTargetFromMainNavigation("home");
       await app.portfolio.clickAsset(swapEntryPoint.swap.accountToDebit.currency);
-      await app.swap.goAndWaitForSwapToBeReady(() => app.assetPage.startSwapFlow());
+      // aggregatedAssets ON opens swap as the AssetDetail embedded rail; otherwise the legacy
+      // asset page's Swap CTA navigates to the full /swap page.
+      const swapSurface = (await isAggregatedAssetsEnabled(app.getPage())) ? "embedded" : "full";
+      await app.swap.goAndWaitForSwapToBeReady(() => app.assetPage.startSwapFlow(), swapSurface);
       await app.swap.checkAssetToContains(swapEntryPoint.swap.accountToDebit.currency.ticker);
     },
   );
@@ -135,10 +139,14 @@ test.describe("Swap flow from different entry point", () => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.marketBanner.clickExploreMarketHeader();
       await app.market.clickCoinRow(swapEntryPoint.swap.accountToDebit.currency.ticker);
-      await app.marketCoin.expectMarketCoinPageToBeVisible(
-        swapEntryPoint.swap.accountToDebit.currency.id,
-      );
-      await app.swap.goAndWaitForSwapToBeReady(() => app.marketCoin.clickSwapButton());
+      if (await isAggregatedAssetsEnabled(app.getPage())) {
+        await app.assetDetail.expectMarketInfoVisible();
+      } else {
+        await app.marketCoin.expectMarketCoinPageToBeVisible(
+          swapEntryPoint.swap.accountToDebit.currency.id,
+        );
+        await app.swap.goAndWaitForSwapToBeReady(() => app.marketCoin.clickSwapButton());
+      }
       await app.swap.checkAssetToContains(swapEntryPoint.swap.accountToDebit.currency.ticker);
     },
   );


### PR DESCRIPTION


<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The "Entry Point - Asset Allocation" swap test flaked because on the legacy
asset page startSwapFlow matched the previous page's embedded swap rail while
it lingered in the DOM during the route transition, so the availability-gated
"Swap" CTA (asset-page-swap-button) was never clicked and the swap page never
opened.

- startSwapFlow now branches on aggregatedAssets: wait for the embedded rail on
  AssetDetail, otherwise wait for and click the Swap CTA.
- goAndWaitForSwapToBeReady now waits for the swap web-app container of the
  surface the caller opens (full page vs Wallet 4.0 embedded rail), passed in as
  an argument, instead of racing the settling route. Adds
  `swap-web-app-container-{full,embedded}` testids on SwapWebView

### 🔗 Context

- **JIRA / GitHub issue**:  [QAA-1385](https://ledgerhq.atlassian.net/browse/QAA-1385)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->

[CI](https://github.com/LedgerHQ/ledger-live/actions/runs/28952552788) default FF
[CI](https://github.com/LedgerHQ/ledger-live/actions/runs/28953622608) Q2 FF


[QAA-1385]: https://ledgerhq.atlassian.net/browse/QAA-1385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ