### PR TITLE
feat(feature-flags): add lwdPayTab flag for desktop Pay tab

### DIFF
--- a/.changeset/witty-jokes-cheer.md
+++ b/.changeset/witty-jokes-cheer.md
@@ -1,0 +1,5 @@
+---
+"@shared/feature-flags": minor
+---
+
+add lwdPayTab feature flag for desktop Pay tab

--- a/shared/feature-flags/src/flags/team-wallet-xp/index.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/index.ts
@@ -21,3 +21,4 @@ export * from "./lwmWallet40";
 export * from "./lwmQuickActionsCtasVariant";
 export * from "./llmTransferButtonCopyVariant";
 export * from "./llRobinhoodDisclaimer";
+export * from "./lwdPayTab";

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwdPayTab.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwdPayTab.ts
@@ -1,0 +1,2 @@
+import { flag } from "../../define";
+export const lwdPayTab = flag();


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Feature flag addition with no logic to test._
- [x] **Impact of the changes:**
  - The `lwdPayTab` flag is off by default — no visible change for users until the flag is enabled.

### 📝 Description

This PR introduces the `lwdPayTab` feature flag for the Ledger Live Desktop Pay tab.

The flag is disabled by default and gates the Pay tab UI on desktop, allowing gradual rollout and controlled activation via the feature flag system.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34078](https://ledgerhq.atlassian.net/browse/LIVE-34078)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34078]: https://ledgerhq.atlassian.net/browse/LIVE-34078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ