### PR TITLE
test(e2e-mobile): force enable flag until default is true

### DIFF
--- a/e2e/mobile/specs/earn/earnV2.ts
+++ b/e2e/mobile/specs/earn/earnV2.ts
@@ -11,6 +11,8 @@ setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
 const EARN_V2_FLAGS: PartialFeatures = {
   ptxEarnUi: { enabled: true, params: { value: "v2" } },
+  // TODO: remove once deposit flow v2 is fully rolled out and set to 'true' by default
+  swapToEarn: { enabled: true },
 };
 
 // Pins the ETH deposit webview to the `basic_sorting` cohort (mirrors the desktop


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Earn deposit flow v2 is now only shown if the swapToEarn feature flag is set to `true`.
Set this flag explicitly so that the expected button is rendered during the deposit flow.

Earn [regression](https://github.com/LedgerHQ/ledger-live/actions/runs/28959519742): all Earn V2 specs passing

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/QAA-1393
