### PR TITLE
[LWDM] fix(hedera): parse multi-asset CryptoTransfers into per-asset operations

### DIFF
--- a/.changeset/hedera-multi-asset-transfers.md
+++ b/.changeset/hedera-multi-asset-transfers.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+fix(hedera): parse multi-asset CryptoTransfers into one operation per fund movement (HBAR on the main account, one per token on its sub-account) instead of a synthetic FEES operation. Operation ids change, so already-synced accounts may need a resync or cache clear.

--- a/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
@@ -940,6 +940,99 @@ describe("createApi", () => {
       expect(ops.every(op => /^0\.0\.\d+$/.test(op.tx.feesPayer ?? ""))).toBe(true);
     });
 
+    describe("real multi-asset (packed) CryptoTransfer", () => {
+      const packedTxHash = "OoaJ/10qHN/97Zaxj8vxGIJfL9UhrGKaJBwclsL4wUeqbegBAXhdmw+/6/dB6mow";
+      const sender = MAINNET_TEST_ACCOUNTS.withTokens.accountId;
+      const usdc = "0.0.456858";
+      const hbark = "0.0.5022567";
+      const r1 = "0.0.9124531";
+      const r2 = "0.0.9169746";
+      const expectedFee = 1176695n;
+
+      let packedOps: Awaited<ReturnType<typeof api.listOperations>>["items"];
+
+      beforeAll(async () => {
+        const { items: ops } = await api.listOperations(sender, {
+          minHeight: 0,
+          cursor: "1760510880.000000000",
+          limit: 100,
+          order: "desc",
+        });
+
+        packedOps = ops.filter(o => o.tx.hash === packedTxHash);
+      });
+
+      it("should return one operation per fund movement", () => {
+        expect(packedOps).toHaveLength(5);
+      });
+
+      it("should not create a standalone FEES operation when HBAR moved", () => {
+        expect(packedOps.some(o => o.type === "FEES")).toBe(false);
+      });
+
+      it("should report the same tx fee and fees payer on every OUT leg", () => {
+        for (const op of packedOps) {
+          expect(op.type).toBe("OUT");
+          expect(op.tx.fees).toBe(expectedFee);
+          expect(op.tx.feesPayer).toBe(sender);
+          expect(op.senders).toEqual([sender]);
+        }
+      });
+
+      it("should return one native OUT operation per recipient with a fee-exclusive value", () => {
+        const native = packedOps.filter(o => o.asset.type === "native");
+        expect(native).toHaveLength(2);
+        expect(native.map(o => o.recipients).sort()).toEqual([[r1], [r2]].sort());
+        for (const op of native) {
+          expect(op.value).toBe(1000000n);
+        }
+        expect(native.reduce((acc, o) => acc + o.value, 0n)).toBe(2000000n);
+      });
+
+      it("should return one OUT operation per HTS token movement with the raw token value", () => {
+        const tokens = packedOps.filter(o => o.asset.type !== "native");
+        expect(tokens).toHaveLength(3);
+        const tokenSummary = tokens
+          .map(t =>
+            [
+              (t.asset as { assetReference: string }).assetReference,
+              t.recipients[0],
+              t.value,
+            ].join(":"),
+          )
+          .sort();
+        expect(tokenSummary).toEqual(
+          [`${usdc}:${r1}:10000`, `${hbark}:${r2}:1`, `${hbark}:${r1}:1`].sort(),
+        );
+      });
+    });
+
+    it("should return a standalone FEES operation for a fee-only HBAR allowance approve", async () => {
+      const allowanceTxHash = "PjwF86OcFhvrIZlp+Rwg74Vg+yqxCAuTyNcgrXb8dKMbk5f/y//rZB+vokZMXd4W";
+      const payer = MAINNET_TEST_ACCOUNTS.withTokens.accountId;
+
+      const { items: ops } = await api.listOperations(payer, {
+        minHeight: 0,
+        cursor: "1783953434.000000000",
+        limit: 10,
+        order: "desc",
+      });
+
+      const allowanceOps = ops.filter(o => o.tx.hash === allowanceTxHash);
+
+      expect(allowanceOps).toHaveLength(1);
+      expect(allowanceOps[0]).toMatchObject({
+        type: "FEES",
+        value: 0n,
+        asset: { type: "native" },
+        senders: [payer],
+        tx: {
+          fees: 74754802n,
+          feesPayer: payer,
+        },
+      });
+    });
+
     it("returns IN/OUT operations for mint and burn of amUSDC", async () => {
       const ownerAccountId = MAINNET_TEST_ACCOUNTS.withTokens.accountIdWithErc20;
       const { items: ops } = await api.listOperations(ownerAccountId, {

--- a/libs/coin-modules/coin-hedera/src/api/listOperations.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/listOperations.test.ts
@@ -1,0 +1,153 @@
+import { setupMockCryptoAssetsStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
+import { encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account/accountId";
+import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
+import BigNumber from "bignumber.js";
+import { apiClient } from "../network/api";
+import { hgraphClient } from "../network/hgraph";
+import * as networkUtils from "../network/utils";
+import { getMockedConfig } from "../test/fixtures/config.fixture";
+import { getMockedCurrency } from "../test/fixtures/currency.fixture";
+import { getMockedMirrorTransaction } from "../test/fixtures/mirror.fixture";
+import * as logicUtils from "../logic/utils";
+import { createApi } from "./index";
+
+// Exercises the real pipeline end-to-end (real `listOperationsV2` + real
+// `getOperationValue`), mocking only the network boundary.
+setupMockCryptoAssetsStore();
+
+jest.mock("@ledgerhq/ledger-wallet-framework/account/accountId", () => ({
+  ...jest.requireActual("@ledgerhq/ledger-wallet-framework/account/accountId"),
+  encodeTokenAccountId: jest.fn(),
+}));
+jest.mock("@ledgerhq/ledger-wallet-framework/operation");
+jest.mock("../network/api");
+jest.mock("../network/hgraph");
+jest.mock("../network/utils", () => ({
+  ...jest.requireActual("../network/utils"),
+  toEVMAddress: jest.fn(),
+  getERC20BalancesForAccountV2: jest.fn(),
+  enrichERC20Transfers: jest.fn(),
+  analyzeStakingOperation: jest.fn(),
+}));
+jest.mock("../logic/utils", () => ({
+  ...jest.requireActual("../logic/utils"),
+  base64ToUrlSafeBase64: jest.fn().mockImplementation(hash => `encoded-${hash}`),
+  getMemoFromBase64: jest.fn().mockImplementation(memo => (memo ? `decoded-${memo}` : null)),
+  getSyntheticBlock: jest.fn(),
+  extractFeesPayer: jest.fn(),
+}));
+
+describe("createApi().listOperations - fee-exclusive API surface", () => {
+  const currencyId = getMockedCurrency().id;
+  const api = createApi(getMockedConfig(), currencyId);
+
+  const payer = "0.0.8835924";
+  const usdc = "0.0.456858";
+  const hbark = "0.0.5022567";
+  const r1 = "0.0.9124531";
+  const r2 = "0.0.9169746";
+  const fee = 1176695;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (networkUtils.toEVMAddress as jest.Mock).mockResolvedValue(
+      "0x0000000000000000000000000000000000000001",
+    );
+    (networkUtils.getERC20BalancesForAccountV2 as jest.Mock).mockResolvedValue([]);
+    (networkUtils.enrichERC20Transfers as jest.Mock).mockResolvedValue([]);
+    (networkUtils.analyzeStakingOperation as jest.Mock).mockResolvedValue(null);
+    (apiClient.getAccountTokens as jest.Mock).mockResolvedValue([]);
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [],
+      nextCursor: null,
+    });
+    (hgraphClient.getERC20Transfers as jest.Mock).mockResolvedValue([]);
+    (hgraphClient.getLatestIndexedConsensusTimestamp as jest.Mock).mockResolvedValue(
+      new BigNumber(0),
+    );
+    (encodeOperationId as jest.Mock).mockImplementation(
+      (accountId, hash, type) => `${accountId}-${hash}-${type}`,
+    );
+    (encodeTokenAccountId as jest.Mock).mockImplementation(
+      (accountId, token) => `${accountId}-${token.id}`,
+    );
+    (logicUtils.getSyntheticBlock as jest.Mock).mockReturnValue({
+      blockHeight: 176051087,
+      blockHash: "0xsynthetic",
+      blockTime: new Date("2025-10-15T00:00:00Z"),
+    });
+    (logicUtils.extractFeesPayer as jest.Mock).mockReturnValue(payer);
+    // keep the token off CAL so it takes the raw HTS path (deterministic, no lookup)
+    setupMockCryptoAssetsStore({
+      findTokenByAddressInCurrency: jest.fn().mockResolvedValue(null),
+    });
+  });
+
+  describe("multi-asset CryptoTransfer", () => {
+    let items: Awaited<ReturnType<typeof api.listOperations>>["items"];
+
+    beforeEach(async () => {
+      (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+        transactions: [
+          getMockedMirrorTransaction({
+            consensus_timestamp: "1760510879.300860000",
+            transaction_id: `${payer}-1760510879-300860000`,
+            transaction_hash: "multiasset",
+            charged_tx_fee: fee,
+            result: "SUCCESS",
+            name: "CRYPTOTRANSFER",
+            staking_reward_transfers: [],
+            transfers: [
+              { account: payer, amount: -(2000000 + fee) },
+              { account: r1, amount: 1000000 },
+              { account: r2, amount: 1000000 },
+              { account: "0.0.802", amount: fee },
+            ],
+            token_transfers: [
+              { token_id: usdc, account: payer, amount: -10000 },
+              { token_id: usdc, account: r1, amount: 10000 },
+              { token_id: hbark, account: payer, amount: -2 },
+              { token_id: hbark, account: r2, amount: 2 },
+            ],
+          }),
+        ],
+        nextCursor: null,
+      });
+
+      ({ items } = await api.listOperations(payer, { limit: 10, order: "desc", minHeight: 0 }));
+    });
+
+    it("should return one native OUT operation per recipient with a fee-exclusive value", () => {
+      const native = items.filter(o => o.asset.type === "native");
+      expect(native).toHaveLength(2);
+      expect(native.map(o => o.recipients).sort()).toEqual([[r1], [r2]].sort());
+      for (const op of native) {
+        expect(op).toMatchObject({ type: "OUT", value: 1000000n });
+      }
+    });
+
+    it("should report the tx fee on every native operation", () => {
+      const native = items.filter(o => o.asset.type === "native");
+      for (const op of native) {
+        expect(op.tx.fees).toBe(BigInt(fee));
+      }
+    });
+
+    it("should not create a standalone FEES operation when HBAR moved", () => {
+      expect(items.some(o => o.type === "FEES")).toBe(false);
+    });
+
+    it("should return one OUT operation per HTS token with the raw token value", () => {
+      const tokens = items.filter(o => o.asset.type !== "native");
+      expect(tokens).toHaveLength(2);
+      expect(
+        tokens
+          .map(t => [(t.asset as { assetReference: string }).assetReference, t.value].join(":"))
+          .sort(),
+      ).toEqual([`${hbark}:2`, `${usdc}:10000`].sort());
+      expect(tokens.every(t => t.type === "OUT")).toBe(true);
+      expect(tokens.every(t => t.tx.fees === BigInt(fee))).toBe(true);
+    });
+  });
+});

--- a/libs/coin-modules/coin-hedera/src/bridge/serialization.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/serialization.test.ts
@@ -1,3 +1,4 @@
+import type { Account, Operation, OperationType } from "@ledgerhq/types-live";
 import {
   getMockedAccount,
   getMockedAccountRaw,
@@ -35,5 +36,37 @@ describe("serialization", () => {
     assignFromAccountRaw(mockedAccountRaw, mockedAccount);
     expect(typeof mockedAccountRaw.hederaResources).toBe("object");
     expect(mockedAccountRaw.hederaResources).not.toBeNull();
+  });
+
+  describe("assignFromAccountRaw – subOperations inferred at deserialization", () => {
+    const tokenSubOperation = { id: "token-op", type: "OUT", hash: "h1" } as Operation;
+    const makeOperation = (type: OperationType): Operation =>
+      ({ id: `op-${type}`, type, hash: "h1", subOperations: [tokenSubOperation] }) as Operation;
+
+    const deserialize = (operations: Operation[]): Account => {
+      const account = { ...getMockedAccount(), operations };
+      assignFromAccountRaw(getMockedAccountRaw(), account);
+      return account;
+    };
+
+    test("strips subOperations from value coin operations of a multi-asset tx", () => {
+      const account = deserialize([
+        makeOperation("OUT"),
+        makeOperation("IN"),
+        makeOperation("REWARD"),
+      ]);
+
+      for (const operation of account.operations) {
+        expect(operation.subOperations).toEqual([]);
+      }
+    });
+
+    test("keeps subOperations on FEES and NONE parent operations", () => {
+      const account = deserialize([makeOperation("FEES"), makeOperation("NONE")]);
+
+      for (const operation of account.operations) {
+        expect(operation.subOperations).toEqual([tokenSubOperation]);
+      }
+    });
   });
 });

--- a/libs/coin-modules/coin-hedera/src/bridge/serialization.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/serialization.ts
@@ -1,4 +1,4 @@
-import type { AccountRaw, Account } from "@ledgerhq/types-live";
+import type { AccountRaw, Account, OperationType } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import type {
   HederaAccount,
@@ -50,6 +50,10 @@ export function assignToAccountRaw(account: Account, accountRaw: AccountRaw): vo
   }
 }
 
+// The only operation types allowed to parent token operations (see prepareOperations):
+// FEES (fee of a token transfer) and NONE (anchor of an orphan token operation).
+const TOKEN_PARENT_OPERATION_TYPES = new Set<OperationType>(["FEES", "NONE"]);
+
 export function assignFromAccountRaw(accountRaw: AccountRaw, account: Account) {
   const hederaAccount = account as HederaAccount;
   const hederaAccountRaw = accountRaw as HederaAccountRaw;
@@ -57,4 +61,14 @@ export function assignFromAccountRaw(accountRaw: AccountRaw, account: Account) {
   if (hederaAccountRaw.hederaResources) {
     hederaAccount.hederaResources = fromHederaResourcesRaw(hederaAccountRaw.hederaResources);
   }
+
+  // fromAccountRaw rebuilds subOperations with inferSubOperations, which attaches
+  // every token operation sharing the tx hash to every coin operation of that tx.
+  // A value coin operation of a multi-asset tx must not list them, so re-apply
+  // the prepareOperations parenting rule after deserialization.
+  account.operations = account.operations.map(op =>
+    op.subOperations?.length && !TOKEN_PARENT_OPERATION_TYPES.has(op.type)
+      ? { ...op, subOperations: [] }
+      : op,
+  );
 }

--- a/libs/coin-modules/coin-hedera/src/bridge/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/utils.test.ts
@@ -20,6 +20,9 @@ import {
 } from "./utils";
 import { getMockedMirrorToken } from "../test/fixtures/mirror.fixture";
 
+const idsByValue = (ops: { value: BigNumber; id: string }[]) =>
+  new Map(ops.map(op => [op.value.toString(), op.id]));
+
 describe("bridge utils", () => {
   describe("prepareOperations", () => {
     const tokenCurrencyFromCAL = getTokenCurrencyFromCALByType("hts");
@@ -32,9 +35,9 @@ describe("bridge utils", () => {
       });
     });
 
-    it("links token operation to existing coin operation with matching hash", async () => {
+    it("should link the token operation to the existing FEES coin operation when hashes match", async () => {
       const mockedTokenAccount = getMockedTokenAccount(tokenCurrencyFromCAL);
-      const mockedCoinOperation = getMockedOperation({ hash: "shared" });
+      const mockedCoinOperation = getMockedOperation({ hash: "shared", type: "FEES" });
       const mockedTokenOperation = getMockedOperation({
         hash: "shared",
         accountId: encodeTokenAccountId(mockedTokenAccount.parentId, tokenCurrencyFromCAL),
@@ -44,6 +47,40 @@ describe("bridge utils", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].subOperations).toEqual([mockedTokenOperation]);
+    });
+
+    it("should keep the coin operation standalone with no subOperations when a token operation shares its hash", async () => {
+      const mockedTokenAccount = getMockedTokenAccount(tokenCurrencyFromCAL);
+      const mockedCoinOperation = getMockedOperation({ hash: "shared", type: "OUT" });
+      const mockedTokenOperation = getMockedOperation({
+        hash: "shared",
+        accountId: encodeTokenAccountId(mockedTokenAccount.parentId, tokenCurrencyFromCAL),
+      });
+
+      const result = await prepareOperations([mockedCoinOperation], [mockedTokenOperation]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe("OUT");
+      expect(result[0].subOperations).toEqual([]);
+    });
+
+    it("should share one NONE parent operation when multiple orphan token operations share a hash", async () => {
+      const mockedTokenAccount = getMockedTokenAccount(tokenCurrencyFromCAL);
+      const tokenAccountId = encodeTokenAccountId(mockedTokenAccount.parentId, tokenCurrencyFromCAL);
+      const mockedTokenOperationA = getMockedOperation({
+        hash: "orphan-hash",
+        accountId: tokenAccountId,
+      });
+      const mockedTokenOperationB = getMockedOperation({
+        hash: "orphan-hash",
+        accountId: tokenAccountId,
+      });
+
+      const result = await prepareOperations([], [mockedTokenOperationA, mockedTokenOperationB]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe("NONE");
+      expect(result[0].subOperations).toEqual([mockedTokenOperationA, mockedTokenOperationB]);
     });
 
     it("creates NONE coin operation as parent if no coin op with matching hash exists", async () => {
@@ -340,6 +377,181 @@ describe("bridge utils", () => {
       });
 
       expect(bridgeCoinOperations).toEqual([expect.objectContaining({ hash: "h1", type: "FEES" })]);
+    });
+
+    it("should keep a standalone FEES coin op when the tx has no token operations", () => {
+      const feesOp = getMockedOperation({ hash: "h1", type: "FEES" });
+
+      const { bridgeCoinOperations } = resolveBridgeOperations({
+        coinOperations: [feesOp],
+        tokenOperations: [],
+        ledgerAccountId,
+        calTokenByAddress: new Map(),
+      });
+
+      expect(bridgeCoinOperations).toEqual([expect.objectContaining({ hash: "h1", type: "FEES" })]);
+    });
+
+    it("should keep the clean tx hash on token ops and give them a unique id when an HBAR value op shares the hash", () => {
+      const htsToken = getMockedHTSTokenCurrency({ contractAddress: "0.0.1001" });
+      const coinOut = getMockedOperation({ hash: "h1", type: "OUT" });
+      const tokenOp = getMockedOperation({
+        hash: "h1",
+        type: "OUT",
+        contract: htsToken.contractAddress,
+      });
+
+      const { bridgeCoinOperations, bridgeTokenOperations } = resolveBridgeOperations({
+        coinOperations: [coinOut],
+        tokenOperations: [tokenOp],
+        ledgerAccountId,
+        calTokenByAddress: new Map([[htsToken.contractAddress, htsToken]]),
+      });
+
+      const expectedTokenAccountId = encodeTokenAccountId(ledgerAccountId, htsToken);
+      expect(bridgeCoinOperations).toEqual([expect.objectContaining({ hash: "h1", type: "OUT" })]);
+      expect(bridgeTokenOperations).toEqual([
+        expect.objectContaining({
+          hash: "h1",
+          id: encodeOperationId(expectedTokenAccountId, "h1-token-anchor", "OUT"),
+        }),
+      ]);
+      expect(bridgeTokenOperations[0].id).not.toBe(bridgeCoinOperations[0].id);
+    });
+
+    it("should keep the raw hash on token ops when only a FEES op shares it", () => {
+      const htsToken = getMockedHTSTokenCurrency({ contractAddress: "0.0.1001" });
+      const feesOp = getMockedOperation({ hash: "h1", type: "FEES" });
+      const tokenOp = getMockedOperation({
+        hash: "h1",
+        type: "OUT",
+        contract: htsToken.contractAddress,
+      });
+
+      const { bridgeCoinOperations, bridgeTokenOperations } = resolveBridgeOperations({
+        coinOperations: [feesOp],
+        tokenOperations: [tokenOp],
+        ledgerAccountId,
+        calTokenByAddress: new Map([[htsToken.contractAddress, htsToken]]),
+      });
+
+      expect(bridgeCoinOperations).toEqual([expect.objectContaining({ hash: "h1", type: "FEES" })]);
+      expect(bridgeTokenOperations).toEqual([expect.objectContaining({ hash: "h1" })]);
+    });
+
+    it("should keep the HBAR OUT standalone with no NONE anchor when a token op shares its hash, end to end", async () => {
+      const htsToken = getTokenCurrencyFromCALByType("hts");
+      const coinOut = getMockedOperation({ hash: "h1", type: "OUT" });
+      const tokenOp = getMockedOperation({
+        hash: "h1",
+        type: "OUT",
+        contract: htsToken.contractAddress,
+      });
+
+      const { bridgeCoinOperations, bridgeTokenOperations } = resolveBridgeOperations({
+        coinOperations: [coinOut],
+        tokenOperations: [tokenOp],
+        ledgerAccountId,
+        calTokenByAddress: new Map([[htsToken.contractAddress, htsToken]]),
+      });
+      const result = await prepareOperations(bridgeCoinOperations, bridgeTokenOperations);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe("OUT");
+      expect(result[0].hash).toBe("h1");
+      expect(result[0].subOperations).toEqual([]);
+      expect(bridgeTokenOperations).toEqual([expect.objectContaining({ hash: "h1" })]);
+    });
+
+    it("should keep split fan-out coin ops with distinct ids when hash and type match but recipients differ", () => {
+      const split1 = getMockedOperation({
+        hash: "h1",
+        type: "OUT",
+        recipients: ["0.0.6855655"],
+      });
+      const split2 = getMockedOperation({
+        hash: "h1",
+        type: "OUT",
+        recipients: ["0.0.9509310"],
+      });
+
+      const { bridgeCoinOperations } = resolveBridgeOperations({
+        coinOperations: [split1, split2],
+        tokenOperations: [],
+        ledgerAccountId,
+        calTokenByAddress: new Map(),
+      });
+
+      expect(bridgeCoinOperations).toHaveLength(2);
+      const ids = bridgeCoinOperations.map(op => op.id);
+      expect(new Set(ids).size).toBe(2);
+      expect(ids).toEqual([
+        `${encodeOperationId(ledgerAccountId, "h1", "OUT")}-0.0.6855655`,
+        `${encodeOperationId(ledgerAccountId, "h1", "OUT")}-0.0.9509310`,
+      ]);
+    });
+
+    it("should keep split fan-out token ops distinct when the same token, hash and type differ only by recipient", () => {
+      const htsToken = getMockedHTSTokenCurrency({ contractAddress: "0.0.1001" });
+      const split1 = getMockedOperation({
+        hash: "h1",
+        type: "OUT",
+        contract: htsToken.contractAddress,
+        recipients: ["0.0.6855655"],
+      });
+      const split2 = getMockedOperation({
+        hash: "h1",
+        type: "OUT",
+        contract: htsToken.contractAddress,
+        recipients: ["0.0.9509310"],
+      });
+
+      const { bridgeTokenOperations } = resolveBridgeOperations({
+        coinOperations: [],
+        tokenOperations: [split1, split2],
+        ledgerAccountId,
+        calTokenByAddress: new Map([[htsToken.contractAddress, htsToken]]),
+      });
+
+      const expectedTokenAccountId = encodeTokenAccountId(ledgerAccountId, htsToken);
+      expect(bridgeTokenOperations).toHaveLength(2);
+      expect(new Set(bridgeTokenOperations.map(op => op.id)).size).toBe(2);
+      expect(bridgeTokenOperations.map(op => op.id)).toEqual([
+        `${encodeOperationId(expectedTokenAccountId, "h1", "OUT")}-0.0.6855655`,
+        `${encodeOperationId(expectedTokenAccountId, "h1", "OUT")}-0.0.9509310`,
+      ]);
+    });
+
+    it("should derive the same fallback discriminator from the operation's value regardless of array order", () => {
+      const opA = getMockedOperation({
+        hash: "h1",
+        type: "OUT",
+        recipients: [],
+        value: new BigNumber(100),
+      });
+      const opB = getMockedOperation({
+        hash: "h1",
+        type: "OUT",
+        recipients: [],
+        value: new BigNumber(200),
+      });
+
+      const forward = resolveBridgeOperations({
+        coinOperations: [opA, opB],
+        tokenOperations: [],
+        ledgerAccountId,
+        calTokenByAddress: new Map(),
+      });
+      const reversed = resolveBridgeOperations({
+        coinOperations: [opB, opA],
+        tokenOperations: [],
+        ledgerAccountId,
+        calTokenByAddress: new Map(),
+      });
+
+      expect(idsByValue(forward.bridgeCoinOperations)).toEqual(
+        idsByValue(reversed.bridgeCoinOperations),
+      );
     });
   });
 

--- a/libs/coin-modules/coin-hedera/src/bridge/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/utils.ts
@@ -12,7 +12,7 @@ import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
-import { HEDERA_OPERATION_TYPES } from "../constants";
+import { HEDERA_OPERATION_TYPES, TOKEN_ANCHOR_HASH_SUFFIX } from "../constants";
 import { estimateFees } from "../logic/estimateFees";
 import { isTokenAssociateTransaction, isValidExtra } from "../logic/utils";
 import type {
@@ -116,8 +116,29 @@ export async function buildCalTokenMap({
   return tokenByAddress;
 }
 
+// Appends a discriminator (recipient, falling back to value) to ids shared by
+// several ops, so fan-out legs of the same hash+type don't collide.
+function assignBridgeOperationIds<O extends Operation<HederaOperationExtra>>(
+  operations: O[],
+  idHashOf: (op: O) => string = op => op.hash,
+): O[] {
+  const baseIdCounts = new Map<string, number>();
+  for (const op of operations) {
+    const baseId = encodeOperationId(op.accountId, idHashOf(op), op.type);
+    baseIdCounts.set(baseId, (baseIdCounts.get(baseId) ?? 0) + 1);
+  }
+
+  return operations.map(op => {
+    const baseId = encodeOperationId(op.accountId, idHashOf(op), op.type);
+    const needsDiscriminator = (baseIdCounts.get(baseId) ?? 0) > 1;
+    const discriminator = op.recipients[0] ?? op.value.toString();
+    return { ...op, id: needsDiscriminator ? `${baseId}-${discriminator}` : baseId };
+  });
+}
+
 /**
- * Re-encodes id and accountId for both coin and token operations into the bridge's format.
+ * Re-encodes accountId for both coin and token operations into the bridge's format,
+ * then delegates id assignment to `assignBridgeOperationIds`.
  * Token operations: accountId becomes encodeTokenAccountId, filtered to CAL-listed tokens only.
  * Coin operations: accountId becomes ledgerAccountId.
  */
@@ -136,33 +157,41 @@ export function resolveBridgeOperations({
   bridgeTokenOperations: Operation<HederaOperationExtra>[];
 } {
   const keptTokenOperationHashes = new Set<string>();
+  // A fee-only tx (no token ops at all) must keep its FEES op regardless of CAL.
+  const allTokenOperationHashes = new Set(tokenOperations.map(op => op.hash));
 
-  const bridgeTokenOperations = tokenOperations.flatMap(operation => {
+  // Token ops sharing a hash with one of these get an anchored id (see
+  // TOKEN_ANCHOR_HASH_SUFFIX) so they don't collide with the coin op's id.
+  const valueCoinOperationHashes = new Set(
+    coinOperations.filter(op => op.type !== "FEES").map(op => op.hash),
+  );
+
+  const resolvedTokenOperations = tokenOperations.flatMap(operation => {
     const tokenAddress = operation.contract?.toLowerCase();
     const token = tokenAddress ? calTokenByAddress.get(tokenAddress) : undefined;
     if (!token) return [];
 
     keptTokenOperationHashes.add(operation.hash);
     const tokenAccountId = encodeTokenAccountId(ledgerAccountId, token);
-    return [
-      {
-        ...operation,
-        accountId: tokenAccountId,
-        id: encodeOperationId(tokenAccountId, operation.hash, operation.type),
-      },
-    ];
+    return [{ ...operation, accountId: tokenAccountId }];
   });
 
-  // persist only FEES ops for token transfers that are in CAL
-  const bridgeCoinOperations = coinOperations
-    .filter(op => (op.type !== "FEES" ? true : keptTokenOperationHashes.has(op.hash)))
-    .map(op => ({
-      ...op,
-      id: encodeOperationId(ledgerAccountId, op.hash, op.type),
-      accountId: ledgerAccountId,
-    }));
+  // Drop a FEES op only if its tx had token ops and none survived the CAL filter.
+  const resolvedCoinOperations = coinOperations
+    .filter(
+      op =>
+        op.type !== "FEES" ||
+        keptTokenOperationHashes.has(op.hash) ||
+        !allTokenOperationHashes.has(op.hash),
+    )
+    .map(op => ({ ...op, accountId: ledgerAccountId }));
 
-  return { bridgeCoinOperations, bridgeTokenOperations };
+  return {
+    bridgeCoinOperations: assignBridgeOperationIds(resolvedCoinOperations),
+    bridgeTokenOperations: assignBridgeOperationIds(resolvedTokenOperations, op =>
+      valueCoinOperationHashes.has(op.hash) ? `${op.hash}${TOKEN_ANCHOR_HASH_SUFFIX}` : op.hash,
+    ),
+  };
 }
 
 export const getSubAccounts = async ({
@@ -301,9 +330,10 @@ const makeCoinOperationForOrphanChildOperation = async (
     subOperations: [],
     nftOperations: [],
     internalOperations: [],
-    accountId: "",
+    accountId,
     date: childOperation.date,
-    extra: {},
+    // carries the child's extra so the anchor row has its own explorer link/details
+    extra: { ...childOperation.extra },
   };
 };
 
@@ -317,15 +347,18 @@ export const prepareOperations = async (
   const preparedCoinOperations = coinOperations.map(op => ({ ...op }));
   const preparedTokenOperations = tokenOperations.map(op => ({ ...op }));
 
-  // loop through coin operations to prepare a map of hash => operations
+  // Map hash => FEES coin operations, the only valid parent for a token operation.
+  // A non-FEES coin op sharing the hash (multi-asset tx) means the token op
+  // renders on its own sub-account instead, so no NONE anchor is created for it.
   const coinOperationsByHash: Record<string, CoinOperationForOrphanChildOperation[]> = {};
+  const coinOperationHashes = new Set<string>();
   preparedCoinOperations.forEach(op => {
-    if (!coinOperationsByHash[op.hash]) {
-      coinOperationsByHash[op.hash] = [];
-    }
-
     op.subOperations = [];
-    coinOperationsByHash[op.hash].push(op as CoinOperationForOrphanChildOperation);
+    coinOperationHashes.add(op.hash);
+
+    if (op.type !== "FEES") return;
+
+    (coinOperationsByHash[op.hash] ??= []).push(op as CoinOperationForOrphanChildOperation);
   });
 
   // loop through token operations to potentially copy them as a child operation of a coin operation
@@ -336,9 +369,12 @@ export const prepareOperations = async (
     let mainOperations = coinOperationsByHash[tokenOperation.hash];
 
     if (!mainOperations?.length) {
+      if (coinOperationHashes.has(tokenOperation.hash)) continue;
+
       const noneOperation = await makeCoinOperationForOrphanChildOperation(tokenOperation);
       mainOperations = [noneOperation];
       preparedCoinOperations.push(noneOperation);
+      coinOperationsByHash[tokenOperation.hash] = mainOperations;
     }
 
     // ugly loop in loop but in theory, this can only be a 2 elements array maximum in the case of a self send

--- a/libs/coin-modules/coin-hedera/src/constants.ts
+++ b/libs/coin-modules/coin-hedera/src/constants.ts
@@ -127,6 +127,13 @@ export const OP_TYPES_EXCLUDING_FEES: OperationType[] = [
  */
 export const STAKING_REWARD_HASH_SUFFIX = "-staking-reward";
 
+/**
+ * Discriminator mixed into the `encodeOperationId` hash argument for token operations
+ * of a transaction that also moves HBAR. Affects only `operation.id`; `operation.hash`
+ * always stays the clean transaction hash.
+ */
+export const TOKEN_ANCHOR_HASH_SUFFIX = "-token-anchor";
+
 export const MAP_TX_NAME_TO_CUSTOM_OPERATION_TYPE: Record<string, OperationType> = {
   [HEDERA_TRANSACTION_NAMES.TokenAssociate]: "ASSOCIATE_TOKEN",
   [HEDERA_TRANSACTION_NAMES.ContractCall]: "CONTRACT_CALL",

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
@@ -56,6 +56,25 @@ describe("listOperationsV2", () => {
   const mockLimit = 10;
   const mockOrder = "desc";
 
+  function makeListOperationsParams(
+    overrides: Partial<Parameters<typeof listOperations>[0]> = {},
+  ): Parameters<typeof listOperations>[0] {
+    return {
+      limit: mockLimit,
+      order: mockOrder,
+      currencyId: mockCurrency.id,
+      address: mockMirrorAccount.account,
+      evmAddress: mockMirrorAccount.evm_address,
+      mirrorTokens: [],
+      tokenEvmAddresses: [],
+      fetchAllPages: true,
+      skipFeesForTokenOperations: false,
+      useEncodedHash: false,
+      useSyntheticBlocks: false,
+      ...overrides,
+    };
+  }
+
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -89,19 +108,7 @@ describe("listOperationsV2", () => {
       nextCursor: null,
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(makeListOperationsParams());
 
     expect(apiClient.getAccountTransactions).toHaveBeenCalledTimes(1);
     expect(apiClient.getAccountTransactions).toHaveBeenCalledWith({
@@ -147,19 +154,7 @@ describe("listOperationsV2", () => {
       nextCursor: null,
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(makeListOperationsParams());
 
     expect(result.tokenOperations).toEqual([]);
     expect(result.coinOperations).toHaveLength(1);
@@ -185,6 +180,7 @@ describe("listOperationsV2", () => {
     const mockTokenHTS = getMockedHTSTokenCurrency();
     const mockTransaction = getMockedMirrorTransaction({
       consensus_timestamp: "1625097600.000000000",
+      transaction_id: `${mockMirrorAccount.account}-1625097600-000000000`,
       transaction_hash: "hash1",
       charged_tx_fee: 500000,
       result: "SUCCESS",
@@ -197,7 +193,10 @@ describe("listOperationsV2", () => {
         { token_id: mockTokenHTS.contractAddress, account: "0.0.67890", amount: 1000 },
       ],
       staking_reward_transfers: [],
-      transfers: [],
+      transfers: [
+        { account: mockMirrorAccount.account, amount: -500000 },
+        { account: "0.0.802", amount: 500000 },
+      ],
       name: "CRYPTOTRANSFER",
     });
 
@@ -205,29 +204,20 @@ describe("listOperationsV2", () => {
       transactions: [mockTransaction],
       nextCursor: null,
     });
+    (utils.extractFeesPayer as jest.Mock).mockReturnValue(mockMirrorAccount.account);
 
     setupMockCryptoAssetsStore({
       findTokenByAddressInCurrency: jest.fn().mockResolvedValue(mockTokenHTS),
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(makeListOperationsParams());
 
     expect(result.coinOperations).toMatchObject([
       {
         type: "FEES",
         fee: expect.any(Object),
+        senders: [mockMirrorAccount.account],
+        recipients: ["0.0.67890"],
       },
     ]);
     expect(result.tokenOperations).toMatchObject([
@@ -301,19 +291,11 @@ describe("listOperationsV2", () => {
       findTokenByAddressInCurrency: jest.fn().mockResolvedValue(mockTokenERC20),
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [mockTokenERC20.contractAddress],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(
+      makeListOperationsParams({
+        tokenEvmAddresses: [mockTokenERC20.contractAddress],
+      }),
+    );
 
     expect(result.tokenOperations).toEqual([
       expect.objectContaining({
@@ -392,19 +374,11 @@ describe("listOperationsV2", () => {
       findTokenByAddressInCurrency: jest.fn().mockResolvedValue(mockTokenERC20),
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [mockTokenERC20.contractAddress],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(
+      makeListOperationsParams({
+        tokenEvmAddresses: [mockTokenERC20.contractAddress],
+      }),
+    );
 
     expect(result.tokenOperations).toEqual([
       expect.objectContaining({
@@ -456,19 +430,11 @@ describe("listOperationsV2", () => {
       findTokenByAddressInCurrency: jest.fn().mockResolvedValue(mockTokenERC20),
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [mockTokenERC20.contractAddress],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(
+      makeListOperationsParams({
+        tokenEvmAddresses: [mockTokenERC20.contractAddress],
+      }),
+    );
 
     expect(result.tokenOperations).toEqual([]);
     expect(result.coinOperations).toEqual([]);
@@ -491,19 +457,7 @@ describe("listOperationsV2", () => {
       nextCursor: null,
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(makeListOperationsParams());
 
     expect(result.tokenOperations).toEqual([]);
     expect(result.coinOperations).toMatchObject([
@@ -545,19 +499,11 @@ describe("listOperationsV2", () => {
       nextCursor: null,
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [mockMirrorToken],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(
+      makeListOperationsParams({
+        mirrorTokens: [mockMirrorToken],
+      }),
+    );
 
     expect(result.tokenOperations).toEqual([]);
     expect(result.coinOperations).toEqual([
@@ -575,6 +521,7 @@ describe("listOperationsV2", () => {
     const tokenId = "0.0.7890";
     const mockTransaction = getMockedMirrorTransaction({
       consensus_timestamp: "1625097600.000000000",
+      transaction_id: `${mockMirrorAccount.account}-1625097600-000000000`,
       transaction_hash: "hash1",
       charged_tx_fee: 500000,
       result: "SUCCESS",
@@ -583,7 +530,10 @@ describe("listOperationsV2", () => {
         { token_id: tokenId, account: "0.0.67890", amount: 1000 },
       ],
       staking_reward_transfers: [],
-      transfers: [],
+      transfers: [
+        { account: mockMirrorAccount.account, amount: -500000 },
+        { account: "0.0.802", amount: 500000 },
+      ],
       name: "CRYPTOTRANSFER",
     });
 
@@ -591,20 +541,9 @@ describe("listOperationsV2", () => {
       transactions: [mockTransaction],
       nextCursor: null,
     });
+    (utils.extractFeesPayer as jest.Mock).mockReturnValue(mockMirrorAccount.account);
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(makeListOperationsParams());
 
     expect(result.tokenOperations).toEqual([
       expect.objectContaining({
@@ -620,12 +559,11 @@ describe("listOperationsV2", () => {
     ]);
   });
 
-  it("should not emit FEES coin op for child HTS token transfer (nonce > 0)", async () => {
+  it("should emit only a token operation when a token transfer has no HBAR transfers and zero fee", async () => {
     const tokenId = "0.0.7890";
     const mockTransaction = getMockedMirrorTransaction({
       consensus_timestamp: "1625097600.000000000",
       transaction_hash: "hash1",
-      nonce: 1,
       charged_tx_fee: 0,
       token_transfers: [
         { token_id: tokenId, account: mockMirrorAccount.account, amount: -1000 },
@@ -640,19 +578,7 @@ describe("listOperationsV2", () => {
       nextCursor: null,
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(makeListOperationsParams());
 
     expect(result.coinOperations).toEqual([]);
     expect(result.tokenOperations).toEqual([
@@ -670,20 +596,13 @@ describe("listOperationsV2", () => {
       nextCursor: null,
     });
 
-    await listOperations({
-      limit: customLimit,
-      order: customOrder,
-      cursor: lastPagingToken,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    await listOperations(
+      makeListOperationsParams({
+        limit: customLimit,
+        order: customOrder,
+        cursor: lastPagingToken,
+      }),
+    );
 
     expect(apiClient.getAccountTransactions).toHaveBeenCalledTimes(1);
     expect(apiClient.getAccountTransactions).toHaveBeenCalledWith({
@@ -717,19 +636,7 @@ describe("listOperationsV2", () => {
       nextCursor: null,
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      currencyId: mockCurrency.id,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(makeListOperationsParams());
 
     expect(result.coinOperations).toMatchObject([{ hasFailed: true }]);
   });
@@ -746,7 +653,7 @@ describe("listOperationsV2", () => {
       token_transfers: [],
       staking_reward_transfers: [],
       transfers: [
-        { account: "0.0.23", amount: -40743 },
+        { account: mockMirrorAccount.account, amount: -40743 },
         { account: "0.0.801", amount: 40743 },
       ],
       name: "CRYPTOTRANSFER",
@@ -757,19 +664,7 @@ describe("listOperationsV2", () => {
       nextCursor: null,
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      currencyId: mockCurrency.id,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(makeListOperationsParams());
 
     expect(result.coinOperations).toMatchObject([
       {
@@ -799,19 +694,7 @@ describe("listOperationsV2", () => {
       nextCursor: null,
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      currencyId: mockCurrency.id,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(makeListOperationsParams());
 
     const rewardTimestamp = result.coinOperations[0].date.getTime();
     const mainTimestamp = result.coinOperations[1].date.getTime();
@@ -883,19 +766,11 @@ describe("listOperationsV2", () => {
       findTokenByAddressInCurrency: jest.fn().mockResolvedValue(mockTokenERC20),
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [mockTokenERC20.contractAddress],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(
+      makeListOperationsParams({
+        tokenEvmAddresses: [mockTokenERC20.contractAddress],
+      }),
+    );
 
     expect(result.tokenOperations).toEqual([
       expect.objectContaining({
@@ -946,19 +821,7 @@ describe("listOperationsV2", () => {
     });
     (networkUtils.analyzeStakingOperation as jest.Mock).mockResolvedValue(mockStakingAnalysis);
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(makeListOperationsParams());
 
     expect(result.tokenOperations).toEqual([]);
     expect(result.coinOperations).toEqual([
@@ -1001,19 +864,7 @@ describe("listOperationsV2", () => {
     });
     (networkUtils.analyzeStakingOperation as jest.Mock).mockResolvedValue(mockStakingAnalysis);
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(makeListOperationsParams());
 
     expect(result.tokenOperations).toEqual([]);
     expect(result.coinOperations).toEqual([
@@ -1059,19 +910,7 @@ describe("listOperationsV2", () => {
       findTokenByAddressInCurrency: jest.fn().mockResolvedValue(mockTokenHTS),
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(makeListOperationsParams());
 
     expect(result.coinOperations).toEqual([]);
     expect(result.tokenOperations).toEqual([expect.objectContaining({ type: "IN" })]);
@@ -1123,19 +962,11 @@ describe("listOperationsV2", () => {
       findTokenByAddressInCurrency: jest.fn().mockResolvedValue(mockTokenERC20),
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [mockTokenERC20.contractAddress],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(
+      makeListOperationsParams({
+        tokenEvmAddresses: [mockTokenERC20.contractAddress],
+      }),
+    );
 
     expect(result.coinOperations).toEqual([]);
     expect(result.tokenOperations).toEqual([expect.objectContaining({ type: "IN" })]);
@@ -1192,19 +1023,11 @@ describe("listOperationsV2", () => {
         .mockResolvedValueOnce(mockTokenB), // for transfer in
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [mockTokenA.contractAddress, mockTokenB.contractAddress],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(
+      makeListOperationsParams({
+        tokenEvmAddresses: [mockTokenA.contractAddress, mockTokenB.contractAddress],
+      }),
+    );
 
     expect(result.coinOperations).toEqual([expect.objectContaining({ type: "FEES" })]);
     expect(result.tokenOperations).toEqual([
@@ -1242,23 +1065,49 @@ describe("listOperationsV2", () => {
       findTokenByAddressInCurrency: jest.fn().mockResolvedValue(mockTokenHTS),
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: true,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(
+      makeListOperationsParams({
+        skipFeesForTokenOperations: true,
+      }),
+    );
 
     expect(result.coinOperations).toHaveLength(0);
     expect(result.tokenOperations).toHaveLength(1);
     expect(result.tokenOperations[0].type).toBe("OUT");
+  });
+
+  it("should keep the standalone FEES op of a fee-only tx when skipFeesForTokenOperations is true", async () => {
+    const mockTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1625097600.000000000",
+      transaction_hash: "hash1",
+      transaction_id: `${mockMirrorAccount.account}-1625097600-000000000`,
+      charged_tx_fee: 500000,
+      name: "CRYPTOAPPROVEALLOWANCE",
+      transfers: [
+        { account: mockMirrorAccount.account, amount: -500000 },
+        { account: "0.0.98", amount: 500000 },
+      ],
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [mockTransaction],
+      nextCursor: null,
+    });
+
+    const result = await listOperations(
+      makeListOperationsParams({
+        skipFeesForTokenOperations: true,
+      }),
+    );
+
+    expect(result.coinOperations).toEqual([
+      expect.objectContaining({
+        type: "FEES",
+        hash: "hash1",
+        value: new BigNumber(500000),
+      }),
+    ]);
+    expect(result.tokenOperations).toHaveLength(0);
   });
 
   it("should use encoded hash when useEncodedHash is true", async () => {
@@ -1282,19 +1131,11 @@ describe("listOperationsV2", () => {
       nextCursor: null,
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: true,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(
+      makeListOperationsParams({
+        useEncodedHash: true,
+      }),
+    );
 
     expect(result.coinOperations).toHaveLength(1);
     expect(result.coinOperations[0].hash).toBe("encoded-hash1");
@@ -1321,19 +1162,11 @@ describe("listOperationsV2", () => {
       nextCursor: null,
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: true,
-    });
+    const result = await listOperations(
+      makeListOperationsParams({
+        useSyntheticBlocks: true,
+      }),
+    );
 
     expect(utils.getSyntheticBlock).toHaveBeenCalledTimes(1);
     expect(result.coinOperations).toEqual([
@@ -1392,19 +1225,12 @@ describe("listOperationsV2", () => {
       findTokenByAddressInCurrency: jest.fn().mockResolvedValue(mockTokenERC20),
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [mockTokenERC20.contractAddress],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: true,
-    });
+    const result = await listOperations(
+      makeListOperationsParams({
+        tokenEvmAddresses: [mockTokenERC20.contractAddress],
+        useSyntheticBlocks: true,
+      }),
+    );
 
     expect(result.tokenOperations).toEqual([
       expect.objectContaining({
@@ -1462,19 +1288,11 @@ describe("listOperationsV2", () => {
       findTokenByAddressInCurrency: jest.fn().mockResolvedValue(mockTokenERC20),
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [mockTokenERC20.contractAddress],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(
+      makeListOperationsParams({
+        tokenEvmAddresses: [mockTokenERC20.contractAddress],
+      }),
+    );
 
     expect(result.coinOperations).toEqual([expect.objectContaining({ type: "FEES" })]);
     expect(result.tokenOperations).toEqual([
@@ -1519,19 +1337,7 @@ describe("listOperationsV2", () => {
       nextCursor: null,
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(makeListOperationsParams());
 
     expect(result.coinOperations.map(op => op.hash)).toEqual(["hash3", "hash2", "hash1"]);
   });
@@ -1594,19 +1400,11 @@ describe("listOperationsV2", () => {
       findTokenByAddressInCurrency: jest.fn().mockResolvedValue(mockTokenERC20),
     });
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [mockTokenERC20.contractAddress],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(
+      makeListOperationsParams({
+        tokenEvmAddresses: [mockTokenERC20.contractAddress],
+      }),
+    );
 
     expect(result.tokenOperations).toHaveLength(1);
     expect(result.coinOperations).toEqual([
@@ -1630,21 +1428,498 @@ describe("listOperationsV2", () => {
     });
     (networkUtils.analyzeStakingOperation as jest.Mock).mockResolvedValue(null);
 
-    const result = await listOperations({
-      limit: mockLimit,
-      order: mockOrder,
-      currencyId: mockCurrency.id,
-      address: mockMirrorAccount.account,
-      evmAddress: mockMirrorAccount.evm_address,
-      mirrorTokens: [],
-      tokenEvmAddresses: [],
-      fetchAllPages: true,
-      skipFeesForTokenOperations: false,
-      useEncodedHash: false,
-      useSyntheticBlocks: false,
-    });
+    const result = await listOperations(makeListOperationsParams());
 
     expect(result.coinOperations).toHaveLength(1);
     expect(result.coinOperations[0].recipients).toEqual([nodeAccountId]);
+  });
+
+  // Real-world data: https://mainnet.mirrornode.hedera.com/api/v1/transactions?timestamp=1760510879.300860000
+  it("should split a multi-asset CryptoTransfer into one op per (asset, direction) with no FEES", async () => {
+    const usdc = "0.0.456858";
+    const hbark = "0.0.5022567";
+    const receiver1 = "0.0.9124531";
+    const receiver2 = "0.0.9169746";
+    const fee = 1176695;
+
+    const mockTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1760510879.300860000",
+      transaction_id: `${mockMirrorAccount.account}-1760510879-300860000`,
+      transaction_hash: "multiasset",
+      charged_tx_fee: fee,
+      result: "SUCCESS",
+      name: "CRYPTOTRANSFER",
+      staking_reward_transfers: [],
+      // mirror sorts transfer rows by account id, so the node row (0.0.15) comes first
+      transfers: [
+        { account: "0.0.15", amount: 55631 },
+        { account: "0.0.801", amount: 1121064 },
+        { account: mockMirrorAccount.account, amount: -(2000000 + fee) },
+        { account: receiver1, amount: 1000000 },
+        { account: receiver2, amount: 1000000 },
+      ],
+      token_transfers: [
+        { token_id: usdc, account: mockMirrorAccount.account, amount: -10000 },
+        { token_id: usdc, account: receiver1, amount: 10000 },
+        { token_id: hbark, account: mockMirrorAccount.account, amount: -2 },
+        { token_id: hbark, account: receiver2, amount: 2 },
+      ],
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [mockTransaction],
+      nextCursor: null,
+    });
+    (utils.extractFeesPayer as jest.Mock).mockReturnValue(mockMirrorAccount.account);
+
+    const result = await listOperations(makeListOperationsParams());
+
+    expect(result.coinOperations).toEqual([
+      expect.objectContaining({
+        type: "OUT",
+        value: new BigNumber(1000000 + fee),
+        fee: new BigNumber(fee),
+        senders: [mockMirrorAccount.account],
+        recipients: [receiver2],
+      }),
+      expect.objectContaining({
+        type: "OUT",
+        value: new BigNumber(1000000 + fee),
+        fee: new BigNumber(fee),
+        senders: [mockMirrorAccount.account],
+        recipients: [receiver1],
+      }),
+    ]);
+    expect(result.tokenOperations).toEqual([
+      expect.objectContaining({
+        type: "OUT",
+        contract: usdc,
+        standard: "hts",
+        value: new BigNumber(10000),
+      }),
+      expect.objectContaining({
+        type: "OUT",
+        contract: hbark,
+        standard: "hts",
+        value: new BigNumber(2),
+      }),
+    ]);
+  });
+
+  it("should fold the fee into a simple HBAR OUT (fee-inclusive value, no FEES op)", async () => {
+    const fee = 500000;
+    const mockTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1625097600.000000000",
+      transaction_id: `${mockMirrorAccount.account}-1625097600-000000000`,
+      transaction_hash: "simpleout",
+      charged_tx_fee: fee,
+      result: "SUCCESS",
+      name: "CRYPTOTRANSFER",
+      staking_reward_transfers: [],
+      token_transfers: [],
+      transfers: [
+        { account: mockMirrorAccount.account, amount: -(1000000 + fee) },
+        { account: "0.0.67890", amount: 1000000 },
+        { account: "0.0.802", amount: fee },
+      ],
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [mockTransaction],
+      nextCursor: null,
+    });
+    (utils.extractFeesPayer as jest.Mock).mockReturnValue(mockMirrorAccount.account);
+
+    const result = await listOperations(makeListOperationsParams());
+
+    expect(result.coinOperations).toEqual([
+      expect.objectContaining({
+        type: "OUT",
+        value: new BigNumber(1000000 + fee),
+        fee: new BigNumber(fee),
+        senders: [mockMirrorAccount.account],
+        recipients: ["0.0.67890"],
+      }),
+    ]);
+  });
+
+  it("should emit HBAR IN + FEES for a swap where the user receives HBAR and pays the fee", async () => {
+    const token = "0.0.7890";
+    const fee = 100000;
+    const mockTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1625097600.000000000",
+      transaction_id: `${mockMirrorAccount.account}-1625097600-000000000`,
+      transaction_hash: "swap",
+      charged_tx_fee: fee,
+      result: "SUCCESS",
+      name: "CRYPTOTRANSFER",
+      staking_reward_transfers: [],
+      transfers: [
+        { account: "0.0.67890", amount: -500000 },
+        { account: mockMirrorAccount.account, amount: 500000 - fee },
+        { account: "0.0.802", amount: fee },
+      ],
+      token_transfers: [
+        { token_id: token, account: mockMirrorAccount.account, amount: -1000 },
+        { token_id: token, account: "0.0.67890", amount: 1000 },
+      ],
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [mockTransaction],
+      nextCursor: null,
+    });
+    (utils.extractFeesPayer as jest.Mock).mockReturnValue(mockMirrorAccount.account);
+
+    const result = await listOperations(makeListOperationsParams());
+
+    expect(result.coinOperations).toEqual([
+      expect.objectContaining({
+        type: "IN",
+        value: new BigNumber(500000),
+        fee: new BigNumber(fee),
+      }),
+      expect.objectContaining({ type: "FEES", value: new BigNumber(fee), fee: new BigNumber(fee) }),
+    ]);
+    expect(result.tokenOperations).toEqual([
+      expect.objectContaining({ type: "OUT", contract: token, standard: "hts" }),
+    ]);
+  });
+
+  it("should emit only IN (no FEES) for an incoming HBAR transfer when the user is not the payer", async () => {
+    const mockTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1625097600.000000000",
+      transaction_id: "0.0.67890-1625097600-000000000",
+      transaction_hash: "incoming",
+      charged_tx_fee: 100000,
+      result: "SUCCESS",
+      name: "CRYPTOTRANSFER",
+      staking_reward_transfers: [],
+      token_transfers: [],
+      transfers: [
+        { account: "0.0.67890", amount: -1100000 },
+        { account: mockMirrorAccount.account, amount: 1000000 },
+        { account: "0.0.802", amount: 100000 },
+      ],
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [mockTransaction],
+      nextCursor: null,
+    });
+    (utils.extractFeesPayer as jest.Mock).mockReturnValue("0.0.67890");
+
+    const result = await listOperations(makeListOperationsParams());
+
+    expect(result.coinOperations).toEqual([
+      expect.objectContaining({
+        type: "IN",
+        value: new BigNumber(1000000),
+        fee: new BigNumber(100000),
+        recipients: [mockMirrorAccount.account],
+        senders: ["0.0.67890"],
+      }),
+    ]);
+  });
+
+  it("should list all net counterparties and never fee/node/system rows", async () => {
+    const fee = 300000;
+    const mockTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1625097600.000000000",
+      transaction_id: `${mockMirrorAccount.account}-1625097600-000000000`,
+      transaction_hash: "multirecipient",
+      charged_tx_fee: fee,
+      result: "SUCCESS",
+      name: "CRYPTOTRANSFER",
+      staking_reward_transfers: [],
+      token_transfers: [],
+      transfers: [
+        { account: mockMirrorAccount.account, amount: -(3000000 + fee) },
+        { account: "0.0.9124531", amount: 1000000 },
+        { account: "0.0.9169746", amount: 1000000 },
+        { account: "0.0.9200000", amount: 1000000 },
+        { account: "0.0.800", amount: 100000 },
+        { account: "0.0.801", amount: 100000 },
+        { account: "0.0.802", amount: 100000 },
+      ],
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [mockTransaction],
+      nextCursor: null,
+    });
+    (utils.extractFeesPayer as jest.Mock).mockReturnValue(mockMirrorAccount.account);
+
+    const result = await listOperations(makeListOperationsParams());
+
+    expect(result.coinOperations.map(op => op.recipients)).toEqual([
+      ["0.0.9200000"],
+      ["0.0.9169746"],
+      ["0.0.9124531"],
+    ]);
+    const allRecipients = result.coinOperations.flatMap(op => op.recipients);
+    expect(allRecipients).not.toContain("0.0.800");
+    expect(allRecipients).not.toContain("0.0.801");
+    expect(allRecipients).not.toContain("0.0.802");
+  });
+
+  // Real-world data: testnet tx 0.0.6136753-1783676710-421838210
+  it("should split a sole-sender multi-receiver HBAR transfer into one OUT per recipient", async () => {
+    const fee = 284122;
+    const mockTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1783676722.704196728",
+      transaction_id: `${mockMirrorAccount.account}-1783676710-421838210`,
+      transaction_hash: "multireceiver",
+      charged_tx_fee: fee,
+      result: "SUCCESS",
+      name: "CRYPTOTRANSFER",
+      staking_reward_transfers: [],
+      token_transfers: [],
+      transfers: [
+        { account: "0.0.802", amount: fee },
+        { account: mockMirrorAccount.account, amount: -(2000000 + fee) },
+        { account: "0.0.6855655", amount: 1000000 },
+        { account: "0.0.9509310", amount: 1000000 },
+      ],
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [mockTransaction],
+      nextCursor: null,
+    });
+    (utils.extractFeesPayer as jest.Mock).mockReturnValue(mockMirrorAccount.account);
+
+    const result = await listOperations(makeListOperationsParams());
+
+    expect(result.tokenOperations).toEqual([]);
+    expect(result.coinOperations).toEqual([
+      expect.objectContaining({
+        id: "multireceiver:OUT:0.0.9509310",
+        type: "OUT",
+        value: new BigNumber(1000000 + fee),
+        fee: new BigNumber(fee),
+        senders: [mockMirrorAccount.account],
+        recipients: ["0.0.9509310"],
+      }),
+      expect.objectContaining({
+        id: "multireceiver:OUT:0.0.6855655",
+        type: "OUT",
+        value: new BigNumber(1000000 + fee),
+        fee: new BigNumber(fee),
+        senders: [mockMirrorAccount.account],
+        recipients: ["0.0.6855655"],
+      }),
+    ]);
+  });
+
+  it("should keep a single netted OUT when the user is not the sole sender (many-to-many)", async () => {
+    const fee = 300000;
+    const mockTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1625097600.000000000",
+      transaction_id: `${mockMirrorAccount.account}-1625097600-000000000`,
+      transaction_hash: "manytomany",
+      charged_tx_fee: fee,
+      result: "SUCCESS",
+      name: "CRYPTOTRANSFER",
+      staking_reward_transfers: [],
+      token_transfers: [],
+      transfers: [
+        { account: mockMirrorAccount.account, amount: -(1000000 + fee) },
+        { account: "0.0.55555", amount: -1000000 },
+        { account: "0.0.9124531", amount: 1500000 },
+        { account: "0.0.9169746", amount: 500000 },
+        { account: "0.0.802", amount: fee },
+      ],
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [mockTransaction],
+      nextCursor: null,
+    });
+    (utils.extractFeesPayer as jest.Mock).mockReturnValue(mockMirrorAccount.account);
+
+    const result = await listOperations(makeListOperationsParams());
+
+    expect(result.coinOperations).toEqual([
+      expect.objectContaining({
+        id: "manytomany:OUT",
+        type: "OUT",
+        value: new BigNumber(1000000 + fee),
+        fee: new BigNumber(fee),
+        senders: ["0.0.55555", mockMirrorAccount.account],
+        recipients: ["0.0.9169746", "0.0.9124531"],
+      }),
+    ]);
+  });
+
+  it("should not fold the fee into a co-sender's OUT value when another account paid it (many-to-many)", async () => {
+    const payerAccount = "0.0.55555";
+    const fee = 300000;
+    const recipient1 = "0.0.9124531";
+    const recipient2 = "0.0.9169746";
+
+    const mockTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1625097600.000000000",
+      transaction_id: `${payerAccount}-1625097600-000000000`,
+      transaction_hash: "manytomany-nonpayer",
+      charged_tx_fee: fee,
+      result: "SUCCESS",
+      name: "CRYPTOTRANSFER",
+      staking_reward_transfers: [],
+      token_transfers: [],
+      transfers: [
+        { account: payerAccount, amount: -(2000000 + fee) },
+        { account: mockMirrorAccount.account, amount: -1000000 },
+        { account: recipient1, amount: 1500000 },
+        { account: recipient2, amount: 1500000 },
+        { account: "0.0.802", amount: fee },
+      ],
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [mockTransaction],
+      nextCursor: null,
+    });
+    (utils.extractFeesPayer as jest.Mock).mockReturnValue(payerAccount);
+
+    const result = await listOperations(makeListOperationsParams());
+
+    expect(result.coinOperations).toEqual([
+      expect.objectContaining({
+        id: "manytomany-nonpayer:OUT",
+        type: "OUT",
+        value: new BigNumber(1000000),
+        fee: new BigNumber(fee),
+        senders: [mockMirrorAccount.account, payerAccount],
+        recipients: [recipient2, recipient1],
+      }),
+    ]);
+  });
+
+  it("should split a sole-sender multi-receiver token transfer into one OUT per recipient", async () => {
+    const tokenId = "0.0.7890";
+    const fee = 100000;
+    const mockTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1625097600.000000000",
+      transaction_id: `${mockMirrorAccount.account}-1625097600-000000000`,
+      transaction_hash: "tokenmultireceiver",
+      charged_tx_fee: fee,
+      result: "SUCCESS",
+      name: "CRYPTOTRANSFER",
+      staking_reward_transfers: [],
+      token_transfers: [
+        { token_id: tokenId, account: mockMirrorAccount.account, amount: -3000 },
+        { token_id: tokenId, account: "0.0.67890", amount: 1000 },
+        { token_id: tokenId, account: "0.0.67891", amount: 2000 },
+      ],
+      transfers: [
+        { account: mockMirrorAccount.account, amount: -fee },
+        { account: "0.0.802", amount: fee },
+      ],
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [mockTransaction],
+      nextCursor: null,
+    });
+    (utils.extractFeesPayer as jest.Mock).mockReturnValue(mockMirrorAccount.account);
+
+    const result = await listOperations(makeListOperationsParams());
+
+    expect(result.coinOperations).toEqual([expect.objectContaining({ type: "FEES" })]);
+    expect(result.tokenOperations).toEqual([
+      expect.objectContaining({
+        id: "tokenmultireceiver:OUT:0.0.7890:0.0.67891",
+        type: "OUT",
+        contract: tokenId,
+        standard: "hts",
+        value: new BigNumber(2000),
+        recipients: ["0.0.67891"],
+      }),
+      expect.objectContaining({
+        id: "tokenmultireceiver:OUT:0.0.7890:0.0.67890",
+        type: "OUT",
+        contract: tokenId,
+        standard: "hts",
+        value: new BigNumber(1000),
+        recipients: ["0.0.67890"],
+      }),
+    ]);
+  });
+
+  it("should flag isApproval on a token op when the user's tokens were moved via an allowance", async () => {
+    const token = "0.0.7890";
+    const mockTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1625097600.000000000",
+      transaction_id: "0.0.999999-1625097600-000000000",
+      transaction_hash: "allowance",
+      charged_tx_fee: 100000,
+      result: "SUCCESS",
+      name: "CRYPTOTRANSFER",
+      staking_reward_transfers: [],
+      transfers: [
+        { account: "0.0.999999", amount: -100000 },
+        { account: "0.0.802", amount: 100000 },
+      ],
+      token_transfers: [
+        { token_id: token, account: mockMirrorAccount.account, amount: -1000, is_approval: true },
+        { token_id: token, account: "0.0.67890", amount: 1000 },
+      ],
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [mockTransaction],
+      nextCursor: null,
+    });
+    (utils.extractFeesPayer as jest.Mock).mockReturnValue("0.0.999999");
+
+    const result = await listOperations(makeListOperationsParams());
+
+    expect(result.coinOperations).toEqual([]);
+    expect(result.tokenOperations).toEqual([
+      expect.objectContaining({
+        type: "OUT",
+        contract: token,
+        standard: "hts",
+        extra: expect.objectContaining({ isApproval: true }),
+      }),
+    ]);
+  });
+
+  it("should flag isApproval on a native HBAR OUT op when the user's HBAR was moved via an allowance", async () => {
+    const fee = 500000;
+    const mockTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1625097600.000000000",
+      transaction_id: "0.0.999999-1625097600-000000000",
+      transaction_hash: "hbarallowance",
+      charged_tx_fee: fee,
+      result: "SUCCESS",
+      name: "CRYPTOTRANSFER",
+      staking_reward_transfers: [],
+      token_transfers: [],
+      transfers: [
+        { account: mockMirrorAccount.account, amount: -1000000, is_approval: true },
+        { account: "0.0.67890", amount: 1000000 },
+        { account: "0.0.802", amount: fee },
+        { account: "0.0.999999", amount: -fee },
+      ],
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [mockTransaction],
+      nextCursor: null,
+    });
+    (utils.extractFeesPayer as jest.Mock).mockReturnValue("0.0.999999");
+
+    const result = await listOperations(makeListOperationsParams());
+
+    expect(result.coinOperations).toEqual([
+      expect.objectContaining({
+        type: "OUT",
+        value: new BigNumber(1000000),
+        recipients: ["0.0.67890"],
+        extra: expect.objectContaining({ isApproval: true }),
+      }),
+    ]);
   });
 });

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
@@ -14,6 +14,7 @@ import { parseTransfers, enrichERC20Transfers, analyzeStakingOperation } from ".
 import type {
   EnrichedERC20Transfer,
   HederaMirrorToken,
+  HederaMirrorTokenTransfer,
   HederaMirrorTransaction,
   HederaOperationExtra,
   MergedTransaction,
@@ -209,7 +210,61 @@ async function processERC20TokenTransfer({
   };
 }
 
-async function processHTSTokenTransfers({
+// Returns null when the mirror data doesn't support sender->receiver pairing
+// (e.g. many-to-many transfers); callers should then emit a single netted operation.
+function decomposeSoleSenderFanout({
+  address,
+  senders,
+  recipients,
+  recipientNets,
+  valueLeg,
+}: {
+  address: string;
+  senders: string[];
+  recipients: string[];
+  recipientNets: Map<string, BigNumber>;
+  valueLeg: BigNumber;
+}): { recipient: string; net: BigNumber }[] | null {
+  const isSoleSender = senders.length === 1 && senders[0] === address;
+  if (!isSoleSender || recipients.length <= 1) return null;
+
+  const recipientSum = [...recipientNets.values()].reduce(
+    (acc, amount) => acc.plus(amount),
+    new BigNumber(0),
+  );
+  if (!recipientSum.eq(valueLeg)) return null;
+
+  return recipients.map(recipient => ({
+    recipient,
+    net: recipientNets.get(recipient) ?? new BigNumber(0),
+  }));
+}
+
+// True when a third party moved this transfer via a granted allowance (Hedera "approval" transfer).
+function isApprovalTransfer(
+  transfer: { account: string; amount: number; is_approval?: boolean },
+  address: string,
+): boolean {
+  return transfer.account === address && transfer.amount < 0 && !!transfer.is_approval;
+}
+
+function groupTransfersByTokenId(
+  transfers: HederaMirrorTokenTransfer[],
+): Map<string, HederaMirrorTokenTransfer[]> {
+  const grouped = new Map<string, HederaMirrorTokenTransfer[]>();
+  for (const transfer of transfers) {
+    const group = grouped.get(transfer.token_id);
+    if (group) {
+      group.push(transfer);
+    } else {
+      grouped.set(transfer.token_id, [transfer]);
+    }
+  }
+  return grouped;
+}
+
+// The HBAR fee is attributed in processCoinTransfers; no FEES op is created here.
+function processHTSTokenTransfers({
   rawTx,
   address,
   ledgerAccountId,
@@ -219,44 +274,94 @@ async function processHTSTokenTransfers({
   address: string;
   ledgerAccountId: string;
   commonData: ReturnType<typeof getCommonMirrorOperationData>;
-}): Promise<{
-  coinOperation: Operation<HederaOperationExtra> | undefined;
-  tokenOperation: Operation<HederaOperationExtra>;
-} | null> {
+}): Operation<HederaOperationExtra>[] {
   const tokenTransfers = rawTx.token_transfers ?? [];
-  if (tokenTransfers.length === 0) return null;
+  if (tokenTransfers.length === 0) return [];
 
-  const tokenId = tokenTransfers[0].token_id;
-  const { type, value, senders, recipients } = parseTransfers(tokenTransfers, address);
   const { hash, fee, date, blockHeight, blockHash, hasFailed } = commonData;
-  const extra = { ...commonData.extra };
+  const transfersByTokenId = groupTransfersByTokenId(tokenTransfers);
+  const tokenOperations: Operation<HederaOperationExtra>[] = [];
 
-  let coinOperation: Operation<HederaOperationExtra> | undefined;
+  for (const [tokenId, group] of transfersByTokenId) {
+    const { type, value, senders, recipients, recipientNets } = parseTransfers(group, address);
 
-  // Add main FEES coin operation for parent tx representing a token transfer (nonce > 0 means child transaction like TOKENWIPE)
-  if (type === "OUT" && rawTx.nonce === 0) {
-    coinOperation = {
-      id: `${hash}:FEES`,
+    if (type === "NONE" || value.isZero()) continue;
+
+    const isApproval = group.some(transfer => isApprovalTransfer(transfer, address));
+
+    const commonFields = {
       accountId: ledgerAccountId,
-      type: "FEES",
-      value: fee,
-      recipients,
-      senders,
+      contract: tokenId,
+      standard: "hts",
+      type,
       hash,
       fee,
       date,
       blockHeight,
       blockHash,
       hasFailed,
-      extra,
-    } satisfies Operation<HederaOperationExtra>;
+      extra: {
+        ...commonData.extra,
+        ...(isApproval && { isApproval: true }),
+      },
+    } satisfies Partial<Operation<HederaOperationExtra>>;
+
+    const pushTokenOperation = (idSuffix: string, legValue: BigNumber, legRecipients: string[]) => {
+      tokenOperations.push({
+        ...commonFields,
+        id: `${hash}:${type}:${tokenId}${idSuffix}`,
+        value: legValue,
+        recipients: legRecipients,
+        senders,
+      } satisfies Operation<HederaOperationExtra>);
+    };
+
+    const fanout =
+      type === "OUT"
+        ? decomposeSoleSenderFanout({
+            address,
+            senders,
+            recipients,
+            recipientNets,
+            valueLeg: value,
+          })
+        : null;
+
+    if (fanout) {
+      for (const { recipient, net } of fanout) {
+        pushTokenOperation(`:${recipient}`, net, [recipient]);
+      }
+    } else {
+      pushTokenOperation("", value, recipients);
+    }
   }
 
-  const tokenOperation = {
-    id: `${hash}:${type}:${tokenId}`,
+  return tokenOperations;
+}
+
+function buildCoinOperation({
+  commonData,
+  ledgerAccountId,
+  idSuffix,
+  type,
+  value,
+  senders,
+  recipients,
+  extra,
+}: {
+  commonData: ReturnType<typeof getCommonMirrorOperationData>;
+  ledgerAccountId: string;
+  idSuffix: string;
+  type: OperationType;
+  value: BigNumber;
+  senders: string[];
+  recipients: string[];
+  extra: HederaOperationExtra;
+}): Operation<HederaOperationExtra> {
+  const { hash, fee, date, blockHeight, blockHash, hasFailed } = commonData;
+  return {
+    id: `${hash}:${idSuffix}`,
     accountId: ledgerAccountId,
-    contract: tokenId,
-    standard: "hts",
     type,
     value,
     recipients,
@@ -268,11 +373,6 @@ async function processHTSTokenTransfers({
     blockHash,
     hasFailed,
     extra,
-  } satisfies Operation<HederaOperationExtra>;
-
-  return {
-    coinOperation,
-    tokenOperation,
   };
 }
 
@@ -300,53 +400,150 @@ function processCoinTransfers({
     return [];
   }
 
-  const { type, value, senders, recipients } = parseTransfers(transfers, address, stakingReward);
+  const { senders, recipients, netAmount, recipientNets } = parseTransfers(
+    transfers,
+    address,
+    stakingReward,
+  );
+  const fee = commonData.fee;
 
-  const { hash, fee, date, blockHeight, blockHash, hasFailed } = commonData;
-  const extra = { ...commonData.extra };
-  let operationType = MAP_TX_NAME_TO_CUSTOM_OPERATION_TYPE[rawTx.name] ?? type;
+  const isApproval = transfers.some(transfer => isApprovalTransfer(transfer, address));
+  const customType = MAP_TX_NAME_TO_CUSTOM_OPERATION_TYPE[rawTx.name];
 
-  // update operation type and extra fields if staking analysis is available
-  if (stakingAnalysis) {
-    operationType = stakingAnalysis.operationType;
-    extra.previousStakingNodeId = stakingAnalysis.previousStakingNodeId;
-    extra.targetStakingNodeId = stakingAnalysis.targetStakingNodeId;
-    extra.stakedAmount = new BigNumber(stakingAnalysis.stakedAmount.toString());
+  if (customType || stakingAnalysis) {
+    const extra = { ...commonData.extra };
+    let operationType: OperationType =
+      customType ?? (netAmount.lt(0) ? "OUT" : netAmount.gt(0) ? "IN" : "NONE");
+
+    if (stakingAnalysis) {
+      operationType = stakingAnalysis.operationType;
+      extra.previousStakingNodeId = stakingAnalysis.previousStakingNodeId;
+      extra.targetStakingNodeId = stakingAnalysis.targetStakingNodeId;
+      extra.stakedAmount = new BigNumber(stakingAnalysis.stakedAmount.toString());
+    }
+
+    // if recipients array is empty, add the node where the transaction was submitted as recipient
+    if (recipients.length === 0 && rawTx.node) {
+      recipients.push(rawTx.node);
+    }
+
+    // try to enrich ASSOCIATE_TOKEN operation with extra.associatedTokenId
+    // this value is used by custom OperationDetails components in Hedera family
+    // accounts or contracts must first associate with an HTS token before they can receive or send that token; without association, token transfers fail
+    if (operationType === "ASSOCIATE_TOKEN") {
+      const relatedMirrorToken = mirrorTokens.find(t => {
+        return t.created_timestamp === rawTx.consensus_timestamp;
+      });
+
+      if (relatedMirrorToken) {
+        extra.associatedTokenId = relatedMirrorToken.token_id;
+      }
+    }
+
+    coinOperations.push(
+      buildCoinOperation({
+        commonData,
+        ledgerAccountId,
+        idSuffix: operationType,
+        type: operationType,
+        value: netAmount.abs(),
+        senders,
+        recipients,
+        extra,
+      }),
+    );
+
+    return coinOperations;
   }
 
-  // if recipients array is empty, add the node where the transaction was submitted as recipient
-  if (recipients.length === 0 && rawTx.node) {
-    recipients.push(rawTx.node);
-  }
+  // Mirror nets the payer's row as value+fee combined; add the fee back to
+  // recover the pre-fee transfer amount so direction/value can be classified.
+  const isPayer = extractFeesPayer(rawTx) === address;
+  const valueDelta = netAmount.plus(isPayer ? fee : new BigNumber(0));
 
-  // try to enrich ASSOCIATE_TOKEN operation with extra.associatedTokenId
-  // this value is used by custom OperationDetails components in Hedera family
-  // accounts or contracts must first associate with an HTS token before they can receive or send that token; without association, token transfers fail
-  if (operationType === "ASSOCIATE_TOKEN") {
-    const relatedMirrorToken = mirrorTokens.find(t => {
-      return t.created_timestamp === rawTx.consensus_timestamp;
+  const pushFeesOperation = (parties?: Pick<Operation, "senders" | "recipients">) => {
+    coinOperations.push(
+      buildCoinOperation({
+        commonData,
+        ledgerAccountId,
+        idSuffix: "FEES",
+        type: "FEES",
+        value: fee,
+        senders: parties?.senders ?? senders,
+        recipients:
+          parties?.recipients ??
+          (recipients.length === 0 && rawTx.node ? [rawTx.node] : recipients),
+        extra: { ...commonData.extra },
+      }),
+    );
+  };
+
+  if (valueDelta.lt(0)) {
+    // Fee is duplicated onto every fanned-out OUT leg (known limitation).
+    const fanout = decomposeSoleSenderFanout({
+      address,
+      senders,
+      recipients,
+      recipientNets,
+      valueLeg: valueDelta.abs(),
     });
 
-    if (relatedMirrorToken) {
-      extra.associatedTokenId = relatedMirrorToken.token_id;
+    if (fanout) {
+      for (const { recipient, net } of fanout) {
+        coinOperations.push(
+          buildCoinOperation({
+            commonData,
+            ledgerAccountId,
+            idSuffix: `OUT:${recipient}`,
+            type: "OUT",
+            // value is fee-inclusive only when this account paid the fee
+            value: net.plus(isPayer ? fee : new BigNumber(0)),
+            senders,
+            recipients: [recipient],
+            extra: { ...commonData.extra, ...(isApproval && { isApproval: true }) },
+          }),
+        );
+      }
+    } else {
+      // OUT value includes the fee (Ledger Live convention); no separate FEES op.
+      coinOperations.push(
+        buildCoinOperation({
+          commonData,
+          ledgerAccountId,
+          idSuffix: "OUT",
+          type: "OUT",
+          value: netAmount.abs(),
+          senders,
+          recipients: recipients.length === 0 && rawTx.node ? [rawTx.node] : recipients,
+          extra: { ...commonData.extra, ...(isApproval && { isApproval: true }) },
+        }),
+      );
     }
-  }
+  } else if (valueDelta.gt(0)) {
+    // IN excludes the fee; a fee paid by the user (e.g. swap) becomes a separate FEES op.
+    coinOperations.push(
+      buildCoinOperation({
+        commonData,
+        ledgerAccountId,
+        idSuffix: "IN",
+        type: "IN",
+        value: valueDelta,
+        senders,
+        recipients,
+        extra: { ...commonData.extra },
+      }),
+    );
 
-  coinOperations.push({
-    id: `${hash}:${operationType}`,
-    accountId: ledgerAccountId,
-    type: operationType,
-    value,
-    recipients,
-    senders,
-    hash,
-    fee,
-    date,
-    blockHeight,
-    blockHash,
-    hasFailed,
-    extra,
-  });
+    if (isPayer && fee.gt(0)) {
+      pushFeesOperation();
+    }
+  } else if (isPayer && fee.gt(0)) {
+    // token-only send: no HBAR leg, but attribute the FEES op to the token transfer's parties
+    const tokenTransfers = rawTx.token_transfers ?? [];
+    pushFeesOperation(
+      tokenTransfers.length > 0 ? parseTransfers(tokenTransfers, address) : undefined,
+    );
+  }
 
   return coinOperations;
 }
@@ -400,28 +597,25 @@ async function processTransactionItem({
       : null;
 
   if (mergedTx.type === "mirror") {
-    const htsTokenResult = await processHTSTokenTransfers({
+    // a single CryptoTransfer can move HBAR and HTS tokens at once, so run both paths
+    const tokenOps = processHTSTokenTransfers({
       rawTx: mirrorTx,
       address,
       ledgerAccountId,
       commonData,
     });
+    newTokenOperations.push(...tokenOps);
 
-    if (htsTokenResult?.tokenOperation) newTokenOperations.push(htsTokenResult.tokenOperation);
-    if (htsTokenResult?.coinOperation) newCoinOperations.push(htsTokenResult.coinOperation);
-
-    if (!htsTokenResult) {
-      const coinOps = processCoinTransfers({
-        rawTx: mirrorTx,
-        address,
-        ledgerAccountId,
-        commonData,
-        mirrorTokens,
-        stakingReward,
-        stakingAnalysis,
-      });
-      newCoinOperations.push(...coinOps);
-    }
+    const coinOps = processCoinTransfers({
+      rawTx: mirrorTx,
+      address,
+      ledgerAccountId,
+      commonData,
+      mirrorTokens,
+      stakingReward,
+      stakingAnalysis,
+    });
+    newCoinOperations.push(...coinOps);
   } else {
     const erc20TokenResult = await processERC20TokenTransfer({
       enrichedERC20Transfer: mergedTx.data,
@@ -536,10 +730,14 @@ export async function listOperationsV2({
     tokenOperations.push(...result.newTokenOperations);
   }
 
+  // Keep standalone FEES ops (e.g. allowance approve, netted self-send) — they're
+  // the tx's only trace, unlike FEES ops that accompany a token op of the same tx.
+  const tokenOperationHashes = new Set(tokenOperations.map(op => op.hash));
+
   return {
     tokenOperations,
     coinOperations: skipFeesForTokenOperations
-      ? coinOperations.filter(op => op.type !== "FEES")
+      ? coinOperations.filter(op => op.type !== "FEES" || !tokenOperationHashes.has(op.hash))
       : coinOperations,
     nextCursor: mergeResult.nextCursor,
   };

--- a/libs/coin-modules/coin-hedera/src/network/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.ts
@@ -43,58 +43,82 @@ export async function createTransactionId(
   }
 }
 
-function isValidRecipient(accountId: AccountId, recipients: string[]): boolean {
-  if (accountId.shard.eq(0) && accountId.realm.eq(0)) {
-    // account is a node, only add to list if we have none
-    if (accountId.num.lt(100)) {
-      return recipients.length === 0;
-    }
+type RecipientKind = "node" | "system" | "regular";
 
-    // account is a system account that is not a node, do NOT add
-    if (accountId.num.lt(1000)) {
-      return false;
-    }
+function classifyRecipient(accountId: AccountId): RecipientKind {
+  if (accountId.shard.eq(0) && accountId.realm.eq(0)) {
+    if (accountId.num.lt(100)) return "node";
+    if (accountId.num.lt(1000)) return "system";
   }
 
-  return true;
+  return "regular";
 }
 
 export function parseTransfers(
   mirrorTransfers: (HederaMirrorCoinTransfer | HederaMirrorTokenTransfer)[],
   address: string,
   stakingReward = new BigNumber(0),
-): Pick<Operation, "type" | "value" | "senders" | "recipients"> {
-  let value = new BigNumber(0);
-  let type: OperationType = "NONE";
+): Pick<Operation, "type" | "value" | "senders" | "recipients"> & {
+  netAmount: BigNumber;
+  /** net positive amount per account listed in `recipients` (exact per-receiver values) */
+  recipientNets: Map<string, BigNumber>;
+} {
+  const rewardPayerAddress = getEnv("HEDERA_STAKING_REWARD_ACCOUNT_ID");
+
+  // Sum rather than overwrite: an account can appear on more than one row for the
+  // same asset (e.g. an allowance leg alongside a direct leg).
+  const netByAccount = new Map<string, BigNumber>();
+  for (const transfer of mirrorTransfers) {
+    const previous = netByAccount.get(transfer.account) ?? new BigNumber(0);
+    netByAccount.set(transfer.account, previous.plus(transfer.amount));
+  }
+
+  // staking reward is included in the transfer, so the user's net can be positive
+  // even if they sent more HBAR than they received; it is shown as a separate op.
+  const userNet = netByAccount.get(address);
+  const netAmount = (userNet ?? new BigNumber(0)).minus(stakingReward);
+
+  // "NONE" only when the user is not involved at all; a present-but-zero net keeps
+  // the incoming classification (matches historical behavior).
+  const type: OperationType = userNet === undefined ? "NONE" : netAmount.isNegative() ? "OUT" : "IN";
+  const value = netAmount.abs();
 
   const senders: string[] = [];
   const recipients: string[] = [];
-  const rewardPayerAddress = getEnv("HEDERA_STAKING_REWARD_ACCOUNT_ID");
+  const recipientNets = new Map<string, BigNumber>();
+  // A node's fee share is a positive leg on every tx; only show it as recipient
+  // when nobody else received funds.
+  let nodeFallback: { account: string; net: BigNumber } | null = null;
 
-  for (const transfer of mirrorTransfers) {
-    const amount = new BigNumber(transfer.amount);
-    const accountId = AccountId.fromString(transfer.account);
+  for (const [account, rawNet] of netByAccount) {
+    const net = account === address ? rawNet.minus(stakingReward) : rawNet;
 
-    // staking reward is included in transfer, so it can be positive even if user sent less HBARs than the reward is
-    const amountWithoutReward = transfer.account === address ? amount.minus(stakingReward) : amount;
-
-    if (transfer.account === address) {
-      value = amountWithoutReward.abs();
-      type = amountWithoutReward.isNegative() ? "OUT" : "IN";
-    }
-
-    if (amountWithoutReward.isNegative()) {
+    if (net.isNegative()) {
       // exclude reward payer from senders list, because rewards are shown as separate operations
-      const shouldIgnoreAddress = transfer.account === rewardPayerAddress && stakingReward.gt(0);
+      const shouldIgnoreAddress = account === rewardPayerAddress && stakingReward.gt(0);
 
       if (shouldIgnoreAddress) {
         continue;
       }
 
-      senders.push(transfer.account);
-    } else if (isValidRecipient(accountId, recipients)) {
-      recipients.push(transfer.account);
+      senders.push(account);
+    } else if (net.isPositive()) {
+      const kind = classifyRecipient(AccountId.fromString(account));
+
+      if (kind === "system") continue;
+      if (kind === "node") {
+        nodeFallback ??= { account, net };
+        continue;
+      }
+
+      recipients.push(account);
+      recipientNets.set(account, net);
     }
+  }
+
+  if (recipients.length === 0 && nodeFallback) {
+    recipients.push(nodeFallback.account);
+    recipientNets.set(nodeFallback.account, nodeFallback.net);
   }
 
   // NOTE: earlier addresses are the "fee" addresses
@@ -106,6 +130,8 @@ export function parseTransfers(
     value,
     senders,
     recipients,
+    netAmount,
+    recipientNets,
   };
 }
 

--- a/libs/coin-modules/coin-hedera/src/types/bridge.ts
+++ b/libs/coin-modules/coin-hedera/src/types/bridge.ts
@@ -173,6 +173,11 @@ export type HederaOperationExtra = {
   targetStakingNodeId?: number | null;
   previousStakingNodeId?: number | null;
   stakedAmount?: BigNumber;
+  // set on an HTS token or native HBAR operation when the user's funds were moved
+  // by a third party (spender) through a previously-granted allowance (mirror row
+  // is_approval=true on the user's negative leg). Data-only; not surfaced in
+  // operation details yet.
+  isApproval?: boolean;
 };
 
 export type HederaValidator = {

--- a/libs/coin-modules/coin-hedera/src/types/mirror.ts
+++ b/libs/coin-modules/coin-hedera/src/types/mirror.ts
@@ -5,6 +5,7 @@ type KycStatus = "NOT_APPLICABLE" | "GRANTED" | "REVOKED";
 export interface HederaMirrorCoinTransfer {
   account: string;
   amount: number;
+  is_approval?: boolean;
 }
 
 export interface HederaMirrorTokenTransfer {


### PR DESCRIPTION
A single transaction moving HBAR and one or more HTS tokens now produces one operation per fund movement instead of a synthetic FEES operation that dropped the HBAR send and collapsed multiple tokens into one. Fee is attributed once on the main-account operation, allowance-based token spends are flagged in the operation extra, and token operations are no longer nested under real HBAR value operations sharing the same hash.

<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
