### PR TITLE
[LWD] fix(desktop): equal account card heights in accounts grid view

### DIFF
--- a/.changeset/tidy-cards-stretch.md
+++ b/.changeset/tidy-cards-stretch.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix unequal account-card heights in the Accounts grid view. Cards now stretch to fill their grid row, so a card whose title wraps to multiple lines no longer leaves shorter cards in the same row with an empty gap below them.

--- a/apps/ledger-live-desktop/src/renderer/screens/accounts/AccountGridItem/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/accounts/AccountGridItem/index.tsx
@@ -50,6 +50,7 @@ const Card = styled(Box).attrs(() => ({
   boxShadow: 0,
   borderRadius: 1,
 }))`
+  height: 100%;
   cursor: pointer;
   border: 1px solid transparent;
   transition: background-color ease-in-out 200ms;


### PR DESCRIPTION
### 📝 Description

In Ledger Live Desktop's Accounts grid view, cards in the same row can render at different heights. When one account's title wraps to two lines, that card grows taller and stretches the whole grid row, but the shorter-title cards next to it keep their natural height, leaving an empty gap below them.

The grid container (`AccountList/GridBody.tsx`) is a CSS grid with the default `align-items: stretch`, so it already stretches its direct grid children to the full row height. The direct child is the plain wrapper `<div>` rendered by `ContextMenuItem`, which does stretch. The break in the chain is the visible `Card` styled-component in `AccountGridItem/index.tsx`: it has no height, so it only takes its content height and does not fill the stretched wrapper.

This adds `height: 100%` to that `Card` block so each card fills its already-stretched grid cell and every card in a row matches the row height. The change is a single CSS line scoped to the grid card; it does not touch the shared `ContextMenuItem` wrapper or the list-view layout, so no other view is affected. Hidden cards use inline `display: none`, which is unchanged.

## Why this matters

This is a long-standing cosmetic bug (open since 2023, still reproducible on recent releases) that makes the Accounts grid look misaligned whenever any account name wraps to multiple lines. Equal-height cards are the expected behavior for a grid, and this restores it with a minimal, self-contained fix.

Note on verification: this is a visual CSS change. It was verified to compile and pass lint/typecheck for the desktop app, but was not run visually in the Electron app in this environment. Reviewers may want to confirm with before/after screenshots of a grid row containing a multi-line account title.

### 🔗 Context

- **GitHub issue**: Closes #4135
