### PR TITLE
[LWM] feat(mobile): add Pay tab to main navigation bar behind lwmPayTab flag

### DIFF
--- a/.changeset/two-feet-smash.md
+++ b/.changeset/two-feet-smash.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat(mobile): add Pay tab to main navigation bar (Wallet 4.0) behind `lwmPayTab` feature flag

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator/Wallet40TabNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator/Wallet40TabNavigator.tsx
@@ -4,6 +4,7 @@ import PortfolioNavigator from "../PortfolioNavigator";
 import SwapNavigator from "../SwapNavigator";
 import EarnLiveAppNavigator from "../EarnLiveAppNavigator";
 import CardLandingNavigator from "LLM/features/Card";
+import PayTabNavigator from "LLM/features/PayTab";
 import { Tab } from "./tabNavigator";
 import type { Wallet40TabNavigatorProps } from "./types";
 import { SwapWallet40Header } from "~/screens/Swap/LiveApp/components/SwapWallet40Header";
@@ -16,6 +17,7 @@ function Wallet40SwapTabHeader() {
 export function Wallet40TabNavigator({
   tabBar,
   screenOptions,
+  isPayTabEnabled,
 }: Readonly<Wallet40TabNavigatorProps>): React.JSX.Element {
   return (
     <Tab.Navigator tabBar={tabBar} screenOptions={screenOptions}>
@@ -32,7 +34,11 @@ export function Wallet40TabNavigator({
         })}
       />
       <Tab.Screen name={NavigatorName.Earn} component={EarnLiveAppNavigator} />
-      <Tab.Screen name={NavigatorName.CardTab} component={CardLandingNavigator} />
+      {isPayTabEnabled ? (
+        <Tab.Screen name={NavigatorName.PayTab} component={PayTabNavigator} />
+      ) : (
+        <Tab.Screen name={NavigatorName.CardTab} component={CardLandingNavigator} />
+      )}
     </Tab.Navigator>
   );
 }

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator/index.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useTheme } from "styled-components/native";
+import { useFeature } from "@features/platform-feature-flags";
 import { useSelector } from "~/context/hooks";
 import { isMainNavigatorVisibleSelector } from "~/reducers/appstate";
 import { useTabBar } from "./useTabBar";
@@ -9,6 +10,7 @@ import { Wallet40TabNavigator } from "./Wallet40TabNavigator";
 export default function MainNavigator() {
   const { colors } = useTheme();
   const isMainNavigatorVisible = useSelector(isMainNavigatorVisibleSelector);
+  const isPayTabEnabled = !!useFeature("lwmPayTab")?.enabled;
 
   const tabBar = useTabBar({
     isMainNavigatorVisible,
@@ -18,5 +20,11 @@ export default function MainNavigator() {
     colors,
   });
 
-  return <Wallet40TabNavigator tabBar={tabBar} screenOptions={screenOptions} />;
+  return (
+    <Wallet40TabNavigator
+      tabBar={tabBar}
+      screenOptions={screenOptions}
+      isPayTabEnabled={isPayTabEnabled}
+    />
+  );
 }

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator/types.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator/types.ts
@@ -12,7 +12,9 @@ export type TabNavigatorProps = CommonTabNavigatorProps & {
   navigateToRebornFlow: () => void;
 };
 
-export type Wallet40TabNavigatorProps = CommonTabNavigatorProps;
+export type Wallet40TabNavigatorProps = CommonTabNavigatorProps & {
+  isPayTabEnabled: boolean;
+};
 
 export type LegacyTabNavigatorProps = TabNavigatorProps & {
   openTransferDrawer: (params: { sourceScreenName: string }) => void;

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/MainNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/MainNavigator.ts
@@ -6,6 +6,7 @@ import { MyLedgerNavigatorStackParamList } from "./MyLedgerNavigator";
 import { PortfolioNavigatorStackParamList } from "./PortfolioNavigator";
 import { EarnLiveAppNavigatorParamList } from "./EarnLiveAppNavigator";
 import type { CardLandingNavigatorParamList } from "LLM/features/Card";
+import type { PayTabNavigatorParamList } from "LLM/features/PayTab";
 import type { SwapNavigatorParamList } from "./SwapNavigator";
 
 export type MainNavigatorParamList = {
@@ -17,4 +18,5 @@ export type MainNavigatorParamList = {
   [NavigatorName.Web3HubTab]: NavigatorScreenParams<Web3HubTabStackParamList> | undefined;
   [NavigatorName.MyLedger]: NavigatorScreenParams<MyLedgerNavigatorStackParamList> | undefined;
   [NavigatorName.CardTab]: NavigatorScreenParams<CardLandingNavigatorParamList> | undefined;
+  [NavigatorName.PayTab]: NavigatorScreenParams<PayTabNavigatorParamList> | undefined;
 };

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -108,6 +108,7 @@ export enum ScreenName {
   EditAccountName = "EditAccountName",
   EditDeviceName = "EditDeviceName",
   Card = "Card",
+  PayTab = "PayTab",
   ExchangeBuy = "ExchangeBuy",
   ExchangeDeveloperMode = "ExchangeDeveloperMode",
   ExchangeSelectAccount = "ExchangeSelectAccount",
@@ -773,6 +774,7 @@ export enum NavigatorName {
   // Tab
   Main = "Main",
   CardTab = "CardTab",
+  PayTab = "PayTab",
   // Root
   RootNavigator = "RootNavigator",
   Discover = "Discover",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9935,7 +9935,8 @@
     "swap": "Swap",
     "earn": "Earn",
     "yield": "Yield",
-    "card": "Card"
+    "card": "Card",
+    "paytab": "Pay"
   },
   "syncIndicator": {
     "accessibilityLabel": {

--- a/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/constants.ts
@@ -5,6 +5,7 @@ const LABELKEY_MAP: Partial<Record<string, string>> = {
   [NavigatorName.Portfolio]: "mainNavigation.home",
   [NavigatorName.Swap]: "mainNavigation.swap",
   [NavigatorName.CardTab]: "mainNavigation.card",
+  [NavigatorName.PayTab]: "mainNavigation.paytab",
 };
 
 export const getLabelKey = (routeName: string): string =>
@@ -19,4 +20,5 @@ export const TRACKING_LABEL_MAP: Partial<Record<string, string>> = {
   [NavigatorName.Swap]: "Swap",
   [NavigatorName.Earn]: "Earn",
   [NavigatorName.CardTab]: "Card",
+  [NavigatorName.PayTab]: "PayTab",
 };

--- a/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/useMainTabBarViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/useMainTabBarViewModel.ts
@@ -9,6 +9,7 @@ import {
   ExchangeFill,
   CreditCard,
   CreditCardFill,
+  DollarConvert,
 } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { NavigatorName } from "~/const";
 import type { TabItemConfig, MainTabBarViewProps } from "./types";
@@ -31,6 +32,7 @@ const TAB_ICONS: Partial<Record<string, TabIconConfig>> = {
   [NavigatorName.Swap]: { icon: Exchange, activeIcon: ExchangeFill },
   [NavigatorName.Earn]: { icon: Chart5, activeIcon: Chart5Fill },
   [NavigatorName.CardTab]: { icon: CreditCard, activeIcon: CreditCardFill },
+  [NavigatorName.PayTab]: { icon: DollarConvert, activeIcon: DollarConvert },
 };
 
 const TAB_TEST_IDS: Partial<Record<string, string>> = {
@@ -38,6 +40,7 @@ const TAB_TEST_IDS: Partial<Record<string, string>> = {
   [NavigatorName.Swap]: "w40-tab-swap",
   [NavigatorName.Earn]: "w40-tab-earn",
   [NavigatorName.CardTab]: "w40-tab-card",
+  [NavigatorName.PayTab]: "w40-tab-paytab",
 };
 
 function trackTabNavigation(targetName: string, sourceName: string, value: string) {

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/Navigator.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { ScreenName } from "~/const";
+import { PayTabScreen } from "./screens/PayTab";
+import type { PayTabNavigatorParamList } from "./types";
+
+const TabStack = createNativeStackNavigator<PayTabNavigatorParamList>();
+
+export default function PayTabNavigator() {
+  return (
+    <TabStack.Navigator screenOptions={{ headerShown: false }}>
+      <TabStack.Screen name={ScreenName.PayTab} component={PayTabScreen} />
+    </TabStack.Navigator>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/index.ts
@@ -1,0 +1,3 @@
+export { default } from "./Navigator";
+export { PayTabScreen } from "./screens/PayTab";
+export type { PayTabNavigatorParamList } from "./types";

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/index.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { View } from "react-native";
+import SafeAreaView from "~/components/SafeAreaView";
+
+export const PayTabScreen = () => {
+  return (
+    <SafeAreaView isFlex testID="paytab-screen">
+      <View />
+    </SafeAreaView>
+  );
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/types.ts
@@ -1,0 +1,5 @@
+import { ScreenName } from "~/const";
+
+export type PayTabNavigatorParamList = {
+  [ScreenName.PayTab]: undefined;
+};


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Pay tab appears in the main tab bar when the `lwmPayTab` feature flag is enabled
  - Card tab is shown as fallback when the flag is disabled — no regression for existing users
  - Tab bar layout, ordering, and icons for all other tabs remain unaffected
  - Localization: "Pay" label added to English locale (and will propagate to other languages)

### 📝 Description

The Wallet 4.0 main tab bar currently shows a Card tab. This PR introduces a **Pay tab** as a feature-flagged replacement for that slot, allowing the team to roll out the Pay experience progressively without impacting existing users.

When the `lwmPayTab` feature flag is enabled, the `PayTab` navigator is mounted in place of `CardLandingNavigator`. The flag is read in `MainNavigator` via `useFeature("lwmPayTab")` and passed down as a prop to `Wallet40TabNavigator`. The `PayTab` feature module lives under `src/mvvm/features/PayTab/` following the MVVM structure.


https://github.com/user-attachments/assets/45d85c81-3912-4766-bf96-8add03923abd



### ❓ Context

- **JIRA or GitHub link**: [LIVE-34082](https://ledgerhq.atlassian.net/browse/LIVE-34082)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34082]: https://ledgerhq.atlassian.net/browse/LIVE-34082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ