### PR TITLE
[LWDM] fix(algorand): not opt in asa error message

### DIFF
--- a/.changeset/angry-cooks-tell.md
+++ b/.changeset/angry-cooks-tell.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+fix(algorand): not opt in asa error message

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
@@ -7,6 +7,7 @@ import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/featu
 import { useBridgeRecipientValidation } from "@ledgerhq/live-common/flows/send/recipient/hooks/useBridgeRecipientValidation";
 import { renderHook, waitFor } from "@testing-library/react";
 import type { Operation } from "@ledgerhq/types-live";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { useSelector } from "LLD/hooks/redux";
 import { useMaybeAccountName } from "~/renderer/reducers/wallet";
 import {
@@ -474,6 +475,25 @@ describe("useAddressValidation", () => {
     expect(mockedUseBridgeRecipientValidation).toHaveBeenCalledWith(
       expect.objectContaining({
         recipient: "0xResolved",
+      }),
+    );
+  });
+
+  it("passes the current transaction to bridge validation", () => {
+    const transaction = { family: "bitcoin", recipient: "" } as Transaction;
+
+    renderHook(() =>
+      useAddressValidation({
+        searchValue: "valid_address",
+        currency: mockAccount.currency,
+        account: mockAccount,
+        transaction,
+      }),
+    );
+
+    expect(mockedUseBridgeRecipientValidation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transaction,
       }),
     );
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientAddressModalViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientAddressModalViewModel.test.ts
@@ -8,7 +8,8 @@ import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { InvalidAddress, InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
 import { createMockAccount } from "../../__integrations__/__fixtures__/accounts";
-import { SendFlowState } from "@ledgerhq/live-common/flows/send/types";
+import type { SendFlowState } from "@ledgerhq/live-common/flows/send/types";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
 
 jest.mock("../useAddressValidation");
 jest.mock("../../../../context/SendFlowContext");
@@ -126,6 +127,35 @@ describe("useRecipientAddressModalViewModel", () => {
     result.current.handleAddressSelect("new_address", "ens_name");
 
     expect(onAddressSelected).toHaveBeenCalledWith("new_address", "ens_name", true);
+  });
+
+  it("passes the current transaction to address validation", () => {
+    const transaction = { family: "bitcoin", recipient: "" } as Transaction;
+    mockedUseSendFlowData.mockReturnValue({
+      recipientSearch: { ...mockRecipientSearch, value: "some_address" },
+      state: {
+        ...DEFAULT_STATE,
+        transaction: {
+          ...DEFAULT_STATE.transaction,
+          transaction,
+        },
+      },
+      uiConfig: {} as never,
+      isRecipientAddressComplete: false,
+    });
+
+    renderHook(() =>
+      useRecipientAddressModalViewModel({
+        account: mockAccount,
+        currency: mockAccount.currency,
+        onAddressSelected: jest.fn(),
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    expect(mockedUseAddressValidation).toHaveBeenCalledWith(
+      expect.objectContaining({ transaction }),
+    );
   });
 
   it("shows sanctioned banner when address is sanctioned", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -14,6 +14,7 @@ import type {
   MatchedAccount,
   RecentAddress,
 } from "@ledgerhq/live-common/flows/send/recipient/types";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import { useSelector } from "LLD/hooks/redux";
@@ -68,6 +69,7 @@ type UseAddressValidationProps = Readonly<{
   currency: CryptoCurrency | TokenCurrency;
   account?: AccountLike;
   parentAccount?: Account;
+  transaction?: Transaction | null;
   currentAccountId?: string;
   recipientSupportsDomain?: boolean;
 }>;
@@ -83,6 +85,7 @@ export function useAddressValidation({
   currency,
   account,
   parentAccount,
+  transaction,
   currentAccountId,
   recipientSupportsDomain = false,
 }: UseAddressValidationProps): UseAddressValidationResult {
@@ -127,6 +130,7 @@ export function useAddressValidation({
     recipient: addressForBridgeValidation,
     account: account ?? null,
     parentAccount: parentAccount ?? null,
+    transaction,
     enabled: Boolean(
       addressForBridgeValidation &&
       account &&

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientAddressModalViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientAddressModalViewModel.ts
@@ -37,6 +37,7 @@ export function useRecipientAddressModalViewModel({
     currency,
     account,
     parentAccount,
+    transaction: state.transaction.transaction,
     currentAccountId: mainAccount.id,
     recipientSupportsDomain,
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
@@ -75,7 +75,7 @@ jest.mock("expo-keep-awake", () => ({
 
 async function flushTimers(): Promise<void> {
   await act(async () => {
-    jest.advanceTimersByTime(600);
+    await jest.advanceTimersByTimeAsync(600);
   });
 }
 
@@ -120,12 +120,12 @@ describe("Send flow integration tests", () => {
   ): Promise<void> {
     // EVM enables ENS resolution so the placeholder is "Enter address or ENS";
     // every other family uses "Enter address".
-    await user.type(
-      await screen.findByPlaceholderText(/^Enter address( or ENS)?$/),
-      opts.recipient,
-    );
+    const recipientInput = await screen.findByPlaceholderText(/^Enter address( or ENS)?$/);
+    await user.paste(recipientInput, opts.recipient);
+    await flushTimers();
     if (opts.memo !== undefined) {
-      await user.type(await screen.findByTestId("send-memo-input"), opts.memo);
+      const memoInput = await screen.findByTestId("send-memo-input");
+      await user.paste(memoInput, opts.memo);
     }
     await user.press(await screen.findByText(/^Send to /));
     await screen.findByText("Review");

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
@@ -1,6 +1,7 @@
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { SendFlowLayout } from "LLM/features/Send/components/SendFlowLayout";
 import { MemoControls } from "LLM/features/Send/components/Memo/MemoControls";
 import { useMemoViewModel } from "LLM/features/Send/components/Memo/hooks/useMemoViewModel";
@@ -19,6 +20,7 @@ import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework
 type RecipientScreenViewProps = Readonly<{
   account: AccountLike;
   parentAccount?: Account | null;
+  transaction?: Transaction | null;
   currency: CryptoOrTokenCurrency;
   onAddressSelected: (address: string, ensName?: string) => void;
   recipientSupportsDomain: boolean;
@@ -28,6 +30,7 @@ type RecipientScreenViewProps = Readonly<{
 export const RecipientScreenView = ({
   account,
   parentAccount,
+  transaction,
   currency,
   onAddressSelected,
   recipientSupportsDomain,
@@ -55,6 +58,7 @@ export const RecipientScreenView = ({
   } = useRecipientScreenView({
     account,
     parentAccount,
+    transaction,
     currency,
     onAddressSelected,
     recipientSupportsDomain,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
@@ -368,7 +368,7 @@ describe("useAddressValidation", () => {
     );
   });
 
-  it("shows loading during bridge validation", () => {
+  it("does not surface bridge validation loading as recipient input loading", () => {
     mockedUseBridgeRecipientValidation.mockReturnValue({
       errors: {},
       warnings: {},
@@ -385,7 +385,7 @@ describe("useAddressValidation", () => {
       }),
     );
 
-    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isLoading).toBe(false);
   });
 
   it("resets state when search value is cleared", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
@@ -13,6 +13,7 @@ import { useBridgeRecipientValidation } from "@ledgerhq/live-common/flows/send/r
 import { useFormattedAccountBalance } from "LLM/hooks/useFormattedAccountBalance";
 import { useMaybeAccountName, useBatchMaybeAccountName } from "~/reducers/wallet";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { createMockAccount, createMockCurrency } from "./accounts";
 
 jest.mock("~/context/hooks");
@@ -484,6 +485,25 @@ describe("useAddressValidation", () => {
     expect(mockedUseBridgeRecipientValidation).toHaveBeenCalledWith(
       expect.objectContaining({
         recipient: "0xResolved",
+      }),
+    );
+  });
+
+  it("passes the current transaction to bridge validation", () => {
+    const transaction = { family: "bitcoin", recipient: "" } as Transaction;
+
+    renderHook(() =>
+      useAddressValidation({
+        searchValue: "valid_address",
+        currency: mockAccount.currency,
+        account: mockAccount,
+        transaction,
+      }),
+    );
+
+    expect(mockedUseBridgeRecipientValidation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transaction,
       }),
     );
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
@@ -5,6 +5,7 @@ import { useClipboardRecipient } from "../useClipboardRecipient";
 import { useSendFlowData } from "../../../../context/SendFlowContext";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { InvalidAddress, InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { createMockAccount } from "./accounts";
 
 jest.mock("../useAddressValidation");
@@ -111,6 +112,27 @@ describe("useRecipientScreenView", () => {
     result.current.handleAddressSelect("new_address", "ens_name");
 
     expect(onAddressSelected).toHaveBeenCalledWith("new_address", "ens_name");
+  });
+
+  it("passes the current transaction to address and clipboard validation", () => {
+    const transaction = { family: "bitcoin", recipient: "" } as Transaction;
+
+    renderHook(() =>
+      useRecipientScreenView({
+        account: mockAccount,
+        transaction,
+        currency: mockAccount.currency,
+        onAddressSelected: jest.fn(),
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    expect(mockedUseAddressValidation).toHaveBeenCalledWith(
+      expect.objectContaining({ transaction }),
+    );
+    expect(mockedUseClipboardRecipient).toHaveBeenCalledWith(
+      expect.objectContaining({ transaction }),
+    );
   });
 
   it("shows sanctioned banner when address is sanctioned", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -9,6 +9,7 @@ import {
   getRecentAddressesStore,
 } from "@ledgerhq/live-common/account/index";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { useCallback, useMemo, useRef, useState } from "react";
@@ -37,6 +38,7 @@ type UseAddressValidationProps = Readonly<{
   currency: CryptoCurrency | TokenCurrency;
   account?: AccountLike;
   parentAccount?: Account | null;
+  transaction?: Transaction | null;
   currentAccountId?: string;
   recipientSupportsDomain?: boolean;
   /** Debounce before bridge validation. Pass 0 for one-shot values (e.g. clipboard). */
@@ -54,6 +56,7 @@ export function useAddressValidation({
   currency,
   account,
   parentAccount,
+  transaction,
   currentAccountId,
   recipientSupportsDomain = false,
   debounceMs,
@@ -99,6 +102,7 @@ export function useAddressValidation({
     recipient: addressForBridgeValidation,
     account: account ?? null,
     parentAccount: parentAccount ?? null,
+    transaction,
     enabled: Boolean(
       addressForBridgeValidation &&
       account &&

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -332,8 +332,7 @@ export function useAddressValidation({
 
   return {
     result,
-    isLoading:
-      validationState.status === "loading" || domainIsLoading || bridgeValidation.isLoading,
+    isLoading: validationState.status === "loading" || domainIsLoading,
     validateAddress,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useClipboardRecipient.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useClipboardRecipient.ts
@@ -1,5 +1,6 @@
 import Clipboard from "@react-native-clipboard/clipboard";
 import { useRecipientSearchState } from "@ledgerhq/live-common/flows/send/recipient/hooks/useRecipientSearchState";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { useFocusEffect } from "@react-navigation/native";
@@ -25,6 +26,7 @@ type UseClipboardRecipientProps = Readonly<{
   currency: CryptoCurrency | TokenCurrency;
   account?: AccountLike;
   parentAccount?: Account | null;
+  transaction?: Transaction | null;
   currentAccountId?: string;
   recipientSupportsDomain: boolean;
 }>;
@@ -51,6 +53,7 @@ export function useClipboardRecipient({
   currency,
   account,
   parentAccount,
+  transaction,
   currentAccountId,
   recipientSupportsDomain,
 }: UseClipboardRecipientProps): UseClipboardRecipientResult {
@@ -89,6 +92,7 @@ export function useClipboardRecipient({
     currency,
     account,
     parentAccount,
+    transaction,
     currentAccountId,
     recipientSupportsDomain,
     // One-shot clipboard read: skip the typing debounce so the banner appears as

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
@@ -1,5 +1,6 @@
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { useRecipientSearchState } from "@ledgerhq/live-common/flows/send/recipient/hooks/useRecipientSearchState";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { useCallback } from "react";
@@ -10,6 +11,7 @@ import { useClipboardRecipient } from "./useClipboardRecipient";
 type UseRecipientScreenViewProps = Readonly<{
   account: AccountLike;
   parentAccount?: Account | null;
+  transaction?: Transaction | null;
   currency: CryptoCurrency | TokenCurrency;
   onAddressSelected: (address: string, ensName?: string) => void;
   recipientSupportsDomain: boolean;
@@ -18,6 +20,7 @@ type UseRecipientScreenViewProps = Readonly<{
 export function useRecipientScreenView({
   account,
   parentAccount,
+  transaction,
   currency,
   onAddressSelected,
   recipientSupportsDomain,
@@ -31,6 +34,7 @@ export function useRecipientScreenView({
     currency,
     account,
     parentAccount,
+    transaction,
     currentAccountId: mainAccount.id,
     recipientSupportsDomain,
   });
@@ -43,6 +47,7 @@ export function useRecipientScreenView({
     currency,
     account,
     parentAccount,
+    transaction,
     currentAccountId: mainAccount.id,
     recipientSupportsDomain,
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/index.tsx
@@ -42,6 +42,7 @@ export function RecipientScreen() {
     <RecipientScreenView
       account={account}
       parentAccount={parentAccount}
+      transaction={state.transaction.transaction}
       currency={currency}
       onAddressSelected={handleAddressSelected}
       recipientSupportsDomain={uiConfig.recipientSupportsDomain}

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useBridgeRecipientValidation.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useBridgeRecipientValidation.test.ts
@@ -118,6 +118,30 @@ describe("useBridgeRecipientValidation", () => {
     expect(mockBridge.getTransactionStatus).toHaveBeenCalled();
   });
 
+  it("uses the provided transaction as validation base when available", async () => {
+    const baseTransaction = mockBridge.createTransaction();
+    baseTransaction.opaqueField = "preserved";
+    mockBridge.createTransaction.mockClear();
+
+    renderHook(() =>
+      useBridgeRecipientValidation({
+        recipient: "valid_address",
+        account: mockAccount,
+        transaction: baseTransaction,
+      }),
+    );
+
+    jest.advanceTimersByTime(300);
+
+    await waitFor(() => {
+      expect(mockBridge.updateTransaction).toHaveBeenCalledWith(baseTransaction, {
+        recipient: "valid_address",
+      });
+    });
+
+    expect(mockBridge.createTransaction).not.toHaveBeenCalled();
+  });
+
   it("returns recipient error when bridge detects invalid address", async () => {
     const recipientError = new InvalidAddress();
     mockBridge.getTransactionStatus.mockResolvedValue({

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useRecipientSearchState.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useRecipientSearchState.test.ts
@@ -108,7 +108,20 @@ describe("useRecipientSearchState", () => {
     expect(result.current.isSanctioned).toBe(true);
   });
 
-  it("should not set isAddressComplete while validation is loading", () => {
+  it("should not set isAddressComplete while address validation is loading", () => {
+    const { result } = renderHook(() =>
+      useRecipientSearchState({
+        ...defaultProps,
+        searchValue: "0xvalid",
+        result: createDefaultResult({ status: "loading" }),
+        isLoading: true,
+      }),
+    );
+
+    expect(result.current.isAddressComplete).toBe(false);
+  });
+
+  it("should keep a validated address complete while bridge validation is loading", () => {
     const { result } = renderHook(() =>
       useRecipientSearchState({
         ...defaultProps,
@@ -118,7 +131,8 @@ describe("useRecipientSearchState", () => {
       }),
     );
 
-    expect(result.current.isAddressComplete).toBe(false);
+    expect(result.current.isAddressComplete).toBe(true);
+    expect(result.current.showSearchResults).toBe(true);
   });
 
   it("should not set isAddressComplete for idle or invalid status", () => {

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/useBridgeRecipientValidation.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/useBridgeRecipientValidation.ts
@@ -2,7 +2,10 @@ import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { applyMemoToTransaction } from "@ledgerhq/live-common/bridge/descriptor/send/memo";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import type { Memo } from "@ledgerhq/live-common/flows/send/types";
-import type { TransactionStatus } from "@ledgerhq/live-common/coin-modules/transaction-types";
+import type {
+  Transaction,
+  TransactionStatus,
+} from "@ledgerhq/live-common/coin-modules/transaction-types";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { useCallback, useMemo, useRef, useState } from "react";
 import type { BridgeValidationErrors, BridgeValidationWarnings } from "../types";
@@ -19,6 +22,7 @@ type UseBridgeRecipientValidationProps = {
   recipient: string;
   account: AccountLike | null;
   parentAccount?: Account | null;
+  transaction?: Transaction | null;
   memo?: Memo;
   enabled?: boolean;
   /**
@@ -40,6 +44,7 @@ export function useBridgeRecipientValidation({
   recipient,
   account,
   parentAccount,
+  transaction: baseTransaction,
   memo,
   enabled = true,
   debounceMs = DEBOUNCE_DELAY,
@@ -57,6 +62,7 @@ export function useBridgeRecipientValidation({
   });
 
   const lastRecipientRef = useRef<string>("");
+  const lastBaseTransactionRef = useRef<Transaction | null | undefined>(undefined);
   const validationTriggeredRef = useRef<boolean>(false);
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -100,7 +106,7 @@ export function useBridgeRecipientValidation({
       const mainAccount = getMainAccount(account, parentAccount);
       const bridge = await getAccountBridge(account, parentAccount);
 
-      let transaction = bridge.createTransaction(mainAccount);
+      let transaction = baseTransaction ?? bridge.createTransaction(mainAccount);
       transaction = bridge.updateTransaction(transaction, { recipient });
 
       if (memo) {
@@ -154,10 +160,14 @@ export function useBridgeRecipientValidation({
         status: null,
       });
     }
-  }, [account, recipient, enabled, parentAccount, memo]);
+  }, [account, recipient, enabled, parentAccount, baseTransaction, memo]);
 
-  if (recipient !== lastRecipientRef.current) {
+  if (
+    recipient !== lastRecipientRef.current ||
+    baseTransaction !== lastBaseTransactionRef.current
+  ) {
     lastRecipientRef.current = recipient;
+    lastBaseTransactionRef.current = baseTransaction;
     validationTriggeredRef.current = false;
 
     if (debounceTimeoutRef.current) {

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/useRecipientSearchState.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/useRecipientSearchState.ts
@@ -16,7 +16,6 @@ export function useRecipientSearchState({
   recipientSupportsDomain,
 }: UseRecipientSearchStateProps) {
   const hasSearchValue = searchValue.length > 0;
-  const showSearchResults = hasSearchValue && !isLoading;
   const isSanctioned = result.status === "sanctioned";
 
   const bridgeRecipientError = result.bridgeErrors?.recipient;
@@ -28,15 +27,14 @@ export function useRecipientSearchState({
   const isBridgeInvalidAddress =
     bridgeRecipientError instanceof InvalidAddress && !isSelfTransferError;
 
+  const hasValidatedAddress =
+    result.status === "valid" || result.status === "ens_resolved" || result.status === "sanctioned";
+
+  const showSearchResults = hasSearchValue && (!isLoading || hasValidatedAddress);
+
   const isAddressComplete = useMemo(() => {
-    if (isLoading) return false;
-    return (
-      (result.status === "valid" ||
-        result.status === "ens_resolved" ||
-        result.status === "sanctioned") &&
-      !isBridgeInvalidAddress
-    );
-  }, [result.status, isBridgeInvalidAddress, isLoading]);
+    return hasValidatedAddress && !isBridgeInvalidAddress;
+  }, [hasValidatedAddress, isBridgeInvalidAddress]);
 
   const hasAnyMatches =
     (result.matchedAccounts && result.matchedAccounts.length > 0) ||


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Update LWDM to display the error message for a tx of USDT between two account, with the recipient which has not opt-in for the ASA in the recipient step instead of the amount step

<img width="452" height="417" alt="image" src="https://github.com/user-attachments/assets/ef37a490-f8f0-4e86-89a2-ffaca61265c8" />


### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-34110)** <!-- e.g. [LLD-1234] or #456 --> 
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
