### PR TITLE
refactor(cli): repoint currency accessor imports to @domain/entity-currency-crypto

### DIFF
--- a/.changeset/live-cli-currencies-repoint-domain.md
+++ b/.changeset/live-cli-currencies-repoint-domain.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-cli": minor
+---
+
+Repoint currency accessor imports off the `@ledgerhq/live-common/currencies` barrel onto `@domain/entity-currency-crypto` directly. `findCryptoCurrencyByKeyword`, `findCryptoCurrencyById`, and `getCryptoCurrencyById` are now sourced from the domain entity package. Runtime behaviour is unchanged.

--- a/apps/cli/src/commands/blockchain/tokenAllowance.ts
+++ b/apps/cli/src/commands/blockchain/tokenAllowance.ts
@@ -2,11 +2,8 @@ import { BigNumber } from "bignumber.js";
 import { from } from "rxjs";
 import { concatMap } from "rxjs/operators";
 import type { Account, DerivationMode } from "@ledgerhq/types-live";
-import {
-  formatCurrencyUnit,
-  findCryptoCurrencyByKeyword,
-  getCryptoCurrencyById,
-} from "@ledgerhq/live-common/currencies/index";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { findCryptoCurrencyByKeyword, getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import {
   encodeAccountId,
   decodeAccountId,

--- a/apps/cli/src/scan.ts
+++ b/apps/cli/src/scan.ts
@@ -19,7 +19,7 @@ import {
   findCryptoCurrencyByKeyword,
   findCryptoCurrencyById,
   getCryptoCurrencyById,
-} from "@ledgerhq/live-common/currencies/index";
+} from "@domain/entity-currency-crypto";
 import { makeBridgeCacheSystem } from "@ledgerhq/live-common/bridge/cache";
 import getAppAndVersion from "@ledgerhq/live-common/hw/getAppAndVersion";
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Moves three crypto currency accessor imports in the CLI app off the `@ledgerhq/live-common/currencies` barrel and onto `@domain/entity-currency-crypto` directly:

- `findCryptoCurrencyByKeyword`
- `findCryptoCurrencyById`
- `getCryptoCurrencyById`

`formatCurrencyUnit` and `parseCurrencyUnit` (formatting utilities backed by `@ledgerhq/live-currency-format`) remain in live-common. Runtime behaviour is unchanged — the domain registry is already the single source of truth via the injected crypto store (LIVE-32900).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-31958](https://ledgerhq.atlassian.net/browse/LIVE-31958) — part of the Repoint epic [LIVE-32343](https://ledgerhq.atlassian.net/browse/LIVE-32343)
- **ADR** (if any): [LIVE-31919](https://ledgerhq.atlassian.net/browse/LIVE-31919) (supported-currencies ADR); depends on [LIVE-31955](https://ledgerhq.atlassian.net/browse/LIVE-31955) (live-common barrel repoint, merged)

[LIVE-31958]: https://ledgerhq.atlassian.net/browse/LIVE-31958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-32343]: https://ledgerhq.atlassian.net/browse/LIVE-32343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-31919]: https://ledgerhq.atlassian.net/browse/LIVE-31919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-31955]: https://ledgerhq.atlassian.net/browse/LIVE-31955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ