### PR TITLE
ci: run every coin testers with "all" input

### DIFF
--- a/.github/workflows/test-coin-tester.yml
+++ b/.github/workflows/test-coin-tester.yml
@@ -1,4 +1,4 @@
-name: "[Coin] - Coin Tester - Scheduled"
+name: "[Coin] - Coin Tester - Scheduled and Manual"
 
 on:
   schedule:
@@ -11,9 +11,9 @@ on:
   workflow_dispatch:
     inputs:
       chain:
-        description: "Coin family to test, separated by commas (,)"
+        description: 'Coin family to test, separated with commas (,), or "all" to run all coins (default)'
         required: false
-        default: ""
+        default: "all"
 
 permissions:
   id-token: write
@@ -56,7 +56,13 @@ jobs:
         run: |
           CHAINS=()
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.chain }}" != "" ]]; then
-            IFS=',' read -ra CHAINS <<< "${{ github.event.inputs.chain }}"
+            if [[ "${{ github.event.inputs.chain }}" == "all" ]]; then
+              for coin in $COIN_TESTER_CURRENCIES; do
+                CHAINS+=("$coin")
+              done
+            else
+              IFS=',' read -ra CHAINS <<< "${{ github.event.inputs.chain }}"
+            fi
           elif echo "${{ steps.affected.outputs.paths }}" | grep -qE "(^|/| )coin-tester(/| |$)"; then
             echo "Detected base coin-tester → adding all coins"
             for coin in $COIN_TESTER_CURRENCIES; do


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Add the ability to manually run all coin modules. This is useful to have an overall visibility of theirs statuses.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
