### PR TITLE
[LWDM] refactor(live-common): repoint families @ledgerhq/cryptoassets currency-accessor imports to @domain/entity-currency-crypto

### DIFF
--- a/.changeset/swift-domains-repoint.md
+++ b/.changeset/swift-domains-repoint.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+repoint families direct @ledgerhq/cryptoassets currency-accessor imports to @domain/entity-currency-crypto

--- a/libs/ledger-live-common/src/families/aleo/__mocks__/currency.mock.ts
+++ b/libs/ledger-live-common/src/families/aleo/__mocks__/currency.mock.ts
@@ -1,3 +1,3 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 export const aleoCurrency = getCryptoCurrencyById("aleo");

--- a/libs/ledger-live-common/src/families/aleo/react.test.ts
+++ b/libs/ledger-live-common/src/families/aleo/react.test.ts
@@ -9,7 +9,7 @@ import { configureStore } from "@reduxjs/toolkit";
 import { Subject } from "rxjs";
 import type { Account } from "@ledgerhq/types-live";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { AleoAccount } from "./types";
 import { aleoPrivateSyncProgress$ } from "./privateSyncProgress";

--- a/libs/ledger-live-common/src/families/bitcoin/editTransaction/rbfReplaceCancel.integ.test.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/editTransaction/rbfReplaceCancel.integ.test.ts
@@ -12,9 +12,8 @@
  * - Single UTXO and multiple UTXO account fixtures.
  */
 import { BigNumber } from "bignumber.js";
-import { listCryptoCurrencies } from "@ledgerhq/cryptoassets/currencies";
 import { emptyHistoryCache } from "@ledgerhq/ledger-wallet-framework/account/index";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { DerivationModes } from "@ledgerhq/coin-bitcoin/wallet-btc/index";
 import BitcoinLikeWallet from "@ledgerhq/coin-bitcoin/wallet-btc/wallet";
 import type { Account as WalletAccount } from "@ledgerhq/coin-bitcoin/wallet-btc/index";
@@ -66,7 +65,7 @@ function createBitcoinAccount(
   walletAccount: WalletAccount,
   pendingOp: { hash: string; recipients: string[]; value: number },
 ): BitcoinAccount {
-  const currency = listCryptoCurrencies(true).find(c => c.id === "bitcoin")!;
+  const currency = getCryptoCurrencyById("bitcoin");
   return {
     type: "Account",
     id: "test-btc-account-rbf",

--- a/libs/ledger-live-common/src/families/cardano/bridge/api.test.ts
+++ b/libs/ledger-live-common/src/families/cardano/bridge/api.test.ts
@@ -3,7 +3,7 @@ import type { AssetInfo } from "@ledgerhq/coin-module-framework/api/types";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 import cardanoBridge, { getAssetFromToken, getTokenFromAsset } from "./api";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 jest.mock("@ledgerhq/cryptoassets/state");
 

--- a/libs/ledger-live-common/src/families/celo/bridge/api.test.ts
+++ b/libs/ledger-live-common/src/families/celo/bridge/api.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import type { AssetInfo } from "@ledgerhq/coin-module-framework/api/types";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 import { computeIntentType, getAssetFromToken, getTokenFromAsset } from "./api";

--- a/libs/ledger-live-common/src/families/cosmos/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/cosmos/bridge/mock.ts
@@ -16,7 +16,7 @@ import {
   getSerializedAddressParameters,
   updateTransaction,
 } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import {
   AmountRequired,
   FeeTooHigh,

--- a/libs/ledger-live-common/src/families/evm/bridge/api.test.ts
+++ b/libs/ledger-live-common/src/families/evm/bridge/api.test.ts
@@ -1,4 +1,4 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { getCryptoAssetsStore, setCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { setCoinConfig } from "@ledgerhq/coin-evm/config";
 import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";

--- a/libs/ledger-live-common/src/families/evm/common.fixtures.ts
+++ b/libs/ledger-live-common/src/families/evm/common.fixtures.ts
@@ -10,7 +10,7 @@ import {
   getDerivationScheme,
   runDerivationScheme,
 } from "@ledgerhq/ledger-wallet-framework/derivation";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account, DerivationMode, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";

--- a/libs/ledger-live-common/src/families/evm/deviceTransactionConfig.test.ts
+++ b/libs/ledger-live-common/src/families/evm/deviceTransactionConfig.test.ts
@@ -1,4 +1,4 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { setCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { encodeNftId } from "@ledgerhq/ledger-wallet-framework/nft/nftId";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";

--- a/libs/ledger-live-common/src/families/evm/editTransaction/getEditTransactionPatch.test.ts
+++ b/libs/ledger-live-common/src/families/evm/editTransaction/getEditTransactionPatch.test.ts
@@ -1,4 +1,4 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import BigNumber from "bignumber.js";
 import { getCoinConfig } from "@ledgerhq/coin-evm/config";
 import { makeAccount } from "../common.fixtures";

--- a/libs/ledger-live-common/src/families/evm/editTransaction/getFormattedFeeFields.test.ts
+++ b/libs/ledger-live-common/src/families/evm/editTransaction/getFormattedFeeFields.test.ts
@@ -1,4 +1,4 @@
-import { cryptocurrenciesById } from "@ledgerhq/cryptoassets/currencies";
+import { CRYPTO_CURRENCIES_REGISTRY } from "@domain/entity-currency-crypto";
 import { Account } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { getCoinConfig } from "@ledgerhq/coin-evm/config";
@@ -32,12 +32,12 @@ const testCases: {
   account: Account;
   type2Transaction: EvmTransaction;
   type0Transaction: EvmTransaction;
-}[] = Object.values(cryptocurrenciesById)
+}[] = Object.values(CRYPTO_CURRENCIES_REGISTRY)
   .filter(currency => currency.family === "evm")
   .map(currency => {
     return {
       currencyName: currency.name,
-      account: { type: "Account", currency } as Account,
+      account: { type: "Account", currency } as unknown as Account,
       type2Transaction: dummyType2Transaction,
       type0Transaction: dummyType0Transaction,
     };

--- a/libs/ledger-live-common/src/families/evm/editTransaction/operation.test.ts
+++ b/libs/ledger-live-common/src/families/evm/editTransaction/operation.test.ts
@@ -1,4 +1,4 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import {
   genAccount,
   genOperation,

--- a/libs/ledger-live-common/src/families/evm/getAddress.test.ts
+++ b/libs/ledger-live-common/src/families/evm/getAddress.test.ts
@@ -1,4 +1,4 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import eip55 from "eip55";
 import resolver from "./getAddress";
 import type { EvmSigner } from "@ledgerhq/live-signer-evm";

--- a/libs/ledger-live-common/src/families/evm/walletApiAdapter.ts
+++ b/libs/ledger-live-common/src/families/evm/walletApiAdapter.ts
@@ -6,7 +6,7 @@ import {
   GetWalletAPITransactionSignFlowInfos,
 } from "../../wallet-api/types";
 import BigNumber from "bignumber.js";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { AccountLike } from "@ledgerhq/types-live";
 import { DEFAULT_GAS_LIMIT, DEFAULT_NONCE } from "@ledgerhq/coin-evm/utils";
 

--- a/libs/ledger-live-common/src/families/solana/bridge/api.test.ts
+++ b/libs/ledger-live-common/src/families/solana/bridge/api.test.ts
@@ -3,7 +3,7 @@ import type { AssetInfo } from "@ledgerhq/coin-module-framework/api/types";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 import { getAssetFromToken, getTokenFromAsset, computeIntentType } from "./api";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 jest.mock("@ledgerhq/cryptoassets/state");
 

--- a/libs/ledger-live-common/src/families/solana/signer.test.ts
+++ b/libs/ledger-live-common/src/families/solana/signer.test.ts
@@ -7,7 +7,7 @@ jest.mock("../../hw/dmkUtils");
 import { LegacySignerSolana, DmkSignerSol } from "@ledgerhq/live-signer-solana";
 import { isDmkTransport } from "../../hw/dmkUtils";
 import Transport from "@ledgerhq/hw-transport";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { DeviceManagementKit } from "@ledgerhq/device-management-kit";
 
 const MockedLegacySignerSolana = LegacySignerSolana as jest.MockedClass<typeof LegacySignerSolana>;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Removes direct `@ledgerhq/cryptoassets` value imports for currency-accessor functions from all 16 files under `libs/ledger-live-common/src/families/**`, routing them to `@domain/entity-currency-crypto` instead.

**Symbols migrated:**
- `getCryptoCurrencyById` → `getCryptoCurrencyById` from `@domain/entity-currency-crypto` (identical throw semantics)
- `cryptocurrenciesById` → `CRYPTO_CURRENCIES_REGISTRY` from `@domain/entity-currency-crypto` (same `Record<string, CryptoCurrency>` shape)
- `listCryptoCurrencies().find(c => c.id === "bitcoin")` → `getCryptoCurrencyById("bitcoin")` (bitcoin/editTransaction)

**Out of scope:** CAL store accessors (`getCryptoAssetsStore`, `setCryptoAssetsStore`) remain on `@ledgerhq/cryptoassets/state` — separate migration. Type imports (`@ledgerhq/types-cryptoassets`) are [LIVE-34297](https://ledgerhq.atlassian.net/browse/LIVE-34297).

One test cast widened to `as unknown as Account` in `getFormattedFeeFields.test.ts` — the `id: CurrencyId` brand on domain `CryptoCurrency` made the existing partial-object cast ambiguous; `as unknown as` is the standard pattern for intentionally incomplete test stubs.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34298](https://ledgerhq.atlassian.net/browse/LIVE-34298) — families value repoint (slice 2 of [LIVE-31955](https://ledgerhq.atlassian.net/browse/LIVE-31955))
- **ADR** (if any): n/a

[LIVE-34297]: https://ledgerhq.atlassian.net/browse/LIVE-34297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ