### PR TITLE
[LWDM] refactor: build CAL store via buildStandaloneCryptoAssetsStore (drop setupCalClientStore)

### DIFF
--- a/.changeset/drop-setupcalclientstore-real-store.md
+++ b/.changeset/drop-setupcalclientstore-real-store.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/wallet-cli": minor
+"@ledgerhq/coin-modules-monitoring": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/coin-aleo": minor
+"@ledgerhq/coin-hedera": minor
+"@ledgerhq/coin-tester-evm": minor
+---
+
+Build the CAL client store via `buildStandaloneCryptoAssetsStore` (`@features/platform-currencies`) instead of the legacy `setupCalClientStore` test-helper from `@ledgerhq/cryptoassets`. Callers now resolve `CAL_SERVICE_URL` / `LEDGER_CLIENT_VERSION` from the environment and inject the built store explicitly (the standalone builder does not auto-inject the global). No runtime behaviour change.

--- a/.changeset/platform-currencies-rtk-runtime-dep.md
+++ b/.changeset/platform-currencies-rtk-runtime-dep.md
@@ -1,0 +1,5 @@
+---
+"@features/platform-currencies": minor
+---
+
+Declare `@reduxjs/toolkit` as a runtime dependency (moved from `devDependencies`). `buildStandaloneCryptoAssetsStore` calls `configureStore` at runtime, so consumers building a standalone store need RTK resolvable as a real dependency.

--- a/apps/wallet-cli/package.json
+++ b/apps/wallet-cli/package.json
@@ -45,6 +45,7 @@
     "@bunli/core": "0.9.1",
     "@bunli/utils": "0.6.0",
     "@domain/entity-currency-crypto": "workspace:^",
+    "@features/platform-currencies": "workspace:^",
     "@napi-rs/keyring": "1.3.0",
     "@ledgerhq/coin-bitcoin": "workspace:^",
     "@ledgerhq/coin-evm": "workspace:^",

--- a/apps/wallet-cli/src/live-common-setup.ts
+++ b/apps/wallet-cli/src/live-common-setup.ts
@@ -1,13 +1,14 @@
-import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client";
+import { buildStandaloneCryptoAssetsStore } from "@features/platform-currencies";
 import { walletCliConfig } from "./config";
 import { registerCoinModules } from "@ledgerhq/live-common/coin-modules/registry";
 import type { CoinModuleLoader } from "@ledgerhq/live-common/coin-modules/types";
 import { setWalletAPIVersion } from "@ledgerhq/live-common/wallet-api/version";
 import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
-import { setEnv } from "@ledgerhq/live-env";
+import { getEnv, setEnv } from "@ledgerhq/live-env";
 import { registerWalletCliDmkTransport } from "./device/register-dmk-transport";
 import { setCryptoCurrenciesStore, setFiatCurrenciesStore } from "@ledgerhq/cryptoassets";
+import { setCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import {
   CRYPTO_CURRENCIES_REGISTRY,
   CRYPTO_CURRENCY_ALIASES,
@@ -123,7 +124,10 @@ setCurrenciesResolver({
 setWalletAPIVersion(WALLET_API_VERSION);
 registerCoinModules(walletCliLoaders);
 LiveConfig.setConfig(walletCliConfig);
-// TODO: wallet-cli should own its Redux store setup (createRtkCryptoAssetsStore + RTK middleware)
-// instead of relying on setupCalClientStore from @ledgerhq/cryptoassets/cal-client (test-helpers).
-setFrameworkCryptoAssetsStore(setupCalClientStore());
+const cryptoAssetsStore = buildStandaloneCryptoAssetsStore({
+  calServiceUrl: getEnv("CAL_SERVICE_URL"),
+  ledgerClientVersion,
+});
+setCryptoAssetsStore(cryptoAssetsStore);
+setFrameworkCryptoAssetsStore(cryptoAssetsStore);
 registerWalletCliDmkTransport();

--- a/features/platform/currencies/package.json
+++ b/features/platform/currencies/package.json
@@ -16,14 +16,14 @@
     "@domain/api-currency-token": "workspace:^",
     "@domain/entity-currency-crypto": "workspace:^",
     "@domain/entity-currency-token": "workspace:^",
-    "@features/platform-feature-flags": "workspace:^"
+    "@features/platform-feature-flags": "workspace:^",
+    "@reduxjs/toolkit": "catalog:"
   },
   "peerDependencies": {
     "react": ">=19.0.0",
     "react-redux": ">=9.0.0"
   },
   "devDependencies": {
-    "@reduxjs/toolkit": "catalog:",
     "@shared/feature-flags": "workspace:^",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",

--- a/libs/coin-modules-monitoring/package.json
+++ b/libs/coin-modules-monitoring/package.json
@@ -17,10 +17,12 @@
   "dependencies": {
     "@datadog/datadog-api-client": "^1.40",
     "@domain/entity-currency-crypto": "workspace:^",
+    "@features/platform-currencies": "workspace:^",
     "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/ledger-wallet-framework": "workspace:^",
     "@ledgerhq/live-common": "workspace:^",
     "@ledgerhq/live-config": "workspace:^",
+    "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/live-network": "workspace:^",
     "command-line-args": "6.0.1",
     "rxjs": "catalog:"

--- a/libs/coin-modules-monitoring/src/run.ts
+++ b/libs/coin-modules-monitoring/src/run.ts
@@ -1,6 +1,6 @@
 import type { Account } from "@ledgerhq/types-live";
 import { getAccountBridgeByFamily } from "@ledgerhq/live-common/bridge/impl";
-import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
+import { buildStandaloneCryptoAssetsStore } from "@features/platform-currencies";
 import {
   type CryptoCurrency,
   getCryptoCurrencyById,
@@ -9,7 +9,8 @@ import {
   listCryptoCurrencies,
   hasCryptoCurrencyId,
 } from "@domain/entity-currency-crypto";
-import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
+import { getCryptoAssetsStore, setCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
+import { getEnv } from "@ledgerhq/live-env";
 import { setCurrenciesResolver } from "@ledgerhq/ledger-wallet-framework/currencies";
 import { setCryptoAssetsStore as setFrameworkCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 import { firstValueFrom, reduce } from "rxjs";
@@ -158,8 +159,13 @@ export default async function (currencyIds: string[], accountTypes: AccountType[
 
   LiveConfig.setConfig(liveConfig);
 
-  // Setup CAL client store for monitoring (automatically set as global store)
-  setupCalClientStore();
+  // Build the CAL store and set it as the cryptoassets global store for monitoring
+  setCryptoAssetsStore(
+    buildStandaloneCryptoAssetsStore({
+      calServiceUrl: getEnv("CAL_SERVICE_URL"),
+      ledgerClientVersion: getEnv("LEDGER_CLIENT_VERSION"),
+    }),
+  );
 
   // Wire wallet-framework ports to the same cryptoassets global store
   setFrameworkCryptoAssetsStore({

--- a/libs/coin-modules/coin-aleo/package.json
+++ b/libs/coin-modules/coin-aleo/package.json
@@ -119,6 +119,7 @@
     "rxjs": "catalog:"
   },
   "devDependencies": {
+    "@features/platform-currencies": "workspace:^",
     "@ledgerhq/disable-network-setup": "workspace:^",
     "@ledgerhq/wallet-framework-test-setup": "workspace:^",
     "@provablehq/sdk": "0.10.2",

--- a/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
@@ -1,5 +1,6 @@
 import invariant from "invariant";
-import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
+import { buildStandaloneCryptoAssetsStore } from "@features/platform-currencies";
+import { setCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { getEnv } from "@ledgerhq/live-env";
 import { createApi } from "../api";
 import { TRANSACTION_TYPE } from "../constants";
@@ -22,7 +23,12 @@ describe("createApi", () => {
   );
 
   beforeAll(() => {
-    setupCalClientStore();
+    setCryptoAssetsStore(
+      buildStandaloneCryptoAssetsStore({
+        calServiceUrl: getEnv("CAL_SERVICE_URL"),
+        ledgerClientVersion: getEnv("LEDGER_CLIENT_VERSION"),
+      }),
+    );
   });
 
   describe("estimateFees", () => {

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
@@ -1,13 +1,19 @@
 import BigNumber from "bignumber.js";
 import { getEnv } from "@ledgerhq/live-env";
-import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
+import { buildStandaloneCryptoAssetsStore } from "@features/platform-currencies";
+import { setCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import aleoConfig from "../config";
 import { mockFeeByTransactionType } from "../__tests__/fixtures/config.fixture";
 import { testnetViewKey, testnetPrivateRecord } from "../__tests__/fixtures/api.fixture";
 import { getPrivateBalance } from "./getPrivateBalance";
 
-setupCalClientStore();
+setCryptoAssetsStore(
+  buildStandaloneCryptoAssetsStore({
+    calServiceUrl: getEnv("CAL_SERVICE_URL"),
+    ledgerClientVersion: getEnv("LEDGER_CLIENT_VERSION"),
+  }),
+);
 
 describe("getPrivateBalance", () => {
   const currency = getCryptoCurrencyById("aleo");

--- a/libs/coin-modules/coin-hedera/package.json
+++ b/libs/coin-modules/coin-hedera/package.json
@@ -103,6 +103,7 @@
   },
   "devDependencies": {
     "@domain/entity-currency-crypto": "workspace:^",
+    "@features/platform-currencies": "workspace:^",
     "@ledgerhq/disable-network-setup": "workspace:^",
     "@ledgerhq/wallet-framework-test-setup": "workspace:^",
     "@swc/core": "catalog:",

--- a/libs/coin-modules/coin-hedera/src/bridge/utils.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/utils.integ.test.ts
@@ -1,5 +1,6 @@
-import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
-import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
+import { buildStandaloneCryptoAssetsStore } from "@features/platform-currencies";
+import { getCryptoAssetsStore, setCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
+import { getEnv } from "@ledgerhq/live-env";
 import { encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account";
 import BigNumber from "bignumber.js";
 import { HEDERA_OPERATION_TYPES, HEDERA_TRANSACTION_MODES } from "../constants";
@@ -23,8 +24,12 @@ describe("utils", () => {
   const mockedAccount = getMockedAccount();
 
   beforeAll(() => {
-    // Setup CAL client store (automatically set as global store)
-    setupCalClientStore();
+    setCryptoAssetsStore(
+      buildStandaloneCryptoAssetsStore({
+        calServiceUrl: getEnv("CAL_SERVICE_URL"),
+        ledgerClientVersion: getEnv("LEDGER_CLIENT_VERSION"),
+      }),
+    );
   });
 
   beforeEach(() => {

--- a/libs/coin-tester-modules/coin-tester-evm/package.json
+++ b/libs/coin-tester-modules/coin-tester-evm/package.json
@@ -58,12 +58,14 @@
     "unimported": "unimported"
   },
   "dependencies": {
+    "@features/platform-currencies": "workspace:^",
     "@ledgerhq/coin-evm": "workspace:^",
     "@ledgerhq/coin-tester": "workspace:^",
     "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/ledger-wallet-framework": "workspace:^",
     "@ledgerhq/live-common": "workspace:^",
     "@ledgerhq/live-config": "workspace:^",
+    "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/live-signer-evm": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",
     "bignumber.js": "^9.1.2",

--- a/libs/coin-tester-modules/coin-tester-evm/src/tokenFixtures.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/tokenFixtures.ts
@@ -1,5 +1,6 @@
-import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
+import { buildStandaloneCryptoAssetsStore } from "@features/platform-currencies";
 import { setCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
+import { getEnv } from "@ledgerhq/live-env";
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 
@@ -102,5 +103,8 @@ export const STCORE_ON_CORE: TokenCurrency = {
   units: [{ name: "stCORE", code: "stCORE", magnitude: 18 }],
 } as TokenCurrency;
 
-const cryptoAssetsStore = setupCalClientStore();
+const cryptoAssetsStore = buildStandaloneCryptoAssetsStore({
+  calServiceUrl: getEnv("CAL_SERVICE_URL"),
+  ledgerClientVersion: getEnv("LEDGER_CLIENT_VERSION"),
+});
 setCryptoAssetsStore(cryptoAssetsStore);

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -410,6 +410,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@features/platform-currencies": "workspace:^",
     "@ledgerhq/device-react": "workspace:^",
     "@ledgerhq/types-cryptoassets": "workspace:^",
     "@ledgerhq/types-devices": "workspace:^",

--- a/libs/ledger-live-common/src/__tests__/test-helpers/setup.integration.ts
+++ b/libs/ledger-live-common/src/__tests__/test-helpers/setup.integration.ts
@@ -1,11 +1,17 @@
 import BigNumber from "bignumber.js";
-import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
+import { buildStandaloneCryptoAssetsStore } from "@features/platform-currencies";
+import { setCryptoAssetsStore as setGlobalCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
+import { getEnv } from "@ledgerhq/live-env";
 import { setCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 import "./environment";
 
 // wallet-framework-test-setup (in setupFilesAfterEnv) already wired CurrenciesResolver.
 // Override the CryptoAssetsStore with the real CAL RTK store for integration tests.
-const calStore = setupCalClientStore();
+const calStore = buildStandaloneCryptoAssetsStore({
+  calServiceUrl: getEnv("CAL_SERVICE_URL"),
+  ledgerClientVersion: getEnv("LEDGER_CLIENT_VERSION"),
+});
+setGlobalCryptoAssetsStore(calStore);
 setCryptoAssetsStore(calStore);
 
 jest.setTimeout(360000);

--- a/libs/ledger-live-common/src/test-helpers/cryptoAssetsStore.ts
+++ b/libs/ledger-live-common/src/test-helpers/cryptoAssetsStore.ts
@@ -1,5 +1,4 @@
 export {
-  setupCalClientStore,
   setupMockCryptoAssetsStore,
   createMockCryptoAssetsStore,
 } from "@ledgerhq/cryptoassets/cal-client/test-helpers";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2347,6 +2347,9 @@ importers:
       '@domain/entity-currency-fiat':
         specifier: workspace:^
         version: link:../../domain/entity/currency-fiat
+      '@features/platform-currencies':
+        specifier: workspace:^
+        version: link:../../features/platform/currencies
       '@ledgerhq/coin-bitcoin':
         specifier: workspace:^
         version: link:../../libs/coin-modules/coin-bitcoin
@@ -4482,10 +4485,10 @@ importers:
       '@features/platform-feature-flags':
         specifier: workspace:^
         version: link:../feature-flags
-    devDependencies:
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2(react-redux@9.2.0(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+    devDependencies:
       '@shared/feature-flags':
         specifier: workspace:^
         version: link:../../../shared/feature-flags
@@ -4736,6 +4739,9 @@ importers:
       '@domain/entity-currency-crypto':
         specifier: workspace:^
         version: link:../../domain/entity/currency-crypto
+      '@features/platform-currencies':
+        specifier: workspace:^
+        version: link:../../features/platform/currencies
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../ledgerjs/packages/cryptoassets
@@ -4748,6 +4754,9 @@ importers:
       '@ledgerhq/live-config':
         specifier: workspace:^
         version: link:../live-config
+      '@ledgerhq/live-env':
+        specifier: workspace:^
+        version: link:../env
       '@ledgerhq/live-network':
         specifier: workspace:^
         version: link:../live-network
@@ -4840,6 +4849,9 @@ importers:
         specifier: 'catalog:'
         version: 7.8.2
     devDependencies:
+      '@features/platform-currencies':
+        specifier: workspace:^
+        version: link:../../../features/platform/currencies
       '@ledgerhq/disable-network-setup':
         specifier: workspace:^
         version: link:../../disable-network-setup
@@ -6010,6 +6022,9 @@ importers:
       '@domain/entity-currency-crypto':
         specifier: workspace:^
         version: link:../../../domain/entity/currency-crypto
+      '@features/platform-currencies':
+        specifier: workspace:^
+        version: link:../../../features/platform/currencies
       '@ledgerhq/disable-network-setup':
         specifier: workspace:^
         version: link:../../disable-network-setup
@@ -7637,6 +7652,9 @@ importers:
 
   libs/coin-tester-modules/coin-tester-evm:
     dependencies:
+      '@features/platform-currencies':
+        specifier: workspace:^
+        version: link:../../../features/platform/currencies
       '@ledgerhq/coin-evm':
         specifier: workspace:^
         version: link:../../coin-modules/coin-evm
@@ -7655,6 +7673,9 @@ importers:
       '@ledgerhq/live-config':
         specifier: workspace:^
         version: link:../../live-config
+      '@ledgerhq/live-env':
+        specifier: workspace:^
+        version: link:../../env
       '@ledgerhq/live-signer-evm':
         specifier: workspace:^
         version: link:../../live-signer-evm
@@ -9355,6 +9376,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@features/platform-currencies':
+        specifier: workspace:^
+        version: link:../../features/platform/currencies
       '@ledgerhq/device-react':
         specifier: workspace:^
         version: link:../device-react
@@ -66020,7 +66044,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -66144,6 +66168,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
### 📝 Description

Migrates the **real CAL store** consumers off the legacy `setupCalClientStore` test-helper (`@ledgerhq/cryptoassets/cal-client/test-helpers`) onto **`buildStandaloneCryptoAssetsStore`** (`@features/platform-currencies`, added in #19693) — dropping the `@ledgerhq/cryptoassets` coupling from those files.

**Why:** `setupCalClientStore` lives in the cryptoassets package and reads CAL env internally. `buildStandaloneCryptoAssetsStore` is the new-arch equivalent — it configures its own RTK store over `@domain/api-currency-token` and takes the CAL config as an argument (composition-root DI).

**Also — fix that #19693 merged without:** `@reduxjs/toolkit` moved `devDependencies` → `dependencies` in `@features/platform-currencies` (it calls `configureStore` at runtime, so consumers building a standalone store need RTK resolvable).

**Migrated:** `apps/wallet-cli`, `coin-modules-monitoring`, live-common integration setup, `coin-aleo` (×2 integ tests), `coin-hedera` integ test, `coin-tester-evm` fixtures; dropped the `setupCalClientStore` re-export from live-common's test-helpers wrapper. Each caller now resolves `getEnv("CAL_SERVICE_URL")` / `getEnv("LEDGER_CLIENT_VERSION")` and injects the built store explicitly (the standalone builder does not auto-inject the cryptoassets global, unlike the old helper).

**Out of scope:** `apps/cli` stays on the legacy helper — it's coupled to `getReduxStore` (which the new builder doesn't expose; niche debug command). The **mock** helper (`setupMockCryptoAssetsStore`, 46 files) is a follow-up (Part B). No runtime behaviour change.

**Verification:** `pnpm lint:boundaries` ✓ · `@features/platform-currencies` typecheck ✓ · `pnpm install` reconciled cleanly (lockfile diff = only the new `@features`/`live-env` links + the RTK move). Consumer typechecks locally surface `TS2307` from unbuilt workspace deps (needs `build:libs`; CI builds first), so CI is the gate — incl. the integ / coin-tester suites (real CAL) and the domain↔legacy `CryptoAssetsStore` assignability at the injection sites.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34548](https://ledgerhq.atlassian.net/browse/LIVE-34548)
- **ADR** (if any): —


[LIVE-34548]: https://ledgerhq.atlassian.net/browse/LIVE-34548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ