### PR TITLE
[LWM] feat(LIVE-34174): aleo tokens support in mobile send flows

### DIFF
--- a/.changeset/early-windows-mix.md
+++ b/.changeset/early-windows-mix.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat: aleo tokens support in mobile send flows

--- a/apps/ledger-live-mobile/src/families/aleo/Send/BalanceSelectionScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/BalanceSelectionScreen.tsx
@@ -57,6 +57,7 @@ function buildTransaction({
   return bridge.updateTransaction(tx, {
     mode,
     recipient: isSelfTransfer ? mainAccount.freshAddress : "",
+    ...(account.type === "TokenAccount" && { subAccountId: account.id }),
   });
 }
 

--- a/apps/ledger-live-mobile/src/families/aleo/Send/SummaryToSection.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/SummaryToSection.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { StyleSheet, View } from "react-native";
-import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
+import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { isSelfTransferTransaction } from "@ledgerhq/live-common/families/aleo/utils";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
@@ -29,18 +29,21 @@ export function SummaryToSection({ transaction, currency, badge, account, parent
   const { t } = useTranslation();
   const allAccounts = useSelector(flattenAccountsSelector);
 
+  const accountCurrency = getAccountCurrency(account);
   const mainAccount = getMainAccount(account, parentAccount);
   const isSelfTransfer = transaction.family === "aleo" && isSelfTransferTransaction(transaction);
+  const isTokenAccount = account.type === "TokenAccount";
 
-  const recipientAccount = isSelfTransfer
-    ? (allAccounts.find(
+  const selfTransferAccount = isTokenAccount
+    ? account
+    : (allAccounts.find(
         a =>
           a.type === "Account" &&
           a.currency.id === currency.id &&
           a.freshAddress === transaction.recipient,
-      ) ?? mainAccount)
-    : undefined;
+      ) ?? mainAccount);
 
+  const recipientAccount = isSelfTransfer ? selfTransferAccount : undefined;
   const recipientAccountName = useMaybeAccountName(recipientAccount);
 
   return (
@@ -56,7 +59,7 @@ export function SummaryToSection({ transaction, currency, badge, account, parent
         isSelfTransfer && recipientAccountName ? (
           <View style={styles.row}>
             <View style={styles.iconWrapper}>
-              <CurrencyIcon size={14} currency={currency} />
+              <CurrencyIcon size={14} currency={accountCurrency} />
             </View>
             <LText numberOfLines={1} style={styles.text}>
               {recipientAccountName}

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/BalanceSelectionScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/BalanceSelectionScreen.test.tsx
@@ -76,6 +76,11 @@ describe("BalanceSelectionScreen", () => {
     parentAccount: ALEO_ACCOUNT_1,
     isSelfTransfer: false,
   });
+  const tokenSelfTransferRoute = makeRoute({
+    account: ALEO_TOKEN_ACCOUNT_1,
+    parentAccount: ALEO_ACCOUNT_1,
+    isSelfTransfer: true,
+  });
 
   beforeEach(() => {
     mockNavigation.navigate.mockClear();
@@ -133,6 +138,59 @@ describe("BalanceSelectionScreen", () => {
 
       expect(mockCreateTransaction).toHaveBeenCalledWith(ALEO_TOKEN_ACCOUNT_1);
       expect(mockCreateTransaction).not.toHaveBeenCalledWith(ALEO_ACCOUNT_1);
+      expect(mockNavigation.navigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        ScreenName.SendSelectRecipient,
+        expect.objectContaining({
+          transaction: expect.objectContaining({ subAccountId: ALEO_TOKEN_ACCOUNT_1.id }),
+        }),
+      );
+    });
+
+    it("navigates to SendSelectRecipient with subAccountId for token private send", async () => {
+      const { user } = render(
+        <BalanceSelectionScreen
+          navigation={mockNavigation as never}
+          route={tokenSendRoute as never}
+        />,
+      );
+
+      await user.press(screen.getByText("Private"));
+      await user.press(screen.getByText("Send privately"));
+
+      expect(mockNavigation.navigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        ScreenName.SendSelectRecipient,
+        expect.objectContaining({
+          transaction: expect.objectContaining({
+            mode: "transfer_token_private",
+            subAccountId: ALEO_TOKEN_ACCOUNT_1.id,
+          }),
+        }),
+      );
+    });
+
+    it("navigates to AleoMandatoryPrivateSync with subAccountId for token private self-transfer", async () => {
+      const { user } = render(
+        <BalanceSelectionScreen
+          navigation={mockNavigation as never}
+          route={tokenSelfTransferRoute as never}
+        />,
+      );
+
+      await user.press(screen.getByText("Private"));
+      await user.press(screen.getByText("Convert to public"));
+
+      expect(mockNavigation.navigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        ScreenName.AleoMandatoryPrivateSync,
+        expect.objectContaining({
+          transaction: expect.objectContaining({
+            mode: "convert_token_private_to_public",
+            subAccountId: ALEO_TOKEN_ACCOUNT_1.id,
+          }),
+        }),
+      );
     });
   });
 

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/SummaryToSection.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/SummaryToSection.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { Transaction } from "@ledgerhq/live-common/families/aleo/types";
 import { render, screen } from "@tests/test-renderer";
 import { SummaryToSection } from "../SummaryToSection";
-import { ALEO_ACCOUNT_1 } from "../../__mocks__/account.mock";
+import { ALEO_ACCOUNT_1, ALEO_TOKEN_ACCOUNT_1 } from "../../__mocks__/account.mock";
 
 const mockUseMaybeAccountName = jest.fn();
 
@@ -57,5 +57,27 @@ describe("SummaryToSection", () => {
     );
 
     expect(screen.getByText("My Aleo Account")).toBeOnTheScreen();
+  });
+
+  it("shows token account name for a token self-transfer, not the parent account name", () => {
+    mockUseMaybeAccountName.mockReturnValue("My USAD Token");
+
+    const transaction = {
+      family: "aleo",
+      mode: "convert_token_private_to_public",
+      recipient: ALEO_ACCOUNT_1.freshAddress,
+    } as Transaction;
+
+    render(
+      <SummaryToSection
+        transaction={transaction}
+        currency={currency}
+        account={ALEO_TOKEN_ACCOUNT_1}
+        parentAccount={ALEO_ACCOUNT_1}
+      />,
+    );
+
+    expect(mockUseMaybeAccountName).toHaveBeenCalledWith(ALEO_TOKEN_ACCOUNT_1);
+    expect(screen.getByText("My USAD Token")).toBeOnTheScreen();
   });
 });


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR extends the Aleo mobile send flow with token account support. `subAccountId` is now set on the transaction when sending from a TokenAccount, and the send summary correctly displays the token's currency icon and account name (instead of the parent account's) for token self-transfers.

| <img width="1206" height="2622" alt="tokens-1" src="https://github.com/user-attachments/assets/4b729c88-70cf-4f66-b92b-8ee636fa6b49" /> | <img width="1206" height="2622" alt="tokens-2" src="https://github.com/user-attachments/assets/61dfa83f-baf1-4dc6-ab11-59fcf14f365c" /> | <img width="1206" height="2622" alt="tokens-3" src="https://github.com/user-attachments/assets/9877b90a-0249-45d2-8f40-a04da299e513" /> |
|---|---|---|

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-34174
