### PR TITLE
[LWDM] Feat/somnia delegation info

### DIFF
--- a/.changeset/giant-days-appear.md
+++ b/.changeset/giant-days-appear.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+Fix: staking gas-estimation retry for Somnia-style chains (calldata + value rebuilt together, prepared intent reused) + tests.

--- a/libs/coin-modules/coin-evm/src/logic/common.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/common.test.ts
@@ -177,11 +177,13 @@ describe("common", () => {
     it("retries with the chain calldataAmountScale (USEI_TO_EVM_SCALE for SEI) when initial gas estimation fails for a payable staking call (value > 0)", async () => {
       const spendableBalance = 1_000_000_000_000_000_000n; // 1 SEI
 
-      mockBuildStakingTransactionParams.mockReturnValue({
+      // Payable delegate: msg.value = amount. Amount-aware so the retry (which rebuilds the
+      // params from the min calldata unit) reflects the real value it would send.
+      mockBuildStakingTransactionParams.mockImplementation((_currency, intent) => ({
         to: stakingContractAddress,
         data: stakingData,
-        value: spendableBalance, // payable: amount goes into msg.value
-      });
+        value: intent.amount,
+      }));
 
       // First call (full balance) fails, retry (1 usei) succeeds
       nodeApiMock.getGasEstimation
@@ -218,11 +220,12 @@ describe("common", () => {
     });
 
     it("retries with the chain calldataAmountScale (USEI_TO_EVM_SCALE for SEI) when initial gas estimation fails for a staking call with amount=0 (delegation form freshly opened)", async () => {
-      mockBuildStakingTransactionParams.mockReturnValue({
+      // amount=0 → precompile rejects; retry rebuilds params from the min calldata unit.
+      mockBuildStakingTransactionParams.mockImplementation((_currency, intent) => ({
         to: stakingContractAddress,
         data: stakingData,
-        value: 0n, // amount=0 → 0 usei → precompile rejects
-      });
+        value: intent.amount,
+      }));
 
       nodeApiMock.getGasEstimation
         .mockRejectedValueOnce(GAS_ESTIMATION_ERROR)
@@ -256,6 +259,44 @@ describe("common", () => {
 
       expect(nodeApiMock.getGasEstimation).toHaveBeenCalledTimes(2);
       expect(result.gasLimit).toEqual(new BigNumber(0));
+    });
+
+    it("rebuilds calldata and value from the min amount on retry (amount-in-calldata chains e.g. Somnia)", async () => {
+      // Uses the sei_evm mockCurrency as a stand-in fixture (hence USEI_TO_EVM_SCALE as the
+      // min unit); it stands in for any amount-in-calldata chain such as Somnia.
+      // Simulate a contract that encodes the amount in the calldata AND requires
+      // msg.value === amount (e.g. Somnia delegateStake). Both data and value derive from
+      // the intent amount, so a retry that only swapped the value would be inconsistent.
+      mockBuildStakingTransactionParams.mockImplementation((_currency, intent) => {
+        const { amount } = intent;
+        return {
+          to: stakingContractAddress,
+          data: Buffer.from(`delegate:${amount.toString()}`),
+          value: amount,
+        };
+      });
+
+      nodeApiMock.getGasEstimation
+        .mockRejectedValueOnce(GAS_ESTIMATION_ERROR)
+        .mockResolvedValueOnce(new BigNumber(1_412_179));
+
+      const result = await prepareUnsignedTxParams(mockCurrency, makeStakingIntent(0n));
+
+      expect(nodeApiMock.getGasEstimation).toHaveBeenCalledTimes(2);
+      // Retry rebuilds BOTH calldata and value from the min unit (USEI_TO_EVM_SCALE), so the
+      // calldata-encoded amount matches msg.value — otherwise the contract would revert.
+      expect(nodeApiMock.getGasEstimation).toHaveBeenNthCalledWith(
+        2,
+        { currency: mockCurrency, freshAddress: "0xSender" },
+        {
+          amount: new BigNumber(USEI_TO_EVM_SCALE.toString()),
+          recipient: stakingContractAddress,
+          data: Buffer.from(`delegate:${USEI_TO_EVM_SCALE.toString()}`),
+        },
+      );
+      // The returned params keep the ORIGINAL intent (amount=0) — only the estimate is retried.
+      expect(result.data).toEqual("0x" + Buffer.from("delegate:0").toString("hex"));
+      expect(result.gasLimit).toEqual(new BigNumber(1_412_179));
     });
 
     it("does not retry for send transactions — falls back to gasLimit=0 on first failure without a second call", async () => {

--- a/libs/coin-modules/coin-evm/src/logic/common.ts
+++ b/libs/coin-modules/coin-evm/src/logic/common.ts
@@ -112,8 +112,14 @@ export async function prepareUnsignedTxParams(
   const transactionType = getTransactionType(type);
   const node = getNodeApi(currency);
 
+  const isSend = isSendTransactionIntent(transactionIntent);
+
+  // Prepare staking intents once (can require async on-chain lookups). See: LIVE-32750
+  const preparedStakingIntent = isSend
+    ? undefined
+    : await prepareStakingIntent(currency, transactionIntent);
   // Build transaction parameters based on type
-  const { to, data, value } = isSendTransactionIntent(transactionIntent)
+  const { to, data, value } = isSend
     ? ((): { to: string; data: Buffer; value: bigint } => {
         const { amount, asset, recipient } = transactionIntent;
         return {
@@ -122,10 +128,7 @@ export async function prepareUnsignedTxParams(
           value: isNative(asset) ? amount : 0n,
         };
       })()
-    : buildStakingTransactionParams(
-        currency,
-        await prepareStakingIntent(currency, transactionIntent),
-      );
+    : buildStakingTransactionParams(currency, preparedStakingIntent ?? transactionIntent);
   const gasLimit =
     typeof customFeesParameters?.gasLimit === "bigint"
       ? BigNumber(customFeesParameters.gasLimit.toString())
@@ -139,14 +142,23 @@ export async function prepareUnsignedTxParams(
           )
           .catch(async () => {
             if (isStakingTransactionIntent(transactionIntent)) {
-              // Staking precompiles may reject the initial amount (e.g. 0 or rounded value).
-              // Retry with the minimum meaningful calldata unit for this chain so the node
-              // can at least estimate the gas overhead of the contract call itself.
+              // Retry staking gas estimation with the chain min calldata unit (LIVE-32750).
+              // Rebuild calldata + value to keep `msg.value` consistent with calldata-encoded amounts (e.g. Somnia).
               const minUnit = STAKING_CONTRACTS[currency.id]?.calldataAmountScale ?? 1n;
+              // Reuse the already-prepared staking intent (enrichment done above) and only
+              // override the amount, so we don't repeat the async on-chain lookups.
+              const retry = buildStakingTransactionParams(currency, {
+                ...(preparedStakingIntent ?? transactionIntent),
+                amount: minUnit,
+              });
               return node
                 .getGasEstimation(
                   { currency, freshAddress: sender },
-                  { amount: new BigNumber(minUnit.toString()), recipient: to, data },
+                  {
+                    amount: new BigNumber(retry.value.toString()),
+                    recipient: retry.to,
+                    data: retry.data,
+                  },
                 )
                 .catch(() => {
                   return new BigNumber(0);


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Fixes gas estimation for staking transactions on amount-in-calldata chains (e.g. Somnia), where the delegated amount is encoded in the calldata and must equal msg.value.

When the initial gas estimation fails (e.g. the contract rejects a 0 or freshly-opened-form amount), we retry with the chain's minimum calldata unit (calldataAmountScale). The retry now rebuilds both the calldata and the value from that min amount, so the calldata-encoded amount stays consistent with msg.value — otherwise the contract would revert and the estimate would fall back to 0.

Changes

- logic/common.ts: on the staking gas-estimation retry, rebuild calldata + value from the min unit instead of reusing the original calldata with a swapped value.
- Prepare the staking intent once and reuse it on retry (only overriding amount), avoiding a repeat of the expensive async enrichment (e.g. Monad's on-chain free withdraw-slot lookup).
- logic/common.test.ts: added coverage for the retry rebuild, the min-unit retry with amount=0, the double-failure fallback to gasLimit=0, and the no-retry-for-send case.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32750](https://ledgerhq.atlassian.net/browse/LIVE-32750)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-32750]: https://ledgerhq.atlassian.net/browse/LIVE-32750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ