### PR TITLE
[LWM] fix(mobile): fix countervalue and swap button for multi-network assets

### DIFF
--- a/.changeset/golden-rivers-fix.md
+++ b/.changeset/golden-rivers-fix.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix countervalue not shown for multi-network assets with no base-chain account

--- a/.changeset/golden-rivers-fix.md
+++ b/.changeset/golden-rivers-fix.md
@@ -2,4 +2,4 @@
 "live-mobile": patch
 ---
 
-fix countervalue not shown for multi-network assets with no base-chain account
+fix multi-network asset countervalues and Asset Detail CTA placement

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/usePrecomputedAssetListData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/usePrecomputedAssetListData.test.ts
@@ -179,7 +179,7 @@ describe("usePrecomputedAssetListData", () => {
     const { result } = renderHook(() => usePrecomputedAssetListData(assets));
 
     expect(mockedCalculate).not.toHaveBeenCalled();
-    expect(result.current.get(bitcoin.id)?.formattedCounterValue).toBe("$50,000.00");
+    expect(result.current.get(bitcoin.id)?.formattedCounterValue).toBe("$420.00");
   });
 
   it("falls back to calculate when countervalue is not set", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/usePrecomputedAssetListData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/usePrecomputedAssetListData.test.ts
@@ -173,6 +173,23 @@ describe("usePrecomputedAssetListData", () => {
     expect(result.current.get(bitcoin.id)?.formattedCounterValue).toBeNull();
   });
 
+  it("uses the pre-computed countervalue when present and skips calculate", () => {
+    const assets: Asset[] = [{ ...createCryptoAsset(bitcoin, 100_000), countervalue: 42_000 }];
+
+    const { result } = renderHook(() => usePrecomputedAssetListData(assets));
+
+    expect(mockedCalculate).not.toHaveBeenCalled();
+    expect(result.current.get(bitcoin.id)?.formattedCounterValue).toBe("$50,000.00");
+  });
+
+  it("falls back to calculate when countervalue is not set", () => {
+    const assets: Asset[] = [createCryptoAsset(bitcoin, 100_000)];
+
+    renderHook(() => usePrecomputedAssetListData(assets));
+
+    expect(mockedCalculate).toHaveBeenCalledTimes(1);
+  });
+
   it("should pass through negative countervalueChange", () => {
     const btcAccount = genAccount("btc-neg", { currency: getCryptoCurrencyById("bitcoin") });
     mockedGetCurrencyPortfolio.mockReturnValue(makePortfolio(-0.012));

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/usePrecomputedAssetListData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/usePrecomputedAssetListData.ts
@@ -51,6 +51,10 @@ function getCounterValue(
     return 0;
   }
 
+  if (asset.countervalue !== undefined) {
+    return asset.countervalue;
+  }
+
   const cv = calculate(cvState, {
     from: asset.currency,
     to: counterValueCurrency,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -177,7 +177,7 @@ describe("AssetDetail screen layout", () => {
     // While market data is loading, the header is rendered as a skeleton (no
     // "Market price" text). The chart container is still mounted.
     expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.chart)).toBeVisible();
-    expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.receiveButton)).toBeNull();
+    expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.receiveButton)).toBeVisible();
   });
 
   it("hides the addresses section when there are no accounts", () => {
@@ -277,7 +277,7 @@ describe("AssetDetail screen layout", () => {
   });
 
   describe("floating bar CTAs", () => {
-    it("shows Buy + Swap when buyable, swappable and the asset has funds", () => {
+    it("shows Buy + Swap in the footer and hides graph Receive when the asset has an account", () => {
       setAvailability({ availableOnBuy: true, availableOnSwap: true });
 
       render(
@@ -289,25 +289,28 @@ describe("AssetDetail screen layout", () => {
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.buyButton)).toBeVisible();
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeVisible();
       expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeNull();
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.receiveButton)).toBeNull();
       expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.fallbackBanner)).toBeNull();
     });
 
-    it("shows Buy + Receive when buyable but the wallet has no funds", () => {
+    it("shows Buy + Swap in the footer and Receive in the graph when the asset has no account", () => {
       setAvailability({ availableOnBuy: true, availableOnSwap: true });
 
       render(<AssetDetailTestNavigator />);
 
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.buyButton)).toBeVisible();
-      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeVisible();
-      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeNull();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeVisible();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.receiveButton)).toBeVisible();
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeNull();
     });
 
-    it("shows Receive and the fallback banner when supported but neither buyable nor swappable", () => {
+    it("shows graph Receive and the fallback banner when supported but neither buyable nor swappable", () => {
       setAvailability({ availableOnBuy: false, availableOnSwap: false });
 
       render(<AssetDetailTestNavigator />);
 
-      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeVisible();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.receiveButton)).toBeVisible();
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeNull();
       expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.buyButton)).toBeNull();
       expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeNull();
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.fallbackBanner)).toBeVisible();
@@ -332,16 +335,16 @@ describe("AssetDetail screen layout", () => {
       expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.fallbackBanner)).toBeNull();
     });
 
-    it("hides the BalanceGraph Receive when the footer shows Receive (no funds)", () => {
+    it("shows the BalanceGraph Receive when the asset has no account and no footer CTA", () => {
       setAvailability({ availableOnBuy: false, availableOnSwap: false });
 
       render(<AssetDetailTestNavigator />);
 
-      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeVisible();
-      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.receiveButton)).toBeNull();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.receiveButton)).toBeVisible();
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeNull();
     });
 
-    it("shows the BalanceGraph Receive when the footer shows Swap (funds elsewhere)", () => {
+    it("shows the BalanceGraph Receive when the footer shows Swap and only another asset has an account", () => {
       setAvailability({ availableOnSwap: true });
 
       render(
@@ -352,6 +355,20 @@ describe("AssetDetail screen layout", () => {
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeVisible();
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.receiveButton)).toBeVisible();
       expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.footerReceiveButton)).toBeNull();
+    });
+
+    it("hides the BalanceGraph Receive when the asset account exists without funds", () => {
+      setAvailability({ availableOnBuy: true, availableOnSwap: true });
+
+      render(
+        <AssetDetailTestNavigator />,
+        withAccounts([{ seed: "btc-0", currencyId: "bitcoin", balance: 0 }]),
+      );
+
+      expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.receiveButton)).toBeNull();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.ctas)).toBeVisible();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.buyButton)).toBeVisible();
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.swapButton)).toBeVisible();
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
@@ -12,6 +12,7 @@ import {
   mockBtcCryptoCurrency,
   mockEthCryptoCurrency,
 } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import BigNumber from "bignumber.js";
@@ -104,6 +105,7 @@ type AccountFunds = { currencyId: string; balance: number; tokens?: TokenFunds[]
 const CURRENCY_BY_ID: Record<string, CryptoCurrency> = {
   bitcoin: mockBtcCryptoCurrency,
   ethereum: mockEthCryptoCurrency,
+  optimism: getCryptoCurrencyById("optimism"),
 };
 
 function buildAccount({ currencyId, balance, tokens }: AccountFunds, index: number) {
@@ -264,7 +266,16 @@ describe("useBalanceGraphViewModel", () => {
       expect(result.current.showReceive).toBe(false);
     });
 
-    it("is true when the asset has no funds but another asset does", () => {
+    it("is true when the asset has no account", () => {
+      const { result } = renderVM(
+        { currency: mockBtcCryptoCurrency },
+        withFunds([{ currencyId: "ethereum", balance: 1000 }]),
+      );
+
+      expect(result.current.showReceive).toBe(true);
+    });
+
+    it("is false when the asset already has an account without funds", () => {
       const { result } = renderVM(
         { currency: mockBtcCryptoCurrency },
         withFunds([
@@ -273,7 +284,7 @@ describe("useBalanceGraphViewModel", () => {
         ]),
       );
 
-      expect(result.current.showReceive).toBe(true);
+      expect(result.current.showReceive).toBe(false);
     });
 
     it("is false when the asset already has funds", () => {
@@ -288,7 +299,19 @@ describe("useBalanceGraphViewModel", () => {
       expect(result.current.showReceive).toBe(false);
     });
 
-    it("is false when the wallet has no funds at all", () => {
+    it("is false when a multi-network asset has funds on another ledger id", () => {
+      const { result } = renderVM(
+        { currency: mockEthCryptoCurrency, ledgerIds: ["ethereum", "optimism"] },
+        withFunds([
+          { currencyId: "ethereum", balance: 0 },
+          { currencyId: "optimism", balance: 500 },
+        ]),
+      );
+
+      expect(result.current.showReceive).toBe(false);
+    });
+
+    it("is false when the wallet has an asset account with no funds at all", () => {
       const { result } = renderVM(
         { currency: mockBtcCryptoCurrency },
         withFunds([

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
@@ -267,7 +267,8 @@ export function useBalanceGraphViewModel({
   const flatAccounts = useSelector(flattenAccountsSelector);
 
   const assetCurrencyIds = useMemo(
-    () => new Set(currency ? [currency.id, ...effectiveLedgerIds] : effectiveLedgerIds),
+    () =>
+      new Set(currency ? [currency.id, ...(effectiveLedgerIds ?? [])] : (effectiveLedgerIds ?? [])),
     [currency, effectiveLedgerIds],
   );
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
@@ -266,16 +266,16 @@ export function useBalanceGraphViewModel({
   // funded token asset.
   const flatAccounts = useSelector(flattenAccountsSelector);
 
+  const assetCurrencyIds = useMemo(
+    () => new Set(currency ? [currency.id, ...effectiveLedgerIds] : effectiveLedgerIds),
+    [currency, effectiveLedgerIds],
+  );
+
   const showReceive = useMemo(() => {
     if (hideReceive || !currency) return false;
-    const hasAssetFunds = flatAccounts.some(
-      a => getAccountCurrency(a).id === currency.id && a.balance.gt(0),
-    );
-    const hasFundsElsewhere = flatAccounts.some(
-      a => getAccountCurrency(a).id !== currency.id && a.balance.gt(0),
-    );
-    return !hasAssetFunds && hasFundsElsewhere;
-  }, [hideReceive, flatAccounts, currency]);
+    const hasAssetAccounts = flatAccounts.some(a => assetCurrencyIds.has(getAccountCurrency(a).id));
+    return !hasAssetAccounts;
+  }, [hideReceive, flatAccounts, currency, assetCurrencyIds]);
 
   const { handleOpenReceiveDrawer } = useOpenReceiveDrawer({
     currency,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/FooterView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/FooterView.tsx
@@ -11,26 +11,21 @@ type Props = Readonly<{
   secondaryButton: SecondaryButtonType;
   onBuyPress: () => void;
   onSwapPress: () => void;
-  onReceivePress: () => void;
 }>;
 
-export function FooterView({
-  isBuyAvailable,
-  secondaryButton,
-  onBuyPress,
-  onSwapPress,
-  onReceivePress,
-}: Props) {
+export function FooterView({ isBuyAvailable, secondaryButton, onBuyPress, onSwapPress }: Props) {
   const { t } = useTranslation();
 
   if (!isBuyAvailable && !secondaryButton) return null;
+
+  const hasTwoButtons = isBuyAvailable && secondaryButton !== null;
 
   return (
     <BottomGradientFooter testID={ASSET_DETAIL_TEST_IDS.ctas} contentStyle={rowStyle}>
       {isBuyAvailable && (
         <Box lx={buttonSlotStyle}>
           <Button
-            appearance="gray"
+            appearance={hasTwoButtons ? "gray" : "base"}
             size="lg"
             isFull
             onPress={onBuyPress}
@@ -51,20 +46,6 @@ export function FooterView({
             testID={ASSET_DETAIL_TEST_IDS.swapButton}
           >
             {t("transfer.swap.title")}
-          </Button>
-        </Box>
-      )}
-
-      {secondaryButton === "receive" && (
-        <Box lx={buttonSlotStyle}>
-          <Button
-            appearance="base"
-            size="lg"
-            isFull
-            onPress={onReceivePress}
-            testID={ASSET_DETAIL_TEST_IDS.footerReceiveButton}
-          >
-            {t("transfer.receive.title")}
           </Button>
         </Box>
       )}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/__tests__/useFooterViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/__tests__/useFooterViewModel.test.ts
@@ -1,20 +1,21 @@
 import { renderHook, act } from "@tests/test-renderer";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { useTradeAvailability, type TradeAvailability } from "@ledgerhq/asset-detail";
+import type { Account } from "@ledgerhq/types-live";
+import BigNumber from "bignumber.js";
 import { track } from "~/analytics";
 import { useFooterViewModel } from "../useFooterViewModel";
 
-let mockAccounts: { currency: { id: string }; balance: { gt: () => boolean } }[] = [];
+let mockAccounts: Account[] = [];
 
 jest.mock("~/reducers/accounts", () => ({
   ...jest.requireActual("~/reducers/accounts"),
-  shallowAccountsSelector: () => mockAccounts,
+  flattenAccountsSelector: () => mockAccounts,
 }));
 
 const mockHandleOpenBuySell = jest.fn();
 const mockHandleOpenSwap = jest.fn();
-const mockHandleOpenReceiveDrawer = jest.fn();
-const mockUseOpenReceiveDrawer = jest.fn();
 
 jest.mock("@ledgerhq/asset-detail", () => ({
   ...jest.requireActual("@ledgerhq/asset-detail"),
@@ -29,13 +30,6 @@ jest.mock("LLM/features/Swap", () => ({
   useOpenSwap: () => ({ handleOpenSwap: mockHandleOpenSwap }),
 }));
 
-jest.mock("LLM/features/Receive", () => ({
-  useOpenReceiveDrawer: (params: unknown) => {
-    mockUseOpenReceiveDrawer(params);
-    return { handleOpenReceiveDrawer: mockHandleOpenReceiveDrawer };
-  },
-}));
-
 const mockedUseTradeAvailability = jest.mocked(useTradeAvailability);
 const setAvailability = (overrides: Partial<TradeAvailability> = {}) =>
   mockedUseTradeAvailability.mockReturnValue({
@@ -47,6 +41,14 @@ const setAvailability = (overrides: Partial<TradeAvailability> = {}) =>
   });
 
 const bitcoin = getCryptoCurrencyById("bitcoin");
+
+function buildAccount(currencyId: string, balance = 0) {
+  const currency = getCryptoCurrencyById(currencyId);
+  const account = genAccount(currencyId, { currency, operationsSize: 0 });
+  account.balance = new BigNumber(balance);
+  account.spendableBalance = new BigNumber(balance);
+  return account;
+}
 
 describe("useFooterViewModel", () => {
   beforeEach(() => {
@@ -82,6 +84,13 @@ describe("useFooterViewModel", () => {
 
       expect(result.current.isBuyAvailable).toBe(false);
     });
+
+    it("returns true when the user already has an account for the asset", () => {
+      mockAccounts = [buildAccount("bitcoin")];
+      const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
+
+      expect(result.current.isBuyAvailable).toBe(true);
+    });
   });
 
   describe("secondaryButton", () => {
@@ -92,28 +101,28 @@ describe("useFooterViewModel", () => {
       expect(result.current.secondaryButton).toBeNull();
     });
 
-    it("is receive when the asset has no accounts with funds", () => {
-      const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
-
-      expect(result.current.secondaryButton).toBe("receive");
-    });
-
-    it("is swap when an account matching ledgerIds has funds and swap is available", () => {
-      mockAccounts = [{ currency: { id: "bitcoin" }, balance: { gt: () => true } }];
+    it("is swap when the asset has no accounts and swap is available", () => {
       const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
 
       expect(result.current.secondaryButton).toBe("swap");
     });
 
-    it("is receive when only accounts outside ledgerIds have funds", () => {
-      mockAccounts = [{ currency: { id: "ethereum" }, balance: { gt: () => true } }];
+    it("is null when swap is unavailable", () => {
+      setAvailability({ availableOnSwap: false });
       const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
 
-      expect(result.current.secondaryButton).toBe("receive");
+      expect(result.current.secondaryButton).toBeNull();
     });
 
-    it("is swap when any network account in ledgerIds has funds for a multi-network asset", () => {
-      mockAccounts = [{ currency: { id: "optimism" }, balance: { gt: () => true } }];
+    it("is swap when only accounts outside ledgerIds exist", () => {
+      mockAccounts = [buildAccount("ethereum", 1000)];
+      const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
+
+      expect(result.current.secondaryButton).toBe("swap");
+    });
+
+    it("is swap when any network account in ledgerIds exists for a multi-network asset", () => {
+      mockAccounts = [buildAccount("optimism")];
       const { result } = renderHook(() =>
         useFooterViewModel(bitcoin, ["ethereum", "optimism", "base"]),
       );
@@ -149,29 +158,7 @@ describe("useFooterViewModel", () => {
       expect(mockHandleOpenSwap).toHaveBeenCalled();
     });
 
-    it("onReceivePress fires tracking and opens receive flow", () => {
-      const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
-
-      act(() => result.current.onReceivePress());
-
-      expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: "receive",
-        currency: "bitcoin",
-        page: "Asset Detail",
-      });
-      expect(mockHandleOpenReceiveDrawer).toHaveBeenCalled();
-    });
-
-    it("forwards the multi-network ledgerIds list to useOpenReceiveDrawer", () => {
-      const ledgerIds = ["ethereum", "optimism", "arbitrum", "base"];
-      renderHook(() => useFooterViewModel(bitcoin, ledgerIds));
-
-      expect(mockUseOpenReceiveDrawer).toHaveBeenCalledWith(
-        expect.objectContaining({ currency: bitcoin, currencyIds: ledgerIds }),
-      );
-    });
-
-    it.each(["onBuyPress", "onSwapPress", "onReceivePress"] as const)(
+    it.each(["onBuyPress", "onSwapPress"] as const)(
       "%s does nothing when currency is undefined",
       handler => {
         const { result } = renderHook(() => useFooterViewModel(undefined));

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/__tests__/useFooterViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/__tests__/useFooterViewModel.test.ts
@@ -85,11 +85,18 @@ describe("useFooterViewModel", () => {
       expect(result.current.isBuyAvailable).toBe(false);
     });
 
-    it("returns true when the user already has an account for the asset", () => {
+    it("follows buy availability when the user already has an account for the asset", () => {
       mockAccounts = [buildAccount("bitcoin")];
-      const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
+      setAvailability({ availableOnBuy: true });
+      const { result: buyableResult } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
 
-      expect(result.current.isBuyAvailable).toBe(true);
+      setAvailability({ availableOnBuy: false });
+      const { result: notBuyableResult } = renderHook(() =>
+        useFooterViewModel(bitcoin, ["bitcoin"]),
+      );
+
+      expect(buyableResult.current.isBuyAvailable).toBe(true);
+      expect(notBuyableResult.current.isBuyAvailable).toBe(false);
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/__tests__/useFooterViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/__tests__/useFooterViewModel.test.ts
@@ -4,6 +4,13 @@ import { useTradeAvailability, type TradeAvailability } from "@ledgerhq/asset-de
 import { track } from "~/analytics";
 import { useFooterViewModel } from "../useFooterViewModel";
 
+let mockAccounts: { currency: { id: string }; balance: { gt: () => boolean } }[] = [];
+
+jest.mock("~/reducers/accounts", () => ({
+  ...jest.requireActual("~/reducers/accounts"),
+  shallowAccountsSelector: () => mockAccounts,
+}));
+
 const mockHandleOpenBuySell = jest.fn();
 const mockHandleOpenSwap = jest.fn();
 const mockHandleOpenReceiveDrawer = jest.fn();
@@ -45,6 +52,7 @@ describe("useFooterViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     setAvailability();
+    mockAccounts = [];
   });
 
   describe("isBuyAvailable", () => {
@@ -84,10 +92,33 @@ describe("useFooterViewModel", () => {
       expect(result.current.secondaryButton).toBeNull();
     });
 
-    it("is receive when supported and the wallet has no funds", () => {
+    it("is receive when the asset has no accounts with funds", () => {
       const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
 
       expect(result.current.secondaryButton).toBe("receive");
+    });
+
+    it("is swap when an account matching ledgerIds has funds and swap is available", () => {
+      mockAccounts = [{ currency: { id: "bitcoin" }, balance: { gt: () => true } }];
+      const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
+
+      expect(result.current.secondaryButton).toBe("swap");
+    });
+
+    it("is receive when only accounts outside ledgerIds have funds", () => {
+      mockAccounts = [{ currency: { id: "ethereum" }, balance: { gt: () => true } }];
+      const { result } = renderHook(() => useFooterViewModel(bitcoin, ["bitcoin"]));
+
+      expect(result.current.secondaryButton).toBe("receive");
+    });
+
+    it("is swap when any network account in ledgerIds has funds for a multi-network asset", () => {
+      mockAccounts = [{ currency: { id: "optimism" }, balance: { gt: () => true } }];
+      const { result } = renderHook(() =>
+        useFooterViewModel(bitcoin, ["ethereum", "optimism", "base"]),
+      );
+
+      expect(result.current.secondaryButton).toBe("swap");
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/useFooterViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/useFooterViewModel.ts
@@ -13,7 +13,6 @@ export type SecondaryButtonType = "swap" | null;
 export type AssetActionsAvailability = Readonly<{
   isCurrencySupported: boolean;
   isBuyAvailable: boolean;
-  isBuyButtonVisible: boolean;
   availableOnSwap: boolean;
   hasAssetAccounts: boolean;
   secondaryButton: SecondaryButtonType;
@@ -36,7 +35,6 @@ export function useAssetActionsAvailability(
       return {
         isCurrencySupported: false,
         isBuyAvailable: false,
-        isBuyButtonVisible: false,
         availableOnSwap: false,
         hasAssetAccounts: false,
         secondaryButton: null,
@@ -45,13 +43,11 @@ export function useAssetActionsAvailability(
 
     const assetCurrencyIds = new Set([currency.id, ...(ledgerIds ?? [])]);
     const hasAssetAccounts = accounts.some(a => assetCurrencyIds.has(getAccountCurrency(a).id));
-    const isBuyButtonVisible = availableOnBuy;
     const secondaryButton: SecondaryButtonType = availableOnSwap ? "swap" : null;
 
     return {
       isCurrencySupported,
       isBuyAvailable: availableOnBuy,
-      isBuyButtonVisible,
       availableOnSwap,
       hasAssetAccounts,
       secondaryButton,
@@ -70,7 +66,7 @@ export function useFooterViewModel(currency: AssetDetailCurrencyProps, ledgerIds
     sourceScreenName: "Asset Detail",
   });
 
-  const { isBuyButtonVisible, secondaryButton } = useAssetActionsAvailability(currency, ledgerIds);
+  const { isBuyAvailable, secondaryButton } = useAssetActionsAvailability(currency, ledgerIds);
 
   const onBuyPress = useCallback(() => {
     if (!currency) return;
@@ -93,7 +89,7 @@ export function useFooterViewModel(currency: AssetDetailCurrencyProps, ledgerIds
   }, [currency, handleOpenSwap]);
 
   return {
-    isBuyAvailable: isBuyButtonVisible,
+    isBuyAvailable,
     secondaryButton,
     onBuyPress,
     onSwapPress,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/useFooterViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/useFooterViewModel.ts
@@ -1,19 +1,21 @@
 import { useCallback, useMemo } from "react";
 import { useTradeAvailability } from "@ledgerhq/asset-detail";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { useSelector } from "~/context/hooks";
-import { shallowAccountsSelector } from "~/reducers/accounts";
+import { flattenAccountsSelector } from "~/reducers/accounts";
 import { track } from "~/analytics";
 import { useOpenBuySell } from "LLM/features/Buy";
 import { useOpenSwap } from "LLM/features/Swap";
-import { useOpenReceiveDrawer } from "LLM/features/Receive";
 import type { AssetDetailCurrencyProps } from "LLM/features/AssetDetail/types";
 
-export type SecondaryButtonType = "swap" | "receive" | null;
+export type SecondaryButtonType = "swap" | null;
 
 export type AssetActionsAvailability = Readonly<{
   isCurrencySupported: boolean;
   isBuyAvailable: boolean;
+  isBuyButtonVisible: boolean;
   availableOnSwap: boolean;
+  hasAssetAccounts: boolean;
   secondaryButton: SecondaryButtonType;
 }>;
 
@@ -26,7 +28,7 @@ export function useAssetActionsAvailability(
   currency: AssetDetailCurrencyProps,
   ledgerIds?: string[],
 ): AssetActionsAvailability {
-  const accounts = useSelector(shallowAccountsSelector);
+  const accounts = useSelector(flattenAccountsSelector);
   const { availableOnBuy, availableOnSwap, isCurrencySupported } = useTradeAvailability(ledgerIds);
 
   return useMemo(() => {
@@ -34,22 +36,24 @@ export function useAssetActionsAvailability(
       return {
         isCurrencySupported: false,
         isBuyAvailable: false,
+        isBuyButtonVisible: false,
         availableOnSwap: false,
+        hasAssetAccounts: false,
         secondaryButton: null,
       };
     }
 
-    const assetCurrencyIds = ledgerIds ?? [currency.id];
-    const assetHasFunds = accounts.some(
-      a => assetCurrencyIds.includes(a.currency.id) && a.balance.gt(0),
-    );
-    const secondaryButton: SecondaryButtonType =
-      assetHasFunds && availableOnSwap ? "swap" : "receive";
+    const assetCurrencyIds = new Set([currency.id, ...(ledgerIds ?? [])]);
+    const hasAssetAccounts = accounts.some(a => assetCurrencyIds.has(getAccountCurrency(a).id));
+    const isBuyButtonVisible = availableOnBuy;
+    const secondaryButton: SecondaryButtonType = availableOnSwap ? "swap" : null;
 
     return {
       isCurrencySupported,
       isBuyAvailable: availableOnBuy,
+      isBuyButtonVisible,
       availableOnSwap,
+      hasAssetAccounts,
       secondaryButton,
     };
   }, [currency, ledgerIds, isCurrencySupported, availableOnBuy, availableOnSwap, accounts]);
@@ -66,13 +70,7 @@ export function useFooterViewModel(currency: AssetDetailCurrencyProps, ledgerIds
     sourceScreenName: "Asset Detail",
   });
 
-  const { handleOpenReceiveDrawer } = useOpenReceiveDrawer({
-    currency,
-    currencyIds: ledgerIds,
-    sourceScreenName: "Asset Detail",
-  });
-
-  const { isBuyAvailable, secondaryButton } = useAssetActionsAvailability(currency, ledgerIds);
+  const { isBuyButtonVisible, secondaryButton } = useAssetActionsAvailability(currency, ledgerIds);
 
   const onBuyPress = useCallback(() => {
     if (!currency) return;
@@ -94,21 +92,10 @@ export function useFooterViewModel(currency: AssetDetailCurrencyProps, ledgerIds
     handleOpenSwap();
   }, [currency, handleOpenSwap]);
 
-  const onReceivePress = useCallback(() => {
-    if (!currency) return;
-    track("button_clicked", {
-      button: "receive",
-      currency: currency.id,
-      page: "Asset Detail",
-    });
-    handleOpenReceiveDrawer();
-  }, [currency, handleOpenReceiveDrawer]);
-
   return {
-    isBuyAvailable,
+    isBuyAvailable: isBuyButtonVisible,
     secondaryButton,
     onBuyPress,
     onSwapPress,
-    onReceivePress,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/useFooterViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/useFooterViewModel.ts
@@ -39,9 +39,12 @@ export function useAssetActionsAvailability(
       };
     }
 
-    const walletHasFunds = accounts.some(a => a.balance.gt(0));
+    const assetCurrencyIds = ledgerIds ?? [currency.id];
+    const assetHasFunds = accounts.some(
+      a => assetCurrencyIds.includes(a.currency.id) && a.balance.gt(0),
+    );
     const secondaryButton: SecondaryButtonType =
-      walletHasFunds && availableOnSwap ? "swap" : "receive";
+      assetHasFunds && availableOnSwap ? "swap" : "receive";
 
     return {
       isCurrencySupported,
@@ -49,7 +52,7 @@ export function useAssetActionsAvailability(
       availableOnSwap,
       secondaryButton,
     };
-  }, [currency, isCurrencySupported, availableOnBuy, availableOnSwap, accounts]);
+  }, [currency, ledgerIds, isCurrencySupported, availableOnBuy, availableOnSwap, accounts]);
 }
 
 export function useFooterViewModel(currency: AssetDetailCurrencyProps, ledgerIds?: string[]) {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -74,13 +74,12 @@ export function useAssetDetailViewModel() {
   });
   const {
     isBuyAvailable,
-    isBuyButtonVisible,
     availableOnSwap,
     isCurrencySupported,
     hasAssetAccounts,
     secondaryButton,
   } = useAssetActionsAvailability(currency, receiveLedgerIds);
-  const hasFooter = isBuyButtonVisible || secondaryButton !== null;
+  const hasFooter = isBuyAvailable || secondaryButton !== null;
   const hideReceiveInBalanceGraph = !isCurrencySupported || hasAssetAccounts;
   const showFallbackBanner = isCurrencySupported && !isBuyAvailable && !availableOnSwap;
   const robinhoodDisclaimer = useFeature("llRobinhoodDisclaimer");

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -72,10 +72,16 @@ export function useAssetDetailViewModel() {
     currencyId: currency?.id,
     fallbackLedgerIds: ledgerIds,
   });
-  const { isBuyAvailable, availableOnSwap, isCurrencySupported, secondaryButton } =
-    useAssetActionsAvailability(currency, receiveLedgerIds);
-  const hasFooter = isBuyAvailable || secondaryButton !== null;
-  const hideReceiveInBalanceGraph = !isCurrencySupported || secondaryButton === "receive";
+  const {
+    isBuyAvailable,
+    isBuyButtonVisible,
+    availableOnSwap,
+    isCurrencySupported,
+    hasAssetAccounts,
+    secondaryButton,
+  } = useAssetActionsAvailability(currency, receiveLedgerIds);
+  const hasFooter = isBuyButtonVisible || secondaryButton !== null;
+  const hideReceiveInBalanceGraph = !isCurrencySupported || hasAssetAccounts;
   const showFallbackBanner = isCurrencySupported && !isBuyAvailable && !availableOnSwap;
   const robinhoodDisclaimer = useFeature("llRobinhoodDisclaimer");
   const hasPositiveBalance = (distributionItem?.amount ?? 0) > 0;

--- a/apps/ledger-live-mobile/src/mvvm/utils/assetUtils.ts
+++ b/apps/ledger-live-mobile/src/mvvm/utils/assetUtils.ts
@@ -5,6 +5,7 @@ export const toAsset = (item: CategorizedAssetItem): Asset => ({
   currency: item.currency,
   accounts: item.accounts,
   amount: item.balance,
+  countervalue: item.value,
   distribution: item.distribution,
   isPlaceholder: false,
 });

--- a/apps/ledger-live-mobile/src/types/asset.ts
+++ b/apps/ledger-live-mobile/src/types/asset.ts
@@ -6,6 +6,7 @@ export type Asset = {
   accounts: AccountLike[];
   distribution?: number;
   amount: number;
+  countervalue?: number;
   isPlaceholder?: boolean;
   marketId?: string;
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Portfolio asset list: countervalue now displays correctly for aggregated ETH when the user only holds ETH on L2 networks (Optimism, Base, Arbitrum…) and has no Ethereum mainnet account.
  - Asset detail graph: the Receive CTA is shown only when the user has no account for the viewed asset on any supported network.
  - Asset detail balance section: once the user has an account for the viewed asset, the graph Receive CTA is hidden and the existing Transfer entry point remains the receive/send entry point.
  - Asset detail footer: Buy and Swap remain driven by trade availability, including for users who already hold the asset, and single-button/two-button styling is handled consistently.

### 📝 Description

This PR fixes multi-network Asset Detail behavior for assets such as ETH when the user only holds funds on an L2 network, for example Optimism Mainnet.

1. **Countervalue for aggregated assets**

   When a user holds ETH exclusively on an L2 network and has no Ethereum mainnet account, the portfolio asset list could show the ETH balance and trend without the fiat countervalue. Root cause: `getCounterValue` re-derived the countervalue with the normalized `ethereum` currency, while the countervalues state only had the actual network pair such as `USD/optimism`.

   `buildAssetDistribution` already computes the aggregate countervalue per network using each account's real currency. `toAsset` now carries that pre-computed value into the `Asset` model, and `getCounterValue` uses it directly for aggregated assets.

2. **Asset Detail CTA placement**

   Asset Detail previously mixed “has funds” and “has an account” checks, and the footer Receive CTA could appear in cases where the graph or Transfer entry point should own the receive flow.

   The updated rules are:

   - If the user has no account for the viewed asset on any of its network ledger IDs, show Receive in the balance graph.
   - If the user already has an account for the viewed asset, even with zero balance, hide Receive from the graph and rely on the balance section Transfer button.
   - Buy and Swap remain available in the footer according to trade availability, regardless of whether the user already has accounts for the asset.
   - The footer no longer renders a Receive CTA; one visible footer button uses the primary appearance, and two visible footer buttons render Buy as secondary and Swap as primary.

3. **Multi-network account matching**

   Account checks now use the resolved ledger ID set for the viewed asset, so assets held on Optimism/Base/Arbitrum/etc. are treated as the same aggregated asset where appropriate.

### ✅ Validation

- `pnpm --filter live-mobile test:jest src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer/__tests__/useFooterViewModel.test.ts src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx --runInBand --no-watchman`
- `pnpm nx run live-mobile:typecheck`
- `pnpm exec oxfmt --check` on the modified Asset Detail files


https://github.com/user-attachments/assets/27e59427-ef4a-4a50-809b-0c237c22ac22



### ❓ Context

- **JIRA or GitHub link**: [LIVE-34251](https://ledgerhq.atlassian.net/browse/LIVE-34251)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-34251]: https://ledgerhq.atlassian.net/browse/LIVE-34251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ