### PR TITLE
feat(coin-control): improve mobile screen layout and selection

### DIFF
--- a/.changeset/coin-control-improvements-refine.md
+++ b/.changeset/coin-control-improvements-refine.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Refine coin control screen UI: set the header title to "Coin control" and force its balance to crypto, move strategy/amount labels into their components, add info icon on "Coin to send", disable coin selection when no amount is entered, and fix the custom fees selection failing silently from the coin control screen

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useSendHeaderViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useSendHeaderViewModel.test.ts
@@ -131,4 +131,24 @@ describe("useSendHeaderViewModel", () => {
     expect(result.current.descriptionText).toBe("Base 1 · 0.0596983 ETH");
     expect(mockedUseAvailableBalance).toHaveBeenCalledWith(mockAccount, "crypto");
   });
+
+  it("forces the header balance to crypto on the coin control step, ignoring the fiat display mode", () => {
+    mockedUseSendAmountDisplayMode.mockReturnValue({
+      displayMode: "fiat",
+      setDisplayMode: jest.fn(),
+    });
+    mockedUseCurrentSendFlowStep.mockReturnValue([
+      SEND_FLOW_STEP.COIN_CONTROL,
+      {
+        id: SEND_FLOW_STEP.COIN_CONTROL,
+        canGoBack: true,
+        showTitle: true,
+        showHeaderRight: false,
+      },
+    ]);
+
+    renderHook(() => useSendHeaderViewModel());
+
+    expect(mockedUseAvailableBalance).toHaveBeenCalledWith(mockAccount, "crypto");
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
@@ -47,16 +47,20 @@ export function useSendHeaderViewModel(): SendHeaderViewModel {
   const { displayMode } = useSendAmountDisplayMode();
 
   const accountName = useMaybeAccountName(state.account.account);
-  const spendableBalanceText = useAvailableBalance(state.account.account, displayMode);
   const [currentStep, currentStepConfig] = useCurrentSendFlowStep();
+  const headerDisplayMode = currentStep === SEND_FLOW_STEP.COIN_CONTROL ? "crypto" : displayMode;
+  const spendableBalanceText = useAvailableBalance(state.account.account, headerDisplayMode);
 
   const currencyName = state.account.currency?.ticker ?? "";
   const showTitle = currentStepConfig?.showTitle !== false;
   const isCustomFeesStep = currentStep === SEND_FLOW_STEP.CUSTOM_FEES;
+  const isCoinControlStep = currentStep === SEND_FLOW_STEP.COIN_CONTROL;
   let title = "";
   if (showTitle) {
     if (isCustomFeesStep) {
       title = t("send.newSendFlow.customFees.title");
+    } else if (isCoinControlStep) {
+      title = t("send.newSendFlow.coinControl.title");
     } else {
       title = t("send.newSendFlow.title", { currency: currencyName });
     }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/CoinControlScreen.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/CoinControlScreen.tsx
@@ -20,6 +20,7 @@ export function CoinControlScreen() {
       transactionActions={viewModel.transactionActions}
       onReview={viewModel.onReview}
       onGetFunds={viewModel.onGetFunds}
+      onSelectCustomFees={viewModel.onSelectCustomFees}
     />
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/components/AmountInput.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/components/AmountInput.tsx
@@ -1,18 +1,11 @@
 import React from "react";
-import {
-  Subheader,
-  SubheaderRow,
-  SubheaderTitle,
-  TextInput,
-  Box,
-} from "@ledgerhq/lumen-ui-rnative";
+import { TextInput, Box } from "@ledgerhq/lumen-ui-rnative";
 
 type AmountInputProps = Readonly<{
   onAmountChange: (text: string) => void;
   amount: string | null;
   errorMessage?: string | null;
   amountToSendLabel: string;
-  amountInputLabel: string;
 }>;
 
 export const AmountInput = ({
@@ -20,18 +13,12 @@ export const AmountInput = ({
   amount,
   errorMessage,
   amountToSendLabel,
-  amountInputLabel,
 }: AmountInputProps) => {
   return (
     <Box lx={{ flexDirection: "column", gap: "s12", paddingHorizontal: "s8" }}>
-      <Subheader>
-        <SubheaderRow>
-          <SubheaderTitle>{amountToSendLabel}</SubheaderTitle>
-        </SubheaderRow>
-      </Subheader>
       <TextInput
-        label={amountInputLabel}
-        aria-label={amountInputLabel}
+        label={amountToSendLabel}
+        aria-label={amountToSendLabel}
         value={amount ?? ""}
         helperText={errorMessage ?? undefined}
         status={errorMessage ? "error" : undefined}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/components/CoinControlScreenInner.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/components/CoinControlScreenInner.tsx
@@ -18,6 +18,7 @@ type CoinControlScreenInnerProps = Readonly<{
   transactionActions: SendFlowTransactionActions;
   onReview: () => void;
   onGetFunds: () => void;
+  onSelectCustomFees: () => void;
 }>;
 
 export function CoinControlScreenInner({
@@ -30,6 +31,7 @@ export function CoinControlScreenInner({
   transactionActions,
   onReview,
   onGetFunds,
+  onSelectCustomFees,
 }: CoinControlScreenInnerProps) {
   const handleReview = useCallback(() => {
     onReview();
@@ -43,6 +45,7 @@ export function CoinControlScreenInner({
     bridgePending,
     uiConfig,
     transactionActions,
+    onSelectCustomFees,
   });
 
   return (
@@ -55,11 +58,9 @@ export function CoinControlScreenInner({
       onAmountChange={viewModel.onAmountChange}
       amountError={viewModel.amountError}
       strategyLabel={viewModel.coinControlStrategyLabel}
-      learnMoreLabel={viewModel.learnMoreLabel}
-      onLearnMoreClick={viewModel.onLearnMoreClick}
+      onInfoPress={viewModel.onInfoPress}
       coinToSendLabel={viewModel.coinToSendLabel}
       amountToSendLabel={viewModel.amountToSendLabel}
-      amountInputLabel={viewModel.amountInputLabel}
       networkFees={viewModel.networkFees}
       reviewLabel={viewModel.reviewLabel}
       reviewShowIcon={viewModel.reviewShowIcon}
@@ -69,6 +70,7 @@ export function CoinControlScreenInner({
       onGetFunds={onGetFunds}
       isCustomPickingStrategy={viewModel.isCustomPickingStrategy}
       onToggleUtxoExclusion={viewModel.onToggleUtxoExclusion}
+      hasAmount={viewModel.hasAmount}
     />
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/components/CoinControlScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/components/CoinControlScreenView.tsx
@@ -20,11 +20,9 @@ type CoinControlScreenViewProps = Readonly<{
   onAmountChange: (text: string) => void;
   amountError: string | undefined;
   strategyLabel: string;
-  learnMoreLabel: string;
-  onLearnMoreClick: () => void;
+  onInfoPress: () => void;
   coinToSendLabel: string;
   amountToSendLabel: string;
-  amountInputLabel: string;
   networkFees: NetworkFeesViewModel;
   reviewLabel: string;
   reviewShowIcon: boolean;
@@ -34,6 +32,7 @@ type CoinControlScreenViewProps = Readonly<{
   onGetFunds: () => void;
   isCustomPickingStrategy: boolean;
   onToggleUtxoExclusion?: (rowKey: string) => void;
+  hasAmount: boolean;
 }>;
 
 export function CoinControlScreenView({
@@ -45,11 +44,9 @@ export function CoinControlScreenView({
   onAmountChange,
   amountError,
   strategyLabel,
-  learnMoreLabel,
-  onLearnMoreClick,
+  onInfoPress,
   coinToSendLabel,
   amountToSendLabel,
-  amountInputLabel,
   networkFees,
   reviewLabel,
   reviewShowIcon,
@@ -59,30 +56,30 @@ export function CoinControlScreenView({
   onGetFunds,
   isCustomPickingStrategy,
   onToggleUtxoExclusion,
+  hasAmount,
 }: CoinControlScreenViewProps) {
   return (
     <SendFlowLayout>
-      <Box lx={{ marginHorizontal: "-s8", flex: 1, gap: "s24" }}>
+      <Box lx={{ marginHorizontal: "-s8", flex: 1, gap: "s16" }}>
         <StrategySelect
           value={utxoDisplayData?.pickingStrategyValue?.toString() ?? ""}
           options={strategyOptionsWithLabels}
           onValueChange={onSelectStrategy}
           strategyLabel={strategyLabel}
-          learnMoreLabel={learnMoreLabel}
-          onLearnMorePress={onLearnMoreClick}
         />
         <AmountInput
           onAmountChange={onAmountChange}
           amount={amountValue}
           errorMessage={amountError}
           amountToSendLabel={amountToSendLabel}
-          amountInputLabel={amountInputLabel}
         />
         <UtxoSelector
           utxoDisplayData={utxoDisplayData}
           coinToSendLabel={coinToSendLabel}
           isCustomPickingStrategy={isCustomPickingStrategy}
           onToggleUtxoExclusion={onToggleUtxoExclusion}
+          onInfoPress={onInfoPress}
+          hasAmount={hasAmount}
         />
       </Box>
       <CoinControlFooter

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/components/StrategySelect.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/components/StrategySelect.tsx
@@ -3,16 +3,12 @@ import {
   BottomSheet,
   BottomSheetHeader,
   BottomSheetView,
-  Link,
   OptionList,
   OptionListContent,
   OptionListItem,
   OptionListItemContent,
   OptionListItemText,
   OptionListTrigger,
-  Subheader,
-  SubheaderRow,
-  SubheaderTitle,
   Text,
   useBottomSheetRef,
 } from "@ledgerhq/lumen-ui-rnative";
@@ -25,8 +21,6 @@ type StrategySelectProps = Readonly<{
   options: readonly StrategyOptionWithLabel[];
   value: string;
   strategyLabel: string;
-  learnMoreLabel: string;
-  onLearnMorePress: () => void;
 }>;
 
 export const StrategySelect = ({
@@ -34,8 +28,6 @@ export const StrategySelect = ({
   options,
   value,
   strategyLabel,
-  learnMoreLabel,
-  onLearnMorePress,
 }: StrategySelectProps) => {
   const bottomSheetRef = useBottomSheetRef();
 
@@ -69,17 +61,7 @@ export const StrategySelect = ({
 
   return (
     <Box lx={{ flexDirection: "column", gap: "s12", paddingHorizontal: "s8" }}>
-      <Subheader>
-        <Box>
-          <SubheaderRow lx={{ flexDirection: "row", justifyContent: "space-between" }}>
-            <SubheaderTitle>{strategyLabel}</SubheaderTitle>
-            <Link appearance="accent" underline={false} onPress={onLearnMorePress} size="md">
-              {learnMoreLabel}
-            </Link>
-          </SubheaderRow>
-        </Box>
-      </Subheader>
-      <OptionListTrigger onPress={handleOpenSheet}>
+      <OptionListTrigger label={strategyLabel} onPress={handleOpenSheet}>
         {selectedOption != null && <Text lx={{ color: "base" }}>{selectedOption.label}</Text>}
       </OptionListTrigger>
       <BottomSheet

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/components/UtxoSelector.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/components/UtxoSelector.tsx
@@ -8,6 +8,7 @@ import {
   Subheader,
   SubheaderRow,
   SubheaderTitle,
+  SubheaderInfo,
   Box,
   Checkbox,
 } from "@ledgerhq/lumen-ui-rnative";
@@ -21,6 +22,8 @@ type UtxoSelectorProps = Readonly<{
   coinToSendLabel: string;
   isCustomPickingStrategy: boolean;
   onToggleUtxoExclusion?: (rowKey: string) => void;
+  onInfoPress: () => void;
+  hasAmount: boolean;
 }>;
 
 export const UtxoSelector = ({
@@ -28,55 +31,65 @@ export const UtxoSelector = ({
   coinToSendLabel,
   isCustomPickingStrategy,
   onToggleUtxoExclusion,
+  onInfoPress,
+  hasAmount,
 }: UtxoSelectorProps) => {
   const rows = utxoDisplayData?.utxoRows ?? [];
 
   const handleToggle = React.useCallback(
     (rowKey: string, disabled: boolean) => {
-      if (!isCustomPickingStrategy || disabled) return;
+      if (!isCustomPickingStrategy || disabled || !hasAmount) return;
       onToggleUtxoExclusion?.(rowKey);
     },
-    [isCustomPickingStrategy, onToggleUtxoExclusion],
+    [isCustomPickingStrategy, onToggleUtxoExclusion, hasAmount],
   );
 
   return (
-    <Box lx={{ flexDirection: "column", gap: "s12", flex: 1 }} style={{ minHeight: 0 }}>
+    <Box lx={{ flexDirection: "column", gap: "s8", flex: 1 }} style={{ minHeight: 0 }}>
       <Subheader>
         <SubheaderRow lx={{ paddingHorizontal: "s8" }}>
           <SubheaderTitle>{coinToSendLabel}</SubheaderTitle>
+          <SubheaderInfo onPress={onInfoPress} />
         </SubheaderRow>
       </Subheader>
       <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1 }}>
-        {rows.map(row => (
-          <ListItem
-            key={row.rowKey}
-            disabled={row.disabled}
-            onPress={
-              isCustomPickingStrategy ? () => handleToggle(row.rowKey, row.disabled) : undefined
-            }
-          >
-            <ListItemLeading>
-              <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s12", flex: 1 }}>
-                {isCustomPickingStrategy ? (
-                  <Checkbox
-                    checked={!row.excluded}
-                    disabled={row.disabled}
-                    onCheckedChange={() => handleToggle(row.rowKey, row.disabled)}
-                  />
-                ) : null}
-                <ListItemContent>
-                  <ListItemTitle>{row.titleLabel}</ListItemTitle>
-                  <ListItemDescription>{row.formattedValue}</ListItemDescription>
-                </ListItemContent>
-              </Box>
-            </ListItemLeading>
-            {row.isUsedInTx && !isCustomPickingStrategy && (
-              <ListItemTrailing>
-                <Check />
-              </ListItemTrailing>
-            )}
-          </ListItem>
-        ))}
+        {rows.map(row => {
+          const rowDisabled = row.disabled || !hasAmount;
+          return (
+            <ListItem
+              key={row.rowKey}
+              disabled={rowDisabled}
+              onPress={
+                isCustomPickingStrategy && !rowDisabled
+                  ? () => handleToggle(row.rowKey, rowDisabled)
+                  : undefined
+              }
+            >
+              <ListItemLeading>
+                <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s12", flex: 1 }}>
+                  {isCustomPickingStrategy ? (
+                    <Checkbox
+                      checked={!row.excluded}
+                      disabled={rowDisabled}
+                      onCheckedChange={
+                        !rowDisabled ? () => handleToggle(row.rowKey, rowDisabled) : undefined
+                      }
+                    />
+                  ) : null}
+                  <ListItemContent>
+                    <ListItemTitle>{row.titleLabel}</ListItemTitle>
+                    <ListItemDescription>{row.formattedValue}</ListItemDescription>
+                  </ListItemContent>
+                </Box>
+              </ListItemLeading>
+              {row.isUsedInTx && !isCustomPickingStrategy && !rowDisabled && (
+                <ListItemTrailing>
+                  <Check />
+                </ListItemTrailing>
+              )}
+            </ListItem>
+          );
+        })}
       </ScrollView>
     </Box>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/hooks/__tests__/useCoinControlScreenViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/hooks/__tests__/useCoinControlScreenViewModel.test.tsx
@@ -128,6 +128,7 @@ function buildBaseParams(overrides?: {
     bridgeError: null as Error | null,
     uiConfig: { hasFeePresets: false } as never,
     transactionActions: { updateTransaction: mockUpdateTransaction } as never,
+    onSelectCustomFees: jest.fn(),
   };
 }
 
@@ -347,6 +348,36 @@ describe("useCoinControlScreenViewModel", () => {
     const { result } = renderHook(() => useCoinControlScreenViewModel(params));
 
     expect(result.current.amountError).toBeUndefined();
+  });
+
+  it("should set hasAmount to true when the transaction amount is greater than zero", () => {
+    const params = buildBaseParams({
+      transaction: { amount: new BigNumber(1000), useAllAmount: false },
+    });
+
+    const { result } = renderHook(() => useCoinControlScreenViewModel(params));
+
+    expect(result.current.hasAmount).toBe(true);
+  });
+
+  it("should set hasAmount to false when the transaction amount is zero and not using all amount", () => {
+    const params = buildBaseParams({
+      transaction: { amount: new BigNumber(0), useAllAmount: false },
+    });
+
+    const { result } = renderHook(() => useCoinControlScreenViewModel(params));
+
+    expect(result.current.hasAmount).toBe(false);
+  });
+
+  it("should set hasAmount to true when useAllAmount is enabled even with a zero amount", () => {
+    const params = buildBaseParams({
+      transaction: { amount: new BigNumber(0), useAllAmount: true },
+    });
+
+    const { result } = renderHook(() => useCoinControlScreenViewModel(params));
+
+    expect(result.current.hasAmount).toBe(true);
   });
 
   it("should open the localized coin control support URL when learn more is pressed", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/hooks/useCoinControlScreen.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/hooks/useCoinControlScreen.ts
@@ -24,6 +24,7 @@ export type CoinControlScreenViewModel =
       transactionActions: SendFlowTransactionActions;
       onReview: () => void;
       onGetFunds: () => void;
+      onSelectCustomFees: () => void;
     };
 
 export function useCoinControlScreen(): CoinControlScreenViewModel {
@@ -43,6 +44,10 @@ export function useCoinControlScreen(): CoinControlScreenViewModel {
     close();
   }, [close]);
 
+  const onSelectCustomFees = useCallback(() => {
+    navigation.navigate(ScreenName.SendFlowCustomFees);
+  }, [navigation]);
+
   if (!account || !transaction || !status || !uiConfig || !transactionActions) {
     return { ready: false };
   }
@@ -58,5 +63,6 @@ export function useCoinControlScreen(): CoinControlScreenViewModel {
     transactionActions,
     onReview,
     onGetFunds,
+    onSelectCustomFees,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/hooks/useCoinControlScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/hooks/useCoinControlScreenViewModel.ts
@@ -28,6 +28,7 @@ type UseCoinControlScreenViewModelParams = Readonly<{
   bridgePending: boolean;
   uiConfig: SendFlowUiConfig;
   transactionActions: SendFlowTransactionActions;
+  onSelectCustomFees: () => void;
 }>;
 
 export function useCoinControlScreenViewModel({
@@ -38,6 +39,7 @@ export function useCoinControlScreenViewModel({
   bridgePending,
   uiConfig,
   transactionActions,
+  onSelectCustomFees,
 }: UseCoinControlScreenViewModelParams) {
   const { t } = useTranslation();
   const locale = useSelector(localeSelector);
@@ -56,6 +58,7 @@ export function useCoinControlScreenViewModel({
     status,
     uiConfig,
     transactionActions,
+    onSelectCustomFees,
   });
 
   const amountErrorTranslated = useTranslatedBridgeError(
@@ -106,9 +109,13 @@ export function useCoinControlScreenViewModel({
     onLearnMoreClick,
   });
 
+  const hasAmount = transaction.useAllAmount || transaction.amount?.gt(0) === true;
+
   return {
     ...core,
     coinControlStrategyLabel: core.strategyLabel,
     networkFees: core.networkFees,
+    hasAmount,
+    onInfoPress: onLearnMoreClick,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _UI/presentational changes only; existing coin control view-model unit tests still pass, but the new presentational behaviour (info icon, selection disabling, forced-crypto header) is not covered by new automated tests._
- [x] **Impact of the changes:**
      - Coin control header must always show the **crypto** balance, never fiat
      - "Strategy" label now lives inside the select; "Learn more" link removed
      - Amount input floating label reads "Amount to send in {ticker}"
      - Info icon on "Coin to send" opens the Coin control help page
      - Coin rows / selection tick are disabled when no amount is entered or the coin is not active
      - Spacing/layout of the coin control screen

### 📝 Description

UI improvements on the LWM Coin control screen (new send flow), following design feedback.

**Problem**: The coin control screen header could show the fiat counter value, subheaders duplicated labels that belong inside their components, there was no entry point to the help page, and coin selection stayed interactive even without an amount.

**Solution**:
- Force the header balance to **crypto** on the coin control step (via `useAvailableBalance` with a forced `displayMode` when the current step is `COIN_CONTROL`).
- Remove the "Strategy" subheader + "Learn more" link; move the "Strategy" label into the select component.
- Remove the "Amount to send in {ticker}" subheader; use it as the input's floating label.
- Add an info icon in the "Coin to send" subheader that redirects to the Coin control help page.
- Disable coin rows and hide the selection tick when no amount is entered (or the coin is not active).
- Tighten spacing per the design.

The Amount screen header already follows the amount input toggle (crypto ↔ fiat) via the shared `SendAmountDisplayModeContext`, so no change was needed there.

#### 📸 Screenshots

**Amount input header (follows the crypto/fiat toggle)**

| BTC mode | Fiat ($) mode |
| -------- | ------------- |
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-13 at 16 34 09" src="https://github.com/user-attachments/assets/11383f60-31c0-488c-8b9f-259ba7acd2e6" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-13 at 16 34 05" src="https://github.com/user-attachments/assets/de236df9-bd83-42fb-9cc1-5051c9d6a31c" />|

**Coin control screen**

| With amount | Without amount |
| ----------- | -------------- |
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-13 at 16 33 25" src="https://github.com/user-attachments/assets/0586aa68-5c55-49bc-93aa-9e185e3f981f" />| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-13 at 16 33 36" src="https://github.com/user-attachments/assets/57e79e39-5873-4d9a-ab53-d6b5c64ea8c5" />|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30468](https://ledgerhq.atlassian.net/browse/LIVE-30468)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-30468]: https://ledgerhq.atlassian.net/browse/LIVE-30468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ