### PR TITLE
[LWM] feat(lwm): upsell eligibility gate (audience + cooldown)

### DIFF
--- a/.changeset/dull-weeks-camp.md
+++ b/.changeset/dull-weeks-camp.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat(lwm): upsell eligibility gate (audience + cooldown)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -435,6 +435,7 @@ apps/ledger-live-mobile/src/mvvm/features/ProductTour/                          
 apps/ledger-live-mobile/src/mvvm/features/Q2WalletV4Tour/                                       @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/BackupHub/                                           @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/LNSUpsell/                                           @ledgerhq/engagement
+apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/                                   @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/Reborn/                                              @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/                               @ledgerhq/engagement
 apps/ledger-live-mobile/src/mvvm/components/FeatureIntroLayout/                                @ledgerhq/engagement

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/largeScreenUpsellEligibility.integration.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/largeScreenUpsellEligibility.integration.test.ts
@@ -4,18 +4,6 @@ import { renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { useLargeScreenUpsellEligibility } from "..";
 import type { State } from "~/reducers/types";
 
-jest.mock("react-native-mmkv", () => ({
-  createMMKV: jest.fn(() => ({
-    clearAll: jest.fn(),
-    contains: jest.fn(() => false),
-    getAllKeys: jest.fn(() => []),
-    getString: jest.fn(),
-    remove: jest.fn(),
-    set: jest.fn(),
-    size: 0,
-  })),
-}));
-
 jest.mock(
   "@ledgerhq/live-common/postOnboarding/logic/upsellFrequency",
   () => ({

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/largeScreenUpsellEligibility.integration.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/largeScreenUpsellEligibility.integration.test.ts
@@ -1,0 +1,86 @@
+import { DeviceModelId } from "@ledgerhq/devices";
+import { isCooldownElapsed } from "@ledgerhq/live-common/postOnboarding/logic/upsellFrequency";
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { useLargeScreenUpsellEligibility } from "..";
+import type { State } from "~/reducers/types";
+
+jest.mock("react-native-mmkv", () => ({
+  createMMKV: jest.fn(() => ({
+    clearAll: jest.fn(),
+    contains: jest.fn(() => false),
+    getAllKeys: jest.fn(() => []),
+    getString: jest.fn(),
+    remove: jest.fn(),
+    set: jest.fn(),
+    size: 0,
+  })),
+}));
+
+jest.mock(
+  "@ledgerhq/live-common/postOnboarding/logic/upsellFrequency",
+  () => ({
+    isCooldownElapsed: jest.fn(),
+  }),
+  { virtual: true },
+);
+
+const mockedIsCooldownElapsed = jest.mocked(isCooldownElapsed);
+
+function withKnownDeviceModels(deviceModelIds: DeviceModelId[]) {
+  return (state: State): State => ({
+    ...state,
+    settings: {
+      ...state.settings,
+      knownDeviceModelIds: {
+        ...state.settings.knownDeviceModelIds,
+        ...Object.fromEntries(deviceModelIds.map(deviceModelId => [deviceModelId, true])),
+      },
+    },
+    postOnboarding: {
+      ...state.postOnboarding,
+      onboardingDate: "2026-06-01T12:00:00.000Z",
+    },
+  });
+}
+
+describe("large screen upsell eligibility integration", () => {
+  beforeEach(() => {
+    mockedIsCooldownElapsed.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should be eligible when the feature is enabled and only a nano has been seen", () => {
+    const { result } = renderHook(() => useLargeScreenUpsellEligibility(), {
+      overrideInitialState: withFlagOverrides(
+        { largeScreenUpsell: { enabled: true } },
+        withKnownDeviceModels([DeviceModelId.nanoS]),
+      ),
+    });
+
+    expect(result.current).toEqual({
+      isEligible: true,
+      deviceModelId: DeviceModelId.nanoS,
+      cooldownDays: 0,
+    });
+    expect(mockedIsCooldownElapsed).toHaveBeenCalledWith(
+      new Date("2026-06-01T12:00:00.000Z"),
+      0,
+      expect.any(Date),
+    );
+  });
+
+  it("should be ineligible for dual owners who have seen a nano and a touchscreen device", () => {
+    const { result } = renderHook(() => useLargeScreenUpsellEligibility(), {
+      overrideInitialState: withFlagOverrides(
+        { largeScreenUpsell: { enabled: true } },
+        withKnownDeviceModels([DeviceModelId.nanoX, DeviceModelId.stax]),
+      ),
+    });
+
+    expect(result.current).toEqual({ isEligible: false, reason: "touchscreen_seen" });
+    expect(mockedIsCooldownElapsed).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/__tests__/useLargeScreenUpsellEligibility.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/__tests__/useLargeScreenUpsellEligibility.test.ts
@@ -1,56 +1,11 @@
 import { DeviceModelId } from "@ledgerhq/devices";
-import { renderHook } from "@testing-library/react-native";
-import { useFeature } from "@features/platform-feature-flags";
-import { useSelector } from "~/context/hooks";
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { useLargeScreenUpsellEligibility } from "../useLargeScreenUpsellEligibility";
 import type { State } from "~/reducers/types";
-import type { Features } from "@shared/feature-flags";
-
-jest.mock("@features/platform-feature-flags", () => ({
-  useFeature: jest.fn(),
-}));
-
-jest.mock("~/context/hooks", () => ({
-  useSelector: jest.fn(),
-}));
 
 const NOW = new Date("2026-07-06T12:00:00.000Z");
 
-type LargeScreenUpsellFeature = Features["largeScreenUpsell"];
-type LargeScreenUpsellParams = NonNullable<LargeScreenUpsellFeature["params"]>;
 type NanoDeviceModelId = DeviceModelId.nanoS | DeviceModelId.nanoSP | DeviceModelId.nanoX;
-
-const DEFAULT_KNOWN_DEVICE_MODEL_IDS: Record<DeviceModelId, boolean> = {
-  [DeviceModelId.blue]: false,
-  [DeviceModelId.nanoS]: false,
-  [DeviceModelId.nanoSP]: false,
-  [DeviceModelId.nanoX]: false,
-  [DeviceModelId.stax]: false,
-  [DeviceModelId.europa]: false,
-  [DeviceModelId.apex]: false,
-};
-
-const DEFAULT_PARAMS: LargeScreenUpsellParams = {
-  audience: {
-    models: {
-      [DeviceModelId.nanoS]: true,
-      [DeviceModelId.nanoSP]: true,
-      [DeviceModelId.nanoX]: true,
-    },
-  },
-  cooldownDays: {
-    default: 30,
-    [DeviceModelId.nanoS]: 0,
-  },
-  discount: 0.2,
-  modal: {
-    enabled: true,
-    killThreshold: 3,
-    cadenceDays: 30,
-  },
-  opted_in: { link: "https://example.com/opt-in" },
-  opted_out: { link: "https://example.com/opt-out" },
-};
 
 type RenderOptions = {
   enabled?: boolean;
@@ -65,31 +20,38 @@ function renderEligibility({
   onboardingDate = "2026-06-01T12:00:00.000Z",
   audienceModels,
 }: RenderOptions = {}) {
-  const mockUseFeature = jest.mocked(useFeature);
-  const mockUseSelector = jest.mocked(useSelector);
-  const state = {
+  const withState = (state: State): State => ({
+    ...state,
     settings: {
+      ...state.settings,
       knownDeviceModelIds: {
-        ...DEFAULT_KNOWN_DEVICE_MODEL_IDS,
+        ...state.settings.knownDeviceModelIds,
         ...Object.fromEntries(knownDeviceModelIds.map(deviceModelId => [deviceModelId, true])),
       },
     },
-    postOnboarding: { onboardingDate },
-  } as State;
-  const params: LargeScreenUpsellParams = {
-    ...DEFAULT_PARAMS,
-    audience: {
-      models: {
-        ...DEFAULT_PARAMS.audience.models,
-        ...audienceModels,
-      },
+    postOnboarding: {
+      ...state.postOnboarding,
+      onboardingDate,
     },
-  };
+  });
 
-  mockUseFeature.mockReturnValue({ enabled, params } as LargeScreenUpsellFeature);
-  mockUseSelector.mockImplementation(selector => (selector as (state: State) => unknown)(state));
-
-  return renderHook(() => useLargeScreenUpsellEligibility());
+  return renderHook(() => useLargeScreenUpsellEligibility(), {
+    overrideInitialState: withFlagOverrides(
+      {
+        largeScreenUpsell: {
+          enabled,
+          ...(audienceModels && {
+            params: {
+              audience: {
+                models: { nanoS: true, nanoSP: true, nanoX: true, ...audienceModels },
+              },
+            },
+          }),
+        },
+      },
+      withState,
+    ),
+  });
 }
 
 describe("useLargeScreenUpsellEligibility", () => {
@@ -99,7 +61,6 @@ describe("useLargeScreenUpsellEligibility", () => {
 
   afterEach(() => {
     jest.useRealTimers();
-    jest.clearAllMocks();
   });
 
   it("should be ineligible when the largeScreenUpsell flag is off", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/__tests__/useLargeScreenUpsellEligibility.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/__tests__/useLargeScreenUpsellEligibility.test.ts
@@ -1,0 +1,218 @@
+import { DeviceModelId } from "@ledgerhq/devices";
+import { renderHook } from "@testing-library/react-native";
+import { useFeature } from "@features/platform-feature-flags";
+import { useSelector } from "~/context/hooks";
+import { useLargeScreenUpsellEligibility } from "../useLargeScreenUpsellEligibility";
+import type { State } from "~/reducers/types";
+import type { Features } from "@shared/feature-flags";
+
+jest.mock("@features/platform-feature-flags", () => ({
+  useFeature: jest.fn(),
+}));
+
+jest.mock("~/context/hooks", () => ({
+  useSelector: jest.fn(),
+}));
+
+const NOW = new Date("2026-07-06T12:00:00.000Z");
+
+type LargeScreenUpsellFeature = Features["largeScreenUpsell"];
+type LargeScreenUpsellParams = NonNullable<LargeScreenUpsellFeature["params"]>;
+type NanoDeviceModelId = DeviceModelId.nanoS | DeviceModelId.nanoSP | DeviceModelId.nanoX;
+
+const DEFAULT_KNOWN_DEVICE_MODEL_IDS: Record<DeviceModelId, boolean> = {
+  [DeviceModelId.blue]: false,
+  [DeviceModelId.nanoS]: false,
+  [DeviceModelId.nanoSP]: false,
+  [DeviceModelId.nanoX]: false,
+  [DeviceModelId.stax]: false,
+  [DeviceModelId.europa]: false,
+  [DeviceModelId.apex]: false,
+};
+
+const DEFAULT_PARAMS: LargeScreenUpsellParams = {
+  audience: {
+    models: {
+      [DeviceModelId.nanoS]: true,
+      [DeviceModelId.nanoSP]: true,
+      [DeviceModelId.nanoX]: true,
+    },
+  },
+  cooldownDays: {
+    default: 30,
+    [DeviceModelId.nanoS]: 0,
+  },
+  discount: 0.2,
+  modal: {
+    enabled: true,
+    killThreshold: 3,
+    cadenceDays: 30,
+  },
+  opted_in: { link: "https://example.com/opt-in" },
+  opted_out: { link: "https://example.com/opt-out" },
+};
+
+type RenderOptions = {
+  enabled?: boolean;
+  knownDeviceModelIds?: DeviceModelId[];
+  onboardingDate?: string | null;
+  audienceModels?: Partial<Record<NanoDeviceModelId, boolean>>;
+};
+
+function renderEligibility({
+  enabled = true,
+  knownDeviceModelIds = [],
+  onboardingDate = "2026-06-01T12:00:00.000Z",
+  audienceModels,
+}: RenderOptions = {}) {
+  const mockUseFeature = jest.mocked(useFeature);
+  const mockUseSelector = jest.mocked(useSelector);
+  const state = {
+    settings: {
+      knownDeviceModelIds: {
+        ...DEFAULT_KNOWN_DEVICE_MODEL_IDS,
+        ...Object.fromEntries(knownDeviceModelIds.map(deviceModelId => [deviceModelId, true])),
+      },
+    },
+    postOnboarding: { onboardingDate },
+  } as State;
+  const params: LargeScreenUpsellParams = {
+    ...DEFAULT_PARAMS,
+    audience: {
+      models: {
+        ...DEFAULT_PARAMS.audience.models,
+        ...audienceModels,
+      },
+    },
+  };
+
+  mockUseFeature.mockReturnValue({ enabled, params } as LargeScreenUpsellFeature);
+  mockUseSelector.mockImplementation(selector => (selector as (state: State) => unknown)(state));
+
+  return renderHook(() => useLargeScreenUpsellEligibility());
+}
+
+describe("useLargeScreenUpsellEligibility", () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it("should be ineligible when the largeScreenUpsell flag is off", () => {
+    const { result } = renderEligibility({
+      enabled: false,
+      knownDeviceModelIds: [DeviceModelId.nanoS],
+    });
+
+    expect(result.current).toEqual({ isEligible: false, reason: "feature_disabled" });
+  });
+
+  it("should be ineligible when no nano device has been seen", () => {
+    const { result } = renderEligibility();
+
+    expect(result.current).toEqual({ isEligible: false, reason: "no_nano" });
+  });
+
+  it.each([DeviceModelId.stax, DeviceModelId.europa, DeviceModelId.apex])(
+    "should be ineligible when only touchscreen device %s has been seen",
+    deviceModelId => {
+      const { result } = renderEligibility({ knownDeviceModelIds: [deviceModelId] });
+
+      expect(result.current).toEqual({ isEligible: false, reason: "touchscreen_seen" });
+    },
+  );
+
+  it("should exclude dual owners who have seen a nano and a touchscreen device", () => {
+    const { result } = renderEligibility({
+      knownDeviceModelIds: [DeviceModelId.nanoS, DeviceModelId.stax],
+    });
+
+    expect(result.current).toEqual({ isEligible: false, reason: "touchscreen_seen" });
+  });
+
+  it("should make Nano S eligible from day 0", () => {
+    const { result } = renderEligibility({
+      knownDeviceModelIds: [DeviceModelId.nanoS],
+      onboardingDate: NOW.toISOString(),
+    });
+
+    expect(result.current).toEqual({
+      isEligible: true,
+      deviceModelId: DeviceModelId.nanoS,
+      cooldownDays: 0,
+    });
+  });
+
+  it.each([DeviceModelId.nanoSP, DeviceModelId.nanoX])(
+    "should suppress %s during the 30-day cooldown",
+    deviceModelId => {
+      const { result } = renderEligibility({
+        knownDeviceModelIds: [deviceModelId],
+        onboardingDate: "2026-06-07T12:00:00.000Z",
+      });
+
+      expect(result.current).toEqual({
+        isEligible: false,
+        reason: "cooldown",
+        deviceModelId,
+        cooldownDays: 30,
+      });
+    },
+  );
+
+  it.each([DeviceModelId.nanoSP, DeviceModelId.nanoX])(
+    "should make %s eligible on the 30-day cooldown boundary",
+    deviceModelId => {
+      const { result } = renderEligibility({
+        knownDeviceModelIds: [deviceModelId],
+        onboardingDate: "2026-06-06T12:00:00.000Z",
+      });
+
+      expect(result.current).toEqual({
+        isEligible: true,
+        deviceModelId,
+        cooldownDays: 30,
+      });
+    },
+  );
+
+  it("should be ineligible when the seen nano model is disabled in the audience params", () => {
+    const { result } = renderEligibility({
+      knownDeviceModelIds: [DeviceModelId.nanoS],
+      audienceModels: { nanoS: false },
+    });
+
+    expect(result.current).toEqual({ isEligible: false, reason: "model_disabled" });
+  });
+
+  it("should treat a null onboarding date as eligible defensively", () => {
+    const { result } = renderEligibility({
+      knownDeviceModelIds: [DeviceModelId.nanoX],
+      onboardingDate: null,
+    });
+
+    expect(result.current).toEqual({
+      isEligible: true,
+      deviceModelId: DeviceModelId.nanoX,
+      cooldownDays: 30,
+    });
+  });
+
+  it("should use the longest cooldown when multiple eligible nano models have been seen", () => {
+    const { result } = renderEligibility({
+      knownDeviceModelIds: [DeviceModelId.nanoS, DeviceModelId.nanoX],
+      onboardingDate: NOW.toISOString(),
+    });
+
+    expect(result.current).toEqual({
+      isEligible: false,
+      reason: "cooldown",
+      deviceModelId: DeviceModelId.nanoX,
+      cooldownDays: 30,
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/useLargeScreenUpsellEligibility.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/useLargeScreenUpsellEligibility.ts
@@ -1,6 +1,6 @@
-import { DeviceModelId } from "@ledgerhq/devices";
 import { isCooldownElapsed } from "@ledgerhq/live-common/postOnboarding/logic/upsellFrequency";
 import { onboardingDateSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
+import { DeviceModelId, DevicesWithTouchScreen } from "@ledgerhq/types-devices";
 import { useFeature } from "@features/platform-feature-flags";
 import { useSelector } from "~/context/hooks";
 import { knownDeviceModelIdsSelector } from "~/reducers/settings";
@@ -10,12 +10,6 @@ const NANO_DEVICE_MODEL_IDS = [
   DeviceModelId.nanoSP,
   DeviceModelId.nanoX,
 ] as const;
-
-const TOUCHSCREEN_DEVICE_MODEL_IDS = new Set<DeviceModelId>([
-  DeviceModelId.apex,
-  DeviceModelId.europa,
-  DeviceModelId.stax,
-]);
 
 type NanoDeviceModelId = (typeof NANO_DEVICE_MODEL_IDS)[number];
 
@@ -49,13 +43,7 @@ function getSeenNanoDeviceModelIds(
 }
 
 function hasSeenTouchscreenDevice(knownDeviceModelIds: Record<DeviceModelId, boolean>): boolean {
-  for (const deviceModelId of TOUCHSCREEN_DEVICE_MODEL_IDS) {
-    if (knownDeviceModelIds[deviceModelId]) {
-      return true;
-    }
-  }
-
-  return false;
+  return DevicesWithTouchScreen.some(deviceModelId => knownDeviceModelIds[deviceModelId]);
 }
 
 function selectCooldownDeviceModelId(

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/useLargeScreenUpsellEligibility.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/useLargeScreenUpsellEligibility.ts
@@ -1,0 +1,110 @@
+import { DeviceModelId } from "@ledgerhq/devices";
+import { isCooldownElapsed } from "@ledgerhq/live-common/postOnboarding/logic/upsellFrequency";
+import { onboardingDateSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
+import { useFeature } from "@features/platform-feature-flags";
+import { useSelector } from "~/context/hooks";
+import { knownDeviceModelIdsSelector } from "~/reducers/settings";
+
+const NANO_DEVICE_MODEL_IDS = [
+  DeviceModelId.nanoS,
+  DeviceModelId.nanoSP,
+  DeviceModelId.nanoX,
+] as const;
+
+const TOUCHSCREEN_DEVICE_MODEL_IDS = new Set<DeviceModelId>([
+  DeviceModelId.apex,
+  DeviceModelId.europa,
+  DeviceModelId.stax,
+]);
+
+type NanoDeviceModelId = (typeof NANO_DEVICE_MODEL_IDS)[number];
+
+type CooldownDays = { default: number } & Partial<Record<NanoDeviceModelId, number>>;
+
+export type LargeScreenUpsellIneligibilityReason =
+  | "feature_disabled"
+  | "no_nano"
+  | "touchscreen_seen"
+  | "model_disabled"
+  | "cooldown";
+
+export type LargeScreenUpsellEligibility =
+  | { isEligible: true; deviceModelId: NanoDeviceModelId; cooldownDays: number }
+  | { isEligible: false; reason: Exclude<LargeScreenUpsellIneligibilityReason, "cooldown"> }
+  | {
+      isEligible: false;
+      reason: "cooldown";
+      deviceModelId: NanoDeviceModelId;
+      cooldownDays: number;
+    };
+
+function resolveCooldownDays(cooldownDays: CooldownDays, deviceModelId: NanoDeviceModelId): number {
+  return cooldownDays[deviceModelId] ?? cooldownDays.default;
+}
+
+function getSeenNanoDeviceModelIds(
+  knownDeviceModelIds: Record<DeviceModelId, boolean>,
+): NanoDeviceModelId[] {
+  return NANO_DEVICE_MODEL_IDS.filter(deviceModelId => knownDeviceModelIds[deviceModelId]);
+}
+
+function hasSeenTouchscreenDevice(knownDeviceModelIds: Record<DeviceModelId, boolean>): boolean {
+  for (const deviceModelId of TOUCHSCREEN_DEVICE_MODEL_IDS) {
+    if (knownDeviceModelIds[deviceModelId]) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function selectCooldownDeviceModelId(
+  deviceModelIds: NanoDeviceModelId[],
+  cooldownDays: CooldownDays,
+): NanoDeviceModelId {
+  const [firstDeviceModelId, ...restDeviceModelIds] = deviceModelIds;
+
+  return restDeviceModelIds.reduce((selectedDeviceModelId, deviceModelId) => {
+    const selectedCooldownDays = resolveCooldownDays(cooldownDays, selectedDeviceModelId);
+    const candidateCooldownDays = resolveCooldownDays(cooldownDays, deviceModelId);
+
+    return candidateCooldownDays > selectedCooldownDays ? deviceModelId : selectedDeviceModelId;
+  }, firstDeviceModelId);
+}
+
+export function useLargeScreenUpsellEligibility(): LargeScreenUpsellEligibility {
+  const feature = useFeature("largeScreenUpsell");
+  const knownDeviceModelIds = useSelector(knownDeviceModelIdsSelector);
+  const onboardingDate = useSelector(onboardingDateSelector);
+
+  const params = feature?.params;
+  if (!feature?.enabled || !params) {
+    return { isEligible: false, reason: "feature_disabled" };
+  }
+
+  if (hasSeenTouchscreenDevice(knownDeviceModelIds)) {
+    return { isEligible: false, reason: "touchscreen_seen" };
+  }
+
+  const seenNanoDeviceModelIds = getSeenNanoDeviceModelIds(knownDeviceModelIds);
+  if (seenNanoDeviceModelIds.length === 0) {
+    return { isEligible: false, reason: "no_nano" };
+  }
+
+  const enabledNanoDeviceModelIds = seenNanoDeviceModelIds.filter(
+    deviceModelId => params.audience.models[deviceModelId],
+  );
+
+  if (enabledNanoDeviceModelIds.length === 0) {
+    return { isEligible: false, reason: "model_disabled" };
+  }
+
+  const deviceModelId = selectCooldownDeviceModelId(enabledNanoDeviceModelIds, params.cooldownDays);
+  const cooldownDays = resolveCooldownDays(params.cooldownDays, deviceModelId);
+
+  if (!isCooldownElapsed(onboardingDate, cooldownDays, new Date())) {
+    return { isEligible: false, reason: "cooldown", deviceModelId, cooldownDays };
+  }
+
+  return { isEligible: true, deviceModelId, cooldownDays };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/index.ts
@@ -1,0 +1,5 @@
+export {
+  useLargeScreenUpsellEligibility,
+  type LargeScreenUpsellEligibility,
+  type LargeScreenUpsellIneligibilityReason,
+} from "./hooks/useLargeScreenUpsellEligibility";


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Shared large-screen upsell eligibility gate for LWM: eligible only if the user has connected a nano (LNS/LNSP/LNX) and never a touchscreen device (Gen5/Flex/Stax); dual-owners excluded. 
Per-model cooldown (LNSP/LNX: 30d, LNS: day 0) via the shared `isCooldownElapsed` helper. Flag off ⇒ not eligible.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-33153]<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-33153]: https://ledgerhq.atlassian.net/browse/LIVE-33153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ