### PR TITLE
[LWDM] fix(coin-near): guard gas price against empty indexer responses

### DIFF
--- a/.changeset/near-gas-price-guard.md
+++ b/.changeset/near-gas-price-guard.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-near": patch
+---
+
+Guard NEAR gas price parsing against empty/degraded indexer responses. When the NEARBLOCKS indexer `/v1/stats` endpoint returns no stats, `getGasPrice` now throws a clear `NearGasPriceNotLoaded` error instead of an opaque `Cannot read properties of null (reading '0')`.

--- a/libs/coin-modules/coin-near/src/api/node.test.ts
+++ b/libs/coin-modules/coin-near/src/api/node.test.ts
@@ -1,0 +1,50 @@
+import liveNetwork from "@ledgerhq/live-network";
+import { setCoinConfig } from "../config";
+import { getGasPrice } from "./node";
+
+jest.mock("@ledgerhq/live-network");
+
+const mockedLiveNetwork = jest.mocked(liveNetwork);
+
+describe("getGasPrice", () => {
+  beforeAll(() => {
+    setCoinConfig(() => ({
+      status: { type: "active" },
+      infra: {
+        API_NEAR_PRIVATE_NODE: "https://mocked",
+        API_NEAR_PUBLIC_NODE: "https://mocked",
+        API_NEAR_INDEXER: "https://mocked",
+        API_NEARBLOCKS_INDEXER: "https://mocked",
+      },
+    }));
+  });
+
+  afterEach(() => {
+    mockedLiveNetwork.mockReset();
+  });
+
+  it("returns the gas price from the indexer stats response", async () => {
+    mockedLiveNetwork.mockResolvedValueOnce({
+      data: { stats: [{ gas_price: "100000000" }] },
+    } as never);
+
+    await expect(getGasPrice()).resolves.toBe("100000000");
+  });
+
+  it.each([
+    ["stats is null", { stats: null }],
+    ["stats is an empty array", { stats: [] }],
+    ["stats entry has no gas_price", { stats: [{}] }],
+    ["data is empty", {}],
+  ])("throws NearGasPriceNotLoaded when %s", async (_label, data) => {
+    mockedLiveNetwork.mockResolvedValueOnce({ data } as never);
+
+    await expect(getGasPrice()).rejects.toMatchObject({ name: "NearGasPriceNotLoaded" });
+  });
+
+  it("includes the offending response payload in the error message", async () => {
+    mockedLiveNetwork.mockResolvedValueOnce({ data: { stats: null } } as never);
+
+    await expect(getGasPrice()).rejects.toThrow(JSON.stringify({ stats: null }));
+  });
+});

--- a/libs/coin-modules/coin-near/src/api/node.ts
+++ b/libs/coin-modules/coin-near/src/api/node.ts
@@ -6,6 +6,7 @@ import { BigNumber } from "bignumber.js";
 import * as nearAPI from "near-api-js";
 import { getCoinConfig } from "../config";
 import { MIN_ACCOUNT_BALANCE_BUFFER } from "../constants";
+import { NearGasPriceNotLoaded } from "../errors";
 import { canUnstake, canWithdraw, getYoctoThreshold } from "../logic";
 import { getCurrentNearPreloadData } from "../preload-data";
 import { NearAccount } from "../types";
@@ -129,7 +130,12 @@ export const getGasPrice = async (): Promise<string> => {
     url: `${currencyConfig.infra.API_NEARBLOCKS_INDEXER}/v1/stats`,
   });
 
-  return response.data.stats[0].gas_price;
+  const gasPrice = response.data?.stats?.[0]?.gas_price;
+  if (!gasPrice) {
+    throw new NearGasPriceNotLoaded(JSON.stringify(response.data)?.slice(0, 500));
+  }
+
+  return gasPrice;
 };
 
 export const getAccessKey = async ({

--- a/libs/coin-modules/coin-near/src/errors.ts
+++ b/libs/coin-modules/coin-near/src/errors.ts
@@ -44,3 +44,17 @@ export const NearRecommendUnstake = createCustomErrorClass("NearRecommendUnstake
  * When trying to stake, unstake, or withdraw less than the threshold.
  */
 export const NearStakingThresholdNotMet = createCustomErrorClass("NearStakingThresholdNotMet");
+
+/*
+ * When the gas price can not be read from the indexer's stats response.
+ * Typically an empty/degraded/rate-limited response from the NEARBLOCKS indexer.
+ */
+export class NearGasPriceNotLoaded extends Error {
+  override name = "NearGasPriceNotLoaded";
+  constructor(details?: string) {
+    super(
+      "NEAR gas price could not be loaded from the indexer stats response" +
+        (details ? `: ${details}` : ""),
+    );
+  }
+}


### PR DESCRIPTION
## Context

The `delegateNEAR` mobile e2e test failed on CI (iOS shard 9):

> https://github.com/LedgerHQ/ledger-live/actions/runs/29304880414/job/86996246247#step:16:793

The failure was in **test setup**, not the test body — seeding the NEAR account via `liveData --currency Near --index 0 --add` crashed with:

```
Cannot read properties of null (reading '0')
```

## Root cause

That CLI command triggers the NEAR currency-bridge `preload()`, which calls `getGasPrice()`:

```ts
// libs/coin-modules/coin-near/src/api/node.ts
return response.data.stats[0].gas_price;
```

When the `API_NEARBLOCKS_INDEXER` `/v1/stats` endpoint returns a body whose `stats` field is `null`, `stats[0]` throws the opaque `Cannot read properties of null (reading '0')`. The bad response is external (indexer degradation/stale cache), so it is not reproducible on demand and passes locally.

## Change

- `getGasPrice()` now guards the read and throws a typed **`NearGasPriceNotLoaded`** error instead of crashing.
- The error message includes a capped (≤500 char) snapshot of the offending response payload, so the actual indexer body is attributable straight from CI logs — no verbose logging required.
- Added unit tests for `getGasPrice` covering the happy path and the `null` / empty / missing-field cases.

This does not fix the upstream indexer flake — it turns an opaque crash into a clear, attributable, retryable failure. `gasPrice` feeds fee computation, so a hard error is deliberately preferred over silently degrading.

## Testing

```
cd libs/coin-modules/coin-near && npx jest src/api/node.test.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)