### PR TITLE
fix(wallet-cli): always reset device session on connect failure

### DIFF
--- a/apps/wallet-cli/src/session/bridge-device-session.test.ts
+++ b/apps/wallet-cli/src/session/bridge-device-session.test.ts
@@ -55,7 +55,7 @@ let executeImpl: () => { observable: Observable<unknown>; cancel: () => void };
 const { _setTestDmkTransport, disposeWalletCliDmkTransportFully } =
   await import("../device/register-dmk-transport");
 const { WalletCliDeviceError } = await import("../device/wallet-cli-device-error");
-const { getManagerAppNameForCurrencyId, withCurrencyDeviceSession } =
+const { getManagerAppNameForCurrencyId, withCurrencyDeviceSession, withDmkDeviceSession } =
   await import("./bridge-device-session");
 
 describe("withCurrencyDeviceSession", () => {
@@ -125,6 +125,60 @@ describe("withCurrencyDeviceSession", () => {
     const result = await withCurrencyDeviceSession("bitcoin", async () => "done");
 
     expect(result).toBe("done");
+    expect(calls.reset).toBe(1);
+  });
+});
+
+describe("withDmkDeviceSession", () => {
+  beforeEach(async () => {
+    _setTestDmkTransport(null);
+    await disposeWalletCliDmkTransportFully();
+    calls.execute = [];
+    calls.reset = 0;
+    executeImpl = () => completedAction();
+    _setTestDmkTransport(testTransport as never);
+  });
+
+  afterEach(async () => {
+    await disposeWalletCliDmkTransportFully();
+    _setTestDmkTransport(null);
+  });
+
+  it("wraps setup failures as WalletCliDeviceError", async () => {
+    const usbError = new Error("USB down");
+    _setTestDmkTransport({
+      get dmk() {
+        throw usbError;
+      },
+      sessionId: "broken-session-id",
+    } as never);
+
+    await expect(withDmkDeviceSession(async () => "ok")).rejects.toBeInstanceOf(
+      WalletCliDeviceError,
+    );
+    // No session was established, so the always-on reset has nothing to disconnect.
+    expect(calls.reset).toBe(0);
+  });
+
+  it("rethrows callback failures unchanged after resetting the session", async () => {
+    const callbackError = new Error("HTTP parsing bug");
+
+    await expect(
+      withDmkDeviceSession(async () => {
+        throw callbackError;
+      }),
+    ).rejects.toBe(callbackError);
+
+    // No app is opened on this path, so the device action is never executed.
+    expect(calls.execute).toHaveLength(0);
+    expect(calls.reset).toBe(1);
+  });
+
+  it("resets the session after a successful callback", async () => {
+    const result = await withDmkDeviceSession(async () => "done");
+
+    expect(result).toBe("done");
+    expect(calls.execute).toHaveLength(0);
     expect(calls.reset).toBe(1);
   });
 });

--- a/apps/wallet-cli/src/session/bridge-device-session.test.ts
+++ b/apps/wallet-cli/src/session/bridge-device-session.test.ts
@@ -86,17 +86,19 @@ describe("withCurrencyDeviceSession", () => {
       WalletCliDeviceError,
     );
     expect(calls.execute).toHaveLength(0);
+    // The transport was never established, so the always-on reset has nothing to disconnect.
     expect(calls.reset).toBe(0);
   });
 
-  it("wraps connect failures as WalletCliDeviceError", async () => {
+  it("wraps connect failures as WalletCliDeviceError and resets the session", async () => {
     executeImpl = () => errorAction(new Error("connect failed"));
 
     await expect(withCurrencyDeviceSession("ethereum", async () => "ok")).rejects.toBeInstanceOf(
       WalletCliDeviceError,
     );
     expect(calls.execute).toHaveLength(1);
-    expect(calls.reset).toBe(0);
+    // A session was opened before app-open failed, so it must be torn down.
+    expect(calls.reset).toBe(1);
   });
 
   it("rethrows callback failures unchanged after resetting the session", async () => {

--- a/apps/wallet-cli/src/session/bridge-device-session.test.ts
+++ b/apps/wallet-cli/src/session/bridge-device-session.test.ts
@@ -86,7 +86,7 @@ describe("withCurrencyDeviceSession", () => {
       WalletCliDeviceError,
     );
     expect(calls.execute).toHaveLength(0);
-    // The transport was never established, so the always-on reset has nothing to disconnect.
+    // No session was established, so the always-on reset has nothing to disconnect.
     expect(calls.reset).toBe(0);
   });
 
@@ -97,7 +97,6 @@ describe("withCurrencyDeviceSession", () => {
       WalletCliDeviceError,
     );
     expect(calls.execute).toHaveLength(1);
-    // A session was opened before app-open failed, so it must be torn down.
     expect(calls.reset).toBe(1);
   });
 

--- a/apps/wallet-cli/src/session/bridge-device-session.ts
+++ b/apps/wallet-cli/src/session/bridge-device-session.ts
@@ -28,20 +28,20 @@ export function withCurrencyDeviceSession<T>(
 ): Promise<T> {
   return withWalletCliDeviceInterruptScope(async () => {
     const managerAppName = getManagerAppNameForCurrencyId(currencyId);
-    walletCliDebug("Ensuring DMK transport…");
     try {
-      const transport = await ensureWalletCliDmkTransport();
-      walletCliDebug(`Connecting Ledger app (${managerAppName})…`);
-      await connectLedgerApp(transport.dmk, transport.sessionId, managerAppName, {
-        onStateChange: options.onStateChange,
-        deviceTimeoutMs: options.deviceTimeoutMs,
-      });
-    } catch (e) {
-      const deviceModelId = await getWalletCliDeviceModelId().catch(() => undefined);
-      throw WalletCliDeviceError.fromUnknown(e, { expectedApp: managerAppName, deviceModelId });
-    }
-    walletCliDebug("Device session ready.");
-    try {
+      walletCliDebug("Ensuring DMK transport…");
+      try {
+        const transport = await ensureWalletCliDmkTransport();
+        walletCliDebug(`Connecting Ledger app (${managerAppName})…`);
+        await connectLedgerApp(transport.dmk, transport.sessionId, managerAppName, {
+          onStateChange: options.onStateChange,
+          deviceTimeoutMs: options.deviceTimeoutMs,
+        });
+      } catch (e) {
+        const deviceModelId = await getWalletCliDeviceModelId().catch(() => undefined);
+        throw WalletCliDeviceError.fromUnknown(e, { expectedApp: managerAppName, deviceModelId });
+      }
+      walletCliDebug("Device session ready.");
       return await fn();
     } finally {
       walletCliDebug("Resetting device session…");
@@ -55,14 +55,14 @@ export function withCurrencyDeviceSession<T>(
  */
 export function withDmkDeviceSession<T>(fn: () => Promise<T>): Promise<T> {
   return withWalletCliDeviceInterruptScope(async () => {
-    walletCliDebug("Ensuring DMK transport…");
     try {
-      await ensureWalletCliDmkTransport();
-    } catch (e) {
-      throw WalletCliDeviceError.fromUnknown(e, { expectedApp: "Ledger dashboard" });
-    }
-    walletCliDebug("DMK device session ready.");
-    try {
+      walletCliDebug("Ensuring DMK transport…");
+      try {
+        await ensureWalletCliDmkTransport();
+      } catch (e) {
+        throw WalletCliDeviceError.fromUnknown(e, { expectedApp: "Ledger dashboard" });
+      }
+      walletCliDebug("DMK device session ready.");
       return await fn();
     } finally {
       walletCliDebug("Resetting device session…");


### PR DESCRIPTION
## Summary

The DMK device-session reset in `withCurrencyDeviceSession` and `withDmkDeviceSession` lived in a `finally` block that only wrapped the command callback (`fn()`). When a failure happened earlier — during transport setup (`ensureWalletCliDmkTransport`) or Ledger app-open (`connectLedgerApp`) — the reset never ran, leaving the USB session and persistent DMK kit dangling after a failed connect.

This wraps the entire session (connect + callback) in a single `try/finally` that always resets, while keeping the inner `try/catch` that wraps setup/open errors as `WalletCliDeviceError`.

`resetWalletCliDmkSession()` is safe/idempotent when nothing was established: a null session short-circuits every teardown step.

## Changes

- `withCurrencyDeviceSession`: single outer try/finally around connect + callback; inner try/catch preserves `WalletCliDeviceError` wrapping (with `deviceModelId`).
- `withDmkDeviceSession`: same restructuring.

## Tests

- Renamed the connect-failure test to assert the session is now reset (`calls.reset` `0 → 1`).
- Setup-failure test stays at `0` (transport never established → nothing to disconnect) with a clarifying comment.
- `bun test src/session/bridge-device-session.test.ts` — 6 pass.