### PR TITLE
test(e2e): fix and re-enable BSC verify address tests

### DIFF
--- a/e2e/desktop/tests/specs/receive.address.spec.ts
+++ b/e2e/desktop/tests/specs/receive.address.spec.ts
@@ -24,8 +24,7 @@ const nativeAccounts = [
   { account: Account.BCH_1, xrayTicket: "B2CQA-2558, B2CQA-2693" },
   { account: Account.ATOM_1, xrayTicket: "B2CQA-2560, B2CQA-2694" },
   { account: Account.XTZ_1, xrayTicket: "B2CQA-2564, B2CQA-2695" },
-  //TODO: re-enable test when https://ledgerhq.atlassian.net/browse/LIVE-25852 is fixed
-  //{ account: Account.BSC_1, xrayTicket: "B2CQA-2686, B2CQA-2696, B2CQA-2698" },
+  { account: Account.BSC_1, xrayTicket: "B2CQA-2686, B2CQA-2696, B2CQA-2698" },
 ];
 
 const tokenAccount = { account: TokenAccount.ETH_USDT_1, xrayTicket: "B2CQA-5694" };

--- a/e2e/desktop/tests/specs/subAccount.spec.ts
+++ b/e2e/desktop/tests/specs/subAccount.spec.ts
@@ -76,10 +76,9 @@ const subAccountReceive: Array<{
     shouldSelectReceiveCryptoOption: true,
   },
   { account: TokenAccount.TRX_USDT, xrayTicket: "B2CQA-2496" },
-  //TODO: re-enable tests when https://ledgerhq.atlassian.net/browse/LIVE-25852 is fixed
-  // { account: TokenAccount.BSC_BUSD_1, xrayTicket: "B2CQA-2489" },
-  // { account: TokenAccount.POL_DAI_1, xrayTicket: "B2CQA-2493" },
-  // { account: TokenAccount.POL_UNI, xrayTicket: "B2CQA-2494" },
+  { account: TokenAccount.BSC_BUSD_1, xrayTicket: "B2CQA-2489" },
+  { account: TokenAccount.POL_DAI_1, xrayTicket: "B2CQA-2493" },
+  { account: TokenAccount.POL_UNI, xrayTicket: "B2CQA-2494" },
   { account: TokenAccount.SUI_USDC_1, xrayTicket: "B2CQA-3906" },
 ];
 

--- a/e2e/mobile/specs/verifyAddress/verifyAddressBSC.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressBSC.spec.ts
@@ -1,6 +1,5 @@
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { runVerifyAddressTest } from "./verifyAddress";
-//TODO: re-enable test when https://ledgerhq.atlassian.net/browse/LIVE-25852 is fixed
 runVerifyAddressTest(
   Account.BSC_1,
   ["B2CQA-2686", "B2CQA-2696"],

--- a/libs/live-e2e-shared/src/enum/DeviceLabels.ts
+++ b/libs/live-e2e-shared/src/enum/DeviceLabels.ts
@@ -60,7 +60,7 @@ export enum DeviceLabels {
   TYPE_SEND = "Type Send",
   VALUE = "Value",
   VERIFY_ADDRESS = "Verify address",
-  VERIFY_BSC = "Verify BSC",
+  VERIFY_BSC = "Verify Binance Smart",
   VERIFY_ETHEREUM = "Verify Ethereum",
   VERIFY_POLYGON = "Verify Polygon",
   VERIFY_COSMOS = "Verify Cosmos",


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not required: only E2E/test changes in the private `@ledgerhq/live-e2e-shared` package and `e2e/` specs._
- [x] **Covered by automatic tests.** _These changes are the E2E tests themselves._
- [x] **Impact of the changes:**
  - BSC receive native coin E2E (desktop)
  - BSC token receive E2E (subAccount: BSC_BUSD, POL_DAI, POL_UNI)
  - BSC verify address E2E (mobile)

### 📝 Description

**Problem**: The BSC "Receive native coin" E2E test was failing with `Error: Text "Verify BSC" not found on device screen after 60 attempts. Last screen text: "Verify Binance Smart Chain address"`. The BSC app now renders "Verify Binance Smart Chain address" instead of "Verify BSC", so the stale `VERIFY_BSC` device label no longer matched.

**Solution**:
- Update `DeviceLabels.VERIFY_BSC` from `"Verify BSC"` to `"Verify Binance Smart"` (substring match, resilient to the "Smart"/"Chain" line wrap seen on device).
- Re-enable the previously skipped BSC E2E tests that were blocked on LIVE-25852:
  - `e2e/desktop/tests/specs/receive.address.spec.ts` — `Account.BSC_1`
  - `e2e/desktop/tests/specs/subAccount.spec.ts` — `BSC_BUSD_1`, `POL_DAI_1`, `POL_UNI`
  - `e2e/mobile/specs/verifyAddress/verifyAddressBSC.spec.ts` (renamed from `.skip.spec.ts`)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25852](https://ledgerhq.atlassian.net/browse/LIVE-25852)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.



[LIVE-25852]: https://ledgerhq.atlassian.net/browse/LIVE-25852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ