### PR TITLE
[LWDM] Claim rewards fails when Compound selected — should disable or support Cash in only

### DIFF
--- a/.changeset/babylon-disable-compound-claim.md
+++ b/.changeset/babylon-disable-compound-claim.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-cosmos": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Hide the "Compound" claim-rewards option for Cosmos-family chains that use epoching (wrapped) staking messages, such as Babylon. Compound restaking is not supported on those chains yet — its embedded delegate is not epoching-wrapped — so only "Cash in" (claim rewards) is offered, preventing the "claimRewardCompound is not supported" error.

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepClaimRewards.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepClaimRewards.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import type { CosmosAccount } from "@ledgerhq/live-common/families/cosmos/types";
+import StepClaimRewards from "./StepClaimRewards";
+import type { StepProps } from "../types";
+
+// Mock only external deps (bridge, unit, the delegation-selector's data hook, analytics);
+// the mode selector renders for real so we assert on the actual user-visible toggle.
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: () => ({
+    createTransaction: () => ({}),
+    updateTransaction: (tx: object, patch: object) => ({ ...tx, ...patch }),
+  }),
+}));
+jest.mock("~/renderer/hooks/useAccountUnit", () => ({
+  useAccountUnit: () => ({ code: "ATOM", name: "Cosmos", magnitude: 6 }),
+}));
+jest.mock("@ledgerhq/live-common/families/cosmos/react", () => ({
+  useCosmosFamilyDelegationsQuerySelector: () => ({
+    query: "",
+    setQuery: jest.fn(),
+    options: [],
+    value: null,
+  }),
+}));
+jest.mock("~/renderer/analytics/TrackPage", () => ({ __esModule: true, default: () => null }));
+
+const buildAccount = (currencyId: string) =>
+  ({
+    type: "Account",
+    freshAddress: "cosmos1test",
+    currency: getCryptoCurrencyById(currencyId),
+    cosmosResources: { delegations: [] },
+  }) as unknown as CosmosAccount;
+
+const buildProps = (currencyId: string, mode: string): StepProps =>
+  ({
+    account: buildAccount(currencyId),
+    parentAccount: undefined,
+    transaction: { family: "cosmos", mode, validators: [] },
+    status: { errors: {}, warnings: {} },
+    onUpdateTransaction: jest.fn(),
+    warning: null,
+    error: null,
+    t: (k: string) => k,
+  }) as unknown as StepProps;
+
+describe("Cosmos StepClaimRewards compound gating", () => {
+  it("shows the compound option on a standard cosmos chain", () => {
+    render(<StepClaimRewards {...buildProps("cosmos", "claimReward")} />);
+    expect(screen.getByRole("button", { name: "Compound" })).toBeVisible();
+  });
+
+  it("hides the compound option on an epoching chain (babylon)", () => {
+    render(<StepClaimRewards {...buildProps("babylon", "claimReward")} />);
+    expect(screen.queryByRole("button", { name: "Compound" })).not.toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepClaimRewards.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepClaimRewards.tsx
@@ -6,6 +6,7 @@ import { StepProps } from "../types";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Transaction } from "@ledgerhq/live-common/families/cosmos/types";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { isCompoundRewardSupported } from "@ledgerhq/live-common/families/cosmos/logic";
 import { localeSelector } from "~/renderer/reducers/settings";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
@@ -53,6 +54,7 @@ export default function StepClaimRewards({
     },
     [updateClaimRewards, transaction],
   );
+  const compoundSupported = isCompoundRewardSupported(account.currency.id);
   const selectedValidator = transaction.validators && transaction.validators[0];
   const amount =
     selectedValidator &&
@@ -90,7 +92,7 @@ export default function StepClaimRewards({
       />
       {warning && !error ? <ErrorBanner error={warning} warning /> : null}
       {error ? <ErrorBanner error={error} /> : null}
-      <ModeSelectorField mode={transaction.mode} onChange={onChangeMode} />
+      {compoundSupported && <ModeSelectorField mode={transaction.mode} onChange={onChangeMode} />}
       {amount && (
         <Text fontSize={4} ff="Inter|Medium" textAlign="center">
           <Trans

--- a/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/02-SelectMethod.test.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/02-SelectMethod.test.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { screen } from "@testing-library/react-native";
+import { render } from "@tests/test-renderer";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountScreen } from "LLM/hooks/useAccountScreen";
+import ClaimRewardsMethod from "./02-SelectMethod";
+
+// Mock only external deps (bridge/tx/account hooks, navigation theme); the mode toggle and
+// the rest of the screen render for real so we assert on the actual user-visible label.
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useTheme: () => ({
+    colors: { background: "#fff", grey: "#999", live: "#0af", white: "#fff" },
+  }),
+}));
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: () => ({
+    createTransaction: () => ({}),
+    updateTransaction: (tx: object, patch: object) => ({ ...tx, ...patch }),
+  }),
+}));
+jest.mock("@ledgerhq/live-common/bridge/useBridgeTransaction");
+jest.mock("LLM/hooks/useAccountScreen");
+jest.mock("LLM/hooks/useAccountUnit", () => ({
+  useAccountUnit: () => ({ code: "ATOM", name: "Cosmos", magnitude: 6 }),
+}));
+
+type Props = React.ComponentProps<typeof ClaimRewardsMethod>;
+
+const route = {
+  key: "k",
+  name: "CosmosClaimRewardsMethod",
+  params: {
+    accountId: "acc",
+    validator: { validatorAddress: "cosmosvaloper1x", name: "Val" },
+    value: BigNumber(1000),
+  },
+} as unknown as Props["route"];
+const navigation = { navigate: jest.fn() } as unknown as Props["navigation"];
+
+function setup(currencyId: string, mode: string) {
+  (useAccountScreen as jest.Mock).mockReturnValue({
+    account: {
+      type: "Account",
+      freshAddress: "cosmos1test",
+      currency: getCryptoCurrencyById(currencyId),
+      cosmosResources: { delegations: [] },
+    },
+  });
+  (useBridgeTransaction as jest.Mock).mockReturnValue({
+    transaction: { family: "cosmos", mode, recipient: "", validators: [] },
+    status: { errors: {}, warnings: {} },
+    updateTransaction: jest.fn(),
+  });
+}
+
+describe("Cosmos ClaimRewards SelectMethod compound gating", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("shows the compound option on a standard cosmos chain", () => {
+    setup("cosmos", "claimReward");
+    render(<ClaimRewardsMethod navigation={navigation} route={route} />);
+    expect(screen.getByText("Compound")).toBeVisible();
+  });
+
+  it("hides the compound option on an epoching chain (babylon)", () => {
+    setup("babylon", "claimReward");
+    render(<ClaimRewardsMethod navigation={navigation} route={route} />);
+    expect(screen.queryByText("Compound")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/02-SelectMethod.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/02-SelectMethod.tsx
@@ -14,6 +14,10 @@ import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/accoun
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useTheme } from "@react-navigation/native";
 import cosmosBase from "@ledgerhq/coin-cosmos/chain/cosmosBase";
+import {
+  isCompoundRewardSupported,
+  resolveClaimRewardMode,
+} from "@ledgerhq/live-common/families/cosmos/logic";
 import Button from "~/components/Button";
 import LText from "~/components/LText";
 import { ScreenName } from "~/const";
@@ -66,46 +70,28 @@ function ClaimRewardsAmount({ navigation, route }: Props) {
   const unit = useAccountUnit(mainAccount);
   const currency = getAccountCurrency(mainAccount);
   const bridgeTransaction = useBridgeTransaction(bridge, () => {
-    const tx = route.params.transaction;
-
-    if (!tx) {
-      const t = bridge.createTransaction(mainAccount);
+    const initialTx = route.params.transaction;
+    // Normalize an injected tx's mode at creation so an unsupported compound can't reach signing.
+    if (initialTx) {
       return {
         account,
-        transaction: bridge.updateTransaction(t, {
-          mode: "claimReward",
-          validators: [
-            {
-              address: route.params.validator.validatorAddress,
-              amount: route.params.value,
-            },
-          ],
+        transaction: bridge.updateTransaction(initialTx, {
+          mode: resolveClaimRewardMode(currency.id, initialTx.mode),
         }),
       };
     }
-
-    if (!tx) {
-      const t = bridge.createTransaction(mainAccount);
-      return {
-        account,
-        transaction: bridge.updateTransaction(t, {
-          mode: "claimReward",
-          validators: [
-            {
-              address: route.params.validator.validatorAddress,
-              amount: route.params.value,
-            },
-          ],
-
-          /** @TODO remove this once the bridge handles it */
-          recipient: mainAccount.freshAddress,
-        }),
-      };
-    }
-
+    const t = bridge.createTransaction(mainAccount);
     return {
       account,
-      transaction: tx,
+      transaction: bridge.updateTransaction(t, {
+        mode: "claimReward",
+        validators: [
+          {
+            address: route.params.validator.validatorAddress,
+            amount: route.params.value,
+          },
+        ],
+      }),
     };
   });
   const { status, updateTransaction } = bridgeTransaction;
@@ -127,6 +113,7 @@ function ClaimRewardsAmount({ navigation, route }: Props) {
     },
     [transaction, bridge, updateTransaction],
   );
+  const compoundSupported = isCompoundRewardSupported(currency.id);
   const [infoModalOpen, setInfoModalOpen] = useState<boolean>();
   const openInfoModal = useCallback(() => {
     setInfoModalOpen(true);
@@ -151,13 +138,17 @@ function ClaimRewardsAmount({ navigation, route }: Props) {
       ]}
     >
       <View style={styles.main}>
-        <ToggleButton value={mode} options={options} onChange={onChangeMode} />
-        <TouchableOpacity onPress={openInfoModal} style={styles.info}>
-          <LText semiBold style={styles.infoLabel} color="grey">
-            <Trans i18nKey="cosmos.claimRewards.flow.steps.method.compoundOrCashIn" />
-          </LText>
-          <Info size={16} color={colors.grey} />
-        </TouchableOpacity>
+        {compoundSupported && (
+          <>
+            <ToggleButton value={mode} options={options} onChange={onChangeMode} />
+            <TouchableOpacity onPress={openInfoModal} style={styles.info}>
+              <LText semiBold style={styles.infoLabel} color="grey">
+                <Trans i18nKey="cosmos.claimRewards.flow.steps.method.compoundOrCashIn" />
+              </LText>
+              <Info size={16} color={colors.grey} />
+            </TouchableOpacity>
+          </>
+        )}
         <View style={styles.spacer} />
         <View style={styles.sectionLabel}>
           <LText semiBold style={styles.subLabel} color="grey">

--- a/libs/coin-modules/coin-cosmos/src/buildTransaction.ts
+++ b/libs/coin-modules/coin-cosmos/src/buildTransaction.ts
@@ -212,8 +212,8 @@ export const txToMessages = (
       ) {
         const validator = transaction.validators[0];
         if (stakingMessages.wrapped) {
-          // compound's embedded delegate isn't epoching-wrapped yet (LIVE-31837); fail fast on
-          // babylon rather than sign a bare cosmos-sdk delegate the chain rejects.
+          // compound's embedded delegate isn't epoching-wrapped yet (LIVE-33994); fail fast on
+          // wrapped/epoching chains rather than sign a bare cosmos-sdk delegate the chain rejects.
           throw new Error(`claimRewardCompound is not supported on ${account.currency.id}`);
         }
         // AMINO MESSAGES

--- a/libs/coin-modules/coin-cosmos/src/logic.ts
+++ b/libs/coin-modules/coin-cosmos/src/logic.ts
@@ -12,6 +12,7 @@ import type {
   CosmosMappedDelegationInfo,
   CosmosMappedRedelegation,
   CosmosMappedUnbonding,
+  CosmosOperationMode,
   CosmosRedelegation,
   CosmosSearchFilter,
   CosmosUnbonding,
@@ -27,11 +28,26 @@ export const COSMOS_MIN_SAFE = new BigNumber(100000); // 100000 uAtom
 export const COSMOS_MIN_FEES = new BigNumber(6000); // 6000 uAtom
 
 const DUMMY_PAYLOAD = Buffer.from("28ff5c6d57d8cfd492b6fb42614536ed648e01fd", "hex");
+
+// croeseid testnet has no own cryptoFactory entry; it reuses crypto_org's params.
+const resolveChainCurrencyId = (currencyId: string): string =>
+  currencyId === "crypto_org_croeseid" ? "crypto_org" : currencyId;
+
 export const getCosmosDummyRecipient = (currencyId: string): string => {
-  // croeseid testnet has no own chain in cryptoFactory; it reuses crypto_org's prefix
-  const id = currencyId === "crypto_org_croeseid" ? "crypto_org" : currencyId;
+  const id = resolveChainCurrencyId(currencyId);
   return bech32.encode(cryptoFactory(id).prefix, bech32.toWords(DUMMY_PAYLOAD));
 };
+
+// Compound embeds a plain delegate that epoching chains reject unless wrapped (LIVE-33994).
+export const isCompoundRewardSupported = (currencyId: string): boolean =>
+  !cryptoFactory(resolveChainCurrencyId(currencyId)).stakingMessages.wrapped;
+
+// Downgrade compound → plain claim on chains where compound isn't supported.
+export const resolveClaimRewardMode = (
+  currencyId: string,
+  mode: CosmosOperationMode,
+): CosmosOperationMode =>
+  mode === "claimRewardCompound" && !isCompoundRewardSupported(currencyId) ? "claimReward" : mode;
 
 export function mapDelegations(
   delegations: CosmosDelegation[],

--- a/libs/coin-modules/coin-cosmos/src/logic.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/logic.unit.test.ts
@@ -1,6 +1,11 @@
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import BigNumber from "bignumber.js";
-import { mapUnbondings } from "./logic";
+import {
+  getCosmosDummyRecipient,
+  isCompoundRewardSupported,
+  mapUnbondings,
+  resolveClaimRewardMode,
+} from "./logic";
 import type { CosmosUnbonding } from "./types";
 
 const unit = getCryptoCurrencyById("cosmos").units[0];
@@ -38,5 +43,49 @@ describe("mapUnbondings", () => {
       "validator-1",
       "validator-2",
     ]);
+  });
+});
+
+describe("isCompoundRewardSupported", () => {
+  it("returns true for standard (non-epoching) cosmos chains", () => {
+    expect(isCompoundRewardSupported("cosmos")).toBe(true);
+  });
+
+  it("returns false for epoching chains whose staking messages are wrapped (babylon)", () => {
+    expect(isCompoundRewardSupported("babylon")).toBe(false);
+  });
+
+  it("does not throw for currencies that reuse another chain's params (crypto_org_croeseid)", () => {
+    expect(() => isCompoundRewardSupported("crypto_org_croeseid")).not.toThrow();
+    expect(isCompoundRewardSupported("crypto_org_croeseid")).toBe(
+      isCompoundRewardSupported("crypto_org"),
+    );
+  });
+});
+
+describe("resolveClaimRewardMode", () => {
+  it("keeps claimRewardCompound on chains that support it (cosmos)", () => {
+    expect(resolveClaimRewardMode("cosmos", "claimRewardCompound")).toBe("claimRewardCompound");
+  });
+
+  it("downgrades claimRewardCompound to claimReward on epoching chains (babylon)", () => {
+    expect(resolveClaimRewardMode("babylon", "claimRewardCompound")).toBe("claimReward");
+  });
+
+  it("leaves non-compound modes untouched", () => {
+    expect(resolveClaimRewardMode("babylon", "claimReward")).toBe("claimReward");
+    expect(resolveClaimRewardMode("babylon", "delegate")).toBe("delegate");
+  });
+});
+
+describe("getCosmosDummyRecipient", () => {
+  it("returns a bech32 address with the chain prefix", () => {
+    expect(getCosmosDummyRecipient("cosmos")).toMatch(/^cosmos1/);
+  });
+
+  it("reuses crypto_org's params for the croeseid testnet", () => {
+    expect(getCosmosDummyRecipient("crypto_org_croeseid")).toBe(
+      getCosmosDummyRecipient("crypto_org"),
+    );
   });
 });


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Compound rewards (claim + immediate restake) embeds a delegate message. On epoching chains such as Babylon that inner delegate must be wrapped in MsgWrappedDelegate, which the compound path does not do, so the node rejects the transaction. The claim-rewards flow (desktop and mobile) now hides the "Compound" option when a chain's staking messages are wrapped, leaving only "Cash in" (MsgWithdrawDelegatorReward). buildTransaction keeps a fail-fast throw as a backstop.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-33994](https://ledgerhq.atlassian.net/browse/LIVE-33994?atlOrigin=eyJpIjoiNjcxMjBhZDdiYWQxNDExOGJmODUyMTFiZTY5YzU2YzQiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-33994]: https://ledgerhq.atlassian.net/browse/LIVE-33994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ