### PR TITLE
[LWM] feat(LIVE-30496): add Aleo quick amount selector to send flow

### DIFF
--- a/.changeset/quiet-lions-drift.md
+++ b/.changeset/quiet-lions-drift.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add the Aleo private-send quick amount selector (Fast/Balanced/Full record tiers and spendable balance summary) to the mobile Amount screen, matching desktop.

--- a/apps/ledger-live-mobile/src/families/aleo/Send/QuickAmountSelector.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/QuickAmountSelector.tsx
@@ -1,21 +1,289 @@
-import React from "react";
-import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
-import { isPrivateTransaction } from "@ledgerhq/live-common/families/aleo/utils";
+import React, { useCallback, useState } from "react";
+import { Linking, Pressable, ScrollView, StyleSheet } from "react-native";
+import { log } from "@ledgerhq/logs";
+import { InformationFill } from "@ledgerhq/native-ui/assets/icons";
+import { Box, Link, Text } from "@ledgerhq/lumen-ui-rnative";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
+import { SpeedFast, SpeedLow, SpeedMedium } from "@ledgerhq/lumen-ui-rnative/symbols";
+import {
+  getEstimatedSigningTime,
+  getMaxPrivateRecordsForAccount,
+  isAleoTransaction,
+  isPrivateTransaction,
+} from "@ledgerhq/live-common/families/aleo/utils";
+import type { SigningStrategy } from "@ledgerhq/live-common/families/aleo/types";
+import { useAleoQuickAmountSelector } from "@ledgerhq/live-common/families/aleo/react";
+import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import { useTranslation } from "~/context/Locale";
+import CurrencyUnitValue from "~/components/CurrencyUnitValue";
+import InfoIcon from "~/icons/Info";
+import QueuedDrawer from "~/components/QueuedDrawer";
+import { GenericInformationBody } from "~/components/GenericInformationBody";
+import { useKeyboardVisible } from "~/logic/keyboardVisible";
+import { urls } from "~/utils/urls";
 import type { AfterAmountInputProps } from "~/screens/SendFunds/utils/customSendFlow";
 
-export function QuickAmountSelector({ transaction }: Readonly<AfterAmountInputProps>) {
-  const { t } = useTranslation();
+const STRATEGY_ICONS: Record<SigningStrategy, typeof SpeedFast> = {
+  fast: SpeedFast,
+  balanced: SpeedMedium,
+  full: SpeedLow,
+};
 
-  if (transaction.family !== "aleo" || !isPrivateTransaction(transaction)) {
+const selectorStyles = StyleSheet.create({
+  scrollContainer: {
+    maxHeight: 340,
+  },
+});
+
+export function QuickAmountSelector({
+  account,
+  transaction,
+  updateTransaction,
+  maxSpendable,
+}: Readonly<AfterAmountInputProps>) {
+  const { t } = useTranslation();
+  const unit = useAccountUnit(account);
+  const quickAmountSelector = useAleoQuickAmountSelector({
+    account,
+    transaction,
+    updateTransaction,
+  });
+  const [infoOpen, setInfoOpen] = useState(false);
+  const onLearnMore = useCallback(
+    () =>
+      Linking.openURL(urls.maxSpendable).catch(error => {
+        log("aleo-quick-amount-selector", "Failed to open max spendable URL", {
+          error,
+          url: urls.maxSpendable,
+        });
+      }),
+    [],
+  );
+  const { isKeyboardVisible } = useKeyboardVisible();
+
+  const styles = useStyleSheet(
+    theme => ({
+      tile: {
+        flex: 1,
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: theme.spacings.s4,
+        padding: theme.spacings.s12,
+        borderRadius: theme.borderRadius.sm,
+        borderWidth: theme.borderWidth.s1,
+        minHeight: 96,
+      },
+      tileDefault: {
+        backgroundColor: theme.colors.bg.muted,
+        borderColor: "transparent",
+      },
+      tileSelected: {
+        backgroundColor: theme.colors.bg.activeSubtle,
+        borderColor: theme.colors.border.active,
+      },
+      tileDisabled: {
+        backgroundColor: theme.colors.bg.disabled,
+        borderColor: "transparent",
+      },
+      tilePressed: {
+        backgroundColor: theme.colors.bg.surfacePressed,
+      },
+      badge: {
+        alignItems: "center",
+        borderRadius: theme.borderRadius.xs,
+        paddingHorizontal: theme.spacings.s6,
+        paddingVertical: theme.spacings.s2,
+        backgroundColor: theme.colors.bg.mutedStrong,
+      },
+      badgeSelected: {
+        backgroundColor: theme.colors.bg.active,
+      },
+      badgeDisabled: {
+        backgroundColor: theme.colors.bg.disabledStrong,
+      },
+    }),
+    [],
+  );
+
+  if (!isAleoTransaction(transaction) || !isPrivateTransaction(transaction)) {
     return null;
   }
 
+  const {
+    account: aleoAccount,
+    strategyData,
+    totalSpendableBalance,
+    selectedRecordsCount,
+    selectStrategy,
+  } = quickAmountSelector;
+
+  const selectedRecordsSigningTime = getEstimatedSigningTime(
+    selectedRecordsCount,
+    t("time.second_short"),
+    t("time.minute_short"),
+  );
+  const maxRecords = getMaxPrivateRecordsForAccount(aleoAccount);
+  const spendableBalance = maxSpendable ?? totalSpendableBalance;
+
   return (
-    <Box lx={{ flex: 1 }}>
-      <Text typography="heading4SemiBold" lx={{ color: "base", textAlign: "center" }}>
-        {t("aleo.send.quickAmountSelector.mockTitle")}
-      </Text>
+    <Box>
+      {/* Bounded height keeps the tile grid from growing past the keyboard on short devices. */}
+      <ScrollView
+        style={selectorStyles.scrollContainer}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <Pressable
+          onPress={() => setInfoOpen(true)}
+          disabled={isKeyboardVisible}
+          style={{ marginBottom: 8, flexDirection: "row", alignItems: "center", gap: 4 }}
+        >
+          <Text typography="body4SemiBold" lx={{ color: "muted" }}>
+            {t("aleo.send.quickAmountSelector.title")}
+          </Text>
+          <InfoIcon size={12} color="grey" />
+        </Pressable>
+
+        <Box lx={{ gap: "s16" }}>
+          <Box lx={{ flexDirection: "row", gap: "s12" }}>
+            {strategyData.map(tile => {
+              const Icon = STRATEGY_ICONS[tile.strategy];
+              const signingTime = getEstimatedSigningTime(
+                tile.availableCount,
+                t("time.second_short"),
+                t("time.minute_short"),
+              );
+              let labelColor: "disabled" | "active" | "muted";
+              if (tile.disabled) {
+                labelColor = "disabled";
+              } else if (tile.selected) {
+                labelColor = "active";
+              } else {
+                labelColor = "muted";
+              }
+
+              let tileVariantStyle: (typeof styles)[
+                | "tileDefault"
+                | "tileSelected"
+                | "tileDisabled"];
+              if (tile.disabled) {
+                tileVariantStyle = styles.tileDisabled;
+              } else if (tile.selected) {
+                tileVariantStyle = styles.tileSelected;
+              } else {
+                tileVariantStyle = styles.tileDefault;
+              }
+
+              return (
+                <Pressable
+                  key={tile.strategy}
+                  onPress={() => selectStrategy(tile)}
+                  disabled={tile.disabled || isKeyboardVisible}
+                  style={({ pressed }) => [
+                    styles.tile,
+                    tileVariantStyle,
+                    pressed && !tile.disabled && styles.tilePressed,
+                  ]}
+                >
+                  <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s4" }}>
+                    <Icon size={16} color={labelColor} />
+                    <Text typography="body4SemiBold" lx={{ color: labelColor }}>
+                      {t(`aleo.send.quickAmountSelector.strategies.${tile.strategy}`)}
+                    </Text>
+                  </Box>
+
+                  {tile.disabled ? (
+                    <Text typography="body3" lx={{ color: "disabled" }}>
+                      {t("aleo.send.quickAmountSelector.noValue")}
+                    </Text>
+                  ) : (
+                    <Text
+                      typography="body3SemiBold"
+                      lx={{ color: tile.selected ? "active" : "base" }}
+                      numberOfLines={1}
+                      adjustsFontSizeToFit
+                    >
+                      <CurrencyUnitValue unit={unit} value={tile.rangeSum} showCode />
+                    </Text>
+                  )}
+
+                  {!tile.disabled && (
+                    <Text typography="body4" lx={{ color: tile.selected ? "active" : "muted" }}>
+                      {signingTime}
+                    </Text>
+                  )}
+
+                  <Box
+                    style={[
+                      styles.badge,
+                      tile.selected && styles.badgeSelected,
+                      tile.disabled && styles.badgeDisabled,
+                    ]}
+                  >
+                    <Text
+                      typography="body4SemiBold"
+                      lx={{ color: tile.disabled ? "disabled" : "onInteractive" }}
+                    >
+                      {tile.disabled
+                        ? t("aleo.send.quickAmountSelector.unavailable")
+                        : t("aleo.send.quickAmountSelector.recordCount", {
+                            count: tile.availableCount,
+                          })}
+                    </Text>
+                  </Box>
+                </Pressable>
+              );
+            })}
+          </Box>
+
+          <Box lx={{ gap: "s4" }}>
+            <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s4" }}>
+              <Text typography="body4" lx={{ color: "muted" }}>
+                {t("aleo.send.quickAmountSelector.spendableBalance")}
+              </Text>
+              <Text
+                typography="body4SemiBold"
+                lx={{ color: "muted" }}
+                numberOfLines={1}
+                adjustsFontSizeToFit
+              >
+                <CurrencyUnitValue unit={unit} value={spendableBalance} showCode />
+              </Text>
+            </Box>
+            <Box
+              lx={{ flexDirection: "row", alignItems: "center", gap: "s4" }}
+              style={{ opacity: selectedRecordsCount > 0 ? 1 : 0 }}
+              accessibilityElementsHidden={selectedRecordsCount === 0}
+              importantForAccessibility={
+                selectedRecordsCount === 0 ? "no-hide-descendants" : "auto"
+              }
+            >
+              <Text typography="body4" lx={{ color: "muted" }}>
+                {`${t("aleo.send.quickAmountSelector.recordCount", {
+                  count: selectedRecordsCount,
+                })} · ${selectedRecordsSigningTime}`}
+              </Text>
+            </Box>
+          </Box>
+        </Box>
+      </ScrollView>
+
+      <QueuedDrawer isRequestingToBeOpened={infoOpen} onClose={() => setInfoOpen(false)}>
+        <Box>
+          <GenericInformationBody
+            Icon={InformationFill}
+            iconColor={"primary.c80"}
+            title={t("aleo.send.quickAmountSelector.title")}
+            description={t("aleo.send.quickAmountSelector.tooltip.desc", { max: maxRecords })}
+          />
+          <Box lx={{ paddingVertical: "s24" }}>
+            <Link appearance="accent" size="md" isExternal onPress={onLearnMore}>
+              {t("common.learnMore")}
+            </Link>
+          </Box>
+        </Box>
+      </QueuedDrawer>
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/families/aleo/Send/QuickAmountSelector.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/QuickAmountSelector.tsx
@@ -14,6 +14,7 @@ import {
 import type { SigningStrategy } from "@ledgerhq/live-common/families/aleo/types";
 import { useAleoQuickAmountSelector } from "@ledgerhq/live-common/families/aleo/react";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
+import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 import { useTranslation } from "~/context/Locale";
 import CurrencyUnitValue from "~/components/CurrencyUnitValue";
 import InfoIcon from "~/icons/Info";
@@ -49,15 +50,16 @@ export function QuickAmountSelector({
     updateTransaction,
   });
   const [infoOpen, setInfoOpen] = useState(false);
+  const maxSpendableUrl = useLocalizedUrl(urls.maxSpendable);
   const onLearnMore = useCallback(
     () =>
-      Linking.openURL(urls.maxSpendable).catch(error => {
+      Linking.openURL(maxSpendableUrl).catch(error => {
         log("aleo-quick-amount-selector", "Failed to open max spendable URL", {
           error,
-          url: urls.maxSpendable,
+          url: maxSpendableUrl,
         });
       }),
-    [],
+    [maxSpendableUrl],
   );
   const { isKeyboardVisible } = useKeyboardVisible();
 
@@ -277,8 +279,8 @@ export function QuickAmountSelector({
             title={t("aleo.send.quickAmountSelector.title")}
             description={t("aleo.send.quickAmountSelector.tooltip.desc", { max: maxRecords })}
           />
-          <Box lx={{ paddingVertical: "s24" }}>
-            <Link appearance="accent" size="md" isExternal onPress={onLearnMore}>
+          <Box lx={{ paddingVertical: "s24", alignItems: "center" }}>
+            <Link appearance="base" size="md" underline={false} isExternal onPress={onLearnMore}>
               {t("common.learnMore")}
             </Link>
           </Box>

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/QuickAmountSelector.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/QuickAmountSelector.test.tsx
@@ -1,46 +1,217 @@
 import React from "react";
+import BigNumber from "bignumber.js";
+import { Linking, Text } from "react-native";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { AleoAccount, AleoUnspentRecord } from "@ledgerhq/live-common/families/aleo/types";
 import { render, screen } from "@tests/test-renderer";
 import { QuickAmountSelector } from "../QuickAmountSelector";
-import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import { ALEO_ACCOUNT_1 } from "../../__mocks__/account.mock";
+import { urls } from "~/utils/urls";
+
+const openURLSpy = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+
+jest.mock("LLM/hooks/useAccountUnit", () => ({
+  useAccountUnit: jest.fn(() => ({ name: "ALEO", code: "ALEO", magnitude: 6 })),
+}));
+
+jest.mock("~/components/CurrencyUnitValue", () => ({
+  __esModule: true,
+  default: ({ value }: { value: BigNumber }) => <Text>{value.toString()}</Text>,
+}));
+
+const mockUseKeyboardVisible = jest.fn(() => ({ isKeyboardVisible: false, keyboardHeight: 0 }));
+jest.mock("~/logic/keyboardVisible", () => ({
+  useKeyboardVisible: () => mockUseKeyboardVisible(),
+}));
 
 const mockUpdateTransaction = jest.fn();
 
+function makeRecord(microcredits: string): AleoUnspentRecord {
+  return { microcredits } as unknown as AleoUnspentRecord;
+}
+
+function makeAccount(records: AleoUnspentRecord[]): AleoAccount {
+  return {
+    ...(ALEO_ACCOUNT_1 as AleoAccount),
+    aleoResources: {
+      transparentBalance: new BigNumber(0),
+      privateBalance: new BigNumber(0),
+      unspentPrivateRecords: records,
+      provableApi: null,
+      lastPrivateSyncDate: null,
+    },
+  };
+}
+
+function makePrivateTransaction(overrides?: Partial<Transaction>): Transaction {
+  return {
+    family: "aleo",
+    mode: "transfer_private",
+    amount: new BigNumber(0),
+    useAllAmount: false,
+    properties: { amountRecordCommitments: [], feeRecordCommitment: null },
+    ...overrides,
+  } as unknown as Transaction;
+}
+
+const manyRecords = Array.from({ length: 16 }, (_, i) => makeRecord(`${(20 - i) * 100000}`));
+const sixRecords = Array.from({ length: 6 }, (_, i) => makeRecord(`${(6 - i) * 100000}`));
+
+function renderSelector(
+  account: unknown,
+  transaction: Transaction,
+  maxSpendable: BigNumber | null = null,
+) {
+  return render(
+    <QuickAmountSelector
+      account={account as never}
+      transaction={transaction}
+      updateTransaction={mockUpdateTransaction}
+      maxSpendable={maxSpendable}
+    />,
+  );
+}
+
 describe("QuickAmountSelector", () => {
-  const mockAccount = {} as never;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseKeyboardVisible.mockReturnValue({ isKeyboardVisible: false, keyboardHeight: 0 });
+  });
 
-  it("renders null for non-aleo transaction", () => {
-    const { toJSON } = render(
-      <QuickAmountSelector
-        account={mockAccount}
-        transaction={{ family: "ethereum" } as Transaction}
-        updateTransaction={mockUpdateTransaction}
-      />,
-    );
+  afterAll(() => {
+    openURLSpy.mockRestore();
+  });
+
+  it("renders null for a non-aleo transaction", () => {
+    const { toJSON } = renderSelector(ALEO_ACCOUNT_1, {
+      family: "ethereum",
+    } as unknown as Transaction);
 
     expect(toJSON()).toBeNull();
   });
 
-  it("renders null for aleo public transaction", () => {
-    const { toJSON } = render(
-      <QuickAmountSelector
-        account={mockAccount}
-        transaction={{ family: "aleo", mode: "transfer_public" } as Transaction}
-        updateTransaction={mockUpdateTransaction}
-      />,
-    );
+  it("renders null for an aleo public transaction", () => {
+    const { toJSON } = renderSelector(ALEO_ACCOUNT_1, {
+      family: "aleo",
+      mode: "transfer_public",
+    } as unknown as Transaction);
 
     expect(toJSON()).toBeNull();
   });
 
-  it("renders for aleo private transaction", () => {
-    render(
-      <QuickAmountSelector
-        account={mockAccount}
-        transaction={{ family: "aleo", mode: "transfer_private" } as Transaction}
-        updateTransaction={mockUpdateTransaction}
-      />,
-    );
+  describe("with more spendable records than the Full tier cap (16 records)", () => {
+    const account = makeAccount(manyRecords);
+    const transaction = makePrivateTransaction();
 
-    expect(screen.getByText("Quick amount selector mock")).toBeOnTheScreen();
+    it("shows all 3 tiles enabled with correct amounts, record counts, and signing times", () => {
+      renderSelector(account, transaction);
+
+      expect(screen.getByText("Quick select")).toBeOnTheScreen();
+      expect(screen.getByText("Fast")).toBeOnTheScreen();
+      expect(screen.getByText("Balanced")).toBeOnTheScreen();
+      expect(screen.getByText("Full")).toBeOnTheScreen();
+
+      expect(screen.getByText("7400000")).toBeOnTheScreen();
+      expect(screen.getByText("13200000")).toBeOnTheScreen();
+      expect(screen.getAllByText("18900000")).toHaveLength(2);
+
+      expect(screen.getByText("4 records")).toBeOnTheScreen();
+      expect(screen.getByText("8 records")).toBeOnTheScreen();
+      expect(screen.getByText("14 records")).toBeOnTheScreen();
+
+      expect(screen.getByText("~50 s")).toBeOnTheScreen();
+      expect(screen.getByText("~1.5 min")).toBeOnTheScreen();
+      expect(screen.getByText("~2.5 min")).toBeOnTheScreen();
+    });
+
+    it("shows the bridge-estimated maxSpendable value instead of its own capped sum, when provided", () => {
+      renderSelector(account, transaction, new BigNumber("19999999"));
+
+      expect(screen.getByText("19999999")).toBeOnTheScreen();
+      expect(screen.getAllByText("18900000")).toHaveLength(1);
+    });
+
+    it("opens the info tooltip when tapping the Quick select label, with a working learn-more link", async () => {
+      const { user } = renderSelector(account, transaction);
+
+      await user.press(screen.getByText("Quick select"));
+
+      expect(screen.getByText(/Sender, amount and recipient hidden on-chain\./)).toBeOnTheScreen();
+
+      await user.press(screen.getByText("Learn more"));
+
+      expect(openURLSpy).toHaveBeenCalledTimes(1);
+      expect(openURLSpy).toHaveBeenCalledWith(urls.maxSpendable);
+    });
+
+    it("blocks the tiles and the tooltip while the keyboard is visible", async () => {
+      mockUseKeyboardVisible.mockReturnValue({ isKeyboardVisible: true, keyboardHeight: 300 });
+      const { user } = renderSelector(account, transaction);
+
+      await user.press(screen.getByText("Quick select"));
+      expect(
+        screen.queryByText(/Sender, amount and recipient hidden on-chain\./),
+      ).not.toBeOnTheScreen();
+
+      await user.press(screen.getByText("Fast"));
+      expect(mockUpdateTransaction).not.toHaveBeenCalled();
+    });
+
+    it("calls updateTransaction with the tier sum when tapping the Fast tile", async () => {
+      const { user } = renderSelector(account, transaction);
+
+      await user.press(screen.getByText("Fast"));
+
+      expect(mockUpdateTransaction).toHaveBeenCalledTimes(1);
+      const updater = mockUpdateTransaction.mock.calls[0][0];
+      const result = updater(transaction);
+      expect(result.useAllAmount).toBe(false);
+      expect((result.amount as BigNumber).toString()).toBe("7400000");
+    });
+
+    it("calls updateTransaction with useAllAmount when tapping the Full (cap) tile", async () => {
+      const { user } = renderSelector(account, transaction);
+
+      await user.press(screen.getByText("Full"));
+
+      expect(mockUpdateTransaction).toHaveBeenCalledTimes(1);
+      const updater = mockUpdateTransaction.mock.calls[0][0];
+      const result = updater(transaction);
+      expect(result.useAllAmount).toBe(true);
+      expect((result.amount as BigNumber).toString()).toBe("0");
+    });
+  });
+
+  describe("with only 6 spendable records", () => {
+    const account = makeAccount(sixRecords);
+    const transaction = makePrivateTransaction();
+
+    it("enables Fast and Balanced (as send-max), disables Full", () => {
+      renderSelector(account, transaction);
+
+      expect(screen.getByText("4 records")).toBeOnTheScreen();
+      expect(screen.getByText("6 records")).toBeOnTheScreen();
+      expect(screen.getByText("Unavailable")).toBeOnTheScreen();
+      expect(screen.getByText("—")).toBeOnTheScreen();
+    });
+
+    it("does not call updateTransaction when tapping the disabled Full tile", async () => {
+      const { user } = renderSelector(account, transaction);
+
+      await user.press(screen.getByText("Full"));
+
+      expect(mockUpdateTransaction).not.toHaveBeenCalled();
+    });
+
+    it("calls updateTransaction with useAllAmount when tapping the Balanced (send-max) tile", async () => {
+      const { user } = renderSelector(account, transaction);
+
+      await user.press(screen.getByText("Balanced"));
+
+      expect(mockUpdateTransaction).toHaveBeenCalledTimes(1);
+      const updater = mockUpdateTransaction.mock.calls[0][0];
+      const result = updater(transaction);
+      expect(result.useAllAmount).toBe(true);
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/QuickAmountSelector.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/QuickAmountSelector.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { Linking, Text } from "react-native";
+import type { AccountLike } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { AleoAccount, AleoUnspentRecord } from "@ledgerhq/live-common/families/aleo/types";
 import { render, screen } from "@tests/test-renderer";
@@ -12,6 +13,10 @@ const openURLSpy = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
 
 jest.mock("LLM/hooks/useAccountUnit", () => ({
   useAccountUnit: jest.fn(() => ({ name: "ALEO", code: "ALEO", magnitude: 6 })),
+}));
+
+jest.mock("LLM/hooks/useLocalizedUrls", () => ({
+  useLocalizedUrl: (url: string) => url,
 }));
 
 jest.mock("~/components/CurrencyUnitValue", () => ({
@@ -58,13 +63,13 @@ const manyRecords = Array.from({ length: 16 }, (_, i) => makeRecord(`${(20 - i) 
 const sixRecords = Array.from({ length: 6 }, (_, i) => makeRecord(`${(6 - i) * 100000}`));
 
 function renderSelector(
-  account: unknown,
+  account: AccountLike,
   transaction: Transaction,
   maxSpendable: BigNumber | null = null,
 ) {
   return render(
     <QuickAmountSelector
-      account={account as never}
+      account={account}
       transaction={transaction}
       updateTransaction={mockUpdateTransaction}
       maxSpendable={maxSpendable}

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10145,7 +10145,20 @@
         "errorDesc": "Something went wrong, please try again"
       },
       "quickAmountSelector": {
-        "mockTitle": "Quick amount selector mock"
+        "title": "Quick select",
+        "strategies": {
+          "fast": "Fast",
+          "balanced": "Balanced",
+          "full": "Full"
+        },
+        "recordCount_one": "{{count}} record",
+        "recordCount_other": "{{count}} records",
+        "unavailable": "Unavailable",
+        "noValue": "—",
+        "spendableBalance": "Max Spendable Balance:",
+        "tooltip": {
+          "desc": "Sender, amount and recipient hidden on-chain. Up to {{max}} records per send."
+        }
       },
       "summary": {
         "proofGenerationNotice": "Aleo transaction requires proof generation. This may take some time."

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
@@ -161,8 +161,7 @@ function SendAmountCoinContent({ navigation, route, account, parentAccount }: Co
       ? transaction.model.commandDescriptor.command.extensions?.transferFee
       : undefined;
 
-  // Guards AmountInput's height when a family widget below it (e.g. aleo's
-  // quick-amount tiles) See: LIVE-30496
+  // Guards AmountInput's height when a family widget renders below it.
   const AmountInputWrapper = familySendFlow?.AfterAmountInput ? AmountInputHeightGuard : Fragment;
 
   return (
@@ -334,7 +333,6 @@ const styles = StyleSheet.create({
   },
   // Keeps AmountInput's content from clipping when the keyboard shrinks this column;
   // no flexGrow so it stays at its natural compact height instead of expanding.
-  // See: LIVE-30496
   amountInputHeightGuard: {
     flexShrink: 1,
     minHeight: 160,

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
@@ -1,5 +1,5 @@
 import { BigNumber } from "bignumber.js";
-import React, { useCallback, useState, useEffect } from "react";
+import React, { Fragment, useCallback, useState, useEffect } from "react";
 import { View, StyleSheet, TouchableWithoutFeedback, Keyboard, Linking } from "react-native";
 import Switch from "~/components/Switch";
 import SafeAreaView from "~/components/SafeAreaView";
@@ -56,6 +56,10 @@ type ContentProps = {
   navigation: Props["navigation"];
   route: Props["route"];
 };
+
+function AmountInputHeightGuard({ children }: Readonly<{ children: React.ReactNode }>) {
+  return <View style={styles.amountInputHeightGuard}>{children}</View>;
+}
 
 function SendAmountCoinContent({ navigation, route, account, parentAccount }: ContentProps) {
   const { colors } = useTheme();
@@ -157,6 +161,10 @@ function SendAmountCoinContent({ navigation, route, account, parentAccount }: Co
       ? transaction.model.commandDescriptor.command.extensions?.transferFee
       : undefined;
 
+  // Guards AmountInput's height when a family widget below it (e.g. aleo's
+  // quick-amount tiles) See: LIVE-30496
+  const AmountInputWrapper = familySendFlow?.AfterAmountInput ? AmountInputHeightGuard : Fragment;
+
   return (
     <>
       <TrackScreen category="SendFunds" name="Amount" currencyName={currency.name} />
@@ -173,22 +181,24 @@ function SendAmountCoinContent({ navigation, route, account, parentAccount }: Co
         <KeyboardView style={styles.container}>
           <TouchableWithoutFeedback onPress={blur}>
             <View style={styles.amountWrapper}>
-              <AmountInput
-                testID="amount-input"
-                editable={!useAllAmount}
-                account={account}
-                onChange={onChange}
-                value={amount}
-                transferFeeCalculated={transferFee}
-                error={
-                  status.errors.dustLimit
-                    ? status.errors.dustLimit
-                    : amount.eq(0) && (bridgePending || !transaction.useAllAmount)
-                      ? null
-                      : status.errors.amount
-                }
-                warning={status.warnings.amount}
-              />
+              <AmountInputWrapper>
+                <AmountInput
+                  testID="amount-input"
+                  editable={!useAllAmount}
+                  account={account}
+                  onChange={onChange}
+                  value={amount}
+                  transferFeeCalculated={transferFee}
+                  error={
+                    status.errors.dustLimit
+                      ? status.errors.dustLimit
+                      : amount.eq(0) && (bridgePending || !transaction.useAllAmount)
+                        ? null
+                        : status.errors.amount
+                  }
+                  warning={status.warnings.amount}
+                />
+              </AmountInputWrapper>
 
               {familySendFlow?.AfterAmountInput && (
                 <View style={styles.afterAmountInputWrapper}>
@@ -196,6 +206,7 @@ function SendAmountCoinContent({ navigation, route, account, parentAccount }: Co
                     account={account}
                     transaction={transaction}
                     updateTransaction={handleUpdateTransaction}
+                    maxSpendable={maxSpendable}
                   />
                 </View>
               )}
@@ -307,7 +318,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     display: "flex",
     flexGrow: 1,
-    marginBottom: 16,
+    marginVertical: 16,
   },
   availableRight: {
     alignItems: "center",
@@ -320,6 +331,13 @@ const styles = StyleSheet.create({
   },
   maxLabel: {
     marginRight: 4,
+  },
+  // Keeps AmountInput's content from clipping when the keyboard shrinks this column;
+  // no flexGrow so it stays at its natural compact height instead of expanding.
+  // See: LIVE-30496
+  amountInputHeightGuard: {
+    flexShrink: 1,
+    minHeight: 160,
   },
   afterAmountInputWrapper: {
     flex: 1,

--- a/apps/ledger-live-mobile/src/screens/SendFunds/utils/customSendFlow.ts
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/utils/customSendFlow.ts
@@ -1,4 +1,5 @@
 import type { ComponentType } from "react";
+import type { BigNumber } from "bignumber.js";
 import type { AccountLike, Account } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { NativeStackNavigationOptions } from "@react-navigation/native-stack";
@@ -37,6 +38,8 @@ export type AfterAmountInputProps = {
   account: AccountLike;
   transaction: Transaction;
   updateTransaction: (updater: (t: Transaction) => Transaction) => void;
+  /** Bridge-estimated max-spendable value shown in the screen's "Total available" row; `null` until the first estimate resolves (and possibly stale while a new estimate is computing). */
+  maxSpendable: BigNumber | null;
 };
 
 type InitialScreenNavParams = {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Add the Aleo private-send quick amount selector (Fast/Balanced/Full record tiers and spendable balance summary) to the mobile Amount screen, matching the desktop experience.

<img src="https://github.com/user-attachments/assets/fd10c56b-da52-4813-a62c-7d2ddee610b2" alt="aleo-private-send-amount" width="220" />
<img src="https://github.com/user-attachments/assets/70abff58-766a-42ac-bfbb-8021bcac007e" alt="aleo-private-send-fast-tier" width="220" />
<img src="https://github.com/user-attachments/assets/509e2030-46a0-440c-8399-88529c7daf34" alt="aleo-private-send-balanced-tier" width="220" />
<img src="https://github.com/user-attachments/assets/f396577c-be26-4685-b09f-133663d9e509" alt="aleo-private-send-full-record-tier" width="220" />
<img src="https://github.com/user-attachments/assets/4b87b064-af38-4aed-8d6f-49bb538b49b1" alt="aleo-private-send-spendable-balance" width="220" />
<img src="https://github.com/user-attachments/assets/8c33958a-f9a3-4885-883c-300d9e22faf3" alt="aleo-private-send-amount-confirmation" width="220" />

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-30496