### PR TITLE
[LWDM] fix(coin-testers): wire wallet-framework ports in 6 missing jest setups

### DIFF
--- a/libs/coin-modules-monitoring/package.json
+++ b/libs/coin-modules-monitoring/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@datadog/datadog-api-client": "^1.40",
+    "@domain/entity-currency-crypto": "workspace:^",
     "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/ledger-wallet-framework": "workspace:^",
     "@ledgerhq/live-common": "workspace:^",

--- a/libs/coin-modules-monitoring/src/run.ts
+++ b/libs/coin-modules-monitoring/src/run.ts
@@ -2,7 +2,16 @@ import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account } from "@ledgerhq/types-live";
 import { getAccountBridgeByFamily } from "@ledgerhq/live-common/bridge/impl";
 import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import {
+  getCryptoCurrencyById,
+  findCryptoCurrencyById,
+  findCryptoCurrencyByScheme,
+  listCryptoCurrencies,
+  hasCryptoCurrencyId,
+} from "@domain/entity-currency-crypto";
+import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
+import { setCurrenciesResolver } from "@ledgerhq/ledger-wallet-framework/currencies";
+import { setCryptoAssetsStore as setFrameworkCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 import { firstValueFrom, reduce } from "rxjs";
 import {
   decodeAccountId,
@@ -151,6 +160,21 @@ export default async function (currencyIds: string[], accountTypes: AccountType[
 
   // Setup CAL client store for monitoring (automatically set as global store)
   setupCalClientStore();
+
+  // Wire wallet-framework ports to the same cryptoassets global store
+  setFrameworkCryptoAssetsStore({
+    findTokenById: id => getCryptoAssetsStore().findTokenById(id),
+    findTokenByAddressInCurrency: (addr, currencyId) =>
+      getCryptoAssetsStore().findTokenByAddressInCurrency(addr, currencyId),
+    getTokensSyncHash: currencyId => getCryptoAssetsStore().getTokensSyncHash(currencyId),
+  });
+  setCurrenciesResolver({
+    getCryptoCurrencyById,
+    findCryptoCurrencyById,
+    findCryptoCurrencyByScheme,
+    listCryptoCurrencies,
+    hasCryptoCurrencyId,
+  });
   const result: RunResult = {
     entries: [],
     failed: false,
@@ -250,7 +274,7 @@ export default async function (currencyIds: string[], accountTypes: AccountType[
         );
       } catch (err) {
         console.error(
-          `Skipping failing run. Error: ${err instanceof Error ? err.stack ?? err.message : err}`,
+          `Skipping failing run. Error: ${err instanceof Error ? (err.stack ?? err.message) : err}`,
         );
         // We may miss some parameters added to the error on runtime
         // We display only the message on the top for convenience and better readability

--- a/libs/coin-modules-monitoring/tsconfig.json
+++ b/libs/coin-modules-monitoring/tsconfig.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "lib": [
-      "es2020",
+      "es2022",
       "dom"
     ],
     "outDir": "lib",

--- a/libs/coin-tester-modules/coin-tester-bitcoin/jest.config.ts
+++ b/libs/coin-tester-modules/coin-tester-bitcoin/jest.config.ts
@@ -2,6 +2,7 @@ import type { Config } from "jest";
 
 const config: Config = {
   testEnvironment: "node",
+  setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup"],
   transform: {
     "^.+\\.tsx?$": [
       "@swc/jest",

--- a/libs/coin-tester-modules/coin-tester-bitcoin/package.json
+++ b/libs/coin-tester-modules/coin-tester-bitcoin/package.json
@@ -78,14 +78,15 @@
     "msw": "catalog:"
   },
   "devDependencies": {
-    "@types/node": "catalog:",
+    "@ledgerhq/wallet-framework-test-setup": "workspace:^",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",
+    "@types/node": "catalog:",
     "jest": "catalog:",
-    "tsx": "^4.19.3",
-    "typescript": "catalog:",
+    "oxfmt": "catalog:",
     "oxlint": "catalog:",
-    "oxfmt": "catalog:"
+    "tsx": "^4.19.3",
+    "typescript": "catalog:"
   }
 }

--- a/libs/coin-tester-modules/coin-tester-cosmos/jest.config.ts
+++ b/libs/coin-tester-modules/coin-tester-cosmos/jest.config.ts
@@ -6,12 +6,9 @@ import type { Config } from "jest";
 // TypeScript SOURCE, so this tester exercises the coin module's current source
 // without a prior `pnpm build` of lib/.
 //
-// Unlike coin-tester-cardano there is no `setupFiles`: the Babylon scenario
-// injects its config through `createBridges(() => coinConfig)` and points the
-// LCD at the local node, so nothing needs to be set in the environment before
-// coin-cosmos modules evaluate.
 const config: Config = {
   testEnvironment: "node",
+  setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup"],
   testEnvironmentOptions: {
     customExportConditions: ["@ledgerhq/source", "node", "require", "default"],
   },

--- a/libs/coin-tester-modules/coin-tester-cosmos/package.json
+++ b/libs/coin-tester-modules/coin-tester-cosmos/package.json
@@ -76,6 +76,7 @@
     "expect": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/wallet-framework-test-setup": "workspace:^",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/libs/coin-tester-modules/coin-tester-evm/jest.config.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/jest.config.ts
@@ -4,6 +4,7 @@ const esmDeps = ["ky"];
 
 const config: Config = {
   testEnvironment: "node",
+  setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup"],
   transform: {
     "^.+\\.(t|j)sx?$": [
       "@swc/jest",

--- a/libs/coin-tester-modules/coin-tester-evm/package.json
+++ b/libs/coin-tester-modules/coin-tester-evm/package.json
@@ -74,14 +74,15 @@
     "msw": "catalog:"
   },
   "devDependencies": {
-    "@types/node": "catalog:",
-    "@types/jest": "catalog:",
-    "jest": "catalog:",
-    "rimraf": "^5.0.5",
-    "@swc/jest": "catalog:",
+    "@ledgerhq/wallet-framework-test-setup": "workspace:^",
     "@swc/core": "catalog:",
-    "typescript": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "oxfmt": "catalog:",
     "oxlint": "catalog:",
-    "oxfmt": "catalog:"
+    "rimraf": "^5.0.5",
+    "typescript": "catalog:"
   }
 }

--- a/libs/coin-tester-modules/coin-tester-polkadot/jest.config.ts
+++ b/libs/coin-tester-modules/coin-tester-polkadot/jest.config.ts
@@ -2,6 +2,7 @@ import type { Config } from "jest";
 
 const config: Config = {
   testEnvironment: "node",
+  setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup"],
   transform: {
     "^.+\\.tsx?$": [
       "@swc/jest",

--- a/libs/coin-tester-modules/coin-tester-polkadot/package.json
+++ b/libs/coin-tester-modules/coin-tester-polkadot/package.json
@@ -71,15 +71,16 @@
     "msw": "catalog:"
   },
   "devDependencies": {
-    "@types/node": "catalog:",
+    "@ledgerhq/wallet-framework-test-setup": "workspace:^",
     "@polkadot/rpc-provider": "catalog:",
     "@polkadot/util": "catalog:",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",
+    "@types/node": "catalog:",
     "jest": "catalog:",
-    "typescript": "catalog:",
+    "oxfmt": "catalog:",
     "oxlint": "catalog:",
-    "oxfmt": "catalog:"
+    "typescript": "catalog:"
   }
 }

--- a/libs/coin-tester-modules/coin-tester-tezos/jest.config.ts
+++ b/libs/coin-tester-modules/coin-tester-tezos/jest.config.ts
@@ -4,6 +4,7 @@ const esmDeps = ["ky"];
 
 const config: Config = {
   testEnvironment: "node",
+  setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup"],
   transform: {
     "^.+\\.(t|j)sx?$": [
       "@swc/jest",

--- a/libs/coin-tester-modules/coin-tester-tezos/package.json
+++ b/libs/coin-tester-modules/coin-tester-tezos/package.json
@@ -75,15 +75,16 @@
     "msw": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/wallet-framework-test-setup": "workspace:^",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/bs58": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
-    "@types/bs58": "catalog:",
     "jest": "catalog:",
-    "rimraf": "^5.0.5",
-    "@swc/jest": "catalog:",
-    "@swc/core": "catalog:",
-    "typescript": "catalog:",
+    "oxfmt": "catalog:",
     "oxlint": "catalog:",
-    "oxfmt": "catalog:"
+    "rimraf": "^5.0.5",
+    "typescript": "catalog:"
   }
 }

--- a/libs/coin-tester-modules/coin-tester-xrp/jest.config.ts
+++ b/libs/coin-tester-modules/coin-tester-xrp/jest.config.ts
@@ -4,6 +4,7 @@ const esmDeps = ["ky"];
 
 const config: Config = {
   testEnvironment: "node",
+  setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup"],
   transform: {
     "^.+\\.(t|j)sx?$": [
       "@swc/jest",

--- a/libs/coin-tester-modules/coin-tester-xrp/package.json
+++ b/libs/coin-tester-modules/coin-tester-xrp/package.json
@@ -75,14 +75,15 @@
     "ripple-keypairs": "^2.0.0"
   },
   "devDependencies": {
+    "@ledgerhq/wallet-framework-test-setup": "workspace:^",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "jest": "catalog:",
-    "rimraf": "^5.0.5",
-    "@swc/jest": "catalog:",
-    "@swc/core": "catalog:",
-    "typescript": "catalog:",
+    "oxfmt": "catalog:",
     "oxlint": "catalog:",
-    "oxfmt": "catalog:"
+    "rimraf": "^5.0.5",
+    "typescript": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4669,6 +4669,9 @@ importers:
       '@datadog/datadog-api-client':
         specifier: ^1.40
         version: 1.40.0
+      '@domain/entity-currency-crypto':
+        specifier: workspace:^
+        version: link:../../domain/entity/currency-crypto
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../ledgerjs/packages/cryptoassets

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7466,6 +7466,9 @@ importers:
         specifier: 'catalog:'
         version: 2.7.3(@types/node@24.12.0)(typescript@6.0.2)
     devDependencies:
+      '@ledgerhq/wallet-framework-test-setup':
+        specifier: workspace:^
+        version: link:../../wallet-framework-test-setup
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -7621,6 +7624,9 @@ importers:
         specifier: 'catalog:'
         version: 30.2.0
     devDependencies:
+      '@ledgerhq/wallet-framework-test-setup':
+        specifier: workspace:^
+        version: link:../../wallet-framework-test-setup
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -7694,6 +7700,9 @@ importers:
         specifier: 'catalog:'
         version: 2.7.3(@types/node@24.12.0)(typescript@6.0.2)
     devDependencies:
+      '@ledgerhq/wallet-framework-test-setup':
+        specifier: workspace:^
+        version: link:../../wallet-framework-test-setup
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -7843,6 +7852,9 @@ importers:
         specifier: 'catalog:'
         version: 2.7.3(@types/node@24.12.0)(typescript@6.0.2)
     devDependencies:
+      '@ledgerhq/wallet-framework-test-setup':
+        specifier: workspace:^
+        version: link:../../wallet-framework-test-setup
       '@polkadot/rpc-provider':
         specifier: 'catalog:'
         version: 16.5.4
@@ -8095,6 +8107,9 @@ importers:
         specifier: 'catalog:'
         version: 2.7.3(@types/node@24.12.0)(typescript@6.0.2)
     devDependencies:
+      '@ledgerhq/wallet-framework-test-setup':
+        specifier: workspace:^
+        version: link:../../wallet-framework-test-setup
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -8253,6 +8268,9 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
     devDependencies:
+      '@ledgerhq/wallet-framework-test-setup':
+        specifier: workspace:^
+        version: link:../../wallet-framework-test-setup
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11


### PR DESCRIPTION
## Summary

Follow-up to #19229. The original PR updated coin-tester-{solana,tron,stellar,multiversx,cardano} but six coin-testers did not run in CI during review and were missed:

- coin-tester-bitcoin
- coin-tester-cosmos
- coin-tester-evm
- coin-tester-polkadot
- coin-tester-tezos
- coin-tester-xrp

Each now gets `setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup"]` in its `jest.config.ts` and `@ledgerhq/wallet-framework-test-setup: workspace:^` in its `devDependencies`.

Also fixes `coin-modules-monitoring`: `setCryptoAssetsStore` and `setCurrenciesResolver` were not initialized at bootstrap, causing the daily monitoring run to fail after the wallet-framework DI decoupling. Both ports are now wired in `run.ts` using the same forwarding-proxy pattern as `wallet-framework-test-setup`, with currency accessors sourced from `@domain/entity-currency-crypto`.

## Test plan

- [ ] Coin Tester CI passes for bitcoin, cosmos, evm, polkadot, tezos, xrp
- [ ] `pnpm coin:modules:monitoring run start monitor -t pristine -c ethereum` completes without error