### PR TITLE
chore(contacts): assign Wallet XP code ownership

### DIFF
--- a/.changeset/own-contacts-flow.md
+++ b/.changeset/own-contacts-flow.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": patch
+---
+
+Assign Wallet XP as the Contacts flow code owner.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -92,6 +92,9 @@ apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/ @ledge
 apps/ledger-live-mobile/src/mvvm/                        @ledgerhq/wallet-xp
 apps/ledger-live-mobile/src/screens/Portfolio/           @ledgerhq/wallet-xp
 
+# Wallet — Contacts
+features/flow/contacts/                                  @ledgerhq/wallet-xp
+
 # Platform — desktop mvvm overrides (override WXP mvvm catch-all)
 apps/ledger-live-desktop/src/mvvm/features/AppBlockers/  @ledgerhq/platform
 apps/ledger-live-desktop/src/mvvm/features/WalletSync/   @ledgerhq/platform


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _CODEOWNERS metadata only; rule precedence and diff checks were verified._
- [x] **Impact of the changes:**
  - Review ownership for `features/flow/contacts/`

### 📝 Description

This PR assigns Wallet XP as the code owner for `features/flow/contacts/`.

The specific rule is placed after the generic Platform features catch-all, so Contacts changes request Wallet XP review without pinging Platform.

### ❓ Context

- **JIRA or GitHub link**: N/A - requested ownership alignment

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)