### PR TITLE
[LWM] feat(mobile): add ledgerlive://paytab deeplink behind lwmPayTab feature flag

### DIFF
--- a/.changeset/long-years-approve.md
+++ b/.changeset/long-years-approve.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add `ledgerlive://paytab` deeplink to open the Pay Tab when the `lwmPayTab` feature flag is enabled. Falls back to the Card page when the flag is off.

--- a/apps/ledger-live-mobile/docs/deeplinks.md
+++ b/apps/ledger-live-mobile/docs/deeplinks.md
@@ -117,6 +117,12 @@ When working on deeplinks, please update the **Wiki** accordingly.
 
   `ledgerlive://earn?action=get-funds&currencyId=ethereum` will open buy drawer with specified currency
 
+- **_paytab_** 🠒 Pay Tab (when `lwmPayTab` is on)
+
+  `ledgerlive://paytab` opens the Pay tab.
+
+  When `lwmPayTab` is off, the link falls back to the Card page.
+
 **_Testing on android_** in order to test in debug your link run using [**_adb_**](https://developer.android.com/training/app-links/deep-linking#testing-filters)
 
 ```

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -361,6 +361,7 @@ export const DeeplinksProvider = ({
   const web3hubFlag = useFeature("web3hub");
   const lwmProductTourFlag = useFeature("lwmProductTour");
   const lwmBackupHubFlag = useFeature("lwmBackupHub");
+  const lwmPayTabFlag = useFeature("lwmPayTab");
 
   const buySellUiManifestId = buySellUiFlag?.params?.manifestId;
 
@@ -506,6 +507,16 @@ export const DeeplinksProvider = ({
                               [ScreenName.Borrow]: "borrow",
                             },
                           },
+                          ...(lwmPayTabFlag?.enabled && {
+                            /**
+                             * ie: "ledgerlive://paytab" will open the Pay tab
+                             */
+                            [NavigatorName.PayTab]: {
+                              screens: {
+                                [ScreenName.PayTab]: "paytab",
+                              },
+                            },
+                          }),
                           [NavigatorName.MyLedger]: {
                             screens: {
                               /**
@@ -710,6 +721,10 @@ export const DeeplinksProvider = ({
             return handleModularDrawerDeeplink(hostname, searchParams, dispatch, config);
           }
 
+          if (hostname === "paytab" && !lwmPayTabFlag?.enabled) {
+            return getStateFromPath("card", config);
+          }
+
           if (hostname === "earn") {
             const earnParamAction = searchParams.get("action");
             const validatedAction = validateEarnAction(earnParamAction);
@@ -900,6 +915,7 @@ export const DeeplinksProvider = ({
     genericAwarenessModalFlag?.enabled,
     lwmProductTourFlag?.enabled,
     lwmBackupHubFlag?.enabled,
+    lwmPayTabFlag?.enabled,
   ]);
   const [isReady, setIsReady] = React.useState(false);
   const [isNavigationContainerReady, setIsNavigationContainerReady] = React.useState(false);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - `ledgerlive://paytab` deeplink routing logic in `DeeplinksProvider`
  - Feature flag `lwmPayTab` gate and fallback behaviour (redirects to Card page when flag is off)
  - Deeplinks documentation (`docs/deeplinks.md`)

### 📝 Description

The Pay Tab feature (`lwmPayTab`) lacked a dedicated deeplink, making it impossible to navigate directly to the tab via an external link.

This PR adds the `ledgerlive://paytab` deeplink that opens the Pay Tab when the `lwmPayTab` feature flag is enabled. When the flag is disabled, the link gracefully falls back to the Card page, preserving backwards compatibility.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34083](https://ledgerhq.atlassian.net/browse/LIVE-34083)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34083]: https://ledgerhq.atlassian.net/browse/LIVE-34083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ