### PR TITLE
[LWDM] Fix/solana ocms and libs bump

### DIFF
--- a/.changeset/brave-flowers-cover.md
+++ b/.changeset/brave-flowers-cover.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": patch
+---
+
+Add new OCMS v1 msg format

--- a/libs/coin-modules/coin-solana/src/__tests__/unit/hw-signMessage.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/__tests__/unit/hw-signMessage.unit.test.ts
@@ -1,5 +1,6 @@
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { Account, AnyMessage, TypedEvmMessage } from "@ledgerhq/types-live";
+import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
 import bs58 from "bs58";
 import coinConfig from "../../config";
 import { signMessage } from "../../hw-signMessage";
@@ -20,7 +21,7 @@ describe("Testing call to hardware off-chain sign message on Solana", () => {
     const BASE58_SIGNATURE =
       "23mXB2pc8EQzc2mT3VJR4KkBFZaUVL9Pn7LUn8NMKeHKbS1hMj1QqGsUHHD3JMGhAWtFfcmnPhFSpPttChTNzsB9";
     const BASE58_ENVELOPE =
-      "LwsiJTXpooGk31Y4CaV1Qs12wTabaF83J9Tg32kPb7kk9BXc8ncpoDBzV1NPSumKckhx7dVwFH729vdvB71f8KGpp18g29N2XAD3MUiNz9tPJu36GGN4pkL7vXurXUeQqMTXdJMdH2tzaXkT3vQ9hSLDfBPhQ7Vx9Echz5CYu5u4hZapaytx177WNke8oWDTqABnqQZ3YDGt7vYDoJ2LkiGHqcqXfeVmmsAtuALSxqo75zrWi7EXadQ9CZWWX7tFnXHLY6kEksqVj2ERM9RZEyNQ3tt";
+      "nHpqPBfv1CJUvmpaDaHp4hZZmoucL7f9qFkdwdQj1hFGbLWwWP5rBaBzh2kSFSNJSj5g8yC3Yo5TBHQMCE4ezkQthvpDMpcRvoLkYdwvvDZsqjt3AQnYGzV5fCCrZGnA1pecUUgczB4weoTSQmocrFX2dhqdZ39B71jwWShjn9pW3NY3DtvvMTug9vEkZW8b2GWPbaqoiXMZXAwGQXu4hVBYc8ScN1qV1BXHzX8FCPA";
 
     const getAppConfigurationMock = jest.fn(() => {
       return Promise.resolve({
@@ -44,7 +45,7 @@ describe("Testing call to hardware off-chain sign message on Solana", () => {
     const freshAddress = "8DpKDisipx6f76cEmuGvCX9TrA3SjeR76HaTRePxHBDe";
     const messageHex = "54657374696E67206F6E20536F6C616E61";
     const offchainMessage =
-      "ff736f6c616e61206f6666636861696e00000000000000000000000000000000000000000000000000000000000000000000016b4a46c53959cac0eff146ab323053cfc503321adfd453a7c67c91a24be03235220035343635373337343639364536373230364636453230353336463643363136453631";
+      "ff736f6c616e61206f6666636861696e01016b4a46c53959cac0eff146ab323053cfc503321adfd453a7c67c91a24be0323535343635373337343639364536373230364636453230353336463643363136453631";
 
     const result = await signMessage(signerContext)(
       "",
@@ -102,6 +103,97 @@ describe("Testing call to hardware off-chain sign message on Solana", () => {
     expect(bs58.encode(bs58.decode(result.signature).subarray(1, 65))).toEqual(BASE58_SIGNATURE);
     expect(signMessageMock).toHaveBeenCalledTimes(1);
     expect(signMessageMock).toHaveBeenCalledWith(accountFreshAddressPath, offchainMessage);
+  });
+
+  describe("non-legacy fallback sequencing", () => {
+    const APP_VERSION = "1.8.2";
+    const SIGNATURE =
+      "4gVuB1KsM58fb3vRpnDucwW4Vi6fVGA51QDQd9ARvx4GH5yYVDPzDnvzUbSJf3YLWWdsX7zCMSN9N1GMnTYwWiJf";
+    const accountFreshAddressPath = "44'/501'/0'/0/0";
+    const freshAddress = "8DpKDisipx6f76cEmuGvCX9TrA3SjeR76HaTRePxHBDe";
+    const messageHex = "54657374696E67206F6E20536F6C616E61";
+
+    const V1_NO_LENGTH =
+      "ff736f6c616e61206f6666636861696e01016b4a46c53959cac0eff146ab323053cfc503321adfd453a7c67c91a24be0323535343635373337343639364536373230364636453230353336463643363136453631";
+    const V1_WITH_LENGTH =
+      "ff736f6c616e61206f6666636861696e01016b4a46c53959cac0eff146ab323053cfc503321adfd453a7c67c91a24be03235220035343635373337343639364536373230364636453230353336463643363136453631";
+    const V0 =
+      "ff736f6c616e61206f6666636861696e00000000000000000000000000000000000000000000000000000000000000000000016b4a46c53959cac0eff146ab323053cfc503321adfd453a7c67c91a24be03235220035343635373337343639364536373230364636453230353336463643363136453631";
+
+    function makeContext(signMessageMock: jest.Mock): SignerContext<SolanaSigner> {
+      const signer: SolanaSigner = {
+        getAppConfiguration: jest.fn(() =>
+          Promise.resolve({
+            version: APP_VERSION,
+            blindSigningEnabled: false,
+            pubKeyDisplayMode: PubKeyDisplayMode.LONG,
+          }),
+        ),
+        getAddress: jest.fn(),
+        signTransaction: jest.fn(),
+        signMessage: signMessageMock,
+      };
+      return (_, fn) => fn(signer);
+    }
+
+    it("falls back from V1 no-length to V1 with-length on format rejection", async () => {
+      const signMessageMock = jest
+        .fn()
+        .mockRejectedValueOnce(new Error("format not supported"))
+        .mockResolvedValueOnce({ signature: Buffer.from(SIGNATURE) });
+
+      await signMessage(makeContext(signMessageMock))(
+        "",
+        { freshAddressPath: accountFreshAddressPath, freshAddress } as Account,
+        { message: messageHex },
+      );
+
+      expect(signMessageMock).toHaveBeenCalledTimes(2);
+      expect(signMessageMock).toHaveBeenNthCalledWith(1, accountFreshAddressPath, V1_NO_LENGTH);
+      expect(signMessageMock).toHaveBeenNthCalledWith(2, accountFreshAddressPath, V1_WITH_LENGTH);
+    });
+
+    it("falls back all the way to V0 when both V1 variants are rejected", async () => {
+      const signMessageMock = jest
+        .fn()
+        .mockRejectedValueOnce(new Error("format not supported"))
+        .mockRejectedValueOnce(new Error("format not supported"))
+        .mockResolvedValueOnce({ signature: Buffer.from(SIGNATURE) });
+
+      await signMessage(makeContext(signMessageMock))(
+        "",
+        { freshAddressPath: accountFreshAddressPath, freshAddress } as Account,
+        { message: messageHex },
+      );
+
+      expect(signMessageMock).toHaveBeenCalledTimes(3);
+      expect(signMessageMock).toHaveBeenNthCalledWith(1, accountFreshAddressPath, V1_NO_LENGTH);
+      expect(signMessageMock).toHaveBeenNthCalledWith(2, accountFreshAddressPath, V1_WITH_LENGTH);
+      expect(signMessageMock).toHaveBeenNthCalledWith(3, accountFreshAddressPath, V0);
+    });
+
+    it.each([
+      ["UserRefusedOnDevice", new UserRefusedOnDevice()],
+      ["LockedDeviceError", new LockedDeviceError()],
+      ["TransportStatusError 0x6985 (user refused)", { statusCode: 0x6985 }],
+      ["TransportStatusError 0x5515 (device locked)", { statusCode: 0x5515 }],
+    ])("does not retry on %s", async (_label, error) => {
+      const signMessageMock = jest.fn().mockRejectedValue(error);
+
+      let caught: unknown;
+      try {
+        await signMessage(makeContext(signMessageMock))(
+          "",
+          { freshAddressPath: accountFreshAddressPath, freshAddress } as Account,
+          { message: messageHex },
+        );
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toBe(error);
+      expect(signMessageMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   it.each([{} as AnyMessage, {} as TypedEvmMessage])(

--- a/libs/coin-modules/coin-solana/src/hw-signMessage.ts
+++ b/libs/coin-modules/coin-solana/src/hw-signMessage.ts
@@ -1,11 +1,28 @@
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { Account, AnyMessage, DeviceId } from "@ledgerhq/types-live";
+import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
 import bs58 from "bs58";
 import invariant from "invariant";
 import semver from "semver";
 import coinConfig from "./config";
-import { toOffChainMessage } from "./offchainMessage/format";
+import { toOffChainMessage, toOffChainMessageV1 } from "./offchainMessage/format";
 import { SolanaSigner } from "./signer";
+
+// Returns true for device rejections that should trigger a format fallback
+// (e.g. firmware does not support this OCM layout). Propagates user refusals
+// and locked-device errors so they are never silently retried.
+// Handles both DmkSignerSol (maps to typed errors) and LegacySignerSolana
+// (propagates raw TransportStatusError with a numeric statusCode).
+function isFormatRejection(err: unknown): boolean {
+  if (err instanceof UserRefusedOnDevice) return false;
+  if (err instanceof LockedDeviceError) return false;
+  // TransportStatusError duck-type: 0x6985 = user refused, 0x5515 = device locked
+  if (err && typeof err === "object" && "statusCode" in err) {
+    const { statusCode } = err as { statusCode: number };
+    if (statusCode === 0x6985 || statusCode === 0x5515) return false;
+  }
+  return true;
+}
 
 export const signMessage =
   (signerContext: SignerContext<SolanaSigner>) =>
@@ -29,9 +46,42 @@ export const signMessage =
       const { version } = await signer.getAppConfiguration();
       const isLegacy = semver.lt(version, coinConfig.getCoinConfig().legacyOCMSMaxVersion);
 
-      signedMessage = toOffChainMessage(message, account.freshAddress, isLegacy);
+      if (isLegacy) {
+        const ocm = toOffChainMessage(message, account.freshAddress, true);
+        signedMessage = ocm;
+        return signer.signMessage(account.freshAddressPath, ocm.toString("hex"));
+      }
 
-      return signer.signMessage(account.freshAddressPath, signedMessage.toString("hex"));
+      // Step 1 — V1 without length prefix (finalised sRFC 38 spec).
+      const v1NoLength = toOffChainMessageV1(message, account.freshAddress, false);
+      try {
+        const sig = await signer.signMessage(
+          account.freshAddressPath,
+          v1NoLength.toString("hex"),
+        );
+        signedMessage = v1NoLength;
+        return sig;
+      } catch (err) {
+        if (!isFormatRejection(err)) throw err;
+      }
+
+      // Step 2 — V1 with length prefix (pre-sRFC-38 firmware).
+      const v1WithLength = toOffChainMessageV1(message, account.freshAddress, true);
+      try {
+        const sig = await signer.signMessage(
+          account.freshAddressPath,
+          v1WithLength.toString("hex"),
+        );
+        signedMessage = v1WithLength;
+        return sig;
+      } catch (err) {
+        if (!isFormatRejection(err)) throw err;
+      }
+
+      // Step 3 — V0 fallback (older firmware that does not support V1 at all).
+      const v0 = toOffChainMessage(message, account.freshAddress, false);
+      signedMessage = v0;
+      return signer.signMessage(account.freshAddressPath, v0.toString("hex"));
     });
 
     invariant(signedMessage, "signedMessage should exist");

--- a/libs/coin-modules/coin-solana/src/offchainMessage/format.ts
+++ b/libs/coin-modules/coin-solana/src/offchainMessage/format.ts
@@ -6,11 +6,9 @@
 
 import { PublicKey } from "@solana/web3.js";
 
-// Max off-chain message length supported by Ledger
+// Max off-chain message length supported by Ledger (= app-solana MAX_OFFCHAIN_MESSAGE_LENGTH)
 const OFFCM_MAX_LEDGER_LEN = 15 * 1024 - 40 - 8;
 const LEGACY_OFFCM_MAX_LEDGER_LEN = 1280 - 40 - 8;
-// Max length of version 0 off-chain message
-const OFFCM_MAX_V0_LEN = 65515;
 
 const MAX_PRINTABLE_ASCII = 0x7e;
 const MIN_PRINTABLE_ASCII = 0x20;
@@ -37,32 +35,72 @@ function isUTF8(buffer: Buffer) {
 
 function findMessageFormat(messageBuffer: Buffer, isLegacy: boolean): number {
   const maxLedgerLen = isLegacy ? LEGACY_OFFCM_MAX_LEDGER_LEN : OFFCM_MAX_LEDGER_LEN;
-
-  if (messageBuffer.length <= maxLedgerLen) {
-    if (isPrintableASCII(messageBuffer, isLegacy)) {
-      return 0;
-    } else if (isUTF8(messageBuffer)) {
-      return 1;
-    }
-  } else if (messageBuffer.length <= OFFCM_MAX_V0_LEN) {
-    if (isUTF8(messageBuffer)) {
-      return 2;
-    }
+  if (messageBuffer.length > maxLedgerLen) {
+    throw new Error(`Message too long: ${messageBuffer.length} bytes (max is ${maxLedgerLen})`);
   }
+  if (isPrintableASCII(messageBuffer, isLegacy)) return 0;
+  if (isUTF8(messageBuffer)) return 1;
   return 0;
 }
 
-/**
- * 1. Signing domain (16 bytes)
- * 2. Header version (1 byte)
- * 3. Application domain (32 bytes)
- * 4. Message format (1 byte)
- * 5. Signer count (1 bytes)
- * 6. Signers (signer_count *  32 bytes) - assume that only one signer is present
- * 7. Message length (2 bytes)
- */
 const signingDomain = Buffer.concat([Buffer.from([255]), Buffer.from("solana offchain")]);
-const headerVersion = Buffer.alloc(1);
+
+/**
+ * V1 wire format (sRFC 38, per app-solana parser):
+ *   signing domain  (16 B): 0xFF + "solana offchain"
+ *   version         ( 1 B): 0x01
+ *   signer count    ( 1 B): 1
+ *   signer          (32 B)
+ *   [message length ( 2 B): little-endian uint16] — only when includeLengthPrefix
+ *   message body    (variable)
+ *
+ * The finalised sRFC 38 layout drops the length prefix. `includeLengthPrefix`
+ * reproduces the pre-spec-update layout for backward compatibility with older
+ * firmware that rejects the no-prefix form with 6a81.
+ */
+export function toOffChainMessageV1(
+  message: string,
+  signerAddress: string,
+  includeLengthPrefix = false,
+): Buffer {
+  const messageBuffer = Buffer.from(message);
+  if (messageBuffer.length > OFFCM_MAX_LEDGER_LEN) {
+    throw new Error(
+      `Message too long: ${messageBuffer.length} bytes (max is ${OFFCM_MAX_LEDGER_LEN})`,
+    );
+  }
+
+  const version = Buffer.from([0x01]);
+  const signerCount = Buffer.from([0x01]);
+  const signer = new PublicKey(signerAddress).toBuffer();
+
+  if (includeLengthPrefix) {
+    const messageLength = Buffer.alloc(2);
+    messageLength.writeUInt16LE(messageBuffer.length);
+    return Buffer.concat([signingDomain, version, signerCount, signer, messageLength, messageBuffer]);
+  }
+  return Buffer.concat([signingDomain, version, signerCount, signer, messageBuffer]);
+}
+
+/**
+ * V0 wire format:
+ *   signing domain  (16 B): 0xFF + "solana offchain"
+ *   version         ( 1 B): 0x00
+ *   application domain (32 B): zero-padded
+ *   format          ( 1 B): 0 = ASCII, 1 = UTF-8
+ *   signer count    ( 1 B): 1
+ *   signer          (32 B)
+ *   message length  ( 2 B): little-endian uint16
+ *   message body    (variable)
+ *
+ * Legacy format (Nano S / old firmware):
+ *   signing domain  (16 B)
+ *   version         ( 1 B): 0x00
+ *   format          ( 1 B)
+ *   message length  ( 2 B): always present
+ *   message body    (variable)
+ */
+const v0HeaderVersion = Buffer.alloc(1); // 0x00
 const applicationDomain = Buffer.alloc(32);
 const messageFormat = Buffer.alloc(1);
 const signerCount = Buffer.alloc(1);
@@ -79,20 +117,26 @@ export function toOffChainMessage(
 
   const signers = new PublicKey(signerAddress).toBuffer();
 
-  messageLength.writeUint16LE(messageBuffer.length);
+  messageLength.writeUInt16LE(messageBuffer.length);
 
-  return Buffer.concat(
-    isLegacy
-      ? [signingDomain, headerVersion, messageFormat, messageLength, messageBuffer]
-      : [
-          signingDomain,
-          headerVersion,
-          applicationDomain,
-          messageFormat,
-          signerCount,
-          signers,
-          messageLength,
-          messageBuffer,
-        ],
-  );
+  if (isLegacy) {
+    return Buffer.concat([
+      signingDomain,
+      v0HeaderVersion,
+      messageFormat,
+      messageLength,
+      messageBuffer,
+    ]);
+  }
+
+  return Buffer.concat([
+    signingDomain,
+    v0HeaderVersion,
+    applicationDomain,
+    messageFormat,
+    signerCount,
+    signers,
+    messageLength,
+    messageBuffer,
+  ]);
 }

--- a/libs/coin-modules/coin-solana/src/offchainMessage/format.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/offchainMessage/format.unit.test.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from "@solana/web3.js";
-import { toOffChainMessage } from "./format";
+import { toOffChainMessage, toOffChainMessageV1 } from "./format";
 
 type MessageCase = {
   value: string;
@@ -78,8 +78,9 @@ Issued At: now`,
   const addressHex = new PublicKey(address).toBuffer().toString("hex");
   const emptyApplicationDomain = "0000000000000000000000000000000000000000000000000000000000000000";
 
+  // V0 layout: header(32) + version(2) + appDomain(64) + format(2) + signerCount(2) + signer(64) + length(4) + body
   it.each(cases)(
-    'should format message "$value" correctly for off-chain signing on Solana',
+    'should format message "$value" correctly for off-chain signing on Solana (V0)',
     ({ value, hexadecimal, messageFormat, messageLength }) => {
       const result = toOffChainMessage(value, address, false).toString("hex");
 
@@ -106,8 +107,53 @@ Issued At: now`,
       const length = result.substring(SOLANA_HEADER.length + 134, SOLANA_HEADER.length + 138);
       expect(length).toEqual(messageLength);
 
-      // message should end with message parameter
       expect(result.substring(SOLANA_HEADER.length + 138)).toEqual(hexadecimal);
+    },
+  );
+
+  // V1 layout (no length): header(32) + version(2) + signerCount(2) + signer(64) + body
+  it.each(cases)(
+    'should format message "$value" correctly for off-chain signing on Solana (V1, no length)',
+    ({ value, hexadecimal, messageLength: _ignored }) => {
+      const result = toOffChainMessageV1(value, address).toString("hex");
+
+      expect(result.startsWith(SOLANA_HEADER)).toBe(true);
+
+      const version = result.substring(SOLANA_HEADER.length, SOLANA_HEADER.length + 2);
+      expect(version).toEqual("01");
+
+      const signerCount = result.substring(SOLANA_HEADER.length + 2, SOLANA_HEADER.length + 4);
+      expect(signerCount).toEqual("01");
+
+      const signerAddress = result.substring(SOLANA_HEADER.length + 4, SOLANA_HEADER.length + 68);
+      expect(signerAddress).toEqual(addressHex);
+
+      // no length field — message body starts immediately after signer
+      expect(result.substring(SOLANA_HEADER.length + 68)).toEqual(hexadecimal);
+    },
+  );
+
+  // V1 layout (with length): header(32) + version(2) + signerCount(2) + signer(64) + length(4) + body
+  it.each(cases)(
+    'should format message "$value" correctly for off-chain signing on Solana (V1, with length prefix)',
+    ({ value, hexadecimal, messageLength }) => {
+      const result = toOffChainMessageV1(value, address, true).toString("hex");
+
+      expect(result.startsWith(SOLANA_HEADER)).toBe(true);
+
+      const version = result.substring(SOLANA_HEADER.length, SOLANA_HEADER.length + 2);
+      expect(version).toEqual("01");
+
+      const signerCount = result.substring(SOLANA_HEADER.length + 2, SOLANA_HEADER.length + 4);
+      expect(signerCount).toEqual("01");
+
+      const signerAddress = result.substring(SOLANA_HEADER.length + 4, SOLANA_HEADER.length + 68);
+      expect(signerAddress).toEqual(addressHex);
+
+      const length = result.substring(SOLANA_HEADER.length + 68, SOLANA_HEADER.length + 72);
+      expect(length).toEqual(messageLength);
+
+      expect(result.substring(SOLANA_HEADER.length + 72)).toEqual(hexadecimal);
     },
   );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ catalogs:
       specifier: 1.1.0
       version: 1.1.0
     '@ledgerhq/device-signer-kit-solana':
-      specifier: 1.9.1
-      version: 1.9.1
+      specifier: 1.10.0
+      version: 1.10.0
     '@ledgerhq/device-transport-kit-react-native-ble':
       specifier: 1.3.2
       version: 1.3.2
@@ -497,7 +497,7 @@ overrides:
   remove-flow-types-loader>loader-utils: '*'
   '@ledgerhq/devices': workspace:*
   '@ledgerhq/hw-transport': workspace:*
-  '@ledgerhq/context-module': 2.1.0
+  '@ledgerhq/context-module': 2.2.0
   tslib: 2.6.2
   '@ethersproject/providers>ws': 7.5.10
   elliptic: 6.6.1
@@ -1642,8 +1642,8 @@ importers:
         specifier: workspace:^
         version: link:../../libs/coin-modules/coin-stacks
       '@ledgerhq/context-module':
-        specifier: 2.1.0
-        version: 2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        specifier: 2.2.0
+        version: 2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.4(@ledgerhq/lumen-design-core@0.1.17)(@ledgerhq/lumen-ui-rnative@0.1.42(dcc3c8c6a72bd292a8f68e8d09060e5e))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -1658,7 +1658,7 @@ importers:
         version: 1.7.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.16.0(@ledgerhq/context-module@2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        version: 1.16.0(@ledgerhq/context-module@2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-transport-kit-react-native-hid':
         specifier: 'catalog:'
         version: 1.0.4(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(rxjs@7.8.2)
@@ -11375,8 +11375,8 @@ importers:
   libs/live-dmk-shared:
     dependencies:
       '@ledgerhq/context-module':
-        specifier: 2.1.0
-        version: 2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        specifier: 2.2.0
+        version: 2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -11585,14 +11585,14 @@ importers:
         specifier: workspace:^
         version: link:../coin-modules/coin-aleo
       '@ledgerhq/context-module':
-        specifier: 2.1.0
-        version: 2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        specifier: 2.2.0
+        version: 2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.7.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-aleo':
         specifier: 'catalog:'
-        version: 0.4.0(@ledgerhq/context-module@2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        version: 0.4.0(@ledgerhq/context-module@2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -11729,14 +11729,14 @@ importers:
         specifier: workspace:^
         version: link:../concordium-core
       '@ledgerhq/context-module':
-        specifier: 2.1.0
-        version: 2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        specifier: 2.2.0
+        version: 2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.7.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-concordium':
         specifier: 'catalog:'
-        version: 0.4.0(@ledgerhq/context-module@2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        version: 0.4.0(@ledgerhq/context-module@2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -11830,14 +11830,14 @@ importers:
         specifier: workspace:^
         version: link:../coin-modules/coin-evm
       '@ledgerhq/context-module':
-        specifier: 2.1.0
-        version: 2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        specifier: 2.2.0
+        version: 2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.7.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.16.0(@ledgerhq/context-module@2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        version: 1.16.0(@ledgerhq/context-module@2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -11935,7 +11935,7 @@ importers:
         version: 1.7.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-solana':
         specifier: 'catalog:'
-        version: 1.9.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))(typescript@6.0.2)
+        version: 1.10.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))(typescript@6.0.2)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -17557,10 +17557,10 @@ packages:
       '@ledgerhq/live-network': ^2.4.0
       '@ledgerhq/logs': ^6.17.0
 
-  '@ledgerhq/context-module@2.1.0':
-    resolution: {integrity: sha512-t5mIA6DcxGafYF1xEHwAj6RyxvmTY5ZfnC/qxVf3PEF65+3J11qcw5Xs3pYWz49mSXQxjTiGKWs0JINiZagGWA==}
+  '@ledgerhq/context-module@2.2.0':
+    resolution: {integrity: sha512-nRJqEhsA83v4MSsBTCUwpiswdzc9wj+oKv57o7CMF7DeQzdGlITlKhDV1SixLXp7YxoVH7ovAMkCYcTdB4sZeA==}
     peerDependencies:
-      '@ledgerhq/device-management-kit': ^1.5.1
+      '@ledgerhq/device-management-kit': ^1.7.1
 
   '@ledgerhq/crypto-icons@2.0.4':
     resolution: {integrity: sha512-PbUs85RtyGaq4R/KBcscHxbeSb7s6E69JbISJkBH9q7V7pmKtsABu31Yaq7UmOodiulidQKrYo7lKcZ7UxXO9w==}
@@ -17591,13 +17591,13 @@ packages:
   '@ledgerhq/device-signer-kit-aleo@0.4.0':
     resolution: {integrity: sha512-GeWvln9TY/EAVxnxmMTPITxOstZLD5tiwupFih2avIayoeYa3Q8Gh8gkW77wd/Sd9oQLmwLQByHdcwRmMcSLrQ==}
     peerDependencies:
-      '@ledgerhq/context-module': 2.1.0
+      '@ledgerhq/context-module': 2.2.0
       '@ledgerhq/device-management-kit': ^1.6.0
 
   '@ledgerhq/device-signer-kit-concordium@0.4.0':
     resolution: {integrity: sha512-jqVp8232dkI34ZVbsQOcGpjK9J+g8BzGD9+/0Ezy7nGtMUfX8c6AhEmn79kj3w96kJ0z1YkakaClCHxicFWtKQ==}
     peerDependencies:
-      '@ledgerhq/context-module': 2.1.0
+      '@ledgerhq/context-module': 2.2.0
       '@ledgerhq/device-management-kit': ^1.5.0
 
   '@ledgerhq/device-signer-kit-cosmos@1.0.1':
@@ -17608,7 +17608,7 @@ packages:
   '@ledgerhq/device-signer-kit-ethereum@1.16.0':
     resolution: {integrity: sha512-lRXCAHlNcZObazX4sQrD2fiVssolzJYjcyzH+9b2AKnV1bfxN5JCY4coIge/L+23LjDVhqibVK6jg8ioUJ4znQ==}
     peerDependencies:
-      '@ledgerhq/context-module': 2.1.0
+      '@ledgerhq/context-module': 2.2.0
       '@ledgerhq/device-management-kit': ^1.5.0
 
   '@ledgerhq/device-signer-kit-hyperliquid@1.1.0':
@@ -17616,10 +17616,10 @@ packages:
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.5.0
 
-  '@ledgerhq/device-signer-kit-solana@1.9.1':
-    resolution: {integrity: sha512-/30PBWzwo52aOHbtsOaAiqY4c3sm1EECBFGMKris5ddPydOq41HxBKqNKJVq9tOuOIIP5huvr2iBwOy2//isUw==}
+  '@ledgerhq/device-signer-kit-solana@1.10.0':
+    resolution: {integrity: sha512-re2EundpA6vqroXIZMs9uWOqmAYeODOiKkYT9WsNE/mbDHfX2ketFOqqh/1MD0sjtE3dq3YHMZTDj+bTHV22Mg==}
     peerDependencies:
-      '@ledgerhq/device-management-kit': ^1.5.1
+      '@ledgerhq/device-management-kit': ^1.7.1
 
   '@ledgerhq/device-signer-kit-zcash@0.2.0':
     resolution: {integrity: sha512-VE+wb64WXBkvVwMF7SwzAU1UQwlJ1Hb/dNJeuLSlpTWmsY9x0WZnQKTH5U/CLvnfoLXadl21tdthSQb0XlCDPA==}
@@ -17783,6 +17783,11 @@ packages:
     resolution: {integrity: sha512-Ek4/NXGt6gfiZUmiAFE19534f8wnlQSHvZMsjmqCEktbJd/mYbzvTrvYeo0+PQPw2D/kTYD1fRC6ADKQRSBeGw==}
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.2.0
+
+  '@ledgerhq/signer-utils@1.3.0':
+    resolution: {integrity: sha512-qe+HQMgZxq6SPv8ghvlq4c33RchUwlf1qE/qp7MtUGPbKGAqD/0PKNyzx05sKLpmA8m6YZdtndHH4CEkikzqSQ==}
+    peerDependencies:
+      '@ledgerhq/device-management-kit': ^1.7.1
 
   '@ledgerhq/speculos-device-controller@0.3.0':
     resolution: {integrity: sha512-FCOGVs28pTxYEom+Yr8skQ1QUyj1+sC0YDvE+Xk+DfXQx8FMRI1l41x+XT8ZGPNUh8kRTd0hsZc2lqVpxD6a8w==}
@@ -45706,7 +45711,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/context-module@2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
+  '@ledgerhq/context-module@2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
       bs58: 6.0.0
@@ -45794,9 +45799,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-aleo@0.4.0(@ledgerhq/context-module@2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-aleo@0.4.0(@ledgerhq/context-module@2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.1.3(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
@@ -45804,9 +45809,9 @@ snapshots:
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-concordium@0.4.0(@ledgerhq/context-module@2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-concordium@0.4.0(@ledgerhq/context-module@2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
@@ -45823,9 +45828,9 @@ snapshots:
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-ethereum@1.16.0(@ledgerhq/context-module@2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-ethereum@1.16.0(@ledgerhq/context-module@2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       ethers: 6.15.0
@@ -45840,7 +45845,7 @@ snapshots:
 
   '@ledgerhq/device-signer-kit-hyperliquid@1.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
@@ -45851,12 +45856,11 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-solana@1.9.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))(typescript@6.0.2)':
+  '@ledgerhq/device-signer-kit-solana@1.10.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))(typescript@6.0.2)':
     dependencies:
-      '@ledgerhq/context-module': 2.1.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
-      '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(typescript@6.0.2))(typescript@6.0.2)
+      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@solana/web3.js': 1.98.4(typescript@6.0.2)
       bs58: 6.0.0
       buffer: 6.0.3(patch_hash=42321bf7b7c77317e644bb216138271640fb39808e74312037dac216f4b9bc5d)
@@ -45868,7 +45872,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - encoding
-      - fastestsmallesttextencoderdecoder
       - typescript
       - utf-8-validate
 
@@ -46197,6 +46200,11 @@ snapshots:
       semver: 7.7.2
 
   '@ledgerhq/signer-utils@1.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
+    dependencies:
+      '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
+      semver: 7.7.2
+
+  '@ledgerhq/signer-utils@1.3.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
       semver: 7.7.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,14 +21,14 @@ packages:
 
 catalog:
   "@jest/globals": 30.2.0
-  "@ledgerhq/context-module": 2.1.0
+  "@ledgerhq/context-module": 2.2.0
   "@ledgerhq/crypto-icons": "2.0.4"
   "@ledgerhq/device-management-kit": 1.7.1
   "@ledgerhq/device-signer-kit-aleo": 0.4.0
   "@ledgerhq/device-signer-kit-concordium": 0.4.0
   "@ledgerhq/device-signer-kit-ethereum": 1.16.0
   "@ledgerhq/device-signer-kit-hyperliquid": 1.1.0
-  "@ledgerhq/device-signer-kit-solana": 1.9.1
+  "@ledgerhq/device-signer-kit-solana": 1.10.0
   "@ledgerhq/device-signer-kit-cosmos": 1.0.1
   "@ledgerhq/device-transport-kit-react-native-ble": 1.3.2
   "@ledgerhq/device-transport-kit-react-native-hid": 1.0.4


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

- `feat(coin-solana): Add new OCMS v1 format` - implements the sRFC 38 Off-Chain Message Signing V1 wire format in `coin-solana`. The signing flow now attempts three layouts in sequence: V1 without length prefix (finalised sRFC 38), V1 with length prefix (pre-spec-update firmware), and V0 as a final fallback for older firmware. `isFormatRejection` guards against silently retrying user refusals or locked-device errors. The `toOffChainMessageV1` function is added alongside the existing `toOffChainMessage` (V0) and tests are updated to cover the new paths.
- `chore: bump solana and context module` - updates `@ledgerhq/coin-solana` and the context module versions in `pnpm-workspace.yaml / pnpm-lock.yaml`.


### 🔗 Context

- **JIRA / GitHub issue**: [NO-ISSUE]
