### PR TITLE
fix(contact): relax contact address schema format

### DIFF
--- a/.changeset/relax-contact-address-schema.md
+++ b/.changeset/relax-contact-address-schema.md
@@ -1,0 +1,5 @@
+---
+"@domain/entity-contact": minor
+---
+
+Relax Contact address schema to store currency-specific addresses as generic non-empty strings.

--- a/domain/entity/contact/README.md
+++ b/domain/entity/contact/README.md
@@ -8,9 +8,9 @@ This package describes what Contacts flows manipulate:
 
 - the default `Me` contact used by the `Me` screens;
 - saved contacts;
-- EVM contact addresses with `currencyId`, `label`, and `address`.
+- contact addresses with `currencyId`, `label`, and `address`.
 
-`currencyId` is the id of the `CryptoOrTokenCurrency` selected by MAD. Asset names, tickers, icons, and network display data are resolved later by flow or platform adapters.
+`currencyId` is the id of the `CryptoOrTokenCurrency` selected by MAD. `address` is intentionally stored as a generic non-empty string because address parsing and currency-specific validation belong to flow or platform adapters. Asset names, tickers, icons, and network display data are also resolved later by those adapters.
 
 It does not implement persistence, WalletSync, Ledger Sync, device actions, signer payloads, routing, Redux slices, or UI.
 

--- a/domain/entity/contact/src/schema.test.ts
+++ b/domain/entity/contact/src/schema.test.ts
@@ -1,8 +1,8 @@
 import {
   ContactAddressLabelSchema,
   ContactAddressSchema,
+  ContactAddressValueSchema,
   ContactCurrencyIdSchema,
-  ContactEvmAddressSchema,
   ContactSchema,
 } from "./schema";
 import {
@@ -38,11 +38,20 @@ describe("ContactSchema", () => {
 });
 
 describe("ContactAddressSchema", () => {
-  it("parses an EVM contact address", () => {
+  it("parses a contact address", () => {
     const address = mockContactAddress();
 
     expect(ContactAddressSchema.parse(address)).toEqual(address);
     expect(address.currencyId).toBe("ethereum");
+  });
+
+  it("keeps address format generic for the selected currency", () => {
+    const address = mockContactAddress({
+      currencyId: "solana",
+      address: "So11111111111111111111111111111111111111112",
+    });
+
+    expect(ContactAddressSchema.parse(address)).toEqual(address);
   });
 
   it("parses a token currency id selected through MAD", () => {
@@ -55,8 +64,8 @@ describe("ContactAddressSchema", () => {
     expect(ContactCurrencyIdSchema.parse("ethereum")).toBe("ethereum");
   });
 
-  it("rejects non-EVM address format", () => {
-    expect(() => ContactEvmAddressSchema.parse("not-an-address")).toThrow();
+  it("rejects empty addresses", () => {
+    expect(() => ContactAddressValueSchema.parse("   ")).toThrow();
   });
 
   it("rejects non-ASCII address labels", () => {

--- a/domain/entity/contact/src/schema.ts
+++ b/domain/entity/contact/src/schema.ts
@@ -13,16 +13,13 @@ export const ContactAddressLabelSchema = z
   .min(1)
   .regex(/^[\x20-\x7E]+$/, "Expected printable ASCII characters");
 
-export const ContactEvmAddressSchema = z
-  .string()
-  .trim()
-  .regex(/^0x[a-fA-F0-9]{40}$/, "Expected an EVM address");
+export const ContactAddressValueSchema = NonEmptyStringSchema;
 
 export const ContactAddressSchema = z.object({
   id: ContactAddressIdSchema,
   currencyId: ContactCurrencyIdSchema,
   label: ContactAddressLabelSchema,
-  address: ContactEvmAddressSchema,
+  address: ContactAddressValueSchema,
 });
 
 export const ContactSchema = z.object({

--- a/domain/entity/contact/src/types.ts
+++ b/domain/entity/contact/src/types.ts
@@ -3,8 +3,8 @@ import {
   ContactAddressIdSchema,
   ContactAddressLabelSchema,
   ContactAddressSchema,
+  ContactAddressValueSchema,
   ContactCurrencyIdSchema,
-  ContactEvmAddressSchema,
   ContactIdSchema,
   ContactNameSchema,
   ContactSchema,
@@ -15,7 +15,7 @@ export type ContactAddressId = z.infer<typeof ContactAddressIdSchema>;
 export type ContactCurrencyId = z.infer<typeof ContactCurrencyIdSchema>;
 export type ContactName = z.infer<typeof ContactNameSchema>;
 export type ContactAddressLabel = z.infer<typeof ContactAddressLabelSchema>;
-export type ContactEvmAddress = z.infer<typeof ContactEvmAddressSchema>;
+export type ContactAddressValue = z.infer<typeof ContactAddressValueSchema>;
 export type ContactAddress = z.infer<typeof ContactAddressSchema>;
 export type Contact = z.infer<typeof ContactSchema>;
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Ran Contact entity Jest, TypeScript, Knip, and `git diff --check`.
- [x] **Impact of the changes:**
      Contact addresses are no longer constrained to an EVM `0x` 40-character hex format at the generic domain entity level.

### 📝 Description

Contact address values were previously validated with an EVM-specific `0x[a-fA-F0-9]{40}` regex inside `@domain/entity-contact`. That made the generic Contact entity assume one currency family, even though Contacts are modeled per `currencyId` and future currencies may use different address formats.

This PR replaces the EVM-specific address schema with a generic non-empty string schema. Currency-specific parsing and validation should live in flow/platform adapters where the selected currency context is available. The PR also updates tests to prove a non-EVM address-like value is accepted while empty addresses are still rejected.

This PR intentionally does not add device proof / Address Book verification fields. That should be handled in a dedicated model update once we align the stable Contact persistence shape with the DMK Address Book intent payloads (`groupHandle`, `hmacProof`, `hmacRest`, etc.).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33875](https://ledgerhq.atlassian.net/browse/LIVE-33875)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-33875]: https://ledgerhq.atlassian.net/browse/LIVE-33875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ