### PR TITLE
fix(mobile): reset large-screen upsell retries only after successful CTA navigation

### DIFF
--- a/.changeset/quiet-points-chew.md
+++ b/.changeset/quiet-points-chew.md
@@ -1,5 +1,5 @@
 ---
-"live-mobile": minor
+"live-mobile": patch
 ---
 
 Fix large-screen upsell CTA to reset retries only after successful URL navigation

--- a/.changeset/quiet-points-chew.md
+++ b/.changeset/quiet-points-chew.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix large-screen upsell CTA to reset retries only after successful URL navigation

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalContent/__tests__/LargeScreenUpsellModalContent.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalContent/__tests__/LargeScreenUpsellModalContent.test.tsx
@@ -87,7 +87,7 @@ describe("LargeScreenUpsellModalContent", () => {
 
     await waitFor(() => expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com"));
     expect(openURLSpy).not.toHaveBeenCalled();
-    expect(onPrimaryPress).toHaveBeenCalledTimes(1);
+    expect(onPrimaryPress).not.toHaveBeenCalled();
   });
 
   it("should not open the primary CTA link when canOpenURL rejects", async () => {
@@ -97,7 +97,17 @@ describe("LargeScreenUpsellModalContent", () => {
 
     await waitFor(() => expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com"));
     expect(openURLSpy).not.toHaveBeenCalled();
-    expect(onPrimaryPress).toHaveBeenCalledTimes(1);
+    expect(onPrimaryPress).not.toHaveBeenCalled();
+  });
+
+  it("should not trigger onPrimaryPress when openURL rejects", async () => {
+    openURLSpy.mockRejectedValue(new Error("Unable to open URL"));
+
+    const { onPrimaryPress } = await renderAndPressPrimaryCta();
+
+    await waitFor(() => expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com"));
+    expect(openURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
+    expect(onPrimaryPress).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalContent/__tests__/LargeScreenUpsellModalContent.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalContent/__tests__/LargeScreenUpsellModalContent.test.tsx
@@ -75,9 +75,11 @@ describe("LargeScreenUpsellModalContent", () => {
   it("should open the primary CTA link when the platform can handle it", async () => {
     const { onPrimaryPress } = await renderAndPressPrimaryCta();
 
-    await waitFor(() => expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com"));
-    expect(openURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
-    expect(onPrimaryPress).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
+      expect(openURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
+      expect(onPrimaryPress).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("should not open the primary CTA link when the platform cannot handle it", async () => {
@@ -85,9 +87,11 @@ describe("LargeScreenUpsellModalContent", () => {
 
     const { onPrimaryPress } = await renderAndPressPrimaryCta();
 
-    await waitFor(() => expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com"));
-    expect(openURLSpy).not.toHaveBeenCalled();
-    expect(onPrimaryPress).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
+      expect(openURLSpy).not.toHaveBeenCalled();
+      expect(onPrimaryPress).not.toHaveBeenCalled();
+    });
   });
 
   it("should not open the primary CTA link when canOpenURL rejects", async () => {
@@ -95,9 +99,11 @@ describe("LargeScreenUpsellModalContent", () => {
 
     const { onPrimaryPress } = await renderAndPressPrimaryCta();
 
-    await waitFor(() => expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com"));
-    expect(openURLSpy).not.toHaveBeenCalled();
-    expect(onPrimaryPress).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
+      expect(openURLSpy).not.toHaveBeenCalled();
+      expect(onPrimaryPress).not.toHaveBeenCalled();
+    });
   });
 
   it("should not trigger onPrimaryPress when openURL rejects", async () => {
@@ -105,9 +111,39 @@ describe("LargeScreenUpsellModalContent", () => {
 
     const { onPrimaryPress } = await renderAndPressPrimaryCta();
 
-    await waitFor(() => expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com"));
-    expect(openURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
+    await waitFor(() => {
+      expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
+      expect(openURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
+      expect(onPrimaryPress).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should ignore repeated CTA presses while URL opening is in flight", async () => {
+    let resolveOpenURL: (() => void) | null = null;
+    openURLSpy.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveOpenURL = resolve;
+        }),
+    );
+
+    const { onPrimaryPress, user } = renderLargeScreenUpsellModalContent();
+    const cta = screen.getByTestId("large-screen-upsell-modal-primary-button");
+
+    await user.press(cta);
+    await user.press(cta);
+
+    await waitFor(() => {
+      expect(canOpenURLSpy).toHaveBeenCalledTimes(1);
+      expect(openURLSpy).toHaveBeenCalledTimes(1);
+    });
     expect(onPrimaryPress).not.toHaveBeenCalled();
+
+    resolveOpenURL?.();
+
+    await waitFor(() => {
+      expect(onPrimaryPress).toHaveBeenCalledTimes(1);
+    });
   });
 
   it.each([

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalContent/__tests__/LargeScreenUpsellModalContent.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalContent/__tests__/LargeScreenUpsellModalContent.test.tsx
@@ -87,11 +87,10 @@ describe("LargeScreenUpsellModalContent", () => {
 
     const { onPrimaryPress } = await renderAndPressPrimaryCta();
 
-    await waitFor(() => {
-      expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
-      expect(openURLSpy).not.toHaveBeenCalled();
-      expect(onPrimaryPress).not.toHaveBeenCalled();
-    });
+    await waitFor(() => expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com"));
+    await expect(canOpenURLSpy.mock.results[0]?.value).resolves.toBe(false);
+    expect(openURLSpy).not.toHaveBeenCalled();
+    expect(onPrimaryPress).not.toHaveBeenCalled();
   });
 
   it("should not open the primary CTA link when canOpenURL rejects", async () => {
@@ -99,11 +98,10 @@ describe("LargeScreenUpsellModalContent", () => {
 
     const { onPrimaryPress } = await renderAndPressPrimaryCta();
 
-    await waitFor(() => {
-      expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
-      expect(openURLSpy).not.toHaveBeenCalled();
-      expect(onPrimaryPress).not.toHaveBeenCalled();
-    });
+    await waitFor(() => expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com"));
+    await expect(canOpenURLSpy.mock.results[0]?.value).rejects.toThrow("Unsupported URL");
+    expect(openURLSpy).not.toHaveBeenCalled();
+    expect(onPrimaryPress).not.toHaveBeenCalled();
   });
 
   it("should not trigger onPrimaryPress when openURL rejects", async () => {
@@ -111,11 +109,9 @@ describe("LargeScreenUpsellModalContent", () => {
 
     const { onPrimaryPress } = await renderAndPressPrimaryCta();
 
-    await waitFor(() => {
-      expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
-      expect(openURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
-      expect(onPrimaryPress).not.toHaveBeenCalled();
-    });
+    await waitFor(() => expect(openURLSpy).toHaveBeenCalledWith("https://www.ledger.com"));
+    await expect(openURLSpy.mock.results[0]?.value).rejects.toThrow("Unable to open URL");
+    expect(onPrimaryPress).not.toHaveBeenCalled();
   });
 
   it("should ignore repeated CTA presses while URL opening is in flight", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalContent/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalContent/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useRef } from "react";
 import { Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
 import { Image, Linking } from "react-native";
 import { useThemedAwarenessModalImage } from "LLM/features/GenericAwarenessModal/hooks/useThemedAwarenessModalImage";
@@ -20,24 +20,40 @@ export function LargeScreenUpsellModalContent({ viewModel }: LargeScreenUpsellMo
   const { imageUrlLight, imageUrlDark, title, subtitle, primaryButtonLabel, primaryButtonLink } =
     content;
   const { imageUrl, showImage } = useThemedAwarenessModalImage({ imageUrlLight, imageUrlDark });
+  const isHandlingCtaPressRef = useRef(false);
   const resolvedPrimaryButtonLink = primaryButtonLink.trim();
   const showPrimaryButton =
     primaryButtonLabel.trim().length > 0 && resolvedPrimaryButtonLink.length > 0;
 
   const handleCtaPress = useCallback(async () => {
+    if (isHandlingCtaPressRef.current) {
+      return;
+    }
+
+    isHandlingCtaPressRef.current = true;
+
     const canOpenPrimaryButtonLink = await Linking.canOpenURL(resolvedPrimaryButtonLink).catch(
       () => false,
     );
 
-    if (!canOpenPrimaryButtonLink) return;
+    if (!canOpenPrimaryButtonLink) {
+      isHandlingCtaPressRef.current = false;
+      return;
+    }
 
-    const hasOpenedPrimaryButtonLink = await Linking.openURL(resolvedPrimaryButtonLink)
-      .then(() => true)
-      .catch(() => false);
+    try {
+      const hasOpenedPrimaryButtonLink = await Linking.openURL(resolvedPrimaryButtonLink)
+        .then(() => true)
+        .catch(() => false);
 
-    if (!hasOpenedPrimaryButtonLink) return;
+      if (!hasOpenedPrimaryButtonLink) {
+        return;
+      }
 
-    onPrimaryPress();
+      onPrimaryPress();
+    } finally {
+      isHandlingCtaPressRef.current = false;
+    }
   }, [onPrimaryPress, resolvedPrimaryButtonLink]);
 
   return (

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalContent/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalContent/index.tsx
@@ -25,14 +25,19 @@ export function LargeScreenUpsellModalContent({ viewModel }: LargeScreenUpsellMo
     primaryButtonLabel.trim().length > 0 && resolvedPrimaryButtonLink.length > 0;
 
   const handleCtaPress = useCallback(async () => {
-    onPrimaryPress();
     const canOpenPrimaryButtonLink = await Linking.canOpenURL(resolvedPrimaryButtonLink).catch(
       () => false,
     );
 
-    if (canOpenPrimaryButtonLink) {
-      await Linking.openURL(resolvedPrimaryButtonLink).catch(() => undefined);
-    }
+    if (!canOpenPrimaryButtonLink) return;
+
+    const hasOpenedPrimaryButtonLink = await Linking.openURL(resolvedPrimaryButtonLink)
+      .then(() => true)
+      .catch(() => false);
+
+    if (!hasOpenedPrimaryButtonLink) return;
+
+    onPrimaryPress();
   }, [onPrimaryPress, resolvedPrimaryButtonLink]);
 
   return (


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Large-screen upsell CTA behavior when URL opening fails
      - Retry counter consistency with real user navigation outcome
      - Regression coverage for `canOpenURL` and `openURL` failure paths

### 📝 Description

The large-screen upsell modal was resetting retries and closing as soon as the CTA was tapped, even when the external upsell URL could not be opened on device.

This PR updates the CTA flow so the success handler (`onPrimaryPress`) runs only after both `Linking.canOpenURL` and `Linking.openURL` succeed. This keeps modal frequency state aligned with actual user navigation and prevents false-positive resets.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-34369

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)