### PR TITLE
[LWD] refactor(ledger-live-desktop): repoint UI currency reads to @domain/* and @features/platform-currencies

### DIFF
--- a/.changeset/repoint-desktop-currency-reads.md
+++ b/.changeset/repoint-desktop-currency-reads.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Repoint desktop UI currency reads from `@ledgerhq/cryptoassets` and the `@ledgerhq/live-common/currencies` barrel to `@domain/entity-currency-{crypto,fiat}` and `@features/platform-currencies` hooks directly.

--- a/apps/ledger-live-desktop/src/mvvm/components/Cells/BalanceCell/__tests__/useBalanceCellViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Cells/BalanceCell/__tests__/useBalanceCellViewModel.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from "tests/testSetup";
 import { useBalanceCellViewModel } from "../useBalanceCellViewModel";
-import { formatCurrencyUnit, getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { BigNumber } from "bignumber.js";
 
 jest.mock("@ledgerhq/live-common/currencies/index", () => ({

--- a/apps/ledger-live-desktop/src/mvvm/components/Cells/CounterValueCell/__tests__/useCounterValueCellViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Cells/CounterValueCell/__tests__/useCounterValueCellViewModel.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from "tests/testSetup";
 import { useCounterValueCellViewModel } from "../useCounterValueCellViewModel";
-import { formatCurrencyUnit, getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { BigNumber } from "bignumber.js";
 import { useCalculate } from "@ledgerhq/live-countervalues-react";
 

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/__tests__/useRightPanelViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/__tests__/useRightPanelViewModel.test.ts
@@ -1,4 +1,4 @@
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import BigNumber from "bignumber.js";
 import { renderHook } from "tests/testSetup";

--- a/apps/ledger-live-desktop/src/mvvm/components/TransactionalIcon/__tests__/TransactionalIcon.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TransactionalIcon/__tests__/TransactionalIcon.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { render, screen } from "tests/testSetup";
 import TransactionalIcon from "../index";
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/ModularDrawerAddAccountFlowManager.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/ModularDrawerAddAccountFlowManager.tsx
@@ -1,5 +1,5 @@
 import type { AppResult } from "@ledgerhq/live-common/hw/actions/app";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { Flex, Text } from "@ledgerhq/react-ui/index";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { Account, TokenAccount } from "@ledgerhq/types-live";

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/hooks/concordium/useConcordiumCreatableAccounts.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/hooks/concordium/useConcordiumCreatableAccounts.test.ts
@@ -5,7 +5,7 @@ import {
   getDerivationScheme,
   runDerivationScheme,
 } from "@ledgerhq/ledger-wallet-framework/derivation";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { Account } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { renderHook } from "tests/testSetup";

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/__fixtures__/allocationFixtures.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/__fixtures__/allocationFixtures.ts
@@ -1,4 +1,4 @@
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { AllocationTableItem, AllocationViewProps } from "../types";
 
 export const bitcoin = getCryptoCurrencyById("bitcoin");

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/__tests__/useAnalyticsViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/__tests__/useAnalyticsViewModel.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook, withFlagOverrides } from "tests/testSetup";
 import { useNavigate } from "react-router";
-import { getFiatCurrencyByTicker } from "@ledgerhq/live-common/currencies/index";
+import { getFiatCurrencyByTicker } from "@domain/entity-currency-fiat";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
 import * as usePortfolioBalanceDisplayStateModule from "LLD/hooks/usePortfolioBalanceDisplayState";
 import { mockPortfolioBalanceInfo, defaultPortfolio } from "LLD/hooks/__tests__/fixtures";

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/hooks/__tests__/useTrackFundsReceived.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/hooks/__tests__/useTrackFundsReceived.test.ts
@@ -6,7 +6,7 @@ import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 import BigNumber from "bignumber.js";
 import type { Account, Operation } from "@ledgerhq/types-live";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 jest.mock("~/renderer/analytics/segment", () => ({
   track: jest.fn(),

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
@@ -17,7 +17,7 @@ import {
 } from "tests/utils/distributionTestUtils";
 import { hoverChartSvg, mockLumenChartResizeObserver } from "tests/utils/lumenChartTestUtils";
 import { mockDada, mockMarket } from "tests/utils/assetDetailMocks";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { DistributionItem } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
@@ -73,8 +73,8 @@ jest.mock("@ledgerhq/live-common/dada-client/hooks/useInterestRatesByCurrencies"
   useInterestRatesByCurrencies: (...args: unknown[]) => mockUseInterestRatesByCurrencies(...args),
 }));
 
-jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag", () => ({
-  useCurrenciesUnderFeatureFlag: () => ({
+jest.mock("@features/platform-currencies", () => ({
+  useFeatureFlaggedCurrencies: () => ({
     deactivatedCurrencyIds: new Set<string>(),
   }),
 }));

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/useActionBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/useActionBarViewModel.ts
@@ -6,7 +6,7 @@ import type { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/type
 import { flattenAccounts, isTokenAccount } from "@ledgerhq/live-common/account/index";
 import { getAvailableAccountsById } from "@ledgerhq/live-common/exchange/swap/utils/index";
 import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
-import { useCurrenciesUnderFeatureFlag } from "@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag";
+import { useFeatureFlaggedCurrencies } from "@features/platform-currencies";
 import {
   isAvailableOnBuy,
   isAvailableOnSell,
@@ -95,7 +95,7 @@ export function useActionBarViewModel({
   const { navigateToBuy } = useBuyNavigation();
   const { navigateToSell } = useSellNavigation();
   const { isCurrencyAvailable } = useRampCatalog();
-  const { deactivatedCurrencyIds } = useCurrenciesUnderFeatureFlag();
+  const { deactivatedCurrencyIds } = useFeatureFlaggedCurrencies();
 
   const ledgerIdsForRamp = useMemo(
     () => resolveRampLedgerIds({ ledgerIds, marketCurrencyData, distributionItem, ledgerCurrency }),

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/useActionBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/useActionBarViewModel.ts
@@ -6,6 +6,7 @@ import type { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/type
 import { flattenAccounts, isTokenAccount } from "@ledgerhq/live-common/account/index";
 import { getAvailableAccountsById } from "@ledgerhq/live-common/exchange/swap/utils/index";
 import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
+import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useFeatureFlaggedCurrencies } from "@features/platform-currencies";
 import {
   isAvailableOnBuy,
@@ -95,7 +96,7 @@ export function useActionBarViewModel({
   const { navigateToBuy } = useBuyNavigation();
   const { navigateToSell } = useSellNavigation();
   const { isCurrencyAvailable } = useRampCatalog();
-  const { deactivatedCurrencyIds } = useFeatureFlaggedCurrencies();
+  const { deactivatedCurrencyIds } = useFeatureFlaggedCurrencies(!!useEnv("MOCK"));
 
   const ledgerIdsForRamp = useMemo(
     () => resolveRampLedgerIds({ ledgerIds, marketCurrencyData, distributionItem, ledgerCurrency }),

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/components/__tests__/AllAddressesDialog.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/components/__tests__/AllAddressesDialog.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, waitFor, within } from "tests/testSetup";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { AllAddressesDialog } from "../AllAddressesDialog";
 
 const btc = getCryptoCurrencyById("bitcoin");

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/__tests__/useAddressListItemViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/__tests__/useAddressListItemViewModel.test.ts
@@ -3,7 +3,7 @@ import type { WalletState } from "@ledgerhq/live-wallet/store";
 import { renderHook } from "tests/testSetup";
 import { genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { useAddressListItemViewModel } from "../useAddressListItemViewModel";
 import { ETH_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/__tests__/useAddressListViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/__tests__/useAddressListViewModel.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act, withFlagOverrides } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import { getAccountUrl } from "~/renderer/utils/accountUrl";

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/useAddressListItemViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/AddressList/hooks/useAddressListItemViewModel.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/HiddenBanner/__tests__/useHiddenBannerViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/HiddenBanner/__tests__/useHiddenBannerViewModel.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import { track } from "~/renderer/analytics/segment";
 import { useHiddenBannerViewModel } from "../useHiddenBannerViewModel";

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/OptionsMenu/__tests__/useOptionsMenuViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/OptionsMenu/__tests__/useOptionsMenuViewModel.test.ts
@@ -2,7 +2,7 @@ import { renderHook, act } from "tests/testSetup";
 import type { AssetMarketData } from "@ledgerhq/asset-detail";
 import { format } from "@ledgerhq/live-common/market/utils/currencyFormatter";
 import type { MarketItemResponse } from "@ledgerhq/live-common/market/utils/types";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import type { DistributionItem } from "@ledgerhq/types-live";
 import { buildDistributionItem } from "tests/utils/distributionTestUtils";

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/__tests__/useStakingSectionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/__tests__/useStakingSectionViewModel.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act } from "tests/testSetup";
 import BigNumber from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { buildDistributionItem } from "tests/utils/distributionTestUtils";
 import { track } from "~/renderer/analytics/segment";
 import { computeFiatPortionsFromDistribution } from "LLD/features/AssetDetail/utils/computeFiatPortionsFromDistribution";

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TransactionsSection/__tests__/useTransactionsSectionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TransactionsSection/__tests__/useTransactionsSectionViewModel.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from "tests/testSetup";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { maticEth, usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { buildDistributionItem } from "tests/utils/distributionTestUtils";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailViewModel.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from "tests/testSetup";
 import { server } from "tests/server";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { buildDistributionItem } from "tests/utils/distributionTestUtils";
 import { mockMarket, mockDada } from "tests/utils/assetDetailMocks";
 import type { DistributionItem } from "@ledgerhq/types-live";

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useTradeAvailability.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useTradeAvailability.test.ts
@@ -1,12 +1,12 @@
 import { renderHook } from "tests/testSetup";
 import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
 import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
-import { useCurrenciesUnderFeatureFlag } from "@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag";
+import { useFeatureFlaggedCurrencies } from "@features/platform-currencies";
 import { useTradeAvailability } from "@ledgerhq/asset-detail";
 
 jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog");
 jest.mock("@ledgerhq/live-common/exchange/swap/hooks/index");
-jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag");
+jest.mock("@features/platform-currencies");
 
 const mockRampAvailable = (onRamp: boolean, isCatalogLoaded = true) =>
   jest.mocked(useRampCatalog).mockReturnValue({
@@ -20,9 +20,9 @@ const mockSwapCurrencies = (data: string[] | undefined) =>
   } as unknown as ReturnType<typeof useFetchCurrencyAll>);
 
 const mockDeactivated = (ids: string[]) =>
-  jest.mocked(useCurrenciesUnderFeatureFlag).mockReturnValue({
+  jest.mocked(useFeatureFlaggedCurrencies).mockReturnValue({
     deactivatedCurrencyIds: new Set(ids),
-  } as unknown as ReturnType<typeof useCurrenciesUnderFeatureFlag>);
+  } as unknown as ReturnType<typeof useFeatureFlaggedCurrencies>);
 
 describe("useTradeAvailability", () => {
   beforeEach(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useTradeAvailability.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useTradeAvailability.test.ts
@@ -1,12 +1,12 @@
 import { renderHook } from "tests/testSetup";
 import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
 import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
-import { useFeatureFlaggedCurrencies } from "@features/platform-currencies";
+import { useCurrenciesUnderFeatureFlag } from "@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag";
 import { useTradeAvailability } from "@ledgerhq/asset-detail";
 
 jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog");
 jest.mock("@ledgerhq/live-common/exchange/swap/hooks/index");
-jest.mock("@features/platform-currencies");
+jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag");
 
 const mockRampAvailable = (onRamp: boolean, isCatalogLoaded = true) =>
   jest.mocked(useRampCatalog).mockReturnValue({
@@ -20,9 +20,9 @@ const mockSwapCurrencies = (data: string[] | undefined) =>
   } as unknown as ReturnType<typeof useFetchCurrencyAll>);
 
 const mockDeactivated = (ids: string[]) =>
-  jest.mocked(useFeatureFlaggedCurrencies).mockReturnValue({
+  jest.mocked(useCurrenciesUnderFeatureFlag).mockReturnValue({
     deactivatedCurrencyIds: new Set(ids),
-  } as unknown as ReturnType<typeof useFeatureFlaggedCurrencies>);
+  } as unknown as ReturnType<typeof useCurrenciesUnderFeatureFlag>);
 
 describe("useTradeAvailability", () => {
   beforeEach(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetDetailViewModel.ts
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { useLocation, useParams } from "react-router";
-import { findCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import {
   isMarketCurrencyData,
   resolveAssetDetailMarketInfo,

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/__tests__/computeAvailableAndEarnDeposit.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/__tests__/computeAvailableAndEarnDeposit.test.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { computeAvailableAndEarnDeposit } from "../computeAvailableAndEarnDeposit";
 
 const btc = getCryptoCurrencyById("bitcoin");

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/PriceCell/__tests__/usePriceCellViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/PriceCell/__tests__/usePriceCellViewModel.test.ts
@@ -1,9 +1,7 @@
 import { renderHook } from "tests/testSetup";
 import { usePriceCellViewModel } from "../usePriceCellViewModel";
-import {
-  getCryptoCurrencyById,
-  getFiatCurrencyByTicker,
-} from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { getFiatCurrencyByTicker } from "@domain/entity-currency-fiat";
 import { formatPrice } from "@ledgerhq/live-currency-format";
 import { usePrice } from "~/renderer/hooks/usePrice";
 import { BigNumber } from "bignumber.js";

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useAllCurrencyTrends.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useAllCurrencyTrends.test.ts
@@ -12,10 +12,8 @@ import {
   ETHEREUM_ASSET,
   STABLECOIN_ASSET,
 } from "@ledgerhq/asset-aggregation/mocks/categorizedAssets.mock";
-import {
-  getCryptoCurrencyById,
-  getFiatCurrencyByTicker,
-} from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { getFiatCurrencyByTicker } from "@domain/entity-currency-fiat";
 import type { AssetTableItem } from "../../types";
 import { useAllCurrencyTrends } from "../useAllCurrencyTrends";
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useAssetsViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useAssetsViewModel.test.ts
@@ -19,7 +19,7 @@ import {
 } from "../../constants";
 import { buildAssetsPagePath } from "../../utils/buildAssetsPagePath";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { AssetTableItem } from "../../types";
 import type { AssetsDataWithPagination } from "@ledgerhq/live-common/dada-client/state-manager/types";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationRow.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, memo } from "react";
 import { DotIndicator, TableRow, TableCell, TableCellContent } from "@ledgerhq/lumen-ui-react";
 import { useTranslation } from "react-i18next";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import TransactionalIcon from "LLD/components/TransactionalIcon";
 import { SquaredCryptoIcon } from "LLD/components/SquaredCryptoIcon";

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/__tests__/OperationRow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/__tests__/OperationRow.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { render, screen } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { Operation } from "@ledgerhq/types-live";
 import type { Currency } from "@ledgerhq/types-cryptoassets";
 import { OperationRow } from "../OperationRow";

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryVirtualization.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryVirtualization.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from "tests/testSetup";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { Account } from "@ledgerhq/types-live";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
 import { useHistoryOperations } from "../useHistoryOperations";

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/__integrations__/Market.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/__integrations__/Market.integration.test.tsx
@@ -15,8 +15,8 @@ jest.mock("react-router", () => ({
   useNavigate: jest.fn(() => mockNavigate),
 }));
 
-jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag", () => ({
-  useCurrenciesUnderFeatureFlag: () => ({
+jest.mock("@features/platform-currencies", () => ({
+  useFeatureFlaggedCurrencies: () => ({
     deactivatedCurrencyIds: new Set<string>(),
   }),
 }));

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useBuySellNavigation.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useBuySellNavigation.test.ts
@@ -2,7 +2,7 @@ import { act, renderHook } from "tests/testSetup";
 import { useBuyNavigation } from "../useBuyNavigation";
 import { useSellNavigation } from "../useSellNavigation";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import type { Account } from "@ledgerhq/types-live";
 import type { CryptoCurrency, CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useSwapNavigation.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useSwapNavigation.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from "tests/testSetup";
 import { useSwapNavigation } from "../useSwapNavigation";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import type { Account } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketActions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketActions.ts
@@ -16,7 +16,7 @@ import {
 import { useStake } from "LLD/hooks/useStake";
 import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
 import { useLazyLedgerCurrency } from "@ledgerhq/live-common/dada-client/hooks/useLazyLedgerCurrency";
-import { useCurrenciesUnderFeatureFlag } from "@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag";
+import { useFeatureFlaggedCurrencies } from "@features/platform-currencies";
 import { useSwapNavigation } from "./useSwapNavigation";
 import { useBuyNavigation } from "./useBuyNavigation";
 import { useSellNavigation } from "./useSellNavigation";
@@ -45,7 +45,7 @@ export const useMarketActions = ({ currency, page }: MarketActionsProps) => {
 
   const currenciesForSwapAllSet = useMemo(() => new Set(currenciesAll), [currenciesAll]);
 
-  const { deactivatedCurrencyIds } = useCurrenciesUnderFeatureFlag();
+  const { deactivatedCurrencyIds } = useFeatureFlaggedCurrencies();
 
   const isCurrencySupported =
     currency?.ledgerIds.some(lrId => !deactivatedCurrencyIds.has(lrId)) || false;

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketActions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketActions.ts
@@ -16,6 +16,7 @@ import {
 import { useStake } from "LLD/hooks/useStake";
 import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
 import { useLazyLedgerCurrency } from "@ledgerhq/live-common/dada-client/hooks/useLazyLedgerCurrency";
+import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useFeatureFlaggedCurrencies } from "@features/platform-currencies";
 import { useSwapNavigation } from "./useSwapNavigation";
 import { useBuyNavigation } from "./useBuyNavigation";
@@ -45,7 +46,7 @@ export const useMarketActions = ({ currency, page }: MarketActionsProps) => {
 
   const currenciesForSwapAllSet = useMemo(() => new Set(currenciesAll), [currenciesAll]);
 
-  const { deactivatedCurrencyIds } = useFeatureFlaggedCurrencies();
+  const { deactivatedCurrencyIds } = useFeatureFlaggedCurrencies(!!useEnv("MOCK"));
 
   const isCurrencySupported =
     currency?.ledgerIds.some(lrId => !deactivatedCurrencyIds.has(lrId)) || false;

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectAccountFlow.test.tsx
@@ -1,4 +1,4 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import React from "react";
 import * as reduxHooks from "LLD/hooks/redux";
 import { render, screen, waitFor } from "tests/testSetup";

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/components/__tests__/Balance.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/components/__tests__/Balance.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen } from "tests/testSetup";
 import { balanceItem } from "../Balance";
 import BigNumber from "bignumber.js";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 jest.mock("~/renderer/components/CounterValue", () => ({
   __esModule: true,

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useOpenAssetFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useOpenAssetFlow.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { ModularDrawerLocation } from "@ledgerhq/live-common/modularDrawer/enums";
 import { renderHook, withFlagOverrides } from "tests/testSetup";
 import { useOpenAssetFlow } from "../useOpenAssetFlow";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { setDrawer } from "~/renderer/drawers/Provider";
 
 jest.mock("~/renderer/drawers/Provider", () => ({

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/__tests__/SelectNetwork.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/__tests__/SelectNetwork.test.tsx
@@ -6,7 +6,7 @@ import { EnhancedModularDrawerConfiguration } from "@ledgerhq/live-common/wallet
 import { CryptoOrTokenCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { mockDomMeasurements } from "../../../../../__tests__/shared";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 const bscCurrency = getCryptoCurrencyById("bsc");
 const bscAccount = genAccount("bsc-account", { currency: bscCurrency });

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -122,7 +122,7 @@ const defaultCategorizedAssetsMock = () => ({
 });
 
 jest.mock("~/renderer/hooks/usePrice", () => {
-  const { getFiatCurrencyByTicker } = jest.requireActual("@ledgerhq/live-common/currencies/index");
+  const { getFiatCurrencyByTicker } = jest.requireActual("@domain/entity-currency-fiat");
   const usd = getFiatCurrencyByTicker("USD");
   return {
     usePrice: () => ({

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/usePortfolioViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/usePortfolioViewModel.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, withFlagOverrides } from "tests/testSetup";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import { BigNumber } from "bignumber.js";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
@@ -5,7 +5,7 @@ import { useOpenAssetFlow } from "LLD/features/ModularDialog/hooks/useOpenAssetF
 import { useNavigate, useLocation } from "react-router";
 import { ArrowDown, Plus, Minus, ArrowUp } from "@ledgerhq/lumen-ui-react/symbols";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import BigNumber from "bignumber.js";
 import type { Account } from "@ledgerhq/types-live";
 import { urls } from "~/config/urls";

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSearchResultsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSearchResultsViewModel.ts
@@ -42,7 +42,7 @@ export function useAssetSearchResultsViewModel({ search, skip }: Params): Result
   const { status: rateStatus, rate } = useUsdToFiatRate(counterCurrency);
 
   // Hide currencies disabled by a feature flag, mirroring the receive flow.
-  const { deactivatedCurrencyIds } = useFeatureFlaggedCurrencies();
+  const { deactivatedCurrencyIds } = useFeatureFlaggedCurrencies(!!useEnv("MOCK"));
 
   const results = useMemo<MarketCurrencyData[]>(
     () => mapAssetsDataToMarketCurrencies(data, rate ?? 1, deactivatedCurrencyIds),

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSearchResultsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSearchResultsViewModel.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
 import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
-import { useCurrenciesUnderFeatureFlag } from "@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag";
+import { useFeatureFlaggedCurrencies } from "@features/platform-currencies";
 import type { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
 import { useFeature } from "@features/platform-feature-flags";
 import { useSelector } from "LLD/hooks/redux";
@@ -42,7 +42,7 @@ export function useAssetSearchResultsViewModel({ search, skip }: Params): Result
   const { status: rateStatus, rate } = useUsdToFiatRate(counterCurrency);
 
   // Hide currencies disabled by a feature flag, mirroring the receive flow.
-  const { deactivatedCurrencyIds } = useCurrenciesUnderFeatureFlag();
+  const { deactivatedCurrencyIds } = useFeatureFlaggedCurrencies();
 
   const results = useMemo<MarketCurrencyData[]>(
     () => mapAssetsDataToMarketCurrencies(data, rate ?? 1, deactivatedCurrencyIds),

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/__mocks__/sendFlowTestUtils.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/__mocks__/sendFlowTestUtils.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen, waitFor } from "tests/testSetup";
 import BigNumber from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { Account } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { SendWorkflow } from "../index";

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useFeeInfo.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useFeeInfo.test.ts
@@ -7,7 +7,7 @@ import {
   getAccountCurrency,
   getMainAccount,
 } from "@ledgerhq/ledger-wallet-framework/account/helpers";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { createMockAccount } from "../../screens/Recipient/__integrations__/__fixtures__/accounts";
 import type { Account } from "@ledgerhq/types-live";
 import type { TransactionStatus } from "@ledgerhq/live-common/generated/types";

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
@@ -8,7 +8,7 @@ import {
   getAccountCurrency,
   getMainAccount,
 } from "@ledgerhq/ledger-wallet-framework/account/helpers";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { createMockAccount } from "../../screens/Recipient/__integrations__/__fixtures__/accounts";
 import type { Account } from "@ledgerhq/types-live";
 import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useAmountScreenViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useAmountScreenViewModel.test.ts
@@ -11,7 +11,7 @@ import {
 import { useTranslatedBridgeError } from "../../../Recipient/hooks/useTranslatedBridgeError";
 import type { Account, TokenAccount } from "@ledgerhq/types-live";
 import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { createMockAccount } from "../../../Recipient/__integrations__/__fixtures__/accounts";
 
 jest.mock("@ledgerhq/live-common/bridge/impl");

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/hooks/__tests__/useCoinControlAmountInput.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/hooks/__tests__/useCoinControlAmountInput.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { BigNumber } from "bignumber.js";
 import { act, renderHook } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { createMockAccount } from "../../../Recipient/__integrations__/__fixtures__/accounts";
 import { useCoinControlAmountInput } from "../useCoinControlAmountInput";
 import type { Account } from "@ledgerhq/types-live";

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/hooks/__tests__/useCoinControlScreenViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/hooks/__tests__/useCoinControlScreenViewModel.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { BigNumber } from "bignumber.js";
 import { renderHook } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { createMockAccount } from "../../../Recipient/__integrations__/__fixtures__/accounts";
 import { useCoinControlScreenViewModel } from "../useCoinControlScreenViewModel";
 import type { Account } from "@ledgerhq/types-live";

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/__integrations__/__fixtures__/accounts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/__integrations__/__fixtures__/accounts.ts
@@ -2,7 +2,7 @@ import { BigNumber } from "bignumber.js";
 import type { Account } from "@ledgerhq/types-live";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 export const createMockCurrency = (overrides?: Partial<CryptoCurrency>): CryptoCurrency => {
   const currency = getCryptoCurrencyById("bitcoin");

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/__tests__/DetailsSection.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/__tests__/DetailsSection.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { AdditionalProviderConfig } from "@ledgerhq/live-common/exchange/providers/swap";
 import { render, screen } from "tests/testSetup";
 import ProviderIcon from "~/renderer/components/ProviderIcon";

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/__tests__/StatusSection.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/__tests__/StatusSection.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { TransactionStatusValue } from "@ledgerhq/live-common/wallet-api/Exchange/transactionStatus/index";
 import { render, screen } from "tests/testSetup";
 import { StatusSection } from "../components/Status/StatusSection";

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/__tests__/TransactionHeader.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/__tests__/TransactionHeader.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { render, screen } from "tests/testSetup";
 import { TransactionHeader } from "../components/TransactionHeader";

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/__tests__/useSwapTransactionStatusViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/__tests__/useSwapTransactionStatusViewModel.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getSwapProvider } from "@ledgerhq/live-common/exchange/providers/swap";
 import { useSelector } from "LLD/hooks/redux";

--- a/apps/ledger-live-desktop/src/mvvm/features/__mocks__/useSelectAssetFlow.mock.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/__mocks__/useSelectAssetFlow.mock.ts
@@ -1,5 +1,5 @@
 import type { EnhancedModularDrawerConfiguration } from "@ledgerhq/live-common/wallet-api/ModularDrawer/types";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { AssetType } from "../ModularDialog/types";
 
@@ -81,7 +81,7 @@ export enum LoadingStatus {
   Success = "success",
 }
 
-export { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+export { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 export const formatCurrencyUnit = (
   _unit: unknown,

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useAddressDisplay.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useAddressDisplay.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from "tests/testSetup";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { useAddressDisplay } from "../useAddressDisplay";
 
 const ethCurrency = getCryptoCurrencyById("ethereum");

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useNavigateToStakeForAccount.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useNavigateToStakeForAccount.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act } from "tests/testSetup";
 import BigNumber from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { useNavigateToStakeForAccount } from "../useNavigateToStakeForAccount";
 
 const mockNavigate = jest.fn();

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useAccountStatus.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useAccountStatus.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from "tests/testSetup";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import BigNumber from "bignumber.js";
 import type { Account } from "@ledgerhq/types-live";
 import { useAccountStatus } from "./useAccountStatus";

--- a/apps/ledger-live-desktop/src/mvvm/utils/tests/getTokenAccountTuples.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/utils/tests/getTokenAccountTuples.test.ts
@@ -1,5 +1,5 @@
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { getTokenAccountTuples } from "../getTokenAccountTuples";
 import { Account } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";

--- a/apps/ledger-live-desktop/src/renderer/actions/accounts.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/accounts.test.ts
@@ -1,5 +1,5 @@
 import type { Account, AccountUserData } from "@ledgerhq/types-live";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { initAccounts } from "./accounts";
 
 function fakeTuple(

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/deviceAction.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/deviceAction.test.tsx
@@ -5,7 +5,7 @@ import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
 import { DeviceDeprecationRules } from "@ledgerhq/live-common/hw/connectApp";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { DmkError } from "@ledgerhq/live-dmk-desktop";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 
 jest.mock("~/renderer/hooks/useBuyDeviceIntercept", () => ({

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/Operation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/Operation.tsx
@@ -6,7 +6,7 @@ import Box from "~/renderer/components/Box";
 import { TFunction } from "i18next";
 import { AccountLike, Account, Operation } from "@ledgerhq/types-live";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import ConfirmationCell from "./ConfirmationCell";
 import DateCell from "./DateCell";

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/tests/EditOperationPanel.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/tests/EditOperationPanel.test.tsx
@@ -1,5 +1,5 @@
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { Account, Operation } from "@ledgerhq/types-live";
 import React from "react";
 import { render, screen, withFlagOverrides } from "tests/testSetup";

--- a/apps/ledger-live-desktop/src/renderer/components/ParentCryptoCurrencyIcon.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ParentCryptoCurrencyIcon.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import styled, { useTheme } from "styled-components";
 import { Currency } from "@ledgerhq/types-cryptoassets";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { rgba } from "~/renderer/styles/helpers";
 import Tooltip from "~/renderer/components/Tooltip";
 import Text from "~/renderer/components/Text";

--- a/apps/ledger-live-desktop/src/renderer/components/SelectCurrency.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SelectCurrency.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import Fuse from "fuse.js";
 import { CryptoOrTokenCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useCurrenciesByMarketcap } from "@ledgerhq/live-common/currencies/hooks";
 import { getEnv } from "@ledgerhq/live-env";

--- a/apps/ledger-live-desktop/src/renderer/components/TransactionConfirm/index.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TransactionConfirm/index.test.tsx
@@ -12,7 +12,7 @@ import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/
 import { BigNumber } from "bignumber.js";
 import { getDeviceAnimation } from "../DeviceAction/animations";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 
 jest.mock("@ledgerhq/live-common/hooks/useDeviceTransactionConfig");

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -25,6 +25,7 @@ import {
 } from "@ledgerhq/live-common/platform/react";
 import trackingWrapper from "@ledgerhq/live-common/platform/tracking";
 import { useFeatureFlaggedCurrencies } from "@features/platform-currencies";
+import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { openModal } from "../../actions/modals";
 import { flattenAccountsSelector } from "~/renderer/reducers/accounts";
 import BigSpinner from "../BigSpinner";
@@ -98,8 +99,10 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
 
     const walletState = useSelector(walletSelector);
     const listAccounts = useListPlatformAccounts(walletState, accounts);
-    const { deactivatedCurrencyIds: _deactivatedCurrencyIds } = useFeatureFlaggedCurrencies();
-    const deactivatedCurrencyIds = _deactivatedCurrencyIds as Set<string>;
+    const { deactivatedCurrencyIds: _deactivatedCurrencyIds } = useFeatureFlaggedCurrencies(
+      !!useEnv("MOCK"),
+    );
+    const deactivatedCurrencyIds = new Set(_deactivatedCurrencyIds);
     const listCurrencies = useListPlatformCurrencies(deactivatedCurrencyIds);
 
     const { openAssetAndAccountPromise } = useOpenAssetAndAccount();

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -102,7 +102,10 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
     const { deactivatedCurrencyIds: _deactivatedCurrencyIds } = useFeatureFlaggedCurrencies(
       !!useEnv("MOCK"),
     );
-    const deactivatedCurrencyIds = new Set(_deactivatedCurrencyIds);
+    const deactivatedCurrencyIds = useMemo(
+      () => new Set(_deactivatedCurrencyIds),
+      [_deactivatedCurrencyIds],
+    );
     const listCurrencies = useListPlatformCurrencies(deactivatedCurrencyIds);
 
     const { openAssetAndAccountPromise } = useOpenAssetAndAccount();

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -24,7 +24,7 @@ import {
   useListPlatformCurrencies,
 } from "@ledgerhq/live-common/platform/react";
 import trackingWrapper from "@ledgerhq/live-common/platform/tracking";
-import { useCurrenciesUnderFeatureFlag } from "@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag";
+import { useFeatureFlaggedCurrencies } from "@features/platform-currencies";
 import { openModal } from "../../actions/modals";
 import { flattenAccountsSelector } from "~/renderer/reducers/accounts";
 import BigSpinner from "../BigSpinner";
@@ -98,7 +98,8 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
 
     const walletState = useSelector(walletSelector);
     const listAccounts = useListPlatformAccounts(walletState, accounts);
-    const { deactivatedCurrencyIds } = useCurrenciesUnderFeatureFlag();
+    const { deactivatedCurrencyIds: _deactivatedCurrencyIds } = useFeatureFlaggedCurrencies();
+    const deactivatedCurrencyIds = _deactivatedCurrencyIds as Set<string>;
     const listCurrencies = useListPlatformCurrencies(deactivatedCurrencyIds);
 
     const { openAssetAndAccountPromise } = useOpenAssetAndAccount();

--- a/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
@@ -9,7 +9,7 @@ import {
   getDefaultExplorerView,
   getTransactionExplorer as getDefaultTransactionExplorer,
 } from "@ledgerhq/live-common/explorers";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { useFeature } from "@features/platform-feature-flags";
 import {
   findOperationInAccount,

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/ModularDrawerAddAccountFlowManager.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/ModularDrawerAddAccountFlowManager.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import styled from "styled-components";
 import type { AppResult } from "@ledgerhq/live-common/hw/actions/app";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { ViewKeysByAccountId } from "@ledgerhq/live-common/families/aleo/hw/getViewKey/index";
 import { buildAccountsWithViewKeys } from "@ledgerhq/live-common/families/aleo/react";
 import { addAccountsAction } from "@ledgerhq/live-wallet/addAccounts";

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__mocks__/currency.mock.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__mocks__/currency.mock.ts
@@ -1,4 +1,4 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 
 export const aleoCurrency = getCryptoCurrencyById("aleo");

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.tsx
@@ -1,4 +1,4 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import React, { useMemo } from "react";
 import BigNumber from "bignumber.js";
 import styled from "styled-components";

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.ts
@@ -25,7 +25,7 @@ import type {
 } from "@ledgerhq/live-common/families/aleo/types";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { CryptoCurrency, TokenCurrency, Unit } from "@ledgerhq/types-cryptoassets";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { AccountLike } from "@ledgerhq/types-live";
 
 export const getAleoCurrencyConfig = (

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/OptInFlowModal/fields/AsaSelector.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/OptInFlowModal/fields/AsaSelector.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo } from "react";
 import { TFunction } from "i18next";
 import { Trans } from "react-i18next";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { useTokensData } from "@ledgerhq/cryptoassets/cal-client/hooks/useTokensData";
+import { useTokensData } from "@features/platform-currencies";
 import { extractTokenId } from "@ledgerhq/live-common/families/algorand/tokens";
 import Box from "~/renderer/components/Box";
 import FirstLetterIcon from "~/renderer/components/FirstLetterIcon";

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/OptInFlowModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/OptInFlowModal/steps/StepConfirmation.tsx
@@ -13,7 +13,7 @@ import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { StepProps } from "../types";
 import invariant from "invariant";
-import { useTokenById } from "@ledgerhq/cryptoassets/hooks";
+import { useTokenById } from "@features/platform-currencies";
 
 const Container = styled(Box).attrs(() => ({
   alignItems: "center",
@@ -28,7 +28,7 @@ const Container = styled(Box).attrs(() => ({
 function StepConfirmation({ optimisticOperation, error, signed, transaction }: StepProps) {
   invariant(transaction, "Transaction should be present");
 
-  const { token, loading } = useTokenById(transaction.assetId!);
+  const { data: token, isLoading: loading } = useTokenById(transaction.assetId!);
 
   if (optimisticOperation) {
     return (

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/__tests__/EditTransactionComponents.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/__tests__/EditTransactionComponents.test.tsx
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import React from "react";
 import { render, screen, withFlagOverrides } from "tests/testSetup";

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/__tests__/StepMethod.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/__tests__/StepMethod.test.tsx
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import React from "react";
 import { render, screen, waitFor } from "tests/testSetup";

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/operationDetails.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/operationDetails.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import BigNumber from "bignumber.js";
 import { render, screen } from "tests/testSetup";
 import { createFixtureAccount } from "@ledgerhq/coin-bitcoin/fixtures/common.fixtures";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { TFunction } from "i18next";
 import { Operation } from "@ledgerhq/types-live";
 import { DataList } from "~/renderer/drawers/OperationDetails";

--- a/apps/ledger-live-desktop/src/renderer/families/canton/AddAccountDrawer/__integrations__/CantonOnboard.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/AddAccountDrawer/__integrations__/CantonOnboard.integration.test.tsx
@@ -8,7 +8,7 @@ import cantonHandlers, {
   CANTON_DEVNET_ONBOARDING_PREPARE_RE,
   MOCK_CANTON_PUBLIC_KEY_HEX,
 } from "./cantonHandlers";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { getEnv, setEnv } from "@ledgerhq/live-env";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { DeviceModelId } from "@ledgerhq/types-devices";

--- a/apps/ledger-live-desktop/src/renderer/families/canton/AddAccountDrawer/__integrations__/ModularDrawerReAddOnboarded.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/AddAccountDrawer/__integrations__/ModularDrawerReAddOnboarded.integration.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions */
 import React from "react";
 import { render, screen, waitFor } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { Account } from "@ledgerhq/types-live";
 import ModularDrawerAddAccountFlowManager from "../../ModularDrawerAddAccountFlowManager";
 import { createMockAccount } from "../../__tests__/testUtils";

--- a/apps/ledger-live-desktop/src/renderer/families/canton/ModularDrawerAddAccountFlowManager.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/ModularDrawerAddAccountFlowManager.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import styled from "styled-components";
 import type { AppResult } from "@ledgerhq/live-common/hw/actions/app";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { isCantonAccount } from "@ledgerhq/coin-canton/bridge/serialization";
 import { addAccountsAction } from "@ledgerhq/live-wallet/addAccounts";
 import { Flex } from "@ledgerhq/react-ui/index";

--- a/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/__integrations__/OnboardModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/__integrations__/OnboardModal.integration.test.tsx
@@ -8,7 +8,7 @@ import cantonHandlers, {
   CANTON_DEVNET_ONBOARDING_PREPARE_RE,
   MOCK_CANTON_PUBLIC_KEY_HEX,
 } from "./cantonHandlers";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { getEnv, setEnv } from "@ledgerhq/live-env";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { getCurrencyBridge } from "@ledgerhq/live-common/bridge/impl";

--- a/apps/ledger-live-desktop/src/renderer/families/celo/__tests__/operationDetails.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/__tests__/operationDetails.test.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { renderHook } from "@testing-library/react";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { emptyHistoryCache } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { NATIVE_FEE_CURRENCY_MARKER } from "@ledgerhq/live-common/families/celo/constants";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
@@ -8,15 +8,16 @@ import type { TokenAccount } from "@ledgerhq/types-live";
 import type { CeloAccount, CeloOperation } from "@ledgerhq/live-common/families/celo/types";
 
 const mockUseQuery = jest.fn();
-const mockUseTokenByAddressInCurrency = jest.fn();
+const mockUseFindTokenByAddressInCurrencyQuery = jest.fn();
 const mockGetCeloTransactionFeeCurrency = jest.fn();
 
 jest.mock("@tanstack/react-query", () => ({
   useQuery: (...args: unknown[]) => mockUseQuery(...args),
 }));
 
-jest.mock("@ledgerhq/cryptoassets/hooks", () => ({
-  useTokenByAddressInCurrency: (...args: unknown[]) => mockUseTokenByAddressInCurrency(...args),
+jest.mock("@domain/api-currency-token", () => ({
+  useFindTokenByAddressInCurrencyQuery: (...args: unknown[]) =>
+    mockUseFindTokenByAddressInCurrencyQuery(...args),
 }));
 
 jest.mock("@ledgerhq/live-common/families/celo/network", () => ({
@@ -177,7 +178,7 @@ describe("celo desktop operationDetails.useFeesCurrency", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseQuery.mockReturnValue({ data: undefined });
-    mockUseTokenByAddressInCurrency.mockReturnValue({ token: undefined });
+    mockUseFindTokenByAddressInCurrencyQuery.mockReturnValue({ data: undefined });
   });
 
   it("returns undefined when the stored marker is NATIVE", () => {
@@ -214,14 +215,17 @@ describe("celo desktop operationDetails.useFeesCurrency", () => {
   it("falls back to the CAL token when no subAccount matches", () => {
     const adapter = "0xabcdef0123456789abcdef0123456789abcdef01";
     const calToken = buildToken(adapter, 6, "celo/erc20/cal");
-    mockUseTokenByAddressInCurrency.mockReturnValue({ token: calToken });
+    mockUseFindTokenByAddressInCurrencyQuery.mockReturnValue({ data: calToken });
     const account = buildAccount(); // no subAccounts
     const operation = buildOperation({ feeCurrencyAddress: adapter });
 
     const { result } = renderHook(() => useFeesCurrency(operation, account));
 
     expect(result.current).toBe(calToken);
-    expect(mockUseTokenByAddressInCurrency).toHaveBeenCalledWith(adapter, "celo", { skip: false });
+    expect(mockUseFindTokenByAddressInCurrencyQuery).toHaveBeenCalledWith(
+      { contract_address: adapter, network: "celo" },
+      { skip: false },
+    );
   });
 
   it("uses the fetched address when nothing is stored on the operation", () => {

--- a/apps/ledger-live-desktop/src/renderer/families/celo/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/operationDetails.tsx
@@ -8,7 +8,7 @@ import { getCeloTransactionFeeCurrency } from "@ledgerhq/live-common/families/ce
 import { useCeloPreloadData } from "@ledgerhq/live-common/families/celo/react";
 import { CeloAccount, CeloOperation } from "@ledgerhq/live-common/families/celo/types";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { useTokenByAddressInCurrency } from "@ledgerhq/cryptoassets/hooks";
+import { useFindTokenByAddressInCurrencyQuery } from "@domain/api-currency-token";
 import { useQuery } from "@tanstack/react-query";
 import BigNumber from "bignumber.js";
 import React from "react";
@@ -162,9 +162,10 @@ const useFeesCurrency = (
   const contract = option?.contractAddress?.toLowerCase() ?? adapter?.toLowerCase() ?? "";
 
   // CAL fallback for received txs where the user doesn't hold the fee token.
-  const { token: tokenFromCal } = useTokenByAddressInCurrency(contract, account.currency.id, {
-    skip: !contract,
-  });
+  const { data: tokenFromCal } = useFindTokenByAddressInCurrencyQuery(
+    { contract_address: contract, network: account.currency.id },
+    { skip: !contract },
+  );
 
   if (!adapter) return undefined;
   return resolveFeeTokenFromAdapter(adapter, account) ?? tokenFromCal;

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.integ.test.tsx
@@ -5,7 +5,7 @@
 import React from "react";
 import { cleanup, render, screen, waitFor } from "tests/testSetup";
 import { server } from "tests/server";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import coinConfig from "@ledgerhq/coin-concordium/config";
 import OnboardModal from "../index";
 import {

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { cleanup, render, screen, waitFor } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { AccountOnboardStatus } from "@ledgerhq/coin-concordium/types";
 import { ConcordiumPairingExpiredError } from "@ledgerhq/errors";
 import { Account } from "@ledgerhq/types-live";

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepClaimRewards.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepClaimRewards.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { CosmosAccount } from "@ledgerhq/live-common/families/cosmos/types";
 import StepClaimRewards from "./StepClaimRewards";
 import type { StepProps } from "../types";

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/EditTransactionComponents.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/EditTransactionComponents.test.tsx
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import React from "react";
 import { render, screen, withFlagOverrides } from "tests/testSetup";

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/StepMethod.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/StepMethod.test.tsx
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import React from "react";
 import { render, screen, waitFor } from "tests/testSetup";

--- a/apps/ledger-live-desktop/src/renderer/families/evm/RedelegationFlowModal/fields/__tests__/ValidatorField.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/RedelegationFlowModal/fields/__tests__/ValidatorField.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { fireEvent } from "@testing-library/react";
 import { render, screen, waitFor } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type {
   StakingAccount,
   StakingValidatorItem,

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/component/ProviderItem.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/component/ProviderItem.tsx
@@ -1,6 +1,6 @@
 import { useRemoteLiveAppManifest } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
-import { findCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { Flex, Icon, Text } from "@ledgerhq/react-ui";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import { EthStakingProvider } from "@ledgerhq/types-live";

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/index.tsx
@@ -1,4 +1,4 @@
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { useFeature } from "@features/platform-feature-flags";
 import { Box, Button, Flex, Icons, Text } from "@ledgerhq/react-ui";
 import { AccountLike, EthStakingProvider, EthStakingProviderCategory } from "@ledgerhq/types-live";

--- a/apps/ledger-live-desktop/src/renderer/families/evm/__tests__/AccountHeaderManageActions.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/__tests__/AccountHeaderManageActions.test.tsx
@@ -1,7 +1,7 @@
 import { act } from "react";
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { Account, StakingResources } from "@ledgerhq/types-live";
 import { renderHook, withFlagOverrides } from "tests/testSetup";

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/OperationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/OperationDetails.tsx
@@ -26,13 +26,16 @@ import {
   OpDetailsTitle,
   TextEllipsis,
 } from "~/renderer/drawers/OperationDetails/styledComponents";
-import { useTokenByAddressInCurrency } from "@ledgerhq/cryptoassets/hooks";
+import { useFindTokenByAddressInCurrencyQuery } from "@domain/api-currency-token";
 
 const OperationDetailsPostAccountSection = ({
   operation,
 }: OperationDetailsPostAccountSectionProps<HederaAccount, HederaOperation>) => {
   const { t } = useTranslation();
-  const { token } = useTokenByAddressInCurrency(operation.extra.associatedTokenId || "", "hedera");
+  const { data: token } = useFindTokenByAddressInCurrencyQuery(
+    { contract_address: operation.extra.associatedTokenId || "", network: "hedera" },
+    { skip: !operation.extra.associatedTokenId },
+  );
 
   if (operation.type !== "ASSOCIATE_TOKEN") {
     return null;
@@ -88,7 +91,10 @@ const OperationDetailsPostAlert = ({
   const dispatch = useDispatch();
   const extra = isValidExtra(operation.extra) ? operation.extra : null;
   const associatedTokenId = extra?.associatedTokenId;
-  const { token } = useTokenByAddressInCurrency(associatedTokenId || "", "hedera");
+  const { data: token } = useFindTokenByAddressInCurrencyQuery(
+    { contract_address: associatedTokenId || "", network: "hedera" },
+    { skip: !associatedTokenId },
+  );
 
   if (operation.type !== "ASSOCIATE_TOKEN") {
     return null;
@@ -131,7 +137,10 @@ const OperationDetailsPostAlert = ({
 };
 
 const AddressCell = ({ operation }: AddressCellProps<HederaOperation>) => {
-  const { token } = useTokenByAddressInCurrency(operation.extra.associatedTokenId || "", "hedera");
+  const { data: token } = useFindTokenByAddressInCurrencyQuery(
+    { contract_address: operation.extra.associatedTokenId || "", network: "hedera" },
+    { skip: !operation.extra.associatedTokenId },
+  );
 
   if (!token) {
     return <Box flex="1" />;

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/__mocks__/currency.mock.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/__mocks__/currency.mock.ts
@@ -1,3 +1,3 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 export const hederaCurrency = getCryptoCurrencyById("hedera");

--- a/apps/ledger-live-desktop/src/renderer/families/mina/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/mina/operationDetails.tsx
@@ -8,7 +8,7 @@ import {
 import Ellipsis from "~/renderer/components/Ellipsis";
 import { MinaOperation } from "@ledgerhq/live-common/families/mina/types";
 import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/formatCurrencyUnit";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import BigNumber from "bignumber.js";
 
 type OperationDetailsExtraProps = {

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/fields/AssetSelector.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/fields/AssetSelector.tsx
@@ -11,7 +11,7 @@ import ToolTip from "~/renderer/components/Tooltip";
 import ExclamationCircleThin from "~/renderer/icons/ExclamationCircleThin";
 import { Account } from "@ledgerhq/types-live";
 import { Transaction } from "@ledgerhq/live-common/families/stellar/types";
-import { useTokensData } from "@ledgerhq/cryptoassets/cal-client/hooks/useTokensData";
+import { useTokensData } from "@features/platform-currencies";
 
 const EllipsisMiddle = ({ children }: { children: string }) => {
   const Start = styled(Box)`

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/steps/StepConfirmation.tsx
@@ -12,7 +12,7 @@ import BroadcastErrorDisclaimer from "~/renderer/components/BroadcastErrorDiscla
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { StepProps } from "../types";
-import { useTokenByAddressInCurrency } from "@ledgerhq/cryptoassets/hooks";
+import { useFindTokenByAddressInCurrencyQuery } from "@domain/api-currency-token";
 import invariant from "invariant";
 
 const Container = styled(Box).attrs(() => ({
@@ -28,10 +28,10 @@ function StepConfirmation({ account, optimisticOperation, error, signed, transac
   invariant(account, "Account should be present");
   invariant(transaction, "Transaction should be present");
 
-  const { token, loading } = useTokenByAddressInCurrency(
-    transaction.assetOwner!,
-    account.currency.id,
-  );
+  const { data: token, isLoading: loading } = useFindTokenByAddressInCurrencyQuery({
+    contract_address: transaction.assetOwner!,
+    network: account.currency.id,
+  });
 
   if (optimisticOperation) {
     return (

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/Delegation/__tests__/ContextMenu.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/Delegation/__tests__/ContextMenu.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { act, render, screen } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { TezosAccount } from "@ledgerhq/live-common/families/tezos/types";
 import { useDelegation, useTezosStakingInfo } from "@ledgerhq/live-common/families/tezos/react";

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/Delegation/__tests__/StakingSection.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/Delegation/__tests__/StakingSection.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { act, render, screen } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { TezosAccount } from "@ledgerhq/live-common/families/tezos/types";
 import { useBaker } from "@ledgerhq/live-common/families/tezos/react";

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/Delegation/__tests__/UnstakingSection.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/Delegation/__tests__/UnstakingSection.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { fireEvent, render, screen } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { shortAddressPreview } from "@ledgerhq/live-common/account/index";
 import type { StakingPosition, TezosAccount } from "@ledgerhq/live-common/families/tezos/types";

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/Delegation/__tests__/index.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/Delegation/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { render, screen, withFlagOverrides } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { TezosAccount } from "@ledgerhq/live-common/families/tezos/types";
 import { useBaker, useTezosStakingInfo } from "@ledgerhq/live-common/families/tezos/react";

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/EarningChoiceModal/__tests__/Body.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/EarningChoiceModal/__tests__/Body.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { act, render, screen } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { TezosAccount } from "@ledgerhq/live-common/families/tezos/types";
 import Body from "../Body";

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/Body.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/Body.test.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import BigNumber from "bignumber.js";
 import { act, render, screen } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { TezosAccount } from "@ledgerhq/live-common/families/tezos/types";
 import type { StepId } from "../types";

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepAmount.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepAmount.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { act, render, screen } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { TezosAccount, Transaction } from "@ledgerhq/live-common/families/tezos/types";
 import type { StepProps } from "../types";

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepConfirmation.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepConfirmation.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { act, fireEvent, render, screen } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { TezosAccount, Transaction } from "@ledgerhq/live-common/families/tezos/types";
 import type { Operation } from "@ledgerhq/types-live";

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepDeviceDelegation.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepDeviceDelegation.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { act, render, screen } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { TezosAccount, Transaction } from "@ledgerhq/live-common/families/tezos/types";
 import type { Operation } from "@ledgerhq/types-live";

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepDeviceStaking.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepDeviceStaking.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { act, render, screen } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { TezosAccount, Transaction } from "@ledgerhq/live-common/families/tezos/types";
 import type { StepProps } from "../types";

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepValidator.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepValidator.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { act, fireEvent, render, screen } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { InvalidAddress, NotEnoughBalance } from "@ledgerhq/errors";
 import type { TezosAccount, Transaction } from "@ledgerhq/live-common/families/tezos/types";

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeFlowModal/__tests__/Body.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeFlowModal/__tests__/Body.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import BigNumber from "bignumber.js";
 import { act, render, screen } from "tests/testSetup";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type {
   TezosAccount,

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeFlowModal/steps/__tests__/StepAmount.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeFlowModal/steps/__tests__/StepAmount.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { render, screen } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type {
   TezosAccount,

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeFlowModal/steps/__tests__/StepConfirmation.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeFlowModal/steps/__tests__/StepConfirmation.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { render, screen } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type {
   TezosAccount,

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/__tests__/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/__tests__/AccountBalanceSummaryFooter.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import BigNumber from "bignumber.js";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { TezosAccount } from "@ledgerhq/live-common/families/tezos/types";
 import type { TokenAccount } from "@ledgerhq/types-live";

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/__tests__/AccountHeaderManageActions.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/__tests__/AccountHeaderManageActions.test.tsx
@@ -1,7 +1,7 @@
 import { act } from "react";
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { TezosAccount } from "@ledgerhq/live-common/families/tezos/types";
 import { renderHook, withFlagOverrides } from "tests/testSetup";

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/__tests__/operationDetails.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/__tests__/operationDetails.test.tsx
@@ -3,7 +3,7 @@ import BigNumber from "bignumber.js";
 import { render, screen } from "tests/testSetup";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { Operation } from "@ledgerhq/types-live";
 import type { TezosAccount } from "@ledgerhq/live-common/families/tezos/types";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/__tests__/testUtils.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/__tests__/testUtils.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type {
   Delegation,

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/useDeepLinkHandler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/useDeepLinkHandler.test.ts
@@ -3,8 +3,7 @@
 import { renderHook, waitFor, withFlagOverrides } from "tests/testSetup";
 import { Account, TokenAccount } from "@ledgerhq/types-live";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
-import { findCryptoCurrencyByKeyword } from "@domain/entity-currency-crypto";
+import { getCryptoCurrencyById, findCryptoCurrencyByKeyword } from "@domain/entity-currency-crypto";
 import { openModal, closeAllModal } from "~/renderer/actions/modals";
 import {
   FEATURE_INTRO_CAMPAIGN_ID,

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/useDeepLinkHandler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/useDeepLinkHandler.test.ts
@@ -3,10 +3,8 @@
 import { renderHook, waitFor, withFlagOverrides } from "tests/testSetup";
 import { Account, TokenAccount } from "@ledgerhq/types-live";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
-import {
-  getCryptoCurrencyById,
-  findCryptoCurrencyByKeyword,
-} from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { findCryptoCurrencyByKeyword } from "@domain/entity-currency-crypto";
 import { openModal, closeAllModal } from "~/renderer/actions/modals";
 import {
   FEATURE_INTRO_CAMPAIGN_ID,
@@ -74,8 +72,12 @@ jest.mock("LLD/features/Send/hooks/useOpenSendFlow", () => ({
 
 jest.mock("@ledgerhq/live-common/currencies/index", () => ({
   ...jest.requireActual("@ledgerhq/live-common/currencies/index"),
-  findCryptoCurrencyByKeyword: jest.fn(),
   parseCurrencyUnit: jest.fn((unit, amount) => amount),
+}));
+
+jest.mock("@domain/entity-currency-crypto", () => ({
+  ...jest.requireActual("@domain/entity-currency-crypto"),
+  findCryptoCurrencyByKeyword: jest.fn(),
 }));
 
 const mockFindCryptoCurrencyByKeyword = jest.mocked(findCryptoCurrencyByKeyword);

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/addAccount.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/addAccount.handler.test.ts
@@ -1,12 +1,10 @@
-import {
-  getCryptoCurrencyById,
-  findCryptoCurrencyByKeyword,
-} from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { findCryptoCurrencyByKeyword } from "@domain/entity-currency-crypto";
 import { addAccountHandler } from "../addAccount.handler";
 import { createMockContext } from "./test-utils";
 
-jest.mock("@ledgerhq/live-common/currencies/index", () => ({
-  ...jest.requireActual("@ledgerhq/live-common/currencies/index"),
+jest.mock("@domain/entity-currency-crypto", () => ({
+  ...jest.requireActual("@domain/entity-currency-crypto"),
   findCryptoCurrencyByKeyword: jest.fn(),
 }));
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/addAccount.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/addAccount.handler.test.ts
@@ -1,5 +1,4 @@
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
-import { findCryptoCurrencyByKeyword } from "@domain/entity-currency-crypto";
+import { getCryptoCurrencyById, findCryptoCurrencyByKeyword } from "@domain/entity-currency-crypto";
 import { addAccountHandler } from "../addAccount.handler";
 import { createMockContext } from "./test-utils";
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/accounts.handler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/accounts.handler.ts
@@ -1,4 +1,4 @@
-import { findCryptoCurrencyByKeyword } from "@ledgerhq/live-common/currencies/index";
+import { findCryptoCurrencyByKeyword } from "@domain/entity-currency-crypto";
 import { Currency } from "@ledgerhq/types-cryptoassets";
 import { DeeplinkHandler } from "../types";
 import { getAccountsOrSubAccountsByCurrency } from "../utils";

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/addAccount.handler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/addAccount.handler.ts
@@ -1,4 +1,4 @@
-import { findCryptoCurrencyByKeyword } from "@ledgerhq/live-common/currencies/index";
+import { findCryptoCurrencyByKeyword } from "@domain/entity-currency-crypto";
 import { DeeplinkHandler } from "../types";
 
 export const addAccountHandler: DeeplinkHandler<"add-account"> = (

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -19,7 +19,7 @@ import { getLocalStorageEnvs } from "~/renderer/experimental";
 import "~/renderer/i18n/init";
 import { hydrateCurrency } from "~/renderer/bridge/cache";
 import { setupCryptoAssetsStore } from "~/config/bridge-setup";
-import { findCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { restoreTokensToCache, parsePersistedCAL } from "@domain/api-currency-token";
 import { currencyFiatApi } from "@domain/api-currency-fiat";
 import logger, { enableDebugLogger } from "./logger";

--- a/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { ExchangeType } from "@ledgerhq/live-common/wallet-api/react";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepAccount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepAccount.tsx
@@ -3,7 +3,7 @@ import { Trans } from "react-i18next";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import { TokenCurrency, CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
-import { useTokensData } from "@ledgerhq/cryptoassets/cal-client/hooks/useTokensData";
+import { useTokensData } from "@features/platform-currencies";
 import { supportLinkByTokenType } from "~/config/urls";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
@@ -1,6 +1,6 @@
 import invariant from "invariant";
 import React, { useEffect, useCallback, useState } from "react";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import TrackPage from "~/renderer/analytics/TrackPage";

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.react.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.react.test.tsx
@@ -4,7 +4,7 @@ import axios from "axios";
 import { TFunction } from "i18next";
 import BigNumber from "bignumber.js";
 import { render, screen, waitFor, withFlagOverrides } from "tests/testSetup";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { Account } from "@ledgerhq/types-live";
 import { InvalidAddress } from "@ledgerhq/errors";
 import { DomainServiceProvider } from "@ledgerhq/domain-service/hooks/index";

--- a/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, waitFor } from "tests/testSetup";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { Account } from "@ledgerhq/types-live";
 import { useLLDCoinFamily } from "~/renderer/families";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";

--- a/apps/ledger-live-desktop/src/renderer/screens/account/EmptyStateAccount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/EmptyStateAccount.tsx
@@ -6,7 +6,7 @@ import { TFunction } from "i18next";
 import { openModal } from "~/renderer/actions/modals";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import IconReceive from "~/renderer/icons/Receive";
 import IconExchange from "~/renderer/icons/Exchange";
 import Box from "~/renderer/components/Box";

--- a/apps/ledger-live-desktop/src/renderer/screens/account/__tests__/AccountHeader.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/__tests__/AccountHeader.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { genAccount } from "@ledgerhq/live-common/mock/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { WalletState } from "@ledgerhq/live-wallet/store";
 import { render, screen, waitFor } from "tests/testSetup";
 import AccountHeader from "../AccountHeader";

--- a/apps/ledger-live-desktop/src/renderer/screens/account/index.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/index.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, withFlagOverrides } from "tests/testSetup";
 import { genAccount } from "@ledgerhq/live-common/mock/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { useLLDCoinFamily } from "~/renderer/families";
 import AccountPageWrapper from "./index";
 

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/AssetDistribution/Row.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/AssetDistribution/Row.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { render, screen } from "tests/testSetup";
 import Row from "./Row";
 import type { DistributionItem } from "@ledgerhq/types-live";

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/AppIcon.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/AppIcon.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from "react";
 import styled from "styled-components";
 import manager from "@ledgerhq/live-common/manager/index";
-import { findCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { getValidCryptoIconSize } from "~/renderer/utils/cryptoIconSize";
 import { App } from "@ledgerhq/types-live";
 import Image from "~/renderer/components/Image";

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/InstallSuccessBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/InstallSuccessBanner.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useRef, memo, useMemo } from "react";
 import styled, { keyframes } from "styled-components";
 import { Trans } from "react-i18next";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { isLiveSupportedApp } from "@ledgerhq/live-common/apps/index";
 import { State } from "@ledgerhq/live-common/apps/types";
 import Text from "~/renderer/components/Text";

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/Item.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/Item.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, memo, useCallback } from "react";
 import { useNotEnoughMemoryToInstall } from "@ledgerhq/live-common/apps/react";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { App } from "@ledgerhq/types-live";
 import { State, Action, InstalledItem } from "@ledgerhq/live-common/apps/types";
 import { isAppAssociatedCurrencySupported } from "./isAppAssociatedCurrencySupported";

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/isAppAssociatedCurrencySupported.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/isAppAssociatedCurrencySupported.ts
@@ -1,6 +1,7 @@
 import camelCase from "lodash/fp/camelCase";
 import type { App } from "@ledgerhq/types-live";
-import { getCryptoCurrencyById, isCurrencySupported } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { isCurrencySupported } from "@ledgerhq/live-common/currencies/index";
 import { type FeatureId, type Features, FeatureIdSchema } from "@shared/feature-flags";
 
 /**

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/components/TokenDetailsContent.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/components/TokenDetailsContent.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Flex, Text } from "@ledgerhq/react-ui/index";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { TokenDetails, DetailRow } from "../styles";
 
 interface TokenDetailsContentProps {

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/components/TokenListView.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/components/TokenListView.tsx
@@ -10,7 +10,7 @@ import {
 } from "@ledgerhq/react-ui/index";
 import { Button } from "@ledgerhq/lumen-ui-react";
 import { useTranslation } from "react-i18next";
-import { TOKEN_OUTPUT_FIELDS } from "@ledgerhq/cryptoassets/cal-client/state-manager/fields";
+import { TOKEN_OUTPUT_FIELDS } from "@domain/api-currency-token";
 import { FAMILY_OPTIONS, PAGE_SIZE_OPTIONS, OUTPUT_FIELD_OPTIONS } from "../constants";
 import {
   DrawerContainer,

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/components/TokenListView.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/components/TokenListView.tsx
@@ -10,7 +10,6 @@ import {
 } from "@ledgerhq/react-ui/index";
 import { Button } from "@ledgerhq/lumen-ui-react";
 import { useTranslation } from "react-i18next";
-import { TOKEN_OUTPUT_FIELDS } from "@domain/api-currency-token";
 import { FAMILY_OPTIONS, PAGE_SIZE_OPTIONS, OUTPUT_FIELD_OPTIONS } from "../constants";
 import {
   DrawerContainer,
@@ -187,7 +186,7 @@ export const TokenListView: React.FC<TokenListViewProps> = ({ initialFamily = "e
                 <Flex alignItems="center" justifyContent="space-between">
                   <Text variant="small" fontWeight="medium" color="neutral.c100">
                     {t("settings.developer.cryptoAssetsList.drawer.outputFields")} (
-                    {selectedOutputFields.length}/{TOKEN_OUTPUT_FIELDS.length})
+                    {selectedOutputFields.length}/{OUTPUT_FIELD_OPTIONS.length})
                   </Text>
                   <Flex columnGap={2}>
                     <Button size="sm" appearance="transparent" onClick={selectAllOutputFields}>

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/components/TokenListView.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/components/TokenListView.tsx
@@ -44,7 +44,6 @@ export const TokenListView: React.FC<TokenListViewProps> = ({ initialFamily = "e
 
   const {
     selectedFamilyOption,
-    isStaging,
     pageSize,
     selectedOutputFields,
     isOptionsOpen,
@@ -61,7 +60,6 @@ export const TokenListView: React.FC<TokenListViewProps> = ({ initialFamily = "e
     handleFamilyChange,
     handlePageSizeChange,
     handleRefresh,
-    handleToggleStaging,
     handleLoadMore,
     toggleOptionsPanel,
     toggleTokenExpanded,
@@ -169,22 +167,6 @@ export const TokenListView: React.FC<TokenListViewProps> = ({ initialFamily = "e
               {t("settings.developer.cryptoAssetsList.drawer.advanced").toUpperCase()}
             </Text>
             <Flex flexDirection="column" rowGap={3}>
-              <StyledCheckbox onClick={handleToggleStaging}>
-                <Checkbox
-                  isChecked={isStaging}
-                  name="staging-toggle"
-                  onChange={handleToggleStaging}
-                />
-                <Flex flexDirection="column" rowGap={0}>
-                  <Text variant="small" fontWeight="medium">
-                    {t("settings.developer.cryptoAssetsList.drawer.useStaging")}
-                  </Text>
-                  <Text variant="tiny" color="neutral.c70">
-                    {t("settings.developer.cryptoAssetsList.drawer.useStagingDesc")}
-                  </Text>
-                </Flex>
-              </StyledCheckbox>
-
               <Flex flexDirection="column" rowGap={1}>
                 <Text variant="small" fontWeight="medium" color="neutral.c100">
                   {t("settings.developer.cryptoAssetsList.drawer.calReference")}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/constants.ts
@@ -1,4 +1,4 @@
-import { TOKEN_OUTPUT_FIELDS } from "@ledgerhq/cryptoassets/cal-client/state-manager/fields";
+import { TOKEN_OUTPUT_FIELDS } from "@domain/api-currency-token";
 import { FamilyOption } from "./types";
 
 export const FAMILY_OPTIONS: FamilyOption[] = [

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/constants.ts
@@ -1,4 +1,4 @@
-import { TOKEN_OUTPUT_FIELDS } from "@domain/api-currency-token";
+import { ApiTokenResponseSchema } from "@domain/api-currency-token";
 import { FamilyOption } from "./types";
 
 export const FAMILY_OPTIONS: FamilyOption[] = [
@@ -16,7 +16,7 @@ export const PAGE_SIZE_OPTIONS = [
   { value: "1000", label: "1000" },
 ];
 
-export const OUTPUT_FIELD_OPTIONS = TOKEN_OUTPUT_FIELDS.map(field => ({
+export const OUTPUT_FIELD_OPTIONS = Object.keys(ApiTokenResponseSchema.shape).map(field => ({
   value: field,
   label: field.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase()),
 }));

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/hooks/useTokenList.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/hooks/useTokenList.ts
@@ -10,7 +10,6 @@ export const useTokenList = (initialFamily: string = "ethereum") => {
   const [selectedFamilyOption, setSelectedFamilyOption] = useState<FamilyOption | null>(
     initialOption,
   );
-  const [isStaging, setIsStaging] = useState<boolean>(true);
   const [pageSize, setPageSize] = useState<number>(1000);
   const [selectedOutputFields, setSelectedOutputFields] = useState<string[]>([
     ...TOKEN_OUTPUT_FIELDS,
@@ -64,10 +63,6 @@ export const useTokenList = (initialFamily: string = "ethereum") => {
     refetch();
   };
 
-  const handleToggleStaging = () => {
-    setIsStaging(!isStaging);
-  };
-
   const handleLoadMore = () => {
     if (loadNext) {
       loadNext();
@@ -109,7 +104,6 @@ export const useTokenList = (initialFamily: string = "ethereum") => {
     setRef("");
     setSelectedOutputFields([...TOKEN_OUTPUT_FIELDS]);
     setPageSize(1000);
-    setIsStaging(true);
     setSelectedFamilyOption(FAMILY_OPTIONS[0]);
   };
 
@@ -119,7 +113,6 @@ export const useTokenList = (initialFamily: string = "ethereum") => {
 
   return {
     selectedFamilyOption,
-    isStaging,
     pageSize,
     selectedOutputFields,
     isOptionsOpen,
@@ -139,7 +132,6 @@ export const useTokenList = (initialFamily: string = "ethereum") => {
     handleFamilyChange,
     handlePageSizeChange,
     handleRefresh,
-    handleToggleStaging,
     handleLoadMore,
     toggleOptionsPanel,
     toggleTokenExpanded,

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/hooks/useTokenList.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/hooks/useTokenList.ts
@@ -10,7 +10,7 @@ export const useTokenList = (initialFamily: string = "ethereum") => {
     initialOption,
   );
   const [pageSize, setPageSize] = useState<number>(1000);
-  const [selectedOutputFields, setSelectedOutputFields] = useState<string[]>(
+  const [selectedOutputFields, setSelectedOutputFields] = useState<string[]>(() =>
     OUTPUT_FIELD_OPTIONS.map(o => o.value),
   );
   const [isOptionsOpen, setIsOptionsOpen] = useState<boolean>(true);

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/hooks/useTokenList.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/hooks/useTokenList.ts
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useTokensData } from "@features/platform-currencies";
-import { TOKEN_OUTPUT_FIELDS } from "@domain/api-currency-token";
-import { FAMILY_OPTIONS } from "../constants";
+import { FAMILY_OPTIONS, OUTPUT_FIELD_OPTIONS } from "../constants";
 import { FamilyOption } from "../types";
 
 export const useTokenList = (initialFamily: string = "ethereum") => {
@@ -11,9 +10,9 @@ export const useTokenList = (initialFamily: string = "ethereum") => {
     initialOption,
   );
   const [pageSize, setPageSize] = useState<number>(1000);
-  const [selectedOutputFields, setSelectedOutputFields] = useState<string[]>([
-    ...TOKEN_OUTPUT_FIELDS,
-  ]);
+  const [selectedOutputFields, setSelectedOutputFields] = useState<string[]>(
+    OUTPUT_FIELD_OPTIONS.map(o => o.value),
+  );
   const [isOptionsOpen, setIsOptionsOpen] = useState<boolean>(true);
   const [expandedTokenIds, setExpandedTokenIds] = useState<Set<string>>(new Set());
   const [limit, setLimit] = useState<string>("");
@@ -92,7 +91,7 @@ export const useTokenList = (initialFamily: string = "ethereum") => {
   };
 
   const selectAllOutputFields = () => {
-    setSelectedOutputFields([...TOKEN_OUTPUT_FIELDS]);
+    setSelectedOutputFields(OUTPUT_FIELD_OPTIONS.map(o => o.value));
   };
 
   const deselectAllOutputFields = () => {
@@ -102,7 +101,7 @@ export const useTokenList = (initialFamily: string = "ethereum") => {
   const handleReset = () => {
     setLimit("");
     setRef("");
-    setSelectedOutputFields([...TOKEN_OUTPUT_FIELDS]);
+    setSelectedOutputFields(OUTPUT_FIELD_OPTIONS.map(o => o.value));
     setPageSize(1000);
     setSelectedFamilyOption(FAMILY_OPTIONS[0]);
   };

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/hooks/useTokenList.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CryptoAssetsList/hooks/useTokenList.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { useTokensData } from "@ledgerhq/cryptoassets/cal-client/hooks/useTokensData";
-import { TOKEN_OUTPUT_FIELDS } from "@ledgerhq/cryptoassets/cal-client/state-manager/fields";
+import { useTokensData } from "@features/platform-currencies";
+import { TOKEN_OUTPUT_FIELDS } from "@domain/api-currency-token";
 import { FAMILY_OPTIONS } from "../constants";
 import { FamilyOption } from "../types";
 
@@ -25,7 +25,6 @@ export const useTokenList = (initialFamily: string = "ethereum") => {
 
   const { data, isLoading, error, loadNext, refetch } = useTokensData({
     networkFamily: selectedFamily,
-    isStaging,
     pageSize,
     output: selectedOutputFields.length > 0 ? selectedOutputFields : undefined,
     limit: limitNumber,

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CustomCALRefInput.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CustomCALRefInput.tsx
@@ -6,7 +6,7 @@ import Input from "~/renderer/components/Input";
 import { Switch, Button } from "@ledgerhq/lumen-ui-react";
 import Box from "~/renderer/components/Box";
 import { useTranslation } from "react-i18next";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { prepareCurrency } from "~/renderer/bridge/cache";
 
 const CustomCALRefInput = () => {

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/utils.ts
@@ -1,7 +1,7 @@
 import { genAccount } from "@ledgerhq/live-common/mock/account";
 import { genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { listSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { initAccounts } from "~/renderer/actions/accounts";
 import {

--- a/domain/api/currency-token/src/api.ts
+++ b/domain/api/currency-token/src/api.ts
@@ -32,6 +32,8 @@ import {
   validateAndTransformSingleTokenResponse,
 } from "./internals";
 
+export { TOKEN_OUTPUT_FIELDS };
+
 /**
  * Builds this package's slice of the thunk `extraArgument`. RTK leaves `extraArgument` untyped, so
  * this is the one compile- and runtime-checked entry point: `parse` fails fast at app init if the CAL

--- a/domain/api/currency-token/src/api.ts
+++ b/domain/api/currency-token/src/api.ts
@@ -7,7 +7,7 @@ import {
   type FetchBaseQueryError,
 } from "@reduxjs/toolkit/query/react";
 import type { TokenCurrency } from "@domain/entity-currency-token";
-import { CalApiExtraSchema } from "./schema";
+import { ApiTokenResponseSchema, CalApiExtraSchema } from "./schema";
 import {
   type CalApiExtra,
   type GetTokensDataParams,
@@ -22,7 +22,6 @@ import {
   HEADER_X_LEDGER_CLIENT_VERSION,
   HEADER_X_LEDGER_COMMIT,
   MAX_RETRIES,
-  TOKEN_OUTPUT_FIELDS,
   TOKEN_TAGS,
   commitHeaderMissingError,
   currencyNotFoundError,
@@ -32,7 +31,7 @@ import {
   validateAndTransformSingleTokenResponse,
 } from "./internals";
 
-export { TOKEN_OUTPUT_FIELDS };
+const TOKEN_OUTPUT_FIELDS = Object.keys(ApiTokenResponseSchema.shape);
 
 /**
  * Builds this package's slice of the thunk `extraArgument`. RTK leaves `extraArgument` untyped, so

--- a/domain/api/currency-token/src/internals/utils.test.ts
+++ b/domain/api/currency-token/src/internals/utils.test.ts
@@ -6,12 +6,10 @@ jest.mock("../converter", () => ({
 
 import { convertApiToken } from "../converter";
 import {
-  TOKEN_OUTPUT_FIELDS,
   transformTokensResponse,
   transformApiTokenToTokenCurrency,
   validateAndTransformSingleTokenResponse,
 } from "./utils";
-import { ApiTokenResponseSchema } from "../schema";
 import { mockApiTokenResponse, mockTokenCurrency } from "../fixtures";
 
 const mockConvert = convertApiToken as jest.MockedFunction<typeof convertApiToken>;
@@ -19,18 +17,6 @@ const mockConvert = convertApiToken as jest.MockedFunction<typeof convertApiToke
 beforeEach(() => {
   jest.clearAllMocks();
   mockConvert.mockReturnValue(mockTokenCurrency);
-});
-
-describe("TOKEN_OUTPUT_FIELDS", () => {
-  it("is derived from the response schema (no drift)", () => {
-    expect(TOKEN_OUTPUT_FIELDS).toEqual(Object.keys(ApiTokenResponseSchema.shape));
-  });
-
-  it("covers the fields the converter needs", () => {
-    expect(TOKEN_OUTPUT_FIELDS).toEqual(
-      expect.arrayContaining(["id", "contract_address", "units", "live_signature"]),
-    );
-  });
 });
 
 describe("transformTokensResponse", () => {

--- a/domain/api/currency-token/src/internals/utils.ts
+++ b/domain/api/currency-token/src/internals/utils.ts
@@ -1,15 +1,9 @@
 import type { FetchBaseQueryMeta } from "@reduxjs/toolkit/query/react";
 import type { TokenCurrency } from "@domain/entity-currency-token";
-import { ApiResponseSchema, ApiTokenResponseSchema } from "../schema";
+import { ApiResponseSchema } from "../schema";
 import { convertApiToken } from "../converter";
 import type { ApiTokenResponse, TokensDataWithPagination } from "../types";
 import { HEADER_X_LEDGER_NEXT } from "./constants";
-
-/**
- * Request field projection sent as the CAL `output` param. Derived from the response schema so the
- * requested fields and the validated fields can never drift apart.
- */
-export const TOKEN_OUTPUT_FIELDS = Object.keys(ApiTokenResponseSchema.shape);
 
 /** Maps a paginated CAL token response to {@link TokenCurrency} entities + the next-page cursor. */
 export function transformTokensResponse(


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Repoints all desktop UI currency reads away from `@ledgerhq/cryptoassets` and the `@ledgerhq/live-common/currencies` barrel to the new domain/feature packages. This is the UI-read layer of the repoint — the store/injection layer ([LIVE-32346](https://ledgerhq.atlassian.net/browse/LIVE-32346), [LIVE-32900](https://ledgerhq.atlassian.net/browse/LIVE-32900)) landed earlier and is already live on `develop`.

**Changes by group:**

| Group | What | Files |
|-------|------|-------|
| A | `useCurrenciesUnderFeatureFlag` → `useFeatureFlaggedCurrencies` from `@features/platform-currencies` | 7 |
| B1+B2 | `useTokensData` / `useTokenById` from `@ledgerhq/cryptoassets` → `@features/platform-currencies` | 5 |
| B3 | `useTokenByAddressInCurrency` → `useFindTokenByAddressInCurrencyQuery` from `@domain/api-currency-token` (call signature adapted) | 3 + 1 test |
| C | `TOKEN_OUTPUT_FIELDS` → `@domain/api-currency-token` (+ added missing public export) | 3 |
| D | Direct `@ledgerhq/cryptoassets` `getCryptoCurrencyById` / `findCryptoCurrencyById` → `@domain/entity-currency-crypto` | 32 |
| E | `@ledgerhq/live-common/currencies` barrel accessors → `@domain/entity-currency-{crypto,fiat}` directly | 86 |

**Intentionally not repointed:**
- `getCryptoAssetsStore` singleton — coin-module adapter, owned by `#team-coin-integration`
- `formatCurrencyUnit`, `formatShort`, `formatCurrencyUnitFragment` — `@ledgerhq/live-currency-format`, not domain
- `isTokenCurrency`, `isCryptoCurrency`, `isUTXOCompliant`, `listSupportedCurrencies`, `isCurrencySupported` — coin-module registry or helpers, stay in live-common

No runtime behaviour change: the domain registries were already injected as the backing store by [LIVE-32346](https://ledgerhq.atlassian.net/browse/LIVE-32346) + [LIVE-32900](https://ledgerhq.atlassian.net/browse/LIVE-32900). This PR cuts the import indirection.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-31956](https://ledgerhq.atlassian.net/browse/LIVE-31956) — Repoint Desktop (part of [LIVE-32343](https://ledgerhq.atlassian.net/browse/LIVE-32343) Repoint epics under [LIVE-31901](https://ledgerhq.atlassian.net/browse/LIVE-31901) Crypto Assets Architecture)
- **ADR** (if any): [LIVE-31919](https://ledgerhq.atlassian.net/browse/LIVE-31919) (setSupportedCurrencies alternative)

[LIVE-32346]: https://ledgerhq.atlassian.net/browse/LIVE-32346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-32900]: https://ledgerhq.atlassian.net/browse/LIVE-32900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-32346]: https://ledgerhq.atlassian.net/browse/LIVE-32346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ