### PR TITLE
[LWM] fix(mobile): fix upsell modal content test typecheck

### DIFF
--- a/.changeset/quiet-hotels-relax.md
+++ b/.changeset/quiet-hotels-relax.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix a typecheck failure in large-screen upsell modal content tests by replacing optional-call resolver invocation with a safely narrowed function reference.

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalContent/__tests__/LargeScreenUpsellModalContent.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalContent/__tests__/LargeScreenUpsellModalContent.test.tsx
@@ -115,11 +115,11 @@ describe("LargeScreenUpsellModalContent", () => {
   });
 
   it("should ignore repeated CTA presses while URL opening is in flight", async () => {
-    let resolveOpenURL: (() => void) | null = null;
+    let releaseOpenURL: (() => void) | undefined;
     openURLSpy.mockImplementation(
       () =>
         new Promise<void>(resolve => {
-          resolveOpenURL = resolve;
+          releaseOpenURL = () => resolve();
         }),
     );
 
@@ -135,7 +135,8 @@ describe("LargeScreenUpsellModalContent", () => {
     });
     expect(onPrimaryPress).not.toHaveBeenCalled();
 
-    resolveOpenURL?.();
+    expect(releaseOpenURL).toBeDefined();
+    releaseOpenURL!();
 
     await waitFor(() => {
       expect(onPrimaryPress).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _I couldn't run the full local mobile typecheck workflow in this environment; fix is scoped to the exact CI TS error and validated by lint/hooks._
- [x] **Impact of the changes:**
      - Unblocks `Codecheck Mobile / Mobile Code Check` typecheck failure.
      - Keeps the in-flight CTA test behavior identical while making resolver typing explicit.
      - No production runtime logic changes.

### 📝 Description

This PR fixes the TypeScript failure seen in mobile codecheck for the Large Screen Upsell modal content test.

The failing test used `resolveOpenURL?.()` on a resolver captured from a Promise callback, which could be inferred as `never` in CI (`TS2349: This expression is not callable`). The fix stores an explicit callback (`releaseOpenURL`) and invokes it after a runtime presence assertion.

### ❓ Context

- **JIRA or GitHub link**: [#19550](https://github.com/LedgerHQ/ledger-live/pull/19550)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)