### PR TITLE
[LWD] refactor(desktop): reduce console.error in analytics opt-in [engagement]

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/hooks/useAnalyticsConsentDialogViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/hooks/useAnalyticsConsentDialogViewModel.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import logger from "~/renderer/logger";
 import { useTranslation } from "react-i18next";
 import { useMatch } from "react-router";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
@@ -113,8 +114,8 @@ export function useAnalyticsConsentDialogViewModel() {
     dispatch(setHasSeenAnalyticsOptInPrompt(true));
     try {
       await updateIdentify({ force: true });
-    } catch (error) {
-      console.error("Failed to update analytics identify after consent change", error);
+    } catch (e) {
+      logger.critical(e, "Failed to update analytics identify after consent change");
     }
   };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo } from "react";
+import logger from "~/renderer/logger";
 import { useFeature } from "@features/platform-feature-flags";
 import { resolveAnalyticsOptInParams } from "@ledgerhq/live-common/analyticsConsent/index";
 import {
@@ -74,8 +75,8 @@ export const useAnalyticsOptInPrompt = ({ entryPoint }: Props) => {
     dispatch(setHasSeenAnalyticsOptInPrompt(true));
     try {
       await updateIdentify({ force: true });
-    } catch (error) {
-      console.error("Failed to update analytics identify", error);
+    } catch (e) {
+      logger.critical(e, "Failed to update analytics identify");
     }
     if (entryPoint === EntryPoint.onboarding) {
       nextStep?.();


### PR DESCRIPTION
### 📝 Description

Replace `console.error` in analytics identify catch blocks with `logger.critical` to preserve observability while avoiding Datadog RUM noise.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34349](https://ledgerhq.atlassian.net/browse/LIVE-34349)

[LIVE-34349]: https://ledgerhq.atlassian.net/browse/LIVE-34349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ