### PR TITLE
[LWDM] feat(coin-evm): wire 0G delegate

### DIFF
--- a/.changeset/happy-wolves-swim.md
+++ b/.changeset/happy-wolves-swim.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+Wire 0G (zero_gravity) delegate: add protocol encoder, stake fetcher (getDelegation + convertToTokens), and STAKING_CONFIG entry. Fix Blockscout adapter to derive methodId from input calldata when the API field is absent, so staking ops keep their DELEGATE type after confirmation.

--- a/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
@@ -72,8 +72,9 @@ export const etherscanOperationToOperations = (
     types.push("IN");
   }
   if (from === checksummedAddress) {
-    const isContractInteraction = new RegExp(/0[xX][0-9a-fA-F]{8}/).test(etherscanOp.methodId); // 0x + 4 bytes selector
-    const stakingType = detectEvmStakingOperationType(currencyId, to, etherscanOp.methodId);
+    const methodId = etherscanOp.methodId || etherscanOp.input?.slice(0, 10) || "";
+    const isContractInteraction = new RegExp(/0[xX][0-9a-fA-F]{8}/).test(methodId); // 0x + 4 bytes selector
+    const stakingType = detectEvmStakingOperationType(currencyId, to, methodId);
     types.push(stakingType ?? (isContractInteraction ? "FEES" : "OUT"));
   }
   if (!types.length) {

--- a/libs/coin-modules/coin-evm/src/staking/contracts.ts
+++ b/libs/coin-modules/coin-evm/src/staking/contracts.ts
@@ -166,6 +166,8 @@ export const STAKING_CONTRACTS: Record<string, StakingContractConfig> = {
       undelegate: "undelegate",
       getStakedBalance: "getDelegation",
     },
+    // https://docs.0g.ai/developer-hub/building-on-0g/contracts-on-0g/validator-contract-functions#delegateaddress-delegatoraddress
+    calldataAmountScale: 10n ** 9n,
     apiConfig: {
       baseUrl: "https://api.0g.exploreme.pro",
       validatorsEndpoint: "/api/v2/validators?limit=100",

--- a/libs/coin-modules/coin-evm/src/staking/fetchers.ts
+++ b/libs/coin-modules/coin-evm/src/staking/fetchers.ts
@@ -17,6 +17,7 @@ import { buildTransactionParams } from "./operations";
 import { fetchRewards } from "./rewards";
 import { getValidators } from "./validators";
 import { fetchMonadStakes } from "./validators/monad";
+import { fetchZeroGravityStakes } from "./validators/zero_gravity";
 
 /**
  * Generic staking fetcher that adapts to different blockchain requirements
@@ -61,6 +62,9 @@ export const STAKING_CONFIG: Record<string, StakingStrategy> = {
   },
   monad: {
     fetcher: fetchMonadStakes,
+  },
+  zero_gravity: {
+    fetcher: fetchZeroGravityStakes,
   },
 };
 

--- a/libs/coin-modules/coin-evm/src/staking/operations/index.ts
+++ b/libs/coin-modules/coin-evm/src/staking/operations/index.ts
@@ -2,12 +2,14 @@ import type { StakingOperation } from "../../types/staking";
 import celoProtocol from "./celo";
 import monadProtocol from "./monad";
 import seiProtocol from "./sei";
+import zeroGravityProtocol from "./zero_gravity";
 import type { OperationParams, StakingProtocol } from "./types";
 
 const STAKING_PROTOCOLS: Record<string, StakingProtocol> = {
   sei_evm: seiProtocol as StakingProtocol,
   celo: celoProtocol as StakingProtocol,
   monad: monadProtocol as StakingProtocol,
+  zero_gravity: zeroGravityProtocol as StakingProtocol,
 };
 
 export const buildTransactionParams = (
@@ -31,6 +33,10 @@ export const buildTransactionParams = (
 
   if (!params.valId && currencyId === "monad") {
     throw new Error(`${currencyId} staking requires valId`);
+  }
+
+  if (!params.delegator && currencyId === "zero_gravity") {
+    throw new Error(`${currencyId} staking requires delegator`);
   }
 
   if (

--- a/libs/coin-modules/coin-evm/src/staking/operations/types.ts
+++ b/libs/coin-modules/coin-evm/src/staking/operations/types.ts
@@ -16,6 +16,10 @@ export type OperationParamsMonad = OperationParams & {
   withdrawId?: string | undefined;
 };
 
+export type OperationParamsZeroGravity = OperationParams & {
+  delegator: string;
+};
+
 export type OperationFn<P extends OperationParams = OperationParams> = (
   params: P,
 ) => Array<string | bigint>;

--- a/libs/coin-modules/coin-evm/src/staking/operations/zero_gravity.ts
+++ b/libs/coin-modules/coin-evm/src/staking/operations/zero_gravity.ts
@@ -1,0 +1,7 @@
+import type { OperationParamsZeroGravity, StakingProtocol } from "./types";
+
+const zeroGravityProtocol: StakingProtocol<OperationParamsZeroGravity> = {
+  delegate: ({ delegator }) => [delegator],
+};
+
+export default zeroGravityProtocol;

--- a/libs/coin-modules/coin-evm/src/staking/transactionData.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/transactionData.test.ts
@@ -119,6 +119,39 @@ describe("buildStakingTransactionParams", () => {
   });
 });
 
+describe("0G / zero_gravity delegate", () => {
+  it("encodes sender as the delegate(address) arg, routes to valAddress, carries amount as value", () => {
+    const intent = delegateIntent({
+      valAddress: "0x0000000000000000000000000000000000000001",
+      sender: "0x0000000000000000000000000000000000000002",
+    });
+
+    const { to, data, value } = buildStakingTransactionParams(asCurrency("zero_gravity"), intent);
+
+    const iface = new ethers.Interface(getStakingABI("zero_gravity") as ethers.InterfaceAbi);
+    expect("0x" + data.toString("hex")).toEqual(
+      iface.encodeFunctionData("delegate", ["0x0000000000000000000000000000000000000002"]),
+    );
+    expect(to).toEqual("0x0000000000000000000000000000000000000001");
+    expect(value).toEqual(1000000000000000000n);
+  });
+
+  it("throws when valAddress is missing", () => {
+    expect(() => {
+      buildStakingTransactionParams(asCurrency("zero_gravity"), delegateIntent({}));
+    }).toThrow("0G staking requires a validator address");
+  });
+
+  it("throws when delegator is missing", () => {
+    expect(() => {
+      buildStakingTransactionParams(
+        asCurrency("zero_gravity"),
+        delegateIntent({ valAddress: "0x0000000000000000000000000000000000000001", sender: "" }),
+      );
+    }).toThrow("zero_gravity staking requires delegator");
+  });
+});
+
 describe("0G / zero_gravity contractAddress resolver", () => {
   const config = STAKING_CONTRACTS["zero_gravity"];
 

--- a/libs/coin-modules/coin-evm/src/staking/validators/zero_gravity.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators/zero_gravity.test.ts
@@ -1,13 +1,27 @@
 import { ethers } from "ethers";
 import network from "@ledgerhq/live-network";
+import { getCoinConfig } from "../../config";
+import { withApi } from "../../network/node/rpc.common";
+import { isExternalNodeConfig } from "../../network/node/types";
+import zeroGravityAbi from "../../abis/zero_gravity-validator.abi.json";
 import { clearValidatorsCache, getValidators } from "./index";
+import { fetchZeroGravityStakes } from "./zero_gravity";
 
 jest.mock("@ledgerhq/live-network", () => ({
   __esModule: true,
   default: jest.fn(),
 }));
+jest.mock("../../config", () => ({ __esModule: true, getCoinConfig: jest.fn() }));
+jest.mock("../../network/node/rpc.common", () => ({ __esModule: true, withApi: jest.fn() }));
+jest.mock("../../network/node/types", () => ({
+  __esModule: true,
+  isExternalNodeConfig: jest.fn(),
+}));
 
 const mockedNetwork = jest.mocked(network);
+const mockedGetCoinConfig = jest.mocked(getCoinConfig);
+const mockedWithApi = jest.mocked(withApi);
+const mockedIsExternalNodeConfig = jest.mocked(isExternalNodeConfig);
 
 const makeValidator = (
   overrides: Partial<{
@@ -105,5 +119,106 @@ describe("staking/validators/zero_gravity", () => {
     const page = await getValidators("zero_gravity");
 
     expect(page.next).toBeUndefined();
+  });
+
+  describe("fetchZeroGravityStakes", () => {
+    const CURRENCY = {
+      id: "zero_gravity",
+      name: "0G",
+      units: [{ magnitude: 18, name: "A0GI", code: "A0GI" }],
+    } as never;
+    const DELEGATOR = "0x" + "11".repeat(20);
+    const VALIDATOR_ADDR = ethers.getAddress("0xaabbccddee" + "00".repeat(15));
+    const NODE = { type: "external", uri: "https://zero-gravity.coin.ledger.com" };
+    const zg0Iface = new ethers.Interface(zeroGravityAbi as ethers.InterfaceAbi);
+
+    function makeCallHandler(getDelegationShares: bigint, convertToTokensAmount: bigint) {
+      return jest.fn(async ({ data }: { data?: string }) => {
+        const desc = zg0Iface.parseTransaction({ data: data ?? "0x" });
+        if (desc?.name === "getDelegation") {
+          return zg0Iface.encodeFunctionResult("getDelegation", [
+            "0x0000000000000000000000000000000000000000",
+            getDelegationShares,
+          ]);
+        }
+        if (desc?.name === "convertToTokens") {
+          return zg0Iface.encodeFunctionResult("convertToTokens", [convertToTokensAmount]);
+        }
+        throw new Error(`unexpected call: ${desc?.name}`);
+      });
+    }
+
+    function setupProvider(callHandler: ReturnType<typeof jest.fn>) {
+      mockedWithApi.mockImplementation(async (_currency, fn) => fn({ call: callHandler } as never));
+    }
+
+    beforeEach(() => {
+      mockedGetCoinConfig.mockReturnValue({ info: { node: NODE } } as never);
+      mockedIsExternalNodeConfig.mockReturnValue(true);
+      mockedNetwork.mockResolvedValueOnce({ data: [makeValidator()] } as never);
+    });
+
+    it("returns an active stake when shares and amount are non-zero", async () => {
+      setupProvider(makeCallHandler(1000n, 500n));
+
+      const stakes = await fetchZeroGravityStakes(DELEGATOR, {} as never, CURRENCY);
+
+      expect(stakes).toHaveLength(1);
+      expect(stakes[0]).toMatchObject({
+        delegate: VALIDATOR_ADDR,
+        amount: 500n,
+        state: "active",
+      });
+    });
+
+    it("filters out validators with shares = 0", async () => {
+      setupProvider(makeCallHandler(0n, 0n));
+
+      const stakes = await fetchZeroGravityStakes(DELEGATOR, {} as never, CURRENCY);
+
+      expect(stakes).toEqual([]);
+    });
+
+    it("filters out validators when convertToTokens returns 0", async () => {
+      setupProvider(makeCallHandler(1000n, 0n));
+
+      const stakes = await fetchZeroGravityStakes(DELEGATOR, {} as never, CURRENCY);
+
+      expect(stakes).toEqual([]);
+    });
+
+    it("handles a rejected getDelegation call without throwing", async () => {
+      mockedWithApi.mockImplementation(async (_currency, fn) =>
+        fn({ call: jest.fn().mockRejectedValue(new Error("RPC error")) } as never),
+      );
+
+      const stakes = await fetchZeroGravityStakes(DELEGATOR, {} as never, CURRENCY);
+
+      expect(stakes).toEqual([]);
+    });
+
+    it("processes validators across batching boundaries (> 10)", async () => {
+      const validators = Array.from({ length: 11 }, (_, i) => ({
+        addr: `aabb${i.toString().padStart(2, "0")}` + "00".repeat(17),
+        moniker: `Validator${i}`,
+        commission_pct: "5.00",
+        voting_power_tokens: "1000",
+      }));
+      mockedNetwork.mockReset();
+      mockedNetwork.mockResolvedValueOnce({ data: validators } as never);
+      setupProvider(makeCallHandler(1000n, 500n));
+
+      const stakes = await fetchZeroGravityStakes(DELEGATOR, {} as never, CURRENCY);
+
+      expect(stakes).toHaveLength(11);
+    });
+
+    it("returns [] when node config is not external", async () => {
+      mockedIsExternalNodeConfig.mockReturnValue(false);
+
+      const stakes = await fetchZeroGravityStakes(DELEGATOR, {} as never, CURRENCY);
+
+      expect(stakes).toEqual([]);
+    });
   });
 });

--- a/libs/coin-modules/coin-evm/src/staking/validators/zero_gravity.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators/zero_gravity.ts
@@ -1,8 +1,15 @@
-import { ethers } from "ethers";
+import { ethers, type JsonRpcProvider } from "ethers";
 import network from "@ledgerhq/live-network";
 import { log } from "@ledgerhq/logs";
 import type { Page } from "@ledgerhq/coin-module-framework/api/index";
+import type { AssetInfo, Stake } from "@ledgerhq/coin-module-framework/api/types";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { StakingValidatorItem } from "@ledgerhq/types-live";
+import { getCoinConfig } from "../../config";
+import { withApi } from "../../network/node/rpc.common";
+import { isExternalNodeConfig } from "../../network/node/types";
+import type { StakingContractConfig } from "../../types/staking";
+import { getStakingABI } from "../abis";
 import { STAKING_CONTRACTS } from "../contracts";
 import type { ValidatorApi } from "./types";
 
@@ -64,6 +71,110 @@ const zeroGravityValidatorApi: ValidatorApi = {
       return { items: [], next: undefined };
     }
   },
+};
+
+const DETAILS_BATCH_SIZE = 10;
+
+type GetDelegationResult = [string, bigint];
+
+function isGetDelegationResult(value: unknown): value is GetDelegationResult {
+  return Array.isArray(value) && typeof value[0] === "string" && typeof value[1] === "bigint";
+}
+
+const fetchStakeForValidator = async (
+  provider: JsonRpcProvider,
+  iface: ethers.Interface,
+  validatorAddress: string,
+  delegatorAddress: string,
+  asset: AssetInfo,
+): Promise<Stake | null> => {
+  const getDelegationData = iface.encodeFunctionData("getDelegation", [delegatorAddress]);
+  const rawDelegation = await provider.call({ to: validatorAddress, data: getDelegationData });
+  const decodedDelegation = iface.decodeFunctionResult("getDelegation", rawDelegation);
+
+  if (!isGetDelegationResult(decodedDelegation)) return null;
+
+  const [, shares] = decodedDelegation;
+  if (shares === 0n) return null;
+
+  const convertData = iface.encodeFunctionData("convertToTokens", [shares]);
+  const rawAmount = await provider.call({ to: validatorAddress, data: convertData });
+  const decodedAmount = iface.decodeFunctionResult("convertToTokens", rawAmount);
+  const amount =
+    Array.isArray(decodedAmount) && typeof decodedAmount[0] === "bigint" ? decodedAmount[0] : 0n;
+
+  if (amount === 0n) return null;
+
+  return {
+    uid: `${validatorAddress}-${delegatorAddress}`,
+    address: delegatorAddress,
+    delegate: validatorAddress,
+    state: "active",
+    asset,
+    amount,
+    actions: [],
+    details: { contractAddress: validatorAddress, validator: validatorAddress },
+  };
+};
+
+export const fetchZeroGravityStakes = async (
+  address: string,
+  _config: StakingContractConfig,
+  currency: CryptoCurrency,
+): Promise<Stake[]> => {
+  const abi = getStakingABI(currency.id);
+  if (!abi) return [];
+
+  const node = getCoinConfig(currency.id).info.node;
+  if (!isExternalNodeConfig(node)) return [];
+
+  const { items: validators } = await zeroGravityValidatorApi.fetchValidators(currency.id);
+  if (validators.length === 0) return [];
+
+  const asset: AssetInfo = {
+    type: "native",
+    name: currency.name,
+    unit: currency.units[0],
+  };
+
+  try {
+    return await withApi(
+      currency,
+      async provider => {
+        const iface = new ethers.Interface(abi as ethers.InterfaceAbi);
+        const stakes: Stake[] = [];
+
+        for (let i = 0; i < validators.length; i += DETAILS_BATCH_SIZE) {
+          const chunk = validators.slice(i, i + DETAILS_BATCH_SIZE);
+          const settled = await Promise.allSettled(
+            chunk.map(({ validatorAddress: valAddr }) =>
+              fetchStakeForValidator(provider, iface, valAddr, address, asset),
+            ),
+          );
+
+          settled.forEach((res, idx) => {
+            if (res.status === "rejected") {
+              log("coin-evm/staking", "fetchZeroGravityStakes: getDelegation call failed", {
+                validator: chunk[idx].validatorAddress,
+                error: res.reason instanceof Error ? res.reason.message : String(res.reason),
+              });
+              return;
+            }
+            if (res.value) stakes.push(res.value);
+          });
+        }
+
+        return stakes;
+      },
+      node,
+    );
+  } catch (error) {
+    log("coin-evm/staking", "fetchZeroGravityStakes: delegations fetch failed", {
+      currencyId: currency.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
 };
 
 export default zeroGravityValidatorApi;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Wires the 0G delegate flow at the coin-evm level: protocol encoder, stake fetcher, and two bug fixes required to make it work end-to-end.

- `zeroGravityProtocol.delegate` encodes the sender address as the `delegate(address)` calldata arg; amount is `msg.value`
- `fetchZeroGravityStakes` reads `getDelegation` + `convertToTokens` per validator (batched 10 at a time) to display positions
- `calldataAmountScale: 10n ** 9n` - without it `amount=0n` reaches `eth_estimateGas`, which reverts and produces `gasLimit=0` / `FeeNotLoaded`
- methodId fallback to `input.slice(0, 10)` - `chainscan.0g.ai` omits the `methodId` field, causing confirmed DELEGATE ops to be typed as `OUT`

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32754](https://ledgerhq.atlassian.net/browse/LIVE-32754)

[LIVE-32754]: https://ledgerhq.atlassian.net/browse/LIVE-32754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
