### PR TITLE
[LWDM] docs: add lifecycle status markers to all lib/package READMEs

### DIFF
--- a/docs/new-library.md
+++ b/docs/new-library.md
@@ -21,7 +21,7 @@ The repo is moving toward a DDD layout (`domain/`, `features/`, `shared/`); it i
 - [ ] `scripts.test` and `scripts.coverage` — `jest` / `jest --coverage`
 
 **Additional files**
-- [ ] `README.md` — scope, problem solved, main exports (a few paragraphs)
+- [ ] `README.md` — scope, problem solved, main exports (a few paragraphs); **must include a status marker** (see [README status marker](#readme-status-marker) below)
 - [ ] `tsconfig.json` — use the template below
 - [ ] `jest.config.js` — `@swc/jest` transformer, `testEnvironment: "node"` (or `"jsdom"` for React), sonar reporter; copy from a neighbouring package
 - [ ] `project.json` — minimum `{ "targets": { "build": { "executor": "nx:noop" } } }` for source-only packages; required for Nx task graph
@@ -58,3 +58,48 @@ The repo is moving toward a DDD layout (`domain/`, `features/`, `shared/`); it i
 | `libs/` | `@ledgerhq/<name>` | `@ledgerhq/coin-evm` |
 
 Keep names short and self-describing. No cross-package relative imports — always use the npm package name.
+
+## README status marker
+
+Every package README must declare its lifecycle status right after the first `# Title` heading. Use a GitHub callout block so it renders prominently on GitHub and in IDEs.
+
+### STABLE
+
+The package is production-ready and its public API is considered stable.
+
+```markdown
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+```
+
+### UNSTABLE
+
+The package is in active development; its API may change without notice.
+
+```markdown
+> [!CAUTION]
+> **Status: UNSTABLE** — <one-line reason, e.g. "In active development; API may change.">
+```
+
+Common reasons:
+- New package with an API still being designed.
+- Package is part of the emerging `domain/` / `features/` / `shared/` DDD layer and is under active development.
+- Package is being migrated from another location (e.g. out of `live-common`).
+
+### DEPRECATED
+
+The package is no longer receiving new features. Consumers should migrate away.
+
+```markdown
+> [!WARNING]
+> **Status: DEPRECATED** — <one-line reason and/or migration target.>
+```
+
+Common reasons:
+- Package is in maintenance mode and being progressively dismantled.
+- Package is scheduled to be removed or extracted to another repository.
+- A replacement package exists (always name it).
+
+### Updating the marker
+
+When a package's status changes (e.g. UNSTABLE → STABLE after an API stabilisation, or STABLE → DEPRECATED), update the marker in the README as part of the same PR that makes the change.

--- a/domain/api/altcoins-sentiment/README.md
+++ b/domain/api/altcoins-sentiment/README.md
@@ -1,5 +1,8 @@
 # @domain/api-altcoins-sentiment
 
+> [!CAUTION]
+> **Status: UNSTABLE** — Part of the emerging DDD layer; under active development.
+
 Domain API client for **altcoins sentiment**, backed by the CoinMarketCap Altcoin Season Index
 endpoint. RTK Query endpoint typed on the canonical `@domain/entity-altcoins-sentiment` entity. Owns
 no env/config/logging dependency.

--- a/domain/api/currency-fiat/README.md
+++ b/domain/api/currency-fiat/README.md
@@ -1,5 +1,8 @@
 # @domain/api-currency-fiat
 
+> [!CAUTION]
+> **Status: UNSTABLE** — Part of the emerging DDD layer; under active development.
+
 Domain API client for **fiat currencies**, backed by the Ledger Countervalues Service (CVS). RTK
 Query endpoint and helpers, typed on the Zod-first `@domain/entity-currency-fiat` entity. Owns no
 env/config/logging dependency.

--- a/domain/api/currency-token/README.md
+++ b/domain/api/currency-token/README.md
@@ -1,5 +1,8 @@
 # @domain/api-currency-token
 
+> [!CAUTION]
+> **Status: UNSTABLE** — Part of the emerging DDD layer; under active development.
+
 Domain API client for **token currencies**, backed by the Crypto Asset List (CAL). RTK Query
 endpoints and helpers, typed on the Zod-first `@domain/entity-currency-token` entity. Owns no
 env/config/logging dependency.

--- a/domain/api/market-sentiment/README.md
+++ b/domain/api/market-sentiment/README.md
@@ -1,5 +1,8 @@
 # @domain/api-market-sentiment
 
+> [!CAUTION]
+> **Status: UNSTABLE** — Part of the emerging DDD layer; under active development.
+
 Domain API client for **market sentiment**, backed by the CoinMarketCap Crypto Fear & Greed endpoint.
 RTK Query endpoint typed on the canonical `@domain/entity-market-sentiment` entity. Owns no
 env/config/logging dependency.

--- a/domain/api/push-devices/README.md
+++ b/domain/api/push-devices/README.md
@@ -1,5 +1,8 @@
 # @domain/api-push-devices
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Domain API client for the **Push Devices Service** — the Ledger backend endpoint that associates a user's device push tokens with their userId. RTK Query endpoint and Redux middleware, typed on `@domain/entity-client-identity`.
 
 ## Responsibility

--- a/domain/entity/altcoins-sentiment/README.md
+++ b/domain/entity/altcoins-sentiment/README.md
@@ -1,5 +1,8 @@
 # @domain/entity-altcoins-sentiment
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Domain entity for **altcoins sentiment**, backed by the CoinMarketCap Altcoin Season Index.
 
 - `schema.ts` — `AltcoinSeasonIndexSchema` (canonical `{ value, altcoinMarketcap }`).

--- a/domain/entity/client-identity/README.md
+++ b/domain/entity/client-identity/README.md
@@ -1,5 +1,8 @@
 # @domain/entity-client-identity
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Privacy-protected identity value objects and Redux slice for the three client identities managed by Ledger Live: **UserId**, **DatadogId**, and **DeviceId**.
 
 ## Responsibility

--- a/domain/entity/contact/README.md
+++ b/domain/entity/contact/README.md
@@ -1,5 +1,8 @@
 # @domain/entity-contact
 
+> [!CAUTION]
+> **Status: UNSTABLE** — In active development as part of the Contacts feature.
+
 Domain entity for Contacts. It contains the Zod-first model, Redux slice, selectors, and mock factories required by the first Contacts flows.
 
 ## Scope

--- a/domain/entity/currency-crypto/README.md
+++ b/domain/entity/currency-crypto/README.md
@@ -1,5 +1,8 @@
 # @domain/entity-currency-crypto
 
+> [!CAUTION]
+> **Status: UNSTABLE** — Part of the emerging DDD layer; under active development.
+
 Zod-first canonical schema and static registry for the `CryptoCurrency` domain entity.
 
 ## Responsibility

--- a/domain/entity/currency-fiat/README.md
+++ b/domain/entity/currency-fiat/README.md
@@ -1,5 +1,8 @@
 # @domain/entity-currency-fiat
 
+> [!CAUTION]
+> **Status: UNSTABLE** — Part of the emerging DDD layer; under active development.
+
 Zod-first canonical schema and static registry for the `FiatCurrency` domain entity.
 
 ## Responsibility

--- a/domain/entity/currency-token/README.md
+++ b/domain/entity/currency-token/README.md
@@ -1,5 +1,8 @@
 # @domain/entity-currency-token
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Domain entity for token currencies: Zod-first schema with FK-based parent currency reference.
 
 ## Key Design

--- a/domain/entity/currency-unit/README.md
+++ b/domain/entity/currency-unit/README.md
@@ -1,5 +1,8 @@
 # @domain/entity-currency-unit
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Zod-first schema for the `Unit` value object.
 
 A `Unit` represents a denomination of a currency (e.g. BTC, mBTC, satoshi). It is a **value object** —

--- a/domain/entity/currency/README.md
+++ b/domain/entity/currency/README.md
@@ -1,5 +1,8 @@
 # @domain/entity-currency
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Currency union types and single entry-point for all currency entity packages.
 
 ## Responsibility

--- a/domain/entity/large-screen-upsell-modal/README.md
+++ b/domain/entity/large-screen-upsell-modal/README.md
@@ -1,5 +1,8 @@
 # @domain/entity-large-screen-upsell-modal
 
+> [!CAUTION]
+> **Status: UNSTABLE** — In active development as part of the large-screen upsell feature.
+
 Domain entity for the large-screen upsell modal's display-frequency state: how many times it has
 been shown (`retries`) and when it was last shown (`lastSeenAt`).
 

--- a/domain/entity/market-sentiment/README.md
+++ b/domain/entity/market-sentiment/README.md
@@ -1,5 +1,8 @@
 # @domain/entity-market-sentiment
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Domain entity for **market sentiment**, backed by the CoinMarketCap Crypto Fear & Greed index.
 
 - `schema.ts` — `FearAndGreedIndexSchema` (canonical `{ value, classification }`).

--- a/features/flow/card/README.md
+++ b/features/flow/card/README.md
@@ -1,5 +1,8 @@
 # Card
 
+> [!CAUTION]
+> **Status: UNSTABLE** — In active development.
+
 Cross-platform card flow scaffold for Ledger Live. Currently exposes a minimal
 `CardScreen` used as a placeholder inside the Pay tab of both apps.
 

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -1,5 +1,8 @@
 # @features/flow-contacts
 
+> [!CAUTION]
+> **Status: UNSTABLE** — In active development as part of the Contacts feature.
+
 Shared Contacts flow package for Desktop and Mobile.
 
 ## Scope

--- a/features/flow/fear-and-greed/README.md
+++ b/features/flow/fear-and-greed/README.md
@@ -1,5 +1,8 @@
 # @features/flow-fear-and-greed
 
+> [!CAUTION]
+> **Status: UNSTABLE** — In active development.
+
 User-facing Fear & Greed helpers shared across desktop and mobile.
 
 - `utils/fearAndGreed.ts` — maps a Fear & Greed value (0-100) to a `FearAndGreedLevel`, a translation

--- a/features/flow/large-screen-upsell/README.md
+++ b/features/flow/large-screen-upsell/README.md
@@ -1,5 +1,8 @@
 # @features/flow-large-screen-upsell
 
+> [!CAUTION]
+> **Status: UNSTABLE** — In active development as part of the large-screen upsell feature.
+
 Eligibility + frequency-throttle decision for the large-screen upsell modal, plus the
 portable modal UI (Lumen Dialog) and content helpers.
 

--- a/features/flow/market-banner/README.md
+++ b/features/flow/market-banner/README.md
@@ -1,5 +1,8 @@
 # Market Banner
 
+> [!CAUTION]
+> **Status: UNSTABLE** — In active development.
+
 Cross-platform banner component for Ledger Live.
 
 ## Usage

--- a/features/platform/currencies/README.md
+++ b/features/platform/currencies/README.md
@@ -1,5 +1,8 @@
 # `@features/platform-currencies`
 
+> [!CAUTION]
+> **Status: UNSTABLE** — Part of the emerging DDD layer; under active development.
+
 App-facing currency **runtime glue**. Mirrors `@features/platform-feature-flags`:
 this package owns hooks + the crypto-assets store builder; currency **state lives in
 the `@domain/entity-currency-*` packages** (no slices here).

--- a/features/platform/feature-flags/README.md
+++ b/features/platform/feature-flags/README.md
@@ -1,5 +1,8 @@
 # `@features/platform-feature-flags`
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Redux-backed React hooks for resolved feature flags. Drop-in replacement for the
 Context-based hooks exported from `@ledgerhq/live-common/featureFlags`.
 

--- a/features/platform/jest-config/README.md
+++ b/features/platform/jest-config/README.md
@@ -1,5 +1,8 @@
 # @features/platform-jest-config
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Shared jest configuration for `features/flow/*` packages.
 
 `createFlowJestConfig()` returns a dual-project jest config:

--- a/features/platform/style/README.md
+++ b/features/platform/style/README.md
@@ -1,5 +1,8 @@
 # @features/platform-style
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Single source of truth for the React theme provider across Ledger Live apps, following the DDD `features/platform` architecture.
 
 ## What it provides

--- a/libs/asset-aggregation/README.md
+++ b/libs/asset-aggregation/README.md
@@ -1,5 +1,8 @@
 # asset-aggregation
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/asset-aggregation` aggregates and categorizes assets across all user accounts for portfolio display in Ledger Live. It computes per-asset totals, groups assets by category, and calculates the distribution of holdings — feeding the portfolio and asset screens on both desktop and mobile.
 
 ## What it does

--- a/libs/asset-detail/README.md
+++ b/libs/asset-detail/README.md
@@ -1,5 +1,8 @@
 # asset-detail
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/asset-detail` is a shared module providing React hooks, types, and utilities for the asset detail screen in Ledger Live. It abstracts the data-fetching and formatting logic needed to display an asset's market data (price, chart, stats) in one place, shared between desktop and mobile.
 
 ## What it does

--- a/libs/coin-modules-monitoring/README.md
+++ b/libs/coin-modules-monitoring/README.md
@@ -1,5 +1,8 @@
 # @ledgerhq/coin-modules-monitoring
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 A monitoring tool that measures the performance of cryptocurrency modules in the Ledger Live ecosystem. It tracks scan and sync operations across different blockchain networks, measuring execution time, network calls, CPU usage, and memory consumption.
 
 ## 🎯 Purpose

--- a/libs/coin-modules/coin-canton/README.md
+++ b/libs/coin-modules/coin-canton/README.md
@@ -1,5 +1,8 @@
 # coin-canton
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 This repository contains the Coin Canton module for Ledger Live.
 
 ## Overview

--- a/libs/coin-tester-modules/README.md
+++ b/libs/coin-tester-modules/README.md
@@ -1,5 +1,8 @@
 # coin-tester-modules
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 A workspace directory of coin-specific end-to-end test packages for Ledger Live. Each sub-package implements the test scenarios, fixtures, and hardware-wallet signer integration needed to run the coin tester against a real (or simulated) Ledger device for a specific blockchain.
 
 ## What it does

--- a/libs/coin-tester-modules/coin-tester-bitcoin/README.md
+++ b/libs/coin-tester-modules/coin-tester-bitcoin/README.md
@@ -1,5 +1,8 @@
 # @ledgerhq/coin-tester-bitcoin
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 This package contains the deterministic testing infrastructure for Bitcoin in Ledger Live.
 
 ## Features

--- a/libs/coin-tester-modules/coin-tester-cardano/README.md
+++ b/libs/coin-tester-modules/coin-tester-cardano/README.md
@@ -1,5 +1,8 @@
 # @ledgerhq/coin-tester-cardano
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 This package contains the deterministic testing infrastructure for Cardano in Ledger Live.
 
 ## Features

--- a/libs/coin-tester-modules/coin-tester-cosmos/README.md
+++ b/libs/coin-tester-modules/coin-tester-cosmos/README.md
@@ -1,5 +1,8 @@
 # @ledgerhq/coin-tester-cosmos
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 This package contains the testing infrastructure for Cosmos-SDK chains in Ledger
 Live, reusing the cosmos coin module end to end against local devnets. Two
 scenarios run:

--- a/libs/coin-tester-modules/coin-tester-evm/README.md
+++ b/libs/coin-tester-modules/coin-tester-evm/README.md
@@ -1,5 +1,8 @@
 # @ledgerhq/coin-tester-evm
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 This package contains the deterministic testing infrastructure for EVM-based coins in Ledger Live.
 
 ## Features

--- a/libs/coin-tester-modules/coin-tester-multiversx/README.md
+++ b/libs/coin-tester-modules/coin-tester-multiversx/README.md
@@ -1,5 +1,8 @@
 # @ledgerhq/coin-tester-multiversx
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Deterministic coin tester for the MultiversX (`coin-multiversx`) bridge. It runs
 the full bridge flow — sync, craft, sign, broadcast, account-state assertions —
 against a local [MultiversX Chain Simulator](https://github.com/multiversx/mx-chain-simulator-go)

--- a/libs/coin-tester-modules/coin-tester-polkadot/README.md
+++ b/libs/coin-tester-modules/coin-tester-polkadot/README.md
@@ -1,5 +1,8 @@
 # @ledgerhq/coin-tester-polkadot
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 This package contains the deterministic testing infrastructure for Polkadot in Ledger Live.
 
 ## Features

--- a/libs/coin-tester-modules/coin-tester-solana/README.md
+++ b/libs/coin-tester-modules/coin-tester-solana/README.md
@@ -1,5 +1,8 @@
 # @ledgerhq/coin-tester-solana
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 This package contains the deterministic testing infrastructure for Solana in Ledger Live.
 
 ## Features

--- a/libs/coin-tester-modules/coin-tester-tron/README.md
+++ b/libs/coin-tester-modules/coin-tester-tron/README.md
@@ -1,5 +1,8 @@
 # @ledgerhq/coin-tester-tron
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Deterministic integration tester for `@ledgerhq/coin-tron`. Spins up a local
 `tronbox/tre` node in Docker and runs scenarios through both the legacy bridge
 (`@ledgerhq/coin-tron/bridge`) — the bridge that ships in production — and the

--- a/libs/coin-tester-modules/coin-tester-xrp/README.md
+++ b/libs/coin-tester-modules/coin-tester-xrp/README.md
@@ -1,5 +1,8 @@
 # @ledgerhq/coin-tester-xrp
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Deterministic integration tester for the XRP family. Spins up a local rippled
 node in standalone mode via Docker and runs a single scenario through the
 coin-framework bridge that ships in production.

--- a/libs/coin-tester/README.md
+++ b/libs/coin-tester/README.md
@@ -1,5 +1,8 @@
 # Coin-tester
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 - [Setup](#setup)
 - [Run tests for a coin module](#runtests)
 

--- a/libs/concordium-core/README.md
+++ b/libs/concordium-core/README.md
@@ -1,5 +1,8 @@
 # @ledgerhq/concordium-core
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Shared Concordium protocol types, serialization, and utilities used by `@ledgerhq/coin-concordium` and `@ledgerhq/live-signer-concordium`.
 
 ## Purpose

--- a/libs/deeplink-module/README.md
+++ b/libs/deeplink-module/README.md
@@ -1,5 +1,8 @@
 # deeplink-module
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/wallet-api-deeplink-module` is a Wallet-API module that adds deep-link handling to Live apps embedded in Ledger Live. It allows web apps and DApps running inside the Ledger Live browser to trigger in-app navigation or actions by emitting deep-link URLs, which the host app then resolves.
 
 ## What it does

--- a/libs/device-core/README.md
+++ b/libs/device-core/README.md
@@ -1,5 +1,8 @@
 # device-core
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/device-core` is the core library for interacting with Ledger hardware devices in Ledger Live. It provides low-level device commands (APDU wrappers), high-level flows (firmware update, manager API), capability detection, and custom lock screen support — shared across desktop and mobile.
 
 ## What it does

--- a/libs/device-intent/README.md
+++ b/libs/device-intent/README.md
@@ -1,5 +1,8 @@
 # @ledgerhq/device-intent
 
+> [!CAUTION]
+> **Status: UNSTABLE** — The Device Intent Executor (DIE) pattern is actively rolling out across wallet flows; API may change.
+
 Shared types, helpers and the **Device Intent Executor** component for Ledger Wallet.
 
 See the [ADR: Device Intent Executor component](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6852083917) for the full design rationale.

--- a/libs/device-react/README.md
+++ b/libs/device-react/README.md
@@ -1,5 +1,8 @@
 # device-react
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/device-react` is a thin React layer on top of `@ledgerhq/device-core`, exposing React hooks for device-related operations in Ledger Live. It handles the async lifecycle of device queries (mounting/unmounting, state updates) so UI components don't have to.
 
 ## What it does

--- a/libs/disable-network-setup/README.md
+++ b/libs/disable-network-setup/README.md
@@ -1,5 +1,8 @@
 # @ledgerhq/disable-network-setup
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 This module disables all real network access during tests.
 
 It’s designed for use with Jest to enforce isolated and reliable test environments.

--- a/libs/domain-service/README.md
+++ b/libs/domain-service/README.md
@@ -1,5 +1,8 @@
 # Domain Service
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 ### Description
 
 This library is in charge of handling all domain related features for a Wallet

--- a/libs/env/README.md
+++ b/libs/env/README.md
@@ -1,5 +1,8 @@
 # live-env
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/live-env` centralizes all runtime environment variables and configuration flags for Ledger Live. It defines every env key with a typed default value and a description, and exposes a reactive API to read and override them at runtime — useful for debugging, testing, and feature toggling without a full rebuild.
 
 ## What it does

--- a/libs/ethereum-provider/README.md
+++ b/libs/ethereum-provider/README.md
@@ -1,5 +1,8 @@
 # ethereum-provider
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/ethereum-provider` implements an [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193)-compatible Ethereum provider backed by the Ledger Live Wallet API. It bridges dApps embedded in the Ledger Live webview (both Electron and React Native) to Ethereum accounts managed by the connected hardware wallet.
 
 ## What it does

--- a/libs/evm-tools/README.md
+++ b/libs/evm-tools/README.md
@@ -1,5 +1,8 @@
 # EVM Tools
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 ### Description
 
 This library is in charge of packaging a set of EVM related tools, needed by coin integrations, Nano app bindings & UI clients.

--- a/libs/exchange-module/README.md
+++ b/libs/exchange-module/README.md
@@ -1,5 +1,8 @@
 # wallet-api-exchange-module
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/wallet-api-exchange-module` is a [Wallet API](https://github.com/LedgerHQ/wallet-api) `CustomModule` that exposes swap, sell, and fund exchange flows to Live Apps running inside Ledger Live. It lets dApps initiate exchange transactions through Ledger Live's built-in exchange service without implementing device signing themselves.
 
 ## What it does

--- a/libs/feature-flag-module/README.md
+++ b/libs/feature-flag-module/README.md
@@ -1,5 +1,8 @@
 # wallet-api-feature-flag-module
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/wallet-api-feature-flag-module` is a [Wallet API](https://github.com/LedgerHQ/wallet-api) `CustomModule` that lets Live Apps query Ledger Live's feature flags at runtime. A Live App can gate UI or behaviour on whether a specific flag is enabled in the host app, without needing its own flag infrastructure.
 
 ## What it does

--- a/libs/hw-ledger-key-ring-protocol/README.md
+++ b/libs/hw-ledger-key-ring-protocol/README.md
@@ -1,5 +1,8 @@
 # @ledgerhq/hw-ledger-key-ring-protocol
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Hardware integration layer for Ledger Key Ring Protocol flows.
 
 Use it with the protocol package in

--- a/libs/ledger-auth/README.md
+++ b/libs/ledger-auth/README.md
@@ -1,5 +1,8 @@
 # ledger-auth
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/ledger-auth` provides authentication helpers for Ledger Live apps to authenticate users against Ledger's Keycloak-based OAuth2/OIDC service. It handles the full PKCE authorization code flow, token storage, and silent token refresh, exposing a simple `AuthSDK` facade.
 
 ## What it does

--- a/libs/ledger-key-ring-protocol/README.md
+++ b/libs/ledger-key-ring-protocol/README.md
@@ -1,5 +1,8 @@
 # @ledgerhq/ledger-key-ring-protocol
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Key Ring Protocol layer.
 
 > This is the Trustchain SDK powering **Ledger Sync**. For the full picture (auth, members, key

--- a/libs/ledger-live-common/README.md
+++ b/libs/ledger-live-common/README.md
@@ -1,9 +1,7 @@
 # @ledgerhq/live-common
 
 > [!WARNING]
-> **`@ledgerhq/live-common` is in maintenance mode and is being progressively dismantled.**
-> Do **not** add new features, folders or top-level modules here. Bugfixes and edits to existing
-> code are welcome. New shared logic belongs in a dedicated `libs/*` package.
+> **Status: DEPRECATED** — In maintenance mode and being progressively dismantled. Do **not** add new features, folders or top-level modules here. Bugfixes and edits to existing code are welcome. New shared logic belongs in a dedicated `libs/*` package.
 
 `@ledgerhq/live-common` contains shared Ledger Wallet business logic used by
 Ledger Live Desktop, Ledger Live Mobile, CLI tooling, tests, and coin

--- a/libs/ledger-services/README.md
+++ b/libs/ledger-services/README.md
@@ -1,5 +1,8 @@
 # ledger-services
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 This workspace groups typed HTTP client libraries for Ledger's backend services. Each sub-package wraps a specific Ledger API, providing strongly-typed request/response models and integration-tested clients.
 
 ## Packages

--- a/libs/ledger-wallet-framework/README.md
+++ b/libs/ledger-wallet-framework/README.md
@@ -1,5 +1,8 @@
 # ledger-wallet-framework
 
+> [!CAUTION]
+> **Status: UNSTABLE** — Actively consolidating shared logic migrated out of `@ledgerhq/live-common`; API is in flux.
+
 `@ledgerhq/ledger-wallet-framework` is the core wallet logic framework that consolidates shared infrastructure for coin implementations in Ledger Live. It was introduced to centralize concerns that previously lived in `ledger-live-common` or were duplicated across coin modules, extending and wrapping `@ledgerhq/coin-module-framework`.
 
 ## What it does

--- a/libs/ledgerjs/packages/cryptoassets/README.md
+++ b/libs/ledgerjs/packages/cryptoassets/README.md
@@ -1,6 +1,9 @@
 
 # @ledgerhq/cryptoassets
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger's material for crypto currencies, tokens and fiats. Also includes signatures required by Nano devices for these tokens.
 
 This library provides dynamic RTK Query-based token lookup capabilities through the **CAL (Crypto Assets List) Client**. Static token data has been removed in favor of the async API.

--- a/libs/ledgerjs/packages/devices/README.md
+++ b/libs/ledgerjs/packages/devices/README.md
@@ -2,7 +2,7 @@
 
 ## @ledgerhq/devices
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Logic for all Ledger devices.

--- a/libs/ledgerjs/packages/devices/README.md
+++ b/libs/ledgerjs/packages/devices/README.md
@@ -2,6 +2,9 @@
 
 ## @ledgerhq/devices
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Logic for all Ledger devices.
 
 ## API

--- a/libs/ledgerjs/packages/errors/README.md
+++ b/libs/ledgerjs/packages/errors/README.md
@@ -2,6 +2,9 @@
 
 ## @ledgerhq/errors
 
+> [!WARNING]
+> **Status: DEPRECATED** — Frozen; do not add new errors here. Define errors as plain `class extends Error` in your own package's `src/errors.ts`.
+
 > ⚠️ **Deprecated and frozen.** Do not add new errors here and do not use
 > `createCustomErrorClass` or the serialize/deserialize stack. Define errors as
 > plain native classes in your own package's `src/errors.ts` and check them with

--- a/libs/ledgerjs/packages/errors/README.md
+++ b/libs/ledgerjs/packages/errors/README.md
@@ -2,7 +2,7 @@
 
 ## @ledgerhq/errors
 
-> [!WARNING]
+> \[!WARNING]
 > **Status: DEPRECATED** — Frozen; do not add new errors here. Define errors as plain `class extends Error` in your own package's `src/errors.ts`.
 
 > ⚠️ **Deprecated and frozen.** Do not add new errors here and do not use

--- a/libs/ledgerjs/packages/hw-app-algorand/README.md
+++ b/libs/ledgerjs/packages/hw-app-algorand/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-algorand
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Ledger Hardware Wallet Algorand JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-algorand/README.md
+++ b/libs/ledgerjs/packages/hw-app-algorand/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-app-algorand
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Algorand JavaScript bindings.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-aptos/README.md
+++ b/libs/ledgerjs/packages/hw-app-aptos/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-app-aptos
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Aptos JavaScript bindings.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-aptos/README.md
+++ b/libs/ledgerjs/packages/hw-app-aptos/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-aptos
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Ledger Hardware Wallet Aptos JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-btc/README.md
+++ b/libs/ledgerjs/packages/hw-app-btc/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-app-btc
 
+> [!WARNING]
+> **Status: DEPRECATED** — Replaced by the Device Management Kit (DMK). Migrate to `@ledgerhq/device-signer-kit-bitcoin`.
+
 Ledger Hardware Wallet BTC JavaScript bindings. Also supports many altcoins.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-btc/README.md
+++ b/libs/ledgerjs/packages/hw-app-btc/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-btc
 
-> [!WARNING]
+> \[!WARNING]
 > **Status: DEPRECATED** — Replaced by the Device Management Kit (DMK). Migrate to `@ledgerhq/device-signer-kit-bitcoin`.
 
 Ledger Hardware Wallet BTC JavaScript bindings. Also supports many altcoins.

--- a/libs/ledgerjs/packages/hw-app-canton/README.md
+++ b/libs/ledgerjs/packages/hw-app-canton/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-canton
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Ledger Hardware Wallet Canton JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-canton/README.md
+++ b/libs/ledgerjs/packages/hw-app-canton/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-app-canton
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Canton JavaScript bindings.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-celo/README.md
+++ b/libs/ledgerjs/packages/hw-app-celo/README.md
@@ -4,9 +4,12 @@
 [Ledger Devs Discord](https://developers.ledger.com/discord-pro),
 [Developer Portal](https://developers.ledger.com/)
 
-## @ledgerhq/hw-app-polkadot
+## @ledgerhq/hw-app-celo
 
-Ledger Hardware Wallet Polkadot JavaScript bindings.
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
+Ledger Hardware Wallet Celo JavaScript bindings.
 
 ***
 

--- a/libs/ledgerjs/packages/hw-app-celo/README.md
+++ b/libs/ledgerjs/packages/hw-app-celo/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-celo
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Ledger Hardware Wallet Celo JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-cosmos/README.md
+++ b/libs/ledgerjs/packages/hw-app-cosmos/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-app-cosmos
 
+> [!WARNING]
+> **Status: DEPRECATED** — Replaced by the Device Management Kit (DMK). Migrate to `@ledgerhq/device-signer-kit-cosmos`.
+
 Ledger Hardware Wallet Cosmos JavaScript bindings.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-cosmos/README.md
+++ b/libs/ledgerjs/packages/hw-app-cosmos/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-cosmos
 
-> [!WARNING]
+> \[!WARNING]
 > **Status: DEPRECATED** — Replaced by the Device Management Kit (DMK). Migrate to `@ledgerhq/device-signer-kit-cosmos`.
 
 Ledger Hardware Wallet Cosmos JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-eth/README.md
+++ b/libs/ledgerjs/packages/hw-app-eth/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-app-eth
 
+> [!WARNING]
+> **Status: DEPRECATED** — Replaced by the Device Management Kit (DMK). Migrate to `@ledgerhq/device-signer-kit-ethereum`.
+
 Ledger Hardware Wallet ETH JavaScript bindings.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-eth/README.md
+++ b/libs/ledgerjs/packages/hw-app-eth/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-eth
 
-> [!WARNING]
+> \[!WARNING]
 > **Status: DEPRECATED** — Replaced by the Device Management Kit (DMK). Migrate to `@ledgerhq/device-signer-kit-ethereum`.
 
 Ledger Hardware Wallet ETH JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-exchange/README.md
+++ b/libs/ledgerjs/packages/hw-app-exchange/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-app-exchange
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Exchange app.
 
 ## API

--- a/libs/ledgerjs/packages/hw-app-exchange/README.md
+++ b/libs/ledgerjs/packages/hw-app-exchange/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-exchange
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Ledger Hardware Wallet Exchange app.

--- a/libs/ledgerjs/packages/hw-app-hedera/README.md
+++ b/libs/ledgerjs/packages/hw-app-hedera/README.md
@@ -4,7 +4,7 @@
 
 ## @ledgerhq/hw-app-hedera
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Ledger Hardware Wallet Hedera JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-hedera/README.md
+++ b/libs/ledgerjs/packages/hw-app-hedera/README.md
@@ -4,6 +4,9 @@
 
 ## @ledgerhq/hw-app-hedera
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Hedera JavaScript bindings.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-helium/README.md
+++ b/libs/ledgerjs/packages/hw-app-helium/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-app-helium
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Helium JavaScript bindings.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-helium/README.md
+++ b/libs/ledgerjs/packages/hw-app-helium/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-helium
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Ledger Hardware Wallet Helium JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-icon/README.md
+++ b/libs/ledgerjs/packages/hw-app-icon/README.md
@@ -1,5 +1,8 @@
 ## @ledgerhq/hw-app-icon
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Icon JavaScript bindings.
 
 ## API

--- a/libs/ledgerjs/packages/hw-app-icon/README.md
+++ b/libs/ledgerjs/packages/hw-app-icon/README.md
@@ -1,6 +1,6 @@
 ## @ledgerhq/hw-app-icon
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Ledger Hardware Wallet Icon JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-kaspa/README.md
+++ b/libs/ledgerjs/packages/hw-app-kaspa/README.md
@@ -2,6 +2,9 @@
 
 ## coderofstuff/hw-app-kaspa
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Kaspa JavaScript bindings.
 
 

--- a/libs/ledgerjs/packages/hw-app-multiversx/README.md
+++ b/libs/ledgerjs/packages/hw-app-multiversx/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-app-multiversx
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Multiversx JavaScript bindings.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-multiversx/README.md
+++ b/libs/ledgerjs/packages/hw-app-multiversx/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-multiversx
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Ledger Hardware Wallet Multiversx JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-near/README.md
+++ b/libs/ledgerjs/packages/hw-app-near/README.md
@@ -5,7 +5,7 @@
 
 ## @ledgerhq/hw-app-near
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Ledger Hardware Wallet NEAR JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-near/README.md
+++ b/libs/ledgerjs/packages/hw-app-near/README.md
@@ -5,6 +5,9 @@
 
 ## @ledgerhq/hw-app-near
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet NEAR JavaScript bindings.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-polkadot/README.md
+++ b/libs/ledgerjs/packages/hw-app-polkadot/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-polkadot
 
-> [!WARNING]
+> \[!WARNING]
 > **Status: DEPRECATED** — Replaced by the Device Management Kit (DMK). Migrate to `@ledgerhq/device-signer-kit-polkadot`.
 
 Ledger Hardware Wallet Polkadot JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-polkadot/README.md
+++ b/libs/ledgerjs/packages/hw-app-polkadot/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-app-polkadot
 
+> [!WARNING]
+> **Status: DEPRECATED** — Replaced by the Device Management Kit (DMK). Migrate to `@ledgerhq/device-signer-kit-polkadot`.
+
 Ledger Hardware Wallet Polkadot JavaScript bindings.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-solana/README.md
+++ b/libs/ledgerjs/packages/hw-app-solana/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-app-solana
 
+> [!WARNING]
+> **Status: DEPRECATED** — Replaced by the Device Management Kit (DMK). Migrate to `@ledgerhq/device-signer-kit-solana`.
+
 Ledger Hardware Wallet Solana JavaScript bindings.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-solana/README.md
+++ b/libs/ledgerjs/packages/hw-app-solana/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-solana
 
-> [!WARNING]
+> \[!WARNING]
 > **Status: DEPRECATED** — Replaced by the Device Management Kit (DMK). Migrate to `@ledgerhq/device-signer-kit-solana`.
 
 Ledger Hardware Wallet Solana JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-str/README.md
+++ b/libs/ledgerjs/packages/hw-app-str/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-app-str
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Stellar JavaScript bindings.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-str/README.md
+++ b/libs/ledgerjs/packages/hw-app-str/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-str
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Ledger Hardware Wallet Stellar JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-sui/README.md
+++ b/libs/ledgerjs/packages/hw-app-sui/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-app-sui
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Sui JavaScript bindings.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-sui/README.md
+++ b/libs/ledgerjs/packages/hw-app-sui/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-sui
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Ledger Hardware Wallet Sui JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-tezos/README.md
+++ b/libs/ledgerjs/packages/hw-app-tezos/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-app-tezos
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Tezos JavaScript bindings.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-tezos/README.md
+++ b/libs/ledgerjs/packages/hw-app-tezos/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-tezos
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Ledger Hardware Wallet Tezos JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-trx/README.md
+++ b/libs/ledgerjs/packages/hw-app-trx/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-trx
 
-> [!WARNING]
+> \[!WARNING]
 > **Status: DEPRECATED** — Replaced by the Device Management Kit (DMK). Migrate to `@ledgerhq/device-signer-kit-tron`.
 
 Ledger Hardware Wallet TRX JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-trx/README.md
+++ b/libs/ledgerjs/packages/hw-app-trx/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-app-trx
 
+> [!WARNING]
+> **Status: DEPRECATED** — Replaced by the Device Management Kit (DMK). Migrate to `@ledgerhq/device-signer-kit-tron`.
+
 Ledger Hardware Wallet TRX JavaScript bindings.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-vet/README.md
+++ b/libs/ledgerjs/packages/hw-app-vet/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-vet
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Ledger Hardware Wallet ETH JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-app-vet/README.md
+++ b/libs/ledgerjs/packages/hw-app-vet/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-app-vet
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet ETH JavaScript bindings.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-xrp/README.md
+++ b/libs/ledgerjs/packages/hw-app-xrp/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-app-xrp
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet XRP JavaScript bindings.
 
 ***

--- a/libs/ledgerjs/packages/hw-app-xrp/README.md
+++ b/libs/ledgerjs/packages/hw-app-xrp/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-app-xrp
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Ledger Hardware Wallet XRP JavaScript bindings.

--- a/libs/ledgerjs/packages/hw-bolos/README.md
+++ b/libs/ledgerjs/packages/hw-bolos/README.md
@@ -1,6 +1,6 @@
 ## hw-bolos
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 A list of commands (APDUs) to send directly to the OS of Ledger devices (a.k.a. BOLOS).

--- a/libs/ledgerjs/packages/hw-bolos/README.md
+++ b/libs/ledgerjs/packages/hw-bolos/README.md
@@ -1,5 +1,8 @@
 ## hw-bolos
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 A list of commands (APDUs) to send directly to the OS of Ledger devices (a.k.a. BOLOS).
 
 ## API

--- a/libs/ledgerjs/packages/hw-transport-http/README.md
+++ b/libs/ledgerjs/packages/hw-transport-http/README.md
@@ -2,6 +2,9 @@
 
 ## @ledgerhq/hw-transport-http
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Library for Ledger Hardware Wallets.
 
 [GitHub](https://github.com/LedgerHQ/ledger-live/),

--- a/libs/ledgerjs/packages/hw-transport-mocker/README.md
+++ b/libs/ledgerjs/packages/hw-transport-mocker/README.md
@@ -2,6 +2,9 @@
 
 ## @ledgerhq/hw-transport-mocker
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Library for Ledger Hardware Wallets.
 
 [GitHub](https://github.com/LedgerHQ/ledger-live/),

--- a/libs/ledgerjs/packages/hw-transport-node-speculos-http/README.md
+++ b/libs/ledgerjs/packages/hw-transport-node-speculos-http/README.md
@@ -2,7 +2,7 @@
 
 ## @ledgerhq/hw-transport-node-speculos-http
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 A transport for <https://github.com/LedgerHQ/speculos> Nano simulator using its HTTP API.

--- a/libs/ledgerjs/packages/hw-transport-node-speculos-http/README.md
+++ b/libs/ledgerjs/packages/hw-transport-node-speculos-http/README.md
@@ -2,6 +2,9 @@
 
 ## @ledgerhq/hw-transport-node-speculos-http
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 A transport for <https://github.com/LedgerHQ/speculos> Nano simulator using its HTTP API.
 
 [GitHub](https://github.com/LedgerHQ/ledger-live/),

--- a/libs/ledgerjs/packages/hw-transport-node-speculos/README.md
+++ b/libs/ledgerjs/packages/hw-transport-node-speculos/README.md
@@ -2,6 +2,9 @@
 
 ## @ledgerhq/hw-transport-node-speculos
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 A transport for <https://github.com/LedgerHQ/speculos> Nano simulator.
 
 [GitHub](https://github.com/LedgerHQ/ledger-live/),

--- a/libs/ledgerjs/packages/hw-transport-node-speculos/README.md
+++ b/libs/ledgerjs/packages/hw-transport-node-speculos/README.md
@@ -2,7 +2,7 @@
 
 ## @ledgerhq/hw-transport-node-speculos
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 A transport for <https://github.com/LedgerHQ/speculos> Nano simulator.

--- a/libs/ledgerjs/packages/hw-transport-vault/README.md
+++ b/libs/ledgerjs/packages/hw-transport-vault/README.md
@@ -1,6 +1,9 @@
 <img src="https://user-images.githubusercontent.com/4631227/191834116-59cf590e-25cc-4956-ae5c-812ea464f324.png" height="100" />
 
-## @ledgerhq/hw-transport-http
+## @ledgerhq/hw-transport-vault
+
+> [!WARNING]
+> **Status: DEPRECATED** — Being removed from the monorepo. This was a Vault-specific transport with no replacement in scope.
 
 Library for Ledger Hardware Wallets.
 

--- a/libs/ledgerjs/packages/hw-transport/README.md
+++ b/libs/ledgerjs/packages/hw-transport/README.md
@@ -6,7 +6,7 @@
 
 ## @ledgerhq/hw-transport
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 `@ledgerhq/hw-transport` implements the generic interface of a Ledger Hardware Wallet transport.

--- a/libs/ledgerjs/packages/hw-transport/README.md
+++ b/libs/ledgerjs/packages/hw-transport/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/hw-transport
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/hw-transport` implements the generic interface of a Ledger Hardware Wallet transport.
 
 ## API

--- a/libs/ledgerjs/packages/logs/README.md
+++ b/libs/ledgerjs/packages/logs/README.md
@@ -2,7 +2,7 @@
 
 ## @ledgerhq/logs
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Utility library that is used by all Ledger libraries to dispatch logs so we can deal with them in a unified way.

--- a/libs/ledgerjs/packages/logs/README.md
+++ b/libs/ledgerjs/packages/logs/README.md
@@ -2,6 +2,9 @@
 
 ## @ledgerhq/logs
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Utility library that is used by all Ledger libraries to dispatch logs so we can deal with them in a unified way.
 
 ## API

--- a/libs/ledgerjs/packages/types-cryptoassets/README.md
+++ b/libs/ledgerjs/packages/types-cryptoassets/README.md
@@ -2,4 +2,7 @@
 
 ## @ledgerhq/types-cryptoassets
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger types for crypto assets and tokens.

--- a/libs/ledgerjs/packages/types-devices/README.md
+++ b/libs/ledgerjs/packages/types-devices/README.md
@@ -2,7 +2,7 @@
 
 ## @ledgerhq/types-devices
 
-> [!NOTE]
+> \[!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
 Ledger types for devices and transport.

--- a/libs/ledgerjs/packages/types-devices/README.md
+++ b/libs/ledgerjs/packages/types-devices/README.md
@@ -2,6 +2,9 @@
 
 ## @ledgerhq/types-devices
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger types for devices and transport.
 
 ## API

--- a/libs/ledgerjs/packages/types-live/README.md
+++ b/libs/ledgerjs/packages/types-live/README.md
@@ -2,4 +2,7 @@
 
 ## @ledgerhq/types-live
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Live main types.

--- a/libs/live-config/README.md
+++ b/libs/live-config/README.md
@@ -5,6 +5,9 @@
 
 Welcome to Ledger's @ledgerhq/live-config JavaScript lib.
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 ### Introduction
 
 @ledgerhq/live-config is a versatile TypeScript library designed to manage application configurations dynamically. It supports various data types and integrates seamlessly with different configuration providers.
@@ -29,6 +32,7 @@ yarn add @ledgerhq/live-config
 
 ### Usage
 ## Initializing LiveConfig
+
 LiveConfig is a singleton class. To use it, you must first set a provider and a configuration schema.
 
 Set a Provider

--- a/libs/live-countervalues-react/README.md
+++ b/libs/live-countervalues-react/README.md
@@ -1,5 +1,8 @@
 # live-countervalues-react
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/live-countervalues-react` is the React layer over `@ledgerhq/live-countervalues`. It provides a context provider and hooks so that components can subscribe to fiat countervalue data without managing rate-fetching or caching themselves.
 
 ## What it does

--- a/libs/live-countervalues/README.md
+++ b/libs/live-countervalues/README.md
@@ -1,5 +1,8 @@
 # live-countervalues
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/live-countervalues` manages fiat (and cross-crypto) exchange rate fetching, caching, and portfolio valuation for Ledger Live. It fetches rates from Ledger's countervalues API and exposes pure functions to convert crypto amounts to fiat at any point in time.
 
 ## What it does

--- a/libs/live-currency-format/README.md
+++ b/libs/live-currency-format/README.md
@@ -1,5 +1,8 @@
 # live-currency-format
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Locale-aware currency formatting utilities for Ledger Live. Handles display of crypto and fiat amounts, parsing user input back into BigNumber values, RTL language support, and price formatting. Used across both desktop and mobile UIs wherever a balance, fee, or price must be rendered as a human-readable string.
 
 ## What it does

--- a/libs/live-dmk-desktop/README.md
+++ b/libs/live-dmk-desktop/README.md
@@ -1,7 +1,7 @@
 # live-dmk-desktop
 
-> [!CAUTION]
-> **Status: UNSTABLE** — Active Device Management Kit (DMK) migration in progress; API may change.
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
 
 Desktop-specific integration of the Ledger Device Management Kit (DMK) for Ledger Live Desktop. Provides the Electron/USB transport adapter and React hooks that wire the DMK into the LLD renderer process, enabling USB-based hardware wallet communication on macOS, Windows, and Linux.
 

--- a/libs/live-dmk-desktop/README.md
+++ b/libs/live-dmk-desktop/README.md
@@ -1,5 +1,8 @@
 # live-dmk-desktop
 
+> [!CAUTION]
+> **Status: UNSTABLE** — Active Device Management Kit (DMK) migration in progress; API may change.
+
 Desktop-specific integration of the Ledger Device Management Kit (DMK) for Ledger Live Desktop. Provides the Electron/USB transport adapter and React hooks that wire the DMK into the LLD renderer process, enabling USB-based hardware wallet communication on macOS, Windows, and Linux.
 
 ## What it does

--- a/libs/live-dmk-mobile/README.md
+++ b/libs/live-dmk-mobile/README.md
@@ -1,5 +1,8 @@
 # live-dmk-mobile
 
+> [!CAUTION]
+> **Status: UNSTABLE** — Active Device Management Kit (DMK) migration in progress; API may change.
+
 Mobile-specific integration of the Ledger Device Management Kit (DMK) for Ledger Live Mobile. Provides React Native BLE and USB-C transport adapters, device discovery flows, and React hooks for hardware wallet communication on iOS and Android.
 
 ## What it does

--- a/libs/live-dmk-mobile/README.md
+++ b/libs/live-dmk-mobile/README.md
@@ -1,7 +1,7 @@
 # live-dmk-mobile
 
-> [!CAUTION]
-> **Status: UNSTABLE** — Active Device Management Kit (DMK) migration in progress; API may change.
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
 
 Mobile-specific integration of the Ledger Device Management Kit (DMK) for Ledger Live Mobile. Provides React Native BLE and USB-C transport adapters, device discovery flows, and React hooks for hardware wallet communication on iOS and Android.
 

--- a/libs/live-dmk-shared/README.md
+++ b/libs/live-dmk-shared/README.md
@@ -1,5 +1,8 @@
 # live-dmk-shared
 
+> [!CAUTION]
+> **Status: UNSTABLE** — Active Device Management Kit (DMK) migration in progress; API may change.
+
 Platform-agnostic shared logic for the Ledger Device Management Kit (DMK) integration in Ledger Live. Contains device discovery interfaces, device-action orchestration, transport abstractions, and cross-platform services used by both the desktop and mobile DMK adapters.
 
 ## What it does

--- a/libs/live-dmk-shared/README.md
+++ b/libs/live-dmk-shared/README.md
@@ -1,7 +1,7 @@
 # live-dmk-shared
 
-> [!CAUTION]
-> **Status: UNSTABLE** — Active Device Management Kit (DMK) migration in progress; API may change.
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
 
 Platform-agnostic shared logic for the Ledger Device Management Kit (DMK) integration in Ledger Live. Contains device discovery interfaces, device-action orchestration, transport abstractions, and cross-platform services used by both the desktop and mobile DMK adapters.
 

--- a/libs/live-dmk-speculos/README.md
+++ b/libs/live-dmk-speculos/README.md
@@ -1,7 +1,7 @@
 # live-dmk-speculos
 
-> [!CAUTION]
-> **Status: UNSTABLE** — Active Device Management Kit (DMK) migration in progress; API may change.
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
 
 DMK transport adapter for Speculos, Ledger's hardware wallet emulator. Enables automated tests and CI pipelines to run full device-interaction flows without physical Ledger hardware by connecting the Device Management Kit to a running Speculos instance over HTTP/WebSocket.
 

--- a/libs/live-dmk-speculos/README.md
+++ b/libs/live-dmk-speculos/README.md
@@ -1,5 +1,8 @@
 # live-dmk-speculos
 
+> [!CAUTION]
+> **Status: UNSTABLE** — Active Device Management Kit (DMK) migration in progress; API may change.
+
 DMK transport adapter for Speculos, Ledger's hardware wallet emulator. Enables automated tests and CI pipelines to run full device-interaction flows without physical Ledger hardware by connecting the Device Management Kit to a running Speculos instance over HTTP/WebSocket.
 
 ## What it does

--- a/libs/live-engagement/README.md
+++ b/libs/live-engagement/README.md
@@ -1,5 +1,8 @@
 # live-engagement
 
+> [!CAUTION]
+> **Status: UNSTABLE** — New engagement module under active development; API may evolve as use cases grow.
+
 `@ledgerhq/live-engagement` holds shared Redux state for engagement surfaces (upsells, awareness modals, cooldown/frequency tracking) that more than one app needs, without growing `live-common` (frozen - see [libs/README.md](../README.md)).
 
 ## Scope

--- a/libs/live-hooks/README.md
+++ b/libs/live-hooks/README.md
@@ -1,5 +1,8 @@
 # live-hooks
 
+> [!WARNING]
+> **Status: DEPRECATED** — Planned for removal. Migrate to a standard npm package such as `usehooks-ts`.
+
 `@ledgerhq/live-hooks` is a small collection of shared React hooks used across Ledger Live desktop and mobile. It centralises common UI performance patterns — debouncing and throttling — so they don't need to be re-implemented in each app.
 
 ## What it does

--- a/libs/live-network/README.md
+++ b/libs/live-network/README.md
@@ -1,5 +1,8 @@
 # live-network
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/live-network` is the shared network layer for Ledger Live. It wraps the underlying HTTP client with Ledger-specific logging, error normalisation, and request optimisation utilities so all services in the monorepo make network calls consistently.
 
 ## What it does

--- a/libs/live-signer-aleo/README.md
+++ b/libs/live-signer-aleo/README.md
@@ -6,4 +6,7 @@
 
 ## @ledgerhq/live-signer-aleo
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Aleo JavaScript bindings via DMK.

--- a/libs/live-signer-canton/README.md
+++ b/libs/live-signer-canton/README.md
@@ -6,4 +6,7 @@
 
 ## @ledgerhq/live-signer-canton
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Canton JavaScript bindings via legacy hw-app-canton.

--- a/libs/live-signer-celo/README.md
+++ b/libs/live-signer-celo/README.md
@@ -1,5 +1,8 @@
 # live-signer-celo
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/live-signer-celo` is the hardware-wallet signer for the Celo blockchain. It wraps the Celo Ledger app's APDU protocol and exposes a typed signer interface consumed by the Celo coin module.
 
 ## What it does

--- a/libs/live-signer-concordium/README.md
+++ b/libs/live-signer-concordium/README.md
@@ -6,4 +6,7 @@
 
 ## @ledgerhq/live-signer-concordium
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Concordium JavaScript bindings via DMK.

--- a/libs/live-signer-cosmos/README.md
+++ b/libs/live-signer-cosmos/README.md
@@ -6,4 +6,7 @@
 
 ## @ledgerhq/live-signer-cosmos
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Cosmos JavaScript bindings, integrating [`@ledgerhq/device-signer-kit-cosmos`](https://github.com/LedgerHQ/device-sdk-ts/tree/develop/packages/signer/signer-cosmos) from the Device Management Kit alongside legacy `hw-app-cosmos` and `ledger-cosmos-js`.

--- a/libs/live-signer-evm/README.md
+++ b/libs/live-signer-evm/README.md
@@ -6,4 +6,7 @@
 
 ## @ledgerhq/live-signer-evm
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet ETH JavaScript bindings via DMK or legacy hw-app-eth.

--- a/libs/live-signer-hyperliquid/README.md
+++ b/libs/live-signer-hyperliquid/README.md
@@ -6,6 +6,9 @@
 
 ## @ledgerhq/live-signer-hyperliquid
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Hyperliquid JavaScript bindings via Device Management Kit (DMK).
 
 This library provides a simple interface to interact with Hyperliquid applications on Ledger devices using the Device Management Kit framework.

--- a/libs/live-signer-solana/README.md
+++ b/libs/live-signer-solana/README.md
@@ -6,4 +6,7 @@
 
 ## @ledgerhq/live-signer-solana
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet Solana JavaScript bindings via legacy hw-app-solana.

--- a/libs/live-signer-zcash/README.md
+++ b/libs/live-signer-zcash/README.md
@@ -6,4 +6,7 @@
 
 ## @ledgerhq/live-signer-zcash
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Hardware Wallet ZCash JavaScript bindings via DMK.

--- a/libs/live-wallet/README.md
+++ b/libs/live-wallet/README.md
@@ -1,5 +1,8 @@
 ## live-wallet
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 > This library is the top layer of **Ledger Sync** (Cloud Sync SDK, WalletSyncDataManager,
 > watch loop). See the full technical documentation: [`docs/ledger-sync`](../../docs/ledger-sync/README.md).
 

--- a/libs/oxc-live-libs/README.md
+++ b/libs/oxc-live-libs/README.md
@@ -1,5 +1,8 @@
 # Shared Oxlint / Oxfmt for `libs/live-*`
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 - `.oxlintrc.json` — shared linter config for packages under `libs/live-*` (use `-c ../oxc-live-libs/.oxlintrc.json`).
 - `.oxfmtrc.json` — shared formatter; `live-currency-format` exposes `format` / `format:check` using this file.
 

--- a/libs/promise/README.md
+++ b/libs/promise/README.md
@@ -1,5 +1,8 @@
 # live-promise
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/live-promise` provides small, focused Promise utilities for Ledger Live. Rather than pulling in a heavy async library, it ships only the primitives the codebase actually needs: retrying, delaying, and composing async operations.
 
 ## What it does

--- a/libs/psbtv2/README.md
+++ b/libs/psbtv2/README.md
@@ -1,5 +1,8 @@
 # @ledgerhq/psbtv2
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Partially Signed Bitcoin Transaction version 2 (PSBT v2) implementation following BIP370 and BIP174.
 
 ## Overview

--- a/libs/speculos-transport/README.md
+++ b/libs/speculos-transport/README.md
@@ -1,5 +1,8 @@
 ## speculos-transport
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Ledger Live speculos transport test helper
 
 ## API

--- a/libs/test-utils/README.md
+++ b/libs/test-utils/README.md
@@ -1,5 +1,8 @@
 # test-utils
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/test-utils` is a shared test-support package for the Ledger Live monorepo. It provides dummy application scaffolding and reusable helpers that multiple test suites depend on, keeping test boilerplate out of production packages.
 
 ## What it does

--- a/libs/ui/README.md
+++ b/libs/ui/README.md
@@ -1,8 +1,10 @@
 # `ui` <br/> [![react storybook](https://img.shields.io/badge/storybook%20📚-react-61DBFB)](https://react-ui-storybook.vercel.app) [![native storybook](https://img.shields.io/badge/storybook%20📚-native-9665B7)](https://native-ui-storybook.vercel.app)
 
+> [!WARNING]
+> **Status: DEPRECATED** — The whole `@ledgerhq/ui` suite is deprecated in favour of the Lumen design system. Migrate to `@ledgerhq/lumen-ui-react` (React), `@ledgerhq/lumen-ui-rnative` (React Native), or `@ledgerhq/lumen-design-core` (shared tokens).
+
 ### Design and interface resources for React and React Native projects.
 
-##### Status: while perfectly useable the libraries are still in alpha state and are subject to breaking changes without notice :fire:.
 
 ## About
 

--- a/libs/ui/packages/icons/README.md
+++ b/libs/ui/packages/icons/README.md
@@ -1,5 +1,8 @@
 # `@ledgerhq/icons-ui`
 
+> [!WARNING]
+> **Status: DEPRECATED** — Deprecated. Icons are now provided by `@ledgerhq/lumen-ui-react` and `@ledgerhq/lumen-ui-rnative`.
+
 [![npm](https://img.shields.io/npm/v/@ledgerhq/icons-ui)](https://www.npmjs.com/package/@ledgerhq/icons-ui)
 
 ### A collection of Ledger-flavoured icons

--- a/libs/ui/packages/native/README.md
+++ b/libs/ui/packages/native/README.md
@@ -1,5 +1,8 @@
 # `@ledgerhq/native-ui`
 
+> [!WARNING]
+> **Status: DEPRECATED** — Deprecated. Migrate to `@ledgerhq/lumen-ui-rnative`.
+
 [![npm](https://img.shields.io/npm/v/@ledgerhq/native-ui)](https://www.npmjs.com/package/@ledgerhq/native-ui)
 [![storybook](https://img.shields.io/badge/Storybook-📚-61DBFB)](https://native-ui-storybook.vercel.app)
 

--- a/libs/ui/packages/react/README.md
+++ b/libs/ui/packages/react/README.md
@@ -1,5 +1,8 @@
 # `@ledgerhq/react-ui`
 
+> [!WARNING]
+> **Status: DEPRECATED** — Deprecated. Migrate to `@ledgerhq/lumen-ui-react`.
+
 [![npm](https://img.shields.io/npm/v/@ledgerhq/react-ui)](https://www.npmjs.com/package/@ledgerhq/react-ui)
 [![storybook](https://img.shields.io/badge/Storybook-📚-61DBFB)](https://react-ui-storybook.vercel.app)
 

--- a/libs/ui/packages/shared/README.md
+++ b/libs/ui/packages/shared/README.md
@@ -1,5 +1,8 @@
 # `@ledgerhq/ui-shared`
 
+> [!WARNING]
+> **Status: DEPRECATED** — Deprecated. Migrate to `@ledgerhq/lumen-design-core`.
+
 [![npm](https://img.shields.io/npm/v/@ledgerhq/ui-shared)](https://www.npmjs.com/package/@ledgerhq/ui-shared)
 
 ### Shared assets and code

--- a/libs/wallet-api-acre-module/README.md
+++ b/libs/wallet-api-acre-module/README.md
@@ -1,5 +1,8 @@
 # ACRE Wallet API Module
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 This module provides ACRE-specific functionality for the Ledger Live Wallet API, including message signing, transaction signing/broadcasting, and yield-bearing Ethereum address registration.
 
 ## Features

--- a/libs/wallet-framework-test-setup/README.md
+++ b/libs/wallet-framework-test-setup/README.md
@@ -1,5 +1,8 @@
 # @ledgerhq/wallet-framework-test-setup
 
+> [!CAUTION]
+> **Status: UNSTABLE** — Tied to `@ledgerhq/ledger-wallet-framework` which is actively being developed.
+
 Jest bootstrap for `@ledgerhq/ledger-wallet-framework`. Wires both framework ports for tests:
 
 - **`CurrenciesResolver`** — real domain currencies from `@domain/entity-currency-crypto`

--- a/libs/wallet-pnl/README.md
+++ b/libs/wallet-pnl/README.md
@@ -1,5 +1,8 @@
 # wallet-pnl
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 `@ledgerhq/wallet-pnl` computes Profit & Loss (PnL) for crypto assets and the overall portfolio inside Ledger Live. It implements the **Average Cost Basis (ACB)** accounting method to translate on-chain operation history into realised and unrealised gains, percentage returns, and trend indicators.
 
 ## What it does

--- a/shared/auth/README.md
+++ b/shared/auth/README.md
@@ -1,5 +1,8 @@
 # @shared/auth
 
+> [!CAUTION]
+> **Status: UNSTABLE** — RTK Query auth adapter; under active development.
+
 RTK Query helpers for APIs that authenticate through an injected token provider.
 
 ## Usage

--- a/shared/feature-flags/README.md
+++ b/shared/feature-flags/README.md
@@ -1,5 +1,8 @@
 # @shared/feature-flags
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Shared feature flags package for Ledger Live. Provides a **Zod-first flag registry**, an RTK slice with resolution logic, and typed selectors — replacing the scattered definitions across `@ledgerhq/types-live`, `@ledgerhq/live-common`, and each app's settings reducer.
 
 ## Quick start

--- a/shared/schema-primitives/README.md
+++ b/shared/schema-primitives/README.md
@@ -1,5 +1,8 @@
 # @shared/schema-primitives
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Branded Zod value objects shared across the `domain/` layer. Provides common types so entity packages don't define them locally.
 
 ## Design constraints


### PR DESCRIPTION
### 📝 Description

Adds a **status marker** to the README of every standalone package in `libs/`, `libs/ledgerjs/packages/`, `domain/`, `features/`, and `shared/`. The marker is a GitHub callout block placed right after the package title so it's visible at a glance — both for humans and LLMs consuming context from READMEs.

Three statuses:

| Status | Callout | Meaning |
|---|---|---|
| `STABLE` | `[!NOTE]` | Production-ready; API is stable |
| `UNSTABLE` | `[!CAUTION]` | In active development; API may change |
| `DEPRECATED` | `[!WARNING]` | Migrate away; replacement named inline |

Convention documented in [`docs/new-library.md`](../blob/docs/readme-status-markers/docs/new-library.md) under *"README status marker"* — required for all new packages going forward.

**Notable classifications:**
- `@ledgerhq/live-common` → DEPRECATED (already in maintenance mode)
- `@ledgerhq/react-ui`, `native-ui`, `ui-shared`, `icons-ui` → DEPRECATED (migrate to Lumen)
- `hw-app-btc/eth/cosmos/polkadot/solana/trx` → DEPRECATED (DMK signer-kit-* is the replacement)
- `live-dmk-*`, `ledger-wallet-framework`, `device-intent` → UNSTABLE (active migration)
- DDD-layer packages (`domain/`, `features/`, `shared/`) with recent activity → UNSTABLE

### 🔗 Context

- **JIRA / GitHub issue**: N/A
- **ADR** (if any): N/A