### PR TITLE
[LWDM] chore: coin control improvements

### DIFF
--- a/.changeset/brave-coins-select.md
+++ b/.changeset/brave-coins-select.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"live-mobile": patch
+---
+
+Fix coin control not showing selected coins after entering an amount, and refine the coin control screen layout (subheader sizing, header spacing, and scrollbar gutter)

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
@@ -26,9 +26,11 @@ export function SendHeader() {
   const { close, transaction } = useSendFlowActions();
   const { displayMode } = useSendAmountDisplayMode();
   const { t } = useTranslation();
-  const availableText = useAvailableBalance(state.account.account, displayMode);
-
   const { navigation, currentStep } = wizard;
+
+  const headerDisplayMode = currentStep === SEND_FLOW_STEP.COIN_CONTROL ? "crypto" : displayMode;
+  const availableText = useAvailableBalance(state.account.account, headerDisplayMode);
+
   const currencyId = state.account.currency?.id;
 
   const sendFlowTrackingProperties = useMemo(

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/NetworkFeesMenu.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/NetworkFeesMenu.tsx
@@ -142,7 +142,7 @@ export function NetworkFeesMenu({ display, selection, presets, actions }: Networ
   if (!hasMenuOptions) {
     return (
       <div
-        className="flex w-full items-center justify-between mt-16 mb-12"
+        className="flex w-full items-center justify-between mt-8 mb-12"
         data-testid="send-network-fees-row"
       >
         <span className="flex items-center gap-8">

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/AmountInput.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/AmountInput.tsx
@@ -1,11 +1,10 @@
 import React from "react";
-import { Subheader, SubheaderRow, SubheaderTitle, TextInput } from "@ledgerhq/lumen-ui-react";
+import { TextInput } from "@ledgerhq/lumen-ui-react";
 
 type AmountInputProps = Readonly<{
   onAmountChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   amount: string | null;
   errorMessage?: string | null;
-  amountToSendLabel: string;
   amountInputLabel: string;
 }>;
 
@@ -13,16 +12,10 @@ export const AmountInput = ({
   onAmountChange,
   amount,
   errorMessage,
-  amountToSendLabel,
   amountInputLabel,
 }: AmountInputProps) => {
   return (
     <div className="flex flex-col gap-12">
-      <Subheader>
-        <SubheaderRow>
-          <SubheaderTitle>{amountToSendLabel}</SubheaderTitle>
-        </SubheaderRow>
-      </Subheader>
       <TextInput
         label={amountInputLabel}
         aria-label={amountInputLabel}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/ChangeToReturn.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/ChangeToReturn.tsx
@@ -8,7 +8,7 @@ type ChangeToReturnProps = Readonly<{
 export const ChangeToReturn = ({ changeToReturn }: ChangeToReturnProps) => {
   return (
     <div
-      className="flex w-full items-center justify-between py-8"
+      className="flex w-full items-center justify-between pt-8"
       data-testid="send-change-to-return-row"
     >
       <span className="flex items-center gap-8">

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/CoinControlScreenInner.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/CoinControlScreenInner.tsx
@@ -68,10 +68,8 @@ export function CoinControlScreenInner({
         onAmountChange={onAmountChange}
         amountError={viewModel.amountError}
         strategyLabel={viewModel.strategyLabel}
-        learnMoreLabel={viewModel.learnMoreLabel}
-        onLearnMoreClick={viewModel.onLearnMoreClick}
+        onInfoPress={viewModel.onInfoPress}
         coinToSendLabel={viewModel.coinToSendLabel}
-        amountToSendLabel={viewModel.amountToSendLabel}
         amountInputLabel={viewModel.amountInputLabel}
         networkFees={viewModel.networkFees}
         reviewLabel={viewModel.reviewLabel}
@@ -83,6 +81,7 @@ export function CoinControlScreenInner({
         isCustomPickingStrategy={viewModel.isCustomPickingStrategy}
         onToggleUtxoExclusion={viewModel.onToggleUtxoExclusion}
         onSelectCustomFees={onSelectCustomFees}
+        hasAmount={viewModel.hasAmount}
       />
     </>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/CoinControlScreenView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/CoinControlScreenView.tsx
@@ -19,10 +19,9 @@ type CoinControlScreenViewProps = Readonly<{
   onAmountChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   amountError: string | undefined;
   strategyLabel: string;
-  learnMoreLabel: string;
-  onLearnMoreClick: () => void;
+  hasAmount: boolean;
+  onInfoPress: () => void;
   coinToSendLabel: string;
-  amountToSendLabel: string;
   amountInputLabel: string;
   networkFees: NetworkFeesViewModel;
   reviewLabel: string;
@@ -45,10 +44,9 @@ export function CoinControlScreenView({
   onAmountChange,
   amountError,
   strategyLabel,
-  learnMoreLabel,
-  onLearnMoreClick,
+  hasAmount,
+  onInfoPress,
   coinToSendLabel,
-  amountToSendLabel,
   amountInputLabel,
   networkFees,
   reviewLabel,
@@ -63,20 +61,20 @@ export function CoinControlScreenView({
 }: CoinControlScreenViewProps) {
   return (
     <>
-      <DialogBody scrollbarWidth="auto" className="flex flex-col gap-12">
+      <DialogBody
+        scrollbarWidth="auto"
+        className="flex flex-col gap-16 [scrollbar-gutter:stable] -mt-4"
+      >
         <StrategySelect
           value={utxoDisplayData?.pickingStrategyValue?.toString() ?? ""}
           options={strategyOptionsWithLabels}
           onValueChange={onSelectStrategy}
           strategyLabel={strategyLabel}
-          learnMoreLabel={learnMoreLabel}
-          onLearnMoreClick={onLearnMoreClick}
         />
         <AmountInput
           onAmountChange={onAmountChange}
           amount={amountValue}
           errorMessage={amountError}
-          amountToSendLabel={amountToSendLabel}
           amountInputLabel={amountInputLabel}
         />
         <UtxoSelector
@@ -84,6 +82,8 @@ export function CoinControlScreenView({
           coinToSendLabel={coinToSendLabel}
           isCustomPickingStrategy={isCustomPickingStrategy}
           onToggleUtxoExclusion={onToggleUtxoExclusion}
+          onInfoPress={onInfoPress}
+          hasAmount={hasAmount}
         />
       </DialogBody>
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/StrategySelect.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/StrategySelect.tsx
@@ -1,14 +1,10 @@
 import {
-  Link,
   Select,
   SelectContent,
   SelectItem,
   SelectItemText,
   SelectList,
   SelectTrigger,
-  Subheader,
-  SubheaderRow,
-  SubheaderTitle,
 } from "@ledgerhq/lumen-ui-react";
 import React from "react";
 
@@ -19,8 +15,6 @@ type StrategySelectProps = Readonly<{
   options: readonly StrategyOptionWithLabel[];
   value: string;
   strategyLabel: string;
-  learnMoreLabel: string;
-  onLearnMoreClick: () => void;
 }>;
 
 export const StrategySelect = ({
@@ -28,8 +22,6 @@ export const StrategySelect = ({
   options,
   value,
   strategyLabel,
-  learnMoreLabel,
-  onLearnMoreClick,
 }: StrategySelectProps) => {
   const items = options.map(option => ({
     value: String(option.value),
@@ -37,17 +29,7 @@ export const StrategySelect = ({
   }));
 
   return (
-    <div className="flex flex-col gap-12">
-      <Subheader>
-        <div className="flex items-center gap-24">
-          <SubheaderRow className="min-w-0 flex-1">
-            <SubheaderTitle>{strategyLabel}</SubheaderTitle>
-          </SubheaderRow>
-          <Link appearance="accent" underline={false} size="md" onClick={onLearnMoreClick}>
-            {learnMoreLabel}
-          </Link>
-        </div>
-      </Subheader>
+    <div className="flex flex-col gap-12 pt-8">
       <Select
         value={value}
         onValueChange={v => {
@@ -55,7 +37,7 @@ export const StrategySelect = ({
         }}
         items={items}
       >
-        <SelectTrigger />
+        <SelectTrigger label={strategyLabel} />
         <SelectContent>
           <SelectList
             renderItem={item => (

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/UtxoSelector.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/UtxoSelector.tsx
@@ -9,6 +9,7 @@ import {
   Subheader,
   SubheaderRow,
   SubheaderTitle,
+  SubheaderInfo,
 } from "@ledgerhq/lumen-ui-react";
 import { Check } from "@ledgerhq/lumen-ui-react/symbols";
 import type { CoinControlDisplayData } from "@ledgerhq/live-common/bridge/descriptor/types";
@@ -18,6 +19,8 @@ type UtxoSelectorProps = Readonly<{
   utxoDisplayData: CoinControlDisplayData | null;
   coinToSendLabel: string;
   isCustomPickingStrategy: boolean;
+  hasAmount: boolean;
+  onInfoPress: () => void;
   onToggleUtxoExclusion?: (rowKey: string) => void;
 }>;
 
@@ -25,52 +28,58 @@ export const UtxoSelector = ({
   utxoDisplayData,
   coinToSendLabel,
   isCustomPickingStrategy,
+  hasAmount,
+  onInfoPress,
   onToggleUtxoExclusion,
 }: UtxoSelectorProps) => {
   const rows = utxoDisplayData?.utxoRows ?? [];
 
   return (
-    <div className="flex flex-col gap-12">
+    <div className="flex flex-col gap-8">
       <Subheader>
         <SubheaderRow>
           <SubheaderTitle>{coinToSendLabel}</SubheaderTitle>
+          <SubheaderInfo onClick={onInfoPress} />
         </SubheaderRow>
       </Subheader>
       <div>
-        {rows.map(row => (
-          <ListItem
-            key={row.rowKey}
-            disabled={row.disabled}
-            onClick={
-              isCustomPickingStrategy && !row.disabled
-                ? () => {
-                    onToggleUtxoExclusion?.(row.rowKey);
-                  }
-                : undefined
-            }
-          >
-            <ListItemLeading>
-              <div className="flex items-center gap-12">
-                {isCustomPickingStrategy ? (
-                  <Checkbox
-                    name={`utxo-${row.rowKey}`}
-                    checked={!row.excluded}
-                    disabled={row.disabled}
-                  />
-                ) : null}
-                <ListItemContent>
-                  <ListItemTitle>{row.titleLabel}</ListItemTitle>
-                  <ListItemDescription>{row.formattedValue}</ListItemDescription>
-                </ListItemContent>
-              </div>
-            </ListItemLeading>
-            {row.isUsedInTx && !isCustomPickingStrategy && (
-              <ListItemTrailing>
-                <Check />
-              </ListItemTrailing>
-            )}
-          </ListItem>
-        ))}
+        {rows.map(row => {
+          const rowDisabled = row.disabled || !hasAmount;
+          return (
+            <ListItem
+              key={row.rowKey}
+              disabled={rowDisabled}
+              onClick={
+                isCustomPickingStrategy && !rowDisabled
+                  ? () => {
+                      onToggleUtxoExclusion?.(row.rowKey);
+                    }
+                  : undefined
+              }
+            >
+              <ListItemLeading>
+                <div className="flex items-center gap-12">
+                  {isCustomPickingStrategy ? (
+                    <Checkbox
+                      name={`utxo-${row.rowKey}`}
+                      checked={!row.excluded}
+                      disabled={rowDisabled}
+                    />
+                  ) : null}
+                  <ListItemContent>
+                    <ListItemTitle>{row.titleLabel}</ListItemTitle>
+                    <ListItemDescription>{row.formattedValue}</ListItemDescription>
+                  </ListItemContent>
+                </div>
+              </ListItemLeading>
+              {row.isUsedInTx && !isCustomPickingStrategy && !rowDisabled && (
+                <ListItemTrailing>
+                  <Check />
+                </ListItemTrailing>
+              )}
+            </ListItem>
+          );
+        })}
       </div>
     </div>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/hooks/__tests__/useCoinControlScreenViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/hooks/__tests__/useCoinControlScreenViewModel.test.tsx
@@ -179,15 +179,15 @@ describe("useCoinControlScreenViewModel", () => {
       reviewDisabled: true,
       reviewLoading: false,
       isCustomPickingStrategy: false,
+      hasAmount: false,
     });
     expect(typeof result.current.onAmountChange).toBe("function");
     expect(typeof result.current.onSelectStrategy).toBe("function");
-    expect(typeof result.current.onLearnMoreClick).toBe("function");
+    expect(typeof result.current.onInfoPress).toBe("function");
     expect(result.current.strategyOptionsWithLabels).toBeDefined();
     expect(result.current.utxoDisplayData).toBeDefined();
     expect(result.current.changeToReturn.value).toBe("");
     expect(result.current.reviewLabel).toBeDefined();
-    expect(result.current.learnMoreLabel).toBeDefined();
     expect(result.current.coinToSendLabel).toBeDefined();
     expect(result.current.changeToReturn.changeToReturnLabel).toBeDefined();
     expect(result.current.enterAmountPlaceholder).toBeDefined();
@@ -346,14 +346,14 @@ describe("useCoinControlScreenViewModel", () => {
     }).not.toThrow();
   });
 
-  it("should open coin control URL when onLearnMoreClick is called", () => {
+  it("should open coin control URL when onInfoPress is called", () => {
     const params = buildBaseParams();
 
     const { result } = renderHook(() => useCoinControlScreenViewModel(params), {
       initialState: defaultInitialState,
     });
 
-    result.current.onLearnMoreClick();
+    result.current.onInfoPress();
 
     expect(mockOpenURL).toHaveBeenCalledWith("https://support.ledger.com/coin-control");
   });
@@ -408,5 +408,43 @@ describe("useCoinControlScreenViewModel", () => {
     });
 
     expect(result.current.amountError).toBeUndefined();
+  });
+
+  describe("hasAmount", () => {
+    it("should be false when amount is zero and useAllAmount is false", () => {
+      const params = buildBaseParams({
+        transaction: { amount: new BigNumber(0), useAllAmount: false },
+      });
+
+      const { result } = renderHook(() => useCoinControlScreenViewModel(params), {
+        initialState: defaultInitialState,
+      });
+
+      expect(result.current.hasAmount).toBe(false);
+    });
+
+    it("should be true when amount is greater than zero", () => {
+      const params = buildBaseParams({
+        transaction: { amount: new BigNumber(1000) },
+      });
+
+      const { result } = renderHook(() => useCoinControlScreenViewModel(params), {
+        initialState: defaultInitialState,
+      });
+
+      expect(result.current.hasAmount).toBe(true);
+    });
+
+    it("should be true when useAllAmount is set even if amount is zero", () => {
+      const params = buildBaseParams({
+        transaction: { amount: new BigNumber(0), useAllAmount: true },
+      });
+
+      const { result } = renderHook(() => useCoinControlScreenViewModel(params), {
+        initialState: defaultInitialState,
+      });
+
+      expect(result.current.hasAmount).toBe(true);
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/hooks/useCoinControlScreenViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/hooks/useCoinControlScreenViewModel.ts
@@ -89,7 +89,6 @@ export function useCoinControlScreenViewModel({
       reviewCta: t("newSendFlow.reviewCta"),
       getCtaLabel: (currency: string) => t("newSendFlow.getCta", { currency }),
       strategyLabel: t("newSendFlow.coinControl.strategy"),
-      learnMoreLabel: t("newSendFlow.coinControl.learnMore"),
       coinToSendLabel: t("newSendFlow.coinControl.coinToSend"),
       changeToReturnLabel: t("newSendFlow.coinControl.changeToReturn"),
       enterAmountPlaceholder: t("newSendFlow.coinControl.enterAmount"),
@@ -97,7 +96,9 @@ export function useCoinControlScreenViewModel({
       amountToSendLabel: t("newSendFlow.coinControl.amountToSendInCurrency", {
         ticker: accountCurrency?.ticker ?? "CRYPTO",
       }),
-      amountInputLabel: t("newSendFlow.coinControl.amountInputLabel"),
+      amountInputLabel: t("newSendFlow.coinControl.amountToSendInCurrency", {
+        ticker: accountCurrency?.ticker ?? "CRYPTO",
+      }),
       getStrategyOptionLabel: (labelKey: string) => t(labelKey),
     }),
     [t, accountCurrency?.ticker],
@@ -119,5 +120,8 @@ export function useCoinControlScreenViewModel({
     onLearnMoreClick,
   });
 
-  return core;
+  return {
+    ...core,
+    onInfoPress: onLearnMoreClick,
+  };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/hooks/__tests__/useCoinControlScreenViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/hooks/__tests__/useCoinControlScreenViewModel.test.tsx
@@ -158,12 +158,11 @@ describe("useCoinControlScreenViewModel", () => {
     });
     expect(typeof result.current.onAmountChange).toBe("function");
     expect(typeof result.current.onSelectStrategy).toBe("function");
-    expect(typeof result.current.onLearnMoreClick).toBe("function");
+    expect(typeof result.current.onInfoPress).toBe("function");
     expect(result.current.strategyOptionsWithLabels).toBeDefined();
     expect(result.current.utxoDisplayData).toBeDefined();
     expect(result.current.changeToReturn.value).toBe("");
     expect(result.current.reviewLabel).toBeDefined();
-    expect(result.current.learnMoreLabel).toBeDefined();
     expect(result.current.coinToSendLabel).toBeDefined();
     expect(result.current.changeToReturn.changeToReturnLabel).toBeDefined();
     expect(result.current.enterAmountPlaceholder).toBeDefined();
@@ -387,7 +386,7 @@ describe("useCoinControlScreenViewModel", () => {
     const { result } = renderHook(() => useCoinControlScreenViewModel(params));
 
     act(() => {
-      result.current.onLearnMoreClick();
+      result.current.onInfoPress();
     });
 
     expect(openURLSpy).toHaveBeenCalledTimes(1);

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/hooks/useCoinControlScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/hooks/useCoinControlScreenViewModel.ts
@@ -79,7 +79,6 @@ export function useCoinControlScreenViewModel({
       reviewCta: t("send.newSendFlow.reviewCta"),
       getCtaLabel: (currency: string) => t("send.newSendFlow.getCta", { currency }),
       strategyLabel: t("send.newSendFlow.coinControl.strategy"),
-      learnMoreLabel: t("send.newSendFlow.coinControl.learnMore"),
       coinToSendLabel: t("send.newSendFlow.coinControl.coinToSend"),
       changeToReturnLabel: t("send.newSendFlow.coinControl.changeToReturn"),
       enterAmountPlaceholder: t("send.newSendFlow.coinControl.enterAmount"),

--- a/libs/ledger-live-common/src/flows/send/coinControl/hooks/__tests__/useCoinControlScreenViewModelCore.test.ts
+++ b/libs/ledger-live-common/src/flows/send/coinControl/hooks/__tests__/useCoinControlScreenViewModelCore.test.ts
@@ -102,7 +102,6 @@ const mockLabels = {
   reviewCta: "Review",
   getCtaLabel: (currency: string) => `Get ${currency}`,
   strategyLabel: "Strategy",
-  learnMoreLabel: "Learn more",
   coinToSendLabel: "Coin to send",
   changeToReturnLabel: "Change to return",
   enterAmountPlaceholder: "Enter amount",
@@ -254,7 +253,6 @@ describe("useCoinControlScreenViewModelCore", () => {
       amountError: undefined,
       reviewShowIcon: true,
       strategyLabel: "Strategy",
-      learnMoreLabel: "Learn more",
       isCustomPickingStrategy: false,
     });
     expect(typeof result.current.onAmountChange).toBe("function");
@@ -498,6 +496,44 @@ describe("useCoinControlScreenViewModelCore", () => {
       expect(result.current.changeToReturn.value).toBe("3500 BTC");
       expect(result.current.enterAmountPlaceholder).toBe("Enter amount");
       expect(result.current.changeToReturn.placeholder).toBe("Enter amount");
+    });
+  });
+
+  describe("hasAmount", () => {
+    it("is false when amount is zero and useAllAmount is false", () => {
+      const { result } = renderCoinControlCore({ transaction: createTransaction() });
+      expect(result.current.hasAmount).toBe(false);
+    });
+
+    it("is true when amount is greater than zero", () => {
+      const { result } = renderCoinControlCore({
+        transaction: {
+          ...createTransaction(),
+          amount: new BigNumber(1000),
+        } as unknown as Transaction,
+      });
+      expect(result.current.hasAmount).toBe(true);
+    });
+
+    it("is true when useAllAmount is set even if amount is zero", () => {
+      const { result } = renderCoinControlCore({
+        transaction: {
+          ...createTransaction(),
+          useAllAmount: true,
+          amount: new BigNumber(0),
+        } as unknown as Transaction,
+      });
+      expect(result.current.hasAmount).toBe(true);
+    });
+
+    it("is false when amount is undefined", () => {
+      const { result } = renderCoinControlCore({
+        transaction: {
+          ...createTransaction(),
+          amount: undefined,
+        } as unknown as Transaction,
+      });
+      expect(result.current.hasAmount).toBe(false);
     });
   });
 });

--- a/libs/ledger-live-common/src/flows/send/coinControl/hooks/useCoinControlScreenViewModelCore.ts
+++ b/libs/ledger-live-common/src/flows/send/coinControl/hooks/useCoinControlScreenViewModelCore.ts
@@ -16,7 +16,6 @@ export type CoinControlScreenViewModelLabels = Readonly<{
   reviewCta: string;
   getCtaLabel: (currency: string) => string;
   strategyLabel: string;
-  learnMoreLabel: string;
   coinToSendLabel: string;
   changeToReturnLabel: string;
   enterAmountPlaceholder: string;
@@ -62,7 +61,6 @@ export type CoinControlScreenViewModelCoreResult<TNetworkFees = unknown> = Reado
   reviewLoading: boolean;
   strategyLabel: string;
   onLearnMoreClick: () => void;
-  learnMoreLabel: string;
   coinToSendLabel: string;
   enterAmountPlaceholder: string;
   amountToSendLabel: string;
@@ -70,6 +68,7 @@ export type CoinControlScreenViewModelCoreResult<TNetworkFees = unknown> = Reado
   networkFees: TNetworkFees;
   /** True when the active UTXO picking strategy is the coin’s “custom selection” mode. */
   isCustomPickingStrategy: boolean;
+  hasAmount: boolean;
   onToggleUtxoExclusion?: (rowKey: string) => void;
 }>;
 
@@ -127,6 +126,8 @@ export function useCoinControlScreenViewModelCore<TNetworkFees = unknown>({
   }, [account, coinControlConfig, locale, status, transaction]);
 
   const customStrategyValue = coinControlConfig?.customStrategyValue;
+
+  const hasAmount = transaction.useAllAmount || transaction.amount?.gt(0) === true;
 
   const isCustomPickingStrategy = useMemo(
     () =>
@@ -285,13 +286,13 @@ export function useCoinControlScreenViewModelCore<TNetworkFees = unknown>({
     reviewLoading: amountComputationPending,
     strategyLabel: labels.strategyLabel,
     onLearnMoreClick,
-    learnMoreLabel: labels.learnMoreLabel,
     coinToSendLabel: labels.coinToSendLabel,
     enterAmountPlaceholder: labels.enterAmountPlaceholder,
     amountToSendLabel: labels.amountToSendLabel,
     amountInputLabel: labels.amountInputLabel,
     networkFees,
     isCustomPickingStrategy,
+    hasAmount,
     onToggleUtxoExclusion,
   };
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Brings the fixes of the UI for the coin control of the new send flow in LWD

The header must keep the crypto value and never the fiat for the coin control screen (use useAvailableBalance hook to force the displayMode to crypto in the coin control screen, or check by current screen to force it to be crypto)

 Applies several layout refinements to match the design spec.


https://github.com/user-attachments/assets/e347ac9a-ba55-4100-9e01-96dd8f7d354e


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-33254](https://ledgerhq.atlassian.net/browse/LIVE-33254)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-33254]: https://ledgerhq.atlassian.net/browse/LIVE-33254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ