### PR TITLE
[LWDM] fix(common): ARB ERC-20 token wrongly resolved as Arbitrum One chain (ETH)

### DIFF
--- a/.changeset/fix-arb-token-eth-collision.md
+++ b/.changeset/fix-arb-token-eth-collision.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+fix selectCurrencyForMetaId returning Arbitrum One chain instead of ARB ERC-20 token

--- a/libs/ledger-live-common/src/dada-client/__mocks__/assets.mock.ts
+++ b/libs/ledger-live-common/src/dada-client/__mocks__/assets.mock.ts
@@ -211,3 +211,53 @@ export const mockUsdcAssetsData = {
     metaCurrencyIds: ["usdc"],
   },
 };
+
+export const mockArbitrumTokenAssetsData = {
+  cryptoAssets: {
+    arbitrum: {
+      id: "arbitrum",
+      ticker: "ARB",
+      name: "Arbitrum",
+      assetsIds: {
+        ethereum: "ethereum/erc20/arbitrum",
+        arbitrum: "arbitrum",
+      },
+    },
+  },
+  networks: {
+    ethereum: { id: "ethereum", name: "Ethereum" },
+    arbitrum: { id: "arbitrum", name: "Arbitrum One" },
+  },
+  cryptoOrTokenCurrencies: {
+    "ethereum/erc20/arbitrum": {
+      type: "TokenCurrency" as const,
+      id: "ethereum/erc20/arbitrum",
+      name: "Arbitrum",
+      ticker: "ARB",
+      contractAddress: "0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1",
+      parentCurrencyId: "ethereum",
+      tokenType: "erc20",
+      units: [{ name: "ARB", code: "ARB", magnitude: 18 }],
+    },
+    arbitrum: {
+      type: "CryptoCurrency" as const,
+      id: "arbitrum",
+      name: "Arbitrum One",
+      ticker: "ETH",
+      units: [{ name: "ETH", code: "ETH", magnitude: 18 }],
+      family: "evm",
+      managerAppName: "Ethereum",
+      coinType: 60,
+      scheme: "arbitrum",
+      color: "#28A0F0",
+      explorerViews: [],
+    },
+  },
+  interestRates: {},
+  markets: {},
+  currenciesOrder: {
+    key: "marketCap",
+    order: "desc",
+    metaCurrencyIds: ["arbitrum"],
+  },
+};

--- a/libs/ledger-live-common/src/dada-client/utils/__test__/currencySelection.test.ts
+++ b/libs/ledger-live-common/src/dada-client/utils/__test__/currencySelection.test.ts
@@ -1,6 +1,7 @@
 import { selectCurrency, selectCurrencyForMetaId } from "../currencySelection";
 import {
   mockAssetsDataWithPagination,
+  mockArbitrumTokenAssetsData,
   mockBitcoinAssetsData,
   mockUsdcAssetsData,
 } from "../../__mocks__/assets.mock";
@@ -64,6 +65,16 @@ describe("currencySelection", () => {
       const result = selectCurrencyForMetaId("usdc", data);
 
       expect(result).toBeDefined();
+      expect(result!.type).toBe("TokenCurrency");
+    });
+
+    it("prefers the ERC-20 token over a same-named L2 chain when their tickers differ", () => {
+      const data = { ...mockArbitrumTokenAssetsData, pagination: {} } as AssetsDataWithPagination;
+      const result = selectCurrencyForMetaId("arbitrum", data);
+
+      expect(result).toBeDefined();
+      expect(result!.id).toBe("ethereum/erc20/arbitrum");
+      expect(result!.ticker).toBe("ARB");
       expect(result!.type).toBe("TokenCurrency");
     });
   });

--- a/libs/ledger-live-common/src/dada-client/utils/currencySelection.ts
+++ b/libs/ledger-live-common/src/dada-client/utils/currencySelection.ts
@@ -1,37 +1,40 @@
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { AssetsDataWithPagination } from "../state-manager/types";
 
-/**
- * Selects the best currency for a given meta-currency ID based on priority:
- * 1. Main currency (matching metaCurrencyId)
- * 2. CryptoCurrency type
- * 3. First available network
- */
 export function selectCurrencyForMetaId(
   metaCurrencyId: string,
   data: AssetsDataWithPagination,
 ): CryptoOrTokenCurrency | undefined {
-  const assetsIds = data.cryptoAssets[metaCurrencyId]?.assetsIds;
+  const meta = data.cryptoAssets[metaCurrencyId];
+  const assetsIds = meta?.assetsIds;
   if (!assetsIds) return undefined;
+
+  const metaTicker = meta.ticker?.toUpperCase();
 
   let fallback: CryptoOrTokenCurrency | undefined;
   let crypto: CryptoOrTokenCurrency | undefined;
+  let token: CryptoOrTokenCurrency | undefined;
 
   for (const id of Object.values(assetsIds)) {
     const currency = data.cryptoOrTokenCurrencies[id];
     if (!currency) continue;
 
-    if (currency.id === metaCurrencyId) return currency;
+    const tickerMatches = currency.ticker?.toUpperCase() === metaTicker;
+
+    // Require both id and ticker to match: some L2 chains share their ledger id with a
+    // token meta-currency id but use a different native ticker (e.g. an L2 that uses ETH
+    // as gas). Id alone would pick the chain when we actually want the token.
+    if (currency.id === metaCurrencyId && tickerMatches) return currency;
     if (!fallback) fallback = currency;
-    if (!crypto && currency.type === "CryptoCurrency") crypto = currency;
+    // Prefer chain coins over tokens when the ticker matches — the chain is the primary
+    // form of the asset. Skip chains whose ticker differs: they are unrelated assets.
+    if (!crypto && currency.type === "CryptoCurrency" && tickerMatches) crypto = currency;
+    if (!token && currency.type === "TokenCurrency" && tickerMatches) token = currency;
   }
 
-  return crypto ?? fallback;
+  return crypto ?? token ?? fallback;
 }
 
-/**
- * Selects the best currency from the first meta-currency in the asset data result.
- */
 export function selectCurrency(
   result: AssetsDataWithPagination,
 ): CryptoOrTokenCurrency | undefined {


### PR DESCRIPTION
> Cherry-pick of #19570 onto `release`.

### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - ARB token accounts now correctly show ARB price and ticker instead of ETH
  - Global search: tapping the ARB result navigates to the ARB asset detail page, not ETH (fixes LWM and LWD)
  - Any other token whose meta-currency id collides with a same-named L2 chain is also fixed by the same logic

### 📝 Description

**Problem**: The ARB governance token (ERC-20 on Ethereum) and the Arbitrum One L2 chain share the same DADA meta-currency id `"arbitrum"`. The Arbitrum One chain has ledger id `"arbitrum"` and ticker `"ETH"` (it uses ETH as gas). The previous `selectCurrencyForMetaId` logic returned the first currency whose `id === metaCurrencyId`, which matched the chain before even considering the ARB token. This caused:
- ARB accounts in the asset list to display ETH price (~$1,765) and ETH ticker
- Pressing the ARB result in global search to navigate to the ETH/Arbitrum One asset detail page on both LWM and LWD

**Fix**: The early-return rule now requires both `currency.id === metaCurrencyId` **and** `currency.ticker === meta.ticker`. A chain whose ticker differs from the meta-currency ticker (Arbitrum One: `ETH` ≠ `ARB`) is no longer treated as the primary asset. The selection priority becomes:

1. Currency with matching id **and** matching ticker (native coin — e.g. BTC)
2. CryptoCurrency with matching ticker (chain coin — e.g. INJ chain)
3. TokenCurrency with matching ticker (ERC-20 — e.g. ARB token) ← **new winner for ARB**
4. First available (last resort)

Existing behaviour for BTC, ETH, INJ, USDC is unchanged (verified by existing tests passing).

### ❓ Context

- **JIRA**: [LIVE-34368](https://ledgerhq.atlassian.net/browse/LIVE-34368)
- **GitHub issue**: [#19527](https://github.com/LedgerHQ/ledger-live/issues/19527)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34368]: https://ledgerhq.atlassian.net/browse/LIVE-34368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ