### PR TITLE
[LWD] feat(desktop): add large-screen upsell QA debug screen

### DIFF
--- a/.changeset/nimble-screens-debug.md
+++ b/.changeset/nimble-screens-debug.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"@domain/entity-large-screen-upsell-modal": minor
+"@features/flow-large-screen-upsell": minor
+---
+
+Add large-screen upsell QA debug screen and domain setters for simulating modal state

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/LargeScreenUpsellModalMount.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/LargeScreenUpsellModalMount.tsx
@@ -2,7 +2,11 @@ import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { onboardingDateSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
 import { useFeature } from "@features/platform-feature-flags";
-import { retriesUpsellModalSelector } from "@domain/entity-large-screen-upsell-modal";
+import {
+  markBlockedByCompeting,
+  retriesUpsellModalSelector,
+  sessionSelector,
+} from "@domain/entity-large-screen-upsell-modal";
 import {
   LargeScreenUpsellModal,
   mapDevicesModelListToUpsellInputs,
@@ -11,7 +15,7 @@ import {
   type LargeScreenUpsellModalViewedContext,
   type NanoDeviceModelId,
 } from "@features/flow-large-screen-upsell";
-import { useSelector } from "LLD/hooks/redux";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { themeSelector } from "~/renderer/actions/general";
 import { useShouldShowDeferredModals } from "~/renderer/hooks/useShouldShowDeferredModals";
 import { selectIsGenericAwarenessModalOpen } from "LLD/features/GenericAwarenessModal/genericAwarenessModalDialog";
@@ -50,24 +54,25 @@ function buildSharedAnalyticsProps({
 }
 
 export function LargeScreenUpsellModalMount() {
+  const dispatch = useDispatch();
   const { t } = useTranslation();
   const devicesModelList = useSelector(devicesModelListSelector);
   const onboardingDate = useSelector(onboardingDateSelector);
   const theme = useSelector(themeSelector);
   const personalizedRecommendationsEnabled = useSelector(sharePersonalizedRecommendationsSelector);
   const retries = useSelector(retriesUpsellModalSelector);
+  const session = useSelector(sessionSelector);
   const feature = useFeature("largeScreenUpsell");
   const shouldShowDeferredModals = useShouldShowDeferredModals();
   const isGenericAwarenessModalOpen = useSelector(selectIsGenericAwarenessModalOpen);
 
   const hasCompetingAppStartModal = !shouldShowDeferredModals || isGenericAwarenessModalOpen;
-  const hasSeenCompetingAppStartModalRef = useRef(false);
 
   useEffect(() => {
-    if (hasCompetingAppStartModal) {
-      hasSeenCompetingAppStartModalRef.current = true;
+    if (hasCompetingAppStartModal && session === "ready") {
+      dispatch(markBlockedByCompeting());
     }
-  }, [hasCompetingAppStartModal]);
+  }, [dispatch, hasCompetingAppStartModal, session]);
 
   const currentModalAnalyticsPropsRef = useRef<LargeScreenUpsellSharedAnalyticsProps | null>(null);
 
@@ -110,7 +115,8 @@ export function LargeScreenUpsellModalMount() {
     [getAnalyticsPropsForDevice],
   );
 
-  if (hasCompetingAppStartModal || hasSeenCompetingAppStartModalRef.current) {
+  // session becomes "dismissed" on close — while visible it stays "ready" so Mount stays mounted.
+  if (session !== "ready" || hasCompetingAppStartModal) {
     return null;
   }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import {
   act,
@@ -14,6 +14,23 @@ import { closeDialog, openDialog } from "~/renderer/reducers/dialogs";
 import { openURL } from "~/renderer/linking";
 import { track, trackPage } from "~/renderer/analytics/segment";
 import { LargeScreenUpsellModalMount } from "..";
+
+/** Mimics Portfolio scoping: Mount unmounts when leaving portfolio. */
+function LargeScreenUpsellModalMountOnPortfolio() {
+  const [onPortfolio, setOnPortfolio] = useState(true);
+
+  return (
+    <>
+      <button type="button" onClick={() => setOnPortfolio(true)}>
+        go-portfolio
+      </button>
+      <button type="button" onClick={() => setOnPortfolio(false)}>
+        go-qa
+      </button>
+      {onPortfolio ? <LargeScreenUpsellModalMount /> : null}
+    </>
+  );
+}
 
 jest.mock("~/renderer/linking", () => ({
   openURL: jest.fn(),
@@ -56,6 +73,7 @@ function eligibleState(settingsOverrides: Partial<State["settings"]> = {}): Deep
     largeScreenUpsellModal: {
       retries: 0,
       lastSeenAt: null,
+      session: "ready",
     },
     dialogs: {
       GENERIC_AWARENESS_MODAL: false,
@@ -87,9 +105,14 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     jest.useRealTimers();
   });
 
-  const renderMount = (initialState: DeepPartial<State> = eligibleState()) =>
-    render(<LargeScreenUpsellModalMount />, {
+  const renderMount = (
+    initialState: DeepPartial<State> = eligibleState(),
+    initialRoute?: string,
+    ui: React.ReactElement = <LargeScreenUpsellModalMount />,
+  ) =>
+    render(ui, {
       initialState,
+      initialRoute,
       userEventOptions: {
         advanceTimers: jest.advanceTimersByTime,
       },
@@ -102,6 +125,37 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     });
     expect(screen.queryByTestId("large-screen-upsell-modal")).not.toBeInTheDocument();
   };
+
+  it("should not re-open after dismiss when remounting on portfolio return", async () => {
+    const { user, store } = renderMount(
+      eligibleState(),
+      "/",
+      <LargeScreenUpsellModalMountOnPortfolio />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("large-screen-upsell-modal")).toBeVisible();
+    });
+
+    await user.click(screen.getByLabelText("components.dialogHeader.closeAriaLabel"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("large-screen-upsell-modal")).not.toBeInTheDocument();
+    });
+    expect(store.getState().largeScreenUpsellModal.session).toBe("dismissed");
+
+    await user.click(screen.getByRole("button", { name: "go-qa" }));
+
+    expect(screen.queryByTestId("large-screen-upsell-modal")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "go-portfolio" }));
+
+    await expectModalNotOpen();
+
+    expect(
+      jest.mocked(trackPage).mock.calls.filter(([page]) => page === "Modal - Upgrade"),
+    ).toHaveLength(1);
+  });
 
   it("should open with opted-out copy when personalized recommendations are off", async () => {
     renderMount();
@@ -248,7 +302,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     });
   });
 
-  it("should increment retries and set lastSeenAt when the modal opens", async () => {
+  it("should increment retries and set lastSeenAt when the modal opens without dismissing session", async () => {
     const { store } = renderMount();
 
     await waitFor(() => {
@@ -259,6 +313,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
       expect(store.getState().largeScreenUpsellModal.retries).toBe(1);
       expect(store.getState().largeScreenUpsellModal.lastSeenAt).not.toBeNull();
     });
+    expect(store.getState().largeScreenUpsellModal.session).toBe("ready");
   });
 
   it("should close when the header close control is pressed and stay closed", async () => {
@@ -271,6 +326,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     await waitFor(() => {
       expect(store.getState().largeScreenUpsellModal.retries).toBe(1);
     });
+    expect(store.getState().largeScreenUpsellModal.session).toBe("ready");
 
     await user.click(screen.getByLabelText(i18n.t("components.dialogHeader.closeAriaLabel")));
 
@@ -280,6 +336,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
 
     expect(openURL).not.toHaveBeenCalled();
     expect(store.getState().largeScreenUpsellModal.retries).toBe(1);
+    expect(store.getState().largeScreenUpsellModal.session).toBe("dismissed");
     expect(screen.queryByTestId("large-screen-upsell-modal")).not.toBeInTheDocument();
     expect(track).toHaveBeenCalledWith("modal_dismissed", {
       modal: "upgrade modal",
@@ -354,6 +411,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
       largeScreenUpsellModal: {
         retries: 2,
         lastSeenAt: Date.parse("2026-07-14T12:00:00.000Z"),
+        session: "ready",
       },
     });
 
@@ -511,6 +569,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
       largeScreenUpsellModal: {
         retries: 3,
         lastSeenAt: Date.parse("2026-07-14T12:00:00.000Z"),
+        session: "ready",
       },
     });
 
@@ -532,6 +591,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
       largeScreenUpsellModal: {
         retries: 3,
         lastSeenAt: Date.parse("2026-05-01T12:00:00.000Z"),
+        session: "ready",
       },
     });
 
@@ -570,6 +630,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
       largeScreenUpsellModal: {
         retries: 0,
         lastSeenAt: null,
+        session: "ready",
       },
     });
 
@@ -595,6 +656,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
       largeScreenUpsellModal: {
         retries: 0,
         lastSeenAt: null,
+        session: "ready",
       },
     });
 
@@ -647,8 +709,8 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     expect(store.getState().largeScreenUpsellModal.retries).toBe(1);
   });
 
-  it("should dismiss via Escape and outside tap with the matching dismissMethod", async () => {
-    const { unmount: unmountEscape } = renderMount();
+  it("should dismiss via Escape with dismissMethod escape key down", async () => {
+    renderMount();
 
     await waitFor(() => {
       expect(screen.getByTestId("large-screen-upsell-modal")).toBeVisible();
@@ -670,11 +732,9 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
       ...NANO_S_OPTED_OUT_ANALYTICS_PROPS,
     });
     expect(track).not.toHaveBeenCalledWith("button_clicked", expect.anything());
+  });
 
-    unmountEscape();
-    jest.mocked(track).mockClear();
-    jest.mocked(trackPage).mockClear();
-
+  it("should dismiss via outside tap with dismissMethod outside tap", async () => {
     renderMount();
 
     await waitFor(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/index.ts
@@ -1,1 +1,2 @@
 export { LargeScreenUpsellModalMount } from "./LargeScreenUpsellModalMount";
+export { default as LargeScreenUpsellQa } from "./screens/LargeScreenUpsellQa";

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/LargeScreenUpsellQaView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/LargeScreenUpsellQaView.tsx
@@ -6,21 +6,30 @@ import { COPY } from "./copy";
 import { ONBOARDING_DATE_PRESETS } from "./utils";
 import type { LargeScreenUpsellQaViewModel } from "./useLargeScreenUpsellQaViewModel";
 
-type Props = LargeScreenUpsellQaViewModel;
+type Props = Readonly<LargeScreenUpsellQaViewModel>;
 
-function ToggleRow({
-  label,
-  selected,
-  onChange,
-  name,
-  explanation,
-}: {
+type ToggleRowProps = Readonly<{
   label: string;
   selected: boolean;
   onChange: (selected: boolean) => void;
   name: string;
   explanation?: string;
-}) {
+}>;
+
+type ParamRowProps = Readonly<{
+  label: string;
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+  onApply: () => void;
+  onReset: () => void;
+  disabled: boolean;
+  testId: string;
+  explanation: string;
+  isOverridden: boolean;
+}>;
+
+function ToggleRow({ label, selected, onChange, name, explanation }: ToggleRowProps) {
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between gap-16">
@@ -43,18 +52,7 @@ function ParamRow({
   testId,
   explanation,
   isOverridden,
-}: {
-  label: string;
-  value: string;
-  placeholder: string;
-  onChange: (value: string) => void;
-  onApply: () => void;
-  onReset: () => void;
-  disabled: boolean;
-  testId: string;
-  explanation: string;
-  isOverridden: boolean;
-}) {
+}: ParamRowProps) {
   return (
     <div className="flex flex-col gap-4">
       <span className="body-2 font-medium text-base">{label}</span>
@@ -192,25 +190,26 @@ export function LargeScreenUpsellQaView({
 
             <p className="body-3 mb-6 text-muted">{COPY.gatesTitle}</p>
             <ul className="mb-14 flex flex-col gap-4" data-testid="large-screen-upsell-qa-gates">
-              {gateRows.map(gate => (
-                <li key={gate.reason} className="body-2 flex items-start gap-6">
-                  <span className={gate.passes ? "text-success" : "text-error"} aria-hidden>
-                    {gate.passes ? "✓" : "✗"}
-                  </span>
-                  <span
-                    className={
-                      gate.passes
-                        ? "text-muted"
-                        : gate.isBlocking
-                          ? "font-medium text-error"
-                          : "text-error"
-                    }
-                  >
-                    {gate.label}
-                    {gate.isBlocking ? ` ${COPY.blockingNow}` : ""}
-                  </span>
-                </li>
-              ))}
+              {gateRows.map(gate => {
+                let labelColorClass = "text-error";
+                if (gate.passes) {
+                  labelColorClass = "text-muted";
+                } else if (gate.isBlocking) {
+                  labelColorClass = "font-medium text-error";
+                }
+
+                return (
+                  <li key={gate.reason} className="body-2 flex items-start gap-6">
+                    <span className={gate.passes ? "text-success" : "text-error"} aria-hidden>
+                      {gate.passes ? "✓" : "✗"}
+                    </span>
+                    <span className={labelColorClass}>
+                      {gate.label}
+                      {gate.isBlocking ? ` ${COPY.blockingNow}` : ""}
+                    </span>
+                  </li>
+                );
+              })}
             </ul>
 
             <p
@@ -260,9 +259,9 @@ export function LargeScreenUpsellQaView({
               <span className="body-2 font-medium text-base">{COPY.seenNanos}</span>
               <div className="flex flex-wrap items-center gap-12">
                 {nanoModelRows.map(row => (
-                  <div
+                  <label
                     key={row.id}
-                    className="flex items-center gap-8"
+                    className="flex cursor-pointer items-center gap-8"
                     data-testid={`large-screen-upsell-qa-nano-${row.id}`}
                   >
                     <Checkbox
@@ -271,7 +270,7 @@ export function LargeScreenUpsellQaView({
                       onCheckedChange={checked => handleToggleDeviceModel(row.id, checked === true)}
                     />
                     <span className="body-2 text-base">{row.label}</span>
-                  </div>
+                  </label>
                 ))}
               </div>
             </div>
@@ -281,9 +280,9 @@ export function LargeScreenUpsellQaView({
               <p className="body-3 text-muted">{COPY.seenTouchscreensHint}</p>
               <div className="flex flex-wrap items-center gap-12">
                 {touchscreenModelRows.map(row => (
-                  <div
+                  <label
                     key={row.id}
-                    className="flex items-center gap-8"
+                    className="flex cursor-pointer items-center gap-8"
                     data-testid={`large-screen-upsell-qa-touchscreen-${row.id}`}
                   >
                     <Checkbox
@@ -292,7 +291,7 @@ export function LargeScreenUpsellQaView({
                       onCheckedChange={checked => handleToggleDeviceModel(row.id, checked === true)}
                     />
                     <span className="body-2 text-base">{row.label}</span>
-                  </div>
+                  </label>
                 ))}
               </div>
             </div>

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/LargeScreenUpsellQaView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/LargeScreenUpsellQaView.tsx
@@ -1,0 +1,513 @@
+import React from "react";
+import { Button, Checkbox, Switch, TextInput } from "@ledgerhq/lumen-ui-react";
+import { ArrowLeft } from "@ledgerhq/lumen-ui-react/symbols";
+import Box from "~/renderer/components/Box";
+import { COPY } from "./copy";
+import { ONBOARDING_DATE_PRESETS } from "./utils";
+import type { LargeScreenUpsellQaViewModel } from "./useLargeScreenUpsellQaViewModel";
+
+type Props = LargeScreenUpsellQaViewModel;
+
+function ToggleRow({
+  label,
+  selected,
+  onChange,
+  name,
+  explanation,
+}: {
+  label: string;
+  selected: boolean;
+  onChange: (selected: boolean) => void;
+  name: string;
+  explanation?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-16">
+        <span className="body-2 font-medium text-base">{label}</span>
+        <Switch name={name} selected={selected} onChange={onChange} />
+      </div>
+      {explanation ? <p className="body-3 text-muted">{explanation}</p> : null}
+    </div>
+  );
+}
+
+function ParamRow({
+  label,
+  value,
+  placeholder,
+  onChange,
+  onApply,
+  onReset,
+  disabled,
+  testId,
+  explanation,
+  isOverridden,
+}: {
+  label: string;
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+  onApply: () => void;
+  onReset: () => void;
+  disabled: boolean;
+  testId: string;
+  explanation: string;
+  isOverridden: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <span className="body-2 font-medium text-base">{label}</span>
+      <p className="body-3 text-muted">{explanation}</p>
+      <div className="flex flex-nowrap items-center gap-8">
+        <TextInput
+          aria-label={label}
+          value={value}
+          placeholder={placeholder}
+          onChange={event => onChange(event.target.value)}
+          className="min-w-0 flex-1"
+          disabled={disabled}
+          data-testid={testId}
+        />
+        <Button size="sm" appearance="base" onClick={onApply} disabled={disabled}>
+          {COPY.set}
+        </Button>
+        {isOverridden ? (
+          <Button
+            size="sm"
+            appearance="base"
+            onClick={onReset}
+            disabled={disabled}
+            data-testid={`${testId}-reset`}
+          >
+            {COPY.reset}
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function LargeScreenUpsellQaView({
+  wouldShow,
+  copyVariant,
+  onboardingDisplay,
+  pastCooldownLabel,
+  gateRows,
+  retriesDisplay,
+  killThresholdValue,
+  lastSeenDisplay,
+  isFeatureEnabled,
+  personalizedRecommendationsEnabled,
+  isModalEnabled,
+  nanoModelRows,
+  touchscreenModelRows,
+  isAdvancedOpen,
+  draftKillThreshold,
+  draftCooldownDefault,
+  draftCooldownNanoS,
+  draftCooldownNanoSP,
+  draftCooldownNanoX,
+  draftCadenceDays,
+  canEditFlagParams,
+  killThresholdLabel,
+  cooldownDefaultLabel,
+  cooldownNanoSLabel,
+  cooldownNanoSPLabel,
+  cooldownNanoXLabel,
+  cadenceDaysLabel,
+  modalEnabledLabel,
+  killThresholdPlaceholder,
+  cooldownDefaultPlaceholder,
+  cooldownNanoSPlaceholder,
+  cooldownNanoSPPlaceholder,
+  cooldownNanoXPlaceholder,
+  cadenceDaysPlaceholder,
+  killThresholdOverridden,
+  cooldownDefaultOverridden,
+  cooldownNanoSOverridden,
+  cooldownNanoSPOverridden,
+  cooldownNanoXOverridden,
+  cadenceDaysOverridden,
+  hasLocalOverride,
+  handleBack,
+  handleReload,
+  handleResetAllFlagParams,
+  handleToggleFeature,
+  handleTogglePersonalizedRecommendations,
+  handleToggleDeviceModel,
+  handleToggleAdvanced,
+  handleToggleModalEnabled,
+  handleSetOnboardingDaysAgo,
+  handleSetOnboardingPastCooldown,
+  handleClearOnboardingDate,
+  handleDecrementRetries,
+  handleIncrementRetries,
+  handleResetRetries,
+  handleSetLastSeenNow,
+  handleClearLastSeen,
+  setDraftKillThreshold,
+  handleApplyKillThreshold,
+  handleResetKillThreshold,
+  setDraftCooldownDefault,
+  handleApplyCooldownDefault,
+  handleResetCooldownDefault,
+  setDraftCooldownNanoS,
+  handleApplyCooldownNanoS,
+  handleResetCooldownNanoS,
+  setDraftCooldownNanoSP,
+  handleApplyCooldownNanoSP,
+  handleResetCooldownNanoSP,
+  setDraftCooldownNanoX,
+  handleApplyCooldownNanoX,
+  handleResetCooldownNanoX,
+  setDraftCadenceDays,
+  handleApplyCadenceDays,
+  handleResetCadenceDays,
+}: Props) {
+  return (
+    <Box grow shrink className="p-8 pb-16">
+      <header className="mb-14 grid grid-cols-[1fr_auto_1fr] items-center gap-x-3 py-6">
+        <div className="flex min-w-0 justify-start">
+          <Button size="sm" appearance="no-background" onClick={handleBack} icon={ArrowLeft}>
+            {COPY.back}
+          </Button>
+        </div>
+        <span className="heading-2-semi-bold max-w-[min(100vw-8rem,28rem)] text-center text-base">
+          {COPY.title}
+        </span>
+        <div aria-hidden className="min-w-0" />
+      </header>
+
+      <div className="mx-auto grid w-full max-w-5xl grid-cols-1 items-start gap-20 px-4 md:grid-cols-[minmax(20rem,28rem)_minmax(0,1fr)]">
+        <aside className="self-start md:sticky md:top-8">
+          <section className="rounded-xl bg-surface p-16">
+            <p className="body-3 mb-6 text-muted">{COPY.willItShow}</p>
+            <p
+              className={`heading-2-semi-bold mb-14 ${wouldShow ? "text-success" : "text-error"}`}
+              data-testid="large-screen-upsell-qa-would-show"
+            >
+              {wouldShow ? COPY.yes : COPY.no}
+            </p>
+
+            <p className="body-3 mb-6 text-muted">{COPY.gatesTitle}</p>
+            <ul className="mb-14 flex flex-col gap-4" data-testid="large-screen-upsell-qa-gates">
+              {gateRows.map(gate => (
+                <li key={gate.reason} className="body-2 flex items-start gap-6">
+                  <span className={gate.passes ? "text-success" : "text-error"} aria-hidden>
+                    {gate.passes ? "✓" : "✗"}
+                  </span>
+                  <span
+                    className={
+                      gate.passes
+                        ? "text-muted"
+                        : gate.isBlocking
+                          ? "font-medium text-error"
+                          : "text-error"
+                    }
+                  >
+                    {gate.label}
+                    {gate.isBlocking ? ` ${COPY.blockingNow}` : ""}
+                  </span>
+                </li>
+              ))}
+            </ul>
+
+            <p
+              className="body-2 mb-14 font-medium text-base"
+              data-testid="large-screen-upsell-qa-copy-variant"
+            >
+              {COPY.copyVariantLabel}: {copyVariant}
+            </p>
+
+            <div className="flex flex-col gap-6" data-testid="large-screen-upsell-qa-reload-hint">
+              <p className="body-3 text-muted">{COPY.reloadHintLead}</p>
+              <p className="body-2 font-medium text-warning">{COPY.reloadHintRestart}</p>
+              {wouldShow ? (
+                <Button
+                  size="sm"
+                  appearance="accent"
+                  onClick={handleReload}
+                  data-testid="large-screen-upsell-qa-reload"
+                >
+                  {COPY.reload}
+                </Button>
+              ) : null}
+            </div>
+          </section>
+        </aside>
+
+        <section className="min-w-0 rounded-xl bg-surface p-16">
+          <div className="flex flex-col gap-16">
+            <p className="heading-4-semi-bold text-base">{COPY.configure}</p>
+
+            <ToggleRow
+              name="large-screen-upsell-qa-feature"
+              label={COPY.featureOn}
+              selected={isFeatureEnabled}
+              onChange={handleToggleFeature}
+            />
+
+            <ToggleRow
+              name="large-screen-upsell-qa-personalized-recommendations"
+              label={COPY.personalizedRecommendations}
+              selected={personalizedRecommendationsEnabled}
+              onChange={handleTogglePersonalizedRecommendations}
+              explanation={COPY.personalizedRecommendationsExplain}
+            />
+
+            <div className="flex flex-col gap-6">
+              <span className="body-2 font-medium text-base">{COPY.seenNanos}</span>
+              <div className="flex flex-wrap items-center gap-12">
+                {nanoModelRows.map(row => (
+                  <div
+                    key={row.id}
+                    className="flex items-center gap-8"
+                    data-testid={`large-screen-upsell-qa-nano-${row.id}`}
+                  >
+                    <Checkbox
+                      name={`large-screen-upsell-qa-nano-${row.id}`}
+                      checked={row.checked}
+                      onCheckedChange={checked => handleToggleDeviceModel(row.id, checked === true)}
+                    />
+                    <span className="body-2 text-base">{row.label}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-6">
+              <span className="body-2 font-medium text-base">{COPY.seenTouchscreens}</span>
+              <p className="body-3 text-muted">{COPY.seenTouchscreensHint}</p>
+              <div className="flex flex-wrap items-center gap-12">
+                {touchscreenModelRows.map(row => (
+                  <div
+                    key={row.id}
+                    className="flex items-center gap-8"
+                    data-testid={`large-screen-upsell-qa-touchscreen-${row.id}`}
+                  >
+                    <Checkbox
+                      name={`large-screen-upsell-qa-touchscreen-${row.id}`}
+                      checked={row.checked}
+                      onCheckedChange={checked => handleToggleDeviceModel(row.id, checked === true)}
+                    />
+                    <span className="body-2 text-base">{row.label}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-6">
+              <span className="body-2 font-medium text-base">{COPY.onboardingDate}</span>
+              <p className="body-3 text-muted">{COPY.onboardingConfigureHint}</p>
+              <p className="body-3 text-muted" data-testid="large-screen-upsell-qa-onboarding">
+                {COPY.currentValue(onboardingDisplay)}
+              </p>
+              <div className="flex flex-wrap gap-8">
+                {ONBOARDING_DATE_PRESETS.map(preset => (
+                  <Button
+                    key={preset.id}
+                    size="sm"
+                    appearance="base"
+                    onClick={() => handleSetOnboardingDaysAgo(preset.days)}
+                    data-testid={`large-screen-upsell-qa-onboarding-${preset.id}`}
+                  >
+                    {COPY[preset.labelKey]}
+                  </Button>
+                ))}
+                <Button
+                  size="sm"
+                  appearance="accent"
+                  onClick={handleSetOnboardingPastCooldown}
+                  data-testid="large-screen-upsell-qa-onboarding-past-cooldown"
+                >
+                  {pastCooldownLabel}
+                </Button>
+                <Button
+                  size="sm"
+                  appearance="transparent"
+                  onClick={handleClearOnboardingDate}
+                  data-testid="large-screen-upsell-qa-onboarding-clear"
+                >
+                  {COPY.onboardingClearLegacy}
+                </Button>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-6">
+              <span className="body-2 font-medium text-base">{COPY.retriesEdit}</span>
+              <p className="body-3 text-muted" data-testid="large-screen-upsell-qa-retries-status">
+                {COPY.currentValue(COPY.retriesValue(retriesDisplay, killThresholdValue))}
+              </p>
+              <div className="flex flex-wrap gap-8">
+                <Button
+                  size="sm"
+                  appearance="base"
+                  onClick={handleDecrementRetries}
+                  data-testid="large-screen-upsell-qa-retries-decrement"
+                >
+                  {COPY.retriesDecrement}
+                </Button>
+                <Button
+                  size="sm"
+                  appearance="base"
+                  onClick={handleIncrementRetries}
+                  data-testid="large-screen-upsell-qa-retries-increment"
+                >
+                  {COPY.retriesIncrement}
+                </Button>
+                <Button
+                  size="sm"
+                  appearance="transparent"
+                  onClick={handleResetRetries}
+                  data-testid="large-screen-upsell-qa-retries-reset"
+                >
+                  {COPY.reset}
+                </Button>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-6">
+              <span className="body-2 font-medium text-base">{COPY.lastSeenLabel}</span>
+              <p className="body-3 text-muted">{COPY.lastSeenHint}</p>
+              <p
+                className="body-3 text-muted"
+                data-testid="large-screen-upsell-qa-last-seen-status"
+              >
+                {COPY.currentValue(lastSeenDisplay)}
+              </p>
+              <div className="flex flex-wrap gap-8">
+                <Button
+                  size="sm"
+                  appearance="transparent"
+                  onClick={handleSetLastSeenNow}
+                  data-testid="large-screen-upsell-qa-last-seen-set-now"
+                >
+                  {COPY.lastSeenSetNow}
+                </Button>
+                <Button
+                  size="sm"
+                  appearance="transparent"
+                  onClick={handleClearLastSeen}
+                  data-testid="large-screen-upsell-qa-last-seen-clear"
+                >
+                  {COPY.clear}
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-16 border-t border-muted-subtle pt-14">
+            <Button size="sm" appearance="no-background" onClick={handleToggleAdvanced}>
+              {isAdvancedOpen ? COPY.hideAdvanced : COPY.advanced}
+            </Button>
+
+            {isAdvancedOpen ? (
+              <div className="mt-14 flex flex-col gap-16">
+                <ToggleRow
+                  name="large-screen-upsell-qa-modal-enabled"
+                  label={modalEnabledLabel}
+                  selected={isModalEnabled}
+                  onChange={handleToggleModalEnabled}
+                  explanation={COPY.modalEnabledExplain}
+                />
+
+                <div className="flex flex-col gap-6">
+                  <div className="flex flex-wrap items-center justify-between gap-8">
+                    <span className="body-2 font-medium text-base">{COPY.flagParamsTitle}</span>
+                    {hasLocalOverride ? (
+                      <Button
+                        size="sm"
+                        appearance="base"
+                        onClick={handleResetAllFlagParams}
+                        data-testid="large-screen-upsell-qa-reset-all-flag-params"
+                      >
+                        {COPY.resetAllFlagParams}
+                      </Button>
+                    ) : null}
+                  </div>
+                  <p className="body-3 text-muted">{COPY.flagParamsHint}</p>
+                </div>
+
+                <div className="flex flex-col gap-10">
+                  <ParamRow
+                    label={killThresholdLabel}
+                    value={draftKillThreshold}
+                    placeholder={killThresholdPlaceholder}
+                    onChange={setDraftKillThreshold}
+                    onApply={handleApplyKillThreshold}
+                    onReset={handleResetKillThreshold}
+                    disabled={!canEditFlagParams}
+                    testId="large-screen-upsell-qa-kill-threshold"
+                    explanation={COPY.killThresholdExplain}
+                    isOverridden={killThresholdOverridden}
+                  />
+                  <ParamRow
+                    label={cooldownDefaultLabel}
+                    value={draftCooldownDefault}
+                    placeholder={cooldownDefaultPlaceholder}
+                    onChange={setDraftCooldownDefault}
+                    onApply={handleApplyCooldownDefault}
+                    onReset={handleResetCooldownDefault}
+                    disabled={!canEditFlagParams}
+                    testId="large-screen-upsell-qa-cooldown-default"
+                    explanation={COPY.cooldownDefaultExplain}
+                    isOverridden={cooldownDefaultOverridden}
+                  />
+                  <ParamRow
+                    label={cooldownNanoSLabel}
+                    value={draftCooldownNanoS}
+                    placeholder={cooldownNanoSPlaceholder}
+                    onChange={setDraftCooldownNanoS}
+                    onApply={handleApplyCooldownNanoS}
+                    onReset={handleResetCooldownNanoS}
+                    disabled={!canEditFlagParams}
+                    testId="large-screen-upsell-qa-cooldown-nanos"
+                    explanation={COPY.cooldownNanoSExplain}
+                    isOverridden={cooldownNanoSOverridden}
+                  />
+                  <ParamRow
+                    label={cooldownNanoSPLabel}
+                    value={draftCooldownNanoSP}
+                    placeholder={cooldownNanoSPPlaceholder}
+                    onChange={setDraftCooldownNanoSP}
+                    onApply={handleApplyCooldownNanoSP}
+                    onReset={handleResetCooldownNanoSP}
+                    disabled={!canEditFlagParams}
+                    testId="large-screen-upsell-qa-cooldown-nanosp"
+                    explanation={COPY.cooldownNanoSPExplain}
+                    isOverridden={cooldownNanoSPOverridden}
+                  />
+                  <ParamRow
+                    label={cooldownNanoXLabel}
+                    value={draftCooldownNanoX}
+                    placeholder={cooldownNanoXPlaceholder}
+                    onChange={setDraftCooldownNanoX}
+                    onApply={handleApplyCooldownNanoX}
+                    onReset={handleResetCooldownNanoX}
+                    disabled={!canEditFlagParams}
+                    testId="large-screen-upsell-qa-cooldown-nanox"
+                    explanation={COPY.cooldownNanoXExplain}
+                    isOverridden={cooldownNanoXOverridden}
+                  />
+                  <ParamRow
+                    label={cadenceDaysLabel}
+                    value={draftCadenceDays}
+                    placeholder={cadenceDaysPlaceholder}
+                    onChange={setDraftCadenceDays}
+                    onApply={handleApplyCadenceDays}
+                    onReset={handleResetCadenceDays}
+                    disabled={!canEditFlagParams}
+                    testId="large-screen-upsell-qa-cadence-days"
+                    explanation={COPY.cadenceDaysExplain}
+                    isOverridden={cadenceDaysOverridden}
+                  />
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </section>
+      </div>
+    </Box>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/copy.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/copy.ts
@@ -1,0 +1,95 @@
+export const COPY = {
+  back: "Back",
+  title: "Large-screen upsell",
+  willItShow: "Will it show?",
+  yes: "YES",
+  no: "NO",
+  onboardingLegacy: "legacy / none (today)",
+  gatesTitle: "Gates (checked in this order)",
+  blockingNow: "(blocking)",
+  throttleNeedsLastSeen: " (lastSeen unset, not throttled)",
+  currentValue: (value: string) => `Now: ${value}`,
+  retriesValue: (retries: string, limit: string) => `${retries} / ${limit}`,
+  lastSeenNone: "none",
+  lastSeenHint: "Throttle needs this when retries ≥ killThreshold. Clear means never shown.",
+  lastSeenSetNow: "Set to now",
+  reloadHintLead: "Set every gate to pass so Will it show? reads YES.",
+  reloadHintRestart: "Opens on Portfolio after reload while you stay eligible.",
+  reload: "Reload",
+  copyVariantLabel: "Copy variant",
+  copyVariantOptIn: "opt-in",
+  copyVariantOptOut: "opt-out",
+  configure: "Configure",
+  featureOn: "Feature on",
+  personalizedRecommendations: "Personalized recommendations",
+  personalizedRecommendationsExplain:
+    "Uses your settings toggle. Opt-in vs opt-out copy applies on the next reload.",
+  seenNanos: "Seen Nano models",
+  nanoS: "Nano S",
+  nanoSP: "Nano SP",
+  nanoX: "Nano X",
+  seenTouchscreens: "Seen touchscreen models",
+  seenTouchscreensHint: "Checking any model fails the No touchscreen seen gate.",
+  stax: "Stax",
+  europa: "Europa",
+  apex: "Apex",
+  onboardingDate: "Onboarding date",
+  onboardingConfigureHint: "Cooldown counts from this date. Clear means legacy (treated as today).",
+  onboardingSevenDaysAgo: "7 days ago",
+  onboardingPastCooldown: (days: number) =>
+    days === 0 ? "Past cooldown (elapsed)" : `Past cooldown (${days} days ago)`,
+  onboardingClearLegacy: "Clear / legacy",
+  retriesEdit: "Retries",
+  retriesDecrement: "−",
+  retriesIncrement: "+",
+  lastSeenLabel: "Last seen",
+  advanced: "Advanced",
+  hideAdvanced: "Hide advanced",
+  popupEnabled: "Popup enabled (flag)",
+  flagParamsTitle: "Feature flag params",
+  flagParamsHint:
+    "Edits go into a local flag override. Empty fields show the remote or schema baseline. Reset shows when a value differs from that baseline.",
+  resetAllFlagParams: "Reset all",
+  killThresholdEdit: "killThreshold",
+  killThresholdExplain: "Shows allowed before cadence throttle starts",
+  cooldownDefaultEdit: "cooldownDays.default",
+  cooldownDefaultExplain: "Days after onboarding before the upsell can show",
+  cooldownNanoSEdit: "cooldownDays.nanoS",
+  cooldownNanoSExplain: "Days after onboarding before Nano S can see the upsell",
+  cooldownNanoSPEdit: "cooldownDays.nanoSP",
+  cooldownNanoSPExplain: "Days after onboarding before Nano SP can see the upsell",
+  cooldownNanoXEdit: "cooldownDays.nanoX",
+  cooldownNanoXExplain: "Days after onboarding before Nano X can see the upsell",
+  cadenceDaysEdit: "cadenceDays",
+  cadenceDaysExplain: "Days to wait after last show once retries ≥ killThreshold",
+  modalEnabledExplain: "Allows the modal when the feature flag is on",
+  set: "Set",
+  clear: "Clear",
+  reset: "Reset",
+} as const;
+
+export const GATE_LABELS = [
+  { reason: "feature_disabled", label: "Feature on" },
+  { reason: "modal_disabled", label: "Popup enabled" },
+  { reason: "touchscreen_seen", label: "No touchscreen seen" },
+  { reason: "no_nano", label: "Has a Nano" },
+  { reason: "model_disabled", label: "Nano model in audience" },
+  { reason: "cooldown", label: "Post-onboarding cooldown elapsed" },
+  {
+    reason: "throttled",
+    label: "Not throttled by kill streak",
+  },
+] as const;
+
+export function formatOnboardingDisplay(onboardingDate: Date | null): string {
+  if (onboardingDate == null) return COPY.onboardingLegacy;
+  if (Number.isNaN(onboardingDate.getTime())) return COPY.onboardingLegacy;
+  return `${onboardingDate.toISOString().slice(0, 16).replace("T", " ")} UTC`;
+}
+
+export function formatLastSeenDisplay(lastSeenAt: number | null): string {
+  if (lastSeenAt == null) return COPY.lastSeenNone;
+  const d = new Date(lastSeenAt);
+  if (Number.isNaN(d.getTime())) return COPY.lastSeenNone;
+  return `${d.toISOString().slice(0, 16).replace("T", " ")} UTC`;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/index.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { LargeScreenUpsellQaView } from "./LargeScreenUpsellQaView";
+import { useLargeScreenUpsellQaViewModel } from "./useLargeScreenUpsellQaViewModel";
+
+export default function LargeScreenUpsellQa() {
+  const viewModel = useLargeScreenUpsellQaViewModel();
+  return <LargeScreenUpsellQaView {...viewModel} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/useLargeScreenUpsellQaViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/useLargeScreenUpsellQaViewModel.ts
@@ -1,0 +1,560 @@
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import { DeviceModelId } from "@ledgerhq/devices";
+import { useFeature } from "@features/platform-feature-flags";
+import {
+  FEATURE_FLAGS_DEFAULTS,
+  featureFlagsOverridesSelector,
+  setOverride,
+} from "@shared/feature-flags";
+import { onboardingDateSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
+import { setPostOnboardingDate } from "@ledgerhq/live-common/postOnboarding/actions";
+import {
+  lastSeenUpsellModalSelector,
+  resetUpsellModalRetries,
+  retriesUpsellModalSelector,
+  setLastSeenUpsellModal,
+  setUpsellModalRetries,
+} from "@domain/entity-large-screen-upsell-modal";
+import {
+  getLargeScreenUpsellDecision,
+  mapDevicesModelListToUpsellInputs,
+} from "@features/flow-large-screen-upsell";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import {
+  DANGEROUSLY_setDevicesModelListForQa,
+  setSharePersonalizedRecommendations,
+} from "~/renderer/actions/settings";
+import {
+  devicesModelListSelector,
+  sharePersonalizedRecommendationsSelector,
+} from "~/renderer/reducers/settings";
+import {
+  buildUpsellGateRows,
+  daysAgoDate,
+  draftDisplayFromEffective,
+  isPostOnboardingCooldownPassed,
+  isThrottleGatePassed,
+  parseNonNegativeInteger,
+  pastCooldownOffsetDays,
+  resolveParamBaseline,
+} from "./utils";
+import { COPY, formatLastSeenDisplay, formatOnboardingDisplay, GATE_LABELS } from "./copy";
+
+const FLAG_KEY = "largeScreenUpsell";
+
+export const QA_NANO_MODELS = [
+  { id: DeviceModelId.nanoS, labelKey: "nanoS" },
+  { id: DeviceModelId.nanoSP, labelKey: "nanoSP" },
+  { id: DeviceModelId.nanoX, labelKey: "nanoX" },
+] as const;
+
+export const QA_TOUCHSCREEN_MODELS = [
+  { id: DeviceModelId.stax, labelKey: "stax" },
+  { id: DeviceModelId.europa, labelKey: "europa" },
+  { id: DeviceModelId.apex, labelKey: "apex" },
+] as const;
+
+export function useLargeScreenUpsellQaViewModel() {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const feature = useFeature(FLAG_KEY);
+  const overrides = useSelector(featureFlagsOverridesSelector);
+  const hasLocalOverride = overrides[FLAG_KEY] !== undefined;
+  const schemaDefaults = FEATURE_FLAGS_DEFAULTS[FLAG_KEY];
+  const devicesModelList = useSelector(devicesModelListSelector);
+  const personalizedRecommendationsEnabled = useSelector(sharePersonalizedRecommendationsSelector);
+  const onboardingDate = useSelector(onboardingDateSelector);
+  const retries = useSelector(retriesUpsellModalSelector);
+  const lastSeenAt = useSelector(lastSeenUpsellModalSelector);
+
+  const params = feature?.params;
+  const isFeatureEnabled = Boolean(feature?.enabled) && params !== undefined;
+  const killThreshold = params?.modal?.killThreshold;
+  const isModalEnabled = Boolean(params?.modal?.enabled);
+
+  const killThresholdBaseline = resolveParamBaseline({
+    effective: params?.modal?.killThreshold,
+    schemaDefault: schemaDefaults.params?.modal.killThreshold,
+    hasLocalOverride,
+  });
+  const cooldownDefaultBaseline = resolveParamBaseline({
+    effective: params?.cooldownDays?.default,
+    schemaDefault: schemaDefaults.params?.cooldownDays.default,
+    hasLocalOverride,
+  });
+  const cooldownNanoSBaseline = resolveParamBaseline({
+    effective: params?.cooldownDays?.nanoS,
+    schemaDefault: schemaDefaults.params?.cooldownDays.nanoS ?? 0,
+    hasLocalOverride,
+  });
+  const cooldownNanoSPBaseline = resolveParamBaseline({
+    effective: params?.cooldownDays?.nanoSP,
+    schemaDefault: schemaDefaults.params?.cooldownDays.nanoSP,
+    hasLocalOverride,
+  });
+  const cooldownNanoXBaseline = resolveParamBaseline({
+    effective: params?.cooldownDays?.nanoX,
+    schemaDefault: schemaDefaults.params?.cooldownDays.nanoX,
+    hasLocalOverride,
+  });
+  const cadenceDaysBaseline = resolveParamBaseline({
+    effective: params?.modal?.cadenceDays,
+    schemaDefault: schemaDefaults.params?.modal.cadenceDays,
+    hasLocalOverride,
+  });
+
+  const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
+  const [draftKillThreshold, setDraftKillThreshold] = useState(() =>
+    draftDisplayFromEffective(params?.modal?.killThreshold, killThresholdBaseline.baseline),
+  );
+  const [draftCooldownDefault, setDraftCooldownDefault] = useState(() =>
+    draftDisplayFromEffective(params?.cooldownDays?.default, cooldownDefaultBaseline.baseline),
+  );
+  const [draftCooldownNanoS, setDraftCooldownNanoS] = useState(() =>
+    draftDisplayFromEffective(params?.cooldownDays?.nanoS, cooldownNanoSBaseline.baseline),
+  );
+  const [draftCooldownNanoSP, setDraftCooldownNanoSP] = useState(() =>
+    draftDisplayFromEffective(params?.cooldownDays?.nanoSP, cooldownNanoSPBaseline.baseline),
+  );
+  const [draftCooldownNanoX, setDraftCooldownNanoX] = useState(() =>
+    draftDisplayFromEffective(params?.cooldownDays?.nanoX, cooldownNanoXBaseline.baseline),
+  );
+  const [draftCadenceDays, setDraftCadenceDays] = useState(() =>
+    draftDisplayFromEffective(params?.modal?.cadenceDays, cadenceDaysBaseline.baseline),
+  );
+
+  const { seenNanoModelIds, hasSeenTouchscreenDevice } =
+    mapDevicesModelListToUpsellInputs(devicesModelList);
+  const isNanoSeen = seenNanoModelIds.length > 0;
+  const now = new Date();
+
+  const nanoModelRows = QA_NANO_MODELS.map(model => ({
+    id: model.id,
+    label: COPY[model.labelKey],
+    checked: devicesModelList.includes(model.id),
+  }));
+
+  const touchscreenModelRows = QA_TOUCHSCREEN_MODELS.map(model => ({
+    id: model.id,
+    label: COPY[model.labelKey],
+    checked: devicesModelList.includes(model.id),
+  }));
+
+  // Missing params → feature_disabled (same early gate as production; no invented defaults).
+  const decision = !params
+    ? { shouldShow: false as const, reason: "feature_disabled" as const }
+    : getLargeScreenUpsellDecision(
+        {
+          seenNanoModelIds,
+          hasSeenTouchscreenDevice,
+          onboardingDate,
+          frequency: { retries, lastSeenAt },
+        },
+        {
+          isFeatureEnabled,
+          isModalEnabled,
+          audienceModels: params.audience.models,
+          cooldownDays: params.cooldownDays,
+          killThreshold: params.modal.killThreshold,
+          cadenceDays: params.modal.cadenceDays,
+          now,
+        },
+      );
+
+  const wouldShow = decision.shouldShow;
+
+  const enabledSeenNanoModelIds = params
+    ? seenNanoModelIds.filter(id => params.audience.models[id])
+    : [];
+  const isModelInAudience = enabledSeenNanoModelIds.length > 0;
+
+  const deviceModelIdForCooldown =
+    "deviceModelId" in decision ? decision.deviceModelId : enabledSeenNanoModelIds[0];
+  const resolvedCooldownDays =
+    params == null
+      ? undefined
+      : deviceModelIdForCooldown != null
+        ? (params.cooldownDays[deviceModelIdForCooldown] ?? params.cooldownDays.default)
+        : params.cooldownDays.default;
+
+  const cooldownPassed =
+    resolvedCooldownDays != null &&
+    isPostOnboardingCooldownPassed({
+      onboardingDate,
+      cooldownDays: resolvedCooldownDays,
+      now,
+    });
+
+  const throttlePassed =
+    params == null ||
+    isThrottleGatePassed({
+      retries,
+      lastSeenAt,
+      killThreshold: params.modal.killThreshold,
+      cadenceDays: params.modal.cadenceDays,
+      now,
+    });
+
+  const throttleNeedsLastSeenHint =
+    params != null && retries >= params.modal.killThreshold && lastSeenAt == null;
+
+  const gateRows = buildUpsellGateRows({
+    isFeatureEnabled,
+    isModalEnabled,
+    hasSeenTouchscreenDevice,
+    hasNano: isNanoSeen,
+    isModelInAudience: !isNanoSeen || isModelInAudience,
+    cooldownPassed,
+    throttlePassed,
+    blockingReason: decision.shouldShow ? undefined : decision.reason,
+  }).map(row => {
+    const baseLabel = GATE_LABELS.find(g => g.reason === row.reason)?.label ?? row.reason;
+    const label =
+      row.reason === "throttled" && throttleNeedsLastSeenHint
+        ? `${baseLabel}${COPY.throttleNeedsLastSeen}`
+        : baseLabel;
+    return { ...row, label };
+  });
+
+  const onboardingDisplay = formatOnboardingDisplay(onboardingDate);
+  const pastCooldownDays = pastCooldownOffsetDays(
+    resolvedCooldownDays ?? params?.cooldownDays.default ?? 0,
+  );
+  const pastCooldownLabel = COPY.onboardingPastCooldown(pastCooldownDays);
+
+  function overrideFeature(next: NonNullable<typeof feature>) {
+    dispatch(setOverride({ key: FLAG_KEY, value: next }));
+  }
+
+  function handleBack() {
+    navigate("/settings/developer");
+  }
+
+  function handleReload() {
+    window.api?.reloadRenderer();
+  }
+
+  function handleToggleFeature(enabled: boolean) {
+    if (!feature) return;
+    overrideFeature({ ...feature, enabled });
+  }
+
+  function handleTogglePersonalizedRecommendations(enabled: boolean) {
+    dispatch(setSharePersonalizedRecommendations(enabled));
+  }
+
+  function handleToggleModalEnabled(enabled: boolean) {
+    if (!feature || !params) return;
+    overrideFeature({
+      ...feature,
+      params: { ...params, modal: { ...params.modal, enabled } },
+    });
+  }
+
+  function handleToggleDeviceModel(modelId: DeviceModelId, seen: boolean) {
+    if (seen) {
+      const next = devicesModelList.includes(modelId)
+        ? devicesModelList
+        : [...devicesModelList, modelId];
+      dispatch(DANGEROUSLY_setDevicesModelListForQa(next));
+      return;
+    }
+
+    dispatch(DANGEROUSLY_setDevicesModelListForQa(devicesModelList.filter(id => id !== modelId)));
+  }
+
+  function handleSetOnboardingDaysAgo(days: number) {
+    dispatch(setPostOnboardingDate({ onboardingDate: daysAgoDate(days) }));
+  }
+
+  function handleSetOnboardingPastCooldown() {
+    handleSetOnboardingDaysAgo(pastCooldownDays);
+  }
+
+  function handleClearOnboardingDate() {
+    dispatch(setPostOnboardingDate({ onboardingDate: null }));
+  }
+
+  function handleDecrementRetries() {
+    dispatch(setUpsellModalRetries(Math.max(0, retries - 1)));
+  }
+
+  function handleIncrementRetries() {
+    dispatch(setUpsellModalRetries(retries + 1));
+  }
+
+  function handleResetRetries() {
+    dispatch(resetUpsellModalRetries());
+  }
+
+  function handleClearLastSeen() {
+    dispatch(setLastSeenUpsellModal(null));
+  }
+
+  function handleSetLastSeenNow() {
+    dispatch(setLastSeenUpsellModal(Date.now()));
+  }
+
+  function handleApplyKillThreshold() {
+    if (!feature || !params) return;
+    const parsed = parseNonNegativeInteger(draftKillThreshold);
+    if (parsed === undefined) return;
+    overrideFeature({
+      ...feature,
+      params: { ...params, modal: { ...params.modal, killThreshold: parsed } },
+    });
+    setDraftKillThreshold(draftDisplayFromEffective(parsed, killThresholdBaseline.baseline));
+  }
+
+  function handleApplyCooldownDefault() {
+    if (!feature || !params) return;
+    const parsed = parseNonNegativeInteger(draftCooldownDefault);
+    if (parsed === undefined) return;
+    overrideFeature({
+      ...feature,
+      params: {
+        ...params,
+        cooldownDays: { ...params.cooldownDays, default: parsed },
+      },
+    });
+    setDraftCooldownDefault(draftDisplayFromEffective(parsed, cooldownDefaultBaseline.baseline));
+  }
+
+  function handleApplyCooldownNanoS() {
+    if (!feature || !params) return;
+    const parsed = parseNonNegativeInteger(draftCooldownNanoS);
+    if (parsed === undefined) return;
+    overrideFeature({
+      ...feature,
+      params: {
+        ...params,
+        cooldownDays: { ...params.cooldownDays, nanoS: parsed },
+      },
+    });
+    setDraftCooldownNanoS(draftDisplayFromEffective(parsed, cooldownNanoSBaseline.baseline));
+  }
+
+  function handleApplyCooldownNanoSP() {
+    if (!feature || !params) return;
+    const parsed = parseNonNegativeInteger(draftCooldownNanoSP);
+    if (parsed === undefined) return;
+    overrideFeature({
+      ...feature,
+      params: {
+        ...params,
+        cooldownDays: { ...params.cooldownDays, nanoSP: parsed },
+      },
+    });
+    setDraftCooldownNanoSP(draftDisplayFromEffective(parsed, cooldownNanoSPBaseline.baseline));
+  }
+
+  function handleApplyCooldownNanoX() {
+    if (!feature || !params) return;
+    const parsed = parseNonNegativeInteger(draftCooldownNanoX);
+    if (parsed === undefined) return;
+    overrideFeature({
+      ...feature,
+      params: {
+        ...params,
+        cooldownDays: { ...params.cooldownDays, nanoX: parsed },
+      },
+    });
+    setDraftCooldownNanoX(draftDisplayFromEffective(parsed, cooldownNanoXBaseline.baseline));
+  }
+
+  function handleApplyCadenceDays() {
+    if (!feature || !params) return;
+    const parsed = parseNonNegativeInteger(draftCadenceDays);
+    if (parsed === undefined) return;
+    overrideFeature({
+      ...feature,
+      params: { ...params, modal: { ...params.modal, cadenceDays: parsed } },
+    });
+    setDraftCadenceDays(draftDisplayFromEffective(parsed, cadenceDaysBaseline.baseline));
+  }
+
+  /** Restore one FF param to baseline inside the full-flag override (no per-key clear API). */
+  function handleResetKillThreshold() {
+    if (!feature || !params) return;
+    const value = killThresholdBaseline.baselineValue;
+    if (value === undefined || value === null) return;
+    if (hasLocalOverride) {
+      overrideFeature({
+        ...feature,
+        params: { ...params, modal: { ...params.modal, killThreshold: value } },
+      });
+    }
+    setDraftKillThreshold("");
+  }
+
+  function handleResetCooldownDefault() {
+    if (!feature || !params) return;
+    const value = cooldownDefaultBaseline.baselineValue;
+    if (value === undefined || value === null) return;
+    if (hasLocalOverride) {
+      overrideFeature({
+        ...feature,
+        params: {
+          ...params,
+          cooldownDays: { ...params.cooldownDays, default: value },
+        },
+      });
+    }
+    setDraftCooldownDefault("");
+  }
+
+  function handleResetCooldownNanoS() {
+    if (!feature || !params) return;
+    const value = cooldownNanoSBaseline.baselineValue;
+    if (hasLocalOverride) {
+      overrideFeature({
+        ...feature,
+        params: {
+          ...params,
+          cooldownDays: { ...params.cooldownDays, nanoS: value },
+        },
+      });
+    }
+    setDraftCooldownNanoS("");
+  }
+
+  function handleResetCooldownNanoSP() {
+    if (!feature || !params) return;
+    const value = cooldownNanoSPBaseline.baselineValue;
+    if (hasLocalOverride) {
+      overrideFeature({
+        ...feature,
+        params: {
+          ...params,
+          cooldownDays: { ...params.cooldownDays, nanoSP: value },
+        },
+      });
+    }
+    setDraftCooldownNanoSP("");
+  }
+
+  function handleResetCooldownNanoX() {
+    if (!feature || !params) return;
+    const value = cooldownNanoXBaseline.baselineValue;
+    if (hasLocalOverride) {
+      overrideFeature({
+        ...feature,
+        params: {
+          ...params,
+          cooldownDays: { ...params.cooldownDays, nanoX: value },
+        },
+      });
+    }
+    setDraftCooldownNanoX("");
+  }
+
+  function handleResetCadenceDays() {
+    if (!feature || !params) return;
+    const value = cadenceDaysBaseline.baselineValue;
+    if (value === undefined || value === null) return;
+    if (hasLocalOverride) {
+      overrideFeature({
+        ...feature,
+        params: { ...params, modal: { ...params.modal, cadenceDays: value } },
+      });
+    }
+    setDraftCadenceDays("");
+  }
+
+  function handleResetAllFlagParams() {
+    dispatch(setOverride({ key: FLAG_KEY, value: undefined }));
+    setDraftKillThreshold("");
+    setDraftCooldownDefault("");
+    setDraftCooldownNanoS("");
+    setDraftCooldownNanoSP("");
+    setDraftCooldownNanoX("");
+    setDraftCadenceDays("");
+  }
+
+  function handleToggleAdvanced() {
+    setIsAdvancedOpen(open => !open);
+  }
+
+  return {
+    wouldShow,
+    copyVariant: personalizedRecommendationsEnabled
+      ? COPY.copyVariantOptIn
+      : COPY.copyVariantOptOut,
+    onboardingDisplay,
+    pastCooldownLabel,
+    gateRows,
+    retriesDisplay: String(retries),
+    lastSeenDisplay: formatLastSeenDisplay(lastSeenAt),
+    isFeatureEnabled: feature?.enabled ?? false,
+    personalizedRecommendationsEnabled,
+    isModalEnabled,
+    nanoModelRows,
+    touchscreenModelRows,
+    isAdvancedOpen,
+    draftKillThreshold,
+    draftCooldownDefault,
+    draftCooldownNanoS,
+    draftCooldownNanoSP,
+    draftCooldownNanoX,
+    draftCadenceDays,
+    killThresholdValue: killThreshold != null ? String(killThreshold) : "-",
+    killThresholdLabel: COPY.killThresholdEdit,
+    cooldownDefaultLabel: COPY.cooldownDefaultEdit,
+    cooldownNanoSLabel: COPY.cooldownNanoSEdit,
+    cooldownNanoSPLabel: COPY.cooldownNanoSPEdit,
+    cooldownNanoXLabel: COPY.cooldownNanoXEdit,
+    cadenceDaysLabel: COPY.cadenceDaysEdit,
+    modalEnabledLabel: COPY.popupEnabled,
+    killThresholdPlaceholder: killThresholdBaseline.baseline,
+    cooldownDefaultPlaceholder: cooldownDefaultBaseline.baseline,
+    cooldownNanoSPlaceholder: cooldownNanoSBaseline.baseline,
+    cooldownNanoSPPlaceholder: cooldownNanoSPBaseline.baseline,
+    cooldownNanoXPlaceholder: cooldownNanoXBaseline.baseline,
+    cadenceDaysPlaceholder: cadenceDaysBaseline.baseline,
+    killThresholdOverridden: killThresholdBaseline.isOverridden,
+    cooldownDefaultOverridden: cooldownDefaultBaseline.isOverridden,
+    cooldownNanoSOverridden: cooldownNanoSBaseline.isOverridden,
+    cooldownNanoSPOverridden: cooldownNanoSPBaseline.isOverridden,
+    cooldownNanoXOverridden: cooldownNanoXBaseline.isOverridden,
+    cadenceDaysOverridden: cadenceDaysBaseline.isOverridden,
+    hasLocalOverride,
+    canEditFlagParams: Boolean(feature && params),
+    handleBack,
+    handleReload,
+    handleToggleFeature,
+    handleTogglePersonalizedRecommendations,
+    handleToggleDeviceModel,
+    handleToggleAdvanced,
+    handleToggleModalEnabled,
+    handleSetOnboardingDaysAgo,
+    handleSetOnboardingPastCooldown,
+    handleClearOnboardingDate,
+    handleDecrementRetries,
+    handleIncrementRetries,
+    handleResetRetries,
+    handleSetLastSeenNow,
+    handleClearLastSeen,
+    setDraftKillThreshold,
+    handleApplyKillThreshold,
+    handleResetKillThreshold,
+    setDraftCooldownDefault,
+    handleApplyCooldownDefault,
+    handleResetCooldownDefault,
+    setDraftCooldownNanoS,
+    handleApplyCooldownNanoS,
+    handleResetCooldownNanoS,
+    setDraftCooldownNanoSP,
+    handleApplyCooldownNanoSP,
+    handleResetCooldownNanoSP,
+    setDraftCooldownNanoX,
+    handleApplyCooldownNanoX,
+    handleResetCooldownNanoX,
+    setDraftCadenceDays,
+    handleApplyCadenceDays,
+    handleResetCadenceDays,
+    handleResetAllFlagParams,
+  };
+}
+
+export type LargeScreenUpsellQaViewModel = ReturnType<typeof useLargeScreenUpsellQaViewModel>;

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/useLargeScreenUpsellQaViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/useLargeScreenUpsellQaViewModel.ts
@@ -21,10 +21,7 @@ import {
   mapDevicesModelListToUpsellInputs,
 } from "@features/flow-large-screen-upsell";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
-import {
-  DANGEROUSLY_setDevicesModelListForQa,
-  setSharePersonalizedRecommendations,
-} from "~/renderer/actions/settings";
+import { saveSettings, setSharePersonalizedRecommendations } from "~/renderer/actions/settings";
 import {
   devicesModelListSelector,
   sharePersonalizedRecommendationsSelector,
@@ -54,6 +51,10 @@ export const QA_TOUCHSCREEN_MODELS = [
   { id: DeviceModelId.europa, labelKey: "europa" },
   { id: DeviceModelId.apex, labelKey: "apex" },
 ] as const;
+
+function handleReload() {
+  window.api?.reloadRenderer();
+}
 
 export function useLargeScreenUpsellQaViewModel() {
   const navigate = useNavigate();
@@ -171,12 +172,15 @@ export function useLargeScreenUpsellQaViewModel() {
 
   const deviceModelIdForCooldown =
     "deviceModelId" in decision ? decision.deviceModelId : enabledSeenNanoModelIds[0];
-  const resolvedCooldownDays =
-    params == null
-      ? undefined
-      : deviceModelIdForCooldown != null
-        ? (params.cooldownDays[deviceModelIdForCooldown] ?? params.cooldownDays.default)
-        : params.cooldownDays.default;
+  let resolvedCooldownDays: number | undefined;
+  if (params == null) {
+    resolvedCooldownDays = undefined;
+  } else if (deviceModelIdForCooldown != null) {
+    resolvedCooldownDays =
+      params.cooldownDays[deviceModelIdForCooldown] ?? params.cooldownDays.default;
+  } else {
+    resolvedCooldownDays = params.cooldownDays.default;
+  }
 
   const cooldownPassed =
     resolvedCooldownDays != null &&
@@ -231,10 +235,6 @@ export function useLargeScreenUpsellQaViewModel() {
     navigate("/settings/developer");
   }
 
-  function handleReload() {
-    window.api?.reloadRenderer();
-  }
-
   function handleToggleFeature(enabled: boolean) {
     if (!feature) return;
     overrideFeature({ ...feature, enabled });
@@ -257,11 +257,15 @@ export function useLargeScreenUpsellQaViewModel() {
       const next = devicesModelList.includes(modelId)
         ? devicesModelList
         : [...devicesModelList, modelId];
-      dispatch(DANGEROUSLY_setDevicesModelListForQa(next));
+      dispatch(saveSettings({ devicesModelList: next }));
       return;
     }
 
-    dispatch(DANGEROUSLY_setDevicesModelListForQa(devicesModelList.filter(id => id !== modelId)));
+    dispatch(
+      saveSettings({
+        devicesModelList: devicesModelList.filter(id => id !== modelId),
+      }),
+    );
   }
 
   function handleSetOnboardingDaysAgo(days: number) {

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/utils.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/utils.test.ts
@@ -1,0 +1,208 @@
+import {
+  buildUpsellGateRows,
+  calendarDaysBetween,
+  daysAgoDate,
+  daysAgoIso,
+  isPostOnboardingCooldownPassed,
+  isThrottleGatePassed,
+  parseNonNegativeInteger,
+  pastCooldownOffsetDays,
+  draftDisplayFromEffective,
+  resolveParamBaseline,
+} from "./utils";
+
+describe("LargeScreenUpsellQa utils", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("parses non-negative integers and builds days-ago ISO", () => {
+    expect(parseNonNegativeInteger("3")).toBe(3);
+    expect(parseNonNegativeInteger("-1")).toBeUndefined();
+    expect(parseNonNegativeInteger("1.5")).toBeUndefined();
+
+    jest.useFakeTimers().setSystemTime(new Date("2026-07-17T08:00:00.000Z"));
+    expect(daysAgoIso(45)).toBe("2026-06-02T12:00:00.000Z");
+  });
+
+  it("pastCooldownOffsetDays mirrors cooldownDays so the gate passes (>=)", () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-07-17T12:00:00.000Z"));
+
+    expect(pastCooldownOffsetDays(30)).toBe(30);
+    expect(pastCooldownOffsetDays(0)).toBe(0);
+    expect(pastCooldownOffsetDays(-5)).toBe(0);
+
+    const now = new Date();
+    expect(
+      isPostOnboardingCooldownPassed({
+        onboardingDate: daysAgoDate(pastCooldownOffsetDays(30)),
+        cooldownDays: 30,
+        now,
+      }),
+    ).toBe(true);
+    expect(
+      isPostOnboardingCooldownPassed({
+        onboardingDate: daysAgoDate(pastCooldownOffsetDays(0)),
+        cooldownDays: 0,
+        now,
+      }),
+    ).toBe(true);
+  });
+
+  it("resolveParamBaseline prefers remote, else schema; flags override", () => {
+    expect(
+      resolveParamBaseline({
+        effective: 30,
+        schemaDefault: 30,
+        hasLocalOverride: false,
+      }),
+    ).toEqual({ baseline: "30", baselineValue: 30, isOverridden: false });
+
+    expect(
+      resolveParamBaseline({
+        effective: 45,
+        schemaDefault: 30,
+        hasLocalOverride: false,
+      }),
+    ).toEqual({ baseline: "45", baselineValue: 45, isOverridden: false });
+
+    expect(
+      resolveParamBaseline({
+        effective: 10,
+        schemaDefault: 30,
+        hasLocalOverride: true,
+      }),
+    ).toEqual({ baseline: "30", baselineValue: 30, isOverridden: true });
+
+    expect(
+      resolveParamBaseline({
+        effective: true,
+        schemaDefault: false,
+        hasLocalOverride: false,
+      }),
+    ).toEqual({ baseline: "on", baselineValue: true, isOverridden: false });
+
+    expect(
+      resolveParamBaseline({
+        effective: 5,
+        schemaDefault: undefined,
+        hasLocalOverride: true,
+      }),
+    ).toEqual({ baseline: "-", baselineValue: undefined, isOverridden: true });
+  });
+
+  it("draftDisplayFromEffective leaves input empty when unset or at baseline", () => {
+    expect(draftDisplayFromEffective(3, "3")).toBe("");
+    expect(draftDisplayFromEffective(undefined, "-")).toBe("");
+    expect(draftDisplayFromEffective(null, "30")).toBe("");
+    expect(draftDisplayFromEffective(10, "3")).toBe("10");
+    expect(draftDisplayFromEffective(0, "0")).toBe("");
+    expect(draftDisplayFromEffective(0, "30")).toBe("0");
+  });
+
+  it("mirrors post-onboarding cooldown: null date is treated as today", () => {
+    const now = new Date("2026-07-17T12:00:00.000Z");
+
+    expect(
+      isPostOnboardingCooldownPassed({
+        onboardingDate: null,
+        cooldownDays: 30,
+        now,
+      }),
+    ).toBe(false);
+
+    expect(
+      isPostOnboardingCooldownPassed({
+        onboardingDate: new Date("2026-06-01T12:00:00.000Z"),
+        cooldownDays: 30,
+        now,
+      }),
+    ).toBe(true);
+
+    expect(calendarDaysBetween(now, new Date("2026-07-10T12:00:00.000Z"))).toBe(7);
+  });
+
+  it("marks the first failing gate as blocking", () => {
+    const rows = buildUpsellGateRows({
+      isFeatureEnabled: true,
+      isModalEnabled: true,
+      hasSeenTouchscreenDevice: false,
+      hasNano: true,
+      isModelInAudience: true,
+      cooldownPassed: false,
+      throttlePassed: true,
+      blockingReason: "cooldown",
+    });
+
+    expect(rows.find(r => r.reason === "cooldown")).toEqual({
+      reason: "cooldown",
+      passes: false,
+      isBlocking: true,
+    });
+    expect(rows.filter(r => r.isBlocking)).toHaveLength(1);
+  });
+
+  it("evaluates throttle independently: high retries alone do not fail without lastSeen", () => {
+    const now = new Date("2026-07-17T12:00:00.000Z");
+
+    expect(
+      isThrottleGatePassed({
+        retries: 10,
+        lastSeenAt: null,
+        killThreshold: 3,
+        cadenceDays: 30,
+        now,
+      }),
+    ).toBe(true);
+
+    expect(
+      isThrottleGatePassed({
+        retries: 10,
+        lastSeenAt: Date.parse("2026-07-14T12:00:00.000Z"),
+        killThreshold: 3,
+        cadenceDays: 30,
+        now,
+      }),
+    ).toBe(false);
+
+    expect(
+      isThrottleGatePassed({
+        retries: 10,
+        lastSeenAt: Date.parse("2026-05-01T12:00:00.000Z"),
+        killThreshold: 3,
+        cadenceDays: 30,
+        now,
+      }),
+    ).toBe(true);
+
+    expect(
+      isThrottleGatePassed({
+        retries: 2,
+        lastSeenAt: Date.parse("2026-07-14T12:00:00.000Z"),
+        killThreshold: 3,
+        cadenceDays: 30,
+        now,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps throttle fail independent of other gates when building rows", () => {
+    const rows = buildUpsellGateRows({
+      isFeatureEnabled: true,
+      isModalEnabled: true,
+      hasSeenTouchscreenDevice: false,
+      hasNano: true,
+      isModelInAudience: true,
+      cooldownPassed: true,
+      throttlePassed: false,
+      blockingReason: "throttled",
+    });
+
+    expect(rows.find(r => r.reason === "throttled")).toEqual({
+      reason: "throttled",
+      passes: false,
+      isBlocking: true,
+    });
+    expect(rows.filter(r => r.passes)).toHaveLength(6);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/utils.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/utils.ts
@@ -1,0 +1,156 @@
+const MS_PER_DAY = 86_400_000;
+
+/** Noon UTC N calendar days ago. Stable QA presets (matches canvas / FF cooldown demos). */
+export function daysAgoDate(days: number): Date {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() - days);
+  date.setUTCHours(12, 0, 0, 0);
+  return date;
+}
+
+export function daysAgoIso(days: number): string {
+  return daysAgoDate(days).toISOString();
+}
+
+/** cooldownDays 0 → today (already elapsed). */
+export function pastCooldownOffsetDays(cooldownDays: number): number {
+  return Math.max(0, cooldownDays);
+}
+
+// No "Today" preset: Clear/legacy already means today.
+export const ONBOARDING_DATE_PRESETS = [
+  { id: "sevenDaysAgo", days: 7, labelKey: "onboardingSevenDaysAgo" },
+] as const;
+
+function displayParamValue(value: string | number | boolean | null | undefined): string {
+  if (value === undefined || value === null || value === "") return "-";
+  if (typeof value === "boolean") return value ? "on" : "off";
+  return String(value);
+}
+
+export function resolveParamBaseline<T extends string | number | boolean | null | undefined>({
+  effective,
+  schemaDefault,
+  hasLocalOverride,
+}: {
+  effective: T;
+  schemaDefault: T;
+  hasLocalOverride: boolean;
+}): { baseline: string; baselineValue: T; isOverridden: boolean } {
+  const defStr = displayParamValue(schemaDefault);
+  const effStr = displayParamValue(effective);
+
+  const useRemote = !hasLocalOverride && effStr !== "-" && effStr !== defStr;
+  const baselineValue = (useRemote ? effective : schemaDefault) as T;
+  const baseline = useRemote ? effStr : defStr;
+
+  return {
+    baseline,
+    baselineValue,
+    isOverridden: hasLocalOverride && effStr !== "-" && effStr !== baseline,
+  };
+}
+
+export function draftDisplayFromEffective(
+  effective: string | number | boolean | null | undefined,
+  baseline: string,
+): string {
+  const effStr = displayParamValue(effective);
+  if (effStr === "-" || effStr === baseline) return "";
+  return effStr;
+}
+
+export function parseNonNegativeInteger(value: string): number | undefined {
+  const trimmed = value.trim();
+  const parsed = Number(trimmed);
+  return trimmed !== "" && Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+/** Local calendar days; matches flow isCooldownElapsed. */
+export function calendarDaysBetween(later: Date, earlier: Date): number {
+  const startOfLocalDayUtc = (date: Date) =>
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate());
+
+  return Math.round((startOfLocalDayUtc(later) - startOfLocalDayUtc(earlier)) / MS_PER_DAY);
+}
+
+/**
+ * Mirrors getLargeScreenUpsellDecision: null onboardingDate is treated as `now`
+ * (legacy installs wait the full cooldown unless cooldownDays is 0).
+ */
+export function isPostOnboardingCooldownPassed({
+  onboardingDate,
+  cooldownDays,
+  now,
+}: {
+  onboardingDate: Date | null;
+  cooldownDays: number;
+  now: Date;
+}): boolean {
+  const elapsedSinceDate = onboardingDate ?? now;
+  return calendarDaysBetween(now, elapsedSinceDate) >= cooldownDays;
+}
+
+export type UpsellGateReason =
+  | "feature_disabled"
+  | "modal_disabled"
+  | "touchscreen_seen"
+  | "no_nano"
+  | "model_disabled"
+  | "cooldown"
+  | "throttled";
+
+export type UpsellGateRow = {
+  reason: UpsellGateReason;
+  passes: boolean;
+  isBlocking: boolean;
+};
+
+/** High retries alone do not fail this gate when lastSeenAt is null. */
+export function isThrottleGatePassed({
+  retries,
+  lastSeenAt,
+  killThreshold,
+  cadenceDays,
+  now,
+}: {
+  retries: number;
+  lastSeenAt: number | null;
+  killThreshold: number;
+  cadenceDays: number;
+  now: Date;
+}): boolean {
+  if (retries < killThreshold || lastSeenAt === null) return true;
+
+  return isPostOnboardingCooldownPassed({
+    onboardingDate: new Date(lastSeenAt),
+    cooldownDays: cadenceDays,
+    now,
+  });
+}
+
+export function buildUpsellGateRows(input: {
+  isFeatureEnabled: boolean;
+  isModalEnabled: boolean;
+  hasSeenTouchscreenDevice: boolean;
+  hasNano: boolean;
+  isModelInAudience: boolean;
+  cooldownPassed: boolean;
+  throttlePassed: boolean;
+  blockingReason?: UpsellGateReason;
+}): UpsellGateRow[] {
+  const rows: Array<{ reason: UpsellGateReason; passes: boolean }> = [
+    { reason: "feature_disabled", passes: input.isFeatureEnabled },
+    { reason: "modal_disabled", passes: input.isModalEnabled },
+    { reason: "touchscreen_seen", passes: !input.hasSeenTouchscreenDevice },
+    { reason: "no_nano", passes: input.hasNano },
+    { reason: "model_disabled", passes: input.isModelInAudience },
+    { reason: "cooldown", passes: input.cooldownPassed },
+    { reason: "throttled", passes: input.throttlePassed },
+  ];
+
+  return rows.map(row => ({
+    ...row,
+    isBlocking: input.blockingReason === row.reason,
+  }));
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/utils.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/utils.ts
@@ -1,5 +1,7 @@
 const MS_PER_DAY = 86_400_000;
 
+type DisplayParamValue = string | number | boolean | null | undefined;
+
 /** Noon UTC N calendar days ago. Stable QA presets (matches canvas / FF cooldown demos). */
 export function daysAgoDate(days: number): Date {
   const date = new Date();
@@ -22,13 +24,13 @@ export const ONBOARDING_DATE_PRESETS = [
   { id: "sevenDaysAgo", days: 7, labelKey: "onboardingSevenDaysAgo" },
 ] as const;
 
-function displayParamValue(value: string | number | boolean | null | undefined): string {
+function displayParamValue(value: DisplayParamValue): string {
   if (value === undefined || value === null || value === "") return "-";
   if (typeof value === "boolean") return value ? "on" : "off";
   return String(value);
 }
 
-export function resolveParamBaseline<T extends string | number | boolean | null | undefined>({
+export function resolveParamBaseline<T extends DisplayParamValue>({
   effective,
   schemaDefault,
   hasLocalOverride,
@@ -51,10 +53,7 @@ export function resolveParamBaseline<T extends string | number | boolean | null 
   };
 }
 
-export function draftDisplayFromEffective(
-  effective: string | number | boolean | null | undefined,
-  baseline: string,
-): string {
+export function draftDisplayFromEffective(effective: DisplayParamValue, baseline: string): string {
   const effStr = displayParamValue(effective);
   if (effStr === "-" || effStr === baseline) return "";
   return effStr;
@@ -106,6 +105,11 @@ export type UpsellGateRow = {
   isBlocking: boolean;
 };
 
+type UpsellGateCandidateRow = {
+  reason: UpsellGateReason;
+  passes: boolean;
+};
+
 /** High retries alone do not fail this gate when lastSeenAt is null. */
 export function isThrottleGatePassed({
   retries,
@@ -139,7 +143,7 @@ export function buildUpsellGateRows(input: {
   throttlePassed: boolean;
   blockingReason?: UpsellGateReason;
 }): UpsellGateRow[] {
-  const rows: Array<{ reason: UpsellGateReason; passes: boolean }> = [
+  const rows: UpsellGateCandidateRow[] = [
     { reason: "feature_disabled", passes: input.isFeatureEnabled },
     { reason: "modal_disabled", passes: input.isModalEnabled },
     { reason: "touchscreen_seen", passes: !input.hasSeenTouchscreenDevice },

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/index.tsx
@@ -7,6 +7,7 @@ import {
   useWalletV4TourDrawerViewModel,
   WalletV4TourDialog,
 } from "LLD/features/WalletV4Tour/Drawer";
+import { LargeScreenUpsellModalMount } from "LLD/features/LargeScreenUpsell";
 import { usePortfolioViewModel } from "./hooks/usePortfolioViewModel";
 import { PortfolioView } from "./PortfolioView";
 
@@ -33,6 +34,7 @@ const Portfolio = () => {
   return (
     <>
       <PortfolioView {...viewModel} />
+      <LargeScreenUpsellModalMount />
       <AnalyticsConsentDialog />
       {lwdProductTour?.enabled ? <ProductTourDialog {...productTourDialogViewModel} /> : null}
       <Q2TourDialog

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -69,7 +69,6 @@ import { themeSelector } from "./actions/general";
 import useCheckAccountWithFunds from "./components/PostOnboardingHub/logic/useCheckAccountWithFunds";
 import GlobalDialogs from "LLD/features/GlobalDialogs";
 import GenericAwarenessModalAppStart from "LLD/features/GenericAwarenessModal/GenericAwarenessModalAppStart";
-import { LargeScreenUpsellModalMount } from "LLD/features/LargeScreenUpsell";
 import GlobalDrawers from "LLD/features/GlobalDrawers";
 import { useShouldShowDeferredModals } from "~/renderer/hooks/useShouldShowDeferredModals";
 import {
@@ -320,7 +319,6 @@ export const MainAppLayout = () => {
         </>
       )}
       <GenericAwarenessModalAppStart />
-      <LargeScreenUpsellModalMount />
       <SyncNewAccounts priority={2} />
 
       <div

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -103,6 +103,13 @@ export const DANGEROUSLY_resetAnalyticsOptInStateForQa = () => (dispatch: AppDis
   );
 };
 
+/**
+ * @deprecated QA / developer tools only. Do not use in production flows.
+ * Replaces `devicesModelList` so debug screens can simulate audience gates (e.g. pretend Nano seen).
+ */
+export const DANGEROUSLY_setDevicesModelListForQa = (devicesModelList: DeviceModelId[]) =>
+  saveSettings({ devicesModelList });
+
 export const setAutoLockTimeout = (autoLockTimeout: number) =>
   saveSettings({
     autoLockTimeout,

--- a/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
@@ -207,11 +207,10 @@ describe("DBMiddleware - largeScreenUpsellModal branch", () => {
     });
 
     expect(mockedSetKey).toHaveBeenCalledTimes(1);
-    expect(mockedSetKey).toHaveBeenCalledWith(
-      "app",
-      LARGE_SCREEN_UPSELL_MODAL,
-      state.largeScreenUpsellModal,
-    );
+    expect(mockedSetKey).toHaveBeenCalledWith("app", LARGE_SCREEN_UPSELL_MODAL, {
+      retries: 2,
+      lastSeenAt: 1_720_000_000_000,
+    });
   });
 });
 

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -28,7 +28,7 @@ import { marketStoreSelector } from "../reducers/market";
 import { marketBannerStoreSelector } from "../reducers/marketBanner";
 import {
   LARGE_SCREEN_UPSELL_MODAL,
-  largeScreenUpsellModalSelector,
+  persistedLargeScreenUpsellModalSelector,
 } from "@domain/entity-large-screen-upsell-modal";
 import { knownDevicesStoreSelector } from "../reducers/knownDevices";
 import { exportIdentitiesForPersistence } from "@domain/entity-client-identity";
@@ -126,7 +126,7 @@ const DBMiddleware: Middleware<object, State> = store => next => action => {
   if (action.type.startsWith(`${LARGE_SCREEN_UPSELL_MODAL}/`)) {
     const res = next(action);
     const state = store.getState();
-    setKey("app", LARGE_SCREEN_UPSELL_MODAL, largeScreenUpsellModalSelector(state));
+    setKey("app", LARGE_SCREEN_UPSELL_MODAL, persistedLargeScreenUpsellModalSelector(state));
     return res;
   }
 

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/LargeScreenUpsellDevTool/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/LargeScreenUpsellDevTool/index.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import { useNavigate } from "react-router";
+import { SettingsSectionRow } from "~/renderer/screens/settings/SettingsSection";
+
+const COPY = {
+  rowTitle: "Large-screen upsell (QA)",
+  rowDesc: "Debug would-show, gates, and frequency for the large-screen upsell.",
+  open: "Open",
+} as const;
+
+export default function LargeScreenUpsellDevTool() {
+  const navigate = useNavigate();
+
+  return (
+    <SettingsSectionRow title={COPY.rowTitle} desc={COPY.rowDesc}>
+      <Button
+        size="sm"
+        appearance="accent"
+        onClick={() => navigate("/settings/developer/large-screen-upsell-qa")}
+      >
+        {COPY.open}
+      </Button>
+    </SettingsSectionRow>
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/index.tsx
@@ -51,7 +51,7 @@ import DeviceActionContentDevScreen from "./DeviceActionContentDevTool/screens/D
 import DeviceIntentExecutorDevTool from "./DeviceIntentExecutorDevTool";
 import DeviceIntentExecutorDevScreen from "./DeviceIntentExecutorDevTool/screens/DeviceIntentExecutorDevScreen";
 import LargeScreenUpsellDevTool from "./LargeScreenUpsellDevTool";
-import LargeScreenUpsellQa from "LLD/features/LargeScreenUpsell/screens/LargeScreenUpsellQa";
+import { LargeScreenUpsellQa } from "LLD/features/LargeScreenUpsell";
 
 const Default = () => {
   const { t } = useTranslation();

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/index.tsx
@@ -50,6 +50,8 @@ import DeviceActionContentDevTool from "./DeviceActionContentDevTool";
 import DeviceActionContentDevScreen from "./DeviceActionContentDevTool/screens/DeviceActionContentDevScreen";
 import DeviceIntentExecutorDevTool from "./DeviceIntentExecutorDevTool";
 import DeviceIntentExecutorDevScreen from "./DeviceIntentExecutorDevTool/screens/DeviceIntentExecutorDevScreen";
+import LargeScreenUpsellDevTool from "./LargeScreenUpsellDevTool";
+import LargeScreenUpsellQa from "LLD/features/LargeScreenUpsell/screens/LargeScreenUpsellQa";
 
 const Default = () => {
   const { t } = useTranslation();
@@ -157,6 +159,7 @@ const Default = () => {
       <FeaturesAndFlowsDevTool />
       <AnalyticsConsentOptInDevTool />
       <GenericAwarenessModalDevTool />
+      <LargeScreenUpsellDevTool />
       <InfoStateDevTool />
       <DeviceActionContentDevTool />
       <DeviceIntentExecutorDevTool />
@@ -174,6 +177,7 @@ const SectionDeveloper = () => (
       <Route path="custom-locksscreen-assets" element={<CustomLockScreenAssets />} />
       <Route path="analytics-consent-opt-in-qa" element={<AnalyticsConsentOptInDevScreen />} />
       <Route path="generic-awareness-modal-qa" element={<GenericAwarenessModalDevScreen />} />
+      <Route path="large-screen-upsell-qa" element={<LargeScreenUpsellQa />} />
       <Route path="info-state-qa" element={<InfoStateDevScreen />} />
       <Route path="device-action-content-qa" element={<DeviceActionContentDevScreen />} />
       <Route path="device-intent-executor-qa" element={<DeviceIntentExecutorDevScreen />} />

--- a/apps/ledger-live-desktop/src/renderer/storage.ts
+++ b/apps/ledger-live-desktop/src/renderer/storage.ts
@@ -21,7 +21,7 @@ import { ExportedWalletState } from "@ledgerhq/live-wallet/store";
 import type { PersistedCAL } from "@domain/api-currency-token";
 import type { PersistedIdentities } from "@domain/entity-client-identity";
 import type { FeatureFlagsState } from "@shared/feature-flags";
-import type { LargeScreenUpsellModalState } from "@domain/entity-large-screen-upsell-modal";
+import type { RestorableLargeScreenUpsellModalState } from "@domain/entity-large-screen-upsell-modal";
 
 /*
   This file serve as an interface for the RPC binding to the main thread that now manage the config file.
@@ -69,7 +69,7 @@ type DatabaseValues = {
   ptx: {
     lastScreen: string;
   };
-  largeScreenUpsellModal: LargeScreenUpsellModalState;
+  largeScreenUpsellModal: RestorableLargeScreenUpsellModalState;
 };
 
 // Infers the type seen from the user side (non-raw).

--- a/domain/entity/large-screen-upsell-modal/src/schema.mock.ts
+++ b/domain/entity/large-screen-upsell-modal/src/schema.mock.ts
@@ -6,6 +6,7 @@ export function mockLargeScreenUpsellModalState(
   return {
     retries: 0,
     lastSeenAt: null,
+    session: "ready",
     ...overrides,
   };
 }
@@ -16,6 +17,7 @@ export function mockSeenLargeScreenUpsellModalState(
   return mockLargeScreenUpsellModalState({
     retries: 1,
     lastSeenAt: Date.parse("2026-07-01T12:00:00.000Z"),
+    session: "dismissed",
     ...overrides,
   });
 }

--- a/domain/entity/large-screen-upsell-modal/src/schema.test.ts
+++ b/domain/entity/large-screen-upsell-modal/src/schema.test.ts
@@ -1,6 +1,7 @@
 import {
   defaultLargeScreenUpsellModalState,
   LargeScreenUpsellModalStateSchema,
+  MAX_DATE_MS,
   RestorableLargeScreenUpsellModalStateSchema,
 } from "./schema";
 
@@ -19,7 +20,7 @@ describe("LargeScreenUpsellModalStateSchema", () => {
     },
     {
       retries: Number.MAX_SAFE_INTEGER,
-      lastSeenAt: Number.MAX_SAFE_INTEGER,
+      lastSeenAt: MAX_DATE_MS,
       session: "blockedByCompeting" as const,
     },
   ])("accepts $retries retries with lastSeenAt $lastSeenAt", state => {
@@ -33,6 +34,8 @@ describe("LargeScreenUpsellModalStateSchema", () => {
     { field: "retries", value: "2" },
     { field: "lastSeenAt", value: -1 },
     { field: "lastSeenAt", value: 1.5 },
+    { field: "lastSeenAt", value: MAX_DATE_MS + 1 },
+    { field: "lastSeenAt", value: Number.MAX_SAFE_INTEGER },
     { field: "lastSeenAt", value: Number.MAX_SAFE_INTEGER + 1 },
     { field: "lastSeenAt", value: "2026-07-01" },
     { field: "session", value: "pending" },

--- a/domain/entity/large-screen-upsell-modal/src/schema.test.ts
+++ b/domain/entity/large-screen-upsell-modal/src/schema.test.ts
@@ -4,11 +4,24 @@ import {
   RestorableLargeScreenUpsellModalStateSchema,
 } from "./schema";
 
+const restorableDefaults = {
+  retries: defaultLargeScreenUpsellModalState.retries,
+  lastSeenAt: defaultLargeScreenUpsellModalState.lastSeenAt,
+};
+
 describe("LargeScreenUpsellModalStateSchema", () => {
   it.each([
-    { retries: 0, lastSeenAt: null },
-    { retries: 3, lastSeenAt: Date.parse("2026-07-01T12:00:00.000Z") },
-    { retries: Number.MAX_SAFE_INTEGER, lastSeenAt: Number.MAX_SAFE_INTEGER },
+    { retries: 0, lastSeenAt: null, session: "ready" as const },
+    {
+      retries: 3,
+      lastSeenAt: Date.parse("2026-07-01T12:00:00.000Z"),
+      session: "dismissed" as const,
+    },
+    {
+      retries: Number.MAX_SAFE_INTEGER,
+      lastSeenAt: Number.MAX_SAFE_INTEGER,
+      session: "blockedByCompeting" as const,
+    },
   ])("accepts $retries retries with lastSeenAt $lastSeenAt", state => {
     expect(LargeScreenUpsellModalStateSchema.parse(state)).toEqual(state);
   });
@@ -22,8 +35,15 @@ describe("LargeScreenUpsellModalStateSchema", () => {
     { field: "lastSeenAt", value: 1.5 },
     { field: "lastSeenAt", value: Number.MAX_SAFE_INTEGER + 1 },
     { field: "lastSeenAt", value: "2026-07-01" },
+    { field: "session", value: "pending" },
+    { field: "session", value: true },
   ])("rejects $field of $value", ({ field, value }) => {
-    const state = { retries: 0, lastSeenAt: null, [field]: value };
+    const state = {
+      retries: 0,
+      lastSeenAt: null,
+      session: "ready" as const,
+      [field]: value,
+    };
 
     expect(() => LargeScreenUpsellModalStateSchema.parse(state)).toThrow();
   });
@@ -38,8 +58,21 @@ describe("RestorableLargeScreenUpsellModalStateSchema", () => {
     "falls back to defaults given the non-object payload %p",
     payload => {
       expect(RestorableLargeScreenUpsellModalStateSchema.parse(payload)).toEqual(
-        defaultLargeScreenUpsellModalState,
+        restorableDefaults,
       );
     },
   );
+
+  it("strips ephemeral session from a persisted payload", () => {
+    expect(
+      RestorableLargeScreenUpsellModalStateSchema.parse({
+        retries: 2,
+        lastSeenAt: Date.parse("2026-07-01T12:00:00.000Z"),
+        session: "dismissed",
+      }),
+    ).toEqual({
+      retries: 2,
+      lastSeenAt: Date.parse("2026-07-01T12:00:00.000Z"),
+    });
+  });
 });

--- a/domain/entity/large-screen-upsell-modal/src/schema.ts
+++ b/domain/entity/large-screen-upsell-modal/src/schema.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+// Max JS Date timestamp (ECMA-262): +/-8.64e15 ms. Values above this yield an Invalid Date.
+export const MAX_DATE_MS = 8_640_000_000_000_000;
+
 export const LargeScreenUpsellModalSessionSchema = z.enum([
   "ready",
   "dismissed",
@@ -10,7 +13,7 @@ export type LargeScreenUpsellModalSession = z.infer<typeof LargeScreenUpsellModa
 
 export const LargeScreenUpsellModalStateSchema = z.object({
   retries: z.number().int().nonnegative().safe(),
-  lastSeenAt: z.number().int().nonnegative().safe().nullable(),
+  lastSeenAt: z.number().int().nonnegative().max(MAX_DATE_MS).safe().nullable(),
   session: LargeScreenUpsellModalSessionSchema,
 });
 

--- a/domain/entity/large-screen-upsell-modal/src/schema.ts
+++ b/domain/entity/large-screen-upsell-modal/src/schema.ts
@@ -1,16 +1,27 @@
 import { z } from "zod";
 
+export const LargeScreenUpsellModalSessionSchema = z.enum([
+  "ready",
+  "dismissed",
+  "blockedByCompeting",
+]);
+
+export type LargeScreenUpsellModalSession = z.infer<typeof LargeScreenUpsellModalSessionSchema>;
+
 export const LargeScreenUpsellModalStateSchema = z.object({
   retries: z.number().int().nonnegative().safe(),
   lastSeenAt: z.number().int().nonnegative().safe().nullable(),
+  session: LargeScreenUpsellModalSessionSchema,
 });
 
 export const defaultLargeScreenUpsellModalState: z.infer<typeof LargeScreenUpsellModalStateSchema> =
   {
     retries: 0,
     lastSeenAt: null,
+    session: "ready",
   };
 
+/** Persisted fields only — session is ephemeral. */
 export const RestorableLargeScreenUpsellModalStateSchema = z
   .object({
     retries: LargeScreenUpsellModalStateSchema.shape.retries.catch(
@@ -20,4 +31,12 @@ export const RestorableLargeScreenUpsellModalStateSchema = z
       defaultLargeScreenUpsellModalState.lastSeenAt,
     ),
   })
-  .catch(defaultLargeScreenUpsellModalState);
+  .catch({
+    retries: defaultLargeScreenUpsellModalState.retries,
+    lastSeenAt: defaultLargeScreenUpsellModalState.lastSeenAt,
+  });
+
+export type RestorableLargeScreenUpsellModalState = Pick<
+  z.infer<typeof LargeScreenUpsellModalStateSchema>,
+  "retries" | "lastSeenAt"
+>;

--- a/domain/entity/large-screen-upsell-modal/src/slice.test.ts
+++ b/domain/entity/large-screen-upsell-modal/src/slice.test.ts
@@ -80,7 +80,7 @@ describe("largeScreenUpsellModal", () => {
       {
         description: "a lastSeenAt above the JS Date range",
         payload: { retries: 2, lastSeenAt: Number.MAX_SAFE_INTEGER },
-        expected: withSession({ retries: 2, lastSeenAt: Number.MAX_SAFE_INTEGER }),
+        expected: withSession({ retries: 2, lastSeenAt: null }),
       },
       {
         description: "an unsafe integer lastSeenAt",

--- a/domain/entity/large-screen-upsell-modal/src/slice.test.ts
+++ b/domain/entity/large-screen-upsell-modal/src/slice.test.ts
@@ -1,16 +1,31 @@
 import {
   initialState,
+  isStorableTimestamp,
   largeScreenUpsellModalSlice,
   lastSeenUpsellModalSelector,
+  markBlockedByCompeting,
+  markDismissed,
+  persistedLargeScreenUpsellModalSelector,
   recordUpsellModalDisplay,
   restoreLargeScreenUpsellModalState,
   resetUpsellModalRetries,
   retriesUpsellModalSelector,
+  sessionSelector,
+  setLastSeenUpsellModal,
+  setUpsellModalRetries,
 } from "./slice";
 import type { LargeScreenUpsellModalState } from "./types";
 
 const reducer = largeScreenUpsellModalSlice.reducer;
 const lastSeenAt = Date.parse("2026-07-01T12:00:00.000Z");
+
+const withSession = (
+  state: Pick<LargeScreenUpsellModalState, "retries" | "lastSeenAt">,
+  session: LargeScreenUpsellModalState["session"] = "ready",
+): LargeScreenUpsellModalState => ({
+  ...state,
+  session,
+});
 
 describe("largeScreenUpsellModal", () => {
   afterEach(() => {
@@ -30,42 +45,47 @@ describe("largeScreenUpsellModal", () => {
       {
         description: "a valid persisted state",
         payload: { retries: 2, lastSeenAt },
-        expected: { retries: 2, lastSeenAt },
+        expected: withSession({ retries: 2, lastSeenAt }),
       },
       {
         description: "a missing lastSeenAt",
         payload: { retries: 2 },
-        expected: { retries: 2, lastSeenAt: null },
+        expected: withSession({ retries: 2, lastSeenAt: null }),
       },
       {
         description: "a non-integer retries count",
         payload: { retries: 2.7, lastSeenAt },
-        expected: { retries: 0, lastSeenAt },
+        expected: withSession({ retries: 0, lastSeenAt }),
       },
       {
         description: "a negative retries count",
         payload: { retries: -1, lastSeenAt },
-        expected: { retries: 0, lastSeenAt },
+        expected: withSession({ retries: 0, lastSeenAt }),
       },
       {
         description: "an unsafe integer retries count",
         payload: { retries: Number.MAX_SAFE_INTEGER + 1, lastSeenAt },
-        expected: { retries: 0, lastSeenAt },
+        expected: withSession({ retries: 0, lastSeenAt }),
       },
       {
         description: "a non-integer lastSeenAt",
         payload: { retries: 2, lastSeenAt: 2.7 },
-        expected: { retries: 2, lastSeenAt: null },
+        expected: withSession({ retries: 2, lastSeenAt: null }),
       },
       {
         description: "a negative lastSeenAt",
         payload: { retries: 2, lastSeenAt: -1 },
-        expected: { retries: 2, lastSeenAt: null },
+        expected: withSession({ retries: 2, lastSeenAt: null }),
+      },
+      {
+        description: "a lastSeenAt above the JS Date range",
+        payload: { retries: 2, lastSeenAt: Number.MAX_SAFE_INTEGER },
+        expected: withSession({ retries: 2, lastSeenAt: Number.MAX_SAFE_INTEGER }),
       },
       {
         description: "an unsafe integer lastSeenAt",
         payload: { retries: 2, lastSeenAt: Number.MAX_SAFE_INTEGER + 1 },
-        expected: { retries: 2, lastSeenAt: null },
+        expected: withSession({ retries: 2, lastSeenAt: null }),
       },
       {
         description: "an entirely malformed payload",
@@ -75,9 +95,22 @@ describe("largeScreenUpsellModal", () => {
     ])("falls back to defaults given $description", ({ payload, expected }) => {
       expect(reducer(undefined, restoreLargeScreenUpsellModalState(payload))).toEqual(expected);
     });
+
+    it("does not restore ephemeral session from a persisted payload", () => {
+      expect(
+        reducer(
+          undefined,
+          restoreLargeScreenUpsellModalState({
+            retries: 2,
+            lastSeenAt,
+            session: "dismissed",
+          }),
+        ),
+      ).toEqual(withSession({ retries: 2, lastSeenAt }));
+    });
   });
 
-  it("increments retries and refreshes the last display timestamp", () => {
+  it("increments retries and refreshes the last display timestamp without changing session", () => {
     const firstDisplayTimestamp = lastSeenAt;
     const secondDisplayTimestamp = Date.parse("2026-07-02T12:00:00.000Z");
 
@@ -85,34 +118,107 @@ describe("largeScreenUpsellModal", () => {
       initialState,
       recordUpsellModalDisplay(firstDisplayTimestamp),
     );
-    expect(firstDisplayState).toEqual({ retries: 1, lastSeenAt: firstDisplayTimestamp });
+    expect(firstDisplayState).toEqual(
+      withSession({ retries: 1, lastSeenAt: firstDisplayTimestamp }),
+    );
 
-    expect(reducer(firstDisplayState, recordUpsellModalDisplay(secondDisplayTimestamp))).toEqual({
-      retries: 2,
-      lastSeenAt: secondDisplayTimestamp,
-    });
+    expect(reducer(firstDisplayState, recordUpsellModalDisplay(secondDisplayTimestamp))).toEqual(
+      withSession({ retries: 2, lastSeenAt: secondDisplayTimestamp }),
+    );
   });
 
   it("defaults the display timestamp to now", () => {
     jest.useFakeTimers().setSystemTime(new Date("2026-07-01T12:00:00.000Z"));
 
-    expect(reducer(initialState, recordUpsellModalDisplay())).toEqual({
-      retries: 1,
-      lastSeenAt,
-    });
+    expect(reducer(initialState, recordUpsellModalDisplay())).toEqual(
+      withSession({ retries: 1, lastSeenAt }),
+    );
   });
 
-  it("resets retries without clearing the last display timestamp", () => {
-    expect(reducer({ retries: 3, lastSeenAt }, resetUpsellModalRetries())).toEqual({
-      retries: 0,
-      lastSeenAt,
-    });
+  it("marks session as dismissed", () => {
+    expect(reducer(initialState, markDismissed())).toEqual(
+      withSession({ retries: 0, lastSeenAt: null }, "dismissed"),
+    );
+  });
+
+  it("marks session as blockedByCompeting only while ready", () => {
+    expect(reducer(initialState, markBlockedByCompeting())).toEqual(
+      withSession({ retries: 0, lastSeenAt: null }, "blockedByCompeting"),
+    );
+
+    expect(
+      reducer(withSession({ retries: 0, lastSeenAt: null }, "dismissed"), markBlockedByCompeting()),
+    ).toEqual(withSession({ retries: 0, lastSeenAt: null }, "dismissed"));
+  });
+
+  it("resets retries without clearing the last display timestamp or session", () => {
+    expect(
+      reducer(withSession({ retries: 3, lastSeenAt }, "dismissed"), resetUpsellModalRetries()),
+    ).toEqual(withSession({ retries: 0, lastSeenAt }, "dismissed"));
+  });
+
+  it("sets the retry count to an arbitrary non-negative integer", () => {
+    expect(reducer(withSession({ retries: 0, lastSeenAt }), setUpsellModalRetries(5))).toEqual(
+      withSession({ retries: 5, lastSeenAt }),
+    );
+  });
+
+  it("ignores invalid retry counts", () => {
+    const state = withSession({ retries: 3, lastSeenAt: null });
+
+    for (const invalid of [-1, 2.7, NaN]) {
+      expect(reducer(state, setUpsellModalRetries(invalid))).toEqual(state);
+    }
+  });
+
+  it("sets the last display timestamp to an arbitrary value or null", () => {
+    expect(
+      reducer(withSession({ retries: 1, lastSeenAt: null }), setLastSeenUpsellModal(lastSeenAt)),
+    ).toEqual(withSession({ retries: 1, lastSeenAt }));
+
+    expect(reducer(withSession({ retries: 1, lastSeenAt }), setLastSeenUpsellModal(null))).toEqual(
+      withSession({ retries: 1, lastSeenAt: null }),
+    );
+  });
+
+  it("ignores invalid last display timestamps", () => {
+    const state = withSession({ retries: 1, lastSeenAt });
+
+    for (const invalid of [-1, 2.7, NaN, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER + 1]) {
+      expect(reducer(state, setLastSeenUpsellModal(invalid))).toEqual(state);
+    }
+  });
+
+  it("accepts only non-negative timestamps within the JS Date range", () => {
+    const MAX_DATE_MS = 8.64e15;
+
+    expect(isStorableTimestamp(0)).toBe(true);
+    expect(isStorableTimestamp(lastSeenAt)).toBe(true);
+    expect(isStorableTimestamp(MAX_DATE_MS)).toBe(true);
+
+    for (const invalid of [
+      -1,
+      2.7,
+      NaN,
+      MAX_DATE_MS + 1,
+      Number.MAX_SAFE_INTEGER,
+      Number.MAX_SAFE_INTEGER + 1,
+    ]) {
+      expect(isStorableTimestamp(invalid)).toBe(false);
+    }
   });
 
   it("selects raw values from root state", () => {
-    const state = { largeScreenUpsellModal: { retries: 3, lastSeenAt } };
+    const state = {
+      largeScreenUpsellModal: withSession({ retries: 3, lastSeenAt }, "dismissed"),
+    };
 
     expect(retriesUpsellModalSelector(state)).toBe(3);
     expect(lastSeenUpsellModalSelector(state)).toBe(lastSeenAt);
+    expect(sessionSelector(state)).toBe("dismissed");
+    expect(persistedLargeScreenUpsellModalSelector(state)).toEqual({
+      retries: 3,
+      lastSeenAt,
+    });
   });
 });

--- a/domain/entity/large-screen-upsell-modal/src/slice.test.ts
+++ b/domain/entity/large-screen-upsell-modal/src/slice.test.ts
@@ -14,6 +14,7 @@ import {
   setLastSeenUpsellModal,
   setUpsellModalRetries,
 } from "./slice";
+import { MAX_DATE_MS } from "./schema";
 import type { LargeScreenUpsellModalState } from "./types";
 
 const reducer = largeScreenUpsellModalSlice.reducer;
@@ -190,8 +191,6 @@ describe("largeScreenUpsellModal", () => {
   });
 
   it("accepts only non-negative timestamps within the JS Date range", () => {
-    const MAX_DATE_MS = 8.64e15;
-
     expect(isStorableTimestamp(0)).toBe(true);
     expect(isStorableTimestamp(lastSeenAt)).toBe(true);
     expect(isStorableTimestamp(MAX_DATE_MS)).toBe(true);

--- a/domain/entity/large-screen-upsell-modal/src/slice.ts
+++ b/domain/entity/large-screen-upsell-modal/src/slice.ts
@@ -3,10 +3,17 @@ import { LARGE_SCREEN_UPSELL_MODAL } from "./constants";
 import {
   defaultLargeScreenUpsellModalState,
   RestorableLargeScreenUpsellModalStateSchema,
+  type RestorableLargeScreenUpsellModalState,
 } from "./schema";
 import type { LargeScreenUpsellModalState } from "./types";
 
 export const initialState: LargeScreenUpsellModalState = defaultLargeScreenUpsellModalState;
+
+// Max JS Date timestamp (ECMA-262): ±8.64e15 ms. Values above this yield an Invalid Date.
+const MAX_DATE_MS = 8_640_000_000_000_000;
+
+export const isStorableTimestamp = (value: number): boolean =>
+  Number.isSafeInteger(value) && value >= 0 && value <= MAX_DATE_MS;
 
 export const largeScreenUpsellModalSlice = createSlice({
   name: LARGE_SCREEN_UPSELL_MODAL,
@@ -30,25 +37,60 @@ export const largeScreenUpsellModalSlice = createSlice({
         payload: timestamp,
       }),
     },
+    markDismissed: state => {
+      state.session = "dismissed";
+    },
+    markBlockedByCompeting: state => {
+      if (state.session === "ready") {
+        state.session = "blockedByCompeting";
+      }
+    },
     resetUpsellModalRetries: state => {
       state.retries = initialState.retries;
+    },
+    setUpsellModalRetries: (state, action: PayloadAction<number>) => {
+      const retries = action.payload;
+      if (Number.isSafeInteger(retries) && retries >= 0) {
+        state.retries = retries;
+      }
+    },
+    setLastSeenUpsellModal: (state, action: PayloadAction<number | null>) => {
+      const lastSeenAt = action.payload;
+      if (lastSeenAt === null) {
+        state.lastSeenAt = null;
+        return;
+      }
+      if (isStorableTimestamp(lastSeenAt)) {
+        state.lastSeenAt = lastSeenAt;
+      }
     },
   },
   selectors: {
     largeScreenUpsellModalSelector: state => state,
+    persistedLargeScreenUpsellModalSelector: (state): RestorableLargeScreenUpsellModalState => ({
+      retries: state.retries,
+      lastSeenAt: state.lastSeenAt,
+    }),
     retriesUpsellModalSelector: state => state.retries,
     lastSeenUpsellModalSelector: state => state.lastSeenAt,
+    sessionSelector: state => state.session,
   },
 });
 
 export const {
   restoreLargeScreenUpsellModalState,
   recordUpsellModalDisplay,
+  markDismissed,
+  markBlockedByCompeting,
   resetUpsellModalRetries,
+  setUpsellModalRetries,
+  setLastSeenUpsellModal,
 } = largeScreenUpsellModalSlice.actions;
 
 export const {
   largeScreenUpsellModalSelector,
+  persistedLargeScreenUpsellModalSelector,
   retriesUpsellModalSelector,
   lastSeenUpsellModalSelector,
+  sessionSelector,
 } = largeScreenUpsellModalSlice.selectors;

--- a/domain/entity/large-screen-upsell-modal/src/slice.ts
+++ b/domain/entity/large-screen-upsell-modal/src/slice.ts
@@ -2,15 +2,13 @@ import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import { LARGE_SCREEN_UPSELL_MODAL } from "./constants";
 import {
   defaultLargeScreenUpsellModalState,
+  MAX_DATE_MS,
   RestorableLargeScreenUpsellModalStateSchema,
   type RestorableLargeScreenUpsellModalState,
 } from "./schema";
 import type { LargeScreenUpsellModalState } from "./types";
 
 export const initialState: LargeScreenUpsellModalState = defaultLargeScreenUpsellModalState;
-
-// Max JS Date timestamp (ECMA-262): ±8.64e15 ms. Values above this yield an Invalid Date.
-const MAX_DATE_MS = 8_640_000_000_000_000;
 
 export const isStorableTimestamp = (value: number): boolean =>
   Number.isSafeInteger(value) && value >= 0 && value <= MAX_DATE_MS;

--- a/features/flow/large-screen-upsell/src/index.ts
+++ b/features/flow/large-screen-upsell/src/index.ts
@@ -6,6 +6,7 @@ export * from "./utils/upsellContent";
 export * from "./utils/mapDevicesModelListToUpsellInputs";
 export { LARGE_SCREEN_UPSELL_IMAGES } from "./assets";
 export { LargeScreenUpsellModal } from "./screens/LargeScreenUpsellModal";
+export { LargeScreenUpsellModalView } from "./screens/LargeScreenUpsellModal/LargeScreenUpsellModalView.web";
 export type { LargeScreenUpsellModalProps } from "./screens/LargeScreenUpsellModal";
 export type { LargeScreenUpsellModalViewModel } from "./screens/LargeScreenUpsellModal/types";
 export type { UseLargeScreenUpsellModalViewModelInput } from "./screens/LargeScreenUpsellModal/useLargeScreenUpsellModalViewModel";

--- a/features/flow/large-screen-upsell/src/screens/LargeScreenUpsellModal/useLargeScreenUpsellModalViewModel.ts
+++ b/features/flow/large-screen-upsell/src/screens/LargeScreenUpsellModal/useLargeScreenUpsellModalViewModel.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDispatch } from "react-redux";
 import { useFeature } from "@features/platform-feature-flags";
 import {
+  markDismissed,
   recordUpsellModalDisplay,
   resetUpsellModalRetries,
 } from "@domain/entity-large-screen-upsell-modal";
@@ -99,9 +100,10 @@ export function useLargeScreenUpsellModalViewModel({
 
       hasHandledCurrentModalInteractionRef.current = true;
       analytics?.onDismissed(method);
+      dispatch(markDismissed());
       setIsOpen(false);
     },
-    [analytics],
+    [analytics, dispatch],
   );
 
   const onCtaPress = useCallback(() => {
@@ -118,6 +120,7 @@ export function useLargeScreenUpsellModalViewModel({
       openUrl(link);
     }
     dispatch(resetUpsellModalRetries());
+    dispatch(markDismissed());
     setIsOpen(false);
   }, [analytics, content?.primaryButtonLink, dispatch, openUrl]);
 

--- a/features/flow/large-screen-upsell/src/types.ts
+++ b/features/flow/large-screen-upsell/src/types.ts
@@ -24,7 +24,7 @@ export type LargeScreenUpsellUserState = {
   seenNanoModelIds: NanoDeviceModelId[];
   hasSeenTouchscreenDevice: boolean;
   onboardingDate: Date | null;
-  frequency: LargeScreenUpsellModalState;
+  frequency: Pick<LargeScreenUpsellModalState, "retries" | "lastSeenAt">;
 };
 
 export type LargeScreenUpsellContext = {

--- a/features/flow/large-screen-upsell/src/types.ts
+++ b/features/flow/large-screen-upsell/src/types.ts
@@ -1,4 +1,4 @@
-import type { LargeScreenUpsellModalState } from "@domain/entity-large-screen-upsell-modal";
+import type { RestorableLargeScreenUpsellModalState } from "@domain/entity-large-screen-upsell-modal";
 import type { Features } from "@shared/feature-flags";
 
 type LargeScreenUpsellParams = NonNullable<Features["largeScreenUpsell"]["params"]>;
@@ -24,7 +24,7 @@ export type LargeScreenUpsellUserState = {
   seenNanoModelIds: NanoDeviceModelId[];
   hasSeenTouchscreenDevice: boolean;
   onboardingDate: Date | null;
-  frequency: Pick<LargeScreenUpsellModalState, "retries" | "lastSeenAt">;
+  frequency: RestorableLargeScreenUpsellModalState;
 };
 
 export type LargeScreenUpsellContext = {

--- a/libs/live-engagement/src/largeScreenUpsellModal.test.ts
+++ b/libs/live-engagement/src/largeScreenUpsellModal.test.ts
@@ -83,12 +83,7 @@ describe("largeScreenUpsellModal", () => {
   });
 
   it("restores only non-negative timestamps representable by JS Date", () => {
-    const invalidLastSeenAtValues = [
-      2.7,
-      -1,
-      Number.MAX_SAFE_INTEGER,
-      Number.MAX_SAFE_INTEGER + 1,
-    ];
+    const invalidLastSeenAtValues = [2.7, -1, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER + 1];
 
     for (const lastSeenAt of invalidLastSeenAtValues) {
       expect(
@@ -193,7 +188,10 @@ describe("largeScreenUpsellModal", () => {
     const lastSeenAt = Date.parse("2026-07-01T12:00:00.000Z");
 
     expect(
-      largeScreenUpsellModalReducer({ retries: 1, lastSeenAt: null }, setLastSeenUpsellModal(lastSeenAt)),
+      largeScreenUpsellModalReducer(
+        { retries: 1, lastSeenAt: null },
+        setLastSeenUpsellModal(lastSeenAt),
+      ),
     ).toEqual({
       retries: 1,
       lastSeenAt,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Partial — domain/utils/integration tests; UI is manual._
- [x] **Impact of the changes:**
  - Developer → Large-screen upsell QA
  - Live would-show + gates readout
  - FF / Nano / frequency / onboarding overrides
  - Reload → real dialog on portfolio only
  - Personalized recommendations variant

### 📝 Description

QA can't wait cooldowns. Settings → Developer gets a Large-screen upsell debug screen: live would-show + gates, configure FF/devices/frequency/onboarding, reload to see the real dialog on portfolio.


https://github.com/user-attachments/assets/54434f85-f49d-4d58-9e4b-1bd25f8c134d



### ❓ Context

- **JIRA or GitHub link**: [LIVE-33164](https://ledgerhq.atlassian.net/browse/LIVE-33164)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33164]: https://ledgerhq.atlassian.net/browse/LIVE-33164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ