### PR TITLE
[LWDM] feat(LIVE-30496): extract Aleo quick-amount tier logic into shared hook

### DIFF
--- a/.changeset/silent-tigers-swim.md
+++ b/.changeset/silent-tigers-swim.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-aleo": minor
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+---
+
+Extract the Aleo private-send quick amount tier selection logic (Fast/Balanced/Full record boundaries) into `@ledgerhq/coin-aleo` and a shared `useAleoQuickAmountSelector` hook in `@ledgerhq/live-common`, and refactor the desktop QuickAmountSelector to consume it instead of duplicating the logic locally.

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/QuickAmountSelector.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/QuickAmountSelector.tsx
@@ -1,5 +1,4 @@
-import BigNumber from "bignumber.js";
-import React, { memo, useMemo } from "react";
+import React, { memo } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { rgba } from "@ledgerhq/react-ui/styles/helpers";
@@ -14,46 +13,11 @@ import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import type {
   AleoAccount,
   AleoTokenAccount,
-  AleoUnspentRecord,
+  SigningStrategy,
 } from "@ledgerhq/live-common/families/aleo/types";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
-import {
-  getEstimatedSigningTime,
-  isPrivateTransaction,
-  sumPrivateRecords,
-} from "@ledgerhq/live-common/families/aleo/utils";
-import { getMaxPrivateRecordsForAccount, isAleoTransaction } from "./utils";
-
-type SigningStrategy = "fast" | "balanced" | "full";
-
-interface StrategyConfig {
-  min: number;
-  max: number;
-}
-
-// The maximum number of records that can be selected for a transaction based on signing time constraints.
-const FAST_PRIVATE_RECORDS_PER_TRANSACTION = 4;
-const BALANCED_PRIVATE_RECORDS_PER_TRANSACTION = 8;
-
-function getStrategyConfig(
-  account: AleoAccount | AleoTokenAccount,
-): Record<SigningStrategy, StrategyConfig> {
-  const maxRecords = getMaxPrivateRecordsForAccount(account);
-
-  return {
-    fast: { min: 1, max: FAST_PRIVATE_RECORDS_PER_TRANSACTION },
-    balanced: {
-      min: FAST_PRIVATE_RECORDS_PER_TRANSACTION + 1,
-      max: BALANCED_PRIVATE_RECORDS_PER_TRANSACTION,
-    },
-    full: {
-      min: BALANCED_PRIVATE_RECORDS_PER_TRANSACTION + 1,
-      max: maxRecords,
-    },
-  };
-}
-
-const STRATEGIES: SigningStrategy[] = ["fast", "balanced", "full"];
+import { getEstimatedSigningTime } from "@ledgerhq/live-common/families/aleo/utils";
+import { useAleoQuickAmountSelector } from "@ledgerhq/live-common/families/aleo/react";
 
 const STRATEGY_ICONS: Record<SigningStrategy, React.ReactElement> = {
   fast: <TachometerHigh size={13} />,
@@ -121,62 +85,13 @@ const QuickAmountSelector = ({ account, transaction, updateTransaction, onSelect
   const { t } = useTranslation();
   const accountUnit = useAccountUnit(account);
 
-  const sortedRecords: AleoUnspentRecord[] = useMemo(() => {
-    const unspentPrivateRecords =
-      (account.type === "TokenAccount"
-        ? account.unspentPrivateRecords
-        : account.aleoResources?.unspentPrivateRecords) ?? [];
-
-    return unspentPrivateRecords
-      .filter(r => new BigNumber(r.microcredits).isGreaterThan(0))
-      .sort((a, b) => new BigNumber(b.microcredits).comparedTo(a.microcredits));
-  }, [account]);
-
-  const strategyConfig = useMemo(() => getStrategyConfig(account), [account]);
-
-  const spendableRecords = useMemo(
-    () => sortedRecords.slice(0, strategyConfig.full.max),
-    [sortedRecords, strategyConfig],
-  );
-
-  const totalSpendableBalance = sumPrivateRecords(spendableRecords);
-  const totalRecords = sortedRecords.length;
-  const selectedRecordsCount =
-    isAleoTransaction(transaction) && isPrivateTransaction(transaction)
-      ? transaction.properties.amountRecordCommitments.length
-      : 0;
+  const { strategyData, totalSpendableBalance, selectedRecordsCount, selectStrategy } =
+    useAleoQuickAmountSelector({ account, transaction, updateTransaction });
 
   const selectedRecordsSigningTime = getEstimatedSigningTime(
     selectedRecordsCount,
     t("time.second_short"),
     t("time.minute_short"),
-  );
-
-  const strategyData = useMemo(
-    () =>
-      STRATEGIES.map(strategy => {
-        const { min, max } = strategyConfig[strategy];
-
-        const rangeRecords = sortedRecords.slice(0, max);
-        const availableCount = rangeRecords.length;
-        const rangeSum = sumPrivateRecords(rangeRecords);
-
-        const disabled = totalRecords < min;
-        const isSendMax =
-          !disabled &&
-          (availableCount === totalRecords ||
-            (max === strategyConfig.full.max && availableCount === max));
-        const selected =
-          !disabled &&
-          (isSendMax
-            ? transaction.useAllAmount === true
-            : !rangeSum.isZero() &&
-              transaction.amount.isEqualTo(rangeSum) &&
-              !transaction.useAllAmount);
-
-        return { strategy, min, max, availableCount, rangeSum, disabled, selected, isSendMax };
-      }),
-    [sortedRecords, totalRecords, transaction.amount, transaction.useAllAmount, strategyConfig],
   );
 
   return (
@@ -211,86 +126,81 @@ const QuickAmountSelector = ({ account, transaction, updateTransaction, onSelect
         </Box>
       </Box>
       <Box horizontal justifyContent="center" flexWrap="wrap" gap="16px">
-        {strategyData.map(
-          ({ strategy, min, max, availableCount, rangeSum, disabled, selected, isSendMax }) => {
-            const signingTime = getEstimatedSigningTime(
-              availableCount,
-              t("time.second_short"),
-              t("time.minute_short"),
-            );
+        {strategyData.map(tile => {
+          const { strategy, min, max, availableCount, rangeSum, disabled, selected } = tile;
+          const signingTime = getEstimatedSigningTime(
+            availableCount,
+            t("time.second_short"),
+            t("time.minute_short"),
+          );
 
-            const disabledBadgeColor = disabled ? "neutral.c40" : "neutral.c100";
-            const badgeTextColor = selected ? "neutral.c00" : disabledBadgeColor;
+          const disabledBadgeColor = disabled ? "neutral.c40" : "neutral.c100";
+          const badgeTextColor = selected ? "neutral.c00" : disabledBadgeColor;
 
-            const handleClick = () => {
-              if (disabled) return;
-              if (isSendMax) {
-                updateTransaction(tx => ({ ...tx, useAllAmount: true, amount: new BigNumber(0) }));
-              } else {
-                updateTransaction(tx => ({ ...tx, amount: rangeSum, useAllAmount: false }));
-              }
-              onSelect?.();
-            };
+          const handleClick = () => {
+            if (disabled) return;
+            selectStrategy(tile);
+            onSelect?.();
+          };
 
-            return (
-              <QuickAmountWrapper
-                key={strategy}
+          return (
+            <QuickAmountWrapper
+              key={strategy}
+              selected={selected}
+              disabled={disabled}
+              onClick={handleClick}
+            >
+              <QuickAmountHeader
+                horizontal
+                alignItems="center"
                 selected={selected}
                 disabled={disabled}
-                onClick={handleClick}
               >
-                <QuickAmountHeader
-                  horizontal
-                  alignItems="center"
-                  selected={selected}
-                  disabled={disabled}
-                >
-                  {STRATEGY_ICONS[strategy]}
-                  <Text fontSize={0} ff="Inter|ExtraBold" uppercase ml={1} letterSpacing="0.1em">
-                    {t(`aleo.shared.quickAmountSelector.strategies.${strategy}`)}
-                  </Text>
-                </QuickAmountHeader>
+                {STRATEGY_ICONS[strategy]}
+                <Text fontSize={0} ff="Inter|ExtraBold" uppercase ml={1} letterSpacing="0.1em">
+                  {t(`aleo.shared.quickAmountSelector.strategies.${strategy}`)}
+                </Text>
+              </QuickAmountHeader>
 
-                <QuickAmountValue>
-                  {disabled ? (
-                    <Text fontSize={3} color="neutral.c40">
-                      —
-                    </Text>
-                  ) : (
-                    <WrappedFormattedVal>
-                      <FormattedVal
-                        inline
-                        ellipsis={false}
-                        color={selected ? "primary.c80" : "neutral.c100"}
-                        fontSize={3}
-                        fontWeight="600"
-                        val={rangeSum}
-                        unit={accountUnit}
-                        showCode
-                        alwaysShowValue
-                        showAllDigits
-                      />
-                    </WrappedFormattedVal>
-                  )}
-                </QuickAmountValue>
-
-                {!disabled && (
-                  <Text fontSize={2} color={selected ? "primary.c80" : "neutral.c70"}>
-                    {signingTime}
+              <QuickAmountValue>
+                {disabled ? (
+                  <Text fontSize={3} color="neutral.c40">
+                    —
                   </Text>
+                ) : (
+                  <WrappedFormattedVal>
+                    <FormattedVal
+                      inline
+                      ellipsis={false}
+                      color={selected ? "primary.c80" : "neutral.c100"}
+                      fontSize={3}
+                      fontWeight="600"
+                      val={rangeSum}
+                      unit={accountUnit}
+                      showCode
+                      alwaysShowValue
+                      showAllDigits
+                    />
+                  </WrappedFormattedVal>
                 )}
+              </QuickAmountValue>
 
-                <QuickAmountBadge selected={selected} disabled={disabled}>
-                  <Text fontSize={2} fontWeight="500" color={badgeTextColor}>
-                    {disabled
-                      ? t("aleo.shared.quickAmountSelector.unavailable", { min, max })
-                      : t("aleo.shared.quickAmountSelector.recordCount", { count: availableCount })}
-                  </Text>
-                </QuickAmountBadge>
-              </QuickAmountWrapper>
-            );
-          },
-        )}
+              {!disabled && (
+                <Text fontSize={2} color={selected ? "primary.c80" : "neutral.c70"}>
+                  {signingTime}
+                </Text>
+              )}
+
+              <QuickAmountBadge selected={selected} disabled={disabled}>
+                <Text fontSize={2} fontWeight="500" color={badgeTextColor}>
+                  {disabled
+                    ? t("aleo.shared.quickAmountSelector.unavailable", { min, max })
+                    : t("aleo.shared.quickAmountSelector.recordCount", { count: availableCount })}
+                </Text>
+              </QuickAmountBadge>
+            </QuickAmountWrapper>
+          );
+        })}
       </Box>
     </>
   );

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.test.ts
@@ -131,10 +131,7 @@ describe("isAleoTransaction", () => {
   });
 
   it("should return false for a non-aleo transaction", () => {
-    expect(
-      // @ts-expect-error - testing invalid family
-      isAleoTransaction({ ...makeAleoTransaction(), family: "bitcoin" }),
-    ).toBe(false);
+    expect(isAleoTransaction({ ...makeAleoTransaction(), family: "bitcoin" })).toBe(false);
   });
 });
 

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/shared/utils.ts
@@ -5,11 +5,7 @@ import {
   formatCurrencyUnit,
   type formatCurrencyUnitOptions,
 } from "@ledgerhq/live-common/currencies/index";
-import {
-  MAX_PRIVATE_RECORDS_PER_TRANSACTION,
-  MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION,
-  PRIVATE_BALANCE_PLACEHOLDER,
-} from "@ledgerhq/live-common/families/aleo/constants";
+import { PRIVATE_BALANCE_PLACEHOLDER } from "@ledgerhq/live-common/families/aleo/constants";
 import {
   derivePrivateTransactionMode,
   derivePublicTransactionMode,
@@ -18,15 +14,17 @@ import {
   isSelfTransferTransaction,
 } from "@ledgerhq/live-common/families/aleo/utils";
 import type {
-  AleoAccount,
   AleoCoinConfig,
-  AleoTokenAccount,
   Transaction as AleoTransaction,
 } from "@ledgerhq/live-common/families/aleo/types";
-import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { CryptoCurrency, TokenCurrency, Unit } from "@ledgerhq/types-cryptoassets";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import type { AccountLike } from "@ledgerhq/types-live";
+
+export {
+  isAleoAccount,
+  isAleoTransaction,
+  getMaxPrivateRecordsForAccount,
+} from "@ledgerhq/live-common/families/aleo/utils";
 
 export const getAleoCurrencyConfig = (
   currency: CryptoCurrency | TokenCurrency,
@@ -40,16 +38,6 @@ export const getAleoCurrencyConfig = (
     return undefined;
   }
 };
-
-export function isAleoAccount(acc: AccountLike): acc is AleoAccount | AleoTokenAccount {
-  const currency =
-    acc.type === "Account" ? acc.currency : getCryptoCurrencyById(acc.token.parentCurrencyId);
-  return currency.family === "aleo";
-}
-
-export function isAleoTransaction(tx: Transaction): tx is AleoTransaction {
-  return tx.family === "aleo";
-}
 
 export function getAleoAddressBadgeI18nKey(
   transaction: AleoTransaction,
@@ -107,10 +95,4 @@ export function formatAleoBalances({
       ? formatCurrencyUnit(unit, balances.privateBalance, formatConfig)
       : PRIVATE_BALANCE_PLACEHOLDER,
   };
-}
-
-export function getMaxPrivateRecordsForAccount(account: AleoAccount | AleoTokenAccount): number {
-  return account.type === "TokenAccount"
-    ? MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION
-    : MAX_PRIVATE_RECORDS_PER_TRANSACTION;
 }

--- a/libs/coin-modules/coin-aleo/src/constants.ts
+++ b/libs/coin-modules/coin-aleo/src/constants.ts
@@ -71,5 +71,10 @@ export const MAX_PRIVATE_RECORDS_PER_TRANSACTION = 14;
 // Token batcher programs only support up to 13 records (no _14 variant exists).
 export const MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION = 13;
 
+// The record-count boundary between the "Fast" and "Balanced" quick-amount tiers.
+export const FAST_PRIVATE_RECORDS_PER_TRANSACTION = 4;
+// The record-count boundary between the "Balanced" and "Full" quick-amount tiers.
+export const BALANCED_PRIVATE_RECORDS_PER_TRANSACTION = 8;
+
 // The estimated time in milliseconds it takes to sign a single record during transaction signing.
 export const SINGLE_CALL_SIGNING_TIME = 12500;

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -93,6 +93,10 @@ import {
   getEstimatedSigningTime,
   sumPrivateRecords,
   getCalTokens,
+  getMaxPrivateRecordsForAccount,
+  getStrategyConfig,
+  isAleoAccount,
+  isAleoTransaction,
 } from "./utils";
 
 jest.mock("../config");
@@ -1527,6 +1531,16 @@ describe("isSelfTransferTransaction", () => {
   });
 });
 
+describe("isAleoTransaction", () => {
+  it("returns true for an aleo transaction", () => {
+    expect(isAleoTransaction({ family: "aleo" })).toBe(true);
+  });
+
+  it("returns false for a non-aleo transaction", () => {
+    expect(isAleoTransaction({ family: "bitcoin" })).toBe(false);
+  });
+});
+
 describe("isPublicTransaction", () => {
   it.each([
     [true, TRANSACTION_TYPE.TRANSFER_PUBLIC],
@@ -2533,6 +2547,58 @@ describe("sumPrivateRecords", () => {
       { ...mockUnspentRecord1, microcredits: "58" },
     ];
     expect(sumPrivateRecords(records).isEqualTo(new BigNumber(100))).toBe(true);
+  });
+});
+
+describe("getMaxPrivateRecordsForAccount", () => {
+  it("returns 14 for a native Aleo account", () => {
+    expect(getMaxPrivateRecordsForAccount(getMockedAccount())).toBe(14);
+  });
+
+  it("returns 13 for an Aleo token account", () => {
+    expect(getMaxPrivateRecordsForAccount(getMockedTokenAccount())).toBe(13);
+  });
+});
+
+describe("getStrategyConfig", () => {
+  it("returns fast/balanced/full boundaries for a native account", () => {
+    expect(getStrategyConfig(getMockedAccount())).toEqual({
+      fast: { min: 1, max: 4 },
+      balanced: { min: 5, max: 8 },
+      full: { min: 9, max: 14 },
+    });
+  });
+
+  it("caps the full tier at 13 for a token account", () => {
+    expect(getStrategyConfig(getMockedTokenAccount())).toEqual({
+      fast: { min: 1, max: 4 },
+      balanced: { min: 5, max: 8 },
+      full: { min: 9, max: 13 },
+    });
+  });
+});
+
+describe("isAleoAccount", () => {
+  it("returns true for a native Aleo account", () => {
+    expect(isAleoAccount(getMockedAccount())).toBe(true);
+  });
+
+  it("returns true for an Aleo token account", () => {
+    expect(isAleoAccount(getMockedTokenAccount())).toBe(true);
+  });
+
+  it("returns false for an account of another family", () => {
+    const nonAleoAccount = getMockedAccount({
+      currency: { ...getMockedCurrency(), family: "bitcoin" },
+    });
+    expect(isAleoAccount(nonAleoAccount)).toBe(false);
+  });
+
+  it("returns false instead of throwing for a token account with an unregistered parentCurrencyId", () => {
+    const unknownTokenAccount = getMockedTokenAccount(undefined, {
+      token: { ...getMockedTokenCurrency(), parentCurrencyId: "unregistered_currency_id" },
+    });
+    expect(isAleoAccount(unknownTokenAccount)).toBe(false);
   });
 });
 

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -1,8 +1,15 @@
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
 import { log } from "@ledgerhq/logs";
+import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import type { Account, Operation, OperationType, TokenAccount } from "@ledgerhq/types-live";
+import type {
+  Account,
+  AccountLike,
+  Operation,
+  OperationType,
+  TokenAccount,
+} from "@ledgerhq/types-live";
 import type {
   Operation as CoinFrameworkOperation,
   MemoNotSupported,
@@ -18,7 +25,9 @@ import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { promiseAllBatched } from "@ledgerhq/live-promise";
 import aleoConfig from "../config";
 import {
+  BALANCED_PRIVATE_RECORDS_PER_TRANSACTION,
   EXPLORER_TRANSFER_TYPES,
+  FAST_PRIVATE_RECORDS_PER_TRANSACTION,
   MAX_PRIVATE_RECORDS_PER_TRANSACTION,
   MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION,
   PROGRAM_ID,
@@ -45,6 +54,8 @@ import type {
   AleoCoinConfig,
   AleoUnspentRecord,
   AleoTransactionIntent,
+  SigningStrategy,
+  StrategyConfig,
 } from "../types";
 
 const MICROCREDITS_REGEX = /^(\d+)u\d+$/;
@@ -980,6 +991,37 @@ export function sumPrivateRecords(records: AleoUnspentRecord[]): BigNumber {
   );
 }
 
+export function getMaxPrivateRecordsForAccount(account: AleoAccount | AleoTokenAccount): number {
+  return account.type === "TokenAccount"
+    ? MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION
+    : MAX_PRIVATE_RECORDS_PER_TRANSACTION;
+}
+
+export function getStrategyConfig(
+  account: AleoAccount | AleoTokenAccount,
+): Record<SigningStrategy, StrategyConfig> {
+  const maxRecords = getMaxPrivateRecordsForAccount(account);
+
+  return {
+    fast: { min: 1, max: FAST_PRIVATE_RECORDS_PER_TRANSACTION },
+    balanced: {
+      min: FAST_PRIVATE_RECORDS_PER_TRANSACTION + 1,
+      max: BALANCED_PRIVATE_RECORDS_PER_TRANSACTION,
+    },
+    full: {
+      min: BALANCED_PRIVATE_RECORDS_PER_TRANSACTION + 1,
+      max: maxRecords,
+    },
+  };
+}
+
+export function isAleoAccount(acc: AccountLike): acc is AleoAccount | AleoTokenAccount {
+  if (acc.type === "Account") {
+    return acc.currency.family === "aleo";
+  }
+  return findCryptoCurrencyById(acc.token.parentCurrencyId)?.family === "aleo";
+}
+
 export const getNextSequenceNumber = (account: AleoAccount): BigNumber => {
   const pendingSequenceNumbers = account.pendingOperations
     .map(op => op.transactionSequenceNumber)
@@ -1124,6 +1166,11 @@ export async function getCalTokens({
   });
 
   return calTokens;
+}
+
+/** Narrows any cross-family transaction shape down to Aleo's own `Transaction` type. */
+export function isAleoTransaction(tx: { family: string }): tx is Transaction {
+  return tx.family === "aleo";
 }
 
 export function isAleoAddressPlaintext(v: string): boolean {

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -87,3 +87,10 @@ export interface SignedAleoTransaction {
   authorization: string;
   feeAuthorization: string | null;
 }
+
+export type SigningStrategy = "fast" | "balanced" | "full";
+
+export interface StrategyConfig {
+  min: number;
+  max: number;
+}

--- a/libs/ledger-live-common/src/families/aleo/react.test.ts
+++ b/libs/ledger-live-common/src/families/aleo/react.test.ts
@@ -7,14 +7,21 @@ import { renderHook, act } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import { Subject } from "rxjs";
+import BigNumber from "bignumber.js";
 import type { Account } from "@ledgerhq/types-live";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import type { AleoAccount } from "./types";
+import type { Transaction } from "../../generated/types";
+import type { AleoAccount, AleoUnspentRecord } from "./types";
 import { aleoPrivateSyncProgress$ } from "./privateSyncProgress";
 import { MANDATORY_SYNC_POLLING_DELAY, PROGRESS_THROTTLE_INTERVAL_MS } from "./constants";
-import { useAleoViewKeyApproval, buildAccountsWithViewKeys, useAleoPrivateSync } from "./react";
+import {
+  useAleoViewKeyApproval,
+  buildAccountsWithViewKeys,
+  useAleoPrivateSync,
+  useAleoQuickAmountSelector,
+} from "./react";
 import { ALEO_ACCOUNT_1, makeAleoAccount } from "./__mocks__/account.mock";
 
 const mockCreateAction = jest.fn();
@@ -37,6 +44,7 @@ jest.mock("../../hw/connectApp", () => ({
 }));
 
 jest.mock("./utils", () => ({
+  ...jest.requireActual("./utils"),
   patchAccountWithViewKey: jest.fn((account: Account, viewKey: string) => ({
     ...account,
     id: `${account.id}:patched:${viewKey}`,
@@ -1213,5 +1221,163 @@ describe("useAleoPrivateSync", () => {
         }),
       );
     });
+  });
+});
+
+describe("useAleoQuickAmountSelector", () => {
+  function makeRecord(microcredits: string): AleoUnspentRecord {
+    return { microcredits } as unknown as AleoUnspentRecord;
+  }
+
+  function makeAccountWithRecords(records: AleoUnspentRecord[]): AleoAccount {
+    return {
+      ...ALEO_ACCOUNT_1,
+      aleoResources: {
+        transparentBalance: new BigNumber(0),
+        privateBalance: new BigNumber(0),
+        unspentPrivateRecords: records,
+        provableApi: null,
+        lastPrivateSyncDate: null,
+      },
+    } as AleoAccount;
+  }
+
+  function makePrivateTransaction(overrides?: Record<string, unknown>): Transaction {
+    return {
+      family: "aleo",
+      mode: "transfer_private",
+      amount: new BigNumber(0),
+      useAllAmount: false,
+      properties: { amountRecordCommitments: [], feeRecordCommitment: null },
+      ...overrides,
+    } as unknown as Transaction;
+  }
+
+  const manyRecords = Array.from({ length: 16 }, (_, i) => makeRecord(`${(20 - i) * 100000}`));
+  const sixRecords = Array.from({ length: 6 }, (_, i) => makeRecord(`${(6 - i) * 100000}`));
+
+  it("throws for an account of another family", () => {
+    const account = {
+      ...makeAccountWithRecords(manyRecords),
+      currency: { ...ALEO_ACCOUNT_1.currency, family: "bitcoin" },
+    };
+    const transaction = makePrivateTransaction();
+
+    expect(() =>
+      renderHook(() =>
+        useAleoQuickAmountSelector({
+          account,
+          transaction,
+          updateTransaction: jest.fn(),
+        }),
+      ),
+    ).toThrow();
+  });
+
+  it("still computes tiles for a public-mode aleo transaction — privacy gating is a caller concern", () => {
+    const account = makeAccountWithRecords(manyRecords);
+    const transaction = makePrivateTransaction({ mode: "transfer_public" });
+
+    const { result } = renderHook(() =>
+      useAleoQuickAmountSelector({
+        account,
+        transaction,
+        updateTransaction: jest.fn(),
+      }),
+    );
+
+    expect(result.current.strategyData).toHaveLength(3);
+    expect(result.current.selectedRecordsCount).toBe(0);
+  });
+
+  it("computes fast/balanced/full tiers from the sorted unspent records", () => {
+    const account = makeAccountWithRecords(manyRecords);
+    const transaction = makePrivateTransaction();
+
+    const { result } = renderHook(() =>
+      useAleoQuickAmountSelector({
+        account,
+        transaction,
+        updateTransaction: jest.fn(),
+      }),
+    );
+
+    expect(result.current.strategyData.map(tile => tile.strategy)).toEqual([
+      "fast",
+      "balanced",
+      "full",
+    ]);
+    expect(result.current.strategyData.map(tile => tile.availableCount)).toEqual([4, 8, 14]);
+    expect(result.current.strategyData.map(tile => tile.rangeSum.toString())).toEqual([
+      "7400000",
+      "13200000",
+      "18900000",
+    ]);
+    expect(result.current.totalSpendableBalance.toString()).toBe("18900000");
+  });
+
+  it("disables tiers past the available record count and marks the last reachable tier as send-max", () => {
+    const account = makeAccountWithRecords(sixRecords);
+    const transaction = makePrivateTransaction();
+
+    const { result } = renderHook(() =>
+      useAleoQuickAmountSelector({
+        account,
+        transaction,
+        updateTransaction: jest.fn(),
+      }),
+    );
+
+    const [fast, balanced, full] = result.current.strategyData;
+    expect(fast.disabled).toBe(false);
+    expect(balanced.disabled).toBe(false);
+    expect(balanced.isSendMax).toBe(true);
+    expect(full.disabled).toBe(true);
+  });
+
+  it("selectStrategy calls updateTransaction with the tier sum for a non-max tile", () => {
+    const account = makeAccountWithRecords(manyRecords);
+    const transaction = makePrivateTransaction();
+    const updateTransaction = jest.fn();
+
+    const { result } = renderHook(() =>
+      useAleoQuickAmountSelector({ account, transaction, updateTransaction }),
+    );
+
+    result.current.selectStrategy(result.current.strategyData[0]);
+
+    expect(updateTransaction).toHaveBeenCalledTimes(1);
+    const updated = updateTransaction.mock.calls[0][0](transaction);
+    expect(updated.useAllAmount).toBe(false);
+    expect((updated.amount as BigNumber).toString()).toBe("7400000");
+  });
+
+  it("selectStrategy calls updateTransaction with useAllAmount for the capped full tile", () => {
+    const account = makeAccountWithRecords(manyRecords);
+    const transaction = makePrivateTransaction();
+    const updateTransaction = jest.fn();
+
+    const { result } = renderHook(() =>
+      useAleoQuickAmountSelector({ account, transaction, updateTransaction }),
+    );
+
+    result.current.selectStrategy(result.current.strategyData[2]);
+
+    const updated = updateTransaction.mock.calls[0][0](transaction);
+    expect(updated.useAllAmount).toBe(true);
+  });
+
+  it("selectStrategy does nothing for a disabled tile", () => {
+    const account = makeAccountWithRecords(sixRecords);
+    const transaction = makePrivateTransaction();
+    const updateTransaction = jest.fn();
+
+    const { result } = renderHook(() =>
+      useAleoQuickAmountSelector({ account, transaction, updateTransaction }),
+    );
+
+    result.current.selectStrategy(result.current.strategyData[2]);
+
+    expect(updateTransaction).not.toHaveBeenCalled();
   });
 });

--- a/libs/ledger-live-common/src/families/aleo/react.ts
+++ b/libs/ledger-live-common/src/families/aleo/react.ts
@@ -1,11 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDispatch, useSelector, useStore } from "react-redux";
+import BigNumber from "bignumber.js";
+import invariant from "invariant";
 import { useFeature } from "@features/platform-feature-flags";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { SYNC_TYPE_SHIELDED } from "@ledgerhq/types-live";
-import type { Account } from "@ledgerhq/types-live";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type Transport from "@ledgerhq/hw-transport";
 import { asyncScheduler, from, mergeMap, throttleTime, type Observable } from "rxjs";
+import type { Transaction } from "../../generated/types";
 import type { ConnectAppEvent, Input as ConnectAppInput } from "../../hw/connectApp";
 import connectApp from "../../hw/connectApp";
 import type { Device } from "../../hw/actions/types";
@@ -17,10 +20,160 @@ import {
   type ViewKeyProgress,
   type ViewKeysByAccountId,
 } from "./hw/getViewKey/index";
-import { patchAccountWithViewKey } from "./utils";
-import type { AleoAccount } from "./types";
+import {
+  getStrategyConfig,
+  isAleoAccount,
+  isAleoTransaction,
+  isPrivateTransaction,
+  patchAccountWithViewKey,
+  sumPrivateRecords,
+} from "./utils";
+import type { AleoAccount, AleoTokenAccount, AleoUnspentRecord, SigningStrategy } from "./types";
 import { aleoPrivateSyncProgress$ } from "./privateSyncProgress";
 import { MANDATORY_SYNC_POLLING_DELAY, PROGRESS_THROTTLE_INTERVAL_MS } from "./constants";
+
+const QUICK_AMOUNT_STRATEGIES: SigningStrategy[] = ["fast", "balanced", "full"];
+
+interface QuickAmountStrategyTile {
+  strategy: SigningStrategy;
+  min: number;
+  max: number;
+  availableCount: number;
+  rangeSum: BigNumber;
+  disabled: boolean;
+  selected: boolean;
+  isSendMax: boolean;
+}
+
+export interface UseAleoQuickAmountSelectorResult {
+  /** Narrowed from the input `AccountLike` — safe to pass to Aleo-only components. */
+  account: AleoAccount | AleoTokenAccount;
+  strategyData: QuickAmountStrategyTile[];
+  totalSpendableBalance: BigNumber;
+  selectedRecordsCount: number;
+  selectStrategy: (tile: QuickAmountStrategyTile) => void;
+}
+
+function getUnspentPrivateRecords(account: AleoAccount | AleoTokenAccount): AleoUnspentRecord[] {
+  return (
+    (account.type === "TokenAccount"
+      ? account.unspentPrivateRecords
+      : account.aleoResources?.unspentPrivateRecords) ?? []
+  );
+}
+
+/**
+ * Derives the fast/balanced/full quick-amount tiles for an Aleo account's private records,
+ * shared between the desktop and mobile QuickAmountSelector components so only rendering
+ * differs. Whether the widget should be shown for the current transaction mode is up to callers.
+ *
+ * Only meant to be called from the Aleo send flow — throws if `account` isn't an Aleo account.
+ */
+export function useAleoQuickAmountSelector({
+  account,
+  transaction,
+  updateTransaction,
+}: {
+  account: AccountLike;
+  transaction: Transaction;
+  updateTransaction: (updater: (t: Transaction) => Transaction) => void;
+}): UseAleoQuickAmountSelectorResult {
+  const sortedRecords = useMemo(() => {
+    if (!isAleoAccount(account)) return [];
+    return getUnspentPrivateRecords(account)
+      .filter(r => new BigNumber(r.microcredits).isGreaterThan(0))
+      .sort((a, b) => new BigNumber(b.microcredits).comparedTo(a.microcredits));
+  }, [account]);
+
+  const strategyConfig = useMemo(
+    () => (isAleoAccount(account) ? getStrategyConfig(account) : null),
+    [account],
+  );
+
+  const totalRecords = sortedRecords.length;
+
+  const totalSpendableBalance = useMemo(
+    () =>
+      strategyConfig
+        ? sumPrivateRecords(sortedRecords.slice(0, strategyConfig.full.max))
+        : new BigNumber(0),
+    [sortedRecords, strategyConfig],
+  );
+
+  const selectedRecordsCount =
+    isAleoTransaction(transaction) && isPrivateTransaction(transaction)
+      ? (transaction.properties?.amountRecordCommitments.length ?? 0)
+      : 0;
+
+  const strategyData = useMemo(() => {
+    if (!strategyConfig) return [];
+
+    return QUICK_AMOUNT_STRATEGIES.map(strategy => {
+      const { min, max } = strategyConfig[strategy];
+      const rangeRecords = sortedRecords.slice(0, max);
+      const availableCount = rangeRecords.length;
+      const rangeSum = sumPrivateRecords(rangeRecords);
+
+      const disabled = totalRecords < min;
+      const coversAllRecords = availableCount === totalRecords;
+      const isFullTierAtCap = max === strategyConfig.full.max && availableCount === max;
+      const isSendMax = !disabled && (coversAllRecords || isFullTierAtCap);
+
+      const matchesTierRangeSum =
+        !disabled &&
+        !isSendMax &&
+        !rangeSum.isZero() &&
+        transaction.amount.isEqualTo(rangeSum) &&
+        !transaction.useAllAmount;
+      const selected =
+        !disabled && (isSendMax ? transaction.useAllAmount === true : matchesTierRangeSum);
+
+      return {
+        strategy,
+        min,
+        max,
+        availableCount,
+        rangeSum,
+        disabled,
+        selected,
+        isSendMax,
+      };
+    });
+  }, [sortedRecords, totalRecords, transaction.amount, transaction.useAllAmount, strategyConfig]);
+
+  const selectStrategy = useCallback(
+    (tile: QuickAmountStrategyTile) => {
+      if (tile.disabled) return;
+      if (tile.isSendMax) {
+        updateTransaction(tx => ({
+          ...tx,
+          useAllAmount: true,
+          amount: new BigNumber(0),
+        }));
+      } else {
+        updateTransaction(tx => ({
+          ...tx,
+          amount: tile.rangeSum,
+          useAllAmount: false,
+        }));
+      }
+    },
+    [updateTransaction],
+  );
+
+  invariant(
+    isAleoAccount(account),
+    "aleo: useAleoQuickAmountSelector called with a non-Aleo account",
+  );
+
+  return {
+    account,
+    strategyData,
+    totalSpendableBalance,
+    selectedRecordsCount,
+    selectStrategy,
+  };
+}
 
 type ConnectAppExec = (input: ConnectAppInput) => Observable<ConnectAppEvent>;
 type GetViewKeyExec = (transport: Transport, request: Request) => Observable<ViewKeyProgress>;
@@ -85,10 +238,6 @@ export function buildAccountsWithViewKeys(
     acc.push(patchAccountWithViewKey(account, viewKey));
     return acc;
   }, []);
-}
-
-function isAleoAccount(acc: Account): acc is AleoAccount {
-  return acc.currency.family === "aleo";
 }
 
 /**


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Extract the Aleo private-send quick amount tier selection logic (Fast/Balanced/Full record boundaries) into `@ledgerhq/coin-aleo` and a shared `useAleoQuickAmountSelector` hook in `@ledgerhq/live-common`, and refactor the desktop QuickAmountSelector to consume it instead of duplicating the logic locally.

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-30496