### PR TITLE
[LWDM] feat(lwdm): wire AuthSDK into desktop and mobile store

### DIFF
--- a/.changeset/long-kids-heal.md
+++ b/.changeset/long-kids-heal.md
@@ -1,5 +1,6 @@
 ---
 "@ledgerhq/ledger-key-ring-protocol": minor
+"@shared/auth": minor
 "@shared/env": minor
 "@shared/feature-flags": minor
 "ledger-live-desktop": minor

--- a/.changeset/long-kids-heal.md
+++ b/.changeset/long-kids-heal.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/ledger-key-ring-protocol": minor
+"@shared/env": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Connect @ledgerhq/ledger-auth to the Ledger Wallet apps Redux store

--- a/.changeset/long-kids-heal.md
+++ b/.changeset/long-kids-heal.md
@@ -1,6 +1,7 @@
 ---
 "@ledgerhq/ledger-key-ring-protocol": minor
 "@shared/env": minor
+"@shared/feature-flags": minor
 "ledger-live-desktop": minor
 "live-mobile": minor
 ---

--- a/apps/ledger-live-desktop/jest.config.js
+++ b/apps/ledger-live-desktop/jest.config.js
@@ -37,6 +37,8 @@ const testPathIgnorePatterns = [
 
 const moduleNameMapper = {
   ".*\\.lottie$": "<rootDir>/fileMock.js",
+  "^@ledgerhq/ledger-key-ring-protocol/__mocks__/(.*)$":
+    "<rootDir>/../../libs/ledger-key-ring-protocol/src/__mocks__/$1",
   ...pathsToModuleNameMapper(compilerOptions.paths),
   "~/(.*)": "<rootDir>/src/$1",
   "^@ledgerhq/(lumen-ui-react|lumen-design-core)$": "<rootDir>/node_modules/@ledgerhq/$1",

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -124,6 +124,7 @@
     "@ledgerhq/live-dmk-shared": "workspace:^",
     "@ledgerhq/live-dmk-speculos": "workspace:^",
     "@features/platform-env": "workspace:*",
+    "@shared/auth": "workspace:*",
     "@shared/env": "workspace:*",
     "@ledgerhq/live-network": "workspace:^",
     "@ledgerhq/live-wallet": "workspace:^",

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -112,6 +112,7 @@
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/hw-transport-http": "workspace:^",
     "@ledgerhq/hw-transport-vault": "workspace:^",
+    "@ledgerhq/ledger-auth": "workspace:^",
     "@ledgerhq/ledger-key-ring-protocol": "workspace:^",
     "@ledgerhq/ledger-wallet-framework": "workspace:^",
     "@ledgerhq/live-common": "workspace:^",

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useTrustchainSdk.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useTrustchainSdk.test.ts
@@ -1,0 +1,42 @@
+import { getSdk } from "@ledgerhq/ledger-key-ring-protocol/index";
+import { renderHook, withFlagOverrides } from "tests/testSetup";
+import { useTrustchainSdk } from "../hooks/useTrustchainSdk";
+
+jest.mock("@ledgerhq/ledger-key-ring-protocol/index", () => ({
+  ...jest.requireActual("@ledgerhq/ledger-key-ring-protocol/index"),
+  getSdk: jest.fn(),
+}));
+
+jest.mock("../hooks/useInstanceName", () => ({
+  useInstanceName: () => "Desktop instance",
+}));
+
+describe("useTrustchainSdk", () => {
+  it("publishes the environment captured by the Trustchain SDK", () => {
+    const sdk = {} as ReturnType<typeof getSdk>;
+    jest.mocked(getSdk).mockReturnValue(sdk);
+
+    const { result, store } = renderHook(() => useTrustchainSdk(), {
+      initialState: withFlagOverrides({
+        lldWalletSync: {
+          enabled: true,
+          params: {
+            environment: "STAGING",
+            watchConfig: {},
+            learnMoreLink: "",
+          },
+        },
+      }),
+    });
+
+    expect(result.current).toBe(sdk);
+    expect(jest.mocked(getSdk)).toHaveBeenCalledWith(
+      expect.any(Boolean),
+      expect.not.objectContaining({ environment: expect.anything() }),
+      expect.any(Function),
+      expect.any(Object),
+    );
+    expect(store.getState().authEnvironment).toBe("STAGING");
+    expect(getSdk).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useTrustchainSdk.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useTrustchainSdk.ts
@@ -1,5 +1,6 @@
-import { useMemo } from "react";
+import { useLayoutEffect, useMemo } from "react";
 import { getEnv } from "@shared/env";
+import { authEnvironmentSelector, setAuthEnvironment, type AuthEnvironment } from "@shared/auth";
 import { getSdk } from "@ledgerhq/ledger-key-ring-protocol/index";
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
 import { trustchainLifecycle } from "@ledgerhq/live-wallet/walletsync/index";
@@ -12,12 +13,13 @@ import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/get
 import { useInstanceName } from "./useInstanceName";
 
 let sdkInstance: TrustchainSDK | null = null;
+let instanceEnvironment: AuthEnvironment | null = null;
 
 export function useTrustchainSdk() {
   const featureWalletSync = useFeature("lldWalletSync");
-  const { trustchainApiBaseUrl, cloudSyncApiBaseUrl } = getWalletSyncEnvironmentParams(
-    featureWalletSync?.params?.environment,
-  );
+  const environment: AuthEnvironment =
+    featureWalletSync?.params?.environment === "STAGING" ? "STAGING" : "PROD";
+  const { trustchainApiBaseUrl, cloudSyncApiBaseUrl } = getWalletSyncEnvironmentParams(environment);
   const name = useInstanceName();
   const isMockEnv = !!getEnv("MOCK");
 
@@ -36,8 +38,14 @@ export function useTrustchainSdk() {
     [cloudSyncApiBaseUrl, store],
   );
 
+  useLayoutEffect(() => {
+    if (authEnvironmentSelector(store.getState()) || !instanceEnvironment) return;
+    store.dispatch(setAuthEnvironment(instanceEnvironment));
+  }, [store]);
+
   if (sdkInstance === null) {
     sdkInstance = getSdk(isMockEnv, defaultContext, withDevice, lifecycle);
+    instanceEnvironment = environment;
   }
 
   return sdkInstance;

--- a/apps/ledger-live-desktop/src/renderer/actions/trustchain.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/trustchain.test.ts
@@ -1,0 +1,56 @@
+import type { TrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
+import { trustchainStoreActionTypePrefix } from "@ledgerhq/ledger-key-ring-protocol/store";
+import { initMemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/utils";
+import { getKey } from "~/renderer/storage";
+import { fetchTrustchain } from "./trustchain";
+
+jest.mock("~/renderer/storage", () => ({
+  getKey: jest.fn(),
+}));
+
+describe("fetchTrustchain", () => {
+  const dispatch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should dispatch the persisted trustchain state", async () => {
+    const persistedTrustchainStore: TrustchainStore = {
+      trustchain: {
+        rootId: "root-id",
+        walletSyncEncryptionKey: "wallet-sync-encryption-key",
+        applicationPath: "m/0'/16'/0'",
+      },
+      memberCredentials: initMemberCredentials(),
+    };
+    jest.mocked(getKey).mockResolvedValue(persistedTrustchainStore);
+
+    await fetchTrustchain()(dispatch, jest.fn(), undefined);
+
+    expect(getKey).toHaveBeenCalledWith("app", "trustchain");
+    expect(dispatch).toHaveBeenCalledWith({
+      type: `${trustchainStoreActionTypePrefix}IMPORT_STATE`,
+      payload: { trustchain: persistedTrustchainStore },
+    });
+  });
+
+  it("should dispatch a default trustchain state when storage is missing", async () => {
+    jest.mocked(getKey).mockResolvedValue(undefined);
+
+    await fetchTrustchain()(dispatch, jest.fn(), undefined);
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: `${trustchainStoreActionTypePrefix}IMPORT_STATE`,
+      payload: {
+        trustchain: {
+          trustchain: null,
+          memberCredentials: {
+            pubkey: expect.stringMatching(/^[0-9a-f]+$/),
+            privatekey: expect.stringMatching(/^[0-9a-f]+$/),
+          },
+        },
+      },
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/actions/trustchain.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/trustchain.ts
@@ -5,8 +5,5 @@ import { ThunkResult } from "./types";
 export const fetchTrustchain =
   (): ThunkResult<Promise<void>> => async (dispatch, _getState, _extra) => {
     const data = await getKey("app", "trustchain");
-    if (data && typeof data === "object") {
-      // we don't throw in this case, only accounts is used as password check safeguard
-      dispatch(importTrustchainStoreState(data));
-    }
+    dispatch(importTrustchainStoreState(data));
   };

--- a/apps/ledger-live-desktop/src/renderer/reducers/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/index.ts
@@ -14,6 +14,7 @@ import market, { MarketState } from "./market";
 import marketBanner, { MarketBannerState } from "./marketBanner";
 import wallet from "./wallet";
 import { WalletState } from "@ledgerhq/live-wallet/store";
+import { authEnvironmentReducer, type AuthEnvironmentState } from "@shared/auth";
 import walletSync, { WalletSyncState } from "./walletSync";
 import trustchain from "./trustchain";
 import { TrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
@@ -60,6 +61,7 @@ export type State = LLDRTKApiState & {
   featureFlags: FeatureFlagsState;
   history: HistoryState;
   identities: IdentitiesState;
+  authEnvironment: AuthEnvironmentState;
   market: MarketState;
   marketBanner: MarketBannerState;
   modals: ModalsState;
@@ -99,6 +101,7 @@ const appReducer = combineReducers({
   featureFlags,
   history,
   identities: identitiesSlice.reducer,
+  authEnvironment: authEnvironmentReducer,
   modals,
   modularDialog,
   sendFlow,

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.test.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.test.ts
@@ -8,6 +8,7 @@ import { importTrustchainStoreState } from "@ledgerhq/ledger-key-ring-protocol/s
 import { CHALLENGE } from "@ledgerhq/ledger-key-ring-protocol/__mocks__/challenge";
 import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { liveAuthentication } from "@ledgerhq/ledger-key-ring-protocol/utils";
+import { setOverride } from "@shared/feature-flags";
 import customCreateStore from "./configureStore";
 
 describe("customCreateStore", () => {
@@ -70,6 +71,29 @@ describe("customCreateStore", () => {
       server.close();
     });
 
+    it("should keep AuthSDK undefined when ledger auth is disabled by default", async () => {
+      const store = customCreateStore({ fetchRemoteFlags: null });
+
+      await dispatchThunk(store, async (_dispatch, _getState, extra) => {
+        expect(extra.authSDK).toBeUndefined();
+      });
+    });
+
+    it("should clear AuthSDK when ledger auth is disabled at runtime", async () => {
+      const store = customCreateStore({ fetchRemoteFlags: null });
+      store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: true } }));
+
+      await dispatchThunk(store, async (_dispatch, _getState, extra) => {
+        expect(extra.authSDK).toBeInstanceOf(AuthSDK);
+      });
+
+      store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: false } }));
+
+      await dispatchThunk(store, async (_dispatch, _getState, extra) => {
+        expect(extra.authSDK).toBeUndefined();
+      });
+    });
+
     it("should authenticate with attestation when trustchain store has a root id", async () => {
       endpoints.keycloakAuth.mockReturnValue(
         HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
@@ -83,6 +107,7 @@ describe("customCreateStore", () => {
       );
 
       const store = customCreateStore({ fetchRemoteFlags: null });
+      store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: true } }));
       store.dispatch(
         importTrustchainStoreState({
           trustchain: {
@@ -126,6 +151,7 @@ describe("customCreateStore", () => {
       );
 
       const store = customCreateStore({ fetchRemoteFlags: null });
+      store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: true } }));
       store.dispatch(
         importTrustchainStoreState({
           trustchain: null,

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.test.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.test.ts
@@ -1,9 +1,9 @@
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
 import { webcrypto } from "crypto";
-import { setEnv } from "@ledgerhq/live-env";
+import { setAuthEnvironment, type AuthProvider } from "@shared/auth";
+import { setEnv } from "@shared/env";
 import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
-import { AuthSDK } from "@ledgerhq/ledger-auth";
 import { importTrustchainStoreState } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { CHALLENGE } from "@ledgerhq/ledger-key-ring-protocol/__mocks__/challenge";
 import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
@@ -12,10 +12,13 @@ import { setOverride } from "@shared/feature-flags";
 import customCreateStore from "./configureStore";
 
 describe("customCreateStore", () => {
-  describe("AuthSDK flow", () => {
+  describe("auth provider flow", () => {
+    const PROD_KEYCLOAK_BASE_URL = "http://keycloak-prod.test";
+    const STAGING_KEYCLOAK_BASE_URL = "http://keycloak-staging.test";
+
     const AUTH_CONFIG = {
       clientId: "ledger-keycloak",
-      keycloakBaseUrl: "http://keycloak.test",
+      keycloakBaseUrl: PROD_KEYCLOAK_BASE_URL,
       keycloakRealm: "ledger-bc-customers",
     };
 
@@ -33,15 +36,20 @@ describe("customCreateStore", () => {
     const queryFn = jest.fn(() => Promise.resolve());
 
     const endpoints = {
-      keycloakAuth: jest.fn<Response, [{ request: Request }]>(),
+      prodKeycloakAuth: jest.fn<Response, [{ request: Request }]>(),
+      stagingKeycloakAuth: jest.fn<Response, [{ request: Request }]>(),
       lkrpAuth: jest.fn<Response, [{ request: Request }]>(),
       lkrpToken: jest.fn<Response, [{ request: Request }]>(),
       tokenExchange: jest.fn<Response, [{ request: Request }]>(),
     };
     const server = setupServer(
       http.get(
-        `${AUTH_CONFIG.keycloakBaseUrl}/realms/${AUTH_CONFIG.keycloakRealm}/protocol/openid-connect/auth`,
-        endpoints.keycloakAuth,
+        `${PROD_KEYCLOAK_BASE_URL}/realms/${AUTH_CONFIG.keycloakRealm}/protocol/openid-connect/auth`,
+        endpoints.prodKeycloakAuth,
+      ),
+      http.get(
+        `${STAGING_KEYCLOAK_BASE_URL}/realms/${AUTH_CONFIG.keycloakRealm}/protocol/openid-connect/auth`,
+        endpoints.stagingKeycloakAuth,
       ),
       http.post(`https://${CHALLENGE.json.host}/openid/v1/authenticate`, endpoints.lkrpAuth),
       http.post(`https://${CHALLENGE.json.host}/openid/v1/token`, endpoints.lkrpToken),
@@ -54,8 +62,9 @@ describe("customCreateStore", () => {
 
     beforeAll(() => {
       setEnv("LEDGER_CLIENT_VERSION", "jest");
+      setEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL_PROD", PROD_KEYCLOAK_BASE_URL);
+      setEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL_STAGING", STAGING_KEYCLOAK_BASE_URL);
       setEnv("LEDGER_AUTH_CLIENT_ID", AUTH_CONFIG.clientId);
-      setEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL", AUTH_CONFIG.keycloakBaseUrl);
       setEnv("LEDGER_AUTH_KEYCLOAK_REALM", AUTH_CONFIG.keycloakRealm);
 
       server.listen({ onUnhandledRequest: "error" });
@@ -71,31 +80,45 @@ describe("customCreateStore", () => {
       server.close();
     });
 
-    it("should keep AuthSDK undefined when ledger auth is disabled by default", async () => {
+    it("should execute without a token when ledger auth is disabled by default", async () => {
       const store = customCreateStore({ fetchRemoteFlags: null });
 
-      await dispatchThunk(store, async (_dispatch, _getState, extra) => {
-        expect(extra.authSDK).toBeUndefined();
-      });
+      await dispatchThunk(store, (_dispatch, _getState, extra) =>
+        extra.authProvider.withToken({ queryFn }),
+      );
+
+      expect(queryFn).toHaveBeenCalledWith();
+      expect(endpoints.prodKeycloakAuth).not.toHaveBeenCalled();
+      expect(endpoints.stagingKeycloakAuth).not.toHaveBeenCalled();
     });
 
-    it("should clear AuthSDK when ledger auth is disabled at runtime", async () => {
+    it("should keep a stable auth provider facade when ledger auth is disabled at runtime", async () => {
       const store = customCreateStore({ fetchRemoteFlags: null });
-      store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: true } }));
+      let injectedAuthProvider: AuthProvider | undefined;
 
       await dispatchThunk(store, async (_dispatch, _getState, extra) => {
-        expect(extra.authSDK).toBeInstanceOf(AuthSDK);
+        injectedAuthProvider = extra.authProvider;
+      });
+
+      store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: true } }));
+      store.dispatch(setAuthEnvironment("PROD"));
+
+      await dispatchThunk(store, async (_dispatch, _getState, extra) => {
+        expect(extra.authProvider).toBe(injectedAuthProvider);
       });
 
       store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: false } }));
 
-      await dispatchThunk(store, async (_dispatch, _getState, extra) => {
-        expect(extra.authSDK).toBeUndefined();
-      });
+      await dispatchThunk(store, (_dispatch, _getState, extra) =>
+        extra.authProvider.withToken({ queryFn }),
+      );
+
+      expect(queryFn).toHaveBeenCalledWith();
+      expect(endpoints.prodKeycloakAuth).not.toHaveBeenCalled();
     });
 
-    it("should authenticate with attestation when trustchain store has a root id", async () => {
-      endpoints.keycloakAuth.mockReturnValue(
+    it("should use the staging Keycloak URL for a staging Trustchain SDK", async () => {
+      endpoints.stagingKeycloakAuth.mockReturnValue(
         HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
       );
       endpoints.lkrpAuth.mockReturnValue(HttpResponse.json("auth-code-xyz"));
@@ -107,6 +130,38 @@ describe("customCreateStore", () => {
       );
 
       const store = customCreateStore({ fetchRemoteFlags: null });
+
+      store.dispatch(setAuthEnvironment("STAGING"));
+
+      store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: true } }));
+      store.dispatch(
+        importTrustchainStoreState({
+          trustchain: null,
+          memberCredentials: MEMBER_CREDENTIALS,
+        }),
+      );
+
+      await dispatchThunk(store, async (_dispatch, _getState, extra) =>
+        extra.authProvider.withToken({ queryFn }),
+      );
+
+      expect(endpoints.stagingKeycloakAuth).toHaveBeenCalledTimes(1);
+    });
+
+    it("should authenticate with attestation when trustchain store has a root id", async () => {
+      endpoints.prodKeycloakAuth.mockReturnValue(
+        HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
+      );
+      endpoints.lkrpAuth.mockReturnValue(HttpResponse.json("auth-code-xyz"));
+      endpoints.lkrpToken.mockReturnValue(
+        HttpResponse.json({ access_token: LKRP_TOKEN, token_type: "Bearer" }),
+      );
+      endpoints.tokenExchange.mockReturnValue(
+        HttpResponse.json({ access_token: KEYCLOAK_JWT, token_type: "Bearer" }),
+      );
+
+      const store = customCreateStore({ fetchRemoteFlags: null });
+      store.dispatch(setAuthEnvironment("PROD"));
       store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: true } }));
       store.dispatch(
         importTrustchainStoreState({
@@ -120,11 +175,14 @@ describe("customCreateStore", () => {
       );
 
       await dispatchThunk(store, async (_dispatch, _getState, extra) =>
-        extra.authSDK?.withToken({ queryFn }),
+        extra.authProvider.withToken({ queryFn }),
       );
 
       expect(queryFn).toHaveBeenCalledWith(
         expect.objectContaining({ accessToken: KEYCLOAK_JWT, tokenType: "Bearer" }),
+      );
+      expect(endpoints.prodKeycloakAuth.mock.calls[0][0].request.url).toEqual(
+        expect.stringContaining(AUTH_CONFIG.keycloakBaseUrl),
       );
 
       const challengeRequest = await endpoints.lkrpAuth.mock.calls[0][0].request.json();
@@ -139,7 +197,7 @@ describe("customCreateStore", () => {
     });
 
     it("should authenticate without attestation when trustchain store only has credentials", async () => {
-      endpoints.keycloakAuth.mockReturnValue(
+      endpoints.prodKeycloakAuth.mockReturnValue(
         HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
       );
       endpoints.lkrpAuth.mockReturnValue(HttpResponse.json("auth-code-xyz"));
@@ -151,6 +209,7 @@ describe("customCreateStore", () => {
       );
 
       const store = customCreateStore({ fetchRemoteFlags: null });
+      store.dispatch(setAuthEnvironment("PROD"));
       store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: true } }));
       store.dispatch(
         importTrustchainStoreState({
@@ -160,7 +219,7 @@ describe("customCreateStore", () => {
       );
 
       await dispatchThunk(store, async (_dispatch, _getState, extra) =>
-        extra.authSDK?.withToken({ queryFn }),
+        extra.authProvider.withToken({ queryFn }),
       );
 
       expect(queryFn).toHaveBeenCalledWith(
@@ -185,7 +244,7 @@ describe("customCreateStore", () => {
 type AuthThunk = (
   dispatch: unknown,
   getState: unknown,
-  extra: { authSDK?: AuthSDK },
+  extra: { authProvider: AuthProvider },
 ) => Promise<unknown>;
 type DispatchThunk = (thunk: AuthThunk) => Promise<unknown>;
 function dispatchThunk(store: unknown, thunk: AuthThunk): Promise<unknown> {

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.test.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.test.ts
@@ -1,0 +1,174 @@
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { webcrypto } from "crypto";
+import { setEnv } from "@ledgerhq/live-env";
+import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
+import { AuthSDK } from "@ledgerhq/ledger-auth";
+import { importTrustchainStoreState } from "@ledgerhq/ledger-key-ring-protocol/store";
+import { CHALLENGE } from "@ledgerhq/ledger-key-ring-protocol/__mocks__/challenge";
+import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
+import { liveAuthentication } from "@ledgerhq/ledger-key-ring-protocol/utils";
+import customCreateStore from "./configureStore";
+
+describe("customCreateStore", () => {
+  describe("AuthSDK flow", () => {
+    const AUTH_CONFIG = {
+      clientId: "ledger-keycloak",
+      keycloakBaseUrl: "http://keycloak.test",
+      keycloakRealm: "ledger-bc-customers",
+    };
+
+    const MEMBER_CREDENTIALS: MemberCredentials = {
+      pubkey: "02e3311a12c450604725f02d1a775ef5cdb4a1b832eb41ac6b1302adbe92a612fc",
+      privatekey: "873f500bd20783224f7e78d4f8cce3d2bf69eb8008fbd697d20bbea31a721a03",
+    };
+
+    const TRUSTCHAIN_ID = "ROOTID";
+    const ATTESTATION = crypto.to_hex(liveAuthentication(TRUSTCHAIN_ID));
+
+    const LKRP_TOKEN = makeJwt({ sub: "idp", exp: 4102444800 });
+    const KEYCLOAK_JWT = makeJwt({ sub: "keycloak", exp: 4102444800 });
+
+    const queryFn = jest.fn(() => Promise.resolve());
+
+    const endpoints = {
+      keycloakAuth: jest.fn<Response, [{ request: Request }]>(),
+      lkrpAuth: jest.fn<Response, [{ request: Request }]>(),
+      lkrpToken: jest.fn<Response, [{ request: Request }]>(),
+      tokenExchange: jest.fn<Response, [{ request: Request }]>(),
+    };
+    const server = setupServer(
+      http.get(
+        `${AUTH_CONFIG.keycloakBaseUrl}/realms/${AUTH_CONFIG.keycloakRealm}/protocol/openid-connect/auth`,
+        endpoints.keycloakAuth,
+      ),
+      http.post(`https://${CHALLENGE.json.host}/openid/v1/authenticate`, endpoints.lkrpAuth),
+      http.post(`https://${CHALLENGE.json.host}/openid/v1/token`, endpoints.lkrpToken),
+      http.post(`https://${CHALLENGE.json.host}/openid/v1/exchange`, endpoints.tokenExchange),
+    );
+
+    // WebCrypto API is used to generate the PKCE pair
+    const globalCrypto = globalThis.crypto;
+    Object.defineProperty(globalThis, "crypto", { configurable: true, value: webcrypto });
+
+    beforeAll(() => {
+      setEnv("LEDGER_CLIENT_VERSION", "jest");
+      setEnv("LEDGER_AUTH_CLIENT_ID", AUTH_CONFIG.clientId);
+      setEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL", AUTH_CONFIG.keycloakBaseUrl);
+      setEnv("LEDGER_AUTH_KEYCLOAK_REALM", AUTH_CONFIG.keycloakRealm);
+
+      server.listen({ onUnhandledRequest: "error" });
+    });
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      server.resetHandlers();
+    });
+
+    afterAll(() => {
+      Object.defineProperty(globalThis, "crypto", { configurable: true, value: globalCrypto });
+      server.close();
+    });
+
+    it("should authenticate with attestation when trustchain store has a root id", async () => {
+      endpoints.keycloakAuth.mockReturnValue(
+        HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
+      );
+      endpoints.lkrpAuth.mockReturnValue(HttpResponse.json("auth-code-xyz"));
+      endpoints.lkrpToken.mockReturnValue(
+        HttpResponse.json({ access_token: LKRP_TOKEN, token_type: "Bearer" }),
+      );
+      endpoints.tokenExchange.mockReturnValue(
+        HttpResponse.json({ access_token: KEYCLOAK_JWT, token_type: "Bearer" }),
+      );
+
+      const store = customCreateStore({ fetchRemoteFlags: null });
+      store.dispatch(
+        importTrustchainStoreState({
+          trustchain: {
+            rootId: TRUSTCHAIN_ID,
+            walletSyncEncryptionKey: "wallet-sync-encryption-key",
+            applicationPath: "m/0'/16'/0'",
+          },
+          memberCredentials: MEMBER_CREDENTIALS,
+        }),
+      );
+
+      await dispatchThunk(store, async (_dispatch, _getState, extra) =>
+        extra.authSDK?.withToken({ queryFn }),
+      );
+
+      expect(queryFn).toHaveBeenCalledWith(
+        expect.objectContaining({ accessToken: KEYCLOAK_JWT, tokenType: "Bearer" }),
+      );
+
+      const challengeRequest = await endpoints.lkrpAuth.mock.calls[0][0].request.json();
+      expect(challengeRequest).toEqual(
+        expect.objectContaining({
+          signature: expect.objectContaining({
+            credential: expect.objectContaining({ publicKey: MEMBER_CREDENTIALS.pubkey }),
+            attestation: ATTESTATION,
+          }),
+        }),
+      );
+    });
+
+    it("should authenticate without attestation when trustchain store only has credentials", async () => {
+      endpoints.keycloakAuth.mockReturnValue(
+        HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
+      );
+      endpoints.lkrpAuth.mockReturnValue(HttpResponse.json("auth-code-xyz"));
+      endpoints.lkrpToken.mockReturnValue(
+        HttpResponse.json({ access_token: LKRP_TOKEN, token_type: "Bearer" }),
+      );
+      endpoints.tokenExchange.mockReturnValue(
+        HttpResponse.json({ access_token: KEYCLOAK_JWT, token_type: "Bearer" }),
+      );
+
+      const store = customCreateStore({ fetchRemoteFlags: null });
+      store.dispatch(
+        importTrustchainStoreState({
+          trustchain: null,
+          memberCredentials: MEMBER_CREDENTIALS,
+        }),
+      );
+
+      await dispatchThunk(store, async (_dispatch, _getState, extra) =>
+        extra.authSDK?.withToken({ queryFn }),
+      );
+
+      expect(queryFn).toHaveBeenCalledWith(
+        expect.objectContaining({ accessToken: KEYCLOAK_JWT, tokenType: "Bearer" }),
+      );
+
+      const challengeRequest = await endpoints.lkrpAuth.mock.calls[0][0].request.json();
+      expect(challengeRequest).toEqual(
+        expect.objectContaining({
+          signature: expect.objectContaining({
+            credential: expect.objectContaining({
+              publicKey: MEMBER_CREDENTIALS.pubkey,
+            }),
+          }),
+        }),
+      );
+      expect(challengeRequest.signature).not.toHaveProperty("attestation");
+    });
+  });
+});
+
+type AuthThunk = (
+  dispatch: unknown,
+  getState: unknown,
+  extra: { authSDK?: AuthSDK },
+) => Promise<unknown>;
+type DispatchThunk = (thunk: AuthThunk) => Promise<unknown>;
+function dispatchThunk(store: unknown, thunk: AuthThunk): Promise<unknown> {
+  const dispatch = (store as { dispatch: unknown }).dispatch as DispatchThunk;
+  return dispatch(thunk);
+}
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const prefix = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${prefix}.${body}.signature`;
+}

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.test.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.test.ts
@@ -1,6 +1,5 @@
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
-import { webcrypto } from "crypto";
 import { setAuthEnvironment, type AuthProvider } from "@shared/auth";
 import { setEnv } from "@shared/env";
 import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
@@ -56,10 +55,6 @@ describe("customCreateStore", () => {
       http.post(`https://${CHALLENGE.json.host}/openid/v1/exchange`, endpoints.tokenExchange),
     );
 
-    // WebCrypto API is used to generate the PKCE pair
-    const globalCrypto = globalThis.crypto;
-    Object.defineProperty(globalThis, "crypto", { configurable: true, value: webcrypto });
-
     beforeAll(() => {
       setEnv("LEDGER_CLIENT_VERSION", "jest");
       setEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL_PROD", PROD_KEYCLOAK_BASE_URL);
@@ -76,7 +71,6 @@ describe("customCreateStore", () => {
     });
 
     afterAll(() => {
-      Object.defineProperty(globalThis, "crypto", { configurable: true, value: globalCrypto });
       server.close();
     });
 

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.ts
@@ -87,6 +87,7 @@ const customCreateStore = ({
                       clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
                       keycloakBaseUrl: getEnv(`LEDGER_AUTH_KEYCLOAK_BASE_URL_${environment}`),
                       keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
+                      disablePkce: true,
                     },
                     { provider: identityProvider },
                   ),

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.ts
@@ -19,7 +19,11 @@ import reducers, { State } from "~/renderer/reducers";
 import { applyLldRTKApiMiddlewares } from "~/renderer/reducers/rtkQueryApi";
 import { createIdentitiesSyncMiddleware, pushDevicesApiExtra } from "@domain/api-push-devices";
 import { canPushDeviceIdsSelector, languageSelector } from "~/renderer/reducers/settings";
-import { createFeatureFlagsMiddleware, type PartialFeatures } from "@shared/feature-flags";
+import {
+  createFeatureFlagsMiddleware,
+  selectFeature,
+  type PartialFeatures,
+} from "@shared/feature-flags";
 import { fetchRemoteFlags as defaultFetchRemoteFlags } from "~/firebase/remoteConfig";
 type Props = {
   state?: State;
@@ -38,13 +42,33 @@ const customCreateStore = ({
   analyticsMiddleware,
   fetchRemoteFlags = defaultFetchRemoteFlags,
 }: Props) => {
+  const listenerMiddleware = createListenerMiddleware();
+
   const lkrpIdentityProvider = new LkrpIdentityProvider();
-  const lkrpListenerMiddleware = createListenerMiddleware();
-  lkrpListenerMiddleware.startListening({
+  listenerMiddleware.startListening({
     predicate: action => action.type.startsWith(trustchainStoreActionTypePrefix),
     effect(_action, listenerApi) {
       const { trustchain } = listenerApi.getState() as State;
       lkrpIdentityProvider.setTrustchainStore(trustchain);
+    },
+  });
+
+  const authSDKRef: { current?: AuthSDK } = {};
+  const authSDK = new AuthSDK(
+    {
+      clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
+      keycloakBaseUrl: getEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL_PROD"),
+      keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
+    },
+    { provider: lkrpIdentityProvider },
+  );
+  const syncAuthSDK = (currentState: State) => {
+    authSDKRef.current = selectFeature(currentState, "lwdAuth").enabled ? authSDK : undefined;
+  };
+  listenerMiddleware.startListening({
+    predicate: action => action.type.startsWith("featureFlags/"),
+    effect(_action, listenerApi) {
+      syncAuthSDK(listenerApi.getState() as State);
     },
   });
 
@@ -79,17 +103,12 @@ const customCreateStore = ({
                 // LIVE-33829: force mocks until Pay Card API base URL is wired.
                 payCardApiMocksEnabled: true,
               }),
-              authSDK: new AuthSDK(
-                {
-                  clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
-                  keycloakBaseUrl: getEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL_PROD"),
-                  keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
-                },
-                { provider: lkrpIdentityProvider },
-              ),
+              get authSDK() {
+                return authSDKRef.current;
+              },
             },
           },
-        }).prepend(lkrpListenerMiddleware.middleware),
+        }).prepend(listenerMiddleware.middleware),
       )
         .concat(logger)
         .concat(analyticsMiddleware ? [analyticsMiddleware] : [])
@@ -114,6 +133,7 @@ const customCreateStore = ({
         ),
     devTools: __DEV__,
   });
+  syncAuthSDK(store.getState());
   return store;
 };
 

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.ts
@@ -7,8 +7,8 @@ import {
 import { UnknownAction } from "redux";
 import { AuthSDK } from "@ledgerhq/ledger-auth";
 import { getEnv } from "@shared/env";
+import { authApiExtra } from "@shared/auth";
 import { LkrpIdentityProvider } from "@ledgerhq/ledger-key-ring-protocol";
-import { trustchainStoreActionTypePrefix } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { calApiExtra } from "@domain/api-currency-token";
 import { cvsApiExtra } from "@domain/api-currency-fiat";
 import { marketSentimentApiExtra } from "@domain/api-market-sentiment";
@@ -19,11 +19,7 @@ import reducers, { State } from "~/renderer/reducers";
 import { applyLldRTKApiMiddlewares } from "~/renderer/reducers/rtkQueryApi";
 import { createIdentitiesSyncMiddleware, pushDevicesApiExtra } from "@domain/api-push-devices";
 import { canPushDeviceIdsSelector, languageSelector } from "~/renderer/reducers/settings";
-import {
-  createFeatureFlagsMiddleware,
-  selectFeature,
-  type PartialFeatures,
-} from "@shared/feature-flags";
+import { createFeatureFlagsMiddleware, type PartialFeatures } from "@shared/feature-flags";
 import { fetchRemoteFlags as defaultFetchRemoteFlags } from "~/firebase/remoteConfig";
 type Props = {
   state?: State;
@@ -42,35 +38,9 @@ const customCreateStore = ({
   analyticsMiddleware,
   fetchRemoteFlags = defaultFetchRemoteFlags,
 }: Props) => {
-  const listenerMiddleware = createListenerMiddleware();
-
-  const lkrpIdentityProvider = new LkrpIdentityProvider();
-  listenerMiddleware.startListening({
-    predicate: action => action.type.startsWith(trustchainStoreActionTypePrefix),
-    effect(_action, listenerApi) {
-      const { trustchain } = listenerApi.getState() as State;
-      lkrpIdentityProvider.setTrustchainStore(trustchain);
-    },
-  });
-
-  const authSDKRef: { current?: AuthSDK } = {};
-  const authSDK = new AuthSDK(
-    {
-      clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
-      keycloakBaseUrl: getEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL_PROD"),
-      keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
-    },
-    { provider: lkrpIdentityProvider },
-  );
-  const syncAuthSDK = (currentState: State) => {
-    authSDKRef.current = selectFeature(currentState, "lwdAuth").enabled ? authSDK : undefined;
-  };
-  listenerMiddleware.startListening({
-    predicate: action => action.type.startsWith("featureFlags/"),
-    effect(_action, listenerApi) {
-      syncAuthSDK(listenerApi.getState() as State);
-    },
-  });
+  // This listenerMiddleware is cross-scope as it is preferable to have one instance per store
+  // Source: https://github.com/reduxjs/redux-toolkit/discussions/3665
+  const listenerMiddleware = createListenerMiddleware<State>();
 
   const store = configureStore({
     reducer: reducers,
@@ -103,9 +73,24 @@ const customCreateStore = ({
                 // LIVE-33829: force mocks until Pay Card API base URL is wired.
                 payCardApiMocksEnabled: true,
               }),
-              get authSDK() {
-                return authSDKRef.current;
-              },
+              ...authApiExtra({
+                authFeatureId: "lwdAuth",
+                startListening: listenerMiddleware.startListening,
+                providerParams: {
+                  identityProvider: new LkrpIdentityProvider<State>({
+                    startListening: listenerMiddleware.startListening,
+                  }),
+                },
+                createAuthProvider: (environment, { identityProvider }) =>
+                  new AuthSDK(
+                    {
+                      clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
+                      keycloakBaseUrl: getEnv(`LEDGER_AUTH_KEYCLOAK_BASE_URL_${environment}`),
+                      keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
+                    },
+                    { provider: identityProvider },
+                  ),
+              }),
             },
           },
         }).prepend(listenerMiddleware.middleware),
@@ -133,7 +118,7 @@ const customCreateStore = ({
         ),
     devTools: __DEV__,
   });
-  syncAuthSDK(store.getState());
+
   return store;
 };
 

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.ts
@@ -1,6 +1,14 @@
-import { configureStore, Middleware, ThunkDispatch } from "@reduxjs/toolkit";
+import {
+  configureStore,
+  createListenerMiddleware,
+  type Middleware,
+  type ThunkDispatch,
+} from "@reduxjs/toolkit";
 import { UnknownAction } from "redux";
+import { AuthSDK } from "@ledgerhq/ledger-auth";
 import { getEnv } from "@shared/env";
+import { LkrpIdentityProvider } from "@ledgerhq/ledger-key-ring-protocol";
+import { trustchainStoreActionTypePrefix } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { calApiExtra } from "@domain/api-currency-token";
 import { cvsApiExtra } from "@domain/api-currency-fiat";
 import { marketSentimentApiExtra } from "@domain/api-market-sentiment";
@@ -30,6 +38,16 @@ const customCreateStore = ({
   analyticsMiddleware,
   fetchRemoteFlags = defaultFetchRemoteFlags,
 }: Props) => {
+  const lkrpIdentityProvider = new LkrpIdentityProvider();
+  const lkrpListenerMiddleware = createListenerMiddleware();
+  lkrpListenerMiddleware.startListening({
+    predicate: action => action.type.startsWith(trustchainStoreActionTypePrefix),
+    effect(_action, listenerApi) {
+      const { trustchain } = listenerApi.getState() as State;
+      lkrpIdentityProvider.setTrustchainStore(trustchain);
+    },
+  });
+
   const store = configureStore({
     reducer: reducers,
     preloadedState: state,
@@ -61,9 +79,17 @@ const customCreateStore = ({
                 // LIVE-33829: force mocks until Pay Card API base URL is wired.
                 payCardApiMocksEnabled: true,
               }),
+              authSDK: new AuthSDK(
+                {
+                  clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
+                  keycloakBaseUrl: getEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL_PROD"),
+                  keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
+                },
+                { provider: lkrpIdentityProvider },
+              ),
             },
           },
-        }),
+        }).prepend(lkrpListenerMiddleware.middleware),
       )
         .concat(logger)
         .concat(analyticsMiddleware ? [analyticsMiddleware] : [])
@@ -71,7 +97,7 @@ const customCreateStore = ({
         .concat(
           createIdentitiesSyncMiddleware({
             pushDevicesServiceUrl: getEnv("PUSH_DEVICES_SERVICE_URL").trim(),
-            getIdentitiesState: (state: State) => state.identities,
+            getIdentitiesState: ({ identities }: State) => identities,
             getAnalyticsConsent: canPushDeviceIdsSelector,
           }),
         )

--- a/apps/ledger-live-mobile/__tests__/jest-setup.js
+++ b/apps/ledger-live-mobile/__tests__/jest-setup.js
@@ -40,6 +40,13 @@ import mockAsyncStorage from "@react-native-async-storage/async-storage/jest/asy
 import mockLocalize from "react-native-localize/mock";
 import { EventEmitter } from "events";
 
+jest.mock("expo-crypto", () => ({
+  CryptoDigestAlgorithm: { SHA256: "SHA-256" },
+  CryptoEncoding: { BASE64: "base64" },
+  getRandomBytesAsync: jest.fn(() => Promise.resolve(new Uint8Array(32))),
+  digestStringAsync: jest.fn(() => Promise.resolve("Y29kZS1jaGFsbGVuZ2U=")),
+}));
+
 // Disable max listeners warning for MSW (known issue with multiple tests)
 EventEmitter.defaultMaxListeners = 0;
 

--- a/apps/ledger-live-mobile/jest.config.js
+++ b/apps/ledger-live-mobile/jest.config.js
@@ -33,6 +33,8 @@ const transformIncludePatterns = [
   "@hashgraph/sdk",
   "react-native-startup-time",
   "@segment/analytics-react-native",
+  "expo-crypto",
+  "expo-modules-core",
   "uuid",
   "react-native-ble-plx",
   "react-native-android-location-services-dialog-box",
@@ -133,6 +135,8 @@ module.exports = {
   ],
   resolver: "<rootDir>/scripts/resolver.js",
   moduleNameMapper: {
+    "^@ledgerhq/ledger-key-ring-protocol/__mocks__/(.*)$":
+      "<rootDir>/../../libs/ledger-key-ring-protocol/src/__mocks__/$1",
     ...pathsToModuleNameMapper(compilerOptions.paths),
     // Logic-only stub — integration tests overlay UI components via jest.mock.
     "^@features/flow-contacts$": "<rootDir>/../../features/flow/contacts/src/jest.native.ts",

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -182,6 +182,7 @@
     "@sbaiahmed1/react-native-blur": "4.5.5",
     "@segment/analytics-react-native": "2.21.4",
     "@segment/sovran-react-native": "1.1.3",
+    "@shared/auth": "workspace:*",
     "@shared/env": "workspace:*",
     "@shared/feature-flags": "workspace:*",
     "@shopify/flash-list": "2.2.0",

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -138,6 +138,7 @@
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/hw-transport-http": "workspace:^",
     "@ledgerhq/icons-ui": "workspace:^",
+    "@ledgerhq/ledger-auth": "workspace:^",
     "@ledgerhq/ledger-key-ring-protocol": "workspace:^",
     "@ledgerhq/ledger-wallet-framework": "workspace:^",
     "@ledgerhq/live-config": "workspace:^",

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -199,9 +199,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
         store.dispatch(importMarketBannerState(marketBannerState));
       }
 
-      if (trustchainStore) {
-        store.dispatch(importTrustchainStoreState(trustchainStore));
-      }
+      store.dispatch(importTrustchainStoreState(trustchainStore));
 
       if (walletStore) {
         store.dispatch(importWalletState(walletStore));

--- a/apps/ledger-live-mobile/src/helpers/base64Url.test.ts
+++ b/apps/ledger-live-mobile/src/helpers/base64Url.test.ts
@@ -1,0 +1,11 @@
+import { bytesToBase64Url, toBase64Url } from "./base64Url";
+
+describe("base64Url", () => {
+  it("should convert base64 to an unpadded URL-safe value", () => {
+    expect(toBase64Url("ab+/==")).toBe("ab-_");
+  });
+
+  it("should encode bytes as an unpadded URL-safe value", () => {
+    expect(bytesToBase64Url(Uint8Array.from([251, 255]))).toBe("-_8");
+  });
+});

--- a/apps/ledger-live-mobile/src/helpers/base64Url.ts
+++ b/apps/ledger-live-mobile/src/helpers/base64Url.ts
@@ -1,0 +1,7 @@
+export function bytesToBase64Url(bytes: Uint8Array): string {
+  return toBase64Url(btoa(String.fromCodePoint(...bytes)));
+}
+
+export function toBase64Url(value: string): string {
+  return value.replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}

--- a/apps/ledger-live-mobile/src/helpers/pkce.ts
+++ b/apps/ledger-live-mobile/src/helpers/pkce.ts
@@ -1,0 +1,18 @@
+import * as Crypto from "expo-crypto";
+import { bytesToBase64Url, toBase64Url } from "./base64Url";
+
+const PKCE_RANDOM_BYTE_LENGTH = 32;
+
+export async function createPkcePairWithExpoCrypto() {
+  const codeVerifier = bytesToBase64Url(await Crypto.getRandomBytesAsync(PKCE_RANDOM_BYTE_LENGTH));
+  const codeChallenge = toBase64Url(
+    await Crypto.digestStringAsync(Crypto.CryptoDigestAlgorithm.SHA256, codeVerifier, {
+      encoding: Crypto.CryptoEncoding.BASE64,
+    }),
+  );
+  return {
+    codeVerifier,
+    codeChallenge,
+    codeChallengeMethod: "S256" as const,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/__integrations__/useTrustchainSdk.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/__integrations__/useTrustchainSdk.test.ts
@@ -1,0 +1,41 @@
+import { getSdk } from "@ledgerhq/ledger-key-ring-protocol/index";
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { useTrustchainSdk } from "../hooks/useTrustchainSdk";
+
+jest.mock("@ledgerhq/ledger-key-ring-protocol/index", () => ({
+  ...jest.requireActual("@ledgerhq/ledger-key-ring-protocol/index"),
+  getSdk: jest.fn(),
+}));
+
+jest.mock("../hooks/useInstanceName", () => ({
+  useInstanceName: () => "Mobile instance",
+}));
+
+describe("useTrustchainSdk", () => {
+  it("publishes the environment captured by the Trustchain SDK", () => {
+    const sdk = {} as ReturnType<typeof getSdk>;
+    jest.mocked(getSdk).mockReturnValue(sdk);
+
+    const { result, store } = renderHook(() => useTrustchainSdk(), {
+      overrideInitialState: withFlagOverrides({
+        llmWalletSync: {
+          enabled: true,
+          params: {
+            environment: "STAGING",
+            watchConfig: {},
+            learnMoreLink: "",
+          },
+        },
+      }),
+    });
+
+    expect(result.current).toBe(sdk);
+    expect(jest.mocked(getSdk)).toHaveBeenCalledWith(
+      expect.any(Boolean),
+      expect.not.objectContaining({ environment: expect.anything() }),
+      expect.any(Function),
+    );
+    expect(store.getState().authEnvironment).toBe("STAGING");
+    expect(getSdk).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useTrustchainSdk.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useTrustchainSdk.ts
@@ -1,17 +1,21 @@
-import { useMemo } from "react";
+import { useLayoutEffect, useMemo } from "react";
 import { getEnv } from "@shared/env";
+import { authEnvironmentSelector, setAuthEnvironment, type AuthEnvironment } from "@shared/auth";
 import { getSdk } from "@ledgerhq/ledger-key-ring-protocol/index";
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
 import { TrustchainSDK } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { useFeature } from "@features/platform-feature-flags";
 import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/getEnvironmentParams";
+import { useStore } from "~/context/hooks";
 import { useInstanceName } from "./useInstanceName";
 
 let sdkInstance: TrustchainSDK | null = null;
+let instanceEnvironment: AuthEnvironment | null = null;
 
 export function useTrustchainSdk() {
   const featureWalletSync = useFeature("llmWalletSync");
-  const environment = featureWalletSync?.params?.environment;
+  const environment: AuthEnvironment =
+    featureWalletSync?.params?.environment === "STAGING" ? "STAGING" : "PROD";
   const { trustchainApiBaseUrl } = getWalletSyncEnvironmentParams(environment);
   const isMockEnv = !!getEnv("MOCK");
   const instanceName = useInstanceName();
@@ -23,8 +27,16 @@ export function useTrustchainSdk() {
     return { applicationId, name, apiBaseUrl: trustchainApiBaseUrl };
   }, [trustchainApiBaseUrl, instanceName]);
 
+  const store = useStore();
+
+  useLayoutEffect(() => {
+    if (authEnvironmentSelector(store.getState()) || !instanceEnvironment) return;
+    store.dispatch(setAuthEnvironment(instanceEnvironment));
+  }, [store]);
+
   if (sdkInstance === null) {
     sdkInstance = getSdk(isMockEnv, defaultContext, withDevice);
+    instanceEnvironment = environment;
   }
 
   return sdkInstance;

--- a/apps/ledger-live-mobile/src/reducers/index.ts
+++ b/apps/ledger-live-mobile/src/reducers/index.ts
@@ -41,6 +41,7 @@ import portfolioRefresh from "./portfolioRefresh";
 import portfolioBalanceDisplay from "./portfolioBalanceDisplay";
 import recoverState from "./recoverState";
 import liveAppModal from "./liveAppModal";
+import { authEnvironmentReducer } from "@shared/auth";
 import { identitiesSlice } from "@domain/entity-client-identity";
 import { supportedFiatsSlice } from "@domain/entity-currency-fiat";
 import { payCardSlice } from "@domain/entity-pay-card";
@@ -66,6 +67,7 @@ const appReducer = combineReducers({
   identities: identitiesSlice.reducer,
   inView,
   knownDevices,
+  authEnvironment: authEnvironmentReducer,
   largeMover,
   market,
   marketListConfig: marketListConfigReducer,

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -22,7 +22,8 @@ import {
 import { ProtectStateNumberEnum } from "../components/ServicesWidget/types";
 import { ImageType } from "../components/CustomImage/types";
 import { WalletState } from "@ledgerhq/live-wallet/store";
-import { TrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
+import type { AuthEnvironmentState } from "@shared/auth";
+import type { TrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { Steps } from "LLM/features/WalletSync/types/Activation";
 import { type TabListType as TabPortfolioAssetsType } from "~/screens/Portfolio/TabSection";
 import type { BorrowState } from "./borrow";
@@ -458,6 +459,7 @@ export type State = LLMRTKApiState & {
   identities: IdentitiesState;
   inView: InViewState;
   knownDevices: KnownDevicesState;
+  authEnvironment: AuthEnvironmentState;
   largeScreenUpsellModal: LargeScreenUpsellModalState;
   largeMover: LargeMoverState;
   market: MarketState;

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.test.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.test.ts
@@ -6,6 +6,7 @@ import { importTrustchainStoreState } from "@ledgerhq/ledger-key-ring-protocol/s
 import { CHALLENGE } from "@ledgerhq/ledger-key-ring-protocol/__mocks__/challenge";
 import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { liveAuthentication } from "@ledgerhq/ledger-key-ring-protocol/utils";
+import { setOverride } from "@shared/feature-flags";
 
 let expoCrypto: typeof import("expo-crypto");
 
@@ -109,6 +110,29 @@ describe("mobile store", () => {
       server.close();
     });
 
+    it("should keep AuthSDK undefined when ledger auth is disabled by default", async () => {
+      const { store } = require("./configureStore");
+
+      await dispatchThunk(store, async (_dispatch, _getState, extra) => {
+        expect(extra.authSDK).toBeUndefined();
+      });
+    });
+
+    it("should clear AuthSDK when ledger auth is disabled at runtime", async () => {
+      const { store } = require("./configureStore");
+      store.dispatch(setOverride({ key: "lwmAuth", value: { enabled: true } }));
+
+      await dispatchThunk(store, async (_dispatch, _getState, extra) => {
+        expect(extra.authSDK).toBeDefined();
+      });
+
+      store.dispatch(setOverride({ key: "lwmAuth", value: { enabled: false } }));
+
+      await dispatchThunk(store, async (_dispatch, _getState, extra) => {
+        expect(extra.authSDK).toBeUndefined();
+      });
+    });
+
     it("should authenticate with attestation when trustchain store has a root id", async () => {
       endpoints.keycloakAuth.mockImplementation(() =>
         HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
@@ -122,6 +146,7 @@ describe("mobile store", () => {
       );
 
       const { store } = require("./configureStore");
+      store.dispatch(setOverride({ key: "lwmAuth", value: { enabled: true } }));
       store.dispatch(
         importTrustchainStoreState({
           trustchain: {
@@ -185,6 +210,7 @@ describe("mobile store", () => {
       );
 
       const { store } = require("./configureStore");
+      store.dispatch(setOverride({ key: "lwmAuth", value: { enabled: true } }));
       store.dispatch(
         importTrustchainStoreState({
           trustchain: null,

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.test.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.test.ts
@@ -8,8 +8,6 @@ import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types
 import { liveAuthentication } from "@ledgerhq/ledger-key-ring-protocol/utils";
 import { setOverride } from "@shared/feature-flags";
 
-let expoCrypto: typeof import("expo-crypto");
-
 jest.mock("@react-native-community/netinfo", () => ({
   addEventListener: jest.fn(() => jest.fn()),
 }));
@@ -69,8 +67,6 @@ describe("mobile store", () => {
 
     const LKRP_TOKEN = makeJwt({ sub: "idp", exp: 4102444800 });
     const KEYCLOAK_JWT = makeJwt({ sub: "keycloak", exp: 4102444800 });
-    const PKCE_CODE_VERIFIER = "A".repeat(43);
-    const PKCE_CODE_CHALLENGE = "Y29kZS1jaGFsbGVuZ2U";
 
     const queryFn = jest.fn(() => Promise.resolve());
 
@@ -111,8 +107,6 @@ describe("mobile store", () => {
       setEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL_STAGING", STAGING_KEYCLOAK_BASE_URL);
       setEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL_PROD", PROD_KEYCLOAK_BASE_URL);
       setEnv("LEDGER_AUTH_KEYCLOAK_REALM", AUTH_CONFIG.keycloakRealm);
-      // Keep PKCE assertions on the same post-reset mock instance used by configureStore.
-      expoCrypto = require("expo-crypto") as typeof import("expo-crypto");
     });
 
     afterAll(() => {
@@ -229,21 +223,6 @@ describe("mobile store", () => {
           request.url.startsWith(AUTH_CONFIG.keycloakBaseUrl),
         ),
       ).toBe(true);
-
-      expect(expoCrypto.getRandomBytesAsync).toHaveBeenCalledWith(32);
-      expect(expoCrypto.digestStringAsync).toHaveBeenCalledWith(
-        expoCrypto.CryptoDigestAlgorithm.SHA256,
-        PKCE_CODE_VERIFIER,
-        { encoding: expoCrypto.CryptoEncoding.BASE64 },
-      );
-
-      const keycloakRequest = endpoints.prodKeycloakAuth.mock.calls[0][0].request;
-      expect(new URL(keycloakRequest.url).searchParams.get("code_challenge")).toBe(
-        PKCE_CODE_CHALLENGE,
-      );
-      const tokenRequest = endpoints.lkrpToken.mock.calls[0][0].request;
-      const tokenRequestBody = new URLSearchParams(await tokenRequest.text());
-      expect(tokenRequestBody.get("code_verifier")).toBe(PKCE_CODE_VERIFIER);
 
       const challengeRequest = await endpoints.lkrpAuth.mock.calls.at(-1)?.[0].request.json();
       expect(challengeRequest).toEqual(

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.test.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.test.ts
@@ -1,0 +1,236 @@
+import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import type { AuthSDK } from "@ledgerhq/ledger-auth";
+import { importTrustchainStoreState } from "@ledgerhq/ledger-key-ring-protocol/store";
+import { CHALLENGE } from "@ledgerhq/ledger-key-ring-protocol/__mocks__/challenge";
+import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
+import { liveAuthentication } from "@ledgerhq/ledger-key-ring-protocol/utils";
+
+let expoCrypto: typeof import("expo-crypto");
+
+jest.mock("@react-native-community/netinfo", () => ({
+  addEventListener: jest.fn(() => jest.fn()),
+}));
+
+jest.mock("@rozenite/redux-devtools-plugin", () => ({
+  rozeniteDevToolsEnhancer: jest.fn(() => (next: (...args: unknown[]) => unknown) => {
+    return (...args: unknown[]) => next(...args);
+  }),
+}));
+
+jest.mock("~/config/bridge-setup", () => ({
+  setupCryptoAssetsStore: jest.fn(),
+}));
+
+jest.mock("LLM/storage/recentAddresses", () => ({
+  setupRecentAddressesStore: jest.fn(),
+}));
+
+jest.mock(
+  "@ledgerhq/live-engagement/largeScreenUpsellModal",
+  () => ({
+    largeScreenUpsellModalReducer: (state = {}) => state,
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  "@ledgerhq/live-dmk-mobile",
+  () => ({
+    findMatchingOldDevice: jest.fn(() => null),
+  }),
+  { virtual: true },
+);
+
+jest.mock("~/firebase/remoteConfig", () => ({
+  fetchRemoteFlags: jest.fn(() => Promise.resolve({})),
+}));
+
+describe("mobile store", () => {
+  describe("AuthSDK flow", () => {
+    const AUTH_CONFIG = {
+      clientId: "ledger-keycloak",
+      keycloakBaseUrl: "http://keycloak.test",
+      keycloakRealm: "ledger-bc-customers",
+    };
+
+    const MEMBER_CREDENTIALS: MemberCredentials = {
+      pubkey: "02e3311a12c450604725f02d1a775ef5cdb4a1b832eb41ac6b1302adbe92a612fc",
+      privatekey: "873f500bd20783224f7e78d4f8cce3d2bf69eb8008fbd697d20bbea31a721a03",
+    };
+
+    const TRUSTCHAIN_ID = "ROOTID";
+    const ATTESTATION = crypto.to_hex(liveAuthentication(TRUSTCHAIN_ID));
+
+    const LKRP_TOKEN = makeJwt({ sub: "idp", exp: 4102444800 });
+    const KEYCLOAK_JWT = makeJwt({ sub: "keycloak", exp: 4102444800 });
+    const PKCE_CODE_VERIFIER = "A".repeat(43);
+    const PKCE_CODE_CHALLENGE = "Y29kZS1jaGFsbGVuZ2U";
+
+    const queryFn = jest.fn(() => Promise.resolve());
+
+    const endpoints = {
+      keycloakAuth: jest.fn<Response, [{ request: Request }]>(),
+      lkrpAuth: jest.fn<Response, [{ request: Request }]>(),
+      lkrpToken: jest.fn<Response, [{ request: Request }]>(),
+      tokenExchange: jest.fn<Response, [{ request: Request }]>(),
+    };
+    const server = setupServer(
+      http.get(
+        `${AUTH_CONFIG.keycloakBaseUrl}/realms/${AUTH_CONFIG.keycloakRealm}/protocol/openid-connect/auth`,
+        endpoints.keycloakAuth,
+      ),
+      http.post(`https://${CHALLENGE.json.host}/openid/v1/authenticate`, endpoints.lkrpAuth),
+      http.post(`https://${CHALLENGE.json.host}/openid/v1/token`, endpoints.lkrpToken),
+      http.post(`https://${CHALLENGE.json.host}/openid/v1/exchange`, endpoints.tokenExchange),
+    );
+
+    beforeAll(() => {
+      server.listen({ onUnhandledRequest: "error" });
+    });
+
+    beforeEach(() => {
+      jest.resetModules();
+      jest.clearAllMocks();
+      server.resetHandlers();
+
+      // Use the post-reset instance so configureStore reads these environment values.
+      const { setEnv } = require("@ledgerhq/live-env") as typeof import("@ledgerhq/live-env");
+      setEnv("LEDGER_CLIENT_VERSION", "jest");
+      setEnv("LEDGER_AUTH_CLIENT_ID", AUTH_CONFIG.clientId);
+      setEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL", AUTH_CONFIG.keycloakBaseUrl);
+      setEnv("LEDGER_AUTH_KEYCLOAK_REALM", AUTH_CONFIG.keycloakRealm);
+      // Keep PKCE assertions on the same post-reset mock instance used by configureStore.
+      expoCrypto = require("expo-crypto") as typeof import("expo-crypto");
+    });
+
+    afterAll(() => {
+      server.close();
+    });
+
+    it("should authenticate with attestation when trustchain store has a root id", async () => {
+      endpoints.keycloakAuth.mockImplementation(() =>
+        HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
+      );
+      endpoints.lkrpAuth.mockImplementation(() => HttpResponse.json("auth-code-xyz"));
+      endpoints.lkrpToken.mockImplementation(() =>
+        HttpResponse.json({ access_token: LKRP_TOKEN, token_type: "Bearer" }),
+      );
+      endpoints.tokenExchange.mockImplementation(() =>
+        HttpResponse.json({ access_token: KEYCLOAK_JWT, token_type: "Bearer" }),
+      );
+
+      const { store } = require("./configureStore");
+      store.dispatch(
+        importTrustchainStoreState({
+          trustchain: {
+            rootId: TRUSTCHAIN_ID,
+            walletSyncEncryptionKey: "wallet-sync-encryption-key",
+            applicationPath: "m/0'/16'/0'",
+          },
+          memberCredentials: MEMBER_CREDENTIALS,
+        }),
+      );
+
+      await dispatchThunk(store, async (_dispatch, _getState, extra) =>
+        extra.authSDK?.withToken({
+          queryFn,
+          refreshAndRetryWhen: () => true,
+        }),
+      );
+
+      expect(queryFn).toHaveBeenCalledWith(
+        expect.objectContaining({ accessToken: KEYCLOAK_JWT, tokenType: "Bearer" }),
+      );
+
+      expect(expoCrypto.getRandomBytesAsync).toHaveBeenCalledWith(32);
+      expect(expoCrypto.digestStringAsync).toHaveBeenCalledWith(
+        expoCrypto.CryptoDigestAlgorithm.SHA256,
+        PKCE_CODE_VERIFIER,
+        { encoding: expoCrypto.CryptoEncoding.BASE64 },
+      );
+
+      const keycloakRequest = endpoints.keycloakAuth.mock.calls[0][0].request;
+      expect(new URL(keycloakRequest.url).searchParams.get("code_challenge")).toBe(
+        PKCE_CODE_CHALLENGE,
+      );
+      const tokenRequest = endpoints.lkrpToken.mock.calls[0][0].request;
+      const tokenRequestBody = new URLSearchParams(await tokenRequest.text());
+      expect(tokenRequestBody.get("code_verifier")).toBe(PKCE_CODE_VERIFIER);
+
+      const challengeRequest = await endpoints.lkrpAuth.mock.calls.at(-1)?.[0].request.json();
+      expect(challengeRequest).toEqual(
+        expect.objectContaining({
+          signature: expect.objectContaining({
+            credential: expect.objectContaining({
+              publicKey: MEMBER_CREDENTIALS.pubkey,
+            }),
+            attestation: ATTESTATION,
+          }),
+        }),
+      );
+    });
+
+    it("should authenticate without attestation when trustchain store only has credentials", async () => {
+      endpoints.keycloakAuth.mockImplementation(() =>
+        HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
+      );
+      endpoints.lkrpAuth.mockImplementation(() => HttpResponse.json("auth-code-xyz"));
+      endpoints.lkrpToken.mockImplementation(() =>
+        HttpResponse.json({ access_token: LKRP_TOKEN, token_type: "Bearer" }),
+      );
+      endpoints.tokenExchange.mockImplementation(() =>
+        HttpResponse.json({ access_token: KEYCLOAK_JWT, token_type: "Bearer" }),
+      );
+
+      const { store } = require("./configureStore");
+      store.dispatch(
+        importTrustchainStoreState({
+          trustchain: null,
+          memberCredentials: MEMBER_CREDENTIALS,
+        }),
+      );
+
+      await dispatchThunk(store, async (_dispatch, _getState, extra) =>
+        extra.authSDK?.withToken({
+          queryFn,
+          refreshAndRetryWhen: () => true,
+        }),
+      );
+
+      expect(queryFn).toHaveBeenCalledWith(
+        expect.objectContaining({ accessToken: KEYCLOAK_JWT, tokenType: "Bearer" }),
+      );
+
+      const challengeRequest = await endpoints.lkrpAuth.mock.calls.at(-1)?.[0].request.json();
+      expect(challengeRequest).toEqual(
+        expect.objectContaining({
+          signature: expect.objectContaining({
+            credential: expect.objectContaining({
+              publicKey: MEMBER_CREDENTIALS.pubkey,
+            }),
+          }),
+        }),
+      );
+      expect(challengeRequest.signature).not.toHaveProperty("attestation");
+    });
+  });
+});
+
+type AuthThunk = (
+  dispatch: unknown,
+  getState: unknown,
+  extra: { authSDK?: AuthSDK },
+) => Promise<unknown>;
+type DispatchThunk = (thunk: AuthThunk) => Promise<unknown>;
+function dispatchThunk(store: unknown, thunk: AuthThunk): Promise<unknown> {
+  const dispatch = (store as { dispatch: unknown }).dispatch as DispatchThunk;
+  return dispatch(thunk);
+}
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const prefix = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${prefix}.${body}.signature`;
+}

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.test.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.test.ts
@@ -1,7 +1,7 @@
 import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
-import type { AuthSDK } from "@ledgerhq/ledger-auth";
+import { setAuthEnvironment, type AuthProvider } from "@shared/auth";
 import { importTrustchainStoreState } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { CHALLENGE } from "@ledgerhq/ledger-key-ring-protocol/__mocks__/challenge";
 import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
@@ -49,10 +49,13 @@ jest.mock("~/firebase/remoteConfig", () => ({
 }));
 
 describe("mobile store", () => {
-  describe("AuthSDK flow", () => {
+  describe("auth provider flow", () => {
+    const PROD_KEYCLOAK_BASE_URL = "http://keycloak-prod.test";
+    const STAGING_KEYCLOAK_BASE_URL = "http://keycloak-staging.test";
+
     const AUTH_CONFIG = {
       clientId: "ledger-keycloak",
-      keycloakBaseUrl: "http://keycloak.test",
+      keycloakBaseUrl: PROD_KEYCLOAK_BASE_URL,
       keycloakRealm: "ledger-bc-customers",
     };
 
@@ -72,15 +75,20 @@ describe("mobile store", () => {
     const queryFn = jest.fn(() => Promise.resolve());
 
     const endpoints = {
-      keycloakAuth: jest.fn<Response, [{ request: Request }]>(),
+      prodKeycloakAuth: jest.fn<Response, [{ request: Request }]>(),
+      stagingKeycloakAuth: jest.fn<Response, [{ request: Request }]>(),
       lkrpAuth: jest.fn<Response, [{ request: Request }]>(),
       lkrpToken: jest.fn<Response, [{ request: Request }]>(),
       tokenExchange: jest.fn<Response, [{ request: Request }]>(),
     };
     const server = setupServer(
       http.get(
-        `${AUTH_CONFIG.keycloakBaseUrl}/realms/${AUTH_CONFIG.keycloakRealm}/protocol/openid-connect/auth`,
-        endpoints.keycloakAuth,
+        `${PROD_KEYCLOAK_BASE_URL}/realms/${AUTH_CONFIG.keycloakRealm}/protocol/openid-connect/auth`,
+        endpoints.prodKeycloakAuth,
+      ),
+      http.get(
+        `${STAGING_KEYCLOAK_BASE_URL}/realms/${AUTH_CONFIG.keycloakRealm}/protocol/openid-connect/auth`,
+        endpoints.stagingKeycloakAuth,
       ),
       http.post(`https://${CHALLENGE.json.host}/openid/v1/authenticate`, endpoints.lkrpAuth),
       http.post(`https://${CHALLENGE.json.host}/openid/v1/token`, endpoints.lkrpToken),
@@ -97,10 +105,11 @@ describe("mobile store", () => {
       server.resetHandlers();
 
       // Use the post-reset instance so configureStore reads these environment values.
-      const { setEnv } = require("@ledgerhq/live-env") as typeof import("@ledgerhq/live-env");
+      const { setEnv } = require("@shared/env") as typeof import("@shared/env");
       setEnv("LEDGER_CLIENT_VERSION", "jest");
       setEnv("LEDGER_AUTH_CLIENT_ID", AUTH_CONFIG.clientId);
-      setEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL", AUTH_CONFIG.keycloakBaseUrl);
+      setEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL_STAGING", STAGING_KEYCLOAK_BASE_URL);
+      setEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL_PROD", PROD_KEYCLOAK_BASE_URL);
       setEnv("LEDGER_AUTH_KEYCLOAK_REALM", AUTH_CONFIG.keycloakRealm);
       // Keep PKCE assertions on the same post-reset mock instance used by configureStore.
       expoCrypto = require("expo-crypto") as typeof import("expo-crypto");
@@ -110,31 +119,45 @@ describe("mobile store", () => {
       server.close();
     });
 
-    it("should keep AuthSDK undefined when ledger auth is disabled by default", async () => {
+    it("should execute without a token when ledger auth is disabled by default", async () => {
       const { store } = require("./configureStore");
 
-      await dispatchThunk(store, async (_dispatch, _getState, extra) => {
-        expect(extra.authSDK).toBeUndefined();
-      });
+      await dispatchThunk(store, (_dispatch, _getState, extra) =>
+        extra.authProvider.withToken({ queryFn }),
+      );
+
+      expect(queryFn).toHaveBeenCalledWith();
+      expect(endpoints.prodKeycloakAuth).not.toHaveBeenCalled();
+      expect(endpoints.stagingKeycloakAuth).not.toHaveBeenCalled();
     });
 
-    it("should clear AuthSDK when ledger auth is disabled at runtime", async () => {
+    it("should keep a stable auth provider facade when ledger auth is disabled at runtime", async () => {
       const { store } = require("./configureStore");
-      store.dispatch(setOverride({ key: "lwmAuth", value: { enabled: true } }));
+      let injectedAuthProvider: AuthProvider | undefined;
 
       await dispatchThunk(store, async (_dispatch, _getState, extra) => {
-        expect(extra.authSDK).toBeDefined();
+        injectedAuthProvider = extra.authProvider;
+      });
+
+      store.dispatch(setOverride({ key: "lwmAuth", value: { enabled: true } }));
+      store.dispatch(setAuthEnvironment("PROD"));
+
+      await dispatchThunk(store, async (_dispatch, _getState, extra) => {
+        expect(extra.authProvider).toBe(injectedAuthProvider);
       });
 
       store.dispatch(setOverride({ key: "lwmAuth", value: { enabled: false } }));
 
-      await dispatchThunk(store, async (_dispatch, _getState, extra) => {
-        expect(extra.authSDK).toBeUndefined();
-      });
+      await dispatchThunk(store, (_dispatch, _getState, extra) =>
+        extra.authProvider.withToken({ queryFn }),
+      );
+
+      expect(queryFn).toHaveBeenCalledWith();
+      expect(endpoints.prodKeycloakAuth).not.toHaveBeenCalled();
     });
 
-    it("should authenticate with attestation when trustchain store has a root id", async () => {
-      endpoints.keycloakAuth.mockImplementation(() =>
+    it("should use the staging Keycloak URL for a staging Trustchain SDK", async () => {
+      endpoints.stagingKeycloakAuth.mockImplementation(() =>
         HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
       );
       endpoints.lkrpAuth.mockImplementation(() => HttpResponse.json("auth-code-xyz"));
@@ -146,6 +169,39 @@ describe("mobile store", () => {
       );
 
       const { store } = require("./configureStore");
+      store.dispatch(setAuthEnvironment("STAGING"));
+      store.dispatch(setOverride({ key: "lwmAuth", value: { enabled: true } }));
+      store.dispatch(
+        importTrustchainStoreState({
+          trustchain: null,
+          memberCredentials: MEMBER_CREDENTIALS,
+        }),
+      );
+
+      await dispatchThunk(store, async (_dispatch, _getState, extra) =>
+        extra.authProvider.withToken({
+          queryFn,
+          refreshAndRetryWhen: () => true,
+        }),
+      );
+
+      expect(endpoints.stagingKeycloakAuth).toHaveBeenCalled();
+    });
+
+    it("should authenticate with attestation when trustchain store has a root id", async () => {
+      endpoints.prodKeycloakAuth.mockImplementation(() =>
+        HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
+      );
+      endpoints.lkrpAuth.mockImplementation(() => HttpResponse.json("auth-code-xyz"));
+      endpoints.lkrpToken.mockImplementation(() =>
+        HttpResponse.json({ access_token: LKRP_TOKEN, token_type: "Bearer" }),
+      );
+      endpoints.tokenExchange.mockImplementation(() =>
+        HttpResponse.json({ access_token: KEYCLOAK_JWT, token_type: "Bearer" }),
+      );
+
+      const { store } = require("./configureStore");
+      store.dispatch(setAuthEnvironment("PROD"));
       store.dispatch(setOverride({ key: "lwmAuth", value: { enabled: true } }));
       store.dispatch(
         importTrustchainStoreState({
@@ -159,7 +215,7 @@ describe("mobile store", () => {
       );
 
       await dispatchThunk(store, async (_dispatch, _getState, extra) =>
-        extra.authSDK?.withToken({
+        extra.authProvider.withToken({
           queryFn,
           refreshAndRetryWhen: () => true,
         }),
@@ -168,6 +224,11 @@ describe("mobile store", () => {
       expect(queryFn).toHaveBeenCalledWith(
         expect.objectContaining({ accessToken: KEYCLOAK_JWT, tokenType: "Bearer" }),
       );
+      expect(
+        endpoints.prodKeycloakAuth.mock.calls.every(([{ request }]) =>
+          request.url.startsWith(AUTH_CONFIG.keycloakBaseUrl),
+        ),
+      ).toBe(true);
 
       expect(expoCrypto.getRandomBytesAsync).toHaveBeenCalledWith(32);
       expect(expoCrypto.digestStringAsync).toHaveBeenCalledWith(
@@ -176,7 +237,7 @@ describe("mobile store", () => {
         { encoding: expoCrypto.CryptoEncoding.BASE64 },
       );
 
-      const keycloakRequest = endpoints.keycloakAuth.mock.calls[0][0].request;
+      const keycloakRequest = endpoints.prodKeycloakAuth.mock.calls[0][0].request;
       expect(new URL(keycloakRequest.url).searchParams.get("code_challenge")).toBe(
         PKCE_CODE_CHALLENGE,
       );
@@ -198,7 +259,7 @@ describe("mobile store", () => {
     });
 
     it("should authenticate without attestation when trustchain store only has credentials", async () => {
-      endpoints.keycloakAuth.mockImplementation(() =>
+      endpoints.prodKeycloakAuth.mockImplementation(() =>
         HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
       );
       endpoints.lkrpAuth.mockImplementation(() => HttpResponse.json("auth-code-xyz"));
@@ -210,6 +271,7 @@ describe("mobile store", () => {
       );
 
       const { store } = require("./configureStore");
+      store.dispatch(setAuthEnvironment("PROD"));
       store.dispatch(setOverride({ key: "lwmAuth", value: { enabled: true } }));
       store.dispatch(
         importTrustchainStoreState({
@@ -219,7 +281,7 @@ describe("mobile store", () => {
       );
 
       await dispatchThunk(store, async (_dispatch, _getState, extra) =>
-        extra.authSDK?.withToken({
+        extra.authProvider.withToken({
           queryFn,
           refreshAndRetryWhen: () => true,
         }),
@@ -247,7 +309,7 @@ describe("mobile store", () => {
 type AuthThunk = (
   dispatch: unknown,
   getState: unknown,
-  extra: { authSDK?: AuthSDK },
+  extra: { authProvider: AuthProvider },
 ) => Promise<unknown>;
 type DispatchThunk = (thunk: AuthThunk) => Promise<unknown>;
 function dispatchThunk(store: unknown, thunk: AuthThunk): Promise<unknown> {

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.ts
@@ -75,6 +75,7 @@ export const store = configureStore({
                     clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
                     keycloakBaseUrl: getEnv(`LEDGER_AUTH_KEYCLOAK_BASE_URL_${environment}`),
                     keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
+                    disablePkce: true,
                   },
                   { provider: identityProvider, createPkcePair: createPkcePairWithExpoCrypto },
                 ),

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.ts
@@ -1,9 +1,12 @@
 import Config from "react-native-config";
-import { configureStore, StoreEnhancer } from "@reduxjs/toolkit";
+import { configureStore, createListenerMiddleware, StoreEnhancer } from "@reduxjs/toolkit";
 import { setupListeners } from "@reduxjs/toolkit/query";
 import NetInfo from "@react-native-community/netinfo";
 import { Platform } from "react-native";
 import VersionNumber from "react-native-version-number";
+import { AuthSDK } from "@ledgerhq/ledger-auth";
+import { LkrpIdentityProvider } from "@ledgerhq/ledger-key-ring-protocol";
+import { trustchainStoreActionTypePrefix } from "@ledgerhq/ledger-key-ring-protocol/store";
 import reducers from "~/reducers";
 import { rebootMiddleware } from "~/middleware/rebootMiddleware";
 import { rozeniteDevToolsEnhancer } from "@rozenite/redux-devtools-plugin";
@@ -11,6 +14,7 @@ import { applyLlmRTKApiMiddlewares } from "~/context/rtkQueryApi";
 import { setupCryptoAssetsStore } from "~/config/bridge-setup";
 import { setupRecentAddressesStore } from "LLM/storage/recentAddresses";
 import { createIdentitiesSyncMiddleware, pushDevicesApiExtra } from "@domain/api-push-devices";
+import { createPkcePairWithExpoCrypto } from "~/helpers/pkce";
 import { State } from "~/reducers/types";
 import { canPushDeviceIdsSelector, languageSelector } from "~/reducers/settings";
 import { getEnv } from "@shared/env";
@@ -21,6 +25,16 @@ import { altcoinsSentimentApiExtra } from "@domain/api-altcoins-sentiment";
 import { payCardApiExtra } from "@domain/api-pay-card";
 import { createFeatureFlagsMiddleware, type PartialFeatures } from "@shared/feature-flags";
 import { fetchRemoteFlags } from "~/firebase/remoteConfig";
+
+const lkrpIdentityProvider = new LkrpIdentityProvider();
+const lkrpListenerMiddleware = createListenerMiddleware();
+lkrpListenerMiddleware.startListening({
+  predicate: action => action.type.startsWith(trustchainStoreActionTypePrefix),
+  effect(_action, listenerApi) {
+    const { trustchain } = listenerApi.getState() as State;
+    lkrpIdentityProvider.setTrustchainStore(trustchain);
+  },
+});
 
 export const store = configureStore({
   reducer: reducers,
@@ -53,9 +67,20 @@ export const store = configureStore({
               // LIVE-33829: force mocks until Pay Card API base URL is wired.
               payCardApiMocksEnabled: true,
             }),
+            authSDK: new AuthSDK(
+              {
+                clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
+                keycloakBaseUrl: getEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL_PROD"),
+                keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
+              },
+              {
+                provider: lkrpIdentityProvider,
+                createPkcePair: createPkcePairWithExpoCrypto,
+              },
+            ),
           },
         },
-      }),
+      }).prepend(lkrpListenerMiddleware.middleware),
     )
       .concat(rebootMiddleware)
       .concat(

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.ts
@@ -1,12 +1,12 @@
 import Config from "react-native-config";
-import { configureStore, createListenerMiddleware, StoreEnhancer } from "@reduxjs/toolkit";
+import { configureStore, createListenerMiddleware, type StoreEnhancer } from "@reduxjs/toolkit";
 import { setupListeners } from "@reduxjs/toolkit/query";
+import { authApiExtra } from "@shared/auth";
+import { AuthSDK } from "@ledgerhq/ledger-auth";
+import { LkrpIdentityProvider } from "@ledgerhq/ledger-key-ring-protocol";
 import NetInfo from "@react-native-community/netinfo";
 import { Platform } from "react-native";
 import VersionNumber from "react-native-version-number";
-import { AuthSDK } from "@ledgerhq/ledger-auth";
-import { LkrpIdentityProvider } from "@ledgerhq/ledger-key-ring-protocol";
-import { trustchainStoreActionTypePrefix } from "@ledgerhq/ledger-key-ring-protocol/store";
 import reducers from "~/reducers";
 import { rebootMiddleware } from "~/middleware/rebootMiddleware";
 import { rozeniteDevToolsEnhancer } from "@rozenite/redux-devtools-plugin";
@@ -14,7 +14,6 @@ import { applyLlmRTKApiMiddlewares } from "~/context/rtkQueryApi";
 import { setupCryptoAssetsStore } from "~/config/bridge-setup";
 import { setupRecentAddressesStore } from "LLM/storage/recentAddresses";
 import { createIdentitiesSyncMiddleware, pushDevicesApiExtra } from "@domain/api-push-devices";
-import { createPkcePairWithExpoCrypto } from "~/helpers/pkce";
 import { State } from "~/reducers/types";
 import { canPushDeviceIdsSelector, languageSelector } from "~/reducers/settings";
 import { getEnv } from "@shared/env";
@@ -23,45 +22,13 @@ import { cvsApiExtra } from "@domain/api-currency-fiat";
 import { marketSentimentApiExtra } from "@domain/api-market-sentiment";
 import { altcoinsSentimentApiExtra } from "@domain/api-altcoins-sentiment";
 import { payCardApiExtra } from "@domain/api-pay-card";
-import {
-  createFeatureFlagsMiddleware,
-  selectFeature,
-  type PartialFeatures,
-} from "@shared/feature-flags";
+import { createFeatureFlagsMiddleware, type PartialFeatures } from "@shared/feature-flags";
 import { fetchRemoteFlags } from "~/firebase/remoteConfig";
+import { createPkcePairWithExpoCrypto } from "~/helpers/pkce";
 
-const listenerMiddleware = createListenerMiddleware();
-
-const lkrpIdentityProvider = new LkrpIdentityProvider();
-listenerMiddleware.startListening({
-  predicate: action => action.type.startsWith(trustchainStoreActionTypePrefix),
-  effect(_action, listenerApi) {
-    const { trustchain } = listenerApi.getState() as State;
-    lkrpIdentityProvider.setTrustchainStore(trustchain);
-  },
-});
-
-const authSDKRef: { current?: AuthSDK } = {};
-const authSDK = new AuthSDK(
-  {
-    clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
-    keycloakBaseUrl: getEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL_PROD"),
-    keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
-  },
-  {
-    provider: lkrpIdentityProvider,
-    createPkcePair: createPkcePairWithExpoCrypto,
-  },
-);
-const syncAuthSDK = (currentState: State) => {
-  authSDKRef.current = selectFeature(currentState, "lwmAuth").enabled ? authSDK : undefined;
-};
-listenerMiddleware.startListening({
-  predicate: action => action.type.startsWith("featureFlags/"),
-  effect(_action, listenerApi) {
-    syncAuthSDK(listenerApi.getState() as State);
-  },
-});
+// This listenerMiddleware is cross-scope as it is preferable to have one instance per store
+// Source: https://github.com/reduxjs/redux-toolkit/discussions/3665
+const listenerMiddleware = createListenerMiddleware<State>();
 
 export const store = configureStore({
   reducer: reducers,
@@ -94,9 +61,24 @@ export const store = configureStore({
               // LIVE-33829: force mocks until Pay Card API base URL is wired.
               payCardApiMocksEnabled: true,
             }),
-            get authSDK() {
-              return authSDKRef.current;
-            },
+            ...authApiExtra({
+              authFeatureId: "lwmAuth",
+              startListening: listenerMiddleware.startListening,
+              providerParams: {
+                identityProvider: new LkrpIdentityProvider<State>({
+                  startListening: listenerMiddleware.startListening,
+                }),
+              },
+              createAuthProvider: (environment, { identityProvider }) =>
+                new AuthSDK(
+                  {
+                    clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
+                    keycloakBaseUrl: getEnv(`LEDGER_AUTH_KEYCLOAK_BASE_URL_${environment}`),
+                    keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
+                  },
+                  { provider: identityProvider, createPkcePair: createPkcePairWithExpoCrypto },
+                ),
+            }),
           },
         },
       }).prepend(listenerMiddleware.middleware),
@@ -128,8 +110,6 @@ export const store = configureStore({
     return enhancers.concat(rozeniteDevToolsEnhancer() as StoreEnhancer);
   },
 });
-
-syncAuthSDK(store.getState());
 
 export type StoreType = typeof store;
 export type AppDispatch = typeof store.dispatch;

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.ts
@@ -23,16 +23,43 @@ import { cvsApiExtra } from "@domain/api-currency-fiat";
 import { marketSentimentApiExtra } from "@domain/api-market-sentiment";
 import { altcoinsSentimentApiExtra } from "@domain/api-altcoins-sentiment";
 import { payCardApiExtra } from "@domain/api-pay-card";
-import { createFeatureFlagsMiddleware, type PartialFeatures } from "@shared/feature-flags";
+import {
+  createFeatureFlagsMiddleware,
+  selectFeature,
+  type PartialFeatures,
+} from "@shared/feature-flags";
 import { fetchRemoteFlags } from "~/firebase/remoteConfig";
 
+const listenerMiddleware = createListenerMiddleware();
+
 const lkrpIdentityProvider = new LkrpIdentityProvider();
-const lkrpListenerMiddleware = createListenerMiddleware();
-lkrpListenerMiddleware.startListening({
+listenerMiddleware.startListening({
   predicate: action => action.type.startsWith(trustchainStoreActionTypePrefix),
   effect(_action, listenerApi) {
     const { trustchain } = listenerApi.getState() as State;
     lkrpIdentityProvider.setTrustchainStore(trustchain);
+  },
+});
+
+const authSDKRef: { current?: AuthSDK } = {};
+const authSDK = new AuthSDK(
+  {
+    clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
+    keycloakBaseUrl: getEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL_PROD"),
+    keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
+  },
+  {
+    provider: lkrpIdentityProvider,
+    createPkcePair: createPkcePairWithExpoCrypto,
+  },
+);
+const syncAuthSDK = (currentState: State) => {
+  authSDKRef.current = selectFeature(currentState, "lwmAuth").enabled ? authSDK : undefined;
+};
+listenerMiddleware.startListening({
+  predicate: action => action.type.startsWith("featureFlags/"),
+  effect(_action, listenerApi) {
+    syncAuthSDK(listenerApi.getState() as State);
   },
 });
 
@@ -67,20 +94,12 @@ export const store = configureStore({
               // LIVE-33829: force mocks until Pay Card API base URL is wired.
               payCardApiMocksEnabled: true,
             }),
-            authSDK: new AuthSDK(
-              {
-                clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
-                keycloakBaseUrl: getEnv("LEDGER_AUTH_KEYCLOAK_BASE_URL_PROD"),
-                keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
-              },
-              {
-                provider: lkrpIdentityProvider,
-                createPkcePair: createPkcePairWithExpoCrypto,
-              },
-            ),
+            get authSDK() {
+              return authSDKRef.current;
+            },
           },
         },
-      }).prepend(lkrpListenerMiddleware.middleware),
+      }).prepend(listenerMiddleware.middleware),
     )
       .concat(rebootMiddleware)
       .concat(
@@ -109,6 +128,8 @@ export const store = configureStore({
     return enhancers.concat(rozeniteDevToolsEnhancer() as StoreEnhancer);
   },
 });
+
+syncAuthSDK(store.getState());
 
 export type StoreType = typeof store;
 export type AppDispatch = typeof store.dispatch;

--- a/docs/services.md
+++ b/docs/services.md
@@ -116,6 +116,7 @@ Inside the Internal and Third-party tables, rows are grouped by **owning team** 
 | NFT metadata | `nft.api.live.ledger.com` | [env](/libs/env/src/env.ts) | prod |
 | Wallet icons / avatars CDN | `lw-icons.ledger.com` | [env](/libs/env/src/env.ts) | prod |
 | Sanctioned addresses (compliance) | `compliance.ledger.com` | [env](/libs/env/src/env.ts) | prod |
+| Ledger API authentication (Keycloak) | `keycloak.api.live.aws.stg.ldg-tech.com`<br>_⚠️ only staging found; prod in progress   | [env](/libs/env/src/env.ts) | staging |
 | Ledger Button tracking | `ledgerb.api.ledger.com` | [code](/libs/ledger-live-common/src/wallet-api/utils/ledgerButtonTracking.ts) | prod |
 | **Live Devices** | | | |
 | Manager API | `manager.api.live.ledger.com` | [env](/libs/env/src/env.ts) | prod |

--- a/docs/services.md
+++ b/docs/services.md
@@ -116,7 +116,7 @@ Inside the Internal and Third-party tables, rows are grouped by **owning team** 
 | NFT metadata | `nft.api.live.ledger.com` | [env](/libs/env/src/env.ts) | prod |
 | Wallet icons / avatars CDN | `lw-icons.ledger.com` | [env](/libs/env/src/env.ts) | prod |
 | Sanctioned addresses (compliance) | `compliance.ledger.com` | [env](/libs/env/src/env.ts) | prod |
-| Ledger API authentication (Keycloak) | `keycloak.api.live.aws.stg.ldg-tech.com`<br>_⚠️ only staging found; prod in progress   | [env](/libs/env/src/env.ts) | staging |
+| Ledger API authentication (Keycloak) | `global.api.prd.ledger.com`<br>path: `/keycloak`; staging: `keycloak.api.live.aws.stg.ldg-tech.com` | [env](/shared/env/src/definitions/team-platform/index.ts) | prod / staging |
 | Ledger Button tracking | `ledgerb.api.ledger.com` | [code](/libs/ledger-live-common/src/wallet-api/utils/ledgerButtonTracking.ts) | prod |
 | **Live Devices** | | | |
 | Manager API | `manager.api.live.ledger.com` | [env](/libs/env/src/env.ts) | prod |

--- a/knip.json
+++ b/knip.json
@@ -216,6 +216,9 @@
     "./shared/schema-primitives": {
       "entry": ["src/index.ts"]
     },
+    "./shared/auth": {
+      "entry": ["src/index.ts"]
+    },
     "./shared/feature-flags": {
       "entry": ["src/index.ts"]
     },

--- a/libs/ledger-auth/README.md
+++ b/libs/ledger-auth/README.md
@@ -3,7 +3,7 @@
 > [!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
-`@ledgerhq/ledger-auth` provides authentication helpers for Ledger Live apps to authenticate users against Ledger's Keycloak-based OAuth2/OIDC service. It handles the full PKCE authorization code flow, token storage, and silent token refresh, exposing a simple `AuthSDK` facade.
+`@ledgerhq/ledger-auth` provides authentication helpers for Ledger Live apps to authenticate users against Ledger's Keycloak-based OAuth2/OIDC service. It handles the full PKCE authorization code flow, token storage, and silent token refresh through the concrete `AuthSDK` implementation.
 
 ## What it does
 
@@ -14,11 +14,11 @@
 
 ## Key exports / concepts
 
-- `AuthSDK` — main class; call `.login()`, `.logout()`, `.getAccessToken()`, `.refreshToken()`
+- `AuthSDK` — main class; call `.withToken()` to run and retry an authenticated operation
 - `pkce` — PKCE code verifier/challenge utilities
 - `keycloakService` — low-level Keycloak endpoint wrappers
 - Error classes: `AuthError` and subtypes from `errors.ts`
 
 ## Usage context
 
-Used by Ledger Live Desktop and Mobile wherever a Ledger account login is required (e.g. accessing Ledger services that require authentication). Consumed via the `AuthSDK` singleton initialized at app boot.
+Ledger Live Desktop and Mobile expose a stable `AuthProvider` through their Redux thunk extra argument. That facade lazily creates and caches `AuthSDK` when authentication is enabled and its environment is known.

--- a/libs/ledger-key-ring-protocol/package.json
+++ b/libs/ledger-key-ring-protocol/package.json
@@ -65,6 +65,7 @@
     "@ledgerhq/logs": "workspace:*",
     "@ledgerhq/speculos-transport": "workspace:*",
     "@ledgerhq/types-devices": "workspace:^",
+    "@reduxjs/toolkit": "catalog:",
     "base64-js": "1",
     "isomorphic-ws": "catalog:",
     "rxjs": "catalog:",

--- a/libs/ledger-key-ring-protocol/scripts/keycloakAuth.ts
+++ b/libs/ledger-key-ring-protocol/scripts/keycloakAuth.ts
@@ -29,8 +29,10 @@ async function main(): Promise<void> {
   const provider = new LkrpIdentityProvider();
 
   const credentials = await readMemberCredentials();
-  provider.setKeypair(credentials);
-  provider.setTrustchainId(credentials.trustchainId);
+  provider.setTrustchainStore({
+    trustchain: credentials.trustchainId ? { rootId: credentials.trustchainId } : null,
+    memberCredentials: credentials,
+  });
 
   console.log("[CHECK] keycloak base url:", KEYCLOAK_BASE_URL);
   console.log("[CHECK] keycloak realm:", KEYCLOAK_REALM);

--- a/libs/ledger-key-ring-protocol/src/LKRPIdentityProvider.ts
+++ b/libs/ledger-key-ring-protocol/src/LKRPIdentityProvider.ts
@@ -12,8 +12,8 @@ import getApi, {
   LKRPChallengeSchema,
   type WeakChallengeSignature,
 } from "./api";
+import type { MemberCredentials, Trustchain } from "./types";
 import { convertLiveCredentialsToKeyPair, credentialForPubKey, liveAuthentication } from "./utils";
-import { MemberCredentials, Trustchain } from "./types";
 
 type PartialTrustchainStore = {
   trustchain: Pick<Trustchain, "rootId"> | null;

--- a/libs/ledger-key-ring-protocol/src/LKRPIdentityProvider.ts
+++ b/libs/ledger-key-ring-protocol/src/LKRPIdentityProvider.ts
@@ -12,20 +12,26 @@ import getApi, {
   LKRPChallengeSchema,
   type WeakChallengeSignature,
 } from "./api";
-import type { MemberCredentials } from "./types";
 import { convertLiveCredentialsToKeyPair, credentialForPubKey, liveAuthentication } from "./utils";
+import { MemberCredentials, Trustchain } from "./types";
+
+type PartialTrustchainStore = {
+  trustchain: Pick<Trustchain, "rootId"> | null;
+  memberCredentials: MemberCredentials | null;
+};
 
 export class LkrpIdentityProvider implements IdentityProvider {
   readonly brokerId = "lkrp";
-  private keypair?: MemberCredentials;
-  private trustchainId?: string;
+  private trustchainStore: PartialTrustchainStore | undefined;
 
   async authenticate(request: IdPAuthParams): Promise<KeycloakToken> {
     const challenge = LkrpIdentityProvider.checkChallenge(request.challenge);
     const host = challenge.json.host;
     const api = getApi(`https://${host}`);
 
-    const authorizationCode = await api.oidcPostChallengeResponse(this.signChallenge(challenge));
+    const authorizationCode = await api.oidcPostChallengeResponse(
+      await this.signChallenge(challenge),
+    );
 
     const idPToken = await api.oidcExchangeAuthCode(
       authorizationCode,
@@ -37,33 +43,29 @@ export class LkrpIdentityProvider implements IdentityProvider {
     return api.oidcExchangeToken(idPToken, request.clientId);
   }
 
-  setKeypair(keypair?: MemberCredentials | undefined): void {
-    this.keypair = keypair ?? undefined;
+  setTrustchainStore(store: PartialTrustchainStore | undefined): void {
+    this.trustchainStore = store;
   }
 
-  setTrustchainId(trustchainId: string | undefined): void {
-    this.trustchainId = trustchainId ?? undefined;
-  }
-
-  private signChallenge(challenge: LKRPChallenge): {
+  private async signChallenge(challenge: LKRPChallenge): Promise<{
     challenge: ChallengeJson;
     signature: WeakChallengeSignature;
-  } {
-    if (!this.keypair) {
+  }> {
+    if (!this.trustchainStore?.memberCredentials) {
       throw new WalletAuthNoCredentialsError(this.brokerId);
     }
 
     const data = crypto.from_hex(challenge.tlv);
     const [parsed] = Challenge.fromBytes(data);
     const hash = crypto.hash(parsed.getUnsignedTLV());
-    const keypair = convertLiveCredentialsToKeyPair(this.keypair);
+    const keypair = convertLiveCredentialsToKeyPair(this.trustchainStore.memberCredentials);
     return {
       challenge: challenge.json,
       signature: {
-        credential: credentialForPubKey(this.keypair.pubkey),
+        credential: credentialForPubKey(this.trustchainStore.memberCredentials.pubkey),
         signature: crypto.to_hex(crypto.sign(hash, keypair)),
-        attestation: this.trustchainId
-          ? crypto.to_hex(liveAuthentication(this.trustchainId))
+        attestation: this.trustchainStore.trustchain?.rootId
+          ? crypto.to_hex(liveAuthentication(this.trustchainStore.trustchain.rootId))
           : undefined,
       },
     };

--- a/libs/ledger-key-ring-protocol/src/LKRPIdentityProvider.ts
+++ b/libs/ledger-key-ring-protocol/src/LKRPIdentityProvider.ts
@@ -6,6 +6,7 @@ import {
   type IdPAuthParams,
   type KeycloakToken,
 } from "@ledgerhq/ledger-auth";
+import type { TypedStartListening } from "@reduxjs/toolkit";
 import getApi, {
   type Challenge as ChallengeJson,
   type LKRPChallenge,
@@ -14,15 +15,35 @@ import getApi, {
 } from "./api";
 import type { MemberCredentials, Trustchain } from "./types";
 import { convertLiveCredentialsToKeyPair, credentialForPubKey, liveAuthentication } from "./utils";
+import { trustchainStoreActionTypePrefix, type TrustchainStore } from "./store";
 
-type PartialTrustchainStore = {
+interface PartialTrustchainStore {
   trustchain: Pick<Trustchain, "rootId"> | null;
   memberCredentials: MemberCredentials | null;
-};
+}
 
-export class LkrpIdentityProvider implements IdentityProvider {
+interface StateWithTrustchain {
+  trustchain: TrustchainStore;
+}
+
+export interface LkrpIdentityProviderOptions<State extends StateWithTrustchain> {
+  startListening?: TypedStartListening<State>;
+}
+
+export class LkrpIdentityProvider<
+  State extends StateWithTrustchain = StateWithTrustchain,
+> implements IdentityProvider {
   readonly brokerId = "lkrp";
   private trustchainStore: PartialTrustchainStore | undefined;
+
+  constructor({ startListening }: LkrpIdentityProviderOptions<State> = {}) {
+    startListening?.({
+      predicate: action => action.type.startsWith(trustchainStoreActionTypePrefix),
+      effect: (_action, listenerApi) => {
+        this.setTrustchainStore(listenerApi.getState().trustchain);
+      },
+    });
+  }
 
   async authenticate(request: IdPAuthParams): Promise<KeycloakToken> {
     const challenge = LkrpIdentityProvider.checkChallenge(request.challenge);

--- a/libs/ledger-key-ring-protocol/src/__mocks__/challenge.ts
+++ b/libs/ledger-key-ring-protocol/src/__mocks__/challenge.ts
@@ -1,0 +1,22 @@
+import { Challenge, crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
+import type { LKRPChallenge } from "../api";
+
+class MockChallenge {
+  constructor(public readonly tlv: string) {}
+
+  #parsed: Challenge | undefined;
+  get parsed() {
+    this.#parsed ??= Challenge.fromBytes(crypto.from_hex(this.tlv))[0];
+    return this.#parsed;
+  }
+
+  #json: LKRPChallenge["json"] | undefined;
+  get json() {
+    this.#json ??= this.parsed.toJSON();
+    return this.#json;
+  }
+}
+
+export const CHALLENGE = new MockChallenge(
+  "010107020100121053801a35c2e24b627d6e4925ce318980140101154630440220319b42a416512437e48d9c9bf204daea7da03d452c50a8caa4c2d152407ffd0c02201f121b0e99df1d30f4757b6a00b8d974d70996771893ac49c4a245c147cc1d8f160466a90248202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000",
+);

--- a/libs/ledger-key-ring-protocol/src/__tests__/LKRPIdentityProvider.integration.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/LKRPIdentityProvider.integration.test.ts
@@ -1,11 +1,13 @@
 import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import { AuthSDK } from "@ledgerhq/ledger-auth";
+import { configureStore, createListenerMiddleware } from "@reduxjs/toolkit";
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
 import type { Challenge as ChallengeJson, WeakChallengeSignature } from "../api";
 import { LkrpIdentityProvider } from "../LKRPIdentityProvider";
+import { getInitialStore, importTrustchainStoreState, type TrustchainStore } from "../store";
 import type { MemberCredentials } from "../types";
-import { credentialForPubKey, liveAuthentication } from "../utils";
+import { credentialForPubKey, initMemberCredentials, liveAuthentication } from "../utils";
 import { CHALLENGE } from "../__mocks__/challenge";
 
 type SignedChallengeRequest = {
@@ -57,6 +59,61 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     server.resetHandlers();
+  });
+
+  it("synchronizes credentials after Trustchain import actions", async () => {
+    endpoints.lkrpAuth.mockImplementation(() => HttpResponse.json(AUTHORIZATION_CODE));
+    endpoints.lkrpToken.mockImplementation(() =>
+      HttpResponse.json({ access_token: LKRP_TOKEN, token_type: "Bearer" }),
+    );
+    endpoints.tokenExchange.mockImplementation(() =>
+      HttpResponse.json({ access_token: KEYCLOAK_JWT, token_type: "Bearer" }),
+    );
+
+    const listenerMiddleware = createListenerMiddleware<{ trustchain: TrustchainStore }>();
+    const lkrpIdentityProvider = new LkrpIdentityProvider<{ trustchain: TrustchainStore }>({
+      startListening: listenerMiddleware.startListening,
+    });
+    const store = configureStore({
+      reducer: {
+        trustchain: (
+          state = getInitialStore(),
+          action: { type: string; payload?: { trustchain?: TrustchainStore } },
+        ) => action.payload?.trustchain ?? state,
+      },
+      middleware: getDefaultMiddleware =>
+        getDefaultMiddleware().prepend(listenerMiddleware.middleware),
+    });
+    const request = {
+      challenge: { tlv: CHALLENGE.tlv, json: CHALLENGE.json },
+      clientId: CLIENT_ID,
+      redirectUri: REDIRECT_URI,
+    };
+
+    store.dispatch({ type: "unrelated/action" });
+    await expect(lkrpIdentityProvider.authenticate(request)).rejects.toMatchObject({
+      name: "WalletAuthNoCredentialsError",
+    });
+    expect(endpoints.lkrpAuth).not.toHaveBeenCalled();
+
+    store.dispatch(
+      importTrustchainStoreState({ trustchain: null, memberCredentials: MEMBER_CREDENTIALS }),
+    );
+    await lkrpIdentityProvider.authenticate(request);
+    expect(await endpoints.lkrpAuth.mock.calls[0][0].request.json()).toHaveProperty(
+      "signature.credential.publicKey",
+      MEMBER_CREDENTIALS.pubkey,
+    );
+
+    const updatedMemberCredentials = initMemberCredentials();
+    store.dispatch(
+      importTrustchainStoreState({ trustchain: null, memberCredentials: updatedMemberCredentials }),
+    );
+    await lkrpIdentityProvider.authenticate(request);
+    expect(await endpoints.lkrpAuth.mock.calls[1][0].request.json()).toHaveProperty(
+      "signature.credential.publicKey",
+      updatedMemberCredentials.pubkey,
+    );
   });
 
   it("retrieves a Keycloak JWT with PKCE", async () => {

--- a/libs/ledger-key-ring-protocol/src/__tests__/LKRPIdentityProvider.integration.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/LKRPIdentityProvider.integration.test.ts
@@ -1,11 +1,12 @@
-import { Challenge, crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
+import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import { AuthSDK } from "@ledgerhq/ledger-auth";
 import { HttpResponse, http } from "msw";
-import { setupServer, type SetupServerApi } from "msw/node";
+import { setupServer } from "msw/node";
 import type { Challenge as ChallengeJson, WeakChallengeSignature } from "../api";
 import { LkrpIdentityProvider } from "../LKRPIdentityProvider";
 import type { MemberCredentials } from "../types";
 import { credentialForPubKey, liveAuthentication } from "../utils";
+import { CHALLENGE } from "../__mocks__/challenge";
 
 type SignedChallengeRequest = {
   challenge: ChallengeJson;
@@ -19,8 +20,8 @@ const REDIRECT_URI = `${KEYCLOAK_BASE_URL}/realms/${REALM}/broker/lkrp/endpoint`
 const KEYCLOAK_OPENID_URL = `${KEYCLOAK_BASE_URL}/realms/${REALM}/protocol/openid-connect`;
 const TRUSTCHAIN_ID = "ROOTID";
 const AUTHORIZATION_CODE = "auth-code-xyz";
-const IDP_TOKEN = makeJwt({ sub: "idp", exp: 4102444800 });
-const EXPECTED_JWT = makeJwt({ sub: "keycloak", exp: 4102444800 });
+const LKRP_TOKEN = makeJwt({ sub: "idp", exp: 4102444800 });
+const KEYCLOAK_JWT = makeJwt({ sub: "keycloak", exp: 4102444800 });
 const REFRESH_TOKEN = makeJwt({ sub: "refresh", exp: 4102444800 });
 const EXPECTED_ATTESTATION = crypto.to_hex(liveAuthentication(TRUSTCHAIN_ID));
 
@@ -29,16 +30,21 @@ const MEMBER_CREDENTIALS: MemberCredentials = {
   privatekey: "873f500bd20783224f7e78d4f8cce3d2bf69eb8008fbd697d20bbea31a721a03",
 };
 
-const CHALLENGE_TLV =
-  "010107020100121053801a35c2e24b627d6e4925ce318980140101154630440220319b42a416512437e48d9c9bf204daea7da03d452c50a8caa4c2d152407ffd0c02201f121b0e99df1d30f4757b6a00b8d974d70996771893ac49c4a245c147cc1d8f160466a90248202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000";
-const [PARSED_CHALLENGE] = Challenge.fromBytes(crypto.from_hex(CHALLENGE_TLV));
-const CHALLENGE_JSON = toApiChallenge(PARSED_CHALLENGE);
-const IDP_HOST = CHALLENGE_JSON.host;
-
 describe("LkrpIdentityProvider (integration, MSW)", () => {
-  const oidcAuthenticateMock = jest.fn<void, [SignedChallengeRequest]>();
-  const server: SetupServerApi = initServer(oidcAuthenticateMock);
   const queryFn = jest.fn().mockResolvedValue({ ok: true });
+
+  const endpoints = {
+    keycloakAuth: jest.fn<Response, [{ request: Request }]>(),
+    lkrpAuth: jest.fn<Response, [{ request: Request }]>(),
+    lkrpToken: jest.fn<Response, [{ request: Request }]>(),
+    tokenExchange: jest.fn<Response, [{ request: Request }]>(),
+  };
+  const server = setupServer(
+    http.get(`${KEYCLOAK_OPENID_URL}/auth`, endpoints.keycloakAuth),
+    http.post(`https://${CHALLENGE.json.host}/openid/v1/authenticate`, endpoints.lkrpAuth),
+    http.post(`https://${CHALLENGE.json.host}/openid/v1/token`, endpoints.lkrpToken),
+    http.post(`https://${CHALLENGE.json.host}/openid/v1/exchange`, endpoints.tokenExchange),
+  );
 
   beforeAll(() => {
     server.listen({ onUnhandledRequest: "error" });
@@ -53,36 +59,25 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
     server.resetHandlers();
   });
 
-  it("retrieves a Keycloak JWT without PKCE", async () => {
-    await new AuthSDK(
-      {
-        clientId: CLIENT_ID,
-        keycloakBaseUrl: KEYCLOAK_BASE_URL,
-        keycloakRealm: REALM,
-        disablePkce: true,
-      },
-      { provider: createIdentityProvider(TRUSTCHAIN_ID) },
-    ).withToken({ queryFn });
-
-    expect(queryFn).toHaveBeenCalledWith({
-      accessToken: EXPECTED_JWT,
-      tokenType: "Bearer",
-      scope: "openid",
-      expiresIn: 300,
-      refreshToken: REFRESH_TOKEN,
-      refreshExpiresIn: 1800,
-    });
-    expect(oidcAuthenticateMock).toHaveBeenCalledTimes(1);
-    expect(oidcAuthenticateMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        signature: expect.objectContaining({
-          attestation: EXPECTED_ATTESTATION,
-        }),
+  it("retrieves a Keycloak JWT with PKCE", async () => {
+    endpoints.keycloakAuth.mockReturnValue(
+      HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
+    );
+    endpoints.lkrpAuth.mockReturnValue(HttpResponse.json("auth-code-xyz"));
+    endpoints.lkrpToken.mockReturnValue(
+      HttpResponse.json({ access_token: LKRP_TOKEN, token_type: "Bearer" }),
+    );
+    endpoints.tokenExchange.mockReturnValue(
+      HttpResponse.json({
+        access_token: KEYCLOAK_JWT,
+        token_type: "Bearer",
+        scope: "openid",
+        expires_in: 300,
+        refresh_token: REFRESH_TOKEN,
+        refresh_expires_in: 1800,
       }),
     );
-  });
 
-  it("retrieves a Keycloak JWT with PKCE", async () => {
     await new AuthSDK(
       {
         clientId: CLIENT_ID,
@@ -94,24 +89,108 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
     ).withToken({ queryFn });
 
     expect(queryFn).toHaveBeenCalledWith({
-      accessToken: EXPECTED_JWT,
+      accessToken: KEYCLOAK_JWT,
       tokenType: "Bearer",
       scope: "openid",
       expiresIn: 300,
       refreshToken: REFRESH_TOKEN,
       refreshExpiresIn: 1800,
     });
-    expect(oidcAuthenticateMock).toHaveBeenCalledTimes(1);
-    expect(oidcAuthenticateMock).toHaveBeenCalledWith(
+
+    const keycloakRequest = endpoints.keycloakAuth.mock.calls[0][0].request;
+    const pkceChallenge = new URL(keycloakRequest.url).searchParams.get("code_challenge");
+
+    // Check /authenticate
+    const challengeRequestBody = await endpoints.lkrpAuth.mock.calls[0][0].request.json();
+    expect(challengeRequestBody).toEqual(
       expect.objectContaining({
+        challenge: CHALLENGE.json,
         signature: expect.objectContaining({
+          credential: credentialForPubKey(MEMBER_CREDENTIALS.pubkey),
           attestation: EXPECTED_ATTESTATION,
+          signature: expect.any(String),
         }),
       }),
     );
+    const signature = (challengeRequestBody as SignedChallengeRequest).signature;
+    expect(
+      crypto.verify(
+        crypto.hash(CHALLENGE.parsed.getUnsignedTLV()),
+        crypto.from_hex(signature.signature),
+        crypto.from_hex(MEMBER_CREDENTIALS.pubkey),
+      ),
+    ).toBe(true);
+
+    // Check /token
+    const tokenRequest = endpoints.lkrpToken.mock.calls[0][0].request;
+    expect(tokenRequest.headers.get("Content-Type")).toContain("application/x-www-form-urlencoded");
+    const tokenRequestBody = new URLSearchParams(await tokenRequest.text());
+    expect(Object.fromEntries(tokenRequestBody)).toEqual({
+      grant_type: "authorization_code",
+      code: AUTHORIZATION_CODE,
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT_URI,
+      code_verifier: expect.any(String),
+    });
+    const codeVerifier = tokenRequestBody.get("code_verifier") ?? "";
+    const digest = await globalThis.crypto.subtle.digest(
+      "SHA-256",
+      stringToArrayBuffer(codeVerifier),
+    );
+    expect(bytesToBase64Url(digest)).toBe(pkceChallenge);
+
+    // Check /exchange
+    const tokenExchangeRequest = endpoints.tokenExchange.mock.calls[0][0].request;
+    expect(tokenExchangeRequest.headers.get("Authorization")).toBe(`Bearer ${LKRP_TOKEN}`);
+    expect(await tokenExchangeRequest.json()).toEqual({ client_id: CLIENT_ID });
+  });
+
+  it("retrieves a Keycloak JWT without PKCE", async () => {
+    endpoints.keycloakAuth.mockReturnValue(
+      HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
+    );
+    endpoints.lkrpAuth.mockReturnValue(HttpResponse.json("auth-code-xyz"));
+    endpoints.lkrpToken.mockReturnValue(
+      HttpResponse.json({ access_token: LKRP_TOKEN, token_type: "Bearer" }),
+    );
+    endpoints.tokenExchange.mockReturnValue(
+      HttpResponse.json({ access_token: KEYCLOAK_JWT, token_type: "Bearer" }),
+    );
+
+    await new AuthSDK(
+      {
+        clientId: CLIENT_ID,
+        keycloakBaseUrl: KEYCLOAK_BASE_URL,
+        keycloakRealm: REALM,
+        disablePkce: true,
+      },
+      { provider: createIdentityProvider(TRUSTCHAIN_ID) },
+    ).withToken({ queryFn });
+
+    expect(queryFn).toHaveBeenCalledWith({ accessToken: KEYCLOAK_JWT, tokenType: "Bearer" });
+
+    const keycloakRequest = endpoints.keycloakAuth.mock.calls[0][0].request;
+    const keycloakSearchParams = new URL(keycloakRequest.url).searchParams;
+    expect(keycloakSearchParams.has("code_challenge")).toBe(false);
+    expect(keycloakSearchParams.has("code_challenge_method")).toBe(false);
+
+    const tokenRequest = endpoints.lkrpToken.mock.calls[0][0].request;
+    const tokenRequestBody = new URLSearchParams(await tokenRequest.text());
+    expect(tokenRequestBody.has("code_verifier")).toBe(false);
   });
 
   it("retrieves a Keycloak JWT without attestation when no trustchain id is set", async () => {
+    endpoints.keycloakAuth.mockReturnValue(
+      HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
+    );
+    endpoints.lkrpAuth.mockReturnValue(HttpResponse.json("auth-code-xyz"));
+    endpoints.lkrpToken.mockReturnValue(
+      HttpResponse.json({ access_token: LKRP_TOKEN, token_type: "Bearer" }),
+    );
+    endpoints.tokenExchange.mockReturnValue(
+      HttpResponse.json({ access_token: KEYCLOAK_JWT, token_type: "Bearer" }),
+    );
+
     await new AuthSDK(
       {
         clientId: CLIENT_ID,
@@ -122,17 +201,19 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
       { provider: createIdentityProvider(undefined) },
     ).withToken({ queryFn });
 
-    expect(queryFn).toHaveBeenCalledWith({
-      accessToken: EXPECTED_JWT,
-      tokenType: "Bearer",
-      scope: "openid",
-      expiresIn: 300,
-      refreshToken: REFRESH_TOKEN,
-      refreshExpiresIn: 1800,
-    });
-    expect(oidcAuthenticateMock).toHaveBeenCalledTimes(1);
-    const request = oidcAuthenticateMock.mock.calls[0]?.[0];
-    expect(request?.signature).not.toHaveProperty("attestation");
+    expect(queryFn).toHaveBeenCalledWith({ accessToken: KEYCLOAK_JWT, tokenType: "Bearer" });
+
+    const challengeRequestBody = await endpoints.lkrpAuth.mock.calls[0][0].request.json();
+    const signature = (challengeRequestBody as SignedChallengeRequest).signature;
+    expect(signature).not.toHaveProperty("attestation");
+    expect(signature.credential).toEqual(credentialForPubKey(MEMBER_CREDENTIALS.pubkey));
+    expect(
+      crypto.verify(
+        crypto.hash(CHALLENGE.parsed.getUnsignedTLV()),
+        crypto.from_hex(signature.signature),
+        crypto.from_hex(MEMBER_CREDENTIALS.pubkey),
+      ),
+    ).toBe(true);
   });
 });
 
@@ -143,150 +224,6 @@ function createIdentityProvider(trustchainId: string | undefined): LkrpIdentityP
     trustchain: trustchainId ? { rootId: trustchainId } : null,
   });
   return provider;
-}
-
-function initServer(
-  oidcAuthenticateMock: jest.Mock<void, [SignedChallengeRequest]>,
-): SetupServerApi {
-  const sessionStore = new Map<string, { codeChallenge?: string }>();
-  let pendingCodeChallenge: string | undefined;
-
-  return setupServer(
-    http.get(`${KEYCLOAK_OPENID_URL}/auth`, ({ request }) => {
-      const url = new URL(request.url);
-      const codeChallenge = url.searchParams.get("code_challenge") ?? undefined;
-      const codeChallengeMethod = url.searchParams.get("code_challenge_method") ?? undefined;
-
-      if (
-        url.searchParams.get("response_type") !== "code" ||
-        url.searchParams.get("client_id") !== CLIENT_ID ||
-        url.searchParams.get("scope") !== "openid" ||
-        url.searchParams.get("redirect_uri") !== REDIRECT_URI ||
-        (codeChallenge ? codeChallengeMethod !== "S256" : codeChallengeMethod !== undefined)
-      ) {
-        return HttpResponse.json({ error: "invalid_request" }, { status: 400 });
-      }
-
-      pendingCodeChallenge = codeChallenge;
-      return HttpResponse.json({ json: CHALLENGE_JSON, tlv: CHALLENGE_TLV });
-    }),
-
-    http.post(`https://${IDP_HOST}/openid/v1/authenticate`, async ({ request }) => {
-      const body = (await request.json()) as SignedChallengeRequest;
-      oidcAuthenticateMock(body);
-      if (!isValidSignedChallengeRequest(body)) {
-        return HttpResponse.json({ error: "invalid_request" }, { status: 400 });
-      }
-
-      sessionStore.set(AUTHORIZATION_CODE, { codeChallenge: pendingCodeChallenge });
-      pendingCodeChallenge = undefined;
-
-      return HttpResponse.json(AUTHORIZATION_CODE);
-    }),
-
-    http.post(`https://${IDP_HOST}/openid/v1/token`, async ({ request }) => {
-      const contentType = request.headers.get("Content-Type") ?? "";
-      if (!contentType.includes("application/x-www-form-urlencoded")) {
-        return HttpResponse.json({ error: "invalid_request" }, { status: 400 });
-      }
-
-      const params = new URLSearchParams(await request.text());
-      if (params.get("grant_type") !== "authorization_code") {
-        return HttpResponse.json({ error: "unsupported_grant_type" }, { status: 400 });
-      }
-      if (params.get("client_id") !== CLIENT_ID || params.get("redirect_uri") !== REDIRECT_URI) {
-        return HttpResponse.json({ error: "invalid_client" }, { status: 400 });
-      }
-
-      const code = params.get("code") ?? "";
-      const codeVerifier = params.get("code_verifier");
-      const authRequest = sessionStore.get(code);
-      sessionStore.delete(code);
-
-      if (!code || !authRequest) {
-        return HttpResponse.json({ error: "invalid_request" }, { status: 400 });
-      }
-
-      if (authRequest.codeChallenge) {
-        if (!codeVerifier) {
-          return HttpResponse.json({ error: "invalid_request" }, { status: 400 });
-        }
-        const digest = await globalThis.crypto.subtle.digest(
-          "SHA-256",
-          stringToArrayBuffer(codeVerifier),
-        );
-        if (bytesToBase64Url(digest) !== authRequest.codeChallenge) {
-          return HttpResponse.json({ error: "invalid_grant" }, { status: 400 });
-        }
-      } else if (codeVerifier) {
-        return HttpResponse.json({ error: "invalid_request" }, { status: 400 });
-      }
-
-      const tokenResponse: Record<string, unknown> = {
-        access_token: IDP_TOKEN,
-        token_type: "Bearer",
-      };
-
-      return HttpResponse.json(tokenResponse);
-    }),
-
-    http.post(`https://${IDP_HOST}/openid/v1/exchange`, async ({ request }) => {
-      if (request.headers.get("Authorization") !== `Bearer ${IDP_TOKEN}`) {
-        return HttpResponse.json({ error: "invalid_token" }, { status: 401 });
-      }
-
-      const body = (await request.json()) as { client_id?: string };
-      if (body.client_id !== CLIENT_ID) {
-        return HttpResponse.json({ error: "invalid_client" }, { status: 400 });
-      }
-
-      return HttpResponse.json({
-        access_token: EXPECTED_JWT,
-        token_type: "Bearer",
-        scope: "openid",
-        expires_in: 300,
-        refresh_token: REFRESH_TOKEN,
-        refresh_expires_in: 1800,
-      });
-    }),
-  );
-}
-
-function isValidSignedChallengeRequest(body: SignedChallengeRequest): boolean {
-  if (JSON.stringify(body.challenge) !== JSON.stringify(CHALLENGE_JSON)) {
-    return false;
-  }
-
-  if (
-    JSON.stringify(body.signature.credential) !==
-    JSON.stringify(credentialForPubKey(MEMBER_CREDENTIALS.pubkey))
-  ) {
-    return false;
-  }
-
-  if (
-    body.signature.attestation !== undefined &&
-    body.signature.attestation !== EXPECTED_ATTESTATION
-  ) {
-    return false;
-  }
-
-  return crypto.verify(
-    crypto.hash(PARSED_CHALLENGE.getUnsignedTLV()),
-    crypto.from_hex(body.signature.signature),
-    crypto.from_hex(MEMBER_CREDENTIALS.pubkey),
-  );
-}
-
-function toApiChallenge(challenge: Challenge): ChallengeJson {
-  const json = challenge.toJSON();
-  return {
-    version: json.version,
-    challenge: json.challenge,
-    host: json.host,
-    rp: json.rp,
-    protocolVersion: json.protocolVersion,
-  };
 }
 
 function stringToArrayBuffer(value: string): ArrayBuffer {

--- a/libs/ledger-key-ring-protocol/src/__tests__/LKRPIdentityProvider.integration.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/LKRPIdentityProvider.integration.test.ts
@@ -138,8 +138,10 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
 
 function createIdentityProvider(trustchainId: string | undefined): LkrpIdentityProvider {
   const provider = new LkrpIdentityProvider();
-  provider.setKeypair(MEMBER_CREDENTIALS);
-  provider.setTrustchainId(trustchainId);
+  provider.setTrustchainStore({
+    memberCredentials: MEMBER_CREDENTIALS,
+    trustchain: trustchainId ? { rootId: trustchainId } : null,
+  });
   return provider;
 }
 

--- a/libs/ledger-key-ring-protocol/src/__tests__/unit/sdk.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/unit/sdk.test.ts
@@ -15,6 +15,7 @@ import { HWDeviceProvider } from "../../HWDeviceProvider";
 import { SDK } from "../../sdk";
 import { TrustchainResultType } from "../../types";
 import { convertLiveCredentialsToKeyPair } from "../../utils";
+import { CHALLENGE } from "../../__mocks__/challenge";
 
 describe("Trustchain SDK", () => {
   // Setup API calls mocks
@@ -69,7 +70,7 @@ describe("Trustchain SDK", () => {
   it("encryptUserData + decryptUserData", async () => {
     const sdk = new SDK(sdkContext, hwDeviceProviderMock);
     const obj = new Uint8Array([1, 2, 3, 4, 5]);
-    const keypair = await crypto.randomKeypair();
+    const keypair = crypto.randomKeypair();
     const trustchain = {
       rootId: "",
       walletSyncEncryptionKey: crypto.to_hex(keypair.privateKey),
@@ -94,7 +95,7 @@ describe("Trustchain SDK", () => {
     apiMocks.getTrustchainByIdMock.mockReturnValue(initialTree.serialize());
 
     // Mock APDU device interactions:
-    HWDeviceProviderMethodsMocks.withJwt.mockImplementation(async (deviceId, job) =>
+    HWDeviceProviderMethodsMocks.withJwt.mockImplementation(async (_deviceId, job) =>
       job({ accessToken: "ACCESS TOKEN" }),
     );
     HWDeviceProviderMethodsMocks.withHw.mockResolvedValueOnce(initialTree);
@@ -143,7 +144,7 @@ describe("Trustchain SDK", () => {
     });
 
     // Mock APDU device interactions:
-    HWDeviceProviderMethodsMocks.withJwt.mockImplementation(async (deviceId, job) =>
+    HWDeviceProviderMethodsMocks.withJwt.mockImplementation(async (_deviceId, job) =>
       job({ accessToken: "ACCESS TOKEN" }),
     );
     HWDeviceProviderMethodsMocks.withHw.mockResolvedValueOnce(closedStreamTree);
@@ -256,8 +257,7 @@ const MOCK_DATA = {
     },
   },
 
-  challengeTlv:
-    "010107020100121053801a35c2e24b627d6e4925ce318980140101154630440220319b42a416512437e48d9c9bf204daea7da03d452c50a8caa4c2d152407ffd0c02201f121b0e99df1d30f4757b6a00b8d974d70996771893ac49c4a245c147cc1d8f160466a90248202b7472757374636861696e2d6261636b656e642e6170692e6177732e7374672e6c64672d746563682e636f6d320121332103cb7628e7248ddf9c07da54b979f16bf081fb3d173aac0992ad2a44ef6a388ae2600401000000",
+  challengeTlv: CHALLENGE.tlv,
 };
 
 function createTrustChain(device: Device): Promise<StreamTree> {

--- a/libs/ledger-key-ring-protocol/src/__tests__/unit/store.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/unit/store.test.ts
@@ -1,0 +1,92 @@
+import { importTrustchainStoreState, resetTrustchainStore, trustchainHandlers } from "../../store";
+import type { MemberCredentials } from "../../types";
+
+describe("trustchain store", () => {
+  it("should initialize member credentials when importing missing trustchain state", () => {
+    const action = importTrustchainStoreState();
+
+    expect(action.payload.trustchain).toEqual({
+      trustchain: null,
+      memberCredentials: {
+        pubkey: expect.stringMatching(/^[0-9a-f]+$/),
+        privatekey: expect.stringMatching(/^[0-9a-f]+$/),
+      },
+    });
+  });
+
+  it("should reset the trustchain when imported state has no member credentials", () => {
+    const action = importTrustchainStoreState({
+      trustchain: {
+        rootId: "root-id",
+        walletSyncEncryptionKey: "wallet-sync-encryption-key",
+        applicationPath: "m/0'/16'/0'",
+      },
+      memberCredentials: null,
+    });
+
+    expect(action.payload.trustchain).toEqual({
+      trustchain: null,
+      memberCredentials: {
+        pubkey: expect.stringMatching(/^[0-9a-f]+$/),
+        privatekey: expect.stringMatching(/^[0-9a-f]+$/),
+      },
+    });
+  });
+
+  it("should preserve persisted state with valid member credentials", () => {
+    const persistedState = {
+      trustchain: null,
+      memberCredentials: {
+        pubkey: "02e3311a12c450604725f02d1a775ef5cdb4a1b832eb41ac6b1302adbe92a612fc",
+        privatekey: "873f500bd20783224f7e78d4f8cce3d2bf69eb8008fbd697d20bbea31a721a03",
+      },
+    };
+
+    expect(importTrustchainStoreState(persistedState).payload.trustchain).toBe(persistedState);
+  });
+
+  it("should regenerate credentials and clear the trustchain when persisted credentials are invalid", () => {
+    const action = importTrustchainStoreState({
+      trustchain: {
+        rootId: "root-id",
+        walletSyncEncryptionKey: "wallet-sync-encryption-key",
+        applicationPath: "m/0'/16'/0'",
+      },
+      memberCredentials: {} as MemberCredentials,
+    });
+
+    expect(action.payload.trustchain).toEqual({
+      trustchain: null,
+      memberCredentials: {
+        pubkey: expect.stringMatching(/^[0-9a-f]+$/),
+        privatekey: expect.stringMatching(/^[0-9a-f]+$/),
+      },
+    });
+  });
+
+  it("should deterministically reset the trustchain with fresh member credentials", () => {
+    const previousState = {
+      trustchain: {
+        rootId: "root-id",
+        walletSyncEncryptionKey: "wallet-sync-encryption-key",
+        applicationPath: "m/0'/16'/0'",
+      },
+      memberCredentials: {
+        pubkey: "persisted-pubkey",
+        privatekey: "persisted-privatekey",
+      },
+    };
+    const action = resetTrustchainStore();
+    const resetState = trustchainHandlers.TRUSTCHAIN_STORE_RESET(previousState, action);
+
+    expect(resetState).toEqual({
+      trustchain: null,
+      memberCredentials: {
+        pubkey: expect.stringMatching(/^[0-9a-f]+$/),
+        privatekey: expect.stringMatching(/^[0-9a-f]+$/),
+      },
+    });
+    expect(resetState.memberCredentials).not.toEqual(previousState.memberCredentials);
+    expect(trustchainHandlers.TRUSTCHAIN_STORE_RESET(previousState, action)).toEqual(resetState);
+  });
+});

--- a/libs/ledger-key-ring-protocol/src/__tests__/unit/types.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/unit/types.test.ts
@@ -1,0 +1,25 @@
+import { MemberCredentialsSchema } from "../../types";
+
+describe("MemberCredentialsSchema", () => {
+  const memberCredentials = {
+    pubkey: "02e3311a12c450604725f02d1a775ef5cdb4a1b832eb41ac6b1302adbe92a612fc",
+    privatekey: "873f500bd20783224f7e78d4f8cce3d2bf69eb8008fbd697d20bbea31a721a03",
+  };
+
+  it("should accept matching member credentials", () => {
+    expect(MemberCredentialsSchema.safeParse(memberCredentials).success).toBe(true);
+  });
+
+  it.each([
+    null,
+    {},
+    { ...memberCredentials, pubkey: "" },
+    { ...memberCredentials, privatekey: "not-hex" },
+    { ...memberCredentials, unexpected: "value" },
+    { ...memberCredentials, pubkey: memberCredentials.pubkey.toUpperCase() },
+    { ...memberCredentials, privatekey: memberCredentials.privatekey.toUpperCase() },
+    { ...memberCredentials, privatekey: "01".repeat(32) },
+  ])("should reject invalid member credentials", invalidCredentials => {
+    expect(MemberCredentialsSchema.safeParse(invalidCredentials).success).toBe(false);
+  });
+});

--- a/libs/ledger-key-ring-protocol/src/api.ts
+++ b/libs/ledger-key-ring-protocol/src/api.ts
@@ -20,6 +20,7 @@ export const APIJWTSchema = z.object({
 export type APIJWT = z.infer<typeof APIJWTSchema>;
 
 export const ChallengeJsonSchema = z.object({
+  payloadType: z.optional(z.number().int()),
   version: z.number().int(),
   challenge: z.object({
     data: z.hex().min(1),

--- a/libs/ledger-key-ring-protocol/src/api.ts
+++ b/libs/ledger-key-ring-protocol/src/api.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import network from "@ledgerhq/live-network";
-import { JWT } from "./types";
+import type { JWT } from "./types";
 import {
   type KeycloakToken,
   KeycloakTokenResponseSchema,

--- a/libs/ledger-key-ring-protocol/src/qrcode/index.test.ts
+++ b/libs/ledger-key-ring-protocol/src/qrcode/index.test.ts
@@ -1,6 +1,6 @@
 import { createQRCodeHostInstance, createQRCodeCandidateInstance } from ".";
 import WebSocket from "ws";
-import { convertKeyPairToLiveCredentials } from "../sdk";
+import { convertKeyPairToLiveCredentials } from "../utils";
 import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import { ScannedInvalidQrCode, ScannedOldImportQrCode } from "../errors";
 

--- a/libs/ledger-key-ring-protocol/src/sdk.ts
+++ b/libs/ledger-key-ring-protocol/src/sdk.ts
@@ -23,7 +23,6 @@ import {
   Device,
 } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import getApi from "./api";
-import { KeyPair as CryptoKeyPair } from "@ledgerhq/hw-ledger-key-ring-protocol/Crypto";
 import { log } from "@ledgerhq/logs";
 import {
   TrustchainAlreadyInitialized,
@@ -34,7 +33,12 @@ import {
 } from "./errors";
 import { HWDeviceProvider } from "./HWDeviceProvider";
 import { genericWithJWT } from "./auth";
-import { convertLiveCredentialsToKeyPair, credentialForPubKey, liveAuthentication } from "./utils";
+import {
+  convertLiveCredentialsToKeyPair,
+  credentialForPubKey,
+  initMemberCredentials,
+  liveAuthentication,
+} from "./utils";
 
 type WithJwt = <T>(job: (jwt: JWT) => Promise<T>) => Promise<T>;
 type WithDevice = <T>(job: (device: Device) => Promise<T>) => Promise<T>;
@@ -95,8 +99,7 @@ export class SDK implements TrustchainSDK {
   }
 
   async initMemberCredentials(): Promise<MemberCredentials> {
-    const kp = crypto.randomKeypair();
-    return convertKeyPairToLiveCredentials(kp);
+    return initMemberCredentials();
   }
 
   async getOrCreateTrustchain(
@@ -514,13 +517,6 @@ export class SDK implements TrustchainSDK {
     };
     return () => withJwt(jwt => this.api.putCommands(jwt, trustchainId, request));
   }
-}
-
-export function convertKeyPairToLiveCredentials(keyPair: CryptoKeyPair): MemberCredentials {
-  return {
-    pubkey: crypto.to_hex(keyPair.publicKey),
-    privatekey: crypto.to_hex(keyPair.privateKey),
-  };
 }
 
 function getSoftwareDevice(memberCredentials: MemberCredentials): SoftwareDevice {

--- a/libs/ledger-key-ring-protocol/src/store.ts
+++ b/libs/ledger-key-ring-protocol/src/store.ts
@@ -4,7 +4,8 @@
  * It essentially is the client's credentials that are only stored on the
  * client side and the trustchain returned by the backend.
  */
-import { MemberCredentials, Trustchain } from "./types";
+import { MemberCredentialsSchema, type MemberCredentials, type Trustchain } from "./types";
+import { initMemberCredentials } from "./utils";
 
 export type TrustchainStore = {
   trustchain: Trustchain | null;
@@ -31,7 +32,7 @@ export enum TrustchainHandlerType {
 
 export type TrustchainHandlersPayloads = {
   TRUSTCHAIN_STORE_IMPORT_STATE: { trustchain: TrustchainStore };
-  TRUSTCHAIN_STORE_RESET: never;
+  TRUSTCHAIN_STORE_RESET: { memberCredentials: MemberCredentials };
   TRUSTCHAIN_STORE_SET_TRUSTCHAIN: { trustchain: Trustchain };
   TRUSTCHAIN_STORE_SET_MEMBER_CREDENTIALS: { memberCredentials: MemberCredentials };
 };
@@ -53,8 +54,8 @@ export const trustchainHandlers: TrustchainHandlers = {
   TRUSTCHAIN_STORE_IMPORT_STATE: (_, { payload: { trustchain } }) => {
     return trustchain;
   },
-  TRUSTCHAIN_STORE_RESET: (): TrustchainStore => {
-    return { ...getInitialStore() };
+  TRUSTCHAIN_STORE_RESET: (_, { payload: { memberCredentials } }): TrustchainStore => {
+    return { ...INITIAL_STATE, memberCredentials };
   },
   TRUSTCHAIN_STORE_SET_TRUSTCHAIN: (state, { payload: { trustchain } }) => {
     return { ...state, trustchain };
@@ -66,13 +67,20 @@ export const trustchainHandlers: TrustchainHandlers = {
 
 // actions
 
-export const importTrustchainStoreState = (trustchain?: TrustchainStore) => ({
+export const importTrustchainStoreState = (persistedState?: TrustchainStore) => ({
   type: `${trustchainStoreActionTypePrefix}IMPORT_STATE`,
-  payload: { trustchain },
+  payload: {
+    trustchain: MemberCredentialsSchema.safeParse(persistedState?.memberCredentials).success
+      ? persistedState
+      : { ...INITIAL_STATE, memberCredentials: initMemberCredentials() },
+  },
 });
 
 export const resetTrustchainStore = () => ({
   type: `${trustchainStoreActionTypePrefix}RESET`,
+  payload: {
+    memberCredentials: initMemberCredentials(),
+  },
 });
 
 export const setTrustchain = (trustchain: Trustchain) => ({

--- a/libs/ledger-key-ring-protocol/src/store.ts
+++ b/libs/ledger-key-ring-protocol/src/store.ts
@@ -66,7 +66,7 @@ export const trustchainHandlers: TrustchainHandlers = {
 
 // actions
 
-export const importTrustchainStoreState = (trustchain: TrustchainStore) => ({
+export const importTrustchainStoreState = (trustchain?: TrustchainStore) => ({
   type: `${trustchainStoreActionTypePrefix}IMPORT_STATE`,
   payload: { trustchain },
 });

--- a/libs/ledger-key-ring-protocol/src/types.ts
+++ b/libs/ledger-key-ring-protocol/src/types.ts
@@ -1,6 +1,8 @@
-import { Observable } from "rxjs";
-import Transport from "@ledgerhq/hw-transport";
-import { TrustchainsResponse } from "./api";
+import type { Observable } from "rxjs";
+import { z } from "zod";
+import type Transport from "@ledgerhq/hw-transport";
+import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
+import type { TrustchainsResponse } from "./api";
 
 /**
  * The JWT is a JSON Web Token that is used to authenticate the user.
@@ -43,16 +45,27 @@ export type Trustchain = {
 /**
  * The Trustchain member credentials are stored on each client, with the privatekey only known by the current client.
  */
-export type MemberCredentials = {
-  /**
-   * The public key of the member (in hexadecimal)
-   */
-  pubkey: string;
-  /**
-   * The private key of the member (in hexadecimal)
-   */
-  privatekey: string;
-};
+export const MemberCredentialsSchema = z
+  .strictObject({
+    pubkey: z.hex().length(66).lowercase(),
+    privatekey: z.hex().length(64).lowercase(),
+  })
+  .refine(
+    ({ pubkey, privatekey }) => {
+      try {
+        const keyPair = crypto.keypairFromSecretKey(crypto.from_hex(privatekey));
+        return crypto.to_hex(keyPair.publicKey) === pubkey;
+      } catch {
+        return false;
+      }
+    },
+    {
+      path: ["pubkey"],
+      message: "Public key does not match private key",
+    },
+  );
+
+export type MemberCredentials = z.infer<typeof MemberCredentialsSchema>;
 
 /**
  * A member of the trustchain

--- a/libs/ledger-key-ring-protocol/src/utils.ts
+++ b/libs/ledger-key-ring-protocol/src/utils.ts
@@ -2,6 +2,18 @@ import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import type { KeyPair } from "@ledgerhq/hw-ledger-key-ring-protocol/Crypto";
 import type { MemberCredentials } from "./types";
 
+export function initMemberCredentials(): MemberCredentials {
+  const kp = crypto.randomKeypair();
+  return convertKeyPairToLiveCredentials(kp);
+}
+
+export function convertKeyPairToLiveCredentials(keyPair: KeyPair): MemberCredentials {
+  return {
+    pubkey: crypto.to_hex(keyPair.publicKey),
+    privatekey: crypto.to_hex(keyPair.privateKey),
+  };
+}
+
 export function convertLiveCredentialsToKeyPair(memberCredentials: MemberCredentials): KeyPair {
   return {
     publicKey: crypto.from_hex(memberCredentials.pubkey),

--- a/nx.workspace.json
+++ b/nx.workspace.json
@@ -210,6 +210,18 @@
         "env": "GIT_REPO_USER"
       },
       {
+        "env": "LEDGER_AUTH_CLIENT_ID"
+      },
+      {
+        "env": "LEDGER_AUTH_KEYCLOAK_BASE_URL_PROD"
+      },
+      {
+        "env": "LEDGER_AUTH_KEYCLOAK_BASE_URL_STAGING"
+      },
+      {
+        "env": "LEDGER_AUTH_KEYCLOAK_REALM"
+      },
+      {
         "env": "LEDGER_INTERNAL_ARGS"
       },
       {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1066,6 +1066,9 @@ importers:
       '@segment/analytics-next':
         specifier: 1.81.1
         version: 1.81.1
+      '@shared/auth':
+        specifier: workspace:*
+        version: link:../../shared/auth
       '@shared/env':
         specifier: workspace:*
         version: link:../../shared/env
@@ -1839,6 +1842,9 @@ importers:
       '@segment/sovran-react-native':
         specifier: 1.1.3
         version: 1.1.3(@react-native-async-storage/async-storage@2.1.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@shared/auth':
+        specifier: workspace:*
+        version: link:../../shared/auth
       '@shared/env':
         specifier: workspace:*
         version: link:../../shared/env
@@ -9026,6 +9032,9 @@ importers:
       '@ledgerhq/types-devices':
         specifier: workspace:^
         version: link:../ledgerjs/packages/types-devices
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2
       base64-js:
         specifier: '1'
         version: 1.5.1
@@ -13740,6 +13749,9 @@ importers:
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2
+      '@shared/feature-flags':
+        specifier: workspace:*
+        version: link:../feature-flags
       zod:
         specifier: 'catalog:'
         version: 4.3.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -964,6 +964,9 @@ importers:
       '@ledgerhq/hw-transport-vault':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/hw-transport-vault
+      '@ledgerhq/ledger-auth':
+        specifier: workspace:^
+        version: link:../../libs/ledger-auth
       '@ledgerhq/ledger-key-ring-protocol':
         specifier: workspace:^
         version: link:../../libs/ledger-key-ring-protocol
@@ -1704,6 +1707,9 @@ importers:
       '@ledgerhq/icons-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/icons
+      '@ledgerhq/ledger-auth':
+        specifier: workspace:^
+        version: link:../../libs/ledger-auth
       '@ledgerhq/ledger-key-ring-protocol':
         specifier: workspace:^
         version: link:../../libs/ledger-key-ring-protocol

--- a/shared/auth/README.md
+++ b/shared/auth/README.md
@@ -46,6 +46,25 @@ authorization: `${token.tokenType} ${token.accessToken}`;
 
 Set `extraOptions.authenticated` to `false` on endpoints that must stay public.
 
+By default, `401` and `403` responses rejected by `fetchBaseQuery` refresh the token
+and retry the request once. If an endpoint accepts these responses through
+`validateStatus`, set `extraOptions.refreshAndRetryWhen` to inspect the response
+metadata instead:
+
+```ts
+query: () => ({
+  url: "foo/read",
+  validateStatus: () => true,
+}),
+extraOptions: {
+  refreshAndRetryWhen: result => result.meta?.response?.status === 401,
+},
+```
+
+Supplying `refreshAndRetryWhen` replaces the default predicate.
+Only match responses that definitively indicate an authentication failure. Retried
+mutations must be idempotent or use idempotency keys to avoid duplicate side effects.
+
 Use `authApiExtra` to provide a stable `authProvider` through RTK Query's
 [`api.extra`](https://redux-toolkit.js.org/rtk-query/api/fetchBaseQuery#prepareheaders)
 ([Redux thunk `extraArgument`](https://redux-toolkit.js.org/api/getDefaultMiddleware#customizing-the-included-middleware)):

--- a/shared/auth/README.md
+++ b/shared/auth/README.md
@@ -37,7 +37,7 @@ export const customApi = createApi({
 });
 ```
 
-For each authenticated endpoint, the base query calls `authSDK.withToken()` and
+For each authenticated endpoint, the base query calls `authProvider.withToken()` and
 adds:
 
 ```ts
@@ -46,27 +46,50 @@ authorization: `${token.tokenType} ${token.accessToken}`;
 
 Set `extraOptions.authenticated` to `false` on endpoints that must stay public.
 
-The Redux store must provide an `authSDK` through RTK Query's
+Use `authApiExtra` to provide a stable `authProvider` through RTK Query's
 [`api.extra`](https://redux-toolkit.js.org/rtk-query/api/fetchBaseQuery#prepareheaders)
 ([Redux thunk `extraArgument`](https://redux-toolkit.js.org/api/getDefaultMiddleware#customizing-the-included-middleware)):
 
 ```ts
-getDefaultMiddleware({
-  thunk: {
-    extraArgument: {
-      authSDK,
-    },
-  },
+const listenerMiddleware = createListenerMiddleware<State>();
+
+const store = configureStore({
+  reducer,
+  middleware: getDefaultMiddleware =>
+    getDefaultMiddleware({
+      thunk: {
+        extraArgument: {
+          ...authApiExtra({
+            startListening: listenerMiddleware.startListening,
+            authFeatureId: "lwdAuth",
+            providerParams: { provider: identityProvider },
+            createAuthProvider: (environment, providerParams) =>
+              new AuthSDK(getAuthConfig(environment), providerParams),
+          }),
+        },
+      },
+    }).prepend(listenerMiddleware.middleware),
 });
 ```
 
-- With `authSDK` implementing `AuthProvider`, for example an instance of `AuthSDK` from `@ledgerhq/ledger-auth`.
+The facade calls queries without a token while authentication is disabled. Once
+authentication is enabled and an environment is selected, it creates and caches
+the injected `AuthProvider`. `AuthSDK` from `@ledgerhq/ledger-auth` is one concrete
+implementation behind this thunk contract.
+
+No initialization action is required: the integration reads the complete state
+whenever the auth environment or feature flags change, regardless of which action
+arrives first. Apps must publish the auth environment before starting authenticated
+queries.
+
+The typed `authFeatureId` selects either `lwdAuth` or `lwmAuth` from
+`@shared/feature-flags`; the Redux state must include its `featureFlags` slice.
 
 ## Scope
 
-This package only owns the RTK Query adapter and its authentication contract.
-Concrete authentication construction, credential loading, and lifecycle
-management belong to the app or feature using the adapter.
+This package owns the RTK Query adapter, auth environment state, and generic
+feature/environment lifecycle. Concrete provider construction, credentials, and
+platform cryptography remain in each app's composition root.
 
 ## Validation
 

--- a/shared/auth/package.json
+++ b/shared/auth/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "catalog:",
+    "@shared/feature-flags": "workspace:*",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/shared/auth/src/api.test.ts
+++ b/shared/auth/src/api.test.ts
@@ -1,0 +1,121 @@
+import { configureStore, createListenerMiddleware } from "@reduxjs/toolkit";
+import { featureFlagsReducer, setOverride, type FeatureFlagsState } from "@shared/feature-flags";
+import { authEnvironmentReducer, setAuthEnvironment, type AuthEnvironmentState } from "./data";
+import { authApiExtra } from "./api";
+import { AuthProviderUnavailableError } from "./errors";
+import type { AuthProvider } from "./types";
+
+type State = {
+  authEnvironment: AuthEnvironmentState;
+  featureFlags: FeatureFlagsState;
+};
+
+const EXPECTED_TOKEN = { accessToken: "foo", tokenType: "Bearer" };
+
+describe("authApiExtra", () => {
+  const createAuthProvider = jest.fn(
+    (): AuthProvider => ({ withToken: ({ queryFn }) => queryFn(EXPECTED_TOKEN) }),
+  );
+  const queryFn = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should bypass authentication for unrelated actions and the other platform flag", async () => {
+    const listenerMiddleware = createListenerMiddleware<State>();
+    const { authProvider } = authApiExtra({
+      startListening: listenerMiddleware.startListening,
+      authFeatureId: "lwdAuth",
+      providerParams: undefined,
+      createAuthProvider,
+    });
+    const store = configureStore({
+      reducer: {
+        authEnvironment: authEnvironmentReducer,
+        featureFlags: featureFlagsReducer,
+      },
+      middleware: getDefaultMiddleware =>
+        getDefaultMiddleware().prepend(listenerMiddleware.middleware),
+    });
+
+    store.dispatch(setAuthEnvironment("PROD"));
+    store.dispatch(setOverride({ key: "lwmAuth", value: { enabled: true } }));
+    store.dispatch({ type: "unrelated/action" });
+
+    await authProvider.withToken({ queryFn });
+    expect(createAuthProvider).not.toHaveBeenCalled();
+    expect(queryFn).toHaveBeenCalledTimes(1);
+    expect(queryFn).toHaveBeenNthCalledWith(1);
+  });
+
+  it("should initialize, bypass, and reuse the provider as configuration changes", async () => {
+    const listenerMiddleware = createListenerMiddleware<State>();
+    const { authProvider } = authApiExtra({
+      startListening: listenerMiddleware.startListening,
+      authFeatureId: "lwdAuth",
+      providerParams: undefined,
+      createAuthProvider,
+    });
+    const store = configureStore({
+      reducer: {
+        authEnvironment: authEnvironmentReducer,
+        featureFlags: featureFlagsReducer,
+      },
+      middleware: getDefaultMiddleware =>
+        getDefaultMiddleware().prepend(listenerMiddleware.middleware),
+    });
+
+    store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: true } }));
+    expect(() => authProvider.withToken({ queryFn })).toThrow(AuthProviderUnavailableError);
+    expect(createAuthProvider).not.toHaveBeenCalled();
+    expect(queryFn).not.toHaveBeenCalled();
+
+    store.dispatch(setAuthEnvironment("PROD"));
+    await authProvider.withToken({ queryFn });
+    expect(createAuthProvider).toHaveBeenCalledTimes(1);
+    expect(createAuthProvider).toHaveBeenCalledWith("PROD", undefined);
+    expect(queryFn).toHaveBeenCalledTimes(1);
+    expect(queryFn).toHaveBeenNthCalledWith(1, EXPECTED_TOKEN);
+
+    store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: false } }));
+    await authProvider.withToken({ queryFn });
+    expect(createAuthProvider).toHaveBeenCalledTimes(1);
+    expect(queryFn).toHaveBeenCalledTimes(2);
+    expect(queryFn).toHaveBeenNthCalledWith(2);
+
+    store.dispatch(setAuthEnvironment("STAGING"));
+    store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: true } }));
+    await authProvider.withToken({ queryFn });
+    expect(createAuthProvider).toHaveBeenCalledTimes(1);
+    expect(queryFn).toHaveBeenCalledTimes(3);
+    expect(queryFn).toHaveBeenNthCalledWith(3, EXPECTED_TOKEN);
+  });
+
+  it("should create the provider when authentication is enabled after the environment is set", async () => {
+    const listenerMiddleware = createListenerMiddleware<State>();
+    const { authProvider } = authApiExtra({
+      startListening: listenerMiddleware.startListening,
+      authFeatureId: "lwdAuth",
+      providerParams: undefined,
+      createAuthProvider,
+    });
+    const store = configureStore({
+      reducer: {
+        authEnvironment: authEnvironmentReducer,
+        featureFlags: featureFlagsReducer,
+      },
+      middleware: getDefaultMiddleware =>
+        getDefaultMiddleware().prepend(listenerMiddleware.middleware),
+    });
+
+    store.dispatch(setAuthEnvironment("STAGING"));
+    store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: true } }));
+
+    await authProvider.withToken({ queryFn });
+    expect(createAuthProvider).toHaveBeenCalledTimes(1);
+    expect(createAuthProvider).toHaveBeenCalledWith("STAGING", undefined);
+    expect(queryFn).toHaveBeenCalledTimes(1);
+    expect(queryFn).toHaveBeenNthCalledWith(1, EXPECTED_TOKEN);
+  });
+});

--- a/shared/auth/src/api.ts
+++ b/shared/auth/src/api.ts
@@ -1,0 +1,61 @@
+import type { TypedStartListening } from "@reduxjs/toolkit";
+import { selectFeature, type FeatureId, type WithFeatureFlags } from "@shared/feature-flags";
+import {
+  authEnvironmentSelector,
+  setAuthEnvironment,
+  type AuthEnvironment,
+  type AuthEnvironmentState,
+} from "./data";
+import type { AuthProvider } from "./types";
+import { AuthProviderUnavailableError } from "./errors";
+
+export interface AuthApiExtra {
+  readonly authProvider: AuthProvider;
+}
+
+export type AuthFeatureId = Extract<FeatureId, "lwdAuth" | "lwmAuth">;
+
+export function authApiExtra<State extends StateWithAuthEnvironment, ProviderParams>({
+  startListening,
+  authFeatureId,
+  providerParams,
+  createAuthProvider,
+}: AuthApiExtraOptions<State, ProviderParams>): AuthApiExtra {
+  let authEnabled = false;
+  let provider: AuthProvider | undefined;
+
+  startListening({
+    predicate: action =>
+      action.type.startsWith("featureFlags/") || setAuthEnvironment.match(action),
+    effect(_action, listenerApi) {
+      const state = listenerApi.getState();
+      authEnabled = selectFeature(state, authFeatureId).enabled;
+      if (!authEnabled || provider) return;
+      const environment = authEnvironmentSelector(state);
+      if (environment) {
+        provider = createAuthProvider(environment, providerParams);
+      }
+    },
+  });
+
+  return {
+    authProvider: {
+      withToken(options) {
+        if (!authEnabled) return options.queryFn();
+        if (!provider) throw new AuthProviderUnavailableError();
+        return provider.withToken(options);
+      },
+    },
+  };
+}
+
+export interface AuthApiExtraOptions<State extends StateWithAuthEnvironment, ProviderParams> {
+  startListening: TypedStartListening<State>;
+  authFeatureId: AuthFeatureId;
+  providerParams: ProviderParams;
+  createAuthProvider(environment: AuthEnvironment, providerParams: ProviderParams): AuthProvider;
+}
+
+interface StateWithAuthEnvironment extends WithFeatureFlags {
+  authEnvironment: AuthEnvironmentState;
+}

--- a/shared/auth/src/createAuthenticatedBaseQuery.test.ts
+++ b/shared/auth/src/createAuthenticatedBaseQuery.test.ts
@@ -9,6 +9,8 @@ const API_BASE_URL = "https://api.ledger.test";
 
 describe("createAuthenticatedBaseQuery", () => {
   const withToken = jest.fn();
+  const retryPredicateError = new Error("Retry predicate failed");
+  const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
   const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
 
   // Setup RTK API
@@ -32,6 +34,29 @@ describe("createAuthenticatedBaseQuery", () => {
           url: "/private",
           headers: { "x-custom-header": "request-value" },
         }),
+      }),
+      gatedQueryWithValidatedStatus: build.query<{ ok: boolean }, void>({
+        query: () => ({
+          url: "/private",
+          validateStatus: () => true,
+        }),
+      }),
+      gatedQueryWithValidatedStatusAndCustomRetry: build.query<{ ok: boolean }, void>({
+        query: () => ({
+          url: "/private",
+          validateStatus: () => true,
+        }),
+        extraOptions: {
+          refreshAndRetryWhen: result => result.meta?.response?.status === 401,
+        },
+      }),
+      gatedQueryWithThrowingRetry: build.query<{ ok: boolean }, void>({
+        query: () => "/private",
+        extraOptions: {
+          refreshAndRetryWhen() {
+            throw retryPredicateError;
+          },
+        },
       }),
     }),
   });
@@ -67,7 +92,13 @@ describe("createAuthenticatedBaseQuery", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    withToken.mockReset();
+    withToken.mockReset().mockImplementation(async ({ queryFn, refreshAndRetryWhen }) => {
+      const result = await queryFn({ tokenType: "Bearer", accessToken: "access-token" });
+      return refreshAndRetryWhen?.(result)
+        ? queryFn({ tokenType: "Bearer", accessToken: "refreshed-token" })
+        : result;
+    });
+
     store.dispatch(api.util.resetApiState());
 
     endpoints.public.mockReturnValue(HttpResponse.json({ ok: true }));
@@ -79,6 +110,7 @@ describe("createAuthenticatedBaseQuery", () => {
   });
 
   afterAll(() => {
+    consoleErrorSpy.mockRestore();
     consoleWarnSpy.mockRestore();
     server.close();
   });
@@ -98,10 +130,6 @@ describe("createAuthenticatedBaseQuery", () => {
   });
 
   it("preserves request headers while appending authorization by default", async () => {
-    withToken.mockImplementation(({ queryFn }) =>
-      queryFn({ tokenType: "Bearer", accessToken: "access-token" }),
-    );
-
     const { status, data, error } = await store.dispatch(
       api.endpoints.gatedQueryWithHeader.initiate(),
     );
@@ -118,13 +146,6 @@ describe("createAuthenticatedBaseQuery", () => {
   });
 
   it("refreshes the token and retries once on 401", async () => {
-    withToken.mockImplementation(async ({ queryFn, refreshAndRetryWhen }) => {
-      const result = await queryFn({ tokenType: "Bearer", accessToken: "stale-token" });
-      return refreshAndRetryWhen?.(result)
-        ? queryFn({ tokenType: "Bearer", accessToken: "fresh-token" })
-        : result;
-    });
-
     endpoints.private
       .mockReturnValueOnce(HttpResponse.json({ ok: false }, { status: 401 }))
       .mockReturnValueOnce(HttpResponse.json({ ok: true }));
@@ -137,20 +158,13 @@ describe("createAuthenticatedBaseQuery", () => {
 
     expect(endpoints.private).toHaveBeenCalledTimes(2);
     const firstRequest = endpoints.private.mock.calls[0][0].request;
-    expect(firstRequest.headers.get("authorization")).toBe("Bearer stale-token");
+    expect(firstRequest.headers.get("authorization")).toBe("Bearer access-token");
     const secondRequest = endpoints.private.mock.calls[1][0].request;
-    expect(secondRequest.headers.get("authorization")).toBe("Bearer fresh-token");
+    expect(secondRequest.headers.get("authorization")).toBe("Bearer refreshed-token");
     expect(authProvider.withToken).toHaveBeenCalledTimes(1);
   });
 
   it("does not refresh or retry non-401 failures", async () => {
-    withToken.mockImplementation(async ({ queryFn, refreshAndRetryWhen }) => {
-      const result = await queryFn({ tokenType: "Bearer", accessToken: "access-token" });
-      return refreshAndRetryWhen?.(result)
-        ? queryFn({ tokenType: "Bearer", accessToken: "refreshed-token" })
-        : result;
-    });
-
     endpoints.private.mockReturnValueOnce(HttpResponse.json({ ok: true }, { status: 500 }));
 
     const { status, data, error } = await store.dispatch(api.endpoints.gatedQuery.initiate());
@@ -161,6 +175,66 @@ describe("createAuthenticatedBaseQuery", () => {
 
     expect(endpoints.private).toHaveBeenCalledTimes(1);
     expect(authProvider.withToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a 401 accepted by validateStatus by default", async () => {
+    endpoints.private.mockReturnValueOnce(HttpResponse.json({ ok: false }, { status: 401 }));
+
+    const { status, data, error } = await store.dispatch(
+      api.endpoints.gatedQueryWithValidatedStatus.initiate(),
+    );
+
+    expect(status).toBe("fulfilled");
+    expect(data).toEqual({ ok: false });
+    expect(error).toBe(undefined);
+    expect(endpoints.private).toHaveBeenCalledTimes(1);
+    expect(endpoints.private.mock.calls[0][0].request.headers.get("authorization")).toBe(
+      "Bearer access-token",
+    );
+    expect(authProvider.withToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a custom predicate to retry a 401 accepted by validateStatus", async () => {
+    endpoints.private
+      .mockReturnValueOnce(HttpResponse.json({ ok: false }, { status: 401 }))
+      .mockReturnValueOnce(HttpResponse.json({ ok: true }));
+
+    const { status, data, error } = await store.dispatch(
+      api.endpoints.gatedQueryWithValidatedStatusAndCustomRetry.initiate(),
+    );
+
+    expect(status).toBe("fulfilled");
+    expect(data).toEqual({ ok: true });
+    expect(error).toBe(undefined);
+    expect(endpoints.private).toHaveBeenCalledTimes(2);
+    expect(endpoints.private.mock.calls[0][0].request.headers.get("authorization")).toBe(
+      "Bearer access-token",
+    );
+    expect(endpoints.private.mock.calls[1][0].request.headers.get("authorization")).toBe(
+      "Bearer refreshed-token",
+    );
+    expect(authProvider.withToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the original authenticated response when a custom predicate throws", async () => {
+    endpoints.private.mockReturnValueOnce(HttpResponse.json({ ok: false }, { status: 401 }));
+
+    const { status, data, error } = await store.dispatch(
+      api.endpoints.gatedQueryWithThrowingRetry.initiate(),
+    );
+
+    expect(status).toBe("rejected");
+    expect(data).toBe(undefined);
+    expect(error).toHaveProperty("status", 401);
+    expect(endpoints.private).toHaveBeenCalledTimes(1);
+    expect(endpoints.private.mock.calls[0][0].request.headers.get("authorization")).toBe(
+      "Bearer access-token",
+    );
+    expect(authProvider.withToken).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "AuthenticatedBaseQuery retry predicate failed:",
+      retryPredicateError,
+    );
   });
 
   it("performs one unauthenticated request when the provider does not supply a token", async () => {

--- a/shared/auth/src/createAuthenticatedBaseQuery.test.ts
+++ b/shared/auth/src/createAuthenticatedBaseQuery.test.ts
@@ -9,6 +9,7 @@ const API_BASE_URL = "https://api.ledger.test";
 
 describe("createAuthenticatedBaseQuery", () => {
   const withToken = jest.fn();
+  const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
 
   // Setup RTK API
   const api = createApi({
@@ -36,7 +37,7 @@ describe("createAuthenticatedBaseQuery", () => {
   });
 
   // Setup Redux store
-  const authSDK: AuthProvider = { withToken };
+  const authProvider: AuthProvider = { withToken };
   const store = configureStore({
     reducer: {
       [api.reducerPath]: api.reducer,
@@ -44,7 +45,7 @@ describe("createAuthenticatedBaseQuery", () => {
     middleware: getDefaultMiddleware =>
       getDefaultMiddleware({
         thunk: {
-          extraArgument: { authSDK },
+          extraArgument: { authProvider },
         },
       }).concat(api.middleware),
   });
@@ -78,6 +79,7 @@ describe("createAuthenticatedBaseQuery", () => {
   });
 
   afterAll(() => {
+    consoleWarnSpy.mockRestore();
     server.close();
   });
 
@@ -92,7 +94,7 @@ describe("createAuthenticatedBaseQuery", () => {
     const request = endpoints.public.mock.calls[0][0].request;
     expect(request.headers.get("authorization")).toBeNull();
     expect(request.headers.get("x-custom-header")).toBeNull();
-    expect(authSDK.withToken).not.toHaveBeenCalled();
+    expect(authProvider.withToken).not.toHaveBeenCalled();
   });
 
   it("preserves request headers while appending authorization by default", async () => {
@@ -112,7 +114,7 @@ describe("createAuthenticatedBaseQuery", () => {
     const request = endpoints.private.mock.calls[0][0].request;
     expect(request.headers.get("authorization")).toBe("Bearer access-token");
     expect(request.headers.get("x-custom-header")).toBe("request-value");
-    expect(authSDK.withToken).toHaveBeenCalledTimes(1);
+    expect(authProvider.withToken).toHaveBeenCalledTimes(1);
   });
 
   it("refreshes the token and retries once on 401", async () => {
@@ -138,7 +140,7 @@ describe("createAuthenticatedBaseQuery", () => {
     expect(firstRequest.headers.get("authorization")).toBe("Bearer stale-token");
     const secondRequest = endpoints.private.mock.calls[1][0].request;
     expect(secondRequest.headers.get("authorization")).toBe("Bearer fresh-token");
-    expect(authSDK.withToken).toHaveBeenCalledTimes(1);
+    expect(authProvider.withToken).toHaveBeenCalledTimes(1);
   });
 
   it("does not refresh or retry non-401 failures", async () => {
@@ -158,64 +160,68 @@ describe("createAuthenticatedBaseQuery", () => {
     expect(error).toHaveProperty("status", 500);
 
     expect(endpoints.private).toHaveBeenCalledTimes(1);
-    expect(authSDK.withToken).toHaveBeenCalledTimes(1);
+    expect(authProvider.withToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("performs one unauthenticated request when the provider does not supply a token", async () => {
+    withToken.mockImplementation(({ queryFn }) => queryFn());
+
+    const { status, data, error } = await store.dispatch(api.endpoints.gatedQuery.initiate());
+
+    expect(status).toBe("fulfilled");
+    expect(data).toEqual({ ok: true });
+    expect(error).toBe(undefined);
+    expect(endpoints.private).toHaveBeenCalledTimes(1);
+    expect(endpoints.private.mock.calls[0][0].request.headers.get("authorization")).toBeNull();
+    expect(authProvider.withToken).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
   it("falls back to an unauthenticated request when authentication fails", async () => {
     const authenticationError = new Error("Authentication failed");
-    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
     withToken.mockImplementation(() => Promise.reject(authenticationError));
 
-    try {
-      const { status, data, error } = await store.dispatch(api.endpoints.gatedQuery.initiate());
+    const { status, data, error } = await store.dispatch(api.endpoints.gatedQuery.initiate());
 
-      expect(status).toBe("fulfilled");
-      expect(data).toEqual({ ok: true });
-      expect(error).toBe(undefined);
+    expect(status).toBe("fulfilled");
+    expect(data).toEqual({ ok: true });
+    expect(error).toBe(undefined);
 
-      expect(endpoints.private).toHaveBeenCalledTimes(1);
-      const request = endpoints.private.mock.calls[0][0].request;
-      expect(request.headers.get("authorization")).toBeNull();
-      expect(authSDK.withToken).toHaveBeenCalledTimes(1);
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        "AuthenticatedBaseQuery failed to authenticate:",
-        authenticationError,
-      );
-    } finally {
-      consoleWarnSpy.mockRestore();
-    }
+    expect(endpoints.private).toHaveBeenCalledTimes(1);
+    const request = endpoints.private.mock.calls[0][0].request;
+    expect(request.headers.get("authorization")).toBeNull();
+    expect(authProvider.withToken).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "AuthenticatedBaseQuery failed to authenticate:",
+      authenticationError,
+    );
   });
 
-  it("falls back to an unauthenticated request when AuthSDK is missing", async () => {
-    const storeWithoutAuthSDK = configureStore({
+  it("falls back to an unauthenticated request when the auth provider is missing", async () => {
+    const storeWithoutAuthProvider = configureStore({
       reducer: {
         [api.reducerPath]: api.reducer,
       },
       middleware: getDefaultMiddleware => getDefaultMiddleware().concat(api.middleware),
     });
-    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
 
-    try {
-      const { status, data, error } = await storeWithoutAuthSDK.dispatch(
-        api.endpoints.gatedQuery.initiate(),
-      );
+    const { status, data, error } = await storeWithoutAuthProvider.dispatch(
+      api.endpoints.gatedQuery.initiate(),
+    );
 
-      expect(status).toBe("fulfilled");
-      expect(data).toEqual({ ok: true });
-      expect(error).toBe(undefined);
-      expect(authSDK.withToken).not.toHaveBeenCalled();
-      expect(endpoints.private).toHaveBeenCalledTimes(1);
-      const request = endpoints.private.mock.calls[0][0].request;
-      expect(request.headers.get("authorization")).toBeNull();
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        "AuthenticatedBaseQuery failed to authenticate:",
-        expect.objectContaining({
-          name: "AuthenticatedBaseQueryMissingAuthSDKError",
-          message: "Authenticated base query requires api.extra.authSDK",
-        }),
-      );
-    } finally {
-      consoleWarnSpy.mockRestore();
-    }
+    expect(status).toBe("fulfilled");
+    expect(data).toEqual({ ok: true });
+    expect(error).toBe(undefined);
+    expect(authProvider.withToken).not.toHaveBeenCalled();
+    expect(endpoints.private).toHaveBeenCalledTimes(1);
+    const request = endpoints.private.mock.calls[0][0].request;
+    expect(request.headers.get("authorization")).toBeNull();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "AuthenticatedBaseQuery failed to authenticate:",
+      expect.objectContaining({
+        name: "AuthProviderMissingError",
+        message: "Authenticated base query requires api.extra.authProvider",
+      }),
+    );
   });
 });

--- a/shared/auth/src/createAuthenticatedBaseQuery.ts
+++ b/shared/auth/src/createAuthenticatedBaseQuery.ts
@@ -25,7 +25,7 @@ export function createAuthenticatedBaseQuery(baseQueryArgs: FetchBaseQueryArgs):
     if (extraOptions?.authenticated !== false) {
       try {
         return await getAuthProvider(api.extra).withToken({
-          queryFn: async token => {
+          async queryFn(token) {
             if (!token) {
               return fetchBaseQuery(baseQueryArgs)(args, api, extraOptions);
             }
@@ -40,10 +40,21 @@ export function createAuthenticatedBaseQuery(baseQueryArgs: FetchBaseQueryArgs):
             })(args, api, extraOptions);
           },
 
-          refreshAndRetryWhen: result =>
-            !!result.error &&
-            typeof result.error?.status === "number" &&
-            UNAUTHORIZED_STATUSES.has(result.error.status),
+          refreshAndRetryWhen(result) {
+            if (extraOptions?.refreshAndRetryWhen) {
+              try {
+                return extraOptions.refreshAndRetryWhen(result);
+              } catch (error) {
+                console?.error("AuthenticatedBaseQuery retry predicate failed:", error);
+                return false;
+              }
+            }
+            return (
+              !!result.error &&
+              typeof result.error?.status === "number" &&
+              UNAUTHORIZED_STATUSES.has(result.error.status)
+            );
+          },
         });
       } catch (error) {
         // Authentication failed; fall back to an unauthenticated request.

--- a/shared/auth/src/createAuthenticatedBaseQuery.ts
+++ b/shared/auth/src/createAuthenticatedBaseQuery.ts
@@ -5,7 +5,7 @@ import {
   type FetchBaseQueryArgs,
   type FetchBaseQueryError,
 } from "@reduxjs/toolkit/query";
-import { AuthenticatedBaseQueryMissingAuthSDKError } from "./errors";
+import { AuthProviderMissingError } from "./errors";
 import {
   AuthenticatedBaseQueryExtraSchema,
   type AuthenticatedBaseQueryExtraOptions,
@@ -24,9 +24,12 @@ export function createAuthenticatedBaseQuery(baseQueryArgs: FetchBaseQueryArgs):
   return async (args, api, extraOptions) => {
     if (extraOptions?.authenticated !== false) {
       try {
-        return await getAuthSDK(api.extra).withToken({
-          queryFn: async token =>
-            fetchBaseQuery({
+        return await getAuthProvider(api.extra).withToken({
+          queryFn: async token => {
+            if (!token) {
+              return fetchBaseQuery(baseQueryArgs)(args, api, extraOptions);
+            }
+            return fetchBaseQuery({
               ...baseQueryArgs,
               async prepareHeaders(headers, baseQueryApi) {
                 const preparedHeaders =
@@ -34,7 +37,8 @@ export function createAuthenticatedBaseQuery(baseQueryArgs: FetchBaseQueryArgs):
                 preparedHeaders.set("authorization", `${token.tokenType} ${token.accessToken}`);
                 return preparedHeaders;
               },
-            })(args, api, extraOptions),
+            })(args, api, extraOptions);
+          },
 
           refreshAndRetryWhen: result =>
             !!result.error &&
@@ -51,10 +55,10 @@ export function createAuthenticatedBaseQuery(baseQueryArgs: FetchBaseQueryArgs):
   };
 }
 
-function getAuthSDK(extra: unknown) {
+function getAuthProvider(extra: unknown) {
   try {
-    return AuthenticatedBaseQueryExtraSchema.parse(extra).authSDK;
+    return AuthenticatedBaseQueryExtraSchema.parse(extra).authProvider;
   } catch {
-    throw new AuthenticatedBaseQueryMissingAuthSDKError();
+    throw new AuthProviderMissingError();
   }
 }

--- a/shared/auth/src/data/index.ts
+++ b/shared/auth/src/data/index.ts
@@ -1,0 +1,1 @@
+export * from "./slice";

--- a/shared/auth/src/data/slice.test.ts
+++ b/shared/auth/src/data/slice.test.ts
@@ -1,0 +1,20 @@
+import { authEnvironmentReducer, authEnvironmentSelector, setAuthEnvironment } from "./slice";
+
+describe("auth environment", () => {
+  it("should initialize without an environment", () => {
+    expect(authEnvironmentReducer(undefined, { type: "unknown" })).toBeNull();
+  });
+
+  it("should replace the current environment", () => {
+    const stagingState = authEnvironmentReducer(undefined, setAuthEnvironment("STAGING"));
+    const prodState = authEnvironmentReducer(stagingState, setAuthEnvironment("PROD"));
+
+    expect(prodState).toBe("PROD");
+    expect(authEnvironmentSelector({ authEnvironment: prodState })).toBe("PROD");
+  });
+
+  it("should match generated environment actions", () => {
+    expect(setAuthEnvironment.match(setAuthEnvironment("STAGING"))).toBe(true);
+    expect(setAuthEnvironment.match({ type: "unknown" })).toBe(false);
+  });
+});

--- a/shared/auth/src/data/slice.ts
+++ b/shared/auth/src/data/slice.ts
@@ -1,0 +1,28 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+
+export type AuthEnvironment = "STAGING" | "PROD";
+export type AuthEnvironmentState = AuthEnvironment | null;
+
+const getInitialState = (): AuthEnvironmentState => null;
+
+/**
+ * Temporary bridge between Wallet Sync components that resolve service environments independently.
+ * The process-lifetime Trustchain SDK and cached auth provider capture API URLs when created, so
+ * auth must currently reuse the environment selected by the first Trustchain SDK instance.
+ * Remove once Wallet Sync has a unified environment source and long-lived SDK/provider instances
+ * can be recreated or reconfigured dynamically.
+ */
+const authEnvironmentSlice = createSlice({
+  name: "authEnvironment",
+  initialState: getInitialState(),
+  reducers: {
+    setAuthEnvironment: (_state, action: PayloadAction<AuthEnvironment>) => action.payload,
+  },
+  selectors: {
+    authEnvironmentSelector: state => state,
+  },
+});
+
+export const { setAuthEnvironment } = authEnvironmentSlice.actions;
+export const { authEnvironmentSelector } = authEnvironmentSlice.selectors;
+export const authEnvironmentReducer = authEnvironmentSlice.reducer;

--- a/shared/auth/src/errors.ts
+++ b/shared/auth/src/errors.ts
@@ -1,7 +1,15 @@
-export class AuthenticatedBaseQueryMissingAuthSDKError extends Error {
-  override name = "AuthenticatedBaseQueryMissingAuthSDKError";
+export class AuthProviderMissingError extends Error {
+  override name = "AuthProviderMissingError";
 
   constructor() {
-    super("Authenticated base query requires api.extra.authSDK");
+    super("Authenticated base query requires api.extra.authProvider");
+  }
+}
+
+export class AuthProviderUnavailableError extends Error {
+  override name = "AuthProviderUnavailableError";
+
+  constructor() {
+    super("Authentication is enabled but no auth provider is available");
   }
 }

--- a/shared/auth/src/index.ts
+++ b/shared/auth/src/index.ts
@@ -1,5 +1,22 @@
+export {
+  authApiExtra,
+  type AuthApiExtra,
+  type AuthApiExtraOptions,
+  type AuthFeatureId,
+} from "./api";
+
 export { createAuthenticatedBaseQuery } from "./createAuthenticatedBaseQuery";
-export { AuthenticatedBaseQueryMissingAuthSDKError } from "./errors";
+
+export * from "./errors";
+
+export {
+  authEnvironmentReducer,
+  authEnvironmentSelector,
+  setAuthEnvironment,
+  type AuthEnvironment,
+  type AuthEnvironmentState,
+} from "./data";
+
 export type {
   AuthenticatedBaseQueryExtraOptions,
   AuthProvider,

--- a/shared/auth/src/types.ts
+++ b/shared/auth/src/types.ts
@@ -10,7 +10,7 @@ export type AuthToken = {
 };
 
 export type WithTokenOptions<T> = {
-  queryFn: (token: AuthToken) => Promise<T>;
+  queryFn: (token?: AuthToken) => Promise<T>;
   refreshAndRetryWhen?: (result: T) => boolean;
 };
 
@@ -26,5 +26,5 @@ const AuthProviderSchema = z.custom<AuthProvider>(
     typeof value.withToken === "function",
 );
 export const AuthenticatedBaseQueryExtraSchema = z.object({
-  authSDK: AuthProviderSchema,
+  authProvider: AuthProviderSchema,
 });

--- a/shared/auth/src/types.ts
+++ b/shared/auth/src/types.ts
@@ -1,7 +1,15 @@
+import type {
+  FetchBaseQueryError,
+  FetchBaseQueryMeta,
+  QueryReturnValue,
+} from "@reduxjs/toolkit/query";
 import { z } from "zod";
 
 export type AuthenticatedBaseQueryExtraOptions = {
   authenticated?: boolean;
+  refreshAndRetryWhen?: (
+    result: QueryReturnValue<unknown, FetchBaseQueryError, FetchBaseQueryMeta>,
+  ) => boolean;
 };
 
 export type AuthToken = {

--- a/shared/env/src/definitions/team-platform/index.ts
+++ b/shared/env/src/definitions/team-platform/index.ts
@@ -97,6 +97,26 @@ const teamPlatform = {
     parser: stringParser,
     desc: "Trustchain API Prod",
   },
+  LEDGER_AUTH_KEYCLOAK_BASE_URL_STAGING: {
+    def: "https://keycloak.api.live.aws.stg.ldg-tech.com",
+    parser: stringParser,
+    desc: "Keycloak base URL for Ledger authenticated APIs (staging)",
+  },
+  LEDGER_AUTH_KEYCLOAK_BASE_URL_PROD: {
+    def: "https://global.api.prd.ledger.com/keycloak",
+    parser: stringParser,
+    desc: "Keycloak base URL for Ledger authenticated APIs (production)",
+  },
+  LEDGER_AUTH_KEYCLOAK_REALM: {
+    def: "ledger-bc-customers",
+    parser: stringParser,
+    desc: "Keycloak realm for Ledger authenticated APIs",
+  },
+  LEDGER_AUTH_CLIENT_ID: {
+    def: "ledger-keycloak",
+    parser: stringParser,
+    desc: "Keycloak client ID for Ledger authenticated APIs",
+  },
 };
 
 export default teamPlatform;

--- a/shared/feature-flags/src/flags/team-platform/index.ts
+++ b/shared/feature-flags/src/flags/team-platform/index.ts
@@ -7,6 +7,8 @@ export * from "./llmLedgerSyncEntryPoints";
 export * from "./llmMmkvMigration";
 export * from "./llmSentry";
 export * from "./llmWalletSync";
+export * from "./lwdAuth";
+export * from "./lwmAuth";
 export * from "./lwdLedgerSyncOptimisation";
 export * from "./lwmLedgerSyncOptimisation";
 export * from "./mixpanelAnalytics";

--- a/shared/feature-flags/src/flags/team-platform/lwdAuth.ts
+++ b/shared/feature-flags/src/flags/team-platform/lwdAuth.ts
@@ -1,0 +1,3 @@
+import { flag } from "../../define";
+
+export const lwdAuth = flag({ enabled: false });

--- a/shared/feature-flags/src/flags/team-platform/lwmAuth.ts
+++ b/shared/feature-flags/src/flags/team-platform/lwmAuth.ts
@@ -1,0 +1,3 @@
+import { flag } from "../../define";
+
+export const lwmAuth = flag({ enabled: false });


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Make the RTK query adapter from #18790 usable on LWD and LWM by:
- providing a valid `api.extra.authProvider`.
- by populating the store `trustchain.memberCredentials` on first launch.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-31621] <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-31621]: https://ledgerhq.atlassian.net/browse/LIVE-31621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ