### PR TITLE
[LWDM] fix(common): ARB ERC-20 token wrongly resolved as Arbitrum One chain (ETH)

### DIFF
--- a/.changeset/fix-arb-token-eth-collision.md
+++ b/.changeset/fix-arb-token-eth-collision.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+fix selectCurrencyForMetaId returning Arbitrum One chain instead of ARB ERC-20 token

--- a/.changeset/tiny-lions-run.md
+++ b/.changeset/tiny-lions-run.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/asset-aggregation": minor
+---
+
+fix resolveNormalizedCurrency mapping token meta-currencies to same-named L2 chains when their tickers differ

--- a/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
+++ b/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
@@ -221,6 +221,55 @@ describe("buildAssetDistribution", () => {
     expect(result.list).toHaveLength(2);
   });
 
+  it("does not canonicalize a token meta-currency to a same-named L2 chain when tickers differ", () => {
+    const arbChain = {
+      type: "CryptoCurrency" as const,
+      id: "arbitrum",
+      name: "Arbitrum One",
+      ticker: "ETH",
+      units: [{ name: "ETH", code: "ETH", magnitude: 18 }],
+    } as unknown as CryptoCurrency;
+
+    const arbToken = {
+      type: "TokenCurrency" as const,
+      id: "ethereum/erc20/arbitrum",
+      name: "Arbitrum",
+      ticker: "ARB",
+      units: [{ name: "ARB", code: "ARB", magnitude: 18 }],
+      parentCurrencyId: "ethereum",
+      tokenType: "erc20",
+      contractAddress: "0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1",
+    } as unknown as CryptoCurrency;
+
+    mockFindCryptoCurrencyById.mockImplementation((id: string) => {
+      if (id === "arbitrum") return arbChain;
+      return undefined;
+    });
+
+    const arbAssetsData: AssetsDataLike = {
+      cryptoAssets: {
+        arbitrum: {
+          id: "arbitrum",
+          ticker: "ARB",
+          assetsIds: {
+            ethereum: "ethereum/erc20/arbitrum",
+            arbitrum: "arbitrum",
+          },
+        },
+      },
+      markets: {
+        "ethereum/erc20/arbitrum": { id: "arbitrum-dao" },
+      },
+    };
+
+    const result = distribute([makeAccount("arb-1", arbToken, 1000)], undefined, arbAssetsData);
+
+    expect(result.list).toHaveLength(1);
+    expect(result.list[0].currency.id).toBe("ethereum/erc20/arbitrum");
+    expect(result.list[0].currency.ticker).toBe("ARB");
+    expect(result.list[0].marketId).toBe("arbitrum-dao");
+  });
+
   it("should normalize cross-network amounts when tokens have different magnitudes", () => {
     const ethUsdt = makeCurrency("ethereum/erc20/usd_tether__erc20_", "Tether USD", 6);
     const bscUsdt = makeCurrency("bsc/bep20/binance-peg_bsc-usd", "Tether USD", 18);

--- a/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
+++ b/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
@@ -38,8 +38,20 @@ function buildCurrencyLookups(cryptoAssets: AssetsDataLike["cryptoAssets"]): Cur
   return { currencyToMetaId, primaryAssets };
 }
 
-function resolveNormalizedCurrency(metaCurrencyId: string): CryptoCurrency | undefined {
-  return findCryptoCurrencyById(toSlug(metaCurrencyId));
+function resolveNormalizedCurrency(
+  metaCurrencyId: string,
+  cryptoAssets: AssetsDataLike["cryptoAssets"],
+): CryptoCurrency | undefined {
+  const candidate = findCryptoCurrencyById(toSlug(metaCurrencyId));
+  if (!candidate) return undefined;
+
+  // Reject the candidate if its ticker differs from the meta-currency ticker: a chain
+  // (e.g. Arbitrum One, ticker "ETH") must not represent a token meta-currency that
+  // shares its name (e.g. ARB governance token, ticker "ARB").
+  const metaTicker = cryptoAssets[metaCurrencyId]?.ticker?.toUpperCase();
+  if (metaTicker && candidate.ticker.toUpperCase() !== metaTicker) return undefined;
+
+  return candidate;
 }
 
 function computeDistribution(countervalue: number, sum: number, fallback: number): number {
@@ -137,7 +149,10 @@ export function buildAssetDistribution(
   let sum = 0;
   for (const group of groups.values()) {
     const primaryAssetId = primaryAssets[group.metaCurrencyId];
-    const normalizedCurrency = resolveNormalizedCurrency(group.metaCurrencyId);
+    const normalizedCurrency = resolveNormalizedCurrency(
+      group.metaCurrencyId,
+      assetsData.cryptoAssets,
+    );
     const primaryCurrency = currencyById.get(primaryAssetId);
     if (normalizedCurrency) {
       group.currency = normalizedCurrency;

--- a/libs/asset-aggregation/src/assetDistribution/types.ts
+++ b/libs/asset-aggregation/src/assetDistribution/types.ts
@@ -9,6 +9,7 @@ import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets
 /** Minimal shape of DADA's CryptoAssetMeta needed by buildAssetDistribution. */
 export interface CryptoAssetMetaLike {
   id: string;
+  ticker?: string;
   assetsIds: Record<string, string>;
 }
 

--- a/libs/ledger-live-common/src/dada-client/__mocks__/assets.mock.ts
+++ b/libs/ledger-live-common/src/dada-client/__mocks__/assets.mock.ts
@@ -211,3 +211,53 @@ export const mockUsdcAssetsData = {
     metaCurrencyIds: ["usdc"],
   },
 };
+
+export const mockArbitrumTokenAssetsData = {
+  cryptoAssets: {
+    arbitrum: {
+      id: "arbitrum",
+      ticker: "ARB",
+      name: "Arbitrum",
+      assetsIds: {
+        ethereum: "ethereum/erc20/arbitrum",
+        arbitrum: "arbitrum",
+      },
+    },
+  },
+  networks: {
+    ethereum: { id: "ethereum", name: "Ethereum" },
+    arbitrum: { id: "arbitrum", name: "Arbitrum One" },
+  },
+  cryptoOrTokenCurrencies: {
+    "ethereum/erc20/arbitrum": {
+      type: "TokenCurrency" as const,
+      id: "ethereum/erc20/arbitrum",
+      name: "Arbitrum",
+      ticker: "ARB",
+      contractAddress: "0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1",
+      parentCurrencyId: "ethereum",
+      tokenType: "erc20",
+      units: [{ name: "ARB", code: "ARB", magnitude: 18 }],
+    },
+    arbitrum: {
+      type: "CryptoCurrency" as const,
+      id: "arbitrum",
+      name: "Arbitrum One",
+      ticker: "ETH",
+      units: [{ name: "ETH", code: "ETH", magnitude: 18 }],
+      family: "evm",
+      managerAppName: "Ethereum",
+      coinType: 60,
+      scheme: "arbitrum",
+      color: "#28A0F0",
+      explorerViews: [],
+    },
+  },
+  interestRates: {},
+  markets: {},
+  currenciesOrder: {
+    key: "marketCap",
+    order: "desc",
+    metaCurrencyIds: ["arbitrum"],
+  },
+};

--- a/libs/ledger-live-common/src/dada-client/utils/__test__/currencySelection.test.ts
+++ b/libs/ledger-live-common/src/dada-client/utils/__test__/currencySelection.test.ts
@@ -1,6 +1,7 @@
 import { selectCurrency, selectCurrencyForMetaId } from "../currencySelection";
 import {
   mockAssetsDataWithPagination,
+  mockArbitrumTokenAssetsData,
   mockBitcoinAssetsData,
   mockUsdcAssetsData,
 } from "../../__mocks__/assets.mock";
@@ -64,6 +65,16 @@ describe("currencySelection", () => {
       const result = selectCurrencyForMetaId("usdc", data);
 
       expect(result).toBeDefined();
+      expect(result!.type).toBe("TokenCurrency");
+    });
+
+    it("prefers the ERC-20 token over a same-named L2 chain when their tickers differ", () => {
+      const data = { ...mockArbitrumTokenAssetsData, pagination: {} } as AssetsDataWithPagination;
+      const result = selectCurrencyForMetaId("arbitrum", data);
+
+      expect(result).toBeDefined();
+      expect(result!.id).toBe("ethereum/erc20/arbitrum");
+      expect(result!.ticker).toBe("ARB");
       expect(result!.type).toBe("TokenCurrency");
     });
   });

--- a/libs/ledger-live-common/src/dada-client/utils/currencySelection.ts
+++ b/libs/ledger-live-common/src/dada-client/utils/currencySelection.ts
@@ -1,37 +1,40 @@
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { AssetsDataWithPagination } from "../state-manager/types";
 
-/**
- * Selects the best currency for a given meta-currency ID based on priority:
- * 1. Main currency (matching metaCurrencyId)
- * 2. CryptoCurrency type
- * 3. First available network
- */
 export function selectCurrencyForMetaId(
   metaCurrencyId: string,
   data: AssetsDataWithPagination,
 ): CryptoOrTokenCurrency | undefined {
-  const assetsIds = data.cryptoAssets[metaCurrencyId]?.assetsIds;
+  const meta = data.cryptoAssets[metaCurrencyId];
+  const assetsIds = meta?.assetsIds;
   if (!assetsIds) return undefined;
+
+  const metaTicker = meta.ticker?.toUpperCase();
 
   let fallback: CryptoOrTokenCurrency | undefined;
   let crypto: CryptoOrTokenCurrency | undefined;
+  let token: CryptoOrTokenCurrency | undefined;
 
   for (const id of Object.values(assetsIds)) {
     const currency = data.cryptoOrTokenCurrencies[id];
     if (!currency) continue;
 
-    if (currency.id === metaCurrencyId) return currency;
+    const tickerMatches = currency.ticker?.toUpperCase() === metaTicker;
+
+    // Require both id and ticker to match: some L2 chains share their ledger id with a
+    // token meta-currency id but use a different native ticker (e.g. an L2 that uses ETH
+    // as gas). Id alone would pick the chain when we actually want the token.
+    if (currency.id === metaCurrencyId && tickerMatches) return currency;
     if (!fallback) fallback = currency;
-    if (!crypto && currency.type === "CryptoCurrency") crypto = currency;
+    // Prefer chain coins over tokens when the ticker matches — the chain is the primary
+    // form of the asset. Skip chains whose ticker differs: they are unrelated assets.
+    if (!crypto && currency.type === "CryptoCurrency" && tickerMatches) crypto = currency;
+    if (!token && currency.type === "TokenCurrency" && tickerMatches) token = currency;
   }
 
-  return crypto ?? fallback;
+  return crypto ?? token ?? fallback;
 }
 
-/**
- * Selects the best currency from the first meta-currency in the asset data result.
- */
 export function selectCurrency(
   result: AssetsDataWithPagination,
 ): CryptoOrTokenCurrency | undefined {


### PR DESCRIPTION
> Cherry-pick of #19570 + #19583 onto \`hotfix\`.

### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - ARB token accounts now correctly show ARB price and ticker instead of ETH
  - Global search: tapping the ARB result navigates to the ARB asset detail page, not ETH (fixes LWM and LWD)
  - Any other token whose meta-currency id collides with a same-named L2 chain is also fixed by the same logic

### 📝 Description

Two independent bugs caused the same symptom (ARB accounts displaying ETH ticker/price and navigating to the ETH detail page):

**Bug a — `selectCurrencyForMetaId` (live-common, #19570)**: The early-return rule matched `currency.id === metaCurrencyId` without checking the ticker. For the ARB meta-currency `"arbitrum"`, this picked the Arbitrum One chain (id `"arbitrum"`, ticker `"ETH"`) over the ARB ERC-20 token (id `"ethereum/erc20/arbitrum"`, ticker `"ARB"`). Fix: require both id AND ticker to match.

**Bug b — `resolveNormalizedCurrency` (asset-aggregation, #19583)**: `buildAssetDistribution` calls `findCryptoCurrencyById(toSlug("arbitrum"))` which also finds the Arbitrum One chain and unconditionally overwrites `group.currency` and `group.marketId` with chain data. This affected all existing ARB token accounts viewed from the portfolio. Fix: validate that the found candidate's ticker matches the DADA meta-currency ticker before using it.

### ❓ Context

- **JIRA**: [LIVE-34368](https://ledgerhq.atlassian.net/browse/LIVE-34368)
- **GitHub issue**: [#19527](https://github.com/LedgerHQ/ledger-live/issues/19527)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34368]: https://ledgerhq.atlassian.net/browse/LIVE-34368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ