### PR TITLE
fix(ci): stabilize qaa-allure report name across nightly runs

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -1116,7 +1116,7 @@ jobs:
         with:
           api_key: ${{ secrets.QAA_ALLURE_API_KEY }}
           path: ios-test-artifacts
-          name: "mobile-e2e-ios-${{ github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual') }}-#${{ github.run_id }}"
+          name: "mobile-e2e-ios-${{ github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual') }}"
           tags: ${{ format('["mobile","ios",{0}]', toJSON(github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual'))) }}
           branch: ${{ inputs.ref || github.ref_name }}
 
@@ -1139,7 +1139,7 @@ jobs:
         with:
           api_key: ${{ secrets.QAA_ALLURE_API_KEY }}
           path: android-test-artifacts
-          name: "mobile-e2e-android-${{ github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual') }}-#${{ github.run_id }}"
+          name: "mobile-e2e-android-${{ github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual') }}"
           tags: ${{ format('["mobile","android",{0}]', toJSON(github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual'))) }}
           branch: ${{ inputs.ref || github.ref_name }}
 

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -503,7 +503,7 @@ jobs:
         with:
           api_key: ${{ secrets.QAA_ALLURE_API_KEY }}
           path: ${{ env.ALLURE_RESULTS }}
-          name: "desktop-e2e-${{ needs.prepare-devices.outputs.device_1 }}-${{ github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual') }}-#${{ github.run_id }}"
+          name: "desktop-e2e-${{ needs.prepare-devices.outputs.device_1 }}-${{ github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual') }}"
           tags: ${{ format('["desktop","speculos",{0},{1}]', toJSON(needs.prepare-devices.outputs.device_1), toJSON(github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual'))) }}
           branch: ${{ inputs.ref || github.ref_name }}
 
@@ -528,7 +528,7 @@ jobs:
         with:
           api_key: ${{ secrets.QAA_ALLURE_API_KEY }}
           path: ${{ env.ALLURE_RESULTS }}
-          name: "desktop-e2e-${{ needs.prepare-devices.outputs.device_2 }}-${{ github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual') }}-#${{ github.run_id }}"
+          name: "desktop-e2e-${{ needs.prepare-devices.outputs.device_2 }}-${{ github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual') }}"
           tags: ${{ format('["desktop","speculos",{0},{1}]', toJSON(needs.prepare-devices.outputs.device_2), toJSON(github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual'))) }}
           branch: ${{ inputs.ref || github.ref_name }}
 


### PR DESCRIPTION
## Problem

The qaa-allure server (`qaa-allure`) groups Allure history/trends by a hashed **`(name, branch)`** lineage key. Every qaa-allure upload baked the GitHub Actions run id into the `name` field, e.g.:

```
mobile-e2e-ios-nightly-#29553715831
```

Because the run id is unique per run, `name` changed on every nightly, so each run was treated as a brand-new series with **no prior trend data** — even though it's conceptually the same nightly job every night.

## Fix

Drop the `-#${{ github.run_id }}` suffix from `name` in all four qaa-allure callers so it's stable across runs:

| Upload | New `name` |
|--------|-----------|
| Mobile iOS | `mobile-e2e-ios-<nightly\|smoke\|manual>` |
| Mobile Android | `mobile-e2e-android-<nightly\|smoke\|manual>` |
| Desktop device 1 | `desktop-e2e-<device>-<nightly\|smoke\|manual>` |
| Desktop device 2 | `desktop-e2e-<device>-<nightly\|smoke\|manual>` |

The per-run identifier is **already preserved** without extra work: none of these callers pass `job_url`, so they inherit the composite's default (`.../actions/runs/${{ github.run_id }}`), which is sent as `jobUrl` and deep-links back to the exact Actions run. `jobUrl` is not part of the grouping key, so history/trends now accumulate correctly. `branch` (`develop` for nightlies) is unchanged.

The `nightly`/`smoke`/`manual` discriminator stays in `name` intentionally — those are genuinely different series.

## Scope check

The separate `upload-allure-report` composite (different server, groups by `report-path` = `<branch>-<platform>`) already uses a stable key with the run id only in `build-url` — not affected, left unchanged.

## Files

- `.github/workflows/test-mobile-e2e-reusable.yml` (iOS + Android)
- `.github/workflows/test-ui-e2e-only-desktop.yml` (device 1 + device 2)

## Notes

Reusable workflows/composites are pinned to `@develop`, so the trend fix begins accumulating from the first nightly after this merges to `develop`.