### PR TITLE
[LWM] Feat(LIVE-30499): aleo private list ops mobile changes

### DIFF
--- a/.changeset/witty-planets-talk.md
+++ b/.changeset/witty-planets-talk.md
@@ -2,4 +2,4 @@
 "live-mobile": minor
 ---
 
-added type badge into mobile list ops for Aleo
+add a private/public transaction type badge to Aleo operation status icons on mobile

--- a/.changeset/witty-planets-talk.md
+++ b/.changeset/witty-planets-talk.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+added type badge into mobile list ops for Aleo

--- a/apps/ledger-live-mobile/src/families/aleo/__tests__/operationDetails.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/__tests__/operationDetails.test.tsx
@@ -4,7 +4,8 @@ import type { AleoOperation } from "@ledgerhq/live-common/families/aleo/types";
 import { ALEO_ACCOUNT_1 } from "../__mocks__/account.mock";
 import operationDetails from "../operationDetails";
 
-const { OperationDetailsExtra } = operationDetails;
+const { OperationDetailsExtra, operationStatusIcon } = operationDetails;
+const AleoOperationStatusIcon = operationStatusIcon.OUT;
 
 describe("OperationDetailsExtra", () => {
   it("should only render functionId and not expose transactionType or patched", () => {
@@ -24,5 +25,40 @@ describe("OperationDetailsExtra", () => {
     expect(screen.queryByText("transactionType")).not.toBeOnTheScreen();
     expect(screen.queryByText("public")).not.toBeOnTheScreen();
     expect(screen.queryByText("patched")).not.toBeOnTheScreen();
+  });
+});
+
+describe("operationStatusIcon", () => {
+  it("renders a shield badge labeled Private for a private transaction", () => {
+    const mockOperation: AleoOperation = {
+      ...ALEO_ACCOUNT_1.operations[0],
+      extra: { functionId: "transfer_private", transactionType: "private" },
+    };
+
+    render(<AleoOperationStatusIcon operation={mockOperation} confirmed type="OUT" size={40} />);
+
+    expect(screen.getByLabelText("Private")).toBeOnTheScreen();
+  });
+
+  it("renders a globe badge labeled Public for a public transaction", () => {
+    const mockOperation: AleoOperation = {
+      ...ALEO_ACCOUNT_1.operations[0],
+      extra: { functionId: "transfer_public", transactionType: "public" },
+    };
+
+    render(<AleoOperationStatusIcon operation={mockOperation} confirmed type="OUT" size={40} />);
+
+    expect(screen.getByLabelText("Public")).toBeOnTheScreen();
+  });
+
+  it("renders no badge when transactionType is missing", () => {
+    const mockOperation: AleoOperation = {
+      ...ALEO_ACCOUNT_1.operations[0],
+      extra: { functionId: "transfer_public" } as AleoOperation["extra"],
+    };
+
+    render(<AleoOperationStatusIcon operation={mockOperation} confirmed type="OUT" size={40} />);
+
+    expect(screen.queryByLabelText(/Private|Public/)).not.toBeOnTheScreen();
   });
 });

--- a/apps/ledger-live-mobile/src/families/aleo/operationDetails.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/operationDetails.tsx
@@ -1,8 +1,13 @@
 import React from "react";
+import { StyleSheet } from "react-native";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { Globe, ShieldLock } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { getOperationDetailsExtraFields } from "@ledgerhq/live-common/families/aleo/utils";
-import type { AleoOperation } from "@ledgerhq/live-common/families/aleo/types";
+import type { AleoOperation, AleoTransactionType } from "@ledgerhq/live-common/families/aleo/types";
+import type { Operation, OperationType } from "@ledgerhq/types-live";
 import { useTranslation } from "~/context/Locale";
 import Section from "~/screens/OperationDetails/Section";
+import OperationStatusIcon from "~/icons/OperationStatusIcon";
 
 interface OperationDetailsExtraProps {
   operation: AleoOperation;
@@ -26,6 +31,103 @@ const OperationDetailsExtra = ({ operation }: OperationDetailsExtraProps) => {
   );
 };
 
+const mapTransactionTypeToTranslationKey: Record<AleoTransactionType, string> = {
+  public: "aleo.operations.type.public",
+  private: "aleo.operations.type.private",
+};
+
+const mapTransactionTypeToIcon: Record<AleoTransactionType, typeof ShieldLock> = {
+  public: Globe,
+  private: ShieldLock,
+};
+
+// Badge scales with the main icon (e.g. 40px in the list row vs 57px in
+// operation details), so it stays visually consistent across both screens.
+const BADGE_SIZE_RATIO = 0.5;
+const BADGE_ICON_SIZE_RATIO = 0.6;
+const BADGE_ICON_STROKE_WIDTH = 1;
+
+interface AleoOperationStatusIconProps {
+  operation: Operation;
+  confirmed: boolean;
+  type: OperationType;
+  failed?: boolean;
+  size: number;
+}
+
+// Renders the usual incoming/outgoing status icon, with a small bordered shield
+// (private) or globe (public) badge overflowing off its bottom-right corner —
+// same visual style (border + base background) as the status icon itself.
+const AleoOperationStatusIcon = ({
+  operation,
+  confirmed,
+  type,
+  failed,
+  size,
+}: AleoOperationStatusIconProps) => {
+  const { t } = useTranslation();
+  const transactionType = (operation as AleoOperation).extra?.transactionType;
+  const BadgeIcon = transactionType && mapTransactionTypeToIcon[transactionType];
+
+  const statusIcon = (
+    <OperationStatusIcon confirmed={confirmed} type={type} failed={failed} size={size} />
+  );
+
+  if (!transactionType || !BadgeIcon) {
+    return statusIcon;
+  }
+
+  const badgeSize = Math.round(size * BADGE_SIZE_RATIO);
+  const badgeIconSize = Math.round(badgeSize * BADGE_ICON_SIZE_RATIO);
+  const offset = Math.round(-(badgeSize / 2 - 4));
+
+  return (
+    <Box style={styles.container}>
+      {statusIcon}
+      <Box
+        lx={{
+          borderRadius: "full",
+          borderWidth: "s1",
+          borderColor: "mutedSubtle",
+          backgroundColor: "base",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+        style={[
+          styles.badge,
+          { width: badgeSize, height: badgeSize, bottom: offset, right: offset },
+        ]}
+        accessible
+        accessibilityLabel={t(mapTransactionTypeToTranslationKey[transactionType])}
+      >
+        <BadgeIcon
+          width={badgeIconSize}
+          height={badgeIconSize}
+          color="base"
+          strokeWidth={BADGE_ICON_STROKE_WIDTH}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: "relative",
+  },
+  badge: {
+    position: "absolute",
+  },
+});
+
+const operationStatusIcon = {
+  OUT: AleoOperationStatusIcon,
+  IN: AleoOperationStatusIcon,
+  FEES: AleoOperationStatusIcon,
+  NONE: AleoOperationStatusIcon,
+};
+
 export default {
   OperationDetailsExtra,
+  operationStatusIcon,
 };

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10090,6 +10090,12 @@
         "syncAgain": "Sync again",
         "lastSync": "Last synced: {{date}}"
       }
+    },
+    "operations": {
+      "type": {
+        "public": "Public",
+        "private": "Private"
+      }
     }
   }
 }


### PR DESCRIPTION
### 📝 Description

Adds a visual badge to the Aleo operation status icon to distinguish **private** (shielded) from **public** (transparent) transactions, both in the operation list and on the operation details screen.

- `operationStatusIcon` (shield/globe badge overlaid on the existing IN/OUT/FEES/NONE status icon) is now exported from `operationDetails.tsx` and wired up for all operation types.
- The badge is derived from `operation.extra.transactionType` (`"private"` → shield icon, `"public"` → globe icon); operations without a `transactionType` fall back to the plain status icon, unchanged.
- Badge size scales relative to the parent icon (`BADGE_SIZE_RATIO` / `BADGE_ICON_SIZE_RATIO`) so it stays visually consistent between the smaller list-row icon (40px) and the larger operation-details icon (57px).
- Badge is accessible via `accessibilityLabel`, using new `aleo.operations.type.public` / `aleo.operations.type.private` locale strings.
- Added tests covering: private badge rendering, public badge rendering, and no-badge fallback when `transactionType` is missing.

Example screens: 

<img width="1080" height="2400" alt="Screenshot_2026-07-07-13-04-47-229_com ledger live debug" src="https://github.com/user-attachments/assets/37e3b30a-477f-4477-8364-771ff18b9275" />
<img width="1080" height="2400" alt="Screenshot_2026-07-07-13-04-09-398_com ledger live debug" src="https://github.com/user-attachments/assets/4d8127f5-07d7-4b5c-965b-93657326d97f" />
<img width="1080" height="2400" alt="Screenshot_2026-07-07-13-04-16-522_com ledger live debug" src="https://github.com/user-attachments/assets/4f072555-aea3-4be0-93e9-c73e326e8b15" />


### 🔗 Context

- **JIRA / GitHub issue**:  [https://ledgerhq.atlassian.net/browse/LIVE-30499](https://ledgerhq.atlassian.net/browse/LIVE-30499)
