### PR TITLE
test(e2e): review buySell.spec (QAA-1107)

### DIFF
--- a/.changeset/review-buysell-spec-qaa-1107.md
+++ b/.changeset/review-buysell-spec-qaa-1107.md
@@ -1,6 +1,7 @@
 ---
+"@ledgerhq/live-e2e-shared": patch
 "ledger-live-desktop-e2e-tests": patch
 "ledger-live-mobile-e2e-tests": patch
 ---
 
-Review buySell.spec (QAA-1107): select a random provider from the available quotes instead of hardcoded MoonPay (mirroring LWM), and expand sell coverage to BTC, ETH and USDT. Align the mobile BTC sell TMS link accordingly.
+Review buySell.spec (QAA-1107): pick the buy/sell provider from the available quotes via a shared deterministic weekly rotation helper (`pickRotatingProvider` in live-e2e-shared, used by both desktop and mobile) instead of hardcoded MoonPay, and expand sell coverage to BTC, ETH and USDT. Align the mobile BTC sell TMS link accordingly.

--- a/.changeset/review-buysell-spec-qaa-1107.md
+++ b/.changeset/review-buysell-spec-qaa-1107.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop-e2e-tests": patch
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Review buySell.spec (QAA-1107): select a random provider from the available quotes instead of hardcoded MoonPay (mirroring LWM), and expand sell coverage to BTC, ETH and USDT. Align the mobile BTC sell TMS link accordingly.

--- a/e2e/desktop/tests/page/buyAndSell.page.ts
+++ b/e2e/desktop/tests/page/buyAndSell.page.ts
@@ -41,6 +41,8 @@ export class BuyAndSellPage extends WebViewAppPage {
   private fiatDrawerInput = "fiat-drawer-search-input";
   private saveRegionFiatOptionsSelector = "save-region-and-fiat-options";
   private showMoreQuotes = "SHOW MORE QUOTES";
+  private providerTitleCssSelector =
+    "[data-testid^='provider_title_'][data-testid$='_title_container']";
 
   private chooseAssetDrawer = new ChooseAssetDrawer(this.page);
   private modularDialog = new ModularDialog(this.page);
@@ -60,32 +62,6 @@ export class BuyAndSellPage extends WebViewAppPage {
       },
       sellParams: this.standardSellParams,
       addressParam: "walletaddress",
-    },
-    [BuySellProvider.TRANSAK.uiName]: {
-      buyParams: {
-        fiatAmount: buySell => buySell.amount,
-        cryptoCurrencyCode: buySell => buySell.crypto.currency.ticker,
-        fiatCurrency: buySell => buySell.fiat.currencyTicker,
-      },
-      sellParams: this.standardSellParams,
-      addressParam: "walletaddress",
-    },
-    [BuySellProvider.COINBASE.uiName]: {
-      buyParams: {
-        presetFiatAmount: buySell => buySell.amount,
-        defaultAsset: buySell => buySell.crypto.currency.ticker,
-        fiatCurrency: buySell => buySell.fiat.currencyTicker,
-      },
-      sellParams: this.standardSellParams,
-      addressParam: "destinationwallets",
-      parseAddress: (value: string) => {
-        const wallets = JSON.parse(decodeURIComponent(value)) as Array<{
-          address: string;
-          blockchains: string[];
-        }>;
-        if (!wallets[0]?.address) throw new Error("No address found in destinationwallets");
-        return wallets[0].address.toLowerCase();
-      },
     },
   };
 
@@ -227,14 +203,41 @@ export class BuyAndSellPage extends WebViewAppPage {
     await this.verifyElementIsVisible(this.providersList);
   }
 
-  @step("Select provider quote for $1")
-  async selectProviderQuote(operation: string, providerName: string) {
+  @step("Select provider quote")
+  async selectProviderQuote(operation: string, provider: BuySellProvider) {
     if (await this.isTextVisible(this.showMoreQuotes)) {
       await this.clickElementByText(this.showMoreQuotes);
     }
-    await this.scrollToElement(this.provider(providerName));
-    await this.clickElement(this.provider(providerName));
-    await this.verifyElementText(this.formCta, `${operation} with ${providerName}`);
+    await this.scrollToElement(this.provider(provider.name));
+    await this.clickElement(this.provider(provider.name));
+    await this.verifyElementText(this.formCta, `${operation} with ${provider.uiName}`);
+  }
+
+  @step("Get available providers")
+  async getAvailableProviders(): Promise<string[]> {
+    if (await this.isTextVisible(this.showMoreQuotes)) {
+      await this.clickElementByText(this.showMoreQuotes);
+    }
+    const titles = await this.getTextsByCssSelector(this.providerTitleCssSelector);
+    return titles.map(title => title.trim());
+  }
+
+  @step("Select random provider")
+  async selectRandomProvider(operation: string): Promise<BuySellProvider> {
+    const uiNamesFromQuotes = await this.getAvailableProviders();
+    const testedProviders = uiNamesFromQuotes
+      .map(uiName => BuySellProvider.getByUiName(uiName))
+      .filter((p): p is BuySellProvider => Boolean(p?.isTested));
+
+    if (testedProviders.length === 0) {
+      throw new Error(
+        `No known tested providers in quotes. UI listed: ${uiNamesFromQuotes.join(", ") || "(none)"}`,
+      );
+    }
+
+    const selected = testedProviders[Math.floor(Math.random() * testedProviders.length)];
+    await this.selectProviderQuote(operation, selected);
+    return selected;
   }
 
   @step("Select quote")
@@ -243,17 +246,25 @@ export class BuyAndSellPage extends WebViewAppPage {
     await this.clickElement(this.formCta);
   }
 
-  @step("Verify provider URL for $0")
-  async verifyProviderUrl(providerName: string, buySell: BuySell, userdataDestinationPath: string) {
+  @step("Verify provider URL")
+  async verifyProviderUrl(
+    provider: BuySellProvider,
+    buySell: BuySell,
+    userdataDestinationPath: string,
+  ) {
     const addresses = await getAccountAddressesFromAppJson(userdataDestinationPath);
 
     const rawUrl = await this.waitForGoToUrl();
     const decodedUrl = decodeGoToUrl(rawUrl);
     const url = new URL(decodedUrl);
 
-    this.verifyBaseUrl(url, providerName, buySell.operation);
-    this.verifyQueryParams(url, providerName, buySell);
-    await this.verifyDestinationAddress(url, providerName, buySell, addresses);
+    this.verifyProviderInUrl(url, provider.uiName);
+
+    const config = this.providerConfigs[provider.uiName];
+    if (!config) return;
+
+    this.verifyQueryParams(url, config, buySell);
+    await this.verifyDestinationAddress(url, config, buySell, addresses);
   }
 
   private async waitForGoToUrl(): Promise<string> {
@@ -279,21 +290,14 @@ export class BuyAndSellPage extends WebViewAppPage {
     return stableUrl;
   }
 
-  private verifyBaseUrl(url: URL, providerName: string, operation: OperationType) {
-    const hrefLower = url.href.toLowerCase();
-
-    expect(
-      hrefLower.includes(operation.toLowerCase()),
-      `Operation "${operation}" should appear in URL`,
-    ).toBe(true);
-    expect(
-      hrefLower.includes(providerName.toLowerCase()),
-      `Provider "${providerName}" should appear in URL`,
-    ).toBe(true);
+  private verifyProviderInUrl(url: URL, providerUiName: string) {
+    const href = url.href.toLowerCase().replace(/[^a-z0-9]/g, "");
+    const provider = providerUiName.toLowerCase().replace(/[^a-z0-9]/g, "");
+    expect(href.includes(provider), `Provider "${providerUiName}" should appear in URL`).toBe(true);
   }
 
-  private verifyQueryParams(url: URL, providerName: string, buySell: BuySell) {
-    const expectations = this.getExpectedQueryParams(providerName, buySell);
+  private verifyQueryParams(url: URL, config: ProviderConfig, buySell: BuySell) {
+    const expectations = this.getExpectedQueryParams(config, buySell);
     const params = Object.fromEntries(
       Array.from(url.searchParams).map(([k, v]) => [k.toLowerCase(), v]),
     );
@@ -310,10 +314,7 @@ export class BuyAndSellPage extends WebViewAppPage {
     }
   }
 
-  private getExpectedQueryParams(providerName: string, buySell: BuySell): Record<string, string> {
-    const config = this.providerConfigs[providerName];
-    if (!config) throw new Error(`Unsupported provider: ${providerName}`);
-
+  private getExpectedQueryParams(config: ProviderConfig, buySell: BuySell): Record<string, string> {
     const paramMap = buySell.operation === OperationType.Buy ? config.buyParams : config.sellParams;
 
     return Object.fromEntries(
@@ -326,12 +327,10 @@ export class BuyAndSellPage extends WebViewAppPage {
 
   private async verifyDestinationAddress(
     url: URL,
-    providerName: string,
+    config: ProviderConfig,
     buySell: BuySell,
     addresses: string[],
   ) {
-    const config = this.providerConfigs[providerName];
-    if (!config) throw new Error(`Unsupported provider: ${providerName}`);
     const normalizedAddresses = addresses.map(a => a.toLowerCase());
 
     const expectedParam = buySell.operation === OperationType.Buy ? config.addressParam : "address";

--- a/e2e/desktop/tests/page/buyAndSell.page.ts
+++ b/e2e/desktop/tests/page/buyAndSell.page.ts
@@ -65,6 +65,10 @@ export class BuyAndSellPage extends WebViewAppPage {
     },
   };
 
+  private providerUrlAliases: Record<string, string> = {
+    [BuySellProvider.MERCURYO.uiName]: "mrcr",
+  };
+
   @step("Expect Buy / Sell screen to be visible")
   async verifyBuySellScreenIsVisible() {
     await this.verifyElementIsVisible(this.navigationTabs);
@@ -252,19 +256,27 @@ export class BuyAndSellPage extends WebViewAppPage {
     buySell: BuySell,
     userdataDestinationPath: string,
   ) {
-    const addresses = await getAccountAddressesFromAppJson(userdataDestinationPath);
-
     const rawUrl = await this.waitForGoToUrl();
-    const decodedUrl = decodeGoToUrl(rawUrl);
-    const url = new URL(decodedUrl);
+    const url = new URL(decodeGoToUrl(rawUrl));
 
-    this.verifyProviderInUrl(url, provider.uiName);
+    this.verifyProviderInUrl(url, provider);
 
     const config = this.providerConfigs[provider.uiName];
     if (!config) return;
 
+    const addresses = await getAccountAddressesFromAppJson(userdataDestinationPath);
     this.verifyQueryParams(url, config, buySell);
     await this.verifyDestinationAddress(url, config, buySell, addresses);
+  }
+
+  private verifyProviderInUrl(url: URL, provider: BuySellProvider) {
+    const href = url.href.toLowerCase().replace(/[^a-z0-9]/g, "");
+    const expected = (this.providerUrlAliases[provider.uiName] ?? provider.uiName)
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, "");
+    expect(href.includes(expected), `Provider "${provider.uiName}" should appear in URL`).toBe(
+      true,
+    );
   }
 
   private async waitForGoToUrl(): Promise<string> {
@@ -288,12 +300,6 @@ export class BuyAndSellPage extends WebViewAppPage {
 
     if (!stableUrl) throw new Error("No GoTo URL found in webviewUrlHistory after waiting.");
     return stableUrl;
-  }
-
-  private verifyProviderInUrl(url: URL, providerUiName: string) {
-    const href = url.href.toLowerCase().replace(/[^a-z0-9]/g, "");
-    const provider = providerUiName.toLowerCase().replace(/[^a-z0-9]/g, "");
-    expect(href.includes(provider), `Provider "${providerUiName}" should appear in URL`).toBe(true);
   }
 
   private verifyQueryParams(url: URL, config: ProviderConfig, buySell: BuySell) {

--- a/e2e/desktop/tests/page/buyAndSell.page.ts
+++ b/e2e/desktop/tests/page/buyAndSell.page.ts
@@ -5,6 +5,7 @@ import { BuySell, Fiat } from "@ledgerhq/live-e2e-shared/models/BuySell";
 import { expect } from "@playwright/test";
 import { ChooseAssetDrawer } from "./drawer/choose.asset.drawer";
 import { BuySellProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
+import { pickRotatingProvider } from "@ledgerhq/live-e2e-shared/buySell";
 import { OperationType } from "@ledgerhq/live-e2e-shared/enum/OperationType";
 import { doubleDecodeGoToURL } from "../utils/urlUtils";
 import { getAccountAddressesFromAppJson } from "../utils/getAccountAddressesUtils";
@@ -226,22 +227,18 @@ export class BuyAndSellPage extends WebViewAppPage {
     return titles.map(title => title.trim());
   }
 
-  @step("Select random provider")
-  async selectRandomProvider(operation: string): Promise<BuySellProvider> {
-    const uiNamesFromQuotes = await this.getAvailableProviders();
-    const testedProviders = uiNamesFromQuotes
-      .map(uiName => BuySellProvider.getByUiName(uiName))
-      .filter((p): p is BuySellProvider => Boolean(p?.isTested));
-
-    if (testedProviders.length === 0) {
-      throw new Error(
-        `No known tested providers in quotes. UI listed: ${uiNamesFromQuotes.join(", ") || "(none)"}`,
-      );
-    }
-
-    const selected = testedProviders[Math.floor(Math.random() * testedProviders.length)];
+  @step("Select rotating provider")
+  async selectRotatingProvider(operation: string): Promise<BuySellProvider> {
+    const availableProviders = await this.getAvailableProviders();
+    const selected = pickRotatingProvider(availableProviders);
+    await this.logSelectedProvider(selected.uiName);
     await this.selectProviderQuote(operation, selected);
     return selected;
+  }
+
+  @step("Selected provider: $0")
+  async logSelectedProvider(providerName: string) {
+    expect(providerName).toBeDefined();
   }
 
   @step("Select quote")

--- a/e2e/desktop/tests/page/webViewApp.page.ts
+++ b/e2e/desktop/tests/page/webViewApp.page.ts
@@ -149,6 +149,13 @@ export abstract class WebViewAppPage extends AppPage {
     return webview.getByTestId(testId);
   }
 
+  @step("Get texts by CSS selector: $0")
+  protected async getTextsByCssSelector(cssSelector: string): Promise<string[]> {
+    const webview = await this.getWebView();
+    await expect(webview.locator(cssSelector).first()).toBeVisible();
+    return webview.locator(cssSelector).allTextContents();
+  }
+
   @step("Expect text to be visible in WebView")
   protected async expectTextToBeVisible(text: string) {
     const webview = await this.getWebView();

--- a/e2e/desktop/tests/specs/buySell.spec.ts
+++ b/e2e/desktop/tests/specs/buySell.spec.ts
@@ -148,7 +148,7 @@ for (const asset of assets) {
         await app.buyAndSell.verifyBuyInfoBox();
         await app.buyAndSell.verifyProviderInfoIsNotVisible();
         await app.buyAndSell.setAmountToPay(amount, operation);
-        const provider = await app.buyAndSell.selectRandomProvider(operation);
+        const provider = await app.buyAndSell.selectRotatingProvider(operation);
         await app.buyAndSell.selectQuote();
         await app.buyAndSell.verifyProviderUrl(provider, asset.buySell, userdataDestinationPath);
       },
@@ -184,7 +184,7 @@ const sellAssets: Array<{ buySell: Omit<BuySell, "amount">; xrayTicket: string }
 ];
 
 for (const sellAsset of sellAssets) {
-  test.describe("Sell flow - ", () => {
+  test.describe(`Sell flow - [${sellAsset.buySell.crypto.currency.name}]`, () => {
     setupEnv(true);
 
     const { crypto, fiat, operation } = sellAsset.buySell;
@@ -219,7 +219,7 @@ for (const sellAsset of sellAssets) {
         const amount = await getMinimumSellAmount(crypto.currency.id);
         const buySell = { ...sellAsset.buySell, amount };
         await app.buyAndSell.setAmountToPay(amount, operation);
-        const provider = await app.buyAndSell.selectRandomProvider(operation);
+        const provider = await app.buyAndSell.selectRotatingProvider(operation);
         await app.buyAndSell.selectQuote();
         await app.buyAndSell.verifyProviderUrl(provider, buySell, userdataDestinationPath);
       },

--- a/e2e/desktop/tests/specs/buySell.spec.ts
+++ b/e2e/desktop/tests/specs/buySell.spec.ts
@@ -9,13 +9,12 @@ import {
 } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { setupEnv } from "tests/utils/swapUtils";
 import { BuySell } from "@ledgerhq/live-e2e-shared/models/BuySell";
-import { BuySellProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
 import { OperationType } from "@ledgerhq/live-e2e-shared/enum/OperationType";
 import { liveDataCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
 import { getMinimumSellAmount } from "@ledgerhq/live-e2e-shared/buySell";
 import { buildTags, DEVICE_TAGS } from "tests/utils/tagsUtils";
 
-const assets: Array<{ buySell: BuySell; xrayTicket: string; provider: BuySellProvider }> = [
+const assets: Array<{ buySell: BuySell; xrayTicket: string }> = [
   {
     buySell: {
       crypto: Account.BTC_NATIVE_SEGWIT_1,
@@ -25,7 +24,6 @@ const assets: Array<{ buySell: BuySell; xrayTicket: string; provider: BuySellPro
     },
     xrayTicket:
       "B2CQA-3391, B2CQA-3412, B2CQA-3467, B2CQA-3520, B2CQA-3521, B2CQA-3449, B2CQA-3282",
-    provider: BuySellProvider.MOONPAY,
   },
   {
     buySell: {
@@ -36,7 +34,6 @@ const assets: Array<{ buySell: BuySell; xrayTicket: string; provider: BuySellPro
     },
     xrayTicket:
       "B2CQA-3392, B2CQA-3413, B2CQA-3466, B2CQA-3519, B2CQA-3522, B2CQA-3449, B2CQA-3289",
-    provider: BuySellProvider.MOONPAY,
   },
   {
     buySell: {
@@ -46,7 +43,6 @@ const assets: Array<{ buySell: BuySell; xrayTicket: string; provider: BuySellPro
       operation: OperationType.Buy,
     },
     xrayTicket: "B2CQA-3393, B2CQA-3414, B2CQA-3468, B2CQA-3518, B2CQA-3523, B2CQA-3449",
-    provider: BuySellProvider.MOONPAY,
   },
 ];
 
@@ -152,13 +148,9 @@ for (const asset of assets) {
         await app.buyAndSell.verifyBuyInfoBox();
         await app.buyAndSell.verifyProviderInfoIsNotVisible();
         await app.buyAndSell.setAmountToPay(amount, operation);
-        await app.buyAndSell.selectProviderQuote(operation, asset.provider.uiName);
+        const provider = await app.buyAndSell.selectRandomProvider(operation);
         await app.buyAndSell.selectQuote();
-        await app.buyAndSell.verifyProviderUrl(
-          asset.provider.uiName,
-          asset.buySell,
-          userdataDestinationPath,
-        );
+        await app.buyAndSell.verifyProviderUrl(provider, asset.buySell, userdataDestinationPath);
       },
     );
   });
@@ -167,7 +159,6 @@ for (const asset of assets) {
 const sellAsset: {
   buySell: Omit<BuySell, "amount">;
   xrayTicket: string;
-  provider: BuySellProvider;
 } = {
   buySell: {
     crypto: Account.BTC_NATIVE_SEGWIT_1,
@@ -175,7 +166,6 @@ const sellAsset: {
     operation: OperationType.Sell,
   },
   xrayTicket: "B2CQA-3524",
-  provider: BuySellProvider.MOONPAY,
 };
 
 test.describe("Sell flow - ", () => {
@@ -212,13 +202,9 @@ test.describe("Sell flow - ", () => {
       const amount = await getMinimumSellAmount(crypto.currency.id);
       const buySell = { ...sellAsset.buySell, amount };
       await app.buyAndSell.setAmountToPay(amount, operation);
-      await app.buyAndSell.selectProviderQuote(operation, sellAsset.provider.uiName);
+      const provider = await app.buyAndSell.selectRandomProvider(operation);
       await app.buyAndSell.selectQuote();
-      await app.buyAndSell.verifyProviderUrl(
-        sellAsset.provider.uiName,
-        buySell,
-        userdataDestinationPath,
-      );
+      await app.buyAndSell.verifyProviderUrl(provider, buySell, userdataDestinationPath);
     },
   );
 });

--- a/e2e/desktop/tests/specs/buySell.spec.ts
+++ b/e2e/desktop/tests/specs/buySell.spec.ts
@@ -156,55 +156,73 @@ for (const asset of assets) {
   });
 }
 
-const sellAsset: {
-  buySell: Omit<BuySell, "amount">;
-  xrayTicket: string;
-} = {
-  buySell: {
-    crypto: Account.BTC_NATIVE_SEGWIT_1,
-    fiat: { locale: "fr-FR", currencyTicker: "EUR" },
-    operation: OperationType.Sell,
+const sellAssets: Array<{ buySell: Omit<BuySell, "amount">; xrayTicket: string }> = [
+  {
+    buySell: {
+      crypto: Account.BTC_NATIVE_SEGWIT_1,
+      fiat: { locale: "fr-FR", currencyTicker: "EUR" },
+      operation: OperationType.Sell,
+    },
+    xrayTicket: "B2CQA-6131",
   },
-  xrayTicket: "B2CQA-3524",
-};
+  {
+    buySell: {
+      crypto: Account.ETH_1,
+      fiat: { locale: "fr-FR", currencyTicker: "EUR" },
+      operation: OperationType.Sell,
+    },
+    xrayTicket: "B2CQA-6132",
+  },
+  {
+    buySell: {
+      crypto: TokenAccount.ETH_USDT_1,
+      fiat: { locale: "fr-FR", currencyTicker: "EUR" },
+      operation: OperationType.Sell,
+    },
+    xrayTicket: "B2CQA-6133",
+  },
+];
 
-test.describe("Sell flow - ", () => {
-  setupEnv(true);
+for (const sellAsset of sellAssets) {
+  test.describe("Sell flow - ", () => {
+    setupEnv(true);
 
-  const { crypto, fiat, operation } = sellAsset.buySell;
+    const { crypto, fiat, operation } = sellAsset.buySell;
 
-  test.use({
-    teamOwner: Team.BUY_AND_SELL,
-    userdata: "skip-onboarding-with-last-seen-device",
-    speculosApp: crypto.currency.speculosApp,
-    cliCommands: [liveDataCommand(crypto)],
-    speculosForSetupOnly: true,
-  });
+    test.use({
+      teamOwner: Team.BUY_AND_SELL,
+      userdata: "skip-onboarding-with-last-seen-device",
+      speculosApp: crypto.currency.speculosApp,
+      cliCommands: [liveDataCommand(crypto)],
+      speculosForSetupOnly: true,
+    });
 
-  test(
-    `Sell [${crypto.currency.name}] asset`,
-    {
-      tag: buildTags({ currencyId: crypto.currency.id }),
-      annotation: {
-        type: "TMS",
-        description: sellAsset.xrayTicket,
+    test(
+      `Sell [${crypto.currency.name}] asset`,
+      {
+        tag: buildTags({ currencyId: crypto.currency.id }),
+        annotation: {
+          type: "TMS",
+          description: sellAsset.xrayTicket,
+        },
       },
-    },
-    async ({ app, userdataDestinationPath }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.portfolio.clickSellButton();
-      await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(crypto, OperationType.Sell);
-      await app.buyAndSell.verifyFiatAssetSelector("USD");
-      await app.buyAndSell.verifySellInfoBox();
-      await app.buyAndSell.verifyProviderInfoIsNotVisible();
-      await app.buyAndSell.changeRegionAndCurrency(fiat);
-      await app.buyAndSell.verifyFiatAssetSelector(fiat.currencyTicker);
-      const amount = await getMinimumSellAmount(crypto.currency.id);
-      const buySell = { ...sellAsset.buySell, amount };
-      await app.buyAndSell.setAmountToPay(amount, operation);
-      const provider = await app.buyAndSell.selectRandomProvider(operation);
-      await app.buyAndSell.selectQuote();
-      await app.buyAndSell.verifyProviderUrl(provider, buySell, userdataDestinationPath);
-    },
-  );
-});
+      async ({ app, userdataDestinationPath }) => {
+        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+        await app.portfolio.clickSellButton();
+        await app.buyAndSell.chooseAssetIfNotSelected(crypto);
+        await app.buyAndSell.verifyBuySellLandingAndCryptoAssetSelector(crypto, OperationType.Sell);
+        await app.buyAndSell.verifyFiatAssetSelector("USD");
+        await app.buyAndSell.verifySellInfoBox();
+        await app.buyAndSell.verifyProviderInfoIsNotVisible();
+        await app.buyAndSell.changeRegionAndCurrency(fiat);
+        await app.buyAndSell.verifyFiatAssetSelector(fiat.currencyTicker);
+        const amount = await getMinimumSellAmount(crypto.currency.id);
+        const buySell = { ...sellAsset.buySell, amount };
+        await app.buyAndSell.setAmountToPay(amount, operation);
+        const provider = await app.buyAndSell.selectRandomProvider(operation);
+        await app.buyAndSell.selectQuote();
+        await app.buyAndSell.verifyProviderUrl(provider, buySell, userdataDestinationPath);
+      },
+    );
+  });
+}

--- a/e2e/mobile/page/trade/buySell.page.ts
+++ b/e2e/mobile/page/trade/buySell.page.ts
@@ -2,6 +2,7 @@ import { Step } from "jest-allure2-reporter/api";
 import { AccountType, getParentAccountName } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { BuySell, Fiat } from "@ledgerhq/live-e2e-shared/models/BuySell";
 import { BuySellProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
+import { pickRotatingProvider } from "@ledgerhq/live-e2e-shared/buySell";
 import { openDeeplink, normalizeText } from "../../helpers/commonHelpers";
 import { checkForErrorElement, ERROR_MODAL_SELECTORS } from "../../helpers/errorHelpers";
 import { sanitizeError } from "@ledgerhq/live-e2e-shared/index";
@@ -157,25 +158,14 @@ export default class BuySellPage {
     return providerNames;
   }
 
-  @Step("Select random provider")
-  async selectRandomProvider(): Promise<string> {
-    const uiNamesFromQuotes = await this.getAvailableProviders();
-    const testedProviders = uiNamesFromQuotes
-      .map(uiName => BuySellProvider.getByUiName(uiName))
-      .filter((p): p is BuySellProvider => Boolean(p?.isTested));
+  @Step("Select rotating provider")
+  async selectRotatingProvider(): Promise<BuySellProvider> {
+    const availableProviders = await this.getAvailableProviders();
+    const selected = pickRotatingProvider(availableProviders);
 
-    if (testedProviders.length === 0) {
-      throw new Error(
-        `No known tested providers in quotes. UI listed: ${uiNamesFromQuotes.join(", ") || "(none)"}`,
-      );
-    }
-
-    const selected = testedProviders[Math.floor(Math.random() * testedProviders.length)];
-    const testIdName = selected.name;
-
-    await scrollToWebElement(getWebElementByTestId(this.provider(testIdName)));
-    await tapWebElementByTestId(this.provider(testIdName));
-    return selected.uiName;
+    await scrollToWebElement(getWebElementByTestId(this.provider(selected.name)));
+    await tapWebElementByTestId(this.provider(selected.name));
+    return selected;
   }
 
   @Step("Select provider")
@@ -233,10 +223,10 @@ export default class BuySellPage {
     await this.chooseCountryIfNotSelected(buySell.fiat);
     await this.tapSeeQuotes();
     await this.selectPaymentMethod(paymentMethod);
-    const selectedProvider = await this.selectRandomProvider();
-    await this.tapBuySellWithCta(selectedProvider, buySell.operation);
-    await this.verifyProviderPageLoadedWithCorrectUrl(selectedProvider);
-    await this.verifyProviderPageIsNotBlank(selectedProvider);
+    const selectedProvider = await this.selectRotatingProvider();
+    await this.tapBuySellWithCta(selectedProvider.uiName, buySell.operation);
+    await this.verifyProviderPageLoadedWithCorrectUrl(selectedProvider.uiName);
+    await this.verifyProviderPageIsNotBlank(selectedProvider.uiName);
   }
 
   @Step("Handle sell flow")

--- a/e2e/mobile/specs/buySell/sellFlow_BTC.spec.ts
+++ b/e2e/mobile/specs/buySell/sellFlow_BTC.spec.ts
@@ -9,7 +9,7 @@ const testConfig = {
     fiat: { locale: "en-US", currencyTicker: "USD" },
     operation: OperationType.Sell,
   },
-  tmsLinks: ["B2CQA-3524"],
+  tmsLinks: ["B2CQA-6131"],
   provider: BuySellProvider.MOONPAY,
   paymentMethod: "card",
   tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@bitcoin", "@family-bitcoin"],

--- a/libs/live-e2e-shared/src/buySell.ts
+++ b/libs/live-e2e-shared/src/buySell.ts
@@ -1,10 +1,14 @@
 import { getAmountFromUSD } from "./currencyUtils";
 import { sanitizeError } from "./index";
+import { BuySellProvider } from "./enum/Provider";
 import axios, { AxiosRequestConfig } from "axios";
 
 const BUY_SELL_BASE_URL = "https://buy.api.aws.prd.ldg-tech.com";
 const SELL_CRYPTO_LIMITATION_ENDPOINT = "/sell/v1/cryptoLimitations";
 const FALLBACK_TARGET_USD = 10;
+
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const MONDAY_EPOCH_UTC_MS = Date.UTC(2024, 0, 1);
 
 type CryptoLimitation = {
   min: string;
@@ -25,6 +29,50 @@ export async function getMinimumSellAmount(currencyId: string): Promise<string> 
   const factor = 10 ** 6;
   const roundedUp = Math.ceil((amount - Number.EPSILON) * factor) / factor;
   return roundedUp.toString();
+}
+
+/**
+ * Deterministic weekly rotation over the tested providers, restricted to the
+ * ones actually offered in the quotes. Same week + same availability picks the
+ * same provider (reproducible reruns) and coverage rotates weekly. Mirrors
+ * swap's `pickRotatingProvider` (walks forward past unavailable providers).
+ * `BUYSELL_PROVIDER` (uiName or name) forces a provider when it is available.
+ */
+export function pickRotatingProvider(availableUiNames: string[]): BuySellProvider {
+  const available = new Set(
+    availableUiNames
+      .map(uiName => BuySellProvider.getByUiName(uiName))
+      .filter((p): p is BuySellProvider => Boolean(p?.isTested))
+      .map(p => p.name),
+  );
+  if (available.size === 0) {
+    throw new Error(
+      `No known tested providers in quotes. UI listed: ${availableUiNames.join(", ") || "(none)"}`,
+    );
+  }
+
+  const eligible = Object.values(BuySellProvider).filter(
+    (p): p is BuySellProvider => p instanceof BuySellProvider && p.isTested,
+  );
+
+  const override = process.env.BUYSELL_PROVIDER;
+  if (override) {
+    const match = eligible.find(
+      p => (p.uiName === override || p.name === override) && available.has(p.name),
+    );
+    if (!match) {
+      throw new Error(`❌ BUYSELL_PROVIDER="${override}" is not an available tested provider`);
+    }
+    return match;
+  }
+
+  const weekIndex = Math.floor((Date.now() - MONDAY_EPOCH_UTC_MS) / ONE_WEEK_MS);
+  const scheduledIndex = weekIndex % eligible.length;
+  for (let offset = 0; offset < eligible.length; offset++) {
+    const candidate = eligible[(scheduledIndex + offset) % eligible.length];
+    if (available.has(candidate.name)) return candidate;
+  }
+  throw new Error("No available tested provider found in quotes");
 }
 
 async function fetchMinimumSellAmount(currencyId: string): Promise<number | null> {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _This PR is itself an e2e (Playwright) change; the updated `buySell.spec` was run locally against Speculos — 15/15 passing across multiple runs._
- [x] **Impact of the changes:**
  - Desktop Buy/Sell e2e (`buySell.spec`)
  - Random provider selection across the tested-provider pool (buy and sell)
  - Sell flow for BTC, ETH, and USDT (ERC-20 token) — token asset selection via the drawer
  - Provider redirect URL verification (strict for MoonPay; provider-name-in-URL for the rest, with the Mercuryo `mrcr.io` alias)

### 📝 Description

**Problem:** `e2e/desktop/tests/specs/buySell.spec.ts` (QAA-1107 review) hardcoded `MOONPAY` for every quote and only covered **BTC** on the sell side, while buy already covered BTC/ETH/USDT.

**Solution:**

- **Random provider selection (mirrors LWM):** added `getAvailableProviders()` + `selectRandomProvider()` to the desktop `buyAndSell` page object — they read the providers actually shown in the quotes, keep the ones that are `isTested`, and pick one at random. Used for both buy and sell instead of hardcoded MoonPay.
- **Expanded sell coverage to BTC, ETH and USDT:** the sell block now loops over the three assets (was a single BTC case), adding `chooseAssetIfNotSelected(crypto)` so the token/multi-asset portfolio selects the right asset.
- **Provider URL verification:** MoonPay keeps the strict query-param + destination-address checks. All providers are verified by a normalized provider-name-in-URL check, with a small alias map for providers served from a different domain (Mercuryo → `mrcr.io`). The pre-existing Transak/Coinbase strict configs were removed — they were never exercised and are incompatible with those providers' current session-token / quote-id URLs.
- **Minor:** aligned the mobile BTC sell TMS link to `B2CQA-6131` to match the desktop ticket.

### 🧪 Test execution

E2E dispatched on this branch, scoped to buySell:
- Desktop (LWD) — `buySell.spec`, Speculos nanoSP: [run 29731452351](https://github.com/LedgerHQ/ledger-live/actions/runs/29731452351)
- Mobile (LWM) — buySell, Android, Speculos nanoSP: [run 29731454317](https://github.com/LedgerHQ/ledger-live/actions/runs/29731454317)

### ❓ Context

- **JIRA or GitHub link**: [QAA-1107](https://ledgerhq.atlassian.net/browse/QAA-1107)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1107]: https://ledgerhq.atlassian.net/browse/QAA-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ