### PR TITLE
[LWD] feat: add feature flag gate for Contacts entry configuration

### DIFF
--- a/.changeset/lwd-contacts-flag-gate.md
+++ b/.changeset/lwd-contacts-flag-gate.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add Desktop Contacts MVVM feature flag gate for `lwdContacts` entry configuration.

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -65,6 +65,7 @@
     "@devtools/shell": "workspace:^",
     "@devtools/bindings": "workspace:*",
     "@electron/fuses": "2.0.0",
+    "@features/flow-contacts": "workspace:^",
     "@features/platform-currencies": "workspace:^",
     "@features/platform-feature-flags": "workspace:^",
     "@features/platform-style": "workspace:^",

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/types.ts
@@ -1,4 +1,5 @@
 import type { Location } from "react-router";
+import type { ContactsEntryConfig } from "LLD/features/Contacts";
 import type { SideBarActiveValue } from "./utils";
 
 export interface ReferralProgramParams {
@@ -36,6 +37,7 @@ export interface SideBarViewModel {
   readonly isAccountsDisabled: boolean;
   readonly isLiveAppTabSelected: boolean;
   readonly isMyWalletEnabled: boolean;
+  readonly contactsEntryConfig: ContactsEntryConfig;
   readonly referralProgramConfig: ReferralProgramConfig | null;
   readonly recoverFeature: RecoverFeatureConfig | null;
   readonly recoverHomePath: string | undefined;

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/useSideBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/useSideBarViewModel.ts
@@ -13,6 +13,7 @@ import { openModal } from "~/renderer/actions/modals";
 import { setSidebarCollapsed } from "~/renderer/actions/settings";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { track } from "~/renderer/analytics/segment";
+import { useContactsEntryConfig } from "LLD/features/Contacts";
 import { RECEIVE_SOURCE_PAGE } from "LLD/features/Receive/types";
 import { useGetStakeLabelLocaleBased } from "~/renderer/hooks/useGetStakeLabelLocaleBased";
 import { useOpenSendFlow } from "LLD/features/Send/hooks/useOpenSendFlow";
@@ -144,6 +145,7 @@ export function useSideBarViewModel(): SideBarViewModel {
 
   const { shouldDisplayAssetSection, shouldDisplayMyWallet: isMyWalletEnabled } =
     useWalletFeaturesConfig("desktop");
+  const contactsEntryConfig = useContactsEntryConfig();
 
   const accountsSidebarPath = getAccountsSidebarPath(shouldDisplayAssetSection);
 
@@ -328,6 +330,7 @@ export function useSideBarViewModel(): SideBarViewModel {
     isAccountsDisabled: noAccounts,
     isLiveAppTabSelected,
     isMyWalletEnabled,
+    contactsEntryConfig,
     referralProgramConfig,
     recoverFeature,
     recoverHomePath,

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { render, screen, withFlagOverrides } from "tests/testSetup";
+import { useContactsEntryConfig } from "LLD/features/Contacts";
+
+const ContactsEntryGateProbe = () => {
+  const { isEnabled, showNewBadge } = useContactsEntryConfig();
+
+  if (!isEnabled) {
+    return null;
+  }
+
+  return (
+    <div data-testid="contacts-entry">
+      {showNewBadge ? <span data-testid="contacts-entry-new-badge">New</span> : null}
+    </div>
+  );
+};
+
+describe("Contacts integration", () => {
+  it("should not render the Contacts entry when lwdContacts is disabled", () => {
+    render(<ContactsEntryGateProbe />, {
+      initialState: withFlagOverrides({
+        lwdContacts: { enabled: false, params: { newBadge: false } },
+      }),
+    });
+
+    expect(screen.queryByTestId("contacts-entry")).not.toBeInTheDocument();
+  });
+
+  it("should render the Contacts entry without a New badge when enabled and newBadge is false", () => {
+    render(<ContactsEntryGateProbe />, {
+      initialState: withFlagOverrides({
+        lwdContacts: { enabled: true, params: { newBadge: false } },
+      }),
+    });
+
+    expect(screen.getByTestId("contacts-entry")).toBeVisible();
+    expect(screen.queryByTestId("contacts-entry-new-badge")).not.toBeInTheDocument();
+  });
+
+  it("should render the Contacts entry with a New badge when enabled and newBadge is true", () => {
+    render(<ContactsEntryGateProbe />, {
+      initialState: withFlagOverrides({
+        lwdContacts: { enabled: true, params: { newBadge: true } },
+      }),
+    });
+
+    expect(screen.getByTestId("contacts-entry")).toBeVisible();
+    expect(screen.getByTestId("contacts-entry-new-badge")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/__tests__/useContactsEntryConfig.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/__tests__/useContactsEntryConfig.test.ts
@@ -1,0 +1,56 @@
+import { renderHook, withFlagOverrides } from "tests/testSetup";
+import { resolveContactsEntryConfig, useContactsEntryConfig } from "../useContactsEntryConfig";
+
+describe("resolveContactsEntryConfig", () => {
+  it("should return disabled config without a feature value", () => {
+    expect(resolveContactsEntryConfig(null)).toEqual({
+      isEnabled: false,
+      showNewBadge: false,
+    });
+  });
+
+  it("should return enabled config with a new badge only when the flag and param are enabled", () => {
+    expect(resolveContactsEntryConfig({ enabled: true, params: { newBadge: true } })).toEqual({
+      isEnabled: true,
+      showNewBadge: true,
+    });
+  });
+});
+
+describe("useContactsEntryConfig", () => {
+  it("should return disabled config with the default registry value", () => {
+    const { result } = renderHook(() => useContactsEntryConfig());
+
+    expect(result.current).toEqual({ isEnabled: false, showNewBadge: false });
+  });
+
+  it("should return no new badge when the flag is disabled", () => {
+    const { result } = renderHook(() => useContactsEntryConfig(), {
+      initialState: withFlagOverrides({
+        lwdContacts: { enabled: false, params: { newBadge: true } },
+      }),
+    });
+
+    expect(result.current).toEqual({ isEnabled: false, showNewBadge: false });
+  });
+
+  it("should return enabled without new badge when newBadge is false", () => {
+    const { result } = renderHook(() => useContactsEntryConfig(), {
+      initialState: withFlagOverrides({
+        lwdContacts: { enabled: true, params: { newBadge: false } },
+      }),
+    });
+
+    expect(result.current).toEqual({ isEnabled: true, showNewBadge: false });
+  });
+
+  it("should return enabled with new badge when newBadge is true", () => {
+    const { result } = renderHook(() => useContactsEntryConfig(), {
+      initialState: withFlagOverrides({
+        lwdContacts: { enabled: true, params: { newBadge: true } },
+      }),
+    });
+
+    expect(result.current).toEqual({ isEnabled: true, showNewBadge: true });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsEntryConfig.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsEntryConfig.ts
@@ -1,0 +1,8 @@
+import { resolveContactsFeatureConfig, useContactsFeature } from "@features/flow-contacts";
+import type { ContactsEntryConfig } from "../types";
+
+export const resolveContactsEntryConfig = resolveContactsFeatureConfig;
+
+export function useContactsEntryConfig(): ContactsEntryConfig {
+  return useContactsFeature("desktop");
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/index.ts
@@ -1,0 +1,2 @@
+export { resolveContactsEntryConfig, useContactsEntryConfig } from "./hooks/useContactsEntryConfig";
+export type { ContactsEntryConfig } from "./types";

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/types.ts
@@ -1,0 +1,1 @@
+export type { ContactsFeatureConfig as ContactsEntryConfig } from "@features/flow-contacts";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -823,6 +823,9 @@ importers:
       '@features/flow-fear-and-greed':
         specifier: workspace:^
         version: link:../../features/flow/fear-and-greed
+      '@features/flow-contacts':
+        specifier: workspace:^
+        version: link:../../features/flow/contacts
       '@features/platform-currencies':
         specifier: workspace:^
         version: link:../../features/platform/currencies


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

This pull request introduces a feature flag gate for the Contacts entry in the Ledger Live Desktop app, allowing the Contacts feature to be conditionally enabled and to display a "New" badge based on flag parameters. The changes include the implementation of configuration logic, integration and unit tests, and type definitions to support this new feature flag.

**Feature flag gate for Contacts entry:**

* Added a feature flag gate for the Contacts entry (`lwdContacts`) using a new `useContactsEntryConfig` hook, which determines if the Contacts entry should be enabled and whether a "New" badge should be shown based on flag parameters. 
* Exported the configuration hook and related types from the Contacts feature module for broader usage.
* Documented the new feature flag in the changeset file.

**Testing:**

* Added integration tests to verify the Contacts entry visibility and "New" badge behavior under different flag configurations in `Contacts.integration.test.tsx`.
* Added unit tests for the configuration logic in `useContactsEntryConfig` and `resolveContactsEntryConfig`.

### 🔗 Context

[LIVE-33873](https://ledgerhq.atlassian.net/browse/LIVE-33873)

[LIVE-33873]: https://ledgerhq.atlassian.net/browse/LIVE-33873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ