### PR TITLE
[LWDM] feat(send): add TRON energy/bandwidth network-fees explanation to send flow

### DIFF
--- a/.changeset/tron-send-network-fees-explanation.md
+++ b/.changeset/tron-send-network-fees-explanation.md
@@ -4,4 +4,4 @@
 "live-mobile": patch
 ---
 
-Add a TRON send-flow network-fees explanation (tooltip on desktop, drawer on mobile) describing whether staked energy and bandwidth cover the transfer or the fee is paid by burning TRX, via a new family-agnostic `getNetworkFeesInfo` send-descriptor accessor. Other currencies are unchanged.
+Add a TRON send-flow network-fees explanation on the amount screen. The fee row now shows the cost in both fiat and TRX (e.g. `$4.12 • 0.000056 TRX`, or `$0 • 0 TRX` when staked energy and bandwidth cover the transfer), and an info tooltip (desktop) / drawer (mobile) explains whether resources cover the fee or it is paid by burning TRX. Implemented via two family-agnostic send-descriptor accessors (`getNetworkFeesInfo` for the copy, `showFeeCurrencyAmount` for the fee-row display). Other currencies are unchanged.

--- a/.changeset/tron-send-network-fees-explanation.md
+++ b/.changeset/tron-send-network-fees-explanation.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Add a TRON send-flow network-fees explanation (tooltip on desktop, drawer on mobile) describing whether staked energy and bandwidth cover the transfer or the fee is paid by burning TRX, via a new family-agnostic `getNetworkFeesInfo` send-descriptor accessor. Other currencies are unchanged.

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
@@ -26,6 +26,7 @@ jest.mock("@ledgerhq/live-common/bridge/descriptor/send/features", () => ({
     canEstimateFeePresetsWithZeroAmount: jest.fn(() => false),
     getFeePresetOptions: jest.fn(() => []),
     getFeeCurrencyAccountId: jest.fn(() => null),
+    showFeeCurrencyAmount: jest.fn(() => false),
   },
 }));
 jest.mock("@ledgerhq/live-countervalues-react", () => ({

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useNetworkFees.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useNetworkFees.ts
@@ -76,6 +76,8 @@ export function useNetworkFees({
   return useMemo(
     () => ({
       feesRowLabel: t("fees.networkFees"),
+      // A selected preset's fiat value takes precedence here. Coins using `showFeeCurrencyAmount`
+      // have no fee presets today, so this never drops the combined value; revisit if that changes.
       feesRowValue:
         core.selectedPresetFiatValue ??
         (core.displayFeesValue === "-" ? "--" : core.displayFeesValue),

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/NetworkFeesMenu.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/NetworkFeesMenu.tsx
@@ -68,7 +68,7 @@ export function NetworkFeesMenu({ display, selection, presets, actions }: Networ
   const { t } = useTranslation();
   const { state } = useSendFlowData();
   const { account, parentAccount } = state.account;
-  const { transaction } = state.transaction;
+  const { transaction, status } = state.transaction;
   const { currentStep } = useFlowWizard();
 
   const mainAccount = useMemo(
@@ -128,13 +128,19 @@ export function NetworkFeesMenu({ display, selection, presets, actions }: Networ
 
   const hasMenuOptions = hasPresets || hasCustom || hasCoinControl;
 
+  const networkFeesInfo = sendFeatures.getNetworkFeesInfo(currency, { transaction, status });
+
   const informationIcon = (
     <Tooltip>
       <TooltipTrigger asChild>
         <Information size={16} className="text-muted" />
       </TooltipTrigger>
       <TooltipContent>
-        <p>{t("newSendFlow.feesPaid")}</p>
+        <p>
+          {networkFeesInfo
+            ? t(`newSendFlow.${networkFeesInfo.translationKey}.description`, networkFeesInfo.values)
+            : t("newSendFlow.feesPaid")}
+        </p>
       </TooltipContent>
     </Tooltip>
   );

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -2596,6 +2596,14 @@
     "feesAmount": "Fees amount ({{unit}})",
     "gasLimit": "Gas limit ({{unit}})",
     "feesPaid": "Fees paid to the network to proceed your transaction",
+    "tronFees": {
+      "sufficient": {
+        "description": "You'll use {{energy}} energy and {{bandwidth}} bandwidth to pay for the network fees."
+      },
+      "insufficient": {
+        "description": "You don't have enough energy and bandwidth to cover this transfer. The shortfall will be covered by burning TRX."
+      }
+    },
     "insufficientBalanceFees": "Insufficient balance to cover the network fees",
     "amountToSend": "Amount to send in ({{currency}})",
     "coinToSend": "Coin to send",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4569,6 +4569,16 @@
       "feesAmount": "Fees amount ({{unit}})",
       "gasLimit": "Gas limit ({{unit}})",
       "feesPaid": "Fees paid to the network to proceed your transaction",
+      "tronFees": {
+        "sufficient": {
+          "title": "TRX network fees",
+          "description": "You'll use {{energy}} energy and {{bandwidth}} bandwidth to pay for the network fees."
+        },
+        "insufficient": {
+          "title": "Network fee breakdown",
+          "description": "You don't have enough energy and bandwidth to cover this transfer. The shortfall will be covered by burning TRX."
+        }
+      },
       "insufficientBalanceFees": "Insufficient balance to cover the network fees",
       "amountToSend": "Amount to send in ({{currency}})",
       "coinToSend": "Coin to send",

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/NetworkFeesRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/NetworkFeesRow.tsx
@@ -171,10 +171,22 @@ export function NetworkFeesRow({ viewModel }: NetworkFeesRowProps) {
 
       <BottomSheet ref={infoBottomSheetRef} snapPoints="small">
         <BottomSheetView>
-          <BottomSheetHeader title={viewModel.label} density="compact" />
+          <BottomSheetHeader
+            title={
+              viewModel.networkFeesInfo
+                ? t(`send.newSendFlow.${viewModel.networkFeesInfo.translationKey}.title`)
+                : viewModel.label
+            }
+            density="compact"
+          />
           <View style={styles.infoContent}>
             <Text typography="body2" lx={{ color: "muted" }} style={styles.infoDescription}>
-              {t("send.newSendFlow.feesPaid")}
+              {viewModel.networkFeesInfo
+                ? t(
+                    `send.newSendFlow.${viewModel.networkFeesInfo.translationKey}.description`,
+                    viewModel.networkFeesInfo.values,
+                  )
+                : t("send.newSendFlow.feesPaid")}
             </Text>
             <Button appearance="base" size="lg" onPress={handleCloseInfo}>
               {t("common.gotit")}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/NetworkFeesRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/NetworkFeesRow.tsx
@@ -158,12 +158,16 @@ export function NetworkFeesRow({ viewModel }: NetworkFeesRowProps) {
             <Text typography="body3" lx={{ color: "base" }}>
               {viewModel.value}
             </Text>
-            <Text typography="body3" lx={{ color: "muted" }}>
-              •
-            </Text>
-            <Text typography="body3" lx={{ color: "muted" }}>
-              {viewModel.strategyLabel}
-            </Text>
+            {viewModel.showFeeCurrencyAmount ? null : (
+              <>
+                <Text typography="body3" lx={{ color: "muted" }}>
+                  •
+                </Text>
+                <Text typography="body3" lx={{ color: "muted" }}>
+                  {viewModel.strategyLabel}
+                </Text>
+              </>
+            )}
           </View>
           {canOpenFeeSelector ? <ChevronDown size={16} /> : null}
         </Pressable>

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/NetworkFeesRow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/NetworkFeesRow.test.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { NetworkFeesRow } from "../NetworkFeesRow";
+import type { NetworkFeesViewModel } from "../../types";
+
+const dismiss = jest.fn();
+
+jest.mock("@ledgerhq/lumen-ui-rnative", () => {
+  const RN = jest.requireActual<typeof import("react-native")>("react-native");
+  return {
+    Text: ({ children }: { children: React.ReactNode }) => <RN.Text>{children}</RN.Text>,
+    Button: ({ children }: { children: React.ReactNode }) => <RN.Text>{children}</RN.Text>,
+    BottomSheet: ({ children }: { children: React.ReactNode }) => <RN.View>{children}</RN.View>,
+    BottomSheetView: ({ children }: { children: React.ReactNode }) => <RN.View>{children}</RN.View>,
+    BottomSheetHeader: ({ title }: { title: React.ReactNode }) => <RN.Text>{title}</RN.Text>,
+    Divider: () => null,
+    useBottomSheetRef: () => ({ current: { present: jest.fn(), dismiss } }),
+  };
+});
+jest.mock("@ledgerhq/lumen-ui-rnative/symbols", () => ({
+  Information: () => null,
+  ChevronDown: () => null,
+  Check: () => null,
+}));
+jest.mock("@ledgerhq/lumen-ui-rnative/styles", () => ({
+  useStyleSheet: (createStyles: (theme: { spacings: Record<string, number> }) => unknown) =>
+    createStyles({ spacings: { s4: 4, s8: 8, s10: 10, s12: 12, s16: 16, s24: 24 } }),
+}));
+jest.mock("~/context/Locale", () => ({
+  useTranslation: () => ({
+    t: (key: string, vals?: Record<string, string | number>) =>
+      vals ? `${key} ${JSON.stringify(vals)}` : key,
+  }),
+}));
+jest.mock("../../context/SendFlowContext", () => ({
+  useSendFlowData: () => ({ state: { account: { account: null, parentAccount: null } } }),
+}));
+jest.mock("~/analytics", () => ({ useAnalytics: () => ({ track: jest.fn() }) }));
+jest.mock("@ledgerhq/ledger-wallet-framework/tracking/send", () => ({
+  getSendFlowTrackingProperties: () => ({}),
+}));
+
+const baseViewModel: NetworkFeesViewModel = {
+  label: "Network fees",
+  value: "0 TRX",
+  strategyLabel: "",
+  showFeePresets: false,
+  selectedFeeStrategy: null,
+  feePresetLabelsOptions: [],
+  onSelectFeeStrategy: jest.fn(),
+  networkFeesInfo: null,
+};
+
+describe("NetworkFeesRow info drawer", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("renders the generic static copy when no currency-specific info is present", () => {
+    render(<NetworkFeesRow viewModel={baseViewModel} />);
+    expect(screen.getByText("send.newSendFlow.feesPaid")).toBeOnTheScreen();
+  });
+
+  it("renders the TRON sufficient title and body when the breakdown covers the fee", () => {
+    render(
+      <NetworkFeesRow
+        viewModel={{
+          ...baseViewModel,
+          networkFeesInfo: {
+            translationKey: "tronFees.sufficient",
+            values: { energy: "65000", bandwidth: "1500" },
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText("send.newSendFlow.tronFees.sufficient.title")).toBeOnTheScreen();
+    expect(
+      screen.getByText(/send\.newSendFlow\.tronFees\.sufficient\.description.*65000.*1500/),
+    ).toBeOnTheScreen();
+  });
+
+  it("renders the TRON insufficient breakdown title and burn-TRX body", () => {
+    render(
+      <NetworkFeesRow
+        viewModel={{
+          ...baseViewModel,
+          networkFeesInfo: {
+            translationKey: "tronFees.insufficient",
+            values: { energy: "0", bandwidth: "1500" },
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText("send.newSendFlow.tronFees.insufficient.title")).toBeOnTheScreen();
+    expect(
+      screen.getByText(/send\.newSendFlow\.tronFees\.insufficient\.description/),
+    ).toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/NetworkFeesRow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/NetworkFeesRow.test.tsx
@@ -44,12 +44,40 @@ const baseViewModel: NetworkFeesViewModel = {
   label: "Network fees",
   value: "0 TRX",
   strategyLabel: "",
+  showFeeCurrencyAmount: false,
   showFeePresets: false,
   selectedFeeStrategy: null,
   feePresetLabelsOptions: [],
   onSelectFeeStrategy: jest.fn(),
   networkFeesInfo: null,
 };
+
+describe("NetworkFeesRow fee value", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("shows the value followed by the strategy label by default", () => {
+    render(
+      <NetworkFeesRow viewModel={{ ...baseViewModel, value: "$0.12", strategyLabel: "Medium" }} />,
+    );
+    expect(screen.getByText("$0.12")).toBeOnTheScreen();
+    expect(screen.getByText("Medium")).toBeOnTheScreen();
+  });
+
+  it("shows the fiat • crypto value alone (no strategy label) when showFeeCurrencyAmount is set", () => {
+    render(
+      <NetworkFeesRow
+        viewModel={{
+          ...baseViewModel,
+          value: "$0.00 • 0 TRX",
+          strategyLabel: "Medium",
+          showFeeCurrencyAmount: true,
+        }}
+      />,
+    );
+    expect(screen.getByText("$0.00 • 0 TRX")).toBeOnTheScreen();
+    expect(screen.queryByText("Medium")).toBeNull();
+  });
+});
 
 describe("NetworkFeesRow info drawer", () => {
   beforeEach(() => jest.clearAllMocks());

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
@@ -2,6 +2,7 @@
 import { BigNumber } from "bignumber.js";
 import { act, renderHook } from "@testing-library/react-native";
 import { createMockAccount } from "../../screens/Recipient/hooks/__tests__/accounts";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { useNetworkFees } from "../useNetworkFees";
 import type { Account } from "@ledgerhq/types-live";
 import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
@@ -128,6 +129,49 @@ describe("useNetworkFees", () => {
       uiConfig: { hasCustomFees: false, hasCoinControl: false },
     });
     expect(result.current.feePresetLabelsOptions).toHaveLength(3);
+  });
+
+  it("exposes no networkFeesInfo for a non-TRON currency", () => {
+    const { result } = renderHook(() => useNetworkFees(buildParams()));
+    expect(result.current.networkFeesInfo).toBeNull();
+  });
+
+  it("exposes the TRON fee explanation derived from the status breakdown", () => {
+    const tron = getCryptoCurrencyById("tron");
+    const sufficient = renderHook(() =>
+      useNetworkFees(
+        buildParams({
+          account: { currency: tron },
+          transaction: { family: "tron" },
+          status: {
+            energyRequired: new BigNumber(0),
+            energyAvailable: new BigNumber(0),
+            bandwidthRequired: new BigNumber(270),
+            bandwidthAvailable: new BigNumber(1500),
+          },
+        }),
+      ),
+    );
+    expect(sufficient.result.current.networkFeesInfo?.translationKey).toBe("tronFees.sufficient");
+
+    const insufficient = renderHook(() =>
+      useNetworkFees(
+        buildParams({
+          account: { currency: tron },
+          transaction: { family: "tron" },
+          status: {
+            estimatedFees: new BigNumber(13_740_900),
+            energyRequired: new BigNumber(65000),
+            energyAvailable: new BigNumber(0),
+            bandwidthRequired: new BigNumber(270),
+            bandwidthAvailable: new BigNumber(1500),
+          },
+        }),
+      ),
+    );
+    expect(insufficient.result.current.networkFeesInfo?.translationKey).toBe(
+      "tronFees.insufficient",
+    );
   });
 
   it("maps fee preset options with translated labels and fiat values", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
@@ -113,6 +113,7 @@ describe("useNetworkFees", () => {
       onSelectFeeStrategy: jest.fn(),
       displayFeesValue: "-",
       showFeePresets: false,
+      showFeeCurrencyAmount: false,
     });
   });
 
@@ -194,6 +195,7 @@ describe("useNetworkFees", () => {
       onSelectFeeStrategy: jest.fn(),
       displayFeesValue: "$15.00 USD",
       showFeePresets: true,
+      showFeeCurrencyAmount: false,
     });
 
     const { result } = renderHook(() =>
@@ -226,6 +228,7 @@ describe("useNetworkFees", () => {
       onSelectFeeStrategy,
       displayFeesValue: "-",
       showFeePresets: false,
+      showFeeCurrencyAmount: false,
     });
 
     const { result } = renderHook(() => useNetworkFees(buildParams()));

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useNetworkFees.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useNetworkFees.ts
@@ -16,6 +16,7 @@ import { useMaybeAccountUnit } from "LLM/hooks/useAccountUnit";
 import { useCalculateCountervalueCallback } from "@ledgerhq/live-countervalues-react";
 import { asFeesStrategy } from "@ledgerhq/live-common/flows/send/utils/feesStrategy";
 import { useNetworkFeesCore } from "@ledgerhq/live-common/flows/send/hooks/useNetworkFeesCore";
+import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import type { NetworkFeesViewModel } from "../types";
 
 type UseNetworkFeesParams = Readonly<{
@@ -73,6 +74,11 @@ export function useNetworkFees({
     [t],
   );
 
+  const networkFeesInfo = useMemo(
+    () => sendFeatures.getNetworkFeesInfo(accountCurrency, { transaction, status }),
+    [accountCurrency, transaction, status],
+  );
+
   const feePresetOptionsMapped = useMemo(
     () =>
       core.feePresetOptions.map(opt => ({
@@ -99,6 +105,7 @@ export function useNetworkFees({
         hasCustomFees: uiConfig.hasCustomFees,
         hasCoinControl: uiConfig.hasCoinControl,
       },
+      networkFeesInfo,
     }),
     [
       core.displayFeesValue,
@@ -112,6 +119,7 @@ export function useNetworkFees({
       t,
       uiConfig.hasCoinControl,
       uiConfig.hasCustomFees,
+      networkFeesInfo,
     ],
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useNetworkFees.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useNetworkFees.ts
@@ -95,6 +95,7 @@ export function useNetworkFees({
       label: t("send.fees.title"),
       value: core.displayFeesValue,
       strategyLabel: getFeeStrategyLabel(core.selectedFeeStrategy),
+      showFeeCurrencyAmount: core.showFeeCurrencyAmount,
       showFeePresets: core.showFeePresets,
       selectedFeeStrategy: core.selectedFeeStrategy,
       feePresetLabelsOptions: feePresetOptionsMapped,
@@ -110,6 +111,7 @@ export function useNetworkFees({
     [
       core.displayFeesValue,
       core.selectedFeeStrategy,
+      core.showFeeCurrencyAmount,
       core.showFeePresets,
       core.onSelectFeeStrategy,
       feePresetOptionsMapped,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/types.ts
@@ -37,6 +37,8 @@ export type NetworkFeesViewModel = Readonly<{
   label: string;
   value: string;
   strategyLabel: string;
+  /** When true, `value` already includes the native fee-currency amount (with fiat when a rate exists); the row omits the strategy label. */
+  showFeeCurrencyAmount: boolean;
   showFeePresets: boolean;
   selectedFeeStrategy: string | null;
   feePresetLabelsOptions: FeePresetLabelOption[];

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/types.ts
@@ -1,6 +1,7 @@
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { ReactNativeFlowStepConfig, ReactNativeFlowConfig } from "../FlowWizard/types";
 import type { SendFlowStep } from "@ledgerhq/live-common/flows/send/types";
+import type { NetworkFeesInfo } from "@ledgerhq/live-common/bridge/descriptor/types";
 import { ScreenName } from "~/const";
 
 export type SendStepConfig = ReactNativeFlowStepConfig<SendFlowStep> &
@@ -46,4 +47,5 @@ export type NetworkFeesViewModel = Readonly<{
     hasCustomFees: boolean;
     hasCoinControl: boolean;
   }>;
+  networkFeesInfo: NetworkFeesInfo | null;
 }>;

--- a/libs/ledger-live-common/src/bridge/descriptor/send/features.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/send/features.ts
@@ -50,6 +50,7 @@ export const sendFeatures = {
   getCustomAssetsConfig: fromDescriptor(d => d.fees.customAssets, noFeeAssetsConfig),
   hasCoinControl: fromDescriptor(d => d.fees.hasCoinControl, false),
   getCoinControlConfig: fromDescriptor(d => d.fees.coinControl, noCoinControlConfig),
+  showFeeCurrencyAmount: fromDescriptor(d => d.fees.showFeeCurrencyAmount, false),
   getFeePresetOptions: (
     currency: CryptoOrTokenCurrency | undefined,
     transaction: unknown,

--- a/libs/ledger-live-common/src/bridge/descriptor/send/features.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/send/features.ts
@@ -7,6 +7,7 @@ import type {
   FeePresetOption,
   FeeUnitLabel,
   FlowEffect,
+  NetworkFeesInfo,
   SelfTransferPolicy,
   SendDescriptor,
 } from "../types";
@@ -94,6 +95,13 @@ export const sendFeatures = {
   ): string | null => {
     const d = getSendDescriptor(currency);
     return d?.fees.getFeeCurrencyAccountId?.(transaction) ?? null;
+  },
+  getNetworkFeesInfo: (
+    currency: CryptoOrTokenCurrency | undefined,
+    ctx: { transaction: unknown; status: unknown },
+  ): NetworkFeesInfo | null => {
+    const d = getSendDescriptor(currency);
+    return d?.fees.getNetworkFeesInfo?.(ctx) ?? null;
   },
   getMemoType: fromDescriptor(d => d.inputs.memo?.type, undefined),
   getMemoMaxLength: fromDescriptor(d => d.inputs.memo?.maxLength, undefined),

--- a/libs/ledger-live-common/src/bridge/descriptor/types.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/types.ts
@@ -209,6 +209,18 @@ export type CoinControlConfig = Readonly<{
 }>;
 
 /**
+ * Family-agnostic content for the network-fees info affordance (tooltip/drawer): an i18n key
+ * *suffix* (each app prepends its namespace + `.title`/`.description`) plus interpolation values,
+ * mirroring the `fees.${presetId}` pattern so coin logic stays out of the apps.
+ */
+export type NetworkFeesInfo = Readonly<{
+  /** i18n key suffix (e.g. `tronFees.sufficient`); the UI prefixes and suffixes it. */
+  translationKey: string;
+  /** Interpolation values for the resolved translations (e.g. energy/bandwidth amounts). */
+  values?: Record<string, string | number>;
+}>;
+
+/**
  * Fee input options
  */
 export type FeeDescriptor = {
@@ -268,6 +280,8 @@ export type FeeDescriptor = {
    * inspecting `transaction.family`.
    */
   getFeeCurrencyAccountId?: (transaction: unknown) => string | null;
+  /** Family-specific network-fees explanation derived from the tx status; `null` ⇒ generic copy. */
+  getNetworkFeesInfo?: (ctx: { transaction: unknown; status: unknown }) => NetworkFeesInfo | null;
 };
 
 /**

--- a/libs/ledger-live-common/src/bridge/descriptor/types.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/types.ts
@@ -210,13 +210,13 @@ export type CoinControlConfig = Readonly<{
 
 /**
  * Family-agnostic content for the network-fees info affordance (tooltip/drawer): an i18n key
- * *suffix* (each app prepends its namespace + `.title`/`.description`) plus interpolation values,
- * mirroring the `fees.${presetId}` pattern so coin logic stays out of the apps.
+ * *suffix* (each app prepends its namespace and appends `.title` and/or `.description`) plus
+ * interpolation values, mirroring the `fees.${presetId}` pattern so coin logic stays out of the apps.
  */
 export type NetworkFeesInfo = Readonly<{
-  /** i18n key suffix (e.g. `tronFees.sufficient`); the UI prefixes and suffixes it. */
+  /** i18n key suffix; the UI prepends its namespace and appends `.title` and/or `.description`. */
   translationKey: string;
-  /** Interpolation values for the resolved translations (e.g. energy/bandwidth amounts). */
+  /** Interpolation values for the resolved translations. */
   values?: Record<string, string | number>;
 }>;
 
@@ -228,6 +228,12 @@ export type FeeDescriptor = {
   hasCustom: boolean;
   hasCustomAssets?: boolean;
   hasCoinControl?: boolean;
+  /**
+   * Opt-in: also display the fee amount in its own fee currency (native) next to the fiat value on
+   * the Amount fee row, and render `0` explicitly instead of the `"-"` sentinel for a zero fee. Off
+   * by default (fiat value, with a native-amount fallback). Independent of `getNetworkFeesInfo`.
+   */
+  showFeeCurrencyAmount?: boolean;
   presets?: {
     /**
      * Optional UI legend for presets (ex: fee rate like `2 sat/vbyte`).

--- a/libs/ledger-live-common/src/families/tron/descriptor/index.test.ts
+++ b/libs/ledger-live-common/src/families/tron/descriptor/index.test.ts
@@ -17,6 +17,12 @@ const status = (fields: {
   bandwidthAvailable: new BigNumber(fields.bandwidthAvailable ?? 0),
 });
 
+describe("tron descriptor", () => {
+  it("opts into showing the fee-currency amount on the fee row", () => {
+    expect(descriptor.send.fees.showFeeCurrencyAmount).toBe(true);
+  });
+});
+
 describe("tron descriptor - getNetworkFeesInfo", () => {
   it("is exposed on the tron fee descriptor", () => {
     expect(typeof getNetworkFeesInfo).toBe("function");
@@ -84,5 +90,24 @@ describe("tron descriptor - getNetworkFeesInfo", () => {
   it("returns null when status is null/undefined", () => {
     expect(getNetworkFeesInfo?.({ transaction: {}, status: null })).toBeNull();
     expect(getNetworkFeesInfo?.({ transaction: {}, status: undefined })).toBeNull();
+  });
+
+  it("returns null when a breakdown field is non-finite (unknown, matches the fee row)", () => {
+    const info = getNetworkFeesInfo?.({
+      transaction: {},
+      status: status({ estimatedFees: NaN, energyRequired: 0, bandwidthRequired: 0 }),
+    });
+    expect(info).toBeNull();
+  });
+
+  it("returns null for a zero fee while the transaction has errors (unknown, not covered)", () => {
+    const info = getNetworkFeesInfo?.({
+      transaction: {},
+      status: {
+        ...status({ estimatedFees: 0, energyRequired: 0, bandwidthRequired: 0 }),
+        errors: { recipient: new Error("bad") },
+      },
+    });
+    expect(info).toBeNull();
   });
 });

--- a/libs/ledger-live-common/src/families/tron/descriptor/index.test.ts
+++ b/libs/ledger-live-common/src/families/tron/descriptor/index.test.ts
@@ -1,0 +1,88 @@
+import { BigNumber } from "bignumber.js";
+import { descriptor } from "./index";
+
+const getNetworkFeesInfo = descriptor.send.fees.getNetworkFeesInfo;
+
+const status = (fields: {
+  estimatedFees: number;
+  energyRequired: number;
+  bandwidthRequired: number;
+  energyAvailable?: number;
+  bandwidthAvailable?: number;
+}) => ({
+  estimatedFees: new BigNumber(fields.estimatedFees),
+  energyRequired: new BigNumber(fields.energyRequired),
+  bandwidthRequired: new BigNumber(fields.bandwidthRequired),
+  energyAvailable: new BigNumber(fields.energyAvailable ?? 0),
+  bandwidthAvailable: new BigNumber(fields.bandwidthAvailable ?? 0),
+});
+
+describe("tron descriptor - getNetworkFeesInfo", () => {
+  it("is exposed on the tron fee descriptor", () => {
+    expect(typeof getNetworkFeesInfo).toBe("function");
+  });
+
+  it("zero fee → sufficient, values are the amounts the transfer uses", () => {
+    const info = getNetworkFeesInfo?.({
+      transaction: {},
+      status: status({ estimatedFees: 0, energyRequired: 50_000, bandwidthRequired: 345 }),
+    });
+    expect(info).toEqual({
+      translationKey: "tronFees.sufficient",
+      values: { energy: "50000", bandwidth: "345" },
+    });
+  });
+
+  it("non-zero fee → insufficient", () => {
+    const info = getNetworkFeesInfo?.({
+      transaction: {},
+      status: status({ estimatedFees: 13_740_900, energyRequired: 65_000, bandwidthRequired: 345 }),
+    });
+    expect(info?.translationKey).toBe("tronFees.insufficient");
+  });
+
+  it("ample resources but a non-zero fee (inactive-recipient TRC20) → insufficient, not sufficient", () => {
+    const info = getNetworkFeesInfo?.({
+      transaction: {},
+      status: status({
+        estimatedFees: 13_740_900,
+        energyRequired: 50_000,
+        energyAvailable: 999_999,
+        bandwidthRequired: 345,
+        bandwidthAvailable: 999_999,
+      }),
+    });
+    expect(info?.translationKey).toBe("tronFees.insufficient");
+  });
+
+  it("native TRX / TRC10 covered (zero fee, zero energy) → sufficient", () => {
+    const info = getNetworkFeesInfo?.({
+      transaction: {},
+      status: status({ estimatedFees: 0, energyRequired: 0, bandwidthRequired: 270 }),
+    });
+    expect(info?.translationKey).toBe("tronFees.sufficient");
+    expect(info?.values).toEqual({ energy: "0", bandwidth: "270" });
+  });
+
+  it("native TRX / TRC10 with a bandwidth fee (non-zero) → insufficient", () => {
+    const info = getNetworkFeesInfo?.({
+      transaction: {},
+      status: status({ estimatedFees: 270_000, energyRequired: 0, bandwidthRequired: 270 }),
+    });
+    expect(info?.translationKey).toBe("tronFees.insufficient");
+  });
+
+  it("returns null when the TRON breakdown fields are absent", () => {
+    expect(
+      getNetworkFeesInfo?.({
+        transaction: {},
+        status: { errors: {}, warnings: {}, estimatedFees: new BigNumber(0) },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when status is null/undefined", () => {
+    expect(getNetworkFeesInfo?.({ transaction: {}, status: null })).toBeNull();
+    expect(getNetworkFeesInfo?.({ transaction: {}, status: undefined })).toBeNull();
+  });
+});

--- a/libs/ledger-live-common/src/families/tron/descriptor/index.ts
+++ b/libs/ledger-live-common/src/families/tron/descriptor/index.ts
@@ -1,10 +1,11 @@
-import BigNumber from "bignumber.js";
+import { BigNumber } from "bignumber.js";
 import type { CoinDescriptor, NetworkFeesInfo } from "../../../bridge/descriptor/types";
 
 type TronFeeStatus = {
   estimatedFees?: BigNumber;
   energyRequired?: BigNumber;
   bandwidthRequired?: BigNumber;
+  errors?: Record<string, unknown>;
 };
 
 // Variant keys off `estimatedFees` (the amount the fee row shows), never a resource comparison, so
@@ -17,15 +18,27 @@ function getNetworkFeesInfo({
   status: unknown;
 }): NetworkFeesInfo | null {
   const s = (status ?? {}) as TronFeeStatus;
+  // Require finite BigNumbers: a non-finite field is unknown, so return the generic copy to stay
+  // consistent with the fee row (which shows "-") and to avoid interpolating `NaN` into the text.
   if (
     !BigNumber.isBigNumber(s.estimatedFees) ||
     !BigNumber.isBigNumber(s.energyRequired) ||
-    !BigNumber.isBigNumber(s.bandwidthRequired)
+    !BigNumber.isBigNumber(s.bandwidthRequired) ||
+    !s.estimatedFees.isFinite() ||
+    !s.energyRequired.isFinite() ||
+    !s.bandwidthRequired.isFinite()
   ) {
     return null;
   }
 
   const covered = s.estimatedFees.isZero();
+
+  // While the transaction has errors, fee estimation may be skipped, leaving a defaulted 0 that is
+  // unknown rather than covered. Fall back to the generic copy so it matches the fee row (which
+  // shows "-" in this state) instead of asserting resources cover the fee.
+  if (covered && Object.keys(s.errors ?? {}).length > 0) {
+    return null;
+  }
 
   return {
     translationKey: covered ? "tronFees.sufficient" : "tronFees.insufficient",
@@ -42,6 +55,7 @@ export const descriptor: CoinDescriptor = {
     fees: {
       hasPresets: false,
       hasCustom: false,
+      showFeeCurrencyAmount: true,
       getNetworkFeesInfo,
     },
   },

--- a/libs/ledger-live-common/src/families/tron/descriptor/index.ts
+++ b/libs/ledger-live-common/src/families/tron/descriptor/index.ts
@@ -1,4 +1,40 @@
-import type { CoinDescriptor } from "../../../bridge/descriptor/types";
+import BigNumber from "bignumber.js";
+import type { CoinDescriptor, NetworkFeesInfo } from "../../../bridge/descriptor/types";
+
+type TronFeeStatus = {
+  estimatedFees?: BigNumber;
+  energyRequired?: BigNumber;
+  bandwidthRequired?: BigNumber;
+};
+
+// Variant keys off `estimatedFees` (the amount the fee row shows), never a resource comparison, so
+// the copy can't contradict the fee — notably inactive-recipient TRC20, which charges a flat fee
+// despite ample resources. `energyRequired`/`bandwidthRequired` are the amounts consumed (0 native/TRC10).
+function getNetworkFeesInfo({
+  status,
+}: {
+  transaction: unknown;
+  status: unknown;
+}): NetworkFeesInfo | null {
+  const s = (status ?? {}) as TronFeeStatus;
+  if (
+    !BigNumber.isBigNumber(s.estimatedFees) ||
+    !BigNumber.isBigNumber(s.energyRequired) ||
+    !BigNumber.isBigNumber(s.bandwidthRequired)
+  ) {
+    return null;
+  }
+
+  const covered = s.estimatedFees.isZero();
+
+  return {
+    translationKey: covered ? "tronFees.sufficient" : "tronFees.insufficient",
+    values: {
+      energy: s.energyRequired.toFixed(),
+      bandwidth: s.bandwidthRequired.toFixed(),
+    },
+  };
+}
 
 export const descriptor: CoinDescriptor = {
   send: {
@@ -6,6 +42,7 @@ export const descriptor: CoinDescriptor = {
     fees: {
       hasPresets: false,
       hasCustom: false,
+      getNetworkFeesInfo,
     },
   },
 };

--- a/libs/ledger-live-common/src/flows/send/hooks/__tests__/useNetworkFeesCore.test.ts
+++ b/libs/ledger-live-common/src/flows/send/hooks/__tests__/useNetworkFeesCore.test.ts
@@ -154,6 +154,45 @@ describe("useNetworkFeesCore", () => {
     expect(result.current.displayFeesValue).toBe("-");
   });
 
+  it("shows fiat • crypto (incl. a zero fee) when the coin opts into showFeeCurrencyAmount", () => {
+    mockedSendFeatures.showFeeCurrencyAmount.mockReturnValue(true);
+
+    const { result: nonZero } = renderCore();
+    expect(nonZero.current.showFeeCurrencyAmount).toBe(true);
+    expect(nonZero.current.displayFeesValue).toBe("FORMATTED_10 • FORMATTED_1000");
+
+    const { result: zero } = renderCore({ status: { estimatedFees: new BigNumber(0) } });
+    expect(zero.current.displayFeesValue).toBe("FORMATTED_0 • FORMATTED_0");
+  });
+
+  it("falls back to the default display for a zero fee while the transaction has errors", () => {
+    mockedSendFeatures.showFeeCurrencyAmount.mockReturnValue(true);
+
+    const { result } = renderCore({
+      status: { estimatedFees: new BigNumber(0), errors: { recipient: new Error("bad") } },
+    });
+
+    expect(result.current.displayFeesValue).toBe("-");
+  });
+
+  it("still shows the combined value for a known (non-zero) fee despite a transaction error", () => {
+    mockedSendFeatures.showFeeCurrencyAmount.mockReturnValue(true);
+
+    const { result } = renderCore({
+      status: { estimatedFees: new BigNumber(1_000), errors: { amount: new Error("too much") } },
+    });
+
+    expect(result.current.displayFeesValue).toBe("FORMATTED_10 • FORMATTED_1000");
+  });
+
+  it("falls back to the default display for a non-finite estimate", () => {
+    mockedSendFeatures.showFeeCurrencyAmount.mockReturnValue(true);
+
+    const { result } = renderCore({ status: { estimatedFees: new BigNumber(NaN) } });
+
+    expect(result.current.displayFeesValue).toBe("-");
+  });
+
   it("calls updateTransaction when selecting a fee strategy", () => {
     const { result } = renderCore();
 

--- a/libs/ledger-live-common/src/flows/send/hooks/useNetworkFeesCore.ts
+++ b/libs/ledger-live-common/src/flows/send/hooks/useNetworkFeesCore.ts
@@ -14,6 +14,7 @@ import type { SendFlowTransactionActions, SendFlowUiConfig } from "../types";
 import { buildFeePresetLegendMap, type FeePresetLegendMap } from "../utils/feePresetLegends";
 import { asFeesStrategy } from "../utils/feesStrategy";
 import {
+  formatCombinedFeesValue,
   formatDisplayFeesValue,
   getFeePresetEstimationConfig,
   getSelectedPresetFiatValue,
@@ -48,6 +49,7 @@ export type UseNetworkFeesCoreResult = Readonly<{
   displayFeesValue: string;
   formattedEstimatedFeesFiat: string | null;
   showFeePresets: boolean;
+  showFeeCurrencyAmount: boolean;
 }>;
 
 export function useNetworkFeesCore({
@@ -114,16 +116,24 @@ export function useNetworkFeesCore({
     () => calculateCountervalue(displayCurrency, estimatedFees),
     [calculateCountervalue, displayCurrency, estimatedFees],
   );
+  // Coin-declared opt-in: append the fee amount in its own currency next to fiat.
+  const showFeeCurrencyAmount = sendFeatures.showFeeCurrencyAmount(accountCurrency);
+  // A zero fee only means "covered" once fees are actually estimated. Estimation can be skipped
+  // while the transaction has errors, leaving a defaulted 0 — fall back to the default display so
+  // an unknown fee is not shown as a confirmed zero. A non-finite estimate is likewise unknown.
+  const hasErrors = Object.keys(status.errors ?? {}).length > 0;
+  const useCombinedFeesValue =
+    showFeeCurrencyAmount && estimatedFees.isFinite() && !(hasErrors && estimatedFees.lte(0));
   const { displayFeesValue, formattedEstimatedFeesFiat } = useMemo(
     () =>
-      formatDisplayFeesValue({
+      (useCombinedFeesValue ? formatCombinedFeesValue : formatDisplayFeesValue)({
         estimatedFees,
         estimatedFeesCountervalue,
         fiatUnit,
         displayUnit,
         locale,
       }),
-    [displayUnit, estimatedFees, estimatedFeesCountervalue, fiatUnit, locale],
+    [displayUnit, estimatedFees, estimatedFeesCountervalue, fiatUnit, locale, useCombinedFeesValue],
   );
 
   const updateTransactionWithPatch = useCallback(
@@ -155,5 +165,6 @@ export function useNetworkFeesCore({
     displayFeesValue,
     formattedEstimatedFeesFiat,
     showFeePresets: uiConfig.hasFeePresets,
+    showFeeCurrencyAmount,
   };
 }

--- a/libs/ledger-live-common/src/flows/send/utils/__tests__/networkFeesDisplay.realformat.test.ts
+++ b/libs/ledger-live-common/src/flows/send/utils/__tests__/networkFeesDisplay.realformat.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Uses the REAL `formatCurrencyUnit` (no mock) to lock the actually-rendered fee row strings.
+ * The sibling `networkFeesDisplay.test.ts` mocks the formatter and so cannot catch how zero and
+ * fractional amounts render — notably that a zero fee is `0 TRX` / `0 USD` (not `0.00`), which is
+ * the accepted format for the combined row.
+ */
+import { BigNumber } from "bignumber.js";
+import type { Unit } from "@ledgerhq/types-cryptoassets";
+import { formatCombinedFeesValue, formatDisplayFeesValue } from "../networkFeesDisplay";
+
+const trxUnit: Unit = { name: "TRX", code: "TRX", magnitude: 6 };
+const usdUnit: Unit = { name: "US Dollar", code: "USD", magnitude: 2 };
+
+// `formatCurrencyUnit` separates the amount and code with a non-breaking space; normalise it so the
+// assertions read naturally while still locking the amount precision and the " • " composition.
+const norm = (value: string) => value.replace(/[\u00A0\u202F\u2009]/g, " ");
+
+describe("networkFeesDisplay (real formatter)", () => {
+  it("formatCombinedFeesValue renders `<fiat> • <crypto>` with explicit zeros for a covered fee", () => {
+    const { displayFeesValue } = formatCombinedFeesValue({
+      estimatedFees: new BigNumber(0),
+      estimatedFeesCountervalue: null,
+      fiatUnit: usdUnit,
+      displayUnit: trxUnit,
+    });
+
+    expect(norm(displayFeesValue)).toBe("0 USD • 0 TRX");
+  });
+
+  it("formatCombinedFeesValue renders full native precision alongside fiat for a shortfall", () => {
+    const { displayFeesValue } = formatCombinedFeesValue({
+      estimatedFees: new BigNumber(56), // 0.000056 TRX
+      estimatedFeesCountervalue: new BigNumber(35), // 0.35 USD
+      fiatUnit: usdUnit,
+      displayUnit: trxUnit,
+    });
+
+    expect(norm(displayFeesValue)).toBe("0.35 USD • 0.000056 TRX");
+  });
+
+  it("formatDisplayFeesValue (default) is unchanged: `-` for zero, fiat when a rate exists", () => {
+    expect(
+      formatDisplayFeesValue({
+        estimatedFees: new BigNumber(0),
+        estimatedFeesCountervalue: null,
+        fiatUnit: usdUnit,
+        displayUnit: trxUnit,
+      }).displayFeesValue,
+    ).toBe("-");
+
+    expect(
+      norm(
+        formatDisplayFeesValue({
+          estimatedFees: new BigNumber(56),
+          estimatedFeesCountervalue: new BigNumber(35),
+          fiatUnit: usdUnit,
+          displayUnit: trxUnit,
+        }).displayFeesValue,
+      ),
+    ).toBe("0.35 USD");
+  });
+});

--- a/libs/ledger-live-common/src/flows/send/utils/__tests__/networkFeesDisplay.test.ts
+++ b/libs/ledger-live-common/src/flows/send/utils/__tests__/networkFeesDisplay.test.ts
@@ -3,6 +3,7 @@
  */
 import { BigNumber } from "bignumber.js";
 import {
+  formatCombinedFeesValue,
   formatDisplayFeesValue,
   getSelectedPresetFiatValue,
   resolveFeeDisplayContext,
@@ -73,6 +74,87 @@ describe("networkFeesDisplay", () => {
 
     expect(result.displayFeesValue).toBe("FMT_42");
     expect(result.formattedEstimatedFeesFiat).toBe("FMT_42");
+  });
+
+  it("formatDisplayFeesValue falls back to the crypto amount when no countervalue is available", () => {
+    const result = formatDisplayFeesValue({
+      estimatedFees: new BigNumber(1000),
+      estimatedFeesCountervalue: null,
+      fiatUnit: usdUnit,
+      displayUnit: btcUnit,
+    });
+
+    expect(result.displayFeesValue).toBe("FMT_1000");
+    expect(result.formattedEstimatedFeesFiat).toBeNull();
+  });
+
+  it("formatDisplayFeesValue returns '-' for a non-finite estimate (never renders NaN)", () => {
+    expect(
+      formatDisplayFeesValue({
+        estimatedFees: new BigNumber(NaN),
+        estimatedFeesCountervalue: null,
+        fiatUnit: usdUnit,
+        displayUnit: btcUnit,
+      }).displayFeesValue,
+    ).toBe("-");
+  });
+
+  it("formatCombinedFeesValue shows fiat • crypto and 0 (not '-') for a zero fee", () => {
+    const result = formatCombinedFeesValue({
+      estimatedFees: new BigNumber(0),
+      estimatedFeesCountervalue: null,
+      fiatUnit: usdUnit,
+      displayUnit: btcUnit,
+    });
+
+    expect(result.displayFeesValue).toBe("FMT_0 • FMT_0");
+    expect(result.formattedEstimatedFeesFiat).toBe("FMT_0");
+  });
+
+  it("formatCombinedFeesValue shows fiat • crypto for a non-zero fee with a countervalue", () => {
+    const result = formatCombinedFeesValue({
+      estimatedFees: new BigNumber(1000),
+      estimatedFeesCountervalue: new BigNumber(42),
+      fiatUnit: usdUnit,
+      displayUnit: btcUnit,
+    });
+
+    expect(result.displayFeesValue).toBe("FMT_42 • FMT_1000");
+    expect(result.formattedEstimatedFeesFiat).toBe("FMT_42");
+  });
+
+  it("formatCombinedFeesValue shows the crypto amount alone for a non-zero fee with no countervalue", () => {
+    const result = formatCombinedFeesValue({
+      estimatedFees: new BigNumber(1000),
+      estimatedFeesCountervalue: null,
+      fiatUnit: usdUnit,
+      displayUnit: btcUnit,
+    });
+
+    expect(result.displayFeesValue).toBe("FMT_1000");
+    expect(result.formattedEstimatedFeesFiat).toBeNull();
+  });
+
+  it("formatCombinedFeesValue clamps a negative/invalid estimate to zero", () => {
+    const result = formatCombinedFeesValue({
+      estimatedFees: new BigNumber(-5),
+      estimatedFeesCountervalue: new BigNumber(3),
+      fiatUnit: usdUnit,
+      displayUnit: btcUnit,
+    });
+
+    expect(result.displayFeesValue).toBe("FMT_0 • FMT_0");
+  });
+
+  it("formatCombinedFeesValue treats a non-finite estimate as zero (never renders NaN)", () => {
+    const result = formatCombinedFeesValue({
+      estimatedFees: new BigNumber(NaN),
+      estimatedFeesCountervalue: null,
+      fiatUnit: usdUnit,
+      displayUnit: btcUnit,
+    });
+
+    expect(result.displayFeesValue).toBe("FMT_0 • FMT_0");
   });
 
   it("getSelectedPresetFiatValue ignores custom strategy", () => {

--- a/libs/ledger-live-common/src/flows/send/utils/networkFeesDisplay.ts
+++ b/libs/ledger-live-common/src/flows/send/utils/networkFeesDisplay.ts
@@ -30,42 +30,70 @@ export function resolveFeeDisplayContext(params: {
   };
 }
 
-export function formatDisplayFeesValue(params: {
+function formatFeeAmount(unit: Unit, amount: BigNumber, locale?: string): string {
+  return formatCurrencyUnit(unit, amount, {
+    showCode: true,
+    disableRounding: true,
+    ...(locale ? { locale } : {}),
+  });
+}
+
+export type FormatFeesValueParams = Readonly<{
   estimatedFees: BigNumber;
   estimatedFeesCountervalue: BigNumber | null | undefined;
   fiatUnit: Unit;
   displayUnit: Unit;
   locale?: string;
-}): Readonly<{
+}>;
+
+export type FormattedFeesValue = Readonly<{
   displayFeesValue: string;
   formattedEstimatedFeesFiat: string | null;
-}> {
-  const formatOptions = {
-    showCode: true,
-    disableRounding: true,
-    ...(params.locale ? { locale: params.locale } : {}),
-  };
+}>;
 
-  if (params.estimatedFees.lte(0)) {
+/**
+ * Default fee row value: fiat when a positive countervalue exists, native amount otherwise, `"-"`
+ * when the fee is not a positive finite value (zero, negative, or non-finite).
+ */
+export function formatDisplayFeesValue(params: FormatFeesValueParams): FormattedFeesValue {
+  if (!params.estimatedFees.isFinite() || params.estimatedFees.lte(0)) {
     return { displayFeesValue: "-", formattedEstimatedFeesFiat: null };
   }
 
   const fiatAmount = new BigNumber(params.estimatedFeesCountervalue ?? 0);
   if (fiatAmount.gt(0)) {
-    const formattedEstimatedFeesFiat = formatCurrencyUnit(
-      params.fiatUnit,
-      fiatAmount,
-      formatOptions,
-    );
+    const formattedEstimatedFeesFiat = formatFeeAmount(params.fiatUnit, fiatAmount, params.locale);
     return { displayFeesValue: formattedEstimatedFeesFiat, formattedEstimatedFeesFiat };
   }
 
-  const displayFeesValue = formatCurrencyUnit(
-    params.displayUnit,
-    params.estimatedFees,
-    formatOptions,
-  );
+  const displayFeesValue = formatFeeAmount(params.displayUnit, params.estimatedFees, params.locale);
   return { displayFeesValue, formattedEstimatedFeesFiat: null };
+}
+
+/**
+ * Fee row value for coins that opt into `FeeDescriptor.showFeeCurrencyAmount`: the native fee-currency
+ * amount shown next to the fiat value (`<fiat> • <amount> <code>`). Fiat is prepended when the fee is
+ * zero (0 fiat is accurate) or a positive countervalue exists; with no rate for a non-zero fee the
+ * native amount is shown alone rather than implying a zero fiat rate. A non-finite/negative estimate
+ * is treated as zero.
+ */
+export function formatCombinedFeesValue(params: FormatFeesValueParams): FormattedFeesValue {
+  const isZeroFee = !params.estimatedFees.isFinite() || params.estimatedFees.lte(0);
+  const cryptoAmount = isZeroFee ? new BigNumber(0) : params.estimatedFees;
+  const crypto = formatFeeAmount(params.displayUnit, cryptoAmount, params.locale);
+
+  const fiatAmount = isZeroFee
+    ? new BigNumber(0)
+    : new BigNumber(params.estimatedFeesCountervalue ?? 0);
+  if (isZeroFee || fiatAmount.gt(0)) {
+    const formattedEstimatedFeesFiat = formatFeeAmount(params.fiatUnit, fiatAmount, params.locale);
+    return {
+      displayFeesValue: `${formattedEstimatedFeesFiat} • ${crypto}`,
+      formattedEstimatedFeesFiat,
+    };
+  }
+
+  return { displayFeesValue: crypto, formattedEstimatedFeesFiat: null };
 }
 
 export function getSelectedPresetFiatValue(


### PR DESCRIPTION
### 📝 Description

TRON's send flow showed the network fee as fiat only, with no indication that staked energy/bandwidth cover the cost — accurate but confusing. This implements LIVE-33341 on the Amount screen for both Desktop (LWD) and Mobile (LWM):

**Fee row value** — shows the cost in both fiat and TRX, adapting to the resource state:
- **Covered** (resources pay the fee): `$0 • 0 TRX`
- **Shortfall** (TRX burned): `$4.12 • 0.000056 TRX`

**Info affordance** — a tooltip (Desktop) / bottom drawer (Mobile) opened from the fee info icon:
- **Covered:** "You'll use {energy} energy and {bandwidth} bandwidth to pay for the network fees." (drawer title "TRX network fees")
- **Shortfall:** "You don't have enough energy and bandwidth to cover this transfer. The shortfall will be covered by burning TRX." (drawer title "Network fee breakdown")

Both are derived from `status.estimatedFees` — the exact amount the fee row displays — plus the energy/bandwidth `TransactionStatus` fields added in #19404, so the copy can never contradict the shown fee (native/TRC10, account-activation, inactive-recipient and simulation-failure paths included).

**Design** — two shared, family-agnostic send-descriptor accessors (exposed via `sendFeatures`), not a TRON fork of the fee row:
- `getNetworkFeesInfo` — the tooltip/drawer copy (i18n key suffix + interpolation values).
- `showFeeCurrencyAmount` — opt-in flag to render the fee amount in its own currency next to fiat (and show `0` explicitly instead of the `-` sentinel).

Both default off; only TRON opts in, so every other currency keeps the existing generic behaviour. When a fee is not yet estimated (e.g. a validation error), the row keeps the neutral `-` rather than a misleading `$0 • 0 TRX`. English i18n keys are added (other locales fall back to English).

**Tests** — descriptor state matrix (incl. the inactive-recipient consistency case and the opt-in flag), the shared `formatCombinedFeesValue` (covered / shortfall / no-rate / negative / non-finite), an un-mocked real-format test locking the actual rendered strings, the core hook's formatter selection (incl. the error-state fallback), and the Mobile hook + drawer/row rendering. Desktop renders the same shared value and is covered by the existing send-flow integration test.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-33341](https://ledgerhq.atlassian.net/browse/LIVE-33341)
- **ADR** (if any): —


[LIVE-33341]: https://ledgerhq.atlassian.net/browse/LIVE-33341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
