### PR TITLE
ci(libs): make format:check mandatory on develop, skip on release branches

### DIFF
--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -165,10 +165,7 @@ jobs:
         run: pnpm i
       - name: Check formatting of affected libraries
         id: format-check-libs
-        # TODO(LIVE-31553): remove continue-on-error once the release cycle has
-        # the format:check scripts on HEAD (~2 weeks). format:check does not yet
-        # exist on release branches, so keep this non-blocking to not break release.
-        continue-on-error: true
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop'
         run: pnpm exec nx run-many -t format:check --exclude=ledger-live-desktop,live-mobile,@ledgerhq/live-cli,@ledgerhq/web-tools,ledger-live-desktop-e2e-tests,ledger-live-mobile-e2e-tests --parallel=3 --nxBail=false
       - name: Lint affected libraries
         id: lint-libs


### PR DESCRIPTION
> [!IMPORTANT]
> The format:check step in test-libs-reusable.yml was set to continue-on-error: true, so formatting violations were silently ignored. This PR makes it a hard gate on develop, mirroring what PR #19304 did for desktop and mobile.

### 📝 Description

Replaces continue-on-error: true with an if condition on the Check formatting of affected libraries step in test-libs-reusable.yml.

The step now:
- Runs and blocks merges when the PR targets develop (github.base_ref == 'develop')
- Runs and blocks on direct pushes to develop (github.ref == 'refs/heads/develop')
- Is skipped entirely on release branches (which do not have format:check scripts)

This completes the work from #19210 (which missed test-libs-reusable.yml) and #19304 (which fixed desktop/mobile gates).

Root cause of the recent format drift in libs/ledger-live-common/src/intents/signTransactionIntent/job.ts: the file was merged without being oxfmt-formatted, and the CI gate was non-blocking so it went unnoticed.

### 🔗 Context

- **JIRA / GitHub issue**: LIVE-31553
- **ADR** (if any): N/A