### PR TITLE
[LWD] refactor(desktop): reduce console.error in PTX + swap fees [ptx]

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
@@ -212,7 +212,6 @@ export function usePTXCustomHandlers(manifest: WebviewProps["manifest"], account
                   onSuccess(operation.hash);
                 },
                 onCancel: (error: Error) => {
-                  console.error(error);
                   onCancel(error);
                 },
               }),
@@ -230,7 +229,6 @@ export function usePTXCustomHandlers(manifest: WebviewProps["manifest"], account
             let cancelCalled = false;
             const safeOnCancel = (error: Error) => {
               if (!cancelCalled) {
-                console.error(error);
                 cancelCalled = true;
                 onCancel(error);
               }

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
@@ -72,8 +72,7 @@ export default function FeesDrawerLiveApp({
             isPreparingRef.current = false;
           });
         })
-        .catch(error => {
-          console.error("Error preparing transaction:", error);
+        .catch(() => {
           isPreparingRef.current = false;
         });
     },
@@ -112,8 +111,7 @@ export default function FeesDrawerLiveApp({
             isPreparingRef.current = false;
           });
         })
-        .catch(error => {
-          console.error("Error updating transaction:", error);
+        .catch(() => {
           isPreparingRef.current = false;
         });
     },


### PR DESCRIPTION
### 📝 Description

Drop `console.error` from WebPTXPlayer cancel callbacks and FeesDrawerLiveApp — cancel is a normal user action, transaction errors are already handled via state.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34349](https://ledgerhq.atlassian.net/browse/LIVE-34349)

[LIVE-34349]: https://ledgerhq.atlassian.net/browse/LIVE-34349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ