### PR TITLE
[LWD] feat(desktop): add dust filter tracking and copy

### DIFF
--- a/.changeset/dust-filter-tracking-copy.md
+++ b/.changeset/dust-filter-tracking-copy.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add dust filter tracking and active-state copy.

--- a/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { useExportOperationsCsv } from "~/renderer/hooks/useExportOperationsCsv";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { track } from "~/renderer/analytics/segment";
 import { BTC_ACCOUNT, EMPTY_BTC_ACCOUNT } from "../../__mocks__/accounts.mock";
 import { bitcoinCurrency, ethereumCurrency } from "../../__mocks__/useSelectAssetFlow.mock";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
@@ -204,6 +205,25 @@ describe("History integration", () => {
     await user.click(await screen.findByTestId("history-toggle-dust-filter-button"));
 
     expect(store.getState().settings.hideSmallValueTokenOperations).toBe(true);
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "dust_filter",
+      enabled: true,
+    });
+  });
+
+  it("describes dust transactions as displayed when dust filtering is active", async () => {
+    const { user } = renderHistory([BTC_ACCOUNT], {
+      ...withFlagOverrides({ lwdDustFiltering: { enabled: true } }),
+      settings: {
+        ...AFTER_ONBOARDING_STATE,
+        hideSmallValueTokenOperations: true,
+      },
+    });
+
+    await user.click(await screen.findByTestId("history-actions-menu-button"));
+
+    expect(await screen.findByText("Show dust transactions")).toBeVisible();
+    expect(screen.getByText("Transactions below US$0.01 will be displayed.")).toBeVisible();
   });
 
   it("does not render the dust filtering action when the feature flag is disabled", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryPageHeader/Dust.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryPageHeader/Dust.tsx
@@ -18,6 +18,13 @@ export function Dust({
   const dustFilterLabel = hideSmallValueTokenOperations
     ? t("history.actionsBar.showDustTransactions")
     : t("history.actionsBar.hideDustTransactions");
+  const dustFilterDescription = hideSmallValueTokenOperations
+    ? t("history.actionsBar.dustTransactionsDisplayedDescription", {
+        threshold: dustFilterThreshold,
+      })
+    : t("history.actionsBar.dustTransactionsDescription", {
+        threshold: dustFilterThreshold,
+      });
   const DustFilterIcon = hideSmallValueTokenOperations ? Eye : EyeCross;
 
   return (
@@ -29,11 +36,7 @@ export function Dust({
       <DustFilterIcon size={20} className="shrink-0" />
       <span className="flex flex-col">
         <span>{dustFilterLabel}</span>
-        <span className="body-3 text-muted">
-          {t("history.actionsBar.dustTransactionsDescription", {
-            threshold: dustFilterThreshold,
-          })}
-        </span>
+        <span className="body-3 text-muted">{dustFilterDescription}</span>
       </span>
     </MenuItem>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryViewModel.test.ts
@@ -8,6 +8,7 @@ import type {
 } from "@ledgerhq/live-countervalues/types";
 import { getFiatCurrencyByTicker } from "@ledgerhq/live-common/currencies/index";
 import type { CountervaluesState } from "~/renderer/reducers/countervalues";
+import { track } from "~/renderer/analytics/segment";
 
 jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
@@ -164,5 +165,34 @@ describe("useHistoryViewModel navigateBack", () => {
     });
 
     expect(store.getState().countervaluesExtraTracking.extraTrackingPairs).toEqual([]);
+  });
+
+  it("should track the target dust filter state when toggling dust filtering", () => {
+    const { result, store } = renderHook(() => useHistoryViewModel(), {
+      initialState: {
+        settings: { hideSmallValueTokenOperations: false },
+        ...withFlagOverrides({ lwdDustFiltering: { enabled: true } }),
+      },
+    });
+
+    act(() => {
+      result.current.onToggleHideSmallValueTokenOperations();
+    });
+
+    expect(store.getState().settings.hideSmallValueTokenOperations).toBe(true);
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "dust_filter",
+      enabled: true,
+    });
+
+    act(() => {
+      result.current.onToggleHideSmallValueTokenOperations();
+    });
+
+    expect(store.getState().settings.hideSmallValueTokenOperations).toBe(false);
+    expect(track).toHaveBeenLastCalledWith("button_clicked", {
+      button: "dust_filter",
+      enabled: false,
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryViewModel.ts
@@ -174,7 +174,12 @@ export function useHistoryViewModel(): HistoryViewModel {
   }, [countervaluesState, counterValueCurrency, locale]);
   const onToggleHideSmallValueTokenOperations = useCallback(() => {
     if (!showDustFilterOption) return;
-    setHideSmallValueTokenOperations(!hideSmallValueTokenOperations);
+    const enabled = !hideSmallValueTokenOperations;
+    track("button_clicked", {
+      button: "dust_filter",
+      enabled,
+    });
+    setHideSmallValueTokenOperations(enabled);
   }, [hideSmallValueTokenOperations, setHideSmallValueTokenOperations, showDustFilterOption]);
 
   return {

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9209,7 +9209,8 @@
       "more": "Transaction history options",
       "hideDustTransactions": "Hide dust transactions",
       "showDustTransactions": "Show dust transactions",
-      "dustTransactionsDescription": "Transactions below {{threshold}} will be hidden."
+      "dustTransactionsDescription": "Transactions below {{threshold}} will be hidden.",
+      "dustTransactionsDisplayedDescription": "Transactions below {{threshold}} will be displayed."
     },
     "exportDialog": {
       "title": "Export transaction history",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Transaction history dust filter actions menu copy
      - Dust filter toggle analytics payload
      - Dust filter feature flag enabled and disabled behavior

### 📝 Description

The transaction history dust filter needed two follow-up updates for LIVE-29298: the menu subtitle had to describe the current action correctly, and clicks on the dust filter action had to be tracked.

This PR updates the Desktop History actions menu so “Show dust transactions” uses a “will be displayed” subtitle, keeps the existing “will be hidden” copy for the hide action, and tracks `button_clicked` with `button: "dust_filter"` plus the target `enabled` state. It also adds focused hook and integration coverage for the new analytics and copy behavior.

<img width="455" height="166" alt="image" src="https://github.com/user-attachments/assets/b99cee51-3d6d-4321-ad0e-deb76a1b779d" />
<img width="460" height="176" alt="image" src="https://github.com/user-attachments/assets/b210671b-7a15-4f33-87e9-607c9fd89ddc" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-29298](https://ledgerhq.atlassian.net/browse/LIVE-29298)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29298]: https://ledgerhq.atlassian.net/browse/LIVE-29298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ