### PR TITLE
[LWDM] test(contacts): align entry config tests

### DIFF
--- a/.changeset/bright-contacts-align.md
+++ b/.changeset/bright-contacts-align.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Fix Contacts entry config test expectations

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/__tests__/useContactsEntryConfig.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/__tests__/useContactsEntryConfig.test.ts
@@ -1,18 +1,27 @@
 import { renderHook, withFlagOverrides } from "tests/testSetup";
 import { resolveContactsEntryConfig, useContactsEntryConfig } from "../useContactsEntryConfig";
 
+const ELIGIBLE_ADDRESS_FAMILIES = ["evm"];
+
 describe("resolveContactsEntryConfig", () => {
   it("should return disabled config without a feature value", () => {
     expect(resolveContactsEntryConfig(null)).toEqual({
       isEnabled: false,
       showNewBadge: false,
+      eligibleAddressFamilies: ELIGIBLE_ADDRESS_FAMILIES,
     });
   });
 
   it("should return enabled config with a new badge only when the flag and param are enabled", () => {
-    expect(resolveContactsEntryConfig({ enabled: true, params: { newBadge: true } })).toEqual({
+    expect(
+      resolveContactsEntryConfig({
+        enabled: true,
+        params: { newBadge: true, eligibleAddressFamilies: [...ELIGIBLE_ADDRESS_FAMILIES] },
+      }),
+    ).toEqual({
       isEnabled: true,
       showNewBadge: true,
+      eligibleAddressFamilies: ELIGIBLE_ADDRESS_FAMILIES,
     });
   });
 });
@@ -21,36 +30,61 @@ describe("useContactsEntryConfig", () => {
   it("should return disabled config with the default registry value", () => {
     const { result } = renderHook(() => useContactsEntryConfig());
 
-    expect(result.current).toEqual({ isEnabled: false, showNewBadge: false });
+    expect(result.current).toEqual({
+      isEnabled: false,
+      showNewBadge: false,
+      eligibleAddressFamilies: ELIGIBLE_ADDRESS_FAMILIES,
+    });
   });
 
   it("should return no new badge when the flag is disabled", () => {
     const { result } = renderHook(() => useContactsEntryConfig(), {
       initialState: withFlagOverrides({
-        lwdContacts: { enabled: false, params: { newBadge: true } },
+        lwdContacts: {
+          enabled: false,
+          params: { newBadge: true, eligibleAddressFamilies: [...ELIGIBLE_ADDRESS_FAMILIES] },
+        },
       }),
     });
 
-    expect(result.current).toEqual({ isEnabled: false, showNewBadge: false });
+    expect(result.current).toEqual({
+      isEnabled: false,
+      showNewBadge: false,
+      eligibleAddressFamilies: ELIGIBLE_ADDRESS_FAMILIES,
+    });
   });
 
   it("should return enabled without new badge when newBadge is false", () => {
     const { result } = renderHook(() => useContactsEntryConfig(), {
       initialState: withFlagOverrides({
-        lwdContacts: { enabled: true, params: { newBadge: false } },
+        lwdContacts: {
+          enabled: true,
+          params: { newBadge: false, eligibleAddressFamilies: [...ELIGIBLE_ADDRESS_FAMILIES] },
+        },
       }),
     });
 
-    expect(result.current).toEqual({ isEnabled: true, showNewBadge: false });
+    expect(result.current).toEqual({
+      isEnabled: true,
+      showNewBadge: false,
+      eligibleAddressFamilies: ELIGIBLE_ADDRESS_FAMILIES,
+    });
   });
 
   it("should return enabled with new badge when newBadge is true", () => {
     const { result } = renderHook(() => useContactsEntryConfig(), {
       initialState: withFlagOverrides({
-        lwdContacts: { enabled: true, params: { newBadge: true } },
+        lwdContacts: {
+          enabled: true,
+          params: { newBadge: true, eligibleAddressFamilies: [...ELIGIBLE_ADDRESS_FAMILIES] },
+        },
       }),
     });
 
-    expect(result.current).toEqual({ isEnabled: true, showNewBadge: true });
+    expect(result.current).toEqual({
+      isEnabled: true,
+      showNewBadge: true,
+      eligibleAddressFamilies: ELIGIBLE_ADDRESS_FAMILIES,
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/__tests__/useContactsEntryConfig.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/__tests__/useContactsEntryConfig.test.ts
@@ -1,18 +1,27 @@
 import { renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { resolveContactsEntryConfig, useContactsEntryConfig } from "../useContactsEntryConfig";
 
+const ELIGIBLE_ADDRESS_FAMILIES = ["evm"];
+
 describe("resolveContactsEntryConfig", () => {
   it("should return disabled config without a feature value", () => {
     expect(resolveContactsEntryConfig(null)).toEqual({
       isEnabled: false,
       showNewBadge: false,
+      eligibleAddressFamilies: ELIGIBLE_ADDRESS_FAMILIES,
     });
   });
 
   it("should return enabled config with a new badge only when the flag and param are enabled", () => {
-    expect(resolveContactsEntryConfig({ enabled: true, params: { newBadge: true } })).toEqual({
+    expect(
+      resolveContactsEntryConfig({
+        enabled: true,
+        params: { newBadge: true, eligibleAddressFamilies: [...ELIGIBLE_ADDRESS_FAMILIES] },
+      }),
+    ).toEqual({
       isEnabled: true,
       showNewBadge: true,
+      eligibleAddressFamilies: ELIGIBLE_ADDRESS_FAMILIES,
     });
   });
 });
@@ -21,36 +30,61 @@ describe("useContactsEntryConfig", () => {
   it("should return disabled config with the default registry value", () => {
     const { result } = renderHook(() => useContactsEntryConfig());
 
-    expect(result.current).toEqual({ isEnabled: false, showNewBadge: false });
+    expect(result.current).toEqual({
+      isEnabled: false,
+      showNewBadge: false,
+      eligibleAddressFamilies: ELIGIBLE_ADDRESS_FAMILIES,
+    });
   });
 
   it("should return no new badge when the flag is disabled", () => {
     const { result } = renderHook(() => useContactsEntryConfig(), {
       overrideInitialState: withFlagOverrides({
-        lwmContacts: { enabled: false, params: { newBadge: true } },
+        lwmContacts: {
+          enabled: false,
+          params: { newBadge: true, eligibleAddressFamilies: [...ELIGIBLE_ADDRESS_FAMILIES] },
+        },
       }),
     });
 
-    expect(result.current).toEqual({ isEnabled: false, showNewBadge: false });
+    expect(result.current).toEqual({
+      isEnabled: false,
+      showNewBadge: false,
+      eligibleAddressFamilies: ELIGIBLE_ADDRESS_FAMILIES,
+    });
   });
 
   it("should return enabled without new badge when newBadge is false", () => {
     const { result } = renderHook(() => useContactsEntryConfig(), {
       overrideInitialState: withFlagOverrides({
-        lwmContacts: { enabled: true, params: { newBadge: false } },
+        lwmContacts: {
+          enabled: true,
+          params: { newBadge: false, eligibleAddressFamilies: [...ELIGIBLE_ADDRESS_FAMILIES] },
+        },
       }),
     });
 
-    expect(result.current).toEqual({ isEnabled: true, showNewBadge: false });
+    expect(result.current).toEqual({
+      isEnabled: true,
+      showNewBadge: false,
+      eligibleAddressFamilies: ELIGIBLE_ADDRESS_FAMILIES,
+    });
   });
 
   it("should return enabled with new badge when newBadge is true", () => {
     const { result } = renderHook(() => useContactsEntryConfig(), {
       overrideInitialState: withFlagOverrides({
-        lwmContacts: { enabled: true, params: { newBadge: true } },
+        lwmContacts: {
+          enabled: true,
+          params: { newBadge: true, eligibleAddressFamilies: [...ELIGIBLE_ADDRESS_FAMILIES] },
+        },
       }),
     });
 
-    expect(result.current).toEqual({ isEnabled: true, showNewBadge: true });
+    expect(result.current).toEqual({
+      isEnabled: true,
+      showNewBadge: true,
+      eligibleAddressFamilies: ELIGIBLE_ADDRESS_FAMILIES,
+    });
   });
 });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Desktop and Mobile Contacts entry configuration test coverage.

### 📝 Description

Desktop and Mobile Contacts entry configuration tests did not include `eligibleAddressFamilies`, although the shared resolver now returns it.

The feature-flag overrides and expected configurations now include the default EVM family on both platforms. This restores the Desktop typecheck and the failing unit-test assertions.

### ❓ Context

- **JIRA or GitHub link**: [CI run 29079503147](https://github.com/LedgerHQ/ledger-live/actions/runs/29079503147)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)