### PR TITLE
[LWDM] refactor(coin-evm): read feesStrategy/sponsored from customFees parameters

### DIFF
--- a/.changeset/live-23554-coin-evm-customfees-params.md
+++ b/.changeset/live-23554-coin-evm-customfees-params.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-evm": minor
+"@ledgerhq/live-common": minor
+---
+
+coin-evm now reads `feesStrategy` and `sponsored` from the `customFees` fee-estimation parameters instead of the transaction intent. The generic-coin-framework bridge and the EVM swap job fold these fields into `customFees.parameters` accordingly, aligning with the coin-module framework where both are deprecated on `TransactionIntent`.

--- a/libs/coin-modules/coin-evm/src/logic/common.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/common.test.ts
@@ -268,7 +268,6 @@ describe("common", () => {
         asset: { type: "native" },
         recipient: "0x7b2C7232f9E38F30E2868f0E5Bf311Cd83554b5A",
         sender: "0xSender",
-        feesStrategy: "medium",
         data: { type: "buffer", value: Buffer.from([]) },
       } as unknown as TransactionIntent<MemoNotSupported, BufferTxData>;
 

--- a/libs/coin-modules/coin-evm/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-evm/src/logic/craftTransaction.ts
@@ -2,6 +2,7 @@ import {
   BufferTxData,
   CraftedTransaction,
   FeeEstimation,
+  FeesStrategy,
   MemoNotSupported,
   TransactionIntent,
 } from "@ledgerhq/coin-module-framework/api/types";
@@ -68,7 +69,7 @@ export async function craftTransaction(
     const node = getNodeApi(currency);
     const feeData = await node.getFeeData(currency, {
       type,
-      feesStrategy: transactionIntent.feesStrategy,
+      feesStrategy: customFees?.parameters?.feesStrategy as FeesStrategy | undefined,
     });
 
     if (type === TransactionTypes.legacy && feeData.gasPrice) {

--- a/libs/coin-modules/coin-evm/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/estimateFees.test.ts
@@ -48,7 +48,6 @@ describe("estimateFees", () => {
     asset: mockNativeAsset,
     recipient: "0x7b2C7232f9E38F30E2868f0E5Bf311Cd83554b5A",
     sender: "0xsender",
-    feesStrategy: "fast",
     data: { type: "buffer", value: Buffer.from([]) },
   };
 
@@ -73,10 +72,10 @@ describe("estimateFees", () => {
     expect(
       await estimateFees(
         {} as CryptoCurrency,
-        { type: "send-legacy", recipient: "not-an-address" } as TransactionIntent<
-          MemoNotSupported,
-          BufferTxData
-        >,
+        {
+          type: "send-legacy",
+          recipient: "not-an-address",
+        } as TransactionIntent<MemoNotSupported, BufferTxData>,
       ),
     ).toEqual({ value: 0n });
     expect(nodeApiMock.getGasEstimation).not.toHaveBeenCalled();
@@ -95,10 +94,10 @@ describe("estimateFees", () => {
         asset: { type: "native" },
         recipient: "0x7b2C7232f9E38F30E2868f0E5Bf311Cd83554b5A",
         sender: "0xsender",
-        feesStrategy: "fast",
         data: { type: "buffer", value: Buffer.from([]) },
       } as SendTransactionIntent<MemoNotSupported, BufferTxData>,
       {
+        feesStrategy: "fast",
         gasOptions: {
           fast: {
             maxFeePerGas: null,
@@ -182,16 +181,22 @@ describe("estimateFees", () => {
       }),
     });
 
-    const result = await estimateFees(mockCurrency, {
-      intentType: "transaction",
-      type: "send-legacy",
-      amount: BigInt("1000000000000000000"),
-      recipient: "0x7b2C7232f9E38F30E2868f0E5Bf311Cd83554b5A",
-      sender: "0xsender",
-      feesStrategy: "fast",
-      data: { type: "buffer", value: Buffer.from([]) },
-      asset: { type: "erc20", assetReference: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" },
-    } as SendTransactionIntent<MemoNotSupported, BufferTxData>);
+    const result = await estimateFees(
+      mockCurrency,
+      {
+        intentType: "transaction",
+        type: "send-legacy",
+        amount: BigInt("1000000000000000000"),
+        recipient: "0x7b2C7232f9E38F30E2868f0E5Bf311Cd83554b5A",
+        sender: "0xsender",
+        data: { type: "buffer", value: Buffer.from([]) },
+        asset: {
+          type: "erc20",
+          assetReference: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        },
+      } as SendTransactionIntent<MemoNotSupported, BufferTxData>,
+      { feesStrategy: "fast" },
+    );
 
     expect(nodeApiMock.getFeeData).not.toHaveBeenCalled();
     expect(result).toEqual({
@@ -238,16 +243,19 @@ describe("estimateFees", () => {
     });
     mockGetGasTracker.mockReturnValue(null);
 
-    const result = await estimateFees(mockCurrency, {
-      intentType: "transaction",
-      type: "send-eip1559",
-      amount: BigInt("1000000000000000000"),
-      recipient: "0x7b2C7232f9E38F30E2868f0E5Bf311Cd83554b5A",
-      sender: "0xsender",
-      feesStrategy: "medium",
-      data: { type: "buffer", value: Buffer.from([]) },
-      asset: { type: "native" },
-    } as SendTransactionIntent<MemoNotSupported, BufferTxData>);
+    const result = await estimateFees(
+      mockCurrency,
+      {
+        intentType: "transaction",
+        type: "send-eip1559",
+        amount: BigInt("1000000000000000000"),
+        recipient: "0x7b2C7232f9E38F30E2868f0E5Bf311Cd83554b5A",
+        sender: "0xsender",
+        data: { type: "buffer", value: Buffer.from([]) },
+        asset: { type: "native" },
+      } as SendTransactionIntent<MemoNotSupported, BufferTxData>,
+      { feesStrategy: "medium" },
+    );
 
     expect(result).toEqual({
       value: 420000000000n,
@@ -274,10 +282,10 @@ describe("estimateFees", () => {
         asset: { type: "native" },
         recipient: "0x7b2C7232f9E38F30E2868f0E5Bf311Cd83554b5A",
         sender: "0xsender",
-        feesStrategy: "custom",
         data: { type: "buffer", value: Buffer.from([]) },
       } as SendTransactionIntent<MemoNotSupported, BufferTxData>,
       {
+        feesStrategy: "custom",
         gasPrice: 60000n,
       },
     );
@@ -306,16 +314,19 @@ describe("estimateFees", () => {
     });
     mockGetGasTracker.mockReturnValue(null);
 
-    const result = await estimateFees(mockCurrency, {
-      intentType: "transaction",
-      type: "send-legacy",
-      amount: BigInt("1000000000000000000"),
-      asset: { type: "native" },
-      recipient: "0x7b2C7232f9E38F30E2868f0E5Bf311Cd83554b5A",
-      sender: "0xsender",
-      feesStrategy: "slow",
-      data: { type: "buffer", value: Buffer.from([]) },
-    } as SendTransactionIntent<MemoNotSupported, BufferTxData>);
+    const result = await estimateFees(
+      mockCurrency,
+      {
+        intentType: "transaction",
+        type: "send-legacy",
+        amount: BigInt("1000000000000000000"),
+        asset: { type: "native" },
+        recipient: "0x7b2C7232f9E38F30E2868f0E5Bf311Cd83554b5A",
+        sender: "0xsender",
+        data: { type: "buffer", value: Buffer.from([]) },
+      } as SendTransactionIntent<MemoNotSupported, BufferTxData>,
+      { feesStrategy: "slow" },
+    );
 
     expect(result).toEqual({
       value: 0n,
@@ -341,16 +352,19 @@ describe("estimateFees", () => {
     });
     mockGetGasTracker.mockReturnValue(null);
 
-    const result = await estimateFees(mockCurrency, {
-      intentType: "transaction",
-      type: "send-legacy",
-      amount: BigInt("1000000000000000000"),
-      asset: { type: "native" },
-      recipient: "0x7b2C7232f9E38F30E2868f0E5Bf311Cd83554b5A",
-      sender: "0xsender",
-      feesStrategy: "slow",
-      data: { type: "buffer", value: Buffer.from([]) },
-    } as SendTransactionIntent<MemoNotSupported, BufferTxData>);
+    const result = await estimateFees(
+      mockCurrency,
+      {
+        intentType: "transaction",
+        type: "send-legacy",
+        amount: BigInt("1000000000000000000"),
+        asset: { type: "native" },
+        recipient: "0x7b2C7232f9E38F30E2868f0E5Bf311Cd83554b5A",
+        sender: "0xsender",
+        data: { type: "buffer", value: Buffer.from([]) },
+      } as SendTransactionIntent<MemoNotSupported, BufferTxData>,
+      { feesStrategy: "slow" },
+    );
 
     expect(result).toEqual({
       value: 0n,
@@ -585,10 +599,10 @@ describe("estimateFees", () => {
         asset: { type: "native" },
         recipient: "0x7b2C7232f9E38F30E2868f0E5Bf311Cd83554b5A",
         sender: "0xsender",
-        feesStrategy: "custom",
         data: { type: "buffer", value: Buffer.from([]) },
       } as SendTransactionIntent<MemoNotSupported, BufferTxData>,
       {
+        feesStrategy: "custom",
         gasLimit: 50000n,
         gasPrice: 30000000000n,
       },

--- a/libs/coin-modules/coin-evm/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-evm/src/logic/estimateFees.ts
@@ -1,6 +1,7 @@
 import type {
   BufferTxData,
   FeeEstimation,
+  FeesStrategy,
   MemoNotSupported,
   TransactionIntent,
 } from "@ledgerhq/coin-module-framework/api/index";
@@ -139,7 +140,7 @@ export async function estimateFees(
     finalFeeData: FeeData;
     finalGasOptions?: GasOptions;
   }> => {
-    const feesStrategy = transactionIntent.feesStrategy;
+    const feesStrategy = customFeesParameters?.feesStrategy as FeesStrategy | undefined;
 
     if (feesStrategy === "custom") {
       return { finalFeeData: extractFeeData(customFeesParameters) };
@@ -164,7 +165,7 @@ export async function estimateFees(
     const node = getNodeApi(currency);
     const feeData = await node.getFeeData(currency, {
       type: txType,
-      feesStrategy: transactionIntent.feesStrategy,
+      feesStrategy,
     });
 
     return { finalFeeData: feeData };

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
@@ -331,7 +331,9 @@ describe("validateIntent", () => {
         lastInternalOperations: [],
         lastNftOperations: [],
         lastTokenOperations: [
-          { contract: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" } as Operation,
+          {
+            contract: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          } as Operation,
         ],
         nextPagingToken: "",
       });
@@ -342,13 +344,19 @@ describe("validateIntent", () => {
           sender: "sender-address",
           recipient: "0xe2ca7390e76c5A992749bB622087310d2e63ca29",
           amount: 20n,
-          asset: { type: "erc20", assetReference: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" },
+          asset: {
+            type: "erc20",
+            assetReference: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          },
         }),
         [
           { value: 50n, asset: { type: "native" } },
           {
             value: 10n,
-            asset: { type: "erc20", assetReference: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" },
+            asset: {
+              type: "erc20",
+              assetReference: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            },
           },
         ],
       );
@@ -371,7 +379,11 @@ describe("validateIntent", () => {
         [{ value: 100n, locked: 50n, asset: { type: "native" } }],
         {
           value: 5n,
-          parameters: { gasLimit: 1n, maxFeePerGas: 5n, maxPriorityFeePerGas: 1n },
+          parameters: {
+            gasLimit: 1n,
+            maxFeePerGas: 5n,
+            maxPriorityFeePerGas: 1n,
+          },
         },
       );
 
@@ -691,10 +703,17 @@ describe("validateIntent", () => {
       { value: 10_000_000n, asset: { type: "native" as const } },
       ...(native ? [] : [{ value: 1_000n, asset: tokenAsset }]),
     ];
-    const claimRewardFees = { value: 150n, parameters: { gasLimit: 21000n, gasPrice: 1n } };
+    const claimRewardFees = {
+      value: 150n,
+      parameters: { gasLimit: 21000n, gasPrice: 1n },
+    };
 
     it.each([
-      { name: "fires when network fees exceed claim reward amount", amount: 100n, native: true },
+      {
+        name: "fires when network fees exceed claim reward amount",
+        amount: 100n,
+        native: true,
+      },
     ])("$name", async ({ amount, native }) => {
       const res = await validateIntent(
         stakingCurrency,
@@ -706,9 +725,21 @@ describe("validateIntent", () => {
     });
 
     it.each([
-      { name: "does not fire when claim rewards exceed fees", amount: 1_000_000n, native: true },
-      { name: "does not fire when claim reward amount is zero", amount: 0n, native: true },
-      { name: "does not fire when claim reward asset is not native", amount: 100n, native: false },
+      {
+        name: "does not fire when claim rewards exceed fees",
+        amount: 1_000_000n,
+        native: true,
+      },
+      {
+        name: "does not fire when claim reward amount is zero",
+        amount: 0n,
+        native: true,
+      },
+      {
+        name: "does not fire when claim reward asset is not native",
+        amount: 100n,
+        native: false,
+      },
     ])("$name", async ({ amount, native }) => {
       const res = await validateIntent(
         stakingCurrency,
@@ -797,7 +828,9 @@ describe("validateIntent", () => {
 
         it("if the recipient has been set, detects fees being too high for the account balance with an error", async () => {
           const notEnoughBalanceRes = await validateIntent(
-            { units: [{ code: "ETH", name: "ETH", magnitude: 18 }] } as CryptoCurrency,
+            {
+              units: [{ code: "ETH", name: "ETH", magnitude: 18 }],
+            } as CryptoCurrency,
             createIntent({ recipient: "recipient-address" }),
             [{ value: 10n, asset: { type: "native" } }],
             {
@@ -811,12 +844,15 @@ describe("validateIntent", () => {
             },
           );
           const notEnoughBalanceSponsoredRes = await validateIntent(
-            { units: [{ code: "ETH", name: "ETH", magnitude: 18 }] } as CryptoCurrency,
-            createIntent({ recipient: "recipient-address", sponsored: true }),
+            {
+              units: [{ code: "ETH", name: "ETH", magnitude: 18 }],
+            } as CryptoCurrency,
+            createIntent({ recipient: "recipient-address" }),
             [{ value: 10n, asset: { type: "native" } }],
             {
               value: 11n,
               parameters: {
+                sponsored: true,
                 gasLimit: 11n,
                 gasPrice: 1n,
                 maxFeePerGas: 1n,
@@ -825,7 +861,9 @@ describe("validateIntent", () => {
             },
           );
           const enoughBalanceRes = await validateIntent(
-            { units: [{ code: "ETH", name: "ETH", magnitude: 18 }] } as CryptoCurrency,
+            {
+              units: [{ code: "ETH", name: "ETH", magnitude: 18 }],
+            } as CryptoCurrency,
             createIntent({ recipient: "recipient-address" }),
             [{ value: 10n, asset: { type: "native" } }],
             {
@@ -860,7 +898,9 @@ describe("validateIntent", () => {
           // gas fee alone fits in the available balance, but the additionalFees
           // (e.g. L1 data fee on L2s) push the total above the native balance.
           const res = await validateIntent(
-            { units: [{ code: "ETH", name: "ETH", magnitude: 18 }] } as CryptoCurrency,
+            {
+              units: [{ code: "ETH", name: "ETH", magnitude: 18 }],
+            } as CryptoCurrency,
             createIntent({ recipient: "recipient-address" }),
             [{ value: 10n, asset: { type: "native" } }],
             {
@@ -884,21 +924,33 @@ describe("validateIntent", () => {
 
         it("if the recipient has not been set, does not detect gas being too high", async () => {
           const notEnoughBalanceRes = await validateIntent(
-            { units: [{ code: "ETH", name: "ETH", magnitude: 18 }] } as CryptoCurrency,
+            {
+              units: [{ code: "ETH", name: "ETH", magnitude: 18 }],
+            } as CryptoCurrency,
             createIntent({ recipient: "" }),
             [{ value: 10n, asset: { type: "native" } }],
             {
               value: 11n,
-              parameters: { gasPrice: 1n, maxFeePerGas: 1n, maxPriorityFeePerGas: 1n },
+              parameters: {
+                gasPrice: 1n,
+                maxFeePerGas: 1n,
+                maxPriorityFeePerGas: 1n,
+              },
             },
           );
           const enoughBalanceRes = await validateIntent(
-            { units: [{ code: "ETH", name: "ETH", magnitude: 18 }] } as CryptoCurrency,
+            {
+              units: [{ code: "ETH", name: "ETH", magnitude: 18 }],
+            } as CryptoCurrency,
             createIntent({ recipient: "" }),
             [{ value: 10n, asset: { type: "native" } }],
             {
               value: 9n,
-              parameters: { gasPrice: 1n, maxFeePerGas: 1n, maxPriorityFeePerGas: 1n },
+              parameters: {
+                gasPrice: 1n,
+                maxFeePerGas: 1n,
+                maxPriorityFeePerGas: 1n,
+              },
             },
           );
 
@@ -1255,56 +1307,88 @@ describe("validateIntent", () => {
       { type: "native" },
       { amount: 10000000n },
       { additionalFees: undefined },
-      { expectedTotalFees: 105000n, expectedTotalSpent: 10105000n, expectedAmount: 10000000n },
+      {
+        expectedTotalFees: 105000n,
+        expectedTotalSpent: 10105000n,
+        expectedAmount: 10000000n,
+      },
     ],
     [
       "native asset and additional fees",
       { type: "native" },
       { amount: 10000000n },
       { additionalFees: 4000n },
-      { expectedTotalFees: 109000n, expectedTotalSpent: 10109000n, expectedAmount: 10000000n },
+      {
+        expectedTotalFees: 109000n,
+        expectedTotalSpent: 10109000n,
+        expectedAmount: 10000000n,
+      },
     ],
     [
       "native asset and no additional fees, using all amounts",
       { type: "native" },
       { useAllAmount: true },
       { additionalFees: undefined },
-      { expectedTotalFees: 105000n, expectedTotalSpent: 20000000n, expectedAmount: 19895000n },
+      {
+        expectedTotalFees: 105000n,
+        expectedTotalSpent: 20000000n,
+        expectedAmount: 19895000n,
+      },
     ],
     [
       "native asset and additional fees, using all amounts",
       { type: "native" },
       { useAllAmount: true },
       { additionalFees: 4000n },
-      { expectedTotalFees: 109000n, expectedTotalSpent: 20000000n, expectedAmount: 19891000n },
+      {
+        expectedTotalFees: 109000n,
+        expectedTotalSpent: 20000000n,
+        expectedAmount: 19891000n,
+      },
     ],
     [
       "token asset and no additional fees",
       { type: "erc20", assetReference: "contract-address" },
       { amount: 2n },
       { additionalFees: undefined },
-      { expectedTotalFees: 105000n, expectedTotalSpent: 2n, expectedAmount: 2n },
+      {
+        expectedTotalFees: 105000n,
+        expectedTotalSpent: 2n,
+        expectedAmount: 2n,
+      },
     ],
     [
       "token asset and additional fees",
       { type: "erc20", assetReference: "contract-address" },
       { amount: 2n },
       { additionalFees: 4000n },
-      { expectedTotalFees: 109000n, expectedTotalSpent: 2n, expectedAmount: 2n },
+      {
+        expectedTotalFees: 109000n,
+        expectedTotalSpent: 2n,
+        expectedAmount: 2n,
+      },
     ],
     [
       "token asset and no additional fees, using all amounts",
       { type: "erc20", assetReference: "contract-address" },
       { useAllAmount: true },
       { additionalFees: undefined },
-      { expectedTotalFees: 105000n, expectedTotalSpent: 10n, expectedAmount: 10n },
+      {
+        expectedTotalFees: 105000n,
+        expectedTotalSpent: 10n,
+        expectedAmount: 10n,
+      },
     ],
     [
       "token asset and additional fees, using all amounts",
       { type: "erc20", assetReference: "contract-address" },
       { useAllAmount: true },
       { additionalFees: 4000n },
-      { expectedTotalFees: 109000n, expectedTotalSpent: 10n, expectedAmount: 10n },
+      {
+        expectedTotalFees: 109000n,
+        expectedTotalSpent: 10n,
+        expectedAmount: 10n,
+      },
     ],
   ])(
     "valid intent with %s",
@@ -1333,7 +1417,10 @@ describe("validateIntent", () => {
           }),
           [
             { value: 20000000n, asset: { type: "native" } },
-            { value: 10n, asset: { type: "erc20", assetReference: "contract-address" } },
+            {
+              value: 10n,
+              asset: { type: "erc20", assetReference: "contract-address" },
+            },
           ],
           {
             value: 105000n,
@@ -1389,7 +1476,10 @@ describe("validateIntent", () => {
           }),
           [
             { value: 20000000n, asset: { type: "native" } },
-            { value: 10n, asset: { type: "erc20", assetReference: "contract-address" } },
+            {
+              value: 10n,
+              asset: { type: "erc20", assetReference: "contract-address" },
+            },
           ],
           {
             value: 105000n,
@@ -1450,7 +1540,10 @@ describe("validateIntent", () => {
           }),
           [
             { value: 20000000n, asset: { type: "native" } },
-            { value: 10n, asset: { type: "erc20", assetReference: "contract-address" } },
+            {
+              value: 10n,
+              asset: { type: "erc20", assetReference: "contract-address" },
+            },
           ],
           {
             value: 105000n,
@@ -1511,7 +1604,10 @@ describe("validateIntent", () => {
           }),
           [
             { value: 20000000n, asset: { type: "native" } },
-            { value: 10n, asset: { type: "erc20", assetReference: "contract-address" } },
+            {
+              value: 10n,
+              asset: { type: "erc20", assetReference: "contract-address" },
+            },
           ],
           estimation,
         ),

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
@@ -197,7 +197,7 @@ async function validateGas(
   } else if (
     intent.recipient &&
     totalFees > nativeBalance.value - (nativeBalance.locked ?? 0n) &&
-    !intent.sponsored
+    estimatedFees.parameters?.sponsored !== true
   ) {
     errors.gasPrice = new NotEnoughGas(undefined, {
       // "You need {{fees}} {{ticker}} for network fees to swap as you are on {{cryptoName}} network. <link0>Buy {{ticker}}</link0>"
@@ -420,7 +420,7 @@ export async function validateIntent(
   const amountSpentFromSpendableBalance =
     isStakingIntent(intent) && intent.mode !== "delegate" ? 0n : amount;
   const totalSpent =
-    isNative(intent.asset) && !intent.sponsored
+    isNative(intent.asset) && estimatedFees.parameters?.sponsored !== true
       ? amountSpentFromSpendableBalance + totalFees
       : amountSpentFromSpendableBalance;
 

--- a/libs/coin-modules/coin-evm/src/staking/transactionData.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/transactionData.test.ts
@@ -20,7 +20,6 @@ const delegateIntent = (
     asset: { type: "native" },
     recipient: "0xRecipient",
     sender: "0xSender",
-    feesStrategy: "medium",
     data: { type: "buffer", value: Buffer.from([]) },
     ...fields,
   }) as unknown as TransactionIntent<MemoNotSupported, BufferTxData>;

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
@@ -27,10 +27,8 @@ export function genericGetTransactionStatus(
       memoValue: transaction.memoValue || "",
       tag: transaction.tag,
       family: transaction.family,
-      feesStrategy: transaction.feesStrategy,
       data: transaction.data,
       type: transaction.type,
-      sponsored: transaction.sponsored,
       valAddress: transaction.valAddress,
       valId: transaction.valId,
       dstValAddress: transaction.dstValAddress,
@@ -55,6 +53,8 @@ export function genericGetTransactionStatus(
     const customFees = bigNumberToBigIntDeep({
       value: transaction.fees ?? new BigNumber(0),
       parameters: {
+        feesStrategy: transaction.feesStrategy ?? undefined,
+        sponsored: transaction.sponsored,
         gasLimit: transaction.gasLimit,
         customGasLimit: transaction.customGasLimit,
         gasPrice: transaction.gasPrice,

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
@@ -104,6 +104,8 @@ export function genericPrepareTransaction(
       coinModuleApi.craftTransactionData,
     );
     const customFeesParameters = bigNumberToBigIntDeep({
+      feesStrategy: transaction.feesStrategy ?? undefined,
+      sponsored: transaction.sponsored,
       gasPrice: transaction.gasPrice,
       maxFeePerGas: transaction.maxFeePerGas,
       maxPriorityFeePerGas: transaction.maxPriorityFeePerGas,

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
@@ -33,6 +33,8 @@ export const genericSignOperation =
         const customFees = bigNumberToBigIntDeep({
           value: transaction.fees ?? new BigNumber(0),
           parameters: {
+            feesStrategy: transaction.feesStrategy ?? undefined,
+            sponsored: transaction.sponsored,
             gasLimit: transaction.customGasLimit ?? transaction.gasLimit,
             gasPrice: transaction.gasPrice,
             maxFeePerGas: transaction.maxFeePerGas,

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -481,12 +481,10 @@ export function transactionToIntent(
     amount,
     asset: { type: "native", name: account.currency.name, unit: account.currency.units[0] },
     useAllAmount,
-    feesStrategy: transaction.feesStrategy ?? undefined,
     sequence:
       transaction.nonce !== null && transaction.nonce !== undefined
         ? BigInt(transaction.nonce.toString())
         : undefined,
-    sponsored: transaction.sponsored,
     ...getDelegationIntentFields(delegationMode, transaction),
   };
   if (transaction.assetReference && transaction.assetOwner) {

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/signSwapEvm/job.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/signSwapEvm/job.ts
@@ -33,13 +33,12 @@ async function buildUnsignedSwapTxHex(
       amount: BigInt(transactionData.value || "0"),
       asset: { type: "native" },
       data: { type: "buffer", value: data },
-      feesStrategy: "medium",
     } satisfies Parameters<typeof craftTransaction>[1]["transactionIntent"],
     customFees: {
       value: 0n,
-      // Only gasLimit is pinned — `craftTransaction` fetches `maxFeePerGas`
-      // and `maxPriorityFeePerGas` from the node when fee params are missing.
-      parameters: { gasLimit: BigInt(transactionData.gasLimit) },
+      // Pin the medium tier and gasLimit; `craftTransaction` fetches
+      // `maxFeePerGas` / `maxPriorityFeePerGas` from the node.
+      parameters: { feesStrategy: "medium", gasLimit: BigInt(transactionData.gasLimit) },
     },
   });
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _coin-evm 111/111, bridge + swap 147/147._
- [x] **Impact of the changes:**
  - EVM fee-tier selection (`feesStrategy`) and `sponsored` now read from `customFees.parameters` instead of the transaction intent.
  - No user-facing behavior change; internal source of the two fields moves from the intent to `customFees`.

### 📝 Description

Part of LIVE-23554 (Generic Adapter Cleaning). `feesStrategy` and `sponsored` are fee-estimation inputs, so they belong to `customFees`, not to the coin-module `TransactionIntent` (where they are now `@deprecated`).

- **coin-evm**: `estimateFees`, `craftTransaction` and `validateIntent` read `feesStrategy` / `sponsored` from `customFees.parameters` (helpers `getFeesStrategy` / `isSponsored`) instead of `transactionIntent.feesStrategy` / `.sponsored`.
- **live-common (generic-coin-framework bridge + EVM swap job)**: fold `feesStrategy` / `sponsored` into `customFees.parameters` and stop setting them on the intent.

This matches the already-released `@ledgerhq/coin-module-framework@3.6.0` and `@ledgerhq/coin-service@4.9.0`. Once this ships (new `coin-evm` nightly), coin-service can bump its `coin-evm` dependency to restore EVM tier selection through coin-service.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-23554](https://ledgerhq.atlassian.net/browse/LIVE-23554)

[LIVE-23554]: https://ledgerhq.atlassian.net/browse/LIVE-23554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ