### PR TITLE
test(e2e): remove obsolete Solana default-validator delegate test (QAA-1396)

### DIFF
--- a/e2e/desktop/tests/specs/delegate.spec.ts
+++ b/e2e/desktop/tests/specs/delegate.spec.ts
@@ -54,7 +54,7 @@ const validators = [
   },
   {
     delegate: new Delegate(Account.SOL_3, "0.001", "Ledger by Figment"),
-    xrayTicket: "B2CQA-2730, B2CQA-2764",
+    xrayTicket: "B2CQA-2764",
   },
   {
     delegate: new Delegate(Account.NEAR_2, "0.01", "ledgerbyfigment.poolv1.near"),
@@ -504,13 +504,13 @@ for (const validator of validators) {
           await app.delegate.checkValidatorListIsVisible();
           await app.delegate.selectProviderOnRow(Number.parseInt(validator.delegate.provider, 10));
           await app.delegate.closeProviderList(Number.parseInt(validator.delegate.provider, 10));
+        } else if (validator.delegate.account.currency.name == Currency.SOL.name) {
+          await app.delegate.verifyContinueDisabled();
+          await app.delegate.selectProviderByName(validator.delegate.provider);
+          await app.delegate.verifyProviderTC(validator.delegate.provider);
         } else {
           await app.delegate.verifyFirstProviderName(validator.delegate.provider);
-          if (validator.delegate.account.currency.name == Currency.SOL.name) {
-            await app.delegate.verifyContinueDisabled();
-            await app.delegate.selectProviderByName(validator.delegate.provider);
-            await app.delegate.verifyProviderTC(validator.delegate.provider);
-          } else await app.delegate.verifyContinueEnabled();
+          await app.delegate.verifyContinueEnabled();
         }
         await app.delegate.verifyProvider(1);
         await app.delegate.openSearchProviderModal();

--- a/e2e/mobile/specs/delegate/delegate.ts
+++ b/e2e/mobile/specs/delegate/delegate.ts
@@ -126,33 +126,6 @@ export function runSuiUndelegateTest(delegation: DelegateType, tmsLinks: string[
   });
 }
 
-export function runDelegateDefaultValidatorTest(
-  delegation: DelegateType,
-  tmsLinks: string[],
-  tags: string[],
-) {
-  setTeamOwner(Team.COIN_INTEGRATION);
-  tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
-  tags.forEach(tag => $Tag(tag));
-  describe("Delegate - default validator", () => {
-    beforeAll(async () => {
-      await beforeAllFunction(delegation);
-    });
-
-    it(`Defaults to ${delegation.provider} on ${delegation.account.currency.name}`, async () => {
-      const currencyId =
-        getCurrencyManagerApp(delegation.account.currency.id) ?? delegation.account.currency.id;
-
-      await app.portfolio.goToAccounts(delegation.account.currency.name);
-      await app.common.goToAccountByName(delegation.account.accountName);
-      await app.account.tapEarn();
-
-      await app.stake.dismissDelegationStart(currencyId);
-      await app.stake.expectProvider(currencyId, delegation.provider);
-    });
-  });
-}
-
 export function runLockCelo(delegation: DelegateType, tmsLinks: string[], tags: string[]) {
   setTeamOwner(Team.COIN_INTEGRATION);
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));

--- a/e2e/mobile/specs/delegate/delegateSOLDefaultValidator.spec.ts
+++ b/e2e/mobile/specs/delegate/delegateSOLDefaultValidator.spec.ts
@@ -1,9 +1,0 @@
-import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
-import { runDelegateDefaultValidatorTest } from "./delegate";
-
-const delegation = new Delegate(Account.SOL_2, "0.001", "Ledger by Figment");
-runDelegateDefaultValidatorTest(
-  delegation,
-  ["B2CQA-2730"],
-  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@solana", "@family-solana"],
-);


### PR DESCRIPTION
### 📝 Description

Removes the obsolete Solana "default validator" delegate E2E test. The behaviour it asserted — a Ledger validator being **selected by default** on Solana ([B2CQA-2730](https://ledgerhq.atlassian.net/browse/B2CQA-2730)) — no longer applies: there is no longer any validator selected by default, so the test is not applicable to the expected behaviour anymore.

Provider-presence coverage is retained by the general Solana delegate test already in scope, [B2CQA-2742](https://ledgerhq.atlassian.net/browse/B2CQA-2742) (*Delegate on Solana*), which also asserts "Ledger by Figment" as the provider in the summary.

**Mobile (LWM)**
- Delete the dedicated `e2e/mobile/specs/delegate/delegateSOLDefaultValidator.spec.ts` (`Delegate - default validator › Defaults to Ledger by Figment on Solana`).
- Remove its now-orphaned `runDelegateDefaultValidatorTest` builder from `delegate.ts` (this spec was its only consumer).

**Desktop (LWD)**
- Drop `B2CQA-2730` from the Solana *Select a validator* entry (`xrayTicket` → `B2CQA-2764`).
- Stop asserting the default/first validator for Solana, while keeping the manual selection flow — so [B2CQA-2764](https://ledgerhq.atlassian.net/browse/B2CQA-2764) (*User should be able to select a validator*) coverage is preserved.

**Validation**
- `ledger-live-mobile-e2e-tests` typecheck ✅
- `ledger-live-desktop-e2e-tests` typecheck ✅
- `oxfmt --check` on changed files ✅

> Note: deletion of the `B2CQA-2730` test case in the B2CQA testing space is handled separately by QA once this is merged.

### 🧪 Triggered E2E CI

Manually dispatched on `support/remove-solana-default-validator-e2e` (commit `d4ddaff7c63`), scoped to `@solana` (this change is Solana-delegate only):

| Workflow | Scope | Run |
|---|---|---|
| [Desktop] E2E Only | `@solana`, Speculos nanoSP | [run 29250867502](https://github.com/LedgerHQ/ledger-live/actions/runs/29250867502) |
| [Mobile] E2E Only | `@solana`, iOS & Android, Speculos nanoSP | [run 29250869424](https://github.com/LedgerHQ/ledger-live/actions/runs/29250869424) |

### 🔗 Context

- **JIRA / GitHub issue**: [QAA-1396](https://ledgerhq.atlassian.net/browse/QAA-1396)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[B2CQA-2730]: https://ledgerhq.atlassian.net/browse/B2CQA-2730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[B2CQA-2742]: https://ledgerhq.atlassian.net/browse/B2CQA-2742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[B2CQA-2764]: https://ledgerhq.atlassian.net/browse/B2CQA-2764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ