### PR TITLE
[LWDM] fix(zcash): fix wrong ZIP-244 txid and guard shielded-to-transparent signing [LIVE-34569]

### DIFF
--- a/.changeset/spicy-icons-press.md
+++ b/.changeset/spicy-icons-press.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-bitcoin": patch
+"@ledgerhq/live-signer-zcash": patch
+---
+
+Fix wrong ZIP-244 txid

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/adapter.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/adapter.test.ts
@@ -9,7 +9,7 @@ import type {
   SpendableNote,
   DecryptedOutput,
 } from "../types";
-import { Observable } from "rxjs";
+import { Observable, firstValueFrom } from "rxjs";
 import { getChainAdapter } from "../../registry";
 import { setZcashShieldedEnabled } from "../constants";
 
@@ -124,22 +124,35 @@ describe("zcash chain adapter — transaction routing", () => {
   describe("signOperation", () => {
     // Contract: routing is flag-driven, not transferType-driven. flag ON ⇒ every
     // flow (including Public→Public / transparent t→t) goes through PCZT and
-    // returns an Observable; flag OFF ⇒ every flow returns undefined (legacy).
-    describe.each([
-      { label: "ON", enabled: true },
-      { label: "OFF", enabled: false },
-    ])("zcashShielded flag $label", ({ enabled }) => {
-      beforeEach(() => setZcashShieldedEnabled(enabled));
+    // returns an Observable. flag OFF ⇒ transparent-input flows fall back to the
+    // legacy Bitcoin path (undefined); shielded-input flows ("shielded",
+    // "shielded-to-transparent") cannot be represented by the legacy path (no
+    // Orchard note spends), so they return an error Observable rather than
+    // silently producing an invalid transaction.
+    describe("zcashShielded flag ON ⇒ every flow returns an Observable (PCZT)", () => {
+      beforeEach(() => setZcashShieldedEnabled(true));
 
       it.each<ZcashTransferType>([
         "transparent",
         "transparent-to-shielded",
         "shielded-to-transparent",
         "shielded",
-      ])(
-        enabled
-          ? "returns an Observable (PCZT) for %s transfers"
-          : "returns undefined (legacy) for %s transfers",
+      ])("returns an Observable (PCZT) for %s transfers", transferType => {
+        const result = adapter.signOperation!(
+          makeZcashAccount({ ufvk: "testufvk" }),
+          "device",
+          makeTx(transferType),
+          mockSignerContext,
+        );
+        expect(result).toBeInstanceOf(Observable);
+      });
+    });
+
+    describe("zcashShielded flag OFF", () => {
+      beforeEach(() => setZcashShieldedEnabled(false));
+
+      it.each<ZcashTransferType>(["transparent", "transparent-to-shielded"])(
+        "returns undefined (legacy Bitcoin path) for %s transfers",
         transferType => {
           const result = adapter.signOperation!(
             makeZcashAccount({ ufvk: "testufvk" }),
@@ -147,16 +160,34 @@ describe("zcash chain adapter — transaction routing", () => {
             makeTx(transferType),
             mockSignerContext,
           );
-          if (enabled) expect(result).toBeInstanceOf(Observable);
-          else expect(result).toBeUndefined();
+          expect(result).toBeUndefined();
+        },
+      );
+
+      it.each<ZcashTransferType>(["shielded", "shielded-to-transparent"])(
+        "returns an error Observable for %s transfers (legacy path cannot represent note spends)",
+        async transferType => {
+          const result = adapter.signOperation!(
+            makeZcashAccount({ ufvk: "testufvk" }),
+            "device",
+            makeTx(transferType),
+            mockSignerContext,
+          );
+          expect(result).toBeInstanceOf(Observable);
+          await expect(firstValueFrom(result as Observable<unknown>)).rejects.toThrow(
+            "require the zcashShielded feature to be enabled",
+          );
         },
       );
     });
   });
 
-  // Contract check: with the flag OFF, EVERY hook short-circuits to the legacy
-  // Bitcoin path (undefined) regardless of transfer type — including shielded
-  // flows, which the UI never surfaces while the flag is off.
+  // Contract check: with the flag OFF, prepareTransaction/getTransactionStatus/
+  // estimateMaxSpendable short-circuit to the legacy Bitcoin path (undefined)
+  // regardless of transfer type. signOperation follows the same rule for
+  // transparent-input flows, but shielded-input flows return an error Observable
+  // (asserted in the signOperation suite above) because the legacy path cannot
+  // represent Orchard note spends.
   describe("zcashShielded flag OFF ⇒ all hooks fall back to legacy", () => {
     beforeEach(() => setZcashShieldedEnabled(false));
 
@@ -166,14 +197,22 @@ describe("zcash chain adapter — transaction routing", () => {
       "shielded-to-transparent",
       "shielded",
     ])(
-      "signOperation/prepareTransaction/getTransactionStatus/estimateMaxSpendable are undefined for %s",
+      "prepareTransaction/getTransactionStatus/estimateMaxSpendable are undefined for %s",
+      transferType => {
+        const account = makeZcashAccount({ ufvk: "testufvk" });
+        const tx = makeTx(transferType);
+        expect(adapter.prepareTransaction!(account, tx)).toBeUndefined();
+        expect(adapter.getTransactionStatus!(account, tx)).toBeUndefined();
+        expect(adapter.estimateMaxSpendable!(account, undefined, tx)).toBeUndefined();
+      },
+    );
+
+    it.each<ZcashTransferType>(["transparent", "transparent-to-shielded"])(
+      "signOperation is undefined for %s (legacy Bitcoin path)",
       transferType => {
         const account = makeZcashAccount({ ufvk: "testufvk" });
         const tx = makeTx(transferType);
         expect(adapter.signOperation!(account, "device", tx, mockSignerContext)).toBeUndefined();
-        expect(adapter.prepareTransaction!(account, tx)).toBeUndefined();
-        expect(adapter.getTransactionStatus!(account, tx)).toBeUndefined();
-        expect(adapter.estimateMaxSpendable!(account, undefined, tx)).toBeUndefined();
       },
     );
   });

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/signOperation.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/signOperation.test.ts
@@ -279,17 +279,28 @@ afterEach(() => {
 // ── Suite 1: Orchestration flow ────────────────────────────────────────────
 
 describe("signOperation — orchestration flow", () => {
-  it("returns undefined for every transferType when the flag is OFF (Bitcoin legacy fallback)", () => {
+  it("returns undefined for transparent transfer types when the flag is OFF (Bitcoin legacy fallback)", () => {
     setZcashShieldedEnabled(false);
     const account = makeAccount();
     const signerContext = makeSignerContext();
-    for (const transferType of [
-      "transparent",
-      "transparent-to-shielded",
-      "shielded-to-transparent",
-      "shielded",
-    ] as const) {
+    for (const transferType of ["transparent", "transparent-to-shielded"] as const) {
       expect(callSignOperation(account, makeTx(transferType), signerContext)).toBeUndefined();
+    }
+  });
+
+  it("returns an error Observable for shielded-input types when the flag is OFF", async () => {
+    // The legacy transparent path cannot represent Orchard note spends: it would
+    // strip the shielded bundle, compute a wrong ZIP-244 txid, and the network
+    // would reject with "Missing inputs". Fail early with a clear error.
+    setZcashShieldedEnabled(false);
+    const account = makeAccount();
+    const signerContext = makeSignerContext();
+    for (const transferType of ["shielded", "shielded-to-transparent"] as const) {
+      const obs = callSignOperation(account, makeTx(transferType), signerContext);
+      expect(obs).toBeInstanceOf(Observable);
+      await expect(lastValueFrom(obs!)).rejects.toThrow(
+        `Zcash ${transferType} transactions require the zcashShielded feature to be enabled`,
+      );
     }
   });
 

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/index.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/index.ts
@@ -435,7 +435,28 @@ const zcashChainAdapter: ChainAdapter = {
     // type: flag ON ⇒ every Zcash send (including Public→Public / transparent
     // t→t) is built and signed as a V5 PCZT here; flag OFF ⇒ fall through to the
     // legacy Bitcoin PSBT path for every send.
-    if (!isZcashShieldedEnabled()) return undefined;
+    //
+    // Exception: shielded-input types ("shielded", "shielded-to-transparent")
+    // spend Orchard notes and have NO transparent inputs. The legacy path cannot
+    // represent note spends at all — it would emit a transparent-only transaction
+    // with a wrong ZIP-244 txid and the network would reject it with "Missing
+    // inputs". Fail immediately with a clear error rather than silently producing
+    // an invalid transaction.
+    if (!isZcashShieldedEnabled()) {
+      if (isZcashTransaction(transaction)) {
+        const { transferType } = transaction;
+        if (transferType === "shielded" || transferType === "shielded-to-transparent") {
+          return new Observable(sub =>
+            sub.error(
+              new Error(
+                `Zcash ${transferType} transactions require the zcashShielded feature to be enabled`,
+              ),
+            ),
+          );
+        }
+      }
+      return undefined;
+    }
 
     // createTransaction() returns a base Bitcoin-family Transaction with no
     // Zcash-specific fields. Until the UI populates the Zcash shape (transferType
@@ -858,7 +879,31 @@ const zcashChainAdapter: ChainAdapter = {
     // signer via createPaymentTransaction; the remaining BitcoinSigner methods
     // (e.g. splitTransaction) continue to come from Btc.
     const dmk = new DmkSignerZcash(transport.dmk, transport.sessionId);
+
+    // Wrap splitTransaction to carry the original raw hex on the returned
+    // object. wallet.signAccountTx discards i.txHex after calling splitTransaction
+    // and only forwards the parsed structure to createPaymentTransaction.
+    // Without the raw bytes, DmkSignerZcash cannot populate
+    // serializedPreviousTransactionOverride, so the device receives a truncated
+    // transaction (Orchard bundle stripped by serializeTransaction) and computes
+    // a wrong ZIP-244 txid — causing "Missing inputs" on broadcast.
+    const baseSplitTransaction = defaultSigner.splitTransaction.bind(defaultSigner);
+
     return Object.assign(defaultSigner, {
+      splitTransaction: (
+        transactionHex: string,
+        isSegwitSupported: boolean | null | undefined,
+        hasExtraData: boolean | null | undefined,
+        additionals: Array<string> | null | undefined,
+      ) => {
+        const result = baseSplitTransaction(
+          transactionHex,
+          isSegwitSupported,
+          hasExtraData,
+          additionals,
+        );
+        return { ...result, rawTxHex: transactionHex };
+      },
       getAddress: dmk.getAddress.bind(dmk),
       getFullViewingKey: dmk.getFullViewingKey.bind(dmk),
       createPaymentTransaction: dmk.createPaymentTransaction.bind(dmk),

--- a/libs/live-signer-zcash/src/DmkSignerZcash.ts
+++ b/libs/live-signer-zcash/src/DmkSignerZcash.ts
@@ -147,6 +147,16 @@ export class DmkSignerZcash implements ZcashSigner {
   }
 
   private toLegacyTransaction(tx: SignerTransactionLike): LegacyTransaction {
+    // When the source transaction carries a shielded bundle (e.g. an Orchard
+    // bundle in a V5 tx), serializeTransaction strips it and emits zeroed
+    // routing-count bytes instead. The device then computes the ZIP-244 txid of
+    // those truncated bytes — not the original txid — and the resulting trusted
+    // input references a txid that does not exist on-chain, causing "Missing
+    // inputs" on broadcast. Passing the full raw bytes via
+    // serializedPreviousTransactionOverride lets the device hash the original
+    // transaction and produce the correct txid.
+    const serializedPreviousTransactionOverride =
+      tx.rawTxHex !== undefined ? Buffer.from(tx.rawTxHex, "hex") : undefined;
     return {
       version: tx.version,
       inputs: tx.inputs.map(input => ({
@@ -163,6 +173,9 @@ export class DmkSignerZcash implements ZcashSigner {
       ...(tx.nVersionGroupId !== undefined ? { nVersionGroupId: tx.nVersionGroupId } : {}),
       ...(tx.nExpiryHeight !== undefined ? { nExpiryHeight: tx.nExpiryHeight } : {}),
       ...(tx.extraData !== undefined ? { extraData: tx.extraData } : {}),
+      ...(serializedPreviousTransactionOverride !== undefined
+        ? { serializedPreviousTransactionOverride }
+        : {}),
     };
   }
 

--- a/libs/live-signer-zcash/src/types.ts
+++ b/libs/live-signer-zcash/src/types.ts
@@ -58,6 +58,12 @@ export type SignerTransactionLike = {
   nVersionGroupId?: Uint8Array;
   nExpiryHeight?: Uint8Array;
   extraData?: Uint8Array;
+  // Raw hex of the source transaction. Set by the Zcash createSigner wrapper
+  // around splitTransaction so toLegacyTransaction can populate
+  // serializedPreviousTransactionOverride — required for any source tx that
+  // carries a shielded bundle (Orchard), whose bytes are stripped by
+  // serializeTransaction, causing the device to compute a wrong ZIP-244 txid.
+  rawTxHex?: string;
 };
 
 /**

--- a/libs/live-signer-zcash/tests/DmkSignerZcash.test.ts
+++ b/libs/live-signer-zcash/tests/DmkSignerZcash.test.ts
@@ -405,6 +405,47 @@ describe("DmkSignerZcash", () => {
 
       await expect(signer.createPaymentTransaction(baseArg)).resolves.toBe("00signed");
     });
+
+    it("sets serializedPreviousTransactionOverride from rawTxHex so the device hashes the full original transaction", async () => {
+      // A V5 tx containing an Orchard bundle: serializeTransaction strips the
+      // bundle and the device would hash truncated bytes, computing the wrong
+      // ZIP-244 txid. rawTxHex carries the original bytes so the device gets the
+      // full transaction via serializedPreviousTransactionOverride.
+      const rawTxHex = "0500008001" + "ab".repeat(59);
+      const prevTxWithRaw = { ...prevTx, rawTxHex };
+
+      mockSignerZcash.signTransaction.mockReturnValue({
+        observable: createCompletedObservable("00signed"),
+      });
+
+      await signer.createPaymentTransaction({
+        ...baseArg,
+        inputs: [[prevTxWithRaw, 0, null, 0xfffffffd, 2_000_000]] as Parameters<
+          typeof signer.createPaymentTransaction
+        >[0]["inputs"],
+      });
+
+      const [legacyArg] = mockSignerZcash.signTransaction.mock.calls[0];
+      const legacyPrev = legacyArg.inputs[0][0];
+      expect(legacyPrev.serializedPreviousTransactionOverride).toBeInstanceOf(Uint8Array);
+      expect(Buffer.from(legacyPrev.serializedPreviousTransactionOverride).toString("hex")).toBe(
+        rawTxHex,
+      );
+    });
+
+    it("omits serializedPreviousTransactionOverride when rawTxHex is absent (plain transparent source tx)", async () => {
+      // Source transactions without a shielded bundle are handled correctly by
+      // serializeTransaction; no override is needed.
+      mockSignerZcash.signTransaction.mockReturnValue({
+        observable: createCompletedObservable("00signed"),
+      });
+
+      await signer.createPaymentTransaction(baseArg);
+
+      const [legacyArg] = mockSignerZcash.signTransaction.mock.calls[0];
+      const legacyPrev = legacyArg.inputs[0][0];
+      expect(legacyPrev.serializedPreviousTransactionOverride).toBeUndefined();
+    });
   });
 
   describe("signPcztTransaction", () => {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Two bugs caused shielded-to-transparent (Z→T) transactions to fail with
"Missing inputs (-25)" on broadcast:

1. When a source transparent UTXO's origin transaction contains an Orchard
   bundle, serializeTransaction strips that bundle and emits zeroed routing
   bytes. The device hashes those truncated bytes and produces a wrong
   ZIP-244 txid, so the signed input references an unknown outpoint.
   Fix: wrap splitTransaction in createSigner to attach rawTxHex to the
   parsed object; toLegacyTransaction now sets
   serializedPreviousTransactionOverride from those raw bytes so the device
   receives the full original transaction when computing the txid.

2. When the zcashShielded feature flag is OFF, signOperation returns
   undefined for all transfer types, including "shielded" and
   "shielded-to-transparent" which spend Orchard notes. The legacy Bitcoin
   path cannot represent note spends and silently produces a malformed tx.
   Fix: return an error Observable for shielded-input types when the flag is
   off, preventing the malformed transaction from reaching the network.
### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-34569
