### PR TITLE
[LWDM] fix(coin-evm): pass contract address as staking operation recipient

### DIFF
--- a/.changeset/clean-lions-rest.md
+++ b/.changeset/clean-lions-rest.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/coin-evm": patch
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Fix EVM staking operation history showing the user's own address instead of the staking contract as recipient

--- a/apps/ledger-live-desktop/src/renderer/families/evm/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/ClaimRewardsFlowModal/Body.tsx
@@ -30,6 +30,7 @@ import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmati
 import { St, StepId, StepProps } from "./types";
 import { findDelegationByValidator } from "./utils";
 import type { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
+import { getStakingContractAddress } from "@ledgerhq/coin-evm/staking/index";
 
 export type Data = {
   account: Account;
@@ -114,12 +115,16 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
         findDelegationByValidator(validatorAddressFromParams, delegations)) ||
       getDelegationWithMaximumReward(delegations);
 
+    const contractAddress = getStakingContractAddress(account.currency.id, {
+      mode: "claimReward",
+      valAddress: delegation.validatorAddress,
+    });
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode: "claimReward",
       valAddress: delegation.validatorAddress,
       valId: delegation.validatorId,
-      recipient: account.freshAddress,
+      recipient: contractAddress ?? account.freshAddress,
     }) as unknown as EvmTransaction;
     return {
       account,

--- a/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/steps/StepDelegation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/steps/StepDelegation.tsx
@@ -1,4 +1,5 @@
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { getStakingContractAddress } from "@ledgerhq/coin-evm/staking/index";
 import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
 import invariant from "invariant";
 import React, { useCallback } from "react";
@@ -24,15 +25,20 @@ export default function StepDelegation({
   const bridge = useAccountBridge<GenericTransaction>(account, parentAccount);
   const updateValidator = useCallback(
     (address: string, valId?: string) => {
-      onUpdateTransaction(_tx =>
-        bridge.updateTransaction(transaction, {
+      const contractAddress = getStakingContractAddress(account.currency.id, {
+        mode: "delegate",
+        valAddress: address,
+      });
+      onUpdateTransaction(tx =>
+        bridge.updateTransaction(tx, {
           mode: "delegate",
           valAddress: address,
           valId,
+          recipient: contractAddress ?? account.freshAddress,
         }),
       );
     },
-    [bridge, onUpdateTransaction, transaction],
+    [bridge, onUpdateTransaction, account.currency.id, account.freshAddress],
   );
 
   const chosenVoteAccAddr = transaction.valAddress || "";

--- a/apps/ledger-live-desktop/src/renderer/families/evm/RedelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/RedelegationFlowModal/Body.tsx
@@ -12,6 +12,7 @@ import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
+import { useStakingContractAddress } from "@ledgerhq/live-common/families/evm/staking/react";
 import { StepId, StepProps, St } from "./types";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -105,6 +106,11 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
   const { account, validatorAddress, source = "Account Page" } = params;
 
   const bridge = useAccountBridge<EvmTransaction>(account, undefined);
+  const contractAddress = useStakingContractAddress(account.currency.id, {
+    mode: "redelegate",
+    valAddress: validatorAddress ?? undefined,
+  });
+
   const {
     transaction,
     setTransaction,
@@ -122,7 +128,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     const transaction = bridge.updateTransaction(baseTransaction, {
       mode: "redelegate",
       valAddress: validatorAddress ?? "",
-      recipient: account.freshAddress,
+      recipient: contractAddress ?? account.freshAddress,
       ...(sourceDelegation && { amount: sourceDelegation.amount }),
     } as unknown as Partial<EvmTransaction>);
     return {

--- a/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/Body.tsx
@@ -26,6 +26,7 @@ import logger from "~/renderer/logger";
 import type { StakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
 import { isStakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
 import type { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
+import { useStakingContractAddress } from "@ledgerhq/live-common/families/evm/staking/react";
 
 export type Data = {
   account: StakingAccount;
@@ -83,6 +84,10 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
   const dispatch = useDispatch();
   const { account, validatorAddress, source = "Account Page" } = params;
   const bridge = useAccountBridge<EvmTransaction>(account, undefined);
+  const contractAddress = useStakingContractAddress(account.currency.id, {
+    mode: "undelegate",
+    valAddress: validatorAddress,
+  });
 
   const {
     transaction,
@@ -94,8 +99,6 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     bridgePending,
   } = useBridgeTransaction(bridge, () => {
     invariant(isStakingAccount(account), "evm: account with staking resources required");
-    // Pre-populate the transaction with the existing delegation amount so the user starts
-    // on a valid "undelegate all" intent. The amount field lets them reduce it afterwards.
     const delegation = account.stakingResources.delegations.find(
       d => d.validatorAddress === validatorAddress,
     );
@@ -103,7 +106,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     const transaction = bridge.updateTransaction(baseTransaction, {
       mode: "undelegate",
       valAddress: validatorAddress,
-      recipient: account.freshAddress,
+      recipient: contractAddress ?? account.freshAddress,
       amount: delegation?.amount,
       useAllAmount: false,
       valId: delegation?.validatorId,

--- a/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/Body.tsx
@@ -26,6 +26,7 @@ import logger from "~/renderer/logger";
 import type { StakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
 import { isStakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
 import type { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
+import { useStakingContractAddress } from "@ledgerhq/live-common/families/evm/staking/react";
 import { BigNumber } from "bignumber.js";
 
 export type Data = {
@@ -95,19 +96,22 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     source = "Account Page",
   } = params;
   const bridge = useAccountBridge<EvmTransaction>(account, undefined);
+  const contractAddress = useStakingContractAddress(account.currency.id, {
+    mode: "withdraw",
+    valAddress: validatorAddress,
+  });
 
   const { transaction, parentAccount, status, bridgeError, bridgePending } = useBridgeTransaction(
     bridge,
     () => {
       invariant(isStakingAccount(account), "evm: account with staking resources required");
-      // Monad: finalize the matured withdrawal slot via `withdraw(validatorId, withdrawId)`.
       const baseTransaction = bridge.createTransaction(account);
       const transaction = bridge.updateTransaction(baseTransaction, {
         mode: "withdraw",
         valAddress: validatorAddress,
         valId: validatorId,
         withdrawId: withdrawId?.toString(),
-        recipient: account.freshAddress,
+        recipient: contractAddress ?? account.freshAddress,
         amount,
         useAllAmount: false,
       } as unknown as Partial<EvmTransaction>);

--- a/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/02-Claim.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/02-Claim.tsx
@@ -8,6 +8,7 @@ import { useTheme } from "@react-navigation/native";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { hasCompound } from "@ledgerhq/live-common/families/evm/staking/logic";
+import { getStakingContractAddress } from "@ledgerhq/coin-evm/staking/index";
 import type {
   GenericTransaction,
   GenericTransactionMode,
@@ -67,10 +68,12 @@ function ClaimRewardsClaim({ navigation, route }: Props) {
 
   const { transaction, status, bridgePending, bridgeError, updateTransaction } =
     useBridgeTransaction(bridge, () => {
-      const base = bridge.updateTransaction(bridge.createTransaction(account), {
-        recipient: account.freshAddress,
+      const contractAddress = getStakingContractAddress(account.currency.id, {
+        mode: "claimReward",
+        valAddress: validator.validatorAddress,
       });
-      const claimTx = bridge.updateTransaction(base, {
+      const claimTx = bridge.updateTransaction(bridge.createTransaction(account), {
+        recipient: contractAddress ?? account.freshAddress,
         mode: "claimReward",
         valAddress: validator.validatorAddress,
         valId: validator.validatorId,
@@ -83,16 +86,22 @@ function ClaimRewardsClaim({ navigation, route }: Props) {
 
   const evmTransaction = transaction as unknown as GenericTransaction;
   const mode = evmTransaction.mode ?? "claimReward";
+
   const onChangeMode = useCallback(
     (nextMode: string) => {
+      const contractAddress = getStakingContractAddress(account.currency.id, {
+        mode: nextMode === "compoundReward" ? "compoundReward" : "claimReward",
+        valAddress: evmTransaction.valAddress,
+      });
       updateTransaction(
         () =>
           bridge.updateTransaction(evmTransaction, {
             mode: nextMode as GenericTransactionMode,
+            recipient: contractAddress ?? account.freshAddress,
           }) as unknown as Transaction,
       );
     },
-    [bridge, updateTransaction, evmTransaction],
+    [bridge, updateTransaction, evmTransaction, account.currency.id, account.freshAddress],
   );
 
   const [infoModalOpen, setInfoModalOpen] = useState(false);

--- a/apps/ledger-live-mobile/src/families/evm/DelegationFlow/01-SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/DelegationFlow/01-SelectValidator.tsx
@@ -2,7 +2,11 @@
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
 import { useFeature } from "@features/platform-feature-flags";
-import { useEvmStakingValidators } from "@ledgerhq/live-common/families/evm/staking/react";
+import {
+  useEvmStakingValidators,
+  useStakingContractAddress,
+} from "@ledgerhq/live-common/families/evm/staking/react";
+import { getStakingContractAddress } from "@ledgerhq/coin-evm/staking/index";
 import { sortLedgerValidatorFirst } from "@ledgerhq/live-common/families/evm/staking/ledgerValidator";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import {
@@ -78,19 +82,27 @@ export default function SelectValidator({ navigation, route }: Props) {
 
     return sortLedgerValidatorFirst(sorted, account.currency.id);
   }, [account.currency.id, account.stakingResources?.validators, fetchedValidators, searchQuery]);
+  const contractAddress = useStakingContractAddress(account.currency.id, {
+    mode: "delegate",
+  });
   const baseTransaction = useMemo(() => {
     const transaction = bridge.createTransaction(account);
     return bridge.updateTransaction(transaction, {
-      recipient: account.freshAddress,
+      recipient: contractAddress ?? account.freshAddress,
     });
-  }, [account, bridge]);
+  }, [account, bridge, contractAddress]);
 
   const onItemPress = useCallback(
     (validator: StakingValidatorItem) => {
+      const contractAddress = getStakingContractAddress(account.currency.id, {
+        mode: "delegate",
+        valAddress: validator.validatorAddress,
+      });
       const transaction = bridge.updateTransaction(baseTransaction, {
         mode: "delegate",
         valAddress: validator.validatorAddress,
         valId: validator.validatorId,
+        recipient: contractAddress ?? account.freshAddress,
       }) as unknown as Transaction;
 
       navigation.navigate(ScreenName.EvmDelegationAmount, {
@@ -99,7 +111,7 @@ export default function SelectValidator({ navigation, route }: Props) {
         validator,
       });
     },
-    [baseTransaction, bridge, navigation, route.params],
+    [account.currency.id, account.freshAddress, baseTransaction, bridge, navigation, route.params],
   );
 
   const renderItem = useCallback(

--- a/apps/ledger-live-mobile/src/families/evm/DelegationFlow/04-SelectRedelegationValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/DelegationFlow/04-SelectRedelegationValidator.tsx
@@ -3,6 +3,7 @@ import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge"
 import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
 import { useFeature } from "@features/platform-feature-flags";
 import { useEvmStakingValidators } from "@ledgerhq/live-common/families/evm/staking/react";
+import { getStakingContractAddress } from "@ledgerhq/coin-evm/staking/index";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import {
   canRedelegate,
@@ -83,6 +84,10 @@ export default function SelectRedelegationValidator() {
   const onItemPress = useCallback(
     (validator: StakingValidatorItem) => {
       invariant(sourceDelegation, "source delegation required");
+      const contractAddress = getStakingContractAddress(account.currency.id, {
+        mode: "redelegate",
+        valAddress: sourceDelegation.validatorAddress,
+      });
       const baseTransaction = bridge.createTransaction(account);
       navigation.navigate(ScreenName.EvmRedelegationAmount, {
         ...route.params,
@@ -91,7 +96,7 @@ export default function SelectRedelegationValidator() {
           valAddress: sourceDelegation.validatorAddress,
           dstValAddress: validator.validatorAddress,
           amount: sourceDelegation.amount,
-          recipient: account.freshAddress,
+          recipient: contractAddress ?? account.freshAddress,
         }) as unknown as Transaction,
         validator,
         validatorSrc: sourceValidator,

--- a/apps/ledger-live-mobile/src/families/evm/UndelegationFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/UndelegationFlow/01-Amount.tsx
@@ -8,6 +8,7 @@ import {
   hasUnbondingPeriod,
 } from "@ledgerhq/live-common/families/evm/staking/logic";
 import { isStakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
+import { getStakingContractAddress } from "@ledgerhq/coin-evm/staking/index";
 import type { TransactionStatus } from "@ledgerhq/coin-evm/types/index";
 import { Alert, Text } from "@ledgerhq/native-ui";
 import BigNumber from "bignumber.js";
@@ -58,6 +59,10 @@ export default function UndelegationAmount({ navigation, route }: Props) {
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
     bridge,
     () => {
+      const contractAddress = getStakingContractAddress(account.currency.id, {
+        mode: "undelegate",
+        valAddress: delegation.validatorAddress,
+      });
       const tx = bridge.createTransaction(account);
       return {
         account,
@@ -66,7 +71,7 @@ export default function UndelegationAmount({ navigation, route }: Props) {
           mode: "undelegate",
           valAddress: delegation.validatorAddress,
           valId: delegation.validatorId,
-          recipient: account.freshAddress,
+          recipient: contractAddress ?? account.freshAddress,
         }) as unknown as Transaction,
       };
     },

--- a/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/01-Withdraw.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/01-Withdraw.tsx
@@ -8,6 +8,7 @@ import { Alert, Flex, Text } from "@ledgerhq/native-ui";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
+import { getStakingContractAddress } from "@ledgerhq/coin-evm/staking/index";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { TransactionStatus } from "@ledgerhq/coin-evm/types/index";
 import { Trans } from "~/context/Locale";
@@ -39,17 +40,24 @@ function Withdraw() {
   const bridge = useAccountBridge<GenericTransaction>(account);
 
   const { transaction, status, bridgePending, bridgeError } = useBridgeTransaction(bridge, () => {
-    // Monad: finalize the matured withdrawal slot via `withdraw(validatorId, withdrawId)`.
+    const contractAddress = getStakingContractAddress(account.currency.id, {
+      mode: "withdraw",
+      valAddress: unbonding.validatorAddress,
+    });
     const withdrawTx = bridge.updateTransaction(bridge.createTransaction(account), {
       mode: "withdraw",
       valAddress: unbonding.validatorAddress,
       valId: unbonding.validatorId,
       withdrawId: unbonding.withdrawId?.toString(),
-      recipient: account.freshAddress,
+      recipient: contractAddress ?? account.freshAddress,
       amount: unbonding.amount,
       useAllAmount: false,
     });
-    return { account, parentAccount: undefined, transaction: withdrawTx as unknown as Transaction };
+    return {
+      account,
+      parentAccount: undefined,
+      transaction: withdrawTx as unknown as Transaction,
+    };
   });
 
   invariant(transaction, "transaction required");

--- a/libs/coin-modules/coin-evm/src/staking/contracts.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/contracts.test.ts
@@ -1,0 +1,19 @@
+import { getStakingContractAddress } from "./contracts";
+
+describe("getStakingContractAddress", () => {
+  it.each([
+    ["0x55E1A0C8f376964bd339167476063bFED7f213d5", "celo", undefined],
+    ["0x0000000000000000000000000000000000001000", "monad", undefined],
+    ["0x0000000000000000000000000000000000001005", "sei_evm", { mode: "delegate" }],
+    ["0x0000000000000000000000000000000000001007", "sei_evm", { mode: "claimReward" }],
+    [
+      "0x1111111111111111111111111111111111111111",
+      "zero_gravity",
+      { mode: "delegate", valAddress: "0x1111111111111111111111111111111111111111" },
+    ],
+    [undefined, "zero_gravity", { mode: "delegate" }],
+    [undefined, "unknown_chain", undefined],
+  ] as const)("returns %s for %s", (expected, currencyId, ctx) => {
+    expect(getStakingContractAddress(currencyId, ctx)).toEqual(expected);
+  });
+});

--- a/libs/coin-modules/coin-evm/src/staking/contracts.ts
+++ b/libs/coin-modules/coin-evm/src/staking/contracts.ts
@@ -1,7 +1,20 @@
 import { ethers } from "ethers";
-import type { StakingContractConfig } from "../types/staking";
+import type { StakingContractConfig, StakingOperation } from "../types/staking";
 import { USEI_TO_EVM_SCALE } from "../utils";
 import { getValidatorAddressById } from "./validators/monadResolver";
+
+export function getStakingContractAddress(
+  currencyId: string,
+  ctx?: { mode: StakingOperation; valAddress?: string },
+): string | undefined {
+  const config = STAKING_CONTRACTS[currencyId];
+  if (!config) return undefined;
+  try {
+    return config.contractAddress(ctx);
+  } catch {
+    return undefined;
+  }
+}
 
 export const STAKING_CONTRACTS: Record<string, StakingContractConfig> = {
   // Sei EVM staking

--- a/libs/coin-modules/coin-evm/src/staking/index.ts
+++ b/libs/coin-modules/coin-evm/src/staking/index.ts
@@ -1,4 +1,4 @@
-export { STAKING_CONTRACTS } from "./contracts";
+export { STAKING_CONTRACTS, getStakingContractAddress } from "./contracts";
 export { STAKING_CONFIG } from "./fetchers";
 export { buildTransactionParams } from "./operations";
 export { buildStakingTransactionParams } from "./transactionData";

--- a/libs/ledger-live-common/src/families/evm/staking/react.test.ts
+++ b/libs/ledger-live-common/src/families/evm/staking/react.test.ts
@@ -13,6 +13,7 @@ import {
   useEvmFamilyPreloadData,
   useEvmFamilyMappedDelegations,
   useEvmFamilyDelegationsQuerySelector,
+  useStakingContractAddress,
 } from "./react";
 import { GenericTransaction } from "bridge/generic-coin-framework/types";
 
@@ -632,5 +633,34 @@ describe("useEvmFamilyDelegationsQuerySelector", () => {
       expect.objectContaining({ validatorAddress: "0x02" }),
     ]);
     expect(result.current.value).toBeUndefined();
+  });
+});
+
+describe("useStakingContractAddress", () => {
+  it("returns the celo contract address with no ctx", () => {
+    const { result } = renderHook(() => useStakingContractAddress("celo"));
+    expect(result.current).toEqual("0x55E1A0C8f376964bd339167476063bFED7f213d5");
+  });
+
+  it("returns the validator address for zero_gravity delegate with valAddress", () => {
+    const { result } = renderHook(() =>
+      useStakingContractAddress("zero_gravity", {
+        mode: "delegate",
+        valAddress: "0x1111111111111111111111111111111111111111",
+      }),
+    );
+    expect(result.current).toEqual("0x1111111111111111111111111111111111111111");
+  });
+
+  it("returns undefined for zero_gravity delegate without valAddress", () => {
+    const { result } = renderHook(() =>
+      useStakingContractAddress("zero_gravity", { mode: "delegate" }),
+    );
+    expect(result.current).toEqual(undefined);
+  });
+
+  it("returns undefined for an unknown currencyId", () => {
+    const { result } = renderHook(() => useStakingContractAddress("unknown_chain"));
+    expect(result.current).toEqual(undefined);
   });
 });

--- a/libs/ledger-live-common/src/families/evm/staking/react.ts
+++ b/libs/ledger-live-common/src/families/evm/staking/react.ts
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
-import { getValidators, mapDelegations } from "@ledgerhq/coin-evm/staking/index";
+import {
+  getStakingContractAddress,
+  getValidators,
+  mapDelegations,
+} from "@ledgerhq/coin-evm/staking/index";
+import type { StakingOperation } from "@ledgerhq/coin-evm/types/staking";
 import type { Cursor } from "@ledgerhq/coin-module-framework/api/index";
 import type { StakingValidatorItem } from "@ledgerhq/types-live";
 import { sortLedgerValidatorFirst } from "./ledgerValidator";
@@ -164,4 +169,20 @@ export function useEvmFamilyDelegationsQuerySelector(
     options,
     value,
   };
+}
+
+export function useStakingContractAddress(
+  currencyId: string,
+  ctx?: { mode: StakingOperation; valAddress?: string },
+): string | undefined {
+  const mode = ctx?.mode;
+  const valAddress = ctx?.valAddress;
+  return useMemo(
+    () =>
+      getStakingContractAddress(
+        currencyId,
+        typeof mode === "string" ? { mode, valAddress } : undefined,
+      ),
+    [currencyId, mode, valAddress],
+  );
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Fix EVM staking optimistic operations always showing `account.freshAddress` as recipient instead of the contract address.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-34342
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
