### PR TITLE
chore: add coin-modules to coin-integration CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -118,6 +118,7 @@ libs/domain-service/                                                @ledgerhq/co
 libs/evm-tools/                                                     @ledgerhq/coin-integration
 libs/ledger-live-common/src/bot/                                    @ledgerhq/coin-integration
 libs/ledger-live-common/src/bridge/                                 @ledgerhq/coin-integration
+libs/ledger-live-common/src/coin-modules/                           @ledgerhq/coin-integration
 libs/ledger-live-common/src/apps/config.ts                          @ledgerhq/coin-integration
 libs/ledger-live-common/src/families/                               @ledgerhq/coin-integration
 libs/ledger-live-common/src/flows/                                  @ledgerhq/coin-integration


### PR DESCRIPTION
### 📝 Description

Adds `libs/ledger-live-common/src/coin-modules/` to the `@ledgerhq/coin-integration` team in CODEOWNERS, alongside the other `libs/ledger-live-common/src/` paths already owned by that team.

### 🔗 Context

- **JIRA / GitHub issue**: N/A
- **ADR** (if any): N/A