### PR TITLE
feat(contacts): add flow contacts package

### DIFF
--- a/.changeset/contacts-flow-skeleton.md
+++ b/.changeset/contacts-flow-skeleton.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": patch
+---
+
+Create the Contacts flow package.

--- a/features/flow/contacts/CHANGELOG.md
+++ b/features/flow/contacts/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @features/flow-contacts

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -1,0 +1,22 @@
+# @features/flow-contacts
+
+Shared Contacts flow package.
+
+This package owns Contacts-specific flow logic shared by Desktop and Mobile. It may depend on feature platform packages, domain packages, and shared packages when a flow needs them, but it must not contain app routing, app screen composition, persistence, Ledger Sync, device actions, or signer payloads.
+
+## Current scope
+
+- Minimal pure resolver for the Contacts feature flag configuration.
+
+UI screens and scenario state will be added by the dedicated Contacts scenario tickets.
+
+## Usage
+
+```ts
+import { resolveContactsFeatureConfig } from "@features/flow-contacts";
+
+const { isEnabled, showNewBadge } = resolveContactsFeatureConfig({
+  enabled: true,
+  params: { newFlag: true },
+});
+```

--- a/features/flow/contacts/jest.config.js
+++ b/features/flow/contacts/jest.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+          parser: { syntax: "typescript" },
+        },
+      },
+    ],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/features/flow/contacts/package.json
+++ b/features/flow/contacts/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@features/flow-contacts",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shared Contacts flow package",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./featureFlags": "./src/featureFlags.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W features/flow/contacts"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/features/flow/contacts/project.json
+++ b/features/flow/contacts/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@features/flow-contacts",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/features/flow/contacts/src/featureFlags.test.ts
+++ b/features/flow/contacts/src/featureFlags.test.ts
@@ -1,0 +1,31 @@
+import { resolveContactsFeatureConfig } from "./featureFlags";
+
+describe("resolveContactsFeatureConfig", () => {
+  it("returns disabled config without a feature value", () => {
+    expect(resolveContactsFeatureConfig(null)).toEqual({
+      isEnabled: false,
+      showNewBadge: false,
+    });
+  });
+
+  it("returns disabled config when the flag is disabled", () => {
+    expect(resolveContactsFeatureConfig({ enabled: false, params: { newFlag: true } })).toEqual({
+      isEnabled: false,
+      showNewBadge: false,
+    });
+  });
+
+  it("returns enabled config without a new badge when the flag is enabled only", () => {
+    expect(resolveContactsFeatureConfig({ enabled: true, params: { newFlag: false } })).toEqual({
+      isEnabled: true,
+      showNewBadge: false,
+    });
+  });
+
+  it("returns enabled config with a new badge only when the flag and param are enabled", () => {
+    expect(resolveContactsFeatureConfig({ enabled: true, params: { newFlag: true } })).toEqual({
+      isEnabled: true,
+      showNewBadge: true,
+    });
+  });
+});

--- a/features/flow/contacts/src/featureFlags.ts
+++ b/features/flow/contacts/src/featureFlags.ts
@@ -1,0 +1,22 @@
+export type ContactsFeatureConfig = Readonly<{
+  isEnabled: boolean;
+  showNewBadge: boolean;
+}>;
+
+export type ContactsFeatureValue = Readonly<{
+  enabled?: boolean;
+  params?: Readonly<{
+    newFlag?: boolean;
+  }>;
+}>;
+
+export function resolveContactsFeatureConfig(
+  feature: ContactsFeatureValue | null | undefined,
+): ContactsFeatureConfig {
+  const isEnabled = feature?.enabled === true;
+
+  return {
+    isEnabled,
+    showNewBadge: isEnabled && feature?.params?.newFlag === true,
+  };
+}

--- a/features/flow/contacts/src/index.ts
+++ b/features/flow/contacts/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./featureFlags";

--- a/features/flow/contacts/tsconfig.json
+++ b/features/flow/contacts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/knip.json
+++ b/knip.json
@@ -197,6 +197,9 @@
     "./features/flow/market-banner": {
       "entry": ["src/index.ts", "src/components/MarketBanner/index.native.ts"]
     },
+    "./features/flow/contacts": {
+      "entry": ["src/index.ts"]
+    },
     "./features/platform/feature-flags": {
       "entry": ["src/index.ts"]
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3625,6 +3625,24 @@ importers:
         specifier: 1.51.0
         version: 1.51.0
 
+  features/flow/contacts:
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.2
+
   features/flow/market-banner:
     devDependencies:
       '@gorhom/bottom-sheet':


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Ran `pnpm --filter @features/flow-contacts test --runInBand`, `typecheck`, `unimported`, and `git diff --check`.
- [x] **Impact of the changes:**
      Adds the minimal `@features/flow-contacts` package used as the Contacts flow home before moving Contacts-specific feature flag logic out of platform feature flags.

### 📝 Description

Creates `@features/flow-contacts` with explicit exports, package configuration, Nx noop build target, Jest/TypeScript setup, knip workspace entry, README, changelog, lockfile entry, and changeset.

The package intentionally contains only a pure `resolveContactsFeatureConfig` helper for now. UI, routing, Ledger Sync, device actions, signer validation, and the React `useContactsFeature` hook remain out of this PR. The hook will be added in the Contacts feature flag PR once the shared flags exist in the stacked branch.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-33877

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
