### PR TITLE
[LWDM] style(live-common): apply oxfmt formatting to signTransactionIntent/job.ts

### DIFF
--- a/libs/ledger-live-common/src/intents/signTransactionIntent/job.ts
+++ b/libs/ledger-live-common/src/intents/signTransactionIntent/job.ts
@@ -22,10 +22,7 @@ function buildSigningDevice(connectionResult: DeviceConnectionResult): SigningDe
   };
 }
 
-function isUserRefusalError(
-  error: unknown,
-  currency: CryptoOrTokenCurrency | undefined,
-): boolean {
+function isUserRefusalError(error: unknown, currency: CryptoOrTokenCurrency | undefined): boolean {
   return (
     sendFeatures.isUserRefusedTransactionError(currency, error) ||
     error instanceof TransactionRefusedOnDevice ||


### PR DESCRIPTION
### 📝 Description

Fixes an oxfmt formatting drift in signTransactionIntent/job.ts.

The isUserRefusalError function signature was committed with multi-line formatting that does not match the oxfmt rules. This collapses it to a single line as oxfmt requires.

This was undetected because the format:check step in test-libs-reusable.yml had continue-on-error: true (tracked in PR #19446).

### 🔗 Context

- **JIRA / GitHub issue**: N/A
- **ADR** (if any): N/A