### PR TITLE
[LWM] feat(mobile): add estimated label for received amounts in mobile swaps

### DIFF
--- a/.changeset/calm-swaps-estimate.md
+++ b/.changeset/calm-swaps-estimate.md
@@ -1,0 +1,6 @@
+---
+"@shared/feature-flags": minor
+"live-mobile": minor
+---
+
+Show an estimated label for configured providers on completed mobile swaps.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4219,7 +4219,8 @@
               "sendPending": "Sending {{ticker}}",
               "sendCompleted": "Sent {{ticker}}",
               "receivePending": "Receiving {{ticker}}",
-              "receiveCompleted": "Received {{ticker}}"
+              "receiveCompleted": "Received {{ticker}}",
+              "estimated": "(Estimated)"
             },
             "details": {
               "networkFees": "Network fees",

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__integrations__/SwapTransactionStatusDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__integrations__/SwapTransactionStatusDrawer.integration.test.tsx
@@ -39,6 +39,7 @@ describe("SwapTransactionStatusDrawer", () => {
       receiveStatus: "finished",
       sentAmount: "0.1 BTC",
       receivedAmount: "2 ETH",
+      showReceivedAmountEstimated: true,
       feesAmount: "0.0001 BTC",
       receiveAccountName: "Ethereum 1",
       provider: "lifi",
@@ -63,6 +64,7 @@ describe("SwapTransactionStatusDrawer", () => {
     });
 
     expect(await screen.findByText("Swap BTC → ETH")).toBeOnTheScreen();
+    expect(screen.getByText("(Estimated)")).toBeVisible();
     expect(mockedUseSwapTransactionStatusViewModel).toHaveBeenCalledWith({
       params: { provider: "lifi", swapId: "swap-1" },
       onClose: expect.any(Function),

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/StatusSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/StatusSection.test.tsx
@@ -10,9 +10,11 @@ const ethereum = getCryptoCurrencyById("ethereum");
 function renderStatusSection({
   sendStatus = "pending",
   receiveStatus = "pending",
+  showReceivedAmountEstimated = false,
 }: {
   sendStatus?: TransactionStatusValue;
   receiveStatus?: TransactionStatusValue;
+  showReceivedAmountEstimated?: boolean;
 } = {}) {
   return render(
     <StatusSection
@@ -22,6 +24,7 @@ function renderStatusSection({
       receiveStatus={receiveStatus}
       sentAmount="0.1 BTC"
       receivedAmount="2 ETH"
+      showReceivedAmountEstimated={showReceivedAmountEstimated}
       isLoading={false}
     />,
   );
@@ -44,6 +47,39 @@ describe("StatusSection", () => {
     expect(screen.getByText("Receiving ETH")).toBeVisible();
     expect(screen.getByText("Refunded")).toBeVisible();
     expect(screen.getByText("Cancelled")).toBeVisible();
+  });
+
+  it("should render the estimated label under the received amount when enabled", () => {
+    renderStatusSection({
+      sendStatus: "finished",
+      receiveStatus: "finished",
+      showReceivedAmountEstimated: true,
+    });
+
+    expect(screen.getByText("(Estimated)")).toBeVisible();
+  });
+
+  it("should not render the estimated label when disabled", () => {
+    renderStatusSection({ sendStatus: "finished", receiveStatus: "finished" });
+
+    expect(screen.queryByText("(Estimated)")).toBeNull();
+  });
+
+  it("should not render the estimated label while the received amount is unavailable", () => {
+    render(
+      <StatusSection
+        sendCurrency={bitcoin}
+        receiveCurrency={ethereum}
+        sendStatus="finished"
+        receiveStatus="finished"
+        sentAmount="0.1 BTC"
+        receivedAmount={undefined}
+        showReceivedAmountEstimated
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.queryByText("(Estimated)")).toBeNull();
   });
 
   it("should hide title and status labels while loading", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/useSwapTransactionStatusViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/useSwapTransactionStatusViewModel.test.ts
@@ -1,6 +1,7 @@
-import { renderHook, waitFor } from "@tests/test-renderer";
+import { renderHook, waitFor, withFlagOverrides } from "@tests/test-renderer";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import type { TransactionStatusValue } from "@ledgerhq/live-common/wallet-api/Exchange/transactionStatus/index";
 import type { Account } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getSwapProvider } from "@ledgerhq/live-common/exchange/providers/swap";
@@ -56,6 +57,29 @@ const withTestAccounts =
     accounts: { ...state.accounts, active: accounts },
     settings: { ...state.settings, locale: "en-US" },
   });
+
+function mockSwapStatus(provider: string, receiveStatus: TransactionStatusValue) {
+  mockedUseSwapTransactionStatus.mockReturnValue({
+    phase: "settled_visible",
+    latestStatus: {
+      provider,
+      swapId: "swap-1",
+      status: receiveStatus,
+    },
+    details: {
+      provider,
+      swapId: "swap-1",
+      status: receiveStatus,
+      sendStatus: "finished",
+      receiveStatus,
+      fromAccountId: sendAccount.id,
+      toAccountId: receiveAccount.id,
+      receivedAmount: "2000000000000000000",
+    },
+    isInitialLoading: false,
+    isSettled: true,
+  });
+}
 
 describe("useSwapTransactionStatusViewModel", () => {
   beforeEach(() => {
@@ -127,10 +151,86 @@ describe("useSwapTransactionStatusViewModel", () => {
     expect(result.current.explorerUrl).toBe("https://scan.li.fi/tx/hash-1");
     expect(result.current.isStatusSectionLoading).toBe(false);
     expect(result.current.isFooterLoading).toBe(false);
+    expect(result.current.showReceivedAmountEstimated).toBe(false);
 
     await waitFor(() => {
       expect(result.current.providerData?.mainUrl).toBe("https://provider.test");
     });
+  });
+
+  it("should mark a finished received amount as estimated when enabled for the provider", () => {
+    mockSwapStatus("moonpay", "finished");
+
+    const { result } = renderHook(
+      () =>
+        useSwapTransactionStatusViewModel({
+          params: { swapId: "swap-1", provider: "moonpay" },
+          onClose: jest.fn(),
+        }),
+      {
+        overrideInitialState: withFlagOverrides(
+          {
+            ptxSwapEstimatedReceivedAmount: {
+              enabled: true,
+              params: { providers: { moonpay: true } },
+            },
+          },
+          withTestAccounts([sendAccount, receiveAccount]),
+        ),
+      },
+    );
+
+    expect(result.current.showReceivedAmountEstimated).toBe(true);
+  });
+
+  it("should not mark a pending received amount as estimated", () => {
+    mockSwapStatus("moonpay", "pending");
+
+    const { result } = renderHook(
+      () =>
+        useSwapTransactionStatusViewModel({
+          params: { swapId: "swap-1", provider: "moonpay" },
+          onClose: jest.fn(),
+        }),
+      {
+        overrideInitialState: withFlagOverrides(
+          {
+            ptxSwapEstimatedReceivedAmount: {
+              enabled: true,
+              params: { providers: { moonpay: true } },
+            },
+          },
+          withTestAccounts([sendAccount, receiveAccount]),
+        ),
+      },
+    );
+
+    expect(result.current.showReceivedAmountEstimated).toBe(false);
+  });
+
+  it("should not mark a received amount as estimated when the feature is disabled", () => {
+    mockSwapStatus("moonpay", "finished");
+
+    const { result } = renderHook(
+      () =>
+        useSwapTransactionStatusViewModel({
+          params: { swapId: "swap-1", provider: "moonpay" },
+          onClose: jest.fn(),
+        }),
+      {
+        overrideInitialState: withFlagOverrides(
+          {
+            ptxSwapEstimatedReceivedAmount: {
+              enabled: false,
+              params: { providers: { moonpay: true } },
+            },
+          },
+          withTestAccounts([sendAccount, receiveAccount]),
+        ),
+      },
+    );
+
+    expect(result.current.showReceivedAmountEstimated).toBe(false);
   });
 
   it("should fall back to pending loading state when details are unavailable", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Status/StatusRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Status/StatusRow.tsx
@@ -14,6 +14,7 @@ type StatusRowProps = Readonly<{
   title: string;
   subtitle: string;
   value: React.ReactNode;
+  valueCaption?: string;
   isLoading: boolean;
   lineStatus?: SwapTransactionStatusDisplayStatus;
   isLast?: boolean;
@@ -25,6 +26,7 @@ export function StatusRow({
   title,
   subtitle,
   value,
+  valueCaption,
   isLoading,
   lineStatus,
   isLast,
@@ -39,7 +41,13 @@ export function StatusRow({
         {isLast ? null : <StatusLine status={lineStatus ?? status} />}
       </Box>
       <Box lx={{ flex: 1, gap: "s2" }}>
-        <Box lx={{ flexDirection: "row", justifyContent: "space-between", gap: "s12" }}>
+        <Box
+          lx={{
+            flexDirection: "row",
+            justifyContent: "space-between",
+            gap: "s12",
+          }}
+        >
           {isLoading ? (
             <Skeleton lx={{ height: "s16", width: "s112" }} />
           ) : (
@@ -47,17 +55,24 @@ export function StatusRow({
               {title}
             </Text>
           )}
-          {typeof value === "string" ? (
-            <Text
-              testID={testId ? `${testId}-amount` : undefined}
-              typography="body2SemiBold"
-              lx={{ color: "base", textAlign: "right" }}
-            >
-              {value}
-            </Text>
-          ) : (
-            value
-          )}
+          <Box lx={{ alignItems: "flex-end", gap: "s2" }}>
+            {typeof value === "string" ? (
+              <Text
+                testID={testId ? `${testId}-amount` : undefined}
+                typography="body2SemiBold"
+                lx={{ color: "base", textAlign: "right" }}
+              >
+                {value}
+              </Text>
+            ) : (
+              value
+            )}
+            {!isLoading && valueCaption ? (
+              <Text typography="body3" lx={{ color: "muted", textAlign: "right" }}>
+                {valueCaption}
+              </Text>
+            ) : null}
+          </Box>
         </Box>
         {isLoading ? (
           <Skeleton lx={{ height: "s14", width: "s72" }} />

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Status/StatusSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Status/StatusSection.tsx
@@ -12,6 +12,7 @@ type StatusSectionProps = Readonly<{
   receiveStatus: TransactionStatusValue;
   sentAmount?: string;
   receivedAmount?: string;
+  showReceivedAmountEstimated?: boolean;
   isLoading: boolean;
 }>;
 
@@ -22,9 +23,10 @@ export function StatusSection({
   receiveStatus,
   sentAmount,
   receivedAmount,
+  showReceivedAmountEstimated,
   isLoading,
 }: StatusSectionProps) {
-  const { heading, sendRow, receiveRow } = useStatusSectionViewModel({
+  const { heading, estimatedLabel, sendRow, receiveRow } = useStatusSectionViewModel({
     sendCurrency,
     receiveCurrency,
     sendStatus,
@@ -36,7 +38,14 @@ export function StatusSection({
       <Text typography="heading5SemiBold" lx={{ color: "base" }}>
         {heading}
       </Text>
-      <Box lx={{ gap: "s4", borderRadius: "md", backgroundColor: "surface", padding: "s12" }}>
+      <Box
+        lx={{
+          gap: "s4",
+          borderRadius: "md",
+          backgroundColor: "surface",
+          padding: "s12",
+        }}
+      >
         <StatusRow
           status={sendRow.status}
           title={sendRow.title}
@@ -51,6 +60,7 @@ export function StatusSection({
           title={receiveRow.title}
           subtitle={receiveRow.subtitle}
           value={receivedAmount ?? <Skeleton lx={{ height: "s16", width: "s96" }} />}
+          valueCaption={showReceivedAmountEstimated && receivedAmount ? estimatedLabel : undefined}
           isLoading={isLoading}
           isLast
           testId="swap-transaction-status-receive"

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/SwapTransactionStatusView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/SwapTransactionStatusView.tsx
@@ -15,6 +15,7 @@ export function SwapTransactionStatusView({
   receiveStatus,
   sentAmount,
   receivedAmount,
+  showReceivedAmountEstimated,
   feesAmount,
   receiveAccountName,
   receiveAccountCurrency,
@@ -45,6 +46,7 @@ export function SwapTransactionStatusView({
           receiveStatus={receiveStatus}
           sentAmount={sentAmount}
           receivedAmount={receivedAmount}
+          showReceivedAmountEstimated={showReceivedAmountEstimated}
           isLoading={isStatusSectionLoading}
         />
 

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useStatusSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useStatusSectionViewModel.ts
@@ -29,6 +29,7 @@ export function useStatusSectionViewModel({
 
   return {
     heading: t(`${TRANSLATION_PREFIX}.sections.status.heading`),
+    estimatedLabel: t(`${TRANSLATION_PREFIX}.sections.status.estimated`),
     sendRow: {
       status: statusItems.send.displayStatus,
       title: t(statusItems.send.titleKey, statusItems.send.titleValues),

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useSwapTransactionStatusViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useSwapTransactionStatusViewModel.ts
@@ -5,6 +5,7 @@ import {
   type SwapTransactionStatusTransactionExplorerBuilder,
 } from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { useFeature } from "@features/platform-feature-flags";
 import { useSelector } from "~/context/hooks";
 import byFamiliesOperationDetails from "~/generated/operationDetails";
 import { flattenAccountsSelector } from "~/reducers/accounts";
@@ -22,8 +23,9 @@ export function useSwapTransactionStatusViewModel({
   const transactionStatus = useSwapTransactionStatus({ params, onClose });
   const accounts = useSelector(flattenAccountsSelector);
   const locale = useSelector(localeSelector);
+  const estimatedReceivedAmountFeature = useFeature("ptxSwapEstimatedReceivedAmount");
 
-  return useSwapTransactionStatusDisplayViewModel({
+  const viewModel = useSwapTransactionStatusDisplayViewModel({
     params,
     transactionStatus,
     accounts,
@@ -31,6 +33,15 @@ export function useSwapTransactionStatusViewModel({
     useReceiveAccountName: useMaybeAccountName,
     useTransactionExplorerBuilder: useMobileTransactionExplorerBuilder,
   });
+
+  const showReceivedAmountEstimated =
+    estimatedReceivedAmountFeature?.enabled === true &&
+    viewModel.receiveStatus === "finished" &&
+    (viewModel.provider
+      ? estimatedReceivedAmountFeature.params?.providers?.[viewModel.provider] === true
+      : false);
+
+  return { ...viewModel, showReceivedAmountEstimated };
 }
 
 export type SwapTransactionStatusViewModel = ReturnType<typeof useSwapTransactionStatusViewModel>;

--- a/shared/feature-flags/src/flags/team-ptx/index.ts
+++ b/shared/feature-flags/src/flags/team-ptx/index.ts
@@ -16,6 +16,7 @@ export * from "./ptxPerpsLiveAppMobile";
 export * from "./ptxServiceCtaExchangeDrawer";
 export * from "./ptxServiceCtaScreens";
 export * from "./ptxSwapDetailedView";
+export * from "./ptxSwapEstimatedReceivedAmount";
 export * from "./ptxSwapExodusProvider";
 export * from "./ptxSwapLiveApp";
 export * from "./ptxSwapLiveAppKycWarning";

--- a/shared/feature-flags/src/flags/team-ptx/ptxSwapEstimatedReceivedAmount.ts
+++ b/shared/feature-flags/src/flags/team-ptx/ptxSwapEstimatedReceivedAmount.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import { flagWith } from "../../define";
+
+export const ptxSwapEstimatedReceivedAmount = flagWith(
+  {
+    providers: z.record(z.string(), z.boolean()),
+  },
+  {
+    enabled: false,
+    params: {
+      providers: {
+        changelly: false,
+        changelly_v2: false,
+        exodus: false,
+        cic: false,
+        cic_v2: false,
+        moonpay: true,
+        oneinch: false,
+        paraswap: false,
+        thorswap: false,
+        nearintents: false,
+        swapsxyz: false,
+        moonpay_trade: true,
+        lifi: false,
+        velora: false,
+        okx: false,
+      },
+    },
+  },
+);


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Show an estimated label for configured providers on completed mobile swaps.

<img width="397" height="845" alt="SCR-20260713-mysh" src="https://github.com/user-attachments/assets/3f34ec42-a03a-4f84-ab89-443221860541" />

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 --> https://ledgerhq.atlassian.net/browse/LIVE-34312
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
