### PR TITLE
[LWM] feat(live-mobile): add large screen upsell analytics

### DIFF
--- a/.changeset/bright-screens-track.md
+++ b/.changeset/bright-screens-track.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add large screen upsell modal analytics tracking

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
@@ -1,13 +1,27 @@
 import React, { useEffect } from "react";
-import { View } from "react-native";
+import { Linking, View } from "react-native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { DeviceModelId } from "@ledgerhq/devices";
-import { render, screen, waitFor, withFlagOverrides } from "@tests/test-renderer";
+import { act, fireEvent, render, screen, waitFor, withFlagOverrides } from "@tests/test-renderer";
+import { screen as analyticsScreen, track } from "~/analytics";
 import { useDispatch } from "~/context/hooks";
 import { openBackupHubFeatureIntro } from "~/reducers/backupHubFeatureIntro";
 import type { State } from "~/reducers/types";
 import { LargeScreenUpsellModalPortfolioMount } from "..";
 import { __resetLargeScreenUpsellAutoOpenForTests } from "../components/LargeScreenUpsellModalPortfolioMount/useLargeScreenUpsellModalPortfolioMountViewModel";
+
+const NANO_S_OPTED_OUT_ANALYTICS_PROPS = {
+  deviceModel: "lns",
+  personalRecoOptIn: false,
+  offerType: "none",
+  retriesUpsellModal: 0,
+  throttled: false,
+};
+const NANO_S_OPTED_IN_ANALYTICS_PROPS = {
+  ...NANO_S_OPTED_OUT_ANALYTICS_PROPS,
+  personalRecoOptIn: true,
+  offerType: "discount",
+};
 
 const Stack = createNativeStackNavigator();
 const NOW = new Date("2026-06-01T12:00:00.000Z");
@@ -78,12 +92,20 @@ function IntegrationNavigatorWithDelayedCompetitor() {
 }
 
 describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
+  let canOpenURLSpy: jest.SpiedFunction<typeof Linking.canOpenURL>;
+  let openURLSpy: jest.SpiedFunction<typeof Linking.openURL>;
+
   beforeEach(() => {
+    jest.clearAllMocks();
+    canOpenURLSpy = jest.spyOn(Linking, "canOpenURL").mockResolvedValue(true);
+    openURLSpy = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
     jest.useFakeTimers().setSystemTime(NOW);
     __resetLargeScreenUpsellAutoOpenForTests();
   });
 
   afterEach(() => {
+    canOpenURLSpy.mockRestore();
+    openURLSpy.mockRestore();
     jest.useRealTimers();
   });
 
@@ -106,6 +128,114 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
     await waitFor(() => {
       expect(screen.getByTestId("large-screen-upsell-modal-drawer")).toBeVisible();
     });
+  });
+
+  it("should track the modal view with shared analytics properties when it auto-opens", async () => {
+    const overrideInitialState = withFlagOverrides(
+      {
+        largeScreenUpsell: { enabled: true },
+        lwmProductTour: { enabled: false },
+        lwmGenericAwarenessModal: { enabled: false },
+        analyticsOptIn: { enabled: false },
+      },
+      withKnownDeviceModels([DeviceModelId.nanoS]),
+    );
+
+    render(<IntegrationNavigator />, { overrideInitialState });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("large-screen-upsell-modal-drawer")).toBeVisible();
+    });
+
+    expect(jest.mocked(analyticsScreen)).toHaveBeenCalledWith("Upgrade modal", undefined, {
+      name: "Upgrade modal",
+      ...NANO_S_OPTED_OUT_ANALYTICS_PROPS,
+    });
+  });
+
+  it("should track opted-in offer properties when personalized recommendations are enabled", async () => {
+    const overrideInitialState = withFlagOverrides(
+      {
+        largeScreenUpsell: { enabled: true },
+        lwmProductTour: { enabled: false },
+        lwmGenericAwarenessModal: { enabled: false },
+        analyticsOptIn: { enabled: false },
+      },
+      withKnownDeviceModels([DeviceModelId.nanoS], {
+        personalizedRecommendationsEnabled: true,
+      }),
+    );
+
+    render(<IntegrationNavigator />, { overrideInitialState });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("large-screen-upsell-modal-drawer")).toBeVisible();
+    });
+
+    expect(jest.mocked(analyticsScreen)).toHaveBeenCalledWith("Upgrade modal", undefined, {
+      name: "Upgrade modal",
+      ...NANO_S_OPTED_IN_ANALYTICS_PROPS,
+    });
+  });
+
+  it("should track button_clicked with shared analytics properties when the CTA is pressed", async () => {
+    const overrideInitialState = withFlagOverrides(
+      {
+        largeScreenUpsell: { enabled: true },
+        lwmProductTour: { enabled: false },
+        lwmGenericAwarenessModal: { enabled: false },
+        analyticsOptIn: { enabled: false },
+      },
+      withKnownDeviceModels([DeviceModelId.nanoS]),
+    );
+
+    const { user } = render(<IntegrationNavigator />, { overrideInitialState });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("large-screen-upsell-modal-drawer")).toBeVisible();
+    });
+
+    await user.press(screen.getByTestId("large-screen-upsell-modal-primary-button"));
+
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "explore large screen devices",
+      page: "Upgrade modal",
+      ...NANO_S_OPTED_OUT_ANALYTICS_PROPS,
+    });
+    expect(track).not.toHaveBeenCalledWith("modal_dismissed", expect.anything());
+  });
+
+  it("should track modal_dismissed with dismissMethod close_button exactly once when the header close button is pressed", async () => {
+    const overrideInitialState = withFlagOverrides(
+      {
+        largeScreenUpsell: { enabled: true },
+        lwmProductTour: { enabled: false },
+        lwmGenericAwarenessModal: { enabled: false },
+        analyticsOptIn: { enabled: false },
+      },
+      withKnownDeviceModels([DeviceModelId.nanoS]),
+    );
+
+    const { user } = render(<IntegrationNavigator />, { overrideInitialState });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("large-screen-upsell-modal-drawer")).toBeVisible();
+    });
+
+    const closeButton = screen.getByTestId("bottom-sheet-header-close-button");
+    await user.press(closeButton);
+    fireEvent(closeButton, "dismiss");
+    act(() => jest.runOnlyPendingTimers());
+
+    expect(track).toHaveBeenCalledWith("modal_dismissed", {
+      modal: "upgrade modal",
+      page: "Upgrade modal",
+      dismissMethod: "close_button",
+      ...NANO_S_OPTED_OUT_ANALYTICS_PROPS,
+    });
+    expect(
+      jest.mocked(track).mock.calls.filter(([event]) => event === "modal_dismissed"),
+    ).toHaveLength(1);
   });
 
   it("should auto-open the upsell modal when product tour is enabled but onboarding is not completed", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/analytics.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/analytics.ts
@@ -1,0 +1,67 @@
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { screen, track } from "~/analytics";
+
+export const LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME = "Upgrade modal";
+
+export type LargeScreenUpsellDismissMethod = "close_button" | "outside_tap";
+
+export type LargeScreenUpsellNanoDeviceModelId =
+  | DeviceModelId.nanoS
+  | DeviceModelId.nanoSP
+  | DeviceModelId.nanoX;
+
+export type LargeScreenUpsellDeviceModelAnalyticsValue = "lns" | "lnsp" | "lnx";
+
+const DEVICE_MODEL_ANALYTICS_VALUES: Record<
+  LargeScreenUpsellNanoDeviceModelId,
+  LargeScreenUpsellDeviceModelAnalyticsValue
+> = {
+  [DeviceModelId.nanoS]: "lns",
+  [DeviceModelId.nanoSP]: "lnsp",
+  [DeviceModelId.nanoX]: "lnx",
+};
+
+export function toLargeScreenUpsellDeviceModelAnalyticsValue(
+  deviceModelId: LargeScreenUpsellNanoDeviceModelId,
+): LargeScreenUpsellDeviceModelAnalyticsValue {
+  return DEVICE_MODEL_ANALYTICS_VALUES[deviceModelId];
+}
+
+export type LargeScreenUpsellSharedAnalyticsProps = Readonly<{
+  deviceModel: LargeScreenUpsellDeviceModelAnalyticsValue;
+  personalRecoOptIn: boolean;
+  offerType: "discount" | "none";
+  retriesUpsellModal: number;
+  throttled: boolean;
+}>;
+
+export function trackLargeScreenUpsellModalViewed(
+  sharedProps: LargeScreenUpsellSharedAnalyticsProps,
+) {
+  screen(LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME, undefined, {
+    name: LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME,
+    ...sharedProps,
+  });
+}
+
+export function trackLargeScreenUpsellModalCtaClicked(
+  sharedProps: LargeScreenUpsellSharedAnalyticsProps,
+) {
+  track("button_clicked", {
+    button: "explore large screen devices",
+    page: LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME,
+    ...sharedProps,
+  });
+}
+
+export function trackLargeScreenUpsellModalDismissed(
+  dismissMethod: LargeScreenUpsellDismissMethod,
+  sharedProps: LargeScreenUpsellSharedAnalyticsProps,
+) {
+  track("modal_dismissed", {
+    modal: "upgrade modal",
+    page: LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME,
+    dismissMethod,
+    ...sharedProps,
+  });
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalDrawer/__tests__/LargeScreenUpsellModalDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalDrawer/__tests__/LargeScreenUpsellModalDrawer.test.tsx
@@ -5,7 +5,28 @@ import {
   type GenericAwarenessModalFeatureIntro,
 } from "@ledgerhq/live-common/genericAwarenessModal";
 import type { FeatureIntroViewModel } from "LLM/components/FeatureIntroLayout/types";
+import type { LargeScreenUpsellDismissMethod } from "../../../analytics";
 import { LargeScreenUpsellModalDrawer } from "..";
+
+type MockQueuedDrawerBottomSheetProps = Readonly<{
+  children: React.ReactNode;
+  onClose?: () => void;
+  onHeaderClosePressed?: () => void;
+  onBackdropPress?: () => void;
+}>;
+
+let capturedDrawerProps: MockQueuedDrawerBottomSheetProps | null = null;
+
+jest.mock("LLM/components/QueuedDrawer/QueuedDrawerBottomSheet", () => ({
+  __esModule: true,
+  default: (props: MockQueuedDrawerBottomSheetProps) => {
+    const React = require("react");
+    const { BottomSheet } = jest.requireActual("@ledgerhq/lumen-ui-rnative");
+
+    capturedDrawerProps = props;
+    return React.createElement(BottomSheet, { snapPoints: ["70%", "90%"] }, props.children);
+  },
+}));
 
 const content: GenericAwarenessModalFeatureIntro = {
   id: "large-screen-upsell-modal",
@@ -28,18 +49,39 @@ const viewModel: FeatureIntroViewModel = {
   onSecondaryPress: jest.fn(),
 };
 
-function renderLargeScreenUpsellModalDrawer(isOpen: boolean) {
+function renderLargeScreenUpsellModalDrawer(
+  isOpen: boolean,
+  onDismiss: (dismissMethod: LargeScreenUpsellDismissMethod) => void = jest.fn(),
+) {
   return render(
     <LargeScreenUpsellModalDrawer
       isOpen={isOpen}
-      onClose={jest.fn()}
+      onDismiss={onDismiss}
       featureIntroViewModel={viewModel}
       bottomInset={0}
     />,
   );
 }
 
+function pressHeaderClose() {
+  capturedDrawerProps?.onHeaderClosePressed?.();
+  capturedDrawerProps?.onClose?.();
+}
+
+function pressBackdrop() {
+  capturedDrawerProps?.onBackdropPress?.();
+  capturedDrawerProps?.onClose?.();
+}
+
+function panDownToClose() {
+  capturedDrawerProps?.onClose?.();
+}
+
 describe("LargeScreenUpsellModalDrawer", () => {
+  beforeEach(() => {
+    capturedDrawerProps = null;
+  });
+
   it("should not render drawer content before it is opened", () => {
     renderLargeScreenUpsellModalDrawer(false);
 
@@ -50,5 +92,57 @@ describe("LargeScreenUpsellModalDrawer", () => {
     renderLargeScreenUpsellModalDrawer(true);
 
     expect(screen.getByTestId("large-screen-upsell-modal-drawer")).toBeOnTheScreen();
+  });
+
+  it("should ignore close signals before the drawer has opened", () => {
+    const onDismiss = jest.fn();
+    renderLargeScreenUpsellModalDrawer(false, onDismiss);
+
+    panDownToClose();
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("should report close_button exactly once when the header close button is pressed", () => {
+    const onDismiss = jest.fn();
+    renderLargeScreenUpsellModalDrawer(true, onDismiss);
+
+    pressHeaderClose();
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledWith("close_button");
+  });
+
+  it("should ignore duplicate close signals for the same opening", () => {
+    const onDismiss = jest.fn();
+    renderLargeScreenUpsellModalDrawer(true, onDismiss);
+
+    pressHeaderClose();
+    pressHeaderClose();
+    pressBackdrop();
+    panDownToClose();
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledWith("close_button");
+  });
+
+  it("should report outside_tap exactly once when the backdrop is pressed", () => {
+    const onDismiss = jest.fn();
+    renderLargeScreenUpsellModalDrawer(true, onDismiss);
+
+    pressBackdrop();
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledWith("outside_tap");
+  });
+
+  it("should fall back to outside_tap when the sheet closes via pan-down gesture", () => {
+    const onDismiss = jest.fn();
+    renderLargeScreenUpsellModalDrawer(true, onDismiss);
+
+    panDownToClose();
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledWith("outside_tap");
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalDrawer/index.tsx
@@ -4,35 +4,74 @@ import { Platform } from "react-native";
 import type { FeatureIntroViewModel } from "LLM/components/FeatureIntroLayout/types";
 import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
 import { LargeScreenUpsellModalContent } from "../LargeScreenUpsellModalContent";
+import type { LargeScreenUpsellDismissMethod } from "../../analytics";
 
 type LargeScreenUpsellModalDrawerProps = Readonly<{
   isOpen: boolean;
-  onClose: () => void;
+  onDismiss: (dismissMethod: LargeScreenUpsellDismissMethod) => void;
   featureIntroViewModel: FeatureIntroViewModel;
   bottomInset: number;
 }>;
 
 export function LargeScreenUpsellModalDrawer({
   isOpen,
-  onClose,
+  onDismiss,
   featureIntroViewModel,
   bottomInset,
 }: LargeScreenUpsellModalDrawerProps) {
   const [hasRenderedContent, setHasRenderedContent] = useState(isOpen);
   const isOpenRef = useRef(isOpen);
   isOpenRef.current = isOpen;
+  const lastExplicitDismissMethodRef = useRef<LargeScreenUpsellDismissMethod | null>(null);
+  const hasReportedDismissRef = useRef(false);
+  const hasActiveOpeningRef = useRef(isOpen);
 
   useEffect(() => {
     if (isOpen) {
       setHasRenderedContent(true);
+      hasReportedDismissRef.current = false;
+      lastExplicitDismissMethodRef.current = null;
+      hasActiveOpeningRef.current = true;
     }
   }, [isOpen]);
 
   const handleModalHide = useCallback(() => {
     if (!isOpenRef.current) {
       setHasRenderedContent(false);
+      hasActiveOpeningRef.current = false;
     }
   }, []);
+
+  const reportDismiss = useCallback(
+    (dismissMethod: LargeScreenUpsellDismissMethod) => {
+      if (!hasActiveOpeningRef.current || hasReportedDismissRef.current) {
+        return;
+      }
+
+      hasReportedDismissRef.current = true;
+      onDismiss(dismissMethod);
+    },
+    [onDismiss],
+  );
+
+  const handleHeaderClosePressed = useCallback(() => {
+    lastExplicitDismissMethodRef.current = "close_button";
+    reportDismiss("close_button");
+  }, [reportDismiss]);
+
+  const handleBackdropPress = useCallback(() => {
+    lastExplicitDismissMethodRef.current = "outside_tap";
+    reportDismiss("outside_tap");
+  }, [reportDismiss]);
+
+  const handleClose = useCallback(() => {
+    if (lastExplicitDismissMethodRef.current) {
+      lastExplicitDismissMethodRef.current = null;
+      return;
+    }
+
+    reportDismiss("outside_tap");
+  }, [reportDismiss]);
 
   const shouldRenderContent = isOpen || hasRenderedContent;
 
@@ -40,7 +79,9 @@ export function LargeScreenUpsellModalDrawer({
     <QueuedDrawerBottomSheet
       key="large-screen-upsell-modal-drawer"
       isRequestingToBeOpened={isOpen}
-      onClose={onClose}
+      onClose={handleClose}
+      onHeaderClosePressed={handleHeaderClosePressed}
+      onBackdropPress={handleBackdropPress}
       onModalHide={handleModalHide}
       enableDynamicSizing
     >

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalPortfolioMount/LargeScreenUpsellModalPortfolioMountView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalPortfolioMount/LargeScreenUpsellModalPortfolioMountView.tsx
@@ -2,11 +2,12 @@ import React, { useRef } from "react";
 import { View } from "react-native";
 import type { FeatureIntroViewModel } from "LLM/components/FeatureIntroLayout/types";
 import { LargeScreenUpsellModalDrawer } from "../LargeScreenUpsellModalDrawer";
+import type { LargeScreenUpsellDismissMethod } from "../../analytics";
 
 type LargeScreenUpsellModalPortfolioMountViewProps = Readonly<{
   isEligible: boolean;
   isOpen: boolean;
-  onClose: () => void;
+  onDismiss: (dismissMethod: LargeScreenUpsellDismissMethod) => void;
   featureIntroViewModel: FeatureIntroViewModel;
   bottomInset: number;
 }>;
@@ -14,7 +15,7 @@ type LargeScreenUpsellModalPortfolioMountViewProps = Readonly<{
 export function LargeScreenUpsellModalPortfolioMountView({
   isEligible,
   isOpen,
-  onClose,
+  onDismiss,
   featureIntroViewModel,
   bottomInset,
 }: LargeScreenUpsellModalPortfolioMountViewProps) {
@@ -31,7 +32,7 @@ export function LargeScreenUpsellModalPortfolioMountView({
     <View testID="large-screen-upsell-portfolio-mount" collapsable={false}>
       <LargeScreenUpsellModalDrawer
         isOpen={isOpen}
-        onClose={onClose}
+        onDismiss={onDismiss}
         featureIntroViewModel={featureIntroViewModel}
         bottomInset={bottomInset}
       />

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalPortfolioMount/useLargeScreenUpsellModalPortfolioMountViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalPortfolioMount/useLargeScreenUpsellModalPortfolioMountViewModel.ts
@@ -10,7 +10,7 @@ import {
 import type { FeatureIntroViewModel } from "LLM/components/FeatureIntroLayout/types";
 import { useTranslation } from "~/context/Locale";
 import { useDispatch, useSelector } from "~/context/hooks";
-import { analyticsEnabledSelector } from "~/reducers/settings";
+import { personalizedRecommendationsEnabledSelector } from "~/reducers/settings";
 import type { State } from "~/reducers/types";
 import { useLargeScreenUpsellEligibility } from "../../hooks/useLargeScreenUpsellEligibility";
 import { useCompetingAppStartModalsPresent } from "../../hooks/useCompetingAppStartModalsPresent";
@@ -18,6 +18,14 @@ import {
   buildLargeScreenUpsellContent,
   type LargeScreenUpsellVariant,
 } from "../../utils/upsellContent";
+import {
+  toLargeScreenUpsellDeviceModelAnalyticsValue,
+  trackLargeScreenUpsellModalCtaClicked,
+  trackLargeScreenUpsellModalDismissed,
+  trackLargeScreenUpsellModalViewed,
+  type LargeScreenUpsellDismissMethod,
+  type LargeScreenUpsellSharedAnalyticsProps,
+} from "../../analytics";
 
 const LARGE_SCREEN_UPSELL_MODAL_ID = "large-screen-upsell-modal";
 const LARGE_SCREEN_UPSELL_MODAL_IOS_BOTTOM_PADDING = 20;
@@ -31,7 +39,7 @@ export const __resetLargeScreenUpsellAutoOpenForTests = () => {
 type LargeScreenUpsellModalPortfolioMountViewModel = Readonly<{
   isEligible: boolean;
   isOpen: boolean;
-  onClose: () => void;
+  onDismiss: (dismissMethod: LargeScreenUpsellDismissMethod) => void;
   featureIntroViewModel: FeatureIntroViewModel;
   bottomInset: number;
 }>;
@@ -43,10 +51,14 @@ export function useLargeScreenUpsellModalPortfolioMountViewModel(): LargeScreenU
   const feature = useFeature("largeScreenUpsell");
   const eligibility = useLargeScreenUpsellEligibility();
   const hasCompetingAppStartModal = useCompetingAppStartModalsPresent();
-  const analyticsEnabled = useSelector(analyticsEnabledSelector);
+  const personalizedRecommendationsEnabled = useSelector(
+    personalizedRecommendationsEnabledSelector,
+  );
   const retries = useSelector((state: State) => state.largeScreenUpsellModal.retries);
   const lastSeenAt = useSelector((state: State) => state.largeScreenUpsellModal.lastSeenAt);
   const hasSeenCompetingAppStartModalRef = useRef(hasCompetingAppStartModal);
+  const currentModalAnalyticsPropsRef = useRef<LargeScreenUpsellSharedAnalyticsProps | null>(null);
+  const hasHandledCurrentModalInteractionRef = useRef(false);
   const [isOpen, setIsOpen] = useState(false);
 
   if (hasCompetingAppStartModal) {
@@ -55,17 +67,20 @@ export function useLargeScreenUpsellModalPortfolioMountViewModel(): LargeScreenU
 
   const params = feature?.params;
   const hasEnabledFeature = Boolean(feature?.enabled && params);
+  const lastSeenAtDate = typeof lastSeenAt === "number" ? new Date(lastSeenAt) : null;
 
   const isThrottled =
     hasEnabledFeature && params
       ? shouldThrottle(
           retries,
-          typeof lastSeenAt === "number" ? new Date(lastSeenAt) : null,
+          lastSeenAtDate,
           params.modal.killThreshold,
           params.modal.cadenceDays,
           new Date(),
         )
       : false;
+  const hasReachedFrequencyCap =
+    hasEnabledFeature && params ? retries >= params.modal.killThreshold : false;
 
   const isEligible = Boolean(
     hasEnabledFeature && params && eligibility.isEligible && params.modal.enabled && !isThrottled,
@@ -73,14 +88,62 @@ export function useLargeScreenUpsellModalPortfolioMountViewModel(): LargeScreenU
   const shouldAttemptAutoOpen =
     isEligible && !hasSeenCompetingAppStartModalRef.current && !hasAutoOpenedThisSession;
 
-  const onClose = useCallback(() => {
-    setIsOpen(false);
-  }, []);
+  const variant: LargeScreenUpsellVariant = personalizedRecommendationsEnabled
+    ? "opted_in"
+    : "opted_out";
+
+  const sharedAnalyticsProps: LargeScreenUpsellSharedAnalyticsProps | null = useMemo(() => {
+    if (!("deviceModelId" in eligibility)) {
+      return null;
+    }
+
+    return {
+      deviceModel: toLargeScreenUpsellDeviceModelAnalyticsValue(eligibility.deviceModelId),
+      personalRecoOptIn: personalizedRecommendationsEnabled,
+      offerType: variant === "opted_in" ? "discount" : "none",
+      retriesUpsellModal: retries,
+      throttled: hasReachedFrequencyCap,
+    };
+  }, [eligibility, personalizedRecommendationsEnabled, variant, retries, hasReachedFrequencyCap]);
+
+  const getCurrentModalAnalyticsProps = useCallback(
+    () => currentModalAnalyticsPropsRef.current ?? sharedAnalyticsProps,
+    [sharedAnalyticsProps],
+  );
+
+  const onDismiss = useCallback(
+    (dismissMethod: LargeScreenUpsellDismissMethod) => {
+      if (hasHandledCurrentModalInteractionRef.current) {
+        setIsOpen(false);
+        return;
+      }
+
+      hasHandledCurrentModalInteractionRef.current = true;
+      const analyticsProps = getCurrentModalAnalyticsProps();
+      if (analyticsProps) {
+        trackLargeScreenUpsellModalDismissed(dismissMethod, analyticsProps);
+      }
+      currentModalAnalyticsPropsRef.current = null;
+      setIsOpen(false);
+    },
+    [getCurrentModalAnalyticsProps],
+  );
 
   const onCloseFromCta = useCallback(() => {
+    if (hasHandledCurrentModalInteractionRef.current) {
+      setIsOpen(false);
+      return;
+    }
+
+    hasHandledCurrentModalInteractionRef.current = true;
+    const analyticsProps = getCurrentModalAnalyticsProps();
+    if (analyticsProps) {
+      trackLargeScreenUpsellModalCtaClicked(analyticsProps);
+    }
+    currentModalAnalyticsPropsRef.current = null;
     dispatch(resetUpsellModalRetries());
     setIsOpen(false);
-  }, [dispatch]);
+  }, [dispatch, getCurrentModalAnalyticsProps]);
 
   useFocusEffect(
     useCallback(() => {
@@ -94,6 +157,11 @@ export function useLargeScreenUpsellModalPortfolioMountViewModel(): LargeScreenU
         }
 
         hasAutoOpenedThisSession = true;
+        hasHandledCurrentModalInteractionRef.current = false;
+        currentModalAnalyticsPropsRef.current = sharedAnalyticsProps;
+        if (currentModalAnalyticsPropsRef.current) {
+          trackLargeScreenUpsellModalViewed(currentModalAnalyticsPropsRef.current);
+        }
         dispatch(recordUpsellModalDisplay());
         setIsOpen(true);
       });
@@ -101,10 +169,9 @@ export function useLargeScreenUpsellModalPortfolioMountViewModel(): LargeScreenU
       return () => {
         cancelAnimationFrame(frame);
       };
-    }, [dispatch, shouldAttemptAutoOpen]),
+    }, [dispatch, shouldAttemptAutoOpen, sharedAnalyticsProps]),
   );
 
-  const variant: LargeScreenUpsellVariant = analyticsEnabled ? "opted_in" : "opted_out";
   const content = useMemo(
     () =>
       hasEnabledFeature && params
@@ -127,11 +194,11 @@ export function useLargeScreenUpsellModalPortfolioMountViewModel(): LargeScreenU
   return {
     isEligible,
     isOpen,
-    onClose,
+    onDismiss,
     featureIntroViewModel: {
       content,
       onPrimaryPress: onCloseFromCta,
-      onSecondaryPress: onClose,
+      onSecondaryPress: () => onDismiss("outside_tap"),
     },
     bottomInset: bottom + LARGE_SCREEN_UPSELL_MODAL_IOS_BOTTOM_PADDING,
   };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Large screen upsell modal analytics events on mobile
  - CTA and dismiss tracking from the app-start modal
  - Duplicate dismiss handling for bottom-sheet close signals

### 📝 Description

This PR adds the Touchscreen Upgrade Program tracking for the large screen upsell app-start modal on Ledger Wallet Mobile.

It introduces feature-local analytics helpers for the modal view, CTA click, and dismiss events, including shared tracking properties for the eligible Nano device model, personalized recommendations opt-in state, offer type, modal retry count, and throttling/frequency-cap state. It also hardens the bottom-sheet dismiss flow so CTA presses and duplicate close signals do not emit duplicate `modal_dismissed` events.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33155](https://ledgerhq.atlassian.net/browse/LIVE-33155)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33155]: https://ledgerhq.atlassian.net/browse/LIVE-33155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ