### PR TITLE
[LWD] Fix concordium account onboarding flaky test

### DIFF
--- a/.changeset/wise-lions-cheer.md
+++ b/.changeset/wise-lions-cheer.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Stabilize Concordium OnboardModal happy-path test by widening the waitFor timeout so the debounced SUCCESS/account-created state has margin over CI real-timer drift

--- a/.changeset/wise-lions-cheer.md
+++ b/.changeset/wise-lions-cheer.md
@@ -1,5 +1,0 @@
----
-"ledger-live-desktop": patch
----
-
-Stabilize Concordium OnboardModal happy-path test by widening the waitFor timeout so the debounced SUCCESS/account-created state has margin over CI real-timer drift

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/testUtils.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/testUtils.ts
@@ -20,8 +20,7 @@ export { createMockAccount, createMockConcordiumCurrency };
 // STEP_TRANSITION_TIMEOUT in OnboardModal
 export const T = 1500;
 export const SESSION_TOPIC = "ABCDsession-topic-rest";
-// Terminal states settle after ~2*T (mock emit + the component's transition debounce);
-// budget generously above that to absorb real-timer drift on loaded CI.
+// Generous timeout to absorb real-timer drift on loaded CI. See LIVE-34490.
 export const WAIT_OPTS = { timeout: 3 * T + 500 };
 
 export const defaultConcordiumResources: ConcordiumResources = {

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/testUtils.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/testUtils.ts
@@ -20,7 +20,9 @@ export { createMockAccount, createMockConcordiumCurrency };
 // STEP_TRANSITION_TIMEOUT in OnboardModal
 export const T = 1500;
 export const SESSION_TOPIC = "ABCDsession-topic-rest";
-export const WAIT_OPTS = { timeout: 2 * T + 500 };
+// Terminal states settle after ~2*T (mock emit + the component's transition debounce);
+// budget generously above that to absorb real-timer drift on loaded CI.
+export const WAIT_OPTS = { timeout: 3 * T + 500 };
 
 export const defaultConcordiumResources: ConcordiumResources = {
   isOnboarded: false,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Fix for the flaky Concordium `OnboardModal › should complete the full onboarding happy path` ([CI run](https://github.com/LedgerHQ/ledger-live/actions/runs/29506212485/job/87647521884)), which timed out on the "successfully connected" wait.

Terminal screens settle after two stacked delays (mock emit `~T+200` + the component's `STEP_TRANSITION_TIMEOUT` debounce `= T`), ~3200 ms — leaving only ~300 ms under the old `WAIT_OPTS` budget of 3500 ms. On loaded CI that margin is presumably exceeded. Fix: bump `WAIT_OPTS` to `3*T+500` (5000 ms).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34490](https://ledgerhq.atlassian.net/browse/LIVE-34490?atlOrigin=eyJpIjoiZDE4MTI0NDQyODI0NGNhYjk2ZjAxNDdmNjAxZTU3MDYiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-34490]: https://ledgerhq.atlassian.net/browse/LIVE-34490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ