### PR TITLE
feat(contacts): model populated list state

### DIFF
--- a/.changeset/brisk-contacts-populate.md
+++ b/.changeset/brisk-contacts-populate.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Add the populated Contacts list view model.

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -7,7 +7,7 @@ Shared Contacts flow package for Desktop and Mobile.
 - Feature-flag configuration (`useContactsFeature`, resolvers)
 - `useContactsMeContact` hook (`@domain/entity-contact`)
 - Shared UI components (`.web.tsx` / `.native.tsx`)
-- Contacts list view models and the Desktop Contacts page shell
+- Empty and populated Contacts list view models and the Desktop Contacts page shell
 
 App layers own routing, screen composition, i18n, and analytics.
 

--- a/features/flow/contacts/src/list/index.ts
+++ b/features/flow/contacts/src/list/index.ts
@@ -1,7 +1,11 @@
-export { createEmptyContactsListViewModel } from "./viewModel";
+export {
+  createEmptyContactsListViewModel,
+  createPopulatedContactsListViewModel,
+} from "./viewModel";
 export type {
   ContactsPageLabels,
   ContactsPageProps,
   ContactsListItem,
   EmptyContactsListViewModel,
+  PopulatedContactsListViewModel,
 } from "./types";

--- a/features/flow/contacts/src/list/types.ts
+++ b/features/flow/contacts/src/list/types.ts
@@ -25,3 +25,8 @@ export type ContactsPageProps = Readonly<{
   onOpenMe: (contactId: ContactId) => void;
   onAddContact: () => void;
 }>;
+
+export type PopulatedContactsListViewModel = Readonly<{
+  me: ContactsListItem;
+  savedContacts: readonly ContactsListItem[];
+}>;

--- a/features/flow/contacts/src/list/viewModel.test.ts
+++ b/features/flow/contacts/src/list/viewModel.test.ts
@@ -1,5 +1,8 @@
-import { mockContactAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
-import { createEmptyContactsListViewModel } from "./viewModel";
+import { mockContact, mockContactAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
+import {
+  createEmptyContactsListViewModel,
+  createPopulatedContactsListViewModel,
+} from "./viewModel";
 
 describe("createEmptyContactsListViewModel", () => {
   it("returns the Me row with no addresses", () => {
@@ -27,5 +30,73 @@ describe("createEmptyContactsListViewModel", () => {
         addressCount: 1,
       },
     });
+  });
+});
+
+describe("createPopulatedContactsListViewModel", () => {
+  it("should keep Me separate and sort saved contacts alphabetically", () => {
+    const me = mockMeContact({
+      addresses: [mockContactAddress()],
+    });
+    const contacts = [
+      mockContact({ id: "contact-olive", name: "Olive" }),
+      me,
+      mockContact({
+        id: "contact-ben",
+        name: "Ben",
+        addresses: [mockContactAddress()],
+      }),
+      mockContact({ id: "contact-ada", name: "Ada" }),
+    ];
+
+    expect(createPopulatedContactsListViewModel(me, contacts)).toEqual({
+      me: {
+        contactId: "contact-me",
+        name: "Me",
+        initial: "M",
+        addressCount: 1,
+      },
+      savedContacts: [
+        {
+          contactId: "contact-ada",
+          name: "Ada",
+          initial: "A",
+          addressCount: 0,
+        },
+        {
+          contactId: "contact-ben",
+          name: "Ben",
+          initial: "B",
+          addressCount: 1,
+        },
+        {
+          contactId: "contact-olive",
+          name: "Olive",
+          initial: "O",
+          addressCount: 0,
+        },
+      ],
+    });
+  });
+
+  it("should derive initials and address counts for saved contacts", () => {
+    const me = mockMeContact();
+    const contacts = [
+      me,
+      mockContact({
+        id: "contact-elodie",
+        name: "Élodie",
+        addresses: [mockContactAddress(), mockContactAddress({ id: "address-polygon" })],
+      }),
+    ];
+
+    expect(createPopulatedContactsListViewModel(me, contacts).savedContacts).toEqual([
+      {
+        contactId: "contact-elodie",
+        name: "Élodie",
+        initial: "É",
+        addressCount: 2,
+      },
+    ]);
   });
 });

--- a/features/flow/contacts/src/list/viewModel.ts
+++ b/features/flow/contacts/src/list/viewModel.ts
@@ -1,5 +1,9 @@
 import type { Contact } from "@domain/entity-contact";
-import type { ContactsListItem, EmptyContactsListViewModel } from "./types";
+import type {
+  ContactsListItem,
+  EmptyContactsListViewModel,
+  PopulatedContactsListViewModel,
+} from "./types";
 import { getContactInitial } from "./internals";
 
 function createContactsListItem(contact: Contact): ContactsListItem {
@@ -14,5 +18,18 @@ function createContactsListItem(contact: Contact): ContactsListItem {
 export function createEmptyContactsListViewModel(me: Contact): EmptyContactsListViewModel {
   return {
     me: createContactsListItem(me),
+  };
+}
+
+export function createPopulatedContactsListViewModel(
+  me: Contact,
+  contacts: readonly Contact[],
+): PopulatedContactsListViewModel {
+  return {
+    me: createContactsListItem(me),
+    savedContacts: contacts
+      .filter(contact => !contact.isMe)
+      .sort((left, right) => left.name.localeCompare(right.name))
+      .map(createContactsListItem),
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Shared Contacts list state consumed by upcoming Desktop and Mobile populated-list rendering
      - Alphabetical ordering, avatar initials, and address counts

### 📝 Description

This PR adds the shared populated Contacts list view model for `LIVE-33885`.

It keeps `Me` separate from saved contacts, derives the existing display data (initial and address count), and sorts saved contacts alphabetically without mutating the Contacts domain state. The API stays pure and contains no Redux access, UI, routing, i18n, search, or picture metadata.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33885](https://ledgerhq.atlassian.net/browse/LIVE-33885)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33885]: https://ledgerhq.atlassian.net/browse/LIVE-33885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ