### PR TITLE
[LWDM] feat(auth): handle concurrent auth and non lkrp users

### DIFF
--- a/.changeset/nice-goats-destroy.md
+++ b/.changeset/nice-goats-destroy.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/ledger-auth": minor
+---
+
+Handle concurrent authentication calls

--- a/.changeset/purple-oranges-agree.md
+++ b/.changeset/purple-oranges-agree.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/ledger-key-ring-protocol": minor
+---
+
+Make the attestation optional for the oidc flow

--- a/libs/ledger-auth/src/__tests__/authSDK.integration.test.ts
+++ b/libs/ledger-auth/src/__tests__/authSDK.integration.test.ts
@@ -1,9 +1,9 @@
 import { HttpResponse, http } from "msw";
 import { setupServer, type SetupServerApi } from "msw/node";
 import { AuthSDK } from "../authSDK";
-import { CustomIdentityProvider } from "./__mocks__/CustomIdentityProvider.mock";
-import type { CustomChallenge, Signer } from "./__mocks__/CustomIdentityProvider.mock";
 import { bytesToBase64Url, stringToBytes } from "../utils";
+import { CustomIdentityProvider } from "./__mocks__/CustomIdentityProvider.mock";
+import type { CustomChallenge } from "./__mocks__/CustomIdentityProvider.mock";
 
 type SignedChallengeRequest = {
   challenge: string;
@@ -26,10 +26,12 @@ describe("AuthSDK (integration, MSW)", () => {
   let keyPair: CryptoKeyPair;
   let server: SetupServerApi;
 
-  const signer: Signer = {
+  const queryFn = jest.fn().mockResolvedValue({ ok: true });
+
+  const identityProvider = new CustomIdentityProvider({
     jwk: { kty: "EC", crv: "P-256", x: "x", y: "y" },
     sign: async (algorithm, data) => crypto.subtle.sign(algorithm, keyPair.privateKey, data),
-  };
+  });
 
   beforeAll(async () => {
     keyPair = await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, false, [
@@ -44,14 +46,13 @@ describe("AuthSDK (integration, MSW)", () => {
     server.close();
   });
 
-  afterEach(() => {
+  beforeEach(() => {
+    jest.clearAllMocks();
     server.resetHandlers();
   });
 
   it("retrieves a Keycloak JWT without PKCE", async () => {
-    const identityProvider = new CustomIdentityProvider(signer);
-
-    const token = await new AuthSDK(
+    await new AuthSDK(
       {
         clientId: CLIENT_ID,
         keycloakBaseUrl: KEYCLOAK_BASE_URL,
@@ -59,9 +60,9 @@ describe("AuthSDK (integration, MSW)", () => {
         disablePkce: true,
       },
       { provider: identityProvider },
-    ).authenticate();
+    ).withToken({ queryFn });
 
-    expect(token).toEqual({
+    expect(queryFn).toHaveBeenCalledWith({
       accessToken: EXPECTED_JWT,
       tokenType: "Bearer",
       scope: "openid",
@@ -72,9 +73,7 @@ describe("AuthSDK (integration, MSW)", () => {
   });
 
   it("retrieves a Keycloak JWT", async () => {
-    const identityProvider = new CustomIdentityProvider(signer);
-
-    const token = await new AuthSDK(
+    await new AuthSDK(
       {
         clientId: CLIENT_ID,
         keycloakBaseUrl: KEYCLOAK_BASE_URL,
@@ -82,9 +81,9 @@ describe("AuthSDK (integration, MSW)", () => {
         disablePkce: false,
       },
       { provider: identityProvider },
-    ).authenticate();
+    ).withToken({ queryFn });
 
-    expect(token).toEqual({
+    expect(queryFn).toHaveBeenCalledWith({
       accessToken: EXPECTED_JWT,
       tokenType: "Bearer",
       scope: "openid",
@@ -150,7 +149,9 @@ function initServer(publicKey: CryptoKey): SetupServerApi {
         return HttpResponse.json({ error: "invalid_request" }, { status: 400 });
       }
 
-      sessionStore.set(AUTHORIZATION_CODE, { codeChallenge: pendingCodeChallenge });
+      sessionStore.set(AUTHORIZATION_CODE, {
+        codeChallenge: pendingCodeChallenge,
+      });
       pendingCodeChallenge = undefined;
 
       return HttpResponse.json(AUTHORIZATION_CODE);

--- a/libs/ledger-auth/src/__tests__/authSDK.test.ts
+++ b/libs/ledger-auth/src/__tests__/authSDK.test.ts
@@ -25,8 +25,12 @@ describe("AuthSDK", () => {
     authenticate: jest.fn(),
   };
 
+  const queryFn = jest.fn();
+
   beforeEach(() => {
-    identityProvider.brokerId = "lkrp";
+    jest.clearAllMocks();
+    queryFn.mockReset();
+    queryFn.mockReturnValue(Promise.resolve());
 
     keycloakService.getChallenge.mockResolvedValue("challenge");
     identityProvider.authenticate.mockResolvedValue({
@@ -35,17 +39,16 @@ describe("AuthSDK", () => {
     });
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   it("retrieves a Keycloak JWT with PKCE by default", async () => {
-    const token = await new AuthSDK(config, {
+    await new AuthSDK(config, {
       provider: identityProvider,
       keycloakService,
-    }).authenticate();
+    }).withToken({ queryFn });
 
-    expect(token).toEqual({ accessToken: "keycloak-jwt", tokenType: "Bearer" });
+    expect(queryFn).toHaveBeenCalledWith({
+      accessToken: "keycloak-jwt",
+      tokenType: "Bearer",
+    });
 
     expect(keycloakService.getChallenge).toHaveBeenLastCalledWith({
       responseType: "code",
@@ -68,7 +71,7 @@ describe("AuthSDK", () => {
     await new AuthSDK(
       { ...config, disablePkce: true },
       { provider: identityProvider, keycloakService },
-    ).authenticate();
+    ).withToken({ queryFn });
 
     expect(keycloakService.getChallenge).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -86,17 +89,111 @@ describe("AuthSDK", () => {
 
   it("returns the cached token on subsequent calls without re-authenticating", async () => {
     const futureExp = Math.floor(Date.now() / 1000) + 3600;
-    identityProvider.authenticate.mockResolvedValue({
+    const token = {
       accessToken: makeJwt({ exp: futureExp }),
       tokenType: "Bearer",
+    };
+    identityProvider.authenticate.mockResolvedValue(token);
+
+    const sdk = new AuthSDK(config, {
+      provider: identityProvider,
+      keycloakService,
     });
 
-    const sdk = new AuthSDK(config, { provider: identityProvider, keycloakService });
+    await sdk.withToken({ queryFn });
+    await sdk.withToken({ queryFn });
 
-    const first = await sdk.authenticate();
-    const second = await sdk.authenticate();
+    expect(queryFn).toHaveBeenCalledTimes(2);
+    expect(queryFn).toHaveBeenNthCalledWith(1, token);
+    expect(queryFn).toHaveBeenNthCalledWith(2, token);
+    expect(keycloakService.getChallenge).toHaveBeenCalledTimes(1);
+    expect(identityProvider.authenticate).toHaveBeenCalledTimes(1);
+  });
 
-    expect(second).toBe(first);
+  it("shares the in-flight token request across concurrent calls", async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 3600;
+    const token = {
+      accessToken: makeJwt({ exp: futureExp }),
+      tokenType: "Bearer" as const,
+    };
+    const deferredToken = createDeferred<typeof token>();
+    identityProvider.authenticate.mockReturnValue(deferredToken.promise);
+
+    const sdk = new AuthSDK(config, {
+      provider: identityProvider,
+      keycloakService,
+    });
+
+    const first = sdk.withToken({ queryFn });
+    const second = sdk.withToken({ queryFn });
+
+    await waitForMicrotasks();
+    expect(keycloakService.getChallenge).toHaveBeenCalledTimes(1);
+    expect(identityProvider.authenticate).toHaveBeenCalledTimes(1);
+
+    deferredToken.resolve(token);
+    await Promise.all([first, second]);
+
+    expect(queryFn).toHaveBeenCalledTimes(2);
+    expect(queryFn).toHaveBeenNthCalledWith(1, token);
+    expect(queryFn).toHaveBeenNthCalledWith(2, token);
+  });
+
+  it("should retry with a fresh token when queryFn returns a retryable result", async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 3600;
+    const firstToken = {
+      accessToken: makeJwt({ exp: futureExp, sub: "first" }),
+      tokenType: "Bearer" as const,
+    };
+    const secondToken = {
+      accessToken: makeJwt({ exp: futureExp, sub: "second" }),
+      tokenType: "Bearer" as const,
+    };
+    identityProvider.authenticate
+      .mockResolvedValueOnce(firstToken)
+      .mockResolvedValueOnce(secondToken);
+    const retryableResult = { status: 401 };
+    const finalResult = { status: 200 };
+    queryFn.mockResolvedValueOnce(retryableResult).mockResolvedValueOnce(finalResult);
+    const refreshAndRetryWhen = jest.fn(result => result === retryableResult);
+
+    await expect(
+      new AuthSDK(config, {
+        provider: identityProvider,
+        keycloakService,
+      }).withToken({ queryFn, refreshAndRetryWhen }),
+    ).resolves.toBe(finalResult);
+
+    expect(queryFn).toHaveBeenCalledTimes(2);
+    expect(queryFn).toHaveBeenNthCalledWith(1, firstToken);
+    expect(queryFn).toHaveBeenNthCalledWith(2, secondToken);
+    expect(refreshAndRetryWhen).toHaveBeenCalledTimes(1);
+    expect(refreshAndRetryWhen).toHaveBeenCalledWith(retryableResult);
+    expect(keycloakService.getChallenge).toHaveBeenCalledTimes(2);
+    expect(identityProvider.authenticate).toHaveBeenCalledTimes(2);
+  });
+
+  it("should propagate queryFn errors without checking retry", async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 3600;
+    const token = {
+      accessToken: makeJwt({ exp: futureExp }),
+      tokenType: "Bearer",
+    };
+    identityProvider.authenticate.mockResolvedValue(token);
+    const queryFnError = new Error("Unavailable");
+    queryFn.mockRejectedValue(queryFnError);
+    const refreshAndRetryWhen = jest.fn().mockReturnValue(false);
+
+    await expect(
+      new AuthSDK(config, {
+        provider: identityProvider,
+        keycloakService,
+      }).withToken({ queryFn, refreshAndRetryWhen }),
+    ).rejects.toBe(queryFnError);
+
+    expect(queryFn).toHaveBeenCalledTimes(1);
+    expect(queryFn).toHaveBeenCalledWith(token);
+    expect(refreshAndRetryWhen).not.toHaveBeenCalled();
     expect(keycloakService.getChallenge).toHaveBeenCalledTimes(1);
     expect(identityProvider.authenticate).toHaveBeenCalledTimes(1);
   });
@@ -108,11 +205,15 @@ describe("AuthSDK", () => {
       tokenType: "Bearer",
     });
 
-    const sdk = new AuthSDK(config, { provider: identityProvider, keycloakService });
+    const sdk = new AuthSDK(config, {
+      provider: identityProvider,
+      keycloakService,
+    });
 
-    await sdk.authenticate();
-    await sdk.authenticate();
+    await sdk.withToken({ queryFn });
+    await sdk.withToken({ queryFn });
 
+    expect(queryFn).toHaveBeenCalledTimes(2);
     expect(keycloakService.getChallenge).toHaveBeenCalledTimes(2);
     expect(identityProvider.authenticate).toHaveBeenCalledTimes(2);
   });
@@ -121,17 +222,44 @@ describe("AuthSDK", () => {
     keycloakService.getChallenge.mockResolvedValueOnce(undefined);
 
     await expect(
-      new AuthSDK(config, { provider: identityProvider, keycloakService }).authenticate(),
+      new AuthSDK(config, {
+        provider: identityProvider,
+        keycloakService,
+      }).withToken({ queryFn }),
     ).rejects.toBeInstanceOf(WalletAuthInvalidChallengeError);
 
+    expect(queryFn).not.toHaveBeenCalled();
     expect(identityProvider.authenticate).not.toHaveBeenCalled();
   });
 
   it("stops when the identity provider token response is invalid", async () => {
-    identityProvider.authenticate.mockResolvedValueOnce({ accessToken: "", tokenType: "Bearer" });
+    identityProvider.authenticate.mockResolvedValueOnce({
+      accessToken: "",
+      tokenType: "Bearer",
+    });
 
     await expect(
-      new AuthSDK(config, { provider: identityProvider, keycloakService }).authenticate(),
+      new AuthSDK(config, {
+        provider: identityProvider,
+        keycloakService,
+      }).withToken({ queryFn }),
     ).rejects.toBeInstanceOf(WalletAuthInvalidTokenError);
+
+    expect(queryFn).not.toHaveBeenCalled();
   });
 });
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(res => {
+    resolve = res;
+  });
+
+  return { promise, resolve };
+}
+
+function waitForMicrotasks(): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, 0);
+  });
+}

--- a/libs/ledger-auth/src/authSDK.ts
+++ b/libs/ledger-auth/src/authSDK.ts
@@ -5,7 +5,7 @@ import type { AuthConfig, IdentityProvider, KeycloakService, KeycloakToken } fro
 import { getTokenState } from "./utils";
 
 export class AuthSDK {
-  private token?: KeycloakToken;
+  private token?: Promise<KeycloakToken>;
   private readonly idP: IdentityProvider;
   private readonly keycloakService: KeycloakService;
 
@@ -29,11 +29,54 @@ export class AuthSDK {
     this.keycloakService = keycloakService;
   }
 
-  async authenticate(): Promise<KeycloakToken> {
-    if (this.token && getTokenState(this.token.accessToken) === "valid") {
+  async withToken<T>({
+    queryFn,
+    refreshAndRetryWhen,
+  }: {
+    queryFn: (token: KeycloakToken) => Promise<T>;
+    refreshAndRetryWhen?: (result: T) => boolean;
+  }): Promise<T> {
+    const token = await this.getToken();
+    return queryFn(token).then(async (result: T) => {
+      if (!refreshAndRetryWhen?.(result)) return result;
+      const refreshedToken = await this.getToken(true);
+      return queryFn(refreshedToken);
+    });
+  }
+
+  private async getToken(forceRefresh = false): Promise<KeycloakToken> {
+    if (forceRefresh) {
+      this.token = undefined;
+    }
+
+    if (this.token) {
+      const cachedToken = this.token;
+      const token = await cachedToken;
+      if (getTokenState(token.accessToken) === "valid") {
+        return token;
+      }
+
+      if (this.token === cachedToken) {
+        this.token = this.createTokenPromise();
+      }
       return this.token;
     }
 
+    this.token = this.createTokenPromise();
+    return this.token;
+  }
+
+  private createTokenPromise(): Promise<KeycloakToken> {
+    const tokenPromise = this.fetchToken().catch(error => {
+      if (this.token === tokenPromise) {
+        this.token = undefined;
+      }
+      throw error;
+    });
+    return tokenPromise;
+  }
+
+  private async fetchToken(): Promise<KeycloakToken> {
     const pkce = this.config.disablePkce ? undefined : await createPkcePair();
     const redirectUri = `${this.keycloakService.realmBaseUrl}/broker/${this.idP.brokerId}/endpoint`;
 
@@ -59,8 +102,6 @@ export class AuthSDK {
       throw new WalletAuthInvalidTokenError();
     }
 
-    this.token = identityProviderTokenResponse;
-
-    return this.token;
+    return identityProviderTokenResponse;
   }
 }

--- a/libs/ledger-key-ring-protocol/scripts/keycloakAuth.ts
+++ b/libs/ledger-key-ring-protocol/scripts/keycloakAuth.ts
@@ -36,7 +36,7 @@ async function main(): Promise<void> {
   console.log("[CHECK] keycloak realm:", KEYCLOAK_REALM);
   console.log("[CHECK] client id:", CLIENT_ID);
 
-  const token = await new AuthSDK(
+  await new AuthSDK(
     {
       clientId: CLIENT_ID,
       keycloakBaseUrl: KEYCLOAK_BASE_URL,
@@ -46,11 +46,13 @@ async function main(): Promise<void> {
       provider,
       fetch: makeFetchCookie(fetch),
     },
-  ).authenticate();
-
-  console.log("[CHECK] token:", token);
-  if (!token.accessToken) {
-    throw new Error("Authentication succeeded but returned an empty access token");
-  }
-  console.log("\nAuth flow OK: received an access token.");
+  ).withToken({
+    queryFn: async token => {
+      console.log("[CHECK] token:", token);
+      if (!token.accessToken) {
+        throw new Error("Authentication succeeded but returned an empty access token");
+      }
+      console.log("\nAuth flow OK: received an access token.");
+    },
+  });
 }

--- a/libs/ledger-key-ring-protocol/scripts/utils/readMemberCredentials.ts
+++ b/libs/ledger-key-ring-protocol/scripts/utils/readMemberCredentials.ts
@@ -1,37 +1,39 @@
+import { createECDH } from "node:crypto";
 import type { MemberCredentials } from "../../src/types";
 
-type Credentials = MemberCredentials & { trustchainId: string };
+type Credentials = MemberCredentials & { trustchainId?: string };
 
 export async function readMemberCredentials(): Promise<Credentials> {
   const credentials = await readObjectFromStdin(
-    'Paste JSON credentials (multi-line ok) { "trustchainId": "...", "pubkey": "...", "privatekey": "..." }:\n> ',
+    [
+      'Paste JSON credentials (multi-line ok) { "trustchainId": "...", "privatekey": "..." }:',
+      "(all fields are optional enter {} to continue)",
+      "> ",
+    ].join("\n"),
   );
-  validateMemberCredentials(credentials);
-  return credentials;
+  return getCredentials(credentials);
 }
 
-function validateMemberCredentials(credentials: unknown): asserts credentials is Credentials {
-  if (typeof credentials !== "object" || credentials === null) {
-    throw new TypeError("Credentials must be a JSON object");
+function getCredentials(input: unknown): Credentials {
+  const _input =
+    typeof input !== "object" || input === null ? {} : (input as Record<string, string>);
+
+  const trustchainId = _input.trustchainId;
+  const { pubkey, privatekey } = getKeyPair(_input.privatekey);
+  return { trustchainId, pubkey, privatekey };
+}
+
+function getKeyPair(privatekey?: string): MemberCredentials {
+  const ecdh = createECDH("secp256k1");
+  if (typeof privatekey === "string") {
+    ecdh.setPrivateKey(Buffer.from(privatekey.replace(/^0x/, ""), "hex"));
+  } else {
+    ecdh.generateKeys();
   }
-  const { trustchainId, pubkey, privatekey } = credentials as Record<string, unknown>;
-  if (
-    typeof trustchainId !== "string" ||
-    typeof pubkey !== "string" ||
-    typeof privatekey !== "string"
-  ) {
-    throw new TypeError(
-      'Credentials must contain string "trustchainId", "pubkey" and "privatekey"',
-    );
-  }
-  if (pubkey.length !== 66) {
-    // LKRP public keys have a 1 byte prefix, so 33 bytes = 66 hex chars.
-    throw new RangeError(`Expected pubkey to be 66 hex chars, got ${pubkey.length}`);
-  }
-  if (privatekey.length !== 64) {
-    throw new RangeError(`Expected privatekey to be 64 hex chars, got ${privatekey.length}`);
-  }
-  console.log("[CHECK] Received valid member credentials!");
+  return {
+    pubkey: ecdh.getPublicKey("hex", "compressed"),
+    privatekey: ecdh.getPrivateKey("hex"),
+  };
 }
 
 async function readObjectFromStdin(prompt: string): Promise<unknown> {

--- a/libs/ledger-key-ring-protocol/src/LKRPIdentityProvider.ts
+++ b/libs/ledger-key-ring-protocol/src/LKRPIdentityProvider.ts
@@ -7,10 +7,10 @@ import {
   type KeycloakToken,
 } from "@ledgerhq/ledger-auth";
 import getApi, {
-  type ChallengeSignature,
   type Challenge as ChallengeJson,
   type LKRPChallenge,
   LKRPChallengeSchema,
+  type WeakChallengeSignature,
 } from "./api";
 import type { MemberCredentials } from "./types";
 import { convertLiveCredentialsToKeyPair, credentialForPubKey, liveAuthentication } from "./utils";
@@ -47,9 +47,9 @@ export class LkrpIdentityProvider implements IdentityProvider {
 
   private signChallenge(challenge: LKRPChallenge): {
     challenge: ChallengeJson;
-    signature: ChallengeSignature;
+    signature: WeakChallengeSignature;
   } {
-    if (!this.keypair || !this.trustchainId) {
+    if (!this.keypair) {
       throw new WalletAuthNoCredentialsError(this.brokerId);
     }
 
@@ -62,7 +62,9 @@ export class LkrpIdentityProvider implements IdentityProvider {
       signature: {
         credential: credentialForPubKey(this.keypair.pubkey),
         signature: crypto.to_hex(crypto.sign(hash, keypair)),
-        attestation: crypto.to_hex(liveAuthentication(this.trustchainId)),
+        attestation: this.trustchainId
+          ? crypto.to_hex(liveAuthentication(this.trustchainId))
+          : undefined,
       },
     };
   }

--- a/libs/ledger-key-ring-protocol/src/__tests__/LKRPIdentityProvider.integration.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/LKRPIdentityProvider.integration.test.ts
@@ -35,10 +35,10 @@ const CHALLENGE_JSON = toApiChallenge(PARSED_CHALLENGE);
 const IDP_HOST = CHALLENGE_JSON.host;
 
 describe("LkrpIdentityProvider (integration, MSW)", () => {
-  let server: SetupServerApi;
+  const server: SetupServerApi = initServer();
+  const queryFn = jest.fn().mockResolvedValue({ ok: true });
 
   beforeAll(() => {
-    server = initServer();
     server.listen({ onUnhandledRequest: "error" });
   });
 
@@ -46,12 +46,13 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
     server.close();
   });
 
-  afterEach(() => {
+  beforeEach(() => {
+    jest.clearAllMocks();
     server.resetHandlers();
   });
 
   it("retrieves a Keycloak JWT without PKCE", async () => {
-    const token = await new AuthSDK(
+    await new AuthSDK(
       {
         clientId: CLIENT_ID,
         keycloakBaseUrl: KEYCLOAK_BASE_URL,
@@ -59,9 +60,9 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
         disablePkce: true,
       },
       { provider: createIdentityProvider() },
-    ).authenticate();
+    ).withToken({ queryFn });
 
-    expect(token).toEqual({
+    expect(queryFn).toHaveBeenCalledWith({
       accessToken: EXPECTED_JWT,
       tokenType: "Bearer",
       scope: "openid",
@@ -72,7 +73,7 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
   });
 
   it("retrieves a Keycloak JWT with PKCE", async () => {
-    const token = await new AuthSDK(
+    await new AuthSDK(
       {
         clientId: CLIENT_ID,
         keycloakBaseUrl: KEYCLOAK_BASE_URL,
@@ -80,9 +81,9 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
         disablePkce: false,
       },
       { provider: createIdentityProvider() },
-    ).authenticate();
+    ).withToken({ queryFn });
 
-    expect(token).toEqual({
+    expect(queryFn).toHaveBeenCalledWith({
       accessToken: EXPECTED_JWT,
       tokenType: "Bearer",
       scope: "openid",

--- a/libs/ledger-key-ring-protocol/src/__tests__/LKRPIdentityProvider.integration.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/LKRPIdentityProvider.integration.test.ts
@@ -2,14 +2,14 @@ import { Challenge, crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import { AuthSDK } from "@ledgerhq/ledger-auth";
 import { HttpResponse, http } from "msw";
 import { setupServer, type SetupServerApi } from "msw/node";
-import type { Challenge as ChallengeJson, ChallengeSignature } from "../api";
+import type { Challenge as ChallengeJson, WeakChallengeSignature } from "../api";
 import { LkrpIdentityProvider } from "../LKRPIdentityProvider";
 import type { MemberCredentials } from "../types";
 import { credentialForPubKey, liveAuthentication } from "../utils";
 
 type SignedChallengeRequest = {
   challenge: ChallengeJson;
-  signature: ChallengeSignature;
+  signature: WeakChallengeSignature;
 };
 
 const CLIENT_ID = "ledger-keycloak";
@@ -22,6 +22,7 @@ const AUTHORIZATION_CODE = "auth-code-xyz";
 const IDP_TOKEN = makeJwt({ sub: "idp", exp: 4102444800 });
 const EXPECTED_JWT = makeJwt({ sub: "keycloak", exp: 4102444800 });
 const REFRESH_TOKEN = makeJwt({ sub: "refresh", exp: 4102444800 });
+const EXPECTED_ATTESTATION = crypto.to_hex(liveAuthentication(TRUSTCHAIN_ID));
 
 const MEMBER_CREDENTIALS: MemberCredentials = {
   pubkey: "02e3311a12c450604725f02d1a775ef5cdb4a1b832eb41ac6b1302adbe92a612fc",
@@ -35,7 +36,8 @@ const CHALLENGE_JSON = toApiChallenge(PARSED_CHALLENGE);
 const IDP_HOST = CHALLENGE_JSON.host;
 
 describe("LkrpIdentityProvider (integration, MSW)", () => {
-  const server: SetupServerApi = initServer();
+  const oidcAuthenticateMock = jest.fn<void, [SignedChallengeRequest]>();
+  const server: SetupServerApi = initServer(oidcAuthenticateMock);
   const queryFn = jest.fn().mockResolvedValue({ ok: true });
 
   beforeAll(() => {
@@ -59,7 +61,7 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
         keycloakRealm: REALM,
         disablePkce: true,
       },
-      { provider: createIdentityProvider() },
+      { provider: createIdentityProvider(TRUSTCHAIN_ID) },
     ).withToken({ queryFn });
 
     expect(queryFn).toHaveBeenCalledWith({
@@ -70,6 +72,14 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
       refreshToken: REFRESH_TOKEN,
       refreshExpiresIn: 1800,
     });
+    expect(oidcAuthenticateMock).toHaveBeenCalledTimes(1);
+    expect(oidcAuthenticateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signature: expect.objectContaining({
+          attestation: EXPECTED_ATTESTATION,
+        }),
+      }),
+    );
   });
 
   it("retrieves a Keycloak JWT with PKCE", async () => {
@@ -80,7 +90,7 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
         keycloakRealm: REALM,
         disablePkce: false,
       },
-      { provider: createIdentityProvider() },
+      { provider: createIdentityProvider(TRUSTCHAIN_ID) },
     ).withToken({ queryFn });
 
     expect(queryFn).toHaveBeenCalledWith({
@@ -91,17 +101,51 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
       refreshToken: REFRESH_TOKEN,
       refreshExpiresIn: 1800,
     });
+    expect(oidcAuthenticateMock).toHaveBeenCalledTimes(1);
+    expect(oidcAuthenticateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signature: expect.objectContaining({
+          attestation: EXPECTED_ATTESTATION,
+        }),
+      }),
+    );
+  });
+
+  it("retrieves a Keycloak JWT without attestation when no trustchain id is set", async () => {
+    await new AuthSDK(
+      {
+        clientId: CLIENT_ID,
+        keycloakBaseUrl: KEYCLOAK_BASE_URL,
+        keycloakRealm: REALM,
+        disablePkce: true,
+      },
+      { provider: createIdentityProvider(undefined) },
+    ).withToken({ queryFn });
+
+    expect(queryFn).toHaveBeenCalledWith({
+      accessToken: EXPECTED_JWT,
+      tokenType: "Bearer",
+      scope: "openid",
+      expiresIn: 300,
+      refreshToken: REFRESH_TOKEN,
+      refreshExpiresIn: 1800,
+    });
+    expect(oidcAuthenticateMock).toHaveBeenCalledTimes(1);
+    const request = oidcAuthenticateMock.mock.calls[0]?.[0];
+    expect(request?.signature).not.toHaveProperty("attestation");
   });
 });
 
-function createIdentityProvider(): LkrpIdentityProvider {
+function createIdentityProvider(trustchainId: string | undefined): LkrpIdentityProvider {
   const provider = new LkrpIdentityProvider();
   provider.setKeypair(MEMBER_CREDENTIALS);
-  provider.setTrustchainId(TRUSTCHAIN_ID);
+  provider.setTrustchainId(trustchainId);
   return provider;
 }
 
-function initServer(): SetupServerApi {
+function initServer(
+  oidcAuthenticateMock: jest.Mock<void, [SignedChallengeRequest]>,
+): SetupServerApi {
   const sessionStore = new Map<string, { codeChallenge?: string }>();
   let pendingCodeChallenge: string | undefined;
 
@@ -127,6 +171,7 @@ function initServer(): SetupServerApi {
 
     http.post(`https://${IDP_HOST}/openid/v1/authenticate`, async ({ request }) => {
       const body = (await request.json()) as SignedChallengeRequest;
+      oidcAuthenticateMock(body);
       if (!isValidSignedChallengeRequest(body)) {
         return HttpResponse.json({ error: "invalid_request" }, { status: 400 });
       }
@@ -175,11 +220,12 @@ function initServer(): SetupServerApi {
         return HttpResponse.json({ error: "invalid_request" }, { status: 400 });
       }
 
-      return HttpResponse.json({
+      const tokenResponse: Record<string, unknown> = {
         access_token: IDP_TOKEN,
-        permissions: { [TRUSTCHAIN_ID]: { "m/0'/16'/0'": "ffffffff" } },
         token_type: "Bearer",
-      });
+      };
+
+      return HttpResponse.json(tokenResponse);
     }),
 
     http.post(`https://${IDP_HOST}/openid/v1/exchange`, async ({ request }) => {
@@ -216,7 +262,10 @@ function isValidSignedChallengeRequest(body: SignedChallengeRequest): boolean {
     return false;
   }
 
-  if (body.signature.attestation !== crypto.to_hex(liveAuthentication(TRUSTCHAIN_ID))) {
+  if (
+    body.signature.attestation !== undefined &&
+    body.signature.attestation !== EXPECTED_ATTESTATION
+  ) {
     return false;
   }
 

--- a/libs/ledger-key-ring-protocol/src/api.ts
+++ b/libs/ledger-key-ring-protocol/src/api.ts
@@ -15,8 +15,7 @@ export type StatusAPIResponse = {
 
 export const APIJWTSchema = z.object({
   access_token: z.jwt(),
-  // permissions: { [trustchainId]: { [path]: string } }
-  permissions: z.record(z.string(), z.record(z.string(), z.string())),
+  permissions: z.optional(z.record(z.string(), z.record(z.string(), z.string()))),
 });
 export type APIJWT = z.infer<typeof APIJWTSchema>;
 
@@ -51,6 +50,10 @@ export const LKRPChallengeSchema = z.object({
   tlv: z.hex().min(1),
 });
 export type LKRPChallenge = z.infer<typeof LKRPChallengeSchema>;
+
+export type WeakChallengeSignature = Omit<ChallengeSignature, "attestation"> & {
+  attestation?: string;
+};
 
 export type ChallengeSignature = {
   credential: {
@@ -122,7 +125,7 @@ const getApi = (apiBaseURL: string) => {
 
   async function oidcPostChallengeResponse(request: {
     challenge: Challenge;
-    signature: ChallengeSignature;
+    signature: WeakChallengeSignature;
   }): Promise<string> {
     const { data } = await network<unknown>({
       url: `${apiBaseURL}/openid/v1/authenticate`,

--- a/libs/ledger-key-ring-protocol/src/sdk.ts
+++ b/libs/ledger-key-ring-protocol/src/sdk.ts
@@ -75,7 +75,7 @@ export class SDK implements TrustchainSDK {
       jwt => {
         this.jwt = jwt;
         if (!ignorePermissionsChecks) {
-          const permissions = jwt.permissions[trustchain.rootId];
+          const permissions = jwt?.permissions?.[trustchain.rootId];
           if (!permissions) {
             throw new TrustchainNotAllowed("permissions not available for current trustchain");
           }

--- a/libs/ledger-key-ring-protocol/src/types.ts
+++ b/libs/ledger-key-ring-protocol/src/types.ts
@@ -7,7 +7,7 @@ import { TrustchainsResponse } from "./api";
  */
 export type JWT = {
   accessToken: string;
-  permissions: {
+  permissions?: {
     [trustchainId: string]: {
       [path: string]: string;
     };


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR adds support for concurrent authentication directly in the AuthSDK for more flexible integration.
It also allows non-LKRP users to authenticate based on https://ledgerhq.atlassian.net/wiki/spaces/TA/pages/7206305867/ADR+Allow+unattested+signature+for+openid+flow+in+LKRP

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): https://ledgerhq.atlassian.net/wiki/spaces/TA/pages/7206305867/ADR+Allow+unattested+signature+for+openid+flow+in+LKRP <!-- link to the relevant architectural decision record -->
