### PR TITLE
fix(hw-app-btc): add NU6.3 zcash consensus branch id

### DIFF
--- a/.changeset/zcash-nu63-branchid-hw-app-btc.md
+++ b/.changeset/zcash-nu63-branchid-hw-app-btc.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-app-btc": patch
+---
+
+Add the NU6.3 Zcash consensus branch id (0x37a5165b, mainnet activation height 3,428,143) to the transparent height→branch-id table, so transactions signed through the legacy (non-DMK) Btc path after NU6.3 activation are accepted by the network. Unknown block heights now default to the NU6.3 branch id.

--- a/libs/ledgerjs/packages/hw-app-btc/src/constants.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/constants.ts
@@ -20,6 +20,7 @@ export const OP_RETURN = 0x6a;
 export const ZCASH_ACTIVATION_HEIGHTS = {
   // https://zcash.readthedocs.io/en/latest/rtd_pages/nu_dev_guide.html
   //
+  NU6_3: 3428143,
   // https://z.cash/upgrade/nu6.2/
   NU6_2: 3364600,
   // https://zips.z.cash/zip-0255

--- a/libs/ledgerjs/packages/hw-app-btc/src/createTransaction.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/createTransaction.ts
@@ -38,8 +38,10 @@ const defaultsSignTransaction = {
 
 export const getZcashBranchId = (blockHeight: number | null | undefined): Buffer => {
   const branchId = Buffer.alloc(4);
-  if (!blockHeight || blockHeight >= ZCASH_ACTIVATION_HEIGHTS.NU6_2) {
+  if (!blockHeight || blockHeight >= ZCASH_ACTIVATION_HEIGHTS.NU6_3) {
     // NOTE: null and undefined should default to latest version
+    branchId.writeUInt32LE(0x37a5165b, 0);
+  } else if (blockHeight >= ZCASH_ACTIVATION_HEIGHTS.NU6_2) {
     branchId.writeUInt32LE(0x5437f330, 0);
   } else if (blockHeight >= ZCASH_ACTIVATION_HEIGHTS.NU6_1) {
     branchId.writeUInt32LE(0x4dec4df0, 0);

--- a/libs/ledgerjs/packages/hw-app-btc/tests/createTransaction.test.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/tests/createTransaction.test.ts
@@ -1,7 +1,23 @@
 import { ZCASH_ACTIVATION_HEIGHTS } from "../src/constants";
-import { getDefaultVersions } from "../src/createTransaction";
+import { getDefaultVersions, getZcashBranchId } from "../src/createTransaction";
 import { openTransportReplayer, RecordStore } from "@ledgerhq/hw-transport-mocker";
 import Btc from "../src/Btc";
+
+describe("getZcashBranchId", () => {
+  it("returns the NU6.3 branch id at and above its activation height", () => {
+    expect(getZcashBranchId(ZCASH_ACTIVATION_HEIGHTS.NU6_3)).toEqual(
+      Buffer.from([0x5b, 0x16, 0xa5, 0x37]),
+    );
+    expect(getZcashBranchId(ZCASH_ACTIVATION_HEIGHTS.NU6_3 - 1)).toEqual(
+      Buffer.from([0x30, 0xf3, 0x37, 0x54]),
+    );
+  });
+
+  it("defaults an unknown block height to the latest (NU6.3) branch id", () => {
+    expect(getZcashBranchId(undefined)).toEqual(Buffer.from([0x5b, 0x16, 0xa5, 0x37]));
+    expect(getZcashBranchId(null)).toEqual(Buffer.from([0x5b, 0x16, 0xa5, 0x37]));
+  });
+});
 
 describe("createTransaction", () => {
   describe("createTransaction", () => {

--- a/libs/live-signer-zcash/package.json
+++ b/libs/live-signer-zcash/package.json
@@ -28,7 +28,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/device-management-kit": "catalog:",
-    "@ledgerhq/device-signer-kit-zcash": "0.4.0",
+    "@ledgerhq/device-signer-kit-zcash": "0.4.1",
     "@ledgerhq/errors": "workspace:^",
     "rxjs": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12070,8 +12070,8 @@ importers:
         specifier: 'catalog:'
         version: 1.7.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-zcash':
-        specifier: 0.4.0
-        version: 0.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        specifier: 0.4.1
+        version: 0.4.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -17764,8 +17764,8 @@ packages:
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.5.1
 
-  '@ledgerhq/device-signer-kit-zcash@0.4.0':
-    resolution: {integrity: sha512-ipCVVjyWiRchK1iKu83v7VIc6IYQEIkgIseMSF1VLy/UpzEr3Ou29y8YsNFNTHoURznRUDqG5k6mF3xM64wPDg==}
+  '@ledgerhq/device-signer-kit-zcash@0.4.1':
+    resolution: {integrity: sha512-5syzQIqjsv8zMget2nJfVLJG6FpwebnVaV4Vk8TbaDQeZpN0O49KlKVXcxG5t6NqGh+uOP/8z6RpJdGm39obog==}
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.7.1
 
@@ -17921,6 +17921,11 @@ packages:
     resolution: {integrity: sha512-Ek4/NXGt6gfiZUmiAFE19534f8wnlQSHvZMsjmqCEktbJd/mYbzvTrvYeo0+PQPw2D/kTYD1fRC6ADKQRSBeGw==}
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.2.0
+
+  '@ledgerhq/signer-utils@1.3.0':
+    resolution: {integrity: sha512-qe+HQMgZxq6SPv8ghvlq4c33RchUwlf1qE/qp7MtUGPbKGAqD/0PKNyzx05sKLpmA8m6YZdtndHH4CEkikzqSQ==}
+    peerDependencies:
+      '@ledgerhq/device-management-kit': ^1.7.1
 
   '@ledgerhq/speculos-device-controller@0.3.0':
     resolution: {integrity: sha512-FCOGVs28pTxYEom+Yr8skQ1QUyj1+sC0YDvE+Xk+DfXQx8FMRI1l41x+XT8ZGPNUh8kRTd0hsZc2lqVpxD6a8w==}
@@ -46091,10 +46096,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-zcash@0.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-zcash@0.4.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@noble/hashes': 1.8.0
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
@@ -46439,6 +46444,11 @@ snapshots:
       semver: 7.7.2
 
   '@ledgerhq/signer-utils@1.2.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
+    dependencies:
+      '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
+      semver: 7.7.2
+
+  '@ledgerhq/signer-utils@1.3.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
       semver: 7.7.2


### PR DESCRIPTION
### 📝 Description

Add the NU6.3 Zcash consensus branch id to the `hw-app-btc` transparent height→branch-id table (`getZcashBranchId`), so transparent ZEC transactions signed through the legacy (non-DMK) `Btc` path after NU6.3 activation are accepted by the network.

**Previous behaviour**: the table topped out at NU6.2 (`0x5437f330`); a transparent send at a post-NU6.3 height (≥ `3_428_143`) would be signed with the NU6.2 branch id and rejected by the network.
**Fix**: heights ≥ `3_428_143` now map to `0x37a5165b`, and unknown heights default to it.
**Regression guard**: a new `getZcashBranchId` unit test asserts the NU6.2↔NU6.3 boundary (`3_428_142` → `0x5437f330`, `3_428_143` → `0x37a5165b`) and the unknown-height default.

This `hw-app-btc` table is the defensive fallback used when the `ldmkTransport` feature flag is **off**; when on, transparent ZEC signing routes through the DMK signer-zcash (see LIVE-34318). Mirrors the NU6.2 precedent #18183. **Consensus continuity only — no new Ironwood feature.** The mapping is height-driven, so it is safe to merge ahead of the 2026-07-28 mainnet activation.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34320](https://ledgerhq.atlassian.net/browse/LIVE-34320)
- **ADR** (if any): n/a


[LIVE-34320]: https://ledgerhq.atlassian.net/browse/LIVE-34320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ