### PR TITLE
[LWM] fix(mobile): prevent duplicate contentcard_clicked events

### DIFF
--- a/.changeset/quiet-clicks-guard.md
+++ b/.changeset/quiet-clicks-guard.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix duplicate `contentcard_clicked` events by deduping in-flight click tracking and isolating top-wallet banner dismiss from CTA presses

--- a/apps/ledger-live-mobile/src/components/Carousel/useCarouselCardModel.test.ts
+++ b/apps/ledger-live-mobile/src/components/Carousel/useCarouselCardModel.test.ts
@@ -40,6 +40,7 @@ describe("useCarouselCardModel", () => {
 
     expect(trackContentCardEvent).toHaveBeenCalledWith(ContentCardEvent.Clicked, {
       location: ContentCardLocation.Wallet,
+      page: ContentCardLocation.Wallet,
       order: 1,
       screen: ContentCardLocation.Wallet,
       campaign: "wallet-card-1",
@@ -47,6 +48,7 @@ describe("useCarouselCardModel", () => {
     });
     expect(trackContentCardEvent).toHaveBeenCalledWith(ContentCardEvent.Dismissed, {
       location: ContentCardLocation.Wallet,
+      page: ContentCardLocation.Wallet,
       order: 1,
       screen: ContentCardLocation.Wallet,
       campaign: "wallet-card-1",

--- a/apps/ledger-live-mobile/src/components/Carousel/useCarouselCardModel.ts
+++ b/apps/ledger-live-mobile/src/components/Carousel/useCarouselCardModel.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from "react";
 import { Linking } from "react-native";
 
 import {
-  sanitizeExtras,
+  buildContentCardTrackingProperties,
   ContentCardEvent,
   type ContentCardEventProperties,
   type ContentCardInteractionEvent,
@@ -36,7 +36,10 @@ export function useCarouselCardModel({
 }: Args) {
   const trackingBase = useMemo(
     () => ({
-      ...sanitizeExtras(cardProps.extras),
+      ...buildContentCardTrackingProperties({
+        cardExtras: cardProps.extras,
+        categoryLocation: cardProps.location,
+      }),
       screen: cardProps.location,
       campaign: cardProps.id,
     }),

--- a/apps/ledger-live-mobile/src/contentCards/cards/contentBannerAction/index.test.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/cards/contentBannerAction/index.test.tsx
@@ -46,11 +46,12 @@ describe("ContentBannerActionCard", () => {
     expect(screen.getByText("Promo title")).toBeVisible();
     expect(screen.getByText("Promo body")).toBeVisible();
 
-    await user.press(screen.getByText("Promo title"));
-    expect(actions.onClick).toHaveBeenCalledTimes(1);
-
     await user.press(screen.getByTestId("content-banner-close-button"));
     expect(actions.onDismiss).toHaveBeenCalledTimes(1);
+    expect(actions.onClick).not.toHaveBeenCalled();
+
+    await user.press(screen.getByText("Promo title"));
+    expect(actions.onClick).toHaveBeenCalledTimes(1);
   });
 
   it("when Braze sends `image_background`: MediaBanner, close must not fire CTA", async () => {

--- a/apps/ledger-live-mobile/src/contentCards/cards/contentBannerAction/index.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/cards/contentBannerAction/index.tsx
@@ -1,19 +1,23 @@
 import React, { useCallback, useEffect } from "react";
-import { GestureResponderEvent } from "react-native";
 import {
+  Box,
   ContentBanner,
   ContentBannerContent,
   ContentBannerDescription,
   ContentBannerTitle,
+  InteractiveIcon,
   MediaBanner,
   MediaBannerDescription,
   MediaBannerTitle,
   Pressable,
   Spot,
 } from "@ledgerhq/lumen-ui-rnative";
+import { Close } from "@ledgerhq/lumen-ui-rnative/symbols";
 import * as Icons from "@ledgerhq/lumen-ui-rnative/symbols";
 import { ContentCardBuilder } from "~/contentCards/cards/utils";
 import type { ContentCardProps } from "~/contentCards/cards/types";
+
+const CONTENT_BANNER_CLOSE_LABEL = "Close content banner";
 
 const ContentBannerActionCard = ContentCardBuilder<ContentCardProps>(props => {
   const { title, metadata } = props;
@@ -29,23 +33,16 @@ const ContentBannerActionCard = ContentCardBuilder<ContentCardProps>(props => {
 
   useEffect(() => metadata.actions?.onView?.());
 
-  const handleDismiss = useCallback(
-    (event?: GestureResponderEvent) => {
-      if (event) {
-        event.preventDefault();
-        event.stopPropagation();
-      }
-      metadata.actions?.onDismiss?.();
-    },
-    [metadata.actions],
-  );
+  const handleDismiss = useCallback(() => {
+    metadata.actions?.onDismiss?.();
+  }, [metadata.actions]);
 
   if (imageBackground && imageBackground.length > 0) {
     return (
       <MediaBanner
         key={metadata.id}
         imageUrl={imageBackground}
-        onClose={handleDismiss}
+        onClose={metadata.actions?.onDismiss ? handleDismiss : undefined}
         onPress={metadata.actions?.onClick}
       >
         {title ? <MediaBannerTitle>{title}</MediaBannerTitle> : null}
@@ -55,15 +52,31 @@ const ContentBannerActionCard = ContentCardBuilder<ContentCardProps>(props => {
   }
 
   return (
-    <Pressable onPress={metadata.actions?.onClick} key={metadata.id}>
-      <ContentBanner onClose={handleDismiss}>
-        <Spot appearance="icon" icon={icon} size={48} />
-        <ContentBannerContent>
-          <ContentBannerTitle>{title ?? ""}</ContentBannerTitle>
-          {description ? <ContentBannerDescription>{description}</ContentBannerDescription> : null}
-        </ContentBannerContent>
-      </ContentBanner>
-    </Pressable>
+    <Box key={metadata.id} lx={{ position: "relative", width: "full" }}>
+      <Pressable onPress={metadata.actions?.onClick}>
+        <ContentBanner>
+          <Spot appearance="icon" icon={icon} size={48} />
+          <ContentBannerContent>
+            <ContentBannerTitle>{title ?? ""}</ContentBannerTitle>
+            {description ? (
+              <ContentBannerDescription>{description}</ContentBannerDescription>
+            ) : null}
+          </ContentBannerContent>
+        </ContentBanner>
+      </Pressable>
+      {metadata.actions?.onDismiss ? (
+        <Box lx={{ position: "absolute", top: "s8", right: "s8", zIndex: 1 }}>
+          <InteractiveIcon
+            testID="content-banner-close-button"
+            iconType="stroked"
+            icon={Close}
+            size={16}
+            onPress={handleDismiss}
+            accessibilityLabel={CONTENT_BANNER_CLOSE_LABEL}
+          />
+        </Box>
+      ) : null}
+    </Box>
   );
 });
 

--- a/apps/ledger-live-mobile/src/dynamicContent/useDynamicContent.test.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/useDynamicContent.test.ts
@@ -160,6 +160,36 @@ describe("useDynamicContent", () => {
     });
   });
 
+  it("should ignore duplicate clicked events while the first is in flight", async () => {
+    let resolveTrack: (() => void) | undefined;
+    mockedTrack.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveTrack = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useDynamicContent());
+
+    let firstClick: Promise<void> | undefined;
+    let secondClick: Promise<void> | undefined;
+    act(() => {
+      firstClick = result.current.trackContentCardEvent(ContentCardEvent.Clicked, {
+        campaign: "card-1",
+      });
+      secondClick = result.current.trackContentCardEvent(ContentCardEvent.Clicked, {
+        campaign: "card-1",
+      });
+    });
+
+    expect(mockedTrack).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveTrack?.();
+      await Promise.all([firstClick, secondClick]);
+    });
+  });
+
   it("should swallow analytics errors", async () => {
     mockedTrack.mockRejectedValueOnce(new Error("track failed"));
 

--- a/apps/ledger-live-mobile/src/dynamicContent/useDynamicContent.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/useDynamicContent.tsx
@@ -1,6 +1,6 @@
 import { useSelector, useDispatch } from "~/context/hooks";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useBrazeContentCard } from "./brazeContentCard";
 import {
   assetsCardsSelector,
@@ -102,8 +102,23 @@ const useDynamicContent = () => {
     ],
   );
 
+  const clickedCampaignsInFlightRef = useRef(new Set<string>());
+
   const trackContentCardEvent = useCallback(
     async (event: ContentCardInteractionEvent, params: ContentCardEventProperties) => {
+      const campaign = params.campaign;
+      if (
+        event === ContentCardEvent.Clicked &&
+        typeof campaign === "string" &&
+        clickedCampaignsInFlightRef.current.has(campaign)
+      ) {
+        return;
+      }
+
+      if (event === ContentCardEvent.Clicked && typeof campaign === "string") {
+        clickedCampaignsInFlightRef.current.add(campaign);
+      }
+
       try {
         await track(event, finalizeContentCardEventProperties(params));
         if (event === ContentCardEvent.Clicked) {
@@ -113,6 +128,10 @@ const useDynamicContent = () => {
         }
       } catch {
         // Analytics must never block the user action that follows.
+      } finally {
+        if (event === ContentCardEvent.Clicked && typeof campaign === "string") {
+          clickedCampaignsInFlightRef.current.delete(campaign);
+        }
       }
     },
     [],


### PR DESCRIPTION
## Description
LWM was sending duplicate `contentcard_clicked` Segment events on top-wallet action banners.
Dismissing an icon `ContentBanner` could also fire the CTA handler because the close control lived inside the same `Pressable`. Rapid or re-entrant taps could also track the same campaign twice while analytics was still in flight.
This PR:
- Moves the icon banner dismiss button outside the CTA `Pressable` (desktop pattern)
- Dedupes in-flight `contentcard_clicked` events per campaign in `trackContentCardEvent`
- Uses `buildContentCardTrackingProperties` in the wallet carousel for consistent `location`/`page`
Covered by unit tests for `ContentBannerActionCard`, `useDynamicContent`, and `useCarouselCardModel`.
## Context
- **JIRA Ticket**: [LIVE-33757](https://ledgerhq.atlassian.net/browse/LIVE-33757)

[LIVE-33757]: https://ledgerhq.atlassian.net/browse/LIVE-33757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ