### PR TITLE
[LWDM] refactor(back-11492): add runtime internal-tx source parser

### DIFF
--- a/.changeset/brave-rivers-fetch.md
+++ b/.changeset/brave-rivers-fetch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+Add configurable getBlock internal-tx source list with runtime validation, split node trace RPC methods, and behaviour-preserving default fallback semantics

--- a/.changeset/evm-internal-tx-sources.md
+++ b/.changeset/evm-internal-tx-sources.md
@@ -2,4 +2,4 @@
 "@ledgerhq/coin-evm": patch
 ---
 
-Add configurable getBlock internal-tx source list with runtime validation, split node trace RPC methods, and behaviour-preserving default fallback semantics
+Add configurable getBlock internal-tx source list with compile-time-safe builder, split node trace RPC methods, and behaviour-preserving default fallback semantics

--- a/.changeset/evm-internal-tx-sources.md
+++ b/.changeset/evm-internal-tx-sources.md
@@ -2,4 +2,4 @@
 "@ledgerhq/coin-evm": patch
 ---
 
-Add configurable getBlock internal-tx source list with compile-time-safe builder, split node trace RPC methods, and behaviour-preserving default fallback semantics
+Add configurable getBlock internal-tx source list with runtime validation, split node trace RPC methods, and behaviour-preserving default fallback semantics

--- a/libs/coin-modules/coin-evm/docs/getBlock-internal-txs-schema.md
+++ b/libs/coin-modules/coin-evm/docs/getBlock-internal-txs-schema.md
@@ -61,7 +61,7 @@ When `getBlockInternalTxsSources` is absent, the default is:
 
 `["explorer", "trace_block", "debug_traceBlockByNumber", "empty"]`
 
-Built via `internalTxSources().addSource("explorer").addSource("trace_block").addSource("debug_traceBlockByNumber").addSource("empty").build()` in `internalTxSources.ts`.
+Built via `internalTxSourcesFromList(["explorer", "trace_block", "debug_traceBlockByNumber", "empty"])` in `internalTxSources.ts`.
 
 ## Source semantics
 

--- a/libs/coin-modules/coin-evm/src/config.ts
+++ b/libs/coin-modules/coin-evm/src/config.ts
@@ -3,7 +3,7 @@ import { LedgerExplorerId } from "@ledgerhq/types-cryptoassets";
 import type { InternalTxSourceList } from "./internalTxSources";
 
 export type { InternalTxSource, InternalTxSourceList, NonEmptySource } from "./internalTxSources";
-export { DEFAULT_INTERNAL_TX_SOURCES, internalTxSources } from "./internalTxSources";
+export { DEFAULT_INTERNAL_TX_SOURCES, internalTxSourcesFromList } from "./internalTxSources";
 
 /**
  * Block finalization levels supported by EVM JSON-RPC API, used to fetch the latest block.
@@ -89,7 +89,7 @@ export type EvmConfig = {
    */
   feeHistoryRewardPercentile?: number;
   /**
-   * Ordered list of internal-tx sources for `getBlock`. Built via `internalTxSources()`.
+   * Ordered list of internal-tx sources for `getBlock`. Built via `internalTxSourcesFromList()`.
    * Defaults to explorer-first, then node traces, then `empty` (resolves only when no
    * real trace runtime error was remembered; trace failures still propagate for retry).
    * @see https://ledgerhq.atlassian.net/wiki/spaces/CF/pages/7297957892

--- a/libs/coin-modules/coin-evm/src/config.ts
+++ b/libs/coin-modules/coin-evm/src/config.ts
@@ -3,7 +3,11 @@ import { LedgerExplorerId } from "@ledgerhq/types-cryptoassets";
 import type { InternalTxSourceList } from "./internalTxSources";
 
 export type { InternalTxSource, InternalTxSourceList, NonEmptySource } from "./internalTxSources";
-export { DEFAULT_INTERNAL_TX_SOURCES, internalTxSourcesFromList } from "./internalTxSources";
+export {
+  DEFAULT_INTERNAL_TX_SOURCES,
+  internalTxSourcesFromList,
+  isInternalTxSource,
+} from "./internalTxSources";
 
 /**
  * Block finalization levels supported by EVM JSON-RPC API, used to fetch the latest block.

--- a/libs/coin-modules/coin-evm/src/internalTxSources.test.ts
+++ b/libs/coin-modules/coin-evm/src/internalTxSources.test.ts
@@ -1,10 +1,10 @@
 import {
   DEFAULT_INTERNAL_TX_SOURCES,
-  internalTxSources,
+  internalTxSourcesFromList,
   type InternalTxSourceList,
 } from "./internalTxSources";
 
-describe("internalTxSources", () => {
+describe("internalTxSourcesFromList", () => {
   it("builds the default explorer-first strategy", () => {
     expect(DEFAULT_INTERNAL_TX_SOURCES).toEqual([
       "explorer",
@@ -15,53 +15,52 @@ describe("internalTxSources", () => {
   });
 
   it("builds a node-only strategy without empty", () => {
-    const sources: InternalTxSourceList = internalTxSources()
-      .addSource("trace_block")
-      .addSource("debug_traceBlockByNumber")
-      .build();
+    const sources: InternalTxSourceList = internalTxSourcesFromList([
+      "trace_block",
+      "debug_traceBlockByNumber",
+    ]);
 
     expect(sources).toEqual(["trace_block", "debug_traceBlockByNumber"]);
   });
 
   it("builds explorer-only strategy", () => {
-    const sources = internalTxSources().addSource("explorer").build();
+    const sources = internalTxSourcesFromList(["explorer"]);
     expect(sources).toEqual(["explorer"]);
   });
 
   it("allows empty as the only source", () => {
-    const sources = internalTxSources().addSource("empty").build();
+    const sources = internalTxSourcesFromList(["empty"]);
     expect(sources).toEqual(["empty"]);
   });
 
-  // The following invalid usages are prevented at compile time by the builder's
-  // interface state machine. The `@ts-expect-error` assertions are enforced by
-  // `tsc --noEmit` (typecheck), which fails if any of them stops being an error.
-  describe("rejects invalid source lists at compile time", () => {
-    it("rejects an empty list: build() is unavailable before any source is added", () => {
-      const builder = internalTxSources();
-      // @ts-expect-error - InitialBuilder exposes no build(): at least one source is required
-      builder.build();
+  describe("rejects invalid source lists at runtime", () => {
+    it("rejects an empty list", () => {
+      expect(() => internalTxSourcesFromList([])).toThrow(
+        "internalTxSources: at least one source is required",
+      );
     });
 
     it("rejects adding a source after empty: empty must be last", () => {
-      const sealed = internalTxSources().addSource("empty");
-      // @ts-expect-error - SealedBuilder is terminal: nothing may follow "empty"
-      sealed.addSource("explorer");
+      expect(() => internalTxSourcesFromList(["empty", "explorer"])).toThrow(
+        'internalTxSources: "empty" must be the last source',
+      );
     });
 
     it("rejects duplicate sources", () => {
-      // @ts-expect-error - "explorer" was already added; duplicates are not allowed
-      internalTxSources().addSource("explorer").addSource("explorer").build();
+      expect(() => internalTxSourcesFromList(["explorer", "explorer"])).toThrow(
+        'internalTxSources: duplicate source "explorer"',
+      );
     });
 
     it("rejects unknown sources", () => {
-      // @ts-expect-error - "bogus" is not a valid InternalTxSource
-      internalTxSources().addSource("bogus");
+      expect(() => internalTxSourcesFromList(["bogus"])).toThrow(
+        'internalTxSources: invalid source "bogus"',
+      );
     });
 
     it("rejects raw arrays bypassing the builder", () => {
       const raw = ["explorer", "empty"] as const;
-      // @ts-expect-error - InternalTxSourceList is branded; only build() can produce it
+      // @ts-expect-error - InternalTxSourceList is branded; only internalTxSourcesFromList can produce it
       const sources: InternalTxSourceList = raw;
       void sources;
     });

--- a/libs/coin-modules/coin-evm/src/internalTxSources.test.ts
+++ b/libs/coin-modules/coin-evm/src/internalTxSources.test.ts
@@ -33,6 +33,14 @@ describe("internalTxSourcesFromList", () => {
     expect(sources).toEqual(["empty"]);
   });
 
+  it("returns a frozen copy independent of the input", () => {
+    const input = ["explorer", "trace_block"];
+    const sources = internalTxSourcesFromList(input);
+    input.push("empty");
+    expect(sources).toEqual(["explorer", "trace_block"]);
+    expect(Object.isFrozen(sources)).toBe(true);
+  });
+
   describe("rejects invalid source lists at runtime", () => {
     it("rejects an empty list", () => {
       expect(() => internalTxSourcesFromList([])).toThrow(

--- a/libs/coin-modules/coin-evm/src/internalTxSources.ts
+++ b/libs/coin-modules/coin-evm/src/internalTxSources.ts
@@ -8,15 +8,15 @@ export type InternalTxSourceList = readonly InternalTxSource[] & {
   readonly [brand]: "InternalTxSourceList";
 };
 
-const ALL_SOURCES: readonly InternalTxSource[] = [
+const ALL_SOURCES = new Set<string>([
   "trace_block",
   "debug_traceBlockByNumber",
   "explorer",
   "empty",
-];
+] satisfies ReadonlyArray<InternalTxSource>);
 
 export function isInternalTxSource(value: string): value is InternalTxSource {
-  return (ALL_SOURCES as readonly string[]).includes(value);
+  return ALL_SOURCES.has(value);
 }
 
 /**

--- a/libs/coin-modules/coin-evm/src/internalTxSources.ts
+++ b/libs/coin-modules/coin-evm/src/internalTxSources.ts
@@ -50,3 +50,39 @@ export const DEFAULT_INTERNAL_TX_SOURCES = internalTxSources()
   .addSource("debug_traceBlockByNumber")
   .addSource("empty")
   .build();
+
+const ALL_SOURCES: readonly InternalTxSource[] = [
+  "trace_block",
+  "debug_traceBlockByNumber",
+  "explorer",
+  "empty",
+];
+
+export function isInternalTxSource(value: string): value is InternalTxSource {
+  return (ALL_SOURCES as readonly string[]).includes(value);
+}
+
+/**
+ * Runtime-checked construction from a dynamic (e.g. config-driven) list.
+ * Enforces the same invariants as the compile-time builder:
+ * non-empty, no duplicate non-empty sources, `empty` only as the final element.
+ */
+export function internalTxSourcesFromList(sources: readonly string[]): InternalTxSourceList {
+  if (sources.length === 0) {
+    throw new Error("internalTxSources: at least one source is required");
+  }
+  const seen = new Set<string>();
+  sources.forEach((source, index) => {
+    if (!isInternalTxSource(source)) {
+      throw new Error(`internalTxSources: invalid source "${source}"`);
+    }
+    if (source === "empty" && index !== sources.length - 1) {
+      throw new Error('internalTxSources: "empty" must be the last source');
+    }
+    if (source !== "empty") {
+      if (seen.has(source)) throw new Error(`internalTxSources: duplicate source "${source}"`);
+      seen.add(source);
+    }
+  });
+  return sources as unknown as InternalTxSourceList;
+}

--- a/libs/coin-modules/coin-evm/src/internalTxSources.ts
+++ b/libs/coin-modules/coin-evm/src/internalTxSources.ts
@@ -40,7 +40,7 @@ export function internalTxSourcesFromList(sources: readonly string[]): InternalT
       seen.add(source);
     }
   });
-  return sources as unknown as InternalTxSourceList;
+  return Object.freeze([...sources]) as unknown as InternalTxSourceList;
 }
 
 export const DEFAULT_INTERNAL_TX_SOURCES = internalTxSourcesFromList([

--- a/libs/coin-modules/coin-evm/src/internalTxSources.ts
+++ b/libs/coin-modules/coin-evm/src/internalTxSources.ts
@@ -8,49 +8,6 @@ export type InternalTxSourceList = readonly InternalTxSource[] & {
   readonly [brand]: "InternalTxSourceList";
 };
 
-/** No source chosen yet: at least one source must be added (hence no `build`). */
-export interface InitialBuilder {
-  addSource<S extends NonEmptySource>(source: S): OpenBuilder<S>;
-  addSource(source: "empty"): SealedBuilder;
-}
-
-/** At least one non-empty source added; more can be added, but no duplicates. */
-export interface OpenBuilder<Added extends NonEmptySource> {
-  addSource<S extends Exclude<NonEmptySource, Added>>(source: S): OpenBuilder<Added | S>;
-  addSource(source: "empty"): SealedBuilder;
-  build(): InternalTxSourceList;
-}
-
-/** Terminated by `empty`: nothing may follow. */
-export interface SealedBuilder {
-  build(): InternalTxSourceList;
-}
-
-// The compile-time state machine lives entirely in the interfaces above; at
-// runtime building the list is just appending to an array.
-class Builder {
-  constructor(private readonly sources: readonly InternalTxSource[] = []) {}
-
-  addSource(source: InternalTxSource): Builder {
-    return new Builder([...this.sources, source]);
-  }
-
-  build(): InternalTxSourceList {
-    return this.sources as unknown as InternalTxSourceList;
-  }
-}
-
-export function internalTxSources(): InitialBuilder {
-  return new Builder() as unknown as InitialBuilder;
-}
-
-export const DEFAULT_INTERNAL_TX_SOURCES = internalTxSources()
-  .addSource("explorer")
-  .addSource("trace_block")
-  .addSource("debug_traceBlockByNumber")
-  .addSource("empty")
-  .build();
-
 const ALL_SOURCES: readonly InternalTxSource[] = [
   "trace_block",
   "debug_traceBlockByNumber",
@@ -64,8 +21,7 @@ export function isInternalTxSource(value: string): value is InternalTxSource {
 
 /**
  * Runtime-checked construction from a dynamic (e.g. config-driven) list.
- * Enforces the same invariants as the compile-time builder:
- * non-empty, no duplicate non-empty sources, `empty` only as the final element.
+ * Enforces: non-empty, no duplicate non-empty sources, `empty` only as the final element.
  */
 export function internalTxSourcesFromList(sources: readonly string[]): InternalTxSourceList {
   if (sources.length === 0) {
@@ -86,3 +42,10 @@ export function internalTxSourcesFromList(sources: readonly string[]): InternalT
   });
   return sources as unknown as InternalTxSourceList;
 }
+
+export const DEFAULT_INTERNAL_TX_SOURCES = internalTxSourcesFromList([
+  "explorer",
+  "trace_block",
+  "debug_traceBlockByNumber",
+  "empty",
+]);

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
@@ -1,6 +1,6 @@
 import type { BlockOperation } from "@ledgerhq/coin-module-framework/api/index";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import { EvmCoinConfig, internalTxSources, setCoinConfig } from "../config";
+import { EvmCoinConfig, internalTxSourcesFromList, setCoinConfig } from "../config";
 import { UnsupportedRpcMethodError } from "../errors";
 import { getInternalTransactionsByBlock } from "../network/explorer/etherscan";
 import { getNodeApi } from "../network/node";
@@ -762,7 +762,7 @@ describe("getBlock", () => {
           info: {
             node: { type: "external" as const, retries: 0 },
             explorer: { type: "ledger" },
-            getBlockInternalTxsSources: internalTxSources().addSource("trace_block").build(),
+            getBlockInternalTxsSources: internalTxSourcesFromList(["trace_block"]),
           },
         }) as unknown as EvmCoinConfig,
     );
@@ -911,10 +911,7 @@ describe("getBlock", () => {
           info: {
             node: { type: "external" as const, retries: 0 },
             explorer: { type: "etherscan", uri: "https://api.etherscan.io" },
-            getBlockInternalTxsSources: internalTxSources()
-              .addSource("explorer")
-              .addSource("trace_block")
-              .build(),
+            getBlockInternalTxsSources: internalTxSourcesFromList(["explorer", "trace_block"]),
           },
         }) as unknown as EvmCoinConfig,
     );

--- a/libs/coin-modules/coin-evm/src/logic/internalTransactionsFetcher.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/internalTransactionsFetcher.test.ts
@@ -1,6 +1,6 @@
 import type { BlockOperation } from "@ledgerhq/coin-module-framework/api/index";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import { EvmCoinConfig, internalTxSources, setCoinConfig } from "../config";
+import { EvmCoinConfig, internalTxSourcesFromList, setCoinConfig } from "../config";
 import { SourceUnavailableError } from "../errors";
 import { getInternalTransactionsByBlock } from "../network/explorer/etherscan";
 import { mockNodeApi } from "../network/node/node.fixtures";
@@ -102,7 +102,7 @@ describe("composeInternalTxsFetcher", () => {
     const explorerError = new Error("explorer down");
     const traceError = new Error("trace down");
     const fetch = composeInternalTxsFetcher(
-      internalTxSources().addSource("explorer").addSource("trace_block").build(),
+      internalTxSourcesFromList(["explorer", "trace_block"]),
       makeFetchers({
         explorer: jest.fn().mockRejectedValue(explorerError),
         trace_block: jest.fn().mockRejectedValue(traceError),
@@ -133,7 +133,7 @@ describe("composeInternalTxsFetcher", () => {
   it("falls back from trace_block to debug_traceBlockByNumber", async () => {
     const gethResult = new Map<string, BlockOperation[]>([["0x3", []]]);
     const fetch = composeInternalTxsFetcher(
-      internalTxSources().addSource("trace_block").addSource("debug_traceBlockByNumber").build(),
+      internalTxSourcesFromList(["trace_block", "debug_traceBlockByNumber"]),
       makeFetchers({
         trace_block: jest.fn().mockRejectedValue(new Error("no erigon")),
         debug_traceBlockByNumber: jest.fn().mockResolvedValue(gethResult),
@@ -145,7 +145,7 @@ describe("composeInternalTxsFetcher", () => {
 
   it("throws when all sources are unavailable and empty is not configured", async () => {
     const fetch = composeInternalTxsFetcher(
-      internalTxSources().addSource("trace_block").addSource("debug_traceBlockByNumber").build(),
+      internalTxSourcesFromList(["trace_block", "debug_traceBlockByNumber"]),
       makeFetchers({
         trace_block: jest.fn().mockRejectedValue(new SourceUnavailableError("no erigon")),
         debug_traceBlockByNumber: jest


### PR DESCRIPTION
Follow-up to #19243: add runtime-checked construction of internal-tx source lists for config-driven wiring (coin-service per-network overrides) and refine node trace RPC helpers.

### ✅ Checklist

- [x] `npx changeset` was attached (updated `.changeset/evm-internal-tx-sources.md`).
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - `coin-evm` only — no consumer app or per-network config in this PR.
  - **Default behaviour is preserved** — no change to `DEFAULT_INTERNAL_TX_SOURCES` or `getBlock` semantics.
  - Unblocks coin-service follow-up to pin Somnia (and others) to node-only sources from string config.

### 📝 Description

**Problem**

#19243 introduced a compile-time-safe `internalTxSources()` builder (branded `InternalTxSourceList`), but coin-service and other consumers load per-network config as dynamic strings. There was no runtime path to validate those lists with the same invariants (non-empty, no duplicate non-empty sources, `empty` only last).

**Solution**

**`internalTxSourcesFromList`** — runtime-checked construction from a `readonly string[]`, enforcing the same rules as the compile-time builder.


**Usage** (planned for coin-service per-network config):

```ts
getBlockInternalTxsSources: internalTxSourcesFromList([
  "trace_block",
  "debug_traceBlockByNumber",
]),
```

### ❓ Context

- **JIRA**: [BACK-11492](https://ledgerhq.atlassian.net/browse/BACK-11492)
- **ADR**: [ADR-048 — Configurable internal transactions fetch strategy for EVM getBlock](https://ledgerhq.atlassian.net/wiki/spaces/CF/pages/7297957892)
- **Prior PR**: #19243
- **Docs**: `libs/coin-modules/coin-evm/docs/getBlock-internal-txs-schema.md`

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[BACK-11492]: https://ledgerhq.atlassian.net/browse/BACK-11492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ