### PR TITLE
[LWD] fix(desktop): filter blacklisted tokens from CryptoAddresses asset cell

### DIFF
--- a/.changeset/strong-parents-rule.md
+++ b/.changeset/strong-parents-rule.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix CryptoAddresses asset cell showing blacklisted tokens

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoDataTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoDataTable.tsx
@@ -8,6 +8,7 @@ import { accountNameWithDefaultSelector } from "@ledgerhq/live-wallet/store";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { useCalculateCountervalueCallback } from "~/renderer/actions/general";
 import { walletSelector } from "~/renderer/reducers/wallet";
+import { blacklistedTokenIdsSelector } from "~/renderer/reducers/settings";
 import type { ColumnDef, Row, SortingState, Updater } from "@tanstack/react-table";
 import { track } from "~/renderer/analytics/segment";
 import { CRYPTO_TRACKING_PAGE_NAME } from "../../../constants";
@@ -40,6 +41,7 @@ export function useCryptoDataTable({
   const { t } = useTranslation();
   const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
   const walletState = useSelector(walletSelector);
+  const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
   const calculateCountervalue = useCalculateCountervalueCallback();
   const syncPhase = useSyncPhase();
   const isSyncing = syncPhase === "syncing";
@@ -110,7 +112,9 @@ export function useCryptoDataTable({
               header: t("cryptoAddresses.table.columns.asset"),
               enableSorting: false,
               cell: ({ row }: { row: Row<AccountLike> }) => (
-                <AccountAssetsCell currencies={getAccountAssetsCurrencies(row.original)} />
+                <AccountAssetsCell
+                  currencies={getAccountAssetsCurrencies(row.original, blacklistedTokenIds)}
+                />
               ),
               meta: { align: "end" },
             } satisfies ColumnDef<AccountLike>,
@@ -156,6 +160,7 @@ export function useCryptoDataTable({
       getSortCountervalue,
       aggregatedDataByAccountId,
       isSyncing,
+      blacklistedTokenIds,
     ],
   );
 

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/__tests__/getAccountAssetsCurrencies.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/__tests__/getAccountAssetsCurrencies.test.ts
@@ -33,4 +33,17 @@ describe("getAccountAssetsCurrencies", () => {
 
     expect(getAccountAssetsCurrencies(parent)).toEqual([parent.subAccounts![0].token]);
   });
+
+  it("omits blacklisted token sub-accounts", () => {
+    const tokenAccount = ETH_ACCOUNT_WITH_USDC.subAccounts![0];
+    const result = getAccountAssetsCurrencies(ETH_ACCOUNT_WITH_USDC, [tokenAccount.token.id]);
+    expect(result).toEqual([ethereumCurrency]);
+  });
+
+  it("falls back to the parent currency when all sub-accounts are blacklisted", () => {
+    const tokenAccount = ETH_ACCOUNT_WITH_USDC.subAccounts![0];
+    const parentWithZeroBalance = { ...ETH_ACCOUNT_WITH_USDC, balance: new BigNumber(0) };
+    const result = getAccountAssetsCurrencies(parentWithZeroBalance, [tokenAccount.token.id]);
+    expect(result).toEqual([ethereumCurrency]);
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/getAccountAssetsCurrencies.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/getAccountAssetsCurrencies.ts
@@ -4,12 +4,20 @@ import type { AccountLike } from "@ledgerhq/types-live";
 
 export type AccountAssetCurrency = CryptoCurrency | TokenCurrency;
 
-export function getAccountAssetsCurrencies(account: AccountLike): AccountAssetCurrency[] {
+export function getAccountAssetsCurrencies(
+  account: AccountLike,
+  blacklistedTokenIds?: readonly string[],
+): AccountAssetCurrency[] {
   if (account.type === "TokenAccount") {
     return [account.token];
   }
 
-  const subs = listSubAccounts(account);
+  const allSubs = listSubAccounts(account);
+  const blacklistedTokenIdsSet = blacklistedTokenIds?.length ? new Set(blacklistedTokenIds) : null;
+  const subs = blacklistedTokenIdsSet
+    ? allSubs.filter(sub => !blacklistedTokenIdsSet.has(sub.token.id))
+    : allSubs;
+
   if (subs.length === 0) {
     return [account.currency];
   }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - The `AccountAssetsCell` in the CryptoAddresses table no longer displays tokens the user has hidden (blacklisted)
  - Existing behaviour for non-blacklisted accounts is unchanged

### 📝 Description

The `AccountAssetsCell` in the CryptoAddresses table was showing all sub-account tokens, including those the user had explicitly hidden via the blacklist setting.

`getAccountAssetsCurrencies` now accepts an optional `blacklistedTokenIds` parameter. `useCryptoDataTable` reads the blacklist from Redux state and passes it through, so hidden tokens are filtered out before the cell renders.


https://github.com/user-attachments/assets/e368de76-69ee-40b0-8539-32726ffdd7cb



### ❓ Context

- **JIRA or GitHub link**: [LIVE-34191](https://ledgerhq.atlassian.net/browse/LIVE-34191)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34191]: https://ledgerhq.atlassian.net/browse/LIVE-34191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ