### PR TITLE
[LWDM] feat(swap): enrich device deserialization error with precise protobuf field

### DIFF
--- a/.changeset/swap-check-protobuf-specs.md
+++ b/.changeset/swap-check-protobuf-specs.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/hw-app-exchange": minor
+"@ledgerhq/live-common": patch
+---
+
+feat(swap): enrich the device's generic payload deserialization error with the exact Exchange app protobuf field that exceeds its limit
+
+When the Exchange device app rejects a swap `NewTransactionResponse` with the generic `DESERIALIZATION_FAILED` (0x6a81) status, we now decode the payload locally and, if a field is larger than the device's protobuf `max_size` (mirrored from app-exchange `protocol.options`), surface a precise `SwapPayloadFieldExceedsLimit` carrying the field name, limit and actual size (e.g. an oversized `payin_extra_id`).
+
+The device remains the source of truth: this check only runs **after** the device has already rejected the payload, never gates the flow, and silently falls back to the device's error if our hardcoded limits ever drift from the app. The user-facing flow and step (`PROCESS_TRANSACTION`) are unchanged; the added precision is only meant to speed up investigations.

--- a/libs/ledger-live-common/src/exchange/swap/completeExchange.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/completeExchange.test.ts
@@ -1,4 +1,10 @@
-import { shouldForceZeroAmountForDexSwap } from "./completeExchange";
+import { TransportStatusError } from "@ledgerhq/errors";
+import { ErrorStatus } from "@ledgerhq/hw-app-exchange/ReturnCode";
+import { CompleteExchangeError } from "../error";
+import {
+  enrichSwapDeserializationError,
+  shouldForceZeroAmountForDexSwap,
+} from "./completeExchange";
 
 describe("shouldForceZeroAmountForDexSwap", () => {
   const base = {
@@ -17,5 +23,59 @@ describe("shouldForceZeroAmountForDexSwap", () => {
     ["non-Arc native coin without sub-account", {}, false],
   ])("%s", (_case, params, expected) => {
     expect(shouldForceZeroAmountForDexSwap({ ...base, ...params })).toBe(expected);
+  });
+});
+
+describe("enrichSwapDeserializationError", () => {
+  // Minimal NewTransactionResponse protobuf with only payin_extra_id (field 2) = 40 * "a",
+  // which is above the device's 19-byte usable limit for that field.
+  const payloadWithOversizedExtraId = "1228" + "61".repeat(40);
+
+  it("enriches a device DESERIALIZATION_FAILED with the precise offending field", () => {
+    const deviceError = new TransportStatusError(ErrorStatus.DESERIALIZATION_FAILED);
+
+    const result = enrichSwapDeserializationError(
+      "PROCESS_TRANSACTION",
+      payloadWithOversizedExtraId,
+      deviceError,
+    );
+
+    expect(result).toBeInstanceOf(CompleteExchangeError);
+    // Title stays the device error's translation key so the user-facing copy is unchanged;
+    // the precise field only enriches the message (logs/analytics).
+    expect(result).toMatchObject({
+      step: "PROCESS_TRANSACTION",
+      title: "deserializationFailed",
+    });
+    expect(result?.message).toContain("payin_extra_id");
+  });
+
+  it("returns undefined for a DESERIALIZATION_FAILED when no field violation is found", () => {
+    const deviceError = new TransportStatusError(ErrorStatus.DESERIALIZATION_FAILED);
+    // Payload cannot be decoded locally -> defer to the device's generic error.
+    expect(
+      enrichSwapDeserializationError("PROCESS_TRANSACTION", "0aff", deviceError),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for unrelated device status codes", () => {
+    const deviceError = new TransportStatusError(ErrorStatus.INVALID_ADDRESS);
+    expect(
+      enrichSwapDeserializationError(
+        "CHECK_REFUND_ADDRESS",
+        payloadWithOversizedExtraId,
+        deviceError,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for non-transport errors", () => {
+    expect(
+      enrichSwapDeserializationError(
+        "PROCESS_TRANSACTION",
+        payloadWithOversizedExtraId,
+        new Error("boom"),
+      ),
+    ).toBeUndefined();
   });
 });

--- a/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
+++ b/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
@@ -7,9 +7,11 @@ import {
 import {
   createExchange,
   ExchangeTypes,
+  findSwapPayloadSpecViolation,
   getExchangeErrorMessage,
   PayloadSignatureComputedFormat,
 } from "@ledgerhq/hw-app-exchange";
+import { ErrorStatus } from "@ledgerhq/hw-app-exchange/ReturnCode";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
 import { log } from "@ledgerhq/logs";
 import BigNumber from "bignumber.js";
@@ -23,7 +25,7 @@ import { TransactionRefusedOnDevice } from "../../errors";
 import { handleHederaTrustedFlow } from "../../families/hedera/exchange";
 import { withDevicePromise } from "../../hw/deviceAccess";
 import { delay } from "../../promise";
-import { CompleteExchangeStep, convertTransportError } from "../error";
+import { CompleteExchangeError, CompleteExchangeStep, convertTransportError } from "../error";
 import type { CompleteExchangeInputSwap, CompleteExchangeRequestEvent } from "../platform/types";
 import { convertToAppExchangePartnerKey, getSwapProvider } from "../providers";
 import { CEXProviderConfig } from "../providers/swap";
@@ -49,6 +51,37 @@ export function shouldForceZeroAmountForDexSwap({
 }): boolean {
   if (!isDex || family !== "evm") return false;
   return hasSubAccountId || ARC_CURRENCY_IDS.has(fromCurrencyId);
+}
+
+/**
+ * Device stays the source of truth: only once it rejects the payload with a generic
+ * DESERIALIZATION_FAILED (0x6a81) do we decode it locally to name the field that exceeds
+ * its limit. We keep the device error's title (a translation key, so the user-facing copy
+ * stays unchanged) and only enrich the message with the precise field for logs/analytics.
+ * Returns undefined when the error is unrelated or no violation can be pinpointed, so callers
+ * fall back to the device error. See LIVE-34253.
+ */
+export function enrichSwapDeserializationError(
+  step: CompleteExchangeStep,
+  binaryPayload: string,
+  error: unknown,
+): CompleteExchangeError | undefined {
+  // Duck-type on `name` + `statusCode` rather than `instanceof TransportStatusError`, matching
+  // the rest of this file and the repo-wide migration off `@ledgerhq/errors` class checks (#19849,
+  // which dropped the `TransportStatusError` import from here).
+  const transportErr = error as { name?: string; statusCode?: number } | null | undefined;
+  if (
+    transportErr?.name !== "TransportStatusError" ||
+    transportErr?.statusCode !== ErrorStatus.DESERIALIZATION_FAILED
+  ) {
+    return undefined;
+  }
+
+  const violation = findSwapPayloadSpecViolation(binaryPayload);
+  if (!violation) return undefined;
+
+  const { errorName } = getExchangeErrorMessage(transportErr.statusCode, step);
+  return new CompleteExchangeError(step, errorName, violation.message);
 }
 
 const completeExchange = (
@@ -330,6 +363,9 @@ const completeExchange = (
         ) {
           throw new TransactionRefusedOnDevice();
         }
+
+        const enrichedError = enrichSwapDeserializationError(currentStep, binaryPayload, e);
+        if (enrichedError) throw enrichedError;
 
         throw convertTransportError(currentStep, e);
       });

--- a/libs/ledger-live-common/src/wallet-api/Exchange/server.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/server.test.ts
@@ -12,6 +12,7 @@ import { WalletContext, WalletHandlers } from "@ledgerhq/wallet-api-server";
 import BigNumber from "bignumber.js";
 import { genAccount } from "../../mock/account";
 import { AppBranch, AppPlatform, Visibility } from "../types";
+import { CompleteExchangeError } from "../../exchange/error";
 import { handlers } from "./server";
 
 const mockTracking = {
@@ -353,6 +354,88 @@ describe("handlers", () => {
       );
       expect(networkCall).toBeDefined();
       expect((networkCall![0] as { url: string }).url).toContain("/swap/accepted");
+    });
+
+    it("reports the enriched reason to /swap/cancelled when the swap is cancelled", async () => {
+      const accounts = [genAccount("accountId1"), genAccount("accountId2")];
+      const fromAccount = accounts[0];
+      const toAccount = accounts[1];
+
+      const { getMainAccount } = jest.requireMock(
+        "@ledgerhq/ledger-wallet-framework/account/index",
+      );
+      getMainAccount.mockReturnValue(fromAccount);
+
+      const { getAccountBridge } = jest.requireMock("../../bridge");
+      getAccountBridge.mockResolvedValue({
+        createTransaction: jest.fn().mockReturnValue({ family: "bitcoin", recipient: "" }),
+        updateTransaction: jest.fn().mockImplementation((tx: object, upd: object) => ({
+          ...tx,
+          ...upd,
+          amount: new BigNumber("1000000"),
+        })),
+      });
+
+      mockUiStartExchange.mockImplementation(({ onSuccess }) => {
+        onSuccess("NONCE", { modelId: "nanoX", deviceId: "device-1" });
+      });
+
+      // Simulates completeExchange enriching a device DESERIALIZATION_FAILED: the title stays
+      // the device status (translation key), only the message names the offending field.
+      const enrichedError = new CompleteExchangeError(
+        "PROCESS_TRANSACTION",
+        "deserializationFailed",
+        'Swap payload field "payin_extra_id" exceeds device limit: 40 > 19 bytes',
+      );
+      mockUiSwap.mockImplementation(({ onCancel }) => {
+        onCancel(enrichedError);
+      });
+
+      const handler = handlers({
+        accounts,
+        locale: "en",
+        counterValueCurrency: "USD",
+        tracking: mockTracking,
+        manifest: testAppManifest,
+        uiHooks: mockUiHooks,
+      });
+
+      const params: ExchangeSwapParams = {
+        exchangeType: "SWAP",
+        provider: "TestProvider",
+        fromAccountId: fromAccount.id,
+        toAccountId: toAccount.id,
+        tokenCurrency: undefined,
+        fromAmount: "1000000",
+        fromAmountAtomic: new BigNumber("1000000"),
+        feeStrategy: "medium",
+      };
+
+      const request = {
+        jsonrpc: "2.0",
+        method: "custom.exchange.swap",
+        params,
+        id: "test",
+      } as unknown as RpcRequest<string, ExchangeSwapParams>;
+      const context = {
+        config: { userId: "u", tracking: false, wallet: { name: "w", version: "2" }, appId: "a" },
+      };
+
+      await expect(handler["custom.exchange.swap"](request, context, {})).rejects.toBeDefined();
+
+      const cancelledCall = mockedNetwork.mock.calls.find(([req]) =>
+        (req as { url?: string }).url?.includes("/swap/cancelled"),
+      );
+      expect(cancelledCall).toBeDefined();
+
+      const { data } = cancelledCall![0] as {
+        data: { statusCode: string; errorMessage: string; swapId: string };
+      };
+      // The device status is preserved as the reported statusCode (unchanged grouping in Datadog)...
+      expect(data.statusCode).toBe("deserializationFailed");
+      // ...while the precise field is carried through in errorMessage.
+      expect(data.errorMessage).toContain("payin_extra_id");
+      expect(data.swapId).toBe("swap-123");
     });
   });
 

--- a/libs/ledgerjs/packages/hw-app-exchange/README.md
+++ b/libs/ledgerjs/packages/hw-app-exchange/README.md
@@ -17,11 +17,30 @@ Ledger Hardware Wallet Exchange app.
 
 #### Table of Contents
 
-*   [resolveTransactionType](#resolvetransactiontype)
+*   [SwapPayloadFieldExceedsLimit](#swappayloadfieldexceedslimit)
     *   [Parameters](#parameters)
+*   [resolveTransactionType](#resolvetransactiontype)
+    *   [Parameters](#parameters-1)
 *   [OkStatus](#okstatus)
 *   [decodePayloadProtobuf](#decodepayloadprotobuf)
-    *   [Parameters](#parameters-1)
+    *   [Parameters](#parameters-2)
+*   [findSwapPayloadSpecViolation](#findswappayloadspecviolation)
+    *   [Parameters](#parameters-3)
+
+### SwapPayloadFieldExceedsLimit
+
+**Extends Error**
+
+Thrown when a decoded swap payload field is larger than what the Exchange
+device app can store. It lets us surface a precise reason (which field, its
+limit and the actual size) instead of the device's generic
+DESERIALIZATION\_FAILED (0x6a81) status, which is opaque for investigations.
+
+#### Parameters
+
+*   `field` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**&#x20;
+*   `limit` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)**&#x20;
+*   `actual` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)**&#x20;
 
 ### resolveTransactionType
 
@@ -51,6 +70,28 @@ deprecated use `decodeSwapPayload` instead
 *   `payload` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**&#x20;
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<SwapPayload>**&#x20;
+
+### findSwapPayloadSpecViolation
+
+Decodes a raw swap payload (hex or base64) and returns the first field that
+exceeds the Exchange device app's protobuf size limits as a precise
+`SwapPayloadFieldExceedsLimit`, or `undefined` when everything fits (or the
+payload cannot be decoded locally).
+
+This is meant to *enrich* the device's opaque DESERIALIZATION\_FAILED (0x6a81)
+with an actionable reason (e.g. an oversized `payin_extra_id`) — it must never
+gate the flow. The device stays the source of truth, so if these (hardcoded)
+limits ever drift from the app we simply return `undefined` and keep the
+device's own error.
+
+nanopb reserves one byte for the NUL terminator on `string` fields, so their
+usable content limit is `max_size - 1`; `bytes` fields use the full `max_size`.
+
+#### Parameters
+
+*   `payload` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**&#x20;
+
+Returns **([SwapPayloadFieldExceedsLimit](#swappayloadfieldexceedslimit) | [undefined](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined))**&#x20;
 
 ## Integration test
 

--- a/libs/ledgerjs/packages/hw-app-exchange/src/SwapUtils.test.ts
+++ b/libs/ledgerjs/packages/hw-app-exchange/src/SwapUtils.test.ts
@@ -1,4 +1,7 @@
-import { decodePayloadProtobuf } from "./SwapUtils"; // Asegúrate de proporcionar la ruta correcta
+import protobuf from "protobufjs";
+import * as protoJson from "./generate-protocol.json";
+import { decodePayloadProtobuf, findSwapPayloadSpecViolation } from "./SwapUtils";
+import { SwapPayloadFieldExceedsLimit } from "./errors";
 
 describe("decodePayloadProtobuf function", () => {
   test("should decode NewTransactionResponse correctly with hex payload", async () => {
@@ -52,5 +55,80 @@ describe("decodePayloadProtobuf function", () => {
     );
     expect(decodedPayload).toHaveProperty("amountToProvider", BigInt(5.91e16));
     expect(decodedPayload).toHaveProperty("amountToWallet", BigInt(2.82e5));
+  });
+});
+
+describe("findSwapPayloadSpecViolation function", () => {
+  function encodeSwapPayload(fields: Record<string, unknown>): string {
+    const root = protobuf.Root.fromJSON(protoJson);
+    const TransactionResponse = root.lookupType("ledger_swap.NewTransactionResponse");
+    const message = TransactionResponse.create(fields);
+    return Buffer.from(TransactionResponse.encode(message).finish()).toString("hex");
+  }
+
+  const validFields = {
+    payinAddress: "0x976c3954c5dbbf39a591510db32d2f8cc2252807",
+    refundAddress: "0xccaEBcB3876a75ab9E96975058aA75463773029c",
+    payoutAddress: "bc1qqdykdw8u36yhdsletwsyv4xe95s375qjjy4gk0",
+    currencyFrom: "ETH",
+    currencyTo: "BTC",
+    amountToProvider: Buffer.from("0111", "hex"),
+    amountToWallet: Buffer.from("0111", "hex"),
+    deviceTransactionId: "URUOKQIBOB",
+  };
+
+  it("returns undefined for a valid hex payload", () => {
+    const binaryPayload =
+      "0a2a3078393736633339353463356462626633396135393135313064623332643266386363323235323830371a2a3078636361454263423338373661373561623945393639373530353861413735343633373733303239632a2a626331717164796b647738753336796864736c657477737976347865393573333735716a6a7934676b303a0345544842034254434a10000000000000000001118f178fb48000521000000000000000000000000000080e355a0a5552554f4b5149424f42";
+    expect(findSwapPayloadSpecViolation(binaryPayload)).toBeUndefined();
+  });
+
+  it("returns undefined for a valid base64 payload with a 32-byte device_transaction_id_ng", () => {
+    const binaryPayload =
+      "CioweEZBRDhjMTA4MGNiQTUwRkRlQzY1RTk0ODUzNEE5YjM4ZGQyNTM2NmYaKjB4RkI0MjRBYUJjMmU0Q2EyZjQ0NzUwMDMwMkREOUVjNjRDRjBlMjZDZSoqYmMxcXo0a3EyOGt2cDM3cHU3cGNxZGQ0dGo1ZnNxODdwcGdlMngzcnE5OgNFVEhCA0JUQ0oQAAAAAAAAAAAA0fcjCjnAAFIQAAAAAAAAAAAAAAAAAARNkFoAYiAIHOswy_grHVflNJ6xgxHiVltXXWqEGSRbKgM1hpV3VQ";
+    expect(findSwapPayloadSpecViolation(binaryPayload)).toBeUndefined();
+  });
+
+  it("decodes a Swap NG base64url payload handed to us in JWS form with a leading dot", () => {
+    // Same payload as above, kept in JWS form (leading ".") with base64url alphabet.
+    const binaryPayload =
+      ".CioweEZBRDhjMTA4MGNiQTUwRkRlQzY1RTk0ODUzNEE5YjM4ZGQyNTM2NmYaKjB4RkI0MjRBYUJjMmU0Q2EyZjQ0NzUwMDMwMkREOUVjNjRDRjBlMjZDZSoqYmMxcXo0a3EyOGt2cDM3cHU3cGNxZGQ0dGo1ZnNxODdwcGdlMngzcnE5OgNFVEhCA0JUQ0oQAAAAAAAAAAAA0fcjCjnAAFIQAAAAAAAAAAAAAAAAAARNkFoAYiAIHOswy_grHVflNJ6xgxHiVltXXWqEGSRbKgM1hpV3VQ";
+    expect(findSwapPayloadSpecViolation(binaryPayload)).toBeUndefined();
+  });
+
+  it("returns a SwapPayloadFieldExceedsLimit when payin_extra_id exceeds the device limit", () => {
+    const binaryPayload = encodeSwapPayload({ ...validFields, payinExtraId: "a".repeat(40) });
+
+    const violation = findSwapPayloadSpecViolation(binaryPayload);
+    expect(violation).toBeInstanceOf(SwapPayloadFieldExceedsLimit);
+    expect(violation).toMatchObject({
+      name: "SwapPayloadFieldExceedsLimit",
+      field: "payin_extra_id",
+      limit: 19,
+      actual: 40,
+    });
+  });
+
+  it("returns undefined for a string field sized exactly at the device usable limit", () => {
+    const binaryPayload = encodeSwapPayload({ ...validFields, payinExtraId: "a".repeat(19) });
+    expect(findSwapPayloadSpecViolation(binaryPayload)).toBeUndefined();
+  });
+
+  it("returns a violation when a bytes field (amount_to_provider) exceeds its 16-byte limit", () => {
+    const binaryPayload = encodeSwapPayload({
+      ...validFields,
+      amountToProvider: Buffer.alloc(17, 0xff),
+    });
+
+    expect(findSwapPayloadSpecViolation(binaryPayload)).toMatchObject({
+      field: "amount_to_provider",
+      limit: 16,
+      actual: 17,
+    });
+  });
+
+  it("returns undefined when the payload cannot be decoded locally", () => {
+    // field 1, length-delimited, with a length prefix that overflows the buffer
+    expect(findSwapPayloadSpecViolation("0aff")).toBeUndefined();
   });
 });

--- a/libs/ledgerjs/packages/hw-app-exchange/src/SwapUtils.ts
+++ b/libs/ledgerjs/packages/hw-app-exchange/src/SwapUtils.ts
@@ -1,6 +1,7 @@
 import protobuf from "protobufjs";
 import * as protoJson from "./generate-protocol.json";
 import { isHexadecimal } from "./shared-utils";
+import { SwapPayloadFieldExceedsLimit } from "./errors";
 
 type SwapProtobufPayload = {
   payinAddress: string;
@@ -40,17 +41,25 @@ export type SwapPayload = {
 export const decodePayloadProtobuf = (payload: string): Promise<SwapPayload> =>
   decodeSwapPayload(payload);
 
+function decodeNewTransactionResponse(payload: string): SwapProtobufPayload {
+  // Swap NG payloads are base64url and can reach us in JWS form with a leading "."
+  // separator; normalize both so we decode exactly the bytes the device receives.
+  // (React Native's Buffer has no "base64url" encoding, hence the manual mapping.)
+  const normalized = payload.startsWith(".") ? payload.slice(1) : payload;
+  const buffer = isHexadecimal(normalized)
+    ? Buffer.from(normalized, "hex")
+    : Buffer.from(normalized.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+  const root = protobuf.Root.fromJSON(protoJson);
+  // lookupType is protobufjs' public API for resolving a fully-qualified type; it is robust
+  // across runtimes, unlike reaching into `root.nested.*` which relies on internals.
+  const TransactionResponse = root.lookupType("ledger_swap.NewTransactionResponse");
+  // `decode` throws on malformed wire bytes, which is the validation we want here.
+  // (protobufjs `verify` only checks a plain message object, not an encoded buffer.)
+  return TransactionResponse.decode(buffer) as unknown as SwapProtobufPayload;
+}
+
 export async function decodeSwapPayload(payload: string): Promise<SwapPayload> {
-  const buffer = isHexadecimal(payload)
-    ? Buffer.from(payload, "hex")
-    : Buffer.from(payload, "base64");
-  const root: { [key: string]: any } = protobuf.Root.fromJSON(protoJson) || {};
-  const TransactionResponse = root?.nested.ledger_swap?.NewTransactionResponse;
-  const err = TransactionResponse.verify(buffer);
-  if (err) {
-    throw Error(err);
-  }
-  const decodePayload = TransactionResponse.decode(buffer) as unknown as SwapProtobufPayload;
+  const decodePayload = decodeNewTransactionResponse(payload);
   const {
     amountToWallet: amountToWalletBuffer,
     amountToProvider: amountToProviderBuffer,
@@ -62,7 +71,90 @@ export async function decodeSwapPayload(payload: string): Promise<SwapPayload> {
   const amountToProviderHexString = Buffer.from(amountToProviderBuffer).toString("hex"); // Gets the hexadecimal representation from the Buffer
   const amountToProvider = BigInt("0x" + amountToProviderHexString); // Convert hexadecimal representation to a big integer
 
-  const deviceTransactionIdNg = deviceTransactionIdNgBuffer?.toString("hex") || undefined;
+  // Normalize with Buffer.from: protobufjs may hand back a plain Uint8Array (browser/RN)
+  // whose toString("hex") would not produce hex, unlike the amount buffers above.
+  const deviceTransactionIdNg = deviceTransactionIdNgBuffer
+    ? Buffer.from(deviceTransactionIdNgBuffer).toString("hex") || undefined
+    : undefined;
 
   return { ...decodePayload, amountToWallet, amountToProvider, deviceTransactionIdNg };
+}
+
+type ProtoFieldKind = "string" | "bytes";
+
+type NewTransactionResponseFieldLimit = {
+  key: keyof SwapProtobufPayload;
+  protoName: string;
+  kind: ProtoFieldKind;
+  maxSize: number;
+};
+
+/**
+ * Field size limits enforced by the Exchange device app for a swap
+ * `NewTransactionResponse`, mirrored from app-exchange `src/proto/protocol.options`.
+ * These are what the device rejects with a generic DESERIALIZATION_FAILED (0x6a81).
+ *
+ * @ignore internal lookup table, consumers should use `findSwapPayloadSpecViolation`.
+ */
+const NEW_TRANSACTION_RESPONSE_FIELD_LIMITS: NewTransactionResponseFieldLimit[] = [
+  { key: "payinAddress", protoName: "payin_address", kind: "string", maxSize: 151 },
+  { key: "payinExtraId", protoName: "payin_extra_id", kind: "string", maxSize: 20 },
+  { key: "refundAddress", protoName: "refund_address", kind: "string", maxSize: 151 },
+  { key: "refundExtraId", protoName: "refund_extra_id", kind: "string", maxSize: 20 },
+  { key: "payoutAddress", protoName: "payout_address", kind: "string", maxSize: 151 },
+  { key: "payoutExtraId", protoName: "payout_extra_id", kind: "string", maxSize: 20 },
+  { key: "currencyFrom", protoName: "currency_from", kind: "string", maxSize: 10 },
+  { key: "currencyTo", protoName: "currency_to", kind: "string", maxSize: 10 },
+  { key: "amountToProvider", protoName: "amount_to_provider", kind: "bytes", maxSize: 16 },
+  { key: "amountToWallet", protoName: "amount_to_wallet", kind: "bytes", maxSize: 16 },
+  { key: "deviceTransactionId", protoName: "device_transaction_id", kind: "string", maxSize: 11 },
+  {
+    key: "deviceTransactionIdNg",
+    protoName: "device_transaction_id_ng",
+    kind: "bytes",
+    maxSize: 32,
+  },
+];
+
+function measureBytes(value: unknown): number {
+  if (typeof value === "string") return Buffer.byteLength(value, "utf8");
+  if (value instanceof Uint8Array) return value.length;
+  return 0;
+}
+
+/**
+ * Decodes a raw swap payload (hex or base64) and returns the first field that
+ * exceeds the Exchange device app's protobuf size limits as a precise
+ * `SwapPayloadFieldExceedsLimit`, or `undefined` when everything fits (or the
+ * payload cannot be decoded locally).
+ *
+ * This is meant to *enrich* the device's opaque DESERIALIZATION_FAILED (0x6a81)
+ * with an actionable reason (e.g. an oversized `payin_extra_id`) — it must never
+ * gate the flow. The device stays the source of truth, so if these (hardcoded)
+ * limits ever drift from the app we simply return `undefined` and keep the
+ * device's own error.
+ *
+ * nanopb reserves one byte for the NUL terminator on `string` fields, so their
+ * usable content limit is `max_size - 1`; `bytes` fields use the full `max_size`.
+ */
+export function findSwapPayloadSpecViolation(
+  payload: string,
+): SwapPayloadFieldExceedsLimit | undefined {
+  let decoded: SwapProtobufPayload;
+  try {
+    decoded = decodeNewTransactionResponse(payload);
+  } catch {
+    return undefined;
+  }
+
+  for (const { key, protoName, kind, maxSize } of NEW_TRANSACTION_RESPONSE_FIELD_LIMITS) {
+    const actualBytes = measureBytes(decoded[key]);
+    const maxBytes = kind === "string" ? maxSize - 1 : maxSize;
+
+    if (actualBytes > maxBytes) {
+      return new SwapPayloadFieldExceedsLimit(protoName, maxBytes, actualBytes);
+    }
+  }
+
+  return undefined;
 }

--- a/libs/ledgerjs/packages/hw-app-exchange/src/errors.ts
+++ b/libs/ledgerjs/packages/hw-app-exchange/src/errors.ts
@@ -1,0 +1,19 @@
+/**
+ * Thrown when a decoded swap payload field is larger than what the Exchange
+ * device app can store. It lets us surface a precise reason (which field, its
+ * limit and the actual size) instead of the device's generic
+ * DESERIALIZATION_FAILED (0x6a81) status, which is opaque for investigations.
+ */
+export class SwapPayloadFieldExceedsLimit extends Error {
+  override name = "SwapPayloadFieldExceedsLimit";
+  readonly field: string;
+  readonly limit: number;
+  readonly actual: number;
+
+  constructor(field: string, limit: number, actual: number) {
+    super(`Swap payload field "${field}" exceeds device limit: ${actual} > ${limit} bytes`);
+    this.field = field;
+    this.limit = limit;
+    this.actual = actual;
+  }
+}

--- a/libs/ledgerjs/packages/hw-app-exchange/src/index.ts
+++ b/libs/ledgerjs/packages/hw-app-exchange/src/index.ts
@@ -24,5 +24,7 @@ export {
   decodeSellPayload,
   decodeFundPayload,
 };
+export { findSwapPayloadSpecViolation } from "./SwapUtils";
+export { SwapPayloadFieldExceedsLimit } from "./errors";
 
 export default Exchange;


### PR DESCRIPTION
### 📝 Description

When the Exchange device app rejects a swap `NewTransactionResponse` with the generic `DESERIALIZATION_FAILED` (`0x6a81`) status, we now decode the payload locally and, if a field is larger than the device's protobuf `max_size` (mirrored from app-exchange `protocol.options`), surface a precise `SwapPayloadFieldExceedsLimit` reason carrying the field name, its limit and the actual size — e.g. an oversized `payin_extra_id` (in STG, Exodus set it to 40 bytes on Hedera for a field capped at 20).

**The device stays the source of truth.** The local check runs *only after* the device has already rejected the payload — it never gates the flow. If our hardcoded limits ever drift from the app, `findSwapPayloadSpecViolation` returns `undefined` and we fall back to the device's original generic error, so nothing breaks even if a future spec change is missed here.

**The device error status is preserved.** The error is still raised at the same `PROCESS_TRANSACTION` step, and we keep the device error's title / translation key (so the user-facing copy stays identical). Only the error **message** is enriched with the precise field — the error name/status is intentionally *not* changed.

**Observability.** The enriched error flows through `completeExchange` → the wallet-api swap handler (`onCancel`) → `postSwapCancelled` → `POST /swap/cancelled`. The precise reason is reported in the **`errorMessage`** field, while **`statusCode` stays the device status name** (e.g. the `DESERIALIZATION_FAILED` key). So in Datadog you group/filter by `statusCode` as before and read the field detail from `errorMessage`. As with any cancel report, this requires a `swapId`.

**Changes**
- `@ledgerhq/hw-app-exchange`:
  - New `findSwapPayloadSpecViolation(payload)` returning `SwapPayloadFieldExceedsLimit | undefined`. Limits are mirrored from app-exchange `protocol.options`; nanopb reserves one byte for the NUL terminator on `string` fields, so their usable size is `max_size - 1` (`bytes` use the full `max_size`).
  - New `SwapPayloadFieldExceedsLimit` error class, re-exported from the package entrypoint.
  - Payload-decoding refactor: extracted a shared `decodeNewTransactionResponse` used by both `decodeSwapPayload` and the new helper. It resolves the protobuf type via the public `lookupType` API (instead of reaching into `root.nested.*`), drops a `verify(buffer)` call that was a no-op (protobufjs `verify` validates a plain message object, not encoded bytes), normalizes base64url + a leading JWS `.` so Swap NG payloads decode across runtimes, and wraps `deviceTransactionIdNg` in `Buffer.from` for consistent hex on RN/browser. All existing hex / standard-base64 inputs decode identically (covered by tests).
  - README API section regenerated (internal field-limits table hidden from docs).
- `@ledgerhq/live-common`: `completeExchange` enriches the device's `DESERIALIZATION_FAILED` (`0x6a81`) with the precise field via `enrichSwapDeserializationError`, and falls back to the generic error otherwise.

Usage sample:

```ts
import { findSwapPayloadSpecViolation } from "@ledgerhq/hw-app-exchange";

const violation = findSwapPayloadSpecViolation(binaryPayload);
// violation?.field  === "payin_extra_id"
// violation?.limit  === 19
// violation?.actual === 40
```

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34253](https://ledgerhq.atlassian.net/browse/LIVE-34253)
- **ADR** (if any): n/a

Made with [Cursor](https://cursor.com)

[LIVE-34253]: https://ledgerhq.atlassian.net/browse/LIVE-34253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
