### PR TITLE
[LWDM] refactor(generic-bridge): drop assetReference/assetOwner from GenericTransaction

### DIFF
--- a/.changeset/rare-tigers-cheer.md
+++ b/.changeset/rare-tigers-cheer.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/coin-evm": patch
+---
+
+Remove `assetReference`/`assetOwner` from `GenericTransaction` and make `subAccountId` the single source of truth for token identification in the generic coin framework (LIVE-24044). The token asset is now derived from the sub-account's token via `getAssetFromToken` in `transactionToIntent`, and `subAccountId` is serialized so the edit-transaction flow restores the token without those fields. Stellar keeps its own `assetReference`/`assetOwner` for the `changeTrust` flow (no sub-account yet), and its device confirmation now derives the token asset from the sub-account for token sends.

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/TransactionConfirmFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/TransactionConfirmFields.tsx
@@ -1,4 +1,3 @@
-import invariant from "invariant";
 import React from "react";
 import { Transaction } from "@ledgerhq/live-common/families/stellar/types";
 import styled from "styled-components";
@@ -49,26 +48,20 @@ const StellarNetworkField = ({ field }: StellarFieldComponentProps) => (
     </Text>
   </TransactionConfirmField>
 );
-const StellarAssetCodeField = ({ transaction, field }: StellarFieldComponentProps) => {
-  invariant(transaction.family === "stellar", "stellar transaction");
-  return (
-    <TransactionConfirmField label={field.label}>
-      <Text ff="Inter|Medium" color="neutral.c80" fontSize={3}>
-        {transaction.assetReference}
-      </Text>
-    </TransactionConfirmField>
-  );
-};
-const StellarAssetIssuerField = ({ transaction, field }: StellarFieldComponentProps) => {
-  invariant(transaction.family === "stellar", "stellar transaction");
-  return (
-    <TransactionConfirmField label={field.label}>
-      <WrappedAssetIssuer ff="Inter|Medium" color="neutral.c80" fontSize={3}>
-        {transaction.assetOwner}
-      </WrappedAssetIssuer>
-    </TransactionConfirmField>
-  );
-};
+const StellarAssetCodeField = ({ field }: StellarFieldComponentProps) => (
+  <TransactionConfirmField label={field.label}>
+    <Text ff="Inter|Medium" color="neutral.c80" fontSize={3}>
+      {"value" in field && typeof field.value === "string" ? field.value : undefined}
+    </Text>
+  </TransactionConfirmField>
+);
+const StellarAssetIssuerField = ({ field }: StellarFieldComponentProps) => (
+  <TransactionConfirmField label={field.label}>
+    <WrappedAssetIssuer ff="Inter|Medium" color="neutral.c80" fontSize={3}>
+      {"value" in field && typeof field.value === "string" ? field.value : undefined}
+    </WrappedAssetIssuer>
+  </TransactionConfirmField>
+);
 const fieldComponents = {
   "stellar.memo": StellarMemoField,
   "stellar.network": StellarNetworkField,

--- a/apps/ledger-live-mobile/src/families/stellar/TransactionConfirmFields.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/TransactionConfirmFields.tsx
@@ -38,18 +38,18 @@ const StellarNetworkField = () => (
   </DataRow>
 );
 
-const StellarAssetCodeField = ({ transaction }: Props) => (
+const StellarAssetCodeField = ({ field }: { field: { value?: string } }) => (
   <DataRow label={<Trans i18nKey="stellar.assetCode" />}>
     <LText semiBold style={styles.text}>
-      {(transaction as StellarTransaction).assetReference}
+      {field.value}
     </LText>
   </DataRow>
 );
 
-const StellarAssetIssuerField = ({ transaction }: Props) => (
+const StellarAssetIssuerField = ({ field }: { field: { value?: string } }) => (
   <DataRow label={<Trans i18nKey="stellar.assetIssuer" />}>
     <LText semiBold style={styles.text}>
-      {(transaction as StellarTransaction).assetOwner}
+      {field.value}
     </LText>
   </DataRow>
 );

--- a/libs/coin-modules/coin-evm/src/types/transaction.ts
+++ b/libs/coin-modules/coin-evm/src/types/transaction.ts
@@ -81,8 +81,6 @@ type EvmTransactionBaseRaw = TransactionCommonRaw & {
   nonce: number;
   gasLimit: string;
   customGasLimit?: string | undefined;
-  assetReference?: string | null | undefined;
-  assetOwner?: string | null | undefined;
   chainId: number;
   data?: string | null | undefined;
   type?: number | undefined;

--- a/libs/coin-tester-modules/coin-tester-stellar/src/scenarii/stellar.ts
+++ b/libs/coin-tester-modules/coin-tester-stellar/src/scenarii/stellar.ts
@@ -33,7 +33,12 @@ jest.setTimeout(600_000);
 
 let closeMsw: (() => void) | null = null;
 
-type StellarScenarioTransaction = ScenarioTransaction<GenericTransaction, Account>;
+// `assetReference`/`assetOwner` are no longer on `GenericTransaction`; stellar carries them on its
+// own transaction for the `changeTrust` flow (no sub-account yet). Token sends rely on `subAccountId`.
+type StellarScenarioTransaction = ScenarioTransaction<GenericTransaction, Account> & {
+  assetReference?: string;
+  assetOwner?: string;
+};
 
 /**
  * Hook flag: ensures we only inject USDC into the test account once,
@@ -144,8 +149,6 @@ function makeScenarioTransactions(address: string): StellarScenarioTransaction[]
     amount: new BigNumber(10 * 1e7),
     recipient: RECIPIENT_ADDRESS,
     subAccountId: tokenSubAccountId,
-    assetReference: USDC_ASSET_CODE,
-    assetOwner: ISSUER_ADDRESS,
     expect: (previousAccount, currentAccount) => {
       const previousSub = findUsdcSubAccount(previousAccount);
       const currentSub = findUsdcSubAccount(currentAccount);
@@ -163,8 +166,6 @@ function makeScenarioTransactions(address: string): StellarScenarioTransaction[]
     name: "Send all USDC to recipient",
     recipient: RECIPIENT_ADDRESS,
     subAccountId: tokenSubAccountId,
-    assetReference: USDC_ASSET_CODE,
-    assetOwner: ISSUER_ADDRESS,
     useAllAmount: true,
     expect: (previousAccount, currentAccount) => {
       const currentSub = findUsdcSubAccount(currentAccount);

--- a/libs/coin-tester-modules/coin-tester-stellar/src/scenarii/stellar.ts
+++ b/libs/coin-tester-modules/coin-tester-stellar/src/scenarii/stellar.ts
@@ -3,6 +3,7 @@ import { Config as StellarSdkConfig } from "@stellar/stellar-sdk";
 import { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
 import type { Account, TokenAccount } from "@ledgerhq/types-live";
 import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
+import type { Transaction as StellarTransaction } from "@ledgerhq/live-common/families/stellar/types";
 import coinConfig from "@ledgerhq/coin-stellar/config";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { setupMockCryptoAssetsStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
@@ -33,12 +34,9 @@ jest.setTimeout(600_000);
 
 let closeMsw: (() => void) | null = null;
 
-// `assetReference`/`assetOwner` are no longer on `GenericTransaction`; stellar carries them on its
-// own transaction for the `changeTrust` flow (no sub-account yet). Token sends rely on `subAccountId`.
-type StellarScenarioTransaction = ScenarioTransaction<GenericTransaction, Account> & {
-  assetReference?: string;
-  assetOwner?: string;
-};
+// changeTrust carries the asset on the stellar transaction (no sub-account yet).
+type StellarScenarioTransaction = ScenarioTransaction<GenericTransaction, Account> &
+  Pick<StellarTransaction, "assetReference" | "assetOwner">;
 
 /**
  * Hook flag: ensures we only inject USDC into the test account once,

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/createTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/createTransaction.ts
@@ -28,8 +28,6 @@ export function createTransaction(account: Account | TokenAccount): GenericTrans
         memoType: null,
         useAllAmount: false,
         mode: "send",
-        assetReference: "",
-        assetOwner: "",
         networkInfo: null,
       };
     case "tezos":

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/estimateMaxSpendable.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/estimateMaxSpendable.ts
@@ -36,6 +36,7 @@ export function genericEstimateMaxSpendable(
       transactionToIntent(
         mainAccount,
         draftTransaction,
+        bridgeApi.getAssetFromToken,
         bridgeApi.computeIntentType,
         coinModuleApi.craftTransactionData,
       ),

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/estimateMaxSpendable.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/estimateMaxSpendable.ts
@@ -37,6 +37,7 @@ export function genericEstimateMaxSpendable(
         mainAccount,
         draftTransaction,
         bridgeApi.getAssetFromToken,
+        bridgeApi.getAssetFromTransaction,
         bridgeApi.computeIntentType,
         coinModuleApi.craftTransactionData,
       ),

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
@@ -15,30 +15,13 @@ export function genericGetTransactionStatus(
     const coinModuleApi = await getCoinModuleApi(account.currency.id, kind);
     const bridgeApi = await getBridgeApi(account.currency, network);
 
+    // Spread so family-specific fields (e.g. stellar `changeTrust` asset) survive for the asset hooks.
     const draftTransaction = {
-      mode: transaction?.mode ?? "send",
-      recipient: transaction.recipient,
+      ...transaction,
+      mode: transaction.mode ?? "send",
       amount: transaction.amount ?? new BigNumber(0),
       useAllAmount: !!transaction.useAllAmount,
-      // Forward the asset carried directly on the transaction (e.g. stellar `changeTrust`, which has
-      // no sub-account yet). These fields are no longer on `GenericTransaction`, hence the `in` reads;
-      // guard the value type to match `transactionToIntent`'s fallback.
-      ...("assetReference" in transaction && typeof transaction.assetReference === "string"
-        ? { assetReference: transaction.assetReference }
-        : {}),
-      ...("assetOwner" in transaction && typeof transaction.assetOwner === "string"
-        ? { assetOwner: transaction.assetOwner }
-        : {}),
       subAccountId: transaction.subAccountId || "",
-      memoType: transaction.memoType || "",
-      memoValue: transaction.memoValue || "",
-      tag: transaction.tag,
-      family: transaction.family,
-      data: transaction.data,
-      type: transaction.type,
-      valAddress: transaction.valAddress,
-      valId: transaction.valId,
-      dstValAddress: transaction.dstValAddress,
     };
 
     const chainSpecificValidation = bridgeApi.getChainSpecificRules;
@@ -54,6 +37,7 @@ export function genericGetTransactionStatus(
       account,
       draftTransaction,
       bridgeApi.getAssetFromToken,
+      bridgeApi.getAssetFromTransaction,
       bridgeApi.computeIntentType,
       coinModuleApi.craftTransactionData,
     );

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
@@ -20,8 +20,15 @@ export function genericGetTransactionStatus(
       recipient: transaction.recipient,
       amount: transaction.amount ?? new BigNumber(0),
       useAllAmount: !!transaction.useAllAmount,
-      assetReference: transaction.assetReference || "",
-      assetOwner: transaction.assetOwner || "",
+      // Forward the asset carried directly on the transaction (e.g. stellar `changeTrust`, which has
+      // no sub-account yet). These fields are no longer on `GenericTransaction`, hence the `in` reads;
+      // guard the value type to match `transactionToIntent`'s fallback.
+      ...("assetReference" in transaction && typeof transaction.assetReference === "string"
+        ? { assetReference: transaction.assetReference }
+        : {}),
+      ...("assetOwner" in transaction && typeof transaction.assetOwner === "string"
+        ? { assetOwner: transaction.assetOwner }
+        : {}),
       subAccountId: transaction.subAccountId || "",
       memoType: transaction.memoType || "",
       memoValue: transaction.memoValue || "",
@@ -46,6 +53,7 @@ export function genericGetTransactionStatus(
     const intent = transactionToIntent(
       account,
       draftTransaction,
+      bridgeApi.getAssetFromToken,
       bridgeApi.computeIntentType,
       coinModuleApi.craftTransactionData,
     );

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
@@ -10,23 +10,11 @@ import {
   transactionToIntent,
 } from "./utils";
 import BigNumber from "bignumber.js";
-import type { AssetInfo, FeeEstimation } from "@ledgerhq/coin-module-framework/api/types";
-import { decodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account/index";
-import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { FeeEstimation } from "@ledgerhq/coin-module-framework/api/types";
 import type { GenericTransaction } from "./types";
 
 function bnEq(a: BigNumber | null | undefined, b: BigNumber | null | undefined): boolean {
   return !a && !b ? true : !a || !b ? false : a.eq(b);
-}
-
-function assetInfosFallback(transaction: GenericTransaction): {
-  assetReference: string;
-  assetOwner: string;
-} {
-  return {
-    assetReference: transaction.assetReference ?? "",
-    assetOwner: transaction.assetOwner ?? "",
-  };
 }
 
 function propagateField(estimation: FeeEstimation, field: string, dest: GenericTransaction): void {
@@ -66,10 +54,6 @@ export function genericPrepareTransaction(
     const coinModuleApi = await getCoinModuleApi(account.currency.id, kind);
     const bridgeApi = await getBridgeApi(account.currency, network);
 
-    const getAssetFromTokenForCurrency = bridgeApi.getAssetFromToken;
-    const { assetReference, assetOwner } = getAssetFromTokenForCurrency
-      ? await getAssetInfos(transaction, account.freshAddress, getAssetFromTokenForCurrency)
-      : assetInfosFallback(transaction);
     const customParametersFees = transaction.customFees?.parameters?.fees;
 
     /**
@@ -88,18 +72,15 @@ export function genericPrepareTransaction(
       }
     }
 
-    // Pass any parameters that help estimating fees
-    // This includes `assetOwner` and `assetReference` that are not used by some apps that only rely on `subAccountId`
-    // TODO Remove `assetOwner` and `assetReference` in order to maintain one unique way of identifying the type of asset
-    // https://ledgerhq.atlassian.net/browse/LIVE-24044
+    // The asset (assetReference/assetOwner) is derived inside transactionToIntent from `subAccountId`
+    // (the single source of truth) via bridgeApi.getAssetFromToken.
     const intent = transactionToIntent(
       account,
       {
         ...transaction,
-        assetOwner,
-        assetReference,
         amount,
       },
+      bridgeApi.getAssetFromToken,
       bridgeApi.computeIntentType,
       coinModuleApi.craftTransactionData,
     );
@@ -130,12 +111,7 @@ export function genericPrepareTransaction(
         : computeUseAllAmount(estimation, getNativeSpendableAfterPending(account));
     }
 
-    if (
-      bnEq(transaction.fees, fees) &&
-      bnEq(transaction.amount, nextAmount) &&
-      (transaction.assetReference ?? "") === assetReference &&
-      (transaction.assetOwner ?? "") === assetOwner
-    ) {
+    if (bnEq(transaction.fees, fees) && bnEq(transaction.amount, nextAmount)) {
       return transaction;
     }
 
@@ -143,8 +119,6 @@ export function genericPrepareTransaction(
       ...transaction,
       fees,
       amount: nextAmount,
-      assetReference,
-      assetOwner,
       customFees: {
         parameters: {
           fees: customParametersFees ? new BigNumber(customParametersFees.toString()) : undefined,
@@ -174,27 +148,4 @@ export function genericPrepareTransaction(
 
     return next;
   };
-}
-
-export async function getAssetInfos(
-  tr: GenericTransaction,
-  owner: string,
-  getAssetFromToken: (token: TokenCurrency, owner: string) => AssetInfo,
-): Promise<{
-  assetReference: string;
-  assetOwner: string;
-}> {
-  if (tr.subAccountId) {
-    const { token } = await decodeTokenAccountId(tr.subAccountId);
-
-    if (!token) return assetInfosFallback(tr);
-
-    const asset = getAssetFromToken(token, owner);
-
-    return {
-      assetOwner: ("assetOwner" in asset && asset.assetOwner) || "",
-      assetReference: ("assetReference" in asset && asset.assetReference) || "",
-    };
-  }
-  return assetInfosFallback(tr);
 }

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
@@ -72,8 +72,6 @@ export function genericPrepareTransaction(
       }
     }
 
-    // The asset (assetReference/assetOwner) is derived inside transactionToIntent from `subAccountId`
-    // (the single source of truth) via bridgeApi.getAssetFromToken.
     const intent = transactionToIntent(
       account,
       {
@@ -81,6 +79,7 @@ export function genericPrepareTransaction(
         amount,
       },
       bridgeApi.getAssetFromToken,
+      bridgeApi.getAssetFromTransaction,
       bridgeApi.computeIntentType,
       coinModuleApi.craftTransactionData,
     );

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
@@ -53,6 +53,7 @@ export const genericSignOperation =
             account,
             { ...transaction },
             bridgeApi.getAssetFromToken,
+            bridgeApi.getAssetFromTransaction,
             bridgeApi.computeIntentType,
             coinModuleApi.craftTransactionData,
           );

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
@@ -52,6 +52,7 @@ export const genericSignOperation =
           const transactionIntent = transactionToIntent(
             account,
             { ...transaction },
+            bridgeApi.getAssetFromToken,
             bridgeApi.computeIntentType,
             coinModuleApi.craftTransactionData,
           );

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/prepareTransaction.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/prepareTransaction.test.ts
@@ -69,6 +69,7 @@ describe("genericPrepareTransaction", () => {
       expect.any(Function),
       undefined,
       undefined,
+      undefined,
     );
   });
 
@@ -465,6 +466,7 @@ describe("genericPrepareTransaction", () => {
         amount: new BigNumber(10),
       },
       getAssetFromToken,
+      undefined,
       undefined,
       undefined,
     );

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/prepareTransaction.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/prepareTransaction.test.ts
@@ -5,7 +5,6 @@ import { transactionToIntent } from "../utils";
 import BigNumber from "bignumber.js";
 import { GenericTransaction } from "../types";
 import { setupMockCryptoAssetsStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
-import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { decodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account/index";
 
 jest.mock("../api", () => ({
@@ -67,6 +66,7 @@ describe("genericPrepareTransaction", () => {
     expect(transactionToIntent).toHaveBeenCalledWith(
       account,
       expect.objectContaining(baseTransaction),
+      expect.any(Function),
       undefined,
       undefined,
     );
@@ -434,20 +434,12 @@ describe("genericPrepareTransaction", () => {
     expect((result as any).amount.toString()).toBe("70");
   });
 
-  it("fills 'assetOwner' and 'assetReference' from 'subAccountId' for retro compatibility", async () => {
-    setupMockCryptoAssetsStore({
-      findTokenById: tokenId =>
-        Promise.resolve(tokenId === "usdc" ? ({ id: tokenId } as TokenCurrency) : undefined),
-    });
+  it("forwards getAssetFromToken to transactionToIntent so the asset is derived from subAccountId", async () => {
     (getCoinModuleApi as jest.Mock).mockReturnValue({
       estimateFees: () => Promise.resolve({ value: 0n }),
     });
-    (getBridgeApi as jest.Mock).mockResolvedValue({
-      getAssetFromToken: jest.fn().mockImplementation((token: TokenCurrency, owner: string) => ({
-        assetOwner: owner,
-        assetReference: token.id,
-      })),
-    });
+    const getAssetFromToken = jest.fn();
+    (getBridgeApi as jest.Mock).mockResolvedValue({ getAssetFromToken });
     const prepareTransaction = genericPrepareTransaction("testnet", "local");
 
     await prepareTransaction(
@@ -471,9 +463,8 @@ describe("genericPrepareTransaction", () => {
       {
         subAccountId: "test-sub-account+usdc",
         amount: new BigNumber(10),
-        assetOwner: "test-account-address",
-        assetReference: "usdc",
       },
+      getAssetFromToken,
       undefined,
       undefined,
     );

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/types.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/types.ts
@@ -73,8 +73,6 @@ export type GenericTransaction = TransactionCommon & {
   data?: Buffer;
   mode?: GenericTransactionMode;
   type?: number | null;
-  assetReference?: string;
-  assetOwner?: string;
   networkInfo?: NetworkInfo | null;
   chainId?: number | null;
   gasLimit?: BigNumber | null;
@@ -105,8 +103,6 @@ export type GenericTransactionRaw = TransactionCommonRaw & {
   data?: string;
   mode?: GenericTransactionMode;
   type?: number | null;
-  assetReference?: string | null;
-  assetOwner?: string | null;
   networkInfo?: NetworkInfoRaw | null;
   chainId?: number | null;
   gasLimit?: string | null;

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -12,7 +12,10 @@ import {
 } from "./utils";
 import { addPendingOperation } from "@ledgerhq/ledger-wallet-framework/account/index";
 import BigNumber from "bignumber.js";
-import type { AssetInfo, Operation as CoreOperation } from "@ledgerhq/coin-module-framework/api/types";
+import type {
+  AssetInfo,
+  Operation as CoreOperation,
+} from "@ledgerhq/coin-module-framework/api/types";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { Account } from "@ledgerhq/types-live";
 import { GenericTransaction, GenericTransactionMode, OperationCommon } from "./types";
@@ -549,6 +552,7 @@ describe("coin-framework utils", () => {
             { currency: { name: "ethereum", units: [{}] } } as Account,
             { mode: "send", type: 2 } as GenericTransaction,
             undefined,
+            undefined,
             computeIntentType,
           ),
         ).toMatchObject({
@@ -582,6 +586,7 @@ describe("coin-framework utils", () => {
             },
           } as unknown as Account,
           { data } as unknown as GenericTransaction,
+          undefined,
           undefined,
           undefined,
           craftTransactionDataMock,
@@ -630,6 +635,7 @@ describe("coin-framework utils", () => {
             },
           } as unknown as Account,
           { data: expectedData } as unknown as GenericTransaction,
+          undefined,
           undefined,
           undefined,
           craftTransactionDataMock,
@@ -723,19 +729,33 @@ describe("coin-framework utils", () => {
         });
       });
 
-      it("reads assetReference/assetOwner off the transaction when there is no subAccountId (stellar changeTrust)", () => {
-        const intent = transactionToIntent(account, {
-          mode: "changeTrust",
-          assetReference: "USDC",
-          assetOwner: "GISSUER",
-        } as unknown as GenericTransaction);
+      it("reads the asset via getAssetFromTransaction when there is no subAccountId (stellar changeTrust)", () => {
+        const getAssetFromTransaction = (tx: Record<string, unknown>): AssetInfo | undefined =>
+          typeof tx.assetReference === "string" && typeof tx.assetOwner === "string"
+            ? {
+                type: "token",
+                assetReference: tx.assetReference,
+                assetOwner: tx.assetOwner,
+                name: tx.assetReference,
+              }
+            : undefined;
+
+        const intent = transactionToIntent(
+          account,
+          {
+            mode: "changeTrust",
+            assetReference: "USDC",
+            assetOwner: "GISSUER",
+          } as unknown as GenericTransaction,
+          undefined,
+          getAssetFromTransaction,
+        );
 
         expect(intent.asset).toEqual({
           type: "token",
           assetReference: "USDC",
-          name: "USDC",
-          unit: { code: "ETH" },
           assetOwner: "GISSUER",
+          name: "USDC",
         });
       });
 
@@ -789,6 +809,7 @@ describe("coin-framework utils", () => {
           } as Account,
           transaction,
           undefined,
+          undefined,
           computeIntentType,
         );
         expect(intent).toMatchObject({
@@ -831,6 +852,7 @@ describe("coin-framework utils", () => {
             },
           } as Account,
           transaction,
+          undefined,
           undefined,
           computeIntentType,
         );

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -12,7 +12,8 @@ import {
 } from "./utils";
 import { addPendingOperation } from "@ledgerhq/ledger-wallet-framework/account/index";
 import BigNumber from "bignumber.js";
-import type { Operation as CoreOperation } from "@ledgerhq/coin-module-framework/api/types";
+import type { AssetInfo, Operation as CoreOperation } from "@ledgerhq/coin-module-framework/api/types";
+import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { Account } from "@ledgerhq/types-live";
 import { GenericTransaction, GenericTransactionMode, OperationCommon } from "./types";
 import * as craftTransactionDataModule from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
@@ -547,6 +548,7 @@ describe("coin-framework utils", () => {
           transactionToIntent(
             { currency: { name: "ethereum", units: [{}] } } as Account,
             { mode: "send", type: 2 } as GenericTransaction,
+            undefined,
             computeIntentType,
           ),
         ).toMatchObject({
@@ -580,6 +582,7 @@ describe("coin-framework utils", () => {
             },
           } as unknown as Account,
           { data } as unknown as GenericTransaction,
+          undefined,
           undefined,
           craftTransactionDataMock,
         );
@@ -627,6 +630,7 @@ describe("coin-framework utils", () => {
             },
           } as unknown as Account,
           { data: expectedData } as unknown as GenericTransaction,
+          undefined,
           undefined,
           craftTransactionDataMock,
         );
@@ -678,6 +682,77 @@ describe("coin-framework utils", () => {
       });
     });
 
+    describe("asset", () => {
+      const subAccountId = "js:2:ethereum:0xacc:+0xA0b8";
+      const token = {
+        tokenType: "erc20",
+        name: "USD Coin",
+        contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      };
+      const account = {
+        freshAddress: "sender-address",
+        currency: { name: "ethereum", units: [{ code: "ETH" }] },
+        subAccounts: [{ id: subAccountId, type: "TokenAccount", token }],
+      } as unknown as Account;
+
+      it("derives the token asset from subAccountId via getAssetFromToken (token send)", () => {
+        const getAssetFromToken = jest.fn(
+          (tkn: TokenCurrency, owner: string): AssetInfo =>
+            ({
+              type: tkn.tokenType,
+              assetReference: tkn.contractAddress,
+              assetOwner: owner,
+              name: tkn.name,
+              unit: { code: "USDC" },
+            }) as unknown as AssetInfo,
+        );
+
+        const intent = transactionToIntent(
+          account,
+          { subAccountId, mode: "send" } as unknown as GenericTransaction,
+          getAssetFromToken,
+        );
+
+        expect(getAssetFromToken).toHaveBeenCalledWith(token, "sender-address");
+        expect(intent.asset).toEqual({
+          type: "erc20",
+          assetReference: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          assetOwner: "sender-address",
+          name: "USD Coin",
+          unit: { code: "USDC" },
+        });
+      });
+
+      it("reads assetReference/assetOwner off the transaction when there is no subAccountId (stellar changeTrust)", () => {
+        const intent = transactionToIntent(account, {
+          mode: "changeTrust",
+          assetReference: "USDC",
+          assetOwner: "GISSUER",
+        } as unknown as GenericTransaction);
+
+        expect(intent.asset).toEqual({
+          type: "token",
+          assetReference: "USDC",
+          name: "USDC",
+          unit: { code: "ETH" },
+          assetOwner: "GISSUER",
+        });
+      });
+
+      it("keeps the native asset when subAccountId has no getAssetFromToken and no inline asset", () => {
+        const intent = transactionToIntent(account, {
+          subAccountId,
+          mode: "send",
+        } as unknown as GenericTransaction);
+
+        expect(intent.asset).toEqual({
+          type: "native",
+          name: "ethereum",
+          unit: { code: "ETH" },
+        });
+      });
+    });
+
     it.each([
       "delegate",
       "undelegate",
@@ -713,6 +788,7 @@ describe("coin-framework utils", () => {
             },
           } as Account,
           transaction,
+          undefined,
           computeIntentType,
         );
         expect(intent).toMatchObject({
@@ -755,6 +831,7 @@ describe("coin-framework utils", () => {
             },
           } as Account,
           transaction,
+          undefined,
           computeIntentType,
         );
 

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -446,17 +446,20 @@ function defaultComputeIntentType(transaction: GenericTransaction): string {
  *
  * @param account - The account initiating the transaction. Contains details such as the sender's address.
  * @param transaction - The transaction object containing details about the operation to be performed.
- *   - `assetOwner` (optional): The issuer of the asset, if applicable.
- *   - `assetReference` (optional): The code of the asset, if applicable.
- *   - `mode` (optional): The mode of the transaction, e.g., "changetrust" or "send".
+ *   - `subAccountId` (optional): identifies the token being transacted; the single source of truth for token sends.
+ *   - `mode` (optional): The mode of the transaction, e.g., "changeTrust" or "send".
  *   - `fees` (optional): The fees associated with the transaction.
  *   - `memoType` (optional): The type of memo to attach to the transaction.
  *   - `memoValue` (optional): The value of the memo to attach to the transaction.
+ * @param getAssetFromToken - An optional function (from the family BridgeApi) that derives the asset
+ *   (assetReference/assetOwner) from a TokenAccount's token, for token sends identified by `subAccountId`.
  * @param computeIntentType - An optional function to compute the intent type that supersedes the default implementation if present
  *
  * @returns A `TransactionIntent` object containing the standardized representation of the transaction.
  *   - Includes details such as type, sender, recipient, amount, fees, asset, and an optional memo.
- *   - If `assetReference` and `assetOwner` are provided, the asset is represented as a token.
+ *   - For a token send, the asset is derived from the `subAccountId`'s TokenAccount via `getAssetFromToken`.
+ *   - When no sub-account exists yet (e.g. stellar `changeTrust`), the asset is read from the family
+ *     transaction's own `assetReference`/`assetOwner` fields.
  *   - If `memoType` and `memoValue` are provided, a memo is included; otherwise, a default memo of type "NO_MEMO" is added.
  *
  * @throws An error if the transaction mode is unsupported.
@@ -464,6 +467,7 @@ function defaultComputeIntentType(transaction: GenericTransaction): string {
 export function transactionToIntent(
   account: Account,
   transaction: GenericTransaction,
+  getAssetFromToken?: (token: TokenCurrency, owner: string) => AssetInfo,
   computeIntentType?: (transaction: GenericTransaction) => string,
   craftTransactionData?: (intent: TransactionIntent) => TxData,
 ): GenericCoinFrameworkTransactionIntent {
@@ -487,19 +491,37 @@ export function transactionToIntent(
         : undefined,
     ...getDelegationIntentFields(delegationMode, transaction),
   };
-  if (transaction.assetReference && transaction.assetOwner) {
-    const { subAccountId } = transaction;
-    const { subAccounts } = account;
+  const { subAccountId } = transaction;
+  const tokenAccount = subAccountId
+    ? account.subAccounts?.find(ta => ta.id === subAccountId)
+    : undefined;
 
-    const tokenAccount = subAccountId ? subAccounts?.find(ta => ta.id === subAccountId) : null;
+  if (tokenAccount?.type === "TokenAccount" && getAssetFromToken) {
+    // Token send: `subAccountId` is the single source of truth. The asset (assetReference/assetOwner)
+    // is derived from the TokenAccount's token, not carried on the transaction anymore.
+    res.asset = getAssetFromToken(tokenAccount.token, account.freshAddress);
+  } else {
+    // Fallback for families that carry the asset directly on the transaction when no sub-account
+    // exists yet (e.g. stellar `changeTrust`/AddAsset). These fields are no longer declared on
+    // `GenericTransaction`, so we read them via `in` narrowing off the concrete family transaction.
+    const assetReference =
+      "assetReference" in transaction && typeof transaction.assetReference === "string"
+        ? transaction.assetReference
+        : undefined;
+    const assetOwner =
+      "assetOwner" in transaction && typeof transaction.assetOwner === "string"
+        ? transaction.assetOwner
+        : undefined;
 
-    res.asset = {
-      type: tokenAccount?.token.tokenType ?? "token",
-      assetReference: transaction.assetReference,
-      name: tokenAccount?.token.name ?? transaction.assetReference, // NOTE: for stellar, assetReference = tokenAccount.name, this is futureproofing
-      unit: account.currency.units[0],
-      assetOwner: transaction.assetOwner,
-    };
+    if (assetReference && assetOwner) {
+      res.asset = {
+        type: "token",
+        assetReference,
+        name: assetReference,
+        unit: account.currency.units[0],
+        assetOwner,
+      };
+    }
   }
 
   if (typeof transaction.tag === "number") {
@@ -558,16 +580,18 @@ function toGenericTransactionRaw(transaction: GenericTransaction): GenericTransa
     }
   }
 
-  const stringFieldsToPropagate = [
-    "memoType",
-    "memoValue",
-    "assetReference",
-    "assetOwner",
-  ] as const;
+  const stringFieldsToPropagate = ["memoType", "memoValue"] as const;
   for (const field of stringFieldsToPropagate) {
     if (field in transaction) {
       raw[field] = transaction[field];
     }
+  }
+
+  // `subAccountId` is the single source of truth identifying a token. Serializing it lets the
+  // edit-transaction flow restore the token from the raw (e.g. EVM), without relying on
+  // assetReference/assetOwner anymore. Only persist a meaningful (non-empty) value.
+  if (transaction.subAccountId) {
+    raw.subAccountId = transaction.subAccountId;
   }
 
   const numberFieldsToPropagate = ["tag", "type", "chainId"] as const;

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -451,15 +451,16 @@ function defaultComputeIntentType(transaction: GenericTransaction): string {
  *   - `fees` (optional): The fees associated with the transaction.
  *   - `memoType` (optional): The type of memo to attach to the transaction.
  *   - `memoValue` (optional): The value of the memo to attach to the transaction.
- * @param getAssetFromToken - An optional function (from the family BridgeApi) that derives the asset
- *   (assetReference/assetOwner) from a TokenAccount's token, for token sends identified by `subAccountId`.
+ * @param getAssetFromToken - Optional family hook that resolves the asset from a TokenAccount's token,
+ *   for token sends identified by `subAccountId`.
+ * @param getAssetFromTransaction - Optional family hook that resolves the asset carried on the transaction
+ *   itself, for flows without a sub-account yet (e.g. stellar `changeTrust`).
  * @param computeIntentType - An optional function to compute the intent type that supersedes the default implementation if present
  *
  * @returns A `TransactionIntent` object containing the standardized representation of the transaction.
  *   - Includes details such as type, sender, recipient, amount, fees, asset, and an optional memo.
  *   - For a token send, the asset is derived from the `subAccountId`'s TokenAccount via `getAssetFromToken`.
- *   - When no sub-account exists yet (e.g. stellar `changeTrust`), the asset is read from the family
- *     transaction's own `assetReference`/`assetOwner` fields.
+ *   - When no sub-account exists yet (e.g. stellar `changeTrust`), the asset comes from `getAssetFromTransaction`.
  *   - If `memoType` and `memoValue` are provided, a memo is included; otherwise, a default memo of type "NO_MEMO" is added.
  *
  * @throws An error if the transaction mode is unsupported.
@@ -468,6 +469,7 @@ export function transactionToIntent(
   account: Account,
   transaction: GenericTransaction,
   getAssetFromToken?: (token: TokenCurrency, owner: string) => AssetInfo,
+  getAssetFromTransaction?: (transaction: Record<string, unknown>) => AssetInfo | undefined,
   computeIntentType?: (transaction: GenericTransaction) => string,
   craftTransactionData?: (intent: TransactionIntent) => TxData,
 ): GenericCoinFrameworkTransactionIntent {
@@ -496,32 +498,12 @@ export function transactionToIntent(
     ? account.subAccounts?.find(ta => ta.id === subAccountId)
     : undefined;
 
-  if (tokenAccount?.type === "TokenAccount" && getAssetFromToken) {
-    // Token send: `subAccountId` is the single source of truth. The asset (assetReference/assetOwner)
-    // is derived from the TokenAccount's token, not carried on the transaction anymore.
-    res.asset = getAssetFromToken(tokenAccount.token, account.freshAddress);
+  if (tokenAccount?.type === "TokenAccount") {
+    // Token send: asset derived from the sub-account's token.
+    res.asset = getAssetFromToken?.(tokenAccount.token, account.freshAddress) ?? res.asset;
   } else {
-    // Fallback for families that carry the asset directly on the transaction when no sub-account
-    // exists yet (e.g. stellar `changeTrust`/AddAsset). These fields are no longer declared on
-    // `GenericTransaction`, so we read them via `in` narrowing off the concrete family transaction.
-    const assetReference =
-      "assetReference" in transaction && typeof transaction.assetReference === "string"
-        ? transaction.assetReference
-        : undefined;
-    const assetOwner =
-      "assetOwner" in transaction && typeof transaction.assetOwner === "string"
-        ? transaction.assetOwner
-        : undefined;
-
-    if (assetReference && assetOwner) {
-      res.asset = {
-        type: "token",
-        assetReference,
-        name: assetReference,
-        unit: account.currency.units[0],
-        assetOwner,
-      };
-    }
+    // No sub-account yet (e.g. stellar changeTrust): the family resolves the asset from the transaction.
+    res.asset = getAssetFromTransaction?.(transaction) ?? res.asset;
   }
 
   if (typeof transaction.tag === "number") {
@@ -587,9 +569,7 @@ function toGenericTransactionRaw(transaction: GenericTransaction): GenericTransa
     }
   }
 
-  // `subAccountId` is the single source of truth identifying a token. Serializing it lets the
-  // edit-transaction flow restore the token from the raw (e.g. EVM), without relying on
-  // assetReference/assetOwner anymore. Only persist a meaningful (non-empty) value.
+  // Persist the token identifier so edit-transaction can restore it from the raw (e.g. EVM).
   if (transaction.subAccountId) {
     raw.subAccountId = transaction.subAccountId;
   }

--- a/libs/ledger-live-common/src/families/evm/transaction.test.ts
+++ b/libs/ledger-live-common/src/families/evm/transaction.test.ts
@@ -96,54 +96,47 @@ describe("EVM Family", () => {
         });
       });
 
-      describe("with token fields (assetReference / assetOwner)", () => {
+      describe("with a token sub-account (subAccountId is the single source of truth)", () => {
+        const SUB_ACCOUNT_ID =
+          "js:2:ethereum:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045:+0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
         const CONTRACT = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
         const OWNER = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
 
-        it("should deserialize both assetReference and assetOwner when present", () => {
-          expect(
-            fromTransactionRaw({ ...rawEip1559Tx, assetReference: CONTRACT, assetOwner: OWNER }),
-          ).toEqual({ ...eip1559Tx, assetReference: CONTRACT, assetOwner: OWNER });
+        it("restores the token identity from subAccountId (eip1559)", () => {
+          expect(fromTransactionRaw({ ...rawEip1559Tx, subAccountId: SUB_ACCOUNT_ID })).toEqual({
+            ...eip1559Tx,
+            subAccountId: SUB_ACCOUNT_ID,
+          });
         });
 
-        it("should deserialize only assetReference when assetOwner is absent", () => {
-          expect(fromTransactionRaw({ ...rawEip1559Tx, assetReference: CONTRACT })).toEqual({
-            ...eip1559Tx,
+        it("restores the token identity from subAccountId (legacy)", () => {
+          expect(fromTransactionRaw({ ...rawLegacyTx, subAccountId: SUB_ACCOUNT_ID })).toEqual({
+            ...legacyTx,
+            subAccountId: SUB_ACCOUNT_ID,
+          });
+        });
+
+        it("ignores legacy assetReference/assetOwner when subAccountId is present", () => {
+          const tx = fromTransactionRaw({
+            ...rawEip1559Tx,
+            subAccountId: SUB_ACCOUNT_ID,
             assetReference: CONTRACT,
-          });
-        });
-
-        it("should deserialize only assetOwner when assetReference is absent", () => {
-          expect(fromTransactionRaw({ ...rawEip1559Tx, assetOwner: OWNER })).toEqual({
-            ...eip1559Tx,
             assetOwner: OWNER,
-          });
+          } as any);
+          expect(tx).not.toHaveProperty("assetReference");
+          expect(tx).not.toHaveProperty("assetOwner");
+          expect(tx.subAccountId).toBe(SUB_ACCOUNT_ID);
         });
 
-        it("should not set assetReference when absent from raw", () => {
-          expect(fromTransactionRaw(rawEip1559Tx)).not.toHaveProperty("assetReference");
-        });
-
-        it("should not set assetOwner when absent from raw", () => {
-          expect(fromTransactionRaw(rawEip1559Tx)).not.toHaveProperty("assetOwner");
-        });
-
-        it("should not set assetReference when raw value is an empty string", () => {
-          expect(
-            fromTransactionRaw({ ...rawEip1559Tx, assetReference: "" } as any),
-          ).not.toHaveProperty("assetReference");
-        });
-
-        it("should not set assetOwner when raw value is an empty string", () => {
-          expect(fromTransactionRaw({ ...rawEip1559Tx, assetOwner: "" } as any)).not.toHaveProperty(
-            "assetOwner",
-          );
-        });
-
-        it("should deserialize both fields on a legacy transaction", () => {
-          expect(
-            fromTransactionRaw({ ...rawLegacyTx, assetReference: CONTRACT, assetOwner: OWNER }),
-          ).toEqual({ ...legacyTx, assetReference: CONTRACT, assetOwner: OWNER });
+        it("restores legacy assetReference/assetOwner for pre-upgrade raws without subAccountId", () => {
+          const tx = fromTransactionRaw({
+            ...rawEip1559Tx,
+            subAccountId: undefined,
+            assetReference: CONTRACT,
+            assetOwner: OWNER,
+          } as any) as any;
+          expect(tx.assetReference).toBe(CONTRACT);
+          expect(tx.assetOwner).toBe(OWNER);
         });
       });
     });

--- a/libs/ledger-live-common/src/families/evm/transaction.ts
+++ b/libs/ledger-live-common/src/families/evm/transaction.ts
@@ -94,15 +94,23 @@ export const fromTransactionRaw = (rawTx: EvmTransactionRaw): EvmTransaction => 
     type: rawTx.type ?? 0, // if rawTx.type is undefined, transaction will be considered legacy and therefore type 0
   };
 
-  // Restore assetReference and assetOwner when present in the raw.
-  // These fields can be present in the transactionRaw produced by `toGenericTransactionRaw`
-  // (used in buildOptimisticOperation), so we map them back to the transaction here to
-  // support the edit-transaction flow on previously-broadcast token operations.
-  if (rawTx.assetReference) {
-    (tx as Record<string, unknown>).assetReference = rawTx.assetReference;
-  }
-  if (rawTx.assetOwner) {
-    (tx as Record<string, unknown>).assetOwner = rawTx.assetOwner;
+  // The token identity is restored from `subAccountId` (carried by `...common` via
+  // fromTransactionCommonRaw and serialized in `toGenericTransactionRaw`), which is the single
+  // source of truth. This supports the edit-transaction flow on previously-broadcast token operations.
+  //
+  // Backward-compat (LIVE-24044): pre-upgrade pending token ops may only have `assetReference`/`assetOwner`
+  // on the raw. New raws rely on `subAccountId`; only fall back to legacy fields when it's absent. Remove
+  // once pre-upgrade pending ops can no longer exist (they self-heal on the next sync).
+  if (!rawTx.subAccountId) {
+    const legacyRaw = rawTx as Record<string, unknown>;
+    // Only restore non-empty legacy values, matching the previous truthy check (an empty string is
+    // not a meaningful token identifier and would just add noise).
+    if (typeof legacyRaw.assetReference === "string" && legacyRaw.assetReference) {
+      (tx as Record<string, unknown>).assetReference = legacyRaw.assetReference;
+    }
+    if (typeof legacyRaw.assetOwner === "string" && legacyRaw.assetOwner) {
+      (tx as Record<string, unknown>).assetOwner = legacyRaw.assetOwner;
+    }
   }
 
   if (rawTx.data) {

--- a/libs/ledger-live-common/src/families/evm/transaction.ts
+++ b/libs/ledger-live-common/src/families/evm/transaction.ts
@@ -94,17 +94,11 @@ export const fromTransactionRaw = (rawTx: EvmTransactionRaw): EvmTransaction => 
     type: rawTx.type ?? 0, // if rawTx.type is undefined, transaction will be considered legacy and therefore type 0
   };
 
-  // The token identity is restored from `subAccountId` (carried by `...common` via
-  // fromTransactionCommonRaw and serialized in `toGenericTransactionRaw`), which is the single
-  // source of truth. This supports the edit-transaction flow on previously-broadcast token operations.
-  //
-  // Backward-compat (LIVE-24044): pre-upgrade pending token ops may only have `assetReference`/`assetOwner`
-  // on the raw. New raws rely on `subAccountId`; only fall back to legacy fields when it's absent. Remove
-  // once pre-upgrade pending ops can no longer exist (they self-heal on the next sync).
+  // The token is restored from `subAccountId` (via `...common`). Backward-compat (LIVE-24044): pre-upgrade
+  // pending ops only had `assetReference`/`assetOwner` on the raw, so fall back to them when `subAccountId`
+  // is absent. Removable once no pre-upgrade pending op can remain.
   if (!rawTx.subAccountId) {
     const legacyRaw = rawTx as Record<string, unknown>;
-    // Only restore non-empty legacy values, matching the previous truthy check (an empty string is
-    // not a meaningful token identifier and would just add noise).
     if (typeof legacyRaw.assetReference === "string" && legacyRaw.assetReference) {
       (tx as Record<string, unknown>).assetReference = legacyRaw.assetReference;
     }

--- a/libs/ledger-live-common/src/families/stellar/bridge/api.ts
+++ b/libs/ledger-live-common/src/families/stellar/bridge/api.ts
@@ -4,6 +4,7 @@ import type { BridgeApi, ChainSpecificRules } from "@ledgerhq/ledger-wallet-fram
 import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { StellarBurnAddressError } from "@ledgerhq/coin-stellar/types";
 import { STELLAR_BURN_ADDRESS } from "@ledgerhq/coin-stellar/logic";
+import type { Transaction } from "../types";
 
 export const getChainSpecificRules: ChainSpecificRules = {
   getAccountShape: (address: string) => {
@@ -43,8 +44,17 @@ export function getAssetFromToken(token: TokenCurrency): AssetInfo {
   };
 }
 
+// changeTrust has no sub-account yet: resolve the asset from the transaction (code = name, issuer = owner).
+export function getAssetFromTransaction(transaction: Record<string, unknown>): AssetInfo | undefined {
+  const { assetReference, assetOwner } = transaction as Transaction;
+  return assetReference && assetOwner
+    ? { type: "token", assetReference, assetOwner, name: assetReference }
+    : undefined;
+}
+
 export default {
   getTokenFromAsset,
   getAssetFromToken,
+  getAssetFromTransaction,
   getChainSpecificRules,
 } satisfies BridgeApi;

--- a/libs/ledger-live-common/src/families/stellar/deviceTransactionConfig.test.ts
+++ b/libs/ledger-live-common/src/families/stellar/deviceTransactionConfig.test.ts
@@ -3,7 +3,7 @@ import getDeviceTransactionConfig from "./deviceTransactionConfig";
 
 describe("getDeviceTransactionConfig", () => {
   const baseParams = {
-    account: {} as any,
+    account: { type: "Account", subAccounts: [] } as any,
     parentAccount: null,
     transaction: {} as any,
   };
@@ -40,7 +40,7 @@ describe("getDeviceTransactionConfig", () => {
     ]);
   });
 
-  it("adds asset fields when asset reference and owner are provided", async () => {
+  it("adds asset fields carried on the transaction (changeTrust, no sub-account)", async () => {
     const fields = await getDeviceTransactionConfig({
       ...baseParams,
       transaction: {
@@ -56,8 +56,37 @@ describe("getDeviceTransactionConfig", () => {
     expect(fields).toEqual([
       { type: "stellar.network", label: "Network" },
       { type: "amount", label: "Amount" },
-      { type: "stellar.assetCode", label: "Asset" },
-      { type: "stellar.assetIssuer", label: "Asset issuer" },
+      { type: "stellar.assetCode", label: "Asset", value: "USDC" },
+      { type: "stellar.assetIssuer", label: "Asset issuer", value: "GISSUER" },
+      { type: "stellar.memo", label: "Memo" },
+    ]);
+  });
+
+  it("derives asset fields from the sub-account token for a token send (subAccountId)", async () => {
+    const fields = await getDeviceTransactionConfig({
+      ...baseParams,
+      account: {
+        type: "Account",
+        subAccounts: [
+          {
+            id: "sub-usdc",
+            type: "TokenAccount",
+            token: { name: "USDC", contractAddress: "GISSUER" },
+          },
+        ],
+      } as any,
+      transaction: { subAccountId: "sub-usdc" } as any,
+      status: {
+        amount: new BigNumber(1),
+        estimatedFees: new BigNumber(0),
+      } as any,
+    });
+
+    expect(fields).toEqual([
+      { type: "stellar.network", label: "Network" },
+      { type: "amount", label: "Amount" },
+      { type: "stellar.assetCode", label: "Asset", value: "USDC" },
+      { type: "stellar.assetIssuer", label: "Asset issuer", value: "GISSUER" },
       { type: "stellar.memo", label: "Memo" },
     ]);
   });

--- a/libs/ledger-live-common/src/families/stellar/deviceTransactionConfig.ts
+++ b/libs/ledger-live-common/src/families/stellar/deviceTransactionConfig.ts
@@ -1,5 +1,6 @@
 import type { CommonDeviceTransactionField as DeviceTransactionField } from "@ledgerhq/ledger-wallet-framework/transaction/common";
 import type { AccountLike, Account } from "@ledgerhq/types-live";
+import { getMainAccount } from "../../account";
 import type { Transaction, TransactionStatus } from "./types";
 
 export type ExtraDeviceTransactionField =
@@ -14,13 +15,17 @@ export type ExtraDeviceTransactionField =
   | {
       type: "stellar.assetCode";
       label: string;
+      value: string;
     }
   | {
       type: "stellar.assetIssuer";
       label: string;
+      value: string;
     };
 
 async function getDeviceTransactionConfig({
+  account,
+  parentAccount,
   status: { amount, estimatedFees },
   transaction,
 }: {
@@ -29,7 +34,17 @@ async function getDeviceTransactionConfig({
   transaction: Transaction;
   status: TransactionStatus;
 }): Promise<Array<DeviceTransactionField | ExtraDeviceTransactionField>> {
-  const { assetReference, assetOwner } = transaction;
+  // The token asset is derived from `subAccountId` (single source of truth) for a token send,
+  // or from the transaction itself for changeTrust (no sub-account yet). For stellar,
+  // token.name = asset code and token.contractAddress = asset issuer (see bridge/api.ts).
+  const mainAccount = getMainAccount(account, parentAccount);
+  const subAccount = transaction.subAccountId
+    ? mainAccount.subAccounts?.find(a => a.id === transaction.subAccountId)
+    : undefined;
+  const { assetReference, assetOwner } =
+    subAccount?.type === "TokenAccount"
+      ? { assetReference: subAccount.token.name, assetOwner: subAccount.token.contractAddress }
+      : { assetReference: transaction.assetReference, assetOwner: transaction.assetOwner };
 
   const fields: Array<DeviceTransactionField | ExtraDeviceTransactionField> = [
     {
@@ -49,10 +64,12 @@ async function getDeviceTransactionConfig({
     fields.push({
       type: "stellar.assetCode",
       label: "Asset",
+      value: assetReference,
     });
     fields.push({
       type: "stellar.assetIssuer",
       label: "Asset issuer",
+      value: assetOwner,
     });
   }
 

--- a/libs/ledger-live-common/src/families/stellar/deviceTransactionConfig.ts
+++ b/libs/ledger-live-common/src/families/stellar/deviceTransactionConfig.ts
@@ -34,9 +34,7 @@ async function getDeviceTransactionConfig({
   transaction: Transaction;
   status: TransactionStatus;
 }): Promise<Array<DeviceTransactionField | ExtraDeviceTransactionField>> {
-  // The token asset is derived from `subAccountId` (single source of truth) for a token send,
-  // or from the transaction itself for changeTrust (no sub-account yet). For stellar,
-  // token.name = asset code and token.contractAddress = asset issuer (see bridge/api.ts).
+  // Token send: asset from the sub-account's token; changeTrust: from the transaction.
   const mainAccount = getMainAccount(account, parentAccount);
   const subAccount = transaction.subAccountId
     ? mainAccount.subAccounts?.find(a => a.id === transaction.subAccountId)

--- a/libs/ledger-wallet-framework/src/api/types.ts
+++ b/libs/ledger-wallet-framework/src/api/types.ts
@@ -13,6 +13,8 @@ export type BridgeApi = {
   getChainSpecificRules?: ChainSpecificRules;
   getTokenFromAsset?: (asset: AssetInfo) => Promise<TokenCurrency | undefined>;
   getAssetFromToken?: (token: TokenCurrency, owner: string) => AssetInfo;
+  /** Resolves the asset from a family transaction that has no sub-account yet (e.g. stellar `changeTrust`). */
+  getAssetFromTransaction?: (transaction: Record<string, unknown>) => AssetInfo | undefined;
   computeIntentType?: (transaction: Record<string, unknown>) => string;
   refreshOperations?: (operations: LiveOperation[]) => Promise<LiveOperation[]>;
   validateTransaction?: (signature: string) => Promise<{ error: Error | undefined }>;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Token send on generic-bridge families (evm, xrp, tezos, stellar): intent `asset`, status/fees and signature
  - Stellar `changeTrust` / AddAsset flow (desktop + mobile): asset still resolved, `@ledgerhq/coin-stellar` must not throw
  - Stellar token-send device confirmation: `Asset` / `Asset issuer` fields still displayed (now derived from the sub-account)
  - EVM edit-transaction on a pending token operation: token restored via `subAccountId`

### 📝 Description

The generic coin framework carried **three** ways to identify a token on a transaction: `subAccountId`, `assetReference` and `assetOwner`. For a token send, `assetReference`/`assetOwner` are fully rededucible from the `TokenAccount` (via `subAccountId`), so this was a multiple-source-of-truth.

This PR makes `subAccountId` the single source of truth and removes `assetReference`/`assetOwner` from the shared `GenericTransaction` / `GenericTransactionRaw` types:

- `transactionToIntent` derives the token asset from the sub-account's token via `bridgeApi.getAssetFromToken`.
- `toGenericTransactionRaw` serializes `subAccountId` so the edit-transaction flow (e.g. EVM) restores the token without those fields; the EVM raw-restore block and the vestigial `coin-evm` `TransactionRaw` fields are removed (a documented backward-compat fallback keeps pre-upgrade pending token ops working).
- The redundant plumbing (`getAssetInfos`/`assetInfosFallback`, spreads, `next` writes) is dropped from `prepareTransaction`, `getTransactionStatus`, `createTransaction`.

**Stellar `changeTrust` (Add asset) — the one flow where these fields aren't redundant:** it has no `subAccountId` yet (the token sub-account doesn't exist until the trustline is created), and `@ledgerhq/coin-stellar` reads the asset from the intent. So Stellar keeps `assetReference`/`assetOwner` on its **own** `Transaction` type (not on `GenericTransaction`).

To handle that without the generic code ever touching those fields, a new **optional `BridgeApi` hook `getAssetFromTransaction`** is added: the generic `transactionToIntent` calls it, and **Stellar** implements it by reading its own transaction. This follows the existing `BridgeApi` extension pattern (e.g. `getChainSpecificRules`, also implemented only by Stellar) — the generic bridge stays 100% `subAccountId`-based, Stellar-specific logic lives in Stellar. Device confirmation (`deviceTransactionConfig`, `TransactionConfirmFields` desktop + mobile) derives the token asset from the sub-account for token sends, avoiding a display regression.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-24044](https://ledgerhq.atlassian.net/browse/LIVE-24044)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-24044]: https://ledgerhq.atlassian.net/browse/LIVE-24044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ