### PR TITLE
[LWM] fix: solana withdraw amount

### DIFF
--- a/.changeset/selfish-dancers-relate.md
+++ b/.changeset/selfish-dancers-relate.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix: solana amount when withdraw from a desactivated delegation

--- a/apps/ledger-live-mobile/src/families/solana/Delegations/index.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/Delegations/index.tsx
@@ -296,7 +296,12 @@ function Delegations({ account }: Props) {
             size={size}
           />
         )}
-        amount={new BigNumber(selectedStakeWithMeta?.stake?.delegation?.stake ?? 0)}
+        amount={
+          new BigNumber(
+            (selectedStakeWithMeta?.stake?.delegation?.stake ?? 0) ||
+              (selectedStakeWithMeta?.stake?.withdrawable ?? 0),
+          )
+        }
         data={data}
         actions={delegationActions}
       />


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

In Ledger Wallet Mobile v4.10, when a user attempts to withdraw deactivated SOL, the main display shows 0 SOL and $0.00 fiat value. However, the Available balance and Withdrawable Rewards fields correctly show the amounts (e.g., 0.063341632 SOL). This causes user confusion as they believe they have nothing to withdraw, even though they can proceed to the next stage and select the full amount. This issue is specific to mobile and does not occur on the desktop version.

The buggy line — mobile delegation drawer main amount:
apps/ledger-live-mobile/src/families/solana/Delegations/index.tsx:299
amount={new BigNumber(selectedStakeWithMeta?.stake?.delegation?.stake ?? 0)}
This amount prop feeds the big number + fiat at the top of the drawer (DelegationDrawer.tsx:76 renders CurrencyUnitValue → "0 SOL", :80-88 renders CounterValue → "$0.00"). It uses delegation.stake with only a ?? 0 guard, no fallback to withdrawable.

<img width="385" height="773" alt="Screenshot 2026-07-09 at 15 24 09" src="https://github.com/user-attachments/assets/78f60848-4b04-4704-8903-1a7b70c8df2c" />


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-33633](https://ledgerhq.atlassian.net/browse/LIVE-33633)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-33633]: https://ledgerhq.atlassian.net/browse/LIVE-33633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ