### PR TITLE
[LWDM] fix(stellar): use token fields for add-asset trustline asset

### DIFF
--- a/.changeset/stellar-issuer-uppercase-fix.md
+++ b/.changeset/stellar-issuer-uppercase-fix.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Fix Stellar "Issuer is invalid" (and wrong lowercase asset code) when adding an asset. The add-asset screens parsed the case-sensitive Stellar code and issuer out of the CAL token id, which CAL lowercases; read them from the case-preserved token fields (name and contractAddress) instead. Also disable the desktop "Continue" button until an asset is selected.

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/fields/AssetSelector.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/fields/AssetSelector.tsx
@@ -36,14 +36,12 @@ const EllipsisMiddle = ({ children }: { children: string }) => {
   );
 };
 const renderItem = ({
-  data: { id, name },
+  data: { id, name, contractAddress: assetIssuer },
   isDisabled,
 }: {
   data: TokenCurrency;
   isDisabled: boolean;
 }) => {
-  const tokenId = id.split("/")[2];
-  const assetIssuer = tokenId.split(":")[1];
   return (
     <Box
       key={id}
@@ -75,14 +73,11 @@ const renderItem = ({
   );
 };
 
-export const getAssetObject = (assetId: string) => {
-  const assetString = assetId.split("/")[2];
-  const [assetCode, assetIssuer] = assetString.split(":");
-  return {
-    assetCode,
-    assetIssuer,
-  };
-};
+// The CAL id is lowercased; read the case-sensitive code/issuer from token fields (as getAssetFromToken does).
+export const getAssetObject = (token: TokenCurrency) => ({
+  assetCode: token.name,
+  assetIssuer: token.contractAddress,
+});
 
 export default function DelegationSelectorField({
   account,
@@ -107,8 +102,8 @@ export default function DelegationSelectorField({
 
   const value = useMemo(
     () =>
-      options.find(({ id }) => {
-        const { assetCode, assetIssuer } = getAssetObject(id);
+      options.find(option => {
+        const { assetCode, assetIssuer } = getAssetObject(option);
         return assetCode === transaction.assetReference && assetIssuer === transaction.assetOwner;
       }),
     [options, transaction.assetOwner, transaction.assetReference],

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/steps/StepAsset.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/steps/StepAsset.tsx
@@ -28,8 +28,7 @@ export default function StepAsset({
   const onUpdateAsset = useCallback(
     (token?: TokenCurrency | null) => {
       if (!token) return;
-      const { id: assetId } = token;
-      const { assetCode, assetIssuer } = getAssetObject(assetId);
+      const { assetCode, assetIssuer } = getAssetObject(token);
       onUpdateTransaction(transaction =>
         bridge.updateTransaction(transaction, {
           assetReference: assetCode,
@@ -63,11 +62,13 @@ export function StepAssetFooter({
   onClose,
   status,
   bridgePending,
+  transaction,
 }: StepProps) {
   invariant(account, "account required");
   const { errors } = status;
   const hasErrors = Object.keys(errors).length;
-  const canNext = !bridgePending && !hasErrors;
+  const hasSelectedAsset = !!transaction?.assetReference && !!transaction?.assetOwner;
+  const canNext = !bridgePending && !hasErrors && hasSelectedAsset;
   return (
     <>
       <AccountFooter parentAccount={parentAccount} account={account} status={status} />

--- a/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/01-SelectAsset.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/01-SelectAsset.tsx
@@ -37,8 +37,7 @@ const Row = ({
   disabled: boolean;
 }) => {
   const { colors } = useTheme();
-  const tokenId = item.id.split("/")[2];
-  const assetIssuer = tokenId.split(":")[1];
+  const assetIssuer = item.contractAddress;
   return (
     <TouchableOpacity style={[styles.row]} onPress={disabled ? onDisabledPress : onPress}>
       <FirstLetterIcon
@@ -106,13 +105,12 @@ export default function DelegationStarted({ navigation, route }: Props) {
     };
   });
   const onNext = useCallback(
-    (assetId: string) => {
+    (token: TokenCurrency) => {
       if (!transaction) return;
-      const tokenId = assetId.split("/")[2];
-      const [assetCode, assetIssuer] = tokenId.split(":");
+      // The CAL id is lowercased; read the case-sensitive code/issuer from token fields.
       const t = bridge.updateTransaction(transaction, {
-        assetReference: assetCode,
-        assetOwner: assetIssuer,
+        assetReference: token.name,
+        assetOwner: token.contractAddress,
       }) as StellarTransaction;
       navigation.navigate(ScreenName.StellarAddAssetSelectDevice, {
         ...route.params,
@@ -145,7 +143,7 @@ export default function DelegationStarted({ navigation, route }: Props) {
               (sub: TokenAccount) =>
                 sub.type === "TokenAccount" && sub.token && sub.token.id === item.id,
             )}
-            onPress={() => onNext(item.id)}
+            onPress={() => onNext(item)}
             // FIXME: why to we pass a string to a function that accepts boolean ?
             onDisabledPress={() => openModal(item.name)}
           />


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _The change touches the Stellar add-asset UI (desktop + mobile), which has no unit coverage. Validated end-to-end on-chain (correct `USDC` trustline crafted, confirmed on stellar.expert) and via typecheck._
- [x] **Impact of the changes:**
      - Stellar "Add asset" flow on **desktop** and **mobile**: adding an asset (e.g. USDC) must create a trustline with the correct, case-sensitive asset code and issuer.
      - Verify the created trustline uses uppercase `USDC` + uppercase issuer (`GA5Z…`), and that sending USDC afterwards works.
      - Desktop: the "Continue" button must stay disabled until an asset is actually selected.
      - Non-regression on the send flow from an existing Stellar token account.

### 📝 Description

Adding a Stellar asset failed with **"Issuer is invalid"**.

**Problem**: the add-asset screens parsed the case-sensitive Stellar asset code and issuer out of the CAL token `id`. CAL lowercases token ids by convention (`stellar/asset/usdc:ga5z…`), while a Stellar id embeds a case-sensitive `CODE:ISSUER`. The lowercased issuer made the Stellar SDK reject the trustline (`new Asset` → "Issuer is invalid"), and the lowercased code silently created a trustline to a *different* asset (`usdc` instead of `USDC`). Only the `id` is affected; `contract_address` and `token_identifier` from CAL are already correct.

**Solution**: stop parsing the opaque `id`. Read the code and issuer from the case-preserved token fields (`name`, `contractAddress`), mirroring `getAssetFromToken` (the send path) so add-asset and send resolve the same asset. Also disable the desktop "Continue" button until an asset is selected.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34229](https://ledgerhq.atlassian.net/browse/LIVE-34229)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34229]: https://ledgerhq.atlassian.net/browse/LIVE-34229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ