### PR TITLE
ci: fix publishing of builds

### DIFF
--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -74,10 +74,10 @@ jobs:
           ruby-version: 3.3.0
 
       - name: install dependencies
-        run: pnpm i -F "ledger-live" -F "{libs/**}..." -F "@ledgerhq/live-cli" -F "@ledgerhq/wallet-cli..." -F "@ledgerhq/wallet-cli-*"
+        run: pnpm i -F "ledger-live" -F "{libs/**}..." -F "@ledgerhq/live-cli..." -F "@ledgerhq/wallet-cli..." -F "@ledgerhq/wallet-cli-*"
 
       - name: build libs
-        run: pnpm exec nx run-many -t build --projects=tag:scope:libs
+        run: pnpm exec nx run-many -t build --projects=tag:scope:libs,@ledgerhq/live-e2e-shared
 
       - name: authenticate with npm
         uses: actions/setup-node@v4


### PR DESCRIPTION


### 📝 Description

Following QAA changes to live-cli the following fix had to be put in place: https://github.com/LedgerHQ/ledger-live/pull/19323

This in turn led to a [refactor request](https://ledgerhq.atlassian.net/browse/QAA-1379) which was [completed](https://github.com/LedgerHQ/ledger-live/pull/19312) and prematurely removed (post release creation) the extra build targeting which caused release to fail. This PR re-introduces the step to stabalise the release process with a follow up ticket spawned for 1 month time.

### 🎫 Tickets

- Fix: [LIVE-34486](https://ledgerhq.atlassian.net/browse/LIVE-34486) — Re-introduce shared e2e build step in `release-final.yml` to stabilise the release process
- Follow-up (~1 month): [LIVE-34487](https://ledgerhq.atlassian.net/browse/LIVE-34487) — Revisit re-introduced shared e2e build step in `release-final.yml` and remove if no longer needed


[LIVE-34486]: https://ledgerhq.atlassian.net/browse/LIVE-34486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34487]: https://ledgerhq.atlassian.net/browse/LIVE-34487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Run
https://github.com/LedgerHQ/ledger-live/actions/runs/29505358180/job/87644602756