### PR TITLE
fix(web-tools): reuse DMK session to avoid WebHID re-prompting on each device interaction

### DIFF
--- a/apps/web-tools/src/trustchain/live-common-setup.ts
+++ b/apps/web-tools/src/trustchain/live-common-setup.ts
@@ -1,10 +1,10 @@
 import "../live-common-setup-network";
 import { registerTransportModule } from "@ledgerhq/live-common/hw/index";
-import { DeviceManagementKitBuilder } from "@ledgerhq/device-management-kit";
+import { DeviceManagementKitBuilder, DeviceStatus } from "@ledgerhq/device-management-kit";
 import { webHidTransportFactory } from "@ledgerhq/device-transport-kit-web-hid";
 import { DmkCompatTransport } from "@ledgerhq/live-dmk-shared";
 import { listen } from "@ledgerhq/logs";
-import { firstValueFrom } from "rxjs";
+import { firstValueFrom, type Subscription } from "rxjs";
 
 listen(log => {
   console.log(log.type + ": " + log.message);
@@ -12,16 +12,81 @@ listen(log => {
 
 const dmk = new DeviceManagementKitBuilder().addTransport(webHidTransportFactory).build();
 
+type SessionCache = {
+  sessionId: string;
+  transport: DmkCompatTransport;
+  subscription: Subscription;
+};
+let sessionCache: SessionCache | null = null;
+let openingPromise: Promise<DmkCompatTransport> | null = null;
+
+function clearCache() {
+  sessionCache?.subscription.unsubscribe();
+  sessionCache = null;
+}
+
+function evictSession(sessionId: string) {
+  clearCache();
+  return dmk.disconnect({ sessionId }).catch(() => {});
+}
+
+async function doOpen(): Promise<DmkCompatTransport> {
+  if (sessionCache) {
+    const state = await firstValueFrom(
+      dmk.getDeviceSessionState({ sessionId: sessionCache.sessionId }),
+    ).catch(() => null);
+
+    if (state && state.deviceStatus !== DeviceStatus.NOT_CONNECTED) {
+      return sessionCache.transport;
+    }
+    await evictSession(sessionCache.sessionId);
+  }
+
+  const device = await firstValueFrom(dmk.startDiscovering({})).finally(() =>
+    dmk.stopDiscovering().catch(() => {}),
+  );
+  const sessionId = await dmk.connect({
+    device,
+    sessionRefresherOptions: { isRefresherDisabled: true },
+  });
+  const transport = new DmkCompatTransport(dmk, sessionId);
+
+  const subscription = dmk.getDeviceSessionState({ sessionId }).subscribe({
+    next: state => {
+      if (
+        state.deviceStatus === DeviceStatus.NOT_CONNECTED &&
+        sessionCache?.sessionId === sessionId
+      ) {
+        clearCache();
+      }
+    },
+    error: () => {
+      if (sessionCache?.sessionId === sessionId) clearCache();
+    },
+    complete: () => {
+      if (sessionCache?.sessionId === sessionId) clearCache();
+    },
+  });
+
+  sessionCache = { sessionId, transport, subscription };
+
+  return transport;
+}
+
 registerTransportModule({
   id: "dmk",
-  open: async () => {
-    const device = await firstValueFrom(dmk.startDiscovering({}));
-    await dmk.stopDiscovering();
-    const sessionId = await dmk.connect({
-      device,
-      sessionRefresherOptions: { isRefresherDisabled: true },
-    });
-    return new DmkCompatTransport(dmk, sessionId);
+  open: () => {
+    if (!openingPromise) {
+      openingPromise = doOpen().finally(() => {
+        openingPromise = null;
+      });
+    }
+    return openingPromise;
   },
-  disconnect: () => Promise.resolve(),
+  disconnect: () => {
+    if (!sessionCache) return Promise.resolve();
+    const { sessionId } = sessionCache;
+    clearCache();
+    return dmk.disconnect({ sessionId }).catch(() => {});
+  },
 });


### PR DESCRIPTION
### 📝 Description

The DMK transport registered in web-tools/trustchain was calling startDiscovering on every
open() call, which triggers the WebHID/WebUSB browser permission dialog on every device
interaction. This made the /trustchain page nearly unusable — every button that talks to
the device popped a permission prompt.

Previous behaviour: each open() → startDiscovering → connect → new DmkCompatTransport.
No session was reused; the disconnect callback was always a no-op.

Fix: cache the DMK session across open() calls using the same pattern as
DeviceManagementKitTransport in live-dmk-desktop:
- On open(), check the cached session liveness via getDeviceSessionState + DeviceStatus.NOT_CONNECTED
- On a valid cached session, return it directly (no new discovery, no WebHID prompt)
- Subscribe to getDeviceSessionState to invalidate the cache on physical disconnect (next/error/complete)
- Store the subscription reference and unsubscribe it on cache clear (no leak)
- Guard handlers with sessionId check so stale subscriptions from a prior session cannot
  wipe a newer session cache

### 🔗 Context

- **JIRA / GitHub issue**: N/A (web-tools dev tooling fix)
- **ADR** (if any): N/A