### PR TITLE
[LWD] fix(LIVE-34367): re-enable db middleware after hard reset so identities are persisted

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
@@ -1,7 +1,7 @@
 import type { Dispatch, MiddlewareAPI, UnknownAction } from "@reduxjs/toolkit";
 import { setKey } from "~/renderer/storage";
 import type { State } from "../../reducers";
-import DBMiddleware from "../db";
+import DBMiddleware, { disable, enable } from "../db";
 
 jest.mock("~/renderer/storage", () => ({
   setKey: jest.fn(),
@@ -184,6 +184,42 @@ describe("DBMiddleware - featureFlags branch", () => {
 
     const persisted = mockedSetKey.mock.calls[0][2] as Record<string, unknown>;
     expect(persisted).not.toHaveProperty("remoteFlagsReady");
+  });
+});
+
+describe("DBMiddleware - disable / enable", () => {
+  beforeEach(() => {
+    mockedSetKey.mockReset();
+    enable(); // ensure clean enabled state before each test
+  });
+
+  afterEach(() => {
+    enable(); // always re-enable so other suites are unaffected
+  });
+
+  it("skips all persistence writes when disabled", () => {
+    disable();
+    const state = baseState();
+    const after: FakeState = { ...state, history: { entries: ["/"] } };
+    runMiddleware([state, after], { type: "ROUTER_LOCATION_CHANGED" });
+    expect(mockedSetKey).not.toHaveBeenCalled();
+  });
+
+  it("resumes persistence writes after enable()", () => {
+    disable();
+    enable();
+    const before = baseState();
+    const after: FakeState = { ...before, history: { entries: ["/"] } };
+    runMiddleware([before, after], { type: "ROUTER_LOCATION_CHANGED" });
+    expect(mockedSetKey).toHaveBeenCalledWith("app", "history", after.history);
+  });
+
+  it("calling enable() without a prior disable() is a no-op", () => {
+    enable();
+    const before = baseState();
+    const after: FakeState = { ...before, history: { entries: ["/"] } };
+    runMiddleware([before, after], { type: "ROUTER_LOCATION_CHANGED" });
+    expect(mockedSetKey).toHaveBeenCalledWith("app", "history", after.history);
   });
 });
 

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -33,9 +33,12 @@ import { accountsPersistedStateChanged } from "@ledgerhq/live-common/account/ind
 let DB_MIDDLEWARE_ENABLED = true;
 
 /** Used during hard reset (reset.ts): disable persist so we don't re-write app.json while clearing. */
-export const disable = (ms = 1000) => {
+export const disable = () => {
   DB_MIDDLEWARE_ENABLED = false;
-  setTimeout(() => (DB_MIDDLEWARE_ENABLED = true), ms);
+};
+
+export const enable = () => {
+  DB_MIDDLEWARE_ENABLED = true;
 };
 
 function accountsExportSelector(state: State) {

--- a/apps/ledger-live-desktop/src/renderer/reset.ts
+++ b/apps/ledger-live-desktop/src/renderer/reset.ts
@@ -7,7 +7,7 @@ import { useCountervaluesPolling } from "@ledgerhq/live-countervalues-react";
 import { resetAll, cleanCache } from "~/renderer/storage";
 import { resetStore } from "~/renderer/store";
 import { cleanAccountsCache } from "~/renderer/actions/accounts";
-import { disable as disableDBMiddleware } from "./middlewares/db";
+import { disable as disableDBMiddleware, enable as enableDBMiddleware } from "./middlewares/db";
 import { clearBridgeCache } from "./bridge/cache";
 
 function reload() {
@@ -18,7 +18,11 @@ export async function hardReset() {
   clearBridgeCache();
   log("clear-cache", "hardReset()");
   disableDBMiddleware();
-  await resetAll();
+  try {
+    await resetAll();
+  } finally {
+    enableDBMiddleware();
+  }
   resetStore();
   // Preserve the hard-reset flag across localStorage.clear() so init.tsx can detect it
   const hardResetFlag = window.localStorage.getItem("hard-reset");


### PR DESCRIPTION
> [!NOTE]
> This fixes a bug found independently during work on LIVE-34028. The regression is pre-existing and unrelated to that migration.

### 📝 Description

After a **Reset App** (hard reset) on Ledger Live Desktop, `userId`, `datadogId` and `deviceIds` are never written back to `app.json` on the next launch — `jq .data.identities` returns `null`.

**Root cause:** `hardReset()` calls `disable()` on the DB middleware to prevent stale writes during `resetAll()`. The original implementation used a 1-second auto-re-enable timeout. On the post-reload init path, `initIdentities` runs and dispatches `initFromScratch` — but still within that 1-second window — so the middleware skips the write. No further state change on `identities` occurs, so the key is never written.

**Fix:** Replace the blind timeout with an explicit `enable()` call immediately after `await resetAll()` resolves. The middleware is re-enabled as soon as the file is cleared, before `initIdentities` runs.

```ts
// reset.ts
disableDBMiddleware();
await resetAll();       // IPC queue drains; file cleared
enableDBMiddleware();   // ← added: re-enable before init
resetStore();
```

No change to the persisted data shape or any other reset behaviour.

**Regression test:** build the app, trigger Reset App, relaunch, inspect `app.json`:
```sh
cat ~/Library/Application\ Support/Ledger\ Live\ Beta/app.json | jq .data.identities
# should return a valid object, not null
```

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34367](https://ledgerhq.atlassian.net/browse/LIVE-34367)
- **ADR** (if any): N/A

[LIVE-34367]: https://ledgerhq.atlassian.net/browse/LIVE-34367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ