### PR TITLE
[LWM] feat(lwm): rebuild notifications prompt QA debug screen

### DIFF
--- a/.changeset/quiet-prompts-debug.md
+++ b/.changeset/quiet-prompts-debug.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Rebuild the LWM notifications prompt QA debug screen: a status hero with a live, step-by-step decision trace explains exactly why the drawer would or wouldn't show for either trigger type, "trigger via production rules" and "force open" let QA see the real drawer for both prompt targets, and new remote-config override controls (feature toggle, Fast QA mode, per-action-event and transaction-alerts-prompt toggles, restore-to-remote) plus user-state simulation (OS permission, app notification toggles, opt-in/opt-out, scenario prep, full reset) make every configuration and state directly testable from the screen.

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
@@ -37,6 +37,7 @@ import DebugPlayground from "~/screens/Settings/Debug/Playground";
 import DebugBluetoothAndLocationServices from "~/screens/Settings/Debug/Debugging/BluetoothAndLocationServices";
 import DebugSettings from "~/screens/Settings/Debug";
 import DebugAnalyticsConsentQA from "~/screens/Settings/Debug/AnalyticsConsentQA";
+import DebugNotificationsPromptQA from "LLM/features/NotificationsPrompt/screens/NotificationsPromptQADebug";
 import DebugSnackbars from "~/screens/Settings/Debug/Features/Snackbars";
 import DebugTransactionsAlerts from "~/screens/Settings/Debug/Features/TransactionsAlerts";
 import DebugStore from "~/screens/Settings/Debug/Debugging/Store";
@@ -253,6 +254,13 @@ export default function SettingsNavigator() {
         component={DebugAnalyticsConsentQA}
         options={{
           title: "Analytics opt-in consent — QA",
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.DebugNotificationsPromptQA}
+        component={DebugNotificationsPromptQA}
+        options={{
+          title: "Notifications prompt — QA",
         }}
       />
       <Stack.Screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
@@ -30,6 +30,7 @@ export type SettingsNavigatorStackParamList = {
   [ScreenName.CustomCALRefInput]: undefined;
   [ScreenName.DebugSettings]: undefined;
   [ScreenName.DebugAnalyticsConsentQA]: undefined;
+  [ScreenName.DebugNotificationsPromptQA]: undefined;
   [ScreenName.DebugFeatureFlags]: undefined;
   [ScreenName.DebugInformation]: undefined;
   [ScreenName.DebugPerformance]: undefined;

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -39,6 +39,7 @@ export enum ScreenName {
   EditCurrencyUnits = "EditCurrencyUnits",
   CustomCALRefInput = "CustomCALRefInput",
   DebugAnalyticsConsentQA = "DebugAnalyticsConsentQA",
+  DebugNotificationsPromptQA = "DebugNotificationsPromptQA",
   DebugBLEDevicePairing = "DebugBLEDevicePairing",
   DebugConfiguration = "DebugConfiguration",
   DebugCommandSender = "DebugCommandSender",

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/index.ts
@@ -6,6 +6,7 @@ export { useNotificationsData } from "./hooks/useNotificationsData";
 export { useNotificationsPrompt } from "./hooks/useNotificationsPrompt";
 export { useNotificationsDrawer } from "./hooks/useNotificationsDrawer";
 export {
+  AFTER_ACTION_SOURCE_TO_EVENT_KEY,
   INACTIVITY_DRAWER_DELAY_MS,
   checkIsInactive,
   evaluateAfterActionTrigger,

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptQADebug/NotificationsPromptQADebugView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptQADebug/NotificationsPromptQADebugView.tsx
@@ -1,0 +1,647 @@
+import React from "react";
+import { ScrollView, StyleSheet } from "react-native";
+import {
+  Banner,
+  Box,
+  Button,
+  Card,
+  Divider,
+  SegmentedControl,
+  SegmentedControlButton,
+  Switch,
+  Tag,
+  Text,
+} from "@ledgerhq/lumen-ui-rnative";
+import { AuthorizationStatus } from "@react-native-firebase/messaging";
+import { TrackScreen } from "~/analytics";
+import type {
+  NotificationsPromptQADebugViewModel,
+  PromptTargetVerdict,
+  TransactionsAlertsOverview,
+} from "./useNotificationsPromptQADebugViewModel";
+import type { RepromptTiming } from "../../utils/notificationsPromptDebug";
+
+const PERMISSION_LABEL: Record<
+  (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus],
+  string
+> = {
+  [AuthorizationStatus.AUTHORIZED]: "Authorized",
+  [AuthorizationStatus.DENIED]: "Denied",
+  [AuthorizationStatus.NOT_DETERMINED]: "Not determined",
+  [AuthorizationStatus.PROVISIONAL]: "Provisional",
+  [AuthorizationStatus.EPHEMERAL]: "Ephemeral",
+};
+
+// AuthorizationStatus.DENIED is 0 (falsy), so a plain `permissionStatus && ...` truthy check
+// would silently skip the label for that status — check against null/undefined explicitly.
+const getPermissionLabel = (
+  permissionStatus:
+    | (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus]
+    | null
+    | undefined,
+): string => (permissionStatus != null ? PERMISSION_LABEL[permissionStatus] : "Unknown");
+
+const SectionLabel = ({ children }: { children: React.ReactNode }) => (
+  <Box lx={{ marginBottom: "s8" }}>
+    <Text typography="body2SemiBold" lx={{ color: "muted", marginBottom: "s8" }}>
+      {children}
+    </Text>
+    <Divider />
+  </Box>
+);
+
+const TraceRow = ({ label, status }: { label: string; status: "pass" | "fail" | "pending" }) => (
+  <Box lx={{ flexDirection: "row", alignItems: "flex-start", paddingVertical: "s8" }}>
+    <Text
+      typography="body2SemiBold"
+      lx={{
+        marginRight: "s8",
+        color: status === "pass" ? "success" : status === "fail" ? "error" : "muted",
+      }}
+    >
+      {status === "pass" ? "✓" : status === "fail" ? "✗" : "○"}
+    </Text>
+    <Text typography="body3" lx={{ color: status === "pending" ? "muted" : "base", flexShrink: 1 }}>
+      {label}
+    </Text>
+  </Box>
+);
+
+/**
+ * Lightweight dismissal → cooldown → eligible-again timeline, built from Lumen primitives only.
+ * Kept prominent (own section, not just a caption) so the exact WHEN is never just an abstract
+ * banner: the absolute eligible-at instant is always spelled out next to the bar.
+ */
+const CooldownTimeline = ({ timing, now }: { timing: RepromptTiming; now: number }) => {
+  if (timing.startAt === null || timing.eligibleAt === null) {
+    return (
+      <Text typography="body3" lx={{ color: "muted", marginBottom: "s16" }}>
+        Cooldown: {timing.remaining}
+      </Text>
+    );
+  }
+
+  const total = timing.eligibleAt - timing.startAt;
+  const pct = total > 0 ? Math.min(1, Math.max(0, (now - timing.startAt) / total)) : 1;
+  const eligibleAtLabel = new Date(timing.eligibleAt).toLocaleString();
+
+  return (
+    <Box lx={{ marginBottom: "s16" }}>
+      <Box
+        lx={{ height: "s8", borderRadius: "full", backgroundColor: "muted", overflow: "hidden" }}
+      >
+        <Box
+          lx={{
+            height: "s8",
+            borderRadius: "full",
+            backgroundColor: timing.state === "eligible" ? "successStrong" : "active",
+          }}
+          style={{ width: `${pct * 100}%` }}
+        />
+      </Box>
+      <Box lx={{ flexDirection: "row", justifyContent: "space-between", marginTop: "s4" }}>
+        <Text typography="body4" lx={{ color: "muted" }}>
+          Dismissed
+        </Text>
+        <Text typography="body4" lx={{ color: "muted" }}>
+          Eligible again
+        </Text>
+      </Box>
+      <Text typography="body3SemiBold" lx={{ color: "base", marginTop: "s8" }}>
+        Cooldown: {timing.remaining}
+      </Text>
+      <Text typography="body4" lx={{ color: "muted" }}>
+        Eligible at {eligibleAtLabel}
+      </Text>
+    </Box>
+  );
+};
+
+const PromptTargetRow = ({ verdict }: { verdict: PromptTargetVerdict }) => (
+  <Box lx={{ paddingVertical: "s12" }}>
+    <Box lx={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between" }}>
+      <Box lx={{ flexDirection: "row", alignItems: "center", columnGap: "s8", flexShrink: 1 }}>
+        <Text typography="body2SemiBold" lx={{ color: "base" }}>
+          {verdict.label}
+        </Text>
+        {verdict.isLive ? (
+          <Tag appearance="accent" size="sm" label="LIVE NOW" />
+        ) : (
+          <Tag appearance="gray" size="sm" label="hypothetical" />
+        )}
+      </Box>
+      <Tag
+        appearance={verdict.wouldShow ? "success" : "gray"}
+        size="sm"
+        label={verdict.wouldShow ? "Would show" : "Blocked"}
+      />
+    </Box>
+    {verdict.reasonLabel && (
+      <Text typography="body3" lx={{ color: "muted", marginTop: "s4" }}>
+        {verdict.reasonLabel}
+      </Text>
+    )}
+  </Box>
+);
+
+/**
+ * "Transaction alerts" row for the "After an action" tab. Deliberately NOT re-evaluated per
+ * selected source (that was confusing — see NotificationsPromptQADebug follow-up feedback):
+ * only the gates that don't depend on the source are shown at the top, and the per-action
+ * breakdown below is a static list against the real configured `drawerPromptActions`, so it
+ * doesn't shuffle around as the source selector changes.
+ */
+const TransactionsAlertsBreakdown = ({ overview }: { overview: TransactionsAlertsOverview }) => (
+  <Box lx={{ paddingVertical: "s12" }}>
+    <Box lx={{ flexDirection: "row", alignItems: "center", columnGap: "s8", marginBottom: "s4" }}>
+      <Text typography="body2SemiBold" lx={{ color: "base" }}>
+        Transaction alerts
+      </Text>
+      {overview.isLive ? (
+        <Tag appearance="accent" size="sm" label="LIVE NOW" />
+      ) : (
+        <Tag appearance="gray" size="sm" label="hypothetical" />
+      )}
+    </Box>
+    {overview.blockedReason && (
+      <Text typography="body3" lx={{ color: "muted", marginBottom: "s8" }}>
+        {overview.blockedReason}
+      </Text>
+    )}
+    <Text typography="body3" lx={{ color: "muted", marginBottom: "s8" }}>
+      Per action, against the real configured drawerPromptActions (remote config, not hardcoded) —
+      doesn't change with the source selector above:
+    </Text>
+    <Box lx={{ paddingLeft: "s16" }}>
+      {overview.perSourceEligibility.map(({ value, label, eligible }) => (
+        <Box
+          key={value}
+          lx={{
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            paddingVertical: "s4",
+          }}
+        >
+          <Text typography="body3" lx={{ color: "base" }}>
+            {label}
+          </Text>
+          <Tag
+            appearance={eligible ? "success" : "gray"}
+            size="sm"
+            label={eligible ? "Eligible" : "Not eligible"}
+          />
+        </Box>
+      ))}
+    </Box>
+  </Box>
+);
+
+type DecisionSectionProps = Pick<
+  NotificationsPromptQADebugViewModel,
+  | "hero"
+  | "timing"
+  | "now"
+  | "trace"
+  | "canTriggerViaProductionRules"
+  | "triggerViaProductionRulesDisabledReason"
+  | "triggerViaProductionRulesLabel"
+  | "triggerViaProductionRules"
+  | "forceOpenDrawer"
+>;
+
+/** Shared by the "After an action" and "After inactivity" tabs: hero, timeline, trace, live actions. */
+const DecisionSection = ({
+  hero,
+  timing,
+  now,
+  trace,
+  canTriggerViaProductionRules,
+  triggerViaProductionRulesDisabledReason,
+  triggerViaProductionRulesLabel,
+  triggerViaProductionRules,
+  forceOpenDrawer,
+}: DecisionSectionProps) => (
+  <>
+    <Banner
+      appearance={hero.appearance}
+      title={hero.title}
+      description={hero.description}
+      lx={{ marginBottom: "s8" }}
+    />
+    <CooldownTimeline timing={timing} now={now} />
+
+    <SectionLabel>WHY</SectionLabel>
+    <Card type="info">
+      <Box lx={{ paddingHorizontal: "s16", paddingVertical: "s8" }}>
+        {trace.map(step => (
+          <TraceRow key={step.id} label={step.label} status={step.status} />
+        ))}
+      </Box>
+    </Card>
+
+    <Box lx={{ marginTop: "s24" }}>
+      <SectionLabel>SEE IT LIVE</SectionLabel>
+      <Button
+        appearance="accent"
+        onPress={triggerViaProductionRules}
+        disabled={!canTriggerViaProductionRules}
+        lx={{ marginBottom: "s8" }}
+      >
+        {triggerViaProductionRulesLabel}
+      </Button>
+      <Text typography="body3" lx={{ color: "muted", marginBottom: "s16" }}>
+        {canTriggerViaProductionRules
+          ? "Runs the real eligibility check and emits real analytics."
+          : `Disabled — ${triggerViaProductionRulesDisabledReason}`}
+      </Text>
+
+      <Box lx={{ flexDirection: "row", columnGap: "s8", marginBottom: "s8" }}>
+        <Box lx={{ flex: 1 }}>
+          <Button
+            appearance="no-background"
+            onPress={() => forceOpenDrawer("globalPushNotifications")}
+          >
+            Force open — global push
+          </Button>
+        </Box>
+        <Box lx={{ flex: 1 }}>
+          <Button
+            appearance="no-background"
+            onPress={() => forceOpenDrawer("transactionsAlertsCategory")}
+          >
+            Force open — tx alerts
+          </Button>
+        </Box>
+      </Box>
+      <Text typography="body3" lx={{ color: "muted", marginBottom: "s24" }}>
+        Bypasses every check — no analytics. Use to preview copy for either target.
+      </Text>
+    </Box>
+  </>
+);
+
+const StatusRow = ({
+  label,
+  value,
+  valueAppearance,
+  onEdit,
+  editLabel = "Edit",
+}: {
+  label: string;
+  value: string;
+  valueAppearance: "success" | "gray";
+  onEdit: () => void;
+  editLabel?: string;
+}) => (
+  <Box
+    lx={{
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      paddingVertical: "s12",
+    }}
+  >
+    <Box lx={{ flexShrink: 1, paddingRight: "s12" }}>
+      <Text typography="body2" lx={{ color: "base", marginBottom: "s4" }}>
+        {label}
+      </Text>
+      <Tag appearance={valueAppearance} size="sm" label={value} />
+    </Box>
+    <Button size="sm" appearance="no-background" onPress={onEdit}>
+      {editLabel}
+    </Button>
+  </Box>
+);
+
+export function NotificationsPromptQADebugView({
+  activeTab,
+  setActiveTab,
+  mode,
+  sources,
+  selectedSource,
+  setSelectedSource,
+  goVerify,
+  hero,
+  trace,
+  timing,
+  now,
+  globalPushVerdict,
+  transactionsAlertsOverview,
+  canTriggerViaProductionRules,
+  triggerViaProductionRulesDisabledReason,
+  triggerViaProductionRulesLabel,
+  permissionStatus,
+  notifications,
+  isFeatureEnabled,
+  isOverridden,
+  selectedActionEventEnabled,
+  transactionsAlertsConfiguredForSelectedSource,
+  dismissalHistory,
+  triggerViaProductionRules,
+  forceOpenDrawer,
+  toggleFeatureEnabled,
+  applyFastQaConfig,
+  toggleActionEventForSelectedSource,
+  toggleTransactionsAlertsPromptForSelectedSource,
+  restoreRemoteConfig,
+  navigateToNotificationsSettings,
+  openOsSettings,
+  simulateFullOptIn,
+  recordDismissalNow,
+  makeEligibleNow,
+  truncateDismissals,
+  resetAllQaState,
+}: NotificationsPromptQADebugViewModel) {
+  const decisionSectionProps: DecisionSectionProps = {
+    hero,
+    timing,
+    now,
+    trace,
+    canTriggerViaProductionRules,
+    triggerViaProductionRulesDisabledReason,
+    triggerViaProductionRulesLabel,
+    triggerViaProductionRules,
+    forceOpenDrawer,
+  };
+  const selectedSourceLabel =
+    sources.find(source => source.value === selectedSource)?.label ?? selectedSource;
+
+  return (
+    <Box lx={{ flex: 1 }}>
+      <TrackScreen category="Settings" name="DebugNotificationsPromptQA" />
+      {/* Fixed header (not part of the ScrollView): stays on screen while the tab content below
+          scrolls, so the tab switcher and — on "After an action" — the source picker/"Go verify"
+          link never require scrolling back up to reach. */}
+      <Box lx={{ paddingHorizontal: "s24", paddingTop: "s16" }}>
+        <SegmentedControl
+          selectedValue={activeTab}
+          onSelectedChange={setActiveTab}
+          accessibilityLabel="QA debug tab"
+          lx={{ marginBottom: "s16" }}
+        >
+          <SegmentedControlButton value="action">After an action</SegmentedControlButton>
+          <SegmentedControlButton value="inactivity">After inactivity</SegmentedControlButton>
+          <SegmentedControlButton value="config">Config & status</SegmentedControlButton>
+        </SegmentedControl>
+
+        <Box
+          lx={{
+            flexDirection: "row",
+            flexWrap: "wrap",
+            columnGap: "s8",
+            rowGap: "s8",
+            marginBottom: "s16",
+          }}
+        >
+          <Tag
+            appearance={isFeatureEnabled ? "success" : "error"}
+            size="sm"
+            label={`Feature ${isFeatureEnabled ? "ON" : "OFF"}`}
+          />
+          {isOverridden && <Tag appearance="warning" size="sm" label="OVERRIDDEN" />}
+          <Tag appearance="gray" size="sm" label={`OS: ${getPermissionLabel(permissionStatus)}`} />
+          <Tag
+            appearance={notifications.areNotificationsAllowed ? "success" : "gray"}
+            size="sm"
+            label={`Global push ${notifications.areNotificationsAllowed ? "ON" : "OFF"}`}
+          />
+          <Tag
+            appearance={notifications.transactionsAlertsCategory ? "success" : "gray"}
+            size="sm"
+            label={`Tx alerts ${notifications.transactionsAlertsCategory ? "ON" : "OFF"}`}
+          />
+        </Box>
+
+        {activeTab === "action" && (
+          <Box lx={{ marginBottom: "s16" }}>
+            <Box lx={{ flexDirection: "row", flexWrap: "wrap", columnGap: "s8", rowGap: "s8" }}>
+              {sources.map(source => (
+                <Button
+                  key={source.value}
+                  size="sm"
+                  appearance={selectedSource === source.value ? "accent" : "no-background"}
+                  onPress={() => setSelectedSource(source.value)}
+                >
+                  {source.label}
+                </Button>
+              ))}
+            </Box>
+            {goVerify && (
+              <Button
+                size="sm"
+                appearance="no-background"
+                onPress={goVerify}
+                lx={{ marginTop: "s8" }}
+              >
+                Go verify → open the real {selectedSourceLabel} flow
+              </Button>
+            )}
+          </Box>
+        )}
+      </Box>
+
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <Box lx={{ paddingHorizontal: "s24", paddingBottom: "s16" }}>
+          {activeTab === "action" && (
+            <>
+              <DecisionSection {...decisionSectionProps} />
+
+              <SectionLabel>PROMPT TARGETS FOR "{selectedSourceLabel}"</SectionLabel>
+              <Text typography="body3" lx={{ color: "muted", marginBottom: "s8" }}>
+                An action routes to exactly one of these, never both. Global push opt-in depends on
+                the selected source above; transaction alerts below is a static, source-independent
+                view of the real config.
+              </Text>
+              <Card type="info">
+                <Box lx={{ paddingHorizontal: "s16" }}>
+                  <PromptTargetRow verdict={globalPushVerdict} />
+                  <Divider />
+                  <TransactionsAlertsBreakdown overview={transactionsAlertsOverview} />
+                </Box>
+              </Card>
+            </>
+          )}
+
+          {activeTab === "inactivity" && <DecisionSection {...decisionSectionProps} />}
+
+          {activeTab === "config" && (
+            <>
+              <SectionLabel>CHANGE CONFIGS — remote flag (brazePushNotifications)</SectionLabel>
+              <Card type="info">
+                <Box lx={{ paddingHorizontal: "s16" }}>
+                  <Box
+                    lx={{
+                      flexDirection: "row",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                      paddingVertical: "s12",
+                    }}
+                  >
+                    <Text typography="body2" lx={{ color: "base" }}>
+                      Feature enabled
+                    </Text>
+                    <Switch checked={isFeatureEnabled} onCheckedChange={toggleFeatureEnabled} />
+                  </Box>
+                  <Divider />
+                  <Box
+                    lx={{
+                      flexDirection: "row",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                      paddingVertical: "s12",
+                    }}
+                  >
+                    <Text
+                      typography="body2"
+                      lx={{ color: "base", flexShrink: 1, paddingRight: "s12" }}
+                    >
+                      action_events[{selectedSource}].enabled
+                    </Text>
+                    <Switch
+                      checked={selectedActionEventEnabled}
+                      onCheckedChange={toggleActionEventForSelectedSource}
+                    />
+                  </Box>
+                  <Divider />
+                  <Box
+                    lx={{
+                      flexDirection: "row",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                      paddingVertical: "s12",
+                    }}
+                  >
+                    <Text
+                      typography="body2"
+                      lx={{ color: "base", flexShrink: 1, paddingRight: "s12" }}
+                    >
+                      Transaction alerts prompt for {selectedSource}
+                    </Text>
+                    <Switch
+                      checked={transactionsAlertsConfiguredForSelectedSource}
+                      onCheckedChange={toggleTransactionsAlertsPromptForSelectedSource}
+                    />
+                  </Box>
+                  <Divider />
+                  <Box lx={{ flexDirection: "row", columnGap: "s8", paddingVertical: "s12" }}>
+                    <Box lx={{ flex: 1 }}>
+                      <Button size="sm" appearance="accent" onPress={applyFastQaConfig}>
+                        Apply Fast QA mode (5s)
+                      </Button>
+                    </Box>
+                    <Box lx={{ flex: 1 }}>
+                      <Button
+                        size="sm"
+                        appearance="gray"
+                        onPress={restoreRemoteConfig}
+                        disabled={!isOverridden}
+                      >
+                        Restore remote config
+                      </Button>
+                    </Box>
+                  </Box>
+                </Box>
+              </Card>
+
+              <SectionLabel>USER STATUS</SectionLabel>
+              <Card type="info">
+                <Box lx={{ paddingHorizontal: "s16" }}>
+                  <StatusRow
+                    label="OS permission status"
+                    value={getPermissionLabel(permissionStatus)}
+                    valueAppearance={
+                      permissionStatus === AuthorizationStatus.AUTHORIZED ? "success" : "gray"
+                    }
+                    onEdit={openOsSettings}
+                    editLabel="Open OS settings"
+                  />
+                  <Divider />
+                  <StatusRow
+                    label="App notifications allowed"
+                    value={notifications.areNotificationsAllowed ? "ON" : "OFF"}
+                    valueAppearance={notifications.areNotificationsAllowed ? "success" : "gray"}
+                    onEdit={navigateToNotificationsSettings}
+                  />
+                  <Divider />
+                  <StatusRow
+                    label="Transaction alerts"
+                    value={notifications.transactionsAlertsCategory ? "ON" : "OFF"}
+                    valueAppearance={notifications.transactionsAlertsCategory ? "success" : "gray"}
+                    onEdit={navigateToNotificationsSettings}
+                  />
+                  <Divider />
+                  <Box lx={{ paddingVertical: "s12" }}>
+                    <Button
+                      size="sm"
+                      appearance="accent"
+                      onPress={simulateFullOptIn}
+                      lx={{ marginBottom: "s8" }}
+                    >
+                      Opt in for real (Braze + identify)
+                    </Button>
+                    <Button
+                      size="sm"
+                      appearance="gray"
+                      onPress={recordDismissalNow}
+                      lx={{ marginBottom: "s8" }}
+                    >
+                      Record a dismissal now
+                    </Button>
+                    <Button
+                      size="sm"
+                      appearance="gray"
+                      onPress={makeEligibleNow}
+                      lx={{ marginBottom: "s8" }}
+                    >
+                      {mode === "action"
+                        ? "Make eligible now (skip cooldown)"
+                        : "Make eligible now (backdate last action)"}
+                    </Button>
+                    <Button
+                      size="sm"
+                      appearance="gray"
+                      onPress={truncateDismissals}
+                      lx={{ marginBottom: "s8" }}
+                    >
+                      Truncate dismissal history to 1
+                    </Button>
+                    <Button size="sm" appearance="red" onPress={resetAllQaState}>
+                      Reset all QA state
+                    </Button>
+                  </Box>
+                </Box>
+              </Card>
+
+              {dismissalHistory.length > 0 && (
+                <Box lx={{ marginTop: "s24" }}>
+                  <SectionLabel>DISMISSAL HISTORY ({dismissalHistory.length})</SectionLabel>
+                  <Card type="info">
+                    <Box lx={{ paddingHorizontal: "s16" }}>
+                      {dismissalHistory.map(({ timestamp, formatted }, index) => (
+                        <Box key={timestamp}>
+                          <Box lx={{ paddingVertical: "s8" }}>
+                            <Text typography="body3" lx={{ color: "base" }}>
+                              {formatted?.local ?? `invalid (${timestamp})`}
+                            </Text>
+                          </Box>
+                          {index < dismissalHistory.length - 1 && <Divider />}
+                        </Box>
+                      ))}
+                    </Box>
+                  </Card>
+                </Box>
+              )}
+            </>
+          )}
+        </Box>
+      </ScrollView>
+    </Box>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    flexGrow: 1,
+  },
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptQADebug/__tests__/NotificationsPromptQADebug.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptQADebug/__tests__/NotificationsPromptQADebug.test.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { Linking } from "react-native";
+import { fireEvent } from "@testing-library/react-native";
+import { renderWithReactQuery as render, withFlagOverrides } from "@tests/test-renderer";
+import { NotificationsPromptProvider } from "LLM/features/NotificationsPrompt";
+import { ScreenName } from "~/const";
+import {
+  createNotificationsPromptFeatureFlags,
+  transactionsAlertsDrawerPromptCategoryConfig,
+} from "../../../testUtils";
+import { NotificationsPromptQADebugView } from "../NotificationsPromptQADebugView";
+import { useNotificationsPromptQADebugViewModel } from "../useNotificationsPromptQADebugViewModel";
+
+const mockNavigate = jest.fn();
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+  // The "Go verify" links reuse the same drawer-opening hooks as the real quick actions
+  // (useOpenReceiveDrawer/useOpenSwap/useOpenStakeDrawer), which call useRoute() internally.
+  useRoute: () => ({ key: "test", name: "DebugNotificationsPromptQA", params: undefined }),
+}));
+
+function NotificationsPromptQADebug() {
+  return <NotificationsPromptQADebugView {...useNotificationsPromptQADebugViewModel()} />;
+}
+
+const renderDebugScreen = () =>
+  render(
+    <NotificationsPromptProvider>
+      <NotificationsPromptQADebug />
+    </NotificationsPromptProvider>,
+    { overrideInitialState: withFlagOverrides(createNotificationsPromptFeatureFlags()) },
+  );
+
+describe("NotificationsPromptQADebug", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    jest.spyOn(Linking, "openSettings").mockResolvedValue();
+  });
+
+  it("renders the after-action tab without crashing and shows a verdict", () => {
+    const { getByText } = renderDebugScreen();
+    expect(getByText(/Drawer would/i)).toBeTruthy();
+  });
+
+  it("switches to the inactivity tab and re-renders without crashing", () => {
+    const { getByText } = renderDebugScreen();
+    fireEvent.press(getByText("After inactivity"));
+    expect(getByText(/Drawer would/i)).toBeTruthy();
+  });
+
+  it("switches the selected action source without crashing", () => {
+    const { getAllByText, getByText } = renderDebugScreen();
+    // "Receive" also appears in the static transaction-alerts breakdown, so scope to the chip.
+    fireEvent.press(getAllByText("Receive")[0]);
+    expect(getByText(/Drawer would/i)).toBeTruthy();
+  });
+
+  it("shows both prompt-target rows on the after-action tab, with only one marked live", () => {
+    const { getByText, getAllByText } = render(
+      <NotificationsPromptProvider>
+        <NotificationsPromptQADebug />
+      </NotificationsPromptProvider>,
+      {
+        overrideInitialState: withFlagOverrides(
+          createNotificationsPromptFeatureFlags({
+            notificationsCategories: [transactionsAlertsDrawerPromptCategoryConfig],
+          }),
+        ),
+      },
+    );
+    expect(getByText("Global push opt-in")).toBeTruthy();
+    expect(getByText("Transaction alerts")).toBeTruthy();
+    // Not opted in to global push yet -> that target is the live one, tx alerts is hypothetical.
+    expect(getAllByText("LIVE NOW")).toHaveLength(1);
+    // Static per-source breakdown (drawerPromptActions: ["send", "receive"]), independent of selection.
+    expect(getByText(/Per action, against the real configured drawerPromptActions/)).toBeTruthy();
+    expect(getAllByText("Eligible")).toHaveLength(2); // send, receive
+    expect(getAllByText("Not eligible")).toHaveLength(5); // onboarding, dapp_complete, swap, stake, add_favorite_coin
+  });
+
+  it("disables the production-rules trigger with a reason when the decision is a skip", () => {
+    // createNotificationsPromptFeatureFlags shares its action_events object across calls —
+    // clone before mutating so this doesn't leak into other tests in this file.
+    const flags = structuredClone(createNotificationsPromptFeatureFlags());
+    flags.brazePushNotifications.params.action_events.send.enabled = false;
+    const { getByText } = render(
+      <NotificationsPromptProvider>
+        <NotificationsPromptQADebug />
+      </NotificationsPromptProvider>,
+      { overrideInitialState: withFlagOverrides(flags) },
+    );
+
+    expect(getByText(/^Disabled — /)).toBeTruthy();
+  });
+
+  it("enables the production-rules trigger with a target-aware label when the decision shows", () => {
+    const { getByText } = renderDebugScreen();
+    expect(getByText(/Trigger via production rules → opens .* \(real analytics\)/)).toBeTruthy();
+  });
+
+  it("navigates to the real Notifications settings screen when editing app notifications", () => {
+    const { getByText, getAllByText } = renderDebugScreen();
+    fireEvent.press(getByText("Config & status"));
+    fireEvent.press(getAllByText("Edit")[0]);
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.NotificationsSettings);
+  });
+
+  it("opens the OS settings app when editing OS permission status", () => {
+    const { getByText } = renderDebugScreen();
+    fireEvent.press(getByText("Config & status"));
+    fireEvent.press(getByText("Open OS settings"));
+    expect(Linking.openSettings).toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptQADebug/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptQADebug/index.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { NotificationsPromptQADebugView } from "./NotificationsPromptQADebugView";
+import { useNotificationsPromptQADebugViewModel } from "./useNotificationsPromptQADebugViewModel";
+
+export default function NotificationsPromptQADebug() {
+  return <NotificationsPromptQADebugView {...useNotificationsPromptQADebugViewModel()} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptQADebug/useNotificationsPromptQADebugViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptQADebug/useNotificationsPromptQADebugViewModel.ts
@@ -1,0 +1,631 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Linking } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import { AuthorizationStatus } from "@react-native-firebase/messaging";
+import { useFeature } from "@features/platform-feature-flags";
+import { featureFlagsOverridesSelector, setOverride } from "@shared/feature-flags";
+import { useDispatch, useSelector } from "~/context/hooks";
+import { setNotifications } from "~/actions/settings";
+import { notificationsSelector, hasCompletedOnboardingSelector } from "~/reducers/settings";
+import { ratingsModalOpenSelector } from "~/reducers/ratings";
+import { NavigatorName, ScreenName } from "~/const";
+import type {
+  BaseNavigationComposite,
+  StackNavigatorNavigation,
+} from "~/components/RootNavigator/types/helpers";
+import type { SettingsNavigatorStackParamList } from "~/components/RootNavigator/types/SettingsNavigator";
+import { useOpenReceiveDrawer } from "LLM/features/Receive";
+import { useOpenSwap } from "LLM/features/Swap";
+import { useOpenStakeDrawer } from "LLM/features/Stake";
+import {
+  AFTER_ACTION_SOURCE_TO_EVENT_KEY,
+  canPromptTransactionsAlertsForAction,
+  evaluateAfterActionTrigger,
+  evaluateInactivityTrigger,
+  getNotificationPromptTarget,
+  useNotificationsContext,
+  useNotificationsData,
+  type AfterActionTriggerDecision,
+  type InactivityTriggerDecision,
+  type NotificationsPromptAfterActionSource,
+  type NotificationsPromptSkipReason,
+} from "LLM/features/NotificationsPrompt";
+import { useNotificationsPermission } from "LLM/hooks/useNotificationsPermission";
+import { useNotificationsPromptDrawerScheduler } from "LLM/features/NotificationsPrompt/new/hooks/useNotificationsPromptDrawerScheduler";
+import {
+  buildActionEventToggleOverride,
+  buildAfterActionTrace,
+  buildFastQaFeatureOverride,
+  buildInactiveUserData,
+  buildInactivityTrace,
+  buildRepromptableUserData,
+  buildTransactionsAlertsPromptToggleOverride,
+  buildTruncatedDismissalsUserData,
+  formatTimestamp,
+  getDismissalsForTarget,
+  getInactivityRepromptTiming,
+  getRepromptTiming,
+  type TraceStep,
+} from "../../utils/notificationsPromptDebug";
+
+const FEATURE_FLAG_KEY = "brazePushNotifications" as const;
+
+const ACTION_SOURCES: { value: NotificationsPromptAfterActionSource; label: string }[] = [
+  { value: "onboarding", label: "Onboarding" },
+  { value: "send", label: "Send" },
+  { value: "receive", label: "Receive" },
+  { value: "dapp_complete", label: "DApp" },
+  { value: "swap", label: "Swap" },
+  { value: "stake", label: "Stake" },
+  { value: "add_favorite_coin", label: "Favorite" },
+];
+
+const SKIP_REASON_COPY: Record<
+  NotificationsPromptSkipReason,
+  { headline: string; severity: "blocker" | "info" }
+> = {
+  feature_disabled: {
+    headline: "brazePushNotifications (or a required sub-flag) is disabled.",
+    severity: "blocker",
+  },
+  configuration_missing: {
+    headline: "Required remote configuration is missing for this check.",
+    severity: "blocker",
+  },
+  ratings_modal_open: {
+    headline: "The App Store ratings modal is currently open.",
+    severity: "blocker",
+  },
+  drawer_already_pending: {
+    headline: "Another notifications drawer is already open or scheduled.",
+    severity: "blocker",
+  },
+  fully_opted_in: {
+    headline: "Already fully opted in — nothing left to prompt for.",
+    severity: "info",
+  },
+  reprompt_delay_not_reached: {
+    headline: "The dismissal cooldown hasn't elapsed yet.",
+    severity: "info",
+  },
+  action_event_disabled: {
+    headline: "This action is disabled in action_events.",
+    severity: "blocker",
+  },
+  transactions_alerts_not_eligible: {
+    headline: "Transaction alerts aren't configured to prompt for this action.",
+    severity: "blocker",
+  },
+  onboarding_incomplete: {
+    headline: "The user hasn't completed onboarding yet.",
+    severity: "info",
+  },
+  user_not_inactive: {
+    headline: "The user hasn't been inactive long enough yet.",
+    severity: "info",
+  },
+  globally_opted_in_no_inactivity_drawer: {
+    headline: "Already opted in to global push — inactivity only targets that.",
+    severity: "info",
+  },
+};
+
+const TARGET_LABEL: Record<"globalPushNotifications" | "transactionsAlertsCategory", string> = {
+  globalPushNotifications: "Global push opt-in",
+  transactionsAlertsCategory: "Transaction alerts",
+};
+
+export type NotificationsPromptQADebugMode = "action" | "inactivity";
+export type NotificationsPromptQADebugTab = NotificationsPromptQADebugMode | "config";
+
+export type NotificationsPromptQADebugHero = {
+  wouldShow: boolean;
+  appearance: "success" | "warning" | "error";
+  title: string;
+  description: string;
+};
+
+/** Verdict for one specific prompt target, shown as its own row on the "After an action" tab. */
+export type PromptTargetVerdict = {
+  target: "globalPushNotifications" | "transactionsAlertsCategory";
+  label: string;
+  isLive: boolean;
+  wouldShow: boolean;
+  reasonLabel: string | null;
+};
+
+/** Static (selectedSource-independent) breakdown for the "Transaction alerts" row. */
+export type TransactionsAlertsOverview = {
+  isLive: boolean;
+  blockedReason: string | null;
+  perSourceEligibility: {
+    value: NotificationsPromptAfterActionSource;
+    label: string;
+    eligible: boolean;
+  }[];
+};
+
+// Hypothetical opt-in input used to preview the "Global push opt-in" verdict when transaction
+// alerts is the real live target right now. Only the opt-in fields matter here — everything
+// else (dismissals, config, ratings modal, etc.) still comes from the real current state.
+const HYPOTHETICAL_NOT_OPTED_IN = {
+  permissionStatus: AuthorizationStatus.NOT_DETERMINED,
+  areNotificationsAllowed: false,
+} as const;
+
+// "Go verify" — for each real per-action source, jump to the actual screen/flow that would
+// normally trigger it, reusing existing routes/hooks (same ones the real quick actions use).
+// Deliberately a tiny inline map (not a registry): there is exactly one caller and exactly 7
+// sources, of which "onboarding" intentionally has no verify target.
+const QA_DEBUG_SOURCE_SCREEN_NAME = "DebugNotificationsPromptQA";
+
+const useLiveNow = () => {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+  return now;
+};
+
+export const useNotificationsPromptQADebugViewModel = () => {
+  const dispatch = useDispatch();
+  const navigation =
+    useNavigation<
+      BaseNavigationComposite<StackNavigatorNavigation<SettingsNavigatorStackParamList>>
+    >();
+  const now = useLiveNow();
+
+  const { handleOpenReceiveDrawer } = useOpenReceiveDrawer({
+    sourceScreenName: QA_DEBUG_SOURCE_SCREEN_NAME,
+  });
+  const { handleOpenSwap } = useOpenSwap({ sourceScreenName: QA_DEBUG_SOURCE_SCREEN_NAME });
+  const { handleOpenStakeDrawer } = useOpenStakeDrawer({
+    sourceScreenName: QA_DEBUG_SOURCE_SCREEN_NAME,
+  });
+  const goVerifyBySource: Partial<Record<NotificationsPromptAfterActionSource, () => void>> = {
+    send: () => navigation.navigate(NavigatorName.SendFunds, { screen: ScreenName.SendCoin }),
+    receive: handleOpenReceiveDrawer,
+    swap: handleOpenSwap,
+    stake: handleOpenStakeDrawer,
+    dapp_complete: () =>
+      navigation.navigate(NavigatorName.Discover, { screen: ScreenName.DiscoverScreen }),
+    add_favorite_coin: () => navigation.navigate(ScreenName.MarketList),
+  };
+
+  // `activeTab` drives the SegmentedControl (3 tabs). `mode` tracks which trace ("action" or
+  // "inactivity") the decision/trace/scenario-prep controls apply to — it stays on its last
+  // value while the user is on the "config" tab, so config-tab scenario actions keep acting on
+  // whichever trace the user was just looking at.
+  const [activeTab, setActiveTabState] = useState<NotificationsPromptQADebugTab>("action");
+  const [mode, setMode] = useState<NotificationsPromptQADebugMode>("action");
+  const setActiveTab = useCallback((tab: NotificationsPromptQADebugTab) => {
+    setActiveTabState(tab);
+    if (tab !== "config") setMode(tab);
+  }, []);
+
+  const [selectedSource, setSelectedSource] =
+    useState<NotificationsPromptAfterActionSource>("send");
+  const goVerify = goVerifyBySource[selectedSource] ?? null;
+
+  const brazePushNotifications = useFeature(FEATURE_FLAG_KEY);
+  const overrides = useSelector(featureFlagsOverridesSelector);
+  const isOverridden = overrides[FEATURE_FLAG_KEY] !== undefined;
+
+  const notifications = useSelector(notificationsSelector);
+  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const isRatingsModalOpen = useSelector(ratingsModalOpenSelector);
+
+  const { permissionStatus, setPermissionStatus } = useNotificationsPermission();
+  const {
+    pushNotificationsDataOfUser,
+    updatePushNotificationsDataOfUserInStateAndStore,
+    enableAppNotifications,
+    markUserAsOptIn,
+    markUserAsOptOut,
+  } = useNotificationsData();
+  const { notifyFlowCompleted, tryTriggerPushNotificationDrawerAfterInactivity } =
+    useNotificationsContext();
+  const { openDrawer, isDrawerPending } = useNotificationsPromptDrawerScheduler();
+
+  const { areNotificationsAllowed, transactionsAlertsCategory } = notifications;
+  const globallyOptedIn =
+    permissionStatus === AuthorizationStatus.AUTHORIZED && areNotificationsAllowed === true;
+  const promptTarget = getNotificationPromptTarget({
+    permissionStatus,
+    areNotificationsAllowed,
+    transactionsAlertsCategory,
+  });
+  const isDrawerBusy = isDrawerPending();
+
+  const evaluationContext = useMemo(
+    () => ({ brazePushNotifications, isRatingsModalOpen, isDrawerPending: isDrawerBusy, now }),
+    [brazePushNotifications, isRatingsModalOpen, isDrawerBusy, now],
+  );
+
+  const afterActionDecision: AfterActionTriggerDecision = useMemo(
+    () =>
+      evaluateAfterActionTrigger(
+        {
+          source: selectedSource,
+          permissionStatus,
+          areNotificationsAllowed,
+          transactionsAlertsCategory,
+          pushNotificationsDataOfUser,
+        },
+        evaluationContext,
+      ),
+    [
+      selectedSource,
+      permissionStatus,
+      areNotificationsAllowed,
+      transactionsAlertsCategory,
+      pushNotificationsDataOfUser,
+      evaluationContext,
+    ],
+  );
+
+  const inactivityDecision: InactivityTriggerDecision = useMemo(
+    () =>
+      evaluateInactivityTrigger(
+        {
+          permissionStatus,
+          areNotificationsAllowed,
+          pushNotificationsDataOfUser,
+          hasCompletedOnboarding,
+        },
+        evaluationContext,
+      ),
+    [
+      permissionStatus,
+      areNotificationsAllowed,
+      pushNotificationsDataOfUser,
+      hasCompletedOnboarding,
+      evaluationContext,
+    ],
+  );
+
+  const decision = mode === "action" ? afterActionDecision : inactivityDecision;
+
+  const hasActionEventsConfig = !!brazePushNotifications?.params?.action_events;
+  const actionEventKey = AFTER_ACTION_SOURCE_TO_EVENT_KEY[selectedSource];
+  const hasActionEventForSource = !!brazePushNotifications?.params?.action_events?.[actionEventKey];
+  const selectedActionEvent = brazePushNotifications?.params?.action_events?.[actionEventKey];
+
+  // --- Tab 1: dual prompt-target clarity ----------------------------------
+  // A given action can only ever route to ONE of the two targets (per getNotificationPromptTarget).
+  // For the target that isn't "live" right now, re-run the same engine function with a
+  // hypothetical opt-in state so QA still sees a real (not fabricated) verdict for it.
+  const globalPushDecision: AfterActionTriggerDecision = useMemo(
+    () =>
+      promptTarget === "globalPushNotifications"
+        ? afterActionDecision
+        : evaluateAfterActionTrigger(
+            {
+              source: selectedSource,
+              ...HYPOTHETICAL_NOT_OPTED_IN,
+              transactionsAlertsCategory,
+              pushNotificationsDataOfUser,
+            },
+            evaluationContext,
+          ),
+    [
+      promptTarget,
+      afterActionDecision,
+      selectedSource,
+      transactionsAlertsCategory,
+      pushNotificationsDataOfUser,
+      evaluationContext,
+    ],
+  );
+
+  const globalPushVerdict: PromptTargetVerdict = {
+    target: "globalPushNotifications",
+    label: TARGET_LABEL.globalPushNotifications,
+    isLive: promptTarget === "globalPushNotifications",
+    wouldShow: globalPushDecision.kind === "show",
+    reasonLabel:
+      globalPushDecision.kind === "skip"
+        ? SKIP_REASON_COPY[globalPushDecision.reason].headline
+        : null,
+  };
+
+  // Transaction alerts is intentionally NOT re-evaluated per selectedSource: QA found a single
+  // "would show/blocked" verdict that silently changed as they clicked through sources confusing
+  // (e.g. for "receive"). Instead this row shows only the gates that don't depend on which source
+  // is selected, plus a static per-source breakdown against the real configured
+  // `drawerPromptActions` list (via the same engine function used everywhere else).
+  const transactionsAlertsBlockedReason = !brazePushNotifications?.enabled
+    ? SKIP_REASON_COPY.feature_disabled.headline
+    : isRatingsModalOpen
+      ? SKIP_REASON_COPY.ratings_modal_open.headline
+      : isDrawerBusy
+        ? SKIP_REASON_COPY.drawer_already_pending.headline
+        : transactionsAlertsCategory === true
+          ? SKIP_REASON_COPY.fully_opted_in.headline
+          : null;
+
+  const transactionsAlertsOverview: TransactionsAlertsOverview = {
+    isLive: promptTarget === "transactionsAlertsCategory",
+    blockedReason: transactionsAlertsBlockedReason,
+    perSourceEligibility: ACTION_SOURCES.map(source => ({
+      value: source.value,
+      label: source.label,
+      eligible: canPromptTransactionsAlertsForAction(
+        source.value,
+        brazePushNotifications?.params?.notificationsCategories,
+      ),
+    })),
+  };
+
+  const trace: TraceStep[] = useMemo(
+    () =>
+      mode === "action"
+        ? buildAfterActionTrace(afterActionDecision, {
+            globallyOptedIn,
+            hasActionEventsConfig,
+            hasActionEventForSource,
+          })
+        : buildInactivityTrace(inactivityDecision, {
+            isFeatureEnabled: !!brazePushNotifications?.enabled,
+          }),
+    [
+      mode,
+      afterActionDecision,
+      inactivityDecision,
+      globallyOptedIn,
+      hasActionEventsConfig,
+      hasActionEventForSource,
+      brazePushNotifications?.enabled,
+    ],
+  );
+
+  const hero: NotificationsPromptQADebugHero = useMemo(() => {
+    if (decision.kind === "show") {
+      return {
+        wouldShow: true,
+        appearance: "success",
+        title: "Drawer would show",
+        description: `Target: ${TARGET_LABEL[decision.drawerPromptTarget as keyof typeof TARGET_LABEL] ?? decision.drawerPromptTarget} · opens after ${decision.delayMs}ms`,
+      };
+    }
+
+    const copy = SKIP_REASON_COPY[decision.reason];
+    return {
+      wouldShow: false,
+      appearance: copy.severity === "info" ? "warning" : "error",
+      title: "Drawer would not show",
+      description: copy.headline,
+    };
+  }, [decision]);
+
+  const timing =
+    mode === "action"
+      ? getRepromptTiming({
+          dismissals: getDismissalsForTarget(
+            pushNotificationsDataOfUser,
+            promptTarget ?? "globalPushNotifications",
+          ),
+          repromptSchedule: brazePushNotifications?.params?.reprompt_schedule,
+          now,
+        })
+      : getInactivityRepromptTiming({
+          inactivityEnabled: brazePushNotifications?.params?.inactivity_enabled,
+          inactivityReprompt: brazePushNotifications?.params?.inactivity_reprompt,
+          lastActionAt: pushNotificationsDataOfUser?.lastActionAt,
+          now,
+        });
+
+  // --- Tab 1/2: "Trigger via production rules" must reflect eligibility ---
+  const canTriggerViaProductionRules = decision.kind === "show";
+  const triggerViaProductionRulesDisabledReason =
+    decision.kind === "skip" ? SKIP_REASON_COPY[decision.reason].headline : null;
+  const triggerViaProductionRulesLabel =
+    decision.kind === "show"
+      ? `Trigger via production rules → opens ${TARGET_LABEL[decision.drawerPromptTarget as keyof typeof TARGET_LABEL] ?? decision.drawerPromptTarget} (real analytics)`
+      : "Trigger via production rules (real analytics)";
+
+  // --- Live actions -------------------------------------------------------
+
+  const triggerViaProductionRules = useCallback(() => {
+    if (!canTriggerViaProductionRules) return;
+
+    if (mode === "action") {
+      notifyFlowCompleted(selectedSource);
+      return;
+    }
+
+    tryTriggerPushNotificationDrawerAfterInactivity({
+      status: "success",
+      storedUserData: pushNotificationsDataOfUser ?? null,
+      osPermissionStatus: permissionStatus ?? AuthorizationStatus.NOT_DETERMINED,
+      areAppNotificationsEnabled: notifications.areNotificationsAllowed ?? false,
+    });
+  }, [
+    canTriggerViaProductionRules,
+    mode,
+    notifyFlowCompleted,
+    selectedSource,
+    tryTriggerPushNotificationDrawerAfterInactivity,
+    pushNotificationsDataOfUser,
+    permissionStatus,
+    notifications.areNotificationsAllowed,
+  ]);
+
+  const forceOpenDrawer = useCallback(
+    (target: "globalPushNotifications" | "transactionsAlertsCategory") => {
+      openDrawer(mode === "action" ? selectedSource : "inactivity", 0, target);
+    },
+    [mode, selectedSource, openDrawer],
+  );
+
+  // --- Remote config overrides --------------------------------------------
+
+  const toggleFeatureEnabled = useCallback(() => {
+    dispatch(
+      setOverride({
+        key: FEATURE_FLAG_KEY,
+        value: { ...brazePushNotifications, enabled: !brazePushNotifications?.enabled },
+      }),
+    );
+  }, [dispatch, brazePushNotifications]);
+
+  const applyFastQaConfig = useCallback(() => {
+    dispatch(
+      setOverride({
+        key: FEATURE_FLAG_KEY,
+        value: buildFastQaFeatureOverride(brazePushNotifications),
+      }),
+    );
+  }, [dispatch, brazePushNotifications]);
+
+  const toggleActionEventForSelectedSource = useCallback(() => {
+    dispatch(
+      setOverride({
+        key: FEATURE_FLAG_KEY,
+        value: buildActionEventToggleOverride(brazePushNotifications, selectedSource),
+      }),
+    );
+  }, [dispatch, brazePushNotifications, selectedSource]);
+
+  const toggleTransactionsAlertsPromptForSelectedSource = useCallback(() => {
+    dispatch(
+      setOverride({
+        key: FEATURE_FLAG_KEY,
+        value: buildTransactionsAlertsPromptToggleOverride(brazePushNotifications, selectedSource),
+      }),
+    );
+  }, [dispatch, brazePushNotifications, selectedSource]);
+
+  const restoreRemoteConfig = useCallback(() => {
+    dispatch(setOverride({ key: FEATURE_FLAG_KEY, value: undefined }));
+  }, [dispatch]);
+
+  // --- User status: read-only + deep links to the real settings screens ---
+
+  const navigateToNotificationsSettings = useCallback(() => {
+    navigation.navigate(ScreenName.NotificationsSettings);
+  }, [navigation]);
+
+  const openOsSettings = useCallback(() => {
+    Linking.openSettings();
+  }, []);
+
+  // --- Simulate user state (scenario prep with no real-screen equivalent) -
+
+  const simulateFullOptIn = useCallback(() => {
+    enableAppNotifications();
+    setPermissionStatus(AuthorizationStatus.AUTHORIZED);
+    markUserAsOptIn();
+  }, [enableAppNotifications, setPermissionStatus, markUserAsOptIn]);
+
+  const recordDismissalNow = useCallback(() => {
+    markUserAsOptOut(promptTarget ?? undefined);
+  }, [markUserAsOptOut, promptTarget]);
+
+  const makeEligibleNow = useCallback(() => {
+    const target = promptTarget ?? "globalPushNotifications";
+    const next =
+      mode === "action"
+        ? buildRepromptableUserData(
+            pushNotificationsDataOfUser,
+            target,
+            brazePushNotifications?.params?.reprompt_schedule,
+            now,
+          )
+        : buildInactiveUserData(
+            pushNotificationsDataOfUser,
+            brazePushNotifications?.params?.inactivity_reprompt,
+            now,
+          );
+
+    if (next) {
+      updatePushNotificationsDataOfUserInStateAndStore(next);
+    }
+  }, [
+    mode,
+    promptTarget,
+    pushNotificationsDataOfUser,
+    brazePushNotifications?.params?.reprompt_schedule,
+    brazePushNotifications?.params?.inactivity_reprompt,
+    now,
+    updatePushNotificationsDataOfUserInStateAndStore,
+  ]);
+
+  const truncateDismissals = useCallback(() => {
+    updatePushNotificationsDataOfUserInStateAndStore(
+      buildTruncatedDismissalsUserData(
+        pushNotificationsDataOfUser,
+        promptTarget ?? "globalPushNotifications",
+        1,
+      ),
+    );
+  }, [pushNotificationsDataOfUser, promptTarget, updatePushNotificationsDataOfUserInStateAndStore]);
+
+  const resetAllQaState = useCallback(() => {
+    updatePushNotificationsDataOfUserInStateAndStore({});
+    dispatch(
+      setNotifications({ areNotificationsAllowed: false, transactionsAlertsCategory: false }),
+    );
+    setPermissionStatus(AuthorizationStatus.NOT_DETERMINED);
+  }, [updatePushNotificationsDataOfUserInStateAndStore, dispatch, setPermissionStatus]);
+
+  const dismissalHistory = useMemo(() => {
+    const dismissals =
+      getDismissalsForTarget(
+        pushNotificationsDataOfUser,
+        promptTarget ?? "globalPushNotifications",
+      ) ?? [];
+    return dismissals
+      .slice()
+      .reverse()
+      .map(timestamp => ({ timestamp, formatted: formatTimestamp(timestamp) }));
+  }, [pushNotificationsDataOfUser, promptTarget]);
+
+  return {
+    activeTab,
+    setActiveTab,
+    mode,
+    sources: ACTION_SOURCES,
+    selectedSource,
+    setSelectedSource,
+    goVerify,
+    hero,
+    trace,
+    timing,
+    now,
+    globalPushVerdict,
+    transactionsAlertsOverview,
+    canTriggerViaProductionRules,
+    triggerViaProductionRulesDisabledReason,
+    triggerViaProductionRulesLabel,
+    permissionStatus,
+    notifications,
+    isFeatureEnabled: !!brazePushNotifications?.enabled,
+    isOverridden,
+    selectedActionEventEnabled: selectedActionEvent?.enabled ?? false,
+    transactionsAlertsConfiguredForSelectedSource: canPromptTransactionsAlertsForAction(
+      selectedSource,
+      brazePushNotifications?.params?.notificationsCategories,
+    ),
+    dismissalHistory,
+    triggerViaProductionRules,
+    forceOpenDrawer,
+    toggleFeatureEnabled,
+    applyFastQaConfig,
+    toggleActionEventForSelectedSource,
+    toggleTransactionsAlertsPromptForSelectedSource,
+    restoreRemoteConfig,
+    navigateToNotificationsSettings,
+    openOsSettings,
+    simulateFullOptIn,
+    recordDismissalNow,
+    makeEligibleNow,
+    truncateDismissals,
+    resetAllQaState,
+  };
+};
+
+export type NotificationsPromptQADebugViewModel = ReturnType<
+  typeof useNotificationsPromptQADebugViewModel
+>;

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/__tests__/notificationsPromptDebug.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/__tests__/notificationsPromptDebug.test.ts
@@ -1,0 +1,478 @@
+import { sub } from "date-fns";
+import { AuthorizationStatus } from "@react-native-firebase/messaging";
+import type { Features } from "@shared/feature-flags";
+import {
+  evaluateAfterActionTrigger,
+  evaluateInactivityTrigger,
+} from "../notificationsPromptEngine";
+import {
+  FAST_QA_DELAY,
+  buildActionEventToggleOverride,
+  buildAfterActionTrace,
+  buildFastQaFeatureOverride,
+  buildInactiveUserData,
+  buildInactivityTrace,
+  buildRepromptableUserData,
+  buildTransactionsAlertsPromptToggleOverride,
+  buildTruncatedDismissalsUserData,
+  formatTimestamp,
+  getDismissalsForTarget,
+  getInactivityRepromptTiming,
+  getRepromptTiming,
+} from "../notificationsPromptDebug";
+
+type BrazePushNotifications = Features["brazePushNotifications"];
+type BrazeParams = NonNullable<BrazePushNotifications["params"]>;
+
+const NOW = new Date("2026-01-01T00:00:00.000Z").getTime();
+const WEEK: BrazeParams["reprompt_schedule"][number] = {
+  months: 0,
+  days: 7,
+  hours: 0,
+  minutes: 0,
+  seconds: 0,
+};
+
+const defaultParams: BrazeParams = {
+  reprompt_schedule: [WEEK],
+  action_events: {
+    complete_onboarding: { enabled: true, timer: 0 },
+    send: { enabled: true, timer: 0 },
+    dapp_complete: { enabled: true, timer: 0 },
+    receive: { enabled: true, timer: 0 },
+    buy: { enabled: true, timer: 0 },
+    swap: { enabled: true, timer: 0 },
+    stake: { enabled: true, timer: 0 },
+    add_favorite_coin: { enabled: true, timer: 0 },
+  },
+  inactivity_enabled: true,
+  inactivity_reprompt: { months: 6, days: 0, hours: 0, minutes: 0, seconds: 0 },
+  notificationsCategories: [],
+};
+
+const createFeature = (overrides?: Partial<BrazeParams>): BrazePushNotifications =>
+  ({ enabled: true, params: { ...defaultParams, ...overrides } }) as BrazePushNotifications;
+
+describe("notificationsPromptDebug: timing math", () => {
+  describe("getDismissalsForTarget", () => {
+    it("falls back to the legacy list for globalPushNotifications", () => {
+      expect(
+        getDismissalsForTarget({ dismissedOptInDrawerAtList: [1, 2] }, "globalPushNotifications"),
+      ).toEqual([1, 2]);
+    });
+
+    it("prefers the per-target list when present", () => {
+      expect(
+        getDismissalsForTarget(
+          {
+            dismissedOptInDrawerAtList: [1],
+            dismissedPromptAtListByTarget: { globalPushNotifications: [2, 3] },
+          },
+          "globalPushNotifications",
+        ),
+      ).toEqual([2, 3]);
+    });
+  });
+
+  describe("getRepromptTiming", () => {
+    it("is eligible on the first prompt (no dismissals yet)", () => {
+      expect(
+        getRepromptTiming({ dismissals: undefined, repromptSchedule: [WEEK], now: NOW }),
+      ).toEqual({
+        state: "eligible",
+        eligibleAt: null,
+        startAt: null,
+        remaining: "now (first prompt)",
+      });
+    });
+
+    it("is exactly eligible at the boundary and reports startAt for the timeline", () => {
+      const dismissedAt = NOW - 7 * 24 * 60 * 60 * 1000;
+      const timing = getRepromptTiming({
+        dismissals: [dismissedAt],
+        repromptSchedule: [WEEK],
+        now: NOW,
+      });
+      expect(timing.state).toBe("eligible");
+      expect(timing.startAt).toBe(dismissedAt);
+      expect(timing.eligibleAt).toBe(NOW);
+    });
+
+    it("is waiting one millisecond before the boundary", () => {
+      const dismissedAt = NOW - 7 * 24 * 60 * 60 * 1000 + 1;
+      expect(
+        getRepromptTiming({ dismissals: [dismissedAt], repromptSchedule: [WEEK], now: NOW }).state,
+      ).toBe("waiting");
+    });
+
+    it("reports a missing schedule", () => {
+      expect(getRepromptTiming({ dismissals: [NOW], repromptSchedule: [], now: NOW }).state).toBe(
+        "missing",
+      );
+    });
+  });
+
+  describe("getInactivityRepromptTiming", () => {
+    it("reports disabled when inactivity is off", () => {
+      expect(
+        getInactivityRepromptTiming({
+          inactivityEnabled: false,
+          inactivityReprompt: WEEK,
+          lastActionAt: NOW,
+          now: NOW,
+        }).state,
+      ).toBe("disabled");
+    });
+
+    it("is exactly eligible at the boundary", () => {
+      const lastActionAt = NOW - 7 * 24 * 60 * 60 * 1000;
+      expect(
+        getInactivityRepromptTiming({
+          inactivityEnabled: true,
+          inactivityReprompt: WEEK,
+          lastActionAt,
+          now: NOW,
+        }).state,
+      ).toBe("eligible");
+    });
+
+    // Regression: the real engine (checkIsInactive) only checks that inactivityReprompt is
+    // truthy before handing it to date-fns' `add`, which treats missing keys as 0 — it never
+    // requires all 5 duration keys. A partial delay (as reported by QA) must NOT be reported as
+    // "missing" here, or the trace checklist ("configuration is present") and the cooldown line
+    // ("schedule missing") visibly contradict each other.
+    it("treats a partial delay (missing keys) as present, matching the engine's own leniency", () => {
+      const partialWeek = { days: 7 } as BrazeParams["inactivity_reprompt"];
+      const lastActionAt = NOW - 7 * 24 * 60 * 60 * 1000;
+      const timing = getInactivityRepromptTiming({
+        inactivityEnabled: true,
+        inactivityReprompt: partialWeek,
+        lastActionAt,
+        now: NOW,
+      });
+      expect(timing.state).not.toBe("missing");
+      expect(timing.state).toBe("eligible");
+    });
+  });
+
+  describe("scenario builders round-trip through the real engine", () => {
+    it("buildRepromptableUserData makes the after-action trigger show", () => {
+      const feature = createFeature();
+      const dataOfUser = buildRepromptableUserData(
+        { dismissedOptInDrawerAtList: [NOW - 1000] },
+        "globalPushNotifications",
+        feature.params!.reprompt_schedule,
+        NOW,
+      );
+
+      const decision = evaluateAfterActionTrigger(
+        {
+          source: "send",
+          permissionStatus: AuthorizationStatus.NOT_DETERMINED,
+          areNotificationsAllowed: false,
+          transactionsAlertsCategory: false,
+          pushNotificationsDataOfUser: dataOfUser,
+        },
+        {
+          brazePushNotifications: feature,
+          isRatingsModalOpen: false,
+          isDrawerPending: false,
+          now: NOW,
+        },
+      );
+
+      expect(decision.kind).toBe("show");
+    });
+
+    it("buildInactiveUserData makes the inactivity trigger show", () => {
+      const feature = createFeature();
+      const dataOfUser = buildInactiveUserData(null, feature.params!.inactivity_reprompt, NOW);
+
+      const decision = evaluateInactivityTrigger(
+        {
+          permissionStatus: AuthorizationStatus.NOT_DETERMINED,
+          areNotificationsAllowed: false,
+          pushNotificationsDataOfUser: dataOfUser,
+          hasCompletedOnboarding: true,
+        },
+        {
+          brazePushNotifications: feature,
+          isRatingsModalOpen: false,
+          isDrawerPending: false,
+          now: NOW,
+        },
+      );
+
+      expect(decision.kind).toBe("show");
+    });
+
+    it("buildTruncatedDismissalsUserData keeps only the requested count", () => {
+      const result = buildTruncatedDismissalsUserData(
+        { dismissedOptInDrawerAtList: [1, 2, 3] },
+        "globalPushNotifications",
+        1,
+      );
+      expect(result.dismissedOptInDrawerAtList).toEqual([1]);
+      expect(result.dismissedPromptAtListByTarget?.globalPushNotifications).toEqual([1]);
+    });
+  });
+
+  describe("formatTimestamp", () => {
+    it("returns null for invalid input", () => {
+      expect(formatTimestamp(NaN)).toBeNull();
+    });
+
+    it("formats a valid timestamp", () => {
+      expect(formatTimestamp(NOW)?.iso).toBe("2026-01-01T00:00:00.000Z");
+    });
+  });
+});
+
+describe("notificationsPromptDebug: config overrides", () => {
+  it("buildFastQaFeatureOverride enables every trigger with a 5-second cooldown", () => {
+    const override = buildFastQaFeatureOverride(null);
+    expect(override.enabled).toBe(true);
+    expect(override.params?.reprompt_schedule).toEqual([FAST_QA_DELAY]);
+    expect(override.params?.inactivity_reprompt).toEqual(FAST_QA_DELAY);
+    expect(Object.values(override.params!.action_events).every(event => event.enabled)).toBe(true);
+  });
+
+  it("buildActionEventToggleOverride flips only the targeted source", () => {
+    const feature = createFeature();
+    const toggled = buildActionEventToggleOverride(feature, "send");
+    expect(toggled.params?.action_events.send.enabled).toBe(false);
+    expect(toggled.params?.action_events.receive.enabled).toBe(true);
+
+    const toggledBack = buildActionEventToggleOverride(toggled, "send");
+    expect(toggledBack.params?.action_events.send.enabled).toBe(true);
+  });
+
+  it("buildTransactionsAlertsPromptToggleOverride adds then removes a source", () => {
+    const feature = createFeature();
+    const withSend = buildTransactionsAlertsPromptToggleOverride(feature, "send");
+    const category = withSend.params?.notificationsCategories.find(
+      c => c.category === "transactionsAlertsCategory",
+    );
+    expect(category?.drawerPromptActions).toContain("send");
+    expect(category?.drawerPromptEnabled).toBe(true);
+
+    const withoutSend = buildTransactionsAlertsPromptToggleOverride(withSend, "send");
+    const categoryAfter = withoutSend.params?.notificationsCategories.find(
+      c => c.category === "transactionsAlertsCategory",
+    );
+    expect(categoryAfter?.drawerPromptActions).not.toContain("send");
+    expect(categoryAfter?.drawerPromptEnabled).toBe(false);
+  });
+});
+
+const assertSingleFailureAt = (steps: ReturnType<typeof buildAfterActionTrace>, id: string) => {
+  const failing = steps.filter(step => step.status === "fail");
+  expect(failing).toHaveLength(1);
+  expect(failing[0].id).toBe(id);
+  const failIndex = steps.findIndex(step => step.id === id);
+  expect(steps.slice(0, failIndex).every(step => step.status === "pass")).toBe(true);
+  expect(steps.slice(failIndex + 1).every(step => step.status === "pending")).toBe(true);
+};
+
+describe("notificationsPromptDebug: decision trace matches the real engine", () => {
+  const baseContext = (feature: BrazePushNotifications) => ({
+    brazePushNotifications: feature,
+    isRatingsModalOpen: false,
+    isDrawerPending: false,
+    now: NOW,
+  });
+
+  it("marks every step as pass when the decision is show", () => {
+    const feature = createFeature();
+    const decision = evaluateAfterActionTrigger(
+      {
+        source: "send",
+        permissionStatus: AuthorizationStatus.NOT_DETERMINED,
+        areNotificationsAllowed: false,
+        transactionsAlertsCategory: false,
+        pushNotificationsDataOfUser: null,
+      },
+      baseContext(feature),
+    );
+    expect(decision.kind).toBe("show");
+
+    const trace = buildAfterActionTrace(decision, {
+      globallyOptedIn: false,
+      hasActionEventsConfig: true,
+      hasActionEventForSource: true,
+    });
+    expect(trace.every(step => step.status === "pass")).toBe(true);
+  });
+
+  it("stops at feature_enabled when the flag is disabled", () => {
+    const feature = createFeature();
+    feature.enabled = false;
+    const decision = evaluateAfterActionTrigger(
+      {
+        source: "send",
+        permissionStatus: AuthorizationStatus.NOT_DETERMINED,
+        areNotificationsAllowed: false,
+        transactionsAlertsCategory: false,
+        pushNotificationsDataOfUser: null,
+      },
+      baseContext(feature),
+    );
+    expect(decision).toMatchObject({ kind: "skip", reason: "feature_disabled" });
+
+    const trace = buildAfterActionTrace(decision, {
+      globallyOptedIn: false,
+      hasActionEventsConfig: true,
+      hasActionEventForSource: true,
+    });
+    assertSingleFailureAt(trace, "feature_enabled");
+  });
+
+  it("stops at action_event_enabled when the action event is disabled", () => {
+    const feature = createFeature({
+      action_events: { ...defaultParams.action_events, send: { enabled: false, timer: 0 } },
+    });
+    const decision = evaluateAfterActionTrigger(
+      {
+        source: "send",
+        permissionStatus: AuthorizationStatus.NOT_DETERMINED,
+        areNotificationsAllowed: false,
+        transactionsAlertsCategory: false,
+        pushNotificationsDataOfUser: null,
+      },
+      baseContext(feature),
+    );
+    expect(decision).toMatchObject({ kind: "skip", reason: "action_event_disabled" });
+
+    const trace = buildAfterActionTrace(decision, {
+      globallyOptedIn: false,
+      hasActionEventsConfig: true,
+      hasActionEventForSource: true,
+    });
+    assertSingleFailureAt(trace, "action_event_enabled");
+  });
+
+  it("stops at cooldown_elapsed when the reprompt delay has not been reached", () => {
+    const feature = createFeature();
+    const decision = evaluateAfterActionTrigger(
+      {
+        source: "send",
+        permissionStatus: AuthorizationStatus.NOT_DETERMINED,
+        areNotificationsAllowed: false,
+        transactionsAlertsCategory: false,
+        pushNotificationsDataOfUser: { dismissedOptInDrawerAtList: [NOW] },
+      },
+      baseContext(feature),
+    );
+    expect(decision).toMatchObject({ kind: "skip", reason: "reprompt_delay_not_reached" });
+
+    const trace = buildAfterActionTrace(decision, {
+      globallyOptedIn: false,
+      hasActionEventsConfig: true,
+      hasActionEventForSource: true,
+    });
+    assertSingleFailureAt(trace, "cooldown_elapsed");
+  });
+
+  it("stops at not_fully_opted_in when transaction alerts are already enabled", () => {
+    const feature = createFeature();
+    const decision = evaluateAfterActionTrigger(
+      {
+        source: "send",
+        permissionStatus: AuthorizationStatus.AUTHORIZED,
+        areNotificationsAllowed: true,
+        transactionsAlertsCategory: true,
+        pushNotificationsDataOfUser: null,
+      },
+      baseContext(feature),
+    );
+    expect(decision).toMatchObject({ kind: "skip", reason: "fully_opted_in" });
+
+    const trace = buildAfterActionTrace(decision, {
+      globallyOptedIn: true,
+      hasActionEventsConfig: true,
+      hasActionEventForSource: true,
+    });
+    assertSingleFailureAt(trace, "not_fully_opted_in");
+  });
+
+  it("stops at transactions_alerts_eligible when the category isn't configured for this source", () => {
+    const feature = createFeature();
+    const decision = evaluateAfterActionTrigger(
+      {
+        source: "send",
+        permissionStatus: AuthorizationStatus.AUTHORIZED,
+        areNotificationsAllowed: true,
+        transactionsAlertsCategory: false,
+        pushNotificationsDataOfUser: null,
+      },
+      baseContext(feature),
+    );
+    expect(decision).toMatchObject({ kind: "skip", reason: "transactions_alerts_not_eligible" });
+
+    const trace = buildAfterActionTrace(decision, {
+      globallyOptedIn: true,
+      hasActionEventsConfig: true,
+      hasActionEventForSource: true,
+    });
+    assertSingleFailureAt(trace, "transactions_alerts_eligible");
+  });
+
+  it("disambiguates configuration_missing to config_present when action_events is absent", () => {
+    const feature = createFeature();
+    feature.params = { ...feature.params, action_events: undefined } as unknown as BrazeParams;
+    const decision = evaluateAfterActionTrigger(
+      {
+        source: "send",
+        permissionStatus: AuthorizationStatus.NOT_DETERMINED,
+        areNotificationsAllowed: false,
+        transactionsAlertsCategory: false,
+        pushNotificationsDataOfUser: null,
+      },
+      baseContext(feature),
+    );
+    expect(decision).toMatchObject({ kind: "skip", reason: "configuration_missing" });
+
+    const trace = buildAfterActionTrace(decision, {
+      globallyOptedIn: false,
+      hasActionEventsConfig: false,
+      hasActionEventForSource: false,
+    });
+    assertSingleFailureAt(trace, "config_present");
+  });
+
+  it("inactivity trace disambiguates feature_disabled between the master flag and inactivity_enabled", () => {
+    const feature = createFeature({ inactivity_enabled: false });
+    const decision = evaluateInactivityTrigger(
+      {
+        permissionStatus: AuthorizationStatus.NOT_DETERMINED,
+        areNotificationsAllowed: false,
+        pushNotificationsDataOfUser: null,
+        hasCompletedOnboarding: true,
+      },
+      baseContext(feature),
+    );
+    expect(decision).toMatchObject({ kind: "skip", reason: "feature_disabled" });
+
+    const trace = buildInactivityTrace(decision, { isFeatureEnabled: true });
+    assertSingleFailureAt(trace, "inactivity_enabled_flag");
+  });
+
+  it("inactivity trace shows all-pass on a show decision", () => {
+    const feature = createFeature();
+    const decision = evaluateInactivityTrigger(
+      {
+        permissionStatus: AuthorizationStatus.NOT_DETERMINED,
+        areNotificationsAllowed: false,
+        pushNotificationsDataOfUser: {
+          lastActionAt: sub(NOW, defaultParams.inactivity_reprompt).getTime(),
+        },
+        hasCompletedOnboarding: true,
+      },
+      baseContext(feature),
+    );
+    expect(decision.kind).toBe("show");
+
+    const trace = buildInactivityTrace(decision, { isFeatureEnabled: true });
+    expect(trace.every(step => step.status === "pass")).toBe(true);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/notificationsPromptDebug.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/notificationsPromptDebug.ts
@@ -1,0 +1,559 @@
+import { add, sub } from "date-fns";
+import type { Features } from "@shared/feature-flags";
+import {
+  type AfterActionTriggerDecision,
+  type DataOfUser,
+  type InactivityTriggerDecision,
+  type NotificationPromptTarget,
+  type NotificationsPromptAfterActionSource,
+  type NotificationsPromptRepromptDelay,
+} from "LLM/features/NotificationsPrompt";
+
+type RepromptTimingState = "eligible" | "waiting" | "missing" | "disabled" | "invalid";
+
+export type RepromptTiming = {
+  state: RepromptTimingState;
+  eligibleAt: number | null;
+  /** Start of the cooldown window (last dismissal / last action). Null when there's nothing to plot. */
+  startAt: number | null;
+  remaining: string;
+};
+
+const durationKeys = ["months", "days", "hours", "minutes", "seconds"] as const;
+
+// The real engine (`checkIsInactive`/`hasRepromptDelayElapsed`) only checks truthiness before
+// handing the delay straight to date-fns' `add` (which treats missing keys as 0) — it never
+// requires all 5 keys to be set. Mirror that leniency here: only reject keys that are actually
+// present but garbage (non-finite/negative). Requiring full completeness previously made this
+// timing helper report "missing" for delays the engine (and its decision trace) already treats
+// as present, which made the trace checklist and the cooldown line visibly disagree.
+const isValidDelay = (
+  delay: NotificationsPromptRepromptDelay | null | undefined,
+): delay is NotificationsPromptRepromptDelay =>
+  Boolean(
+    delay &&
+    durationKeys.every(
+      key => delay[key] === undefined || (Number.isFinite(delay[key]) && delay[key] >= 0),
+    ),
+  );
+
+const isValidTimestamp = (timestamp: number | undefined): timestamp is number =>
+  timestamp !== undefined &&
+  Number.isFinite(timestamp) &&
+  Number.isFinite(new Date(timestamp).getTime());
+
+const formatDuration = (durationMs: number): string => {
+  if (durationMs < 1000) {
+    return "<1 second";
+  }
+
+  const units = [
+    { label: "day", milliseconds: 24 * 60 * 60 * 1000 },
+    { label: "hour", milliseconds: 60 * 60 * 1000 },
+    { label: "minute", milliseconds: 60 * 1000 },
+    { label: "second", milliseconds: 1000 },
+  ];
+  const parts: string[] = [];
+  let remainingMs = durationMs;
+
+  for (const { label, milliseconds } of units) {
+    const value = Math.floor(remainingMs / milliseconds);
+    if (value > 0) {
+      parts.push(`${value} ${label}${value === 1 ? "" : "s"}`);
+      remainingMs -= value * milliseconds;
+    }
+    if (parts.length === 2) {
+      break;
+    }
+  }
+
+  return parts.join(" ");
+};
+
+const buildTiming = (startAt: number, eligibleAt: number, now: number): RepromptTiming => {
+  if (eligibleAt <= now) {
+    return {
+      state: "eligible",
+      eligibleAt,
+      startAt,
+      remaining:
+        eligibleAt === now ? "now" : `now (overdue by ${formatDuration(now - eligibleAt)})`,
+    };
+  }
+
+  return {
+    state: "waiting",
+    eligibleAt,
+    startAt,
+    remaining: `in ${formatDuration(eligibleAt - now)}`,
+  };
+};
+
+export const getDismissalsForTarget = (
+  pushNotificationsDataOfUser: DataOfUser | null | undefined,
+  promptTarget: NotificationPromptTarget,
+): number[] | undefined => {
+  const targetDismissals =
+    pushNotificationsDataOfUser?.dismissedPromptAtListByTarget?.[promptTarget];
+
+  if (promptTarget === "globalPushNotifications") {
+    return targetDismissals ?? pushNotificationsDataOfUser?.dismissedOptInDrawerAtList;
+  }
+
+  return targetDismissals;
+};
+
+export const getRepromptTiming = ({
+  dismissals,
+  repromptSchedule,
+  now,
+}: {
+  dismissals: number[] | undefined;
+  repromptSchedule: NotificationsPromptRepromptDelay[] | null | undefined;
+  now: number;
+}): RepromptTiming => {
+  if (!dismissals?.length) {
+    return { state: "eligible", eligibleAt: null, startAt: null, remaining: "now (first prompt)" };
+  }
+
+  if (!repromptSchedule?.length) {
+    return {
+      state: "missing",
+      eligibleAt: null,
+      startAt: null,
+      remaining: "reprompt schedule missing",
+    };
+  }
+
+  const lastDismissedAt = dismissals.at(-1);
+  if (!isValidTimestamp(lastDismissedAt)) {
+    return {
+      state: "invalid",
+      eligibleAt: null,
+      startAt: null,
+      remaining: "latest dismissal timestamp invalid",
+    };
+  }
+
+  const scheduleIndex = Math.min(dismissals.length - 1, repromptSchedule.length - 1);
+  const delay = repromptSchedule[scheduleIndex];
+  if (!isValidDelay(delay)) {
+    return {
+      state: "invalid",
+      eligibleAt: null,
+      startAt: null,
+      remaining: "reprompt schedule invalid",
+    };
+  }
+
+  const eligibleAt = add(lastDismissedAt, delay).getTime();
+  if (!isValidTimestamp(eligibleAt)) {
+    return {
+      state: "invalid",
+      eligibleAt: null,
+      startAt: null,
+      remaining: "next eligible timestamp invalid",
+    };
+  }
+
+  return buildTiming(lastDismissedAt, eligibleAt, now);
+};
+
+export const getInactivityRepromptTiming = ({
+  inactivityEnabled,
+  inactivityReprompt,
+  lastActionAt,
+  now,
+}: {
+  inactivityEnabled: boolean | undefined;
+  inactivityReprompt: NotificationsPromptRepromptDelay | null | undefined;
+  lastActionAt: number | undefined;
+  now: number;
+}): RepromptTiming => {
+  if (!inactivityEnabled) {
+    return {
+      state: "disabled",
+      eligibleAt: null,
+      startAt: null,
+      remaining: "inactivity reprompt disabled",
+    };
+  }
+
+  if (!isValidDelay(inactivityReprompt)) {
+    return {
+      state: "missing",
+      eligibleAt: null,
+      startAt: null,
+      remaining: "inactivity schedule missing",
+    };
+  }
+
+  if (lastActionAt === undefined) {
+    return {
+      state: "missing",
+      eligibleAt: null,
+      startAt: null,
+      remaining: "last action timestamp missing",
+    };
+  }
+
+  if (!isValidTimestamp(lastActionAt)) {
+    return {
+      state: "invalid",
+      eligibleAt: null,
+      startAt: null,
+      remaining: "last action timestamp invalid",
+    };
+  }
+
+  const eligibleAt = add(lastActionAt, inactivityReprompt).getTime();
+  if (!isValidTimestamp(eligibleAt)) {
+    return {
+      state: "invalid",
+      eligibleAt: null,
+      startAt: null,
+      remaining: "next eligible timestamp invalid",
+    };
+  }
+
+  return buildTiming(lastActionAt, eligibleAt, now);
+};
+
+const withDismissalsForTarget = (
+  pushNotificationsDataOfUser: DataOfUser | null | undefined,
+  promptTarget: NotificationPromptTarget,
+  dismissals: number[],
+): DataOfUser => ({
+  ...pushNotificationsDataOfUser,
+  ...(promptTarget === "globalPushNotifications" ? { dismissedOptInDrawerAtList: dismissals } : {}),
+  dismissedPromptAtListByTarget: {
+    ...pushNotificationsDataOfUser?.dismissedPromptAtListByTarget,
+    [promptTarget]: dismissals,
+  },
+});
+
+export const buildRepromptableUserData = (
+  pushNotificationsDataOfUser: DataOfUser | null | undefined,
+  promptTarget: NotificationPromptTarget,
+  repromptSchedule: NotificationsPromptRepromptDelay[] | null | undefined,
+  now: number,
+): DataOfUser | null => {
+  const dismissals = [...(getDismissalsForTarget(pushNotificationsDataOfUser, promptTarget) ?? [])];
+  if (!dismissals.length || !repromptSchedule?.length) {
+    return null;
+  }
+
+  const scheduleIndex = Math.min(dismissals.length - 1, repromptSchedule.length - 1);
+  const delay = repromptSchedule[scheduleIndex];
+  if (!isValidDelay(delay)) {
+    return null;
+  }
+
+  const repromptableDismissalAt = sub(now, delay).getTime();
+  if (!isValidTimestamp(repromptableDismissalAt)) {
+    return null;
+  }
+
+  dismissals[dismissals.length - 1] = repromptableDismissalAt;
+  return withDismissalsForTarget(pushNotificationsDataOfUser, promptTarget, dismissals);
+};
+
+export const buildInactiveUserData = (
+  pushNotificationsDataOfUser: DataOfUser | null | undefined,
+  inactivityReprompt: NotificationsPromptRepromptDelay | null | undefined,
+  now: number,
+): DataOfUser | null => {
+  if (!isValidDelay(inactivityReprompt)) {
+    return null;
+  }
+
+  const lastActionAt = sub(now, inactivityReprompt).getTime();
+  if (!isValidTimestamp(lastActionAt)) {
+    return null;
+  }
+
+  return { ...pushNotificationsDataOfUser, lastActionAt };
+};
+
+export const buildTruncatedDismissalsUserData = (
+  pushNotificationsDataOfUser: DataOfUser | null | undefined,
+  promptTarget: NotificationPromptTarget,
+  keepCount: number,
+): DataOfUser =>
+  withDismissalsForTarget(
+    pushNotificationsDataOfUser,
+    promptTarget,
+    (getDismissalsForTarget(pushNotificationsDataOfUser, promptTarget) ?? []).slice(0, keepCount),
+  );
+
+export const formatTimestamp = (
+  timestamp: number,
+): { epochMs: string; iso: string; local: string } | null => {
+  if (!isValidTimestamp(timestamp)) {
+    return null;
+  }
+
+  const date = new Date(timestamp);
+  return { epochMs: String(timestamp), iso: date.toISOString(), local: date.toLocaleString() };
+};
+
+export const FAST_QA_DELAY: NotificationsPromptRepromptDelay = {
+  months: 0,
+  days: 0,
+  hours: 0,
+  minutes: 0,
+  seconds: 5,
+};
+
+type BrazePushNotificationsFeature = Features["brazePushNotifications"];
+type BrazeParams = NonNullable<BrazePushNotificationsFeature["params"]>;
+
+const actionEventKeyBySource = {
+  onboarding: "complete_onboarding",
+  send: "send",
+  dapp_complete: "dapp_complete",
+  receive: "receive",
+  swap: "swap",
+  stake: "stake",
+  add_favorite_coin: "add_favorite_coin",
+} as const satisfies Record<
+  NotificationsPromptAfterActionSource,
+  keyof BrazeParams["action_events"]
+>;
+
+export const getActionEventKey = (source: NotificationsPromptAfterActionSource) =>
+  actionEventKeyBySource[source];
+
+const DEFAULT_ACTION_EVENTS: BrazeParams["action_events"] = {
+  complete_onboarding: { enabled: true, timer: 0 },
+  send: { enabled: true, timer: 0 },
+  dapp_complete: { enabled: true, timer: 0 },
+  receive: { enabled: true, timer: 0 },
+  buy: { enabled: true, timer: 0 },
+  swap: { enabled: true, timer: 0 },
+  stake: { enabled: true, timer: 0 },
+  add_favorite_coin: { enabled: true, timer: 0 },
+};
+
+export const buildFastQaFeatureOverride = (
+  current: BrazePushNotificationsFeature | null | undefined,
+): BrazePushNotificationsFeature => ({
+  ...current,
+  enabled: true,
+  params: {
+    reprompt_schedule: [FAST_QA_DELAY],
+    inactivity_enabled: true,
+    inactivity_reprompt: FAST_QA_DELAY,
+    action_events: DEFAULT_ACTION_EVENTS,
+    notificationsCategories: [
+      {
+        displayed: true,
+        category: "transactionsAlertsCategory",
+        drawerPromptEnabled: true,
+        drawerPromptActions: [
+          "onboarding",
+          "send",
+          "dapp_complete",
+          "receive",
+          "swap",
+          "stake",
+          "add_favorite_coin",
+        ],
+      },
+    ],
+  },
+});
+
+const withDefaultParams = (
+  current: BrazePushNotificationsFeature | null | undefined,
+): BrazeParams => ({
+  reprompt_schedule: current?.params?.reprompt_schedule ?? [FAST_QA_DELAY],
+  inactivity_enabled: current?.params?.inactivity_enabled ?? true,
+  inactivity_reprompt: current?.params?.inactivity_reprompt ?? FAST_QA_DELAY,
+  action_events: current?.params?.action_events ?? DEFAULT_ACTION_EVENTS,
+  notificationsCategories: current?.params?.notificationsCategories ?? [],
+});
+
+export const buildActionEventToggleOverride = (
+  current: BrazePushNotificationsFeature | null | undefined,
+  source: NotificationsPromptAfterActionSource,
+): BrazePushNotificationsFeature => {
+  const key = getActionEventKey(source);
+  const params = withDefaultParams(current);
+  const currentEvent = params.action_events[key];
+  return {
+    ...current,
+    enabled: current?.enabled ?? false,
+    params: {
+      ...params,
+      action_events: {
+        ...params.action_events,
+        [key]: { enabled: !currentEvent?.enabled, timer: currentEvent?.timer ?? 0 },
+      },
+    },
+  };
+};
+
+// --- Decision trace ---------------------------------------------------------
+// Maps the engine's authoritative `decision.reason` to a fixed, ordered list of
+// steps mirroring the checks `evaluateAfterActionTrigger`/`evaluateInactivityTrigger`
+// perform internally. Steps before the failing one are marked "pass" (the engine
+// got that far), the matching step is "fail", and everything after is "pending"
+// (the engine never got there). On a "show" decision every step is "pass".
+// Kept in sync with the engine via the round-trip tests in this file's test suite.
+
+export type TraceStepStatus = "pass" | "fail" | "pending";
+
+export type TraceStep = {
+  id: string;
+  label: string;
+  status: TraceStepStatus;
+};
+
+const buildTraceFromFailingStep = (
+  steps: ReadonlyArray<{ id: string; label: string }>,
+  failingStepId: string | null,
+): TraceStep[] => {
+  const failIndex =
+    failingStepId === null ? -1 : steps.findIndex(step => step.id === failingStepId);
+
+  return steps.map((step, index) => ({
+    ...step,
+    status:
+      failIndex === -1 || index < failIndex ? "pass" : index === failIndex ? "fail" : "pending",
+  }));
+};
+
+const AFTER_ACTION_TRACE_STEPS: ReadonlyArray<{ id: string; label: string }> = [
+  { id: "feature_enabled", label: "brazePushNotifications is enabled" },
+  { id: "config_present", label: "action_events configuration is present for this source" },
+  { id: "ratings_modal_clear", label: "Ratings modal is not currently open" },
+  { id: "drawer_not_pending", label: "No other drawer is already open or scheduled" },
+  { id: "action_event_enabled", label: "This action's event is enabled" },
+  { id: "cooldown_elapsed", label: "Reprompt cooldown has elapsed" },
+  { id: "not_fully_opted_in", label: "Not already fully opted in" },
+  {
+    id: "transactions_alerts_eligible",
+    label: "Transaction alerts are configured to prompt for this action",
+  },
+];
+
+export const buildAfterActionTrace = (
+  decision: AfterActionTriggerDecision,
+  context: {
+    globallyOptedIn: boolean;
+    hasActionEventsConfig: boolean;
+    hasActionEventForSource: boolean;
+  },
+): TraceStep[] => {
+  if (decision.kind === "show") {
+    return buildTraceFromFailingStep(AFTER_ACTION_TRACE_STEPS, null);
+  }
+
+  const failingStepId = ((): string | null => {
+    switch (decision.reason) {
+      case "feature_disabled":
+        return "feature_enabled";
+      case "configuration_missing":
+        // Same reason covers "action_events missing entirely" and "this source has
+        // no action_events entry"; anything else falling through here means the
+        // reprompt schedule itself is misconfigured.
+        return !context.hasActionEventsConfig || !context.hasActionEventForSource
+          ? "config_present"
+          : "cooldown_elapsed";
+      case "ratings_modal_open":
+        return "ratings_modal_clear";
+      case "drawer_already_pending":
+        return "drawer_not_pending";
+      case "action_event_disabled":
+        return "action_event_enabled";
+      case "reprompt_delay_not_reached":
+        return "cooldown_elapsed";
+      case "fully_opted_in":
+        return "not_fully_opted_in";
+      case "transactions_alerts_not_eligible":
+        return "transactions_alerts_eligible";
+      default:
+        return null;
+    }
+  })();
+
+  return buildTraceFromFailingStep(AFTER_ACTION_TRACE_STEPS, failingStepId);
+};
+
+const INACTIVITY_TRACE_STEPS: ReadonlyArray<{ id: string; label: string }> = [
+  { id: "feature_enabled", label: "brazePushNotifications is enabled" },
+  { id: "ratings_modal_clear", label: "Ratings modal is not currently open" },
+  { id: "drawer_not_pending", label: "No other drawer is already open or scheduled" },
+  { id: "onboarding_complete", label: "Onboarding is complete" },
+  { id: "inactivity_schedule_present", label: "inactivity_reprompt configuration is present" },
+  { id: "inactivity_enabled_flag", label: "inactivity_enabled is true" },
+  { id: "not_globally_opted_in", label: "Not already globally opted in" },
+  { id: "user_inactive", label: "User has been inactive long enough" },
+];
+
+export const buildInactivityTrace = (
+  decision: InactivityTriggerDecision,
+  context: { isFeatureEnabled: boolean },
+): TraceStep[] => {
+  if (decision.kind === "show") {
+    return buildTraceFromFailingStep(INACTIVITY_TRACE_STEPS, null);
+  }
+
+  const failingStepId = ((): string | null => {
+    switch (decision.reason) {
+      case "feature_disabled":
+        // Same reason covers the master flag and the inactivity-specific sub-flag.
+        return context.isFeatureEnabled ? "inactivity_enabled_flag" : "feature_enabled";
+      case "ratings_modal_open":
+        return "ratings_modal_clear";
+      case "drawer_already_pending":
+        return "drawer_not_pending";
+      case "onboarding_incomplete":
+        return "onboarding_complete";
+      case "configuration_missing":
+        return "inactivity_schedule_present";
+      case "globally_opted_in_no_inactivity_drawer":
+        return "not_globally_opted_in";
+      case "user_not_inactive":
+        return "user_inactive";
+      default:
+        return null;
+    }
+  })();
+
+  return buildTraceFromFailingStep(INACTIVITY_TRACE_STEPS, failingStepId);
+};
+
+export const buildTransactionsAlertsPromptToggleOverride = (
+  current: BrazePushNotificationsFeature | null | undefined,
+  source: NotificationsPromptAfterActionSource,
+): BrazePushNotificationsFeature => {
+  const params = withDefaultParams(current);
+  const existing = params.notificationsCategories.find(
+    category => category.category === "transactionsAlertsCategory",
+  );
+  const currentActions = existing?.drawerPromptActions ?? [];
+  const nextActions = currentActions.includes(source)
+    ? currentActions.filter(action => action !== source)
+    : [...currentActions, source];
+
+  return {
+    ...current,
+    enabled: current?.enabled ?? false,
+    params: {
+      ...params,
+      notificationsCategories: [
+        ...params.notificationsCategories.filter(
+          category => category.category !== "transactionsAlertsCategory",
+        ),
+        {
+          displayed: existing?.displayed ?? true,
+          category: "transactionsAlertsCategory",
+          drawerPromptEnabled: nextActions.length > 0,
+          drawerPromptActions: nextActions,
+        },
+      ],
+    },
+  };
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/notificationsPromptEngine.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/utils/notificationsPromptEngine.ts
@@ -105,7 +105,7 @@ type CheckIsInactiveInput = {
   now?: number;
 };
 
-const AFTER_ACTION_SOURCE_TO_EVENT_KEY = {
+export const AFTER_ACTION_SOURCE_TO_EVENT_KEY = {
   onboarding: "complete_onboarding",
   send: "send",
   dapp_complete: "dapp_complete",

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/index.tsx
@@ -103,6 +103,12 @@ export default function DebugSettings({
         iconLeft={<IconsLegacy.ChartNetworkMedium size={24} color="black" />}
         onPress={() => navigate(ScreenName.DebugAnalyticsConsentQA)}
       />
+      <SettingsRow
+        title="Notifications prompt — QA"
+        desc="Inspect notifications opt-in state, reprompt timing, and trigger the drawer"
+        iconLeft={<IconsLegacy.NotificationsMedium size={24} color="black" />}
+        onPress={() => navigate(ScreenName.DebugNotificationsPromptQA)}
+      />
     </SettingsNavigationScrollView>
   );
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - All three tabs and the sticky source selector
      - Action and inactivity eligibility decisions and exact cooldown timelines
      - Configuration override, Fast QA mode, and reset-to-remote behavior
      - Global push versus transaction-alert previews and configured transaction-alert actions
      - Settings and per-source real-flow deep links
      - Production-trigger disabled reasons and force-open behavior

### 📝 Description

The notifications prompt QA debug screen no longer exposed enough production-engine context to reliably verify eligibility, cooldowns, prompt targets, and real entry points as the prompt behavior evolved.

This PR rebuilds the screen around three focused tabs with a status hero and decision trace, exact action and inactivity timelines, explicit global-push versus transaction-alert targets, feature-flag overrides and Fast QA mode, read-only user status with real Settings links, a sticky source selector, and per-source real-flow verification links. Production triggering is disabled when ineligible with the reason shown, while explicit force-open controls remain available for visual QA.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: N/A — internal notifications-prompt QA tooling

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)