### PR TITLE
[LWD] refactor(desktop): reduce console.error in CustomImage [live-devices]

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/components/CustomImage/ImageCropper.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CustomImage/ImageCropper.tsx
@@ -173,9 +173,8 @@ const ImageCropper: React.FC<Props> = props => {
         if (dead) return;
         onResult(res);
       })
-      .catch(e => {
+      .catch(() => {
         if (dead) return;
-        console.error(e);
         onError(new ImageCropError());
       });
     return () => {
@@ -227,13 +226,9 @@ const ImageCropper: React.FC<Props> = props => {
     [setCompleteCropPixel, imageUuid, rotationIncrements, setCropParams, zoom],
   );
 
-  const handleError = useCallback(
-    (e: SyntheticEvent) => {
-      console.error(e);
-      onError(new ImageCropError());
-    },
-    [onError],
-  );
+  const handleError = useCallback(() => {
+    onError(new ImageCropError());
+  }, [onError]);
 
   return (
     <Flex flexDirection="column" justifyContent="center" alignItems="center">

--- a/apps/ledger-live-desktop/src/renderer/components/CustomImage/ImageDithering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CustomImage/ImageDithering.tsx
@@ -76,8 +76,7 @@ const ImageDithering: React.FC<Props> = props => {
         setPreviewResult(previewResult);
         onResult({ previewResult, rawResult });
         setLoading(false);
-      } catch (e) {
-        console.error(e);
+      } catch {
         onError(new ImageProcessingError());
       }
     }

--- a/apps/ledger-live-desktop/src/renderer/components/CustomImage/TestImage.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CustomImage/TestImage.tsx
@@ -103,8 +103,7 @@ const TestImage: React.FC<Props> = props => {
   useEffect(() => {
     try {
       if (result) setReconstructedImage(reconstructImage({ ...result.rawResult, bitsPerPixel }));
-    } catch (e) {
-      console.error(e);
+    } catch {
       onError(new ImageProcessingError());
     }
   }, [result, setReconstructedImage, onError, bitsPerPixel]);

--- a/apps/ledger-live-desktop/src/renderer/screens/customImage/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/customImage/index.tsx
@@ -126,8 +126,7 @@ const CustomImage: React.FC<Props> = props => {
           setLoadedImage({ imageBase64DataUri: res });
           setStepWrapper(Step.adjustImage);
         })
-        .catch(e => {
-          console.error(e);
+        .catch(() => {
           if (dead) return;
           setStepError({ [Step.chooseImage]: new ImageDownloadError() });
         });


### PR DESCRIPTION
### 📝 Description

Drop `console.error` from CustomImage components (ImageCropper, ImageDithering, TestImage, customImage screen) — errors are already surfaced via the `onError` prop.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34349](https://ledgerhq.atlassian.net/browse/LIVE-34349)

[LIVE-34349]: https://ledgerhq.atlassian.net/browse/LIVE-34349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ