### PR TITLE
feat(contacts): model search list state

### DIFF
--- a/.changeset/vivid-contacts-search.md
+++ b/.changeset/vivid-contacts-search.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Add the Contacts search list view model.

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -7,7 +7,7 @@ Shared Contacts flow package for Desktop and Mobile.
 - Feature-flag configuration (`useContactsFeature`, resolvers)
 - `useContactsMeContact` hook (`@domain/entity-contact`)
 - Shared UI components (`.web.tsx` / `.native.tsx`)
-- Contacts list view models and their Desktop and Mobile page shells
+- Empty, populated, and search Contacts list view models and their Desktop and Mobile page shells
 
 App layers own routing, screen composition, i18n, and analytics.
 

--- a/features/flow/contacts/src/list/index.ts
+++ b/features/flow/contacts/src/list/index.ts
@@ -1,10 +1,14 @@
 export {
+  createContactsSearchViewModel,
   createEmptyContactsListViewModel,
   createPopulatedContactsListViewModel,
 } from "./viewModel";
 export type {
   ContactsPageLabels,
   ContactsPageProps,
+  ContactsSearchNoResultsViewModel,
+  ContactsSearchResultsViewModel,
+  ContactsSearchViewModel,
   ContactsListItem,
   EmptyContactsListViewModel,
   PopulatedContactsListViewModel,

--- a/features/flow/contacts/src/list/types.ts
+++ b/features/flow/contacts/src/list/types.ts
@@ -30,3 +30,18 @@ export type PopulatedContactsListViewModel = Readonly<{
   me: ContactsListItem;
   savedContacts: readonly ContactsListItem[];
 }>;
+
+export type ContactsSearchResultsViewModel = Readonly<{
+  status: "results";
+  me: ContactsListItem;
+  savedContacts: readonly ContactsListItem[];
+}>;
+
+export type ContactsSearchNoResultsViewModel = Readonly<{
+  status: "no-results";
+  me: ContactsListItem;
+}>;
+
+export type ContactsSearchViewModel =
+  | ContactsSearchResultsViewModel
+  | ContactsSearchNoResultsViewModel;

--- a/features/flow/contacts/src/list/types.ts
+++ b/features/flow/contacts/src/list/types.ts
@@ -31,16 +31,15 @@ export type PopulatedContactsListViewModel = Readonly<{
   savedContacts: readonly ContactsListItem[];
 }>;
 
-export type ContactsSearchResultsViewModel = Readonly<{
-  status: "results";
-  me: ContactsListItem;
-  savedContacts: readonly ContactsListItem[];
-}>;
+export type ContactsSearchResultsViewModel = PopulatedContactsListViewModel &
+  Readonly<{
+    status: "results";
+  }>;
 
-export type ContactsSearchNoResultsViewModel = Readonly<{
-  status: "no-results";
-  me: ContactsListItem;
-}>;
+export type ContactsSearchNoResultsViewModel = EmptyContactsListViewModel &
+  Readonly<{
+    status: "no-results";
+  }>;
 
 export type ContactsSearchViewModel =
   | ContactsSearchResultsViewModel

--- a/features/flow/contacts/src/list/viewModel.test.ts
+++ b/features/flow/contacts/src/list/viewModel.test.ts
@@ -1,5 +1,6 @@
 import { mockContact, mockContactAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
 import {
+  createContactsSearchViewModel,
   createEmptyContactsListViewModel,
   createPopulatedContactsListViewModel,
 } from "./viewModel";
@@ -98,5 +99,79 @@ describe("createPopulatedContactsListViewModel", () => {
         addressCount: 2,
       },
     ]);
+  });
+});
+
+describe("createContactsSearchViewModel", () => {
+  const me = mockMeContact();
+  const contacts = [
+    mockContact({ id: "contact-olive", name: "Olive" }),
+    me,
+    mockContact({ id: "contact-ben", name: "Ben" }),
+    mockContact({ id: "contact-ada", name: "Ada" }),
+  ];
+
+  it("should return the populated list for an empty query", () => {
+    expect(createContactsSearchViewModel(me, contacts, "  ")).toEqual({
+      status: "results",
+      me: {
+        contactId: "contact-me",
+        name: "Me",
+        initial: "M",
+        addressCount: 0,
+      },
+      savedContacts: [
+        {
+          contactId: "contact-ada",
+          name: "Ada",
+          initial: "A",
+          addressCount: 0,
+        },
+        {
+          contactId: "contact-ben",
+          name: "Ben",
+          initial: "B",
+          addressCount: 0,
+        },
+        {
+          contactId: "contact-olive",
+          name: "Olive",
+          initial: "O",
+          addressCount: 0,
+        },
+      ],
+    });
+  });
+
+  it("should return case-insensitive saved contact matches", () => {
+    expect(createContactsSearchViewModel(me, contacts, "bEn")).toEqual({
+      status: "results",
+      me: {
+        contactId: "contact-me",
+        name: "Me",
+        initial: "M",
+        addressCount: 0,
+      },
+      savedContacts: [
+        {
+          contactId: "contact-ben",
+          name: "Ben",
+          initial: "B",
+          addressCount: 0,
+        },
+      ],
+    });
+  });
+
+  it("should return no results when only Me matches the query", () => {
+    expect(createContactsSearchViewModel(me, contacts, "Me")).toEqual({
+      status: "no-results",
+      me: {
+        contactId: "contact-me",
+        name: "Me",
+        initial: "M",
+        addressCount: 0,
+      },
+    });
   });
 });

--- a/features/flow/contacts/src/list/viewModel.ts
+++ b/features/flow/contacts/src/list/viewModel.ts
@@ -1,5 +1,6 @@
 import type { Contact } from "@domain/entity-contact";
 import type {
+  ContactsSearchViewModel,
   ContactsListItem,
   EmptyContactsListViewModel,
   PopulatedContactsListViewModel,
@@ -31,5 +32,32 @@ export function createPopulatedContactsListViewModel(
       .filter(contact => !contact.isMe)
       .sort((left, right) => left.name.localeCompare(right.name))
       .map(createContactsListItem),
+  };
+}
+
+export function createContactsSearchViewModel(
+  me: Contact,
+  contacts: readonly Contact[],
+  query: string,
+): ContactsSearchViewModel {
+  const populatedList = createPopulatedContactsListViewModel(me, contacts);
+  const normalizedQuery = query.trim().toLowerCase();
+  const savedContacts = normalizedQuery
+    ? populatedList.savedContacts.filter(contact =>
+        contact.name.toLowerCase().includes(normalizedQuery),
+      )
+    : populatedList.savedContacts;
+
+  if (normalizedQuery && savedContacts.length === 0) {
+    return {
+      status: "no-results",
+      me: populatedList.me,
+    };
+  }
+
+  return {
+    status: "results",
+    me: populatedList.me,
+    savedContacts,
   };
 }

--- a/features/flow/contacts/src/list/viewModel.ts
+++ b/features/flow/contacts/src/list/viewModel.ts
@@ -16,6 +16,17 @@ function createContactsListItem(contact: Contact): ContactsListItem {
   };
 }
 
+function createSavedContactsListItems(contacts: readonly Contact[], normalizedQuery = "") {
+  return contacts
+    .filter(
+      contact =>
+        !contact.isMe &&
+        (normalizedQuery.length === 0 || contact.name.toLowerCase().includes(normalizedQuery)),
+    )
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .map(createContactsListItem);
+}
+
 export function createEmptyContactsListViewModel(me: Contact): EmptyContactsListViewModel {
   return {
     me: createContactsListItem(me),
@@ -28,10 +39,7 @@ export function createPopulatedContactsListViewModel(
 ): PopulatedContactsListViewModel {
   return {
     me: createContactsListItem(me),
-    savedContacts: contacts
-      .filter(contact => !contact.isMe)
-      .sort((left, right) => left.name.localeCompare(right.name))
-      .map(createContactsListItem),
+    savedContacts: createSavedContactsListItems(contacts),
   };
 }
 
@@ -40,24 +48,27 @@ export function createContactsSearchViewModel(
   contacts: readonly Contact[],
   query: string,
 ): ContactsSearchViewModel {
-  const populatedList = createPopulatedContactsListViewModel(me, contacts);
   const normalizedQuery = query.trim().toLowerCase();
-  const savedContacts = normalizedQuery
-    ? populatedList.savedContacts.filter(contact =>
-        contact.name.toLowerCase().includes(normalizedQuery),
-      )
-    : populatedList.savedContacts;
 
-  if (normalizedQuery && savedContacts.length === 0) {
+  if (normalizedQuery.length === 0) {
+    return {
+      status: "results",
+      ...createPopulatedContactsListViewModel(me, contacts),
+    };
+  }
+
+  const savedContacts = createSavedContactsListItems(contacts, normalizedQuery);
+
+  if (savedContacts.length === 0) {
     return {
       status: "no-results",
-      me: populatedList.me,
+      ...createEmptyContactsListViewModel(me),
     };
   }
 
   return {
     status: "results",
-    me: populatedList.me,
+    me: createContactsListItem(me),
     savedContacts,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Shared Contacts search state consumed by upcoming Desktop and Mobile list rendering
      - Case-insensitive matching and the no-result state for saved contacts

### 📝 Description

This stacked PR adds the shared Contacts search view model for `LIVE-33888`.

It reuses the populated-list state from `LIVE-33885`, filters only saved contacts by name, and returns an explicit `results` or `no-results` state. `Me` remains separate from the search results. The API stays pure and does not introduce Redux access, UI, routing, i18n, or navigation.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33888](https://ledgerhq.atlassian.net/browse/LIVE-33888)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33888]: https://ledgerhq.atlassian.net/browse/LIVE-33888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ