### PR TITLE
ci: use jfrog-npm-auth composite on self-hosted macOS jobs

### DIFF
--- a/.github/workflows/test-mobile-build-ios-reusable.yml
+++ b/.github/workflows/test-mobile-build-ios-reusable.yml
@@ -136,6 +136,11 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
 
+      - name: JFrog npm auth
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_URL }}
+
       - uses: nick-fields/retry@v4
         name: install dependencies
         id: install-dependencies

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -571,6 +571,11 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
           echo "Using pre-computed shard ${{ matrix.shard }}/${{ matrix.total }} with $(echo '${{ matrix.files }}' | wc -w) test files"
 
+      - name: JFrog npm auth
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_URL }}
+
       - uses: nick-fields/retry@v4
         name: install dependencies
         id: install-dependencies

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -636,6 +636,11 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
 
+      - name: JFrog npm auth
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_URL }}
+
       - uses: nick-fields/retry@v3
         name: install dependencies
         id: install-dependencies
@@ -812,6 +817,11 @@ jobs:
           region: ${{ secrets.AWS_CACHE_REGION }}
           use-mise: true
           gh-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: JFrog npm auth
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_URL }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
### 📝 Description

Wires the `jfrog-npm-auth` composite (added in #19686) into every CI job that runs on the self-hosted `macOS` runner tag, so npm is authenticated against the Artifactory registry before dependencies are installed.

The step is inserted right after `setup caches` and before the dependency install in each job, and passes `registry: ${{ vars.ARTIFACTORY_URL }}`:

| Workflow | Job | `runs-on` |
|---|---|---|
| `test-mobile-build-ios-reusable.yml` | `build-ios-native` | `[…, macOS, ARM64]` |
| `test-mobile-mock-reusable.yml` | `detox-ui-e2e-ios` | `[…, macOS, ARM64]` |
| `test-mobile-mock-reusable.yml` | `test-pod-lockfile` | `[macOS, ARM64]` |
| `test-mobile-e2e-reusable.yml` | `detox-tests-ios` | `["qaa", macOS, ARM64, "performance-pool"]` |

Scope notes:
- Only the self-hosted `macOS`-tagged runners are targeted. GitHub-hosted `macos-14` jobs (e.g. `regen-pods`, desktop mac matrix, `test-integration`) are intentionally out of scope.
- The Linux `build-ios-js` job in `test-mobile-build-ios-reusable.yml` is left untouched.
- The composite guards on an empty `registry`, so if `vars.ARTIFACTORY_URL` isn't set it is a no-op rather than a failure.

This branch is based on the composite branch, so the diff also contains `tools/actions/composites/jfrog-npm-auth/action.yml` (introduced in #19686). The composite is referenced at `@develop` per repo convention, so **#19686 must merge first** for these references to resolve.

### 🔗 Context

- **Depends on**: #19686
Test runs: https://github.com/LedgerHQ/ledger-live/actions/runs/29730588533/job/88314091121
https://github.com/LedgerHQ/ledger-live/actions/runs/29731122735/job/88315809810
