### PR TITLE
[LWM] fix(LIVE-34137): updated usage of private sync hook

### DIFF
--- a/.changeset/mean-drinks-yawn.md
+++ b/.changeset/mean-drinks-yawn.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+updated useAleoPrivateSync wrapper for mobile Aleo

--- a/apps/ledger-live-mobile/src/families/aleo/hooks/useAleoPrivateSync.test.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/hooks/useAleoPrivateSync.test.ts
@@ -74,6 +74,22 @@ describe("useAleoPrivateSync (mobile wrapper)", () => {
     expect(call.autoStart).toBe(false);
   });
 
+  it("latches focus: once focused, a later blur does not flip autoStart back to false", () => {
+    mockUseIsFocused.mockReturnValue(true);
+    const { rerender } = renderHook(() =>
+      useAleoPrivateSync({ account: ALEO_ACCOUNT_1, autoStart: true }),
+    );
+    expect(mockCore.mock.calls[0][0].autoStart).toBe(true);
+
+    mockUseIsFocused.mockReturnValue(false);
+    rerender(undefined);
+
+    // If this ANDed the live isFocused value directly, the core hook's autoStart effect
+    // would treat this as a stop() (or a restart on the next refocus) instead of a no-op —
+    // see libs/ledger-live-common/src/families/aleo/react.ts's autoStart effect.
+    expect(mockCore.mock.calls[1][0].autoStart).toBe(true);
+  });
+
   it("wires accountSelector through to the app's real selector", () => {
     renderHook(() => useAleoPrivateSync({ account: ALEO_ACCOUNT_1 }));
 

--- a/apps/ledger-live-mobile/src/families/aleo/hooks/useAleoPrivateSync.test.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/hooks/useAleoPrivateSync.test.ts
@@ -1,3 +1,5 @@
+import { renderHook } from "@testing-library/react-native";
+import { useIsFocused } from "@react-navigation/native";
 import { useAleoPrivateSync as useAleoPrivateSyncCore } from "@ledgerhq/live-common/families/aleo/react";
 import { accountSelector } from "~/reducers/accounts";
 import { updateAccountWithUpdater } from "~/actions/accounts";
@@ -15,10 +17,15 @@ jest.mock("~/actions/accounts", () => ({
   ...jest.requireActual("~/actions/accounts"),
   updateAccountWithUpdater: jest.fn(),
 }));
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useIsFocused: jest.fn(),
+}));
 
 const mockCore = jest.mocked(useAleoPrivateSyncCore);
 const mockAccountSelector = jest.mocked(accountSelector);
 const mockUpdateAccountWithUpdater = jest.mocked(updateAccountWithUpdater);
+const mockUseIsFocused = jest.mocked(useIsFocused);
 
 describe("useAleoPrivateSync (mobile wrapper)", () => {
   beforeEach(() => {
@@ -30,16 +37,19 @@ describe("useAleoPrivateSync (mobile wrapper)", () => {
       start: jest.fn(),
       stop: jest.fn(),
     });
+    mockUseIsFocused.mockReturnValue(true);
   });
 
   it("delegates to the live-common core hook with the given options", () => {
     const onAccountUpdated = jest.fn();
-    useAleoPrivateSync({
-      account: ALEO_ACCOUNT_1,
-      autoStart: true,
-      keepAliveOnUnmount: true,
-      onAccountUpdated,
-    });
+    renderHook(() =>
+      useAleoPrivateSync({
+        account: ALEO_ACCOUNT_1,
+        autoStart: true,
+        keepAliveOnUnmount: true,
+        onAccountUpdated,
+      }),
+    );
 
     expect(mockCore).toHaveBeenCalledTimes(1);
     const call = mockCore.mock.calls[0][0];
@@ -49,8 +59,23 @@ describe("useAleoPrivateSync (mobile wrapper)", () => {
     expect(call.onAccountUpdated).toBe(onAccountUpdated);
   });
 
+  it("ANDs autoStart with screen focus, so a mounted-but-unfocused screen doesn't start syncing", () => {
+    mockUseIsFocused.mockReturnValue(false);
+    renderHook(() => useAleoPrivateSync({ account: ALEO_ACCOUNT_1, autoStart: true }));
+
+    const call = mockCore.mock.calls[0][0];
+    expect(call.autoStart).toBe(false);
+  });
+
+  it("keeps autoStart false when the caller opts out, regardless of focus", () => {
+    renderHook(() => useAleoPrivateSync({ account: ALEO_ACCOUNT_1, autoStart: false }));
+
+    const call = mockCore.mock.calls[0][0];
+    expect(call.autoStart).toBe(false);
+  });
+
   it("wires accountSelector through to the app's real selector", () => {
-    useAleoPrivateSync({ account: ALEO_ACCOUNT_1 });
+    renderHook(() => useAleoPrivateSync({ account: ALEO_ACCOUNT_1 }));
 
     const call = mockCore.mock.calls[0][0];
     const state = { accounts: [ALEO_ACCOUNT_1] };
@@ -60,7 +85,7 @@ describe("useAleoPrivateSync (mobile wrapper)", () => {
   });
 
   it("wires updateAccountWithUpdater through to the app's real action creator", () => {
-    useAleoPrivateSync({ account: ALEO_ACCOUNT_1 });
+    renderHook(() => useAleoPrivateSync({ account: ALEO_ACCOUNT_1 }));
 
     const call = mockCore.mock.calls[0][0];
     const updater = (a: typeof ALEO_ACCOUNT_1) => a;

--- a/apps/ledger-live-mobile/src/families/aleo/hooks/useAleoPrivateSync.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/hooks/useAleoPrivateSync.ts
@@ -1,3 +1,4 @@
+import { useIsFocused } from "@react-navigation/native";
 import { useAleoPrivateSync as useAleoPrivateSyncCore } from "@ledgerhq/live-common/families/aleo/react";
 import { accountSelector } from "~/reducers/accounts";
 import type { State } from "~/reducers/types";
@@ -8,10 +9,16 @@ type UseAleoPrivateSyncOptions = Omit<
   "accountSelector" | "updateAccountWithUpdater"
 >;
 
-export const useAleoPrivateSync = (options: UseAleoPrivateSyncOptions) =>
-  useAleoPrivateSyncCore({
+export const useAleoPrivateSync = ({ autoStart, ...options }: UseAleoPrivateSyncOptions) => {
+  // Gating on focus keeps autoStart from firing on a screen the
+  // user hasn't actually opened yet, on either platform.
+  const isFocused = useIsFocused();
+
+  return useAleoPrivateSyncCore({
     ...options,
+    autoStart: autoStart && isFocused,
     accountSelector: (state, params) => accountSelector(state as State, params),
     updateAccountWithUpdater: (accountId, updater) =>
       updateAccountWithUpdater({ accountId, updater }),
   });
+};

--- a/apps/ledger-live-mobile/src/families/aleo/hooks/useAleoPrivateSync.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/hooks/useAleoPrivateSync.ts
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { useIsFocused } from "@react-navigation/native";
 import { useAleoPrivateSync as useAleoPrivateSyncCore } from "@ledgerhq/live-common/families/aleo/react";
 import { accountSelector } from "~/reducers/accounts";
@@ -10,13 +11,15 @@ type UseAleoPrivateSyncOptions = Omit<
 >;
 
 export const useAleoPrivateSync = ({ autoStart, ...options }: UseAleoPrivateSyncOptions) => {
+  const isFocused = useIsFocused();
   // Gating on focus keeps autoStart from firing on a screen the
   // user hasn't actually opened yet, on either platform.
-  const isFocused = useIsFocused();
+  const hasBeenFocusedRef = useRef(isFocused);
+  if (isFocused) hasBeenFocusedRef.current = true;
 
   return useAleoPrivateSyncCore({
     ...options,
-    autoStart: autoStart && isFocused,
+    autoStart: autoStart && hasBeenFocusedRef.current,
     accountSelector: (state, params) => accountSelector(state as State, params),
     updateAccountWithUpdater: (accountId, updater) =>
       updateAccountWithUpdater({ accountId, updater }),


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Mobile-specific wrapper around the shared useAleoPrivateSync core hook (@ledgerhq/live-common/families/aleo/react). Injects the app's Redux account selector/updater, and gates autoStart on useIsFocused() so a screen that's mounted but not yet focused (e.g. iOS can mount a pushed screen's React tree before it's actually visible) doesn't kick off a private sync prematurely.

### 🔗 Context

- **JIRA / GitHub issue**: [https://ledgerhq.atlassian.net/browse/LIVE-34137](https://ledgerhq.atlassian.net/browse/LIVE-34137)