### PR TITLE
[LWDM] fix: tezos getblock details

### DIFF
--- a/.changeset/few-poems-think.md
+++ b/.changeset/few-poems-think.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": minor
+---
+
+tezos getblock: move stakedAmount and ledgerOpType at top level

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.integ.test.ts
@@ -83,12 +83,8 @@ describe("getBlock", () => {
           address: "tz29GPjgeRQTRX6mcPQXkiuHnq7jbya1Abnq",
           asset: { type: "native", name: "XTZ" },
           amount: 0n,
-          details: {
-            counter: 14472417,
-            gasLimit: 581,
-            storageLimit: 0,
-            ledgerOpType: "REVEAL",
-          },
+          ledgerOpType: "REVEAL",
+          details: { counter: 14472417, gasLimit: 581, storageLimit: 0 },
         },
       ]),
     );
@@ -126,28 +122,21 @@ describe("getBlock — Shadownet Paris staking ops", () => {
     [STAKE_BLOCK, "STAKE", 500_000_000n],
     [UNSTAKE_BLOCK, "UNSTAKE", 250_000_000n],
   ])(
-    "block %s contains a staking op with operationType=%s and stakedAmount=%s",
+    "block %s contains a staking op with ledgerOpType=%s and stakedAmount=%s",
     async (height, expectedOpType, expectedAmount) => {
       const block = await getBlock(height);
       const stakingTx = block.transactions.find(tx =>
-        tx.operations.some(op => {
-          const details = (op as OtherBlockOperation).details as
-            | Record<string, unknown>
-            | undefined;
-          return details?.operationType === expectedOpType;
-        }),
+        tx.operations.some(op => (op as Record<string, unknown>).ledgerOpType === expectedOpType),
       );
 
       if (!stakingTx) throw new Error(`No ${expectedOpType} op found in block ${height}`);
       expect(stakingTx.feesPayer).toBe(SHADOWNET_STAKER);
 
-      const stakingOp = stakingTx.operations[0] as OtherBlockOperation;
-      const details = stakingOp.details as Record<string, unknown>;
+      const stakingOp = stakingTx.operations[0] as Record<string, unknown>;
       expect(stakingOp.type).toBe("other");
-      expect(details.operationType).toBe(expectedOpType);
-      expect(details.stakedAmount).toBe(expectedAmount);
-      expect(details.ledgerOpType).toBe(expectedOpType);
-      expect(details).not.toHaveProperty("delegate");
+      expect(stakingOp.ledgerOpType).toBe(expectedOpType);
+      expect(stakingOp.stakedAmount).toBe(expectedAmount);
+      expect(stakingOp).not.toHaveProperty("delegate");
     },
   );
 

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
@@ -885,14 +885,9 @@ describe("delegation operations", () => {
       address: "tz1Delegator",
       asset: { type: "native", name: "XTZ" },
       amount: 0n,
-      details: {
-        operationType: "DELEGATE",
-        stakedAmount: 0n,
-        counter: 42,
-        gasLimit: 1000,
-        storageLimit: 257,
-        ledgerOpType: "DELEGATE",
-      },
+      ledgerOpType: "DELEGATE",
+      stakedAmount: 0n,
+      details: { counter: 42, gasLimit: 1000, storageLimit: 257 },
     });
   });
 
@@ -922,14 +917,9 @@ describe("delegation operations", () => {
       address: "tz1Delegator",
       asset: { type: "native", name: "XTZ" },
       amount: 0n,
-      details: {
-        operationType: "UNDELEGATE",
-        stakedAmount: 0n,
-        counter: 7,
-        gasLimit: 500,
-        storageLimit: 100,
-        ledgerOpType: "UNDELEGATE",
-      },
+      ledgerOpType: "UNDELEGATE",
+      stakedAmount: 0n,
+      details: { counter: 7, gasLimit: 500, storageLimit: 100 },
     });
   });
 
@@ -1096,12 +1086,9 @@ describe("delegation operations", () => {
     const result = await getBlock(5_000_000);
 
     // Then
-    const details = (result.transactions[0].operations[0] as OtherBlockOperation).details as Record<
-      string,
-      unknown
-    >;
-    expect(details).not.toHaveProperty("delegate");
-    expect(details.operationType).toBe("UNDELEGATE");
+    const op = result.transactions[0].operations[0] as Record<string, unknown>;
+    expect(op).not.toHaveProperty("delegate");
+    expect(op.ledgerOpType).toBe("UNDELEGATE");
   });
 });
 
@@ -1115,7 +1102,7 @@ describe("staking operations", () => {
     ["unstake", "UNSTAKE", 250_000_000n],
     ["finalize", "FINALIZE_UNSTAKE", 0n],
   ] as const)(
-    "creates a BlockTransaction for action=%s with operationType=%s",
+    "creates a BlockTransaction for action=%s with ledgerOpType=%s",
     async (action, expectedOpType, expectedStakedAmount) => {
       mockGetBlockByLevel.mockResolvedValue(makeBlock());
       mockFetchBlockStaking.mockResolvedValue([
@@ -1136,14 +1123,9 @@ describe("staking operations", () => {
         address: "tz1Staker",
         asset: { type: "native", name: "XTZ" },
         amount: 0n,
-        details: {
-          operationType: expectedOpType,
-          stakedAmount: expectedStakedAmount,
-          counter: 1,
-          gasLimit: 3630,
-          storageLimit: 0,
-          ledgerOpType: expectedOpType,
-        },
+        ledgerOpType: expectedOpType,
+        stakedAmount: expectedStakedAmount,
+        details: { counter: 1, gasLimit: 3630, storageLimit: 0 },
       });
     },
   );
@@ -1205,12 +1187,9 @@ describe("staking operations", () => {
 
     const result = await getBlock(5_000_000);
 
-    const details = (result.transactions[0].operations[0] as OtherBlockOperation).details as Record<
-      string,
-      unknown
-    >;
-    expect(details).not.toHaveProperty("delegate");
-    expect(details.operationType).toBe("STAKE");
+    const op = result.transactions[0].operations[0] as Record<string, unknown>;
+    expect(op).not.toHaveProperty("delegate");
+    expect(op.ledgerOpType).toBe("STAKE");
   });
 });
 
@@ -1238,9 +1217,10 @@ describe("origination operations", () => {
       type: "other",
       address: "tz1Deployer",
       amount: 0n,
-      details: { ledgerOpType: "ORIGINATION", counter: 42, gasLimit: 3494, storageLimit: 5852 },
+      ledgerOpType: "ORIGINATION",
+      details: { counter: 42, gasLimit: 3494, storageLimit: 5852 },
     });
-    expect((tx.operations[0] as any).details).not.toHaveProperty("originatedContract");
+    expect(tx.operations[0]).not.toHaveProperty("originatedContract");
   });
 
   it("produces negative amount for an origination with contractBalance > 0", async () => {
@@ -1256,7 +1236,7 @@ describe("origination operations", () => {
     expect(op.type).toBe("other");
     expect(op.amount).toBe(-500_000n);
     expect(op.address).toBe("tz1Deployer");
-    expect((op.details as any).ledgerOpType).toBe("ORIGINATION");
+    expect((op as any).ledgerOpType).toBe("ORIGINATION");
   });
 
   it("treats negative contractBalance as zero (defensive guard)", async () => {
@@ -1371,7 +1351,8 @@ describe("reveal operations", () => {
       address: "tz1Revealer",
       asset: { type: "native", name: "XTZ" },
       amount: 0n,
-      details: { counter: 10, gasLimit: 10600, storageLimit: 0, ledgerOpType: "REVEAL" },
+      ledgerOpType: "REVEAL",
+      details: { counter: 10, gasLimit: 10600, storageLimit: 0 },
     });
   });
 
@@ -1390,8 +1371,8 @@ describe("reveal operations", () => {
     const tx = result.transactions[0];
     expect(tx.fees).toBe(6535n); // 5115 + 1420
     expect(tx.operations.some(op => op.type === "other")).toBe(true);
-    const revealOp = tx.operations.find(op => op.type === "other") as OtherBlockOperation;
-    expect(revealOp.details).toMatchObject({ ledgerOpType: "REVEAL" });
+    const revealOp = tx.operations.find(op => op.type === "other") as Record<string, unknown>;
+    expect(revealOp).toMatchObject({ ledgerOpType: "REVEAL" });
   });
 
   it("marks a reveal as failed when status is not 'applied'", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
@@ -1075,7 +1075,7 @@ describe("delegation operations", () => {
     expect(result.transactions[0].feesPayer).toBeUndefined();
   });
 
-  it("omits delegate field from details when neither newDelegate nor prevDelegate is present", async () => {
+  it("omits delegate field when neither newDelegate nor prevDelegate is present", async () => {
     // Given - edge case: both delegates are null
     mockGetBlockByLevel.mockResolvedValue(makeBlock());
     mockFetchBlockDelegations.mockResolvedValue([
@@ -1181,7 +1181,7 @@ describe("staking operations", () => {
     expect(tx.fees).toBe(800n);
   });
 
-  it("omits delegate field from details when baker is missing", async () => {
+  it("omits delegate field when baker is missing", async () => {
     mockGetBlockByLevel.mockResolvedValue(makeBlock());
     mockFetchBlockStaking.mockResolvedValue([makeStaking({ baker: null })]);
 
@@ -1236,7 +1236,7 @@ describe("origination operations", () => {
     expect(op.type).toBe("other");
     expect(op.amount).toBe(-500_000n);
     expect(op.address).toBe("tz1Deployer");
-    expect((op as any).ledgerOpType).toBe("ORIGINATION");
+    expect((op as Record<string, unknown>).ledgerOpType).toBe("ORIGINATION");
   });
 
   it("treats negative contractBalance as zero (defensive guard)", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
@@ -149,13 +149,12 @@ function buildDelegationOperations(op: APIDelegationType): BlockOperation[] {
       address: senderAddr,
       asset: NATIVE_ASSET,
       amount: 0n,
+      ledgerOpType: isDelegate ? "DELEGATE" : "UNDELEGATE",
+      stakedAmount: 0n,
       details: {
-        operationType: isDelegate ? "DELEGATE" : "UNDELEGATE",
-        stakedAmount: 0n,
         counter: op.counter,
         gasLimit: op.gasLimit,
         storageLimit: op.storageLimit,
-        ledgerOpType: isDelegate ? "DELEGATE" : "UNDELEGATE",
       },
     },
   ];
@@ -193,13 +192,12 @@ function buildStakingOperations(op: APIStakingType): BlockOperation[] {
       address: senderAddr,
       asset: NATIVE_ASSET,
       amount: 0n,
+      ledgerOpType: operationType,
+      stakedAmount: BigInt(op.amount ?? 0),
       details: {
-        operationType,
-        stakedAmount: BigInt(op.amount ?? 0),
         counter: op.counter,
         gasLimit: op.gasLimit,
         storageLimit: op.storageLimit,
-        ledgerOpType: operationType,
       },
     },
   ];
@@ -235,11 +233,11 @@ function buildOriginationOperations(op: APIOriginationType): BlockOperation[] {
       address: senderAddr,
       asset: NATIVE_ASSET,
       amount: op.contractBalance > 0 ? -BigInt(op.contractBalance) : 0n,
+      ledgerOpType: "ORIGINATION",
       details: {
         counter: op.counter,
         gasLimit: op.gasLimit,
         storageLimit: op.storageLimit,
-        ledgerOpType: "ORIGINATION",
       },
     },
   ];
@@ -275,11 +273,11 @@ function buildRevealOperations(op: APIRevealType): BlockOperation[] {
       address: senderAddr,
       asset: NATIVE_ASSET,
       amount: 0n,
+      ledgerOpType: "REVEAL",
       details: {
         counter: op.counter,
         gasLimit: op.gasLimit,
         storageLimit: op.storageLimit,
-        ledgerOpType: "REVEAL",
       },
     },
   ];


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

ledgerOpType and stakedAmount were nested inside details, which is different from listOp
Moves ledgerOpType and stakedAmount to the top level of the operation, keeps metadata (counter, gasLimit, storageLimit) in details. Drops redundant operationType. Matches the pattern already used by coin-hedera.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
