### PR TITLE
fix(mise): Remove unused plugins

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -17,11 +17,6 @@ lockfile_platforms = [
   "windows-x64",
 ]
 
-[plugins]
-bundler = "jonathanmorley/asdf-bundler"
-cocoapods = "mise-plugins/mise-cocoapods"
-
-
 [tools]
 node = '24.14.0'
 pnpm = '10.24.0'


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

- Removes the `[plugins]` section from `mise.toml` (`bundler` and `cocoapods`)
- Both plugins were unused, their corresponding tools (`bundler`, `cocoapods`, `ruby`) are fully commented out in `[tools]`


## Root cause

The hotfix workflow (`release-create-hotfix.yml`) was failing at the "Setup the caches" step because mise tried to resolve `jonathanmorley/asdf-bundler` as a local path (`/home/runner/work/ledger-live/ledger-live/jonathanmorley/asdf-bundler`), which doesn't exist.

### 🔗 Context

- **JIRA / GitHub issue**: [NO-ISSUE]