### PR TITLE
feat(domain): add contacts entity package

### DIFF
--- a/.changeset/contacts-domain-entity.md
+++ b/.changeset/contacts-domain-entity.md
@@ -1,0 +1,5 @@
+---
+"@domain/entity-contact": patch
+---
+
+Create the Contacts domain entity package.

--- a/domain/entity/contact/CHANGELOG.md
+++ b/domain/entity/contact/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @domain/entity-contact

--- a/domain/entity/contact/README.md
+++ b/domain/entity/contact/README.md
@@ -1,0 +1,41 @@
+# @domain/entity-contact
+
+Domain entity for Contacts. It contains the minimal Zod-first model and mock factories required by the first mock-first Contacts flows.
+
+## Scope
+
+This package describes what Contacts flows manipulate:
+
+- the default `Me` contact used by the `Me` screens;
+- saved contacts;
+- EVM contact addresses with `currencyId`, `label`, and `address`.
+
+`currencyId` is the id of the `CryptoOrTokenCurrency` selected by MAD. Asset names, tickers, icons, and network display data are resolved later by flow or platform adapters.
+
+It does not implement persistence, WalletSync, Ledger Sync, device actions, signer payloads, routing, Redux slices, or UI.
+
+## Usage
+
+```ts
+import { contact } from "@domain/entity-contact";
+
+const ben = contact({
+  id: "contact-ben",
+  isMe: false,
+  name: "Ben",
+  addresses: [],
+});
+```
+
+Mock factories are available for tests:
+
+```ts
+import { mockMeContact, mockContactWithMultipleAddresses } from "@domain/entity-contact/schema.mock";
+```
+
+## Testing
+
+```sh
+pnpm test
+pnpm typecheck
+```

--- a/domain/entity/contact/jest.config.js
+++ b/domain/entity/contact/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/domain/entity/contact/package.json
+++ b/domain/entity/contact/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@domain/entity-contact",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Domain entity for Contacts: Zod schemas and mock factories",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./schema.mock": "./src/schema.mock.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W domain/entity/contact"
+  },
+  "dependencies": {
+    "@shared/schema-primitives": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/domain/entity/contact/project.json
+++ b/domain/entity/contact/project.json
@@ -1,0 +1,7 @@
+{
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/entity/contact/src/define.ts
+++ b/domain/entity/contact/src/define.ts
@@ -1,0 +1,10 @@
+import { ContactAddressSchema, ContactSchema } from "./schema";
+import type { Contact, ContactAddress, ContactAddressInput, ContactInput } from "./types";
+
+export function contact(data: ContactInput): Contact {
+  return ContactSchema.parse(data);
+}
+
+export function contactAddress(data: ContactAddressInput): ContactAddress {
+  return ContactAddressSchema.parse(data);
+}

--- a/domain/entity/contact/src/index.ts
+++ b/domain/entity/contact/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./schema";
+export * from "./types";
+export * from "./define";

--- a/domain/entity/contact/src/schema.mock.ts
+++ b/domain/entity/contact/src/schema.mock.ts
@@ -1,0 +1,67 @@
+import { contact, contactAddress } from "./define";
+import type { Contact, ContactAddress, ContactAddressInput, ContactInput } from "./types";
+
+export function mockContactAddress(overrides?: Partial<ContactAddressInput>): ContactAddress {
+  return contactAddress({
+    id: "address-ethereum",
+    currencyId: "ethereum",
+    label: "Ethereum",
+    address: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+    ...overrides,
+  });
+}
+
+export function mockMeContact(overrides?: Partial<ContactInput>): Contact {
+  return contact({
+    id: "contact-me",
+    isMe: true,
+    name: "Me",
+    addresses: [],
+    ...overrides,
+  });
+}
+
+export function mockContact(overrides?: Partial<ContactInput>): Contact {
+  return contact({
+    id: "contact-ben",
+    isMe: false,
+    name: "Ben",
+    addresses: [],
+    ...overrides,
+  });
+}
+
+export function mockContactWithAddress(overrides?: Partial<ContactInput>): Contact {
+  return mockContact({
+    addresses: [mockContactAddress()],
+    ...overrides,
+  });
+}
+
+export function mockContactWithMultipleAddresses(overrides?: Partial<ContactInput>): Contact {
+  return mockContact({
+    addresses: [
+      mockContactAddress({
+        id: "address-polygon",
+        currencyId: "polygon",
+        label: "Polygon",
+        address: "0x2ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+      }),
+      mockContactAddress(),
+    ],
+    ...overrides,
+  });
+}
+
+export function mockEmptyContacts(): Contact[] {
+  return [mockMeContact()];
+}
+
+export function mockPopulatedContacts(): Contact[] {
+  return [
+    mockMeContact(),
+    mockContact({ id: "contact-ada", name: "Ada" }),
+    mockContactWithMultipleAddresses(),
+    mockContact({ id: "contact-olive", name: "Olive" }),
+  ];
+}

--- a/domain/entity/contact/src/schema.test.ts
+++ b/domain/entity/contact/src/schema.test.ts
@@ -1,0 +1,91 @@
+import {
+  ContactAddressLabelSchema,
+  ContactAddressSchema,
+  ContactCurrencyIdSchema,
+  ContactEvmAddressSchema,
+  ContactSchema,
+} from "./schema";
+import {
+  mockContact,
+  mockContactAddress,
+  mockContactWithAddress,
+  mockContactWithMultipleAddresses,
+  mockEmptyContacts,
+  mockMeContact,
+  mockPopulatedContacts,
+} from "./schema.mock";
+
+describe("ContactSchema", () => {
+  it("parses the self contact used by Me screens", () => {
+    const contact = mockMeContact();
+
+    expect(ContactSchema.parse(contact)).toEqual(contact);
+    expect(contact.isMe).toBe(true);
+    expect(contact.name).toBe("Me");
+    expect(contact.addresses).toHaveLength(0);
+  });
+
+  it("parses a regular contact", () => {
+    const contact = mockContact();
+
+    expect(ContactSchema.parse(contact)).toEqual(contact);
+    expect(contact.isMe).toBe(false);
+  });
+
+  it("rejects a contact without a name", () => {
+    expect(() => ContactSchema.parse(mockContact({ name: "   " }))).toThrow();
+  });
+});
+
+describe("ContactAddressSchema", () => {
+  it("parses an EVM contact address", () => {
+    const address = mockContactAddress();
+
+    expect(ContactAddressSchema.parse(address)).toEqual(address);
+    expect(address.currencyId).toBe("ethereum");
+  });
+
+  it("parses a token currency id selected through MAD", () => {
+    expect(ContactCurrencyIdSchema.parse("ethereum/erc20/usd-tether")).toBe(
+      "ethereum/erc20/usd-tether",
+    );
+  });
+
+  it("parses a crypto currency id selected through MAD", () => {
+    expect(ContactCurrencyIdSchema.parse("ethereum")).toBe("ethereum");
+  });
+
+  it("rejects non-EVM address format", () => {
+    expect(() => ContactEvmAddressSchema.parse("not-an-address")).toThrow();
+  });
+
+  it("rejects non-ASCII address labels", () => {
+    expect(() => ContactAddressLabelSchema.parse("Ethér")).toThrow();
+  });
+});
+
+describe("contact mock factories", () => {
+  it("builds a contact with one address", () => {
+    const contact = mockContactWithAddress();
+
+    expect(ContactSchema.parse(contact)).toEqual(contact);
+    expect(contact.addresses).toHaveLength(1);
+    expect(contact.addresses[0]?.currencyId).toBe("ethereum");
+  });
+
+  it("builds a contact with multiple addresses", () => {
+    const contact = mockContactWithMultipleAddresses();
+
+    expect(ContactSchema.parse(contact)).toEqual(contact);
+    expect(contact.addresses.map(address => address.currencyId)).toEqual(["polygon", "ethereum"]);
+  });
+
+  it("builds empty and populated contact lists", () => {
+    expect(mockEmptyContacts()).toEqual([mockMeContact()]);
+
+    const contacts = mockPopulatedContacts();
+
+    expect(contacts.map(contact => contact.name)).toEqual(["Me", "Ada", "Ben", "Olive"]);
+    expect(contacts[2]?.addresses).toHaveLength(2);
+  });
+});

--- a/domain/entity/contact/src/schema.ts
+++ b/domain/entity/contact/src/schema.ts
@@ -1,0 +1,33 @@
+import { CurrencyIdSchema, NonEmptyStringSchema, TokenIdSchema } from "@shared/schema-primitives";
+import { z } from "zod";
+
+export const ContactIdSchema = NonEmptyStringSchema;
+export const ContactAddressIdSchema = NonEmptyStringSchema;
+export const ContactCurrencyIdSchema = z.union([CurrencyIdSchema, TokenIdSchema]);
+
+export const ContactNameSchema = NonEmptyStringSchema;
+
+export const ContactAddressLabelSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .regex(/^[\x20-\x7E]+$/, "Expected printable ASCII characters");
+
+export const ContactEvmAddressSchema = z
+  .string()
+  .trim()
+  .regex(/^0x[a-fA-F0-9]{40}$/, "Expected an EVM address");
+
+export const ContactAddressSchema = z.object({
+  id: ContactAddressIdSchema,
+  currencyId: ContactCurrencyIdSchema,
+  label: ContactAddressLabelSchema,
+  address: ContactEvmAddressSchema,
+});
+
+export const ContactSchema = z.object({
+  id: ContactIdSchema,
+  isMe: z.boolean(),
+  name: ContactNameSchema,
+  addresses: z.array(ContactAddressSchema),
+});

--- a/domain/entity/contact/src/types.ts
+++ b/domain/entity/contact/src/types.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import {
+  ContactAddressIdSchema,
+  ContactAddressLabelSchema,
+  ContactAddressSchema,
+  ContactCurrencyIdSchema,
+  ContactEvmAddressSchema,
+  ContactIdSchema,
+  ContactNameSchema,
+  ContactSchema,
+} from "./schema";
+
+export type ContactId = z.infer<typeof ContactIdSchema>;
+export type ContactAddressId = z.infer<typeof ContactAddressIdSchema>;
+export type ContactCurrencyId = z.infer<typeof ContactCurrencyIdSchema>;
+export type ContactName = z.infer<typeof ContactNameSchema>;
+export type ContactAddressLabel = z.infer<typeof ContactAddressLabelSchema>;
+export type ContactEvmAddress = z.infer<typeof ContactEvmAddressSchema>;
+export type ContactAddress = z.infer<typeof ContactAddressSchema>;
+export type Contact = z.infer<typeof ContactSchema>;
+
+export type ContactAddressInput = z.input<typeof ContactAddressSchema>;
+export type ContactInput = z.input<typeof ContactSchema>;

--- a/domain/entity/contact/tsconfig.json
+++ b/domain/entity/contact/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/knip.json
+++ b/knip.json
@@ -182,6 +182,9 @@
     "./domain/entity/currency-unit": {
       "entry": ["src/index.ts"]
     },
+    "./domain/entity/contact": {
+      "entry": ["src/index.ts"]
+    },
     "./domain/api/currency-fiat": {
       "entry": ["src/index.ts"]
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3193,6 +3193,31 @@ importers:
         specifier: 'catalog:'
         version: 6.0.2
 
+  domain/entity/contact:
+    dependencies:
+      '@shared/schema-primitives':
+        specifier: workspace:*
+        version: link:../../../shared/schema-primitives
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.2
+
   domain/entity/currency:
     dependencies:
       '@domain/entity-currency-crypto':


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Contacts domain schema and test mocks
      - Future Contacts flow/platform adapters that will consume the entity package

### 📝 Description

This PR adds the minimal `@domain/entity-contact` package for the Contacts feature. It defines the Zod-first Contact and ContactAddress entities, parser helpers, schema mocks, package configuration, and package-level tests.

The model intentionally stays small and MAD-compatible: contacts do not own networks, and contact addresses store only the resolved `currencyId` selected from a `CryptoOrTokenCurrency`. Display data such as asset name, ticker, icon, and network label will be resolved later by flow/platform adapters.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33875](https://ledgerhq.atlassian.net/browse/LIVE-33875)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33875]: https://ledgerhq.atlassian.net/browse/LIVE-33875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ