### PR TITLE
test: fix libs graph for e2e mobile

### DIFF
--- a/e2e/mobile/project.json
+++ b/e2e/mobile/project.json
@@ -3,7 +3,7 @@
   "targets": {
     "build-e2e-deps": {
       "executor": "nx:noop",
-      "dependsOn": ["^build", "@ledgerhq/live-cli:build"]
+      "dependsOn": ["^build", "@ledgerhq/live-cli:build", "live-mobile:build"]
     },
     "e2e:ci": {
       "executor": "nx:run-script",


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Fix the failing mobile native build after switching to the nx build-e2e-deps target. Added live-mobile:build to that target's dependsOn in e2e/mobile/project.json

### 🔗 Context

- E2E [Smoke](https://github.com/LedgerHQ/ledger-live/actions/runs/28873182516)
