### PR TITLE
refactor(coin-evm): pass `to` into staking selector cache for factory-per-validator chains

### DIFF
--- a/.changeset/silent-wolves-run.md
+++ b/.changeset/silent-wolves-run.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+Pass `to` into staking selector cache to support factory-per-validator chains

--- a/libs/coin-modules/coin-evm/src/staking/detectOperationType.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/detectOperationType.test.ts
@@ -97,4 +97,22 @@ describe("detectEvmStakingOperationType", () => {
     const methodId = "0x9ddb511a"; // selector for delegate(address,uint256)
     expect(detectEvmStakingOperationType("unknown", contractAddress, methodId)).toBeUndefined();
   });
+
+  it("returns DELEGATE for 0G regardless of which validator contract address is the `to`", () => {
+    const selector = ethers.id("delegate(address)").slice(0, 10).toLowerCase();
+    expect(
+      detectEvmStakingOperationType(
+        "zero_gravity",
+        "0x0000000000000000000000000000000000000001",
+        selector,
+      ),
+    ).toBe("DELEGATE");
+    expect(
+      detectEvmStakingOperationType(
+        "zero_gravity",
+        "0x0000000000000000000000000000000000000002",
+        selector,
+      ),
+    ).toBe("DELEGATE");
+  });
 });

--- a/libs/coin-modules/coin-evm/src/staking/detectOperationType.ts
+++ b/libs/coin-modules/coin-evm/src/staking/detectOperationType.ts
@@ -30,13 +30,29 @@ export function isStakingOperation(value: string): value is StakingOperation {
   return stakingOperations.includes(value as StakingOperation);
 }
 
+type SelectorEntry = {
+  resolveAddress: (to: string) => string;
+  opType: OperationType;
+};
+
 /**
- * Builds a map of `(to, 4-byte selector)` pairs to OperationType for a staking currency.
- * The `to` address is resolved per-operation via `config.contractAddress` (e.g. SEI routes
- * claimReward to its distribution precompile). Cached per `currencyId` since inputs are static.
+ * Builds and caches, per currency, a selector → entry map derived from the staking ABI.
+ * The cache is bounded — one entry per staking-enabled currency — regardless of how many
+ * distinct `to` addresses appear in the tx history. A per-(currencyId, to) cache would
+ * grow unboundedly for factory-per-validator chains like 0G, since
+ * detectEvmStakingOperationType is called for every outgoing tx.
+ *
+ * At lookup time `resolveAddress` is called with the tx `to` to verify the tx targets the
+ * expected contract for that operation. For static-precompile chains this resolves to a
+ * constant; for factory-per-validator chains (e.g. 0G) the validator contract IS the tx
+ * recipient, so `resolveAddress(to) === to` always holds when the selector matches.
+ *
+ * Address verification after the selector lookup guards against false positives: a tx with
+ * a matching selector sent to the wrong contract (e.g. SEI claimReward selector hitting the
+ * staking precompile instead of the distribution precompile) is not a staking operation.
  */
-const selectorsCache = new Map<string, Map<string, OperationType>>();
-const getStakingMethodSelectors = (currencyId: string): Map<string, OperationType> | undefined => {
+const selectorsCache = new Map<string, Map<string, SelectorEntry>>();
+const getStakingEntries = (currencyId: string): Map<string, SelectorEntry> | undefined => {
   const cached = selectorsCache.get(currencyId);
   if (cached) return cached;
 
@@ -44,10 +60,8 @@ const getStakingMethodSelectors = (currencyId: string): Map<string, OperationTyp
   const abi = getStakingABI(currencyId);
   if (!config || !abi) return undefined;
 
-  const selectors = new Map<string, OperationType>();
-  selectorsCache.set(currencyId, selectors);
-  const key = (to: string, selector: string): string =>
-    `${to.toLowerCase()}|${selector.toLowerCase()}`;
+  const entries = new Map<string, SelectorEntry>();
+  selectorsCache.set(currencyId, entries);
 
   for (const [op, fn] of Object.entries(config.functions)) {
     const operation = op as StakingOperation;
@@ -55,25 +69,23 @@ const getStakingMethodSelectors = (currencyId: string): Map<string, OperationTyp
     if (!mapped || !fn) continue;
 
     try {
-      // Find the appropriate function in the ABI by the name
       const abiFunction = abi.find(item => item.type === "function" && item.name === fn);
       if (!abiFunction) continue;
 
-      // Build the complete function signature from ABI
       const inputs = abiFunction.inputs || [];
       const paramTypes = inputs.map(input => input.type).join(",");
       const signature = `${fn}(${paramTypes})`;
-      // calculate selector (first 4 bytes of the keccak256 hash)
-      const selector = ethers.id(signature).slice(0, 10);
-      const opContractAddress = config.contractAddress({ mode: operation });
-      selectors.set(key(opContractAddress, selector), mapped);
+      const selector = ethers.id(signature).slice(0, 10).toLowerCase();
+      entries.set(selector, {
+        resolveAddress: to => config.contractAddress({ mode: operation, valAddress: to }),
+        opType: mapped,
+      });
     } catch {
-      // ignore if function not in ABI or malformed
       continue;
     }
   }
 
-  return selectors;
+  return entries;
 };
 
 export const detectEvmStakingOperationType = (
@@ -83,8 +95,15 @@ export const detectEvmStakingOperationType = (
 ): OperationType | undefined => {
   if (!to || !methodId) return undefined;
 
-  const selectors = getStakingMethodSelectors(currencyId);
-  if (!selectors) return undefined;
+  const entries = getStakingEntries(currencyId);
+  if (!entries) return undefined;
 
-  return selectors.get(`${to.toLowerCase()}|${methodId.toLowerCase()}`);
+  const entry = entries.get(methodId.toLowerCase());
+  if (!entry) return undefined;
+
+  try {
+    return entry.resolveAddress(to).toLowerCase() === to.toLowerCase() ? entry.opType : undefined;
+  } catch {
+    return undefined;
+  }
 };


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Fixes 0G staking operation detection and replaces the per-(currencyId, to) selector cache with a per-currencyId `Map<selector, SelectorEntry>`.

**Why the old approach was broken for 0G**: `contractAddress()` throws when `valAddress` is missing, but `to` was never forwarded into the selector build. Every 0G validator has its own contract, so without `to` the resolver had nothing to work with.

**Why the old cache was also problematic**: `detectEvmStakingOperationType` is called for every outgoing tx in both the Etherscan and Ledger Explorer adapters. A per-(currencyId, to) outer cache grows with every unique recipient on a staking-enabled currency — unbounded for factory-per-validator chains like 0G.

**New design**:
- Builds the ABI-derived selector map **once per currency** (bounded cache)
- At lookup, `resolveAddress(to)` verifies the tx recipient matches the expected contract for that operation — O(1) via `Map` keyed by 4-byte selector
- For static-precompile chains (SEI, Monad, Celo) `resolveAddress` returns a constant; for 0G, `resolveAddress(to) === to` so any validator contract matches when the selector is right

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32754](https://ledgerhq.atlassian.net/browse/LIVE-32754)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->

[LIVE-32754]: https://ledgerhq.atlassian.net/browse/LIVE-32754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
