### PR TITLE
[LWDM] fix(swap): tx status dialog UI fixes and mobile swapId history parity

### DIFF
--- a/.changeset/swap-tx-status-dialog-ui.md
+++ b/.changeset/swap-tx-status-dialog-ui.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Fix minor UI issues on the Swap transaction status dialog on Desktop (canvas-sheet background and spacing below the main button). Forward a `swapId` from the `swapRedirectToHistory` handler to the Swap History screen on both Desktop and Mobile so the transaction status dialog/drawer opens automatically for the matching operation.

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/Footer/FooterSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/Footer/FooterSection.tsx
@@ -21,18 +21,16 @@ export function FooterSection({ explorerUrl, isLoading }: FooterSectionProps) {
   }
 
   return (
-    <div className="pb-4">
-      <Button
-        appearance="transparent"
-        isFull
-        size="md"
-        icon={ExternalLink}
-        data-testid="swap-transaction-view-explorer-btn"
-        data-href={explorerUrl}
-        onClick={() => openURL(explorerUrl, "SwapTransactionStatus_ViewExplorer")}
-      >
-        {t("swap2.modals.transactionStatus.actions.viewInExplorer")}
-      </Button>
-    </div>
+    <Button
+      appearance="transparent"
+      isFull
+      size="md"
+      icon={ExternalLink}
+      data-testid="swap-transaction-view-explorer-btn"
+      data-href={explorerUrl}
+      onClick={() => openURL(explorerUrl, "SwapTransactionStatus_ViewExplorer")}
+    >
+      {t("swap2.modals.transactionStatus.actions.viewInExplorer")}
+    </Button>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/SwapTransactionStatusDialogView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/SwapTransactionStatusDialogView.tsx
@@ -29,10 +29,10 @@ export function SwapTransactionStatusDialogView({
     <Dialog open={isOpen} onOpenChange={onOpenChange} height="fit">
       <DialogContent
         data-testid="swap-transaction-status-dialog"
-        className="max-h-[calc(100vh-16px)] w-[400px] bg-base p-0"
+        className="max-h-[calc(100vh-16px)] w-[400px] bg-canvas-sheet p-0 pb-24"
       >
         <DialogHeader density="compact" onClose={onClose} />
-        <DialogBody className="flex flex-col px-24 pb-24 gap-24">
+        <DialogBody className="flex flex-col px-24 gap-24">
           <SwapTransactionStatusDialogContent key={contentKey} params={params} />
         </DialogBody>
       </DialogContent>

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -405,8 +405,12 @@ const SwapWebView = ({
           return Promise.resolve({});
         }
       },
-      "custom.swapRedirectToHistory": async () => {
-        redirectToHistory();
+      "custom.swapRedirectToHistory": async ({
+        params,
+      }: {
+        params?: { swapId?: string };
+      } = {}) => {
+        redirectToHistory({ swapId: params?.swapId });
       },
       "custom.saveSwapToHistory": async ({
         params,

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/History/History.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/History/History.tsx
@@ -1,5 +1,5 @@
 import { ipcRenderer } from "electron";
-import React, { useMemo, useEffect, useState, useCallback, useRef } from "react";
+import React, { useMemo, useEffect, useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector, useDispatch } from "LLD/hooks/redux";
 import { accountsSelector } from "~/renderer/reducers/accounts";
@@ -26,6 +26,7 @@ import HistoryPlaceholder from "./HistoryPlaceholder";
 import { useLocation } from "react-router";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { useTechnicalDateFn } from "~/renderer/hooks/useDateFormatter";
+import { useAutoOpenSwapDialog } from "./useAutoOpenSwapDialog";
 import { getEnv } from "@ledgerhq/live-env";
 
 const Head = styled(Box)`
@@ -59,9 +60,8 @@ const History = () => {
   const location = useLocation();
   const dispatch = useDispatch();
   const { t } = useTranslation();
-  const defaultOpenedOnce = useRef(false);
   const locationState = location.state as { swapId?: string } | null;
-  const defaultOpenedSwapOperationId = locationState?.swapId;
+  const autoOpenSwapId = locationState?.swapId;
   const getDateTxt = useTechnicalDateFn();
   const onExportOperations = useCallback(() => {
     async function asyncExport() {
@@ -108,21 +108,7 @@ const History = () => {
       setMappedSwapOperations(sections);
     })();
   }, [accounts]);
-  useEffect(() => {
-    if (defaultOpenedOnce.current || !defaultOpenedSwapOperationId) return;
-    if (mappedSwapOperations) {
-      defaultOpenedOnce.current = true;
-      mappedSwapOperations.some(section => {
-        const openedOperation = section.data.find(
-          ({ swapId }) => swapId === defaultOpenedSwapOperationId,
-        );
-        if (openedOperation) {
-          dispatch(openSwapTransactionStatusDialog(fromSwapOperation(openedOperation)));
-        }
-        return !!openedOperation;
-      });
-    }
-  }, [dispatch, mappedSwapOperations, defaultOpenedSwapOperationId]);
+  useAutoOpenSwapDialog(autoOpenSwapId, mappedSwapOperations);
   const updateSwapStatus = useCallback(() => {
     let cancelled = false;
     async function fetchUpdatedSwapStatus() {

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/History/useAutoOpenSwapDialog.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/History/useAutoOpenSwapDialog.test.ts
@@ -1,0 +1,96 @@
+import { renderHook } from "tests/testSetup";
+import type {
+  MappedSwapOperation,
+  SwapHistorySection,
+} from "@ledgerhq/live-common/exchange/swap/types";
+import { useAutoOpenSwapDialog } from "./useAutoOpenSwapDialog";
+import {
+  closeSwapTransactionStatusDialog,
+  selectIsSwapTransactionStatusDialogOpen,
+  selectSwapTransactionStatusDialogParams,
+} from "LLD/features/SwapTransactionStatusDialog/swapTransactionStatusDialog";
+
+const makeOperation = (swapId: string): MappedSwapOperation =>
+  ({ swapId, provider: "changelly" }) as unknown as MappedSwapOperation;
+
+const makeSections = (swapIds: string[]): SwapHistorySection[] =>
+  swapIds.length
+    ? [{ day: new Date(), data: swapIds.map(makeOperation) } as SwapHistorySection]
+    : [];
+
+type Props = { swapId: string | undefined; sections: SwapHistorySection[] | undefined | null };
+
+const renderAutoOpen = (swapId: string | undefined, sections: Props["sections"]) =>
+  renderHook(({ swapId, sections }: Props) => useAutoOpenSwapDialog(swapId, sections), {
+    initialProps: { swapId, sections },
+  });
+
+describe("useAutoOpenSwapDialog", () => {
+  it("opens the dialog for the operation matching the swapId", () => {
+    const { store } = renderAutoOpen("swap-1", makeSections(["swap-0", "swap-1"]));
+
+    expect(selectIsSwapTransactionStatusDialogOpen(store.getState())).toBe(true);
+    expect(selectSwapTransactionStatusDialogParams(store.getState())).toEqual({
+      swapId: "swap-1",
+      provider: "changelly",
+    });
+  });
+
+  it("does nothing when no swapId is passed", () => {
+    const { store } = renderAutoOpen(undefined, makeSections(["swap-1"]));
+
+    expect(selectIsSwapTransactionStatusDialogOpen(store.getState())).toBe(false);
+  });
+
+  it("does nothing when the history has not loaded yet", () => {
+    const { store } = renderAutoOpen("swap-1", null);
+
+    expect(selectIsSwapTransactionStatusDialogOpen(store.getState())).toBe(false);
+  });
+
+  it("does nothing when no operation matches the swapId", () => {
+    const { store } = renderAutoOpen("missing", makeSections(["swap-1"]));
+
+    expect(selectIsSwapTransactionStatusDialogOpen(store.getState())).toBe(false);
+  });
+
+  it("retries on later syncs until the swap operation appears", () => {
+    const { store, rerender } = renderAutoOpen("swap-1", null);
+    expect(selectIsSwapTransactionStatusDialogOpen(store.getState())).toBe(false);
+
+    rerender({ swapId: "swap-1", sections: makeSections(["swap-1"]) });
+
+    expect(selectIsSwapTransactionStatusDialogOpen(store.getState())).toBe(true);
+    expect(selectSwapTransactionStatusDialogParams(store.getState())).toEqual({
+      swapId: "swap-1",
+      provider: "changelly",
+    });
+  });
+
+  it("re-opens when a different swapId is passed to an already-mounted screen", () => {
+    const sections = makeSections(["swap-1", "swap-2"]);
+    const { store, rerender } = renderAutoOpen("swap-1", sections);
+    expect(selectSwapTransactionStatusDialogParams(store.getState())).toEqual({
+      swapId: "swap-1",
+      provider: "changelly",
+    });
+
+    rerender({ swapId: "swap-2", sections });
+
+    expect(selectSwapTransactionStatusDialogParams(store.getState())).toEqual({
+      swapId: "swap-2",
+      provider: "changelly",
+    });
+  });
+
+  it("does not re-open for the same swapId once it has already been opened", () => {
+    const sections = makeSections(["swap-1"]);
+    const { store, rerender } = renderAutoOpen("swap-1", sections);
+    expect(selectIsSwapTransactionStatusDialogOpen(store.getState())).toBe(true);
+
+    store.dispatch(closeSwapTransactionStatusDialog());
+    rerender({ swapId: "swap-1", sections });
+
+    expect(selectIsSwapTransactionStatusDialogOpen(store.getState())).toBe(false);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/History/useAutoOpenSwapDialog.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/History/useAutoOpenSwapDialog.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from "react";
+import { useDispatch } from "LLD/hooks/redux";
+import { fromSwapOperation } from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
+import type {
+  MappedSwapOperation,
+  SwapHistorySection,
+} from "@ledgerhq/live-common/exchange/swap/types";
+import { openSwapTransactionStatusDialog } from "LLD/features/SwapTransactionStatusDialog/swapTransactionStatusDialog";
+
+/**
+ * Opens the swap transaction status dialog for the operation matching `autoOpenSwapId`
+ * as soon as it appears in the loaded history sections.
+ *
+ * Tracks the last auto-opened swapId (rather than a one-shot flag) so it keeps retrying
+ * across syncs until a match is found, and re-opens if a different swapId is passed to an
+ * already-mounted screen.
+ */
+export function useAutoOpenSwapDialog(
+  autoOpenSwapId: string | undefined,
+  sections: SwapHistorySection[] | undefined | null,
+) {
+  const dispatch = useDispatch();
+  const lastAutoOpenedSwapId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!autoOpenSwapId || lastAutoOpenedSwapId.current === autoOpenSwapId) return;
+    if (!sections?.length) return;
+
+    let openedOperation: MappedSwapOperation | undefined;
+    for (const section of sections) {
+      openedOperation = section.data.find(({ swapId }) => swapId === autoOpenSwapId);
+      if (openedOperation) break;
+    }
+
+    if (openedOperation) {
+      lastAutoOpenedSwapId.current = autoOpenSwapId;
+      dispatch(openSwapTransactionStatusDialog(fromSwapOperation(openedOperation)));
+    }
+  }, [autoOpenSwapId, dispatch, sections]);
+}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SwapNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SwapNavigator.ts
@@ -40,6 +40,7 @@ import { ScreenName } from "~/const";
 import type {
   DefaultAccountSwapParamList,
   DetailsSwapParamList,
+  SwapHistoryParams,
   SwapOperationDetails,
   SwapPendingOperation,
   SwapSelectCurrency,
@@ -51,7 +52,7 @@ export type SwapNavigatorParamList = {
     | DefaultAccountSwapParamList
     | SwapSelectCurrency
     | SwapPendingOperation;
-  [ScreenName.SwapHistory]: undefined;
+  [ScreenName.SwapHistory]: SwapHistoryParams | undefined;
   [ScreenName.SwapPendingOperation]: SwapPendingOperation;
   [ScreenName.SwapOperationDetails]: {
     swapOperation: SwapOperationDetails;

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SwapSubScreensNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SwapSubScreensNavigator.ts
@@ -1,10 +1,14 @@
 import type { SwapLiveError } from "@ledgerhq/live-common/exchange/swap/types";
 import { ScreenName } from "~/const";
-import type { SwapOperationDetails, SwapPendingOperation } from "~/screens/Swap/types";
+import type {
+  SwapHistoryParams,
+  SwapOperationDetails,
+  SwapPendingOperation,
+} from "~/screens/Swap/types";
 
 export type SwapSubScreensNavigatorParamList = {
   [ScreenName.SwapPendingOperation]: SwapPendingOperation;
-  [ScreenName.SwapHistory]: undefined;
+  [ScreenName.SwapHistory]: SwapHistoryParams | undefined;
   [ScreenName.SwapLoading]: undefined;
   [ScreenName.SwapCustomError]: { error: SwapLiveError | Error };
   [ScreenName.SwapOperationDetails]: {

--- a/apps/ledger-live-mobile/src/screens/Swap/History/__tests__/useAutoOpenSwapDrawer.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/History/__tests__/useAutoOpenSwapDrawer.test.ts
@@ -1,0 +1,112 @@
+import { renderHook } from "@tests/test-renderer";
+import type {
+  MappedSwapOperation,
+  SwapHistorySection,
+} from "@ledgerhq/live-common/exchange/swap/types";
+import { useAutoOpenSwapDrawer } from "../useAutoOpenSwapDrawer";
+import { closeSwapTransactionStatusDrawer } from "~/reducers/swapTransactionStatusDrawer";
+
+const makeOperation = (swapId: string): MappedSwapOperation =>
+  ({ swapId, provider: "changelly" }) as unknown as MappedSwapOperation;
+
+const makeSections = (swapIds: string[]): SwapHistorySection[] =>
+  swapIds.length
+    ? [{ day: new Date(), data: swapIds.map(makeOperation) } as SwapHistorySection]
+    : [];
+
+describe("useAutoOpenSwapDrawer", () => {
+  let swapId: string | undefined;
+  let sections: SwapHistorySection[];
+
+  const render = () => renderHook(() => useAutoOpenSwapDrawer(swapId, sections));
+
+  beforeEach(() => {
+    swapId = undefined;
+    sections = [];
+  });
+
+  it("opens the drawer for the operation matching the swapId", () => {
+    swapId = "swap-1";
+    sections = makeSections(["swap-0", "swap-1"]);
+
+    const { store } = render();
+
+    expect(store.getState().swapTransactionStatusDrawer).toEqual({
+      isOpen: true,
+      params: { swapId: "swap-1", provider: "changelly" },
+    });
+  });
+
+  it("does nothing when no swapId is passed", () => {
+    sections = makeSections(["swap-1"]);
+
+    const { store } = render();
+
+    expect(store.getState().swapTransactionStatusDrawer.isOpen).toBe(false);
+  });
+
+  it("does nothing when the history is still empty", () => {
+    swapId = "swap-1";
+
+    const { store } = render();
+
+    expect(store.getState().swapTransactionStatusDrawer.isOpen).toBe(false);
+  });
+
+  it("does nothing when no operation matches the swapId", () => {
+    swapId = "missing";
+    sections = makeSections(["swap-1"]);
+
+    const { store } = render();
+
+    expect(store.getState().swapTransactionStatusDrawer.isOpen).toBe(false);
+  });
+
+  it("retries on later syncs until the swap operation appears", () => {
+    swapId = "swap-1";
+    sections = [];
+
+    const { store, rerender } = render();
+    expect(store.getState().swapTransactionStatusDrawer.isOpen).toBe(false);
+
+    sections = makeSections(["swap-1"]);
+    rerender({});
+
+    expect(store.getState().swapTransactionStatusDrawer).toEqual({
+      isOpen: true,
+      params: { swapId: "swap-1", provider: "changelly" },
+    });
+  });
+
+  it("re-opens when a different swapId is passed to an already-mounted screen", () => {
+    sections = makeSections(["swap-1", "swap-2"]);
+    swapId = "swap-1";
+
+    const { store, rerender } = render();
+    expect(store.getState().swapTransactionStatusDrawer.params).toEqual({
+      swapId: "swap-1",
+      provider: "changelly",
+    });
+
+    swapId = "swap-2";
+    rerender({});
+
+    expect(store.getState().swapTransactionStatusDrawer.params).toEqual({
+      swapId: "swap-2",
+      provider: "changelly",
+    });
+  });
+
+  it("does not re-open for the same swapId once it has already been opened", () => {
+    sections = makeSections(["swap-1"]);
+    swapId = "swap-1";
+
+    const { store, rerender } = render();
+    expect(store.getState().swapTransactionStatusDrawer.isOpen).toBe(true);
+
+    store.dispatch(closeSwapTransactionStatusDrawer());
+    rerender({});
+
+    expect(store.getState().swapTransactionStatusDrawer.isOpen).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Swap/History/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/History/index.tsx
@@ -5,7 +5,7 @@ import { MappedSwapOperation, SwapHistorySection } from "@ledgerhq/live-common/e
 import updateAccountSwapStatus from "@ledgerhq/live-common/exchange/swap/updateAccountSwapStatus";
 import { getParentAccount } from "@ledgerhq/live-common/account/index";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
-import { useTheme } from "@react-navigation/native";
+import { RouteProp, useRoute, useTheme } from "@react-navigation/native";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Trans, useTranslation } from "~/context/Locale";
 import {
@@ -37,6 +37,9 @@ import { getEnv } from "@ledgerhq/live-env";
 import { sendFile } from "~/e2e/bridge/client";
 import ExternalLink from "@ledgerhq/icons-ui/native/ExternalLink";
 import SafeAreaView from "~/components/SafeAreaView";
+import { ScreenName } from "~/const";
+import type { SwapSubScreensNavigatorParamList } from "~/components/RootNavigator/types/SwapSubScreensNavigator";
+import { useAutoOpenSwapDrawer } from "./useAutoOpenSwapDrawer";
 
 // const SList : SectionList<MappedSwapOperation, SwapHistorySection> = SectionList;
 const AnimatedSectionList: typeof SectionList = Animated.createAnimatedComponent(
@@ -44,6 +47,8 @@ const AnimatedSectionList: typeof SectionList = Animated.createAnimatedComponent
 ) as unknown as typeof SectionList;
 const feedbackFormUrl =
   "https://form.typeform.com/to/FIHc3fk2?typeform-source=ledger.typeform.com#source=mobile";
+
+type SwapHistoryRoute = RouteProp<SwapSubScreensNavigatorParamList, ScreenName.SwapHistory>;
 
 // Helper function to ensure parent account is set for token accounts
 const ensureParentAccount = (
@@ -67,6 +72,8 @@ const History = () => {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const ref = useRef(null);
   const syncAccounts = useSyncAllAccounts();
+  const route = useRoute<SwapHistoryRoute>();
+  const autoOpenSwapId = route.params?.swapId;
 
   // fix token account parent
   const [sections, setSections] = useState<SwapHistorySection[]>([]);
@@ -137,6 +144,8 @@ const History = () => {
       updateSwapStatus();
     }
   }, 10000);
+
+  useAutoOpenSwapDrawer(autoOpenSwapId, sections);
 
   const renderItem = ({ item }: ListRenderItemInfo<MappedSwapOperation>) => (
     <OperationRow item={item} />

--- a/apps/ledger-live-mobile/src/screens/Swap/History/useAutoOpenSwapDrawer.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/History/useAutoOpenSwapDrawer.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from "react";
+import { useDispatch } from "~/context/hooks";
+import { fromSwapOperation } from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
+import type {
+  MappedSwapOperation,
+  SwapHistorySection,
+} from "@ledgerhq/live-common/exchange/swap/types";
+import { openSwapTransactionStatusDrawer } from "~/reducers/swapTransactionStatusDrawer";
+
+/**
+ * Opens the swap transaction status drawer for the operation matching `autoOpenSwapId`
+ * as soon as it appears in the loaded history sections.
+ *
+ * Tracks the last auto-opened swapId (rather than a one-shot flag) so it keeps retrying
+ * across syncs until a match is found, and re-opens if a different swapId is passed to an
+ * already-mounted screen.
+ */
+export function useAutoOpenSwapDrawer(
+  autoOpenSwapId: string | undefined,
+  sections: SwapHistorySection[],
+) {
+  const dispatch = useDispatch();
+  const lastAutoOpenedSwapId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!autoOpenSwapId || lastAutoOpenedSwapId.current === autoOpenSwapId) return;
+    if (!sections.length) return;
+
+    let openedOperation: MappedSwapOperation | undefined;
+    for (const section of sections) {
+      openedOperation = section.data.find(({ swapId }) => swapId === autoOpenSwapId);
+      if (openedOperation) break;
+    }
+
+    if (openedOperation) {
+      lastAutoOpenedSwapId.current = autoOpenSwapId;
+      dispatch(openSwapTransactionStatusDrawer(fromSwapOperation(openedOperation)));
+    }
+  }, [autoOpenSwapId, dispatch, sections]);
+}

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/__tests__/useSwapCustomHandlers.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/__tests__/useSwapCustomHandlers.test.ts
@@ -210,6 +210,26 @@ describe("useSwapCustomHandlers", () => {
         screen: ScreenName.SwapHistory,
       });
     });
+
+    it("passes swapId to SwapHistory when swapRedirectToHistory handler is called with params", () => {
+      const { result } = render();
+
+      const handler = (result.current as Record<string, unknown>)["custom.swapRedirectToHistory"];
+      expect(typeof handler).toBe("function");
+
+      (handler as (request: unknown) => void)({
+        params: {
+          swapId: "swap-123",
+        },
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SwapSubScreens, {
+        screen: ScreenName.SwapHistory,
+        params: {
+          swapId: "swap-123",
+        },
+      });
+    });
   });
 
   describe("returned handlers shape", () => {

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/index.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/index.ts
@@ -20,6 +20,7 @@ import { getTransactionByHash } from "./getTransactionByHash";
 import { saveSwapToHistory } from "./saveSwapToHistory";
 import { useCustomExchangeHandlers } from "~/components/WebPTXPlayer/CustomHandlers";
 import { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
+import type { SwapHistoryParams } from "../../types";
 
 export type NavigationType = Omit<NavigationProp<ReactNavigation.RootParamList>, "getState"> & {
   getState(): NavigationState | undefined;
@@ -103,11 +104,15 @@ export function useSwapCustomHandlers(
     });
   }, [navigation]);
 
-  const navigateToSwapHistory = useCallback(() => {
-    navigation.navigate(NavigatorName.SwapSubScreens, {
-      screen: ScreenName.SwapHistory,
-    });
-  }, [navigation]);
+  const navigateToSwapHistory = useCallback(
+    ({ params }: { params?: SwapHistoryParams } = {}) => {
+      navigation.navigate(NavigatorName.SwapSubScreens, {
+        screen: ScreenName.SwapHistory,
+        ...(params?.swapId ? { params: { swapId: params.swapId } } : {}),
+      });
+    },
+    [navigation],
+  );
 
   const walletAPISwapHandlers = useCustomExchangeHandlers({
     manifest,

--- a/apps/ledger-live-mobile/src/screens/Swap/types.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/types.ts
@@ -46,6 +46,10 @@ export type SwapPendingOperation = {
   sponsored?: boolean;
 };
 
+export type SwapHistoryParams = {
+  swapId?: string;
+};
+
 export interface DefaultAccountSwapParamList {
   defaultAccount?: AccountLike;
   defaultParentAccount?: Account;


### PR DESCRIPTION
## 📝 Description

Fixes [LIVE-34263](https://ledgerhq.atlassian.net/browse/LIVE-34263) and adds Desktop/Mobile parity for the Swap History `swapId` handler.

### Desktop — Swap transaction status dialog UI fixes (LIVE-34263)
- Background now uses `bg-canvas-sheet` instead of `bg-base` (was rendering black).
- Added spacing below the main button (`pb-24` on the footer), removing the now-redundant `pb-24` on `DialogBody`.

### Mobile — Swap History `swapId` parity with Desktop
- The `swapRedirectToHistory` custom handler now forwards a `swapId` into the `SwapHistory` route params.
- The Swap History screen reads the `swapId` and automatically opens the transaction status drawer for the matching operation once, mirroring the existing Desktop behavior (`location.state.swapId`).

## ❓ Context

Minor visual polish reported on the Desktop Tx status dialog, plus aligning Mobile navigation behavior with Desktop when a `swapId` is passed to the Swap History screen.

## ✅ Checklist

- [x] Added a changeset
- [x] Unit tests updated and passing (`useSwapCustomHandlers.test.ts`)


[LIVE-34263]: https://ledgerhq.atlassian.net/browse/LIVE-34263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Before
<img width="400" alt="Screenshot 2026-07-09 at 17 49 25" src="https://github.com/user-attachments/assets/edd3376f-3dc9-4c9b-b461-1f58c86ab0d3" />

After
<img width="400" alt="Screenshot 2026-07-09 at 17 49 08" src="https://github.com/user-attachments/assets/9755f963-89fe-4121-8608-d188b9ec22dd" />
