### PR TITLE
[LWDM] fix(charts): guard mobile charts against non-finite values

### DIFF
--- a/.changeset/mobile-charts-nonfinite-guard.md
+++ b/.changeset/mobile-charts-nonfinite-guard.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": patch
+"live-mobile": patch
+---
+
+Guard mobile charts (line, ring, balance graph, distribution) and market chart series against non-finite values so invalid data points no longer produce broken SVG paths.

--- a/apps/ledger-live-mobile/src/components/Graph/__tests__/Graph.test.tsx
+++ b/apps/ledger-live-mobile/src/components/Graph/__tests__/Graph.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Path } from "react-native-svg";
+import { render } from "@tests/test-renderer";
+import Graph from "..";
+
+const defaultProps = {
+  width: 100,
+  height: 50,
+  color: "#000",
+  isInteractive: false,
+  mapValue: (item: { value: number }) => item.value,
+};
+
+describe("Graph", () => {
+  it("does not render paths when fewer than two safe points are available", () => {
+    const { UNSAFE_queryAllByType } = render(
+      <Graph
+        {...defaultProps}
+        data={[
+          { date: new Date("2024-01-01T00:00:00.000Z"), value: 1 },
+          { date: undefined, value: 2 },
+          { date: new Date("2024-01-03T00:00:00.000Z"), value: Number.NaN },
+        ]}
+      />,
+    );
+
+    expect(UNSAFE_queryAllByType(Path)).toHaveLength(0);
+  });
+
+  it("renders area and line paths for safe data", () => {
+    const { UNSAFE_queryAllByType } = render(
+      <Graph
+        {...defaultProps}
+        data={[
+          { date: new Date("2024-01-01T00:00:00.000Z"), value: 1 },
+          { date: new Date("2024-01-02T00:00:00.000Z"), value: 2 },
+        ]}
+      />,
+    );
+
+    expect(UNSAFE_queryAllByType(Path)).toHaveLength(2);
+  });
+});

--- a/apps/ledger-live-mobile/src/components/Graph/index.tsx
+++ b/apps/ledger-live-mobile/src/components/Graph/index.tsx
@@ -11,7 +11,7 @@ import DefGraph from "./DefGrad";
 import BarInteraction from "./BarInteraction";
 import type { Item, ItemArray } from "./types";
 
-type Props = {
+type Props = Readonly<{
   width: number;
   height: number;
   /** Represents the offset to apply to the chart positioning on x-axis. Default to 0.  */
@@ -27,7 +27,7 @@ type Props = {
   verticalRangeRatio?: number;
   fill?: string;
   testID?: string;
-};
+}>;
 const STROKE_WIDTH = 2;
 const FOCUS_RADIUS = 4;
 
@@ -48,15 +48,37 @@ function Graph({
 }: Props) {
   const { colors } = useTheme();
   const color = initialColor || colors.primary.c80;
-  const maxY = mapValue(maxBy(data, mapValue)!);
-  const minY = mapValue(minBy(data, mapValue)!);
+  const safeData = data.filter(item => {
+    const timestamp = item.date?.getTime();
+    return Number.isFinite(timestamp) && Number.isFinite(mapValue(item));
+  });
+  const contentBounds = {
+    height,
+    width,
+    viewBox: `${xOffset * -1} ${yOffset * -1} ${width} ${height}`,
+  };
+
+  if (width <= 0 || height <= 0 || safeData.length < 2) {
+    return (
+      <Svg
+        testID={testID}
+        height={contentBounds.height}
+        width={contentBounds.width}
+        viewBox={contentBounds.viewBox}
+        preserveAspectRatio="none"
+      />
+    );
+  }
+
+  const maxY = mapValue(maxBy(safeData, mapValue)!);
+  const minY = mapValue(minBy(safeData, mapValue)!);
   const isSameValue = maxY === minY;
   const paddedMinY = minY - (maxY - minY) / verticalRangeRatio;
   const curve = d3shape[shape] as d3shape.CurveFactory;
   const x = d3scale
     .scaleTime()
     .range([0, width])
-    .domain([data[0].date!, data[data.length - 1].date!]);
+    .domain([safeData[0].date!, safeData.at(-1)!.date!]);
   const y = d3scale
     .scaleLinear()
     .domain([paddedMinY, maxY])
@@ -76,19 +98,19 @@ function Graph({
     .x(d => x(d.date!))
     .y0(() => height)
     .y1(d => yExtractor(d))
-    .curve(curve)(data);
+    .curve(curve)(safeData);
 
   const line = d3shape
     .line<Item>()
     .x(d => x(d.date!))
     .y(yExtractor)
-    .curve(curve)(data);
+    .curve(curve)(safeData);
   const content = (
     <Svg
       testID={testID}
-      height={height}
-      width={width}
-      viewBox={`${xOffset * -1} ${yOffset * -1} ${width} ${height}`}
+      height={contentBounds.height}
+      width={contentBounds.width}
+      viewBox={contentBounds.viewBox}
       preserveAspectRatio="none"
     >
       <Defs>
@@ -103,7 +125,7 @@ function Graph({
     <BarInteraction
       width={width}
       height={height}
-      data={data}
+      data={safeData}
       color={color}
       mapValue={mapValue}
       onItemHover={onItemHover}

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/useLineChartViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/__tests__/useLineChartViewModel.test.ts
@@ -65,6 +65,25 @@ describe("useLineChartViewModel", () => {
     expect(new Set([mutedStroke, successStroke, errorStroke]).size).toBe(3);
   });
 
+  it("sanitizes non-finite values before handing series to the native chart", () => {
+    const { result } = renderHook(() =>
+      useLineChartViewModel(
+        buildProps({
+          series: [
+            {
+              id: "price",
+              data: [1, Number.NaN, Number.POSITIVE_INFINITY, null, 2],
+              label: "Price",
+              stroke: "",
+            },
+          ],
+        }),
+      ),
+    );
+
+    expect(result.current.chartSeries[0]?.data).toEqual([1, null, null, null, 2]);
+  });
+
   it("forwards onRangeChange via handleSelectedChange", () => {
     const onRangeChange = jest.fn();
     const { result } = renderHook(() => useLineChartViewModel(buildProps({ onRangeChange })));

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/useLineChartViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/useLineChartViewModel.ts
@@ -19,6 +19,10 @@ import { getExtremaPointMarkers } from "./utils/getExtremaPointMarkers";
 
 const defaultFormatValue: LineChartValueFormatter = value => String(value);
 
+function sanitizeSeriesData(data: LineChartSeries["data"]): LineChartSeries["data"] {
+  return data?.map(value => (Number.isFinite(value) ? value : null));
+}
+
 export type LineChartViewModelResult<TRange extends string = string> = Readonly<{
   chartSeries: LineChartSeries[];
   selectedRange: TRange;
@@ -81,7 +85,10 @@ export function useLineChartViewModel<TRange extends string>({
     [color, theme.colors.bg],
   );
 
-  const chartSeries = useMemo(() => series.map(entry => ({ ...entry, stroke })), [series, stroke]);
+  const chartSeries = useMemo(
+    () => series.map(entry => ({ ...entry, data: sanitizeSeriesData(entry.data), stroke })),
+    [series, stroke],
+  );
 
   const resolvedPoints = useMemo(
     () => points ?? getExtremaPointMarkers(chartSeries),

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/__integrations__/ringChartAndDistributionCard.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/__integrations__/ringChartAndDistributionCard.integration.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "@tests/test-renderer";
+import { Path } from "react-native-svg";
 import { track } from "~/analytics";
 import { NavigatorName, ScreenName } from "~/const";
 import { State } from "~/reducers/types";
@@ -76,6 +77,31 @@ describe("RingChart integration", () => {
 
     expect(screen.getByTestId("analytics-ring-chart")).toBeVisible();
   });
+
+  it("should skip chart paths when an allocation distribution is not finite", () => {
+    const { UNSAFE_queryAllByType } = render(
+      <RingChart
+        size={76}
+        strokeWidth={3}
+        data={[
+          {
+            currency: mockBitcoinCurrency,
+            distribution: Number.NaN,
+            amount: 1,
+          },
+          {
+            currency: mockEthereumCurrency,
+            distribution: 0.4,
+            amount: 4,
+          },
+        ]}
+      />,
+    );
+
+    const paths = UNSAFE_queryAllByType(Path);
+    expect(paths.length).toBeGreaterThan(0);
+    expect(paths.every(path => !String(path.props.d).includes("NaN"))).toBe(true);
+  });
 });
 
 describe("DistributionCard integration", () => {
@@ -96,6 +122,14 @@ describe("DistributionCard integration", () => {
 
     expect(screen.getByText(mockBitcoinCurrency.name)).toBeVisible();
     expect(screen.getByText("37.5%")).toBeVisible();
+  });
+
+  it("should display zero percent when the distribution item is not finite", () => {
+    render(<DistributionCard item={{ ...item, distribution: Number.NaN }} />, {
+      overrideInitialState: mockStateWithCountervalues,
+    });
+
+    expect(screen.getByText("0%")).toBeVisible();
   });
 
   it("should track and navigate to the asset screen when the card is pressed", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/RingChart/useRingChartViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/RingChart/useRingChartViewModel.ts
@@ -22,6 +22,10 @@ export function useRingChartViewModel(data: Array<ColorableDistributionItem>, st
 
     return data.reduce<Paths>(
       (acc, item) => {
+        if (!Number.isFinite(item.distribution)) {
+          return acc;
+        }
+
         const increment = item.distribution * 2 * Math.PI;
 
         const pathData =

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/DetailedAllocation/components/DistributionCard.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/DetailedAllocation/components/DistributionCard.tsx
@@ -63,7 +63,10 @@ function DistributionCard({ item: { currency, amount, distribution } }: Props) {
     () => ensureContrast(getCurrencyColor(currency), colors.background.main),
     [colors, currency],
   );
-  const percentage = useMemo(() => Math.round(distribution * 1e4) / 1e2, [distribution]);
+  const percentage = useMemo(
+    () => (Number.isFinite(distribution) ? Math.round(distribution * 1e4) / 1e2 : 0),
+    [distribution],
+  );
 
   const navigateToAccounts = useCallback(() => {
     track("button_clicked", {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
@@ -489,6 +489,13 @@ describe("useBalanceGraphViewModel", () => {
       expect(result.current.formatValue(100)).toContain("100");
     });
 
+    it("does not format non-finite chart values", () => {
+      const { result } = renderVM();
+
+      expect(result.current.formatValue(Number.NaN)).toBe("");
+      expect(result.current.formatValue(Number.POSITIVE_INFINITY)).toBe("");
+    });
+
     it("builds a tooltip title from the timestamp at the given index", () => {
       const { result } = renderVM();
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
@@ -316,11 +316,17 @@ export function useBalanceGraphViewModel({
   const chartColor = resolveLineChartColorFromPercentChange(priceChangePercentage);
 
   const formatValue = useCallback<LineChartValueFormatter>(
-    value =>
-      formatPrice(counterValueUnit, new BigNumber(value).times(10 ** counterValueUnit.magnitude), {
-        showCode: true,
-        locale,
-      }),
+    value => {
+      if (!Number.isFinite(value)) return "";
+      return formatPrice(
+        counterValueUnit,
+        new BigNumber(value).times(10 ** counterValueUnit.magnitude),
+        {
+          showCode: true,
+          locale,
+        },
+      );
+    },
     [counterValueUnit, locale],
   );
 

--- a/apps/ledger-live-mobile/src/screens/Analytics/DistributionCard.tsx
+++ b/apps/ledger-live-mobile/src/screens/Analytics/DistributionCard.tsx
@@ -67,7 +67,7 @@ function DistributionCard({ item: { currency, amount, distribution } }: Props) {
     () => ensureContrast(getCurrencyColor(currency), colors.background.main),
     [colors, currency],
   );
-  const percentage = Math.round(distribution * 1e4) / 1e2;
+  const percentage = Number.isFinite(distribution) ? Math.round(distribution * 1e4) / 1e2 : 0;
 
   const navigateToAccounts = useCallback(() => {
     openFromAsset({ currency, source: "analytics_distribution" });

--- a/apps/ledger-live-mobile/src/screens/Analytics/RingChart.tsx
+++ b/apps/ledger-live-mobile/src/screens/Analytics/RingChart.tsx
@@ -53,6 +53,10 @@ class RingChart extends PureComponent<Props> {
   }
 
   reducer = (data: Paths, item: ColorableDistributionItem, index: number): Paths => {
+    if (!Number.isFinite(item.distribution)) {
+      return data;
+    }
+
     const increment = item.distribution * 2 * Math.PI;
 
     const pathData =

--- a/apps/ledger-live-mobile/src/screens/Analytics/__tests__/analyticsCharts.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Analytics/__tests__/analyticsCharts.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { Path } from "react-native-svg";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { render, screen } from "@tests/test-renderer";
+import { State } from "~/reducers/types";
+import RingChart from "../RingChart";
+import DistributionCard from "../DistributionCard";
+
+jest.mock("LLM/features/AssetDetail/hooks/useAssetDetailNavigation", () => ({
+  useAssetDetailNavigation: () => ({ openFromAsset: jest.fn() }),
+}));
+
+const bitcoin = getCryptoCurrencyById("bitcoin");
+const ethereum = getCryptoCurrencyById("ethereum");
+
+const withCounterValue = (state: State): State => ({
+  ...state,
+  settings: { ...state.settings, counterValue: "USD" },
+});
+
+describe("Analytics RingChart (legacy)", () => {
+  it("skips ring paths for a non-finite distribution but still renders the finite one", () => {
+    const { UNSAFE_queryAllByType } = render(
+      <RingChart
+        size={76}
+        strokeWidth={3}
+        data={[
+          { currency: bitcoin, distribution: Number.NaN, amount: 1 },
+          { currency: ethereum, distribution: 0.4, amount: 4 },
+        ]}
+      />,
+    );
+
+    const paths = UNSAFE_queryAllByType(Path);
+    expect(paths.length).toBeGreaterThan(0);
+    expect(paths.every(path => !String(path.props.d).includes("NaN"))).toBe(true);
+  });
+});
+
+describe("Analytics DistributionCard (legacy)", () => {
+  it("renders 0% when the distribution is not finite", () => {
+    render(<DistributionCard item={{ currency: bitcoin, distribution: Number.NaN, amount: 1 }} />, {
+      overrideInitialState: withCounterValue,
+    });
+
+    expect(screen.getByText("0%")).toBeVisible();
+  });
+});

--- a/libs/ledger-live-common/src/market/utils/__tests__/buildMarketChartSeries.test.ts
+++ b/libs/ledger-live-common/src/market/utils/__tests__/buildMarketChartSeries.test.ts
@@ -46,4 +46,43 @@ describe("buildMarketChartSeries", () => {
     expect(prices).toContain(500);
     expect(prices).toContain(50);
   });
+
+  it("drops non-finite chart points before building the series", () => {
+    const chartData: MarketCoinDataChart = {
+      "1d": [
+        [1_000, 100],
+        [2_000, Number.NaN],
+        [Number.NaN, 110],
+        [3_000, Number.POSITIVE_INFINITY],
+        [4_000, 130],
+      ],
+    };
+
+    const { prices, timestamps } = buildMarketChartSeries({
+      chartData,
+      range: "1d",
+      targetIntervalMs: 5 * 60_000,
+    });
+
+    expect(prices).toEqual([100, 130]);
+    expect(timestamps).toEqual([1_000, 4_000]);
+  });
+
+  it("returns an empty series when every chart point is non-finite", () => {
+    const chartData: MarketCoinDataChart = {
+      "1d": [
+        [1_000, Number.NaN],
+        [2_000, Number.POSITIVE_INFINITY],
+      ],
+    };
+
+    const { prices, timestamps } = buildMarketChartSeries({
+      chartData,
+      range: "1d",
+      targetIntervalMs: 5 * 60_000,
+    });
+
+    expect(prices).toEqual([]);
+    expect(timestamps).toEqual([]);
+  });
 });

--- a/libs/ledger-live-common/src/market/utils/buildMarketChartSeries.ts
+++ b/libs/ledger-live-common/src/market/utils/buildMarketChartSeries.ts
@@ -12,6 +12,10 @@ type BuildMarketChartSeriesParams = Readonly<{
   atlTime?: number;
 }>;
 
+function isFiniteChartPoint([timestamp, value]: readonly [number, number]): boolean {
+  return Number.isFinite(timestamp) && Number.isFinite(value);
+}
+
 export function buildMarketChartSeries({
   chartData,
   range,
@@ -21,7 +25,7 @@ export function buildMarketChartSeries({
   athTime,
   atlTime,
 }: BuildMarketChartSeriesParams): { prices: number[]; timestamps: number[] } {
-  const rawPoints = chartData?.[range] ?? [];
+  const rawPoints = (chartData?.[range] ?? []).filter(isFiniteChartPoint);
   const withExtrema =
     range === "all"
       ? injectMarketExtrema(rawPoints, { ath, athDate: athTime, atl, atlDate: atlTime })


### PR DESCRIPTION
## Summary

Split out from #19275 (token asset-detail deeplinks) at the reviewer's request — this PR contains **only** the chart-hardening changes, which are unrelated to deeplink URL sanitization.

Guards the mobile charts and the market chart-series builder against non-finite (`NaN` / `Infinity`) values so invalid data points no longer produce broken SVG paths:

- `components/Graph` — filter non-finite points, render an empty SVG for degenerate/empty input
- `LineChart/useLineChartViewModel` — sanitize series data (`NaN`/`Infinity` → `null`)
- `Analytics/RingChart/useRingChartViewModel` — skip non-finite distribution slices
- `AssetDetail/BalanceGraph/useBalanceGraphViewModel` — guard the value formatter
- `market/utils/buildMarketChartSeries` — drop non-finite `[timestamp, value]` points
- Distribution cards / analytics screens + tests

## Test plan

- [ ] `pnpm jest` for the touched mobile chart components and `buildMarketChartSeries`
- [ ] Verify charts render safely with empty / single-point / NaN-containing datasets

Made with [Cursor](https://cursor.com)