### PR TITLE
[CI][QAA] Fix e2e fail filter

### DIFF
--- a/e2e/mobile/jest.config.js
+++ b/e2e/mobile/jest.config.js
@@ -1,3 +1,4 @@
+const path = require("node:path");
 const { parseExtraFeatureFlags } = require("@ledgerhq/live-e2e-shared/featureFlagsJsonUtils");
 const { compilerOptions } = require("./tsconfig.json");
 
@@ -32,6 +33,12 @@ const jestAllure2ReporterOptions = {
     },
     labels: {
       host: process.env.RUNNER_NAME,
+      // Bare spec-file basename (never a directory) so the rerun filter stays portable:
+      // `filePath` may be an array of path segments or an absolute/relative path string.
+      sourceFile: ({ filePath }) => {
+        const fp = Array.isArray(filePath) ? filePath[filePath.length - 1] : filePath;
+        return path.basename(String(fp ?? ""));
+      },
     },
     status: ({ value }) => (value === "broken" ? "failed" : value),
     historyId: ({ value }) => `${value}:${platform}`,

--- a/tools/actions/composites/get-failed-tests-summary/action.yml
+++ b/tools/actions/composites/get-failed-tests-summary/action.yml
@@ -2,7 +2,7 @@ name: "Failed Tests Summary"
 description: "Writes a GitHub job summary with a ready-to-copy Filter pattern that reruns only the failed/broken E2E tests. Shared by mobile and desktop e2e workflows."
 inputs:
   results-path:
-    description: "Directory containing the test results (Allure *-result.json for Playwright, Jest --json e2e-test-results-*.json for Detox)"
+    description: "Directory containing the Allure *-result.json files (both Playwright and Detox emit these; each file is one test attempt, retries share a historyId)"
     required: true
   runner:
     description: >-
@@ -35,9 +35,13 @@ runs:
         case "$RUNNER" in
           detox)
             # Detox selects whole spec files via a regex tested against file path/content,
-            # so the reusable unit is the failed spec file (basename). Source: Jest --json.
+            # so the reusable unit is the failed spec file (basename). Source: Allure
+            # *-result.json so a pass on a Detox retry clears the earlier failure — the raw
+            # Jest --json only records the failing attempt and would over-include specs.
+            # The spec file comes from the `sourceFile` label set by e2e/mobile/jest.config.js
+            # (mobile Allure results carry only test titles, never the file path otherwise).
             shopt -s nullglob
-            files=("$RESULTS_DIR"/e2e-test-results-*.json)
+            files=("$RESULTS_DIR"/*-result.json)
             shopt -u nullglob
             ;;
           playwright)
@@ -63,15 +67,24 @@ runs:
         fi
 
         if [ "$RUNNER" = "detox" ]; then
-          # Failed spec files (basename), deduplicated.
-          FAILED_LIST=$(jq -rs '
-            [ .[].testResults[]? | select(.status == "failed") | .name | sub(".*/"; "") ]
-            | unique | .[]
-          ' "${files[@]}")
-          FILTER_PATTERN=$(jq -rs "$JQ_ESC"'
-            [ .[].testResults[]? | select(.status == "failed") | .name | sub(".*/"; "") | esc ]
-            | unique | join("|")
-          ' "${files[@]}")
+          # Spec files (basename) that still have a genuinely-failing test after retries.
+          # Each Allure result is one attempt; retries of a test share a historyId. A test
+          # "finally failed" when it has a failed/broken attempt and never passed. A spec
+          # file is included when it holds at least one such test. The spec basename is read
+          # from the `sourceFile` label (set by e2e/mobile/jest.config.js).
+          DETOX_JQ='
+            def specFile:
+              [ (.labels // [])[] | select(.name == "sourceFile") | .value ][0] // "";
+            [ .[] | { id: (.historyId // .fullName), spec: specFile, status: .status } ]
+            | group_by(.id)
+            | map(select(
+                (any(.[]; .status == "failed" or .status == "broken"))
+                and (all(.[]; .status != "passed"))
+              ) | .[0].spec)
+            | map(select(. != "")) | unique
+          '
+          FAILED_LIST=$(jq -rs "$DETOX_JQ"' | .[]' "${files[@]}")
+          FILTER_PATTERN=$(jq -rs "$JQ_ESC$DETOX_JQ"' | map(esc) | join("|")' "${files[@]}")
         else
           # Failed/broken test titles that never passed (a pass on retry clears the failure).
           FAILED_LIST=$(jq -rs '

--- a/tools/actions/composites/get-failed-tests-summary/action.yml
+++ b/tools/actions/composites/get-failed-tests-summary/action.yml
@@ -66,16 +66,20 @@ runs:
           exit 0
         fi
 
+        # ITEMS_JQ produces the exact list of rerun units this runner selects by, as a JSON
+        # array. FILTER_PATTERN and failed_count are both derived from it, so the count can
+        # never diverge from what users actually rerun.
         if [ "$RUNNER" = "detox" ]; then
           # Spec files (basename) that still have a genuinely-failing test after retries.
           # Each Allure result is one attempt; retries of a test share a historyId. A test
           # "finally failed" when it has a failed/broken attempt and never passed. A spec
           # file is included when it holds at least one such test. The spec basename is read
           # from the `sourceFile` label (set by e2e/mobile/jest.config.js).
-          DETOX_JQ='
+          ITEMS_JQ='
             def specFile:
-              [ (.labels // [])[] | select(.name == "sourceFile") | .value ][0] // "";
-            [ .[] | { id: (.historyId // .fullName), spec: specFile, status: .status } ]
+              ([ (.labels // [])[] | select(.name == "sourceFile") | .value ][0] // "")
+              | sub(".*/"; "");
+            [ .[] | { id: (.historyId // .fullName // .name), spec: specFile, status: .status } ]
             | group_by(.id)
             | map(select(
                 (any(.[]; .status == "failed" or .status == "broken"))
@@ -83,42 +87,51 @@ runs:
               ) | .[0].spec)
             | map(select(. != "")) | unique
           '
-          FAILED_LIST=$(jq -rs "$DETOX_JQ"' | .[]' "${files[@]}")
-          FILTER_PATTERN=$(jq -rs "$JQ_ESC$DETOX_JQ"' | map(esc) | join("|")' "${files[@]}")
         else
           # Failed/broken test titles that never passed (a pass on retry clears the failure).
-          FAILED_LIST=$(jq -rs '
+          ITEMS_JQ='
             [ .[] | { name: .name, status: .status } ] as $all
             | ( $all | map(select(.status == "passed") | .name) | unique ) as $passed
             | $all | map(select(.status == "failed" or .status == "broken") | .name)
-              | unique | map(select(. as $n | ($passed | index($n)) | not)) | .[]
-          ' "${files[@]}")
-          FILTER_PATTERN=$(jq -rs "$JQ_ESC"'
-            [ .[] | { name: .name, status: .status } ] as $all
-            | ( $all | map(select(.status == "passed") | .name) | unique ) as $passed
-            | $all | map(select(.status == "failed" or .status == "broken") | .name)
-              | unique | map(select(. as $n | ($passed | index($n)) | not)) | map(esc) | join("|")
-          ' "${files[@]}")
+              | unique | map(select(. as $n | ($passed | index($n)) | not))
+          '
         fi
 
-        FAILED_COUNT=0
-        [ -n "$FAILED_LIST" ] && FAILED_COUNT=$(printf '%s\n' "$FAILED_LIST" | grep -c '' || true)
+        FILTER_PATTERN=$(jq -rs "$JQ_ESC$ITEMS_JQ"' | map(esc) | join("|")' "${files[@]}")
+        FAILED_COUNT=$(jq -rs "$ITEMS_JQ"' | length' "${files[@]}")
+
+        # Robust "did anything fail" gate: counts finally-failing tests (not rerun items),
+        # keyed by historyId/fullName/name so a missing field can't zero it out. This keeps
+        # the summary rendering even when e.g. a detox result lacks its sourceFile label and
+        # FAILED_COUNT (spec files) comes out empty.
+        FF_COUNT=$(jq -rs '
+          group_by(.historyId // .fullName // .name)
+          | map(select(
+              (any(.[]; .status == "failed" or .status == "broken"))
+              and (all(.[]; .status != "passed"))
+            ))
+          | length
+        ' "${files[@]}")
 
         echo "failed_count=$FAILED_COUNT" >> "$GITHUB_OUTPUT"
+        echo "filter_pattern=$FILTER_PATTERN" >> "$GITHUB_OUTPUT"
 
-        if [ "$FAILED_COUNT" -eq 0 ]; then
-          echo "filter_pattern=" >> "$GITHUB_OUTPUT"
+        if [ "${FF_COUNT:-0}" -eq 0 ]; then
           exit 0
         fi
 
-        echo "filter_pattern=$FILTER_PATTERN" >> "$GITHUB_OUTPUT"
 
         {
-          echo "<details><summary>Copy this into the **Filter pattern** input to rerun:</summary>"
           echo ""
-          echo '```'
-          echo "$FILTER_PATTERN"
-          echo '```'
-          echo ""
-          echo "</details>"
+          if [ -n "$FILTER_PATTERN" ]; then
+            echo "<details><summary>Copy this into the **Filter pattern** input to rerun:</summary>"
+            echo ""
+            echo '```'
+            echo "$FILTER_PATTERN"
+            echo '```'
+            echo ""
+            echo "</details>"
+          else
+            echo "> ⚠️ Could not build a rerun filter pattern from these results."
+          fi
         } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR updates the “failed tests summary” composite action to derive Detox rerun filters from Allure *-result.json (instead of Jest --json output) so that retries that eventually pass don’t end in failed tests filter.

### 🔗 Context

- E2E [Mobile](https://github.com/LedgerHQ/ledger-live/actions/runs/28854164656)
- E2E [Desktop](https://github.com/LedgerHQ/ledger-live/actions/runs/28854148204)