### PR TITLE
[LWDM] chore(mobile,desktop): add product tour analytics flags

### DIFF
--- a/.changeset/plain-tours-track.md
+++ b/.changeset/plain-tours-track.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Include LWD and LWM product tour feature flags in analytics attributes.

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -145,6 +145,15 @@ const getBackupHubAttributes = () => {
   };
 };
 
+const getProductTourAttributes = () => {
+  if (!analyticsFeatureFlagMethod) return {};
+  const productTour = analyticsFeatureFlagMethod("lwdProductTour");
+
+  return {
+    lwdProductTour: !!productTour?.enabled,
+  };
+};
+
 const getPtxAttributes = () => {
   if (!analyticsFeatureFlagMethod) return {};
   const fetchAdditionalCoins = analyticsFeatureFlagMethod("fetchAdditionalCoins");
@@ -259,6 +268,7 @@ const extraProperties = (store: ReduxStore) => {
   const madAttributes = getMADAttributes();
   const addAccountAttributes = getAddAccountAttributes();
   const backupHubAttributes = getBackupHubAttributes();
+  const productTourAttributes = getProductTourAttributes();
 
   const deviceInfo = device
     ? {
@@ -329,6 +339,7 @@ const extraProperties = (store: ReduxStore) => {
     ...mevProtectionAttributes,
     ...addAccountAttributes,
     ...backupHubAttributes,
+    ...productTourAttributes,
     madAttributes,
     isLDMKTransportEnabled: ldmkTransport?.enabled,
     isLDMKConnectAppEnabled: ldmkConnectApp?.enabled,

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -285,6 +285,14 @@ const getBackupHubAttributes = () => {
   };
 };
 
+const getProductTourAttributes = () => {
+  if (!analyticsFeatureFlagMethod) return { lwmProductTour: false };
+  const flag = analyticsFeatureFlagMethod("lwmProductTour");
+  return {
+    lwmProductTour: !!flag?.enabled,
+  };
+};
+
 const getLdmkAndSyncFlags = () => ({
   ldmkTransport: analyticsFeatureFlagMethod?.("ldmkTransport") ?? { enabled: false },
   ldmkConnectApp: analyticsFeatureFlagMethod?.("ldmkConnectApp") ?? { enabled: false },
@@ -424,6 +432,7 @@ const extraProperties = async (store: AppStore) => {
   )?.time;
 
   const backupHubAttributes = getBackupHubAttributes();
+  const productTourAttributes = getProductTourAttributes();
 
   return {
     ...mandatoryProperties,
@@ -461,6 +470,7 @@ const extraProperties = async (store: AppStore) => {
     ...rebornAttributes,
     ...mevProtectionAttributes,
     ...backupHubAttributes,
+    ...productTourAttributes,
     migrationToMMKV,
     tokenWithFunds,
     isLDMKTransportEnabled: ldmkTransport?.enabled,


### PR DESCRIPTION
### 📝 Description

Adds `lwdProductTour` and `lwmProductTour` as top-level analytics attributes in the desktop and mobile Segment payloads.

These product tour flags are standalone feature flags, so they are kept out of the Wallet 4.0 analytics helper and exposed from each app's `segment.ts` alongside the other app-level feature flag attributes.

Typechecks passed for both impacted apps:

- `pnpm --filter ledger-live-desktop typecheck`
- `pnpm --filter live-mobile typecheck`

### 🔗 Context

- **JIRA / GitHub issue**: N/A
- **ADR** (if any): N/A
