### PR TITLE
ci(allure): send git branch with qaa-allure upload

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -1115,7 +1115,8 @@ jobs:
           api_key: ${{ secrets.QAA_ALLURE_API_KEY }}
           path: ios-test-artifacts
           name: "mobile-e2e-ios-${{ github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual') }}-#${{ github.run_id }}"
-          tags: ${{ format('["mobile","ios",{0},{1}]', toJSON(github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual')), toJSON(inputs.ref || github.ref_name)) }}
+          tags: ${{ format('["mobile","ios",{0}]', toJSON(github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual'))) }}
+          branch: ${{ inputs.ref || github.ref_name }}
 
   qaa-allure-upload-android:
     name: "QAA Allure Upload - Android (Experimental)"
@@ -1137,7 +1138,8 @@ jobs:
           api_key: ${{ secrets.QAA_ALLURE_API_KEY }}
           path: android-test-artifacts
           name: "mobile-e2e-android-${{ github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual') }}-#${{ github.run_id }}"
-          tags: ${{ format('["mobile","android",{0},{1}]', toJSON(github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual')), toJSON(inputs.ref || github.ref_name)) }}
+          tags: ${{ format('["mobile","android",{0}]', toJSON(github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual'))) }}
+          branch: ${{ inputs.ref || github.ref_name }}
 
   upload-to-xray:
     name: "Test Mobile E2E > XRAY Report"

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -505,7 +505,8 @@ jobs:
           api_key: ${{ secrets.QAA_ALLURE_API_KEY }}
           path: ${{ env.ALLURE_RESULTS }}
           name: "desktop-e2e-${{ needs.prepare-devices.outputs.device_1 }}-${{ github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual') }}-#${{ github.run_id }}"
-          tags: ${{ format('["desktop","speculos",{0},{1},{2}]', toJSON(needs.prepare-devices.outputs.device_1), toJSON(github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual')), toJSON(inputs.ref || github.ref_name)) }}
+          tags: ${{ format('["desktop","speculos",{0},{1}]', toJSON(needs.prepare-devices.outputs.device_1), toJSON(github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual'))) }}
+          branch: ${{ inputs.ref || github.ref_name }}
 
   qaa-allure-upload-device2:
     name: "QAA Allure Upload - device 2 (Experimental)"
@@ -529,7 +530,8 @@ jobs:
           api_key: ${{ secrets.QAA_ALLURE_API_KEY }}
           path: ${{ env.ALLURE_RESULTS }}
           name: "desktop-e2e-${{ needs.prepare-devices.outputs.device_2 }}-${{ github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual') }}-#${{ github.run_id }}"
-          tags: ${{ format('["desktop","speculos",{0},{1},{2}]', toJSON(needs.prepare-devices.outputs.device_2), toJSON(github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual')), toJSON(inputs.ref || github.ref_name)) }}
+          tags: ${{ format('["desktop","speculos",{0},{1}]', toJSON(needs.prepare-devices.outputs.device_2), toJSON(github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual'))) }}
+          branch: ${{ inputs.ref || github.ref_name }}
 
   upload-to-xray:
     name: "Upload to Xray"

--- a/tools/actions/composites/upload-allure-report-qaa/action.yml
+++ b/tools/actions/composites/upload-allure-report-qaa/action.yml
@@ -22,6 +22,10 @@ inputs:
     required: false
     default: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
     description: "URL pointing back to the CI run that produced this report. Pass empty string to disable."
+  branch:
+    required: false
+    default: ""
+    description: "Git branch the run came from, shown/filterable on the portal."
 outputs:
   report_id:
     description: "ID of the uploaded report."
@@ -46,4 +50,5 @@ runs:
         QAA_ALLURE_TAGS: ${{ inputs.tags }}
         QAA_ALLURE_HISTORY: ${{ inputs.history_level }}
         QAA_ALLURE_JOB_URL: ${{ inputs.job_url }}
+        QAA_ALLURE_BRANCH: ${{ inputs.branch }}
       run: ${{ github.action_path }}/upload.sh

--- a/tools/actions/composites/upload-allure-report-qaa/upload.sh
+++ b/tools/actions/composites/upload-allure-report-qaa/upload.sh
@@ -16,6 +16,8 @@
 #   QAA_ALLURE_HISTORY  — historyLevel, 1–200 (default: 50)
 #   QAA_ALLURE_JOB_URL  — when set, sent as multipart `jobUrl` so the portal can
 #                         deep-link back to the CI run that produced the report
+#   QAA_ALLURE_BRANCH   — when set, sent as multipart `branch` so the portal can
+#                         show/filter which git branch the run came from
 #   GITHUB_OUTPUT       — when set, writes report_id / report_url / view_url
 #
 # Exits 0 with a warning when the API key is empty or the path has no files,
@@ -30,6 +32,7 @@ QAA_ALLURE_HOST="${QAA_ALLURE_HOST:-https://allure-new.aws.sbx.ldg-tech.com}"
 QAA_ALLURE_TAGS="${QAA_ALLURE_TAGS:-}"
 QAA_ALLURE_HISTORY="${QAA_ALLURE_HISTORY:-50}"
 QAA_ALLURE_JOB_URL="${QAA_ALLURE_JOB_URL:-}"
+QAA_ALLURE_BRANCH="${QAA_ALLURE_BRANCH:-}"
 
 warn() { echo "::warning title=qaa-allure::$*"; }
 fail() { echo "::error title=qaa-allure::$*"; exit 1; }
@@ -93,6 +96,9 @@ if [ -n "${QAA_ALLURE_TAGS}" ]; then
 fi
 if [ -n "${QAA_ALLURE_JOB_URL}" ]; then
   curl_args+=(--form-string "jobUrl=${QAA_ALLURE_JOB_URL}")
+fi
+if [ -n "${QAA_ALLURE_BRANCH}" ]; then
+  curl_args+=(--form-string "branch=${QAA_ALLURE_BRANCH}")
 fi
 
 # Capture body + exit code separately so we can log the body when curl fails


### PR DESCRIPTION
### 📝 Description

The qaa-allure report server now accepts an optional `branch` form field on its
upload endpoint (`POST /api/v1/reports`, multipart/form-data). Sending it makes
the dashboard surface which git branch a run came from (Branch column, filter,
and a suffix in the report header). It's optional and backward-compatible.

This PR wires that field through the existing `upload-allure-report-qaa` composite:

- Added an optional `branch` input to the composite → `QAA_ALLURE_BRANCH` env →
  `--form-string "branch=…"` in `upload.sh`. It's only sent when non-empty, so
  the upload stays backward-compatible with the current server.
- Passed `inputs.ref || github.ref_name` — the ref actually checked out and
  tested — from the desktop + mobile E2E upload steps. (These workflows are
  `schedule`/`workflow_dispatch`/`workflow_call` only, never `pull_request`, so
  `github.head_ref` would always be empty; `inputs.ref || github.ref_name` is the
  same expression already used for the run-name and concurrency group.)
- Dropped the now-redundant branch entry from `tags`, since the dedicated
  `branch` field is the canonical place for it.

<img width="3018" height="1266" alt="Kapture 2026-07-13 at 09 31 38" src="https://github.com/user-attachments/assets/fe30a933-2b2f-4974-b69a-3a2119ee4d0c" />


### ✅ CI runs (manual E2E validating the branch upload)

[- `@Mobile E2E • Manual • iOS & Android • support/qaa-allure-branch-field • cunhabruno`
](https://github.com/LedgerHQ/ledger-live/actions/runs/29234263610)
[@Desktop E2E • triggered on support/qaa-allure-branch-field by cunhabruno](https://github.com/LedgerHQ/ledger-live/actions/runs/29234242690)
### 🔗 Context

- **JIRA / GitHub issue**: N/A — experimental qaa-allure tooling
- **ADR** (if any): N/A
