### PR TITLE
[LWD] Feat/live 33886 populated list

### DIFF
--- a/.changeset/lwd-contacts-populated-list.md
+++ b/.changeset/lwd-contacts-populated-list.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"ledger-live-desktop": minor
+---
+
+Render the populated Desktop Contacts list and add Dev Tool controls to load mock contacts for testing.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { MemoryRouter, Route, Routes } from "react-router";
+import { mockPopulatedContacts } from "@domain/entity-contact/schema.mock";
 import { render, screen, withFlagOverrides, waitFor } from "tests/testSetup";
 import ContactsScreen, { ContactsButton } from "LLD/features/Contacts";
 import ContextMenuContext from "LLD/features/MyWallet/components/ContextMenuContext";
@@ -161,5 +162,36 @@ describe("Contacts integration", () => {
 
     expect(screen.getByTestId("contacts-page")).toBeVisible();
     expect(screen.getByTestId("contacts-me-row")).toHaveTextContent("Me");
+  });
+
+  it("should render saved contacts in alphabetical order when contacts exist", () => {
+    render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <Routes>
+          <Route path="/contacts" element={<ContactsScreen />} />
+        </Routes>
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: {
+          ...withFlagOverrides({
+            lwdContacts: { enabled: true, params: { newBadge: false } },
+          }),
+          contacts: { contacts: mockPopulatedContacts() },
+        },
+      },
+    );
+
+    expect(screen.getByTestId("contacts-page")).toBeVisible();
+    expect(screen.getByTestId("contacts-add-contact")).toBeVisible();
+    expect(screen.getByTestId("contacts-add-contact-header")).toBeVisible();
+    expect(screen.getByTestId("contacts-section-A")).toBeVisible();
+    expect(screen.getByTestId("contacts-section-B")).toBeVisible();
+    expect(screen.getByTestId("contacts-section-O")).toBeVisible();
+
+    expect(screen.getByTestId("contacts-me-row")).toHaveTextContent("Me");
+    expect(screen.getByTestId("contacts-saved-row-contact-ada")).toHaveTextContent("Ada");
+    expect(screen.getByTestId("contacts-saved-row-contact-ben")).toHaveTextContent("Ben");
+    expect(screen.getByTestId("contacts-saved-row-contact-olive")).toHaveTextContent("Olive");
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  createEmptyContactsListViewModel,
-  useContactsMeContact,
+  useContactsListViewModel,
   type ContactsLedgerSyncStatus,
   type ContactsPageLabels,
 } from "@features/flow-contacts";
@@ -13,7 +12,7 @@ export type ContactsViewModel = ContactsViewProps;
 
 export function useContactsViewModel(): ContactsViewModel {
   const { t } = useTranslation();
-  const meContact = useContactsMeContact();
+  const viewModel = useContactsListViewModel();
   const [isIntroductionDismissed, setIsIntroductionDismissed] = useState(false);
   const [ledgerSyncStatus] = useState<ContactsLedgerSyncStatus>("ready");
   const labels = useMemo<ContactsPageLabels>(
@@ -41,7 +40,7 @@ export function useContactsViewModel(): ContactsViewModel {
   const isIntroductionOpen = ledgerSyncStatus === "inactive" && !isIntroductionDismissed;
 
   return {
-    viewModel: createEmptyContactsListViewModel(meContact),
+    viewModel,
     labels,
     meAvatarSrc: MY_WALLET_AVATAR_USER_URL,
     onOpenContact,

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/ContactsDevToolContent.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/ContactsDevToolContent.tsx
@@ -23,6 +23,8 @@ export const ContactsDevToolContent = ({ expanded }: ContactsDevToolContentProps
     handleSetEligibleAddressFamilies,
     setCustomFamiliesInput,
     handleApplyCustomFamilies,
+    handleLoadPopulatedContacts,
+    handleResetContacts,
     handleResetOverride,
   } = useContactsDevToolViewModel();
 
@@ -72,11 +74,23 @@ export const ContactsDevToolContent = ({ expanded }: ContactsDevToolContentProps
             </div>
           </div>
 
-          <div className="flex flex-wrap items-start gap-4">
-            <Button appearance="transparent" size="sm" onClick={handleResetOverride}>
-              {t("settings.developer.contactsDevTool.resetOverride")}
-            </Button>
-            <FeatureFlagPreview featureFlag={featureFlag} />
+          <div className="flex flex-col gap-4">
+            <span className="body-2-semi-bold text-muted">
+              {t("settings.developer.contactsDevTool.contactsData")}
+            </span>
+            <Divider />
+            <div className="flex flex-wrap items-center gap-4 pt-8">
+              <Button appearance="accent" size="sm" onClick={handleLoadPopulatedContacts}>
+                {t("settings.developer.contactsDevTool.loadPopulatedContacts")}
+              </Button>
+              <Button appearance="transparent" size="sm" onClick={handleResetContacts}>
+                {t("settings.developer.contactsDevTool.resetContacts")}
+              </Button>
+              <Button appearance="transparent" size="sm" onClick={handleResetOverride}>
+                {t("settings.developer.contactsDevTool.resetOverride")}
+              </Button>
+              <FeatureFlagPreview featureFlag={featureFlag} />
+            </div>
           </div>
         </div>
       )}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/components/EligibleAddressFamiliesSection.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/components/EligibleAddressFamiliesSection.tsx
@@ -33,9 +33,11 @@ export const EligibleAddressFamiliesSection = ({
 
   return (
     <div
-      className={`flex flex-col gap-4 rounded-md bg-surface p-10 transition-opacity ${isEnabled ? "opacity-100" : "opacity-50"}`}
+      className={`flex flex-col gap-4 rounded-md bg-surface p-10 transition-opacity ${
+        isEnabled ? "opacity-100" : "opacity-50"
+      }`}
     >
-      <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2">
         <span className="body-3">
           {t("settings.developer.contactsDevTool.eligibleAddressFamilies")}
         </span>
@@ -46,7 +48,7 @@ export const EligibleAddressFamiliesSection = ({
         </div>
       </div>
 
-      <div className="flex flex-wrap gap-2">
+      <div className="flex items-center justify-between gap-2">
         {ELIGIBLE_ADDRESS_FAMILIES_PRESETS.map(preset => (
           <Button
             key={preset.id}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/__tests__/useContactsDevToolViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/__tests__/useContactsDevToolViewModel.test.ts
@@ -160,4 +160,36 @@ describe("useContactsDevToolViewModel", () => {
 
     expect(store.getState().featureFlags.overrides.lwdContacts).toBeUndefined();
   });
+
+  it("should load populated contacts into the contacts slice", () => {
+    const { result, store } = renderHook(() => useContactsDevToolViewModel());
+
+    act(() => {
+      result.current.handleLoadPopulatedContacts();
+    });
+
+    expect(store.getState().contacts.contacts).toHaveLength(4);
+    expect(store.getState().contacts.contacts.map(contact => contact.name)).toEqual([
+      "Me",
+      "Ada",
+      "Ben",
+      "Olive",
+    ]);
+  });
+
+  it("should reset contacts to the default Me contact", () => {
+    const { result, store } = renderHook(() => useContactsDevToolViewModel());
+
+    act(() => {
+      result.current.handleLoadPopulatedContacts();
+    });
+
+    act(() => {
+      result.current.handleResetContacts();
+    });
+
+    expect(store.getState().contacts.contacts).toEqual([
+      expect.objectContaining({ id: "contact-me", isMe: true, name: "Me", addresses: [] }),
+    ]);
+  });
 });

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/useContactsDevToolViewModel.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/useContactsDevToolViewModel.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useDispatch } from "LLD/hooks/redux";
+import { setContacts } from "@domain/entity-contact";
+import { mockEmptyContacts, mockPopulatedContacts } from "@domain/entity-contact/schema.mock";
 import { useFeature } from "@features/platform-feature-flags";
 import {
   parseEligibleAddressFamiliesInput,
@@ -8,6 +9,7 @@ import {
   type ContactsFeatureValuePatch,
 } from "@features/flow-contacts";
 import { setOverride } from "@shared/feature-flags";
+import { useDispatch } from "LLD/hooks/redux";
 import { CONTACTS_FLAG } from "../constants";
 import { ContactsDevToolViewModel } from "../types";
 
@@ -57,6 +59,14 @@ export const useContactsDevToolViewModel = (): ContactsDevToolViewModel => {
     handleSetEligibleAddressFamilies(parseEligibleAddressFamiliesInput(customFamiliesInput));
   }, [customFamiliesInput, handleSetEligibleAddressFamilies]);
 
+  const handleLoadPopulatedContacts = useCallback(() => {
+    dispatch(setContacts(mockPopulatedContacts()));
+  }, [dispatch]);
+
+  const handleResetContacts = useCallback(() => {
+    dispatch(setContacts(mockEmptyContacts()));
+  }, [dispatch]);
+
   const handleResetOverride = useCallback(() => {
     dispatch(setOverride({ key: CONTACTS_FLAG, value: undefined }));
   }, [dispatch]);
@@ -71,6 +81,8 @@ export const useContactsDevToolViewModel = (): ContactsDevToolViewModel => {
     handleSetEligibleAddressFamilies,
     setCustomFamiliesInput,
     handleApplyCustomFamilies,
+    handleLoadPopulatedContacts,
+    handleResetContacts,
     handleResetOverride,
   };
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/types.ts
@@ -14,5 +14,7 @@ export interface ContactsDevToolViewModel {
   readonly handleSetEligibleAddressFamilies: (families: readonly string[]) => void;
   readonly setCustomFamiliesInput: (value: string) => void;
   readonly handleApplyCustomFamilies: () => void;
+  readonly handleLoadPopulatedContacts: () => void;
+  readonly handleResetContacts: () => void;
   readonly handleResetOverride: () => void;
 }

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -5265,6 +5265,9 @@
         "customFamiliesHint": "Comma-separated families for custom multi-family testing.",
         "customFamiliesPlaceholder": "evm, stellar, aptos",
         "applyFamilies": "Apply",
+        "contactsData": "Contacts data",
+        "loadPopulatedContacts": "Load populated contacts",
+        "resetContacts": "Reset contacts",
         "resetOverride": "Reset override"
       },
       "cryptoAssetsList": {

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -5,7 +5,7 @@ Shared Contacts flow package for Desktop and Mobile.
 ## Scope
 
 - Feature-flag configuration (`useContactsFeature`, resolvers)
-- `useContactsMeContact` hook (`@domain/entity-contact`)
+- `useContacts` and `useContactsMeContact` hooks (`@domain/entity-contact`)
 - Shared UI components (`.web.tsx` / `.native.tsx`)
 - Empty, populated, and search Contacts list view models and their Desktop and Mobile page shells
 

--- a/features/flow/contacts/src/hooks/index.ts
+++ b/features/flow/contacts/src/hooks/index.ts
@@ -1,3 +1,3 @@
 export { useContacts } from "./useContacts";
-export { useContactsMeContact } from "./useContactsMeContact";
 export { useContactsListViewModel } from "./useContactsListViewModel";
+export { useContactsMeContact } from "./useContactsMeContact";

--- a/features/flow/contacts/src/hooks/index.ts
+++ b/features/flow/contacts/src/hooks/index.ts
@@ -1,2 +1,3 @@
+export { useContacts } from "./useContacts";
 export { useContactsMeContact } from "./useContactsMeContact";
 export { useContactsListViewModel } from "./useContactsListViewModel";

--- a/features/flow/contacts/src/hooks/useContacts.ts
+++ b/features/flow/contacts/src/hooks/useContacts.ts
@@ -1,0 +1,6 @@
+import { selectContacts } from "@domain/entity-contact";
+import { useSelector } from "react-redux";
+
+export function useContacts() {
+  return useSelector(selectContacts);
+}

--- a/features/flow/contacts/src/hooks/useContactsListViewModel.ts
+++ b/features/flow/contacts/src/hooks/useContactsListViewModel.ts
@@ -1,13 +1,15 @@
-import { selectContacts } from "@domain/entity-contact";
 import { useMemo } from "react";
-import { useSelector } from "react-redux";
 import { createContactsListViewModel } from "../list/viewModel";
 import type { ContactsListViewModel } from "../list/types";
+import { useContacts } from "./useContacts";
 import { useContactsMeContact } from "./useContactsMeContact";
 
 export function useContactsListViewModel(): ContactsListViewModel {
-  const contacts = useSelector(selectContacts);
   const meContact = useContactsMeContact();
+  const contacts = useContacts();
 
-  return useMemo(() => createContactsListViewModel(meContact, contacts), [contacts, meContact]);
+  return useMemo(
+    () => createContactsListViewModel(meContact, contacts),
+    [contacts, meContact],
+  );
 }

--- a/features/flow/contacts/src/list/components/ContactsList/ContactsAddContactListItem.web.tsx
+++ b/features/flow/contacts/src/list/components/ContactsList/ContactsAddContactListItem.web.tsx
@@ -17,7 +17,7 @@ export function ContactsAddContactListItem({
   onAddContact,
 }: ContactsAddContactListItemProps): React.ReactNode {
   return (
-    <ListItem className="mt-16" onClick={onAddContact} data-testid="contacts-add-contact">
+    <ListItem onClick={onAddContact} data-testid="contacts-add-contact">
       <ListItemLeading>
         <div
           className="flex size-48 shrink-0 items-center justify-center rounded-full bg-muted-transparent text-base"

--- a/features/flow/contacts/src/list/components/ContactsList/ContactsList.web.tsx
+++ b/features/flow/contacts/src/list/components/ContactsList/ContactsList.web.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { SearchInput } from "@ledgerhq/lumen-ui-react";
+import {
+  SearchInput,
+  SectionHeader,
+  SectionHeaderTitle,
+} from "@ledgerhq/lumen-ui-react";
 import { isPopulatedContactsListViewModel, type ContactsPageProps } from "../../types";
 import { ContactsAddContactListItem } from "./ContactsAddContactListItem.web";
 import { ContactsMeListItem } from "./ContactsMeListItem.web";
@@ -46,7 +50,9 @@ export function ContactsList({
               className="flex flex-col gap-8"
               data-testid={`contacts-section-${section.title}`}
             >
-              <p className="body-4-semi-bold text-muted-subtle uppercase">{section.title}</p>
+              <SectionHeader appearance="plain">
+                <SectionHeaderTitle>{section.title}</SectionHeaderTitle>
+              </SectionHeader>
               <div className="flex flex-col">
                 {section.data.map(contact => (
                   <ContactsSavedListItem

--- a/features/flow/contacts/src/list/components/ContactsList/ContactsList.web.tsx
+++ b/features/flow/contacts/src/list/components/ContactsList/ContactsList.web.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { SearchInput } from "@ledgerhq/lumen-ui-react";
-import type { ContactsPageProps } from "../../types";
+import { isPopulatedContactsListViewModel, type ContactsPageProps } from "../../types";
 import { ContactsAddContactListItem } from "./ContactsAddContactListItem.web";
 import { ContactsMeListItem } from "./ContactsMeListItem.web";
+import { ContactsSavedListItem } from "./ContactsSavedListItem.web";
 
 type ContactsListProps = Pick<
   ContactsPageProps,
@@ -16,8 +17,12 @@ export function ContactsList({
   onOpenContact,
   onAddContact,
 }: ContactsListProps): React.ReactNode {
+  const savedContactSections = isPopulatedContactsListViewModel(viewModel)
+    ? viewModel.sections
+    : [];
+
   return (
-    <div className="flex flex-col" data-testid="contacts-list">
+    <div className="flex min-h-0 flex-1 flex-col gap-16" data-testid="contacts-list">
       <div className="flex flex-col gap-8">
         <SearchInput
           value=""
@@ -33,6 +38,29 @@ export function ContactsList({
           onOpen={onOpenContact}
         />
       </div>
+      {savedContactSections.length > 0 ? (
+        <div className="flex flex-col gap-16">
+          {savedContactSections.map(section => (
+            <div
+              key={section.title}
+              className="flex flex-col gap-8"
+              data-testid={`contacts-section-${section.title}`}
+            >
+              <p className="body-4-semi-bold text-muted-subtle uppercase">{section.title}</p>
+              <div className="flex flex-col">
+                {section.data.map(contact => (
+                  <ContactsSavedListItem
+                    key={contact.contactId}
+                    contact={contact}
+                    formatAddressCount={labels.formatAddressCount}
+                    onOpen={onOpenContact}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
       <ContactsAddContactListItem label={labels.addContact} onAddContact={onAddContact} />
     </div>
   );

--- a/features/flow/contacts/src/list/components/ContactsList/ContactsMeListItem.web.tsx
+++ b/features/flow/contacts/src/list/components/ContactsList/ContactsMeListItem.web.tsx
@@ -24,7 +24,6 @@ export function ContactsMeListItem({
 }: ContactsMeListItemProps): React.ReactNode {
   return (
     <ListItem
-      className="bg-muted"
       onClick={() => onOpen(contact.contactId)}
       data-testid="contacts-me-row"
     >

--- a/features/flow/contacts/src/list/components/ContactsList/ContactsSavedListItem.web.tsx
+++ b/features/flow/contacts/src/list/components/ContactsList/ContactsSavedListItem.web.tsx
@@ -37,7 +37,9 @@ export function ContactsSavedListItem({
         </div>
         <ListItemContent>
           <ListItemTitle>{contact.name}</ListItemTitle>
-          <ListItemDescription>{formatAddressCount(contact.addressCount)}</ListItemDescription>
+          <ListItemDescription>
+            {formatAddressCount(contact.addressCount)}
+          </ListItemDescription>
         </ListItemContent>
       </ListItemLeading>
     </ListItem>

--- a/features/flow/contacts/src/list/components/ContactsList/ContactsSavedListItem.web.tsx
+++ b/features/flow/contacts/src/list/components/ContactsList/ContactsSavedListItem.web.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import {
+  ListItem,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
+} from "@ledgerhq/lumen-ui-react";
+import { getContactAvatarColorClass } from "../../internals/getContactAvatarColorClass";
+import type { ContactsListItem } from "../../types";
+
+type ContactsSavedListItemProps = Readonly<{
+  contact: ContactsListItem;
+  formatAddressCount: (count: number) => string;
+  onOpen: (contactId: ContactsListItem["contactId"]) => void;
+}>;
+
+export function ContactsSavedListItem({
+  contact,
+  formatAddressCount,
+  onOpen,
+}: ContactsSavedListItemProps): React.ReactNode {
+  const avatarColorClass = getContactAvatarColorClass(contact.contactId);
+
+  return (
+    <ListItem
+      onClick={() => onOpen(contact.contactId)}
+      data-testid={`contacts-saved-row-${contact.contactId}`}
+    >
+      <ListItemLeading>
+        <div
+          className={`body-1-semi-bold flex size-48 shrink-0 items-center justify-center rounded-full ${avatarColorClass}`}
+          aria-hidden
+          data-testid={`contacts-saved-avatar-${contact.contactId}`}
+        >
+          {contact.initial}
+        </div>
+        <ListItemContent>
+          <ListItemTitle>{contact.name}</ListItemTitle>
+          <ListItemDescription>{formatAddressCount(contact.addressCount)}</ListItemDescription>
+        </ListItemContent>
+      </ListItemLeading>
+    </ListItem>
+  );
+}

--- a/features/flow/contacts/src/list/components/ContactsPage/ContactsPage.web.test.tsx
+++ b/features/flow/contacts/src/list/components/ContactsPage/ContactsPage.web.test.tsx
@@ -1,12 +1,23 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ContactId } from "@domain/entity-contact";
-import { mockMeContact } from "@domain/entity-contact/schema.mock";
-import type { ContactsLedgerSyncStatus } from "../../types";
-import { createEmptyContactsListViewModel } from "../../viewModel";
+import { mockMeContact, mockPopulatedContacts } from "@domain/entity-contact/schema.mock";
+import type { ContactsLedgerSyncStatus, ContactsListViewModel } from "../../types";
+import {
+  createEmptyContactsListViewModel,
+  createPopulatedContactsListViewModel,
+} from "../../viewModel";
 import { ContactsPage } from "./ContactsPage.web";
 
+const labels = {
+  title: "Contacts",
+  searchPlaceholder: "Search contact",
+  addContact: "Add contact",
+  formatAddressCount: (count: number) => `${count} address`,
+};
+
 type RenderContactsPageOptions = Readonly<{
+  viewModel?: ContactsListViewModel;
   ledgerSyncStatus?: ContactsLedgerSyncStatus;
   isIntroductionOpen?: boolean;
   onDismissIntroduction?: () => void;
@@ -15,6 +26,7 @@ type RenderContactsPageOptions = Readonly<{
 }>;
 
 function renderContactsPage({
+  viewModel = createEmptyContactsListViewModel(mockMeContact()),
   ledgerSyncStatus = "ready",
   isIntroductionOpen = false,
   onDismissIntroduction = jest.fn(),
@@ -23,13 +35,8 @@ function renderContactsPage({
 }: RenderContactsPageOptions = {}) {
   render(
     <ContactsPage
-      viewModel={createEmptyContactsListViewModel(mockMeContact())}
-      labels={{
-        title: "Contacts",
-        searchPlaceholder: "Search contact",
-        addContact: "Add contact",
-        formatAddressCount: count => `${count} address`,
-      }}
+      viewModel={viewModel}
+      labels={labels}
       meAvatarSrc="https://example.com/black/user.png"
       onOpenContact={onOpenContact}
       onAddContact={onAddContact}
@@ -65,6 +72,7 @@ describe("ContactsPage", () => {
     expect(meAvatar.querySelector("img")?.getAttribute("src")).toBe(
       "https://example.com/black/user.png",
     );
+    expect(screen.queryByTestId("contacts-section-A")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("contacts-me-row"));
     fireEvent.click(screen.getByTestId("contacts-add-contact"));
@@ -72,6 +80,35 @@ describe("ContactsPage", () => {
 
     expect(onOpenContact).toHaveBeenCalledWith("contact-me");
     expect(onAddContact).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders saved contacts in alphabetical sections and delegates row actions", () => {
+    const onOpenContact = jest.fn();
+    const onAddContact = jest.fn();
+    const contacts = mockPopulatedContacts();
+    const me = contacts.find(contact => contact.isMe) ?? mockMeContact();
+
+    renderContactsPage({
+      viewModel: createPopulatedContactsListViewModel(me, contacts),
+      onOpenContact,
+      onAddContact,
+    });
+
+    expect(screen.getByTestId("contacts-section-A")).toBeVisible();
+    expect(screen.getByTestId("contacts-section-B")).toBeVisible();
+    expect(screen.getByTestId("contacts-section-O")).toBeVisible();
+    expect(screen.getByTestId("contacts-saved-row-contact-ada")).toHaveTextContent("Ada");
+    expect(screen.getByTestId("contacts-saved-row-contact-ada")).toHaveTextContent("0 address");
+    expect(screen.getByTestId("contacts-saved-row-contact-ben")).toHaveTextContent("Ben");
+    expect(screen.getByTestId("contacts-saved-row-contact-ben")).toHaveTextContent("2 address");
+    expect(screen.getByTestId("contacts-saved-row-contact-olive")).toHaveTextContent("Olive");
+    expect(screen.getByTestId("contacts-saved-avatar-contact-ada")).toHaveTextContent("A");
+    expect(screen.getByTestId("contacts-add-contact")).toBeVisible();
+    expect(screen.getByTestId("contacts-add-contact-header")).toBeVisible();
+
+    fireEvent.click(screen.getByTestId("contacts-saved-row-contact-ben"));
+
+    expect(onOpenContact).toHaveBeenCalledWith("contact-ben");
   });
 
   it("keeps the Contacts page visible while Ledger Sync is checking", () => {

--- a/features/flow/contacts/src/list/components/ContactsPageLayout/ContactsDetailPane.web.tsx
+++ b/features/flow/contacts/src/list/components/ContactsPageLayout/ContactsDetailPane.web.tsx
@@ -4,9 +4,14 @@ type ContactsDetailPaneProps = Readonly<{
   children?: ReactNode;
 }>;
 
-export function ContactsDetailPane({ children }: ContactsDetailPaneProps): React.ReactNode {
+export function ContactsDetailPane({
+  children,
+}: ContactsDetailPaneProps): React.ReactNode {
   return (
-    <div className="min-w-0 flex-1 rounded-lg bg-surface" data-testid="contacts-detail-pane">
+    <div
+      className="min-w-0 flex-1 rounded-lg bg-section"
+      data-testid="contacts-detail-pane"
+    >
       {children}
     </div>
   );

--- a/features/flow/contacts/src/list/components/ContactsPageLayout/ContactsListPane.web.tsx
+++ b/features/flow/contacts/src/list/components/ContactsPageLayout/ContactsListPane.web.tsx
@@ -4,10 +4,12 @@ type ContactsListPaneProps = Readonly<{
   children: ReactNode;
 }>;
 
-export function ContactsListPane({ children }: ContactsListPaneProps): React.ReactNode {
+export function ContactsListPane({
+  children,
+}: ContactsListPaneProps): React.ReactNode {
   return (
     <aside
-      className="flex w-2/5 min-w-[400px] max-w-[445px] shrink-0 flex-col overflow-auto rounded-lg bg-surface p-16"
+      className="flex w-2/5 min-w-[400px] max-w-[445px] shrink-0 flex-col overflow-auto rounded-lg bg-section p-16"
       data-testid="contacts-list-pane"
     >
       {children}

--- a/features/flow/contacts/src/list/index.ts
+++ b/features/flow/contacts/src/list/index.ts
@@ -18,3 +18,4 @@ export type {
   EmptyContactsListViewModel,
   PopulatedContactsListViewModel,
 } from "./types";
+export { isPopulatedContactsListViewModel } from "./types";

--- a/features/flow/contacts/src/list/internals/getContactAvatarColorClass.test.ts
+++ b/features/flow/contacts/src/list/internals/getContactAvatarColorClass.test.ts
@@ -1,0 +1,25 @@
+import { getContactAvatarColorClass } from "./getContactAvatarColorClass";
+
+const ContactAvatarColorClasses = [
+  "bg-accent text-on-accent",
+  "bg-active-subtle text-active",
+  "bg-interactive text-on-interactive",
+  "bg-success-transparent text-success",
+  "bg-warning-transparent text-warning",
+] as const;
+
+describe("getContactAvatarColorClass", () => {
+  it("returns a deterministic color class for a contact id", () => {
+    expect(getContactAvatarColorClass("contact-ada")).toBe("bg-interactive text-on-interactive");
+    expect(getContactAvatarColorClass("contact-ada")).toBe(getContactAvatarColorClass("contact-ada"));
+  });
+
+  it("returns one of the avatar color classes", () => {
+    expect(ContactAvatarColorClasses).toContain(getContactAvatarColorClass("contact-ben"));
+    expect(ContactAvatarColorClasses).toContain(getContactAvatarColorClass("contact-olive"));
+  });
+
+  it("returns the first color class for an empty contact id", () => {
+    expect(getContactAvatarColorClass("")).toBe("bg-accent text-on-accent");
+  });
+});

--- a/features/flow/contacts/src/list/internals/getContactAvatarColorClass.ts
+++ b/features/flow/contacts/src/list/internals/getContactAvatarColorClass.ts
@@ -1,0 +1,17 @@
+const ContactAvatarColorClasses = [
+  "bg-accent text-on-accent",
+  "bg-active-subtle text-active",
+  "bg-interactive text-on-interactive",
+  "bg-success-transparent text-success",
+  "bg-warning-transparent text-warning",
+] as const;
+
+export function getContactAvatarColorClass(contactId: string): string {
+  let hash = 0;
+
+  for (const char of contactId) {
+    hash = (hash + char.charCodeAt(0)) % ContactAvatarColorClasses.length;
+  }
+
+  return ContactAvatarColorClasses[hash] ?? ContactAvatarColorClasses[0];
+}

--- a/features/flow/contacts/src/list/internals/getContactAvatarColorClass.ts
+++ b/features/flow/contacts/src/list/internals/getContactAvatarColorClass.ts
@@ -10,8 +10,8 @@ export function getContactAvatarColorClass(contactId: string): string {
   let hash = 0;
 
   for (const char of contactId) {
-    hash = (hash + char.charCodeAt(0)) % ContactAvatarColorClasses.length;
+    hash = (hash + (char.codePointAt(0) ?? 0)) % ContactAvatarColorClasses.length;
   }
 
-  return ContactAvatarColorClasses[hash] ?? ContactAvatarColorClasses[0];
+  return ContactAvatarColorClasses[hash];
 }

--- a/features/flow/contacts/src/list/internals/groupSavedContactsByInitial.test.ts
+++ b/features/flow/contacts/src/list/internals/groupSavedContactsByInitial.test.ts
@@ -1,0 +1,31 @@
+import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
+import { createPopulatedContactsListViewModel } from "../viewModel";
+import { groupSavedContactsByInitial } from "./groupSavedContactsByInitial";
+
+describe("groupSavedContactsByInitial", () => {
+  it("groups alphabetically sorted contacts by their initial", () => {
+    const me = mockMeContact();
+    const contacts = [
+      me,
+      mockContact({ id: "contact-ada", name: "Ada" }),
+      mockContact({ id: "contact-anna", name: "Anna", addresses: [] }),
+      mockContact({ id: "contact-ben", name: "Ben" }),
+    ];
+    const savedContacts = createPopulatedContactsListViewModel(me, contacts).savedContacts;
+
+    expect(groupSavedContactsByInitial(savedContacts)).toEqual([
+      {
+        initial: "A",
+        contacts: [savedContacts[0], savedContacts[1]],
+      },
+      {
+        initial: "B",
+        contacts: [savedContacts[2]],
+      },
+    ]);
+  });
+
+  it("returns an empty list when there are no saved contacts", () => {
+    expect(groupSavedContactsByInitial([])).toEqual([]);
+  });
+});

--- a/features/flow/contacts/src/list/internals/groupSavedContactsByInitial.test.ts
+++ b/features/flow/contacts/src/list/internals/groupSavedContactsByInitial.test.ts
@@ -1,25 +1,24 @@
-import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
+import { mockPopulatedContacts } from "@domain/entity-contact/schema.mock";
 import { createPopulatedContactsListViewModel } from "../viewModel";
 import { groupSavedContactsByInitial } from "./groupSavedContactsByInitial";
 
 describe("groupSavedContactsByInitial", () => {
   it("groups alphabetically sorted contacts by their initial", () => {
-    const me = mockMeContact();
-    const contacts = [
-      me,
-      mockContact({ id: "contact-ada", name: "Ada" }),
-      mockContact({ id: "contact-anna", name: "Anna", addresses: [] }),
-      mockContact({ id: "contact-ben", name: "Ben" }),
-    ];
+    const contacts = mockPopulatedContacts();
+    const me = contacts.find(contact => contact.isMe)!;
     const savedContacts = createPopulatedContactsListViewModel(me, contacts).savedContacts;
 
     expect(groupSavedContactsByInitial(savedContacts)).toEqual([
       {
         initial: "A",
-        contacts: [savedContacts[0], savedContacts[1]],
+        contacts: [savedContacts[0]],
       },
       {
         initial: "B",
+        contacts: [savedContacts[1]],
+      },
+      {
+        initial: "O",
         contacts: [savedContacts[2]],
       },
     ]);

--- a/features/flow/contacts/src/list/internals/groupSavedContactsByInitial.ts
+++ b/features/flow/contacts/src/list/internals/groupSavedContactsByInitial.ts
@@ -1,0 +1,25 @@
+import type { ContactsListItem } from "../types";
+
+export type ContactsListSection = Readonly<{
+  initial: string;
+  contacts: readonly ContactsListItem[];
+}>;
+
+export function groupSavedContactsByInitial(
+  savedContacts: readonly ContactsListItem[],
+): readonly ContactsListSection[] {
+  const sections: { initial: string; contacts: ContactsListItem[] }[] = [];
+
+  for (const contact of savedContacts) {
+    const lastSection = sections[sections.length - 1];
+
+    if (lastSection?.initial === contact.initial) {
+      lastSection.contacts.push(contact);
+      continue;
+    }
+
+    sections.push({ initial: contact.initial, contacts: [contact] });
+  }
+
+  return sections;
+}

--- a/features/flow/contacts/src/list/internals/groupSavedContactsByInitial.ts
+++ b/features/flow/contacts/src/list/internals/groupSavedContactsByInitial.ts
@@ -11,7 +11,7 @@ export function groupSavedContactsByInitial(
   const sections: { initial: string; contacts: ContactsListItem[] }[] = [];
 
   for (const contact of savedContacts) {
-    const lastSection = sections[sections.length - 1];
+    const lastSection = sections.at(-1);
 
     if (lastSection?.initial === contact.initial) {
       lastSection.contacts.push(contact);

--- a/features/flow/contacts/src/list/internals/index.ts
+++ b/features/flow/contacts/src/list/internals/index.ts
@@ -1,3 +1,4 @@
+export { getContactAvatarColorClass } from "./getContactAvatarColorClass";
 export { getContactInitial } from "./getContactInitial";
 export { createContactsListSections } from "./createContactsListSections";
 export { getContactInitialAvatarBackground } from "./getContactInitialAvatarBackground";

--- a/features/flow/contacts/src/list/types.ts
+++ b/features/flow/contacts/src/list/types.ts
@@ -52,6 +52,12 @@ export type ContactsPageProps = Readonly<{
   ledgerSyncIntroduction: ContactsLedgerSyncIntroduction;
 }>;
 
+export function isPopulatedContactsListViewModel(
+  viewModel: ContactsListViewModel,
+): viewModel is PopulatedContactsListViewModel {
+  return viewModel.displayMode === "populated";
+}
+
 export type ContactsSearchResultsViewModel = PopulatedContactsListViewModel &
   Readonly<{
     status: "results";

--- a/features/flow/contacts/src/list/viewModel.test.ts
+++ b/features/flow/contacts/src/list/viewModel.test.ts
@@ -1,5 +1,6 @@
 import { mockContact, mockContactAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
 import {
+  createContactsListViewModel,
   createContactsSearchViewModel,
   createEmptyContactsListViewModel,
   createPopulatedContactsListViewModel,
@@ -31,6 +32,26 @@ describe("createEmptyContactsListViewModel", () => {
         addressCount: 1,
       },
     });
+  });
+});
+
+describe("createContactsListViewModel", () => {
+  it("returns an empty list when only Me is present", () => {
+    const me = mockMeContact();
+
+    expect(createContactsListViewModel(me, [me])).toEqual(createEmptyContactsListViewModel(me));
+  });
+
+  it("returns a populated list when saved contacts exist", () => {
+    const me = mockMeContact();
+    const contacts = [
+      me,
+      mockContact({ id: "contact-ada", name: "Ada" }),
+    ];
+
+    expect(createContactsListViewModel(me, contacts)).toEqual(
+      createPopulatedContactsListViewModel(me, contacts),
+    );
   });
 });
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

This pull request enhances the Contacts feature on Ledger Live Desktop with a fully populated Contacts list and developer tooling for easier testing and development. The main improvements include rendering saved contacts in the UI, grouping them alphabetically, and adding developer tool controls to load or reset mock contacts data. It also introduces new hooks and test coverage to support these features.

**Contacts List Rendering & View Model Updates:**

- The Contacts list on desktop now renders saved contacts (not just "Me") in alphabetical order, grouped by initial, using a populated view model when contacts exist. 
- Added the `useContacts` hook to access contacts from the Redux store, and updated the view model logic to select between empty and populated states.

**Developer Tooling:**

- The Developer Tools panel now includes controls to load a set of mock contacts and reset contacts to the default state, making it easier to test the Contacts feature with real data scenarios
- Added integration and unit tests to verify that loading and resetting contacts works as intended. 

**UI & Code Quality Improvements:**

- Refactored and improved the layout and code style of the Contacts list and developer tool components for better readability and maintainability.



https://github.com/user-attachments/assets/e97a9bb8-f2ec-4293-b9a1-9d4fbae740e1


<img width="933" height="863" alt="Screenshot 2026-07-20 at 10 31 41" src="https://github.com/user-attachments/assets/9f76ed95-bd13-4b1b-91e2-6982689fc0ba" />

### 🔗 Context

[LIVE-33886](https://ledgerhq.atlassian.net/browse/LIVE-33886)

[LIVE-33886]: https://ledgerhq.atlassian.net/browse/LIVE-33886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ