### PR TITLE
[LWM] fix(mobile): reset upsell retries only after successful CTA navigation

### DIFF
--- a/.changeset/cool-emus-peel.md
+++ b/.changeset/cool-emus-peel.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Reset large-screen upsell retries only after successful CTA navigation and cover display-threshold cadence behavior in tests.

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
@@ -121,7 +121,7 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
       withKnownDeviceModels([DeviceModelId.nanoS]),
     );
 
-    render(<IntegrationNavigator />, { overrideInitialState });
+    const { store } = render(<IntegrationNavigator />, { overrideInitialState });
 
     expect(await screen.findByTestId("large-screen-upsell-integration-portfolio")).toBeVisible();
     expect(screen.getByTestId("large-screen-upsell-portfolio-mount")).toBeVisible();
@@ -129,6 +129,7 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
     await waitFor(() => {
       expect(screen.getByTestId("large-screen-upsell-modal-drawer")).toBeVisible();
     });
+    expect(store.getState().largeScreenUpsellModal.retries).toBe(1);
   });
 
   it("should track the modal view with shared analytics properties when it auto-opens", async () => {
@@ -194,7 +195,7 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
       withKnownDeviceModels([DeviceModelId.nanoS]),
     );
 
-    const { user } = render(<IntegrationNavigator />, { overrideInitialState });
+    const { user, store } = render(<IntegrationNavigator />, { overrideInitialState });
 
     await waitFor(() => {
       expect(screen.getByTestId("large-screen-upsell-modal-drawer")).toBeVisible();
@@ -208,6 +209,7 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
       ...NANO_S_OPTED_OUT_ANALYTICS_PROPS,
     });
     expect(track).not.toHaveBeenCalledWith("modal_dismissed", expect.anything());
+    expect(store.getState().largeScreenUpsellModal.retries).toBe(0);
   });
 
   it("should track modal_dismissed with dismissMethod close button exactly once when the header close button is pressed", async () => {
@@ -288,5 +290,33 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
       expect(store.getState().backupHubFeatureIntro.isOpen).toBe(true);
     });
     expect(store.getState().largeScreenUpsellModal.retries).toBe(0);
+  });
+
+  it("should not auto-open when retries already reached threshold and cadence is still active", async () => {
+    const overrideInitialState = withFlagOverrides(
+      {
+        largeScreenUpsell: { enabled: true },
+        lwmProductTour: { enabled: false },
+        lwmGenericAwarenessModal: { enabled: false },
+        analyticsOptIn: { enabled: false },
+      },
+      state => {
+        const stateWithKnownDevice = withKnownDeviceModels([DeviceModelId.nanoS])(state);
+
+        return {
+          ...stateWithKnownDevice,
+          largeScreenUpsellModal: {
+            ...stateWithKnownDevice.largeScreenUpsellModal,
+            retries: 3,
+            lastSeenAt: NOW.getTime(),
+          },
+        };
+      },
+    );
+
+    render(<IntegrationNavigator />, { overrideInitialState });
+
+    expect(await screen.findByTestId("large-screen-upsell-integration-portfolio")).toBeVisible();
+    expect(screen.queryByTestId("large-screen-upsell-modal-drawer")).not.toBeOnTheScreen();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalContent/__tests__/LargeScreenUpsellModalContent.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalContent/__tests__/LargeScreenUpsellModalContent.test.tsx
@@ -75,9 +75,11 @@ describe("LargeScreenUpsellModalContent", () => {
   it("should open the primary CTA link when the platform can handle it", async () => {
     const { onPrimaryPress } = await renderAndPressPrimaryCta();
 
-    await waitFor(() => expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com"));
-    expect(openURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
-    expect(onPrimaryPress).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
+      expect(openURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
+      expect(onPrimaryPress).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("should not open the primary CTA link when the platform cannot handle it", async () => {
@@ -85,9 +87,11 @@ describe("LargeScreenUpsellModalContent", () => {
 
     const { onPrimaryPress } = await renderAndPressPrimaryCta();
 
-    await waitFor(() => expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com"));
-    expect(openURLSpy).not.toHaveBeenCalled();
-    expect(onPrimaryPress).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
+      expect(openURLSpy).not.toHaveBeenCalled();
+      expect(onPrimaryPress).not.toHaveBeenCalled();
+    });
   });
 
   it("should not open the primary CTA link when canOpenURL rejects", async () => {
@@ -95,9 +99,23 @@ describe("LargeScreenUpsellModalContent", () => {
 
     const { onPrimaryPress } = await renderAndPressPrimaryCta();
 
-    await waitFor(() => expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com"));
-    expect(openURLSpy).not.toHaveBeenCalled();
-    expect(onPrimaryPress).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
+      expect(openURLSpy).not.toHaveBeenCalled();
+      expect(onPrimaryPress).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should not trigger onPrimaryPress when openURL rejects", async () => {
+    openURLSpy.mockRejectedValue(new Error("Unable to open URL"));
+
+    const { onPrimaryPress } = await renderAndPressPrimaryCta();
+
+    await waitFor(() => {
+      expect(canOpenURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
+      expect(openURLSpy).toHaveBeenCalledWith("https://www.ledger.com");
+      expect(onPrimaryPress).not.toHaveBeenCalled();
+    });
   });
 
   it.each([

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalContent/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalContent/index.tsx
@@ -25,14 +25,24 @@ export function LargeScreenUpsellModalContent({ viewModel }: LargeScreenUpsellMo
     primaryButtonLabel.trim().length > 0 && resolvedPrimaryButtonLink.length > 0;
 
   const handleCtaPress = useCallback(async () => {
-    onPrimaryPress();
     const canOpenPrimaryButtonLink = await Linking.canOpenURL(resolvedPrimaryButtonLink).catch(
       () => false,
     );
 
-    if (canOpenPrimaryButtonLink) {
-      await Linking.openURL(resolvedPrimaryButtonLink).catch(() => undefined);
+    if (!canOpenPrimaryButtonLink) {
+      return;
     }
+
+    const hasOpenedPrimaryButtonLink = await Linking.openURL(resolvedPrimaryButtonLink).then(
+      () => true,
+      () => false,
+    );
+
+    if (!hasOpenedPrimaryButtonLink) {
+      return;
+    }
+
+    onPrimaryPress();
   }, [onPrimaryPress, resolvedPrimaryButtonLink]);
 
   return (


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Large-screen upsell retries increment when the modal is displayed, regardless of dismiss method.
      - Retries reset to `0` only when CTA navigation succeeds.
      - Cadence throttling still blocks display when `killThreshold` is reached and `cadenceDays` has not elapsed.

### 📝 Description

The large-screen upsell flow needed to enforce the display-based retry logic more strictly: seeing the modal should count toward the threshold regardless of how it is dismissed, while retry reset should happen only when CTA navigation actually succeeds.

This PR updates CTA behavior so `onPrimaryPress` is triggered only after both `canOpenURL` and `openURL` succeed, which makes the reset conditional on successful navigation. It also expands unit and integration coverage to verify display counting, non-reset on navigation failures, reset on successful CTA, and cadence blocking once threshold is reached.

### ❓ Context

- **JIRA or GitHub link**: [#19566](https://github.com/LedgerHQ/ledger-live/pull/19566)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)