### PR TITLE
fix(wallet-cli): inject getQuotes into swap execute to stop leaking a global mock

### DIFF
--- a/apps/wallet-cli/src/commands/swap/execute.ts
+++ b/apps/wallet-cli/src/commands/swap/execute.ts
@@ -34,6 +34,7 @@ import { getErrorDetails } from "@ledgerhq/live-common/exchange/error";
 
 type RunFullSwapPipeline = typeof runFullSwapPipelineDefault;
 type RunCliSwapDiePipeline = typeof runCliSwapDiePipelineDefault;
+type GetQuotes = typeof getQuotes;
 
 type CryptoOrTokenCurrency = CryptoCurrency | TokenCurrency;
 type FindTokenById = (id: string) => Promise<TokenCurrency | null | undefined>;
@@ -100,17 +101,21 @@ export type SwapExecuteDependencies = {
   getAccountBridge?: typeof getAccountBridge;
   makeBridgeCacheSystem?: typeof makeBridgeCacheSystem;
   findTokenById?: FindTokenById;
+  getQuotes?: GetQuotes;
 };
 
-async function selectDieQuote(args: {
-  provider: string;
-  from: string;
-  to: string;
-  amount: string;
-  sendAddress: string;
-  receiveAddress: string;
-}): Promise<Quote> {
-  const { quotes, providerErrors } = await getQuotes(
+async function selectDieQuote(
+  getQuotesFn: GetQuotes,
+  args: {
+    provider: string;
+    from: string;
+    to: string;
+    amount: string;
+    sendAddress: string;
+    receiveAddress: string;
+  },
+): Promise<Quote> {
+  const { quotes, providerErrors } = await getQuotesFn(
     {
       providers: [args.provider],
       data: {
@@ -148,6 +153,7 @@ export async function executeSwapCommand({
   getAccountBridge: getBridge = getAccountBridge,
   makeBridgeCacheSystem: makeCacheSystem = makeBridgeCacheSystem,
   findTokenById = id => getCryptoAssetsStore().findTokenById(id),
+  getQuotes: getQuotesFn = getQuotes,
 }: {
   flags: SwapExecuteFlags;
   positional: readonly string[];
@@ -248,7 +254,7 @@ export async function executeSwapCommand({
       const mainToAccount: Account = getMainAccount(toAccount, toParent);
       const receiveAddress = mainToAccount.freshAddress;
 
-      const quote = await selectDieQuote({
+      const quote = await selectDieQuote(getQuotesFn, {
         provider,
         from: flags.from,
         to: flags.to,

--- a/apps/wallet-cli/src/test/commands/swap/execute.test.ts
+++ b/apps/wallet-cli/src/test/commands/swap/execute.test.ts
@@ -5,14 +5,19 @@ import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { BigNumber } from "bignumber.js";
 import type { Account } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import type { GetQuotesArgs, Quote } from "@ledgerhq/live-common/wallet-api/Exchange/quotes/types";
+import type {
+  GetQuotesArgs,
+  GetQuotesResponse,
+  Quote,
+} from "@ledgerhq/live-common/wallet-api/Exchange/quotes/types";
 import type { getAccountBridge as getLiveAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { installOutputCapture } from "../../../shared/ui";
 import { CliProcessExitError } from "../../../cli-process-exit-error";
 import type { AccountDescriptor } from "../../../wallet/models";
 import { MOCK_ETH_DESCRIPTOR } from "../../../test/helpers/constants";
 import { USDT_CONTRACT } from "../../helpers/cal-fixtures";
-import type { SwapExecuteFlags } from "../../../commands/swap/execute";
+import { executeSwapCommand, type SwapExecuteFlags } from "../../../commands/swap/execute";
+
 import type { FullSwapPipelineInput } from "../../../commands/swap/cli-swap-pipeline";
 import type {
   CliSwapDieInput,
@@ -104,16 +109,14 @@ const mockDiePipelineResult = {
   },
 };
 
-const getQuotesMock = mock(async (_args: GetQuotesArgs) => ({
-  quotes: [mockDieQuote],
-  providerErrors: [] as { provider: string; message: string }[],
-}));
-
-mock.module("@ledgerhq/live-common/wallet-api/Exchange/quotes/getQuotes", () => ({
-  getQuotes: getQuotesMock,
-}));
-
-const { executeSwapCommand } = await import("../../../commands/swap/execute");
+const getQuotesMock = mock(
+  async (_args: GetQuotesArgs): Promise<GetQuotesResponse> => ({
+    quotes: [mockDieQuote],
+    providerErrors: [],
+    warnings: [],
+    errors: [],
+  }),
+);
 
 function makeAccount(descriptor: AccountDescriptor): Account {
   const family =
@@ -193,6 +196,7 @@ async function runExecuteSwapCommand(flags: SwapExecuteFlags = baseFlags) {
       runFullSwapPipeline: runFullSwapPipelineMock,
       runCliSwapDiePipeline: runCliSwapDiePipelineMock,
       findTokenById: findTokenByIdMock,
+      getQuotes: getQuotesMock,
     });
   } finally {
     restoreCapture();
@@ -214,6 +218,8 @@ describe("swap execute command", () => {
     getQuotesMock.mockImplementation(async () => ({
       quotes: [mockDieQuote],
       providerErrors: [],
+      warnings: [],
+      errors: [],
     }));
     runCliSwapDiePipelineMock.mockImplementation(async (_input: CliSwapDieInput) => ({
       plan: mockDiePipelineResult.plan,
@@ -398,6 +404,8 @@ describe("swap execute command", () => {
       getQuotesMock.mockImplementationOnce(async () => ({
         quotes: [oneInchQuote],
         providerErrors: [],
+        warnings: [],
+        errors: [],
       }));
 
       const data = await runExecuteSwapCommand({ ...dieBaseFlags, provider: "1inch" });
@@ -429,7 +437,17 @@ describe("swap execute command", () => {
     it("should reject when no DIE quote is returned", async () => {
       getQuotesMock.mockImplementationOnce(async () => ({
         quotes: [],
-        providerErrors: [{ provider: "uniswap", message: "rate unavailable" }],
+        providerErrors: [
+          {
+            provider: "uniswap",
+            message: "rate unavailable",
+            code: "rate_unavailable",
+            type: "fixed",
+            parameter: { rate: "rate" },
+          },
+        ],
+        warnings: [],
+        errors: [],
       }));
 
       const writes: string[] = [];
@@ -448,6 +466,7 @@ describe("swap execute command", () => {
             runFullSwapPipeline: runFullSwapPipelineMock,
             runCliSwapDiePipeline: runCliSwapDiePipelineMock,
             findTokenById: findTokenByIdMock,
+            getQuotes: getQuotesMock,
           }),
         ).rejects.toThrow(CliProcessExitError);
       } finally {

--- a/apps/wallet-cli/src/test/commands/swap/quote.test.ts
+++ b/apps/wallet-cli/src/test/commands/swap/quote.test.ts
@@ -84,7 +84,7 @@ describe("quote command", () => {
       ],
       { WALLET_CLI_MOCK_PORT: String(server.port), ...fixture.env },
     );
-    expect(exitCode, `stderr: ${stderr}`).toBe(0);
+    expect(exitCode, `stdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
     expect(stdout).toMatch(/ethereum\s*→\s*bitcoin/i);
     expect(stdout).toMatch(/ethereum/i);
     expect(stdout).toMatch(/bitcoin/i);
@@ -111,7 +111,7 @@ describe("quote command", () => {
       ],
       { WALLET_CLI_MOCK_PORT: String(server.port), ...fixture.env },
     );
-    expect(exitCode, `stderr: ${stderr}`).toBe(0);
+    expect(exitCode, `stdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
 
     const data = JSON.parse(stdout);
     expect(data.command).toBe("swap quote");


### PR DESCRIPTION
## Why

The wallet-cli `swap quote` test failed **only on CI** with:

```
undefined is not an object (evaluating 'quoteDetails.exchangeRate')
774 pass / 2 fail
```

Root cause: `execute.test.ts` stubbed `getQuotes` with a **process-global** `mock.module(...)`. `bun test` runs every file in one shared module registry, so that mock could bleed into the `swap quote` command — which imports the same `getQuotes` through the `Exchange` barrel. When the CLI module graph first bound `getQuotes` while the mock was active, the quote command received a DIE-shaped quote (no `quoteDetails`) and crashed. Whether this happened depended on test-file load order, which differs between CI (Linux) and local (macOS) — hence CI-only.

The earlier attempt (restore the mock in `afterAll`) did **not** work: once the barrel re-export binding is materialized it can't be rebound, so the leaked stub persisted. CI kept failing with the same `774 pass / 2 fail`.

## What

- `execute.ts`: `getQuotes` is now an **injected dependency** of `executeSwapCommand` (default = the real import), matching every other collaborator the command already injects. Production behavior is unchanged.
- `execute.test.ts`: removed the global `mock.module` (and the `afterAll` restore) entirely; the stub is passed via the `getQuotes` dependency, so it is scoped to this file and no global module mock exists.
- `quote.test.ts`: assertions now include \`stdout\` in the failure message (kept from the prior commit).

## Reproduced locally (before → after)

Built a fix-sensitive repro that imports `execute.test.ts` (triggering its top-level side effects) then runs the **real** `swap quote` command:

- On the previous committed code → **fails** with the exact CI error `undefined is not an object (evaluating 'quoteDetails.exchangeRate')`.
- With this fix → **passes**.

## Verification

- `bun test src/`: **776 pass / 0 fail** (66 files)
- typecheck ✓ · lint (0 errors) ✓ · format:check ✓