### PR TITLE
[LWDM] LLD Tezos Send Max from Staking Account shows max spendable = 0

### DIFF
--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
@@ -1224,6 +1224,37 @@ describe("validateIntent", () => {
       expect(result.amount).toBe(3_499_000n);
       expect(result.totalSpent).toBe(3_500_000n);
     });
+
+    it("resolves a positive send-max for a delegated account with staked funds (LIVE-28506)", async () => {
+      // Regression for LIVE-28506: a staking account (necessarily delegated, since you must
+      // delegate before staking) doing Send Max used to report max spendable = 0 — a soft
+      // "don't empty a delegated account" error short-circuited the amount computation. Send Max
+      // must now surface the liquid balance (total minus staked) minus fees, never 0.
+      mockGetAccountByAddress.mockResolvedValue(
+        makeUserAccount({
+          balance: 5_000_000,
+          stakedBalance: 3_000_000,
+          delegate: { alias: "baker", address: validRecipient, active: true },
+          delegationLevel: 1,
+        }),
+      );
+
+      const result = await validateIntent({
+        intentType: "transaction",
+        asset: { type: "native" },
+        type: "send",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount: 0n,
+        useAllAmount: true,
+      });
+
+      expect(result.errors).toEqual({});
+      expect(result.warnings).toEqual({});
+      // spendable = balance 5_000_000 - staked 3_000_000 = 2_000_000; minus fees 1_000
+      expect(result.amount).toBe(1_999_000n);
+      expect(result.totalSpent).toBe(2_000_000n);
+    });
   });
 
   describe("successful validation", () => {

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
@@ -1229,7 +1229,16 @@ describe("validateIntent", () => {
       // Regression for LIVE-28506: a staking account (necessarily delegated, since you must
       // delegate before staking) doing Send Max used to report max spendable = 0 — a soft
       // "don't empty a delegated account" error short-circuited the amount computation. Send Max
-      // must now surface the liquid balance (total minus staked) minus fees, never 0.
+      // must now surface the liquid balance (total minus staked) minus fees: a positive amount
+      // whenever that liquid balance exceeds fees (as it does here), instead of short-circuiting
+      // to 0. (It can still be 0 when fees exceed the liquid balance — not the case tested here.)
+      mockEstimateFees.mockResolvedValue({
+        fees: 1000n,
+        gasLimit: 10000n,
+        storageLimit: 0n,
+        estimatedFees: 1000n,
+        amount: 0n,
+      });
       mockGetAccountByAddress.mockResolvedValue(
         makeUserAccount({
           balance: 5_000_000,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

 This PR does not contain the fix for LIVE-28506 — the bug is already resolved on develop. This PR only closes a test-coverage gap so the scenario can't silently regress again.

 The root cause was eliminated by the coin-tezos migration to the TransactionIntent / generic-coin-framework, together with the staking-aware balance work (8992a18 — "exclude staked and pending-unstake funds from spendable"; 27a6979). In the current code:

- RecommendUndelegation is gone — it isn't even imported in validateIntent.ts anymore, and a send intent no longer produces a blocking constraint on Send Max.
- Send-max resolves via partitionNativeBalance(...).spendable → calculateNativeSendMaxAmountForUser, with a fallback to spendable − fees when fee estimation returns no amount, so the result is never spuriously 0.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 --> [LIVE-28506](https://ledgerhq.atlassian.net/browse/LIVE-28506)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
