### PR TITLE
[LWDM] feat(LIVE-33578): update CAL env defaults to Gravitee URLs

### DIFF
--- a/.changeset/cal-gravitee-urls.md
+++ b/.changeset/cal-gravitee-urls.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-env": patch
+"@ledgerhq/cryptoassets": patch
+---
+
+Update default values for `CAL_SERVICE_URL` and `CAL_SERVICE_URL_STAGING` to the Gravitee gateway URLs (`https://global.api.prd.ledger.com/cal` and `https://global.api.stg.ledger-test.com/cal`).

--- a/docs/services.md
+++ b/docs/services.md
@@ -95,7 +95,7 @@ Inside the Internal and Third-party tables, rows are grouped by **owning team** 
 | Provider session | `buy.api.live.ledger.com` | [env](/libs/env/src/env.ts) | prod |
 | Swap backend | `swap.ledger.com` | [env](/libs/env/src/env.ts) | prod |
 | Ramp catalog | `cdn.live.ledger.com` | [env](/libs/env/src/env.ts) | prod |
-| Partner signatures (CAL) | `crypto-assets-service.api.ledger.com` | [env](/libs/env/src/env.ts) | prod |
+| Partner signatures (CAL) | `global.api.prd.ledger.com`<br>_path: `/cal`; staging: `global.api.stg.ledger-test.com`_ | [env](/libs/env/src/env.ts) | prod |
 | Buy/Sell limits | `buy.api.aws.prd.ldg-tech.com`<br>_E2E only_ | [code](/libs/ledger-live-common/src/e2e/buySell.ts) | test |
 | Live app — Swap | `swap-live-app.ledger.com`<br>_manifest [`swap-live-app-aws`](https://live-app-catalog.ledger.com/api/v1/apps)_ | feature-flag | prod |
 | Live app — Buy / Sell | `buy-sell.live.ledger.com`<br>_manifest [`buy-sell`](https://live-app-catalog.ledger.com/api/v1/apps)_ | feature-flag | prod |
@@ -107,7 +107,7 @@ Inside the Internal and Third-party tables, rows are grouped by **owning team** 
 | Countervalues / prices | `countervalues.live.ledger.com`<br>_also `countervalues.api.live`, `countervalues-service.api`_ | [env](/libs/env/src/env.ts) | prod |
 | CoinMarketCap proxy | `proxycmc.api.live.ledger.com` | [env](/libs/env/src/env.ts) | prod |
 | CoinGecko proxy | `proxycg.api.live.ledger.com`<br>_`proxycgassets.api.live` also seen_ | [env](/libs/env/src/env.ts) | prod |
-| Crypto Assets List (CAL) | `crypto-assets-service.api.ledger.com`<br>_`cal.api.*` also seen_ | [env](/libs/env/src/env.ts) | prod |
+| Crypto Assets List (CAL) | `global.api.prd.ledger.com`<br>_path: `/cal`; staging: `global.api.stg.ledger-test.com`_ | [env](/libs/env/src/env.ts) | prod |
 | CAL dynamic CDN | `cdn.live.ledger.com` | [env](/libs/env/src/env.ts) | prod |
 | DADA (assets data aggregator) | `dada.api.ledger.com` | [env](/libs/env/src/env.ts) | prod |
 | Mapping service | `mapping-service.api.ledger.com` | [env](/libs/env/src/env.ts) | prod |

--- a/domain/api/currency-token/src/api.test.ts
+++ b/domain/api/currency-token/src/api.test.ts
@@ -216,6 +216,27 @@ describe("cryptoAssetsApi requests", () => {
     expect(url).toContain("id=ethereum");
   });
 
+  it("getTokensSyncHash preserves a path prefix in the base URL (Gravitee /cal prefix)", async () => {
+    mockFetch([{ id: "ethereum" }], { "X-Ledger-Commit": "abc123" });
+    const store = configureStore({
+      reducer: { [cryptoAssetsApi.reducerPath]: cryptoAssetsApi.reducer },
+      middleware: gdm =>
+        gdm({
+          thunk: {
+            extraArgument: calApiExtra({
+              calServiceUrl: "https://global.api.prd.ledger.com/cal",
+              ledgerClientVersion: "1.2.3",
+            }),
+          },
+        }).concat(cryptoAssetsApi.middleware),
+    });
+
+    await store.dispatch(cryptoAssetsApi.endpoints.getTokensSyncHash.initiate("ethereum"));
+
+    const url = String(fetchSpy.mock.calls[0][0]);
+    expect(url).toContain("https://global.api.prd.ledger.com/cal/v1/currencies");
+  });
+
   it("getTokensSyncHash errors with 404 on an empty currency array", async () => {
     mockFetch([], { "X-Ledger-Commit": "commit-hash" });
     const store = makeStore();

--- a/domain/api/currency-token/src/api.ts
+++ b/domain/api/currency-token/src/api.ts
@@ -105,7 +105,7 @@ export const cryptoAssetsApi = createApi({
       async queryFn(currencyId, queryApi) {
         const extra = getCalExtra(queryApi);
         try {
-          const url = new URL("/v1/currencies", extra.calServiceUrl);
+          const url = new URL(`${extra.calServiceUrl}/v1/currencies`);
           url.searchParams.set("output", "id");
           url.searchParams.set("limit", "1");
           url.searchParams.set("id", currencyId);

--- a/e2e/mobile/helpers/commonHelpers.ts
+++ b/e2e/mobile/helpers/commonHelpers.ts
@@ -61,7 +61,7 @@ function createDetoxURLBlacklistRegex(): string {
     ".*.googleapis.com/.*",
     ".*clients3.google.com.*",
     ".*tron.coin.ledger.com/wallet/getBrokerage.*",
-    ".*crypto-assets-service.api.ledger.com.*",
+    ".*global.api.prd.ledger.com/cal.*",
     ".*127.0.0.1.*",
     ".*speculos.*ldg-tech.com.*",
     ".*optimism.*",

--- a/libs/coin-tester-modules/coin-tester-evm/src/indexer.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/indexer.ts
@@ -764,7 +764,7 @@ const getEtherscanOpsMap = (action: string) => {
 let server: SetupServerApi;
 export const initMswHandlers = (currencyConfig: EvmConfigInfo) => {
   const handlers = [
-    http.get("https://crypto-assets-service.api.ledger.com/v1/currencies", ({ request }) => {
+    http.get("https://global.api.prd.ledger.com/cal/v1/currencies", ({ request }) => {
       const response: Array<{ id: string; type: string }> = [];
       const url = new URL(request.url);
       const id = url.searchParams.get("id");
@@ -785,7 +785,7 @@ export const initMswHandlers = (currencyConfig: EvmConfigInfo) => {
 
       return HttpResponse.json(response, { headers: { "X-Ledger-Commit": "hash" } });
     }),
-    http.get("https://crypto-assets-service.api.ledger.com/v1/tokens", ({ request }) => {
+    http.get("https://global.api.prd.ledger.com/cal/v1/tokens", ({ request }) => {
       const response: Array<{
         id: string;
         contract_address: string;

--- a/libs/coin-tester-modules/coin-tester-solana/src/fixtures.ts
+++ b/libs/coin-tester-modules/coin-tester-solana/src/fixtures.ts
@@ -156,7 +156,7 @@ export const makeAccount = (
 
 export function initMSW(): () => void {
   const mockServer = setupServer(
-    http.get("https://crypto-assets-service.api.ledger.com/v1/certificates", ({ request }) => {
+    http.get("https://global.api.prd.ledger.com/cal/v1/certificates", ({ request }) => {
       const url = new URL(request.url);
 
       if (url.searchParams.get("target_device") !== "nanox") {
@@ -292,7 +292,7 @@ export function initMSW(): () => void {
     http.get("https://earn-dashboard.aws.stg.ldg-tech.com/figment/solana/validators_summary", () =>
       HttpResponse.json([]),
     ),
-    http.get("https://crypto-assets-service.api.ledger.com/v1/tokens", ({ request }) => {
+    http.get("https://global.api.prd.ledger.com/cal/v1/tokens", ({ request }) => {
       const url = new URL(request.url);
       switch (url.searchParams.get("id")) {
         case "solana/spl/epjfwdd5aufqssqem2qn1xzybapc8g4weggkzwytdt1v": // USDC

--- a/libs/coin-tester-modules/coin-tester-stellar/src/indexer.ts
+++ b/libs/coin-tester-modules/coin-tester-stellar/src/indexer.ts
@@ -14,7 +14,7 @@ import { setupServer } from "msw/node";
  */
 export function initMswHandlers(): () => void {
   const server = setupServer(
-    http.get("https://crypto-assets-service.api.ledger.com/*", () => HttpResponse.json([])),
+    http.get("https://global.api.prd.ledger.com/cal/*", () => HttpResponse.json([])),
     http.get("https://nft.api.live.ledger.com/*", () => HttpResponse.json([])),
     http.get("https://earn.api.live.ledger.com/*", () => HttpResponse.json([])),
     http.get("https://countervalues.live.ledger.com/*", () => HttpResponse.json([])),

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -954,12 +954,12 @@ const envDefinitions = {
     desc: "bucket S3 of the dynamic cryptoassets list",
   },
   CAL_SERVICE_URL: {
-    def: "https://crypto-assets-service.api.ledger.com",
+    def: "https://global.api.prd.ledger.com/cal",
     parser: stringParser,
     desc: "Cryptoassets list service url",
   },
   CAL_SERVICE_URL_STAGING: {
-    def: "https://crypto-assets-service.api.ledger-test.com",
+    def: "https://global.api.stg.ledger-test.com/cal",
     parser: stringParser,
     desc: "Cryptoassets list service url (staging)",
   },

--- a/libs/ledger-services/cal/src/partners/index.test.ts
+++ b/libs/ledger-services/cal/src/partners/index.test.ts
@@ -209,7 +209,7 @@ describe("getProvidersData", () => {
 
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: "https://crypto-assets-service.api.ledger.com/v1/partners",
+        url: "https://global.api.prd.ledger.com/cal/v1/partners",
         params: {
           env: partnerSignatureEnv,
           output: "name,public_key,public_key_curve,service_app_version,descriptor,partner_id,env",

--- a/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/api.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/api.ts
@@ -145,7 +145,7 @@ const cryptoAssetsApiInstance = createApi({
       queryFn: async currencyId => {
         try {
           const baseUrl = getEnv("CAL_SERVICE_URL");
-          const url = new URL("/v1/currencies", baseUrl);
+          const url = new URL(`${baseUrl}/v1/currencies`);
           url.searchParams.set("output", "id");
           url.searchParams.set("limit", "1");
           url.searchParams.set("id", currencyId);


### PR DESCRIPTION
### 📝 Description

Updates the default values for `CAL_SERVICE_URL` and `CAL_SERVICE_URL_STAGING` to point to the Gravitee gateway URLs instead of the old direct service URLs.

Also fixes a URL construction bug in `getTokensSyncHash`: `new URL("/v1/currencies", baseUrl)` treated the path as absolute and silently dropped the `/cal` prefix from the base URL. Switched to a template literal to preserve it.

Old → New defaults:

- prod: `crypto-assets-service.api.ledger.com` → `global.api.prd.ledger.com/cal`
- staging: `crypto-assets-service.api.ledger-test.com` → `global.api.stg.ledger-test.com/cal`

> [!NOTE]
> The new default values have no trailing slash and neither should any override. Trailing-slash normalization was intentionally not added — these env vars are internal and controlled by us.

### 🔗 Context

- **JIRA / GitHub issue**: LIVE-33578
- **ADR** (if any): N/A