### PR TITLE
[LWDM] fix: mark Q2 tour seen at onboarding start

### DIFF
--- a/.changeset/q2tour-onboarding-gate.md
+++ b/.changeset/q2tour-onboarding-gate.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+fix: prevent the Q2 tour from opening during onboarding by marking it as seen on the Welcome screen

--- a/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/hooks/useMarkQ2TourSeenAtOnboardingStart.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/hooks/useMarkQ2TourSeenAtOnboardingStart.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { useDispatch } from "LLD/hooks/redux";
+import { setHasSeenQ2Tour } from "~/renderer/actions/settings";
+
+/**
+ * Call on the first screen of the onboarding flow (Welcome).
+ * Marks the Q2 tour as "seen" so the tour dialog does not open after onboarding.
+ */
+export function useMarkQ2TourSeenAtOnboardingStart(): void {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(setHasSeenQ2Tour(true));
+  }, [dispatch]);
+}

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Welcome/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Welcome/index.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { Welcome as WelcomeMVVM } from "LLD/features/Onboarding/screens/Welcome";
 import { useMarkWalletV4TourSeenAtOnboardingStart } from "LLD/features/WalletV4Tour/hooks/useMarkWalletV4TourSeenAtOnboardingStart";
+import { useMarkQ2TourSeenAtOnboardingStart } from "LLD/features/Q2Tour/hooks/useMarkQ2TourSeenAtOnboardingStart";
 
 export function Welcome() {
   useMarkWalletV4TourSeenAtOnboardingStart();
+  useMarkQ2TourSeenAtOnboardingStart();
 
   return <WelcomeMVVM />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Q2WalletV4Tour/hooks/useMarkQ2WalletV4TourSeenAtOnboardingStart.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Q2WalletV4Tour/hooks/useMarkQ2WalletV4TourSeenAtOnboardingStart.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { useDispatch } from "~/context/hooks";
+import { setHasSeenQ2WalletV4Tour } from "~/actions/settings";
+
+/**
+ * Call on the first screen of the onboarding flow (Welcome).
+ * Marks the Q2 Wallet V4 tour as "seen" so the tour drawer does not open after onboarding.
+ */
+export function useMarkQ2WalletV4TourSeenAtOnboardingStart(): void {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(setHasSeenQ2WalletV4Tour(true));
+  }, [dispatch]);
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/index.tsx
@@ -12,6 +12,7 @@ import { TappableMask } from "./components/TappableMask";
 import { useWelcomeNavigation } from "./hooks/useWelcomeNavigation";
 import { useWelcomeStories } from "./hooks/useWelcomeStories";
 import { useMarkWalletV4TourSeenAtOnboardingStart } from "LLM/features/WalletV4Tour/hooks/useMarkWalletV4TourSeenAtOnboardingStart";
+import { useMarkQ2WalletV4TourSeenAtOnboardingStart } from "LLM/features/Q2WalletV4Tour/hooks/useMarkQ2WalletV4TourSeenAtOnboardingStart";
 import SafeAreaView from "~/components/SafeAreaView";
 
 export default function WelcomePage() {
@@ -20,6 +21,7 @@ export default function WelcomePage() {
   const isFocused = useIsFocused();
 
   useMarkWalletV4TourSeenAtOnboardingStart();
+  useMarkQ2WalletV4TourSeenAtOnboardingStart();
 
   const { welcomeVideos, currentVideoIndex, videoDurations, onLoad, onPrevious, onNext } =
     useWelcomeStories();


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

mark Q2 tour seen at onboarding start (same as WalletV4Tour)

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34321]<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-34321]: https://ledgerhq.atlassian.net/browse/LIVE-34321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ