### PR TITLE
[LWM] chore(desktop): add Ledger Wallet network logs to the Allure report

### DIFF
--- a/apps/ledger-live-mobile/src/e2e/webviewNetworkLogCapture.ts
+++ b/apps/ledger-live-mobile/src/e2e/webviewNetworkLogCapture.ts
@@ -1,6 +1,6 @@
 /**
  * Injected script to capture fetch/XHR network traffic inside WebViews during e2e tests.
- * Posts log entries to React Native via postMessage for attachment to Allure (like desktop WebviewLogCollector).
+ * Posts log entries to React Native via postMessage for attachment to Allure (like desktop PageLogCollector).
  * No outer IIFE (RN WebView injects the source as-is); locals are block-scoped with let/const. Ends with `true` for RN WebView.
  */
 

--- a/e2e/desktop/tests/fixtures/common.ts
+++ b/e2e/desktop/tests/fixtures/common.ts
@@ -15,7 +15,7 @@ import {
   runCliStep,
 } from "tests/utils/allureUtils";
 import { isLastRetry } from "tests/utils/testInfoUtils";
-import { WebviewLogCollector } from "tests/utils/webviewLogCollector";
+import { PageLogCollector } from "tests/utils/pageLogCollector";
 import { randomUUID } from "crypto";
 import { AppInfos } from "@ledgerhq/live-e2e-shared/enum/AppInfos";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
@@ -265,6 +265,9 @@ export const test = base.extend<TestFixtures>({
     page.setDefaultTimeout(120000);
 
     attachNetworkLogging(page, testInfo);
+    // capture main app (Ledger Wallet) network logs, attached to Allure on failure
+    const appCollector = new PageLogCollector();
+    appCollector.attach(page);
 
     if (process.env.PLAYWRIGHT_CPU_THROTTLING_RATE) {
       const client = await (page.context() as ChromiumBrowserContext).newCDPSession(page);
@@ -288,7 +291,7 @@ export const test = base.extend<TestFixtures>({
     });
 
     // capture webview console and network logs for debugging (e.g. swap live app)
-    const webviewCollector = new WebviewLogCollector();
+    const webviewCollector = new PageLogCollector();
     webviewCollector.start(electronApp);
 
     // app is loaded
@@ -303,7 +306,14 @@ export const test = base.extend<TestFixtures>({
       const takeSpeculosScreenshot = Boolean(
         speculos.device || (cliCommandsOnApp?.length ?? 0) > 0,
       );
-      await captureArtifacts(page, testInfo, electronApp, takeSpeculosScreenshot, webviewCollector);
+      await captureArtifacts(
+        page,
+        testInfo,
+        electronApp,
+        takeSpeculosScreenshot,
+        webviewCollector,
+        appCollector,
+      );
     }
 
     // Remove video if test passed

--- a/e2e/desktop/tests/fixtures/common.ts
+++ b/e2e/desktop/tests/fixtures/common.ts
@@ -292,7 +292,7 @@ export const test = base.extend<TestFixtures>({
 
     // capture webview console and network logs for debugging (e.g. swap live app)
     const webviewCollector = new PageLogCollector();
-    webviewCollector.start(electronApp);
+    webviewCollector.attachWebview(electronApp);
 
     // app is loaded
     await page.waitForLoadState("domcontentloaded");

--- a/e2e/desktop/tests/utils/allureUtils.ts
+++ b/e2e/desktop/tests/utils/allureUtils.ts
@@ -6,7 +6,7 @@ import { getEnv, setEnv } from "@ledgerhq/live-env";
 import { listen } from "@ledgerhq/logs";
 import * as allure from "allure-js-commons";
 import { isLastRetry } from "tests/utils/testInfoUtils";
-import { WebviewLogCollector } from "tests/utils/webviewLogCollector";
+import { PageLogCollector } from "tests/utils/pageLogCollector";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 
 const readFileAsync = promisify(readFile);
@@ -189,7 +189,8 @@ export async function captureArtifacts(
   testInfo: TestInfo,
   electronApp: ElectronApplication,
   takeSpeculosScreenshot: boolean,
-  webviewCollector?: WebviewLogCollector,
+  webviewCollector?: PageLogCollector,
+  appCollector?: PageLogCollector,
 ) {
   const screenshot = await page.screenshot();
   await testInfo.attach("Screenshot", { body: screenshot, contentType: "image/png" });
@@ -226,6 +227,13 @@ export async function captureArtifacts(
 
     await testInfo.attach("Webview Network Logs", {
       body: Buffer.from(webviewCollector.getFormattedNetworkLogs()),
+      contentType: "application/json",
+    });
+  }
+
+  if (appCollector) {
+    await testInfo.attach("Ledger Wallet Network Logs", {
+      body: Buffer.from(appCollector.getFormattedNetworkLogs()),
       contentType: "application/json",
     });
   }

--- a/e2e/desktop/tests/utils/pageLogCollector.ts
+++ b/e2e/desktop/tests/utils/pageLogCollector.ts
@@ -106,17 +106,14 @@ export class PageLogCollector {
     page.on("requestfailed", this.onRequestFailed);
   }
 
-  start(electronApp: ElectronApplication): void {
+  attachWebview(electronApp: ElectronApplication): void {
     electronApp.on("window", (page: Page) => {
-      // Exit early if we've already attached to a webview
       if (this.targetPage) return;
 
-      // In the current implementation, the webview is the second window opened by the app.
-      // If this changes in the future, we may need a more robust way to identify the webview.
+      // The webview is the second window the app opens; revisit this if that assumption changes.
       const windows = electronApp.windows();
       if (windows.length <= 1) return;
 
-      // Attach to the webview page
       this.attach(page);
     });
   }

--- a/e2e/desktop/tests/utils/pageLogCollector.ts
+++ b/e2e/desktop/tests/utils/pageLogCollector.ts
@@ -33,15 +33,16 @@ export class PageLogCollector {
   };
 
   private readonly onRequest = (request: Request) => {
-    const url = request.url();
+    const requestUrl = request.url();
     // skip file://, data:, devtools:, ...
-    if (!/^https?:\/\//.test(url)) return;
-    this.requestsMap.set(request, {
-      timestamp: new Date().toISOString(),
-      method: request.method(),
-      url,
-      pending: true,
-    });
+    if (/^https?:\/\//.test(requestUrl)) {
+      this.requestsMap.set(request, {
+        timestamp: new Date().toISOString(),
+        method: request.method(),
+        url: requestUrl,
+        pending: true,
+      });
+    }
   };
 
   private readonly onResponse = async (response: Response) => {

--- a/e2e/desktop/tests/utils/pageLogCollector.ts
+++ b/e2e/desktop/tests/utils/pageLogCollector.ts
@@ -18,11 +18,11 @@ interface NetworkLog {
   failureText?: string;
 }
 
-export class WebviewLogCollector {
+export class PageLogCollector {
   private readonly consoleLogs: ConsoleLog[] = [];
   private readonly requestsMap: Map<Request, NetworkLog> = new Map();
 
-  private webviewPage: Page | null = null;
+  private targetPage: Page | null = null;
 
   private readonly onConsole = (msg: ConsoleMessage) => {
     this.consoleLogs.push({
@@ -33,10 +33,13 @@ export class WebviewLogCollector {
   };
 
   private readonly onRequest = (request: Request) => {
+    const url = request.url();
+    // skip file://, data:, devtools:, ...
+    if (!/^https?:\/\//.test(url)) return;
     this.requestsMap.set(request, {
       timestamp: new Date().toISOString(),
       method: request.method(),
-      url: request.url(),
+      url,
       pending: true,
     });
   };
@@ -93,8 +96,8 @@ export class WebviewLogCollector {
     }
   };
 
-  private attachToWebview(page: Page): void {
-    this.webviewPage = page;
+  attach(page: Page): void {
+    this.targetPage = page;
     page.on("console", this.onConsole);
     page.on("request", this.onRequest);
     page.on("response", this.onResponse);
@@ -105,7 +108,7 @@ export class WebviewLogCollector {
   start(electronApp: ElectronApplication): void {
     electronApp.on("window", (page: Page) => {
       // Exit early if we've already attached to a webview
-      if (this.webviewPage) return;
+      if (this.targetPage) return;
 
       // In the current implementation, the webview is the second window opened by the app.
       // If this changes in the future, we may need a more robust way to identify the webview.
@@ -113,7 +116,7 @@ export class WebviewLogCollector {
       if (windows.length <= 1) return;
 
       // Attach to the webview page
-      this.attachToWebview(page);
+      this.attach(page);
     });
   }
 

--- a/e2e/desktop/tests/utils/pageLogCollector.ts
+++ b/e2e/desktop/tests/utils/pageLogCollector.ts
@@ -129,8 +129,8 @@ export class PageLogCollector {
   }
 
   getFormattedNetworkLogs(): string {
-    if (this.requestsMap.size === 0) return "";
-
+    // Always return valid JSON: an empty map serializes to "[]", which keeps the
+    // application/json attachment parseable instead of an empty (invalid) body.
     const logEntriesArray = Array.from(this.requestsMap.values());
     return JSON.stringify(logEntriesArray, null, 2);
   }


### PR DESCRIPTION
### ✅ Checklist

- [x] No changeset needed — all changes are limited to `e2e/` (no published package is impacted).
- [ ] **Covered by automatic tests.** _This is E2E test-reporting infrastructure; it is exercised by the E2E suite itself and was verified manually by running a failing desktop E2E test and confirming the new attachment in the Allure report (see test plan below)._
- [x] **Impact of the changes:**
  - New **"Ledger Wallet Network Logs"** attachment on **failed** desktop E2E tests, sitting next to the existing "Webview Network Logs".
  - Captures the **main app window's** HTTP(S) traffic (e.g. `countervalues.live.ledger.com`, `global.api.prd.ledger.com/cal/v1/tokens`, swap backend, sanctioned-address checks).
  - Only `http(s)` requests are recorded — local `file://` bundle loads and `data:`/`devtools:` URLs are filtered out.
  - Request/response bodies are captured only for `status >= 400` (keeps the artifact small and limits sensitive-data exposure).
  - Passing tests produce no such attachment.

### 📝 Description

The desktop E2E Allure report only contained **"Webview Network Logs"** — the traffic of the embedded swap live-app webview. Requests made by the **main Ledger Live app** (countervalues, account/token sync, swap backend, sanctioned-address checks, explorers…) were not captured anywhere, so failures whose root cause is an app-level request were hard to investigate.

This PR adds a second attachment, in the same JSON format, carrying the **main app's** network logs, **on failed tests only**:

- `tests/utils/webviewLogCollector.ts` → renamed to `tests/utils/pageLogCollector.ts` (`WebviewLogCollector` → `PageLogCollector`). The page-attach method is now public (`attach(page)`) so a collector can bind to any window; `start(electronApp)` is still used to locate the webview (2nd window). `onRequest` now records only `^https?://` requests.
- `tests/utils/allureUtils.ts` — `captureArtifacts` accepts an `appCollector` and attaches **"Ledger Wallet Network Logs"** (`application/json`) alongside the webview block, inheriting the existing failure-only gating.
- `tests/fixtures/common.ts` — a `PageLogCollector` is attached to the main window (`electronApp.firstWindow()`) and passed to `captureArtifacts`.

This works because the app's `libs/live-network` traffic uses the axios XHR adapter in the renderer, so it goes through Chromium and is visible to Playwright's `page.on(...)` — the same mechanism already used for the webview.

**Test plan**

- Ran a failing desktop E2E test → the report shows a **"Ledger Wallet Network Logs"** attachment containing real backend calls (`countervalues.live.ledger.com`, `global.api.prd.ledger.com/cal/v1/tokens`, …), distinct from "Webview Network Logs".
- Confirmed a passing test produces no such attachment.

**Follow-up (out of scope)**

Mobile (Detox) app network logs use a different, app-side mechanism (`log-report` / `@ledgerhq/logs` + `ENABLE_NETWORK_LOGS` + the e2e bridge) and are tracked in a separate ticket.

### ❓ Context

- **JIRA or GitHub link**: [QAA-1287](https://ledgerhq.atlassian.net/browse/QAA-1287)
- **CI**: https://github.com/LedgerHQ/ledger-live/actions/runs/29509151914

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1287]: https://ledgerhq.atlassian.net/browse/QAA-1287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ