### PR TITLE
fix(e2e-mobile): fix marketScreenRow ERC20 id mismatch and Aleo Q2 navigation

### DIFF
--- a/e2e/mobile/page/market/market.page.ts
+++ b/e2e/mobile/page/market/market.page.ts
@@ -41,8 +41,9 @@ export default class MarketPage {
   marketScreenFilterButton = () => getElementById("market-screen-assets-filter-button");
   coinOptionsTrigger = () => getElementById("asset-detail-coin-options-trailing");
   coinOptionsFavouriteRow = () => getElementById("asset-detail-coin-options-favourite-row");
-  // The new MarketScreen keys rows by ledger currency id, the legacy list by ticker.
-  marketScreenRow = (currency: CurrencyType) => getElementById(this.marketItemId(currency.id));
+  // New MarketScreen keys rows by CoinGecko market.id; ERC20s differ from their ledger currency.id.
+  marketScreenRow = (currency: CurrencyType) =>
+    getElementById(this.marketItemId(currency.market?.id ?? currency.id));
 
   @Step("Go back from the market screen")
   async goBack() {

--- a/e2e/mobile/specs/addAccount/addAccountALEO.spec.ts
+++ b/e2e/mobile/specs/addAccount/addAccountALEO.spec.ts
@@ -41,8 +41,8 @@ describe("Add accounts - Aleo", () => {
     await app.speculos.shareViewKey();
     await app.addAccount.tapCloseAddAccountCta();
 
-    await app.portfolio.goToAccounts(Currency.ALEO.name);
-    await app.assetAccountsPage.waitForAccountPageToLoad(Currency.ALEO.name);
+    await app.portfolio.goToAccounts(Currency.ALEO.name, Currency.ALEO.id);
+    await app.assetAccountsPage.waitForAccountPageToLoad(Currency.ALEO.name, undefined, true);
     await app.assetAccountsPage.expectAccountsBalanceVisible();
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #19522 (LIVE-33895-b) fixing two remaining e2e test failures under `E2E_MOBILE_FEATURE_FLAGS=wallet40-q2`.

- **Navigate to Buy/Sell [Tether USD] from market page**: `marketScreenRow` was using `currency.id` (`"ethereum/erc20/usd_tether__erc20_"` — the Ledger currency ID) to build the testID, but `AssetListItem`'s `MarketRow` renders `testID=\`marketItem-${market.id}\`` where `market.id` is the CoinGecko ID (`"tether"`). Fixed to use `currency.market?.id ?? currency.id`; native coins (BTC, ETH…) already share the same ID so they're unaffected.

- **Add account - Aleo**: In Q2, `goToAccounts("Aleo")` without a `currencyId` navigates to `CryptoAddressesScreen` but stops there. `waitForAccountPageToLoad` then timed out waiting for `asset-detail-scroll-view-aleo` which doesn't exist on that screen. Fixed by passing `Currency.ALEO.id` so `goToAccounts` navigates into the specific Aleo account item, and `inCryptoAddressesList = true` so `waitForAccountPageToLoad` skips the scroll-view wait.

## Test plan

- [ ] `navigateToBuyFromMarketPage_USDT` passes with `E2E_MOBILE_FEATURE_FLAGS=wallet40-q2`
- [ ] `addAccountALEO` passes with `E2E_MOBILE_FEATURE_FLAGS=wallet40-q2`
- [ ] Both tests still pass without Q2 flags