### PR TITLE
[LWD] test(desktop-e2e): borrow cold-start E2E (B2CQA-6062)

### DIFF
--- a/.changeset/borrow-cold-start-e2e.md
+++ b/.changeset/borrow-cold-start-e2e.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": minor
+---
+
+Add Playwright cold-start E2E for the portfolio Borrow entry point and Introducing Crypto Loan modal (B2CQA-6062, LIVE-33746).

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/BorrowEntryPoint/BorrowEntryPointView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/BorrowEntryPoint/BorrowEntryPointView.tsx
@@ -42,7 +42,7 @@ export function BorrowEntryPointView({ onClick }: BorrowEntryPointViewProps) {
             </CardContent>
           </CardLeading>
           <CardTrailing>
-            <Button appearance="base" size="sm">
+            <Button appearance="base" size="sm" data-testid="portfolio-borrow-entry-point-cta">
               {t("portfolio.borrowEntry.cta")}
             </Button>
           </CardTrailing>

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/BorrowEntryPoint/__tests__/BorrowEntryPoint.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/BorrowEntryPoint/__tests__/BorrowEntryPoint.test.tsx
@@ -36,7 +36,7 @@ describe("BorrowEntryPoint", () => {
   it("should call the view model handleClick when the CTA is clicked", async () => {
     const { user } = render(<BorrowEntryPoint />);
 
-    await user.click(screen.getByText(t("portfolio.borrowEntry.cta")));
+    await user.click(screen.getByTestId("portfolio-borrow-entry-point-cta"));
 
     expect(handleClick).toHaveBeenCalledTimes(1);
   });

--- a/e2e/desktop/tests/page/borrow.page.ts
+++ b/e2e/desktop/tests/page/borrow.page.ts
@@ -1,0 +1,37 @@
+import { expect, type Page } from "@playwright/test";
+import { step } from "tests/misc/reporters/step";
+import { WebViewAppPage } from "./webViewApp.page";
+
+export class BorrowPage extends WebViewAppPage {
+  protected readonly webviewIdentifier = "borrow";
+
+  private readonly borrowRoutePattern = /\/borrow/;
+  private readonly simulateLoanRoutePattern = /\/loan\/simulate-loan/;
+  private readonly introModalTitle = "Introducing Crypto Loan";
+
+  private introModal(webview: Page) {
+    return webview.getByRole("dialog").filter({
+      has: webview.getByRole("heading", { name: this.introModalTitle }),
+    });
+  }
+
+  private introModalHeading(webview: Page) {
+    return this.introModal(webview).getByRole("heading", { name: this.introModalTitle });
+  }
+
+  @step("Go and wait for Borrow app to be ready")
+  async goAndWaitForBorrowToBeReady(entryFn: () => Promise<void>) {
+    this._webviewPage = undefined;
+    await entryFn();
+    await expect(this.page).toHaveURL(this.borrowRoutePattern);
+    const webview = await this.getWebView();
+    await expect(webview).toHaveURL(this.simulateLoanRoutePattern);
+  }
+
+  @step("Verify Introducing Crypto Loan modal is visible")
+  async verifyIntroModalVisible() {
+    const webview = await this.getWebView();
+    await expect(this.introModal(webview)).toBeVisible();
+    await expect(this.introModalHeading(webview)).toBeVisible();
+  }
+}

--- a/e2e/desktop/tests/page/index.ts
+++ b/e2e/desktop/tests/page/index.ts
@@ -5,6 +5,7 @@ import { AddAccountModal } from "./modal/add.account.modal";
 import { AssetDrawer } from "./drawer/asset.drawer";
 import { AssetDetailPage } from "./assetDetail.page";
 import { AssetPage } from "./asset.page";
+import { BorrowPage } from "./borrow.page";
 import { BuyAndSellPage } from "./buyAndSell.page";
 import { DelegateDrawer } from "./drawer/delegate.drawer";
 import { DelegateModal } from "./modal/delegate.modal";
@@ -58,6 +59,7 @@ export class Application extends PageHolder {
   public assetDrawer = new AssetDrawer(this.page);
   public assetDetail = new AssetDetailPage(this.page);
   public assetPage = new AssetPage(this.page);
+  public borrow = new BorrowPage(this.page, this.electronApp);
   public buyAndSell = new BuyAndSellPage(this.page, this.electronApp);
   public delegate = new DelegateModal(this.page);
   public evmDelegate = new EvmDelegateModal(this.page);

--- a/e2e/desktop/tests/page/portfolio.page.ts
+++ b/e2e/desktop/tests/page/portfolio.page.ts
@@ -60,6 +60,8 @@ export class PortfolioPage extends AppPage {
   private readonly stocksSection = this.page.getByTestId("stocks-section");
   private readonly stocksExploreCta = this.page.getByTestId("stocks-explore");
   private readonly stocksSectionHeader = this.page.getByTestId("stocks-section-header-button");
+  private readonly borrowEntryPoint = this.page.getByTestId("portfolio-borrow-entry-point");
+  private readonly borrowEntryCtaButton = this.page.getByTestId("portfolio-borrow-entry-point-cta");
 
   private getExpectedCounterValuePattern(counterValue: string): RegExp {
     const countervalueAliases: Record<string, RegExp> = {
@@ -377,5 +379,16 @@ export class PortfolioPage extends AppPage {
   @step("Click the Stocks category title")
   async clickStocksSectionTitle() {
     await this.stocksSectionHeader.click();
+  }
+
+  @step("Expect borrow entry point to be visible")
+  async expectBorrowEntryPointVisible() {
+    await this.borrowEntryPoint.scrollIntoViewIfNeeded();
+    await expect(this.borrowEntryPoint).toBeVisible();
+  }
+
+  @step("Click borrow entry point")
+  async clickBorrowEntryPoint() {
+    await this.borrowEntryCtaButton.click();
   }
 }

--- a/e2e/desktop/tests/specs/borrow.cold-start.spec.ts
+++ b/e2e/desktop/tests/specs/borrow.cold-start.spec.ts
@@ -49,9 +49,9 @@ test.describe("Borrow cold start", () => {
       await app.mainNavigation.openTargetFromMainNavigation("home");
       await app.portfolio.expectBorrowEntryPointVisible();
 
-      await app.borrow.goAndWaitForBorrowToBeReady(async () => {
-        await app.portfolio.clickBorrowEntryPoint();
-      });
+      await app.borrow.goAndWaitForBorrowToBeReady(async () =>
+        app.portfolio.clickBorrowEntryPoint(),
+      );
 
       await app.borrow.verifyIntroModalVisible();
     },

--- a/e2e/desktop/tests/specs/borrow.cold-start.spec.ts
+++ b/e2e/desktop/tests/specs/borrow.cold-start.spec.ts
@@ -1,0 +1,57 @@
+import { test } from "tests/fixtures/common";
+import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { addTmsLink } from "tests/utils/allureUtils";
+import { getDescription } from "tests/utils/customJsonReporter";
+import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/helpers";
+import { liveDataCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
+import {
+  FF_BORROW_DESKTOP,
+  FF_LWD_WALLET_40_Q2_NO_ANALYTICS_CONSENT,
+} from "tests/utils/featureFlagUtils";
+
+const account = Account.ETH_4;
+const family = getFamilyByCurrencyId(account.currency.id);
+
+const tags = [
+  "@NanoSP",
+  "@LNS",
+  "@NanoX",
+  "@Stax",
+  "@Flex",
+  "@NanoGen5",
+  `@${account.currency.id}`,
+  ...(family ? [`@family-${family}`] : []),
+];
+
+test.describe("Borrow cold start", () => {
+  test.use({
+    userdata: "skip-onboarding-with-last-seen-device",
+    speculosApp: account.currency.speculosApp,
+    cliCommands: [liveDataCommand(account)],
+    speculosForSetupOnly: true,
+    featureFlags: {
+      ...FF_LWD_WALLET_40_Q2_NO_ANALYTICS_CONSENT,
+      ...FF_BORROW_DESKTOP,
+    },
+  });
+
+  test(
+    "Portfolio entry point opens borrow and shows Introducing Crypto Loan modal",
+    {
+      tag: tags,
+      annotation: { type: "TMS", description: "B2CQA-6062" },
+    },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+
+      await app.mainNavigation.openTargetFromMainNavigation("home");
+      await app.portfolio.expectBorrowEntryPointVisible();
+
+      await app.borrow.goAndWaitForBorrowToBeReady(async () => {
+        await app.portfolio.clickBorrowEntryPoint();
+      });
+
+      await app.borrow.verifyIntroModalVisible();
+    },
+  );
+});

--- a/e2e/desktop/tests/specs/borrow.cold-start.spec.ts
+++ b/e2e/desktop/tests/specs/borrow.cold-start.spec.ts
@@ -4,6 +4,7 @@ import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/helpers";
 import { liveDataCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
+import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import {
   FF_BORROW_DESKTOP,
   FF_LWD_WALLET_40_Q2_NO_ANALYTICS_CONSENT,
@@ -25,6 +26,7 @@ const tags = [
 
 test.describe("Borrow cold start", () => {
   test.use({
+    teamOwner: Team.EARN,
     userdata: "skip-onboarding-with-last-seen-device",
     speculosApp: account.currency.speculosApp,
     cliCommands: [liveDataCommand(account)],

--- a/e2e/desktop/tests/utils/featureFlagUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagUtils.ts
@@ -83,6 +83,13 @@ export const FF_LWD_WALLET_40_Q2_NO_ANALYTICS_CONSENT = {
   analyticsOptIn: { enabled: false },
 } satisfies OptionalFeatureMap;
 
+export const FF_BORROW_DESKTOP = {
+  ptxBorrowLiveApp: {
+    enabled: true,
+    params: { manifest_id: "borrow" },
+  },
+} satisfies OptionalFeatureMap;
+
 export const FF_EARN_V2_DESKTOP = {
   ...(useLocalEarnManifest && {
     ptxEarnLiveApp: {

--- a/libs/live-e2e-shared/src/enum/Account.ts
+++ b/libs/live-e2e-shared/src/enum/Account.ts
@@ -171,6 +171,7 @@ export class Account {
   );
   static readonly ETH_2_LOWER_CASE = new Account(Currency.ETH, "Ethereum 2", 1, "44'/60'/1'/0/0");
   static readonly ETH_3 = new Account(Currency.ETH, "Ethereum 3", 2, "44'/60'/2'/0/0");
+  static readonly ETH_4 = new Account(Currency.ETH, "Ethereum 4", 3, "44'/60'/3'/0/0");
   static readonly SANCTIONED_ETH = new Account(Currency.ETH, "Sanctioned Ethereum", 0, "");
 
   // Hedera accounts use pre-configured addresses because account IDs cannot be derived from path


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Portfolio → Borrow entry point (cold start)
  - Borrow webview loads and **Introducing Crypto Loan** intro modal is visible

### 📝 Description

Adds the first desktop Playwright E2E spec for the Borrow cold-start flow when `ptxBorrowLiveApp` is enabled (**B2CQA-6062**).

**Problem**: No automated E2E coverage for the portfolio Borrow entry point and intro modal on desktop.

**Solution**:
- New `borrow.cold-start.spec.ts` covering portfolio entry → borrow webview → intro modal
- `BorrowPage` page object (webview navigation + intro modal assertion)
- Portfolio page object helpers for the borrow entry point (i18n-safe CTA selector)
- `FF_BORROW_DESKTOP` and `FF_LWD_WALLET_40_Q2_NO_ANALYTICS_CONSENT` feature flags to enable Borrow and avoid analytics modal flakiness
- Changeset for `ledger-live-desktop-e2e-tests` (minor)

**Out of scope (follow-up PR, B2CQA-6065):** simulate loan, asset picker, open-loan execution with Speculos.

Locally verified: `pnpm e2e:desktop test:playwright borrow.cold-start` — 1 passed.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33746](https://ledgerhq.atlassian.net/browse/LIVE-33746)
- **Xray**: [B2CQA-6062](https://ledgerhq.atlassian.net/browse/B2CQA-6062)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33746]: https://ledgerhq.atlassian.net/browse/LIVE-33746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ