### PR TITLE
[LWD] refactor(desktop): reduce console.error in settings + helpers [wallet-xp]

### DIFF
--- a/apps/ledger-live-desktop/src/helpers/saveLogs.test.ts
+++ b/apps/ledger-live-desktop/src/helpers/saveLogs.test.ts
@@ -78,17 +78,14 @@ describe("saveLogs", () => {
     const error = new Error("IPC error");
     (memoryLogger.getMemoryLogs as jest.Mock).mockReturnValue({ log: "test" });
     (ipcRenderer.invoke as jest.Mock).mockRejectedValue(error);
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
     // when
     await saveLogs(fakePath);
 
     // then
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Error while requesting to save logs from the renderer process",
-      error,
-    );
+    expect(consoleWarnSpy).toHaveBeenCalledWith("Failed to save logs:", error);
 
-    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
   });
 });

--- a/apps/ledger-live-desktop/src/helpers/saveLogs.ts
+++ b/apps/ledger-live-desktop/src/helpers/saveLogs.ts
@@ -46,6 +46,6 @@ export const saveLogs = async (path: Electron.SaveDialogReturnValue) => {
     // Requests the main process to save logs in a file
     await ipcRenderer.invoke("save-logs", path, memoryLogsStr);
   } catch (error) {
-    console.error("Error while requesting to save logs from the renderer process", error);
+    console.warn("Failed to save logs:", error);
   }
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetListItem/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetListItem/index.tsx
@@ -13,9 +13,7 @@ import { AssetType } from "../../../../types";
 const copyToClipboard = async (text: string) => {
   try {
     await navigator.clipboard.writeText(text);
-  } catch (err) {
-    console.error("Failed to copy to clipboard:", err);
-  }
+  } catch {}
 };
 
 type AssetListItemProps = AssetType & {

--- a/apps/ledger-live-desktop/src/renderer/components/debug/DebugMock.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/debug/DebugMock.tsx
@@ -249,7 +249,7 @@ window.saveLogs = async (path: string): Promise<void> => {
       memoryLogsStr,
     );
   } catch (error) {
-    console.error("Error while requesting to save logs from the renderer process", error);
+    console.warn("Failed to save logs:", error);
   }
 };
 

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -62,8 +62,8 @@ const saveCryptoAssetsCache = throttle((state: State) => {
       setKey("app", "cryptoAssets", persistedData);
       lastPersistedCryptoAssets = persistedData;
     }
-  } catch (error) {
-    console.error("Failed to save crypto assets cache:", error);
+  } catch (e) {
+    console.warn("crypto assets cache write failed:", e);
   }
 }, 5000);
 

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/BlacklistedTokens.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/BlacklistedTokens.test.tsx
@@ -155,19 +155,19 @@ describe("BlacklistedTokens", () => {
   it("handles async loading errors gracefully", async () => {
     mockFindTokenById.mockRejectedValue(new Error("Token not found"));
 
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
     render(<BlacklistedTokens />, {
       initialState: { settings: { blacklistedTokenIds: ["ethereum/erc20/invalid"] } },
     });
 
     await waitFor(() => {
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         "Failed to load blacklisted tokens:",
         expect.any(Error),
       );
     });
 
-    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/BlacklistedTokens.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/BlacklistedTokens.tsx
@@ -54,7 +54,7 @@ export default function BlacklistedTokens() {
         }
       })
       .catch(error => {
-        console.error("Failed to load blacklisted tokens:", error);
+        console.warn("Failed to load blacklisted tokens:", error);
         if (mounted) {
           setSections([]);
         }

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/CustomMockAccountGenerator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/CustomMockAccountGenerator.tsx
@@ -41,7 +41,7 @@ export default function CustomMockAccountGenerator({ title, desc }: Props) {
         const accounts = generateAccountsForCurrencies(currencies, tokens);
         await injectMockAccounts(accounts, true);
       } catch (error) {
-        console.error("Failed to generate mock accounts:", error);
+        console.warn("Failed to generate mock accounts:", error);
         alert(t("settings.developer.mockAccounts.alerts.generateError"));
       }
     }

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/EmptyAccountGenerator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/EmptyAccountGenerator.tsx
@@ -17,7 +17,7 @@ export default function EmptyAccountGenerator({ title, desc }: Props) {
       const account = createEmptyAccount();
       await injectMockAccounts([account], true);
     } catch (error) {
-      console.error("Failed to generate mock accounts:", error);
+      console.warn("Failed to generate mock accounts:", error);
       alert(t("settings.developer.mockAccounts.alerts.generateError"));
     }
   };

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/MockAccountGenerator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/MockAccountGenerator.tsx
@@ -18,7 +18,7 @@ export default function MockAccountGenerator({ count, title, desc }: Props) {
       const accounts = generateRandomAccounts(count);
       await injectMockAccounts(accounts, true);
     } catch (error) {
-      console.error("Failed to generate mock accounts:", error);
+      console.warn("Failed to generate mock accounts:", error);
       alert(t("settings.developer.mockAccounts.alerts.generateError"));
     }
   };

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/StablecoinMockAccountGenerator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/StablecoinMockAccountGenerator.tsx
@@ -20,7 +20,7 @@ export default function StablecoinMockAccountGenerator({ title, desc }: Props) {
       const accounts = await generateStablecoinAccounts();
       await injectMockAccounts(accounts, true);
     } catch (error) {
-      console.error("Failed to generate stablecoin accounts:", error);
+      console.warn("Failed to generate stablecoin accounts:", error);
       alert(t("settings.developer.mockAccounts.alerts.generateError"));
     } finally {
       setLoading(false);

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/StocksMockAccountGenerator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/StocksMockAccountGenerator.tsx
@@ -24,7 +24,7 @@ export default function StocksMockAccountGenerator({ title, desc }: Props) {
       const accounts = generateStockAccounts(tokensByParent);
       await injectMockAccounts(accounts, true);
     } catch (error) {
-      console.error("Failed to generate stock accounts:", error);
+      console.warn("Failed to generate stock accounts:", error);
       alert(t("settings.developer.mockAccounts.alerts.generateError"));
     } finally {
       setLoading(false);

--- a/apps/ledger-live-desktop/src/renderer/webworkers/workers/publicKeyTweakAdd.ts
+++ b/apps/ledger-live-desktop/src/renderer/webworkers/workers/publicKeyTweakAdd.ts
@@ -33,7 +33,6 @@ onmessage = (e: MessageEvent<{ publicKey?: string; tweak?: string; id: string }>
       postMessage({ response: uint8ArrayToHex(r), id });
     })
     .catch((e: unknown) => {
-      console.error(e);
       const errorMessage = e instanceof Error ? e.message : String(e);
       postMessage({ error: errorMessage, id });
     });


### PR DESCRIPTION
### 📝 Description

Replace debug `console.error` with `console.warn` or drop entirely in settings screens, helpers, mock account generators, and webworkers.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34349](https://ledgerhq.atlassian.net/browse/LIVE-34349)

[LIVE-34349]: https://ledgerhq.atlassian.net/browse/LIVE-34349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ