### PR TITLE
[LWD] fix: prevent clipping of chart elements in Analytics view

### DIFF
--- a/.changeset/fix-analytics-chart-label-clipping.md
+++ b/.changeset/fix-analytics-chart-label-clipping.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix clipped min/max labels on Analytics portfolio chart by removing overflow-hidden from the chart container

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
@@ -16,7 +16,11 @@ export default function Analytics() {
   return <AnalyticsView viewModel={viewModel} />;
 }
 
-function AnalyticsView({ viewModel }: { readonly viewModel: AnalyticsViewModel }) {
+function AnalyticsView({
+  viewModel,
+}: {
+  readonly viewModel: AnalyticsViewModel;
+}) {
   const {
     counterValue,
     selectedTimeRange,
@@ -32,7 +36,11 @@ function AnalyticsView({ viewModel }: { readonly viewModel: AnalyticsViewModel }
 
   return (
     <div className="flex flex-col gap-32 pb-32">
-      <TrackPage category="Analytics" range={selectedTimeRange} countervalue={counterValue} />
+      <TrackPage
+        category="Analytics"
+        range={selectedTimeRange}
+        countervalue={counterValue}
+      />
       <PageHeader title={t("analytics.title")} onBack={navigateToDashboard} />
 
       <div
@@ -40,7 +48,11 @@ function AnalyticsView({ viewModel }: { readonly viewModel: AnalyticsViewModel }
         data-testid="analytics-chart"
       >
         {shouldDisplayPnl ? (
-          <ChartSection balanceInfo={balanceInfo} portfolio={portfolio} isLoading={isLoading} />
+          <ChartSection
+            balanceInfo={balanceInfo}
+            portfolio={portfolio}
+            isLoading={isLoading}
+          />
         ) : (
           <PortfolioBalanceSummary
             counterValue={counterValue}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This pull request addresses an issue with clipped min/max labels on the Analytics portfolio chart in `ledger-live-desktop`. The main change removes the `overflow-hidden` property from the chart container, ensuring that chart labels are fully visible. Additionally, the code is refactored for improved readability by formatting component props across multiple lines.


<img width="651" height="461" alt="Screenshot 2026-07-06 at 15 31 02" src="https://github.com/user-attachments/assets/2751820d-1e14-43fa-90d7-2e0bcfe47cbc" />


### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
[LIVE-34002](https://ledgerhq.atlassian.net/browse/LIVE-34002)


[LIVE-34002]: https://ledgerhq.atlassian.net/browse/LIVE-34002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ