### PR TITLE
[LWDM] fix(asset-aggregation): ARB token accounts no longer display ETH price/ticker (part b)

### DIFF
--- a/.changeset/tiny-lions-run.md
+++ b/.changeset/tiny-lions-run.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/asset-aggregation": minor
+---
+
+fix resolveNormalizedCurrency mapping token meta-currencies to same-named L2 chains when their tickers differ

--- a/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
+++ b/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
@@ -221,6 +221,55 @@ describe("buildAssetDistribution", () => {
     expect(result.list).toHaveLength(2);
   });
 
+  it("does not canonicalize a token meta-currency to a same-named L2 chain when tickers differ", () => {
+    const arbChain = {
+      type: "CryptoCurrency" as const,
+      id: "arbitrum",
+      name: "Arbitrum One",
+      ticker: "ETH",
+      units: [{ name: "ETH", code: "ETH", magnitude: 18 }],
+    } as unknown as CryptoCurrency;
+
+    const arbToken = {
+      type: "TokenCurrency" as const,
+      id: "ethereum/erc20/arbitrum",
+      name: "Arbitrum",
+      ticker: "ARB",
+      units: [{ name: "ARB", code: "ARB", magnitude: 18 }],
+      parentCurrencyId: "ethereum",
+      tokenType: "erc20",
+      contractAddress: "0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1",
+    } as unknown as CryptoCurrency;
+
+    mockFindCryptoCurrencyById.mockImplementation((id: string) => {
+      if (id === "arbitrum") return arbChain;
+      return undefined;
+    });
+
+    const arbAssetsData: AssetsDataLike = {
+      cryptoAssets: {
+        arbitrum: {
+          id: "arbitrum",
+          ticker: "ARB",
+          assetsIds: {
+            ethereum: "ethereum/erc20/arbitrum",
+            arbitrum: "arbitrum",
+          },
+        },
+      },
+      markets: {
+        "ethereum/erc20/arbitrum": { id: "arbitrum-dao" },
+      },
+    };
+
+    const result = distribute([makeAccount("arb-1", arbToken, 1000)], undefined, arbAssetsData);
+
+    expect(result.list).toHaveLength(1);
+    expect(result.list[0].currency.id).toBe("ethereum/erc20/arbitrum");
+    expect(result.list[0].currency.ticker).toBe("ARB");
+    expect(result.list[0].marketId).toBe("arbitrum-dao");
+  });
+
   it("should normalize cross-network amounts when tokens have different magnitudes", () => {
     const ethUsdt = makeCurrency("ethereum/erc20/usd_tether__erc20_", "Tether USD", 6);
     const bscUsdt = makeCurrency("bsc/bep20/binance-peg_bsc-usd", "Tether USD", 18);

--- a/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
+++ b/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
@@ -38,8 +38,20 @@ function buildCurrencyLookups(cryptoAssets: AssetsDataLike["cryptoAssets"]): Cur
   return { currencyToMetaId, primaryAssets };
 }
 
-function resolveNormalizedCurrency(metaCurrencyId: string): CryptoCurrency | undefined {
-  return findCryptoCurrencyById(toSlug(metaCurrencyId));
+function resolveNormalizedCurrency(
+  metaCurrencyId: string,
+  cryptoAssets: AssetsDataLike["cryptoAssets"],
+): CryptoCurrency | undefined {
+  const candidate = findCryptoCurrencyById(toSlug(metaCurrencyId));
+  if (!candidate) return undefined;
+
+  // Reject the candidate if its ticker differs from the meta-currency ticker: a chain
+  // (e.g. Arbitrum One, ticker "ETH") must not represent a token meta-currency that
+  // shares its name (e.g. ARB governance token, ticker "ARB").
+  const metaTicker = cryptoAssets[metaCurrencyId]?.ticker?.toUpperCase();
+  if (metaTicker && candidate.ticker.toUpperCase() !== metaTicker) return undefined;
+
+  return candidate;
 }
 
 function computeDistribution(countervalue: number, sum: number, fallback: number): number {
@@ -137,7 +149,10 @@ export function buildAssetDistribution(
   let sum = 0;
   for (const group of groups.values()) {
     const primaryAssetId = primaryAssets[group.metaCurrencyId];
-    const normalizedCurrency = resolveNormalizedCurrency(group.metaCurrencyId);
+    const normalizedCurrency = resolveNormalizedCurrency(
+      group.metaCurrencyId,
+      assetsData.cryptoAssets,
+    );
     const primaryCurrency = currencyById.get(primaryAssetId);
     if (normalizedCurrency) {
       group.currency = normalizedCurrency;

--- a/libs/asset-aggregation/src/assetDistribution/types.ts
+++ b/libs/asset-aggregation/src/assetDistribution/types.ts
@@ -9,6 +9,7 @@ import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets
 /** Minimal shape of DADA's CryptoAssetMeta needed by buildAssetDistribution. */
 export interface CryptoAssetMetaLike {
   id: string;
+  ticker?: string;
   assetsIds: Record<string, string>;
 }
 


### PR DESCRIPTION
> Follow-up to #19570 — the complete fix for [LIVE-34368](https://ledgerhq.atlassian.net/browse/LIVE-34368).

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - ARB token accounts now correctly display ARB ticker and ARB market price (not ETH)
  - The ARB row in portfolio now resolves to the ARB governance token, not the Arbitrum One chain
  - Any other token whose DADA meta-currency id collides with an L2 chain name is also fixed

### 📝 Description

**Root cause (missed in #19570)**: `buildAssetDistribution` calls `resolveNormalizedCurrency` which does `findCryptoCurrencyById(toSlug(metaCurrencyId))`. For the ARB governance token the DADA meta-currency id is `"arbitrum"`, so `findCryptoCurrencyById("arbitrum")` returns the **Arbitrum One chain** (ticker `"ETH"`). This made `buildAssetDistribution` unconditionally overwrite `group.currency` with the chain and `group.marketId` with the chain's market data — causing every ARB token account to display `ETH` price, `ETH` ticker, and navigate to the Arbitrum One / ETH asset detail page.

**Fix**: `resolveNormalizedCurrency` now compares the found candidate's ticker against the DADA meta-currency ticker. If they differ (chain `"ETH"` ≠ token `"ARB"`), the candidate is rejected and the function returns `undefined`, letting the code fall through to use the actual primary currency from the user's account (the ARB ERC-20 token).

```typescript
// Before
function resolveNormalizedCurrency(metaCurrencyId: string): CryptoCurrency | undefined {
  return findCryptoCurrencyById(toSlug(metaCurrencyId));
}

// After
function resolveNormalizedCurrency(
  metaCurrencyId: string,
  cryptoAssets: AssetsDataLike["cryptoAssets"],
): CryptoCurrency | undefined {
  const candidate = findCryptoCurrencyById(toSlug(metaCurrencyId));
  if (!candidate) return undefined;

  // Reject the candidate if its ticker differs from the meta-currency ticker: a chain
  // (e.g. Arbitrum One, ticker "ETH") must not represent a token meta-currency that
  // shares its name (e.g. ARB governance token, ticker "ARB").
  const metaTicker = cryptoAssets[metaCurrencyId]?.ticker?.toUpperCase();
  if (metaTicker && candidate.ticker.toUpperCase() !== metaTicker) return undefined;

  return candidate;
}
```

**Why #19570 alone wasn't enough**: PR #19570 fixed `selectCurrencyForMetaId` (used during search and asset list rendering). But `buildAssetDistribution` has its own currency resolution path via `resolveNormalizedCurrency` which was not covered by that fix. The account display and navigation from the portfolio still went through this second buggy path.

**Safety**: The ticker check only activates when `cryptoAssets[metaCurrencyId]?.ticker` is defined. All existing assets where the chain ticker matches the meta-currency ticker (e.g. ETH `"urn:crypto:meta-currency:ethereum"` → `"ETH"`, BTC `"bitcoin"` → `"BTC"`) are unaffected — existing tests confirm this.

https://github.com/user-attachments/assets/4388bcb9-065f-4c01-a430-a37042da1851

https://github.com/user-attachments/assets/5a0be641-0dca-4adb-915e-4d8a72e443b1





### ❓ Context

- **JIRA or GitHub link**: [LIVE-34368](https://ledgerhq.atlassian.net/browse/LIVE-34368)
- **GitHub issue**: [#19527](https://github.com/LedgerHQ/ledger-live/issues/19527)
- **Part a (live-common fix)**: #19570

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34368]: https://ledgerhq.atlassian.net/browse/LIVE-34368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34368]: https://ledgerhq.atlassian.net/browse/LIVE-34368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ