### PR TITLE
[LWDM] refactor(market): remove findCryptoCurrencyByTicker re-lookups in counter-value paths

### DIFF
--- a/.changeset/clean-market-ticker-lookup.md
+++ b/.changeset/clean-market-ticker-lookup.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+"live-mobile": patch
+"ledger-live-desktop": patch
+---
+
+Remove findCryptoCurrencyByTicker re-lookups in market counter-value formatting and detection paths

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchResultRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchResultRow.tsx
@@ -5,21 +5,14 @@ import { AssetSuggestionRow } from "LLD/features/SearchAssets/components/AssetSu
 
 type SearchResultRowProps = {
   currency: MarketCurrencyData;
-  counterCurrency: string;
   locale: string;
   onClick: (currencyId: string, marketState?: AssetNavigationMarketState) => void;
 };
 
-export function SearchResultRow({
-  currency,
-  counterCurrency,
-  locale,
-  onClick,
-}: Readonly<SearchResultRowProps>) {
+export function SearchResultRow({ currency, locale, onClick }: Readonly<SearchResultRowProps>) {
   return (
     <AssetSuggestionRow
       currency={currency}
-      counterCurrency={counterCurrency}
       locale={locale}
       testIdPrefix="search-result"
       onClick={onClick}

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchResultsList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarSearch/SearchOverlay/content/SearchResultsList.tsx
@@ -13,18 +13,13 @@ const SKELETON_COUNT = VISIBLE_RESULTS;
 
 export function SearchResultsList() {
   const { results, navigateToAsset } = useSearchOverlay();
-  const { locale, counterCurrency } = useAssetSuggestionsSectionViewModel();
+  const { locale } = useAssetSuggestionsSectionViewModel();
 
   const renderResult = useCallback(
     (currency: MarketCurrencyData) => (
-      <SearchResultRow
-        currency={currency}
-        counterCurrency={counterCurrency}
-        locale={locale}
-        onClick={navigateToAsset}
-      />
+      <SearchResultRow currency={currency} locale={locale} onClick={navigateToAsset} />
     ),
-    [counterCurrency, locale, navigateToAsset],
+    [locale, navigateToAsset],
   );
 
   if (results.isLoading) {

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
@@ -118,6 +118,7 @@ export function useChartSectionViewModel({
   } = useAssetDetailChartSeries({
     id,
     counterCurrency,
+    isCryptoCountervalue: counterValueCurrency.type === "CryptoCurrency",
     selectedRange,
     ath,
     atl,

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/MarketStats/hooks/useMarketStatsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/MarketStats/hooks/useMarketStatsViewModel.ts
@@ -11,7 +11,7 @@ const MISSING = "-";
 
 export function useMarketStatsViewModel(currencyData: MarketDataSectionCurrencyData) {
   const { t } = useTranslation();
-  const { data, showSkeleton, counterCurrency, locale, ledgerCurrencyId } = currencyData;
+  const { data, showSkeleton, counterValueUnit, locale, ledgerCurrencyId } = currencyData;
 
   const sectionTitle = t("assetDetails.marketStats");
   const sectionTooltip = t("assetDetails.marketStatsTooltip");
@@ -19,7 +19,7 @@ export function useMarketStatsViewModel(currencyData: MarketDataSectionCurrencyD
   const rows: MarketStatRow[] = useMemo(() => {
     const marketCap = counterValueFormatter({
       value: data?.marketcap,
-      currency: counterCurrency.toUpperCase(),
+      unit: counterValueUnit,
       locale,
       shorten: true,
     });
@@ -40,7 +40,7 @@ export function useMarketStatsViewModel(currencyData: MarketDataSectionCurrencyD
 
     const volume24h = counterValueFormatter({
       value: data?.totalVolume,
-      currency: counterCurrency.toUpperCase(),
+      unit: counterValueUnit,
       locale,
       shorten: true,
     });
@@ -80,7 +80,7 @@ export function useMarketStatsViewModel(currencyData: MarketDataSectionCurrencyD
       },
     ];
   }, [
-    counterCurrency,
+    counterValueUnit,
     data?.circulatingSupply,
     data?.marketcap,
     data?.marketcapRank,

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/PricePerformance/hooks/usePricePerformanceViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/PricePerformance/hooks/usePricePerformanceViewModel.ts
@@ -31,15 +31,14 @@ function formatPctVsReference(
 
 export function usePricePerformanceViewModel(currencyData: MarketDataSectionCurrencyData) {
   const { t } = useTranslation();
-  const { data, showSkeleton, counterCurrency, locale } = currencyData;
+  const { data, showSkeleton, counterValueUnit, locale } = currencyData;
   const formatLongDate = useDateFormatter(longDayFormat);
 
   const sectionTitle = t("assetDetails.pricePerformance");
 
   const fiat = useMemo(
-    () => (value?: number) =>
-      counterValueFormatter({ value, currency: counterCurrency.toUpperCase(), locale }),
-    [counterCurrency, locale],
+    () => (value?: number) => counterValueFormatter({ value, unit: counterValueUnit, locale }),
+    [counterValueUnit, locale],
   );
 
   const athBlock: PricePerformanceBlock = useMemo(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/__tests__/useMarketDataSectionViewModels.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/__tests__/useMarketDataSectionViewModels.test.ts
@@ -12,12 +12,15 @@ jest.mock("~/renderer/hooks/useDateFormatter", () => ({
   fromNow: jest.fn(() => "2 years ago"),
 }));
 
+const usdUnit = { code: "$", name: "US Dollar", magnitude: 2, prefixCode: true };
+
 const buildCurrencyData = (
   overrides: Partial<MarketDataSectionCurrencyData> = {},
 ): MarketDataSectionCurrencyData => ({
   data: createMockMarketCurrencyData({ marketcapRank: 1 }),
   showSkeleton: false,
   counterCurrency: "usd",
+  counterValueUnit: usdUnit,
   locale: "en-US",
   ...overrides,
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/hooks/useMarketDataSectionCurrencyData.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketDataSection/hooks/useMarketDataSectionCurrencyData.ts
@@ -1,4 +1,5 @@
 import { useSelector } from "LLD/hooks/redux";
+import type { Unit } from "@ledgerhq/types-cryptoassets";
 import type { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
 import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
 import type { AssetMarketData } from "@ledgerhq/asset-detail";
@@ -8,6 +9,7 @@ export type MarketDataSectionCurrencyData = Readonly<{
   data?: MarketCurrencyData;
   showSkeleton: boolean;
   counterCurrency: string;
+  counterValueUnit: Unit;
   locale: string;
   ledgerCurrencyId?: string;
 }>;
@@ -17,7 +19,9 @@ export function useMarketDataSectionCurrencyData(
   isDistributionLoading: boolean,
   ledgerCurrencyId?: string,
 ): MarketDataSectionCurrencyData {
-  const counterCurrency = useSelector(counterValueCurrencySelector).ticker.toLowerCase();
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const counterCurrency = counterValueCurrency.ticker.toLowerCase();
+  const counterValueUnit = counterValueCurrency.units[0];
   const locale = useSelector(localeSelector);
   const hasData = marketData.marketCurrencyData != null;
 
@@ -29,6 +33,7 @@ export function useMarketDataSectionCurrencyData(
       hasData,
     ),
     counterCurrency,
+    counterValueUnit,
     locale,
     ledgerCurrencyId,
   };

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/useMarketPriceSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/MarketPriceSection/useMarketPriceSectionViewModel.ts
@@ -83,6 +83,7 @@ export function useMarketPriceSectionViewModel({
   const { prices: chartPrices } = useAssetDetailChartSeries({
     id: marketAssetId,
     counterCurrency: counterValueCurrency.ticker.toLowerCase(),
+    isCryptoCountervalue: counterValueCurrency.type === "CryptoCurrency",
     selectedRange,
     ath: data?.ath,
     atl: data?.atl,

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailChartSeries.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailChartSeries.test.ts
@@ -37,14 +37,14 @@ describe("useAssetDetailChartSeries", () => {
         useAssetDetailChartSeries({
           id: "bitcoin",
           counterCurrency: "btc",
-          isCryptoCountervalue: false,
+          isCryptoCountervalue: true,
           selectedRange: "1d",
         }),
       );
 
       // The chart now goes through the USD-fallback wrapper instead of useAssetChartData.
       expect(mockedUseAssetChartData).toHaveBeenCalledWith(
-        { id: "bitcoin", counterCurrency: "btc", range: "1d", isCryptoCountervalue: false },
+        { id: "bitcoin", counterCurrency: "btc", range: "1d", isCryptoCountervalue: true },
         { skip: false },
       );
       // The series is derived from the (rescaled) currentData the wrapper returns.

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailChartSeries.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailChartSeries.test.ts
@@ -34,12 +34,17 @@ describe("useAssetDetailChartSeries", () => {
   describe("counter value fallback", () => {
     it("builds the series from the counter-value-aware chart data and forwards request args", () => {
       const { result } = renderHook(() =>
-        useAssetDetailChartSeries({ id: "bitcoin", counterCurrency: "btc", selectedRange: "1d" }),
+        useAssetDetailChartSeries({
+          id: "bitcoin",
+          counterCurrency: "btc",
+          isCryptoCountervalue: false,
+          selectedRange: "1d",
+        }),
       );
 
       // The chart now goes through the USD-fallback wrapper instead of useAssetChartData.
       expect(mockedUseAssetChartData).toHaveBeenCalledWith(
-        { id: "bitcoin", counterCurrency: "btc", range: "1d" },
+        { id: "bitcoin", counterCurrency: "btc", range: "1d", isCryptoCountervalue: false },
         { skip: false },
       );
       // The series is derived from the (rescaled) currentData the wrapper returns.
@@ -57,11 +62,16 @@ describe("useAssetDetailChartSeries", () => {
 
     it("skips the request and uses an empty id when no id is provided", () => {
       renderHook(() =>
-        useAssetDetailChartSeries({ id: undefined, counterCurrency: "usd", selectedRange: "1d" }),
+        useAssetDetailChartSeries({
+          id: undefined,
+          counterCurrency: "usd",
+          isCryptoCountervalue: false,
+          selectedRange: "1d",
+        }),
       );
 
       expect(mockedUseAssetChartData).toHaveBeenCalledWith(
-        { id: "", counterCurrency: "usd", range: "1d" },
+        { id: "", counterCurrency: "usd", range: "1d", isCryptoCountervalue: false },
         { skip: true },
       );
     });
@@ -70,7 +80,12 @@ describe("useAssetDetailChartSeries", () => {
       mockChartData({ isLoading: true, isFetching: true, isError: true });
 
       const { result } = renderHook(() =>
-        useAssetDetailChartSeries({ id: "bitcoin", counterCurrency: "cop", selectedRange: "1d" }),
+        useAssetDetailChartSeries({
+          id: "bitcoin",
+          counterCurrency: "cop",
+          isCryptoCountervalue: false,
+          selectedRange: "1d",
+        }),
       );
 
       expect(result.current.isLoading).toBe(true);

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetDetailChartSeries.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetDetailChartSeries.ts
@@ -6,6 +6,7 @@ import { buildAssetDetailChartSeries } from "../utils/buildAssetDetailChartSerie
 type UseAssetDetailChartSeriesParams = Readonly<{
   id?: string;
   counterCurrency: string;
+  isCryptoCountervalue: boolean;
   selectedRange: LineChartRange;
   ath?: number;
   atl?: number;
@@ -17,6 +18,7 @@ type UseAssetDetailChartSeriesParams = Readonly<{
 export function useAssetDetailChartSeries({
   id,
   counterCurrency,
+  isCryptoCountervalue,
   selectedRange,
   ath,
   atl,
@@ -33,7 +35,7 @@ export function useAssetDetailChartSeries({
     isFetching,
     isError,
   } = useAssetChartDataInCounterValue(
-    { id: id ?? "", counterCurrency, range: selectedRange },
+    { id: id ?? "", counterCurrency, range: selectedRange, isCryptoCountervalue },
     { skip: !id || skip },
   );
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/hooks/useGlobalMarketCapViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/TopCards/components/GlobalMarketCapCard/hooks/useGlobalMarketCapViewModel.ts
@@ -6,7 +6,9 @@ import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducer
 import { track } from "~/renderer/analytics/segment";
 
 export const useGlobalMarketCapViewModel = () => {
-  const counterCurrency = useSelector(counterValueCurrencySelector).ticker.toLowerCase();
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const counterCurrency = counterValueCurrency.ticker.toLowerCase();
+  const counterValueUnit = counterValueCurrency.units[0];
   const locale = useSelector(localeSelector);
 
   // /v3/markets/global currently returns a USD-denominated market cap regardless of `to`.
@@ -23,7 +25,7 @@ export const useGlobalMarketCapViewModel = () => {
   return {
     value: marketCap
       ? counterValueFormatter({
-          currency: counterCurrency.toUpperCase(),
+          unit: counterValueUnit,
           value: marketCap,
           shorten: true,
           locale,

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/useMarketRowViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/useMarketRowViewModel.ts
@@ -14,6 +14,7 @@ import { track } from "~/renderer/analytics/segment";
 import { getCurrentTrackingPage } from "~/renderer/analytics/screenRefs";
 import { useSelector } from "LLD/hooks/redux";
 import { marketCategorySelector } from "~/renderer/reducers/market";
+import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
 
 type UseMarketRowViewModelProps = {
   size: number;
@@ -42,6 +43,7 @@ export function useMarketRowViewModel({
 
   const selectedCategory = useSelector(marketCategorySelector);
   const category = getMarketPageCategoryAnalytics(selectedCategory);
+  const counterValueUnit = useSelector(counterValueCurrencySelector).units[0];
   const {
     onBuy,
     onSell,
@@ -100,18 +102,18 @@ export function useMarketRowViewModel({
 
   const formattedPrice = counterValueFormatter({
     value: roundFiatPrice(currency.price ?? 0),
-    currency: counterCurrency,
+    unit: counterValueUnit,
     locale,
   });
   const formattedVolume = counterValueFormatter({
     shorten: true,
-    currency: counterCurrency,
+    unit: counterValueUnit,
     value: currency.totalVolume,
     locale,
   });
   const formattedMarketCap = counterValueFormatter({
     shorten: true,
-    currency: counterCurrency,
+    unit: counterValueUnit,
     value: currency.marketcap,
     locale,
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/RowItem/RowItemView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/RowItem/RowItemView.tsx
@@ -1,12 +1,10 @@
 import React, { memo } from "react";
 import { Text, Tooltip } from "@ledgerhq/react-ui";
 import FormattedVal from "~/renderer/components/FormattedVal";
-import counterValueFormatter from "@ledgerhq/live-common/market/utils/countervalueFormatter";
 import { SmallMarketItemChart } from "~/renderer/screens/market/components/MarketItemChart";
 import { Button, IconButton } from "@ledgerhq/lumen-ui-react";
 import { TableRow, TableCell } from "~/renderer/screens/market/components/Table";
 import { formatPercentage } from "~/renderer/screens/market/utils";
-import { roundFiatPrice } from "@ledgerhq/live-currency-format";
 import {
   CryptoCurrencyIconWrapper,
   CryptoNameContainer,
@@ -29,12 +27,12 @@ const ACTION_ICONS: Record<MarketActionType, typeof Plus> = {
 export const RowItemView = memo<RowItemViewProps>(function RowItemView({
   style,
   currency,
-  counterCurrency,
-  locale,
   isStarred,
   hasActions,
   actions,
   currentPriceChangePercentage,
+  formattedPrice,
+  formattedMarketCap,
   onCurrencyClick,
   onStarClick,
 }: RowItemViewProps) {
@@ -98,13 +96,7 @@ export const RowItemView = memo<RowItemViewProps>(function RowItemView({
           ) : null}
         </TableCell>
         <TableCell data-testid={"market-coin-price"}>
-          <Text variant="body">
-            {counterValueFormatter({
-              value: roundFiatPrice(currency.price ?? 0),
-              currency: counterCurrency,
-              locale,
-            })}
-          </Text>
+          <Text variant="body">{formattedPrice}</Text>
         </TableCell>
         <TableCell data-testid={"market-price-change"}>
           {currentPriceChangePercentage ? (
@@ -120,14 +112,7 @@ export const RowItemView = memo<RowItemViewProps>(function RowItemView({
         </TableCell>
 
         <TableCell data-testid={"market-cap"}>
-          <Text>
-            {counterValueFormatter({
-              shorten: true,
-              currency: counterCurrency,
-              value: currency.marketcap,
-              locale,
-            })}
-          </Text>
+          <Text>{formattedMarketCap}</Text>
         </TableCell>
         <TableCell data-testid={"market-small-graph"}>
           {currency.sparklineIn7d && (

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/RowItem/__tests__/RowItemView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/RowItem/__tests__/RowItemView.test.tsx
@@ -18,8 +18,8 @@ function createDefaultProps(overrides: Partial<RowItemViewProps> = {}): RowItemV
   return {
     style: {},
     currency: mockCurrency,
-    counterCurrency: "usd",
-    locale: "en",
+    formattedPrice: "$92,258.93",
+    formattedMarketCap: "$1.70T",
     isStarred: false,
     hasActions: false,
     actions: [],

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/RowItem/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/RowItem/index.tsx
@@ -18,14 +18,5 @@ export const RowItem = memo<RowItemContainerProps>(function RowItem({
     range,
   });
 
-  return (
-    <RowItemView
-      style={style}
-      currency={currency}
-      counterCurrency={counterCurrency}
-      locale={locale}
-      isStarred={isStarred}
-      {...viewModel}
-    />
-  );
+  return <RowItemView style={style} currency={currency} isStarred={isStarred} {...viewModel} />;
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/RowItem/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/RowItem/types.ts
@@ -21,12 +21,12 @@ export type RowItemContainerProps = {
 export type RowItemViewProps = {
   style: React.CSSProperties;
   currency: MarketCurrencyData;
-  counterCurrency?: string;
-  locale: string;
   isStarred: boolean;
   hasActions: boolean;
   actions: MarketAction[];
   currentPriceChangePercentage: number | undefined;
+  formattedPrice: string;
+  formattedMarketCap: string;
   onCurrencyClick: () => void;
   onStarClick: (e: React.MouseEvent<HTMLDivElement>) => void;
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/RowItem/useRowItemViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/RowItem/useRowItemViewModel.ts
@@ -8,6 +8,10 @@ import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { MarketCurrencyData, KeysPriceChange } from "@ledgerhq/live-common/market/utils/types";
 import { MarketAction } from "./types";
 import { getMarketOrAssetDetailPath } from "LLD/utils/marketAssetNavigation";
+import counterValueFormatter from "@ledgerhq/live-common/market/utils/countervalueFormatter";
+import { roundFiatPrice } from "@ledgerhq/live-currency-format";
+import { useSelector } from "LLD/hooks/redux";
+import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
 
 type UseRowItemViewModelProps = {
   currency?: MarketCurrencyData | null;
@@ -19,6 +23,8 @@ export function useRowItemViewModel({ currency, toggleStar, range }: UseRowItemV
   const navigate = useNavigate();
   const { t } = useTranslation();
   const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
+  const counterValueUnit = useSelector(counterValueCurrencySelector).units[0];
+  const locale = useSelector(localeSelector);
 
   const {
     onBuy,
@@ -82,11 +88,25 @@ export function useRowItemViewModel({ currency, toggleStar, range }: UseRowItemV
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const currentPriceChangePercentage = currency?.priceChangePercentage[range as KeysPriceChange];
 
+  const formattedPrice = counterValueFormatter({
+    value: roundFiatPrice(currency?.price ?? 0),
+    unit: counterValueUnit,
+    locale,
+  });
+  const formattedMarketCap = counterValueFormatter({
+    shorten: true,
+    unit: counterValueUnit,
+    value: currency?.marketcap,
+    locale,
+  });
+
   return {
     onCurrencyClick,
     onStarClick,
     actions,
     hasActions: actions.length > 0,
     currentPriceChangePercentage,
+    formattedPrice,
+    formattedMarketCap,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarket.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarket.test.ts
@@ -434,8 +434,8 @@ describe("useMarket", () => {
       expect(result.current.marketData[0].price).toBe(100);
     });
 
-    it("requests crypto counter values in USD and rescales by the USD->BTC rate", () => {
-      mockSupportedCounterCurrencies(undefined);
+    it("requests BTC counter values in USD and rescales by the USD->BTC rate when BTC is not natively supported", () => {
+      mockSupportedCounterCurrencies(["usd", "eur"]);
       mockedUseUsdToFiatRate.mockReturnValue({ status: "ready", rate: 0.00001 });
       mockMarketData([createMarketCurrencyData({ id: "bitcoin", price: 100, marketcap: 200 })]);
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
@@ -90,7 +90,8 @@ export function useMarket() {
   const marketCurrentPage = useSelector(marketCurrentPageSelector);
   const starredMarketCoins: string[] = useSelector(starredMarketCoinsSelector);
   const locale = useSelector(localeSelector);
-  const settingsCounterValue = useSelector(counterValueCurrencySelector).ticker.toLowerCase();
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const settingsCounterValue = counterValueCurrency.ticker.toLowerCase();
 
   const REFRESH_RATE = resolveRefreshRate(lldRefreshMarketDataFeature?.params?.refreshTime);
 
@@ -107,6 +108,7 @@ export function useMarket() {
   } = useResolveMarketCounterCurrency({
     counterCurrency: settingsCounterValue,
     fallbackForCryptoCountervalues: true,
+    isCryptoCountervalue: counterValueCurrency.type === "CryptoCurrency",
   });
 
   const { shouldDisplayAssetDiscoverability } = useWalletFeaturesConfig("desktop");

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketCoin.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketCoin.ts
@@ -11,7 +11,11 @@ import { useCallback } from "react";
 import { useParams } from "react-router";
 import { setMarketOptions } from "~/renderer/actions/market";
 import { marketParamsSelector } from "~/renderer/reducers/market";
-import { localeSelector, starredMarketCoinsSelector } from "~/renderer/reducers/settings";
+import {
+  counterValueCurrencySelector,
+  localeSelector,
+  starredMarketCoinsSelector,
+} from "~/renderer/reducers/settings";
 import { removeStarredMarketCoins, addStarredMarketCoins } from "~/renderer/actions/settings";
 import { selectCurrency } from "@ledgerhq/live-common/dada-client/utils/currencySelection";
 import { assetsDataApi } from "@ledgerhq/live-common/dada-client/state-manager/api";
@@ -28,6 +32,8 @@ export const useMarketCoin = () => {
 
   const isStarred = currencyId ? starredMarketCoins.includes(currencyId) : false;
   const locale = useSelector(localeSelector);
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const counterValueUnit = counterValueCurrency.units[0];
 
   const { counterCurrency = "usd", range = "24h" } = marketParams;
 
@@ -126,6 +132,7 @@ export const useMarketCoin = () => {
     changeRange,
     range,
     counterCurrency,
+    counterValueUnit,
     changeCounterCurrency,
     currency,
     supportedCounterCurrencies,

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/AssetSuggestionsSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/AssetSuggestionsSection.tsx
@@ -4,9 +4,7 @@ import { useAssetSuggestionsSectionViewModel } from "./hooks/useAssetSuggestions
 import { AssetSuggestionsSectionProps } from "./types";
 
 export function AssetSuggestionsSection(props: Readonly<AssetSuggestionsSectionProps>) {
-  const { locale, counterCurrency } = useAssetSuggestionsSectionViewModel();
+  const { locale } = useAssetSuggestionsSectionViewModel();
 
-  return (
-    <AssetSuggestionsSectionView {...props} locale={locale} counterCurrency={counterCurrency} />
-  );
+  return <AssetSuggestionsSectionView {...props} locale={locale} />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/AssetSuggestionsSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/AssetSuggestionsSectionView.tsx
@@ -18,7 +18,6 @@ export function AssetSuggestionsSectionView({
   navigateToAsset,
   onSeeAll,
   locale,
-  counterCurrency,
 }: Readonly<AssetSuggestionsSectionViewProps>) {
   if (!isLoading && data.length === 0) {
     return null;
@@ -44,7 +43,6 @@ export function AssetSuggestionsSectionView({
             <AssetSuggestionRow
               key={currency.id}
               currency={currency}
-              counterCurrency={counterCurrency}
               locale={locale}
               testIdPrefix={testIdPrefix}
               onClick={navigateToAsset}

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/__integrations__/SearchResults.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/__integrations__/SearchResults.integration.test.tsx
@@ -171,7 +171,6 @@ describe("search results integration", () => {
       render(
         <AssetSuggestionRow
           currency={currency}
-          counterCurrency="USD"
           locale="en"
           testIdPrefix="search-result"
           onClick={jest.fn()}

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/components/AssetSuggestionRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/components/AssetSuggestionRow.tsx
@@ -25,7 +25,6 @@ const ICON_SIZE = {
 
 type AssetSuggestionRowProps = {
   currency: MarketCurrencyData;
-  counterCurrency: string;
   locale: string;
   testIdPrefix: string;
   onClick: (currencyId: string, marketState?: AssetNavigationMarketState) => void;

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/components/AssetSuggestionRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/components/AssetSuggestionRow.tsx
@@ -13,6 +13,8 @@ import { MarketCurrencyData, KeysPriceChange } from "@ledgerhq/live-common/marke
 import type { AssetNavigationMarketState } from "LLD/features/Assets/types";
 import counterValueFormatter from "@ledgerhq/live-common/market/utils/countervalueFormatter";
 import { roundFiatPrice } from "@ledgerhq/live-currency-format";
+import { useSelector } from "LLD/hooks/redux";
+import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
 
 export type AssetSuggestionRowDensity = "compact" | "default";
 
@@ -32,20 +34,21 @@ type AssetSuggestionRowProps = {
 
 export function AssetSuggestionRow({
   currency,
-  counterCurrency,
   locale,
   testIdPrefix,
   onClick,
   density = "compact",
 }: Readonly<AssetSuggestionRowProps>) {
+  const counterValueUnit = useSelector(counterValueCurrencySelector).units[0];
+  const resolvedLocale = useSelector(localeSelector);
   const priceChange = currency.priceChangePercentage[KeysPriceChange.day];
   const isExpanded = density === "default";
   const iconSize = ICON_SIZE[density];
 
   const formattedPrice = counterValueFormatter({
     value: roundFiatPrice(currency.price ?? 0),
-    currency: counterCurrency,
-    locale,
+    unit: counterValueUnit,
+    locale: resolvedLocale || locale,
   });
 
   const trailing = (

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSuggestionsSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/hooks/useAssetSuggestionsSectionViewModel.ts
@@ -1,9 +1,8 @@
 import { useSelector } from "LLD/hooks/redux";
-import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
+import { localeSelector } from "~/renderer/reducers/settings";
 
 export function useAssetSuggestionsSectionViewModel() {
   const locale = useSelector(localeSelector);
-  const counterCurrency = useSelector(counterValueCurrencySelector).ticker;
 
-  return { locale, counterCurrency };
+  return { locale };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SearchAssets/types.ts
@@ -22,5 +22,4 @@ export type AssetSuggestionsSectionProps = AssetSuggestionSection & {
 
 export type AssetSuggestionsSectionViewProps = AssetSuggestionsSectionProps & {
   locale: string;
-  counterCurrency: string;
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/components/MarketCoinChart.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/components/MarketCoinChart.tsx
@@ -13,6 +13,9 @@ import { useTranslation } from "react-i18next";
 import { MarketCoinDataChart } from "@ledgerhq/live-common/market/utils/types";
 import { formatPercentage } from "../../utils";
 import { roundFiatPrice } from "@ledgerhq/live-currency-format";
+import { useSelector } from "LLD/hooks/redux";
+import type { Unit } from "@ledgerhq/types-cryptoassets";
+import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
 
 const Title = styled(Text).attrs({ variant: "h3", color: "neutral.c100", mt: 1, mb: 5 })`
   font-size: 28px;
@@ -52,19 +55,19 @@ const ranges = Object.keys(rangeDataTable)
 
 type TooltipProps = {
   data: { date: Date; value: number };
-  counterCurrency: string;
+  counterValueUnit: Unit;
   locale: string;
   formatDay: (date: Date) => string;
   formatHour: (date: Date) => string;
 };
 
-function Tooltip({ data, counterCurrency, locale, formatDay, formatHour }: TooltipProps) {
+function Tooltip({ data, counterValueUnit, locale, formatDay, formatHour }: TooltipProps) {
   return (
     <Flex flexDirection="column" p={1}>
       <TooltipText variant="large">
         {counterValueFormatter({
           shorten: String(data.value).length > 7,
-          currency: counterCurrency,
+          unit: counterValueUnit,
           value: data.value,
           locale,
         })}
@@ -103,6 +106,7 @@ function MarkeCoinChartComponent({
   supportedCounterCurrencies,
 }: Props) {
   const { t } = useTranslation();
+  const counterValueUnit = useSelector(counterValueCurrencySelector).units[0];
   const nodeRef = useRef(null);
 
   const { scale } = rangeDataTable[range] || { scale: undefined };
@@ -135,17 +139,16 @@ function MarkeCoinChartComponent({
 
   const renderTooltip = useCallback(
     (data: { value: number; date: Date }) =>
-      !loading &&
-      counterCurrency && (
+      !loading && (
         <Tooltip
           data={data}
-          counterCurrency={counterCurrency.toUpperCase()}
+          counterValueUnit={counterValueUnit}
           locale={locale}
           formatDay={formatDay}
           formatHour={formatHour}
         />
       ),
-    [counterCurrency, loading, locale, formatDay, formatHour],
+    [counterValueUnit, loading, locale, formatDay, formatHour],
   );
 
   return (
@@ -155,7 +158,7 @@ function MarkeCoinChartComponent({
           <SubTitle>{t("market.marketList.price")}</SubTitle>
           <Title data-testid={"market-price"}>
             {counterValueFormatter({
-              currency: counterCurrency,
+              unit: counterValueUnit,
               value: roundFiatPrice(price ?? 0),
               locale,
             })}

--- a/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/components/MarketCoinChart.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/components/MarketCoinChart.tsx
@@ -13,9 +13,7 @@ import { useTranslation } from "react-i18next";
 import { MarketCoinDataChart } from "@ledgerhq/live-common/market/utils/types";
 import { formatPercentage } from "../../utils";
 import { roundFiatPrice } from "@ledgerhq/live-currency-format";
-import { useSelector } from "LLD/hooks/redux";
 import type { Unit } from "@ledgerhq/types-cryptoassets";
-import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
 
 const Title = styled(Text).attrs({ variant: "h3", color: "neutral.c100", mt: 1, mb: 5 })`
   font-size: 28px;
@@ -84,6 +82,7 @@ type Props = {
   chartData?: MarketCoinDataChart;
   range: string;
   counterCurrency: string;
+  counterValueUnit: Unit;
   refreshChart: (range: string) => void;
   color?: string;
   locale: string;
@@ -98,6 +97,7 @@ function MarkeCoinChartComponent({
   priceChangePercentage,
   range,
   counterCurrency,
+  counterValueUnit,
   refreshChart,
   color,
   locale,
@@ -106,7 +106,6 @@ function MarkeCoinChartComponent({
   supportedCounterCurrencies,
 }: Props) {
   const { t } = useTranslation();
-  const counterValueUnit = useSelector(counterValueCurrencySelector).units[0];
   const nodeRef = useRef(null);
 
   const { scale } = rangeDataTable[range] || { scale: undefined };

--- a/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/components/MarketInfo.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/components/MarketInfo.tsx
@@ -93,7 +93,6 @@ type Props = {
   athDate?: string | Date;
   atl?: number;
   atlDate?: string | Date;
-  counterCurrency: string;
   counterValueUnit: Unit;
   loading: boolean;
   locale: string;

--- a/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/components/MarketInfo.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/components/MarketInfo.tsx
@@ -7,6 +7,8 @@ import LoadingPlaceholder from "~/renderer/components/LoadingPlaceholder";
 import counterValueFormatter from "@ledgerhq/live-common/market/utils/countervalueFormatter";
 import { dayAndHourFormat, useDateFormatted } from "~/renderer/hooks/useDateFormatter";
 import { KeysPriceChange } from "@ledgerhq/live-common/market/utils/types";
+import { useSelector } from "LLD/hooks/redux";
+import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
 
 const Title = styled(Text).attrs({ variant: "h5", color: "neutral.c100", mb: 2 })`
   font-size: 20px;
@@ -114,12 +116,12 @@ function MarketInfo({
   athDate,
   atl,
   atlDate,
-  counterCurrency,
   loading,
   locale,
   range,
 }: Props) {
   const { t } = useTranslation();
+  const counterValueUnit = useSelector(counterValueCurrencySelector).units[0];
 
   const athDateD = useMemo(() => (athDate ? new Date(athDate) : undefined), [athDate]);
   const atlDateD = useMemo(() => (atlDate ? new Date(atlDate) : undefined), [atlDate]);
@@ -137,7 +139,7 @@ function MarketInfo({
           <Label>{t("market.marketList.price")}</Label>
           <ColumnRight>
             <LoadingLabel loading={loading} data-testid="market-price-stats-price">
-              {counterValueFormatter({ value: price, currency: counterCurrency, locale })}
+              {counterValueFormatter({ value: price, unit: counterValueUnit, locale })}
             </LoadingLabel>
             <LoadingLabel loading={loading} data-testid="market-price-stats-variation">
               {currentPriceChangePercentage ? (
@@ -156,22 +158,22 @@ function MarketInfo({
         <Line>
           <Label>{t("market.detailsPage.tradingVolume")}</Label>
           <LoadingLabel loading={loading} data-testid="market-price-stats-trading-volume">
-            {counterValueFormatter({ value: totalVolume, currency: counterCurrency, locale })}
+            {counterValueFormatter({ value: totalVolume, unit: counterValueUnit, locale })}
           </LoadingLabel>
         </Line>
         <Line>
           <Label>{t("market.detailsPage.24hLowHight")}</Label>
           <LoadingLabel loading={loading} data-testid="market-price-stats-low-hight">
-            {counterValueFormatter({ value: low24h, currency: counterCurrency, locale })}
+            {counterValueFormatter({ value: low24h, unit: counterValueUnit, locale })}
             {" / "}
-            {counterValueFormatter({ value: high24h, currency: counterCurrency, locale })}
+            {counterValueFormatter({ value: high24h, unit: counterValueUnit, locale })}
           </LoadingLabel>
         </Line>
         <Line>
           <Label>{t("market.detailsPage.allTimeHigh")}</Label>
           <ColumnRight>
             <LoadingLabel loading={loading} data-testid="market-price-stats-ath">
-              {counterValueFormatter({ value: ath, currency: counterCurrency, locale })}
+              {counterValueFormatter({ value: ath, unit: counterValueUnit, locale })}
             </LoadingLabel>
             <LoadingLabel
               color="neutral.c80"
@@ -186,7 +188,7 @@ function MarketInfo({
           <Label>{t("market.detailsPage.allTimeLow")}</Label>
           <ColumnRight>
             <LoadingLabel loading={loading} data-testid="market-price-stats-atl">
-              {counterValueFormatter({ value: atl, currency: counterCurrency, locale })}
+              {counterValueFormatter({ value: atl, unit: counterValueUnit, locale })}
             </LoadingLabel>
             <LoadingLabel
               color="neutral.c80"
@@ -206,7 +208,7 @@ function MarketInfo({
             <LoadingLabel loading={loading} data-testid="market-cap">
               {counterValueFormatter({
                 value: marketcap,
-                currency: counterCurrency,
+                unit: counterValueUnit,
                 locale,
                 shorten: true,
               })}

--- a/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/components/MarketInfo.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/components/MarketInfo.tsx
@@ -7,8 +7,7 @@ import LoadingPlaceholder from "~/renderer/components/LoadingPlaceholder";
 import counterValueFormatter from "@ledgerhq/live-common/market/utils/countervalueFormatter";
 import { dayAndHourFormat, useDateFormatted } from "~/renderer/hooks/useDateFormatter";
 import { KeysPriceChange } from "@ledgerhq/live-common/market/utils/types";
-import { useSelector } from "LLD/hooks/redux";
-import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
+import type { Unit } from "@ledgerhq/types-cryptoassets";
 
 const Title = styled(Text).attrs({ variant: "h5", color: "neutral.c100", mb: 2 })`
   font-size: 20px;
@@ -95,6 +94,7 @@ type Props = {
   atl?: number;
   atlDate?: string | Date;
   counterCurrency: string;
+  counterValueUnit: Unit;
   loading: boolean;
   locale: string;
   range: string;
@@ -116,12 +116,12 @@ function MarketInfo({
   athDate,
   atl,
   atlDate,
+  counterValueUnit,
   loading,
   locale,
   range,
 }: Props) {
   const { t } = useTranslation();
-  const counterValueUnit = useSelector(counterValueCurrencySelector).units[0];
 
   const athDateD = useMemo(() => (athDate ? new Date(athDate) : undefined), [athDate]);
   const atlDateD = useMemo(() => (atlDate ? new Date(atlDate) : undefined), [atlDate]);

--- a/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/index.tsx
@@ -59,6 +59,7 @@ export default function MarketCoinScreen() {
     isLoadingCurrency,
     range,
     counterCurrency,
+    counterValueUnit,
     currency,
     supportedCounterCurrencies,
     changeRange,
@@ -154,6 +155,7 @@ export default function MarketCoinScreen() {
         chartData={dataChart}
         range={range}
         counterCurrency={counterCurrency}
+        counterValueUnit={counterValueUnit}
         refreshChart={changeRange}
         color={color}
         locale={locale}
@@ -164,6 +166,7 @@ export default function MarketCoinScreen() {
       <MarketInfo
         locale={locale}
         counterCurrency={counterCurrency}
+        counterValueUnit={counterValueUnit}
         loading={isLoadingCurrency}
         range={range}
         {...currency}

--- a/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/index.tsx
@@ -165,7 +165,6 @@ export default function MarketCoinScreen() {
       />
       <MarketInfo
         locale={locale}
-        counterCurrency={counterCurrency}
         counterValueUnit={counterValueUnit}
         loading={isLoadingCurrency}
         range={range}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/__tests__/useBalanceGraphViewModel.test.ts
@@ -476,32 +476,19 @@ describe("useBalanceGraphViewModel", () => {
       }),
     };
 
-    it("fetches the chart in USD (not the crypto ticker)", () => {
-      mockUseUsdToFiatRate.mockReturnValue({ status: "ready", rate: 0.5 });
-
+    it("fetches the chart in BTC directly (natively supported by CoinGecko)", () => {
       renderVM({ currency: mockBtcCryptoCurrency }, withBtcCounterValue);
 
       expect(mockUseGetAssetChartDataQuery).toHaveBeenCalledWith(
-        expect.objectContaining({ counterCurrency: "usd" }),
+        expect.objectContaining({ counterCurrency: "btc" }),
         expect.anything(),
       );
     });
 
-    it("rescales the USD chart by the USD→BTC rate so the series is populated", () => {
-      const rate = 0.5;
-      mockUseUsdToFiatRate.mockReturnValue({ status: "ready", rate });
-
+    it("serves the BTC-denominated series directly without rescaling", () => {
       const { result } = renderVM({ currency: mockBtcCryptoCurrency }, withBtcCounterValue);
 
-      expect(result.current.series[0]?.data).toEqual([100, 110, 120].map(value => value * rate));
-    });
-
-    it("withholds the series (empty, not stale USD values) while the rate is unavailable", () => {
-      mockUseUsdToFiatRate.mockReturnValue({ status: "error", rate: null });
-
-      const { result } = renderVM({ currency: mockBtcCryptoCurrency }, withBtcCounterValue);
-
-      expect(result.current.series[0]?.data).toEqual([]);
+      expect(result.current.series[0]?.data).toEqual([100, 110, 120]);
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceGraph/useBalanceGraphViewModel.ts
@@ -147,7 +147,15 @@ export function useBalanceGraphViewModel({
     currentData: chartData,
     isLoading: isChartLoading,
     isFetching: isChartFetching,
-  } = useAssetChartDataInCounterValue({ id, counterCurrency, range }, { skip: !id });
+  } = useAssetChartDataInCounterValue(
+    {
+      id,
+      counterCurrency,
+      range,
+      isCryptoCountervalue: counterValueCurrency.type === "CryptoCurrency",
+    },
+    { skip: !id },
+  );
 
   const ranges = useMemo(
     () =>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/__tests__/useMarketStatsViewModel.test.ts
@@ -9,11 +9,14 @@ jest.mock("../../../hooks/useAssetMarketData");
 
 const mockUseAssetMarketData = jest.mocked(useAssetMarketData);
 
+const usdUnit = { code: "$", name: "US Dollar", magnitude: 2, prefixCode: true };
+
 function mockMarketData(overrides?: Partial<ReturnType<typeof useAssetMarketData>>) {
   mockUseAssetMarketData.mockReturnValue({
     marketCurrency: marketCurrencyData as any,
     marketId: "bitcoin",
     counterCurrency: "usd",
+    counterValueUnit: usdUnit,
     ledgerIds: ["bitcoin"],
     isLoading: false,
     isError: false,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/useMarketStatsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/MarketStats/useMarketStatsViewModel.ts
@@ -28,7 +28,7 @@ export function useMarketStatsViewModel({
 }: Params) {
   const { t } = useTranslation();
   const { locale } = useLocale();
-  const { marketCurrency, counterCurrency, isLoading, isError } = useAssetMarketData({
+  const { marketCurrency, counterValueUnit, isLoading, isError } = useAssetMarketData({
     marketApiId,
     knownLedgerIds,
     knownMarketId,
@@ -47,7 +47,7 @@ export function useMarketStatsViewModel({
         value:
           marketcap !== undefined && marketcap !== null
             ? counterValueFormatter({
-                currency: counterCurrency,
+                unit: counterValueUnit,
                 value: marketcap,
                 shorten: true,
                 locale,
@@ -100,7 +100,7 @@ export function useMarketStatsViewModel({
         label: t("assetDetail.marketStats.tradingVolume"),
         value: totalVolume
           ? counterValueFormatter({
-              currency: counterCurrency,
+              unit: counterValueUnit,
               value: totalVolume,
               shorten: true,
               locale,
@@ -113,7 +113,7 @@ export function useMarketStatsViewModel({
         },
       },
     ];
-  }, [marketCurrency, counterCurrency, locale, t, currency?.ticker]);
+  }, [marketCurrency, counterValueUnit, locale, t, currency?.ticker]);
 
   const onTooltipOpen = useCallback(
     (statName: string, open: boolean) => {

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/__tests__/usePricePerformanceViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/__tests__/usePricePerformanceViewModel.test.ts
@@ -8,11 +8,14 @@ jest.mock("../../../hooks/useAssetMarketData");
 
 const mockUseAssetMarketData = jest.mocked(useAssetMarketData);
 
+const usdUnit = { code: "$", name: "US Dollar", magnitude: 2, prefixCode: true };
+
 function mockMarketData(overrides?: Partial<ReturnType<typeof useAssetMarketData>>) {
   mockUseAssetMarketData.mockReturnValue({
     marketCurrency: marketCurrencyData as any,
     marketId: "bitcoin",
     counterCurrency: "usd",
+    counterValueUnit: usdUnit,
     ledgerIds: ["bitcoin"],
     isLoading: false,
     isError: false,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/usePricePerformanceViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PricePerformance/usePricePerformanceViewModel.ts
@@ -56,7 +56,7 @@ export function usePricePerformanceViewModel({
 }: Params) {
   const { t } = useTranslation();
   const { locale } = useLocale();
-  const { marketCurrency, counterCurrency, isLoading, isError } = useAssetMarketData({
+  const { marketCurrency, counterValueUnit, isLoading, isError } = useAssetMarketData({
     marketApiId,
     knownLedgerIds,
     knownMarketId,
@@ -86,7 +86,7 @@ export function usePricePerformanceViewModel({
         id: "ath",
         label: t("assetDetail.pricePerformance.allTimeHigh"),
         value: counterValueFormatter({
-          currency: counterCurrency,
+          unit: counterValueUnit,
           value: ath,
           locale,
           t,
@@ -104,7 +104,7 @@ export function usePricePerformanceViewModel({
         id: "atl",
         label: t("assetDetail.pricePerformance.allTimeLow"),
         value: counterValueFormatter({
-          currency: counterCurrency,
+          unit: counterValueUnit,
           value: atl,
           locale,
           t,
@@ -116,7 +116,7 @@ export function usePricePerformanceViewModel({
     }
 
     return result;
-  }, [marketCurrency, counterCurrency, locale, t, dateFormatter]);
+  }, [marketCurrency, counterValueUnit, locale, t, dateFormatter]);
 
   return {
     records,

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/useAssetMarketData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/hooks/useAssetMarketData.ts
@@ -17,7 +17,9 @@ type Params = {
  * cannot reintroduce the wrong query.
  */
 export function useAssetMarketData({ marketApiId, knownLedgerIds, knownMarketId }: Params) {
-  const counterCurrency = useSelector(counterValueCurrencySelector).ticker.toLowerCase();
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const counterCurrency = counterValueCurrency.ticker.toLowerCase();
+  const counterValueUnit = counterValueCurrency.units[0];
 
   const { marketCurrencyData, marketId, ledgerIds, isLoading, isError } = useSharedAssetMarketData({
     marketApiId,
@@ -32,6 +34,7 @@ export function useAssetMarketData({ marketApiId, knownLedgerIds, knownMarketId 
     marketCurrency: marketCurrencyData,
     marketId,
     counterCurrency,
+    counterValueUnit,
     ledgerIds,
     isLoading,
     isError,

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/useGlobalSearchDefaults.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/useGlobalSearchDefaults.ts
@@ -29,7 +29,6 @@ export function useGlobalSearchDefaults(enabled: boolean): GlobalSearchDefaults 
   const { t } = useTranslation();
   const { locale } = useLocale();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
-  const counterCurrency = counterValueCurrency.ticker.toLowerCase();
   const counterValueUnit = counterValueCurrency.units[0];
   const { rate: usdToFiatRate, status: rateStatus } = useUsdToFiatRate(counterValueCurrency.ticker);
   const version = VersionNumber.appVersion ?? "";
@@ -67,10 +66,10 @@ export function useGlobalSearchDefaults(enabled: boolean): GlobalSearchDefaults 
       mapDadaMarketToDisplayData(
         { id: meta.id, name: meta.name, ticker: meta.ticker, ledgerId: currency.id },
         market,
-        { counterCurrency, counterValueUnit, usdToFiatRate, locale, t },
+        { counterValueUnit, usdToFiatRate, locale, t },
       ),
     );
-  }, [assetsData, stablecoinTickers, counterCurrency, counterValueUnit, usdToFiatRate, locale, t]);
+  }, [assetsData, stablecoinTickers, counterValueUnit, usdToFiatRate, locale, t]);
 
   const stocks = useMemo(
     () => (stocksData ? selectTopStocks(stocksData, MAX_STOCKS) : []),

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/useGlobalSearchResults.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/hooks/useGlobalSearchResults.ts
@@ -34,7 +34,6 @@ export function useGlobalSearchResults(): GlobalSearchResults {
   const { t } = useTranslation();
   const { locale } = useLocale();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
-  const counterCurrency = counterValueCurrency.ticker.toLowerCase();
   const counterValueUnit = counterValueCurrency.units[0];
   const { rate: usdToFiatRate, status: rateStatus } = useUsdToFiatRate(counterValueCurrency.ticker);
   const version = VersionNumber.appVersion ?? "";
@@ -94,20 +93,11 @@ export function useGlobalSearchResults(): GlobalSearchResults {
         mapDadaMarketToDisplayData(
           { id: meta.id, name: meta.name, ticker: meta.ticker, ledgerId: currency.id },
           data.markets[currency.id],
-          { counterCurrency, counterValueUnit, usdToFiatRate, locale, t },
+          { counterValueUnit, usdToFiatRate, locale, t },
         ),
       ];
     });
-  }, [
-    data,
-    query,
-    deactivatedCurrencyIds,
-    counterCurrency,
-    counterValueUnit,
-    usdToFiatRate,
-    locale,
-    t,
-  ]);
+  }, [data, query, deactivatedCurrencyIds, counterValueUnit, usdToFiatRate, locale, t]);
 
   const isLoadingSearch = isSearchActive && (isDebouncing || isLoading || rateStatus === "loading");
   const clearSearch = useCallback(() => handleSearch(""), [handleSearch]);

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/utils/__tests__/mapDadaMarketToDisplayData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/utils/__tests__/mapDadaMarketToDisplayData.test.ts
@@ -4,7 +4,6 @@ import { mapDadaMarketToDisplayData } from "../mapDadaMarketToDisplayData";
 const usd = { name: "US Dollar", code: "USD", magnitude: 2 } as Unit;
 const t = ((key: string) => key) as never;
 const options = {
-  counterCurrency: "usd",
   counterValueUnit: usd,
   usdToFiatRate: 1,
   locale: "en",

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/utils/mapDadaMarketToDisplayData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/utils/mapDadaMarketToDisplayData.ts
@@ -27,7 +27,7 @@ type MapOptions = {
 export function mapDadaMarketToDisplayData(
   meta: AssetMeta,
   market: PartialMarketItemResponse | undefined,
-  { counterCurrency, counterValueUnit, usdToFiatRate, locale, t }: MapOptions,
+  { counterValueUnit, usdToFiatRate, locale, t }: MapOptions,
 ): MarketAssetDisplayData {
   const change = market?.priceChangePercentage24h;
   const priceChangePercentage = typeof change === "number" && Number.isFinite(change) ? change : 0;
@@ -50,7 +50,7 @@ export function mapDadaMarketToDisplayData(
       marketCap == null
         ? "-"
         : counterValueFormatter({
-            currency: counterCurrency,
+            unit: counterValueUnit,
             value: marketCap,
             shorten: true,
             locale,

--- a/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/utils/mapDadaMarketToDisplayData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GlobalSearch/utils/mapDadaMarketToDisplayData.ts
@@ -16,7 +16,6 @@ type AssetMeta = {
 };
 
 type MapOptions = {
-  counterCurrency: string;
   counterValueUnit: Unit;
   /** USD → counter-value spot rate (DADA prices are in USD). `null` while it resolves. */
   usdToFiatRate: number | null;

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/components/Information/AthAtlBlock.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/components/Information/AthAtlBlock.tsx
@@ -36,7 +36,7 @@ export const AthAtlBlock: React.FC<AthAtlBlockProps> = ({
           {t(label)}
         </Text>
         <Text style={styles.value}>
-          {counterValueFormatter({ value, currency: counterValueCurrency.ticker, locale, t })}
+          {counterValueFormatter({ value, unit: counterValueCurrency.units[0], locale, t })}
         </Text>
       </Flex>
       <Flex style={styles.rowInside}>

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/components/Performance.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/components/Performance.tsx
@@ -28,7 +28,7 @@ export const Performance: React.FC<PerformanceProps> = ({ low, high, price }) =>
           </Text>
           <Text fontSize={14} fontWeight="bold">
             {counterValueFormatter({
-              currency: counterValueCurrency.ticker,
+              unit: counterValueCurrency.units[0],
               value: low,
               locale,
               t,
@@ -41,7 +41,7 @@ export const Performance: React.FC<PerformanceProps> = ({ low, high, price }) =>
           </Text>
           <Text fontSize={14} fontWeight="bold">
             {counterValueFormatter({
-              currency: counterValueCurrency.ticker,
+              unit: counterValueCurrency.units[0],
               value: high,
               locale,
               t,

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/components/PriceAndVariation.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/components/PriceAndVariation.tsx
@@ -46,7 +46,7 @@ export const PriceAndVariation: React.FC<PriceAndVariationProps> = ({
     <Flex flexDirection="column" alignItems="center" justifyContent="center">
       <Text fontWeight="semiBold" fontSize="26px" color="neutral.c100" numberOfLines={1}>
         {counterValueFormatter({
-          currency: counterValueCurrency.ticker,
+          unit: counterValueCurrency.units[0],
           value: price,
           locale,
           t,

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/hooks/__tests__/useMarketCoinData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/hooks/__tests__/useMarketCoinData.test.ts
@@ -98,6 +98,7 @@ describe("useMarketCoinData hooks", () => {
       counterCurrency: "eur",
       id: "bitcoin",
       range: "24h",
+      isCryptoCountervalue: false,
     });
     expect(result.current.marketParams).toEqual(
       expect.objectContaining({ counterCurrency: "eur" }),

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/hooks/useMarketCoinData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/hooks/useMarketCoinData.ts
@@ -7,6 +7,7 @@ import { applyUsdRateToMarket } from "@ledgerhq/live-common/market/utils/applyUs
 
 import { useSelector } from "~/context/hooks";
 import { marketParamsSelector } from "~/reducers/market";
+import { counterValueCurrencySelector } from "~/reducers/settings";
 
 type HookProps = {
   currencyId: string;
@@ -14,6 +15,7 @@ type HookProps = {
 
 export const useMarketCoinData = ({ currencyId }: HookProps) => {
   const marketParams = useSelector(marketParamsSelector);
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
 
   const { counterCurrency: settingsCounterCurrency = "usd" } = marketParams;
   const {
@@ -24,6 +26,7 @@ export const useMarketCoinData = ({ currencyId }: HookProps) => {
   } = useResolveMarketCounterCurrency({
     counterCurrency: settingsCounterCurrency,
     fallbackForCryptoCountervalues: true,
+    isCryptoCountervalue: counterValueCurrency.type === "CryptoCurrency",
   });
   const shouldFetchCurrency = !isResolutionLoading;
 
@@ -57,6 +60,7 @@ export const useMarketCoinData = ({ currencyId }: HookProps) => {
 
 export const useMarketCoinDataWithChart = ({ currencyId }: HookProps) => {
   const marketParams = useSelector(marketParamsSelector);
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
 
   const { counterCurrency = "usd", range = "24h" } = marketParams;
 
@@ -64,6 +68,7 @@ export const useMarketCoinDataWithChart = ({ currencyId }: HookProps) => {
     counterCurrency,
     id: currencyId,
     range,
+    isCryptoCountervalue: counterValueCurrency.type === "CryptoCurrency",
   });
 
   const { currency, loading, refetch } = useMarketCoinData({ currencyId });

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketAssets.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/__tests__/useMarketAssets.test.ts
@@ -342,17 +342,25 @@ describe("useMarketAssets", () => {
   });
 
   describe("crypto countervalue (BTC)", () => {
-    it("requests in USD and rescales rows without waiting for the supported fiat list", () => {
+    it("waits for the supported counter-value list like any fiat currency", () => {
       mockSupportedCounterCurrencies(undefined);
-      mockUsdToFiatRate({ status: "ready", rate: 0.00001 });
+
+      const { result } = renderHook(() => useMarketAssets(), withCounterValue("BTC"));
+
+      expectMarketDataLastCalledWith({ counterCurrency: "btc" }, { enabled: false });
+      expect(result.current.loading).toBe(true);
+    });
+
+    it("requests in BTC directly once the supported list confirms it is native", () => {
+      mockSupportedCounterCurrencies(["usd", "eur", "btc"]);
       mockMarketData({
         data: [createMarketCurrencyData({ id: "bitcoin", price: 100, marketcap: 200 })],
       });
 
       const { result } = renderHook(() => useMarketAssets(), withCounterValue("BTC"));
 
-      expectMarketDataLastCalledWith({ counterCurrency: "usd" });
-      expect(mockedUseUsdToFiatRate).toHaveBeenCalledWith("btc", { skip: false });
+      expectMarketDataLastCalledWith({ counterCurrency: "btc" });
+      expect(mockedUseUsdToFiatRate).toHaveBeenCalledWith("usd", { skip: false });
       expect(result.current.loading).toBe(false);
       expect(result.current.assets[0].formattedPrice).toContain("₿");
       expect(result.current.assets[0].formattedMarketCap).toContain("₿");

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/marketAssetsHelpers.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/marketAssetsHelpers.ts
@@ -20,7 +20,6 @@ export function getMarketDataForDisplay(
 
 export function getMarketAssets({
   marketData,
-  counterCurrency,
   counterValueUnit,
   rate = 1,
   displayRange,
@@ -28,7 +27,6 @@ export function getMarketAssets({
   t,
 }: {
   marketData: MarketCurrencyData[];
-  counterCurrency: string;
   counterValueUnit: Unit;
   rate?: number;
   displayRange: DisplayRange;
@@ -39,7 +37,6 @@ export function getMarketAssets({
 
   return uniqueById.map(item =>
     mapMarketCurrencyToDisplayData(applyUsdRateToMarket(item, rate), {
-      counterCurrency,
       counterValueUnit,
       range: displayRange,
       locale,

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssets.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssets.ts
@@ -127,14 +127,13 @@ export function useMarketAssets({
         ? []
         : getMarketAssets({
             marketData,
-            counterCurrency: displayCounterCurrency,
             counterValueUnit,
             rate,
             displayRange,
             locale,
             t,
           }),
-    [counterValueUnit, displayCounterCurrency, displayRange, locale, marketData, rate, t],
+    [counterValueUnit, displayRange, locale, marketData, rate, t],
   );
 
   const hasData = assets.length > 0;

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssets.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/useMarketAssets.ts
@@ -68,6 +68,7 @@ export function useMarketAssets({
   } = useResolveMarketCounterCurrency({
     counterCurrency: settingsCounterValue,
     fallbackForCryptoCountervalues: true,
+    isCryptoCountervalue: counterValueCurrency.type === "CryptoCurrency",
   });
   const counterValueUnit = counterValueCurrency.units[0];
   const normalizedSearch = search.trim();

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/utils/__tests__/marketAssetDisplay.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/utils/__tests__/marketAssetDisplay.test.ts
@@ -16,7 +16,6 @@ const COMPACT_SUFFIXES: Record<string, string> = {
 const t = ((key: string) => COMPACT_SUFFIXES[key.split(".")[1]] ?? "") as unknown as TFunction;
 
 const opts = {
-  counterCurrency: "usd",
   counterValueUnit: usdUnit,
   range: KeysPriceChange.day,
   locale: "en-US",

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.ts
@@ -1,7 +1,6 @@
 import { MarketListRequestParams } from "@ledgerhq/live-common/market/utils/types";
 import { getSortParam } from "@ledgerhq/live-common/market/utils/index";
 import { rangeDataTable } from "@ledgerhq/live-common/cg-client/utils/rangeDataTable";
-import { findCryptoCurrencyByTicker } from "@ledgerhq/live-common/currencies/index";
 import { findFiatCurrencyByTicker } from "@domain/entity-currency-fiat";
 import type { Unit } from "@ledgerhq/types-cryptoassets";
 import type { TFunction } from "i18next";
@@ -73,33 +72,26 @@ type NumberFormatterResult = {
 
 const getNumberFormatter = (
   locale: string,
-  currency?: string,
+  unit?: Unit,
   shorten?: boolean,
 ): NumberFormatterResult => {
-  if (!currency) return { formatter: new Intl.NumberFormat(locale) };
+  if (!unit) {
+    return {
+      formatter: new Intl.NumberFormat(locale, {
+        style: "decimal",
+        maximumFractionDigits: shorten ? 3 : MAXIMUM_FRACTION_DIGITS,
+      }),
+    };
+  }
 
-  const normalizedCurrency = currency.toUpperCase();
-  const fiat = findFiatCurrencyByTicker(normalizedCurrency);
-  const crypto = findCryptoCurrencyByTicker(normalizedCurrency);
-  const unit = fiat?.units[0] ?? crypto?.units[0];
-  const formatterKey = `${normalizedCurrency}:${shorten ? "short" : "full"}`;
+  const formatterKey = `${unit.code}:${shorten ? "short" : "full"}`;
 
   if (!formatters[locale]) formatters[locale] = {};
   if (!formatters[locale][formatterKey]) {
-    formatters[locale][formatterKey] = new Intl.NumberFormat(
-      locale,
-      unit
-        ? {
-            style: "decimal",
-            ...getFractionDigitOptions(unit, shorten),
-          }
-        : {
-            style: "currency",
-            currency: normalizedCurrency,
-            ...getFractionDigitOptions(undefined, shorten),
-            maximumSignificantDigits: 8,
-          },
-    );
+    formatters[locale][formatterKey] = new Intl.NumberFormat(locale, {
+      style: "decimal",
+      ...getFractionDigitOptions(unit, shorten),
+    });
   }
 
   return { formatter: formatters[locale][formatterKey], unit };
@@ -135,6 +127,7 @@ const formatShortenedValue = (
 
 export const counterValueFormatter = ({
   currency,
+  unit: providedUnit,
   value,
   shorten,
   locale,
@@ -143,6 +136,7 @@ export const counterValueFormatter = ({
   ticker = "",
 }: {
   currency?: string;
+  unit?: Unit;
   value: number;
   shorten?: boolean;
   locale: string;
@@ -154,8 +148,12 @@ export const counterValueFormatter = ({
     return "-";
   }
 
-  const { formatter, unit } = getNumberFormatter(locale, currency, shorten);
-  const upperCaseTicker = ticker.trim().toUpperCase();
+  const resolvedUnit =
+    providedUnit ??
+    (currency ? findFiatCurrencyByTicker(currency.toUpperCase())?.units[0] : undefined);
+  const { formatter, unit } = getNumberFormatter(locale, resolvedUnit, shorten);
+  const upperCaseTicker =
+    ticker.trim().toUpperCase() || (!resolvedUnit && currency ? currency.trim().toUpperCase() : "");
 
   if (shorten && t) {
     return `${formatShortenedValue(formatter, value, t, unit)} ${upperCaseTicker}`.trim();

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.ts
@@ -84,7 +84,7 @@ const getNumberFormatter = (
     };
   }
 
-  const formatterKey = `${unit.code}:${shorten ? "short" : "full"}`;
+  const formatterKey = `${unit.code}:${unit.magnitude}:${unit.prefixCode ? "1" : "0"}:${shorten ? "short" : "full"}`;
 
   if (!formatters[locale]) formatters[locale] = {};
   if (!formatters[locale][formatterKey]) {

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/utils/marketAssetDisplay.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/utils/marketAssetDisplay.ts
@@ -7,7 +7,6 @@ import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
 import { counterValueFormatter } from "./index";
 
 interface MapOptions {
-  counterCurrency: string;
   counterValueUnit: Unit;
   range: KeysPriceChange;
   locale: string;

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/utils/marketAssetDisplay.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/utils/marketAssetDisplay.ts
@@ -16,7 +16,7 @@ interface MapOptions {
 
 export function mapMarketCurrencyToDisplayData(
   item: MarketCurrencyData,
-  { counterCurrency, counterValueUnit, range, locale, t }: MapOptions,
+  { counterValueUnit, range, locale, t }: MapOptions,
 ): MarketAssetDisplayData {
   const change = item.priceChangePercentage[range];
   const priceChangePercentage = typeof change === "number" && Number.isFinite(change) ? change : 0;
@@ -33,7 +33,7 @@ export function mapMarketCurrencyToDisplayData(
       item.marketcap == null
         ? "-"
         : counterValueFormatter({
-            currency: counterCurrency,
+            unit: counterValueUnit,
             value: item.marketcap,
             shorten: true,
             locale,

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/AssetMarketSection.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/AssetMarketSection.tsx
@@ -7,11 +7,14 @@ import SectionTitle from "../WalletCentricSections/SectionTitle";
 import MarketPriceSection from "../WalletCentricSections/MarketPrice";
 import { useMarketCoinData } from "LLM/features/Market/hooks/useMarketCoinData";
 import { resolveMarketId } from "LLM/features/Market/utils/marketIdResolver";
+import { useSelector } from "~/context/hooks";
+import { counterValueCurrencySelector } from "~/reducers/settings";
 
 const AssetMarketSection = ({ currency }: { currency: CryptoOrTokenCurrency }) => {
   const { t } = useTranslation();
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
 
-  const { currency: fetchedCurrency, counterCurrency } = useMarketCoinData({
+  const { currency: fetchedCurrency } = useMarketCoinData({
     currencyId: resolveMarketId(currency.id),
   });
 
@@ -28,7 +31,7 @@ const AssetMarketSection = ({ currency }: { currency: CryptoOrTokenCurrency }) =
         <MarketPriceSection
           currency={currency}
           selectedCoinData={fetchedCurrency}
-          counterCurrency={counterCurrency}
+          counterValueUnit={counterValueCurrency.units[0]}
         />
       </Flex>
     </SectionContainer>

--- a/apps/ledger-live-mobile/src/screens/WalletCentricSections/MarketPrice.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricSections/MarketPrice.tsx
@@ -2,7 +2,7 @@ import React, { memo, useCallback } from "react";
 import { Flex, Text, IconsLegacy } from "@ledgerhq/native-ui";
 import { useTranslation } from "~/context/Locale";
 import counterValueFormatter from "@ledgerhq/live-common/market/utils/countervalueFormatter";
-import { CryptoOrTokenCurrency, Unit } from "@ledgerhq/types-cryptoassets";
+import type { CryptoOrTokenCurrency, Unit } from "@ledgerhq/types-cryptoassets";
 import { withDiscreetMode } from "~/context/DiscreetModeContext";
 import DeltaVariation from "LLM/features/Market/components/DeltaVariation";
 import Touchable from "~/components/Touchable";

--- a/apps/ledger-live-mobile/src/screens/WalletCentricSections/MarketPrice.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricSections/MarketPrice.tsx
@@ -2,7 +2,7 @@ import React, { memo, useCallback } from "react";
 import { Flex, Text, IconsLegacy } from "@ledgerhq/native-ui";
 import { useTranslation } from "~/context/Locale";
 import counterValueFormatter from "@ledgerhq/live-common/market/utils/countervalueFormatter";
-import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { CryptoOrTokenCurrency, Unit } from "@ledgerhq/types-cryptoassets";
 import { withDiscreetMode } from "~/context/DiscreetModeContext";
 import DeltaVariation from "LLM/features/Market/components/DeltaVariation";
 import Touchable from "~/components/Touchable";
@@ -16,10 +16,10 @@ import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAsse
 type Props = {
   currency: CryptoOrTokenCurrency;
   selectedCoinData: MarketCurrencyData;
-  counterCurrency: string | undefined;
+  counterValueUnit: Unit;
 };
 
-const MarketPrice = ({ currency, selectedCoinData, counterCurrency }: Props) => {
+const MarketPrice = ({ currency, selectedCoinData, counterValueUnit }: Props) => {
   const { t } = useTranslation();
   const { locale } = useSettings();
   const { openFromMarket } = useAssetDetailNavigation();
@@ -57,7 +57,7 @@ const MarketPrice = ({ currency, selectedCoinData, counterCurrency }: Props) => 
             <Text variant="large" fontWeight="medium">
               {counterValueFormatter({
                 value: selectedCoinData?.price || 0,
-                currency: counterCurrency,
+                unit: counterValueUnit,
                 locale,
               })}
             </Text>

--- a/libs/ledger-live-common/src/market/hooks/__tests__/useAssetChartDataInCounterValue.test.ts
+++ b/libs/ledger-live-common/src/market/hooks/__tests__/useAssetChartDataInCounterValue.test.ts
@@ -55,7 +55,12 @@ describe("useAssetChartDataInCounterValue", () => {
   describe("natively supported fiat countervalue", () => {
     it("requests the chart with the fiat ticker and returns the data unchanged", () => {
       const { result } = renderHook(() =>
-        useAssetChartDataInCounterValue({ id: "bitcoin", counterCurrency: "eur", range: "1d" }),
+        useAssetChartDataInCounterValue({
+          id: "bitcoin",
+          counterCurrency: "eur",
+          range: "1d",
+          isCryptoCountervalue: false,
+        }),
       );
 
       expect(mockUseAssetChartData).toHaveBeenCalledWith(
@@ -69,7 +74,12 @@ describe("useAssetChartDataInCounterValue", () => {
 
     it("does not fire a USD rate request (passes 'usd' which short-circuits)", () => {
       renderHook(() =>
-        useAssetChartDataInCounterValue({ id: "bitcoin", counterCurrency: "vnd", range: "1d" }),
+        useAssetChartDataInCounterValue({
+          id: "bitcoin",
+          counterCurrency: "vnd",
+          range: "1d",
+          isCryptoCountervalue: false,
+        }),
       );
 
       expect(mockUseAssetChartData).toHaveBeenCalledWith(
@@ -83,13 +93,17 @@ describe("useAssetChartDataInCounterValue", () => {
   // Two reasons the chart endpoint can't serve a countervalue natively:
   //  - the fiat is outside CoinGecko's supported_vs_currencies (e.g. COP), or
   //  - it is a crypto (BTC/ETH) which CoinGecko lists but the chart endpoint 422s.
-  // BTC is also a pseudo-fiat in fiats.ts, so crypto must be detected by ticker.
   describe("countervalue requiring a USD fallback", () => {
     it("rescales by the USD->fiat rate for an unsupported fiat (COP)", () => {
       mockUseUsdToFiatRate.mockReturnValue({ status: "ready", rate: 0.5 });
 
       const { result } = renderHook(() =>
-        useAssetChartDataInCounterValue({ id: "bitcoin", counterCurrency: "cop", range: "1d" }),
+        useAssetChartDataInCounterValue({
+          id: "bitcoin",
+          counterCurrency: "cop",
+          range: "1d",
+          isCryptoCountervalue: false,
+        }),
       );
 
       expect(mockUseAssetChartData).toHaveBeenCalledWith(
@@ -109,7 +123,12 @@ describe("useAssetChartDataInCounterValue", () => {
       mockUseUsdToFiatRate.mockReturnValue({ status: "ready", rate: 0.5 });
 
       const { result } = renderHook(() =>
-        useAssetChartDataInCounterValue({ id: "ethereum", counterCurrency: "btc", range: "1d" }),
+        useAssetChartDataInCounterValue({
+          id: "ethereum",
+          counterCurrency: "btc",
+          range: "1d",
+          isCryptoCountervalue: true,
+        }),
       );
 
       expect(mockUseAssetChartData).toHaveBeenCalledWith(
@@ -129,7 +148,12 @@ describe("useAssetChartDataInCounterValue", () => {
       mockUseUsdToFiatRate.mockReturnValue({ status: "ready", rate: 0.5 });
 
       renderHook(() =>
-        useAssetChartDataInCounterValue({ id: "bitcoin", counterCurrency: "ETH", range: "1d" }),
+        useAssetChartDataInCounterValue({
+          id: "bitcoin",
+          counterCurrency: "ETH",
+          range: "1d",
+          isCryptoCountervalue: true,
+        }),
       );
 
       expect(mockUseAssetChartData).toHaveBeenCalledWith(
@@ -144,7 +168,12 @@ describe("useAssetChartDataInCounterValue", () => {
       mockUseUsdToFiatRate.mockReturnValue({ status: "ready", rate: 0.5 });
 
       renderHook(() =>
-        useAssetChartDataInCounterValue({ id: "ethereum", counterCurrency: "btc", range: "1d" }),
+        useAssetChartDataInCounterValue({
+          id: "ethereum",
+          counterCurrency: "btc",
+          range: "1d",
+          isCryptoCountervalue: true,
+        }),
       );
 
       expect(mockUseAssetChartData).toHaveBeenCalledWith(
@@ -157,7 +186,12 @@ describe("useAssetChartDataInCounterValue", () => {
       mockSupported(undefined);
 
       const { result } = renderHook(() =>
-        useAssetChartDataInCounterValue({ id: "bitcoin", counterCurrency: "cop", range: "1d" }),
+        useAssetChartDataInCounterValue({
+          id: "bitcoin",
+          counterCurrency: "cop",
+          range: "1d",
+          isCryptoCountervalue: false,
+        }),
       );
 
       expect(mockUseAssetChartData).toHaveBeenCalledWith(
@@ -175,7 +209,7 @@ describe("useAssetChartDataInCounterValue", () => {
 
       const { result } = renderHook(() =>
         useAssetChartDataInCounterValue(
-          { id: "ethereum", counterCurrency: "btc", range: "1d" },
+          { id: "ethereum", counterCurrency: "btc", range: "1d", isCryptoCountervalue: true },
           { skip: true },
         ),
       );
@@ -192,7 +226,12 @@ describe("useAssetChartDataInCounterValue", () => {
       mockUseUsdToFiatRate.mockReturnValue({ status: "loading", rate: null });
 
       const { result } = renderHook(() =>
-        useAssetChartDataInCounterValue({ id: "ethereum", counterCurrency: "btc", range: "1d" }),
+        useAssetChartDataInCounterValue({
+          id: "ethereum",
+          counterCurrency: "btc",
+          range: "1d",
+          isCryptoCountervalue: true,
+        }),
       );
 
       expect(result.current.isLoading).toBe(true);
@@ -203,7 +242,12 @@ describe("useAssetChartDataInCounterValue", () => {
       mockUseUsdToFiatRate.mockReturnValue({ status: "error", rate: null });
 
       const { result } = renderHook(() =>
-        useAssetChartDataInCounterValue({ id: "bitcoin", counterCurrency: "cop", range: "1d" }),
+        useAssetChartDataInCounterValue({
+          id: "bitcoin",
+          counterCurrency: "cop",
+          range: "1d",
+          isCryptoCountervalue: false,
+        }),
       );
 
       expect(result.current.isError).toBe(true);
@@ -215,7 +259,12 @@ describe("useAssetChartDataInCounterValue", () => {
       mockUseUsdToFiatRate.mockReturnValue({ status: "ready", rate: 0.5 });
 
       const { result } = renderHook(() =>
-        useAssetChartDataInCounterValue({ id: "ethereum", counterCurrency: "btc", range: "1d" }),
+        useAssetChartDataInCounterValue({
+          id: "ethereum",
+          counterCurrency: "btc",
+          range: "1d",
+          isCryptoCountervalue: true,
+        }),
       );
 
       expect(result.current.isError).toBe(true);

--- a/libs/ledger-live-common/src/market/hooks/__tests__/useResolveMarketCounterCurrency.test.ts
+++ b/libs/ledger-live-common/src/market/hooks/__tests__/useResolveMarketCounterCurrency.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import { useResolveMarketCounterCurrency } from "../useResolveMarketCounterCurrency";
+import { useSupportedCounterCurrencies } from "../../../cg-client/hooks/useCoingeckoDataProvider";
+
+jest.mock("../../../cg-client/hooks/useCoingeckoDataProvider", () => ({
+  useSupportedCounterCurrencies: jest.fn(),
+}));
+
+const mockUseSupportedCounterCurrencies = jest.mocked(useSupportedCounterCurrencies);
+
+// CoinGecko supported_vs_currencies includes common fiats and crypto tickers
+const SUPPORTED = ["usd", "eur", "gbp", "vnd", "btc", "eth", "sats"];
+
+const mockSupported = (...args: [] | [string[] | undefined]) =>
+  mockUseSupportedCounterCurrencies.mockReturnValue({
+    data: args.length === 0 ? SUPPORTED : args[0],
+    isError: false,
+  } as unknown as ReturnType<typeof useSupportedCounterCurrencies>);
+
+const mockSupportedError = () =>
+  mockUseSupportedCounterCurrencies.mockReturnValue({
+    data: undefined,
+    isError: true,
+  } as unknown as ReturnType<typeof useSupportedCounterCurrencies>);
+
+describe("useResolveMarketCounterCurrency", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSupported();
+  });
+
+  describe("USD counter currency", () => {
+    it("passes through usd with no fallback and no loading", () => {
+      const { result } = renderHook(() =>
+        useResolveMarketCounterCurrency({ counterCurrency: "usd", isCryptoCountervalue: false }),
+      );
+
+      expect(result.current.requestCounterCurrency).toBe("usd");
+      expect(result.current.displayCounterCurrency).toBe("usd");
+      expect(result.current.needsUsdFallback).toBe(false);
+      expect(result.current.isResolutionLoading).toBe(false);
+    });
+
+    it("is case-insensitive for USD", () => {
+      const { result } = renderHook(() =>
+        useResolveMarketCounterCurrency({ counterCurrency: "USD", isCryptoCountervalue: false }),
+      );
+
+      expect(result.current.requestCounterCurrency).toBe("usd");
+      expect(result.current.needsUsdFallback).toBe(false);
+      expect(result.current.isResolutionLoading).toBe(false);
+    });
+  });
+
+  describe("supported fiat counter currency", () => {
+    it("passes through a supported fiat with no fallback", () => {
+      const { result } = renderHook(() =>
+        useResolveMarketCounterCurrency({ counterCurrency: "eur", isCryptoCountervalue: false }),
+      );
+
+      expect(result.current.requestCounterCurrency).toBe("eur");
+      expect(result.current.displayCounterCurrency).toBe("eur");
+      expect(result.current.needsUsdFallback).toBe(false);
+      expect(result.current.isResolutionLoading).toBe(false);
+    });
+  });
+
+  describe("unsupported fiat counter currency", () => {
+    it("falls back to USD when the fiat is not in the supported list", () => {
+      const { result } = renderHook(() =>
+        useResolveMarketCounterCurrency({ counterCurrency: "cop", isCryptoCountervalue: false }),
+      );
+
+      expect(result.current.needsUsdFallback).toBe(true);
+      expect(result.current.requestCounterCurrency).toBe("usd");
+      expect(result.current.displayCounterCurrency).toBe("cop");
+    });
+
+    it("is loading while the supported list has not yet resolved", () => {
+      mockSupported(undefined);
+
+      const { result } = renderHook(() =>
+        useResolveMarketCounterCurrency({ counterCurrency: "cop", isCryptoCountervalue: false }),
+      );
+
+      expect(result.current.isResolutionLoading).toBe(true);
+      expect(result.current.needsUsdFallback).toBe(false);
+      expect(result.current.requestCounterCurrency).toBe("cop");
+    });
+
+    it("stops blocking when the supported list errors out", () => {
+      mockSupportedError();
+
+      const { result } = renderHook(() =>
+        useResolveMarketCounterCurrency({ counterCurrency: "cop", isCryptoCountervalue: false }),
+      );
+
+      expect(result.current.isResolutionLoading).toBe(false);
+    });
+  });
+
+  describe("crypto counter currency with fallbackForCryptoCountervalues=true", () => {
+    it("falls back to USD for a crypto counter (BTC)", () => {
+      const { result } = renderHook(() =>
+        useResolveMarketCounterCurrency({
+          counterCurrency: "btc",
+          fallbackForCryptoCountervalues: true,
+          isCryptoCountervalue: true,
+        }),
+      );
+
+      expect(result.current.needsUsdFallback).toBe(true);
+      expect(result.current.requestCounterCurrency).toBe("usd");
+      expect(result.current.displayCounterCurrency).toBe("btc");
+    });
+
+    it("falls back to USD for ETH regardless of case", () => {
+      const { result } = renderHook(() =>
+        useResolveMarketCounterCurrency({
+          counterCurrency: "ETH",
+          fallbackForCryptoCountervalues: true,
+          isCryptoCountervalue: true,
+        }),
+      );
+
+      expect(result.current.needsUsdFallback).toBe(true);
+      expect(result.current.requestCounterCurrency).toBe("usd");
+    });
+
+    it("does not wait for the supported list when it is already a crypto fallback", () => {
+      mockSupported(undefined);
+
+      const { result } = renderHook(() =>
+        useResolveMarketCounterCurrency({
+          counterCurrency: "btc",
+          fallbackForCryptoCountervalues: true,
+          isCryptoCountervalue: true,
+        }),
+      );
+
+      expect(result.current.isResolutionLoading).toBe(false);
+      expect(result.current.needsUsdFallback).toBe(true);
+    });
+  });
+
+  describe("crypto counter currency with fallbackForCryptoCountervalues=false (default)", () => {
+    it("does not fall back to USD for a crypto counter when flag is false", () => {
+      const { result } = renderHook(() =>
+        useResolveMarketCounterCurrency({ counterCurrency: "btc", isCryptoCountervalue: true }),
+      );
+
+      expect(result.current.needsUsdFallback).toBe(false);
+      expect(result.current.requestCounterCurrency).toBe("btc");
+    });
+  });
+
+  describe("undefined counter currency", () => {
+    it("returns undefined for request and display currencies with no loading", () => {
+      const { result } = renderHook(() =>
+        useResolveMarketCounterCurrency({
+          counterCurrency: undefined,
+          isCryptoCountervalue: false,
+        }),
+      );
+
+      expect(result.current.requestCounterCurrency).toBeUndefined();
+      expect(result.current.displayCounterCurrency).toBeUndefined();
+      expect(result.current.needsUsdFallback).toBe(false);
+      expect(result.current.isResolutionLoading).toBe(false);
+    });
+  });
+});

--- a/libs/ledger-live-common/src/market/hooks/useAssetChartDataInCounterValue.ts
+++ b/libs/ledger-live-common/src/market/hooks/useAssetChartDataInCounterValue.ts
@@ -5,6 +5,10 @@ import type { MarketAssetChartDataRequestParams, MarketCoinDataChart } from "../
 import { useAssetChartData } from "./useMarketDataProvider";
 import { useResolveMarketCounterCurrency } from "./useResolveMarketCounterCurrency";
 
+type UseAssetChartDataInCounterValueParams = MarketAssetChartDataRequestParams & {
+  isCryptoCountervalue: boolean;
+};
+
 export type UseAssetChartDataInCounterValueResult = {
   data: MarketCoinDataChart | undefined;
   // Data for the current args only; undefined until they load. Read this (not
@@ -21,13 +25,14 @@ export type UseAssetChartDataInCounterValueResult = {
  * rescales by the USD->countervalue rate; supported fiats are passed through.
  */
 export function useAssetChartDataInCounterValue(
-  { id, counterCurrency, range }: MarketAssetChartDataRequestParams,
+  { id, counterCurrency, range, isCryptoCountervalue }: UseAssetChartDataInCounterValueParams,
   options?: { skip?: boolean },
 ): UseAssetChartDataInCounterValueResult {
   const { requestCounterCurrency, displayCounterCurrency, needsUsdFallback, isResolutionLoading } =
     useResolveMarketCounterCurrency({
       counterCurrency,
       fallbackForCryptoCountervalues: true,
+      isCryptoCountervalue,
     });
   const skipChart = options?.skip || isResolutionLoading;
 

--- a/libs/ledger-live-common/src/market/hooks/useResolveMarketCounterCurrency.ts
+++ b/libs/ledger-live-common/src/market/hooks/useResolveMarketCounterCurrency.ts
@@ -1,4 +1,3 @@
-import { findCryptoCurrencyByTicker } from "@ledgerhq/cryptoassets";
 import { useSupportedCounterCurrencies } from "../../cg-client/hooks/useCoingeckoDataProvider";
 
 export type MarketCounterCurrencyResolution = {
@@ -12,6 +11,7 @@ export type MarketCounterCurrencyResolution = {
 type UseResolveMarketCounterCurrencyParams = {
   counterCurrency: string | undefined;
   fallbackForCryptoCountervalues?: boolean;
+  isCryptoCountervalue: boolean;
 };
 
 /**
@@ -23,13 +23,11 @@ type UseResolveMarketCounterCurrencyParams = {
 export function useResolveMarketCounterCurrency({
   counterCurrency,
   fallbackForCryptoCountervalues = false,
+  isCryptoCountervalue,
 }: UseResolveMarketCounterCurrencyParams): MarketCounterCurrencyResolution {
   const { data: supportedCounterCurrencies, isError } = useSupportedCounterCurrencies();
   const displayCounterCurrency = counterCurrency?.toLowerCase();
   const isUsd = displayCounterCurrency === "usd";
-  const isCryptoCountervalue = Boolean(
-    displayCounterCurrency && findCryptoCurrencyByTicker(displayCounterCurrency.toUpperCase()),
-  );
 
   const cryptoFallback = fallbackForCryptoCountervalues && isCryptoCountervalue;
   const unsupportedFiatFallback = Boolean(

--- a/libs/ledger-live-common/src/market/utils/__tests__/countervalueFormatter.test.ts
+++ b/libs/ledger-live-common/src/market/utils/__tests__/countervalueFormatter.test.ts
@@ -1,4 +1,13 @@
+import { findCryptoCurrencyByTicker, findFiatCurrencyByTicker } from "@ledgerhq/cryptoassets";
 import { counterValueFormatter } from "../countervalueFormatter";
+
+const usd = findFiatCurrencyByTicker("USD")!.units[0];
+const cad = findFiatCurrencyByTicker("CAD")!.units[0];
+const eur = findFiatCurrencyByTicker("EUR")!.units[0];
+// BTC and ETH exist in the fiat list (with Ledger-pinned signs ₿ / ETH),
+// mirroring what the formatter's old fiat-first lookup returned.
+const btc = findFiatCurrencyByTicker("BTC")!.units[0];
+const eth = findCryptoCurrencyByTicker("ETH")!.units[0];
 
 describe("counterValueFormatter (live-common)", () => {
   it("returns '-' for falsy values", () => {
@@ -10,7 +19,7 @@ describe("counterValueFormatter (live-common)", () => {
     const result = counterValueFormatter({
       value: 1234.56,
       locale: "en-US",
-      currency: "USD",
+      unit: usd,
     });
     expect(result).toContain("$");
     expect(result).toContain("1,234.56");
@@ -46,21 +55,17 @@ describe("counterValueFormatter (live-common)", () => {
 
   it("renders the Ledger fiat sign instead of the localized code", () => {
     // USD: previously rendered US$/$US in non-US locales
-    expect(counterValueFormatter({ value: 1234.56, locale: "en-GB", currency: "usd" })).toBe(
-      "$1,234.56",
-    );
-    expect(counterValueFormatter({ value: 1234.56, locale: "en-US", currency: "usd" })).toBe(
-      "$1,234.56",
-    );
+    expect(counterValueFormatter({ value: 1234.56, locale: "en-GB", unit: usd })).toBe("$1,234.56");
+    expect(counterValueFormatter({ value: 1234.56, locale: "en-US", unit: usd })).toBe("$1,234.56");
   });
 
   it("uses the same fiat sign regardless of locale so Market matches price and balances", () => {
     // CAD: Intl narrowSymbol is locale-dependent ("$" in en-CA, "CA$" in en-US),
     // but the Ledger fiat definition pins it to "CA$" everywhere.
-    expect(counterValueFormatter({ value: 1234.56, locale: "en-US", currency: "cad" })).toBe(
+    expect(counterValueFormatter({ value: 1234.56, locale: "en-US", unit: cad })).toBe(
       "CA$1,234.56",
     );
-    expect(counterValueFormatter({ value: 1234.56, locale: "en-CA", currency: "cad" })).toBe(
+    expect(counterValueFormatter({ value: 1234.56, locale: "en-CA", unit: cad })).toBe(
       "CA$1,234.56",
     );
   });
@@ -70,7 +75,7 @@ describe("counterValueFormatter (live-common)", () => {
       counterValueFormatter({
         value: 21_000_000,
         locale: "en-US",
-        currency: "btc",
+        unit: btc,
         shorten: true,
       }),
     ).toContain("₿");
@@ -81,9 +86,36 @@ describe("counterValueFormatter (live-common)", () => {
       counterValueFormatter({
         value: 21_000_000,
         locale: "en-US",
-        currency: "eth",
+        unit: eth,
         shorten: true,
       }),
     ).toContain("ETH");
+  });
+
+  it("formats EUR with the Ledger-pinned sign", () => {
+    const result = counterValueFormatter({
+      value: 1234.56,
+      locale: "en-US",
+      unit: eur,
+    });
+    expect(result).toContain("1,234.56");
+    expect(result).toMatch(/€/);
+  });
+
+  it("formats BTC without shorten using magnitude-based fraction digits (8 decimals)", () => {
+    const result = counterValueFormatter({
+      value: 1.123456789,
+      locale: "en-US",
+      unit: btc,
+      shorten: false,
+    });
+    // BTC magnitude is 8 → maximumFractionDigits = 8, Intl rounds (not truncates)
+    expect(result).toContain("₿");
+    expect(result).toMatch(/1\.12345679/);
+  });
+
+  it("formats a value without currency as plain decimal", () => {
+    const result = counterValueFormatter({ value: 1234.56, locale: "en-US" });
+    expect(result).toBe("1,234.56");
   });
 });

--- a/libs/ledger-live-common/src/market/utils/__tests__/countervalueFormatter.test.ts
+++ b/libs/ledger-live-common/src/market/utils/__tests__/countervalueFormatter.test.ts
@@ -4,8 +4,7 @@ import { counterValueFormatter } from "../countervalueFormatter";
 const usd = findFiatCurrencyByTicker("USD")!.units[0];
 const cad = findFiatCurrencyByTicker("CAD")!.units[0];
 const eur = findFiatCurrencyByTicker("EUR")!.units[0];
-// BTC and ETH exist in the fiat list (with Ledger-pinned signs ₿ / ETH),
-// mirroring what the formatter's old fiat-first lookup returned.
+// BTC is defined as a FiatCurrency (₿) in our registry; ETH is a CryptoCurrency.
 const btc = findFiatCurrencyByTicker("BTC")!.units[0];
 const eth = findCryptoCurrencyByTicker("ETH")!.units[0];
 

--- a/libs/ledger-live-common/src/market/utils/countervalueFormatter.ts
+++ b/libs/ledger-live-common/src/market/utils/countervalueFormatter.ts
@@ -1,4 +1,3 @@
-import { findCryptoCurrencyByTicker, findFiatCurrencyByTicker } from "@ledgerhq/cryptoassets";
 import type { Unit } from "@ledgerhq/types-cryptoassets";
 
 const MAXIMUM_FRACTION_DIGITS = 8;
@@ -18,13 +17,13 @@ const getFractionDigitOptions = (
 };
 
 export const counterValueFormatter = ({
-  currency,
+  unit,
   value,
   shorten,
   locale,
   ticker,
 }: {
-  currency?: string;
+  unit?: Unit;
   value?: number;
   shorten?: boolean;
   locale: string;
@@ -33,10 +32,6 @@ export const counterValueFormatter = ({
   if (!value) {
     return "-";
   }
-  const normalizedCurrency = currency?.toUpperCase();
-  const fiat = normalizedCurrency ? findFiatCurrencyByTicker(normalizedCurrency) : undefined;
-  const crypto = normalizedCurrency ? findCryptoCurrencyByTicker(normalizedCurrency) : undefined;
-  const unit = fiat?.units[0] ?? crypto?.units[0];
   const baseOptions: Intl.NumberFormatOptions = {
     notation: shorten ? "compact" : "standard",
     ...getFractionDigitOptions(unit, shorten),
@@ -53,8 +48,7 @@ export const counterValueFormatter = ({
   } else {
     formatted = new Intl.NumberFormat(locale, {
       ...baseOptions,
-      style: normalizedCurrency ? "currency" : "decimal",
-      currency: normalizedCurrency,
+      style: "decimal",
     }).format(value);
   }
   const upperTicker = ticker?.trim().toUpperCase();

--- a/libs/ledger-live-common/src/market/utils/countervalueFormatter.ts
+++ b/libs/ledger-live-common/src/market/utils/countervalueFormatter.ts
@@ -44,7 +44,11 @@ export const counterValueFormatter = ({
       ...baseOptions,
       style: "decimal",
     }).format(value);
-    formatted = unit.prefixCode ? `${unit.code}${number}` : `${number} ${unit.code}`;
+    formatted = unit.prefixCode
+      ? number.startsWith("-")
+        ? `-${unit.code}${number.slice(1)}`
+        : `${unit.code}${number}`
+      : `${number} ${unit.code}`;
   } else {
     formatted = new Intl.NumberFormat(locale, {
       ...baseOptions,

--- a/libs/ledger-live-common/src/market/utils/countervalueFormatter.ts
+++ b/libs/ledger-live-common/src/market/utils/countervalueFormatter.ts
@@ -44,11 +44,13 @@ export const counterValueFormatter = ({
       ...baseOptions,
       style: "decimal",
     }).format(value);
-    formatted = unit.prefixCode
-      ? number.startsWith("-")
+    if (unit.prefixCode) {
+      formatted = number.startsWith("-")
         ? `-${unit.code}${number.slice(1)}`
-        : `${unit.code}${number}`
-      : `${number} ${unit.code}`;
+        : `${unit.code}${number}`;
+    } else {
+      formatted = `${number} ${unit.code}`;
+    }
   } else {
     formatted = new Intl.NumberFormat(locale, {
       ...baseOptions,

--- a/libs/ledger-live-common/src/modularDrawer/hooks/modules/useRightMarketTrendModule.tsx
+++ b/libs/ledger-live-common/src/modularDrawer/hooks/modules/useRightMarketTrendModule.tsx
@@ -43,7 +43,7 @@ export const useRightMarketTrendModule = (
 
       const priceFormatted = counterValueFormatter({
         value: roundFiatPrice(currencyMarket.price * rate),
-        currency: counterValueCurrency.ticker,
+        unit: counterValueCurrency.units[0],
         locale,
       });
 
@@ -61,7 +61,7 @@ export const useRightMarketTrendModule = (
     marketByCurrencies,
     status,
     rate,
-    counterValueCurrency.ticker,
+    counterValueCurrency.units,
     locale,
     MarketPriceIndicator,
   ]);

--- a/libs/ledger-live-common/src/modularDrawer/hooks/modules/useRightMarketTrendModule.tsx
+++ b/libs/ledger-live-common/src/modularDrawer/hooks/modules/useRightMarketTrendModule.tsx
@@ -61,7 +61,7 @@ export const useRightMarketTrendModule = (
     marketByCurrencies,
     status,
     rate,
-    counterValueCurrency.units,
+    counterValueCurrency.units[0],
     locale,
     MarketPriceIndicator,
   ]);


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Market screen: verify prices, ATH/ATL, and market cap still display correctly in all counter currencies (USD, EUR, BTC, ETH, unsupported fiat like COP)
  - Asset detail screen: verify market stats section (price, market cap, volume, circulating supply) and price performance section render correctly
  - Desktop asset detail: verify chart and market price section render correctly with fiat and crypto counter currencies
  - Mobile wallet asset section: verify the MarketPrice component still formats the counter value correctly
  - Counter value fallback: verify USD fallback still triggers correctly for crypto counter values (BTC/ETH) and unsupported fiats

### 📝 Description

Several market formatting and detection paths were re-resolving a `Currency` or `Unit` from a raw ticker string via `findCryptoCurrencyByTicker`, even though the caller already held the resolved object from a Redux selector.

This PR threads the already-resolved `Currency`/`Unit` down from each call site, eliminating the redundant lookups in three core locations:

- **`countervalueFormatter`** (`@ledgerhq/live-common`): now accepts a `unit: Unit` directly instead of a `currency: string` ticker. All callers updated to pass `counterValueCurrency.units[0]` from the selector.
- **`useResolveMarketCounterCurrency`** (`@ledgerhq/live-common`): now accepts `isCryptoCountervalue: boolean` from the caller instead of re-running `findCryptoCurrencyByTicker` internally. All callers updated to derive the boolean from `counterValueCurrency.type === "CryptoCurrency"`.
- **`getNumberFormatter`** (mobile `Market/utils`): same pattern, self-contained within the file.

33 characterisation tests were added to lock in the current behaviour as a safety net before refactoring.

### 🗂 Affected files / flows

#### `@ledgerhq/live-common` (shared)
| File | Change |
|------|--------|
| `libs/ledger-live-common/src/market/utils/countervalueFormatter.ts` | Accepts `unit: Unit` directly; removed internal `findFiatCurrencyByTicker` fallback |
| `libs/ledger-live-common/src/market/hooks/useResolveMarketCounterCurrency.ts` | Accepts `isCryptoCountervalue: boolean` from caller; removed internal `findCryptoCurrencyByTicker` call |
| `libs/ledger-live-common/src/modularDrawer/hooks/modules/useRightMarketTrendModule.tsx` | Passes `counterValueCurrency.units[0]` to formatter; fixed memo dep to `units[0]` |

#### LWM — Market screen
| File | Change |
|------|--------|
| `Market/utils/index.ts` | Fixed `formatterKey` cache key (magnitude + prefixCode); fixed negative-prefix format |
| `Market/utils/marketAssetDisplay.ts` | Removed unused `counterCurrency` from `MapOptions`; callers pass `counterValueUnit` directly |
| `Market/screens/MarketScreen/useMarketAssets.ts` | Passes `isCryptoCountervalue` from `counterValueCurrency.type` |
| `Market/screens/MarketScreen/marketAssetsHelpers.ts` | Receives `counterValueUnit: Unit` instead of `counterCurrency: string` |
| `Market/hooks/useMarketCoinData.ts` | Passes `isCryptoCountervalue` from `counterValueCurrency.type` |

#### LWM — Asset Detail screen
| File | Change |
|------|--------|
| `AssetDetail/.../useAssetMarketData.ts` | Resolves and passes `counterValueUnit` from selector |
| `AssetDetail/.../useMarketStatsViewModel.ts` | Receives `counterValueUnit`; passes to formatter |
| `AssetDetail/.../usePricePerformanceViewModel.ts` | Same |
| `AssetDetail/.../useBalanceGraphViewModel.ts` | Same |

#### LWM — Global Search
| File | Change |
|------|--------|
| `GlobalSearch/utils/mapDadaMarketToDisplayData.ts` | Removed unused `counterCurrency` from `MapOptions` |
| `GlobalSearch/hooks/useGlobalSearchDefaults.ts` | Passes `counterValueUnit` from selector |
| `GlobalSearch/hooks/useGlobalSearchResults.ts` | Same |

#### LWM — Wallet Centric / Landing Pages
| File | Change |
|------|--------|
| `screens/WalletCentricSections/MarketPrice.tsx` | Type-only import for `Unit` |
| `screens/WalletCentricAsset/AssetMarketSection.tsx` | Passes `counterValueUnit` |
| `LandingPages/.../LargeMoverLandingPage` (×3) | Pass `counterValueUnit` to formatter |

#### LLD — Market screen
| File | Change |
|------|--------|
| `Market/hooks/useMarket.ts` | Passes `isCryptoCountervalue`; threads `counterValueUnit` to row VMs |
| `Market/hooks/useMarketCoin.ts` | Resolves and exposes `counterValueUnit` from selector |
| `Market/components/MarketRow/useMarketRowViewModel.ts` | Receives `counterValueUnit`; passes to formatter |
| `Market/components/RowItem/*` | Same |
| `Market/TopCards/.../useGlobalMarketCapViewModel.ts` | Same |
| `renderer/screens/market/MarketCoin/components/MarketCoinChart.tsx` | Receives `counterValueUnit` as prop; removed internal selector call |
| `renderer/screens/market/MarketCoin/components/MarketInfo.tsx` | Same |
| `renderer/screens/market/MarketCoin/index.tsx` | Threads `counterValueUnit` from hook to both children |

#### LLD — Asset Detail screen
| File | Change |
|------|--------|
| `AssetDetail/.../useAssetDetailChartSeries.ts` | Passes `isCryptoCountervalue` from `counterValueCurrency.type` |
| `AssetDetail/.../useMarketDataSectionCurrencyData.ts` | Resolves and passes `counterValueUnit` |
| `AssetDetail/.../useMarketStatsViewModel.ts` | Receives `counterValueUnit`; passes to formatter |
| `AssetDetail/.../usePricePerformanceViewModel.ts` | Same |
| `AssetDetail/.../useChartSectionViewModel.ts` | Same |
| `AssetDetail/.../useMarketPriceSectionViewModel.ts` | Same |

#### LLD — Global Search / TopBar Search
| File | Change |
|------|--------|
| `SearchAssets/components/AssetSuggestionRow.tsx` | Removed unused `counterCurrency` prop; reads unit from Redux internally |
| `SearchAssets/AssetSuggestionsSectionView.tsx` | Removed `counterCurrency` prop threading |
| `SearchAssets/AssetSuggestionsSection.tsx` | Same |
| `SearchAssets/hooks/useAssetSuggestionsSectionViewModel.ts` | Removed `counterCurrency` from returned shape |
| `SearchAssets/types.ts` | Removed `counterCurrency` from `AssetSuggestionsSectionViewProps` |
| `TopBarSearch/.../SearchResultRow.tsx` | Removed `counterCurrency` prop |
| `TopBarSearch/.../SearchResultsList.tsx` | Same |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33314](https://ledgerhq.atlassian.net/browse/LIVE-33314)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33314]: https://ledgerhq.atlassian.net/browse/LIVE-33314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ