### PR TITLE
[LWM] fix(live-mobile): align app-start upsell modal tracking naming

### DIFF
--- a/.changeset/quiet-pianos-wave.md
+++ b/.changeset/quiet-pianos-wave.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Align large-screen upsell app-start modal tracking names with the corrected plan while keeping retries and throttling analytics properties.

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
@@ -14,6 +14,7 @@ const NANO_S_OPTED_OUT_ANALYTICS_PROPS = {
   deviceModel: "lns",
   personalRecoOptIn: false,
   offerType: "none",
+  platform: "lwm",
   retriesUpsellModal: 0,
   throttled: false,
 };
@@ -147,8 +148,10 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
       expect(screen.getByTestId("large-screen-upsell-modal-drawer")).toBeVisible();
     });
 
-    expect(jest.mocked(analyticsScreen)).toHaveBeenCalledWith("Upgrade modal", undefined, {
-      name: "Upgrade modal",
+    expect(jest.mocked(analyticsScreen)).toHaveBeenCalledWith("Modal - Upgrade", undefined, {
+      name: "Modal - Upgrade",
+      sourceFlow: "app start",
+      modalFrequencyState: "every start",
       ...NANO_S_OPTED_OUT_ANALYTICS_PROPS,
     });
   });
@@ -172,8 +175,10 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
       expect(screen.getByTestId("large-screen-upsell-modal-drawer")).toBeVisible();
     });
 
-    expect(jest.mocked(analyticsScreen)).toHaveBeenCalledWith("Upgrade modal", undefined, {
-      name: "Upgrade modal",
+    expect(jest.mocked(analyticsScreen)).toHaveBeenCalledWith("Modal - Upgrade", undefined, {
+      name: "Modal - Upgrade",
+      sourceFlow: "app start",
+      modalFrequencyState: "every start",
       ...NANO_S_OPTED_IN_ANALYTICS_PROPS,
     });
   });
@@ -199,13 +204,13 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
 
     expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "explore large screen devices",
-      page: "Upgrade modal",
+      page: "Modal - Upgrade",
       ...NANO_S_OPTED_OUT_ANALYTICS_PROPS,
     });
     expect(track).not.toHaveBeenCalledWith("modal_dismissed", expect.anything());
   });
 
-  it("should track modal_dismissed with dismissMethod close_button exactly once when the header close button is pressed", async () => {
+  it("should track modal_dismissed with dismissMethod close button exactly once when the header close button is pressed", async () => {
     const overrideInitialState = withFlagOverrides(
       {
         largeScreenUpsell: { enabled: true },
@@ -229,8 +234,8 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
 
     expect(track).toHaveBeenCalledWith("modal_dismissed", {
       modal: "upgrade modal",
-      page: "Upgrade modal",
-      dismissMethod: "close_button",
+      page: "Modal - Upgrade",
+      dismissMethod: "close button",
       ...NANO_S_OPTED_OUT_ANALYTICS_PROPS,
     });
     expect(

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/analytics.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/analytics.ts
@@ -1,9 +1,9 @@
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { screen, track } from "~/analytics";
 
-export const LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME = "Upgrade modal";
+export const LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME = "Modal - Upgrade";
 
-export type LargeScreenUpsellDismissMethod = "close_button" | "outside_tap";
+export type LargeScreenUpsellDismissMethod = "close button" | "outside tap";
 
 export type LargeScreenUpsellNanoDeviceModelId =
   | DeviceModelId.nanoS
@@ -31,6 +31,7 @@ export type LargeScreenUpsellSharedAnalyticsProps = Readonly<{
   deviceModel: LargeScreenUpsellDeviceModelAnalyticsValue;
   personalRecoOptIn: boolean;
   offerType: "discount" | "none";
+  platform: "lwm";
   retriesUpsellModal: number;
   throttled: boolean;
 }>;
@@ -40,6 +41,8 @@ export function trackLargeScreenUpsellModalViewed(
 ) {
   screen(LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME, undefined, {
     name: LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME,
+    sourceFlow: "app start",
+    modalFrequencyState: "every start",
     ...sharedProps,
   });
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalDrawer/__tests__/LargeScreenUpsellModalDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalDrawer/__tests__/LargeScreenUpsellModalDrawer.test.tsx
@@ -103,14 +103,14 @@ describe("LargeScreenUpsellModalDrawer", () => {
     expect(onDismiss).not.toHaveBeenCalled();
   });
 
-  it("should report close_button exactly once when the header close button is pressed", () => {
+  it("should report close button exactly once when the header close button is pressed", () => {
     const onDismiss = jest.fn();
     renderLargeScreenUpsellModalDrawer(true, onDismiss);
 
     pressHeaderClose();
 
     expect(onDismiss).toHaveBeenCalledTimes(1);
-    expect(onDismiss).toHaveBeenCalledWith("close_button");
+    expect(onDismiss).toHaveBeenCalledWith("close button");
   });
 
   it("should ignore duplicate close signals for the same opening", () => {
@@ -123,26 +123,26 @@ describe("LargeScreenUpsellModalDrawer", () => {
     panDownToClose();
 
     expect(onDismiss).toHaveBeenCalledTimes(1);
-    expect(onDismiss).toHaveBeenCalledWith("close_button");
+    expect(onDismiss).toHaveBeenCalledWith("close button");
   });
 
-  it("should report outside_tap exactly once when the backdrop is pressed", () => {
+  it("should report outside tap exactly once when the backdrop is pressed", () => {
     const onDismiss = jest.fn();
     renderLargeScreenUpsellModalDrawer(true, onDismiss);
 
     pressBackdrop();
 
     expect(onDismiss).toHaveBeenCalledTimes(1);
-    expect(onDismiss).toHaveBeenCalledWith("outside_tap");
+    expect(onDismiss).toHaveBeenCalledWith("outside tap");
   });
 
-  it("should fall back to outside_tap when the sheet closes via pan-down gesture", () => {
+  it("should fall back to outside tap when the sheet closes via pan-down gesture", () => {
     const onDismiss = jest.fn();
     renderLargeScreenUpsellModalDrawer(true, onDismiss);
 
     panDownToClose();
 
     expect(onDismiss).toHaveBeenCalledTimes(1);
-    expect(onDismiss).toHaveBeenCalledWith("outside_tap");
+    expect(onDismiss).toHaveBeenCalledWith("outside tap");
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalDrawer/index.tsx
@@ -55,13 +55,13 @@ export function LargeScreenUpsellModalDrawer({
   );
 
   const handleHeaderClosePressed = useCallback(() => {
-    lastExplicitDismissMethodRef.current = "close_button";
-    reportDismiss("close_button");
+    lastExplicitDismissMethodRef.current = "close button";
+    reportDismiss("close button");
   }, [reportDismiss]);
 
   const handleBackdropPress = useCallback(() => {
-    lastExplicitDismissMethodRef.current = "outside_tap";
-    reportDismiss("outside_tap");
+    lastExplicitDismissMethodRef.current = "outside tap";
+    reportDismiss("outside tap");
   }, [reportDismiss]);
 
   const handleClose = useCallback(() => {
@@ -70,7 +70,7 @@ export function LargeScreenUpsellModalDrawer({
       return;
     }
 
-    reportDismiss("outside_tap");
+    reportDismiss("outside tap");
   }, [reportDismiss]);
 
   const shouldRenderContent = isOpen || hasRenderedContent;

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalPortfolioMount/useLargeScreenUpsellModalPortfolioMountViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalPortfolioMount/useLargeScreenUpsellModalPortfolioMountViewModel.ts
@@ -101,6 +101,7 @@ export function useLargeScreenUpsellModalPortfolioMountViewModel(): LargeScreenU
       deviceModel: toLargeScreenUpsellDeviceModelAnalyticsValue(eligibility.deviceModelId),
       personalRecoOptIn: personalizedRecommendationsEnabled,
       offerType: variant === "opted_in" ? "discount" : "none",
+      platform: "lwm",
       retriesUpsellModal: retries,
       throttled: hasReachedFrequencyCap,
     };
@@ -198,7 +199,7 @@ export function useLargeScreenUpsellModalPortfolioMountViewModel(): LargeScreenU
     featureIntroViewModel: {
       content,
       onPrimaryPress: onCloseFromCta,
-      onSecondaryPress: () => onDismiss("outside_tap"),
+      onSecondaryPress: () => onDismiss("outside tap"),
     },
     bottomInset: bottom + LARGE_SCREEN_UPSELL_MODAL_IOS_BOTTOM_PADDING,
   };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - App-start Large Screen Upsell modal analytics naming (`Modal - Upgrade`) and context fields.
  - Dismiss method values normalization (`close button` / `outside tap`) with existing deduplication behavior preserved.
  - Shared tracking payload consistency on mobile (`platform`, `retriesUpsellModal`, `throttled`).

### 📝 Description

This PR aligns the Large Screen Upsell app-start modal analytics on mobile with the corrected tracking naming conventions for the same LIVE-33155 initiative.

It updates the modal page name and dismiss method values to match the corrected plan, adds missing modal context fields (`sourceFlow`, `modalFrequencyState`, `platform`), and keeps the previously shipped retry/throttling properties and dismiss de-duplication behavior intact.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33155](https://ledgerhq.atlassian.net/browse/LIVE-33155)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-33155]: https://ledgerhq.atlassian.net/browse/LIVE-33155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ