### PR TITLE
docs(wallet-cli): sync README with v2 and bump to 2.0.1

### DIFF
--- a/apps/wallet-cli/CHANGELOG.md
+++ b/apps/wallet-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ledgerhq/wallet-cli
 
+## 2.0.1
+
+### Patch Changes
+
+- Refresh README documentation for the `2.0.0` release: bump the version, retitle the status section to v2, and document the `earn` (staking & DeFi yield) and `ring` (Ledger Key Ring / LKRP encryption) command groups in the commands table, `--help` list, and prerequisites.
+
 ## 2.0.0
 
 > This is a manual major version bump. There are no breaking changes; the `2.0.0` release marks the addition of the `earn` and `ring` command groups as a product milestone. All entries below are additive (minor) or fixes (patch).

--- a/apps/wallet-cli/README.md
+++ b/apps/wallet-cli/README.md
@@ -1,10 +1,10 @@
 # wallet-cli (`@ledgerhq/wallet-cli`)
 
-Command-line tool for Ledger Wallet flows over **USB**, built on the **Device Management Kit (DMK)** and [Bunli](https://www.npmjs.com/package/bunli). Version **1.0.1**.
+Command-line tool for Ledger Wallet flows over **USB**, built on the **Device Management Kit (DMK)** and [Bunli](https://www.npmjs.com/package/bunli). Version **2.0.1**.
 
-## Status (v1)
+## Status (v2)
 
-wallet-cli is the stable v1 CLI for USB-based Ledger Wallet flows. Its scope is intentionally focused: it does not aim for full Ledger Live desktop or mobile feature parity.
+wallet-cli is the stable CLI for USB-based Ledger Wallet flows. Its scope is intentionally focused: it does not aim for full Ledger Live desktop or mobile feature parity. The `2.0.0` release adds the **`earn`** (staking & DeFi yield) and **`ring`** (Ledger Key Ring / LKRP encryption) command groups.
 
 **Supported networks** today: **bitcoin**, **ethereum**, and **solana** (aligned with `live-common-setup.ts`). Token flows are supported for tokens on those networks.
 
@@ -23,6 +23,11 @@ wallet-cli is the stable v1 CLI for USB-based Ledger Wallet flows. Its scope is 
 | `swap status`                         | Read the current swap status from the partner API.                                                                                                                                                              |
 | `assets token` / `assets token-by-id` | Resolve token metadata by contract address or token id.                                                                                                                                                         |
 | `genuine-check`                       | Check whether the connected Ledger device is genuine.                                                                                                                                                           |
+| `earn yields` / `earn positions`      | List yield opportunities (per-network deposit targets with `-n ethereum`/`-n solana`) and active staking/vault positions for an account. **No device** required.                                                |
+| `earn deposit` / `earn withdraw`      | Stake / deposit into a vault, or unstake / redeem. Ethereum ERC-4626 vaults and Solana native staking. Signs on the **device**; `--dry-run` validates without signing.                                          |
+| `ring init`                           | One-time provisioning of your Ledger Key Ring (LKRP) via the device. Prompts for a password unless `--unsecure-no-password`.                                                                                     |
+| `ring encrypt` / `ring decrypt`       | AES-256-GCM encrypt/decrypt of files (`-i`/`-o`) or text (stdin/stdout) under a named key (`--key`). **No device** after `init`; requires network to restore the trustchain.                                     |
+| `ring keys` / `ring destroy`          | List the keys this machine has used, or tear down the ring (local credentials + remote LKRP application).                                                                                                        |
 
 Typical flow: run `account discover` with a currency id (e.g. `bitcoin`, `ethereum`), then pass the assigned **session label** (e.g. `--account ethereum-1`) to `balances`, `operations`, `send`, or `receive`. Use `session view` to see what's saved.
 
@@ -40,6 +45,13 @@ pnpm wallet-cli start -- genuine-check --help
 pnpm wallet-cli start -- swap quote --help
 pnpm wallet-cli start -- swap execute --help
 pnpm wallet-cli start -- swap status --help
+pnpm wallet-cli start -- earn yields --help
+pnpm wallet-cli start -- earn positions --help
+pnpm wallet-cli start -- earn deposit --help
+pnpm wallet-cli start -- earn withdraw --help
+pnpm wallet-cli start -- ring init --help
+pnpm wallet-cli start -- ring encrypt --help
+pnpm wallet-cli start -- ring decrypt --help
 ```
 
 From `apps/wallet-cli`, use `pnpm start` in place of `pnpm wallet-cli start` (same args after `--`).
@@ -50,7 +62,7 @@ Most commands support `--output human` (default) or `--output json`.
 
 - **[Bun](https://bun.sh)** ≥ 1.1.0 (`engines` in `package.json`)
 - **pnpm** and this monorepo checked out; install dependencies per [repo commands](../../docs/repo-commands.md) (e.g. `mise install`, `pnpm i`)
-- A **Ledger** on USB when using `account discover`, `send`, `swap execute`, or `receive --verify`
+- A **Ledger** on USB when using `account discover`, `send`, `swap execute`, `receive --verify`, `earn deposit`/`earn withdraw`, `genuine-check`, or `ring init`
 - **Linux:** USB/HID build deps, for example:
 
   ```bash

--- a/apps/wallet-cli/npm/darwin-arm64/CHANGELOG.md
+++ b/apps/wallet-cli/npm/darwin-arm64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @ledgerhq/wallet-cli-darwin-arm64
 
+## 2.0.1
+
 ## 2.0.0
 
 ## 1.1.0

--- a/apps/wallet-cli/npm/darwin-arm64/package.json
+++ b/apps/wallet-cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/wallet-cli-darwin-arm64",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "macOS arm64 native binary for @ledgerhq/wallet-cli",
   "license": "Apache-2.0",

--- a/apps/wallet-cli/npm/linux-arm64/CHANGELOG.md
+++ b/apps/wallet-cli/npm/linux-arm64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @ledgerhq/wallet-cli-linux-arm64
 
+## 2.0.1
+
 ## 2.0.0
 
 ## 1.1.0

--- a/apps/wallet-cli/npm/linux-arm64/package.json
+++ b/apps/wallet-cli/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/wallet-cli-linux-arm64",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "Linux arm64 native binary for @ledgerhq/wallet-cli",
   "license": "Apache-2.0",

--- a/apps/wallet-cli/npm/linux-x64/CHANGELOG.md
+++ b/apps/wallet-cli/npm/linux-x64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @ledgerhq/wallet-cli-linux-x64
 
+## 2.0.1
+
 ## 2.0.0
 
 ## 1.1.0

--- a/apps/wallet-cli/npm/linux-x64/package.json
+++ b/apps/wallet-cli/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/wallet-cli-linux-x64",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "Linux x64 native binary for @ledgerhq/wallet-cli",
   "license": "Apache-2.0",

--- a/apps/wallet-cli/npm/windows-x64/CHANGELOG.md
+++ b/apps/wallet-cli/npm/windows-x64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @ledgerhq/wallet-cli-windows-x64
 
+## 2.0.1
+
 ## 2.0.0
 
 ## 1.1.0

--- a/apps/wallet-cli/npm/windows-x64/package.json
+++ b/apps/wallet-cli/npm/windows-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/wallet-cli-windows-x64",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "Windows x64 native binary for @ledgerhq/wallet-cli",
   "license": "Apache-2.0",

--- a/apps/wallet-cli/package.json
+++ b/apps/wallet-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/wallet-cli",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "Ledger Wallet CLI using Device Management Kit (USB)",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Context

The `apps/wallet-cli` README was stuck at **v1.0.1** while the CLI had already shipped **2.0.0** (the `earn` and `ring` command groups). We forgot to update the README alongside the version bumps.

## Changes

- **README** synced with the v2 CLI:
  - Version line `1.0.1` → `2.0.1`
  - "Status (v1)" → "Status (v2)", noting the v2 milestone (`earn` + `ring`)
  - Commands table now documents `earn yields`/`positions`/`deposit`/`withdraw` and `ring init`/`encrypt`/`decrypt`/`keys`/`destroy`
  - Added the corresponding `--help` lines and expanded the "Ledger on USB" prerequisites
- **Patch bump 2.0.0 → 2.0.1** (documentation-only), applied to the main package and the four platform binaries (`prepare-npm.mjs` requires platform versions to match main). CHANGELOG entries added accordingly — no changeset, bumped directly in this PR.

## Notes

Docs + version metadata only; no runtime/source changes.
