### PR TITLE
[LWM] Feat(LIVE-34175): aleo token accounts balance

### DIFF
--- a/.changeset/old-mayflies-attack.md
+++ b/.changeset/old-mayflies-attack.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+added balance summary header for Aleo tokens

--- a/apps/ledger-live-mobile/src/families/aleo/AccountBalanceHeader.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AccountBalanceHeader.tsx
@@ -1,4 +1,5 @@
-import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
+import type { AleoAccount, AleoTokenAccount } from "@ledgerhq/live-common/families/aleo/types";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import BigNumber from "bignumber.js";
 import React, { useCallback, useMemo, useState } from "react";
@@ -8,7 +9,7 @@ import type { TFunction } from "i18next";
 import CurrencyUnitValue from "~/components/CurrencyUnitValue";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import type { ModalInfo } from "~/modals/Info";
-import type { AccountLike } from "@ledgerhq/types-live";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { PRIVATE_BALANCE_PLACEHOLDER } from "@ledgerhq/live-common/families/aleo/constants";
 import InfoModal from "~/modals/Info";
 import InfoItem from "~/components/BalanceSummaryInfoItem";
@@ -18,15 +19,25 @@ import PrivateSyncButton from "./PrivateSyncButton";
 
 type InfoName = "transparent" | "private";
 
-function AleoBalanceSummary({ account }: { readonly account: AleoAccount }) {
+function AleoBalanceSummary({
+  account,
+  mainAccount,
+}: {
+  readonly account: AleoAccount | AleoTokenAccount;
+  readonly mainAccount: AleoAccount;
+}) {
   const { t } = useTranslation();
   const [infoName, setInfoName] = useState<InfoName>();
   const info = useMemo(() => getInfo(t), [t]);
   const unit = useAccountUnit(account);
 
-  const { aleoResources } = account;
-  const transparentBalance = aleoResources?.transparentBalance ?? BigNumber(0);
-  const privateBalance = aleoResources?.privateBalance ?? null;
+  const isTokenAccount = account.type === "TokenAccount";
+  const transparentBalance = isTokenAccount
+    ? account.transparentBalance
+    : (account.aleoResources?.transparentBalance ?? BigNumber(0));
+  const privateBalance = isTokenAccount
+    ? account.privateBalance
+    : (account.aleoResources?.privateBalance ?? null);
 
   const onCloseModal = useCallback(() => {
     setInfoName(undefined);
@@ -66,15 +77,31 @@ function AleoBalanceSummary({ account }: { readonly account: AleoAccount }) {
           />
         </Box>
       </ScrollView>
-      <PrivateSyncButton account={account} />
+      {!isTokenAccount && <PrivateSyncButton account={mainAccount} />}
     </SectionContainer>
   );
 }
 
-export default function AccountBalanceHeader({ account }: { readonly account?: AccountLike }) {
-  const aleoAccount = account as AleoAccount;
-  if (!aleoAccount?.aleoResources || aleoAccount.balance.lte(0)) return null;
-  return <AleoBalanceSummary account={aleoAccount} />;
+export default function AccountBalanceHeader({
+  account,
+  parentAccount,
+}: {
+  readonly account?: AccountLike;
+  readonly parentAccount?: Account;
+}) {
+  if (!account || (account.type === "TokenAccount" && !parentAccount)) return null;
+
+  const aleoAccount = account as AleoAccount | AleoTokenAccount;
+  const mainAccount = getMainAccount(account, parentAccount) as AleoAccount;
+
+  const hasBalances =
+    aleoAccount.type === "TokenAccount"
+      ? aleoAccount.transparentBalance !== undefined
+      : Boolean(aleoAccount.aleoResources);
+
+  if (!hasBalances || aleoAccount.balance.lte(0)) return null;
+
+  return <AleoBalanceSummary account={aleoAccount} mainAccount={mainAccount} />;
 }
 
 function getInfo(t: TFunction<"translation">): Record<InfoName, ModalInfo[]> {

--- a/apps/ledger-live-mobile/src/families/aleo/__tests__/AccountBalanceHeader.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/__tests__/AccountBalanceHeader.test.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { render, screen } from "@tests/test-renderer";
 import BigNumber from "bignumber.js";
-import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
-import { ALEO_ACCOUNT_1 } from "../__mocks__/account.mock";
+import type { AleoAccount, AleoTokenAccount } from "@ledgerhq/live-common/families/aleo/types";
+import { ALEO_ACCOUNT_1, ALEO_TOKEN_ACCOUNT_1 } from "../__mocks__/account.mock";
 import AccountBalanceHeader from "../AccountBalanceHeader";
 import { PRIVATE_BALANCE_PLACEHOLDER } from "@ledgerhq/live-common/families/aleo/constants";
 import { useAleoPrivateSync } from "../hooks/useAleoPrivateSync";
@@ -109,5 +109,69 @@ describe("AccountBalanceHeader", () => {
 
     const { toJSON } = render(<AccountBalanceHeader account={account} />);
     expect(toJSON()).toBeNull();
+  });
+
+  it("shows the private sync button for a regular account", () => {
+    render(<AccountBalanceHeader account={baseAccount} />);
+
+    expect(screen.getByTestId("start-private-sync-button")).toBeOnTheScreen();
+  });
+
+  describe("token account", () => {
+    const tokenAccount: AleoTokenAccount = {
+      ...(ALEO_TOKEN_ACCOUNT_1 as AleoTokenAccount),
+      balance: new BigNumber(1000000),
+      transparentBalance: new BigNumber(600000),
+      privateBalance: new BigNumber(400000),
+      unspentPrivateRecords: null,
+    };
+
+    it("renders balances from the token account's own fields", () => {
+      render(<AccountBalanceHeader account={tokenAccount} parentAccount={baseAccount} />);
+
+      expect(screen.getByText("aleo.balancesSection")).toBeOnTheScreen();
+      expect(screen.getByText("aleo.info.transparent.title")).toBeOnTheScreen();
+      expect(screen.getByText("aleo.info.private.title")).toBeOnTheScreen();
+    });
+
+    it("hides the private sync button", () => {
+      render(<AccountBalanceHeader account={tokenAccount} parentAccount={baseAccount} />);
+
+      expect(screen.queryByTestId("start-private-sync-button")).not.toBeOnTheScreen();
+    });
+
+    it("shows placeholder text when the token's privateBalance is null (not yet synced)", () => {
+      const account: AleoTokenAccount = { ...tokenAccount, privateBalance: null };
+
+      render(<AccountBalanceHeader account={account} parentAccount={baseAccount} />);
+
+      expect(screen.getByText(PRIVATE_BALANCE_PLACEHOLDER)).toBeOnTheScreen();
+    });
+
+    it("returns null when the token account has no transparentBalance yet", () => {
+      const account = {
+        ...tokenAccount,
+        transparentBalance: undefined,
+      } as unknown as AleoTokenAccount;
+
+      const { toJSON } = render(
+        <AccountBalanceHeader account={account} parentAccount={baseAccount} />,
+      );
+      expect(toJSON()).toBeNull();
+    });
+
+    it("returns null when the token's balance is zero", () => {
+      const account: AleoTokenAccount = { ...tokenAccount, balance: new BigNumber(0) };
+
+      const { toJSON } = render(
+        <AccountBalanceHeader account={account} parentAccount={baseAccount} />,
+      );
+      expect(toJSON()).toBeNull();
+    });
+
+    it("returns null instead of throwing when parentAccount is missing", () => {
+      const { toJSON } = render(<AccountBalanceHeader account={tokenAccount} />);
+      expect(toJSON()).toBeNull();
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
@@ -219,7 +219,11 @@ export function useListHeaderComponents({
         <FabAccountMainActions account={account} parentAccount={parentAccount} />
       </SectionContainer>,
       !!AccountBalanceHeader && (
-        <AccountBalanceHeader key="AccountBalanceHeader" account={account} />
+        <AccountBalanceHeader
+          key="AccountBalanceHeader"
+          account={account}
+          parentAccount={parentAccount}
+        />
       ),
       ...(!empty &&
       !disableDelegation &&


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Extends AccountBalanceHeader (mobile) to render for Aleo token accounts, not just the main Aleo coin account.

- AccountBalanceHeader now accepts an optional parentAccount prop and resolves the mainAccount via getMainAccount, passed down separately from account.
- AleoBalanceSummary accepts AleoAccount | AleoTokenAccount. Transparent/private balances are read from aleoResources for coin accounts, or directly from transparentBalance/privateBalance for token accounts.
- Visibility check (hasBalances) now branches on account type: coin accounts require aleoResources, token accounts require transparentBalance !== undefined.
- PrivateSyncButton is only rendered for non-token accounts (since private sync operates on the main coin account, not per-token — see below) and is now passed mainAccount instead of account.
- ListHeaderComponent now passes parentAccount through to AccountBalanceHeader so token accounts can resolve their main account.
- Added a changeset (live-mobile, minor): "added balance summary header for Aleo tokens".
- Test coverage extended in AccountBalanceHeader.test.tsx for the token-account cases.

<img width="1080" height="2400" alt="Screenshot_2026-07-16-09-43-56-021_com ledger live debug" src="https://github.com/user-attachments/assets/c976aa5d-e584-4639-a01b-cc2add226255" />


### 🔗 Context

- **JIRA / GitHub issue**: [https://ledgerhq.atlassian.net/browse/LIVE-34175](https://ledgerhq.atlassian.net/browse/LIVE-34175)
