### PR TITLE
[LWDM] feat(platform-currencies): add buildStandaloneCryptoAssetsStore

### DIFF
--- a/.changeset/standalone-cryptoassets-store.md
+++ b/.changeset/standalone-cryptoassets-store.md
@@ -1,0 +1,5 @@
+---
+"@features/platform-currencies": minor
+---
+
+Add `buildStandaloneCryptoAssetsStore` — a crypto-assets token store that configures its own Redux store, for runtimes without an application store (CLI scripts, monitoring jobs, integration-test setup). Complements `buildCryptoAssetsStore`, which binds to an existing store's `dispatch`.

--- a/features/platform/currencies/src/legacy/store/buildCryptoAssetsStore.ts
+++ b/features/platform/currencies/src/legacy/store/buildCryptoAssetsStore.ts
@@ -19,12 +19,40 @@ export interface BuildCryptoAssetsStoreConfig {
 }
 
 /**
- * Builds a {@link CryptoAssetsStore} over the `@domain/api-currency-token` RTK-Query
- * api — the runtime reimplementation of the legacy `createRtkCryptoAssetsStore`.
+ * Builds a {@link CryptoAssetsStore} bound to an **existing** Redux store, over the
+ * `@domain/api-currency-token` CAL RTK-Query api.
  *
- * Each method dispatches the matching endpoint's `initiate` thunk, remaps RTK-Query
- * errors to the local error taxonomy, and returns the cached data. Apps inject the
- * result through the legacy `setCryptoAssetsStore` singleton.
+ * Use this from an application composition root that already owns a configured store:
+ * pass that store's `dispatch`. The CAL api's reducer and middleware must be
+ * registered in the store, and its base URL + client version supplied through the
+ * store's thunk `extraArgument` (see `calApiExtra`). Each method dispatches the
+ * matching endpoint's `initiate` thunk, maps RTK-Query errors to the local error
+ * taxonomy, and resolves with the cached data. Apps inject the result through the
+ * legacy `setCryptoAssetsStore` singleton.
+ *
+ * For runtimes that do **not** own a Redux store (CLI scripts, monitoring, tests),
+ * use {@link buildStandaloneCryptoAssetsStore}, which configures its own store from
+ * the CAL configuration.
+ *
+ * @param config.dispatch
+ * The host store's `dispatch`. Its reducer must include `cryptoAssetsApi.reducer`, its
+ * middleware `cryptoAssetsApi.middleware`, and its thunk `extraArgument` the CAL
+ * configuration (`calApiExtra`).
+ *
+ * @param config.api
+ * The CAL token api. Defaults to the shared `cryptoAssetsApi`; override only to inject
+ * a mock in tests.
+ *
+ * @returns
+ * A {@link CryptoAssetsStore} — async `findTokenById`, `findTokenByAddressInCurrency`,
+ * and `getTokensSyncHash`.
+ *
+ * @example
+ * ```ts
+ * // Inside an app that already configured its store:
+ * const store = buildCryptoAssetsStore({ dispatch: reduxStore.dispatch });
+ * const token = await store.findTokenById("ethereum/erc20/usd__coin");
+ * ```
  */
 export function buildCryptoAssetsStore({
   dispatch,

--- a/features/platform/currencies/src/legacy/store/buildStandaloneCryptoAssetsStore.test.ts
+++ b/features/platform/currencies/src/legacy/store/buildStandaloneCryptoAssetsStore.test.ts
@@ -1,0 +1,14 @@
+import { buildStandaloneCryptoAssetsStore } from "./buildStandaloneCryptoAssetsStore";
+
+describe("buildStandaloneCryptoAssetsStore", () => {
+  it("configures its own store and exposes the token accessors", () => {
+    const store = buildStandaloneCryptoAssetsStore({
+      calServiceUrl: "https://crypto-assets-service.test",
+      ledgerClientVersion: "test/0.0.0",
+    });
+
+    expect(typeof store.findTokenById).toBe("function");
+    expect(typeof store.findTokenByAddressInCurrency).toBe("function");
+    expect(typeof store.getTokensSyncHash).toBe("function");
+  });
+});

--- a/features/platform/currencies/src/legacy/store/buildStandaloneCryptoAssetsStore.ts
+++ b/features/platform/currencies/src/legacy/store/buildStandaloneCryptoAssetsStore.ts
@@ -1,0 +1,52 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { calApiExtra, cryptoAssetsApi, type CalApiExtra } from "@domain/api-currency-token";
+import { buildCryptoAssetsStore } from "./buildCryptoAssetsStore";
+import type { CryptoAssetsStore } from "./port";
+
+/**
+ * Builds a {@link CryptoAssetsStore} backed by its **own**, internally-configured
+ * Redux store — for runtimes that do not own one: CLI scripts, monitoring jobs,
+ * bots, and integration-test setup.
+ *
+ * It configures a minimal store (the CAL api's reducer + middleware, with the CAL
+ * configuration installed as the thunk `extraArgument`) and delegates to
+ * {@link buildCryptoAssetsStore}. Because it owns the store, the caller supplies no
+ * `dispatch` — only the CAL configuration. That configuration cannot be read here
+ * (this package must not depend on the runtime environment); the composition root
+ * resolves it and passes the resolved values in.
+ *
+ * For code running inside an application that already owns a store, use
+ * {@link buildCryptoAssetsStore} instead — creating a second store here would
+ * duplicate the CAL cache.
+ *
+ * @param extra
+ * Resolved CAL configuration: `calServiceUrl`, `ledgerClientVersion`, and an optional
+ * `logger`. The composition root typically reads these from its environment and passes
+ * the resolved values (this package never reads them).
+ *
+ * @returns
+ * A {@link CryptoAssetsStore} owning a private CAL cache — async `findTokenById`,
+ * `findTokenByAddressInCurrency`, and `getTokensSyncHash`.
+ *
+ * @example
+ * ```ts
+ * // Standalone runtime (no application store):
+ * const store = buildStandaloneCryptoAssetsStore({
+ *   calServiceUrl: readEnv("CAL_SERVICE_URL"),
+ *   ledgerClientVersion: readEnv("LEDGER_CLIENT_VERSION"),
+ * });
+ * const hash = await store.getTokensSyncHash("ethereum");
+ * ```
+ */
+export function buildStandaloneCryptoAssetsStore(extra: CalApiExtra): CryptoAssetsStore {
+  const store = configureStore({
+    reducer: { [cryptoAssetsApi.reducerPath]: cryptoAssetsApi.reducer },
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware({
+        serializableCheck: false,
+        thunk: { extraArgument: calApiExtra(extra) },
+      }).concat(cryptoAssetsApi.middleware),
+  });
+
+  return buildCryptoAssetsStore({ dispatch: store.dispatch });
+}

--- a/features/platform/currencies/src/legacy/store/index.ts
+++ b/features/platform/currencies/src/legacy/store/index.ts
@@ -4,3 +4,4 @@ export {
   type BuildCryptoAssetsStoreConfig,
   type CryptoAssetsStoreDispatch,
 } from "./buildCryptoAssetsStore";
+export { buildStandaloneCryptoAssetsStore } from "./buildStandaloneCryptoAssetsStore";


### PR DESCRIPTION
### 📝 Description

Adds `buildStandaloneCryptoAssetsStore(extra)` to `@features/platform-currencies` — a crypto-assets **token store** that configures **its own** Redux store, for runtimes that don't own one (CLI scripts, monitoring jobs, bots, integration-test setup).

**Why:** `@domain/api-currency-token`'s `cryptoAssetsApi` reads its CAL config from the thunk `extraArgument` (via `calApiExtra`), so a store has to supply it. `buildCryptoAssetsStore({ dispatch })` binds to an **existing** app store; store-less runtimes previously reached for `setupCalClientStore()` in `@ledgerhq/cryptoassets/cal-client/test-helpers`, which secretly configured its own store — and pulled in `@ledgerhq/cryptoassets`. This helper is the new-arch equivalent: it configures a minimal store (CAL reducer + middleware + `calApiExtra` as `extraArgument`) and delegates to `buildCryptoAssetsStore`, with **no `@ledgerhq/cryptoassets` dependency**. Since `@features/*` must not read the environment, the caller passes the resolved `CalApiExtra` (composition-root DI).

Both factories now carry framework-style JSDoc spelling out which to use when (`buildCryptoAssetsStore` = bind to an existing store's `dispatch`; `buildStandaloneCryptoAssetsStore` = owns its store).

**Usage:**

```ts
import { buildStandaloneCryptoAssetsStore } from "@features/platform-currencies";

// In a runtime with no application store (the composition root resolves the env):
const store = buildStandaloneCryptoAssetsStore({
  calServiceUrl: getEnv("CAL_SERVICE_URL"),
  ledgerClientVersion: getEnv("LEDGER_CLIENT_VERSION"),
});

const token = await store.findTokenById("ethereum/erc20/usd__coin");
const hash = await store.getTokensSyncHash("ethereum");
```

**Scope:** this PR adds the API only. Repointing `coin-modules-monitoring` and `@ledgerhq/wallet-framework-test-setup` off `@ledgerhq/cryptoassets/cal-client/test-helpers` onto this helper is a **follow-up** — it should land after the in-flight monitoring change (#19689) to avoid two PRs editing the same `run.ts`.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34513](https://ledgerhq.atlassian.net/browse/LIVE-34513)
- **ADR** (if any): —


[LIVE-34513]: https://ledgerhq.atlassian.net/browse/LIVE-34513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ