### PR TITLE
test(e2e): fix desktop e2e tests for W4.0 feature flag compatibility

### DIFF
--- a/.changeset/modern-crabs-rush.md
+++ b/.changeset/modern-crabs-rush.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": patch
+---
+
+fix desktop e2e tests for W4.0 feature flag compatibility

--- a/e2e/desktop/tests/page/history.page.ts
+++ b/e2e/desktop/tests/page/history.page.ts
@@ -41,6 +41,7 @@ export class HistoryPage extends AppPage {
   private readonly operationRows = this.page.locator(`[data-testid^='history-operation-row-']`);
   private readonly operationType = this.page.getByTestId("history-operation-type");
 
+  private readonly actionsMenuButton = this.page.getByTestId("history-actions-menu-button");
   private readonly exportCsvButton = this.page.getByTestId("history-export-csv-button");
   private readonly exportDialog = this.page.getByTestId("history-export-dialog");
   private readonly exportFirstAccount = this.exportDialog.getByRole("checkbox").first();
@@ -127,6 +128,7 @@ export class HistoryPage extends AppPage {
 
   @step("Click Export CSV button")
   async clickExportCsv() {
+    await this.actionsMenuButton.click();
     await this.exportCsvButton.click();
     await expect(this.exportDialog).toBeVisible();
   }

--- a/e2e/desktop/tests/page/marketCoin.page.ts
+++ b/e2e/desktop/tests/page/marketCoin.page.ts
@@ -5,6 +5,7 @@ import { AppPage } from "./abstractClasses";
 export class MarketCoinPage extends AppPage {
   readonly root = this.page.getByTestId("market-coin-page-container");
   readonly swapButton = this.root.getByTestId("market-coin-swap-button");
+  private readonly coinPageContainer = this.root.or(this.page.getByTestId("asset-detail-header"));
   private readonly loadingPlaceholder = this.root.getByTestId("loading-placeholder");
 
   @step("Click on swap button on asset")
@@ -15,8 +16,9 @@ export class MarketCoinPage extends AppPage {
   @step("Expect market coin page to be visible")
   async expectMarketCoinPageToBeVisible(currencyId: string) {
     const escaped = currencyId.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`).toLowerCase();
-    await expect(this.getPage()).toHaveURL(new RegExp(`/market/${escaped}`));
-    await this.root.waitFor({ state: "attached" });
+    // Accept both routes: aggregatedAssets ON serves `/asset/:id`, OFF serves `/market/:id`.
+    await expect(this.getPage()).toHaveURL(new RegExp(`/(asset|market)/${escaped}`));
+    await this.coinPageContainer.first().waitFor({ state: "attached" });
     await expect(this.loadingPlaceholder).toHaveCount(0);
   }
 }

--- a/e2e/desktop/tests/specs/myWallet.spec.ts
+++ b/e2e/desktop/tests/specs/myWallet.spec.ts
@@ -15,6 +15,7 @@ test.describe("Wallet 4.0 - My Wallet", () => {
         enabled: true,
         params: { path: "/refer-a-friend" },
       },
+      lwdBackupHub: { enabled: false },
     },
   });
 


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Market coin navigation (accepts both \`/asset/:id\` and \`/market/:id\` routes depending on \`aggregatedAssets\` flag)
  - History page export flow (actions menu button now required before CSV export)
  - Market banner test fixed with Market coin navigation
  - My Wallet test stability (\`lwdBackupHub\` disabled to prevent interference)

### 📝 Description

E2e tests were failing after recent W4.0 feature flag rollouts changed routing and UI structure.

This PR fixes four test files to align with the updated app behaviour:
- **marketCoin page**: URL pattern updated to accept both \`/(asset|market)/:id\` since \`aggregatedAssets\` ON routes to \`/asset/:id\` instead of \`/market/:id\`
- **history page**: Added click on \`history-actions-menu-button\` before \`history-export-csv-button\`, which is now nested inside an actions menu
- **myWallet spec**: Disabled \`lwdBackupHub\` to prevent the backup hub modal from interfering with assertions

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34090](https://ledgerhq.atlassian.net/browse/LIVE-34090)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34090]: https://ledgerhq.atlassian.net/browse/LIVE-34090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ