### PR TITLE
[LWDM] test(swap): conditionally verify provider link in swap history (QAA-721)

### DIFF
--- a/.changeset/chatty-swans-swap.md
+++ b/.changeset/chatty-swans-swap.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Expose the swap transaction-details provider link URL via test/accessibility attributes so E2E can conditionally verify the provider link only when a provider URL exists (QAA-721)

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/Details/DetailsSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/Details/DetailsSection.tsx
@@ -71,6 +71,7 @@ export function DetailsSection({
                 <button
                   type="button"
                   data-testid="swap-transaction-details-provider"
+                  data-href={providerMainUrl}
                   className="inline-flex cursor-pointer items-center gap-6 border-0 bg-transparent p-0 body-3 text-base"
                   onClick={() => openURL(providerMainUrl, "SwapTransactionStatus_Provider")}
                 >

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Details/DetailsSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Details/DetailsSection.tsx
@@ -162,6 +162,7 @@ function renderProviderValue({
 
   return (
     <Pressable
+      testID="swap-transaction-details-provider-link"
       onPress={() =>
         Linking.openURL(providerMainUrl).catch(error => {
           log("swap-transaction-status", "Failed to open provider URL", {
@@ -171,6 +172,8 @@ function renderProviderValue({
         })
       }
       accessibilityRole="link"
+      accessibilityLabel={providerName}
+      accessibilityValue={{ text: providerMainUrl }}
     >
       {providerValue}
     </Pressable>

--- a/e2e/desktop/tests/page/dialog/swap.transaction.status.dialog.ts
+++ b/e2e/desktop/tests/page/dialog/swap.transaction.status.dialog.ts
@@ -27,6 +27,8 @@ export class SwapTransactionStatusDialog extends Dialog {
       receivedAmount: string;
       networkFees: string;
       receiveAccount: string;
+      // Present when the provider is expected to expose a website link; absent when it should show name-only.
+      providerUrl?: string;
     },
   ) {
     await expect(this.dialog).toBeVisible();
@@ -46,6 +48,13 @@ export class SwapTransactionStatusDialog extends Dialog {
     await expect(this.receiveAccount).toHaveText(details.receiveAccount);
     await expect(this.swapId).toContainText(swapIdPrefix);
     await expect(this.provider).toHaveText(provider.uiName);
+    // Only providers with a configured URL render the provider name as a link (data-href).
+    // Verify the link when expected, and assert its absence otherwise (see QAA-721 / LIVE-18412).
+    if (details.providerUrl) {
+      await expect(this.provider).toHaveAttribute("data-href", details.providerUrl);
+    } else {
+      await expect(this.provider).not.toHaveAttribute("data-href");
+    }
     await expect(this.viewExplorerBtn).toBeVisible();
     await expect(this.viewExplorerBtn).toHaveAttribute("data-href", /^https:\/\/.+/);
   }

--- a/e2e/desktop/tests/page/dialog/swap.transaction.status.dialog.ts
+++ b/e2e/desktop/tests/page/dialog/swap.transaction.status.dialog.ts
@@ -27,7 +27,6 @@ export class SwapTransactionStatusDialog extends Dialog {
       receivedAmount: string;
       networkFees: string;
       receiveAccount: string;
-      // Present when the provider is expected to expose a website link; absent when it should show name-only.
       providerUrl?: string;
     },
   ) {
@@ -48,8 +47,6 @@ export class SwapTransactionStatusDialog extends Dialog {
     await expect(this.receiveAccount).toHaveText(details.receiveAccount);
     await expect(this.swapId).toContainText(swapIdPrefix);
     await expect(this.provider).toHaveText(provider.uiName);
-    // Only providers with a configured URL render the provider name as a link (data-href).
-    // Verify the link when expected, and assert its absence otherwise (see QAA-721 / LIVE-18412).
     if (details.providerUrl) {
       await expect(this.provider).toHaveAttribute("data-href", details.providerUrl);
     } else {

--- a/e2e/desktop/tests/specs/entrypoint.swap.spec.ts
+++ b/e2e/desktop/tests/specs/entrypoint.swap.spec.ts
@@ -339,6 +339,7 @@ test.describe("Swap history", () => {
       receivedAmount: "751.0672 ETH",
       networkFees: "0.000005 SOL",
       receiveAccount: "Ethereum 1",
+      providerUrl: "https://www.exodus.com/",
     },
   };
 

--- a/e2e/mobile/page/drawer/swapTransactionStatus.drawer.ts
+++ b/e2e/mobile/page/drawer/swapTransactionStatus.drawer.ts
@@ -79,7 +79,7 @@ export default class SwapTransactionStatusDrawer {
         jestExpect(label).toContain(details.providerUrl);
       }
     } else {
-      await detoxExpect(getElementById(this.providerLinkId)).not.toBeVisible();
+      await detoxExpect(getElementById(this.providerLinkId)).not.toExist();
     }
     jestExpect(normalizeText(await getTextOfElement(this.swapIdId))).toContain(swapIdPrefix);
 

--- a/e2e/mobile/page/drawer/swapTransactionStatus.drawer.ts
+++ b/e2e/mobile/page/drawer/swapTransactionStatus.drawer.ts
@@ -10,7 +10,6 @@ export type SwapTransactionStatusDetails = {
   receivedAmount?: string;
   networkFees: string;
   receiveAccount: string;
-  // Present when the provider is expected to expose a website link; absent when it should show name-only.
   providerUrl?: string;
 };
 
@@ -67,8 +66,6 @@ export default class SwapTransactionStatusDrawer {
     jestExpect(normalizeText(await getTextOfElement(this.providerId))).toEqual(
       normalizeText(provider.uiName),
     );
-    // Only providers with a configured URL render the provider name as a link (QAA-721 / LIVE-18412).
-    // Verify the link (and its URL) when expected; assert its absence otherwise.
     if (details.providerUrl) {
       await scrollToId(this.providerLinkId, this.scrollViewId);
       await detoxExpect(getElementById(this.providerLinkId)).toBeVisible();

--- a/e2e/mobile/page/drawer/swapTransactionStatus.drawer.ts
+++ b/e2e/mobile/page/drawer/swapTransactionStatus.drawer.ts
@@ -1,5 +1,5 @@
 import { Step } from "jest-allure2-reporter/api";
-import { normalizeText } from "../../helpers/commonHelpers";
+import { normalizeText, isIos } from "../../helpers/commonHelpers";
 import { SwapProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
 import { DEFAULT_TIMEOUT } from "../../helpers/elementHelpers";
 
@@ -10,6 +10,8 @@ export type SwapTransactionStatusDetails = {
   receivedAmount?: string;
   networkFees: string;
   receiveAccount: string;
+  // Present when the provider is expected to expose a website link; absent when it should show name-only.
+  providerUrl?: string;
 };
 
 export default class SwapTransactionStatusDrawer {
@@ -23,6 +25,7 @@ export default class SwapTransactionStatusDrawer {
   networkFeesId = "swap-transaction-details-network-fees";
   receiveAccountId = "swap-transaction-details-receive-account";
   providerId = "swap-transaction-details-provider";
+  providerLinkId = "swap-transaction-details-provider-link";
   swapIdId = "swap-transaction-details-swap-id";
   viewInExplorerButtonId = "swap-transaction-view-explorer-btn";
 
@@ -64,6 +67,20 @@ export default class SwapTransactionStatusDrawer {
     jestExpect(normalizeText(await getTextOfElement(this.providerId))).toEqual(
       normalizeText(provider.uiName),
     );
+    // Only providers with a configured URL render the provider name as a link (QAA-721 / LIVE-18412).
+    // Verify the link (and its URL) when expected; assert its absence otherwise.
+    if (details.providerUrl) {
+      await scrollToId(this.providerLinkId, this.scrollViewId);
+      await detoxExpect(getElementById(this.providerLinkId)).toBeVisible();
+      const { value, label } = await getAttributesOfElement(this.providerLinkId);
+      if (isIos()) {
+        jestExpect(value).toContain(details.providerUrl);
+      } else {
+        jestExpect(label).toContain(details.providerUrl);
+      }
+    } else {
+      await detoxExpect(getElementById(this.providerLinkId)).not.toBeVisible();
+    }
     jestExpect(normalizeText(await getTextOfElement(this.swapIdId))).toContain(swapIdPrefix);
 
     await waitForElementById(this.viewInExplorerButtonId, DEFAULT_TIMEOUT, {

--- a/e2e/mobile/specs/swap/otherTestCases/swapSeeHistoryOperations.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapSeeHistoryOperations.spec.ts
@@ -24,6 +24,7 @@ const swapHistoryTestConfig = {
     sentAmount: "0.07 SOL",
     networkFees: "0.000005 SOL",
     receiveAccount: "Ethereum 1",
+    providerUrl: "https://www.exodus.com/",
   },
 };
 


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _The change is E2E test code plus additive test/accessibility hooks. The swap-history E2E specs (B2CQA-602/604) provide the coverage and run in CI (Speculos required — not runnable locally). The app-side hooks are additive and validated by typecheck; app unit tests were not run locally due to unrelated workspace-install gaps in the sandbox._
- [x] **Impact of the changes:**
      - Swap → History → transaction-details drawer: provider row / link (desktop & mobile)
      - Provider link URL verification (Exodus → https://www.exodus.com/)
      - No user-facing behavior change (additive `data-href` / `testID` / accessibility value)

### Description

Following [LIVE-18412](https://ledgerhq.atlassian.net/browse/LIVE-18412), not all swap providers expose a website link in the transaction-details drawer (History): the link is rendered only when the provider has a configured URL, otherwise the provider name is shown as plain text. The E2E tests previously asserted only the provider **name** and never verified the link.

This PR adds **conditional provider-link verification**:

- **App test hooks (additive, no behavior change):** the desktop provider-link `<button>` gets `data-href={providerMainUrl}` (mirroring the existing "view in explorer" link); the mobile provider-link `<Pressable>` gets `testID="swap-transaction-details-provider-link"` + `accessibilityValue={{ text: providerMainUrl }}` (mirroring the swap-history feedback link).
- **E2E:** when the provider is expected to have a URL (carried in each history spec's `details.providerUrl`), assert the link is present and points to the expected URL — desktop via `data-href`, mobile via `value` (iOS) / `label` (Android). Otherwise assert the link is **absent**. The link is never tapped (tapping opens an external browser — the original crash path in LIVE-18412).

The only provider exercised by the current history specs is Exodus, which has a URL, so the link-present path is covered; the link-absent branch is defensive.

### Context

- **JIRA or GitHub link**: [QAA-721](https://ledgerhq.atlassian.net/browse/QAA-721)
- **Desktop CI**: https://github.com/LedgerHQ/ledger-live/actions/runs/29425087607
- **Mobile CI**: https://github.com/LedgerHQ/ledger-live/actions/runs/29425103955

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-18412]: https://ledgerhq.atlassian.net/browse/LIVE-18412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QAA-721]: https://ledgerhq.atlassian.net/browse/QAA-721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ