### PR TITLE
[LWDM] test(coin-sui): skip integ suites bound to retired public JSON-RPC

### DIFF
--- a/libs/coin-modules/coin-sui/src/bridge/buildTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/buildTransaction.integ.test.ts
@@ -6,7 +6,11 @@ import { createFixtureAccount, createFixtureTransaction } from "../types/bridge.
 
 import { buildTransaction } from "./buildTransaction";
 
-describe("buildTransaction", () => {
+// SKIP — Sui JSON-RPC public-endpoint shutdown. This suite targets the public mainnet
+// fullnode (fullnode.mainnet.sui.io), which the Sui Foundation retired (testnet wk of
+// 2026-07-06, mainnet wk of 2026-07-20) as JSON-RPC is deprecated for gRPC/GraphQL.
+// Re-enable after porting the integ config to the GraphQL transport.
+describe.skip("buildTransaction", () => {
   beforeAll(() => {
     coinConfig.setCoinConfig(() => ({
       status: {

--- a/libs/coin-modules/coin-sui/src/bridge/synchronisation.migration.integ.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/synchronisation.migration.integ.test.ts
@@ -38,7 +38,12 @@ const SHAPE_INFO = {
 
 const SYNC_CONFIG = { blacklistedTokenIds: [], paginationConfig: {} };
 
-describe("getAccountShape: JSON-RPC vs GraphQL parity (live mainnet)", () => {
+// SKIP — Sui JSON-RPC public-endpoint shutdown. The JSON-RPC reference leg of this parity
+// suite hits the public mainnet fullnode (fullnode.mainnet.sui.io), retired by the Sui
+// Foundation (mainnet wk of 2026-07-20) as JSON-RPC is deprecated for gRPC/GraphQL, so
+// cross-transport parity can no longer run. Re-enable once a GraphQL-only live baseline
+// replaces the JSON-RPC reference.
+describe.skip("getAccountShape: JSON-RPC vs GraphQL parity (live mainnet)", () => {
   // Two back-to-back syncs (JSON-RPC + GraphQL) on a high-traffic validator
   // address; ~70s under normal mainnet latency. Bumped above the 60s default.
   test("balance, spendable and suiResources.stakes match across transports", async () => {

--- a/libs/coin-modules/coin-sui/src/logic/craftTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-sui/src/logic/craftTransaction.integ.test.ts
@@ -7,7 +7,11 @@ import { craftTransaction } from "./craftTransaction";
 const SENDER = "0x33444cf803c690db96527cec67e3c9ab512596f4ba2d4eace43f0b4f716e0164";
 const RECIPIENT = "0x33444cf803c690db96527cec67e3c9ab512596f4ba2d4eace43f0b4f716e0164";
 
-describe("craftTransaction", () => {
+// SKIP — Sui JSON-RPC public-endpoint shutdown. This suite targets the public mainnet
+// fullnode (fullnode.mainnet.sui.io), which the Sui Foundation retired (testnet wk of
+// 2026-07-06, mainnet wk of 2026-07-20) as JSON-RPC is deprecated for gRPC/GraphQL.
+// Re-enable after porting the integ config to the GraphQL transport.
+describe.skip("craftTransaction", () => {
   beforeAll(() => {
     coinConfig.setCoinConfig(() => ({
       status: {

--- a/libs/coin-modules/coin-sui/src/logic/estimateFees.integ.test.ts
+++ b/libs/coin-modules/coin-sui/src/logic/estimateFees.integ.test.ts
@@ -6,7 +6,11 @@ import { estimateFees } from "./estimateFees";
 const SENDER = "0x33444cf803c690db96527cec67e3c9ab512596f4ba2d4eace43f0b4f716e0164";
 const RECIPIENT = "0x33444cf803c690db96527cec67e3c9ab512596f4ba2d4eace43f0b4f716e0164";
 
-describe("estimateFees", () => {
+// SKIP — Sui JSON-RPC public-endpoint shutdown. This suite targets the public mainnet
+// fullnode (fullnode.mainnet.sui.io), which the Sui Foundation retired (testnet wk of
+// 2026-07-06, mainnet wk of 2026-07-20) as JSON-RPC is deprecated for gRPC/GraphQL.
+// Re-enable after porting the integ config to the GraphQL transport.
+describe.skip("estimateFees", () => {
   beforeAll(() => {
     coinConfig.setCoinConfig(() => ({
       status: {

--- a/libs/coin-modules/coin-sui/src/logic/getBalance.integ.test.ts
+++ b/libs/coin-modules/coin-sui/src/logic/getBalance.integ.test.ts
@@ -4,7 +4,11 @@ import { getBalance } from "./getBalance";
 
 const SENDER = "0x33444cf803c690db96527cec67e3c9ab512596f4ba2d4eace43f0b4f716e0164";
 
-describe("getBalance", () => {
+// SKIP — Sui JSON-RPC public-endpoint shutdown. This suite targets the public testnet
+// fullnode (fullnode.testnet.sui.io), which the Sui Foundation retired (testnet wk of
+// 2026-07-06, mainnet wk of 2026-07-20) as JSON-RPC is deprecated for gRPC/GraphQL.
+// Re-enable after porting the integ config to the GraphQL transport.
+describe.skip("getBalance", () => {
   beforeAll(() => {
     coinConfig.setCoinConfig(() => ({
       status: {

--- a/libs/coin-modules/coin-sui/src/network/build.migration.integ.test.ts
+++ b/libs/coin-modules/coin-sui/src/network/build.migration.integ.test.ts
@@ -97,7 +97,12 @@ const assertShapeBothBuilt = (rpcBytes: Uint8Array, gqlBytes: Uint8Array, label:
   expect(label).not.toBe("");
 };
 
-describe("createTransactionFor* parity (live mainnet)", () => {
+// SKIP — Sui JSON-RPC public-endpoint shutdown. The JSON-RPC reference leg of this parity
+// suite hits the public mainnet fullnode (fullnode.mainnet.sui.io), retired by the Sui
+// Foundation (mainnet wk of 2026-07-20) as JSON-RPC is deprecated for gRPC/GraphQL, so
+// cross-transport parity can no longer run. Re-enable once a GraphQL-only live baseline
+// replaces the JSON-RPC reference.
+describe.skip("createTransactionFor* parity (live mainnet)", () => {
   test("transfer: same TransactionData shape across transports", async () => {
     const transaction = {
       amount: new BigNumber("1000000"),

--- a/libs/coin-modules/coin-sui/src/network/sdk.integ.test.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.integ.test.ts
@@ -545,7 +545,11 @@ describe("SUI SDK Integration tests", () => {
   // Legacy flow pins to mainnet (long retention); SIP-58 stays on testnet
   // since the accumulator-event shape is testnet-only at the moment. Each
   // inner block sets its own RPC URL; afterAll restores the suite default.
-  describe("Transfer flow comparison: legacy coin vs SIP-58 address balance", () => {
+  // SKIP — Sui JSON-RPC public-endpoint shutdown. Only this block leaves the Ledger proxy
+  // for the public testnet/mainnet fullnodes (fullnode.*.sui.io via getJsonRpcFullnodeUrl),
+  // retired by the Sui Foundation as JSON-RPC is deprecated for gRPC/GraphQL. The rest of
+  // the suite runs on the Ledger proxy and stays enabled. Re-enable after porting to GraphQL.
+  describe.skip("Transfer flow comparison: legacy coin vs SIP-58 address balance", () => {
     beforeAll(() => {
       coinConfig.setCoinConfig(() => ({
         status: { type: "active" },

--- a/libs/coin-modules/coin-sui/src/network/sdk.migration.integ.test.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.migration.integ.test.ts
@@ -202,7 +202,12 @@ function assertIdsSubset<T>(
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("JSON-RPC vs GraphQL shape parity (live mainnet)", () => {
+// SKIP — Sui JSON-RPC public-endpoint shutdown. The JSON-RPC reference leg of this parity
+// suite hits the public mainnet fullnode (fullnode.mainnet.sui.io), retired by the Sui
+// Foundation (mainnet wk of 2026-07-20) as JSON-RPC is deprecated for gRPC/GraphQL, so
+// cross-transport parity can no longer run. Re-enable once a GraphQL-only live baseline
+// replaces the JSON-RPC reference.
+describe.skip("JSON-RPC vs GraphQL shape parity (live mainnet)", () => {
   // ----- Read-side: balances ----------------------------------------------
 
   describe("getAllBalancesCached", () => {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

`coin-sui`'s `test-integ` job fails on every PR with `Unexpected status code: 404` — environmental, not a code bug.

**Cause:** the integ suites drive the legacy JSON-RPC transport against public Sui fullnodes (`fullnode.*.sui.io`), which the Sui Foundation retired (testnet wk of 2026-07-06, mainnet wk of 2026-07-20) as JSON-RPC is deprecated for gRPC/GraphQL.

**Fix:** `describe.skip` the 8 suites bound to `fullnode.*.sui.io` (testnet + mainnet). The 4 suites on the Ledger proxy (`sui.coin.ledger.com`) stay live. Test-only; production already runs GraphQL. Durable follow-up: re-point these suites at GraphQL.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-34493
- **ADR** (if any): —