### PR TITLE
ci: move check-export-rules to domain workflow, remove from libs

### DIFF
--- a/.github/workflows/test-domain-reusable.yml
+++ b/.github/workflows/test-domain-reusable.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Install dependencies
         run: pnpm i --filter="./domain/**" --filter="./shared/**"
 
+      - name: Check export rules
+        run: pnpm exec nx run-many -t check-export-rules
+
       - name: Run coverage on domain packages
         run: |
           mkdir -p ${{ github.workspace }}/coverage

--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -170,8 +170,6 @@ jobs:
       - name: Lint affected libraries
         id: lint-libs
         run: pnpm exec nx run-many -t lint --exclude=ledger-live-desktop,live-mobile,@ledgerhq/live-cli,@ledgerhq/web-tools,ledger-live-desktop-e2e-tests,ledger-live-mobile-e2e-tests --parallel=3 --nxBail=false -- --quiet
-      - name: Check export rules
-        run: pnpm exec nx run @ledgerhq/client-ids:check-export-rules
       - name: Typecheck affected libraries
         id: typecheck-libs
         run: pnpm exec nx run-many -t typecheck --exclude=ledger-live-desktop,live-mobile,@ledgerhq/live-cli,@ledgerhq/web-tools,ledger-live-desktop-e2e-tests,ledger-live-mobile-e2e-tests --parallel=3 --nxBail=false


### PR DESCRIPTION
### 📝 Description

Moves the `check-export-rules` CI step from `test-libs-reusable.yml` to `test-domain-reusable.yml` and switches from a single-package invocation to `nx run-many`.

In anticipation of #19552 (where `check-export-rules` becomes a domain-only target), the step no longer belongs in the libs workflow.

### 🔗 Context

- **JIRA / GitHub issue**: anticipates #19552
- **ADR** (if any): N/A