### PR TITLE
[LWD] fix(desktop): logger.critical now captures non-Error thrown values

### DIFF
--- a/.changeset/fix-logger-critical-non-error.md
+++ b/.changeset/fix-logger-critical-non-error.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix logger.critical not capturing non-Error thrown values

--- a/apps/ledger-live-desktop/src/renderer/logger/index.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/logger/index.test.ts
@@ -37,10 +37,10 @@ describe("renderer logger", () => {
       });
     });
 
-    it("should not call captureException when error is not an Error instance", () => {
+    it("should wrap non-Error values in Error and still call captureException", () => {
       logger.critical("string error");
-      expect(sentryRenderer.captureException).not.toHaveBeenCalled();
-      expect(datadogRenderer.captureException).not.toHaveBeenCalled();
+      expect(sentryRenderer.captureException).toHaveBeenCalledWith(new Error("string error"));
+      expect(datadogRenderer.captureException).toHaveBeenCalledWith(new Error("string error"));
     });
   });
 

--- a/apps/ledger-live-desktop/src/renderer/logger/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/logger/index.ts
@@ -339,15 +339,13 @@ export default {
         message: context,
       });
     }
-    if (error instanceof Error) {
-      logger.log("error", error?.message, {
-        stack: error?.stack,
-
-        ...error,
-      });
-      captureException(error);
-      datadog.captureException(error);
-    }
+    const err = error instanceof Error ? error : new Error(String(error));
+    logger.log("error", err.message, {
+      stack: err.stack,
+      ...err,
+    });
+    captureException(err);
+    datadog.captureException(err);
   },
   add,
   onLog: (log: LogEntry | string) => {


### PR DESCRIPTION
### 📝 Description

`logger.critical` previously did nothing when the caught value wasn't an `Error` instance. Non-Error rejects/throws (strings, plain objects, etc.) were silently dropped — no Sentry capture, no Datadog capture.

Fix: normalize with `const err = error instanceof Error ? error : new Error(String(error))` before forwarding to `captureException`.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34349](https://ledgerhq.atlassian.net/browse/LIVE-34349)

[LIVE-34349]: https://ledgerhq.atlassian.net/browse/LIVE-34349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ