### PR TITLE
[Contacts] fix: share debug feature flag updates

### DIFF
--- a/.changeset/smooth-contacts-debug-flow.md
+++ b/.changeset/smooth-contacts-debug-flow.md
@@ -1,6 +1,7 @@
 ---
 "@features/flow-contacts": patch
 "ledger-live-desktop": patch
+"live-mobile": patch
 ---
 
-Move Contacts feature flag parameter normalization and updates into the shared flow package.
+Move Contacts feature flag parameter normalization and updates into the shared flow package for both debug tools.

--- a/.changeset/smooth-contacts-debug-flow.md
+++ b/.changeset/smooth-contacts-debug-flow.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": patch
+"ledger-live-desktop": patch
+---
+
+Move Contacts feature flag parameter normalization and updates into the shared flow package.

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/useContactsDevToolViewModel.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/useContactsDevToolViewModel.ts
@@ -1,71 +1,41 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useDispatch } from "LLD/hooks/redux";
 import { useFeature } from "@features/platform-feature-flags";
-import { setOverride, type Features } from "@shared/feature-flags";
-import { CONTACTS_FLAG, DEFAULT_ELIGIBLE_ADDRESS_FAMILIES } from "../constants";
-import { ContactsDevToolViewModel, ContactsFeatureParams } from "../types";
-
-type ContactsFeatureFlag = Features["lwdContacts"];
-
-const parseFamiliesInput = (value: string): string[] => {
-  const seen = new Set<string>();
-  const families: string[] = [];
-
-  for (const part of value.split(",")) {
-    const family = part.trim().toLowerCase();
-    if (family && !seen.has(family)) {
-      seen.add(family);
-      families.push(family);
-    }
-  }
-
-  return families;
-};
+import {
+  parseEligibleAddressFamiliesInput,
+  resolveContactsFeatureParams,
+  updateContactsFeatureValue,
+  type ContactsFeatureValuePatch,
+} from "@features/flow-contacts";
+import { setOverride } from "@shared/feature-flags";
+import { CONTACTS_FLAG } from "../constants";
+import { ContactsDevToolViewModel } from "../types";
 
 export const useContactsDevToolViewModel = (): ContactsDevToolViewModel => {
   const dispatch = useDispatch();
   const featureFlag = useFeature(CONTACTS_FLAG);
   const [customFamiliesInput, setCustomFamiliesInput] = useState("");
 
-  const isEnabled = featureFlag?.enabled ?? false;
-
-  const params = useMemo<ContactsFeatureParams>(() => {
-    const flagParams = featureFlag?.params;
-
-    return {
-      newBadge: flagParams?.newBadge ?? false,
-      eligibleAddressFamilies:
-        flagParams?.eligibleAddressFamilies ?? DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
-    };
-  }, [featureFlag?.params]);
+  const isEnabled = featureFlag?.enabled === true;
+  const params = useMemo(
+    () => resolveContactsFeatureParams(featureFlag?.params),
+    [featureFlag?.params],
+  );
+  const familiesInput = params.eligibleAddressFamilies.join(", ");
 
   useEffect(() => {
-    setCustomFamiliesInput(params.eligibleAddressFamilies.join(", "));
-  }, [params.eligibleAddressFamilies]);
+    setCustomFamiliesInput(familiesInput);
+  }, [familiesInput]);
 
   const setContactsOverride = useCallback(
-    (patch: { enabled?: boolean; params?: Partial<ContactsFeatureParams> }) => {
-      const currentFamilies: string[] = featureFlag?.params?.eligibleAddressFamilies ?? [
-        ...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
-      ];
-
-      const nextEligibleAddressFamilies: string[] =
-        patch.params?.eligibleAddressFamilies !== undefined
-          ? [...patch.params.eligibleAddressFamilies]
-          : currentFamilies;
-
-      const nextValue: ContactsFeatureFlag = {
-        ...(featureFlag ?? {}),
-        enabled: patch.enabled ?? isEnabled,
-        params: {
-          newBadge: patch.params?.newBadge ?? params.newBadge,
-          eligibleAddressFamilies: nextEligibleAddressFamilies,
-        },
-      };
-
-      dispatch(setOverride({ key: CONTACTS_FLAG, value: nextValue }));
-    },
-    [dispatch, featureFlag, isEnabled, params],
+    (patch: ContactsFeatureValuePatch) =>
+      dispatch(
+        setOverride({
+          key: CONTACTS_FLAG,
+          value: updateContactsFeatureValue(featureFlag, patch),
+        }),
+      ),
+    [dispatch, featureFlag],
   );
 
   const handleToggleEnabled = useCallback(() => {
@@ -84,7 +54,7 @@ export const useContactsDevToolViewModel = (): ContactsDevToolViewModel => {
   );
 
   const handleApplyCustomFamilies = useCallback(() => {
-    handleSetEligibleAddressFamilies(parseFamiliesInput(customFamiliesInput));
+    handleSetEligibleAddressFamilies(parseEligibleAddressFamiliesInput(customFamiliesInput));
   }, [customFamiliesInput, handleSetEligibleAddressFamilies]);
 
   const handleResetOverride = useCallback(() => {

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/types.ts
@@ -1,16 +1,11 @@
-import { Feature } from "@shared/feature-flags";
+import type { ContactsFeatureParams, ContactsFeatureValue } from "@features/flow-contacts";
 
 export interface ContactsDevToolContentProps {
   readonly expanded: boolean;
 }
 
-export interface ContactsFeatureParams {
-  readonly newBadge: boolean;
-  readonly eligibleAddressFamilies: readonly string[];
-}
-
 export interface ContactsDevToolViewModel {
-  readonly featureFlag: Feature | null;
+  readonly featureFlag: ContactsFeatureValue | null;
   readonly isEnabled: boolean;
   readonly params: ContactsFeatureParams;
   readonly customFamiliesInput: string;

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/useContactsDevToolViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/useContactsDevToolViewModel.ts
@@ -1,33 +1,29 @@
 import { useCallback, useMemo } from "react";
 import { useDispatch } from "react-redux";
 import { useFeature } from "@features/platform-feature-flags";
-import { DEFAULT_ELIGIBLE_ADDRESS_FAMILIES } from "@features/flow-contacts";
+import {
+  resolveContactsFeatureParams,
+  updateContactsFeatureValue,
+  type ContactsFeatureValuePatch,
+} from "@features/flow-contacts";
 import { setOverride } from "@shared/feature-flags";
 import { CONTACTS_FLAG } from "./constants";
 
 export function useContactsDevToolViewModel() {
   const dispatch = useDispatch();
   const featureFlag = useFeature(CONTACTS_FLAG);
-  const isEnabled = featureFlag?.enabled ?? false;
-  const newBadge = featureFlag?.params?.newBadge ?? false;
-
-  const eligibleAddressFamilies = useMemo(
-    () => featureFlag?.params?.eligibleAddressFamilies ?? [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES],
-    [featureFlag?.params?.eligibleAddressFamilies],
+  const isEnabled = featureFlag?.enabled === true;
+  const params = useMemo(
+    () => resolveContactsFeatureParams(featureFlag?.params),
+    [featureFlag?.params],
   );
 
-  const dispatchOverride = useCallback(
-    (value: {
-      enabled: boolean;
-      params: {
-        newBadge: boolean;
-        eligibleAddressFamilies: readonly string[];
-      };
-    }) => {
+  const setContactsOverride = useCallback(
+    (patch: ContactsFeatureValuePatch) => {
       dispatch(
         setOverride({
           key: CONTACTS_FLAG,
-          value: { ...featureFlag, ...value },
+          value: updateContactsFeatureValue(featureFlag, patch),
         }),
       );
     },
@@ -35,36 +31,18 @@ export function useContactsDevToolViewModel() {
   );
 
   const handleToggleEnabled = useCallback(() => {
-    dispatchOverride({
-      enabled: !isEnabled,
-      params: {
-        newBadge,
-        eligibleAddressFamilies,
-      },
-    });
-  }, [dispatchOverride, isEnabled, newBadge, eligibleAddressFamilies]);
+    setContactsOverride({ enabled: !isEnabled });
+  }, [isEnabled, setContactsOverride]);
 
   const handleToggleNewBadge = useCallback(() => {
-    dispatchOverride({
-      enabled: isEnabled,
-      params: {
-        newBadge: !newBadge,
-        eligibleAddressFamilies,
-      },
-    });
-  }, [dispatchOverride, isEnabled, newBadge, eligibleAddressFamilies]);
+    setContactsOverride({ params: { newBadge: !params.newBadge } });
+  }, [params.newBadge, setContactsOverride]);
 
   const handleSetEligibleAddressFamilies = useCallback(
     (families: readonly string[]) => {
-      dispatchOverride({
-        enabled: isEnabled,
-        params: {
-          newBadge,
-          eligibleAddressFamilies: [...families],
-        },
-      });
+      setContactsOverride({ params: { eligibleAddressFamilies: [...families] } });
     },
-    [dispatchOverride, isEnabled, newBadge],
+    [setContactsOverride],
   );
 
   const handleRestoreDefaults = useCallback(() => {
@@ -74,8 +52,8 @@ export function useContactsDevToolViewModel() {
   return {
     featureFlag,
     isEnabled,
-    newBadge,
-    eligibleAddressFamilies,
+    newBadge: params.newBadge,
+    eligibleAddressFamilies: params.eligibleAddressFamilies,
     handleToggleEnabled,
     handleToggleNewBadge,
     handleSetEligibleAddressFamilies,

--- a/features/flow/contacts/src/featureFlags.test.tsx
+++ b/features/flow/contacts/src/featureFlags.test.tsx
@@ -12,7 +12,10 @@ import {
 import {
   CONTACTS_FEATURE_FLAG_KEYS,
   DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
+  parseEligibleAddressFamiliesInput,
   resolveContactsFeatureConfig,
+  resolveContactsFeatureParams,
+  updateContactsFeatureValue,
   useContactsFeature,
   type ContactsFeatureConfig,
   type ContactsFeaturePlatform,
@@ -26,10 +29,7 @@ const DEFAULT_CONFIG: ContactsFeatureConfig = {
   eligibleAddressFamilies: DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
 };
 
-function makeContactsFeatureValue(
-  enabled: boolean,
-  newBadge: boolean,
-): ContactsFeatureValue {
+function makeContactsFeatureValue(enabled: boolean, newBadge: boolean): ContactsFeatureValue {
   return {
     enabled,
     params: {
@@ -81,6 +81,68 @@ describe("resolveContactsFeatureConfig", () => {
     });
   });
 
+  it("normalizes eligible address families from the feature value", () => {
+    expect(
+      resolveContactsFeatureConfig({
+        enabled: true,
+        params: { newBadge: false, eligibleAddressFamilies: [" EVM ", "bitcoin", "evm"] },
+      }),
+    ).toEqual({
+      isEnabled: true,
+      showNewBadge: false,
+      eligibleAddressFamilies: ["evm", "bitcoin"],
+    });
+  });
+});
+
+describe("resolveContactsFeatureParams", () => {
+  it("falls back to the default families when the configured value is invalid", () => {
+    expect(resolveContactsFeatureParams({ eligibleAddressFamilies: ["evm", 1] })).toEqual({
+      newBadge: false,
+      eligibleAddressFamilies: ["evm"],
+    });
+  });
+
+  it("falls back to the default families when the configured value is empty", () => {
+    expect(resolveContactsFeatureParams({ eligibleAddressFamilies: [] })).toEqual({
+      newBadge: false,
+      eligibleAddressFamilies: ["evm"],
+    });
+  });
+});
+
+describe("parseEligibleAddressFamiliesInput", () => {
+  it("normalizes a comma-separated input", () => {
+    expect(parseEligibleAddressFamiliesInput(" EVM, bitcoin, evm ")).toEqual(["evm", "bitcoin"]);
+  });
+
+  it("falls back to the default families for empty input", () => {
+    expect(parseEligibleAddressFamiliesInput(" , ")).toEqual(["evm"]);
+  });
+});
+
+describe("updateContactsFeatureValue", () => {
+  it("preserves unmodified Contacts params", () => {
+    expect(
+      updateContactsFeatureValue(makeContactsFeatureValue(true, false), {
+        params: { newBadge: true },
+      }),
+    ).toEqual({
+      enabled: true,
+      params: { newBadge: true, eligibleAddressFamilies: ["evm"] },
+    });
+  });
+
+  it("normalizes an updated eligible address families value", () => {
+    expect(
+      updateContactsFeatureValue(makeContactsFeatureValue(true, false), {
+        params: { eligibleAddressFamilies: ["EVM", "bitcoin", "evm"] },
+      }),
+    ).toEqual({
+      enabled: true,
+      params: { newBadge: false, eligibleAddressFamilies: ["evm", "bitcoin"] },
+    });
+  });
 });
 
 describe("useContactsFeature", () => {

--- a/features/flow/contacts/src/featureFlags.test.tsx
+++ b/features/flow/contacts/src/featureFlags.test.tsx
@@ -122,6 +122,24 @@ describe("parseEligibleAddressFamiliesInput", () => {
 });
 
 describe("updateContactsFeatureValue", () => {
+  it("preserves generic feature metadata", () => {
+    expect(
+      updateContactsFeatureValue(
+        {
+          ...makeContactsFeatureValue(true, false),
+          desktop_version: "1.0.0",
+          languages_whitelisted: ["fr"],
+        },
+        { params: { newBadge: true } },
+      ),
+    ).toEqual({
+      enabled: true,
+      desktop_version: "1.0.0",
+      languages_whitelisted: ["fr"],
+      params: { newBadge: true, eligibleAddressFamilies: ["evm"] },
+    });
+  });
+
   it("preserves unmodified Contacts params", () => {
     expect(
       updateContactsFeatureValue(makeContactsFeatureValue(true, false), {
@@ -141,6 +159,18 @@ describe("updateContactsFeatureValue", () => {
     ).toEqual({
       enabled: true,
       params: { newBadge: false, eligibleAddressFamilies: ["evm", "bitcoin"] },
+    });
+  });
+
+  it("does not copy malformed current params into the override", () => {
+    expect(
+      updateContactsFeatureValue(
+        { enabled: true, params: "invalid" } as unknown as ContactsFeatureValue,
+        { params: { newBadge: true } },
+      ),
+    ).toEqual({
+      enabled: true,
+      params: { newBadge: true, eligibleAddressFamilies: ["evm"] },
     });
   });
 });

--- a/features/flow/contacts/src/featureFlags.ts
+++ b/features/flow/contacts/src/featureFlags.ts
@@ -19,16 +19,58 @@ export type ContactsFeatureConfig = Readonly<{
 
 export type ContactsFeatureValue = Features["lwdContacts"] | Features["lwmContacts"];
 
+export type ContactsFeatureParams = Readonly<{
+  newBadge: boolean;
+  eligibleAddressFamilies: string[];
+}>;
+
+export type ContactsFeatureValuePatch = Readonly<{
+  enabled?: boolean;
+  params?: Partial<ContactsFeatureParams>;
+}>;
+
 export function resolveContactsFeatureConfig(
   feature: ContactsFeatureValue | null | undefined,
 ): ContactsFeatureConfig {
   const isEnabled = feature?.enabled === true;
+  const params = resolveContactsFeatureParams(feature?.params);
 
   return {
     isEnabled,
-    showNewBadge: isEnabled && feature?.params?.newBadge === true,
-    eligibleAddressFamilies:
-      feature?.params?.eligibleAddressFamilies ?? DEFAULT_ELIGIBLE_ADDRESS_FAMILIES,
+    showNewBadge: isEnabled && params.newBadge,
+    eligibleAddressFamilies: params.eligibleAddressFamilies,
+  };
+}
+
+export function resolveContactsFeatureParams(params: unknown): ContactsFeatureParams {
+  const input = toContactsFeatureParamsInput(params);
+
+  return {
+    newBadge: input?.newBadge === true,
+    eligibleAddressFamilies: normalizeEligibleAddressFamilies(input?.eligibleAddressFamilies),
+  };
+}
+
+export function parseEligibleAddressFamiliesInput(value: string): string[] {
+  return normalizeEligibleAddressFamilies(value.split(","));
+}
+
+export function updateContactsFeatureValue(
+  current: ContactsFeatureValue | null | undefined,
+  patch: ContactsFeatureValuePatch,
+): ContactsFeatureValue {
+  const params = resolveContactsFeatureParams(current?.params);
+  const patchParams = patch.params;
+
+  return {
+    enabled: patch.enabled ?? current?.enabled === true,
+    params: {
+      newBadge: patchParams?.newBadge ?? params.newBadge,
+      eligibleAddressFamilies:
+        patchParams?.eligibleAddressFamilies === undefined
+          ? params.eligibleAddressFamilies
+          : normalizeEligibleAddressFamilies(patchParams.eligibleAddressFamilies),
+    },
   };
 }
 
@@ -36,4 +78,31 @@ export function useContactsFeature(platform: ContactsFeaturePlatform): ContactsF
   const feature = useFeature(CONTACTS_FEATURE_FLAG_KEYS[platform]);
 
   return useMemo(() => resolveContactsFeatureConfig(feature), [feature]);
+}
+
+function normalizeEligibleAddressFamilies(value: unknown): string[] {
+  if (!Array.isArray(value) || !value.every(family => typeof family === "string")) {
+    return [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES];
+  }
+
+  const families = [...new Set(value.map(family => family.trim().toLowerCase()).filter(Boolean))];
+
+  return families.length > 0 ? families : [...DEFAULT_ELIGIBLE_ADDRESS_FAMILIES];
+}
+
+function toContactsFeatureParamsInput(
+  value: unknown,
+): Readonly<{ newBadge?: unknown; eligibleAddressFamilies?: unknown }> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  return {
+    newBadge: value.newBadge,
+    eligibleAddressFamilies: value.eligibleAddressFamilies,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/features/flow/contacts/src/featureFlags.ts
+++ b/features/flow/contacts/src/featureFlags.ts
@@ -59,12 +59,15 @@ export function updateContactsFeatureValue(
   current: ContactsFeatureValue | null | undefined,
   patch: ContactsFeatureValuePatch,
 ): ContactsFeatureValue {
-  const params = resolveContactsFeatureParams(current?.params);
+  const currentParams = isRecord(current?.params) ? current.params : undefined;
+  const params = resolveContactsFeatureParams(currentParams);
   const patchParams = patch.params;
 
   return {
+    ...current,
     enabled: patch.enabled ?? current?.enabled === true,
     params: {
+      ...currentParams,
       newBadge: patchParams?.newBadge ?? params.newBadge,
       eligibleAddressFamilies:
         patchParams?.eligibleAddressFamilies === undefined


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Shared flow helper tests and the targeted Desktop view-model test pass. The targeted Mobile test is blocked locally by a missing `live-common` artifact in this isolated worktree; CI will run it in a complete environment.
- [x] **Impact of the changes:**
      Contacts feature-flag parameter resolution and local debug overrides on Desktop and Mobile.

### 📝 Description

This PR centralizes Contacts feature-flag parameter resolution and partial override construction in `@features/flow-contacts`.

Both Contacts debug tools now consume the shared resolver and updater. The Mobile debugger no longer owns local defaults or merges the feature-flag value itself. Screen-specific presets and UI state remain in each application.

The shared updater preserves generic feature metadata and unchanged Contacts parameters. It also ignores malformed current parameters instead of copying them into a local override.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34109](https://ledgerhq.atlassian.net/browse/LIVE-34109)
- **Related Mobile ticket**: [LIVE-34108](https://ledgerhq.atlassian.net/browse/LIVE-34108)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked Jira issues.
- **The PR description clearly documents the changes** made and explains the DDD ownership decision.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The modified flow behavior is covered by focused tests**; CI should validate the Mobile test in its complete environment.
- **No new dependencies** were added.
- **Performance** impact is negligible: the debug tools keep only their existing UI state and dispatch pattern.

[LIVE-34109]: https://ledgerhq.atlassian.net/browse/LIVE-34109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ