### PR TITLE
[LWDM] refactor(types-live): drop @ledgerhq/client-ids dependency

### DIFF
--- a/.changeset/silent-bears-jump.md
+++ b/.changeset/silent-bears-jump.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/types-live": patch
+---
+
+Drop @ledgerhq/client-ids dep by inlining a DeviceId interface

--- a/libs/client-ids/package.json
+++ b/libs/client-ids/package.json
@@ -13,9 +13,7 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/client-ids",
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "main": "lib/index.js",
   "module": "lib-es/index.js",
   "types": "lib/index.d.ts",

--- a/libs/client-ids/scripts/check-export-rules.mjs
+++ b/libs/client-ids/scripts/check-export-rules.mjs
@@ -62,7 +62,7 @@ async function extractExportMethods(filePath) {
 async function findUsages(functionName) {
   try {
     const { stdout } = await execAsync(
-      `grep -r --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" --exclude-dir=lib --exclude-dir=lib-es --exclude-dir=node_modules --exclude-dir=.next --exclude-dir=build --exclude-dir=generated --exclude-dir=dist --exclude-dir=.expo -l "${functionName}" .`,
+      `grep -r --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" --exclude-dir=lib --exclude-dir=lib-es --exclude-dir=node_modules --exclude-dir=.next --exclude-dir=build --exclude-dir=generated --exclude-dir=dist --exclude-dir=.expo --exclude-dir=.claude -l "${functionName}" .`,
       {
         cwd: rootDir,
         encoding: "utf-8",
@@ -95,7 +95,8 @@ async function checkFunction(sourceFile, functionName, allowedFiles, rules) {
   );
   const finalAllowedFiles = [...new Set([sourceFile, ...idDefinitionFiles, ...allowedFiles])];
 
-  // Exclude test files, webpack bundles, next.js builds, and the source file itself (where the function is defined)
+  // Exclude test files, webpack bundles, next.js builds, types-* packages (interface declarations),
+  // and the source file itself (where the function is defined)
   const violations = usages.filter(
     file =>
       !file.includes(".test.") &&
@@ -105,6 +106,7 @@ async function checkFunction(sourceFile, functionName, allowedFiles, rules) {
       !file.includes("/build/") &&
       !file.includes("/generated/") &&
       !file.includes("CHANGELOG") &&
+      !file.split("/").some(seg => seg.startsWith("types-")) &&
       file !== sourceFile &&
       !finalAllowedFiles.includes(file),
   );
@@ -172,6 +174,7 @@ async function main() {
             !file.includes("/build/") &&
             !file.includes("/generated/") &&
             !file.includes("CHANGELOG") &&
+            !file.split("/").some(seg => seg.startsWith("types-")) &&
             file !== sourceFile &&
             !file.startsWith(sourceDir + "/"),
         );

--- a/libs/ledger-live-common/src/apps/listApps.ts
+++ b/libs/ledger-live-common/src/apps/listApps.ts
@@ -112,7 +112,9 @@ export const listApps = ({
                 case "device-id": {
                   // Normalize deviceId to DeviceId object (SocketEvent may have string or DeviceId)
                   const deviceIdValue =
-                    typeof e.deviceId === "string" ? DeviceId.fromString(e.deviceId) : e.deviceId;
+                    typeof e.deviceId === "string"
+                      ? DeviceId.fromString(e.deviceId)
+                      : (e.deviceId as DeviceId);
                   o.next({
                     type: "device-id",
                     deviceId: deviceIdValue,

--- a/libs/ledgerjs/packages/types-live/package.json
+++ b/libs/ledgerjs/packages/types-live/package.json
@@ -21,7 +21,6 @@
   "types": "lib/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ledgerhq/client-ids": "workspace:*",
     "bignumber.js": "^9.1.2",
     "rxjs": "catalog:"
   },

--- a/libs/ledgerjs/packages/types-live/src/manager.ts
+++ b/libs/ledgerjs/packages/types-live/src/manager.ts
@@ -1,6 +1,11 @@
 import type { DeviceModelId } from "@ledgerhq/types-devices";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import type { DeviceId } from "@ledgerhq/client-ids/ids";
+
+interface DeviceId {
+  exportDeviceIdForPersistence(): string;
+  exportDeviceIdForPushDevicesService(): string;
+  equals(other: DeviceId): boolean;
+}
 // FIXME we need to clearly differentiate what is API types and what is our inner own type
 export type Id = number;
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -946,12 +946,12 @@ importers:
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/types-live
-      '@ledgerhq/wallet-pnl':
-        specifier: workspace:^
-        version: link:../../libs/wallet-pnl
       '@ledgerhq/wallet-analytics':
         specifier: workspace:^
         version: link:../../libs/wallet-analytics
+      '@ledgerhq/wallet-pnl':
+        specifier: workspace:^
+        version: link:../../libs/wallet-pnl
       '@ledgerhq/zcash-utils':
         specifier: 'catalog:'
         version: 0.3.1
@@ -1641,12 +1641,12 @@ importers:
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/types-live
-      '@ledgerhq/wallet-pnl':
-        specifier: workspace:^
-        version: link:../../libs/wallet-pnl
       '@ledgerhq/wallet-analytics':
         specifier: workspace:^
         version: link:../../libs/wallet-analytics
+      '@ledgerhq/wallet-pnl':
+        specifier: workspace:^
+        version: link:../../libs/wallet-pnl
       '@react-native-async-storage/async-storage':
         specifier: 2.1.2
         version: 2.1.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))
@@ -3626,7 +3626,7 @@ importers:
         version: 0.1.19
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.45(@ledgerhq/lumen-design-core@0.1.19)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
+        version: 0.1.45(@ledgerhq/lumen-design-core@0.1.19)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
         version: 0.1.48(bdae926a59af589d19d78b5b880d45b3)
@@ -10672,9 +10672,6 @@ importers:
 
   libs/ledgerjs/packages/types-live:
     dependencies:
-      '@ledgerhq/client-ids':
-        specifier: workspace:*
-        version: link:../../../client-ids
       bignumber.js:
         specifier: 9.1.2
         version: 9.1.2
@@ -12576,7 +12573,7 @@ importers:
         version: 9.1.2
       jest:
         specifier: 'catalog:'
-        version: 30.2.0
+        version: 30.2.0(@types/node@24.12.0)
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -21850,7 +21847,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -24125,7 +24122,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -45896,16 +45893,14 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.45(@ledgerhq/lumen-design-core@0.1.19)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react@0.1.45(@ledgerhq/lumen-design-core@0.1.19)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
     dependencies:
       '@ledgerhq/lumen-design-core': 0.1.19
       '@ledgerhq/lumen-utils-shared': 0.1.7(react@19.1.4)
-      clsx: 2.1.1
       i18next: 23.10.1
       react: 19.1.4
       react-dom: 19.1.4(react@19.1.4)
       react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      tailwind-merge: 3.4.0
     transitivePeerDependencies:
       - react-native
 
@@ -65137,7 +65132,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -65261,6 +65256,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
### 📝 Description

types-live/src/manager.ts was importing the concrete DeviceId class from @ledgerhq/client-ids only to type one field in the SocketEvent discriminated union. This pulled a heavy application-level dep into a foundational types package.

The fix inlines a minimal structural DeviceId interface in manager.ts (3 public methods). The concrete class in client-ids satisfies it structurally — no casts, no changes in live-common or client-ids.

With types-live no longer depending on it, no public package depends on @ledgerhq/client-ids anymore, so it is now marked private.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34030](https://ledgerhq.atlassian.net/browse/LIVE-34030)
- **ADR** (if any): N/A

[LIVE-34030]: https://ledgerhq.atlassian.net/browse/LIVE-34030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ