### PR TITLE
[LWDM] fix(mobile,desktop): stop showing Q2 tour for non onboarded users

### DIFF
--- a/.changeset/empty-drinks-flash.md
+++ b/.changeset/empty-drinks-flash.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+fix: prevent Q2 tour from showing to users who haven't onboarded

--- a/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/hooks/__tests__/useSuppressQ2TourForNewUsers.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/hooks/__tests__/useSuppressQ2TourForNewUsers.test.ts
@@ -1,0 +1,59 @@
+import { renderHook, withFlagOverrides } from "tests/testSetup";
+import { useSuppressQ2TourForNewUsers } from "../useSuppressQ2TourForNewUsers";
+
+const q2TourEnabledOverrides = {
+  lwdWallet40: {
+    enabled: true,
+    params: { q2Tour: true },
+  },
+};
+
+const getInitialState = (overrides?: {
+  loaded?: boolean;
+  hasSeenQ2Tour?: boolean;
+  hasCompletedOnboarding?: boolean;
+  featureFlagOverrides?: typeof q2TourEnabledOverrides;
+}) => ({
+  ...withFlagOverrides(overrides?.featureFlagOverrides ?? q2TourEnabledOverrides),
+  settings: {
+    loaded: overrides?.loaded ?? true,
+    hasCompletedOnboarding: overrides?.hasCompletedOnboarding ?? false,
+    hasSeenQ2Tour: overrides?.hasSeenQ2Tour ?? false,
+  },
+});
+
+describe("useSuppressQ2TourForNewUsers", () => {
+  it("marks the tour as seen when settings load, tour is enabled, and user is not onboarded", () => {
+    const { store } = renderHook(() => useSuppressQ2TourForNewUsers(), {
+      initialState: getInitialState(),
+    });
+
+    expect(store.getState().settings.hasSeenQ2Tour).toBe(true);
+  });
+
+  it("does nothing when the tour feature is disabled", () => {
+    const { store } = renderHook(() => useSuppressQ2TourForNewUsers(), {
+      initialState: getInitialState({
+        featureFlagOverrides: { lwdWallet40: { enabled: true, params: { q2Tour: false } } },
+      }),
+    });
+
+    expect(store.getState().settings.hasSeenQ2Tour).toBe(false);
+  });
+
+  it("does nothing for an already-onboarded user", () => {
+    const { store } = renderHook(() => useSuppressQ2TourForNewUsers(), {
+      initialState: getInitialState({ hasCompletedOnboarding: true }),
+    });
+
+    expect(store.getState().settings.hasSeenQ2Tour).toBe(false);
+  });
+
+  it("does nothing until settings are loaded", () => {
+    const { store } = renderHook(() => useSuppressQ2TourForNewUsers(), {
+      initialState: getInitialState({ loaded: false }),
+    });
+
+    expect(store.getState().settings.hasSeenQ2Tour).toBe(false);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/hooks/useSuppressQ2TourForNewUsers.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Q2Tour/hooks/useSuppressQ2TourForNewUsers.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from "react";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import {
+  areSettingsLoaded,
+  hasCompletedOnboardingSelector,
+  hasSeenQ2TourSelector,
+} from "~/renderer/reducers/settings";
+import { setHasSeenQ2Tour } from "~/renderer/actions/settings";
+
+/**
+ * The Q2 tour is only meant for users who were already onboarded when they got the
+ * app version that introduced it. If the app opens and the user is not onboarded, mark
+ * the tour as seen so they never see it (they'll onboard on a tour-aware build). See
+ * LIVE-34321.
+ */
+export const useSuppressQ2TourForNewUsers = (): void => {
+  const dispatch = useDispatch();
+  const settingsLoaded = useSelector(areSettingsLoaded);
+  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const hasSeenQ2Tour = useSelector(hasSeenQ2TourSelector);
+  const { shouldDisplayQ2Tour } = useWalletFeaturesConfig("desktop");
+
+  // Snapshot onboarding state at app open (first render where settings are loaded). The
+  // tour flag can resolve after that, so we react to it — but decide against the snapshot
+  // so a user who finishes onboarding later in this session stays suppressed.
+  const wasOnboardedAtOpenRef = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    if (!settingsLoaded) return;
+    if (wasOnboardedAtOpenRef.current === null) {
+      wasOnboardedAtOpenRef.current = hasCompletedOnboarding;
+    }
+    if (shouldDisplayQ2Tour && !wasOnboardedAtOpenRef.current && !hasSeenQ2Tour) {
+      dispatch(setHasSeenQ2Tour(true));
+    }
+  }, [settingsLoaded, shouldDisplayQ2Tour, hasCompletedOnboarding, hasSeenQ2Tour, dispatch]);
+};

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -57,6 +57,7 @@ import { hasCompletedOnboardingSelector, areSettingsLoaded } from "~/renderer/re
 import { useAutoDismissPostOnboardingEntryPoint } from "@ledgerhq/live-common/postOnboarding/hooks/index";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useEnforceSupportedLanguage } from "./hooks/useEnforceSupportedLanguage";
+import { useSuppressQ2TourForNewUsers } from "LLD/features/Q2Tour/hooks/useSuppressQ2TourForNewUsers";
 import { useDeviceManagementKit } from "@ledgerhq/live-dmk-desktop";
 import { AppGeoBlocker } from "LLD/features/AppBlockers/components/AppGeoBlocker";
 import { AppVersionBlocker } from "LLD/features/AppBlockers/components/AppVersionBlocker";
@@ -426,6 +427,7 @@ export default function Default() {
   useRecoverRestoreOnboarding();
   useAutoDismissPostOnboardingEntryPoint();
   useEnforceSupportedLanguage();
+  useSuppressQ2TourForNewUsers();
 
   useEffect(() => {
     if (typeof ldmkSolanaSignerFeatureFlag?.enabled === "boolean") {

--- a/apps/ledger-live-mobile/src/components/RootNavigator/index.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/index.tsx
@@ -9,9 +9,11 @@ import BaseOnboardingNavigator from "./BaseOnboardingNavigator";
 import { RootStackParamList } from "./types/RootNavigator";
 import { AnalyticsContextProvider } from "~/analytics/AnalyticsContext";
 import { StartupTimeMarker } from "../../StartupTimeMarker";
+import { useSuppressQ2TourForNewUsers } from "LLM/features/Q2WalletV4Tour/hooks/useSuppressQ2TourForNewUsers";
 
 export default function RootNavigator() {
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  useSuppressQ2TourForNewUsers();
   const goToOnboarding = !hasCompletedOnboarding && !Config.SKIP_ONBOARDING;
 
   return (

--- a/apps/ledger-live-mobile/src/mvvm/features/Q2WalletV4Tour/hooks/__tests__/useSuppressQ2TourForNewUsers.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Q2WalletV4Tour/hooks/__tests__/useSuppressQ2TourForNewUsers.test.ts
@@ -1,0 +1,86 @@
+import { renderHook } from "@testing-library/react-native";
+import { useFeature } from "@features/platform-feature-flags";
+import { useDispatch, useSelector } from "~/context/hooks";
+import { setHasSeenQ2WalletV4Tour } from "~/actions/settings";
+import { useSuppressQ2TourForNewUsers } from "../useSuppressQ2TourForNewUsers";
+
+jest.mock("@features/platform-feature-flags");
+jest.mock("~/context/hooks", () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}));
+
+const mockUseSelector = jest.mocked(useSelector);
+const mockUseDispatch = jest.mocked(useDispatch);
+const mockUseFeature = jest.mocked(useFeature);
+const dispatch = jest.fn();
+
+function mockState({
+  hasCompletedOnboarding,
+  hasSeenQ2WalletV4Tour,
+}: {
+  hasCompletedOnboarding: boolean;
+  hasSeenQ2WalletV4Tour: boolean;
+}) {
+  const state = { settings: { hasCompletedOnboarding, hasSeenQ2WalletV4Tour } };
+  mockUseSelector.mockImplementation(selector => selector(state as never));
+}
+
+function mockTourEnabled(enabled: boolean) {
+  mockUseFeature.mockReturnValue({ enabled, params: { q2Tour: enabled } } as never);
+}
+
+describe("useSuppressQ2TourForNewUsers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDispatch.mockReturnValue(dispatch);
+    mockTourEnabled(true);
+  });
+
+  it("marks the tour as seen when the app opens enabled and the user is not onboarded", () => {
+    mockState({ hasCompletedOnboarding: false, hasSeenQ2WalletV4Tour: false });
+
+    renderHook(() => useSuppressQ2TourForNewUsers());
+
+    expect(dispatch).toHaveBeenCalledWith(setHasSeenQ2WalletV4Tour(true));
+  });
+
+  it("marks the tour as seen when the flag turns on after mount for a not-onboarded user", () => {
+    mockTourEnabled(false);
+    mockState({ hasCompletedOnboarding: false, hasSeenQ2WalletV4Tour: false });
+
+    const { rerender } = renderHook(() => useSuppressQ2TourForNewUsers());
+    expect(dispatch).not.toHaveBeenCalled();
+
+    // Flag arrives after mount.
+    mockTourEnabled(true);
+    rerender({});
+
+    expect(dispatch).toHaveBeenCalledWith(setHasSeenQ2WalletV4Tour(true));
+  });
+
+  it("does nothing when the tour feature is disabled", () => {
+    mockTourEnabled(false);
+    mockState({ hasCompletedOnboarding: false, hasSeenQ2WalletV4Tour: false });
+
+    renderHook(() => useSuppressQ2TourForNewUsers());
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for an already-onboarded user", () => {
+    mockState({ hasCompletedOnboarding: true, hasSeenQ2WalletV4Tour: false });
+
+    renderHook(() => useSuppressQ2TourForNewUsers());
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("does nothing if the tour was already seen", () => {
+    mockState({ hasCompletedOnboarding: false, hasSeenQ2WalletV4Tour: true });
+
+    renderHook(() => useSuppressQ2TourForNewUsers());
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Q2WalletV4Tour/hooks/useSuppressQ2TourForNewUsers.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Q2WalletV4Tour/hooks/useSuppressQ2TourForNewUsers.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from "react";
+import { useFeature } from "@features/platform-feature-flags";
+import { useDispatch, useSelector } from "~/context/hooks";
+import { setHasSeenQ2WalletV4Tour } from "~/actions/settings";
+import { hasCompletedOnboardingSelector, hasSeenQ2WalletV4TourSelector } from "~/reducers/settings";
+
+/**
+ * The Q2 tour is only meant for users who were already onboarded when they got the
+ * app version that introduced it. If the app opens and the user is not onboarded, mark
+ * the tour as seen so they never see it (they'll onboard on a tour-aware build).
+ * Called once from RootNavigator, which mounts after the store is hydrated. See LIVE-34321.
+ */
+export const useSuppressQ2TourForNewUsers = (): void => {
+  const dispatch = useDispatch();
+  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const hasSeenTour = useSelector(hasSeenQ2WalletV4TourSelector);
+  const lwmWallet40 = useFeature("lwmWallet40");
+  const isTourEnabled = (lwmWallet40?.enabled && lwmWallet40?.params?.q2Tour) ?? false;
+
+  // Snapshot onboarding state at app open (first render; the store is already hydrated).
+  // The tour flag can toggle on after mount, so we react to it — but decide against the
+  // snapshot so a user who finishes onboarding later in this session stays suppressed.
+  const wasOnboardedAtOpenRef = useRef(hasCompletedOnboarding);
+
+  useEffect(() => {
+    if (isTourEnabled && !wasOnboardedAtOpenRef.current && !hasSeenTour) {
+      dispatch(setHasSeenQ2WalletV4Tour(true));
+    }
+  }, [isTourEnabled, hasSeenTour, dispatch]);
+};


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The Q2 product tour is only meant for users who were **already onboarded** when they got the app version that introduced it. It should never appear for a user who onboards on a tour-aware build.

**Previous behaviour (mobile):** an empty tour drawer flashed on the Portfolio right after device connection during onboarding. `completeOnboarding()` is dispatched at the device-pairing step and the app navigates straight to `Main`/Portfolio, where the tour drawer auto-opens on mount — so it popped mid-onboarding, before content/layout was ready (LIVE-34321). Desktop didn't show the empty drawer (it routes to the Post-Onboarding Hub first and gates on `isOnPortfolioPage`), but it also didn't enforce the "already-onboarded-only" rule — a freshly-onboarded user who then opened Portfolio in the same session would still see it.

**Fix (both platforms):** on app open, if the tour feature is enabled and the user is **not** onboarded, mark the tour as seen (`setHasSeenQ2WalletV4Tour` / `setHasSeenQ2Tour`). Already-onboarded users are untouched and still get the tour.

- New `useSuppressQ2TourForNewUsers` hook per app.
  - Mobile: called from `RootNavigator` (mounts after the store is hydrated).
  - Desktop: called from `Default`, evaluated once `areSettingsLoaded` is true.
- The tour feature flag can resolve **after** the hook mounts, so the effect reacts to the flag turning on — but decides against a ref snapshot of the onboarding state **at app open**, so a user who finishes onboarding later in the same session stays suppressed.

**Regression coverage:** unit tests for both hooks (mobile 5/5, desktop 4/4), including the "flag turns on after mount for a not-onboarded user" case that reproduced the original bug.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34321](https://ledgerhq.atlassian.net/browse/LIVE-34321)
- **ADR** (if any): N/A


[LIVE-34321]: https://ledgerhq.atlassian.net/browse/LIVE-34321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ