### PR TITLE
test(e2e-desktop): scope modal locators to the settled container

### DIFF
--- a/e2e/desktop/tests/component/modal.component.ts
+++ b/e2e/desktop/tests/component/modal.component.ts
@@ -6,13 +6,13 @@ export class Modal extends Component {
   readonly container = this.page.locator(
     '[data-testid=modal-container][style*="opacity: 1"][style*="transform: scale(1)"]',
   );
-  readonly title = this.page.getByTestId("modal-title");
-  readonly content = this.page.getByTestId("modal-content");
-  readonly continueButton = this.page.getByRole("button", { name: "continue" });
+  readonly title = this.container.getByTestId("modal-title");
+  readonly content = this.container.getByTestId("modal-content");
+  readonly continueButton = this.container.getByRole("button", { name: "continue" });
 
   protected backdrop = this.page.getByTestId("modal-backdrop");
-  protected closeButton = this.page.getByTestId("modal-close-button");
-  protected maxAmountCheckbox = this.page.getByTestId("modal-max-checkbox");
+  protected closeButton = this.container.getByTestId("modal-close-button");
+  protected maxAmountCheckbox = this.container.getByTestId("modal-max-checkbox");
 
   @step("Click Continue button")
   async continue() {


### PR DESCRIPTION
## Context

Desktop E2E `[Tezos] Receive` (`receive.address.spec.ts`) was intermittently failing on CI with a 120s timeout on `#address-field`, non-reproducible locally.

Root cause: the Receive modal opens with a 200ms entrance animation (`opacity 0→1`, `transform: scale(1.1)→scale(1)`). The `continue()` helper clicked the Continue button directly on the page, so the click could land during the animation before the step's transition was wired. Playwright reported the click as successful, but the app never advanced from the **Account** step — Speculos was never even engaged (device stayed on "Application is ready"), so `#address-field` never rendered. Coins whose spec asserts a warning/menu before `continue()` got a natural settle-wait, which is why only Tezos flaked.

## Change

Nest the modal sub-locators under the already-defined settled `container` locator (`[data-testid=modal-container][style*="opacity: 1"][style*="transform: scale(1)"]`), so every interaction waits for the entrance animation to finish first:

- `title`, `content`, `continueButton`, `closeButton`, `maxAmountCheckbox` → scoped to `container`
- `backdrop` stays page-scoped — it's the container's ancestor, not a descendant

## Validation

[@Desktop E2E • triggered on test/e2e-modal-settled-container-locators by cunhabruno](https://github.com/LedgerHQ/ledger-live/actions/runs/29253265176)
