### PR TITLE
[LWDM] fix(feature-flags): validate Firebase payloads against registry

### DIFF
--- a/.changeset/validate-firebase-feature-flags.md
+++ b/.changeset/validate-firebase-feature-flags.md
@@ -1,0 +1,7 @@
+---
+"@shared/feature-flags": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Validate Firebase feature flags with their registered schemas before resolving them.

--- a/apps/ledger-live-desktop/src/firebase/remoteConfig.test.ts
+++ b/apps/ledger-live-desktop/src/firebase/remoteConfig.test.ts
@@ -42,7 +42,22 @@ describe("fetchRemoteFlags", () => {
   it("maps known Firebase keys to FeatureIds, drops unknown keys", async () => {
     mockGetAll.mockReturnValue({
       feature_counter_value: value(JSON.stringify({ enabled: true })),
-      feature_lwd_wallet_40: value(JSON.stringify({ enabled: false, params: { mainNav: true } })),
+      feature_lwd_wallet_40: value(
+        JSON.stringify({
+          enabled: false,
+          params: {
+            tour: true,
+            q2Tour: false,
+            lazyOnboarding: true,
+            assetSection: false,
+            operationsList: false,
+            aggregatedAssets: false,
+            myWallet: false,
+            pnl: false,
+            assetDiscoverability: false,
+          },
+        }),
+      ),
       config_unrelated: value('"ignored"'),
       stranger_key: value('"ignored"'),
       feature_unknown_flag: value('"ignored"'),
@@ -53,7 +68,20 @@ describe("fetchRemoteFlags", () => {
 
     expect(result).toEqual({
       counterValue: { enabled: true },
-      lwdWallet40: { enabled: false, params: { mainNav: true } },
+      lwdWallet40: {
+        enabled: false,
+        params: {
+          tour: true,
+          q2Tour: false,
+          lazyOnboarding: true,
+          assetSection: false,
+          operationsList: false,
+          aggregatedAssets: false,
+          myWallet: false,
+          pnl: false,
+          assetDiscoverability: false,
+        },
+      },
     });
   });
 
@@ -102,6 +130,17 @@ describe("fetchRemoteFlags", () => {
     const result = await fetchRemoteFlags();
 
     expect(result).toEqual({ counterValue: { enabled: true } });
+  });
+
+  it("silently drops values that do not match their registered schema", async () => {
+    mockGetAll.mockReturnValue({
+      feature_counter_value: value(JSON.stringify({ enabled: "true" })),
+    });
+
+    const { fetchRemoteFlags } = await loadModule();
+    const result = await fetchRemoteFlags();
+
+    expect(result).toEqual({});
   });
 
   it("propagates the fetchAndActivate failure (middleware swallows it)", async () => {

--- a/apps/ledger-live-desktop/src/firebase/remoteConfig.ts
+++ b/apps/ledger-live-desktop/src/firebase/remoteConfig.ts
@@ -12,7 +12,7 @@ import * as fs from "fs";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { FirebaseRemoteConfigProvider } from "@ledgerhq/live-config/providers/index";
 import { formatDefaultFeatures } from "@features/platform-feature-flags";
-import { FEATURE_FLAGS_DEFAULTS, FeatureIdSchema } from "@shared/feature-flags";
+import { FEATURE_FLAGS_DEFAULTS, FeatureIdSchema, parseFeatureValue } from "@shared/feature-flags";
 import type { FeatureId, PartialFeatures } from "@shared/feature-flags";
 import { getFirebaseConfig } from "~/firebase-setup";
 
@@ -100,9 +100,10 @@ export function whenReady(): Promise<void> {
  * Context provider hydrates from the same payload at the same tick.
  *
  * Maps each known Firebase key (`feature_${snakeCase(id)}`) back to its canonical
- * FeatureId via {@link FIREBASE_KEY_TO_FEATURE_ID}, then JSON-parses each value.
- * Unknown keys (`config_*`, stray entries) and malformed JSON are dropped
- * silently — at worst the slice falls back to defaults for that flag.
+ * FeatureId via {@link FIREBASE_KEY_TO_FEATURE_ID}, JSON-parses each value, and
+ * validates it with the registered schema. Unknown keys (`config_*`, stray
+ * entries) and invalid values are dropped silently — at worst the slice falls
+ * back to defaults for that flag.
  */
 export async function fetchRemoteFlags(): Promise<PartialFeatures> {
   try {
@@ -116,9 +117,12 @@ export async function fetchRemoteFlags(): Promise<PartialFeatures> {
       const featureId = FIREBASE_KEY_TO_FEATURE_ID[key.toLowerCase()];
       if (!featureId) continue;
       try {
-        flags[featureId] = JSON.parse(value.asString());
+        const parsedFeature = parseFeatureValue(featureId, JSON.parse(value.asString()));
+        if (parsedFeature) {
+          Object.assign(flags, { [featureId]: parsedFeature });
+        }
       } catch {
-        // Malformed JSON in remote config — drop this key, fall back to default.
+        // Invalid remote config — drop this key, fall back to default.
       }
     }
     const fetchedAt = Date.now();

--- a/apps/ledger-live-mobile/src/firebase/remoteConfig.test.ts
+++ b/apps/ledger-live-mobile/src/firebase/remoteConfig.test.ts
@@ -40,7 +40,21 @@ describe("fetchRemoteFlags", () => {
   it("maps known Firebase keys to FeatureIds, drops unknown keys", async () => {
     mockGetAll.mockReturnValue({
       feature_counter_value: value(JSON.stringify({ enabled: true })),
-      feature_lwm_wallet_40: value(JSON.stringify({ enabled: false, params: { mainNav: true } })),
+      feature_lwm_wallet_40: value(
+        JSON.stringify({
+          enabled: false,
+          params: {
+            tour: true,
+            lazyOnboarding: true,
+            assetSection: false,
+            operationsList: false,
+            aggregatedAssets: false,
+            myWallet: false,
+            pnl: false,
+            assetDiscoverability: false,
+          },
+        }),
+      ),
       config_unrelated: value('"ignored"'),
       stranger_key: value('"ignored"'),
       feature_unknown_flag: value('"ignored"'),
@@ -51,7 +65,19 @@ describe("fetchRemoteFlags", () => {
 
     expect(result).toEqual({
       counterValue: { enabled: true },
-      lwmWallet40: { enabled: false, params: { mainNav: true } },
+      lwmWallet40: {
+        enabled: false,
+        params: {
+          tour: true,
+          lazyOnboarding: true,
+          assetSection: false,
+          operationsList: false,
+          aggregatedAssets: false,
+          myWallet: false,
+          pnl: false,
+          assetDiscoverability: false,
+        },
+      },
     });
   });
 
@@ -100,6 +126,17 @@ describe("fetchRemoteFlags", () => {
     const result = await fetchRemoteFlags();
 
     expect(result).toEqual({ counterValue: { enabled: true } });
+  });
+
+  it("silently drops values that do not match their registered schema", async () => {
+    mockGetAll.mockReturnValue({
+      feature_counter_value: value(JSON.stringify({ enabled: "true" })),
+    });
+
+    const { fetchRemoteFlags } = await loadModule();
+    const result = await fetchRemoteFlags();
+
+    expect(result).toEqual({});
   });
 
   it("propagates the fetchAndActivate failure (middleware swallows it)", async () => {

--- a/apps/ledger-live-mobile/src/firebase/remoteConfig.ts
+++ b/apps/ledger-live-mobile/src/firebase/remoteConfig.ts
@@ -3,7 +3,7 @@ import snakeCase from "lodash/snakeCase";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { FirebaseRemoteConfigProvider } from "@ledgerhq/live-config/providers/index";
 import { formatDefaultFeatures } from "@features/platform-feature-flags";
-import { FEATURE_FLAGS_DEFAULTS, FeatureIdSchema } from "@shared/feature-flags";
+import { FEATURE_FLAGS_DEFAULTS, FeatureIdSchema, parseFeatureValue } from "@shared/feature-flags";
 import type { FeatureId, PartialFeatures } from "@shared/feature-flags";
 
 // Precomputed inverse of @features/platform-feature-flags' `formatToFirebaseFeatureId`
@@ -89,9 +89,10 @@ export function whenReady(): Promise<void> {
  * consumers hydrate from the same payload at the same tick.
  *
  * Maps each known Firebase key (`feature_${snakeCase(id)}`) back to its canonical
- * FeatureId via {@link FIREBASE_KEY_TO_FEATURE_ID}, then JSON-parses each value.
- * Unknown keys (`config_*`, stray entries) and malformed JSON are dropped
- * silently — at worst the slice falls back to defaults for that flag.
+ * FeatureId via {@link FIREBASE_KEY_TO_FEATURE_ID}, JSON-parses each value, and
+ * validates it with the registered schema. Unknown keys (`config_*`, stray
+ * entries) and invalid values are dropped silently — at worst the slice falls
+ * back to defaults for that flag.
  */
 export async function fetchRemoteFlags(): Promise<PartialFeatures> {
   try {
@@ -105,9 +106,12 @@ export async function fetchRemoteFlags(): Promise<PartialFeatures> {
       const featureId = FIREBASE_KEY_TO_FEATURE_ID[key.toLowerCase()];
       if (!featureId) continue;
       try {
-        flags[featureId] = JSON.parse(value.asString());
+        const parsedFeature = parseFeatureValue(featureId, JSON.parse(value.asString()));
+        if (parsedFeature) {
+          Object.assign(flags, { [featureId]: parsedFeature });
+        }
       } catch {
-        // Malformed JSON in remote config — drop this key, fall back to default.
+        // Invalid remote config — drop this key, fall back to default.
       }
     }
     const fetchedAt = Date.now();

--- a/shared/feature-flags/src/data/utils.test.ts
+++ b/shared/feature-flags/src/data/utils.test.ts
@@ -1,4 +1,4 @@
-import { isValidFeatureId } from "./utils";
+import { isValidFeatureId, parseFeatureValue } from "./utils";
 
 describe("isValidFeatureId", () => {
   it("returns true for a registered flag id", () => {
@@ -8,5 +8,28 @@ describe("isValidFeatureId", () => {
 
   it("returns false for an unknown id", () => {
     expect(isValidFeatureId("nonexistent_flag_xyz")).toBe(false);
+  });
+});
+
+describe("parseFeatureValue", () => {
+  it.each([
+    ["is absent", undefined],
+    ["is empty", []],
+    ["is not an array", "evm"],
+    ["contains an empty family", [" "]],
+  ])("normalizes Contacts address families when the value %s", (_, eligibleAddressFamilies) => {
+    expect(
+      parseFeatureValue("lwdContacts", {
+        enabled: true,
+        params: { newBadge: true, eligibleAddressFamilies },
+      }),
+    ).toEqual({
+      enabled: true,
+      params: { newBadge: true, eligibleAddressFamilies: ["evm"] },
+    });
+  });
+
+  it("returns undefined when a value does not match its registered schema", () => {
+    expect(parseFeatureValue("lwdContacts", { enabled: "true" })).toBeUndefined();
   });
 });

--- a/shared/feature-flags/src/data/utils.ts
+++ b/shared/feature-flags/src/data/utils.ts
@@ -1,8 +1,15 @@
-import { FeatureIdSchema, type FeatureId } from "./schema";
+import { FeatureIdSchema, flagRegistry, type FeatureId, type Features } from "./schema";
 
 const FEATURE_ID_SET = new Set<string>(FeatureIdSchema.options);
 
 /** Type guard: whether a string is a registered feature flag id. */
 export function isValidFeatureId(key: string): key is FeatureId {
   return FEATURE_ID_SET.has(key);
+}
+
+/** Parses an untrusted feature value with the registered schema for its key. */
+export function parseFeatureValue(key: FeatureId, value: unknown): Features[FeatureId] | undefined {
+  const result = flagRegistry[key].safeParse(value);
+
+  return result.success ? result.data : undefined;
 }

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwdContacts.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwdContacts.ts
@@ -7,8 +7,10 @@ export const lwdContacts = flagWith(
   {
     newBadge: z.boolean(),
     eligibleAddressFamilies: z
-      .array(z.string())
-      .default(() => [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES]),
+      .array(z.string().trim().min(1))
+      .min(1)
+      .default(() => [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES])
+      .catch(() => [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES]),
   },
   {
     enabled: false,

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwmContacts.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwmContacts.ts
@@ -7,8 +7,10 @@ export const lwmContacts = flagWith(
   {
     newBadge: z.boolean(),
     eligibleAddressFamilies: z
-      .array(z.string())
-      .default(() => [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES]),
+      .array(z.string().trim().min(1))
+      .min(1)
+      .default(() => [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES])
+      .catch(() => [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES]),
   },
   {
     enabled: false,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added shared registry-validation tests and Desktop/Mobile Firebase ingestion tests.
- [x] **Impact of the changes:**
      Desktop and Mobile Remote Config feature-flag ingestion. Invalid payloads now fall back to local defaults.

### 📝 Description

Validate Remote Config JSON values against their registered Zod schemas before adding them to the resolved feature flags.

- Adds a generic `parseFeatureValue` helper in `@shared/feature-flags`.
- Uses it from Desktop and Mobile Firebase adapters.
- Drops malformed or schema-invalid values so applications use their local defaults.
- Normalizes Contacts `eligibleAddressFamilies` to `["evm"]` for absent, empty, or invalid values.

This PR does not change Contacts mocks, MAD wiring, or Developer Tool UI.

### ❓ Context

- **JIRA or GitHub link**: Related context only: [#19468](https://github.com/LedgerHQ/ledger-live/pull/19468). This PR is independently based on `develop`.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)