### PR TITLE
[LWDM] fix(mobile): align asset favourites with market ids

### DIFF
--- a/.changeset/calm-dais-align.md
+++ b/.changeset/calm-dais-align.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix asset favourites to use the Market identifier before market data loads.

--- a/.changeset/calm-dais-align.md
+++ b/.changeset/calm-dais-align.md
@@ -2,4 +2,4 @@
 "live-mobile": minor
 ---
 
-Fix asset favourites to use the Market identifier before market data loads.
+Fix asset favourites to preserve canonical Market identifiers and migrate DAI V2 favourites.

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -44,6 +44,7 @@ import {
   INITIAL_STATE as settingsState,
   counterValueIdOf,
   migrateLegacyCryptoCounterValue,
+  migrateLegacyStarredMarketCoins,
 } from "~/reducers/settings";
 import { listCachedCurrencyIds, hydrateCurrency } from "~/bridge/cache";
 import { importMarket } from "~/actions/market";
@@ -150,6 +151,11 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
       // Legacy crypto counter-values were persisted as ticker (BTC/ETH); migrate them to Ledger ids.
       if (settingsData && typeof settingsData.counterValue === "string") {
         settingsData.counterValue = migrateLegacyCryptoCounterValue(settingsData.counterValue);
+      }
+      if (settingsData?.starredMarketCoins) {
+        settingsData.starredMarketCoins = migrateLegacyStarredMarketCoins(
+          settingsData.starredMarketCoins,
+        );
       }
 
       store.dispatch(importSettings(settingsData));

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/__tests__/useAssetCoinOptionsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/CoinOptions/__tests__/useAssetCoinOptionsViewModel.test.ts
@@ -15,14 +15,16 @@ const bitcoin = getCryptoCurrencyById("bitcoin");
 function renderViewModel({
   blacklistedTokenIds = [],
   starredMarketCoins = [],
+  currencyId = bitcoin.id,
   marketId,
 }: {
   blacklistedTokenIds?: string[];
   starredMarketCoins?: string[];
+  currencyId?: string;
   marketId?: string;
 } = {}) {
   return renderHook(
-    () => useAssetCoinOptionsViewModel({ currency: bitcoin, currencyId: bitcoin.id, marketId }),
+    () => useAssetCoinOptionsViewModel({ currency: bitcoin, currencyId, marketId }),
     {
       overrideInitialState: (state: State): State => ({
         ...state,
@@ -82,14 +84,15 @@ describe("useAssetCoinOptionsViewModel", () => {
     expect(store.getState().settings.starredMarketCoins).toContain("shiba-inu");
   });
 
-  it("prefers marketId over currencyId as the star key so favourites stay aligned with the Market list", () => {
-    const { result, store } = renderViewModel({ marketId: "bitcoin-coingecko-id" });
+  it("persists DAI's market id instead of the DAI V2 Ledger token id", () => {
+    const daiV2Id = "ethereum/erc20/dai_stablecoin_v2_0";
+    const { result, store } = renderViewModel({ currencyId: daiV2Id, marketId: "dai" });
 
     act(() => result.current.onToggleFavourite());
 
     const { starredMarketCoins } = store.getState().settings;
-    expect(starredMarketCoins).toContain("bitcoin-coingecko-id");
-    expect(starredMarketCoins).not.toContain(bitcoin.id);
+    expect(starredMarketCoins).toContain("dai");
+    expect(starredMarketCoins).not.toContain(daiV2Id);
   });
 
   it("persists the hidden state and tracks analytics in both directions", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/assetsList.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/assetsList.integration.test.tsx
@@ -30,6 +30,14 @@ const enableAssetDiscoverability = withFlagOverrides({
   lwmWallet40: { enabled: true, params: { assetDiscoverability: true } },
 });
 
+const daiMarket = {
+  ...marketsMock[0],
+  id: "dai",
+  ledgerIds: ["ethereum/erc20/dai_stablecoin_v2_0"],
+  ticker: "dai",
+  name: "Dai",
+};
+
 function withStarredMarketCoins(starredMarketCoins: string[] = []) {
   return withFlagOverrides(
     { lwmWallet40: { enabled: true, params: { assetDiscoverability: true } } },
@@ -212,6 +220,37 @@ describe("MarketScreen assets list (Block 3)", () => {
     );
 
     expect(screen.queryByTestId("marketItem-ethereum")).toBeNull();
+  });
+
+  it("renders DAI when its canonical Market id is starred", async () => {
+    const marketRequests: string[] = [];
+    server.use(
+      http.get("https://countervalues.live.ledger.com/v3/markets", ({ request }) => {
+        marketRequests.push(request.url);
+        const ids = new URL(request.url).searchParams.get("ids")?.split(",") ?? [];
+        const data =
+          ids.length > 0 ? [daiMarket].filter(({ id }) => ids.includes(id)) : [daiMarket];
+
+        return HttpResponse.json(data);
+      }),
+    );
+
+    const { user } = renderWithReactQuery(<NavigatorWrapper />, {
+      overrideInitialState: withStarredMarketCoins(["dai"]),
+    });
+
+    await waitFor(() => expect(screen.getByTestId("marketItem-dai")).toBeVisible(), {
+      timeout: 5000,
+    });
+
+    await user.press(
+      screen.getByTestId(`${MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher}-starred`),
+    );
+
+    await waitFor(() => expect(screen.getByTestId("marketItem-dai")).toBeVisible(), {
+      timeout: 5000,
+    });
+    expect(marketRequests.some(url => new URL(url).searchParams.get("ids") === "dai")).toBe(true);
   });
 
   it("renders CVS stock rows after selecting the Stocks category", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/__tests__/usePortfolioSectionActions.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/__tests__/usePortfolioSectionActions.test.ts
@@ -57,6 +57,27 @@ describe("usePortfolioSectionActions", () => {
       });
     });
 
+    it("forwards the canonical Market id from a portfolio asset", () => {
+      const { result } = renderHook(() => usePortfolioSectionActions(false, "stablecoin"), {
+        overrideInitialState: withFlagOverrides({
+          lwmWallet40: { enabled: true, params: { aggregatedAssets: true } },
+        }),
+      });
+
+      act(() => {
+        result.current.onItemPress({ ...btcAsset, marketId: "dai" });
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.AssetDetail, {
+        screen: ScreenName.AssetDetail,
+        params: {
+          currencyId: mockBtcCryptoCurrency.id,
+          source: "portfolio",
+          marketState: { id: "dai", ledgerIds: [mockBtcCryptoCurrency.id] },
+        },
+      });
+    });
+
     it("navigates to MarketDetail for placeholder assets when aggregatedAssets is disabled", () => {
       const { result } = renderHook(() => usePortfolioSectionActions(false, "crypto"), {
         overrideInitialState: withFlagOverrides({

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StablecoinsSection/__tests__/usePortfolioStablecoinsSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StablecoinsSection/__tests__/usePortfolioStablecoinsSectionViewModel.test.ts
@@ -28,6 +28,7 @@ jest.mock("LLM/hooks/useCategorizedAssetsFromPortfolio", () => ({
 
 const toCategorizedItem = (asset: Asset) => ({
   currency: asset.currency,
+  marketId: asset.marketId,
   balance: asset.amount,
   value: 0,
   distribution: 0,
@@ -72,6 +73,14 @@ describe("usePortfolioStablecoinsSectionViewModel", () => {
 
       expect(result.current.assetsCount).toBe(1);
       expect(result.current.assetsToDisplay[0].currency).toBe(ethereum);
+    });
+
+    it("should preserve the Market id when mapping a stablecoin to an asset", () => {
+      mockPortfolioWithStablecoins([{ ...createAsset(ethereum, 2000), marketId: "dai" }]);
+
+      const { result } = renderHook(() => usePortfolioStablecoinsSectionViewModel());
+
+      expect(result.current.assetsToDisplay[0]?.marketId).toBe("dai");
     });
 
     it("should cap display at 6, report total count, and set hasMore when list exceeds limit", () => {

--- a/apps/ledger-live-mobile/src/mvvm/utils/assetUtils.ts
+++ b/apps/ledger-live-mobile/src/mvvm/utils/assetUtils.ts
@@ -3,6 +3,7 @@ import { Asset } from "~/types/asset";
 
 export const toAsset = (item: CategorizedAssetItem): Asset => ({
   currency: item.currency,
+  marketId: item.marketId,
   accounts: item.accounts,
   amount: item.balance,
   countervalue: item.value,

--- a/apps/ledger-live-mobile/src/reducers/settings.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.test.ts
@@ -13,6 +13,7 @@ import reducer, {
   counterValueCurrencySelector,
   counterValueIdOf,
   migrateLegacyCryptoCounterValue,
+  migrateLegacyStarredMarketCoins,
   INITIAL_STATE as SETTINGS_INITIAL_STATE,
   filterValidSettings,
 } from "./settings";
@@ -720,5 +721,23 @@ describe("migrateLegacyCryptoCounterValue", () => {
   it("leaves fiat tickers and already-migrated ids untouched", () => {
     expect(migrateLegacyCryptoCounterValue("USD")).toBe("USD");
     expect(migrateLegacyCryptoCounterValue("bitcoin")).toBe("bitcoin");
+  });
+});
+
+describe("migrateLegacyStarredMarketCoins", () => {
+  it("migrates the legacy DAI V2 identifier", () => {
+    expect(migrateLegacyStarredMarketCoins(["ethereum/erc20/dai_stablecoin_v2_0"])).toEqual([
+      "dai",
+    ]);
+  });
+
+  it("keeps the canonical DAI identifier unchanged", () => {
+    expect(migrateLegacyStarredMarketCoins(["dai"])).toEqual(["dai"]);
+  });
+
+  it("deduplicates legacy and canonical DAI identifiers while preserving order", () => {
+    expect(
+      migrateLegacyStarredMarketCoins(["bitcoin", "ethereum/erc20/dai_stablecoin_v2_0", "dai"]),
+    ).toEqual(["bitcoin", "dai"]);
   });
 });

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -709,6 +709,14 @@ const LEGACY_CRYPTO_COUNTERVALUE_TICKER_TO_ID: Record<string, string> = {
 export const migrateLegacyCryptoCounterValue = (counterValue: string): string =>
   LEGACY_CRYPTO_COUNTERVALUE_TICKER_TO_ID[counterValue] ?? counterValue;
 
+const LEGACY_DAI_V2_FAVORITE_ID = "ethereum/erc20/dai_stablecoin_v2_0";
+const DAI_MARKET_ID = "dai";
+
+export const migrateLegacyStarredMarketCoins = (starredMarketCoins: readonly string[]): string[] =>
+  Array.from(
+    new Set(starredMarketCoins.map(id => (id === LEGACY_DAI_V2_FAVORITE_ID ? DAI_MARKET_ID : id))),
+  );
+
 const counterValueCurrencyLocalSelector = (state: SettingsState): Currency =>
   findFiatCurrencyByTicker(state.counterValue) ||
   findCryptoCurrencyById(state.counterValue) ||

--- a/libs/asset-aggregation/src/assetCategorization/__tests__/categorizeAssets.test.ts
+++ b/libs/asset-aggregation/src/assetCategorization/__tests__/categorizeAssets.test.ts
@@ -1,5 +1,5 @@
 import { categorizeAssets } from "../categorizeAssets";
-import { btc, eth, usdtEth, usdcEth, makeDistItem, mockAccounts } from "./fixtures";
+import { btc, eth, usdtEth, usdcEth, makeDistItem, makeToken, mockAccounts } from "./fixtures";
 
 describe("categorizeAssets", () => {
   const stablecoinTickers = new Set(["USDT", "USDC"]);
@@ -40,6 +40,16 @@ describe("categorizeAssets", () => {
     expect(btcItem?.balance).toBe(1e8);
     expect(btcItem?.value).toBe(60000);
     expect(btcItem?.distribution).toBe(0.6);
+  });
+
+  it("should preserve the canonical Market id for DAI V2", () => {
+    const daiV2 = makeToken("ethereum/erc20/dai_stablecoin_v2_0", "DAI", "Dai Stablecoin v2.0");
+    const result = categorizeAssets([makeDistItem(daiV2, { marketId: "dai" })], new Set(["DAI"]));
+
+    expect(result.stablecoins[0]).toMatchObject({
+      currency: daiV2,
+      marketId: "dai",
+    });
   });
 
   it("should handle empty distribution", () => {

--- a/libs/asset-aggregation/src/assetCategorization/categorizeAssets.ts
+++ b/libs/asset-aggregation/src/assetCategorization/categorizeAssets.ts
@@ -12,6 +12,7 @@ export function categorizeAssets(
   for (const item of distribution) {
     const enriched: CategorizedAssetItem = {
       currency: item.currency,
+      marketId: item.marketId,
       balance: item.amount,
       value: item.countervalue ?? 0,
       distribution: item.distribution,

--- a/libs/asset-aggregation/src/assetCategorization/types.ts
+++ b/libs/asset-aggregation/src/assetCategorization/types.ts
@@ -3,6 +3,7 @@ import type { AccountLike } from "@ledgerhq/types-live";
 
 export type CategorizedAssetItem = {
   currency: CryptoCurrency | TokenCurrency;
+  marketId?: string;
   balance: number;
   value: number;
   distribution: number;

--- a/libs/asset-aggregation/src/assetDistribution/__tests__/resolveAssetMarketInputs.test.ts
+++ b/libs/asset-aggregation/src/assetDistribution/__tests__/resolveAssetMarketInputs.test.ts
@@ -36,15 +36,35 @@ describe("resolveAssetMarketInputs", () => {
       fallbackId: "fallback",
     });
 
-    expect(result.marketApiId).toBe("binancecoin");
+    expect(result).toMatchObject({
+      marketApiId: "binancecoin",
+      knownMarketId: "binancecoin",
+    });
+  });
+
+  it("resolves DAI V2 to its canonical market id", () => {
+    const result = resolveAssetMarketInputs({
+      distributionItem: item(cryptoCurrency("ethereum/erc20/dai_stablecoin_v2_0"), {
+        marketId: "dai",
+      }),
+    });
+
+    expect(result).toMatchObject({
+      knownLedgerIds: ["ethereum/erc20/dai_stablecoin_v2_0"],
+      knownMarketId: "dai",
+    });
   });
 
   it("falls back to distributionItem.slug when marketId is missing", () => {
     const result = resolveAssetMarketInputs({
       distributionItem: item(cryptoCurrency("bsc"), { slug: "binancecoin" }),
+      marketState: { id: "another-id" },
     });
 
-    expect(result.marketApiId).toBe("binancecoin");
+    expect(result).toMatchObject({
+      marketApiId: "binancecoin",
+      knownMarketId: "binancecoin",
+    });
   });
 
   it("falls back to distributionItem.currency.id when marketId and slug are missing", () => {

--- a/libs/asset-aggregation/src/assetDistribution/resolveAssetMarketInputs.ts
+++ b/libs/asset-aggregation/src/assetDistribution/resolveAssetMarketInputs.ts
@@ -52,7 +52,7 @@ export function resolveAssetMarketInputs({
   return {
     marketApiId,
     knownLedgerIds,
-    knownMarketId: marketState?.id,
+    knownMarketId: distributionItem?.marketId ?? distributionItem?.slug ?? marketState?.id,
   };
 }
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Adding and removing DAI V2 from the Wallet 4.0 asset detail favourites.
      - Displaying the resulting favourite under DAI in the Market favourites list.

### 📝 Description

DAI V2 can expose its Ledger token identifier (`ethereum/erc20/dai_stablecoin_v2_0`) before the Market query resolves. The favourites menu then persists that identifier, while the Market list expects the canonical `dai` identifier.

The shared asset Market input resolver now exposes the known Market identifier from the aggregated asset before the query completes:

```ts
knownMarketId: distributionItem?.marketId ?? distributionItem?.slug ?? marketState?.id;
```

Before, adding DAI V2 from the portfolio stored the Ledger token identifier and no favourite appeared in Market. After this change, it immediately stores `dai`, so the existing DAI Market favourite is displayed and can be removed normally.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34351](https://ledgerhq.atlassian.net/browse/LIVE-34351)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-34351]: https://ledgerhq.atlassian.net/browse/LIVE-34351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ