### PR TITLE
[LWM] test(mobile): verify large-screen upsell display threshold behavior

### DIFF
--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
@@ -120,7 +120,7 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
       withKnownDeviceModels([DeviceModelId.nanoS]),
     );
 
-    render(<IntegrationNavigator />, { overrideInitialState });
+    const { store } = render(<IntegrationNavigator />, { overrideInitialState });
 
     expect(await screen.findByTestId("large-screen-upsell-integration-portfolio")).toBeVisible();
     expect(screen.getByTestId("large-screen-upsell-portfolio-mount")).toBeVisible();
@@ -128,6 +128,7 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
     await waitFor(() => {
       expect(screen.getByTestId("large-screen-upsell-modal-drawer")).toBeVisible();
     });
+    expect(store.getState().largeScreenUpsellModal.retries).toBe(1);
   });
 
   it("should track the modal view with shared analytics properties when it auto-opens", async () => {
@@ -189,7 +190,7 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
       withKnownDeviceModels([DeviceModelId.nanoS]),
     );
 
-    const { user } = render(<IntegrationNavigator />, { overrideInitialState });
+    const { user, store } = render(<IntegrationNavigator />, { overrideInitialState });
 
     await waitFor(() => {
       expect(screen.getByTestId("large-screen-upsell-modal-drawer")).toBeVisible();
@@ -203,6 +204,7 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
       ...NANO_S_OPTED_OUT_ANALYTICS_PROPS,
     });
     expect(track).not.toHaveBeenCalledWith("modal_dismissed", expect.anything());
+    expect(store.getState().largeScreenUpsellModal.retries).toBe(0);
   });
 
   it("should track modal_dismissed with dismissMethod close_button exactly once when the header close button is pressed", async () => {
@@ -283,5 +285,33 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
       expect(store.getState().backupHubFeatureIntro.isOpen).toBe(true);
     });
     expect(store.getState().largeScreenUpsellModal.retries).toBe(0);
+  });
+
+  it("should not auto-open when retries already reached threshold and cadence is still active", async () => {
+    const overrideInitialState = withFlagOverrides(
+      {
+        largeScreenUpsell: { enabled: true },
+        lwmProductTour: { enabled: false },
+        lwmGenericAwarenessModal: { enabled: false },
+        analyticsOptIn: { enabled: false },
+      },
+      state => {
+        const stateWithKnownDevice = withKnownDeviceModels([DeviceModelId.nanoS])(state);
+
+        return {
+          ...stateWithKnownDevice,
+          largeScreenUpsellModal: {
+            ...stateWithKnownDevice.largeScreenUpsellModal,
+            retries: 3,
+            lastSeenAt: NOW.getTime(),
+          },
+        };
+      },
+    );
+
+    render(<IntegrationNavigator />, { overrideInitialState });
+
+    expect(await screen.findByTestId("large-screen-upsell-integration-portfolio")).toBeVisible();
+    expect(screen.queryByTestId("large-screen-upsell-modal-drawer")).not.toBeOnTheScreen();
   });
 });


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not required: this PR only adds test coverage without runtime or release-impacting changes._
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Large Screen Upsell display counter increments on modal auto-open
      - Retry reset behavior after successful CTA interaction
      - Cadence gate behavior once threshold is reached

### 📝 Description

This PR strengthens integration coverage for the Large Screen Upsell frequency logic on mobile.

It adds explicit assertions for the behavior we agreed on: each modal display increments the counter, CTA success resets the counter to 0, and once the threshold is reached the modal remains blocked while `cadenceDays` is still active.

### ❓ Context

- **JIRA or GitHub link**: [#19566](https://github.com/LedgerHQ/ledger-live/pull/19566)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)