### PR TITLE
[LWDM] feat(hypercore): hide send and receive for hypercore accounts on desktop

### DIFF
--- a/.changeset/hide-send-receive-hypercore-lld.md
+++ b/.changeset/hide-send-receive-hypercore-lld.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+"@ledgerhq/cryptoassets": patch
+"@domain/entity-currency-crypto": patch
+---
+
+Hide Send and Receive for HyperCore accounts on desktop: HyperCore has no on-chain send on Ledger Wallet and a plain receive is misleading (deposits go through bridging). Both actions are now hidden across the account page, the account context menu and the empty-account state. Also drop the HyperCore per-transaction explorer view: the perps proxy exposes no HyperCore tx hash (deposits settle on Arbitrum, withdrawals expose no link), so the `tx` explorer URL was always broken — only the address explorer view is kept. Finally, the currency is renamed from "Hyperliquid (HyperCore)" to "Hyperliquid".

--- a/apps/ledger-live-desktop/src/renderer/components/ContextMenu/AccountContextMenu.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ContextMenu/AccountContextMenu.tsx
@@ -3,6 +3,10 @@ import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { useLocation, useNavigate } from "react-router";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/helpers";
+import {
+  isReceiveDisabledForFamily,
+  isSendDisabledForFamily,
+} from "@ledgerhq/live-common/account/index";
 import { openModal } from "~/renderer/actions/modals";
 import IconReceive from "~/renderer/icons/Receive";
 import IconSend from "~/renderer/icons/Send";
@@ -59,8 +63,10 @@ export default function AccountContextMenu({
   const menuItems = useMemo(() => {
     const currency = getAccountCurrency(account);
     const mainAccount = getMainAccount(account, parentAccount);
-    const items: ContextMenuItemType[] = [
-      {
+    const family = mainAccount.currency.family;
+    const items: ContextMenuItemType[] = [];
+    if (!isSendDisabledForFamily(family)) {
+      items.push({
         label: "accounts.contextMenu.send",
         Icon: IconSend,
         callback: () =>
@@ -68,8 +74,10 @@ export default function AccountContextMenu({
             account,
             parentAccount: parentAccount ?? undefined,
           }),
-      },
-      {
+      });
+    }
+    if (!isReceiveDisabledForFamily(family)) {
+      items.push({
         label: "accounts.contextMenu.receive",
         Icon: IconReceive,
         callback: () =>
@@ -80,8 +88,8 @@ export default function AccountContextMenu({
               sourcePage: RECEIVE_SOURCE_PAGE.ACCOUNT_PAGE,
             }),
           ),
-      },
-    ];
+      });
+    }
     const availableOnBuy = isCurrencySupported("BUY", currency);
     if (availableOnBuy) {
       items.push({

--- a/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.test.tsx
@@ -24,8 +24,15 @@ jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
 
 jest.mock("@ledgerhq/live-common/account/index", () => {
   const framework = jest.requireActual("@ledgerhq/ledger-wallet-framework/account/index");
+  // hypercore disables both send and receive; every other family allows them.
+  const allowsTransfer = (account: unknown, parentAccount: unknown) =>
+    framework.getMainAccount(account, parentAccount).currency.family !== "hypercore";
   return {
-    canSend: jest.fn().mockResolvedValue(true),
+    canSend: jest.fn((account, parentAccount) =>
+      Promise.resolve(allowsTransfer(account, parentAccount)),
+    ),
+    canReceive: (account: unknown, parentAccount: unknown) =>
+      allowsTransfer(account, parentAccount),
     getMainAccount: framework.getMainAccount,
     getAccountCurrency: framework.getAccountCurrency,
     flattenAccounts: framework.flattenAccounts,
@@ -131,5 +138,19 @@ describe("AccountHeaderActions — family slot / fallback logic", () => {
 
     await waitFor(() => expect(screen.getByTestId("send-button")).toBeVisible());
     expect(screen.getByTestId("receive-account-action-button")).toBeVisible();
+  });
+
+  it("hides both send and receive for a family that disables them (hypercore)", async () => {
+    mockFamily.mockReturnValue({} as never);
+    const hypercoreAccount = genAccount("test-hypercore-account", {
+      currency: getCryptoCurrencyById("hypercore"),
+    }) as Account;
+
+    render(<AccountHeaderActions account={hypercoreAccount} parentAccount={undefined} />);
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("receive-account-action-button")).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("send-button")).not.toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
@@ -1,4 +1,9 @@
-import { canSend, getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
+import {
+  canReceive,
+  canSend,
+  getAccountCurrency,
+  getMainAccount,
+} from "@ledgerhq/live-common/account/index";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
 
@@ -398,7 +403,9 @@ const AccountHeaderActions = ({ account, parentAccount, openModal }: Props) => {
       {canSendResult ? (
         <SendAction account={account} parentAccount={parentAccount} onClick={onSend} />
       ) : null}
-      <ReceiveAction account={account} parentAccount={parentAccount} onClick={onReceive} />
+      {canReceive(mainAccount, undefined) ? (
+        <ReceiveAction account={account} parentAccount={parentAccount} onClick={onReceive} />
+      ) : null}
     </FadeInButtonsContainer>
   );
 

--- a/apps/ledger-live-desktop/src/renderer/screens/account/EmptyStateAccount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/EmptyStateAccount.tsx
@@ -5,7 +5,7 @@ import { withTranslation, Trans } from "react-i18next";
 import { TFunction } from "i18next";
 import { openModal } from "~/renderer/actions/modals";
 import { Account, AccountLike } from "@ledgerhq/types-live";
-import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { canReceive, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import IconReceive from "~/renderer/icons/Receive";
 import IconExchange from "~/renderer/icons/Exchange";
@@ -113,22 +113,24 @@ function EmptyStateAccount({ t, account, parentAccount, openModal }: Props) {
               </Box>
             </Button>
           ) : null}
-          <Button
-            mt={5}
-            primary
-            onClick={() =>
-              openModal("MODAL_RECEIVE", {
-                account,
-                parentAccount,
-                sourcePage: RECEIVE_SOURCE_PAGE.ACCOUNT_PAGE,
-              })
-            }
-          >
-            <Box horizontal flow={1} alignItems="center">
-              <IconReceive size={12} />
-              <Box>{t("account.emptyState.buttons.receiveFunds")}</Box>
-            </Box>
-          </Button>
+          {canReceive(mainAccount, undefined) ? (
+            <Button
+              mt={5}
+              primary
+              onClick={() =>
+                openModal("MODAL_RECEIVE", {
+                  account,
+                  parentAccount,
+                  sourcePage: RECEIVE_SOURCE_PAGE.ACCOUNT_PAGE,
+                })
+              }
+            >
+              <Box horizontal flow={1} alignItems="center">
+                <IconReceive size={12} />
+                <Box>{t("account.emptyState.buttons.receiveFunds")}</Box>
+              </Box>
+            </Button>
+          ) : null}
         </Box>
       </Box>
     </Box>

--- a/domain/entity/currency-crypto/src/currencies/hypercore.ts
+++ b/domain/entity/currency-crypto/src/currencies/hypercore.ts
@@ -4,7 +4,7 @@ export const hypercore = currency({
   type: "CryptoCurrency",
   id: "hypercore",
   coinType: 60,
-  name: "Hyperliquid (HyperCore)",
+  name: "Hyperliquid",
   managerAppName: "Ethereum",
   ticker: "USDC",
   scheme: "hypercore",
@@ -19,7 +19,7 @@ export const hypercore = currency({
   ],
   explorerViews: [
     {
-      tx: "https://app.hyperliquid.xyz/explorer/tx/$hash",
+      // Address view only (no HyperCore tx hash exposed by the proxy).
       address: "https://app.hyperliquid.xyz/explorer/address/$address",
     },
   ],

--- a/libs/ledger-live-common/src/account/support.test.ts
+++ b/libs/ledger-live-common/src/account/support.test.ts
@@ -1,0 +1,63 @@
+import { getCryptoCurrencyById } from "../currencies";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { Account } from "@ledgerhq/types-live";
+import { getAccountBridge } from "../bridge";
+import {
+  canReceive,
+  canSend,
+  isReceiveDisabledForFamily,
+  isSendDisabledForFamily,
+} from "./support";
+
+jest.mock("../bridge");
+const mockGetAccountBridge = jest.mocked(getAccountBridge);
+
+const ethAccount = genAccount("eth", { currency: getCryptoCurrencyById("ethereum") }) as Account;
+const hypercoreAccount = genAccount("hc", {
+  currency: getCryptoCurrencyById("hypercore"),
+}) as Account;
+
+const bridgeWith = (createTransaction: jest.Mock) =>
+  ({ createTransaction }) as unknown as ReturnType<typeof getAccountBridge>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("family transfer capability", () => {
+  it("disables send and receive for hypercore, allows them for other families", () => {
+    expect(isSendDisabledForFamily("hypercore")).toBe(true);
+    expect(isReceiveDisabledForFamily("hypercore")).toBe(true);
+    expect(isSendDisabledForFamily("ethereum")).toBe(false);
+    expect(isReceiveDisabledForFamily("ethereum")).toBe(false);
+  });
+
+  it("canReceive follows the family capability", () => {
+    expect(canReceive(hypercoreAccount, undefined)).toBe(false);
+    expect(canReceive(ethAccount, undefined)).toBe(true);
+  });
+});
+
+describe("canSend", () => {
+  it("short-circuits to false for send-disabled families without probing the bridge", async () => {
+    await expect(canSend(hypercoreAccount, undefined)).resolves.toBe(false);
+    expect(mockGetAccountBridge).not.toHaveBeenCalled();
+  });
+
+  it("probes the bridge for other families", async () => {
+    const createTransaction = jest.fn();
+    mockGetAccountBridge.mockReturnValue(bridgeWith(createTransaction));
+    await expect(canSend(ethAccount, undefined)).resolves.toBe(true);
+    expect(mockGetAccountBridge).toHaveBeenCalled();
+    expect(createTransaction).toHaveBeenCalled();
+  });
+
+  it("returns false when building a transaction throws", async () => {
+    mockGetAccountBridge.mockReturnValue(
+      bridgeWith(
+        jest.fn(() => {
+          throw new Error("cannot build");
+        }),
+      ),
+    );
+    await expect(canSend(ethAccount, undefined)).resolves.toBe(false);
+  });
+});

--- a/libs/ledger-live-common/src/account/support.ts
+++ b/libs/ledger-live-common/src/account/support.ts
@@ -4,6 +4,7 @@ import { checkAccountSupported as checkAccountDerivationSupported } from "@ledge
 import { isCoinModuleRegistered } from "../coin-modules/registry";
 import { getAccountBridge } from "../bridge";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 
 export { getReceiveFlowError } from "@ledgerhq/ledger-wallet-framework/account/support";
 
@@ -18,16 +19,48 @@ export function checkAccountSupported(account: Account): Error | null | undefine
   return checkAccountDerivationSupported(account);
 }
 
+// Send/Receive capability per family on Ledger Wallet. Defaults to both supported; only exceptions
+// are listed.
+type TransferCapability = { send: boolean; receive: boolean };
+const DEFAULT_TRANSFER_CAPABILITY: TransferCapability = { send: true, receive: true };
+const FAMILY_TRANSFER_CAPABILITY: Partial<Record<CryptoCurrency["family"], TransferCapability>> = {
+  hypercore: { send: false, receive: false },
+};
+
+const transferCapability = (family: CryptoCurrency["family"]): TransferCapability =>
+  FAMILY_TRANSFER_CAPABILITY[family] ?? DEFAULT_TRANSFER_CAPABILITY;
+
+export const isSendDisabledForFamily = (family: CryptoCurrency["family"]): boolean =>
+  !transferCapability(family).send;
+
+export const isReceiveDisabledForFamily = (family: CryptoCurrency["family"]): boolean =>
+  !transferCapability(family).receive;
+
+// Send capability: the family must allow it AND the bridge must accept building a transaction.
+// Total: any throw (incl. getMainAccount on a malformed account) resolves to false.
 export async function canSend(
   account: AccountLike,
   parentAccount: Account | null | undefined,
 ): Promise<boolean> {
   try {
-    (await getAccountBridge(account, parentAccount)).createTransaction(
-      getMainAccount(account, parentAccount),
-    );
+    const mainAccount = getMainAccount(account, parentAccount);
+    if (isSendDisabledForFamily(mainAccount.currency.family)) return false;
+    (await getAccountBridge(account, parentAccount)).createTransaction(mainAccount);
     return true;
   } catch {
     return false;
   }
 }
+
+// Receive capability for the account's family (no bridge probe, unlike canSend).
+// Total: returns false rather than throwing if the account cannot be resolved.
+export const canReceive = (
+  account: AccountLike,
+  parentAccount: Account | null | undefined,
+): boolean => {
+  try {
+    return !isReceiveDisabledForFamily(getMainAccount(account, parentAccount).currency.family);
+  } catch {
+    return false;
+  }
+};

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -4236,7 +4236,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     type: "CryptoCurrency",
     id: "hypercore",
     coinType: CoinType.ETH,
-    name: "Hyperliquid (HyperCore)",
+    name: "Hyperliquid",
     managerAppName: "Ethereum",
     ticker: "USDC",
     scheme: "hypercore",
@@ -4251,7 +4251,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ],
     explorerViews: [
       {
-        tx: "https://app.hyperliquid.xyz/explorer/tx/$hash",
+        // Address view only (no HyperCore tx hash exposed by the proxy).
         address: "https://app.hyperliquid.xyz/explorer/address/$address",
       },
     ],

--- a/libs/live-currency-format/src/__snapshots__/formatCurrencyUnit.test.ts.snap
+++ b/libs/live-currency-format/src/__snapshots__/formatCurrencyUnit.test.ts.snap
@@ -182,7 +182,7 @@ exports[`formatCurrencyUnit with custom options with locale de-DE should correct
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format HyperEVM unit (HYPE) 1`] = `"0,012345678900000000- -HYPE"`;
 
-exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Hyperliquid (HyperCore) unit (USD Coin) 1`] = `"12.345.678.900,000000- -USDC"`;
+exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Hyperliquid unit (USD Coin) 1`] = `"12.345.678.900,000000- -USDC"`;
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format ICON Berlin Testnet unit (ICX) 1`] = `"0,012345678900000000- -ICX"`;
 
@@ -586,7 +586,7 @@ exports[`formatCurrencyUnit with custom options with locale en-US should correct
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format HyperEVM unit (HYPE) 1`] = `"0.012345678900000000- -HYPE"`;
 
-exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Hyperliquid (HyperCore) unit (USD Coin) 1`] = `"12,345,678,900.000000- -USDC"`;
+exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Hyperliquid unit (USD Coin) 1`] = `"12,345,678,900.000000- -USDC"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format ICON Berlin Testnet unit (ICX) 1`] = `"0.012345678900000000- -ICX"`;
 
@@ -990,7 +990,7 @@ exports[`formatCurrencyUnit with custom options with locale es-ES should correct
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format HyperEVM unit (HYPE) 1`] = `"0,012345678900000000- -HYPE"`;
 
-exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Hyperliquid (HyperCore) unit (USD Coin) 1`] = `"12.345.678.900,000000- -USDC"`;
+exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Hyperliquid unit (USD Coin) 1`] = `"12.345.678.900,000000- -USDC"`;
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format ICON Berlin Testnet unit (ICX) 1`] = `"0,012345678900000000- -ICX"`;
 
@@ -1394,7 +1394,7 @@ exports[`formatCurrencyUnit with custom options with locale fr-FR should correct
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format HyperEVM unit (HYPE) 1`] = `"0,012345678900000000- -HYPE"`;
 
-exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Hyperliquid (HyperCore) unit (USD Coin) 1`] = `"12 345 678 900,000000- -USDC"`;
+exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Hyperliquid unit (USD Coin) 1`] = `"12 345 678 900,000000- -USDC"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format ICON Berlin Testnet unit (ICX) 1`] = `"0,012345678900000000- -ICX"`;
 
@@ -1798,7 +1798,7 @@ exports[`formatCurrencyUnit with custom options with locale ja-JP should correct
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format HyperEVM unit (HYPE) 1`] = `"0.012345678900000000- -HYPE"`;
 
-exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Hyperliquid (HyperCore) unit (USD Coin) 1`] = `"12,345,678,900.000000- -USDC"`;
+exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Hyperliquid unit (USD Coin) 1`] = `"12,345,678,900.000000- -USDC"`;
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format ICON Berlin Testnet unit (ICX) 1`] = `"0.012345678900000000- -ICX"`;
 
@@ -2202,7 +2202,7 @@ exports[`formatCurrencyUnit with custom options with locale ko-KR should correct
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format HyperEVM unit (HYPE) 1`] = `"0.012345678900000000- -HYPE"`;
 
-exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Hyperliquid (HyperCore) unit (USD Coin) 1`] = `"12,345,678,900.000000- -USDC"`;
+exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Hyperliquid unit (USD Coin) 1`] = `"12,345,678,900.000000- -USDC"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format ICON Berlin Testnet unit (ICX) 1`] = `"0.012345678900000000- -ICX"`;
 
@@ -2606,7 +2606,7 @@ exports[`formatCurrencyUnit with custom options with locale pt-BR should correct
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format HyperEVM unit (HYPE) 1`] = `"0,012345678900000000- -HYPE"`;
 
-exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Hyperliquid (HyperCore) unit (USD Coin) 1`] = `"12.345.678.900,000000- -USDC"`;
+exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Hyperliquid unit (USD Coin) 1`] = `"12.345.678.900,000000- -USDC"`;
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format ICON Berlin Testnet unit (ICX) 1`] = `"0,012345678900000000- -ICX"`;
 
@@ -3010,7 +3010,7 @@ exports[`formatCurrencyUnit with custom options with locale ru-RU should correct
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format HyperEVM unit (HYPE) 1`] = `"0,012345678900000000- -HYPE"`;
 
-exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Hyperliquid (HyperCore) unit (USD Coin) 1`] = `"12 345 678 900,000000- -USDC"`;
+exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Hyperliquid unit (USD Coin) 1`] = `"12 345 678 900,000000- -USDC"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format ICON Berlin Testnet unit (ICX) 1`] = `"0,012345678900000000- -ICX"`;
 
@@ -3414,7 +3414,7 @@ exports[`formatCurrencyUnit with custom options with locale tr-TR should correct
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format HyperEVM unit (HYPE) 1`] = `"0,012345678900000000- -HYPE"`;
 
-exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Hyperliquid (HyperCore) unit (USD Coin) 1`] = `"12.345.678.900,000000- -USDC"`;
+exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Hyperliquid unit (USD Coin) 1`] = `"12.345.678.900,000000- -USDC"`;
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format ICON Berlin Testnet unit (ICX) 1`] = `"0,012345678900000000- -ICX"`;
 
@@ -3818,7 +3818,7 @@ exports[`formatCurrencyUnit with custom options with locale zh-CN should correct
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format HyperEVM unit (HYPE) 1`] = `"0.012345678900000000- -HYPE"`;
 
-exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Hyperliquid (HyperCore) unit (USD Coin) 1`] = `"12,345,678,900.000000- -USDC"`;
+exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Hyperliquid unit (USD Coin) 1`] = `"12,345,678,900.000000- -USDC"`;
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format ICON Berlin Testnet unit (ICX) 1`] = `"0.012345678900000000- -ICX"`;
 
@@ -4222,7 +4222,7 @@ exports[`formatCurrencyUnit with default options should correctly format Hycon u
 
 exports[`formatCurrencyUnit with default options should correctly format HyperEVM unit (HYPE) 1`] = `"0.0123456"`;
 
-exports[`formatCurrencyUnit with default options should correctly format Hyperliquid (HyperCore) unit (USD Coin) 1`] = `"12,345,678,900"`;
+exports[`formatCurrencyUnit with default options should correctly format Hyperliquid unit (USD Coin) 1`] = `"12,345,678,900"`;
 
 exports[`formatCurrencyUnit with default options should correctly format ICON Berlin Testnet unit (ICX) 1`] = `"0.0123456"`;
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _`support.test.ts` covers the family capability + `canSend` short-circuit; `AccountHeaderActions` test asserts Send/Receive are hidden for HyperCore and shown for other families._
- [x] **Impact of the changes:**
  - Account page header: no Send / Receive buttons for HyperCore accounts.
  - Account context menu (accounts list rows, grid tiles, Asset-page distribution rows): no Send / Receive items for HyperCore.
  - Empty HyperCore account state: no "Receive funds" button.
  - Operation history: the per-transaction explorer link is removed for HyperCore (the perps proxy exposes no HyperCore tx hash — deposits settle on Arbitrum, withdrawals expose no link — so the `tx` URL was always broken); the address explorer view is kept.
  - The currency is renamed from "Hyperliquid (HyperCore)" to "Hyperliquid".
  - Regression: normal accounts (e.g. ethereum) still show Send + Receive everywhere.

### 📝 Description

HyperCore accounts (`family: "hypercore"`, plugged via the generic coin framework) have **no on-chain Send** on Ledger Wallet, and a plain **Receive** is misleading — the HyperCore address is an Ethereum-format address but deposits go through bridging, not a normal receive flow. So both actions are hidden for HyperCore accounts across every desktop surface that offers them per-account.

**Solution**: the per-family transfer capability lives in a single place in `@ledgerhq/live-common`, and surfaces ask a semantic question rather than reaching into the family:

```ts
// libs/ledger-live-common/src/account/support.ts
// Defaults to both supported; only exceptions are listed.
const FAMILY_TRANSFER_CAPABILITY: Partial<
  Record<CryptoCurrency["family"], { send: boolean; receive: boolean }>
> = {
  hypercore: { send: false, receive: false },
};

// canSend is family-aware: it short-circuits to false before the bridge probe for send-disabled
// families, so every canSend call site (incl. wallet-api) is covered and no wasted lookup happens.
export async function canSend(account, parentAccount) { /* family check → bridge.createTransaction */ }
export const canReceive = (account, parentAccount) => /* !isReceiveDisabledForFamily(family) */;
```

Account-based surfaces (`AccountHeaderActions.tsx`, `EmptyStateAccount.tsx`) consume `canSend` / `canReceive`; the currency/family-level context menu (`AccountContextMenu.tsx`) uses the underlying `isSendDisabledForFamily` / `isReceiveDisabledForFamily` predicates. Adding a new send/receive-disabled family is a one-line entry in the capability map.

> Note: `canSend` is now family-aware (previously it only probed the bridge). This is intentional — HyperCore should never expose a send flow, wallet-api included.

Also included:
- The broken HyperCore per-transaction explorer view is dropped (`@ledgerhq/cryptoassets` + `@domain/entity-currency-crypto`), keeping only the address explorer view.
- The currency is renamed from "Hyperliquid (HyperCore)" to "Hyperliquid".

### ❓ Context

- **JIRA link**: [LIVE-33244](https://ledgerhq.atlassian.net/browse/LIVE-33244) (Hide Send) & [LIVE-33248](https://ledgerhq.atlassian.net/browse/LIVE-33248) (Hide Receive)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.


[LIVE-33244]: https://ledgerhq.atlassian.net/browse/LIVE-33244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
