### PR TITLE
[LWDM] Warn and explain when staking is blocked by an unfinalizable unstake to another validator

### DIFF
--- a/.changeset/gentle-falcons-return.md
+++ b/.changeset/gentle-falcons-return.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-tezos": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Warn and explain when Tezos staking is blocked by an unfinalizable unstake to another validator: translate the raw fee-estimation error into a clear message, and show an inline warning on the change-validator summary while a pending unstake is still unfinalizable

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepSummary.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepSummary.test.tsx
@@ -4,9 +4,8 @@ import { render, screen } from "tests/testSetup";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import StepSummary from "./StepSummary";
 
-const mockStakingInfo: { unstakedBalance: BigNumber; delegateAddress: string | undefined } = {
-  unstakedBalance: new BigNumber(0),
-  delegateAddress: undefined,
+const mockStakingInfo: { unstakingPositions: { uid: string; delegate?: string }[] } = {
+  unstakingPositions: [],
 };
 
 jest.mock("@ledgerhq/live-common/families/tezos/react", () => ({
@@ -14,6 +13,7 @@ jest.mock("@ledgerhq/live-common/families/tezos/react", () => ({
   useDelegation: () => null,
   useStakingPositions: () => [],
   useBaker: () => null,
+  isUnstakingPosition: (uid: string) => uid.startsWith("unstaking-"),
 }));
 
 jest.mock("~/renderer/hooks/useAccountUnit", () => ({
@@ -46,28 +46,30 @@ const makeProps = ({ recipient = "tz1NEW", mode = "delegate" } = {}) =>
 
 describe("Tezos delegate StepSummary — pending-unstake warning", () => {
   beforeEach(() => {
-    mockStakingInfo.unstakedBalance = new BigNumber(0);
-    mockStakingInfo.delegateAddress = undefined;
+    mockStakingInfo.unstakingPositions = [];
   });
 
-  it("warns when a pending unstake exists and a different validator is selected", () => {
-    mockStakingInfo.unstakedBalance = new BigNumber(5);
-    mockStakingInfo.delegateAddress = "tz1OLD";
+  it("warns when an unfinalizable unstake to a different validator is pending", () => {
+    mockStakingInfo.unstakingPositions = [{ uid: "unstaking-1", delegate: "tz1OLD" }];
     render(<StepSummary {...makeProps({ recipient: "tz1NEW" })} />);
-    expect(screen.getByTestId("tezos-pending-unstake-warning")).toBeInTheDocument();
+    expect(screen.getByTestId("tezos-pending-unstake-warning")).toBeVisible();
   });
 
   it("does not warn without a pending unstake", () => {
-    mockStakingInfo.unstakedBalance = new BigNumber(0);
-    mockStakingInfo.delegateAddress = "tz1OLD";
+    mockStakingInfo.unstakingPositions = [];
     render(<StepSummary {...makeProps({ recipient: "tz1NEW" })} />);
     expect(screen.queryByTestId("tezos-pending-unstake-warning")).not.toBeInTheDocument();
   });
 
-  it("does not warn when the selected validator is unchanged", () => {
-    mockStakingInfo.unstakedBalance = new BigNumber(5);
-    mockStakingInfo.delegateAddress = "tz1SAME";
+  it("does not warn when the selected validator matches the pending unstake's delegate", () => {
+    mockStakingInfo.unstakingPositions = [{ uid: "unstaking-1", delegate: "tz1SAME" }];
     render(<StepSummary {...makeProps({ recipient: "tz1SAME" })} />);
+    expect(screen.queryByTestId("tezos-pending-unstake-warning")).not.toBeInTheDocument();
+  });
+
+  it("does not warn when the unstake is already finalizable", () => {
+    mockStakingInfo.unstakingPositions = [{ uid: "finalizable-1", delegate: "tz1OLD" }];
+    render(<StepSummary {...makeProps({ recipient: "tz1NEW" })} />);
     expect(screen.queryByTestId("tezos-pending-unstake-warning")).not.toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepSummary.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepSummary.test.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { render, screen } from "tests/testSetup";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import StepSummary from "./StepSummary";
+
+const mockStakingInfo: { unstakedBalance: BigNumber; delegateAddress: string | undefined } = {
+  unstakedBalance: new BigNumber(0),
+  delegateAddress: undefined,
+};
+
+jest.mock("@ledgerhq/live-common/families/tezos/react", () => ({
+  useTezosStakingInfo: () => mockStakingInfo,
+  useDelegation: () => null,
+  useStakingPositions: () => [],
+  useBaker: () => null,
+}));
+
+jest.mock("~/renderer/hooks/useAccountUnit", () => ({
+  useAccountUnit: () => ({ code: "XTZ", name: "tez", magnitude: 6 }),
+}));
+
+// Analytics reads broad store state we don't seed; irrelevant to the warning.
+jest.mock("~/renderer/analytics/TrackPage", () => () => null);
+
+// Body layout is irrelevant to the footer warning under test.
+jest.mock("../DelegationContainer", () => () => null);
+jest.mock("../../BakerImage", () => () => null);
+
+const currency = getCryptoCurrencyById("tezos");
+
+const makeProps = ({ recipient = "tz1NEW", mode = "delegate" } = {}) =>
+  ({
+    account: {
+      type: "Account",
+      id: "js:2:tezos:tz1acc:",
+      currency,
+      balance: new BigNumber(100),
+      spendableBalance: new BigNumber(100),
+    },
+    transaction: { family: "tezos", mode, recipient },
+    status: { errors: {}, warnings: {} },
+    transitionTo: jest.fn(),
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  }) as unknown as React.ComponentProps<typeof StepSummary>;
+
+describe("Tezos delegate StepSummary — pending-unstake warning", () => {
+  beforeEach(() => {
+    mockStakingInfo.unstakedBalance = new BigNumber(0);
+    mockStakingInfo.delegateAddress = undefined;
+  });
+
+  it("warns when a pending unstake exists and a different validator is selected", () => {
+    mockStakingInfo.unstakedBalance = new BigNumber(5);
+    mockStakingInfo.delegateAddress = "tz1OLD";
+    render(<StepSummary {...makeProps({ recipient: "tz1NEW" })} />);
+    expect(screen.getByTestId("tezos-pending-unstake-warning")).toBeInTheDocument();
+  });
+
+  it("does not warn without a pending unstake", () => {
+    mockStakingInfo.unstakedBalance = new BigNumber(0);
+    mockStakingInfo.delegateAddress = "tz1OLD";
+    render(<StepSummary {...makeProps({ recipient: "tz1NEW" })} />);
+    expect(screen.queryByTestId("tezos-pending-unstake-warning")).not.toBeInTheDocument();
+  });
+
+  it("does not warn when the selected validator is unchanged", () => {
+    mockStakingInfo.unstakedBalance = new BigNumber(5);
+    mockStakingInfo.delegateAddress = "tz1SAME";
+    render(<StepSummary {...makeProps({ recipient: "tz1SAME" })} />);
+    expect(screen.queryByTestId("tezos-pending-unstake-warning")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepSummary.tsx
@@ -214,7 +214,7 @@ const StepSummary = ({ account, transaction, eventType, transitionTo, status }: 
       {transaction.mode === "delegate" && (
         <Box mt={32}>
           {hasPendingUnstakeToOtherBaker && (
-            <Alert type="warning" mb={4}>
+            <Alert type="warning" mb={4} data-testid="tezos-pending-unstake-warning">
               <Trans i18nKey="tezos.delegation.pendingUnstakeWarning" />
             </Alert>
           )}

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepSummary.tsx
@@ -6,6 +6,7 @@ import {
   useBaker,
   useDelegation,
   useStakingPositions,
+  useTezosStakingInfo,
 } from "@ledgerhq/live-common/families/tezos/react";
 import { Baker } from "@ledgerhq/live-common/families/tezos/types";
 import { Trans } from "react-i18next";
@@ -19,6 +20,7 @@ import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
 import Button from "~/renderer/components/Button";
 import Ellipsis from "~/renderer/components/Ellipsis";
 import WarnBox from "~/renderer/components/WarnBox";
+import Alert from "~/renderer/components/Alert";
 import TranslatedError from "~/renderer/components/TranslatedError";
 import InfoCircle from "~/renderer/icons/InfoCircle";
 import BakerImage from "../../BakerImage";
@@ -60,6 +62,7 @@ const StepSummary = ({ account, transaction, eventType, transitionTo, status }: 
   const accountName = useAccountName(account);
   const delegation = useDelegation(account);
   const stakingPositions = useStakingPositions(account);
+  const { unstakedBalance, delegateAddress } = useTezosStakingInfo(account);
   const baker = useBaker(transaction.recipient);
   const currency = getAccountCurrency(account);
   const unit = useAccountUnit(account);
@@ -67,6 +70,11 @@ const StepSummary = ({ account, transaction, eventType, transitionTo, status }: 
     baker ? baker.name : fallback;
 
   const isDelegation = delegation || stakingPositions.length > 0;
+
+  // Changing validator while an unfinalizable unstake to the current one is pending blocks staking
+  // with the new validator until that unstake finalizes (~4 days).
+  const hasPendingUnstakeToOtherBaker =
+    unstakedBalance.gt(0) && !!transaction.recipient && transaction.recipient !== delegateAddress;
 
   return (
     <Box flow={4} mx={40}>
@@ -205,6 +213,11 @@ const StepSummary = ({ account, transaction, eventType, transitionTo, status }: 
       />
       {transaction.mode === "delegate" && (
         <Box mt={32}>
+          {hasPendingUnstakeToOtherBaker && (
+            <Alert type="warning" mb={4}>
+              <Trans i18nKey="tezos.delegation.pendingUnstakeWarning" />
+            </Alert>
+          )}
           <WarnBox>
             <Trans i18nKey="delegation.flow.steps.summary.termsAndPrivacy" />
           </WarnBox>

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepSummary.tsx
@@ -7,6 +7,7 @@ import {
   useDelegation,
   useStakingPositions,
   useTezosStakingInfo,
+  isUnstakingPosition,
 } from "@ledgerhq/live-common/families/tezos/react";
 import { Baker } from "@ledgerhq/live-common/families/tezos/types";
 import { Trans } from "react-i18next";
@@ -62,7 +63,7 @@ const StepSummary = ({ account, transaction, eventType, transitionTo, status }: 
   const accountName = useAccountName(account);
   const delegation = useDelegation(account);
   const stakingPositions = useStakingPositions(account);
-  const { unstakedBalance, delegateAddress } = useTezosStakingInfo(account);
+  const { unstakingPositions } = useTezosStakingInfo(account);
   const baker = useBaker(transaction.recipient);
   const currency = getAccountCurrency(account);
   const unit = useAccountUnit(account);
@@ -71,10 +72,13 @@ const StepSummary = ({ account, transaction, eventType, transitionTo, status }: 
 
   const isDelegation = delegation || stakingPositions.length > 0;
 
-  // Changing validator while an unfinalizable unstake to the current one is pending blocks staking
-  // with the new validator until that unstake finalizes (~4 days).
+  // Staking with the newly selected validator is blocked by the protocol while an unfinalizable
+  // unstake to a different validator is still pending; warn before the user commits to the change.
   const hasPendingUnstakeToOtherBaker =
-    unstakedBalance.gt(0) && !!transaction.recipient && transaction.recipient !== delegateAddress;
+    !!transaction.recipient &&
+    unstakingPositions.some(
+      p => isUnstakingPosition(p.uid) && !!p.delegate && p.delegate !== transaction.recipient,
+    );
 
   return (
     <Box flow={4} mx={40}>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4888,7 +4888,8 @@
     "delegation": {
       "contextMenu": {
         "stake": "Stake your XTZ"
-      }
+      },
+      "pendingUnstakeWarning": "You can change validator now, but you won't be able to stake with the new one until your pending unstake from your current validator finalizes, in ~4 days."
     },
     "staking": {
       "header": "Staking",
@@ -7345,6 +7346,9 @@
     },
     "TezosNotEnoughStaked": {
       "title": "Insufficient staked balance"
+    },
+    "TezosStakeBlockedByPendingUnstake": {
+      "title": "Unstaking from your previous validator must finish first"
     },
     "RecommendSubAccountsToEmpty": {
       "title": "Please empty all subaccounts first"

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4889,7 +4889,7 @@
       "contextMenu": {
         "stake": "Stake your XTZ"
       },
-      "pendingUnstakeWarning": "You can change validator now, but you won't be able to stake with the new one until your pending unstake from your current validator finalizes, in ~4 days."
+      "pendingUnstakeWarning": "You can change validator now, but you won't be able to stake with the new one until your pending unstake from your current validator finalizes in ~4 days."
     },
     "staking": {
       "header": "Staking",

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
@@ -16,6 +16,7 @@ import {
   useBaker,
   useBakers,
   useStakingPositions,
+  useTezosStakingInfo,
 } from "@ledgerhq/live-common/families/tezos/react";
 import { whitelist } from "@ledgerhq/live-common/families/tezos/staking";
 import type { AccountLike } from "@ledgerhq/types-live";
@@ -165,6 +166,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
 
   const delegation = useDelegation(account);
   const stakingPositions = useStakingPositions(account);
+  const { unstakedBalance, delegateAddress } = useTezosStakingInfo(account);
   const addr =
     transaction.mode === "undelegate"
       ? delegation?.address || stakingPositions[0]?.delegate || ""
@@ -191,6 +193,14 @@ export default function DelegationSummary({ navigation, route }: Props) {
   const notEnoughBalance = status.errors.amount instanceof NotEnoughBalanceToDelegate;
   const isUndelagating = route.params?.mode === "undelegate";
   const hasNotEnoughBalanceWhenUndelegating = notEnoughBalance && isUndelagating;
+
+  // Changing validator while an unfinalizable unstake to the current one is pending blocks staking
+  // with the new validator until that unstake finalizes (~4 days).
+  const hasPendingUnstakeToOtherBaker =
+    transaction.mode === "delegate" &&
+    unstakedBalance.gt(0) &&
+    !!transaction.recipient &&
+    transaction.recipient !== delegateAddress;
 
   return (
     <SafeAreaView style={[styles.root, { backgroundColor: colors.background }]}>
@@ -313,6 +323,8 @@ export default function DelegationSummary({ navigation, route }: Props) {
         {hasNotEnoughBalanceWhenUndelegating && <NotEnoughFundFeesAlert account={account} />}
         {transaction.mode === "undelegate" ? (
           <Alert type="info" title={t("delegation.warnUndelegation")} />
+        ) : hasPendingUnstakeToOtherBaker ? (
+          <Alert type="warning" title={t("tezos.delegation.pendingUnstakeWarning")} />
         ) : (
           <Alert type="info" title={t("delegation.warnDelegation")} />
         )}

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
@@ -17,6 +17,7 @@ import {
   useBakers,
   useStakingPositions,
   useTezosStakingInfo,
+  isUnstakingPosition,
 } from "@ledgerhq/live-common/families/tezos/react";
 import { whitelist } from "@ledgerhq/live-common/families/tezos/staking";
 import type { AccountLike } from "@ledgerhq/types-live";
@@ -166,7 +167,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
 
   const delegation = useDelegation(account);
   const stakingPositions = useStakingPositions(account);
-  const { unstakedBalance, delegateAddress } = useTezosStakingInfo(account);
+  const { unstakingPositions } = useTezosStakingInfo(account);
   const addr =
     transaction.mode === "undelegate"
       ? delegation?.address || stakingPositions[0]?.delegate || ""
@@ -194,13 +195,14 @@ export default function DelegationSummary({ navigation, route }: Props) {
   const isUndelagating = route.params?.mode === "undelegate";
   const hasNotEnoughBalanceWhenUndelegating = notEnoughBalance && isUndelagating;
 
-  // Changing validator while an unfinalizable unstake to the current one is pending blocks staking
-  // with the new validator until that unstake finalizes (~4 days).
+  // Staking with the newly selected validator is blocked by the protocol while an unfinalizable
+  // unstake to a different validator is still pending; warn before the user commits to the change.
   const hasPendingUnstakeToOtherBaker =
     transaction.mode === "delegate" &&
-    unstakedBalance.gt(0) &&
     !!transaction.recipient &&
-    transaction.recipient !== delegateAddress;
+    unstakingPositions.some(
+      p => isUnstakingPosition(p.uid) && !!p.delegate && p.delegate !== transaction.recipient,
+    );
 
   return (
     <SafeAreaView style={[styles.root, { backgroundColor: colors.background }]}>

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/__tests__/Summary.test.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/__tests__/Summary.test.tsx
@@ -16,7 +16,7 @@ const mockAccount = {
 } as unknown as AccountLike;
 
 let mockTransaction: Record<string, unknown>;
-let mockStakingInfo: { unstakedBalance: BigNumber; delegateAddress: string | undefined };
+let mockStakingInfo: { unstakingPositions: { uid: string; delegate?: string }[] };
 const mockStatus = { errors: {}, warnings: {} };
 
 jest.mock("@react-navigation/native", () => ({
@@ -48,6 +48,7 @@ jest.mock("@ledgerhq/live-common/families/tezos/react", () => ({
   useStakingPositions: () => [],
   useBaker: () => null,
   useBakers: () => [],
+  isUnstakingPosition: (uid: string) => uid.startsWith("unstaking-"),
 }));
 
 jest.mock("@ledgerhq/live-common/families/tezos/staking", () => ({ whitelist: [] }));
@@ -91,14 +92,6 @@ jest.mock("~/logic/screenTransactionHooks", () => ({
 
 jest.mock("~/analytics", () => ({ TrackScreen: () => null }));
 
-jest.mock("react-native-safe-area-context", () => {
-  const { View } = jest.requireActual("react-native");
-  return {
-    SafeAreaView: ({ children }: { children?: React.ReactNode }) => <View>{children}</View>,
-    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
-  };
-});
-
 // Body/footer siblings irrelevant to the warning under test (mocked via ~/ paths = same modules).
 jest.mock("~/families/tezos/DelegatingContainer", () => () => null);
 jest.mock("~/families/tezos/BakerImage", () => () => null);
@@ -137,24 +130,30 @@ const makeProps = () =>
 describe("Tezos DelegationSummary — pending-unstake warning", () => {
   beforeEach(() => {
     mockTransaction = { family: "tezos", mode: "delegate", recipient: "tz1NEW" };
-    mockStakingInfo = { unstakedBalance: new BigNumber(0), delegateAddress: undefined };
+    mockStakingInfo = { unstakingPositions: [] };
   });
 
-  it("warns when a pending unstake exists and a different validator is selected", () => {
-    mockStakingInfo = { unstakedBalance: new BigNumber(5), delegateAddress: "tz1OLD" };
+  it("warns when an unfinalizable unstake to a different validator is pending", () => {
+    mockStakingInfo = { unstakingPositions: [{ uid: "unstaking-1", delegate: "tz1OLD" }] };
     render(<DelegationSummary {...makeProps()} />);
-    expect(screen.getByText(WARNING_KEY)).toBeTruthy();
+    expect(screen.getByText(WARNING_KEY)).toBeVisible();
   });
 
   it("does not warn without a pending unstake", () => {
-    mockStakingInfo = { unstakedBalance: new BigNumber(0), delegateAddress: "tz1OLD" };
+    mockStakingInfo = { unstakingPositions: [] };
     render(<DelegationSummary {...makeProps()} />);
     expect(screen.queryByText(WARNING_KEY)).toBeNull();
   });
 
-  it("does not warn when the selected validator is unchanged", () => {
+  it("does not warn when the selected validator matches the pending unstake's delegate", () => {
     mockTransaction = { family: "tezos", mode: "delegate", recipient: "tz1SAME" };
-    mockStakingInfo = { unstakedBalance: new BigNumber(5), delegateAddress: "tz1SAME" };
+    mockStakingInfo = { unstakingPositions: [{ uid: "unstaking-1", delegate: "tz1SAME" }] };
+    render(<DelegationSummary {...makeProps()} />);
+    expect(screen.queryByText(WARNING_KEY)).toBeNull();
+  });
+
+  it("does not warn when the unstake is already finalizable", () => {
+    mockStakingInfo = { unstakingPositions: [{ uid: "finalizable-1", delegate: "tz1OLD" }] };
     render(<DelegationSummary {...makeProps()} />);
     expect(screen.queryByText(WARNING_KEY)).toBeNull();
   });

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/__tests__/Summary.test.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/__tests__/Summary.test.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { render, screen } from "@tests/test-renderer";
+import type { AccountLike } from "@ledgerhq/types-live";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import DelegationSummary from "../Summary";
+import { ScreenName } from "~/const";
+
+const mockAccount = {
+  type: "Account",
+  id: "tezos-acc-1",
+  currency: getCryptoCurrencyById("tezos"),
+  balance: new BigNumber(100),
+  spendableBalance: new BigNumber(100),
+  operations: [],
+} as unknown as AccountLike;
+
+let mockTransaction: Record<string, unknown>;
+let mockStakingInfo: { unstakedBalance: BigNumber; delegateAddress: string | undefined };
+const mockStatus = { errors: {}, warnings: {} };
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useTheme: () => ({ colors: { background: "#000", live: "#0f0", grey: "#888", white: "#fff" } }),
+}));
+
+jest.mock("~/context/Locale", () => {
+  const { Text } = jest.requireActual("react-native");
+  return {
+    useTranslation: () => ({ t: (key: string) => key }),
+    Trans: ({ i18nKey }: { i18nKey: string }) => <Text>{i18nKey}</Text>,
+  };
+});
+
+// native-ui Alert renders its `title`; we assert on that. Icons.PenEdit is used in the summary body.
+jest.mock("@ledgerhq/native-ui", () => {
+  const { Text } = jest.requireActual("react-native");
+  return {
+    __esModule: true,
+    Alert: ({ title }: { title?: React.ReactNode }) => <Text>{title}</Text>,
+    Icons: { PenEdit: () => null },
+  };
+});
+
+jest.mock("@ledgerhq/live-common/families/tezos/react", () => ({
+  useTezosStakingInfo: () => mockStakingInfo,
+  useDelegation: () => null,
+  useStakingPositions: () => [],
+  useBaker: () => null,
+  useBakers: () => [],
+}));
+
+jest.mock("@ledgerhq/live-common/families/tezos/staking", () => ({ whitelist: [] }));
+
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: () => ({
+    updateTransaction: (t: Record<string, unknown>, patch: Record<string, unknown>) => ({
+      ...t,
+      ...patch,
+    }),
+  }),
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/useBridgeTransaction", () => ({
+  __esModule: true,
+  default: () => ({
+    transaction: mockTransaction,
+    setTransaction: jest.fn(),
+    status: mockStatus,
+    bridgePending: false,
+    bridgeError: null,
+  }),
+}));
+
+jest.mock("LLM/hooks/useAccountScreen", () => ({
+  useAccountScreen: () => ({ account: mockAccount, parentAccount: undefined }),
+}));
+
+jest.mock("LLM/hooks/useAccountUnit", () => ({
+  useAccountUnit: () => ({ code: "XTZ", name: "tez", magnitude: 6 }),
+}));
+
+jest.mock("~/reducers/wallet", () => ({
+  ...jest.requireActual("~/reducers/wallet"),
+  useAccountName: () => "My Tezos Account",
+}));
+
+jest.mock("~/logic/screenTransactionHooks", () => ({
+  useTransactionChangeFromNavigation: () => {},
+}));
+
+jest.mock("~/analytics", () => ({ TrackScreen: () => null }));
+
+jest.mock("react-native-safe-area-context", () => {
+  const { View } = jest.requireActual("react-native");
+  return {
+    SafeAreaView: ({ children }: { children?: React.ReactNode }) => <View>{children}</View>,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+// Body/footer siblings irrelevant to the warning under test (mocked via ~/ paths = same modules).
+jest.mock("~/families/tezos/DelegatingContainer", () => () => null);
+jest.mock("~/families/tezos/BakerImage", () => () => null);
+jest.mock("~/families/shared/StakingErrors/NotEnoughFundFeesAlert", () => () => null);
+jest.mock("~/families/shared/useChangeValidatorRotateAnim", () => ({
+  useChangeValidatorRotateAnim: () => ({ rotate: 0, resetRotation: jest.fn() }),
+}));
+jest.mock("~/components/TranslatedError", () => () => null);
+jest.mock("~/components/SupportLinkError", () => () => null);
+jest.mock("~/components/Button", () => () => null);
+// Decorative body components (rendered only inside the nulled DelegatingContainer) that pull
+// heavy native-ui chains; stub them so the module graph stays light.
+jest.mock("~/components/CurrencyIcon", () => () => null);
+jest.mock("~/components/CurrencyUnitValue", () => () => null);
+jest.mock("~/components/Circle", () => () => null);
+jest.mock("~/components/LText", () => {
+  const { Text } = jest.requireActual("react-native");
+  return ({ children }: { children?: React.ReactNode }) => <Text>{children}</Text>;
+});
+jest.mock("~/components/Touchable", () => {
+  const { TouchableOpacity } = jest.requireActual("react-native");
+  return ({ children, onPress }: { children?: React.ReactNode; onPress?: () => void }) => (
+    <TouchableOpacity onPress={onPress}>{children}</TouchableOpacity>
+  );
+});
+
+const WARNING_KEY = "tezos.delegation.pendingUnstakeWarning";
+
+const makeProps = () =>
+  ({
+    navigation: { navigate: jest.fn() },
+    route: { key: "k", name: ScreenName.DelegationSummary, params: { accountId: "tezos-acc-1" } },
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  }) as unknown as React.ComponentProps<typeof DelegationSummary>;
+
+describe("Tezos DelegationSummary — pending-unstake warning", () => {
+  beforeEach(() => {
+    mockTransaction = { family: "tezos", mode: "delegate", recipient: "tz1NEW" };
+    mockStakingInfo = { unstakedBalance: new BigNumber(0), delegateAddress: undefined };
+  });
+
+  it("warns when a pending unstake exists and a different validator is selected", () => {
+    mockStakingInfo = { unstakedBalance: new BigNumber(5), delegateAddress: "tz1OLD" };
+    render(<DelegationSummary {...makeProps()} />);
+    expect(screen.getByText(WARNING_KEY)).toBeTruthy();
+  });
+
+  it("does not warn without a pending unstake", () => {
+    mockStakingInfo = { unstakedBalance: new BigNumber(0), delegateAddress: "tz1OLD" };
+    render(<DelegationSummary {...makeProps()} />);
+    expect(screen.queryByText(WARNING_KEY)).toBeNull();
+  });
+
+  it("does not warn when the selected validator is unchanged", () => {
+    mockTransaction = { family: "tezos", mode: "delegate", recipient: "tz1SAME" };
+    mockStakingInfo = { unstakedBalance: new BigNumber(5), delegateAddress: "tz1SAME" };
+    render(<DelegationSummary {...makeProps()} />);
+    expect(screen.queryByText(WARNING_KEY)).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -6770,7 +6770,7 @@
     "delegation": {
       "addCustomValidator": "+ Add custom validator",
       "sectionLabel": "Delegation",
-      "pendingUnstakeWarning": "You can change validator now, but you won't be able to stake with the new one until your pending unstake from your current validator finalizes, in ~4 days."
+      "pendingUnstakeWarning": "You can change validator now, but you won't be able to stake with the new one until your pending unstake from your current validator finalizes in ~4 days."
     },
     "staking": {
       "sectionLabel": "Staking",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -913,6 +913,9 @@
     "TezosNotEnoughStaked": {
       "title": "Insufficient staked balance"
     },
+    "TezosStakeBlockedByPendingUnstake": {
+      "title": "Unstaking from your previous validator must finish first"
+    },
     "RecommendSubAccountsToEmpty": {
       "title": "Please empty all subaccounts first"
     },
@@ -6766,7 +6769,8 @@
     },
     "delegation": {
       "addCustomValidator": "+ Add custom validator",
-      "sectionLabel": "Delegation"
+      "sectionLabel": "Delegation",
+      "pendingUnstakeWarning": "You can change validator now, but you won't be able to stake with the new one until your pending unstake from your current validator finalizes, in ~4 days."
     },
     "staking": {
       "sectionLabel": "Staking",

--- a/libs/coin-modules/coin-tezos/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.test.ts
@@ -547,6 +547,31 @@ describe("estimateFees", () => {
     });
   });
 
+  it("should not throw for cannot_stake_with_unfinalizable_unstake errors", async () => {
+    logicEstimateFees.mockResolvedValue({
+      estimatedFees: DEFAULT_ESTIMATED_FEES,
+      gasLimit: DEFAULT_GAS_LIMIT,
+      storageLimit: DEFAULT_STORAGE_LIMIT,
+      taquitoError:
+        "proto.alpha.cannot_stake_with_unfinalizable_unstake_requests_to_another_delegate",
+    });
+    const result = await api.estimateFees({
+      intentType: "staking",
+      type: "stake",
+      sender: "tz1test",
+      recipient: "tz1validator",
+      amount: 1000n,
+    } as TransactionIntent);
+
+    expect(result).toEqual({
+      value: DEFAULT_ESTIMATED_FEES,
+      parameters: {
+        gasLimit: DEFAULT_GAS_LIMIT,
+        storageLimit: DEFAULT_STORAGE_LIMIT,
+      },
+    });
+  });
+
   it("returns total estimation for unrevealed delegate when minFees applied (composite)", async () => {
     const unrevealedSender = "tz2TaTpo31sAiX2HBJUTLLdUnqVJR4QjLy1V";
     (networkApi.getAccountByAddress as jest.Mock).mockResolvedValueOnce({

--- a/libs/coin-modules/coin-tezos/src/api/index.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.ts
@@ -287,7 +287,10 @@ async function estimate(transactionIntent: TransactionIntent): Promise<TezosFeeE
       !estimation.taquitoError.includes("delegate.unchanged") &&
       !estimation.taquitoError.includes("subtraction_underflow") &&
       !estimation.taquitoError.includes("balance_too_low") &&
-      !estimation.taquitoError.includes("script_rejected")
+      !estimation.taquitoError.includes("script_rejected") &&
+      !estimation.taquitoError.includes(
+        "cannot_stake_with_unfinalizable_unstake_requests_to_another_delegate",
+      )
     ) {
       throw new Error(`Fees estimation failed: ${estimation.taquitoError}`);
     }

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
@@ -12,6 +12,7 @@ import {
   InvalidAddressBecauseAlreadyDelegated,
   MustDelegateBeforeStaking,
   TezosNotEnoughStaked,
+  TezosStakeBlockedByPendingUnstake,
 } from "../types/errors";
 import { STAKE_USE_ALL_RESERVE_MUTEZ } from "../utils";
 import { validateIntent } from "./validateIntent";
@@ -951,6 +952,34 @@ describe("validateIntent", () => {
       });
 
       expect(result.errors.amount).toBeInstanceOf(MustDelegateBeforeStaking);
+    });
+
+    it("maps cannot_stake_with_unfinalizable_unstake_requests_to_another_delegate to TezosStakeBlockedByPendingUnstake for stake", async () => {
+      mockGetAccountByAddress.mockResolvedValue(
+        makeUserAccount({
+          delegate: { alias: "baker", address: validRecipient, active: true },
+          delegationLevel: 1,
+        }),
+      );
+      mockEstimateFees.mockResolvedValue({
+        fees: 0n,
+        gasLimit: 0n,
+        storageLimit: 0n,
+        estimatedFees: 500n,
+        taquitoError:
+          "proto.alpha.cannot_stake_with_unfinalizable_unstake_requests_to_another_delegate",
+      });
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "stake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 1000n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(TezosStakeBlockedByPendingUnstake);
     });
 
     it("maps unknown taquito errors to a generic Error on amount", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
@@ -980,6 +980,7 @@ describe("validateIntent", () => {
       });
 
       expect(result.errors.amount).toBeInstanceOf(TezosStakeBlockedByPendingUnstake);
+      expect(result.errors.amount?.name).toBe("TezosStakeBlockedByPendingUnstake");
     });
 
     it("maps unknown taquito errors to a generic Error on amount", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
@@ -17,6 +17,7 @@ import {
   InvalidAddressBecauseAlreadyDelegated,
   MustDelegateBeforeStaking,
   TezosNotEnoughStaked,
+  TezosStakeBlockedByPendingUnstake,
 } from "../types/errors";
 import {
   computeMaxStakeAmount,
@@ -147,6 +148,12 @@ function mapTaquitoErrors(taquitoError: string, intentType: string): Record<stri
     errors.amount = new TezosNotEnoughStaked();
   } else if (taquitoError.endsWith("contract.must_be_delegated_to_stake")) {
     errors.amount = new MustDelegateBeforeStaking();
+  } else if (
+    taquitoError.endsWith("cannot_stake_with_unfinalizable_unstake_requests_to_another_delegate")
+  ) {
+    // Changing delegate implicitly unstakes the frozen deposit toward the old delegate; the
+    // protocol blocks staking with the new delegate until that unstake finalizes (~4 days).
+    errors.amount = new TezosStakeBlockedByPendingUnstake();
   } else if (taquitoError.endsWith("delegate.unchanged")) {
     // Re-delegating (or staking) to the current baker leaves the delegate unchanged; the node
     // rejects it. Surfaces for both `delegate` and `stake` intents as "already delegated".

--- a/libs/coin-modules/coin-tezos/src/types/errors.ts
+++ b/libs/coin-modules/coin-tezos/src/types/errors.ts
@@ -19,8 +19,10 @@ export const TezosNotEnoughStaked = createCustomErrorClass("TezosNotEnoughStaked
 // to the previous delegate still exists (~4-day freeze). Surfaced during stake fee estimation.
 // Display is i18n-driven (via error.name); the message is a fallback for logs.
 export class TezosStakeBlockedByPendingUnstake extends Error {
-  override name = "TezosStakeBlockedByPendingUnstake";
   constructor() {
-    super("Cannot stake with the new validator while an unfinalizable unstake to the previous one is pending");
+    super(
+      "Cannot stake with the new validator while an unfinalizable unstake to the previous one is pending",
+    );
+    this.name = "TezosStakeBlockedByPendingUnstake";
   }
 }

--- a/libs/coin-modules/coin-tezos/src/types/errors.ts
+++ b/libs/coin-modules/coin-tezos/src/types/errors.ts
@@ -16,7 +16,11 @@ export const MustDelegateBeforeStaking = createCustomErrorClass("MustDelegateBef
 export const TezosNotEnoughStaked = createCustomErrorClass("TezosNotEnoughStaked");
 
 // Staking with a new delegate is rejected by the protocol while an unfinalizable unstake request
-// to the previous delegate still exists (~4 day freeze). Surfaced during stake fee estimation.
+// to the previous delegate still exists (~4-day freeze). Surfaced during stake fee estimation.
+// Display is i18n-driven (via error.name); the message is a fallback for logs.
 export class TezosStakeBlockedByPendingUnstake extends Error {
   override name = "TezosStakeBlockedByPendingUnstake";
+  constructor() {
+    super("Cannot stake with the new validator while an unfinalizable unstake to the previous one is pending");
+  }
 }

--- a/libs/coin-modules/coin-tezos/src/types/errors.ts
+++ b/libs/coin-modules/coin-tezos/src/types/errors.ts
@@ -14,3 +14,9 @@ export const UnsupportedOperationKind = createCustomErrorClass<
 >("UnsupportedOperationKind");
 export const MustDelegateBeforeStaking = createCustomErrorClass("MustDelegateBeforeStaking");
 export const TezosNotEnoughStaked = createCustomErrorClass("TezosNotEnoughStaked");
+
+// Staking with a new delegate is rejected by the protocol while an unfinalizable unstake request
+// to the previous delegate still exists (~4 day freeze). Surfaced during stake fee estimation.
+export class TezosStakeBlockedByPendingUnstake extends Error {
+  override name = "TezosStakeBlockedByPendingUnstake";
+}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Tezos blocks staking with a new validator while an unfinalizable unstake to the previous one still exists (~4-day freeze), previously surfaced only as a raw protocol error. This PR handles it on **LLD + LLM**:

- **Explain after** — map the stake fee-estimation error to a clear message ("Unstaking from your previous validator must finish first"). Backstop for validator changes made outside Ledger Live.
- **Warn before** — non-blocking inline warning on the change-validator summary when a pending unstake exists and a different validator is picked.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34067](https://ledgerhq.atlassian.net/browse/LIVE-34067?atlOrigin=eyJpIjoiYzc4MWQ5YTIyZTFjNGJmYmI1YjMxYjkxMDJjYWRjOWIiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-34067]: https://ledgerhq.atlassian.net/browse/LIVE-34067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ