### PR TITLE
feat(wallet-cli): ring destroy handles non-destructive deactivation [NTTVS-406]

### DIFF
--- a/.changeset/ring-destroy-non-destructive.md
+++ b/.changeset/ring-destroy-non-destructive.md
@@ -1,0 +1,11 @@
+---
+"@ledgerhq/wallet-cli": patch
+---
+
+`ring destroy` now handles the non-destructive application deactivation introduced by the LKRP
+per-application close: it calls `destroyApplication` directly (which is idempotent on an
+already-closed stream) and, when the member has been ejected from the ring (`TrustchainEjected` —
+removed by another owner, or the trustchain destroyed remotely), treats the remote as already gone
+and proceeds to the local credential wipe instead of aborting as a transient network failure.
+`ring encrypt`/`ring decrypt` now surface actionable guidance when the wallet-cli application has
+been deactivated on the ring.

--- a/apps/wallet-cli/src/commands/ring/destroy.ts
+++ b/apps/wallet-cli/src/commands/ring/destroy.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from "@bunli/core";
 import { createInterface } from "node:readline";
 import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
+import { TrustchainEjected } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import type { Spinner } from "yocto-spinner";
 import { Session, trustchainFromMeta, type TrustchainMeta } from "../../session/session-store";
 import {
@@ -103,21 +104,36 @@ async function performRemoteDestroy(
   trustchainMeta: TrustchainMeta,
   memberCredentials: MemberCredentials,
   destroySpin: Spinner | null,
-): Promise<{ remoteSucceeded: boolean; trustchainDestroyed: boolean }> {
+): Promise<{
+  remoteSucceeded: boolean;
+  trustchainDestroyed: boolean;
+  memberEjected: boolean;
+}> {
   const sdk = createLkrpSdk();
   try {
-    const latest = await sdk.restoreTrustchain(
+    // destroyApplication resolves the trustchain itself (no encryption key, no separate
+    // restoreTrustchain round-trip), closes only the wallet-cli stream (or the whole trustchain when
+    // it's the last open app), and is idempotent on an already-closed stream (returns without throwing).
+    const { trustchainDestroyed } = await sdk.destroyApplication(
       trustchainFromMeta(trustchainMeta),
       memberCredentials,
     );
-    const { trustchainDestroyed } = await sdk.destroyApplication(latest, memberCredentials);
     // Stop without a message: out.ringDestroy() below is the single source of the outcome line.
     destroySpin?.stop();
-    return { remoteSucceeded: true, trustchainDestroyed };
-  } catch {
+    return { remoteSucceeded: true, trustchainDestroyed, memberEjected: false };
+  } catch (e) {
+    if (e instanceof TrustchainEjected) {
+      // destroyApplication is idempotent on an already-closed stream (returns without throwing), so
+      // TrustchainEjected means this member is no longer on the ring: it was removed by another
+      // owner, or the trustchain was destroyed remotely. Either way there's nothing left for us to
+      // tear down, so proceed to the local wipe rather than aborting as a transient failure
+      // (retrying would never succeed).
+      destroySpin?.stop();
+      return { remoteSucceeded: true, trustchainDestroyed: false, memberEjected: true };
+    }
     // No local wipe here: the handler aborts on a failed teardown (keeping the key). See below.
     destroySpin?.error("Remote teardown failed");
-    return { remoteSucceeded: false, trustchainDestroyed: false };
+    return { remoteSucceeded: false, trustchainDestroyed: false, memberEjected: false };
   }
 }
 
@@ -189,10 +205,11 @@ export default defineCommand({
 
       let remoteSucceeded = false;
       let trustchainDestroyed = false;
+      let memberEjected = false;
 
       if (creds.status === "ok") {
         const destroySpin = out.spin("Tearing down your Ledger Key Ring…");
-        ({ remoteSucceeded, trustchainDestroyed } = await performRemoteDestroy(
+        ({ remoteSucceeded, trustchainDestroyed, memberEjected } = await performRemoteDestroy(
           trustchainMeta,
           creds.memberCredentials,
           destroySpin,
@@ -227,7 +244,7 @@ export default defineCommand({
         session.wipeRing();
         session.write();
       }
-      out.ringDestroy({ remoteSucceeded, trustchainDestroyed, localWiped });
+      out.ringDestroy({ remoteSucceeded, trustchainDestroyed, localWiped, memberEjected });
       trackRingDestroyCompleted({
         remoteSucceeded,
         trustchainDestroyed,

--- a/apps/wallet-cli/src/key-ring/load-key-ring.ts
+++ b/apps/wallet-cli/src/key-ring/load-key-ring.ts
@@ -1,4 +1,5 @@
-import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
+import type { MemberCredentials, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
+import { TrustchainEjected } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { Session, type TrustchainMeta, trustchainFromMeta } from "../session/session-store";
 import { loadMemberCredentials } from "./keychain";
 import { createLkrpSdk } from "./lkrp-sdk";
@@ -49,10 +50,23 @@ export async function loadDomainKey(
     preloadedSession,
   );
   const sdk = createLkrpSdk();
-  const restored = await sdk.restoreTrustchain(
-    trustchainFromMeta(trustchainMeta),
-    memberCredentials,
-  );
+  let restored: Trustchain;
+  try {
+    restored = await sdk.restoreTrustchain(trustchainFromMeta(trustchainMeta), memberCredentials);
+  } catch (e) {
+    // The wallet-cli application stream was closed (deactivated from another device, or this member
+    // was removed): restoreTrustchain rejects a closed stream with TrustchainEjected. Point the user
+    // at the recovery path rather than surfacing the raw protocol error.
+    if (e instanceof TrustchainEjected) {
+      throw new Error(
+        "The wallet-cli application is no longer active on this Ledger Key Ring (deactivated " +
+          "elsewhere, or this member was removed). Run `wallet-cli ring destroy` then " +
+          "`wallet-cli ring init` to reactivate.",
+        { cause: e },
+      );
+    }
+    throw e;
+  }
   if (restored.applicationPath !== trustchainMeta.applicationPath) {
     // The ring rotated (e.g. a member was removed), changing the encryption key: warn loudly since
     // data encrypted before the rotation can no longer be decrypted from the new application path.

--- a/apps/wallet-cli/src/output-json.test.ts
+++ b/apps/wallet-cli/src/output-json.test.ts
@@ -264,6 +264,40 @@ describe("JsonCommandOutput", () => {
     });
   });
 
+  it("ringDestroy emits member_ejected=true when the member was ejected from the ring", () => {
+    const out = createCommandOutput("json", { command: "ring destroy", network: "all" });
+    out.ringDestroy({
+      remoteSucceeded: true,
+      trustchainDestroyed: false,
+      localWiped: true,
+      memberEjected: true,
+    });
+
+    const [line] = parseLines();
+    expect(line).toMatchObject({
+      status: "success",
+      destroyed: false,
+      remote_succeeded: true,
+      member_ejected: true,
+      local_wiped: true,
+    });
+  });
+
+  it("ringDestroy reports member_ejected=false when the remote teardown did not succeed", () => {
+    const out = createCommandOutput("json", { command: "ring destroy", network: "all" });
+    // member_ejected is only meaningful alongside remote_succeeded, so a failed teardown must not
+    // report it even if a caller mis-populates memberEjected.
+    out.ringDestroy({
+      remoteSucceeded: false,
+      trustchainDestroyed: false,
+      localWiped: true,
+      memberEjected: true,
+    });
+
+    const [line] = parseLines();
+    expect(line).toMatchObject({ remote_succeeded: false, member_ejected: false });
+  });
+
   it("ringDestroy emits destroyed=false and remote_succeeded=false when only local wipe", () => {
     const out = createCommandOutput("json", { command: "ring destroy", network: "all" });
     out.ringDestroy({ remoteSucceeded: false, trustchainDestroyed: false, localWiped: true });

--- a/apps/wallet-cli/src/output.ts
+++ b/apps/wallet-cli/src/output.ts
@@ -59,6 +59,9 @@ export type RingDestroyResult = {
   remoteSucceeded: boolean;
   trustchainDestroyed: boolean;
   localWiped: boolean;
+  // Remote teardown hit TrustchainEjected: this member is no longer on the ring (removed, or the ring
+  // was destroyed remotely), so the remote is already gone. Only meaningful alongside remoteSucceeded.
+  memberEjected?: boolean;
 };
 
 export interface CommandOutput {
@@ -568,11 +571,20 @@ class HumanCommandOutput implements CommandOutput {
     }
   }
 
-  ringDestroy({ remoteSucceeded, trustchainDestroyed, localWiped }: RingDestroyResult): void {
+  ringDestroy({
+    remoteSucceeded,
+    trustchainDestroyed,
+    localWiped,
+    memberEjected,
+  }: RingDestroyResult): void {
     // Report the remote outcome first so a successful teardown is never hidden by a local-wipe
     // failure, then append the local-credentials warning when the keychain delete did not succeed.
     if (trustchainDestroyed) {
       writeStdout(`${colors.green("✔")} Ledger Key Ring destroyed.`);
+    } else if (remoteSucceeded && memberEjected) {
+      writeStdout(
+        `${colors.green("✔")} wallet-cli is no longer a member of this Ledger Key Ring — it was removed, or the ring was destroyed remotely.`,
+      );
     } else if (remoteSucceeded) {
       writeStdout(
         `${colors.green("✔")} wallet-cli application deactivated (Ledger Key Ring kept for other apps).`,
@@ -910,12 +922,18 @@ class JsonCommandOutput implements CommandOutput {
     );
   }
 
-  ringDestroy({ remoteSucceeded, trustchainDestroyed, localWiped }: RingDestroyResult): void {
+  ringDestroy({
+    remoteSucceeded,
+    trustchainDestroyed,
+    localWiped,
+    memberEjected,
+  }: RingDestroyResult): void {
     this._writeNdjson(
       this._envelope({
         destroyed: trustchainDestroyed,
         remote_succeeded: remoteSucceeded,
         local_wiped: localWiped,
+        member_ejected: remoteSucceeded && !!memberEjected,
       }),
     );
   }

--- a/apps/wallet-cli/src/test/commands/ring.test.ts
+++ b/apps/wallet-cli/src/test/commands/ring.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, mock } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { TrustchainEjected } from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { Readable } from "node:stream";
@@ -584,10 +585,10 @@ describe("ring destroy — transient remote failure keeps the local key", () => 
     const before = [..._store.values()];
     expect(before).toHaveLength(1);
 
-    // Simulate a transient remote failure: restoreTrustchain throws before any teardown happens.
+    // Simulate a transient remote failure: destroyApplication throws a non-ejected error.
     mock.module("../../key-ring/lkrp-sdk", () => ({
       createLkrpSdk: () => ({
-        restoreTrustchain: async () => {
+        destroyApplication: async () => {
           throw new Error("network down");
         },
       }),
@@ -596,5 +597,183 @@ describe("ring destroy — transient remote failure keeps the local key", () => 
     const r = await runCliWithStdin(["ring", "destroy"], env, ["destroy"]);
     expect(r.exitCode).toBe(1);
     expect([..._store.values()]).toEqual(before); // key kept — no orphaning on a transient failure
+  });
+});
+
+// The runner shares one in-process module graph across tests (see cli-runner.ts), and an lkrp-sdk
+// `mock.module` from an earlier block stays registered here — so a real `ring init` would use the
+// mocked SDK and fail. We therefore seed the initialized ring state (session + keychain) directly
+// and mock only the SDK method under test.
+async function seedInitializedRing(dir: string): Promise<void> {
+  const sessionPath = join(dir, "ledger-wallet-cli", "session.yaml");
+  mkdirSync(dirname(sessionPath), { recursive: true });
+  writeFileSync(
+    sessionPath,
+    YAML.stringify({
+      accounts: [],
+      trustchain: { rootId: "seed-root", applicationPath: "m/0'/17'/0'" },
+    }),
+  );
+  // savePrivateKey hashes the account name from XDG_STATE_HOME, so pin it to this temp dir (matching
+  // the env passed to runCli) before saving.
+  const { savePrivateKey } = await import("../../key-ring/keychain");
+  const saved = process.env.XDG_STATE_HOME;
+  process.env.XDG_STATE_HOME = dir;
+  try {
+    await savePrivateKey("aa".repeat(32), "bb".repeat(33));
+  } finally {
+    if (saved === undefined) delete process.env.XDG_STATE_HOME;
+    else process.env.XDG_STATE_HOME = saved;
+  }
+}
+
+describe("ring destroy — ejected member wipes locally", () => {
+  const { dir, env, cleanup } = makeTmpDir();
+  afterAll(() => {
+    // See the transient-failure block: mock.restore() is all-or-nothing, so re-install the file-wide
+    // keychain mock afterwards.
+    mock.restore();
+    installKeychainMock();
+    cleanup();
+  });
+
+  it("treats TrustchainEjected as remote-already-gone and wipes the key (exit 0)", async () => {
+    _store.clear();
+    await seedInitializedRing(dir);
+    expect([..._store.values()]).toHaveLength(1);
+
+    // destroyApplication is idempotent on an already-closed stream (returns without throwing), so
+    // TrustchainEjected means this member is no longer on the ring (removed by another owner, or the
+    // trustchain was destroyed remotely): the remote is gone for us, so destroy should proceed to the
+    // local wipe rather than abort.
+    mock.module("../../key-ring/lkrp-sdk", () => ({
+      createLkrpSdk: () => ({
+        destroyApplication: async () => {
+          throw new TrustchainEjected("not a member of trustchain");
+        },
+      }),
+    }));
+
+    const r = await runCliWithStdin(["ring", "destroy"], env, ["destroy"]);
+    expect(r.exitCode, r.stderr).toBe(0);
+    expect([..._store.values()]).toHaveLength(0); // key wiped despite the remote being already gone
+    expect(r.stdout).toMatch(/no longer a member/i);
+  });
+});
+
+describe("ring encrypt/decrypt — closed application stream gives reactivation guidance", () => {
+  const { dir, env, cleanup } = makeTmpDir();
+  afterAll(() => {
+    mock.restore();
+    installKeychainMock();
+    cleanup();
+  });
+
+  // Asserted at unit level (like the "stray password-protected key" block above): Bunli prints the
+  // command Error to the real stderr, which runCli's output capture does not observe.
+  it("loadDomainKey rethrows an ejected stream as actionable guidance", async () => {
+    _store.clear();
+    await seedInitializedRing(dir);
+
+    // The application was deactivated on the ring elsewhere: restoreTrustchain rejects a closed stream.
+    mock.module("../../key-ring/lkrp-sdk", () => ({
+      createLkrpSdk: () => ({
+        restoreTrustchain: async () => {
+          throw new TrustchainEjected("application stream is closed");
+        },
+      }),
+    }));
+    // Dynamic import so the mock above is in effect (a static import would hoist above it).
+    const { loadDomainKey } = await import("../../key-ring/load-key-ring");
+
+    const saved = process.env.XDG_STATE_HOME;
+    process.env.XDG_STATE_HOME = dir; // pin the session dir + keychain account to this temp dir
+    try {
+      await expect(loadDomainKey("mykey")).rejects.toThrow(/deactivated/i);
+      await expect(loadDomainKey("mykey")).rejects.toThrow(/ring init/i);
+    } finally {
+      if (saved === undefined) delete process.env.XDG_STATE_HOME;
+      else process.env.XDG_STATE_HOME = saved;
+    }
+  });
+
+  it("the encrypt command fails on an ejected stream (but succeeds on an open one)", async () => {
+    // Self-contained: seed the ring state here too so the test passes when run in isolation (filtered).
+    _store.clear();
+    await seedInitializedRing(dir);
+    const inputFile = join(dir, "plain.txt");
+    writeFileSync(inputFile, "payload");
+    const outFile = join(dir, "o.enc");
+    const encryptArgs = [
+      "ring",
+      "encrypt",
+      "--key",
+      "mykey",
+      "--input",
+      inputFile,
+      "--out",
+      outFile,
+    ];
+
+    // Positive control: with an open stream, the exact same command succeeds and writes ciphertext.
+    // This pins the failure below to the ejection — Bunli prints the command Error to the real stderr
+    // (not captured by runCli), so exit code + file side effect are all we can observe at CLI level.
+    mock.module("../../key-ring/lkrp-sdk", () => ({
+      createLkrpSdk: () => ({
+        restoreTrustchain: async () => ({
+          rootId: "seed-root",
+          applicationPath: "m/0'/17'/0'", // matches the seed → no rotation warning
+          walletSyncEncryptionKey: "00".repeat(32),
+        }),
+      }),
+    }));
+    const ok = await runCli(encryptArgs, env);
+    expect(ok.exitCode, ok.stderr).toBe(0);
+    expect(existsSync(outFile)).toBe(true);
+
+    // Now the stream is ejected: the same command must fail and must NOT leave ciphertext behind.
+    rmSync(outFile, { force: true });
+    mock.module("../../key-ring/lkrp-sdk", () => ({
+      createLkrpSdk: () => ({
+        restoreTrustchain: async () => {
+          throw new TrustchainEjected("application stream is closed");
+        },
+      }),
+    }));
+    const r = await runCli(encryptArgs, env);
+    expect(r.exitCode).toBe(1);
+    expect(existsSync(outFile)).toBe(false); // aborted before writing ciphertext
+  });
+});
+
+describe("ring destroy — non-destructive deactivation keeps the ring but wipes locally", () => {
+  const { dir, env, cleanup } = makeTmpDir();
+  afterAll(() => {
+    mock.restore();
+    installKeychainMock();
+    cleanup();
+  });
+
+  it("reports the app was deactivated (kept for other apps), wipes locally, and unblocks re-init", async () => {
+    _store.clear();
+    await seedInitializedRing(dir);
+
+    // Non-destructive close: destroyApplication closes only the wallet-cli stream (the trustchain is
+    // kept for other applications), so trustchainDestroyed is false.
+    mock.module("../../key-ring/lkrp-sdk", () => ({
+      createLkrpSdk: () => ({
+        destroyApplication: async () => ({ trustchainDestroyed: false }),
+      }),
+    }));
+    const r = await runCliWithStdin(["ring", "destroy"], env, ["destroy"]);
+    expect(r.exitCode, r.stderr).toBe(0);
+    expect([..._store.values()]).toHaveLength(0); // local credentials still wiped
+    expect(r.stdout).toMatch(/kept for other apps/i);
+
+    // Reactivation is unblocked: destroy cleared the local trustchain pointer, so the ring is no
+    // longer "initialized" and `ring init` (which reopens a closed stream on the next index — covered
+    // at the lib level) would run instead of hitting the "already initialized" guard.
+    const keys = await runCli(["ring", "keys"], env);
+    expect(keys.exitCode).toBe(1); // not initialized → init guard is clear
   });
 });


### PR DESCRIPTION
### 📝 Description

Adapts the wallet-cli `ring destroy` command to the **non-destructive per-application close** introduced by #18568 (LKRP per-application close on Wallet Sync deactivation).

The `destroyApplication` base wiring was already on `develop`, but the wallet-cli did not handle the new closed-stream reality. After #18568, `restoreTrustchain` (and `getMembers`) reject an already-closed application stream with `TrustchainEjected`. `ring destroy` called `restoreTrustchain` first and mislabelled that rejection as a transient "Remote teardown failed" — so it aborted and **kept the local key**, leaving the user stuck: the remote is already gone (so retrying never succeeds), and a password-less ring has no interactive skip.

**Fix / approach:**
- `ring destroy` now calls `destroyApplication` **directly** — dropping the redundant `restoreTrustchain` round-trip, since `destroyApplication` resolves the trustchain itself, doesn't need the encryption key, and is idempotent on an already-closed stream (returns without throwing). It catches `TrustchainEjected` — which here means this member is no longer on the ring (removed by another owner, or the trustchain destroyed remotely) — and treats it as *remote already torn down* → proceeds to the local credential wipe. Genuine network/backend errors still abort and keep the key (transient-failure protection unchanged).
- Outcome reporting gained an optional `memberEjected` flag on `RingDestroyResult`, with a dedicated human-readable line and `member_ejected` in the JSON output.
- `ring encrypt` / `ring decrypt` (`loadDomainKey`) now rethrow a closed-stream `TrustchainEjected` as actionable guidance pointing at the `ring destroy` → `ring init` recovery path, instead of surfacing the raw protocol error.

**Reactivation:** confirmed it already works — `getOrCreateTrustchain` reopens a closed stream on the next index, so after `destroy` wipes local state a fresh `ring init` reactivates. No `init.ts` change was needed; locked with a test. (`getMembers` is not consumed anywhere in the wallet-cli, so no change there.)

**Decisions:** keep the single `ring destroy` command; still wipe local credentials on a non-destructive deactivation.

**Regression coverage** (`apps/wallet-cli/src/test/commands/ring.test.ts`): new tests for the ejected-destroy wipe, the encrypt/decrypt guidance (unit-level, as Bunli writes command errors to the real stderr), and the non-destructive/reactivation flow. The existing transient-failure test was updated to mock `destroyApplication` (no longer `restoreTrustchain`).

Verification: `bun test src/` → 764 pass / 0 fail; `pnpm typecheck` clean; `oxfmt --check` clean; lint 0 errors.

### 🔗 Context

- **JIRA / GitHub issue**: NTTVS-406 — follow-up to #18568
- **ADR** (if any): N/A
