### PR TITLE
[LWDM] chore(coin-modules): relax oxlint rules on tests

### DIFF
--- a/libs/coin-modules/.oxlintrc.json
+++ b/libs/coin-modules/.oxlintrc.json
@@ -85,6 +85,8 @@
       "files": [
         "**/src/**/*.test.{ts,tsx}",
         "**/src/**/__tests__/**",
+        "**/src/**/test/**",
+        "**/src/**/tests/**",
         "**/*.integ.test.{ts,tsx}"
       ],
       "env": {
@@ -101,7 +103,8 @@
           }
         ],
         "eslint/no-console": "off",
-        "typescript/no-explicit-any": "warn"
+        "typescript/no-explicit-any": "off",
+        "typescript/consistent-type-assertions": "off"
       }
     }
   ]

--- a/libs/coin-modules/coin-aleo/src/api/index.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import type {
   BalanceOptions,
   MemoNotSupported,

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -1031,7 +1031,6 @@ describe("splitPrivateAndPublicOperations", () => {
     const opNoExtra = getMockedOperation({
       id: "no-extra",
       // Intentionally omit `transactionType` to exercise the defaulting logic.
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       extra: {} as AleoOperationExtra,
     });
 

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/ZCash.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/ZCash.test.ts
@@ -1,4 +1,3 @@
-/* eslint @typescript-eslint/consistent-type-assertions: 0 */
 import { Observable } from "rxjs";
 import type { ShieldedSyncResult, ShieldedSyncResultRaw, SyncShieldedArgs } from "../types";
 import type { StartSyncJobArgs } from "../native-engine/engine";

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/ZCashIPC.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/ZCashIPC.test.ts
@@ -1,4 +1,3 @@
-/* eslint @typescript-eslint/consistent-type-assertions: 0 */
 import type { Subscription } from "rxjs";
 import type { ShieldedSyncResultRaw, SyncShieldedArgs } from "../types";
 import type {

--- a/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.test.ts
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/consistent-type-assertions: 0 */
-
 import { Account } from "@ledgerhq/types-live";
 import { InvalidAddress } from "@ledgerhq/errors";
 import { BitcoinInput, Transaction } from "./types";

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/xpub.syncing.integ.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/xpub.syncing.integ.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import coininfo from "coininfo";

--- a/libs/coin-modules/coin-canton/src/bridge/onboard.test.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/onboard.test.ts
@@ -135,7 +135,6 @@ describe("onboard", () => {
         party_id: newPartyId,
         party_name: "test-party-name",
         public_key_fingerprint: "test-fingerprint",
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         transactions: {} as any,
         challenge_nonce: "test-nonce",
         challenge_deadline: 1735689599,

--- a/libs/coin-modules/coin-canton/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/signOperation.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import prepareTransferMock from "@ledgerhq/hw-app-canton/tests/fixtures/prepare-transfer.json";
 import { craftTransaction } from "../common-logic";
 import {

--- a/libs/coin-modules/coin-canton/src/bridge/sync.integ.test.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/sync.integ.test.ts
@@ -116,7 +116,6 @@ describe.skip("sync (devnet)", () => {
         const result = await getAccountShape(
           {
             ...ACCOUNT_SHAPE_INFO,
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             initialAccount: {
               xpub,
               operations,
@@ -191,7 +190,6 @@ describe.skip("sync (devnet)", () => {
           extra: { uid: "uid-1" },
         };
 
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         const initialAccount = {
           xpub,
           operations: [operation],

--- a/libs/coin-modules/coin-canton/src/network/gateway.integ.test.ts
+++ b/libs/coin-modules/coin-canton/src/network/gateway.integ.test.ts
@@ -25,7 +25,6 @@ const mockCurrency = createMockCantonCurrency();
  * `@ledgerhq/errors` module from live-network, which breaks instanceof and disables retries.
  */
 function readErr(error: object): { name?: string; status?: number; message: string } {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrow API error fields
   const rec = error as Record<string, unknown>;
   const out: { name?: string; status?: number; message: string } = {
     message: typeof rec.message === "string" ? rec.message : "",

--- a/libs/coin-modules/coin-canton/src/network/gateway.test.ts
+++ b/libs/coin-modules/coin-canton/src/network/gateway.test.ts
@@ -117,7 +117,6 @@ describe("isPartyAlreadyExists", () => {
 
 describe("getPartyById and getPartyByPubKey", () => {
   const mockCurrency = createMockCantonCurrency();
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const mockNetwork = network as jest.MockedFunction<typeof network>;
 
   beforeAll(() => {
@@ -167,7 +166,6 @@ describe("getPartyById and getPartyByPubKey", () => {
 
 describe("prepareOnboarding", () => {
   const mockCurrency = createMockCantonCurrency();
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const mockNetwork = network as jest.MockedFunction<typeof network>;
 
   beforeAll(() => {
@@ -206,7 +204,6 @@ describe("prepareOnboarding", () => {
 
 describe("submitOnboarding", () => {
   const mockCurrency = createMockCantonCurrency();
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const mockNetwork = network as jest.MockedFunction<typeof network>;
   const prepareResponse = createMockOnboardingPrepareResponse();
 
@@ -229,7 +226,6 @@ describe("submitOnboarding", () => {
     });
 
     expect(result).toEqual(submitResponse);
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const call = mockNetwork.mock.calls[0][0] as { data: Record<string, unknown> };
     expect(call.data).not.toHaveProperty("application_signature");
   });
@@ -245,7 +241,6 @@ describe("submitOnboarding", () => {
       applicationSignature: "app-sig",
     });
 
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const call = mockNetwork.mock.calls[0][0] as { data: { application_signature?: string } };
     expect(call.data.application_signature).toBe("app-sig");
   });
@@ -253,7 +248,6 @@ describe("submitOnboarding", () => {
 
 describe("isTopologyChangeRequired", () => {
   const mockCurrency = createMockCantonCurrency();
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const mockNetwork = network as jest.MockedFunction<typeof network>;
 
   beforeAll(() => {
@@ -294,7 +288,6 @@ describe("isTopologyChangeRequired", () => {
 describe("isTopologyChangeRequiredCached", () => {
   const mockCurrency = createMockCantonCurrency();
   const pubKey = "test-pub-key";
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const mockNetwork = network as jest.MockedFunction<typeof network>;
 
   beforeAll(() => {
@@ -330,7 +323,6 @@ describe("isTopologyChangeRequiredCached", () => {
 
 describe("getLedgerEnd, getOperations, getPendingTransferProposals, getTransferPreApproval", () => {
   const mockCurrency = createMockCantonCurrency();
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const mockNetwork = network as jest.MockedFunction<typeof network>;
 
   beforeAll(() => {
@@ -409,7 +401,6 @@ describe("getLedgerEnd, getOperations, getPendingTransferProposals, getTransferP
 
 describe("prepare and submit transaction helpers", () => {
   const mockCurrency = createMockCantonCurrency();
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const mockNetwork = network as jest.MockedFunction<typeof network>;
 
   beforeAll(() => {
@@ -640,7 +631,6 @@ describe("prepare and submit transaction helpers", () => {
 
 describe("getCalTokensCached", () => {
   const mockCurrency = createMockCantonCurrency();
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const mockNetwork = network as jest.MockedFunction<typeof network>;
 
   beforeAll(() => {
@@ -707,7 +697,6 @@ describe("getCalTokensCached", () => {
 
 describe("getBalance", () => {
   const mockCurrency = createMockCantonCurrency();
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const mockNetwork = network as jest.MockedFunction<typeof network>;
 
   beforeAll(() => {
@@ -770,12 +759,10 @@ describe("getBalance", () => {
 });
 
 describe("getEnabledInstruments", () => {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const mockCurrency = {
     id: "canton_network",
   } as unknown as CryptoCurrency;
 
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const mockNetwork = network as jest.MockedFunction<typeof network>;
 
   beforeAll(() => {
@@ -857,12 +844,10 @@ describe("getEnabledInstruments", () => {
 });
 
 describe("getEnabledInstrumentsCached", () => {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const mockCurrency = {
     id: "canton_network",
   } as unknown as CryptoCurrency;
 
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const mockNetwork = network as jest.MockedFunction<typeof network>;
 
   beforeAll(() => {

--- a/libs/coin-modules/coin-canton/src/test/cantonTestUtils.ts
+++ b/libs/coin-modules/coin-canton/src/test/cantonTestUtils.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 /**
  * Canton Testing Utilities for Ed25519 Key Generation
  *
@@ -44,7 +42,6 @@ export function generateMockKeyPair(): CantonTestKeyPair {
   const rawPublicKey = publicKeyBuffer.slice(-32);
   const publicKeyHex = rawPublicKey.toString("hex");
 
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const privateKeyPem = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
   const privateKeyDer = privateKey.export({ type: "pkcs8", format: "der" });
   const privateKeyHex = privateKeyDer.toString("hex");

--- a/libs/coin-modules/coin-canton/src/test/fixtures.ts
+++ b/libs/coin-modules/coin-canton/src/test/fixtures.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { CoinConfig } from "@ledgerhq/coin-module-framework/config";
 import {
   createEmptyHistoryCache,

--- a/libs/coin-modules/coin-cardano/src/getTransactionStatus/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-cardano/src/getTransactionStatus/getTransactionStatus.test.ts
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/consistent-type-assertions: 0 */
-
 import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 import * as sanction from "@ledgerhq/ledger-wallet-framework/sanction/index";
 import { Operation } from "@ledgerhq/types-live";

--- a/libs/coin-modules/coin-cardano/src/getTransactionStatus/handler.test.ts
+++ b/libs/coin-modules/coin-cardano/src/getTransactionStatus/handler.test.ts
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/consistent-type-assertions: 0 */
-
 import { CardanoAccount, Transaction } from "../types";
 import * as delegate from "./delegate";
 import { getTransactionStatusByTransactionMode } from "./handler";

--- a/libs/coin-modules/coin-concordium/src/bridge/validateAddress.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/validateAddress.test.ts
@@ -2,7 +2,6 @@ import type { AddressValidationCurrencyParameters } from "@ledgerhq/coin-module-
 import { validateAddress } from "./validateAddress";
 
 describe("validateAddress", () => {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const parameters = {} as unknown as AddressValidationCurrencyParameters;
 
   it("should return true for a valid Concordium address", async () => {

--- a/libs/coin-modules/coin-concordium/src/test/concordiumTestUtils.ts
+++ b/libs/coin-modules/coin-concordium/src/test/concordiumTestUtils.ts
@@ -32,7 +32,6 @@ export function generateMockKeyPair(): ConcordiumTestKeyPair {
   const rawPublicKey = publicKeyBuffer.subarray(-32); // Ed25519 public key is 32 bytes
   const publicKeyHex = rawPublicKey.toString("hex");
 
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const privateKeyPem = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
   const privateKeyDer = privateKey.export({ type: "pkcs8", format: "der" });
   const privateKeyHex = privateKeyDer.toString("hex");

--- a/libs/coin-modules/coin-cosmos/src/validateAddress.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/validateAddress.test.ts
@@ -34,7 +34,6 @@ describe("validateAddress", () => {
         currencyId: "cosmos id",
       };
 
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       mockedCryptoFactory.mockReturnValueOnce({
         prefix: expectedValue ? "cosmos" : "other",
       } as unknown as cosmosBase);
@@ -61,7 +60,6 @@ describe("validateAddress", () => {
       currencyId: "cosmos id",
     };
 
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     mockedCryptoFactory.mockReturnValueOnce({
       prefix: "juno:",
     } as unknown as cosmosBase);

--- a/libs/coin-modules/coin-evm/src/logic/common.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/common.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
-
 import { MemoNotSupported } from "@ledgerhq/coin-module-framework/api/index";
 import { TransactionIntent, BufferTxData } from "@ledgerhq/coin-module-framework/api/types";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";

--- a/libs/coin-modules/coin-evm/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBalance.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { AssetInfo } from "@ledgerhq/coin-module-framework/api/types";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import BigNumber from "bignumber.js";

--- a/libs/coin-modules/coin-evm/src/staking/validators/monad.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators/monad.test.ts
@@ -217,7 +217,6 @@ describe("staking/validators/monad", () => {
     // Repo filename is the lowercase secp hex without the `0x` prefix.
     mockedNetwork.mockResolvedValueOnce({
       data: { name: "GalaxyDigital" },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
 
     const page = await getValidators("monad");
@@ -542,7 +541,6 @@ describe("staking/validators/monad", () => {
       );
       mockedNetwork.mockResolvedValueOnce({
         data: { name: "GalaxyDigital" },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any);
 
       const stakes = await fetchStakes();

--- a/libs/coin-modules/coin-filecoin/src/api/index.unit.test.ts
+++ b/libs/coin-modules/coin-filecoin/src/api/index.unit.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { getEnv } from "@ledgerhq/live-env";
 import network from "@ledgerhq/live-network";
 import {

--- a/libs/coin-modules/coin-filecoin/src/bridge/validateAddress.test.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/validateAddress.test.ts
@@ -16,7 +16,6 @@ describe("validateAddress", () => {
   it.each([true, false])(
     "should call validateAddress and return the expected value (%s)",
     async (expectedValue: boolean) => {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       mockedNetworkValidateAddress.mockReturnValueOnce({
         isValid: expectedValue,
       } as unknown as ValidateAddressResult);

--- a/libs/coin-modules/coin-mina/src/bridge/deviceTransactionConfig.test.ts
+++ b/libs/coin-modules/coin-mina/src/bridge/deviceTransactionConfig.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 jest.mock("@ledgerhq/coin-module-framework/currencies", () => ({
   formatCurrencyUnit: jest.fn().mockReturnValue("0.01 MINA"),
 }));

--- a/libs/coin-modules/coin-mina/src/bridge/synchronisation.test.ts
+++ b/libs/coin-modules/coin-mina/src/bridge/synchronisation.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 jest.mock("@ledgerhq/ledger-wallet-framework/account/accountId");
 jest.mock("@ledgerhq/ledger-wallet-framework/bridge/jsHelpers");
 jest.mock("@ledgerhq/ledger-wallet-framework/operation");

--- a/libs/coin-modules/coin-mina/src/bridge/transaction.test.ts
+++ b/libs/coin-modules/coin-mina/src/bridge/transaction.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 jest.mock("@ledgerhq/coin-module-framework/currencies/index", () => ({
   formatCurrencyUnit: jest.fn().mockReturnValue("1000 MINA"),
 }));

--- a/libs/coin-modules/coin-multiversx/src/api/index.unit.test.ts
+++ b/libs/coin-modules/coin-multiversx/src/api/index.unit.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 /**
  * Unit tests for the createApi factory — verifies the coin config is set, every
  * CoinModuleApi method is wired and delegates to its logic function with the

--- a/libs/coin-modules/coin-polkadot/src/api/index.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/api/index.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
-
 import type {
   AssetInfo,
   BalanceOptions,

--- a/libs/coin-modules/coin-polkadot/src/bridge/broadcast.integ.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/broadcast.integ.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
-
 import { Operation } from "@ledgerhq/types-live";
 import { ApiPromise, HttpProvider, Keyring } from "@polkadot/api";
 import { type ProviderInterface } from "@polkadot/rpc-provider/types";

--- a/libs/coin-modules/coin-polkadot/src/bridge/buildOptimisticOperation.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/buildOptimisticOperation.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
-
 import { Operation } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { PolkadotAccount, Transaction } from "../types";

--- a/libs/coin-modules/coin-polkadot/src/bridge/createTransaction.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/createTransaction.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
-
 import { AccountLike } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import createTransaction from "./createTransaction";

--- a/libs/coin-modules/coin-polkadot/src/bridge/deviceTransactionConfig.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/deviceTransactionConfig.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
-
 import { AccountLike } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { PolkadotAccount, Transaction, TransactionStatus } from "../types";

--- a/libs/coin-modules/coin-polkadot/src/bridge/estimateMaxSpendable.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/estimateMaxSpendable.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
-
 import type { AccountLike } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { PolkadotAccount, Transaction } from "../types";

--- a/libs/coin-modules/coin-polkadot/src/bridge/exchange.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/exchange.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
-
 import { Account } from "@ledgerhq/types-live";
 import { getSerializedAddressParameters } from "./exchange";
 

--- a/libs/coin-modules/coin-polkadot/src/bridge/formatters.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/formatters.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
-
 import BigNumber from "bignumber.js";
 import { PolkadotAccount } from "../types";
 import formatters from "./formatters";

--- a/libs/coin-modules/coin-polkadot/src/network/sidecar.unit.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/sidecar.unit.test.ts
@@ -99,7 +99,6 @@ describe("getAccount", () => {
 
     jest
       .spyOn(node.default, "fetchStakingInfo")
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       .mockResolvedValue(undefined as unknown as SidecarStakingInfo);
 
     mockServer.use(
@@ -185,7 +184,6 @@ describe("getAccount", () => {
 
     jest
       .spyOn(node.default, "fetchStakingInfo")
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       .mockResolvedValue(stakingInfoResponseStub as SidecarStakingInfo);
 
     mockServer.use(

--- a/libs/coin-modules/coin-solana/src/api/index.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/api/index.unit.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import type {
   CoinModuleApi,
   Balance,

--- a/libs/coin-modules/coin-solana/src/logic/tests/broadcast.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/broadcast.unit.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { InvalidTransactionError } from "@ledgerhq/errors";
 import {
   BlockhashWithExpiryBlockHeight,

--- a/libs/coin-modules/coin-solana/src/logic/tests/craftTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/craftTransaction.integ.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { TransactionIntent } from "@ledgerhq/coin-module-framework/api/types";
 import { VersionedTransaction } from "@solana/web3.js";
 import { getChainAPI } from "../../network";

--- a/libs/coin-modules/coin-solana/src/logic/tests/craftTransaction.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/craftTransaction.unit.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import type {
   StakingTransactionIntent,
   TransactionIntent,

--- a/libs/coin-modules/coin-solana/src/logic/tests/estimateFees.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/estimateFees.unit.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import type {
   StakingTransactionIntent,
   TransactionIntent,

--- a/libs/coin-modules/coin-solana/src/logic/tests/getBalance.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getBalance.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { PublicKey } from "@solana/web3.js";
 import { getBalance } from "../getBalance";
 import { server, rpcHandler, createTestChainApi } from "../tests/helpers/msw-rpc.mock";

--- a/libs/coin-modules/coin-solana/src/logic/tests/getBalance.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getBalance.unit.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import type { DeepPartialReturn } from "@ledgerhq/coin-module-framework/test/utils";
 import type { ChainAPI } from "../../network";
 import type { StakeAccount } from "../../network/chain/stake-activation/rpc";

--- a/libs/coin-modules/coin-solana/src/logic/tests/helpers/msw-rpc.mock.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/helpers/msw-rpc.mock.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import type {
   BlockhashWithExpiryBlockHeight,
   Connection,

--- a/libs/coin-modules/coin-solana/src/logic/tests/lastBlock.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/lastBlock.unit.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import type { ChainAPI } from "../../network";
 import { lastBlock } from "../lastBlock";
 

--- a/libs/coin-modules/coin-solana/src/logic/tests/listOperations.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/listOperations.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import type { ParsedInstruction, PartiallyDecodedInstruction } from "@solana/web3.js";
 import { PublicKey } from "@solana/web3.js";
 import { http, HttpResponse } from "msw";

--- a/libs/coin-modules/coin-solana/src/logic/tests/listOperations.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/listOperations.unit.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import type { DeepPartialReturn } from "@ledgerhq/coin-module-framework/test/utils";
 import { PublicKey } from "@solana/web3.js";
 import type { ChainAPI } from "../../network";

--- a/libs/coin-modules/coin-solana/src/network/chain/index.test.ts
+++ b/libs/coin-modules/coin-solana/src/network/chain/index.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
-
 import { NetworkError } from "@ledgerhq/errors";
 import { Config, getChainAPI } from ".";
 import { Connection, SendTransactionError } from "@solana/web3.js";

--- a/libs/coin-modules/coin-solana/src/preload.test.ts
+++ b/libs/coin-modules/coin-solana/src/preload.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
-
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { Cluster } from "@solana/web3.js";
 import { firstValueFrom } from "rxjs";

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.test.ts
@@ -60,7 +60,6 @@ describe("testing prepareTransaction", () => {
 
   it("packs a 'NotEnoughGas' error if the sender can not afford the fees during a token transfer", async () => {
     const preparedTransaction = await prepareTransaction(
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       {
         currency: { units: [{ magnitude: 2 }] },
         spendableBalance: new BigNumber(0),
@@ -73,7 +72,6 @@ describe("testing prepareTransaction", () => {
         ],
       } as unknown as SolanaAccount,
       transaction({ kind: "token.transfer", subAccountId: "subAccountId" }),
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       {
         getAccountInfo: () => ({
           data: {
@@ -427,7 +425,6 @@ describe("testing prepareTransaction", () => {
 
     // When
     const preparedTransaction = await prepareTransaction(
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       {} as SolanaAccount,
       rawTransaction,
       chainAPI,
@@ -471,7 +468,6 @@ describe("testing prepareTransaction", () => {
 
     // When
     const preparedTransaction = await prepareTransaction(
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       {} as SolanaAccount,
       rawTransaction,
       chainAPI,
@@ -507,10 +503,8 @@ describe("testing prepareTransaction", () => {
   it("should return a new transaction when user does not provide a raw one", async () => {
     const nonRawTransaction = transaction();
     const preparedTransaction = await prepareTransaction(
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       {} as SolanaAccount,
       nonRawTransaction,
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       {} as ChainAPI,
     );
 
@@ -562,7 +556,6 @@ describe("testing prepareTransaction", () => {
         subAccountId: "subAccountId",
       });
       const preparedTransaction = await prepareTransaction(
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         {
           currency: { units: [{ magnitude: 2 }] },
           spendableBalance: new BigNumber(0),
@@ -575,7 +568,6 @@ describe("testing prepareTransaction", () => {
           ],
         } as unknown as SolanaAccount,
         transactionToPrepare,
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         {
           getAccountInfo: () => ({
             data: {
@@ -613,7 +605,6 @@ describe("testing prepareTransaction", () => {
         subAccountId: "subAccountId",
       });
       const preparedTransaction = await prepareTransaction(
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         {
           currency: { units: [{ magnitude: 2 }] },
           spendableBalance: new BigNumber(0),
@@ -626,7 +617,6 @@ describe("testing prepareTransaction", () => {
           ],
         } as unknown as SolanaAccount,
         transactionToPrepare,
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         {
           getAccountInfo: () => ({
             data: {
@@ -874,7 +864,6 @@ describe("testing prepareTransaction", () => {
 });
 
 function api(estimatedFees?: number) {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   return {
     getLatestBlockhash: () => {
       return Promise.resolve({

--- a/libs/coin-modules/coin-solana/src/signOperation.test.ts
+++ b/libs/coin-modules/coin-solana/src/signOperation.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { DeviceModelId } from "@ledgerhq/devices";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { Account, Operation, OperationType, SignOperationEvent } from "@ledgerhq/types-live";

--- a/libs/coin-modules/coin-stacks/src/bridge/synchronization.test.ts
+++ b/libs/coin-modules/coin-stacks/src/bridge/synchronization.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions */
 import * as cryptoAssets from "@ledgerhq/cryptoassets/state";
 import * as accountIndex from "@ledgerhq/ledger-wallet-framework/account/index";
 import { log } from "@ledgerhq/logs";

--- a/libs/coin-modules/coin-sui/src/bridge/synchronisation.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/synchronisation.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
-
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import { setCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";

--- a/libs/coin-modules/coin-sui/src/network/sdk.test.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.test.ts
@@ -1614,7 +1614,6 @@ describe("Staking Operations", () => {
       };
       const operation = sdk.transactionToCoinFrameworkOperation(
         senderAddress,
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         sponsoredTx as unknown as SuiTransactionBlockResponse,
         "mockCheckpointHash",
       );
@@ -3468,10 +3467,7 @@ describe("filterOperations", () => {
 
     test("toBlockTransaction should map transactions correctly", () => {
       expect(
-        sdk.toBlockTransaction(
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          mockTransaction as unknown as SuiTransactionBlockResponse,
-        ),
+        sdk.toBlockTransaction(mockTransaction as unknown as SuiTransactionBlockResponse),
       ).toEqual({
         hash: "DhKLpX5kwuKuyRa71RGqpX5EY2M8Efw535ZVXYXsRiDt",
         failed: false,
@@ -3520,10 +3516,7 @@ describe("filterOperations", () => {
           },
         },
       };
-      const result = sdk.toBlockTransaction(
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        sponsoredTx as unknown as SuiTransactionBlockResponse,
-      );
+      const result = sdk.toBlockTransaction(sponsoredTx as unknown as SuiTransactionBlockResponse);
       expect(result.feesPayer).toBe(sponsorAddress);
     });
 
@@ -3556,11 +3549,9 @@ describe("filterOperations", () => {
       };
 
       const resultWithoutOwner = sdk.toBlockTransaction(
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         txWithoutOwner as unknown as SuiTransactionBlockResponse,
       );
       const resultWithEmptyOwner = sdk.toBlockTransaction(
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         txWithEmptyOwner as unknown as SuiTransactionBlockResponse,
       );
 

--- a/libs/coin-modules/coin-tezos/src/api/index-mainnet.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index-mainnet.integ.test.ts
@@ -120,7 +120,6 @@ describe("Tezos Api - Mainnet", () => {
 
       expect(decoded.contents.length).toBe(2);
 
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const reveal = decoded.contents[0] as DecodedOperation;
       expect(reveal.kind).toBe(OpKind.REVEAL);
       expect(BigInt(reveal.fee ?? "0")).toBeGreaterThanOrEqual(500);
@@ -128,7 +127,6 @@ describe("Tezos Api - Mainnet", () => {
       expect(Number(reveal.storage_limit ?? "0")).toBeGreaterThanOrEqual(0);
       expect(reveal.source).toEqual(sender);
 
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const delegation = decoded.contents[1] as DecodedOperation;
       expect(delegation.kind).toBe(OpKind.DELEGATION);
       expect(BigInt(delegation.fee ?? "0")).toBeGreaterThanOrEqual(500);
@@ -190,12 +188,10 @@ describe("Tezos Api - Mainnet", () => {
           );
           const decoded = await localForger.parse(encodedTransaction.slice(2));
 
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           const reveal = decoded.contents[0] as DecodedOperation;
           expect(reveal.kind).toBe(OpKind.REVEAL);
           expect(BigInt(reveal.fee ?? "0")).toEqual(1200n);
 
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           const delegation = decoded.contents[1] as DecodedOperation;
           expect(delegation.kind).toBe(OpKind.DELEGATION);
           expect(BigInt(delegation.fee ?? "0")).toBeGreaterThanOrEqual(1800n);
@@ -221,12 +217,10 @@ describe("Tezos Api - Mainnet", () => {
           );
           const decoded = await localForger.parse(encodedTransaction.slice(2));
 
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           const reveal = decoded.contents[0] as DecodedOperation;
           expect(reveal.kind).toBe(OpKind.REVEAL);
           expect(BigInt(reveal.fee ?? "0")).toEqual(1200n);
 
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           const delegation = decoded.contents[1] as DecodedOperation;
           expect(delegation.kind).toBe(OpKind.DELEGATION);
           expect(BigInt(delegation.fee ?? "0")).toBeGreaterThanOrEqual(800n);

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.test.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.test.ts
@@ -40,10 +40,8 @@ function networkResponse<T>(data: T) {
   return Promise.resolve({
     data,
     status: 200,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     headers: {} as any,
     statusText: "",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     config: { headers: {} as any },
   });
 }

--- a/libs/coin-modules/coin-ton/src/transaction.unit.test.ts
+++ b/libs/coin-modules/coin-ton/src/transaction.unit.test.ts
@@ -586,12 +586,10 @@ const cases: Array<{
     // Cast via unknown to avoid direct any assertions
     tx: {
       ...baseTx,
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       payload: { type: "fake-type", as: "is" } as unknown as Transaction["payload"],
     },
     rawTx: {
       ...baseRawTx,
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       payload: { type: "fake-type", as: "is" } as unknown as TransactionRaw["payload"],
     },
   },

--- a/libs/coin-modules/coin-vechain/src/network/sdk.integ.test.ts
+++ b/libs/coin-modules/coin-vechain/src/network/sdk.integ.test.ts
@@ -150,7 +150,6 @@ describe("sdk", () => {
             LAST_BLOCK_COUNT,
           );
         } catch (err: unknown) {
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           const error = err as { message: string };
           expect(error.message).toMatch("something went wrong");
         }
@@ -207,7 +206,6 @@ describe("sdk", () => {
             LAST_BLOCK_COUNT,
           );
         } catch (err: unknown) {
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           const error = err as { message: string };
           expect(error.message).toMatch("something went wrong");
         }

--- a/libs/coin-modules/coin-vechain/src/network/sdk.test.ts
+++ b/libs/coin-modules/coin-vechain/src/network/sdk.test.ts
@@ -18,7 +18,6 @@ const mockAccount = {
   energy: "",
   hasCode: false,
 };
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 const mockTransaction: VechainSDKTransaction = {
   get encoded() {
     return new Uint8Array();
@@ -158,7 +157,6 @@ describe("sdk", () => {
         try {
           await submit(mockTransaction);
         } catch (err: unknown) {
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           const error = err as { message: string };
           expect(error.message).toMatch("Expected an ID");
         }
@@ -183,7 +181,6 @@ describe("sdk", () => {
             LAST_BLOCK_COUNT,
           );
         } catch (err: unknown) {
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           const error = err as { message: string };
           expect(error.message).toMatch(/internal server error/);
         }
@@ -221,7 +218,6 @@ describe("sdk", () => {
               LAST_BLOCK_COUNT,
             );
           } catch (err: unknown) {
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             const error = err as { message: string };
             expect(error.message).toMatch(/Unable to split/);
           }
@@ -261,7 +257,6 @@ describe("sdk", () => {
             LAST_BLOCK_COUNT,
           );
         } catch (err: unknown) {
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           const error = err as { message: string };
           expect(error.message).toMatch(/internal server error/);
         }
@@ -301,7 +296,6 @@ describe("sdk", () => {
               LAST_BLOCK_COUNT,
             );
           } catch (err: unknown) {
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             const error = err as { message: string };
             expect(error.message).toMatch(/Unable to split/);
           }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Turn off `typescript/no-explicit-any` and `typescript/consistent-type-assertions` on tests.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
