### PR TITLE
[LWD] 4.11.0 release notes

### DIFF
--- a/.changeset/lwd-4-11-0-release-notes.md
+++ b/.changeset/lwd-4-11-0-release-notes.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+LWD 4.11.0 release notes

--- a/apps/ledger-live-desktop/RELEASE_NOTES.md
+++ b/apps/ledger-live-desktop/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+# 4.11.0
+
+This release includes small security improvements, UI tweaks, and minor bug fixes.
+
 # 4.10.0
 
 This release includes small security improvements, UI tweaks, and minor bug fixes.


### PR DESCRIPTION
## Summary

- Add generic release notes for **LWD 4.11.0** to `apps/ledger-live-desktop/RELEASE_NOTES.md` (same generic wording as the 4.10.0 entry).
- Add a `minor` changeset for `ledger-live-desktop`.

## Test plan

- [ ] Confirm the `# 4.11.0` section renders at the top of the release notes.
- [ ] Confirm the changeset is picked up by the release tooling.