### PR TITLE
[LWM] fix(mobile): enforce cooldown when onboarding date is missing

### DIFF
--- a/.changeset/tidy-llamas-fail.md
+++ b/.changeset/tidy-llamas-fail.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Backfill missing onboarding date to enforce large-screen upsell cooldown

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/__tests__/useLargeScreenUpsellEligibility.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/__tests__/useLargeScreenUpsellEligibility.test.ts
@@ -150,14 +150,15 @@ describe("useLargeScreenUpsellEligibility", () => {
     expect(result.current).toEqual({ isEligible: false, reason: "model_disabled" });
   });
 
-  it("should treat a null onboarding date as eligible defensively", () => {
+  it("should treat a null onboarding date as today and apply cooldown", () => {
     const { result } = renderEligibility({
       knownDeviceModelIds: [DeviceModelId.nanoX],
       onboardingDate: null,
     });
 
     expect(result.current).toEqual({
-      isEligible: true,
+      isEligible: false,
+      reason: "cooldown",
       deviceModelId: DeviceModelId.nanoX,
       cooldownDays: 30,
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/useLargeScreenUpsellEligibility.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/useLargeScreenUpsellEligibility.ts
@@ -1,8 +1,10 @@
+import { useEffect, useRef } from "react";
+import { setPostOnboardingDate } from "@ledgerhq/live-common/postOnboarding/actions";
 import { isCooldownElapsed } from "@ledgerhq/live-common/postOnboarding/logic/upsellFrequency";
 import { onboardingDateSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
 import { DeviceModelId, DevicesWithTouchScreen } from "@ledgerhq/types-devices";
 import { useFeature } from "@features/platform-feature-flags";
-import { useSelector } from "~/context/hooks";
+import { useDispatch, useSelector } from "~/context/hooks";
 import { knownDeviceModelIdsSelector } from "~/reducers/settings";
 
 const NANO_DEVICE_MODEL_IDS = [
@@ -61,27 +63,52 @@ function selectCooldownDeviceModelId(
 }
 
 export function useLargeScreenUpsellEligibility(): LargeScreenUpsellEligibility {
+  const dispatch = useDispatch();
   const feature = useFeature("largeScreenUpsell");
   const knownDeviceModelIds = useSelector(knownDeviceModelIdsSelector);
   const onboardingDate = useSelector(onboardingDateSelector);
+  const hasBackfilledOnboardingDateRef = useRef(false);
 
   const params = feature?.params;
+  const hasSeenTouchscreen = hasSeenTouchscreenDevice(knownDeviceModelIds);
+  const seenNanoDeviceModelIds = getSeenNanoDeviceModelIds(knownDeviceModelIds);
+  const enabledNanoDeviceModelIds = params
+    ? seenNanoDeviceModelIds.filter(deviceModelId => params.audience.models[deviceModelId])
+    : [];
+
+  const shouldBackfillOnboardingDate = Boolean(
+    feature?.enabled &&
+    params &&
+    onboardingDate === null &&
+    !hasSeenTouchscreen &&
+    enabledNanoDeviceModelIds.length > 0,
+  );
+
+  useEffect(() => {
+    if (!shouldBackfillOnboardingDate) {
+      hasBackfilledOnboardingDateRef.current = false;
+      return;
+    }
+
+    if (hasBackfilledOnboardingDateRef.current) {
+      return;
+    }
+
+    hasBackfilledOnboardingDateRef.current = true;
+    dispatch(setPostOnboardingDate({ onboardingDate: new Date() }));
+  }, [dispatch, shouldBackfillOnboardingDate]);
+
   if (!feature?.enabled || !params) {
     return { isEligible: false, reason: "feature_disabled" };
   }
 
-  if (hasSeenTouchscreenDevice(knownDeviceModelIds)) {
+  if (hasSeenTouchscreen) {
     return { isEligible: false, reason: "touchscreen_seen" };
   }
 
-  const seenNanoDeviceModelIds = getSeenNanoDeviceModelIds(knownDeviceModelIds);
   if (seenNanoDeviceModelIds.length === 0) {
     return { isEligible: false, reason: "no_nano" };
   }
-
-  const enabledNanoDeviceModelIds = seenNanoDeviceModelIds.filter(
-    deviceModelId => params.audience.models[deviceModelId],
-  );
 
   if (enabledNanoDeviceModelIds.length === 0) {
     return { isEligible: false, reason: "model_disabled" };
@@ -89,8 +116,9 @@ export function useLargeScreenUpsellEligibility(): LargeScreenUpsellEligibility 
 
   const deviceModelId = selectCooldownDeviceModelId(enabledNanoDeviceModelIds, params.cooldownDays);
   const cooldownDays = resolveCooldownDays(params.cooldownDays, deviceModelId);
+  const onboardingDateForEligibility = onboardingDate ?? new Date();
 
-  if (!isCooldownElapsed(onboardingDate, cooldownDays, new Date())) {
+  if (!isCooldownElapsed(onboardingDateForEligibility, cooldownDays, new Date())) {
     return { isEligible: false, reason: "cooldown", deviceModelId, cooldownDays };
   }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/useLargeScreenUpsellEligibility.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/useLargeScreenUpsellEligibility.ts
@@ -116,9 +116,10 @@ export function useLargeScreenUpsellEligibility(): LargeScreenUpsellEligibility 
 
   const deviceModelId = selectCooldownDeviceModelId(enabledNanoDeviceModelIds, params.cooldownDays);
   const cooldownDays = resolveCooldownDays(params.cooldownDays, deviceModelId);
-  const onboardingDateForEligibility = onboardingDate ?? new Date();
+  const now = new Date();
+  const onboardingDateForEligibility = onboardingDate ?? now;
 
-  if (!isCooldownElapsed(onboardingDateForEligibility, cooldownDays, new Date())) {
+  if (!isCooldownElapsed(onboardingDateForEligibility, cooldownDays, now)) {
     return { isEligible: false, reason: "cooldown", deviceModelId, cooldownDays };
   }
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - LargeScreenUpsell eligibility when `postOnboarding.onboardingDate` is missing
      - Cooldown behavior for Nano SP / Nano X users on fresh state
      - Persistence of backfilled onboarding date to avoid repeated immediate eligibility

### 📝 Description

On some fresh app states, `onboardingDate` can be `null` when LargeScreenUpsell eligibility is evaluated. That made Nano X users pass cooldown checks immediately and see the app-start modal earlier than intended.

This PR makes the eligibility flow treat a missing onboarding date as `now`, and backfills the date in state so cooldown timing is persisted from that point forward. It also updates eligibility tests to assert the new cooldown behavior when onboarding date is missing.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34371](https://ledgerhq.atlassian.net/browse/LIVE-34371)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-34371]: https://ledgerhq.atlassian.net/browse/LIVE-34371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ