### PR TITLE
[LWD] fix(coin-evm): resolve delegation validator moniker from reactive hook

### DIFF
--- a/.changeset/evm-staking-delegation-moniker.md
+++ b/.changeset/evm-staking-delegation-moniker.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix EVM native staking delegation row not always showing the validator name on the account page. The moniker is now resolved from the reactive validators hook (the same source as the Delegate modal) instead of `account.stakingResources.validators`, which was only populated by a successful, non-empty account sync and could leave the raw validator address showing until the next sync.

--- a/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback } from "react";
 import { useDispatch } from "LLD/hooks/redux";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
@@ -9,10 +9,10 @@ import {
   mapUnbondings,
   canDelegate,
   getValidatorExplorerUrl,
-  prefetchValidators,
   hasUnbondingPeriod,
   getUnbondingPeriodDays,
 } from "@ledgerhq/live-common/families/evm/staking/logic";
+import { useEvmStakingValidators } from "@ledgerhq/live-common/families/evm/staking/react";
 import { isStakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
 import type { StakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
 import { getDefaultExplorerView, getAddressExplorer } from "@ledgerhq/live-common/explorers";
@@ -40,26 +40,13 @@ const Wrapper = styled(Box).attrs(() => ({
   align-items: center;
 `;
 
-const Delegation = ({ account }: { account: StakingAccount }) => {
+const DelegationBody = ({ account }: { account: StakingAccount }) => {
   const dispatch = useDispatch();
-  const { enabled: isEvmNativeStakingEnabled, params } = useFeature("evmNativeStaking") ?? {};
-  const isCurrencySupported = params?.supportedCurrencyIds?.includes(account.currency.id) || false;
-
-  if (!isCurrencySupported || !isEvmNativeStakingEnabled) return null;
-
   const unit = useAccountUnit(account);
   const currencyId = account.currency.id;
 
-  // Warm the validators cache on the account page so that opening either the
-  // "Earn rewards" info modal or the "Delegate" modal directly never shows an
-  // empty list while the first fetch resolves.
-  useEffect(() => {
-    if (isCurrencySupported && isEvmNativeStakingEnabled) {
-      prefetchValidators(currencyId);
-    }
-  }, [currencyId, isCurrencySupported, isEvmNativeStakingEnabled]);
-
-  const validators = account.stakingResources.validators ?? [];
+  // Use reactive validators (LIVE-33986) so monikers resolve without waiting for account sync.
+  const { validators } = useEvmStakingValidators(currencyId);
 
   const explorerView = getDefaultExplorerView(account.currency);
   const onExternalLink = useCallback(
@@ -270,6 +257,16 @@ const Delegation = ({ account }: { account: StakingAccount }) => {
       ) : null}
     </>
   );
+};
+
+// Feature-gate wrapper to avoid conditional hooks while the feature flag resolves.
+const Delegation = ({ account }: { account: StakingAccount }) => {
+  const { enabled: isEvmNativeStakingEnabled, params } = useFeature("evmNativeStaking") ?? {};
+  const isCurrencySupported = params?.supportedCurrencyIds?.includes(account.currency.id) || false;
+
+  if (!isCurrencySupported || !isEvmNativeStakingEnabled) return null;
+
+  return <DelegationBody account={account} />;
 };
 
 const Delegations = ({ account }: { account: Account | TokenAccount }) => {


### PR DESCRIPTION
The account-page Delegation component read validators from account.stakingResources.validators, which is only populated by a successful, non-empty account sync. On slower environments the moniker could stay unresolved (showing the raw validator address) until the next sync, causing a flaky e2e failure. Source validators from the reactive useEvmStakingValidators hook (same source as the Delegate modal) so the name resolves on mount and re-renders when the list arrives; this also warms the shared cache, making the prefetch effect redundant.

<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-33986](https://ledgerhq.atlassian.net/browse/LIVE-33986)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-33986]: https://ledgerhq.atlassian.net/browse/LIVE-33986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ