### PR TITLE
[LWM] feat(LIVE-30503): aleo public send flow

### DIFF
--- a/.changeset/strong-bananas-clap.md
+++ b/.changeset/strong-bananas-clap.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat: aleo public send flow

--- a/apps/ledger-live-mobile/src/families/aleo/PrivateSyncButton.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/PrivateSyncButton.tsx
@@ -1,24 +1,15 @@
 import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
 import { Box, Button, Spinner, Text } from "@ledgerhq/lumen-ui-rnative";
-import React, { useMemo } from "react";
+import React from "react";
 import { useTranslation } from "~/context/Locale";
-import { useSelector } from "~/context/hooks";
-import { localeSelector } from "~/reducers/settings";
 import { useAleoPrivateSync } from "./hooks/useAleoPrivateSync";
+import { useFormatPrivateSyncDate } from "./hooks/useFormatPrivateSyncDate";
 
 type AleoSyncState = "ready" | "running" | "complete";
 
-const lastSyncDateFormat: Intl.DateTimeFormatOptions = {
-  day: "numeric",
-  month: "numeric",
-  year: "numeric",
-  hour: "numeric",
-  minute: "numeric",
-};
-
 export default function PrivateSyncButton({ account }: { readonly account: AleoAccount }) {
   const { t } = useTranslation();
-  const locale = useSelector(localeSelector);
+  const formatPrivateSyncDate = useFormatPrivateSyncDate();
 
   const { isSyncing, progress, start, stop } = useAleoPrivateSync({
     account,
@@ -29,10 +20,7 @@ export default function PrivateSyncButton({ account }: { readonly account: AleoA
   const lastSync = account.aleoResources?.lastPrivateSyncDate ?? null;
   const syncState: AleoSyncState = isSyncing ? "running" : lastSync ? "complete" : "ready";
 
-  const formattedLastSync = useMemo(
-    () => (lastSync ? new Intl.DateTimeFormat(locale, lastSyncDateFormat).format(lastSync) : ""),
-    [lastSync, locale],
-  );
+  const formattedLastSync = lastSync ? formatPrivateSyncDate(lastSync) : "";
 
   return (
     <Box

--- a/apps/ledger-live-mobile/src/families/aleo/Send/BalanceCard.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/BalanceCard.tsx
@@ -1,0 +1,77 @@
+import React, { type ReactNode } from "react";
+import { Pressable, View } from "react-native";
+import { Text } from "@ledgerhq/lumen-ui-rnative";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
+
+type Props = Readonly<{
+  label: string;
+  lastUpdateLabel?: string;
+  balance: ReactNode;
+  selected: boolean;
+  onPress: () => void;
+}>;
+
+export function BalanceCard({ label, lastUpdateLabel, balance, selected, onPress }: Props) {
+  const styles = useStyleSheet(
+    t => ({
+      card: {
+        flexDirection: "row",
+        alignItems: "center",
+        padding: t.spacings.s12,
+        gap: t.spacings.s12,
+        borderRadius: t.borderRadius.sm,
+        borderWidth: t.borderWidth.s1,
+        overflow: "hidden",
+        minHeight: 64,
+      },
+      cardDefault: {
+        backgroundColor: t.colors.bg.muted,
+        borderColor: "transparent",
+      },
+      cardSelected: {
+        backgroundColor: t.colors.bg.activeSubtle,
+        borderColor: t.colors.border.active,
+      },
+      cardPressed: {
+        backgroundColor: t.colors.bg.surfacePressed,
+      },
+      content: {
+        flex: 1,
+        alignSelf: "stretch",
+        justifyContent: "center",
+        gap: t.spacings.s4,
+      },
+    }),
+    [],
+  );
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.card,
+        selected ? styles.cardSelected : styles.cardDefault,
+        pressed && styles.cardPressed,
+      ]}
+    >
+      <View style={styles.content}>
+        <Text typography="body2SemiBold" lx={{ color: "base" }} numberOfLines={1}>
+          {label}
+        </Text>
+        {lastUpdateLabel && (
+          <Text typography="body3" lx={{ color: "muted" }} numberOfLines={1}>
+            {lastUpdateLabel}
+          </Text>
+        )}
+      </View>
+      <Text
+        typography="body2SemiBold"
+        lx={{ color: "base" }}
+        numberOfLines={1}
+        adjustsFontSizeToFit
+      >
+        {balance}
+      </Text>
+    </Pressable>
+  );
+}

--- a/apps/ledger-live-mobile/src/families/aleo/Send/BalanceSelectionScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/BalanceSelectionScreen.tsx
@@ -1,18 +1,36 @@
-import React, { useCallback } from "react";
-import { Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
+import React, { useCallback, useState } from "react";
+import BigNumber from "bignumber.js";
+import { ScrollView } from "react-native";
+import { Box, Button } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import type { AccountBridge, AccountLike } from "@ledgerhq/types-live";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
-import type { Transaction as AleoTransaction } from "@ledgerhq/live-common/families/aleo/types";
+import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
+import {
+  derivePrivateTransactionMode,
+  derivePublicTransactionMode,
+} from "@ledgerhq/live-common/families/aleo/utils";
+import { PRIVATE_BALANCE_PLACEHOLDER } from "@ledgerhq/live-common/families/aleo/constants";
+import type {
+  AleoAccount,
+  AleoTokenAccount,
+  Transaction as AleoTransaction,
+} from "@ledgerhq/live-common/families/aleo/types";
+import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import { useTranslation } from "~/context/Locale";
+import CurrencyUnitValue from "~/components/CurrencyUnitValue";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import type { SendFundsNavigatorStackParamList } from "~/components/RootNavigator/types/SendFundsNavigator";
+import { BalanceCard } from "./BalanceCard";
 
 type Props = StackNavigatorProps<
   SendFundsNavigatorStackParamList,
   ScreenName.AleoSendBalanceSelection
 >;
+
+type BalanceOption = "public" | "private";
 
 export function BalanceSelectionHeaderTitle() {
   const { t } = useTranslation();
@@ -20,53 +38,125 @@ export function BalanceSelectionHeaderTitle() {
   return <StepHeader title={t("aleo.send.balanceSelection.title")} />;
 }
 
+function buildTransaction({
+  bridge,
+  account,
+  mainAccount,
+  isSelfTransfer,
+  mode,
+}: {
+  bridge: AccountBridge<AleoTransaction>;
+  account: AccountLike;
+  mainAccount: AleoAccount;
+  isSelfTransfer: boolean;
+  mode: AleoTransaction["mode"];
+}): AleoTransaction {
+  const tx = bridge.createTransaction(account);
+
+  return bridge.updateTransaction(tx, {
+    mode,
+    recipient: isSelfTransfer ? mainAccount.freshAddress : "",
+  });
+}
+
+function getCtaLabelKey(isSelfTransfer: boolean, option: BalanceOption) {
+  if (isSelfTransfer) {
+    return option === "public"
+      ? "aleo.send.balanceSelection.convertToPrivate"
+      : "aleo.send.balanceSelection.convertToPublic";
+  }
+
+  return option === "public"
+    ? "aleo.send.balanceSelection.sendPublicly"
+    : "aleo.send.balanceSelection.sendPrivately";
+}
+
 export function BalanceSelectionScreen({ navigation, route }: Props) {
   const { account, parentAccount, isSelfTransfer } = route.params;
+  const [selected, setSelected] = useState<BalanceOption>("public");
   const { t } = useTranslation();
   const bridge = useAccountBridge<AleoTransaction>(account, parentAccount);
+  const unit = useAccountUnit(account);
 
-  const onConfirm = useCallback(
-    (variant: "public" | "private") => {
-      const transaction = bridge.createTransaction(account);
+  const mainAccount = getMainAccount(account, parentAccount) as AleoAccount;
+  const isToken = account.type === "TokenAccount";
+  const aleoAccount = account as AleoAccount | AleoTokenAccount;
+  const ctaLabelKey = getCtaLabelKey(isSelfTransfer, selected);
+  const ctaLabel = t(ctaLabelKey);
 
-      if (variant === "private") {
-        navigation.navigate(ScreenName.AleoMandatoryPrivateSync, {
-          account,
-          parentAccount,
-          transaction,
-        });
-        return;
-      }
+  const transparentBalance =
+    aleoAccount.type === "TokenAccount"
+      ? aleoAccount.transparentBalance
+      : (aleoAccount.aleoResources?.transparentBalance ?? new BigNumber(0));
 
-      const targetScreen = isSelfTransfer
-        ? ScreenName.SendAmountCoin
-        : ScreenName.SendSelectRecipient;
+  const privateBalance =
+    aleoAccount.type === "TokenAccount"
+      ? (aleoAccount.privateBalance ?? null)
+      : (aleoAccount.aleoResources?.privateBalance ?? null);
 
-      navigation.navigate(targetScreen, {
-        accountId: account.id,
-        parentId: parentAccount?.id,
+  const privateSyncDate = mainAccount.aleoResources?.lastPrivateSyncDate;
+
+  const onConfirm = useCallback(() => {
+    const isPublic = selected === "public";
+    const deriveMode = isPublic ? derivePublicTransactionMode : derivePrivateTransactionMode;
+    const mode = deriveMode({ isTokenTx: isToken, isSelfTransfer });
+    const transaction = buildTransaction({ bridge, account, mainAccount, isSelfTransfer, mode });
+
+    if (!isPublic && isSelfTransfer) {
+      navigation.navigate(ScreenName.AleoMandatoryPrivateSync, {
+        account,
+        parentAccount,
         transaction,
       });
-    },
-    [account, bridge, navigation, parentAccount, isSelfTransfer],
-  );
+      return;
+    }
+
+    const nextScreen = isSelfTransfer ? ScreenName.SendAmountCoin : ScreenName.SendSelectRecipient;
+
+    navigation.navigate(nextScreen, {
+      accountId: account.id,
+      parentId: parentAccount?.id,
+      transaction,
+    });
+  }, [selected, isToken, isSelfTransfer, bridge, account, mainAccount, navigation, parentAccount]);
 
   return (
     <Box lx={wrapperStyle}>
-      <Box lx={contentStyle}>
-        <Text lx={{ color: "base" }}>{t("aleo.send.balanceSelection.mockTitle")}</Text>
-        <Text lx={{ color: "base" }}>
-          {t("aleo.send.balanceSelection.selfTransfer", {
-            value: isSelfTransfer ? t("common.yes") : t("common.no"),
-          })}
-        </Text>
-      </Box>
+      <ScrollView style={{ flex: 1 }}>
+        <Box lx={cardsStyle}>
+          <BalanceCard
+            label={t("aleo.send.balanceSelector.public")}
+            lastUpdateLabel={t("aleo.send.balanceSelector.lastUpdate", {
+              label: t("aleo.send.balanceSelector.recently"),
+            })}
+            balance={<CurrencyUnitValue unit={unit} value={transparentBalance} disableRounding />}
+            selected={selected === "public"}
+            onPress={() => setSelected("public")}
+          />
+          <BalanceCard
+            label={t("aleo.send.balanceSelector.private")}
+            lastUpdateLabel={
+              privateSyncDate
+                ? t("aleo.send.balanceSelector.lastUpdate", {
+                    label: new Date(privateSyncDate).toLocaleDateString(),
+                  })
+                : undefined
+            }
+            balance={
+              privateBalance === null ? (
+                PRIVATE_BALANCE_PLACEHOLDER
+              ) : (
+                <CurrencyUnitValue unit={unit} value={privateBalance} disableRounding />
+              )
+            }
+            selected={selected === "private"}
+            onPress={() => setSelected("private")}
+          />
+        </Box>
+      </ScrollView>
       <Box lx={footerStyle}>
-        <Button appearance="base" style={{ flexGrow: 1 }} onPress={() => onConfirm("public")}>
-          {t("aleo.send.balanceSelection.mockButtonPublic")}
-        </Button>
-        <Button appearance="base" style={{ flexGrow: 1 }} onPress={() => onConfirm("private")}>
-          {t("aleo.send.balanceSelection.mockButtonPrivate")}
+        <Button appearance="base" style={{ flexGrow: 1 }} onPress={onConfirm}>
+          {ctaLabel}
         </Button>
       </Box>
     </Box>
@@ -75,16 +165,15 @@ export function BalanceSelectionScreen({ navigation, route }: Props) {
 
 const wrapperStyle: LumenViewStyle = {
   flex: 1,
-  paddingHorizontal: "s16",
 };
 
-const contentStyle: LumenViewStyle = {
-  flex: 1,
+const cardsStyle: LumenViewStyle = {
+  padding: "s16",
+  gap: "s12",
 };
 
 const footerStyle: LumenViewStyle = {
-  justifyContent: "center",
-  flexDirection: "row",
-  gap: "s8",
+  paddingHorizontal: "s16",
   paddingBottom: "s24",
+  paddingTop: "s8",
 };

--- a/apps/ledger-live-mobile/src/families/aleo/Send/BalanceSelectionScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/BalanceSelectionScreen.tsx
@@ -18,6 +18,7 @@ import type {
 } from "@ledgerhq/live-common/families/aleo/types";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import { useTranslation } from "~/context/Locale";
+import { useFormatPrivateSyncDate } from "../hooks/useFormatPrivateSyncDate";
 import CurrencyUnitValue from "~/components/CurrencyUnitValue";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
@@ -77,6 +78,7 @@ export function BalanceSelectionScreen({ navigation, route }: Props) {
   const { t } = useTranslation();
   const bridge = useAccountBridge<AleoTransaction>(account, parentAccount);
   const unit = useAccountUnit(account);
+  const formatPrivateSyncDate = useFormatPrivateSyncDate();
 
   const mainAccount = getMainAccount(account, parentAccount) as AleoAccount;
   const isToken = account.type === "TokenAccount";
@@ -138,7 +140,7 @@ export function BalanceSelectionScreen({ navigation, route }: Props) {
             lastUpdateLabel={
               privateSyncDate
                 ? t("aleo.send.balanceSelector.lastUpdate", {
-                    label: new Date(privateSyncDate).toLocaleDateString(),
+                    label: formatPrivateSyncDate(privateSyncDate),
                   })
                 : undefined
             }

--- a/apps/ledger-live-mobile/src/families/aleo/Send/QuickAmountSelector.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/QuickAmountSelector.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import { isPrivateTransaction } from "@ledgerhq/live-common/families/aleo/utils";
+import { useTranslation } from "~/context/Locale";
+import type { AfterAmountInputProps } from "~/screens/SendFunds/utils/customSendFlow";
+
+export function QuickAmountSelector({ transaction }: Readonly<AfterAmountInputProps>) {
+  const { t } = useTranslation();
+
+  if (transaction.family !== "aleo" || !isPrivateTransaction(transaction)) {
+    return null;
+  }
+
+  return (
+    <Box lx={{ flex: 1 }}>
+      <Text typography="heading4SemiBold" lx={{ color: "base", textAlign: "center" }}>
+        {t("aleo.send.quickAmountSelector.mockTitle")}
+      </Text>
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/families/aleo/Send/SummaryFromBadge.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/SummaryFromBadge.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Tag } from "@ledgerhq/lumen-ui-rnative";
+import { isPrivateTransaction } from "@ledgerhq/live-common/families/aleo/utils";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import { useTranslation } from "~/context/Locale";
+
+type BadgeProps = Readonly<{ transaction: Transaction }>;
+
+export function SummaryFromBadge({ transaction }: BadgeProps) {
+  const { t } = useTranslation();
+
+  if (transaction.family !== "aleo") {
+    return null;
+  }
+
+  const key = isPrivateTransaction(transaction)
+    ? "aleo.operations.type.private"
+    : "aleo.operations.type.public";
+
+  return <Tag appearance="gray" size="sm" label={t(key)} />;
+}

--- a/apps/ledger-live-mobile/src/families/aleo/Send/SummaryToBadge.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/SummaryToBadge.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Tag } from "@ledgerhq/lumen-ui-rnative";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import { isPrivateDestination } from "@ledgerhq/live-common/families/aleo/utils";
+import { useTranslation } from "~/context/Locale";
+
+type BadgeProps = Readonly<{ transaction: Transaction }>;
+
+export function SummaryToBadge({ transaction }: BadgeProps) {
+  const { t } = useTranslation();
+
+  if (transaction.family !== "aleo") {
+    return null;
+  }
+
+  const key = isPrivateDestination(transaction)
+    ? "aleo.operations.type.private"
+    : "aleo.operations.type.public";
+
+  return <Tag appearance="gray" size="sm" label={t(key)} />;
+}

--- a/apps/ledger-live-mobile/src/families/aleo/Send/SummaryToSection.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/SummaryToSection.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import { isSelfTransferTransaction } from "@ledgerhq/live-common/families/aleo/utils";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import { useTheme } from "styled-components/native";
+import { useSelector } from "~/context/hooks";
+import { flattenAccountsSelector } from "~/reducers/accounts";
+import { useMaybeAccountName } from "~/reducers/wallet";
+import SummaryRowCustom from "~/screens/SendFunds/SummaryRowCustom";
+import Circle from "~/components/Circle";
+import LText from "~/components/LText";
+import CurrencyIcon from "~/components/CurrencyIcon";
+import QrCode from "@ledgerhq/icons-ui/native/QrCode";
+import { useTranslation } from "~/context/Locale";
+
+type Props = Readonly<{
+  transaction: Transaction;
+  currency: CryptoCurrency;
+  badge?: React.ReactNode;
+  account: AccountLike;
+  parentAccount: Account | null | undefined;
+}>;
+
+export function SummaryToSection({ transaction, currency, badge, account, parentAccount }: Props) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const allAccounts = useSelector(flattenAccountsSelector);
+
+  const mainAccount = getMainAccount(account, parentAccount);
+  const isSelfTransfer = transaction.family === "aleo" && isSelfTransferTransaction(transaction);
+
+  const recipientAccount = isSelfTransfer
+    ? (allAccounts.find(
+        a =>
+          a.type === "Account" &&
+          a.currency.id === currency.id &&
+          a.freshAddress === transaction.recipient,
+      ) ?? mainAccount)
+    : undefined;
+
+  const recipientAccountName = useMaybeAccountName(recipientAccount);
+
+  return (
+    <SummaryRowCustom
+      label={t("send.summary.to")}
+      labelBadge={badge}
+      iconLeft={
+        <Circle bg={colors.opacityDefault.c05} size={34}>
+          <QrCode size="S" color={colors.primary.c80} />
+        </Circle>
+      }
+      data={
+        isSelfTransfer && recipientAccountName ? (
+          <View style={styles.row}>
+            <View style={styles.iconWrapper}>
+              <CurrencyIcon size={14} currency={currency} />
+            </View>
+            <LText numberOfLines={1} style={styles.text}>
+              {recipientAccountName}
+            </LText>
+          </View>
+        ) : (
+          <LText numberOfLines={2} style={styles.text}>
+            {transaction.recipient}
+          </LText>
+        )
+      }
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+  },
+  iconWrapper: {
+    paddingRight: 8,
+    justifyContent: "center",
+  },
+  text: {
+    fontSize: 16,
+  },
+});

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/BalanceCard.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/BalanceCard.test.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { BalanceCard } from "../BalanceCard";
+
+describe("BalanceCard", () => {
+  it("renders label and balance", () => {
+    render(<BalanceCard label="Public" balance="100 ALEO" selected={false} onPress={() => {}} />);
+
+    expect(screen.getByText("Public")).toBeOnTheScreen();
+    expect(screen.getByText("100 ALEO")).toBeOnTheScreen();
+  });
+
+  it("calls onPress when pressed", async () => {
+    const onPress = jest.fn();
+    const { user } = render(
+      <BalanceCard label="Public" balance="100 ALEO" selected={false} onPress={onPress} />,
+    );
+
+    await user.press(screen.getByText("Public"));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders lastUpdateLabel when provided", () => {
+    render(
+      <BalanceCard
+        label="Private"
+        balance="***"
+        selected={true}
+        onPress={() => {}}
+        lastUpdateLabel="Last update: recently"
+      />,
+    );
+
+    expect(screen.getByText("Last update: recently")).toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/BalanceSelectionScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/BalanceSelectionScreen.test.tsx
@@ -1,17 +1,28 @@
 import React from "react";
-import { View, Text } from "react-native";
+import { Text, View } from "react-native";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { screen, render } from "@tests/test-renderer";
 import { BalanceSelectionScreen } from "../BalanceSelectionScreen";
 import { ScreenName } from "~/const";
-import { ALEO_ACCOUNT_1 } from "../../__mocks__/account.mock";
+import { ALEO_ACCOUNT_1, ALEO_TOKEN_ACCOUNT_1 } from "../../__mocks__/account.mock";
 
-const mockTransaction = { family: "aleo" };
-const mockCreateTransaction = jest.fn(() => mockTransaction);
+const mockCreateTransaction = jest.fn(() => ({ family: "aleo" }));
+const mockUpdateTransaction = jest.fn((tx: object, patch: object) => ({ ...tx, ...patch }));
 
 jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
   useAccountBridge: jest.fn(() => ({
     createTransaction: mockCreateTransaction,
+    updateTransaction: mockUpdateTransaction,
   })),
+}));
+
+jest.mock("LLM/hooks/useAccountUnit", () => ({
+  useAccountUnit: jest.fn(() => ({ name: "ALEO", code: "ALEO", magnitude: 6 })),
+}));
+
+jest.mock("~/components/CurrencyUnitValue", () => ({
+  __esModule: true,
+  default: () => null,
 }));
 
 jest.mock("@ledgerhq/lumen-ui-rnative", () => {
@@ -34,32 +45,137 @@ function makeNavigation() {
   return { navigate: jest.fn() };
 }
 
-function makeRoute() {
+function makeRoute({
+  isSelfTransfer,
+  account,
+  parentAccount,
+}: {
+  isSelfTransfer: boolean;
+  account: AccountLike;
+  parentAccount?: Account;
+}) {
   return {
     key: "aleo-balance-selection",
     name: "AleoSendBalanceSelection" as const,
-    params: { account: ALEO_ACCOUNT_1, parentAccount: undefined, isSelfTransfer: false },
+    params: { account, parentAccount, isSelfTransfer },
   };
 }
 
 describe("BalanceSelectionScreen", () => {
   const mockNavigation = makeNavigation();
-  const mockRoute = makeRoute();
+  const sendRoute = makeRoute({ account: ALEO_ACCOUNT_1, isSelfTransfer: false });
+  const selfTransferRoute = makeRoute({ account: ALEO_ACCOUNT_1, isSelfTransfer: true });
+  const tokenSendRoute = makeRoute({
+    account: ALEO_TOKEN_ACCOUNT_1,
+    parentAccount: ALEO_ACCOUNT_1,
+    isSelfTransfer: false,
+  });
 
-  it("navigates to SendSelectRecipient with the created transaction", async () => {
-    const { user } = render(
-      <BalanceSelectionScreen navigation={mockNavigation as never} route={mockRoute as never} />,
-    );
+  beforeEach(() => {
+    mockNavigation.navigate.mockClear();
+    mockCreateTransaction.mockClear();
+    mockUpdateTransaction.mockClear();
+  });
 
-    await user.press(screen.getByText("Public"));
+  describe("non-self-transfer", () => {
+    it("navigates to SendSelectRecipient with a public transaction by default", async () => {
+      const { user } = render(
+        <BalanceSelectionScreen navigation={mockNavigation as never} route={sendRoute as never} />,
+      );
 
-    expect(mockNavigation.navigate).toHaveBeenCalledTimes(1);
-    expect(mockNavigation.navigate).toHaveBeenCalledWith(
-      ScreenName.SendSelectRecipient,
-      expect.objectContaining({
-        accountId: ALEO_ACCOUNT_1.id,
-        transaction: mockTransaction,
-      }),
-    );
+      await user.press(screen.getByText("Send publicly"));
+
+      expect(mockNavigation.navigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        ScreenName.SendSelectRecipient,
+        expect.objectContaining({
+          accountId: ALEO_ACCOUNT_1.id,
+          transaction: expect.objectContaining({ mode: "transfer_public", recipient: "" }),
+        }),
+      );
+    });
+
+    it("navigates to SendSelectRecipient with a private transaction when private is selected", async () => {
+      const { user } = render(
+        <BalanceSelectionScreen navigation={mockNavigation as never} route={sendRoute as never} />,
+      );
+
+      await user.press(screen.getByText("Private"));
+      await user.press(screen.getByText("Send privately"));
+
+      expect(mockNavigation.navigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        ScreenName.SendSelectRecipient,
+        expect.objectContaining({
+          accountId: ALEO_ACCOUNT_1.id,
+          transaction: expect.objectContaining({ mode: "transfer_private", recipient: "" }),
+        }),
+      );
+    });
+  });
+
+  describe("token account", () => {
+    it("calls createTransaction with the token sub-account, not mainAccount", async () => {
+      const { user } = render(
+        <BalanceSelectionScreen
+          navigation={mockNavigation as never}
+          route={tokenSendRoute as never}
+        />,
+      );
+
+      await user.press(screen.getByText("Send publicly"));
+
+      expect(mockCreateTransaction).toHaveBeenCalledWith(ALEO_TOKEN_ACCOUNT_1);
+      expect(mockCreateTransaction).not.toHaveBeenCalledWith(ALEO_ACCOUNT_1);
+    });
+  });
+
+  describe("self-transfer", () => {
+    it("navigates to SendAmountCoin with convert_public_to_private when public (default) is selected", async () => {
+      const { user } = render(
+        <BalanceSelectionScreen
+          navigation={mockNavigation as never}
+          route={selfTransferRoute as never}
+        />,
+      );
+
+      await user.press(screen.getByText("Convert to private"));
+
+      expect(mockNavigation.navigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        ScreenName.SendAmountCoin,
+        expect.objectContaining({
+          accountId: ALEO_ACCOUNT_1.id,
+          transaction: expect.objectContaining({
+            mode: "convert_public_to_private",
+            recipient: ALEO_ACCOUNT_1.freshAddress,
+          }),
+        }),
+      );
+    });
+
+    it("navigates to AleoMandatoryPrivateSync when private is selected", async () => {
+      const { user } = render(
+        <BalanceSelectionScreen
+          navigation={mockNavigation as never}
+          route={selfTransferRoute as never}
+        />,
+      );
+
+      await user.press(screen.getByText("Private"));
+      await user.press(screen.getByText("Convert to public"));
+
+      expect(mockNavigation.navigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        ScreenName.AleoMandatoryPrivateSync,
+        expect.objectContaining({
+          account: ALEO_ACCOUNT_1,
+          transaction: expect.objectContaining({
+            mode: "convert_private_to_public",
+            recipient: ALEO_ACCOUNT_1.freshAddress,
+          }),
+        }),
+      );
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/BalanceSelectionScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/BalanceSelectionScreen.test.tsx
@@ -1,10 +1,16 @@
 import React from "react";
+import BigNumber from "bignumber.js";
 import { Text, View } from "react-native";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
 import { screen, render } from "@tests/test-renderer";
 import { BalanceSelectionScreen } from "../BalanceSelectionScreen";
 import { ScreenName } from "~/const";
 import { ALEO_ACCOUNT_1, ALEO_TOKEN_ACCOUNT_1 } from "../../__mocks__/account.mock";
+
+jest.mock("../../hooks/useFormatPrivateSyncDate", () => ({
+  useFormatPrivateSyncDate: jest.fn(() => (date: Date) => `formatted:${date.toISOString()}`),
+}));
 
 const mockCreateTransaction = jest.fn(() => ({ family: "aleo" }));
 const mockUpdateTransaction = jest.fn((tx: object, patch: object) => ({ ...tx, ...patch }));
@@ -127,6 +133,40 @@ describe("BalanceSelectionScreen", () => {
 
       expect(mockCreateTransaction).toHaveBeenCalledWith(ALEO_TOKEN_ACCOUNT_1);
       expect(mockCreateTransaction).not.toHaveBeenCalledWith(ALEO_ACCOUNT_1);
+    });
+  });
+
+  describe("private sync date", () => {
+    const syncDate = new Date(2024, 0, 15, 14, 30, 0);
+    const syncedAccount: AleoAccount = {
+      ...(ALEO_ACCOUNT_1 as AleoAccount),
+      aleoResources: {
+        transparentBalance: new BigNumber(0),
+        provableApi: null,
+        privateBalance: null,
+        unspentPrivateRecords: null,
+        lastPrivateSyncDate: syncDate,
+      },
+    };
+
+    it("shows the formatted private sync date in the private balance card", () => {
+      const route = makeRoute({ account: syncedAccount, isSelfTransfer: false });
+
+      render(
+        <BalanceSelectionScreen navigation={mockNavigation as never} route={route as never} />,
+      );
+
+      expect(
+        screen.getByText(`Last update: formatted:${syncDate.toISOString()}`),
+      ).toBeOnTheScreen();
+    });
+
+    it("does not show a formatted date when private sync has never run", () => {
+      render(
+        <BalanceSelectionScreen navigation={mockNavigation as never} route={sendRoute as never} />,
+      );
+
+      expect(screen.queryByText(/Last update: formatted:/)).not.toBeOnTheScreen();
     });
   });
 

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/QuickAmountSelector.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/QuickAmountSelector.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { QuickAmountSelector } from "../QuickAmountSelector";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+
+const mockUpdateTransaction = jest.fn();
+
+describe("QuickAmountSelector", () => {
+  const mockAccount = {} as never;
+
+  it("renders null for non-aleo transaction", () => {
+    const { toJSON } = render(
+      <QuickAmountSelector
+        account={mockAccount}
+        transaction={{ family: "ethereum" } as Transaction}
+        updateTransaction={mockUpdateTransaction}
+      />,
+    );
+
+    expect(toJSON()).toBeNull();
+  });
+
+  it("renders null for aleo public transaction", () => {
+    const { toJSON } = render(
+      <QuickAmountSelector
+        account={mockAccount}
+        transaction={{ family: "aleo", mode: "transfer_public" } as Transaction}
+        updateTransaction={mockUpdateTransaction}
+      />,
+    );
+
+    expect(toJSON()).toBeNull();
+  });
+
+  it("renders for aleo private transaction", () => {
+    render(
+      <QuickAmountSelector
+        account={mockAccount}
+        transaction={{ family: "aleo", mode: "transfer_private" } as Transaction}
+        updateTransaction={mockUpdateTransaction}
+      />,
+    );
+
+    expect(screen.getByText("Quick amount selector mock")).toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/SummaryFromBadge.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/SummaryFromBadge.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import { render, screen } from "@tests/test-renderer";
+import { SummaryFromBadge } from "../SummaryFromBadge";
+
+describe("SummaryFromBadge", () => {
+  it("renders null for non-aleo transaction", () => {
+    const { toJSON } = render(
+      <SummaryFromBadge transaction={{ family: "ethereum" } as Transaction} />,
+    );
+
+    expect(toJSON()).toBeNull();
+  });
+
+  it("shows Public for a public transaction", () => {
+    render(
+      <SummaryFromBadge transaction={{ family: "aleo", mode: "transfer_public" } as Transaction} />,
+    );
+
+    expect(screen.getByText("Public")).toBeOnTheScreen();
+  });
+
+  it("shows Private for a private transaction", () => {
+    render(
+      <SummaryFromBadge
+        transaction={{ family: "aleo", mode: "transfer_private" } as Transaction}
+      />,
+    );
+
+    expect(screen.getByText("Private")).toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/SummaryToBadge.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/SummaryToBadge.test.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import { render, screen } from "@tests/test-renderer";
+import { SummaryToBadge } from "../SummaryToBadge";
+
+describe("SummaryToBadge", () => {
+  it("renders null for non-aleo transaction", () => {
+    const { toJSON } = render(
+      <SummaryToBadge transaction={{ family: "ethereum" } as Transaction} />,
+    );
+
+    expect(toJSON()).toBeNull();
+  });
+
+  it("shows Public for a public destination mode", () => {
+    render(
+      <SummaryToBadge transaction={{ family: "aleo", mode: "transfer_public" } as Transaction} />,
+    );
+
+    expect(screen.getByText("Public")).toBeOnTheScreen();
+  });
+
+  it("shows Private for a private destination mode", () => {
+    render(
+      <SummaryToBadge transaction={{ family: "aleo", mode: "transfer_private" } as Transaction} />,
+    );
+
+    expect(screen.getByText("Private")).toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/SummaryToSection.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/SummaryToSection.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import type { Transaction } from "@ledgerhq/live-common/families/aleo/types";
+import { render, screen } from "@tests/test-renderer";
+import { SummaryToSection } from "../SummaryToSection";
+import { ALEO_ACCOUNT_1 } from "../../__mocks__/account.mock";
+
+const mockUseMaybeAccountName = jest.fn();
+
+jest.mock("~/reducers/wallet", () => ({
+  ...jest.requireActual("~/reducers/wallet"),
+  useMaybeAccountName: (...args: Parameters<typeof mockUseMaybeAccountName>) =>
+    mockUseMaybeAccountName(...args),
+}));
+
+const currency = ALEO_ACCOUNT_1.currency;
+
+describe("SummaryToSection", () => {
+  beforeEach(() => {
+    mockUseMaybeAccountName.mockReturnValue(undefined);
+  });
+
+  it("shows recipient address for a regular send", () => {
+    const transaction = {
+      family: "aleo",
+      mode: "transfer_public",
+      recipient: "aleo1abc123",
+    } as Transaction;
+
+    render(
+      <SummaryToSection
+        transaction={transaction}
+        currency={currency}
+        account={ALEO_ACCOUNT_1}
+        parentAccount={undefined}
+      />,
+    );
+
+    expect(screen.getByText("aleo1abc123")).toBeOnTheScreen();
+  });
+
+  it("shows account name for a self-transfer when the account is found", () => {
+    mockUseMaybeAccountName.mockReturnValue("My Aleo Account");
+
+    const transaction = {
+      family: "aleo",
+      mode: "convert_public_to_private",
+      recipient: ALEO_ACCOUNT_1.freshAddress,
+    } as Transaction;
+
+    render(
+      <SummaryToSection
+        transaction={transaction}
+        currency={currency}
+        account={ALEO_ACCOUNT_1}
+        parentAccount={undefined}
+      />,
+    );
+
+    expect(screen.getByText("My Aleo Account")).toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/__mocks__/account.mock.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/__mocks__/account.mock.ts
@@ -1,4 +1,6 @@
-import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { aleoCurrency } from "./currency.mock";
+import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { aleoCurrency, aleoTokenCurrency } from "./currency.mock";
 
 export const ALEO_ACCOUNT_1 = { ...genAccount("aleo-1", { currency: aleoCurrency }), index: 0 };
+
+export const ALEO_TOKEN_ACCOUNT_1 = genTokenAccount(0, ALEO_ACCOUNT_1, aleoTokenCurrency);

--- a/apps/ledger-live-mobile/src/families/aleo/__mocks__/currency.mock.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/__mocks__/currency.mock.ts
@@ -1,3 +1,15 @@
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 
 export const aleoCurrency = getCryptoCurrencyById("aleo");
+
+export const aleoTokenCurrency: TokenCurrency = {
+  type: "TokenCurrency",
+  id: "aleo/arc22/usad",
+  name: "USAD",
+  ticker: "USAD",
+  units: [{ name: "USAD", code: "USAD", magnitude: 6 }],
+  contractAddress: "usad_stablecoin.aleo",
+  parentCurrencyId: aleoCurrency.id,
+  tokenType: "arc22",
+};

--- a/apps/ledger-live-mobile/src/families/aleo/customSendFlow.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/customSendFlow.ts
@@ -6,6 +6,10 @@ import type {
 } from "~/screens/SendFunds/utils/customSendFlow";
 import { BalanceSelectionScreen, BalanceSelectionHeaderTitle } from "./Send/BalanceSelectionScreen";
 import { MandatoryPrivateSyncScreen } from "./Send/MandatoryPrivateSyncScreen";
+import { QuickAmountSelector } from "./Send/QuickAmountSelector";
+import { SummaryFromBadge } from "./Send/SummaryFromBadge";
+import { SummaryToBadge } from "./Send/SummaryToBadge";
+import { SummaryToSection } from "./Send/SummaryToSection";
 
 const screens: CustomSendFlowScreen[] = [
   {
@@ -22,6 +26,10 @@ const screens: CustomSendFlowScreen[] = [
 
 const aleoSendFlow = {
   screens,
+  SummaryFromBadge,
+  SummaryToBadge,
+  SummaryToSection,
+  AfterAmountInput: QuickAmountSelector,
   buildSendEntrypoint: ({ account, parentAccount }) => ({
     screen: ScreenName.AleoSendBalanceSelection,
     params: { account, parentAccount, isSelfTransfer: false },

--- a/apps/ledger-live-mobile/src/families/aleo/hooks/useFormatPrivateSyncDate.test.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/hooks/useFormatPrivateSyncDate.test.ts
@@ -1,0 +1,47 @@
+import { renderHook } from "@tests/test-renderer";
+import { State } from "~/reducers/types";
+import { useFormatPrivateSyncDate } from "./useFormatPrivateSyncDate";
+
+// Jan 15, 2024 at 14:30
+const REFERENCE_DATE = new Date(2024, 0, 15, 14, 30, 0);
+
+const FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  day: "numeric",
+  month: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+};
+
+function renderWithLocale(locale: string) {
+  return renderHook(() => useFormatPrivateSyncDate(), {
+    overrideInitialState: (state: State) => ({
+      ...state,
+      settings: { ...state.settings, locale },
+    }),
+  });
+}
+
+describe("useFormatPrivateSyncDate", () => {
+  it("formats using the locale from settings", () => {
+    const { result } = renderWithLocale("en-US");
+
+    expect(result.current(REFERENCE_DATE)).toBe(
+      new Intl.DateTimeFormat("en-US", FORMAT_OPTIONS).format(REFERENCE_DATE),
+    );
+  });
+
+  it("includes time in the output", () => {
+    const { result } = renderWithLocale("en-US");
+
+    // REFERENCE_DATE is 14:30 -> en-US renders as "2:30 PM"
+    expect(result.current(REFERENCE_DATE)).toMatch(/2:30/);
+  });
+
+  it("produces different output for different locales", () => {
+    const { result: enResult } = renderWithLocale("en-US");
+    const { result: frResult } = renderWithLocale("fr-FR");
+
+    expect(enResult.current(REFERENCE_DATE)).not.toBe(frResult.current(REFERENCE_DATE));
+  });
+});

--- a/apps/ledger-live-mobile/src/families/aleo/hooks/useFormatPrivateSyncDate.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/hooks/useFormatPrivateSyncDate.ts
@@ -1,0 +1,20 @@
+import { useCallback } from "react";
+import { useSelector } from "~/context/hooks";
+import { localeSelector } from "~/reducers/settings";
+
+const privateSyncDateFormat: Intl.DateTimeFormatOptions = {
+  day: "numeric",
+  month: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+};
+
+export function useFormatPrivateSyncDate() {
+  const locale = useSelector(localeSelector);
+
+  return useCallback(
+    (date: Date) => new Intl.DateTimeFormat(locale, privateSyncDateFormat).format(date),
+    [locale],
+  );
+}

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10077,13 +10077,22 @@
     "send": {
       "balanceSelection": {
         "title": "Select balance",
-        "mockTitle": "Balance selection screen mock",
-        "selfTransfer": "Self transfer: {{value}}",
-        "mockButtonPublic": "Public",
-        "mockButtonPrivate": "Private"
+        "convertToPrivate": "Convert to private",
+        "convertToPublic": "Convert to public",
+        "sendPublicly": "Send publicly",
+        "sendPrivately": "Send privately"
+      },
+      "balanceSelector": {
+        "public": "Public",
+        "private": "Private",
+        "lastUpdate": "Last update: {{label}}",
+        "recently": "recently"
       },
       "privateSync": {
         "mockTitle": "Private sync mock"
+      },
+      "quickAmountSelector": {
+        "mockTitle": "Quick amount selector mock"
       }
     },
     "balancesSection": "Balances",


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR Implements the public send flow for Aleo, completing the balance selection screen that was previously a skeleton. Users can now choose between public and private balances via selectable BalanceCard components, with the correct transaction mode derived from their selection and the self-transfer flag. Private balance display shows either the synced amount with a last-update date or a placeholder when unsynced.

recordings:
- send https://drive.google.com/file/d/1rxJD1wChYwo5qgRaNzuEjkHh2LQNNlz8/view?usp=sharing
- self transfer https://drive.google.com/file/d/1WJZsjMdc_59F_1cSfhdAQ5LGkqqS_3NL/view?usp=sharing

screenshots:
| <img width="1206" height="2622" alt="balance-selection-1" src="https://github.com/user-attachments/assets/31b61670-fe37-42c2-aaab-e2699a08f192" /> | <img width="1206" height="2622" alt="balance-selection-2" src="https://github.com/user-attachments/assets/3f0e5a3a-87c6-4043-bf82-8284ef82ad3a" /> |
|----|---|
| <img width="1206" height="2622" alt="aleo-self-transfer-summary" src="https://github.com/user-attachments/assets/6713fb14-682e-44fe-9a39-9443e52a22e5" /> | <img width="1206" height="2622" alt="aleo-send-summary" src="https://github.com/user-attachments/assets/0c33a0c1-7556-445b-85a1-da7a298409f3" /> |
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/8cde0627-a23a-42d2-b840-156948a81eff" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/f60317b9-1f86-4743-9380-b5204a0c0b8d" /> |
<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-30503