### PR TITLE
[LWM] chore(mobile): add large screen upsell translations

### DIFF
--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1380,6 +1380,17 @@
       }
     }
   },
+  "largeScreenUpsellModal": {
+    "optedIn": {
+      "title": "See more. Tap less. Save {{discount}}%",
+      "subtitle": "Enjoy a larger screen, smarter transaction review, enhanced protection, and an exclusive {{discount}}% off."
+    },
+    "optedOut": {
+      "title": "Spot scams. See every detail",
+      "subtitle": "Review details on a touchscreen signer and pair slimmer wallets with advanced security checks."
+    },
+    "cta": "Explore touchscreen signers"
+  },
   "earn": {
     "simulator": {
       "title": "Rewards simulator"


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not needed: mobile source copy only._
- [x] **Covered by automatic tests.** `pnpm nx run live-mobile:lint:i18n`
- [x] **Impact of the changes:**
  - English source copy for the Large Screen Upsell modal
  - Translation pipeline can start before the feature PR lands

### 📝 Description

This PR adds the English source strings for the Large Screen Upsell modal so the translation team can start localization work independently from the feature implementation.

There are no runtime or UI wiring changes in this PR.

### ❓ Context

- **Parent PR**: [#19415](https://github.com/LedgerHQ/ledger-live/pull/19415)

---

### 🧐 Checklist for the PR Reviewers

- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **The PR has been tested** with the mobile i18n lint command.
