### PR TITLE
[LWDM] fix(coin-evm): lowercase validator explorer URL

### DIFF
--- a/.changeset/dull-buttons-double.md
+++ b/.changeset/dull-buttons-double.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+fix(coin-evm): lowercase validator explorer URL

--- a/libs/coin-modules/coin-evm/src/staking/validators.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators.test.ts
@@ -233,9 +233,9 @@ describe("staking/validators", () => {
   });
 
   describe("explorer & unbonding helpers", () => {
-    it("getValidatorExplorerUrl substitutes the validator address", () => {
+    it("getValidatorExplorerUrl substitutes the validator address after turning it to lowercase", () => {
       expect(getValidatorExplorerUrl("sei_evm", "ADDR")).toBe(
-        "https://seistream.app/validators/ADDR",
+        "https://seistream.app/validators/addr",
       );
     });
 

--- a/libs/coin-modules/coin-evm/src/staking/validators/index.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators/index.ts
@@ -103,7 +103,10 @@ export const prefetchValidators = (currencyId: string): void => {
 };
 
 export const getValidatorExplorerUrl = (currencyId: string, address: string): string | undefined =>
-  STAKING_CONTRACTS[currencyId]?.explorerConfig?.validatorUrl?.replace("$address", address);
+  STAKING_CONTRACTS[currencyId]?.explorerConfig?.validatorUrl?.replace(
+    "$address",
+    address.toLowerCase(),
+  );
 
 export const getUnbondingPeriodDays = (currencyId: string): number | undefined =>
   STAKING_CONTRACTS[currencyId]?.unbondingPeriodDays;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

0g explorer needs lowercase validator address in the URL. This works with other chains too.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
