### PR TITLE
[LWDM] feat(coin-tezos): add getAccountInfo returning account revealed state

### DIFF
--- a/.changeset/tezos-baker-delegate-account-support.md
+++ b/.changeset/tezos-baker-delegate-account-support.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": patch
+---
+
+Fix: handle registered baker (tzkt `type: "delegate"`) accounts. Previously only `user` accounts were recognized, so a baker address reported a zero balance, no staking positions, an incorrect reveal state and next-sequence, and failed transaction validation. Account reads and manager-key logic now gate on a shared `hasManagerKey` guard covering both `user` and `delegate`.

--- a/.changeset/tezos-get-account-info.md
+++ b/.changeset/tezos-get-account-info.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": minor
+---
+
+Add `getAccountInfo` to the Tezos coin module API, exposing the account's on-chain reveal state (`{ type: "tezos", revealed: boolean }`). The reveal state was previously only computed internally inside `craftTransaction`/`estimateFees`; it is now a first-class API method.

--- a/libs/coin-modules/coin-tezos/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.test.ts
@@ -1000,6 +1000,25 @@ describe("getAccountInfo", () => {
     expect(networkApi.getAccountByAddress).toHaveBeenCalledWith("tz2unrevealed");
   });
 
+  it("returns revealed:true for a registered baker (delegate) account", async () => {
+    // tzkt reports bakers with type "delegate" (not "user"), still carrying revealed:true.
+    // Regression test for LIVE-34256: bakers must not be reported as unrevealed.
+    (networkApi.getAccountByAddress as jest.Mock).mockResolvedValueOnce({
+      type: "delegate",
+      balance: 616109,
+      revealed: true,
+      address: "tz3RDC3Jdn4j15J7bBHZd29EUee9gVB1CxD9",
+      publicKey: "p2pktest",
+      counter: 18,
+    } as APIAccount);
+
+    await expect(api.getAccountInfo("tz3RDC3Jdn4j15J7bBHZd29EUee9gVB1CxD9")).resolves.toEqual({
+      type: "tezos",
+      revealed: true,
+    });
+    expect(networkApi.getAccountByAddress).toHaveBeenCalledWith("tz3RDC3Jdn4j15J7bBHZd29EUee9gVB1CxD9");
+  });
+
   it("returns revealed:false for an empty / non-existent account", async () => {
     (networkApi.getAccountByAddress as jest.Mock).mockResolvedValueOnce({
       type: "empty",

--- a/libs/coin-modules/coin-tezos/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.test.ts
@@ -1016,7 +1016,9 @@ describe("getAccountInfo", () => {
       type: "tezos",
       revealed: true,
     });
-    expect(networkApi.getAccountByAddress).toHaveBeenCalledWith("tz3RDC3Jdn4j15J7bBHZd29EUee9gVB1CxD9");
+    expect(networkApi.getAccountByAddress).toHaveBeenCalledWith(
+      "tz3RDC3Jdn4j15J7bBHZd29EUee9gVB1CxD9",
+    );
   });
 
   it("returns revealed:false for an empty / non-existent account", async () => {

--- a/libs/coin-modules/coin-tezos/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.test.ts
@@ -952,3 +952,71 @@ describe("getBalance", () => {
     );
   });
 });
+
+describe("getAccountInfo", () => {
+  afterEach(() => {
+    (networkApi.getAccountByAddress as jest.Mock).mockClear();
+  });
+
+  it("returns revealed:true for a revealed user account", async () => {
+    (networkApi.getAccountByAddress as jest.Mock).mockResolvedValueOnce({
+      type: "user",
+      balance: 1000,
+      revealed: true,
+      address: "tz1test",
+      publicKey: "edpktest",
+      counter: 0,
+      delegationLevel: 0,
+      delegationTime: "2021-01-01T00:00:00Z",
+      numTransactions: 0,
+      firstActivityTime: "2021-01-01T00:00:00Z",
+    } as APIAccount);
+
+    await expect(api.getAccountInfo("tz1test")).resolves.toEqual({
+      type: "tezos",
+      revealed: true,
+    });
+    expect(networkApi.getAccountByAddress).toHaveBeenCalledWith("tz1test");
+  });
+
+  it("returns revealed:false for an unrevealed user account", async () => {
+    (networkApi.getAccountByAddress as jest.Mock).mockResolvedValueOnce({
+      type: "user",
+      balance: 1000,
+      revealed: false,
+      address: "tz2unrevealed",
+      publicKey: "",
+      counter: 0,
+      delegationLevel: 0,
+      delegationTime: "2021-01-01T00:00:00Z",
+      numTransactions: 0,
+      firstActivityTime: "2021-01-01T00:00:00Z",
+    } as APIAccount);
+
+    await expect(api.getAccountInfo("tz2unrevealed")).resolves.toEqual({
+      type: "tezos",
+      revealed: false,
+    });
+    expect(networkApi.getAccountByAddress).toHaveBeenCalledWith("tz2unrevealed");
+  });
+
+  it("returns revealed:false for an empty / non-existent account", async () => {
+    (networkApi.getAccountByAddress as jest.Mock).mockResolvedValueOnce({
+      type: "empty",
+      address: "tz1empty",
+      counter: 0,
+    } as APIAccount);
+
+    await expect(api.getAccountInfo("tz1empty")).resolves.toEqual({
+      type: "tezos",
+      revealed: false,
+    });
+    expect(networkApi.getAccountByAddress).toHaveBeenCalledWith("tz1empty");
+  });
+
+  it("propagates errors from getAccountByAddress", async () => {
+    (networkApi.getAccountByAddress as jest.Mock).mockRejectedValueOnce(new Error("boom"));
+
+    await expect(api.getAccountInfo("tz1boom")).rejects.toThrow("boom");
+  });
+});

--- a/libs/coin-modules/coin-tezos/src/api/index.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.ts
@@ -10,7 +10,6 @@ import {
   Validator,
 } from "@ledgerhq/coin-module-framework/api/index";
 import type {
-  CoinModuleApi,
   BalanceOptions,
   FeeEstimation,
   TransactionIntent,
@@ -46,10 +45,10 @@ import {
   parseTezosTokenAsset,
   resolveTezosOperationMode,
 } from "../utils";
-import type { TezosFeeEstimation } from "./types";
+import type { TezosAccountInfo, TezosApi, TezosFeeEstimation } from "./types";
 import type { TezosOperationMode } from "../types/model";
 
-export function createApi(config: TezosConfig): CoinModuleApi {
+export function createApi(config: TezosConfig): TezosApi {
   coinConfig.setCoinConfig(() => ({ ...config, status: { type: "active" } }));
 
   return {
@@ -75,6 +74,12 @@ export function createApi(config: TezosConfig): CoinModuleApi {
     getNextSequence: async (address: string) => {
       const accountInfo = await api.getAccountByAddress(address);
       return accountInfo.type === "user" ? BigInt(accountInfo.counter + 1) : 0n;
+    },
+    getAccountInfo: async (address: string): Promise<TezosAccountInfo> => {
+      const account = await api.getAccountByAddress(address);
+      // Only "user" accounts carry a reveal state; empty / non-existent accounts are
+      // treated as unrevealed (no public key published on-chain yet).
+      return { type: "tezos", revealed: account.type === "user" ? account.revealed : false };
     },
     getBlock,
     getBlockInfo,

--- a/libs/coin-modules/coin-tezos/src/api/index.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.ts
@@ -38,6 +38,7 @@ import { CoreAccountInfo, CoreTransactionInfo, EstimatedFees } from "../logic/es
 import { getTezosToolkit } from "../logic/tezosToolkit";
 import { validateAddress } from "../logic/validateAddress";
 import api from "../network/tzkt";
+import { hasManagerKey } from "../network/types";
 import {
   DUST_MARGIN_MUTEZ,
   hasEmptyBalance,
@@ -73,13 +74,14 @@ export function createApi(config: TezosConfig): TezosApi {
     validateIntent,
     getNextSequence: async (address: string) => {
       const accountInfo = await api.getAccountByAddress(address);
-      return accountInfo.type === "user" ? BigInt(accountInfo.counter + 1) : 0n;
+      return hasManagerKey(accountInfo) ? BigInt(accountInfo.counter + 1) : 0n;
     },
     getAccountInfo: async (address: string): Promise<TezosAccountInfo> => {
       const account = await api.getAccountByAddress(address);
-      // Only "user" accounts carry a reveal state; empty / non-existent accounts are
-      // treated as unrevealed (no public key published on-chain yet).
-      return { type: "tezos", revealed: account.type === "user" ? account.revealed : false };
+      // Manager-key accounts (plain wallets "user" and registered bakers "delegate") carry a
+      // reveal state; empty / non-existent accounts are treated as unrevealed (no public key
+      // published on-chain yet).
+      return { type: "tezos", revealed: hasManagerKey(account) ? account.revealed : false };
     },
     getBlock,
     getBlockInfo,
@@ -124,7 +126,7 @@ async function craft(
   let amountToUse = tezosMode === "finalize_unstake" ? 0n : transactionIntent.amount;
   if (tezosMode === "send" && transactionIntent.useAllAmount) {
     const senderInfo = await api.getAccountByAddress(transactionIntent.sender);
-    if (senderInfo.type === "user") {
+    if (hasManagerKey(senderInfo)) {
       // Use the amount calculated by the estimation which includes proper buffers and adjustments
       if (estimation.parameters?.amount !== undefined) {
         amountToUse = estimation.parameters.amount;
@@ -145,7 +147,7 @@ async function craft(
     address: transactionIntent.sender,
   };
   const senderApiAcc = await api.getAccountByAddress(transactionIntent.sender);
-  const needsReveal = senderApiAcc.type === "user" && !senderApiAcc.revealed;
+  const needsReveal = hasManagerKey(senderApiAcc) && !senderApiAcc.revealed;
   const totalFee = Number(fee.fees || "0");
 
   const feesConfig = coinConfig.getCoinConfig().fees;
@@ -227,8 +229,8 @@ async function estimate(transactionIntent: TransactionIntent): Promise<TezosFeeE
     };
   }
   const senderAccountInfo = await api.getAccountByAddress(transactionIntent.sender);
-  // If the sender is not a user account, return default estimation values
-  if (senderAccountInfo.type !== "user") {
+  // If the sender is not a manager-key account (user or delegate), return default estimation values
+  if (!hasManagerKey(senderAccountInfo)) {
     return {
       value: BigInt(DUST_MARGIN_MUTEZ),
       parameters: {
@@ -265,8 +267,8 @@ async function estimate(transactionIntent: TransactionIntent): Promise<TezosFeeE
   };
 
   async function logicEstimate(xpub?: string): Promise<EstimatedFees> {
-    // needed by the compiler (it can assume it's a "user" account with respective fields)
-    if (senderAccountInfo.type !== "user") throw new Error("unexpected account type");
+    // needed by the compiler (it can assume it's a manager-key account with respective fields)
+    if (!hasManagerKey(senderAccountInfo)) throw new Error("unexpected account type");
     const account = xpub ? { ...accountBase, xpub } : accountBase;
     return await estimateFees({ account, transaction });
   }
@@ -318,7 +320,7 @@ async function estimate(transactionIntent: TransactionIntent): Promise<TezosFeeE
 
       // Check if account needs reveal for proper fee calculation
       const senderApiAcc = await api.getAccountByAddress(transactionIntent.sender);
-      const needsReveal = senderApiAcc.type === "user" && !senderApiAcc.revealed;
+      const needsReveal = hasManagerKey(senderApiAcc) && !senderApiAcc.revealed;
 
       let baseTxFee: bigint;
       let txGasLimit: bigint;

--- a/libs/coin-modules/coin-tezos/src/api/types.ts
+++ b/libs/coin-modules/coin-tezos/src/api/types.ts
@@ -1,4 +1,4 @@
-import type { FeeEstimation } from "@ledgerhq/coin-module-framework/api/types";
+import type { CoinModuleApi, FeeEstimation } from "@ledgerhq/coin-module-framework/api/types";
 
 export type TezosFeeParameters = {
   gasLimit: bigint;
@@ -11,3 +11,24 @@ export type TezosFeeEstimation = FeeEstimation & {
 };
 
 export type TezosSender = { address: string; xpub?: string };
+
+/**
+ * Network-specific account metadata for Tezos (ADR-045 shape).
+ * `revealed` is `true` once the account has published its public key on-chain.
+ */
+export type TezosAccountInfo = { type: "tezos"; revealed: boolean };
+
+/**
+ * coin-tezos public API surface: the generic {@link CoinModuleApi} plus `getAccountInfo`,
+ * which exposes the account's on-chain reveal state.
+ *
+ * Kept local (rather than relying on the future framework-side reveal-state type from ADR-045)
+ * so coin-tezos does not depend on that framework change landing first. The `{ type: "tezos" }`
+ * shape is intentionally identical to the ADR-045 variant. Once the framework's `CoinModuleApi`
+ * ships its own `getAccountInfo`, migrating means dropping this local override entirely (the two
+ * signatures would otherwise intersect into an incompatible-return-type collision) and letting the
+ * implementation satisfy the generic method directly.
+ */
+export type TezosApi = CoinModuleApi & {
+  getAccountInfo: (address: string) => Promise<TezosAccountInfo>;
+};

--- a/libs/coin-modules/coin-tezos/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBalance.test.ts
@@ -386,6 +386,68 @@ describe("getBalance", () => {
       ]);
     });
 
+    it("returns the baker's own balance, self-stake and unstake positions for a delegate account (LIVE-34256)", async () => {
+      // tzkt reports a registered baker with type "delegate" (not "user"). Before the fix this
+      // fell through to a 0 native balance and no stakes; the account appeared empty in Ledger Live.
+      // A delegate has no `delegate` field (it is its own baker), so there is no delegation position —
+      // only its self-stake and any unstake requests. The unstakedBalance > 0 exercises the
+      // delegate → fetchUnstakeRequests path.
+      mockServer.use(
+        http.get(`http://tezos.explorer.com/v1/accounts/${address}`, () =>
+          HttpResponse.json({
+            type: "delegate",
+            balance: 100,
+            stakedBalance: 30,
+            unstakedBalance: 10,
+          }),
+        ),
+        http.get("http://tezos.explorer.com/v1/tokens/balances", () => HttpResponse.json([])),
+        http.get("http://tezos.explorer.com/v1/staking/unstake_requests", () =>
+          HttpResponse.json([
+            {
+              id: 77,
+              cycle: 100,
+              baker: { address },
+              staker: { address },
+              firstTime: "2026-05-01T00:00:00Z",
+              status: "pending",
+              actualAmount: 10,
+            },
+          ]),
+        ),
+      );
+
+      expect(await getBalance(address)).toEqual([
+        { value: 100n, asset: { type: "native" }, locked: 40n },
+        {
+          value: 30n,
+          asset: { type: "native" },
+          stake: {
+            uid: `stake-${address}`,
+            address,
+            state: "active",
+            asset: { type: "native" },
+            amount: 30n,
+            actions: [],
+          },
+        },
+        {
+          value: 10n,
+          asset: { type: "native" },
+          stake: {
+            uid: "unstaking-77",
+            address,
+            delegate: address,
+            state: "deactivating",
+            createdAt: new Date("2026-05-01T00:00:00Z"),
+            asset: { type: "native" },
+            amount: 10n,
+            actions: [],
+          },
+        },
+      ]);
+    });
+
     it("returns only the primary native Balance when no staking activity", async () => {
       mockAccount({ balance: 50 });
 

--- a/libs/coin-modules/coin-tezos/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBalance.ts
@@ -44,7 +44,9 @@ export async function getBalance(address: string): Promise<Balance[]> {
     };
   });
 
-  // Non-manager accounts (empty / contract / ghost / rollup) hold no native balance or stakes.
+  // We don't compute native/stake balances for non-manager account types (empty / contract /
+  // ghost / rollup). KT1 contracts can hold XTZ, but they aren't user-facing wallet accounts
+  // here, so we report a 0 native balance alongside any token balances.
   if (!hasManagerKey(apiAccount)) {
     return [{ value: 0n, asset: { type: "native" } }, ...tokensBalance];
   }

--- a/libs/coin-modules/coin-tezos/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getBalance.ts
@@ -1,6 +1,7 @@
 import type { Balance } from "@ledgerhq/coin-module-framework/api/index";
 import { log } from "@ledgerhq/logs";
 import api from "../network/tzkt";
+import { hasManagerKey } from "../network/types";
 import { buildStakesForAccount, fetchUnstakeRequests } from "./getStakes";
 import { partitionNativeBalance } from "../utils";
 
@@ -18,28 +19,6 @@ export async function getBalance(address: string): Promise<Balance[]> {
   const apiAccount = apiAccountResult.value;
   const tokensBalancesRaw =
     tokensBalancesResult.status === "fulfilled" ? tokensBalancesResult.value : [];
-  const normalized = apiAccount.type === "user" ? BigInt(apiAccount.balance) : 0n;
-
-  const unstakeRequests = await fetchUnstakeRequests(address, apiAccount).catch(error => {
-    log("coin:tezos", "getBalance: fetchUnstakeRequests failed; degrading stakes to []", {
-      error,
-      address,
-    });
-    return [];
-  });
-
-  const stakes =
-    apiAccount.type === "user" ? buildStakesForAccount(address, apiAccount, unstakeRequests) : [];
-
-  const stakedBalance = apiAccount.type === "user" ? BigInt(apiAccount.stakedBalance ?? 0) : 0n;
-  const unstakedBalance = apiAccount.type === "user" ? BigInt(apiAccount.unstakedBalance ?? 0) : 0n;
-  const { locked } = partitionNativeBalance(normalized, stakedBalance, unstakedBalance);
-
-  const stakeBalances: Balance[] = stakes.map(stake => ({
-    value: stake.amount,
-    asset: { type: "native" },
-    stake,
-  }));
 
   const tokensBalance: Balance[] = tokensBalancesRaw.map(({ balance, token }) => {
     const magnitude = Number.parseInt(token.metadata?.decimals || "0", 10);
@@ -64,6 +43,32 @@ export async function getBalance(address: string): Promise<Balance[]> {
       },
     };
   });
+
+  // Non-manager accounts (empty / contract / ghost / rollup) hold no native balance or stakes.
+  if (!hasManagerKey(apiAccount)) {
+    return [{ value: 0n, asset: { type: "native" } }, ...tokensBalance];
+  }
+
+  const normalized = BigInt(apiAccount.balance);
+
+  const unstakeRequests = await fetchUnstakeRequests(address, apiAccount).catch(error => {
+    log("coin:tezos", "getBalance: fetchUnstakeRequests failed; degrading stakes to []", {
+      error,
+      address,
+    });
+    return [];
+  });
+
+  const stakes = buildStakesForAccount(address, apiAccount, unstakeRequests);
+  const stakedBalance = BigInt(apiAccount.stakedBalance ?? 0);
+  const unstakedBalance = BigInt(apiAccount.unstakedBalance ?? 0);
+  const { locked } = partitionNativeBalance(normalized, stakedBalance, unstakedBalance);
+
+  const stakeBalances: Balance[] = stakes.map(stake => ({
+    value: stake.amount,
+    asset: { type: "native" },
+    stake,
+  }));
 
   return [
     {

--- a/libs/coin-modules/coin-tezos/src/logic/getStakes.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/getStakes.ts
@@ -1,7 +1,8 @@
 import type { Cursor, Page, Stake } from "@ledgerhq/coin-module-framework/api/types";
 import { log } from "@ledgerhq/logs";
 import api from "../network/tzkt";
-import type { APIAccount, APIUnstakeRequest } from "../network/types";
+import type { APIAccount, APIManagerAccount, APIUnstakeRequest } from "../network/types";
+import { hasManagerKey } from "../network/types";
 import { partitionNativeBalance } from "../utils";
 import { STAKING_UID_PREFIX } from "./positionUid";
 
@@ -12,13 +13,11 @@ export {
   isUnstakingPosition,
 } from "./positionUid";
 
-type APIUserAccount = Extract<APIAccount, { type: "user" }>;
-
 export function fetchUnstakeRequests(
   address: string,
   account: APIAccount,
 ): Promise<APIUnstakeRequest[]> {
-  if (account.type !== "user") return Promise.resolve([]);
+  if (!hasManagerKey(account)) return Promise.resolve([]);
   return (account.unstakedBalance ?? 0) > 0 ? api.getUnstakeRequests(address) : Promise.resolve([]);
 }
 
@@ -62,7 +61,7 @@ function unstakeRequestToStake(address: string, req: APIUnstakeRequest): Stake |
 
 export function buildStakesForAccount(
   address: string,
-  account: APIUserAccount,
+  account: APIManagerAccount,
   unstakeRequests: APIUnstakeRequest[],
 ): Stake[] {
   const balance = BigInt(account.balance ?? 0);
@@ -124,7 +123,7 @@ export function buildStakesForAccount(
 
 export async function getStakes(address: string, _cursor?: Cursor): Promise<Page<Stake>> {
   const accountInfo = await api.getAccountByAddress(address);
-  if (accountInfo.type !== "user") return { items: [] };
+  if (!hasManagerKey(accountInfo)) return { items: [] };
   const unstakeRequests = await fetchUnstakeRequests(address, accountInfo);
   return { items: buildStakesForAccount(address, accountInfo, unstakeRequests) };
 }

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
@@ -274,6 +274,30 @@ describe("validateIntent", () => {
       expect(mockEstimateFees).not.toHaveBeenCalled();
     });
 
+    it("does not return MustDelegateBeforeStaking for a registered baker (delegate account)", async () => {
+      // A baker is self-delegated: tzkt returns type "delegate" with no `delegate` field, but it
+      // must still be allowed to stake. Regression for LIVE-34256.
+      mockGetAccountByAddress.mockResolvedValue({
+        type: "delegate",
+        address: senderAddress,
+        publicKey: "edpk...",
+        balance: 5000000,
+        revealed: true,
+        counter: 0,
+      });
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "stake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 1000n,
+      });
+
+      expect(result.errors.amount).not.toBeInstanceOf(MustDelegateBeforeStaking);
+    });
+
     it("should return AmountRequired when stake amount is zero", async () => {
       mockGetAccountByAddress.mockResolvedValue(
         makeUserAccount({

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
@@ -274,7 +274,7 @@ describe("validateIntent", () => {
       expect(mockEstimateFees).not.toHaveBeenCalled();
     });
 
-    it("does not return MustDelegateBeforeStaking for a registered baker (delegate account)", async () => {
+    it("allows a registered baker (delegate account) to stake without MustDelegateBeforeStaking", async () => {
       // A baker is self-delegated: tzkt returns type "delegate" with no `delegate` field, but it
       // must still be allowed to stake. Regression for LIVE-34256.
       mockGetAccountByAddress.mockResolvedValue({
@@ -295,7 +295,10 @@ describe("validateIntent", () => {
         amount: 1000n,
       });
 
-      expect(result.errors.amount).not.toBeInstanceOf(MustDelegateBeforeStaking);
+      // No validation errors at all, and fee estimation was reached — a MustDelegateBeforeStaking
+      // short-circuit would return before estimation (see the "no delegate" case above).
+      expect(result.errors).toEqual({});
+      expect(mockEstimateFees).toHaveBeenCalled();
     });
 
     it("should return AmountRequired when stake amount is zero", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
@@ -12,7 +12,8 @@ import {
 } from "@ledgerhq/errors";
 import { validateAddress, ValidationResult } from "@taquito/utils";
 import api from "../network/tzkt";
-import type { APIAccount } from "../network/types";
+import type { APIManagerAccount } from "../network/types";
+import { hasManagerKey } from "../network/types";
 import {
   InvalidAddressBecauseAlreadyDelegated,
   MustDelegateBeforeStaking,
@@ -27,8 +28,6 @@ import {
 } from "../utils";
 import { estimateFees } from "./estimateFees";
 import type { TezosOperationMode } from "../types/model";
-
-type APIUserAccount = Extract<APIAccount, { type: "user" }>;
 
 function resolveValidationOperationMode(intent: TransactionIntent): TezosOperationMode {
   switch (intent.type) {
@@ -82,9 +81,13 @@ function validateBasicSendParams(intent: TransactionIntent): Record<string, Erro
 
 function validateStakeConstraints(
   intent: TransactionIntent,
-  senderInfo: APIUserAccount,
+  senderInfo: APIManagerAccount,
 ): Record<string, Error> {
-  if (!senderInfo.delegate?.address) {
+  // Staking requires an active delegate. A registered baker (`type: "delegate"`) is its own
+  // baker (self-delegated) so it is always eligible, even though tzkt reports no `delegate`
+  // field for it; only plain wallets without a delegate must delegate first.
+  const isSelfBaker = senderInfo.type === "delegate";
+  if (!isSelfBaker && !senderInfo.delegate?.address) {
     return { amount: new MustDelegateBeforeStaking() };
   }
   if (intent.useAllAmount) {
@@ -96,7 +99,7 @@ function validateStakeConstraints(
 
 function validateUnstakeConstraints(
   intent: TransactionIntent,
-  senderInfo: APIUserAccount,
+  senderInfo: APIManagerAccount,
 ): Record<string, Error> {
   const stakedBalance = BigInt(senderInfo.stakedBalance ?? 0);
   if (stakedBalance <= 0n) {
@@ -121,7 +124,7 @@ function validateFinalizeUnstakeConstraints(finalizable: bigint): Record<string,
 
 function validateTransactionConstraints(
   intent: TransactionIntent,
-  senderInfo: APIUserAccount,
+  senderInfo: APIManagerAccount,
   finalizable: bigint,
 ): Record<string, Error> {
   switch (intent.type) {
@@ -187,7 +190,7 @@ function calculateNativeSendMaxAmountForUser(
  */
 function calculateAmounts(
   intent: TransactionIntent,
-  senderInfo: APIUserAccount,
+  senderInfo: APIManagerAccount,
   estimatedFees: bigint,
   estimatedAmount: bigint | undefined,
   tokenBalanceForSendMax?: bigint,
@@ -252,7 +255,7 @@ function validateBalanceCoverage(
 
 async function estimateFeesForIntent(
   intent: TransactionIntent,
-  senderInfo: APIUserAccount,
+  senderInfo: APIManagerAccount,
 ): Promise<{
   estimatedFees: bigint;
   estimatedAmount: bigint | undefined;
@@ -345,7 +348,7 @@ export async function validateIntent(intent: TransactionIntent): Promise<Transac
 
   try {
     const senderInfo = await api.getAccountByAddress(intent.sender);
-    if (senderInfo.type !== "user") throw new Error("unexpected account type");
+    if (!hasManagerKey(senderInfo)) throw new Error("unexpected account type");
 
     // Finalizable amount lives on /v1/staking/unstake_requests, not the account
     // endpoint; only `finalize_unstake` validation needs it.

--- a/libs/coin-modules/coin-tezos/src/network/types.ts
+++ b/libs/coin-modules/coin-tezos/src/network/types.ts
@@ -1,29 +1,73 @@
+/**
+ * Fields common to tzkt account types that own a manager key (`user` and `delegate`):
+ * both publish a public key on-chain and therefore carry a reveal state, counter,
+ * balance, and (un)staked balances.
+ * See https://api.tzkt.io/#operation/Accounts_GetByAddress (schemas `User` / `Delegate`).
+ */
+type APIManagerAccountBase = {
+  address: string;
+  publicKey: string;
+  revealed: boolean;
+  balance: number;
+  stakedBalance?: number;
+  unstakedBalance?: number;
+  stakingUpdatesCount?: number;
+  counter: number;
+  /**
+   * The baker this account delegates to, if any. Present on plain wallets that have set a
+   * delegate. We do not rely on it for registered bakers: a `delegate` account is its own
+   * baker (self-delegated), and staking logic keys off `type === "delegate"` rather than this
+   * field, so it's fine whether or not tzkt populates it.
+   */
+  delegate?: {
+    alias: string;
+    address: string;
+    active: boolean;
+  };
+};
+
+/**
+ * tzkt's `/v1/accounts/{address}` returns a discriminated union on `type` with seven
+ * variants: `user`, `delegate`, `contract`, `ghost`, `empty`, `rollup`, `smart_rollup`.
+ * We model only the ones we consume: `empty` (never appeared on-chain) plus the two
+ * manager-key variants, `user` (plain wallet) and `delegate` (registered baker). A baker
+ * is reported as `type: "delegate"`, NOT `"user"` — so any manager-key logic must accept
+ * both (see {@link hasManagerKey}).
+ */
 export type APIAccount =
   | {
       type: "empty";
       address: string;
       counter: number;
     }
-  | {
+  | (APIManagerAccountBase & {
       type: "user";
-      address: string;
-      publicKey: string;
-      revealed: boolean;
-      balance: number;
-      stakedBalance?: number;
-      unstakedBalance?: number;
-      stakingUpdatesCount?: number;
-      counter: number;
-      delegate?: {
-        alias: string;
-        address: string;
-        active: boolean;
-      };
       delegationLevel: number;
       delegationTime: string;
       numTransactions: number;
       firstActivityTime: string;
-    };
+    })
+  | (APIManagerAccountBase & {
+      // A registered baker. tzkt reports these with `type: "delegate"` (not `"user"`),
+      // still carrying `revealed`/`publicKey`/`counter`. In practice a delegate is revealed
+      // (registration is a manager operation, which requires a prior reveal), but we still
+      // read `revealed` from the payload rather than assuming it.
+      type: "delegate";
+    });
+
+/** tzkt account variants that own a manager key — both `user` and `delegate` qualify. */
+export type APIManagerAccount = Extract<APIAccount, { type: "user" | "delegate" }>;
+
+/**
+ * True for accounts that have published a public key on-chain and therefore carry
+ * `revealed`, `publicKey`, `counter`, and `balance`: plain wallets (`user`) and
+ * registered bakers (`delegate`). `empty` accounts (and the non-manager `contract` /
+ * `ghost` / `rollup` types we don't model) do not qualify. Use this instead of a bare
+ * `type === "user"` check so baker accounts aren't mistaken for empty/unrevealed ones.
+ */
+export function hasManagerKey(account: APIAccount): account is APIManagerAccount {
+  return account.type === "user" || account.type === "delegate";
+}
 
 type CommonOperationType = {
   id: number;

--- a/libs/coin-modules/coin-tezos/src/network/types.ts
+++ b/libs/coin-modules/coin-tezos/src/network/types.ts
@@ -1,7 +1,8 @@
 /**
  * Fields common to tzkt account types that own a manager key (`user` and `delegate`):
- * both publish a public key on-chain and therefore carry a reveal state, counter,
- * balance, and (un)staked balances.
+ * these types carry manager-key metadata — a public key, its on-chain reveal state
+ * (`revealed`), a counter, a balance, and (un)staked balances. The key is not necessarily
+ * published yet: an unrevealed account still has these fields but reports `revealed: false`.
  * See https://api.tzkt.io/#operation/Accounts_GetByAddress (schemas `User` / `Delegate`).
  */
 type APIManagerAccountBase = {
@@ -59,11 +60,13 @@ export type APIAccount =
 export type APIManagerAccount = Extract<APIAccount, { type: "user" | "delegate" }>;
 
 /**
- * True for accounts that have published a public key on-chain and therefore carry
- * `revealed`, `publicKey`, `counter`, and `balance`: plain wallets (`user`) and
- * registered bakers (`delegate`). `empty` accounts (and the non-manager `contract` /
- * `ghost` / `rollup` types we don't model) do not qualify. Use this instead of a bare
- * `type === "user"` check so baker accounts aren't mistaken for empty/unrevealed ones.
+ * True for account *types* that own a manager key and therefore carry the `revealed`,
+ * `publicKey`, `counter`, and `balance` fields: plain wallets (`user`) and registered bakers
+ * (`delegate`). This narrows on the account type, not on whether the key is already published —
+ * it returns true for unrevealed `user` accounts too (check `revealed` separately for that).
+ * `empty` accounts (and the non-manager `contract` / `ghost` / `rollup` types we don't model)
+ * do not qualify. Use this instead of a bare `type === "user"` check so baker accounts aren't
+ * mistaken for non-manager ones.
  */
 export function hasManagerKey(account: APIAccount): account is APIManagerAccount {
   return account.type === "user" || account.type === "delegate";

--- a/libs/coin-modules/coin-tezos/src/network/types.ts
+++ b/libs/coin-modules/coin-tezos/src/network/types.ts
@@ -1,13 +1,14 @@
 /**
  * Fields common to tzkt account types that own a manager key (`user` and `delegate`):
- * these types carry manager-key metadata — a public key, its on-chain reveal state
- * (`revealed`), a counter, a balance, and (un)staked balances. The key is not necessarily
- * published yet: an unrevealed account still has these fields but reports `revealed: false`.
+ * these types carry manager-key metadata — an on-chain reveal state (`revealed`), a counter,
+ * a balance, and (un)staked balances, plus the public key once it has been revealed.
+ * `publicKey` is optional: an unrevealed account (`revealed: false`) has not published one yet.
  * See https://api.tzkt.io/#operation/Accounts_GetByAddress (schemas `User` / `Delegate`).
  */
 type APIManagerAccountBase = {
   address: string;
-  publicKey: string;
+  /** Absent until the account is revealed (`revealed: false` → no public key on-chain yet). */
+  publicKey?: string;
   revealed: boolean;
   balance: number;
   stakedBalance?: number;

--- a/libs/coin-modules/coin-tezos/src/utils.ts
+++ b/libs/coin-modules/coin-tezos/src/utils.ts
@@ -2,7 +2,7 @@ import { DerivationType } from "@taquito/ledger-signer";
 import { compressPublicKey } from "@taquito/ledger-signer/dist/lib/utils";
 import { validatePublicKey, ValidationResult, b58Encode, PrefixV2 } from "@taquito/utils";
 import coinConfig from "./config";
-import type { APIAccount } from "./network/types";
+import { type APIAccount, hasManagerKey } from "./network/types";
 import type { TezosOperationMode } from "./types/model";
 
 /**
@@ -231,6 +231,13 @@ export function createFallbackEstimation() {
   };
 }
 
+/**
+ * Whether an account has nothing on-chain that would spare a recipient the allocation
+ * (storage) burn. Manager-key accounts (`user`/`delegate`) with a zero balance and truly
+ * non-existent (`empty`) accounts count as empty. A registered baker (`delegate`) is always
+ * allocated on-chain, so a zero-balance one is unusual — but keying on `hasManagerKey` keeps
+ * the reveal/storage logic consistent for both wallet and baker recipients.
+ */
 export function hasEmptyBalance(account: APIAccount) {
-  return (account.type === "user" && account.balance === 0) || account.type === "empty";
+  return (hasManagerKey(account) && account.balance === 0) || account.type === "empty";
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Implements `getAccountInfo(address)` on the Tezos coin module, returning the account's
on-chain reveal state as `{ type: "tezos", revealed: boolean }`. Previously the reveal
state was only computed internally inside `craftTransaction`/`estimateFees`; it is now a
first-class API method.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 --> [LIVE-34256](https://ledgerhq.atlassian.net/browse/LIVE-34256)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-34256]: https://ledgerhq.atlassian.net/browse/LIVE-34256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ