### PR TITLE
[LWD] refactor(desktop): reduce console.error usage to lower Datadog noise

### DIFF
--- a/apps/ledger-live-desktop/src/datadog/config.test.ts
+++ b/apps/ledger-live-desktop/src/datadog/config.test.ts
@@ -72,8 +72,7 @@ describe("datadog config", () => {
       expect(beforeSend({ foo: "bar" }, undefined)).toBe(true);
     });
 
-    it("should return true when asar url rewrite throws (logs and continues)", () => {
-      const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+    it("should return true when asar url rewrite throws (continues silently)", () => {
       const beforeSend = buildBeforeSend(() => true);
       const event: Record<string, unknown> = {};
       Object.defineProperty(event, "boom", {
@@ -83,11 +82,6 @@ describe("datadog config", () => {
         },
       });
       expect(beforeSend(event, undefined)).toBe(true);
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Datadog beforeSend: asar url rewrite failed",
-        expect.any(Error),
-      );
-      consoleSpy.mockRestore();
     });
 
     it("should call anonymizer and return true for sendable event", () => {
@@ -100,21 +94,15 @@ describe("datadog config", () => {
       expect(event._anonymized).toBe(true);
     });
 
-    it("should return true when anonymizer throws (logs and continues)", () => {
+    it("should return false when anonymizer throws (drops event for PII safety)", () => {
       const anonymizer = jest.requireMock("~/sentry/anonymizer").default;
       jest.mocked(anonymizer.filepathRecursiveReplacer).mockImplementationOnce(() => {
         throw new Error("anonymizer failed");
       });
-      const consoleSpy = jest.spyOn(console, "error").mockImplementation();
       const shouldSend = jest.fn().mockReturnValue(true);
       const beforeSend = buildBeforeSend(shouldSend);
       const event = { message: "ok" };
-      expect(beforeSend(event, undefined)).toBe(true);
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Datadog beforeSend: anonymization failed",
-        expect.any(Error),
-      );
-      consoleSpy.mockRestore();
+      expect(beforeSend(event, undefined)).toBe(false);
     });
 
     it("should rewrite asar file:// urls in the error stack", () => {

--- a/apps/ledger-live-desktop/src/datadog/config.ts
+++ b/apps/ledger-live-desktop/src/datadog/config.ts
@@ -55,15 +55,13 @@ export function buildBeforeSend(shouldSend: ShouldSendCallback) {
 
     try {
       anonymizer.filepathRecursiveReplacer(ev);
-    } catch (e) {
-      console.error("Datadog beforeSend: anonymization failed", e);
+    } catch (_e) {
+      return false;
     }
 
     try {
       rewriteAsarUrlsRecursive(ev, new Set());
-    } catch (e) {
-      console.error("Datadog beforeSend: asar url rewrite failed", e);
-    }
+    } catch (_e) {}
 
     return true;
   };

--- a/apps/ledger-live-desktop/src/helpers/saveLogs.test.ts
+++ b/apps/ledger-live-desktop/src/helpers/saveLogs.test.ts
@@ -78,17 +78,14 @@ describe("saveLogs", () => {
     const error = new Error("IPC error");
     (memoryLogger.getMemoryLogs as jest.Mock).mockReturnValue({ log: "test" });
     (ipcRenderer.invoke as jest.Mock).mockRejectedValue(error);
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
     // when
     await saveLogs(fakePath);
 
     // then
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Error while requesting to save logs from the renderer process",
-      error,
-    );
+    expect(consoleWarnSpy).toHaveBeenCalledWith("Failed to save logs:", error);
 
-    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
   });
 });

--- a/apps/ledger-live-desktop/src/helpers/saveLogs.ts
+++ b/apps/ledger-live-desktop/src/helpers/saveLogs.ts
@@ -46,6 +46,6 @@ export const saveLogs = async (path: Electron.SaveDialogReturnValue) => {
     // Requests the main process to save logs in a file
     await ipcRenderer.invoke("save-logs", path, memoryLogsStr);
   } catch (error) {
-    console.error("Error while requesting to save logs from the renderer process", error);
+    console.warn("Failed to save logs:", error);
   }
 };

--- a/apps/ledger-live-desktop/src/main/db/index.ts
+++ b/apps/ledger-live-desktop/src/main/db/index.ts
@@ -224,7 +224,6 @@ async function setEncryptionKey(encryptionKey: string): Promise<void> {
       decryptEncryptedPathInMemory(ns, keyPath, encryptionKey);
     } catch (err) {
       log("db", "setEncryptionKey failure: " + String(err));
-      console.error(err);
       throw new DBWrongPassword();
     }
   }
@@ -244,7 +243,6 @@ async function removeEncryptionKey() {
         decryptEncryptedPathInMemory(ns, keyPath, encryptionKey);
       } catch (err) {
         log("db", "removeEncryptionKey failure: " + String(err));
-        console.error(err);
         throw err;
       }
     }

--- a/apps/ledger-live-desktop/src/main/index.ts
+++ b/apps/ledger-live-desktop/src/main/index.ts
@@ -105,7 +105,7 @@ app.on("ready", async () => {
   // Defer extension installation to not block startup
   if (__DEV__) {
     setImmediate(() => {
-      installExtensions().catch(console.error);
+      installExtensions().catch(e => console.warn("Dev extensions install failed:", e));
     });
   }
 
@@ -332,7 +332,7 @@ async function installExtensions() {
       loadExtensionOptions: {
         allowFileAccess: true,
       },
-    }).catch(console.error);
+    }).catch(e => console.warn("Dev extensions install failed:", e));
   });
 }
 

--- a/apps/ledger-live-desktop/src/main/logger.ts
+++ b/apps/ledger-live-desktop/src/main/logger.ts
@@ -128,8 +128,6 @@ export class ConsoleLogger {
           )}`,
         );
       }
-    } catch {
-      console.error("Badly formatted log");
-    }
+    } catch {}
   }
 }

--- a/apps/ledger-live-desktop/src/main/setup.ts
+++ b/apps/ledger-live-desktop/src/main/setup.ts
@@ -42,8 +42,7 @@ ipcMain.handle(
       let rendererLogsChronological: Array<{ timestamp: string }> = [];
       try {
         rendererLogsChronological = JSON.parse(rendererLogsStr).reverse(); // The logs are in reverse order.
-      } catch (error) {
-        console.error("Error while parsing logs from the renderer process", error);
+      } catch {
         return;
       }
 

--- a/apps/ledger-live-desktop/src/main/updater/init.ts
+++ b/apps/ledger-live-desktop/src/main/updater/init.ts
@@ -38,7 +38,6 @@ const handleDownload = async (info: UpdateDownloadedEvent) => {
     await appUpdater.verify();
     sendStatus("check-success");
   } catch (err) {
-    console.error(err);
     if (UPDATE_CHECK_IGNORE) {
       sendStatus("check-success");
     } else {
@@ -53,7 +52,7 @@ const init = () => {
   autoUpdater.on("download-progress", p => sendStatus("download-progress", p));
   autoUpdater.on("update-downloaded", handleDownload);
   autoUpdater.on("error", err => {
-    console.error(err);
+    console.warn("Auto-updater error:", err);
   });
   autoUpdater.autoInstallOnAppQuit = true;
   autoUpdater.autoDownload = true;

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/hooks/useAnalyticsConsentDialogViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/hooks/useAnalyticsConsentDialogViewModel.ts
@@ -113,9 +113,7 @@ export function useAnalyticsConsentDialogViewModel() {
     dispatch(setHasSeenAnalyticsOptInPrompt(true));
     try {
       await updateIdentify({ force: true });
-    } catch (error) {
-      console.error("Failed to update analytics identify after consent change", error);
-    }
+    } catch {}
   };
 
   const applyOptIn = async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
@@ -74,9 +74,7 @@ export const useAnalyticsOptInPrompt = ({ entryPoint }: Props) => {
     dispatch(setHasSeenAnalyticsOptInPrompt(true));
     try {
       await updateIdentify({ force: true });
-    } catch (error) {
-      console.error("Failed to update analytics identify", error);
-    }
+    } catch {}
     if (entryPoint === EntryPoint.onboarding) {
       nextStep?.();
       setNextStep(null);

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetListItem/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetListItem/index.tsx
@@ -13,9 +13,7 @@ import { AssetType } from "../../../../types";
 const copyToClipboard = async (text: string) => {
   try {
     await navigator.clipboard.writeText(text);
-  } catch (err) {
-    console.error("Failed to copy to clipboard:", err);
-  }
+  } catch {}
 };
 
 type AssetListItemProps = AssetType & {

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/walletSync.hooks.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/walletSync.hooks.ts
@@ -30,8 +30,6 @@ export const useLifeCycle = () => {
   };
 
   function handleError(error: Error) {
-    console.error("GetMember :" + error);
-
     if (error instanceof TrustchainEjected) reset();
     if (error instanceof TrustchainNotAllowed) reset();
 
@@ -42,6 +40,7 @@ export const useLifeCycle = () => {
     );
 
     if (errorToHandle) errorToHandle[1]();
+    else console.warn("Unhandled WalletSync error:", error);
   }
 
   return {

--- a/apps/ledger-live-desktop/src/renderer/components/CustomImage/ImageCropper.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CustomImage/ImageCropper.tsx
@@ -173,9 +173,8 @@ const ImageCropper: React.FC<Props> = props => {
         if (dead) return;
         onResult(res);
       })
-      .catch(e => {
+      .catch(() => {
         if (dead) return;
-        console.error(e);
         onError(new ImageCropError());
       });
     return () => {
@@ -227,13 +226,9 @@ const ImageCropper: React.FC<Props> = props => {
     [setCompleteCropPixel, imageUuid, rotationIncrements, setCropParams, zoom],
   );
 
-  const handleError = useCallback(
-    (e: SyntheticEvent) => {
-      console.error(e);
-      onError(new ImageCropError());
-    },
-    [onError],
-  );
+  const handleError = useCallback(() => {
+    onError(new ImageCropError());
+  }, [onError]);
 
   return (
     <Flex flexDirection="column" justifyContent="center" alignItems="center">

--- a/apps/ledger-live-desktop/src/renderer/components/CustomImage/ImageDithering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CustomImage/ImageDithering.tsx
@@ -76,8 +76,7 @@ const ImageDithering: React.FC<Props> = props => {
         setPreviewResult(previewResult);
         onResult({ previewResult, rawResult });
         setLoading(false);
-      } catch (e) {
-        console.error(e);
+      } catch {
         onError(new ImageProcessingError());
       }
     }

--- a/apps/ledger-live-desktop/src/renderer/components/CustomImage/TestImage.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CustomImage/TestImage.tsx
@@ -103,8 +103,7 @@ const TestImage: React.FC<Props> = props => {
   useEffect(() => {
     try {
       if (result) setReconstructedImage(reconstructImage({ ...result.rawResult, bitsPerPixel }));
-    } catch (e) {
-      console.error(e);
+    } catch {
       onError(new ImageProcessingError());
     }
   }, [result, setReconstructedImage, onError, bitsPerPixel]);

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
@@ -231,7 +231,7 @@ export function useWebviewState(
       errorCode,
       url: fullURL.hostname,
     };
-    console.error("Web3AppView handleFailLoad", { errorInfo, isMainFrame });
+    console.warn("Web3AppWebview load failed:", { ...errorInfo, isMainFrame });
     track("useWebviewState", errorInfo);
 
     if (isMainFrame) {

--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
@@ -212,7 +212,6 @@ export function usePTXCustomHandlers(manifest: WebviewProps["manifest"], account
                   onSuccess(operation.hash);
                 },
                 onCancel: (error: Error) => {
-                  console.error(error);
                   onCancel(error);
                 },
               }),
@@ -230,7 +229,6 @@ export function usePTXCustomHandlers(manifest: WebviewProps["manifest"], account
             let cancelCalled = false;
             const safeOnCancel = (error: Error) => {
               if (!cancelCalled) {
-                console.error(error);
                 cancelCalled = true;
                 onCancel(error);
               }

--- a/apps/ledger-live-desktop/src/renderer/components/debug/DebugMock.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/debug/DebugMock.tsx
@@ -249,7 +249,7 @@ window.saveLogs = async (path: string): Promise<void> => {
       memoryLogsStr,
     );
   } catch (error) {
-    console.error("Error while requesting to save logs from the renderer process", error);
+    console.warn("Failed to save logs:", error);
   }
 };
 

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
@@ -289,7 +289,7 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
           dispatch(updateAccountWithUpdater(account.id, accountUpdater));
         },
         error(err) {
-          console.error(err);
+          console.warn("Zcash shielded sync error:", err);
         },
         complete() {
           console.log(`Zcash shielded sync completed on account ${account.id}`);

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/live-common-setup.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/live-common-setup.ts
@@ -58,8 +58,7 @@ runJob() // Simple ping-pong test
       });
     },
     error => {
-      // in error case, we fallback to the default implementation
-      console.error("Failed to initialize publicKeyTweakAdd workers", error);
+      console.warn("publicKeyTweakAdd workers init failed, using default impl:", error);
     },
   );
 

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -62,8 +62,8 @@ const saveCryptoAssetsCache = throttle((state: State) => {
       setKey("app", "cryptoAssets", persistedData);
       lastPersistedCryptoAssets = persistedData;
     }
-  } catch (error) {
-    console.error("Failed to save crypto assets cache:", error);
+  } catch (e) {
+    console.warn("crypto assets cache write failed:", e);
   }
 }, 5000);
 

--- a/apps/ledger-live-desktop/src/renderer/screens/customImage/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/customImage/index.tsx
@@ -126,8 +126,7 @@ const CustomImage: React.FC<Props> = props => {
           setLoadedImage({ imageBase64DataUri: res });
           setStepWrapper(Step.adjustImage);
         })
-        .catch(e => {
-          console.error(e);
+        .catch(() => {
           if (dead) return;
           setStepError({ [Step.chooseImage]: new ImageDownloadError() });
         });

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
@@ -72,8 +72,7 @@ export default function FeesDrawerLiveApp({
             isPreparingRef.current = false;
           });
         })
-        .catch(error => {
-          console.error("Error preparing transaction:", error);
+        .catch(() => {
           isPreparingRef.current = false;
         });
     },
@@ -112,8 +111,7 @@ export default function FeesDrawerLiveApp({
             isPreparingRef.current = false;
           });
         })
-        .catch(error => {
-          console.error("Error updating transaction:", error);
+        .catch(() => {
           isPreparingRef.current = false;
         });
     },

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/BlacklistedTokens.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/BlacklistedTokens.test.tsx
@@ -155,19 +155,19 @@ describe("BlacklistedTokens", () => {
   it("handles async loading errors gracefully", async () => {
     mockFindTokenById.mockRejectedValue(new Error("Token not found"));
 
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
     render(<BlacklistedTokens />, {
       initialState: { settings: { blacklistedTokenIds: ["ethereum/erc20/invalid"] } },
     });
 
     await waitFor(() => {
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         "Failed to load blacklisted tokens:",
         expect.any(Error),
       );
     });
 
-    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/BlacklistedTokens.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/BlacklistedTokens.tsx
@@ -54,7 +54,7 @@ export default function BlacklistedTokens() {
         }
       })
       .catch(error => {
-        console.error("Failed to load blacklisted tokens:", error);
+        console.warn("Failed to load blacklisted tokens:", error);
         if (mounted) {
           setSections([]);
         }

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/CustomMockAccountGenerator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/CustomMockAccountGenerator.tsx
@@ -41,7 +41,7 @@ export default function CustomMockAccountGenerator({ title, desc }: Props) {
         const accounts = generateAccountsForCurrencies(currencies, tokens);
         await injectMockAccounts(accounts, true);
       } catch (error) {
-        console.error("Failed to generate mock accounts:", error);
+        console.warn("Failed to generate mock accounts:", error);
         alert(t("settings.developer.mockAccounts.alerts.generateError"));
       }
     }

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/EmptyAccountGenerator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/EmptyAccountGenerator.tsx
@@ -17,7 +17,7 @@ export default function EmptyAccountGenerator({ title, desc }: Props) {
       const account = createEmptyAccount();
       await injectMockAccounts([account], true);
     } catch (error) {
-      console.error("Failed to generate mock accounts:", error);
+      console.warn("Failed to generate mock accounts:", error);
       alert(t("settings.developer.mockAccounts.alerts.generateError"));
     }
   };

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/MockAccountGenerator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/MockAccountGenerator.tsx
@@ -18,7 +18,7 @@ export default function MockAccountGenerator({ count, title, desc }: Props) {
       const accounts = generateRandomAccounts(count);
       await injectMockAccounts(accounts, true);
     } catch (error) {
-      console.error("Failed to generate mock accounts:", error);
+      console.warn("Failed to generate mock accounts:", error);
       alert(t("settings.developer.mockAccounts.alerts.generateError"));
     }
   };

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/StablecoinMockAccountGenerator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/StablecoinMockAccountGenerator.tsx
@@ -20,7 +20,7 @@ export default function StablecoinMockAccountGenerator({ title, desc }: Props) {
       const accounts = await generateStablecoinAccounts();
       await injectMockAccounts(accounts, true);
     } catch (error) {
-      console.error("Failed to generate stablecoin accounts:", error);
+      console.warn("Failed to generate stablecoin accounts:", error);
       alert(t("settings.developer.mockAccounts.alerts.generateError"));
     } finally {
       setLoading(false);

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/StocksMockAccountGenerator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/StocksMockAccountGenerator.tsx
@@ -24,7 +24,7 @@ export default function StocksMockAccountGenerator({ title, desc }: Props) {
       const accounts = generateStockAccounts(tokensByParent);
       await injectMockAccounts(accounts, true);
     } catch (error) {
-      console.error("Failed to generate stock accounts:", error);
+      console.warn("Failed to generate stock accounts:", error);
       alert(t("settings.developer.mockAccounts.alerts.generateError"));
     } finally {
       setLoading(false);

--- a/apps/ledger-live-desktop/src/renderer/webworkers/workers/publicKeyTweakAdd.ts
+++ b/apps/ledger-live-desktop/src/renderer/webworkers/workers/publicKeyTweakAdd.ts
@@ -33,7 +33,6 @@ onmessage = (e: MessageEvent<{ publicKey?: string; tweak?: string; id: string }>
       postMessage({ response: uint8ArrayToHex(r), id });
     })
     .catch((e: unknown) => {
-      console.error(e);
       const errorMessage = e instanceof Error ? e.message : String(e);
       postMessage({ error: errorMessage, id });
     });


### PR DESCRIPTION
### 📝 Description

Datadog RUM intercepts all `console.error` calls and reports them as errors, generating high noise. This PR audits and cleans up `console.error` usage in LLD:

- **Drop** calls where the error is already surfaced via UI state, thrown error, or return value
- **Replace with `console.warn`** where there's genuine dev-debug value (silent fallbacks, unexpected flows)
- **Keep `console.error`** only for truly illegal states (SDK init failures, `uncaughtException`, unrecoverable crashes)
- **Fix** `datadog/config.ts`: anonymization failure now returns `false` (drops the event) instead of forwarding potentially un-anonymized PII

Result: 33 `console.error` removed, 8 converted to `console.warn`, 11 legitimate ones kept.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34349](https://ledgerhq.atlassian.net/browse/LIVE-34349)
- **ADR** (if any): N/A

[LIVE-34349]: https://ledgerhq.atlassian.net/browse/LIVE-34349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ