### PR TITLE
test(e2e-desktop): review and simplify swap specs and page (QAA-1118)

### DIFF
--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -182,50 +182,32 @@ export class SwapPage extends WebViewAppPage {
   @step("Select available provider without KYC")
   async selectExchangeWithoutKyc(swap?: Swap) {
     const webview = await this.getWebView();
-
     const providersList = await this.getProviderList();
-
-    // Check if the swap is ETH <-> SOL pair (exclude LiFi for these pairs)
+    const isLns = process.env.SPECULOS_DEVICE === Device.LNS.name;
     const isEthSolPair =
-      swap &&
+      !!swap &&
       ((swap.accountToDebit.currency.id === Currency.ETH.id &&
         swap.accountToCredit.currency.id === Currency.SOL.id) ||
         (swap.accountToDebit.currency.id === Currency.SOL.id &&
           swap.accountToCredit.currency.id === Currency.ETH.id));
 
-    const providersWithoutKYC = providersList.filter(providerName => {
-      const provider = Object.values(SwapProvider).find(p => p.uiName === providerName);
-      if (!provider || provider.kyc) {
-        return false;
-      }
+    const provider = providersList
+      .map(uiName => SwapProvider.getByUiName(uiName))
+      .find(
+        p =>
+          !!p &&
+          !p.kyc &&
+          !p.app &&
+          !(isEthSolPair && p.name === SwapProvider.LIFI.name) &&
+          (!isLns || p.availableOnLns),
+      );
 
-      // Exclude LiFi for ETH <-> SOL pairs on all devices
-      if (isEthSolPair && provider.name === SwapProvider.LIFI.name) {
-        return false;
-      }
-
-      // Additional filter for LNS devices
-      if (process.env.SPECULOS_DEVICE === Device.LNS.name) {
-        return provider.availableOnLns;
-      }
-
-      return true;
-    });
-
-    for (const providerName of providersWithoutKYC) {
-      const provider = Object.values(SwapProvider).find(p => p.uiName === providerName);
-      if (provider && !provider.app) {
-        const providerLocator = webview
-          .locator(this.specificQuoteCardProviderName(provider.name))
-          .first();
-
-        await providerLocator.click();
-
-        return provider;
-      }
+    if (!provider) {
+      throw new Error(`No providers without KYC found: ${providersList.join(", ")}`);
     }
 
-    throw new Error(`No providers without KYC found: ${providersList.join(", ")}`);
+    await webview.locator(this.specificQuoteCardProviderName(provider.name)).first().click();
+    return provider;
   }
 
   @step("Select available provider")

--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -194,12 +194,12 @@ export class SwapPage extends WebViewAppPage {
     const provider = providersList
       .map(uiName => SwapProvider.getByUiName(uiName))
       .find(
-        p =>
-          !!p &&
-          !p.kyc &&
-          !p.app &&
-          !(isEthSolPair && p.name === SwapProvider.LIFI.name) &&
-          (!isLns || p.availableOnLns),
+        providerEntry =>
+          !!providerEntry &&
+          !providerEntry.kyc &&
+          !providerEntry.app &&
+          !(isEthSolPair && providerEntry.name === SwapProvider.LIFI.name) &&
+          (!isLns || providerEntry.availableOnLns),
       );
 
     if (!provider) {

--- a/e2e/desktop/tests/specs/accounts.swap.spec.ts
+++ b/e2e/desktop/tests/specs/accounts.swap.spec.ts
@@ -53,7 +53,7 @@ test.describe("Swap - Default currency when landing on swap", () => {
   });
 
   test(
-    `Swap ${fromAccount.currency.name} to ${toAccount.currency.name} - Default currency`,
+    `Swap ${fromAccount.currency.name} to ${toAccount.currency.name} - Default currency and previous set up`,
     {
       tag: [
         "@NanoSP",
@@ -67,50 +67,32 @@ test.describe("Swap - Default currency when landing on swap", () => {
         "@bitcoin",
         "@family-bitcoin",
       ],
-      annotation: { type: "TMS", description: "B2CQA-3079" },
+      annotation: { type: "TMS", description: "B2CQA-3079, B2CQA-3080" },
     },
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-      await app.swap.goAndWaitForSwapToBeReady(() =>
-        app.mainNavigation.openTargetFromMainNavigation("swap"),
-      );
-      await app.swap.checkAssetFromContains("BTC");
-      await app.swap.checkAssetToContains("Choose asset");
-    },
-  );
+      await test.step("Default currency is set when landing on swap", async () => {
+        await app.swap.goAndWaitForSwapToBeReady(() =>
+          app.mainNavigation.openTargetFromMainNavigation("swap"),
+        );
+        await app.swap.checkAssetFromContains("BTC");
+        await app.swap.checkAssetToContains("Choose asset");
+      });
 
-  test(
-    `Swap ${fromAccount.currency.name} to ${toAccount.currency.name} - Previous set up`,
-    {
-      tag: [
-        "@NanoSP",
-        "@LNS",
-        "@NanoX",
-        "@Stax",
-        "@Flex",
-        "@NanoGen5",
-        "@ethereum",
-        "@family-evm",
-        "@bitcoin",
-        "@family-bitcoin",
-      ],
-      annotation: { type: "TMS", description: "B2CQA-3080" },
-    },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await test.step("Currencies persist after leaving and returning to swap", async () => {
+        const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);
+        const swap = new Swap(fromAccount, toAccount, minAmount);
 
-      const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);
-      const swap = new Swap(fromAccount, toAccount, minAmount);
-
-      await performSwapUntilQuoteSelectionStep(app, swap, minAmount);
-      await app.mainNavigation.openTargetFromMainNavigation("accounts");
-      await app.accounts.expectAccountsTitleVisibility();
-      await app.swap.goAndWaitForSwapToBeReady(() =>
-        app.mainNavigation.openTargetFromMainNavigation("swap"),
-      );
-      await app.swap.checkAssetFromContains(swap.accountToDebit.currency.ticker);
-      await app.swap.checkAssetToContains(swap.accountToCredit.currency.ticker);
+        await performSwapUntilQuoteSelectionStep(app, swap, minAmount);
+        await app.mainNavigation.openTargetFromMainNavigation("accounts");
+        await app.accounts.expectAccountsTitleVisibility();
+        await app.swap.goAndWaitForSwapToBeReady(() =>
+          app.mainNavigation.openTargetFromMainNavigation("swap"),
+        );
+        await app.swap.checkAssetFromContains(swap.accountToDebit.currency.ticker);
+        await app.swap.checkAssetToContains(swap.accountToCredit.currency.ticker);
+      });
     },
   );
 });

--- a/e2e/desktop/tests/specs/accounts.swap.spec.ts
+++ b/e2e/desktop/tests/specs/accounts.swap.spec.ts
@@ -82,6 +82,9 @@ test.describe("Swap - Default currency when landing on swap", () => {
 
       await test.step("Currencies persist after leaving and returning to swap", async () => {
         const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);
+        if (!minAmount) {
+          throw new Error("Test failed: No quotes retrieved from swap API.");
+        }
         const swap = new Swap(fromAccount, toAccount, minAmount);
 
         await performSwapUntilQuoteSelectionStep(app, swap, minAmount);

--- a/e2e/desktop/tests/specs/provider.swap.spec.ts
+++ b/e2e/desktop/tests/specs/provider.swap.spec.ts
@@ -101,69 +101,7 @@ for (const { fromAccount, toAccount, provider, xrayTicket, bugTickets } of provi
   });
 }
 
-test.describe("Swap - Check Best Offer", () => {
-  const fromAccount = Account.ETH_1;
-  const toAccount = Account.BTC_NATIVE_SEGWIT_1;
-  setupEnv(true);
-
-  test.beforeEach(async () => {
-    const accountPair: string[] = [fromAccount, toAccount].map(acc =>
-      acc.currency.speculosApp.name.replace(/ /g, "_"),
-    );
-    setExchangeDependencies(accountPair.map(name => ({ name })));
-  });
-
-  test.use({
-    teamOwner: Team.SWAP,
-    userdata: "skip-onboarding-with-last-seen-device",
-    speculosApp: app,
-
-    cliCommandsOnApp: [
-      [
-        {
-          app: fromAccount.currency.speculosApp,
-          cmd: liveDataWithAddressCommand(fromAccount),
-        },
-        {
-          app: toAccount.currency.speculosApp,
-          cmd: liveDataWithAddressCommand(toAccount),
-        },
-      ],
-      { scope: "test" },
-    ],
-  });
-
-  test(
-    `Swap ${fromAccount.currency.name} to ${toAccount.currency.name} - Check "Best Offer"`,
-    {
-      tag: [
-        "@NanoSP",
-        "@LNS",
-        "@NanoX",
-        "@Stax",
-        "@Flex",
-        "@NanoGen5",
-        "@ethereum",
-        "@family-evm",
-        "@bitcoin",
-        "@family-bitcoin",
-      ],
-      annotation: { type: "TMS", description: "B2CQA-2327" },
-    },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-      const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);
-      const swap = new Swap(fromAccount, toAccount, minAmount);
-
-      await performSwapUntilQuoteSelectionStep(app, swap, minAmount);
-      await app.swap.selectExchangeWithoutKyc();
-      await app.swap.checkBestOffer();
-    },
-  );
-});
-
-test.describe("Swap - Landing page", () => {
+test.describe("Swap - Landing page and best offer", () => {
   const fromAccount = Account.ETH_1;
   const toAccount = TokenAccount.ETH_USDC_1;
 
@@ -197,10 +135,10 @@ test.describe("Swap - Landing page", () => {
   });
 
   test(
-    `Swap landing page`,
+    `Swap landing page and best offer`,
     {
       tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
-      annotation: { type: "TMS", description: "B2CQA-2918" },
+      annotation: { type: "TMS", description: "B2CQA-2918, B2CQA-2327" },
     },
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));


### PR DESCRIPTION
## Context

[QAA-1118](https://ledgerhq.atlassian.net/browse/QAA-1118) ("[LWD] Review swap specs and page", epic QAA-1101) is a cleanup checklist created **2026-03-31**. The target files have been refactored several times since, so the ticket had gone **stale**: some TODOs are already resolved, the quoted in-code `// TODO` comments no longer exist, and some symbol names in the ticket don't match today's code. This PR does the still-valid, unblocked work and documents the rest below.

## What this PR does

### 1. Simplify `selectExchangeWithoutKyc()` — `swap.page.ts`
Collapsed the two-pass logic (which scanned the `SwapProvider` enum **twice** — once in a `filter`, again in a click loop) into a single `.map(SwapProvider.getByUiName).find(predicate)`. All selection rules now live in one predicate: known provider, `!kyc`, `!app` (no dedicated device app), the ETH↔SOL LiFi exclusion, and the LNS `availableOnLns` gate.
- **Preserved** the optional `swap?` param and the ETH↔SOL/LiFi carve-out — they are live via `swapUtils.ts` and `send.swap.spec.ts` (the accounts `swapWithDifferentSeed` ETH→SOL case), so this is **not** dead code.

### 2. Merge "Default currency" + "Previous set up" — `accounts.swap.spec.ts`
Merged the two tests in the "Default currency when landing on swap" describe into a single test with two `test.step(...)` phases, keeping both TMS IDs (`B2CQA-3079`, `B2CQA-3080`). Saves one full device/Speculos setup.

### 3. Merge "Check Best Offer" into "Landing page" — `provider.swap.spec.ts`
"Landing page" was a superset of "Check Best Offer" (both call `checkBestOffer()`; Landing additionally runs `getProviderList()` + `checkQuotesContainerInfos()`). Removed the standalone "Check Best Offer" describe and moved its TMS onto the (renamed) "Landing page and best offer" test (`B2CQA-2918`, `B2CQA-2327`).

## Verification
- ✅ `pnpm --filter ledger-live-desktop-e2e-tests typecheck` — clean (exit 0)
- ✅ `prettier --check` on the 3 files — formatted correctly
- ✅ `oxlint` on the 3 files — **0 errors** (only pre-existing `no-shadow` warnings on the `async ({ app })` param, present across every test block)
- ⏳ Playwright swap specs not run locally (need Speculos + built app) → covered by **LWD e2e CI** on this PR

## Not done / could not be done for now

| Ticket TODO | Status | Reason |
|---|---|---|
| Merge 3 "no account yet" blocks into one test | **Not done — needs soft assertions** | Merging these requires soft assertions (`expect.soft`). Desktop e2e uses **no** soft assertions anywhere yet (available in Playwright 1.60, but no established convention/helper). Deferred to avoid introducing that pattern in this cleanup PR. |
| Merge "Switch send/receive" into "both not present" | **Not done** | Depends on the soft-assertion merge above; also uses different `userdata`. |
| Create `deeplink.swap.spec.ts` + move "Default currency" | **Deferred** | Desktop e2e has **no deeplink infrastructure** (no `openDeeplink`/`ledgerlive://` helper — only mobile/Detox has one). The affected tests navigate via the UI, not deeplinks, so a genuine deeplink spec needs a new Electron `open-url`/`deep-linking` IPC helper first — out of scope for a spec cleanup. |
| Remove 2× W40 branches in `entrypoint.swap.spec.ts` | **Blocked** | The branch is `isAggregatedAssetsEnabled()` (the ticket's `isWallet40Enabled()` no longer exists). It still **defaults OFF** (Wallet 4.0 Q1) and is used by `asset.page.ts` / `urlUtils.ts`; removing it now would break the default surface path. Unblocks only once Wallet 4.0 Q2 is deployed. `entrypoint.swap.spec.ts` is intentionally untouched here. |
| Organize the 4 provider flow groups | **Obsolete** | Already handled by `refactor(QAA-1264)` (2026-05-28), which split the provider spec; the array is now a clean 1inch + OKX list. Changelly is also disabled in the provider enum. |

## Coverage note (item 3)
Merging "Check Best Offer" into "Landing page" **drops the ETH→BTC pair** for the best-offer check; the best-offer *logic* stays covered on the ETH→USDC pair. If the BTC pair must be retained, the two blocks can be kept separate instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QAA-1118]: https://ledgerhq.atlassian.net/browse/QAA-1118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ