### PR TITLE
[LWM] fix: aleo mobile add account cancel confirmation

### DIFF
--- a/.changeset/silent-scissors-bake.md
+++ b/.changeset/silent-scissors-bake.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix the Aleo add-account Cancel confirmation not navigating away once confirmed, and add the same confirm-before-quit modal to the ViewKeyApprove screen's Cancel button

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/AddAccountNavigator.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/AddAccountNavigator.tsx
@@ -99,7 +99,7 @@ function AddAccountNavigator({ route, navigation }: Readonly<Props>) {
         name={ScreenName.AleoViewKeyApprove}
         component={ViewKeyApproveScreen}
         initialParams={{ ...route.params, onCloseNavigation: handleClose }}
-        options={{ headerTitle: "" }}
+        options={{ headerTitle: "", headerLeft: () => null, gestureEnabled: false }}
       />
       <Stack.Screen
         name={ScreenName.AleoNoAccountsAdded}

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/QuitConfirmationModal.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/QuitConfirmationModal.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { StyleSheet } from "react-native";
+import ConfirmationModal from "~/components/ConfirmationModal";
+import { Trans } from "~/context/Locale";
+
+const styles = StyleSheet.create({
+  confirmationTitle: {
+    textAlign: "left",
+    fontSize: 18,
+    fontWeight: "600",
+    lineHeight: 32.4,
+    letterSpacing: -0.72,
+    marginBottom: 16,
+    marginTop: -45,
+  },
+});
+
+type Props = {
+  isOpened: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  onModalHide?: () => void;
+};
+
+export default function QuitConfirmationModal({
+  isOpened,
+  onClose,
+  onConfirm,
+  onModalHide,
+}: Props) {
+  return (
+    <ConfirmationModal
+      isOpened={isOpened}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      onModalHide={onModalHide}
+      confirmationTitle={<Trans i18nKey="addAccounts.quitConfirmation.v2.title" />}
+      confirmButtonText={<Trans i18nKey="addAccounts.quitConfirmation.v2.cancel" />}
+      rejectButtonText={<Trans i18nKey="addAccounts.quitConfirmation.v2.continue" />}
+      cancelCTAConfig={{ type: "primary", outline: true }}
+      customTitleStyle={styles.confirmationTitle}
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyApproveScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyApproveScreen.tsx
@@ -25,6 +25,8 @@ import { useSelector, useDispatch } from "~/context/hooks";
 import { accountsSelector } from "~/reducers/accounts";
 import { TrackScreen } from "~/analytics";
 import type { AleoViewKeyFlowParamList } from "./types";
+import QuitConfirmationModal from "./QuitConfirmationModal";
+import useQuitConfirmation from "./useQuitConfirmation";
 
 type Props = StackNavigatorProps<AleoViewKeyFlowParamList, ScreenName.AleoViewKeyApprove>;
 
@@ -90,6 +92,13 @@ export default function ViewKeyApproveScreen({ route, navigation }: Props) {
       onCloseNavigation?.();
     }
   }, [hasAccountsToAdd, onCloseNavigation]);
+
+  const quitConfirmation = useQuitConfirmation({
+    onCloseNavigation,
+    onConfirm: useCallback(() => {
+      abortedRef.current = true;
+    }, []),
+  });
 
   const onResult = useCallback(() => {
     if (abortedRef.current) return;
@@ -159,11 +168,6 @@ export default function ViewKeyApproveScreen({ route, navigation }: Props) {
     ],
   );
 
-  const onCancel = useCallback(() => {
-    abortedRef.current = true;
-    onCloseNavigation?.();
-  }, [onCloseNavigation]);
-
   const renderApprovalContent = () => {
     if (hookState.sharePending) {
       return (
@@ -201,7 +205,7 @@ export default function ViewKeyApproveScreen({ route, navigation }: Props) {
             <Button
               type="main"
               outline
-              onPress={onCancel}
+              onPress={quitConfirmation.open}
               event="AleoAddAccountViewKeyApproveCancelAll"
             >
               {t("aleo.addAccount.stepViewKeyApprove.cancelAllBtn", {
@@ -234,6 +238,12 @@ export default function ViewKeyApproveScreen({ route, navigation }: Props) {
         onResult={onResult}
       />
       {renderApprovalContent()}
+      <QuitConfirmationModal
+        isOpened={quitConfirmation.isOpened}
+        onClose={quitConfirmation.close}
+        onConfirm={quitConfirmation.confirm}
+        onModalHide={quitConfirmation.onModalHide}
+      />
     </SafeAreaView>
   );
 }

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyWarningScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyWarningScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 import { Linking, ScrollView, StyleSheet, View } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "styled-components/native";
@@ -10,7 +10,8 @@ import { Trans, useTranslation } from "~/context/Locale";
 import { urls } from "~/utils/urls";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 import type { AleoViewKeyFlowParamList } from "./types";
-import ConfirmationModal from "~/components/ConfirmationModal";
+import QuitConfirmationModal from "./QuitConfirmationModal";
+import useQuitConfirmation from "./useQuitConfirmation";
 import { TrackScreen } from "~/analytics";
 
 type Props = StackNavigatorProps<AleoViewKeyFlowParamList, ScreenName.AleoViewKeyWarning>;
@@ -23,24 +24,13 @@ const bulletPointTranslationKeys = [
   "aleo.addAccount.stepViewKeyWarning.bullets.4",
 ];
 
-const confirmationTitleStyle: Record<string, unknown> = {
-  textAlign: "left",
-  fontSize: 18,
-  fontWeight: "600",
-  lineHeight: 32.4,
-  letterSpacing: -0.72,
-  marginBottom: 16,
-  marginTop: -45,
-};
-
 export default function ViewKeyWarningScreen({ route, navigation }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
 
   const { onCloseNavigation } = route.params;
   const learnMoreUrl = useLocalizedUrl(urls.aleo.learnMore);
-  const [isConfirmationModalOpened, setIsConfirmationModalOpened] = useState(false);
-  const [shouldNavigateOnHide, setShouldNavigateOnHide] = useState(false);
+  const quitConfirmation = useQuitConfirmation({ onCloseNavigation });
 
   const onContinue = useCallback(() => {
     navigation.getParent()?.navigate(ScreenName.ScanDeviceAccounts, {
@@ -48,20 +38,6 @@ export default function ViewKeyWarningScreen({ route, navigation }: Props) {
       onCloseNavigation,
     });
   }, [navigation, onCloseNavigation, route.params]);
-
-  const onCancel = useCallback(() => {
-    setIsConfirmationModalOpened(true);
-  }, []);
-
-  const closeConfirmationModal = useCallback(() => {
-    setShouldNavigateOnHide(false);
-    setIsConfirmationModalOpened(false);
-  }, []);
-
-  const onConfirmCancel = useCallback(() => {
-    setShouldNavigateOnHide(true);
-    setIsConfirmationModalOpened(false);
-  }, []);
 
   return (
     <SafeAreaView
@@ -101,22 +77,17 @@ export default function ViewKeyWarningScreen({ route, navigation }: Props) {
           type="main"
           outline
           mt={4}
-          onPress={onCancel}
+          onPress={quitConfirmation.open}
           event="AleoAddAccountViewKeyWarningCancel"
         >
           {t("aleo.addAccount.stepViewKeyWarning.cta.cancel")}
         </Button>
       </View>
-      <ConfirmationModal
-        isOpened={isConfirmationModalOpened}
-        onClose={closeConfirmationModal}
-        onConfirm={onConfirmCancel}
-        onModalHide={shouldNavigateOnHide ? onCloseNavigation : undefined}
-        confirmationTitle={<Trans i18nKey="addAccounts.quitConfirmation.v2.title" />}
-        confirmButtonText={<Trans i18nKey="addAccounts.quitConfirmation.v2.cancel" />}
-        rejectButtonText={<Trans i18nKey="addAccounts.quitConfirmation.v2.continue" />}
-        cancelCTAConfig={{ type: "primary", outline: true }}
-        customTitleStyle={confirmationTitleStyle}
+      <QuitConfirmationModal
+        isOpened={quitConfirmation.isOpened}
+        onClose={quitConfirmation.close}
+        onConfirm={quitConfirmation.confirm}
+        onModalHide={quitConfirmation.onModalHide}
       />
     </SafeAreaView>
   );

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyApproveScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyApproveScreen.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { View, Text, TouchableOpacity } from "react-native";
-import { render, screen, fireEvent } from "@tests/test-renderer";
+import { View, Text, TouchableOpacity, Pressable } from "react-native";
+import { render, screen } from "@tests/test-renderer";
 import type { Account } from "@ledgerhq/types-live";
 import {
   useAleoViewKeyApproval,
@@ -39,6 +39,27 @@ const mockUseAleoViewKeyApproval = jest.mocked(useAleoViewKeyApproval);
 const mockBuildAccountsWithViewKeys = jest.mocked(buildAccountsWithViewKeys);
 
 let capturedOnResult: (() => void) | undefined;
+let capturedOnClose: (() => void) | undefined;
+let capturedOnModalHide: (() => void) | undefined;
+
+jest.mock("~/components/ConfirmationModal", () => {
+  return function MockConfirmationModal({
+    isOpened,
+    onClose,
+    onConfirm,
+    onModalHide,
+  }: {
+    isOpened: boolean;
+    onClose?: () => void;
+    onConfirm?: () => void;
+    onModalHide?: () => void;
+  }) {
+    capturedOnClose = onClose;
+    capturedOnModalHide = onModalHide;
+    if (!isOpened) return null;
+    return <Pressable testID="enabled-confirmation-modal-confirm-button" onPress={onConfirm} />;
+  };
+});
 
 jest.mock("~/components/DeviceAction", () => ({
   DeviceActionDefaultRendering: jest.fn(({ onResult }: { onResult: () => void }) => {
@@ -75,13 +96,6 @@ jest.mock("@ledgerhq/lumen-ui-rnative/symbols", () => ({
 
 jest.mock("~/components/Loading", () => ({
   Loading: () => <View testID="loading" />,
-}));
-
-// TrackScreen uses the real useIsFocused(), which subscribes to navigation focus
-// events outside of a Screen context here — stub it out so the test doesn't depend
-// on that subscription's behavior.
-jest.mock("~/analytics", () => ({
-  TrackScreen: () => null,
 }));
 
 jest.mock("~/components/wrappedUi/Button", () => {
@@ -157,6 +171,8 @@ describe("ViewKeyApproveScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     capturedOnResult = undefined;
+    capturedOnClose = undefined;
+    capturedOnModalHide = undefined;
     mockBuildAccountsWithViewKeys.mockReturnValue([]);
     mockViewKeyApprovalReturn = { ...defaultReturn };
   });
@@ -265,22 +281,80 @@ describe("ViewKeyApproveScreen", () => {
   });
 
   describe("cancel button", () => {
-    it("sets abortedRef on cancel so onResult becomes a no-op", () => {
-      renderScreen({
+    it("opens a confirmation modal instead of aborting immediately", async () => {
+      mockBuildAccountsWithViewKeys.mockReturnValue([ACCOUNT_1]);
+      const { user } = renderScreen({
         hookState: { sharePending: true, shareProgress: { completed: 0, total: 2 } },
+        payload: { account1: "vk1" },
       });
-      fireEvent.press(screen.getByTestId("button-AleoAddAccountViewKeyApproveCancelAll"));
-      capturedOnResult!();
+      await user.press(screen.getByTestId("button-AleoAddAccountViewKeyApproveCancelAll"));
+
+      expect(screen.getByTestId("enabled-confirmation-modal-confirm-button")).toBeTruthy();
+      // Not yet aborted: onResult still proceeds normally.
+      capturedOnResult?.();
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+    });
+
+    it("sets abortedRef and calls onCloseNavigation once quit is confirmed", async () => {
+      const mockOnCloseNavigation = jest.fn();
+      const { user } = renderScreen(
+        { hookState: { sharePending: true, shareProgress: { completed: 0, total: 2 } } },
+        { onCloseNavigation: mockOnCloseNavigation },
+      );
+
+      await user.press(screen.getByTestId("button-AleoAddAccountViewKeyApproveCancelAll"));
+      await user.press(screen.getByTestId("enabled-confirmation-modal-confirm-button"));
+      capturedOnModalHide?.();
+
+      capturedOnResult?.();
       expect(mockNavigation.replace).not.toHaveBeenCalled();
       expect(mockParentNavigate).not.toHaveBeenCalled();
       expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockOnCloseNavigation).toHaveBeenCalledTimes(1);
+    });
+
+    it("still calls onCloseNavigation when the drawer re-invokes onClose before onModalHide", async () => {
+      // The drawer fires onClose (sync) before onModalHide (animated); order matters here.
+      const mockOnCloseNavigation = jest.fn();
+      const { user } = renderScreen(
+        { hookState: { sharePending: true, shareProgress: { completed: 0, total: 2 } } },
+        { onCloseNavigation: mockOnCloseNavigation },
+      );
+
+      await user.press(screen.getByTestId("button-AleoAddAccountViewKeyApproveCancelAll"));
+      await user.press(screen.getByTestId("enabled-confirmation-modal-confirm-button"));
+      capturedOnClose?.();
+      capturedOnModalHide?.();
+
+      expect(mockOnCloseNavigation).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onCloseNavigation when the confirmation modal is dismissed without confirming", async () => {
+      const mockOnCloseNavigation = jest.fn();
+      mockBuildAccountsWithViewKeys.mockReturnValue([ACCOUNT_1]);
+      const { user } = renderScreen(
+        {
+          hookState: { sharePending: true, shareProgress: { completed: 0, total: 2 } },
+          payload: { account1: "vk1" },
+        },
+        { onCloseNavigation: mockOnCloseNavigation },
+      );
+
+      await user.press(screen.getByTestId("button-AleoAddAccountViewKeyApproveCancelAll"));
+      capturedOnClose?.();
+      capturedOnModalHide?.();
+
+      expect(mockOnCloseNavigation).not.toHaveBeenCalled();
+      // Not aborted: onResult still proceeds normally.
+      capturedOnResult?.();
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("onResult", () => {
     it("does nothing when payload is null", () => {
       renderScreen({ payload: null });
-      capturedOnResult!();
+      capturedOnResult?.();
       expect(mockDispatch).not.toHaveBeenCalled();
       expect(mockParentNavigate).not.toHaveBeenCalled();
     });
@@ -288,7 +362,7 @@ describe("ViewKeyApproveScreen", () => {
     it("navigates to AleoNoAccountsAdded when buildAccountsWithViewKeys returns empty", () => {
       mockBuildAccountsWithViewKeys.mockReturnValue([]);
       renderScreen({ payload: {} });
-      capturedOnResult!();
+      capturedOnResult?.();
       const { accountsToAdd: _accountsToAdd, ...expectedParams } = mockRoute.params;
       expect(mockNavigation.replace).toHaveBeenCalledTimes(1);
       expect(mockNavigation.replace).toHaveBeenCalledWith(
@@ -301,7 +375,7 @@ describe("ViewKeyApproveScreen", () => {
     it("dispatches addAccountsAction and navigates to AddAccountsSuccess", () => {
       mockBuildAccountsWithViewKeys.mockReturnValue([ACCOUNT_1]);
       renderScreen({ payload: { account1: "vk1" } });
-      capturedOnResult!();
+      capturedOnResult?.();
       expect(mockDispatch).toHaveBeenCalledTimes(1);
       expect(mockDispatch).toHaveBeenCalledWith({ type: "ADD_ACCOUNTS" });
       expect(mockParentNavigate).toHaveBeenCalledTimes(1);

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyWarningScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyWarningScreen.test.tsx
@@ -4,21 +4,25 @@ import { ScreenName } from "~/const";
 import ViewKeyWarningScreen from "../ViewKeyWarningScreen";
 import { aleoCurrency } from "../../__mocks__/currency.mock";
 
-// Capture onModalHide so each test can trigger it directly instead of
+// Capture onClose/onModalHide so each test can trigger them directly instead of
 // simulating the drawer's close animation via hooks.
+let capturedOnClose: (() => void) | undefined;
 let capturedOnModalHide: (() => void) | undefined;
 
 jest.mock("~/components/ConfirmationModal", () => {
   const { Pressable } = jest.requireActual<typeof import("react-native")>("react-native");
   return function MockConfirmationModal({
     isOpened,
+    onClose,
     onConfirm,
     onModalHide,
   }: {
     isOpened: boolean;
+    onClose?: () => void;
     onConfirm?: () => void;
     onModalHide?: () => void;
   }) {
+    capturedOnClose = onClose;
     capturedOnModalHide = onModalHide;
     if (!isOpened) return null;
     return <Pressable testID="enabled-confirmation-modal-confirm-button" onPress={onConfirm} />;
@@ -55,6 +59,7 @@ const renderScreen = () =>
 describe("ViewKeyWarningScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    capturedOnClose = undefined;
     capturedOnModalHide = undefined;
   });
 
@@ -92,10 +97,31 @@ describe("ViewKeyWarningScreen", () => {
 
     await user.press(screen.getByText("Cancel"));
     await user.press(screen.getByTestId("enabled-confirmation-modal-confirm-button"));
-    // After confirm, the component re-renders with onModalHide = onCloseNavigation.
-    // Call it directly to simulate the drawer's close animation completing.
+    // Simulate the drawer's close animation completing.
     capturedOnModalHide?.();
 
     expect(mockOnCloseNavigation).toHaveBeenCalledTimes(1);
+  });
+
+  it("still calls onCloseNavigation when the drawer re-invokes onClose before onModalHide", async () => {
+    // QueuedDrawer fires onClose (sync) before onModalHide (animated); order matters here.
+    const { user } = renderScreen();
+
+    await user.press(screen.getByText("Cancel"));
+    await user.press(screen.getByTestId("enabled-confirmation-modal-confirm-button"));
+    capturedOnClose?.();
+    capturedOnModalHide?.();
+
+    expect(mockOnCloseNavigation).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onCloseNavigation when the modal is dismissed without confirming", async () => {
+    const { user } = renderScreen();
+
+    await user.press(screen.getByText("Cancel"));
+    capturedOnClose?.();
+    capturedOnModalHide?.();
+
+    expect(mockOnCloseNavigation).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/useQuitConfirmation.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/useQuitConfirmation.ts
@@ -1,0 +1,31 @@
+import { useCallback, useRef, useState } from "react";
+
+type Params = {
+  onCloseNavigation?: () => void;
+  onConfirm?: () => void;
+};
+
+export default function useQuitConfirmation({ onCloseNavigation, onConfirm }: Params) {
+  const [isOpened, setIsOpened] = useState(false);
+  // The drawer's onClose fires before the animated onModalHide, even on our own
+  // close, so a ref (not state) is used to survive that and preserve intent.
+  const shouldNavigateOnHideRef = useRef(false);
+
+  const open = useCallback(() => setIsOpened(true), []);
+  const close = useCallback(() => setIsOpened(false), []);
+
+  const confirm = useCallback(() => {
+    onConfirm?.();
+    shouldNavigateOnHideRef.current = true;
+    setIsOpened(false);
+  }, [onConfirm]);
+
+  const onModalHide = useCallback(() => {
+    if (shouldNavigateOnHideRef.current) {
+      shouldNavigateOnHideRef.current = false;
+      onCloseNavigation?.();
+    }
+  }, [onCloseNavigation]);
+
+  return { isOpened, open, close, confirm, onModalHide };
+}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

- Fixes the Aleo mobile add-account flow's Cancel confirmation not navigating away after confirming, extracts the quit-confirmation logic into a shared useQuitConfirmation hook/modal.
- Adds the same confirm-before-quit behavior to the ViewKeyApprove screen's Cancel button.
- Remove ViewKeyApprove screen's back button.

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-30450
https://ledgerhq.atlassian.net/browse/LIVE-30451
https://ledgerhq.atlassian.net/browse/LIVE-30500