### PR TITLE
[LWDM] refactor(live-common): repoint currencies/ submodules off @ledgerhq/cryptoassets (LIVE-34296)

### DIFF
--- a/.changeset/silent-maps-grow.md
+++ b/.changeset/silent-maps-grow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Repoint currencies/helpers.ts and currencies/color.ts off @ledgerhq/cryptoassets onto @domain/entity-currency-crypto

--- a/libs/ledger-live-common/src/currencies/color.test.ts
+++ b/libs/ledger-live-common/src/currencies/color.test.ts
@@ -1,5 +1,5 @@
 import { getCurrencyColor } from "./color";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 
 const defaultColor = "#999";

--- a/libs/ledger-live-common/src/currencies/color.ts
+++ b/libs/ledger-live-common/src/currencies/color.ts
@@ -1,5 +1,5 @@
 import type { Currency } from "@ledgerhq/types-cryptoassets";
-import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 const defaultColor = "#999";
 

--- a/libs/ledger-live-common/src/currencies/helpers.ts
+++ b/libs/ledger-live-common/src/currencies/helpers.ts
@@ -1,5 +1,5 @@
 import { Currency, CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 export function isCryptoCurrency(currency: Currency): currency is CryptoCurrency {
   return currency.type === "CryptoCurrency";


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Repoints the three remaining `@ledgerhq/cryptoassets` **value** imports inside `libs/ledger-live-common/src/currencies/` to `@domain/entity-currency-crypto`.

PR [#19403](https://github.com/LedgerHQ/ledger-live/pull/19403) already repointed the `currencies/index.ts` barrel. This PR covers the submodule files that still imported directly:

| File | Import swapped |
|---|---|
| `src/currencies/helpers.ts` | `findCryptoCurrencyById` → `@domain/entity-currency-crypto` |
| `src/currencies/color.ts` | `findCryptoCurrencyById` → `@domain/entity-currency-crypto` |
| `src/currencies/color.test.ts` | `getCryptoCurrencyById` → `@domain/entity-currency-crypto` |

`src/currencies/**` now has **zero** `@ledgerhq/cryptoassets` value imports.

Correctness invariants preserved:
- Alias keys (`osmosis` → `osmo`, `groestlcoin` → `groestcoin`, `lbry` → `LBRY`) resolve via `CRYPTO_CURRENCY_ALIASES` in the domain accessor.
- `findCryptoCurrencyById` (undefined on miss) and `getCryptoCurrencyById` (throws on miss) semantics unchanged.
- `CryptoCurrency["family"]` return type in `helpers.ts` is compatible (`string` in both legacy and domain).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34296](https://ledgerhq.atlassian.net/browse/LIVE-34296) — part of [LIVE-31955](https://ledgerhq.atlassian.net/browse/LIVE-31955) (repoint live-common currencies off cryptoassets)

[LIVE-34296]: https://ledgerhq.atlassian.net/browse/LIVE-34296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ