### PR TITLE
refactor(feature-flags): move getAllFeatureFlags to data/utils

### DIFF
--- a/shared/feature-flags/src/constants.ts
+++ b/shared/feature-flags/src/constants.ts
@@ -1,4 +1,4 @@
-import type { Feature, FeatureId, Features, FeatureFlagsState } from "./data/schema";
+import type { Feature, Features, FeatureFlagsState } from "./data/schema";
 import * as flags from "./flags";
 
 /**
@@ -29,18 +29,3 @@ export const FEATURE_FLAGS_INITIAL_STATE: FeatureFlagsState = {
 
 /** Default polling interval for fetching remote flags, in milliseconds: 5 minutes. */
 export const FEATURE_FLAGS_REMOTE_POLLING_INTERVAL_MS = 5 * 60 * 1000;
-
-/**
- * Resolves every known feature flag via the provided `getFeature` accessor, returning a map of
- * the non-null results. Used by debug tooling and E2E suites to snapshot the full flag state.
- */
-export const getAllFeatureFlags = (
-  getFeature: (key: FeatureId) => Feature | null,
-): Partial<{ [key in FeatureId]: Feature }> => {
-  const res: Partial<{ [key in FeatureId]: Feature }> = {};
-  (Object.keys(FEATURE_FLAGS_DEFAULTS) as FeatureId[]).forEach(key => {
-    const value = getFeature(key);
-    if (value !== null) res[key] = value;
-  });
-  return res;
-};

--- a/shared/feature-flags/src/data/utils.test.ts
+++ b/shared/feature-flags/src/data/utils.test.ts
@@ -1,4 +1,26 @@
-import { isValidFeatureId } from "./utils";
+import { isValidFeatureId, getAllFeatureFlags } from "./utils";
+import { FEATURE_FLAGS_DEFAULTS } from "../constants";
+import type { Feature, FeatureId } from "./schema";
+
+const mockFeature: Feature = { enabled: true };
+
+describe("getAllFeatureFlags", () => {
+  it("includes all flags when getFeature always returns a value", () => {
+    const result = getAllFeatureFlags(() => mockFeature);
+    const keys = Object.keys(FEATURE_FLAGS_DEFAULTS) as FeatureId[];
+    expect(Object.keys(result)).toEqual(keys);
+    keys.forEach(key => expect(result[key]).toBe(mockFeature));
+  });
+
+  it("omits flags for which getFeature returns null", () => {
+    const result = getAllFeatureFlags(key => (key === "mockFeature" ? mockFeature : null));
+    expect(result).toEqual({ mockFeature: mockFeature });
+  });
+
+  it("returns an empty object when getFeature always returns null", () => {
+    expect(getAllFeatureFlags(() => null)).toEqual({});
+  });
+});
 
 describe("isValidFeatureId", () => {
   it("returns true for a registered flag id", () => {

--- a/shared/feature-flags/src/data/utils.test.ts
+++ b/shared/feature-flags/src/data/utils.test.ts
@@ -1,13 +1,13 @@
 import { isValidFeatureId, getAllFeatureFlags } from "./utils";
-import { FEATURE_FLAGS_DEFAULTS } from "../constants";
-import type { Feature, FeatureId } from "./schema";
+import { FeatureIdSchema } from "./schema";
+import type { Feature } from "./schema";
 
 const mockFeature: Feature = { enabled: true };
 
 describe("getAllFeatureFlags", () => {
   it("includes all flags when getFeature always returns a value", () => {
     const result = getAllFeatureFlags(() => mockFeature);
-    const keys = Object.keys(FEATURE_FLAGS_DEFAULTS) as FeatureId[];
+    const keys = FeatureIdSchema.options;
     expect(Object.keys(result)).toEqual(keys);
     keys.forEach(key => expect(result[key]).toBe(mockFeature));
   });

--- a/shared/feature-flags/src/data/utils.ts
+++ b/shared/feature-flags/src/data/utils.ts
@@ -1,5 +1,4 @@
 import { FeatureIdSchema, type Feature, type FeatureId } from "./schema";
-import { FEATURE_FLAGS_DEFAULTS } from "../constants";
 
 const FEATURE_ID_SET = new Set<string>(FeatureIdSchema.options);
 
@@ -16,9 +15,9 @@ export function getAllFeatureFlags(
   getFeature: (key: FeatureId) => Feature | null,
 ): Partial<{ [key in FeatureId]: Feature }> {
   const res: Partial<{ [key in FeatureId]: Feature }> = {};
-  (Object.keys(FEATURE_FLAGS_DEFAULTS) as FeatureId[]).forEach(key => {
+  for (const key of FeatureIdSchema.options) {
     const value = getFeature(key);
     if (value !== null) res[key] = value;
-  });
+  }
   return res;
 }

--- a/shared/feature-flags/src/data/utils.ts
+++ b/shared/feature-flags/src/data/utils.ts
@@ -1,8 +1,24 @@
-import { FeatureIdSchema, type FeatureId } from "./schema";
+import { FeatureIdSchema, type Feature, type FeatureId } from "./schema";
+import { FEATURE_FLAGS_DEFAULTS } from "../constants";
 
 const FEATURE_ID_SET = new Set<string>(FeatureIdSchema.options);
 
 /** Type guard: whether a string is a registered feature flag id. */
 export function isValidFeatureId(key: string): key is FeatureId {
   return FEATURE_ID_SET.has(key);
+}
+
+/**
+ * Resolves every known feature flag via the provided `getFeature` accessor, returning a map of
+ * the non-null results. Used by debug tooling and E2E suites to snapshot the full flag state.
+ */
+export function getAllFeatureFlags(
+  getFeature: (key: FeatureId) => Feature | null,
+): Partial<{ [key in FeatureId]: Feature }> {
+  const res: Partial<{ [key in FeatureId]: Feature }> = {};
+  (Object.keys(FEATURE_FLAGS_DEFAULTS) as FeatureId[]).forEach(key => {
+    const value = getFeature(key);
+    if (value !== null) res[key] = value;
+  });
+  return res;
 }


### PR DESCRIPTION
## Summary

This [PR](https://github.com/LedgerHQ/ledger-live/pull/19062) introduces a utility function in `constants.ts`

- Moves `getAllFeatureFlags` from `constants.ts` to `data/utils.ts`, co-locating it with the other utility functions (`isValidFeatureId`)
- Converts the `const` arrow function to a `function` declaration
- Public API is unchanged — `data/utils` is re-exported through `data/index` → `index`

## Test plan

- [ ] TypeScript compiles without errors in `@shared/feature-flags`
- [ ] Existing consumers (`DebugMock`, e2e suites) resolve `getAllFeatureFlags` from the package index as before