### PR TITLE
[LWDM] chore(coin-evm): add config driven validator address resolution

### DIFF
--- a/.changeset/refactor-staking-resolve-validator.md
+++ b/.changeset/refactor-staking-resolve-validator.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+Replace `typeof d[0]` type-sniffing in `resolveStakingValidator` with a per-chain `resolveValidatorAddress` on `StakingContractConfig`. Fixes 0G operation drawer pointing to delegator address instead of validator.

--- a/libs/coin-modules/coin-evm/src/staking/contracts.ts
+++ b/libs/coin-modules/coin-evm/src/staking/contracts.ts
@@ -1,5 +1,7 @@
+import { ethers } from "ethers";
 import type { StakingContractConfig } from "../types/staking";
 import { USEI_TO_EVM_SCALE } from "../utils";
+import { getValidatorAddressById } from "./validators/monadResolver";
 
 export const STAKING_CONTRACTS: Record<string, StakingContractConfig> = {
   // Sei EVM staking
@@ -69,6 +71,9 @@ export const STAKING_CONTRACTS: Record<string, StakingContractConfig> = {
     // Reserve 0.1 SEI (≈ 830k gas at 120 gwei) so that fee spikes between
     // prepareTransaction and broadcast do not cause the staking precompile to revert.
     delegationMaxAmountReserve: 10n ** 17n, // 0.1 SEI in wei (10^17)
+    resolveValidatorAddress: async d => {
+      return typeof d[0] === "string" ? d[0] : null;
+    },
   },
 
   // Celo staking
@@ -81,6 +86,9 @@ export const STAKING_CONTRACTS: Record<string, StakingContractConfig> = {
       undelegate: "revokeDelegatedGovernanceVotes",
       getStakedBalance: "getAccountTotalLockedGold",
       getUnstakedBalance: "getTotalPendingWithdrawals",
+    },
+    resolveValidatorAddress: async d => {
+      return typeof d[0] === "string" ? d[0] : null;
     },
   },
 
@@ -135,6 +143,11 @@ export const STAKING_CONTRACTS: Record<string, StakingContractConfig> = {
     // Including the delegation-queue delay (1–2 epochs), the maximum wait is ~3 epochs ≈ 17 h.
     // Source: https://docs.monad.xyz/monad-arch/consensus/staking (WITHDRAWAL_DELAY constant)
     unbondingPeriodDays: 0.75,
+    resolveValidatorAddress: d => {
+      return typeof d[0] === "bigint"
+        ? getValidatorAddressById("monad", d[0])
+        : Promise.resolve(null);
+    },
   },
 
   // 0G staking - factory-per-validator model.
@@ -162,6 +175,9 @@ export const STAKING_CONTRACTS: Record<string, StakingContractConfig> = {
     unbondingPeriodDays: 2.31,
     explorerConfig: {
       validatorUrl: "https://explorer.0g.ai/mainnet/validators/$address/delegators",
+    },
+    resolveValidatorAddress: async (_, contractAddress) => {
+      return contractAddress ? ethers.getAddress(contractAddress) : null;
     },
   },
 

--- a/libs/coin-modules/coin-evm/src/staking/redelegations.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/redelegations.test.ts
@@ -330,6 +330,30 @@ describe("redelegations", () => {
       });
     });
 
+    describe("delegate (0G, recipient-keyed validator)", () => {
+      it("resolves the validator address from operation.recipients[0] ignoring decoded[0]", async () => {
+        const op = makeOperation({
+          type: "DELEGATE",
+          recipients: ["0x2222222222222222222222222222222222222222"],
+          extra: {
+            contractPayload: new ethers.Interface(
+              getStakingABI("zero_gravity")!,
+            ).encodeFunctionData("delegate", ["0x1111111111111111111111111111111111111111"]),
+          },
+        });
+
+        const result = await resolveStakingValidator(
+          { id: "zero_gravity" } as CryptoCurrency,
+          op,
+          "delegate",
+        );
+
+        expect(result).toMatchObject({
+          validatorAddress: "0x2222222222222222222222222222222222222222",
+        });
+      });
+    });
+
     describe("delegate", () => {
       it("should decode validator from cached contractPayload", async () => {
         const op = makeOperation({

--- a/libs/coin-modules/coin-evm/src/staking/redelegations.ts
+++ b/libs/coin-modules/coin-evm/src/staking/redelegations.ts
@@ -7,7 +7,6 @@ import type { Operation, StakingRedelegation } from "@ledgerhq/types-live";
 import type { RedelegationStrategy } from "../types/staking";
 import { STAKING_CONTRACTS } from "./contracts";
 import { getStakingABI } from "./abis";
-import { getValidatorAddressById } from "./validators/monad";
 import { getCoinConfig } from "../config";
 import { withApi } from "../network/node/rpc.common";
 import { isExternalNodeConfig } from "../network/node/types";
@@ -260,14 +259,13 @@ export async function resolveRedelegationValidators(
 
 /**
  * Resolve the validator address for a single DELEGATE, UNDELEGATE or WITHDRAW operation.
- *
- * The validator address is the first ABI argument for all three operations.
  * Follows the same payload-resolution strategy as `resolveRedelegationValidators`:
  * cached `contractPayload` first, then RPC fallback.
  *
- * NOTE: the returned `amount` is only meaningful for DELEGATE/UNDELEGATE, where the
- * second ABI argument is the staked amount. For WITHDRAW the second argument is a slot
- * identifier (`withdrawId`), not an amount, so callers should rely on `operation.value`.
+ * NOTE: `amount` is decoded from the second ABI argument and is `null` when absent (e.g.
+ * Monad/0G `delegate` where the stake is `msg.value`) or when it is a non-numeric slot
+ * identifier (e.g. WITHDRAW's `withdrawId`). Callers should use `operation.value` when
+ * `amount` is `null`.
  *
  * Returns `null` when the payload cannot be obtained or decoded.
  */
@@ -290,14 +288,9 @@ export async function resolveStakingValidator(
   try {
     const iface = new ethers.Interface(abi);
     const d = iface.decodeFunctionData(functionName, payload);
-    const [first, rawAmount] = d;
+    const [, rawAmount] = d;
 
-    const validatorAddress =
-      typeof first === "string"
-        ? first
-        : typeof first === "bigint"
-          ? await getValidatorAddressById(currency.id, first)
-          : null;
+    const validatorAddress = await config.resolveValidatorAddress(d, operation.recipients[0]);
     if (!validatorAddress) return null;
 
     const scale = config.calldataAmountScale ?? 1n;

--- a/libs/coin-modules/coin-evm/src/staking/validators/monad.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators/monad.test.ts
@@ -5,7 +5,8 @@ import monadAbi from "../../abis/monad.abi.json";
 import { getCoinConfig } from "../../config";
 import { withApi } from "../../network/node/rpc.common";
 import { clearValidatorsCache, getValidators } from "./index";
-import { fetchMonadStakes, getValidatorAddressById } from "./monad";
+import { fetchMonadStakes } from "./monad";
+import { getValidatorAddressById } from "./monadResolver";
 
 jest.mock("../../config", () => ({
   __esModule: true,

--- a/libs/coin-modules/coin-evm/src/staking/validators/monad.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators/monad.ts
@@ -15,6 +15,7 @@ import type { StakingContractConfig } from "../../types/staking";
 import { getStakingABI } from "../abis";
 import { STAKING_CONTRACTS } from "../contracts";
 import type { ValidatorApi } from "./types";
+import { callGetValidator } from "./monadResolver";
 
 // Monad staking precompile read functions are marked `nonpayable` (not `view`)
 // in the ABI because precompiles can consume all gas on invalid arguments — but
@@ -77,22 +78,6 @@ const validatorNameCache = makeLRUCache(
 );
 
 type ValidatorSetRaw = [boolean, bigint, bigint[]];
-// getValidator returns 12 fields; we only type/validate the ones we read:
-// [0] authAddress, [2] stake, [4] commission, [10] secpPubkey (bytes -> hex string).
-type ValidatorRaw = [
-  string,
-  unknown,
-  bigint,
-  unknown,
-  bigint,
-  unknown,
-  unknown,
-  unknown,
-  unknown,
-  unknown,
-  string,
-];
-
 function isValidatorSetRaw(value: unknown): value is ValidatorSetRaw {
   return (
     Array.isArray(value) &&
@@ -100,16 +85,6 @@ function isValidatorSetRaw(value: unknown): value is ValidatorSetRaw {
     typeof value[1] === "bigint" &&
     Array.isArray(value[2]) &&
     value[2].every(item => typeof item === "bigint")
-  );
-}
-
-function isValidatorRaw(value: unknown): value is ValidatorRaw {
-  return (
-    Array.isArray(value) &&
-    typeof value[0] === "string" &&
-    typeof value[2] === "bigint" &&
-    typeof value[4] === "bigint" &&
-    typeof value[10] === "string"
   );
 }
 
@@ -167,18 +142,6 @@ const resolveContext = (currencyId: string): ResolvedContext | undefined => {
   }
 };
 
-const callGetValidator = async (
-  provider: JsonRpcProvider,
-  iface: ethers.Interface,
-  contractAddress: string,
-  valId: bigint,
-): Promise<ValidatorRaw | null> => {
-  const data = iface.encodeFunctionData("getValidator", [valId]);
-  const raw = await provider.call({ to: contractAddress, data });
-  const decoded = iface.decodeFunctionResult("getValidator", raw);
-  return isValidatorRaw(decoded) ? decoded : null;
-};
-
 const fetchValidatorDetails = async (
   currencyId: string,
   provider: JsonRpcProvider,
@@ -229,35 +192,6 @@ const fetchValidatorDetails = async (
   }
 
   return items;
-};
-
-export const getValidatorAddressById = async (
-  currencyId: string,
-  valId: bigint,
-): Promise<string | null> => {
-  const ctx = resolveContext(currencyId);
-  if (!ctx) return null;
-
-  try {
-    return await withApi(
-      ctx.currency,
-      async provider => {
-        const iface = new ethers.Interface(ctx.abi);
-        const decoded = await callGetValidator(provider, iface, ctx.contractAddress, valId);
-        if (!decoded) return null;
-        const [, , , , , , , , , , secpPubkey] = decoded;
-        return ethers.computeAddress(secpPubkey);
-      },
-      ctx.node,
-    );
-  } catch (error) {
-    log("coin-evm/staking", "getValidatorAddressById: getValidator call failed", {
-      currencyId,
-      valId: valId.toString(),
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return null;
-  }
 };
 
 const fetchPage = async (

--- a/libs/coin-modules/coin-evm/src/staking/validators/monadResolver.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators/monadResolver.ts
@@ -1,0 +1,82 @@
+import { ethers, type JsonRpcProvider } from "ethers";
+import { log } from "@ledgerhq/logs";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCoinConfig } from "../../config";
+import { withApi } from "../../network/node/rpc.common";
+import { isExternalNodeConfig } from "../../network/node/types";
+import { getStakingABI } from "../abis";
+
+// TODO: stopgap - hardcoded because contracts.ts cannot import from monad.ts (circular dep).
+// Fix when getStakingApi(currencyId) factory replaces the Record in contracts.ts.
+const MONAD_PRECOMPILE = "0x0000000000000000000000000000000000001000";
+
+// getValidator returns 12 fields; we only type/validate the ones we read:
+// [0] authAddress, [2] stake, [4] commission, [10] secpPubkey (bytes -> hex string).
+export type ValidatorRaw = [
+  string,
+  unknown,
+  bigint,
+  unknown,
+  bigint,
+  unknown,
+  unknown,
+  unknown,
+  unknown,
+  unknown,
+  string,
+];
+
+export function isValidatorRaw(value: unknown): value is ValidatorRaw {
+  return (
+    Array.isArray(value) &&
+    typeof value[0] === "string" &&
+    typeof value[2] === "bigint" &&
+    typeof value[4] === "bigint" &&
+    typeof value[10] === "string"
+  );
+}
+
+export const callGetValidator = async (
+  provider: JsonRpcProvider,
+  iface: ethers.Interface,
+  contractAddress: string,
+  valId: bigint,
+): Promise<ValidatorRaw | null> => {
+  const data = iface.encodeFunctionData("getValidator", [valId]);
+  const raw = await provider.call({ to: contractAddress, data });
+  const decoded = iface.decodeFunctionResult("getValidator", raw);
+  return isValidatorRaw(decoded) ? decoded : null;
+};
+
+export const getValidatorAddressById = async (
+  currencyId: string,
+  valId: bigint,
+): Promise<string | null> => {
+  const abi = getStakingABI(currencyId);
+  if (!abi) return null;
+
+  const node = getCoinConfig(currencyId).info.node;
+  if (!isExternalNodeConfig(node)) return null;
+
+  try {
+    const currency = getCryptoCurrencyById(currencyId);
+    return await withApi(
+      currency,
+      async provider => {
+        const iface = new ethers.Interface(abi as ethers.InterfaceAbi);
+        const decoded = await callGetValidator(provider, iface, MONAD_PRECOMPILE, valId);
+        if (!decoded) return null;
+        const [, , , , , , , , , , secpPubkey] = decoded;
+        return ethers.computeAddress(secpPubkey);
+      },
+      node,
+    );
+  } catch (error) {
+    log("coin-evm/staking", "getValidatorAddressById: getValidator call failed", {
+      currencyId,
+      valId: valId.toString(),
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+};

--- a/libs/coin-modules/coin-evm/src/staking/validators/zero_gravity.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators/zero_gravity.test.ts
@@ -1,3 +1,4 @@
+import { ethers } from "ethers";
 import network from "@ledgerhq/live-network";
 import { clearValidatorsCache, getValidators } from "./index";
 
@@ -35,7 +36,7 @@ describe("staking/validators/zero_gravity", () => {
 
     const page = await getValidators("zero_gravity");
 
-    expect(page.items[0].validatorAddress).toEqual("0x" + addr);
+    expect(page.items[0].validatorAddress).toEqual(ethers.getAddress("0x" + addr));
   });
 
   it("uses moniker as name", async () => {
@@ -56,7 +57,7 @@ describe("staking/validators/zero_gravity", () => {
 
     const page = await getValidators("zero_gravity");
 
-    expect(page.items[0].name).toEqual("0x" + addr);
+    expect(page.items[0].name).toEqual(ethers.getAddress("0x" + addr));
   });
 
   it("converts commission_pct string to a decimal fraction", async () => {

--- a/libs/coin-modules/coin-evm/src/staking/validators/zero_gravity.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators/zero_gravity.ts
@@ -1,3 +1,4 @@
+import { ethers } from "ethers";
 import network from "@ledgerhq/live-network";
 import { log } from "@ledgerhq/logs";
 import type { Page } from "@ledgerhq/coin-module-framework/api/index";
@@ -42,14 +43,17 @@ const zeroGravityValidatorApi: ValidatorApi = {
       });
 
       const items: StakingValidatorItem[] = Array.isArray(data)
-        ? data.filter(isExploreMe0gValidator).map((v, index) => ({
-            validatorAddress: "0x" + v.addr,
-            name: v.moniker ?? "0x" + v.addr,
-            commission: parseFloat(v.commission_pct) / 100,
-            tokens: v.voting_power_tokens,
-            votingPower: index,
-            estimatedYearlyRewardsRate: 0,
-          }))
+        ? data.filter(isExploreMe0gValidator).map((v, index) => {
+            const validatorAddress = ethers.getAddress("0x" + v.addr);
+            return {
+              validatorAddress,
+              name: v.moniker ?? validatorAddress,
+              commission: parseFloat(v.commission_pct) / 100,
+              tokens: v.voting_power_tokens,
+              votingPower: index,
+              estimatedYearlyRewardsRate: 0,
+            };
+          })
         : [];
 
       return { items, next: undefined };

--- a/libs/coin-modules/coin-evm/src/types/staking.ts
+++ b/libs/coin-modules/coin-evm/src/types/staking.ts
@@ -151,6 +151,11 @@ export type StakingContractConfig = {
    * Defaults to 0n when omitted.
    */
   delegationMaxAmountReserve?: bigint;
+  /** Extract the validator address from the decoded calldata args and the called contract address (operation recipient). */
+  resolveValidatorAddress: (
+    decoded: readonly unknown[],
+    contractAddress: string | undefined,
+  ) => Promise<string | null>;
 };
 
 export type StakeCreate = {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Replace `typeof d[0]` type-sniffing in `resolveStakingValidator` with a per-chain `resolveValidatorAddress` on `StakingContractConfig`. Fixes 0G drawer showing the delegator address instead of the validator (`d[0]` is the delegator in `delegate(address delegatorAddress)`; validator = `operation.recipients[0]`).

### 🔗 Context

- Fixes review comment on [#19450](https://github.com/LedgerHQ/ledger-live/pull/19450#discussion_r3552931803)
- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-32754
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
