### PR TITLE
[LWD] feat(lwd): open mad on aggregated assets page's send

### DIFF
--- a/.changeset/fair-eels-teach.md
+++ b/.changeset/fair-eels-teach.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(lwd): open MAD on send from aggregated assets page

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
@@ -62,12 +62,17 @@ const TEST_ID = {
 const mockGetCanStakeCurrency = jest.fn().mockReturnValue(false);
 const mockUseInterestRatesByCurrencies = jest.fn().mockReturnValue({});
 const mockStartStakeFlow = jest.fn();
+const mockOpenSendFlow = jest.fn();
 
 jest.mock("LLD/hooks/useStake", () => ({
   useStake: () => ({ getCanStakeCurrency: mockGetCanStakeCurrency }),
 }));
 
 jest.mock("~/renderer/screens/stake", () => () => mockStartStakeFlow);
+
+jest.mock("LLD/features/Send/hooks/useOpenSendFlow", () => ({
+  useOpenSendFlow: () => mockOpenSendFlow,
+}));
 
 jest.mock("@ledgerhq/live-common/dada-client/hooks/useInterestRatesByCurrencies", () => ({
   useInterestRatesByCurrencies: (...args: unknown[]) => mockUseInterestRatesByCurrencies(...args),
@@ -984,6 +989,28 @@ describe("AssetDetail integration", () => {
       });
 
       expect(screen.getByTestId(TEST_ID.ACTION_RECEIVE)).toBeEnabled();
+    });
+
+    it("opens send account selection filtered to the asset instead of preselecting an account", async () => {
+      mockMarket.withData(MarketMockedResponse.bitcoinDetail);
+      const account = genAccount("asset-detail-send-account-selection", { currency: btc });
+      account.balance = new BigNumber(10);
+      account.spendableBalance = new BigNumber(10);
+      const item = buildDistributionItem({ accounts: [account] });
+      setupRoute("bitcoin", { bySlug: { bitcoin: item }, list: [item] });
+
+      renderWithMockedCounterValuesProvider(<AssetDetail />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId(TEST_ID.ACTION_SEND)).toBeEnabled();
+      });
+
+      fireEvent.click(screen.getByTestId(TEST_ID.ACTION_SEND));
+
+      expect(mockOpenSendFlow).toHaveBeenCalledWith({
+        source: "Asset",
+        currencyIds: ["bitcoin"],
+      });
     });
 
     it("enables buy, sell and send when the address has an earn deposit", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/useActionBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ActionBar/useActionBarViewModel.ts
@@ -162,6 +162,15 @@ export function useActionBarViewModel({
     ledgerCurrency?.id ?? distributionItem?.currency.id ?? rampActiveLedgerIds[0];
   const rampNavigationCurrencyIds =
     rampActiveLedgerIds.length > 1 ? rampActiveLedgerIds : undefined;
+  const sendCurrencyIds = useMemo(
+    () =>
+      ledgerIds && ledgerIds.length > 0
+        ? ledgerIds
+        : trackingCurrencyId
+          ? [trackingCurrencyId]
+          : undefined,
+    [ledgerIds, trackingCurrencyId],
+  );
 
   const onBuy = useCallback(() => {
     track("button_clicked", {
@@ -189,16 +198,11 @@ export function useActionBarViewModel({
       currency: trackingCurrencyId,
       page: ASSET_DETAIL_TRACKING_PAGE_NAME,
     });
-    if (primaryAccount) {
-      openSendFlow({
-        source: ASSET_DETAIL_TRACKING_PAGE_NAME,
-        account: primaryAccount,
-        parentAccount: primaryParentAccount,
-      });
-    } else {
-      openSendFlow({ source: ASSET_DETAIL_TRACKING_PAGE_NAME });
-    }
-  }, [openSendFlow, primaryAccount, primaryParentAccount, trackingCurrencyId]);
+    openSendFlow({
+      source: ASSET_DETAIL_TRACKING_PAGE_NAME,
+      currencyIds: sendCurrencyIds,
+    });
+  }, [openSendFlow, sendCurrencyIds, trackingCurrencyId]);
 
   const onReceive = useCallback(() => {
     track("button_clicked", {

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useOpenSendFlow.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useOpenSendFlow.test.ts
@@ -1,0 +1,48 @@
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { renderHook, withFlagOverrides } from "tests/testSetup";
+import { useOpenSendFlow } from "../useOpenSendFlow";
+
+describe("useOpenSendFlow", () => {
+  it("opens account selection filtered to the requested currencies when no account is preselected", () => {
+    const account = genAccount("send-account-selection", {
+      currency: getCryptoCurrencyById("bitcoin"),
+    });
+    const { result, store } = renderHook(() => useOpenSendFlow(), {
+      initialState: {
+        ...withFlagOverrides({
+          newSendFlow: {
+            enabled: true,
+            params: { families: ["bitcoin"], excludedCurrencyIds: [] },
+          },
+        }),
+        accounts: [account],
+      },
+    });
+
+    result.current({
+      source: "Asset Detail",
+      currencyIds: ["bitcoin"],
+    });
+
+    expect(store.getState().modularDialog.isOpen).toBe(true);
+    expect(store.getState().modularDialog.flow).toBe("send");
+    expect(store.getState().modularDialog.source).toBe("Asset Detail");
+    expect(store.getState().modularDialog.dialogParams?.currencies).toEqual(["bitcoin"]);
+    expect(store.getState().modularDialog.dialogParams?.areCurrenciesFiltered).toBe(true);
+    expect(store.getState().modularDialog.dialogParams?.onAccountSelected).toEqual(
+      expect.any(Function),
+    );
+    expect(store.getState().sendFlow.isOpen).toBe(false);
+
+    store.getState().modularDialog.dialogParams?.onAccountSelected?.(account);
+
+    expect(store.getState().modularDialog.isOpen).toBe(false);
+    expect(store.getState().sendFlow.isOpen).toBe(true);
+    expect(store.getState().sendFlow.data?.params).toEqual(
+      expect.objectContaining({
+        account,
+      }),
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
@@ -26,6 +26,7 @@ const SEND_ACCOUNT_SELECTION_DRAWER_CONFIGURATION: EnhancedModularDrawerConfigur
 type WorkflowParams = {
   account?: AccountLike;
   parentAccount?: Account;
+  currencyIds?: readonly string[];
   recipient?: string;
   amount?: string | BigNumber;
   memo?: string;
@@ -45,17 +46,20 @@ export function useOpenSendFlow() {
       setOriginFlow(HOOKS_TRACKING_LOCATIONS.sendModal);
 
       const openSendFlowImpl = (nextParams?: WorkflowParams) => {
-        if (!nextParams?.account) {
+        const { currencyIds, ...flowParams } = nextParams ?? {};
+
+        if (!flowParams.account) {
           // When there are no accounts, the old modal requires an account and would throw.
           // Always use the new drawer for account selection (or empty state) in that case.
           const shouldUseNewFlowForNoAccount = hasNoAccounts || isEnabledForFamily();
           if (shouldUseNewFlowForNoAccount) {
             // Feature flag enabled: use new drawer for account selection
             dispatch(setFlowValue("send"));
-            dispatch(setSourceValue(nextParams?.source ?? ""));
+            dispatch(setSourceValue(flowParams.source ?? ""));
             dispatch(
               openDialog({
-                currencies: [],
+                currencies: currencyIds ? [...currencyIds] : [],
+                areCurrenciesFiltered: Boolean(currencyIds?.length),
                 dialogConfiguration: SEND_ACCOUNT_SELECTION_DRAWER_CONFIGURATION,
                 onAccountSelected: (account: AccountLike, parentAccount?: Account) => {
                   dispatch(closeDialog());
@@ -69,7 +73,7 @@ export function useOpenSendFlow() {
                     ...getSendFlowTrackingProperties(account, parentAccount, shouldUseNewFlow),
                   });
                   openSendFlowImpl({
-                    ...nextParams,
+                    ...flowParams,
                     account,
                     parentAccount,
                   });
@@ -83,37 +87,37 @@ export function useOpenSendFlow() {
           // (when there are no accounts we use the new drawer above to avoid "account required").
           dispatch(
             openModal("MODAL_SEND", {
-              ...nextParams,
+              ...flowParams,
               amount:
-                typeof nextParams?.amount === "string"
-                  ? new BigNumber(nextParams.amount)
-                  : nextParams?.amount,
+                typeof flowParams.amount === "string"
+                  ? new BigNumber(flowParams.amount)
+                  : flowParams.amount,
             }),
           );
           return;
         }
 
-        const family = getFamilyFromAccount(nextParams.account, nextParams.parentAccount ?? null);
+        const family = getFamilyFromAccount(flowParams.account, flowParams.parentAccount ?? null);
         const currencyId = getCurrencyIdFromAccount(
-          nextParams.account,
-          nextParams.parentAccount ?? null,
+          flowParams.account,
+          flowParams.parentAccount ?? null,
         );
         const shouldUseNewFlow = isEnabledForFamily(family, currencyId);
 
         if (shouldUseNewFlow) {
           let normalizedAmount: string | undefined;
-          if (typeof nextParams.amount === "string") {
-            normalizedAmount = nextParams.amount;
-          } else if (nextParams.amount) {
-            normalizedAmount = nextParams.amount.toString();
+          if (typeof flowParams.amount === "string") {
+            normalizedAmount = flowParams.amount;
+          } else if (flowParams.amount) {
+            normalizedAmount = flowParams.amount.toString();
           } else {
             normalizedAmount = undefined;
           }
 
           const normalizedParams: SendFlowParams = {
-            ...nextParams,
+            ...flowParams,
             amount: normalizedAmount,
-            fromMAD: nextParams.fromMAD ?? false,
+            fromMAD: flowParams.fromMAD ?? false,
           };
           dispatch(
             openSendFlowDialog({
@@ -123,11 +127,11 @@ export function useOpenSendFlow() {
         } else {
           dispatch(
             openModal("MODAL_SEND", {
-              ...nextParams,
+              ...flowParams,
               amount:
-                typeof nextParams.amount === "string"
-                  ? new BigNumber(nextParams.amount)
-                  : nextParams.amount,
+                typeof flowParams.amount === "string"
+                  ? new BigNumber(flowParams.amount)
+                  : flowParams.amount,
             }),
           );
         }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The Asset Detail Send action previously preselected an account, bypassing account selection even when multiple accounts were available. It now opens the Modular Asset Drawer filtered to the asset’s currencies before starting the Send flow. Integration and hook tests cover the entry point and the transition from account selection to the Send flow.

https://github.com/user-attachments/assets/c59dec7a-d5b2-4715-94d8-e1de82b33fad


### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-34308)**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
