### PR TITLE
[LWM] fix: analytics chart header label, scrub state, and tooltip

### DIFF
--- a/.changeset/lwm-analytics-chart-header-fixes.md
+++ b/.changeset/lwm-analytics-chart-header-fixes.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Analytics chart header to show Total balance label, scaled cents, scrub-driven balance and date updates, and remove the chart scrubber tooltip.

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/utils/__tests__/buildChartDateFormatters.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/utils/__tests__/buildChartDateFormatters.test.ts
@@ -1,0 +1,19 @@
+import { buildChartDateFormatters } from "../buildChartDateFormatters";
+
+describe("buildChartDateFormatters", () => {
+  const timestamp = new Date("2026-06-28T14:30:00Z").getTime();
+  const formatters = buildChartDateFormatters("en-US");
+
+  it("formats axis dates with time for the 1d range", () => {
+    expect(formatters.formatAxisDate(timestamp, "1d")).toMatch(/\d/);
+    expect(formatters.formatAxisDate(timestamp, "1d")).not.toBe(
+      formatters.formatAxisDate(timestamp, "1w"),
+    );
+  });
+
+  it("formats scrub header dates with time and date for mid-length ranges", () => {
+    const scrubLabel = formatters.formatScrubHeaderDate(timestamp, "1w");
+    expect(scrubLabel).toMatch(/\d/);
+    expect(scrubLabel).not.toBe(formatters.formatScrubHeaderDate(timestamp, "1y"));
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/LineChart/utils/buildChartDateFormatters.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/LineChart/utils/buildChartDateFormatters.ts
@@ -1,0 +1,31 @@
+const HOVER_RANGE_WITH_TIME_AND_DATE = new Set(["1w", "1m", "6m"]);
+
+export type ChartDateFormatters = Readonly<{
+  formatAxisDate: (timestamp: number, range: string) => string;
+  formatScrubHeaderDate: (timestamp: number, range: string) => string;
+}>;
+
+export function buildChartDateFormatters(locale: string): ChartDateFormatters {
+  const hour = new Intl.DateTimeFormat(locale, { hour: "numeric", minute: "numeric" });
+  const day = new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "numeric",
+    year: "numeric",
+  });
+  const dateTime = new Intl.DateTimeFormat(locale, {
+    hour: "numeric",
+    minute: "numeric",
+    day: "numeric",
+    month: "numeric",
+    year: "numeric",
+  });
+
+  return {
+    formatAxisDate: (timestamp, range) => (range === "1d" ? hour : day).format(new Date(timestamp)),
+    formatScrubHeaderDate: (timestamp, range) => {
+      if (range === "1d") return hour.format(new Date(timestamp));
+      if (HOVER_RANGE_WITH_TIME_AND_DATE.has(range)) return dateTime.format(new Date(timestamp));
+      return day.format(new Date(timestamp));
+    },
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/TrendSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TrendSection/index.tsx
@@ -32,7 +32,7 @@ export function TrendSection({
 
   return (
     <Box lx={rowStyle} testID={testID}>
-      {showTrend && <Trend value={percentage} size={trendSize} />}
+      {showTrend && <Trend size={trendSize} value={percentage} />}
       {formattedChange != null && (
         <Text typography="body2" lx={{ color: "muted" }}>
           {formattedChange}

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/index.tsx
@@ -4,6 +4,7 @@ import { useAnalyticsBalanceDisplayViewModel } from "./useAnalyticsBalanceDispla
 
 type Props = {
   hoveredValue?: number | null;
+  animate?: boolean;
 };
 
 /**
@@ -16,7 +17,7 @@ type Props = {
  * value is shown instead of the portfolio balance, and the loading indicator is
  * suppressed because a historical value is already resolved.
  */
-export function AnalyticsBalanceDisplay({ hoveredValue }: Readonly<Props>) {
+export function AnalyticsBalanceDisplay({ hoveredValue, animate = true }: Readonly<Props>) {
   const { value, formatter, discreet, isHovering, isLoading, isBalanceAvailable } =
     useAnalyticsBalanceDisplayViewModel({ hoveredValue });
 
@@ -30,6 +31,8 @@ export function AnalyticsBalanceDisplay({ hoveredValue }: Readonly<Props>) {
       formatter={formatter}
       hidden={discreet}
       loading={!isHovering && isLoading}
+      size="md"
+      animate={animate}
       testID="analytics-balance-amount"
     />
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/ChartSectionHeaderView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/ChartSectionHeaderView.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { useTranslation } from "~/context/Locale";
 import { TrendSection } from "LLM/components/TrendSection";
 import { AnalyticsBalanceDisplay } from "LLM/features/Analytics/components/AnalyticsBalanceDisplay";
 import { CHART_SECTION_TEST_IDS, type ChartSectionHeaderViewModel } from "./types";
@@ -10,8 +11,10 @@ type Props = Readonly<{
 }>;
 
 export function ChartSectionHeaderView({ viewModel }: Props) {
+  const { t } = useTranslation();
   const {
     hoveredBalance,
+    scrubDateLabel,
     isBalanceAvailable,
     percentageValue,
     variationText,
@@ -19,14 +22,23 @@ export function ChartSectionHeaderView({ viewModel }: Props) {
     discreet,
   } = viewModel;
 
+  const isScrubbing = scrubDateLabel != null;
+
   return (
     <Box lx={headerStyle} testID={CHART_SECTION_TEST_IDS.header}>
-      <AnalyticsBalanceDisplay hoveredValue={hoveredBalance} />
+      <Text
+        typography="body2"
+        lx={{ color: "muted" }}
+        testID={CHART_SECTION_TEST_IDS.totalBalanceLabel}
+      >
+        {t("portfolio.totalBalance")}
+      </Text>
+      <AnalyticsBalanceDisplay hoveredValue={hoveredBalance} animate={!isScrubbing} />
       {isBalanceAvailable && (
         <TrendSection
           percentage={percentageValue}
           formattedChange={variationText}
-          timeLabel={rangeLabel}
+          timeLabel={scrubDateLabel ?? rangeLabel}
           testID={CHART_SECTION_TEST_IDS.trend}
           trendSize="sm"
           showTrend={!discreet}

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/ChartSectionView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/ChartSectionView.tsx
@@ -2,12 +2,24 @@ import React from "react";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { LineChart } from "LLM/components/LineChart";
+import type { LineChartProps } from "LLM/components/LineChart";
+import type { AnalyticsChartRange } from "@ledgerhq/wallet-analytics";
 import { ChartSectionHeaderView } from "./ChartSectionHeaderView";
 import { CHART_SECTION_TEST_IDS, type ChartSectionViewModel } from "./types";
 
 type Props = Readonly<{
   viewModel: ChartSectionViewModel;
 }>;
+
+/**
+ * Memoized chart subtree. The header re-renders on every scrub frame; keeping
+ * the chart props stable avoids resetting the Lumen scrubber mid-gesture.
+ */
+const ChartSectionChart = React.memo(function ChartSectionChart(
+  props: LineChartProps<AnalyticsChartRange>,
+) {
+  return <LineChart {...props} />;
+});
 
 export function ChartSectionView({ viewModel }: Props) {
   const { header, chart } = viewModel;
@@ -16,7 +28,7 @@ export function ChartSectionView({ viewModel }: Props) {
     <Box lx={containerStyle} testID={CHART_SECTION_TEST_IDS.root}>
       <ChartSectionHeaderView viewModel={header} />
       <Box lx={chartContainerStyle}>
-        <LineChart {...chart} />
+        <ChartSectionChart {...chart} />
       </Box>
     </Box>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/ChartSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/ChartSection.test.tsx
@@ -40,6 +40,9 @@ describe("ChartSection", () => {
 
     expect(screen.getByTestId(CHART_SECTION_TEST_IDS.root)).toBeVisible();
     expect(screen.getByTestId(CHART_SECTION_TEST_IDS.header)).toBeVisible();
+    expect(screen.getByTestId(CHART_SECTION_TEST_IDS.totalBalanceLabel)).toHaveTextContent(
+      "Total balance",
+    );
     expect(screen.getByTestId("analytics-balance-amount")).toBeVisible();
     expect(screen.getByTestId(CHART_SECTION_TEST_IDS.trend)).toBeVisible();
     expect(screen.getByTestId("analytics-chart")).toBeVisible();

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/useChartSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/useChartSectionViewModel.test.ts
@@ -29,7 +29,9 @@ describe("useChartSectionViewModel", () => {
     expect(result.current.chart.series[0].data).toEqual([1000, 1200]);
     expect(result.current.chart.selectedRange).toBe("1w");
     expect(result.current.header.hoveredBalance).toBeNull();
+    expect(result.current.header.scrubDateLabel).toBeUndefined();
     expect(result.current.header.isBalanceAvailable).toBe(true);
+    expect(result.current.chart.showScrubberTooltip).toBe(false);
   });
 
   it("uses balance availability for the chart loading state", () => {
@@ -105,19 +107,42 @@ describe("useChartSectionViewModel", () => {
     expect(result.current.header.variationText).toBe("***");
   });
 
-  it("updates hoveredBalance when scrubbing the chart", () => {
+  it("updates hovered balance, scrub date, and range variation when scrubbing the chart", () => {
     const { result } = renderHook(() => useChartSectionViewModel(), {
       overrideInitialState: chartSectionInitialState,
     });
+
+    expect(result.current.header.variationText).toBe("+$2.00");
+    expect(result.current.header.percentageValue).toBe(20);
 
     act(() => {
       result.current.chart.onScrubberPositionChange?.(0);
     });
     expect(result.current.header.hoveredBalance).toBe(1000);
+    expect(result.current.header.scrubDateLabel).toBeDefined();
+    expect(result.current.header.percentageValue).toBe(0);
+    expect(result.current.header.variationText).toBe("$0.00");
 
     act(() => {
       result.current.chart.onScrubberPositionChange?.(undefined);
     });
     expect(result.current.header.hoveredBalance).toBeNull();
+    expect(result.current.header.scrubDateLabel).toBeUndefined();
+    expect(result.current.header.percentageValue).toBe(20);
+    expect(result.current.header.variationText).toBe("+$2.00");
+  });
+
+  it("keeps chart props stable while scrubbing so the chart is not re-rendered", () => {
+    const { result } = renderHook(() => useChartSectionViewModel(), {
+      overrideInitialState: chartSectionInitialState,
+    });
+
+    const chartBeforeScrub = result.current.chart;
+
+    act(() => {
+      result.current.chart.onScrubberPositionChange?.(0);
+    });
+
+    expect(result.current.chart).toBe(chartBeforeScrub);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/types.ts
@@ -3,6 +3,7 @@ import type { AnalyticsChartRange } from "@ledgerhq/wallet-analytics";
 
 export type ChartSectionHeaderViewModel = Readonly<{
   hoveredBalance: number | null;
+  scrubDateLabel: string | undefined;
   isBalanceAvailable: boolean;
   percentageValue: number;
   variationText: string;
@@ -18,5 +19,6 @@ export type ChartSectionViewModel = Readonly<{
 export const CHART_SECTION_TEST_IDS = {
   root: "analytics-chart-section",
   header: "analytics-chart-header",
+  totalBalanceLabel: "analytics-total-balance-label",
   trend: "analytics-balance-trend",
 } as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/useChartSectionViewModel.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import BigNumber from "bignumber.js";
+import { getScrubVariation } from "@ledgerhq/live-common/market/utils/scrubVariation";
 import { useDispatch, useSelector } from "~/context/hooks";
 import { useTranslation, useLocale } from "~/context/Locale";
 import { formatPrice, formatSignedFiatVariation } from "@ledgerhq/live-currency-format";
@@ -20,9 +21,9 @@ import {
   resolveLineChartColorFromPercentChange,
   type LineChartScrubberPositionChange,
   type LineChartSeries,
-  type LineChartTooltipTitle,
   type LineChartValueFormatter,
 } from "LLM/components/LineChart";
+import { buildChartDateFormatters } from "LLM/components/LineChart/utils/buildChartDateFormatters";
 import {
   ANALYTICS_CHART_RANGES,
   isAnalyticsChartRange,
@@ -36,6 +37,8 @@ import {
   buildAnalyticsChartYAxisConfig,
 } from "LLM/features/Analytics/utils/chartAxisConfig";
 import type { ChartSectionViewModel } from "./types";
+
+type ScrubSelection = Readonly<{ balance: number; timestamp: number }>;
 
 export function useChartSectionViewModel(): ChartSectionViewModel {
   const { t } = useTranslation();
@@ -51,7 +54,7 @@ export function useChartSectionViewModel(): ChartSectionViewModel {
 
   const selectedRange = portfolioRangeToLineChartRange(selectedTimeRange);
   const fiatUnit = counterValue.units[0];
-  const [hoveredBalance, setHoveredBalance] = useState<number | null>(null);
+  const [selection, setSelection] = useState<ScrubSelection | undefined>(undefined);
 
   const valueChange = useMemo(
     () =>
@@ -96,75 +99,78 @@ export function useChartSectionViewModel(): ChartSectionViewModel {
     [fiatUnit, locale, discreet],
   );
 
-  const dateFormatters = useMemo(
-    () => ({
-      hour: new Intl.DateTimeFormat(locale, { hour: "numeric", minute: "numeric" }),
-      day: new Intl.DateTimeFormat(locale, {
-        day: "numeric",
-        month: "numeric",
-        year: "numeric",
-      }),
-    }),
-    [locale],
-  );
+  const dateFormatters = useMemo(() => buildChartDateFormatters(locale), [locale]);
 
   const formatDate = useCallback(
-    (timestamp: number) =>
-      (selectedRange === "1d" ? dateFormatters.hour : dateFormatters.day).format(
-        new Date(timestamp),
-      ),
-    [selectedRange, dateFormatters],
+    (timestamp: number) => dateFormatters.formatAxisDate(timestamp, selectedRange),
+    [dateFormatters, selectedRange],
   );
 
-  const tooltipTitle = useMemo<LineChartTooltipTitle>(
-    () => dataIndex => {
-      const timestamp = timestamps[dataIndex];
-      if (timestamp == null) return undefined;
-      return formatDate(timestamp);
-    },
-    [timestamps, formatDate],
-  );
+  const scrubDateLabel =
+    selection != null
+      ? dateFormatters.formatScrubHeaderDate(selection.timestamp, selectedRange)
+      : undefined;
+  const hoveredBalance = selection?.balance ?? null;
 
   const onScrubberPositionChange = useCallback<LineChartScrubberPositionChange>(
     index => {
       if (index == null) {
-        setHoveredBalance(null);
+        setSelection(undefined);
         return;
       }
       const value = prices[index];
-      setHoveredBalance(Number.isFinite(value) ? value : null);
+      const timestamp = timestamps[index];
+      setSelection(
+        Number.isFinite(value) && timestamp != null ? { balance: value, timestamp } : undefined,
+      );
     },
-    [prices],
+    [prices, timestamps],
   );
 
   const onRangeChange = useCallback(
     (range: AnalyticsChartRange) => {
       const portfolioRange = lineChartRangeToPortfolioRange(range);
       if (!portfolioRange || portfolioRange === selectedTimeRange) return;
-      setHoveredBalance(null);
+      setSelection(undefined);
       dispatch(setSelectedTimeRange(portfolioRange));
       track("timeframe_clicked", { timeframe: portfolioRange });
     },
     [dispatch, selectedTimeRange],
   );
 
-  const percentageValue = valueChange.percentage == null ? NaN : valueChange.percentage * 100;
-  const mainUnitValue = new BigNumber(valueChange.value).shiftedBy(-fiatUnit.magnitude).toNumber();
-  const variationText = discreet
-    ? "***"
-    : formatSignedFiatVariation(mainUnitValue, fiatUnit, locale);
+  const rangePercentageValue = valueChange.percentage == null ? NaN : valueChange.percentage * 100;
+  const scrubVariation = useMemo(() => {
+    if (selection == null) return undefined;
+    const baselinePrice = prices[0];
+    if (!Number.isFinite(baselinePrice)) return undefined;
+    return getScrubVariation(baselinePrice, selection.balance, {
+      percentageUnit: "percentPoints",
+    });
+  }, [selection, prices]);
+
+  const percentageValue = scrubVariation?.percentage ?? rangePercentageValue;
+
+  const rangeVariationText = useMemo(() => {
+    if (discreet) return "***";
+    const mainUnitValue = new BigNumber(valueChange.value)
+      .shiftedBy(-fiatUnit.magnitude)
+      .toNumber();
+    return formatSignedFiatVariation(mainUnitValue, fiatUnit, locale);
+  }, [discreet, valueChange.value, fiatUnit, locale]);
+
+  const variationText = useMemo(() => {
+    if (scrubVariation == null) return rangeVariationText;
+    if (discreet) return "***";
+    const mainUnitValue = new BigNumber(scrubVariation.variationFiat)
+      .shiftedBy(-fiatUnit.magnitude)
+      .toNumber();
+    return formatSignedFiatVariation(mainUnitValue, fiatUnit, locale);
+  }, [scrubVariation, rangeVariationText, discreet, fiatUnit, locale]);
+
   const rangeLabel = t(`assetDetail.balanceGraph.timeLabel.${selectedRange}`);
 
-  return {
-    header: {
-      hoveredBalance,
-      isBalanceAvailable,
-      percentageValue,
-      variationText,
-      rangeLabel,
-      discreet,
-    },
-    chart: {
+  const chart = useMemo(
+    (): ChartSectionViewModel["chart"] => ({
       series,
       selectedRange,
       onRangeChange,
@@ -174,14 +180,13 @@ export function useChartSectionViewModel(): ChartSectionViewModel {
       })),
       isRangeValue: isAnalyticsChartRange,
       color: resolveLineChartColorFromPercentChange(
-        valueChange.percentage == null ? undefined : percentageValue,
+        valueChange.percentage == null ? undefined : rangePercentageValue,
       ),
       isLoading: !isBalanceAvailable,
       height: DEFAULT_LINE_CHART_HEIGHT,
       formatValue,
-      tooltipTitle,
       onScrubberPositionChange,
-      showScrubberTooltip: true,
+      showScrubberTooltip: false,
       showScrubberBeacons: false,
       showXAxis: false,
       showYAxis: false,
@@ -190,6 +195,32 @@ export function useChartSectionViewModel(): ChartSectionViewModel {
       points: getExtremaPointMarkers(series),
       accessibilityLabel: t("assetDetail.balanceGraph.timeframeSelector"),
       testID: "analytics-chart",
+    }),
+    [
+      series,
+      selectedRange,
+      onRangeChange,
+      t,
+      valueChange.percentage,
+      rangePercentageValue,
+      isBalanceAvailable,
+      formatValue,
+      onScrubberPositionChange,
+      timestamps,
+      formatDate,
+    ],
+  );
+
+  return {
+    header: {
+      hoveredBalance,
+      scrubDateLabel,
+      isBalanceAvailable,
+      percentageValue,
+      variationText,
+      rangeLabel,
+      discreet,
     },
+    chart,
   };
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

This pull request updates the Analytics chart header in the mobile app to improve clarity and user experience. The main changes ensure that the chart header always displays a "Total balance" label, shows the correct balance and date while scrubbing, formats dates more intuitively for different ranges, and removes the chart scrubber tooltip. These improvements also include refactoring and more robust tests.

**Analytics Chart Header Improvements:**
* The header now always displays a "Total balance" label above the balance, and dynamically shows the correct balance and date when the user scrubs the chart. The balance animation is disabled during scrubbing for clarity.
* The chart scrubber tooltip is removed (`showScrubberTooltip: false`), simplifying the UI. 

**Date Formatting Enhancements:**
* Introduced a new utility, `buildChartDateFormatters`, to format axis and scrub header dates based on the selected range, improving date display consistency and clarity. 

**Component and State Refactoring:**
* Refactored state management to track both hovered balance and timestamp as a selection object, enabling accurate display of both value and date during scrubbing.
* Updated `AnalyticsBalanceDisplay` to accept an `animate` prop, allowing animation to be toggled off during scrubbing for a better user experience.

**Testing Improvements:**
* Enhanced and added tests to cover the new header label, scrub date display, and the removal of the scrubber tooltip.


https://github.com/user-attachments/assets/56e0c917-3630-4ad0-89b6-b56c5ef40169


### 🔗 Context

[LIVE-34303](https://ledgerhq.atlassian.net/browse/LIVE-34303)


[LIVE-34303]: https://ledgerhq.atlassian.net/browse/LIVE-34303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ