### PR TITLE
fix(desktop): fix RC/nightly Braze staging vs production targeting

### DIFF
--- a/.changeset/quiet-otters-heal.md
+++ b/.changeset/quiet-otters-heal.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix pre-release desktop builds baking in the production Braze API key instead of the staging one, so Braze staging campaigns can be tested on the desktop staging environment again

--- a/.changeset/quiet-otters-heal.md
+++ b/.changeset/quiet-otters-heal.md
@@ -2,4 +2,4 @@
 "ledger-live-desktop": minor
 ---
 
-Fix pre-release desktop builds baking in the production Braze API key instead of the staging one, so Braze staging campaigns can be tested on the desktop staging environment again
+Fix desktop pre-release and nightly builds using the wrong Braze API key. Pre-release (RC) now correctly shares the production Braze app with `release` (validating the real integration before shipping, matching mobile's convention), and nightly now uses the staging Braze app (internal-only, safe for CRM to test canvases against), instead of both silently falling back to production

--- a/apps/ledger-live-desktop/tools/dist/index.js
+++ b/apps/ledger-live-desktop/tools/dist/index.js
@@ -91,6 +91,9 @@ const buildTasks = args => [
           }
         : args.pre
           ? {
+              // Without this, tools/rspack/utils.ts falls back to NODE_ENV==="production"
+              // and bakes .env.production (incl. BRAZE_API_KEY) into the "staging" build.
+              STAGING: "1",
               SENTRY_URL: prereleaseSentryDSN,
               DATADOG_APPLICATION_ID: process.env.DATADOG_APPLICATION_ID,
               DATADOG_CLIENT_TOKEN: process.env.DATADOG_CLIENT_TOKEN,

--- a/apps/ledger-live-desktop/tools/dist/index.js
+++ b/apps/ledger-live-desktop/tools/dist/index.js
@@ -72,13 +72,18 @@ const buildTasks = args => [
   {
     title: "Compiling assets",
     task: async () => {
+      // RC (--pre) validates the build about to ship, so it uses the same
+      // .env.production (incl. BRAZE_API_KEY) as --release. Nightly is
+      // internal-only, so it uses .env.staging, matching mobile's convention
+      // (prerelease/release share the production Braze app; staging/nightly
+      // share the staging one).
       if (args.release || args.pre) {
         require("dotenv").config({
-          path: path.resolve(
-            __dirname,
-            rootFolder,
-            args.release ? ".env.production" : ".env.staging",
-          ),
+          path: path.resolve(__dirname, rootFolder, ".env.production"),
+        });
+      } else if (args.nightly) {
+        require("dotenv").config({
+          path: path.resolve(__dirname, rootFolder, ".env.staging"),
         });
       }
       const baseEnv = args.release
@@ -91,16 +96,24 @@ const buildTasks = args => [
           }
         : args.pre
           ? {
-              // Without this, tools/rspack/utils.ts falls back to NODE_ENV==="production"
-              // and bakes .env.production (incl. BRAZE_API_KEY) into the "staging" build.
-              STAGING: "1",
               SENTRY_URL: prereleaseSentryDSN,
               DATADOG_APPLICATION_ID: process.env.DATADOG_APPLICATION_ID,
               DATADOG_CLIENT_TOKEN: process.env.DATADOG_CLIENT_TOKEN,
               DATADOG_SITE: process.env.DATADOG_SITE || defaultDatadogSite,
               DATADOG_ENV: "staging",
             }
-          : {};
+          : args.nightly
+            ? {
+                // Without this, tools/rspack/utils.ts falls back to
+                // NODE_ENV==="production" and bakes .env.production (incl.
+                // BRAZE_API_KEY) into what should be the internal-only build.
+                STAGING: "1",
+                DATADOG_APPLICATION_ID: process.env.DATADOG_APPLICATION_ID,
+                DATADOG_CLIENT_TOKEN: process.env.DATADOG_CLIENT_TOKEN,
+                DATADOG_SITE: process.env.DATADOG_SITE || defaultDatadogSite,
+                DATADOG_ENV: "nightly",
+              }
+            : {};
       await exec("pnpm", ["run", "build:js"], { env: { ...process.env, ...baseEnv } });
     },
   },

--- a/apps/ledger-live-desktop/tools/dist/index.js
+++ b/apps/ledger-live-desktop/tools/dist/index.js
@@ -72,11 +72,8 @@ const buildTasks = args => [
   {
     title: "Compiling assets",
     task: async () => {
-      // RC (--pre) validates the build about to ship, so it uses the same
-      // .env.production (incl. BRAZE_API_KEY) as --release. Nightly is
-      // internal-only, so it uses .env.staging, matching mobile's convention
-      // (prerelease/release share the production Braze app; staging/nightly
-      // share the staging one).
+      // Matches mobile: prerelease (--pre) shares prod config with release,
+      // nightly uses staging.
       if (args.release || args.pre) {
         require("dotenv").config({
           path: path.resolve(__dirname, rootFolder, ".env.production"),
@@ -104,9 +101,7 @@ const buildTasks = args => [
             }
           : args.nightly
             ? {
-                // Without this, tools/rspack/utils.ts falls back to
-                // NODE_ENV==="production" and bakes .env.production (incl.
-                // BRAZE_API_KEY) into what should be the internal-only build.
+                // Required for tools/rspack/utils.ts to pick .env.staging.
                 STAGING: "1",
                 DATADOG_APPLICATION_ID: process.env.DATADOG_APPLICATION_ID,
                 DATADOG_CLIENT_TOKEN: process.env.DATADOG_CLIENT_TOKEN,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Not covered by an automated test: the bug lives in the build/packaging pipeline (`tools/dist`), not application code. Verified empirically instead, see "Proof" below._
- [x] **Impact of the changes:**
      - Ran the exact `build:js` command that `tools/dist` spawns for each build mode, then inspected the resulting `renderer.bundle.js` for which Braze API key got baked in by `DefinePlugin`.
      - Confirmed `--release` and `--pre` now embed the production key, `--nightly` embeds the staging key, and unrelated modes (`build:testing`, custom builds) are unaffected. Full matrix below.

### 📝 Description

Desktop pre-release (RC, `--pre`) and nightly (`--nightly`) builds were both silently baking in the **production** Braze API key, regardless of which one they should actually be using.

**Root cause**: `tools/dist/index.js`'s `--pre`/`--nightly` tasks never propagated a `STAGING`/dotenv-file signal that matches what `tools/rspack/utils.ts` actually checks (`TESTING`/`STAGING`/`NODE_ENV`). Since neither flag was set and `build:js` always sets `NODE_ENV=production`, `DOTENV_FILE` fell back to `.env.production`, and `buildDotEnvDefine()` re-reads that file straight off disk (ignoring any inherited `process.env` values) to feed the `DefinePlugin`. Every non-release packaged build ended up with production credentials baked in.

**Intended mapping** (confirmed against mobile's convention, see [LIVE-32802](https://ledgerhq.atlassian.net/browse/LIVE-32802)):
- **RC (`--pre`)** validates the exact build about to ship, so it should share the **production** Braze app with `--release` (mirrors mobile's `prerelease`/`release` sharing the same Braze key).
- **Nightly (`--nightly`)** is internal-only and always-changing, so it should use the **staging** Braze app (mirrors mobile's `nightly`/`staging` sharing the same Braze key). This is also the practical fix for LIVE-32802: CRM can now test Braze staging canvases against nightly desktop builds.
- `--release` is unaffected either way.

**Fix**: in `tools/dist/index.js`, explicitly resolve `.env.production` for `--release`/`--pre` and `.env.staging` for `--nightly`, and set `STAGING: "1"` only in the `--nightly` branch of `baseEnv` so the spawned `build:js` process resolves the matching dotenv file.

### 🔎 Proof (fix confirmed, no regression on other envs)

`tools/dist` always delegates the actual env/key resolution to `pnpm run build:js` (same rspack pipeline, just spawned with different flags per mode). Ran that command directly for every mode, then grepped the output `renderer.bundle.js` for each of the three known Braze key UUIDs (production `d3af8483...`, staging `25715c7f...`, testing `d84c8166...`) to see exactly which one got baked in:

| Build mode | Flags `tools/dist` sets | Dotenv file resolved | Key embedded in bundle | Result |
|---|---|---|---|---|
| `--release` | none (`NODE_ENV=production`) | `.env.production` | production only | ✅ unaffected, same before and after this PR |
| `--pre` (RC) | none (post-fix) | `.env.production` | production only | ✅ now intentional (before this PR it landed on production too, but only by accident, via the same fallback bug that broke nightly) |
| `--nightly` | `STAGING=1` | `.env.staging` | staging only | ✅ fixed (before this PR: production, due to the bug) |
| Custom builds (`ledger-live-build`, `build:lld`) | `STAGING=1` (already set independently) | `.env.staging` | staging only | ✅ unaffected, this path was never broken |
| `build:testing` | `TESTING=1` | `.env.testing` | testing only | ✅ unaffected regression check, this path isn't touched by the diff |

Each row above was a real build: in every case, exactly one of the three UUIDs appeared in the bundle and it matched the expected environment, confirming no cross-contamination between production, staging, and testing keys after the change.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32802](https://ledgerhq.atlassian.net/browse/LIVE-32802)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32802]: https://ledgerhq.atlassian.net/browse/LIVE-32802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ