### PR TITLE
[LWD] test(e2e): fix entrypoint.swap flakiness with root-scoped swap POM

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/components/Page/PageView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/PageView.tsx
@@ -10,6 +10,11 @@ type PageViewProps = PageViewModelResult & {
   readonly children: React.ReactNode;
 };
 
+const getPageTestId = (pathname: string): string => {
+  const path = pathname.replace(/^\/+/, "");
+  return `page-view-${path || "dashboard"}`;
+};
+
 /**
  * PageView
  * Main layout component that renders TopBar and content area
@@ -22,7 +27,7 @@ export const PageView = memo(function PageView({
   shouldRenderRightPanel,
 }: PageViewProps) {
   return (
-    <div className="relative flex flex-1 flex-col min-w-0">
+    <div className="relative flex flex-1 flex-col min-w-0" data-testid={getPageTestId(pathname)}>
       <Wallet40TopBar />
 
       <Wallet40Layout

--- a/e2e/desktop/tests/component/swap/swap-container.ts
+++ b/e2e/desktop/tests/component/swap/swap-container.ts
@@ -1,0 +1,21 @@
+import { expect, Locator } from "@playwright/test";
+import { step } from "tests/misc/reporters/step";
+
+// TODO: migrate the swap logic from `tests/page/swap.page.ts` into this component.
+export class SwapContainer {
+  readonly root: Locator;
+  private readonly swapSurface: "embedded" | "full";
+
+  constructor(ledgerLiveRoot: Locator, swapSurface: "embedded" | "full" = "full") {
+    this.swapSurface = swapSurface;
+    this.root = ledgerLiveRoot.getByTestId(`swap-web-app-container-${swapSurface}`);
+  }
+
+  @step("expect swap container to be visible")
+  async expectSwapContainerVisible() {
+    await expect(
+      this.root,
+      `expect ${this.swapSurface} swap container to be visible`,
+    ).toBeVisible();
+  }
+}

--- a/e2e/desktop/tests/page/abstractClasses.ts
+++ b/e2e/desktop/tests/page/abstractClasses.ts
@@ -50,4 +50,6 @@ export abstract class Component extends PageHolder {
   }
 }
 
-export abstract class AppPage extends Component {}
+export abstract class AppPage extends Component {
+  readonly pageView = (pageId: string) => this.page.getByTestId(`page-view-${pageId}`);
+}

--- a/e2e/desktop/tests/page/asset.page.ts
+++ b/e2e/desktop/tests/page/asset.page.ts
@@ -1,6 +1,5 @@
 import { step } from "../misc/reporters/step";
 import { AppPage } from "./abstractClasses";
-import { isAggregatedAssetsEnabled } from "tests/utils/featureFlagUtils";
 
 export class AssetPage extends AppPage {
   // Buy CTA differs between the legacy Asset page (`asset-page-buy-button`) and the Wallet 4.0
@@ -11,7 +10,6 @@ export class AssetPage extends AppPage {
   // Legacy Asset page exposes a dedicated swap CTA. The AssetDetail page (aggregatedAssets ON) has
   // no swap CTA; swap is the always-mounted embedded rail instead.
   private readonly legacySwapButton = this.page.getByTestId("asset-page-swap-button");
-  private readonly embeddedSwapContainer = this.page.getByTestId("embedded-swap-container");
 
   @step("Start buy flow")
   async startBuyFlow() {
@@ -20,10 +18,6 @@ export class AssetPage extends AppPage {
 
   @step("Start swap flow")
   async startSwapFlow() {
-    if (await isAggregatedAssetsEnabled(this.page)) {
-      await this.embeddedSwapContainer.waitFor();
-      return;
-    }
     await this.legacySwapButton.waitFor();
     await this.legacySwapButton.click();
   }

--- a/e2e/desktop/tests/page/assetDetail.page.ts
+++ b/e2e/desktop/tests/page/assetDetail.page.ts
@@ -1,35 +1,59 @@
-import { expect } from "@playwright/test";
+import { expect, Locator, Page } from "@playwright/test";
 import { step } from "tests/misc/reporters/step";
 import { AppPage } from "./abstractClasses";
+import { SwapContainer } from "tests/component/swap/swap-container";
 
 export class AssetDetailPage extends AppPage {
-  private readonly header = this.page.getByTestId("asset-detail-header");
-  private readonly marketPrice = this.page.getByTestId("asset-detail-market-price");
-  private readonly marketPriceFiatVariation = this.page.getByTestId(
-    "asset-detail-market-price-fiat-variation",
-  );
-  private readonly totalBalance = this.page.getByTestId("asset-detail-total-balance");
-  private readonly addressList = this.page.getByTestId("asset-detail-address-list");
-  private readonly addressRows = this.page.locator(`[data-testid^="asset-detail-address-row-"]`);
-  private readonly addressRowBalances = this.page.locator(
-    `[data-testid^="asset-detail-address-balance-"]`,
-  );
-  private readonly addAddressAction = this.page.getByTestId("asset-detail-add-address");
-  private readonly transactionsSection = this.page.getByTestId("asset-detail-transactions-section");
-  private readonly transactionRows = this.page.locator(`[data-testid^="history-operation-row-"]`);
-  private readonly pnlCards = this.page.locator(`[data-testid^="asset-detail-pnl-card-"]`);
-  private readonly interactivePnlCard = this.page.getByTestId(
-    "asset-detail-pnl-card-unrealisedReturn",
-  );
-  private readonly pnlDetailDialog = this.page.getByTestId("pnl-detail-dialog");
-  private readonly optionsTrigger = this.page.getByTestId("asset-detail-header-options-trigger");
-  private readonly addFavoriteMenuItem = this.page.getByTestId("asset-detail-add-favorite");
-  private readonly removeFavoriteMenuItem = this.page.getByTestId("asset-detail-remove-favorite");
+  private readonly assetId: string;
+  private readonly assetDetailRoot: Locator;
+  readonly swapContainer: SwapContainer;
+
+  private readonly header: Locator;
+  private readonly marketPrice: Locator;
+  private readonly marketPriceFiatVariation: Locator;
+  private readonly totalBalance: Locator;
+  private readonly addressList: Locator;
+  private readonly addressRows: Locator;
+  private readonly addressRowBalances: Locator;
+  private readonly addAddressAction: Locator;
+  private readonly transactionsSection: Locator;
+  private readonly transactionRows: Locator;
+  private readonly pnlCards: Locator;
+  private readonly interactivePnlCard: Locator;
+  private readonly optionsTrigger: Locator;
   // The staking section renders either the "earn banner" (not yet staked) or the "earn deposit"
   // card (already staked); both open the same stake flow.
-  private readonly earnEntry = this.page
-    .getByTestId("asset-detail-earn-banner")
-    .or(this.page.getByTestId("asset-detail-earn-deposit"));
+  private readonly earnEntry: Locator;
+
+  // Rendered in a portal (Lumen Dialog / Menu), so kept page-wide rather than scoped to the root.
+  private readonly pnlDetailDialog = this.page.getByTestId("pnl-detail-dialog");
+  private readonly addFavoriteMenuItem = this.page.getByTestId("asset-detail-add-favorite");
+  private readonly removeFavoriteMenuItem = this.page.getByTestId("asset-detail-remove-favorite");
+
+  constructor(page: Page, assetId: string) {
+    super(page);
+    this.assetId = assetId;
+    this.assetDetailRoot = this.pageView(`asset/${this.assetId}`);
+    this.swapContainer = new SwapContainer(this.assetDetailRoot, "embedded");
+
+    const root = this.assetDetailRoot;
+    this.header = root.getByTestId("asset-detail-header");
+    this.marketPrice = root.getByTestId("asset-detail-market-price");
+    this.marketPriceFiatVariation = root.getByTestId("asset-detail-market-price-fiat-variation");
+    this.totalBalance = root.getByTestId("asset-detail-total-balance");
+    this.addressList = root.getByTestId("asset-detail-address-list");
+    this.addressRows = root.locator(`[data-testid^="asset-detail-address-row-"]`);
+    this.addressRowBalances = root.locator(`[data-testid^="asset-detail-address-balance-"]`);
+    this.addAddressAction = root.getByTestId("asset-detail-add-address");
+    this.transactionsSection = root.getByTestId("asset-detail-transactions-section");
+    this.transactionRows = root.locator(`[data-testid^="history-operation-row-"]`);
+    this.pnlCards = root.locator(`[data-testid^="asset-detail-pnl-card-"]`);
+    this.interactivePnlCard = root.getByTestId("asset-detail-pnl-card-unrealisedReturn");
+    this.optionsTrigger = root.getByTestId("asset-detail-header-options-trigger");
+    this.earnEntry = root
+      .getByTestId("asset-detail-earn-banner")
+      .or(root.getByTestId("asset-detail-earn-deposit"));
+  }
 
   @step("Wait for asset detail page to load")
   async expectLoaded() {

--- a/e2e/desktop/tests/page/index.ts
+++ b/e2e/desktop/tests/page/index.ts
@@ -56,7 +56,7 @@ export class Application extends PageHolder {
   public analytics = new AnalyticsPage(this.page);
   public addAccount = new AddAccountModal(this.page);
   public assetDrawer = new AssetDrawer(this.page);
-  public assetDetail = new AssetDetailPage(this.page);
+  public assetDetail = (assetId: string) => new AssetDetailPage(this.page, assetId);
   public assetPage = new AssetPage(this.page);
   public buyAndSell = new BuyAndSellPage(this.page, this.electronApp);
   public delegate = new DelegateModal(this.page);

--- a/e2e/desktop/tests/specs/assets.aggregation.spec.ts
+++ b/e2e/desktop/tests/specs/assets.aggregation.spec.ts
@@ -43,10 +43,11 @@ test.describe("Wallet 4.0 - Asset Aggregation / Asset Market / Asset Detail", ()
 
         await app.portfolio.assetsView.clickAggregatedAssetInSection("stablecoins", "USD Coin");
         await expect(app.layout.getPage()).toHaveURL(/\/asset\//);
-        await app.assetDetail.expectLoaded();
-        await app.assetDetail.expectAddressListVisible();
-        expect(await app.assetDetail.countAddressRows()).toBeGreaterThanOrEqual(2);
-        await app.assetDetail.expectAddressRowsHaveBalance();
+        const assetDetail = app.assetDetail(Currency.ETH_USDC.id);
+        await assetDetail.expectLoaded();
+        await assetDetail.expectAddressListVisible();
+        expect(await assetDetail.countAddressRows()).toBeGreaterThanOrEqual(2);
+        await assetDetail.expectAddressRowsHaveBalance();
 
         await app.mainNavigation.openTargetFromMainNavigation("home");
         await app.portfolio.assetsView.waitForAssetsToLoad();
@@ -77,22 +78,23 @@ test.describe("Wallet 4.0 - Asset Aggregation / Asset Market / Asset Detail", ()
         await app.portfolio.assetsView.waitForAssetsToLoad();
         await app.portfolio.assetsView.clickAssetInSection("cryptos", Currency.BTC);
         await expect(app.layout.getPage()).toHaveURL(/\/asset\//);
-        await app.assetDetail.expectLoaded();
+        const assetDetail = app.assetDetail(Currency.BTC.id);
+        await assetDetail.expectLoaded();
 
-        await app.assetDetail.expectMarketInfoVisible();
+        await assetDetail.expectMarketInfoVisible();
 
-        await app.assetDetail.expectTotalBalanceVisible();
-        await app.assetDetail.expectAddressListVisible();
-        await app.assetDetail.expectAddAddressVisible();
-        await app.assetDetail.expectTransactionsVisible();
+        await assetDetail.expectTotalBalanceVisible();
+        await assetDetail.expectAddressListVisible();
+        await assetDetail.expectAddAddressVisible();
+        await assetDetail.expectTransactionsVisible();
 
-        await app.assetDetail.clickFirstTransaction();
+        await assetDetail.clickFirstTransaction();
         await app.operationDrawer.waitForDrawerToBeVisible();
         await app.operationDrawer.closeDrawer();
 
-        await app.assetDetail.expectPnlCardsVisible();
-        await app.assetDetail.openPnlCardDetail();
-        await app.assetDetail.closePnlCardDetail();
+        await assetDetail.expectPnlCardsVisible();
+        await assetDetail.openPnlCardDetail();
+        await assetDetail.closePnlCardDetail();
 
         await app.mainNavigation.openTargetFromMainNavigation("home");
         await app.portfolio.assetsView.waitForAssetsToLoad();
@@ -124,9 +126,10 @@ test.describe("Wallet 4.0 - Asset Aggregation / Asset Market / Asset Detail", ()
         await app.mainNavigation.openTargetFromMainNavigation("home");
         await app.portfolio.assetsView.waitForAssetsToLoad();
         await app.portfolio.assetsView.clickAssetInSection("cryptos", Currency.BTC);
-        await app.assetDetail.expectLoaded();
-        await app.assetDetail.addToFavorites();
-        await app.assetDetail.expectFavorited();
+        const assetDetail = app.assetDetail(Currency.BTC.id);
+        await assetDetail.expectLoaded();
+        await assetDetail.addToFavorites();
+        await assetDetail.expectFavorited();
 
         await app.mainNavigation.openTargetFromMainNavigation("home");
         await app.portfolio.assetsView.waitForAssetsToLoad();
@@ -137,11 +140,11 @@ test.describe("Wallet 4.0 - Asset Aggregation / Asset Market / Asset Detail", ()
 
         await app.market.clickCoinRow(ticker);
         await expect(app.layout.getPage()).toHaveURL(/\/asset\//);
-        await app.assetDetail.expectLoaded();
-        await app.assetDetail.expectFavorited();
+        await assetDetail.expectLoaded();
+        await assetDetail.expectFavorited();
 
-        await app.assetDetail.removeFromFavorites();
-        await app.assetDetail.expectNotFavorited();
+        await assetDetail.removeFromFavorites();
+        await assetDetail.expectNotFavorited();
         await app.mainNavigation.openTargetFromMainNavigation("home");
         await app.portfolio.assetsView.waitForAssetsToLoad();
         await app.marketBanner.clickExploreMarketHeader();
@@ -175,9 +178,10 @@ test.describe("Wallet 4.0 - Asset Aggregation / Asset Market / Asset Detail", ()
         await app.mainNavigation.openTargetFromMainNavigation("home");
         await app.portfolio.assetsView.waitForAssetsToLoad();
         await app.portfolio.assetsView.clickAssetInSection("cryptos", Currency.ETH);
-        await app.assetDetail.expectLoaded();
-        await app.assetDetail.expectAddressListVisible();
-        await app.assetDetail.clickFirstAddressRow();
+        const assetDetail = app.assetDetail(Currency.ETH.id);
+        await assetDetail.expectLoaded();
+        await assetDetail.expectAddressListVisible();
+        await assetDetail.clickFirstAddressRow();
         await expect(app.layout.getPage()).toHaveURL(/\/account\//);
 
         await app.account.expectAccountHeaderVisible();

--- a/e2e/desktop/tests/specs/delegate.spec.ts
+++ b/e2e/desktop/tests/specs/delegate.spec.ts
@@ -475,7 +475,7 @@ test.describe("Staking flow from different entry point", () => {
         await app.market.stakeButtonClick(delegateAccount.account.currency.ticker);
       } else {
         await app.market.openCoinPage(delegateAccount.account.currency.ticker);
-        await app.assetDetail.startEarnFlow();
+        await app.assetDetail(delegateAccount.account.currency.id).startEarnFlow();
       }
 
       const selector = await getModularSelector(app, "ACCOUNT");

--- a/e2e/desktop/tests/specs/entrypoint.swap.spec.ts
+++ b/e2e/desktop/tests/specs/entrypoint.swap.spec.ts
@@ -64,10 +64,13 @@ test.describe("Swap flow from different entry point", () => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.mainNavigation.openTargetFromMainNavigation("home");
       await app.portfolio.clickAsset(swapEntryPoint.swap.accountToDebit.currency);
-      // aggregatedAssets ON opens swap as the AssetDetail embedded rail; otherwise the legacy
-      // asset page's Swap CTA navigates to the full /swap page.
-      const swapSurface = (await isAggregatedAssetsEnabled(app.getPage())) ? "embedded" : "full";
-      await app.swap.goAndWaitForSwapToBeReady(() => app.assetPage.startSwapFlow(), swapSurface);
+      if (await isAggregatedAssetsEnabled(app.getPage())) {
+        await app
+          .assetDetail(swapEntryPoint.swap.accountToDebit.currency.id)
+          .swapContainer.expectSwapContainerVisible();
+      } else {
+        await app.swap.goAndWaitForSwapToBeReady(() => app.assetPage.startSwapFlow());
+      }
       await app.swap.checkAssetToContains(swapEntryPoint.swap.accountToDebit.currency.ticker);
     },
   );
@@ -108,7 +111,9 @@ test.describe("Swap flow from different entry point", () => {
       await app.marketBanner.clickExploreMarketHeader();
       await app.market.clickCoinRow(swapEntryPoint.swap.accountToDebit.currency.ticker);
       if (await isAggregatedAssetsEnabled(app.getPage())) {
-        await app.assetDetail.expectMarketInfoVisible();
+        await app
+          .assetDetail(swapEntryPoint.swap.accountToDebit.currency.id)
+          .swapContainer.expectSwapContainerVisible();
       } else {
         await app.marketCoin.expectMarketCoinPageToBeVisible(
           swapEntryPoint.swap.accountToDebit.currency.id,


### PR DESCRIPTION
### 📝 Description

Fixes intermittent CI failures in `e2e/desktop/tests/specs/entrypoint.swap.spec.ts`.

**Problem:** on the Asset Detail page (aggregatedAssets ON) the embedded swap rail was located with a **page-wide** `swap-web-app-container-embedded` selector. When an embedded swap from the previously visited screen was still mounted, the selector could match more than one element — or resolve to the wrong screen's swap — causing flaky, timing-dependent failures.

**Fix:** scope the swap rail (and the Asset Detail page's own locators) to the current page root, adopting the component-based page-object pattern from #16706.

- **PageView**: add a `page-view-<path>` root testid that mirrors the route verbatim, giving each page an exact, unambiguous anchor.
- **`AppPage.pageView()`** helper + new **`SwapContainer`** component scoped to a parent locator (following the `AssetsTable` precedent).
- **`AssetDetailPage`**: takes the asset id, resolves its page root, and scopes its in-page locators to it. Portaled Lumen `Dialog`/`Menu` content (PnL dialog, favorite menu items) intentionally stay page-wide.
- **`index.ts`**: `assetDetail` is now an `assetId` factory; updated callers in `assets.aggregation` and `delegate` specs.

### ❓ Context

- **JIRA**: [QAA-1406](https://ledgerhq.atlassian.net/browse/QAA-1406)
- Failing job: https://github.com/LedgerHQ/ledger-live/actions/runs/29472883044/job/87539485233
- Pattern proposal / precedent: #16706

### ✅ Checklist

- [ ] `npx changeset` — n/a (test-only change, no package published)
- [x] Covered by automatic tests (this *is* an e2e test fix)
- [ ] **QA focus:** the Swap entry-point suite (Asset Allocation and Market → asset entry points) with `aggregatedAssets` enabled.

> Note: the base commit is currently unsigned (CI/local env couldn't reach the GPG agent); will re-sign before merge if required.

[QAA-1406]: https://ledgerhq.atlassian.net/browse/QAA-1406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ