### PR TITLE
ci: extend format-check gate to cover workflow_dispatch

### DIFF
--- a/.github/workflows/build-wallet-cli-reusable.yml
+++ b/.github/workflows/build-wallet-cli-reusable.yml
@@ -55,7 +55,7 @@ jobs:
         run: pnpm i --filter "@ledgerhq/wallet-cli..." --filter "ledger-live"
 
       - name: format check wallet-cli
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || inputs.ref == 'develop'
         run: pnpm exec nx run @ledgerhq/wallet-cli:format:check
 
       - name: Build, lint, typecheck and test wallet-cli

--- a/.github/workflows/build-wallet-cli-reusable.yml
+++ b/.github/workflows/build-wallet-cli-reusable.yml
@@ -55,7 +55,7 @@ jobs:
         run: pnpm i --filter "@ledgerhq/wallet-cli..." --filter "ledger-live"
 
       - name: format check wallet-cli
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || inputs.ref == 'develop'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch'
         run: pnpm exec nx run @ledgerhq/wallet-cli:format:check
 
       - name: Build, lint, typecheck and test wallet-cli

--- a/.github/workflows/build-web-tools-reusable.yml
+++ b/.github/workflows/build-web-tools-reusable.yml
@@ -94,7 +94,7 @@ jobs:
           production: ${{ inputs.vercel-production }}
 
       - name: Check formatting web-tools
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || inputs.ref == 'develop'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch'
         uses: LedgerHQ/ledger-live/tools/actions/composites/nx-step@develop
         with:
           command: pnpm exec nx run @ledgerhq/web-tools:format:check

--- a/.github/workflows/build-web-tools-reusable.yml
+++ b/.github/workflows/build-web-tools-reusable.yml
@@ -94,7 +94,7 @@ jobs:
           production: ${{ inputs.vercel-production }}
 
       - name: Check formatting web-tools
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || inputs.ref == 'develop'
         uses: LedgerHQ/ledger-live/tools/actions/composites/nx-step@develop
         with:
           command: pnpm exec nx run @ledgerhq/web-tools:format:check

--- a/.github/workflows/test-cli-reusable.yml
+++ b/.github/workflows/test-cli-reusable.yml
@@ -46,7 +46,7 @@ jobs:
       - name: build cli
         run: pnpm exec nx run @ledgerhq/live-cli:build
       - name: format check cli
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || inputs.ref == 'develop'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch'
         run: pnpm exec nx run @ledgerhq/live-cli:format:check
       - name: lint cli
         run: pnpm exec nx run @ledgerhq/live-cli:lint -- --quiet

--- a/.github/workflows/test-cli-reusable.yml
+++ b/.github/workflows/test-cli-reusable.yml
@@ -46,7 +46,7 @@ jobs:
       - name: build cli
         run: pnpm exec nx run @ledgerhq/live-cli:build
       - name: format check cli
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || inputs.ref == 'develop'
         run: pnpm exec nx run @ledgerhq/live-cli:format:check
       - name: lint cli
         run: pnpm exec nx run @ledgerhq/live-cli:lint -- --quiet

--- a/.github/workflows/test-desktop-codechecks-reusable.yml
+++ b/.github/workflows/test-desktop-codechecks-reusable.yml
@@ -68,7 +68,7 @@ jobs:
           skip_builds: true
 
       - name: format check
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || inputs.ref == 'develop'
         run: pnpm desktop format:check
 
       - name: lint

--- a/.github/workflows/test-desktop-codechecks-reusable.yml
+++ b/.github/workflows/test-desktop-codechecks-reusable.yml
@@ -68,7 +68,7 @@ jobs:
           skip_builds: true
 
       - name: format check
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || inputs.ref == 'develop'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch'
         run: pnpm desktop format:check
 
       - name: lint

--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -165,10 +165,7 @@ jobs:
         run: pnpm i
       - name: Check formatting of affected libraries
         id: format-check-libs
-        # TODO(LIVE-31553): remove continue-on-error once the release cycle has
-        # the format:check scripts on HEAD (~2 weeks). format:check does not yet
-        # exist on release branches, so keep this non-blocking to not break release.
-        continue-on-error: true
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || inputs.ref == 'develop'
         run: pnpm exec nx run-many -t format:check --exclude=ledger-live-desktop,live-mobile,@ledgerhq/live-cli,@ledgerhq/web-tools,ledger-live-desktop-e2e-tests,ledger-live-mobile-e2e-tests --parallel=3 --nxBail=false
       - name: Lint affected libraries
         id: lint-libs

--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -165,7 +165,7 @@ jobs:
         run: pnpm i
       - name: Check formatting of affected libraries
         id: format-check-libs
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || inputs.ref == 'develop'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch'
         run: pnpm exec nx run-many -t format:check --exclude=ledger-live-desktop,live-mobile,@ledgerhq/live-cli,@ledgerhq/web-tools,ledger-live-desktop-e2e-tests,ledger-live-mobile-e2e-tests --parallel=3 --nxBail=false
       - name: Lint affected libraries
         id: lint-libs

--- a/.github/workflows/test-mobile-reusable.yml
+++ b/.github/workflows/test-mobile-reusable.yml
@@ -63,7 +63,7 @@ jobs:
         run: pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
 
       - name: Run format check
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || inputs.ref == 'develop'
         run: pnpm exec nx run live-mobile:format:check
 
       - name: Run linter

--- a/.github/workflows/test-mobile-reusable.yml
+++ b/.github/workflows/test-mobile-reusable.yml
@@ -63,7 +63,7 @@ jobs:
         run: pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
 
       - name: Run format check
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || inputs.ref == 'develop'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch'
         run: pnpm exec nx run live-mobile:format:check
 
       - name: Run linter


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

## Summary

Removes all `continue-on-error: true` suppressions from format-check steps and replaces them with an `if:` gate that enforces the check only when targeting `develop` — making format failures blocking without breaking
release-branch flows.

- **Replace `continue-on-error: true` with conditional gating** across all affected workflows (`test-libs-reusable`, `test-cli-reusable`,`test-desktop-codechecks-reusable`, `test-mobile-reusable`,  `build-web-tools-reusable`, `build-wallet-cli-reusable`). Format checks now run — and block — only when `github.base_ref == 'develop'` (PR targeting develop) or `github.ref == 'refs/heads/develop'` (push to develop). Release branches are unaffected.
- **Extend the gate to cover `workflow_dispatch`** by adding `|| github.event_name == 'workflow_dispatch'` to the six workflows that support manual dispatch, so manually triggered runs are always held to the same standard regardless of which ref is checked out.

Test run: https://github.com/LedgerHQ/ledger-live/actions/runs/29404254889