### PR TITLE
ci: add jfrog login composite

### DIFF
--- a/tools/actions/composites/jfrog-npm-auth/action.yml
+++ b/tools/actions/composites/jfrog-npm-auth/action.yml
@@ -1,0 +1,19 @@
+name: JFrog npm auth
+description: OIDC login to JFrog and configure npm for the given Artifactory npm registry.
+inputs:
+  registry:
+    description: Artifactory npm registry host and path (same shape as jfrog-npm registry input).
+    required: true
+runs:
+  using: composite
+  steps:
+    - id: jfrog-login
+      if: ${{ inputs.registry != '' }}
+      uses: ledgerhq/actions-security/actions/jfrog-login@actions/jfrog-login-1.4.0
+    - id: jfrog-npm
+      if: ${{ inputs.registry != '' }}
+      uses: ledgerhq/actions-security/actions/jfrog-npm@actions/jfrog-npm-0.3.0
+      with:
+        token: ${{ steps.jfrog-login.outputs.oidc-token }}
+        registry: ${{ inputs.registry }}
+        npmrc-location: "$HOME/.npmrc"


### PR DESCRIPTION
### 📝 Description

Adds a `jfrog-npm-auth` composite action under `tools/actions/composites/`, mirroring the equivalent composite in `ledger-live-build` (`.github/actions/jfrog-npm-auth`).

The composite performs an OIDC login to JFrog and configures npm to use the given Artifactory npm registry:

- `jfrog-login` (`ledgerhq/actions-security/actions/jfrog-login`) to obtain an OIDC token
- `jfrog-npm` (`ledgerhq/actions-security/actions/jfrog-npm`) to write the registry auth into `$HOME/.npmrc`

Both steps are gated on the `registry` input being non-empty, so the action is a no-op when no registry is provided.

Usage:

```yaml
- uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
  with:
    registry: ${{ vars.ARTIFACTORY_URL }}
```
