### PR TITLE
[LWM] fix(mobile): stabilize recover bottomsheet button tracking

### DIFF
--- a/.changeset/stable-recover-buttons.md
+++ b/.changeset/stable-recover-buttons.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Recover intro bottomsheet button tracking to use stable analytics identifiers.

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/__integrations__/RecoverIntroDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/__integrations__/RecoverIntroDrawer.integration.test.tsx
@@ -11,6 +11,8 @@ import { handleBackupHubDeeplink } from "~/navigation/deeplinks/handleBackupHubD
 import { RecoverIntroDrawer } from "../components/RecoverIntroDrawer";
 import {
   BACKUP_HUB_FEATURE_INTRO_PAGE,
+  BACKUP_HUB_FEATURE_INTRO_PRIMARY_BUTTON,
+  BACKUP_HUB_FEATURE_INTRO_SECONDARY_BUTTON,
   BACKUP_HUB_FEATURE_INTRO_SOURCE,
   resetBackupHubFeatureIntroViewTracking,
 } from "../analytics";
@@ -107,7 +109,7 @@ describe("RecoverIntroDrawer", () => {
     await user.press(await screen.findByText("Try 1 month free"));
 
     expect(track).toHaveBeenCalledWith("button_clicked", {
-      button: "Try 1 month free",
+      button: BACKUP_HUB_FEATURE_INTRO_PRIMARY_BUTTON,
       page: BACKUP_HUB_FEATURE_INTRO_PAGE,
       source: BACKUP_HUB_FEATURE_INTRO_SOURCE,
       link: "ledgerlive://recover/protect-prod?redirectTo=resumeActivate",
@@ -127,7 +129,7 @@ describe("RecoverIntroDrawer", () => {
     await user.press(await screen.findByText("Log in"));
 
     expect(track).toHaveBeenCalledWith("button_clicked", {
-      button: "Log in",
+      button: BACKUP_HUB_FEATURE_INTRO_SECONDARY_BUTTON,
       page: BACKUP_HUB_FEATURE_INTRO_PAGE,
       source: BACKUP_HUB_FEATURE_INTRO_SOURCE,
       link: "ledgerlive://recover/protect-prod?redirectTo=login",

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/analytics.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/analytics.ts
@@ -5,6 +5,10 @@ export const BACKUP_HUB_FEATURE_INTRO_PAGE = "Ledger Recover Bottomsheet";
 
 export const BACKUP_HUB_FEATURE_INTRO_SOURCE = BACKUP_HUB_TRACKING_PAGE_NAME;
 
+export const BACKUP_HUB_FEATURE_INTRO_PRIMARY_BUTTON = "Try 1 month free";
+
+export const BACKUP_HUB_FEATURE_INTRO_SECONDARY_BUTTON = "Log in";
+
 let hasTrackedBackupHubFeatureIntroView = false;
 
 export const resetBackupHubFeatureIntroViewTracking = () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/components/RecoverIntroDrawer/useRecoverIntroDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/components/RecoverIntroDrawer/useRecoverIntroDrawerViewModel.ts
@@ -16,6 +16,8 @@ import {
 } from "~/reducers/backupHubFeatureIntro";
 import type { FeatureIntroViewModel } from "LLM/components/FeatureIntroLayout/types";
 import {
+  BACKUP_HUB_FEATURE_INTRO_PRIMARY_BUTTON,
+  BACKUP_HUB_FEATURE_INTRO_SECONDARY_BUTTON,
   trackBackupHubFeatureIntroButtonClicked,
   trackBackupHubFeatureIntroDismissed,
   trackBackupHubFeatureIntroViewed,
@@ -99,17 +101,17 @@ export function useRecoverIntroDrawerViewModel(): UseRecoverIntroDrawerViewModel
 
   const onPrimaryPress = useCallback(() => {
     trackBackupHubFeatureIntroButtonClicked({
-      button: content.primaryButtonLabel,
+      button: BACKUP_HUB_FEATURE_INTRO_PRIMARY_BUTTON,
       link: content.primaryButtonLink,
     });
-  }, [content.primaryButtonLabel, content.primaryButtonLink]);
+  }, [content.primaryButtonLink]);
 
   const onSecondaryPress = useCallback(() => {
     trackBackupHubFeatureIntroButtonClicked({
-      button: content.secondaryButtonLabel,
+      button: BACKUP_HUB_FEATURE_INTRO_SECONDARY_BUTTON,
       link: content.secondaryButtonLink,
     });
-  }, [content.secondaryButtonLabel, content.secondaryButtonLink]);
+  }, [content.secondaryButtonLink]);
 
   const closeDrawer = useCallback(() => {
     if (hasClosedRef.current) {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Recover intro bottomsheet CTA click analytics
  - Backup Hub analytics payload consistency
  - No visual/UI behavior changes expected

### 📝 Description

The Recover intro bottomsheet was using the translated CTA labels as the `button` value in click analytics. That makes the analytics payload depend on visible copy and localization, so a copy update can unexpectedly change tracking values.

This PR moves those `button` values to stable Backup Hub analytics constants and keeps the translated labels only for the UI. The Recover intro integration test now asserts the stable constants for primary and secondary CTA tracking.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34061](https://ledgerhq.atlassian.net/browse/LIVE-34061)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34061]: https://ledgerhq.atlassian.net/browse/LIVE-34061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ