### PR TITLE
feat(contacts): add eligible address families flag param

### DIFF
--- a/.changeset/contacts-eligible-address-families.md
+++ b/.changeset/contacts-eligible-address-families.md
@@ -1,0 +1,6 @@
+---
+"@shared/feature-flags": patch
+"@features/flow-contacts": patch
+---
+
+Add eligible address family configuration to Contacts feature flags.

--- a/features/flow/contacts/src/featureFlags.test.tsx
+++ b/features/flow/contacts/src/featureFlags.test.tsx
@@ -11,6 +11,7 @@ import {
 } from "@shared/feature-flags";
 import {
   CONTACTS_FEATURE_FLAG_KEYS,
+  DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
   resolveContactsFeatureConfig,
   useContactsFeature,
   type ContactsFeatureConfig,
@@ -19,6 +20,24 @@ import {
 } from "./featureFlags";
 
 const PLATFORMS: ContactsFeaturePlatform[] = ["desktop", "mobile"];
+const DEFAULT_CONFIG: ContactsFeatureConfig = {
+  isEnabled: false,
+  showNewBadge: false,
+  eligibleAddressFamilies: DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
+};
+
+function makeContactsFeatureValue(
+  enabled: boolean,
+  newBadge: boolean,
+): ContactsFeatureValue {
+  return {
+    enabled,
+    params: {
+      newBadge,
+      eligibleAddressFamilies: [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES],
+    },
+  };
+}
 
 function makeStoreWrapper(overrides?: Partial<FeatureFlagsState>) {
   const store = configureStore({
@@ -51,71 +70,78 @@ function expectConfig(result: { current: ContactsFeatureConfig }, expected: Cont
 
 describe("resolveContactsFeatureConfig", () => {
   it("returns disabled config without a feature value", () => {
-    expect(resolveContactsFeatureConfig(null)).toEqual({
-      isEnabled: false,
-      showNewBadge: false,
-    });
+    expect(resolveContactsFeatureConfig(null)).toEqual(DEFAULT_CONFIG);
   });
 
   it("returns enabled config with a new badge only when the flag and param are enabled", () => {
-    expect(resolveContactsFeatureConfig({ enabled: true, params: { newBadge: true } })).toEqual({
+    expect(resolveContactsFeatureConfig(makeContactsFeatureValue(true, true))).toEqual({
       isEnabled: true,
       showNewBadge: true,
+      eligibleAddressFamilies: DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
     });
   });
+
 });
 
 describe("useContactsFeature", () => {
   it.each(PLATFORMS)("returns disabled config on %s with the default registry value", platform => {
     const { result } = renderFeature(platform);
 
-    expectConfig(result, { isEnabled: false, showNewBadge: false });
+    expectConfig(result, DEFAULT_CONFIG);
   });
 
   it.each(PLATFORMS)("returns no new badge on %s when the flag is disabled", platform => {
-    const { result } = renderFeature(platform, { enabled: false, params: { newBadge: true } });
+    const { result } = renderFeature(platform, makeContactsFeatureValue(false, true));
 
-    expectConfig(result, { isEnabled: false, showNewBadge: false });
+    expectConfig(result, DEFAULT_CONFIG);
   });
 
   it.each(PLATFORMS)("returns enabled without new badge on %s", platform => {
-    const { result } = renderFeature(platform, { enabled: true, params: { newBadge: false } });
+    const { result } = renderFeature(platform, makeContactsFeatureValue(true, false));
 
-    expectConfig(result, { isEnabled: true, showNewBadge: false });
+    expectConfig(result, {
+      isEnabled: true,
+      showNewBadge: false,
+      eligibleAddressFamilies: DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
+    });
   });
 
   it.each(PLATFORMS)("returns enabled with new badge on %s", platform => {
-    const { result } = renderFeature(platform, { enabled: true, params: { newBadge: true } });
+    const { result } = renderFeature(platform, makeContactsFeatureValue(true, true));
 
-    expectConfig(result, { isEnabled: true, showNewBadge: true });
+    expectConfig(result, {
+      isEnabled: true,
+      showNewBadge: true,
+      eligibleAddressFamilies: DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
+    });
   });
 
   it("does not enable mobile when only the desktop flag is enabled", () => {
     const resolved: Features = {
       ...FEATURE_FLAGS_DEFAULTS,
-      lwdContacts: { enabled: true, params: { newBadge: true } },
-      lwmContacts: { enabled: false, params: { newBadge: false } },
+      lwdContacts: makeContactsFeatureValue(true, true),
+      lwmContacts: makeContactsFeatureValue(false, false),
     };
     const { Wrapper } = makeStoreWrapper({ resolved });
     const { result } = renderHook(() => useContactsFeature("mobile"), {
       wrapper: Wrapper,
     });
 
-    expectConfig(result, { isEnabled: false, showNewBadge: false });
+    expectConfig(result, DEFAULT_CONFIG);
   });
 
   it("does not enable desktop when only the mobile flag is enabled", () => {
     const resolved: Features = {
       ...FEATURE_FLAGS_DEFAULTS,
-      lwdContacts: { enabled: false, params: { newBadge: false } },
-      lwmContacts: { enabled: true, params: { newBadge: true } },
+      lwdContacts: makeContactsFeatureValue(false, false),
+      lwmContacts: makeContactsFeatureValue(true, true),
     };
     const { Wrapper } = makeStoreWrapper({ resolved });
     const { result } = renderHook(() => useContactsFeature("desktop"), {
       wrapper: Wrapper,
     });
 
-    expectConfig(result, { isEnabled: false, showNewBadge: false });
+    expectConfig(result, DEFAULT_CONFIG);
   });
 
   it("maps each platform to its dedicated feature flag", () => {

--- a/features/flow/contacts/src/featureFlags.ts
+++ b/features/flow/contacts/src/featureFlags.ts
@@ -2,6 +2,8 @@ import { useMemo } from "react";
 import type { Features } from "@shared/feature-flags";
 import { useFeature, type WalletPlatform } from "@features/platform-feature-flags";
 
+export const DEFAULT_ELIGIBLE_ADDRESS_FAMILIES = ["evm"] as const;
+
 export type ContactsFeaturePlatform = WalletPlatform;
 
 export const CONTACTS_FEATURE_FLAG_KEYS = {
@@ -12,6 +14,7 @@ export const CONTACTS_FEATURE_FLAG_KEYS = {
 export type ContactsFeatureConfig = Readonly<{
   isEnabled: boolean;
   showNewBadge: boolean;
+  eligibleAddressFamilies: readonly string[];
 }>;
 
 export type ContactsFeatureValue = Features["lwdContacts"] | Features["lwmContacts"];
@@ -24,6 +27,8 @@ export function resolveContactsFeatureConfig(
   return {
     isEnabled,
     showNewBadge: isEnabled && feature?.params?.newBadge === true,
+    eligibleAddressFamilies:
+      feature?.params?.eligibleAddressFamilies ?? DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
   };
 }
 

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwdContacts.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwdContacts.ts
@@ -1,14 +1,20 @@
 import { z } from "zod";
 import { flagWith } from "../../define";
 
+const DEFAULT_ELIGIBLE_ADDRESS_FAMILIES = ["evm"] as const;
+
 export const lwdContacts = flagWith(
   {
     newBadge: z.boolean(),
+    eligibleAddressFamilies: z
+      .array(z.string())
+      .default(() => [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES]),
   },
   {
     enabled: false,
     params: {
       newBadge: false,
+      eligibleAddressFamilies: [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES],
     },
   },
 );

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwmContacts.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwmContacts.ts
@@ -1,14 +1,20 @@
 import { z } from "zod";
 import { flagWith } from "../../define";
 
+const DEFAULT_ELIGIBLE_ADDRESS_FAMILIES = ["evm"] as const;
+
 export const lwmContacts = flagWith(
   {
     newBadge: z.boolean(),
+    eligibleAddressFamilies: z
+      .array(z.string())
+      .default(() => [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES]),
   },
   {
     enabled: false,
     params: {
       newBadge: false,
+      eligibleAddressFamilies: [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES],
     },
   },
 );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Contacts feature flag defaults and schema parsing.
      - Contacts flow feature config exposed to Desktop and Mobile.
      - Future MAD filtering input, without wiring MAD in this PR.

### 📝 Description

This PR adds a new `eligibleAddressFamilies` parameter to the Contacts rollout flags for Desktop and Mobile. The default value is `["evm"]`, matching the first supported scope for Contacts Add Address.

The Contacts flow feature config now exposes `eligibleAddressFamilies` alongside `isEnabled` and `showNewBadge`. MAD filtering and currency resolution remain in follow-up implementation tickets.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34260](https://ledgerhq.atlassian.net/browse/LIVE-34260)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-34260]: https://ledgerhq.atlassian.net/browse/LIVE-34260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ