### PR TITLE
test(desktop): fix new send flow ENS matched-address button flakiness

### DIFF
--- a/e2e/desktop/tests/page/modal/new.send.modal.ts
+++ b/e2e/desktop/tests/page/modal/new.send.modal.ts
@@ -1,5 +1,7 @@
 import { expect } from "@playwright/test";
 import { Fee } from "@ledgerhq/live-e2e-shared/enum/Fee";
+import type { AccountType } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
 import { step } from "tests/misc/reporters/step";
 import { Modal } from "tests/component/modal.component";
 import { looksLikeFiatValue } from "tests/utils/looksLikeFiatValue";
@@ -8,10 +10,9 @@ export class NewSendModal extends Modal {
   readonly dialog = this.page.getByRole("dialog");
 
   readonly recipientInput = this.dialog.getByTestId("send-recipient-input");
-  readonly visibleSendToButton = this.dialog
+  readonly matchedAddressButtons = this.dialog
     .locator('[data-testid="send-matched-address-button"]')
-    .filter({ visible: true })
-    .first();
+    .filter({ visible: true });
   readonly skipMemoLink = this.dialog.getByTestId("send-skip-memo-link");
   readonly skipMemoConfirmButton = this.dialog.getByTestId("send-skip-memo-confirm-button");
   readonly amountInput = this.dialog.getByTestId("send-amount-input");
@@ -57,9 +58,18 @@ export class NewSendModal extends Modal {
   }
 
   @step("Select address from list")
-  async clickOnSendToButton() {
-    await this.visibleSendToButton.scrollIntoViewIfNeeded();
-    await this.visibleSendToButton.click();
+  async clickOnSendToButton(account?: AccountType) {
+    const label =
+      account?.ensName ??
+      (account?.address
+        ? formatAddress(account.address, { prefixLength: 5, suffixLength: 5 })
+        : undefined);
+
+    const button = label
+      ? this.matchedAddressButtons.filter({ hasText: label }).first()
+      : this.matchedAddressButtons.first();
+
+    await button.click();
   }
 
   @step("Skip memo")

--- a/e2e/desktop/tests/specs/newSendFlow.tx.spec.ts
+++ b/e2e/desktop/tests/specs/newSendFlow.tx.spec.ts
@@ -159,7 +159,7 @@ test.describe("New Send Flow", () => {
           if (requiresMemoStep) {
             await app.newSendFlow.skipMemo();
           } else {
-            await app.newSendFlow.clickOnSendToButton();
+            await app.newSendFlow.clickOnSendToButton(tx.accountToCredit);
           }
 
           await app.newSendFlow.fillCryptoAmount(tx.amount);


### PR DESCRIPTION
## Context

The `New Send Flow` desktop E2E failed for EVM recipients whose address reverse-resolves to an ENS name (POL, BASE) with `Error: locator.scrollIntoViewIfNeeded: Element is not attached to the DOM` at `clickOnSendToButton`.

## Root cause

The matched-address button reuses a single `data-testid="send-matched-address-button"` across all of its render states. When the async reverse-ENS lookup resolves, React swaps the plain-address node for the ENS node (same test id, **new** DOM node). The old `scrollIntoViewIfNeeded()` acted on the node it had already resolved, which detaches mid-action → throw.

ETH passed only because its recipient (`ETH_3`, index 2) has no reverse-ENS record; POL and BASE send to index 1 (`44'/60'/1'/0/0`), the same address that resolves to `speculos-qaa.eth`.

## Fix (test-only)

- `clickOnSendToButton(account?)` now targets the button by the account's ENS name (falling back to the truncated address) and drops `scrollIntoViewIfNeeded()`, relying on `click()`'s auto-scroll + locator re-resolution so it survives the node swap.
- The spec passes `tx.accountToCredit` to the click helper.
- `BASE_2` is intentionally left **without** an `ensName`: the app reverse-resolves the ENS in the UI regardless, and the address (present in the ENS button's text) is enough to target it. Setting `ensName` globally pushed the **legacy** send flow into its forward-ENS-resolution branch (`fillRecipientInfo`), which is unsupported on Base and timed out — so it stays unset.

## Testing

**Local** (nanoSP, Speculos) — both flows green:
- `newSendFlow.tx.spec.ts` › New Send Flow › Base 1 → Send 0.000001 ETH from Base 1 to Base 2 ✓
- `send.tx.spec.ts:280` › legacy send flow → Send from Base 1 to Base 2 ✓

**CI** — Desktop E2E, `@base` filter (covers new + legacy Base), nanoSP:
https://github.com/LedgerHQ/ledger-live/actions/runs/29245050935

<sub>Earlier run (New Send Flow filter, before the legacy fix): https://github.com/LedgerHQ/ledger-live/actions/runs/29240251806</sub>
