### PR TITLE
[LWDM] Implement readiness attribute in Accounts + link to Tezos revealed status

### DIFF
--- a/.changeset/tezos-account-readiness.md
+++ b/.changeset/tezos-account-readiness.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/types-live": minor
+"@ledgerhq/ledger-wallet-framework": minor
+"@ledgerhq/live-common": minor
+---
+
+Add an optional `readiness` attribute to the base `Account` type (`{ ready: boolean; reason?: string }`), a generic cross-chain projection of whether an account is fully operational. It is persisted through account serialization and populated during sync via a new optional `BridgeApi.getAccountReadiness` hook. Tezos implements the hook: an account whose public key is not revealed on-chain is reported as `{ ready: false, reason: "unrevealed" }`. Families that do not provide the hook leave `readiness` undefined.

--- a/.changeset/tezos-account-readiness.md
+++ b/.changeset/tezos-account-readiness.md
@@ -2,6 +2,7 @@
 "@ledgerhq/types-live": minor
 "@ledgerhq/ledger-wallet-framework": minor
 "@ledgerhq/live-common": minor
+"@ledgerhq/coin-tezos": patch
 ---
 
-Add an optional `readiness` attribute to the base `Account` type (`{ ready: boolean; reason?: string }`), a generic cross-chain projection of whether an account is fully operational. It is persisted through account serialization and populated during sync via a new optional `BridgeApi.getAccountReadiness` hook. Tezos implements the hook: an account whose public key is not revealed on-chain is reported as `{ ready: false, reason: "unrevealed" }`. Families that do not provide the hook leave `readiness` undefined.
+Add an optional `readiness` attribute to the base `Account` type (`{ ready: boolean; reason?: string }`), a generic cross-chain projection of whether an account is fully operational. It is persisted through account serialization and populated during sync via a new optional `BridgeApi.getAccountReadiness` hook. Tezos implements the hook: an account whose public key is not revealed on-chain is reported as `{ ready: false, reason: "unrevealed" }`. Families that do not provide the hook leave `readiness` undefined. coin-tezos `getAccountByAddress` now coalesces concurrent same-address calls into a single request, so surfacing readiness during sync adds no redundant tzkt call.

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.test.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.test.ts
@@ -173,6 +173,20 @@ describe("tzkt network API", () => {
         }),
       );
     });
+
+    it("coalesces concurrent calls for the same address into a single request", async () => {
+      const account = { type: "user", address: "tz1dup", revealed: true } as APIAccount;
+      mockedNetwork.mockReturnValue(networkResponse(account) as ReturnType<typeof network>);
+
+      const [first, second] = await Promise.all([
+        api.getAccountByAddress("tz1dup"),
+        api.getAccountByAddress("tz1dup"),
+      ]);
+
+      expect(first).toEqual(account);
+      expect(second).toBe(first);
+      expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.ts
@@ -26,6 +26,13 @@ const ID_IN_CHUNK_SIZE = 100;
 
 const getExplorerUrl = () => coinConfig.getCoinConfig().explorer.url;
 
+/**
+ * Coalesces concurrent `getAccountByAddress` calls for the same explorer+address into a
+ * single request. During a sync both `getBalance` and the readiness hook hit this endpoint
+ * in the same tick; the in-flight promise is dropped on settle, so there is no staleness.
+ */
+const accountByAddressInflight = new Map<string, Promise<APIAccount>>();
+
 const clearUndefined = (obj: Record<string, unknown>) => {
   const newObj = { ...obj };
   Object.entries(newObj).forEach(([key, value]) => value === undefined && delete newObj[key]);
@@ -91,10 +98,16 @@ const api = {
     };
   },
   async getAccountByAddress(address: string): Promise<APIAccount> {
-    const { data } = await network<APIAccount>({
+    const key = `${getExplorerUrl()}|${address}`;
+    const existing = accountByAddressInflight.get(key);
+    if (existing) return existing;
+    const request = network<APIAccount>({
       url: `${getExplorerUrl()}/v1/accounts/${address}`,
-    });
-    return data;
+    })
+      .then(({ data }) => data)
+      .finally(() => accountByAddressInflight.delete(key));
+    accountByAddressInflight.set(key, request);
+    return request;
   },
 
   /**

--- a/libs/ledger-live-common/src/account/serialization.test.ts
+++ b/libs/ledger-live-common/src/account/serialization.test.ts
@@ -41,4 +41,26 @@ describe("serialization", () => {
     const deserializedAcc: any = await fromAccountRaw(accRaw);
     expect(deserializedAcc.subAccounts?.[0]?.state).toBe("initialized");
   });
+
+  test("account readiness should be serialized/deserialized", async () => {
+    const acc: any = genAccount("mocked-account-readiness", { currency: Solana });
+    acc.readiness = { ready: false, reason: "unrevealed" };
+
+    const accRaw: any = await toAccountRaw(acc);
+    expect(accRaw.readiness).toEqual({ ready: false, reason: "unrevealed" });
+
+    const deserializedAcc: any = await fromAccountRaw(accRaw);
+    expect(deserializedAcc.readiness).toEqual({ ready: false, reason: "unrevealed" });
+  });
+
+  test("account without readiness stays undefined through serialization", async () => {
+    const acc: any = genAccount("mocked-account-no-readiness", { currency: Solana });
+    delete acc.readiness;
+
+    const accRaw: any = await toAccountRaw(acc);
+    expect(accRaw.readiness).toBeUndefined();
+
+    const deserializedAcc: any = await fromAccountRaw(accRaw);
+    expect(deserializedAcc.readiness).toBeUndefined();
+  });
 });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
@@ -568,6 +568,8 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
       subAccounts,
       operationsCount: operations.length,
       syncHash,
+      // key omitted rather than set to undefined: jsHelpers merges `{ ...a, ...shape }`, so a failed
+      // readiness lookup retains the last persisted value instead of clearing it.
       ...(readiness !== undefined ? { readiness } : {}),
       ...stakingShape,
     };

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
@@ -360,7 +360,12 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
       : Promise.resolve([]);
 
     const readinessPromise: Promise<AccountReadiness | undefined> = bridgeApi.getAccountReadiness
-      ? bridgeApi.getAccountReadiness(currency, address).catch(() => undefined)
+      ? bridgeApi.getAccountReadiness(currency, address).catch(e => {
+          log("generic-coin-framework", "getAccountReadiness failed, leaving readiness undefined", {
+            error: e instanceof Error ? e.message : String(e),
+          });
+          return undefined;
+        })
       : Promise.resolve(undefined);
 
     const [blockInfo, balanceRes, validators, readiness] = await Promise.all([

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
@@ -13,6 +13,7 @@ import type { Balance, Operation, Stake } from "@ledgerhq/coin-module-framework/
 import type { OperationCommon } from "./types";
 import type {
   Account,
+  AccountReadiness,
   StakingDelegation,
   StakingResources,
   StakingUnbonding,
@@ -358,10 +359,15 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
           .catch(() => [])
       : Promise.resolve([]);
 
-    const [blockInfo, balanceRes, validators] = await Promise.all([
+    const readinessPromise: Promise<AccountReadiness | undefined> = bridgeApi.getAccountReadiness
+      ? bridgeApi.getAccountReadiness(currency, address).catch(() => undefined)
+      : Promise.resolve(undefined);
+
+    const [blockInfo, balanceRes, validators, readiness] = await Promise.all([
       coinModuleApi.lastBlock(),
       coinModuleApi.getBalance(address, bridgeApi.balanceOptions),
       validatorsPromise,
+      readinessPromise,
     ]);
 
     const nativeAsset = extractBalance(balanceRes, "native");
@@ -557,6 +563,7 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
       subAccounts,
       operationsCount: operations.length,
       syncHash,
+      ...(readiness !== undefined ? { readiness } : {}),
       ...stakingShape,
     };
     return res;

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
@@ -78,6 +78,48 @@ describe("genericGetAccountShape", () => {
     jest.clearAllMocks();
   });
 
+  describe("readiness", () => {
+    const network = "mainnet";
+    const currency = { id: "tezos", name: "Tezos" };
+
+    beforeEach(() => {
+      getSyncHashMock.mockReturnValue("sync-hash");
+      getBalanceMock.mockResolvedValue([{ asset: { type: "native" }, value: 0n, locked: 0n }]);
+      extractBalanceMock.mockReturnValue({ value: 0n, locked: 0n });
+      listOperationsMock.mockResolvedValue({ items: [], next: undefined });
+      buildSubAccountsMock.mockReturnValue([]);
+      lastBlockMock.mockResolvedValue({ height: 0 });
+      mergeOpsMock.mockImplementation((_old: any[], newOps: any[]) => newOps ?? []);
+      cleanedOperationMock.mockImplementation((op: any) => op);
+      inferSubOperationsMock.mockReturnValue([]);
+    });
+
+    test("sets account.readiness from bridgeApi.getAccountReadiness", async () => {
+      getBridgeApiMock.mockImplementationOnce(() => ({
+        ...defaultBridgeApi(),
+        getAccountReadiness: async () => ({ ready: false, reason: "unrevealed" }),
+      }));
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        { address: "tz1ready", initialAccount: undefined, currency, derivationMode: "" } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect((result as any).readiness).toEqual({ ready: false, reason: "unrevealed" });
+    });
+
+    test("leaves readiness undefined when the bridge has no getAccountReadiness hook", async () => {
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        { address: "tz1noready", initialAccount: undefined, currency, derivationMode: "" } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect((result as any).readiness).toBeUndefined();
+    });
+  });
+
   describe.each(chains)("$currency.id", ({ currency, network }) => {
     test.each([
       [

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
@@ -118,6 +118,23 @@ describe("genericGetAccountShape", () => {
 
       expect((result as any).readiness).toBeUndefined();
     });
+
+    test("leaves readiness undefined when getAccountReadiness rejects", async () => {
+      getBridgeApiMock.mockImplementationOnce(() => ({
+        ...defaultBridgeApi(),
+        getAccountReadiness: async () => {
+          throw new Error("boom");
+        },
+      }));
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        { address: "tz1boom", initialAccount: undefined, currency, derivationMode: "" } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect((result as any).readiness).toBeUndefined();
+    });
   });
 
   describe.each(chains)("$currency.id", ({ currency, network }) => {

--- a/libs/ledger-live-common/src/families/tezos/bridge/api.test.ts
+++ b/libs/ledger-live-common/src/families/tezos/bridge/api.test.ts
@@ -1,8 +1,21 @@
 import { setCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
-import { CryptoCurrencyIdSchema } from "@domain/entity-currency-crypto";
+import { CryptoCurrencyIdSchema, getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@domain/entity-currency-token";
 import { TokenCurrencyIdSchema } from "@domain/entity-currency-token";
-import { computeIntentType, getAssetFromToken, getTokenFromAsset } from "./api";
+import {
+  computeIntentType,
+  getAccountReadiness,
+  getAssetFromToken,
+  getTokenFromAsset,
+} from "./api";
+
+const getAccountInfoMock = jest.fn();
+jest.mock("@ledgerhq/coin-tezos/api/index", () => ({
+  createApi: () => ({ getAccountInfo: getAccountInfoMock }),
+}));
+jest.mock("../../../config", () => ({
+  getCurrencyConfiguration: () => ({}),
+}));
 
 beforeAll(() => {
   const mockStore: Parameters<typeof setCryptoAssetsStore>[0] = {
@@ -207,5 +220,28 @@ describe("generic-coin-framework Tezos token", () => {
       const resolved = await getTokenFromAsset(asset);
       expect(resolved?.id).toBe(token.id);
     });
+  });
+});
+
+describe("getAccountReadiness", () => {
+  const currency = getCryptoCurrencyById("tezos");
+
+  afterEach(() => {
+    getAccountInfoMock.mockReset();
+  });
+
+  it("is ready when the account is revealed", async () => {
+    getAccountInfoMock.mockResolvedValueOnce({ type: "tezos", revealed: true });
+    await expect(getAccountReadiness(currency, "tz1revealed")).resolves.toEqual({ ready: true });
+    expect(getAccountInfoMock).toHaveBeenCalledWith("tz1revealed");
+  });
+
+  it("is not ready with reason 'unrevealed' when the account is not revealed", async () => {
+    getAccountInfoMock.mockResolvedValueOnce({ type: "tezos", revealed: false });
+    await expect(getAccountReadiness(currency, "tz1unrevealed")).resolves.toEqual({
+      ready: false,
+      reason: "unrevealed",
+    });
+    expect(getAccountInfoMock).toHaveBeenCalledWith("tz1unrevealed");
   });
 });

--- a/libs/ledger-live-common/src/families/tezos/bridge/api.ts
+++ b/libs/ledger-live-common/src/families/tezos/bridge/api.ts
@@ -1,5 +1,5 @@
 import { createApi as createTezosApi } from "@ledgerhq/coin-tezos/api/index";
-import { TezosCoinConfig } from "@ledgerhq/coin-tezos/config";
+import type { TezosCoinConfig } from "@ledgerhq/coin-tezos/config";
 import type { AssetInfo } from "@ledgerhq/coin-module-framework/api/types";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@domain/entity-currency-token";

--- a/libs/ledger-live-common/src/families/tezos/bridge/api.ts
+++ b/libs/ledger-live-common/src/families/tezos/bridge/api.ts
@@ -58,8 +58,7 @@ export function computeIntentType(transaction: Record<string, unknown>): string 
 
 /**
  * Readiness for a Tezos account: not ready (reason "unrevealed") until the account's
- * public key is revealed on-chain. Delegates to the coin-module `getAccountInfo`, which
- * is typed here (concrete `TezosApi`) before the generic bridge erases it.
+ * public key is revealed on-chain.
  */
 export async function getAccountReadiness(
   currency: CryptoCurrency,

--- a/libs/ledger-live-common/src/families/tezos/bridge/api.ts
+++ b/libs/ledger-live-common/src/families/tezos/bridge/api.ts
@@ -1,7 +1,12 @@
+import { createApi as createTezosApi } from "@ledgerhq/coin-tezos/api/index";
+import { TezosCoinConfig } from "@ledgerhq/coin-tezos/config";
 import type { AssetInfo } from "@ledgerhq/coin-module-framework/api/types";
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@domain/entity-currency-token";
+import type { AccountReadiness } from "@ledgerhq/types-live";
 import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
 import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
+import { getCurrencyConfiguration } from "../../../config";
 
 export async function getTokenFromAsset(asset: AssetInfo): Promise<TokenCurrency | undefined> {
   if (!("assetReference" in asset) || typeof asset.assetReference !== "string") {
@@ -51,9 +56,24 @@ export function computeIntentType(transaction: Record<string, unknown>): string 
   }
 }
 
+/**
+ * Readiness for a Tezos account: not ready (reason "unrevealed") until the account's
+ * public key is revealed on-chain. Delegates to the coin-module `getAccountInfo`, which
+ * is typed here (concrete `TezosApi`) before the generic bridge erases it.
+ */
+export async function getAccountReadiness(
+  currency: CryptoCurrency,
+  address: string,
+): Promise<AccountReadiness> {
+  const api = createTezosApi(getCurrencyConfiguration<TezosCoinConfig>(currency.id));
+  const { revealed } = await api.getAccountInfo(address);
+  return revealed ? { ready: true } : { ready: false, reason: "unrevealed" };
+}
+
 export default {
   getTokenFromAsset,
   getAssetFromToken,
   usesStakingPositions: true,
   computeIntentType,
+  getAccountReadiness,
 } satisfies BridgeApi;

--- a/libs/ledger-wallet-framework/src/api/types.ts
+++ b/libs/ledger-wallet-framework/src/api/types.ts
@@ -1,6 +1,10 @@
 import type { AssetInfo, BalanceOptions } from "@ledgerhq/coin-module-framework/api/types";
 import type { CryptoCurrency, TokenCurrency } from "../types";
-import type { Operation as LiveOperation, StakingResources } from "@ledgerhq/types-live";
+import type {
+  AccountReadiness,
+  Operation as LiveOperation,
+  StakingResources,
+} from "@ledgerhq/types-live";
 
 export type ChainSpecificRules = {
   getAccountShape: (address: string) => void;
@@ -47,4 +51,14 @@ export type BridgeApi = {
     operations: LiveOperation[],
     stakingResources: StakingResources,
   ) => Promise<StakingResources>;
+  /**
+   * Optional hook returning the account's generic readiness projection, written to
+   * `account.readiness` during sync. Omit for chains with no readiness concept — the
+   * field is then left undefined (consumers treat undefined as ready/unknown).
+   *
+   * @param currency - The crypto currency of the account being synced.
+   * @param address - The account address.
+   * @returns The readiness of the account (ready flag + optional reason).
+   */
+  getAccountReadiness?: (currency: CryptoCurrency, address: string) => Promise<AccountReadiness>;
 };

--- a/libs/ledger-wallet-framework/src/serialization/account.test.ts
+++ b/libs/ledger-wallet-framework/src/serialization/account.test.ts
@@ -1,0 +1,44 @@
+import type { AccountReadiness } from "@ledgerhq/types-live";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { CryptoCurrency } from "../types";
+import { setCryptoAssetsStore } from "../cryptoAssetsStore";
+import { genAccount } from "../mocks/account";
+import { fromAccountRaw, toAccountRaw } from "./account";
+
+const ethereum = getCryptoCurrencyById("ethereum") as unknown as CryptoCurrency;
+
+beforeAll(() => {
+  const store: Parameters<typeof setCryptoAssetsStore>[0] = {
+    findTokenById: async () => undefined,
+    findTokenByAddressInCurrency: async () => undefined,
+    getTokensSyncHash: async () => "",
+  };
+  setCryptoAssetsStore(store);
+});
+
+describe("account serialization — readiness", () => {
+  it("round-trips readiness through to/fromAccountRaw", async () => {
+    const account = genAccount("readiness-acc", { currency: ethereum });
+    account.subAccounts = [];
+    const readiness: AccountReadiness = { ready: false, reason: "unrevealed" };
+    account.readiness = readiness;
+
+    const raw = toAccountRaw(account);
+    expect(raw.readiness).toEqual(readiness);
+
+    const back = await fromAccountRaw(raw);
+    expect(back.readiness).toEqual(readiness);
+  });
+
+  it("leaves readiness undefined when absent", async () => {
+    const account = genAccount("no-readiness-acc", { currency: ethereum });
+    account.subAccounts = [];
+    delete account.readiness;
+
+    const raw = toAccountRaw(account);
+    expect(raw.readiness).toBeUndefined();
+
+    const back = await fromAccountRaw(raw);
+    expect(back.readiness).toBeUndefined();
+  });
+});

--- a/libs/ledger-wallet-framework/src/serialization/account.ts
+++ b/libs/ledger-wallet-framework/src/serialization/account.ts
@@ -60,6 +60,7 @@ export async function fromAccountRaw(
     swapHistory,
     syncHash,
     nfts,
+    readiness,
   } = rawAccount;
 
   const store = getCryptoAssetsStore();
@@ -144,6 +145,10 @@ export async function fromAccountRaw(
     res.nfts = nfts.map(n => fromNFTRaw(n));
   }
 
+  if (readiness) {
+    res.readiness = readiness;
+  }
+
   if (fromRaw?.assignFromAccountRaw) {
     fromRaw.assignFromAccountRaw(rawAccount, res);
   }
@@ -190,6 +195,7 @@ export function toAccountRaw(account: Account, toFamilyRaw?: ToFamiliyRaw): Acco
     swapHistory,
     syncHash,
     nfts,
+    readiness,
   } = account;
 
   const convertOperation = (op: Operation) =>
@@ -250,6 +256,10 @@ export function toAccountRaw(account: Account, toFamilyRaw?: ToFamiliyRaw): Acco
 
   if (nfts) {
     res.nfts = nfts.map(n => toNFTRaw(n));
+  }
+
+  if (readiness) {
+    res.readiness = readiness;
   }
 
   return res;

--- a/libs/ledgerjs/packages/types-live/src/account.ts
+++ b/libs/ledgerjs/packages/types-live/src/account.ts
@@ -134,9 +134,7 @@ export type Account = {
   freshAddressPath: string;
   // says if the account essentially "exists". an account has been used in the past, but for some reason the blockchain finds it empty (no ops, no balance,..)
   used: boolean;
-  // whether the account is fully operational: a generic, cross-chain readiness projection.
-  // Populated per-family during sync via BridgeApi.getAccountReadiness; undefined when the
-  // family provides no readiness (consumers treat undefined as ready/unknown).
+  // generic, cross-chain readiness projection (see AccountReadiness)
   readiness?: AccountReadiness;
   // account balance in satoshi
   balance: BigNumber;

--- a/libs/ledgerjs/packages/types-live/src/account.ts
+++ b/libs/ledgerjs/packages/types-live/src/account.ts
@@ -84,6 +84,18 @@ export type Address = {
 };
 
 /**
+ * Whether an account is fully operational, as a generic cross-chain projection.
+ * `ready` is false when a chain-specific precondition is unmet (e.g. a Tezos account
+ * whose public key is not yet revealed on-chain), with `reason` describing why.
+ * Populated per-family during sync via `BridgeApi.getAccountReadiness`; left undefined
+ * for families that don't provide it (consumers treat undefined as ready/unknown).
+ */
+export type AccountReadiness = {
+  ready: boolean;
+  reason?: string;
+};
+
+/**
  * Account type is the main level account of a blockchain currency.
  * Each family maybe need an extra field, to solve this, you can have some subtyping like this:
 
@@ -122,6 +134,10 @@ export type Account = {
   freshAddressPath: string;
   // says if the account essentially "exists". an account has been used in the past, but for some reason the blockchain finds it empty (no ops, no balance,..)
   used: boolean;
+  // whether the account is fully operational: a generic, cross-chain readiness projection.
+  // Populated per-family during sync via BridgeApi.getAccountReadiness; undefined when the
+  // family provides no readiness (consumers treat undefined as ready/unknown).
+  readiness?: AccountReadiness;
   // account balance in satoshi
   balance: BigNumber;
   // part of the balance that can effectively be spent
@@ -213,6 +229,7 @@ export type AccountRaw = {
   name?: string;
   starred?: boolean;
   used?: boolean;
+  readiness?: AccountReadiness;
   balance: string;
   spendableBalance?: string;
   blockHeight: number;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adds an optional generic `readiness` field to the base `Account` type — `readiness?: { ready: boolean; reason?: string }` — a chain-agnostic projection of whether an account is fully operational. It is persisted through account serialization and populated during sync via a new optional `BridgeApi.getAccountReadiness` hook. Tezos implements the hook: an account whose public key isn't revealed on-chain is reported as `{ ready: false, reason: "unrevealed" }`. Families without the hook leave `readiness` undefined.

Needed so the swap live app can read account readiness generically via wallet-api (LIVE-34259) without chain-specific logic — first consumer is Tezos CEX swap.

```ts
if (account.readiness?.ready === false) {
  // account.readiness.reason e.g. "unrevealed"
}
```

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34257](https://ledgerhq.atlassian.net/browse/LIVE-34257?atlOrigin=eyJpIjoiNWJlYTEzNmNiYjU0NGU2MDkwYjk1MmM0MTU1OTQ2ZTMiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-34257]: https://ledgerhq.atlassian.net/browse/LIVE-34257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ