### PR TITLE
feat(feature-flags): add lwmPayTab flag for Pay Tab in LWM

### DIFF
--- a/.changeset/silly-bats-try.md
+++ b/.changeset/silly-bats-try.md
@@ -1,0 +1,5 @@
+---
+"@shared/feature-flags": minor
+---
+
+Add lwmPayTab feature flag for the Pay Tab in LWM

--- a/shared/feature-flags/src/flags/team-wallet-xp/index.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/index.ts
@@ -22,3 +22,4 @@ export * from "./lwmQuickActionsCtasVariant";
 export * from "./llmTransferButtonCopyVariant";
 export * from "./llRobinhoodDisclaimer";
 export * from "./lwdPayTab";
+export * from "./lwmPayTab";

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwmPayTab.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwmPayTab.ts
@@ -1,0 +1,2 @@
+import { flag } from "../../define";
+export const lwmPayTab = flag();


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _No tests needed — this PR only adds a feature flag definition with no runtime logic._
- [x] **Impact of the changes:**
  - Verify the \`lwmPayTab\` flag can be toggled via the feature flag system
  - Confirm the flag controls Pay Tab visibility as expected in LWM

### 📝 Description

Adds the \`lwmPayTab\` feature flag to the team-wallet-xp flags package. This flag gates the Pay Tab feature in LWM (Ledger Wallet Mobile), allowing controlled rollout via the feature flag system.

The flag is defined using the standard \`flag()\` helper and exported from the team-wallet-xp index.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34081](https://ledgerhq.atlassian.net/browse/LIVE-34081)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34081]: https://ledgerhq.atlassian.net/browse/LIVE-34081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ