### PR TITLE
[LWD] refactor(desktop): reduce console.error in datadog + main process [platform]

### DIFF
--- a/.changeset/reduce-console-error-lld-platform.md
+++ b/.changeset/reduce-console-error-lld-platform.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Reduce console.error usage in main process and Datadog config to lower monitoring noise

--- a/apps/ledger-live-desktop/src/datadog/config.test.ts
+++ b/apps/ledger-live-desktop/src/datadog/config.test.ts
@@ -72,8 +72,7 @@ describe("datadog config", () => {
       expect(beforeSend({ foo: "bar" }, undefined)).toBe(true);
     });
 
-    it("should return true when asar url rewrite throws (logs and continues)", () => {
-      const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+    it("should return true when asar url rewrite throws (continues silently)", () => {
       const beforeSend = buildBeforeSend(() => true);
       const event: Record<string, unknown> = {};
       Object.defineProperty(event, "boom", {
@@ -83,11 +82,6 @@ describe("datadog config", () => {
         },
       });
       expect(beforeSend(event, undefined)).toBe(true);
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Datadog beforeSend: asar url rewrite failed",
-        expect.any(Error),
-      );
-      consoleSpy.mockRestore();
     });
 
     it("should call anonymizer and return true for sendable event", () => {
@@ -100,21 +94,15 @@ describe("datadog config", () => {
       expect(event._anonymized).toBe(true);
     });
 
-    it("should return true when anonymizer throws (logs and continues)", () => {
+    it("should return false when anonymizer throws (drops event for PII safety)", () => {
       const anonymizer = jest.requireMock("~/sentry/anonymizer").default;
       jest.mocked(anonymizer.filepathRecursiveReplacer).mockImplementationOnce(() => {
         throw new Error("anonymizer failed");
       });
-      const consoleSpy = jest.spyOn(console, "error").mockImplementation();
       const shouldSend = jest.fn().mockReturnValue(true);
       const beforeSend = buildBeforeSend(shouldSend);
       const event = { message: "ok" };
-      expect(beforeSend(event, undefined)).toBe(true);
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Datadog beforeSend: anonymization failed",
-        expect.any(Error),
-      );
-      consoleSpy.mockRestore();
+      expect(beforeSend(event, undefined)).toBe(false);
     });
 
     it("should rewrite asar file:// urls in the error stack", () => {

--- a/apps/ledger-live-desktop/src/datadog/config.ts
+++ b/apps/ledger-live-desktop/src/datadog/config.ts
@@ -41,6 +41,8 @@ function rewriteAsarUrlsRecursive(value: unknown, seen: Set<object>): void {
  * Builds the beforeSend callback for Datadog RUM / Log.
  * Drops events when opt-in is off or error message matches ignore list;
  * applies anonymization to the payload (parity with Sentry).
+ * If anonymization throws, the event is dropped (return false) to avoid
+ * sending potentially non-anonymized data.
  */
 export function buildBeforeSend(shouldSend: ShouldSendCallback) {
   return (event: unknown, _context?: unknown): boolean => {
@@ -55,14 +57,14 @@ export function buildBeforeSend(shouldSend: ShouldSendCallback) {
 
     try {
       anonymizer.filepathRecursiveReplacer(ev);
-    } catch (e) {
-      console.error("Datadog beforeSend: anonymization failed", e);
+    } catch {
+      return false;
     }
 
     try {
       rewriteAsarUrlsRecursive(ev, new Set());
     } catch (e) {
-      console.error("Datadog beforeSend: asar url rewrite failed", e);
+      console.warn("Datadog: asar URL rewrite failed (best-effort):", e);
     }
 
     return true;

--- a/apps/ledger-live-desktop/src/main/db/index.ts
+++ b/apps/ledger-live-desktop/src/main/db/index.ts
@@ -224,7 +224,6 @@ async function setEncryptionKey(encryptionKey: string): Promise<void> {
       decryptEncryptedPathInMemory(ns, keyPath, encryptionKey);
     } catch (err) {
       log("db", "setEncryptionKey failure: " + String(err));
-      console.error(err);
       throw new DBWrongPassword();
     }
   }
@@ -244,7 +243,6 @@ async function removeEncryptionKey() {
         decryptEncryptedPathInMemory(ns, keyPath, encryptionKey);
       } catch (err) {
         log("db", "removeEncryptionKey failure: " + String(err));
-        console.error(err);
         throw err;
       }
     }

--- a/apps/ledger-live-desktop/src/main/index.ts
+++ b/apps/ledger-live-desktop/src/main/index.ts
@@ -105,7 +105,7 @@ app.on("ready", async () => {
   // Defer extension installation to not block startup
   if (__DEV__) {
     setImmediate(() => {
-      installExtensions().catch(console.error);
+      installExtensions().catch(e => console.warn("Dev extensions install failed:", e));
     });
   }
 
@@ -327,12 +327,11 @@ function setUserDataPath() {
 
 async function installExtensions() {
   // https://github.com/MarshallOfSound/electron-devtools-installer#usage
-  app.whenReady().then(() => {
-    installExtension([REDUX_DEVTOOLS, REACT_DEVELOPER_TOOLS], {
-      loadExtensionOptions: {
-        allowFileAccess: true,
-      },
-    }).catch(console.error);
+  await app.whenReady();
+  await installExtension([REDUX_DEVTOOLS, REACT_DEVELOPER_TOOLS], {
+    loadExtensionOptions: {
+      allowFileAccess: true,
+    },
   });
 }
 

--- a/apps/ledger-live-desktop/src/main/logger.ts
+++ b/apps/ledger-live-desktop/src/main/logger.ts
@@ -129,7 +129,7 @@ export class ConsoleLogger {
         );
       }
     } catch {
-      console.error("Badly formatted log");
+      console.warn("Badly formatted log");
     }
   }
 }

--- a/apps/ledger-live-desktop/src/main/setup.ts
+++ b/apps/ledger-live-desktop/src/main/setup.ts
@@ -42,8 +42,8 @@ ipcMain.handle(
       let rendererLogsChronological: Array<{ timestamp: string }> = [];
       try {
         rendererLogsChronological = JSON.parse(rendererLogsStr).reverse(); // The logs are in reverse order.
-      } catch (error) {
-        console.error("Error while parsing logs from the renderer process", error);
+      } catch (e) {
+        console.warn("Error while parsing logs from the renderer process", e);
         return;
       }
 

--- a/apps/ledger-live-desktop/src/main/updater/init.ts
+++ b/apps/ledger-live-desktop/src/main/updater/init.ts
@@ -38,7 +38,6 @@ const handleDownload = async (info: UpdateDownloadedEvent) => {
     await appUpdater.verify();
     sendStatus("check-success");
   } catch (err) {
-    console.error(err);
     if (UPDATE_CHECK_IGNORE) {
       sendStatus("check-success");
     } else {
@@ -53,7 +52,7 @@ const init = () => {
   autoUpdater.on("download-progress", p => sendStatus("download-progress", p));
   autoUpdater.on("update-downloaded", handleDownload);
   autoUpdater.on("error", err => {
-    console.error(err);
+    console.warn("Auto-updater error:", err);
   });
   autoUpdater.autoInstallOnAppQuit = true;
   autoUpdater.autoDownload = true;


### PR DESCRIPTION
### 📝 Description

Replace debug `console.error` with `console.warn` or drop entirely in `datadog/` and `main/` process files. Anonymization failure in `beforeSend` now returns `false` to avoid sending un-anonymized PII.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34349](https://ledgerhq.atlassian.net/browse/LIVE-34349)

[LIVE-34349]: https://ledgerhq.atlassian.net/browse/LIVE-34349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ