### PR TITLE
[LWD] feat(desktop): add Pay Tab sidebar entry behind lwdPayTab feature flag

### DIFF
--- a/.changeset/loud-fans-build.md
+++ b/.changeset/loud-fans-build.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add Pay Tab to the desktop sidebar, replacing the Card entry when the `lwdPayTab` feature flag is enabled

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/utils.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/utils.ts
@@ -31,6 +31,7 @@ const WALLET_40_PAGES = new Set<string>([
   "/perps",
   "/borrow",
   "/history",
+  "/paytab",
 ]);
 
 /**

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/SideBarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/SideBarView.tsx
@@ -18,6 +18,7 @@ import {
   Chart5,
   Chart5Fill,
   Compass,
+  DollarConvert,
 } from "@ledgerhq/lumen-ui-react/symbols";
 import { FeatureToggle } from "@features/platform-feature-flags";
 import React from "react";
@@ -79,13 +80,22 @@ export function SideBarView({ viewModel }: SideBarViewProps) {
               activeIcon={Compass}
               label={t("sidebar.catalog")}
             />
-            <SideBarItem
-              value="card"
-              icon={CreditCard}
-              activeIcon={CreditCardFill}
-              label={t("sidebar.card")}
-              disabled={viewModel.isCardDisabled}
-            />
+            {viewModel.isPayTabEnabled ? (
+              <SideBarItem
+                value="paytab"
+                icon={DollarConvert}
+                activeIcon={DollarConvert}
+                label={t("sidebar.paytab")}
+              />
+            ) : (
+              <SideBarItem
+                value="card"
+                icon={CreditCard}
+                activeIcon={CreditCardFill}
+                label={t("sidebar.card")}
+                disabled={viewModel.isCardDisabled}
+              />
+            )}
           </SideBarLeading>
           <SideBarTrailing>
             {viewModel.isMyWalletEnabled ? null : (

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/__integrations__/SideBar.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/__integrations__/SideBar.integration.test.tsx
@@ -110,6 +110,25 @@ describe("SideBar", () => {
       const cardButton = screen.getByText("Card").closest("button");
       expect(cardButton).toBeDisabled();
     });
+
+    it("should render Pay instead of Card when lwdPayTab is enabled", () => {
+      renderSideBarWithRoute(
+        "/",
+        withFeatureFlags({
+          lwdPayTab: { enabled: true },
+        }),
+      );
+
+      expect(screen.getByText("Pay")).toBeVisible();
+      expect(screen.queryByText("Card")).not.toBeInTheDocument();
+    });
+
+    it("should render Card instead of Pay when lwdPayTab is disabled", () => {
+      renderSideBarWithRoute("/");
+
+      expect(screen.getByText("Card")).toBeVisible();
+      expect(screen.queryByText("Pay")).not.toBeInTheDocument();
+    });
     it("should disable Accounts item when no accounts are present", () => {
       renderSideBarWithRoute("/", {
         accounts: [],
@@ -179,6 +198,19 @@ describe("SideBar", () => {
       expect(mockNavigate).toHaveBeenCalledWith("/card-new-wallet");
     });
 
+    it("should navigate to paytab when clicking Pay item and lwdPayTab is enabled", async () => {
+      const { user } = renderSideBarWithRoute(
+        "/",
+        withFeatureFlags({
+          lwdPayTab: { enabled: true },
+        }),
+      );
+
+      await user.click(screen.getByText("Pay"));
+
+      expect(mockNavigate).toHaveBeenCalledWith("/paytab");
+    });
+
     it("should not navigate when clicking the already active item", async () => {
       const { user } = renderSideBarWithRoute("/");
 
@@ -241,6 +273,18 @@ describe("SideBar", () => {
 
       const cardButton = screen.getByText("Card").closest("button");
       expect(cardButton).toHaveAttribute("aria-current", "page");
+    });
+
+    it("should set paytab as active when on paytab path and lwdPayTab is enabled", () => {
+      renderSideBarWithRoute(
+        "/paytab",
+        withFeatureFlags({
+          lwdPayTab: { enabled: true },
+        }),
+      );
+
+      const payTabButton = screen.getByText("Pay").closest("button");
+      expect(payTabButton).toHaveAttribute("aria-current", "page");
     });
 
     it("should set earn as active when on earn path", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/types.ts
@@ -32,6 +32,7 @@ export interface SideBarViewModel {
   readonly displayBlueDot: boolean;
   readonly earnLabel: string;
   readonly isCardDisabled: boolean;
+  readonly isPayTabEnabled: boolean;
   readonly isAccountsDisabled: boolean;
   readonly isLiveAppTabSelected: boolean;
   readonly isMyWalletEnabled: boolean;

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/useSideBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/useSideBarViewModel.ts
@@ -136,8 +136,11 @@ export function useSideBarViewModel(): SideBarViewModel {
   const displayBlueDot = useDeviceHasUpdatesAvailable(lastSeenDevice);
 
   const referralProgramConfig = useFeature("referralProgramDesktopSidebar");
+  const payTabFeature = useFeature("lwdPayTab");
   const recoverFeature = useFeature("protectServicesDesktop");
   const recoverHomePath = useAccountPath(recoverFeature);
+
+  const isPayTabEnabled = !!payTabFeature?.enabled;
 
   const { shouldDisplayAssetSection, shouldDisplayMyWallet: isMyWalletEnabled } =
     useWalletFeaturesConfig("desktop");
@@ -321,6 +324,7 @@ export function useSideBarViewModel(): SideBarViewModel {
     displayBlueDot,
     earnLabel,
     isCardDisabled,
+    isPayTabEnabled,
     isAccountsDisabled: noAccounts,
     isLiveAppTabSelected,
     isMyWalletEnabled,

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/utils/__tests__/helpers.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/utils/__tests__/helpers.test.ts
@@ -15,6 +15,8 @@ describe("pathnameToActive", () => {
     { pathname: SIDEBAR_VALUE_TO_PATH.card, expected: "card" },
     { pathname: "/card", expected: "card" },
     { pathname: "/card/something", expected: "card" },
+    { pathname: SIDEBAR_VALUE_TO_PATH.paytab, expected: "paytab" },
+    { pathname: "/paytab/details", expected: "paytab" },
   ])('should return "$expected" for pathname "$pathname"', ({ pathname, expected }) => {
     expect(pathnameToActive(pathname, undefined)).toBe(expected);
   });

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/utils/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/utils/constants.ts
@@ -9,6 +9,7 @@ export const SIDEBAR_VALUE_TO_PATH = {
   earn: "/earn",
   discover: "/platform",
   card: "/card-new-wallet",
+  paytab: "/paytab",
 } as const;
 
 /** Sidebar "Accounts" entry navigates to CryptoAddresses (Cryptos page) when asset section FF is on, else legacy accounts page. */
@@ -31,6 +32,7 @@ export const SIDEBAR_VALUE_TO_TRACK_ENTRY: Record<SideBarNavValue, string> = {
   earn: "earn",
   discover: "platform",
   card: "card",
+  paytab: "paytab",
 } as const;
 
 /**

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/utils/helpers.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/utils/helpers.ts
@@ -23,6 +23,7 @@ export function pathnameToActive(
   if (pathname.startsWith("/swap")) return "swap";
   if (pathname === "/earn") return "earn";
   if (pathname.startsWith("/platform")) return "discover";
+  if (pathname.startsWith("/paytab")) return "paytab";
   if (pathname === "/card-new-wallet" || pathname.startsWith("/card")) return "card";
   return "";
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/components/PayTabHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/components/PayTabHeader.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import PageHeader from "LLD/components/PageHeader";
+
+export default function PayTabHeader() {
+  const { t } = useTranslation();
+
+  return <PageHeader title={t("sidebar.paytab")} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import PayTabHeader from "./components/PayTabHeader";
+
+const PayTab = () => {
+  return <PayTabHeader />;
+};
+
+export default PayTab;

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -107,6 +107,7 @@ const Analytics = lazy(() => import("LLD/features/Analytics"));
 const CryptoAddresses = lazy(() => import("LLD/features/CryptoAddresses"));
 const CryptoAssets = lazy(() => import("LLD/features/CryptoAddresses/CryptoAssets"));
 const CardW40 = lazy(() => import("LLD/features/Card"));
+const PayTab = lazy(() => import("LLD/features/PayTab"));
 const History = lazy(() => import("LLD/features/History"));
 
 const LoaderWrapper = styled.div`
@@ -294,6 +295,7 @@ const MainAppContent = ({
         />
         <Route path="/card-new-wallet" element={withSuspense(CardW40)({})} />
         <Route path="/card/:appId?" element={withSuspense(Card)({})} />
+        <Route path="/paytab" element={withSuspense(PayTab)({})} />
         <Route path="/manager/reload" element={<Navigate to="/manager" replace />} />
         <Route path="/manager/*" element={withSuspense(Manager)({})} />
         <Route path="/platform" element={withSuspense(PlatformCatalog)({})} />

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -303,6 +303,7 @@
   },
   "sidebar": {
     "card": "Card",
+    "paytab": "Pay",
     "menu": "Menu",
     "stars": "Starred accounts",
     "accounts": "Accounts",


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Sidebar rendering: Pay entry appears instead of Card when \`lwdPayTab\` flag is enabled
  - Navigation to \`/paytab\` route
  - PayTab page renders correctly with its header

### 📝 Description

The Card sidebar item is being replaced by a new Pay tab when the \`lwdPayTab\` feature flag is active. This is the foundational wiring needed before the Pay tab can be built out.

This PR adds:
- A new \`/paytab\` route in the app router
- A \`PayTab\` feature component (initially just a page header)
- Sidebar logic to show **Pay** (with \`DollarConvert\` icon) instead of **Card** when \`lwdPayTab\` is enabled
- \`isPayTabEnabled\` on the SideBar view model, driven by \`useFeature("lwdPayTab")\`
- Integration tests covering the flag-on/flag-off sidebar states and navigation


https://github.com/user-attachments/assets/178d8d76-69de-4e35-b37b-7f91ebb447bf



### ❓ Context

- **JIRA or GitHub link**: [LIVE-34080](https://ledgerhq.atlassian.net/browse/LIVE-34080)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34080]: https://ledgerhq.atlassian.net/browse/LIVE-34080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ