### PR TITLE
[LWM] fix(LIVE-30499): resolved issue with polyfill

### DIFF
--- a/.changeset/twelve-laws-cheer.md
+++ b/.changeset/twelve-laws-cheer.md
@@ -1,5 +1,5 @@
 ---
-"live-mobile": minor
+"live-mobile": patch
 ---
 
-resolved issues with polyfill for ios
+Fix iOS errors by polyfilling AbortSignal.throwIfAborted

--- a/.changeset/twelve-laws-cheer.md
+++ b/.changeset/twelve-laws-cheer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+resolved issues with polyfill for ios

--- a/apps/ledger-live-mobile/src/polyfill.ts
+++ b/apps/ledger-live-mobile/src/polyfill.ts
@@ -37,9 +37,8 @@ if (!console.assert) {
 
 process.browser = true; // for readable-stream/lib/_stream_writable.js
 
-// // Polyfill for AbortSignal.throwIfAborted on Android
-const isAndroid = Platform.OS === "android";
-if (isAndroid && typeof AbortSignal !== "undefined" && !AbortSignal.prototype.throwIfAborted) {
+// // Polyfill for AbortSignal.throwIfAborted
+if (typeof AbortSignal !== "undefined" && !AbortSignal.prototype.throwIfAborted) {
   AbortSignal.prototype.throwIfAborted = function () {
     if (this.aborted) {
       throw new DOMException("The operation was aborted.", "AbortError");

--- a/apps/ledger-live-mobile/src/polyfill.ts
+++ b/apps/ledger-live-mobile/src/polyfill.ts
@@ -17,7 +17,6 @@ loadLocaleData(defaultLanguage);
 
 // Fix error when adding Solana account
 import "@azure/core-asynciterator-polyfill";
-import { Platform } from "react-native";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 global.Buffer = require("buffer").Buffer;
@@ -37,7 +36,7 @@ if (!console.assert) {
 
 process.browser = true; // for readable-stream/lib/_stream_writable.js
 
-// // Polyfill for AbortSignal.throwIfAborted
+// Polyfill for AbortSignal.throwIfAborted
 if (typeof AbortSignal !== "undefined" && !AbortSignal.prototype.throwIfAborted) {
   AbortSignal.prototype.throwIfAborted = function () {
     if (this.aborted) {


### PR DESCRIPTION
### 📝 Description

Fixes a crash/error on iOS caused by `AbortSignal.prototype.throwIfAborted` polyfill being applied only on Android.

**Previous behaviour:** the polyfill in `polyfill.ts` was gated behind `Platform.OS === "android"`, so iOS never got `AbortSignal.throwIfAborted` defined. Any code path relying on it (e.g. abort-aware fetch/request handling) threw on iOS where the native/JS engine doesn't provide it.

**Fix:** removed the Android-only guard so the polyfill applies on all platforms whenever `AbortSignal.throwIfAborted` isn't already provided by the engine.

Screenshot with errors preview: 

<img width="518" height="1031" alt="polyfill" src="https://github.com/user-attachments/assets/28be4bd4-f9db-4c5f-950d-73c9eafbd078" />

### 🔗 Context

- **JIRA / GitHub issue**: [https://ledgerhq.atlassian.net/browse/LIVE-30499](https://ledgerhq.atlassian.net/browse/LIVE-30499)
