### PR TITLE
chore(koda): open PRs as draft and auto-assign initiator

### DIFF
--- a/.koda/config.yaml
+++ b/.koda/config.yaml
@@ -3,3 +3,6 @@ setup: |
   mise install
   pnpm i --frozen-lockfile
 lint: pnpm nx affected -t lint
+github:
+  draft_pull_requests: true
+  assign_pr_initiator: true


### PR DESCRIPTION
### 📝 Description

Enable two Koda repository defaults in .koda/config.yaml:
- draft_pull_requests: true — Koda opens all PRs as Draft by default
- assign_pr_initiator: true — Koda auto-assigns the Slack thread creator to the PR

Both settings can still be overridden per thread via user prompt or Slack channel context canvas.

### 🔗 Context

- **JIRA / GitHub issue**: N/A
- **ADR** (if any): N/A