### PR TITLE
[LWDM] Feat/live 34108 lwm debug controls

### DIFF
--- a/.changeset/lwm-contacts-debug-controls.md
+++ b/.changeset/lwm-contacts-debug-controls.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add Contacts feature flag debug controls in Settings > Debug.

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/__tests__/useContactsDevToolViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/__tests__/useContactsDevToolViewModel.test.ts
@@ -64,7 +64,7 @@ describe("useContactsDevToolViewModel", () => {
     });
 
     act(() => {
-      result.current.setCustomFamiliesInput("evm, bitcoin, solana");
+      result.current.setCustomFamiliesInput("evm, stellar, aptos");
     });
 
     act(() => {
@@ -73,9 +73,9 @@ describe("useContactsDevToolViewModel", () => {
 
     expect(store.getState().featureFlags.overrides.lwdContacts).toEqual({
       enabled: true,
-      params: { newBadge: false, eligibleAddressFamilies: ["evm", "bitcoin", "solana"] },
+      params: { newBadge: false, eligibleAddressFamilies: ["evm", "stellar", "aptos"] },
     });
-    expect(result.current.customFamiliesInput).toBe("evm, bitcoin, solana");
+    expect(result.current.customFamiliesInput).toBe("evm, stellar, aptos");
   });
 
   it("should deduplicate and normalize custom eligibleAddressFamilies values", () => {
@@ -89,7 +89,7 @@ describe("useContactsDevToolViewModel", () => {
     });
 
     act(() => {
-      result.current.setCustomFamiliesInput("EVM, evm, bitcoin, Bitcoin");
+      result.current.setCustomFamiliesInput("EVM, evm, stellar, Stellar");
     });
 
     act(() => {
@@ -98,7 +98,7 @@ describe("useContactsDevToolViewModel", () => {
 
     expect(store.getState().featureFlags.overrides.lwdContacts).toEqual({
       enabled: true,
-      params: { newBadge: false, eligibleAddressFamilies: ["evm", "bitcoin"] },
+      params: { newBadge: false, eligibleAddressFamilies: ["evm", "stellar"] },
     });
   });
 
@@ -113,14 +113,14 @@ describe("useContactsDevToolViewModel", () => {
     });
 
     act(() => {
-      result.current.setCustomFamiliesInput("evm, bitcoin");
+      result.current.setCustomFamiliesInput("evm, stellar");
     });
 
     act(() => {
       result.current.handleToggleEnabled();
     });
 
-    expect(result.current.customFamiliesInput).toBe("evm, bitcoin");
+    expect(result.current.customFamiliesInput).toBe("evm, stellar");
   });
 
   it("should not reset in-progress custom families input when toggling newBadge", () => {
@@ -134,14 +134,14 @@ describe("useContactsDevToolViewModel", () => {
     });
 
     act(() => {
-      result.current.setCustomFamiliesInput("evm, solana");
+      result.current.setCustomFamiliesInput("evm, aptos");
     });
 
     act(() => {
       result.current.handleToggleNewBadge();
     });
 
-    expect(result.current.customFamiliesInput).toBe("evm, solana");
+    expect(result.current.customFamiliesInput).toBe("evm, aptos");
   });
 
   it("should reset the local override", () => {

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -5262,7 +5262,7 @@
         "featureParameters": "Feature Parameters",
         "eligibleAddressFamilies": "Eligible address families",
         "customFamiliesHint": "Comma-separated families for custom multi-family testing.",
-        "customFamiliesPlaceholder": "evm, bitcoin, solana",
+        "customFamiliesPlaceholder": "evm, stellar, aptos",
         "applyFamilies": "Apply",
         "resetOverride": "Reset override"
       },

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
@@ -30,6 +30,7 @@ import DebugLottie from "~/screens/Settings/Debug/Features/Lottie";
 import DebugLumen from "~/screens/Settings/Debug/Debugging/Lumen";
 import DebugLumenVisualization from "~/screens/Settings/Debug/Debugging/LumenVisualization";
 import DebugWallet40 from "~/screens/Settings/Debug/Debugging/Wallet40";
+import DebugContacts from "~/screens/Settings/Debug/Debugging/Contacts";
 import DebugDevTools from "LLM/features/DevTools/screens/DevToolsScreen";
 import DebugNetwork from "~/screens/Settings/Debug/Debugging/Network";
 import DebugCommandSender from "~/screens/Settings/Debug/Connectivity/CommandSender";
@@ -412,6 +413,13 @@ export default function SettingsNavigator() {
         component={DebugWallet40}
         options={{
           title: "Wallet 4.0",
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.DebugContacts}
+        component={DebugContacts}
+        options={{
+          title: "Contacts",
         }}
       />
       <Stack.Screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
@@ -72,6 +72,7 @@ export type SettingsNavigatorStackParamList = {
   [ScreenName.DebugLumen]: undefined;
   [ScreenName.DebugLumenVisualization]: undefined;
   [ScreenName.DebugWallet40]: undefined;
+  [ScreenName.DebugContacts]: undefined;
   [ScreenName.DebugDevTools]: undefined;
   [ScreenName.DebugPlayground]: undefined;
   [ScreenName.DebugBluetoothAndLocationServices]: undefined;

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -73,6 +73,7 @@ export enum ScreenName {
   DebugLumen = "DebugLumen",
   DebugLumenVisualization = "DebugLumenVisualization",
   DebugWallet40 = "DebugWallet40",
+  DebugContacts = "DebugContacts",
   DebugDevTools = "DebugDevTools",
   DebugWalletV4Tour = "DebugWalletV4Tour",
   DebugProductTour = "DebugProductTour",

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/__tests__/useContactsDevToolViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/__tests__/useContactsDevToolViewModel.test.ts
@@ -1,0 +1,73 @@
+import { act } from "@testing-library/react-native";
+import { CONTACTS_FEATURE_FLAG_KEYS } from "@features/flow-contacts";
+import { renderHook } from "@tests/test-renderer";
+import { ELIGIBLE_ADDRESS_FAMILIES_PRESETS } from "../constants";
+import { useContactsDevToolViewModel } from "../useContactsDevToolViewModel";
+
+const CONTACTS_FLAG = CONTACTS_FEATURE_FLAG_KEYS.mobile;
+
+describe("useContactsDevToolViewModel", () => {
+  it("should enable lwmContacts via setOverride when toggling enabled", () => {
+    const { result, store } = renderHook(() => useContactsDevToolViewModel());
+
+    act(() => {
+      result.current.handleToggleEnabled();
+    });
+
+    expect(store.getState().featureFlags.overrides[CONTACTS_FLAG]).toEqual({
+      enabled: true,
+      params: {
+        newBadge: false,
+        eligibleAddressFamilies: ["evm"],
+      },
+    });
+  });
+
+  it("should toggle params.newBadge while keeping enabled state", () => {
+    const { result, store } = renderHook(() => useContactsDevToolViewModel());
+
+    act(() => {
+      result.current.handleToggleEnabled();
+    });
+
+    act(() => {
+      result.current.handleToggleNewBadge();
+    });
+
+    expect(store.getState().featureFlags.overrides[CONTACTS_FLAG]).toEqual({
+      enabled: true,
+      params: {
+        newBadge: true,
+        eligibleAddressFamilies: ["evm"],
+      },
+    });
+  });
+
+  it("should set EVM-only eligibleAddressFamilies preset", () => {
+    const { result, store } = renderHook(() => useContactsDevToolViewModel());
+    const evmOnlyPreset = ELIGIBLE_ADDRESS_FAMILIES_PRESETS[0];
+
+    act(() => {
+      result.current.handleSetEligibleAddressFamilies(evmOnlyPreset.families);
+    });
+
+    expect(store.getState().featureFlags.overrides[CONTACTS_FLAG]?.params).toEqual({
+      newBadge: false,
+      eligibleAddressFamilies: ["evm"],
+    });
+  });
+
+  it("should clear the override when restoring defaults", () => {
+    const { result, store } = renderHook(() => useContactsDevToolViewModel());
+
+    act(() => {
+      result.current.handleToggleEnabled();
+    });
+
+    act(() => {
+      result.current.handleRestoreDefaults();
+    });
+
+    expect(store.getState().featureFlags.overrides[CONTACTS_FLAG]).toBeUndefined();
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/ContactsDevToolHeader.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/ContactsDevToolHeader.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Box, Text, Button } from "@ledgerhq/lumen-ui-rnative";
+import { ContactsDevToolHeaderProps } from "../types";
+
+export const ContactsDevToolHeader = ({ onRestoreDefaults }: ContactsDevToolHeaderProps) => (
+  <Box lx={{ marginBottom: "s24" }}>
+    <Text typography="body2" lx={{ color: "muted", marginBottom: "s16" }}>
+      Toggle the Contacts rollout flag and its parameters for development and QA.
+    </Text>
+    <Button
+      appearance="accent"
+      size="sm"
+      onPress={onRestoreDefaults}
+      testID="debug-contacts-restore-defaults"
+    >
+      Restore defaults
+    </Button>
+  </Box>
+);

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/ContactsEnabledToggle.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/ContactsEnabledToggle.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Box, Text, Switch } from "@ledgerhq/lumen-ui-rnative";
+import { ContactsEnabledToggleProps } from "../types";
+
+export const ContactsEnabledToggle = ({ isEnabled, onToggle }: ContactsEnabledToggleProps) => (
+  <Box lx={{ marginBottom: "s24" }}>
+    <Box
+      lx={{
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "space-between",
+        paddingVertical: "s16",
+        paddingHorizontal: "s16",
+        backgroundColor: isEnabled ? "surfaceHover" : "surface",
+        borderRadius: "md",
+      }}
+    >
+      <Text lx={{ color: "base" }} typography="heading5SemiBold">
+        Contacts enabled
+      </Text>
+      <Switch
+        testID="debug-contacts-enabled-switch"
+        checked={isEnabled}
+        onCheckedChange={onToggle}
+      />
+    </Box>
+  </Box>
+);

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/EligibleAddressFamiliesSection.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/EligibleAddressFamiliesSection.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Box, Text, Button } from "@ledgerhq/lumen-ui-rnative";
+import { ELIGIBLE_ADDRESS_FAMILIES_PRESETS } from "../constants";
+import { EligibleAddressFamiliesSectionProps } from "../types";
+
+const areFamiliesEqual = (left: readonly string[], right: readonly string[]) => {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  const leftFamilies = new Set(left);
+  return right.every(family => leftFamilies.has(family));
+};
+
+export const EligibleAddressFamiliesSection = ({
+  isEnabled,
+  families,
+  onPresetSelect,
+}: EligibleAddressFamiliesSectionProps) => (
+  <Box lx={{ paddingVertical: "s16", paddingHorizontal: "s12" }}>
+    <Text typography="body2" lx={{ color: "base", marginBottom: "s8" }}>
+      Eligible address families
+    </Text>
+    <Text typography="body3" lx={{ color: "muted", marginBottom: "s12" }}>
+      Current: {JSON.stringify(families)}
+    </Text>
+    <Box lx={{ flexDirection: "row", flexWrap: "wrap", gap: "s8" }}>
+      {ELIGIBLE_ADDRESS_FAMILIES_PRESETS.map(preset => {
+        const isSelected = areFamiliesEqual(families, preset.families);
+        return (
+          <Button
+            key={preset.id}
+            appearance={isSelected ? "accent" : "gray"}
+            size="sm"
+            onPress={() => onPresetSelect(preset.families)}
+            disabled={!isEnabled}
+            testID={`debug-contacts-families-preset-${preset.id}`}
+          >
+            {preset.label}
+          </Button>
+        );
+      })}
+    </Box>
+  </Box>
+);

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/FeatureFlagPreview.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/FeatureFlagPreview.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import { FeatureFlagPreviewProps } from "../types";
+import { SectionHeader } from "./SectionHeader";
+
+export const FeatureFlagPreview = ({ summary }: FeatureFlagPreviewProps) => (
+  <>
+    <SectionHeader title="FEATURE FLAG PREVIEW" />
+    <Box
+      lx={{
+        backgroundColor: "surface",
+        borderRadius: "md",
+        padding: "s16",
+      }}
+    >
+      <Text typography="body3" lx={{ color: "base" }}>
+        {summary}
+      </Text>
+    </Box>
+  </>
+);

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/FeatureParamRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/FeatureParamRow.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { Box, Text, Switch, Tag } from "@ledgerhq/lumen-ui-rnative";
+import { FeatureParamRowProps } from "../types";
+
+export const FeatureParamRow = ({
+  label,
+  isFeatureEnabled,
+  value,
+  onToggle,
+  testID,
+}: FeatureParamRowProps) => (
+  <Box
+    lx={{
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      paddingVertical: "s16",
+      paddingHorizontal: "s12",
+      opacity: isFeatureEnabled ? 1 : 0.5,
+    }}
+  >
+    <Box lx={{ flexDirection: "row", alignItems: "center", columnGap: "s12" }}>
+      <Text typography="body2" lx={{ color: "base" }}>
+        {label}
+      </Text>
+      {value && <Tag appearance="success" size="sm" label="ON" />}
+    </Box>
+    <Switch
+      testID={testID}
+      checked={value}
+      onCheckedChange={onToggle}
+      disabled={!isFeatureEnabled}
+    />
+  </Box>
+);

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/SectionHeader.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/SectionHeader.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Box, Text, Divider } from "@ledgerhq/lumen-ui-rnative";
+import { SectionHeaderProps } from "../types";
+
+export const SectionHeader = ({ title }: SectionHeaderProps) => (
+  <Box lx={{ marginBottom: "s16" }}>
+    <Text typography="body2SemiBold" lx={{ color: "muted", marginBottom: "s8" }}>
+      {title}
+    </Text>
+    <Divider />
+  </Box>
+);

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/index.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/index.ts
@@ -1,0 +1,6 @@
+export { ContactsDevToolHeader } from "./ContactsDevToolHeader";
+export { ContactsEnabledToggle } from "./ContactsEnabledToggle";
+export { EligibleAddressFamiliesSection } from "./EligibleAddressFamiliesSection";
+export { FeatureFlagPreview } from "./FeatureFlagPreview";
+export { FeatureParamRow } from "./FeatureParamRow";
+export { SectionHeader } from "./SectionHeader";

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/constants.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/constants.ts
@@ -1,0 +1,17 @@
+import {
+  CONTACTS_FEATURE_FLAG_KEYS,
+  DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
+} from "@features/flow-contacts";
+
+export const CONTACTS_FLAG = CONTACTS_FEATURE_FLAG_KEYS.mobile;
+
+export const ELIGIBLE_ADDRESS_FAMILIES_PRESETS = [
+  {
+    id: "evm-only",
+    label: "EVM only",
+    families: [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES],
+  },
+] as const;
+
+export type EligibleAddressFamiliesPresetId =
+  (typeof ELIGIBLE_ADDRESS_FAMILIES_PRESETS)[number]["id"];

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/index.tsx
@@ -1,0 +1,82 @@
+import React, { useMemo } from "react";
+import { ScrollView, StyleSheet } from "react-native";
+import { Box, Divider } from "@ledgerhq/lumen-ui-rnative";
+import { useContactsDevToolViewModel } from "./useContactsDevToolViewModel";
+import {
+  ContactsDevToolHeader,
+  ContactsEnabledToggle,
+  EligibleAddressFamiliesSection,
+  FeatureFlagPreview,
+  FeatureParamRow,
+  SectionHeader,
+} from "./components";
+
+export default function DebugContacts() {
+  const {
+    featureFlag,
+    isEnabled,
+    newBadge,
+    eligibleAddressFamilies,
+    handleToggleEnabled,
+    handleToggleNewBadge,
+    handleSetEligibleAddressFamilies,
+    handleRestoreDefaults,
+  } = useContactsDevToolViewModel();
+
+  const featureFlagSummary = useMemo(
+    () =>
+      JSON.stringify(
+        {
+          enabled: featureFlag?.enabled ?? false,
+          params: featureFlag?.params ?? null,
+        },
+        null,
+        2,
+      ),
+    [featureFlag?.enabled, featureFlag?.params],
+  );
+
+  return (
+    <ScrollView contentContainerStyle={styles.scrollContent}>
+      <Box lx={{ paddingHorizontal: "s24", paddingVertical: "s16" }}>
+        <ContactsDevToolHeader onRestoreDefaults={handleRestoreDefaults} />
+        <ContactsEnabledToggle isEnabled={isEnabled} onToggle={handleToggleEnabled} />
+
+        <SectionHeader title="FEATURE PARAMETERS" />
+
+        <Box
+          lx={{
+            backgroundColor: "surface",
+            borderRadius: "md",
+            padding: "s8",
+            marginBottom: "s24",
+          }}
+        >
+          <FeatureParamRow
+            label="New badge"
+            isFeatureEnabled={isEnabled}
+            value={newBadge}
+            onToggle={handleToggleNewBadge}
+            testID="debug-contacts-new-badge-switch"
+          />
+
+          <Divider />
+
+          <EligibleAddressFamiliesSection
+            isEnabled={isEnabled}
+            families={eligibleAddressFamilies}
+            onPresetSelect={handleSetEligibleAddressFamilies}
+          />
+        </Box>
+
+        <FeatureFlagPreview summary={featureFlagSummary} />
+      </Box>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    flexGrow: 1,
+  },
+});

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/types.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/types.ts
@@ -1,0 +1,30 @@
+export type SectionHeaderProps = {
+  readonly title: string;
+};
+
+export type ContactsDevToolHeaderProps = {
+  readonly onRestoreDefaults: () => void;
+};
+
+export type ContactsEnabledToggleProps = {
+  readonly isEnabled: boolean;
+  readonly onToggle: () => void;
+};
+
+export type FeatureParamRowProps = {
+  readonly label: string;
+  readonly isFeatureEnabled: boolean;
+  readonly value: boolean;
+  readonly onToggle: () => void;
+  readonly testID?: string;
+};
+
+export type EligibleAddressFamiliesSectionProps = {
+  readonly isEnabled: boolean;
+  readonly families: readonly string[];
+  readonly onPresetSelect: (families: readonly string[]) => void;
+};
+
+export type FeatureFlagPreviewProps = {
+  readonly summary: string;
+};

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/useContactsDevToolViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/useContactsDevToolViewModel.ts
@@ -1,0 +1,84 @@
+import { useCallback, useMemo } from "react";
+import { useDispatch } from "react-redux";
+import { useFeature } from "@features/platform-feature-flags";
+import { DEFAULT_ELIGIBLE_ADDRESS_FAMILIES } from "@features/flow-contacts";
+import { setOverride } from "@shared/feature-flags";
+import { CONTACTS_FLAG } from "./constants";
+
+export function useContactsDevToolViewModel() {
+  const dispatch = useDispatch();
+  const featureFlag = useFeature(CONTACTS_FLAG);
+  const isEnabled = featureFlag?.enabled ?? false;
+  const newBadge = featureFlag?.params?.newBadge ?? false;
+
+  const eligibleAddressFamilies = useMemo(
+    () => featureFlag?.params?.eligibleAddressFamilies ?? [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES],
+    [featureFlag?.params?.eligibleAddressFamilies],
+  );
+
+  const dispatchOverride = useCallback(
+    (value: {
+      enabled: boolean;
+      params: {
+        newBadge: boolean;
+        eligibleAddressFamilies: readonly string[];
+      };
+    }) => {
+      dispatch(
+        setOverride({
+          key: CONTACTS_FLAG,
+          value: { ...featureFlag, ...value },
+        }),
+      );
+    },
+    [dispatch, featureFlag],
+  );
+
+  const handleToggleEnabled = useCallback(() => {
+    dispatchOverride({
+      enabled: !isEnabled,
+      params: {
+        newBadge,
+        eligibleAddressFamilies,
+      },
+    });
+  }, [dispatchOverride, isEnabled, newBadge, eligibleAddressFamilies]);
+
+  const handleToggleNewBadge = useCallback(() => {
+    dispatchOverride({
+      enabled: isEnabled,
+      params: {
+        newBadge: !newBadge,
+        eligibleAddressFamilies,
+      },
+    });
+  }, [dispatchOverride, isEnabled, newBadge, eligibleAddressFamilies]);
+
+  const handleSetEligibleAddressFamilies = useCallback(
+    (families: readonly string[]) => {
+      dispatchOverride({
+        enabled: isEnabled,
+        params: {
+          newBadge,
+          eligibleAddressFamilies: [...families],
+        },
+      });
+    },
+    [dispatchOverride, isEnabled, newBadge],
+  );
+
+  const handleRestoreDefaults = useCallback(() => {
+    dispatch(setOverride({ key: CONTACTS_FLAG, value: undefined }));
+  }, [dispatch]);
+
+  return {
+    featureFlag,
+    isEnabled,
+    newBadge,
+    eligibleAddressFamilies,
+    handleToggleEnabled,
+    handleToggleNewBadge,
+    handleSetEligibleAddressFamilies,
+    handleRestoreDefaults,
+  };
+}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/index.tsx
@@ -92,6 +92,12 @@ export default function DebugSettings({
         onPress={() => navigate(ScreenName.DebugWallet40)}
       />
       <SettingsRow
+        title="Contacts"
+        desc="Toggle Contacts rollout flag (lwmContacts) and its parameters"
+        iconLeft={<IconsLegacy.UserMedium size={24} color="black" />}
+        onPress={() => navigate(ScreenName.DebugContacts)}
+      />
+      <SettingsRow
         title="DevTools"
         desc="Feature flags and dev tools panel"
         iconLeft={<IconsLegacy.ToolsMedium size={24} color="black" />}

--- a/libs/coin-modules/coin-tron/src/bridge/transaction.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/transaction.ts
@@ -9,7 +9,12 @@ import {
 } from "@ledgerhq/ledger-wallet-framework/serialization";
 import type { Account } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
-import type { Transaction, TransactionRaw, TransactionStatus, TransactionStatusRaw } from "../types";
+import type {
+  Transaction,
+  TransactionRaw,
+  TransactionStatus,
+  TransactionStatusRaw,
+} from "../types";
 
 // These resource fields are live-derived and not persisted (absent from TransactionStatusRaw).
 // Default them to 0 on deserialization so the required BigNumber fields are never `undefined`.


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

This pull request adds a new debug screen for the Contacts feature flag in the mobile app's Settings > Debug section. It introduces UI controls for toggling the Contacts feature flag and its parameters, presets for eligible address families, and the ability to restore defaults. The changes include navigation updates, a new view model, and comprehensive tests.

**Contacts Feature Flag Debug Controls:**

* Added a new debug screen (`DebugContacts`) for the Contacts feature flag, allowing developers and QA to toggle the flag, adjust parameters 

**Navigation and Type Updates:**

* Registered the new debug screen in the navigation stack, updated the screen name enum, and extended the navigator's type definitions. 

**Testing:**

* Added unit tests for the Contacts debug view model to ensure correct behavior when toggling the feature flag, modifying parameters, and restoring defaults.

**Documentation:**

* Added a changeset describing the addition of Contacts feature flag debug controls.


https://github.com/user-attachments/assets/cf6fdc88-1ca7-4d34-9137-e4f3f4d8dd54


### 🔗 Context

[LIVE-34108](https://ledgerhq.atlassian.net/browse/LIVE-34108)


[LIVE-34108]: https://ledgerhq.atlassian.net/browse/LIVE-34108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ