### PR TITLE
Fix Cold start E2E  tests Earn

### DIFF
--- a/e2e/desktop/tests/page/earn.v2.dashboard.page.ts
+++ b/e2e/desktop/tests/page/earn.v2.dashboard.page.ts
@@ -9,7 +9,7 @@ export class EarnV2Page extends EarnBasePage {
   private readonly maxPotentialRewards = "max-potential-rewards";
   private readonly walletHeaderAmount = "wallet-header-amount";
   private readonly rewardsSummary = "rewards-summary";
-  private readonly tokensToEarnBanner = "tokens-to-earn-banner";
+  private readonly crowdFavourites = "crowd-favourites";
   private readonly footerDisclaimer = "footer-disclaimer";
   private readonly assetItemTicker = (ticker: string) =>
     `asset-item-ticker-${ticker.toLowerCase()}`;
@@ -36,7 +36,7 @@ export class EarnV2Page extends EarnBasePage {
   @step("Verify cold start page")
   async verifyColdStartPage() {
     await this.verifyElementIsVisible(this.maxPotentialRewards);
-    await this.verifyElementIsVisible(this.tokensToEarnBanner);
+    await this.verifyElementIsVisible(this.crowdFavourites);
   }
 
   @step("Verify asset ready to earn: $0")

--- a/e2e/desktop/tests/page/earn.v2.dashboard.page.ts
+++ b/e2e/desktop/tests/page/earn.v2.dashboard.page.ts
@@ -10,6 +10,7 @@ export class EarnV2Page extends EarnBasePage {
   private readonly walletHeaderAmount = "wallet-header-amount";
   private readonly rewardsSummary = "rewards-summary";
   private readonly crowdFavourites = "crowd-favourites";
+  private readonly tokensToEarnBanner = "tokens-to-earn-banner";
   private readonly footerDisclaimer = "footer-disclaimer";
   private readonly assetItemTicker = (ticker: string) =>
     `asset-item-ticker-${ticker.toLowerCase()}`;
@@ -36,7 +37,11 @@ export class EarnV2Page extends EarnBasePage {
   @step("Verify cold start page")
   async verifyColdStartPage() {
     await this.verifyElementIsVisible(this.maxPotentialRewards);
-    await this.verifyElementIsVisible(this.crowdFavourites);
+    // crowd-favourites is shown when earnUpselling (Q2) is on; tokens-to-earn-banner otherwise (Q1)
+    const webview = await this.getWebView();
+    await expect(
+      webview.getByTestId(this.crowdFavourites).or(webview.getByTestId(this.tokensToEarnBanner)),
+    ).toBeVisible();
   }
 
   @step("Verify asset ready to earn: $0")


### PR DESCRIPTION

### 📝 Description
PR fixing 2 Earn tests for Cold start. 
Changing the data-testid from lwdWallet40Q1 to the one used when we enable the parmeter     "earnUpselling": true from lwdWallet40 Q2.

This change fixes the test:
- Earn v2 cold start page shows ATOM ready to earn
- Earn v2 cold start page shows ETH ready to earn

### 🔗 Context


Allure report: 
https://ledger-live.allure.green.ledgerlabs.net/allure/reports/3bea1c6b-a1d0-4894-affb-a7eaa428958d/#suites