### PR TITLE
docs(agents): add console-log convention skill

### DIFF
--- a/.agents/agents/code-reviewer.md
+++ b/.agents/agents/code-reviewer.md
@@ -20,6 +20,7 @@ Pay special attention to:
 - `.agents/skills/coin-families-contract/SKILL.md` — Coin-families contract: no coin-specific branches (`if (family === "evm")` etc.) in generic UI; extend the families contract and implement in `families/<family>/` instead
 - `.agents/skills/codeownership/SKILL.md` — Team-split convention: multi-team files should be split into `[foo]/index.ts` and `[foo]/team-[team]/*.ts`; suggest this when a touched file clearly involves many teams
 - `.agents/skills/knip-migration/SKILL.md` — Dead-code detection is moving to `knip`, which needs explicit (non-`./*`) `package.json#exports`; new packages must use explicit exports + knip, not `.unimportedrc.json`
+- `.agents/skills/console-log/SKILL.md` — Console logging levels: `console.error` is forwarded to monitoring tools as an error event; flag any new `console.error` that isn't an illegal/unexpected state
 
 ## Review Scope
 

--- a/.agents/skills/console-log/SKILL.md
+++ b/.agents/skills/console-log/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: console-log
+description: Convention for console logging levels across the monorepo.
+---
+
+# Console Logging Convention
+
+`console.error` is intercepted by monitoring tools (Datadog RUM, Sentry) and forwarded as an error event.
+
+- Use `console.warn` for expected or recoverable errors (network failures, optional feature unavailable, etc.)
+- Use `console.error` **only** for illegal/unexpected program states that should never occur in production
+- Prefer dropping the log entirely when the error is neither actionable nor surprising


### PR DESCRIPTION
Add `.agents/skills/console-log/SKILL.md` to document the convention: `console.error` is forwarded to monitoring tools as an error event; use `console.warn` for recoverable errors, `console.error` only for illegal states.

Reference the skill from `.agents/agents/code-reviewer.md` so code reviewers flag unexpected `console.error` usage.