### PR TITLE
[LWDM] feat(LIVE-30496): implement mobile quick amount selector with shared tier logic

### DIFF
--- a/.changeset/silent-tigers-swim.md
+++ b/.changeset/silent-tigers-swim.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/coin-aleo": minor
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add the Aleo private-send quick amount selector (Fast/Balanced/Full record tiers, spendable balance summary, and records-per-send info banner) to the mobile Amount screen, matching desktop. Extracts the shared tier-selection logic into `@ledgerhq/coin-aleo` so both platforms use the same Fast/Balanced/Full boundaries.

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/QuickAmountSelector.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/QuickAmountSelector.tsx
@@ -1,5 +1,4 @@
-import BigNumber from "bignumber.js";
-import React, { memo, useMemo } from "react";
+import React, { memo } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { rgba } from "@ledgerhq/react-ui/styles/helpers";
@@ -11,49 +10,11 @@ import TachometerLow from "~/renderer/icons/TachometerLow";
 import TachometerMedium from "~/renderer/icons/TachometerMedium";
 import Label from "~/renderer/components/Label";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
-import type {
-  AleoAccount,
-  AleoTokenAccount,
-  AleoUnspentRecord,
-} from "@ledgerhq/live-common/families/aleo/types";
+import type { AleoAccount, AleoTokenAccount } from "@ledgerhq/live-common/families/aleo/types";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
-import {
-  getEstimatedSigningTime,
-  isPrivateTransaction,
-  sumPrivateRecords,
-} from "@ledgerhq/live-common/families/aleo/utils";
-import { getMaxPrivateRecordsForAccount, isAleoTransaction } from "./utils";
-
-type SigningStrategy = "fast" | "balanced" | "full";
-
-interface StrategyConfig {
-  min: number;
-  max: number;
-}
-
-// The maximum number of records that can be selected for a transaction based on signing time constraints.
-const FAST_PRIVATE_RECORDS_PER_TRANSACTION = 4;
-const BALANCED_PRIVATE_RECORDS_PER_TRANSACTION = 8;
-
-function getStrategyConfig(
-  account: AleoAccount | AleoTokenAccount,
-): Record<SigningStrategy, StrategyConfig> {
-  const maxRecords = getMaxPrivateRecordsForAccount(account);
-
-  return {
-    fast: { min: 1, max: FAST_PRIVATE_RECORDS_PER_TRANSACTION },
-    balanced: {
-      min: FAST_PRIVATE_RECORDS_PER_TRANSACTION + 1,
-      max: BALANCED_PRIVATE_RECORDS_PER_TRANSACTION,
-    },
-    full: {
-      min: BALANCED_PRIVATE_RECORDS_PER_TRANSACTION + 1,
-      max: maxRecords,
-    },
-  };
-}
-
-const STRATEGIES: SigningStrategy[] = ["fast", "balanced", "full"];
+import type { SigningStrategy } from "@ledgerhq/live-common/families/aleo/utils";
+import { getEstimatedSigningTime } from "@ledgerhq/live-common/families/aleo/utils";
+import { useAleoQuickAmountSelector } from "@ledgerhq/live-common/families/aleo/react";
 
 const STRATEGY_ICONS: Record<SigningStrategy, React.ReactElement> = {
   fast: <TachometerHigh size={13} />,
@@ -121,62 +82,13 @@ const QuickAmountSelector = ({ account, transaction, updateTransaction, onSelect
   const { t } = useTranslation();
   const accountUnit = useAccountUnit(account);
 
-  const sortedRecords: AleoUnspentRecord[] = useMemo(() => {
-    const unspentPrivateRecords =
-      (account.type === "TokenAccount"
-        ? account.unspentPrivateRecords
-        : account.aleoResources?.unspentPrivateRecords) ?? [];
-
-    return unspentPrivateRecords
-      .filter(r => new BigNumber(r.microcredits).isGreaterThan(0))
-      .sort((a, b) => new BigNumber(b.microcredits).comparedTo(a.microcredits));
-  }, [account]);
-
-  const strategyConfig = useMemo(() => getStrategyConfig(account), [account]);
-
-  const spendableRecords = useMemo(
-    () => sortedRecords.slice(0, strategyConfig.full.max),
-    [sortedRecords, strategyConfig],
-  );
-
-  const totalSpendableBalance = sumPrivateRecords(spendableRecords);
-  const totalRecords = sortedRecords.length;
-  const selectedRecordsCount =
-    isAleoTransaction(transaction) && isPrivateTransaction(transaction)
-      ? transaction.properties.amountRecordCommitments.length
-      : 0;
+  const { strategyData, totalSpendableBalance, selectedRecordsCount, selectStrategy } =
+    useAleoQuickAmountSelector({ account, transaction, updateTransaction });
 
   const selectedRecordsSigningTime = getEstimatedSigningTime(
     selectedRecordsCount,
     t("time.second_short"),
     t("time.minute_short"),
-  );
-
-  const strategyData = useMemo(
-    () =>
-      STRATEGIES.map(strategy => {
-        const { min, max } = strategyConfig[strategy];
-
-        const rangeRecords = sortedRecords.slice(0, max);
-        const availableCount = rangeRecords.length;
-        const rangeSum = sumPrivateRecords(rangeRecords);
-
-        const disabled = totalRecords < min;
-        const isSendMax =
-          !disabled &&
-          (availableCount === totalRecords ||
-            (max === strategyConfig.full.max && availableCount === max));
-        const selected =
-          !disabled &&
-          (isSendMax
-            ? transaction.useAllAmount === true
-            : !rangeSum.isZero() &&
-              transaction.amount.isEqualTo(rangeSum) &&
-              !transaction.useAllAmount);
-
-        return { strategy, min, max, availableCount, rangeSum, disabled, selected, isSendMax };
-      }),
-    [sortedRecords, totalRecords, transaction.amount, transaction.useAllAmount, strategyConfig],
   );
 
   return (
@@ -211,86 +123,81 @@ const QuickAmountSelector = ({ account, transaction, updateTransaction, onSelect
         </Box>
       </Box>
       <Box horizontal justifyContent="center" flexWrap="wrap" gap="16px">
-        {strategyData.map(
-          ({ strategy, min, max, availableCount, rangeSum, disabled, selected, isSendMax }) => {
-            const signingTime = getEstimatedSigningTime(
-              availableCount,
-              t("time.second_short"),
-              t("time.minute_short"),
-            );
+        {strategyData.map(tile => {
+          const { strategy, min, max, availableCount, rangeSum, disabled, selected } = tile;
+          const signingTime = getEstimatedSigningTime(
+            availableCount,
+            t("time.second_short"),
+            t("time.minute_short"),
+          );
 
-            const disabledBadgeColor = disabled ? "neutral.c40" : "neutral.c100";
-            const badgeTextColor = selected ? "neutral.c00" : disabledBadgeColor;
+          const disabledBadgeColor = disabled ? "neutral.c40" : "neutral.c100";
+          const badgeTextColor = selected ? "neutral.c00" : disabledBadgeColor;
 
-            const handleClick = () => {
-              if (disabled) return;
-              if (isSendMax) {
-                updateTransaction(tx => ({ ...tx, useAllAmount: true, amount: new BigNumber(0) }));
-              } else {
-                updateTransaction(tx => ({ ...tx, amount: rangeSum, useAllAmount: false }));
-              }
-              onSelect?.();
-            };
+          const handleClick = () => {
+            if (disabled) return;
+            selectStrategy(tile);
+            onSelect?.();
+          };
 
-            return (
-              <QuickAmountWrapper
-                key={strategy}
+          return (
+            <QuickAmountWrapper
+              key={strategy}
+              selected={selected}
+              disabled={disabled}
+              onClick={handleClick}
+            >
+              <QuickAmountHeader
+                horizontal
+                alignItems="center"
                 selected={selected}
                 disabled={disabled}
-                onClick={handleClick}
               >
-                <QuickAmountHeader
-                  horizontal
-                  alignItems="center"
-                  selected={selected}
-                  disabled={disabled}
-                >
-                  {STRATEGY_ICONS[strategy]}
-                  <Text fontSize={0} ff="Inter|ExtraBold" uppercase ml={1} letterSpacing="0.1em">
-                    {t(`aleo.shared.quickAmountSelector.strategies.${strategy}`)}
-                  </Text>
-                </QuickAmountHeader>
+                {STRATEGY_ICONS[strategy]}
+                <Text fontSize={0} ff="Inter|ExtraBold" uppercase ml={1} letterSpacing="0.1em">
+                  {t(`aleo.shared.quickAmountSelector.strategies.${strategy}`)}
+                </Text>
+              </QuickAmountHeader>
 
-                <QuickAmountValue>
-                  {disabled ? (
-                    <Text fontSize={3} color="neutral.c40">
-                      —
-                    </Text>
-                  ) : (
-                    <WrappedFormattedVal>
-                      <FormattedVal
-                        inline
-                        ellipsis={false}
-                        color={selected ? "primary.c80" : "neutral.c100"}
-                        fontSize={3}
-                        fontWeight="600"
-                        val={rangeSum}
-                        unit={accountUnit}
-                        showCode
-                        alwaysShowValue
-                        showAllDigits
-                      />
-                    </WrappedFormattedVal>
-                  )}
-                </QuickAmountValue>
-
-                {!disabled && (
-                  <Text fontSize={2} color={selected ? "primary.c80" : "neutral.c70"}>
-                    {signingTime}
+              <QuickAmountValue>
+                {disabled ? (
+                  <Text fontSize={3} color="neutral.c40">
+                    —
                   </Text>
+                ) : (
+                  <WrappedFormattedVal>
+                    <FormattedVal
+                      inline
+                      ellipsis={false}
+                      color={selected ? "primary.c80" : "neutral.c100"}
+                      fontSize={3}
+                      fontWeight="600"
+                      val={rangeSum}
+                      unit={accountUnit}
+                      showCode
+                      alwaysShowValue
+                      showAllDigits
+                    />
+                  </WrappedFormattedVal>
                 )}
+              </QuickAmountValue>
 
-                <QuickAmountBadge selected={selected} disabled={disabled}>
-                  <Text fontSize={2} fontWeight="500" color={badgeTextColor}>
-                    {disabled
-                      ? t("aleo.shared.quickAmountSelector.unavailable", { min, max })
-                      : t("aleo.shared.quickAmountSelector.recordCount", { count: availableCount })}
-                  </Text>
-                </QuickAmountBadge>
-              </QuickAmountWrapper>
-            );
-          },
-        )}
+              {!disabled && (
+                <Text fontSize={2} color={selected ? "primary.c80" : "neutral.c70"}>
+                  {signingTime}
+                </Text>
+              )}
+
+              <QuickAmountBadge selected={selected} disabled={disabled}>
+                <Text fontSize={2} fontWeight="500" color={badgeTextColor}>
+                  {disabled
+                    ? t("aleo.shared.quickAmountSelector.unavailable", { min, max })
+                    : t("aleo.shared.quickAmountSelector.recordCount", { count: availableCount })}
+                </Text>
+              </QuickAmountBadge>
+            </QuickAmountWrapper>
+          );
+        })}
       </Box>
     </>
   );

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.test.ts
@@ -131,10 +131,7 @@ describe("isAleoTransaction", () => {
   });
 
   it("should return false for a non-aleo transaction", () => {
-    expect(
-      // @ts-expect-error - testing invalid family
-      isAleoTransaction({ ...makeAleoTransaction(), family: "bitcoin" }),
-    ).toBe(false);
+    expect(isAleoTransaction({ ...makeAleoTransaction(), family: "bitcoin" })).toBe(false);
   });
 });
 

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.ts
@@ -5,11 +5,7 @@ import {
   formatCurrencyUnit,
   type formatCurrencyUnitOptions,
 } from "@ledgerhq/live-common/currencies/index";
-import {
-  MAX_PRIVATE_RECORDS_PER_TRANSACTION,
-  MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION,
-  PRIVATE_BALANCE_PLACEHOLDER,
-} from "@ledgerhq/live-common/families/aleo/constants";
+import { PRIVATE_BALANCE_PLACEHOLDER } from "@ledgerhq/live-common/families/aleo/constants";
 import {
   derivePrivateTransactionMode,
   derivePublicTransactionMode,
@@ -18,15 +14,17 @@ import {
   isSelfTransferTransaction,
 } from "@ledgerhq/live-common/families/aleo/utils";
 import type {
-  AleoAccount,
   AleoCoinConfig,
-  AleoTokenAccount,
   Transaction as AleoTransaction,
 } from "@ledgerhq/live-common/families/aleo/types";
-import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { CryptoCurrency, TokenCurrency, Unit } from "@ledgerhq/types-cryptoassets";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import type { AccountLike } from "@ledgerhq/types-live";
+
+export {
+  isAleoAccount,
+  isAleoTransaction,
+  getMaxPrivateRecordsForAccount,
+} from "@ledgerhq/live-common/families/aleo/utils";
 
 export const getAleoCurrencyConfig = (
   currency: CryptoCurrency | TokenCurrency,
@@ -40,16 +38,6 @@ export const getAleoCurrencyConfig = (
     return undefined;
   }
 };
-
-export function isAleoAccount(acc: AccountLike): acc is AleoAccount | AleoTokenAccount {
-  const currency =
-    acc.type === "Account" ? acc.currency : getCryptoCurrencyById(acc.token.parentCurrencyId);
-  return currency.family === "aleo";
-}
-
-export function isAleoTransaction(tx: Transaction): tx is AleoTransaction {
-  return tx.family === "aleo";
-}
 
 export function getAleoAddressBadgeI18nKey(
   transaction: AleoTransaction,
@@ -107,10 +95,4 @@ export function formatAleoBalances({
       ? formatCurrencyUnit(unit, balances.privateBalance, formatConfig)
       : PRIVATE_BALANCE_PLACEHOLDER,
   };
-}
-
-export function getMaxPrivateRecordsForAccount(account: AleoAccount | AleoTokenAccount): number {
-  return account.type === "TokenAccount"
-    ? MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION
-    : MAX_PRIVATE_RECORDS_PER_TRANSACTION;
 }

--- a/apps/ledger-live-mobile/src/families/aleo/Send/QuickAmountSelector.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/QuickAmountSelector.tsx
@@ -1,21 +1,287 @@
-import React from "react";
-import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
-import { isPrivateTransaction } from "@ledgerhq/live-common/families/aleo/utils";
+import React, { useCallback, useState } from "react";
+import { Linking, Pressable, ScrollView, StyleSheet } from "react-native";
+// GenericInformationBody's Icon prop is still typed against native-ui's icon set.
+import { InformationFill } from "@ledgerhq/native-ui/assets/icons";
+import { Box, Link, Text } from "@ledgerhq/lumen-ui-rnative";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
+import { SpeedFast, SpeedLow, SpeedMedium } from "@ledgerhq/lumen-ui-rnative/symbols";
+import {
+  getEstimatedSigningTime,
+  getMaxPrivateRecordsForAccount,
+  isAleoTransaction,
+  isPrivateTransaction,
+  type SigningStrategy,
+} from "@ledgerhq/live-common/families/aleo/utils";
+import { useAleoQuickAmountSelector } from "@ledgerhq/live-common/families/aleo/react";
+import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import { useTranslation } from "~/context/Locale";
+import CurrencyUnitValue from "~/components/CurrencyUnitValue";
+import InfoIcon from "~/icons/Info";
+import QueuedDrawer from "~/components/QueuedDrawer";
+import { GenericInformationBody } from "~/components/GenericInformationBody";
+import { useKeyboardVisible } from "~/logic/keyboardVisible";
+import { urls } from "~/utils/urls";
 import type { AfterAmountInputProps } from "~/screens/SendFunds/utils/customSendFlow";
 
-export function QuickAmountSelector({ transaction }: Readonly<AfterAmountInputProps>) {
-  const { t } = useTranslation();
+const STRATEGY_ICONS: Record<SigningStrategy, typeof SpeedFast> = {
+  fast: SpeedFast,
+  balanced: SpeedMedium,
+  full: SpeedLow,
+};
 
-  if (transaction.family !== "aleo" || !isPrivateTransaction(transaction)) {
+const selectorStyles = StyleSheet.create({
+  scrollContainer: {
+    maxHeight: 340,
+  },
+});
+
+export function QuickAmountSelector({
+  account,
+  transaction,
+  updateTransaction,
+  maxSpendable,
+}: Readonly<AfterAmountInputProps>) {
+  const { t } = useTranslation();
+  const unit = useAccountUnit(account);
+  const quickAmountSelector = useAleoQuickAmountSelector({
+    account,
+    transaction,
+    updateTransaction,
+  });
+  const [infoOpen, setInfoOpen] = useState(false);
+  const onLearnMore = useCallback(() => Linking.openURL(urls.maxSpendable), []);
+  const { isKeyboardVisible } = useKeyboardVisible();
+
+  const styles = useStyleSheet(
+    t => ({
+      tile: {
+        flex: 1,
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: t.spacings.s4,
+        padding: t.spacings.s12,
+        borderRadius: t.borderRadius.sm,
+        borderWidth: t.borderWidth.s1,
+        minHeight: 96,
+      },
+      tileDefault: {
+        backgroundColor: t.colors.bg.muted,
+        borderColor: "transparent",
+      },
+      tileSelected: {
+        backgroundColor: t.colors.bg.activeSubtle,
+        borderColor: t.colors.border.active,
+      },
+      tileDisabled: {
+        backgroundColor: t.colors.bg.disabled,
+        borderColor: "transparent",
+      },
+      tilePressed: {
+        backgroundColor: t.colors.bg.surfacePressed,
+      },
+      badge: {
+        alignItems: "center",
+        borderRadius: t.borderRadius.xs,
+        paddingHorizontal: t.spacings.s6,
+        paddingVertical: t.spacings.s2,
+        backgroundColor: t.colors.bg.mutedStrong,
+      },
+      badgeSelected: {
+        backgroundColor: t.colors.bg.active,
+      },
+      badgeDisabled: {
+        backgroundColor: t.colors.bg.disabledStrong,
+      },
+    }),
+    [],
+  );
+
+  // Guarded after all hooks above (useAleoQuickAmountSelector must run unconditionally).
+  // This widget is only shown for private transfers — unlike desktop, mobile has no
+  // per-mode call site to gate it externally.
+  if (!isAleoTransaction(transaction) || !isPrivateTransaction(transaction)) {
     return null;
   }
 
+  const {
+    account: aleoAccount,
+    strategyData,
+    totalSpendableBalance,
+    selectedRecordsCount,
+    selectStrategy,
+  } = quickAmountSelector;
+
+  const selectedRecordsSigningTime = getEstimatedSigningTime(
+    selectedRecordsCount,
+    t("time.second_short"),
+    t("time.minute_short"),
+  );
+  const maxRecords = getMaxPrivateRecordsForAccount(aleoAccount);
+  // Prefer the bridge-estimated value shown by the screen's own "Total available" row, so the two
+  // never disagree — totalSpendableBalance (a simpler client-side sum, not fee-aware) is only a
+  // fallback while the async estimate hasn't resolved yet.
+  const spendableBalance = maxSpendable ?? totalSpendableBalance;
+
   return (
-    <Box lx={{ flex: 1 }}>
-      <Text typography="heading4SemiBold" lx={{ color: "base", textAlign: "center" }}>
-        {t("aleo.send.quickAmountSelector.mockTitle")}
-      </Text>
+    <Box>
+      {/* Bounded + scrollable so the tile grid never forces the Send Amount screen to grow
+          past what's left under the keyboard on short devices. */}
+      <ScrollView
+        style={selectorStyles.scrollContainer}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <Pressable
+          onPress={() => setInfoOpen(true)}
+          disabled={isKeyboardVisible}
+          style={{ marginBottom: 8, flexDirection: "row", alignItems: "center", gap: 4 }}
+        >
+          <Text typography="body4SemiBold" lx={{ color: "muted" }}>
+            {t("aleo.send.quickAmountSelector.title")}
+          </Text>
+          <InfoIcon size={12} color="grey" />
+        </Pressable>
+
+        <Box lx={{ gap: "s16" }}>
+          <Box lx={{ flexDirection: "row", gap: "s12" }}>
+            {strategyData.map(tile => {
+              const Icon = STRATEGY_ICONS[tile.strategy];
+              const signingTime = getEstimatedSigningTime(
+                tile.availableCount,
+                t("time.second_short"),
+                t("time.minute_short"),
+              );
+              let labelColor: "disabled" | "active" | "muted";
+              if (tile.disabled) {
+                labelColor = "disabled";
+              } else if (tile.selected) {
+                labelColor = "active";
+              } else {
+                labelColor = "muted";
+              }
+
+              let tileVariantStyle: (typeof styles)[
+                | "tileDefault"
+                | "tileSelected"
+                | "tileDisabled"];
+              if (tile.disabled) {
+                tileVariantStyle = styles.tileDisabled;
+              } else if (tile.selected) {
+                tileVariantStyle = styles.tileSelected;
+              } else {
+                tileVariantStyle = styles.tileDefault;
+              }
+
+              return (
+                <Pressable
+                  key={tile.strategy}
+                  onPress={() => selectStrategy(tile)}
+                  disabled={tile.disabled || isKeyboardVisible}
+                  style={({ pressed }) => [
+                    styles.tile,
+                    tileVariantStyle,
+                    pressed && !tile.disabled && styles.tilePressed,
+                  ]}
+                >
+                  <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s4" }}>
+                    <Icon size={16} color={labelColor} />
+                    <Text typography="body4SemiBold" lx={{ color: labelColor }}>
+                      {t(`aleo.send.quickAmountSelector.strategies.${tile.strategy}`)}
+                    </Text>
+                  </Box>
+
+                  {tile.disabled ? (
+                    <Text typography="body3" lx={{ color: "disabled" }}>
+                      {t("aleo.send.quickAmountSelector.noValue")}
+                    </Text>
+                  ) : (
+                    <Text
+                      typography="body3SemiBold"
+                      lx={{ color: tile.selected ? "active" : "base" }}
+                      numberOfLines={1}
+                      adjustsFontSizeToFit
+                    >
+                      <CurrencyUnitValue unit={unit} value={tile.rangeSum} showCode />
+                    </Text>
+                  )}
+
+                  {!tile.disabled && (
+                    <Text typography="body4" lx={{ color: tile.selected ? "active" : "muted" }}>
+                      {signingTime}
+                    </Text>
+                  )}
+
+                  <Box
+                    style={[
+                      styles.badge,
+                      tile.selected && styles.badgeSelected,
+                      tile.disabled && styles.badgeDisabled,
+                    ]}
+                  >
+                    <Text
+                      typography="body4SemiBold"
+                      lx={{ color: tile.disabled ? "disabled" : "onInteractive" }}
+                    >
+                      {tile.disabled
+                        ? t("aleo.send.quickAmountSelector.unavailable")
+                        : t("aleo.send.quickAmountSelector.recordCount", {
+                            count: tile.availableCount,
+                          })}
+                    </Text>
+                  </Box>
+                </Pressable>
+              );
+            })}
+          </Box>
+
+          <Box lx={{ gap: "s4" }}>
+            <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s4" }}>
+              <Text typography="body4" lx={{ color: "muted" }}>
+                {t("aleo.send.quickAmountSelector.spendableBalance")}
+              </Text>
+              <Text
+                typography="body4SemiBold"
+                lx={{ color: "muted" }}
+                numberOfLines={1}
+                adjustsFontSizeToFit
+              >
+                <CurrencyUnitValue unit={unit} value={spendableBalance} showCode />
+              </Text>
+            </Box>
+            <Box
+              lx={{ flexDirection: "row", alignItems: "center", gap: "s4" }}
+              style={{ opacity: selectedRecordsCount > 0 ? 1 : 0 }}
+              accessibilityElementsHidden={selectedRecordsCount === 0}
+              importantForAccessibility={
+                selectedRecordsCount === 0 ? "no-hide-descendants" : "auto"
+              }
+            >
+              <Text typography="body4" lx={{ color: "muted" }}>
+                {`${t("aleo.send.quickAmountSelector.recordCount", {
+                  count: selectedRecordsCount,
+                })} · ${selectedRecordsSigningTime}`}
+              </Text>
+            </Box>
+          </Box>
+        </Box>
+      </ScrollView>
+
+      <QueuedDrawer isRequestingToBeOpened={infoOpen} onClose={() => setInfoOpen(false)}>
+        <Box>
+          <GenericInformationBody
+            Icon={InformationFill}
+            iconColor={"primary.c80"}
+            title={t("aleo.send.quickAmountSelector.title")}
+            description={`${t("aleo.send.tooltip.descPartOne")} ${t("aleo.send.tooltip.descPartTwo", { max: maxRecords })}`}
+          />
+          <Box lx={{ paddingVertical: "s24" }}>
+            <Link appearance="accent" size="md" isExternal onPress={onLearnMore}>
+              {t("common.learnMore")}
+            </Link>
+          </Box>
+        </Box>
+      </QueuedDrawer>
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/QuickAmountSelector.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/QuickAmountSelector.test.tsx
@@ -1,46 +1,216 @@
 import React from "react";
+import BigNumber from "bignumber.js";
+import { Linking, Text } from "react-native";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { AleoAccount, AleoUnspentRecord } from "@ledgerhq/live-common/families/aleo/types";
 import { render, screen } from "@tests/test-renderer";
 import { QuickAmountSelector } from "../QuickAmountSelector";
-import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import { ALEO_ACCOUNT_1 } from "../../__mocks__/account.mock";
+import { urls } from "~/utils/urls";
+
+jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+
+jest.mock("LLM/hooks/useAccountUnit", () => ({
+  useAccountUnit: jest.fn(() => ({ name: "ALEO", code: "ALEO", magnitude: 6 })),
+}));
+
+jest.mock("~/components/CurrencyUnitValue", () => ({
+  __esModule: true,
+  default: ({ value }: { value: BigNumber }) => <Text>{value.toString()}</Text>,
+}));
+
+const mockUseKeyboardVisible = jest.fn(() => ({ isKeyboardVisible: false, keyboardHeight: 0 }));
+jest.mock("~/logic/keyboardVisible", () => ({
+  useKeyboardVisible: () => mockUseKeyboardVisible(),
+}));
 
 const mockUpdateTransaction = jest.fn();
 
+function makeRecord(microcredits: string): AleoUnspentRecord {
+  return { microcredits } as unknown as AleoUnspentRecord;
+}
+
+function makeAccount(records: AleoUnspentRecord[]): AleoAccount {
+  return {
+    ...(ALEO_ACCOUNT_1 as AleoAccount),
+    aleoResources: {
+      transparentBalance: new BigNumber(0),
+      privateBalance: new BigNumber(0),
+      unspentPrivateRecords: records,
+      provableApi: null,
+      lastPrivateSyncDate: null,
+    },
+  };
+}
+
+function makePrivateTransaction(overrides?: Partial<Transaction>): Transaction {
+  return {
+    family: "aleo",
+    mode: "transfer_private",
+    amount: new BigNumber(0),
+    useAllAmount: false,
+    properties: { amountRecordCommitments: [], feeRecordCommitment: null },
+    ...overrides,
+  } as unknown as Transaction;
+}
+
+const manyRecords = Array.from({ length: 16 }, (_, i) => makeRecord(`${(20 - i) * 100000}`));
+const sixRecords = Array.from({ length: 6 }, (_, i) => makeRecord(`${(6 - i) * 100000}`));
+
+function renderSelector(
+  account: unknown,
+  transaction: Transaction,
+  maxSpendable: BigNumber | null = null,
+) {
+  return render(
+    <QuickAmountSelector
+      account={account as never}
+      transaction={transaction}
+      updateTransaction={mockUpdateTransaction}
+      maxSpendable={maxSpendable}
+    />,
+  );
+}
+
 describe("QuickAmountSelector", () => {
-  const mockAccount = {} as never;
+  beforeEach(() => {
+    mockUpdateTransaction.mockClear();
+    mockUseKeyboardVisible.mockReturnValue({ isKeyboardVisible: false, keyboardHeight: 0 });
+  });
 
-  it("renders null for non-aleo transaction", () => {
-    const { toJSON } = render(
-      <QuickAmountSelector
-        account={mockAccount}
-        transaction={{ family: "ethereum" } as Transaction}
-        updateTransaction={mockUpdateTransaction}
-      />,
-    );
+  it("renders null for a non-aleo transaction", () => {
+    const { toJSON } = renderSelector(ALEO_ACCOUNT_1, {
+      family: "ethereum",
+    } as unknown as Transaction);
 
     expect(toJSON()).toBeNull();
   });
 
-  it("renders null for aleo public transaction", () => {
-    const { toJSON } = render(
-      <QuickAmountSelector
-        account={mockAccount}
-        transaction={{ family: "aleo", mode: "transfer_public" } as Transaction}
-        updateTransaction={mockUpdateTransaction}
-      />,
-    );
+  it("renders null for an aleo public transaction", () => {
+    const { toJSON } = renderSelector(ALEO_ACCOUNT_1, {
+      family: "aleo",
+      mode: "transfer_public",
+    } as unknown as Transaction);
 
     expect(toJSON()).toBeNull();
   });
 
-  it("renders for aleo private transaction", () => {
-    render(
-      <QuickAmountSelector
-        account={mockAccount}
-        transaction={{ family: "aleo", mode: "transfer_private" } as Transaction}
-        updateTransaction={mockUpdateTransaction}
-      />,
-    );
+  describe("with more spendable records than the Full tier cap (16 records)", () => {
+    const account = makeAccount(manyRecords);
+    const transaction = makePrivateTransaction();
 
-    expect(screen.getByText("Quick amount selector mock")).toBeOnTheScreen();
+    it("shows all 3 tiles enabled with correct amounts, record counts, and signing times", () => {
+      renderSelector(account, transaction);
+
+      expect(screen.getByText("Quick select")).toBeOnTheScreen();
+      expect(screen.getByText("Fast")).toBeOnTheScreen();
+      expect(screen.getByText("Balanced")).toBeOnTheScreen();
+      expect(screen.getByText("Full")).toBeOnTheScreen();
+
+      expect(screen.getByText("7400000")).toBeOnTheScreen();
+      expect(screen.getByText("13200000")).toBeOnTheScreen();
+      // Max Spendable Balance line and the Full tile both show the same capped sum.
+      expect(screen.getAllByText("18900000")).toHaveLength(2);
+
+      expect(screen.getByText("4 records")).toBeOnTheScreen();
+      expect(screen.getByText("8 records")).toBeOnTheScreen();
+      expect(screen.getByText("14 records")).toBeOnTheScreen();
+
+      expect(screen.getByText("~50 s")).toBeOnTheScreen();
+      expect(screen.getByText("~1.5 min")).toBeOnTheScreen();
+      expect(screen.getByText("~2.5 min")).toBeOnTheScreen();
+    });
+
+    it("shows the bridge-estimated maxSpendable value instead of its own capped sum, when provided", () => {
+      renderSelector(account, transaction, new BigNumber("19999999"));
+
+      expect(screen.getByText("19999999")).toBeOnTheScreen();
+      // Only the Full tile shows "18900000" now — the Max Spendable Balance row shows the
+      // provided maxSpendable estimate instead of its own capped, non-fee-aware sum.
+      expect(screen.getAllByText("18900000")).toHaveLength(1);
+    });
+
+    it("opens the info tooltip when tapping the Quick select label, with a working learn-more link", async () => {
+      const { user } = renderSelector(account, transaction);
+
+      await user.press(screen.getByText("Quick select"));
+
+      expect(screen.getByText(/Sender, amount and recipient hidden on-chain\./)).toBeOnTheScreen();
+
+      await user.press(screen.getByText("Learn more"));
+
+      expect(Linking.openURL).toHaveBeenCalledWith(urls.maxSpendable);
+    });
+
+    it("blocks the tiles and the tooltip while the keyboard is visible", async () => {
+      mockUseKeyboardVisible.mockReturnValue({ isKeyboardVisible: true, keyboardHeight: 300 });
+      const { user } = renderSelector(account, transaction);
+
+      await user.press(screen.getByText("Quick select"));
+      expect(
+        screen.queryByText(/Sender, amount and recipient hidden on-chain\./),
+      ).not.toBeOnTheScreen();
+
+      await user.press(screen.getByText("Fast"));
+      expect(mockUpdateTransaction).not.toHaveBeenCalled();
+    });
+
+    it("calls updateTransaction with the tier sum when tapping the Fast tile", async () => {
+      const { user } = renderSelector(account, transaction);
+
+      await user.press(screen.getByText("Fast"));
+
+      expect(mockUpdateTransaction).toHaveBeenCalledTimes(1);
+      const updater = mockUpdateTransaction.mock.calls[0][0];
+      const result = updater(transaction);
+      expect(result.useAllAmount).toBe(false);
+      expect((result.amount as BigNumber).toString()).toBe("7400000");
+    });
+
+    it("calls updateTransaction with useAllAmount when tapping the Full (cap) tile", async () => {
+      const { user } = renderSelector(account, transaction);
+
+      await user.press(screen.getByText("Full"));
+
+      expect(mockUpdateTransaction).toHaveBeenCalledTimes(1);
+      const updater = mockUpdateTransaction.mock.calls[0][0];
+      const result = updater(transaction);
+      expect(result.useAllAmount).toBe(true);
+      expect((result.amount as BigNumber).toString()).toBe("0");
+    });
+  });
+
+  describe("with only 6 spendable records", () => {
+    const account = makeAccount(sixRecords);
+    const transaction = makePrivateTransaction();
+
+    it("enables Fast and Balanced (as send-max), disables Full", () => {
+      renderSelector(account, transaction);
+
+      expect(screen.getByText("4 records")).toBeOnTheScreen();
+      // Balanced only has 6 of 8 available, and that's all the records there are.
+      expect(screen.getByText("6 records")).toBeOnTheScreen();
+      expect(screen.getByText("Unavailable")).toBeOnTheScreen();
+      expect(screen.getByText("—")).toBeOnTheScreen();
+    });
+
+    it("does not call updateTransaction when tapping the disabled Full tile", async () => {
+      const { user } = renderSelector(account, transaction);
+
+      await user.press(screen.getByText("Full"));
+
+      expect(mockUpdateTransaction).not.toHaveBeenCalled();
+    });
+
+    it("calls updateTransaction with useAllAmount when tapping the Balanced (send-max) tile", async () => {
+      const { user } = renderSelector(account, transaction);
+
+      await user.press(screen.getByText("Balanced"));
+
+      expect(mockUpdateTransaction).toHaveBeenCalledTimes(1);
+      const updater = mockUpdateTransaction.mock.calls[0][0];
+      const result = updater(transaction);
+      expect(result.useAllAmount).toBe(true);
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10145,10 +10145,24 @@
         "errorDesc": "Something went wrong, please try again"
       },
       "quickAmountSelector": {
-        "mockTitle": "Quick amount selector mock"
+        "title": "Quick select",
+        "strategies": {
+          "fast": "Fast",
+          "balanced": "Balanced",
+          "full": "Full"
+        },
+        "recordCount_one": "{{count}} record",
+        "recordCount_other": "{{count}} records",
+        "unavailable": "Unavailable",
+        "noValue": "—",
+        "spendableBalance": "Max Spendable Balance:"
       },
       "summary": {
         "proofGenerationNotice": "Aleo transaction requires proof generation. This may take some time."
+      },
+      "tooltip": {
+        "descPartOne": "Sender, amount and recipient hidden on-chain.",
+        "descPartTwo": "Up to {{max}} records per send."
       }
     },
     "balancesSection": "Balances",

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
@@ -173,22 +173,45 @@ function SendAmountCoinContent({ navigation, route, account, parentAccount }: Co
         <KeyboardView style={styles.container}>
           <TouchableWithoutFeedback onPress={blur}>
             <View style={styles.amountWrapper}>
-              <AmountInput
-                testID="amount-input"
-                editable={!useAllAmount}
-                account={account}
-                onChange={onChange}
-                value={amount}
-                transferFeeCalculated={transferFee}
-                error={
-                  status.errors.dustLimit
-                    ? status.errors.dustLimit
-                    : amount.eq(0) && (bridgePending || !transaction.useAllAmount)
-                      ? null
-                      : status.errors.amount
-                }
-                warning={status.warnings.amount}
-              />
+              {familySendFlow?.AfterAmountInput ? (
+                // Guards AmountInput's height when a family widget below it (e.g. aleo's
+                // quick-amount tiles) See: LIVE-30496
+                <View style={styles.amountInputProtected}>
+                  <AmountInput
+                    testID="amount-input"
+                    editable={!useAllAmount}
+                    account={account}
+                    onChange={onChange}
+                    value={amount}
+                    transferFeeCalculated={transferFee}
+                    error={
+                      status.errors.dustLimit
+                        ? status.errors.dustLimit
+                        : amount.eq(0) && (bridgePending || !transaction.useAllAmount)
+                          ? null
+                          : status.errors.amount
+                    }
+                    warning={status.warnings.amount}
+                  />
+                </View>
+              ) : (
+                <AmountInput
+                  testID="amount-input"
+                  editable={!useAllAmount}
+                  account={account}
+                  onChange={onChange}
+                  value={amount}
+                  transferFeeCalculated={transferFee}
+                  error={
+                    status.errors.dustLimit
+                      ? status.errors.dustLimit
+                      : amount.eq(0) && (bridgePending || !transaction.useAllAmount)
+                        ? null
+                        : status.errors.amount
+                  }
+                  warning={status.warnings.amount}
+                />
+              )}
 
               {familySendFlow?.AfterAmountInput && (
                 <View style={styles.afterAmountInputWrapper}>
@@ -196,6 +219,7 @@ function SendAmountCoinContent({ navigation, route, account, parentAccount }: Co
                     account={account}
                     transaction={transaction}
                     updateTransaction={handleUpdateTransaction}
+                    maxSpendable={maxSpendable}
                   />
                 </View>
               )}
@@ -307,7 +331,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     display: "flex",
     flexGrow: 1,
-    marginBottom: 16,
+    marginVertical: 16,
   },
   availableRight: {
     alignItems: "center",
@@ -320,6 +344,13 @@ const styles = StyleSheet.create({
   },
   maxLabel: {
     marginRight: 4,
+  },
+  // Keeps AmountInput's content from clipping when the keyboard shrinks this column;
+  // no flexGrow so it stays at its natural compact height instead of expanding.
+  // See: LIVE-30496
+  amountInputProtected: {
+    flexShrink: 1,
+    minHeight: 160,
   },
   afterAmountInputWrapper: {
     flex: 1,

--- a/apps/ledger-live-mobile/src/screens/SendFunds/utils/customSendFlow.ts
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/utils/customSendFlow.ts
@@ -1,4 +1,5 @@
 import type { ComponentType } from "react";
+import type { BigNumber } from "bignumber.js";
 import type { AccountLike, Account } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { NativeStackNavigationOptions } from "@react-navigation/native-stack";
@@ -37,6 +38,8 @@ export type AfterAmountInputProps = {
   account: AccountLike;
   transaction: Transaction;
   updateTransaction: (updater: (t: Transaction) => Transaction) => void;
+  /** The same bridge-estimated max-spendable value shown by the screen's own "Total available" row. */
+  maxSpendable: BigNumber | null;
 };
 
 type InitialScreenNavParams = {

--- a/libs/coin-modules/coin-aleo/src/constants.ts
+++ b/libs/coin-modules/coin-aleo/src/constants.ts
@@ -71,5 +71,10 @@ export const MAX_PRIVATE_RECORDS_PER_TRANSACTION = 14;
 // Token batcher programs only support up to 13 records (no _14 variant exists).
 export const MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION = 13;
 
+// The record-count boundary between the "Fast" and "Balanced" quick-amount tiers.
+export const FAST_PRIVATE_RECORDS_PER_TRANSACTION = 4;
+// The record-count boundary between the "Balanced" and "Full" quick-amount tiers.
+export const BALANCED_PRIVATE_RECORDS_PER_TRANSACTION = 8;
+
 // The estimated time in milliseconds it takes to sign a single record during transaction signing.
 export const SINGLE_CALL_SIGNING_TIME = 12500;

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -93,6 +93,10 @@ import {
   getEstimatedSigningTime,
   sumPrivateRecords,
   getCalTokens,
+  getMaxPrivateRecordsForAccount,
+  getStrategyConfig,
+  isAleoAccount,
+  isAleoTransaction,
 } from "./utils";
 
 jest.mock("../config");
@@ -403,7 +407,9 @@ describe("toCoinFrameworkOperation", () => {
   });
 
   it("should set failed to true when transaction_status is not Accepted", () => {
-    const rawTx = getMockedPublicTransaction({ transaction_status: "Rejected" });
+    const rawTx = getMockedPublicTransaction({
+      transaction_status: "Rejected",
+    });
 
     const result = toCoinFrameworkOperation(rawTx, recipientAddress);
 
@@ -547,7 +553,9 @@ describe("resolveConfig", () => {
 describe("getTransactionType", () => {
   it("should return valid transaction type from intent", () => {
     // @ts-expect-error - only intent type is required for this test
-    const mockTx: TransactionIntent = { type: TRANSACTION_TYPE.TRANSFER_PUBLIC };
+    const mockTx: TransactionIntent = {
+      type: TRANSACTION_TYPE.TRANSFER_PUBLIC,
+    };
 
     expect(getTransactionType(mockTx)).toBe(TRANSACTION_TYPE.TRANSFER_PUBLIC);
   });
@@ -971,7 +979,9 @@ describe("toPrivateBridgeOperation", () => {
   });
 
   it("should set value from enriched.value", () => {
-    const enriched = getMockedEnrichedPrivateRecord({ value: new BigNumber(42000000) });
+    const enriched = getMockedEnrichedPrivateRecord({
+      value: new BigNumber(42000000),
+    });
 
     const result = toPrivateBridgeOperation(mockLedgerAccountId, enriched, mockRecipientAddress);
 
@@ -981,7 +991,10 @@ describe("toPrivateBridgeOperation", () => {
 
 describe("splitPrivateAndPublicOperations", () => {
   const makePublicOp = (id: string) =>
-    getMockedOperation({ id, extra: { functionId: "transfer_public", transactionType: "public" } });
+    getMockedOperation({
+      id,
+      extra: { functionId: "transfer_public", transactionType: "public" },
+    });
   const makePrivateOp = (id: string) =>
     getMockedOperation({
       id,
@@ -1425,7 +1438,9 @@ describe("toHex", () => {
 
   it("should produce different hex strings for different transactions", () => {
     const tx1 = getMockedPreparedRequestResponse({ program_id: "custom.aleo" });
-    const tx2 = getMockedPreparedRequestResponse({ program_id: "another.aleo" });
+    const tx2 = getMockedPreparedRequestResponse({
+      program_id: "another.aleo",
+    });
 
     expect(toHex(tx1)).not.toBe(toHex(tx2));
   });
@@ -1524,6 +1539,16 @@ describe("isSelfTransferTransaction", () => {
     const transaction = getMockedTransaction({ mode });
 
     expect(isSelfTransferTransaction(transaction)).toBe(expected);
+  });
+});
+
+describe("isAleoTransaction", () => {
+  it("returns true for an aleo transaction", () => {
+    expect(isAleoTransaction({ family: "aleo" })).toBe(true);
+  });
+
+  it("returns false for a non-aleo transaction", () => {
+    expect(isAleoTransaction({ family: "bitcoin" })).toBe(false);
   });
 });
 
@@ -1633,7 +1658,10 @@ describe("createTransactionIntent", () => {
         recipient: "aleo1recipient",
       });
 
-      const result = createTransactionIntent({ account: mockAccount, transaction });
+      const result = createTransactionIntent({
+        account: mockAccount,
+        transaction,
+      });
 
       expect(result).toEqual({
         intentType: "transaction",
@@ -1654,7 +1682,10 @@ describe("createTransactionIntent", () => {
       useAllAmount: true,
     });
 
-    const result = createTransactionIntent({ account: mockAccount, transaction });
+    const result = createTransactionIntent({
+      account: mockAccount,
+      transaction,
+    });
 
     expect(result.useAllAmount).toBe(true);
   });
@@ -1670,7 +1701,10 @@ describe("createTransactionIntent", () => {
         },
       });
 
-      const result = createTransactionIntent({ account: mockAccount, transaction });
+      const result = createTransactionIntent({
+        account: mockAccount,
+        transaction,
+      });
 
       expect(result).toMatchObject({
         type: transaction.mode,
@@ -2096,10 +2130,16 @@ describe("getRecordByCommitment", () => {
       unspentPrivateRecords: [mockUnspentTokenRecord1],
     });
     // Put a native record with the same commitment to catch any incorrect fallback.
-    const nativeDecoy = { ...mockUnspentRecord1, commitment: missingCommitment };
+    const nativeDecoy = {
+      ...mockUnspentRecord1,
+      commitment: missingCommitment,
+    };
     const account = getMockedAccount({
       subAccounts: [tokenAccount],
-      aleoResources: { ...mockAleoResources, unspentPrivateRecords: [nativeDecoy] },
+      aleoResources: {
+        ...mockAleoResources,
+        unspentPrivateRecords: [nativeDecoy],
+      },
     });
 
     const result = getRecordByCommitment({
@@ -2116,7 +2156,10 @@ describe("getRecordByCommitment", () => {
       unspentPrivateRecords: [],
     });
     const account = getMockedAccount({
-      aleoResources: { ...mockAleoResources, unspentPrivateRecords: [mockUnspentRecord1] },
+      aleoResources: {
+        ...mockAleoResources,
+        unspentPrivateRecords: [mockUnspentRecord1],
+      },
       subAccounts: [tokenAccount],
     });
 
@@ -2130,12 +2173,20 @@ describe("getRecordByCommitment", () => {
   });
 
   it("should return null when tokenAccount.unspentPrivateRecords is null", () => {
-    const tokenAccount = getMockedTokenAccount(undefined, { unspentPrivateRecords: null });
+    const tokenAccount = getMockedTokenAccount(undefined, {
+      unspentPrivateRecords: null,
+    });
     // Put a native record with the same commitment to catch any incorrect fallback.
-    const nativeDecoy = { ...mockUnspentRecord1, commitment: mockUnspentTokenRecord1.commitment };
+    const nativeDecoy = {
+      ...mockUnspentRecord1,
+      commitment: mockUnspentTokenRecord1.commitment,
+    };
     const account = getMockedAccount({
       subAccounts: [tokenAccount],
-      aleoResources: { ...mockAleoResources, unspentPrivateRecords: [nativeDecoy] },
+      aleoResources: {
+        ...mockAleoResources,
+        unspentPrivateRecords: [nativeDecoy],
+      },
     });
 
     const result = getRecordByCommitment({
@@ -2261,7 +2312,10 @@ describe("selectPrivateRecordsForAmount", () => {
       microcredits: `${(i + 1) * 10}`,
     }));
 
-    const result = selectPrivateRecordsForAmount({ unspentRecords: records, targetAmount: null });
+    const result = selectPrivateRecordsForAmount({
+      unspentRecords: records,
+      targetAmount: null,
+    });
     const expectedMicrocredits = [...records]
       .sort((a, b) => new BigNumber(b.microcredits).comparedTo(new BigNumber(a.microcredits)))
       .slice(0, MAX_PRIVATE_RECORDS_PER_TRANSACTION)
@@ -2271,7 +2325,10 @@ describe("selectPrivateRecordsForAmount", () => {
   });
 
   it("should return empty array when targetAmount is null and input is empty", () => {
-    const result = selectPrivateRecordsForAmount({ unspentRecords: [], targetAmount: null });
+    const result = selectPrivateRecordsForAmount({
+      unspentRecords: [],
+      targetAmount: null,
+    });
 
     expect(result).toEqual([]);
   });
@@ -2391,10 +2448,16 @@ describe("selectPrivateRecordsForAmount", () => {
     const unspentRecords = [{ ...mockUnspentRecord1, microcredits: "100" }];
 
     expect(
-      selectPrivateRecordsForAmount({ unspentRecords, targetAmount: new BigNumber(0) }),
+      selectPrivateRecordsForAmount({
+        unspentRecords,
+        targetAmount: new BigNumber(0),
+      }),
     ).toEqual([]);
     expect(
-      selectPrivateRecordsForAmount({ unspentRecords, targetAmount: new BigNumber(-1) }),
+      selectPrivateRecordsForAmount({
+        unspentRecords,
+        targetAmount: new BigNumber(-1),
+      }),
     ).toEqual([]);
   });
 
@@ -2533,6 +2596,58 @@ describe("sumPrivateRecords", () => {
       { ...mockUnspentRecord1, microcredits: "58" },
     ];
     expect(sumPrivateRecords(records).isEqualTo(new BigNumber(100))).toBe(true);
+  });
+});
+
+describe("getMaxPrivateRecordsForAccount", () => {
+  it("returns 14 for a native Aleo account", () => {
+    expect(getMaxPrivateRecordsForAccount(getMockedAccount())).toBe(14);
+  });
+
+  it("returns 13 for an Aleo token account", () => {
+    expect(getMaxPrivateRecordsForAccount(getMockedTokenAccount())).toBe(13);
+  });
+});
+
+describe("getStrategyConfig", () => {
+  it("returns fast/balanced/full boundaries for a native account", () => {
+    expect(getStrategyConfig(getMockedAccount())).toEqual({
+      fast: { min: 1, max: 4 },
+      balanced: { min: 5, max: 8 },
+      full: { min: 9, max: 14 },
+    });
+  });
+
+  it("caps the full tier at 13 for a token account", () => {
+    expect(getStrategyConfig(getMockedTokenAccount())).toEqual({
+      fast: { min: 1, max: 4 },
+      balanced: { min: 5, max: 8 },
+      full: { min: 9, max: 13 },
+    });
+  });
+});
+
+describe("isAleoAccount", () => {
+  it("returns true for a native Aleo account", () => {
+    expect(isAleoAccount(getMockedAccount())).toBe(true);
+  });
+
+  it("returns true for an Aleo token account", () => {
+    expect(isAleoAccount(getMockedTokenAccount())).toBe(true);
+  });
+
+  it("returns false for an account of another family", () => {
+    const nonAleoAccount = getMockedAccount({
+      currency: { ...getMockedCurrency(), family: "bitcoin" },
+    });
+    expect(isAleoAccount(nonAleoAccount)).toBe(false);
+  });
+
+  it("returns false instead of throwing for a token account with an unregistered parentCurrencyId", () => {
+    const unknownTokenAccount = getMockedTokenAccount(undefined, {
+      token: { ...getMockedTokenCurrency(), parentCurrencyId: "unregistered_currency_id" },
+    });
+    expect(isAleoAccount(unknownTokenAccount)).toBe(false);
   });
 });
 

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -1,8 +1,15 @@
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
 import { log } from "@ledgerhq/logs";
+import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import type { Account, Operation, OperationType, TokenAccount } from "@ledgerhq/types-live";
+import type {
+  Account,
+  AccountLike,
+  Operation,
+  OperationType,
+  TokenAccount,
+} from "@ledgerhq/types-live";
 import type {
   Operation as CoinFrameworkOperation,
   MemoNotSupported,
@@ -18,7 +25,9 @@ import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { promiseAllBatched } from "@ledgerhq/live-promise";
 import aleoConfig from "../config";
 import {
+  BALANCED_PRIVATE_RECORDS_PER_TRANSACTION,
   EXPLORER_TRANSFER_TYPES,
+  FAST_PRIVATE_RECORDS_PER_TRANSACTION,
   MAX_PRIVATE_RECORDS_PER_TRANSACTION,
   MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION,
   PROGRAM_ID,
@@ -45,6 +54,8 @@ import type {
   AleoCoinConfig,
   AleoUnspentRecord,
   AleoTransactionIntent,
+  SigningStrategy,
+  StrategyConfig,
 } from "../types";
 
 const MICROCREDITS_REGEX = /^(\d+)u\d+$/;
@@ -980,6 +991,37 @@ export function sumPrivateRecords(records: AleoUnspentRecord[]): BigNumber {
   );
 }
 
+export function getMaxPrivateRecordsForAccount(account: AleoAccount | AleoTokenAccount): number {
+  return account.type === "TokenAccount"
+    ? MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION
+    : MAX_PRIVATE_RECORDS_PER_TRANSACTION;
+}
+
+export function getStrategyConfig(
+  account: AleoAccount | AleoTokenAccount,
+): Record<SigningStrategy, StrategyConfig> {
+  const maxRecords = getMaxPrivateRecordsForAccount(account);
+
+  return {
+    fast: { min: 1, max: FAST_PRIVATE_RECORDS_PER_TRANSACTION },
+    balanced: {
+      min: FAST_PRIVATE_RECORDS_PER_TRANSACTION + 1,
+      max: BALANCED_PRIVATE_RECORDS_PER_TRANSACTION,
+    },
+    full: {
+      min: BALANCED_PRIVATE_RECORDS_PER_TRANSACTION + 1,
+      max: maxRecords,
+    },
+  };
+}
+
+export function isAleoAccount(acc: AccountLike): acc is AleoAccount | AleoTokenAccount {
+  if (acc.type === "Account") {
+    return acc.currency.family === "aleo";
+  }
+  return findCryptoCurrencyById(acc.token.parentCurrencyId)?.family === "aleo";
+}
+
 export const getNextSequenceNumber = (account: AleoAccount): BigNumber => {
   const pendingSequenceNumbers = account.pendingOperations
     .map(op => op.transactionSequenceNumber)
@@ -1124,6 +1166,11 @@ export async function getCalTokens({
   });
 
   return calTokens;
+}
+
+/** Narrows any cross-family transaction shape down to Aleo's own `Transaction` type. */
+export function isAleoTransaction(tx: { family: string }): tx is Transaction {
+  return tx.family === "aleo";
 }
 
 export function isAleoAddressPlaintext(v: string): boolean {

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -87,3 +87,10 @@ export interface SignedAleoTransaction {
   authorization: string;
   feeAuthorization: string | null;
 }
+
+export type SigningStrategy = "fast" | "balanced" | "full";
+
+export interface StrategyConfig {
+  min: number;
+  max: number;
+}

--- a/libs/ledger-live-common/src/families/aleo/react.test.ts
+++ b/libs/ledger-live-common/src/families/aleo/react.test.ts
@@ -7,14 +7,21 @@ import { renderHook, act } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import { Subject } from "rxjs";
+import BigNumber from "bignumber.js";
 import type { Account } from "@ledgerhq/types-live";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import type { AleoAccount } from "./types";
+import type { Transaction } from "../../generated/types";
+import type { AleoAccount, AleoUnspentRecord } from "./types";
 import { aleoPrivateSyncProgress$ } from "./privateSyncProgress";
 import { MANDATORY_SYNC_POLLING_DELAY, PROGRESS_THROTTLE_INTERVAL_MS } from "./constants";
-import { useAleoViewKeyApproval, buildAccountsWithViewKeys, useAleoPrivateSync } from "./react";
+import {
+  useAleoViewKeyApproval,
+  buildAccountsWithViewKeys,
+  useAleoPrivateSync,
+  useAleoQuickAmountSelector,
+} from "./react";
 import { ALEO_ACCOUNT_1, makeAleoAccount } from "./__mocks__/account.mock";
 
 const mockCreateAction = jest.fn();
@@ -37,6 +44,7 @@ jest.mock("../../hw/connectApp", () => ({
 }));
 
 jest.mock("./utils", () => ({
+  ...jest.requireActual("./utils"),
   patchAccountWithViewKey: jest.fn((account: Account, viewKey: string) => ({
     ...account,
     id: `${account.id}:patched:${viewKey}`,
@@ -61,7 +69,10 @@ describe("useAleoViewKeyApproval", () => {
     jest.clearAllMocks();
     mockUseHook.mockReturnValue(mockHookState);
     mockMapResult.mockReturnValue(null);
-    mockCreateAction.mockReturnValue({ useHook: mockUseHook, mapResult: mockMapResult });
+    mockCreateAction.mockReturnValue({
+      useHook: mockUseHook,
+      mapResult: mockMapResult,
+    });
   });
 
   it("creates action with connectApp when ldmkConnectApp is disabled", () => {
@@ -77,7 +88,9 @@ describe("useAleoViewKeyApproval", () => {
       }),
     );
 
-    expect(mockConnectApp).toHaveBeenCalledWith({ isLdmkConnectAppEnabled: false });
+    expect(mockConnectApp).toHaveBeenCalledWith({
+      isLdmkConnectAppEnabled: false,
+    });
     expect(mockCreateAction).toHaveBeenCalledWith(mockExec, getViewKeyExec);
   });
 
@@ -94,7 +107,9 @@ describe("useAleoViewKeyApproval", () => {
       }),
     );
 
-    expect(mockConnectApp).toHaveBeenCalledWith({ isLdmkConnectAppEnabled: true });
+    expect(mockConnectApp).toHaveBeenCalledWith({
+      isLdmkConnectAppEnabled: true,
+    });
   });
 
   it("uses provided connectAppExec override instead of default", () => {
@@ -210,7 +225,9 @@ describe("buildAccountsWithViewKeys", () => {
   });
 
   it("skips accounts absent from the view keys map", () => {
-    const result = buildAccountsWithViewKeys([mockAccount1, mockAccount2], { acc1: "vk1" });
+    const result = buildAccountsWithViewKeys([mockAccount1, mockAccount2], {
+      acc1: "vk1",
+    });
 
     expect(result).toEqual([expect.objectContaining({ id: "acc1:patched:vk1" })]);
   });
@@ -238,11 +255,16 @@ interface TestState {
 
 function accountsTestReducer(
   state: TestState = { accounts: [] },
-  action: { type: string; payload?: { accountId: string; updater: (a: Account) => Account } },
+  action: {
+    type: string;
+    payload?: { accountId: string; updater: (a: Account) => Account };
+  },
 ): TestState {
   if (action.type === "UPDATE_ACCOUNT" && action.payload) {
     const { accountId, updater } = action.payload;
-    return { accounts: state.accounts.map(a => (a.id === accountId ? updater(a) : a)) };
+    return {
+      accounts: state.accounts.map(a => (a.id === accountId ? updater(a) : a)),
+    };
   }
   return state;
 }
@@ -376,7 +398,9 @@ describe("useAleoPrivateSync", () => {
       });
 
       expect(result.current.isSyncing).toBe(false);
-      expect(result.current.error).toMatchObject({ message: "network failure" });
+      expect(result.current.error).toMatchObject({
+        message: "network failure",
+      });
     });
 
     it("should clear error when start() is called again after an error", async () => {
@@ -540,7 +564,9 @@ describe("useAleoPrivateSync", () => {
     });
 
     it("should not call sync for a non-Aleo account", async () => {
-      const nonAleoAccount = genAccount("btc-1", { currency: getCryptoCurrencyById("bitcoin") });
+      const nonAleoAccount = genAccount("btc-1", {
+        currency: getCryptoCurrencyById("bitcoin"),
+      });
       const { result } = renderAleoPrivateSync(() =>
         useTestAleoPrivateSync({ account: nonAleoAccount }),
       );
@@ -673,7 +699,10 @@ describe("useAleoPrivateSync", () => {
 
       const { result, rerender } = renderAleoPrivateSync(
         ({ cb }: { cb: typeof first }) =>
-          useTestAleoPrivateSync({ account: makeAleoAccount(), onAccountUpdated: cb }),
+          useTestAleoPrivateSync({
+            account: makeAleoAccount(),
+            onAccountUpdated: cb,
+          }),
         { initialProps: { cb: first } },
       );
 
@@ -704,7 +733,10 @@ describe("useAleoPrivateSync", () => {
       });
 
       act(() => {
-        aleoPrivateSyncProgress$.next({ accountId: "different-account-id", progress: 60 });
+        aleoPrivateSyncProgress$.next({
+          accountId: "different-account-id",
+          progress: 60,
+        });
         jest.advanceTimersByTime(PROGRESS_THROTTLE_INTERVAL_MS + 100);
       });
 
@@ -721,7 +753,10 @@ describe("useAleoPrivateSync", () => {
       });
 
       act(() => {
-        aleoPrivateSyncProgress$.next({ accountId: account.id, progress: null });
+        aleoPrivateSyncProgress$.next({
+          accountId: account.id,
+          progress: null,
+        });
         jest.advanceTimersByTime(PROGRESS_THROTTLE_INTERVAL_MS + 100);
       });
 
@@ -888,7 +923,12 @@ describe("useAleoPrivateSync", () => {
       const onAccountUpdated = jest.fn();
       const account = makeAleoAccount();
       const { result, unmount } = renderAleoPrivateSync(
-        () => useTestAleoPrivateSync({ account, keepAliveOnUnmount: true, onAccountUpdated }),
+        () =>
+          useTestAleoPrivateSync({
+            account,
+            keepAliveOnUnmount: true,
+            onAccountUpdated,
+          }),
         { initialState: { accounts: [account] } },
       );
 
@@ -912,7 +952,12 @@ describe("useAleoPrivateSync", () => {
       const initialState = { accounts: [account] };
 
       const { result: first, unmount } = renderAleoPrivateSync(
-        () => useTestAleoPrivateSync({ account, keepAliveOnUnmount: true, autoStart: true }),
+        () =>
+          useTestAleoPrivateSync({
+            account,
+            keepAliveOnUnmount: true,
+            autoStart: true,
+          }),
         { initialState },
       );
       const stop = first.current.stop;
@@ -932,7 +977,12 @@ describe("useAleoPrivateSync", () => {
 
       // Remount — should pick up isSyncing=true and progress=55 from registry
       const { result: second } = renderAleoPrivateSync(
-        () => useTestAleoPrivateSync({ account, keepAliveOnUnmount: true, autoStart: true }),
+        () =>
+          useTestAleoPrivateSync({
+            account,
+            keepAliveOnUnmount: true,
+            autoStart: true,
+          }),
         { initialState },
       );
 
@@ -949,7 +999,12 @@ describe("useAleoPrivateSync", () => {
       const onAccountUpdated = jest.fn();
       const account = makeAleoAccount();
       const { result, unmount } = renderAleoPrivateSync(
-        () => useTestAleoPrivateSync({ account, keepAliveOnUnmount: true, onAccountUpdated }),
+        () =>
+          useTestAleoPrivateSync({
+            account,
+            keepAliveOnUnmount: true,
+            onAccountUpdated,
+          }),
         { initialState: { accounts: [account] } },
       );
 
@@ -1015,7 +1070,12 @@ describe("useAleoPrivateSync", () => {
 
       // Remount with autoStart: no live registry entry, so a fresh sync is started
       const { result: second } = renderAleoPrivateSync(
-        () => useTestAleoPrivateSync({ account, keepAliveOnUnmount: true, autoStart: true }),
+        () =>
+          useTestAleoPrivateSync({
+            account,
+            keepAliveOnUnmount: true,
+            autoStart: true,
+          }),
         { initialState },
       );
 
@@ -1050,7 +1110,12 @@ describe("useAleoPrivateSync", () => {
 
       // Remount with autoStart: no live registry entry, so a fresh sync is started
       const { result: second } = renderAleoPrivateSync(
-        () => useTestAleoPrivateSync({ account, keepAliveOnUnmount: true, autoStart: true }),
+        () =>
+          useTestAleoPrivateSync({
+            account,
+            keepAliveOnUnmount: true,
+            autoStart: true,
+          }),
         { initialState },
       );
 
@@ -1094,7 +1159,12 @@ describe("useAleoPrivateSync", () => {
       const onAccountUpdated = jest.fn();
       const account = makeAleoAccount();
       const { result, unmount } = renderAleoPrivateSync(
-        () => useTestAleoPrivateSync({ account, keepAliveOnUnmount: true, onAccountUpdated }),
+        () =>
+          useTestAleoPrivateSync({
+            account,
+            keepAliveOnUnmount: true,
+            onAccountUpdated,
+          }),
         { initialState: { accounts: [account] } },
       );
 
@@ -1149,7 +1219,10 @@ describe("useAleoPrivateSync", () => {
 
       // A keepAlive instance emits progress=100; liveAccount already has lastPrivateSyncDate
       act(() => {
-        aleoPrivateSyncProgress$.next({ accountId: syncedAccount.id, progress: 100 });
+        aleoPrivateSyncProgress$.next({
+          accountId: syncedAccount.id,
+          progress: 100,
+        });
         jest.advanceTimersByTime(PROGRESS_THROTTLE_INTERVAL_MS + 100);
       });
 
@@ -1209,9 +1282,171 @@ describe("useAleoPrivateSync", () => {
       expect(onAccountUpdated).toHaveBeenCalledTimes(1);
       expect(onAccountUpdated).toHaveBeenCalledWith(
         expect.objectContaining({
-          aleoResources: expect.objectContaining({ lastPrivateSyncDate: syncDate }),
+          aleoResources: expect.objectContaining({
+            lastPrivateSyncDate: syncDate,
+          }),
         }),
       );
     });
+  });
+});
+
+function makeRecord(microcredits: string): AleoUnspentRecord {
+  return { microcredits } as unknown as AleoUnspentRecord;
+}
+
+function makeAccountWithRecords(records: AleoUnspentRecord[]): AleoAccount {
+  return {
+    ...ALEO_ACCOUNT_1,
+    aleoResources: {
+      transparentBalance: new BigNumber(0),
+      privateBalance: new BigNumber(0),
+      unspentPrivateRecords: records,
+      provableApi: null,
+      lastPrivateSyncDate: null,
+    },
+  } as AleoAccount;
+}
+
+function makePrivateTransaction(overrides?: Record<string, unknown>): Transaction {
+  return {
+    family: "aleo",
+    mode: "transfer_private",
+    amount: new BigNumber(0),
+    useAllAmount: false,
+    properties: { amountRecordCommitments: [], feeRecordCommitment: null },
+    ...overrides,
+  } as unknown as Transaction;
+}
+
+describe("useAleoQuickAmountSelector", () => {
+  // 16 records, descending: 2000000, 1900000, ... 500000
+  const manyRecords = Array.from({ length: 16 }, (_, i) => makeRecord(`${(20 - i) * 100000}`));
+  // 6 records, descending: 600000 .. 100000
+  const sixRecords = Array.from({ length: 6 }, (_, i) => makeRecord(`${(6 - i) * 100000}`));
+
+  it("throws for an account of another family", () => {
+    const account = {
+      ...makeAccountWithRecords(manyRecords),
+      currency: { ...ALEO_ACCOUNT_1.currency, family: "bitcoin" },
+    };
+    const transaction = makePrivateTransaction();
+
+    expect(() =>
+      renderHook(() =>
+        useAleoQuickAmountSelector({
+          account,
+          transaction,
+          updateTransaction: jest.fn(),
+        }),
+      ),
+    ).toThrow();
+  });
+
+  it("still computes tiles for a public-mode aleo transaction — privacy gating is a caller concern", () => {
+    const account = makeAccountWithRecords(manyRecords);
+    const transaction = makePrivateTransaction({ mode: "transfer_public" });
+
+    const { result } = renderHook(() =>
+      useAleoQuickAmountSelector({
+        account,
+        transaction,
+        updateTransaction: jest.fn(),
+      }),
+    );
+
+    expect(result.current.strategyData).toHaveLength(3);
+    expect(result.current.selectedRecordsCount).toBe(0);
+  });
+
+  it("computes fast/balanced/full tiers from the sorted unspent records", () => {
+    const account = makeAccountWithRecords(manyRecords);
+    const transaction = makePrivateTransaction();
+
+    const { result } = renderHook(() =>
+      useAleoQuickAmountSelector({
+        account,
+        transaction,
+        updateTransaction: jest.fn(),
+      }),
+    );
+
+    expect(result.current.strategyData.map(tile => tile.strategy)).toEqual([
+      "fast",
+      "balanced",
+      "full",
+    ]);
+    expect(result.current.strategyData.map(tile => tile.availableCount)).toEqual([4, 8, 14]);
+    expect(result.current.strategyData.map(tile => tile.rangeSum.toString())).toEqual([
+      "7400000",
+      "13200000",
+      "18900000",
+    ]);
+    expect(result.current.totalSpendableBalance.toString()).toBe("18900000");
+  });
+
+  it("disables tiers past the available record count and marks the last reachable tier as send-max", () => {
+    const account = makeAccountWithRecords(sixRecords);
+    const transaction = makePrivateTransaction();
+
+    const { result } = renderHook(() =>
+      useAleoQuickAmountSelector({
+        account,
+        transaction,
+        updateTransaction: jest.fn(),
+      }),
+    );
+
+    const [fast, balanced, full] = result.current.strategyData;
+    expect(fast.disabled).toBe(false);
+    expect(balanced.disabled).toBe(false);
+    expect(balanced.isSendMax).toBe(true);
+    expect(full.disabled).toBe(true);
+  });
+
+  it("selectStrategy calls updateTransaction with the tier sum for a non-max tile", () => {
+    const account = makeAccountWithRecords(manyRecords);
+    const transaction = makePrivateTransaction();
+    const updateTransaction = jest.fn();
+
+    const { result } = renderHook(() =>
+      useAleoQuickAmountSelector({ account, transaction, updateTransaction }),
+    );
+
+    result.current.selectStrategy(result.current.strategyData[0]);
+
+    expect(updateTransaction).toHaveBeenCalledTimes(1);
+    const updated = updateTransaction.mock.calls[0][0](transaction);
+    expect(updated.useAllAmount).toBe(false);
+    expect((updated.amount as BigNumber).toString()).toBe("7400000");
+  });
+
+  it("selectStrategy calls updateTransaction with useAllAmount for the capped full tile", () => {
+    const account = makeAccountWithRecords(manyRecords);
+    const transaction = makePrivateTransaction();
+    const updateTransaction = jest.fn();
+
+    const { result } = renderHook(() =>
+      useAleoQuickAmountSelector({ account, transaction, updateTransaction }),
+    );
+
+    result.current.selectStrategy(result.current.strategyData[2]);
+
+    const updated = updateTransaction.mock.calls[0][0](transaction);
+    expect(updated.useAllAmount).toBe(true);
+  });
+
+  it("selectStrategy does nothing for a disabled tile", () => {
+    const account = makeAccountWithRecords(sixRecords);
+    const transaction = makePrivateTransaction();
+    const updateTransaction = jest.fn();
+
+    const { result } = renderHook(() =>
+      useAleoQuickAmountSelector({ account, transaction, updateTransaction }),
+    );
+
+    result.current.selectStrategy(result.current.strategyData[2]);
+
+    expect(updateTransaction).not.toHaveBeenCalled();
   });
 });

--- a/libs/ledger-live-common/src/families/aleo/react.ts
+++ b/libs/ledger-live-common/src/families/aleo/react.ts
@@ -1,11 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDispatch, useSelector, useStore } from "react-redux";
+import BigNumber from "bignumber.js";
+import invariant from "invariant";
 import { useFeature } from "@features/platform-feature-flags";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { SYNC_TYPE_SHIELDED } from "@ledgerhq/types-live";
-import type { Account } from "@ledgerhq/types-live";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type Transport from "@ledgerhq/hw-transport";
 import { asyncScheduler, from, mergeMap, throttleTime, type Observable } from "rxjs";
+import type { Transaction } from "../../generated/types";
 import type { ConnectAppEvent, Input as ConnectAppInput } from "../../hw/connectApp";
 import connectApp from "../../hw/connectApp";
 import type { Device } from "../../hw/actions/types";
@@ -17,10 +20,160 @@ import {
   type ViewKeyProgress,
   type ViewKeysByAccountId,
 } from "./hw/getViewKey/index";
-import { patchAccountWithViewKey } from "./utils";
-import type { AleoAccount } from "./types";
+import {
+  getStrategyConfig,
+  isAleoAccount,
+  isAleoTransaction,
+  isPrivateTransaction,
+  patchAccountWithViewKey,
+  sumPrivateRecords,
+} from "./utils";
+import type { AleoAccount, AleoTokenAccount, AleoUnspentRecord, SigningStrategy } from "./types";
 import { aleoPrivateSyncProgress$ } from "./privateSyncProgress";
 import { MANDATORY_SYNC_POLLING_DELAY, PROGRESS_THROTTLE_INTERVAL_MS } from "./constants";
+
+const QUICK_AMOUNT_STRATEGIES: SigningStrategy[] = ["fast", "balanced", "full"];
+
+interface QuickAmountStrategyTile {
+  strategy: SigningStrategy;
+  min: number;
+  max: number;
+  availableCount: number;
+  rangeSum: BigNumber;
+  disabled: boolean;
+  selected: boolean;
+  isSendMax: boolean;
+}
+
+export interface UseAleoQuickAmountSelectorResult {
+  /** Narrowed from the input `AccountLike` — safe to pass to Aleo-only components. */
+  account: AleoAccount | AleoTokenAccount;
+  strategyData: QuickAmountStrategyTile[];
+  totalSpendableBalance: BigNumber;
+  selectedRecordsCount: number;
+  selectStrategy: (tile: QuickAmountStrategyTile) => void;
+}
+
+function getUnspentPrivateRecords(account: AleoAccount | AleoTokenAccount): AleoUnspentRecord[] {
+  return (
+    (account.type === "TokenAccount"
+      ? account.unspentPrivateRecords
+      : account.aleoResources?.unspentPrivateRecords) ?? []
+  );
+}
+
+/**
+ * Derives the fast/balanced/full quick-amount tiles for an Aleo account's private records,
+ * shared between the desktop and mobile QuickAmountSelector components so only rendering
+ * differs. Whether the widget should be shown for the current transaction mode is up to callers.
+ *
+ * Only meant to be called from the Aleo send flow — throws if `account` isn't an Aleo account.
+ */
+export function useAleoQuickAmountSelector({
+  account,
+  transaction,
+  updateTransaction,
+}: {
+  account: AccountLike;
+  transaction: Transaction;
+  updateTransaction: (updater: (t: Transaction) => Transaction) => void;
+}): UseAleoQuickAmountSelectorResult {
+  const sortedRecords = useMemo(() => {
+    if (!isAleoAccount(account)) return [];
+    return getUnspentPrivateRecords(account)
+      .filter(r => new BigNumber(r.microcredits).isGreaterThan(0))
+      .sort((a, b) => new BigNumber(b.microcredits).comparedTo(a.microcredits));
+  }, [account]);
+
+  const strategyConfig = useMemo(
+    () => (isAleoAccount(account) ? getStrategyConfig(account) : null),
+    [account],
+  );
+
+  const totalRecords = sortedRecords.length;
+
+  const totalSpendableBalance = useMemo(
+    () =>
+      strategyConfig
+        ? sumPrivateRecords(sortedRecords.slice(0, strategyConfig.full.max))
+        : new BigNumber(0),
+    [sortedRecords, strategyConfig],
+  );
+
+  const selectedRecordsCount =
+    isAleoTransaction(transaction) && isPrivateTransaction(transaction)
+      ? (transaction.properties?.amountRecordCommitments.length ?? 0)
+      : 0;
+
+  const strategyData = useMemo(() => {
+    if (!strategyConfig) return [];
+
+    return QUICK_AMOUNT_STRATEGIES.map(strategy => {
+      const { min, max } = strategyConfig[strategy];
+      const rangeRecords = sortedRecords.slice(0, max);
+      const availableCount = rangeRecords.length;
+      const rangeSum = sumPrivateRecords(rangeRecords);
+
+      const disabled = totalRecords < min;
+      const coversAllRecords = availableCount === totalRecords;
+      const isFullTierAtCap = max === strategyConfig.full.max && availableCount === max;
+      const isSendMax = !disabled && (coversAllRecords || isFullTierAtCap);
+
+      const matchesTierRangeSum =
+        !disabled &&
+        !isSendMax &&
+        !rangeSum.isZero() &&
+        transaction.amount.isEqualTo(rangeSum) &&
+        !transaction.useAllAmount;
+      const selected =
+        !disabled && (isSendMax ? transaction.useAllAmount === true : matchesTierRangeSum);
+
+      return {
+        strategy,
+        min,
+        max,
+        availableCount,
+        rangeSum,
+        disabled,
+        selected,
+        isSendMax,
+      };
+    });
+  }, [sortedRecords, totalRecords, transaction.amount, transaction.useAllAmount, strategyConfig]);
+
+  const selectStrategy = useCallback(
+    (tile: QuickAmountStrategyTile) => {
+      if (tile.disabled) return;
+      if (tile.isSendMax) {
+        updateTransaction(tx => ({
+          ...tx,
+          useAllAmount: true,
+          amount: new BigNumber(0),
+        }));
+      } else {
+        updateTransaction(tx => ({
+          ...tx,
+          amount: tile.rangeSum,
+          useAllAmount: false,
+        }));
+      }
+    },
+    [updateTransaction],
+  );
+
+  invariant(
+    isAleoAccount(account),
+    "aleo: useAleoQuickAmountSelector called with a non-Aleo account",
+  );
+
+  return {
+    account,
+    strategyData,
+    totalSpendableBalance,
+    selectedRecordsCount,
+    selectStrategy,
+  };
+}
 
 type ConnectAppExec = (input: ConnectAppInput) => Observable<ConnectAppEvent>;
 type GetViewKeyExec = (transport: Transport, request: Request) => Observable<ViewKeyProgress>;
@@ -72,7 +225,13 @@ export function useAleoViewKeyApproval({
     return { confirmedAccountIds: confirmed, rejectedAccountIds: rejected };
   }, [hookState.shareProgress.viewKeys]);
 
-  return { hookState, payload, request, confirmedAccountIds, rejectedAccountIds };
+  return {
+    hookState,
+    payload,
+    request,
+    confirmedAccountIds,
+    rejectedAccountIds,
+  };
 }
 
 export function buildAccountsWithViewKeys(
@@ -85,10 +244,6 @@ export function buildAccountsWithViewKeys(
     acc.push(patchAccountWithViewKey(account, viewKey));
     return acc;
   }, []);
-}
-
-function isAleoAccount(acc: Account): acc is AleoAccount {
-  return acc.currency.family === "aleo";
 }
 
 /**
@@ -206,7 +361,10 @@ export const useAleoPrivateSync = ({
     const sub = from(Promise.resolve(getAccountBridge(acc)))
       .pipe(
         mergeMap(bridge =>
-          bridge.sync(acc, { paginationConfig: {}, syncType: SYNC_TYPE_SHIELDED }),
+          bridge.sync(acc, {
+            paginationConfig: {},
+            syncType: SYNC_TYPE_SHIELDED,
+          }),
         ),
       )
       .subscribe({
@@ -292,7 +450,9 @@ export const useAleoPrivateSync = ({
       // Subscribe to the Redux store so we can cancel the sync if the account
       // is deleted while the component is unmounted.
       const storeUnsubscribe = store.subscribe(() => {
-        const found = accountSelectorRef.current(store.getState(), { accountId: id });
+        const found = accountSelectorRef.current(store.getState(), {
+          accountId: id,
+        });
         if (!found) {
           const entry = keepAliveRegistry.get(id);
           if (entry) {
@@ -302,7 +462,12 @@ export const useAleoPrivateSync = ({
           }
         }
       });
-      keepAliveRegistry.set(id, { isSyncing: true, progress: 0, sub: null, storeUnsubscribe });
+      keepAliveRegistry.set(id, {
+        isSyncing: true,
+        progress: 0,
+        sub: null,
+        storeUnsubscribe,
+      });
     }
     runSync();
   }, [runSync, store]);


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Add the Aleo private-send quick amount selector (Fast/Balanced/Full record tiers, spendable balance summary, and records-per-send info banner) to the mobile Amount screen, matching desktop. Extracts the shared tier-selection logic into `@ledgerhq/coin-aleo` so both platforms use the same Fast/Balanced/Full boundaries.

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-30496
