### PR TITLE
test(mobile): stabilize large screen upsell eligibility

### DIFF
--- a/.changeset/fixed-clock-smile.md
+++ b/.changeset/fixed-clock-smile.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Stabilize large screen upsell eligibility integration test.

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/largeScreenUpsellEligibility.integration.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/largeScreenUpsellEligibility.integration.test.ts
@@ -1,18 +1,9 @@
 import { DeviceModelId } from "@ledgerhq/devices";
-import { isCooldownElapsed } from "@ledgerhq/live-common/postOnboarding/logic/upsellFrequency";
 import { renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { useLargeScreenUpsellEligibility } from "..";
 import type { State } from "~/reducers/types";
 
-jest.mock(
-  "@ledgerhq/live-common/postOnboarding/logic/upsellFrequency",
-  () => ({
-    isCooldownElapsed: jest.fn(),
-  }),
-  { virtual: true },
-);
-
-const mockedIsCooldownElapsed = jest.mocked(isCooldownElapsed);
+const NOW = new Date("2026-06-01T12:00:00.000Z");
 
 function withKnownDeviceModels(deviceModelIds: DeviceModelId[]) {
   return (state: State): State => ({
@@ -33,11 +24,11 @@ function withKnownDeviceModels(deviceModelIds: DeviceModelId[]) {
 
 describe("large screen upsell eligibility integration", () => {
   beforeEach(() => {
-    mockedIsCooldownElapsed.mockReturnValue(true);
+    jest.useFakeTimers().setSystemTime(NOW);
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.useRealTimers();
   });
 
   it("should be eligible when the feature is enabled and only a nano has been seen", () => {
@@ -53,11 +44,6 @@ describe("large screen upsell eligibility integration", () => {
       deviceModelId: DeviceModelId.nanoS,
       cooldownDays: 0,
     });
-    expect(mockedIsCooldownElapsed).toHaveBeenCalledWith(
-      new Date("2026-06-01T12:00:00.000Z"),
-      0,
-      expect.any(Date),
-    );
   });
 
   it("should be ineligible for dual owners who have seen a nano and a touchscreen device", () => {
@@ -69,6 +55,5 @@ describe("large screen upsell eligibility integration", () => {
     });
 
     expect(result.current).toEqual({ isEligible: false, reason: "touchscreen_seen" });
-    expect(mockedIsCooldownElapsed).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Large screen upsell eligibility integration test stability

### 📝 Description

This PR stabilizes the large screen upsell eligibility integration test by freezing Jest's system time during the test run.

The test now uses `jest.useFakeTimers().setSystemTime(...)` and exercises the real cooldown helper instead of mocking it. This keeps the assertion behavioral while avoiding time-dependent flakes from the hook's `new Date()` call.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33153](https://ledgerhq.atlassian.net/browse/LIVE-33153)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-33153]: https://ledgerhq.atlassian.net/browse/LIVE-33153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ