### PR TITLE
[LWM] feat: add MVVM contacts entry feature flag gate

### DIFF
--- a/.changeset/lwm-contacts-flag-gate.md
+++ b/.changeset/lwm-contacts-flag-gate.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add Mobile Contacts MVVM feature flag gate for `lwmContacts` entry configuration.

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -87,6 +87,7 @@
     "@datadog/mobile-react-navigation": "2.8.2",
     "@domain/api-currency-token": "workspace:^",
     "@domain/entity-currency-crypto": "workspace:*",
+    "@features/flow-contacts": "workspace:^",
     "@features/platform-currencies": "workspace:^",
     "@devtools/shell": "workspace:^",
     "@devtools/bindings": "workspace:^",

--- a/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/useMainTabBarViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/useMainTabBarViewModel.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react";
 import type { BottomTabBarProps } from "@react-navigation/bottom-tabs";
+import { useContactsEntryConfig } from "LLM/features/Contacts";
 import {
   Home,
   HomeFill,
@@ -12,6 +13,7 @@ import {
   DollarConvert,
 } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { NavigatorName } from "~/const";
+import type { ContactsEntryConfig } from "LLM/features/Contacts";
 import type { TabItemConfig, MainTabBarViewProps } from "./types";
 import { useTranslation } from "~/context/Locale";
 import { track } from "~/analytics";
@@ -23,7 +25,9 @@ type UseMainTabBarViewModelParams = Pick<BottomTabBarProps, "state" | "navigatio
 type UseMainTabBarViewModelReturn = Pick<
   MainTabBarViewProps,
   "activeRouteName" | "tabItems" | "onTabPress"
->;
+> & {
+  readonly contactsEntryConfig: ContactsEntryConfig;
+};
 
 type TabIconConfig = { icon: TabItemConfig["icon"]; activeIcon?: TabItemConfig["activeIcon"] };
 
@@ -61,6 +65,7 @@ export const useMainTabBarViewModel = ({
 }: UseMainTabBarViewModelParams): UseMainTabBarViewModelReturn => {
   const activeRouteName = state.routes[state.index].name;
   const { t } = useTranslation();
+  const contactsEntryConfig = useContactsEntryConfig();
 
   const tabItems: readonly TabItemConfig[] = useMemo(
     () =>
@@ -104,5 +109,5 @@ export const useMainTabBarViewModel = ({
     [state.routes, activeRouteName, navigateToTab],
   );
 
-  return { activeRouteName, tabItems, onTabPress };
+  return { activeRouteName, tabItems, onTabPress, contactsEntryConfig };
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { Text } from "react-native";
+import { render, screen, withFlagOverrides } from "@tests/test-renderer";
+import { useContactsEntryConfig } from "LLM/features/Contacts";
+
+const ContactsEntryGateProbe = () => {
+  const { isEnabled, showNewBadge } = useContactsEntryConfig();
+
+  if (!isEnabled) {
+    return null;
+  }
+
+  return (
+    <>
+      <Text testID="contacts-entry">Contacts</Text>
+      {showNewBadge ? <Text testID="contacts-entry-new-badge">New</Text> : null}
+    </>
+  );
+};
+
+describe("Contacts integration", () => {
+  it("should not render the Contacts entry when lwmContacts is disabled", () => {
+    render(<ContactsEntryGateProbe />, {
+      overrideInitialState: withFlagOverrides({
+        lwmContacts: { enabled: false, params: { newBadge: false } },
+      }),
+    });
+
+    expect(screen.queryByTestId("contacts-entry")).toBeNull();
+  });
+
+  it("should render the Contacts entry without a New badge when enabled and newBadge is false", () => {
+    render(<ContactsEntryGateProbe />, {
+      overrideInitialState: withFlagOverrides({
+        lwmContacts: { enabled: true, params: { newBadge: false } },
+      }),
+    });
+
+    expect(screen.getByTestId("contacts-entry")).toBeVisible();
+    expect(screen.queryByTestId("contacts-entry-new-badge")).toBeNull();
+  });
+
+  it("should render the Contacts entry with a New badge when enabled and newBadge is true", () => {
+    render(<ContactsEntryGateProbe />, {
+      overrideInitialState: withFlagOverrides({
+        lwmContacts: { enabled: true, params: { newBadge: true } },
+      }),
+    });
+
+    expect(screen.getByTestId("contacts-entry")).toBeVisible();
+    expect(screen.getByTestId("contacts-entry-new-badge")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/__tests__/useContactsEntryConfig.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/__tests__/useContactsEntryConfig.test.ts
@@ -1,0 +1,56 @@
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { resolveContactsEntryConfig, useContactsEntryConfig } from "../useContactsEntryConfig";
+
+describe("resolveContactsEntryConfig", () => {
+  it("should return disabled config without a feature value", () => {
+    expect(resolveContactsEntryConfig(null)).toEqual({
+      isEnabled: false,
+      showNewBadge: false,
+    });
+  });
+
+  it("should return enabled config with a new badge only when the flag and param are enabled", () => {
+    expect(resolveContactsEntryConfig({ enabled: true, params: { newBadge: true } })).toEqual({
+      isEnabled: true,
+      showNewBadge: true,
+    });
+  });
+});
+
+describe("useContactsEntryConfig", () => {
+  it("should return disabled config with the default registry value", () => {
+    const { result } = renderHook(() => useContactsEntryConfig());
+
+    expect(result.current).toEqual({ isEnabled: false, showNewBadge: false });
+  });
+
+  it("should return no new badge when the flag is disabled", () => {
+    const { result } = renderHook(() => useContactsEntryConfig(), {
+      overrideInitialState: withFlagOverrides({
+        lwmContacts: { enabled: false, params: { newBadge: true } },
+      }),
+    });
+
+    expect(result.current).toEqual({ isEnabled: false, showNewBadge: false });
+  });
+
+  it("should return enabled without new badge when newBadge is false", () => {
+    const { result } = renderHook(() => useContactsEntryConfig(), {
+      overrideInitialState: withFlagOverrides({
+        lwmContacts: { enabled: true, params: { newBadge: false } },
+      }),
+    });
+
+    expect(result.current).toEqual({ isEnabled: true, showNewBadge: false });
+  });
+
+  it("should return enabled with new badge when newBadge is true", () => {
+    const { result } = renderHook(() => useContactsEntryConfig(), {
+      overrideInitialState: withFlagOverrides({
+        lwmContacts: { enabled: true, params: { newBadge: true } },
+      }),
+    });
+
+    expect(result.current).toEqual({ isEnabled: true, showNewBadge: true });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsEntryConfig.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsEntryConfig.ts
@@ -1,0 +1,8 @@
+import { resolveContactsFeatureConfig, useContactsFeature } from "@features/flow-contacts";
+import type { ContactsEntryConfig } from "../types";
+
+export const resolveContactsEntryConfig = resolveContactsFeatureConfig;
+
+export function useContactsEntryConfig(): ContactsEntryConfig {
+  return useContactsFeature("mobile");
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/index.ts
@@ -1,0 +1,2 @@
+export { resolveContactsEntryConfig, useContactsEntryConfig } from "./hooks/useContactsEntryConfig";
+export type { ContactsEntryConfig } from "./types";

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/types.ts
@@ -1,0 +1,1 @@
+export type { ContactsFeatureConfig as ContactsEntryConfig } from "@features/flow-contacts";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1521,6 +1521,9 @@ importers:
       '@domain/entity-market-sentiment':
         specifier: workspace:^
         version: link:../../domain/entity/market-sentiment
+      '@features/flow-contacts':
+        specifier: workspace:^
+        version: link:../../features/flow/contacts
       '@features/flow-fear-and-greed':
         specifier: workspace:^
         version: link:../../features/flow/fear-and-greed
@@ -33651,6 +33654,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode-terminal@0.11.0:


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

This pull request introduces a feature flag gate for the Contacts entry in the mobile MVVM architecture, allowing the Contacts feature to be toggled and to display a "New" badge based on the flag configuration. The implementation includes new configuration logic, hooks, types, and comprehensive tests to ensure correct behavior.

**Feature flag integration and configuration:**
- Added a new `resolveContactsEntryConfig` function and `useContactsEntryConfig` hook to determine if the Contacts entry should be enabled and whether to show a "New" badge, based on the `lwmContacts` feature flag and its parameters. 
- Defined a new type `ContactsEntryConfig` to encapsulate the configuration for the Contacts entry.
- Exposed the new configuration functions and types from the Contacts feature module. 

**Testing and validation:**
- Added integration tests to verify that the Contacts entry and "New" badge render correctly based on the feature flag state.
- Added unit tests for the configuration resolution logic and the custom hook to ensure all scenarios are covered.

**Documentation and changelog:**
- Documented the addition of the Mobile Contacts MVVM feature flag gate in the changeset. (`.changeset/lwm-contacts-flag-gate.md` 

### 🔗 Context

[LIVE-33874](https://ledgerhq.atlassian.net/browse/LIVE-33874)


[LIVE-33874]: https://ledgerhq.atlassian.net/browse/LIVE-33874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ