### PR TITLE
[LWM] fix: block continue button if we have any error

### DIFF
--- a/.changeset/mobile-send-summary-block-any-error.md
+++ b/.changeset/mobile-send-summary-block-any-error.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": patch
+---
+
+Block the send Summary CTA on any transaction-status error.
+
+The Summary screen previously gated its Continue button on a named allowlist of error keys (`transaction`, `NotEnoughGas`, `NotEnoughBalance`, sender/recipient) that omitted others such as `gasLimit`. As a result a `FeeNotLoaded` error — raised by `getTransactionStatus` when gas estimation fails (e.g. an EVM `eth_estimateGas` revert leaving `gasLimit = 0`) — was not enforced, letting the user proceed to sign an unexecutable transaction. Desktop already disables on any error; the Summary CTA now does the same, so every current and future status error blocks the flow by default.

--- a/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.test.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import { View, ScrollView } from "react-native";
 import { BigNumber } from "bignumber.js";
+import {
+  FeeNotLoaded,
+  GasLessThanEstimate,
+  NotEnoughBalance,
+  NotEnoughGas,
+} from "@ledgerhq/errors";
 import { render, screen } from "@tests/test-renderer";
 import { ScreenName } from "~/const";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -130,5 +136,76 @@ describe("SendSummary — custom send flow", () => {
     );
 
     expect(screen.getByTestId("enabled-summary-continue-button")).toBeOnTheScreen();
+  });
+});
+
+describe("SendSummary — status errors", () => {
+  const mockNavigation = makeNavigation();
+  const mockRoute = makeRoute();
+
+  beforeEach(() => {
+    mockGetCustomSendFlow.mockReturnValue(null);
+    mockUseAccountScreen.mockReturnValue({ account: ALEO_ACCOUNT_1, parentAccount: null });
+  });
+
+  function mockStatusWithErrors(errors: Record<string, Error>) {
+    mockUseBridgeTransaction.mockReturnValue({
+      transaction: { family: "aleo", recipient: "aleo1abc", useAllAmount: false },
+      setTransaction: jest.fn(),
+      status: { ...mockStatus, errors },
+      bridgePending: false,
+      bridgeError: null,
+    } as never);
+  }
+
+  it("disables Continue and shows the fee message when gas estimation failed (FeeNotLoaded)", () => {
+    // A FeeNotLoaded error on gasLimit must block the CTA and be visible to the user.
+    mockStatusWithErrors({ gasLimit: new FeeNotLoaded() });
+
+    render(<SendSummary navigation={mockNavigation as never} route={mockRoute as never} />);
+
+    expect(screen.getByTestId("disabled-summary-continue-button")).toBeOnTheScreen();
+    expect(screen.getByText("Could not load fee rates")).toBeOnTheScreen();
+  });
+
+  it("disables Continue and shows the balance message when funds are insufficient", () => {
+    mockStatusWithErrors({ amount: new NotEnoughBalance() });
+
+    render(<SendSummary navigation={mockNavigation as never} route={mockRoute as never} />);
+
+    expect(screen.getByTestId("disabled-summary-continue-button")).toBeOnTheScreen();
+    expect(screen.getByText("Sorry, insufficient funds")).toBeOnTheScreen();
+  });
+
+  it("keeps Continue enabled and shows no error message when there are no errors", () => {
+    mockStatusWithErrors({});
+
+    render(<SendSummary navigation={mockNavigation as never} route={mockRoute as never} />);
+
+    expect(screen.getByTestId("enabled-summary-continue-button")).toBeOnTheScreen();
+    expect(screen.queryByText("Could not load fee rates")).not.toBeOnTheScreen();
+  });
+
+  it("disables Continue when the native balance can't cover gas (NotEnoughGas on gasPrice)", () => {
+    mockStatusWithErrors({ gasPrice: new NotEnoughGas() });
+
+    render(<SendSummary navigation={mockNavigation as never} route={mockRoute as never} />);
+
+    expect(screen.getByTestId("disabled-summary-continue-button")).toBeOnTheScreen();
+  });
+
+  it("disables Continue when the blocking error is not the first key (ordering slip-through)", () => {
+    const errors = { gasLimit: new GasLessThanEstimate(), gasPrice: new NotEnoughGas() };
+
+    const firstError = errors[Object.keys(errors)[0] as keyof typeof errors];
+    expect(firstError instanceof NotEnoughGas || firstError instanceof NotEnoughBalance).toBe(
+      false,
+    );
+
+    mockStatusWithErrors(errors);
+
+    render(<SendSummary navigation={mockNavigation as never} route={mockRoute as never} />);
+
+    expect(screen.getByTestId("disabled-summary-continue-button")).toBeOnTheScreen();
   });
 });

--- a/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
@@ -6,7 +6,6 @@ import SafeAreaView from "~/components/SafeAreaView";
 import { Trans } from "~/context/Locale";
 import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import type { TransactionStatus as BitcoinTransactionStatus } from "@ledgerhq/live-common/families/bitcoin/types";
-import { NotEnoughBalance, NotEnoughGas } from "@ledgerhq/errors";
 import { useTheme } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import invariant from "invariant";
@@ -137,6 +136,7 @@ function SendSummary({ navigation, route }: Props) {
   const { amount, totalSpent, errors, warnings } = status;
   const { transaction: transactionError } = errors;
   const error = errors[Object.keys(errors)[0]];
+  const hasErrors = Object.keys(errors).length > 0;
   const { tooManyUtxos } = warnings || {};
   const mainAccount = getMainAccount(account, parentAccount);
   const currencyOrToken = getAccountCurrency(account);
@@ -366,13 +366,7 @@ function SendSummary({ navigation, route }: Props) {
           title={<Trans i18nKey="common.continue" />}
           containerStyle={styles.continueButton}
           onPress={() => setContinuing(true)}
-          disabled={
-            bridgePending ||
-            !!transactionError ||
-            (!!error && error instanceof NotEnoughGas) ||
-            (!!error && error instanceof NotEnoughBalance) ||
-            !!displayedError
-          }
+          disabled={bridgePending || hasErrors}
           pending={bridgePending}
         />
       </View>


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The mobile send Summary screen gated its Continue button on a hard-coded allowlist of error keys (transaction, NotEnoughGas, NotEnoughBalance, sender/recipient). Any other status error — notably gasLimit (FeeNotLoaded, raised by getTransactionStatus when gas estimation fails, e.g. an EVM eth_estimateGas revert that leaves gasLimit = 0) — was not enforced, so the user could tap Continue and go on to sign an unexecutable transaction that fails at broadcast.

This aligns mobile with desktop, which already blocks on any status error. The Summary CTA now disables whenever status.errors has any entry, so every current and future error key blocks the flow by default (fail-safe instead of fail-open).

Changes

- `04-Summary.tsx`: replace the named-allowlist disabled condition with a generic 
hasErrors = Object.keys(errors).length > 0 check (disabled={bridgePending || hasErrors}); 
remove the now-unused NotEnoughBalance / NotEnoughGas imports. Error message display is unchanged.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32642](https://ledgerhq.atlassian.net/browse/LIVE-32642)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-32642]: https://ledgerhq.atlassian.net/browse/LIVE-32642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ