### PR TITLE
feat(web-tools): add wire package in devtools and add websocket to web-tools

### DIFF
--- a/.agents/skills/devtools-import-boundary/SKILL.md
+++ b/.agents/skills/devtools-import-boundary/SKILL.md
@@ -7,15 +7,19 @@ description: |
 
 # DevTools import boundaries
 
-Every `@devtools/*` package is **self-contained**. The only permitted cross-package import within the devtools scope is from `@devtools/registry`, and only from the two packages explicitly designed for it.
+Every `@devtools/*` package is **self-contained**. The only permitted cross-package imports within the devtools scope are listed in the table below; all others are forbidden.
 
 ## Rules
 
 | Package | May import from `@devtools/*` |
 |---|---|
-| `@devtools/shell` | `@devtools/registry` only |
+| `@devtools/registry` | any `@devtools/<tool>` |
+| `@devtools/shell` | `@devtools/transport`, `@devtools/registry` |
 | `@devtools/bindings` | `@devtools/registry` only |
-| `@devtools/<tool>` | **nothing** from `@devtools/*` |
+| `@devtools/wire` | `@devtools/transport`, `@devtools/protocols` |
+| `@devtools/protocols` | `@devtools/transport` only |
+| `@devtools/relay` | `@devtools/transport` only |
+| `@devtools/<tool>` | *none* |
 
 All other `@devtools/*` → `@devtools/*` imports are forbidden.
 
@@ -47,5 +51,5 @@ App state and wiring for a tool arrive as **props**, built in `@devtools/binding
 ## Documentation
 
 When adding a new package under `devtools/`, its `README.md` must state:
-- Whether it may import from `@devtools/registry` (yes for shell and bindings, no for tool packages).
-- That it must not import any other `@devtools/*` package, with a pointer to this rule.
+- Which `@devtools/*` packages it may import, per the table above.
+- That all other `@devtools/*` imports are forbidden, with a pointer to this rule.

--- a/.changeset/orange-rivers-sing.md
+++ b/.changeset/orange-rivers-sing.md
@@ -1,0 +1,6 @@
+---
+"@devtools/wire": minor
+"@ledgerhq/web-tools": minor
+---
+
+Add `@devtools/wire` package with transport and protocol builders; fix `CopyStoreMessages` key widening; wire transport singleton into web-tools devtools page

--- a/apps/web-tools/package.json
+++ b/apps/web-tools/package.json
@@ -16,10 +16,14 @@
     "format": "oxfmt src",
     "format:check": "oxfmt src --check",
     "typecheck": "tsc --noEmit --customConditions node",
-    "coverage": "jest --coverage"
+    "coverage": "jest --coverage",
+    "remote": "pnpm --filter @devtools/relay start",
+    "dev:remote": "concurrently \"pnpm run dev\" \"pnpm --filter @devtools/relay start\""
   },
   "dependencies": {
     "@devtools/shell": "workspace:*",
+    "@devtools/wire": "workspace:*",
+    "@devtools/protocols": "workspace:*",
     "@domain/api-currency-token": "workspace:*",
     "@domain/entity-currency-crypto": "workspace:*",
     "@reduxjs/toolkit": "catalog:",
@@ -115,6 +119,7 @@
     "@types/react-inspector": "^4.0.6",
     "@types/react-table": "^7.7.20",
     "@types/semver": "catalog:",
+    "concurrently": "^8.0.0",
     "autoprefixer": "^10.4.21",
     "@tailwindcss/postcss": "^4.1.0",
     "jest": "catalog:",

--- a/apps/web-tools/src/pages/dev-tools.tsx
+++ b/apps/web-tools/src/pages/dev-tools.tsx
@@ -2,6 +2,18 @@ import { useMemo } from "react";
 import { ThemeProvider } from "@ledgerhq/lumen-ui-react";
 import { DevTools, type DevToolsConfig } from "@devtools/shell";
 import { useFeatureFlagsToolProps } from "@devtools/bindings";
+import { buildTransport, buildCopyStoreProtocol, combineProtocols } from "@devtools/wire";
+import { store } from "../store";
+import { sleepingListener } from "../store/sleepingListener";
+
+// Use 127.0.0.1 (not "localhost") to match the relay's IPv4 bind — on macOS
+const HUB_URL = "ws://127.0.0.1:9090";
+const ROLE = "tool" as const;
+
+export const wire = buildTransport(
+  { hubUrl: HUB_URL, role: ROLE, id: "web-tools", target: "desktop" },
+  combineProtocols(buildCopyStoreProtocol(store, sleepingListener, ROLE)),
+);
 
 export default function DevToolsPage() {
   const featureFlagsProps = useFeatureFlagsToolProps();

--- a/apps/web-tools/src/store/index.ts
+++ b/apps/web-tools/src/store/index.ts
@@ -1,13 +1,17 @@
-import { configureStore } from "@reduxjs/toolkit";
+import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import featureFlagsReducer, { createFeatureFlagsMiddleware } from "@shared/feature-flags";
+import { withCopyStoreHydration } from "@devtools/protocols/copyStore";
+import { sleepingListener } from "./sleepingListener";
 import { cryptoAssetsApi, calApiExtra } from "@domain/api-currency-token";
 import { getEnv } from "@ledgerhq/live-env";
 
+const rootReducer = combineReducers({
+  featureFlags: featureFlagsReducer,
+  [cryptoAssetsApi.reducerPath]: cryptoAssetsApi.reducer,
+});
+
 export const store = configureStore({
-  reducer: {
-    featureFlags: featureFlagsReducer,
-    [cryptoAssetsApi.reducerPath]: cryptoAssetsApi.reducer,
-  },
+  reducer: withCopyStoreHydration(rootReducer),
   middleware: getDefaultMiddleware =>
     getDefaultMiddleware({
       thunk: {
@@ -16,7 +20,9 @@ export const store = configureStore({
           ledgerClientVersion: getEnv("LEDGER_CLIENT_VERSION"),
         }),
       },
-    }).concat(createFeatureFlagsMiddleware({ resolutionConfig: {} }), cryptoAssetsApi.middleware),
+    })
+      .prepend(sleepingListener.middleware)
+      .concat(createFeatureFlagsMiddleware({ resolutionConfig: {} }), cryptoAssetsApi.middleware),
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/apps/web-tools/src/store/sleepingListener.ts
+++ b/apps/web-tools/src/store/sleepingListener.ts
@@ -1,0 +1,3 @@
+import { createListenerMiddleware } from "@reduxjs/toolkit";
+
+export const sleepingListener = createListenerMiddleware();

--- a/devtools/wire/README.md
+++ b/devtools/wire/README.md
@@ -1,0 +1,53 @@
+# @devtools/wire
+
+Builders for wiring DevTools transport and protocols. Each side of the relay (tool or host) instantiates its own transport and protocol independently; this package provides the factories for both.
+
+## Exports
+
+| Export | What it hides |
+|---|---|
+| `buildTransport` | `createTransport` + `identityUrl` assembly + immediate connect; returns a `Wire` |
+| `buildCopyStoreProtocol` | store-aware protocol builder over `@devtools/protocols/copyStore` |
+| `combineProtocols` | fan-out across multiple `TransportProtocol` instances |
+
+`Wire<M>` holds the identity state (`hubUrl`, `role`, `target`) and exposes setters that recompute the URL and call `transport.setUrl` automatically. It follows the same `getState`/`subscribe` contract as `Transport`, so consumers can use `useSyncExternalStore` without any reactive dependency in wire itself. The underlying `Transport<M>` is available at `wire.transport` with full message types preserved.
+
+## Usage
+
+### Single protocol
+
+```ts
+import { buildTransport, buildCopyStoreProtocol } from "@devtools/wire";
+
+const ROLE = "tool" as const;
+const wire = buildTransport(
+  { hubUrl: "ws://127.0.0.1:9090", role: ROLE, id: "web-tools", target: "desktop" },
+  buildCopyStoreProtocol(store, listenerMiddleware, ROLE),
+);
+
+// reconnect to a different target at runtime
+wire.setTarget("mobile");
+```
+
+### Multiple protocols
+
+```ts
+import { buildTransport, buildCopyStoreProtocol, combineProtocols } from "@devtools/wire";
+
+const ROLE = "tool" as const;
+const wire = buildTransport(
+  { hubUrl: "ws://127.0.0.1:9090", role: ROLE, id: "web-tools", target: "desktop" },
+  combineProtocols(
+    buildCopyStoreProtocol(store, listenerMiddleware, ROLE),
+    buildOtherProtocol(ROLE),
+  ),
+);
+```
+
+## Guidelines
+
+- `buildTransport` is generic over `M` — pass the protocol directly, role is a `const` shared between `WireTransportOptions` and the protocol builder. Only `target` and `hubUrl` can change at runtime via `Wire` setters.
+- `buildTransport` connects immediately and returns a `Wire` — no `.connect()` needed at the call site.
+- Identity concerns (`role`, `target`, `hubUrl`) belong to `Wire`; the underlying `Transport` only knows about the URL string.
+- Use `combineProtocols` inside the factory to merge multiple protocols — never nest transports.
+- No logic beyond assembly — all domain logic stays in `@devtools/transport` and `@devtools/protocols`.

--- a/devtools/wire/jest.config.js
+++ b/devtools/wire/jest.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  transform: {
+    "^.+\\.tsx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  transformIgnorePatterns: ["node_modules/(?!@devtools/)"],
+  moduleFileExtensions: ["ts", "js", "json"],
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/devtools/wire/package.json
+++ b/devtools/wire/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@devtools/wire",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Store-aware protocol builders and transport assembly for DevTools host ⇄ tool communication",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "sideEffects": false,
+  "scripts": {
+    "format": "oxfmt src jest.config.js",
+    "format:check": "oxfmt src jest.config.js --check",
+    "typecheck": "tsc --noEmit",
+    "test": "jest --config jest.config.js",
+    "coverage": "jest --config jest.config.js --coverage"
+  },
+  "dependencies": {
+    "@devtools/protocols": "workspace:*",
+    "@devtools/transport": "workspace:*"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/devtools/wire/src/combineProtocols.test.ts
+++ b/devtools/wire/src/combineProtocols.test.ts
@@ -1,0 +1,91 @@
+import type { MessageMap, Transport, TransportProtocol } from "@devtools/transport";
+import { combineProtocols } from "./combineProtocols";
+
+function makeProtocol(
+  overrides?: Partial<TransportProtocol<MessageMap>>,
+): TransportProtocol<MessageMap> {
+  return {
+    onReceive: jest.fn(),
+    onOpen: jest.fn(),
+    onClose: jest.fn(),
+    onError: jest.fn(),
+    ...overrides,
+  };
+}
+
+const transport = {} as Transport<MessageMap>;
+const env = {} as never;
+
+describe("combineProtocols — onOpen", () => {
+  it("should call onOpen on all protocols", () => {
+    const a = makeProtocol();
+    const b = makeProtocol();
+    const combined = combineProtocols(a, b);
+
+    combined.onOpen?.(transport);
+
+    expect(a.onOpen).toHaveBeenCalledWith(transport);
+    expect(b.onOpen).toHaveBeenCalledWith(transport);
+  });
+
+  it("should not throw when a protocol has no onOpen", () => {
+    const a = makeProtocol({ onOpen: undefined });
+    const combined = combineProtocols(a);
+
+    expect(() => combined.onOpen?.(transport)).not.toThrow();
+  });
+});
+
+describe("combineProtocols — onReceive", () => {
+  it("should call onReceive on all protocols", () => {
+    const a = makeProtocol();
+    const b = makeProtocol();
+    const combined = combineProtocols(a, b);
+
+    combined.onReceive("action", { type: "inc" }, env);
+
+    expect(a.onReceive).toHaveBeenCalledWith("action", { type: "inc" }, env);
+    expect(b.onReceive).toHaveBeenCalledWith("action", { type: "inc" }, env);
+  });
+});
+
+describe("combineProtocols — onClose", () => {
+  it("should call onClose on all protocols", () => {
+    const a = makeProtocol();
+    const b = makeProtocol();
+    const combined = combineProtocols(a, b);
+
+    combined.onClose?.();
+
+    expect(a.onClose).toHaveBeenCalledTimes(1);
+    expect(b.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not throw when a protocol has no onClose", () => {
+    const a = makeProtocol({ onClose: undefined });
+    const combined = combineProtocols(a);
+
+    expect(() => combined.onClose?.()).not.toThrow();
+  });
+});
+
+describe("combineProtocols — onError", () => {
+  it("should call onError on all protocols", () => {
+    const a = makeProtocol();
+    const b = makeProtocol();
+    const combined = combineProtocols(a, b);
+    const err = new Error("socket failure");
+
+    combined.onError?.(err);
+
+    expect(a.onError).toHaveBeenCalledWith(err);
+    expect(b.onError).toHaveBeenCalledWith(err);
+  });
+
+  it("should not throw when a protocol has no onError", () => {
+    const a = makeProtocol({ onError: undefined });
+    const combined = combineProtocols(a);
+
+    expect(() => combined.onError?.(new Error())).not.toThrow();
+  });
+});

--- a/devtools/wire/src/combineProtocols.ts
+++ b/devtools/wire/src/combineProtocols.ts
@@ -1,0 +1,43 @@
+import type { TransportProtocol } from "@devtools/transport";
+
+type Head<Ps extends TransportProtocol<any>[]> = Ps extends [
+  infer H extends TransportProtocol<any>,
+  ...TransportProtocol<any>[],
+]
+  ? H
+  : never;
+
+type Tail<Ps extends TransportProtocol<any>[]> = Ps extends [
+  TransportProtocol<any>,
+  ...infer R extends TransportProtocol<any>[],
+]
+  ? R
+  : [];
+
+type MessageMapOf<P extends TransportProtocol<any>> =
+  P extends TransportProtocol<infer M> ? M : never;
+
+type MergeMessageMaps<Ps extends TransportProtocol<any>[]> = Ps extends []
+  ? {}
+  : MessageMapOf<Head<Ps>> & MergeMessageMaps<Tail<Ps>>;
+
+export function combineProtocols<Ps extends TransportProtocol<any>[]>(
+  ...protocols: Ps
+): TransportProtocol<MergeMessageMaps<Ps>> {
+  const ps = protocols;
+  const combined: TransportProtocol<MergeMessageMaps<Ps>> = {
+    onOpen(transport) {
+      for (const p of ps) p.onOpen?.(transport);
+    },
+    onReceive(kind, payload, env) {
+      for (const p of ps) p.onReceive(kind, payload, env);
+    },
+    onClose() {
+      for (const p of ps) p.onClose?.();
+    },
+    onError(err) {
+      for (const p of ps) p.onError?.(err);
+    },
+  };
+  return combined;
+}

--- a/devtools/wire/src/copyStore.test.ts
+++ b/devtools/wire/src/copyStore.test.ts
@@ -1,0 +1,86 @@
+import type { Transport } from "@devtools/transport";
+import { replaceStoreAction, type CopyStoreMessages } from "@devtools/protocols/copyStore";
+import { buildCopyStoreProtocol } from "./copyStore";
+
+function makeStore(initialState: unknown = {}) {
+  const state = initialState;
+  return {
+    dispatch: jest.fn(),
+    getState: jest.fn(() => state),
+  };
+}
+
+function makeListener() {
+  return {
+    startListening: jest.fn(() => jest.fn()),
+  };
+}
+
+function makeTransport() {
+  return { send: jest.fn() } as unknown as Transport<CopyStoreMessages>;
+}
+
+const env = {} as never;
+
+describe("buildCopyStoreProtocol — setStoreState wiring", () => {
+  it("should dispatch replaceStoreAction when a snapshot is received as tool", () => {
+    const store = makeStore();
+    const protocol = buildCopyStoreProtocol(store, makeListener(), "tool");
+    const transport = makeTransport();
+
+    protocol.onOpen?.(transport);
+    protocol.onReceive("snapshot", { count: 5 }, env);
+
+    expect(store.dispatch).toHaveBeenCalledWith(replaceStoreAction({ count: 5 }));
+  });
+});
+
+describe("buildCopyStoreProtocol — getSnapshot wiring", () => {
+  it("should read from store.getState() when sending the snapshot on open", () => {
+    const store = makeStore({ value: 42 });
+    const protocol = buildCopyStoreProtocol(store, makeListener(), "host");
+    const transport = makeTransport();
+
+    protocol.onOpen?.(transport);
+
+    expect(store.getState).toHaveBeenCalled();
+    expect(transport.send).toHaveBeenCalledWith("snapshot", { value: 42 });
+  });
+});
+
+describe("buildCopyStoreProtocol — dispatch wiring", () => {
+  it("should call store.dispatch when a remote action is received", () => {
+    const store = makeStore();
+    const protocol = buildCopyStoreProtocol(store, makeListener(), "host");
+    const transport = makeTransport();
+
+    protocol.onOpen?.(transport);
+    store.dispatch.mockClear();
+
+    protocol.onReceive("action", { type: "remote/inc" }, env);
+
+    expect(store.dispatch).toHaveBeenCalledWith({ type: "remote/inc" });
+  });
+});
+
+describe("buildCopyStoreProtocol — role wiring", () => {
+  it("should send snapshot on open when role is host", () => {
+    const store = makeStore({ x: 1 });
+    const protocol = buildCopyStoreProtocol(store, makeListener(), "host");
+    const transport = makeTransport();
+
+    protocol.onOpen?.(transport);
+
+    expect(transport.send).toHaveBeenCalledWith("snapshot", { x: 1 });
+  });
+
+  it("should request snapshot on open when role is tool", () => {
+    const store = makeStore();
+    const protocol = buildCopyStoreProtocol(store, makeListener(), "tool");
+    const transport = makeTransport();
+
+    protocol.onOpen?.(transport);
+
+    expect(transport.send).toHaveBeenCalledWith("requestSnapshot", null);
+  });
+});

--- a/devtools/wire/src/copyStore.ts
+++ b/devtools/wire/src/copyStore.ts
@@ -1,0 +1,26 @@
+import {
+  createCopyStoreProtocol,
+  replaceStoreAction,
+  type CopyStoreMessages,
+  type StoreActionListener,
+} from "@devtools/protocols/copyStore";
+import type { Role, TransportProtocol } from "@devtools/transport";
+
+type ReduxStore = {
+  getState(): unknown;
+  dispatch(action: unknown): void;
+};
+
+export function buildCopyStoreProtocol(
+  store: ReduxStore,
+  listener: StoreActionListener,
+  role: Role,
+): TransportProtocol<CopyStoreMessages> {
+  return createCopyStoreProtocol({
+    role,
+    getSnapshot: () => store.getState(),
+    dispatch: action => store.dispatch(action),
+    setStoreState: snapshot => store.dispatch(replaceStoreAction(snapshot)),
+    listener,
+  });
+}

--- a/devtools/wire/src/index.ts
+++ b/devtools/wire/src/index.ts
@@ -1,0 +1,3 @@
+export { combineProtocols } from "./combineProtocols";
+export { buildCopyStoreProtocol } from "./copyStore";
+export { buildTransport, type Wire, type WireState, type WireTransportOptions } from "./wire";

--- a/devtools/wire/src/wire.test.ts
+++ b/devtools/wire/src/wire.test.ts
@@ -1,0 +1,147 @@
+import { buildTargetUrl, buildTransport, isMatch } from "./wire";
+import type { MessageMap, TransportProtocol, WebSocketLike } from "@devtools/transport";
+
+const protocol: TransportProtocol<MessageMap> = {
+  onReceive: jest.fn(),
+};
+
+function makeSocketFactory() {
+  const socket: WebSocketLike = {
+    send: jest.fn(),
+    close: jest.fn(),
+    onopen: null,
+    onclose: null,
+    onerror: null,
+    onmessage: null,
+  };
+  return jest.fn(() => socket);
+}
+
+const BASE_OPTIONS = {
+  hubUrl: "ws://localhost:9090",
+  role: "host" as const,
+  id: "app",
+};
+
+describe("isMatch", () => {
+  it("should return true when all partial keys equal the origin", () => {
+    expect(isMatch({ a: 1, b: 2 }, { a: 1 })).toBe(true);
+  });
+
+  it("should return false when a partial key differs from the origin", () => {
+    expect(isMatch({ a: 1, b: 2 }, { a: 99 })).toBe(false);
+  });
+
+  it("should return true for an empty partial", () => {
+    expect(isMatch({ a: 1 }, {})).toBe(true);
+  });
+
+  it("should treat NaN as equal to NaN", () => {
+    expect(isMatch({ a: NaN }, { a: NaN })).toBe(true);
+  });
+
+  it("should distinguish +0 from -0", () => {
+    expect(isMatch({ a: +0 }, { a: -0 })).toBe(false);
+  });
+
+  it("should only check keys present in partial, ignoring extra keys in origin", () => {
+    expect(isMatch({ a: 1, b: 2, c: 3 }, { b: 2 })).toBe(true);
+  });
+});
+
+describe("buildTargetUrl", () => {
+  it("should include role and id in the query string", () => {
+    const url = buildTargetUrl({ ...BASE_OPTIONS });
+    const qs = new URLSearchParams(url.split("?")[1]);
+    expect(qs.get("role")).toBe("host");
+    expect(qs.get("id")).toBe("app");
+  });
+
+  it("should omit target when not provided", () => {
+    const url = buildTargetUrl({ ...BASE_OPTIONS });
+    expect(new URLSearchParams(url.split("?")[1]).has("target")).toBe(false);
+  });
+
+  it("should include target when provided", () => {
+    const url = buildTargetUrl({ ...BASE_OPTIONS, target: "desktop" });
+    expect(new URLSearchParams(url.split("?")[1]).get("target")).toBe("desktop");
+  });
+
+  it("should append with ? when the base URL has no query string", () => {
+    expect(buildTargetUrl({ ...BASE_OPTIONS })).toMatch(/^ws:\/\/localhost:9090\?/);
+  });
+
+  it("should append with & when the base URL already has a query string", () => {
+    expect(buildTargetUrl({ ...BASE_OPTIONS, hubUrl: "ws://localhost:9090?x=1" })).toMatch(
+      /^ws:\/\/localhost:9090\?x=1&/,
+    );
+  });
+});
+
+describe("buildTransport", () => {
+  it("should connect immediately", () => {
+    const { transport } = buildTransport(
+      { ...BASE_OPTIONS, socketFactory: makeSocketFactory() },
+      protocol,
+    );
+    expect(transport.getState().status).toBe("connecting");
+  });
+
+  it("should use the assembled target URL", () => {
+    const options = { ...BASE_OPTIONS, socketFactory: makeSocketFactory() };
+    const { transport } = buildTransport(options, protocol);
+    expect(transport.getState().url).toBe(buildTargetUrl(options));
+  });
+
+  it("getState should reflect initial options", () => {
+    const wire = buildTransport(
+      { ...BASE_OPTIONS, target: "desktop", socketFactory: makeSocketFactory() },
+      protocol,
+    );
+    expect(wire.getState()).toEqual({
+      hubUrl: "ws://localhost:9090",
+      role: "host",
+      target: "desktop",
+    });
+  });
+
+  it("setTarget should update state and recompute transport URL", () => {
+    const wire = buildTransport({ ...BASE_OPTIONS, socketFactory: makeSocketFactory() }, protocol);
+    wire.setTarget("desktop");
+    expect(wire.getState().target).toBe("desktop");
+    expect(new URLSearchParams(wire.transport.getState().url.split("?")[1]).get("target")).toBe(
+      "desktop",
+    );
+  });
+
+  it("setHubUrl should update state and recompute transport URL", () => {
+    const wire = buildTransport({ ...BASE_OPTIONS, socketFactory: makeSocketFactory() }, protocol);
+    wire.setHubUrl("ws://localhost:8080");
+    expect(wire.getState().hubUrl).toBe("ws://localhost:8080");
+    expect(wire.transport.getState().url).toMatch(/^ws:\/\/localhost:8080/);
+  });
+
+  it("subscribe should notify listeners on state change", () => {
+    const wire = buildTransport({ ...BASE_OPTIONS, socketFactory: makeSocketFactory() }, protocol);
+    const listener = jest.fn();
+    wire.subscribe(listener);
+    wire.setTarget("mobile");
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("subscribe should return an unsubscribe function", () => {
+    const wire = buildTransport({ ...BASE_OPTIONS, socketFactory: makeSocketFactory() }, protocol);
+    const listener = jest.fn();
+    const unsubscribe = wire.subscribe(listener);
+    unsubscribe();
+    wire.setTarget("mobile");
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("getState should return a stable reference until next update", () => {
+    const wire = buildTransport({ ...BASE_OPTIONS, socketFactory: makeSocketFactory() }, protocol);
+    expect(wire.getState()).toBe(wire.getState());
+    wire.setTarget("mobile");
+    expect(wire.getState().target).toBe("mobile");
+  });
+});

--- a/devtools/wire/src/wire.ts
+++ b/devtools/wire/src/wire.ts
@@ -1,0 +1,76 @@
+import { createTransport, identityUrl } from "@devtools/transport";
+import type {
+  MessageMap,
+  Role,
+  Transport,
+  TransportProtocol,
+  WebSocketLike,
+} from "@devtools/transport";
+
+export type WireTransportOptions = {
+  hubUrl: string;
+  role: Role;
+  id: string;
+  target?: string;
+  socketFactory?: (url: string, protocols?: string | string[]) => WebSocketLike;
+};
+
+export type WireState = {
+  hubUrl: string;
+  role: Role;
+  target: string | undefined;
+};
+
+export type Wire<M extends MessageMap> = {
+  transport: Transport<M>;
+  getState(): WireState;
+  subscribe(listener: () => void): () => void;
+  setTarget(target: string | undefined): void;
+  setHubUrl(hubUrl: string): void;
+};
+
+export function buildTargetUrl(options: WireTransportOptions): string {
+  return identityUrl(options.hubUrl, {
+    role: options.role,
+    id: options.id,
+    target: options.target,
+  });
+}
+
+export function isMatch<M extends object>(origin: M, partial: Partial<M>): boolean {
+  return (Object.keys(partial) as (keyof M)[]).every(k => Object.is(origin[k], partial[k]));
+}
+
+export function buildTransport<M extends MessageMap>(
+  options: WireTransportOptions,
+  protocol: TransportProtocol<M>,
+): Wire<M> {
+  const config = { ...options };
+  const transport = createTransport(
+    { url: buildTargetUrl(config), origin: config.id, socketFactory: config.socketFactory },
+    protocol,
+  );
+  transport.connect();
+
+  let state: WireState = { hubUrl: config.hubUrl, role: config.role, target: config.target };
+  const listeners = new Set<() => void>();
+
+  function update(patch: Partial<WireState>) {
+    if (isMatch(state, patch)) return;
+    Object.assign(config, patch);
+    state = { ...state, ...patch };
+    listeners.forEach(l => l());
+    transport.setUrl(buildTargetUrl(config));
+  }
+
+  return {
+    transport,
+    getState: () => state,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    setTarget: target => update({ target }),
+    setHubUrl: hubUrl => update({ hubUrl }),
+  };
+}

--- a/devtools/wire/tsconfig.json
+++ b/devtools/wire/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleSuffixes": [".web", ""],
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3270,6 +3270,31 @@ importers:
         specifier: 'catalog:'
         version: 6.0.2
 
+  devtools/wire:
+    dependencies:
+      '@devtools/protocols':
+        specifier: workspace:*
+        version: link:../protocols
+      '@devtools/transport':
+        specifier: workspace:*
+        version: link:../transport
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.2
+
   domain/api/altcoins-sentiment:
     dependencies:
       '@domain/entity-altcoins-sentiment':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2548,9 +2548,15 @@ importers:
       '@devtools/bindings':
         specifier: workspace:*
         version: link:../../devtools/bindings
+      '@devtools/protocols':
+        specifier: workspace:*
+        version: link:../../devtools/protocols
       '@devtools/shell':
         specifier: workspace:*
         version: link:../../devtools/shell
+      '@devtools/wire':
+        specifier: workspace:*
+        version: link:../../devtools/wire
       '@domain/api-currency-token':
         specifier: workspace:*
         version: link:../../domain/api/currency-token
@@ -2828,6 +2834,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.22(postcss@8.5.6)
+      concurrently:
+        specifier: ^8.0.0
+        version: 8.2.2
       jest:
         specifier: 'catalog:'
         version: 30.2.0(@types/node@24.12.0)
@@ -22863,7 +22872,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -66127,7 +66136,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -66251,54 +66260,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

Add a new package called wire in devtools meant to simplify building WebSocket transports in apps. It works similarly to bindings though the responsibilities differ so they are not merged.

In web-tools, add the transport, protocols and wire package to build the transport. Initialize the transport as a module-level singleton in the devtools page
### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34524](https://ledgerhq.atlassian.net/browse/LIVE-34524)<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-34524]: https://ledgerhq.atlassian.net/browse/LIVE-34524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ