### PR TITLE
[LWDM] fix: add fees-only txs to tezos getblock

### DIFF
--- a/.changeset/breezy-stingrays-explain.md
+++ b/.changeset/breezy-stingrays-explain.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": minor
+---
+
+fix: emit getBlock operations for zero-amount fee-bearing transactions and include all FA2 token IDs

--- a/.changeset/breezy-stingrays-explain.md
+++ b/.changeset/breezy-stingrays-explain.md
@@ -1,5 +1,5 @@
 ---
-"@ledgerhq/coin-tezos": minor
+"@ledgerhq/coin-tezos": patch
 ---
 
 fix: emit getBlock operations for zero-amount fee-bearing transactions and include all FA2 token IDs

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
@@ -315,16 +315,44 @@ describe("native XTZ operations", () => {
     });
   });
 
-  it("produces no operations for a zero-amount transaction (e.g. delegation reveal)", async () => {
+  it("produces no operations for a zero-amount, zero-fee transaction", async () => {
     // Given
     mockGetBlockByLevel.mockResolvedValue(makeBlock());
-    mockFetchBlockTransactions.mockResolvedValue([makeTx({ amount: 0 })]);
+    mockFetchBlockTransactions.mockResolvedValue([makeTx({ amount: 0, bakerFee: 0 })]);
 
     // When
     const result = await getBlock(5_000_000);
 
-    // Then
+    // Then — no balance impact, no operations
     expect(result.transactions[0].operations).toEqual([]);
+  });
+
+  it("produces operations for a zero-amount transaction that carries fees", async () => {
+    // Given
+    mockGetBlockByLevel.mockResolvedValue(makeBlock());
+    mockFetchBlockTransactions.mockResolvedValue([makeTx({ amount: 0, bakerFee: 1500 })]);
+
+    // When
+    const result = await getBlock(5_000_000);
+
+    // Then — fees are a balance change, so operations must be emitted for fee attribution
+    expect(result.transactions[0].fees).toBe(1500n);
+    expect(result.transactions[0].operations).toEqual([
+      {
+        type: "transfer",
+        address: "tz1Sender",
+        peer: "tz1Target",
+        asset: { type: "native", name: "XTZ" },
+        amount: 0n,
+      },
+      {
+        type: "transfer",
+        address: "tz1Target",
+        peer: "tz1Sender",
+        asset: { type: "native", name: "XTZ" },
+        amount: 0n,
+      },
+    ]);
   });
 
   it("produces only an incoming operation when sender is null, with no peer field", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
@@ -88,8 +88,8 @@ function isGroupSucceeded(group: APITransactionType[]): boolean {
 }
 
 /**
- * Produces one outgoing and one incoming `BlockOperation` for each XTZ
- * transfer within the group that has a balance impact.
+ * Produces one outgoing and one incoming `BlockOperation` for each transaction in the group
+ * that has a balance impact.
  *
  * A transaction has balance impact when it transfers XTZ (amount > 0) or
  * carries fees (bakerFee + storageFee + allocationFee > 0). Zero-amount,

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
@@ -88,8 +88,12 @@ function isGroupSucceeded(group: APITransactionType[]): boolean {
 }
 
 /**
- * Produces one outgoing and one incoming `BlockOperation` for each non-zero XTZ
- * transfer within the group.
+ * Produces one outgoing and one incoming `BlockOperation` for each XTZ
+ * transfer within the group that has a balance impact.
+ *
+ * A transaction has balance impact when it transfers XTZ (amount > 0) or
+ * carries fees (bakerFee + storageFee + allocationFee > 0). Zero-amount,
+ * zero-fee transactions are skipped — they don't affect any account's balance.
  *
  * Fees are intentionally excluded from amounts — they are reported separately in
  * `BlockTransaction.fees`.  In Tezos, the `amount` field on `APITransactionType`
@@ -99,7 +103,8 @@ function isGroupSucceeded(group: APITransactionType[]): boolean {
 function buildNativeOperations(group: APITransactionType[]): BlockOperation[] {
   const ops: BlockOperation[] = [];
   for (const tx of group) {
-    if (!tx.amount) continue;
+    const amount = BigInt(tx.amount ?? 0);
+    if (!amount && computeOpFees(tx) === 0n) continue;
 
     const fromAddr = tx.sender?.address;
     const toAddr = tx.target?.address;
@@ -110,7 +115,7 @@ function buildNativeOperations(group: APITransactionType[]): BlockOperation[] {
         address: fromAddr,
         ...(toAddr && { peer: toAddr }),
         asset: NATIVE_ASSET,
-        amount: -BigInt(tx.amount),
+        amount: -amount,
       });
     }
     if (toAddr) {
@@ -119,7 +124,7 @@ function buildNativeOperations(group: APITransactionType[]): BlockOperation[] {
         address: toAddr,
         ...(fromAddr && { peer: fromAddr }),
         asset: NATIVE_ASSET,
-        amount: BigInt(tx.amount),
+        amount,
       });
     }
   }

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
@@ -89,11 +89,11 @@ function isGroupSucceeded(group: APITransactionType[]): boolean {
 
 /**
  * Produces one outgoing and one incoming `BlockOperation` for each transaction in the group
- * that has a balance impact.
+ * that should be represented in the block.
  *
- * A transaction has balance impact when it transfers XTZ (amount > 0) or
- * carries fees (bakerFee + storageFee + allocationFee > 0). Zero-amount,
- * zero-fee transactions are skipped — they don't affect any account's balance.
+ * Transactions are skipped only when both the transferred amount and the fees are zero.
+ * Fee-only transactions (amount === 0 but fees > 0) are kept so fee attribution and
+ * sender/target linkage match `listOperations`.
  *
  * Fees are intentionally excluded from amounts — they are reported separately in
  * `BlockTransaction.fees`.  In Tezos, the `amount` field on `APITransactionType`
@@ -104,7 +104,7 @@ function buildNativeOperations(group: APITransactionType[]): BlockOperation[] {
   const ops: BlockOperation[] = [];
   for (const tx of group) {
     const amount = BigInt(tx.amount ?? 0);
-    if (!amount && computeOpFees(tx) === 0n) continue;
+    if (amount === 0n && computeOpFees(tx) === 0n) continue;
 
     const fromAddr = tx.sender?.address;
     const toAddr = tx.target?.address;

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.ts
@@ -224,13 +224,11 @@ const api = {
   async getBlockTokenTransfersPage(level: number, cursor?: number): Promise<APITokenTransfer[]> {
     // Same rationale as getBlockTransactionsPage: explicit ascending sort keeps the
     // offset.cr cursor advancing forward regardless of the API's default ordering.
-    // Filter to FA2 tokenId=0 to match listOperations (getAccountTokenTransfers).
     const params: Record<string, unknown> = {
       level,
       limit: BLOCK_PAGE_SIZE,
       "sort.asc": "id",
       "token.standard": "fa2",
-      "token.tokenId": "0",
     };
     if (cursor !== undefined) params["offset.cr"] = cursor;
     const { data } = await network<APITokenTransfer[]>({


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

getBlock was silently dropping operations that listOperations correctly returns
  
Two bugs fixed:                                                                                                                                                                             
                  
1. Zero-amount native transactions with fees were dropped                                                                                                                                   
                  
Before: buildNativeOperations skipped any transaction with amount === 0, even if it carried fees. This meant contract calls (FA2 transfers, NFT mints, etc.) where the account pays fees but transfers no XTZ produced no BlockOperation — making it impossible to attribute fees to the correct account.
                                                                                                                                                                                              
After: Transactions are only skipped when both amount === 0 AND fees === 0. Zero-amount transactions that carry fees now emit operations for sender/target, matching listOperations behavior.
                                                                                                                                                                                              
2. Block-level token fetch excluded NFTs (FA2 tokenId != 0)                                                                                                                                 
  
Before: getBlockTokenTransfersPage filtered with token.tokenId=0, excluding all FA2 tokens with non-zero tokenId (NFTs). The comment claimed this matched listOperations, but getAccountTokenTransfers has no such filter.
                                                                                                                                                                                              
After: The token.tokenId=0 filter is removed. Block-level and account-level token fetches now return the same set of FA2 tokens.                                                            

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
