### PR TITLE
[LWM] chore(mobile): update large screen upsell copy

### DIFF
--- a/.changeset/loud-crews-brake.md
+++ b/.changeset/loud-crews-brake.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+chore: update copy for large screen upsell

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1393,11 +1393,11 @@
   "largeScreenUpsellModal": {
     "optedIn": {
       "title": "See more. Tap less. Save {{discount}}%",
-      "subtitle": "Enjoy a larger screen, smarter transaction review, enhanced protection, and an exclusive {{discount}}% off."
+      "subtitle": "Enjoy a larger screen, smarter transaction reviews, enhanced protection, and an exclusive {{discount}}% off."
     },
     "optedOut": {
       "title": "Spot scams. See every detail",
-      "subtitle": "Review details on a touchscreen signer and pair slimmer wallets with advanced security checks."
+      "subtitle": "Review clearly on a touchscreen signer and spot scams with advanced security checks."
     },
     "cta": "Explore touchscreen signers"
   },


### PR DESCRIPTION
### 📝 Description

Updates the copy for the large screen upsell modal on mobile:

- **`optedIn.subtitle`**: "smarter transaction review" → "smarter transaction reviews"
- **`optedOut.subtitle`**: "Review details on a touchscreen signer and pair slimmer wallets with advanced security checks." → "Review clearly on a touchscreen signer and spot scams with advanced security checks."

Copy-only change to `en/common.json`. Includes a `live-mobile` patch changeset.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-33165]
- **ADR** (if any): N/A


[LIVE-33165]: https://ledgerhq.atlassian.net/browse/LIVE-33165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ