### PR TITLE
[LWM] chore: format

### DIFF
--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/Inspect.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/Inspect.tsx
@@ -81,7 +81,12 @@ function FunnelStat({
   value,
   tone,
 }: Readonly<{ label: string; value: number; tone?: "positive" | "negative" }>) {
-  const color = value > 0 && tone === "positive" ? "success" : value > 0 && tone === "negative" ? "error" : "base";
+  const color =
+    value > 0 && tone === "positive"
+      ? "success"
+      : value > 0 && tone === "negative"
+        ? "error"
+        : "base";
   return (
     <Box lx={{ flexDirection: "row", justifyContent: "space-between" }}>
       <Text typography="body2" lx={{ color: "muted" }}>

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/index.tsx
@@ -774,7 +774,9 @@ export default function DebugContentCards() {
         {selectedRawCard ? (
           <CardDetailContent
             card={selectedRawCard}
-            isDismissed={dismissedIds.includes(getDismissalKey(selectedRawCard) ?? selectedRawCard.id)}
+            isDismissed={dismissedIds.includes(
+              getDismissalKey(selectedRawCard) ?? selectedRawCard.id,
+            )}
             isUnmapped={unmappedCards.some(card => card.id === selectedRawCard.id)}
             onCopy={() => copyCardJson(selectedRawCard)}
           />

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/qaConsole.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/qaConsole.ts
@@ -828,13 +828,19 @@ export function buildPlacementDiagnostics(
         categoryBlockers.push("No eligible child cards for this category");
       }
     } else {
-      eligibleCardIds = getDirectPlacementEligibleCardIds(placement, buckets, dismissedContentCards);
+      eligibleCardIds = getDirectPlacementEligibleCardIds(
+        placement,
+        buckets,
+        dismissedContentCards,
+      );
     }
 
     // Wallet/Top wallet never mount on the Portfolio screen without a displayable account,
     // regardless of how well-formed their cards are - see PortfolioScreen's `showAssets` gate.
     const accountBlockers =
-      ACCOUNT_GATED_PLACEMENTS.has(placement) && !hasDisplayableAccounts && eligibleCardIds.length > 0
+      ACCOUNT_GATED_PLACEMENTS.has(placement) &&
+      !hasDisplayableAccounts &&
+      eligibleCardIds.length > 0
         ? ["no displayable accounts on this device"]
         : [];
     if (accountBlockers.length > 0) eligibleCardIds = [];


### PR DESCRIPTION
### 📝 Description

Reformat long lines in the ContentCards debug screens (`Inspect.tsx`, `index.tsx`, `qaConsole.ts`) to comply with the project's code style. No logic changes.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- n/a -->
- **ADR** (if any): <!-- n/a -->