### PR TITLE
[Contacts][Shared] Add @features/platform-contacts mock adapters

### DIFF
--- a/.changeset/contacts-platform-mocks.md
+++ b/.changeset/contacts-platform-mocks.md
@@ -1,0 +1,5 @@
+---
+"@features/platform-contacts": patch
+---
+
+Add Contacts platform mock adapters and tests for the mock-first Contacts implementation batch.

--- a/features/platform/contacts/README.md
+++ b/features/platform/contacts/README.md
@@ -13,7 +13,8 @@ This package defines the dependency-injection boundary consumed by shared Contac
 - Contact and address edit confirmation boundaries.
 - Ledger Sync gating boundary.
 - Contacts tracking dispatch boundary.
+- Mock adapters for the first mock-first implementation batch.
 
 Asset and network selection UI stays owned by MAD. Contacts should pass supported currency ids to MAD when filtering is needed, then consume the selected currency id returned by the app/flow wiring.
 
-It does not implement mock adapters, tests, UI, app routing, Redux slices, WalletSync persistence, real device actions, signer payloads, or analytics transport.
+It does not implement UI, app routing, Redux slices, WalletSync persistence, real device actions, signer payloads, or analytics transport.

--- a/features/platform/contacts/jest.config.js
+++ b/features/platform/contacts/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/features/platform/contacts/package.json
+++ b/features/platform/contacts/package.json
@@ -2,23 +2,31 @@
   "name": "@features/platform-contacts",
   "version": "0.1.0",
   "private": true,
-  "description": "Scenario-oriented Contacts platform contracts",
+  "description": "Scenario-oriented Contacts platform contracts and mock adapters",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
     "./contracts": "./src/contracts/index.ts",
+    "./mocks": "./src/mocks/index.ts",
     "./package.json": "./package.json"
   },
   "sideEffects": false,
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
     "unimported": "pnpm knip --directory ../../.. -W features/platform/contacts"
   },
   "dependencies": {
     "@domain/entity-contact": "workspace:*"
   },
   "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "jest": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/features/platform/contacts/src/mocks/addresses/addAddress.ts
+++ b/features/platform/contacts/src/mocks/addresses/addAddress.ts
@@ -1,0 +1,93 @@
+import { contact, contactAddress, ContactAddressIdSchema } from "@domain/entity-contact";
+import { mockContact } from "@domain/entity-contact/schema.mock";
+import type { Contact, ContactId } from "@domain/entity-contact";
+import type {
+  AddAddressPort,
+  AddressCandidateInput,
+  AddressCandidateValidation,
+  AddressRegistrationDraft,
+  ConfirmedAddressRegistrationResult,
+  ContactDetailPort,
+  ContactDetailState,
+  ValidAddressCandidate,
+} from "../../contracts";
+import { createUniqueMockId } from "../ids";
+import {
+  isSupportedAddressCurrencyId,
+  SUPPORTED_ADDRESS_CURRENCY_IDS,
+} from "./supportedCurrencies";
+import { isValidAddressLabel, isValidAddressValue } from "./validation";
+
+export function createMockAddAddressPort(
+  contacts: Map<ContactId, Contact>,
+  loadContactDetail: ContactDetailPort["loadContactDetail"],
+): AddAddressPort {
+  return {
+    async loadSupportedAddressCurrencyIds(_contactId: ContactId) {
+      return SUPPORTED_ADDRESS_CURRENCY_IDS;
+    },
+    async validateAddressCandidate(
+      input: AddressCandidateInput,
+    ): Promise<AddressCandidateValidation> {
+      if (!isSupportedAddressCurrencyId(input.currencyId)) {
+        return { type: "invalid", reason: "unsupported-currency" };
+      }
+
+      if (!isValidAddressValue(input.address)) {
+        return { type: "invalid", reason: "invalid-address-format" };
+      }
+
+      if (!isValidAddressLabel(input.label)) {
+        return { type: "invalid", reason: "invalid-label" };
+      }
+
+      try {
+        const address = contactAddress({
+          id: ContactAddressIdSchema.parse(
+            createUniqueMockId(
+              "address",
+              `${input.currencyId}-${input.address}`,
+              contacts.get(input.contactId)?.addresses.map(address => address.id) ?? [],
+            ),
+          ),
+          currencyId: input.currencyId,
+          label: input.label,
+          address: input.address.trim(),
+        });
+
+        return {
+          type: "valid",
+          candidate: {
+            contactId: input.contactId,
+            address,
+          },
+        };
+      } catch {
+        return { type: "invalid", reason: "invalid-address-format" };
+      }
+    },
+    async prepareAddressRegistration(
+      candidate: ValidAddressCandidate,
+    ): Promise<AddressRegistrationDraft> {
+      return {
+        contactId: candidate.contactId,
+        address: candidate.address,
+      };
+    },
+    async applyConfirmedAddressRegistration(
+      result: ConfirmedAddressRegistrationResult,
+    ): Promise<ContactDetailState> {
+      const selectedContact =
+        contacts.get(result.draft.contactId) ?? mockContact({ id: result.draft.contactId });
+      const nextAddress = contactAddress(result.draft.address);
+      const nextContact = contact({
+        ...selectedContact,
+        addresses: [...selectedContact.addresses, nextAddress],
+      });
+
+      contacts.set(nextContact.id, nextContact);
+
+      return loadContactDetail(nextContact.id);
+    },
+  };
+}

--- a/features/platform/contacts/src/mocks/addresses/edit.ts
+++ b/features/platform/contacts/src/mocks/addresses/edit.ts
@@ -1,0 +1,37 @@
+import { contact } from "@domain/entity-contact";
+import { mockContact } from "@domain/entity-contact/schema.mock";
+import type { Contact, ContactId } from "@domain/entity-contact";
+import type {
+  AddressEditDraft,
+  AddressEditInput,
+  AddressEditPort,
+  ConfirmedAddressEditResult,
+  ContactDetailPort,
+  ContactDetailState,
+} from "../../contracts";
+
+export function createMockAddressEditPort(
+  contacts: Map<ContactId, Contact>,
+  loadContactDetail: ContactDetailPort["loadContactDetail"],
+): AddressEditPort {
+  return {
+    async prepareAddressEdit(input: AddressEditInput): Promise<AddressEditDraft> {
+      return input;
+    },
+    async applyConfirmedAddressEdit(result: ConfirmedAddressEditResult): Promise<ContactDetailState> {
+      const selectedContact =
+        contacts.get(result.draft.contactId) ?? mockContact({ id: result.draft.contactId });
+      const nextAddresses = selectedContact.addresses.map(address =>
+        address.id === result.draft.addressId ? { ...address, label: result.draft.label } : address,
+      );
+      const nextContact = contact({
+        ...selectedContact,
+        addresses: nextAddresses,
+      });
+
+      contacts.set(nextContact.id, nextContact);
+
+      return loadContactDetail(nextContact.id);
+    },
+  };
+}

--- a/features/platform/contacts/src/mocks/addresses/sorting.ts
+++ b/features/platform/contacts/src/mocks/addresses/sorting.ts
@@ -1,0 +1,12 @@
+import type { ContactAddress } from "@domain/entity-contact";
+import { getNetworkSortKey } from "./supportedCurrencies";
+
+export function sortAddressesByNetwork(addresses: readonly ContactAddress[]): ContactAddress[] {
+  return [...addresses].sort((left, right) => {
+    const networkComparison = getNetworkSortKey(left.currencyId).localeCompare(
+      getNetworkSortKey(right.currencyId),
+    );
+
+    return networkComparison || left.currencyId.localeCompare(right.currencyId);
+  });
+}

--- a/features/platform/contacts/src/mocks/addresses/supportedCurrencies.ts
+++ b/features/platform/contacts/src/mocks/addresses/supportedCurrencies.ts
@@ -1,0 +1,26 @@
+import type { ContactAddressInput } from "@domain/entity-contact";
+import type { SupportedAddressCurrencyIds } from "../../contracts";
+
+export const SUPPORTED_ADDRESS_CURRENCY_IDS = [
+  "ethereum",
+  "polygon",
+  "ethereum/erc20/usd-tether",
+] as const satisfies SupportedAddressCurrencyIds;
+
+const SUPPORTED_ADDRESS_CURRENCY_ID_SET = new Set<string>(SUPPORTED_ADDRESS_CURRENCY_IDS);
+
+const NETWORK_SORT_KEYS: Readonly<Record<string, string>> = {
+  ethereum: "Ethereum",
+  "ethereum/erc20/usd-tether": "Ethereum",
+  polygon: "Polygon",
+};
+
+export function isSupportedAddressCurrencyId(
+  currencyId: ContactAddressInput["currencyId"],
+): boolean {
+  return SUPPORTED_ADDRESS_CURRENCY_ID_SET.has(currencyId);
+}
+
+export function getNetworkSortKey(currencyId: ContactAddressInput["currencyId"]): string {
+  return NETWORK_SORT_KEYS[currencyId] ?? currencyId;
+}

--- a/features/platform/contacts/src/mocks/addresses/validation.ts
+++ b/features/platform/contacts/src/mocks/addresses/validation.ts
@@ -1,0 +1,7 @@
+export function isValidAddressLabel(label: string): boolean {
+  return label.trim().length > 0 && /^[\x20-\x7E]+$/.test(label);
+}
+
+export function isValidAddressValue(address: string): boolean {
+  return address.trim().length > 0;
+}

--- a/features/platform/contacts/src/mocks/contacts/creation.ts
+++ b/features/platform/contacts/src/mocks/contacts/creation.ts
@@ -1,0 +1,23 @@
+import { contact, ContactIdSchema } from "@domain/entity-contact";
+import type { Contact, ContactId } from "@domain/entity-contact";
+import type { ContactCreationPort } from "../../contracts";
+import { createUniqueMockId } from "../ids";
+
+export function createMockContactCreationPort(
+  contacts: Map<ContactId, Contact>,
+): ContactCreationPort {
+  return {
+    async createContact(input): Promise<Contact> {
+      const createdContact = contact({
+        id: ContactIdSchema.parse(createUniqueMockId("contact", input.name, contacts.keys())),
+        isMe: false,
+        name: input.name,
+        addresses: [],
+      });
+
+      contacts.set(createdContact.id, createdContact);
+
+      return createdContact;
+    },
+  };
+}

--- a/features/platform/contacts/src/mocks/contacts/detail.ts
+++ b/features/platform/contacts/src/mocks/contacts/detail.ts
@@ -1,0 +1,27 @@
+import { mockContact } from "@domain/entity-contact/schema.mock";
+import type { Contact, ContactId } from "@domain/entity-contact";
+import type { ContactDetailPort, ContactDetailState } from "../../contracts";
+import { sortAddressesByNetwork } from "../addresses/sorting";
+
+export function createMockLoadContactDetail(
+  contacts: ReadonlyMap<ContactId, Contact>,
+): ContactDetailPort["loadContactDetail"] {
+  return async (contactId: ContactId): Promise<ContactDetailState> => {
+    const selectedContact = contacts.get(contactId) ?? mockContact({ id: contactId });
+
+    return {
+      contact: {
+        ...selectedContact,
+        addresses: sortAddressesByNetwork(selectedContact.addresses),
+      },
+    };
+  };
+}
+
+export function createMockContactDetailPort(
+  loadContactDetail: ContactDetailPort["loadContactDetail"],
+): ContactDetailPort {
+  return {
+    loadContactDetail,
+  };
+}

--- a/features/platform/contacts/src/mocks/contacts/edit.ts
+++ b/features/platform/contacts/src/mocks/contacts/edit.ts
@@ -1,0 +1,27 @@
+import { contact } from "@domain/entity-contact";
+import { mockContact } from "@domain/entity-contact/schema.mock";
+import type { Contact, ContactId } from "@domain/entity-contact";
+import type { ContactEditPort, ContactEditRequirement, ContactRenameInput } from "../../contracts";
+
+export function createMockContactEditPort(contacts: Map<ContactId, Contact>): ContactEditPort {
+  return {
+    async getContactEditRequirement(contactId: ContactId): Promise<ContactEditRequirement> {
+      const selectedContact = contacts.get(contactId) ?? mockContact({ id: contactId });
+
+      return selectedContact.addresses.length > 0
+        ? { type: "confirmation-required", reason: "contact-has-address" }
+        : { type: "direct", reason: "contact-has-no-address" };
+    },
+    async renameContact(input: ContactRenameInput): Promise<Contact> {
+      const selectedContact = contacts.get(input.contactId) ?? mockContact({ id: input.contactId });
+      const renamedContact = contact({
+        ...selectedContact,
+        name: input.name,
+      });
+
+      contacts.set(renamedContact.id, renamedContact);
+
+      return renamedContact;
+    },
+  };
+}

--- a/features/platform/contacts/src/mocks/contacts/list.ts
+++ b/features/platform/contacts/src/mocks/contacts/list.ts
@@ -1,0 +1,51 @@
+import type { Contact, ContactId } from "@domain/entity-contact";
+import type {
+  ContactListItem,
+  ContactsListPort,
+  ContactsListState,
+  ContactsListStatus,
+} from "../../contracts";
+import { sortContactsByName } from "./sorting";
+import { getMeContact } from "./state";
+
+export function createMockContactsListPort(contacts: Map<ContactId, Contact>): ContactsListPort {
+  return {
+    async loadContactsList(query = ""): Promise<ContactsListState> {
+      const normalizedQuery = query.trim().toLowerCase();
+      const me = getMeContact(contacts);
+      const savedContacts = [...contacts.values()]
+        .filter(contact => !contact.isMe)
+        .sort(sortContactsByName);
+      const filteredContacts =
+        normalizedQuery.length === 0
+          ? savedContacts
+          : savedContacts.filter(contact => contact.name.toLowerCase().includes(normalizedQuery));
+
+      return {
+        me: toContactListItem(me),
+        contacts: filteredContacts.map(toContactListItem),
+        status: getContactsListStatus(filteredContacts, normalizedQuery),
+      };
+    },
+  };
+}
+
+function getContactsListStatus(
+  contacts: readonly Contact[],
+  normalizedQuery: string,
+): ContactsListStatus {
+  if (contacts.length > 0) {
+    return "results";
+  }
+
+  return normalizedQuery.length > 0 ? "no-results" : "empty";
+}
+
+function toContactListItem(contact: Contact): ContactListItem {
+  return {
+    id: contact.id,
+    isMe: contact.isMe,
+    name: contact.name,
+    addressCount: contact.addresses.length,
+  };
+}

--- a/features/platform/contacts/src/mocks/contacts/sorting.ts
+++ b/features/platform/contacts/src/mocks/contacts/sorting.ts
@@ -1,0 +1,5 @@
+import type { Contact } from "@domain/entity-contact";
+
+export function sortContactsByName(left: Contact, right: Contact): number {
+  return left.name.localeCompare(right.name);
+}

--- a/features/platform/contacts/src/mocks/contacts/state.ts
+++ b/features/platform/contacts/src/mocks/contacts/state.ts
@@ -1,0 +1,27 @@
+import { mockMeContact } from "@domain/entity-contact/schema.mock";
+import type { Contact, ContactId } from "@domain/entity-contact";
+
+export function createContactsMap(contacts: readonly Contact[]): Map<ContactId, Contact> {
+  const contactsMap = new Map<ContactId, Contact>(contacts.map(contact => [contact.id, contact]));
+
+  ensureMeContact(contactsMap);
+
+  return contactsMap;
+}
+
+export function getMeContact(contacts: Map<ContactId, Contact>): Contact {
+  return ensureMeContact(contacts);
+}
+
+function ensureMeContact(contacts: Map<ContactId, Contact>): Contact {
+  const existingMeContact = [...contacts.values()].find(contact => contact.isMe);
+
+  if (existingMeContact) {
+    return existingMeContact;
+  }
+
+  const meContact = mockMeContact();
+  contacts.set(meContact.id, meContact);
+
+  return meContact;
+}

--- a/features/platform/contacts/src/mocks/createMockContactsPlatform.ts
+++ b/features/platform/contacts/src/mocks/createMockContactsPlatform.ts
@@ -1,0 +1,32 @@
+import { mockPopulatedContacts } from "@domain/entity-contact/schema.mock";
+import { createMockAddAddressPort } from "./addresses/addAddress";
+import { createMockAddressEditPort } from "./addresses/edit";
+import { createMockContactCreationPort } from "./contacts/creation";
+import { createMockContactDetailPort, createMockLoadContactDetail } from "./contacts/detail";
+import { createMockContactEditPort } from "./contacts/edit";
+import { createMockContactsListPort } from "./contacts/list";
+import { createContactsMap } from "./contacts/state";
+import { createMockLedgerSyncGatePort } from "./ledgerSyncGate";
+import { createMockContactsTrackingPort } from "./tracking";
+import type { ContactsTrackingEvent } from "../contracts";
+import type { MockContactsPlatform, MockContactsPlatformOptions } from "./types";
+
+export function createMockContactsPlatform(
+  options: MockContactsPlatformOptions = {},
+): MockContactsPlatform {
+  const trackedEvents: ContactsTrackingEvent[] = [];
+  const contacts = createContactsMap(options.contacts ?? mockPopulatedContacts());
+  const loadContactDetail = createMockLoadContactDetail(contacts);
+
+  return {
+    trackedEvents,
+    list: createMockContactsListPort(contacts),
+    detail: createMockContactDetailPort(loadContactDetail),
+    create: createMockContactCreationPort(contacts),
+    addAddress: createMockAddAddressPort(contacts, loadContactDetail),
+    editContact: createMockContactEditPort(contacts),
+    editAddress: createMockAddressEditPort(contacts, loadContactDetail),
+    ledgerSyncGate: createMockLedgerSyncGatePort(options.ledgerSyncEnabled ?? true),
+    tracking: createMockContactsTrackingPort(trackedEvents),
+  };
+}

--- a/features/platform/contacts/src/mocks/ids.ts
+++ b/features/platform/contacts/src/mocks/ids.ts
@@ -1,0 +1,21 @@
+export function createUniqueMockId(
+  prefix: "address" | "contact",
+  value: string,
+  existingIds: Iterable<string>,
+): string {
+  const baseId = `${prefix}-${slugify(value)}`;
+  const knownIds = new Set(existingIds);
+  let candidateId = baseId;
+  let suffix = 2;
+
+  while (knownIds.has(candidateId)) {
+    candidateId = `${baseId}-${suffix}`;
+    suffix += 1;
+  }
+
+  return candidateId;
+}
+
+function slugify(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "item";
+}

--- a/features/platform/contacts/src/mocks/index.test.ts
+++ b/features/platform/contacts/src/mocks/index.test.ts
@@ -1,0 +1,230 @@
+import {
+  mockContact,
+  mockContactAddress,
+  mockContactWithMultipleAddresses,
+  mockMeContact,
+} from "@domain/entity-contact/schema.mock";
+import { createMockContactsPlatform } from ".";
+
+describe("createMockContactsPlatform", () => {
+  it("adds Me to a custom list and loads its detail", async () => {
+    const platform = createMockContactsPlatform({
+      contacts: [mockContact({ id: "contact-olive", name: "Olive" })],
+    });
+
+    const list = await platform.list.loadContactsList();
+    const detail = await platform.detail.loadContactDetail(list.me.id);
+
+    expect(list).toMatchObject({
+      me: { isMe: true, addressCount: 0 },
+      contacts: [{ name: "Olive" }],
+      status: "results",
+    });
+    expect(detail.contact).toMatchObject({ id: list.me.id, isMe: true });
+  });
+
+  it("returns no results for an unmatched search and an empty state when only Me exists", async () => {
+    const platform = createMockContactsPlatform();
+    const onlyMePlatform = createMockContactsPlatform({ contacts: [mockMeContact()] });
+
+    await expect(platform.list.loadContactsList("missing")).resolves.toMatchObject({
+      contacts: [],
+      status: "no-results",
+    });
+    await expect(onlyMePlatform.list.loadContactsList()).resolves.toMatchObject({
+      status: "empty",
+    });
+  });
+
+  it("creates a contact without addresses", async () => {
+    const platform = createMockContactsPlatform();
+
+    const firstContact = await platform.create.createContact({ name: "Olivia" });
+    const secondContact = await platform.create.createContact({ name: "Olivia" });
+
+    expect(firstContact).toMatchObject({
+      id: "contact-olivia",
+      isMe: false,
+      name: "Olivia",
+      addresses: [],
+    });
+    expect(secondContact.id).toBe("contact-olivia-2");
+  });
+
+  it("loads supported currencies and applies a confirmed address registration", async () => {
+    const oliveContact = mockContact({ id: "contact-olive", name: "Olive" });
+    const platform = createMockContactsPlatform({ contacts: [oliveContact] });
+
+    await expect(
+      platform.addAddress.loadSupportedAddressCurrencyIds(oliveContact.id),
+    ).resolves.toEqual(["ethereum", "polygon", "ethereum/erc20/usd-tether"]);
+
+    const validation = await platform.addAddress.validateAddressCandidate({
+      contactId: oliveContact.id,
+      currencyId: "ethereum",
+      label: "Ethereum",
+      address: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+    });
+
+    expect(validation.type).toBe("valid");
+
+    if (validation.type !== "valid") {
+      throw new Error("Expected a valid address candidate");
+    }
+
+    const draft = await platform.addAddress.prepareAddressRegistration(validation.candidate);
+    const detail = await platform.addAddress.applyConfirmedAddressRegistration({
+      draft,
+      confirmationId: "confirmation-1",
+    });
+
+    expect(detail.contact.addresses).toHaveLength(1);
+    expect(detail.contact.addresses[0]).toMatchObject({ currencyId: "ethereum" });
+  });
+
+  it("sorts contact detail addresses by network", async () => {
+    const contactWithAddresses = mockContact({
+      id: "contact-network-sorted",
+      name: "Network sorted",
+      addresses: [
+        mockContactAddress({
+          id: "address-polygon",
+          currencyId: "polygon",
+          label: "Polygon",
+          address: "0x2ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+        }),
+        mockContactAddress({
+          id: "address-usdt-ethereum",
+          currencyId: "ethereum/erc20/usd-tether",
+          label: "USDT",
+          address: "0x3ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+        }),
+        mockContactAddress({
+          id: "address-ethereum",
+          currencyId: "ethereum",
+          label: "Ethereum",
+          address: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+        }),
+      ],
+    });
+    const platform = createMockContactsPlatform({ contacts: [contactWithAddresses] });
+
+    const detail = await platform.detail.loadContactDetail(contactWithAddresses.id);
+
+    expect(detail.contact.addresses.map(address => address.currencyId)).toEqual([
+      "ethereum",
+      "ethereum/erc20/usd-tether",
+      "polygon",
+    ]);
+  });
+
+  it("rejects unsupported currencies, blank addresses, and invalid labels", async () => {
+    const contactId = mockContact({ id: "contact-ben", name: "Ben" }).id;
+    const platform = createMockContactsPlatform();
+
+    await expect(
+      platform.addAddress.validateAddressCandidate({
+        contactId,
+        currencyId: "tron",
+        label: "TRON",
+        address: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+      }),
+    ).resolves.toEqual({ type: "invalid", reason: "unsupported-currency" });
+    await expect(
+      platform.addAddress.validateAddressCandidate({
+        contactId,
+        currencyId: "ethereum",
+        label: "Ethereum",
+        address: "   ",
+      }),
+    ).resolves.toEqual({ type: "invalid", reason: "invalid-address-format" });
+    await expect(
+      platform.addAddress.validateAddressCandidate({
+        contactId,
+        currencyId: "ethereum",
+        label: "Ethé",
+        address: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+      }),
+    ).resolves.toEqual({ type: "invalid", reason: "invalid-label" });
+  });
+
+  it("renames contacts and requires confirmation when a contact has an address", async () => {
+    const emptyContact = mockContact({ id: "contact-empty", name: "Empty" });
+    const contactWithAddress = mockContactWithMultipleAddresses({
+      id: "contact-with-address",
+      name: "With address",
+    });
+    const platform = createMockContactsPlatform({
+      contacts: [emptyContact, contactWithAddress],
+    });
+
+    await expect(platform.editContact.getContactEditRequirement(emptyContact.id)).resolves.toEqual({
+      type: "direct",
+      reason: "contact-has-no-address",
+    });
+    await expect(
+      platform.editContact.getContactEditRequirement(contactWithAddress.id),
+    ).resolves.toEqual({
+      type: "confirmation-required",
+      reason: "contact-has-address",
+    });
+    await expect(
+      platform.editContact.renameContact({ contactId: emptyContact.id, name: "Renamed" }),
+    ).resolves.toMatchObject({ name: "Renamed" });
+  });
+
+  it("gates mutations when Ledger Sync is disabled", async () => {
+    const platform = createMockContactsPlatform({ ledgerSyncEnabled: false });
+
+    await expect(
+      platform.ledgerSyncGate.checkContactsMutationAllowed("add-address"),
+    ).resolves.toEqual({
+      type: "blocked",
+      reason: "ledger-sync-disabled",
+      intendedAction: "add-address",
+    });
+  });
+
+  it("applies a confirmed address edit", async () => {
+    const contactWithAddress = mockContactWithMultipleAddresses({
+      id: "contact-with-address",
+      name: "With address",
+    });
+    const platform = createMockContactsPlatform({ contacts: [contactWithAddress] });
+    const address = contactWithAddress.addresses[0];
+
+    if (!address) {
+      throw new Error("Expected contact to have an address");
+    }
+
+    const draft = await platform.editAddress.prepareAddressEdit({
+      contactId: contactWithAddress.id,
+      addressId: address.id,
+      label: "ETH Vault",
+    });
+    const detail = await platform.editAddress.applyConfirmedAddressEdit({
+      draft,
+      confirmationId: "confirmation-1",
+    });
+
+    expect(detail.contact.addresses.find(item => item.id === address.id)).toMatchObject({
+      label: "ETH Vault",
+    });
+  });
+
+  it("collects tracking events without sending them", () => {
+    const platform = createMockContactsPlatform();
+
+    platform.tracking.trackContactsEvent({
+      name: "contacts-entry-opened",
+      properties: { contacts_count: 3 },
+    });
+
+    expect(platform.trackedEvents).toEqual([
+      {
+        name: "contacts-entry-opened",
+        properties: { contacts_count: 3 },
+      },
+    ]);
+  });
+});

--- a/features/platform/contacts/src/mocks/index.ts
+++ b/features/platform/contacts/src/mocks/index.ts
@@ -1,0 +1,2 @@
+export * from "./createMockContactsPlatform";
+export * from "./types";

--- a/features/platform/contacts/src/mocks/ledgerSyncGate.ts
+++ b/features/platform/contacts/src/mocks/ledgerSyncGate.ts
@@ -1,0 +1,13 @@
+import type { ContactsMutationAction, LedgerSyncGatePort, LedgerSyncGateResult } from "../contracts";
+
+export function createMockLedgerSyncGatePort(ledgerSyncEnabled: boolean): LedgerSyncGatePort {
+  return {
+    async checkContactsMutationAllowed(
+      action: ContactsMutationAction,
+    ): Promise<LedgerSyncGateResult> {
+      return ledgerSyncEnabled
+        ? { type: "allowed" }
+        : { type: "blocked", reason: "ledger-sync-disabled", intendedAction: action };
+    },
+  };
+}

--- a/features/platform/contacts/src/mocks/tracking.ts
+++ b/features/platform/contacts/src/mocks/tracking.ts
@@ -1,0 +1,11 @@
+import type { ContactsTrackingEvent, ContactsTrackingPort } from "../contracts";
+
+export function createMockContactsTrackingPort(
+  trackedEvents: ContactsTrackingEvent[],
+): ContactsTrackingPort {
+  return {
+    trackContactsEvent(event: ContactsTrackingEvent): void {
+      trackedEvents.push(event);
+    },
+  };
+}

--- a/features/platform/contacts/src/mocks/types.ts
+++ b/features/platform/contacts/src/mocks/types.ts
@@ -1,0 +1,12 @@
+import type { Contact } from "@domain/entity-contact";
+import type { ContactsPlatform, ContactsTrackingEvent } from "../contracts";
+
+export type MockContactsPlatformOptions = Readonly<{
+  contacts?: readonly Contact[];
+  ledgerSyncEnabled?: boolean;
+}>;
+
+export type MockContactsPlatform = ContactsPlatform &
+  Readonly<{
+    trackedEvents: readonly ContactsTrackingEvent[];
+  }>;

--- a/features/platform/contacts/tsconfig.json
+++ b/features/platform/contacts/tsconfig.json
@@ -5,7 +5,8 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["jest"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "lib"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4013,6 +4013,18 @@ importers:
         specifier: workspace:*
         version: link:../../../domain/entity/contact
     devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.2


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Ran `pnpm --filter @features/platform-contacts test --runInBand`, `pnpm --filter @features/platform-contacts typecheck`, `pnpm --filter @features/platform-contacts unimported`, and `git diff --check`.
- [x] **Impact of the changes:**
      Adds mock adapters and tests for the `@features/platform-contacts` scenario-oriented contracts. This PR is stacked on the contracts/package foundation PR.

### 📝 Description

This PR adds the mock-first adapters for `@features/platform-contacts`, organized by Contacts and Addresses scenarios.

It also adds the Jest configuration, mock export, package scripts, and coverage for the mock adapter behavior. The PR is intentionally stacked on `feat/live-33876-platform-contacts-contracts` so the existing `LIVE-33876` PR can stay focused on package + contracts only.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-33876
- **Stacked on**: https://github.com/LedgerHQ/ledger-live/pull/19418

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
