### PR TITLE
chore(feature-flags): add card param to lwdPayTab and lwmPayTab flags

### DIFF
--- a/.changeset/eleven-boats-develop.md
+++ b/.changeset/eleven-boats-develop.md
@@ -1,0 +1,5 @@
+---
+"@shared/feature-flags": minor
+---
+
+Add `card` boolean param to `lwdPayTab` and `lwmPayTab` feature flags

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwdPayTab.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwdPayTab.ts
@@ -1,2 +1,14 @@
-import { flag } from "../../define";
-export const lwdPayTab = flag();
+import { flagWith } from "../../define";
+import { z } from "zod";
+
+export const lwdPayTab = flagWith(
+  {
+    card: z.boolean(),
+  },
+  {
+    enabled: false,
+    params: {
+      card: true,
+    },
+  },
+);

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwmPayTab.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwmPayTab.ts
@@ -1,2 +1,14 @@
-import { flag } from "../../define";
-export const lwmPayTab = flag();
+import { flagWith } from "../../define";
+import { z } from "zod";
+
+export const lwmPayTab = flagWith(
+  {
+    card: z.boolean(),
+  },
+  {
+    enabled: false,
+    params: {
+      card: true,
+    },
+  },
+);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Feature flag consumers of `lwdPayTab` and `lwmPayTab` in LWD and LWM

### 📝 Description

The `lwdPayTab` and `lwmPayTab` feature flags previously used the simple `flag()` definition with no configurable parameters. This PR upgrades both flags to use `flagWith()`, adding a `card` boolean parameter (defaulting to `true`) that allows remote configuration to control card-related UI within the Pay Tab feature.

The flags remain disabled by default (`enabled: false`), preserving existing behavior until explicitly enabled via feature flag tooling.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34113](https://ledgerhq.atlassian.net/browse/LIVE-34113)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34113]: https://ledgerhq.atlassian.net/browse/LIVE-34113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ