### PR TITLE
chore(desktop): upgrade Electron 42 → 43

### DIFF
--- a/.changeset/swift-electrons-boot.md
+++ b/.changeset/swift-electrons-boot.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Upgrade Electron from 42 to 43 for boot-time performance improvements

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,8 +325,8 @@ catalogs:
       specifier: 20.51.3
       version: 20.51.3
     electron:
-      specifier: 42.5.0
-      version: 42.5.0
+      specifier: 43.1.1
+      version: 43.1.1
     eslint-plugin-better-tailwindcss:
       specifier: 4.0.0-beta.3
       version: 4.0.0-beta.3
@@ -1408,7 +1408,7 @@ importers:
         version: 26.0.1(lodash@4.17.21)
       electron:
         specifier: 'catalog:'
-        version: 42.5.0
+        version: 43.1.1
       electron-builder:
         specifier: 26.0.1
         version: 26.0.1(lodash@4.17.21)
@@ -3849,7 +3849,7 @@ importers:
         version: 4.17.16
       electron:
         specifier: 'catalog:'
-        version: 42.5.0
+        version: 43.1.1
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -27766,8 +27766,8 @@ packages:
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
-  electron@42.5.0:
-    resolution: {integrity: sha512-cYEKS9XFz+c9fAB4jI0x49yz1FFzB55r3q96wu9YkwwJMv7t9202IE/ltlgy6yitl/J4M7C8JQcmUqdzDvPl/w==}
+  electron@43.1.1:
+    resolution: {integrity: sha512-I5c5vfuVvaXpWx3IZdwvXgxQW44+e7OP1wXGVQkogLeSFSkUZ6sLCcWV05AdEcs65AO5tAIJJwbp7ixw+LdarA==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -59958,7 +59958,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@42.5.0:
+  electron@43.1.1:
     dependencies:
       '@electron-internal/extract-zip': 1.0.4
       '@electron/get': 5.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -134,7 +134,7 @@ catalog:
   bs58check: ^2.1.2
   class-variance-authority: 0.7.1
   clsx: 2.1.1
-  electron: 42.5.0
+  electron: 43.1.1
   eslint-plugin-better-tailwindcss: 4.0.0-beta.3
   eslint-plugin-jest: 27.9.0
   ethers: 6.15.0
@@ -215,3 +215,4 @@ overrides:
 minimumReleaseAge: 3000
 minimumReleaseAgeExclude:
   - "@ledgerhq/*"
+  - electron


### PR DESCRIPTION
### 📝 Description

Bumps electron from 42.5.0 to 43.1.1 in the pnpm workspace catalog (single-line change).

No breaking changes documented for this upgrade. The previous v42 task (LIVE-27552) is Done.

> [!NOTE]
> According to release notes. Boot-time performance improvement: Electron 43 ships V8 13.5 with faster startup and reduced heap pressure compared to 42.
> **In practice: no gain perceptible on our side.**

Example:

```
Before

T-electron: 54ms
T-imports: 56.864ms
T-init: 54.117ms
T-window: 107.198ms
T-db: 5.629ms
T-load: 651.042ms
T-ready: 200.824ms
TOTAL BOOT TIME: 1150ms

After

T-electron: 63ms
T-imports: 65.354ms
T-init: 54.125ms
T-window: 109.233ms
T-db: 4.577ms
T-load: 656.6ms
T-ready: 200.513ms
TOTAL BOOT TIME: 1172ms
```


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34024](https://ledgerhq.atlassian.net/browse/LIVE-34024)
- **ADR** (if any): N/A

[LIVE-34024]: https://ledgerhq.atlassian.net/browse/LIVE-34024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ