### PR TITLE
test(e2e): use account without ASA opt in

### DIFF
--- a/e2e/desktop/tests/specs/subAccount.spec.ts
+++ b/e2e/desktop/tests/specs/subAccount.spec.ts
@@ -319,12 +319,7 @@ for (const transaction of transactionE2E) {
 
 const transactionsAddressInvalid = [
   {
-    transaction: new Transaction(
-      TokenAccount.ALGO_USDT_1,
-      TokenAccount.ALGO_USDT_2,
-      "0.1",
-      Fee.MEDIUM,
-    ),
+    transaction: new Transaction(TokenAccount.ALGO_USDT_1, Account.ALGO_3, "0.1", Fee.MEDIUM),
     recipient: undefined,
     expectedErrorMessage: "Recipient account has not opted in the selected ASA.",
     xrayTicket: "B2CQA-2702",

--- a/e2e/mobile/specs/send/sendInvalid/sendInvalidAddressALGO_USDT.spec.ts
+++ b/e2e/mobile/specs/send/sendInvalid/sendInvalidAddressALGO_USDT.spec.ts
@@ -1,8 +1,9 @@
+import { Account, TokenAccount } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { runSendInvalidAddressTest } from "../send";
 
 const transaction = new Transaction(
   TokenAccount.ALGO_USDT_1,
-  TokenAccount.ALGO_USDT_2,
+  Account.ALGO_3,
   "0.1",
   undefined,
   "noTag",

--- a/libs/live-e2e-shared/src/enum/Account.ts
+++ b/libs/live-e2e-shared/src/enum/Account.ts
@@ -21,6 +21,9 @@ export class Account {
   static readonly ALGO_1 = new Account(Currency.ALGO, "Algorand 1", 0, "44'/283'/0'/0/0");
   static readonly ALGO_2 = new Account(Currency.ALGO, "Algorand 2", 1, "44'/283'/1'/0/0");
 
+  // Algorand account without ASA (tokens) for specific scenarios
+  static readonly ALGO_3 = new Account(Currency.ALGO, "Algorand 3", 2, "44'/283'/2'/0/0");
+
   static readonly APTOS_1 = new Account(Currency.APT, "Aptos 1", 0, "44'/637'/0'/0'/0'");
   static readonly APTOS_2 = new Account(Currency.APT, "Aptos 2", 1, "44'/637'/1'/0'/0'");
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Refer to account specifically without ASA opt in for negative path error message test.

Mobile [regression](https://github.com/LedgerHQ/ledger-live/actions/runs/29249399861) for send:
- [iOS report](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/a7eca62c-ecf5-4cc6-923f-b24dac952355/)
- [Android report](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/9a39a358-4fc8-4550-8304-01f38a323a12/)

Desktop [regression](https://github.com/LedgerHQ/ledger-live/actions/runs/29249468406) for `subAccount.spec.ts`:
- [Allure report](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/d8a03464-76c1-4cfb-b6ef-be1c3798d392/)

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
