### PR TITLE
[LWM] feat(hypercore): hide send and receive for hypercore accounts on mobile

### DIFF
--- a/.changeset/hide-send-receive-hypercore-llm.md
+++ b/.changeset/hide-send-receive-hypercore-llm.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Hide Send and Receive for HyperCore accounts on mobile: HyperCore has no on-chain send on Ledger Wallet and a plain receive is misleading (deposits go through bridging). Both actions are now hidden across the account actions (FAB), the asset actions, the quick-action drawers and the no-funds empty state, reusing the shared `isSendDisabledForFamily` / `isReceiveDisabledForFamily` predicates from `@ledgerhq/live-common`. The account "Quick actions" section is also hidden entirely when it has no actions left (e.g. HyperCore), instead of showing an empty titled section.

--- a/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.test.ts
+++ b/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.test.ts
@@ -125,4 +125,16 @@ describe("useAssetActions - custom send flow", () => {
       expect.arrayContaining([expect.objectContaining({ id: "custom-action" })]),
     );
   });
+
+  it("omits send and receive for a family that disables them (hypercore)", () => {
+    const currencyHypercore = getCryptoCurrencyById("hypercore");
+
+    const { result } = renderHook(
+      () => useAssetActions({ currency: currencyHypercore, accounts: [ALEO_ACCOUNT_1] }),
+      { overrideInitialState: withSingleAccount },
+    );
+
+    expect(result.current.mainActions.find(a => a.id === "send")).toBeUndefined();
+    expect(result.current.mainActions.find(a => a.id === "receive")).toBeUndefined();
+  });
 });

--- a/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.tsx
+++ b/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.tsx
@@ -8,6 +8,8 @@ import {
   getAccountCurrency,
   getParentAccount,
   isTokenAccount,
+  isSendDisabledForFamily,
+  isReceiveDisabledForFamily,
 } from "@ledgerhq/live-common/account/index";
 import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/index";
 import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
@@ -35,11 +37,6 @@ type useAssetActionsProps = {
   accounts?: AccountLikeArray;
 };
 
-function getParentCurrencyId(currency?: CryptoCurrency | TokenCurrency): string | undefined {
-  if (!currency) return undefined;
-  return currency.type === "TokenCurrency" ? currency.parentCurrencyId : currency.id;
-}
-
 const iconBuy = IconsLegacy.PlusMedium;
 const iconSell = IconsLegacy.MinusMedium;
 const iconSwap = IconsLegacy.BuyCryptoMedium;
@@ -47,6 +44,11 @@ const iconReceive = IconsLegacy.ArrowBottomMedium;
 const iconSend = IconsLegacy.ArrowTopMedium;
 const iconAddAccount = IconsLegacy.WalletMedium;
 const iconStake = IconsLegacy.CoinsMedium;
+
+function getParentCurrencyId(currency?: CryptoCurrency | TokenCurrency): string | undefined {
+  if (!currency) return undefined;
+  return currency.type === "TokenCurrency" ? currency.parentCurrencyId : currency.id;
+}
 
 export default function useAssetActions({ currency, accounts }: useAssetActionsProps): {
   mainActions: ActionButtonEvent[];
@@ -93,6 +95,12 @@ export default function useAssetActions({ currency, accounts }: useAssetActionsP
   const parentCurrencyId = getParentCurrencyId(currency);
   const family = parentCurrencyId ? getFamilyByCurrencyId(parentCurrencyId) : undefined;
   const assetId = !currency ? accountCurrency?.id : currency.id;
+  // Gating family; falls back to the account currency when no currency is passed.
+  const actionsParentId =
+    parentCurrencyId ?? (accountCurrency ? getParentCurrencyId(accountCurrency) : undefined);
+  const actionsFamily = actionsParentId ? getFamilyByCurrencyId(actionsParentId) : undefined;
+  const canReceiveAsset = !actionsFamily || !isReceiveDisabledForFamily(actionsFamily);
+  const canSendAsset = !actionsFamily || !isSendDisabledForFamily(actionsFamily);
   const canStakeCurrency = !assetId ? false : getCanStakeCurrency(assetId);
 
   const { handleOpenStakeDrawer } = useOpenStakeDrawer({
@@ -243,22 +251,30 @@ export default function useAssetActions({ currency, accounts }: useAssetActionsP
                   },
                 ]
               : []),
-            {
-              id: "receive",
-              label: t("transfer.receive.title"),
-              Icon: iconReceive,
-              customHandler: handleOpenReceiveDrawer,
-            },
-            {
-              id: "send",
-              label: t("transfer.send.title"),
-              Icon: iconSend,
-              navigationParams: [NavigatorName.SendFunds, getScreenDescriptor()] as const,
-              disabled: areAccountsBalanceEmpty,
-              modalOnDisabledClick: {
-                component: ZeroBalanceDisabledModalContent,
-              },
-            },
+            ...(canReceiveAsset
+              ? [
+                  {
+                    id: "receive",
+                    label: t("transfer.receive.title"),
+                    Icon: iconReceive,
+                    customHandler: handleOpenReceiveDrawer,
+                  },
+                ]
+              : []),
+            ...(canSendAsset
+              ? [
+                  {
+                    id: "send",
+                    label: t("transfer.send.title"),
+                    Icon: iconSend,
+                    navigationParams: [NavigatorName.SendFunds, getScreenDescriptor()] as const,
+                    disabled: areAccountsBalanceEmpty,
+                    modalOnDisabledClick: {
+                      component: ZeroBalanceDisabledModalContent,
+                    },
+                  },
+                ]
+              : []),
             ...additionalAssetActions.map(additionalAction => ({
               disabled: areAccountsBalanceEmpty,
               ...additionalAction,
@@ -287,6 +303,8 @@ export default function useAssetActions({ currency, accounts }: useAssetActionsP
     hasAccounts,
     readOnlyModeEnabled,
     availableOnSwap,
+    canReceiveAsset,
+    canSendAsset,
     defaultAccount,
     parentAccount,
     canStakeCurrency,

--- a/apps/ledger-live-mobile/src/components/NoFunds/NoFunds.tsx
+++ b/apps/ledger-live-mobile/src/components/NoFunds/NoFunds.tsx
@@ -16,8 +16,10 @@ import { Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
 import {
   getAccountCurrency,
+  getMainAccount,
   isTokenAccount,
 } from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import { isReceiveDisabledForFamily } from "@ledgerhq/live-common/account/index";
 import { navigateToSwapTab } from "~/screens/Swap/navigation/navigateToSwapTab";
 import { BaseNavigatorStackParamList } from "../RootNavigator/types/BaseNavigator";
 
@@ -70,7 +72,8 @@ export default function NoFunds({ route }: Readonly<Props>) {
 
   const swapAvailableIds = currenciesAll;
 
-  const availableOnReceive = true;
+  const receiveFamily = getMainAccount(account, parentAccount).currency.family;
+  const availableOnReceive = !isReceiveDisabledForFamily(receiveFamily);
 
   const availableOnSwap = useMemo(() => {
     return currency && swapAvailableIds.includes(currency.id);

--- a/apps/ledger-live-mobile/src/hooks/useQuickActions.ts
+++ b/apps/ledger-live-mobile/src/hooks/useQuickActions.ts
@@ -5,6 +5,11 @@ import { IconsLegacy } from "@ledgerhq/native-ui";
 import { IconType } from "@ledgerhq/native-ui/components/Icon/type";
 import { useFeature, useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
+import {
+  isSendDisabledForFamily,
+  isReceiveDisabledForFamily,
+} from "@ledgerhq/live-common/account/index";
+import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/index";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { AccountLike } from "@ledgerhq/types-live";
 import { NavigatorName, ScreenName } from "~/const";
@@ -96,23 +101,38 @@ function useQuickActions({ currency, accounts }: QuickActionProps = {}) {
   const quickActionsList = useMemo(() => {
     const isLegacyRebornFlow = readOnlyModeEnabled && !shouldUseLazyOnboarding;
 
+    // Some families expose no Send/Receive on Ledger Wallet (e.g. HyperCore).
+    const parentCurrencyId =
+      currency && (currency.type === "TokenCurrency" ? currency.parentCurrencyId : currency.id);
+    const family = parentCurrencyId ? getFamilyByCurrencyId(parentCurrencyId) : undefined;
+    const sendDisabled = !!family && isSendDisabledForFamily(family);
+    const receiveDisabled = !!family && isReceiveDisabledForFamily(family);
+
     const list: Partial<Record<Actions, QuickAction>> = {
-      SEND: {
-        disabled: readOnlyModeEnabled || !hasCurrency,
-        route: [
-          NavigatorName.SendFunds,
-          {
-            screen: ScreenName.SendCoin,
-            params: { selectedCurrency: currency },
-          },
-        ],
-        icon: IconsLegacy.ArrowTopMedium,
-      },
-      RECEIVE: {
-        disabled: isLegacyRebornFlow,
-        customHandler: handleOpenReceiveDrawer,
-        icon: IconsLegacy.ArrowBottomMedium,
-      },
+      ...(sendDisabled
+        ? {}
+        : {
+            SEND: {
+              disabled: readOnlyModeEnabled || !hasCurrency,
+              route: [
+                NavigatorName.SendFunds,
+                {
+                  screen: ScreenName.SendCoin,
+                  params: { selectedCurrency: currency },
+                },
+              ],
+              icon: IconsLegacy.ArrowTopMedium,
+            },
+          }),
+      ...(receiveDisabled
+        ? {}
+        : {
+            RECEIVE: {
+              disabled: isLegacyRebornFlow,
+              customHandler: handleOpenReceiveDrawer,
+              icon: IconsLegacy.ArrowBottomMedium,
+            },
+          }),
       SWAP: {
         disabled: isPtxServiceCtaExchangeDrawerDisabled || isLegacyRebornFlow || !hasFunds,
         customHandler: handleOpenSwap,

--- a/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
@@ -57,6 +57,7 @@ type Props = {
   onSwitchAccountCurrency: () => void;
   onAccountCardLayout: (event: LayoutChangeEvent) => void;
   colors: ColorPalette;
+  mainActions: ActionButtonEvent[];
   secondaryActions: ActionButtonEvent[];
   t: TFunction;
 };
@@ -89,6 +90,7 @@ export function useListHeaderComponents({
   onSwitchAccountCurrency,
   onAccountCardLayout,
   colors,
+  mainActions,
   secondaryActions,
   t,
 }: Props): {
@@ -214,10 +216,12 @@ export function useListHeaderComponents({
           key="EditOperationCard"
         />
       ) : null,
-      <SectionContainer px={6} bg={colors.background.main} key="FabAccountMainActions" isFirst>
-        <SectionTitle title={t("account.quickActions")} containerProps={{ mb: 6 }} />
-        <FabAccountMainActions account={account} parentAccount={parentAccount} />
-      </SectionContainer>,
+      mainActions.length > 0 ? (
+        <SectionContainer px={6} bg={colors.background.main} key="FabAccountMainActions" isFirst>
+          <SectionTitle title={t("account.quickActions")} containerProps={{ mb: 6 }} />
+          <FabAccountMainActions account={account} parentAccount={parentAccount} />
+        </SectionContainer>
+      ) : null,
       !!AccountBalanceHeader && (
         <AccountBalanceHeader
           key="AccountBalanceHeader"

--- a/apps/ledger-live-mobile/src/screens/Account/__tests__/ListHeaderComponent.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/__tests__/ListHeaderComponent.test.tsx
@@ -76,7 +76,10 @@ describe("Testing ListHeaderComponent Component", () => {
       mockIsAccountEmpty.mockImplementation(() => false);
     });
 
-    const getUseListHeaderComponentsResult = (currencyConfig: CurrencyConfig) => {
+    const getUseListHeaderComponentsResult = (
+      currencyConfig: CurrencyConfig,
+      mainActions: ActionButtonEvent[] = [{ label: {} as React.ReactNode } as ActionButtonEvent],
+    ) => {
       let hookResult: ReturnType<typeof useListHeaderComponents> | undefined;
 
       const TestComponent = () => {
@@ -99,6 +102,7 @@ describe("Testing ListHeaderComponent Component", () => {
               main: "#fff",
             },
           } as ColorPalette,
+          mainActions,
           secondaryActions: [
             {
               label: {} as React.ReactNode,
@@ -153,6 +157,26 @@ describe("Testing ListHeaderComponent Component", () => {
       } as unknown as CurrencyConfig);
 
       expect(listHeaderComponents[8]).toBeUndefined();
+    });
+
+    const findByKey = (components: React.ReactNode[], key: string) =>
+      components.find(c => React.isValidElement(c) && c.key === key);
+
+    it("renders the quick actions section when there are main actions", () => {
+      const { listHeaderComponents } = getUseListHeaderComponentsResult(
+        {} as unknown as CurrencyConfig,
+      );
+
+      expect(findByKey(listHeaderComponents, "FabAccountMainActions")).toBeTruthy();
+    });
+
+    it("hides the quick actions section when there are no main actions (e.g. HyperCore)", () => {
+      const { listHeaderComponents } = getUseListHeaderComponentsResult(
+        {} as unknown as CurrencyConfig,
+        [],
+      );
+
+      expect(findByKey(listHeaderComponents, "FabAccountMainActions")).toBeFalsy();
     });
   });
 });

--- a/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
@@ -4,6 +4,8 @@ import {
   getAccountCurrency,
   getMainAccount,
   getAccountSpendableBalance,
+  isSendDisabledForFamily,
+  isReceiveDisabledForFamily,
 } from "@ledgerhq/live-common/account/index";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useSelector } from "~/context/hooks";
@@ -292,8 +294,12 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
     ],
   );
 
-  const mainActions = useMemo(
-    () => [
+  const mainActions = useMemo(() => {
+    const family = mainAccount.currency.family;
+    const canSend = !readOnlyModeEnabled && !isSendDisabledForFamily(family);
+    const canReceive = !isReceiveDisabledForFamily(family);
+
+    return [
       ...(availableOnSwap ? [actionButtonSwap] : []),
       ...(!readOnlyModeEnabled && canBeBought ? [actionButtonBuy] : []),
       ...(!readOnlyModeEnabled && canBeSold ? [actionButtonSell] : []),
@@ -303,25 +309,25 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
             action => action.id !== "stake" || shouldShowLedgerLiveStakeAction,
           ) // keep the Ledger Live stake action only when no platform app stake action is available
         : []),
-      ...(!readOnlyModeEnabled ? [SendAction] : []),
-      ReceiveAction,
-    ],
-    [
-      availableOnSwap,
-      readOnlyModeEnabled,
-      canBeBought,
-      canBeSold,
-      canStakeUsingPlatformApp,
-      StakeAction,
-      familySpecificMainActions,
-      shouldShowLedgerLiveStakeAction,
-      actionButtonSwap,
-      actionButtonBuy,
-      actionButtonSell,
-      SendAction,
-      ReceiveAction,
-    ],
-  );
+      ...(canSend ? [SendAction] : []),
+      ...(canReceive ? [ReceiveAction] : []),
+    ];
+  }, [
+    availableOnSwap,
+    readOnlyModeEnabled,
+    canBeBought,
+    canBeSold,
+    canStakeUsingPlatformApp,
+    StakeAction,
+    familySpecificMainActions,
+    shouldShowLedgerLiveStakeAction,
+    actionButtonSwap,
+    actionButtonBuy,
+    actionButtonSell,
+    SendAction,
+    ReceiveAction,
+    mainAccount.currency.family,
+  ]);
 
   const familySpecificSecondaryActions = useMemo(
     () =>

--- a/apps/ledger-live-mobile/src/screens/Account/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/index.tsx
@@ -133,7 +133,7 @@ const AccountScreenInner = ({
     setGraphCardEndPosition(y + height / 10);
   }, []);
 
-  const { secondaryActions } = useAccountActions({ account, parentAccount });
+  const { mainActions, secondaryActions } = useAccountActions({ account, parentAccount, colors });
 
   let currencyConfig: CurrencyConfig | undefined = undefined;
   try {
@@ -158,6 +158,7 @@ const AccountScreenInner = ({
     onSwitchAccountCurrency,
     onAccountCardLayout,
     colors,
+    mainActions,
     secondaryActions,
     t,
   });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _`useAssetActions` test asserts Send/Receive are omitted for HyperCore; `ListHeaderComponent` test asserts the "Quick actions" section is hidden when it has no actions._
- [x] **Impact of the changes:**
  - Account screen action row (FAB): no Send / Receive for HyperCore accounts.
  - Asset screen actions (FAB): no Send / Receive for HyperCore.
  - Quick-action drawers (`useQuickActions`): SEND / RECEIVE omitted for HyperCore.
  - No-funds empty state: no Receive option.
  - Account "Quick actions" section: hidden entirely when it has no actions left (e.g. HyperCore), instead of showing an empty titled section.
  - Regression: normal accounts (e.g. ethereum) still show Send + Receive everywhere.

### 📝 Description

Mobile counterpart of the desktop PR. HyperCore accounts (`family: "hypercore"`) have **no on-chain send** on Ledger Wallet, and a plain **receive** is misleading — the HyperCore address is an Ethereum-format address but deposits go through bridging. So both actions are hidden for HyperCore across every per-account/per-currency surface on mobile.

**Solution**: reuse the shared `isSendDisabledForFamily` / `isReceiveDisabledForFamily` predicates from `@ledgerhq/live-common` (backed by the single `FAMILY_TRANSFER_CAPABILITY` map introduced in the base PR) and gate each mobile surface. The family is resolved from the account currency (`getMainAccount(...).currency.family`) or, for currency-based surfaces, via the existing `getFamilyByCurrencyId` — no new helper is introduced. `useQuickActions` builds its action list with conditional spreads (no `delete`). This PR touches only `live-mobile`.

- `screens/Account/hooks/useAccountActions.tsx` (account FAB)
- `components/FabActions/hooks/useAssetActions.tsx` (asset FAB)
- `hooks/useQuickActions.ts` (quick-action drawers)
- `components/NoFunds/NoFunds.tsx` (empty state)
- `screens/Account/ListHeaderComponent.tsx` + `screens/Account/index.tsx` (hide the account "Quick actions" section when it has no actions left)

> The base PR (desktop, #19707) is now merged into `develop`; this PR targets `develop` and consumes the capability map / predicates it introduced (it also dropped the broken HyperCore explorer tx view + renamed the currency to "Hyperliquid").

> Scope note: deeplink gating is intentionally left out (matching the base PR). Send is hidden on every UI surface, and the `receive` deeplink reopening the flow is a low-risk edge case to be handled separately if needed.

### ❓ Context

- **JIRA link**: [LIVE-33245](https://ledgerhq.atlassian.net/browse/LIVE-33245) (Hide Send) & [LIVE-33250](https://ledgerhq.atlassian.net/browse/LIVE-33250) (Hide Receive)

###  Screenshot
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-23 at 16 20 16" src="https://github.com/user-attachments/assets/3625c68c-ca6b-45b3-9785-ce72fefd14f8" />

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.


[LIVE-33245]: https://ledgerhq.atlassian.net/browse/LIVE-33245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ





