### PR TITLE
[LWD] feat(desktop): add paytab deeplink

### DIFF
--- a/.changeset/dull-olives-appear.md
+++ b/.changeset/dull-olives-appear.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add `ledgerlive://paytab` deeplink that navigates to the Pay Tab screen when the `lwdPayTab` feature flag is enabled, falling back to the default handler otherwise.

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/parseDeepLink.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/parseDeepLink.test.ts
@@ -341,6 +341,15 @@ describe("parseDeepLink", () => {
       });
     });
 
+    it("creates paytab route", () => {
+      const parsed = parseDeepLink("ledgerlive://paytab");
+      const route = createRoute(parsed);
+
+      expect(route).toEqual({
+        type: "paytab",
+      });
+    });
+
     it("creates product tour route", () => {
       const parsed = parseDeepLink("ledgerlive://product-tour");
       const route = createRoute(parsed);

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/payTab.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/payTab.handler.test.ts
@@ -1,0 +1,27 @@
+import { payTabHandler } from "../payTab.handler";
+import { createMockContext } from "./test-utils";
+
+describe("payTab.handler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("payTabHandler", () => {
+    it("navigates to /paytab when the lwdPayTab flag is enabled", () => {
+      const context = createMockContext({ isPayTabEnabled: true });
+
+      payTabHandler({ type: "paytab" }, context);
+
+      expect(context.navigate).toHaveBeenCalledWith("/paytab");
+    });
+
+    it("falls back to the default handler when the lwdPayTab flag is disabled", () => {
+      const context = createMockContext({ isPayTabEnabled: false });
+
+      payTabHandler({ type: "paytab" }, context);
+
+      expect(context.navigate).toHaveBeenCalledWith("/");
+      expect(context.navigate).not.toHaveBeenCalledWith("/paytab");
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/test-utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/test-utils.ts
@@ -19,5 +19,6 @@ export const createMockContext = (
   assetsPath: "/market",
   isProductTourEnabled: true,
   isGenericAwarenessModalEnabled: true,
+  isPayTabEnabled: false,
   ...overrides,
 });

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/payTab.handler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/payTab.handler.ts
@@ -1,0 +1,10 @@
+import { DeeplinkHandler } from "../types";
+import { defaultHandler } from "./default.handler";
+
+export const payTabHandler: DeeplinkHandler<"paytab"> = (_route, context) => {
+  if (!context.isPayTabEnabled) {
+    return defaultHandler({ type: "default" }, context);
+  }
+
+  context.navigate("/paytab");
+};

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/parseDeepLink.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/parseDeepLink.ts
@@ -21,6 +21,7 @@ import {
   MarketRoute,
   AssetRoute,
   PerpsRoute,
+  PayTabRoute,
   RecoverRoute,
   RecoverRestoreFlowRoute,
   PostOnboardingRoute,
@@ -269,6 +270,13 @@ export function createRoute(parsed: ParsedDeeplink): DeeplinkRoute {
     case "perps": {
       const route: PerpsRoute = {
         type: "perps",
+      };
+      return route;
+    }
+
+    case "paytab": {
+      const route: PayTabRoute = {
+        type: "paytab",
       };
       return route;
     }

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/registry.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/registry.ts
@@ -15,6 +15,7 @@ import { assetHandler } from "./handlers/asset.handler";
 import { marketHandler } from "./handlers/market.handler";
 import { recoverHandler, recoverRestoreFlowHandler } from "./handlers/recover.handler";
 import { perpsHandler } from "./handlers/perps.handler";
+import { payTabHandler } from "./handlers/payTab.handler";
 import { postOnboardingHandler } from "./handlers/postOnboarding.handler";
 import { ledgerSyncHandler } from "./handlers/ledgerSync.handler";
 import { productTourHandler } from "./handlers/productTour.handler";
@@ -41,6 +42,7 @@ export const deeplinkRegistry: DeeplinkHandlerRegistry = {
   market: marketHandler,
   asset: assetHandler,
   perps: perpsHandler,
+  paytab: payTabHandler,
   recover: recoverHandler,
   "recover-restore-flow": recoverRestoreFlowHandler,
   "post-onboarding": postOnboardingHandler,

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
@@ -56,6 +56,8 @@ export interface DeeplinkHandlerContext {
   isProductTourEnabled: boolean;
   /** `lwdGenericAwarenessModal` — deeplink opens the modal only when this flag is enabled. */
   isGenericAwarenessModalEnabled: boolean;
+  /** `lwdPayTab` — deeplink navigates to `/paytab` only when this flag is enabled; otherwise falls back to the default handler. */
+  isPayTabEnabled: boolean;
 }
 
 export interface ParsedDeeplink {
@@ -217,6 +219,10 @@ export interface PerpsRoute {
   type: "perps";
 }
 
+export interface PayTabRoute {
+  type: "paytab";
+}
+
 export interface LedgerSyncRoute {
   type: "ledgersync";
 }
@@ -256,6 +262,7 @@ export type DeeplinkRoute =
   | RecoverRoute
   | RecoverRestoreFlowRoute
   | PerpsRoute
+  | PayTabRoute
   | PostOnboardingRoute
   | LedgerSyncRoute
   | ProductTourRoute

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/useDeepLinkHandler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/useDeepLinkHandler.ts
@@ -46,6 +46,8 @@ export function useDeepLinkHandler() {
   const isProductTourEnabled = lwdProductTour?.enabled === true;
   const lwdGenericAwarenessModal = useFeature("lwdGenericAwarenessModal");
   const isGenericAwarenessModalEnabled = lwdGenericAwarenessModal?.enabled === true;
+  const lwdPayTab = useFeature("lwdPayTab");
+  const isPayTabEnabled = !!lwdPayTab?.enabled;
   const { shouldDisplayAssetSection, shouldDisplayAggregatedAssets } =
     useWalletFeaturesConfig("desktop");
   const accountsPath = getAccountsSidebarPath(shouldDisplayAssetSection);
@@ -88,6 +90,7 @@ export function useDeepLinkHandler() {
       recoverAppId,
       isProductTourEnabled,
       isGenericAwarenessModalEnabled,
+      isPayTabEnabled,
     }),
     [
       dispatch,
@@ -107,6 +110,7 @@ export function useDeepLinkHandler() {
       recoverAppId,
       isProductTourEnabled,
       isGenericAwarenessModalEnabled,
+      isPayTabEnabled,
     ],
   );
 


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Deep linking: `ledgerlive://paytab` route parsing and handler registration
  - Feature-flag gating: navigates to `/paytab` when `lwdPayTab` is enabled, falls back to default handler otherwise

### 📝 Description

This PR adds support for the `ledgerlive://paytab` deeplink in Ledger Live Desktop.

A new `payTabHandler` is registered in the deeplink registry. When invoked, it checks the `lwdPayTab` feature flag: if enabled it navigates to `/paytab`; otherwise it falls back to the default handler, keeping the experience unchanged for users without the flag.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34079](https://ledgerhq.atlassian.net/browse/LIVE-34079)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34079]: https://ledgerhq.atlassian.net/browse/LIVE-34079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ