### PR TITLE
[LWM] test(e2e-mobile): fix e2e failures under wallet40-q2 feature flag [LIVE-33894]

### DIFF
--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -66,7 +66,7 @@ export function AssetDetailView({
     <Box testID={ASSET_DETAIL_TEST_IDS.screen} lx={screenStyle}>
       <TrackScreen category="Asset" currency={currency?.name} source={source} />
       <ScrollView
-        testID={ASSET_DETAIL_TEST_IDS.scrollView(currency.id)}
+        testID={ASSET_DETAIL_TEST_IDS.scrollView(currency?.id ?? "")}
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ paddingBottom: scrollPaddingBottom }}
         refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -66,6 +66,7 @@ export function AssetDetailView({
     <Box testID={ASSET_DETAIL_TEST_IDS.screen} lx={screenStyle}>
       <TrackScreen category="Asset" currency={currency?.name} source={source} />
       <ScrollView
+        testID={ASSET_DETAIL_TEST_IDS.scrollView(currency.id)}
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ paddingBottom: scrollPaddingBottom }}
         refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
@@ -1,5 +1,6 @@
 export const ASSET_DETAIL_TEST_IDS = {
   screen: "asset-detail-screen",
+  scrollView: (currencyId: string) => `asset-detail-scroll-view-${currencyId}`,
   balanceGraph: "asset-detail-balance-graph",
   marketPrice: "asset-detail-market-price",
   chart: "asset-detail-chart",

--- a/e2e/mobile/page/accounts/assetAccounts.page.ts
+++ b/e2e/mobile/page/accounts/assetAccounts.page.ts
@@ -11,12 +11,19 @@ export default class AssetAccountsPage {
     getElementById(`asset-quick-action-button-${action}`);
 
   @Step("Wait for asset page to load")
-  async waitForAccountPageToLoad(assetName: string) {
-    await waitForElementById(this.titleId(assetName.toLowerCase()));
+  async waitForAccountPageToLoad(assetName: string, currencyId?: string) {
+    if (await isAggregatedAssetsEnabled()) {
+      await waitForElementById(`asset-detail-scroll-view-${currencyId ?? assetName.toLowerCase()}`);
+    } else {
+      await waitForElementById(this.titleId(assetName.toLowerCase()));
+    }
   }
 
   @Step("Expect asset balance to be visible")
   async expectAccountsBalanceVisible() {
+    if (await isAggregatedAssetsEnabled()) {
+      return; // screen already confirmed in waitForAccountPageToLoad; no legacy balance element in Q2
+    }
     const balanceEl = this.assetBalance();
     await detoxExpect(balanceEl).toBeVisible();
   }

--- a/e2e/mobile/page/accounts/assetAccounts.page.ts
+++ b/e2e/mobile/page/accounts/assetAccounts.page.ts
@@ -1,5 +1,6 @@
 import { Step } from "jest-allure2-reporter/api";
 import { currencyParam, openDeeplink } from "../../helpers/commonHelpers";
+import { isAggregatedAssetsEnabled } from "../../utils/featureFlagUtils";
 
 export default class AssetAccountsPage {
   baseLink = "account";
@@ -47,6 +48,10 @@ export default class AssetAccountsPage {
   @Step("Expect asset page to be visible")
   async expectAssetPage(currencyId?: string) {
     const currency = currencyId?.toLowerCase() || "bitcoin";
-    await waitForElementById(this.accountAssetId(currency));
+    if (await isAggregatedAssetsEnabled()) {
+      await waitForElementById(`asset-detail-scroll-view-${currency}`);
+    } else {
+      await waitForElementById(this.accountAssetId(currency));
+    }
   }
 }

--- a/e2e/mobile/page/accounts/assetAccounts.page.ts
+++ b/e2e/mobile/page/accounts/assetAccounts.page.ts
@@ -42,9 +42,20 @@ export default class AssetAccountsPage {
 
   @Step("Tap on asset quick action button ")
   async tapOnAssetQuickActionButton(action: "send" | "receive" | "buy" | "sell" | "swap") {
-    const quickActionButton = this.assetQuickActionButton(action);
-    await waitForElement(quickActionButton);
-    await tapByElement(quickActionButton);
+    if (await isAggregatedAssetsEnabled()) {
+      const q2TestIds: Partial<Record<typeof action, string>> = {
+        buy: "asset-detail-buy-button",
+        swap: "asset-detail-swap-button",
+        receive: "asset-detail-footer-receive-button",
+      };
+      const testId = q2TestIds[action] ?? `asset-quick-action-button-${action}`;
+      await waitForElementById(testId);
+      await tapById(testId);
+    } else {
+      const quickActionButton = this.assetQuickActionButton(action);
+      await waitForElement(quickActionButton);
+      await tapByElement(quickActionButton);
+    }
   }
 
   @Step("Open asset page via deeplink")

--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -4,6 +4,7 @@ import { Account, getParentAccountName } from "@ledgerhq/live-e2e-shared/enum/Ac
 import { isIos } from "../helpers/commonHelpers";
 import { device } from "detox";
 import ErrorPage from "./error.page";
+import { openDeeplink } from "../helpers/commonHelpers";
 import { isAggregatedAssetsEnabled } from "../utils/featureFlagUtils";
 
 export default class CommonPage {
@@ -82,6 +83,10 @@ export default class CommonPage {
   @Step("Go to the account")
   async goToAccount(accountId: string, currencyId?: string) {
     if (await isAggregatedAssetsEnabled()) {
+      if (currencyId) {
+        await openDeeplink(`asset/${currencyId}`);
+        await waitForElementById(`asset-detail-scroll-view-${currencyId}`);
+      }
       const q2AccountItemRegExp = /^asset-detail-address-item-.*/;
       const scrollViewId = currencyId ? `asset-detail-scroll-view-${currencyId}` : undefined;
       await scrollToId(q2AccountItemRegExp, scrollViewId);

--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -1,10 +1,9 @@
 import { Step } from "jest-allure2-reporter/api";
 import { removeSpeculosAndDeregisterKnownSpeculos } from "../utils/speculosUtils";
 import { Account, getParentAccountName } from "@ledgerhq/live-e2e-shared/enum/Account";
-import { isIos } from "../helpers/commonHelpers";
+import { isIos, openDeeplink } from "../helpers/commonHelpers";
 import { device } from "detox";
 import ErrorPage from "./error.page";
-import { openDeeplink } from "../helpers/commonHelpers";
 import { isAggregatedAssetsEnabled } from "../utils/featureFlagUtils";
 
 export default class CommonPage {

--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -86,10 +86,10 @@ export default class CommonPage {
         await openDeeplink(`asset/${currencyId}`);
         await waitForElementById(`asset-detail-scroll-view-${currencyId}`);
       }
-      const q2AccountItemRegExp = /^asset-detail-address-item-.*/;
+      const itemId = `asset-detail-address-item-${accountId}`;
       const scrollViewId = currencyId ? `asset-detail-scroll-view-${currencyId}` : undefined;
-      await scrollToId(q2AccountItemRegExp, scrollViewId);
-      await tapByElement(getElementById(q2AccountItemRegExp));
+      await scrollToId(itemId, scrollViewId);
+      await tapByElement(getElementById(itemId));
     } else {
       await scrollToId(this.accountItemRegExp(accountId), this.assetScreenFlatlistId);
       await tapByElement(this.accountItem(accountId));

--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -4,6 +4,7 @@ import { Account, getParentAccountName } from "@ledgerhq/live-e2e-shared/enum/Ac
 import { isIos } from "../helpers/commonHelpers";
 import { device } from "detox";
 import ErrorPage from "./error.page";
+import { isAggregatedAssetsEnabled } from "../utils/featureFlagUtils";
 
 export default class CommonPage {
   assetScreenFlatlistId = "asset-screen-flatlist";
@@ -79,9 +80,16 @@ export default class CommonPage {
   }
 
   @Step("Go to the account")
-  async goToAccount(accountId: string) {
-    await scrollToId(this.accountItemRegExp(accountId), this.assetScreenFlatlistId);
-    await tapByElement(this.accountItem(accountId));
+  async goToAccount(accountId: string, currencyId?: string) {
+    if (await isAggregatedAssetsEnabled()) {
+      const q2AccountItemRegExp = /^asset-detail-address-item-.*/;
+      const scrollViewId = currencyId ? `asset-detail-scroll-view-${currencyId}` : undefined;
+      await scrollToId(q2AccountItemRegExp, scrollViewId);
+      await tapByElement(getElementById(q2AccountItemRegExp));
+    } else {
+      await scrollToId(this.accountItemRegExp(accountId), this.assetScreenFlatlistId);
+      await tapByElement(this.accountItem(accountId));
+    }
   }
 
   @Step("Tap on close with confirmation button")

--- a/e2e/mobile/page/market/market.page.ts
+++ b/e2e/mobile/page/market/market.page.ts
@@ -46,8 +46,13 @@ export default class MarketPage {
   }
 
   @Step("Expect market detail page")
-  async expectMarketDetailPage() {
-    await detoxExpect(this.starButton()).toBeVisible();
+  async expectMarketDetailPage(currencyId?: string) {
+    if (await isAggregatedAssetsEnabled()) {
+      const currency = currencyId?.toLowerCase() || "bitcoin";
+      await waitForElementById(`asset-detail-scroll-view-${currency}`);
+    } else {
+      await detoxExpect(this.starButton()).toBeVisible();
+    }
   }
 
   @Step("Expect market list header left")

--- a/e2e/mobile/page/market/market.page.ts
+++ b/e2e/mobile/page/market/market.page.ts
@@ -69,8 +69,13 @@ export default class MarketPage {
 
   @Step("Leave market detail page")
   async leaveMarketDetailPage() {
-    await waitForElementById(this.backButtonId, 5000);
-    await tapById(this.backButtonId);
+    if (await isAggregatedAssetsEnabled()) {
+      await waitForElementById(this.headerBackButtonId);
+      await tapById(this.headerBackButtonId);
+    } else {
+      await waitForElementById(this.backButtonId, 5000);
+      await tapById(this.backButtonId);
+    }
   }
 
   @Step("Search for asset")

--- a/e2e/mobile/page/market/market.page.ts
+++ b/e2e/mobile/page/market/market.page.ts
@@ -131,7 +131,18 @@ export default class MarketPage {
 
   @Step("Tap on market quick action button ")
   async tapOnMarketQuickActionButton(action: "send" | "receive" | "buy" | "sell" | "swap") {
-    await tapByElement(this.marketQuickActionButton(action));
+    if (await isAggregatedAssetsEnabled()) {
+      const q2TestIds: Partial<Record<typeof action, string>> = {
+        buy: "asset-detail-buy-button",
+        swap: "asset-detail-swap-button",
+        receive: "asset-detail-footer-receive-button",
+      };
+      const testId = q2TestIds[action] ?? `asset-quick-action-button-${action}`;
+      await waitForElementById(testId);
+      await tapById(testId);
+    } else {
+      await tapByElement(this.marketQuickActionButton(action));
+    }
   }
 
   @Step("Expect filters visible")

--- a/e2e/mobile/page/market/market.page.ts
+++ b/e2e/mobile/page/market/market.page.ts
@@ -13,7 +13,8 @@ export default class MarketPage {
   marketFilterSortButton = () => getElementById("market-filter-sort");
   marketFilterTimeButton = () => getElementById("market-filter-time");
   marketFilterCurrencyButton = () => getElementById("market-filter-currency");
-  searchBar = () => getElementById("search-box");
+  searchBarId = async () =>
+    (await isAssetDiscoverabilityEnabled()) ? "market-screen-search-bar" : "search-box";
   starButton = () => getElementById("star-asset");
   backButtonId = "market-back-btn";
   assetDetailBackBtn = () => getElementById(this.backButtonId);
@@ -72,7 +73,7 @@ export default class MarketPage {
 
   @Step("Search for asset")
   async searchAsset(asset: string) {
-    await typeTextByElement(this.searchBar(), asset);
+    await typeTextByElement(getElementById(await this.searchBarId()), asset);
   }
 
   @Step("Open asset page")
@@ -97,7 +98,9 @@ export default class MarketPage {
   @Step("Back to asset list")
   async backToAssetList() {
     if (await isAggregatedAssetsEnabled()) {
-      await this.goBack();
+      await waitForElementById(this.headerBackButtonId);
+      await tapById(this.headerBackButtonId);
+      await waitForElementById(await this.searchBarId());
     } else {
       await tapByElement(this.assetDetailBackBtn());
     }
@@ -106,6 +109,9 @@ export default class MarketPage {
   @Step("Filter starred asset")
   async filterStaredAsset() {
     if (await isAssetDiscoverabilityEnabled()) {
+      // CategorySwitcher is hidden while search is active — clear search bar first
+      await clearTextByElement(getElementById(await this.searchBarId()));
+      await waitForElementById(this.marketCategoryTabId("starred"));
       await tapById(this.marketCategoryTabId("starred"));
     } else {
       await tapByElement(this.starMarketListButton());

--- a/e2e/mobile/page/market/market.page.ts
+++ b/e2e/mobile/page/market/market.page.ts
@@ -49,8 +49,10 @@ export default class MarketPage {
   @Step("Expect market detail page")
   async expectMarketDetailPage(currencyId?: string) {
     if (await isAggregatedAssetsEnabled()) {
-      const currency = currencyId?.toLowerCase() || "bitcoin";
-      await waitForElementById(`asset-detail-scroll-view-${currency}`);
+      const scrollViewId = currencyId
+        ? `asset-detail-scroll-view-${currencyId.toLowerCase()}`
+        : /^asset-detail-scroll-view-.*/;
+      await waitForElementById(scrollViewId);
     } else {
       await detoxExpect(this.starButton()).toBeVisible();
     }

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -2,7 +2,7 @@ import { Step } from "jest-allure2-reporter/api";
 import { openDeeplink } from "../../helpers/commonHelpers";
 import { DEFAULT_TIMEOUT } from "../../helpers/elementHelpers";
 import { getFlags } from "../../bridge/server";
-import { isAssetSectionEnabled } from "../../utils/featureFlagUtils";
+import { isAggregatedAssetsEnabled, isAssetSectionEnabled } from "../../utils/featureFlagUtils";
 import type { Features } from "@shared/feature-flags";
 export default class PortfolioPage {
   addNewOrExistingAccount = "add-new-account-button";
@@ -121,7 +121,11 @@ export default class PortfolioPage {
 
   @Step("Expect balance diff to be visible")
   async expectBalanceDiffToBeVisible() {
-    await waitForElementById(this.portfolioBalanceDelta);
+    if (await isAggregatedAssetsEnabled()) {
+      return;
+    } else {
+      await waitForElementById(this.portfolioBalanceDelta);
+    }
   }
 
   @Step("Expect operation row to be visible")

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -296,7 +296,11 @@ export default class PortfolioPage {
 
   @Step("Expect market banner to be visible")
   async expectMarketBannerVisible() {
-    await scrollToId(this.marketBannerTitle, this.accountsListView, undefined, "down");
+    if (await isAggregatedAssetsEnabled()) {
+      await scrollToId(this.marketBannerTitle, undefined, undefined, "down");
+    } else {
+      await scrollToId(this.marketBannerTitle, this.accountsListView, undefined, "down");
+    }
     await detoxExpect(getElementById(this.marketBannerList)).toBeVisible();
   }
 

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -103,7 +103,11 @@ export default class PortfolioPage {
 
   @Step("Expect asset row to have the correct counter value")
   async expectAssetRowCounterValue(asset: string, counterValue: string) {
-    await scrollToId(this.assetItemBalanceId(asset), this.accountsListView);
+    if (await isAggregatedAssetsEnabled()) {
+      await scrollToId(this.assetItemBalanceId(asset));
+    } else {
+      await scrollToId(this.assetItemBalanceId(asset), this.accountsListView);
+    }
     const text = await getTextOfElement(this.assetItemBalanceId(asset));
     jestExpect(text).toContain(counterValue);
   }
@@ -130,7 +134,11 @@ export default class PortfolioPage {
 
   @Step("Expect operation row to be visible")
   async expectOperationRowToBeVisible() {
-    await scrollToId(this.operationRowCounterValue, this.accountsListView);
+    if (await isAggregatedAssetsEnabled()) {
+      await scrollToId(this.operationRowCounterValue);
+    } else {
+      await scrollToId(this.operationRowCounterValue, this.accountsListView);
+    }
     await detoxExpect(getElementById(this.operationRowCounterValue)).toBeVisible();
   }
 

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -234,7 +234,11 @@ export default class PortfolioPage {
         await tapById(this.showAllAssetsButton);
       }
     }
-    await scrollToId(this.assetItemId(currencyName), this.accountsListView);
+    if (await isAggregatedAssetsEnabled()) {
+      await scrollToId(this.assetItemId(currencyName));
+    } else {
+      await scrollToId(this.assetItemId(currencyName), this.accountsListView);
+    }
     await tapById(this.assetItemId(currencyName));
   }
 

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -2,6 +2,7 @@ import { Step } from "jest-allure2-reporter/api";
 import { openDeeplink } from "../../helpers/commonHelpers";
 import { DEFAULT_TIMEOUT } from "../../helpers/elementHelpers";
 import { getFlags } from "../../bridge/server";
+import { isAssetSectionEnabled } from "../../utils/featureFlagUtils";
 import type { Features } from "@shared/feature-flags";
 export default class PortfolioPage {
   addNewOrExistingAccount = "add-new-account-button";
@@ -174,23 +175,33 @@ export default class PortfolioPage {
 
   @Step("Check asset allocation section")
   async checkAssetAllocationSection() {
-    await scrollToId(this.showAllAssetsButton);
-    const assetsCount = await countElementsById(this.assetItemRegExp);
-    jestExpect(assetsCount).toBeLessThanOrEqual(5);
-    await detoxExpect(getElementById(this.showAllAssetsButton)).toBeVisible();
-    await tapById(this.showAllAssetsButton);
-    jestExpect(await countElementsById(this.assetItemRegExp)).toBeGreaterThan(5);
+    if (await isAssetSectionEnabled()) {
+      await scrollToId(this.cryptosSectionHeaderId);
+      await detoxExpect(getElementById(this.cryptosSectionHeaderId)).toBeVisible();
+    } else {
+      await scrollToId(this.showAllAssetsButton);
+      const assetsCount = await countElementsById(this.assetItemRegExp);
+      jestExpect(assetsCount).toBeLessThanOrEqual(5);
+      await detoxExpect(getElementById(this.showAllAssetsButton)).toBeVisible();
+      await tapById(this.showAllAssetsButton);
+      jestExpect(await countElementsById(this.assetItemRegExp)).toBeGreaterThan(5);
+    }
   }
 
   @Step("Check accounts section")
   async checkAccountsSection() {
-    await this.tapTabSelector("Accounts");
-    await scrollToId(this.showAllAccountsButton, this.accountsListView, 400);
-    jestExpect(await countElementsById(app.common.accountItemNameRegExp)).toBeLessThanOrEqual(5);
-    await this.tapShowAllAccountsButton();
-    jestExpect(await countElementsById(app.common.accountItemNameRegExp)).toBeGreaterThan(5);
-    await this.tapAddNewOrExistingAccountButton();
-    await app.addAccount.importWithYourLedger();
+    if (await isAssetSectionEnabled()) {
+      await this.tapAddNewOrExistingAccountButton();
+      await app.addAccount.importWithYourLedger();
+    } else {
+      await this.tapTabSelector("Accounts");
+      await scrollToId(this.showAllAccountsButton, this.accountsListView, 400);
+      jestExpect(await countElementsById(app.common.accountItemNameRegExp)).toBeLessThanOrEqual(5);
+      await this.tapShowAllAccountsButton();
+      jestExpect(await countElementsById(app.common.accountItemNameRegExp)).toBeGreaterThan(5);
+      await this.tapAddNewOrExistingAccountButton();
+      await app.addAccount.importWithYourLedger();
+    }
   }
 
   @Step("Count Accounts")
@@ -205,11 +216,13 @@ export default class PortfolioPage {
 
   @Step("Navigate asset Page")
   async goToSpecificAsset(currencyName: string) {
-    await scrollToId(this.assetsListId);
-    if (await IsIdVisible(this.showAllAssetsButton)) {
-      await tapById(this.showAllAssetsButton);
-      await scrollToId(this.assetItemId(currencyName), this.accountsListView);
+    if (!(await isAssetSectionEnabled())) {
+      await scrollToId(this.assetsListId);
+      if (await IsIdVisible(this.showAllAssetsButton)) {
+        await tapById(this.showAllAssetsButton);
+      }
     }
+    await scrollToId(this.assetItemId(currencyName), this.accountsListView);
     await tapById(this.assetItemId(currencyName));
   }
 
@@ -231,6 +244,9 @@ export default class PortfolioPage {
 
   @Step("Tap on tab selector")
   async tapTabSelector(id: "Accounts" | "Assets") {
+    if (await isAssetSectionEnabled()) {
+      return;
+    }
     await tapByElement(this.tabSelector(id));
   }
 

--- a/e2e/mobile/specs/addAccount/addAccount.ts
+++ b/e2e/mobile/specs/addAccount/addAccount.ts
@@ -34,9 +34,9 @@ export function runAddAccountTest(currency: CurrencyType, tmsLinks: string[], ta
 
       await app.portfolio.goToAccounts(currency.name);
 
-      await app.assetAccountsPage.waitForAccountPageToLoad(currency.name);
+      await app.assetAccountsPage.waitForAccountPageToLoad(currency.name, currency.id);
       await app.assetAccountsPage.expectAccountsBalanceVisible();
-      await app.common.goToAccount(accountId);
+      await app.common.goToAccount(accountId, currency.id);
       await app.account.expectAccountBalanceVisible(accountId);
       await app.account.expectOperationHistoryVisible(accountId);
       await app.account.expectAddressIndex(0);

--- a/e2e/mobile/specs/buySell/buySell.ts
+++ b/e2e/mobile/specs/buySell/buySell.ts
@@ -124,7 +124,10 @@ export async function runNavigateToBuyFromAssetPageTest(
     tags.forEach(tag => $Tag(tag));
     test(`Navigate to Buy / Sell [${buySell.crypto.currency.name}] asset from asset page`, async () => {
       await app.portfolio.goToSpecificAsset(buySell.crypto.currency.name);
-      await app.assetAccountsPage.waitForAccountPageToLoad(buySell.crypto.currency.name);
+      await app.assetAccountsPage.waitForAccountPageToLoad(
+        buySell.crypto.currency.name,
+        buySell.crypto.currency.id,
+      );
       await app.assetAccountsPage.tapOnAssetQuickActionButton("buy");
       await app.buySell.handleBuyFlow(buySell, paymentMethod);
     });

--- a/e2e/mobile/specs/portfolio/portfolioTabs.spec.ts
+++ b/e2e/mobile/specs/portfolio/portfolioTabs.spec.ts
@@ -3,9 +3,8 @@ import { setTeamOwner } from "../../helpers/allure/allure-helper";
 import { getMergedFeatureFlags } from "../../utils/featureFlagUtils";
 import type { Features } from "@shared/feature-flags";
 const tags = ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"];
-const isQ2 =
-  (getMergedFeatureFlags().lwmWallet40 as Features["lwmWallet40"] | undefined)?.params
-    ?.aggregatedAssets === true;
+const lwmWallet40 = getMergedFeatureFlags().lwmWallet40 as Features["lwmWallet40"] | undefined;
+const isQ2 = lwmWallet40?.enabled === true && lwmWallet40?.params?.aggregatedAssets === true;
 
 setTeamOwner(Team.WALLET_XP);
 // In Q2 the tab layout (Assets/Accounts tabs) no longer exists — skip the whole suite

--- a/e2e/mobile/specs/portfolio/portfolioTabs.spec.ts
+++ b/e2e/mobile/specs/portfolio/portfolioTabs.spec.ts
@@ -1,7 +1,8 @@
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { setTeamOwner } from "../../helpers/allure/allure-helper";
+import { getMergedFeatureFlags } from "../../utils/featureFlagUtils";
 const tags = ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"];
-const isQ2 = process.env.E2E_MOBILE_FEATURE_FLAGS === "wallet40-q2";
+const isQ2 = getMergedFeatureFlags().lwmWallet40?.params?.aggregatedAssets === true;
 
 setTeamOwner(Team.WALLET_XP);
 // In Q2 the tab layout (Assets/Accounts tabs) no longer exists — skip the whole suite

--- a/e2e/mobile/specs/portfolio/portfolioTabs.spec.ts
+++ b/e2e/mobile/specs/portfolio/portfolioTabs.spec.ts
@@ -1,8 +1,11 @@
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { setTeamOwner } from "../../helpers/allure/allure-helper";
 import { getMergedFeatureFlags } from "../../utils/featureFlagUtils";
+import type { Features } from "@shared/feature-flags";
 const tags = ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"];
-const isQ2 = getMergedFeatureFlags().lwmWallet40?.params?.aggregatedAssets === true;
+const isQ2 =
+  (getMergedFeatureFlags().lwmWallet40 as Features["lwmWallet40"] | undefined)?.params
+    ?.aggregatedAssets === true;
 
 setTeamOwner(Team.WALLET_XP);
 // In Q2 the tab layout (Assets/Accounts tabs) no longer exists — skip the whole suite

--- a/e2e/mobile/specs/portfolio/portfolioTabs.spec.ts
+++ b/e2e/mobile/specs/portfolio/portfolioTabs.spec.ts
@@ -1,10 +1,11 @@
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { setTeamOwner } from "../../helpers/allure/allure-helper";
-
 const tags = ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"];
+const isQ2 = process.env.E2E_MOBILE_FEATURE_FLAGS === "wallet40-q2";
 
 setTeamOwner(Team.WALLET_XP);
-describe("Wallet Page", () => {
+// In Q2 the tab layout (Assets/Accounts tabs) no longer exists — skip the whole suite
+(isQ2 ? describe.skip : describe)("Wallet Page", () => {
   beforeAll(async () => {
     await app.init({
       userdata: "speculos-tests-app",

--- a/e2e/mobile/specs/subAccount/subAccount.ts
+++ b/e2e/mobile/specs/subAccount/subAccount.ts
@@ -167,7 +167,10 @@ export function runAddSubAccountTest(testConfig: {
         asset.index,
       );
 
-      await app.common.goToAccount(accountId, asset.parentAccount?.currency.id);
+      await app.common.goToAccount(
+        accountId,
+        asset.parentAccount?.currency.id ?? asset.currency.id,
+      );
       await app.account.expectAccountBalanceVisible(accountId);
       await app.account.expectOperationHistoryVisible(accountId);
       await app.account.expectAddressIndex(0);

--- a/e2e/mobile/specs/subAccount/subAccount.ts
+++ b/e2e/mobile/specs/subAccount/subAccount.ts
@@ -167,7 +167,7 @@ export function runAddSubAccountTest(testConfig: {
         asset.index,
       );
 
-      await app.common.goToAccount(accountId);
+      await app.common.goToAccount(accountId, asset.parentAccount?.currency.id);
       await app.account.expectAccountBalanceVisible(accountId);
       await app.account.expectOperationHistoryVisible(accountId);
       await app.account.expectAddressIndex(0);

--- a/e2e/mobile/utils/featureFlagUtils.ts
+++ b/e2e/mobile/utils/featureFlagUtils.ts
@@ -110,6 +110,21 @@ export const isAssetDiscoverabilityEnabled = async (): Promise<boolean> => {
 
 // Distinct from `assetDiscoverability`: gates the new MVVM AssetDetail (with
 // coin-options) vs the legacy MarketDetail screen (see useAssetDetailNavigation).
+export const isAssetSectionEnabled = async (): Promise<boolean> => {
+  const lwmFlag = await getLwmFlag();
+  return Boolean(lwmFlag?.enabled && lwmFlag?.params?.assetSection);
+};
+
+export const isMyWalletEnabled = async (): Promise<boolean> => {
+  const lwmFlag = await getLwmFlag();
+  return Boolean(lwmFlag?.enabled && lwmFlag?.params?.myWallet);
+};
+
+export const isOperationsListEnabled = async (): Promise<boolean> => {
+  const lwmFlag = await getLwmFlag();
+  return Boolean(lwmFlag?.enabled && lwmFlag?.params?.operationsList);
+};
+
 export const isAggregatedAssetsEnabled = async (): Promise<boolean> => {
   const lwmFlag = await getLwmFlag();
   return Boolean(lwmFlag?.enabled && lwmFlag?.params?.aggregatedAssets);


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

E2E mobile tests fail when running with `E2E_MOBILE_FEATURE_FLAGS=wallet40-q2` because Q2 introduces major UI changes (AssetDetail MVVM screen, no Assets/Accounts tabs, new Market search bar, etc.) that break existing page object selectors.

**Strategy**: branch inside **page object methods** on runtime FF helpers (`isAggregatedAssetsEnabled`, `isAssetSectionEnabled`, `isAssetDiscoverabilityEnabled`) — specs themselves are untouched except where callers needed to forward a `currencyId`.

Key Q2 UI differences handled:
- `asset/bitcoin` and `market/bitcoin` both land on the new `AssetDetail` MVVM screen instead of the legacy `WalletCentricAsset`
- No `tab-selector-Accounts` / `tab-selector-Assets` tabs on Portfolio
- Market search bar ID changed from `search-box` → `market-screen-search-bar`
- `CategorySwitcher` hidden while search is active (must clear search before tapping starred filter)
- Account items in AssetDetail use `asset-detail-address-item-<internalId>` instead of `account-item-<testId>` in `asset-screen-flatlist`
- `asset-graph-balance` does not exist on AssetDetail (screen confirmed via scroll view testID instead)

**NSPredicate regex note**: Detox on iOS uses `SELF MATCHES` (full-string match), so all regex testID matchers need a trailing `.*` to match IDs with a suffix (e.g. `^asset-detail-address-item-.*`).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-33894]

---

### ✅ Fixes checklist

#### Commit 1 — `test(e2e-mobile): fix deeplinks Q2 failures for asset/market detail pages`
- [x] `deeplinks.spec.ts` — should open Asset page for Bitcoin
- [x] `deeplinks.spec.ts` — should open Asset page for Ethereum
- [x] `deeplinks.spec.ts` — should open Market Detail page for Bitcoin

#### Commit 2 — `test(e2e-mobile): fix wallet40-q2 failures across market, portfolio, and addAccount specs`
- [x] `market.spec.ts` — should filter starred asset
- [x] `market.spec.ts` — should navigate back from Market Detail (backToAssetList double-tap fix)
- [x] `portfolioTabs.spec.ts` — all cases (suite skipped in Q2; tab layout no longer exists)
- [x] `addAccountBTC.spec.ts` — Perform a Network Based add account - Bitcoin

#### Commit 3 — `fix(e2e): adapt counterValue, addSubAccount, and goToAccount flows for wallet40-q2`
- [x] `portfolio.page.ts` — `expectBalanceDiffToBeVisible` no-op in Q2 (element exists but not visible)
- [x] `common.page.ts` — `goToAccount` Q2 branch deeplinks to `asset/{currencyId}` before scrolling for address items; uses exact `asset-detail-address-item-${accountId}` (not regex) to avoid tapping the wrong account
- [x] `subAccount.ts` — forward `asset.parentAccount?.currency.id` to `goToAccount`

#### Commit 4 — `fix(e2e): fix portfolio scroll container visibility for wallet40-q2 counter value test`
- [x] `portfolio.page.ts` — `expectAssetRowCounterValue` and `expectOperationRowToBeVisible` omit container hint in Q2 (collapsible header overlaps `PortfolioAccountsList`, failing Detox 100% visibility check)

#### Commit 5 — `fix(e2e): address Copilot review comments on Q2 e2e fixes`
- [x] `portfolioTabs.spec.ts` — replaced raw env string with `getMergedFeatureFlags().lwmWallet40?.params?.aggregatedAssets` for robust Q2 detection
- [x] `market.page.ts` — `expectMarketDetailPage` uses generic regex `/^asset-detail-scroll-view-.*/` when no `currencyId` provided

#### Commit 6 — `fix(e2e): fix market banner Q2 failures`
- [x] `marketBanner.spec.ts` — `expectMarketBannerVisible` omits `PortfolioAccountsList` container in Q2 (same collapsible header overlap issue as counterValue)
- [x] `marketBanner.spec.ts` — `leaveMarketDetailPage` uses `navigation-header-back-button` in Q2 instead of legacy `market-back-btn`

#### Commit 7 — `fix(e2e): fix portfolioTabs typecheck`
- [x] `portfolioTabs.spec.ts` — cast `lwmWallet40` to `Features["lwmWallet40"]` to fix TS2339 (`aggregatedAssets` not found on `{}` — `OptionalFeatureMap` types each value as the full feature union, collapsing `.params`)

#### Commit 8 — `fix(e2e): address remaining Copilot review comments`
- [x] `portfolio.page.ts` — `goToSpecificAsset` omits `PortfolioAccountsList` container in Q2 (same collapsible header overlap pattern)
- [x] `subAccount.ts` — fallback to `asset.currency.id` when `parentAccount` is undefined so native coin accounts still deeplink to AssetDetail in Q2
- [x] `portfolioTabs.spec.ts` — `isQ2` now checks `enabled === true` alongside `aggregatedAssets` to avoid false positives from partial flag overrides

---

### ⚠️ Still failing — to revisit

- [ ] `userCanSelectCounterValue.spec.ts` — counter value scroll/visibility issue in Q2; fix applied (omit container hint) but not yet re-validated in CI
- [ ] `navigateToBuyFromAssetPage_ETH.spec.ts` — `tapOnAssetQuickActionButton("buy")` uses legacy `asset-quick-action-button-buy`; Q2 uses `asset-detail-buy-button`
- [ ] `navigateToBuyFromMarketPage_USDT.spec.ts` — same Q2 buy button issue; additionally `marketScreenRow` uses `currency.id` which doesn't match the market API id for ERC20 tokens (e.g. `ethereum/erc20/usd_tether__erc20_` vs `tether`)
- [ ] `portfolioTransactionsHistory_BTC.spec.ts` / `_ETH.spec.ts` — `checkTransactionHistorySection` / `selectAndClickOnLastOperation` not yet validated under Q2
- [ ] `subAccount` (`addSubAccountWithoutParent`, `subAccountGIGA`) — `goToAccount` deeplink fix applied but not yet validated end-to-end; `navigateToSubAccount` (`account-row-*`) likely needs a Q2 navigation path
- [ ] `wallet40Q2/mainNavigation.spec.ts` — 5 tests (Swap, Earn, Card, Home tabs, layout); likely pre-existing failures unrelated to this PR
- [ ] `receiveFlow.spec.ts` — `receive-qr-code-container-*` scroll issue pre-dates Q2 (fails without Q2 flag too); pre-existing

[LIVE-33894]: https://ledgerhq.atlassian.net/browse/LIVE-33894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ