### PR TITLE
[LWDM] tezos: last changes to getblock

### DIFF
--- a/.changeset/good-dragons-invent.md
+++ b/.changeset/good-dragons-invent.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": minor
+---
+
+Tezos getBlock: align OtherBlockOperation fields with listOperations path

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.integ.test.ts
@@ -81,10 +81,10 @@ describe("getBlock", () => {
         {
           type: "other",
           address: "tz29GPjgeRQTRX6mcPQXkiuHnq7jbya1Abnq",
-          asset: { type: "native", name: "XTZ" },
-          amount: 0n,
           ledgerOpType: "REVEAL",
-          details: { counter: 14472417, gasLimit: 581, storageLimit: 0 },
+          counter: 14472417,
+          gasLimit: 581,
+          storageLimit: 0,
         },
       ]),
     );
@@ -119,8 +119,8 @@ describe("getBlock — Shadownet Paris staking ops", () => {
   });
 
   it.each([
-    [STAKE_BLOCK, "STAKE", 500_000_000n],
-    [UNSTAKE_BLOCK, "UNSTAKE", 250_000_000n],
+    [STAKE_BLOCK, "STAKE", 500_000_000],
+    [UNSTAKE_BLOCK, "UNSTAKE", 250_000_000],
   ])(
     "block %s contains a staking op with ledgerOpType=%s and stakedAmount=%s",
     async (height, expectedOpType, expectedAmount) => {

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
@@ -882,12 +882,12 @@ describe("delegation operations", () => {
     expect(tx.operations).toHaveLength(1);
     expect(tx.operations[0]).toEqual({
       type: "other",
-      address: "tz1Delegator",
-      asset: { type: "native", name: "XTZ" },
-      amount: 0n,
       ledgerOpType: "DELEGATE",
-      stakedAmount: 0n,
-      details: { counter: 42, gasLimit: 1000, storageLimit: 257 },
+      operationType: "DELEGATE",
+      stakedAmount: 0,
+      counter: 42,
+      gasLimit: 1000,
+      storageLimit: 257,
     });
   });
 
@@ -914,12 +914,12 @@ describe("delegation operations", () => {
     expect(tx.operations).toHaveLength(1);
     expect(tx.operations[0]).toEqual({
       type: "other",
-      address: "tz1Delegator",
-      asset: { type: "native", name: "XTZ" },
-      amount: 0n,
       ledgerOpType: "UNDELEGATE",
-      stakedAmount: 0n,
-      details: { counter: 7, gasLimit: 500, storageLimit: 100 },
+      operationType: "UNDELEGATE",
+      stakedAmount: 0,
+      counter: 7,
+      gasLimit: 500,
+      storageLimit: 100,
     });
   });
 
@@ -945,9 +945,9 @@ describe("delegation operations", () => {
     // When
     const result = await getBlock(5_000_000);
 
-    // Then
+    // Then — failed but operations still present (listOperations path always includes them)
     expect(result.transactions[0].failed).toBe(true);
-    expect(result.transactions[0].operations).toEqual([]);
+    expect(result.transactions[0].operations).toHaveLength(1);
   });
 
   it("skips delegations without a hash", async () => {
@@ -1098,9 +1098,9 @@ describe("delegation operations", () => {
 
 describe("staking operations", () => {
   it.each([
-    ["stake", "STAKE", 500_000_000n],
-    ["unstake", "UNSTAKE", 250_000_000n],
-    ["finalize", "FINALIZE_UNSTAKE", 0n],
+    ["stake", "STAKE", 500_000_000],
+    ["unstake", "UNSTAKE", 250_000_000],
+    ["finalize", "FINALIZE_UNSTAKE", 0],
   ] as const)(
     "creates a BlockTransaction for action=%s with ledgerOpType=%s",
     async (action, expectedOpType, expectedStakedAmount) => {
@@ -1120,24 +1120,24 @@ describe("staking operations", () => {
       expect(tx.operations).toHaveLength(1);
       expect(tx.operations[0]).toEqual({
         type: "other",
-        address: "tz1Staker",
-        asset: { type: "native", name: "XTZ" },
-        amount: 0n,
         ledgerOpType: expectedOpType,
+        operationType: expectedOpType,
         stakedAmount: expectedStakedAmount,
-        details: { counter: 1, gasLimit: 3630, storageLimit: 0 },
+        counter: 1,
+        gasLimit: 3630,
+        storageLimit: 0,
       });
     },
   );
 
-  it("marks a staking op as failed and clears operations when status is not 'applied'", async () => {
+  it("marks a staking op as failed but still includes operations", async () => {
     mockGetBlockByLevel.mockResolvedValue(makeBlock());
     mockFetchBlockStaking.mockResolvedValue([makeStaking({ status: "failed" })]);
 
     const result = await getBlock(5_000_000);
 
     expect(result.transactions[0].failed).toBe(true);
-    expect(result.transactions[0].operations).toEqual([]);
+    expect(result.transactions[0].operations).toHaveLength(1);
   });
 
   it("skips a staking op without sender (no operations emitted)", async () => {
@@ -1216,14 +1216,15 @@ describe("origination operations", () => {
     expect(tx.operations[0]).toMatchObject({
       type: "other",
       address: "tz1Deployer",
-      amount: 0n,
       ledgerOpType: "ORIGINATION",
-      details: { counter: 42, gasLimit: 3494, storageLimit: 5852 },
+      counter: 42,
+      gasLimit: 3494,
+      storageLimit: 5852,
     });
     expect(tx.operations[0]).not.toHaveProperty("originatedContract");
   });
 
-  it("produces negative amount for an origination with contractBalance > 0", async () => {
+  it("produces an origination with contractBalance > 0 (no amount field)", async () => {
     mockGetBlockByLevel.mockResolvedValue(makeBlock());
     mockFetchBlockOriginations.mockResolvedValue([makeOrigination({ contractBalance: 500_000 })]);
 
@@ -1234,21 +1235,21 @@ describe("origination operations", () => {
     expect(tx.operations).toHaveLength(1);
     const op = tx.operations[0] as OtherBlockOperation;
     expect(op.type).toBe("other");
-    expect(op.amount).toBe(-500_000n);
     expect(op.address).toBe("tz1Deployer");
     expect((op as Record<string, unknown>).ledgerOpType).toBe("ORIGINATION");
+    expect(op).not.toHaveProperty("amount");
   });
 
-  it("treats negative contractBalance as zero (defensive guard)", async () => {
+  it("treats negative contractBalance same as zero (no amount field)", async () => {
     mockGetBlockByLevel.mockResolvedValue(makeBlock());
     mockFetchBlockOriginations.mockResolvedValue([makeOrigination({ contractBalance: -500 })]);
 
     const result = await getBlock(5_000_000);
 
-    expect(result.transactions[0].operations[0]).toMatchObject({ amount: 0n });
+    expect(result.transactions[0].operations[0]).not.toHaveProperty("amount");
   });
 
-  it("marks a failed origination and emits no operations", async () => {
+  it("marks a failed origination but still includes operations", async () => {
     mockGetBlockByLevel.mockResolvedValue(makeBlock());
     mockFetchBlockOriginations.mockResolvedValue([
       makeOrigination({ status: "failed", contractBalance: 500_000 }),
@@ -1259,7 +1260,7 @@ describe("origination operations", () => {
     expect(result.transactions).toHaveLength(1);
     const tx = result.transactions[0];
     expect(tx.failed).toBe(true);
-    expect(tx.operations).toEqual([]);
+    expect(tx.operations).toHaveLength(1);
     expect(tx.fees).toBe(1_069_250n);
   });
 
@@ -1349,10 +1350,10 @@ describe("reveal operations", () => {
     expect(tx.operations[0]).toEqual({
       type: "other",
       address: "tz1Revealer",
-      asset: { type: "native", name: "XTZ" },
-      amount: 0n,
       ledgerOpType: "REVEAL",
-      details: { counter: 10, gasLimit: 10600, storageLimit: 0 },
+      counter: 10,
+      gasLimit: 10600,
+      storageLimit: 0,
     });
   });
 
@@ -1375,14 +1376,14 @@ describe("reveal operations", () => {
     expect(revealOp).toMatchObject({ ledgerOpType: "REVEAL" });
   });
 
-  it("marks a reveal as failed when status is not 'applied'", async () => {
+  it("marks a reveal as failed but still includes operations", async () => {
     mockGetBlockByLevel.mockResolvedValue(makeBlock());
     mockFetchBlockReveals.mockResolvedValue([makeReveal({ status: "failed" })]);
 
     const result = await getBlock(5_000_000);
 
     expect(result.transactions[0].failed).toBe(true);
-    expect(result.transactions[0].operations).toEqual([]);
+    expect(result.transactions[0].operations).toHaveLength(1);
   });
 
   it("skips reveals without a hash", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
@@ -1130,14 +1130,19 @@ describe("staking operations", () => {
     },
   );
 
-  it("marks a staking op as failed but still includes operations", async () => {
+  it("marks a staking op as failed but still includes operations with requestedAmount fallback", async () => {
+    // TzKT omits `amount` on failed ops; only `requestedAmount` is present
     mockGetBlockByLevel.mockResolvedValue(makeBlock());
-    mockFetchBlockStaking.mockResolvedValue([makeStaking({ status: "failed" })]);
+    mockFetchBlockStaking.mockResolvedValue([
+      makeStaking({ status: "failed", amount: undefined as unknown as number, requestedAmount: 750_000_000 }),
+    ]);
 
     const result = await getBlock(5_000_000);
 
     expect(result.transactions[0].failed).toBe(true);
     expect(result.transactions[0].operations).toHaveLength(1);
+    const op = result.transactions[0].operations[0] as Record<string, unknown>;
+    expect(op.stakedAmount).toBe(750_000_000);
   });
 
   it("skips a staking op without sender (no operations emitted)", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.test.ts
@@ -1134,7 +1134,7 @@ describe("staking operations", () => {
     // TzKT omits `amount` on failed ops; only `requestedAmount` is present
     mockGetBlockByLevel.mockResolvedValue(makeBlock());
     mockFetchBlockStaking.mockResolvedValue([
-      makeStaking({ status: "failed", amount: undefined as unknown as number, requestedAmount: 750_000_000 }),
+      makeStaking({ status: "failed", amount: undefined, requestedAmount: 750_000_000 }),
     ]);
 
     const result = await getBlock(5_000_000);

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
@@ -166,8 +166,9 @@ function buildBlockTransactionFromDelegation(op: APIDelegationType): BlockTransa
     failed: !succeeded,
     fees: computeDelegationFees(op),
     ...(feesPayer && { feesPayer }),
-    // Always include operations even for failed txs — listOperations path
-    // always converts them, so getBlock must match for E2E reindex consistency.
+    // Include operations even for failed standalone txs — listOperations path
+    // always converts them. Note: mergeAuxiliaryTx still clears ops when a
+    // failed auxiliary tx is merged into an existing BlockTransaction.
     operations: buildDelegationOperations(op),
   };
 }

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
@@ -143,19 +143,16 @@ function buildDelegationOperations(op: APIDelegationType): BlockOperation[] {
 
   const isDelegate = !!op.newDelegate?.address;
 
+  const opType = isDelegate ? "DELEGATE" : "UNDELEGATE";
   return [
     {
       type: "other",
-      address: senderAddr,
-      asset: NATIVE_ASSET,
-      amount: 0n,
-      ledgerOpType: isDelegate ? "DELEGATE" : "UNDELEGATE",
-      stakedAmount: 0n,
-      details: {
-        counter: op.counter,
-        gasLimit: op.gasLimit,
-        storageLimit: op.storageLimit,
-      },
+      ledgerOpType: opType,
+      operationType: opType,
+      stakedAmount: 0,
+      counter: op.counter,
+      gasLimit: op.gasLimit,
+      storageLimit: op.storageLimit,
     },
   ];
 }
@@ -170,7 +167,9 @@ function buildBlockTransactionFromDelegation(op: APIDelegationType): BlockTransa
     failed: !succeeded,
     fees: computeDelegationFees(op),
     ...(feesPayer && { feesPayer }),
-    operations: succeeded ? buildDelegationOperations(op) : [],
+    // Always include operations even for failed txs — listOperations path
+    // always converts them, so getBlock must match for E2E reindex consistency.
+    operations: buildDelegationOperations(op),
   };
 }
 
@@ -189,16 +188,12 @@ function buildStakingOperations(op: APIStakingType): BlockOperation[] {
   return [
     {
       type: "other",
-      address: senderAddr,
-      asset: NATIVE_ASSET,
-      amount: 0n,
       ledgerOpType: operationType,
-      stakedAmount: BigInt(op.amount ?? 0),
-      details: {
-        counter: op.counter,
-        gasLimit: op.gasLimit,
-        storageLimit: op.storageLimit,
-      },
+      operationType,
+      stakedAmount: Number(op.amount ?? 0),
+      counter: op.counter,
+      gasLimit: op.gasLimit,
+      storageLimit: op.storageLimit,
     },
   ];
 }
@@ -213,7 +208,7 @@ function buildBlockTransactionFromStaking(op: APIStakingType): BlockTransaction 
     failed: !succeeded,
     fees: computeStakingFees(op),
     ...(feesPayer && { feesPayer }),
-    operations: succeeded ? buildStakingOperations(op) : [],
+    operations: buildStakingOperations(op),
   };
 }
 
@@ -231,14 +226,10 @@ function buildOriginationOperations(op: APIOriginationType): BlockOperation[] {
     {
       type: "other",
       address: senderAddr,
-      asset: NATIVE_ASSET,
-      amount: op.contractBalance > 0 ? -BigInt(op.contractBalance) : 0n,
       ledgerOpType: "ORIGINATION",
-      details: {
-        counter: op.counter,
-        gasLimit: op.gasLimit,
-        storageLimit: op.storageLimit,
-      },
+      counter: op.counter,
+      gasLimit: op.gasLimit,
+      storageLimit: op.storageLimit,
     },
   ];
 }
@@ -253,7 +244,7 @@ function buildBlockTransactionFromOrigination(op: APIOriginationType): BlockTran
     failed: !succeeded,
     fees: computeOriginationFees(op),
     ...(feesPayer && { feesPayer }),
-    operations: succeeded ? buildOriginationOperations(op) : [],
+    operations: buildOriginationOperations(op),
   };
 }
 
@@ -271,14 +262,10 @@ function buildRevealOperations(op: APIRevealType): BlockOperation[] {
     {
       type: "other",
       address: senderAddr,
-      asset: NATIVE_ASSET,
-      amount: 0n,
       ledgerOpType: "REVEAL",
-      details: {
-        counter: op.counter,
-        gasLimit: op.gasLimit,
-        storageLimit: op.storageLimit,
-      },
+      counter: op.counter,
+      gasLimit: op.gasLimit,
+      storageLimit: op.storageLimit,
     },
   ];
 }
@@ -293,7 +280,7 @@ function buildBlockTransactionFromReveal(op: APIRevealType): BlockTransaction | 
     failed: !succeeded,
     fees: computeRevealFees(op),
     ...(feesPayer && { feesPayer }),
-    operations: succeeded ? buildRevealOperations(op) : [],
+    operations: buildRevealOperations(op),
   };
 }
 

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
@@ -138,8 +138,7 @@ function buildNativeOperations(group: APITransactionType[]): BlockOperation[] {
 const computeDelegationFees = computeOpFees;
 
 function buildDelegationOperations(op: APIDelegationType): BlockOperation[] {
-  const senderAddr = op.sender?.address;
-  if (!senderAddr) return [];
+  if (!op.sender?.address) return [];
 
   const isDelegate = !!op.newDelegate?.address;
 
@@ -180,8 +179,7 @@ function buildBlockTransactionFromDelegation(op: APIDelegationType): BlockTransa
 const computeStakingFees = computeOpFees;
 
 function buildStakingOperations(op: APIStakingType): BlockOperation[] {
-  const senderAddr = op.sender?.address;
-  if (!senderAddr) return [];
+  if (!op.sender?.address) return [];
 
   const operationType = STAKING_ACTION_TO_OP_TYPE[op.action];
 

--- a/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBlock.ts
@@ -190,7 +190,7 @@ function buildStakingOperations(op: APIStakingType): BlockOperation[] {
       type: "other",
       ledgerOpType: operationType,
       operationType,
-      stakedAmount: Number(op.amount ?? 0),
+      stakedAmount: Number(op.amount ?? op.requestedAmount ?? 0),
       counter: op.counter,
       gasLimit: op.gasLimit,
       storageLimit: op.storageLimit,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

- Align getBlock's OtherBlockOperation fields with what the listOperations path produces, so A4's block reindex comparison no longer shows event data mismatches
- Remove structural fields (asset, amount) that leak into A4's EventData; flatten details (counter, gasLimit, storageLimit) to top level; add operationType for delegation/staking ops; use number for stakedAmount (matches A4's Json.fromBigInt serialization)                                                                                                                        
- Always emit operations for failed auxiliary txs (delegation, staking, origination, reveal) — the listOperations path always includes them regardless of failure status                    

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
