### PR TITLE
[LWDM] feat(coin-tron): expose energy/bandwidth breakdown and make TRC20 fee energy-aware

### DIFF
--- a/.changeset/tron-energy-bandwidth-resource-breakdown.md
+++ b/.changeset/tron-energy-bandwidth-resource-breakdown.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": minor
+---
+
+Expose energy and bandwidth resource figures (required vs available) on the Tron transaction status, and make the TRC20 transfer fee energy-aware: it is now 0 TRX when staked energy and bandwidth cover the transfer, reflects the real shortfall cost otherwise, and falls back to the previous flat fee when the on-chain energy estimation cannot be determined. The "not enough energy" warning now derives from the real per-transaction energy estimate instead of a hardcoded constant.

--- a/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.test.ts
@@ -1,15 +1,23 @@
-import { Account, TokenAccount } from "@ledgerhq/types-live";
+import type { Account, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { estimateFees, getAccount } from "../logic";
 import { ACTIVATION_FEES, STANDARD_FEES_NATIVE, STANDARD_FEES_TRC_20 } from "../logic/constants";
-import { Transaction } from "../types";
-import getEstimatedFees from "./getEstimateFees";
+import { computeBandwidthFee, computeEnergyFee, estimateEnergy } from "../logic/estimateFees";
+import { getChainParameters, getTronAccountNetwork } from "../network";
+import type { ChainParameters } from "../network/types";
+import type { Transaction } from "../types";
+import getEstimatedFees, { getFeeResourceBreakdown } from "./getEstimateFees";
 import { extractBandwidthInfo } from "./utils";
 
 // Mock typed functions
 const mockGetAccount = jest.mocked(getAccount);
 const mockEstimateFees = jest.mocked(estimateFees);
 const mockExtractBandwidthInfo = jest.mocked(extractBandwidthInfo);
+const mockEstimateEnergy = jest.mocked(estimateEnergy);
+const mockComputeBandwidthFee = jest.mocked(computeBandwidthFee);
+const mockComputeEnergyFee = jest.mocked(computeEnergyFee);
+const mockGetChainParameters = jest.mocked(getChainParameters);
+const mockGetTronAccountNetwork = jest.mocked(getTronAccountNetwork);
 
 jest.mock("./utils", () => ({
   extractBandwidthInfo: jest.fn(),
@@ -18,6 +26,14 @@ jest.mock("./utils", () => ({
 
 jest.mock("../logic/estimateFees");
 jest.mock("../logic/getAccount");
+jest.mock("../network");
+
+const chainParams: ChainParameters = {
+  energyFee: 210,
+  transactionFee: 1000,
+  createAccountFee: 100_000,
+  createNewAccountFeeInSystemContract: 1_000_000,
+};
 
 describe("getEstimatedFees", () => {
   const mockAccount = {
@@ -53,19 +69,33 @@ describe("getEstimatedFees", () => {
     },
   } as TokenAccount;
 
+  const activeRecipient = { address: "mock-recipient-address", trc20: [] };
+
+  const sufficientBandwidth = {
+    freeUsed: new BigNumber(0),
+    freeLimit: new BigNumber(500),
+    gainedUsed: new BigNumber(0),
+    gainedLimit: new BigNumber(500),
+  };
+
+  const insufficientBandwidth = {
+    freeUsed: new BigNumber(0),
+    freeLimit: new BigNumber(0),
+    gainedUsed: new BigNumber(0),
+    gainedLimit: new BigNumber(0),
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetChainParameters.mockResolvedValue(chainParams);
+    mockComputeBandwidthFee.mockReturnValue(new BigNumber(0));
+    mockComputeEnergyFee.mockReturnValue(new BigNumber(0));
   });
 
   describe("getFeesFromBandwidth", () => {
     it("should return STANDARD_FEES_NATIVE if bandwidth is insufficient", async () => {
       mockGetAccount.mockResolvedValue([{ address: "mock-contract-address", trc20: [] }]);
-      mockExtractBandwidthInfo.mockReturnValue({
-        freeUsed: new BigNumber(0),
-        freeLimit: new BigNumber(0),
-        gainedUsed: new BigNumber(0),
-        gainedLimit: new BigNumber(0),
-      });
+      mockExtractBandwidthInfo.mockReturnValue(insufficientBandwidth);
 
       const result = await getEstimatedFees(mockAccount, mockTransaction);
       expect(result).toEqual(STANDARD_FEES_NATIVE);
@@ -73,11 +103,21 @@ describe("getEstimatedFees", () => {
 
     it("should return 0 if bandwidth is sufficient", async () => {
       mockGetAccount.mockResolvedValue([{ address: "mock-contract-address", trc20: [] }]);
+      mockExtractBandwidthInfo.mockReturnValue(sufficientBandwidth);
+
+      const result = await getEstimatedFees(mockAccount, mockTransaction);
+      expect(result).toEqual(new BigNumber(0));
+    });
+
+    it("clamps each bucket independently: a negative free remainder does not mask sufficient staked bandwidth", async () => {
+      mockGetAccount.mockResolvedValue([{ address: "mock-contract-address", trc20: [] }]);
+      // free bucket is negative (used 600 > limit 500); staked/gained alone (250) covers the 200 cost.
+      // Unclamped this sums to 150 < 200 and would wrongly charge; clamped it is 0 + 250 = 250.
       mockExtractBandwidthInfo.mockReturnValue({
-        freeUsed: new BigNumber(0),
+        freeUsed: new BigNumber(600),
         freeLimit: new BigNumber(500),
         gainedUsed: new BigNumber(0),
-        gainedLimit: new BigNumber(500),
+        gainedLimit: new BigNumber(250),
       });
 
       const result = await getEstimatedFees(mockAccount, mockTransaction);
@@ -88,70 +128,329 @@ describe("getEstimatedFees", () => {
   describe("getFeesFromAccountActivation", () => {
     it("should return ACTIVATION_FEES if recipient account is not active", async () => {
       mockGetAccount.mockResolvedValue([]);
-      mockExtractBandwidthInfo.mockReturnValue({
-        freeUsed: new BigNumber(0),
-        freeLimit: new BigNumber(0),
-        gainedUsed: new BigNumber(0),
-        gainedLimit: new BigNumber(0),
-      });
+      mockExtractBandwidthInfo.mockReturnValue(insufficientBandwidth);
 
       const result = await getEstimatedFees(mockAccount, mockTransaction);
       expect(result).toEqual(ACTIVATION_FEES);
     });
 
-    it("should return STANDARD_FEES_TRC_20 if recipient has TRC20 balance", async () => {
-      mockGetAccount.mockResolvedValue([{ address: "mock-contract-address", trc20: [] }]);
-      mockExtractBandwidthInfo.mockReturnValue({
-        freeUsed: new BigNumber(0),
-        freeLimit: new BigNumber(0),
-        gainedUsed: new BigNumber(0),
-        gainedLimit: new BigNumber(500),
-      });
-
-      const result = await getEstimatedFees(mockAccount, mockTransaction, mockTokenAccount);
-      expect(result).toEqual(STANDARD_FEES_TRC_20);
-    });
-
-    it("should return estimated fees for TRC20 token transfer", async () => {
+    it("should return estimated fees for TRC20 token transfer to a new recipient", async () => {
       mockGetAccount.mockResolvedValue([]);
       mockEstimateFees.mockResolvedValue(1000n);
-      mockExtractBandwidthInfo.mockReturnValue({
-        freeUsed: new BigNumber(0),
-        freeLimit: new BigNumber(0),
-        gainedUsed: new BigNumber(0),
-        gainedLimit: new BigNumber(0),
-      });
+      mockExtractBandwidthInfo.mockReturnValue(insufficientBandwidth);
 
       const result = await getEstimatedFees(mockAccount, mockTransaction, mockTokenAccount);
       expect(result).toEqual(new BigNumber(1000));
+    });
+
+    it("inactive-recipient TRC20 with sufficient bandwidth keeps the flat constant (energy-aware only for active recipients)", async () => {
+      mockGetAccount.mockResolvedValue([]); // recipient not active
+      mockExtractBandwidthInfo.mockReturnValue(sufficientBandwidth);
+
+      const result = await getEstimatedFees(mockAccount, mockTransaction, mockTokenAccount);
+
+      expect(result).toEqual(STANDARD_FEES_TRC_20);
+      expect(mockEstimateEnergy).not.toHaveBeenCalled();
+      expect(mockGetChainParameters).not.toHaveBeenCalled();
     });
   });
 
   describe("getEstimatedFees", () => {
     it("should prioritize account activation fees over bandwidth fees", async () => {
       mockGetAccount.mockResolvedValue([]);
-      mockExtractBandwidthInfo.mockReturnValue({
-        freeUsed: new BigNumber(0),
-        freeLimit: new BigNumber(0),
-        gainedUsed: new BigNumber(0),
-        gainedLimit: new BigNumber(0),
-      });
+      mockExtractBandwidthInfo.mockReturnValue(insufficientBandwidth);
 
       const result = await getEstimatedFees(mockAccount, mockTransaction);
       expect(result).toEqual(ACTIVATION_FEES);
     });
 
     it("should return bandwidth fees if no account activation is required", async () => {
-      mockGetAccount.mockResolvedValue([{ address: "mock-address", trc20: [] }]);
-      mockExtractBandwidthInfo.mockReturnValue({
-        freeUsed: new BigNumber(0),
-        freeLimit: new BigNumber(500),
-        gainedUsed: new BigNumber(0),
-        gainedLimit: new BigNumber(500),
-      });
+      mockGetAccount.mockResolvedValue([activeRecipient]);
+      mockExtractBandwidthInfo.mockReturnValue(sufficientBandwidth);
 
       const result = await getEstimatedFees(mockAccount, mockTransaction);
       expect(result).toEqual(new BigNumber(0));
+    });
+  });
+
+  describe("native TRX / TRC10 sends (regression, no energy dimension)", () => {
+    it("native TRX send never triggers energy simulation and energyRequired is 0", async () => {
+      mockExtractBandwidthInfo.mockReturnValue(sufficientBandwidth);
+
+      const breakdown = await getFeeResourceBreakdown(mockAccount, mockTransaction, null);
+
+      expect(breakdown.energyRequired).toEqual(new BigNumber(0));
+      expect(mockEstimateEnergy).not.toHaveBeenCalled();
+    });
+
+    it("TRC10 sub-account send never triggers energy simulation, fee unchanged", async () => {
+      const trc10Account: TokenAccount = {
+        id: "mock-trc10-account-id",
+        token: {
+          id: "mock-trc10-token-id",
+          contractAddress: "mock-trc10-contract-address",
+          tokenType: "trc10",
+        },
+      } as TokenAccount;
+      mockGetAccount.mockResolvedValue([activeRecipient]);
+      mockExtractBandwidthInfo.mockReturnValue(sufficientBandwidth);
+
+      const breakdown = await getFeeResourceBreakdown(mockAccount, mockTransaction, trc10Account);
+      const fee = await getEstimatedFees(mockAccount, mockTransaction, trc10Account, breakdown);
+
+      expect(breakdown.energyRequired).toEqual(new BigNumber(0));
+      expect(mockEstimateEnergy).not.toHaveBeenCalled();
+      expect(fee).toEqual(new BigNumber(0));
+    });
+
+    it("clamps available energy/bandwidth to zero when the node reports used > limit", async () => {
+      mockExtractBandwidthInfo.mockReturnValue({
+        freeUsed: new BigNumber(100),
+        freeLimit: new BigNumber(0),
+        gainedUsed: new BigNumber(0),
+        gainedLimit: new BigNumber(0),
+      });
+      const tx: Transaction = {
+        ...mockTransaction,
+        networkInfo: {
+          ...mockTransaction.networkInfo!,
+          energyLimit: new BigNumber(0),
+          energyUsed: new BigNumber(100),
+        },
+      };
+
+      const breakdown = await getFeeResourceBreakdown(mockAccount, tx, null);
+
+      expect(breakdown.bandwidthAvailable).toEqual(new BigNumber(0));
+      expect(breakdown.energyAvailable).toEqual(new BigNumber(0));
+    });
+
+    it("clamps each bandwidth bucket independently (negative free does not reduce gained)", async () => {
+      mockExtractBandwidthInfo.mockReturnValue({
+        freeUsed: new BigNumber(500),
+        freeLimit: new BigNumber(0), // free = -500 → 0
+        gainedUsed: new BigNumber(0),
+        gainedLimit: new BigNumber(1000), // gained = 1000
+      });
+
+      const breakdown = await getFeeResourceBreakdown(mockAccount, mockTransaction, null);
+
+      // 0 (free) + 1000 (gained), not max(0, -500 + 1000) = 500.
+      expect(breakdown.bandwidthAvailable).toEqual(new BigNumber(1000));
+    });
+  });
+
+  describe("TRC20 active recipient — energy-aware fee (getFeeResourceBreakdown + getEstimatedFees)", () => {
+    beforeEach(() => {
+      mockGetAccount.mockResolvedValue([activeRecipient]);
+    });
+
+    it("handles a large TRC20 amount without an exponential-notation BigInt error", async () => {
+      mockExtractBandwidthInfo.mockReturnValue(sufficientBandwidth);
+      mockEstimateEnergy.mockResolvedValue(1000);
+      // 1e22 base units — BigNumber#toString() would render this as "1e+22", which BigInt() rejects.
+      const largeAmountTx: Transaction = { ...mockTransaction, amount: new BigNumber("1e22") };
+
+      const breakdown = await getFeeResourceBreakdown(mockAccount, largeAmountTx, mockTokenAccount);
+
+      expect(breakdown.energyEstimated).toBe(true);
+      expect(breakdown.energyRequired).toEqual(new BigNumber(1000));
+    });
+
+    it("simulates with the token balance for send-max (useAllAmount), not a 0-amount transfer", async () => {
+      mockExtractBandwidthInfo.mockReturnValue(sufficientBandwidth);
+      mockEstimateEnergy.mockResolvedValue(1000);
+      const maxTx: Transaction = {
+        ...mockTransaction,
+        amount: new BigNumber(0),
+        useAllAmount: true,
+      };
+      const tokenWithBalance = { ...mockTokenAccount, balance: new BigNumber(500) } as TokenAccount;
+
+      await getFeeResourceBreakdown(mockAccount, maxTx, tokenWithBalance);
+
+      expect(mockEstimateEnergy).toHaveBeenCalledWith(expect.objectContaining({ amount: 500n }));
+    });
+
+    it("non-send mode with a TRC20 sub-account does not run the energy simulation", async () => {
+      mockExtractBandwidthInfo.mockReturnValue(sufficientBandwidth);
+      const freezeTx: Transaction = { ...mockTransaction, mode: "freeze" };
+
+      const breakdown = await getFeeResourceBreakdown(mockAccount, freezeTx, mockTokenAccount);
+
+      expect(mockEstimateEnergy).not.toHaveBeenCalled();
+      expect(breakdown.energyRequired).toEqual(new BigNumber(0));
+    });
+
+    it("zero-amount send skips the energy simulation (headed for an amount-required error)", async () => {
+      mockExtractBandwidthInfo.mockReturnValue(sufficientBandwidth);
+      const zeroAmountTx: Transaction = { ...mockTransaction, amount: new BigNumber(0) };
+
+      const breakdown = await getFeeResourceBreakdown(mockAccount, zeroAmountTx, mockTokenAccount);
+
+      expect(mockEstimateEnergy).not.toHaveBeenCalled();
+      expect(breakdown.energyRequired).toEqual(new BigNumber(0));
+      expect(breakdown.energyEstimated).toBe(true);
+    });
+
+    it("sufficient energy and bandwidth -> fee is 0 (State A)", async () => {
+      mockExtractBandwidthInfo.mockReturnValue(sufficientBandwidth);
+      mockEstimateEnergy.mockResolvedValue(1000);
+
+      const breakdown = await getFeeResourceBreakdown(
+        mockAccount,
+        mockTransaction,
+        mockTokenAccount,
+      );
+      const fee = await getEstimatedFees(mockAccount, mockTransaction, mockTokenAccount, breakdown);
+
+      expect(breakdown.energyEstimated).toBe(true);
+      expect(breakdown.energyRequired).toEqual(new BigNumber(1000));
+      expect(breakdown.energyRequired.lte(breakdown.energyAvailable)).toBe(true);
+      expect(breakdown.bandwidthRequired.lte(breakdown.bandwidthAvailable)).toBe(true);
+      expect(fee).toEqual(new BigNumber(0));
+    });
+
+    it("insufficient energy -> fee is computeBandwidthFee + computeEnergyFee", async () => {
+      mockExtractBandwidthInfo.mockReturnValue(insufficientBandwidth);
+      mockEstimateEnergy.mockResolvedValue(31_895);
+      mockComputeBandwidthFee.mockReturnValue(new BigNumber(200_000));
+      mockComputeEnergyFee.mockReturnValue(new BigNumber(6_697_950));
+
+      const breakdown = await getFeeResourceBreakdown(
+        mockAccount,
+        mockTransaction,
+        mockTokenAccount,
+      );
+      const fee = await getEstimatedFees(mockAccount, mockTransaction, mockTokenAccount, breakdown);
+
+      expect(breakdown.energyRequired.gt(breakdown.energyAvailable)).toBe(true);
+      expect(fee).toEqual(new BigNumber(200_000).plus(6_697_950));
+      expect(mockComputeBandwidthFee).toHaveBeenCalledWith(
+        breakdown.bandwidthRequired.toNumber(),
+        breakdown.networkInfo,
+        chainParams,
+      );
+      expect(mockComputeEnergyFee).toHaveBeenCalledWith(
+        breakdown.energyRequired.toNumber(),
+        breakdown.networkInfo,
+        chainParams,
+      );
+    });
+
+    it("insufficient resources -> fee equals the REAL (unmocked) computeBandwidthFee + computeEnergyFee math", async () => {
+      // End-to-end: exercise the real fee helpers (not the summation-only mocks above) so the actual
+      // shortfall subtraction and rate multiplication are proven, not just the wiring.
+      const actual = jest.requireActual("../logic/estimateFees");
+      mockComputeBandwidthFee.mockImplementation(actual.computeBandwidthFee);
+      mockComputeEnergyFee.mockImplementation(actual.computeEnergyFee);
+
+      // Zero available bandwidth AND energy so both dimensions are a full shortfall.
+      const zero = new BigNumber(0);
+      const emptyNetworkInfo = {
+        family: "tron" as const,
+        freeNetUsed: zero,
+        freeNetLimit: zero,
+        netUsed: zero,
+        netLimit: zero,
+        energyUsed: zero,
+        energyLimit: zero,
+      };
+      const tx: Transaction = { ...mockTransaction, networkInfo: emptyNetworkInfo };
+      mockExtractBandwidthInfo.mockReturnValue(insufficientBandwidth);
+      mockEstimateEnergy.mockResolvedValue(31_895);
+
+      const breakdown = await getFeeResourceBreakdown(mockAccount, tx, mockTokenAccount);
+      const fee = await getEstimatedFees(mockAccount, tx, mockTokenAccount, breakdown);
+
+      // bandwidth: getEstimatedBlockSize (mocked 200) − 0 available = 200 missing × transactionFee 1000.
+      // energy: 31_895 − 0 available = 31_895 missing × energyFee 210.
+      const expectedBandwidthFee = 200 * chainParams.transactionFee;
+      const expectedEnergyFee = 31_895 * chainParams.energyFee;
+      expect(fee).toEqual(new BigNumber(expectedBandwidthFee + expectedEnergyFee));
+    });
+
+    it("energyRequired is the full simulated energy_used, not scaled by the contract sponsorship percent", async () => {
+      // Confirmed on mainnet that the caller pays 100% of energy_used regardless of
+      // consume_user_resource_percent (deployers do not sponsor in practice), so the breakdown
+      // must not scale it down.
+      mockExtractBandwidthInfo.mockReturnValue(sufficientBandwidth);
+      mockEstimateEnergy.mockResolvedValue(64_285);
+
+      const breakdown = await getFeeResourceBreakdown(
+        mockAccount,
+        mockTransaction,
+        mockTokenAccount,
+      );
+
+      expect(breakdown.energyRequired).toEqual(new BigNumber(64_285));
+    });
+
+    it("simulation failure -> fee falls back to flat STANDARD_FEES_TRC_20, breakdown reports insufficient", async () => {
+      mockExtractBandwidthInfo.mockReturnValue(sufficientBandwidth);
+      mockEstimateEnergy.mockRejectedValue(new Error("triggerConstantContract failed: REVERT"));
+
+      const breakdown = await getFeeResourceBreakdown(
+        mockAccount,
+        mockTransaction,
+        mockTokenAccount,
+      );
+      const fee = await getEstimatedFees(mockAccount, mockTransaction, mockTokenAccount, breakdown);
+
+      expect(breakdown.energyEstimated).toBe(false);
+      expect(breakdown.energyRequired.gt(breakdown.energyAvailable)).toBe(true);
+      expect(fee).toEqual(STANDARD_FEES_TRC_20);
+    });
+
+    it("does not throw when getChainParameters fails, fee falls back to flat constant", async () => {
+      mockExtractBandwidthInfo.mockReturnValue(sufficientBandwidth);
+      mockEstimateEnergy.mockResolvedValue(31_895);
+      mockGetChainParameters.mockRejectedValue(new Error("chain params unreachable"));
+
+      const breakdown = await getFeeResourceBreakdown(
+        mockAccount,
+        mockTransaction,
+        mockTokenAccount,
+      );
+      const fee = await getEstimatedFees(mockAccount, mockTransaction, mockTokenAccount, breakdown);
+
+      expect(fee).toEqual(STANDARD_FEES_TRC_20);
+    });
+
+    it("null networkInfo does not throw, fetches it instead", async () => {
+      const unpreparedTransaction: Transaction = { ...mockTransaction, networkInfo: null };
+      mockExtractBandwidthInfo.mockReturnValue(sufficientBandwidth);
+      mockEstimateEnergy.mockResolvedValue(1000);
+      mockGetTronAccountNetwork.mockResolvedValue(mockTransaction.networkInfo!);
+
+      await expect(
+        getFeeResourceBreakdown(mockAccount, unpreparedTransaction, mockTokenAccount),
+      ).resolves.not.toThrow();
+      expect(mockGetTronAccountNetwork).toHaveBeenCalledWith(mockAccount.freshAddress);
+    });
+
+    it("network-info fetch failure does not throw", async () => {
+      const unpreparedTransaction: Transaction = { ...mockTransaction, networkInfo: null };
+      mockExtractBandwidthInfo.mockReturnValue(sufficientBandwidth);
+      mockGetTronAccountNetwork.mockRejectedValue(new Error("network down"));
+
+      const breakdown = await getFeeResourceBreakdown(
+        mockAccount,
+        unpreparedTransaction,
+        mockTokenAccount,
+      );
+
+      expect(breakdown.energyEstimated).toBe(false);
+    });
+
+    it("network-info fetch failure on a native/non-TRC20 send reports energyRequired 0, not the sentinel", async () => {
+      const unpreparedTransaction: Transaction = { ...mockTransaction, networkInfo: null };
+      mockGetTronAccountNetwork.mockRejectedValue(new Error("network down"));
+
+      const breakdown = await getFeeResourceBreakdown(mockAccount, unpreparedTransaction, null);
+
+      expect(breakdown.energyRequired).toEqual(new BigNumber(0));
+      expect(breakdown.energyEstimated).toBe(true);
     });
   });
 });

--- a/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
@@ -1,10 +1,13 @@
 import type { TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
-import { Account, TokenAccount } from "@ledgerhq/types-live";
+import { log } from "@ledgerhq/logs";
+import type { Account, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { estimateFees, getAccount } from "../logic";
 import { ACTIVATION_FEES, STANDARD_FEES_NATIVE, STANDARD_FEES_TRC_20 } from "../logic/constants";
-import type { AccountTronAPI } from "../network/types";
-import type { Transaction } from "../types";
+import { computeBandwidthFee, computeEnergyFee, estimateEnergy } from "../logic/estimateFees";
+import { getChainParameters, getTronAccountNetwork } from "../network";
+import type { AccountTronAPI, ChainParameters } from "../network/types";
+import type { NetworkInfo, Transaction } from "../types";
 import { extractBandwidthInfo, getEstimatedBlockSize } from "./utils";
 
 // see : https://developers.tron.network/docs/bandwith#section-bandwidth-points-consumption
@@ -15,7 +18,12 @@ const getFeesFromBandwidth = (account: Account, transaction: Transaction): BigNu
   const { freeUsed, freeLimit, gainedUsed, gainedLimit } = extractBandwidthInfo(
     transaction.networkInfo,
   );
-  const available = freeLimit.minus(freeUsed).plus(gainedLimit).minus(gainedUsed);
+  // Clamp each bucket (free, staked/gained) to ≥ 0 before summing, mirroring the resource breakdown:
+  // a node reporting used > limit in one bucket must not eat into the other's availability, which
+  // would otherwise charge a fee while the breakdown reports bandwidth as sufficient.
+  const available = BigNumber.maximum(0, freeLimit.minus(freeUsed)).plus(
+    BigNumber.maximum(0, gainedLimit.minus(gainedUsed)),
+  );
   const estimatedBandwidthCost = getEstimatedBlockSize(account, transaction);
 
   if (available.lt(estimatedBandwidthCost)) {
@@ -25,11 +33,174 @@ const getFeesFromBandwidth = (account: Account, transaction: Transaction): BigNu
   return new BigNumber(0); // no fee
 };
 
+export type FeeResourceBreakdown = {
+  energyRequired: BigNumber;
+  energyAvailable: BigNumber;
+  bandwidthRequired: BigNumber;
+  bandwidthAvailable: BigNumber;
+  // False when the energy simulation failed and `energyRequired` is a safe "insufficient" sentinel.
+  energyEstimated: boolean;
+  // The networkInfo used above (fetched if the tx was unprepared); reused by the fee computation.
+  networkInfo: NetworkInfo;
+};
+
+// Energy/bandwidth required-vs-available for a transaction, feeding both the status fields and the
+// energy-aware TRC20 fee. Never throws: on failure it reports energy insufficient
+// (`energyEstimated: false`) so callers can fall back to a pessimistic fee.
+export const getFeeResourceBreakdown = async (
+  account: Account,
+  transaction: Transaction,
+  tokenAccount?: TokenAccount | null,
+): Promise<FeeResourceBreakdown> => {
+  // Energy is only required for an actual TRC20 transfer — native/TRC10 use none, non-"send" modes
+  // don't transfer, and a zero-amount non-max send is headed for AmountRequired. Compute it up front
+  // so the network-failure path reports the "insufficient" sentinel only when energy is truly needed.
+  const isZeroAmountSend = transaction.amount.isZero() && !transaction.useAllAmount;
+  const needsEnergySim =
+    tokenAccount?.token.tokenType === "trc20" && transaction.mode === "send" && !isZeroAmountSend;
+
+  let networkInfo: NetworkInfo;
+  try {
+    networkInfo = transaction.networkInfo ?? (await getTronAccountNetwork(account.freshAddress));
+  } catch (err) {
+    log("tron/getFeeResourceBreakdown", "failed to fetch network info", { err });
+    const zero = new BigNumber(0);
+    return {
+      // Sentinel only when energy is genuinely needed; native/TRC10 (and non-transfers) need 0.
+      energyRequired: needsEnergySim ? zero.plus(1) : zero,
+      energyAvailable: zero,
+      bandwidthRequired: getEstimatedBlockSize(account, transaction),
+      bandwidthAvailable: zero,
+      energyEstimated: !needsEnergySim,
+      networkInfo: {
+        family: "tron",
+        freeNetUsed: zero,
+        freeNetLimit: zero,
+        netUsed: zero,
+        netLimit: zero,
+        energyUsed: zero,
+        energyLimit: zero,
+      },
+    };
+  }
+
+  const { freeUsed, freeLimit, gainedUsed, gainedLimit } = extractBandwidthInfo(networkInfo);
+  // Clamp each bucket (free, staked/gained) to ≥ 0 before summing: a node reporting used > limit in
+  // one bucket must not reduce the other, and a negative "available" is nonsensical for the UI.
+  const bandwidthAvailable = BigNumber.maximum(0, freeLimit.minus(freeUsed)).plus(
+    BigNumber.maximum(0, gainedLimit.minus(gainedUsed)),
+  );
+  const bandwidthRequired = getEstimatedBlockSize(account, transaction);
+  const energyAvailable = BigNumber.maximum(
+    0,
+    networkInfo.energyLimit.minus(networkInfo.energyUsed),
+  );
+
+  // Only an actual TRC20 transfer needs an energy simulation (see needsEnergySim above); everything
+  // else has a genuine 0 energy requirement.
+  if (!needsEnergySim) {
+    return {
+      energyRequired: new BigNumber(0),
+      energyAvailable,
+      bandwidthRequired,
+      bandwidthAvailable,
+      energyEstimated: true,
+      networkInfo,
+    };
+  }
+
+  try {
+    // For "send max" the transaction amount is still 0 at this point, so simulate with the token
+    // balance — a 0-value transfer can revert or mis-estimate energy. Use toFixed() (not toString(),
+    // which switches to exponential notation for large values that BigInt() cannot parse).
+    const simulatedAmount = transaction.useAllAmount ? tokenAccount.balance : transaction.amount;
+    const transactionIntent: TransactionIntent = {
+      intentType: "transaction",
+      type: transaction.mode,
+      sender: account.freshAddress,
+      recipient: transaction.recipient,
+      amount: BigInt(simulatedAmount.toFixed()),
+      asset: { type: "trc20", assetReference: tokenAccount.token.contractAddress },
+    };
+    // Full simulated energy, NOT scaled by consume_user_resource_percent: mainnet USDT transfers
+    // charge the caller 100% of energy_used (origin_energy_usage = 0), so scaling would under-report
+    // and risk a surprise TRX burn.
+    const energyUsed = await estimateEnergy(transactionIntent);
+    const energyRequired = new BigNumber(energyUsed).integerValue(BigNumber.ROUND_CEIL);
+
+    return {
+      energyRequired,
+      energyAvailable,
+      bandwidthRequired,
+      bandwidthAvailable,
+      energyEstimated: true,
+      networkInfo,
+    };
+  } catch (err) {
+    log("tron/getFeeResourceBreakdown", "energy simulation failed, reporting insufficient energy", {
+      err,
+    });
+    return {
+      energyRequired: energyAvailable.plus(1),
+      energyAvailable,
+      bandwidthRequired,
+      bandwidthAvailable,
+      energyEstimated: false,
+      networkInfo,
+    };
+  }
+};
+
+// Energy-aware fee for an active-recipient TRC20 transfer: 0 when energy and bandwidth cover it, the
+// real shortfall otherwise, and the flat STANDARD_FEES_TRC_20 on any uncertainty.
+const computeActiveRecipientTrc20Fee = async (
+  account: Account,
+  transaction: Transaction,
+  tokenAccount: TokenAccount,
+  breakdown?: FeeResourceBreakdown,
+): Promise<BigNumber> => {
+  try {
+    const resourceBreakdown =
+      breakdown ?? (await getFeeResourceBreakdown(account, transaction, tokenAccount));
+
+    if (!resourceBreakdown.energyEstimated) {
+      return STANDARD_FEES_TRC_20;
+    }
+
+    const sufficient =
+      resourceBreakdown.energyRequired.lte(resourceBreakdown.energyAvailable) &&
+      resourceBreakdown.bandwidthRequired.lte(resourceBreakdown.bandwidthAvailable);
+
+    if (sufficient) {
+      return new BigNumber(0);
+    }
+
+    const params: ChainParameters = await getChainParameters();
+    return computeBandwidthFee(
+      resourceBreakdown.bandwidthRequired.toNumber(),
+      resourceBreakdown.networkInfo,
+      params,
+    ).plus(
+      computeEnergyFee(
+        resourceBreakdown.energyRequired.integerValue(BigNumber.ROUND_CEIL).toNumber(),
+        resourceBreakdown.networkInfo,
+        params,
+      ),
+    );
+  } catch (err) {
+    log("tron/getEstimatedFees", "energy-aware TRC20 fee computation failed, using flat fee", {
+      err,
+    });
+    return STANDARD_FEES_TRC_20;
+  }
+};
+
 // Special case: If activated an account, cost around 0.1 TRX
 const getFeesFromAccountActivation = async (
   account: Account,
   transaction: Transaction,
   tokenAccount?: TokenAccount | null,
+  breakdown?: FeeResourceBreakdown,
 ): Promise<BigNumber> => {
   const recipientAccounts = await getAccount(transaction.recipient);
   const recipientAccount: AccountTronAPI | undefined = recipientAccounts[0];
@@ -70,9 +241,13 @@ const getFeesFromAccountActivation = async (
     }
   }
 
-  // if account is activated and it does already have a trc20 balance for given token.
-  if (tokenAccount && tokenAccount.token.tokenType === "trc20") {
-    return STANDARD_FEES_TRC_20; // cost is 13.3959 TRX
+  // Only the active-recipient TRC20 case is energy-aware (0 when covered, real shortfall otherwise,
+  // flat STANDARD_FEES_TRC_20 on any uncertainty); inactive recipients keep the prior behavior.
+  if (tokenAccount?.token.tokenType === "trc20") {
+    if (!recipientAccount) {
+      return STANDARD_FEES_TRC_20;
+    }
+    return computeActiveRecipientTrc20Fee(account, transaction, tokenAccount, breakdown);
   }
 
   return new BigNumber(0); // no fee
@@ -82,16 +257,23 @@ const getEstimatedFees = async (
   account: Account,
   transaction: Transaction,
   tokenAccount?: TokenAccount | null,
+  breakdown?: FeeResourceBreakdown,
 ) => {
+  // When a breakdown is supplied it carries the networkInfo actually used (fetched if the tx was
+  // unprepared); route the bandwidth/activation paths through the same data so their gating can't
+  // disagree with the breakdown.
+  const txForFees = breakdown
+    ? { ...transaction, networkInfo: breakdown.networkInfo }
+    : transaction;
   const feesFromAccountActivation =
-    transaction.mode === "send"
-      ? await getFeesFromAccountActivation(account, transaction, tokenAccount)
+    txForFees.mode === "send"
+      ? await getFeesFromAccountActivation(account, txForFees, tokenAccount, breakdown)
       : new BigNumber(0);
   if (feesFromAccountActivation.gt(0)) {
     return feesFromAccountActivation;
   }
 
-  const feesFromBandwidth = getFeesFromBandwidth(account, transaction);
+  const feesFromBandwidth = getFeesFromBandwidth(account, txForFees);
   return feesFromBandwidth;
 };
 

--- a/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.test.ts
@@ -1,0 +1,412 @@
+import {
+  AmountRequired,
+  InvalidAddress,
+  InvalidAddressBecauseDestinationIsAlsoSource,
+  NotEnoughBalance,
+  NotEnoughGas,
+} from "@ledgerhq/errors";
+import type { TokenAccount } from "@ledgerhq/types-live";
+import BigNumber from "bignumber.js";
+import {
+  fetchTronAccount,
+  fetchTronContract,
+  getChainParameters,
+  getDelegatedResource,
+  getTronAccountNetwork,
+  getTronSuperRepresentatives,
+  triggerConstantContract,
+} from "../network";
+import { STANDARD_FEES_TRC_20 } from "../logic/constants";
+import type { NetworkInfo, Transaction, TronAccount } from "../types";
+import {
+  TronInvalidFreezeAmount,
+  TronInvalidUnDelegateResourceAmount,
+  TronNoFrozenForBandwidth,
+  TronNoFrozenForEnergy,
+  TronNoReward,
+  TronNotEnoughEnergy,
+  TronNotEnoughTronPower,
+  TronNoUnfrozenResource,
+  TronUnexpectedFees,
+  TronVoteRequired,
+} from "../types/errors";
+import getTransactionStatus from "./getTransactionStatus";
+
+jest.mock("../network");
+
+const mockFetchTronAccount = jest.mocked(fetchTronAccount);
+const mockFetchTronContract = jest.mocked(fetchTronContract);
+const mockGetDelegatedResource = jest.mocked(getDelegatedResource);
+const mockGetTronSuperRepresentatives = jest.mocked(getTronSuperRepresentatives);
+const mockTriggerConstantContract = jest.mocked(triggerConstantContract);
+const mockGetChainParameters = jest.mocked(getChainParameters);
+const mockGetTronAccountNetwork = jest.mocked(getTronAccountNetwork);
+
+const SENDER_ADDRESS = "TF17BgPaZYbz8oxbjhriubPDsA7ArKoLX3";
+const RECIPIENT_ADDRESS = "TJRabPrwbZy45sbavfcjinPJC18kjpRTv8";
+const TRC20_CONTRACT = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+const TRC20_SUBACCOUNT_ID = "js:2:tron:sender:+trc20";
+
+const chainParams = {
+  energyFee: 210,
+  transactionFee: 1000,
+  createAccountFee: 100_000,
+  createNewAccountFeeInSystemContract: 1_000_000,
+};
+
+const buildNetworkInfo = (overrides: Partial<NetworkInfo> = {}): NetworkInfo => ({
+  family: "tron",
+  freeNetUsed: new BigNumber(0),
+  freeNetLimit: new BigNumber(5000),
+  netUsed: new BigNumber(0),
+  netLimit: new BigNumber(0),
+  energyUsed: new BigNumber(0),
+  energyLimit: new BigNumber(100_000),
+  ...overrides,
+});
+
+const createTrc20TokenAccount = (overrides: Partial<TokenAccount> = {}): TokenAccount =>
+  ({
+    id: TRC20_SUBACCOUNT_ID,
+    type: "TokenAccount",
+    balance: new BigNumber(1_000_000),
+    spendableBalance: new BigNumber(1_000_000),
+    operations: [],
+    token: {
+      id: "tron/trc20/mock",
+      contractAddress: TRC20_CONTRACT,
+      tokenType: "trc20",
+    },
+    ...overrides,
+  }) as TokenAccount;
+
+const createAccount = (overrides: Partial<TronAccount> = {}): TronAccount =>
+  ({
+    id: "js:2:tron:sender:",
+    type: "Account",
+    freshAddress: SENDER_ADDRESS,
+    balance: new BigNumber(50_000_000),
+    spendableBalance: new BigNumber(50_000_000),
+    operations: [],
+    subAccounts: [],
+    currency: {
+      name: "Tron",
+      ticker: "TRX",
+      units: [{ name: "TRX", code: "TRX", magnitude: 6 }],
+    },
+    tronResources: {
+      frozen: { bandwidth: undefined, energy: undefined },
+      unFrozen: { bandwidth: undefined, energy: undefined },
+      delegatedFrozen: { bandwidth: undefined, energy: undefined },
+      legacyFrozen: { bandwidth: undefined, energy: undefined },
+      votes: [],
+      tronPower: 0,
+      energy: new BigNumber(0),
+      bandwidth: {
+        freeUsed: new BigNumber(0),
+        freeLimit: new BigNumber(0),
+        gainedUsed: new BigNumber(0),
+        gainedLimit: new BigNumber(0),
+      },
+      unwithdrawnReward: new BigNumber(0),
+      lastWithdrawnRewardDate: undefined,
+      lastVotedDate: undefined,
+    },
+    ...overrides,
+  }) as TronAccount;
+
+const createTransaction = (overrides: Partial<Transaction> = {}): Transaction => ({
+  family: "tron",
+  mode: "send",
+  resource: "BANDWIDTH",
+  networkInfo: buildNetworkInfo(),
+  duration: null,
+  votes: [],
+  amount: new BigNumber(1000),
+  recipient: RECIPIENT_ADDRESS,
+  ...overrides,
+});
+
+describe("getTransactionStatus", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetchTronAccount.mockResolvedValue([{ address: RECIPIENT_ADDRESS, trc20: [] }]);
+    mockFetchTronContract.mockResolvedValue(undefined);
+    mockGetDelegatedResource.mockResolvedValue(new BigNumber(0));
+    mockGetTronSuperRepresentatives.mockResolvedValue([]);
+    mockGetChainParameters.mockResolvedValue(chainParams);
+    mockTriggerConstantContract.mockResolvedValue({ energy_used: 0 });
+    mockGetTronAccountNetwork.mockResolvedValue(buildNetworkInfo());
+  });
+
+  it("sufficient TRC20 fixture: no TronNotEnoughEnergy, fee 0, no fee warning (State A)", async () => {
+    const tokenAccount = createTrc20TokenAccount();
+    const account = createAccount({ subAccounts: [tokenAccount] });
+    const transaction = createTransaction({ subAccountId: tokenAccount.id });
+    mockTriggerConstantContract.mockResolvedValue({ energy_used: 1000 });
+
+    const status = await getTransactionStatus(account, transaction);
+
+    expect(status.warnings.amount).toBeUndefined();
+    expect(status.estimatedFees.isZero()).toBe(true);
+    expect(status.warnings.fee).toBeUndefined();
+    expect(status.energyRequired.lte(status.energyAvailable)).toBe(true);
+    expect(status.bandwidthRequired.lte(status.bandwidthAvailable)).toBe(true);
+  });
+
+  it("does not raise NotEnoughGas when the fee is 0 and the account holds 0 TRX (resources cover it)", async () => {
+    const tokenAccount = createTrc20TokenAccount();
+    // Zero parent-account TRX balance, but staked energy + free bandwidth cover the transfer.
+    const account = createAccount({
+      subAccounts: [tokenAccount],
+      balance: new BigNumber(0),
+      spendableBalance: new BigNumber(0),
+    });
+    const transaction = createTransaction({ subAccountId: tokenAccount.id });
+    mockTriggerConstantContract.mockResolvedValue({ energy_used: 1000 });
+
+    const status = await getTransactionStatus(account, transaction);
+
+    expect(status.estimatedFees.isZero()).toBe(true);
+    expect(status.errors.gasLimit).toBeUndefined();
+  });
+
+  it("insufficient TRC20 fixture: TronNotEnoughEnergy set, real fee > 0, fee warning set (State B)", async () => {
+    const tokenAccount = createTrc20TokenAccount();
+    const account = createAccount({ subAccounts: [tokenAccount] });
+    const transaction = createTransaction({
+      subAccountId: tokenAccount.id,
+      networkInfo: buildNetworkInfo({ energyLimit: new BigNumber(500) }),
+    });
+    mockTriggerConstantContract.mockResolvedValue({ energy_used: 31_895 });
+
+    const status = await getTransactionStatus(account, transaction);
+
+    expect(status.warnings.amount).toBeInstanceOf(TronNotEnoughEnergy);
+    expect(status.energyRequired.gt(status.energyAvailable)).toBe(true);
+    expect(status.estimatedFees.gt(0)).toBe(true);
+    expect(status.warnings.fee).toBeInstanceOf(TronUnexpectedFees);
+  });
+
+  it("energyRequired reflects the full simulated energy_used (contract sponsorship percent is not applied)", async () => {
+    // Sufficient staked energy here, so despite a large energy_used the transfer is still covered
+    // and no TRX is burned — but energyRequired must equal the full simulated figure, not a
+    // ratio-scaled fraction of it.
+    const tokenAccount = createTrc20TokenAccount();
+    const account = createAccount({ subAccounts: [tokenAccount] });
+    const transaction = createTransaction({
+      subAccountId: tokenAccount.id,
+      networkInfo: buildNetworkInfo({ energyLimit: new BigNumber(1_000_000) }),
+    });
+    mockTriggerConstantContract.mockResolvedValue({ energy_used: 64_285 });
+
+    const status = await getTransactionStatus(account, transaction);
+
+    expect(status.energyRequired).toEqual(new BigNumber(64_285));
+    expect(status.warnings.amount).toBeUndefined();
+    expect(status.estimatedFees.isZero()).toBe(true);
+  });
+
+  it("simulation-failure fixture: does not throw, fee falls back to flat constant, energy reported insufficient", async () => {
+    const tokenAccount = createTrc20TokenAccount();
+    const account = createAccount({ subAccounts: [tokenAccount] });
+    const transaction = createTransaction({ subAccountId: tokenAccount.id });
+    mockTriggerConstantContract.mockResolvedValue({
+      result: { result: false, code: "REVERT", message: "insufficient balance" },
+      energy_used: 0,
+    });
+
+    const status = await getTransactionStatus(account, transaction);
+
+    expect(status.energyRequired.gt(status.energyAvailable)).toBe(true);
+    expect(status.warnings.amount).toBeInstanceOf(TronNotEnoughEnergy);
+    expect(status.estimatedFees).toEqual(STANDARD_FEES_TRC_20);
+  });
+
+  it("warning-gate preservation: a native send with low bandwidth does not raise TronNotEnoughEnergy", async () => {
+    const account = createAccount();
+    const transaction = createTransaction({
+      networkInfo: buildNetworkInfo({ freeNetLimit: new BigNumber(0) }),
+    });
+
+    const status = await getTransactionStatus(account, transaction);
+
+    expect(status.warnings.amount).toBeUndefined();
+    expect(mockTriggerConstantContract).not.toHaveBeenCalled();
+  });
+
+  it("no-errors gating: a transaction with a validation error skips the network-backed breakdown entirely", async () => {
+    const account = createAccount();
+    // recipient === sender triggers InvalidAddressBecauseDestinationIsAlsoSource before any
+    // resource breakdown is computed.
+    const transaction = createTransaction({ recipient: SENDER_ADDRESS });
+
+    const status = await getTransactionStatus(account, transaction);
+
+    expect(status.errors.recipient).toBeInstanceOf(InvalidAddressBecauseDestinationIsAlsoSource);
+    expect(mockTriggerConstantContract).not.toHaveBeenCalled();
+    expect(mockGetChainParameters).not.toHaveBeenCalled();
+    expect(status.estimatedFees.isZero()).toBe(true);
+    expect(status.energyRequired.isZero()).toBe(true);
+    expect(status.energyAvailable.isZero()).toBe(true);
+    expect(status.bandwidthRequired.isZero()).toBe(true);
+    expect(status.bandwidthAvailable.isZero()).toBe(true);
+  });
+
+  it("regression: native TRX send with sufficient bandwidth has estimatedFees 0 and no spurious warnings", async () => {
+    const account = createAccount();
+    const transaction = createTransaction();
+
+    const status = await getTransactionStatus(account, transaction);
+
+    expect(status.estimatedFees.isZero()).toBe(true);
+    expect(status.totalSpent).toEqual(transaction.amount);
+    expect(status.warnings.amount).toBeUndefined();
+    expect(status.warnings.fee).toBeUndefined();
+    expect(status.energyRequired).toEqual(new BigNumber(0));
+  });
+
+  it("regression: TRC10 send with sufficient bandwidth has estimatedFees 0 and no energy dimension", async () => {
+    const trc10TokenAccount = {
+      id: "js:2:tron:sender:+trc10",
+      type: "TokenAccount",
+      balance: new BigNumber(1_000_000),
+      spendableBalance: new BigNumber(1_000_000),
+      operations: [],
+      token: {
+        id: "tron/trc10/1002000",
+        contractAddress: "mock-trc10-contract",
+        tokenType: "trc10",
+      },
+    } as unknown as TokenAccount;
+    const account = createAccount({ subAccounts: [trc10TokenAccount] });
+    const transaction = createTransaction({ subAccountId: trc10TokenAccount.id });
+
+    const status = await getTransactionStatus(account, transaction);
+
+    expect(status.estimatedFees.isZero()).toBe(true);
+    expect(status.energyRequired).toEqual(new BigNumber(0));
+    expect(status.warnings.amount).toBeUndefined();
+    expect(mockTriggerConstantContract).not.toHaveBeenCalled();
+  });
+
+  describe("transaction-mode validations", () => {
+    it("send with zero amount → AmountRequired", async () => {
+      const status = await getTransactionStatus(
+        createAccount(),
+        createTransaction({ amount: new BigNumber(0) }),
+      );
+      expect(status.errors.amount).toBeInstanceOf(AmountRequired);
+    });
+
+    it("send exceeding the spendable balance → NotEnoughBalance", async () => {
+      const status = await getTransactionStatus(
+        createAccount({
+          balance: new BigNumber(50_000_000),
+          spendableBalance: new BigNumber(50_000_000),
+        }),
+        createTransaction({ amount: new BigNumber(100_000_000) }),
+      );
+      expect(status.errors.amount).toBeInstanceOf(NotEnoughBalance);
+    });
+
+    it("freeze below 1 TRX → TronInvalidFreezeAmount", async () => {
+      const status = await getTransactionStatus(
+        createAccount(),
+        createTransaction({ mode: "freeze", amount: new BigNumber(1000) }),
+      );
+      expect(status.errors.amount).toBeInstanceOf(TronInvalidFreezeAmount);
+    });
+
+    it("vote with no votes → TronVoteRequired", async () => {
+      const status = await getTransactionStatus(
+        createAccount(),
+        createTransaction({ mode: "vote", votes: [] }),
+      );
+      expect(status.errors.vote).toBeInstanceOf(TronVoteRequired);
+    });
+
+    it("claimReward with no unwithdrawn reward → TronNoReward", async () => {
+      const status = await getTransactionStatus(
+        createAccount(),
+        createTransaction({ mode: "claimReward" }),
+      );
+      expect(status.errors.reward).toBeInstanceOf(TronNoReward);
+    });
+
+    it("insufficient parent-account balance for fees → NotEnoughGas", async () => {
+      // No free/staked bandwidth → a real native TRX fee is owed that the 0-balance account can't cover.
+      const status = await getTransactionStatus(
+        createAccount({ balance: new BigNumber(0), spendableBalance: new BigNumber(0) }),
+        createTransaction({ networkInfo: buildNetworkInfo({ freeNetLimit: new BigNumber(0) }) }),
+      );
+      expect(status.estimatedFees.gt(0)).toBe(true);
+      expect(status.errors.gasLimit).toBeInstanceOf(NotEnoughGas);
+    });
+
+    it("unfreeze BANDWIDTH with nothing frozen → TronNoFrozenForBandwidth", async () => {
+      const status = await getTransactionStatus(
+        createAccount(),
+        createTransaction({ mode: "unfreeze", resource: "BANDWIDTH", amount: new BigNumber(1000) }),
+      );
+      expect(status.errors.resource).toBeInstanceOf(TronNoFrozenForBandwidth);
+    });
+
+    it("unfreeze ENERGY with nothing frozen → TronNoFrozenForEnergy", async () => {
+      const status = await getTransactionStatus(
+        createAccount(),
+        createTransaction({ mode: "unfreeze", resource: "ENERGY", amount: new BigNumber(1000) }),
+      );
+      expect(status.errors.resource).toBeInstanceOf(TronNoFrozenForEnergy);
+    });
+
+    it("unDelegateResource beyond the delegated amount → TronInvalidUnDelegateResourceAmount", async () => {
+      mockGetDelegatedResource.mockResolvedValue(new BigNumber(0));
+      const status = await getTransactionStatus(
+        createAccount(),
+        createTransaction({
+          mode: "unDelegateResource",
+          resource: "BANDWIDTH",
+          amount: new BigNumber(1000),
+        }),
+      );
+      expect(status.errors.resource).toBeInstanceOf(TronInvalidUnDelegateResourceAmount);
+    });
+
+    it("vote for an address that is not a super representative → InvalidAddress", async () => {
+      mockGetTronSuperRepresentatives.mockResolvedValue([]);
+      const status = await getTransactionStatus(
+        createAccount(),
+        createTransaction({ mode: "vote", votes: [{ address: RECIPIENT_ADDRESS, voteCount: 1 }] }),
+      );
+      expect(status.errors.vote).toBeInstanceOf(InvalidAddress);
+    });
+
+    it("vote exceeding available Tron Power → TronNotEnoughTronPower", async () => {
+      mockGetTronSuperRepresentatives.mockResolvedValue([
+        { address: RECIPIENT_ADDRESS },
+      ] as unknown as Awaited<ReturnType<typeof getTronSuperRepresentatives>>);
+      const status = await getTransactionStatus(
+        createAccount({ tronResources: { ...createAccount().tronResources, tronPower: 0 } }),
+        createTransaction({ mode: "vote", votes: [{ address: RECIPIENT_ADDRESS, voteCount: 5 }] }),
+      );
+      expect(status.errors.vote).toBeInstanceOf(TronNotEnoughTronPower);
+    });
+
+    it("legacyUnfreeze with nothing legacy-frozen → TronNoFrozenForBandwidth", async () => {
+      const status = await getTransactionStatus(
+        createAccount(),
+        createTransaction({ mode: "legacyUnfreeze", resource: "BANDWIDTH" }),
+      );
+      expect(status.errors.resource).toBeInstanceOf(TronNoFrozenForBandwidth);
+    });
+
+    it("withdrawExpireUnfreeze with no unfrozen resource → TronNoUnfrozenResource", async () => {
+      const status = await getTransactionStatus(
+        createAccount(),
+        createTransaction({ mode: "withdrawExpireUnfreeze" }),
+      );
+      expect(status.errors.resource).toBeInstanceOf(TronNoUnfrozenResource);
+    });
+  });
+});

--- a/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.ts
@@ -15,7 +15,6 @@ import { validateAddress } from "../logic/validateAddress";
 import {
   fetchTronAccount,
   fetchTronContract,
-  getContractUserEnergyRatioConsumption,
   getDelegatedResource,
   getTronSuperRepresentatives,
 } from "../network";
@@ -37,7 +36,7 @@ import {
   TronUnfreezeNotExpired,
   TronVoteRequired,
 } from "../types/errors";
-import getEstimatedFees from "./getEstimateFees";
+import getEstimatedFees, { getFeeResourceBreakdown } from "./getEstimateFees";
 
 const getTransactionStatus = async (
   acc: TronAccount,
@@ -189,10 +188,25 @@ const getTransactionStatus = async (
     }
   }
 
-  const estimatedFees =
-    Object.entries(errors).length > 0
-      ? new BigNumber(0)
-      : await getEstimatedFees(acc, transaction, tokenAccount);
+  // Only when no error has been detected so far (the recipient/resource checks above): compute the
+  // breakdown once and reuse it for both the status fields and the fee, so they can't disagree.
+  // (Amount validation runs later; the zero-amount case is guarded inside getFeeResourceBreakdown.)
+  const hasErrors = Object.entries(errors).length > 0;
+  let energyRequired = new BigNumber(0);
+  let energyAvailable = new BigNumber(0);
+  let bandwidthRequired = new BigNumber(0);
+  let bandwidthAvailable = new BigNumber(0);
+  let estimatedFees = new BigNumber(0);
+
+  if (!hasErrors) {
+    const resourceBreakdown = await getFeeResourceBreakdown(acc, transaction, tokenAccount);
+    energyRequired = resourceBreakdown.energyRequired;
+    energyAvailable = resourceBreakdown.energyAvailable;
+    bandwidthRequired = resourceBreakdown.bandwidthRequired;
+    bandwidthAvailable = resourceBreakdown.bandwidthAvailable;
+    estimatedFees = await getEstimatedFees(acc, transaction, tokenAccount, resourceBreakdown);
+  }
+
   const balance =
     account.type === "Account"
       ? BigNumber.max(0, account.spendableBalance.minus(estimatedFees))
@@ -219,25 +233,14 @@ const getTransactionStatus = async (
       errors.amount = new NotEnoughBalance();
     }
 
-    const energy = (acc.tronResources && acc.tronResources.energy) || new BigNumber(0);
-
-    // For the moment, we rely on this rule:
-    // Add a 'TronNotEnoughEnergy' warning only if the account sastifies theses 3 conditions:
-    // - no energy
-    // - balance is lower than 1 TRX
-    // - contract consumes user energy (ie: user's ratio > 0%)
+    // Warn when the real energy requirement exceeds available energy (replaces the former
+    // hardcoded-47619 heuristic).
     if (
       account.type === "TokenAccount" &&
       account.token.tokenType === "trc20" &&
-      energy.lt(47619) // temporary value corresponding to usdt trc20 energy
+      energyRequired.gt(energyAvailable)
     ) {
-      const contractUserEnergyConsumption = await getContractUserEnergyRatioConsumption(
-        account.token.contractAddress,
-      );
-
-      if (contractUserEnergyConsumption > 0) {
-        warnings.amount = new TronNotEnoughEnergy();
-      }
+      warnings.amount = new TronNotEnoughEnergy();
     }
   }
 
@@ -254,9 +257,14 @@ const getTransactionStatus = async (
   const parentAccountBalance = account.type === "Account" ? account.balance : acc.spendableBalance;
   //
   // Not enough gas check
-  // PTX swap uses this to support deeplink to buy additional currency
+  // PTX swap uses this to support deeplink to buy additional currency.
+  // Only require TRX when a fee is actually owed: an energy-aware TRC20 transfer covered by the
+  // account's staked resources costs 0 TRX, so a zero-balance account can still broadcast it.
   //
-  if (parentAccountBalance.lt(estimatedFees) || parentAccountBalance.isZero()) {
+  if (
+    parentAccountBalance.lt(estimatedFees) ||
+    (parentAccountBalance.isZero() && estimatedFees.gt(0))
+  ) {
     const query = new URLSearchParams({
       ...(acc?.id ? { account: acc.id } : {}),
     });
@@ -275,6 +283,10 @@ const getTransactionStatus = async (
     estimatedFees,
     totalSpent,
     family,
+    energyRequired,
+    energyAvailable,
+    bandwidthRequired,
+    bandwidthAvailable,
   });
 };
 

--- a/libs/coin-modules/coin-tron/src/bridge/transaction.test.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/transaction.test.ts
@@ -1,0 +1,22 @@
+import BigNumber from "bignumber.js";
+import type { TransactionStatusRaw } from "../types";
+import { fromTransactionStatusRaw } from "./transaction";
+
+describe("fromTransactionStatusRaw", () => {
+  it("defaults the live-derived resource fields to 0 (they are not persisted in Raw)", () => {
+    const raw = {
+      errors: {},
+      warnings: {},
+      estimatedFees: "0",
+      amount: "0",
+      totalSpent: "0",
+    } as unknown as TransactionStatusRaw;
+
+    const status = fromTransactionStatusRaw(raw);
+
+    expect(status.energyRequired).toEqual(new BigNumber(0));
+    expect(status.energyAvailable).toEqual(new BigNumber(0));
+    expect(status.bandwidthRequired).toEqual(new BigNumber(0));
+    expect(status.bandwidthAvailable).toEqual(new BigNumber(0));
+  });
+});

--- a/libs/coin-modules/coin-tron/src/bridge/transaction.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/transaction.ts
@@ -3,13 +3,26 @@ import { getAccountCurrency } from "@ledgerhq/ledger-wallet-framework/account";
 import { formatTransactionStatus } from "@ledgerhq/ledger-wallet-framework/formatters";
 import {
   fromTransactionCommonRaw,
-  fromTransactionStatusRawCommon as fromTransactionStatusRaw,
+  fromTransactionStatusRawCommon,
   toTransactionCommonRaw,
   toTransactionStatusRawCommon as toTransactionStatusRaw,
 } from "@ledgerhq/ledger-wallet-framework/serialization";
 import type { Account } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
-import type { Transaction, TransactionRaw } from "../types";
+import type { Transaction, TransactionRaw, TransactionStatus, TransactionStatusRaw } from "../types";
+
+// These resource fields are live-derived and not persisted (absent from TransactionStatusRaw).
+// Default them to 0 on deserialization so the required BigNumber fields are never `undefined`.
+export const fromTransactionStatusRaw = (tsr: TransactionStatusRaw): TransactionStatus => {
+  const zero = new BigNumber(0);
+  return {
+    ...fromTransactionStatusRawCommon(tsr),
+    energyRequired: zero,
+    energyAvailable: zero,
+    bandwidthRequired: zero,
+    bandwidthAvailable: zero,
+  };
+};
 
 export const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
   const common = fromTransactionCommonRaw(tr);

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
@@ -9,7 +9,13 @@ import {
 import type { AccountTronAPI, ChainParameters } from "../network/types";
 import type { NetworkInfo } from "../types";
 import { ACTIVATION_FEES, STANDARD_FEES_NATIVE, STANDARD_FEES_TRC_20 } from "./constants";
-import { estimateFees } from "./estimateFees";
+import {
+  computeBandwidthFee,
+  computeEnergyFee,
+  estimateEnergy,
+  estimatedTxSize,
+  estimateFees,
+} from "./estimateFees";
 
 jest.mock("../network", () => ({
   fetchTronAccount: jest.fn(),
@@ -239,6 +245,124 @@ describe("estimateFees", () => {
       const result = await estimateFees(sendTrc20);
 
       expect(result).toBe(BigInt(STANDARD_FEES_TRC_20.toString()));
+    });
+  });
+
+  describe("estimatedTxSize (exported helper)", () => {
+    it("returns the TransferAssetContract size for a trc10 send", () => {
+      expect(estimatedTxSize(sendTrc10)).toBe(285);
+    });
+
+    it("returns the TriggerSmartContract size for a trc20 send", () => {
+      expect(estimatedTxSize(sendTrc20)).toBe(350);
+    });
+
+    it("returns the TransferContract size for a native send", () => {
+      expect(estimatedTxSize(sendNative)).toBe(270);
+    });
+
+    it("throws for an unsupported intent type", () => {
+      expect(() => estimatedTxSize({ ...sendNative, type: "unsupported" as never })).toThrow();
+    });
+  });
+
+  describe("estimateEnergy (exported helper)", () => {
+    it("returns 0 without calling triggerConstantContract for a non-trc20 asset", async () => {
+      const result = await estimateEnergy(sendNative);
+
+      expect(result).toBe(0);
+      expect(mockTriggerConstantContract).not.toHaveBeenCalled();
+    });
+
+    it("returns the simulated energy_used for a trc20 asset", async () => {
+      mockTriggerConstantContract.mockResolvedValue({ energy_used: 12_345 });
+
+      const result = await estimateEnergy(sendTrc20);
+
+      expect(result).toBe(12_345);
+    });
+
+    it("throws when the simulation reports a reverted result", async () => {
+      mockTriggerConstantContract.mockResolvedValue({
+        result: { result: false, code: "REVERT", message: "insufficient balance" },
+      });
+
+      await expect(estimateEnergy(sendTrc20)).rejects.toThrow(/triggerConstantContract failed/);
+    });
+
+    it("throws when a successful simulation omits energy_used", async () => {
+      mockTriggerConstantContract.mockResolvedValue({ result: { result: true } });
+
+      await expect(estimateEnergy(sendTrc20)).rejects.toThrow(/no energy_used/);
+    });
+  });
+
+  describe("computeBandwidthFee (exported helper)", () => {
+    it("returns 0 when the size fits within available bandwidth", () => {
+      const networkInfo = buildNetworkInfo({ freeNetLimit: new BigNumber(5000) });
+
+      expect(computeBandwidthFee(270, networkInfo, chainParams)).toEqual(new BigNumber(0));
+    });
+
+    it("charges (size - available) * transactionFee when bandwidth is insufficient", () => {
+      const networkInfo = buildNetworkInfo();
+
+      expect(computeBandwidthFee(270, networkInfo, chainParams)).toEqual(
+        new BigNumber(270 * chainParams.transactionFee),
+      );
+    });
+
+    it("does not overcharge when used > limit (available clamped to 0)", () => {
+      const networkInfo = buildNetworkInfo({
+        freeNetLimit: new BigNumber(0),
+        freeNetUsed: new BigNumber(500),
+      });
+
+      // available = -500 → clamped 0 → missing = size (270), not size + 500.
+      expect(computeBandwidthFee(270, networkInfo, chainParams)).toEqual(
+        new BigNumber(270 * chainParams.transactionFee),
+      );
+    });
+
+    it("clamps each bucket independently — a negative free bucket does not reduce staked", () => {
+      const networkInfo = buildNetworkInfo({
+        freeNetLimit: new BigNumber(0),
+        freeNetUsed: new BigNumber(500), // free = -500 → 0
+        netLimit: new BigNumber(1000),
+        netUsed: new BigNumber(0), // staked = 1000
+      });
+
+      // 800 fits within the 1000 staked bucket → 0 fee. (Clamping the *sum* would report 500
+      // available and wrongly charge for a 300 shortfall.)
+      expect(computeBandwidthFee(800, networkInfo, chainParams)).toEqual(new BigNumber(0));
+    });
+  });
+
+  describe("computeEnergyFee (exported helper)", () => {
+    it("returns 0 when energy needed fits within available energy", () => {
+      const networkInfo = buildNetworkInfo({ energyLimit: new BigNumber(100_000) });
+
+      expect(computeEnergyFee(31_895, networkInfo, chainParams)).toEqual(new BigNumber(0));
+    });
+
+    it("charges (needed - available) * energyFee when energy is insufficient", () => {
+      const networkInfo = buildNetworkInfo({ energyLimit: new BigNumber(20_000) });
+
+      expect(computeEnergyFee(31_895, networkInfo, chainParams)).toEqual(
+        new BigNumber((31_895 - 20_000) * chainParams.energyFee),
+      );
+    });
+
+    it("does not overcharge when energyUsed > energyLimit (available clamped to 0)", () => {
+      const networkInfo = buildNetworkInfo({
+        energyLimit: new BigNumber(0),
+        energyUsed: new BigNumber(5000),
+      });
+
+      // available = -5000 → clamped 0 → missing = energyNeeded (31_895), not 36_895.
+      expect(computeEnergyFee(31_895, networkInfo, chainParams)).toEqual(
+        new BigNumber(31_895 * chainParams.energyFee),
+      );
     });
   });
 

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
@@ -14,9 +14,11 @@ import type { NetworkInfo, TronMemo } from "../types";
 import { ACTIVATION_FEES, STANDARD_FEES_NATIVE, STANDARD_FEES_TRC_20 } from "./constants";
 
 // Byte sizes of the fully signed transaction (raw_data + signature + protobuf wrapping).
-// Mirrors bridge/utils.ts:getEstimatedBlockSize. Using craftTransaction's raw_data_hex alone
-// would underestimate by ~50% because it doesn't include the signature/outer envelope.
-const estimatedTxSize = (intent: TransactionIntent<TronMemo>): number => {
+// Approximates bridge/utils.ts:getEstimatedBlockSize — using craftTransaction's raw_data_hex alone
+// would underestimate by ~50% because it doesn't include the signature/outer envelope. The `vote`
+// size is a flat estimate: TransactionIntent carries no vote count, so unlike getEstimatedBlockSize
+// it does not grow per vote (a minor bandwidth under-estimate for multi-vote intents).
+export const estimatedTxSize = (intent: TransactionIntent<TronMemo>): number => {
   switch (intent.type) {
     case "send":
       if (intent.asset.type === "trc10") return 285; // TransferAssetContract
@@ -36,7 +38,7 @@ const estimatedTxSize = (intent: TransactionIntent<TronMemo>): number => {
   }
 };
 
-const estimateEnergy = async (intent: TransactionIntent<TronMemo>): Promise<number> => {
+export const estimateEnergy = async (intent: TransactionIntent<TronMemo>): Promise<number> => {
   if (intent.asset.type !== "trc20" || !intent.asset.assetReference) {
     return 0;
   }
@@ -55,27 +57,39 @@ const estimateEnergy = async (intent: TransactionIntent<TronMemo>): Promise<numb
       `triggerConstantContract failed: ${response.result.code ?? "unknown"} ${response.result.message ?? ""}`.trim(),
     );
   }
-  return response.energy_used ?? 0;
+  // A successful simulation that omits energy_used (or returns a non-numeric value) is uncertainty,
+  // not "0 energy". Defaulting to 0 would let a TRC20 transfer report a zero/under-stated fee; throw
+  // so callers fall back to the pessimistic flat fee instead.
+  const energyUsed = response.energy_used;
+  if (energyUsed === undefined || !Number.isFinite(energyUsed)) {
+    throw new Error("triggerConstantContract returned no energy_used for a TRC20 transfer");
+  }
+  return energyUsed;
 };
 
-const computeBandwidthFee = (
+export const computeBandwidthFee = (
   size: number,
   networkInfo: NetworkInfo,
   params: ChainParameters,
 ): BigNumber => {
-  const freeAvailable = networkInfo.freeNetLimit.minus(networkInfo.freeNetUsed);
-  const stakedAvailable = networkInfo.netLimit.minus(networkInfo.netUsed);
+  // Clamp each bucket to ≥ 0 before summing: a node reporting used > limit in one bucket must not
+  // eat into the other's availability, nor inflate the shortfall beyond `size`.
+  const freeAvailable = BigNumber.maximum(
+    0,
+    networkInfo.freeNetLimit.minus(networkInfo.freeNetUsed),
+  );
+  const stakedAvailable = BigNumber.maximum(0, networkInfo.netLimit.minus(networkInfo.netUsed));
   const available = freeAvailable.plus(stakedAvailable);
   const missing = BigNumber.maximum(0, new BigNumber(size).minus(available));
   return missing.multipliedBy(params.transactionFee);
 };
 
-const computeEnergyFee = (
+export const computeEnergyFee = (
   energyNeeded: number,
   networkInfo: NetworkInfo,
   params: ChainParameters,
 ): BigNumber => {
-  const available = networkInfo.energyLimit.minus(networkInfo.energyUsed);
+  const available = BigNumber.maximum(0, networkInfo.energyLimit.minus(networkInfo.energyUsed));
   const missing = BigNumber.maximum(0, new BigNumber(energyNeeded).minus(available));
   return missing.multipliedBy(params.energyFee);
 };

--- a/libs/coin-modules/coin-tron/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-tron/src/test/bridgeDatasetTest.ts
@@ -10,8 +10,9 @@ import type { Account, CurrenciesData, DatasetTest, TokenAccount } from "@ledger
 import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import { fromTransactionRaw } from "../bridge/transaction";
-import { ACTIVATION_FEES } from "../logic/constants";
-import type { Transaction, TronAccountRaw } from "../types";
+import { ACTIVATION_FEES, STANDARD_FEES_TRC_20 } from "../logic/constants";
+import { getChainParameters } from "../network";
+import type { Transaction, TransactionStatus, TronAccountRaw } from "../types";
 import {
   TronInvalidFreezeAmount,
   TronInvalidUnDelegateResourceAmount,
@@ -37,6 +38,44 @@ const getTokenAccountId = (account: Account, id: string) =>
   expectedTokenAccount(
     (account.subAccounts || []).find(a => expectedTokenAccount(a).token.id === id),
   ).id;
+
+// Minimal shape of the dataset harness's `expect` used below (avoids `any` in the signature).
+type ExpectToEqual = (received: string) => { toEqual: (expected: string) => void };
+
+// Active-recipient TRC20 sends carry an energy-aware fee: estimatedFees must equal the resource
+// shortfall derived from the exposed energy/bandwidth breakdown (0 when staked resources cover the
+// transfer). Asserting that invariant — instead of a hardcoded TRX amount — stays deterministic
+// against live mainnet energy state while still catching a silent regression to a too-low fee.
+const assertEnergyAwareTrc20Fee = async (
+  expect: ExpectToEqual,
+  statusCommon: unknown,
+): Promise<void> => {
+  const status = statusCommon as TransactionStatus;
+  // When the energy estimate is uncertain (simulation/network failure), production returns the flat
+  // STANDARD_FEES_TRC_20; otherwise it prices the shortfall from the breakdown. The exposed fields
+  // can't distinguish the two (the "estimated" flag is internal), so discriminate on the fee itself
+  // rather than on the sentinel gap — the flat fallback is a legitimate outcome, and accepting it
+  // here avoids flapping on transient node errors.
+  if (status.estimatedFees.eq(STANDARD_FEES_TRC_20)) {
+    return;
+  }
+  const bandwidthShortfall = BigNumber.maximum(
+    0,
+    status.bandwidthRequired.minus(status.bandwidthAvailable),
+  );
+  const energyShortfall = BigNumber.maximum(0, status.energyRequired.minus(status.energyAvailable));
+  // No shortfall means no fee, so skip the chain-parameters fetch entirely.
+  let shortfallFee = new BigNumber(0);
+  if (!(bandwidthShortfall.isZero() && energyShortfall.isZero())) {
+    const params = await getChainParameters();
+    shortfallFee = bandwidthShortfall
+      .multipliedBy(params.transactionFee)
+      .plus(energyShortfall.multipliedBy(params.energyFee));
+  }
+  // Any value that is neither the flat fallback nor the priced shortfall (e.g. a silent regression
+  // to a too-low fee) fails here.
+  expect(status.estimatedFees.toFixed()).toEqual(shortfallFee.toFixed());
+};
 
 const tron: CurrenciesData<Transaction> = {
   FIXME_ignoreAccountFields: [
@@ -478,8 +517,10 @@ const tron: CurrenciesData<Transaction> = {
             errors: {},
             warnings: {},
             totalSpent: new BigNumber("1000000"),
-            estimatedFees: new BigNumber("13740900"),
           },
+          // estimatedFees is energy-aware, so it varies with live staked energy instead of the flat
+          // STANDARD_FEES_TRC_20; assert it against the exposed breakdown rather than a fixed amount.
+          test: (expect, _transaction, status) => assertEnergyAwareTrc20Fee(expect, status),
         },
         {
           name: "tronSendTrc20ToNewAccountForbidden",
@@ -545,8 +586,10 @@ const tron: CurrenciesData<Transaction> = {
             errors: {},
             warnings: {},
             totalSpent: new BigNumber("1000000"),
-            estimatedFees: new BigNumber("13740900"),
           },
+          // estimatedFees is energy-aware, so it varies with live staked energy instead of the flat
+          // STANDARD_FEES_TRC_20; assert it against the exposed breakdown rather than a fixed amount.
+          test: (expect, _transaction, status) => assertEnergyAwareTrc20Fee(expect, status),
         },
         {
           name: "tronInvalidFreezeAmount",

--- a/libs/coin-modules/coin-tron/src/types/bridge.ts
+++ b/libs/coin-modules/coin-tron/src/types/bridge.ts
@@ -298,5 +298,13 @@ export function isTronAccount(account: Account): account is TronAccount {
 }
 export type TronAccount = Account & { tronResources: TronResources };
 export type TronAccountRaw = AccountRaw & { tronResources: TronResourcesRaw };
-export type TransactionStatus = TransactionStatusCommon;
+// Additive resource-breakdown fields for the send-flow UI. Sufficiency is: energyRequired <=
+// energyAvailable && bandwidthRequired <= bandwidthAvailable. On a failed energy estimate,
+// energyRequired is a safe insufficient sentinel. Not mirrored to TransactionStatusRaw.
+export type TransactionStatus = TransactionStatusCommon & {
+  energyRequired: BigNumber;
+  energyAvailable: BigNumber;
+  bandwidthRequired: BigNumber;
+  bandwidthAvailable: BigNumber;
+};
 export type TransactionStatusRaw = TransactionStatusCommonRaw;


### PR DESCRIPTION
### 📝 Description

TRON's send flow shows a flat TRC20 fee (`STANDARD_FEES_TRC_20`, ~13.74 TRX) regardless of the sender's staked energy, and exposes no resource data — so the UI cannot tell the user whether a transfer is covered by energy/bandwidth or paid by burning TRX.

This exposes four `BigNumber` fields on the Tron `TransactionStatus` (`energyRequired`, `energyAvailable`, `bandwidthRequired`, `bandwidthAvailable`) and makes the active-recipient TRC20 fee energy-aware: 0 TRX when energy and bandwidth cover the transfer, the real shortfall cost otherwise (derived from the `triggerConstantContract` simulation via the existing `computeEnergyFee` / `computeBandwidthFee` helpers), falling back to the previous flat fee on any uncertainty. `energyRequired` uses the full simulated `energy_used` — the caller pays 100% in practice (`origin_energy_usage = 0` on mainnet, incl. USDT), so the `consume_user_resource_percent` sponsorship ratio is not applied. The `TronNotEnoughEnergy` warning now uses the real `energyRequired > energyAvailable` comparison instead of the hardcoded `47619` heuristic.

The insufficient-gas check now raises `NotEnoughGas` only when a fee is actually owed — a 0-TRX account whose transfer is fully covered by staked resources is no longer blocked, while the buy-currency deeplink still fires whenever a fee > 0. Native TRX / TRC10 fee amounts and the new-recipient paths are otherwise unchanged. Prerequisite for the LWD/LWM send-flow fee tooltip & drawer.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34149](https://ledgerhq.atlassian.net/browse/LIVE-34149)
- **ADR** (if any): —


[LIVE-34149]: https://ledgerhq.atlassian.net/browse/LIVE-34149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
