### PR TITLE
[LWDM] feat(send): track usd amount and input mode on review

### DIFF
--- a/.changeset/clean-foxes-run.md
+++ b/.changeset/clean-foxes-run.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Track the USD amount and input mode (fiat/crypto) on the new send flow review button

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountScreenInner.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountScreenInner.tsx
@@ -80,10 +80,12 @@ export function AmountScreenInner({
       page: "step amount",
       quick_amount: activeQuickAction,
       fee_strategy: viewModel.selectedFeeStrategy ?? null,
+      amount: viewModel.amountUsd,
+      input_mode: viewModel.inputMode,
       ...sendFlowTrackingProperties,
     });
     onReview();
-  }, [onReview, viewModel.quickActions, viewModel.selectedFeeStrategy, sendFlowTrackingProperties]);
+  }, [onReview, viewModel.quickActions, viewModel.selectedFeeStrategy, viewModel.amountUsd, viewModel.inputMode, sendFlowTrackingProperties]);
 
   return (
     <AmountScreenView

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountScreenInner.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountScreenInner.tsx
@@ -85,7 +85,14 @@ export function AmountScreenInner({
       ...sendFlowTrackingProperties,
     });
     onReview();
-  }, [onReview, viewModel.quickActions, viewModel.selectedFeeStrategy, viewModel.amountUsd, viewModel.inputMode, sendFlowTrackingProperties]);
+  }, [
+    onReview,
+    viewModel.quickActions,
+    viewModel.selectedFeeStrategy,
+    viewModel.amountUsd,
+    viewModel.inputMode,
+    sendFlowTrackingProperties,
+  ]);
 
   return (
     <AmountScreenView

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useAmountScreenViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useAmountScreenViewModel.test.ts
@@ -55,11 +55,17 @@ jest.mock("../useAmountInput", () => ({
     currencyText: "BTC",
     currencyPosition: "right",
     secondaryValue: "$0",
+    fiatAmountValue: 0,
+    inputMode: "crypto",
     onAmountChange: jest.fn(),
     onToggleInputMode: jest.fn(),
     cancelPendingUpdates: jest.fn(),
     updateBothInputs: jest.fn(),
   }),
+}));
+
+jest.mock("../useAmountUsd", () => ({
+  useAmountUsd: jest.fn(() => 0),
 }));
 
 jest.mock("../useQuickActions", () => ({

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountInput.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountInput.ts
@@ -245,6 +245,7 @@ export function useAmountInput({
 
   const activeInputUnit = inputMode === "fiat" ? fiatUnit : accountUnit;
   const amountInputMaxDecimalLength = Math.max(0, activeInputUnit.magnitude);
+  const fiatAmountValue = fiatAmount.div(10 ** fiatUnit.magnitude).toNumber();
 
   return {
     amountValue,
@@ -252,6 +253,7 @@ export function useAmountInput({
     currencyPosition,
     secondaryValue,
     inputMode,
+    fiatAmountValue,
     amountInputMaxDecimalLength,
     onAmountChange: handleAmountChange,
     onToggleInputMode: handleToggleMode,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreenViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreenViewModel.ts
@@ -12,6 +12,7 @@ import { useSendFlowAmountReviewCore } from "@ledgerhq/live-common/flows/send/ho
 import type { AmountScreenViewModel } from "../types";
 import { useFlowWizard } from "LLD/features/FlowWizard/FlowWizardContext";
 import { useAmountInput } from "./useAmountInput";
+import { useAmountUsd } from "./useAmountUsd";
 import { useQuickActions } from "./useQuickActions";
 import { useInitialTransactionPreparation } from "../../../hooks/useInitialTransactionPreparation";
 import { useAmountScreenMessage } from "./useAmountScreenMessage";
@@ -79,6 +80,8 @@ export function useAmountScreenViewModel({
     status,
     onUpdateTransaction: updateTransactionWithPatch,
   });
+
+  const amountUsd = useAmountUsd(account, transaction.amount, amountInput.fiatAmountValue);
 
   useInitialTransactionPreparation({
     shouldPrepare,
@@ -192,6 +195,8 @@ export function useAmountScreenViewModel({
     onToggleInputMode: amountInput.onToggleInputMode,
     toggleLabel: t("newSendFlow.switchInputMode"),
     secondaryValue: amountInput.secondaryValue,
+    amountUsd,
+    inputMode: amountInput.inputMode,
     quickActions: trackedQuickActions,
     showQuickActions: quickActionsAvailableBalance.gt(0),
     amountMessage,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreenViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreenViewModel.ts
@@ -81,7 +81,11 @@ export function useAmountScreenViewModel({
     onUpdateTransaction: updateTransactionWithPatch,
   });
 
-  const amountUsd = useAmountUsd(account, transaction.amount, amountInput.fiatAmountValue);
+  // On "send max", transaction.amount is 0 and the effective amount lives in status.amount.
+  const cryptoAmount = transaction.useAllAmount
+    ? (status.amount ?? new BigNumber(0))
+    : transaction.amount;
+  const amountUsd = useAmountUsd(account, cryptoAmount, amountInput.fiatAmountValue);
 
   useInitialTransactionPreparation({
     shouldPrepare,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountUsd.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountUsd.ts
@@ -1,0 +1,32 @@
+import { useMemo } from "react";
+import type { BigNumber } from "bignumber.js";
+import type { AccountLike } from "@ledgerhq/types-live";
+import { getFiatCurrencyByTicker } from "@ledgerhq/live-common/currencies/index";
+import { useCalculate } from "@ledgerhq/live-countervalues-react";
+import { getAccountCurrency } from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import { useOnDemandCurrencyCountervalues } from "~/renderer/hooks/useOnDemandCountervalues";
+
+const USD = getFiatCurrencyByTicker("USD");
+
+/**
+ * Converts the transaction amount to USD, regardless of the user's chosen
+ * countervalue currency, so analytics amounts are always comparable.
+ *
+ * The crypto→USD pair is registered on demand (it is not fetched by default
+ * when the user's countervalue is not USD). While that rate is still loading,
+ * we fall back to the provided value (the amount in the user's fiat).
+ */
+export function useAmountUsd(account: AccountLike, amount: BigNumber, fallback: number): number {
+  const currency = useMemo(() => getAccountCurrency(account), [account]);
+
+  useOnDemandCurrencyCountervalues(currency, USD);
+
+  const raw = useCalculate({
+    value: amount.toNumber(),
+    from: currency,
+    to: USD,
+    disableRounding: true,
+  });
+
+  return raw != null ? raw / 10 ** USD.units[0].magnitude : fallback;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountUsd.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountUsd.ts
@@ -15,12 +15,12 @@ export function useAmountUsd(account: AccountLike, amount: BigNumber, fallback: 
 
   useOnDemandCurrencyCountervalues(currency, USD);
 
-  const raw = useCalculate({
-    value: amount.toNumber(),
-    from: currency,
-    to: USD,
-    disableRounding: true,
-  });
+  // Memoize the query so useCalculate's internal memo isn't defeated on every render.
+  const query = useMemo(
+    () => ({ value: amount.toNumber(), from: currency, to: USD, disableRounding: true }),
+    [amount, currency],
+  );
+  const raw = useCalculate(query);
 
   return raw != null ? raw / 10 ** USD.units[0].magnitude : fallback;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountUsd.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountUsd.ts
@@ -8,14 +8,8 @@ import { useOnDemandCurrencyCountervalues } from "~/renderer/hooks/useOnDemandCo
 
 const USD = getFiatCurrencyByTicker("USD");
 
-/**
- * Converts the transaction amount to USD, regardless of the user's chosen
- * countervalue currency, so analytics amounts are always comparable.
- *
- * The crypto→USD pair is registered on demand (it is not fetched by default
- * when the user's countervalue is not USD). While that rate is still loading,
- * we fall back to the provided value (the amount in the user's fiat).
- */
+// Converts the amount to USD for comparable analytics. Registers the crypto→USD
+// pair on demand and falls back to the user's fiat amount until the rate loads.
 export function useAmountUsd(account: AccountLike, amount: BigNumber, fallback: number): number {
   const currency = useMemo(() => getAccountCurrency(account), [account]);
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/types.ts
@@ -81,4 +81,6 @@ export type AmountScreenViewModel = Omit<
   Readonly<{
     showFeePresets: boolean;
     onOpenCustomFees: () => void;
+    amountUsd: number;
+    inputMode: "fiat" | "crypto";
   }>;

--- a/apps/ledger-live-mobile/src/components/CounterValue.tsx
+++ b/apps/ledger-live-mobile/src/components/CounterValue.tsx
@@ -1,14 +1,14 @@
-import React, { useState, useCallback, useMemo, useEffect } from "react";
+import React, { useState, useCallback, useMemo } from "react";
 import { BigNumber } from "bignumber.js";
 import { useSelector } from "~/context/hooks";
 import type { Currency } from "@ledgerhq/types-cryptoassets";
-import { useCalculate, useCountervaluesPolling } from "@ledgerhq/live-countervalues-react";
+import { useCalculate } from "@ledgerhq/live-countervalues-react";
 import { TouchableOpacity, StyleSheet } from "react-native";
 import { Trans } from "~/context/Locale";
 import { useTheme } from "@react-navigation/native";
 import { Flex } from "@ledgerhq/native-ui";
 import { counterValueCurrencySelector } from "~/reducers/settings";
-import { useTrackingPairs, addExtraSessionTrackingPair } from "~/actions/general";
+import { useOnDemandCurrencyCountervalues } from "~/hooks/useOnDemandCountervalues";
 import CurrencyUnitValue from "./CurrencyUnitValue";
 import type { CurrencyUnitValueProps } from "./CurrencyUnitValue";
 import LText from "./LText";
@@ -68,28 +68,7 @@ export default function CounterValue({
   ...props
 }: Props) {
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
-  const trackingPairs = useTrackingPairs();
-  const { poll } = useCountervaluesPolling();
-  const hasTrackingPair = useMemo(
-    () => trackingPairs.some(tp => tp.from === currency && tp.to === counterValueCurrency),
-    [counterValueCurrency, currency, trackingPairs],
-  );
-  useEffect(() => {
-    let t: NodeJS.Timeout | undefined;
-
-    if (!hasTrackingPair) {
-      addExtraSessionTrackingPair({
-        from: currency,
-        to: counterValueCurrency,
-        startDate: new Date(),
-      });
-      t = setTimeout(poll, 2000); // poll after 2s to ensure debounced CV userSettings are effective after this update
-    }
-
-    return () => {
-      if (t) clearTimeout(t);
-    };
-  }, [counterValueCurrency, currency, poll, hasTrackingPair, trackingPairs]);
+  useOnDemandCurrencyCountervalues(currency, counterValueCurrency);
   const param = useMemo(
     () => ({
       from: currency,

--- a/apps/ledger-live-mobile/src/hooks/__tests__/useOnDemandCountervalues.test.ts
+++ b/apps/ledger-live-mobile/src/hooks/__tests__/useOnDemandCountervalues.test.ts
@@ -60,4 +60,20 @@ describe("useOnDemandCurrencyCountervalues", () => {
 
     expect(poll).not.toHaveBeenCalled();
   });
+
+  it("still polls when the pair appears right after registration", () => {
+    (useTrackingPairs as jest.Mock).mockReturnValue([]);
+
+    const { rerender } = renderHook(() => useOnDemandCurrencyCountervalues(btc, usd));
+
+    // Registering the pair flips useTrackingPairs to include it and re-renders.
+    (useTrackingPairs as jest.Mock).mockReturnValue([{ from: btc, to: usd }]);
+    rerender({});
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(poll).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/ledger-live-mobile/src/hooks/__tests__/useOnDemandCountervalues.test.ts
+++ b/apps/ledger-live-mobile/src/hooks/__tests__/useOnDemandCountervalues.test.ts
@@ -1,0 +1,63 @@
+import { renderHook, act } from "@testing-library/react-native";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import { useOnDemandCurrencyCountervalues } from "../useOnDemandCountervalues";
+import { useTrackingPairs, addExtraSessionTrackingPair } from "~/actions/general";
+import { useCountervaluesPolling } from "@ledgerhq/live-countervalues-react";
+
+jest.mock("~/actions/general", () => ({
+  useTrackingPairs: jest.fn(),
+  addExtraSessionTrackingPair: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-countervalues-react", () => ({
+  useCountervaluesPolling: jest.fn(),
+}));
+
+const btc = { id: "bitcoin" } as unknown as Currency;
+const usd = { ticker: "USD" } as unknown as Currency;
+const poll = jest.fn();
+
+describe("useOnDemandCurrencyCountervalues", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    (useCountervaluesPolling as jest.Mock).mockReturnValue({ poll });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("registers the missing pair and polls after the delay", () => {
+    (useTrackingPairs as jest.Mock).mockReturnValue([]);
+
+    renderHook(() => useOnDemandCurrencyCountervalues(btc, usd));
+
+    expect(addExtraSessionTrackingPair).toHaveBeenCalledWith({
+      from: btc,
+      to: usd,
+      startDate: expect.any(Date),
+    });
+    expect(poll).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(poll).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when the pair is already tracked", () => {
+    (useTrackingPairs as jest.Mock).mockReturnValue([{ from: btc, to: usd }]);
+
+    renderHook(() => useOnDemandCurrencyCountervalues(btc, usd));
+
+    expect(addExtraSessionTrackingPair).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(poll).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/hooks/useOnDemandCountervalues.ts
+++ b/apps/ledger-live-mobile/src/hooks/useOnDemandCountervalues.ts
@@ -1,26 +1,27 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import type { Currency } from "@ledgerhq/types-cryptoassets";
 import { useCountervaluesPolling } from "@ledgerhq/live-countervalues-react";
 import { useTrackingPairs, addExtraSessionTrackingPair } from "~/actions/general";
 
-// Registers the (currency, counterValueCurrency) pair with the countervalues
-// engine when missing, then polls so the debounced settings take effect.
 export function useOnDemandCurrencyCountervalues(
   currency: Currency,
   counterValueCurrency: Currency,
 ) {
   const trackingPairs = useTrackingPairs();
   const { poll } = useCountervaluesPolling();
+
+  // Read via refs so registering the pair (which updates trackingPairs) doesn't
+  // re-run the effect and clear the timeout before the poll fires.
   const pollRef = useRef(poll);
   pollRef.current = poll;
-
-  const hasTrackingPair = useMemo(
-    () => trackingPairs.some(tp => tp.from === currency && tp.to === counterValueCurrency),
-    [trackingPairs, currency, counterValueCurrency],
-  );
+  const trackingPairsRef = useRef(trackingPairs);
+  trackingPairsRef.current = trackingPairs;
 
   useEffect(() => {
-    if (hasTrackingPair) return;
+    const alreadyTracked = trackingPairsRef.current.some(
+      tp => tp.from === currency && tp.to === counterValueCurrency,
+    );
+    if (alreadyTracked) return;
     addExtraSessionTrackingPair({
       from: currency,
       to: counterValueCurrency,
@@ -28,5 +29,5 @@ export function useOnDemandCurrencyCountervalues(
     });
     const t = setTimeout(() => pollRef.current(), 2000);
     return () => clearTimeout(t);
-  }, [hasTrackingPair, currency, counterValueCurrency]);
+  }, [currency, counterValueCurrency]);
 }

--- a/apps/ledger-live-mobile/src/hooks/useOnDemandCountervalues.ts
+++ b/apps/ledger-live-mobile/src/hooks/useOnDemandCountervalues.ts
@@ -1,0 +1,34 @@
+import { useEffect, useMemo, useRef } from "react";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import { useCountervaluesPolling } from "@ledgerhq/live-countervalues-react";
+import { useTrackingPairs, addExtraSessionTrackingPair } from "~/actions/general";
+
+/**
+ * Ensures the (currency, counterValueCurrency) pair is tracked by the
+ * countervalues engine, registering it on demand when it is missing.
+ *
+ * Mirrors the desktop `useOnDemandCurrencyCountervalues` hook. Registration
+ * mutates the session tracking pairs, so we poll shortly after to let the
+ * debounced countervalues settings take effect.
+ */
+export function useOnDemandCurrencyCountervalues(
+  currency: Currency,
+  counterValueCurrency: Currency,
+) {
+  const trackingPairs = useTrackingPairs();
+  const { poll } = useCountervaluesPolling();
+  const pollRef = useRef(poll);
+  pollRef.current = poll;
+
+  const hasTrackingPair = useMemo(
+    () => trackingPairs.some(tp => tp.from === currency && tp.to === counterValueCurrency),
+    [trackingPairs, currency, counterValueCurrency],
+  );
+
+  useEffect(() => {
+    if (hasTrackingPair) return;
+    addExtraSessionTrackingPair({ from: currency, to: counterValueCurrency, startDate: new Date() });
+    const t = setTimeout(() => pollRef.current(), 2000);
+    return () => clearTimeout(t);
+  }, [hasTrackingPair, currency, counterValueCurrency]);
+}

--- a/apps/ledger-live-mobile/src/hooks/useOnDemandCountervalues.ts
+++ b/apps/ledger-live-mobile/src/hooks/useOnDemandCountervalues.ts
@@ -3,14 +3,8 @@ import type { Currency } from "@ledgerhq/types-cryptoassets";
 import { useCountervaluesPolling } from "@ledgerhq/live-countervalues-react";
 import { useTrackingPairs, addExtraSessionTrackingPair } from "~/actions/general";
 
-/**
- * Ensures the (currency, counterValueCurrency) pair is tracked by the
- * countervalues engine, registering it on demand when it is missing.
- *
- * Mirrors the desktop `useOnDemandCurrencyCountervalues` hook. Registration
- * mutates the session tracking pairs, so we poll shortly after to let the
- * debounced countervalues settings take effect.
- */
+// Registers the (currency, counterValueCurrency) pair with the countervalues
+// engine when missing, then polls so the debounced settings take effect.
 export function useOnDemandCurrencyCountervalues(
   currency: Currency,
   counterValueCurrency: Currency,

--- a/apps/ledger-live-mobile/src/hooks/useOnDemandCountervalues.ts
+++ b/apps/ledger-live-mobile/src/hooks/useOnDemandCountervalues.ts
@@ -21,7 +21,11 @@ export function useOnDemandCurrencyCountervalues(
 
   useEffect(() => {
     if (hasTrackingPair) return;
-    addExtraSessionTrackingPair({ from: currency, to: counterValueCurrency, startDate: new Date() });
+    addExtraSessionTrackingPair({
+      from: currency,
+      to: counterValueCurrency,
+      startDate: new Date(),
+    });
     const t = setTimeout(() => pollRef.current(), 2000);
     return () => clearTimeout(t);
   }, [hasTrackingPair, currency, counterValueCurrency]);

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useAmountScreenViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useAmountScreenViewModel.test.ts
@@ -18,6 +18,23 @@ jest.mock("../useAmountInputController", () => ({
   useAmountInputController: jest.fn(),
 }));
 
+jest.mock("../useAmountUsd", () => ({
+  useAmountUsd: jest.fn(() => 500),
+}));
+
+const mockTrack = jest.fn();
+jest.mock("~/analytics", () => ({
+  useAnalytics: () => ({ track: mockTrack }),
+}));
+
+jest.mock("@ledgerhq/ledger-wallet-framework/tracking/send", () => ({
+  getSendFlowTrackingProperties: () => ({
+    flow: "send",
+    currency: "BTC",
+    blockchain: "bitcoin",
+  }),
+}));
+
 jest.mock("../useQuickActions", () => ({
   useQuickActions: jest.fn(() => []),
 }));
@@ -85,6 +102,8 @@ const baseAmountInputController = {
   maxDecimalLength: 2,
   isDisabled: false,
   isTyping: false,
+  fiatAmountValue: 100,
+  inputMode: "fiat" as const,
   onChangeText: jest.fn(),
   onToggleMode: jest.fn(),
   updateBothInputs: jest.fn(),
@@ -211,5 +230,42 @@ describe("useAmountScreenViewModel", () => {
       type: "error",
       error: recipientError,
     });
+  });
+
+  it("tracks the review click with the USD amount and input mode", () => {
+    const onReview = jest.fn();
+
+    const { result } = renderHook(() =>
+      useAmountScreenViewModel({
+        account: mockAccount,
+        parentAccount: null,
+        transaction: baseTransaction,
+        status: createBaseStatus(),
+        bridgePending: false,
+        bridgeError: null,
+        uiConfig: { hasFeePresets: false } as never,
+        transactionActions: { updateTransaction: jest.fn() } as never,
+        onReview,
+        onGetFunds: jest.fn(),
+        onSelectCoinControl: jest.fn(),
+      }),
+    );
+
+    if (!result.current.ready) {
+      throw new Error("view model should be ready");
+    }
+
+    result.current.reviewButton.onPress();
+
+    expect(mockTrack).toHaveBeenCalledWith("button_clicked", {
+      flow: "send",
+      currency: "BTC",
+      blockchain: "bitcoin",
+      button: "review",
+      page: "step amount",
+      amount: 500,
+      input_mode: "fiat",
+    });
+    expect(onReview).toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountInputController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountInputController.ts
@@ -254,6 +254,7 @@ export function useAmountInputController({
 
   const activeInputUnit = inputMode === "fiat" ? fiatUnit : accountUnit;
   const amountInputMaxDecimalLength = Math.max(0, activeInputUnit.magnitude);
+  const fiatAmountValue = fiatAmount.div(10 ** fiatUnit.magnitude).toNumber();
 
   return useMemo(
     () => ({
@@ -262,6 +263,7 @@ export function useAmountInputController({
       currencyPosition,
       secondaryValue,
       inputMode,
+      fiatAmountValue,
       maxDecimalLength: amountInputMaxDecimalLength,
       isTyping,
       onChangeText: handleAmountChange,
@@ -275,6 +277,7 @@ export function useAmountInputController({
       currencyPosition,
       secondaryValue,
       inputMode,
+      fiatAmountValue,
       amountInputMaxDecimalLength,
       isTyping,
       handleAmountChange,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreen.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreen.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import { useNavigation } from "@react-navigation/native";
 import { useSendFlowActions, useSendFlowData } from "../../../context/SendFlowContext";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
@@ -10,8 +10,6 @@ import type {
 import { ScreenName } from "~/const";
 import type { SendFlowNavigationProp } from "../../../types";
 import { useSendSignature } from "../../../context/SendSignatureContext";
-import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework/tracking/send";
-import { useAnalytics } from "~/analytics";
 
 type AmountScreenViewModelBase = Readonly<{
   onReview: () => void;
@@ -48,15 +46,9 @@ export function useAmountScreen(): AmountScreenViewModel {
     close();
   }, [close]);
 
-  const { track } = useAnalytics();
-  const trackingProperties = useMemo(() => {
-    return getSendFlowTrackingProperties(account, parentAccount);
-  }, [account, parentAccount]);
-
   const onReview = useCallback(() => {
-    track("button_clicked", { ...trackingProperties, button: "review", page: "step amount" });
     startSigning(() => navigation.navigate(ScreenName.SendFlowConfirmation));
-  }, [startSigning, navigation, track, trackingProperties]);
+  }, [startSigning, navigation]);
 
   const onSelectCoinControl = useCallback(() => {
     navigation.navigate(ScreenName.SendFlowCoinControl);

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreenViewModel.ts
@@ -149,7 +149,11 @@ export function useAmountScreenViewModel({
     [account, parentAccount],
   );
 
-  const amountUsd = useAmountUsd(account, transaction.amount, amountInput.fiatAmountValue);
+  // On "send max", transaction.amount is 0 and the effective amount lives in status.amount.
+  const cryptoAmount = transaction.useAllAmount
+    ? (status.amount ?? new BigNumber(0))
+    : transaction.amount;
+  const amountUsd = useAmountUsd(account, cryptoAmount, amountInput.fiatAmountValue);
 
   const handleReview = useCallback(() => {
     track("button_clicked", {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreenViewModel.ts
@@ -10,8 +10,11 @@ import type {
 import { useSendFlowAmountReviewCore } from "@ledgerhq/live-common/flows/send/hooks/useSendFlowAmountReviewCore";
 import type { AmountScreenMessage, AmountScreenViewModel } from "../types";
 import { useAmountInputController } from "./useAmountInputController";
+import { useAmountUsd } from "./useAmountUsd";
 import { useQuickActions } from "./useQuickActions";
 import { useNetworkFees } from "../../../hooks/useNetworkFees";
+import { useAnalytics } from "~/analytics";
+import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework/tracking/send";
 import {
   getAmountScreenRawMessage,
   isAmountInputDisabledByRecipientError,
@@ -140,6 +143,25 @@ export function useAmountScreenViewModel({
 
   const reviewDisabled = coreReviewDisabled || amountInput.isTyping;
 
+  const { track } = useAnalytics();
+  const trackingProperties = useMemo(
+    () => getSendFlowTrackingProperties(account, parentAccount),
+    [account, parentAccount],
+  );
+
+  const amountUsd = useAmountUsd(account, transaction.amount, amountInput.fiatAmountValue);
+
+  const handleReview = useCallback(() => {
+    track("button_clicked", {
+      ...trackingProperties,
+      button: "review",
+      page: "step amount",
+      amount: amountUsd,
+      input_mode: amountInput.inputMode,
+    });
+    onReview();
+  }, [onReview, amountUsd, amountInput.inputMode, track, trackingProperties]);
+
   return useMemo(
     () => ({
       ready: true,
@@ -164,7 +186,7 @@ export function useAmountScreenViewModel({
         showIcon: coreReviewShowIcon,
         disabled: reviewDisabled,
         loading: amountComputationPending,
-        onPress: hasInsufficientFundsError ? onGetFunds : onReview,
+        onPress: hasInsufficientFundsError ? onGetFunds : handleReview,
       },
       message: amountMessage,
     }),
@@ -180,7 +202,7 @@ export function useAmountScreenViewModel({
       reviewDisabled,
       amountComputationPending,
       onGetFunds,
-      onReview,
+      handleReview,
       amountMessage,
     ],
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountUsd.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountUsd.ts
@@ -15,12 +15,12 @@ export function useAmountUsd(account: AccountLike, amount: BigNumber, fallback: 
 
   useOnDemandCurrencyCountervalues(currency, USD);
 
-  const raw = useCalculate({
-    value: amount.toNumber(),
-    from: currency,
-    to: USD,
-    disableRounding: true,
-  });
+  // Memoize the query so useCalculate's internal memo isn't defeated on every render.
+  const query = useMemo(
+    () => ({ value: amount.toNumber(), from: currency, to: USD, disableRounding: true }),
+    [amount, currency],
+  );
+  const raw = useCalculate(query);
 
   return raw != null ? raw / 10 ** USD.units[0].magnitude : fallback;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountUsd.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountUsd.ts
@@ -1,0 +1,32 @@
+import { useMemo } from "react";
+import type { BigNumber } from "bignumber.js";
+import type { AccountLike } from "@ledgerhq/types-live";
+import { getFiatCurrencyByTicker } from "@ledgerhq/live-common/currencies/index";
+import { useCalculate } from "@ledgerhq/live-countervalues-react";
+import { getAccountCurrency } from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import { useOnDemandCurrencyCountervalues } from "~/hooks/useOnDemandCountervalues";
+
+const USD = getFiatCurrencyByTicker("USD");
+
+/**
+ * Converts the transaction amount to USD, regardless of the user's chosen
+ * countervalue currency, so analytics amounts are always comparable.
+ *
+ * The crypto→USD pair is registered on demand (it is not fetched by default
+ * when the user's countervalue is not USD). While that rate is still loading,
+ * we fall back to the provided value (the amount in the user's fiat).
+ */
+export function useAmountUsd(account: AccountLike, amount: BigNumber, fallback: number): number {
+  const currency = useMemo(() => getAccountCurrency(account), [account]);
+
+  useOnDemandCurrencyCountervalues(currency, USD);
+
+  const raw = useCalculate({
+    value: amount.toNumber(),
+    from: currency,
+    to: USD,
+    disableRounding: true,
+  });
+
+  return raw != null ? raw / 10 ** USD.units[0].magnitude : fallback;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountUsd.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountUsd.ts
@@ -8,14 +8,8 @@ import { useOnDemandCurrencyCountervalues } from "~/hooks/useOnDemandCountervalu
 
 const USD = getFiatCurrencyByTicker("USD");
 
-/**
- * Converts the transaction amount to USD, regardless of the user's chosen
- * countervalue currency, so analytics amounts are always comparable.
- *
- * The crypto→USD pair is registered on demand (it is not fetched by default
- * when the user's countervalue is not USD). While that rate is still loading,
- * we fall back to the provided value (the amount in the user's fiat).
- */
+// Converts the amount to USD for comparable analytics. Registers the crypto→USD
+// pair on demand and falls back to the user's fiat amount until the rate loads.
 export function useAmountUsd(account: AccountLike, amount: BigNumber, fallback: number): number {
   const currency = useMemo(() => getAccountCurrency(account), [account]);
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Mobile view-model tracking is covered by a unit test. Desktop tracking lives in the `AmountScreenInner` component (no existing component test), and the end-to-end analytics payload was verified manually._
- [x] **Impact of the changes:**
      - New Send Flow "Review" click on the amount screen (desktop + mobile) now emits `button_clicked` with `amount` (USD), `input_mode` (`fiat`/`crypto`), `currency`, `blockchain`.
      - Verify `amount` is expressed in **USD even when the user's countervalue currency is set to another fiat** (e.g. EUR).
      - Fallback behavior: on a slow network the amount briefly uses the user's fiat value until the crypto→USD rate finishes loading.

### 📝 Description

The New Send Flow amount-screen analytics needed the entered amount, normalized so events are comparable across users regardless of their chosen countervalue currency.

Added a `useAmountUsd` hook (desktop + mobile) that converts the transaction amount to USD through the countervalues engine. Because the crypto→USD pair is not fetched by default when the user's countervalue isn't USD, the hook registers it on demand (desktop via `useOnDemandCurrencyCountervalues`, mobile via a new equivalent hook) and falls back to the user's fiat amount while the rate loads. The review `button_clicked` event now carries `amount` (USD) and `input_mode` (whether the user typed in fiat or crypto).

**Example event sent on "Review" click:**

```js
analytics.track("button_clicked", {
  button: "review",
  page: "step amount",
  amount: 42.5,          // always in USD
  input_mode: "fiat",    // "fiat" | "crypto" — how the user typed the amount
  flow: "send",
  newSendFlow: true,
  currency: "ETH",       // ticker
  currency_id: "ethereum",
  blockchain: "ethereum",
  // desktop only:
  quick_amount: null,    // active quick-action (25% / 50% / …) or null
  fee_strategy: "medium",
});
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33795](https://ledgerhq.atlassian.net/browse/LIVE-33795)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33795]: https://ledgerhq.atlassian.net/browse/LIVE-33795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ