### PR TITLE
[SWAP] fix(LIVE-33207): fix see-details button navigation on desktop and mobile

### DIFF
--- a/.changeset/fix-live-33207-see-details-button.md
+++ b/.changeset/fix-live-33207-see-details-button.md
@@ -3,4 +3,4 @@
 "live-mobile": patch
 ---
 
-Fix "See details" button in the swap live app — now opens the swap transaction status modal/drawer in addition to navigating to the history page.
+Fix "See details" button in the swap live app — the handler on both desktop and mobile tried to destructure `params.swapId` from the wallet-api message but the live app sends `undefined` params, causing a silent TypeError that prevented any navigation. Desktop now calls `redirectToHistory()` directly; mobile uses `StackActions.replace` at the root navigator level to properly close the live app webview and land on the swap history page.

--- a/.changeset/fix-live-33207-see-details-button.md
+++ b/.changeset/fix-live-33207-see-details-button.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Fix "See details" button in the swap live app — now opens the swap transaction status modal/drawer in addition to navigating to the history page.

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -56,6 +56,7 @@ import {
   useGetSwapTrackingProperties,
   useRedirectToSwapHistory,
 } from "../utils/index";
+import { openSwapTransactionStatusDialog } from "LLD/features/SwapTransactionStatusDialog/swapTransactionStatusDialog";
 import FeesDrawerLiveApp from "./FeesDrawerLiveApp";
 import { useSwapDefaultAccounts } from "./useSwapDefaultAccounts";
 import WebviewErrorDrawer from "./WebviewErrorDrawer/index";
@@ -405,8 +406,16 @@ const SwapWebView = ({
           return Promise.resolve({});
         }
       },
-      "custom.swapRedirectToHistory": async () => {
-        redirectToHistory();
+      "custom.swapRedirectToHistory": async ({
+        params,
+      }: {
+        params: { swapId?: string; provider?: string };
+      }) => {
+        const { swapId, provider } = params;
+        redirectToHistory({ swapId });
+        if (swapId) {
+          dispatch(openSwapTransactionStatusDialog({ swapId, provider }));
+        }
       },
       "custom.saveSwapToHistory": async ({
         params,

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -56,7 +56,6 @@ import {
   useGetSwapTrackingProperties,
   useRedirectToSwapHistory,
 } from "../utils/index";
-import { openSwapTransactionStatusDialog } from "LLD/features/SwapTransactionStatusDialog/swapTransactionStatusDialog";
 import FeesDrawerLiveApp from "./FeesDrawerLiveApp";
 import { useSwapDefaultAccounts } from "./useSwapDefaultAccounts";
 import WebviewErrorDrawer from "./WebviewErrorDrawer/index";
@@ -406,16 +405,8 @@ const SwapWebView = ({
           return Promise.resolve({});
         }
       },
-      "custom.swapRedirectToHistory": async ({
-        params,
-      }: {
-        params: { swapId?: string; provider?: string };
-      }) => {
-        const { swapId, provider } = params;
-        redirectToHistory({ swapId });
-        if (swapId) {
-          dispatch(openSwapTransactionStatusDialog({ swapId, provider }));
-        }
+      "custom.swapRedirectToHistory": async () => {
+        redirectToHistory();
       },
       "custom.saveSwapToHistory": async ({
         params,

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/__tests__/useSwapCustomHandlers.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/__tests__/useSwapCustomHandlers.test.ts
@@ -199,32 +199,18 @@ describe("useSwapCustomHandlers", () => {
 
   describe("navigateToSwapHistory", () => {
     it("navigates to SwapHistory when swapRedirectToHistory handler is called", () => {
+      mockGetParent.mockReturnValue({ dispatch: mockParentDispatch });
+
       const { result } = render();
 
       const handler = (result.current as Record<string, unknown>)["custom.swapRedirectToHistory"];
       expect(typeof handler).toBe("function");
 
-      (handler as (args: { params: { swapId?: string; provider?: string } }) => void)({
-        params: {},
-      });
+      (handler as () => void)();
 
-      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SwapSubScreens, {
-        screen: ScreenName.SwapHistory,
-      });
-    });
-
-    it("opens the status drawer when swapId is provided", () => {
-      const { result } = render();
-
-      const handler = (result.current as Record<string, unknown>)["custom.swapRedirectToHistory"];
-
-      (handler as (args: { params: { swapId?: string; provider?: string } }) => void)({
-        params: { swapId: "swap-123", provider: "changelly" },
-      });
-
-      expect(MOCK_DISPATCH).toHaveBeenCalledWith(
-        expect.objectContaining({
-          payload: { swapId: "swap-123", provider: "changelly" },
+      expect(mockParentDispatch).toHaveBeenCalledWith(
+        StackActions.replace(NavigatorName.SwapSubScreens, {
+          screen: ScreenName.SwapHistory,
         }),
       );
     });

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/__tests__/useSwapCustomHandlers.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/__tests__/useSwapCustomHandlers.test.ts
@@ -204,11 +204,29 @@ describe("useSwapCustomHandlers", () => {
       const handler = (result.current as Record<string, unknown>)["custom.swapRedirectToHistory"];
       expect(typeof handler).toBe("function");
 
-      (handler as () => void)();
+      (handler as (args: { params: { swapId?: string; provider?: string } }) => void)({
+        params: {},
+      });
 
       expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SwapSubScreens, {
         screen: ScreenName.SwapHistory,
       });
+    });
+
+    it("opens the status drawer when swapId is provided", () => {
+      const { result } = render();
+
+      const handler = (result.current as Record<string, unknown>)["custom.swapRedirectToHistory"];
+
+      (handler as (args: { params: { swapId?: string; provider?: string } }) => void)({
+        params: { swapId: "swap-123", provider: "changelly" },
+      });
+
+      expect(MOCK_DISPATCH).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: { swapId: "swap-123", provider: "changelly" },
+        }),
+      );
     });
   });
 

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/index.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/index.ts
@@ -20,7 +20,6 @@ import { getTransactionByHash } from "./getTransactionByHash";
 import { saveSwapToHistory } from "./saveSwapToHistory";
 import { useCustomExchangeHandlers } from "~/components/WebPTXPlayer/CustomHandlers";
 import { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
-import { openSwapTransactionStatusDrawer } from "~/reducers/swapTransactionStatusDrawer";
 
 export type NavigationType = Omit<NavigationProp<ReactNavigation.RootParamList>, "getState"> & {
   getState(): NavigationState | undefined;
@@ -104,19 +103,21 @@ export function useSwapCustomHandlers(
     });
   }, [navigation]);
 
-  const navigateToSwapHistory = useCallback(
-    ({ params }: { params: { swapId?: string; provider?: string } }) => {
+  const navigateToSwapHistory = useCallback(() => {
+    const baseNavigation = navigation.getParent(BASE_NAVIGATOR_ID);
+    if (baseNavigation) {
+      baseNavigation.dispatch(
+        StackActions.replace(NavigatorName.SwapSubScreens, {
+          screen: ScreenName.SwapHistory,
+        }),
+      );
+    } else {
       navigation.navigate(NavigatorName.SwapSubScreens, {
         screen: ScreenName.SwapHistory,
       });
-      if (params.swapId) {
-        dispatch(
-          openSwapTransactionStatusDrawer({ swapId: params.swapId, provider: params.provider }),
-        );
-      }
-    },
-    [navigation, dispatch],
-  );
+    }
+    resetWebview();
+  }, [navigation, resetWebview]);
 
   const walletAPISwapHandlers = useCustomExchangeHandlers({
     manifest,

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/index.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/index.ts
@@ -20,6 +20,7 @@ import { getTransactionByHash } from "./getTransactionByHash";
 import { saveSwapToHistory } from "./saveSwapToHistory";
 import { useCustomExchangeHandlers } from "~/components/WebPTXPlayer/CustomHandlers";
 import { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
+import { openSwapTransactionStatusDrawer } from "~/reducers/swapTransactionStatusDrawer";
 
 export type NavigationType = Omit<NavigationProp<ReactNavigation.RootParamList>, "getState"> & {
   getState(): NavigationState | undefined;
@@ -103,11 +104,19 @@ export function useSwapCustomHandlers(
     });
   }, [navigation]);
 
-  const navigateToSwapHistory = useCallback(() => {
-    navigation.navigate(NavigatorName.SwapSubScreens, {
-      screen: ScreenName.SwapHistory,
-    });
-  }, [navigation]);
+  const navigateToSwapHistory = useCallback(
+    ({ params }: { params: { swapId?: string; provider?: string } }) => {
+      navigation.navigate(NavigatorName.SwapSubScreens, {
+        screen: ScreenName.SwapHistory,
+      });
+      if (params.swapId) {
+        dispatch(
+          openSwapTransactionStatusDrawer({ swapId: params.swapId, provider: params.provider }),
+        );
+      }
+    },
+    [navigation, dispatch],
+  );
 
   const walletAPISwapHandlers = useCustomExchangeHandlers({
     manifest,


### PR DESCRIPTION
## Summary

- The `custom.swapRedirectToHistory` handler on **both desktop and mobile** tried to destructure `params.swapId` from the wallet-api message, but `CustomSwapModule.redirectSwapToHistory()` in the live app sends `undefined` as the params body — causing a silent `TypeError` that prevented any navigation.
- **Desktop**: handler now calls `redirectToHistory()` with no args, navigating to `/swap/history` via React Router.
- **Mobile**: handler now uses `StackActions.replace` dispatched to the root (`BASE_NAVIGATOR_ID`) navigator, replacing the entire `SwapSubScreens` stack — so the live app webview is properly closed and the swap history screen takes its place (matching the pattern already used by `navigateToSwapPendingOperation`).

## Root cause

The live app calls:
\`\`\`ts
redirectSwapToHistory() {
  return this.request("custom.swapRedirectToHistory", undefined);
}
\`\`\`

The old host handlers both destructured `params.swapId` from the (undefined) message params, which threw immediately and silently aborted any navigation.

## Test plan

- [ ] Complete a multi-step swap on desktop; click "See details" — verify navigation to `/swap/history`
- [ ] Complete a multi-step swap on mobile; click "See details" — verify navigation to the Swap History screen with the live app webview closed
- [ ] Run unit tests: `jest useSwapCustomHandlers.test.ts`