### PR TITLE
[LWM] feat: display PnL percentage evolution in detail drawer

### DIFF
--- a/.changeset/lwm-pnl-detail-percent-evolution.md
+++ b/.changeset/lwm-pnl-detail-percent-evolution.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Display percentage evolution alongside absolute values in the LWM PnL detail drawer on Asset Detail and Analytics pages.

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/index.tsx
@@ -54,6 +54,7 @@ export default function PnlSection() {
         description={drawer.description}
         items={drawer.items}
         footer={drawer.footer}
+        discreet={drawer.discreet}
         pageName={drawer.pageName}
         source={drawer.source}
         testID={PNL_SECTION_TEST_IDS.detailDrawer}

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/types.ts
@@ -17,5 +17,6 @@ export type PnlSectionViewModel = {
     footer: string;
     pageName: string;
     source: string;
+    discreet: boolean;
   };
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/usePnlSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/usePnlSectionViewModel.ts
@@ -29,7 +29,13 @@ export function usePnlSectionViewModel(): PnlSectionViewModel {
 
   // Skip the (potentially expensive) portfolio walk when the section is hidden.
   const pnl = usePortfolioPnL(shouldDisplayPnl ? accounts : EMPTY_ACCOUNTS, countervalues, fiat);
-  const { unrealisedPnL = ZERO, realisedPnL = ZERO, totalPnL = ZERO } = pnl ?? {};
+  const {
+    unrealisedPnL = ZERO,
+    realisedPnL = ZERO,
+    totalPnL = ZERO,
+    costBasis = ZERO,
+    lifetimeCost = ZERO,
+  } = pnl ?? {};
 
   const [isDrawerOpen, setDrawerOpen] = useState(false);
   const openDrawer = useCallback(() => setDrawerOpen(true), []);
@@ -91,10 +97,12 @@ export function usePnlSectionViewModel(): PnlSectionViewModel {
         totalPnL,
         unrealisedPnL,
         realisedPnL,
+        costBasis,
+        lifetimeCost,
         formatFiat,
         t,
       }),
-    [totalPnL, unrealisedPnL, realisedPnL, formatFiat, t],
+    [totalPnL, unrealisedPnL, realisedPnL, costBasis, lifetimeCost, formatFiat, t],
   );
 
   return {
@@ -112,6 +120,7 @@ export function usePnlSectionViewModel(): PnlSectionViewModel {
       footer: t("pnl.disclaimer"),
       pageName: PNL_DETAIL_PAGE,
       source: ANALYTICS_PAGE,
+      discreet,
     },
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/index.tsx
@@ -69,6 +69,7 @@ function PnLSectionContent({
         description={pnlDrawer.description}
         items={pnlDrawer.items}
         footer={pnlDrawer.footer}
+        discreet={pnlDrawer.discreet}
         pageName={pnlDrawer.pageName}
         source={pnlDrawer.source}
         testID={ASSET_DETAIL_PNL_TEST_IDS.detailDrawer}
@@ -78,6 +79,7 @@ function PnLSectionContent({
         onClose={secondaryDrawer.onClose}
         title={secondaryDrawer.title}
         bodyText={secondaryDrawer.bodyText}
+        discreet={secondaryDrawer.discreet}
         pageName={secondaryDrawer.pageName}
         source={secondaryDrawer.source}
         testID={ASSET_DETAIL_PNL_TEST_IDS.secondaryDrawer}

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/__integrations__/pnlDetailDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/__integrations__/pnlDetailDrawer.integration.test.tsx
@@ -23,16 +23,19 @@ const ITEMS: PnlDetailItem[] = [
     title: "Total return",
     value: "$1,200.00 USD",
     definition: "Realised + unrealised gains since first inflow.",
+    percentage: 10,
   },
   {
     title: "Unrealised return",
     value: "$900.00 USD",
     definition: "Mark-to-market on coins you still hold.",
+    percentage: 3,
   },
   {
     title: "Realised return",
     value: "$300.00 USD",
     definition: "Gains booked through past sells.",
+    percentage: 1,
   },
 ];
 
@@ -56,6 +59,9 @@ describe("PnlDetailDrawer integration", () => {
       if (item.definition) {
         expect(screen.getByText(item.definition)).toBeVisible();
       }
+      if (item.percentage != null) {
+        expect(screen.getByText(`${item.percentage.toFixed(2)}%`)).toBeVisible();
+      }
     }
   });
 
@@ -75,6 +81,15 @@ describe("PnlDetailDrawer integration", () => {
 
     expect(screen.getByText("Bare row")).toBeVisible();
     expect(screen.getByText("$50.00 USD")).toBeVisible();
+  });
+
+  it("masks percentage values when discreet mode is on", () => {
+    render(
+      <PnlDetailDrawer isOpen onClose={jest.fn()} title={TITLE} items={[ITEMS[1]]} discreet />,
+    );
+
+    expect(screen.getByText("***")).toBeVisible();
+    expect(screen.queryByText("3.00%")).toBeNull();
   });
 
   describe("TrackScreen", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/builders/__tests__/buildPnlDetail.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/builders/__tests__/buildPnlDetail.test.ts
@@ -1,0 +1,79 @@
+import { BigNumber } from "bignumber.js";
+import type { TFunction } from "i18next";
+import { buildPnlDetail } from "../buildPnlDetail";
+
+const fakeT = ((key: string) => key) as unknown as TFunction;
+
+const makeInput = (overrides: Partial<Parameters<typeof buildPnlDetail>[0]> = {}) => ({
+  namespace: "pnl.asset" as const,
+  totalPnL: new BigNumber(100),
+  unrealisedPnL: new BigNumber(60),
+  realisedPnL: new BigNumber(40),
+  costBasis: new BigNumber(2000),
+  lifetimeCost: new BigNumber(3000),
+  formatFiat: (v: BigNumber, alwaysShowSign?: boolean) =>
+    `formatted(${v.toString()}${alwaysShowSign ? ",sign" : ""})`,
+  t: fakeT,
+  ...overrides,
+});
+
+describe("buildPnlDetail", () => {
+  it("uses the asset namespace for translation keys", () => {
+    const detail = buildPnlDetail(makeInput({ namespace: "pnl.asset" }));
+
+    expect(detail.title).toBe("pnl.asset.drawer.title");
+    expect(detail.items.map(i => i.title)).toEqual([
+      "pnl.asset.drawer.estimatedReturn.title",
+      "pnl.asset.drawer.realisedReturn.title",
+      "pnl.asset.drawer.totalReturn.title",
+    ]);
+  });
+
+  it("uses the portfolio namespace for translation keys", () => {
+    const detail = buildPnlDetail(makeInput({ namespace: "pnl.portfolio" }));
+
+    expect(detail.title).toBe("pnl.portfolio.drawer.title");
+    expect(detail.items.map(i => i.title)).toEqual([
+      "pnl.portfolio.drawer.estimatedReturn.title",
+      "pnl.portfolio.drawer.realisedReturn.title",
+      "pnl.portfolio.drawer.totalReturn.title",
+    ]);
+  });
+
+  it("formats each PnL bucket through the provided fiat formatter, always showing the sign", () => {
+    const detail = buildPnlDetail(makeInput());
+
+    expect(detail.items.map(i => i.value)).toEqual([
+      "formatted(60,sign)",
+      "formatted(40,sign)",
+      "formatted(100,sign)",
+    ]);
+  });
+
+  it("computes percentage evolution for each bucket against the appropriate cost basis", () => {
+    const detail = buildPnlDetail(makeInput());
+    const percentages = detail.items.map(i => i.percentage);
+
+    expect(percentages[0]).toBe(3);
+    expect(percentages[1]).toBe(4);
+    expect(percentages[2]).toBeCloseTo(3.33, 2);
+  });
+
+  it("omits percentage when the relevant cost basis is zero", () => {
+    const detail = buildPnlDetail(
+      makeInput({ costBasis: new BigNumber(0), lifetimeCost: new BigNumber(0) }),
+    );
+
+    expect(detail.items.map(i => i.percentage)).toEqual([undefined, undefined, undefined]);
+  });
+
+  it("omits realised percentage when costBasis exceeds lifetimeCost", () => {
+    const detail = buildPnlDetail(
+      makeInput({ costBasis: new BigNumber(3000), lifetimeCost: new BigNumber(2000) }),
+    );
+
+    expect(detail.items[0].percentage).toBe(2);
+    expect(detail.items[1].percentage).toBeUndefined();
+    expect(detail.items[2].percentage).toBeCloseTo(5, 2);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/builders/buildPnlDetail.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/builders/buildPnlDetail.ts
@@ -1,5 +1,6 @@
 import type { BigNumber } from "bignumber.js";
 import type { TFunction } from "i18next";
+import { pnlPercentage } from "@ledgerhq/wallet-pnl";
 import type { PnlDetailItem } from "../components/PnlDetailDrawer/types";
 import type { PnlNamespace } from "../types";
 
@@ -8,6 +9,8 @@ export type BuildPnlDetailInput = {
   totalPnL: BigNumber;
   unrealisedPnL: BigNumber;
   realisedPnL: BigNumber;
+  costBasis: BigNumber;
+  lifetimeCost: BigNumber;
   formatFiat: (value: BigNumber, alwaysShowSign?: boolean) => string;
   t: TFunction;
 };
@@ -18,15 +21,24 @@ export type PnlDetailData = {
   items: PnlDetailItem[];
 };
 
+function toPercentValue(pnl: BigNumber, basis: BigNumber): number | undefined {
+  if (basis.lte(0)) return undefined;
+  return pnlPercentage(pnl, basis)?.toNumber();
+}
+
 export function buildPnlDetail({
   namespace,
   totalPnL,
   unrealisedPnL,
   realisedPnL,
+  costBasis,
+  lifetimeCost,
   formatFiat,
   t,
 }: BuildPnlDetailInput): PnlDetailData {
   const key = (suffix: string) => `${namespace}.drawer.${suffix}`;
+  const realisedCostBasis = lifetimeCost.minus(costBasis);
+
   return {
     title: t(key("title")),
     description: t(key("description")),
@@ -35,16 +47,19 @@ export function buildPnlDetail({
         title: t(key("estimatedReturn.title")),
         definition: t(key("estimatedReturn.description")),
         value: formatFiat(unrealisedPnL, true),
+        percentage: toPercentValue(unrealisedPnL, costBasis),
       },
       {
         title: t(key("realisedReturn.title")),
         definition: t(key("realisedReturn.description")),
         value: formatFiat(realisedPnL, true),
+        percentage: toPercentValue(realisedPnL, realisedCostBasis),
       },
       {
         title: t(key("totalReturn.title")),
         definition: t(key("totalReturn.description")),
         value: formatFiat(totalPnL, true),
+        percentage: toPercentValue(totalPnL, lifetimeCost),
       },
     ],
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/PnlDetailRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/PnlDetailRow.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import { Box, Text, Trend } from "@ledgerhq/lumen-ui-rnative";
 import { PnlDetailItem } from "./types";
 
-type Props = Readonly<{ item: PnlDetailItem }>;
+type Props = Readonly<{ item: PnlDetailItem; discreet?: boolean }>;
 
-export function PnlDetailRow({ item }: Props) {
+export function PnlDetailRow({ item, discreet = false }: Props) {
   return (
     <Box
       lx={{ flexDirection: "row", alignItems: "flex-start", gap: "s16" }}
@@ -20,9 +20,19 @@ export function PnlDetailRow({ item }: Props) {
           </Text>
         ) : null}
       </Box>
-      <Text typography="body2SemiBold" lx={{ color: "base" }}>
-        {item.value}
-      </Text>
+      <Box lx={{ alignItems: "flex-end", gap: "s4" }}>
+        <Text typography="body2SemiBold" lx={{ color: "base" }}>
+          {item.value}
+        </Text>
+        {item.percentage != null &&
+          (discreet ? (
+            <Text typography="body3" lx={{ color: "muted" }}>
+              ***
+            </Text>
+          ) : (
+            <Trend value={item.percentage} size="sm" />
+          ))}
+      </Box>
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/__tests__/PnlDetailRow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/__tests__/PnlDetailRow.test.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { PnlDetailRow } from "../PnlDetailRow";
+import type { PnlDetailItem } from "../types";
+
+const TITLE = "Unrealised return";
+const DEFINITION = "The estimated profit or loss if sold at current price.";
+const VALUE = "+ $243.32";
+
+const makeItem = (overrides: Partial<PnlDetailItem> = {}): PnlDetailItem => ({
+  title: TITLE,
+  value: VALUE,
+  definition: DEFINITION,
+  ...overrides,
+});
+
+describe("PnlDetailRow", () => {
+  it("renders the title, definition and value", () => {
+    render(<PnlDetailRow item={makeItem()} />);
+
+    expect(screen.getByText(TITLE)).toBeVisible();
+    expect(screen.getByText(DEFINITION)).toBeVisible();
+    expect(screen.getByText(VALUE)).toBeVisible();
+  });
+
+  it("renders the percentage evolution with the Lumen Trend component when provided", () => {
+    render(<PnlDetailRow item={makeItem({ percentage: 3 })} />);
+
+    expect(screen.getByText("3.00%")).toBeVisible();
+  });
+
+  it("masks the percentage in discreet mode", () => {
+    render(<PnlDetailRow item={makeItem({ percentage: 3 })} discreet />);
+
+    expect(screen.getByText("***")).toBeVisible();
+    expect(screen.queryByText("3.00%")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/index.tsx
@@ -14,6 +14,7 @@ export function PnlDetailDrawer({
   bodyText,
   items = [],
   footer,
+  discreet = false,
   testID,
   pageName,
   source,
@@ -37,7 +38,7 @@ export function PnlDetailDrawer({
         ) : null}
         <Box lx={{ gap: "s16" }}>
           {items.map(item => (
-            <PnlDetailRow key={item.title} item={item} />
+            <PnlDetailRow key={item.title} item={item} discreet={discreet} />
           ))}
         </Box>
         {footer ? (

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/components/PnlDetailDrawer/types.ts
@@ -2,6 +2,7 @@ export type PnlDetailItem = {
   title: string;
   value: string;
   definition?: string;
+  percentage?: number;
 };
 
 export type PnlDetailDrawerProps = {
@@ -15,6 +16,7 @@ export type PnlDetailDrawerProps = {
   items?: PnlDetailItem[];
   /** Optional muted footer (body4, muted) rendered below the items. */
   footer?: string;
+  discreet?: boolean;
   testID?: string;
   pageName?: string;
   source?: string;

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/hooks/usePnlViewModelBase.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/hooks/usePnlViewModelBase.ts
@@ -45,7 +45,13 @@ export function usePnlViewModelBase({
   const discreet = useSelector(discreetModeSelector);
   const [openDrawer, setOpenDrawer] = useState<Drawer>(null);
 
-  const { unrealisedPnL = ZERO, realisedPnL = ZERO, totalPnL = ZERO } = pnlData ?? {};
+  const {
+    unrealisedPnL = ZERO,
+    realisedPnL = ZERO,
+    totalPnL = ZERO,
+    costBasis = ZERO,
+    lifetimeCost = ZERO,
+  } = pnlData ?? {};
 
   const formatFiat = useCallback(
     (value: BigNumber, alwaysShowSign?: boolean) =>
@@ -111,8 +117,18 @@ export function usePnlViewModelBase({
   );
 
   const detail = useMemo(
-    () => buildPnlDetail({ namespace, totalPnL, unrealisedPnL, realisedPnL, formatFiat, t }),
-    [namespace, totalPnL, unrealisedPnL, realisedPnL, formatFiat, t],
+    () =>
+      buildPnlDetail({
+        namespace,
+        totalPnL,
+        unrealisedPnL,
+        realisedPnL,
+        costBasis,
+        lifetimeCost,
+        formatFiat,
+        t,
+      }),
+    [namespace, totalPnL, unrealisedPnL, realisedPnL, costBasis, lifetimeCost, formatFiat, t],
   );
 
   return {
@@ -128,6 +144,7 @@ export function usePnlViewModelBase({
       footer: t("pnl.disclaimer"),
       pageName: PNL_DETAIL_PAGE,
       source,
+      discreet,
     },
     secondaryDrawer: {
       isOpen: openDrawer === "secondary",
@@ -136,6 +153,7 @@ export function usePnlViewModelBase({
       bodyText: t(secondaryCard.tooltipKey),
       pageName: AVERAGE_PRICE_PAGE,
       source,
+      discreet,
     },
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Pnl/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Pnl/types.ts
@@ -10,6 +10,8 @@ export type PnlNumbers = {
   unrealisedPnL: BigNumber;
   realisedPnL: BigNumber;
   totalPnL: BigNumber;
+  costBasis: BigNumber;
+  lifetimeCost: BigNumber;
 };
 
 export type PnlSecondaryCardConfig = {
@@ -39,6 +41,7 @@ export type PnlDrawerViewModel = {
   title: string;
   pageName?: string;
   source?: string;
+  discreet: boolean;
 };
 
 export type PnlViewModel = {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

This pull request enhances the PnL (Profit and Loss) detail drawer in the Ledger Live Mobile app by displaying the percentage evolution alongside absolute values for each PnL bucket. The changes ensure that users can see both the monetary and percentage returns for total, unrealised, and realised PnL, with appropriate handling for discreet mode and improved test coverage.

**PnL Detail Drawer Enhancements:**

* The PnL detail drawer now displays percentage evolution for total, unrealised, and realised returns, calculated against the relevant cost basis. This is shown using the `Trend` component, and is masked when discreet mode is enabled.

**ViewModel and Data Flow Updates:**

* The `PnlNumbers` and related view models now include `costBasis` and `lifetimeCost` fields, ensuring the necessary data is available for percentage calculations. 
* The `buildPnlDetail` builder and its consumers have been updated to accept and utilize the new cost basis fields for accurate percentage computation. 

**Testing Improvements:**

* Integration and unit tests have been added and updated to verify that percentages are calculated, rendered, and masked correctly in discreet mode. 

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 10 25 00" src="https://github.com/user-attachments/assets/9f360cc1-b57b-45c0-86a0-2c71b28ea295" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 10 25 45" src="https://github.com/user-attachments/assets/93de5857-7de5-45e5-b29d-e2b2a34ec1e7" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 10 25 59" src="https://github.com/user-attachments/assets/8b1f4243-e671-4614-95e7-4a274ed83f4f" />


### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
[LIVE-33174](https://ledgerhq.atlassian.net/browse/LIVE-33174)