### PR TITLE
[LWD] fix(lld): reboot Electron on Reset App to regenerate user identities

### DIFF
--- a/.changeset/calm-foxes-reboot.md
+++ b/.changeset/calm-foxes-reboot.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix Reset App to fully reboot Electron so user identities are regenerated on next launch

--- a/apps/ledger-live-desktop/src/main/db/index.ts
+++ b/apps/ledger-live-desktop/src/main/db/index.ts
@@ -370,7 +370,9 @@ async function resetAll() {
   if (!DBPath) throw new NoDBPathGiven();
   memoryNamespaces.app = null;
   encryptionKeys = {}; // Clear encryption keys to prevent re-encryption of old data
-  await fs.unlink(path.resolve(DBPath, "app.json"));
+  await fs.unlink(path.resolve(DBPath, "app.json")).catch((e: NodeJS.ErrnoException) => {
+    if (e.code !== "ENOENT") throw e;
+  });
 }
 function isEncryptionKeyCorrect(encryptionKey: string) {
   const [ns, keyPath] = encryptedDataPaths[0]; // conventionally we check the first path

--- a/apps/ledger-live-desktop/src/main/index.ts
+++ b/apps/ledger-live-desktop/src/main/index.ts
@@ -263,6 +263,11 @@ ipcMain.on("app-quit", () => {
   app.quit();
 });
 
+ipcMain.once("app-relaunch", () => {
+  app.relaunch();
+  app.quit();
+});
+
 ipcMain.handle("show-open-dialog", (_, opts) => dialog.showOpenDialog(opts));
 ipcMain.handle("show-save-dialog", (_, opts) => dialog.showSaveDialog(opts));
 

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -459,18 +459,7 @@ export default function Default() {
       return;
     }
 
-    const wasHardReset = window.localStorage.getItem("hard-reset") === "1";
-
-    // If we just did a hard reset and onboarding is not completed, force redirect to onboarding
-    // even if we're on the settings page (where the reset button is)
-    if (wasHardReset && !hasCompletedOnboarding) {
-      navigate("/onboarding", { replace: true });
-      window.localStorage.removeItem("hard-reset");
-      updateIdentify();
-      return;
-    }
-
-    // Normal onboarding check (when not after a reset)
+    // Normal onboarding check
     const userIsOnboardingOrSettingUp =
       pathname.includes("onboarding") ||
       pathname.includes("recover") ||

--- a/apps/ledger-live-desktop/src/renderer/components/IsUnlocked.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/IsUnlocked.tsx
@@ -83,7 +83,6 @@ export default function IsUnlocked({ children }: { children: React.ReactNode }):
     setIsHardResetting(true);
     try {
       await hardReset();
-      window.api?.reloadRenderer();
     } catch {
       setIsHardResetting(false);
     }

--- a/apps/ledger-live-desktop/src/renderer/components/RenderError.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RenderError.tsx
@@ -50,7 +50,6 @@ export default function RenderError({ error, withoutAppData, children }: Props) 
     setIsHardResetting(true);
     try {
       await hardReset();
-      window.api?.reloadRenderer();
     } catch {
       setIsHardResetting(false);
     }

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -12,7 +12,6 @@ import i18n from "i18next";
 import { webFrame, ipcRenderer } from "electron";
 import each from "lodash/each";
 import { reload, getKey } from "~/renderer/storage";
-import { hardReset } from "~/renderer/reset";
 import "~/renderer/styles/global";
 import { registerTransportModules } from "~/renderer/live-common-setup";
 import { getLocalStorageEnvs } from "~/renderer/experimental";
@@ -127,14 +126,6 @@ async function init() {
       });
     }
   }
-  const hardResetFlag = window.localStorage.getItem("hard-reset");
-  const wasHardReset = hardResetFlag === "1";
-
-  if (wasHardReset) {
-    await hardReset();
-    // Keep the flag so Default.tsx can detect it for redirect, it will be cleared there
-  }
-
   const store = createStore({
     dbMiddleware,
   });
@@ -206,11 +197,7 @@ async function init() {
 
   liveBlindSigningReporter.setConsentSource(() => trackingEnabledSelector(store.getState()));
 
-  // Build settings to load, ensuring hasCompletedOnboarding is false after a hard reset
   const settingsToLoad = { ...initialSettings };
-  if (wasHardReset) {
-    settingsToLoad.hasCompletedOnboarding = false;
-  }
 
   // Legacy crypto counter-values were persisted as ticker (BTC/ETH); migrate them to Ledger ids.
   if (typeof settingsToLoad.counterValue === "string") {

--- a/apps/ledger-live-desktop/src/renderer/reset.ts
+++ b/apps/ledger-live-desktop/src/renderer/reset.ts
@@ -20,17 +20,12 @@ export async function hardReset() {
   disableDBMiddleware();
   await resetAll();
   resetStore();
-  // Preserve the hard-reset flag across localStorage.clear() so init.tsx can detect it
-  const hardResetFlag = window.localStorage.getItem("hard-reset");
   window.localStorage.clear();
-  if (hardResetFlag === "1") {
-    window.localStorage.setItem("hard-reset", "1");
-  }
 }
 export function useHardReset() {
-  return () => {
-    window.localStorage.setItem("hard-reset", "1");
-    reload();
+  return async () => {
+    await hardReset();
+    ipcRenderer.send("app-relaunch");
   };
 }
 export function useSoftReset() {

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Help/ResetButton.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Help/ResetButton.tsx
@@ -20,11 +20,11 @@ export default function ResetButton() {
   const { opened, pending, fallbackOpened } = state as ActionModalState;
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const { open, close, closeFallback, handleConfirm, handleError } = actions as ActionModalReducer;
-  const onConfirm = useCallback(() => {
+  const onConfirm = useCallback(async () => {
     if (pending) return;
     try {
       handleConfirm();
-      hardReset();
+      await hardReset();
     } catch (err) {
       logger.error(err);
       handleError();


### PR DESCRIPTION
### 📝 Description

**Previous behaviour:** Reset App set a `hard-reset` flag in localStorage then called `BrowserWindow.reload()`. The actual data wipe ran on the next renderer boot, but the Electron **main process never restarted** — so identity-generation code (which runs at main process startup) was never re-executed, leaving stale user identities in the new `app.json`.

**Fix:** Wipe data synchronously in the renderer, then trigger a full `app.relaunch()` + `app.quit()` so the entire Electron process restarts cold. On next launch, the main process initialises fresh and regenerates all user identities.

Key changes:
- `useHardReset()` now `await hardReset()` (full wipe) then `ipcRenderer.send("app-relaunch")`
- Main process: `ipcMain.once("app-relaunch", () => { app.relaunch(); app.quit(); })`
- `resetAll()` ignores `ENOENT` so a double-reset or first-run never throws
- `ResetButton.onConfirm` made `async` + `await hardReset()` so errors surface to the fallback modal
- Removed dead `wasHardReset` flag machinery from `init.tsx` and `Default.tsx`

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34367](https://ledgerhq.atlassian.net/browse/LIVE-34367)
- **ADR** (if any): N/A

[LIVE-34367]: https://ledgerhq.atlassian.net/browse/LIVE-34367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ