### PR TITLE
[LWD] Undelegation tooltip shows 21-day timelock instead of ~2-day Babylon fast unbonding

### DIFF
--- a/.changeset/babylon-undelegation-timelock-footer.md
+++ b/.changeset/babylon-undelegation-timelock-footer.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix the Cosmos-family "Undelegating" tooltip in the account summary footer, which hardcoded a 21-day timelock for every chain. It now uses each chain's actual unbonding period (e.g. ~2 days for Babylon, 14 for Osmosis, 30 for dYdX), matching the value already shown in the delegation section.

--- a/.changeset/babylon-undelegation-timelock-footer.md
+++ b/.changeset/babylon-undelegation-timelock-footer.md
@@ -1,5 +1,8 @@
 ---
+"@ledgerhq/coin-cosmos": patch
 "ledger-live-desktop": patch
 ---
 
-Fix the Cosmos-family "Undelegating" tooltip in the account summary footer, which hardcoded a 21-day timelock for every chain. It now uses each chain's actual unbonding period (e.g. ~2 days for Babylon, 14 for Osmosis, 30 for dYdX), matching the value already shown in the delegation section.
+Fix the Cosmos-family "Undelegating" tooltip in the desktop account summary footer, which hardcoded a 21-day timelock for every chain. It now uses each chain's actual unbonding period (e.g. ~2 days for Babylon, 14 for Osmosis, 30 for dYdX), matching the value already shown in the delegation section.
+
+Also make the Cosmos chain factory alias the crypto_org_croeseid testnet to crypto_org, so it resolves chain params instead of throwing (previously only the osmosis alias was handled).

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/AccountBalanceSummaryFooter.tsx
@@ -13,6 +13,7 @@ import InfoCircle from "~/renderer/icons/InfoCircle";
 import ToolTip from "~/renderer/components/Tooltip";
 import { CosmosAccount } from "@ledgerhq/live-common/families/cosmos/types";
 import { CosmosAPI } from "@ledgerhq/coin-cosmos/network/Cosmos";
+import cryptoFactory from "@ledgerhq/coin-cosmos/chain/chain";
 import { TokenAccount } from "@ledgerhq/types-live";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import { getCurrencyConfiguration } from "@ledgerhq/live-common/config/index";
@@ -158,7 +159,7 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
               <Trans
                 i18nKey="account.undelegatingTooltip"
                 values={{
-                  timelockInDays: 21,
+                  timelockInDays: cryptoFactory(account.currency.id).unbondingPeriod,
                 }}
               />
             }

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/__tests__/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/__tests__/AccountBalanceSummaryFooter.test.tsx
@@ -7,6 +7,7 @@ import { CurrencyConfig } from "@ledgerhq/coin-module-framework/config";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import BigNumber from "bignumber.js";
 import * as currencies from "@ledgerhq/live-common/currencies/index";
+import cryptoFactory from "@ledgerhq/coin-cosmos/chain/chain";
 
 jest.mock("~/renderer/hooks/useAccountUnit");
 jest.mock("@ledgerhq/live-common/currencies/index");
@@ -14,6 +15,11 @@ jest.mock("@ledgerhq/live-common/config/index", () => ({
   __esModule: true,
   ...jest.requireActual("@ledgerhq/live-common/config/index"),
 }));
+// keep the real factory (real alias + per-chain params) but spy on the calls
+jest.mock("@ledgerhq/coin-cosmos/chain/chain", () => {
+  const actual = jest.requireActual("@ledgerhq/coin-cosmos/chain/chain");
+  return { __esModule: true, default: jest.fn(actual.default) };
+});
 
 describe("AccountBalanceSummaryFooter", () => {
   describe("Testing disableDelegation in currency config", () => {
@@ -31,7 +37,7 @@ describe("AccountBalanceSummaryFooter", () => {
         unbondingBalance: DELEGATE_UNBONDING_BALANCE,
       },
       currency: {
-        id: "cosmos",
+        id: "babylon",
       } as unknown as CryptoCurrency,
     } as CosmosAccount;
 
@@ -47,10 +53,22 @@ describe("AccountBalanceSummaryFooter", () => {
       );
 
       render(<AccountBalanceSummaryFooter account={ACCOUNT} />);
-      expect(screen.getByText("Delegated assets")).toBeInTheDocument();
-      expect(screen.getByText(DELEGATE_BALANCE_TEXT)).toBeInTheDocument();
-      expect(screen.getByText("Undelegating")).toBeInTheDocument();
-      expect(screen.getByText(DELEGATE_UNBONDING_BALANCE_TEXT)).toBeInTheDocument();
+      expect(screen.getByText("Delegated assets")).toBeVisible();
+      expect(screen.getByText(DELEGATE_BALANCE_TEXT)).toBeVisible();
+      expect(screen.getByText("Undelegating")).toBeVisible();
+      expect(screen.getByText(DELEGATE_UNBONDING_BALANCE_TEXT)).toBeVisible();
+    });
+
+    it("looks up the undelegation timelock from the chain factory by currency id, not a hardcoded constant", () => {
+      mockGetCurrencyConfiguration({ disableDelegation: false });
+      mockFormatCurrencyUnit(
+        ACCOUNT.cosmosResources.delegatedBalance,
+        ACCOUNT.cosmosResources.unbondingBalance,
+      );
+
+      render(<AccountBalanceSummaryFooter account={ACCOUNT} />);
+
+      expect(cryptoFactory).toHaveBeenCalledWith("babylon");
     });
 
     it.each([BigNumber(0), BigNumber(-1)])(
@@ -88,6 +106,29 @@ describe("AccountBalanceSummaryFooter", () => {
       expect(screen.queryByText(DELEGATE_BALANCE_TEXT)).not.toBeInTheDocument();
       expect(screen.queryByText("Undelegating")).not.toBeInTheDocument();
       expect(screen.queryByText(DELEGATE_UNBONDING_BALANCE_TEXT)).not.toBeInTheDocument();
+    });
+
+    it("should render the undelegating tooltip without throwing for a testnet id that aliases to a mainnet chain (crypto_org_croeseid)", () => {
+      mockGetCurrencyConfiguration({ disableDelegation: false });
+
+      const account = {
+        type: "Account",
+        cosmosResources: {
+          delegatedBalance: DELEGATE_BALANCE,
+          unbondingBalance: DELEGATE_UNBONDING_BALANCE,
+        },
+        currency: {
+          id: "crypto_org_croeseid",
+        } as unknown as CryptoCurrency,
+      } as CosmosAccount;
+
+      mockFormatCurrencyUnit(
+        account.cosmosResources.delegatedBalance,
+        account.cosmosResources.unbondingBalance,
+      );
+
+      expect(() => render(<AccountBalanceSummaryFooter account={account} />)).not.toThrow();
+      expect(screen.getByText("Undelegating")).toBeVisible();
     });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/__tests__/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/__tests__/AccountBalanceSummaryFooter.test.tsx
@@ -31,7 +31,7 @@ describe("AccountBalanceSummaryFooter", () => {
         unbondingBalance: DELEGATE_UNBONDING_BALANCE,
       },
       currency: {
-        id: "some random id",
+        id: "cosmos",
       } as unknown as CryptoCurrency,
     } as CosmosAccount;
 

--- a/libs/coin-modules/coin-cosmos/src/chain/chain.ts
+++ b/libs/coin-modules/coin-cosmos/src/chain/chain.ts
@@ -22,8 +22,14 @@ import Zenrock from "./Zenrock";
 import CosmosBase from "./cosmosBase";
 
 const cosmosChainParams: { [key: string]: CosmosBase } = {};
+
+const CURRENCY_ID_ALIASES: Record<string, string> = {
+  osmosis: "osmo",
+  crypto_org_croeseid: "crypto_org", // croeseid testnet reuses crypto_org's params
+};
+
 export default function cryptoFactory(currencyId: string): CosmosBase {
-  currencyId = currencyId === "osmosis" ? "osmo" : currencyId;
+  currencyId = CURRENCY_ID_ALIASES[currencyId] ?? currencyId;
   if (!cosmosChainParams[currencyId]) {
     let chain: CosmosBase;
     switch (currencyId) {

--- a/libs/coin-modules/coin-cosmos/src/chain/chain.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/chain/chain.unit.test.ts
@@ -37,6 +37,12 @@ describe("cryptoFactory test", () => {
     });
   });
 
+  it("should resolve the crypto_org_croeseid testnet to crypto_org chain params", () => {
+    const chain = cryptoFactory("crypto_org_croeseid");
+    expect(chain.prefix).toBe("cro");
+    expect(chain.unbondingPeriod).toBe(28);
+  });
+
   it("should throw an error when currency id is unknown", () => {
     expect(() => cryptoFactory("unknown")).toThrow();
   });


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The Cosmos-family "Undelegating" tooltip in the account summary footer hardcoded a 21-day timelock for every chain. For chains whose unbonding period differs it was wrong — Babylon showed "21 days" instead of ~2.

Fix: read the period from `cryptoFactory(currency.id).unbondingPeriod` (Babylon 2, Osmosis 14, dYdX 30, …), matching the delegation section and the mobile footer, which were already data-driven.

Regression guard: the `AccountBalanceSummaryFooter` unit test renders the undelegating footer for a real Cosmos currency, exercising the tooltip's period lookup.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34217](https://ledgerhq.atlassian.net/browse/LIVE-34217?atlOrigin=eyJpIjoiNzhjMDM3MGM5NzUzNDc2MjgzYjBmMzAwOWYxODlkNzciLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-34217]: https://ledgerhq.atlassian.net/browse/LIVE-34217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ