### PR TITLE
[LWD] feat(desktop): add large-screen upsell modal Segment analytics

### DIFF
--- a/.changeset/brave-modal-track.md
+++ b/.changeset/brave-modal-track.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@features/flow-large-screen-upsell": minor
+---
+
+Add Segment analytics for the large-screen upsell modal (LIVE-33163): flow dismiss/CTA lifecycle ports and desktop trackPage/track wiring.

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/LargeScreenUpsellModalMount.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/LargeScreenUpsellModalMount.tsx
@@ -1,9 +1,15 @@
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { onboardingDateSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
+import { useFeature } from "@features/platform-feature-flags";
+import { retriesUpsellModalSelector } from "@domain/entity-large-screen-upsell-modal";
 import {
   LargeScreenUpsellModal,
   mapDevicesModelListToUpsellInputs,
+  type LargeScreenUpsellDismissMethod,
+  type LargeScreenUpsellModalAnalyticsPorts,
+  type LargeScreenUpsellModalViewedContext,
+  type NanoDeviceModelId,
 } from "@features/flow-large-screen-upsell";
 import { useSelector } from "LLD/hooks/redux";
 import { themeSelector } from "~/renderer/actions/general";
@@ -14,6 +20,34 @@ import {
   sharePersonalizedRecommendationsSelector,
 } from "~/renderer/reducers/settings";
 import { openURL } from "~/renderer/linking";
+import {
+  toLargeScreenUpsellDeviceModelAnalyticsValue,
+  trackLargeScreenUpsellModalCtaClicked,
+  trackLargeScreenUpsellModalDismissed,
+  trackLargeScreenUpsellModalViewed,
+  type LargeScreenUpsellSharedAnalyticsProps,
+} from "./analytics";
+
+function buildSharedAnalyticsProps({
+  deviceModelId,
+  personalizedRecommendationsEnabled,
+  retries,
+  killThreshold,
+}: {
+  deviceModelId: NanoDeviceModelId;
+  personalizedRecommendationsEnabled: boolean;
+  retries: number;
+  killThreshold: number | undefined;
+}): LargeScreenUpsellSharedAnalyticsProps {
+  return {
+    deviceModel: toLargeScreenUpsellDeviceModelAnalyticsValue(deviceModelId),
+    personalRecoOptIn: personalizedRecommendationsEnabled,
+    offerType: personalizedRecommendationsEnabled ? "discount" : "none",
+    platform: "lwd",
+    retriesUpsellModal: retries,
+    throttled: killThreshold !== undefined && retries >= killThreshold,
+  };
+}
 
 export function LargeScreenUpsellModalMount() {
   const { t } = useTranslation();
@@ -21,6 +55,8 @@ export function LargeScreenUpsellModalMount() {
   const onboardingDate = useSelector(onboardingDateSelector);
   const theme = useSelector(themeSelector);
   const personalizedRecommendationsEnabled = useSelector(sharePersonalizedRecommendationsSelector);
+  const retries = useSelector(retriesUpsellModalSelector);
+  const feature = useFeature("largeScreenUpsell");
   const shouldShowDeferredModals = useShouldShowDeferredModals();
   const isGenericAwarenessModalOpen = useSelector(selectIsGenericAwarenessModalOpen);
 
@@ -32,6 +68,47 @@ export function LargeScreenUpsellModalMount() {
       hasSeenCompetingAppStartModalRef.current = true;
     }
   }, [hasCompetingAppStartModal]);
+
+  const currentModalAnalyticsPropsRef = useRef<LargeScreenUpsellSharedAnalyticsProps | null>(null);
+
+  const killThreshold = feature?.params?.modal?.killThreshold;
+
+  const getAnalyticsPropsForDevice = useCallback(
+    (deviceModelId: NanoDeviceModelId) =>
+      buildSharedAnalyticsProps({
+        deviceModelId,
+        personalizedRecommendationsEnabled,
+        retries,
+        killThreshold,
+      }),
+    [personalizedRecommendationsEnabled, retries, killThreshold],
+  );
+
+  const analytics: LargeScreenUpsellModalAnalyticsPorts = useMemo(
+    () => ({
+      onModalViewed: ({ deviceModelId }: LargeScreenUpsellModalViewedContext) => {
+        const sharedProps = getAnalyticsPropsForDevice(deviceModelId);
+        currentModalAnalyticsPropsRef.current = sharedProps;
+        trackLargeScreenUpsellModalViewed(sharedProps);
+      },
+      onCtaClicked: () => {
+        if (currentModalAnalyticsPropsRef.current) {
+          trackLargeScreenUpsellModalCtaClicked(currentModalAnalyticsPropsRef.current);
+        }
+        currentModalAnalyticsPropsRef.current = null;
+      },
+      onDismissed: (dismissMethod: LargeScreenUpsellDismissMethod) => {
+        if (currentModalAnalyticsPropsRef.current) {
+          trackLargeScreenUpsellModalDismissed(
+            dismissMethod,
+            currentModalAnalyticsPropsRef.current,
+          );
+        }
+        currentModalAnalyticsPropsRef.current = null;
+      },
+    }),
+    [getAnalyticsPropsForDevice],
+  );
 
   if (hasCompetingAppStartModal || hasSeenCompetingAppStartModalRef.current) {
     return null;
@@ -50,6 +127,7 @@ export function LargeScreenUpsellModalMount() {
       variant={personalizedRecommendationsEnabled ? "opted_in" : "opted_out"}
       t={t}
       openUrl={openURL}
+      analytics={analytics}
     />
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
@@ -1,14 +1,38 @@
 import React from "react";
 import { DeviceModelId } from "@ledgerhq/types-devices";
-import { act, render, screen, waitFor, withFlagOverrides, type DeepPartial } from "tests/testSetup";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  withFlagOverrides,
+  type DeepPartial,
+} from "tests/testSetup";
 import type { State } from "~/renderer/reducers";
 import { closeDialog, openDialog } from "~/renderer/reducers/dialogs";
 import { openURL } from "~/renderer/linking";
+import { track, trackPage } from "~/renderer/analytics/segment";
 import { LargeScreenUpsellModalMount } from "..";
 
 jest.mock("~/renderer/linking", () => ({
   openURL: jest.fn(),
 }));
+
+const NANO_S_OPTED_OUT_ANALYTICS_PROPS = {
+  deviceModel: "lns",
+  personalRecoOptIn: false,
+  offerType: "none",
+  platform: "lwd",
+  retriesUpsellModal: 0,
+  throttled: false,
+};
+
+const NANO_S_OPTED_IN_ANALYTICS_PROPS = {
+  ...NANO_S_OPTED_OUT_ANALYTICS_PROPS,
+  personalRecoOptIn: true,
+  offerType: "discount",
+};
 
 const NOW = new Date("2026-07-15T12:00:00.000Z");
 
@@ -42,6 +66,8 @@ function eligibleState(settingsOverrides: Partial<State["settings"]> = {}): Deep
 describe("LargeScreenUpsellModalMount (integration)", () => {
   beforeEach(() => {
     jest.mocked(openURL).mockClear();
+    jest.mocked(track).mockClear();
+    jest.mocked(trackPage).mockClear();
     jest
       .useFakeTimers({
         doNotFake: [
@@ -91,6 +117,18 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
       ),
     ).toBeVisible();
     expect(screen.getByRole("button", { name: "Explore touchscreen signers" })).toBeVisible();
+    expect(trackPage).toHaveBeenCalledWith(
+      "Modal - Upgrade",
+      undefined,
+      {
+        name: "Modal - Upgrade",
+        sourceFlow: "app start",
+        modalFrequencyState: "every start",
+        ...NANO_S_OPTED_OUT_ANALYTICS_PROPS,
+      },
+      true,
+      false,
+    );
   });
 
   it("should open with opted-in copy when personalized recommendations are on", async () => {
@@ -110,6 +148,18 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
         "Enjoy a larger screen, smarter transaction reviews, enhanced protection, and an exclusive 20% off.",
       ),
     ).toBeVisible();
+    expect(trackPage).toHaveBeenCalledWith(
+      "Modal - Upgrade",
+      undefined,
+      {
+        name: "Modal - Upgrade",
+        sourceFlow: "app start",
+        modalFrequencyState: "every start",
+        ...NANO_S_OPTED_IN_ANALYTICS_PROPS,
+      },
+      true,
+      false,
+    );
   });
 
   it("should open the opted-out shop link with desktop UTMs when the CTA is pressed", async () => {
@@ -147,6 +197,12 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     expect(openedUrl.searchParams.get("utm_campaign")).toBe("upsell_large_screen");
     expect(openedUrl.searchParams.get("utm_content")).toBe("app_start_modal");
     expect(store.getState().largeScreenUpsellModal.retries).toBe(0);
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "explore large screen devices",
+      page: "Modal - Upgrade",
+      ...NANO_S_OPTED_OUT_ANALYTICS_PROPS,
+    });
+    expect(track).not.toHaveBeenCalledWith("modal_dismissed", expect.anything());
   });
 
   it("should open the opted-in shop link with desktop UTMs when the CTA is pressed", async () => {
@@ -185,6 +241,11 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     expect(openedUrl.searchParams.get("utm_medium")).toBe("desktop");
     expect(openedUrl.searchParams.get("utm_campaign")).toBe("upsell_large_screen");
     expect(openedUrl.searchParams.get("utm_content")).toBe("app_start_modal");
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "explore large screen devices",
+      page: "Modal - Upgrade",
+      ...NANO_S_OPTED_IN_ANALYTICS_PROPS,
+    });
   });
 
   it("should increment retries and set lastSeenAt when the modal opens", async () => {
@@ -220,6 +281,15 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     expect(openURL).not.toHaveBeenCalled();
     expect(store.getState().largeScreenUpsellModal.retries).toBe(1);
     expect(screen.queryByTestId("large-screen-upsell-modal")).not.toBeInTheDocument();
+    expect(track).toHaveBeenCalledWith("modal_dismissed", {
+      modal: "upgrade modal",
+      page: "Modal - Upgrade",
+      dismissMethod: "close button",
+      ...NANO_S_OPTED_OUT_ANALYTICS_PROPS,
+    });
+    expect(
+      jest.mocked(track).mock.calls.filter(([event]) => event === "modal_dismissed"),
+    ).toHaveLength(1);
   });
 
   it("should close and reset retries without opening a URL when the CTA link is empty", async () => {
@@ -290,6 +360,17 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     await waitFor(() => {
       expect(screen.getByTestId("large-screen-upsell-modal")).toBeVisible();
     });
+
+    expect(trackPage).toHaveBeenCalledWith(
+      "Modal - Upgrade",
+      undefined,
+      expect.objectContaining({
+        retriesUpsellModal: 2,
+        throttled: false,
+      }),
+      true,
+      false,
+    );
   });
 
   it("should render opted-in copy with the configured discount", async () => {
@@ -457,6 +538,17 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     await waitFor(() => {
       expect(screen.getByTestId("large-screen-upsell-modal")).toBeVisible();
     });
+
+    expect(trackPage).toHaveBeenCalledWith(
+      "Modal - Upgrade",
+      undefined,
+      expect.objectContaining({
+        retriesUpsellModal: 3,
+        throttled: true,
+      }),
+      true,
+      false,
+    );
   });
 
   it("should not open when a product tour is competing", async () => {
@@ -553,5 +645,51 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
       expect(screen.queryByTestId("large-screen-upsell-modal")).not.toBeInTheDocument();
     });
     expect(store.getState().largeScreenUpsellModal.retries).toBe(1);
+  });
+
+  it("should dismiss via Escape and outside tap with the matching dismissMethod", async () => {
+    const { unmount: unmountEscape } = renderMount();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("large-screen-upsell-modal")).toBeVisible();
+    });
+
+    fireEvent.keyDown(screen.getByTestId("large-screen-upsell-modal"), {
+      key: "Escape",
+      code: "Escape",
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("large-screen-upsell-modal")).not.toBeInTheDocument();
+    });
+
+    expect(track).toHaveBeenCalledWith("modal_dismissed", {
+      modal: "upgrade modal",
+      page: "Modal - Upgrade",
+      dismissMethod: "escape key down",
+      ...NANO_S_OPTED_OUT_ANALYTICS_PROPS,
+    });
+    expect(track).not.toHaveBeenCalledWith("button_clicked", expect.anything());
+
+    unmountEscape();
+    jest.mocked(track).mockClear();
+    jest.mocked(trackPage).mockClear();
+
+    renderMount();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("large-screen-upsell-modal")).toBeVisible();
+    });
+
+    fireEvent.pointerDown(document.body, { button: 0, clientX: 0, clientY: 0 });
+
+    await waitFor(() => {
+      expect(track).toHaveBeenCalledWith("modal_dismissed", {
+        modal: "upgrade modal",
+        page: "Modal - Upgrade",
+        dismissMethod: "outside tap",
+        ...NANO_S_OPTED_OUT_ANALYTICS_PROPS,
+      });
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__tests__/analytics.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__tests__/analytics.test.ts
@@ -1,0 +1,58 @@
+import { track, trackPage } from "~/renderer/analytics/segment";
+import {
+  LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME,
+  toLargeScreenUpsellDeviceModelAnalyticsValue,
+  trackLargeScreenUpsellModalCtaClicked,
+  trackLargeScreenUpsellModalDismissed,
+  trackLargeScreenUpsellModalViewed,
+  type LargeScreenUpsellSharedAnalyticsProps,
+} from "../analytics";
+
+const SHARED_PROPS: LargeScreenUpsellSharedAnalyticsProps = {
+  deviceModel: "lns",
+  personalRecoOptIn: false,
+  offerType: "none",
+  platform: "lwd",
+  retriesUpsellModal: 0,
+  throttled: false,
+};
+
+describe("LargeScreenUpsell analytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should map device models and emit view, CTA, and dismiss payloads", () => {
+    expect(toLargeScreenUpsellDeviceModelAnalyticsValue("nanoS")).toBe("lns");
+    expect(toLargeScreenUpsellDeviceModelAnalyticsValue("nanoSP")).toBe("lnsp");
+    expect(toLargeScreenUpsellDeviceModelAnalyticsValue("nanoX")).toBe("lnx");
+
+    trackLargeScreenUpsellModalViewed(SHARED_PROPS);
+    trackLargeScreenUpsellModalCtaClicked(SHARED_PROPS);
+    trackLargeScreenUpsellModalDismissed("escape key down", SHARED_PROPS);
+
+    expect(trackPage).toHaveBeenCalledWith(
+      LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME,
+      undefined,
+      {
+        name: LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME,
+        sourceFlow: "app start",
+        modalFrequencyState: "every start",
+        ...SHARED_PROPS,
+      },
+      true,
+      false,
+    );
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "explore large screen devices",
+      page: LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME,
+      ...SHARED_PROPS,
+    });
+    expect(track).toHaveBeenCalledWith("modal_dismissed", {
+      modal: "upgrade modal",
+      page: LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME,
+      dismissMethod: "escape key down",
+      ...SHARED_PROPS,
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/analytics.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/analytics.ts
@@ -1,0 +1,72 @@
+import type {
+  LargeScreenUpsellDismissMethod,
+  NanoDeviceModelId,
+} from "@features/flow-large-screen-upsell";
+import { track, trackPage } from "~/renderer/analytics/segment";
+
+export const LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME = "Modal - Upgrade";
+
+export type LargeScreenUpsellDeviceModelAnalyticsValue = "lns" | "lnsp" | "lnx";
+
+const DEVICE_MODEL_ANALYTICS_VALUES: Record<
+  NanoDeviceModelId,
+  LargeScreenUpsellDeviceModelAnalyticsValue
+> = {
+  nanoS: "lns",
+  nanoSP: "lnsp",
+  nanoX: "lnx",
+};
+
+export function toLargeScreenUpsellDeviceModelAnalyticsValue(
+  deviceModelId: NanoDeviceModelId,
+): LargeScreenUpsellDeviceModelAnalyticsValue {
+  return DEVICE_MODEL_ANALYTICS_VALUES[deviceModelId];
+}
+
+export type LargeScreenUpsellSharedAnalyticsProps = Readonly<{
+  deviceModel: LargeScreenUpsellDeviceModelAnalyticsValue;
+  personalRecoOptIn: boolean;
+  offerType: "discount" | "none";
+  platform: "lwd";
+  retriesUpsellModal: number;
+  throttled: boolean;
+}>;
+
+export function trackLargeScreenUpsellModalViewed(
+  sharedProps: LargeScreenUpsellSharedAnalyticsProps,
+) {
+  trackPage(
+    LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME,
+    undefined,
+    {
+      name: LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME,
+      sourceFlow: "app start",
+      modalFrequencyState: "every start",
+      ...sharedProps,
+    },
+    true,
+    false,
+  );
+}
+
+export function trackLargeScreenUpsellModalCtaClicked(
+  sharedProps: LargeScreenUpsellSharedAnalyticsProps,
+) {
+  track("button_clicked", {
+    button: "explore large screen devices",
+    page: LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME,
+    ...sharedProps,
+  });
+}
+
+export function trackLargeScreenUpsellModalDismissed(
+  dismissMethod: LargeScreenUpsellDismissMethod,
+  sharedProps: LargeScreenUpsellSharedAnalyticsProps,
+) {
+  track("modal_dismissed", {
+    modal: "upgrade modal",
+    page: LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME,
+    dismissMethod,
+    ...sharedProps,
+  });
+}

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -154,6 +154,21 @@ const getProductTourAttributes = () => {
   };
 };
 
+const getLargeScreenUpsellAttributes = () => {
+  if (!analyticsFeatureFlagMethod) return {};
+  const flag = analyticsFeatureFlagMethod("largeScreenUpsell");
+  const params = flag?.params;
+
+  return {
+    enabled: !!flag?.enabled,
+    modalEnabled: !!params?.modal?.enabled,
+    killThreshold: params?.modal?.killThreshold,
+    cadenceDays: params?.modal?.cadenceDays,
+    cooldownDays: params?.cooldownDays,
+    discount: params?.discount,
+  };
+};
+
 const getPtxAttributes = () => {
   if (!analyticsFeatureFlagMethod) return {};
   const fetchAdditionalCoins = analyticsFeatureFlagMethod("fetchAdditionalCoins");
@@ -269,6 +284,7 @@ const extraProperties = (store: ReduxStore) => {
   const addAccountAttributes = getAddAccountAttributes();
   const backupHubAttributes = getBackupHubAttributes();
   const productTourAttributes = getProductTourAttributes();
+  const largeScreenUpsellAttributes = getLargeScreenUpsellAttributes();
 
   const deviceInfo = device
     ? {
@@ -340,6 +356,7 @@ const extraProperties = (store: ReduxStore) => {
     ...addAccountAttributes,
     ...backupHubAttributes,
     ...productTourAttributes,
+    largeScreenUpsellAttributes,
     madAttributes,
     isLDMKTransportEnabled: ldmkTransport?.enabled,
     isLDMKConnectAppEnabled: ldmkConnectApp?.enabled,

--- a/features/flow/large-screen-upsell/README.md
+++ b/features/flow/large-screen-upsell/README.md
@@ -10,8 +10,9 @@ portable modal UI (Lumen Dialog) and content helpers.
 - `buildLargeScreenUpsellCtaLink` / `buildLargeScreenUpsellContent` — pure helpers
 - `LargeScreenUpsellModal` — Lumen Dialog (web) with mobile-matched copy/assets
 - `LARGE_SCREEN_UPSELL_IMAGES` — light/dark hero webps
+- `LargeScreenUpsellModalAnalyticsPorts` — optional viewed / CTA / dismiss callbacks for app-owned Segment
 
-Apps wire theme + i18n + `openUrl` into the ViewModel.
+Apps wire theme + i18n + `openUrl` + analytics into the ViewModel.
 
 Nothing inside `internal/` is exported.
 

--- a/features/flow/large-screen-upsell/src/index.ts
+++ b/features/flow/large-screen-upsell/src/index.ts
@@ -9,3 +9,8 @@ export { LargeScreenUpsellModal } from "./screens/LargeScreenUpsellModal";
 export type { LargeScreenUpsellModalProps } from "./screens/LargeScreenUpsellModal";
 export type { LargeScreenUpsellModalViewModel } from "./screens/LargeScreenUpsellModal/types";
 export type { UseLargeScreenUpsellModalViewModelInput } from "./screens/LargeScreenUpsellModal/useLargeScreenUpsellModalViewModel";
+export type {
+  LargeScreenUpsellDismissMethod,
+  LargeScreenUpsellModalAnalyticsPorts,
+  LargeScreenUpsellModalViewedContext,
+} from "./screens/LargeScreenUpsellModal/analyticsPorts";

--- a/features/flow/large-screen-upsell/src/screens/LargeScreenUpsellModal/LargeScreenUpsellModalView.web.tsx
+++ b/features/flow/large-screen-upsell/src/screens/LargeScreenUpsellModal/LargeScreenUpsellModalView.web.tsx
@@ -9,7 +9,7 @@ export function LargeScreenUpsellModalView({
   title,
   subtitle,
   primaryButtonLabel,
-  onClose,
+  onDismiss,
   onCtaPress,
 }: LargeScreenUpsellModalViewModel) {
   return (
@@ -17,17 +17,17 @@ export function LargeScreenUpsellModalView({
       open={isOpen}
       onOpenChange={open => {
         if (!open) {
-          onClose();
+          onDismiss("close button");
         }
       }}
     >
       <DialogContent
         className="max-h-[90vh] rounded-xl"
         data-testid="large-screen-upsell-modal"
-        onPointerDownOutside={onClose}
-        onEscapeKeyDown={onClose}
+        onPointerDownOutside={() => onDismiss("outside tap")}
+        onEscapeKeyDown={() => onDismiss("escape key down")}
       >
-        <DialogHeader density="expanded" onClose={onClose} />
+        <DialogHeader density="expanded" onClose={() => onDismiss("close button")} />
         <DialogBody className="flex min-h-0 flex-1 flex-col gap-24 overflow-hidden">
           <LargeScreenUpsellModalContent
             imageSrc={imageSrc}

--- a/features/flow/large-screen-upsell/src/screens/LargeScreenUpsellModal/analyticsPorts.ts
+++ b/features/flow/large-screen-upsell/src/screens/LargeScreenUpsellModal/analyticsPorts.ts
@@ -1,0 +1,13 @@
+import type { NanoDeviceModelId } from "../../types";
+
+export type LargeScreenUpsellDismissMethod = "close button" | "outside tap" | "escape key down";
+
+export type LargeScreenUpsellModalViewedContext = Readonly<{
+  deviceModelId: NanoDeviceModelId;
+}>;
+
+export type LargeScreenUpsellModalAnalyticsPorts = Readonly<{
+  onModalViewed: (context: LargeScreenUpsellModalViewedContext) => void;
+  onCtaClicked: () => void;
+  onDismissed: (method: LargeScreenUpsellDismissMethod) => void;
+}>;

--- a/features/flow/large-screen-upsell/src/screens/LargeScreenUpsellModal/types.ts
+++ b/features/flow/large-screen-upsell/src/screens/LargeScreenUpsellModal/types.ts
@@ -1,9 +1,11 @@
+import type { LargeScreenUpsellDismissMethod } from "./analyticsPorts";
+
 export type LargeScreenUpsellModalViewModel = {
   isOpen: boolean;
   imageSrc: string;
   title: string;
   subtitle: string;
   primaryButtonLabel: string;
-  onClose: () => void;
+  onDismiss: (method: LargeScreenUpsellDismissMethod) => void;
   onCtaPress: () => void;
 };

--- a/features/flow/large-screen-upsell/src/screens/LargeScreenUpsellModal/useLargeScreenUpsellModalViewModel.ts
+++ b/features/flow/large-screen-upsell/src/screens/LargeScreenUpsellModal/useLargeScreenUpsellModalViewModel.ts
@@ -15,6 +15,10 @@ import {
   type BuildLargeScreenUpsellContentInput,
   type LargeScreenUpsellVariant,
 } from "../../utils/upsellContent";
+import type {
+  LargeScreenUpsellDismissMethod,
+  LargeScreenUpsellModalAnalyticsPorts,
+} from "./analyticsPorts";
 import type { LargeScreenUpsellModalViewModel } from "./types";
 
 const LARGE_SCREEN_UPSELL_MODAL_ID = "large-screen-upsell-modal";
@@ -25,6 +29,7 @@ export type UseLargeScreenUpsellModalViewModelInput = UseLargeScreenUpsellDecisi
   variant: LargeScreenUpsellVariant;
   t: BuildLargeScreenUpsellContentInput["t"];
   openUrl: (url: string) => void;
+  analytics?: LargeScreenUpsellModalAnalyticsPorts;
 };
 
 export function useLargeScreenUpsellModalViewModel({
@@ -37,6 +42,7 @@ export function useLargeScreenUpsellModalViewModel({
   variant,
   t,
   openUrl,
+  analytics,
 }: UseLargeScreenUpsellModalViewModelInput): LargeScreenUpsellModalViewModel {
   const dispatch = useDispatch();
   const feature = useFeature("largeScreenUpsell");
@@ -48,6 +54,7 @@ export function useLargeScreenUpsellModalViewModel({
   });
   const [isOpen, setIsOpen] = useState(false);
   const hasOpenedRef = useRef(false);
+  const hasHandledCurrentModalInteractionRef = useRef(false);
 
   const params = feature?.params;
   const content = useMemo(() => {
@@ -69,29 +76,50 @@ export function useLargeScreenUpsellModalViewModel({
   }, [medium, params, t, variant]);
 
   const hasContent = content !== null;
+  const viewedDeviceModelId = decision.shouldShow ? decision.deviceModelId : undefined;
 
   useEffect(() => {
-    if (!decision.shouldShow || !hasContent || hasOpenedRef.current) {
+    if (viewedDeviceModelId === undefined || !hasContent || hasOpenedRef.current) {
       return;
     }
 
     hasOpenedRef.current = true;
+    hasHandledCurrentModalInteractionRef.current = false;
+    analytics?.onModalViewed({ deviceModelId: viewedDeviceModelId });
     setIsOpen(true);
     dispatch(recordUpsellModalDisplay());
-  }, [decision.shouldShow, dispatch, hasContent]);
+  }, [viewedDeviceModelId, dispatch, hasContent, analytics]);
 
-  const onClose = useCallback(() => {
-    setIsOpen(false);
-  }, []);
+  const onDismiss = useCallback(
+    (method: LargeScreenUpsellDismissMethod) => {
+      if (hasHandledCurrentModalInteractionRef.current) {
+        setIsOpen(false);
+        return;
+      }
+
+      hasHandledCurrentModalInteractionRef.current = true;
+      analytics?.onDismissed(method);
+      setIsOpen(false);
+    },
+    [analytics],
+  );
 
   const onCtaPress = useCallback(() => {
+    if (hasHandledCurrentModalInteractionRef.current) {
+      setIsOpen(false);
+      return;
+    }
+
+    hasHandledCurrentModalInteractionRef.current = true;
+    analytics?.onCtaClicked();
+
     const link = content?.primaryButtonLink?.trim();
     if (link) {
       openUrl(link);
     }
     dispatch(resetUpsellModalRetries());
     setIsOpen(false);
-  }, [content?.primaryButtonLink, dispatch, openUrl]);
+  }, [analytics, content?.primaryButtonLink, dispatch, openUrl]);
 
   return {
     isOpen,
@@ -102,7 +130,7 @@ export function useLargeScreenUpsellModalViewModel({
     title: content?.title ?? "",
     subtitle: content?.subtitle ?? "",
     primaryButtonLabel: content?.primaryButtonLabel ?? "",
-    onClose,
+    onDismiss,
     onCtaPress,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Segment events on the app-start large-screen upsell modal (view, CTA, dismiss)
  - Dismiss methods: close button, outside tap, escape key down
  - Props frozen at open: `retriesUpsellModal`, `throttled`, `offerType`, `deviceModel`, `platform: lwd`
  - CTA does not emit `modal_dismissed`; duplicate closes fire once

### 📝 Description

Desktop had no Segment coverage for the app-start large-screen upsell modal. Product needs view, CTA, and dismiss events to measure reach and fatigue.

Desktop owns Segment in `analytics.ts` and the mount. `@features/flow-large-screen-upsell` only exposes optional ports (`onModalViewed`, `onCtaClicked`, `onDismissed`) and maps Dialog gestures to dismiss methods. Event names match Mobile and the corrected tracking plan (`Modal - Upgrade`). Desktop adds `dismissMethod: "escape key down"`. We skipped `deeplink_clicked`.

Targets [PR #19643](https://github.com/LedgerHQ/ledger-live/pull/19643) (LIVE-33162).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33163](https://ledgerhq.atlassian.net/browse/LIVE-33163)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33163]: https://ledgerhq.atlassian.net/browse/LIVE-33163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ