### PR TITLE
[LWM] feat(LIVE-30495): add proof-generation alert and signing-time rows to Aleo mobile…

### DIFF
--- a/.changeset/lazy-gifts-applaud.md
+++ b/.changeset/lazy-gifts-applaud.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Aleo mobile send summary to reuse shared UI components and show the Records used / Signing time rows for private transactions

--- a/apps/ledger-live-mobile/src/families/aleo/SendRowsFee.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/SendRowsFee.tsx
@@ -8,6 +8,10 @@ import type {
   Transaction as AleoTransaction,
   TransactionStatus as AleoTransactionStatus,
 } from "@ledgerhq/live-common/families/aleo/types";
+import {
+  getEstimatedSigningTime,
+  isPrivateTransaction,
+} from "@ledgerhq/live-common/families/aleo/utils";
 import type { Account, AccountLike, TransactionStatusCommon } from "@ledgerhq/types-live";
 import { useTheme } from "@react-navigation/native";
 import { Trans, useTranslation } from "~/context/Locale";
@@ -50,6 +54,14 @@ export default function AleoSendRowsFee({ account, parentAccount, transaction, s
   const isSponsored = fees.isZero();
   const learnMoreUrl = useLocalizedUrl(urls.aleo.learnMore);
 
+  const isPrivate = isPrivateTransaction(aleoTransaction);
+  const showRecordRows = isPrivate && !!aleoTransaction.properties;
+  const recordCount =
+    isPrivate && aleoTransaction.properties
+      ? aleoTransaction.properties.amountRecordCommitments.length +
+        (aleoTransaction.properties.feeRecordCommitment === null ? 0 : 1)
+      : 0;
+
   return (
     <>
       <SectionSeparator lineColor={colors.lightFog} />
@@ -69,11 +81,27 @@ export default function AleoSendRowsFee({ account, parentAccount, transaction, s
           </Box>
         )}
       </SummaryRow>
+      {showRecordRows && (
+        <>
+          <SectionSeparator lineColor={colors.lightFog} />
+          <SummaryRow title={t("aleo.send.summary.recordsUsed")}>
+            <Text typography="body2SemiBold" lx={{ color: "base" }}>
+              {recordCount}
+            </Text>
+          </SummaryRow>
+          <SectionSeparator lineColor={colors.lightFog} />
+          <SummaryRow title={t("aleo.send.summary.signingTime")}>
+            <Text typography="body2SemiBold" lx={{ color: "base" }}>
+              {getEstimatedSigningTime(recordCount, t("time.second_short"), t("time.minute_short"))}
+            </Text>
+          </SummaryRow>
+        </>
+      )}
       <SectionSeparator lineColor={colors.lightFog} />
       <SummaryTotalSection account={account} parentAccount={parentAccount} amount={totalSpent} />
       <Alert
         type="secondary"
-        title={t("aleo.send.summary.proofGenerationNotice")}
+        title={t("aleo.send.summary.proofGenerationWarning")}
         learnMoreUrl={learnMoreUrl}
       />
     </>

--- a/apps/ledger-live-mobile/src/families/aleo/__tests__/SendRowsFee.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/__tests__/SendRowsFee.test.tsx
@@ -25,7 +25,7 @@ const baseTransaction = {
 
 const renderFeeRow = (
   statusOverrides: Record<string, unknown> | undefined,
-  transaction = baseTransaction,
+  transaction: Record<string, unknown> = baseTransaction,
 ) =>
   render(
     <AleoSendRowsFee
@@ -84,5 +84,33 @@ describe("AleoSendRowsFee", () => {
 
     expect(screen.queryByText("Sponsored by Provable")).toBeNull();
     expect(screen.getByText("fees:7")).toBeTruthy();
+  });
+
+  it("hides the records/signing rows for a public transaction", () => {
+    renderFeeRow(undefined, { ...baseTransaction, mode: "transfer_public" });
+
+    expect(screen.queryByText("Records used")).toBeNull();
+    expect(screen.queryByText("Signing time")).toBeNull();
+  });
+
+  it("shows the records/signing rows for a private transaction", () => {
+    const properties = {
+      amountRecordCommitments: ["r1", "r2"],
+      feeRecordCommitment: "r3",
+    };
+    renderFeeRow(undefined, { ...baseTransaction, mode: "transfer_private", properties });
+    const expectedRecordCount =
+      properties.amountRecordCommitments.length + (properties.feeRecordCommitment ? 1 : 0);
+
+    expect(screen.getByText("Records used")).toBeTruthy();
+    expect(screen.getByText(String(expectedRecordCount))).toBeTruthy();
+    expect(screen.getByText("Signing time")).toBeTruthy();
+  });
+
+  it("hides the records/signing rows when transaction.properties is missing", () => {
+    renderFeeRow(undefined, { ...baseTransaction, mode: "transfer_private" });
+
+    expect(screen.queryByText("Records used")).toBeNull();
+    expect(screen.queryByText("Signing time")).toBeNull();
   });
 });

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10166,7 +10166,9 @@
         }
       },
       "summary": {
-        "proofGenerationNotice": "Aleo transaction requires proof generation. This may take some time."
+        "proofGenerationWarning": "Aleo transaction requires proof generation. This may take some time.",
+        "recordsUsed": "Records used",
+        "signingTime": "Signing time"
       }
     },
     "balancesSection": "Balances",


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Fix Aleo mobile send summary to reuse shared UI components and show the Records used / Signing time rows for private transactions.

<img src="https://github.com/user-attachments/assets/0950a352-ecc5-487a-b22d-dbd8efd43be9" alt="aleo-private-send-amount-confirmation" width="220" />

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-30495
