### PR TITLE
[LWDM] fix(llc): support `REDELEGATE` optimistic operations

### DIFF
--- a/.changeset/silent-zebras-nail.md
+++ b/.changeset/silent-zebras-nail.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix(llc): support `REDELEGATE` optimistic operations

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -228,6 +228,17 @@ describe("coin-framework utils", () => {
       ],
       [
         "coin",
+        "redelegate",
+        {},
+        {
+          parentType: "REDELEGATE",
+          subType: undefined,
+          parentValue: new BigNumber(50),
+          parentRecipient: "recipient-address",
+        },
+      ],
+      [
+        "coin",
         "stake",
         {},
         {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -655,8 +655,10 @@ export const buildOptimisticOperation = (
       type = "OPT_IN";
       break;
     case "delegate":
-    case "redelegate":
       type = "DELEGATE";
+      break;
+    case "redelegate":
+      type = "REDELEGATE";
       break;
     case "undelegate":
       type = "UNDELEGATE";


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Redelegate optimistic operations on the generic adapter use the `DELEGATE` operation type. This mismatches with the expected `REDELEGATE`.

| Before | After |
| - | - |
| <img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/4badb29c-7225-4a42-a63e-40218359bffa" /> | <img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/1b6396c3-8802-431a-a247-2f88df622e45" /> |
| <img width="547" height="1041" alt="image" src="https://github.com/user-attachments/assets/a8aa307e-a56b-4eed-932a-0f9a9ec4e357" /> | <img width="547" height="1041" alt="image" src="https://github.com/user-attachments/assets/7221e8ce-4198-4b27-9d0b-74cd4dc4562d" /> |

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-34098
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
