### PR TITLE
[LWM] feat(LIVE-30493): wire real private sync into aleo mandatory sync screen

### DIFF
--- a/.changeset/tame-otters-dance.md
+++ b/.changeset/tame-otters-dance.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Wire real private sync into the Aleo mandatory private sync screen, replacing the fixed 2s mock delay with an actual refresh of unspentPrivateRecords before a private send

--- a/apps/ledger-live-mobile/src/families/aleo/Send/MandatoryPrivateSyncScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/MandatoryPrivateSyncScreen.tsx
@@ -1,9 +1,12 @@
 import React, { useEffect } from "react";
-import { Box, Text, Spinner } from "@ledgerhq/lumen-ui-rnative";
+import { Box, Button, Spinner, Text } from "@ledgerhq/lumen-ui-rnative";
+import { WarningFill } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import { useTranslation } from "~/context/Locale";
 import { ScreenName } from "~/const";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import type { SendFundsNavigatorStackParamList } from "~/components/RootNavigator/types/SendFundsNavigator";
+import { useAleoPrivateSync } from "../hooks/useAleoPrivateSync";
 
 type Props = StackNavigatorProps<
   SendFundsNavigatorStackParamList,
@@ -13,18 +16,43 @@ type Props = StackNavigatorProps<
 export function MandatoryPrivateSyncScreen({ navigation, route }: Props) {
   const { t } = useTranslation();
   const { account, parentAccount, transaction } = route.params;
+  const mainAccount = getMainAccount(account, parentAccount);
+
+  const { isSyncing, progress, error, start } = useAleoPrivateSync({
+    account: mainAccount,
+    autoStart: true,
+  });
 
   useEffect(() => {
+    if (progress < 100 || isSyncing || error) return;
+
     const timer = setTimeout(() => {
       navigation.replace(ScreenName.SendAmountCoin, {
         accountId: account.id,
         parentId: parentAccount?.id,
         transaction,
       });
-    }, 2000);
+    }, 500);
 
     return () => clearTimeout(timer);
-  }, [account, navigation, parentAccount, transaction]);
+  }, [progress, isSyncing, error, navigation, account, parentAccount, transaction]);
+
+  if (error) {
+    return (
+      <Box
+        lx={{ flex: 1, alignItems: "center", justifyContent: "center", gap: "s24", padding: "s24" }}
+      >
+        <WarningFill size={40} color="warning" />
+        <Text typography="heading4SemiBold" lx={{ color: "base", textAlign: "center" }}>
+          {t("aleo.send.mandatoryPrivateSync.errorTitle")}
+        </Text>
+        <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
+          {t("aleo.send.mandatoryPrivateSync.errorDesc")}
+        </Text>
+        <Button onPress={start}>{t("common.retry")}</Button>
+      </Box>
+    );
+  }
 
   return (
     <Box
@@ -32,7 +60,10 @@ export function MandatoryPrivateSyncScreen({ navigation, route }: Props) {
     >
       <Spinner size={48} />
       <Text typography="heading4SemiBold" lx={{ color: "base", textAlign: "center" }}>
-        {t("aleo.send.privateSync.mockTitle")}
+        {t("aleo.send.mandatoryPrivateSync.title", { percentage: progress })}
+      </Text>
+      <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
+        {t("aleo.send.mandatoryPrivateSync.desc")}
       </Text>
     </Box>
   );

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/MandatoryPrivateSyncScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/MandatoryPrivateSyncScreen.test.tsx
@@ -1,8 +1,13 @@
 import React from "react";
-import { act, render } from "@tests/test-renderer";
+import { act, render, screen } from "@tests/test-renderer";
 import { MandatoryPrivateSyncScreen } from "../MandatoryPrivateSyncScreen";
 import { ScreenName } from "~/const";
 import { ALEO_ACCOUNT_1 } from "../../__mocks__/account.mock";
+import { useAleoPrivateSync } from "../../hooks/useAleoPrivateSync";
+
+jest.mock("../../hooks/useAleoPrivateSync");
+
+const mockUseAleoPrivateSync = jest.mocked(useAleoPrivateSync);
 
 const mockTransaction = { family: "aleo", recipient: "aleo1abc" } as never;
 
@@ -21,17 +26,27 @@ function makeRoute() {
 describe("MandatoryPrivateSyncScreen", () => {
   const mockNavigation = makeNavigation();
   const mockRoute = makeRoute();
+  let mockStart: jest.Mock;
 
   beforeEach(() => {
     jest.useFakeTimers();
     mockNavigation.replace.mockReset();
+    mockUseAleoPrivateSync.mockReset();
+    mockStart = jest.fn();
+    mockUseAleoPrivateSync.mockReturnValue({
+      isSyncing: false,
+      progress: 0,
+      error: null,
+      start: mockStart,
+      stop: jest.fn(),
+    });
   });
 
   afterEach(() => {
     jest.useRealTimers();
   });
 
-  it("navigates to SendAmountCoin after 2 seconds", () => {
+  it("wires the real sync hook with the main account, autoStart, and no keepAliveOnUnmount", () => {
     render(
       <MandatoryPrivateSyncScreen
         navigation={mockNavigation as never}
@@ -39,21 +54,23 @@ describe("MandatoryPrivateSyncScreen", () => {
       />,
     );
 
-    act(() => {
-      jest.advanceTimersByTime(2000);
-    });
-
-    expect(mockNavigation.replace).toHaveBeenCalledTimes(1);
-    expect(mockNavigation.replace).toHaveBeenCalledWith(
-      ScreenName.SendAmountCoin,
-      expect.objectContaining({
-        accountId: ALEO_ACCOUNT_1.id,
-        transaction: mockTransaction,
-      }),
+    expect(mockUseAleoPrivateSync).toHaveBeenCalledWith(
+      expect.objectContaining({ account: ALEO_ACCOUNT_1, autoStart: true }),
+    );
+    expect(mockUseAleoPrivateSync).not.toHaveBeenCalledWith(
+      expect.objectContaining({ keepAliveOnUnmount: true }),
     );
   });
 
-  it("does not navigate before 2 seconds have elapsed", () => {
+  it("renders the syncing state with interpolated progress and does not navigate", () => {
+    mockUseAleoPrivateSync.mockReturnValue({
+      isSyncing: true,
+      progress: 42,
+      error: null,
+      start: mockStart,
+      stop: jest.fn(),
+    });
+
     render(
       <MandatoryPrivateSyncScreen
         navigation={mockNavigation as never}
@@ -61,14 +78,113 @@ describe("MandatoryPrivateSyncScreen", () => {
       />,
     );
 
-    act(() => {
-      jest.advanceTimersByTime(1999);
-    });
-
+    expect(screen.getByText("Syncing your private balance (42%)")).toBeOnTheScreen();
     expect(mockNavigation.replace).not.toHaveBeenCalled();
   });
 
-  it("cancels the timer on unmount", () => {
+  it("navigates to SendAmountCoin once syncing completes", () => {
+    mockUseAleoPrivateSync.mockReturnValue({
+      isSyncing: false,
+      progress: 100,
+      error: null,
+      start: mockStart,
+      stop: jest.fn(),
+    });
+
+    render(
+      <MandatoryPrivateSyncScreen
+        navigation={mockNavigation as never}
+        route={mockRoute as never}
+      />,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(mockNavigation.replace).toHaveBeenCalledTimes(1);
+    expect(mockNavigation.replace).toHaveBeenCalledWith(ScreenName.SendAmountCoin, {
+      accountId: ALEO_ACCOUNT_1.id,
+      parentId: undefined,
+      transaction: mockTransaction,
+    });
+  });
+
+  it("does not navigate if progress reaches 100 while an error is set", () => {
+    mockUseAleoPrivateSync.mockReturnValue({
+      isSyncing: false,
+      progress: 100,
+      error: new Error("sync failed"),
+      start: mockStart,
+      stop: jest.fn(),
+    });
+
+    render(
+      <MandatoryPrivateSyncScreen
+        navigation={mockNavigation as never}
+        route={mockRoute as never}
+      />,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(mockNavigation.replace).not.toHaveBeenCalled();
+    expect(screen.getByText("Private sync failed")).toBeOnTheScreen();
+  });
+
+  it("renders retry UI on error and does not navigate", () => {
+    mockUseAleoPrivateSync.mockReturnValue({
+      isSyncing: false,
+      progress: 30,
+      error: new Error("sync failed"),
+      start: mockStart,
+      stop: jest.fn(),
+    });
+
+    render(
+      <MandatoryPrivateSyncScreen
+        navigation={mockNavigation as never}
+        route={mockRoute as never}
+      />,
+    );
+
+    expect(screen.getByText("Private sync failed")).toBeOnTheScreen();
+    expect(screen.getByText("Retry")).toBeOnTheScreen();
+    expect(mockNavigation.replace).not.toHaveBeenCalled();
+  });
+
+  it("calls start() when the retry button is pressed", async () => {
+    mockUseAleoPrivateSync.mockReturnValue({
+      isSyncing: false,
+      progress: 30,
+      error: new Error("sync failed"),
+      start: mockStart,
+      stop: jest.fn(),
+    });
+
+    const { user } = render(
+      <MandatoryPrivateSyncScreen
+        navigation={mockNavigation as never}
+        route={mockRoute as never}
+      />,
+    );
+
+    await user.press(screen.getByText("Retry"));
+
+    expect(mockStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels the pending navigation on unmount before the delay fires", () => {
+    mockUseAleoPrivateSync.mockReturnValue({
+      isSyncing: false,
+      progress: 100,
+      error: null,
+      start: mockStart,
+      stop: jest.fn(),
+    });
+
     const { unmount } = render(
       <MandatoryPrivateSyncScreen
         navigation={mockNavigation as never}
@@ -79,7 +195,7 @@ describe("MandatoryPrivateSyncScreen", () => {
     unmount();
 
     act(() => {
-      jest.advanceTimersByTime(2000);
+      jest.advanceTimersByTime(1000);
     });
 
     expect(mockNavigation.replace).not.toHaveBeenCalled();

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10131,8 +10131,11 @@
         "lastUpdate": "Last update: {{label}}",
         "recently": "recently"
       },
-      "privateSync": {
-        "mockTitle": "Private sync mock"
+      "mandatoryPrivateSync": {
+        "title": "Syncing your private balance ({{percentage}}%)",
+        "desc": "Please wait",
+        "errorTitle": "Private sync failed",
+        "errorDesc": "Something went wrong, please try again"
       },
       "quickAmountSelector": {
         "mockTitle": "Quick amount selector mock"


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Wire real private sync into the Aleo mandatory private sync screen, replacing the fixed 2s mock delay with an actual refresh of unspentPrivateRecords before a private send.

<img src="https://github.com/user-attachments/assets/4420f8a9-240e-4442-a59f-239e6e38a6b0" alt="syncing-private-balance" width="220" />
<img src="https://github.com/user-attachments/assets/e5395f3f-0c67-4a7d-a28b-47bc1582e2eb" alt="syncing-private-balance-retry" width="220" />

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-30493