### PR TITLE
[LWDM] feat(history): filter incoming dust transactions

### DIFF
--- a/.changeset/fresh-dust-filter.md
+++ b/.changeset/fresh-dust-filter.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Filter incoming native dust transactions in operation histories.

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryOperations.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryOperations.test.ts
@@ -18,6 +18,8 @@ const ZERO_VALUE_TOKEN_OP_ID = "zero-value-token-op-id";
 const NON_ZERO_VALUE_TOKEN_OP_ID = "non-zero-value-token-op-id";
 const SMALL_NON_ZERO_TOKEN_OP_ID = "small-non-zero-token-op-id";
 const LARGE_NON_ZERO_TOKEN_OP_ID = "large-non-zero-token-op-id";
+const SMALL_NATIVE_IN_OP_ID = "small-native-in-op-id";
+const LARGE_NATIVE_IN_OP_ID = "large-native-in-op-id";
 
 const mockCalculate = calculate as jest.MockedFunction<typeof calculate>;
 
@@ -33,6 +35,23 @@ function createTokenOperation(tokenAccountId: string, id: string, value: BigNumb
     blockHash: "0xblock",
     blockHeight: 1,
     accountId: tokenAccountId,
+    date: new Date(),
+    extra: {},
+  };
+}
+
+function createNativeIncomingOperation(accountId: string, id: string, value: BigNumber): Operation {
+  return {
+    id,
+    hash: id,
+    type: "IN",
+    value,
+    fee: new BigNumber(0),
+    senders: ["0xsender"],
+    recipients: ["0xrecipient"],
+    blockHash: "0xblock",
+    blockHeight: 1,
+    accountId,
     date: new Date(),
     extra: {},
   };
@@ -73,6 +92,24 @@ function createAccountWithNonZeroValueTokenOperations(): Account {
     { id: SMALL_NON_ZERO_TOKEN_OP_ID, value: new BigNumber(1) },
     { id: LARGE_NON_ZERO_TOKEN_OP_ID, value: new BigNumber(2) },
   ]);
+}
+
+function createAccountWithNativeIncomingOperations(): Account {
+  const account = genAccount("eth-native-incoming-dust", {
+    currency: ETH_ACCOUNT.currency,
+    subAccountsCount: 0,
+    operationsSize: 0,
+  });
+  const operations = [
+    createNativeIncomingOperation(account.id, SMALL_NATIVE_IN_OP_ID, new BigNumber(1)),
+    createNativeIncomingOperation(account.id, LARGE_NATIVE_IN_OP_ID, new BigNumber(2)),
+  ];
+
+  return {
+    ...account,
+    operations,
+    operationsCount: operations.length,
+  };
 }
 
 describe("useHistoryOperations", () => {
@@ -207,6 +244,30 @@ describe("useHistoryOperations", () => {
     });
 
     expect(result.current.map(item => item.operation.id)).toEqual([LARGE_NON_ZERO_TOKEN_OP_ID]);
+  });
+
+  it("filters non-zero native incoming operations below the dust countervalue threshold", () => {
+    const account = createAccountWithNativeIncomingOperations();
+    mockCalculate.mockImplementation((_state, query) => {
+      if (query.from === account.currency && query.value === 1) return 0.5;
+      if (query.from === account.currency && query.value === 2) return 2;
+      if (query.from.ticker === "USD") return 1;
+      return null;
+    });
+
+    const { result } = renderHook(() => useHistoryOperations(), {
+      initialState: {
+        accounts: [account],
+        settings: {
+          ...INITIAL_STATE,
+          filterTokenOperationsZeroAmount: false,
+          hideSmallValueTokenOperations: true,
+        },
+        ...withFlagOverrides({ lwdDustFiltering: { enabled: true } }),
+      },
+    });
+
+    expect(result.current.map(item => item.operation.id)).toEqual([LARGE_NATIVE_IN_OP_ID]);
   });
 
   it("keeps zero-value token operations when the dust feature flag is disabled", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/History/utils/historyOperationItems.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/utils/historyOperationItems.ts
@@ -8,7 +8,7 @@ import {
   getAccountCurrency,
   getMainAccount,
 } from "@ledgerhq/live-common/account/index";
-import { isSmallValueTokenOperation } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
+import { isSmallValueIncomingOperation } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
 import {
   getOperationAmountNumber,
   flattenOperationWithInternalsAndNfts,
@@ -200,7 +200,7 @@ export function buildHistoryOperationFilter({
       shouldHideSmallValueTokenOperations &&
       countervaluesState &&
       userCounterValueCurrency &&
-      isSmallValueTokenOperation({
+      isSmallValueIncomingOperation({
         operation,
         account,
         countervaluesState,

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/utils/unreadOperations.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/utils/unreadOperations.ts
@@ -3,7 +3,7 @@ import type { Features } from "@shared/feature-flags";
 import type { Currency } from "@ledgerhq/types-cryptoassets";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
 import { flattenAccounts } from "@ledgerhq/live-common/account/index";
-import { isSmallValueTokenOperation } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
+import { isSmallValueIncomingOperation } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
 import {
   flattenOperationWithInternalsAndNfts,
   isAddressPoisoningOperation,
@@ -72,7 +72,7 @@ export function hasUnreadOperations(
       shouldHideSmallValueTokenOperations &&
       countervaluesState &&
       userCounterValueCurrency &&
-      isSmallValueTokenOperation({
+      isSmallValueIncomingOperation({
         operation,
         account,
         countervaluesState,

--- a/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
@@ -80,6 +80,33 @@ function createAccountWithUnreadZeroValueTokenOperation(): Account {
   };
 }
 
+function createAccountWithUnreadZeroValueNativeOperation(): Account {
+  const account = genAccount("history-test-native-dust", {
+    currency: ethereum,
+    operationsSize: 0,
+  });
+  const operation: Operation = {
+    id: "history-test-dust-zero-value-native-op",
+    hash: "0xnative-dust",
+    type: "IN",
+    value: new BigNumber(0),
+    fee: new BigNumber(0),
+    senders: ["0xsender"],
+    recipients: ["0xrecipient"],
+    blockHash: "0xblock",
+    blockHeight: 1,
+    accountId: account.id,
+    date: new Date("2024-12-01T00:00:00.000Z"),
+    extra: {},
+  };
+
+  return {
+    ...account,
+    operations: [operation],
+    operationsCount: 1,
+  };
+}
+
 function withDustPreferenceEnabled(state: State): State {
   return {
     ...state,
@@ -193,6 +220,18 @@ describe("hasUnreadOperationsSelector", () => {
 
   it("filters dust operations when the dust preference and feature flag are enabled", () => {
     const accountWithDustOperation = createAccountWithUnreadZeroValueTokenOperation();
+
+    expect(
+      hasUnreadOperationsSelector(
+        withDustFeatureEnabled(
+          withDustPreferenceEnabled(makeState(SEEN, [accountWithDustOperation])),
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("filters native dust operations when the dust preference and feature flag are enabled", () => {
+    const accountWithDustOperation = createAccountWithUnreadZeroValueNativeOperation();
 
     expect(
       hasUnreadOperationsSelector(

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
@@ -23,6 +23,8 @@ const EVM_TOKEN: TokenCurrency = {
 };
 
 const ZERO_VALUE_TOKEN_OP_ID = "zero-value-token-op-id";
+const ZERO_VALUE_NATIVE_OP_ID = "zero-value-native-op-id";
+const NON_ZERO_VALUE_NATIVE_OP_ID = "non-zero-value-native-op-id";
 
 function createZeroValueTokenOperation(tokenAccountId: string): Operation {
   return {
@@ -68,6 +70,46 @@ function createAccountWithZeroValueTokenOperation(): Account {
   return {
     ...parentAccount,
     subAccounts: [tokenAccountWithZeroOp],
+  };
+}
+
+function createNativeOperation(accountId: string, id: string, value: BigNumber): Operation {
+  return {
+    id,
+    hash: id,
+    type: "IN",
+    value,
+    fee: new BigNumber(0),
+    senders: ["0xsender"],
+    recipients: ["0xrecipient"],
+    blockHash: "0xblock",
+    blockHeight: 1,
+    accountId,
+    date: new Date(),
+    extra: {},
+  };
+}
+
+function createAccountWithZeroValueNativeOperation(): Account {
+  const account = genAccount("eth-zero-value-native", {
+    currency: ETH,
+    operationsSize: 0,
+  });
+
+  const zeroValueOp = createNativeOperation(account.id, ZERO_VALUE_NATIVE_OP_ID, new BigNumber(0));
+
+  return {
+    ...account,
+    operations: [
+      zeroValueOp,
+      {
+        ...zeroValueOp,
+        id: NON_ZERO_VALUE_NATIVE_OP_ID,
+        hash: NON_ZERO_VALUE_NATIVE_OP_ID,
+        value: new BigNumber(1),
+      },
+    ],
+    operationsCount: 2,
   };
 }
 
@@ -189,5 +231,16 @@ describe("useOperationsV1 integration", () => {
 
     expect(result.current.sections[0].data.length).toBe(1);
     expect(result.current.sections[0].data[0].id).toBe("non-zero-value-token-op-id");
+  });
+
+  it("should filter out zero-value native operations when dust preference and feature flag are enabled", () => {
+    const accountWithZeroValueNativeOp = createAccountWithZeroValueNativeOperation();
+
+    const { result } = renderHook(() => useOperationsV1([accountWithZeroValueNativeOp], 50), {
+      overrideInitialState: initialStateWithDustFilterEnabled,
+    });
+
+    expect(result.current.sections[0].data.length).toBe(1);
+    expect(result.current.sections[0].data[0].id).toBe(NON_ZERO_VALUE_NATIVE_OP_ID);
   });
 });

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/useOperationsV1.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/useOperationsV1.ts
@@ -1,6 +1,6 @@
 import { groupAccountsOperationsByDay } from "@ledgerhq/ledger-wallet-framework/account/groupOperations";
 import { isAddressPoisoningOperation } from "@ledgerhq/ledger-wallet-framework/operation";
-import { isSmallValueTokenOperation } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
+import { isSmallValueIncomingOperation } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
 import { AccountLike, Operation } from "@ledgerhq/types-live";
 import { useCallback } from "react";
 import { useSelector } from "~/context/hooks";
@@ -61,7 +61,7 @@ export function useOperationsV1(
         shouldHideSmallValueTokenOperations &&
         countervaluesState &&
         userCounterValueCurrency &&
-        isSmallValueTokenOperation({
+        isSmallValueIncomingOperation({
           operation,
           account,
           countervaluesState,

--- a/libs/ledger-live-common/src/hideSmallValueTokenOperations/__tests__/smallValueOperationsThreshold.test.ts
+++ b/libs/ledger-live-common/src/hideSmallValueTokenOperations/__tests__/smallValueOperationsThreshold.test.ts
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import { getFiatCurrencyByTicker } from "../../currencies";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
 import type { AccountLike, Operation } from "@ledgerhq/types-live";
-import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import {
   clampSmallValueThresholdUsd,
   convertThresholdFromCountervalueMinorUnitToUsd,
@@ -11,7 +11,7 @@ import {
   floorThresholdToCurrencyMinorUnit,
   formatThresholdMinorUnitForInput,
   formatSmallValueOperationsThreshold,
-  isSmallValueTokenOperation,
+  isSmallValueIncomingOperation,
   SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
 } from "../smallValueOperationsThreshold";
 
@@ -208,24 +208,30 @@ describe("smallValueOperationsThreshold", () => {
     });
   });
 
-  describe("isSmallValueTokenOperation", () => {
+  describe("isSmallValueIncomingOperation", () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const mockToken = { units: [{ magnitude: 6 }] } as TokenCurrency;
+    const mockToken = { ticker: "MOCK", units: [{ magnitude: 6 }] } as TokenCurrency;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const mockNativeCurrency = {
+      ticker: "MOCK_NATIVE",
+      units: [{ magnitude: 10 }],
+    } as CryptoCurrency;
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const tokenAccount = { type: "TokenAccount", token: mockToken } as AccountLike;
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const regularAccount = { type: "Account" } as AccountLike;
+    const regularAccount = { type: "Account", currency: mockNativeCurrency } as AccountLike;
 
     const buildOp = (type: string, value: BigNumber): Operation =>
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       ({ type, value }) as Operation;
 
     const mockSmallValueCalculations = (
+      operationCurrency: CryptoCurrency | TokenCurrency,
       opFiatValue: number | undefined,
       thresholdFiatValue = 50,
     ) => {
       mockCalculate.mockImplementation((_state, query) => {
-        if (query.from === mockToken) return opFiatValue;
+        if (query.from === operationCurrency) return opFiatValue;
         if (query.from === SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY) {
           return thresholdFiatValue;
         }
@@ -233,13 +239,10 @@ describe("smallValueOperationsThreshold", () => {
       });
     };
 
-    it.each([
-      { desc: "non-token Account", account: "regular", opType: "IN" },
-      { desc: "non-IN operation (OUT)", account: "token", opType: "OUT" },
-    ])("should return false for $desc without calling calculate", ({ account, opType }) => {
-      const result = isSmallValueTokenOperation({
-        operation: buildOp(opType, new BigNumber(0)),
-        account: account === "token" ? tokenAccount : regularAccount,
+    it("should keep non-IN operations without calling calculate", () => {
+      const result = isSmallValueIncomingOperation({
+        operation: buildOp("OUT", new BigNumber(0)),
+        account: regularAccount,
         countervaluesState: mockCountervaluesState,
         userCounterValueCurrency: EUR,
       });
@@ -248,8 +251,20 @@ describe("smallValueOperationsThreshold", () => {
       expect(mockCalculate).not.toHaveBeenCalled();
     });
 
+    it("should return true when an incoming native operation has exactly 0 crypto value", () => {
+      const result = isSmallValueIncomingOperation({
+        operation: buildOp("IN", new BigNumber(0)),
+        account: regularAccount,
+        countervaluesState: mockCountervaluesState,
+        userCounterValueCurrency: EUR,
+      });
+
+      expect(result).toBe(true);
+      expect(mockCalculate).not.toHaveBeenCalled();
+    });
+
     it("should return true when token IN operation has exactly 0 crypto value", () => {
-      const result = isSmallValueTokenOperation({
+      const result = isSmallValueIncomingOperation({
         operation: buildOp("IN", new BigNumber(0)),
         account: tokenAccount,
         countervaluesState: mockCountervaluesState,
@@ -272,9 +287,9 @@ describe("smallValueOperationsThreshold", () => {
       },
       { fiatValue: 51, opValue: 510_000, expected: false, desc: "above threshold -> not dust" },
     ])("$desc", ({ fiatValue, opValue, expected }) => {
-      mockSmallValueCalculations(fiatValue);
+      mockSmallValueCalculations(mockToken, fiatValue);
 
-      const result = isSmallValueTokenOperation({
+      const result = isSmallValueIncomingOperation({
         operation: buildOp("IN", new BigNumber(opValue)),
         account: tokenAccount,
         countervaluesState: mockCountervaluesState,
@@ -285,14 +300,42 @@ describe("smallValueOperationsThreshold", () => {
     });
 
     it.each([
+      { fiatValue: 49, opValue: 499_999, expected: true, desc: "below threshold -> dust" },
+      { fiatValue: 51, opValue: 510_000, expected: false, desc: "above threshold -> not dust" },
+    ])("should handle incoming native operations $desc", ({ fiatValue, opValue, expected }) => {
+      mockSmallValueCalculations(mockNativeCurrency, fiatValue);
+
+      const result = isSmallValueIncomingOperation({
+        operation: buildOp("IN", new BigNumber(opValue)),
+        account: regularAccount,
+        countervaluesState: mockCountervaluesState,
+        userCounterValueCurrency: EUR,
+      });
+
+      expect(result).toBe(expected);
+    });
+
+    it("should keep outgoing native operations below the dust threshold", () => {
+      const result = isSmallValueIncomingOperation({
+        operation: buildOp("OUT", new BigNumber(499_999)),
+        account: regularAccount,
+        countervaluesState: mockCountervaluesState,
+        userCounterValueCurrency: EUR,
+      });
+
+      expect(result).toBe(false);
+      expect(mockCalculate).not.toHaveBeenCalled();
+    });
+
+    it.each([
       { fiatValue: undefined, desc: "calculate returns undefined" },
       { fiatValue: Number.POSITIVE_INFINITY, desc: "calculate returns Infinity" },
     ])("should not filter when price feed is unavailable ($desc)", ({ fiatValue }) => {
-      mockSmallValueCalculations(fiatValue);
+      mockSmallValueCalculations(mockNativeCurrency, fiatValue);
 
-      const result = isSmallValueTokenOperation({
+      const result = isSmallValueIncomingOperation({
         operation: buildOp("IN", new BigNumber(1_000_000)),
-        account: tokenAccount,
+        account: regularAccount,
         countervaluesState: mockCountervaluesState,
         userCounterValueCurrency: EUR,
       });
@@ -303,11 +346,11 @@ describe("smallValueOperationsThreshold", () => {
     it("should correctly filter a dust amount from an 18-decimal token", () => {
       // Scenario: 18-decimal token, op worth ~1 EUR cent (dust)
       // calculate(token -> EUR, 10^20) -> 1 EUR cent ; threshold = 50 EUR cents
-      mockSmallValueCalculations(1);
+      mockSmallValueCalculations(mockToken, 1);
 
       const dustAmount = new BigNumber("100").times(new BigNumber(10).pow(18)); // 10^20
 
-      const result = isSmallValueTokenOperation({
+      const result = isSmallValueIncomingOperation({
         operation: buildOp("IN", dustAmount),
         account: tokenAccount,
         countervaluesState: mockCountervaluesState,
@@ -317,10 +360,10 @@ describe("smallValueOperationsThreshold", () => {
       expect(result).toBe(true); // 1 EUR cent < 50 EUR cent threshold -> dust
     });
 
-    it("should use a custom Firebase thresholdUsd when provided", () => {
-      mockSmallValueCalculations(24, 25);
+    it("should use a custom feature flag thresholdUsd when provided", () => {
+      mockSmallValueCalculations(mockToken, 24, 25);
 
-      const result = isSmallValueTokenOperation({
+      const result = isSmallValueIncomingOperation({
         operation: buildOp("IN", new BigNumber(249_999)),
         account: tokenAccount,
         countervaluesState: mockCountervaluesState,
@@ -341,9 +384,9 @@ describe("smallValueOperationsThreshold", () => {
     });
 
     it("should fall back to the default threshold ($0.5 -> 50 EUR cents) when thresholdUsd is omitted", () => {
-      mockSmallValueCalculations(1);
+      mockSmallValueCalculations(mockToken, 1);
 
-      const result = isSmallValueTokenOperation({
+      const result = isSmallValueIncomingOperation({
         operation: buildOp("IN", new BigNumber(1)),
         account: tokenAccount,
         countervaluesState: mockCountervaluesState,
@@ -355,9 +398,9 @@ describe("smallValueOperationsThreshold", () => {
 
     it("should return false when the converted threshold is zero", () => {
       // A zero threshold is treated as "no threshold" to avoid filtering all operations.
-      mockSmallValueCalculations(0, 0);
+      mockSmallValueCalculations(mockToken, 0, 0);
 
-      const result = isSmallValueTokenOperation({
+      const result = isSmallValueIncomingOperation({
         operation: buildOp("IN", new BigNumber(1)),
         account: tokenAccount,
         countervaluesState: mockCountervaluesState,

--- a/libs/ledger-live-common/src/hideSmallValueTokenOperations/smallValueOperationsThreshold.ts
+++ b/libs/ledger-live-common/src/hideSmallValueTokenOperations/smallValueOperationsThreshold.ts
@@ -1,6 +1,7 @@
 import BigNumber from "bignumber.js";
 import { calculate } from "@ledgerhq/live-countervalues/logic";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import { getAccountCurrency } from "../account";
 import { formatCurrencyUnit, getFiatCurrencyByTicker } from "../currencies";
 import type { Currency, Unit } from "@ledgerhq/types-cryptoassets";
 import type { AccountLike, Operation } from "@ledgerhq/types-live";
@@ -176,11 +177,10 @@ export function convertThresholdFromCountervalueMinorUnitToUsd({
 }
 
 /**
- * Returns `true` when an incoming token operation should be hidden as a
+ * Returns `true` when an incoming operation should be hidden as a
  * "small-value" (dust) transaction.
  *
  * An operation is considered dust when:
- * - it belongs to a TokenAccount, AND
  * - its type is "IN" (incoming transfer), AND
  * - either its crypto value is exactly zero, OR its fiat countervalue is
  *   strictly below the configured USD threshold (defaults to $0.5,
@@ -194,7 +194,7 @@ export function convertThresholdFromCountervalueMinorUnitToUsd({
  * we convert both the operation amount and the USD threshold to user-fiat
  * minor units, then compare those raw values.
  */
-export function isSmallValueTokenOperation({
+export function isSmallValueIncomingOperation({
   operation,
   account,
   countervaluesState,
@@ -205,19 +205,21 @@ export function isSmallValueTokenOperation({
   account: AccountLike;
   countervaluesState: CounterValuesState;
   /** The user's selected countervalue (fiat) currency, e.g. EUR.
-   *  The countervalues state stores `{from: token, to: this currency}` pairs. */
+   *  Countervalues are computed from the operation currency (native or token) to this currency. */
   userCounterValueCurrency: Currency;
-  /** USD threshold below which an incoming token operation is considered dust.
+  /** USD threshold below which an incoming operation is considered dust.
    *  Defaults to MAX_SMALL_VALUE_OPERATIONS_THRESHOLD_USD ($0.5).
-   *  Pass the value from the `lldHideSmallValueTokenOperations` feature flag */
+   *  Callers provide their product-specific dust-filter threshold. */
   thresholdUsd?: number;
 }): boolean {
-  if (account.type !== "TokenAccount" || operation.type !== "IN") return false;
+  if (operation.type !== "IN") return false;
 
   if (operation.value.isZero()) return true;
 
+  const operationCurrency = getAccountCurrency(account);
+
   const rawOpFiatValue = calculate(countervaluesState, {
-    from: account.token,
+    from: operationCurrency,
     to: userCounterValueCurrency,
     value: operation.value.toNumber(),
     disableRounding: true,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Desktop transaction history dust filtering
      - Mobile transaction history dust filtering
      - Shared small-value operation predicate in `@ledgerhq/live-common`
      - Unread transaction indicators when dust filtering is enabled

### 📝 Description

The dust filter previously only hid incoming token-account operations, so native incoming transactions below the configured threshold could remain visible in transaction history even when the dust filter was enabled.

This PR updates the shared dust predicate to apply to any incoming operation by resolving the operation currency from the account. Outgoing operations remain visible, and operations remain visible when countervalue data cannot be computed. Desktop and Mobile history paths now use the renamed `isSmallValueIncomingOperation` helper.

Before: only `TokenAccount` + `IN` operations could be hidden as dust.
After: any `IN` operation below the dust threshold can be hidden, including native coins.

### ❓ Context
<img width="1247" height="653" alt="image" src="https://github.com/user-attachments/assets/81c42388-0e35-4e7d-8bc4-41b46b22ab2d" />

<img width="1501" height="788" alt="image" src="https://github.com/user-attachments/assets/d06f035a-1d2e-43c3-8f07-512319801d30" />

- **JIRA or GitHub link**: [29298](https://ledgerhq.atlassian.net/browse/LIVE-29298)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
