### PR TITLE
[LWM] fix(mobile): fix extra spacing between experimental header and wallet 4.0 top bar

### DIFF
--- a/.changeset/brave-clocks-sleep.md
+++ b/.changeset/brave-clocks-sleep.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix extra spacing between experimental header and wallet 4.0 top bar

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -7,7 +7,11 @@ import "./utils/tanstack-setup";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import React, { Component, useMemo, useEffect, useRef } from "react";
 import { StyleSheet, LogBox, Appearance, AppState, View } from "react-native";
-import { SafeAreaProvider } from "react-native-safe-area-context";
+import {
+  SafeAreaProvider,
+  SafeAreaInsetsContext,
+  useSafeAreaInsets,
+} from "react-native-safe-area-context";
 import { I18nextProvider } from "react-i18next";
 import Transport from "@ledgerhq/hw-transport";
 import { NotEnoughBalance } from "@ledgerhq/errors";
@@ -42,7 +46,9 @@ import SegmentSetup from "~/analytics/SegmentSetup";
 import HookNotifications from "~/notifications/HookNotifications";
 import RootNavigator from "~/components/RootNavigator";
 import SetEnvsFromSettings from "~/components/SetEnvsFromSettings";
-import ExperimentalHeader from "~/screens/Settings/Experimental/ExperimentalHeader";
+import ExperimentalHeader, {
+  useIsExperimentalHeaderVisible,
+} from "~/screens/Settings/Experimental/ExperimentalHeader";
 import Modals from "~/screens/Modals";
 import NavBarColorHandler from "~/components/NavBarColorHandler";
 import { TermsAndConditionMigrateLegacyData } from "~/logic/terms";
@@ -265,6 +271,16 @@ function App() {
  * SafeAreaView).
  */
 function AppView() {
+  const insets = useSafeAreaInsets();
+  const isExperimentalHeaderVisible = useIsExperimentalHeaderVisible();
+
+  // When ExperimentalHeader is visible it occupies the top safe-area space so
+  // components inside the navigator must not re-apply insets.top.
+  const adjustedInsets = useMemo(
+    () => (isExperimentalHeaderVisible ? { ...insets, top: 0 } : insets),
+    [insets, isExperimentalHeaderVisible],
+  );
+
   // TODO: Normally, we should use a SafeAreaView as root view to avoid
   // importing it everywhere and recalculating the insets.
   return (
@@ -277,9 +293,11 @@ function AppView() {
       }}
     >
       <ExperimentalHeader />
-      <View style={{ flex: 1 }}>
-        <RootNavigator />
-      </View>
+      <SafeAreaInsetsContext.Provider value={adjustedInsets}>
+        <View style={{ flex: 1 }}>
+          <RootNavigator />
+        </View>
+      </SafeAreaInsetsContext.Provider>
     </View>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Experimental/ExperimentalHeader.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Experimental/ExperimentalHeader.tsx
@@ -25,6 +25,15 @@ import { featureFlagsBannerVisibleSelector } from "@shared/feature-flags";
 export const HEIGHT = 30;
 export const PADDING = 8;
 
+export function useIsExperimentalHeaderVisible(): boolean {
+  const isExperimental = useExperimental();
+  const hasLocallyOverriddenFlags = useHasLocallyOverriddenFeatureFlags();
+  const featureFlagsBannerVisible = useSelector(featureFlagsBannerVisibleSelector);
+  const isMock = !!Config.MOCK;
+  const areFeatureFlagsOverridden = featureFlagsBannerVisible && hasLocallyOverriddenFlags;
+  return isMock || isExperimental || areFeatureFlagsOverridden;
+}
+
 const ANIMATION_DURATION = 200;
 const ANIMATION_CONFIG = { duration: ANIMATION_DURATION };
 const CLOSED_STATE = 0;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Visual/layout fix — covered by manual testing on simulator._
- [x] **Impact of the changes:**
  - Experimental header banner spacing on wallet 4.0 home screen
  - All screens inside the main navigator that use `useSafeAreaInsets().top` (TopBar, PortfolioHeaderSection, etc.)
  - No impact when experimental mode is off (production path unchanged)

### 📝 Description

When the `ExperimentalHeader` banner is visible, it occupies the top safe-area space (status bar height). Because it lives *above* the `RootNavigator` in a flex column, the navigator starts below the safe area — but every component inside still called `useSafeAreaInsets().top` and re-applied that offset, producing a double gap equal to the status bar height (~47 px on modern iPhones).

The fix overrides `SafeAreaInsetsContext` for the navigator subtree with `top: 0` whenever the banner is visible. This lets `MainNavigatorTopBarHeader`, `PortfolioHeaderSection`, and any other consumer automatically get the correct value with no per-screen changes.


https://github.com/user-attachments/assets/a7a571fb-4a47-4f63-98ff-5d44a728d2d3



### ❓ Context

- **JIRA or GitHub link**: [LIVE-31580](https://ledgerhq.atlassian.net/browse/LIVE-31580)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-31580]: https://ledgerhq.atlassian.net/browse/LIVE-31580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ