### PR TITLE
refactor(web-tools): repoint currency layer to @domain/entity-currency-*

### DIFF
--- a/.changeset/swift-coins-land.md
+++ b/.changeset/swift-coins-land.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/web-tools": minor
+---
+
+repoint currency accessors and token store to domain layer (@domain/entity-currency-crypto, @domain/entity-currency-fiat, @features/platform-currencies)

--- a/apps/web-tools/package.json
+++ b/apps/web-tools/package.json
@@ -20,10 +20,12 @@
   },
   "dependencies": {
     "@devtools/shell": "workspace:*",
+    "@domain/api-currency-token": "workspace:*",
     "@domain/entity-currency-crypto": "workspace:*",
     "@reduxjs/toolkit": "catalog:",
     "@shared/feature-flags": "workspace:*",
     "@devtools/bindings": "workspace:*",
+    "@features/platform-currencies": "workspace:*",
     "@features/platform-feature-flags": "workspace:*",
     "@features/platform-style": "workspace:*",
     "react-redux": "catalog:",

--- a/apps/web-tools/src/live-common-setup.ts
+++ b/apps/web-tools/src/live-common-setup.ts
@@ -4,8 +4,10 @@ import { setWalletAPIVersion } from "@ledgerhq/live-common/wallet-api/version";
 import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { liveConfig } from "@ledgerhq/live-common/config/sharedConfig";
-import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
 import { setCryptoCurrenciesStore, setFiatCurrenciesStore } from "@ledgerhq/cryptoassets";
+import { setCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
+import { buildCryptoAssetsStore } from "@features/platform-currencies";
+import { store } from "./store";
 import {
   CRYPTO_CURRENCIES_REGISTRY,
   CRYPTO_CURRENCY_ALIASES,
@@ -29,8 +31,7 @@ setWalletAPIVersion(WALLET_API_VERSION);
 registerAllCoins();
 
 export function setupCryptoAssetsStore(): void {
-  // for now we use the test-helpers one
-  setupCalClientStore();
+  setCryptoAssetsStore(buildCryptoAssetsStore({ dispatch: store.dispatch }));
 }
 
 setupCryptoAssetsStore();

--- a/apps/web-tools/src/logic/syncAccount.ts
+++ b/apps/web-tools/src/logic/syncAccount.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from "bignumber.js";
 import { decodeAccountId, emptyHistoryCache } from "@ledgerhq/live-common/account/index";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { lastValueFrom } from "rxjs";
 import { reduce } from "rxjs/operators";

--- a/apps/web-tools/src/pages/crypto-icons.tsx
+++ b/apps/web-tools/src/pages/crypto-icons.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from "react";
-import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import type { CryptoCurrency, Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";

--- a/apps/web-tools/src/pages/logsviewer.tsx
+++ b/apps/web-tools/src/pages/logsviewer.tsx
@@ -34,7 +34,7 @@ import {
   decodeAccountId,
   shortAddressPreview,
 } from "@ledgerhq/ledger-wallet-framework/account/index";
-import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import {
   getAddressExplorer,

--- a/apps/web-tools/src/pages/pnl-calculator/shared/__tests__/useCryptoFiat.test.ts
+++ b/apps/web-tools/src/pages/pnl-calculator/shared/__tests__/useCryptoFiat.test.ts
@@ -1,0 +1,35 @@
+import { renderHook } from "@testing-library/react";
+import type { FiatCurrency } from "@ledgerhq/types-cryptoassets";
+
+jest.mock("@domain/entity-currency-fiat", () => ({
+  getFiatCurrencyByTicker: jest.fn(),
+}));
+
+import { getFiatCurrencyByTicker } from "@domain/entity-currency-fiat";
+import { useCryptoFiat } from "../useCryptoFiat";
+
+const mockGetFiatCurrencyByTicker = getFiatCurrencyByTicker as jest.Mock;
+
+const EUR_FIAT = { id: "eur", ticker: "EUR", name: "Euro", units: [] } as unknown as FiatCurrency;
+
+describe("useCryptoFiat", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the fiat currency for a known ticker", () => {
+    mockGetFiatCurrencyByTicker.mockReturnValue(EUR_FIAT);
+    const { result } = renderHook(() => useCryptoFiat("EUR"));
+    expect(result.current).toBe(EUR_FIAT);
+    expect(mockGetFiatCurrencyByTicker).toHaveBeenCalledWith("EUR");
+  });
+
+  it("throws for an unknown ticker", () => {
+    mockGetFiatCurrencyByTicker.mockReturnValue(undefined);
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => renderHook(() => useCryptoFiat("ZZZ_UNKNOWN"))).toThrow(
+      "Unknown fiat currency ticker: ZZZ_UNKNOWN",
+    );
+    errorSpy.mockRestore();
+  });
+});

--- a/apps/web-tools/src/pages/pnl-calculator/shared/useCryptoFiat.ts
+++ b/apps/web-tools/src/pages/pnl-calculator/shared/useCryptoFiat.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { getFiatCurrencyByTicker } from "@ledgerhq/cryptoassets";
+import { getFiatCurrencyByTicker } from "@domain/entity-currency-fiat";
 import type { FiatCurrency } from "@ledgerhq/types-cryptoassets";
 
 const cache = new Map<string, FiatCurrency>();
@@ -8,6 +8,7 @@ function get(ticker: string): FiatCurrency {
   const hit = cache.get(ticker);
   if (hit) return hit;
   const fiat = getFiatCurrencyByTicker(ticker);
+  if (!fiat) throw new Error(`Unknown fiat currency ticker: ${ticker}`);
   cache.set(ticker, fiat);
   return fiat;
 }

--- a/apps/web-tools/src/pages/sync.tsx
+++ b/apps/web-tools/src/pages/sync.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { encodeAccountId, decodeAccountId } from "@ledgerhq/live-common/account/index";
-import { findCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { asDerivationMode } from "@ledgerhq/ledger-wallet-framework/derivation";
 import type { Account } from "@ledgerhq/types-live";
 import { Spinner, TextInput } from "@ledgerhq/lumen-ui-react";

--- a/apps/web-tools/src/store/index.ts
+++ b/apps/web-tools/src/store/index.ts
@@ -1,12 +1,22 @@
 import { configureStore } from "@reduxjs/toolkit";
 import featureFlagsReducer, { createFeatureFlagsMiddleware } from "@shared/feature-flags";
+import { cryptoAssetsApi, calApiExtra } from "@domain/api-currency-token";
+import { getEnv } from "@ledgerhq/live-env";
 
 export const store = configureStore({
   reducer: {
     featureFlags: featureFlagsReducer,
+    [cryptoAssetsApi.reducerPath]: cryptoAssetsApi.reducer,
   },
   middleware: getDefaultMiddleware =>
-    getDefaultMiddleware().concat(createFeatureFlagsMiddleware({ resolutionConfig: {} })),
+    getDefaultMiddleware({
+      thunk: {
+        extraArgument: calApiExtra({
+          calServiceUrl: getEnv("CAL_SERVICE_URL"),
+          ledgerClientVersion: getEnv("LEDGER_CLIENT_VERSION"),
+        }),
+      },
+    }).concat(createFeatureFlagsMiddleware({ resolutionConfig: {} }), cryptoAssetsApi.middleware),
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/apps/web-tools/src/trustchain/components/AppAccountsSync.tsx
+++ b/apps/web-tools/src/trustchain/components/AppAccountsSync.tsx
@@ -26,12 +26,11 @@ import { getAccountBridge, getCurrencyBridge } from "@ledgerhq/live-common/bridg
 import { getAccountCurrency } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { Account, BridgeCacheSystem, ScanAccountEvent } from "@ledgerhq/types-live";
 import { makeBridgeCacheSystem } from "@ledgerhq/live-common/bridge/cache";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/formatCurrencyUnit";
-import { listCryptoCurrencies } from "@ledgerhq/cryptoassets";
-import { getCurrencyColor } from "@ledgerhq/live-common/currencies/color";
+import { listCryptoCurrencies, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import { Loading } from "./Loading";
 import { TrustchainEjected } from "@ledgerhq/ledger-key-ring-protocol/errors";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2476,12 +2476,18 @@ importers:
       '@devtools/shell':
         specifier: workspace:*
         version: link:../../devtools/shell
+      '@domain/api-currency-token':
+        specifier: workspace:*
+        version: link:../../domain/api/currency-token
       '@domain/entity-currency-crypto':
         specifier: workspace:*
         version: link:../../domain/entity/currency-crypto
       '@domain/entity-currency-fiat':
         specifier: workspace:^
         version: link:../../domain/entity/currency-fiat
+      '@features/platform-currencies':
+        specifier: workspace:*
+        version: link:../../features/platform/currencies
       '@features/platform-feature-flags':
         specifier: workspace:*
         version: link:../../features/platform/feature-flags


### PR DESCRIPTION
## Summary

- Repoints all currency accessor imports in `apps/web-tools` off `@ledgerhq/cryptoassets` / `@ledgerhq/live-common/currencies` subpaths onto the new domain layer
- Wires the real `buildCryptoAssetsStore` ([@features/platform-currencies](https://github.com/LedgerHQ/ledger-live/tree/develop/features/platform/currencies)) into the app store, replacing the test-helpers `setupCalClientStore`

**Accessor changes (7 files):**
| Accessor | Old source | New source |
|---|---|---|
| `getCryptoCurrencyById` | `@ledgerhq/live-common/currencies/index` / `@ledgerhq/cryptoassets/currencies` | `@domain/entity-currency-crypto` |
| `findCryptoCurrencyById` | `@ledgerhq/cryptoassets` / `@ledgerhq/live-common/currencies/index` | `@domain/entity-currency-crypto` |
| `listCryptoCurrencies` + `getCurrencyColor` | `@ledgerhq/cryptoassets` + `…/color` subpath | `@ledgerhq/live-common/currencies/index` transit |
| `getFiatCurrencyByTicker` | `@ledgerhq/cryptoassets` (throws on miss) | `@domain/entity-currency-fiat` (returns `undefined`) + explicit null guard |

**Store/setup changes:**
- `store/index.ts`: register `cryptoAssetsApi` reducer + `calApiExtra` thunk extraArgument from `@domain/api-currency-token`
- `live-common-setup.ts`: `setupCryptoAssetsStore` now calls `buildCryptoAssetsStore({ dispatch: store.dispatch })` via `setCryptoAssetsStore`; setup-import-hoist (App.tsx imports live-common-setup first) preserved

**Invariants verified:**
- `CRYPTO_CURRENCY_ALIASES` still passed to `setCryptoCurrenciesStore` → alias keys resolve correctly
- Domain accessors use the same registry objects as the injected store → `===` identity stable

## Test plan

- [ ] `pnpm --filter @ledgerhq/web-tools typecheck` — green
- [ ] `pnpm lint:boundaries` — green
- [ ] Dev smoke: crypto-icons page finds currencies by id and contract address; sync page syncs an account; logsviewer decodes account ids from log files

Closes [LIVE-31960](https://ledgerhq.atlassian.net/browse/LIVE-31960)

[LIVE-31960]: https://ledgerhq.atlassian.net/browse/LIVE-31960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ